### PR TITLE
[#3259] feat(spark-connector): Support atomic create or replace Iceberg table

### DIFF
--- a/integration-test/build.gradle.kts
+++ b/integration-test/build.gradle.kts
@@ -114,6 +114,7 @@ dependencies {
     exclude("io.dropwizard.metrics")
     exclude("org.rocksdb")
   }
+  testImplementation("org.apache.spark:spark-catalyst_$scalaVersion:$sparkVersion")
 
   testImplementation(libs.okhttp3.loginterceptor)
   testImplementation(libs.postgresql.driver)


### PR DESCRIPTION
### What changes were proposed in this pull request?

Support atomic create or replace Iceberg table.

### Why are the changes needed?

Support atomic create or replace Iceberg table.

Fix: https://github.com/datastrato/gravitino/issues/3259

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

New ITs.
