### PR TITLE
[#236] Use erroneous params in the CatalogManager::listCatalogs()

### DIFF
--- a/core/src/main/java/com/datastrato/graviton/catalog/CatalogManager.java
+++ b/core/src/main/java/com/datastrato/graviton/catalog/CatalogManager.java
@@ -170,7 +170,7 @@ public class CatalogManager implements SupportsCatalogs, Closeable {
 
     boolean metalakeExists;
     try {
-      metalakeExists = store.exists(metalakeIdent, EntityType.CATALOG);
+      metalakeExists = store.exists(metalakeIdent, EntityType.METALAKE);
     } catch (IOException e) {
       LOG.error("Failed to do storage operation", e);
       throw new RuntimeException(e);
@@ -181,7 +181,7 @@ public class CatalogManager implements SupportsCatalogs, Closeable {
     }
 
     try {
-      return store.list(namespace, CatalogEntity.class, EntityType.METALAKE).stream()
+      return store.list(namespace, CatalogEntity.class, EntityType.CATALOG).stream()
           .map(entity -> NameIdentifier.of(namespace, entity.name()))
           .toArray(NameIdentifier[]::new);
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Use erroneous params in `CatalogManager::listCatalogs()` functions

1. check if metalake exists

    ```
      metalakeExists = store.exists(metalakeIdent, EntityType.CATALOG);
    ```

2. list catalogs in the special metalake

    ```
      return store.list(namespace, CatalogEntity.class, EntityType.METALAKE).stream()
    ```


### Why are the changes needed?

1. Replace `EntityType.CATALOG` to `EntityType.METALAKE`

    ```
      metalakeExists = store.exists(metalakeIdent, EntityType.METALAKE);
    ```

2. Replace `EntityType.METALAKE` to `EntityType.CATALOG`

    ```
      return store.list(namespace, CatalogEntity.class, EntityType.CATALOG).stream()
    ```
Fix: #236 

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

Submission integration test in the next PR.
