### PR TITLE
[#459]  feat(IT): remove hadoop 3.0 dependencies from integrate test

### DIFF
--- a/catalogs/catalog-lakehouse-iceberg/build.gradle.kts
+++ b/catalogs/catalog-lakehouse-iceberg/build.gradle.kts
@@ -52,6 +52,12 @@ dependencies {
         exclude("com.tdunning", "json")
         exclude("javax.transaction", "transaction-api")
         exclude("com.zaxxer","HikariCP")
+        exclude("org.apache.zookeeper")
+        exclude("org.apache.hadoop", "hadoop-yarn-server-common")
+        exclude("org.apache.hadoop", "hadoop-yarn-server-applicationhistoryservice")
+        exclude("org.apache.hadoop", "hadoop-yarn-server-web-proxy")
+        exclude("org.apache.hadoop", "hadoop-yarn-api")
+        exclude("org.apache.hadoop", "hadoop-yarn-server-resourcemanager")
     }
 
     implementation(libs.hadoop2.hdfs)

--- a/integration-test/build.gradle.kts
+++ b/integration-test/build.gradle.kts
@@ -98,8 +98,11 @@ dependencies {
   testImplementation(libs.bundles.log4j)
   testImplementation(libs.iceberg.spark.runtime)
   testImplementation(libs.spark.sql) {
-    exclude("org.apache.hadoop") 
-    exclude("org.rocksdb") 
+    exclude("org.apache.hadoop")
+    exclude("org.rocksdb")
+    exclude("org.apache.avro")
+    exclude("org.apache.zookeeper")
+    exclude("io.dropwizard.metrics")
   }
   testImplementation(libs.slf4j.jdk14)
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

integrate-test jar bumps after using spark-sql, we could remove unnecessary dependencies like Hadoop 3.0

### Why are the changes needed?


Fix: #459 

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
1. existing UTs