### PR TITLE
[#910] fix(iceberg):  Iceberg integrate test failed with new docker envriment

### DIFF
--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/lakehouse/iceberg/CatalogIcebergIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/lakehouse/iceberg/CatalogIcebergIT.java
@@ -105,6 +105,7 @@ public class CatalogIcebergIT extends AbstractIT {
 
   @BeforeAll
   public static void startup() {
+    containerSuite.startHiveContainer();
     HIVE_METASTORE_URIS =
         String.format(
             "thrift://%s:%d",

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/lakehouse/iceberg/IcebergRESTServiceBaseIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/lakehouse/iceberg/IcebergRESTServiceBaseIT.java
@@ -49,6 +49,7 @@ public class IcebergRESTServiceBaseIT extends AbstractIT {
 
   @BeforeAll
   void initIcebergTestEnv() throws Exception {
+    containerSuite.startHiveContainer();
     registerIcebergCatalogConfig();
     AbstractIT.startIntegrationTest();
     initSparkEnv();


### PR DESCRIPTION
### What changes were proposed in this pull request?
start docker in IcebergIT

### Why are the changes needed?
Fix: #910 

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
./gradlew :integration-test:test --tests "com.datastrato.gravitino.integration.test.catalog.lakehouse.iceberg.*"


