### PR TITLE
[#968] improvement(ci): Run the pipeline only if there are changes about the files which are not document

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,7 @@ jobs:
               - server-common/**
               - trino-connector/**
               - web/**
+              - build.gradle.kts
               - gradle.properties
               - gradlew
               - setting.gradle.kts

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -38,6 +38,7 @@ jobs:
               - server-common/**
               - trino-connector/**
               - web/**
+              - build.gradle.kts
               - gradle.properties
               - gradlew
               - setting.gradle.kts


### PR DESCRIPTION
### What changes were proposed in this pull request?
 Run the pipeline only if there are changes about the files which are not document.

### Why are the changes needed?


Fix: #968 

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Yes, I run the action in my repo.
You can see 
Only docs change.
https://github.com/qqqttt123/gravitino/pull/10
Source code changes.
https://github.com/qqqttt123/gravitino/pull/11
