### PR TITLE
[#797] feat(server): Provide a config interface for the front side

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -26,7 +26,7 @@ GravitinoClient client = GravitinoClient.builder(uri)
 
 Gravitino only supports external OAuth 2.0 servers.
 First, users need to guarantee that the external correctly configured OAuth 2.0 server supports Bearer JWT.
-Then, on the server side, users should set `gravitino.authenticator` as `oauth` and give `gravitino.authenticator.oauth.defaultSignKey` a proper value.
+Then, on the server side, users should set `gravitino.authenticator` as `oauth` and give `gravitino.authenticator.oauth.defaultSignKey`, `gravitino.authenticator.oauth.serverURI` and `gravitino.authenticator.oauth.tokenPath`  a proper value.
 Next, for the client side, users can enable `OAuth` mode by the following code:
 
 ```java
@@ -44,13 +44,14 @@ GravitinoClient client = GravitinoClient.builder(uri)
 
 ### Server configuration
 
-| Configuration item                                | Description                                                                | Default value     | Since version |
-|---------------------------------------------------|----------------------------------------------------------------------------|-------------------|---------------|
-| `gravitino.authenticator`                         | The authenticator which Gravitino uses, setting as `simple` or `oauth`     | `simple`          | 0.3.0         |
-| `gravitino.authenticator.oauth.serviceAudience`   | The audience name when Gravitino uses OAuth as the authenticator           | `GravitinoServer` | 0.3.0         |
-| `gravitino.authenticator.oauth.allowSkewSecs`     | The JWT allows skew seconds when Gravitino uses OAuth as the authenticator | `0`               | 0.3.0         |
-| `gravitino.authenticator.oauth.defaultSignKey`    | The signing key of JWT when Gravitino uses OAuth as the authenticator         | ``                | 0.3.0         |
-| `gravitino.authenticator.oauth.signAlgorithmType` | The signature algorithm when Gravitino uses OAuth as the authenticator     | `RS256`           | 0.3.0         |
+| Configuration item                              | Description                                                                | Default value     | Since version |
+|-------------------------------------------------|----------------------------------------------------------------------------|-------------------|---------------|
+| `gravitino.authenticator`                       | The authenticator which Gravitino uses, setting as `simple` or `oauth`     | `simple`          | 0.3.0         |
+| `gravitino.authenticator.oauth.serviceAudience` | The audience name when Gravitino uses OAuth as the authenticator           | `GravitinoServer` | 0.3.0         |
+| `gravitino.authenticator.oauth.allowSkewSecs`   | The JWT allows skew seconds when Gravitino uses OAuth as the authenticator | `0`               | 0.3.0         |
+| `gravitino.authenticator.oauth.defaultSignKey`  | The signing key of JWT when Gravitino uses OAuth as the authenticator      | ``                | 0.3.0         |
+| `gravitino.authenticator.oauth.serverUri`       | The uri of the default OAuth server                                        | ``                | 0.3.0         |
+| `gravitino.authenticator.oauth.tokenPath`       | The path for token of the default OAuth server                             | ``                | 0.3.0         |
 
 The signature algorithms that Gravitino supports follows:
 

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/rest/AuthenticationOperationsIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/rest/AuthenticationOperationsIT.java
@@ -4,7 +4,6 @@
  */
 package com.datastrato.gravitino.integration.test.web.rest;
 
-import com.datastrato.gravitino.auth.AuthConstants;
 import com.datastrato.gravitino.auth.AuthenticatorType;
 import com.datastrato.gravitino.client.GravitinoVersion;
 import com.datastrato.gravitino.integration.test.util.AbstractIT;
@@ -46,7 +45,8 @@ public class AuthenticationOperationsIT extends AbstractIT {
     configs.put(OAuthConfig.SERVICE_AUDIENCE.getKey(), "service1");
     configs.put(OAuthConfig.DEFAULT_SIGN_KEY.getKey(), publicKey);
     configs.put(OAuthConfig.ALLOW_SKEW_SECONDS.getKey(), "6");
-    configs.put(AuthConstants.HTTP_HEADER_AUTHORIZATION, token);
+    configs.put(OAuthConfig.DEFAULT_SERVER_URI.getKey(), "test");
+    configs.put(OAuthConfig.DEFAULT_TOKEN_PATH.getKey(), "test");
 
     registerCustomConfigs(configs);
     OAuthMockDataProvider mockDataProvider = OAuthMockDataProvider.getInstance();

--- a/server-common/src/main/java/com/datastrato/gravitino/server/auth/OAuth2TokenAuthenticator.java
+++ b/server-common/src/main/java/com/datastrato/gravitino/server/auth/OAuth2TokenAuthenticator.java
@@ -102,6 +102,12 @@ class OAuth2TokenAuthenticator implements Authenticator {
     String configuredSignKey = config.get(OAuthConfig.DEFAULT_SIGN_KEY);
     Preconditions.checkArgument(
         StringUtils.isNotBlank(configuredSignKey), "Default signing key can't be blank");
+    Preconditions.checkArgument(
+        StringUtils.isNotBlank(config.get(OAuthConfig.DEFAULT_TOKEN_PATH)),
+        "The path for token of the default OAuth server can't be blank");
+    Preconditions.checkArgument(
+        StringUtils.isNotBlank(config.get(OAuthConfig.DEFAULT_SERVER_URI)),
+        "The uri of the default OAuth server can't be blank");
     String algType = config.get(OAuthConfig.SIGNATURE_ALGORITHM_TYPE);
     this.defaultSigningKey = decodeSignKey(Base64.getDecoder().decode(configuredSignKey), algType);
   }

--- a/server-common/src/main/java/com/datastrato/gravitino/server/auth/OAuthConfig.java
+++ b/server-common/src/main/java/com/datastrato/gravitino/server/auth/OAuthConfig.java
@@ -41,4 +41,18 @@ public interface OAuthConfig extends Configs {
           .version("0.3.0")
           .stringConf()
           .createWithDefault(SignatureAlgorithm.RS256.name());
+
+  ConfigEntry<String> DEFAULT_SERVER_URI =
+      new ConfigBuilder(OAUTH_CONFIG_PREFIX + "serverUri")
+          .doc("The uri of the default OAuth server")
+          .version("0.3.0")
+          .stringConf()
+          .createWithDefault("");
+
+  ConfigEntry<String> DEFAULT_TOKEN_PATH =
+      new ConfigBuilder(OAUTH_CONFIG_PREFIX + "tokenPath")
+          .doc("The path for token of the default OAuth server")
+          .version("0.3.0")
+          .stringConf()
+          .createWithDefault("");
 }

--- a/server-common/src/test/java/com/datastrato/gravitino/server/auth/TestOAuth2TokenAuthenticator.java
+++ b/server-common/src/test/java/com/datastrato/gravitino/server/auth/TestOAuth2TokenAuthenticator.java
@@ -35,6 +35,8 @@ public class TestOAuth2TokenAuthenticator {
         IllegalArgumentException.class, () -> auth2TokenAuthenticator.initialize(config));
     config.set(OAuthConfig.DEFAULT_SIGN_KEY, publicKey);
     config.set(OAuthConfig.ALLOW_SKEW_SECONDS, 6L);
+    config.set(OAuthConfig.DEFAULT_TOKEN_PATH, "test");
+    config.set(OAuthConfig.DEFAULT_SERVER_URI, "test");
     auth2TokenAuthenticator.initialize(config);
     Assertions.assertTrue(auth2TokenAuthenticator.isDataFromToken());
     Exception e =

--- a/server/src/main/java/com/datastrato/gravitino/server/GravitinoServer.java
+++ b/server/src/main/java/com/datastrato/gravitino/server/GravitinoServer.java
@@ -12,6 +12,7 @@ import com.datastrato.gravitino.metrics.MetricsSystem;
 import com.datastrato.gravitino.metrics.source.MetricsSource;
 import com.datastrato.gravitino.server.auth.AuthenticationFilter;
 import com.datastrato.gravitino.server.auth.ServerAuthenticator;
+import com.datastrato.gravitino.server.web.ConfigServlet;
 import com.datastrato.gravitino.server.web.HttpServerMetricsSource;
 import com.datastrato.gravitino.server.web.JettyServer;
 import com.datastrato.gravitino.server.web.JettyServerConfig;
@@ -84,6 +85,8 @@ public class GravitinoServer extends ResourceConfig {
 
     Servlet servlet = new ServletContainer(this);
     server.addServlet(servlet, "/api/*");
+    Servlet configServlet = new ConfigServlet(serverConfig);
+    server.addServlet(configServlet, "/configs");
     server.addFilter(new VersioningFilter(), "/api/*");
     server.addFilter(new AuthenticationFilter(), "/api/*");
   }

--- a/server/src/main/java/com/datastrato/gravitino/server/web/ConfigServlet.java
+++ b/server/src/main/java/com/datastrato/gravitino/server/web/ConfigServlet.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2023 Datastrato.
+ * This software is licensed under the Apache License version 2.
+ */
+package com.datastrato.gravitino.server.web;
+
+import com.datastrato.gravitino.Configs;
+import com.datastrato.gravitino.config.ConfigEntry;
+import com.datastrato.gravitino.json.JsonUtils;
+import com.datastrato.gravitino.server.ServerConfig;
+import com.datastrato.gravitino.server.auth.OAuthConfig;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Map;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+public class ConfigServlet extends HttpServlet {
+
+  private static final ImmutableSet<ConfigEntry<?>> configEntries =
+      ImmutableSet.of(
+          Configs.AUTHENTICATOR, OAuthConfig.DEFAULT_SERVER_URI, OAuthConfig.DEFAULT_TOKEN_PATH);
+
+  private final Map<String, String> configs = Maps.newHashMap();
+
+  public ConfigServlet(ServerConfig serverConfig) {
+    for (ConfigEntry<?> key : configEntries) {
+      String config = String.valueOf(serverConfig.get(key));
+      configs.put(key.getKey(), config);
+    }
+  }
+
+  protected void doGet(HttpServletRequest req, HttpServletResponse res)
+      throws ServletException, IOException {
+    try (PrintWriter writer = res.getWriter()) {
+      ObjectMapper objectMapper = JsonUtils.objectMapper();
+      res.setContentType("application/json;charset=utf-8");
+      writer.write(objectMapper.writeValueAsString(configs));
+    }
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

 Provide a config interface for the front side. Because front side can't read the environment variable. so we can just give an interface to the front side.

### Why are the changes needed?

Fix: #988

### Does this PR introduce _any_ user-facing change?
Yes, I have added the document.

### How was this patch tested?
By hand.
```
http://127.0.0.1:8090/web/config
{"gravitino.authenticator.oauth.tokenPath":"","gravitino.authenticator":"simple","gravitino.authenticator.oauth.serverURI":""}
```