### PR TITLE
[#3732] refactor: update Python client to align with the Java client API: gravitino_metalake, gravitino_client

### DIFF
--- a/clients/client-python/gravitino/client/gravitino_admin_client.py
+++ b/clients/client-python/gravitino/client/gravitino_admin_client.py
@@ -15,7 +15,6 @@ from gravitino.dto.responses.drop_response import DropResponse
 from gravitino.dto.responses.metalake_list_response import MetalakeListResponse
 from gravitino.dto.responses.metalake_response import MetalakeResponse
 from gravitino.api.metalake_change import MetalakeChange
-from gravitino.name_identifier import NameIdentifier
 
 logger = logging.getLogger(__name__)
 
@@ -45,12 +44,12 @@ class GravitinoAdminClient(GravitinoClientBase):
         ]
 
     def create_metalake(
-        self, ident: NameIdentifier, comment: str, properties: Dict[str, str]
+        self, name: str, comment: str, properties: Dict[str, str]
     ) -> GravitinoMetalake:
         """Creates a new Metalake using the Gravitino API.
 
         Args:
-            ident: The identifier of the new Metalake.
+            name: The name of the new Metalake.
             comment: The comment for the new Metalake.
             properties: The properties of the new Metalake.
 
@@ -58,9 +57,7 @@ class GravitinoAdminClient(GravitinoClientBase):
             A GravitinoMetalake instance representing the newly created Metalake.
             TODO: @throws MetalakeAlreadyExistsException If a Metalake with the specified identifier already exists.
         """
-        NameIdentifier.check_metalake(ident)
-
-        req = MetalakeCreateRequest(ident.name(), comment, properties)
+        req = MetalakeCreateRequest(name, comment, properties)
         req.validate()
 
         resp = self._rest_client.post(self.API_METALAKES_LIST_PATH, req)
@@ -70,13 +67,11 @@ class GravitinoAdminClient(GravitinoClientBase):
 
         return GravitinoMetalake(metalake, self._rest_client)
 
-    def alter_metalake(
-        self, ident: NameIdentifier, *changes: MetalakeChange
-    ) -> GravitinoMetalake:
+    def alter_metalake(self, name: str, *changes: MetalakeChange) -> GravitinoMetalake:
         """Alters a specific Metalake using the Gravitino API.
 
         Args:
-            ident: The identifier of the Metalake to be altered.
+            name: The name of the Metalake to be altered.
             changes: The changes to be applied to the Metalake.
 
         Returns:
@@ -85,13 +80,12 @@ class GravitinoAdminClient(GravitinoClientBase):
         TODO: @throws IllegalArgumentException If the provided changes are invalid or not applicable.
         """
 
-        NameIdentifier.check_metalake(ident)
         reqs = [DTOConverters.to_metalake_update_request(change) for change in changes]
         updates_request = MetalakeUpdatesRequest(reqs)
         updates_request.validate()
 
         resp = self._rest_client.put(
-            self.API_METALAKES_IDENTIFIER_PATH + ident.name(), updates_request
+            self.API_METALAKES_IDENTIFIER_PATH + name, updates_request
         )
         metalake_response = MetalakeResponse.from_json(resp.body, infer_missing=True)
         metalake_response.validate()
@@ -99,24 +93,20 @@ class GravitinoAdminClient(GravitinoClientBase):
 
         return GravitinoMetalake(metalake, self._rest_client)
 
-    def drop_metalake(self, ident: NameIdentifier) -> bool:
+    def drop_metalake(self, name: str) -> bool:
         """Drops a specific Metalake using the Gravitino API.
 
         Args:
-            ident: The identifier of the Metalake to be dropped.
+            name: The name of the Metalake to be dropped.
 
         Returns:
             True if the Metalake was successfully dropped, false otherwise.
         """
-        NameIdentifier.check_metalake(ident)
-
         try:
