### PR TITLE
[#490]refactor(hive): Hive table properties follow property name convention

### DIFF
--- a/catalogs/catalog-hive/src/main/java/com/datastrato/graviton/catalog/hive/HiveTablePropertiesMetadata.java
+++ b/catalogs/catalog-hive/src/main/java/com/datastrato/graviton/catalog/hive/HiveTablePropertiesMetadata.java
@@ -28,11 +28,11 @@ public class HiveTablePropertiesMetadata extends BasePropertiesMetadata {
   public static final String EXTERNAL = "EXTERNAL";
   public static final String LOCATION = "location";
   public static final String FORMAT = "format";
-  public static final String TABLE_TYPE = "tableType";
-  public static final String INPUT_FORMAT = "inputFormat";
-  public static final String OUTPUT_FORMAT = "outputFormat";
-  public static final String SERDE_NAME = "serdeName";
-  public static final String SERDE_LIB = "serdeLib";
+  public static final String TABLE_TYPE = "table-type";
+  public static final String INPUT_FORMAT = "input-format";
+  public static final String OUTPUT_FORMAT = "output-format";
+  public static final String SERDE_NAME = "serde-name";
+  public static final String SERDE_LIB = "serde-lib";
   public static final String SERDE_PARAMETER_PREFIX = "serde.parameter.";
   public static final String TRANSIENT_LAST_DDL_TIME = "transient_lastDdlTime";
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Rename some Hive table properties' name to follow the property name convention

### Why are the changes needed?
Follow the unified standard for Graviton property

Fix: #490 

### Does this PR introduce _any_ user-facing change?
Yes, some names of Hive table properties changed

### How was this patch tested?
Existing UTs
