### PR TITLE
[#3136] fix(spark-connector): support replace column with same column name for spark connector

### DIFF
--- a/catalogs/catalog-hive/src/main/java/org/apache/gravitino/catalog/hive/HiveCatalogOperations.java
+++ b/catalogs/catalog-hive/src/main/java/org/apache/gravitino/catalog/hive/HiveCatalogOperations.java
@@ -674,11 +674,11 @@ public class HiveCatalogOperations implements CatalogOperations, SupportsSchemas
         .filter(c -> c instanceof TableChange.ColumnChange)
         .forEach(
             c -> {
-              String fieldToAdd = String.join(".", ((TableChange.ColumnChange) c).fieldName());
+              String fieldName = String.join(".", ((TableChange.ColumnChange) c).fieldName());
               Preconditions.checkArgument(
                   c instanceof TableChange.UpdateColumnComment
-                      || !partitionFields.contains(fieldToAdd),
-                  "Cannot alter partition column: " + fieldToAdd);
+                      || !partitionFields.contains(fieldName),
+                  "Cannot alter partition column: " + fieldName);
 
               if (c instanceof TableChange.UpdateColumnPosition
                   && afterPartitionColumn(
@@ -687,12 +687,16 @@ public class HiveCatalogOperations implements CatalogOperations, SupportsSchemas
                     "Cannot alter column position to after partition column");
               }
 
+              if (c instanceof TableChange.DeleteColumn) {
+                existingFields.remove(fieldName);
+              }
+
               if (c instanceof TableChange.AddColumn) {
                 TableChange.AddColumn addColumn = (TableChange.AddColumn) c;
 
-                if (existingFields.contains(fieldToAdd)) {
+                if (existingFields.contains(fieldName)) {
                   throw new IllegalArgumentException(
-                      "Cannot add column with duplicate name: " + fieldToAdd);
+                      "Cannot add column with duplicate name: " + fieldName);
                 }
 
                 if (addColumn.getPosition() == null) {

--- a/catalogs/catalog-lakehouse-iceberg/src/main/java/org/apache/gravitino/catalog/lakehouse/iceberg/ops/IcebergTableOpsHelper.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/main/java/org/apache/gravitino/catalog/lakehouse/iceberg/ops/IcebergTableOpsHelper.java
@@ -160,7 +160,7 @@ public class IcebergTableOpsHelper {
     icebergUpdateSchema.updateColumn(fieldName, (PrimitiveType) type);
   }
 
-  // Iceberg doesn't support LAST
+  // Iceberg doesn't support LAST position, transform to FIRST or AFTER.
   private ColumnPosition getColumnPositionForIceberg(
       StructType parent, ColumnPosition columnPosition) {
     if (!(columnPosition instanceof TableChange.Default)) {

--- a/catalogs/catalog-lakehouse-iceberg/src/test/java/org/apache/gravitino/catalog/lakehouse/iceberg/integration/test/CatalogIcebergBaseIT.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/test/java/org/apache/gravitino/catalog/lakehouse/iceberg/integration/test/CatalogIcebergBaseIT.java
@@ -588,7 +588,7 @@ public abstract class CatalogIcebergBaseIT extends AbstractIT {
   public void testUpdateIcebergColumnDefaultPosition() {
     Column col1 = Column.of("name", Types.StringType.get(), "comment");
     Column col2 = Column.of("address", Types.StringType.get(), "comment");
-    Column col3 = Column.of("date_of_birth", Types.DateType.get(), "comment");
+    Column col3 = Column.of("date_of_birth", Types.StringType.get(), "comment");
     Column[] newColumns = new Column[] {col1, col2, col3};
     NameIdentifier tableIdentifier =
         NameIdentifier.of(schemaName, GravitinoITUtils.genRandomName("CatalogIcebergIT_table"));

--- a/catalogs/catalog-lakehouse-iceberg/src/test/java/org/apache/gravitino/catalog/lakehouse/iceberg/integration/test/CatalogIcebergBaseIT.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/test/java/org/apache/gravitino/catalog/lakehouse/iceberg/integration/test/CatalogIcebergBaseIT.java
@@ -585,6 +585,43 @@ public abstract class CatalogIcebergBaseIT extends AbstractIT {
   }
 
   @Test
+  public void testUpdateIcebergColumnDefaultPosition() {
+    Column col1 = Column.of("name", Types.StringType.get(), "comment");
+    Column col2 = Column.of("address", Types.StringType.get(), "comment");
+    Column col3 = Column.of("date_of_birth", Types.DateType.get(), "comment");
+    Column[] newColumns = new Column[] {col1, col2, col3};
+    NameIdentifier tableIdentifier =
+        NameIdentifier.of(schemaName, GravitinoITUtils.genRandomName("CatalogIcebergIT_table"));
+    catalog
+        .asTableCatalog()
+        .createTable(
+            tableIdentifier,
+            newColumns,
+            table_comment,
+            ImmutableMap.of(),
+            Transforms.EMPTY_TRANSFORM,
+            Distributions.NONE,
+            new SortOrder[0]);
+
+    catalog
+        .asTableCatalog()
+        .alterTable(
+            tableIdentifier,
+            TableChange.updateColumnPosition(
+                new String[] {col1.name()}, TableChange.ColumnPosition.defaultPos()));
+
+    Table updateColumnPositionTable = catalog.asTableCatalog().loadTable(tableIdentifier);
+
+    Column[] updateCols = updateColumnPositionTable.columns();
+    Assertions.assertEquals(3, updateCols.length);
+    Assertions.assertEquals(col2.name(), updateCols[0].name());
+    Assertions.assertEquals(col3.name(), updateCols[1].name());
+    Assertions.assertEquals(col1.name(), updateCols[2].name());
+
+    catalog.asTableCatalog().dropTable(tableIdentifier);
+  }
+
+  @Test
   public void testAlterIcebergTable() {
     Column[] columns = createColumns();
     Table table =

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,4 +40,4 @@ defaultScalaVersion = 2.12
 pythonVersion = 3.8
 
 # skipDockerTests is used to skip the tests that require Docker to be running.
-skipDockerTests = true
+skipDockerTests = false

--- a/spark-connector/spark-common/src/test/java/org/apache/gravitino/spark/connector/integration/test/hive/SparkHiveCatalogIT.java
+++ b/spark-connector/spark-common/src/test/java/org/apache/gravitino/spark/connector/integration/test/hive/SparkHiveCatalogIT.java
@@ -76,6 +76,11 @@ public abstract class SparkHiveCatalogIT extends SparkCommonIT {
     return false;
   }
 
+  @Override
+  protected boolean supportsSchemaEvolution() {
+    return false;
+  }
+
   @Test
   void testCreateHiveFormatPartitionTable() {
     String tableName = "hive_partition_table";

--- a/spark-connector/spark-common/src/test/java/org/apache/gravitino/spark/connector/integration/test/iceberg/SparkIcebergCatalogIT.java
+++ b/spark-connector/spark-common/src/test/java/org/apache/gravitino/spark/connector/integration/test/iceberg/SparkIcebergCatalogIT.java
@@ -100,6 +100,11 @@ public abstract class SparkIcebergCatalogIT extends SparkCommonIT {
   }
 
   @Override
+  protected boolean supportsSchemaEvolution() {
+    return true;
+  }
+
+  @Override
   protected String getTableLocation(SparkTableInfo table) {
     return String.join(File.separator, table.getTableLocation(), "data");
   }

--- a/spark-connector/spark-common/src/test/java/org/apache/gravitino/spark/connector/integration/test/util/SparkUtilIT.java
+++ b/spark-connector/spark-common/src/test/java/org/apache/gravitino/spark/connector/integration/test/util/SparkUtilIT.java
@@ -45,6 +45,7 @@ import org.junit.jupiter.api.Assertions;
  * <p>Referred from spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
  */
 public abstract class SparkUtilIT extends AbstractIT {
+  protected static final String NULL_STRING = "NULL";
 
   protected abstract SparkSession getSparkSession();
 
@@ -103,6 +104,8 @@ public abstract class SparkUtilIT extends AbstractIT {
       SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
       sdf.setTimeZone(TimeZone.getTimeZone(TIME_ZONE_UTC));
       return sdf.format(timestamp);
+    } else if (item == null) {
+      return NULL_STRING;
     } else {
       return item.toString();
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?
To support replace column:
* support delete and add **`same column name`** in valid column change logic in hive catalog
* remove get column position logic if not specifying column position in Iceberg catalog

### Why are the changes needed?

Fix: #3136 

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
add IT
