### PR TITLE
[#290] ci: Add github action to cherry-pick the PR automatically based on label

### DIFF
--- a/.github/workflows/auto-cherry-pick.yml
+++ b/.github/workflows/auto-cherry-pick.yml
@@ -1,0 +1,28 @@
+name: Automatically cherry-pick merged PR to different branches
+
+on:
+  pull_request_target:
+    branches:
+      - main
+    types: ["closed"]
+
+jobs:
+  cherry_pick_branch_0_1:
+    runs-on: ubuntu-latest
+    name: Cherry pick into branch_0.1
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'branch-0.1') && github.event.pull_request.merged == true }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Cherry pick into branch-0.1
+        uses: carloscastrojumo/github-cherry-pick-action@v1.0.9
+        with:
+          branch: branch-0.1
+          labels: |
+            cherry-pick
+          reviewers: |
+            jerryshao
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds the support of creating a cherry-pick PR against the specified branch based on the label. 

### Why are the changes needed?

With this, we don't have to manually create a new PR against different branches when we need to do a cherry-pick.

Fix: #290 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Local test.