### PR TITLE
[#462] fix(hive): validate non-null column type in Hive catalog

### DIFF
--- a/catalogs/catalog-hive/src/test/java/com/datastrato/graviton/catalog/hive/TestHiveTable.java
+++ b/catalogs/catalog-hive/src/test/java/com/datastrato/graviton/catalog/hive/TestHiveTable.java
@@ -215,7 +215,8 @@ public class TestHiveTable extends MiniHiveMetastoreService {
         exception
             .getMessage()
             .contains(
-                "The NOT NULL constraint for column is supported since Hive3.0, but the current catalog only supports Hive2.x"));
+                "The NOT NULL constraint for column is only supported since Hive 3.0, "
+                    + "but the current Graviton Hive catalog only supports Hive 2.x"));
   }
 
   @Test
@@ -448,10 +449,12 @@ public class TestHiveTable extends MiniHiveMetastoreService {
                     .alterTable(
                         tableIdentifier,
                         TableChange.addColumn(new String[] {"col_1"}, TypeCreator.REQUIRED.I8)));
-    Assertions.assertEquals(
-        exception.getMessage(),
-        "The NOT NULL constraint for column is supported since Hive3.0, "
-            + "but the current catalog only supports Hive2.x");
+    Assertions.assertTrue(
+        exception
+            .getMessage()
+            .contains(
+                "The NOT NULL constraint for column is only supported since Hive 3.0, "
+                    + "but the current Graviton Hive catalog only supports Hive 2.x"));
 
     exception =
         Assertions.assertThrows(
@@ -463,10 +466,12 @@ public class TestHiveTable extends MiniHiveMetastoreService {
                         tableIdentifier,
                         TableChange.updateColumnType(
                             new String[] {"col_1"}, TypeCreator.REQUIRED.I8)));
-    Assertions.assertEquals(
-        exception.getMessage(),
-        "The NOT NULL constraint for column is supported since Hive3.0, "
-            + "but the current catalog only supports Hive2.x");
+    Assertions.assertTrue(
+        exception
+            .getMessage()
+            .contains(
+                "The NOT NULL constraint for column is only supported since Hive 3.0, "
+                    + "but the current Graviton Hive catalog only supports Hive 2.x"));
 
     // test alter
     hiveCatalog


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?
Throw an exception when encountering a non-nullable column type in Hive catalog

### Why are the changes needed?
Currently, we only support Hive 2.x for Hive catalog, but 'NOT NULL' column constraint was supported since Hive3.0

Fix: #462 

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
UTs added
