### PR TITLE
[#952] fix(kv): Server hangs after the initialization exception

### DIFF
--- a/core/src/main/java/com/datastrato/gravitino/storage/kv/KvGarbageCollector.java
+++ b/core/src/main/java/com/datastrato/gravitino/storage/kv/KvGarbageCollector.java
@@ -43,7 +43,11 @@ public final class KvGarbageCollector implements Closeable {
   final ScheduledExecutorService garbageCollectorPool =
       new ScheduledThreadPoolExecutor(
           2,
-          r -> new Thread(r, "KvEntityStore-Garbage-Collector-%d"),
+          r -> {
+            Thread t = new Thread(r, "KvEntityStore-Garbage-Collector-%d");
+            t.setDaemon(true);
+            return t;
+          },
           new ThreadPoolExecutor.AbortPolicy());
 
   public KvGarbageCollector(KvBackend kvBackend, Config config) {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Make the threads of `KvEntityStore-Garbage-Collector` daemon. If the thread isn't a daemon thread, it will block the quit of JVM.

### Why are the changes needed?

Fix: #952 

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
By hand
