### PR TITLE
[Minor] Wrong type of link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Gravitino aims to provide several key features:
 
 ## Contributing to Gravitino
 
-Gravitino is open source software available under the Apache 2.0 license. For information of how to contribute to Gravitino please see the ![Contribution guidelines](CONTRIBUTING.md).
+Gravitino is open source software available under the Apache 2.0 license. For information of how to contribute to Gravitino please see the [Contribution guidelines](CONTRIBUTING.md).
 
 ## Online documentation
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Should be HTTP link not image link syntax.

### Why are the changes needed?

Fix broken image and display link in readme.

Fix: # N/A

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

N/A
