### PR TITLE
[#426] feat(build): Assembling the Graviton distribution as `tar.gz` file

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -176,10 +176,9 @@ tasks {
     group = "graviton distribution"
     finalizedBy("checksumDistribution")
     from(compileDistribution.map { it.outputs.files.single() })
-    archiveBaseName.set(rootProject.name.lowercase())
-    archiveVersion.set("${version}")
-    archiveClassifier.set("bin")
-    destinationDirectory.set(outputDir)
+    compression = Compression.GZIP
+    archiveFileName.set("${rootProject.name}-${version}.tar.gz")
+    destinationDirectory.set(projectDir.dir("distribution"))
   }
 
   register("checksumDistribution") {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Modify `val assembleDistribution by registering(Tar::class)` gradle task.

### Why are the changes needed?

Currently, When you execting `./gradlew assembleDistribution` command, will assemble the Graviton as a tar file, and when you untar it, The doesn't uncompress into `graviton-<version>` directory.

Fix: #426 

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

```
% ls -lt distribution 
graviton-0.2.0-SNAPSHOT
graviton-0.2.0-SNAPSHOT.tar.gz.sha256
graviton-0.2.0-SNAPSHOT.tar.gz
package
ls -lt distribution/graviton-0.2.0-SNAPSHOT
drwxr-xr-x   4 liuxun  staff   128 Sep 20 20:21 bin
drwxr-xr-x   5 liuxun  staff   160 Sep 20 20:21 conf
drwxr-xr-x   4 liuxun  staff   128 Sep 20 20:21 catalogs
drwxr-xr-x  75 liuxun  staff  2400 Sep 20 20:21 libs
```