### PR TITLE
[#399] feat(all): Add provider attribute for Catalog interface and CreateCatalogRequest

### DIFF
--- a/api/src/main/java/com/datastrato/graviton/Catalog.java
+++ b/api/src/main/java/com/datastrato/graviton/Catalog.java
@@ -17,16 +17,6 @@ public interface Catalog extends Auditable {
   }
 
   /**
-   * A reserved property to specify the provider of the catalog. The provider is a string used to
-   * specify the class to create the catalog. The provider can be a short name if the catalog is a
-   * built-in catalog, or it can be a full qualified class name if the catalog is a custom one.
-   *
-   * <p>For example, the provider of a built-in Hive catalog could be "hive", Graviton will figure
-   * out the related class to create the catalog.
-   */
-  String PROPERTY_PROVIDER = "provider";
-
-  /**
    * A reserved property to specify the package location of the catalog. The "package" is a string
    * of path to the folder where all the catalog related dependencies is located. The dependencies
    * under the "package" will be loaded by Graviton to create the catalog.
@@ -42,6 +32,9 @@ public interface Catalog extends Auditable {
 
   /** The type of the catalog. */
   Type type();
+
+  /** The provider of the catalog. */
+  String provider();
 
   /**
    * The comment of the catalog. Note. this method will return null if the comment is not set for

--- a/api/src/main/java/com/datastrato/graviton/SupportsCatalogs.java
+++ b/api/src/main/java/com/datastrato/graviton/SupportsCatalogs.java
@@ -47,16 +47,25 @@ public interface SupportsCatalogs {
   /**
    * Create a catalog with specified identifier.
    *
+   * <p>The parameter "provider" is a short name of the catalog, used to tell Graviton which catalog
+   * should be created. The short name should be the same as the {@link CatalogProvider} interface
+   * provided.
+   *
    * @param ident the identifier of the catalog.
    * @param type the type of the catalog.
    * @param comment the comment of the catalog.
+   * @param provider the provider of the catalog.
    * @param properties the properties of the catalog.
    * @return The created catalog.
    * @throws NoSuchMetalakeException If the metalake does not exist.
    * @throws CatalogAlreadyExistsException If the catalog already exists.
    */
   Catalog createCatalog(
-      NameIdentifier ident, Catalog.Type type, String comment, Map<String, String> properties)
+      NameIdentifier ident,
+      Catalog.Type type,
+      String provider,
+      String comment,
+      Map<String, String> properties)
       throws NoSuchMetalakeException, CatalogAlreadyExistsException;
 
   /**

--- a/catalogs/catalog-hive/src/test/java/com/datastrato/graviton/catalog/hive/TestHiveCatalog.java
+++ b/catalogs/catalog-hive/src/test/java/com/datastrato/graviton/catalog/hive/TestHiveCatalog.java
@@ -29,6 +29,7 @@ public class TestHiveCatalog extends MiniHiveMetastoreService {
             .withName("catalog")
             .withNamespace(Namespace.of("metalake"))
             .withType(HiveCatalog.Type.RELATIONAL)
+            .withProvider("hive")
             .withAuditInfo(auditInfo)
             .build();
 

--- a/catalogs/catalog-hive/src/test/java/com/datastrato/graviton/catalog/hive/TestHiveSchema.java
+++ b/catalogs/catalog-hive/src/test/java/com/datastrato/graviton/catalog/hive/TestHiveSchema.java
@@ -31,6 +31,7 @@ public class TestHiveSchema extends MiniHiveMetastoreService {
             .withName("catalog")
             .withNamespace(Namespace.of("metalake"))
             .withType(HiveCatalog.Type.RELATIONAL)
+            .withProvider("hive")
             .withAuditInfo(auditInfo)
             .build();
 

--- a/catalogs/catalog-hive/src/test/java/com/datastrato/graviton/catalog/hive/TestHiveTable.java
+++ b/catalogs/catalog-hive/src/test/java/com/datastrato/graviton/catalog/hive/TestHiveTable.java
@@ -78,6 +78,7 @@ public class TestHiveTable extends MiniHiveMetastoreService {
             .withName(HIVE_CATALOG_NAME)
             .withNamespace(Namespace.of(META_LAKE_NAME))
             .withType(HiveCatalog.Type.RELATIONAL)
+            .withProvider("hive")
             .withAuditInfo(auditInfo)
             .build();
 

--- a/clients/client-java/src/main/java/com/datastrato/graviton/client/DTOConverters.java
+++ b/clients/client-java/src/main/java/com/datastrato/graviton/client/DTOConverters.java
@@ -60,6 +60,7 @@ class DTOConverters {
         return new RelationalCatalog.Builder()
             .withName(catalog.name())
             .withType(catalog.type())
+            .withProvider(catalog.provider())
             .withComment(catalog.comment())
             .withProperties(catalog.properties())
             .withAudit((AuditDTO) catalog.auditInfo())

--- a/clients/client-java/src/main/java/com/datastrato/graviton/client/GravitonMetaLake.java
+++ b/clients/client-java/src/main/java/com/datastrato/graviton/client/GravitonMetaLake.java
@@ -100,6 +100,7 @@ public class GravitonMetaLake extends MetalakeDTO implements SupportsCatalogs {
    *
    * @param ident The identifier of the catalog.
    * @param type The type of the catalog.
+   * @param provider The provider of the catalog.
    * @param comment The comment of the catalog.
    * @param properties The properties of the catalog.
    * @return The created {@link Catalog}.
@@ -108,11 +109,16 @@ public class GravitonMetaLake extends MetalakeDTO implements SupportsCatalogs {
    */
   @Override
   public Catalog createCatalog(
-      NameIdentifier ident, Catalog.Type type, String comment, Map<String, String> properties)
+      NameIdentifier ident,
+      Catalog.Type type,
+      String provider,
+      String comment,
+      Map<String, String> properties)
       throws NoSuchMetalakeException, CatalogAlreadyExistsException {
     NameIdentifier.checkCatalog(ident);
 
-    CatalogCreateRequest req = new CatalogCreateRequest(ident.name(), type, comment, properties);
+    CatalogCreateRequest req =
+        new CatalogCreateRequest(ident.name(), type, provider, comment, properties);
     req.validate();
 
     CatalogResponse resp =

--- a/clients/client-java/src/main/java/com/datastrato/graviton/client/RelationalCatalog.java
+++ b/clients/client-java/src/main/java/com/datastrato/graviton/client/RelationalCatalog.java
@@ -45,6 +45,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -62,11 +63,12 @@ public class RelationalCatalog extends CatalogDTO implements TableCatalog, Suppo
   RelationalCatalog(
       String name,
       Type type,
+      String provider,
       String comment,
       Map<String, String> properties,
       AuditDTO auditDTO,
       RESTClient restClient) {
-    super(name, type, comment, properties, auditDTO);
+    super(name, type, provider, comment, properties, auditDTO);
     this.restClient = restClient;
   }
 
@@ -406,12 +408,13 @@ public class RelationalCatalog extends CatalogDTO implements TableCatalog, Suppo
     @Override
     public RelationalCatalog build() {
       Preconditions.checkArgument(restClient != null, "restClient must be set");
-      Preconditions.checkArgument(
-          name != null && !name.isEmpty(), "name must not be null or empty");
+      Preconditions.checkArgument(StringUtils.isNotBlank(name), "name must not be null or empty");
       Preconditions.checkArgument(type != null, "type must not be null");
+      Preconditions.checkArgument(
+          StringUtils.isNotBlank(provider), "provider must not be null or empty");
       Preconditions.checkArgument(audit != null, "audit must not be null");
 
-      return new RelationalCatalog(name, type, comment, properties, audit, restClient);
+      return new RelationalCatalog(name, type, provider, comment, properties, audit, restClient);
     }
   }
 }

