### PR TITLE
[#2726] Add Dockerfile for Compile Gravitino using Docker

### DIFF
--- a/dev/ci/dev-env.Dockerfile
+++ b/dev/ci/dev-env.Dockerfile
@@ -1,0 +1,12 @@
+#
+# Copyright 2023 Datastrato Pvt Ltd.
+# This software is licensed under the Apache License version 2.
+#
+FROM openjdk:8-jdk-buster
+LABEL maintainer="support@datastrato.com"
+
+WORKDIR /root/gravitino
+
+COPY ../docker/dockerfile /root/gravitino
+
+RUN ./gradlew assembleDistribution -x test

--- a/dev/docker/building/README.md
+++ b/dev/docker/building/README.md
@@ -1,0 +1,30 @@
+# Gravitino Dev Env Image
+This directory contains dockerfiles to build the docker image for the development environment.
+
+A Gravitino development environment contains all necessary development tools installed as well as prebuilt Gravitino third
+party dependencies.
+
+## 1 Build dev env image
+
+### 1.1 Build dev env image
+```
+DOCKER_BUILDKIT=1 docker build --rm=true -f dev-env.Dockerfile -t ghcr.io/OWNER/gravitino/dev-env:<tag> .
+```
+E.g.:
+```shell
+DOCKER_BUILDKIT=1 docker build --rm=true -f dev-env.Dockerfile -t ghcr.io/gravitino/dev-env:main .
+```
+
+## 2 Publish image to ghcr
+```
+docker push ghcr.io/OWNER/starrocks/dev-env:<tag>
+```
+E.g.:
+```shell
+docker push ghcr.io/starrocks/starrocks/dev-env:main
+```
+
+## 3 Build an image and run in local
+```shell
+./build-docker.sh
+```

--- a/dev/docker/building/build-docker.sh
+++ b/dev/docker/building/build-docker.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+#
+# Copyright 2024 Datastrato Pvt Ltd.
+# This software is licensed under the Apache License version 2.
+#
+# Set Docker BuildKit
+export DOCKER_BUILDKIT=1
+
+# Construct Docker Image
+docker build --rm=true -f dev/docker/building/dev-env.Dockerfile -t gravitino/dev-env:main-v1.0 .
+
+docker run -it --rm gravitino/dev-env:main-v1.0 /bin/bash

--- a/dev/docker/building/dev-env.Dockerfile
+++ b/dev/docker/building/dev-env.Dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Datastrato Pvt Ltd.
+# Copyright 2024 Datastrato Pvt Ltd.
 # This software is licensed under the Apache License version 2.
 #
 FROM openjdk:8-jdk-buster
@@ -7,6 +7,6 @@ LABEL maintainer="support@datastrato.com"
 
 WORKDIR /root/gravitino
 
-COPY ../docker/dockerfile /root/gravitino
+COPY Dockerfile /root/gravitino
 
 RUN ./gradlew assembleDistribution -x test


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add Dockerfile for Compile Gravitino using Docker

### Why are the changes needed?

Gravitino community need to provide Docker images of the development environment, allowing developers to easily launch a Gravitino container and compile Gravitino within it

Fix: #2726

### Does this PR introduce _any_ user-facing change?

no

### How was this patch tested?

a dockerfile 
