### PR TITLE
[#1061] Improvement(server): Bad request may not response JSON content

### DIFF
--- a/server/src/main/java/com/datastrato/gravitino/server/GravitinoServer.java
+++ b/server/src/main/java/com/datastrato/gravitino/server/GravitinoServer.java
@@ -37,6 +37,9 @@ import com.datastrato.gravitino.server.web.JettyServerConfig;
 import com.datastrato.gravitino.server.web.ObjectMapperProvider;
 import com.datastrato.gravitino.server.web.VersioningFilter;
 import com.datastrato.gravitino.server.web.filter.AccessControlNotAllowedFilter;
+import com.datastrato.gravitino.server.web.mapper.JsonMappingExceptionMapper;
+import com.datastrato.gravitino.server.web.mapper.JsonParseExceptionMapper;
+import com.datastrato.gravitino.server.web.mapper.JsonProcessingExceptionMapper;
 import com.datastrato.gravitino.server.web.ui.WebUIFilter;
 import java.io.File;
 import java.util.Properties;
@@ -102,6 +105,9 @@ public class GravitinoServer extends ResourceConfig {
             bind(gravitinoEnv.topicDispatcher()).to(TopicDispatcher.class).ranked(1);
           }
         });
+    register(JsonProcessingExceptionMapper.class);
+    register(JsonParseExceptionMapper.class);
+    register(JsonMappingExceptionMapper.class);
     register(ObjectMapperProvider.class).register(JacksonFeature.class);
 
     if (!enableAuthorization) {

--- a/server/src/main/java/com/datastrato/gravitino/server/web/mapper/JsonMappingExceptionMapper.java
+++ b/server/src/main/java/com/datastrato/gravitino/server/web/mapper/JsonMappingExceptionMapper.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2023 Datastrato Pvt Ltd.
+ * This software is licensed under the Apache License version 2.
+ */
+package com.datastrato.gravitino.server.web.mapper;
+
+import com.datastrato.gravitino.server.web.Utils;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import javax.annotation.Priority;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+/**
+ * JsonMappingExceptionMapper is used for returning consistent format of response when an illegal
+ * Json request is sent. This class overrides the built-in JsonMappingExceptionMapper defined in
+ * Jersey.
+ */
+@Priority(1)
+public class JsonMappingExceptionMapper implements ExceptionMapper<JsonMappingException> {
+  @Override
+  public Response toResponse(JsonMappingException e) {
+    String errorMsg = "Malformed json request";
+    return Utils.illegalArguments(errorMsg, e);
+  }
+}

--- a/server/src/main/java/com/datastrato/gravitino/server/web/mapper/JsonMappingExceptionMapper.java
+++ b/server/src/main/java/com/datastrato/gravitino/server/web/mapper/JsonMappingExceptionMapper.java
@@ -1,6 +1,20 @@
 /*
- * Copyright 2023 Datastrato Pvt Ltd.
- * This software is licensed under the Apache License version 2.
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 package com.datastrato.gravitino.server.web.mapper;
 

--- a/server/src/main/java/com/datastrato/gravitino/server/web/mapper/JsonParseExceptionMapper.java
+++ b/server/src/main/java/com/datastrato/gravitino/server/web/mapper/JsonParseExceptionMapper.java
@@ -1,6 +1,20 @@
 /*
- * Copyright 2023 Datastrato Pvt Ltd.
- * This software is licensed under the Apache License version 2.
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 package com.datastrato.gravitino.server.web.mapper;
 

--- a/server/src/main/java/com/datastrato/gravitino/server/web/mapper/JsonParseExceptionMapper.java
+++ b/server/src/main/java/com/datastrato/gravitino/server/web/mapper/JsonParseExceptionMapper.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2023 Datastrato Pvt Ltd.
+ * This software is licensed under the Apache License version 2.
+ */
+package com.datastrato.gravitino.server.web.mapper;
+
+import com.datastrato.gravitino.server.web.Utils;
+import com.fasterxml.jackson.core.JsonParseException;
+import javax.annotation.Priority;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+/**
+ * JsonParseExceptionMapper is used for returning consistent format of response when an illegal Json
+ * request is sent. This class overrides the built-in JsonParseExceptionMapper defined in Jersey.
+ */
+@Priority(1)
+public class JsonParseExceptionMapper implements ExceptionMapper<JsonParseException> {
+  @Override
+  public Response toResponse(JsonParseException e) {
+    String errorMsg = "Malformed json request";
+    return Utils.illegalArguments(errorMsg, e);
+  }
+}

--- a/server/src/main/java/com/datastrato/gravitino/server/web/mapper/JsonProcessingExceptionMapper.java
+++ b/server/src/main/java/com/datastrato/gravitino/server/web/mapper/JsonProcessingExceptionMapper.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2023 Datastrato Pvt Ltd.
+ * This software is licensed under the Apache License version 2.
+ */
+package com.datastrato.gravitino.server.web.mapper;
+
+import com.datastrato.gravitino.server.web.Utils;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import javax.annotation.Priority;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+/**
+ * JsonProcessingExceptionMapper is used for returning consistent format of response when a general
+ * Json issue occurs.
+ */
+@Priority(1)
+public class JsonProcessingExceptionMapper implements ExceptionMapper<JsonProcessingException> {
+  @Override
+  public Response toResponse(JsonProcessingException e) {
+    String errorMsg = "Unexpected error occurs when json processing.";
+    return Utils.internalError(errorMsg, e);
+  }
+}

--- a/server/src/main/java/com/datastrato/gravitino/server/web/mapper/JsonProcessingExceptionMapper.java
+++ b/server/src/main/java/com/datastrato/gravitino/server/web/mapper/JsonProcessingExceptionMapper.java
@@ -1,6 +1,20 @@
 /*
- * Copyright 2023 Datastrato Pvt Ltd.
- * This software is licensed under the Apache License version 2.
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 package com.datastrato.gravitino.server.web.mapper;
 

--- a/server/src/test/java/com/datastrato/gravitino/server/web/mapper/TestJsonMappingExceptionMapper.java
+++ b/server/src/test/java/com/datastrato/gravitino/server/web/mapper/TestJsonMappingExceptionMapper.java
@@ -1,6 +1,20 @@
 /*
- * Copyright 2024 Datastrato Pvt Ltd.
- * This software is licensed under the Apache License version 2.
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 package com.datastrato.gravitino.server.web.mapper;
 

--- a/server/src/test/java/com/datastrato/gravitino/server/web/mapper/TestJsonMappingExceptionMapper.java
+++ b/server/src/test/java/com/datastrato/gravitino/server/web/mapper/TestJsonMappingExceptionMapper.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2024 Datastrato Pvt Ltd.
+ * This software is licensed under the Apache License version 2.
+ */
+package com.datastrato.gravitino.server.web.mapper;
+
+import com.datastrato.gravitino.dto.responses.ErrorResponse;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import javax.ws.rs.core.Response;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+public class TestJsonMappingExceptionMapper {
+  private final JsonMappingExceptionMapper jsonMappingExceptionMapper =
+      new JsonMappingExceptionMapper();
+
+  @Test
+  public void testJsonMappingExceptionMapper() {
+    JsonParser mockParser = Mockito.mock(JsonParser.class);
+    Response response =
+        jsonMappingExceptionMapper.toResponse(JsonMappingException.from(mockParser, ""));
+    ErrorResponse errorResponse = ErrorResponse.illegalArguments("Malformed json request");
+    ErrorResponse entity = (ErrorResponse) response.getEntity();
+    Assertions.assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+    Assertions.assertEquals(errorResponse.getCode(), entity.getCode());
+    Assertions.assertEquals(errorResponse.getMessage(), entity.getMessage());
+    Assertions.assertEquals(errorResponse.getType(), entity.getType());
+  }
+}

--- a/server/src/test/java/com/datastrato/gravitino/server/web/mapper/TestJsonParseExceptionMapper.java
+++ b/server/src/test/java/com/datastrato/gravitino/server/web/mapper/TestJsonParseExceptionMapper.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2024 Datastrato Pvt Ltd.
+ * This software is licensed under the Apache License version 2.
+ */
+package com.datastrato.gravitino.server.web.mapper;
+
+import com.datastrato.gravitino.dto.responses.ErrorResponse;
+import com.fasterxml.jackson.core.JsonParseException;
+import javax.ws.rs.core.Response;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TestJsonParseExceptionMapper {
+  private final JsonParseExceptionMapper jsonParseExceptionMapper = new JsonParseExceptionMapper();
+
+  @Test
+  public void testJsonParseExceptionMapper() {
+    Response response = jsonParseExceptionMapper.toResponse(new JsonParseException(""));
+    ErrorResponse errorResponse = ErrorResponse.illegalArguments("Malformed json request");
+    ErrorResponse entity = (ErrorResponse) response.getEntity();
+    Assertions.assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+    Assertions.assertEquals(errorResponse.getCode(), entity.getCode());
+    Assertions.assertEquals(errorResponse.getMessage(), entity.getMessage());
+    Assertions.assertEquals(errorResponse.getType(), entity.getType());
+  }
+}

--- a/server/src/test/java/com/datastrato/gravitino/server/web/mapper/TestJsonParseExceptionMapper.java
+++ b/server/src/test/java/com/datastrato/gravitino/server/web/mapper/TestJsonParseExceptionMapper.java
@@ -1,6 +1,20 @@
 /*
- * Copyright 2024 Datastrato Pvt Ltd.
- * This software is licensed under the Apache License version 2.
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 package com.datastrato.gravitino.server.web.mapper;
 

--- a/server/src/test/java/com/datastrato/gravitino/server/web/mapper/TestJsonProcessingExceptionMapper.java
+++ b/server/src/test/java/com/datastrato/gravitino/server/web/mapper/TestJsonProcessingExceptionMapper.java
@@ -1,6 +1,20 @@
 /*
- * Copyright 2024 Datastrato Pvt Ltd.
- * This software is licensed under the Apache License version 2.
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 package com.datastrato.gravitino.server.web.mapper;
 

--- a/server/src/test/java/com/datastrato/gravitino/server/web/mapper/TestJsonProcessingExceptionMapper.java
+++ b/server/src/test/java/com/datastrato/gravitino/server/web/mapper/TestJsonProcessingExceptionMapper.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2024 Datastrato Pvt Ltd.
+ * This software is licensed under the Apache License version 2.
+ */
+package com.datastrato.gravitino.server.web.mapper;
+
+import com.datastrato.gravitino.dto.responses.ErrorResponse;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import javax.ws.rs.core.Response;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TestJsonProcessingExceptionMapper {
+  private final JsonProcessingExceptionMapper jsonProcessingExceptionMapper =
+      new JsonProcessingExceptionMapper();
+
+  @Test
+  public void testJsonProcessingExceptionMapper() {
+    Response response =
+        jsonProcessingExceptionMapper.toResponse(new JsonProcessingException("") {});
+    ErrorResponse errorResponse =
+        ErrorResponse.internalError("Unexpected error occurs when json processing.");
+    ErrorResponse entity = (ErrorResponse) response.getEntity();
+    Assertions.assertEquals(
+        Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatus());
+    Assertions.assertEquals(errorResponse.getCode(), entity.getCode());
+    Assertions.assertEquals(errorResponse.getMessage(), entity.getMessage());
+    Assertions.assertEquals(errorResponse.getType(), entity.getType());
+  }
+}

--- a/server/src/test/java/com/datastrato/gravitino/server/web/rest/TestMetalakeOperations.java
+++ b/server/src/test/java/com/datastrato/gravitino/server/web/rest/TestMetalakeOperations.java
@@ -46,12 +46,21 @@ import com.datastrato.gravitino.meta.SchemaVersion;
 import com.datastrato.gravitino.metalake.MetalakeDispatcher;
 import com.datastrato.gravitino.metalake.MetalakeManager;
 import com.datastrato.gravitino.rest.RESTUtils;
+import com.datastrato.gravitino.server.web.mapper.JsonMappingExceptionMapper;
+import com.datastrato.gravitino.server.web.mapper.JsonParseExceptionMapper;
+import com.datastrato.gravitino.server.web.mapper.JsonProcessingExceptionMapper;
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.List;
 import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.Application;
 import javax.ws.rs.core.MediaType;
@@ -107,8 +116,33 @@ public class TestMetalakeOperations extends JerseyTest {
             bindFactory(MockServletRequestFactory.class).to(HttpServletRequest.class);
           }
         });
