### PR TITLE
[#211] package: Shade the client-java output and bump the version

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -15,6 +15,8 @@ dependencies {
     exclude("com.fasterxml.jackson.datatype")
     exclude("com.fasterxml.jackson.dataformat")
     exclude("com.google.protobuf")
+    exclude("com.google.code.findbugs")
+    exclude("org.slf4j")
   }
   implementation(libs.guava)
   implementation(libs.slf4j.api)

--- a/client-java/build.gradle.kts
+++ b/client-java/build.gradle.kts
@@ -1,3 +1,6 @@
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+import java.util.Locale
+
 /*
  * Copyright 2023 Datastrato.
  * This software is licensed under the Apache License version 2.
@@ -7,6 +10,7 @@ plugins {
   id("java")
   id("idea")
   id("com.diffplug.spotless")
+  alias(libs.plugins.shadow)
 }
 
 dependencies {
@@ -20,6 +24,9 @@ dependencies {
     exclude("org.slf4j")
     exclude("com.fasterxml.jackson.core")
     exclude("com.fasterxml.jackson.datatype")
+    exclude("com.fasterxml.jackson.dataformat")
+    exclude("com.google.code.findbugs")
+    exclude("com.google.protobuf")
   }
   implementation(libs.jackson.databind)
   implementation(libs.jackson.annotations)
@@ -42,3 +49,25 @@ dependencies {
   testImplementation(libs.mockserver.netty)
   testImplementation(libs.mockserver.client.java)
 }
+
+tasks.withType<ShadowJar>(ShadowJar::class.java) {
+  isZip64 = true
+  archiveFileName.set("${rootProject.name.lowercase(Locale.getDefault())}-${project.name}-runtime-${project.version}.jar")
+
+  // Relocate dependencies to avoid conflicts
+  relocate("io.substrait", "com.datastrato.graviton.shaded.io.substrait") {
+    exclude("org.slf4j")
+    exclude("com.fasterxml.jackson.core")
+    exclude("com.fasterxml.jackson.datatype")
+    exclude("com.fasterxml.jackson.dataformat")
+    exclude("com.google.code.findbugs")
+    exclude("com.google.protobuf")
+  }
+  relocate("com.google", "com.datastrato.graviton.shaded.com.google")
+  relocate("com.fasterxml", "com.datastrato.graviton.shaded.com.fasterxml")
+  relocate("org.apache.httpcomponents", "com.datastrato.graviton.shaded.org.apache.httpcomponents")
+  relocate("org.apache.commons", "com.datastrato.graviton.shaded.org.apache.commons")
+  relocate("org.antlr", "com.datastrato.graviton.shaded.org.antlr")
+}
+
+tasks.named("jar") { dependsOn(tasks.named("shadowJar")) }

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -17,6 +17,7 @@ dependencies {
     exclude("com.fasterxml.jackson.datatype")
     exclude("com.fasterxml.jackson.dataformat")
     exclude("com.google.protobuf")
+    exclude("com.google.code.findbugs")
   }
 
   implementation(libs.jackson.databind)

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ org.gradle.parallel=true
 org.gradle.caching=true
 
 #version that is going to be updated automatically by releases
-version = 0.1.0
+version = 0.2.0-SNAPSHOT
 
 #sonatype credentials
 SONATYPE_USER = admin

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,6 +30,7 @@ spotless-plugin = '6.11.0'
 gradle-extensions-plugin = '1.74'
 publish-plugin = '1.1.0'
 rat-plugin = '0.8.0'
+shadow-plugin = "8.1.1"
 
 
 [libraries]
@@ -86,3 +87,4 @@ spotless = { id = "com.diffplug.spotless", version.ref = "spotless-plugin" }
 gradle-extensions = { id = "com.github.vlsi.gradle-extensions", version.ref = "gradle-extensions-plugin" }
 publish = { id = "io.github.gradle-nexus.publish-plugin", version.ref = "publish-plugin" }
 rat = { id = "org.nosphere.apache.rat", version.ref = "rat-plugin" }
+shadow = { id = "com.github.johnrengelman.shadow", version.ref = "shadow-plugin" }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to add shadowJar support for `client-java` module. It will package an uber java with all dependencies shaded, user could leverage this jar to avoid potential dependencies issues.

### Why are the changes needed?

`client-java` will be used by other projects, so we need to shaded all the dependencies of `client-java` to avoid conflicts when outside users leverage this package.

Fix: #211 

### Does this PR introduce _any_ user-facing change?

NA

### How was this patch tested?

NA
