### PR TITLE
[#465] integrate-test: upgrade spark client from 3.3 to 3.4

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,7 +27,7 @@ caffeine = "2.9.3"
 rocksdbjni = "7.7.3"
 iceberg = '1.3.1'
 trino = '426'
-spark = "3.3.3"
+spark = "3.4.1"
 
 
 protobuf-plugin = "0.9.2"
@@ -87,7 +87,7 @@ iceberg-core = { group = "org.apache.iceberg", name = "iceberg-core", version.re
 iceberg-hive-metastore = { group = "org.apache.iceberg", name = "iceberg-hive-metastore", version.ref = "iceberg" }
 trino-spi= { group = "io.trino", name = "trino-spi", version.ref = "trino" }
 trino-toolkit= { group = "io.trino", name = "trino-plugin-toolkit", version.ref = "trino" }
-iceberg-spark-runtime = { group = "org.apache.iceberg", name = "iceberg-spark-runtime-3.3_2.13", version.ref = "iceberg" }
+iceberg-spark-runtime = { group = "org.apache.iceberg", name = "iceberg-spark-runtime-3.4_2.13", version.ref = "iceberg" }
 spark-sql = { group = "org.apache.spark", name = "spark-sql_2.13", version.ref = "spark" }
 
 

--- a/integration-test/src/test/java/com/datastrato/graviton/integration/test/catalog/lakehouse/iceberg/TestIcebergRESTServiceIT.java
+++ b/integration-test/src/test/java/com/datastrato/graviton/integration/test/catalog/lakehouse/iceberg/TestIcebergRESTServiceIT.java
@@ -16,6 +16,7 @@ import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.spark.sql.AnalysisException;
 import org.apache.spark.sql.catalyst.analysis.NamespaceAlreadyExistsException;
 import org.apache.spark.sql.catalyst.analysis.NoSuchNamespaceException;
+import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
 import org.apache.spark.sql.catalyst.analysis.TableAlreadyExistsException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -122,7 +123,7 @@ public class TestIcebergRESTServiceIT extends TestIcebergRESTServiceBaseIT {
         AnalysisException.class, () -> sql("DESC TABLE table_test.drop_foo1"));
 
     Assertions.assertThrowsExactly(
-        AnalysisException.class, () -> sql("DROP TABLE table_test.drop_foo1"));
+        NoSuchTableException.class, () -> sql("DROP TABLE table_test.drop_foo1"));
   }
 
   @Test


### PR DESCRIPTION
### What changes were proposed in this pull request?
upgrade spark client from 3.3 to 3.4

### Why are the changes needed?
suggested by A5, 3.4 is long term supported

Fix: #465 

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
1. UT
2. setup spark 3.4 envriment 
