### PR TITLE
[#503] fix(IT): Fix integrate test error logs are not shown issue

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -92,8 +92,8 @@ jobs:
       - name: Print logs when Graviton integration tests failure
         if: ${{ failure() && steps.integrationTest.outcome == 'failure' }}
         run: |
-          if [ -f "integration-test/build/graviton-server.log" ]; then
-            cat integration-test/build/graviton-server.log
+          if [ -f "integration-test/build/integration-test.log" ]; then
+            cat integration-test/build/integration-test.log
           fi
           if [ -f "distribution/package/logs/graviton-server.out" ]; then
             cat distribution/package/logs/graviton-server.out


### PR DESCRIPTION
### What changes were proposed in this pull request?
logs are located  at `integration-test/build/integration-test.log`, while github cat logs from `integration-test/build/graviton-server.log`

### Why are the changes needed?

Fix: #503 

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
