### PR TITLE
[#2382] feat(gradlew): add AssertFalse errorprone

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -224,6 +224,7 @@ subprojects {
         "ArrayToString",
         "ArraysAsListPrimitiveArray",
         "ArrayFillIncompatibleType",
+        "AssertFalse",
         "BoxedPrimitiveEquality",
         "ChainingConstructorIgnoresParameter",
         "CheckNotNullMultipleTimes",


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Enable`AssertFalse` error-prone.

### Why are the changes needed?

Explicctly disable using `assert false` in Gravition.

Fix: #2382

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

Add `assert false;` to code base, run `./gradlew build -x test` and we can see following error:

```
warning: [AssertFalse] Assertions may be disabled at runtime and do not guarantee that execution will halt here; consider throwing an exception instead
```