### PR TITLE
[MINOR] fix: `tar.gz` package with project name and version dirce

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -174,6 +174,7 @@ tasks {
   val assembleDistribution by registering(Tar::class) {
     group = "graviton distribution"
     finalizedBy("checksumDistribution")
+    into("${rootProject.name}-${version}")
     from(compileDistribution.map { it.outputs.files.single() })
     compression = Compression.GZIP
     archiveFileName.set("${rootProject.name}-${version}.tar.gz")


### PR DESCRIPTION
### What changes were proposed in this pull request?
fix `build.gradle.kts` bug.

### Why are the changes needed?

When we execute `./gradlew assembleDistribution`, `tar.gz` package is without the root directory.

### Does this PR introduce _any_ user-facing change?
N/A

### How was this patch tested?

(Please test your changes, and provide instructions on how to test it:
```
./gradlew assembleDistribution

tar zxvf graviton-0.2.0-SNAPSHOT.tar.gz

ls -lt
-rw-r--r--  1 graviton-0.2.0-SNAPSHOT.tar.gz.sha256
-rw-r--r--  1 graviton-0.2.0-SNAPSHOT.tar.gz
drwxr-xr-x  6 package
drwxr-xr-x  6 graviton-0.2.0-SNAPSHOT

ls -lt graviton-0.2.0-SNAPSHOT
drwxr-xr-x   bin
drwxr-xr-x   conf
drwxr-xr-x  libs
drwxr-xr-x  catalogs
```
