### PR TITLE
[#483] test(lakehouse-iceberg): add graviton IT test for iceberg

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   HIVE_IMAGE_NAME: datastrato/graviton-ci-hive
-  HIVE_IMAGE_TAG_NAME: 0.1.2
+  HIVE_IMAGE_TAG_NAME: 0.1.3
 
 concurrency:
   group: ${{ github.worklfow }}-${{ github.event.pull_request.number || github.ref }}

--- a/bin/graviton.sh
+++ b/bin/graviton.sh
@@ -83,6 +83,7 @@ function wait_for_graviton_server_to_die() {
 
 function start() {
   local pid=$(found_graviton_server_pid)
+  check_jdbc_jar "${GRAVITON_HOME}"
 
   if [[ ! -z "${pid}" ]]; then
     if kill -0 ${pid} >/dev/null 2>&1; then

--- a/catalogs/catalog-lakehouse-iceberg/build.gradle.kts
+++ b/catalogs/catalog-lakehouse-iceberg/build.gradle.kts
@@ -64,7 +64,6 @@ dependencies {
     implementation(libs.hadoop2.hdfs)
     implementation(libs.hadoop2.common)
     implementation(libs.hadoop2.mapreduce.client.core)
-
     compileOnly(libs.lombok)
     annotationProcessor(libs.lombok)
 

--- a/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/graviton/catalog/lakehouse/iceberg/IcebergCatalogPropertiesMetadata.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/graviton/catalog/lakehouse/iceberg/IcebergCatalogPropertiesMetadata.java
@@ -35,6 +35,8 @@ public class IcebergCatalogPropertiesMetadata extends BaseCatalogPropertiesMetad
   // it to `catalogType` automatically and pass it to Iceberg.
   public static final Map<String, String> GRAVITON_CONFIG_TO_ICEBERG =
       ImmutableMap.of(
+          CATALOG_BACKEND_NAME,
+          CATALOG_BACKEND_NAME,
           GRAVITON_JDBC_USER,
           ICEBERG_JDBC_USER,
           GRAVITON_JDBC_PASSWORD,

--- a/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/graviton/catalog/lakehouse/iceberg/IcebergTable.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/graviton/catalog/lakehouse/iceberg/IcebergTable.java
@@ -12,6 +12,7 @@ import com.datastrato.graviton.catalog.lakehouse.iceberg.converter.ToIcebergSort
 import com.datastrato.graviton.catalog.lakehouse.iceberg.ops.IcebergTableOpsHelper;
 import com.datastrato.graviton.catalog.rel.BaseTable;
 import com.datastrato.graviton.meta.AuditInfo;
+import com.datastrato.graviton.rel.Distribution;
 import com.google.common.collect.Maps;
 import java.util.Map;
 import lombok.Getter;
@@ -48,6 +49,7 @@ public class IcebergTable extends BaseTable {
 
     Map<String, String> resultProperties =
         Maps.newHashMap(IcebergTableOpsHelper.removeReservedProperties(properties));
+    resultProperties.putIfAbsent(ICEBERG_COMMENT_FIELD_NAME, comment);
     CreateTableRequest.Builder builder =
         CreateTableRequest.builder()
             .withName(name)
@@ -77,6 +79,7 @@ public class IcebergTable extends BaseTable {
         .withLocation(table.location())
         .withProperties(properties)
         .withColumns(icebergColumns)
+        .withDistribution(Distribution.NONE)
         .withName(tableName)
         .withAuditInfo(AuditInfo.EMPTY)
         .withPartitions(FromIcebergPartitionSpec.fromPartitionSpec(table.spec(), schema))

--- a/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/graviton/catalog/lakehouse/iceberg/ops/IcebergTableOpsHelper.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/graviton/catalog/lakehouse/iceberg/ops/IcebergTableOpsHelper.java
@@ -34,7 +34,6 @@ import java.util.stream.Collectors;
 import javax.ws.rs.NotSupportedException;
 import lombok.Getter;
 import lombok.Setter;
-import org.apache.commons.lang3.ArrayUtils;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.Transaction;
@@ -287,8 +286,8 @@ public class IcebergTableOpsHelper {
         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
   }
 
-  public static Namespace getIcebergNamespace(NameIdentifier ident) {
-    return getIcebergNamespace(ArrayUtils.add(ident.namespace().levels(), ident.name()));
+  public static Namespace getIcebergNamespace(com.datastrato.graviton.Namespace namespace) {
+    return getIcebergNamespace(namespace.level(namespace.length() - 1));
   }
 
   public static Namespace getIcebergNamespace(String... level) {
@@ -297,12 +296,13 @@ public class IcebergTableOpsHelper {
 
   public static TableIdentifier buildIcebergTableIdentifier(
       com.datastrato.graviton.Namespace namespace, String name) {
-    return TableIdentifier.of(ArrayUtils.add(namespace.levels(), name));
+    String[] levels = namespace.levels();
+    return TableIdentifier.of(levels[levels.length - 1], name);
   }
 
   public static TableIdentifier buildIcebergTableIdentifier(NameIdentifier nameIdentifier) {
-    return TableIdentifier.of(
-        ArrayUtils.add(nameIdentifier.namespace().levels(), nameIdentifier.name()));
+    String[] levels = nameIdentifier.namespace().levels();
+    return TableIdentifier.of(levels[levels.length - 1], nameIdentifier.name());
   }
 
   @VisibleForTesting

--- a/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/graviton/catalog/lakehouse/iceberg/utils/IcebergCatalogUtil.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/graviton/catalog/lakehouse/iceberg/utils/IcebergCatalogUtil.java
@@ -45,7 +45,7 @@ public class IcebergCatalogUtil {
         new JdbcCatalog(
             null,
             null,
-            Boolean.parseBoolean(properties.getOrDefault(ICEBERG_JDBC_INITIALIZE, "false")));
+            Boolean.parseBoolean(properties.getOrDefault(ICEBERG_JDBC_INITIALIZE, "true")));
     HdfsConfiguration hdfsConfiguration = new HdfsConfiguration();
     properties.forEach(hdfsConfiguration::set);
     jdbcCatalog.setConf(hdfsConfiguration);

--- a/catalogs/catalog-lakehouse-iceberg/src/test/java/com/datastrato/graviton/catalog/lakehouse/iceberg/TestIcebergSchema.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/test/java/com/datastrato/graviton/catalog/lakehouse/iceberg/TestIcebergSchema.java
@@ -15,6 +15,8 @@ import com.google.common.collect.Maps;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -43,8 +45,11 @@ public class TestIcebergSchema {
 
     Assertions.assertTrue(icebergCatalog.asSchemas().schemaExists(ident));
 
-    NameIdentifier[] idents = icebergCatalog.asSchemas().listSchemas(ident.namespace());
-    Assertions.assertTrue(Arrays.asList(idents).contains(ident));
+    Set<String> names =
+        Arrays.stream(icebergCatalog.asSchemas().listSchemas(ident.namespace()))
+            .map(NameIdentifier::name)
+            .collect(Collectors.toSet());
+    Assertions.assertTrue(names.contains(ident.name()));
 
     // Test schema already exists
     Throwable exception =

--- a/catalogs/catalog-lakehouse-iceberg/src/test/java/com/datastrato/graviton/catalog/lakehouse/iceberg/TestIcebergTable.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/test/java/com/datastrato/graviton/catalog/lakehouse/iceberg/TestIcebergTable.java
@@ -17,7 +17,6 @@ import com.datastrato.graviton.meta.AuditInfo;
 import com.datastrato.graviton.meta.CatalogEntity;
 import com.datastrato.graviton.rel.Column;
 import com.datastrato.graviton.rel.Distribution;
-import com.datastrato.graviton.rel.Distribution.Strategy;
 import com.datastrato.graviton.rel.SortOrder;
 import com.datastrato.graviton.rel.SortOrder.Direction;
 import com.datastrato.graviton.rel.SortOrder.NullOrdering;
@@ -107,14 +106,6 @@ public class TestIcebergTable {
     return entity;
   }
 
-  private Distribution createDistribution() {
-    return Distribution.builder()
-        .withNumber(10)
-        .withTransforms(new Transform[] {Transforms.field(new String[] {"col_1"})})
-        .withStrategy(Strategy.EVEN)
-        .build();
-  }
-
   private SortOrder[] createSortOrder() {
     return new SortOrder[] {
       SortOrder.builder()
@@ -159,7 +150,7 @@ public class TestIcebergTable {
                 ICEBERG_COMMENT,
                 properties,
                 new Transform[0],
-                null,
+                Distribution.NONE,
                 sortOrders);
     Assertions.assertEquals(tableIdentifier.name(), table.name());
     Assertions.assertEquals(ICEBERG_COMMENT, table.comment());
@@ -198,7 +189,7 @@ public class TestIcebergTable {
                         ICEBERG_COMMENT,
                         properties,
                         new Transform[0],
-                        null,
+                        Distribution.NONE,
                         sortOrders));
     Assertions.assertTrue(exception.getMessage().contains("Table already exists"));
   }
@@ -380,7 +371,7 @@ public class TestIcebergTable {
             .build();
     Column[] columns = new Column[] {col1, col2};
 
-    Distribution distribution = createDistribution();
+    Distribution distribution = Distribution.NONE;
     SortOrder[] sortOrders = createSortOrder();
 
     Table createdTable =

--- a/catalogs/catalog-lakehouse-iceberg/src/test/java/com/datastrato/graviton/catalog/lakehouse/iceberg/utils/TestIcebergCatalogUtil.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/test/java/com/datastrato/graviton/catalog/lakehouse/iceberg/utils/TestIcebergCatalogUtil.java
@@ -5,6 +5,7 @@
 
 package com.datastrato.graviton.catalog.lakehouse.iceberg.utils;
 
+import com.datastrato.graviton.catalog.lakehouse.iceberg.IcebergCatalogPropertiesMetadata;
 import com.datastrato.graviton.catalog.lakehouse.iceberg.IcebergConfig;
 import java.util.HashMap;
 import java.util.Map;
@@ -47,6 +48,7 @@ public class TestIcebergCatalogUtil {
     Map<String, String> properties = new HashMap<>();
     properties.put(CatalogProperties.URI, "jdbc://0.0.0.0:3306");
     properties.put(CatalogProperties.WAREHOUSE_LOCATION, "test");
+    properties.put(IcebergCatalogPropertiesMetadata.ICEBERG_JDBC_INITIALIZE, "false");
     catalog = IcebergCatalogUtil.loadCatalogBackend("jdbc", properties);
     Assertions.assertTrue(catalog instanceof JdbcCatalog);
 

--- a/common/src/main/java/com/datastrato/graviton/dto/util/DTOConverters.java
+++ b/common/src/main/java/com/datastrato/graviton/dto/util/DTOConverters.java
@@ -97,7 +97,7 @@ public class DTOConverters {
   }
 
   public static DistributionDTO toDTO(Distribution distribution) {
-    if (Distribution.NONE.equals(distribution)) {
+    if (Distribution.NONE.equals(distribution) || null == distribution) {
       return DistributionDTO.NONE;
     }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,7 +30,6 @@ trino = '426'
 spark = "3.4.1"
 scala-collection-compat = "2.7.0"
 
-
 protobuf-plugin = "0.9.2"
 spotless-plugin = '6.11.0'
 gradle-extensions-plugin = '1.74'
@@ -93,7 +92,6 @@ trino-testing= { group = "io.trino", name = "trino-testing", version.ref = "trin
 iceberg-spark-runtime = { group = "org.apache.iceberg", name = "iceberg-spark-runtime-3.4_2.13", version.ref = "iceberg" }
 spark-sql = { group = "org.apache.spark", name = "spark-sql_2.13", version.ref = "spark" }
 scala-collection-compat =  { group = "org.scala-lang.modules", name = "scala-collection-compat_2.13", version.ref = "scala-collection-compat" }
-
 
 [bundles]
 log4j = ["slf4j-api", "log4j-slf4j2-impl", "log4j-api", "log4j-core", "log4j-12-api"]

--- a/integration-test/build.gradle.kts
+++ b/integration-test/build.gradle.kts
@@ -73,7 +73,9 @@ dependencies {
     exclude("org.eclipse.jetty.aggregate", "jetty-all")
     exclude("org.eclipse.jetty.orbit", "javax.servlet")
   }
-
+  testImplementation(libs.hadoop2.hdfs){
+    exclude("*")
+  }
   testImplementation(libs.hadoop2.mapreduce.client.core) {
     exclude("*")
   }
@@ -105,8 +107,7 @@ dependencies {
     exclude("org.apache.zookeeper")
     exclude("io.dropwizard.metrics")
   }
-  testImplementation(libs.scala.collection.compat) 
-  testImplementation(libs.slf4j.jdk14)
+  testImplementation(libs.scala.collection.compat)
 }
 
 /* Optimizing integration test execution conditions */

--- a/integration-test/src/test/java/com/datastrato/graviton/integration/test/catalog/lakehouse/iceberg/CatalogIcebergIT.java
+++ b/integration-test/src/test/java/com/datastrato/graviton/integration/test/catalog/lakehouse/iceberg/CatalogIcebergIT.java
@@ -1,0 +1,586 @@
+/*
+ * Copyright 2023 Datastrato.
+ * This software is licensed under the Apache License version 2.
+ */
+package com.datastrato.graviton.integration.test.catalog.lakehouse.iceberg;
+
+import static com.datastrato.graviton.rel.transforms.Transforms.day;
+import static com.datastrato.graviton.rel.transforms.Transforms.identity;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.datastrato.graviton.Catalog;
+import com.datastrato.graviton.NameIdentifier;
+import com.datastrato.graviton.Namespace;
+import com.datastrato.graviton.catalog.lakehouse.iceberg.IcebergCatalogBackend;
+import com.datastrato.graviton.catalog.lakehouse.iceberg.IcebergConfig;
+import com.datastrato.graviton.catalog.lakehouse.iceberg.IcebergTable;
+import com.datastrato.graviton.catalog.lakehouse.iceberg.ops.IcebergTableOpsHelper;
+import com.datastrato.graviton.client.GravitonMetaLake;
+import com.datastrato.graviton.dto.rel.ColumnDTO;
+import com.datastrato.graviton.exceptions.NoSuchSchemaException;
+import com.datastrato.graviton.exceptions.SchemaAlreadyExistsException;
+import com.datastrato.graviton.exceptions.TableAlreadyExistsException;
+import com.datastrato.graviton.integration.test.util.AbstractIT;
+import com.datastrato.graviton.integration.test.util.GravitonITUtils;
+import com.datastrato.graviton.rel.Column;
+import com.datastrato.graviton.rel.Distribution;
+import com.datastrato.graviton.rel.Schema;
+import com.datastrato.graviton.rel.SchemaChange;
+import com.datastrato.graviton.rel.SortOrder;
+import com.datastrato.graviton.rel.SortOrder.Direction;
+import com.datastrato.graviton.rel.SortOrder.NullOrdering;
+import com.datastrato.graviton.rel.SupportsSchemas;
+import com.datastrato.graviton.rel.Table;
+import com.datastrato.graviton.rel.TableCatalog;
+import com.datastrato.graviton.rel.TableChange;
+import com.datastrato.graviton.rel.transforms.Transform;
+import com.datastrato.graviton.rel.transforms.Transforms;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+import io.substrait.type.TypeCreator;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.hadoop.hdfs.HdfsConfiguration;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.exceptions.NoSuchNamespaceException;
+import org.apache.iceberg.hive.HiveCatalog;
+import org.apache.thrift.TException;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+@Tag("graviton-docker-it")
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class CatalogIcebergIT extends AbstractIT {
+  public static String metalakeName = GravitonITUtils.genRandomName("iceberg_it_metalake");
+  public static String catalogName = GravitonITUtils.genRandomName("iceberg_it_catalog");
+  public static String schemaName = GravitonITUtils.genRandomName("iceberg_it_schema");
+  public static String tableName = GravitonITUtils.genRandomName("iceberg_it_table");
+  public static String alertTableName = "alert_table_name";
+  public static String table_comment = "table_comment";
+
+  public static String schema_comment = "schema_comment";
+  public static String ICEBERG_COL_NAME1 = "iceberg_col_name1";
+  public static String ICEBERG_COL_NAME2 = "iceberg_col_name2";
+  public static String ICEBERG_COL_NAME3 = "iceberg_col_name3";
+  private static final String provider = "lakehouse-iceberg";
+  private static final String WAREHOUSE = "file:///tmp/iceberg";
+  private static final String URI = "thrift://127.0.0.1:9083";
+
+  private static GravitonMetaLake metalake;
+
+  private static Catalog catalog;
+
+  private static HiveCatalog hiveCatalog;
+
+  @BeforeAll
+  public static void startup() {
+    createMetalake();
+    createCatalog();
+    createSchema();
+  }
+
+  @AfterAll
+  public static void stop() {
+    clearTableAndSchema();
+    client.dropMetalake(NameIdentifier.of(metalakeName));
+  }
+
+  @AfterEach
+  private void resetSchema() {
+    //    clearTableAndSchema();
+    //    createSchema();
+  }
+
+  private static void clearTableAndSchema() {
+    NameIdentifier[] nameIdentifiers =
+        catalog.asTableCatalog().listTables(Namespace.of(metalakeName, catalogName, schemaName));
+    for (NameIdentifier nameIdentifier : nameIdentifiers) {
+      catalog.asTableCatalog().dropTable(nameIdentifier);
+    }
+    catalog.asSchemas().dropSchema(NameIdentifier.of(metalakeName, catalogName, schemaName), false);
+  }
+
+  private static void createMetalake() {
+    GravitonMetaLake[] gravitonMetaLakes = client.listMetalakes();
+    Assertions.assertEquals(0, gravitonMetaLakes.length);
+
+    GravitonMetaLake createdMetalake =
+        client.createMetalake(NameIdentifier.of(metalakeName), "comment", Collections.emptyMap());
+    GravitonMetaLake loadMetalake = client.loadMetalake(NameIdentifier.of(metalakeName));
+    Assertions.assertEquals(createdMetalake, loadMetalake);
+
+    metalake = loadMetalake;
+  }
+
+  private static void createCatalog() {
+    Map<String, String> catalogProperties = Maps.newHashMap();
+    catalogProperties.put("key1", "val1");
+    catalogProperties.put("key2", "val2");
+
+    catalogProperties.put(
+        IcebergConfig.CATALOG_BACKEND.getKey(), IcebergCatalogBackend.HIVE.name());
+    catalogProperties.put(IcebergConfig.CATALOG_URI.getKey(), URI);
+    catalogProperties.put(IcebergConfig.CATALOG_WAREHOUSE.getKey(), WAREHOUSE);
+
+    Map<String, String> hiveProperties = Maps.newHashMap();
+    hiveProperties.put(IcebergConfig.CATALOG_URI.getKey(), URI);
+    hiveProperties.put(IcebergConfig.CATALOG_WAREHOUSE.getKey(), WAREHOUSE);
+
+    hiveCatalog = new HiveCatalog();
+    hiveCatalog.setConf(new HdfsConfiguration());
+    hiveCatalog.initialize("hive", hiveProperties);
+
+    Catalog createdCatalog =
+        metalake.createCatalog(
+            NameIdentifier.of(metalakeName, catalogName),
+            Catalog.Type.RELATIONAL,
+            provider,
+            "comment",
+            catalogProperties);
+    Catalog loadCatalog = metalake.loadCatalog(NameIdentifier.of(metalakeName, catalogName));
+    Assertions.assertEquals(createdCatalog, loadCatalog);
+
+    catalog = loadCatalog;
+  }
+
+  private static void createSchema() {
+    NameIdentifier ident = NameIdentifier.of(metalakeName, catalogName, schemaName);
+    Map<String, String> prop = Maps.newHashMap();
+    prop.put("key1", "val1");
+    prop.put("key2", "val2");
+
+    Schema createdSchema = catalog.asSchemas().createSchema(ident, schema_comment, prop);
+    Schema loadSchema = catalog.asSchemas().loadSchema(ident);
+    Assertions.assertEquals(createdSchema.name(), loadSchema.name());
+    prop.forEach((key, value) -> Assertions.assertEquals(loadSchema.properties().get(key), value));
+  }
+
+  private ColumnDTO[] createColumns() {
+    ColumnDTO col1 =
+        new ColumnDTO.Builder()
+            .withName(ICEBERG_COL_NAME1)
+            .withDataType(TypeCreator.NULLABLE.I32)
+            .withComment("col_1_comment")
+            .build();
+    ColumnDTO col2 =
+        new ColumnDTO.Builder()
+            .withName(ICEBERG_COL_NAME2)
+            .withDataType(TypeCreator.NULLABLE.DATE)
+            .withComment("col_2_comment")
+            .build();
+    ColumnDTO col3 =
+        new ColumnDTO.Builder()
+            .withName(ICEBERG_COL_NAME3)
+            .withDataType(TypeCreator.NULLABLE.STRING)
+            .withComment("col_3_comment")
+            .build();
+    return new ColumnDTO[] {col1, col2, col3};
+  }
+
+  private Map<String, String> createProperties() {
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put("key1", "val1");
+    properties.put("key2", "val2");
+    return properties;
+  }
+
+  @Test
+  void testOperationIcebergSchema() {
+    SupportsSchemas schemas = catalog.asSchemas();
+    Namespace namespace = Namespace.of(metalakeName, catalogName);
+    // list schema check.
+    NameIdentifier[] nameIdentifiers = schemas.listSchemas(namespace);
+    Set<String> schemaNames =
+        Arrays.stream(nameIdentifiers).map(NameIdentifier::name).collect(Collectors.toSet());
+    Assertions.assertTrue(schemaNames.contains(schemaName));
+    List<org.apache.iceberg.catalog.Namespace> icebergNamespaces =
+        hiveCatalog.listNamespaces(IcebergTableOpsHelper.getIcebergNamespace());
+
+    schemaNames =
+        icebergNamespaces.stream().map(ns -> ns.level(ns.length() - 1)).collect(Collectors.toSet());
+    Assertions.assertTrue(schemaNames.contains(schemaName));
+
+    // create schema check.
+    String testSchemaName = GravitonITUtils.genRandomName("test_schema_1");
+    NameIdentifier schemaIdent = NameIdentifier.of(metalakeName, catalogName, testSchemaName);
+    schemas.createSchema(schemaIdent, schema_comment, Collections.emptyMap());
+    nameIdentifiers = schemas.listSchemas(Namespace.of(metalakeName, catalogName));
+    Map<String, NameIdentifier> schemaMap =
+        Arrays.stream(nameIdentifiers).collect(Collectors.toMap(NameIdentifier::name, v -> v));
+    Assertions.assertTrue(schemaMap.containsKey(testSchemaName));
+    icebergNamespaces = hiveCatalog.listNamespaces(IcebergTableOpsHelper.getIcebergNamespace());
+    schemaNames =
+        icebergNamespaces.stream().map(ns -> ns.level(ns.length() - 1)).collect(Collectors.toSet());
+    Assertions.assertTrue(schemaNames.contains(testSchemaName));
+
+    // alert、load schema check.
+    schemas.alterSchema(schemaIdent, SchemaChange.setProperty("t1", "v1"));
+    Schema schema = schemas.loadSchema(schemaIdent);
+    Assertions.assertTrue(schema.properties().containsKey("t1"));
+
+    Map<String, String> hiveCatalogProps =
+        hiveCatalog.loadNamespaceMetadata(
+            IcebergTableOpsHelper.getIcebergNamespace(schemaIdent.name()));
+    Assertions.assertTrue(hiveCatalogProps.containsKey("t1"));
+
+    Assertions.assertThrows(
+        SchemaAlreadyExistsException.class,
+        () -> schemas.createSchema(schemaIdent, schema_comment, Collections.emptyMap()));
+
+    // drop schema check.
+    schemas.dropSchema(schemaIdent, false);
+    Assertions.assertThrows(NoSuchSchemaException.class, () -> schemas.loadSchema(schemaIdent));
+    Assertions.assertThrows(
+        NoSuchNamespaceException.class,
+        () ->
+            hiveCatalog.loadNamespaceMetadata(
+                IcebergTableOpsHelper.getIcebergNamespace(schemaIdent.name())));
+    nameIdentifiers = schemas.listSchemas(Namespace.of(metalakeName, catalogName));
+    schemaMap =
+        Arrays.stream(nameIdentifiers).collect(Collectors.toMap(NameIdentifier::name, v -> v));
+    Assertions.assertFalse(schemaMap.containsKey(testSchemaName));
+    Assertions.assertFalse(
+        schemas.dropSchema(NameIdentifier.of(metalakeName, catalogName, "no-exits"), false));
+    TableCatalog tableCatalog = catalog.asTableCatalog();
+
+    // create failed check.
+    NameIdentifier table =
+        NameIdentifier.of(metalakeName, catalogName, testSchemaName, "test_table");
+    Assertions.assertThrows(
+        NoSuchSchemaException.class,
+        () ->
+            tableCatalog.createTable(
+                table,
+                createColumns(),
+                table_comment,
+                createProperties(),
+                null,
+                Distribution.NONE,
+                null));
+    // drop schema failed check.
+    Assertions.assertFalse(schemas.dropSchema(schemaIdent, false));
+    Assertions.assertDoesNotThrow(() -> tableCatalog.dropTable(table));
+    Assertions.assertDoesNotThrow(() -> schemas.dropSchema(schemaIdent, false));
+    icebergNamespaces = hiveCatalog.listNamespaces(IcebergTableOpsHelper.getIcebergNamespace());
+    schemaNames =
+        icebergNamespaces.stream().map(ns -> ns.level(ns.length() - 1)).collect(Collectors.toSet());
+    Assertions.assertTrue(schemaNames.contains(schemaName));
+  }
+
+  @Test
+  void testCreateAndLoadIcebergTable() {
+    // Create table from Graviton API
+    ColumnDTO[] columns = createColumns();
+
+    NameIdentifier tableIdentifier =
+        NameIdentifier.of(metalakeName, catalogName, schemaName, tableName);
+    Distribution distribution = Distribution.NONE;
+
+    final SortOrder[] sortOrders =
+        new SortOrder[] {
+          SortOrder.builder()
+              .withNullOrdering(NullOrdering.FIRST)
+              .withDirection(Direction.DESC)
+              .withTransform(Transforms.field(new String[] {ICEBERG_COL_NAME2}))
+              .build()
+        };
+
+    Transform[] partitioning =
+        new Transform[] {
+          day(new String[] {columns[1].name()}),
+        };
+
+    Map<String, String> properties = createProperties();
+    TableCatalog tableCatalog = catalog.asTableCatalog();
+    Table createdTable =
+        tableCatalog.createTable(
+            tableIdentifier,
+            columns,
+            table_comment,
+            properties,
+            partitioning,
+            distribution,
+            sortOrders);
+    Assertions.assertEquals(createdTable.name(), tableName);
+    Map<String, String> resultProp = createdTable.properties();
+    for (Map.Entry<String, String> entry : properties.entrySet()) {
+      Assertions.assertTrue(resultProp.containsKey(entry.getKey()));
+      Assertions.assertEquals(entry.getValue(), resultProp.get(entry.getKey()));
+    }
+    Assertions.assertEquals(createdTable.columns().length, columns.length);
+
+    for (int i = 0; i < columns.length; i++) {
+      Assertions.assertEquals(createdTable.columns()[i], columns[i]);
+    }
+
+    // TODO add partitioning and sort order check
+    Assertions.assertEquals(partitioning.length, createdTable.partitioning().length);
+    Assertions.assertEquals(sortOrders.length, createdTable.sortOrder().length);
+
+    Table loadTable = tableCatalog.loadTable(tableIdentifier);
+    Assertions.assertEquals(tableName, loadTable.name());
+    Assertions.assertEquals(table_comment, loadTable.comment());
+    resultProp = loadTable.properties();
+    for (Map.Entry<String, String> entry : properties.entrySet()) {
+      Assertions.assertTrue(resultProp.containsKey(entry.getKey()));
+      Assertions.assertEquals(entry.getValue(), resultProp.get(entry.getKey()));
+    }
+    Assertions.assertEquals(loadTable.columns().length, columns.length);
+    for (int i = 0; i < columns.length; i++) {
+      Assertions.assertEquals(columns[i], loadTable.columns()[i]);
+    }
+
+    Assertions.assertEquals(partitioning.length, loadTable.partitioning().length);
+    Assertions.assertEquals(sortOrders.length, loadTable.sortOrder().length);
+
+    // catalog load check
+    org.apache.iceberg.Table table =
+        hiveCatalog.loadTable(IcebergTableOpsHelper.buildIcebergTableIdentifier(tableIdentifier));
+    Assertions.assertEquals(tableName, table.name().substring(table.name().lastIndexOf(".") + 1));
+    Assertions.assertEquals(
+        table_comment, table.properties().get(IcebergTable.ICEBERG_COMMENT_FIELD_NAME));
+    resultProp = table.properties();
+    for (Map.Entry<String, String> entry : properties.entrySet()) {
+      Assertions.assertTrue(resultProp.containsKey(entry.getKey()));
+      Assertions.assertEquals(entry.getValue(), resultProp.get(entry.getKey()));
+    }
+    org.apache.iceberg.Schema icebergSchema = table.schema();
+    Assertions.assertEquals(icebergSchema.columns().size(), columns.length);
+    for (int i = 0; i < columns.length; i++) {
+      Assertions.assertNotNull(icebergSchema.findField(columns[i].name()));
+    }
+    Assertions.assertEquals(partitioning.length, table.spec().fields().size());
+    Assertions.assertEquals(partitioning.length, table.sortOrder().fields().size());
+
+    Assertions.assertThrows(
+        TableAlreadyExistsException.class,
+        () ->
+            catalog
+                .asTableCatalog()
+                .createTable(
+                    tableIdentifier,
+                    columns,
+                    table_comment,
+                    properties,
+                    new Transform[0],
+                    distribution,
+                    sortOrders));
+  }
+
+  @Test
+  void testListAndDropIcebergTable() {
+    ColumnDTO[] columns = createColumns();
+
+    NameIdentifier table1 = NameIdentifier.of(metalakeName, catalogName, schemaName, "table_1");
+
+    Map<String, String> properties = createProperties();
+    TableCatalog tableCatalog = catalog.asTableCatalog();
+    tableCatalog.createTable(
+        table1,
+        columns,
+        table_comment,
+        properties,
+        new Transform[0],
+        Distribution.NONE,
+        new SortOrder[0]);
+    Namespace schemaNamespace = Namespace.of(metalakeName, catalogName, schemaName);
+    NameIdentifier[] nameIdentifiers =
+        tableCatalog.listTables(Namespace.of(metalakeName, catalogName, schemaName));
+    Assertions.assertEquals(1, nameIdentifiers.length);
+    Assertions.assertEquals("table_1", nameIdentifiers[0].name());
+
+    List<TableIdentifier> tableIdentifiers =
+        hiveCatalog.listTables(IcebergTableOpsHelper.getIcebergNamespace(schemaName));
+    Assertions.assertEquals(1, tableIdentifiers.size());
+    Assertions.assertEquals("table_1", tableIdentifiers.get(0).name());
+
+    NameIdentifier table2 = NameIdentifier.of(metalakeName, catalogName, schemaName, "table_2");
+    tableCatalog.createTable(
+        table2,
+        columns,
+        table_comment,
+        properties,
+        new Transform[0],
+        Distribution.NONE,
+        new SortOrder[0]);
+    nameIdentifiers = tableCatalog.listTables(Namespace.of(metalakeName, catalogName, schemaName));
+    Assertions.assertEquals(2, nameIdentifiers.length);
+    Assertions.assertEquals("table_1", nameIdentifiers[0].name());
+    Assertions.assertEquals("table_2", nameIdentifiers[1].name());
+
+    tableIdentifiers =
+        hiveCatalog.listTables(IcebergTableOpsHelper.getIcebergNamespace(schemaName));
+    Assertions.assertEquals(2, tableIdentifiers.size());
+    Assertions.assertEquals("table_1", tableIdentifiers.get(0).name());
+    Assertions.assertEquals("table_2", tableIdentifiers.get(1).name());
+
+    Assertions.assertDoesNotThrow(() -> tableCatalog.dropTable(table1));
+
+    nameIdentifiers = tableCatalog.listTables(Namespace.of(metalakeName, catalogName, schemaName));
+    Assertions.assertEquals(1, nameIdentifiers.length);
+    Assertions.assertEquals("table_2", nameIdentifiers[0].name());
+
+    Assertions.assertDoesNotThrow(() -> tableCatalog.dropTable(table2));
+    schemaNamespace = Namespace.of(metalakeName, catalogName, schemaName);
+    nameIdentifiers = tableCatalog.listTables(schemaNamespace);
+    Assertions.assertEquals(0, nameIdentifiers.length);
+
+    tableIdentifiers =
+        hiveCatalog.listTables(IcebergTableOpsHelper.getIcebergNamespace(schemaName));
+    Assertions.assertEquals(0, tableIdentifiers.size());
+  }
+
+  @Test
+  public void testAlterIcebergTable() throws TException, InterruptedException {
+    ColumnDTO[] columns = createColumns();
+    catalog
+        .asTableCatalog()
+        .createTable(
+            NameIdentifier.of(metalakeName, catalogName, schemaName, tableName),
+            columns,
+            table_comment,
+            createProperties(),
+            new Transform[] {identity(columns[0])});
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          catalog
+              .asTableCatalog()
+              .alterTable(
+                  NameIdentifier.of(metalakeName, catalogName, schemaName, tableName),
+                  TableChange.rename(alertTableName),
+                  TableChange.updateComment(table_comment + "_new"));
+        });
+
+    catalog
+        .asTableCatalog()
+        .alterTable(
+            NameIdentifier.of(metalakeName, catalogName, schemaName, tableName),
+            TableChange.rename(alertTableName));
+
+    catalog
+        .asTableCatalog()
+        .alterTable(
+            NameIdentifier.of(metalakeName, catalogName, schemaName, alertTableName),
+            TableChange.updateComment(table_comment + "_new"),
+            TableChange.removeProperty("key1"),
+            TableChange.setProperty("key2", "val2_new"),
+            TableChange.addColumn(new String[] {"col_4"}, TypeCreator.NULLABLE.STRING),
+            TableChange.renameColumn(new String[] {ICEBERG_COL_NAME2}, "col_2_new"),
+            TableChange.updateColumnComment(new String[] {ICEBERG_COL_NAME1}, "comment_new"),
+            TableChange.updateColumnType(
+                new String[] {ICEBERG_COL_NAME1}, TypeCreator.NULLABLE.I32));
+
+    Table table =
+        catalog
+            .asTableCatalog()
+            .loadTable(NameIdentifier.of(metalakeName, catalogName, schemaName, alertTableName));
+    Assertions.assertEquals(alertTableName, table.name());
+    Assertions.assertEquals("val2_new", table.properties().get("key2"));
+
+    Assertions.assertEquals(ICEBERG_COL_NAME1, table.columns()[0].name());
+    Assertions.assertEquals(TypeCreator.NULLABLE.I32, table.columns()[0].dataType());
+    Assertions.assertEquals("comment_new", table.columns()[0].comment());
+
+    Assertions.assertEquals("col_2_new", table.columns()[1].name());
+    Assertions.assertEquals(TypeCreator.NULLABLE.DATE, table.columns()[1].dataType());
+    Assertions.assertEquals("col_2_comment", table.columns()[1].comment());
+
+    Assertions.assertEquals(ICEBERG_COL_NAME3, table.columns()[2].name());
+    Assertions.assertEquals(TypeCreator.NULLABLE.STRING, table.columns()[2].dataType());
+    Assertions.assertEquals("col_3_comment", table.columns()[2].comment());
+
+    Assertions.assertEquals("col_4", table.columns()[3].name());
+    Assertions.assertEquals(TypeCreator.NULLABLE.STRING, table.columns()[3].dataType());
+    Assertions.assertNull(table.columns()[3].comment());
+
+    Assertions.assertEquals(1, table.partitioning().length);
+    Assertions.assertEquals(
+        columns[0].name(), ((Transforms.NamedReference) table.partitioning()[0]).value()[0]);
+
+    ColumnDTO col1 =
+        new ColumnDTO.Builder()
+            .withName("name")
+            .withDataType(TypeCreator.NULLABLE.STRING)
+            .withComment("comment")
+            .build();
+    ColumnDTO col2 =
+        new ColumnDTO.Builder()
+            .withName("address")
+            .withDataType(TypeCreator.NULLABLE.STRING)
+            .withComment("comment")
+            .build();
+    ColumnDTO col3 =
+        new ColumnDTO.Builder()
+            .withName("date_of_birth")
+            .withDataType(TypeCreator.NULLABLE.DATE)
+            .withComment("comment")
+            .build();
+    ColumnDTO[] newColumns = new ColumnDTO[] {col1, col2, col3};
+    NameIdentifier tableIdentifier =
+        NameIdentifier.of(
+            metalakeName,
+            catalogName,
+            schemaName,
+            GravitonITUtils.genRandomName("CatalogHiveIT_table"));
+    catalog
+        .asTableCatalog()
+        .createTable(
+            tableIdentifier,
+            newColumns,
+            table_comment,
+            ImmutableMap.of(),
+            new Transform[0],
+            Distribution.NONE,
+            new SortOrder[0]);
+
+    IllegalArgumentException illegalArgumentException =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                catalog
+                    .asTableCatalog()
+                    .alterTable(
+                        tableIdentifier,
+                        TableChange.updateColumnPosition(
+                            new String[] {"no_column"}, TableChange.ColumnPosition.first())));
+    Assertions.assertTrue(illegalArgumentException.getMessage().contains("no_column"));
+
+    catalog
+        .asTableCatalog()
+        .alterTable(
+            tableIdentifier,
+            TableChange.updateColumnPosition(
+                new String[] {col1.name()}, TableChange.ColumnPosition.after(col2.name())));
+
+    Table updateColumnPositionTable = catalog.asTableCatalog().loadTable(tableIdentifier);
+
+    Column[] updateCols = updateColumnPositionTable.columns();
+    Assertions.assertEquals(3, updateCols.length);
+    Assertions.assertEquals(col2.name(), updateCols[0].name());
+    Assertions.assertEquals(col1.name(), updateCols[1].name());
+    Assertions.assertEquals(col3.name(), updateCols[2].name());
+
+    Assertions.assertDoesNotThrow(
+        () ->
+            catalog
+                .asTableCatalog()
+                .alterTable(
+                    tableIdentifier,
+                    TableChange.deleteColumn(new String[] {col3.name()}, true),
+                    TableChange.deleteColumn(new String[] {col2.name()}, true)));
+    Table delColTable = catalog.asTableCatalog().loadTable(tableIdentifier);
+    Assertions.assertEquals(1, delColTable.columns().length);
+    Assertions.assertEquals(col1.name(), delColTable.columns()[0].name());
+  }
+}


### PR DESCRIPTION
What changes were proposed in this pull request?
Integrate testing using Graviton Server, used jdbcCatalog for end-to-end validation.

Why are the changes needed?

Issues: #483 

Does this PR introduce any user-facing change?
No

How was this patch tested?
CatalogIcebergIT