### PR TITLE
[Minor] improvement(docs): Change the link of java doc

### DIFF
--- a/docs/manage-metadata-using-gravitino.md
+++ b/docs/manage-metadata-using-gravitino.md
@@ -565,7 +565,7 @@ The following the types that Gravitino supports:
 | Union                     | `Types.UnionType.of([type1, type2, ...])`                                | `{"type": "union", "types": [type JSON, ...]}`                                                                                       | Union type, indicate a union of types     
 
 
-The related java doc is [here](./api/java/javadoc/com/datastrato/gravitino/rel/types/Type.html).
+The related java doc is [here](./api/java/com/datastrato/gravitino/rel/types/Type.html).
 
 #### Table property and type mapping
 
@@ -581,11 +581,11 @@ The following is the table property that Gravitino supports:
 
 In addition to the basic settings, Gravitino supports the following features:
 
-| Feature             | Description                                                                                  | Java doc                                                                                                |
-|---------------------|----------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------|
-| Partitioned table   | Equal to `PARTITION BY` in Apache Hive and other engine that support partitioning.           | [Partition](./api/java/javadoc/com/datastrato/gravitino/dto/rel/partitions/Partitioning.html)           |
-| Bucketed table      | Equal to `CLUSTERED BY` in Apache Hive, some engine may use different words to describe it.  | [Distribution](./api/java/javadoc/datastrato/gravitino/rel/expressions/distributions/Distribution.html) |
-| Sorted order table  | Equal to `SORTED BY` in Apache Hive, some engine may use different words to describe it.     | [SortOrder](./api/java/javadoc/com/datastrato/gravitino/rel/expressions/sorts/SortOrder.html)           |
+| Feature             | Description                                                                                  | Java doc                                                                                        |
+|---------------------|----------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------|
+| Partitioned table   | Equal to `PARTITION BY` in Apache Hive and other engine that support partitioning.           | [Partition](./api/java/com/datastrato/gravitino/dto/rel/partitions/Partitioning.html)           |
+| Bucketed table      | Equal to `CLUSTERED BY` in Apache Hive, some engine may use different words to describe it.  | [Distribution](./api/java/datastrato/gravitino/rel/expressions/distributions/Distribution.html) |
+| Sorted order table  | Equal to `SORTED BY` in Apache Hive, some engine may use different words to describe it.     | [SortOrder](./api/java/com/datastrato/gravitino/rel/expressions/sorts/SortOrder.html)           |
 
 :::tip
 **Those features may not be supported by all catalogs**. Please refer to the related doc for more details.


### PR DESCRIPTION


### What changes were proposed in this pull request?

Change the link of java doc to `docs/api/java`

### Why are the changes needed?

To uniform links

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

N/A
