### PR TITLE
[#4031][followup] build: Revert the partial protected branches

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -48,12 +48,6 @@ github:
       required_pull_request_reviews:
         dismiss_stale_reviews: true
         required_approving_review_count: 1
-    branch-*:
-      required_status_checks:
-        strict: true
-      required_pull_request_reviews:
-        dismiss_stale_reviews: true
-        required_approving_review_count: 1
 
 notifications:
   commits: commits@gravitino.apache.org


### PR DESCRIPTION
### What changes were proposed in this pull request?
Apache infra doesn't support `branch-*`.

### Why are the changes needed?

This is a follow-up pull request of #4033 

Fix: #4031 

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Verified after merging.
