### PR TITLE
#3840: feat(iceberg) Add partitions rest endpoint for iceberg

### DIFF
--- a/catalogs/catalog-lakehouse-iceberg/build.gradle.kts
+++ b/catalogs/catalog-lakehouse-iceberg/build.gradle.kts
@@ -55,6 +55,8 @@ dependencies {
     exclude("com.sun.jersey", "jersey-server")
   }
   implementation(libs.iceberg.hive.metastore)
+  implementation(libs.iceberg.aws)
+  implementation(libs.aws.sdk)
   implementation(libs.jackson.annotations)
   implementation(libs.jackson.databind)
   implementation(libs.jackson.datatype.jdk8)

--- a/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/IcebergCatalogPropertiesMetadata.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/IcebergCatalogPropertiesMetadata.java
@@ -32,6 +32,8 @@ public class IcebergCatalogPropertiesMetadata extends BaseCatalogPropertiesMetad
   public static final String WAREHOUSE = "warehouse";
   public static final String URI = "uri";
 
+  public static final String ICEBERG_EXECUTOR_POOL_SIZE_KEY = "executor-pool-size";
+
   private static final Map<String, PropertyEntry<?>> PROPERTIES_METADATA;
 
   // Map that maintains the mapping of keys in Gravitino to that in Iceberg, for example, users

--- a/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/IcebergConfig.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/IcebergConfig.java
@@ -7,6 +7,7 @@ package com.datastrato.gravitino.catalog.lakehouse.iceberg;
 
 import static com.datastrato.gravitino.catalog.lakehouse.iceberg.IcebergCatalogPropertiesMetadata.CATALOG_BACKEND_NAME;
 import static com.datastrato.gravitino.catalog.lakehouse.iceberg.IcebergCatalogPropertiesMetadata.GRAVITINO_JDBC_DRIVER;
+import static com.datastrato.gravitino.catalog.lakehouse.iceberg.IcebergCatalogPropertiesMetadata.ICEBERG_EXECUTOR_POOL_SIZE_KEY;
 import static com.datastrato.gravitino.catalog.lakehouse.iceberg.IcebergCatalogPropertiesMetadata.ICEBERG_JDBC_INITIALIZE;
 import static com.datastrato.gravitino.catalog.lakehouse.iceberg.IcebergCatalogPropertiesMetadata.ICEBERG_JDBC_PASSWORD;
 import static com.datastrato.gravitino.catalog.lakehouse.iceberg.IcebergCatalogPropertiesMetadata.ICEBERG_JDBC_USER;
@@ -124,4 +125,12 @@ public class IcebergConfig extends Config implements OverwriteDefaultConfig {
         JettyServerConfig.WEBSERVER_HTTPS_PORT.getKey(),
         String.valueOf(JettyServerConfig.DEFAULT_ICEBERG_REST_SERVICE_HTTPS_PORT));
   }
+
+  public static final ConfigEntry<Integer> ICEBERG_EXECUTOR_POOL_SIZE =
+      new ConfigBuilder(ICEBERG_EXECUTOR_POOL_SIZE_KEY)
+          .doc("Number of threads to use to plan files and tasks in Iceberg catalog")
+          .version(ConfigConstants.VERSION_0_4_0)
+          .intConf()
+          .checkValue(value -> value > 0, ConfigConstants.POSITIVE_NUMBER_ERROR_MSG)
+          .createWithDefault(2);
 }

--- a/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/ops/IcebergTableOps.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/ops/IcebergTableOps.java
@@ -12,9 +12,14 @@ import com.datastrato.gravitino.utils.IsolatedClassLoader;
 import com.google.common.base.Preconditions;
 import java.sql.Driver;
 import java.sql.DriverManager;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import javax.ws.rs.NotSupportedException;
+import org.apache.iceberg.PartitionsTableExt;
+import org.apache.iceberg.Table;
 import org.apache.iceberg.Transaction;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.Namespace;
