### PR TITLE
[#268] (backport) Unable to get explicit catalog identifier in the NameIdentifier

### DIFF
--- a/core/src/test/java/com/datastrato/graviton/catalog/TestCatalogOperationDispatcher.java
+++ b/core/src/test/java/com/datastrato/graviton/catalog/TestCatalogOperationDispatcher.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2023 Datastrato.
+ * This software is licensed under the Apache License version 2.
+ */
+package com.datastrato.graviton.catalog;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.datastrato.graviton.NameIdentifier;
+import org.junit.jupiter.api.Test;
+
+public class TestCatalogOperationDispatcher {
+  @Test
+  public void testGetCatalogIdentifier() {
+    CatalogOperationDispatcher dispatcher = new CatalogOperationDispatcher(null);
+
+    NameIdentifier id1 = NameIdentifier.of("a");
+    assertThrows(IllegalArgumentException.class, () -> dispatcher.getCatalogIdentifier(id1));
+
+    NameIdentifier id2 = NameIdentifier.of("a", "b");
+    assertEquals(dispatcher.getCatalogIdentifier(id2), NameIdentifier.of("a", "b"));
+
+    NameIdentifier id3 = NameIdentifier.of("a", "b", "c");
+    assertEquals(dispatcher.getCatalogIdentifier(id3), NameIdentifier.of("a", "b"));
+
+    NameIdentifier id4 = NameIdentifier.of("a", "b", "c", "d");
+    assertEquals(dispatcher.getCatalogIdentifier(id4), NameIdentifier.of("a", "b"));
+
+    NameIdentifier id5 = NameIdentifier.of("a", "b", "c", "d", "e");
+    assertEquals(dispatcher.getCatalogIdentifier(id5), NameIdentifier.of("a", "b"));
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

The CatalogOperationDispatcher need to get the catalog identifier in the
NameIdentifier object.
But NameIdentifier has a flexible namespace definition inside to support
metalake, schema, multi-level namespace, and table names. Flexibility
also confuses us when we use it.

### Why are the changes needed?

Unable to get explicit catalog identifier in CatalogOperationDispatcher
many functions.

Fix: https://github.com/datastrato/graviton/issues/268 

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

testGetCatalogIdentifier test passed.