### PR TITLE
[#555] improvement(hive): Improve error message about altering an unknown table

### DIFF
--- a/catalogs/catalog-hive/src/main/java/com/datastrato/gravitino/catalog/hive/HiveCatalogOperations.java
+++ b/catalogs/catalog-hive/src/main/java/com/datastrato/gravitino/catalog/hive/HiveCatalogOperations.java
@@ -611,9 +611,6 @@ public class HiveCatalogOperations implements CatalogOperations, SupportsSchemas
       LOG.info("Altered Hive table {} in Hive Metastore", tableIdent.name());
       return HiveTable.fromHiveTable(alteredHiveTable);
 
-    } catch (NoSuchObjectException e) {
-      throw new NoSuchTableException(
-          String.format("Hive table does not exist: %s in Hive Metastore", tableIdent.name()), e);
     } catch (TException | InterruptedException e) {
       if (e.getMessage().contains("types incompatible with the existing columns")) {
         throw new IllegalArgumentException(
@@ -627,7 +624,7 @@ public class HiveCatalogOperations implements CatalogOperations, SupportsSchemas
       }
       throw new RuntimeException(
           "Failed to alter Hive table " + tableIdent.name() + " in Hive metastore", e);
-    } catch (IllegalArgumentException e) {
+    } catch (IllegalArgumentException | NoSuchTableException e) {
       throw e;
     } catch (Exception e) {
       throw new RuntimeException(e);

--- a/core/src/main/java/com/datastrato/gravitino/catalog/CatalogOperationDispatcher.java
+++ b/core/src/main/java/com/datastrato/gravitino/catalog/CatalogOperationDispatcher.java
@@ -607,6 +607,9 @@ public class CatalogOperationDispatcher implements TableCatalog, SupportsSchemas
       } else if (ex2.isInstance(throwable)) {
         throw ex2.cast(throwable);
       }
+      if (RuntimeException.class.isAssignableFrom(throwable.getClass())) {
+        throw (RuntimeException) throwable;
+      }
 
       throw new RuntimeException(throwable);
     }

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/hive/CatalogHiveIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/hive/CatalogHiveIT.java
@@ -30,6 +30,7 @@ import com.datastrato.gravitino.catalog.hive.HiveClientPool;
 import com.datastrato.gravitino.catalog.hive.HiveTablePropertiesMetadata;
 import com.datastrato.gravitino.client.GravitinoMetaLake;
 import com.datastrato.gravitino.dto.rel.ColumnDTO;
+import com.datastrato.gravitino.exceptions.NoSuchTableException;
 import com.datastrato.gravitino.integration.test.util.AbstractIT;
 import com.datastrato.gravitino.integration.test.util.GravitinoITUtils;
 import com.datastrato.gravitino.rel.Distribution;
@@ -493,6 +494,16 @@ public class CatalogHiveIT extends AbstractIT {
     List<String> hivePartitionKeys =
         hiveTab.getPartitionKeys().stream().map(FieldSchema::getName).collect(Collectors.toList());
     Assertions.assertEquals(partitionKeys, hivePartitionKeys);
+  }
+
+  @Test
+  void testAlterUnknownTable() {
+    NameIdentifier identifier = NameIdentifier.of(metalakeName, catalogName, schemaName, "unknown");
+    Assertions.assertThrows(
+        NoSuchTableException.class,
+        () -> {
+          catalog.asTableCatalog().alterTable(identifier, TableChange.updateComment("new_comment"));
+        });
   }
 
   @Test


### PR DESCRIPTION
### What changes were proposed in this pull request?

Change the exception class from `RuntimeException` to `NoSuchTableException` when altering an unknown table.

### Why are the changes needed?

Improving error messages to be more accurate and readable.

Fix: #555 

### Does this PR introduce _any_ user-facing change?

NO

### How was this patch tested?

Add test int IT.