@@ -29,6 +34,7 @@ import org.apache.iceberg.rest.requests.UpdateTableRequest;
 import org.apache.iceberg.rest.responses.CreateNamespaceResponse;
 import org.apache.iceberg.rest.responses.GetNamespaceResponse;
 import org.apache.iceberg.rest.responses.ListNamespacesResponse;
+import org.apache.iceberg.rest.responses.ListPartitionsResponse;
 import org.apache.iceberg.rest.responses.ListTablesResponse;
 import org.apache.iceberg.rest.responses.LoadTableResponse;
 import org.apache.iceberg.rest.responses.UpdateNamespacePropertiesResponse;
@@ -43,6 +49,8 @@ public class IcebergTableOps implements AutoCloseable {
   private final String catalogType;
   private String catalogUri = null;
 
+  private ExecutorService executorService;
+
   public IcebergTableOps(IcebergConfig icebergConfig) {
     this.catalogType = icebergConfig.get(IcebergConfig.CATALOG_BACKEND);
     if (!IcebergCatalogBackend.MEMORY.name().equalsIgnoreCase(catalogType)) {
@@ -53,6 +61,7 @@ public class IcebergTableOps implements AutoCloseable {
     if (catalog instanceof SupportsNamespaces) {
       asNamespaceCatalog = (SupportsNamespaces) catalog;
     }
+    executorService = Executors.newFixedThreadPool(icebergConfig.get(IcebergConfig.ICEBERG_EXECUTOR_POOL_SIZE));
   }
 
   public IcebergTableOps() {
@@ -141,6 +150,16 @@ public class IcebergTableOps implements AutoCloseable {
     Transaction transaction = icebergTableChange.getTransaction();
     transaction.commitTransaction();
     return loadTable(icebergTableChange.getTableIdentifier());
+  }
+
+  public ListPartitionsResponse listPartitions(TableIdentifier tableIdentifier) {
+    // get all partitions for given table
+    Table table = catalog.loadTable(tableIdentifier);
+    PartitionsTableExt partitionsTable = new PartitionsTableExt(table);
+    Collection<String> partitions = PartitionsTableExt.partitions(
+        table, partitionsTable.newScan().select("partition", "lower_bounds", "upper_bounds"), executorService);
+
+    return ListPartitionsResponse.builder().addAll(partitions).build();
   }
 
   @Override

--- a/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/ops/IcebergTableOps.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/ops/IcebergTableOps.java
@@ -12,13 +12,12 @@ import com.datastrato.gravitino.utils.IsolatedClassLoader;
 import com.google.common.base.Preconditions;
 import java.sql.Driver;
 import java.sql.DriverManager;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import javax.ws.rs.NotSupportedException;
-import org.apache.iceberg.PartitionsTableExt;
+import org.apache.iceberg.PartitionsUtils;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.Transaction;
 import org.apache.iceberg.catalog.Catalog;
@@ -155,11 +154,8 @@ public class IcebergTableOps implements AutoCloseable {
   public ListPartitionsResponse listPartitions(TableIdentifier tableIdentifier) {
     // get all partitions for given table
     Table table = catalog.loadTable(tableIdentifier);
-    PartitionsTableExt partitionsTable = new PartitionsTableExt(table);
-    Collection<String> partitions = PartitionsTableExt.partitions(
-        table, partitionsTable.newScan().select("partition", "lower_bounds", "upper_bounds"), executorService);
-
-    return ListPartitionsResponse.builder().addAll(partitions).build();
+    return ListPartitionsResponse.builder().addAll(
+        PartitionsUtils.partitions(table, executorService)).build();
   }
 
   @Override

--- a/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/web/rest/IcebergTableOperations.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/web/rest/IcebergTableOperations.java
@@ -33,6 +33,7 @@ import org.apache.iceberg.rest.RESTUtil;
 import org.apache.iceberg.rest.requests.CreateTableRequest;
 import org.apache.iceberg.rest.requests.ReportMetricsRequest;
 import org.apache.iceberg.rest.requests.UpdateTableRequest;
+import org.apache.iceberg.rest.responses.ListPartitionsResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -156,6 +157,23 @@ public class IcebergTableOperations {
     } else {
       return IcebergRestUtils.notExists();
     }
+  }
+
+  @GET
+  @Path("{table}/partitions")
+  @Produces(MediaType.APPLICATION_JSON)
+  @Timed(name = "load-table-partitions." + MetricNames.HTTP_PROCESS_DURATION, absolute = true)
+  @ResponseMetered(name = "load-table-partitions", absolute = true)
+  public Response loadTablePartitions(
+      @PathParam("namespace") String namespace,
+      @PathParam("table") String table,
+      @DefaultValue("all") @QueryParam("partitions-filter") String partitionsFilter,
+      @DefaultValue("all") @QueryParam("snapshots") String snapshots) {
+    // todo support snapshots
+    TableIdentifier tableIdentifier =
+        TableIdentifier.of(RESTUtil.decodeNamespace(namespace), table);
+    ListPartitionsResponse listPartitionsResponse = icebergTableOps.listPartitions(tableIdentifier);
+    return IcebergRestUtils.ok(listPartitionsResponse);
   }
 
   @POST

--- a/catalogs/catalog-lakehouse-iceberg/src/main/java/org/apache/iceberg/PartitionsTableExt.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/main/java/org/apache/iceberg/PartitionsTableExt.java
@@ -1,0 +1,113 @@
+package org.apache.iceberg;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Sets;
+import com.google.common.collect.Streams;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import org.apache.iceberg.ManifestFile.PartitionFieldSummary;
+import org.apache.iceberg.types.Conversions;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.Tasks;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class PartitionsTableExt extends PartitionsTable {
+  private static final Logger LOG = LoggerFactory.getLogger(PartitionsTableExt.class);
+
+  public PartitionsTableExt(Table table) {
+    super(table);
+  }
+
+  /**
+   * Get all partitions in the table.
+   * @return a collection of partition paths
+   */
+  public static Collection<String> partitions(Table table, TableScan scan, ExecutorService executorService) {
+    List<ManifestFile> manifestFiles = table.currentSnapshot().allManifests(table.io());
+    LOG.info("Scanning {} manifest files", manifestFiles.size());
+    Set<String> partitionPaths = Collections.synchronizedSet(Sets.newLinkedHashSet());
+
+    Tasks.foreach(manifestFiles)
+        .noRetry()
+        .suppressFailureWhenFinished()
+        .executeWith(executorService)
+        .run(manifest -> {
+          // todo: cache partition spec id to partition spec
+          PartitionSpec partitionSpec = table.specs().get(manifest.partitionSpecId());
+          if (hasOnlyOnePartition(manifest, partitionSpec)) {
+            String partitionPath = toPartitionPath(manifest, partitionSpec);
+            partitionPaths.add(partitionPath);
+            LOG.info("Added partition {} from single partition manifest. Collected {} partitions so "
+                + "far.", partitionPath, partitionPaths.size());
+          } else {
+            try (ManifestReader<?> reader =
+                ManifestFiles.open(manifest, table.io())
+                    .caseSensitive(scan.isCaseSensitive())
+                    .select(ImmutableList.of("partition", "lower_bounds", "upper_bounds"))) {
+              for (ManifestEntry<?> entry : reader.entries()) {
+                ContentFile<?> file = entry.file();
+                partitionPaths.add(
+                    // todo: get partition spec from cached partition spec
+                    table.specs().get(file.specId()).partitionToPath(file.partition()));
+              }
+              LOG.info("Added multiple partitions from single manifest. Collected {} partitions so "
+                  + "far.", partitionPaths.size());
+            } catch (IOException e) {
+              throw new RuntimeException(e);
+            }
+          }
+        });
+
+    LOG.info("Found {} partitions", partitionPaths.size());
+    return new ArrayList<>(partitionPaths);
+  }
+
+  /**
+   * Convert a manifest file to a partition path.
+   * @param manifestFile the manifest file
+   * @param partitionSpec the partition spec
+   * @return the partition path
+   */
+  private static String toPartitionPath(ManifestFile manifestFile, PartitionSpec partitionSpec) {
+    List<Types.NestedField> fields = partitionSpec.partitionType().fields();
+    List<PartitionFieldSummary> partitionFieldSummaries = manifestFile.partitions();
+
+    Preconditions.checkState(fields.size() == partitionFieldSummaries.size(),
+        "Partition fields and partition field summaries size mismatch");
+
+    PartitionData partitionData = new PartitionData(partitionSpec.partitionType());
+    for (int i=0; i < fields.size(); i++) {
+      partitionData.put(i, Conversions.fromByteBuffer(fields.get(i).type(),
+          partitionFieldSummaries.get(i).lowerBound()));
+    }
+
+    return partitionSpec.partitionToPath(partitionData);
+  }
+
+  /**
+   * Check if the manifest has only one partition.
+   * @param manifest the manifest file
+   * @param partitionSpec the partition spec
+   * @return true if the manifest has only one partition, false otherwise
+   */
+  private static boolean hasOnlyOnePartition(ManifestFile manifest, PartitionSpec partitionSpec) {
+    Preconditions.checkState(partitionSpec.fields().size() == manifest.partitions().size(),
+        "Partition fields and partition field summaries size mismatch");
+    return Streams.zip(partitionSpec.fields().stream(), manifest.partitions().stream(),
+        (field, fieldSummary) -> {
+          if (field.transform().isIdentity()) {
+            return (fieldSummary.lowerBound() == null && fieldSummary.upperBound() == null) ||
+                fieldSummary.lowerBound().equals(fieldSummary.upperBound());
+          } else {
+            return true;
+          }
+        }).reduce(true, (a, b) -> a && b);
+  }
+}

--- a/catalogs/catalog-lakehouse-iceberg/src/main/java/org/apache/iceberg/PartitionsUtils.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/main/java/org/apache/iceberg/PartitionsUtils.java
@@ -18,18 +18,14 @@ import org.apache.iceberg.util.Tasks;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class PartitionsTableExt extends PartitionsTable {
-  private static final Logger LOG = LoggerFactory.getLogger(PartitionsTableExt.class);
-
-  public PartitionsTableExt(Table table) {
-    super(table);
-  }
+public class PartitionsUtils {
+  private static final Logger LOG = LoggerFactory.getLogger(PartitionsUtils.class);
 
   /**
    * Get all partitions in the table.
    * @return a collection of partition paths
    */
-  public static Collection<String> partitions(Table table, TableScan scan, ExecutorService executorService) {
+  public static Collection<String> partitions(Table table, ExecutorService executorService) {
     List<ManifestFile> manifestFiles = table.currentSnapshot().allManifests(table.io());
     LOG.info("Scanning {} manifest files", manifestFiles.size());
     Set<String> partitionPaths = Collections.synchronizedSet(Sets.newLinkedHashSet());
@@ -49,7 +45,7 @@ public class PartitionsTableExt extends PartitionsTable {
           } else {
             try (ManifestReader<?> reader =
                 ManifestFiles.open(manifest, table.io())
-                    .caseSensitive(scan.isCaseSensitive())
+                    .caseSensitive(false)
                     .select(ImmutableList.of("partition", "lower_bounds", "upper_bounds"))) {
               for (ManifestEntry<?> entry : reader.entries()) {
                 ContentFile<?> file = entry.file();

--- a/catalogs/catalog-lakehouse-iceberg/src/main/java/org/apache/iceberg/rest/responses/ListPartitionsResponse.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/main/java/org/apache/iceberg/rest/responses/ListPartitionsResponse.java
@@ -1,0 +1,67 @@
+package org.apache.iceberg.rest.responses;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import org.apache.iceberg.rest.RESTResponse;
+
+public class ListPartitionsResponse implements RESTResponse {
+
+  private List<String> partitions;
+
+  public ListPartitionsResponse() {
+    // Required for Jackson deserialization
+  }
+
+  private ListPartitionsResponse(List<String> partitions) {
+    this.partitions = partitions;
+    validate();
+  }
+
+  @Override
+  public void validate() {
+    Preconditions.checkArgument(partitions != null, "Invalid partitions list: null");
+  }
+
+  public List<String> partitions() {
+    return partitions != null ? partitions : ImmutableList.of();
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("partitions", partitions)
+        .toString();
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private final ImmutableList.Builder<String> partitions = ImmutableList.builder();
+
+    private Builder() {
+    }
+
+    public ListPartitionsResponse.Builder add(String toAdd) {
+      Preconditions.checkNotNull(toAdd, "Invalid table identifier: null");
+      partitions.add(toAdd);
+      return this;
+    }
+
+    public ListPartitionsResponse.Builder addAll(Collection<String> toAdd) {
+      Preconditions.checkNotNull(toAdd, "Invalid table identifier list: null");
+      Preconditions.checkArgument(!toAdd.contains(null), "Invalid table identifier: null");
+      partitions.addAll(toAdd);
+      return this;
+    }
+
+    public ListPartitionsResponse build() {
+      return new ListPartitionsResponse(partitions.build());
+    }
+  }
+}

--- a/catalogs/catalog-lakehouse-iceberg/src/test/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/web/rest/IcebergTestBase.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/test/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/web/rest/IcebergTestBase.java
@@ -76,6 +76,12 @@ public class IcebergTestBase extends JerseyTest {
     return getIcebergClientBuilder(path, queryParams);
   }
 
+  public Invocation.Builder getPartitionsClientBuilder(Optional<String> name) {
+    String path =
+        Joiner.on("/").skipNulls().join(IcebergRestTestUtil.TABLE_PATH, name.orElseGet(() -> null), "partitions");
+    return getIcebergClientBuilder(path, Optional.empty());
+  }
+
   public Invocation.Builder getUpdateNamespaceClientBuilder(String namespace) {
     String path =
         Joiner.on("/")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -62,6 +62,7 @@ jodd = "3.5.2"
 flink = "1.18.0"
 cglib = "2.2"
 ranger = "2.4.0"
+aws-sdk = "2.20.18"
 
 protobuf-plugin = "0.9.2"
 spotless-plugin = '6.11.0'
@@ -133,6 +134,7 @@ commons-collections4 = { group = "org.apache.commons", name = "commons-collectio
 iceberg-core = { group = "org.apache.iceberg", name = "iceberg-core", version.ref = "iceberg" }
 iceberg-api = { group = "org.apache.iceberg", name = "iceberg-api", version.ref = "iceberg" }
 iceberg-hive-metastore = { group = "org.apache.iceberg", name = "iceberg-hive-metastore", version.ref = "iceberg" }
+iceberg-aws = { group = "org.apache.iceberg", name = "iceberg-aws", version.ref = "iceberg" }
 trino-spi= { group = "io.trino", name = "trino-spi", version.ref = "trino" }
 trino-toolkit= { group = "io.trino", name = "trino-plugin-toolkit", version.ref = "trino" }
 trino-testing= { group = "io.trino", name = "trino-testing", version.ref = "trino" }
@@ -170,6 +172,7 @@ kafka-clients = { group = "org.apache.kafka", name = "kafka-clients", version.re
 kafka = { group = "org.apache.kafka", name = "kafka_2.12", version.ref = "kafka" }
 curator-test = { group = "org.apache.curator", name = "curator-test", version.ref = "curator"}
 cglib = { group = "cglib", name = "cglib", version.ref = "cglib"}
+aws-sdk = { group = "software.amazon.awssdk", name = "bundle", version.ref = "aws-sdk"}
 
 ranger-intg = { group = "org.apache.ranger", name = "ranger-intg", version.ref = "ranger" }
 selenium = { group = "org.seleniumhq.selenium", name = "selenium-java", version.ref = "selenium" }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add rest endpoint to get Iceberg partitions.

### Why are the changes needed?

Add capability to fetch partitions from Iceberg tables to enable easy to use and efficient mechanism to fetch Iceberg table partitions.

Fix: #3840 

### Does this PR introduce _any_ user-facing change?
1. Adds /partitions endpoint for iceberg tables
2. Add config to control parallelism and core usage while planning iceberg tables

### How was this patch tested?
1. Tested with test tables by deploying the change.
2. Added unit tests.