### PR TITLE
minor: fix typo `graviton-ci-hive` in the `dev/docker/hive/README.md`

### DIFF
--- a/dev/docker/hive/README.md
+++ b/dev/docker/hive/README.md
@@ -7,12 +7,18 @@ Build docker image that includes Hadoop2, Hive2
 
 Build Image
 ===========
+```
 ./build-docker.sh
+```
 
 Run container
 =============
-docker run --rm -d -p 8088:8088 -p 50070:50070 -p 50075:50075 -p 10000:10000 -p 10002:10002 -p 8888:8888 -p 9083:9083 -p 8022:22 datastrato/graviton-ci-hivehive:0.1.0
+```
+docker run --rm -d -p 8088:8088 -p 50070:50070 -p 50075:50075 -p 10000:10000 -p 10002:10002 -p 8888:8888 -p 9083:9083 -p 8022:22 datastrato/graviton-ci-hive:0.1.0
+```
 
 Login to the server
 =============
+```
 ssh -p 8022 datastrato@localhost (password: ds123, this is a sudo user)
+```


### PR DESCRIPTION
### What changes were proposed in this pull request?

typo `graviton-ci-hive` in the `dev/docker/hive/README.md`

### Why are the changes needed?

typo `graviton-ci-hive` in the `dev/docker/hive/README.md`

Fix: # (issue)

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

CI Passed.
