### PR TITLE
improvement(ci) Coverage report GitHub action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,5 +26,24 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
+
       - name: Build with Gradle
         run: gradle build
+
+      - name: Jacoco Report to PR
+        id: jacoco
+        uses: madrapps/jacoco-report@v1.6
+        with:
+          paths: ${{ github.workspace }}/**/build/reports/jacoco/test/jacocoTestReport.xml
+          token: ${{ secrets.GITHUB_TOKEN }}
+          min-coverage-overall: 40
+          min-coverage-changed-files: 60
+          title: 'Code Coverage Report'
+          debug-mode: false
+          update-comment: true
+          pass-emoji: ':green_circle:'
+          fail-emoji: ':red_circle:'
+      - name: Get the Coverage info
+        run: |
+          echo "Total coverage ${{ steps.jacoco.outputs.coverage-overall }}"
+          echo "Changed Files coverage ${{ steps.jacoco.outputs.coverage-changed-files }}"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -41,6 +41,14 @@ allprojects {
     finalizedBy(tasks.getByName("jacocoTestReport"))
   }
 
+    tasks.withType<JacocoReport> {
+    reports {
+      csv.required.set(true)
+      xml.required.set(true)
+      html.required.set(true)
+    }
+  }
+
   group = "com.datastrato.graviton"
   version = "${version}"
 


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Current Graviton generator coverage reports through jacoco, which can only be viewed manually in a browser.

### Why are the changes needed?

Integrate via Github action to generate Coverage Report comments on each PR submission.

Fix: #141 

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

Submission this PR will auto-generation a `Coverage Report` in the comment.
