### PR TITLE
[#279] Trigger build workflow when submitting PR in the branch-0.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,9 +4,9 @@ name: build
 on:
   # Triggers the workflow on push or pull request events but only for the "main" branch
   push:
-    branches: [ "main" ]
+    branches: [ "main", "branch-*" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "branch-*" ]
 
 concurrency:
   group: ${{ github.worklfow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
### What changes were proposed in this pull request?

Modify GitHub workflow configuration.

### Why are the changes needed?

The `branch-0.1` GitHub workflow is not triggering build.yml due to the unmodified configuration.

Fix: #279 

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

N/A