### PR TITLE
[#3871] Improvement(spark-connector): Making Iceberg extended sqls compatible with different iceberg versions

### DIFF
--- a/spark-connector/spark-common/src/main/java/com/datastrato/gravitino/spark/connector/iceberg/extensions/IcebergExtendedDataSourceV2Strategy.java
+++ b/spark-connector/spark-common/src/main/java/com/datastrato/gravitino/spark/connector/iceberg/extensions/IcebergExtendedDataSourceV2Strategy.java
@@ -10,6 +10,7 @@ import com.google.common.collect.ImmutableMap;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -149,12 +150,14 @@ public class IcebergExtendedDataSourceV2Strategy extends ExtendedDataSourceV2Str
                     String.format(
                         "Scala case class: %s only have a constructor with parameters.",
                         physicalPlanClassName));
+                List<Object> initArgs = new ArrayList<>();
+                initArgs.add(
+                    Arrays.asList(catalogAndIdentifier.catalog, catalogAndIdentifier.identifier));
+                initArgs.addAll(
+                    parameterValues.subList(
+                        1, parameterValues.size())); // remove the table parameter
                 SparkPlan sparkPlan =
-                    (SparkPlan)
-                        (physicalPlanDeclaredConstructors[0].newInstance(
-                            catalogAndIdentifier.catalog,
-                            catalogAndIdentifier.identifier,
-                            parameterValues.remove(0))); // remove the table parameter
+                    (SparkPlan) (physicalPlanDeclaredConstructors[0].newInstance(initArgs));
                 return toSeq(sparkPlan);
               } catch (ClassNotFoundException
                   | InvocationTargetException


### PR DESCRIPTION

### What changes were proposed in this pull request?

compatible with different iceberg versions by reflection.

### Why are the changes needed?

Making Iceberg extended sqls compatible with different iceberg versions.
For example, in some lower version, such as `0.14.x`, `CreateOrReplaceBranch` is not available.

Fix: https://github.com/datastrato/gravitino/issues/3871

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

existing ITs.
