### PR TITLE
[#3475] fix(all): Fix the problem of multiple version jars in the release tar.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -520,7 +520,6 @@ tasks {
   val outputDir = projectDir.dir("distribution")
 
   val compileDistribution by registering {
-    dependsOn(project.getTasksByName("clean", true))
     dependsOn("copySubprojectDependencies", "copyCatalogLibAndConfigs", "copySubprojectLib")
 
     group = "gravitino distribution"
@@ -635,6 +634,7 @@ tasks {
         it.name != "integration-test" &&
         it.name != "bundled-catalog"
       ) {
+        delete("${it.name}/build/libs")
         dependsOn("${it.name}:build")
         from("${it.name}/build/libs")
         into("distribution/package/libs")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -520,6 +520,7 @@ tasks {
   val outputDir = projectDir.dir("distribution")
 
   val compileDistribution by registering {
+    dependsOn(project.getTasksByName("clean", true))
     dependsOn("copySubprojectDependencies", "copyCatalogLibAndConfigs", "copySubprojectLib")
 
     group = "gravitino distribution"

--- a/catalogs/catalog-hadoop/build.gradle.kts
+++ b/catalogs/catalog-hadoop/build.gradle.kts
@@ -52,6 +52,7 @@ tasks {
   }
 
   val copyCatalogLibs by registering(Copy::class) {
+    delete("build/libs")
     dependsOn("jar", "runtimeJars")
     from("build/libs")
     into("$rootDir/distribution/package/catalogs/hadoop/libs")

--- a/catalogs/catalog-hive/build.gradle.kts
+++ b/catalogs/catalog-hive/build.gradle.kts
@@ -119,6 +119,7 @@ tasks {
   }
 
   val copyCatalogLibs by registering(Copy::class) {
+    delete("build/libs")
     dependsOn("jar", "runtimeJars")
     from("build/libs")
     into("$rootDir/distribution/package/catalogs/hive/libs")

--- a/catalogs/catalog-jdbc-doris/build.gradle.kts
+++ b/catalogs/catalog-jdbc-doris/build.gradle.kts
@@ -46,6 +46,7 @@ tasks {
     into("build/libs")
   }
   val copyCatalogLibs by registering(Copy::class) {
+    delete("build/libs")
     dependsOn("jar", "runtimeJars")
     from("build/libs")
     into("$rootDir/distribution/package/catalogs/jdbc-doris/libs")

--- a/catalogs/catalog-jdbc-mysql/build.gradle.kts
+++ b/catalogs/catalog-jdbc-mysql/build.gradle.kts
@@ -47,6 +47,7 @@ tasks {
   }
 
   val copyCatalogLibs by registering(Copy::class) {
+    delete("build/libs")
     dependsOn("jar", "runtimeJars")
     from("build/libs")
     into("$rootDir/distribution/package/catalogs/jdbc-mysql/libs")

--- a/catalogs/catalog-jdbc-postgresql/build.gradle.kts
+++ b/catalogs/catalog-jdbc-postgresql/build.gradle.kts
@@ -51,6 +51,7 @@ tasks {
   }
 
   val copyCatalogLibs by registering(Copy::class) {
+    delete("build/libs")
     dependsOn("jar", "runtimeJars")
     from("build/libs")
     into("$rootDir/distribution/package/catalogs/jdbc-postgresql/libs")

--- a/catalogs/catalog-kafka/build.gradle.kts
+++ b/catalogs/catalog-kafka/build.gradle.kts
@@ -43,6 +43,7 @@ tasks {
   }
 
   val copyCatalogLibs by registering(Copy::class) {
+    delete("build/libs")
     dependsOn(jar, runtimeJars)
     from("build/libs")
     into("$rootDir/distribution/package/catalogs/kafka/libs")

--- a/catalogs/catalog-lakehouse-iceberg/build.gradle.kts
+++ b/catalogs/catalog-lakehouse-iceberg/build.gradle.kts
@@ -116,6 +116,7 @@ tasks {
   }
 
   val copyCatalogLibs by registering(Copy::class) {
+    delete("build/libs")
     dependsOn("jar", "runtimeJars")
     from("build/libs")
     into("$rootDir/distribution/package/catalogs/lakehouse-iceberg/libs")


### PR DESCRIPTION
### What changes were proposed in this pull request?

Clean build/libs directory before task `compileDistribution`

### Why are the changes needed?

By adding this task, we can reduce multiple version of jars in the release tar file. 

Fix: #3475 

### Does this PR introduce _any_ user-facing change?

N/A.

### How was this patch tested?

Test locally. 
