### PR TITLE
[#3282] improvement: Support sort order when create the Doris table.

### DIFF
--- a/api/src/main/java/com/datastrato/gravitino/rel/expressions/sorts/SortOrders.java
+++ b/api/src/main/java/com/datastrato/gravitino/rel/expressions/sorts/SortOrders.java
@@ -10,6 +10,8 @@ import java.util.Objects;
 /** Helper methods to create SortOrders to pass into Gravitino. */
 public class SortOrders {
 
+  /** A empty sort order instance to avoid using null value as the value of SortOrder[]. */
+  public static final SortOrder[] EMPTY_SORT_ORDERS = new SortOrder[] {};
   /**
    * Create a sort order by the given expression with the ascending sort direction and nulls first
    * ordering.

--- a/catalogs/catalog-jdbc-common/src/main/java/com/datastrato/gravitino/catalog/jdbc/JdbcCatalogOperations.java
+++ b/catalogs/catalog-jdbc-common/src/main/java/com/datastrato/gravitino/catalog/jdbc/JdbcCatalogOperations.java
@@ -370,9 +370,6 @@ public class JdbcCatalogOperations implements CatalogOperations, SupportsSchemas
       SortOrder[] sortOrders,
       Index[] indexes)
       throws NoSuchSchemaException, TableAlreadyExistsException {
-    Preconditions.checkArgument(
-        null == sortOrders || sortOrders.length == 0, "jdbc-catalog does not support sort orders");
-
     StringIdentifier identifier =
         Preconditions.checkNotNull(
             StringIdentifier.fromProperties(properties), GRAVITINO_ATTRIBUTE_DOES_NOT_EXIST_MSG);
@@ -404,6 +401,7 @@ public class JdbcCatalogOperations implements CatalogOperations, SupportsSchemas
         resultProperties,
         partitioning,
         distribution,
+        sortOrders,
         indexes);
 
     return JdbcTable.builder()

--- a/catalogs/catalog-jdbc-common/src/main/java/com/datastrato/gravitino/catalog/jdbc/operation/TableOperation.java
+++ b/catalogs/catalog-jdbc-common/src/main/java/com/datastrato/gravitino/catalog/jdbc/operation/TableOperation.java
@@ -15,6 +15,7 @@ import com.datastrato.gravitino.exceptions.NoSuchTableException;
 import com.datastrato.gravitino.exceptions.TableAlreadyExistsException;
 import com.datastrato.gravitino.rel.TableChange;
 import com.datastrato.gravitino.rel.expressions.distributions.Distribution;
+import com.datastrato.gravitino.rel.expressions.sorts.SortOrder;
 import com.datastrato.gravitino.rel.expressions.transforms.Transform;
 import com.datastrato.gravitino.rel.indexes.Index;
 import java.util.List;
@@ -45,6 +46,7 @@ public interface TableOperation {
    * @param comment The comment of the table.
    * @param properties The properties of the table.
    * @param partitioning The partitioning of the table.
+   * @param sortOrders The sort ordering of the table.
    * @param indexes The indexes of the table.
    */
   void create(
@@ -55,6 +57,7 @@ public interface TableOperation {
       Map<String, String> properties,
       Transform[] partitioning,
       Distribution distribution,
+      SortOrder[] sortOrders,
       Index[] indexes)
       throws TableAlreadyExistsException;
 

--- a/catalogs/catalog-jdbc-common/src/test/java/com/datastrato/gravitino/catalog/jdbc/operation/SqliteTableOperations.java
+++ b/catalogs/catalog-jdbc-common/src/test/java/com/datastrato/gravitino/catalog/jdbc/operation/SqliteTableOperations.java
@@ -11,6 +11,7 @@ import com.datastrato.gravitino.rel.Column;
 import com.datastrato.gravitino.rel.TableChange;
 import com.datastrato.gravitino.rel.expressions.distributions.Distribution;
 import com.datastrato.gravitino.rel.expressions.distributions.Distributions;
+import com.datastrato.gravitino.rel.expressions.sorts.SortOrder;
 import com.datastrato.gravitino.rel.expressions.transforms.Transform;
 import com.datastrato.gravitino.rel.indexes.Index;
 import com.google.common.base.Preconditions;
@@ -31,6 +32,7 @@ public class SqliteTableOperations extends JdbcTableOperations {
       Map<String, String> properties,
       Transform[] partitioning,
       Distribution distribution,
+      SortOrder[] sortOrders,
       Index[] indexes) {
     Preconditions.checkArgument(
         distribution == Distributions.NONE, "SQLite does not support distribution");

--- a/catalogs/catalog-jdbc-common/src/test/java/com/datastrato/gravitino/catalog/jdbc/operation/TestJdbcTableOperations.java
+++ b/catalogs/catalog-jdbc-common/src/test/java/com/datastrato/gravitino/catalog/jdbc/operation/TestJdbcTableOperations.java
@@ -142,6 +142,7 @@ public class TestJdbcTableOperations {
                 properties,
                 null,
                 Distributions.NONE,
+                null,
                 Indexes.EMPTY_INDEXES));
 
     // list table.

--- a/catalogs/catalog-jdbc-mysql/src/main/java/com/datastrato/gravitino/catalog/mysql/operation/MysqlTableOperations.java
+++ b/catalogs/catalog-jdbc-mysql/src/main/java/com/datastrato/gravitino/catalog/mysql/operation/MysqlTableOperations.java
@@ -19,6 +19,7 @@ import com.datastrato.gravitino.rel.Column;
 import com.datastrato.gravitino.rel.TableChange;
 import com.datastrato.gravitino.rel.expressions.distributions.Distribution;
 import com.datastrato.gravitino.rel.expressions.distributions.Distributions;
+import com.datastrato.gravitino.rel.expressions.sorts.SortOrder;
 import com.datastrato.gravitino.rel.expressions.transforms.Transform;
 import com.datastrato.gravitino.rel.indexes.Index;
 import com.datastrato.gravitino.rel.indexes.Indexes;
@@ -79,13 +80,17 @@ public class MysqlTableOperations extends JdbcTableOperations {
       Map<String, String> properties,
       Transform[] partitioning,
       Distribution distribution,
+      SortOrder[] sortOrders,
       Index[] indexes) {
     if (ArrayUtils.isNotEmpty(partitioning)) {
-      throw new UnsupportedOperationException("Currently we do not support Partitioning in mysql");
+      throw new UnsupportedOperationException("Currently we do not support Partitioning in MySQL");
     }
 
     Preconditions.checkArgument(
         Distributions.NONE.equals(distribution), "MySQL does not support distribution");
+
+    Preconditions.checkArgument(
+        null == sortOrders || sortOrders.length == 0, "MySQL catalog does not support sort orders");
 
     validateIncrementCol(columns, indexes);
     StringBuilder sqlBuilder = new StringBuilder();

--- a/catalogs/catalog-jdbc-mysql/src/test/java/com/datastrato/gravitino/catalog/mysql/integration/test/MysqlTableOperationsIT.java
+++ b/catalogs/catalog-jdbc-mysql/src/test/java/com/datastrato/gravitino/catalog/mysql/integration/test/MysqlTableOperationsIT.java
@@ -15,6 +15,7 @@ import com.datastrato.gravitino.rel.Column;
 import com.datastrato.gravitino.rel.TableChange;
 import com.datastrato.gravitino.rel.expressions.distributions.Distributions;
 import com.datastrato.gravitino.rel.expressions.literals.Literals;
+import com.datastrato.gravitino.rel.expressions.sorts.SortOrders;
 import com.datastrato.gravitino.rel.indexes.Index;
 import com.datastrato.gravitino.rel.indexes.Indexes;
 import com.datastrato.gravitino.rel.types.Decimal;
@@ -86,6 +87,7 @@ public class MysqlTableOperationsIT extends TestMysqlAbstractIT {
         properties,
         null,
         Distributions.NONE,
+        SortOrders.EMPTY_SORT_ORDERS,
         indexes);
 
     // list table
@@ -225,6 +227,7 @@ public class MysqlTableOperationsIT extends TestMysqlAbstractIT {
         properties,
         null,
         Distributions.NONE,
+        SortOrders.EMPTY_SORT_ORDERS,
         indexes);
     JdbcTable load = TABLE_OPERATIONS.load(TEST_DB_NAME.toString(), tableName);
     assertionsTableInfo(tableName, tableComment, columns, properties, indexes, load);
@@ -484,6 +487,7 @@ public class MysqlTableOperationsIT extends TestMysqlAbstractIT {
         properties,
         null,
         Distributions.NONE,
+        SortOrders.EMPTY_SORT_ORDERS,
         indexes);
 
     JdbcTable loaded = TABLE_OPERATIONS.load(TEST_DB_NAME.toString(), tableName);
@@ -568,6 +572,7 @@ public class MysqlTableOperationsIT extends TestMysqlAbstractIT {
         properties,
         null,
         Distributions.NONE,
+        SortOrders.EMPTY_SORT_ORDERS,
         indexes);
 
     JdbcTable loaded = TABLE_OPERATIONS.load(TEST_DB_NAME.toString(), tableName);
@@ -666,6 +671,7 @@ public class MysqlTableOperationsIT extends TestMysqlAbstractIT {
         Collections.emptyMap(),
         null,
         Distributions.NONE,
+        SortOrders.EMPTY_SORT_ORDERS,
         Indexes.EMPTY_INDEXES);
 
     JdbcTable load = TABLE_OPERATIONS.load(TEST_DB_NAME.toString(), tableName);
@@ -710,6 +716,7 @@ public class MysqlTableOperationsIT extends TestMysqlAbstractIT {
                     emptyMap,
                     null,
                     Distributions.NONE,
+                    SortOrders.EMPTY_SORT_ORDERS,
                     Indexes.EMPTY_INDEXES);
               });
       Assertions.assertTrue(
@@ -740,6 +747,7 @@ public class MysqlTableOperationsIT extends TestMysqlAbstractIT {
         null,
         null,
         Distributions.NONE,
+        SortOrders.EMPTY_SORT_ORDERS,
         Indexes.EMPTY_INDEXES);
 
     String testDb = "test_db_2";
@@ -765,6 +773,7 @@ public class MysqlTableOperationsIT extends TestMysqlAbstractIT {
         null,
         null,
         Distributions.NONE,
+        SortOrders.EMPTY_SORT_ORDERS,
         Indexes.EMPTY_INDEXES);
 
     tables = TABLE_OPERATIONS.listTables(TEST_DB_NAME.toString());
@@ -789,6 +798,7 @@ public class MysqlTableOperationsIT extends TestMysqlAbstractIT {
         null,
         null,
         Distributions.NONE,
+        SortOrders.EMPTY_SORT_ORDERS,
         Indexes.EMPTY_INDEXES);
     JdbcTable load = TABLE_OPERATIONS.load(TEST_DB_NAME.toString(), test_table_1);
     Assertions.assertEquals("InnoDB", load.properties().get(MYSQL_ENGINE_KEY));
@@ -839,6 +849,7 @@ public class MysqlTableOperationsIT extends TestMysqlAbstractIT {
         properties,
         null,
         Distributions.NONE,
+        SortOrders.EMPTY_SORT_ORDERS,
         indexes);
 
     JdbcTable table = TABLE_OPERATIONS.load(TEST_DB_NAME.toString(), tableName);
@@ -865,6 +876,7 @@ public class MysqlTableOperationsIT extends TestMysqlAbstractIT {
         properties,
         null,
         Distributions.NONE,
+        SortOrders.EMPTY_SORT_ORDERS,
         indexes);
 
     table = TABLE_OPERATIONS.load(TEST_DB_NAME.toString(), tableName);
@@ -887,6 +899,7 @@ public class MysqlTableOperationsIT extends TestMysqlAbstractIT {
         properties,
         null,
         Distributions.NONE,
+        SortOrders.EMPTY_SORT_ORDERS,
         indexes);
 
     table = TABLE_OPERATIONS.load(TEST_DB_NAME.toString(), tableName);
@@ -912,6 +925,7 @@ public class MysqlTableOperationsIT extends TestMysqlAbstractIT {
                     properties,
                     null,
                     Distributions.NONE,
+                    SortOrders.EMPTY_SORT_ORDERS,
                     Indexes.EMPTY_INDEXES));
     Assertions.assertTrue(
         StringUtils.contains(
@@ -946,6 +960,7 @@ public class MysqlTableOperationsIT extends TestMysqlAbstractIT {
                     properties,
                     null,
                     Distributions.NONE,
+                    SortOrders.EMPTY_SORT_ORDERS,
                     primaryIndex));
     Assertions.assertTrue(
         StringUtils.contains(

--- a/catalogs/catalog-jdbc-mysql/src/test/java/com/datastrato/gravitino/catalog/mysql/integration/test/TestMysqlDatabaseOperations.java
+++ b/catalogs/catalog-jdbc-mysql/src/test/java/com/datastrato/gravitino/catalog/mysql/integration/test/TestMysqlDatabaseOperations.java
@@ -8,6 +8,7 @@ import static com.datastrato.gravitino.catalog.mysql.operation.MysqlDatabaseOper
 
 import com.datastrato.gravitino.catalog.jdbc.JdbcColumn;
 import com.datastrato.gravitino.rel.expressions.distributions.Distributions;
+import com.datastrato.gravitino.rel.expressions.sorts.SortOrders;
 import com.datastrato.gravitino.rel.expressions.transforms.Transform;
 import com.datastrato.gravitino.rel.indexes.Index;
 import com.datastrato.gravitino.rel.types.Types;
@@ -66,6 +67,7 @@ public class TestMysqlDatabaseOperations extends TestMysqlAbstractIT {
         properties,
         new Transform[0],
         Distributions.NONE,
+        SortOrders.EMPTY_SORT_ORDERS,
         new Index[0]);
     DATABASE_OPERATIONS.delete(databaseName, true);
   }

--- a/catalogs/catalog-jdbc-postgresql/src/main/java/com/datastrato/gravitino/catalog/postgresql/operation/PostgreSqlTableOperations.java
+++ b/catalogs/catalog-jdbc-postgresql/src/main/java/com/datastrato/gravitino/catalog/postgresql/operation/PostgreSqlTableOperations.java
@@ -20,6 +20,7 @@ import com.datastrato.gravitino.rel.Column;
 import com.datastrato.gravitino.rel.TableChange;
 import com.datastrato.gravitino.rel.expressions.distributions.Distribution;
 import com.datastrato.gravitino.rel.expressions.distributions.Distributions;
+import com.datastrato.gravitino.rel.expressions.sorts.SortOrder;
 import com.datastrato.gravitino.rel.expressions.transforms.Transform;
 import com.datastrato.gravitino.rel.indexes.Index;
 import com.datastrato.gravitino.rel.types.Types;
@@ -101,6 +102,7 @@ public class PostgreSqlTableOperations extends JdbcTableOperations {
       Map<String, String> properties,
       Transform[] partitioning,
       Distribution distribution,
+      SortOrder[] sortOrders,
       Index[] indexes) {
     if (ArrayUtils.isNotEmpty(partitioning)) {
       throw new UnsupportedOperationException(
@@ -108,6 +110,10 @@ public class PostgreSqlTableOperations extends JdbcTableOperations {
     }
     Preconditions.checkArgument(
         Distributions.NONE.equals(distribution), "PostgreSQL does not support distribution");
+
+    Preconditions.checkArgument(
+        null == sortOrders || sortOrders.length == 0,
+        "PostgreSQL catalog does not support sort orders");
 
     StringBuilder sqlBuilder = new StringBuilder();
     sqlBuilder

--- a/catalogs/catalog-jdbc-postgresql/src/test/java/com/datastrato/gravitino/catalog/postgresql/integration/test/PostgreSqlTableOperationsIT.java
+++ b/catalogs/catalog-jdbc-postgresql/src/test/java/com/datastrato/gravitino/catalog/postgresql/integration/test/PostgreSqlTableOperationsIT.java
@@ -18,6 +18,7 @@ import com.datastrato.gravitino.exceptions.NoSuchTableException;
 import com.datastrato.gravitino.rel.TableChange;
 import com.datastrato.gravitino.rel.expressions.distributions.Distributions;
 import com.datastrato.gravitino.rel.expressions.literals.Literals;
+import com.datastrato.gravitino.rel.expressions.sorts.SortOrders;
 import com.datastrato.gravitino.rel.indexes.Index;
 import com.datastrato.gravitino.rel.indexes.Indexes;
 import com.datastrato.gravitino.rel.types.Type;
@@ -352,6 +353,7 @@ public class PostgreSqlTableOperationsIT extends TestPostgreSqlAbstractIT {
         Collections.emptyMap(),
         null,
         Distributions.NONE,
+        SortOrders.EMPTY_SORT_ORDERS,
         Indexes.EMPTY_INDEXES);
 
     JdbcTable load = TABLE_OPERATIONS.load(TEST_DB_NAME, tableName);
@@ -407,6 +409,7 @@ public class PostgreSqlTableOperationsIT extends TestPostgreSqlAbstractIT {
         null,
         null,
         Distributions.NONE,
+        SortOrders.EMPTY_SORT_ORDERS,
         Indexes.EMPTY_INDEXES);
 
     List<String> tableNames = TABLE_OPERATIONS.listTables(TEST_DB_NAME);
@@ -436,6 +439,7 @@ public class PostgreSqlTableOperationsIT extends TestPostgreSqlAbstractIT {
         null,
         null,
         Distributions.NONE,
+        SortOrders.EMPTY_SORT_ORDERS,
         Indexes.EMPTY_INDEXES);
     tableNames = postgreSqlTableOperations.listTables(TEST_DB_NAME);
     Assertions.assertFalse(tableNames.contains(table_2));
@@ -488,6 +492,7 @@ public class PostgreSqlTableOperationsIT extends TestPostgreSqlAbstractIT {
         properties,
         null,
         Distributions.NONE,
+        SortOrders.EMPTY_SORT_ORDERS,
         Indexes.EMPTY_INDEXES);
 
     // list table
@@ -530,6 +535,7 @@ public class PostgreSqlTableOperationsIT extends TestPostgreSqlAbstractIT {
                   properties,
                   null,
                   Distributions.NONE,
+                  SortOrders.EMPTY_SORT_ORDERS,
                   Indexes.EMPTY_INDEXES);
             });
 
@@ -589,6 +595,7 @@ public class PostgreSqlTableOperationsIT extends TestPostgreSqlAbstractIT {
         properties,
         null,
         Distributions.NONE,
+        SortOrders.EMPTY_SORT_ORDERS,
         indexes);
 
     JdbcTable load = TABLE_OPERATIONS.load(TEST_DB_NAME, tableName);
@@ -615,6 +622,7 @@ public class PostgreSqlTableOperationsIT extends TestPostgreSqlAbstractIT {
                   properties,
                   null,
                   Distributions.NONE,
+                  SortOrders.EMPTY_SORT_ORDERS,
                   primaryIndex);
             });
     Assertions.assertTrue(

--- a/catalogs/catalog-jdbc-postgresql/src/test/java/com/datastrato/gravitino/catalog/postgresql/integration/test/PostgreSqlTableOperationsIT.java
+++ b/catalogs/catalog-jdbc-postgresql/src/test/java/com/datastrato/gravitino/catalog/postgresql/integration/test/PostgreSqlTableOperationsIT.java
@@ -82,6 +82,7 @@ public class PostgreSqlTableOperationsIT extends TestPostgreSqlAbstractIT {
         properties,
         null,
         Distributions.NONE,
+        SortOrders.EMPTY_SORT_ORDERS,
         Indexes.EMPTY_INDEXES);
 
     // list table


### PR DESCRIPTION
### What changes were proposed in this pull request?

1. Move check `sortorder` logic into the corresponding implementation from `JdbcTableOperation`
2. Support `SortOrder` when create a Doris table.

### Why are the changes needed?

Doris supports creating a sorted table, we need to implement it in Gravitino API. 

Close: #3282 

### Does this PR introduce _any_ user-facing change?

N/A.

### How was this patch tested?

Add test `testSortOrderTable`
