### PR TITLE
[#168] feat(core): Refactor the ID field of entity to assign a unique id for this field

### DIFF
--- a/catalog-hive/src/main/java/com/datastrato/graviton/catalog/hive/HiveCatalogOperations.java
+++ b/catalog-hive/src/main/java/com/datastrato/graviton/catalog/hive/HiveCatalogOperations.java
@@ -162,8 +162,7 @@ public class HiveCatalogOperations implements CatalogOperations, SupportsSchemas
               () -> {
                 HiveSchema createdSchema =
                     new HiveSchema.Builder()
-                        .withId(1L /*TODO. Use ID generator*/)
-                        .withCatalogId(entity.getId())
+                        .withId(GravitonEnv.getInstance().idGenerator().nextId())
                         .withName(ident.name())
                         .withNamespace(ident.namespace())
                         .withComment(comment)
@@ -236,12 +235,7 @@ public class HiveCatalogOperations implements CatalogOperations, SupportsSchemas
       EntityStore store = GravitonEnv.getInstance().entityStore();
       BaseSchema baseSchema = store.get(ident, SCHEMA, BaseSchema.class);
 
-      builder =
-          builder
-              .withId(baseSchema.getId())
-              .withCatalogId(baseSchema.getCatalogId())
-              .withNamespace(ident.namespace())
-              .withConf(hiveConf);
+      builder = builder.withId(baseSchema.id()).withNamespace(ident.namespace()).withConf(hiveConf);
       HiveSchema hiveSchema = HiveSchema.fromInnerDB(database, builder);
 
       // Merge audit info from Graviton store
@@ -330,8 +324,7 @@ public class HiveCatalogOperations implements CatalogOperations, SupportsSchemas
                 HiveSchema.Builder builder = new HiveSchema.Builder();
                 builder =
                     builder
-                        .withId(oldSchema.getId())
-                        .withCatalogId(oldSchema.getCatalogId())
+                        .withId(oldSchema.id())
                         .withNamespace(ident.namespace())
                         .withConf(hiveConf);
                 HiveSchema hiveSchema = HiveSchema.fromInnerDB(alteredDatabase, builder);
@@ -553,8 +546,7 @@ public class HiveCatalogOperations implements CatalogOperations, SupportsSchemas
 
       builder =
           builder
-              .withId(baseTable.getId())
-              .withSchemaId(baseTable.getSchemaId())
+              .withId(baseTable.id())
               .withName(tableIdent.name())
               .withNameSpace(tableIdent.namespace());
       HiveTable table = HiveTable.fromInnerTable(hiveTable, builder);
@@ -612,8 +604,7 @@ public class HiveCatalogOperations implements CatalogOperations, SupportsSchemas
               () -> {
                 HiveTable createdTable =
                     new HiveTable.Builder()
-                        .withId(1L /* TODO: Use ID generator*/)
-                        .withSchemaId(schema.getId())
+                        .withId(GravitonEnv.getInstance().idGenerator().nextId())
                         .withName(tableIdent.name())
                         .withNameSpace(tableIdent.namespace())
                         .withColumns(columns)
@@ -731,8 +722,7 @@ public class HiveCatalogOperations implements CatalogOperations, SupportsSchemas
                 HiveTable.Builder builder = new HiveTable.Builder();
                 builder =
                     builder
-                        .withId(table.getId())
-                        .withSchemaId(table.getSchemaId())
+                        .withId(table.id())
                         .withName(alteredHiveTable.getTableName())
                         .withNameSpace(tableIdent.namespace());
 

--- a/catalog-hive/src/main/java/com/datastrato/graviton/catalog/hive/HiveSchema.java
+++ b/catalog-hive/src/main/java/com/datastrato/graviton/catalog/hive/HiveSchema.java
@@ -165,7 +165,6 @@ public class HiveSchema extends BaseSchema {
     protected HiveSchema internalBuild() {
       HiveSchema hiveSchema = new HiveSchema();
       hiveSchema.id = id;
-      hiveSchema.catalogId = catalogId;
       hiveSchema.name = name;
       hiveSchema.namespace = namespace;
       hiveSchema.comment = comment;

--- a/catalog-hive/src/main/java/com/datastrato/graviton/catalog/hive/HiveTable.java
+++ b/catalog-hive/src/main/java/com/datastrato/graviton/catalog/hive/HiveTable.java
@@ -157,7 +157,6 @@ public class HiveTable extends BaseTable {
     protected HiveTable internalBuild() {
       HiveTable hiveTable = new HiveTable();
       hiveTable.id = id;
-      hiveTable.schemaId = schemaId;
       hiveTable.namespace = namespace;
       hiveTable.name = name;
       hiveTable.comment = comment;

--- a/catalog-hive/src/test/java/com/datastrato/graviton/catalog/hive/HiveCatalogTest.java
+++ b/catalog-hive/src/test/java/com/datastrato/graviton/catalog/hive/HiveCatalogTest.java
@@ -29,7 +29,6 @@ public class HiveCatalogTest extends MiniHiveMetastoreService {
             .withName("catalog")
             .withNamespace(Namespace.of("metalake"))
             .withType(HiveCatalog.Type.RELATIONAL)
-            .withMetalakeId(1L)
             .withAuditInfo(auditInfo)
             .build();
 

--- a/catalog-hive/src/test/java/com/datastrato/graviton/catalog/hive/HiveSchemaTest.java
+++ b/catalog-hive/src/test/java/com/datastrato/graviton/catalog/hive/HiveSchemaTest.java
@@ -73,7 +73,6 @@ public class HiveSchemaTest extends MiniHiveMetastoreService {
             .withName("catalog")
             .withNamespace(Namespace.of("metalake"))
             .withType(HiveCatalog.Type.RELATIONAL)
-            .withMetalakeId(1L)
             .withAuditInfo(auditInfo)
             .build();
 

--- a/catalog-hive/src/test/java/com/datastrato/graviton/catalog/hive/HiveTableTest.java
+++ b/catalog-hive/src/test/java/com/datastrato/graviton/catalog/hive/HiveTableTest.java
@@ -106,7 +106,6 @@ public class HiveTableTest extends MiniHiveMetastoreService {
             .withName(HIVE_CATALOG_NAME)
             .withNamespace(Namespace.of(META_LAKE_NAME))
             .withType(HiveCatalog.Type.RELATIONAL)
-            .withMetalakeId(1L)
             .withAuditInfo(auditInfo)
             .build();
 

--- a/core/src/main/java/com/datastrato/graviton/Entity.java
+++ b/core/src/main/java/com/datastrato/graviton/Entity.java
@@ -6,9 +6,7 @@ package com.datastrato.graviton;
 
 import java.io.Serializable;
 import java.util.Map;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.ToString;
 
 /** This interface defines an entity within the Graviton framework. */
 public interface Entity extends Serializable {
@@ -31,26 +29,6 @@ public interface Entity extends Serializable {
     EntityType(String shortName, int index) {
       this.shortName = shortName;
       this.index = index;
-    }
-  }
-
-  /** Class representing an identifier for an entity. */
-  @Getter
-  @AllArgsConstructor
-  @ToString
-  class EntityIdentifier {
-    private NameIdentifier nameIdentifier;
-    private EntityType entityType;
-
-    /**
-     * Create an instance of EntityIdentifier.
-     *
-     * @param name The name identifier of the entity.
-     * @param entityType The type of the entity.
-     * @return The created EntityIdentifier instance.
-     */
-    public static EntityIdentifier of(NameIdentifier name, EntityType entityType) {
-      return new EntityIdentifier(name, entityType);
     }
   }
 

--- a/core/src/main/java/com/datastrato/graviton/GravitonEnv.java
+++ b/core/src/main/java/com/datastrato/graviton/GravitonEnv.java
@@ -7,6 +7,8 @@ package com.datastrato.graviton;
 import com.datastrato.graviton.catalog.CatalogManager;
 import com.datastrato.graviton.catalog.CatalogOperationDispatcher;
 import com.datastrato.graviton.meta.MetalakeManager;
+import com.datastrato.graviton.storage.IdGenerator;
+import com.datastrato.graviton.storage.RandomIdGenerator;
 import com.google.common.base.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -29,6 +31,8 @@ public class GravitonEnv {
   private CatalogOperationDispatcher catalogOperationDispatcher;
 
   private MetalakeManager metalakeManager;
+
+  private IdGenerator idGenerator;
 
   private GravitonEnv() {}
 
@@ -63,11 +67,14 @@ public class GravitonEnv {
     entityStore.initialize(config);
     entityStore.setSerDe(entitySerDe);
 
+    // create and initialize a random id generator
+    this.idGenerator = new RandomIdGenerator();
+
     // Create and initialize metalake related modules
-    this.metalakeManager = new MetalakeManager(entityStore);
+    this.metalakeManager = new MetalakeManager(entityStore, idGenerator);
 
     // Create and initialize Catalog related modules
-    this.catalogManager = new CatalogManager(config, entityStore);
+    this.catalogManager = new CatalogManager(config, entityStore, idGenerator);
     this.catalogOperationDispatcher = new CatalogOperationDispatcher(catalogManager);
 
     LOG.info("Graviton Environment is initialized.");
@@ -126,6 +133,15 @@ public class GravitonEnv {
    */
   public MetalakeManager metalakesManager() {
     return metalakeManager;
+  }
+
+  /**
+   * Get the IdGenerator associated with the Graviton environment.
+   *
+   * @return The IdGenerator instance.
+   */
+  public IdGenerator idGenerator() {
+    return idGenerator;
   }
 
   /** Shutdown the Graviton environment. */

--- a/core/src/main/java/com/datastrato/graviton/HasIdentifier.java
+++ b/core/src/main/java/com/datastrato/graviton/HasIdentifier.java
@@ -15,6 +15,13 @@ public interface HasIdentifier {
   String name();
 
   /**
+   * Get the unique id of the entity.
+   *
+   * @return The unique id of the entity.
+   */
+  Long id();
+
+  /**
    * Get the namespace of the entity.
    *
    * @return The namespace of the entity.
@@ -31,11 +38,4 @@ public interface HasIdentifier {
   default NameIdentifier nameIdentifier() {
     return NameIdentifier.of(namespace(), name());
   }
-
-  /**
-   * Returns a binary compact unique identifier of the entity.
-   *
-   * @return The binary compact unique identifier of the entity.
-   */
-  // TODO. Returns a binary compact unique identifier of the entity. @Jerry
 }

--- a/core/src/main/java/com/datastrato/graviton/meta/BaseMetalake.java
+++ b/core/src/main/java/com/datastrato/graviton/meta/BaseMetalake.java
@@ -37,7 +37,7 @@ public class BaseMetalake implements Metalake, Entity, Auditable, HasIdentifier 
   public static final Field SCHEMA_VERSION =
       Field.required("version", SchemaVersion.class, "The version of the schema for the metalake");
 
-  @Getter private Long id;
+  private Long id;
 
   private String name;
 
@@ -87,6 +87,16 @@ public class BaseMetalake implements Metalake, Entity, Auditable, HasIdentifier 
   @Override
   public String name() {
     return name;
+  }
+
+  /**
+   * The unique id of the metalake.
+   *
+   * @return The unique id of the metalake.
+   */
+  @Override
+  public Long id() {
+    return id;
   }
 
   /**

--- a/core/src/main/java/com/datastrato/graviton/meta/CatalogEntity.java
+++ b/core/src/main/java/com/datastrato/graviton/meta/CatalogEntity.java
@@ -25,8 +25,6 @@ public class CatalogEntity implements Entity, Auditable, HasIdentifier {
 
   public static final Field ID =
       Field.required("id", Long.class, "The catalog's unique identifier");
-  public static final Field METALAKE_ID =
-      Field.required("metalake_id", Long.class, "The associated metalake's unique identifier");
   public static final Field NAME = Field.required("name", String.class, "The catalog's name");
   public static final Field TYPE =
       Field.required("type", Catalog.Type.class, "The type of the catalog");
@@ -37,9 +35,7 @@ public class CatalogEntity implements Entity, Auditable, HasIdentifier {
   public static final Field AUDIT_INFO =
       Field.required("audit_info", AuditInfo.class, "The audit details of the catalog");
 
-  @Getter private Long id;
-
-  @Getter private Long metalakeId;
+  private Long id;
 
   private String name;
 
@@ -62,7 +58,6 @@ public class CatalogEntity implements Entity, Auditable, HasIdentifier {
   public Map<Field, Object> fields() {
     Map<Field, Object> fields = new HashMap<>();
     fields.put(ID, id);
-    fields.put(METALAKE_ID, metalakeId);
     fields.put(NAME, name);
     fields.put(COMMENT, comment);
     fields.put(TYPE, type);
@@ -90,6 +85,11 @@ public class CatalogEntity implements Entity, Auditable, HasIdentifier {
   @Override
   public String name() {
     return name;
+  }
+
+  @Override
+  public Long id() {
+    return id;
   }
 
   /**
@@ -130,17 +130,6 @@ public class CatalogEntity implements Entity, Auditable, HasIdentifier {
      */
     public Builder withId(Long id) {
       catalog.id = id;
-      return this;
-    }
-
-    /**
-     * Sets the unique identifier of the associated metalake.
-     *
-     * @param metalakeId the unique identifier of the metalake.
-     * @return the builder instance.
-     */
-    public Builder withMetalakeId(Long metalakeId) {
-      catalog.metalakeId = metalakeId;
       return this;
     }
 
@@ -238,7 +227,6 @@ public class CatalogEntity implements Entity, Auditable, HasIdentifier {
     }
     CatalogEntity that = (CatalogEntity) o;
     return Objects.equal(id, that.id)
-        && Objects.equal(metalakeId, that.metalakeId)
         && Objects.equal(name, that.name)
         && type == that.type
         && Objects.equal(comment, that.comment)
@@ -253,6 +241,6 @@ public class CatalogEntity implements Entity, Auditable, HasIdentifier {
    */
   @Override
   public int hashCode() {
-    return Objects.hashCode(id, metalakeId, name, type, comment, properties, auditInfo);
+    return Objects.hashCode(id, name, type, comment, properties, auditInfo);
   }
 }

--- a/core/src/main/java/com/datastrato/graviton/meta/MetalakeManager.java
+++ b/core/src/main/java/com/datastrato/graviton/meta/MetalakeManager.java
@@ -14,6 +14,7 @@ import com.datastrato.graviton.SupportsMetalakes;
 import com.datastrato.graviton.exceptions.MetalakeAlreadyExistsException;
 import com.datastrato.graviton.exceptions.NoSuchEntityException;
 import com.datastrato.graviton.exceptions.NoSuchMetalakeException;
+import com.datastrato.graviton.storage.IdGenerator;
 import com.google.common.collect.Maps;
 import java.io.IOException;
 import java.time.Instant;
@@ -28,13 +29,17 @@ public class MetalakeManager implements SupportsMetalakes {
 
   private final EntityStore store;
 
+  private final IdGenerator idGenerator;
+
   /**
    * Constructs a MetalakeManager instance.
    *
    * @param store The EntityStore to use for managing Metalakes.
+   * @param idGenerator The IdGenerator to use for generating Metalake identifiers.
    */
-  public MetalakeManager(EntityStore store) {
+  public MetalakeManager(EntityStore store, IdGenerator idGenerator) {
     this.store = store;
+    this.idGenerator = idGenerator;
   }
 
   /**
@@ -92,7 +97,7 @@ public class MetalakeManager implements SupportsMetalakes {
       throws MetalakeAlreadyExistsException {
     BaseMetalake metalake =
         new BaseMetalake.Builder()
-            .withId(1L /* TODO: Use ID generator */)
+            .withId(idGenerator.nextId())
             .withName(ident.name())
             .withComment(comment)
             .withProperties(properties)
@@ -137,7 +142,7 @@ public class MetalakeManager implements SupportsMetalakes {
           metalake -> {
             BaseMetalake.Builder builder =
                 new BaseMetalake.Builder()
-                    .withId(metalake.getId())
+                    .withId(metalake.id())
                     .withName(metalake.name())
                     .withComment(metalake.comment())
                     .withProperties(metalake.properties())
@@ -188,7 +193,7 @@ public class MetalakeManager implements SupportsMetalakes {
     try {
       return store.delete(ident, EntityType.METALAKE);
     } catch (IOException ioe) {
-      LOG.error("Deletinf metalake {} failed due to storage issues", ident, ioe);
+      LOG.error("Deleting metalake {} failed due to storage issues", ident, ioe);
       throw new RuntimeException(ioe);
     }
   }

--- a/core/src/main/java/com/datastrato/graviton/meta/rel/BaseSchema.java
+++ b/core/src/main/java/com/datastrato/graviton/meta/rel/BaseSchema.java
@@ -16,7 +16,6 @@ import com.google.common.collect.Maps;
 import java.util.Collections;
 import java.util.Map;
 import javax.annotation.Nullable;
-import lombok.Getter;
 import lombok.ToString;
 
 /** An abstract class representing a base schema in a relational database. */
@@ -24,8 +23,6 @@ import lombok.ToString;
 public class BaseSchema implements Schema, Entity, HasIdentifier {
 
   public static final Field ID = Field.required("id", Long.class, "The schema's unique identifier");
-  public static final Field CATALOG_ID =
-      Field.required("catalog_id", Long.class, "The catalog's unique identifier");
   public static final Field NAME = Field.required("name", String.class, "The schema's name");
   public static final Field COMMENT =
       Field.optional("comment", String.class, "The comment or description for the schema");
@@ -34,15 +31,13 @@ public class BaseSchema implements Schema, Entity, HasIdentifier {
   public static final Field AUDIT_INFO =
       Field.required("audit_info", AuditInfo.class, "The audit details of the schema");
 
-  @Getter protected Long id;
-
-  @Getter protected Long catalogId;
+  protected Long id;
 
   protected String name;
 
-  @Nullable @Getter protected String comment;
+  @Nullable protected String comment;
 
-  @Nullable @Getter protected Map<String, String> properties;
+  @Nullable protected Map<String, String> properties;
 
   protected AuditInfo auditInfo;
 
@@ -57,7 +52,6 @@ public class BaseSchema implements Schema, Entity, HasIdentifier {
   public Map<Field, Object> fields() {
     Map<Field, Object> fields = Maps.newHashMap();
     fields.put(ID, id);
-    fields.put(CATALOG_ID, catalogId);
     fields.put(NAME, name);
     fields.put(COMMENT, comment);
     fields.put(PROPERTIES, properties);
@@ -74,6 +68,16 @@ public class BaseSchema implements Schema, Entity, HasIdentifier {
   @Override
   public String name() {
     return name;
+  }
+
+  /**
+   * Returns the unique id of the schema.
+   *
+   * @return The unique id of the schema.
+   */
+  @Override
+  public Long id() {
+    return id;
   }
 
   /**
@@ -137,7 +141,6 @@ public class BaseSchema implements Schema, Entity, HasIdentifier {
     }
     BaseSchema schema = (BaseSchema) o;
     return Objects.equal(id, schema.id)
-        && Objects.equal(catalogId, schema.catalogId)
         && Objects.equal(name, schema.name)
         && Objects.equal(properties, schema.properties)
         && Objects.equal(auditInfo, schema.auditInfo);
@@ -145,7 +148,7 @@ public class BaseSchema implements Schema, Entity, HasIdentifier {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(id, catalogId, name, properties, auditInfo);
+    return Objects.hashCode(id, name, properties, auditInfo);
   }
 
   /**
@@ -156,8 +159,6 @@ public class BaseSchema implements Schema, Entity, HasIdentifier {
    */
   interface Builder<SELF extends Builder<SELF, T>, T extends BaseSchema> {
     SELF withId(Long id);
-
-    SELF withCatalogId(Long catalogId);
 
     SELF withName(String name);
 
@@ -182,7 +183,6 @@ public class BaseSchema implements Schema, Entity, HasIdentifier {
           SELF extends Builder<SELF, T>, T extends BaseSchema>
       implements Builder<SELF, T> {
     protected Long id;
-    protected Long catalogId;
     protected String name;
     protected Namespace namespace;
     protected String comment;
@@ -198,18 +198,6 @@ public class BaseSchema implements Schema, Entity, HasIdentifier {
     @Override
     public SELF withId(Long id) {
       this.id = id;
-      return self();
-    }
-
-    /**
-     * Sets the unique identifier of the catalog.
-     *
-     * @param catalogId The unique identifier of the catalog.
-     * @return The builder instance.
-     */
-    @Override
-    public SELF withCatalogId(Long catalogId) {
-      this.catalogId = catalogId;
       return self();
     }
 
@@ -298,7 +286,6 @@ public class BaseSchema implements Schema, Entity, HasIdentifier {
     protected BaseSchema internalBuild() {
       BaseSchema baseSchema = new BaseSchema();
       baseSchema.id = id;
-      baseSchema.catalogId = catalogId;
       baseSchema.name = name;
       baseSchema.comment = comment;
       baseSchema.properties = properties;

--- a/core/src/main/java/com/datastrato/graviton/meta/rel/BaseTable.java
+++ b/core/src/main/java/com/datastrato/graviton/meta/rel/BaseTable.java
@@ -16,7 +16,6 @@ import com.google.common.base.Objects;
 import com.google.common.collect.Maps;
 import java.util.Map;
 import javax.annotation.Nullable;
-import lombok.Getter;
 import lombok.ToString;
 
 /** An abstract class representing a base table in a relational database. */
@@ -24,8 +23,6 @@ import lombok.ToString;
 public class BaseTable implements Table, Entity, HasIdentifier {
 
   public static final Field ID = Field.required("id", Long.class, "The table's unique identifier");
-  public static final Field SCHEMA_ID =
-      Field.required("schema_id", Long.class, "The schema's unique identifier");
   public static final Field NAME = Field.required("name", String.class, "The table's name");
   public static final Field COMMENT =
       Field.optional("comment", String.class, "The comment or description for the table");
@@ -38,9 +35,7 @@ public class BaseTable implements Table, Entity, HasIdentifier {
   public static final Field COLUMNS =
       Field.optional("columns", Column[].class, "The columns that make up the table");
 
-  @Getter protected Long id;
-
-  @Getter protected Long schemaId;
+  protected Long id;
 
   protected String name;
 
@@ -63,7 +58,6 @@ public class BaseTable implements Table, Entity, HasIdentifier {
   public Map<Field, Object> fields() {
     Map<Field, Object> fields = Maps.newHashMap();
     fields.put(ID, id);
-    fields.put(SCHEMA_ID, schemaId);
     fields.put(NAME, name);
     fields.put(COMMENT, comment);
     fields.put(PROPERTIES, properties);
@@ -91,6 +85,16 @@ public class BaseTable implements Table, Entity, HasIdentifier {
   @Override
   public String name() {
     return name;
+  }
+
+  /**
+   * Returns the unique id of the table.
+   *
+   * @return The unique id of the table.
+   */
+  @Override
+  public Long id() {
+    return id;
   }
 
   /**
@@ -156,7 +160,6 @@ public class BaseTable implements Table, Entity, HasIdentifier {
 
     BaseTable baseTable = (BaseTable) o;
     return Objects.equal(id, baseTable.id)
-        && Objects.equal(schemaId, baseTable.schemaId)
         && Objects.equal(name, baseTable.name)
         && Objects.equal(properties, baseTable.properties)
         && Objects.equal(auditInfo, baseTable.auditInfo);
@@ -164,7 +167,7 @@ public class BaseTable implements Table, Entity, HasIdentifier {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(id, schemaId, name, properties, auditInfo);
+    return Objects.hashCode(id, name, comment, properties, auditInfo);
   }
 
   /**
@@ -175,8 +178,6 @@ public class BaseTable implements Table, Entity, HasIdentifier {
    */
   interface Builder<SELF extends Builder<SELF, T>, T extends BaseTable> {
     SELF withId(Long id);
-
-    SELF withSchemaId(Long schemaId);
 
     SELF withNameSpace(Namespace namespace);
 
@@ -202,7 +203,6 @@ public class BaseTable implements Table, Entity, HasIdentifier {
   public abstract static class BaseTableBuilder<SELF extends Builder<SELF, T>, T extends BaseTable>
       implements Builder<SELF, T> {
     protected Long id;
-    protected Long schemaId;
     protected String name;
     protected Namespace namespace;
     protected String comment;
@@ -219,18 +219,6 @@ public class BaseTable implements Table, Entity, HasIdentifier {
     @Override
     public SELF withId(Long id) {
       this.id = id;
-      return self();
-    }
-
-    /**
-     * Sets the unique identifier of the schema.
-     *
-     * @param schemaId The unique identifier of the schema.
-     * @return The builder instance.
-     */
-    @Override
-    public SELF withSchemaId(Long schemaId) {
-      this.schemaId = schemaId;
       return self();
     }
 
@@ -330,7 +318,6 @@ public class BaseTable implements Table, Entity, HasIdentifier {
     protected BaseTable internalBuild() {
       BaseTable table = new BaseTable();
       table.id = id;
-      table.schemaId = schemaId;
       table.name = name;
       table.comment = comment;
       table.properties = properties;

--- a/core/src/main/java/com/datastrato/graviton/proto/BaseMetalakeSerDe.java
+++ b/core/src/main/java/com/datastrato/graviton/proto/BaseMetalakeSerDe.java
@@ -21,7 +21,7 @@ class BaseMetalakeSerDe implements ProtoSerDe<com.datastrato.graviton.meta.BaseM
   public Metalake serialize(com.datastrato.graviton.meta.BaseMetalake baseMetalake) {
     Metalake.Builder builder =
         Metalake.newBuilder()
-            .setId(baseMetalake.getId())
+            .setId(baseMetalake.id())
             .setName(baseMetalake.name())
             .setAuditInfo(new AuditInfoSerDe().serialize((AuditInfo) baseMetalake.auditInfo()));
 

--- a/core/src/main/java/com/datastrato/graviton/proto/CatalogEntitySerDe.java
+++ b/core/src/main/java/com/datastrato/graviton/proto/CatalogEntitySerDe.java
@@ -21,8 +21,7 @@ public class CatalogEntitySerDe implements ProtoSerDe<CatalogEntity, Catalog> {
   public Catalog serialize(CatalogEntity catalogEntity) {
     Catalog.Builder builder =
         Catalog.newBuilder()
-            .setId(catalogEntity.getId())
-            .setMetalakeId(catalogEntity.getMetalakeId())
+            .setId(catalogEntity.id())
             .setName(catalogEntity.name())
             .setAuditInfo(new AuditInfoSerDe().serialize((AuditInfo) catalogEntity.auditInfo()));
 
@@ -54,7 +53,6 @@ public class CatalogEntitySerDe implements ProtoSerDe<CatalogEntity, Catalog> {
     builder
         .withId(p.getId())
         .withName(p.getName())
-        .withMetalakeId(p.getMetalakeId())
         .withAuditInfo(new AuditInfoSerDe().deserialize(p.getAuditInfo()));
 
     if (p.hasComment()) {

--- a/core/src/main/java/com/datastrato/graviton/proto/SchemaEntitySerDe.java
+++ b/core/src/main/java/com/datastrato/graviton/proto/SchemaEntitySerDe.java
@@ -10,8 +10,7 @@ public class SchemaEntitySerDe implements ProtoSerDe<BaseSchema, Schema> {
   @Override
   public Schema serialize(BaseSchema schemaEntity) {
     return Schema.newBuilder()
-        .setId(schemaEntity.getId())
-        .setCatalogId(schemaEntity.getCatalogId())
+        .setId(schemaEntity.id())
         .setName(schemaEntity.name())
         .setAuditInfo(new AuditInfoSerDe().serialize(schemaEntity.auditInfo()))
         .build();
@@ -21,7 +20,6 @@ public class SchemaEntitySerDe implements ProtoSerDe<BaseSchema, Schema> {
   public BaseSchema deserialize(Schema p) {
     return new BaseSchema.SchemaBuilder()
         .withId(p.getId())
-        .withCatalogId(p.getCatalogId())
         .withName(p.getName())
         .withAuditInfo(new AuditInfoSerDe().deserialize(p.getAuditInfo()))
         .build();

--- a/core/src/main/java/com/datastrato/graviton/proto/TableEntitySerde.java
+++ b/core/src/main/java/com/datastrato/graviton/proto/TableEntitySerde.java
@@ -10,8 +10,7 @@ public class TableEntitySerde implements ProtoSerDe<BaseTable, Table> {
   @Override
   public Table serialize(BaseTable tableEntity) {
     return Table.newBuilder()
-        .setId(tableEntity.getId())
-        .setSchemaId(tableEntity.getSchemaId())
+        .setId(tableEntity.id())
         .setName(tableEntity.name())
         .setAuditInfo(new AuditInfoSerDe().serialize(tableEntity.auditInfo()))
         .build();
@@ -21,7 +20,6 @@ public class TableEntitySerde implements ProtoSerDe<BaseTable, Table> {
   public BaseTable deserialize(Table p) {
     return new BaseTable.TableBuilder()
         .withId(p.getId())
-        .withSchemaId(p.getSchemaId())
         .withName(p.getName())
         .withAuditInfo(new AuditInfoSerDe().deserialize(p.getAuditInfo()))
         .build();

--- a/core/src/test/java/com/datastrato/graviton/TestCatalogOperations.java
+++ b/core/src/test/java/com/datastrato/graviton/TestCatalogOperations.java
@@ -56,7 +56,16 @@ public class TestCatalogOperations implements CatalogOperations, TableCatalog {
         new AuditInfo.Builder().withCreator("test").withCreateTime(Instant.now()).build();
 
     TestTable table =
-        new TestTable(ident.name(), ident.namespace(), comment, properties, auditInfo, columns);
+        new TestTable.Builder()
+            .withId(1L)
+            .withName(ident.name())
+            .withNameSpace(ident.namespace())
+            .withComment(comment)
+            .withProperties(properties)
+            .withAuditInfo(auditInfo)
+            .withColumns(columns)
+            .build();
+
     if (tables.containsKey(ident)) {
       throw new TableAlreadyExistsException("Table " + ident + " already exists");
     } else {

--- a/core/src/test/java/com/datastrato/graviton/TestColumn.java
+++ b/core/src/test/java/com/datastrato/graviton/TestColumn.java
@@ -4,69 +4,27 @@
  */
 package com.datastrato.graviton;
 
-import com.datastrato.graviton.rel.Column;
-import io.substrait.type.Type;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-import javax.annotation.Nullable;
+import com.datastrato.graviton.meta.rel.BaseColumn;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = true)
 @ToString
-public class TestColumn implements Column, Entity, HasIdentifier {
+public class TestColumn extends BaseColumn {
 
-  public static final Field NAME = Field.required("name", String.class, "The name of the column");
-  public static final Field COMMENT =
-      Field.optional("comment", String.class, "The comment of the column");
-  public static final Field TYPE = Field.required("type", Type.class, "The type of the column");
+  private TestColumn() {}
 
-  private String name;
+  public static class Builder extends BaseColumn.BaseColumnBuilder<Builder, TestColumn> {
 
-  private String comment;
+    @Override
+    protected TestColumn internalBuild() {
+      TestColumn column = new TestColumn();
 
-  private Type dataType;
+      column.name = name;
+      column.comment = comment;
+      column.dataType = dataType;
 
-  public TestColumn(String name, String comment, Type dataType) {
-    this.name = name;
-    this.comment = comment;
-    this.dataType = dataType;
-
-    validate();
-  }
-
-  // For Jackson Deserialization only.
-  public TestColumn() {}
-
-  @Override
-  public Map<Field, Object> fields() {
-    Map<Field, Object> fields = new HashMap<>();
-    fields.put(NAME, name);
-    fields.put(COMMENT, comment);
-    fields.put(TYPE, dataType);
-
-    return Collections.unmodifiableMap(fields);
-  }
-
-  @Override
-  public String name() {
-    return name;
-  }
-
-  @Override
-  public Type dataType() {
-    return dataType;
-  }
-
-  @Nullable
-  @Override
-  public String comment() {
-    return comment;
-  }
-
-  @Override
-  public EntityType type() {
-    return EntityType.COLUMN;
+      return column;
+    }
   }
 }

--- a/core/src/test/java/com/datastrato/graviton/TestEntityStore.java
+++ b/core/src/test/java/com/datastrato/graviton/TestEntityStore.java
@@ -157,20 +157,26 @@ public class TestEntityStore {
             .withName("catalog")
             .withNamespace(Namespace.of("metalake"))
             .withType(TestCatalog.Type.RELATIONAL)
-            .withMetalakeId(1L)
             .withAuditInfo(auditInfo)
             .build();
 
-    TestColumn column = new TestColumn("column", "comment", TypeCreator.NULLABLE.I8);
+    TestColumn column =
+        new TestColumn.Builder()
+            .withName("column")
+            .withComment("comment")
+            .withType(TypeCreator.NULLABLE.I8)
+            .build();
 
     TestTable table =
-        new TestTable(
-            "table",
-            Namespace.of("metalake", "catalog", "db"),
-            "comment",
-            Maps.newHashMap(),
-            auditInfo,
-            new Column[] {column});
+        new TestTable.Builder()
+            .withId(1L)
+            .withName("table")
+            .withNameSpace(Namespace.of("metalake", "catalog", "db"))
+            .withComment("comment")
+            .withProperties(Maps.newHashMap())
+            .withColumns(new Column[] {column})
+            .withAuditInfo(auditInfo)
+            .build();
 
     InMemoryEntityStore store = new InMemoryEntityStore();
     store.initialize(Mockito.mock(Config.class));

--- a/core/src/test/java/com/datastrato/graviton/TestTable.java
+++ b/core/src/test/java/com/datastrato/graviton/TestTable.java
@@ -4,100 +4,29 @@
  */
 package com.datastrato.graviton;
 
-import com.datastrato.graviton.meta.AuditInfo;
-import com.datastrato.graviton.rel.Column;
-import com.datastrato.graviton.rel.Table;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
+import com.datastrato.graviton.meta.rel.BaseTable;
 import lombok.EqualsAndHashCode;
 
-@EqualsAndHashCode
-public class TestTable implements Table, Entity, HasIdentifier, Auditable {
+@EqualsAndHashCode(callSuper = true)
+public class TestTable extends BaseTable {
 
-  public static final Field NAME = Field.required("name", String.class, "The name of the table");
-  public static final Field COMMENT =
-      Field.optional("comment", String.class, "The comment of the table");
-  public static final Field PROPERTIES =
-      Field.optional("properties", Map.class, "The properties of the table");
-  public static final Field AUDIT_INFO =
-      Field.required("audit_info", AuditInfo.class, "The audit info of the table");
+  private TestTable() {}
 
-  private String name;
+  public static class Builder extends BaseTable.BaseTableBuilder<Builder, TestTable> {
 
-  private Namespace namespace;
+    @Override
+    protected TestTable internalBuild() {
+      TestTable table = new TestTable();
 
-  private String comment;
+      table.id = id;
+      table.name = name;
+      table.comment = comment;
+      table.namespace = namespace;
+      table.properties = properties;
+      table.columns = columns;
+      table.auditInfo = auditInfo;
 
-  private Map<String, String> properties;
-
-  private AuditInfo auditInfo;
-
-  private Column[] columns;
-
-  public TestTable(
-      String name,
-      Namespace namespace,
-      String comment,
-      Map<String, String> properties,
-      AuditInfo auditInfo,
-      Column[] columns) {
-    this.name = name;
-    this.namespace = namespace;
-    this.comment = comment;
-    this.properties = properties;
-    this.auditInfo = auditInfo;
-    this.columns = columns;
-
-    validate();
-  }
-
-  // For Jackson Deserialization only.
-  public TestTable() {}
-
-  @Override
-  public Map<Field, Object> fields() {
-    Map<Field, Object> fields = new HashMap<>();
-    fields.put(NAME, name);
-    fields.put(COMMENT, comment);
-    fields.put(PROPERTIES, properties);
-    fields.put(AUDIT_INFO, auditInfo);
-
-    return Collections.unmodifiableMap(fields);
-  }
-
-  @Override
-  public String name() {
-    return name;
-  }
-
-  @Override
-  public Namespace namespace() {
-    return namespace;
-  }
-
-  @Override
-  public AuditInfo auditInfo() {
-    return auditInfo;
-  }
-
-  @Override
-  public Column[] columns() {
-    return columns;
-  }
-
-  @Override
-  public String comment() {
-    return comment;
-  }
-
-  @Override
-  public Map<String, String> properties() {
-    return properties;
-  }
-
-  @Override
-  public EntityType type() {
-    return EntityType.TABLE;
+      return table;
+    }
   }
 }

--- a/core/src/test/java/com/datastrato/graviton/catalog/TestCatalogManager.java
+++ b/core/src/test/java/com/datastrato/graviton/catalog/TestCatalogManager.java
@@ -17,6 +17,7 @@ import com.datastrato.graviton.exceptions.NoSuchMetalakeException;
 import com.datastrato.graviton.meta.AuditInfo;
 import com.datastrato.graviton.meta.BaseMetalake;
 import com.datastrato.graviton.meta.SchemaVersion;
+import com.datastrato.graviton.storage.RandomIdGenerator;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
 import java.io.IOException;
@@ -57,7 +58,7 @@ public class TestCatalogManager {
             .build();
     entityStore.put(metalakeEntity, true);
 
-    catalogManager = new CatalogManager(config, entityStore);
+    catalogManager = new CatalogManager(config, entityStore, new RandomIdGenerator());
   }
 
   @AfterAll

--- a/core/src/test/java/com/datastrato/graviton/meta/TestEntity.java
+++ b/core/src/test/java/com/datastrato/graviton/meta/TestEntity.java
@@ -55,7 +55,6 @@ public class TestEntity {
     CatalogEntity testCatalog =
         new CatalogEntity.Builder()
             .withId(catalogId)
-            .withMetalakeId(metalakeId)
             .withName(catalogName)
             .withComment(catalogComment)
             .withType(type)
@@ -65,7 +64,6 @@ public class TestEntity {
 
     Map<Field, Object> fields = testCatalog.fields();
     Assertions.assertEquals(catalogId, fields.get(CatalogEntity.ID));
-    Assertions.assertEquals(metalakeId, fields.get(CatalogEntity.METALAKE_ID));
     Assertions.assertEquals(catalogName, fields.get(CatalogEntity.NAME));
     Assertions.assertEquals(catalogComment, fields.get(CatalogEntity.COMMENT));
     Assertions.assertEquals(type, fields.get(CatalogEntity.TYPE));

--- a/core/src/test/java/com/datastrato/graviton/meta/TestMetalakeManager.java
+++ b/core/src/test/java/com/datastrato/graviton/meta/TestMetalakeManager.java
@@ -11,6 +11,7 @@ import com.datastrato.graviton.NameIdentifier;
 import com.datastrato.graviton.TestEntityStore;
 import com.datastrato.graviton.exceptions.MetalakeAlreadyExistsException;
 import com.datastrato.graviton.exceptions.NoSuchMetalakeException;
+import com.datastrato.graviton.storage.RandomIdGenerator;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
 import java.io.IOException;
@@ -37,7 +38,7 @@ public class TestMetalakeManager {
     entityStore.initialize(config);
     entityStore.setSerDe(null);
 
-    metalakeManager = new MetalakeManager(entityStore);
+    metalakeManager = new MetalakeManager(entityStore, new RandomIdGenerator());
   }
 
   @AfterAll

--- a/core/src/test/java/com/datastrato/graviton/meta/rel/TestBaseSchema.java
+++ b/core/src/test/java/com/datastrato/graviton/meta/rel/TestBaseSchema.java
@@ -26,7 +26,6 @@ class BaseSchemaTest {
   void testSchemaFields() {
     BaseSchema schema = new BaseSchemaExtension();
     schema.id = 1L;
-    schema.catalogId = 2L;
     schema.name = "testSchemaName";
     schema.comment = "testSchemaComment";
     schema.properties = new HashMap<>();
@@ -36,14 +35,12 @@ class BaseSchemaTest {
         new AuditInfo.Builder().withCreator("Justin").withCreateTime(Instant.now()).build();
     Map<Field, Object> expectedFields = Maps.newHashMap();
     expectedFields.put(BaseSchema.ID, 1L);
-    expectedFields.put(BaseSchema.CATALOG_ID, 2L);
     expectedFields.put(BaseSchema.NAME, "testSchemaName");
     expectedFields.put(BaseSchema.COMMENT, "testSchemaComment");
     expectedFields.put(BaseSchema.PROPERTIES, schema.properties);
     expectedFields.put(BaseSchema.AUDIT_INFO, schema.auditInfo);
 
     assertEquals(1L, schema.fields().get(BaseSchema.ID));
-    assertEquals(2L, schema.fields().get(BaseSchema.CATALOG_ID));
     assertEquals("testSchemaName", schema.fields().get(BaseSchema.NAME));
     assertEquals("testSchemaComment", schema.fields().get(BaseSchema.COMMENT));
     assertEquals(schema.properties, schema.fields().get(BaseSchema.PROPERTIES));
@@ -62,7 +59,6 @@ class BaseSchemaTest {
     Instant now = Instant.now();
     BaseSchema schema1 = new BaseSchemaExtension();
     schema1.id = 1L;
-    schema1.catalogId = 2L;
     schema1.name = "testSchemaName";
     schema1.comment = "testSchemaComment";
     schema1.properties = new HashMap<>();
@@ -72,7 +68,6 @@ class BaseSchemaTest {
 
     BaseSchema schema2 = new BaseSchemaExtension();
     schema2.id = 1L;
-    schema2.catalogId = 2L;
     schema2.name = "testSchemaName";
     schema2.comment = "testSchemaComment";
     schema2.properties = new HashMap<>();

--- a/core/src/test/java/com/datastrato/graviton/meta/rel/TestBaseTable.java
+++ b/core/src/test/java/com/datastrato/graviton/meta/rel/TestBaseTable.java
@@ -28,7 +28,6 @@ class BaseTableTest {
   void testTableFields() {
     BaseTable table = new BaseTableExtension();
     table.id = 1L;
-    table.schemaId = 2L;
     table.name = "testTableName";
     table.comment = "testTableComment";
     table.properties = new HashMap<>();
@@ -40,7 +39,6 @@ class BaseTableTest {
 
     Map<Field, Object> expectedFields = Maps.newHashMap();
     expectedFields.put(BaseTable.ID, 1L);
-    expectedFields.put(BaseTable.SCHEMA_ID, 2L);
     expectedFields.put(BaseTable.NAME, "testTableName");
     expectedFields.put(BaseTable.COMMENT, "testTableComment");
     expectedFields.put(BaseTable.PROPERTIES, table.properties);
@@ -48,7 +46,6 @@ class BaseTableTest {
     expectedFields.put(BaseTable.COLUMNS, table.columns);
 
     assertEquals(1L, table.fields().get(BaseTable.ID));
-    assertEquals(2L, table.fields().get(BaseTable.SCHEMA_ID));
     assertEquals("testTableName", table.fields().get(BaseTable.NAME));
     assertEquals("testTableComment", table.fields().get(BaseTable.COMMENT));
     assertEquals(table.properties, table.fields().get(BaseTable.PROPERTIES));
@@ -68,7 +65,6 @@ class BaseTableTest {
     Instant now = Instant.now();
     BaseTable table1 = new BaseTableExtension();
     table1.id = 1L;
-    table1.schemaId = 2L;
     table1.name = "testTableName";
     table1.comment = "testTableComment";
     table1.properties = new HashMap<>();
@@ -79,7 +75,6 @@ class BaseTableTest {
 
     BaseTable table2 = new BaseTableExtension();
     table2.id = 1L;
-    table2.schemaId = 2L;
     table2.name = "testTableName";
     table2.comment = "testTableComment";
     table2.properties = new HashMap<>();

--- a/core/src/test/java/com/datastrato/graviton/proto/TestEntityProtoSerDe.java
+++ b/core/src/test/java/com/datastrato/graviton/proto/TestEntityProtoSerDe.java
@@ -118,7 +118,6 @@ public class TestEntityProtoSerDe {
     com.datastrato.graviton.meta.CatalogEntity catalogEntity =
         new com.datastrato.graviton.meta.CatalogEntity.Builder()
             .withId(catalogId)
-            .withMetalakeId(metalakeId)
             .withName(catalogName)
             .withComment(comment)
             .withType(com.datastrato.graviton.Catalog.Type.RELATIONAL)

--- a/core/src/test/java/com/datastrato/graviton/storage/kv/TestKvEntityStorage.java
+++ b/core/src/test/java/com/datastrato/graviton/storage/kv/TestKvEntityStorage.java
@@ -63,7 +63,6 @@ public class TestKvEntityStorage {
       BaseSchema baseSchema = new BaseSchema();
       try {
         setField(baseSchema, "id", id);
-        setField(baseSchema, "catalogId", catalogId);
         setField(baseSchema, "namespace", namespace);
         setField(baseSchema, "name", name);
         setField(baseSchema, "comment", comment);
@@ -90,7 +89,6 @@ public class TestKvEntityStorage {
       BaseTable baseTable = new BaseTable();
       try {
         setField(baseTable, "id", id);
-        setField(baseTable, "schemaId", schemaId);
         setField(baseTable, "namespace", namespace);
         setField(baseTable, "name", name);
         setField(baseTable, "comment", comment);
@@ -126,7 +124,6 @@ public class TestKvEntityStorage {
         .withName(name)
         .withNamespace(namespace)
         .withType(Type.RELATIONAL)
-        .withMetalakeId(1L)
         .withAuditInfo(auditInfo)
         .build();
   }
@@ -135,7 +132,6 @@ public class TestKvEntityStorage {
     return new MockSchemaBuilder()
         .withId(1L)
         .withName(name)
-        .withCatalogId(1L)
         .withNamespace(namespace)
         .withAuditInfo(auditInfo)
         .withComment("a schmea")
@@ -145,7 +141,6 @@ public class TestKvEntityStorage {
   public BaseTable createBaseTable(Namespace namespace, String name, AuditInfo auditInfo) {
     return new MockTableBuilder()
         .withId(1L)
-        .withSchemaId(1L)
         .withName(name)
         .withNameSpace(namespace)
         .withAuditInfo(auditInfo)

--- a/meta/src/main/proto/graviton_meta.proto
+++ b/meta/src/main/proto/graviton_meta.proto
@@ -49,24 +49,21 @@ message Catalog {
   }
 
   uint64 id = 1;
-  uint64 metalake_id = 2;
-  string name = 3;
-  Type type = 4;
-  optional string comment = 5;
-  map<string, string> properties = 6;
-  AuditInfo audit_info = 7;
+  string name = 2;
+  Type type = 3;
+  optional string comment = 4;
+  map<string, string> properties = 5;
+  AuditInfo audit_info = 6;
 }
 
 message Schema {
   uint64 id = 1;
-  uint64 catalog_id = 2;
-  string name = 3;
-  AuditInfo audit_info = 4;
+  string name = 2;
+  AuditInfo audit_info = 3;
 }
 
 message Table {
   uint64 id = 1;
-  uint64 schema_id = 2;
-  string name = 3;
-  AuditInfo audit_info = 4;
+  string name = 2;
+  AuditInfo audit_info = 3;
 }

--- a/server/src/test/java/com/datastrato/graviton/server/web/rest/TestCatalogOperations.java
+++ b/server/src/test/java/com/datastrato/graviton/server/web/rest/TestCatalogOperations.java
@@ -376,7 +376,6 @@ public class TestCatalogOperations extends JerseyTest {
     CatalogEntity entity =
         new CatalogEntity.Builder()
             .withId(1L)
-            .withMetalakeId(1L)
             .withName(catalogName)
             .withComment("comment")
             .withNamespace(Namespace.of(metalake))


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to make some changes to entity's ID field.

1. Assign a unique ID for each entity when creating.
2. Remove the parent ID field for catalog, schema and table entity (since it is useless currently).

### Why are the changes needed?

This is the subtask for #250 . With unique ID assigned to each entity, we could leverage this unique ID as a "record" or "watermark" to be bound between the underlying sources and graviton store, which can guarantee the SSOT of entities.

Fix: #168

### Does this PR introduce _any_ user-facing change?

1. This change removes the parent id field of catalog, schema, and table entity's proto definition.

### How was this patch tested?

With the existing UTs.
