### PR TITLE
[#372] fix(hive): Throw exception while column position not found

### DIFF
--- a/catalogs/catalog-hive/src/test/java/com/datastrato/graviton/catalog/hive/TestHiveTable.java
+++ b/catalogs/catalog-hive/src/test/java/com/datastrato/graviton/catalog/hive/TestHiveTable.java
@@ -401,6 +401,17 @@ public class TestHiveTable extends MiniHiveMetastoreService {
                             TableChange.ColumnPosition.after("not_exist_col"))));
     Assertions.assertTrue(exception.getMessage().contains("Column does not exist"));
 
+    exception =
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                hiveCatalog
+                    .asTableCatalog()
+                    .alterTable(
+                        tableIdentifier,
+                        TableChange.updateColumnPosition(new String[] {"col_1"}, null)));
+    Assertions.assertTrue(exception.getMessage().contains("Column position cannot be null"));
+
     // test alter
     hiveCatalog
         .asTableCatalog()


### PR DESCRIPTION
### What changes were proposed in this pull request?
Throw exception instead of return first position while column position not found

### Why are the changes needed?
Clarify the result of column position not found


Fix: #372 

### Does this PR introduce _any_ user-facing change?
yes, user should specify the existing column position

### How was this patch tested?
UTs added
