### PR TITLE
[#567] enable debug log temporary to get more infomation about IcebergRESTJdbcCatalogIT failures

### DIFF
--- a/conf/log4j2.properties.template
+++ b/conf/log4j2.properties.template
@@ -33,5 +33,5 @@ appender.rolling.strategy.delete.ifLastModified.type = IfLastModified
 appender.rolling.strategy.delete.ifLastModified.age = 30d
 
 # Configure root logger
-rootLogger.level = info
+rootLogger.level = debug 
 rootLogger.appenderRef.rolling.ref = fileLogger

--- a/integration-test/src/test/resources/log4j2.properties
+++ b/integration-test/src/test/resources/log4j2.properties
@@ -26,7 +26,7 @@ appender.file.layout.type = PatternLayout
 appender.file.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
 
 # Root logger level
-rootLogger.level = info
+rootLogger.level = debug
 
 # Root logger referring to console and file appenders
 rootLogger.appenderRef.stdout.ref = consoleLogger


### PR DESCRIPTION
### What changes were proposed in this pull request?
enable debug log

### Why are the changes needed?
[IcebergRESTJdbcCatalogIT may failed](https://github.com/datastrato/gravitino/issues/546#top) , it's hard to reproduce.
we could get the information from the corresponding logs:
Iceberg REST client tries to post the data to Gravitino, and there is no response.
From the logs from Gravitino, the server side doesn't receive the data.  we couldn't distinguish the problem is server side or client side，if enable the debug log, we could get more information.



Fix: #567 

### Does this PR introduce _any_ user-facing change?
more logs are produced.

### How was this patch tested?
