### PR TITLE
[#648] fix(core): Clean up the residue of failed catalog creation

### DIFF
--- a/core/src/main/java/com/datastrato/gravitino/catalog/CatalogManager.java
+++ b/core/src/main/java/com/datastrato/gravitino/catalog/CatalogManager.java
@@ -273,8 +273,9 @@ public class CatalogManager implements SupportsCatalogs, Closeable {
         throw new NoSuchMetalakeException("Metalake " + metalakeIdent + " does not exist");
       }
 
-      store.put(e, false /* overwrite */);
+      // TODO: should avoid a race condition here
       CatalogWrapper wrapper = catalogCache.get(ident, id -> createCatalogWrapper(e));
+      store.put(e, false /* overwrite */);
       return wrapper.catalog;
     } catch (EntityAlreadyExistsException e1) {
       LOG.warn("Catalog {} already exists", ident, e1);
@@ -282,6 +283,7 @@ public class CatalogManager implements SupportsCatalogs, Closeable {
     } catch (IllegalArgumentException | NoSuchMetalakeException e2) {
       throw e2;
     } catch (Exception e3) {
+      catalogCache.invalidate(ident);
       LOG.error("Failed to create catalog {}", ident, e3);
       throw new RuntimeException(e3);
     }

--- a/core/src/test/java/com/datastrato/gravitino/TestCatalog.java
+++ b/core/src/test/java/com/datastrato/gravitino/TestCatalog.java
@@ -4,10 +4,13 @@
  */
 package com.datastrato.gravitino;
 
+import static com.datastrato.gravitino.TestCatalogOperations.FAIL_CREATE;
+
 import com.datastrato.gravitino.catalog.BaseCatalog;
 import com.datastrato.gravitino.catalog.CatalogOperations;
 import com.datastrato.gravitino.rel.TableCatalog;
 import java.util.Map;
+import java.util.Objects;
 
 public class TestCatalog extends BaseCatalog<TestCatalog> {
 
@@ -20,6 +23,9 @@ public class TestCatalog extends BaseCatalog<TestCatalog> {
 
   @Override
   protected CatalogOperations newOps(Map<String, String> config) {
+    if (Objects.equals(config.get(FAIL_CREATE), "true")) {
+      throw new RuntimeException("Failed to create Test catalog");
+    }
     return new TestCatalogOperations(config);
   }
 

--- a/core/src/test/java/com/datastrato/gravitino/TestCatalogOperations.java
+++ b/core/src/test/java/com/datastrato/gravitino/TestCatalogOperations.java
@@ -43,6 +43,8 @@ public class TestCatalogOperations implements CatalogOperations, TableCatalog, S
   private final BasePropertiesMetadata schemaPropertiesMetadata;
   private Map<String, String> config;
 
+  public static final String FAIL_CREATE = "fail-create";
+
   public TestCatalogOperations(Map<String, String> config) {
     tables = Maps.newHashMap();
     schemas = Maps.newHashMap();
@@ -327,6 +329,16 @@ public class TestCatalogOperations implements CatalogOperations, TableCatalog, S
                   "hidden_key",
                   PropertyEntry.stringPropertyEntry(
                       "hidden_key", "hidden_key", false, false, "hidden_value", true, false))
+              .put(
+                  FAIL_CREATE,
+                  PropertyEntry.booleanPropertyEntry(
+                      FAIL_CREATE,
+                      "Whether an exception needs to be thrown on creation",
+                      false,
+                      false,
+                      false,
+                      false,
+                      false))
               .build();
         }
       };

--- a/core/src/test/java/com/datastrato/gravitino/catalog/TestCatalogManager.java
+++ b/core/src/test/java/com/datastrato/gravitino/catalog/TestCatalogManager.java
@@ -23,6 +23,7 @@ import com.datastrato.gravitino.meta.BaseMetalake;
 import com.datastrato.gravitino.meta.SchemaVersion;
 import com.datastrato.gravitino.storage.RandomIdGenerator;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import java.io.IOException;
 import java.time.Instant;
@@ -285,7 +286,7 @@ public class TestCatalogManager {
   @Test
   public void testCreateCatalog() {
     NameIdentifier ident = NameIdentifier.of("metalake", "test1");
-    Map<String, String> props = ImmutableMap.of();
+    Map<String, String> props = Maps.newHashMap();
 
     Catalog testCatalog =
         catalogManager.createCatalog(ident, Catalog.Type.RELATIONAL, provider, "comment", props);
@@ -320,6 +321,27 @@ public class TestCatalogManager {
     // Test if the catalog is already cached
     CatalogManager.CatalogWrapper cached = catalogManager.catalogCache.getIfPresent(ident);
     Assertions.assertNotNull(cached);
+
+    // Test failed creation
+    NameIdentifier failedIdent = NameIdentifier.of("metalake", "test2");
+    props.put("fail-create", "true");
+    Throwable exception3 =
+        Assertions.assertThrows(
+            RuntimeException.class,
+            () ->
+                catalogManager.createCatalog(
+                    failedIdent, Catalog.Type.RELATIONAL, provider, "comment", props));
+    Assertions.assertTrue(exception3.getMessage().contains("Failed to create Test catalog"));
+    Assertions.assertNull(catalogManager.catalogCache.getIfPresent(failedIdent));
+    // Test failed for the second time
+    Throwable exception4 =
+        Assertions.assertThrows(
+            RuntimeException.class,
+            () ->
+                catalogManager.createCatalog(
+                    failedIdent, Catalog.Type.RELATIONAL, provider, "comment", props));
+    Assertions.assertTrue(exception4.getMessage().contains("Failed to create Test catalog"));
+    Assertions.assertNull(catalogManager.catalogCache.getIfPresent(failedIdent));
   }
 
   @Test


### PR DESCRIPTION
### What changes were proposed in this pull request?

Initialize the catalog entity before putting it into the Gravitino store

### Why are the changes needed?
We assume that the underlying storage does not have the ability to roll back, so we need to initialize the entity first. Otherwise, it is unable to create a catalog with the same name after the initial unsuccessful creation attempt.

Fix: #648 

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
UT added
