### PR TITLE
[Minor] Change link to Discourse

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,7 +106,7 @@ For any bugs or new code please add unit tests to provide coverage of the code. 
 
 ## Community and communication
 
-Join the [community chat](https://datastrato-community.slack.com) to discuss ideas and seek help. You are also encouraged to use GitHub discussions and follow Datastrato on social media to stay updated on project news.
+Join the [community discourse group](https://gravitino.discourse.group) to discuss ideas and seek help. You are also encouraged to use GitHub discussions and follow Datastrato on social media to stay updated on project news.
 
 ## License
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

We're using Discourse now.

### Why are the changes needed?

We're no longer using Slack for public discussion.

Fix: # N/A

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

N/A