### PR TITLE
[#894] feat(hive): The `updateColumnNullability` in the Hive catalog clearly failed

### DIFF
--- a/catalogs/catalog-hive/src/main/java/com/datastrato/gravitino/catalog/hive/HiveCatalogOperations.java
+++ b/catalogs/catalog-hive/src/main/java/com/datastrato/gravitino/catalog/hive/HiveCatalogOperations.java
@@ -475,6 +475,11 @@ public class HiveCatalogOperations implements CatalogOperations, SupportsSchemas
                       || !partitionFields.contains(fieldToAdd),
                   "Cannot alter partition column: " + fieldToAdd);
 
+              if (c instanceof TableChange.UpdateColumnNullability) {
+                throw new IllegalArgumentException(
+                    "Hive does not support altering column nullability");
+              }
+
               if (c instanceof TableChange.UpdateColumnPosition
                   && afterPartitionColumn(
                       partitionFields, ((TableChange.UpdateColumnPosition) c).getPosition())) {

--- a/catalogs/catalog-hive/src/test/java/com/datastrato/gravitino/catalog/hive/TestHiveTable.java
+++ b/catalogs/catalog-hive/src/test/java/com/datastrato/gravitino/catalog/hive/TestHiveTable.java
@@ -501,6 +501,18 @@ public class TestHiveTable extends MiniHiveMetastoreService {
                             TableChange.ColumnPosition.after(col1.name()))));
     Assertions.assertTrue(exception.getMessage().contains("Cannot add column with duplicate name"));
 
+    exception =
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                hiveCatalog
+                    .asTableCatalog()
+                    .alterTable(
+                        tableIdentifier,
+                        TableChange.updateColumnNullability(new String[] {"col_1"}, false)));
+    Assertions.assertEquals(
+        "Hive does not support altering column nullability", exception.getMessage());
+
     // test alter
     hiveCatalog
         .asTableCatalog()


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add clear error message for `updateColumnNullability` in the Hive catalog

### Why are the changes needed?
Since Hive does not support change column nullability, we should offer more clearly message for user.

Fix: #894 

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
UT added
