### PR TITLE
[#3989]feat(api): Provide Batch Load Api for Multiple Entities

### DIFF
--- a/api/src/main/java/com/datastrato/gravitino/file/FilesetCatalog.java
+++ b/api/src/main/java/com/datastrato/gravitino/file/FilesetCatalog.java
@@ -39,6 +39,14 @@ public interface FilesetCatalog {
   Fileset loadFileset(NameIdentifier ident) throws NoSuchFilesetException;
 
   /**
+   * Load filesets metadata by {@link NameIdentifier} from the catalog.
+   *
+   * @param idents List of fileset identifier.
+   * @return The fileset metadata.
+   */
+  Fileset[] loadFilesetList(NameIdentifier[] idents);
+
+  /**
    * Check if a fileset exists using an {@link NameIdentifier} from the catalog.
    *
    * @param ident A fileset identifier.

--- a/catalogs/catalog-hadoop/src/main/java/com/datastrato/gravitino/catalog/hadoop/HadoopCatalogOperations.java
+++ b/catalogs/catalog-hadoop/src/main/java/com/datastrato/gravitino/catalog/hadoop/HadoopCatalogOperations.java
@@ -43,6 +43,7 @@ import com.google.common.collect.Maps;
 import java.io.File;
 import java.io.IOException;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
@@ -180,6 +181,20 @@ public class HadoopCatalogOperations implements CatalogOperations, SupportsSchem
     } catch (IOException ioe) {
       throw new RuntimeException("Failed to load fileset %s" + ident, ioe);
     }
+  }
+
+  @Override
+  public Fileset[] loadFilesetList(NameIdentifier[] idents) {
+    List<Fileset> filesets = new ArrayList<>();
+    for (NameIdentifier ident : idents) {
+      try {
+        Fileset fileset = loadFileset(ident);
+        filesets.add(fileset);
+      } catch (NoSuchFilesetException exception) {
+        LOG.warn("Fileset: " + ident + " not exist");
+      }
+    }
+    return filesets.toArray(new Fileset[0]);
   }
 
   @Override

--- a/clients/client-java/src/main/java/com/datastrato/gravitino/client/FilesetCatalog.java
+++ b/clients/client-java/src/main/java/com/datastrato/gravitino/client/FilesetCatalog.java
@@ -10,10 +10,12 @@ import com.datastrato.gravitino.Namespace;
 import com.datastrato.gravitino.dto.AuditDTO;
 import com.datastrato.gravitino.dto.CatalogDTO;
 import com.datastrato.gravitino.dto.requests.FilesetCreateRequest;
+import com.datastrato.gravitino.dto.requests.FilesetListLoadRequest;
 import com.datastrato.gravitino.dto.requests.FilesetUpdateRequest;
 import com.datastrato.gravitino.dto.requests.FilesetUpdatesRequest;
 import com.datastrato.gravitino.dto.responses.DropResponse;
 import com.datastrato.gravitino.dto.responses.EntityListResponse;
+import com.datastrato.gravitino.dto.responses.FileSetListResponse;
 import com.datastrato.gravitino.dto.responses.FilesetResponse;
 import com.datastrato.gravitino.exceptions.FilesetAlreadyExistsException;
 import com.datastrato.gravitino.exceptions.NoSuchFilesetException;
@@ -99,6 +101,31 @@ public class FilesetCatalog extends BaseSchemaCatalog
     resp.validate();
 
     return resp.getFileset();
+  }
+
+  /**
+   * Load filesets metadata by {@link NameIdentifier} from the catalog.
+   *
+   * @param idents List of fileset identifier.
+   * @return The fileset list metadata.
+   */
+  @Override
+  public Fileset[] loadFilesetList(NameIdentifier[] idents) {
+    Arrays.stream(idents).forEach(FilesetCatalog::checkFilesetNameIdentifer);
+    String[] filesetNames = Arrays.stream(idents).map(NameIdentifier::name).toArray(String[]::new);
+
+    FilesetListLoadRequest req =
+        FilesetListLoadRequest.builder().filesetNames(filesetNames).build();
+    FileSetListResponse resp =
+        restClient.post(
+            formatFilesetRequestPath(idents[0].namespace()),
+            req,
+            FileSetListResponse.class,
+            Collections.emptyMap(),
+            ErrorHandlers.filesetErrorHandler());
+    resp.validate();
+
+    return resp.getFilesets();
   }
 
   /**

--- a/common/src/main/java/com/datastrato/gravitino/dto/requests/FilesetListLoadRequest.java
+++ b/common/src/main/java/com/datastrato/gravitino/dto/requests/FilesetListLoadRequest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2024 Datastrato Pvt Ltd.
+ * This software is licensed under the Apache License version 2.
+ */
+package com.datastrato.gravitino.dto.requests;
+
+import com.datastrato.gravitino.rest.RESTRequest;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Preconditions;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+/** Represents a request to load filesets. */
+@Getter
+@EqualsAndHashCode
+@ToString
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class FilesetListLoadRequest implements RESTRequest {
+
+  @JsonProperty("filesetNames")
+  private String[] filesetNames;
+
+  /**
+   * Validates the request.
+   *
+   * @throws IllegalArgumentException if the request is invalid.
+   */
+  @Override
+  public void validate() throws IllegalArgumentException {
+    Preconditions.checkArgument(
+        filesetNames.length != 0, "\"filesetNames\" field is required and cannot be empty");
+  }
+}

--- a/common/src/main/java/com/datastrato/gravitino/dto/responses/FileSetListResponse.java
+++ b/common/src/main/java/com/datastrato/gravitino/dto/responses/FileSetListResponse.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2024 Datastrato Pvt Ltd.
+ * This software is licensed under the Apache License version 2.
+ */
+package com.datastrato.gravitino.dto.responses;
+
+import com.datastrato.gravitino.dto.file.FilesetDTO;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+/** Represents a response for a list of filesets with their information. */
+@Getter
+@ToString
+@EqualsAndHashCode(callSuper = true)
+public class FileSetListResponse extends BaseResponse {
+
+  @JsonProperty("filesets")
+  private final FilesetDTO[] filesets;
+
+  @JsonProperty("noExistsFilesets")
+  private final String[] notExistsFilesets;
+
+  /**
+   * Creates a new FileSetListResponse.
+   *
+   * @param filesets The list of filesets.
+   * @param notExistsFilesets The list of filesets.
+   */
+  public FileSetListResponse(FilesetDTO[] filesets, String[] notExistsFilesets) {
+    super(0);
+    this.filesets = filesets;
+    this.notExistsFilesets = notExistsFilesets;
+  }
+
+  /**
+   * This is the constructor that is used by Jackson deserializer to create an instance of
+   * FileSetListResponse.
+   */
+  public FileSetListResponse() {
+    super();
+    this.filesets = null;
+    this.notExistsFilesets = null;
+  }
+}

--- a/common/src/main/java/com/datastrato/gravitino/dto/util/DTOConverters.java
+++ b/common/src/main/java/com/datastrato/gravitino/dto/util/DTOConverters.java
@@ -602,6 +602,19 @@ public class DTOConverters {
   }
 
   /**
+   * Converts an array of FilesetDTO to an array of FilesetDTO.
+   *
+   * @param filesets The filesets to be converted.
+   * @return The array of CatalogDTOs.
+   */
+  public static FilesetDTO[] toDTOs(Fileset[] filesets) {
+    if (ArrayUtils.isEmpty(filesets)) {
+      return new FilesetDTO[0];
+    }
+    return Arrays.stream(filesets).map(DTOConverters::toDTO).toArray(FilesetDTO[]::new);
+  }
+
+  /**
    * Converts an array of Catalogs to an array of CatalogDTOs.
    *
    * @param catalogs The catalogs to be converted.

--- a/core/src/main/java/com/datastrato/gravitino/catalog/FilesetNormalizeDispatcher.java
+++ b/core/src/main/java/com/datastrato/gravitino/catalog/FilesetNormalizeDispatcher.java
@@ -42,6 +42,14 @@ public class FilesetNormalizeDispatcher implements FilesetDispatcher {
   }
 
   @Override
+  public Fileset[] loadFilesetList(NameIdentifier[] idents) {
+    // The constraints of the name spec may be more strict than underlying catalog,
+    // and for compatibility reasons, we only apply case-sensitive capabilities here.
+    return dispatcher.loadFilesetList(
+        applyCaseSensitive(idents, Capability.Scope.FILESET, dispatcher));
+  }
+
+  @Override
   public boolean filesetExists(NameIdentifier ident) {
     // The constraints of the name spec may be more strict than underlying catalog,
     // and for compatibility reasons, we only apply case-sensitive capabilities here.

--- a/core/src/main/java/com/datastrato/gravitino/catalog/FilesetOperationDispatcher.java
+++ b/core/src/main/java/com/datastrato/gravitino/catalog/FilesetOperationDispatcher.java
@@ -18,6 +18,7 @@ import com.datastrato.gravitino.exceptions.NonEmptyEntityException;
 import com.datastrato.gravitino.file.Fileset;
 import com.datastrato.gravitino.file.FilesetChange;
 import com.datastrato.gravitino.storage.IdGenerator;
+import java.util.Arrays;
 import java.util.Map;
 
 public class FilesetOperationDispatcher extends OperationDispatcher implements FilesetDispatcher {
@@ -71,6 +72,36 @@ public class FilesetOperationDispatcher extends OperationDispatcher implements F
                 catalogIdent,
                 HasPropertyMetadata::filesetPropertiesMetadata,
                 fileset.properties()));
+  }
+
+  /**
+   * Load filesets metadata by {@link NameIdentifier} from the catalog.
+   *
+   * @param idents List of fileset identifier.
+   * @return The fileset metadata.
+   * @throws NoSuchFilesetException If the fileset does not exist.
+   */
+  @Override
+  public Fileset[] loadFilesetList(NameIdentifier[] idents) {
+    NameIdentifier catalogIdent = getCatalogIdentifier(idents[0]);
+    Fileset[] filesets =
+        doWithCatalog(
+            catalogIdent,
+            c -> c.doWithFilesetOps(f -> f.loadFilesetList(idents)),
+            NoSuchFilesetException.class);
+
+    // Currently we only support maintaining the Fileset in the Gravitino's store.
+    return Arrays.stream(filesets)
+        .map(
+            fileset -> {
+              return EntityCombinedFileset.of(fileset)
+                  .withHiddenPropertiesSet(
+                      getHiddenPropertyNames(
+                          catalogIdent,
+                          HasPropertyMetadata::filesetPropertiesMetadata,
+                          fileset.properties()));
+            })
+        .toArray(Fileset[]::new);
   }
 
   /**

--- a/core/src/main/java/com/datastrato/gravitino/listener/FilesetEventDispatcher.java
+++ b/core/src/main/java/com/datastrato/gravitino/listener/FilesetEventDispatcher.java
@@ -23,8 +23,10 @@ import com.datastrato.gravitino.listener.api.event.ListFilesetEvent;
 import com.datastrato.gravitino.listener.api.event.ListFilesetFailureEvent;
 import com.datastrato.gravitino.listener.api.event.LoadFilesetEvent;
 import com.datastrato.gravitino.listener.api.event.LoadFilesetFailureEvent;
+import com.datastrato.gravitino.listener.api.event.LoadFilesetListEvent;
 import com.datastrato.gravitino.listener.api.info.FilesetInfo;
 import com.datastrato.gravitino.utils.PrincipalUtils;
+import java.util.Arrays;
 import java.util.Map;
 
 /**
@@ -67,6 +69,24 @@ public class FilesetEventDispatcher implements FilesetDispatcher {
     } catch (Exception e) {
       eventBus.dispatchEvent(
           new LoadFilesetFailureEvent(PrincipalUtils.getCurrentUserName(), ident, e));
+      throw e;
+    }
+  }
+
+  @Override
+  public Fileset[] loadFilesetList(NameIdentifier[] idents) {
+    NameIdentifier parentIdent = null;
+    try {
+      parentIdent = NameIdentifier.of(idents[0].namespace().toString());
+      Fileset[] filesets = dispatcher.loadFilesetList(idents);
+      FilesetInfo[] filesetInfos =
+          Arrays.stream(filesets).map(FilesetInfo::new).toArray(FilesetInfo[]::new);
+      eventBus.dispatchEvent(
+          new LoadFilesetListEvent(PrincipalUtils.getCurrentUserName(), parentIdent, filesetInfos));
+      return filesets;
+    } catch (Exception e) {
+      eventBus.dispatchEvent(
+          new LoadFilesetFailureEvent(PrincipalUtils.getCurrentUserName(), parentIdent, e));
       throw e;
     }
   }

--- a/core/src/main/java/com/datastrato/gravitino/listener/api/event/LoadFilesetListEvent.java
+++ b/core/src/main/java/com/datastrato/gravitino/listener/api/event/LoadFilesetListEvent.java
@@ -1,0 +1,38 @@
+/*
+ *  Copyright 2024 Datastrato Pvt Ltd.
+ *  This software is licensed under the Apache License version 2.
+ */
+
+package com.datastrato.gravitino.listener.api.event;
+
+import com.datastrato.gravitino.NameIdentifier;
+import com.datastrato.gravitino.annotation.DeveloperApi;
+import com.datastrato.gravitino.listener.api.info.FilesetInfo;
+
+/** Represents an event that occurs when filesets are loaded into the system. */
+@DeveloperApi
+public final class LoadFilesetListEvent extends FilesetEvent {
+  private final FilesetInfo[] loadedFilesetInfos;
+  /**
+   * Constructs a new {@code LoadFilesetListEvent}.
+   *
+   * @param user The user who initiated the loading of the fileset.
+   * @param identifier The unique identifier of the fileset being loaded.
+   * @param loadedFilesetInfos The state of the fileset post-loading.
+   */
+  public LoadFilesetListEvent(
+      String user, NameIdentifier identifier, FilesetInfo[] loadedFilesetInfos) {
+    super(user, identifier);
+    this.loadedFilesetInfos = loadedFilesetInfos;
+  }
+
+  /**
+   * Retrieves the state of the filesets as it was made available to the user after successful
+   * loading.
+   *
+   * @return A {@link FilesetInfo} instance encapsulating the details of the fileset as loaded.
+   */
+  public FilesetInfo[] loadedFilesetInfo() {
+    return loadedFilesetInfos;
+  }
+}

--- a/core/src/main/java/com/datastrato/gravitino/listener/api/event/LoadFilesetListFailureEvent.java
+++ b/core/src/main/java/com/datastrato/gravitino/listener/api/event/LoadFilesetListFailureEvent.java
@@ -1,0 +1,25 @@
+/*
+ *  Copyright 2024 Datastrato Pvt Ltd.
+ *  This software is licensed under the Apache License version 2.
+ */
+
+package com.datastrato.gravitino.listener.api.event;
+
+import com.datastrato.gravitino.NameIdentifier;
+import com.datastrato.gravitino.annotation.DeveloperApi;
+
+/** Represents an event that occurs when an attempt to load a fileset into the system fails. */
+@DeveloperApi
+public final class LoadFilesetListFailureEvent extends FilesetFailureEvent {
+  /**
+   * Constructs a new {@code FilesetFailureEvent} instance.
+   *
+   * @param user The user associated with the failed fileset operation.
+   * @param identifier The identifier of the fileset that was involved in the failed operation.
+   * @param exception The exception that was thrown during the fileset operation, indicating the
+   *     cause of the failure.
+   */
+  public LoadFilesetListFailureEvent(String user, NameIdentifier identifier, Exception exception) {
+    super(user, identifier, exception);
+  }
+}

--- a/server/src/main/java/com/datastrato/gravitino/server/web/rest/FilesetOperations.java
+++ b/server/src/main/java/com/datastrato/gravitino/server/web/rest/FilesetOperations.java
@@ -10,10 +10,12 @@ import com.datastrato.gravitino.NameIdentifier;
 import com.datastrato.gravitino.Namespace;
 import com.datastrato.gravitino.catalog.FilesetDispatcher;
 import com.datastrato.gravitino.dto.requests.FilesetCreateRequest;
+import com.datastrato.gravitino.dto.requests.FilesetListLoadRequest;
 import com.datastrato.gravitino.dto.requests.FilesetUpdateRequest;
 import com.datastrato.gravitino.dto.requests.FilesetUpdatesRequest;
 import com.datastrato.gravitino.dto.responses.DropResponse;
 import com.datastrato.gravitino.dto.responses.EntityListResponse;
+import com.datastrato.gravitino.dto.responses.FileSetListResponse;
 import com.datastrato.gravitino.dto.responses.FilesetResponse;
 import com.datastrato.gravitino.dto.util.DTOConverters;
 import com.datastrato.gravitino.file.Fileset;
@@ -24,7 +26,10 @@ import com.datastrato.gravitino.metrics.MetricNames;
 import com.datastrato.gravitino.server.web.Utils;
 import com.datastrato.gravitino.utils.NameIdentifierUtil;
 import com.datastrato.gravitino.utils.NamespaceUtil;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import javax.inject.Inject;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.DELETE;
@@ -157,6 +162,47 @@ public class FilesetOperations {
           });
     } catch (Exception e) {
       return ExceptionHandlers.handleFilesetException(OperationType.LOAD, fileset, schema, e);
+    }
+  }
+
+  @POST
+  @Path("list")
+  @Produces("application/vnd.gravitino.v1+json")
+  @Timed(name = "load-fileset." + MetricNames.HTTP_PROCESS_DURATION, absolute = true)
+  @ResponseMetered(name = "load-fileset", absolute = true)
+  public Response loadFilesetList(
+      @PathParam("metalake") String metalake,
+      @PathParam("catalog") String catalog,
+      @PathParam("schema") String schema,
+      FilesetListLoadRequest request) {
+    try {
+      return Utils.doAs(
+          httpRequest,
+          () -> {
+            String[] queryFilesetNames = request.getFilesetNames();
+            NameIdentifier[] idents =
+                Arrays.stream(queryFilesetNames)
+                    .map(
+                        fileset -> NameIdentifierUtil.ofFileset(metalake, catalog, schema, fileset))
+                    .toArray(NameIdentifier[]::new);
+            // When batch loading FileSets, a read lock should be applied to each individual
+            // FileSet. Currently, only the first element of the fileset is being locked, which is
+            // an issue that needs to be addressed.
+            Fileset[] filesets =
+                TreeLockUtils.doWithTreeLock(
+                    idents[0], LockType.READ, () -> dispatcher.loadFilesetList(idents));
+            List<String> existFilesetNames =
+                Arrays.stream(filesets).map(Fileset::name).collect(Collectors.toList());
+            String[] notExistsFilesetNames =
+                Arrays.stream(queryFilesetNames)
+                    .filter(fileset -> !existFilesetNames.contains(fileset))
+                    .toArray(String[]::new);
+            return Utils.ok(
+                new FileSetListResponse(DTOConverters.toDTOs(filesets), notExistsFilesetNames));
+          });
+    } catch (Exception e) {
+      return ExceptionHandlers.handleFilesetException(
+          OperationType.LOAD, Arrays.toString(request.getFilesetNames()), schema, e);
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

1. Provide Batch Load Api for Multiple Entities 
2. This version only implement loadFilesetList api for batch loading filesets

### Why are the changes needed?

Reduce the number of invocation calls when making batch query requests.

Fix: # (issue) https://github.com/datastrato/gravitino/issues/3989

### Does this PR introduce _any_ user-facing change?

Yes, provide Batch Load Api

### How was this patch tested?
I have not yet implemented unit tests. We can first discuss and evaluate the reasonableness of the code and then I will add the corresponding unit tests.
