### PR TITLE
[#163] improve(all): add log4j2 configuration file to set log level and log file

### DIFF
--- a/server/src/main/java/com/datastrato/graviton/server/GravitonServer.java
+++ b/server/src/main/java/com/datastrato/graviton/server/GravitonServer.java
@@ -86,7 +86,6 @@ public class GravitonServer extends ResourceConfig {
     GravitonServer server = new GravitonServer();
     server.initialize();
 
-    LOG.info("Starting Graviton server");
     try {
       server.start();
       server.join();


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add log4j2 xml file to set log level and log file

### Why are the changes needed?

Currently, no log4j2 configuration file is found and the default log level is `ERROR`, Which is hard for us to get debugging information


Fix: #163 

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

No
