### PR TITLE
[#424] fix(build): Fix executing `./gradlew clean build` failure issue

### DIFF
--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -86,18 +86,16 @@ fun writeProjectPropertiesFile() {
 }
 
 tasks {
-  build {
-    writeProjectPropertiesFile()
-    val file = file(propertiesFile)
-    if (!file.exists()) {
-      throw GradleException("$propertiesFile file not generated!")
+  jar {
+    doFirst() {
+      writeProjectPropertiesFile()
+      val file = file(propertiesFile)
+      if (!file.exists()) {
+        throw GradleException("$propertiesFile file not generated!")
+      }
     }
   }
   test {
     environment("GRAVITON_HOME", rootDir.path)
   }
-}
-
-tasks.test {
-  environment("GRAVITON_ROOT_DIR", rootDir.path)
 }

--- a/server/src/test/java/com/datastrato/graviton/server/TestServerConfig.java
+++ b/server/src/test/java/com/datastrato/graviton/server/TestServerConfig.java
@@ -29,7 +29,7 @@ public class TestServerConfig {
     // Load all config keys from `graviton.conf.template` into a map
     Properties properties = new Properties();
     String confFile =
-        System.getenv("GRAVITON_ROOT_DIR")
+        System.getenv("GRAVITON_HOME")
             + File.separator
             + "conf"
             + File.separator


### PR DESCRIPTION
### What changes were proposed in this pull request?

Executing `./gradlew clean build`, the gradle build process will hang. 

### Why are the changes needed?

The cause of the problem is `VersionOperations::getVersion()` can't load the `project.properties` file in the `graviton-server.jar`, and it throws an exception. Cause `MiniGraviton` abnormalities.

```
   2023-09-20 13:27:47 INFO  JettyServer:103 - Graviton web server started on host 127.0.0.1 port 2621.
    2023-09-20 13:27:47 INFO  GravitonServer:98 - Done, Graviton server started.
    2023-09-20 13:27:48 INFO  MiniGraviton:174 - checkIfServerIsRunning() URI: http://127.0.0.1:2621
    2023-09-20 13:27:48 WARN  HttpChannel:776 - /api/version
    javax.servlet.ServletException: javax.servlet.ServletException: java.lang.NullPointerException
    	at org.eclipse.jetty.server.handler.HandlerCollection.handle(HandlerCollection.java:162) ~[jetty-server-9.4.51.v20230217.jar:9.4.51.v20230217]
    	at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:127) ~[jetty-server-9.4.51.v20230217.jar:9.4.51.v20230217]
    	at org.eclipse.jetty.server.Server.handle(Server.java:516) ~[jetty-server-9.4.51.v20230217.jar:9.4.51.v20230217]
    	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [?:1.8.0_382]
    	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [?:1.8.0_382]
    	at java.lang.Thread.run(Thread.java:750) [?:1.8.0_382]
    Caused by: javax.servlet.ServletException: java.lang.NullPointerException
    	at org.glassfish.jersey.servlet.WebComponent.serviceImpl(WebComponent.java:410) ~[jersey-container-servlet-core-2.39.1.jar:?]
    	at org.glassfish.jersey.servlet.WebComponent.service(WebComponent.java:346) ~[jersey-container-servlet-core-2.39.1.jar:?]
    	at org.glassfish.jersey.servlet.ServletContainer.service(ServletContainer.java:358) ~[jersey-container-servlet-core-2.39.1.jar:?]
    	at org.glassfish.jersey.servlet.ServletContainer.service(ServletContainer.java:311) ~[jersey-container-servlet-core-2.39.1.jar:?]
    	at org.glassfish.jersey.servlet.ServletContainer.service(ServletContainer.java:205) ~[jersey-container-servlet-core-2.39.1.jar:?]
    	at org.eclipse.jetty.servlet.ServletHolder.handle(ServletHolder.java:799) ~[jetty-servlet-9.4.51.v20230217.jar:9.4.51.v20230217]
    	at org.eclipse.jetty.servlet.ServletHandler$ChainEnd.doFilter(ServletHandler.java:1656) ~[jetty-servlet-9.4.51.v20230217.jar:9.4.51.v20230217]
    	at com.datastrato.graviton.server.web.VersioningFilter.doFilter(VersioningFilter.java:94) ~[graviton-server-0.2.0-SNAPSHOT.jar:?]
    	at org.eclipse.jetty.servlet.FilterHolder.doFilter(FilterHolder.java:193) ~[jetty-servlet-9.4.51.v20230217.jar:9.4.51.v20230217]
    	at org.eclipse.jetty.servlet.ServletHandler$Chain.doFilter(ServletHandler.java:1626) ~[jetty-servlet-9.4.51.v20230217.jar:9.4.51.v20230217]
    	... 12 more
    Caused by: java.lang.NullPointerException
    	at java.util.Properties$LineReader.readLine(Properties.java:434) ~[?:1.8.0_382]
    	at java.util.Properties.load0(Properties.java:353) ~[?:1.8.0_382]
    	at java.util.Properties.load(Properties.java:341) ~[?:1.8.0_382]
    	at com.datastrato.graviton.server.web.rest.VersionOperations.getVersion(VersionOperations.java:29) ~[graviton-server-0.2.0-SNAPSHOT.jar:?]
    	at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_382]
```

The `writeProjectPropertiesFile()` function needs to be called before `task.jar()` to ensure that the `graviton-server.jar` contains the `project.properties` file.

Fix: #424 

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

CI passed
