### PR TITLE
[#24] Add metadata connector plugin framework

### DIFF
--- a/connectors/build.gradle.kts
+++ b/connectors/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
     id("java")
 }
 
-group = "com.datastrato.catalog.connectors"
+group = "com.datastrato.unified_catalog.connectors"
 version = "0.1.0"
 
 repositories {

--- a/connectors/commons/build.gradle.kts
+++ b/connectors/commons/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     id("java")
 }
 
-group = "com.datastrato.catalog.connectors.commons"
+group = "com.datastrato.unified_catalog.connectors.commons"
 version = "0.1.0"
 
 repositories {
@@ -10,21 +10,20 @@ repositories {
 }
 
 dependencies {
-    annotationProcessor("org.projectlombok:lombok:1.18.20")
+    annotationProcessor(libs.lombok)
+    implementation(libs.lombok)
+    implementation(libs.google.findbugs.jsr305)
+    implementation(libs.guava)
+    implementation(libs.google.inject.guice)
+    implementation(libs.slf4j.api)
+    implementation(libs.apache.tomcat.jdbc)
+    implementation(libs.jackson.databind)
+    implementation(libs.substrait.java.core)
 
-    implementation("org.projectlombok:lombok:1.18.20")
-    implementation("com.google.code.findbugs:jsr305:3.0.2")
-    implementation("com.google.guava:guava:30.1.1-jre")
-    implementation("com.google.inject:guice:4.1.0")
-    implementation("org.slf4j:slf4j-api:1.7.32")
-    implementation("org.apache.tomcat:tomcat-jdbc:10.1.0")
-    implementation("com.fasterxml.jackson.core:jackson-databind:2.12.5")
-    implementation("io.substrait:core:0.9.0")
-
-    testImplementation(platform("org.junit:junit-bom:5.9.1"))
-    testImplementation("org.junit.jupiter:junit-jupiter")
-    testImplementation("junit:junit:4.13.1")
-    testImplementation("org.mockito:mockito-core:3.12.4")
+    testImplementation(platform(libs.junit.bom))
+    testImplementation(libs.junit.jupiter)
+    testImplementation(libs.junit.junit)
+    testImplementation(libs.mockito.core)
 }
 
 tasks.test {

--- a/connectors/commons/src/main/java/com/datastrato/unified_catalog/connectors/commons/ConnectorPlugin.java
+++ b/connectors/commons/src/main/java/com/datastrato/unified_catalog/connectors/commons/ConnectorPlugin.java
@@ -1,4 +1,4 @@
-package com.datastrato.catalog.connectors.commons;
+package com.datastrato.unified_catalog.connectors.commons;
 
 /**
  * Plugin interface implemented by Connector.

--- a/connectors/commons/src/main/java/com/datastrato/unified_catalog/connectors/commons/ConnectorPluginManager.java
+++ b/connectors/commons/src/main/java/com/datastrato/unified_catalog/connectors/commons/ConnectorPluginManager.java
@@ -1,4 +1,4 @@
-package com.datastrato.catalog.connectors.commons;
+package com.datastrato.unified_catalog.connectors.commons;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;

--- a/connectors/connector-mysql/build.gradle.kts
+++ b/connectors/connector-mysql/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     id("java")
 }
 
-group = "com.datastrato.catalog.connectors.mysql"
+group = "com.datastrato.unified_catalog.connectors.mysql"
 version = "0.1.0"
 
 repositories {
@@ -12,19 +12,17 @@ repositories {
 dependencies {
     implementation(project(":connectors:commons"))
 
-    implementation("com.google.guava:guava:30.1.1-jre")
-    implementation("org.apache.commons:commons-lang3:3.12.0")
-    implementation("org.projectlombok:lombok:1.18.26")
-    implementation("org.slf4j:slf4j-api:1.7.32")
-    implementation("com.google.inject:guice:4.1.0")
-
-    testImplementation(platform("org.junit:junit-bom:5.9.1"))
-    testImplementation("org.junit.jupiter:junit-jupiter")
-    testImplementation("org.slf4j:slf4j-api:1.7.32")
-    testImplementation("org.mockito:mockito-core:3.12.4")
-
-    compileOnly("com.google.auto.service:auto-service:1.0-rc3")
-    annotationProcessor("com.google.auto.service:auto-service:1.0-rc3")
+    compileOnly(libs.google.auto.service)
+    annotationProcessor(libs.google.auto.service)
+    implementation(libs.guava)
+    implementation(libs.apache.commons.lang3)
+    implementation(libs.lombok)
+    implementation(libs.slf4j.api)
+    implementation(libs.google.inject.guice)
+    testImplementation(platform(libs.junit.bom))
+    testImplementation(libs.junit.jupiter)
+    testImplementation(libs.slf4j.api)
+    testImplementation(libs.mockito.core)
 }
 
 tasks.test {

--- a/connectors/connector-mysql/src/main/java/com/datastrato/unified_catalog/connector/mysql/MySqlConnectorPlugin.java
+++ b/connectors/connector-mysql/src/main/java/com/datastrato/unified_catalog/connector/mysql/MySqlConnectorPlugin.java
@@ -1,6 +1,6 @@
-package com.datastrato.catalog.connector.mysql;
+package com.datastrato.unified_catalog.connector.mysql;
 
-import com.datastrato.catalog.connectors.commons.ConnectorPlugin;
+import com.datastrato.unified_catalog.connectors.commons.ConnectorPlugin;
 import com.google.auto.service.AutoService;
 import com.google.common.annotations.VisibleForTesting;
 

--- a/connectors/connector-mysql/src/test/java/com/datastrato/unified_catalog/connector/mysql/MySqlConnectorPluginTest.java
+++ b/connectors/connector-mysql/src/test/java/com/datastrato/unified_catalog/connector/mysql/MySqlConnectorPluginTest.java
@@ -1,6 +1,6 @@
-package com.datastrato.catalog.connector.mysql;
+package com.datastrato.unified_catalog.connector.mysql;
 
-import com.datastrato.catalog.connectors.commons.ConnectorPluginManager;
+import com.datastrato.unified_catalog.connectors.commons.ConnectorPluginManager;
 import org.junit.jupiter.api.Test;
 import java.util.Objects;
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,10 +1,19 @@
 [versions]
-junit = "5.8.1"
+junit-jupiter = "5.8.1"
 protoc = "3.17.3"
 substrait = "0.9.0"
 jackson = "2.13.4"
 guava = "29.0-jre"
 lombok = "1.18.20"
+slf4j-api = "1.7.32"
+commons-lang3 = "3.12.0"
+google-inject-guice = "4.1.0"
+junit-bom = "5.9.1"
+mockito-core = "3.12.4"
+google-auto-service = "1.0-rc3"
+google-findbugs-jsr305 = "3.0.2"
+apache-tomcat-jdbc = "10.1.0"
+junit-junit = "4.13.1"
 protobuf-plugin = "0.9.2"
 spotless-plugin = '6.11.0'
 gradle-extensions-plugin = '1.74'
@@ -20,9 +29,21 @@ jackson-datatype-jdk8 = { group = "com.fasterxml.jackson.datatype", name = "jack
 jackson-datatype-jsr310 = { group = "com.fasterxml.jackson.datatype", name = "jackson-datatype-jsr310", version.ref = "jackson" }
 guava = { group = "com.google.guava", name = "guava", version.ref = "guava" }
 lombok = { group = "org.projectlombok", name = "lombok", version.ref = "lombok" }
-junit-jupiter-api = { group = "org.junit.jupiter", name = "junit-jupiter-api", version.ref = "junit" }
-junit-jupiter-params = { group = "org.junit.jupiter", name = "junit-jupiter-params", version.ref = "junit" }
+junit-jupiter-api = { group = "org.junit.jupiter", name = "junit-jupiter-api", version.ref = "junit-jupiter" }
+junit-jupiter-params = { group = "org.junit.jupiter", name = "junit-jupiter-params", version.ref = "junit-jupiter" }
 junit-jupiter-engine = { group = "org.junit.jupiter", name = "junit-jupiter-engine"}
+junit-jupiter = { group = "org.junit.jupiter", name = "junit-jupiter"}
+junit-junit = { group = "org.junit", name = "junit", version.ref = "junit-junit" }
+
+junit-bom = { group = "org.junit", name = "junit-bom", version.ref = "junit-bom" }
+slf4j-api = { group = "org.slf4j", name = "slf4j-api", version.ref = "slf4j-api" }
+apache-commons-lang3 = { group = "org.apache.commons", name = "commons-lang3", version.ref = "commons-lang3" }
+google-inject-guice = { group = "com.google.inject", name = "guice", version.ref = "google-inject-guice" }
+google-auto-service = { group = "com.google.auto.service", name = "auto-service", version.ref = "google-auto-service" }
+google-findbugs-jsr305 = { group = "com.google.code.findbugs", name = "jsr305", version.ref = "google-findbugs-jsr305" }
+mockito-core = { group = "org.mockito", name = "mockito-core", version.ref = "mockito-core" }
+apache-tomcat-jdbc = { group = "org.apache.tomcat", name = "tomcat-jdbc", version.ref = "apache-tomcat-jdbc" }
+
 
 [bundles]
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,4 +1,3 @@
 rootProject.name = "Unified Catalog"
 
-include("api", "core", "schema", "server", "connectors")
-include(":connectors:commons", ":connectors:connector-mysql")
+include("api", "core", "schema", "server", "connectors", ":connectors:commons", ":connectors:connector-mysql")


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?
1. Add metadata connector plugin framework.
2. Add MySqlConnectorPlugin, It can dynamically load in the framework and passed `MySqlConnectorPluginTest` unit test.

### Why are the changes needed?
We need to support more data source connectors, Through plugin mode can easily maintain and extend.

Fix: #24 

### Does this PR introduce _any_ user-facing change?
N/A

### How was this patch tested?
N/A
