### PR TITLE
[MINOR]fix(IT): Ignore the MySQL IT if docker is not started

### DIFF
--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/mysql/TestMysqlAbstractIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/mysql/TestMysqlAbstractIT.java
@@ -2,7 +2,7 @@
  * Copyright 2023 Datastrato.
  * This software is licensed under the Apache License version 2.
  */
-package com.datastrato.gravitino.integration.test.catalog.mysql.operation;
+package com.datastrato.gravitino.integration.test.catalog.jdbc.mysql;
 
 import com.datastrato.gravitino.catalog.jdbc.config.JdbcConfig;
 import com.datastrato.gravitino.catalog.jdbc.utils.DataSourceUtils;
@@ -15,9 +15,11 @@ import javax.sql.DataSource;
 import org.apache.commons.lang3.RandomUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.shaded.com.google.common.collect.Maps;
 
+@Tag("gravitino-docker-it")
 public class TestMysqlAbstractIT {
 
   private static MySQLContainer<?> MYSQL_CONTAINER;

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/mysql/TestMysqlDatabaseOperations.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/mysql/TestMysqlDatabaseOperations.java
@@ -2,7 +2,7 @@
  * Copyright 2023 Datastrato.
  * This software is licensed under the Apache License version 2.
  */
-package com.datastrato.gravitino.integration.test.catalog.mysql.operation;
+package com.datastrato.gravitino.integration.test.catalog.jdbc.mysql;
 
 import com.datastrato.gravitino.catalog.jdbc.JdbcSchema;
 import com.datastrato.gravitino.exceptions.NoSuchSchemaException;
@@ -11,8 +11,10 @@ import java.util.List;
 import java.util.Map;
 import org.apache.commons.lang3.RandomUtils;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+@Tag("gravitino-docker-it")
 public class TestMysqlDatabaseOperations extends TestMysqlAbstractIT {
 
   @Test

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/mysql/TestMysqlTableOperations.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/mysql/TestMysqlTableOperations.java
@@ -2,7 +2,7 @@
  * Copyright 2023 Datastrato.
  * This software is licensed under the Apache License version 2.
  */
-package com.datastrato.gravitino.integration.test.catalog.mysql.operation;
+package com.datastrato.gravitino.integration.test.catalog.jdbc.mysql;
 
 import static com.datastrato.gravitino.catalog.mysql.operation.MysqlTableOperations.AUTO_INCREMENT;
 import static com.datastrato.gravitino.catalog.mysql.operation.MysqlTableOperations.PRIMARY_KEY;
@@ -20,8 +20,10 @@ import java.util.List;
 import java.util.Map;
 import org.apache.commons.lang3.RandomUtils;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+@Tag("gravitino-docker-it")
 public class TestMysqlTableOperations extends TestMysqlAbstractIT {
 
   private static Type VARCHAR = Types.VarCharType.of(255);


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to add tag to ignore jdbc-mysql IT if docker is not running. Also renaming the package.

### Why are the changes needed?

IT will be failed if docker is not running.

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

N/A