-            resp = self._rest_client.delete(
-                self.API_METALAKES_IDENTIFIER_PATH + ident.name()
-            )
+            resp = self._rest_client.delete(self.API_METALAKES_IDENTIFIER_PATH + name)
             drop_response = DropResponse.from_json(resp.body, infer_missing=True)
 
             return drop_response.dropped()
         except Exception:
-            logger.warning("Failed to drop metalake %s", ident)
+            logger.warning("Failed to drop metalake %s", name)
             return False

--- a/clients/client-python/gravitino/client/gravitino_client.py
+++ b/clients/client-python/gravitino/client/gravitino_client.py
@@ -10,8 +10,6 @@ from gravitino.api.catalog_change import CatalogChange
 from gravitino.auth.auth_data_provider import AuthDataProvider
 from gravitino.client.gravitino_client_base import GravitinoClientBase
 from gravitino.client.gravitino_metalake import GravitinoMetalake
-from gravitino.name_identifier import NameIdentifier
-from gravitino.namespace import Namespace
 
 
 class NoSuchMetalakeException(Exception):
@@ -53,6 +51,7 @@ class GravitinoClient(GravitinoClientBase):
             NoSuchMetalakeException if the metalake with specified name does not exist.
         """
         super().__init__(uri, check_version, auth_data_provider)
+        self.check_metalake_name(metalake_name)
         self._metalake = super().load_metalake(metalake_name)
 
     def get_metalake(self) -> GravitinoMetalake:
@@ -66,29 +65,29 @@ class GravitinoClient(GravitinoClientBase):
         """
         return self._metalake
 
-    def list_catalogs(self, namespace: Namespace) -> List[NameIdentifier]:
-        return self.get_metalake().list_catalogs(namespace)
+    def list_catalogs(self) -> List[str]:
+        return self.get_metalake().list_catalogs()
 
-    def list_catalogs_info(self, namespace: Namespace) -> List[Catalog]:
-        return self.get_metalake().list_catalogs_info(namespace)
+    def list_catalogs_info(self) -> List[Catalog]:
+        return self.get_metalake().list_catalogs_info()
 
-    def load_catalog(self, ident: NameIdentifier) -> Catalog:
-        return self.get_metalake().load_catalog(ident)
+    def load_catalog(self, name: str) -> Catalog:
+        return self.get_metalake().load_catalog(name)
 
     def create_catalog(
         self,
-        ident: NameIdentifier,
+        name: str,
         catalog_type: Catalog.Type,
         provider: str,
         comment: str,
         properties: Dict[str, str],
     ) -> Catalog:
         return self.get_metalake().create_catalog(
-            ident, catalog_type, provider, comment, properties
+            name, catalog_type, provider, comment, properties
         )
 
-    def alter_catalog(self, ident: NameIdentifier, *changes: CatalogChange):
-        return self.get_metalake().alter_catalog(ident, *changes)
+    def alter_catalog(self, name: str, *changes: CatalogChange):
+        return self.get_metalake().alter_catalog(name, *changes)
 
-    def drop_catalog(self, ident: NameIdentifier):
-        return self.get_metalake().drop_catalog(ident)
+    def drop_catalog(self, name: str):
+        return self.get_metalake().drop_catalog(name)

--- a/clients/client-python/gravitino/client/gravitino_client.py
+++ b/clients/client-python/gravitino/client/gravitino_client.py
@@ -53,7 +53,7 @@ class GravitinoClient(GravitinoClientBase):
             NoSuchMetalakeException if the metalake with specified name does not exist.
         """
         super().__init__(uri, check_version, auth_data_provider)
-        self._metalake = super().load_metalake(NameIdentifier.of(metalake_name))
+        self._metalake = super().load_metalake(metalake_name)
 
     def get_metalake(self) -> GravitinoMetalake:
         """Get the current metalake object

--- a/clients/client-python/gravitino/client/gravitino_client_base.py
+++ b/clients/client-python/gravitino/client/gravitino_client_base.py
@@ -16,6 +16,7 @@ from gravitino.dto.responses.version_response import VersionResponse
 from gravitino.utils import HTTPClient
 from gravitino.exceptions.gravitino_runtime_exception import GravitinoRuntimeException
 from gravitino.constants.version import VERSION_INI, Version
