### PR TITLE
[Minor] Add description about the default JDK version in how-to-build file

### DIFF
--- a/docs/how-to-build.md
+++ b/docs/how-to-build.md
@@ -8,7 +8,7 @@ This software is licensed under the Apache License version 2."
 
 ## Prerequisites
 
-+ JDK 1.8 and JDK 1.17
++ JDK 1.8 and JDK 1.17, **set JDK 1.8 as the default JDK**.
 + Git
 
 Note: Gravitino uses Java 1.8 and Trino uses Java 1.17.


### PR DESCRIPTION


### What changes were proposed in this pull request?

Add some explanation about the default JDK version in how-to-build file.

### Why are the changes needed?

We need JDK8 and JDK17 to build Gravitino at the same time, file `how-to-build` do not specify the default JDK version, if JDK17 was the default, we would encounter errors when compiling Gravitino. 


### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

No