### PR TITLE
[#434] feat(CI): Gravitino CI testing Trino Docker

### DIFF
--- a/dev/docker/hive/start.sh
+++ b/dev/docker/hive/start.sh
@@ -19,13 +19,13 @@ echo -e "$new_content" > /etc/hosts
 ${HADOOP_HOME}/sbin/start-all.sh
 
 ${HADOOP_HOME}/bin/hdfs dfs -mkdir /tmp
-${HADOOP_HOME}/bin/hdfs dfs -chmod 777 /tmp
+${HADOOP_HOME}/bin/hdfs dfs -chmod 1777 /tmp
 ${HADOOP_HOME}/bin/hdfs dfs -mkdir -p /user/hive/warehouse
-${HADOOP_HOME}/bin/hdfs dfs -chown -R hive:hive /user/hive/warehouse
-${HADOOP_HOME}/bin/hdfs dfs -chmod -R 775 /user/hive/warehouse
-#${HADOOP_HOME}/bin/hdfs dfs -mkdir -p /user/datastrato
-#${HADOOP_HOME}/bin/hdfs dfs -chown -R datastrato:hdfs /user/datastrato
-#${HADOOP_HOME}/bin/hdfs dfs -chmod 755 /user/datastrato
+${HADOOP_HOME}/bin/hdfs dfs -chown -R hive:hive /user/hive
+${HADOOP_HOME}/bin/hdfs dfs -chmod -R 775 /user/hive
+${HADOOP_HOME}/bin/hdfs dfs -mkdir -p /user/datastrato
+${HADOOP_HOME}/bin/hdfs dfs -chown -R datastrato:hdfs /user/datastrato
+${HADOOP_HOME}/bin/hdfs dfs -chmod 755 /user/datastrato
 ${HADOOP_HOME}/bin/hdfs dfs -chmod -R 777 /user/hive/tmp
 
 # start mysql and create databases/users for hive


### PR DESCRIPTION
### What changes were proposed in this pull request?

1. Add HiveContainer
2. Add TrinoContainer
3. Use Trino JDBC to connect TrinoContainer execute create database, table, insert, select and join two tables.

### Why are the changes needed?

This Docker needs to connect Gravitino-ci-hive docker container environment
Through Trino operations in the hive
Supports CI testing in the local and GitHub Action.

Fix: #434 

### Does this PR introduce _any_ user-facing change?
N/A

### How was this patch tested?
Add TrinoConnectorIT in the Integration-test
