### PR TITLE
[#1035] fix(dev):  Executing a query failed with a null comment table.

### DIFF
--- a/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/catalog/CatalogConnectorMetadataAdapter.java
+++ b/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/catalog/CatalogConnectorMetadataAdapter.java
@@ -66,7 +66,10 @@ public class CatalogConnectorMetadataAdapter {
 
     Map<String, Object> properties = toTrinoTableProperties(gravitinoTable.getProperties());
     return new ConnectorTableMetadata(
-        schemaTableName, columnMetadataList, properties, Optional.of(gravitinoTable.getComment()));
+        schemaTableName,
+        columnMetadataList,
+        properties,
+        Optional.ofNullable(gravitinoTable.getComment()));
   }
 
   /** Transform trino ConnectorTableMetadata to gravitino table metadata */

--- a/trino-connector/src/test/java/com/datastrato/gravitino/trino/connector/metadata/TestGravitinoTable.java
+++ b/trino-connector/src/test/java/com/datastrato/gravitino/trino/connector/metadata/TestGravitinoTable.java
@@ -5,12 +5,17 @@
 package com.datastrato.gravitino.trino.connector.metadata;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 import com.datastrato.gravitino.dto.AuditDTO;
 import com.datastrato.gravitino.dto.rel.ColumnDTO;
 import com.datastrato.gravitino.dto.rel.TableDTO;
 import com.datastrato.gravitino.rel.types.Types;
+import com.datastrato.gravitino.trino.connector.catalog.CatalogConnectorMetadataAdapter;
+import com.datastrato.gravitino.trino.connector.catalog.hive.HiveMetadataAdapter;
+import io.trino.spi.connector.ConnectorTableMetadata;
 import java.time.Instant;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import org.testng.annotations.Test;
@@ -26,11 +31,7 @@ public class TestGravitinoTable {
               .withDataType(Types.StringType.get())
               .withComment("f1 column")
               .build(),
-          new ColumnDTO.Builder()
-              .withName("f2")
-              .withDataType(Types.IntegerType.get())
-              .withComment("f2 column")
-              .build()
+          new ColumnDTO.Builder().withName("f2").withDataType(Types.IntegerType.get()).build()
         };
     Map<String, String> properties = new HashMap<>();
     properties.put("format", "TEXTFILE");
@@ -54,5 +55,53 @@ public class TestGravitinoTable {
     }
     assertEquals(table.getComment(), tableDTO.comment());
     assertEquals(table.getProperties(), tableDTO.properties());
+
+    CatalogConnectorMetadataAdapter adapter =
+        new HiveMetadataAdapter(
+            Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
+
+    ConnectorTableMetadata tableMetadata = adapter.getTableMetadata(table);
+    assertEquals(tableMetadata.getColumns().size(), table.getColumns().size());
+    assertEquals(tableMetadata.getTableSchema().getTable().getSchemaName(), "db1");
+    assertEquals(tableMetadata.getTableSchema().getTable().getTableName(), table.getName());
+
+    for (int i = 0; i < table.getColumns().size(); i++) {
+      assertEquals(
+          tableMetadata.getColumns().get(i).getName(), table.getColumns().get(i).getName());
+    }
+    assertTrue(tableMetadata.getComment().isPresent());
+    assertEquals(tableMetadata.getComment().get(), tableDTO.comment());
+  }
+
+  @Test
+  public void testGravitinoTableWithOutComment() {
+    ColumnDTO[] columns =
+        new ColumnDTO[] {
+          new ColumnDTO.Builder()
+              .withName("f1")
+              .withDataType(Types.StringType.get())
+              .withComment("f1 column")
+              .build(),
+          new ColumnDTO.Builder().withName("f2").withDataType(Types.IntegerType.get()).build()
+        };
+    Map<String, String> properties = new HashMap<>();
+    properties.put("format", "TEXTFILE");
+    TableDTO tableDTO =
+        new TableDTO.Builder()
+            .withName("table1")
+            .withColumns(columns)
+            .withProperties(properties)
+            .withAudit(
+                new AuditDTO.Builder().withCreator("creator").withCreateTime(Instant.now()).build())
+            .build();
+
+    GravitinoTable table = new GravitinoTable("db1", "table1", tableDTO);
+    assertEquals(table.getComment(), null);
+
+    CatalogConnectorMetadataAdapter adapter =
+        new HiveMetadataAdapter(
+            Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
+    ConnectorTableMetadata tableMetadata = adapter.getTableMetadata(table);
+    assertTrue(tableMetadata.getComment().isEmpty());
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix the bug that throws a NullPointerException when executing a query with a null comment table.

### Why are the changes needed?

Fix: #1035

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Add new UT