### PR TITLE
[#1368] feat(jdbc): Automatically load jdbc-driver.

### DIFF
--- a/catalogs/catalog-jdbc-common/src/main/java/com/datastrato/gravitino/catalog/jdbc/config/JdbcConfig.java
+++ b/catalogs/catalog-jdbc-common/src/main/java/com/datastrato/gravitino/catalog/jdbc/config/JdbcConfig.java
@@ -10,6 +10,7 @@ import com.datastrato.gravitino.config.ConfigBuilder;
 import com.datastrato.gravitino.config.ConfigConstants;
 import com.datastrato.gravitino.config.ConfigEntry;
 import java.util.Map;
+import java.util.Optional;
 import org.apache.commons.lang3.StringUtils;
 
 public class JdbcConfig extends Config {
@@ -30,13 +31,12 @@ public class JdbcConfig extends Config {
           .checkValue(StringUtils::isNotBlank, ConfigConstants.NOT_BLANK_ERROR_MSG)
           .create();
 
-  public static final ConfigEntry<String> JDBC_DRIVER =
+  public static final ConfigEntry<Optional<String>> JDBC_DRIVER =
       new ConfigBuilder("jdbc-driver")
           .doc("The driver of the jdbc connection")
           .version("0.3.0")
           .stringConf()
-          .checkValue(StringUtils::isNotBlank, ConfigConstants.NOT_BLANK_ERROR_MSG)
-          .create();
+          .createWithOptional();
 
   public static final ConfigEntry<String> USERNAME =
       new ConfigBuilder("jdbc-user")
@@ -74,7 +74,7 @@ public class JdbcConfig extends Config {
     return get(JDBC_URL);
   }
 
-  public String getJdbcDriver() {
+  public Optional<String> getJdbcDriverOptional() {
     return get(JDBC_DRIVER);
   }
 

--- a/catalogs/catalog-jdbc-common/src/main/java/com/datastrato/gravitino/catalog/jdbc/utils/DataSourceUtils.java
+++ b/catalogs/catalog-jdbc-common/src/main/java/com/datastrato/gravitino/catalog/jdbc/utils/DataSourceUtils.java
@@ -6,6 +6,7 @@ package com.datastrato.gravitino.catalog.jdbc.utils;
 
 import com.datastrato.gravitino.catalog.jdbc.config.JdbcConfig;
 import com.datastrato.gravitino.exceptions.GravitinoRuntimeException;
+import com.google.common.annotations.VisibleForTesting;
 import java.sql.SQLException;
 import java.util.Map;
 import java.util.Properties;
@@ -23,6 +24,7 @@ public class DataSourceUtils {
   /** SQL statements for database connection pool testing. */
   private static final String POOL_TEST_QUERY = "SELECT 1";
 
+  @VisibleForTesting
   public static DataSource createDataSource(Map<String, String> properties) {
     return createDataSource(new JdbcConfig(properties));
   }
@@ -41,8 +43,7 @@ public class DataSourceUtils {
         BasicDataSourceFactory.createDataSource(getProperties(jdbcConfig));
     String jdbcUrl = jdbcConfig.getJdbcUrl();
     basicDataSource.setUrl(jdbcUrl);
-    String driverClassName = jdbcConfig.getJdbcDriver();
-    basicDataSource.setDriverClassName(driverClassName);
+    jdbcConfig.getJdbcDriverOptional().ifPresent(basicDataSource::setDriverClassName);
     String userName = jdbcConfig.getUsername();
     basicDataSource.setUsername(userName);
     String password = jdbcConfig.getPassword();

--- a/catalogs/catalog-jdbc-mysql/src/main/java/com/datastrato/gravitino/catalog/mysql/MysqlCatalog.java
+++ b/catalogs/catalog-jdbc-mysql/src/main/java/com/datastrato/gravitino/catalog/mysql/MysqlCatalog.java
@@ -17,6 +17,21 @@ import com.datastrato.gravitino.catalog.mysql.operation.MysqlTableOperations;
 /** Implementation of a Mysql catalog in Gravitino. */
 public class MysqlCatalog extends JdbcCatalog {
 
+  public MysqlCatalog() {
+    try {
+      // Try to load the jdbc-driver automatically
+      Class.forName("com.mysql.jdbc.Driver");
+    } catch (ClassNotFoundException ignore) {
+      // Ignore
+      try {
+        // Try to load the jdbc-driver automatically
+        Class.forName("com.mysql.cj.jdbc.Driver");
+      } catch (ClassNotFoundException ignore2) {
+        // Ignore
+      }
+    }
+  }
+
   @Override
   public String shortName() {
     return "jdbc-mysql";

--- a/catalogs/catalog-jdbc-postgresql/src/main/java/com/datastrato/gravitino/catalog/postgresql/PostgreSqlCatalog.java
+++ b/catalogs/catalog-jdbc-postgresql/src/main/java/com/datastrato/gravitino/catalog/postgresql/PostgreSqlCatalog.java
@@ -16,6 +16,15 @@ import com.datastrato.gravitino.catalog.postgresql.operation.PostgreSqlTableOper
 
 public class PostgreSqlCatalog extends JdbcCatalog {
 
+  public PostgreSqlCatalog() {
+    try {
+      // Try to load the jdbc-driver automatically
+      Class.forName("org.postgresql.Driver");
+    } catch (ClassNotFoundException ignore) {
+      // Ignore
+    }
+  }
+
   @Override
   public String shortName() {
     return "jdbc-postgresql";

--- a/docs/jdbc-mysql-catalog.md
+++ b/docs/jdbc-mysql-catalog.md
@@ -27,16 +27,16 @@ Gravitino provides the ability to manage MySQL metadata.
 Any property that isn't defined by Gravitino can pass to MySQL data source by adding `gravitino.bypass` prefix as a catalog property. For example, catalog property `gravitino.bypass.maxWaitMillis` will pass `maxWaitMillis` to the data source property.
 You can check the relevant data source configuration in [data source properties](https://commons.apache.org/proper/commons-dbcp/configuration.html)
 
-If you use JDBC catalog, you must provide `jdbc-url`, `jdbc-driver`, `jdbc-user` and `jdbc-password` to catalog properties.
+If you use JDBC catalog, you must provide `jdbc-url`, `jdbc-user` and `jdbc-password` to catalog properties.
 
-| Configuration item      | Description                                                                                                | Default value | Required | Since Version |
-|-------------------------|------------------------------------------------------------------------------------------------------------|---------------|----------|---------------|
-| `jdbc-url`              | JDBC URL for connecting to the database. For example `jdbc:mysql://localhost:3306`                         | (none)        | Yes      | 0.3.0         |
-| `jdbc-driver`           | The driver of the JDBC connection. For example `com.mysql.jdbc.Driver` or `com.mysql.cj.jdbc.Driver`.      | (none)        | Yes      | 0.3.0         |
-| `jdbc-user`             | The JDBC user name.                                                                                        | (none)        | Yes      | 0.3.0         |
-| `jdbc-password`         | The JDBC password.                                                                                         | (none)        | Yes      | 0.3.0         |
-| `jdbc.pool.min-size`    | The minimum number of connections in the pool. `2` by default.                                             | `2`           | No       | 0.3.0         |
-| `jdbc.pool.max-size`    | The maximum number of connections in the pool. `10` by default.                                            | `10`          | No       | 0.3.0         |
+| Configuration item      | Description                                                                                                             | Default value                                          | Required | Since Version |
+|-------------------------|-------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------|----------|---------------|
+| `jdbc-url`              | JDBC URL for connecting to the database. For example `jdbc:mysql://localhost:3306`                                      | (none)                                                 | Yes      | 0.3.0         |
+| `jdbc-driver`           | The driver of the JDBC connection. Will be loaded automatically `com.mysql.jdbc.Driver` and `com.mysql.cj.jdbc.Driver`. | `com.mysql.jdbc.Driver` and `com.mysql.cj.jdbc.Driver` | No       | 0.4.0         |
+| `jdbc-user`             | The JDBC user name.                                                                                                     | (none)                                                 | Yes      | 0.3.0         |
+| `jdbc-password`         | The JDBC password.                                                                                                      | (none)                                                 | Yes      | 0.3.0         |
+| `jdbc.pool.min-size`    | The minimum number of connections in the pool. `2` by default.                                                          | `2`                                                    | No       | 0.3.0         |
+| `jdbc.pool.max-size`    | The maximum number of connections in the pool. `10` by default.                                                         | `10`                                                   | No       | 0.3.0         |
 
 :::caution
 You must download the corresponding JDBC driver to the `catalogs/jdbc-mysql/libs` directory.

--- a/docs/jdbc-postgresql-catalog.md
+++ b/docs/jdbc-postgresql-catalog.md
@@ -28,17 +28,17 @@ Gravitino provides the ability to manage PostgreSQL metadata.
 Any property that isn't defined by Gravitino can pass to MySQL data source by adding `gravitino.bypass` prefix as a catalog property. For example, catalog property `gravitino.bypass.maxWaitMillis` will pass `maxWaitMillis` to the data source property.
 You can check the relevant data source configuration in [data source properties](https://commons.apache.org/proper/commons-dbcp/configuration.html)
 
-If you use JDBC catalog, you must provide `jdbc-url`, `jdbc-driver`, `jdbc-database`, `jdbc-user` and `jdbc-password` to catalog properties.
+If you use JDBC catalog, you must provide `jdbc-url`, `jdbc-database`, `jdbc-user` and `jdbc-password` to catalog properties.
 
-| Configuration item   | Description                                                                                                                                                       | Default value | Required | Since Version |
-|----------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|----------|---------------|
-| `jdbc-url`           | JDBC URL for connecting to the database. You need to specify the database in the URL. For example `jdbc:postgresql://localhost:3306/pg_database?sslmode=require`. | (none)        | Yes      | 0.3.0         |
-| `jdbc-driver`        | The driver of the JDBC connection. For example `org.postgresql.Driver`.                                                                                           | (none)        | Yes      | 0.3.0         |
-| `jdbc-database`      | The database of the JDBC connection. Configure it with the same value as the database in the `jdbc-url`. For example `pg_database`.                             | (none)        | Yes      | 0.3.0         |
-| `jdbc-user`          | The JDBC user name.                                                                                                                                               | (none)        | Yes      | 0.3.0         |
-| `jdbc-password`      | The JDBC password.                                                                                                                                                | (none)        | Yes      | 0.3.0         |
-| `jdbc.pool.min-size` | The minimum number of connections in the pool. `2` by default.                                                                                                    | `2`           | No       | 0.3.0         |
-| `jdbc.pool.max-size` | The maximum number of connections in the pool. `10` by default.                                                                                                   | `10`          | No       | 0.3.0         |
+| Configuration item   | Description                                                                                                                                                       | Default value               | Required | Since Version |
+|----------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------|----------|---------------|
+| `jdbc-url`           | JDBC URL for connecting to the database. You need to specify the database in the URL. For example `jdbc:postgresql://localhost:3306/pg_database?sslmode=require`. | (none)                      | Yes      | 0.3.0         |
+| `jdbc-driver`        | The driver of the JDBC connection. For example `org.postgresql.Driver`.                                                                                           | `org.postgresql.Driver`     | No       | 0.4.0         |
+| `jdbc-database`      | The database of the JDBC connection. Configure it with the same value as the database in the `jdbc-url`. For example `pg_database`.                               | (none)                      | Yes      | 0.3.0         |
+| `jdbc-user`          | The JDBC user name.                                                                                                                                               | (none)                      | Yes      | 0.3.0         |
+| `jdbc-password`      | The JDBC password.                                                                                                                                                | (none)                      | Yes      | 0.3.0         |
+| `jdbc.pool.min-size` | The minimum number of connections in the pool. `2` by default.                                                                                                    | `2`                         | No       | 0.3.0         |
+| `jdbc.pool.max-size` | The maximum number of connections in the pool. `10` by default.                                                                                                   | `10`                        | No       | 0.3.0         |
 
 :::caution
 You must download the corresponding JDBC driver to the `catalogs/jdbc-postgresql/libs` directory.

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/TestJdbcAbstractIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/TestJdbcAbstractIT.java
@@ -39,7 +39,6 @@ public abstract class TestJdbcAbstractIT {
   public static void startup() {
     CONTAINER.start();
     HashMap<String, String> properties = Maps.newHashMap();
-    properties.put(JdbcConfig.JDBC_DRIVER.getKey(), CONTAINER.getDriverClassName());
     properties.put(JdbcConfig.JDBC_URL.getKey(), CONTAINER.getJdbcUrl());
     properties.put(JdbcConfig.USERNAME.getKey(), CONTAINER.getUsername());
     properties.put(JdbcConfig.PASSWORD.getKey(), CONTAINER.getPassword());

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/TestMultipleJdbcLoad.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/TestMultipleJdbcLoad.java
@@ -85,7 +85,6 @@ public class TestMultipleJdbcLoad extends AbstractIT {
     String database = new URI(jdbcUrl.substring(jdbcUrl.lastIndexOf("/") + 1)).getPath();
     pgConf.put(JdbcConfig.JDBC_URL.getKey(), jdbcUrl);
     pgConf.put(JdbcConfig.JDBC_DATABASE.getKey(), database);
-    pgConf.put(JdbcConfig.JDBC_DRIVER.getKey(), postgreSQLContainer.getDriverClassName());
     pgConf.put(JdbcConfig.USERNAME.getKey(), postgreSQLContainer.getUsername());
     pgConf.put(JdbcConfig.PASSWORD.getKey(), postgreSQLContainer.getPassword());
 
@@ -103,7 +102,6 @@ public class TestMultipleJdbcLoad extends AbstractIT {
         JdbcConfig.JDBC_URL.getKey(),
         StringUtils.substring(
             mySQLContainer.getJdbcUrl(), 0, mySQLContainer.getJdbcUrl().lastIndexOf("/")));
-    mysqlConf.put(JdbcConfig.JDBC_DRIVER.getKey(), mySQLContainer.getDriverClassName());
     mysqlConf.put(JdbcConfig.USERNAME.getKey(), mySQLContainer.getUsername());
     mysqlConf.put(JdbcConfig.PASSWORD.getKey(), mySQLContainer.getPassword());
     String mysqlCatalogName = GravitinoITUtils.genRandomName("it_mysql");

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/mysql/AuditCatalogMysqlIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/mysql/AuditCatalogMysqlIT.java
@@ -155,7 +155,6 @@ public class AuditCatalogMysqlIT extends AbstractIT {
         JdbcConfig.JDBC_URL.getKey(),
         StringUtils.substring(
             MYSQL_CONTAINER.getJdbcUrl(), 0, MYSQL_CONTAINER.getJdbcUrl().lastIndexOf("/")));
-    catalogProperties.put(JdbcConfig.JDBC_DRIVER.getKey(), MYSQL_CONTAINER.getDriverClassName());
     catalogProperties.put(JdbcConfig.USERNAME.getKey(), MYSQL_CONTAINER.getUsername());
     catalogProperties.put(JdbcConfig.PASSWORD.getKey(), MYSQL_CONTAINER.getPassword());
 

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/mysql/CatalogMysqlIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/mysql/CatalogMysqlIT.java
@@ -143,7 +143,6 @@ public class CatalogMysqlIT extends AbstractIT {
         JdbcConfig.JDBC_URL.getKey(),
         StringUtils.substring(
             MYSQL_CONTAINER.getJdbcUrl(), 0, MYSQL_CONTAINER.getJdbcUrl().lastIndexOf("/")));
-    catalogProperties.put(JdbcConfig.JDBC_DRIVER.getKey(), MYSQL_CONTAINER.getDriverClassName());
     catalogProperties.put(JdbcConfig.USERNAME.getKey(), MYSQL_CONTAINER.getUsername());
     catalogProperties.put(JdbcConfig.PASSWORD.getKey(), MYSQL_CONTAINER.getPassword());
 

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/postgresql/CatalogPostgreSqlIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/postgresql/CatalogPostgreSqlIT.java
@@ -140,8 +140,6 @@ public class CatalogPostgreSqlIT extends AbstractIT {
     try {
       String jdbcUrl = POSTGRESQL_CONTAINER.getJdbcUrl();
       String database = new URI(jdbcUrl.substring(jdbcUrl.lastIndexOf("/") + 1)).getPath();
-      catalogProperties.put(
-          JdbcConfig.JDBC_DRIVER.getKey(), POSTGRESQL_CONTAINER.getDriverClassName());
       catalogProperties.put(JdbcConfig.JDBC_URL.getKey(), jdbcUrl);
       catalogProperties.put(JdbcConfig.JDBC_DATABASE.getKey(), database);
       catalogProperties.put(JdbcConfig.USERNAME.getKey(), POSTGRESQL_CONTAINER.getUsername());

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/postgresql/TestPostgreSqlSchemaOperations.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/postgresql/TestPostgreSqlSchemaOperations.java
@@ -50,7 +50,6 @@ public class TestPostgreSqlSchemaOperations extends TestPostgreSqlAbstractIT {
       JdbcConnectorUtils.executeUpdate(connection, "CREATE DATABASE " + testDbName);
     }
     HashMap<String, String> properties = Maps.newHashMap();
-    properties.put(JdbcConfig.JDBC_DRIVER.getKey(), CONTAINER.getDriverClassName());
     String jdbcUrl =
         StringUtils.substring(CONTAINER.getJdbcUrl(), 0, CONTAINER.getJdbcUrl().lastIndexOf("/"));
     properties.put(JdbcConfig.JDBC_URL.getKey(), jdbcUrl + "/" + testDbName);

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/postgresql/TestPostgreSqlTableOperations.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/postgresql/TestPostgreSqlTableOperations.java
@@ -314,7 +314,6 @@ public class TestPostgreSqlTableOperations extends TestPostgreSqlAbstractIT {
       JdbcConnectorUtils.executeUpdate(connection, "CREATE DATABASE " + testDbName);
     }
     HashMap<String, String> properties = Maps.newHashMap();
-    properties.put(JdbcConfig.JDBC_DRIVER.getKey(), CONTAINER.getDriverClassName());
     String jdbcUrl =
         StringUtils.substring(CONTAINER.getJdbcUrl(), 0, CONTAINER.getJdbcUrl().lastIndexOf("/"));
     properties.put(JdbcConfig.JDBC_URL.getKey(), jdbcUrl + "/" + testDbName);


### PR DESCRIPTION
### What changes were proposed in this pull request?
Automatically load based on the catalog when the user has not configured the jdbc-driver parameter.

### Why are the changes needed?
Fix: #1368

### Does this PR introduce _any_ user-facing change?
Users are no longer forced to configure this parameter.

### How was this patch tested?
IT
