### PR TITLE
[#728] improvement(core): Change string charset from default to utf-8 in storage module

### DIFF
--- a/core/src/main/java/com/datastrato/gravitino/storage/kv/BinaryEntityKeyEncoder.java
+++ b/core/src/main/java/com/datastrato/gravitino/storage/kv/BinaryEntityKeyEncoder.java
@@ -20,6 +20,7 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -55,7 +56,8 @@ public class BinaryEntityKeyEncoder implements EntityKeyEncoder<byte[]> {
   public static final String NAMESPACE_SEPARATOR = "/";
 
   @VisibleForTesting
-  static final byte[] BYTABLE_NAMESPACE_SEPARATOR = NAMESPACE_SEPARATOR.getBytes();
+  static final byte[] BYTABLE_NAMESPACE_SEPARATOR =
+      NAMESPACE_SEPARATOR.getBytes(StandardCharsets.UTF_8);
 
   static final String WILD_CARD = "*";
 
@@ -145,9 +147,13 @@ public class BinaryEntityKeyEncoder implements EntityKeyEncoder<byte[]> {
     byte[] bytes = new byte[0];
     for (int i = 0; i < namespaceTemplate.length; i++) {
       if (i != namespaceTemplate.length - 1) {
-        bytes = Bytes.concat(bytes, namespaceTemplate[i].getBytes(), ByteUtils.longToByte(ids[i]));
+        bytes =
+            Bytes.concat(
+                bytes,
+                namespaceTemplate[i].getBytes(StandardCharsets.UTF_8),
+                ByteUtils.longToByte(ids[i]));
       } else {
-        bytes = Bytes.concat(bytes, namespaceTemplate[i].getBytes());
+        bytes = Bytes.concat(bytes, namespaceTemplate[i].getBytes(StandardCharsets.UTF_8));
       }
     }
 
@@ -169,7 +175,10 @@ public class BinaryEntityKeyEncoder implements EntityKeyEncoder<byte[]> {
     byte[] bytes = new byte[0];
     for (int i = 0; i < ids.length; i++) {
       bytes =
-          Bytes.concat(bytes, nameIdentifierTemplate[i].getBytes(), ByteUtils.longToByte(ids[i]));
+          Bytes.concat(
+              bytes,
+              nameIdentifierTemplate[i].getBytes(StandardCharsets.UTF_8),
+              ByteUtils.longToByte(ids[i]));
     }
 
     return bytes;

--- a/core/src/main/java/com/datastrato/gravitino/storage/kv/KvEntityStore.java
+++ b/core/src/main/java/com/datastrato/gravitino/storage/kv/KvEntityStore.java
@@ -34,6 +34,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -299,7 +300,7 @@ public class KvEntityStore implements EntityStore {
   private byte[] replacePrefixTypeInfo(byte[] encode, String subTypePrefix) {
     byte[] result = new byte[encode.length];
     System.arraycopy(encode, 0, result, 0, encode.length);
-    byte[] bytes = subTypePrefix.getBytes();
+    byte[] bytes = subTypePrefix.getBytes(StandardCharsets.UTF_8);
     result[0] = bytes[0];
     result[1] = bytes[1];
 

--- a/core/src/test/java/com/datastrato/gravitino/storage/kv/TestEntityKeyEncoding.java
+++ b/core/src/test/java/com/datastrato/gravitino/storage/kv/TestEntityKeyEncoding.java
@@ -26,6 +26,7 @@ import com.datastrato.gravitino.utils.ByteUtils;
 import com.datastrato.gravitino.utils.Bytes;
 import java.io.IOException;
 import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -108,12 +109,12 @@ public class TestEntityKeyEncoding {
     Mockito.doReturn(0L).when(mockIdGenerator).nextId();
     NameIdentifier mateLakeIdentifier1 = NameIdentifier.of(namespace, "metalake1");
     byte[] realKey = ENCODER.encode(mateLakeIdentifier1, EntityType.METALAKE);
-    byte[] expenctKey =
+    byte[] expectKey =
         Bytes.concat(
-            EntityType.METALAKE.getShortName().getBytes(),
+            EntityType.METALAKE.getShortName().getBytes(StandardCharsets.UTF_8),
             BYTABLE_NAMESPACE_SEPARATOR,
             ByteUtils.longToByte(0L));
-    Assertions.assertArrayEquals(expenctKey, realKey);
+    Assertions.assertArrayEquals(expectKey, realKey);
 
     // name ---> id
     // catalog1 --> 1
@@ -130,14 +131,14 @@ public class TestEntityKeyEncoding {
       Mockito.doReturn(1L + i).when(mockIdGenerator).nextId();
       NameIdentifier identifier = catalogIdentifiers[i];
       realKey = ENCODER.encode(identifier, EntityType.CATALOG);
-      expenctKey =
+      expectKey =
           Bytes.concat(
-              EntityType.CATALOG.getShortName().getBytes(),
+              EntityType.CATALOG.getShortName().getBytes(StandardCharsets.UTF_8),
               BYTABLE_NAMESPACE_SEPARATOR,
               ByteUtils.longToByte(0L),
               BYTABLE_NAMESPACE_SEPARATOR,
               ByteUtils.longToByte(1L + i));
-      Assertions.assertArrayEquals(expenctKey, realKey);
+      Assertions.assertArrayEquals(expectKey, realKey);
     }
 
     // name ---> id
@@ -155,16 +156,16 @@ public class TestEntityKeyEncoding {
       NameIdentifier identifier = schemaIdentifiers[i];
       Mockito.doReturn(4L + i).when(mockIdGenerator).nextId();
       realKey = ENCODER.encode(identifier, EntityType.SCHEMA);
-      expenctKey =
+      expectKey =
           Bytes.concat(
-              EntityType.SCHEMA.getShortName().getBytes(),
+              EntityType.SCHEMA.getShortName().getBytes(StandardCharsets.UTF_8),
               BYTABLE_NAMESPACE_SEPARATOR,
               ByteUtils.longToByte(0L),
               BYTABLE_NAMESPACE_SEPARATOR,
               ByteUtils.longToByte(2L),
               BYTABLE_NAMESPACE_SEPARATOR,
               ByteUtils.longToByte(4L + i));
-      Assertions.assertArrayEquals(expenctKey, realKey);
+      Assertions.assertArrayEquals(expectKey, realKey);
     }
 
     // name ---> id
@@ -182,9 +183,9 @@ public class TestEntityKeyEncoding {
       NameIdentifier identifier = tableIdentifiers[i];
       Mockito.doReturn(7L + i).when(mockIdGenerator).nextId();
       realKey = ENCODER.encode(identifier, EntityType.TABLE);
-      expenctKey =
+      expectKey =
           Bytes.concat(
-              EntityType.TABLE.getShortName().getBytes(),
+              EntityType.TABLE.getShortName().getBytes(StandardCharsets.UTF_8),
               BYTABLE_NAMESPACE_SEPARATOR,
               ByteUtils.longToByte(0L),
               BYTABLE_NAMESPACE_SEPARATOR,
@@ -193,7 +194,7 @@ public class TestEntityKeyEncoding {
               ByteUtils.longToByte(6L),
               BYTABLE_NAMESPACE_SEPARATOR,
               ByteUtils.longToByte(i + 7L));
-      Assertions.assertArrayEquals(expenctKey, realKey);
+      Assertions.assertArrayEquals(expectKey, realKey);
     }
 
     // Unsupported operation
@@ -218,9 +219,11 @@ public class TestEntityKeyEncoding {
 
     NameIdentifier metalakeIdentifier = NameIdentifier.of(namespace, WILD_CARD);
     byte[] realKey = ENCODER.encode(metalakeIdentifier, EntityType.METALAKE);
-    byte[] expenctKey =
-        Bytes.concat(EntityType.METALAKE.getShortName().getBytes(), BYTABLE_NAMESPACE_SEPARATOR);
-    Assertions.assertArrayEquals(expenctKey, realKey);
+    byte[] expectKey =
+        Bytes.concat(
+            EntityType.METALAKE.getShortName().getBytes(StandardCharsets.UTF_8),
+            BYTABLE_NAMESPACE_SEPARATOR);
+    Assertions.assertArrayEquals(expectKey, realKey);
 
     // Scan all catalog in metalake1
     // metalake1 --> 0L
@@ -228,13 +231,13 @@ public class TestEntityKeyEncoding {
     Namespace catalogNamespace = Namespace.of("metalake1");
     NameIdentifier catalogIdentifier = NameIdentifier.of(catalogNamespace, WILD_CARD);
     realKey = ENCODER.encode(catalogIdentifier, EntityType.CATALOG);
-    expenctKey =
+    expectKey =
         Bytes.concat(
-            EntityType.CATALOG.getShortName().getBytes(),
+            EntityType.CATALOG.getShortName().getBytes(StandardCharsets.UTF_8),
             BYTABLE_NAMESPACE_SEPARATOR,
             ByteUtils.longToByte(0L),
             BYTABLE_NAMESPACE_SEPARATOR);
-    Assertions.assertArrayEquals(expenctKey, realKey);
+    Assertions.assertArrayEquals(expectKey, realKey);
 
     // Scan all sc in metalake1.catalog2
     // catalog2 --> 1
@@ -242,15 +245,15 @@ public class TestEntityKeyEncoding {
     Namespace schemaNameSpace = Namespace.of("metalake1", "catalog2");
     NameIdentifier schemaIdentifier = NameIdentifier.of(schemaNameSpace, WILD_CARD);
     realKey = ENCODER.encode(schemaIdentifier, EntityType.SCHEMA);
-    expenctKey =
+    expectKey =
         Bytes.concat(
-            EntityType.SCHEMA.getShortName().getBytes(),
+            EntityType.SCHEMA.getShortName().getBytes(StandardCharsets.UTF_8),
             BYTABLE_NAMESPACE_SEPARATOR,
             ByteUtils.longToByte(0L),
             BYTABLE_NAMESPACE_SEPARATOR,
             ByteUtils.longToByte(1L),
             BYTABLE_NAMESPACE_SEPARATOR);
-    Assertions.assertArrayEquals(expenctKey, realKey);
+    Assertions.assertArrayEquals(expectKey, realKey);
 
     // Scan all table in metalake1.catalog2.schema3
     // schema3 --> 2
@@ -258,9 +261,9 @@ public class TestEntityKeyEncoding {
     Namespace tableNameSpace = Namespace.of("metalake1", "catalog2", "schema3");
     NameIdentifier tableIdentifier = NameIdentifier.of(tableNameSpace, WILD_CARD);
     realKey = ENCODER.encode(tableIdentifier, EntityType.TABLE);
-    expenctKey =
+    expectKey =
         Bytes.concat(
-            EntityType.TABLE.getShortName().getBytes(),
+            EntityType.TABLE.getShortName().getBytes(StandardCharsets.UTF_8),
             BYTABLE_NAMESPACE_SEPARATOR,
             ByteUtils.longToByte(0L),
             BYTABLE_NAMESPACE_SEPARATOR,
@@ -268,7 +271,7 @@ public class TestEntityKeyEncoding {
             BYTABLE_NAMESPACE_SEPARATOR,
             ByteUtils.longToByte(2L),
             BYTABLE_NAMESPACE_SEPARATOR);
-    Assertions.assertArrayEquals(expenctKey, realKey);
+    Assertions.assertArrayEquals(expectKey, realKey);
 
     Mockito.doReturn(3L).when(mockIdGenerator).nextId();
     Assertions.assertThrows(


### PR DESCRIPTION
### What changes were proposed in this pull request?

Change charset from `default` to `utf-8` when converting string to byte array. 


### Why are the changes needed?

`default` charset may be different in different platforms, which will cause problems if we rely on this directly, we'd better use an uniformed charset to convert string to byte array.

Fix: #728 

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

The existing UTs can cover this changes. 