-
+    resourceConfig.register(JsonProcessingExceptionMapper.class);
+    resourceConfig.register(JsonParseExceptionMapper.class);
+    resourceConfig.register(JsonMappingExceptionMapper.class);
+    resourceConfig.register(TestException.class);
     return resourceConfig;
+  }
+
+  @Path("/test")
+  public static class TestException {
+    @GET
+    @Path("/jsonProcessingException")
+    public Response getJsonProcessingException() throws JsonProcessingException {
+      throw new JsonProcessingException("Error processing JSON") {};
+    }
+
+    @GET
+    @Path("/jsonMappingException")
+    public Response getJsonMappingException() throws JsonMappingException {
+      JsonParser mockParser = Mockito.mock(JsonParser.class);
+      throw JsonMappingException.from(mockParser, "Error mapping JSON");
+    }
+
+    @GET
+    @Path("/jsonParseException")
+    public Response getJsonParseException() throws JsonParseException {
+      throw new JsonParseException("Error parsing JSON");
+    }
   }
 
   @Test
@@ -390,5 +424,31 @@ public class TestMetalakeOperations extends JerseyTest {
     Assertions.assertEquals(RuntimeException.class.getSimpleName(), errorResponse.getType());
     Assertions.assertTrue(
         errorResponse.getMessage().contains("Failed to operate object [test] operation [DROP]"));
+  }
+
+  @Test
+  public void testExceptionMapper() {
+    Response resp = target("/test/jsonProcessingException").request().get();
+    Assertions.assertEquals(
+        Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), resp.getStatus());
+    ErrorResponse errorResp = resp.readEntity(ErrorResponse.class);
+    Assertions.assertEquals(ErrorConstants.INTERNAL_ERROR_CODE, errorResp.getCode());
+    Assertions.assertEquals(RuntimeException.class.getSimpleName(), errorResp.getType());
+    Assertions.assertTrue(
+        errorResp.getMessage().contains("Unexpected error occurs when json processing."));
+
+    Response resp1 = target("/test/jsonMappingException").request().get();
+    Assertions.assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), resp1.getStatus());
+    ErrorResponse errorResp1 = resp1.readEntity(ErrorResponse.class);
+    Assertions.assertEquals(ErrorConstants.ILLEGAL_ARGUMENTS_CODE, errorResp1.getCode());
+    Assertions.assertEquals(IllegalArgumentException.class.getSimpleName(), errorResp1.getType());
+    Assertions.assertTrue(errorResp1.getMessage().contains("Malformed json request"));
+
+    Response resp2 = target("/test/jsonParseException").request().get();
+    Assertions.assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), resp2.getStatus());
+    ErrorResponse errorResp2 = resp2.readEntity(ErrorResponse.class);
+    Assertions.assertEquals(ErrorConstants.ILLEGAL_ARGUMENTS_CODE, errorResp2.getCode());
+    Assertions.assertEquals(IllegalArgumentException.class.getSimpleName(), errorResp2.getType());
+    Assertions.assertTrue(errorResp2.getMessage().contains("Malformed json request"));
   }
 }


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->
### Why are the changes needed?
Add three ExceptionMapper to deal with exceptions that came from json deserialization.

Fix: #1061

### Does this PR introduce _any_ user-facing change?

NO, but when a user sends a malformed json request, the response will be in json format and with the call stack shown, which can make the debug process easier.

### How was this patch tested?
Via corresponding unit tests,  
or manually build and start the server, then send a malformed request, for example, 

```
curl -X POST -H "Accept: application/vnd.gravitino.v1+json" \
-H "Content-Type: application/json" -d '{"names":"metalake","comment":"comment","properties":{}}' \ 
http://localhost:8090/api/metalakes
```