+from gravitino.name_identifier import NameIdentifier
 
 logger = logging.getLogger(__name__)
 
@@ -58,6 +59,7 @@ class GravitinoClientBase:
             NoSuchMetalakeException If the specified Metalake does not exist.
         """
 
+        self.check_metalake_name(name)
         response = self._rest_client.get(
             GravitinoClientBase.API_METALAKES_IDENTIFIER_PATH + name
         )
@@ -123,3 +125,12 @@ class GravitinoClientBase:
                 self._rest_client.close()
             except Exception as e:
                 logger.warning("Failed to close the HTTP REST client: %s", e)
+
+    def check_metalake_name(self, metalake_name: str):
+        identifier = NameIdentifier.parse(metalake_name)
+        namespace = identifier.namespace()
+
+        if not namespace:
+            raise ValueError(
+                f"Metalake namespace must be empty, the input namespace is {namespace}"
+            )

--- a/clients/client-python/gravitino/client/gravitino_client_base.py
+++ b/clients/client-python/gravitino/client/gravitino_client_base.py
@@ -13,7 +13,6 @@ from gravitino.client.gravitino_version import GravitinoVersion
 from gravitino.dto.version_dto import VersionDTO
 from gravitino.dto.responses.metalake_response import MetalakeResponse
 from gravitino.dto.responses.version_response import VersionResponse
-from gravitino.name_identifier import NameIdentifier
 from gravitino.utils import HTTPClient
 from gravitino.exceptions.gravitino_runtime_exception import GravitinoRuntimeException
 from gravitino.constants.version import VERSION_INI, Version
@@ -46,11 +45,11 @@ class GravitinoClientBase:
         if check_version:
             self.check_version()
 
-    def load_metalake(self, ident: NameIdentifier) -> GravitinoMetalake:
+    def load_metalake(self, name: str) -> GravitinoMetalake:
         """Loads a specific Metalake from the Gravitino API.
 
         Args:
-            ident The identifier of the Metalake to be loaded.
+            name: The name of the Metalake to be loaded.
 
         Returns:
             A GravitinoMetalake instance representing the loaded Metalake.
@@ -59,10 +58,8 @@ class GravitinoClientBase:
             NoSuchMetalakeException If the specified Metalake does not exist.
         """
 
-        NameIdentifier.check_metalake(ident)
-
         response = self._rest_client.get(
-            GravitinoClientBase.API_METALAKES_IDENTIFIER_PATH + ident.name()
+            GravitinoClientBase.API_METALAKES_IDENTIFIER_PATH + name
         )
         metalake_response = MetalakeResponse.from_json(
             response.body, infer_missing=True

--- a/clients/client-python/gravitino/client/gravitino_metalake.py
+++ b/clients/client-python/gravitino/client/gravitino_metalake.py
@@ -67,7 +67,7 @@ class GravitinoMetalake(MetalakeDTO):
         response = self.rest_client.get(url)
         entity_list = EntityListResponse.from_json(response.body, infer_missing=True)
         entity_list.validate()
-        return [identifier.name for identifier in entity_list.identifiers()]
+        return [identifier.name() for identifier in entity_list.identifiers()]
 
     def list_catalogs_info(self) -> List[Catalog]:
         """List all the catalogs with their information under this metalake.

