### PR TITLE
[MINOR] [#4037] Upgrade twine version to fix python client deploy task

### DIFF
--- a/clients/client-python/requirements-dev.txt
+++ b/clients/client-python/requirements-dev.txt
@@ -4,7 +4,7 @@ requests==2.32.2
 dataclasses-json==0.6.6
 pylint==3.2.2
 black==24.4.2
-twine==5.1.0
+twine==5.1.1
 coverage==7.5.1
 pandas==2.0.3
 pyarrow==15.0.2


### PR DESCRIPTION
### What changes were proposed in this pull request?

Currently twine 5.0.0 will cause Python client deploy task failed, upgrade twine version to fix this problem.

### Why are the changes needed?

Fix: #4037 
