### PR TITLE
[#368] feat(catalog-lakehouse): add optional prefix to Iceberg REST query path

### DIFF
--- a/catalog-lakehouse/build.gradle.kts
+++ b/catalog-lakehouse/build.gradle.kts
@@ -19,6 +19,7 @@ dependencies {
     implementation(libs.jackson.datatype.jdk8)
     implementation(libs.jackson.datatype.jsr310)
     implementation(libs.guava)
+    implementation(libs.commons.lang3)
     implementation(libs.bundles.log4j)
     implementation(libs.bundles.jetty)
     implementation(libs.bundles.jersey)

--- a/catalog-lakehouse/src/main/java/com/datastrato/graviton/catalog/lakehouse/iceberg/web/rest/IcebergConfig.java
+++ b/catalog-lakehouse/src/main/java/com/datastrato/graviton/catalog/lakehouse/iceberg/web/rest/IcebergConfig.java
@@ -15,7 +15,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import org.apache.iceberg.rest.responses.ConfigResponse;
 
-@Path("/v1/config")
+@Path("/v1/{prefix:([^/]*/)?}config")
 @Consumes(MediaType.APPLICATION_JSON)
 @Produces(MediaType.APPLICATION_JSON)
 public class IcebergConfig {

--- a/catalog-lakehouse/src/main/java/com/datastrato/graviton/catalog/lakehouse/iceberg/web/rest/IcebergNamespaceOperations.java
+++ b/catalog-lakehouse/src/main/java/com/datastrato/graviton/catalog/lakehouse/iceberg/web/rest/IcebergNamespaceOperations.java
@@ -31,7 +31,7 @@ import org.apache.iceberg.rest.responses.UpdateNamespacePropertiesResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@Path("/v1/namespaces")
+@Path("/v1/{prefix:([^/]*/)?}namespaces")
 @Consumes(MediaType.APPLICATION_JSON)
 @Produces(MediaType.APPLICATION_JSON)
 public class IcebergNamespaceOperations {

--- a/catalog-lakehouse/src/main/java/com/datastrato/graviton/catalog/lakehouse/iceberg/web/rest/IcebergTableOperations.java
+++ b/catalog-lakehouse/src/main/java/com/datastrato/graviton/catalog/lakehouse/iceberg/web/rest/IcebergTableOperations.java
@@ -28,7 +28,7 @@ import org.apache.iceberg.rest.requests.UpdateTableRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@Path("/v1/namespaces/{namespace}/tables")
+@Path("/v1/{prefix:([^/]*/)?}namespaces/{namespace}/tables")
 @Consumes(MediaType.APPLICATION_JSON)
 @Produces(MediaType.APPLICATION_JSON)
 public class IcebergTableOperations {

--- a/catalog-lakehouse/src/main/java/com/datastrato/graviton/catalog/lakehouse/iceberg/web/rest/IcebergTableRenameOperations.java
+++ b/catalog-lakehouse/src/main/java/com/datastrato/graviton/catalog/lakehouse/iceberg/web/rest/IcebergTableRenameOperations.java
@@ -17,7 +17,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import org.apache.iceberg.rest.requests.RenameTableRequest;
 
-@Path("/v1/tables/rename")
+@Path("/v1/{prefix:([^/]*/)?}tables/rename")
 @Consumes(MediaType.APPLICATION_JSON)
 @Produces(MediaType.APPLICATION_JSON)
 public class IcebergTableRenameOperations {

--- a/catalog-lakehouse/src/test/java/com/datastrato/graviton/catalog/lakehouse/iceberg/web/rest/IcebergRestTestUtil.java
+++ b/catalog-lakehouse/src/test/java/com/datastrato/graviton/catalog/lakehouse/iceberg/web/rest/IcebergRestTestUtil.java
@@ -18,12 +18,13 @@ import org.glassfish.jersey.server.ResourceConfig;
 
 public class IcebergRestTestUtil {
 
-  private static final String PREFIX = "v1";
-  public static final String CONFIG_PATH = PREFIX + "/config";
-  public static final String NAMESPACE_PATH = PREFIX + "/namespaces";
+  private static final String V_1 = "v1";
+  public static final String PREFIX = "prefix_graviton";
+  public static final String CONFIG_PATH = V_1 + "/config";
+  public static final String NAMESPACE_PATH = V_1 + "/namespaces";
   public static final String TEST_NAMESPACE_NAME = "graviton-test";
   public static final String TABLE_PATH = NAMESPACE_PATH + "/" + TEST_NAMESPACE_NAME + "/tables";
-  public static final String RENAME_TABLE_PATH = PREFIX + "/tables/rename";
+  public static final String RENAME_TABLE_PATH = V_1 + "/tables/rename";
 
   public static final boolean DEBUG_SERVER_LOG_ENABLED = true;
 

--- a/catalog-lakehouse/src/test/java/com/datastrato/graviton/catalog/lakehouse/iceberg/web/rest/TestIcebergConfig.java
+++ b/catalog-lakehouse/src/test/java/com/datastrato/graviton/catalog/lakehouse/iceberg/web/rest/TestIcebergConfig.java
@@ -5,12 +5,15 @@
 
 package com.datastrato.graviton.catalog.lakehouse.iceberg.web.rest;
 
+import java.util.Optional;
 import javax.ws.rs.core.Application;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
 import org.apache.iceberg.rest.responses.ConfigResponse;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public class TestIcebergConfig extends IcebergTestBase {
 
@@ -19,8 +22,10 @@ public class TestIcebergConfig extends IcebergTestBase {
     return IcebergRestTestUtil.getIcebergResourceConfig(IcebergConfig.class, false);
   }
 
-  @Test
-  public void testConfig() {
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void testConfig(boolean withPrefix) {
+    setUrlPathWithPrefix(withPrefix);
     Response resp = getConfigClientBuilder().get();
     Assertions.assertEquals(Response.Status.OK.getStatusCode(), resp.getStatus());
     Assertions.assertEquals(MediaType.APPLICATION_JSON_TYPE, resp.getMediaType());
@@ -28,5 +33,21 @@ public class TestIcebergConfig extends IcebergTestBase {
     ConfigResponse response = resp.readEntity(ConfigResponse.class);
     Assertions.assertEquals(response.defaults().size(), 0);
     Assertions.assertEquals(response.overrides().size(), 0);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"PREFIX", "", "\\\n\t\\\'", "\u0024", "\100", "[_~"})
+  void testIcebergRestValidPrefix(String prefix) {
+    String path = injectPrefixToPath(IcebergRestTestUtil.CONFIG_PATH, prefix);
+    Response response = getIcebergClientBuilder(path, Optional.empty()).get();
+    Assertions.assertEquals(Status.OK.getStatusCode(), response.getStatus());
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"/", "hello/"})
+  void testIcebergRestInvalidPrefix(String prefix) {
+    String path = injectPrefixToPath(IcebergRestTestUtil.CONFIG_PATH, prefix);
+    Response response = getIcebergClientBuilder(path, Optional.empty()).get();
+    Assertions.assertEquals(500, response.getStatus());
   }
 }

--- a/catalog-lakehouse/src/test/java/com/datastrato/graviton/catalog/lakehouse/iceberg/web/rest/TestIcebergNamespaceOperations.java
+++ b/catalog-lakehouse/src/test/java/com/datastrato/graviton/catalog/lakehouse/iceberg/web/rest/TestIcebergNamespaceOperations.java
@@ -25,6 +25,8 @@ import org.apache.iceberg.rest.responses.ListNamespacesResponse;
 import org.apache.iceberg.rest.responses.UpdateNamespacePropertiesResponse;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public class TestIcebergNamespaceOperations extends IcebergTestBase {
 
@@ -166,8 +168,10 @@ public class TestIcebergNamespaceOperations extends IcebergTestBase {
     Assertions.assertEquals(schemas, ns);
   }
 
-  @Test
-  void testListNamespace() {
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void testListNamespace(boolean withPrefix) {
+    setUrlPathWithPrefix(withPrefix);
     dropAllExistingNamespace();
     verifyListNamespaceSucc(Optional.empty(), Arrays.asList());
 

--- a/catalog-lakehouse/src/test/java/com/datastrato/graviton/catalog/lakehouse/iceberg/web/rest/TestIcebergTableOperations.java
+++ b/catalog-lakehouse/src/test/java/com/datastrato/graviton/catalog/lakehouse/iceberg/web/rest/TestIcebergTableOperations.java
@@ -31,6 +31,8 @@ import org.apache.iceberg.types.Types.StringType;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public class TestIcebergTableOperations extends TestIcebergNamespaceOperations {
 
@@ -238,8 +240,10 @@ public class TestIcebergTableOperations extends TestIcebergNamespaceOperations {
     verifyUpdateTableFail("update_foo1", 404, metadata);
   }
 
-  @Test
-  void testListTables() {
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void testListTables(boolean withPrefix) {
+    setUrlPathWithPrefix(withPrefix);
     verifyListTableFail(404);
 
     verifyCreateNamespaceSucc(IcebergRestTestUtil.TEST_NAMESPACE_NAME);
@@ -259,8 +263,10 @@ public class TestIcebergTableOperations extends TestIcebergNamespaceOperations {
     verifyLoadTableSucc("exists_foo1");
   }
 
-  @Test
-  void testRenameTable() {
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void testRenameTable(boolean withPrefix) {
+    setUrlPathWithPrefix(withPrefix);
     // namespace not exits
     verifyRenameTableFail("rename_foo1", "rename_foo3", 404);
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
add optional prefix to Iceberg REST query path

### Why are the changes needed?
Iceberg REST api spec


Fix: #368

### Does this PR introduce _any_ user-facing change?
user could add a prefix to url to request Iceberg  REST server

### How was this patch tested?
UT