--- a/clients/client-python/tests/integration/test_catalog.py
+++ b/clients/client-python/tests/integration/test_catalog.py
@@ -1,0 +1,78 @@
+"""
+Copyright 2024 Datastrato Pvt Ltd.
+This software is licensed under the Apache License version 2.
+"""
+
+import logging
+from random import randint
+
+from gravitino import (
+    NameIdentifier,
+    GravitinoAdminClient,
+    GravitinoClient,
+    Catalog,
+)
+
+from tests.integration.integration_test_env import IntegrationTestEnv
+
+logger = logging.getLogger(__name__)
+
+
+class TestCatalog(IntegrationTestEnv):
+    metalake_name: str = "TestSchema_metalake" + str(randint(1, 10000))
+
+    catalog_name: str = "testCatalog"
+    catalog_location_prop: str = "location"  # Fileset Catalog must set `location`
+    catalog_provider: str = "hadoop"
+
+    catalog_ident: NameIdentifier = NameIdentifier.of_catalog(
+        metalake_name, catalog_name
+    )
+
+    gravitino_admin_client: GravitinoAdminClient = GravitinoAdminClient(
+        uri="http://localhost:8090"
+    )
+    gravitino_client: GravitinoClient = None
+
+    def setUp(self):
+        self.init_test_env()
+
+    def tearDown(self):
+        self.clean_test_data()
+
+    def init_test_env(self):
+        self.gravitino_admin_client.create_metalake(
+            self.metalake_name, comment="", properties={}
+        )
+        self.gravitino_client = GravitinoClient(
+            uri="http://localhost:8090", metalake_name=self.metalake_name
+        )
+        self.gravitino_client.create_catalog(
+            name=self.catalog_name,
+            catalog_type=Catalog.Type.FILESET,
+            provider=self.catalog_provider,
+            comment="",
+            properties={self.catalog_location_prop: "/tmp/test_schema"},
+        )
+
+    def clean_test_data(self):
+        try:
+            self.gravitino_client = GravitinoClient(
+                uri="http://localhost:8090", metalake_name=self.metalake_name
+            )
+            logger.info(
+                "Drop catalog %s[%s]",
+                self.catalog_ident,
+                self.gravitino_client.drop_catalog(name=self.catalog_name),
+            )
+            logger.info(
+                "Drop metalake %s[%s]",
+                self.metalake_name,
+                self.gravitino_admin_client.drop_metalake(self.metalake_name),
+            )
+        except Exception as e:
+            logger.error("Clean test data failed: %s", e)
+
+    def test_list_catalogs(self):
+        catalog_names = self.gravitino_client.list_catalogs()
+        self.assertTrue(self.catalog_name in catalog_names)

--- a/clients/client-python/tests/integration/test_fileset_catalog.py
+++ b/clients/client-python/tests/integration/test_fileset_catalog.py
@@ -43,7 +43,6 @@ class TestFilesetCatalog(IntegrationTestEnv):
     }
     fileset_new_name = fileset_name + "_new"
 
-    metalake_ident: NameIdentifier = NameIdentifier.of(metalake_name)
     catalog_ident: NameIdentifier = NameIdentifier.of_catalog(
         metalake_name, catalog_name
     )
