### PR TITLE
[#4065] improvement(test): Fix the path of integration log is wrong.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -182,8 +182,8 @@ allprojects {
       param.environment("jdbcBackend", jdbcDatabase)
 
       val testMode = project.properties["testMode"] as? String ?: "embedded"
-      param.systemProperty("gravitino.log.path", project.buildDir.path + "/${project.name}-integration-test.log")
-      project.delete(project.buildDir.path + "/${project.name}-integration-test.log")
+      param.systemProperty("gravitino.log.path", "build/${project.name}-integration-test.log")
+      project.delete("build/${project.name}-integration-test.log")
       if (testMode == "deploy") {
         param.environment("GRAVITINO_HOME", project.rootDir.path + "/distribution/package")
         param.systemProperty("testMode", "deploy")

--- a/catalogs/catalog-hadoop/src/test/resources/log4j2.properties
+++ b/catalogs/catalog-hadoop/src/test/resources/log4j2.properties
@@ -30,7 +30,7 @@ appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} %-5p [%t] %c{1}:%L - %m%n
 
 # Log files location
-property.logPath = ${sys:gravitino.log.path:-catalog-hadoop/build/integration-test.log}
+property.logPath = ${sys:gravitino.log.path:-build/catalog-hadoop-integration-test.log}
 
 # File appender configuration
 appender.file.type = File

--- a/catalogs/catalog-hive/src/test/resources/log4j2.properties
+++ b/catalogs/catalog-hive/src/test/resources/log4j2.properties
@@ -30,7 +30,7 @@ appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} %-5p [%t] %c{1}:%L - %m%n
 
 # Log files location
-property.logPath = ${sys:gravitino.log.path:-catalog-hive/build/hive-integration-test.log}
+property.logPath = ${sys:gravitino.log.path:-build/catalog-hive-integration-test.log}
 
 # File appender configuration
 appender.file.type = File

--- a/catalogs/catalog-jdbc-doris/src/test/resources/log4j2.properties
+++ b/catalogs/catalog-jdbc-doris/src/test/resources/log4j2.properties
@@ -30,7 +30,7 @@ appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} %-5p [%t] %c{1}:%L - %m%n
 
 # Log files location
-property.logPath = ${sys:gravitino.log.path:-catalog-jdbc-doris/build/doris-integration-test.log}
+property.logPath = ${sys:gravitino.log.path:-build/catalog-jdbc-doris-integration-test.log}
 
 # File appender configuration
 appender.file.type = File

--- a/catalogs/catalog-jdbc-mysql/src/test/resources/log4j2.properties
+++ b/catalogs/catalog-jdbc-mysql/src/test/resources/log4j2.properties
@@ -30,7 +30,7 @@ appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} %-5p [%t] %c{1}:%L - %m%n
 
 # Log files location
-property.logPath = ${sys:gravitino.log.path:-catalog-jdbc-mysql/build/mysql-integration-test.log}
+property.logPath = ${sys:gravitino.log.path:-build/catalog-jdbc-mysql-integration-test.log}
 
 # File appender configuration
 appender.file.type = File

--- a/catalogs/catalog-jdbc-postgresql/src/test/resources/log4j2.properties
+++ b/catalogs/catalog-jdbc-postgresql/src/test/resources/log4j2.properties
@@ -30,7 +30,7 @@ appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} %-5p [%t] %c{1}:%L - %m%n
 
 # Log files location
-property.logPath = ${sys:gravitino.log.path:-catalog-jdbc-postgresql/build/postgresql-integration-test.log}
+property.logPath = ${sys:gravitino.log.path:-build/catalog-jdbc-postgresql-integration-test.log}
 
 # File appender configuration
 appender.file.type = File

--- a/catalogs/catalog-kafka/src/test/resources/log4j2.properties
+++ b/catalogs/catalog-kafka/src/test/resources/log4j2.properties
@@ -30,7 +30,7 @@ appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} %-5p [%t] %c{1}:%L - %m%n
 
 # Log files location
