### PR TITLE
[#971] feat(jdbc-mysql): compatible with mysql 5.7

### DIFF
--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/mysql/CatalogMysqlIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/mysql/CatalogMysqlIT.java
@@ -82,6 +82,8 @@ public class CatalogMysqlIT extends AbstractIT {
 
   protected static final String TEST_DB_NAME = RandomUtils.nextInt(10000) + "_test_db";
 
+  public static final String mysqlImageName = "mysql:8.0";
+
   @BeforeAll
   public static void startup() throws IOException {
 
@@ -92,7 +94,7 @@ public class CatalogMysqlIT extends AbstractIT {
     }
 
     MYSQL_CONTAINER =
-        new MySQLContainer<>("mysql:8.2.0")
+        new MySQLContainer<>(mysqlImageName)
             .withDatabaseName(TEST_DB_NAME)
             .withUsername("root")
             .withPassword("root");

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/mysql/TestMysqlAbstractIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/mysql/TestMysqlAbstractIT.java
@@ -18,7 +18,7 @@ public class TestMysqlAbstractIT extends TestJdbcAbstractIT {
   @BeforeAll
   public static void startup() {
     CONTAINER =
-        new MySQLContainer<>("mysql:8.2.0")
+        new MySQLContainer<>(CatalogMysqlIT.mysqlImageName)
             .withDatabaseName(TEST_DB_NAME)
             .withUsername("root")
             .withPassword("root");

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/mysql/TestMysqlTableOperations.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/mysql/TestMysqlTableOperations.java
@@ -163,13 +163,6 @@ public class TestMysqlTableOperations extends TestMysqlAbstractIT {
             .withName("col_1")
             .withType(INT)
             .withComment("id")
-            .withProperties(
-                new ArrayList<String>() {
-                  {
-                    add(AUTO_INCREMENT);
-                    add(PRIMARY_KEY);
-                  }
-                })
             .withNullable(false)
             .build();
     columns.add(col_1);
@@ -178,20 +171,12 @@ public class TestMysqlTableOperations extends TestMysqlAbstractIT {
             .withName("col_2")
             .withType(VARCHAR)
             .withComment("name")
-            .withProperties(
-                new ArrayList<String>() {
-                  {
-                    add("UNIQUE KEY");
-                  }
-                })
             .withDefaultValue("hello world")
             .withNullable(false)
             .build();
     columns.add(col_2);
     Map<String, String> properties = new HashMap<>();
-    // TODO #804 Properties will be unified in the future.
-    //    properties.put("ENGINE", "InnoDB");
-    //    properties.put(AUTO_INCREMENT, "10");
+
     // create table
     TABLE_OPERATIONS.create(
         TEST_DB_NAME,
@@ -218,12 +203,6 @@ public class TestMysqlTableOperations extends TestMysqlAbstractIT {
             .withName(col_1.name())
             .withType(VARCHAR)
             .withComment(col_1.comment())
-            .withProperties(
-                new ArrayList<String>() {
-                  {
-                    add(PRIMARY_KEY);
-                  }
-                })
             .withNullable(col_1.nullable())
             .withDefaultValue(col_1.getDefaultValue())
             .build();
@@ -362,8 +341,10 @@ public class TestMysqlTableOperations extends TestMysqlAbstractIT {
         new JdbcColumn.Builder()
             .withName("col_3")
             .withType(Types.TimestampType.withoutTimeZone())
-            .withNullable(true)
+            // MySQL 5.7 doesn't support nullable timestamp
+            .withNullable(false)
             .withComment("timestamp")
+            .withDefaultValue("2013-01-01 00:00:00")
             .build());
     columns.add(
         new JdbcColumn.Builder()
@@ -373,7 +354,7 @@ public class TestMysqlTableOperations extends TestMysqlAbstractIT {
             .withComment("date")
             .build());
     Map<String, String> properties = new HashMap<>();
-    //    properties.put("ENGINE", "InnoDB");
+
     // create table
     TABLE_OPERATIONS.create(
         TEST_DB_NAME,


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. change `RENAME COLUMN` change to `CHANGE COLUMN`, both 5.7 and 8.0 supports it
2. remove `primary key` related test to skip test failures, since we don't support table&column properties for now
3. remove nullable from timestamp field since mysql 5.7 doesn't support it.

### Why are the changes needed?
mysql 5.7 and 8.0 are popular version, we should test on them

Fix: #971 

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
change MySQL image to mysql:5.7