@@ -96,15 +95,15 @@ class TestFilesetCatalog(IntegrationTestEnv):
             )
             logger.info(
                 "Drop metalake %s[%s]",
-                self.metalake_ident,
-                self.gravitino_admin_client.drop_metalake(self.metalake_ident),
+                self.metalake_name,
+                self.gravitino_admin_client.drop_metalake(self.metalake_name),
             )
         except Exception as e:
             logger.error("Clean test data failed: %s", e)
 
     def init_test_env(self):
         self.gravitino_admin_client.create_metalake(
-            ident=self.metalake_ident, comment="", properties={}
+            self.metalake_name, comment="", properties={}
         )
         self.gravitino_client = GravitinoClient(
             uri="http://localhost:8090", metalake_name=self.metalake_name

--- a/clients/client-python/tests/integration/test_fileset_catalog.py
+++ b/clients/client-python/tests/integration/test_fileset_catalog.py
@@ -72,7 +72,7 @@ class TestFilesetCatalog(IntegrationTestEnv):
             self.gravitino_client = GravitinoClient(
                 uri="http://localhost:8090", metalake_name=self.metalake_name
             )
-            catalog = self.gravitino_client.load_catalog(ident=self.catalog_ident)
+            catalog = self.gravitino_client.load_catalog(name=self.catalog_name)
             logger.info(
                 "Drop fileset %s[%s]",
                 self.fileset_ident,
@@ -91,7 +91,7 @@ class TestFilesetCatalog(IntegrationTestEnv):
             logger.info(
                 "Drop catalog %s[%s]",
                 self.catalog_ident,
-                self.gravitino_client.drop_catalog(ident=self.catalog_ident),
+                self.gravitino_client.drop_catalog(name=self.catalog_name),
             )
             logger.info(
                 "Drop metalake %s[%s]",
@@ -109,7 +109,7 @@ class TestFilesetCatalog(IntegrationTestEnv):
             uri="http://localhost:8090", metalake_name=self.metalake_name
         )
         catalog = self.gravitino_client.create_catalog(
-            ident=self.catalog_ident,
+            name=self.catalog_name,
             catalog_type=Catalog.Type.FILESET,
             provider=self.catalog_provider,
             comment="",
@@ -120,7 +120,7 @@ class TestFilesetCatalog(IntegrationTestEnv):
         )
 
     def create_fileset(self) -> Fileset:
-        catalog = self.gravitino_client.load_catalog(ident=self.catalog_ident)
+        catalog = self.gravitino_client.load_catalog(name=self.catalog_name)
         return catalog.as_fileset_catalog().create_fileset(
             ident=self.fileset_ident,
             fileset_type=Fileset.Type.MANAGED,
@@ -138,14 +138,14 @@ class TestFilesetCatalog(IntegrationTestEnv):
 
     def test_drop_fileset(self):
         self.create_fileset()
-        catalog = self.gravitino_client.load_catalog(ident=self.catalog_ident)
+        catalog = self.gravitino_client.load_catalog(name=self.catalog_name)
         self.assertTrue(
             catalog.as_fileset_catalog().drop_fileset(ident=self.fileset_ident)
         )
 
     def test_list_fileset(self):
         self.create_fileset()
-        catalog = self.gravitino_client.load_catalog(ident=self.catalog_ident)
+        catalog = self.gravitino_client.load_catalog(name=self.catalog_name)
         fileset_list: List[NameIdentifier] = catalog.as_fileset_catalog().list_filesets(
             namespace=self.fileset_ident.namespace()
         )
@@ -154,7 +154,7 @@ class TestFilesetCatalog(IntegrationTestEnv):
     def test_load_fileset(self):
         self.create_fileset()
         fileset = (
-            self.gravitino_client.load_catalog(ident=self.catalog_ident)
+            self.gravitino_client.load_catalog(name=self.catalog_name)
             .as_fileset_catalog()
             .load_fileset(ident=self.fileset_ident)
         )
@@ -174,7 +174,7 @@ class TestFilesetCatalog(IntegrationTestEnv):
                 self.fileset_properties_key2, fileset_propertie_new_value
             ),
         )
-        catalog = self.gravitino_client.load_catalog(ident=self.catalog_ident)
+        catalog = self.gravitino_client.load_catalog(name=self.catalog_name)
         fileset_new = catalog.as_fileset_catalog().alter_fileset(
             self.fileset_ident, *changes
         )

--- a/clients/client-python/tests/integration/test_metalake.py
+++ b/clients/client-python/tests/integration/test_metalake.py
@@ -6,12 +6,7 @@ This software is licensed under the Apache License version 2.
 import logging
 from typing import Dict, List
 
-from gravitino import (
-    GravitinoAdminClient,
-    GravitinoMetalake,
-    MetalakeChange,
-    NameIdentifier,
-)
+from gravitino import GravitinoAdminClient, GravitinoMetalake, MetalakeChange
 from gravitino.dto.dto_converters import DTOConverters
 from gravitino.dto.requests.metalake_updates_request import MetalakeUpdatesRequest
 from tests.integration.integration_test_env import IntegrationTestEnv
@@ -61,7 +56,7 @@ class TestMetalake(IntegrationTestEnv):
 
     def create_metalake(self, metalake_name) -> GravitinoMetalake:
         return self.gravitino_admin_client.create_metalake(
-            NameIdentifier.of(metalake_name),
+            metalake_name,
             self.metalake_comment,
             self.metalake_properties,
         )
@@ -83,7 +78,7 @@ class TestMetalake(IntegrationTestEnv):
         )
 
         metalake = self.gravitino_admin_client.alter_metalake(
-            NameIdentifier.of(self.metalake_name), *changes
+            self.metalake_name, *changes
         )
         self.assertEqual(metalake.name(), metalake_new_name)
         self.assertEqual(metalake.comment(), metalake_new_comment)
