### PR TITLE
[#981] feat(jdbc-postgres): compatible with postgres 14,15 

### DIFF
--- a/catalogs/catalog-jdbc-postgresql/src/main/java/com/datastrato/gravitino/catalog/postgresql/operation/PostgreSqlTableOperations.java
+++ b/catalogs/catalog-jdbc-postgresql/src/main/java/com/datastrato/gravitino/catalog/postgresql/operation/PostgreSqlTableOperations.java
@@ -52,7 +52,7 @@ public class PostgreSqlTableOperations extends JdbcTableOperations {
           + "    AND c.relname = ?";
 
   private static final String SHOW_COLUMN_INFO_SQL =
-      "select * FROM information_schema.columns WHERE table_name = ?";
+      "select * FROM information_schema.columns WHERE table_name = ? order by ordinal_position";
 
   private static final String SHOW_TABLE_COMMENT_SQL =
       "SELECT tb.table_name, d.description\n"

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/postgresql/CatalogPostgreSqlIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/postgresql/CatalogPostgreSqlIT.java
@@ -79,6 +79,8 @@ public class CatalogPostgreSqlIT extends AbstractIT {
 
   protected static final String TEST_DB_NAME = GravitinoITUtils.genRandomName("test_db");
 
+  public static final String POSTGRES_IMAGE = "postgres:13";
+
   @BeforeAll
   public static void startup() throws IOException {
 
@@ -89,7 +91,7 @@ public class CatalogPostgreSqlIT extends AbstractIT {
     }
 
     POSTGRESQL_CONTAINER =
-        new PostgreSQLContainer<>("postgres:9.6.12")
+        new PostgreSQLContainer<>(POSTGRES_IMAGE)
             .withDatabaseName(TEST_DB_NAME)
             .withUsername("root")
             .withPassword("root");

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/postgresql/TestPostgreSqlAbstractIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/postgresql/TestPostgreSqlAbstractIT.java
@@ -22,7 +22,7 @@ public class TestPostgreSqlAbstractIT extends TestJdbcAbstractIT {
   @BeforeAll
   public static void startup() {
     CONTAINER =
-        new PostgreSQLContainer<>("postgres:9.6.12")
+        new PostgreSQLContainer<>(CatalogPostgreSqlIT.POSTGRES_IMAGE)
             .withDatabaseName(TEST_DB_NAME)
             .withUsername("root")
             .withPassword("root");


### PR DESCRIPTION
### What changes were proposed in this pull request?
get column by position order to keep consistent column order between load table with create table.

### Why are the changes needed?
if create table with column a, b, c, we may get column c, b, a when load table for pg 14, 15 version.

Fix: #981 

### Does this PR introduce _any_ user-facing change?
no
### How was this patch tested?

test pg 9,10,11,12,13,14,15 version