### PR TITLE
[#436]  fix(catalog-lakehouse): create dummy reportMetrics interface to remove warning message when spark writing data using IcebergRestCatalog

### DIFF
--- a/catalogs/catalog-lakehouse/src/main/java/com/datastrato/graviton/catalog/lakehouse/iceberg/web/rest/IcebergTableOperations.java
+++ b/catalogs/catalog-lakehouse/src/main/java/com/datastrato/graviton/catalog/lakehouse/iceberg/web/rest/IcebergTableOperations.java
@@ -24,6 +24,7 @@ import javax.ws.rs.core.Response;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.rest.RESTUtil;
 import org.apache.iceberg.rest.requests.CreateTableRequest;
+import org.apache.iceberg.rest.requests.ReportMetricsRequest;
 import org.apache.iceberg.rest.requests.UpdateTableRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -126,5 +127,15 @@ public class IcebergTableOperations {
     } else {
       return IcebergRestUtils.notExists();
     }
+  }
+
+  @POST
+  @Path("{table}/metrics")
+  @Produces(MediaType.APPLICATION_JSON)
+  public Response reportTableMetrics(
+      @PathParam("namespace") String namespace,
+      @PathParam("table") String table,
+      ReportMetricsRequest request) {
+    return IcebergRestUtils.noContent();
   }
 }

--- a/catalogs/catalog-lakehouse/src/test/java/com/datastrato/graviton/catalog/lakehouse/iceberg/web/rest/IcebergRestTestUtil.java
+++ b/catalogs/catalog-lakehouse/src/test/java/com/datastrato/graviton/catalog/lakehouse/iceberg/web/rest/IcebergRestTestUtil.java
@@ -26,6 +26,7 @@ public class IcebergRestTestUtil {
   public static final String TEST_NAMESPACE_NAME = "graviton-test";
   public static final String TABLE_PATH = NAMESPACE_PATH + "/" + TEST_NAMESPACE_NAME + "/tables";
   public static final String RENAME_TABLE_PATH = V_1 + "/tables/rename";
+  public static final String REPORT_METRICS_POSTFIX = "metrics";
 
   public static final boolean DEBUG_SERVER_LOG_ENABLED = true;
 

--- a/catalogs/catalog-lakehouse/src/test/java/com/datastrato/graviton/catalog/lakehouse/iceberg/web/rest/IcebergTestBase.java
+++ b/catalogs/catalog-lakehouse/src/test/java/com/datastrato/graviton/catalog/lakehouse/iceberg/web/rest/IcebergTestBase.java
@@ -51,6 +51,14 @@ public class IcebergTestBase extends JerseyTest {
     return getIcebergClientBuilder(path, Optional.empty());
   }
 
+  public Builder getReportMetricsClientBuilder(String name) {
+    String path =
+        Joiner.on("/")
+            .skipNulls()
+            .join(IcebergRestTestUtil.TABLE_PATH, name, IcebergRestTestUtil.REPORT_METRICS_POSTFIX);
+    return getIcebergClientBuilder(path, Optional.empty());
+  }
+
   public Builder getNamespaceClientBuilder() {
     return getNamespaceClientBuilder(Optional.empty(), Optional.empty());
   }


### PR DESCRIPTION

### What changes were proposed in this pull request?
add `reportMetrics` interfaces

### Why are the changes needed?
remove warning message when spark writing&reading data using IcebergRestCatalog

Fix: #436 

### Does this PR introduce _any_ user-facing change?
add new Iceberg REST interface

### How was this patch tested?
1. UT
2. real env
