### PR TITLE
[#4032] Fix(CI): Remove some CI actions to make CI back to normal

### DIFF
--- a/.github/workflows/backend-integration-test.yml
+++ b/.github/workflows/backend-integration-test.yml
@@ -85,10 +85,6 @@ jobs:
         run: |
           ./gradlew compileDistribution -x test -PjdkVersion=${{ matrix.java-version }}
 
-      - name: Setup debug Github Action
-        if: ${{ contains(github.event.pull_request.labels.*.name, 'debug action') }}
-        uses: csexton/debugger-action@master
-
       - name: Free up disk space
         run: |
           dev/ci/util_free_space.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,21 +107,3 @@ jobs:
             build/reports
             catalogs/**/*.log
             catalogs/**/*.tar
-
-      - name: Jacoco Report to PR
-        id: jacoco
-        uses: madrapps/jacoco-report@v1.6.1
-        with:
-          paths: ${{ github.workspace }}/**/build/reports/jacoco/test/jacocoTestReport.xml
-          token: ${{ secrets.GITHUB_TOKEN }}
-          min-coverage-overall: 40
-          min-coverage-changed-files: 60
-          title: 'Code Coverage Report'
-          debug-mode: false
-          update-comment: true
-          pass-emoji: ':green_circle:'
-          fail-emoji: ':red_circle:'
-      - name: Get the Coverage info
-        run: |
-          echo "Total coverage ${{ steps.jacoco.outputs.coverage-overall }}"
-          echo "Changed Files coverage ${{ steps.jacoco.outputs.coverage-changed-files }}"

--- a/.github/workflows/cron-integration-test.yml
+++ b/.github/workflows/cron-integration-test.yml
@@ -76,10 +76,6 @@ jobs:
         run: |
           ./gradlew compileDistribution -x test -PjdkVersion=${{ matrix.java-version }}
 
-      - name: Setup debug Github Action
-        if: ${{ contains(github.event.pull_request.labels.*.name, 'debug action') }}
-        uses: csexton/debugger-action@master
-
       - name: Free up disk space
         run: |
           dev/ci/util_free_space.sh

--- a/.github/workflows/flink-integration-test.yml
+++ b/.github/workflows/flink-integration-test.yml
@@ -79,10 +79,6 @@ jobs:
         run: |
           ./gradlew compileDistribution -x test -PjdkVersion=${{ matrix.java-version }}
 
-      - name: Setup debug Github Action
-        if: ${{ contains(github.event.pull_request.labels.*.name, 'debug action') }}
-        uses: csexton/debugger-action@master
-
       - name: Free up disk space
         run: |
           dev/ci/util_free_space.sh

--- a/.github/workflows/frontend-integration-test.yml
+++ b/.github/workflows/frontend-integration-test.yml
@@ -82,10 +82,6 @@ jobs:
         run: |
           ./gradlew compileDistribution -x test -PjdkVersion=${{ matrix.java-version }}
 
-      - name: Setup debug Github Action
-        if: ${{ contains(github.event.pull_request.labels.*.name, 'debug action') }}
-        uses: csexton/debugger-action@master
-
       - name: Free up disk space
         run: |
           dev/ci/util_free_space.sh

--- a/.github/workflows/spark-integration-test.yml
+++ b/.github/workflows/spark-integration-test.yml
@@ -82,10 +82,6 @@ jobs:
         run: |
           ./gradlew compileDistribution -x test -PjdkVersion=${{ matrix.java-version }}
 
-      - name: Setup debug Github Action
-        if: ${{ contains(github.event.pull_request.labels.*.name, 'debug action') }}
-        uses: csexton/debugger-action@master
-
       - name: Free up disk space
         run: |
           dev/ci/util_free_space.sh

--- a/docs/how-to-test.md
+++ b/docs/how-to-test.md
@@ -154,7 +154,6 @@ This mode is closer to the actual environment, but more complex to debug. To deb
 * View the test results in the `Actions` tab of the pull request page.
 * Run the integration tests in several steps:
   * The Gravitino integration tests pull the CI Docker image from the Docker Hub repository. This step typically takes around 15 seconds.
-  * If you set the `debug action` label in the pull request, GitHub actions runs an SSH server with `csexton/debugger-action@master`, allowing you to log into the GitHub actions environment for remote debugging.
   * The Gravitino project compiles and packages in the `distribution` directory using the `./gradlew compileDistribution` command.
   * Run the `./gradlew test -PtestMode=[embedded|deploy]` command.
 

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/MetalakePageTest.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/MetalakePageTest.java
@@ -23,8 +23,7 @@ public class MetalakePageTest extends AbstractWebIT {
   private static final String FOOTER_LINK_DOCS = "https://datastrato.ai/docs/";
   private static final String FOOTER_LINK_LICENSE =
       "https://github.com/apache/gravitino/blob/main/LICENSE";
-  private static final String FOOTER_LINK_SUPPORT =
-      "https://github.com/apache/gravitino/issues";
+  private static final String FOOTER_LINK_SUPPORT = "https://github.com/apache/gravitino/issues";
   MetalakePage metalakePage = new MetalakePage();
 
   // Create a metalake by name, set the default comment and properties.

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/MetalakePageTest.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/MetalakePageTest.java
@@ -22,9 +22,9 @@ public class MetalakePageTest extends AbstractWebIT {
   private static final String FOOTER_LINK_DATASTRATO = "https://datastrato.ai/";
   private static final String FOOTER_LINK_DOCS = "https://datastrato.ai/docs/";
   private static final String FOOTER_LINK_LICENSE =
-      "https://github.com/datastrato/gravitino/blob/main/LICENSE";
+      "https://github.com/apache/gravitino/blob/main/LICENSE";
   private static final String FOOTER_LINK_SUPPORT =
-      "https://github.com/datastrato/gravitino/issues";
+      "https://github.com/apache/gravitino/issues";
   MetalakePage metalakePage = new MetalakePage();
 
   // Create a metalake by name, set the default comment and properties.


### PR DESCRIPTION
### What changes were proposed in this pull request?

Remove `csexton/debugger-action@master` action in the github CI, if someone wants this functionality, they can add it in his fork repo and do the debug work the personal account. 

### Why are the changes needed?

This action is not allowed in the Apache project.


Fixed: #4032 


### Does this PR introduce _any_ user-facing change?

N/A.

### How was this patch tested?

Test in the CI