### PR TITLE
[#880](integrate-test): Fix compile error when git is not installed.

### DIFF
--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/util/AbstractIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/util/AbstractIT.java
@@ -43,7 +43,7 @@ public class AbstractIT {
 
   protected static Config serverConfig;
 
-  static String testMode = "";
+  public static String testMode = "";
 
   protected static Map<String, String> customConfigs = new HashMap<>();
 

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/rest/AuthenticationOperationsIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/rest/AuthenticationOperationsIT.java
@@ -12,6 +12,7 @@ import com.datastrato.gravitino.client.ErrorHandlers;
 import com.datastrato.gravitino.client.HTTPClient;
 import com.datastrato.gravitino.dto.responses.VersionResponse;
 import com.datastrato.gravitino.integration.test.util.AbstractIT;
+import com.datastrato.gravitino.integration.test.util.ITUtils;
 import com.datastrato.gravitino.json.JsonUtils;
 import com.datastrato.gravitino.server.auth.OAuthConfig;
 import com.datastrato.gravitino.server.web.JettyServerConfig;
@@ -80,8 +81,11 @@ public class AuthenticationOperationsIT extends AbstractIT {
       Assertions.assertEquals(System.getenv("PROJECT_VERSION"), version);
       Assertions.assertFalse(compileDate.isEmpty());
 
-      final String gitCommitId = readGitCommitIdFromGitFile();
-      Assertions.assertEquals(gitCommitId, respGitCommit);
+      // Only in embedded will we have the git commit id.
+      if (testMode.equals(ITUtils.EMBEDDED_TEST_MODE)) {
+        final String gitCommitId = readGitCommitIdFromGitFile();
+        Assertions.assertEquals(gitCommitId, respGitCommit);
+      }
     }
   }
 }

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/rest/VersionOperationsIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/rest/VersionOperationsIT.java
@@ -6,6 +6,7 @@ package com.datastrato.gravitino.integration.test.web.rest;
 
 import com.datastrato.gravitino.client.GravitinoVersion;
 import com.datastrato.gravitino.integration.test.util.AbstractIT;
+import com.datastrato.gravitino.integration.test.util.ITUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -15,7 +16,9 @@ public class VersionOperationsIT extends AbstractIT {
     GravitinoVersion gravitinoVersion = client.getVersion();
     Assertions.assertEquals(System.getenv("PROJECT_VERSION"), gravitinoVersion.version());
     Assertions.assertFalse(gravitinoVersion.compileDate().isEmpty());
-    final String gitCommitId = readGitCommitIdFromGitFile();
-    Assertions.assertEquals(gitCommitId, gravitinoVersion.gitCommit());
+    if (testMode.equals(ITUtils.EMBEDDED_TEST_MODE)) {
+      final String gitCommitId = readGitCommitIdFromGitFile();
+      Assertions.assertEquals(gitCommitId, gravitinoVersion.gitCommit());
+    }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Only run some git-related tests when git is installed.

### Why are the changes needed?

Developers and users may download the source code NOT via `git` and git was not installed locally, we need to 
consider and handle this scenario.

Fix: #880 

### Does this PR introduce _any_ user-facing change?

No
### How was this patch tested?

No