### PR TITLE
[#3642] if a schema was created by beeline , give a warn  log instead of error log

### DIFF
--- a/core/src/main/java/com/datastrato/gravitino/catalog/TableOperationDispatcher.java
+++ b/core/src/main/java/com/datastrato/gravitino/catalog/TableOperationDispatcher.java
@@ -190,20 +190,30 @@ public class TableOperationDispatcher extends OperationDispatcher implements Tab
                     .build())
             .build();
 
+    boolean opEntityFail = false;
     try {
       store.put(tableEntity, true /* overwrite */);
+    } catch (NoSuchEntityException noSuchEntityException) {
+      LOG.warn(
+          FormattedErrorMessages.STORE_OP_FAILURE + noSuchEntityException.getMessage(),
+          "put",
+          ident);
+      opEntityFail = true;
     } catch (Exception e) {
       LOG.error(FormattedErrorMessages.STORE_OP_FAILURE, "put", ident, e);
+      opEntityFail = true;
+    }
+    if (opEntityFail) {
       return EntityCombinedTable.of(table)
           .withHiddenPropertiesSet(
               getHiddenPropertyNames(
                   catalogIdent, HasPropertyMetadata::tablePropertiesMetadata, table.properties()));
+    } else {
+      return EntityCombinedTable.of(table, tableEntity)
+          .withHiddenPropertiesSet(
+              getHiddenPropertyNames(
+                  catalogIdent, HasPropertyMetadata::tablePropertiesMetadata, table.properties()));
     }
-
-    return EntityCombinedTable.of(table, tableEntity)
-        .withHiddenPropertiesSet(
-            getHiddenPropertyNames(
-                catalogIdent, HasPropertyMetadata::tablePropertiesMetadata, table.properties()));
   }
 
   /**


### PR DESCRIPTION

### What changes were proposed in this pull request?
change log level and delete log stack when  creating table in ‘default’ database.

### Why are the changes needed?

if create table in 'default' database ,there will report error in log

Fix: #3642 

### Does this PR introduce _any_ user-facing change?

no

### How was this patch tested?

no
