### PR TITLE
[#732] improvement(core): Remove transaction in interface `KvBackend`

### DIFF
--- a/core/src/main/java/com/datastrato/gravitino/storage/kv/KvBackend.java
+++ b/core/src/main/java/com/datastrato/gravitino/storage/kv/KvBackend.java
@@ -7,7 +7,6 @@ package com.datastrato.gravitino.storage.kv;
 
 import com.datastrato.gravitino.Config;
 import com.datastrato.gravitino.EntityAlreadyExistsException;
-import com.datastrato.gravitino.utils.Executable;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.List;
@@ -70,22 +69,4 @@ public interface KvBackend extends Closeable {
    * @throws IOException If an I/O exception occurs during scanning.
    */
   List<Pair<byte[], byte[]>> scan(KvRangeScan scanRange) throws IOException;
-
-  /**
-   * Executes a transactional operation on the KV backend.
-   *
-   * <p>NOTE: Some backends may not support transactions, in which case this method should throw an
-   * UnsupportedOperationException.
-   *
-   * @param executable The executable operation to perform transactionally.
-   * @param <R> The type of the result.
-   * @param <E> The type of exception that the executable may throw.
-   * @return The result of the transactional operation.
-   * @throws E If the executable throws an exception.
-   * @throws IOException If an I/O exception occurs during the transaction.
-   */
-  default <R, E extends Exception> R executeInTransaction(Executable<R, E> executable)
-      throws E, IOException {
-    throw new UnsupportedOperationException("Transaction not supported");
-  }
 }


### PR DESCRIPTION


### What changes were proposed in this pull request?

Remove method `executeInTransaction` in interface `KvBackend`.

### Why are the changes needed?

Method `executeInTransaction` will not be used and we will not support it in the future. 

Fix: #732 

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Minor changes, existing UTs can cover it. 
