### PR TITLE
[#681] improvement(core):  Remove redundant lock operation in `KvNameMappingService`

### DIFF
--- a/api/src/main/java/com/datastrato/gravitino/rel/SchemaChange.java
+++ b/api/src/main/java/com/datastrato/gravitino/rel/SchemaChange.java
@@ -29,7 +29,7 @@ public interface SchemaChange {
    * SchemaChange class to set the property and value pairs for the schema.
    *
    * @param property The property name to set.
-   * @param value The value to set teh property to.
+   * @param value The value to set the property to.
    * @return The SchemaChange object.
    */
   static SchemaChange setProperty(String property, String value) {

--- a/clients/client-java/src/main/java/com/datastrato/gravitino/client/HTTPClient.java
+++ b/clients/client-java/src/main/java/com/datastrato/gravitino/client/HTTPClient.java
@@ -135,11 +135,11 @@ public class HTTPClient implements RESTClient {
   }
 
   /**
-   * Builds an error reponse based on the provided HTTP response.
+   * Builds an error response based on the provided HTTP response.
    *
    * <p>This method extracts the reason phrase from the response and uses it as the message for the
    * ErrorResponse. If the reason phrase doesn't exist, it retrieves the standard reason phrase from
-   * teh English phrase catalog.
+   * the English phrase catalog.
    *
    * @param response The response from which the ErrorResponse is built.
    * @return An ErrorResponse object representing the REST error response.

--- a/clients/client-java/src/main/java/com/datastrato/gravitino/client/RESTClient.java
+++ b/clients/client-java/src/main/java/com/datastrato/gravitino/client/RESTClient.java
@@ -351,7 +351,7 @@ public interface RESTClient extends Closeable {
       Consumer<ErrorResponse> errorHandler);
 
   /**
-   * Perform a POST request with form data on the specified path with teh given information.
+   * Perform a POST request with form data on the specified path with the given information.
    *
    * @param path The path to be requested.
    * @param formData The form data to be included in the POST request body.

--- a/common/src/main/java/com/datastrato/gravitino/dto/responses/CatalogResponse.java
+++ b/common/src/main/java/com/datastrato/gravitino/dto/responses/CatalogResponse.java
@@ -40,7 +40,7 @@ public class CatalogResponse extends BaseResponse {
   /**
    * Validates the response data.
    *
-   * @throws IllegalArgumentException if teh catalog name, type or audit is not set.
+   * @throws IllegalArgumentException if the catalog name, type or audit is not set.
    */
   @Override
   public void validate() throws IllegalArgumentException {

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -15,7 +15,7 @@ You can build from [Github](https://github.com/datastrato/gravitino), see [how t
 
 ## Where is the Documentation?
 
-Gravitino has a local documentation website that you can view by following teh instructions in ``README.md``.
+Gravitino has a local documentation website that you can view by following the instructions in ``README.md``.
 
 ## How to contribute to Gravitino?
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

1. Add `KvNameMappingService` related operation to lock block in `KvEntityStore`
2. Remove redundant lock operation in `KvNameMappingService`
3. Fix some typo. (teh -> the)

### Why are the changes needed?

Simplify the code logic, there seem to be too many lock-related operations in the storage module, so it's better to optimize it.

Fix: #681 

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Existing UTs