@@ -94,8 +89,7 @@ class TestMetalake(IntegrationTestEnv):
         self.assertTrue(self.metalake_properties_key1 not in metalake.properties())
 
     def drop_metalake(self, metalake_name: str) -> bool:
-        ident = NameIdentifier.of(metalake_name)
-        return self.gravitino_admin_client.drop_metalake(ident)
+        return self.gravitino_admin_client.drop_metalake(metalake_name)
 
     def test_drop_metalake(self):
         self.create_metalake(self.metalake_name)
@@ -125,9 +119,7 @@ class TestMetalake(IntegrationTestEnv):
 
     def test_load_metalakes(self):
         self.create_metalake(self.metalake_name)
-        metalake = self.gravitino_admin_client.load_metalake(
-            NameIdentifier.of(self.metalake_name)
-        )
+        metalake = self.gravitino_admin_client.load_metalake(self.metalake_name)
         self.assertIsNotNone(metalake)
         self.assertEqual(metalake.name(), self.metalake_name)
         self.assertEqual(metalake.comment(), self.metalake_comment)

--- a/clients/client-python/tests/integration/test_schema.py
+++ b/clients/client-python/tests/integration/test_schema.py
@@ -41,7 +41,6 @@ class TestSchema(IntegrationTestEnv):
         schema_properties_key2: schema_properties_value2,
     }
 
-    metalake_ident: NameIdentifier = NameIdentifier.of(metalake_name)
     catalog_ident: NameIdentifier = NameIdentifier.of_catalog(
         metalake_name, catalog_name
     )
@@ -65,7 +64,7 @@ class TestSchema(IntegrationTestEnv):
 
     def init_test_env(self):
         self.gravitino_admin_client.create_metalake(
-            ident=self.metalake_ident, comment="", properties={}
+            self.metalake_name, comment="", properties={}
         )
         self.gravitino_client = GravitinoClient(
             uri="http://localhost:8090", metalake_name=self.metalake_name
@@ -101,8 +100,8 @@ class TestSchema(IntegrationTestEnv):
             )
             logger.info(
                 "Drop metalake %s[%s]",
-                self.metalake_ident,
-                self.gravitino_admin_client.drop_metalake(self.metalake_ident),
+                self.metalake_name,
+                self.gravitino_admin_client.drop_metalake(self.metalake_name),
             )
         except Exception as e:
             logger.error("Clean test data failed: %s", e)

