### PR TITLE
[MINOR] Fix the logger's class name of `EntitySerDeFactory`

### DIFF
--- a/core/src/main/java/com/datastrato/gravitino/EntitySerDeFactory.java
+++ b/core/src/main/java/com/datastrato/gravitino/EntitySerDeFactory.java
@@ -17,7 +17,7 @@ import org.slf4j.LoggerFactory;
  */
 public class EntitySerDeFactory {
 
-  private static final Logger LOG = LoggerFactory.getLogger(EntitySerDe.class);
+  private static final Logger LOG = LoggerFactory.getLogger(EntitySerDeFactory.class);
 
   // Register EntitySerDe's short name to its full qualified class name in the map. So that user
   // don't need to specify the full qualified class name when creating an EntitySerDe.


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix the logger's class name of `EntitySerDeFactory`

### Why are the changes needed?
If we don't have this patch, the logger will print wrong class name.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
CI passed.