### PR TITLE
Add issue templates for project

### DIFF
--- a/.github/ISSUE_TEMPLATE/epic.yml
+++ b/.github/ISSUE_TEMPLATE/epic.yml
@@ -1,0 +1,31 @@
+name: Epic
+title: "[EPIC] "
+description: An epic issue with multiple sub-tasks
+labels: [ "kind:epic,priority:major" ]
+body:
+
+  - type: textarea
+    attributes:
+      label: Describe the proposal
+      description: >
+        Please put the related docs here if required.
+      placeholder: >
+        Please describe the content of the proposal clearly and concisely.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Task list
+      description: >
+        For more details, please refer to [github docs](https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists).
+      placeholder: >
+        Please create sub-tasks with the pre-create issues here and @ the assignees if you know any of them. A simple example is as follows:
+          - [ ] #1
+            - [ ] #11 @user1
+            - [ ] #12
+            - [ ] #13
+          - [ ] #2 @user2
+          - [ ] #3
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,40 @@
+name: Feature Request
+title: "[FEATURE] "
+description: Suggest an idea for Unified Catalog
+labels: [ "kind:feature,priority:major" ]
+body:
+
+  - type: textarea
+    attributes:
+      label: Describe the feature
+      description: What is it?
+      placeholder: >
+        Please describe the feature you want here.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Motivation
+      description: Why should it be implemented?
+      placeholder: >
+        Please describe your motivation for requesting this feature.
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: Describe the solution
+      description: How could it be implemented?
+      placeholder: >
+        Please describe the solution to implement the new feature if you have any.
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: Additional context
+      placeholder: >
+        Anything else we need to know.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/subtask.yml
+++ b/.github/ISSUE_TEMPLATE/subtask.yml
@@ -1,0 +1,21 @@
+name: Subtask
+title: "[Subtask] "
+description: A subtask issue
+labels: [ "kind:subtask" ]
+body:
+
+  - type: textarea
+    attributes:
+      label: Describe the subtask
+      placeholder: >
+        Please describe the content of the subtask clearly and concisely.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Parent issue
+      placeholder: >
+        Please put the parent issue link here.
+    validations:
+      required: true


### PR DESCRIPTION
This PR proposes to add the issue templates for the project. The main purpose here is to restrict issue style and make things  clear to others.