### PR TITLE
[#431] fix(catalog-lakehouse): fixed failed to update namespace properties for Iceberg REST server

### DIFF
--- a/catalogs/catalog-lakehouse/src/main/java/com/datastrato/graviton/catalog/lakehouse/iceberg/web/IcebergExceptionMapper.java
+++ b/catalogs/catalog-lakehouse/src/main/java/com/datastrato/graviton/catalog/lakehouse/iceberg/web/IcebergExceptionMapper.java
@@ -59,6 +59,7 @@ public class IcebergExceptionMapper implements ExceptionMapper<Exception> {
     } else {
       LOG.info(
           "Iceberg REST server error maybe caused by user request, response http status: {}, exception: {}, exception message: {}",
+          status,
           ex.getClass(),
           ex.getMessage());
     }

--- a/catalogs/catalog-lakehouse/src/main/java/com/datastrato/graviton/catalog/lakehouse/iceberg/web/rest/IcebergNamespaceOperations.java
+++ b/catalogs/catalog-lakehouse/src/main/java/com/datastrato/graviton/catalog/lakehouse/iceberg/web/rest/IcebergNamespaceOperations.java
@@ -84,7 +84,7 @@ public class IcebergNamespaceOperations {
   }
 
   @POST
-  @Path("{namespace}")
+  @Path("{namespace}/properties")
   @Produces(MediaType.APPLICATION_JSON)
   public Response updateNamespace(
       @PathParam("namespace") String namespace, UpdateNamespacePropertiesRequest request) {

--- a/catalogs/catalog-lakehouse/src/test/java/com/datastrato/graviton/catalog/lakehouse/iceberg/web/rest/IcebergRestTestUtil.java
+++ b/catalogs/catalog-lakehouse/src/test/java/com/datastrato/graviton/catalog/lakehouse/iceberg/web/rest/IcebergRestTestUtil.java
@@ -22,6 +22,7 @@ public class IcebergRestTestUtil {
   public static final String PREFIX = "prefix_graviton";
   public static final String CONFIG_PATH = V_1 + "/config";
   public static final String NAMESPACE_PATH = V_1 + "/namespaces";
+  public static final String UPDATE_NAMESPACE_POSTFIX = "properties";
   public static final String TEST_NAMESPACE_NAME = "graviton-test";
   public static final String TABLE_PATH = NAMESPACE_PATH + "/" + TEST_NAMESPACE_NAME + "/tables";
   public static final String RENAME_TABLE_PATH = V_1 + "/tables/rename";

--- a/catalogs/catalog-lakehouse/src/test/java/com/datastrato/graviton/catalog/lakehouse/iceberg/web/rest/IcebergTestBase.java
+++ b/catalogs/catalog-lakehouse/src/test/java/com/datastrato/graviton/catalog/lakehouse/iceberg/web/rest/IcebergTestBase.java
@@ -68,6 +68,17 @@ public class IcebergTestBase extends JerseyTest {
     return getIcebergClientBuilder(path, queryParams);
   }
 
+  public Builder getUpdateNamespaceClientBuilder(String namespace) {
+    String path =
+        Joiner.on("/")
+            .skipNulls()
+            .join(
+                IcebergRestTestUtil.NAMESPACE_PATH,
+                namespace,
+                IcebergRestTestUtil.UPDATE_NAMESPACE_POSTFIX);
+    return getIcebergClientBuilder(path, Optional.empty());
+  }
+
   public Builder getConfigClientBuilder() {
     return getIcebergClientBuilder(IcebergRestTestUtil.CONFIG_PATH, Optional.empty());
   }

--- a/catalogs/catalog-lakehouse/src/test/java/com/datastrato/graviton/catalog/lakehouse/iceberg/web/rest/TestIcebergNamespaceOperations.java
+++ b/catalogs/catalog-lakehouse/src/test/java/com/datastrato/graviton/catalog/lakehouse/iceberg/web/rest/TestIcebergNamespaceOperations.java
@@ -62,7 +62,7 @@ public class TestIcebergNamespaceOperations extends IcebergTestBase {
             .removeAll(Arrays.asList("a", "a1"))
             .updateAll(updatedProperties)
             .build();
-    return getNamespaceClientBuilder(Optional.of(name))
+    return getUpdateNamespaceClientBuilder(name)
         .post(Entity.entity(request, MediaType.APPLICATION_JSON_TYPE));
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
bug fix for update namespace properties 

### Why are the changes needed?
namespace update uri missing `properties` postfix
Fix: #431 

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
1. UT
2. local env