### PR TITLE
[MINOR] docs: Fix the docker image version which is used for integration-tests

### DIFF
--- a/docs/integration-test.md
+++ b/docs/integration-test.md
@@ -90,7 +90,7 @@ Before running the tests, make sure Docker is installed.
 
 #### Running Gravitino Hive CI Docker Environment
 
-1. Run a hive docker test environment container locally using the `docker run --rm -d -p 8022:22 -p 8088:8088 -p 9000:9000 -p 9083:9083 -p 10000:10000 -p 10002:10002 -p 50010:50010 -p 50070:50070 -p 50075:50075 datastrato/gravitino-ci-hive` command.
+1. Run a hive docker test environment container locally using the `docker run --rm -d -p 8022:22 -p 8088:8088 -p 9000:9000 -p 9083:9083 -p 10000:10000 -p 10002:10002 -p 50010:50010 -p 50070:50070 -p 50075:50075 datastrato/gravitino-ci-hive:0.1.4` command.
 
 The Gravitino server and Docker runtime environments will also use certain ports. Ensure that these ports are not already in use:
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix the docker image version which is used for integration-tests

### Why are the changes needed?
I fail to run the integration-tests with the latest version docker image, so I update the version aligned to the one which CI uses.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Just docs