### PR TITLE
[#897] fix: Unify parameter name of fieldName and fieldNames

### DIFF
--- a/api/src/main/java/com/datastrato/gravitino/rel/TableChange.java
+++ b/api/src/main/java/com/datastrato/gravitino/rel/TableChange.java
@@ -80,12 +80,12 @@ public interface TableChange {
    * If the new field is nested and its parent does not exist or is not a struct, the change will
    * result in an {@link IllegalArgumentException}.
    *
-   * @param fieldNames The field names of the new column.
+   * @param fieldName The field name of the new column.
    * @param dataType The new column's data type.
    * @return A TableChange for the addition.
    */
-  static TableChange addColumn(String[] fieldNames, Type dataType) {
-    return new AddColumn(fieldNames, dataType, null, null, true);
+  static TableChange addColumn(String[] fieldName, Type dataType) {
+    return new AddColumn(fieldName, dataType, null, null, true);
   }
 
   /**
@@ -95,13 +95,13 @@ public interface TableChange {
    * If the new field is nested and its parent does not exist or is not a struct, the change will
    * result in an {@link IllegalArgumentException}.
    *
-   * @param fieldNames The field names of the new column.
+   * @param fieldName The field name of the new column.
    * @param dataType The new column's data type.
    * @param comment The new field's comment string.
    * @return A TableChange for the addition.
    */
-  static TableChange addColumn(String[] fieldNames, Type dataType, String comment) {
-    return new AddColumn(fieldNames, dataType, comment, null, true);
+  static TableChange addColumn(String[] fieldName, Type dataType, String comment) {
+    return new AddColumn(fieldName, dataType, comment, null, true);
   }
 
   /**
@@ -111,13 +111,13 @@ public interface TableChange {
    * If the new field is nested and its parent does not exist or is not a struct, the change will
    * result in an {@link IllegalArgumentException}.
    *
-   * @param fieldNames The field names of the new column.
+   * @param fieldName The field name of the new column.
    * @param dataType The new column's data type.
    * @param position The new column's position.
    * @return A TableChange for the addition.
    */
-  static TableChange addColumn(String[] fieldNames, Type dataType, ColumnPosition position) {
-    return new AddColumn(fieldNames, dataType, null, position, true);
+  static TableChange addColumn(String[] fieldName, Type dataType, ColumnPosition position) {
+    return new AddColumn(fieldName, dataType, null, position, true);
   }
 
   /**
@@ -127,15 +127,15 @@ public interface TableChange {
    * If the new field is nested and its parent does not exist or is not a struct, the change will
    * result in an {@link IllegalArgumentException}.
    *
-   * @param fieldNames Field names of the new column.
+   * @param fieldName Field name of the new column.
    * @param dataType The new column's data type.
    * @param comment The new field's comment string.
    * @param position The new column's position.
    * @return A TableChange for the addition.
    */
   static TableChange addColumn(
-      String[] fieldNames, Type dataType, String comment, ColumnPosition position) {
-    return new AddColumn(fieldNames, dataType, comment, position, true);
+      String[] fieldName, Type dataType, String comment, ColumnPosition position) {
+    return new AddColumn(fieldName, dataType, comment, position, true);
   }
 
   /**
@@ -145,27 +145,27 @@ public interface TableChange {
    * If the new field is nested and its parent does not exist or is not a struct, the change will
    * result in an {@link IllegalArgumentException}.
    *
-   * @param fieldNames Field names of the new column.
+   * @param fieldName Field name of the new column.
    * @param dataType The new column's data type.
    * @param nullable The new column's nullable.
    * @return A TableChange for the addition.
    */
-  static TableChange addColumn(String[] fieldNames, Type dataType, boolean nullable) {
-    return new AddColumn(fieldNames, dataType, null, null, nullable);
+  static TableChange addColumn(String[] fieldName, Type dataType, boolean nullable) {
+    return new AddColumn(fieldName, dataType, null, null, nullable);
   }
 
   /**
    * Create a TableChange for adding a column.
    *
-   * @param fieldNames Field names of the new column.
+   * @param fieldName Field name of the new column.
    * @param dataType The new column's data type.
    * @param comment The new field's comment string.
    * @param nullable The new column's nullable.
    * @return A TableChange for the addition.
    */
   static TableChange addColumn(
-      String[] fieldNames, Type dataType, String comment, boolean nullable) {
-    return new AddColumn(fieldNames, dataType, comment, null, nullable);
+      String[] fieldName, Type dataType, String comment, boolean nullable) {
+    return new AddColumn(fieldName, dataType, comment, null, nullable);
   }
 
   /**
@@ -175,7 +175,7 @@ public interface TableChange {
    * If the new field is nested and its parent does not exist or is not a struct, the change will
    * result in an {@link IllegalArgumentException}.
    *
-   * @param fieldNames Field names of the new column.
+   * @param fieldName Field name of the new column.
    * @param dataType The new column's data type.
    * @param comment The new field's comment string.
    * @param position The new column's position.
@@ -183,12 +183,12 @@ public interface TableChange {
    * @return A TableChange for the addition.
    */
   static TableChange addColumn(
-      String[] fieldNames,
+      String[] fieldName,
       Type dataType,
       String comment,
       ColumnPosition position,
       boolean nullable) {
-    return new AddColumn(fieldNames, dataType, comment, position, nullable);
+    return new AddColumn(fieldName, dataType, comment, position, nullable);
   }
 
   /**
@@ -199,27 +199,27 @@ public interface TableChange {
    *
    * <p>If the field does not exist, the change will result in an {@link IllegalArgumentException}.
    *
-   * @param fieldNames The current field names.
+   * @param fieldName The current field name.
    * @param newName The new name.
    * @return A TableChange for the rename.
    */
-  static TableChange renameColumn(String[] fieldNames, String newName) {
-    return new RenameColumn(fieldNames, newName);
+  static TableChange renameColumn(String[] fieldName, String newName) {
+    return new RenameColumn(fieldName, newName);
   }
 
   /**
    * Create a TableChange for updating the type of a field that is nullable.
    *
-   * <p>The field names are used to find the field to update.
+   * <p>The field name are used to find the field to update.
    *
    * <p>If the field does not exist, the change will result in an {@link IllegalArgumentException}.
    *
-   * @param fieldNames The field names of the column to update.
+   * @param fieldName The field name of the column to update.
    * @param newDataType The new data type.
    * @return A TableChange for the update.
    */
-  static TableChange updateColumnType(String[] fieldNames, Type newDataType) {
-    return new UpdateColumnType(fieldNames, newDataType);
+  static TableChange updateColumnType(String[] fieldName, Type newDataType) {
+    return new UpdateColumnType(fieldName, newDataType);
   }
 
   /**
@@ -229,12 +229,12 @@ public interface TableChange {
    *
    * <p>If the field does not exist, the change will result in an {@link IllegalArgumentException}.
    *
-   * @param fieldNames The field names of the column to update.
+   * @param fieldName The field name of the column to update.
    * @param newComment The new comment.
    * @return A TableChange for the update.
    */
-  static TableChange updateColumnComment(String[] fieldNames, String newComment) {
-    return new UpdateColumnComment(fieldNames, newComment);
+  static TableChange updateColumnComment(String[] fieldName, String newComment) {
+    return new UpdateColumnComment(fieldName, newComment);
   }
 
   /**
@@ -244,12 +244,12 @@ public interface TableChange {
    *
    * <p>If the field does not exist, the change will result in an {@link IllegalArgumentException}.
    *
-   * @param fieldNames The field names of the column to update.
+   * @param fieldName The field name of the column to update.
    * @param newPosition The new position.
    * @return A TableChange for the update.
    */
-  static TableChange updateColumnPosition(String[] fieldNames, ColumnPosition newPosition) {
-    return new UpdateColumnPosition(fieldNames, newPosition);
+  static TableChange updateColumnPosition(String[] fieldName, ColumnPosition newPosition) {
+    return new UpdateColumnPosition(fieldName, newPosition);
   }
 
   /**
@@ -258,13 +258,13 @@ public interface TableChange {
    * <p>If the field does not exist, the change will result in an {@link IllegalArgumentException}
    * unless {@code ifExists} is true.
    *
-   * @param fieldNames Field names of the column to delete.
+   * @param fieldName Field name of the column to delete.
    * @param ifExists If true, silence the error if column does not exist during drop. Otherwise, an
    *     {@link IllegalArgumentException} will be thrown.
    * @return A TableChange for the delete.
    */
-  static TableChange deleteColumn(String[] fieldNames, Boolean ifExists) {
-    return new DeleteColumn(fieldNames, ifExists);
+  static TableChange deleteColumn(String[] fieldName, Boolean ifExists) {
+    return new DeleteColumn(fieldName, ifExists);
   }
 
   /**
@@ -274,12 +274,12 @@ public interface TableChange {
    *
    * <p>If the field does not exist, the change will result in an {@link IllegalArgumentException}.
    *
-   * @param fieldNames The field names of the column to update.
+   * @param fieldName The field name of the column to update.
    * @param nullable The new nullability.
    * @return A TableChange for the update.
    */
-  static TableChange updateColumnNullability(String[] fieldNames, boolean nullable) {
-    return new UpdateColumnNullability(fieldNames, nullable);
+  static TableChange updateColumnNullability(String[] fieldName, boolean nullable) {
+    return new UpdateColumnNullability(fieldName, nullable);
   }
 
   /** A TableChange to rename a table. */
@@ -385,7 +385,7 @@ public interface TableChange {
   }
 
   interface ColumnChange extends TableChange {
-    String[] fieldNames();
+    String[] fieldName();
   }
 
   /**
@@ -399,7 +399,7 @@ public interface TableChange {
    */
   @EqualsAndHashCode
   final class AddColumn implements ColumnChange {
-    private final String[] fieldNames;
+    private final String[] fieldName;
 
     @Getter private final Type dataType;
 
@@ -410,12 +410,12 @@ public interface TableChange {
     @Getter private final boolean nullable;
 
     private AddColumn(
-        String[] fieldNames,
+        String[] fieldName,
         Type dataType,
         String comment,
         ColumnPosition position,
         boolean nullable) {
-      this.fieldNames = fieldNames;
+      this.fieldName = fieldName;
       this.dataType = dataType;
       this.comment = comment;
       this.position = position;
@@ -423,8 +423,8 @@ public interface TableChange {
     }
 
     @Override
-    public String[] fieldNames() {
-      return fieldNames;
+    public String[] fieldName() {
+      return fieldName;
     }
   }
 
@@ -438,18 +438,18 @@ public interface TableChange {
    */
   @EqualsAndHashCode
   final class RenameColumn implements ColumnChange {
-    private final String[] fieldNames;
+    private final String[] fieldName;
 
     @Getter private final String newName;
 
-    private RenameColumn(String[] fieldNames, String newName) {
-      this.fieldNames = fieldNames;
+    private RenameColumn(String[] fieldName, String newName) {
+      this.fieldName = fieldName;
       this.newName = newName;
     }
 
     @Override
-    public String[] fieldNames() {
-      return fieldNames;
+    public String[] fieldName() {
+      return fieldName;
     }
   }
 
@@ -462,18 +462,18 @@ public interface TableChange {
    */
   @EqualsAndHashCode
   final class UpdateColumnType implements ColumnChange {
-    private final String[] fieldNames;
+    private final String[] fieldName;
 
     @Getter private final Type newDataType;
 
-    private UpdateColumnType(String[] fieldNames, Type newDataType) {
-      this.fieldNames = fieldNames;
+    private UpdateColumnType(String[] fieldName, Type newDataType) {
+      this.fieldName = fieldName;
       this.newDataType = newDataType;
     }
 
     @Override
-    public String[] fieldNames() {
-      return fieldNames;
+    public String[] fieldName() {
+      return fieldName;
     }
   }
 
@@ -486,18 +486,18 @@ public interface TableChange {
    */
   @EqualsAndHashCode
   final class UpdateColumnComment implements ColumnChange {
-    private final String[] fieldNames;
+    private final String[] fieldName;
 
     @Getter private final String newComment;
 
-    private UpdateColumnComment(String[] fieldNames, String newComment) {
-      this.fieldNames = fieldNames;
+    private UpdateColumnComment(String[] fieldName, String newComment) {
+      this.fieldName = fieldName;
       this.newComment = newComment;
     }
 
     @Override
-    public String[] fieldNames() {
-      return fieldNames;
+    public String[] fieldName() {
+      return fieldName;
     }
   }
 
@@ -510,18 +510,18 @@ public interface TableChange {
    */
   @EqualsAndHashCode
   final class UpdateColumnPosition implements ColumnChange {
-    private final String[] fieldNames;
+    private final String[] fieldName;
 
     @Getter private final ColumnPosition position;
 
-    private UpdateColumnPosition(String[] fieldNames, ColumnPosition position) {
-      this.fieldNames = fieldNames;
+    private UpdateColumnPosition(String[] fieldName, ColumnPosition position) {
+      this.fieldName = fieldName;
       this.position = position;
     }
 
     @Override
-    public String[] fieldNames() {
-      return fieldNames;
+    public String[] fieldName() {
+      return fieldName;
     }
   }
 
@@ -532,18 +532,18 @@ public interface TableChange {
    */
   @EqualsAndHashCode
   final class DeleteColumn implements ColumnChange {
-    private final String[] fieldNames;
+    private final String[] fieldName;
 
     @Getter private final Boolean ifExists;
 
-    private DeleteColumn(String[] fieldNames, Boolean ifExists) {
-      this.fieldNames = fieldNames;
+    private DeleteColumn(String[] fieldName, Boolean ifExists) {
+      this.fieldName = fieldName;
       this.ifExists = ifExists;
     }
 
     @Override
-    public String[] fieldNames() {
-      return fieldNames;
+    public String[] fieldName() {
+      return fieldName;
     }
   }
 
@@ -555,18 +555,18 @@ public interface TableChange {
    * <p>If the field does not exist, the change must result in an {@link IllegalArgumentException}.
    */
   final class UpdateColumnNullability implements ColumnChange {
-    private final String[] fieldNames;
+    private final String[] fieldName;
 
     private final boolean nullable;
 
-    private UpdateColumnNullability(String[] fieldNames, boolean nullable) {
-      this.fieldNames = fieldNames;
+    private UpdateColumnNullability(String[] fieldName, boolean nullable) {
+      this.fieldName = fieldName;
       this.nullable = nullable;
     }
 
     @Override
-    public String[] fieldNames() {
-      return fieldNames;
+    public String[] fieldName() {
+      return fieldName;
     }
 
     public boolean nullable() {
@@ -582,13 +582,13 @@ public interface TableChange {
         return false;
       }
       UpdateColumnNullability that = (UpdateColumnNullability) o;
-      return nullable == that.nullable && Arrays.equals(fieldNames, that.fieldNames);
+      return nullable == that.nullable && Arrays.equals(fieldName, that.fieldName);
     }
 
     @Override
     public int hashCode() {
       int result = Objects.hash(nullable);
-      result = 31 * result + Arrays.hashCode(fieldNames);
+      result = 31 * result + Arrays.hashCode(fieldName);
       return result;
     }
   }

--- a/api/src/test/java/com/datastrato/gravitino/TestTableChange.java
+++ b/api/src/test/java/com/datastrato/gravitino/TestTableChange.java
@@ -67,12 +67,12 @@ public class TestTableChange {
 
   @Test
   public void testAddColumn() {
-    String[] fieldNames = {"Name"};
+    String[] fieldName = {"Name"};
     Type dataType = Types.StringType.get();
     String comment = "Person name";
-    AddColumn addColumn = (AddColumn) TableChange.addColumn(fieldNames, dataType, comment);
+    AddColumn addColumn = (AddColumn) TableChange.addColumn(fieldName, dataType, comment);
 
-    assertArrayEquals(fieldNames, addColumn.fieldNames());
+    assertArrayEquals(fieldName, addColumn.fieldName());
     assertEquals(dataType, addColumn.getDataType());
     assertEquals(comment, addColumn.getComment());
     assertNull(addColumn.getPosition());
@@ -80,14 +80,13 @@ public class TestTableChange {
 
   @Test
   public void testAddColumnWithPosition() {
-    String[] fieldNames = {"Full Name", "First Name"};
+    String[] fieldName = {"Full Name", "First Name"};
     Type dataType = Types.StringType.get();
     String comment = "First or given name";
     TableChange.ColumnPosition position = TableChange.ColumnPosition.after("Address");
-    AddColumn addColumn =
-        (AddColumn) TableChange.addColumn(fieldNames, dataType, comment, position);
+    AddColumn addColumn = (AddColumn) TableChange.addColumn(fieldName, dataType, comment, position);
 
-    assertArrayEquals(fieldNames, addColumn.fieldNames());
+    assertArrayEquals(fieldName, addColumn.fieldName());
     assertEquals(dataType, addColumn.getDataType());
     assertEquals(comment, addColumn.getComment());
     assertEquals(position, addColumn.getPosition());
@@ -95,11 +94,11 @@ public class TestTableChange {
 
   @Test
   public void testAddColumnWithNullCommentAndPosition() {
-    String[] fieldNames = {"Middle Name"};
+    String[] fieldName = {"Middle Name"};
     Type dataType = Types.StringType.get();
-    AddColumn addColumn = (AddColumn) TableChange.addColumn(fieldNames, dataType, null, null);
+    AddColumn addColumn = (AddColumn) TableChange.addColumn(fieldName, dataType, null, null);
 
-    assertArrayEquals(fieldNames, addColumn.fieldNames());
+    assertArrayEquals(fieldName, addColumn.fieldName());
     assertEquals(dataType, addColumn.getDataType());
     assertNull(addColumn.getComment());
     assertNull(addColumn.getPosition());
@@ -107,118 +106,117 @@ public class TestTableChange {
 
   @Test
   public void testRenameColumn() {
-    String[] fieldNames = {"Last Name"};
+    String[] fieldName = {"Last Name"};
     String newName = "Family Name";
-    RenameColumn renameColumn = (RenameColumn) TableChange.renameColumn(fieldNames, newName);
+    RenameColumn renameColumn = (RenameColumn) TableChange.renameColumn(fieldName, newName);
 
-    assertArrayEquals(fieldNames, renameColumn.fieldNames());
+    assertArrayEquals(fieldName, renameColumn.fieldName());
     assertEquals(newName, renameColumn.getNewName());
   }
 
   @Test
   public void testRenameNestedColumn() {
-    String[] fieldNames = {"Name", "First Name"};
+    String[] fieldName = {"Name", "First Name"};
     String newName = "Name.first";
-    RenameColumn renameColumn = (RenameColumn) TableChange.renameColumn(fieldNames, newName);
+    RenameColumn renameColumn = (RenameColumn) TableChange.renameColumn(fieldName, newName);
 
-    assertArrayEquals(fieldNames, renameColumn.fieldNames());
+    assertArrayEquals(fieldName, renameColumn.fieldName());
     assertEquals(newName, renameColumn.getNewName());
   }
 
   @Test
   public void testUpdateColumnPosition() {
-    String[] fieldNames = {"First Name"};
+    String[] fieldName = {"First Name"};
     ColumnPosition newPosition = TableChange.ColumnPosition.first();
     UpdateColumnPosition updateColumnPosition =
-        (UpdateColumnPosition) TableChange.updateColumnPosition(fieldNames, newPosition);
+        (UpdateColumnPosition) TableChange.updateColumnPosition(fieldName, newPosition);
 
-    assertArrayEquals(fieldNames, updateColumnPosition.fieldNames());
+    assertArrayEquals(fieldName, updateColumnPosition.fieldName());
     assertEquals(newPosition, updateColumnPosition.getPosition());
   }
 
   @Test
   public void testUpdateNestedColumnPosition() {
-    String[] fieldNames = {"Name", "Last Name"};
+    String[] fieldName = {"Name", "Last Name"};
     ColumnPosition newPosition = TableChange.ColumnPosition.after("First Name");
     UpdateColumnPosition updateColumnPosition =
-        (UpdateColumnPosition) TableChange.updateColumnPosition(fieldNames, newPosition);
+        (UpdateColumnPosition) TableChange.updateColumnPosition(fieldName, newPosition);
 
-    assertArrayEquals(fieldNames, updateColumnPosition.fieldNames());
+    assertArrayEquals(fieldName, updateColumnPosition.fieldName());
     assertEquals(newPosition, updateColumnPosition.getPosition());
   }
 
   @Test
   public void testUpdateColumnComment() {
-    String[] fieldNames = {"First Name"};
+    String[] fieldName = {"First Name"};
     String newComment = "First or given name";
     UpdateColumnComment updateColumnComment =
-        (UpdateColumnComment) TableChange.updateColumnComment(fieldNames, newComment);
+        (UpdateColumnComment) TableChange.updateColumnComment(fieldName, newComment);
 
-    assertArrayEquals(fieldNames, updateColumnComment.fieldNames());
+    assertArrayEquals(fieldName, updateColumnComment.fieldName());
     assertEquals(newComment, updateColumnComment.getNewComment());
   }
 
   @Test
   public void testUpdateNestedColumnComment() {
-    String[] fieldNames = {"Name", "Last Name"};
+    String[] fieldName = {"Name", "Last Name"};
     String newComment = "Last or family name";
     UpdateColumnComment updateColumnComment =
-        (UpdateColumnComment) TableChange.updateColumnComment(fieldNames, newComment);
+        (UpdateColumnComment) TableChange.updateColumnComment(fieldName, newComment);
 
-    assertArrayEquals(fieldNames, updateColumnComment.fieldNames());
+    assertArrayEquals(fieldName, updateColumnComment.fieldName());
     assertEquals(newComment, updateColumnComment.getNewComment());
   }
 
   @Test
   public void testDeleteColumn() {
-    String[] fieldNames = {"existing_column"};
+    String[] fieldName = {"existing_column"};
     Boolean ifExists = true;
-    DeleteColumn deleteColumn = (DeleteColumn) TableChange.deleteColumn(fieldNames, ifExists);
+    DeleteColumn deleteColumn = (DeleteColumn) TableChange.deleteColumn(fieldName, ifExists);
 
-    assertArrayEquals(fieldNames, deleteColumn.fieldNames());
+    assertArrayEquals(fieldName, deleteColumn.fieldName());
     assertEquals(ifExists, deleteColumn.getIfExists());
   }
 
   @Test
   public void testDeleteNestedColumn() {
-    String[] fieldNames = {"nested", "existing_column"};
+    String[] fieldName = {"nested", "existing_column"};
     Boolean ifExists = false;
-    DeleteColumn deleteColumn = (DeleteColumn) TableChange.deleteColumn(fieldNames, ifExists);
+    DeleteColumn deleteColumn = (DeleteColumn) TableChange.deleteColumn(fieldName, ifExists);
 
-    assertArrayEquals(fieldNames, deleteColumn.fieldNames());
+    assertArrayEquals(fieldName, deleteColumn.fieldName());
     assertEquals(ifExists, deleteColumn.getIfExists());
   }
 
   @Test
   public void testUpdateColumnNullability() {
-    String[] fieldNames = {"existing_column"};
+    String[] fieldName = {"existing_column"};
     TableChange.UpdateColumnNullability updateColumnType =
-        (TableChange.UpdateColumnNullability)
-            TableChange.updateColumnNullability(fieldNames, false);
+        (TableChange.UpdateColumnNullability) TableChange.updateColumnNullability(fieldName, false);
 
-    assertArrayEquals(fieldNames, updateColumnType.fieldNames());
+    assertArrayEquals(fieldName, updateColumnType.fieldName());
     assertFalse(updateColumnType.nullable());
   }
 
   @Test
   public void testUpdateColumnType() {
-    String[] fieldNames = {"existing_column"};
+    String[] fieldName = {"existing_column"};
     Type dataType = Types.StringType.get();
     UpdateColumnType updateColumnType =
-        (UpdateColumnType) TableChange.updateColumnType(fieldNames, dataType);
+        (UpdateColumnType) TableChange.updateColumnType(fieldName, dataType);
 
-    assertArrayEquals(fieldNames, updateColumnType.fieldNames());
+    assertArrayEquals(fieldName, updateColumnType.fieldName());
     assertEquals(dataType, updateColumnType.getNewDataType());
   }
 
   @Test
   public void testUpdateNestedColumnType() {
-    String[] fieldNames = {"nested", "existing_column"};
+    String[] fieldName = {"nested", "existing_column"};
     Type dataType = Types.StringType.get();
     UpdateColumnType updateColumnType =
-        (UpdateColumnType) TableChange.updateColumnType(fieldNames, dataType);
+        (UpdateColumnType) TableChange.updateColumnType(fieldName, dataType);
 
-    assertArrayEquals(fieldNames, updateColumnType.fieldNames());
+    assertArrayEquals(fieldName, updateColumnType.fieldName());
     assertEquals(dataType, updateColumnType.getNewDataType());
   }
 
@@ -443,13 +441,13 @@ public class TestTableChange {
 
   @Test
   void testUpdateColumnPositionEqualsAndHashCode() {
-    String[] fieldNamesA = {"First Name"};
+    String[] fieldNameA = {"First Name"};
     ColumnPosition newPosition = TableChange.ColumnPosition.first();
     UpdateColumnPosition changeA =
-        (UpdateColumnPosition) TableChange.updateColumnPosition(fieldNamesA, newPosition);
-    String[] fieldNamesB = {"First Name"};
+        (UpdateColumnPosition) TableChange.updateColumnPosition(fieldNameA, newPosition);
+    String[] fieldNameB = {"First Name"};
     UpdateColumnPosition changeB =
-        (UpdateColumnPosition) TableChange.updateColumnPosition(fieldNamesB, newPosition);
+        (UpdateColumnPosition) TableChange.updateColumnPosition(fieldNameB, newPosition);
 
     assertTrue(changeA.equals(changeB));
     assertTrue(changeB.equals(changeA));
@@ -458,13 +456,13 @@ public class TestTableChange {
 
   @Test
   void testUpdateColumnPositionNotEqualsAndHashCode() {
-    String[] fieldNamesA = {"First Name"};
+    String[] fieldNameA = {"First Name"};
     ColumnPosition newPosition = TableChange.ColumnPosition.first();
     UpdateColumnPosition changeA =
-        (UpdateColumnPosition) TableChange.updateColumnPosition(fieldNamesA, newPosition);
-    String[] fieldNamesB = {"Last Name"};
+        (UpdateColumnPosition) TableChange.updateColumnPosition(fieldNameA, newPosition);
+    String[] fieldNameB = {"Last Name"};
     UpdateColumnPosition changeB =
-        (UpdateColumnPosition) TableChange.updateColumnPosition(fieldNamesB, newPosition);
+        (UpdateColumnPosition) TableChange.updateColumnPosition(fieldNameB, newPosition);
 
     assertFalse(changeA.equals(null));
     assertFalse(changeA.equals(changeB));
@@ -503,14 +501,14 @@ public class TestTableChange {
 
   @Test
   void testAddColumnEqualsAndHashCode() {
-    String[] fieldNamesA = {"Name"};
+    String[] fieldNameA = {"Name"};
     Type dataTypeA = Types.StringType.get();
     String commentA = "Person name";
-    AddColumn columnA = (AddColumn) TableChange.addColumn(fieldNamesA, dataTypeA, commentA);
-    String[] fieldNamesB = {"Name"};
+    AddColumn columnA = (AddColumn) TableChange.addColumn(fieldNameA, dataTypeA, commentA);
+    String[] fieldNameB = {"Name"};
     Type dataTypeB = Types.StringType.get();
     String commentB = "Person name";
-    AddColumn columnB = (AddColumn) TableChange.addColumn(fieldNamesB, dataTypeB, commentB);
+    AddColumn columnB = (AddColumn) TableChange.addColumn(fieldNameB, dataTypeB, commentB);
 
     assertTrue(columnA.equals(columnB));
     assertTrue(columnB.equals(columnA));
@@ -519,14 +517,14 @@ public class TestTableChange {
 
   @Test
   void testAddColumnNotEqualsAndHashCode() {
-    String[] fieldNamesA = {"Name"};
+    String[] fieldNameA = {"Name"};
     Type dataTypeA = Types.StringType.get();
     String commentA = "Person name";
-    AddColumn columnA = (AddColumn) TableChange.addColumn(fieldNamesA, dataTypeA, commentA);
-    String[] fieldNamesB = {"First Name"};
+    AddColumn columnA = (AddColumn) TableChange.addColumn(fieldNameA, dataTypeA, commentA);
+    String[] fieldNameB = {"First Name"};
     Type dataTypeB = Types.StringType.get();
     String commentB = "Person name";
-    AddColumn columnB = (AddColumn) TableChange.addColumn(fieldNamesB, dataTypeB, commentB);
+    AddColumn columnB = (AddColumn) TableChange.addColumn(fieldNameB, dataTypeB, commentB);
 
     assertFalse(columnA.equals(null));
     assertFalse(columnA.equals(columnB));

--- a/catalogs/catalog-hive/src/main/java/com/datastrato/gravitino/catalog/hive/HiveCatalogOperations.java
+++ b/catalogs/catalog-hive/src/main/java/com/datastrato/gravitino/catalog/hive/HiveCatalogOperations.java
@@ -469,7 +469,7 @@ public class HiveCatalogOperations implements CatalogOperations, SupportsSchemas
         .filter(c -> c instanceof TableChange.ColumnChange)
         .forEach(
             c -> {
-              String fieldToAdd = String.join(".", ((TableChange.ColumnChange) c).fieldNames());
+              String fieldToAdd = String.join(".", ((TableChange.ColumnChange) c).fieldName());
               Preconditions.checkArgument(
                   c instanceof TableChange.UpdateColumnComment
                       || !partitionFields.contains(fieldToAdd),
@@ -658,7 +658,7 @@ public class HiveCatalogOperations implements CatalogOperations, SupportsSchemas
 
           if (change instanceof TableChange.AddColumn) {
             TableChange.AddColumn addColumn = (TableChange.AddColumn) change;
-            validateNullable(String.join(".", addColumn.fieldNames()), addColumn.isNullable());
+            validateNullable(String.join(".", addColumn.fieldName()), addColumn.isNullable());
             doAddColumn(cols, addColumn);
 
           } else if (change instanceof TableChange.DeleteColumn) {
@@ -787,27 +787,27 @@ public class HiveCatalogOperations implements CatalogOperations, SupportsSchemas
       targetPosition = cols.size();
       LOG.info(
           "Add position is null, add column {} to the end of non-partition columns",
-          change.fieldNames()[0]);
+          change.fieldName()[0]);
     } else {
       targetPosition = columnPosition(cols, change.getPosition());
     }
     cols.add(
         targetPosition,
         new FieldSchema(
-            change.fieldNames()[0],
+            change.fieldName()[0],
             ToHiveType.convert(change.getDataType()).getQualifiedName(),
             change.getComment()));
   }
 
   private void doDeleteColumn(List<FieldSchema> cols, TableChange.DeleteColumn change) {
-    String columnName = change.fieldNames()[0];
+    String columnName = change.fieldName()[0];
     if (!cols.removeIf(c -> c.getName().equals(columnName)) && !change.getIfExists()) {
       throw new IllegalArgumentException("DeleteColumn does not exist: " + columnName);
     }
   }
 
   private void doRenameColumn(List<FieldSchema> cols, TableChange.RenameColumn change) {
-    String columnName = change.fieldNames()[0];
+    String columnName = change.fieldName()[0];
     if (indexOfColumn(cols, columnName) == -1) {
       throw new IllegalArgumentException("RenameColumn does not exist: " + columnName);
     }
@@ -821,12 +821,12 @@ public class HiveCatalogOperations implements CatalogOperations, SupportsSchemas
 
   private void doUpdateColumnComment(
       List<FieldSchema> cols, TableChange.UpdateColumnComment change) {
-    cols.get(indexOfColumn(cols, change.fieldNames()[0])).setComment(change.getNewComment());
+    cols.get(indexOfColumn(cols, change.fieldName()[0])).setComment(change.getNewComment());
   }
 
   private void doUpdateColumnPosition(
       List<FieldSchema> cols, TableChange.UpdateColumnPosition change) {
-    String columnName = change.fieldNames()[0];
+    String columnName = change.fieldName()[0];
     int sourceIndex = indexOfColumn(cols, columnName);
     if (sourceIndex == -1) {
       throw new IllegalArgumentException("UpdateColumnPosition does not exist: " + columnName);
@@ -838,7 +838,7 @@ public class HiveCatalogOperations implements CatalogOperations, SupportsSchemas
   }
 
   private void doUpdateColumnType(List<FieldSchema> cols, TableChange.UpdateColumnType change) {
-    String columnName = change.fieldNames()[0];
+    String columnName = change.fieldName()[0];
     int indexOfColumn = indexOfColumn(cols, columnName);
     if (indexOfColumn == -1) {
       throw new IllegalArgumentException("UpdateColumnType does not exist: " + columnName);

--- a/catalogs/catalog-jdbc-mysql/src/main/java/com/datastrato/gravitino/catalog/mysql/operation/MysqlTableOperations.java
+++ b/catalogs/catalog-jdbc-mysql/src/main/java/com/datastrato/gravitino/catalog/mysql/operation/MysqlTableOperations.java
@@ -353,10 +353,10 @@ public class MysqlTableOperations extends JdbcTableOperations {
   private String updateColumnCommentFieldDefinition(
       TableChange.UpdateColumnComment updateColumnComment, CreateTable createTable) {
     String newComment = updateColumnComment.getNewComment();
-    if (updateColumnComment.fieldNames().length > 1) {
+    if (updateColumnComment.fieldName().length > 1) {
       throw new UnsupportedOperationException("Mysql does not support nested column names.");
     }
-    String col = updateColumnComment.fieldNames()[0];
+    String col = updateColumnComment.fieldName()[0];
     JdbcColumn column = getJdbcColumnFromCreateTable(createTable, col);
     column.getProperties().remove(PRIMARY_KEY);
     JdbcColumn updateColumn =
@@ -374,10 +374,10 @@ public class MysqlTableOperations extends JdbcTableOperations {
   private String addColumnFieldDefinition(
       TableChange.AddColumn addColumn, CreateTable createTable) {
     String dataType = (String) typeConverter.fromGravitinoType(addColumn.getDataType());
-    if (addColumn.fieldNames().length > 1) {
+    if (addColumn.fieldName().length > 1) {
       throw new UnsupportedOperationException("Mysql does not support nested column names.");
     }
-    String col = addColumn.fieldNames()[0];
+    String col = addColumn.fieldName()[0];
 
     StringBuilder columnDefinition = new StringBuilder();
     columnDefinition.append("ADD COLUMN ").append(col).append(SPACE).append(dataType);
@@ -406,11 +406,11 @@ public class MysqlTableOperations extends JdbcTableOperations {
   }
 
   private String renameColumnFieldDefinition(TableChange.RenameColumn renameColumn) {
-    if (renameColumn.fieldNames().length > 1) {
+    if (renameColumn.fieldName().length > 1) {
       throw new UnsupportedOperationException("Mysql does not support nested column names.");
     }
     return "RENAME COLUMN "
-        + renameColumn.fieldNames()[0]
+        + renameColumn.fieldName()[0]
         + SPACE
         + "TO"
         + SPACE
@@ -419,10 +419,10 @@ public class MysqlTableOperations extends JdbcTableOperations {
 
   private String updateColumnPositionFieldDefinition(
       TableChange.UpdateColumnPosition updateColumnPosition, CreateTable createTable) {
-    if (updateColumnPosition.fieldNames().length > 1) {
+    if (updateColumnPosition.fieldName().length > 1) {
       throw new UnsupportedOperationException("Mysql does not support nested column names.");
     }
-    String col = updateColumnPosition.fieldNames()[0];
+    String col = updateColumnPosition.fieldName()[0];
     JdbcColumn column = getJdbcColumnFromCreateTable(createTable, col);
     StringBuilder columnDefinition = new StringBuilder();
     columnDefinition.append("MODIFY COLUMN ").append(col);
@@ -445,19 +445,19 @@ public class MysqlTableOperations extends JdbcTableOperations {
   }
 
   private String deleteColumnFieldDefinition(TableChange.DeleteColumn deleteColumn) {
-    if (deleteColumn.fieldNames().length > 1) {
+    if (deleteColumn.fieldName().length > 1) {
       throw new UnsupportedOperationException("Mysql does not support nested column names.");
     }
-    String col = deleteColumn.fieldNames()[0];
+    String col = deleteColumn.fieldName()[0];
     return "DROP COLUMN " + col;
   }
 
   private String updateColumnTypeFieldDefinition(
       TableChange.UpdateColumnType updateColumnType, CreateTable createTable) {
-    if (updateColumnType.fieldNames().length > 1) {
+    if (updateColumnType.fieldName().length > 1) {
       throw new UnsupportedOperationException("Mysql does not support nested column names.");
     }
-    String col = updateColumnType.fieldNames()[0];
+    String col = updateColumnType.fieldName()[0];
     JdbcColumn column = getJdbcColumnFromCreateTable(createTable, col);
     StringBuilder sqlBuilder = new StringBuilder("MODIFY COLUMN " + col);
     JdbcColumn newColumn =

--- a/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/ops/IcebergTableOpsHelper.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/ops/IcebergTableOpsHelper.java
@@ -78,33 +78,33 @@ public class IcebergTableOpsHelper {
 
   private void doDeleteColumn(
       UpdateSchema icebergUpdateSchema, DeleteColumn deleteColumn, Schema icebergTableSchema) {
-    NestedField deleteField = icebergTableSchema.findField(DOT.join(deleteColumn.fieldNames()));
+    NestedField deleteField = icebergTableSchema.findField(DOT.join(deleteColumn.fieldName()));
     if (deleteField == null) {
       if (deleteColumn.getIfExists()) {
         return;
       } else {
         throw new IllegalArgumentException(
-            "delete column not exists: " + DOT.join(deleteColumn.fieldNames()));
+            "delete column not exists: " + DOT.join(deleteColumn.fieldName()));
       }
     }
-    icebergUpdateSchema.deleteColumn(DOT.join(deleteColumn.fieldNames()));
+    icebergUpdateSchema.deleteColumn(DOT.join(deleteColumn.fieldName()));
   }
 
   private void doUpdateColumnComment(
       UpdateSchema icebergUpdateSchema, UpdateColumnComment updateColumnComment) {
     icebergUpdateSchema.updateColumnDoc(
-        DOT.join(updateColumnComment.fieldNames()), updateColumnComment.getNewComment());
+        DOT.join(updateColumnComment.fieldName()), updateColumnComment.getNewComment());
   }
 
   private void doUpdateColumnNullability(
       UpdateSchema icebergUpdateSchema,
       TableChange.UpdateColumnNullability updateColumnNullability) {
     if (updateColumnNullability.nullable()) {
-      icebergUpdateSchema.makeColumnOptional(DOT.join(updateColumnNullability.fieldNames()));
+      icebergUpdateSchema.makeColumnOptional(DOT.join(updateColumnNullability.fieldName()));
     } else {
       // TODO: figure out how to enable users to make column required
       // icebergUpdateSchema.allowIncompatibleChanges();
-      icebergUpdateSchema.requireColumn(DOT.join(updateColumnNullability.fieldNames()));
+      icebergUpdateSchema.requireColumn(DOT.join(updateColumnNullability.fieldName()));
     }
   }
 
@@ -118,18 +118,17 @@ public class IcebergTableOpsHelper {
   }
 
   private void doRenameColumn(UpdateSchema icebergUpdateSchema, RenameColumn renameColumn) {
-    icebergUpdateSchema.renameColumn(
-        DOT.join(renameColumn.fieldNames()), renameColumn.getNewName());
+    icebergUpdateSchema.renameColumn(DOT.join(renameColumn.fieldName()), renameColumn.getNewName());
   }
 
   private void doMoveColumn(
-      UpdateSchema icebergUpdateSchema, String[] fieldNames, ColumnPosition columnPosition) {
+      UpdateSchema icebergUpdateSchema, String[] fieldName, ColumnPosition columnPosition) {
     if (columnPosition instanceof TableChange.After) {
       After after = (After) columnPosition;
-      String peerName = getSiblingName(fieldNames, after.getColumn());
-      icebergUpdateSchema.moveAfter(DOT.join(fieldNames), peerName);
+      String peerName = getSiblingName(fieldName, after.getColumn());
+      icebergUpdateSchema.moveAfter(DOT.join(fieldName), peerName);
     } else if (columnPosition instanceof TableChange.First) {
-      icebergUpdateSchema.moveFirst(DOT.join(fieldNames));
+      icebergUpdateSchema.moveFirst(DOT.join(fieldName));
     } else {
       throw new NotSupportedException(
           "Iceberg doesn't support column position: " + columnPosition.getClass().getSimpleName());
@@ -139,14 +138,14 @@ public class IcebergTableOpsHelper {
   private void doUpdateColumnPosition(
       UpdateSchema icebergUpdateSchema, UpdateColumnPosition updateColumnPosition) {
     doMoveColumn(
-        icebergUpdateSchema, updateColumnPosition.fieldNames(), updateColumnPosition.getPosition());
+        icebergUpdateSchema, updateColumnPosition.fieldName(), updateColumnPosition.getPosition());
   }
 
   private void doUpdateColumnType(
       UpdateSchema icebergUpdateSchema,
       UpdateColumnType updateColumnType,
       Schema icebergTableSchema) {
-    String fieldName = DOT.join(updateColumnType.fieldNames());
+    String fieldName = DOT.join(updateColumnType.fieldName());
     Preconditions.checkArgument(
         icebergTableSchema.findField(fieldName) != null,
         "Cannot update missing field: %s",
@@ -177,7 +176,7 @@ public class IcebergTableOpsHelper {
 
   private void doAddColumn(
       UpdateSchema icebergUpdateSchema, AddColumn addColumn, Schema icebergTableSchema) {
-    String parentName = getParentName(addColumn.fieldNames());
+    String parentName = getParentName(addColumn.fieldName());
     StructType parentStruct;
     if (parentName != null) {
       org.apache.iceberg.types.Type parent = icebergTableSchema.findType(parentName);
@@ -196,22 +195,22 @@ public class IcebergTableOpsHelper {
 
     if (addColumn.isNullable()) {
       icebergUpdateSchema.addColumn(
-          getParentName(addColumn.fieldNames()),
-          getLeafName(addColumn.fieldNames()),
+          getParentName(addColumn.fieldName()),
+          getLeafName(addColumn.fieldName()),
           ConvertUtil.toIcebergType(addColumn.isNullable(), addColumn.getDataType()),
           addColumn.getComment());
     } else {
       // TODO: figure out how to enable users to add required columns
       // icebergUpdateSchema.allowIncompatibleChanges();
       icebergUpdateSchema.addRequiredColumn(
-          getParentName(addColumn.fieldNames()),
-          getLeafName(addColumn.fieldNames()),
+          getParentName(addColumn.fieldName()),
+          getLeafName(addColumn.fieldName()),
           ConvertUtil.toIcebergType(addColumn.isNullable(), addColumn.getDataType()),
           addColumn.getComment());
     }
 
     ColumnPosition position = getAddColumnPosition(parentStruct, addColumn.getPosition());
-    doMoveColumn(icebergUpdateSchema, addColumn.fieldNames(), position);
+    doMoveColumn(icebergUpdateSchema, addColumn.fieldName(), position);
   }
 
   private void alterTableProperty(
@@ -373,13 +372,13 @@ public class IcebergTableOpsHelper {
   }
 
   @VisibleForTesting
-  static String getSiblingName(String[] fieldNames, String fieldName) {
-    if (fieldNames.length > 1) {
-      String[] peerNames = Arrays.copyOf(fieldNames, fieldNames.length);
-      peerNames[fieldNames.length - 1] = fieldName;
+  static String getSiblingName(String[] originalField, String targetField) {
+    if (originalField.length > 1) {
+      String[] peerNames = Arrays.copyOf(originalField, originalField.length);
+      peerNames[originalField.length - 1] = targetField;
       return DOT.join(peerNames);
     }
-    return fieldName;
+    return targetField;
   }
 
   @VisibleForTesting

--- a/clients/client-java/src/main/java/com/datastrato/gravitino/client/DTOConverters.java
+++ b/clients/client-java/src/main/java/com/datastrato/gravitino/client/DTOConverters.java
@@ -145,7 +145,7 @@ class DTOConverters {
     if (change instanceof TableChange.AddColumn) {
       TableChange.AddColumn addColumn = (TableChange.AddColumn) change;
       return new TableUpdateRequest.AddTableColumnRequest(
-          addColumn.fieldNames(),
+          addColumn.fieldName(),
           addColumn.getDataType(),
           addColumn.getComment(),
           addColumn.getPosition(),
@@ -154,27 +154,27 @@ class DTOConverters {
     } else if (change instanceof TableChange.RenameColumn) {
       TableChange.RenameColumn renameColumn = (TableChange.RenameColumn) change;
       return new TableUpdateRequest.RenameTableColumnRequest(
-          renameColumn.fieldNames(), renameColumn.getNewName());
+          renameColumn.fieldName(), renameColumn.getNewName());
 
     } else if (change instanceof TableChange.UpdateColumnType) {
       return new TableUpdateRequest.UpdateTableColumnTypeRequest(
-          change.fieldNames(), ((TableChange.UpdateColumnType) change).getNewDataType());
+          change.fieldName(), ((TableChange.UpdateColumnType) change).getNewDataType());
 
     } else if (change instanceof TableChange.UpdateColumnComment) {
       return new TableUpdateRequest.UpdateTableColumnCommentRequest(
-          change.fieldNames(), ((TableChange.UpdateColumnComment) change).getNewComment());
+          change.fieldName(), ((TableChange.UpdateColumnComment) change).getNewComment());
 
     } else if (change instanceof TableChange.UpdateColumnPosition) {
       return new TableUpdateRequest.UpdateTableColumnPositionRequest(
-          change.fieldNames(), ((TableChange.UpdateColumnPosition) change).getPosition());
+          change.fieldName(), ((TableChange.UpdateColumnPosition) change).getPosition());
 
     } else if (change instanceof TableChange.DeleteColumn) {
       return new TableUpdateRequest.DeleteTableColumnRequest(
-          change.fieldNames(), ((TableChange.DeleteColumn) change).getIfExists());
+          change.fieldName(), ((TableChange.DeleteColumn) change).getIfExists());
 
     } else if (change instanceof TableChange.UpdateColumnNullability) {
       return new TableUpdateRequest.UpdateTableColumnNullabilityRequest(
-          change.fieldNames(), ((TableChange.UpdateColumnNullability) change).nullable());
+          change.fieldName(), ((TableChange.UpdateColumnNullability) change).nullable());
     } else {
       throw new IllegalArgumentException(
           "Unknown column change type: " + change.getClass().getSimpleName());

--- a/trino-connector/src/test/java/com/datastrato/gravitino/trino/connector/GravitinoMockServer.java
+++ b/trino-connector/src/test/java/com/datastrato/gravitino/trino/connector/GravitinoMockServer.java
@@ -398,7 +398,7 @@ public class GravitinoMockServer implements AutoCloseable {
 
     } else if (tableChange instanceof TableChange.AddColumn) {
       TableChange.AddColumn addColumn = (TableChange.AddColumn) tableChange;
-      String fieldName = addColumn.fieldNames()[0];
+      String fieldName = addColumn.fieldName()[0];
       GravitinoColumn column =
           new GravitinoColumn(fieldName, addColumn.getDataType(), -1, "", true);
       CatalogConnectorMetadataAdapter metadataAdapter =
@@ -407,19 +407,19 @@ public class GravitinoMockServer implements AutoCloseable {
 
     } else if (tableChange instanceof TableChange.DeleteColumn) {
       TableChange.DeleteColumn deleteColumn = (TableChange.DeleteColumn) tableChange;
-      String fieldName = deleteColumn.fieldNames()[0];
+      String fieldName = deleteColumn.fieldName()[0];
       ColumnHandle columnHandle = metadata.getColumnHandles(null, tableHandle).get(fieldName);
       metadata.dropColumn(null, tableHandle, columnHandle);
 
     } else if (tableChange instanceof TableChange.RenameColumn) {
       TableChange.RenameColumn renameColumn = (TableChange.RenameColumn) tableChange;
-      String fieldName = renameColumn.fieldNames()[0];
+      String fieldName = renameColumn.fieldName()[0];
       ColumnHandle columnHandle = metadata.getColumnHandles(null, tableHandle).get(fieldName);
       metadata.renameColumn(null, tableHandle, columnHandle, renameColumn.getNewName());
 
     } else if (tableChange instanceof TableChange.UpdateColumnType) {
       TableChange.UpdateColumnType updateColumnType = (TableChange.UpdateColumnType) tableChange;
-      String fieldName = updateColumnType.fieldNames()[0];
+      String fieldName = updateColumnType.fieldName()[0];
       ColumnHandle columnHandle = metadata.getColumnHandles(null, tableHandle).get(fieldName);
       metadata.setColumnType(
           null,
@@ -435,7 +435,7 @@ public class GravitinoMockServer implements AutoCloseable {
       TableChange.UpdateColumnComment updateColumnComment =
           (TableChange.UpdateColumnComment) tableChange;
       ColumnHandle columnHandle =
-          metadata.getColumnHandles(null, tableHandle).get(updateColumnComment.fieldNames()[0]);
+          metadata.getColumnHandles(null, tableHandle).get(updateColumnComment.fieldName()[0]);
       metadata.setColumnComment(
           null, tableHandle, columnHandle, Optional.of(updateColumnComment.getNewComment()));
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

If this variable ends up pointing to only one field,  it should be named `fieldName`. Therefore, this PR changes all the field parameter name, which point to only one field, from `fieldNames` to `fieldName` even though it's of type string array

### Why are the changes needed?

We have many places that use either "fieldName" or "fieldNames", this will cause confusion

Fix: #897 

### Does this PR introduce _any_ user-facing change?
yes, If it is a single field, the user should use `fieldName()` method

### How was this patch tested?
existing UTs
