### PR TITLE
[#256] fix: Hive read/write Graviton created table error

### DIFF
--- a/catalog-hive/src/main/java/com/datastrato/graviton/catalog/hive/HiveTable.java
+++ b/catalog-hive/src/main/java/com/datastrato/graviton/catalog/hive/HiveTable.java
@@ -97,12 +97,18 @@ public class HiveTable extends BaseTable {
     // `location` must not be null, otherwise it will result in an NPE when calling HMS `alterTable`
     // interface
     sd.setLocation(location);
+    // TODO(minghuang): Remove hard coding below after supporting the specified Hive table
+    //  properties
+    sd.setInputFormat("org.apache.hadoop.mapred.TextInputFormat");
+    sd.setOutputFormat("org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat");
     return sd;
   }
 
   private SerDeInfo buildSerDeInfo() {
     // TODO(minghuang): Build SerDeInfo object based on user specifications.
-    return new SerDeInfo();
+    SerDeInfo serDeInfo = new SerDeInfo();
+    serDeInfo.setSerializationLib("org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe");
+    return serDeInfo;
   }
 
   /**


### PR DESCRIPTION
### What changes were proposed in this pull request?
add  default values of `INPUTFORMAT`,  `OUTPUTFORMAT`, `SERDE` when create hive table

### Why are the changes needed?
without those default values, it will run into NPE when reading/writing the table through Hive although the HMS goes well 

Fix: #256 

### Does this PR introduce _any_ user-facing change?
no
### How was this patch tested?
Later on  HiveCatalog Integration Test