### PR TITLE
[#959] fix(test): Fix the test of `TestJettyServerConfig`

### DIFF
--- a/server-common/src/main/java/com/datastrato/gravitino/server/web/JettyServerConfig.java
+++ b/server-common/src/main/java/com/datastrato/gravitino/server/web/JettyServerConfig.java
@@ -7,6 +7,7 @@ package com.datastrato.gravitino.server.web;
 import com.datastrato.gravitino.Config;
 import com.datastrato.gravitino.config.ConfigBuilder;
 import com.datastrato.gravitino.config.ConfigEntry;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Sets;
 import java.security.KeyManagementException;
@@ -359,14 +360,19 @@ public final class JettyServerConfig {
     if (enableCipherAlgorithms.isEmpty()) {
       return Collections.emptySet();
     }
+
+    Set<String> supportedAlgorithms = Sets.newHashSet(enableCipherAlgorithms);
+    supportedAlgorithms.retainAll(getSupportedCipherSuites());
+    return supportedAlgorithms;
+  }
+
+  @VisibleForTesting
+  Set<String> getSupportedCipherSuites() {
     SSLContext context =
         tlsProtocol.map(this::getSSLContextInstance).orElseGet(this::getDefaultSSLContext);
     if (context == null) {
       return Collections.emptySet();
     }
-    Set<String> supportedAlgorithms = Sets.newHashSet(enableCipherAlgorithms);
-    supportedAlgorithms.retainAll(
-        Sets.newHashSet(context.getServerSocketFactory().getSupportedCipherSuites()));
-    return supportedAlgorithms;
+    return Sets.newHashSet(context.getServerSocketFactory().getSupportedCipherSuites());
   }
 }

--- a/server-common/src/test/java/com/datastrato/gravitino/server/web/TestJettyServerConfig.java
+++ b/server-common/src/test/java/com/datastrato/gravitino/server/web/TestJettyServerConfig.java
@@ -8,6 +8,7 @@ import com.datastrato.gravitino.Config;
 import com.google.common.collect.Sets;
 import java.util.Collections;
 import java.util.Optional;
+import java.util.Set;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -22,7 +23,9 @@ public class TestJettyServerConfig {
     Assertions.assertIterableEquals(
         Collections.emptySet(), jettyServerConfig.getSupportedAlgorithms());
 
-    String algorithm = "TLS_ECDH_RSA_WITH_AES_256_GCM_SHA384";
+    Set<String> supportAlgorithms = jettyServerConfig.getSupportedCipherSuites();
+    Assertions.assertFalse(supportAlgorithms.isEmpty());
+    String algorithm = supportAlgorithms.iterator().next();
     Config containConfig = new Config() {};
     containConfig.set(JettyServerConfig.ENABLE_CIPHER_ALGORITHMS, algorithm);
     jettyServerConfig = JettyServerConfig.fromConfig(containConfig, "");


### PR DESCRIPTION
### What changes were proposed in this pull request?
Choose one algorithm from the algorithms supported by JVM instead of a fixed algorithm.

### Why are the changes needed?
If we use different JDKs,  the supported algorithms are different. So this test may fail without this pr.
fix: #959 

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
By hand.
