### PR TITLE
[#283] feat(server): support purge table for Restful server

### DIFF
--- a/core/src/main/java/com/datastrato/graviton/catalog/CatalogOperationDispatcher.java
+++ b/core/src/main/java/com/datastrato/graviton/catalog/CatalogOperationDispatcher.java
@@ -538,6 +538,28 @@ public class CatalogOperationDispatcher implements TableCatalog, SupportsSchemas
     return true;
   }
 
+  @Override
+  public boolean purgeTable(NameIdentifier ident) throws UnsupportedOperationException {
+    boolean purged =
+        doWithCatalog(
+            getCatalogIdentifier(ident),
+            c -> c.doWithTableOps(t -> t.purgeTable(ident)),
+            NoSuchTableException.class,
+            UnsupportedOperationException.class);
+
+    if (!purged) {
+      return false;
+    }
+
+    try {
+      store.delete(ident, TABLE);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+
+    return true;
+  }
+
   private <R, E extends Throwable> R doWithCatalog(
       NameIdentifier ident, ThrowableFunction<CatalogManager.CatalogWrapper, R> fn, Class<E> ex)
       throws E {

--- a/server/src/main/java/com/datastrato/graviton/server/web/rest/TableOperations.java
+++ b/server/src/main/java/com/datastrato/graviton/server/web/rest/TableOperations.java
@@ -24,12 +24,14 @@ import com.datastrato.graviton.server.web.Utils;
 import javax.inject.Inject;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.DELETE;
+import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 import org.slf4j.Logger;
@@ -146,10 +148,11 @@ public class TableOperations {
       @PathParam("metalake") String metalake,
       @PathParam("catalog") String catalog,
       @PathParam("schema") String schema,
-      @PathParam("table") String table) {
+      @PathParam("table") String table,
+      @QueryParam("purge") @DefaultValue("false") boolean purge) {
     try {
       NameIdentifier ident = NameIdentifier.ofTable(metalake, catalog, schema, table);
-      boolean dropped = dispatcher.dropTable(ident);
+      boolean dropped = purge ? dispatcher.purgeTable(ident) : dispatcher.dropTable(ident);
       if (!dropped) {
         LOG.warn("Failed to drop table {} under schema {}", table, schema);
       }


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?
Add query param `purge` to `dropTable` API to support purge table 

### Why are the changes needed?
purge table is a normal operation, but we didn't export the API for the REST client

Fix: #283 

### Does this PR introduce _any_ user-facing change?
Yes. Restful client can specify `purge=true` in the delete table request to purge the table


### How was this patch tested?
UTs added
