### PR TITLE
[#3732] refactor(client-python): Update Python client to align with the Java client API

### DIFF
--- a/clients/client-python/gravitino/api/supports_schemas.py
+++ b/clients/client-python/gravitino/api/supports_schemas.py
@@ -8,8 +8,6 @@ from typing import List, Dict
 
 from gravitino.api.schema import Schema
 from gravitino.api.schema_change import SchemaChange
-from gravitino.name_identifier import NameIdentifier
-from gravitino.namespace import Namespace
 
 
 class NoSuchSchemaException(Exception):
@@ -25,50 +23,47 @@ class SupportsSchemas(ABC):
     """
 
     @abstractmethod
-    def list_schemas(self, namespace: Namespace) -> List[NameIdentifier]:
-        """List schemas under a namespace.
+    def list_schemas(self) -> List[str]:
+        """List schemas under the entity.
 
         If an entity such as a table, view exists, its parent schemas must also exist and must be
         returned by this discovery method. For example, if table a.b.t exists, this method invoked as
-        list_schemas(a) must return [a.b] in the result array.
-
-        Args:
-            namespace: The namespace to list.
+        listSchemas(a) must return [b] in the result array
 
         Raises:
             NoSuchCatalogException: If the catalog does not exist.
 
         Returns:
-            A list of schema identifiers under the namespace.
+            A list of schema names under the namespace.
         """
         pass
 
-    def schema_exists(self, ident: NameIdentifier) -> bool:
+    def schema_exists(self, schema_name: str) -> bool:
         """Check if a schema exists.
 
         If an entity such as a table, view exists, its parent namespaces must also exist. For
         example, if table a.b.t exists, this method invoked as schema_exists(a.b) must return true.
 
         Args:
-            ident: The name identifier of the schema.
+            schema_name: The name of the schema.
 
         Returns:
             True if the schema exists, false otherwise.
         """
         try:
-            self.load_schema(ident)
+            self.load_schema(schema_name)
             return True
         except NoSuchSchemaException:
             return False
 
     @abstractmethod
     def create_schema(
-        self, ident: NameIdentifier, comment: str, properties: Dict[str, str]
+        self, schema_name: str, comment: str, properties: Dict[str, str]
     ) -> Schema:
         """Create a schema in the catalog.
 
         Args:
-            ident: The name identifier of the schema.
+            schema_name: The name of the schema.
             comment: The comment of the schema.
             properties: The properties of the schema.
 
@@ -82,11 +77,11 @@ class SupportsSchemas(ABC):
         pass
 
     @abstractmethod
-    def load_schema(self, ident: NameIdentifier) -> Schema:
+    def load_schema(self, schema_name: str) -> Schema:
         """Load metadata properties for a schema.
 
         Args:
-            ident: The name identifier of the schema.
+            schema_name: The name of the schema.
 
         Raises:
             NoSuchSchemaException: If the schema does not exist (optional).
@@ -97,11 +92,11 @@ class SupportsSchemas(ABC):
         pass
 
     @abstractmethod
-    def alter_schema(self, ident: NameIdentifier, *changes: SchemaChange) -> Schema:
+    def alter_schema(self, schema_name: str, *changes: SchemaChange) -> Schema:
         """Apply the metadata change to a schema in the catalog.
 
         Args:
-            ident: The name identifier of the schema.
+            schema_name: The name of the schema.
             changes: The metadata changes to apply.
 
         Raises:
@@ -113,12 +108,12 @@ class SupportsSchemas(ABC):
         pass
 
     @abstractmethod
-    def drop_schema(self, ident: NameIdentifier, cascade: bool) -> bool:
+    def drop_schema(self, schema_name: str, cascade: bool) -> bool:
         """Drop a schema from the catalog. If cascade option is true, recursively
         drop all objects within the schema.
 
         Args:
-            ident: The name identifier of the schema.
+            schema_name: The name of the schema.
             cascade: If true, recursively drop all objects within the schema.
 
         Returns:

--- a/clients/client-python/gravitino/catalog/base_schema_catalog.py
+++ b/clients/client-python/gravitino/catalog/base_schema_catalog.py
@@ -4,7 +4,7 @@ This software is licensed under the Apache License version 2.
 """
 
 import logging
-from typing import Dict
+from typing import Dict, List
 
 from gravitino.api.catalog import Catalog
 from gravitino.api.schema import Schema
@@ -18,9 +18,9 @@ from gravitino.dto.requests.schema_updates_request import SchemaUpdatesRequest
 from gravitino.dto.responses.drop_response import DropResponse
 from gravitino.dto.responses.entity_list_response import EntityListResponse
 from gravitino.dto.responses.schema_response import SchemaResponse
-from gravitino.name_identifier import NameIdentifier
 from gravitino.namespace import Namespace
 from gravitino.utils import HTTPClient
+from gravitino.rest.rest_utils import encode_string
 
 logger = logging.getLogger(__name__)
 
@@ -32,11 +32,15 @@ class BaseSchemaCatalog(CatalogDTO, SupportsSchemas):
     create, load, alter and drop a schema with specified identifier.
     """
 
+    # The REST client to send the requests.
     rest_client: HTTPClient
-    """The REST client to send the requests."""
+
+    # The namespace of current catalog, which is the metalake name.
+    _catalog_namespace: Namespace
 
     def __init__(
         self,
+        catalog_namespace: Namespace,
         name: str = None,
         catalog_type: Catalog.Type = Catalog.Type.UNSUPPORTED,
         provider: str = None,
@@ -54,42 +58,42 @@ class BaseSchemaCatalog(CatalogDTO, SupportsSchemas):
             _audit=audit,
         )
         self.rest_client = rest_client
+        self._catalog_namespace = catalog_namespace
+
+        self.validate()
 
     def as_schemas(self):
         return self
 
-    def list_schemas(self, namespace: Namespace) -> [NameIdentifier]:
+    def list_schemas(self) -> List[str]:
         """List all the schemas under the given catalog namespace.
-
-        Args:
-             namespace: The namespace of the catalog.
 
         Raises:
             NoSuchCatalogException if the catalog with specified namespace does not exist.
 
         Returns:
-             A list of {@link NameIdentifier} of the schemas under the given catalog namespace.
+             A list of schema names under the given catalog namespace.
         """
-        Namespace.check_schema(namespace)
         resp = self.rest_client.get(
-            BaseSchemaCatalog.format_schema_request_path(namespace)
+            BaseSchemaCatalog.format_schema_request_path(self._catalog_namespace())
         )
         entity_list_response = EntityListResponse.from_json(
             resp.body, infer_missing=True
         )
         entity_list_response.validate()
-        return entity_list_response.identifiers()
+
+        return [ident.name() for ident in entity_list_response.identifiers()]
 
     def create_schema(
         self,
-        ident: NameIdentifier = None,
+        schema_name: str = None,
         comment: str = None,
         properties: Dict[str, str] = None,
     ) -> Schema:
         """Create a new schema with specified identifier, comment and metadata.
 
         Args:
-            ident: The name identifier of the schema.
+            schema_name: The name of the schema.
             comment: The comment of the schema.
             properties: The properties of the schema.
 
@@ -100,23 +104,23 @@ class BaseSchemaCatalog(CatalogDTO, SupportsSchemas):
         Returns:
              The created Schema.
         """
-        NameIdentifier.check_schema(ident)
-        req = SchemaCreateRequest(ident.name(), comment, properties)
+        req = SchemaCreateRequest(encode_string(schema_name), comment, properties)
         req.validate()
 
         resp = self.rest_client.post(
-            BaseSchemaCatalog.format_schema_request_path(ident.namespace()), json=req
+            BaseSchemaCatalog.format_schema_request_path(self._schema_namespace()),
+            json=req,
         )
         schema_response = SchemaResponse.from_json(resp.body, infer_missing=True)
         schema_response.validate()
 
         return schema_response.schema()
 
-    def load_schema(self, ident: NameIdentifier) -> Schema:
+    def load_schema(self, schema_name: str) -> Schema:
         """Load the schema with specified identifier.
 
         Args:
-            ident: The name identifier of the schema.
+            schema_name: The name of the schema.
 
         Raises:
             NoSuchSchemaException if the schema with specified identifier does not exist.
@@ -124,22 +128,21 @@ class BaseSchemaCatalog(CatalogDTO, SupportsSchemas):
         Returns:
             The Schema with specified identifier.
         """
-        NameIdentifier.check_schema(ident)
         resp = self.rest_client.get(
-            BaseSchemaCatalog.format_schema_request_path(ident.namespace())
+            BaseSchemaCatalog.format_schema_request_path(self._schema_namespace())
             + "/"
-            + ident.name()
+            + encode_string(schema_name)
         )
         schema_response = SchemaResponse.from_json(resp.body, infer_missing=True)
         schema_response.validate()
 
         return schema_response.schema()
 
-    def alter_schema(self, ident: NameIdentifier, *changes: SchemaChange) -> Schema:
+    def alter_schema(self, schema_name: str, *changes: SchemaChange) -> Schema:
         """Alter the schema with specified identifier by applying the changes.
 
         Args:
-             ident: The name identifier of the schema.
+            schema_name: The name of the schema.
             changes: The metadata changes to apply.
 
         Raises:
@@ -148,27 +151,26 @@ class BaseSchemaCatalog(CatalogDTO, SupportsSchemas):
         Returns:
             The altered Schema.
         """
-        NameIdentifier.check_schema(ident)
         reqs = [
             BaseSchemaCatalog.to_schema_update_request(change) for change in changes
         ]
         updates_request = SchemaUpdatesRequest(reqs)
         updates_request.validate()
         resp = self.rest_client.put(
-            BaseSchemaCatalog.format_schema_request_path(ident.namespace())
+            BaseSchemaCatalog.format_schema_request_path(self._schema_namespace())
             + "/"
-            + ident.name(),
+            + encode_string(schema_name),
             updates_request,
         )
         schema_response = SchemaResponse.from_json(resp.body, infer_missing=True)
         schema_response.validate()
         return schema_response.schema()
 
-    def drop_schema(self, ident: NameIdentifier, cascade: bool) -> bool:
+    def drop_schema(self, schema_name: str, cascade: bool) -> bool:
         """Drop the schema with specified identifier.
 
         Args:
-            ident: The name identifier of the schema.
+            schema_name: The name of the schema.
             cascade: Whether to drop all the tables under the schema.
 
         Raises:
@@ -177,21 +179,23 @@ class BaseSchemaCatalog(CatalogDTO, SupportsSchemas):
         Returns:
              true if the schema is dropped successfully, false otherwise.
         """
-        NameIdentifier.check_schema(ident)
         try:
             params = {"cascade": str(cascade)}
             resp = self.rest_client.delete(
-                BaseSchemaCatalog.format_schema_request_path(ident.namespace())
+                BaseSchemaCatalog.format_schema_request_path(self._schema_namespace())
                 + "/"
-                + ident.name(),
+                + encode_string(schema_name),
                 params=params,
             )
             drop_resp = DropResponse.from_json(resp.body, infer_missing=True)
             drop_resp.validate()
             return drop_resp.dropped()
         except Exception:
-            logger.warning("Failed to drop schema %s", ident)
+            logger.warning("Failed to drop schema %s", schema_name)
             return False
+
+    def _schema_namespace(self) -> Namespace:
+        return Namespace.of(self._catalog_namespace.level(0), self.name())
 
     @staticmethod
     def format_schema_request_path(ns: Namespace):
@@ -206,3 +210,20 @@ class BaseSchemaCatalog(CatalogDTO, SupportsSchemas):
         if isinstance(change, SchemaChange.RemoveProperty):
             return SchemaUpdateRequest.RemoveSchemaPropertyRequest(change.property())
         raise ValueError(f"Unknown change type: {type(change).__name__}")
+
+    def validate(self):
+        Namespace.check(
+            self._catalog_namespace is not None
+            and self._catalog_namespace.length() == 1,
+            f"Catalog namespace must be non-null and have 1 level, the input namespace is {self._catalog_namespace}",
+        )
+
+        assert self.rest_client is not None, "restClient must be set"
+        assert (
+            self.name() is not None and len(self.name().strip()) > 0
+        ), "name must not be blank"
+        assert self.type() is not None, "type must not be None"
+        assert (
+            self.provider() is not None and len(self.provider().strip()) > 0
+        ), "provider must not be blank"
+        assert self.audit_info() is not None, "audit must not be None"

--- a/clients/client-python/gravitino/catalog/base_schema_catalog.py
+++ b/clients/client-python/gravitino/catalog/base_schema_catalog.py
@@ -75,7 +75,7 @@ class BaseSchemaCatalog(CatalogDTO, SupportsSchemas):
              A list of schema names under the given catalog namespace.
         """
         resp = self.rest_client.get(
-            BaseSchemaCatalog.format_schema_request_path(self._catalog_namespace())
+            BaseSchemaCatalog.format_schema_request_path(self._schema_namespace())
         )
         entity_list_response = EntityListResponse.from_json(
             resp.body, infer_missing=True

--- a/clients/client-python/gravitino/client/gravitino_metalake.py
+++ b/clients/client-python/gravitino/client/gravitino_metalake.py
@@ -104,7 +104,9 @@ class GravitinoMetalake(MetalakeDTO):
         response = self.rest_client.get(url)
         catalog_resp = CatalogResponse.from_json(response.body, infer_missing=True)
 
-        return DTOConverters.to_catalog(self.name(), catalog_resp.catalog(), self.rest_client)
+        return DTOConverters.to_catalog(
+            self.name(), catalog_resp.catalog(), self.rest_client
+        )
 
     def create_catalog(
         self,
@@ -144,7 +146,9 @@ class GravitinoMetalake(MetalakeDTO):
         response = self.rest_client.post(url, json=catalog_create_request)
         catalog_resp = CatalogResponse.from_json(response.body, infer_missing=True)
 
-        return DTOConverters.to_catalog(self.name(), catalog_resp.catalog(), self.rest_client)
+        return DTOConverters.to_catalog(
+            self.name(), catalog_resp.catalog(), self.rest_client
+        )
 
     def alter_catalog(self, name: str, *changes: CatalogChange) -> Catalog:
         """Alter the catalog with specified name by applying the changes.
@@ -170,7 +174,9 @@ class GravitinoMetalake(MetalakeDTO):
         catalog_response = CatalogResponse.from_json(response.body, infer_missing=True)
         catalog_response.validate()
 
-        return DTOConverters.to_catalog(self.name(), catalog_response.catalog(), self.rest_client)
+        return DTOConverters.to_catalog(
+            self.name(), catalog_response.catalog(), self.rest_client
+        )
 
     def drop_catalog(self, name: str) -> bool:
         """Drop the catalog with specified name.

--- a/clients/client-python/gravitino/client/gravitino_metalake.py
+++ b/clients/client-python/gravitino/client/gravitino_metalake.py
@@ -84,7 +84,7 @@ class GravitinoMetalake(MetalakeDTO):
         catalog_list = CatalogListResponse.from_json(response.body, infer_missing=True)
 
         return [
-            DTOConverters.to_catalog(catalog, self.rest_client)
+            DTOConverters.to_catalog(self.name(), catalog, self.rest_client)
             for catalog in catalog_list.catalogs()
         ]
 
@@ -104,7 +104,7 @@ class GravitinoMetalake(MetalakeDTO):
         response = self.rest_client.get(url)
         catalog_resp = CatalogResponse.from_json(response.body, infer_missing=True)
 
-        return DTOConverters.to_catalog(catalog_resp.catalog(), self.rest_client)
+        return DTOConverters.to_catalog(self.name(), catalog_resp.catalog(), self.rest_client)
 
     def create_catalog(
         self,
@@ -144,7 +144,7 @@ class GravitinoMetalake(MetalakeDTO):
         response = self.rest_client.post(url, json=catalog_create_request)
         catalog_resp = CatalogResponse.from_json(response.body, infer_missing=True)
 
-        return DTOConverters.to_catalog(catalog_resp.catalog(), self.rest_client)
+        return DTOConverters.to_catalog(self.name(), catalog_resp.catalog(), self.rest_client)
 
     def alter_catalog(self, name: str, *changes: CatalogChange) -> Catalog:
         """Alter the catalog with specified name by applying the changes.
@@ -170,7 +170,7 @@ class GravitinoMetalake(MetalakeDTO):
         catalog_response = CatalogResponse.from_json(response.body, infer_missing=True)
         catalog_response.validate()
 
-        return DTOConverters.to_catalog(catalog_response.catalog(), self.rest_client)
+        return DTOConverters.to_catalog(self.name(), catalog_response.catalog(), self.rest_client)
 
     def drop_catalog(self, name: str) -> bool:
         """Drop the catalog with specified name.

--- a/clients/client-python/gravitino/dto/dto_converters.py
+++ b/clients/client-python/gravitino/dto/dto_converters.py
@@ -11,6 +11,7 @@ from gravitino.dto.requests.catalog_update_request import CatalogUpdateRequest
 from gravitino.dto.requests.metalake_update_request import MetalakeUpdateRequest
 from gravitino.api.metalake_change import MetalakeChange
 from gravitino.utils import HTTPClient
+from gravitino.namespace import Namespace
 
 
 class DTOConverters:
@@ -37,9 +38,11 @@ class DTOConverters:
         raise ValueError(f"Unknown change type: {type(change).__name__}")
 
     @staticmethod
-    def to_catalog(catalog: CatalogDTO, client: HTTPClient):
+    def to_catalog(metalake: str, catalog: CatalogDTO, client: HTTPClient):
+        namespace = Namespace.of(metalake)
         if catalog.type() == Catalog.Type.FILESET:
             return FilesetCatalog(
+                namespace=namespace,
                 name=catalog.name(),
                 catalog_type=catalog.type(),
                 provider=catalog.provider(),

--- a/clients/client-python/gravitino/filesystem/gvfs.py
+++ b/clients/client-python/gravitino/filesystem/gvfs.py
@@ -556,7 +556,7 @@ class GravitinoVirtualFileSystem(fsspec.AbstractFileSystem):
 
         match = self._identifier_pattern.match(path)
         if match and len(match.groups()) == 3:
-            return NameIdentifier.of_fileset(
+            return NameIdentifier.of(
                 self._metalake, match.group(1), match.group(2), match.group(3)
             )
         raise GravitinoRuntimeException(
@@ -570,11 +570,14 @@ class GravitinoVirtualFileSystem(fsspec.AbstractFileSystem):
         :return The fileset
         """
         catalog: Catalog = self._client.load_catalog(
-            NameIdentifier.of_catalog(
+            NameIdentifier.of(
                 identifier.namespace().level(0), identifier.namespace().level(1)
             )
         )
-        return catalog.as_fileset_catalog().load_fileset(identifier)
+
+        return catalog.as_fileset_catalog().load_fileset(
+            NameIdentifier.of(identifier.namespace().level(2), identifier.name())
+        )
 
     def _get_actual_path_by_ident(
         self,

--- a/clients/client-python/gravitino/filesystem/gvfs.py
+++ b/clients/client-python/gravitino/filesystem/gvfs.py
@@ -569,11 +569,7 @@ class GravitinoVirtualFileSystem(fsspec.AbstractFileSystem):
         :param identifier: The fileset identifier
         :return The fileset
         """
-        catalog: Catalog = self._client.load_catalog(
-            NameIdentifier.of(
-                identifier.namespace().level(0), identifier.namespace().level(1)
-            )
-        )
+        catalog: Catalog = self._client.load_catalog(identifier.namespace().level(1))
 
         return catalog.as_fileset_catalog().load_fileset(
             NameIdentifier.of(identifier.namespace().level(2), identifier.name())

--- a/clients/client-python/gravitino/name_identifier.py
+++ b/clients/client-python/gravitino/name_identifier.py
@@ -28,7 +28,13 @@ class NameIdentifier(DataClassJsonMixin):
     _DOT: ClassVar[str] = "."
 
     _name: str = field(metadata=config(field_name="name"))
-    _namespace: Namespace = field(metadata=config(field_name="namespace"))
+    _namespace: Namespace = field(
+        metadata=config(
+            field_name="namespace",
+            encoder=Namespace.to_json,
+            decoder=Namespace.from_json,
+        )
+    )
 
     @classmethod
     def builder(cls, namespace: Namespace, name: str):
@@ -59,176 +65,6 @@ class NameIdentifier(DataClassJsonMixin):
         )
 
         return NameIdentifier.builder(Namespace.of(*names[:-1]), names[-1])
-
-    @staticmethod
-    def of_namespace(namespace: Namespace, name: str) -> "NameIdentifier":
-        """Create the NameIdentifier with the given Namespace and name.
-
-        Args:
-            namespace: The namespace of the identifier
-            name: The name of the identifier
-
-        Returns:
-            The created NameIdentifier
-        """
-        return NameIdentifier.builder(namespace, name)
-
-    @staticmethod
-    def of_metalake(metalake: str) -> "NameIdentifier":
-        """Create the metalake NameIdentifier with the given name.
-
-        Args:
-            metalake: The metalake name
-
-        Returns:
-            The created metalake NameIdentifier
-        """
-        return NameIdentifier.of(metalake)
-
-    @staticmethod
-    def of_catalog(metalake: str, catalog: str) -> "NameIdentifier":
-        """Create the catalog NameIdentifier with the given metalake and catalog name.
-
-        Args:
-            metalake: The metalake name
-            catalog: The catalog name
-
-        Returns:
-            The created catalog NameIdentifier
-        """
-        return NameIdentifier.of(metalake, catalog)
-
-    @staticmethod
-    def of_schema(metalake: str, catalog: str, schema: str) -> "NameIdentifier":
-        """Create the schema NameIdentifier with the given metalake, catalog and schema name.
-
-        Args:
-            metalake: The metalake name
-            catalog: The catalog name
-            schema: The schema name
-
-        Returns:
-            The created schema NameIdentifier
-        """
-        return NameIdentifier.of(metalake, catalog, schema)
-
-    @staticmethod
-    def of_table(
-        metalake: str, catalog: str, schema: str, table: str
-    ) -> "NameIdentifier":
-        """Create the table NameIdentifier with the given metalake, catalog, schema and table name.
-
-        Args:
-            metalake: The metalake name
-            catalog: The catalog name
-            schema: The schema name
-            table: The table name
-
-        Returns:
-            The created table NameIdentifier
-        """
-        return NameIdentifier.of(metalake, catalog, schema, table)
-
-    @staticmethod
-    def of_fileset(
-        metalake: str, catalog: str, schema: str, fileset: str
-    ) -> "NameIdentifier":
-        """Create the fileset NameIdentifier with the given metalake, catalog, schema and fileset name.
-
-        Args:
-            metalake: The metalake name
-            catalog: The catalog name
-            schema: The schema name
-            fileset: The fileset name
-
-        Returns:
-            The created fileset NameIdentifier
-        """
-        return NameIdentifier.of(metalake, catalog, schema, fileset)
-
-    @staticmethod
-    def of_topic(
-        metalake: str, catalog: str, schema: str, topic: str
-    ) -> "NameIdentifier":
-        """Create the topic NameIdentifier with the given metalake, catalog, schema and topic
-        name.
-
-        Args:
-            metalake: The metalake name
-            catalog: The catalog name
-            schema: The schema name
-            topic: The topic name
-
-        Returns:
-            The created topic NameIdentifier
-        """
-        return NameIdentifier.of(metalake, catalog, schema, topic)
-
-    @staticmethod
-    def check_metalake(ident: "NameIdentifier") -> None:
-        """Check the given NameIdentifier is a metalake identifier. Throw an {@link
-        IllegalNameIdentifierException} if it's not.
-
-        Args:
-            ident: The metalake NameIdentifier to check.
-        """
-        NameIdentifier.check(ident is not None, "Metalake identifier must not be null")
-        Namespace.check_metalake(ident.namespace())
-
-    @staticmethod
-    def check_catalog(ident: "NameIdentifier") -> None:
-        """Check the given NameIdentifier is a catalog identifier. Throw an {@link
-        IllegalNameIdentifierException} if it's not.
-
-        Args:
-            ident: The catalog NameIdentifier to check.
-        """
-        NameIdentifier.check(ident is not None, "Catalog identifier must not be null")
-        Namespace.check_catalog(ident.namespace())
-
-    @staticmethod
-    def check_schema(ident: "NameIdentifier") -> None:
-        """Check the given NameIdentifier is a schema identifier. Throw an {@link
-        IllegalNameIdentifierException} if it's not.
-
-        Args:
-            ident: The schema NameIdentifier to check.
-        """
-        NameIdentifier.check(ident is not None, "Schema identifier must not be null")
-        Namespace.check_schema(ident.namespace())
-
-    @staticmethod
-    def check_table(ident: "NameIdentifier") -> None:
-        """Check the given NameIdentifier is a table identifier. Throw an {@link
-        IllegalNameIdentifierException} if it's not.
-
-        Args:
-            ident: The table NameIdentifier to check.
-        """
-        NameIdentifier.check(ident is not None, "Table identifier must not be null")
-        Namespace.check_table(ident.namespace())
-
-    @staticmethod
-    def check_fileset(ident: "NameIdentifier") -> None:
-        """Check the given NameIdentifier is a fileset identifier. Throw an {@link
-        IllegalNameIdentifierException} if it's not.
-
-        Args:
-            ident: The fileset NameIdentifier to check.
-        """
-        NameIdentifier.check(ident is not None, "Fileset identifier must not be null")
-        Namespace.check_fileset(ident.namespace())
-
-    @staticmethod
-    def check_topic(ident: "NameIdentifier") -> None:
-        """Check the given NameIdentifier is a topic identifier. Throw an {@link
-        IllegalNameIdentifierException} if it's not.
-
-        Args:
-            ident: The topic NameIdentifier to check.
-        """
-        NameIdentifier.check(ident is not None, "Topic identifier must not be null")
-        Namespace.check_topic(ident.namespace())
 
     @staticmethod
     def parse(identifier: str) -> "NameIdentifier":

--- a/clients/client-python/gravitino/name_identifier.py
+++ b/clients/client-python/gravitino/name_identifier.py
@@ -14,6 +14,8 @@ from gravitino.exceptions.illegal_name_identifier_exception import (
 )
 from gravitino.namespace import Namespace
 
+# TODO: delete redundant methods
+
 
 @dataclass
 class NameIdentifier(DataClassJsonMixin):

--- a/clients/client-python/gravitino/namespace.py
+++ b/clients/client-python/gravitino/namespace.py
@@ -5,6 +5,8 @@ This software is licensed under the Apache License version 2.
 
 from typing import List, ClassVar
 
+# TODO: delete redundant methods
+
 
 class Namespace:
     """A namespace is a sequence of levels separated by dots. It's used to identify a metalake, a

--- a/clients/client-python/gravitino/namespace.py
+++ b/clients/client-python/gravitino/namespace.py
@@ -3,6 +3,7 @@ Copyright 2024 Datastrato Pvt Ltd.
 This software is licensed under the Apache License version 2.
 """
 
+import json
 from typing import List, ClassVar
 
 # TODO: delete redundant methods
@@ -16,10 +17,20 @@ class Namespace:
 
     _DOT: ClassVar[str] = "."
 
-    _levels: List[str] = []
+    _levels: List[str]
 
     def __init__(self, levels: List[str]):
         self._levels = levels
+
+    def to_json(self):
+        return json.dumps(self._levels)
+
+    @classmethod
+    def from_json(cls, levels):
+        assert levels is not None and isinstance(
+            levels, list
+        ), f"Cannot parse name identifier from invalid JSON: {levels}"
+        return cls(levels)
 
     @staticmethod
     def empty() -> "Namespace":
@@ -53,160 +64,6 @@ class Namespace:
             )
 
         return Namespace(list(levels))
-
-    @staticmethod
-    def of_metalake() -> "Namespace":
-        """Create a namespace for metalake.
-
-        Returns:
-            A namespace for metalake
-        """
-        return Namespace.empty()
-
-    @staticmethod
-    def of_catalog(metalake: str) -> "Namespace":
-        """Create a namespace for catalog.
-
-        Args:
-            metalake: The metalake name
-
-        Returns:
-            A namespace for catalog
-        """
-        return Namespace.of(metalake)
-
-    @staticmethod
-    def of_schema(metalake: str, catalog: str) -> "Namespace":
-        """Create a namespace for schema.
-
-        Args:
-            metalake: The metalake name
-            catalog: The catalog name
-
-        Returns:
-             A namespace for schema
-        """
-        return Namespace.of(metalake, catalog)
-
-    @staticmethod
-    def of_table(metalake: str, catalog: str, schema: str) -> "Namespace":
-        """Create a namespace for table.
-
-        Args:
-            metalake: The metalake name
-            catalog: The catalog name
-            schema: The schema name
-
-        Returns:
-             A namespace for table
-        """
-        return Namespace.of(metalake, catalog, schema)
-
-    @staticmethod
-    def of_fileset(metalake: str, catalog: str, schema: str) -> "Namespace":
-        """Create a namespace for fileset.
-
-        Args:
-            metalake: The metalake name
-            catalog: The catalog name
-            schema: The schema name
-
-        Returns:
-             A namespace for fileset
-        """
-        return Namespace.of(metalake, catalog, schema)
-
-    @staticmethod
-    def of_topic(metalake: str, catalog: str, schema: str) -> "Namespace":
-        """Create a namespace for topic.
-
-        Args:
-            metalake: The metalake name
-            catalog: The catalog name
-            schema: The schema name
-
-        Returns:
-             A namespace for topic
-        """
-        return Namespace.of(metalake, catalog, schema)
-
-    @staticmethod
-    def check_metalake(namespace: "Namespace") -> None:
-        """Check if the given metalake namespace is legal, throw an IllegalNamespaceException if
-        it's illegal.
-
-        Args:
-            namespace: The metalake namespace
-        """
-        Namespace.check(
-            namespace is not None and namespace.is_empty(),
-            f"Metalake namespace must be non-null and empty, the input namespace is {namespace}",
-        )
-
-    @staticmethod
-    def check_catalog(namespace: "Namespace") -> None:
-        """Check if the given catalog namespace is legal, throw an IllegalNamespaceException if
-        it's illegal.
-
-        Args:
-            namespace: The catalog namespace
-        """
-        Namespace.check(
-            namespace is not None and namespace.length() == 1,
-            f"Catalog namespace must be non-null and have 1 level, the input namespace is {namespace}",
-        )
-
-    @staticmethod
-    def check_schema(namespace: "Namespace") -> None:
-        """Check if the given schema namespace is legal, throw an IllegalNamespaceException if
-        it's illegal.
-
-        Args:
-            namespace: The schema namespace
-        """
-        Namespace.check(
-            namespace is not None and namespace.length() == 2,
-            f"Schema namespace must be non-null and have 2 levels, the input namespace is {namespace}",
-        )
-
-    @staticmethod
-    def check_table(namespace: "Namespace") -> None:
-        """Check if the given table namespace is legal, throw an IllegalNamespaceException if it's
-        illegal.
-
-        Args:
-            namespace: The table namespace
-        """
-        Namespace.check(
-            namespace is not None and namespace.length() == 3,
-            f"Table namespace must be non-null and have 3 levels, the input namespace is {namespace}",
-        )
-
-    @staticmethod
-    def check_fileset(namespace: "Namespace") -> None:
-        """Check if the given fileset namespace is legal, throw an IllegalNamespaceException if
-        it's illegal.
-
-        Args:
-            namespace: The fileset namespace
-        """
-        Namespace.check(
-            namespace is not None and namespace.length() == 3,
-            f"Fileset namespace must be non-null and have 3 levels, the input namespace is {namespace}",
-        )
-
-    @staticmethod
-    def check_topic(namespace: "Namespace") -> None:
-        """Check if the given topic namespace is legal, throw an IllegalNamespaceException if it's
-        illegal.
-
-        Args:
-            namespace: The topic namespace
-        """
-        Namespace.check(
-            namespace is not None and namespace.length() == 3,
-            f"Topic namespace must be non-null and have 3 levels, the input namespace is {namespace}",
-        )
 
     def levels(self) -> List[str]:
         """Get the levels of the namespace.

--- a/clients/client-python/gravitino/rest/rest_utils.py
+++ b/clients/client-python/gravitino/rest/rest_utils.py
@@ -1,0 +1,13 @@
+"""
+Copyright 2024 Datastrato Pvt Ltd.
+This software is licensed under the Apache License version 2.
+"""
+
+import urllib.parse
+
+
+def encode_string(to_encode: str):
+
+    assert to_encode is not None, "Invalid string to encode: None"
+
+    return urllib.parse.quote(to_encode)

--- a/clients/client-python/tests/integration/test_catalog.py
+++ b/clients/client-python/tests/integration/test_catalog.py
@@ -25,9 +25,7 @@ class TestCatalog(IntegrationTestEnv):
     catalog_location_prop: str = "location"  # Fileset Catalog must set `location`
     catalog_provider: str = "hadoop"
 
-    catalog_ident: NameIdentifier = NameIdentifier.of_catalog(
-        metalake_name, catalog_name
-    )
+    catalog_ident: NameIdentifier = NameIdentifier.of(metalake_name, catalog_name)
 
     gravitino_admin_client: GravitinoAdminClient = GravitinoAdminClient(
         uri="http://localhost:8090"

--- a/clients/client-python/tests/integration/test_fileset_catalog.py
+++ b/clients/client-python/tests/integration/test_fileset_catalog.py
@@ -43,18 +43,12 @@ class TestFilesetCatalog(IntegrationTestEnv):
     }
     fileset_new_name = fileset_name + "_new"
 
-    catalog_ident: NameIdentifier = NameIdentifier.of_catalog(
-        metalake_name, catalog_name
-    )
-    schema_ident: NameIdentifier = NameIdentifier.of_schema(
+    catalog_ident: NameIdentifier = NameIdentifier.of(metalake_name, catalog_name)
+    schema_ident: NameIdentifier = NameIdentifier.of(
         metalake_name, catalog_name, schema_name
     )
-    fileset_ident: NameIdentifier = NameIdentifier.of_fileset(
-        metalake_name, catalog_name, schema_name, fileset_name
-    )
-    fileset_new_ident: NameIdentifier = NameIdentifier.of_fileset(
-        metalake_name, catalog_name, schema_name, fileset_new_name
-    )
+    fileset_ident: NameIdentifier = NameIdentifier.of(schema_name, fileset_name)
+    fileset_new_ident: NameIdentifier = NameIdentifier.of(schema_name, fileset_new_name)
 
     gravitino_admin_client: GravitinoAdminClient = GravitinoAdminClient(
         uri="http://localhost:8090"
@@ -86,7 +80,9 @@ class TestFilesetCatalog(IntegrationTestEnv):
             logger.info(
                 "Drop schema %s[%s]",
                 self.schema_ident,
-                catalog.as_schemas().drop_schema(ident=self.schema_ident, cascade=True),
+                catalog.as_schemas().drop_schema(
+                    schema_name=self.schema_name, cascade=True
+                ),
             )
             logger.info(
                 "Drop catalog %s[%s]",
@@ -116,7 +112,7 @@ class TestFilesetCatalog(IntegrationTestEnv):
             properties={self.catalog_location_prop: "/tmp/test1"},
         )
         catalog.as_schemas().create_schema(
-            ident=self.schema_ident, comment="", properties={}
+            schema_name=self.schema_name, comment="", properties={}
         )
 
     def create_fileset(self) -> Fileset:

--- a/clients/client-python/tests/integration/test_schema.py
+++ b/clients/client-python/tests/integration/test_schema.py
@@ -41,13 +41,11 @@ class TestSchema(IntegrationTestEnv):
         schema_properties_key2: schema_properties_value2,
     }
 
-    catalog_ident: NameIdentifier = NameIdentifier.of_catalog(
-        metalake_name, catalog_name
-    )
-    schema_ident: NameIdentifier = NameIdentifier.of_schema(
+    catalog_ident: NameIdentifier = NameIdentifier.of(metalake_name, catalog_name)
+    schema_ident: NameIdentifier = NameIdentifier.of(
         metalake_name, catalog_name, schema_name
     )
-    schema_new_ident: NameIdentifier = NameIdentifier.of_schema(
+    schema_new_ident: NameIdentifier = NameIdentifier.of(
         metalake_name, catalog_name, schema_new_name
     )
 
@@ -86,12 +84,12 @@ class TestSchema(IntegrationTestEnv):
             logger.info(
                 "Drop schema %s[%s]",
                 self.schema_ident,
-                catalog.as_schemas().drop_schema(self.schema_ident, cascade=True),
+                catalog.as_schemas().drop_schema(self.schema_name, cascade=True),
             )
             logger.info(
                 "Drop schema %s[%s]",
                 self.schema_new_ident,
-                catalog.as_schemas().drop_schema(self.schema_new_ident, cascade=True),
+                catalog.as_schemas().drop_schema(self.schema_new_name, cascade=True),
             )
             logger.info(
                 "Drop catalog %s[%s]",
@@ -109,7 +107,7 @@ class TestSchema(IntegrationTestEnv):
     def create_schema(self) -> Schema:
         catalog = self.gravitino_client.load_catalog(name=self.catalog_name)
         return catalog.as_schemas().create_schema(
-            ident=self.schema_ident,
+            schema_name=self.schema_name,
             comment=self.schema_comment,
             properties=self.schema_properties,
         )
@@ -125,21 +123,21 @@ class TestSchema(IntegrationTestEnv):
         self.create_schema()
         catalog = self.gravitino_client.load_catalog(name=self.catalog_name)
         self.assertTrue(
-            catalog.as_schemas().drop_schema(ident=self.schema_ident, cascade=True)
+            catalog.as_schemas().drop_schema(schema_name=self.schema_name, cascade=True)
         )
 
     def test_list_schema(self):
         self.create_schema()
         catalog = self.gravitino_client.load_catalog(name=self.catalog_name)
-        schema_list: List[NameIdentifier] = catalog.as_schemas().list_schemas(
-            namespace=self.schema_ident.namespace()
+        schema_list: List[str] = catalog.as_schemas().list_schemas()
+        self.assertTrue(
+            any(schema_name == self.schema_name for schema_name in schema_list)
         )
-        self.assertTrue(any(item.name() == self.schema_name for item in schema_list))
 
     def test_load_schema(self):
         self.create_schema()
         catalog = self.gravitino_client.load_catalog(name=self.catalog_name)
-        schema = catalog.as_schemas().load_schema(ident=self.schema_ident)
+        schema = catalog.as_schemas().load_schema(schema_name=self.schema_name)
         self.assertIsNotNone(schema)
         self.assertEqual(schema.name(), self.schema_name)
         self.assertEqual(schema.comment(), self.schema_comment)
@@ -157,7 +155,7 @@ class TestSchema(IntegrationTestEnv):
             ),
         )
         catalog = self.gravitino_client.load_catalog(name=self.catalog_name)
-        schema_new = catalog.as_schemas().alter_schema(self.schema_ident, *changes)
+        schema_new = catalog.as_schemas().alter_schema(self.schema_name, *changes)
         self.assertEqual(
             schema_new.properties().get(self.schema_properties_key2),
             schema_propertie_new_value,

--- a/clients/client-python/tests/integration/test_simple_auth_client.py
+++ b/clients/client-python/tests/integration/test_simple_auth_client.py
@@ -43,15 +43,11 @@ class TestSimpleAuthClient(unittest.TestCase):
         fileset_properties_key2: fileset_properties_value2,
     }
 
-    catalog_ident: NameIdentifier = NameIdentifier.of_catalog(
-        metalake_name, catalog_name
-    )
-    schema_ident: NameIdentifier = NameIdentifier.of_schema(
+    catalog_ident: NameIdentifier = NameIdentifier.of(metalake_name, catalog_name)
+    schema_ident: NameIdentifier = NameIdentifier.of(
         metalake_name, catalog_name, schema_name
     )
-    fileset_ident: NameIdentifier = NameIdentifier.of_fileset(
-        metalake_name, catalog_name, schema_name, fileset_name
-    )
+    fileset_ident: NameIdentifier = NameIdentifier.of(schema_name, fileset_name)
 
     def setUp(self):
         os.environ["GRAVITINO_USER"] = self.creator
@@ -74,7 +70,9 @@ class TestSimpleAuthClient(unittest.TestCase):
             logger.info(
                 "Drop schema %s[%s]",
                 self.schema_ident,
-                catalog.as_schemas().drop_schema(ident=self.schema_ident, cascade=True),
+                catalog.as_schemas().drop_schema(
+                    schema_name=self.schema_name, cascade=True
+                ),
             )
             logger.info(
                 "Drop catalog %s[%s]",
@@ -106,7 +104,7 @@ class TestSimpleAuthClient(unittest.TestCase):
             properties={self.catalog_location_prop: "/tmp/test1"},
         )
         catalog.as_schemas().create_schema(
-            ident=self.schema_ident, comment="", properties={}
+            schema_name=self.schema_name, comment="", properties={}
         )
         catalog.as_fileset_catalog().create_fileset(
             ident=self.fileset_ident,
@@ -126,7 +124,7 @@ class TestSimpleAuthClient(unittest.TestCase):
 
     def test_schema_creator(self):
         catalog = self.gravitino_client.load_catalog(self.catalog_name)
-        schema = catalog.as_schemas().load_schema(self.schema_ident)
+        schema = catalog.as_schemas().load_schema(self.schema_name)
         self.assertEqual(schema.audit_info().creator(), self.creator)
 
     def test_fileset_creator(self):

--- a/clients/client-python/tests/unittests/mock_base.py
+++ b/clients/client-python/tests/unittests/mock_base.py
@@ -10,6 +10,8 @@ from gravitino.catalog.fileset_catalog import FilesetCatalog
 from gravitino.dto.fileset_dto import FilesetDTO
 from gravitino.dto.audit_dto import AuditDTO
 from gravitino.dto.metalake_dto import MetalakeDTO
+from gravitino.namespace import Namespace
+from gravitino.utils.http_client import HTTPClient
 
 
 def mock_load_metalake():
@@ -35,14 +37,18 @@ def mock_load_fileset_catalog():
         _last_modifier="test",
         _last_modified_time="2024-04-05T10:10:35.218Z",
     )
+
+    namespace = Namespace.of("metalake_demo")
+
     catalog = FilesetCatalog(
+        namespace=namespace,
         name="fileset_catalog",
         catalog_type=Catalog.Type.FILESET,
         provider="hadoop",
         comment="this is test",
         properties={"k": "v"},
         audit=audit_dto,
-        rest_client=None,
+        rest_client=HTTPClient("http://localhost:9090", is_debug=True),
     )
     return catalog
 

--- a/clients/client-python/tests/unittests/mock_base.py
+++ b/clients/client-python/tests/unittests/mock_base.py
@@ -3,6 +3,7 @@ Copyright 2024 Datastrato Pvt Ltd.
 This software is licensed under the Apache License version 2.
 """
 
+import json
 from unittest.mock import patch
 
 from gravitino import GravitinoMetalake, Catalog, Fileset
@@ -88,3 +89,8 @@ def mock_data(cls):
         pass
 
     return Wrapper
+
+
+def mock_name_identifier_json(name, namespace):
+
+    return json.dumps({"name": name, "namespace": namespace}).encode("utf-8")

--- a/clients/client-python/tests/unittests/test_gvfs_with_local.py
+++ b/clients/client-python/tests/unittests/test_gvfs_with_local.py
@@ -75,7 +75,7 @@ class TestLocalFilesystem(unittest.TestCase):
         time.sleep(2)
         self.assertIsNone(
             fs.cache.get(
-                NameIdentifier.of_fileset(
+                NameIdentifier.of(
                     "metalake_demo", "fileset_catalog", "tmp", "test_cache"
                 )
             )
@@ -690,7 +690,7 @@ class TestLocalFilesystem(unittest.TestCase):
             _properties={},
         )
         mock_hdfs_context: FilesetContext = FilesetContext(
-            name_identifier=NameIdentifier.of_fileset(
+            name_identifier=NameIdentifier.of(
                 "test_metalake", "test_catalog", "test_schema", "test_f1"
             ),
             storage_type=StorageType.HDFS,
@@ -730,7 +730,7 @@ class TestLocalFilesystem(unittest.TestCase):
             _properties={},
         )
         mock_local_context: FilesetContext = FilesetContext(
-            name_identifier=NameIdentifier.of_fileset(
+            name_identifier=NameIdentifier.of(
                 "test_metalake", "test_catalog", "test_schema", "test_f1"
             ),
             storage_type=StorageType.LOCAL,
@@ -771,7 +771,7 @@ class TestLocalFilesystem(unittest.TestCase):
             _properties={},
         )
         mock_hdfs_context: FilesetContext = FilesetContext(
-            name_identifier=NameIdentifier.of_fileset(
+            name_identifier=NameIdentifier.of(
                 "test_metalake", "test_catalog", "test_schema", "test_f1"
             ),
             storage_type=StorageType.HDFS,
@@ -811,7 +811,7 @@ class TestLocalFilesystem(unittest.TestCase):
             _properties={},
         )
         mock_local_context: FilesetContext = FilesetContext(
-            name_identifier=NameIdentifier.of_fileset(
+            name_identifier=NameIdentifier.of(
                 "test_metalake", "test_catalog", "test_schema", "test_f1"
             ),
             storage_type=StorageType.LOCAL,

--- a/clients/client-python/tests/unittests/test_name_identifier.py
+++ b/clients/client-python/tests/unittests/test_name_identifier.py
@@ -10,10 +10,10 @@ from gravitino import NameIdentifier
 
 class TestNameIdentifier(unittest.TestCase):
     def test_name_identifier_hash(self):
-        name_identifier1: NameIdentifier = NameIdentifier.of_fileset(
+        name_identifier1: NameIdentifier = NameIdentifier.of(
             "test_metalake", "test_catalog", "test_schema", "test_fileset1"
         )
-        name_identifier2: NameIdentifier = NameIdentifier.of_fileset(
+        name_identifier2: NameIdentifier = NameIdentifier.of(
             "test_metalake", "test_catalog", "test_schema", "test_fileset2"
         )
         identifier_dict = {name_identifier1: "test1", name_identifier2: "test2"}

--- a/clients/client-python/tests/unittests/test_name_identifier.py
+++ b/clients/client-python/tests/unittests/test_name_identifier.py
@@ -6,6 +6,7 @@ This software is licensed under the Apache License version 2.
 import unittest
 
 from gravitino import NameIdentifier
+from tests.unittests.mock_base import mock_name_identifier_json
 
 
 class TestNameIdentifier(unittest.TestCase):
@@ -20,3 +21,15 @@ class TestNameIdentifier(unittest.TestCase):
 
         self.assertEqual("test1", identifier_dict.get(name_identifier1))
         self.assertNotEqual("test2", identifier_dict.get(name_identifier1))
+
+    def test_from_json_name_identifier(self):
+
+        test_name = "test_name_identifier"
+        test_namespace_levels = ["1", "2", "3", "4"]
+
+        json_data = mock_name_identifier_json(test_name, test_namespace_levels)
+
+        name_identifier = NameIdentifier.from_json(json_data, infer_missing=True)
+
+        self.assertEqual(test_name, name_identifier.name())
+        self.assertEqual(test_namespace_levels, name_identifier.namespace().levels())


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

After the refactoring work in Java client is done (https://github.com/apache/gravitino/issues/3626), the Python client should also get updated to align with the Java API.

* Update all the catalog, schema and their implementation to align wiith `client-java`
* Remove redundant methods in `Namespace` and `NameIdentifier`
* Add some missing tests and modify existing tests to conform with new API

### Why are the changes needed?

Fix: #3732 

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

UT added and test with `./gradlew clients:client-python:test`