--- a/clients/client-java/src/test/java/com/datastrato/graviton/client/TestGravitonMetalake.java
+++ b/clients/client-java/src/test/java/com/datastrato/graviton/client/TestGravitonMetalake.java
@@ -42,6 +42,8 @@ public class TestGravitonMetalake extends TestBase {
 
   private static final String metalakeName = "test";
 
+  private static final String provider = "test";
+
   @BeforeAll
   public static void setUp() throws Exception {
     TestBase.setUp();
@@ -96,6 +98,7 @@ public class TestGravitonMetalake extends TestBase {
             .withName("mock")
             .withComment("comment")
             .withType(Catalog.Type.RELATIONAL)
+            .withProvider("test")
             .withAudit(
                 new AuditDTO.Builder().withCreator("creator").withCreateTime(Instant.now()).build())
             .build();
@@ -124,6 +127,7 @@ public class TestGravitonMetalake extends TestBase {
             .withName("mock")
             .withComment("comment")
             .withType(Catalog.Type.FILE)
+            .withProvider("test")
             .withAudit(
                 new AuditDTO.Builder().withCreator("creator").withCreateTime(Instant.now()).build())
             .build();
@@ -161,12 +165,13 @@ public class TestGravitonMetalake extends TestBase {
             .withName(catalogName)
             .withComment("comment")
             .withType(Catalog.Type.RELATIONAL)
+            .withProvider("test")
             .withAudit(
                 new AuditDTO.Builder().withCreator("creator").withCreateTime(Instant.now()).build())
             .build();
     CatalogCreateRequest req =
         new CatalogCreateRequest(
-            catalogName, Catalog.Type.RELATIONAL, "comment", Collections.emptyMap());
+            catalogName, Catalog.Type.RELATIONAL, provider, "comment", Collections.emptyMap());
     CatalogResponse resp = new CatalogResponse(mockCatalog);
     buildMockResource(Method.POST, path, req, resp, HttpStatus.SC_OK);
 
@@ -174,6 +179,7 @@ public class TestGravitonMetalake extends TestBase {
         metalake.createCatalog(
             NameIdentifier.of(metalakeName, catalogName),
             Catalog.Type.RELATIONAL,
+            provider,
             "comment",
             Collections.emptyMap());
     Assertions.assertEquals(catalogName, catalog.name());
@@ -186,11 +192,13 @@ public class TestGravitonMetalake extends TestBase {
             .withName("mock")
             .withComment("comment")
             .withType(Catalog.Type.FILE)
+            .withProvider("test")
             .withAudit(
                 new AuditDTO.Builder().withCreator("creator").withCreateTime(Instant.now()).build())
             .build();
     CatalogCreateRequest req1 =
-        new CatalogCreateRequest(catalogName, Catalog.Type.FILE, "comment", Collections.emptyMap());
+        new CatalogCreateRequest(
+            catalogName, Catalog.Type.FILE, provider, "comment", Collections.emptyMap());
     CatalogResponse resp1 = new CatalogResponse(mockCatalog1);
     buildMockResource(Method.POST, path, req1, resp1, HttpStatus.SC_OK);
     Assertions.assertThrows(
@@ -199,6 +207,7 @@ public class TestGravitonMetalake extends TestBase {
             metalake.createCatalog(
                 NameIdentifier.of(metalakeName, catalogName),
                 Catalog.Type.FILE,
+                provider,
                 "comment",
                 Collections.emptyMap()));
 
@@ -213,6 +222,7 @@ public class TestGravitonMetalake extends TestBase {
                 metalake.createCatalog(
                     NameIdentifier.of(metalakeName, catalogName),
                     Catalog.Type.RELATIONAL,
+                    provider,
                     "comment",
                     Collections.emptyMap()));
     Assertions.assertTrue(ex.getMessage().contains("mock error"));
@@ -229,6 +239,7 @@ public class TestGravitonMetalake extends TestBase {
                 metalake.createCatalog(
                     NameIdentifier.of(metalakeName, catalogName),
                     Catalog.Type.RELATIONAL,
+                    provider,
                     "comment",
                     Collections.emptyMap()));
     Assertions.assertTrue(ex1.getMessage().contains("mock error"));
@@ -243,6 +254,7 @@ public class TestGravitonMetalake extends TestBase {
                 metalake.createCatalog(
                     NameIdentifier.of(metalakeName, catalogName),
                     Catalog.Type.RELATIONAL,
+                    provider,
                     "comment",
                     Collections.emptyMap()));
     Assertions.assertTrue(ex2.getMessage().contains("mock error"));
@@ -258,6 +270,7 @@ public class TestGravitonMetalake extends TestBase {
             .withName("mock1")
             .withComment("comment1")
             .withType(Catalog.Type.RELATIONAL)
+            .withProvider("test")
             .withAudit(
                 new AuditDTO.Builder().withCreator("creator").withCreateTime(Instant.now()).build())
             .build();

--- a/clients/client-java/src/test/java/com/datastrato/graviton/client/TestRelationalCatalog.java
+++ b/clients/client-java/src/test/java/com/datastrato/graviton/client/TestRelationalCatalog.java
@@ -78,6 +78,8 @@ public class TestRelationalCatalog extends TestBase {
 
   private static final String catalogName = "testCatalog";
 
+  private static final String provider = "test";
+
   @BeforeAll
   public static void setUp() throws Exception {
     TestBase.setUp();
@@ -88,6 +90,7 @@ public class TestRelationalCatalog extends TestBase {
         new CatalogDTO.Builder()
             .withName(catalogName)
             .withType(CatalogDTO.Type.RELATIONAL)
+            .withProvider(provider)
             .withComment("comment")
             .withProperties(ImmutableMap.of("k1", "k2"))
             .withAudit(
@@ -96,7 +99,11 @@ public class TestRelationalCatalog extends TestBase {
 
     CatalogCreateRequest catalogCreateRequest =
         new CatalogCreateRequest(
-            catalogName, CatalogDTO.Type.RELATIONAL, "comment", ImmutableMap.of("k1", "k2"));
+            catalogName,
+            CatalogDTO.Type.RELATIONAL,
+            provider,
+            "comment",
+            ImmutableMap.of("k1", "k2"));
     CatalogResponse catalogResponse = new CatalogResponse(mockCatalog);
     buildMockResource(
         Method.POST,
@@ -109,6 +116,7 @@ public class TestRelationalCatalog extends TestBase {
         metalake.createCatalog(
             NameIdentifier.of(metalakeName, catalogName),
             CatalogDTO.Type.RELATIONAL,
+            provider,
             "comment",
             ImmutableMap.of("k1", "k2"));
   }

--- a/common/src/main/java/com/datastrato/graviton/dto/CatalogDTO.java
+++ b/common/src/main/java/com/datastrato/graviton/dto/CatalogDTO.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import javax.annotation.Nullable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.apache.commons.lang3.StringUtils;
 
 /** Data transfer object representing catalog information. */
 @EqualsAndHashCode
@@ -23,6 +24,9 @@ public class CatalogDTO implements Catalog {
 
   @JsonProperty("type")
   private Type type;
+
+  @JsonProperty("provider")
+  private String provider;
 
   @Nullable
   @JsonProperty("comment")
@@ -38,9 +42,15 @@ public class CatalogDTO implements Catalog {
   protected CatalogDTO() {}
 
   protected CatalogDTO(
-      String name, Type type, String comment, Map<String, String> properties, AuditDTO audit) {
+      String name,
+      Type type,
+      String provider,
+      String comment,
+      Map<String, String> properties,
+      AuditDTO audit) {
     this.name = name;
     this.type = type;
+    this.provider = provider;
     this.comment = comment;
     this.properties = properties;
     this.audit = audit;
@@ -54,6 +64,11 @@ public class CatalogDTO implements Catalog {
   @Override
   public Type type() {
     return type;
+  }
+
+  @Override
+  public String provider() {
+    return provider;
   }
 
   @Override
@@ -79,6 +94,7 @@ public class CatalogDTO implements Catalog {
   public static class Builder<S extends Builder> {
     protected String name;
     protected Type type;
+    protected String provider;
     protected String comment;
     protected Map<String, String> properties;
     protected AuditDTO audit;
@@ -104,6 +120,17 @@ public class CatalogDTO implements Catalog {
      */
     public S withType(Type type) {
       this.type = type;
+      return (S) this;
+    }
+
+    /**
+     * Sets the provider of the catalog.
+     *
+     * @param provider The provider of the catalog.
+     * @return The builder instance.
+     */
+    public S withProvider(String provider) {
+      this.provider = provider;
       return (S) this;
     }
 
@@ -147,11 +174,13 @@ public class CatalogDTO implements Catalog {
      * @throws IllegalArgumentException If name, type or audit are not set.
      */
     public CatalogDTO build() {
-      Preconditions.checkArgument(name != null && !name.isEmpty(), "name cannot be null or empty");
+      Preconditions.checkArgument(StringUtils.isNotBlank(name), "name cannot be null or empty");
       Preconditions.checkArgument(type != null, "type cannot be null");
+      Preconditions.checkArgument(
+          StringUtils.isNotBlank(provider), "provider cannot be null or empty");
       Preconditions.checkArgument(audit != null, "audit cannot be null");
 
-      return new CatalogDTO(name, type, comment, properties, audit);
+      return new CatalogDTO(name, type, provider, comment, properties, audit);
     }
   }
 }

--- a/common/src/main/java/com/datastrato/graviton/dto/requests/CatalogCreateRequest.java
+++ b/common/src/main/java/com/datastrato/graviton/dto/requests/CatalogCreateRequest.java
@@ -27,6 +27,9 @@ public class CatalogCreateRequest implements RESTRequest {
   @JsonProperty("type")
   private final Catalog.Type type;
 
+  @JsonProperty("provider")
+  private final String provider;
+
   @Nullable
   @JsonProperty("comment")
   private final String comment;
@@ -37,7 +40,7 @@ public class CatalogCreateRequest implements RESTRequest {
 
   /** Default constructor for CatalogCreateRequest. */
   public CatalogCreateRequest() {
-    this(null, null, null, null);
+    this(null, null, null, null, null);
   }
 
   /**
@@ -45,13 +48,19 @@ public class CatalogCreateRequest implements RESTRequest {
    *
    * @param name The name of the catalog.
    * @param type The type of the catalog.
+   * @param provider The provider of the catalog.
    * @param comment The comment for the catalog.
    * @param properties The properties for the catalog.
    */
   public CatalogCreateRequest(
-      String name, Catalog.Type type, String comment, Map<String, String> properties) {
+      String name,
+      Catalog.Type type,
+      String provider,
+      String comment,
+      Map<String, String> properties) {
     this.name = name;
     this.type = type;
+    this.provider = provider;
     this.comment = comment;
     this.properties = properties;
   }
@@ -66,5 +75,7 @@ public class CatalogCreateRequest implements RESTRequest {
     Preconditions.checkArgument(
         StringUtils.isNotBlank(name), "\"name\" field is required and cannot be empty");
     Preconditions.checkArgument(type != null, "\"type\" field is required and cannot be empty");
+    Preconditions.checkArgument(
+        StringUtils.isNotBlank(provider), "\"provider\" field is required and cannot be empty");
   }
 }

--- a/common/src/main/java/com/datastrato/graviton/dto/util/DTOConverters.java
+++ b/common/src/main/java/com/datastrato/graviton/dto/util/DTOConverters.java
@@ -58,6 +58,7 @@ public class DTOConverters {
     return new CatalogDTO.Builder()
         .withName(catalog.name())
         .withType(catalog.type())
+        .withProvider(catalog.provider())
         .withComment(catalog.comment())
         .withProperties(catalog.properties())
         .withAudit(toDTO(catalog.auditInfo()))

--- a/common/src/test/java/com/datastrato/graviton/dto/responses/TestResponses.java
+++ b/common/src/test/java/com/datastrato/graviton/dto/responses/TestResponses.java
@@ -110,6 +110,7 @@ public class TestResponses {
             .withName("CatalogA")
             .withComment("comment")
             .withType(Catalog.Type.RELATIONAL)
+            .withProvider("test")
             .withAudit(audit)
             .build();
     CatalogResponse catalogResponse = new CatalogResponse(catalog);

--- a/common/src/test/java/com/datastrato/graviton/json/TestDTOJsonSerDe.java
+++ b/common/src/test/java/com/datastrato/graviton/json/TestDTOJsonSerDe.java
@@ -135,6 +135,7 @@ public class TestDTOJsonSerDe {
         new CatalogDTO.Builder()
             .withName("catalog")
             .withType(Catalog.Type.RELATIONAL)
+            .withProvider("test")
             .withComment("comment")
             .withProperties(ImmutableMap.of("k1", "v1", "k2", "v2"))
             .withAudit(audit)
@@ -149,6 +150,7 @@ public class TestDTOJsonSerDe {
         new CatalogDTO.Builder()
             .withName("catalog")
             .withType(Catalog.Type.RELATIONAL)
+            .withProvider("test")
             .withAudit(audit)
             .build();
 

--- a/common/src/test/java/com/datastrato/graviton/json/TestRequestJsonSerDe.java
+++ b/common/src/test/java/com/datastrato/graviton/json/TestRequestJsonSerDe.java
@@ -87,7 +87,7 @@ public class TestRequestJsonSerDe {
   public void testCatalogCreateRequestSerDe() throws JsonProcessingException {
     CatalogCreateRequest req =
         new CatalogCreateRequest(
-            "catalog", Catalog.Type.RELATIONAL, "comment", ImmutableMap.of("key", "value"));
+            "catalog", Catalog.Type.RELATIONAL, "hive", "comment", ImmutableMap.of("key", "value"));
     String serJson = JsonUtils.objectMapper().writeValueAsString(req);
     CatalogCreateRequest deserReq =
         JsonUtils.objectMapper().readValue(serJson, CatalogCreateRequest.class);
@@ -95,21 +95,21 @@ public class TestRequestJsonSerDe {
 
     // Test with optional fields
     CatalogCreateRequest req1 =
-        new CatalogCreateRequest("catalog", Catalog.Type.RELATIONAL, null, null);
+        new CatalogCreateRequest("catalog", Catalog.Type.RELATIONAL, "hive", null, null);
     String serJson1 = JsonUtils.objectMapper().writeValueAsString(req1);
     CatalogCreateRequest deserReq1 =
         JsonUtils.objectMapper().readValue(serJson1, CatalogCreateRequest.class);
     Assertions.assertEquals(req1, deserReq1);
 
     CatalogCreateRequest req2 =
-        new CatalogCreateRequest("catalog", Catalog.Type.RELATIONAL, "", null);
+        new CatalogCreateRequest("catalog", Catalog.Type.RELATIONAL, "hive", "", null);
     String serJson2 = JsonUtils.objectMapper().writeValueAsString(req2);
     CatalogCreateRequest deserReq2 =
         JsonUtils.objectMapper().readValue(serJson2, CatalogCreateRequest.class);
     Assertions.assertEquals(req2, deserReq2);
 
     CatalogCreateRequest req3 =
-        new CatalogCreateRequest("catalog", Catalog.Type.RELATIONAL, "", ImmutableMap.of());
+        new CatalogCreateRequest("catalog", Catalog.Type.RELATIONAL, "hive", "", ImmutableMap.of());
     String serJson3 = JsonUtils.objectMapper().writeValueAsString(req3);
     CatalogCreateRequest deserReq3 =
         JsonUtils.objectMapper().readValue(serJson3, CatalogCreateRequest.class);

--- a/core/src/main/java/com/datastrato/graviton/catalog/BaseCatalog.java
+++ b/core/src/main/java/com/datastrato/graviton/catalog/BaseCatalog.java
@@ -104,6 +104,12 @@ public abstract class BaseCatalog<T extends BaseCatalog> implements Catalog, Cat
   }
 
   @Override
+  public String provider() {
+    Preconditions.checkArgument(entity != null, "entity is not set");
+    return entity.getProvider();
+  }
+
+  @Override
   public String comment() {
     Preconditions.checkArgument(entity != null, "entity is not set");
     return entity.getComment();

--- a/core/src/main/java/com/datastrato/graviton/catalog/CatalogManager.java
+++ b/core/src/main/java/com/datastrato/graviton/catalog/CatalogManager.java
@@ -213,6 +213,7 @@ public class CatalogManager implements SupportsCatalogs, Closeable {
    *
    * @param ident The identifier of the new catalog.
    * @param type The type of the new catalog.
+   * @param provider The provider of the new catalog.
    * @param comment The comment for the new catalog.
    * @param properties The properties of the new catalog.
    * @return The created catalog.
@@ -221,7 +222,11 @@ public class CatalogManager implements SupportsCatalogs, Closeable {
    */
   @Override
   public Catalog createCatalog(
-      NameIdentifier ident, Catalog.Type type, String comment, Map<String, String> properties)
+      NameIdentifier ident,
+      Catalog.Type type,
+      String provider,
+      String comment,
+      Map<String, String> properties)
       throws NoSuchMetalakeException, CatalogAlreadyExistsException {
     try {
       CatalogEntity entity =
@@ -243,6 +248,7 @@ public class CatalogManager implements SupportsCatalogs, Closeable {
                         .withName(ident.name())
                         .withNamespace(ident.namespace())
                         .withType(type)
+                        .withProvider(provider)
                         .withComment(comment)
                         .withProperties(StringIdentifier.addToProperties(stringId, properties))
                         .withAuditInfo(
@@ -296,6 +302,7 @@ public class CatalogManager implements SupportsCatalogs, Closeable {
                         .withName(catalog.name())
                         .withNamespace(ident.namespace())
                         .withType(catalog.getType())
+                        .withProvider(catalog.getProvider())
                         .withComment(catalog.getComment());
 
                 AuditInfo newInfo =
@@ -383,12 +390,7 @@ public class CatalogManager implements SupportsCatalogs, Closeable {
   private CatalogWrapper createCatalogWrapper(CatalogEntity entity) {
     Map<String, String> mergedConf =
         mergeConf(entity.getProperties(), catalogConf(entity.name(), config));
-
-    String provider = mergedConf.get(Catalog.PROPERTY_PROVIDER);
-    Preconditions.checkArgument(
-        provider != null,
-        "'provider' not set in catalog properties or conf via "
-            + "'graviton.catalog.<name>.provider'");
+    String provider = entity.getProvider();
 
     IsolatedClassLoader classLoader;
     if (config.get(Configs.CATALOG_LOAD_ISOLATED)) {

--- a/core/src/main/java/com/datastrato/graviton/meta/CatalogEntity.java
+++ b/core/src/main/java/com/datastrato/graviton/meta/CatalogEntity.java
@@ -28,6 +28,8 @@ public class CatalogEntity implements Entity, Auditable, HasIdentifier {
   public static final Field NAME = Field.required("name", String.class, "The catalog's name");
   public static final Field TYPE =
       Field.required("type", Catalog.Type.class, "The type of the catalog");
+  public static final Field PROVIDER =
+      Field.required("provider", String.class, "The provider of the catalog");
   public static final Field COMMENT =
       Field.optional("comment", String.class, "The comment or description of the catalog");
   public static final Field PROPERTIES =
@@ -40,6 +42,8 @@ public class CatalogEntity implements Entity, Auditable, HasIdentifier {
   private String name;
 
   @Getter private Catalog.Type type;
+
+  @Getter private String provider;
 
   @Nullable @Getter private String comment;
 
@@ -61,6 +65,7 @@ public class CatalogEntity implements Entity, Auditable, HasIdentifier {
     fields.put(NAME, name);
     fields.put(COMMENT, comment);
     fields.put(TYPE, type);
+    fields.put(PROVIDER, provider);
     fields.put(PROPERTIES, properties);
     fields.put(AUDIT_INFO, auditInfo);
 
@@ -167,6 +172,17 @@ public class CatalogEntity implements Entity, Auditable, HasIdentifier {
     }
 
     /**
+     * Sets the provider of the catalog.
+     *
+     * @param provider the provider of the catalog.
+     * @return the builder instance.
+     */
+    public Builder withProvider(String provider) {
+      catalog.provider = provider;
+      return this;
+    }
+
+    /**
      * Sets the comment or description of the catalog.
      *
      * @param comment the comment of the catalog.
@@ -229,6 +245,7 @@ public class CatalogEntity implements Entity, Auditable, HasIdentifier {
     return Objects.equal(id, that.id)
         && Objects.equal(name, that.name)
         && type == that.type
+        && Objects.equal(provider, that.provider)
         && Objects.equal(comment, that.comment)
         && Objects.equal(properties, that.properties)
         && Objects.equal(auditInfo, that.auditInfo);
@@ -241,6 +258,6 @@ public class CatalogEntity implements Entity, Auditable, HasIdentifier {
    */
   @Override
   public int hashCode() {
-    return Objects.hashCode(id, name, type, comment, properties, auditInfo);
+    return Objects.hashCode(id, name, type, provider, comment, properties, auditInfo);
   }
 }

--- a/core/src/main/java/com/datastrato/graviton/proto/CatalogEntitySerDe.java
+++ b/core/src/main/java/com/datastrato/graviton/proto/CatalogEntitySerDe.java
@@ -23,6 +23,7 @@ public class CatalogEntitySerDe implements ProtoSerDe<CatalogEntity, Catalog> {
         Catalog.newBuilder()
             .setId(catalogEntity.id())
             .setName(catalogEntity.name())
+            .setProvider(catalogEntity.getProvider())
             .setAuditInfo(new AuditInfoSerDe().serialize((AuditInfo) catalogEntity.auditInfo()));
 
     if (catalogEntity.getComment() != null) {
@@ -53,6 +54,7 @@ public class CatalogEntitySerDe implements ProtoSerDe<CatalogEntity, Catalog> {
     builder
         .withId(p.getId())
         .withName(p.getName())
+        .withProvider(p.getProvider())
         .withAuditInfo(new AuditInfoSerDe().deserialize(p.getAuditInfo()));
 
     if (p.hasComment()) {

--- a/core/src/test/java/com/datastrato/graviton/TestEntityStore.java
+++ b/core/src/test/java/com/datastrato/graviton/TestEntityStore.java
@@ -156,6 +156,7 @@ public class TestEntityStore {
             .withName("catalog")
             .withNamespace(Namespace.of("metalake"))
             .withType(TestCatalog.Type.RELATIONAL)
+            .withProvider("test")
             .withAuditInfo(auditInfo)
             .build();
 

--- a/core/src/test/java/com/datastrato/graviton/catalog/TestCatalogManager.java
+++ b/core/src/test/java/com/datastrato/graviton/catalog/TestCatalogManager.java
@@ -40,6 +40,8 @@ public class TestCatalogManager {
 
   private static String metalake = "metalake";
 
+  private static String provider = "test";
+
   @BeforeAll
   public static void setUp() throws IOException {
     config = new Config(false) {};
@@ -78,38 +80,32 @@ public class TestCatalogManager {
   @Test
   public void testCreateCatalog() {
     NameIdentifier ident = NameIdentifier.of("metalake", "test1");
-    Map<String, String> props = ImmutableMap.of("provider", "test");
+    Map<String, String> props = ImmutableMap.of();
 
     Catalog testCatalog =
-        catalogManager.createCatalog(ident, Catalog.Type.RELATIONAL, "comment", props);
+        catalogManager.createCatalog(ident, Catalog.Type.RELATIONAL, provider, "comment", props);
     Assertions.assertEquals("test1", testCatalog.name());
     Assertions.assertEquals("comment", testCatalog.comment());
     testProperties(props, testCatalog.properties());
     Assertions.assertEquals(Catalog.Type.RELATIONAL, testCatalog.type());
-
-    // Test without setting "provider"
-    Map<String, String> props1 = ImmutableMap.of();
-    NameIdentifier ident1 = NameIdentifier.of("metalake", "test2");
-    Throwable exception =
-        Assertions.assertThrows(
-            IllegalArgumentException.class,
-            () -> catalogManager.createCatalog(ident1, Catalog.Type.RELATIONAL, "comment", props1));
-    Assertions.assertTrue(
-        exception.getMessage().contains("'provider' not set in catalog properties"));
 
     // Test create under non-existed metalake
     NameIdentifier ident2 = NameIdentifier.of("metalake1", "test1");
     Throwable exception1 =
         Assertions.assertThrows(
             NoSuchMetalakeException.class,
-            () -> catalogManager.createCatalog(ident2, Catalog.Type.RELATIONAL, "comment", props));
+            () ->
+                catalogManager.createCatalog(
+                    ident2, Catalog.Type.RELATIONAL, provider, "comment", props));
     Assertions.assertTrue(exception1.getMessage().contains("Metalake metalake1 does not exist"));
 
     // Test create with duplicated name
     Throwable exception2 =
         Assertions.assertThrows(
             CatalogAlreadyExistsException.class,
-            () -> catalogManager.createCatalog(ident, Catalog.Type.RELATIONAL, "comment", props));
+            () ->
+                catalogManager.createCatalog(
+                    ident, Catalog.Type.RELATIONAL, provider, "comment", props));
     Assertions.assertTrue(
         exception2.getMessage().contains("Catalog metalake.test1 already exists"));
 
@@ -124,8 +120,8 @@ public class TestCatalogManager {
     NameIdentifier ident1 = NameIdentifier.of("metalake", "test12");
     Map<String, String> props = ImmutableMap.of("provider", "test");
 
-    catalogManager.createCatalog(ident, Catalog.Type.RELATIONAL, "comment", props);
-    catalogManager.createCatalog(ident1, Catalog.Type.RELATIONAL, "comment", props);
+    catalogManager.createCatalog(ident, Catalog.Type.RELATIONAL, provider, "comment", props);
+    catalogManager.createCatalog(ident1, Catalog.Type.RELATIONAL, provider, "comment", props);
 
     Set<NameIdentifier> idents = Sets.newHashSet(catalogManager.listCatalogs(ident.namespace()));
     Assertions.assertEquals(2, idents.size());
@@ -144,7 +140,7 @@ public class TestCatalogManager {
     NameIdentifier ident = NameIdentifier.of("metalake", "test21");
     Map<String, String> props = ImmutableMap.of("provider", "test");
 
-    catalogManager.createCatalog(ident, Catalog.Type.RELATIONAL, "comment", props);
+    catalogManager.createCatalog(ident, Catalog.Type.RELATIONAL, provider, "comment", props);
 
     Catalog catalog = catalogManager.loadCatalog(ident);
     Assertions.assertEquals("test21", catalog.name());
@@ -170,7 +166,7 @@ public class TestCatalogManager {
     Map<String, String> props = ImmutableMap.of("provider", "test");
     String comment = "comment";
 
-    catalogManager.createCatalog(ident, Catalog.Type.RELATIONAL, comment, props);
+    catalogManager.createCatalog(ident, Catalog.Type.RELATIONAL, provider, comment, props);
 
     // Test alter name;
     CatalogChange change = CatalogChange.rename("test32");
@@ -215,7 +211,7 @@ public class TestCatalogManager {
     Map<String, String> props = ImmutableMap.of("provider", "test");
     String comment = "comment";
 
-    catalogManager.createCatalog(ident, Catalog.Type.RELATIONAL, comment, props);
+    catalogManager.createCatalog(ident, Catalog.Type.RELATIONAL, provider, comment, props);
 
     // Test drop catalog
     boolean dropped = catalogManager.dropCatalog(ident);

--- a/core/src/test/java/com/datastrato/graviton/catalog/TestCatalogOperationDispatcher.java
+++ b/core/src/test/java/com/datastrato/graviton/catalog/TestCatalogOperationDispatcher.java
@@ -91,8 +91,8 @@ public class TestCatalogOperationDispatcher {
     dispatcher = new CatalogOperationDispatcher(catalogManager, entityStore, idGenerator);
 
     NameIdentifier ident = NameIdentifier.of(metalake, catalog);
-    Map<String, String> props = ImmutableMap.of("provider", "test");
-    catalogManager.createCatalog(ident, Catalog.Type.RELATIONAL, "comment", props);
+    Map<String, String> props = ImmutableMap.of();
+    catalogManager.createCatalog(ident, Catalog.Type.RELATIONAL, "test", "comment", props);
   }
 
   @AfterAll

--- a/core/src/test/java/com/datastrato/graviton/meta/TestEntity.java
+++ b/core/src/test/java/com/datastrato/graviton/meta/TestEntity.java
@@ -28,6 +28,7 @@ public class TestEntity {
   private final Long catalogId = 1L;
   private final String catalogName = "testCatalog";
   private final Catalog.Type type = Catalog.Type.RELATIONAL;
+  private final String provider = "test";
 
   // Schema test data
   private final Long schemaId = 1L;
@@ -66,6 +67,7 @@ public class TestEntity {
             .withName(catalogName)
             .withComment(catalogComment)
             .withType(type)
+            .withProvider(provider)
             .withProperties(map)
             .withAuditInfo(auditInfo)
             .build();

--- a/core/src/test/java/com/datastrato/graviton/proto/TestEntityProtoSerDe.java
+++ b/core/src/test/java/com/datastrato/graviton/proto/TestEntityProtoSerDe.java
@@ -114,6 +114,7 @@ public class TestEntityProtoSerDe {
     Long catalogId = 1L;
     String catalogName = "catalog";
     String comment = "comment";
+    String provider = "test";
 
     com.datastrato.graviton.meta.CatalogEntity catalogEntity =
         new com.datastrato.graviton.meta.CatalogEntity.Builder()
@@ -121,6 +122,7 @@ public class TestEntityProtoSerDe {
             .withName(catalogName)
             .withComment(comment)
             .withType(com.datastrato.graviton.Catalog.Type.RELATIONAL)
+            .withProvider(provider)
             .withAuditInfo(auditInfo)
             .build();
 

--- a/core/src/test/java/com/datastrato/graviton/storage/kv/TestKvEntityStorage.java
+++ b/core/src/test/java/com/datastrato/graviton/storage/kv/TestKvEntityStorage.java
@@ -70,6 +70,7 @@ public class TestKvEntityStorage {
         .withName(name)
         .withNamespace(namespace)
         .withType(Type.RELATIONAL)
+        .withProvider("test")
         .withAuditInfo(auditInfo)
         .build();
   }

--- a/integration-test/src/test/java/com/datastrato/graviton/integration/test/catalog/CatalogHiveIT.java
+++ b/integration-test/src/test/java/com/datastrato/graviton/integration/test/catalog/CatalogHiveIT.java
@@ -61,6 +61,8 @@ public class CatalogHiveIT extends AbstractIT {
   public static String HIVE_COL_NAME3 = "hive_col_name3";
   static String HIVE_METASTORE_URIS = "thrift://localhost:9083";
 
+  private static final String provider = "hive";
+
   private static HiveClientPool hiveClientPool;
 
   private static GravitonMetaLake metalake;
@@ -107,7 +109,6 @@ public class CatalogHiveIT extends AbstractIT {
 
   private static void createCatalog() {
     Map<String, String> properties = Maps.newHashMap();
-    properties.put("provider", "hive");
     properties.put(HiveConf.ConfVars.METASTOREURIS.varname, HIVE_METASTORE_URIS);
     properties.put(HiveConf.ConfVars.METASTORETHRIFTCONNECTIONRETRIES.varname, "30");
     properties.put(HiveConf.ConfVars.METASTORETHRIFTFAILURERETRIES.varname, "30");
@@ -117,6 +118,7 @@ public class CatalogHiveIT extends AbstractIT {
         metalake.createCatalog(
             NameIdentifier.of(metalakeName, catalogName),
             Catalog.Type.RELATIONAL,
+            provider,
             "comment",
             properties);
     Catalog loadCatalog = metalake.loadCatalog(NameIdentifier.of(metalakeName, catalogName));

--- a/meta/src/main/proto/graviton_meta.proto
+++ b/meta/src/main/proto/graviton_meta.proto
@@ -54,6 +54,7 @@ message Catalog {
   optional string comment = 4;
   map<string, string> properties = 5;
   AuditInfo audit_info = 6;
+  string provider = 7;
 }
 
 message Schema {

--- a/server/src/main/java/com/datastrato/graviton/server/web/rest/CatalogOperations.java
+++ b/server/src/main/java/com/datastrato/graviton/server/web/rest/CatalogOperations.java
@@ -71,7 +71,11 @@ public class CatalogOperations {
       NameIdentifier ident = NameIdentifier.ofCatalog(metalake, request.getName());
       Catalog catalog =
           manager.createCatalog(
-              ident, request.getType(), request.getComment(), request.getProperties());
+              ident,
+              request.getType(),
+              request.getProvider(),
+              request.getComment(),
+              request.getProperties());
       return Utils.ok(new CatalogResponse(DTOConverters.toDTO(catalog)));
 
     } catch (Exception e) {

--- a/server/src/test/java/com/datastrato/graviton/server/web/rest/TestCatalogOperations.java
+++ b/server/src/test/java/com/datastrato/graviton/server/web/rest/TestCatalogOperations.java
@@ -124,10 +124,14 @@ public class TestCatalogOperations extends JerseyTest {
   public void testCreateCatalog() {
     CatalogCreateRequest req =
         new CatalogCreateRequest(
-            "catalog1", Catalog.Type.RELATIONAL, "comment", ImmutableMap.of("key", "value"));
+            "catalog1",
+            Catalog.Type.RELATIONAL,
+            "test",
+            "comment",
+            ImmutableMap.of("key", "value"));
     TestCatalog catalog = buildCatalog("metalake1", "catalog1");
 
-    when(manager.createCatalog(any(), any(), any(), any())).thenReturn(catalog);
+    when(manager.createCatalog(any(), any(), any(), any(), any())).thenReturn(catalog);
 
     Response resp =
         target("/metalakes/metalake1/catalogs")
@@ -150,7 +154,7 @@ public class TestCatalogOperations extends JerseyTest {
     // Test throw NoSuchMetalakeException
     doThrow(new NoSuchMetalakeException("mock error"))
         .when(manager)
-        .createCatalog(any(), any(), any(), any());
+        .createCatalog(any(), any(), any(), any(), any());
     Response resp1 =
         target("/metalakes/metalake1/catalogs")
             .request(MediaType.APPLICATION_JSON_TYPE)
@@ -167,7 +171,7 @@ public class TestCatalogOperations extends JerseyTest {
     // Test throw CatalogAlreadyExistsException
     doThrow(new CatalogAlreadyExistsException("mock error"))
         .when(manager)
-        .createCatalog(any(), any(), any(), any());
+        .createCatalog(any(), any(), any(), any(), any());
     Response resp2 =
         target("/metalakes/metalake1/catalogs")
             .request(MediaType.APPLICATION_JSON_TYPE)
@@ -184,7 +188,7 @@ public class TestCatalogOperations extends JerseyTest {
     // Test throw internal RuntimeException
     doThrow(new RuntimeException("mock error"))
         .when(manager)
-        .createCatalog(any(), any(), any(), any());
+        .createCatalog(any(), any(), any(), any(), any());
     Response resp3 =
         target("/metalakes/metalake1/catalogs")
             .request(MediaType.APPLICATION_JSON_TYPE)
@@ -391,6 +395,7 @@ public class TestCatalogOperations extends JerseyTest {
             .withNamespace(Namespace.of(metalake))
             .withProperties(ImmutableMap.of("key", "value"))
             .withType(Catalog.Type.RELATIONAL)
+            .withProvider("test")
             .withAuditInfo(
                 new AuditInfo.Builder()
                     .withCreator("creator")


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to add several changes:

1. Add "provider" interface to `Catalog`, so user will get the catalog provider by calling this API.
2. Add "provider" parameter to `CreateCatalogRequest`, so users need to specify "provider" when creating catalogs.
3. Store "provider" to entity store, so catalog will have "provider" when loading from store.

### Why are the changes needed?

As #399 mentioned, "provider" parameter is very important and need to specify during creation. Currently, it is hidden in the catalog properties, so promoting this parameter to the top-level parameter.

Fix: #399 

### Does this PR introduce _any_ user-facing change?

Adding new interface to `Catalog`.

### How was this patch tested?

UTs.
