### PR TITLE
[#547] fix(lakehouse-iceberg): purge table may hang in Iceberg REST server IT with hdfs configurations

### DIFF
--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/lakehouse/iceberg/IcebergRESTServiceBaseIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/lakehouse/iceberg/IcebergRESTServiceBaseIT.java
@@ -222,6 +222,8 @@ public class IcebergRESTServiceBaseIT extends AbstractIT {
             .config("spark.sql.catalog.rest", "org.apache.iceberg.spark.SparkCatalog")
             .config("spark.sql.catalog.rest.type", "rest")
             .config("spark.sql.catalog.rest.uri", IcebergRESTUri)
+            // drop Iceberg table purge may hang in spark local mode
+            .config("spark.locality.wait.node", "0")
             .getOrCreate();
   }
 

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/lakehouse/iceberg/IcebergRESTServiceIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/lakehouse/iceberg/IcebergRESTServiceIT.java
@@ -48,15 +48,13 @@ public class IcebergRESTServiceIT extends IcebergRESTServiceBaseIT {
     purgeAllIcebergTestNamespaces();
   }
 
-  // Spark purge Iceberg table may hang, so use drop table instead
-  // https://github.com/datastrato/gravitino/issues/547 tracks purge table issue
-  private void dropTable(String namespace, String table) {
-    sql(String.format("DROP TABLE %s.%s", namespace, table));
+  private void purgeTable(String namespace, String table) {
+    sql(String.format("DROP TABLE %s.%s PURGE", namespace, table));
   }
 
   private void purgeNameSpace(String namespace) {
     Set<String> tables = convertToStringSet(sql("SHOW TABLES IN " + namespace), 1);
-    tables.forEach(table -> dropTable(namespace, table));
+    tables.forEach(table -> purgeTable(namespace, table));
     sql("DROP database " + namespace);
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
disable Spark task  level node delay schedule to pass purge table
see more: https://github.com/apache/iceberg/issues/9180

### Why are the changes needed?
Fix: #547 

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
UT
