### PR TITLE
[#639] feat(CI): Improvement Docker management for integration test 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,16 +30,8 @@ jobs:
           java-version: '8'
           distribution: 'temurin'
 
-      - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
-        with:
-          gradle-version: '8.2'
-
-      - name: Show gradle version
-        run: gradle --version
-
       - name: Build with Gradle
-        run: gradle build -PskipITs
+        run: ./gradlew build -PskipITs
 
       - name: Upload unit tests report
         uses: actions/upload-artifact@v3

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -8,10 +8,6 @@ on:
   pull_request:
     branches: [ "main", "branch-*" ]
 
-env:
-  HIVE_IMAGE_NAME: datastrato/gravitino-ci-hive
-  HIVE_IMAGE_TAG_NAME: 0.1.4
-
 concurrency:
   group: ${{ github.worklfow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_requests' }}
@@ -38,46 +34,10 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-
-      - name: Build the hive Docker image for AMD64
-        if: ${{ contains(github.event.pull_request.labels.*.name, 'build docker image') }}
-        run: ./dev/docker/hive/build-docker.sh --platform ${PLATFORM} --image ${HIVE_IMAGE_NAME}:${HIVE_IMAGE_TAG_NAME}
-
-      - name: Run AMD64 container
-        run: |
-          docker run --rm --name ${DOCKER_RUN_NAME} --platform ${PLATFORM} -d -p 9000:9000 -p 9083:9083 -p 10000:10000 -p 10002:10002 -p 50010:50010 -p 50070:50070 -p 50075:50075 ${HIVE_IMAGE_NAME}:${HIVE_IMAGE_TAG_NAME}
-          docker ps -a
-
-      - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
-        with:
-          gradle-version: '8.2'
-
-      - name: Show gradle version
-        run: gradle --version
-
       - name: Package Gravitino
         run: |
-          gradle build -x test
-          gradle compileDistribution -x test
-
-      - name: Check docker container status
-        uses: nick-fields/retry@v2
-        with:
-          max_attempts: 3
-          timeout_seconds: 200
-          continue_on_error: false
-          command: |
-            docker exec -i ${DOCKER_RUN_NAME} bash /tmp/check-status.sh
-          on_retry_command: |
-            docker ps -a
-            docker stop ${DOCKER_RUN_NAME}
-            sleep 3
-            docker ps -a
-            docker run --rm --name ${DOCKER_RUN_NAME} --platform ${PLATFORM} -d -p 8022:22 -p 8088:8088 -p 9000:9000 -p 9083:9083 -p 10000:10000 -p 10002:10002 -p 50010:50010 -p 50070:50070 -p 50075:50075 ${HIVE_IMAGE_NAME}:${HIVE_IMAGE_TAG_NAME}
-            sleep 60
+          ./gradlew build -x test
+          ./gradlew compileDistribution -x test
 
       - name: Setup debug Github Action
         if: ${{ contains(github.event.pull_request.labels.*.name, 'debug action') }}
@@ -86,8 +46,8 @@ jobs:
       - name: Integration Test
         id: integrationTest
         run: |
-          gradle test --rerun-tasks -PskipTests -PtestMode=embedded
-          gradle test --rerun-tasks -PskipTests -PtestMode=deploy
+          ./gradlew test --rerun-tasks -PskipTests -PtestMode=embedded
+          ./gradlew test --rerun-tasks -PskipTests -PtestMode=deploy
 
       - name: Upload integrate tests reports
         uses: actions/upload-artifact@v3
@@ -99,10 +59,3 @@ jobs:
             integration-test/build/integration-test.log
             distribution/package/logs/gravitino-server.out
             distribution/package/logs/gravitino-server.log
-
-      - name: Stop and remove container
-        run: |
-          docker stop ${DOCKER_RUN_NAME}
-          sleep 3
-          docker ps -a
-          docker rmi ${HIVE_IMAGE_NAME}:${HIVE_IMAGE_TAG_NAME}

--- a/docs/integration-test.md
+++ b/docs/integration-test.md
@@ -46,56 +46,45 @@ The Gravitino server can be deployed locally to run the integration tests. Follo
 Some integration test cases depend on the Gravitino CI Docker environment.
 
 If an integration test relies on the specific Gravitino CI Docker environment,
-you need to set the `@tag(CI-DOCKER-NAME)` annotation in the test class.
+you need to set the `@tag(gravitino-docker-it)` annotation in the test class.
 For example, the `integration-test/src/test/.../CatalogHiveIT.java` test needs to connect to
 the `datastrato/gravitino-ci-hive` Docker container for testing the Hive data source.
-Therefore, it should have the following `@tag` annotation:`@tag(CI-DOCKER-NAME)`, This annotation
+Therefore, it should have the following `@tag` annotation:`@tag(gravitino-docker-it)`, This annotation
 helps identify the specific Docker container required for the integration test.
 For example:
 
 ```java
-@Tag("gravitino-ci-hive")
+@Tag("gravitino-docker-it")
 public class CatalogHiveIT extends AbstractIT {
 ...
 }
 ```
 
-If you have Docker installed and a special CI Docker container running, the `./gradlew test -PtestMode=[embedded|deploy]`
+### Running all integration tests
+If you're running `Docker server` and `mac-docker-connector` (only macOS need to run `mac-docker-connector`), the `./gradlew test -PtestMode=[embedded|deploy]`
 command will automatically execute all the test cases.
 
 ```text
 ------------------- Check Docker environment --------------------
 Docker server status ............................................ [running]
-Gravitino IT Docker container is already running ................ [yes]
-Using Gravitino IT Docker container to run all integration tests. [embbeded|deploy test]
+mac-docker-connector server status .............................. [running]
+Using Gravitino IT Docker container to run all integration tests. [embedded test]
 -----------------------------------------------------------------
 ```
 
-If Docker is not installed or the special CI Docker container is not running, the `./gradlew test -PtestMode=[embedded|deploy]`
-command will skip the test cases that depend on the special Docker environment.
+### Docker server or mac-docker-connector not running
+If `Docker server` or `mac-docker-connector` is not running (only required to run in macOS), the `./gradlew test -PtestMode=[embedded|deploy]`
+command will run test cases without `gravitino-docker-it` tag.
 
 ```text
 ------------------- Check Docker environment ------------------
-Docker server status .......................................... [running]
-Gravitino IT Docker container is already running .............. [no]
-Run only test cases where a tag is set `gravitino-docker-it`.   [embbeded|deploy test]
+Docker server status ............................................ [stop]
+mac-docker-connector server status .............................. [stop]
+Run test cases without `gravitino-docker-it` tag ................ [embedded test]
 ---------------------------------------------------------------
+Tip: Please make sure to start the `Docker server before` running the integration tests.
+Tip: Please make sure to execute the `dev/docker/tools/mac-docker-connector.sh` script before running the integration test in MacOS.
 ```
-
-> Gravitino will run all integration test cases in the GitHub Actions environment.
-
-### Running Gravitino CI Docker Environment
-
-Before running the tests, make sure Docker is installed.
-
-#### Running Gravitino Hive CI Docker Environment
-
-1. Run a hive docker test environment container locally using the `docker run --rm -d -p 9000:9000 -p 9083:9083 -p 10000:10000 -p 10002:10002 -p 50010:50010 -p 50070:50070 -p 50075:50075 datastrato/gravitino-ci-hive:0.1.4` command.
-
-The Gravitino server and Docker runtime environments will also use certain ports. Ensure that these ports are not already in use:
-
-- Gravitino server: Port `8090`
-- Hive Docker runtime environment: Ports are `9000`, `9083`, `10000`, `10002`, `50010`, `50070`, and `50075`
 
 ## Debugging Gravitino Server and Integration Tests
 
@@ -127,15 +116,11 @@ You have two modes to debug the Gravitino server and integration tests: `embedde
 - Test results can be viewed in the `Actions` tab of the pull request page.
 - The integration tests are executed in several steps:
 
-  - If you set the `build docker image` label in the pull request, GitHub Actions will trigger the build of all Docker
-    images under the `./dev/docker/` directory. This step usually takes around 10 minutes. If you have changed the Dockerfile,
-    you need to set the `build docker image` label in the pull request.
-  - Otherwise, GitHub Actions will pull the Docker image `datastrato/gravitino-ci-hive` from the Docker Hub repository. This step usually takes around 15 seconds.
+  - Gravitino integration tests will pull the CI Docker image from the Docker Hub repository. This step usually takes around 15 seconds.
   - If you set the `debug action` label in the pull request, GitHub Actions will run an SSH server with
     `csexton/debugger-action@master`, allows you to log in to the Actions environment for remote debugging.
   - The Gravitino project is compiled and packaged in the `distribution` directory using the `./gradlew compileDistribution` command.
   - Execution the `./gradlew test -PtestMode=[embedded|deploy]` command.
-  - Stop the Docker image to clean up.
 
 ## Test Failure
 If a test fails, valuable information can be retrieved from the logs and test report. Test reports 

--- a/integration-test/build.gradle.kts
+++ b/integration-test/build.gradle.kts
@@ -2,9 +2,7 @@
  * Copyright 2023 Datastrato.
  * This software is licensed under the Apache License version 2.
  */
-
 import java.io.IOException
-import kotlin.io.*
 import org.gradle.internal.os.OperatingSystem
 
 plugins {
@@ -114,107 +112,95 @@ dependencies {
 
 /* Optimizing integration test execution conditions */
 // Use this variable to control if we need to run docker test or not.
-var HIVE_IMAGE_NAME = "datastrato/gravitino-ci-hive"
-var HIVE_IMAGE_TAG_NAME = "${HIVE_IMAGE_NAME}:0.1.2"
-var EXCLUDE_DOCKER_TEST = true
-var EXCLUDE_TRINO_TEST = true
-// Use these 3 variables allow for more detailed control in the future.
+var DOCKER_IT_TEST = false
 project.extra["dockerRunning"] = false
-project.extra["hiveContainerRunning"] = false
 project.extra["macDockerConnector"] = false
 
 fun printDockerCheckInfo() {
+  checkMacDockerConnector()
+  checkDockerStatus()
+
   val testMode = project.properties["testMode"] as? String ?: "embedded"
   if (testMode != "deploy" && testMode != "embedded") {
     return
   }
   val dockerRunning = project.extra["dockerRunning"] as? Boolean ?: false
-  val hiveContainerRunning = project.extra["hiveContainerRunning"] as? Boolean ?: false
   val macDockerConnector = project.extra["macDockerConnector"] as? Boolean ?: false
 
-  EXCLUDE_DOCKER_TEST = !(dockerRunning && hiveContainerRunning)
-  EXCLUDE_TRINO_TEST = if (OperatingSystem.current().isMacOsX) {
-    !(dockerRunning && macDockerConnector)
-  } else {
-    !dockerRunning
+  if (OperatingSystem.current().isMacOsX() && dockerRunning && macDockerConnector) {
+    DOCKER_IT_TEST = true
+  } else if (OperatingSystem.current().isLinux() && dockerRunning) {
+    DOCKER_IT_TEST = true
   }
 
   println("------------------ Check Docker environment ---------------------")
   println("Docker server status ............................................ [${if (dockerRunning) "running" else "stop"}]")
-  println("Gravitino IT Docker container is already running ................ [${if (hiveContainerRunning) "yes" else "no"}]")
-  if (EXCLUDE_TRINO_TEST) {
-    println("Run test cases without `gravitino-trino-it` tag ................. [$testMode test]")
+  if (OperatingSystem.current().isMacOsX()) {
+    println("mac-docker-connector server status .............................. [${if (macDockerConnector) "running" else "stop"}]")
   }
-  if (!EXCLUDE_DOCKER_TEST) {
-    println("Using Gravitino IT Docker container to run all integration tests. [$testMode test]")
-  } else {
+  if (!DOCKER_IT_TEST) {
     println("Run test cases without `gravitino-docker-it` tag ................ [$testMode test]")
+  } else {
+    println("Using Gravitino IT Docker container to run all integration tests. [$testMode test]")
   }
   println("-----------------------------------------------------------------")
+
+  // Print help message if Docker server or mac-docker-connector is not running
+  printDockerServerTip()
+  printMacDockerConnectorTip()
 }
 
-tasks {
-  register("isMacDockerConnectorRunning") {
-    doLast {
-      val processName = "docker-connector"
-      val command = "pgrep -x ${processName}"
+fun printDockerServerTip() {
+  val dockerRunning = project.extra["dockerRunning"] as? Boolean ?: false
+  if (!dockerRunning) {
+    val redColor = "\u001B[31m"
+    val resetColor = "\u001B[0m"
+    println("Tip: Please make sure to start the ${redColor}Docker server${resetColor} before running the integration tests.")
+  }
+}
 
-      try {
-        val execResult = project.exec {
-          commandLine("bash", "-c", command)
-        }
-        if (execResult.exitValue == 0) {
-          project.extra["macDockerConnector"] = true
-        } else {
-          project.extra["macDockerConnector"] = false
-        }
-      } catch (e: Exception) {
-        project.extra["macDockerConnector"] = false
-      }
-    }
+fun printMacDockerConnectorTip() {
+  val macDockerConnector = project.extra["macDockerConnector"] as? Boolean ?: false
+  if (OperatingSystem.current().isMacOsX() && !macDockerConnector) {
+    val redColor = "\u001B[31m"
+    val resetColor = "\u001B[0m"
+    println("Tip: Please make sure to execute the ${redColor}`dev/docker/tools/mac-docker-connector.sh`${resetColor} script before running the integration test in MacOS.")
+  }
+}
+
+fun checkMacDockerConnector() {
+  if (OperatingSystem.current().isLinux()) {
+    // Linux does not require the use of `docker-connector`
+    return
   }
 
-  // Use this task to check if docker container is running
-  register("checkContainerRunning") {
-    doLast {
-      try {
-        val process = ProcessBuilder("docker", "ps", "--format='{{.Image}}'").start()
-        val exitCode = process.waitFor()
+  try {
+    val processName = "docker-connector"
+    val command = "pgrep -x -q ${processName}"
 
-        if (exitCode == 0) {
-          val output = process.inputStream.bufferedReader().readText()
-          val haveHiveContainer = output.contains("${HIVE_IMAGE_NAME}")
-          if (haveHiveContainer) {
-            project.extra["hiveContainerRunning"] = true
-          }
-        } else {
-          println("checkContainerRunning command execution failed with exit code $exitCode")
-        }
-      } catch (e: IOException) {
-        println("checkContainerRunning command execution failed: ${e.message}")
-      }
+    val execResult = project.exec {
+      commandLine("bash", "-c", command)
     }
+    if (execResult.exitValue == 0) {
+      project.extra["macDockerConnector"] = true
+    }
+  } catch (e: Exception) {
+    println("checkContainerRunning command execution failed: ${e.message}")
   }
+}
 
-  // Use this task to check if docker is running
-  register("checkDockerRunning") {
-    dependsOn("checkContainerRunning", "isMacDockerConnectorRunning")
+fun checkDockerStatus() {
+  try {
+    val process = ProcessBuilder("docker", "info").start()
+    val exitCode = process.waitFor()
 
-    doLast {
-      try {
-        val process = ProcessBuilder("docker", "info").start()
-        val exitCode = process.waitFor()
-
-        if (exitCode == 0) {
-          project.extra["dockerRunning"] = true
-        } else {
-          println("checkDockerRunning Command execution failed with exit code $exitCode")
-        }
-      } catch (e: IOException) {
-        println("checkDockerRunning command execution failed: ${e.message}")
-      }
-      printDockerCheckInfo()
+    if (exitCode == 0) {
+      project.extra["dockerRunning"] = true
+    } else {
+      println("checkDockerStatus command execution failed with exit code $exitCode")
     }
+  } catch (e: IOException) {
+    println("checkDockerStatus command execution failed: ${e.message}")
   }
 }
 
@@ -223,9 +209,9 @@ tasks.test {
   if (skipITs) {
     exclude("**/integration/test/**")
   } else {
-    dependsOn("checkDockerRunning")
-
     doFirst {
+      printDockerCheckInfo()
+
       copy {
         from("${project.rootDir}/dev/docker/trino/conf")
         into("build/trino-conf")
@@ -259,17 +245,8 @@ tasks.test {
       }
 
       useJUnitPlatform {
-        if (EXCLUDE_DOCKER_TEST) {
-          val redColor = "\u001B[31m"
-          val resetColor = "\u001B[0m"
-          println("${redColor}Gravitino-docker is not running locally, all integration test cases tagged with 'gravitino-docker-it' will be excluded.${resetColor}")
+        if (!DOCKER_IT_TEST) {
           excludeTags("gravitino-docker-it")
-        }
-        if (EXCLUDE_TRINO_TEST) {
-          val redColor = "\u001B[31m"
-          val resetColor = "\u001B[0m"
-          println("${redColor}Gravitino-trino-docker is not running locally, all integration test cases tagged with 'gravitino-trino-it' will be excluded.${resetColor}")
-          excludeTags("gravitino-trino-it")
         }
       }
     }

--- a/integration-test/src/main/java/com/datastrato/gravitino/integration/test/MiniGravitino.java
+++ b/integration-test/src/main/java/com/datastrato/gravitino/integration/test/MiniGravitino.java
@@ -106,11 +106,11 @@ public class MiniGravitino {
     long beginTime = System.currentTimeMillis();
     boolean started = false;
     while (System.currentTimeMillis() - beginTime < 1000 * 60 * 3) {
-      Thread.sleep(500);
       started = checkIfServerIsRunning();
       if (started || future.isDone()) {
         break;
       }
+      Thread.sleep(500);
     }
     if (!started) {
       throw new RuntimeException("Can not start Gravitino server");

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/lakehouse/iceberg/CatalogIcebergIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/lakehouse/iceberg/CatalogIcebergIT.java
@@ -24,6 +24,8 @@ import com.datastrato.gravitino.dto.rel.partitions.Partitioning;
 import com.datastrato.gravitino.exceptions.NoSuchSchemaException;
 import com.datastrato.gravitino.exceptions.SchemaAlreadyExistsException;
 import com.datastrato.gravitino.exceptions.TableAlreadyExistsException;
+import com.datastrato.gravitino.integration.test.container.ContainerSuite;
+import com.datastrato.gravitino.integration.test.container.HiveContainer;
 import com.datastrato.gravitino.integration.test.util.AbstractIT;
 import com.datastrato.gravitino.integration.test.util.GravitinoITUtils;
 import com.datastrato.gravitino.rel.Column;
@@ -85,9 +87,10 @@ public class CatalogIcebergIT extends AbstractIT {
   public static String ICEBERG_COL_NAME2 = "iceberg_col_name2";
   public static String ICEBERG_COL_NAME3 = "iceberg_col_name3";
   private static final String provider = "lakehouse-iceberg";
-  private static final String WAREHOUSE =
-      "hdfs://127.0.0.1:9000/user/hive/warehouse-catalog-iceberg/";
-  private static final String URI = "thrift://127.0.0.1:9083";
+
+  private static final ContainerSuite containerSuite = ContainerSuite.getInstance();
+  private static String WAREHOUSE;
+  private static String HIVE_METASTORE_URIS;
 
   private static String SELECT_ALL_TEMPLATE = "SELECT * FROM iceberg.%s";
   private static String INSERT_BATCH_WITHOUT_PARTITION_TEMPLATE =
@@ -102,6 +105,18 @@ public class CatalogIcebergIT extends AbstractIT {
 
   @BeforeAll
   public static void startup() {
+    HIVE_METASTORE_URIS =
+        String.format(
+            "thrift://%s:%d",
+            containerSuite.getHiveContainer().getContainerIpAddress(),
+            HiveContainer.HIVE_METASTORE_PORT);
+
+    WAREHOUSE =
+        String.format(
+            "hdfs://%s:%d/user/hive/warehouse-catalog-iceberg/",
+            containerSuite.getHiveContainer().getContainerIpAddress(),
+            HiveContainer.HDFS_DEFAULTFS_PORT);
+
     createMetalake();
     createCatalog();
     createSchema();
@@ -111,7 +126,7 @@ public class CatalogIcebergIT extends AbstractIT {
             .appName("Iceberg Catalog integration test")
             .config("spark.sql.warehouse.dir", WAREHOUSE)
             .config("spark.sql.catalog.iceberg", "org.apache.iceberg.spark.SparkCatalog")
-            .config("spark.sql.catalog.iceberg.uri", URI)
+            .config("spark.sql.catalog.iceberg.uri", HIVE_METASTORE_URIS)
             .config("spark.sql.catalog.iceberg.type", "hive")
             .config(
                 "spark.sql.extensions",
@@ -161,11 +176,11 @@ public class CatalogIcebergIT extends AbstractIT {
 
     catalogProperties.put(
         IcebergConfig.CATALOG_BACKEND.getKey(), IcebergCatalogBackend.HIVE.name());
-    catalogProperties.put(IcebergConfig.CATALOG_URI.getKey(), URI);
+    catalogProperties.put(IcebergConfig.CATALOG_URI.getKey(), HIVE_METASTORE_URIS);
     catalogProperties.put(IcebergConfig.CATALOG_WAREHOUSE.getKey(), WAREHOUSE);
 
     Map<String, String> hiveProperties = Maps.newHashMap();
-    hiveProperties.put(IcebergConfig.CATALOG_URI.getKey(), URI);
+    hiveProperties.put(IcebergConfig.CATALOG_URI.getKey(), HIVE_METASTORE_URIS);
     hiveProperties.put(IcebergConfig.CATALOG_WAREHOUSE.getKey(), WAREHOUSE);
 
     hiveCatalog = new HiveCatalog();

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/lakehouse/iceberg/IcebergRESTServiceBaseIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/lakehouse/iceberg/IcebergRESTServiceBaseIT.java
@@ -10,6 +10,8 @@ import com.datastrato.gravitino.aux.AuxiliaryServiceManager;
 import com.datastrato.gravitino.catalog.lakehouse.iceberg.IcebergCatalogBackend;
 import com.datastrato.gravitino.catalog.lakehouse.iceberg.IcebergConfig;
 import com.datastrato.gravitino.catalog.lakehouse.iceberg.IcebergRESTService;
+import com.datastrato.gravitino.integration.test.container.ContainerSuite;
+import com.datastrato.gravitino.integration.test.container.HiveContainer;
 import com.datastrato.gravitino.integration.test.util.AbstractIT;
 import com.datastrato.gravitino.integration.test.util.GravitinoITUtils;
 import com.datastrato.gravitino.server.web.JettyServerConfig;
@@ -41,6 +43,7 @@ import org.slf4j.LoggerFactory;
 @TestInstance(Lifecycle.PER_CLASS)
 public class IcebergRESTServiceBaseIT extends AbstractIT {
   public static final Logger LOG = LoggerFactory.getLogger(IcebergRESTServiceBaseIT.class);
+  private static final ContainerSuite containerSuite = ContainerSuite.getInstance();
   private SparkSession sparkSession;
   protected IcebergCatalogBackend catalogType = IcebergCatalogBackend.MEMORY;
 
@@ -154,7 +157,11 @@ public class IcebergRESTServiceBaseIT extends AbstractIT {
             + IcebergRESTService.SERVICE_NAME
             + "."
             + IcebergConfig.CATALOG_WAREHOUSE.getKey(),
-        GravitinoITUtils.genRandomName("hdfs://127.0.0.1:9000/user/hive/warehouse-jdbc-sqlite"));
+        GravitinoITUtils.genRandomName(
+            String.format(
+                "hdfs://%s:%d/user/hive/warehouse-jdbc-sqlite",
+                containerSuite.getHiveContainer().getContainerIpAddress(),
+                HiveContainer.HDFS_DEFAULTFS_PORT)));
 
     return configMap;
   }
@@ -173,14 +180,21 @@ public class IcebergRESTServiceBaseIT extends AbstractIT {
             + IcebergRESTService.SERVICE_NAME
             + "."
             + IcebergConfig.CATALOG_URI.getKey(),
-        "thrift://127.0.0.1:9083");
+        String.format(
+            "thrift://%s:%d",
+            containerSuite.getHiveContainer().getContainerIpAddress(),
+            HiveContainer.HIVE_METASTORE_PORT));
 
     customConfigs.put(
         AuxiliaryServiceManager.GRAVITINO_AUX_SERVICE_PREFIX
             + IcebergRESTService.SERVICE_NAME
             + "."
             + IcebergConfig.CATALOG_WAREHOUSE.getKey(),
-        GravitinoITUtils.genRandomName("hdfs://127.0.0.1:9000/user/hive/warehouse-hive"));
+        GravitinoITUtils.genRandomName(
+            String.format(
+                "hdfs://%s:%d/user/hive/warehouse-hive",
+                containerSuite.getHiveContainer().getContainerIpAddress(),
+                HiveContainer.HDFS_DEFAULTFS_PORT)));
     return customConfigs;
   }
 

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/lakehouse/iceberg/IcebergRESTServiceIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/lakehouse/iceberg/IcebergRESTServiceIT.java
@@ -23,12 +23,14 @@ import org.apache.spark.sql.catalyst.analysis.TableAlreadyExistsException;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.api.condition.EnabledIf;
 
 @TestInstance(Lifecycle.PER_CLASS)
+@Tag("gravitino-docker-it")
 public class IcebergRESTServiceIT extends IcebergRESTServiceBaseIT {
 
   private static final String ICEBERG_REST_NS_PREFIX = "iceberg_rest_";

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/container/BaseContainer.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/container/BaseContainer.java
@@ -2,7 +2,7 @@
  * Copyright 2023 Datastrato.
  * This software is licensed under the Apache License version 2.
  */
-package com.datastrato.gravitino.integration.test.util;
+package com.datastrato.gravitino.integration.test.container;
 
 import static java.util.Objects.requireNonNull;
 import static org.testcontainers.utility.MountableFile.forHostPath;

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/container/ContainerSuite.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/container/ContainerSuite.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2023 Datastrato.
+ * This software is licensed under the Apache License version 2.
+ */
+package com.datastrato.gravitino.integration.test.container;
+
+import com.datastrato.gravitino.integration.test.util.CloseableGroup;
+import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.model.Info;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import java.io.Closeable;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.DockerClientFactory;
+import org.testcontainers.containers.Network;
+
+public class ContainerSuite implements Closeable {
+  public static final Logger LOG = LoggerFactory.getLogger(ContainerSuite.class);
+  private static volatile ContainerSuite instance = null;
+
+  // The subnet must match the configuration in `dev/docker/tools/mac-docker-connector.conf`
+  private static final String CONTAINER_NETWORK_SUBNET = "10.0.0.0/22";
+  private static final String CONTAINER_NETWORK_GATEWAY = "10.0.0.1";
+  private static final String CONTAINER_NETWORK_IPRANGE = "10.0.0.100/22";
+  private static Network network = null;
+  private static HiveContainer hiveContainer;
+  private static TrinoContainer trinoContainer;
+
+  protected static final CloseableGroup closer = CloseableGroup.create();
+
+  private ContainerSuite() {
+    try {
+      // Check if docker is available
+      DockerClient dockerClient = DockerClientFactory.instance().client();
+      Info info = dockerClient.infoCmd().exec();
+      LOG.info("Docker info: {}", info);
+
+      network = createDockerNetwork();
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to initialize ContainerSuite", e);
+    }
+  }
+
+  public static ContainerSuite getInstance() {
+    if (instance == null) {
+      synchronized (ContainerSuite.class) {
+        if (instance == null) {
+          instance = new ContainerSuite();
+        }
+      }
+    }
+    return instance;
+  }
+
+  public Network getNetwork() {
+    return network;
+  }
+
+  public void startHiveContainer() {
+    if (hiveContainer != null) {
+      return;
+    }
+    // Start Hive container
+    HiveContainer.Builder hiveBuilder =
+        HiveContainer.builder()
+            .withHostName("gravitino-ci-hive")
+            .withEnvVars(
+                ImmutableMap.<String, String>builder().put("HADOOP_USER_NAME", "root").build())
+            .withNetwork(network);
+    hiveContainer = closer.register(hiveBuilder.build());
+    hiveContainer.start();
+  }
+
+  public void startTrinoContainer(
+      String trinoConfDir,
+      String trinoConnectorLibDir,
+      InetSocketAddress gravitinoServerAddr,
+      String metalakeName) {
+    if (trinoContainer != null) {
+      return;
+    }
+
+    // Start Trino container
+    String hiveContainerIp = hiveContainer.getContainerIpAddress();
+    TrinoContainer.Builder trinoBuilder =
+        TrinoContainer.builder()
+            .withEnvVars(
+                ImmutableMap.<String, String>builder().put("HADOOP_USER_NAME", "root").build())
+            .withNetwork(getNetwork())
+            .withExtraHosts(
+                ImmutableMap.<String, String>builder()
+                    .put(hiveContainerIp, hiveContainerIp)
+                    .build())
+            .withFilesToMount(
+                ImmutableMap.<String, String>builder()
+                    .put(TrinoContainer.TRINO_CONTAINER_CONF_DIR, trinoConfDir)
+                    .put(TrinoContainer.TRINO_CONTAINER_PLUGIN_GRAVITINO_DIR, trinoConnectorLibDir)
+                    .build())
+            .withExposePorts(ImmutableSet.of(TrinoContainer.TRINO_PORT))
+            .withTrinoConfDir(trinoConfDir)
+            .withMetalakeName(metalakeName)
+            .withGravitinoServerAddress(gravitinoServerAddr)
+            .withHiveContainerIP(hiveContainerIp);
+
+    trinoContainer = closer.register(trinoBuilder.build());
+    trinoContainer.start();
+  }
+
+  public TrinoContainer getTrinoContainer() {
+    return trinoContainer;
+  }
+
+  public HiveContainer getHiveContainer() {
+    return hiveContainer;
+  }
+
+  // Let containers assign addresses in a fixed subnet to avoid `mac-docker-connector` needing to
+  // refresh the configuration
+  private static Network createDockerNetwork() {
+    com.github.dockerjava.api.model.Network.Ipam.Config ipamConfig =
+        new com.github.dockerjava.api.model.Network.Ipam.Config();
+    ipamConfig
+        .withSubnet(CONTAINER_NETWORK_SUBNET)
+        .withGateway(CONTAINER_NETWORK_GATEWAY)
+        .withIpRange(CONTAINER_NETWORK_IPRANGE);
+
+    return closer.register(
+        Network.builder()
+            .createNetworkCmdModifier(
+                cmd ->
+                    cmd.withIpam(
+                        new com.github.dockerjava.api.model.Network.Ipam().withConfig(ipamConfig)))
+            .build());
+  }
+
+  @Override
+  public void close() throws IOException {
+    try {
+      closer.close();
+    } catch (Exception e) {
+      LOG.error("Failed to close ContainerEnvironment", e);
+    }
+  }
+}

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/container/HiveContainer.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/container/HiveContainer.java
@@ -2,7 +2,7 @@
  * Copyright 2023 Datastrato.
  * This software is licensed under the Apache License version 2.
  */
-package com.datastrato.gravitino.integration.test.util;
+package com.datastrato.gravitino.integration.test.container;
 
 import static java.lang.String.format;
 
@@ -22,13 +22,8 @@ public class HiveContainer extends BaseContainer {
   public static final String DEFAULT_IMAGE = System.getenv("GRAVITINO_CI_HIVE_DOCKER_IMAGE");
   public static final String HOST_NAME = "gravitino-ci-hive";
   private static final int MYSQL_PORT = 3306;
-  private static final int HDFS_DEFAULTFS_PORT = 9000;
+  public static final int HDFS_DEFAULTFS_PORT = 9000;
   public static final int HIVE_METASTORE_PORT = 9083;
-  private static final int HIVESERVER2_PORT = 10000;
-  private static final int HIVESERVER2_HTTP_PORT = 10002;
-  private static final int HDFS_NAMENODE_PORT = 50070;
-  private static final int HDFS_DATANODE_HTTP_SERVER_PORT = 50075;
-  private static final int HDFS_DATANODE_DATA_TRANSFER_PORT = 50010;
 
   public static Builder builder() {
     return new Builder();
@@ -92,16 +87,7 @@ public class HiveContainer extends BaseContainer {
     private Builder() {
       this.image = DEFAULT_IMAGE;
       this.hostName = HOST_NAME;
-      this.exposePorts =
-          ImmutableSet.of(
-              MYSQL_PORT,
-              HDFS_DEFAULTFS_PORT,
-              HIVE_METASTORE_PORT,
-              HIVESERVER2_PORT,
-              HIVESERVER2_HTTP_PORT,
-              HDFS_NAMENODE_PORT,
-              HDFS_DATANODE_HTTP_SERVER_PORT,
-              HDFS_DATANODE_DATA_TRANSFER_PORT);
+      this.exposePorts = ImmutableSet.of(MYSQL_PORT, HDFS_DEFAULTFS_PORT, HIVE_METASTORE_PORT);
     }
 
     @Override

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/container/PrintingContainerLog.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/container/PrintingContainerLog.java
@@ -2,7 +2,7 @@
  * Copyright 2023 Datastrato.
  * This software is licensed under the Apache License version 2.
  */
-package com.datastrato.gravitino.integration.test.util;
+package com.datastrato.gravitino.integration.test.container;
 
 import static java.util.Objects.requireNonNull;
 import static org.testcontainers.containers.output.OutputFrame.OutputType.END;

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/trino/TrinoConnectorIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/trino/TrinoConnectorIT.java
@@ -10,18 +10,15 @@ import com.datastrato.gravitino.Catalog;
 import com.datastrato.gravitino.NameIdentifier;
 import com.datastrato.gravitino.catalog.hive.HiveClientPool;
 import com.datastrato.gravitino.client.GravitinoMetaLake;
+import com.datastrato.gravitino.integration.test.container.ContainerSuite;
+import com.datastrato.gravitino.integration.test.container.HiveContainer;
 import com.datastrato.gravitino.integration.test.util.AbstractIT;
-import com.datastrato.gravitino.integration.test.util.CloseableGroup;
 import com.datastrato.gravitino.integration.test.util.GravitinoITUtils;
-import com.datastrato.gravitino.integration.test.util.HiveContainer;
-import com.datastrato.gravitino.integration.test.util.ITUtils;
-import com.datastrato.gravitino.integration.test.util.TrinoContainer;
 import com.datastrato.gravitino.rel.Schema;
 import com.datastrato.gravitino.rel.Table;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import java.io.IOException;
+import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -37,25 +34,15 @@ import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
-import org.rnorth.ducttape.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.testcontainers.containers.Network;
 
-@Tag("gravitino-trino-it")
+@Tag("gravitino-docker-it")
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class TrinoConnectorIT extends AbstractIT {
   public static final Logger LOG = LoggerFactory.getLogger(TrinoConnectorIT.class);
-  private static final CloseableGroup closer = CloseableGroup.create();
 
-  // The subnet must match the configuration in `dev/docker/tools/mac-docker-connector.conf`
-  private static final String CONTAINER_NETWORK_SUBNET = "10.0.0.0/22";
-  private static final String CONTAINER_NETWORK_GATEWAY = "10.0.0.1";
-  private static final String CONTAINER_NETWORK_IPRANGE = "10.0.0.100/22";
-
-  public static TrinoContainer trinoContainer;
-
-  public static HiveContainer hiveContainer;
+  private static final ContainerSuite containerSuite = ContainerSuite.getInstance();
   private static HiveClientPool hiveClientPool;
 
   public static String metalakeName =
@@ -72,48 +59,19 @@ public class TrinoConnectorIT extends AbstractIT {
   private static GravitinoMetaLake metalake;
   private static Catalog catalog;
 
-  static final String TRINO_CONNECTOR_LIB_DIR =
-      System.getenv("GRAVITINO_ROOT_DIR") + "/trino-connector/build/libs";
-
   @BeforeAll
   public static void startDockerContainer() throws IOException, TException, InterruptedException {
     String trinoConfDir = System.getenv("TRINO_CONF_DIR");
 
-    // Let containers assign addresses in a fixed subnet to avoid `mac-docker-connector` needing to
-    // refresh the configuration
-    com.github.dockerjava.api.model.Network.Ipam.Config ipamConfig =
-        new com.github.dockerjava.api.model.Network.Ipam.Config();
-    ipamConfig
-        .withSubnet(CONTAINER_NETWORK_SUBNET)
-        .withGateway(CONTAINER_NETWORK_GATEWAY)
-        .withIpRange(CONTAINER_NETWORK_IPRANGE);
-
-    Network network =
-        closer.register(
-            Network.builder()
-                .createNetworkCmdModifier(
-                    cmd ->
-                        cmd.withIpam(
-                            new com.github.dockerjava.api.model.Network.Ipam()
-                                .withConfig(ipamConfig)))
-                .build());
-
-    // Start Hive container
-    HiveContainer.Builder hiveBuilder =
-        HiveContainer.builder()
-            .withHostName("gravitino-ci-hive")
-            .withEnvVars(
-                ImmutableMap.<String, String>builder().put("HADOOP_USER_NAME", "root").build())
-            .withNetwork(network);
-    hiveContainer = closer.register(hiveBuilder.build());
-    hiveContainer.start();
+    containerSuite.startHiveContainer();
 
     // Initial hive client
     HiveConf hiveConf = new HiveConf();
     String hiveMetastoreUris =
         String.format(
             "thrift://%s:%d",
-            getPrimaryNICIp(), hiveContainer.getMappedPort(HiveContainer.HIVE_METASTORE_PORT));
+            containerSuite.getHiveContainer().getContainerIpAddress(),
+            HiveContainer.HIVE_METASTORE_PORT);
     hiveConf.set(HiveConf.ConfVars.METASTOREURIS.varname, hiveMetastoreUris);
     hiveClientPool = closer.register(new HiveClientPool(1, hiveConf));
 
@@ -121,35 +79,12 @@ public class TrinoConnectorIT extends AbstractIT {
     createMetalake();
     createCatalog();
 
-    // Configure Trino config file
-    updateTrinoConfigFile();
-
-    // Start Trino container
-    String hiveContainerIp = hiveContainer.getContainerIpAddress();
-    TrinoContainer.Builder trinoBuilder =
-        TrinoContainer.builder()
-            .withEnvVars(
-                ImmutableMap.<String, String>builder().put("HADOOP_USER_NAME", "root").build())
-            .withNetwork(network)
-            .withExtraHosts(
-                ImmutableMap.<String, String>builder()
-                    .put(hiveContainerIp, hiveContainerIp)
-                    .build())
-            .withFilesToMount(
-                ImmutableMap.<String, String>builder()
-                    .put(TrinoContainer.TRINO_CONTAINER_CONF_DIR, trinoConfDir)
-                    .put(
-                        TrinoContainer.TRINO_CONTAINER_PLUGIN_GRAVITINO_DIR,
-                        TRINO_CONNECTOR_LIB_DIR)
-                    .build())
-            .withExposePorts(ImmutableSet.of(TrinoContainer.TRINO_PORT));
-
-    trinoContainer = closer.register(trinoBuilder.build());
-    trinoContainer.start();
-
-    Preconditions.check(
-        "Check sync Catalog from Gravitino failed!",
-        trinoContainer.checkSyncCatalogFromGravitino(5, metalakeName, catalogName));
+    containerSuite.startTrinoContainer(
+        trinoConfDir,
+        System.getenv("GRAVITINO_ROOT_DIR") + "/trino-connector/build/libs",
+        new InetSocketAddress(AbstractIT.getPrimaryNICIp(), getGravitinoServerPort()),
+        metalakeName);
+    containerSuite.getTrinoContainer().checkSyncCatalogFromGravitino(5, metalakeName, catalogName);
 
     createSchema();
   }
@@ -167,14 +102,15 @@ public class TrinoConnectorIT extends AbstractIT {
     String sql1 =
         String.format(
             "CREATE SCHEMA \"%s.%s\".%s WITH (\n"
-                + "  location = 'hdfs://%s:9000/user/hive/warehouse/%s.db'\n"
+                + "  location = 'hdfs://%s:%d/user/hive/warehouse/%s.db'\n"
                 + ")",
             metalakeName,
             catalogName,
             databaseName,
-            hiveContainer.getContainerIpAddress(),
+            containerSuite.getHiveContainer().getContainerIpAddress(),
+            HiveContainer.HDFS_DEFAULTFS_PORT,
             databaseName);
-    trinoContainer.executeUpdateSQL(sql1);
+    containerSuite.getTrinoContainer().executeUpdateSQL(sql1);
     NameIdentifier idSchema = NameIdentifier.of(metalakeName, catalogName, databaseName);
     Schema schema = catalog.asSchemas().loadSchema(idSchema);
     Assertions.assertEquals(schema.name(), databaseName);
@@ -188,7 +124,8 @@ public class TrinoConnectorIT extends AbstractIT {
     String sql =
         String.format(
             "SHOW SCHEMAS FROM \"%s.%s\" LIKE '%s'", metalakeName, catalogName, databaseName);
-    ArrayList<ArrayList<String>> queryData = trinoContainer.executeQuerySQL(sql);
+    ArrayList<ArrayList<String>> queryData =
+        containerSuite.getTrinoContainer().executeQuerySQL(sql);
     Assertions.assertEquals(queryData.get(0).get(0), databaseName);
   }
 
@@ -206,7 +143,7 @@ public class TrinoConnectorIT extends AbstractIT {
                 + "  format = 'TEXTFILE'\n"
                 + ")",
             metalakeName, catalogName, databaseName, tab1Name);
-    trinoContainer.executeUpdateSQL(sql3);
+    containerSuite.getTrinoContainer().executeUpdateSQL(sql3);
 
     // Verify in Gravitino Server
     NameIdentifier idTable1 = NameIdentifier.of(metalakeName, catalogName, databaseName, tab1Name);
@@ -227,7 +164,8 @@ public class TrinoConnectorIT extends AbstractIT {
         String.format(
             "SHOW TABLES FROM \"%s.%s\".%s LIKE '%s'",
             metalakeName, catalogName, databaseName, tab1Name);
-    ArrayList<ArrayList<String>> queryData = trinoContainer.executeQuerySQL(sql);
+    ArrayList<ArrayList<String>> queryData =
+        containerSuite.getTrinoContainer().executeQuerySQL(sql);
     Assertions.assertEquals(queryData.get(0).get(0), tab1Name);
   }
 
@@ -251,7 +189,7 @@ public class TrinoConnectorIT extends AbstractIT {
                 + "  format = 'TEXTFILE'\n"
                 + ")",
             metalakeName, catalogName, databaseName, scenarioTab1Name);
-    trinoContainer.executeUpdateSQL(sql3);
+    containerSuite.getTrinoContainer().executeUpdateSQL(sql3);
 
     // Verify in Gravitino Server
     NameIdentifier idTable1 =
@@ -287,14 +225,15 @@ public class TrinoConnectorIT extends AbstractIT {
         sql5.deleteCharAt(sql5.length() - 1);
       }
     }
-    trinoContainer.executeUpdateSQL(sql5.toString());
+    containerSuite.getTrinoContainer().executeUpdateSQL(sql5.toString());
 
     // Select data from table1 and verify it
     String sql6 =
         String.format(
             "SELECT user_name, gender, age, phone FROM \"%s.%s\".%s.%s ORDER BY user_name",
             metalakeName, catalogName, databaseName, scenarioTab1Name);
-    ArrayList<ArrayList<String>> table1QueryData = trinoContainer.executeQuerySQL(sql6);
+    ArrayList<ArrayList<String>> table1QueryData =
+        containerSuite.getTrinoContainer().executeQuerySQL(sql6);
     Assertions.assertEquals(table1Data, table1QueryData);
   }
 
@@ -315,7 +254,7 @@ public class TrinoConnectorIT extends AbstractIT {
                 + "  format = 'TEXTFILE'\n"
                 + ")",
             metalakeName, catalogName, databaseName, scenarioTab2Name);
-    trinoContainer.executeUpdateSQL(sql4);
+    containerSuite.getTrinoContainer().executeUpdateSQL(sql4);
 
     // Verify in Gravitino Server
     NameIdentifier idTable2 =
@@ -351,14 +290,15 @@ public class TrinoConnectorIT extends AbstractIT {
         sql7.deleteCharAt(sql7.length() - 1);
       }
     }
-    trinoContainer.executeUpdateSQL(sql7.toString());
+    containerSuite.getTrinoContainer().executeUpdateSQL(sql7.toString());
 
     // Select data from table1 and verify it
     String sql8 =
         String.format(
             "SELECT user_name, consumer, recharge, event_time FROM \"%s.%s\".%s.%s ORDER BY user_name",
             metalakeName, catalogName, databaseName, scenarioTab2Name);
-    ArrayList<ArrayList<String>> table2QueryData = trinoContainer.executeQuerySQL(sql8);
+    ArrayList<ArrayList<String>> table2QueryData =
+        containerSuite.getTrinoContainer().executeQuerySQL(sql8);
     Assertions.assertEquals(table2Data, table2QueryData);
   }
 
@@ -372,7 +312,8 @@ public class TrinoConnectorIT extends AbstractIT {
                 + "    (SELECT user_name, consumer, recharge, event_time FROM \"%1$s.%2$s\".%3$s.%5$s) AS t2\n"
                 + "        ON t1.user_name = t2.user_name) ORDER BY user_name",
             metalakeName, catalogName, databaseName, scenarioTab1Name, scenarioTab2Name);
-    ArrayList<ArrayList<String>> joinQueryData = trinoContainer.executeQuerySQL(sql9);
+    ArrayList<ArrayList<String>> joinQueryData =
+        containerSuite.getTrinoContainer().executeQuerySQL(sql9);
     ArrayList<ArrayList<String>> joinData = new ArrayList<>();
     joinData.add(
         new ArrayList<>(
@@ -407,7 +348,8 @@ public class TrinoConnectorIT extends AbstractIT {
     String hiveMetastoreUris =
         String.format(
             "thrift://%s:%d",
-            hiveContainer.getContainerIpAddress(), HiveContainer.HIVE_METASTORE_PORT);
+            containerSuite.getHiveContainer().getContainerIpAddress(),
+            HiveContainer.HIVE_METASTORE_PORT);
     LOG.debug("hiveMetastoreUris is {}", hiveMetastoreUris);
     properties.put(METASTORE_URIS, hiveMetastoreUris);
 
@@ -421,27 +363,5 @@ public class TrinoConnectorIT extends AbstractIT {
     Catalog loadCatalog = metalake.loadCatalog(NameIdentifier.of(metalakeName, catalogName));
 
     catalog = loadCatalog;
-  }
-
-  private static void updateTrinoConfigFile() throws IOException {
-    String trinoConfDir = System.getenv("TRINO_CONF_DIR");
-    ITUtils.rewriteConfigFile(
-        trinoConfDir + "/catalog/gravitino.properties.template",
-        trinoConfDir + "/catalog/gravitino.properties",
-        ImmutableMap.<String, String>builder()
-            .put(
-                TrinoContainer.TRINO_CONF_GRAVITINO_URI,
-                String.format(
-                    "http://%s:%d", AbstractIT.getPrimaryNICIp(), getGravitinoServerPort()))
-            .put(TrinoContainer.TRINO_CONF_GRAVITINO_METALAKE, metalakeName)
-            .build());
-    ITUtils.rewriteConfigFile(
-        trinoConfDir + "/catalog/hive.properties.template",
-        trinoConfDir + "/catalog/hive.properties",
-        ImmutableMap.of(
-            TrinoContainer.TRINO_CONF_HIVE_METASTORE_URI,
-            String.format(
-                "thrift://%s:%d",
-                hiveContainer.getContainerIpAddress(), HiveContainer.HIVE_METASTORE_PORT)));
   }
 }

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/util/AbstractIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/util/AbstractIT.java
@@ -34,9 +34,10 @@ import org.slf4j.LoggerFactory;
 
 @ExtendWith(PrintFuncNameExtension.class)
 public class AbstractIT {
-  public static final Logger LOG = LoggerFactory.getLogger(AbstractIT.class);
+  private static final Logger LOG = LoggerFactory.getLogger(AbstractIT.class);
   protected static GravitinoClient client;
 
+  protected static final CloseableGroup closer = CloseableGroup.create();
   private static MiniGravitino miniGravitino;
 
   protected static Config serverConfig;

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/util/GravitinoITUtils.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/util/GravitinoITUtils.java
@@ -4,17 +4,12 @@
  */
 package com.datastrato.gravitino.integration.test.util;
 
-import com.google.common.collect.Maps;
-import java.util.Map;
 import java.util.UUID;
-import org.apache.hadoop.hive.conf.HiveConf;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class GravitinoITUtils {
   public static final Logger LOG = LoggerFactory.getLogger(GravitinoITUtils.class);
-
-  public static String HIVE_METASTORE_URIS = "thrift://localhost:9083";
 
   private GravitinoITUtils() {
     throw new IllegalStateException("Utility class");
@@ -55,23 +50,5 @@ public class GravitinoITUtils {
 
   public static String genRandomName(String prefix) {
     return prefix + "_" + UUID.randomUUID().toString().replace("-", "").substring(0, 8);
-  }
-
-  public static HiveConf hiveConfig() {
-    HiveConf hiveConf = new HiveConf();
-    hiveConf.set(HiveConf.ConfVars.METASTOREURIS.varname, HIVE_METASTORE_URIS);
-
-    return hiveConf;
-  }
-
-  public static Map<String, String> hiveConfigProperties() {
-    Map<String, String> catalogProps = Maps.newHashMap();
-    catalogProps.put("provider", "hive");
-    catalogProps.put(HiveConf.ConfVars.METASTOREURIS.varname, HIVE_METASTORE_URIS);
-    catalogProps.put(HiveConf.ConfVars.METASTORETHRIFTCONNECTIONRETRIES.varname, "30");
-    catalogProps.put(HiveConf.ConfVars.METASTORETHRIFTFAILURERETRIES.varname, "30");
-    catalogProps.put(HiveConf.ConfVars.METASTORE_CLIENT_CONNECT_RETRY_DELAY.varname, "5");
-
-    return catalogProps;
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

I'm considering referencing the `testcontaine` approach in `TrinoConnectorIT`. It can be better to use containers for testing.

### Why are the changes needed?

Currently, the `HiveCatalogIT` and `CatalogIcebergIT` integrated test environment launches the `gravitino-ci-hive` Docker image via a script, This creates a situation where the startup container is in GitHub Action or local to the user, and the test container is in the IT code, which is not uniform.

Fix: #639

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

CI Pass
