### PR TITLE
[#930] Add Hive and Hdfs client test in the HiveContainer

### DIFF
--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/trino/TrinoConnectorIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/trino/TrinoConnectorIT.java
@@ -361,6 +361,7 @@ public class TrinoConnectorIT extends AbstractIT {
             "comment",
             properties);
     Catalog loadCatalog = metalake.loadCatalog(NameIdentifier.of(metalakeName, catalogName));
+    Assertions.assertEquals(createdCatalog, loadCatalog);
 
     catalog = loadCatalog;
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

1. Use Hive Client to connect Hive Sever get all databases and check it.
2. Use HDFS Client to connect HDFS server list root directory and check it.

This PR will make the IT test case stronger.

### Why are the changes needed?

Fix: #930 

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

CI
