### PR TITLE
[#381] Support delete with TTL and physical deletion after TTL expires

### DIFF
--- a/core/src/main/java/com/datastrato/graviton/storage/kv/KvRangeScan.java
+++ b/core/src/main/java/com/datastrato/graviton/storage/kv/KvRangeScan.java
@@ -8,6 +8,7 @@ package com.datastrato.graviton.storage.kv;
 import java.util.function.Predicate;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NonNull;
 
 /** Represents a range scan configuration for the key-value store. */
 @Builder
@@ -19,7 +20,7 @@ public class KvRangeScan {
   private boolean endInclusive;
 
   private int limit;
-  private Predicate<byte[]> predicate;
+  @NonNull private Predicate<byte[]> predicate;
 
   /**
    * Constructs a KvRangeScan instance with the specified parameters.


### PR DESCRIPTION

### What changes were proposed in this pull request?

This work is a follow-up task to this previous assignment #377, it introduces the following feature
1. Supports TTL in the deletion mark
2. Remove the entities that TTL expires physically.

### Why are the changes needed?

#377 only adds deletion marks to indicate whether an entity has been deleted or not and does not remove it from storage physically. As time goes on, there will be many entities that are only marked as deleted in storage and put significant pressure on our system. 

Fix: #381 

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

Add several test case in `TestKvEntityStore`