-property.logPath = ${sys:gravitino.log.path:-catalog-messaging-kafka/build/kafka-integration-test.log}
+property.logPath = ${sys:gravitino.log.path:-build/catalog-kafka-integration-test.log}
 
 # File appender configuration
 appender.file.type = File

--- a/catalogs/catalog-lakehouse-iceberg/src/test/resources/log4j2.properties
+++ b/catalogs/catalog-lakehouse-iceberg/src/test/resources/log4j2.properties
@@ -30,7 +30,7 @@ appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} %-5p [%t] %c{1}:%L - %m%n
 
 # Log files location
-property.logPath = ${sys:gravitino.log.path:-catalog-lakehouse-iceberg/build/iceberg-integration-test.log}
+property.logPath = ${sys:gravitino.log.path:-build/catalog-lakehouse-iceberg-integration-test.log}
 
 # File appender configuration
 appender.file.type = File

--- a/catalogs/catalog-lakehouse-paimon/src/test/resources/log4j2.properties
+++ b/catalogs/catalog-lakehouse-paimon/src/test/resources/log4j2.properties
@@ -30,7 +30,7 @@ appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
 
 # Log files location
-property.logPath = ${sys:gravitino.log.path:-catalog-lakehouse-paimon/build/paimon-integration-test.log}
+property.logPath = ${sys:gravitino.log.path:-build/catalog-lakehouse-paimon-integration-test.log}
 
 # File appender configuration
 appender.file.type = File

--- a/integration-test/src/test/resources/log4j2.properties
+++ b/integration-test/src/test/resources/log4j2.properties
@@ -30,7 +30,7 @@ appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} %-5p [%t] %c{1}:%L - %m%n
 
 # Log files location
-property.logPath = ${sys:gravitino.log.path:-integration-test/build/integration-test.log}
+property.logPath = ${sys:gravitino.log.path:-build/integration-test.log}
 
 # File appender configuration
 appender.file.type = File

--- a/server/src/test/java/com/datastrato/gravitino/server/TestGravitinoServer.java
+++ b/server/src/test/java/com/datastrato/gravitino/server/TestGravitinoServer.java
@@ -19,6 +19,7 @@
 package com.datastrato.gravitino.server;
 
 import static com.datastrato.gravitino.Configs.ENTITY_KV_ROCKSDB_BACKEND_PATH;
+import static com.datastrato.gravitino.Configs.ENTITY_RELATIONAL_JDBC_BACKEND_PATH;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.datastrato.gravitino.auxiliary.AuxiliaryServiceManager;
@@ -26,8 +27,11 @@ import com.datastrato.gravitino.rest.RESTUtils;
 import com.datastrato.gravitino.server.web.JettyServerConfig;
 import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.UUID;
 import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
@@ -73,6 +77,19 @@ public class TestGravitinoServer {
       // Ignore
     }
     gravitinoServer = new GravitinoServer(spyServerConfig);
+  }
+
+  @AfterAll
+  public void clear() {
+    String path = spyServerConfig.get(ENTITY_RELATIONAL_JDBC_BACKEND_PATH);
+    if (path != null) {
+      Path p = Paths.get(path).getParent();
+      try {
+        FileUtils.deleteDirectory(p.toFile());
+      } catch (IOException e) {
+        // Ignore
+      }
+    }
   }
 
   @AfterEach


### PR DESCRIPTION
### What changes were proposed in this pull request?

- Fix the path of the integration test is not as expected. 
- Remove directory data that lies in root project.

### Why are the changes needed?

The path is not right. 

Fixed: #4065 
### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

Test locally. 

**Before**

<img width="790" alt="image" src="https://github.com/datastrato/gravitino/assets/15794564/7d4392b6-cc19-4b75-8b81-10b5d5fe9958">

**After** 

![image](https://github.com/datastrato/gravitino/assets/15794564/f736a4e1-fcc0-4240-b2bb-a02135f29724)