--- a/clients/client-python/tests/integration/test_schema.py
+++ b/clients/client-python/tests/integration/test_schema.py
@@ -70,7 +70,7 @@ class TestSchema(IntegrationTestEnv):
             uri="http://localhost:8090", metalake_name=self.metalake_name
         )
         self.gravitino_client.create_catalog(
-            ident=self.catalog_ident,
+            name=self.catalog_name,
             catalog_type=Catalog.Type.FILESET,
             provider=self.catalog_provider,
             comment="",
@@ -82,7 +82,7 @@ class TestSchema(IntegrationTestEnv):
             self.gravitino_client = GravitinoClient(
                 uri="http://localhost:8090", metalake_name=self.metalake_name
             )
-            catalog = self.gravitino_client.load_catalog(ident=self.catalog_ident)
+            catalog = self.gravitino_client.load_catalog(name=self.catalog_name)
             logger.info(
                 "Drop schema %s[%s]",
                 self.schema_ident,
@@ -96,7 +96,7 @@ class TestSchema(IntegrationTestEnv):
             logger.info(
                 "Drop catalog %s[%s]",
                 self.catalog_ident,
-                self.gravitino_client.drop_catalog(ident=self.catalog_ident),
+                self.gravitino_client.drop_catalog(name=self.catalog_name),
             )
             logger.info(
                 "Drop metalake %s[%s]",
@@ -107,7 +107,7 @@ class TestSchema(IntegrationTestEnv):
             logger.error("Clean test data failed: %s", e)
 
     def create_schema(self) -> Schema:
-        catalog = self.gravitino_client.load_catalog(ident=self.catalog_ident)
+        catalog = self.gravitino_client.load_catalog(name=self.catalog_name)
         return catalog.as_schemas().create_schema(
             ident=self.schema_ident,
             comment=self.schema_comment,
@@ -123,14 +123,14 @@ class TestSchema(IntegrationTestEnv):
 
     def test_drop_schema(self):
         self.create_schema()
-        catalog = self.gravitino_client.load_catalog(ident=self.catalog_ident)
+        catalog = self.gravitino_client.load_catalog(name=self.catalog_name)
         self.assertTrue(
             catalog.as_schemas().drop_schema(ident=self.schema_ident, cascade=True)
         )
 
     def test_list_schema(self):
         self.create_schema()
-        catalog = self.gravitino_client.load_catalog(ident=self.catalog_ident)
+        catalog = self.gravitino_client.load_catalog(name=self.catalog_name)
         schema_list: List[NameIdentifier] = catalog.as_schemas().list_schemas(
             namespace=self.schema_ident.namespace()
         )
@@ -138,7 +138,7 @@ class TestSchema(IntegrationTestEnv):
 
     def test_load_schema(self):
         self.create_schema()
-        catalog = self.gravitino_client.load_catalog(ident=self.catalog_ident)
+        catalog = self.gravitino_client.load_catalog(name=self.catalog_name)
         schema = catalog.as_schemas().load_schema(ident=self.schema_ident)
         self.assertIsNotNone(schema)
         self.assertEqual(schema.name(), self.schema_name)
@@ -156,7 +156,7 @@ class TestSchema(IntegrationTestEnv):
                 self.schema_properties_key2, schema_propertie_new_value
             ),
         )
-        catalog = self.gravitino_client.load_catalog(ident=self.catalog_ident)
+        catalog = self.gravitino_client.load_catalog(name=self.catalog_name)
         schema_new = catalog.as_schemas().alter_schema(self.schema_ident, *changes)
         self.assertEqual(
             schema_new.properties().get(self.schema_properties_key2),

--- a/clients/client-python/tests/integration/test_simple_auth_client.py
+++ b/clients/client-python/tests/integration/test_simple_auth_client.py
@@ -85,14 +85,14 @@ class TestSimpleAuthClient(unittest.TestCase):
             logger.info(
                 "Drop metalake %s[%s]",
                 self.metalake_ident,
-                self.gravitino_admin_client.drop_metalake(self.metalake_ident),
+                self.gravitino_admin_client.drop_metalake(self.metalake_ident.name()),
             )
         except Exception as e:
             logger.error("Clean test data failed: %s", e)
 
     def init_test_env(self):
         self.gravitino_admin_client.create_metalake(
-            ident=self.metalake_ident, comment="", properties={}
+            self.metalake_ident.name(), comment="", properties={}
         )
         self.gravitino_client = GravitinoClient(
             uri="http://localhost:8090",
@@ -118,9 +118,7 @@ class TestSimpleAuthClient(unittest.TestCase):
         )
 
     def test_metalake_creator(self):
-        metalake = self.gravitino_admin_client.load_metalake(
-            NameIdentifier.of_metalake(self.metalake_ident.name())
-        )
+        metalake = self.gravitino_admin_client.load_metalake(self.metalake_name)
         self.assertEqual(metalake.audit_info().creator(), self.creator)
 
     def test_catalog_creator(self):

--- a/clients/client-python/tests/integration/test_simple_auth_client.py
+++ b/clients/client-python/tests/integration/test_simple_auth_client.py
@@ -43,7 +43,6 @@ class TestSimpleAuthClient(unittest.TestCase):
         fileset_properties_key2: fileset_properties_value2,
     }
 
-    metalake_ident: NameIdentifier = NameIdentifier.of(metalake_name)
     catalog_ident: NameIdentifier = NameIdentifier.of_catalog(
         metalake_name, catalog_name
     )
@@ -66,7 +65,7 @@ class TestSimpleAuthClient(unittest.TestCase):
 
     def clean_test_data(self):
         try:
-            catalog = self.gravitino_client.load_catalog(ident=self.catalog_ident)
+            catalog = self.gravitino_client.load_catalog(name=self.catalog_name)
             logger.info(
                 "Drop fileset %s[%s]",
                 self.fileset_ident,
@@ -80,19 +79,19 @@ class TestSimpleAuthClient(unittest.TestCase):
             logger.info(
                 "Drop catalog %s[%s]",
                 self.catalog_ident,
-                self.gravitino_client.drop_catalog(ident=self.catalog_ident),
+                self.gravitino_client.drop_catalog(name=self.catalog_name),
             )
             logger.info(
                 "Drop metalake %s[%s]",
-                self.metalake_ident,
-                self.gravitino_admin_client.drop_metalake(self.metalake_ident.name()),
+                self.metalake_name,
+                self.gravitino_admin_client.drop_metalake(self.metalake_name),
             )
         except Exception as e:
             logger.error("Clean test data failed: %s", e)
 
     def init_test_env(self):
         self.gravitino_admin_client.create_metalake(
-            self.metalake_ident.name(), comment="", properties={}
+            self.metalake_name, comment="", properties={}
         )
         self.gravitino_client = GravitinoClient(
             uri="http://localhost:8090",
@@ -100,7 +99,7 @@ class TestSimpleAuthClient(unittest.TestCase):
             auth_data_provider=SimpleAuthProvider(),
         )
         catalog = self.gravitino_client.create_catalog(
-            ident=self.catalog_ident,
+            name=self.catalog_name,
             catalog_type=Catalog.Type.FILESET,
             provider=self.catalog_provider,
             comment="",
@@ -122,15 +121,15 @@ class TestSimpleAuthClient(unittest.TestCase):
         self.assertEqual(metalake.audit_info().creator(), self.creator)
 
     def test_catalog_creator(self):
-        catalog = self.gravitino_client.load_catalog(self.catalog_ident)
+        catalog = self.gravitino_client.load_catalog(self.catalog_name)
         self.assertEqual(catalog.audit_info().creator(), self.creator)
 
     def test_schema_creator(self):
-        catalog = self.gravitino_client.load_catalog(self.catalog_ident)
+        catalog = self.gravitino_client.load_catalog(self.catalog_name)
         schema = catalog.as_schemas().load_schema(self.schema_ident)
         self.assertEqual(schema.audit_info().creator(), self.creator)
 
     def test_fileset_creator(self):
-        catalog = self.gravitino_client.load_catalog(self.catalog_ident)
+        catalog = self.gravitino_client.load_catalog(self.catalog_name)
         fileset = catalog.as_fileset_catalog().load_fileset(self.fileset_ident)
         self.assertEqual(fileset.audit_info().creator(), self.creator)


### PR DESCRIPTION
### What changes were proposed in this pull request?
After the refactoring work in Java client is done (https://github.com/datastrato/gravitino/issues/3626), the Python client should also get updated to align with the Java API.

This PR mainly work on the following python classes:
1. gravitino_metalake.py
2. gravitino_client.py
3. gravitino_admin_client.py


### Why are the changes needed?

To make the API simple and easy to use.

Fix: #3732

### Does this PR introduce _any_ user-facing change?
Change the Python client API.

### How was this patch tested?
The integration tests are updated and passed. 
