### PR TITLE
[#342] fix: Iceberg package orgnization is wrong

### DIFF
--- a/catalog-lakehouse/src/main/java/com/datastrato/graviton/catalog/lakehouse/iceberg/ops/IcebergTableOps.java
+++ b/catalog-lakehouse/src/main/java/com/datastrato/graviton/catalog/lakehouse/iceberg/ops/IcebergTableOps.java
@@ -2,9 +2,9 @@
  * Copyright 2023 Datastrato.
  * This software is licensed under the Apache License version 2.
  */
-package com.datastrato.graviton.catalog.lakehouse.iceberg.iceberg.ops;
+package com.datastrato.graviton.catalog.lakehouse.iceberg.ops;
 
-import com.datastrato.graviton.catalog.lakehouse.iceberg.iceberg.utils.IcebergCatalogUtil;
+import com.datastrato.graviton.catalog.lakehouse.iceberg.utils.IcebergCatalogUtil;
 import com.google.common.base.Preconditions;
 import java.util.Optional;
 import javax.ws.rs.NotSupportedException;

--- a/catalog-lakehouse/src/main/java/com/datastrato/graviton/catalog/lakehouse/iceberg/utils/IcebergCatalogUtil.java
+++ b/catalog-lakehouse/src/main/java/com/datastrato/graviton/catalog/lakehouse/iceberg/utils/IcebergCatalogUtil.java
@@ -2,7 +2,7 @@
  * Copyright 2023 Datastrato.
  * This software is licensed under the Apache License version 2.
  */
-package com.datastrato.graviton.catalog.lakehouse.iceberg.iceberg.utils;
+package com.datastrato.graviton.catalog.lakehouse.iceberg.utils;
 
 import java.util.HashMap;
 import java.util.Locale;

--- a/catalog-lakehouse/src/main/java/com/datastrato/graviton/catalog/lakehouse/iceberg/web/IcebergExceptionMapper.java
+++ b/catalog-lakehouse/src/main/java/com/datastrato/graviton/catalog/lakehouse/iceberg/web/IcebergExceptionMapper.java
@@ -3,7 +3,7 @@
  * This software is licensed under the Apache License version 2.
  */
 
-package com.datastrato.graviton.catalog.lakehouse.iceberg.iceberg.web;
+package com.datastrato.graviton.catalog.lakehouse.iceberg.web;
 
 import com.google.common.collect.ImmutableMap;
 import java.util.Map;

--- a/catalog-lakehouse/src/main/java/com/datastrato/graviton/catalog/lakehouse/iceberg/web/IcebergObjectMapperProvider.java
+++ b/catalog-lakehouse/src/main/java/com/datastrato/graviton/catalog/lakehouse/iceberg/web/IcebergObjectMapperProvider.java
@@ -2,7 +2,7 @@
  * Copyright 2023 Datastrato.
  * This software is licensed under the Apache License version 2.
  */
-package com.datastrato.graviton.catalog.lakehouse.iceberg.iceberg.web;
+package com.datastrato.graviton.catalog.lakehouse.iceberg.web;
 
 import com.datastrato.graviton.json.JsonUtils;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;

--- a/catalog-lakehouse/src/main/java/com/datastrato/graviton/catalog/lakehouse/iceberg/web/IcebergRestUtils.java
+++ b/catalog-lakehouse/src/main/java/com/datastrato/graviton/catalog/lakehouse/iceberg/web/IcebergRestUtils.java
@@ -2,7 +2,7 @@
  * Copyright 2023 Datastrato.
  * This software is licensed under the Apache License version 2.
  */
-package com.datastrato.graviton.catalog.lakehouse.iceberg.iceberg.web;
+package com.datastrato.graviton.catalog.lakehouse.iceberg.web;
 
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;

--- a/catalog-lakehouse/src/main/java/com/datastrato/graviton/catalog/lakehouse/iceberg/web/rest/IcebergConfig.java
+++ b/catalog-lakehouse/src/main/java/com/datastrato/graviton/catalog/lakehouse/iceberg/web/rest/IcebergConfig.java
@@ -2,9 +2,9 @@
  * Copyright 2023 Datastrato.
  * This software is licensed under the Apache License version 2.
  */
-package com.datastrato.graviton.catalog.lakehouse.iceberg.iceberg.web.rest;
+package com.datastrato.graviton.catalog.lakehouse.iceberg.web.rest;
 
-import com.datastrato.graviton.catalog.lakehouse.iceberg.iceberg.web.IcebergRestUtils;
+import com.datastrato.graviton.catalog.lakehouse.iceberg.web.IcebergRestUtils;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;

--- a/catalog-lakehouse/src/main/java/com/datastrato/graviton/catalog/lakehouse/iceberg/web/rest/IcebergNamespaceOperations.java
+++ b/catalog-lakehouse/src/main/java/com/datastrato/graviton/catalog/lakehouse/iceberg/web/rest/IcebergNamespaceOperations.java
@@ -2,10 +2,10 @@
  * Copyright 2023 Datastrato.
  * This software is licensed under the Apache License version 2.
  */
-package com.datastrato.graviton.catalog.lakehouse.iceberg.iceberg.web.rest;
+package com.datastrato.graviton.catalog.lakehouse.iceberg.web.rest;
 
-import com.datastrato.graviton.catalog.lakehouse.iceberg.iceberg.ops.IcebergTableOps;
-import com.datastrato.graviton.catalog.lakehouse.iceberg.iceberg.web.IcebergRestUtils;
+import com.datastrato.graviton.catalog.lakehouse.iceberg.ops.IcebergTableOps;
+import com.datastrato.graviton.catalog.lakehouse.iceberg.web.IcebergRestUtils;
 import javax.inject.Inject;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.Consumes;

--- a/catalog-lakehouse/src/test/java/com/datastrato/graviton/catalog/lakehouse/iceberg/utils/TestIcebergCatalogUtil.java
+++ b/catalog-lakehouse/src/test/java/com/datastrato/graviton/catalog/lakehouse/iceberg/utils/TestIcebergCatalogUtil.java
@@ -3,9 +3,8 @@
  * This software is licensed under the Apache License version 2.
  */
 
-package com.datastrato.graviton.lakehouse.iceberg.utils;
+package com.datastrato.graviton.catalog.lakehouse.iceberg.utils;
 
-import com.datastrato.graviton.catalog.lakehouse.iceberg.iceberg.utils.IcebergCatalogUtil;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.inmemory.InMemoryCatalog;
 import org.junit.jupiter.api.Assertions;

--- a/catalog-lakehouse/src/test/java/com/datastrato/graviton/catalog/lakehouse/iceberg/web/rest/IcebergRestTestUtil.java
+++ b/catalog-lakehouse/src/test/java/com/datastrato/graviton/catalog/lakehouse/iceberg/web/rest/IcebergRestTestUtil.java
@@ -3,10 +3,10 @@
  * This software is licensed under the Apache License version 2.
  */
 
-package com.datastrato.graviton.lakehouse.iceberg.web.rest;
+package com.datastrato.graviton.catalog.lakehouse.iceberg.web.rest;
 
-import com.datastrato.graviton.catalog.lakehouse.iceberg.iceberg.web.IcebergExceptionMapper;
-import com.datastrato.graviton.catalog.lakehouse.iceberg.iceberg.web.IcebergObjectMapperProvider;
+import com.datastrato.graviton.catalog.lakehouse.iceberg.web.IcebergExceptionMapper;
+import com.datastrato.graviton.catalog.lakehouse.iceberg.web.IcebergObjectMapperProvider;
 import org.glassfish.jersey.jackson.JacksonFeature;
 import org.glassfish.jersey.server.ResourceConfig;
 

--- a/catalog-lakehouse/src/test/java/com/datastrato/graviton/catalog/lakehouse/iceberg/web/rest/TestIcebergConfig.java
+++ b/catalog-lakehouse/src/test/java/com/datastrato/graviton/catalog/lakehouse/iceberg/web/rest/TestIcebergConfig.java
@@ -3,10 +3,9 @@
  * This software is licensed under the Apache License version 2.
  */
 
-package com.datastrato.graviton.lakehouse.iceberg.web.rest;
+package com.datastrato.graviton.catalog.lakehouse.iceberg.web.rest;
 
-import com.datastrato.graviton.catalog.lakehouse.iceberg.iceberg.web.IcebergObjectMapperProvider;
-import com.datastrato.graviton.catalog.lakehouse.iceberg.iceberg.web.rest.IcebergConfig;
+import com.datastrato.graviton.catalog.lakehouse.iceberg.web.IcebergObjectMapperProvider;
 import javax.ws.rs.core.Application;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;

--- a/catalog-lakehouse/src/test/java/com/datastrato/graviton/catalog/lakehouse/iceberg/web/rest/TestIcebergNamespaceOperations.java
+++ b/catalog-lakehouse/src/test/java/com/datastrato/graviton/catalog/lakehouse/iceberg/web/rest/TestIcebergNamespaceOperations.java
@@ -3,11 +3,10 @@
  * This software is licensed under the Apache License version 2.
  */
 
-package com.datastrato.graviton.lakehouse.iceberg.web.rest;
+package com.datastrato.graviton.catalog.lakehouse.iceberg.web.rest;
 
-import com.datastrato.graviton.catalog.lakehouse.iceberg.iceberg.ops.IcebergTableOps;
-import com.datastrato.graviton.catalog.lakehouse.iceberg.iceberg.web.IcebergObjectMapperProvider;
-import com.datastrato.graviton.catalog.lakehouse.iceberg.iceberg.web.rest.IcebergNamespaceOperations;
+import com.datastrato.graviton.catalog.lakehouse.iceberg.ops.IcebergTableOps;
+import com.datastrato.graviton.catalog.lakehouse.iceberg.web.IcebergObjectMapperProvider;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableMap;
 import java.util.Arrays;


### PR DESCRIPTION

### What changes were proposed in this pull request?

correct iceberg package orgnizations，


*  `package com.datastrato.graviton.catalog.lakehouse.iceberg.iceberg` has duplicate `iceberg`, should be corrected to `package com.datastrato.graviton.catalog.lakehouse.iceberg` in source code

*   `package com.datastrato.graviton.lakehouse.iceberg` missing `catalog`,  should be corrected to `package com.datastrato.graviton.catalog.lakehouse.iceberg` in test code


### Why are the changes needed?

Fix: #342 

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
existing UT
