### PR TITLE
[#923] improvement(core): Change the prefix of key that stores storage layout version.

### DIFF
--- a/core/src/main/java/com/datastrato/gravitino/storage/kv/KvEntityStore.java
+++ b/core/src/main/java/com/datastrato/gravitino/storage/kv/KvEntityStore.java
@@ -61,7 +61,9 @@ public class KvEntityStore implements EntityStore {
   public static final Logger LOGGER = LoggerFactory.getLogger(KvEntityStore.class);
   public static final ImmutableMap<String, String> KV_BACKENDS =
       ImmutableMap.of("RocksDBKvBackend", RocksDBKvBackend.class.getCanonicalName());
-  public static final String LAYOUT_VERSION = "layout_version";
+  public static final byte[] LAYOUT_VERSION_KEY =
+      Bytes.concat(
+          new byte[] {0x1D, 0x00, 0x02}, "layout_version".getBytes(StandardCharsets.UTF_8));
 
   @Getter @VisibleForTesting private KvBackend backend;
 
@@ -431,11 +433,11 @@ public class KvEntityStore implements EntityStore {
   private StorageLayoutVersion initStorageVersionInfo() {
     byte[] bytes;
     try {
-      bytes = backend.get(LAYOUT_VERSION.getBytes(StandardCharsets.UTF_8));
+      bytes = backend.get(LAYOUT_VERSION_KEY);
       if (bytes == null) {
         // If the layout version is not set, we will set it to the default version.
         backend.put(
-            LAYOUT_VERSION.getBytes(StandardCharsets.UTF_8),
+            LAYOUT_VERSION_KEY,
             StorageLayoutVersion.V1.getVersion().getBytes(StandardCharsets.UTF_8),
             true);
         return StorageLayoutVersion.V1;

--- a/core/src/main/java/com/datastrato/gravitino/storage/kv/KvGarbageCollector.java
+++ b/core/src/main/java/com/datastrato/gravitino/storage/kv/KvGarbageCollector.java
@@ -104,6 +104,8 @@ public final class KvGarbageCollector implements Closeable {
 
     LOG.info("Start to remove {} uncommitted data", kvs.size());
     for (Pair<byte[], byte[]> pair : kvs) {
+      // Remove is a high-risk operation, So we log every delete operation
+      LOG.info("Remove uncommitted data: Key {}", Bytes.wrap(pair.getKey()));
       kvBackend.delete(pair.getKey());
     }
   }
@@ -173,7 +175,7 @@ public final class KvGarbageCollector implements Closeable {
           // Has a newer version, we can remove it.
           LOG.info(
               "Physically delete key that has newer version: {}, a newer version {}",
-              Bytes.wrap(key),
+              Bytes.wrap(rawKey),
               Bytes.wrap(newVersionOfKey.get(0).getKey()));
           kvBackend.delete(rawKey);
           keysDeletedCount++;

--- a/rfc/rfc-3/Transaction-implementation-on-kv.md
+++ b/rfc/rfc-3/Transaction-implementation-on-kv.md
@@ -120,7 +120,8 @@ Scan and range query are almost the same as that of read process, for more detai
 
 ## Key format after this modification
 
-- Key starts with 0x'1D0000' store the contents of id-name mapping. for more please refer to class `KvNameMappingService`.
-- Key starts with 0x'1D0001' stores the data of current timestamp which is used for generating transaction id, for more please refer to class `TransactionIdGeneratorImpl`.
-- Key starts with 0x'1E' stores transaction marks.
-- Other key spaces are used to store gravitino entities like `metalakes`,`catalogs`, `scheams`, `tables` and so on.   
+- Keys that start with 0x'1D0000' store the contents of id-name mapping. for more please refer to class `KvNameMappingService`.
+- Keys that start with 0x'1D0001' store the data of current timestamp which is used for generating transaction id, for more please refer to class `TransactionIdGeneratorImpl`.
+- Keys that start with 0x'1D0002' store the information of storage layout version. For more please refer to `KvEntityStore#initStorageVersionInfo`
+- Keys that start with 0x'1E' store transaction marks which mark the transaction is committed or not.
+- Other key spaces are used to store gravitino entities like `metalakes`,`catalogs`, `scheams`, `tables` and so on. it usually starts with from 0x'20'(space) to 0x'7F'(delete). For more please refer to class `KvEntityStoreImpl`.


### PR DESCRIPTION
### What changes were proposed in this pull request?

- Change the prefix of the key that stores the version of storage layout information. 
- Add some log in class `KvGarbageCollector`

### Why are the changes needed?

Make the key format more standardized and user-friendly.


Fix: #923 

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

N/A
