### PR TITLE
[#586] fix(trino-connector): Fix retrieve system tables  does not work issue

### DIFF
--- a/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/DummyGravitinoConnector.java
+++ b/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/DummyGravitinoConnector.java
@@ -5,6 +5,12 @@
 package com.datastrato.gravitino.trino.connector;
 
 import io.trino.spi.connector.Connector;
+import io.trino.spi.connector.ConnectorMetadata;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.ConnectorTransactionHandle;
+import io.trino.spi.transaction.IsolationLevel;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * DummyGravitinoConnector is primarily used to drive the GravitinoCatalogManager to load catalog
@@ -16,5 +22,22 @@ public class DummyGravitinoConnector implements Connector {
 
   public DummyGravitinoConnector() {
     super();
+  }
+
+  @Override
+  public ConnectorTransactionHandle beginTransaction(
+      IsolationLevel isolationLevel, boolean readOnly, boolean autoCommit) {
+    return new ConnectorTransactionHandle() {};
+  }
+
+  @Override
+  public ConnectorMetadata getMetadata(
+      ConnectorSession session, ConnectorTransactionHandle transactionHandle) {
+    return new ConnectorMetadata() {
+      @Override
+      public List<String> listSchemaNames(ConnectorSession session) {
+        return Collections.emptyList();
+      }
+    };
   }
 }

--- a/trino-connector/src/test/java/com/datastrato/gravitino/trino/connector/TestGravitinoConnector.java
+++ b/trino-connector/src/test/java/com/datastrato/gravitino/trino/connector/TestGravitinoConnector.java
@@ -34,7 +34,7 @@ import org.slf4j.LoggerFactory;
 import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
 
-@Parameters({"-Xmx1G"})
+@Parameters({"-Xmx2G"})
 public class TestGravitinoConnector extends AbstractTestQueryFramework {
 
   private static final Logger LOG = LoggerFactory.getLogger(TestGravitinoConnector.class);
@@ -79,6 +79,8 @@ public class TestGravitinoConnector extends AbstractTestQueryFramework {
     // testing the catalogs
     assertThat(computeActual("show catalogs").getOnlyColumnAsSet()).contains("gravitino");
     assertThat(computeActual("show catalogs").getOnlyColumnAsSet()).contains(catalogName);
+
+    assertThat(computeActual("select * from system.jdbc.tables"));
 
     String schemaName = "db_01";
     String fullSchemaName = String.format("\"%s\".%s", catalogName, schemaName);


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

The Trino connector is causing issues with the Trino JDBC client's inability to retrieve system tables.

### Why are the changes needed?

The reason is that DumyGravitonConnector does not override listSchemaNames, so it returns null, causing the problem.

Fix: #586 

### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

UT
