### PR TITLE
[#388] fix(IT): Fix `/api/version` RESTful API throws NPE

### DIFF
--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -59,29 +59,36 @@ fun getGitCommitId(): String {
   return refHead.readText().trim()
 }
 
-tasks.register("writeProjectPropertiesFile") {
-  val propertiesFile = file("src/main/resources/project.properties")
+val propertiesFile = "src/main/resources/project.properties"
+fun writeProjectPropertiesFile() {
+  val propertiesFile = file(propertiesFile)
+  if (propertiesFile.exists()) {
+    propertiesFile.delete();
+  }
+
   val dateFormat = SimpleDateFormat("dd/MM/yyyy HH:mm:ss")
 
-  doLast {
-    val compileDate = dateFormat.format(Date())
-    val projectVersion = project.version.toString()
-    val commitId = getGitCommitId()
+  val compileDate = dateFormat.format(Date())
+  val projectVersion = project.version.toString()
+  val commitId = getGitCommitId()
 
-    propertiesFile.parentFile.mkdirs()
-    propertiesFile.createNewFile()
-    propertiesFile.writer().use { writer ->
-      writer.write("#\n" +
-              "# Copyright 2023 Datastrato.\n" +
-              "# This software is licensed under the Apache License version 2.\n" +
-              "#\n")
-      writer.write("project.version=$projectVersion\n")
-      writer.write("compile.date=$compileDate\n")
-      writer.write("git.commit.id=$commitId\n")
-    }
+  propertiesFile.parentFile.mkdirs()
+  propertiesFile.createNewFile()
+  propertiesFile.writer().use { writer ->
+    writer.write("#\n" +
+            "# Copyright 2023 Datastrato.\n" +
+            "# This software is licensed under the Apache License version 2.\n" +
+            "#\n")
+    writer.write("project.version=$projectVersion\n")
+    writer.write("compile.date=$compileDate\n")
+    writer.write("git.commit.id=$commitId\n")
   }
 }
 
 tasks.named("build") {
-  dependsOn("writeProjectPropertiesFile")
+  writeProjectPropertiesFile()
+  val file = file(propertiesFile)
+  if (!file.exists()) {
+    throw GradleException("$propertiesFile file not generated!")
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

When we execute `./gradlew bulid` command. then the Graviton `server` module will execute `writeProjectPropertiesFile` and `build` jobs. But Gradle is a parallel execution jobs system.  It's possible for `writeProjectPropertiesFile` to be after the `build` job. Then `graviton-server-version.jar` JAR package didn't contain `project.properties` file.

When you call `/api/version` RESTful API interface, Graviton server can't read `project.properties` file in the `graviton-server-version.jar` JAR package, So throws NPE.

### Why are the changes needed?

```
Caused by: java.lang.NullPointerException
	at java.util.Properties$LineReader.readLine(Properties.java:434) ~[?:1.8.0_382]
	at java.util.Properties.load0(Properties.java:353) ~[?:1.8.0_382]
	at java.util.Properties.load(Properties.java:341) ~[?:1.8.0_382]
	at com.datastrato.graviton.server.web.rest.VersionOperations.getVersion(VersionOperations.java:29) ~[graviton-server-0.2.0-SNAPSHOT.jar:?]
```

Fix: #388 

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

CI Passed
