### PR TITLE
[#534] fix(build): Fix compile distribution error

### DIFF
--- a/catalogs/catalog-hive/build.gradle.kts
+++ b/catalogs/catalog-hive/build.gradle.kts
@@ -86,7 +86,7 @@ tasks {
     }
 
     val copyCatalogLibs by registering(Copy::class) {
-        dependsOn(copyDepends)
+        dependsOn(copyDepends, "build")
         from("build/libs")
         into("${rootDir}/distribution/package/catalogs/hive/libs")
     }

--- a/catalogs/catalog-lakehouse-iceberg/build.gradle.kts
+++ b/catalogs/catalog-lakehouse-iceberg/build.gradle.kts
@@ -87,7 +87,7 @@ tasks {
         into("build/libs")
     }
     val copyCatalogLibs by registering(Copy::class) {
-        dependsOn(copyDepends)
+        dependsOn(copyDepends, "build")
         from("build/libs")
         into("${rootDir}/distribution/package/catalogs/lakehouse-iceberg/libs")
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds "build" dependency to "copyCatalogLibs" task, so build will be triggered before copy the lib jars.

### Why are the changes needed?

Without this fix, directly run "gradle compileDistribution" and "gradle compileDistribution" will get an incomplete package, which will lead to sever start error.

Fix: #534 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual test.
