### PR TITLE
[MINOR] feat(CI): Support automatically cherry-pick to 0.2 and 0.3 branch

### DIFF
--- a/.github/workflows/auto-cherry-pick.yml
+++ b/.github/workflows/auto-cherry-pick.yml
@@ -24,5 +24,39 @@ jobs:
             cherry-pick
           reviewers: |
             jerryshao
+  cherry_pick_branch_0_2:
+    runs-on: ubuntu-latest
+    name: Cherry pick into branch_0.2
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'branch-0.2') && github.event.pull_request.merged == true }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Cherry pick into branch-0.2
+        uses: carloscastrojumo/github-cherry-pick-action@v1.0.9
+        with:
+          branch: branch-0.2
+          labels: |
+            cherry-pick
+          reviewers: |
+            jerryshao
+  cherry_pick_branch_0_3:
+    runs-on: ubuntu-latest
+    name: Cherry pick into branch_0.3
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'branch-0.3') && github.event.pull_request.merged == true }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Cherry pick into branch-0.3
+        uses: carloscastrojumo/github-cherry-pick-action@v1.0.9
+        with:
+          branch: branch-0.3
+          labels: |
+            cherry-pick
+          reviewers: |
+            jerryshao
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### What changes were proposed in this pull request?

This minor fix add support to automatically cherry-pick merged PR to branch 0.2 and 0.3.

### Why are the changes needed?

With this Github Action will automatically cherry pick merged PRs to branch 0.2 and 0.3


### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

NA.