### PR TITLE
[#391] feat(catalog-lakehouse): Build catalog-lakehouse dependent JAR into catalogs directory

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,7 +40,7 @@ subprojects {
   }
 
   tasks.configureEach<Test> {
-    // Integration test module are tested sepatately
+    // Integration test module are tested separately
     if (project.name != "integration-test") {
       useJUnitPlatform()
       finalizedBy(tasks.getByName("jacocoTestReport"))
@@ -79,14 +79,14 @@ subprojects {
         removeUnusedImports()
         trimTrailingWhitespace()
         replaceRegex(
-                "Remove wildcard imports",
-                "import\\s+[^\\*\\s]+\\*;(\\r\\n|\\r|\\n)",
-                "$1"
+          "Remove wildcard imports",
+          "import\\s+[^\\*\\s]+\\*;(\\r\\n|\\r|\\n)",
+          "$1"
         )
         replaceRegex(
-                "Remove static wildcard imports",
-                "import\\s+(?:static\\s+)?[^*\\s]+\\*;(\\r\\n|\\r|\\n)",
-                "$1"
+          "Remove static wildcard imports",
+          "import\\s+(?:static\\s+)?[^*\\s]+\\*;(\\r\\n|\\r|\\n)",
+          "$1"
         )
 
         targetExclude("**/build/**")
@@ -153,7 +153,7 @@ tasks {
   val outputDir = projectDir.dir("distribution")
 
   val compileDistribution by registering {
-    dependsOn("copyRuntimeClass", "copyCatalogRuntimeClass", "copySubmoduleClass", "copyCatalogModuleClass")
+    dependsOn("copySubprojectDepends", "copyCatalogLibs", "copySubprojectLib")
 
     group = "graviton distribution"
     outputs.dir(projectDir.dir("distribution/package"))
@@ -205,30 +205,20 @@ tasks {
     delete("server/src/main/resources/project.properties")
   }
 
-  val copyRuntimeClass by registering(Copy::class) {
+  val copySubprojectDepends by registering(Copy::class) {
+    dependsOn(":catalog-hive:copyDepends", ":catalog-lakehouse:copyDepends")
     subprojects.forEach() {
-      if (it.name != "catalog-hive" && it.name != "client-java" && it.name != "integration-test") {
-        println("copyRuntimeClass: ${it.name}")
+      if (it.name != "catalog-hive" && it.name != "client-java" && it.name != "integration-test" && it.name != "catalog-lakehouse") {
         from(it.configurations.runtimeClasspath)
         into("distribution/package/libs")
       }
     }
   }
 
-  val copyCatalogRuntimeClass by registering(Copy::class) {
+  val copySubprojectLib by registering(Copy::class) {
     subprojects.forEach() {
-      if (it.name == "catalog-hive") {
-        // println("copyCatalogRuntimeClass: ${it.name}")
-        from(it.configurations.runtimeClasspath)
-        into("distribution/package/catalogs/hive/libs")
-      }
-    }
-  }
-
-  val copySubmoduleClass by registering(Copy::class) {
-    dependsOn("copyRuntimeClass", "copyCatalogRuntimeClass")
-    subprojects.forEach() {
-      if (it.name != "client-java" && it.name != "integration-test" && it.name != "catalog-hive") {
+      if (it.name != "client-java" && it.name != "integration-test" && it.name != "catalog-hive" && it.name != "catalog-lakehouse") {
+        dependsOn("${it.name}:build")
         from("${it.name}/build/libs")
         into("distribution/package/libs")
         include("*.jar")
@@ -237,16 +227,12 @@ tasks {
     }
   }
 
-  val copyCatalogModuleClass by registering(Copy::class) {
-    subprojects.forEach() {
-      if (it.name == "catalog-hive") {
-        from("${it.name}/build/libs")
-        into("distribution/package/catalogs/hive/libs")
-      }
-    }
+  val copyCatalogLibs by registering(Copy::class) {
+    dependsOn(":catalog-hive:copyCatalogLibs", ":catalog-lakehouse:copyCatalogLibs")
   }
 
   task("integrationTest") {
+    mustRunAfter(":catalog-hive:copyDepends", ":catalog-lakehouse:copyDepends")
     dependsOn(":integration-test:integrationTest")
   }
 

--- a/catalog-hive/build.gradle.kts
+++ b/catalog-hive/build.gradle.kts
@@ -79,3 +79,16 @@ dependencies {
     testRuntimeOnly(libs.junit.jupiter.engine)
     testImplementation(libs.mockito.core)
 }
+
+tasks {
+    val copyDepends by registering(Copy::class) {
+        from(configurations.runtimeClasspath)
+        into("build/libs")
+    }
+
+    val copyCatalogLibs by registering(Copy::class) {
+        dependsOn(copyDepends)
+        from("build/libs")
+        into("${rootDir}/distribution/package/catalogs/hive/libs")
+    }
+}

--- a/catalog-lakehouse/build.gradle.kts
+++ b/catalog-lakehouse/build.gradle.kts
@@ -39,3 +39,15 @@ dependencies {
       exclude(group = "org.junit.jupiter")
     }
 }
+
+tasks {
+    val copyDepends by registering(Copy::class) {
+        from(configurations.runtimeClasspath)
+        into("build/libs")
+    }
+    val copyCatalogLibs by registering(Copy::class) {
+        dependsOn(copyDepends)
+        from("build/libs")
+        into("${rootDir}/distribution/package/catalogs/lakehouse/libs")
+    }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

+ Added `catalog-lakehouse` job in the Gradle build scripts.
+ Use better names for some jobs


```
├── bin
├── conf
└── distribution/package
    ├── bin/
    ├── catalogs/hive/libs
    ├── catalogs/lakehouse/libs
    ├── conf/
    └── libs/
```

### Why are the changes needed?

Currently, building `catalog-lakehouse` module can't move dependent JAR into `${graviton}/distribution/package/catalogs/`. It may be in conflict with Graviton.

Fix: #391 

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

CI passed
