### PR TITLE
[#4064] Update to use correct ASF names

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,9 +17,9 @@
   under the License.
 -->
 
-# Contributing to Gravitino
+# Contributing to Apache Gravitino
 
-Thank you for your interest in contributing to Gravitino! You are welcome to contribute in any way you can to enhance the project. Gravitino appreciates your assistance in making it better, whether through code contributions, documentation, tests, best practices, graphic design, or any other means that have a positive impact.
+Thank you for your interest in contributing to Apache Gravitino! You are welcome to contribute in any way you can to enhance the project. Gravitino appreciates your assistance in making it better, whether through code contributions, documentation, tests, best practices, graphic design, or any other means that have a positive impact.
 
 Before you get started, please read and follow these guidelines to ensure a smooth and productive collaboration.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,8 +1,8 @@
-# Gravitino Roadmap
+# Apache Gravitino Roadmap
 
 ## 2024 Roadmap
 
-As of March 2024, this is the current roadmap for the Gravitino project. Please note that Gravitino is an open-source project and relies on the collective efforts of both community contributors and paid developers to shape its future features and direction. While we strive to keep this roadmap up-to-date, it is best seen as a general guide for future developments rather than an exhaustive list of planned features. The Gravitino community may decide to alter the project's direction or prioritize other features that are not listed here.
+As of March 2024, this is the current roadmap for the Apache Gravitino project. Please note that Gravitino is an open-source project and relies on the collective efforts of both community contributors and paid developers to shape its future features and direction. While we strive to keep this roadmap up-to-date, it is best seen as a general guide for future developments rather than an exhaustive list of planned features. The Gravitino community may decide to alter the project's direction or prioritize other features that are not listed here.
 
 ## First half of 2024 (January-June) - Make Gravitino ready for production environment
 
@@ -20,7 +20,7 @@ As of March 2024, this is the current roadmap for the Gravitino project. Please 
 - Implement support for a basic data compliance framework.
 - Continue to encourage and support community work.
 
-## Second half of 2024 (July-December) - Improve Gravitino features
+## Second half of 2024 (July-December) - Improve Apache Gravitino features
 
 ### Q3 (July-September)
 

--- a/api/src/main/java/com/datastrato/gravitino/Catalog.java
+++ b/api/src/main/java/com/datastrato/gravitino/Catalog.java
@@ -25,7 +25,7 @@ import com.datastrato.gravitino.rel.TableCatalog;
 import java.util.Map;
 
 /**
- * The interface of a catalog. The catalog is the second level entity in the gravitino system,
+ * The interface of a catalog. The catalog is the second level entity in the Gravitino system,
  * containing a set of tables. The server side should use the other one with the same name in the
  * core module.
  */

--- a/api/src/main/java/com/datastrato/gravitino/MetadataObject.java
+++ b/api/src/main/java/com/datastrato/gravitino/MetadataObject.java
@@ -24,7 +24,7 @@ import javax.annotation.Nullable;
 
 /**
  * The MetadataObject is the basic unit of the Gravitino system. It represents the metadata object
- * in the Gravitino system. The object can be a metalake, catalog, schema, table, topic, etc.
+ * in the Apache Gravitino system. The object can be a metalake, catalog, schema, table, topic, etc.
  */
 @Unstable
 public interface MetadataObject {

--- a/api/src/main/java/com/datastrato/gravitino/Metalake.java
+++ b/api/src/main/java/com/datastrato/gravitino/Metalake.java
@@ -22,7 +22,7 @@ import com.datastrato.gravitino.annotation.Evolving;
 import java.util.Map;
 
 /**
- * The interface of a metalake. The metalake is the top level entity in the gravitino system,
+ * The interface of a metalake. The metalake is the top level entity in the Apache Gravitino system,
  * containing a set of catalogs.
  */
 @Evolving

--- a/api/src/main/java/com/datastrato/gravitino/authorization/SecurableObject.java
+++ b/api/src/main/java/com/datastrato/gravitino/authorization/SecurableObject.java
@@ -24,7 +24,7 @@ import java.util.List;
 
 /**
  * The securable object is the entity which access can be granted. Unless allowed by a grant, access
- * is denied. Gravitino organizes the securable objects using tree structure. <br>
+ * is denied. Apache Gravitino organizes the securable objects using tree structure. <br>
  * There are three fields in the securable object: parent, name, and type. <br>
  * The types include 6 kinds: CATALOG,SCHEMA,TABLE,FILESET,TOPIC and METALAKE. <br>
  * You can use the helper class `SecurableObjects` to create the securable object which you need.

--- a/api/src/main/java/com/datastrato/gravitino/exceptions/GravitinoRuntimeException.java
+++ b/api/src/main/java/com/datastrato/gravitino/exceptions/GravitinoRuntimeException.java
@@ -21,7 +21,7 @@ package com.datastrato.gravitino.exceptions;
 import com.google.errorprone.annotations.FormatMethod;
 import com.google.errorprone.annotations.FormatString;
 
-/** Base class for all Gravitino runtime exceptions. */
+/** Base class for all Apache Gravitino runtime exceptions. */
 public class GravitinoRuntimeException extends RuntimeException {
 
   /**

--- a/api/src/main/java/com/datastrato/gravitino/file/Fileset.java
+++ b/api/src/main/java/com/datastrato/gravitino/file/Fileset.java
@@ -27,10 +27,10 @@ import javax.annotation.Nullable;
 
 /**
  * An interface representing a fileset under a schema {@link Namespace}. A fileset is a virtual
- * concept of the file or directory that is managed by Gravitino. Users can create a fileset object
- * to manage the non-tabular data on the FS-like storage. The typical use case is to manage the
- * training data for AI workloads. The major difference compare to the relational table is that the
- * fileset is schema-free, the main property of the fileset is the storage location of the
+ * concept of the file or directory that is managed by Apache Gravitino. Users can create a fileset
+ * object to manage the non-tabular data on the FS-like storage. The typical use case is to manage
+ * the training data for AI workloads. The major difference compare to the relational table is that
+ * the fileset is schema-free, the main property of the fileset is the storage location of the
  * underlying data.
  *
  * <p>{@link Fileset} defines the basic properties of a fileset object. A catalog implementation

--- a/api/src/main/java/com/datastrato/gravitino/messaging/Topic.java
+++ b/api/src/main/java/com/datastrato/gravitino/messaging/Topic.java
@@ -26,8 +26,8 @@ import javax.annotation.Nullable;
 
 /**
  * An interface representing a topic under a schema {@link com.datastrato.gravitino.Namespace}. A
- * topic is a message queue that is managed by Gravitino. Users can create/drop/alter a topic on the
- * Message Queue system like Kafka, Pulsar, etc.
+ * topic is a message queue that is managed by Apache Gravitino. Users can create/drop/alter a topic
+ * on the Message Queue system like Apache Kafka, Apache Pulsar, etc.
  *
  * <p>{@link Topic} defines the basic properties of a topic object. A catalog implementation with
  * {@link TopicCatalog} should implement this interface.

--- a/api/src/main/java/com/datastrato/gravitino/rel/expressions/distributions/Distributions.java
+++ b/api/src/main/java/com/datastrato/gravitino/rel/expressions/distributions/Distributions.java
@@ -23,7 +23,7 @@ import com.datastrato.gravitino.rel.expressions.NamedReference;
 import java.util.Arrays;
 import java.util.Objects;
 
-/** Helper methods to create distributions to pass into Gravitino. */
+/** Helper methods to create distributions to pass into Apache Gravitino. */
 public class Distributions {
 
   /** NONE is used to indicate that there is no distribution. */

--- a/api/src/main/java/com/datastrato/gravitino/rel/expressions/literals/Literals.java
+++ b/api/src/main/java/com/datastrato/gravitino/rel/expressions/literals/Literals.java
@@ -26,7 +26,7 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.Objects;
 
-/** The helper class to create literals to pass into Gravitino. */
+/** The helper class to create literals to pass into Apache Gravitino. */
 public class Literals {
 
   /** Used to represent a null literal. */

--- a/api/src/main/java/com/datastrato/gravitino/rel/expressions/sorts/SortOrders.java
+++ b/api/src/main/java/com/datastrato/gravitino/rel/expressions/sorts/SortOrders.java
@@ -21,7 +21,7 @@ package com.datastrato.gravitino.rel.expressions.sorts;
 import com.datastrato.gravitino.rel.expressions.Expression;
 import java.util.Objects;
 
-/** Helper methods to create SortOrders to pass into Gravitino. */
+/** Helper methods to create SortOrders to pass into Apache Gravitino. */
 public class SortOrders {
 
   /** NONE is used to indicate that there is no sort order. */

--- a/api/src/main/java/com/datastrato/gravitino/rel/expressions/transforms/Transforms.java
+++ b/api/src/main/java/com/datastrato/gravitino/rel/expressions/transforms/Transforms.java
@@ -28,7 +28,7 @@ import com.google.common.collect.ObjectArrays;
 import java.util.Arrays;
 import java.util.Objects;
 
-/** Helper methods to create logical transforms to pass into Gravitino. */
+/** Helper methods to create logical transforms to pass into Apache Gravitino. */
 public class Transforms {
   /** An empty array of transforms. */
   public static final Transform[] EMPTY_TRANSFORM = new Transform[0];

--- a/api/src/main/java/com/datastrato/gravitino/rel/indexes/Indexes.java
+++ b/api/src/main/java/com/datastrato/gravitino/rel/indexes/Indexes.java
@@ -18,7 +18,7 @@
  */
 package com.datastrato.gravitino.rel.indexes;
 
-/** Helper methods to create index to pass into Gravitino. */
+/** Helper methods to create index to pass into Apache Gravitino. */
 public class Indexes {
 
   /** An empty array of indexes. */

--- a/api/src/main/java/com/datastrato/gravitino/rel/types/Decimal.java
+++ b/api/src/main/java/com/datastrato/gravitino/rel/types/Decimal.java
@@ -26,7 +26,7 @@ import java.math.RoundingMode;
 import java.util.Objects;
 
 /**
- * Used to represent a {@link Types.DecimalType} value in Gravitino.
+ * Used to represent a {@link Types.DecimalType} value in Apache Gravitino.
  *
  * <p>For Decimal, we expect the precision is equal to or larger than the scale, however, in {@link
  * BigDecimal}, the digit count starts from the leftmost nonzero digit of the exact result. For

--- a/api/src/main/java/com/datastrato/gravitino/rel/types/Type.java
+++ b/api/src/main/java/com/datastrato/gravitino/rel/types/Type.java
@@ -20,7 +20,7 @@ package com.datastrato.gravitino.rel.types;
 
 import com.datastrato.gravitino.annotation.Evolving;
 
-/** An interface representing all data types supported by Gravitino. */
+/** An interface representing all data types supported by Apache Gravitino. */
 @Evolving
 public interface Type {
   /** @return The generic name of the type. */

--- a/catalogs/bundled-catalog/src/main/java/com/datastrato/gravitino/catalog/common/ClassProvider.java
+++ b/catalogs/bundled-catalog/src/main/java/com/datastrato/gravitino/catalog/common/ClassProvider.java
@@ -35,7 +35,7 @@ import java.util.Set;
 
 /**
  * The {@link ClassProvider} class serves as a container for the necessary classes used by the
- * Gravitino query engine, with a primary focus on classes related to property metadata.
+ * Apache Gravitino query engine, with a primary focus on classes related to property metadata.
  *
  * <p>Purpose of this module and class:
  *

--- a/catalogs/bundled-catalog/src/main/java/com/datastrato/gravitino/catalog/property/PropertyConverter.java
+++ b/catalogs/bundled-catalog/src/main/java/com/datastrato/gravitino/catalog/property/PropertyConverter.java
@@ -26,7 +26,7 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** Transforming between gravitino schema/table/column property and engine property. */
+/** Transforming between Apache Gravitino schema/table/column property and engine property. */
 public abstract class PropertyConverter {
 
   protected static final String TRINO_PROPERTIES_PREFIX = "trino.bypass.";
@@ -34,7 +34,7 @@ public abstract class PropertyConverter {
   private static final Logger LOG = LoggerFactory.getLogger(PropertyConverter.class);
   /**
    * Mapping that maps engine properties to Gravitino properties. It will return a map that holds
-   * the mapping between engine and gravitino properties.
+   * the mapping between engine and Gravitino properties.
    *
    * @return a map that holds the mapping from engine to Gravitino properties.
    */

--- a/catalogs/catalog-hive/src/main/java/com/datastrato/gravitino/catalog/hive/HiveCatalog.java
+++ b/catalogs/catalog-hive/src/main/java/com/datastrato/gravitino/catalog/hive/HiveCatalog.java
@@ -26,7 +26,7 @@ import com.datastrato.gravitino.connector.capability.Capability;
 import java.util.Map;
 import java.util.Optional;
 
-/** Implementation of a Hive catalog in Gravitino. */
+/** Implementation of an Apache Hive catalog in Apache Gravitino. */
 public class HiveCatalog extends BaseCatalog<HiveCatalog> {
 
   static final HiveCatalogPropertiesMeta CATALOG_PROPERTIES_METADATA =

--- a/catalogs/catalog-hive/src/main/java/com/datastrato/gravitino/catalog/hive/HiveCatalogCapability.java
+++ b/catalogs/catalog-hive/src/main/java/com/datastrato/gravitino/catalog/hive/HiveCatalogCapability.java
@@ -24,7 +24,7 @@ import com.datastrato.gravitino.connector.capability.CapabilityResult;
 public class HiveCatalogCapability implements Capability {
   @Override
   public CapabilityResult columnNotNull() {
-    // The NOT NULL constraint for column is supported since Hive3.0, see
+    // The NOT NULL constraint for column is supported since Hive 3.0, see
     // https://issues.apache.org/jira/browse/HIVE-16575
     return CapabilityResult.unsupported(
         "The NOT NULL constraint for column is only supported since Hive 3.0, "
@@ -33,7 +33,7 @@ public class HiveCatalogCapability implements Capability {
 
   @Override
   public CapabilityResult columnDefaultValue() {
-    // The DEFAULT constraint for column is supported since Hive3.0, see
+    // The DEFAULT constraint for column is supported since Hive 3.0, see
     // https://issues.apache.org/jira/browse/HIVE-18726
     return CapabilityResult.unsupported(
         "The DEFAULT constraint for column is only supported since Hive 3.0, "

--- a/catalogs/catalog-hive/src/main/java/com/datastrato/gravitino/catalog/hive/HiveCatalogOperations.java
+++ b/catalogs/catalog-hive/src/main/java/com/datastrato/gravitino/catalog/hive/HiveCatalogOperations.java
@@ -99,7 +99,7 @@ import org.apache.thrift.TException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** Operations for interacting with the Hive catalog in Gravitino. */
+/** Operations for interacting with an Apache Hive catalog in Apache Gravitino. */
 public class HiveCatalogOperations implements CatalogOperations, SupportsSchemas, TableCatalog {
 
   public static final Logger LOG = LoggerFactory.getLogger(HiveCatalogOperations.class);
@@ -159,7 +159,7 @@ public class HiveCatalogOperations implements CatalogOperations, SupportsSchemas
     mergeConfig.putAll(gravitinoConfig);
 
     Configuration hadoopConf = new Configuration();
-    // Set byPass first to make gravitino config overwrite it, only keys in byPassConfig
+    // Set byPass first to make Gravitino config overwrite it, only keys in byPassConfig
     // and gravitinoConfig will be passed to Hive config, and gravitinoConfig has higher priority
     mergeConfig.forEach(hadoopConf::set);
     hiveConf = new HiveConf(hadoopConf, HiveCatalogOperations.class);
@@ -466,7 +466,7 @@ public class HiveCatalogOperations implements CatalogOperations, SupportsSchemas
         }
       }
 
-      // alter the hive database parameters
+      // alter the Hive database parameters
       Database alteredDatabase = database.deepCopy();
       alteredDatabase.setParameters(properties);
 

--- a/catalogs/catalog-hive/src/main/java/com/datastrato/gravitino/catalog/hive/HiveClientPool.java
+++ b/catalogs/catalog-hive/src/main/java/com/datastrato/gravitino/catalog/hive/HiveClientPool.java
@@ -35,7 +35,7 @@ import org.slf4j.LoggerFactory;
 
 // hive-metastore/src/main/java/org/apache/iceberg/hive/HiveClientPool.java
 
-/** Represents a client pool for managing connections to the Hive Metastore service. */
+/** Represents a client pool for managing connections to an Apache Hive Metastore service. */
 public class HiveClientPool extends ClientPoolImpl<IMetaStoreClient, TException> {
 
   private static final Logger LOG = LoggerFactory.getLogger(HiveClientPool.class);

--- a/catalogs/catalog-hive/src/main/java/com/datastrato/gravitino/catalog/hive/HiveColumn.java
+++ b/catalogs/catalog-hive/src/main/java/com/datastrato/gravitino/catalog/hive/HiveColumn.java
@@ -21,7 +21,7 @@ package com.datastrato.gravitino.catalog.hive;
 import com.datastrato.gravitino.connector.BaseColumn;
 import lombok.EqualsAndHashCode;
 
-/** Represents a column in the Hive Metastore catalog. */
+/** Represents a column in an Apache Hive Metastore catalog. */
 @EqualsAndHashCode(callSuper = true)
 public class HiveColumn extends BaseColumn {
 

--- a/catalogs/catalog-hive/src/main/java/com/datastrato/gravitino/catalog/hive/HiveSchema.java
+++ b/catalogs/catalog-hive/src/main/java/com/datastrato/gravitino/catalog/hive/HiveSchema.java
@@ -30,7 +30,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.metastore.api.Database;
 import org.apache.hadoop.hive.metastore.api.PrincipalType;
 
-/** Represents a Hive Schema (Database) entity in the Hive Metastore catalog. */
+/** Represents an Apache Hive Schema (Database) entity in the Hive Metastore catalog. */
 @ToString
 public class HiveSchema extends BaseSchema {
   private Configuration conf;

--- a/catalogs/catalog-hive/src/main/java/com/datastrato/gravitino/catalog/hive/HiveTable.java
+++ b/catalogs/catalog-hive/src/main/java/com/datastrato/gravitino/catalog/hive/HiveTable.java
@@ -68,7 +68,7 @@ import org.apache.hadoop.hive.metastore.api.SerDeInfo;
 import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
 import org.apache.hadoop.hive.metastore.api.Table;
 
-/** Represents a Hive Table entity in the Hive Metastore catalog. */
+/** Represents an Apache Hive Table entity in the Hive Metastore catalog. */
 @ToString
 public class HiveTable extends BaseTable {
 

--- a/catalogs/catalog-hive/src/test/java/com/datastrato/gravitino/catalog/hive/integration/test/CatalogHiveIT.java
+++ b/catalogs/catalog-hive/src/test/java/com/datastrato/gravitino/catalog/hive/integration/test/CatalogHiveIT.java
@@ -176,7 +176,7 @@ public class CatalogHiveIT extends AbstractIT {
     HiveConf hiveConf = new HiveConf();
     hiveConf.set(HiveConf.ConfVars.METASTOREURIS.varname, HIVE_METASTORE_URIS);
 
-    // Check if hive client can connect to hive metastore
+    // Check if Hive client can connect to Hive metastore
     hiveClientPool = new HiveClientPool(1, hiveConf);
     List<String> dbs = hiveClientPool.run(client -> client.getAllDatabases());
     Assertions.assertFalse(dbs.isEmpty());
@@ -298,7 +298,7 @@ public class CatalogHiveIT extends AbstractIT {
     Assertions.assertEquals("val2", loadSchema.properties().get("key2"));
     Assertions.assertNotNull(loadSchema.properties().get(HiveSchemaPropertiesMetadata.LOCATION));
 
-    // Directly get database from hive metastore to verify the schema creation
+    // Directly get database from Hive metastore to verify the schema creation
     Database database = hiveClientPool.run(client -> client.getDatabase(schemaName));
     Assertions.assertEquals(schemaName.toLowerCase(), database.getName());
     Assertions.assertEquals(comment, database.getDescription());
@@ -387,7 +387,7 @@ public class CatalogHiveIT extends AbstractIT {
                 distribution,
                 sortOrders);
 
-    // Directly get table from hive metastore to check if the table is created successfully.
+    // Directly get table from Hive metastore to check if the table is created successfully.
     org.apache.hadoop.hive.metastore.api.Table hiveTab =
         hiveClientPool.run(client -> client.getTable(schemaName, tableName));
     properties
@@ -404,7 +404,7 @@ public class CatalogHiveIT extends AbstractIT {
             .asTableCatalog()
             .createTable(nameIdentifier, columns, TABLE_COMMENT, properties, (Transform[]) null);
 
-    // Directly get table from hive metastore to check if the table is created successfully.
+    // Directly get table from Hive metastore to check if the table is created successfully.
     org.apache.hadoop.hive.metastore.api.Table hiveTable1 =
         hiveClientPool.run(client -> client.getTable(schemaName, tableName));
     properties
@@ -468,7 +468,7 @@ public class CatalogHiveIT extends AbstractIT {
             .createTable(
                 nameIdentifier, columns, TABLE_COMMENT, properties, Transforms.EMPTY_TRANSFORM);
 
-    // Directly get table from hive metastore to check if the table is created successfully.
+    // Directly get table from Hive metastore to check if the table is created successfully.
     org.apache.hadoop.hive.metastore.api.Table hiveTab =
         hiveClientPool.run(client -> client.getTable(schemaName, tableName));
     properties
@@ -496,7 +496,7 @@ public class CatalogHiveIT extends AbstractIT {
             .asTableCatalog()
             .createTable(nameIdentifier, columns, TABLE_COMMENT, properties, (Transform[]) null);
 
-    // Directly get table from hive metastore to check if the table is created successfully.
+    // Directly get table from Hive metastore to check if the table is created successfully.
     org.apache.hadoop.hive.metastore.api.Table hiveTable1 =
         hiveClientPool.run(client -> client.getTable(schemaName, tableName));
     properties
@@ -684,7 +684,7 @@ public class CatalogHiveIT extends AbstractIT {
                   Transforms.identity(columns[1].name()), Transforms.identity(columns[2].name())
                 });
 
-    // Directly get table from hive metastore to check if the table is created successfully.
+    // Directly get table from Hive metastore to check if the table is created successfully.
     org.apache.hadoop.hive.metastore.api.Table hiveTab =
         hiveClientPool.run(client -> client.getTable(schemaName, tableName));
     properties
@@ -805,7 +805,7 @@ public class CatalogHiveIT extends AbstractIT {
     Assertions.assertEquals(
         "hive_col_name2=2023-01-01/hive_col_name3=gravitino_it_test", partition.name());
 
-    // Directly get partition from hive metastore
+    // Directly get partition from Hive metastore
     org.apache.hadoop.hive.metastore.api.Partition hivePartition =
         hiveClientPool.run(
             client -> client.getPartition(schemaName, createdTable.name(), partition.name()));
@@ -915,7 +915,7 @@ public class CatalogHiveIT extends AbstractIT {
     IdentityPartition partitionAdded1 =
         (IdentityPartition) createdTable.supportPartitions().addPartition(identity1);
 
-    // Directly get partition from hive metastore to check if the partition is created successfully.
+    // Directly get partition from Hive metastore to check if the partition is created successfully.
     org.apache.hadoop.hive.metastore.api.Partition partitionGot1 =
         hiveClientPool.run(
             client -> client.getPartition(schemaName, createdTable.name(), partitionAdded1.name()));
@@ -934,7 +934,7 @@ public class CatalogHiveIT extends AbstractIT {
         Partitions.identity(new String[][] {field5, field6}, new Literal<?>[] {literal5, literal6});
     IdentityPartition partitionAdded2 =
         (IdentityPartition) createdTable.supportPartitions().addPartition(identity2);
-    // Directly get partition from hive metastore to check if the partition is created successfully.
+    // Directly get partition from Hive metastore to check if the partition is created successfully.
     org.apache.hadoop.hive.metastore.api.Partition partitionGot2 =
         hiveClientPool.run(
             client -> client.getPartition(schemaName, createdTable.name(), partitionAdded2.name()));
@@ -1103,7 +1103,8 @@ public class CatalogHiveIT extends AbstractIT {
                     new String[] {HIVE_COL_NAME1}, Types.IntegerType.get()));
     Assertions.assertEquals(AuthConstants.ANONYMOUS_USER, alteredTable.auditInfo().creator());
     Assertions.assertEquals(AuthConstants.ANONYMOUS_USER, alteredTable.auditInfo().lastModifier());
-    // Direct get table from hive metastore to check if the table is altered successfully.
+
+    // Direct get table from Hive metastore to check if the table is altered successfully.
     org.apache.hadoop.hive.metastore.api.Table hiveTab =
         hiveClientPool.run(client -> client.getTable(schemaName, ALTER_TABLE_NAME));
     Assertions.assertEquals(schemaName.toLowerCase(), hiveTab.getDbName());
@@ -1252,7 +1253,7 @@ public class CatalogHiveIT extends AbstractIT {
             Transforms.EMPTY_TRANSFORM);
     catalog.asTableCatalog().dropTable(NameIdentifier.of(schemaName, ALTER_TABLE_NAME));
 
-    // Directly get table from hive metastore to check if the table is dropped successfully.
+    // Directly get table from Hive metastore to check if the table is dropped successfully.
     assertThrows(
         NoSuchObjectException.class,
         () -> hiveClientPool.run(client -> client.getTable(schemaName, ALTER_TABLE_NAME)));
@@ -1463,7 +1464,8 @@ public class CatalogHiveIT extends AbstractIT {
             TABLE_COMMENT,
             createProperties(),
             new Transform[] {Transforms.identity(columns[2].name())});
-    // Directly get table from hive metastore to check if the table is created successfully.
+
+    // Directly get table from Hive metastore to check if the table is created successfully.
     org.apache.hadoop.hive.metastore.api.Table hiveTab =
         hiveClientPool.run(client -> client.getTable(schemaName, tableName));
     checkTableReadWrite(hiveTab);
@@ -1471,7 +1473,7 @@ public class CatalogHiveIT extends AbstractIT {
     Path tableDirectory = new Path(hiveTab.getSd().getLocation());
     catalog.asTableCatalog().dropTable(NameIdentifier.of(schemaName, tableName));
     Boolean existed = hiveClientPool.run(client -> client.tableExists(schemaName, tableName));
-    Assertions.assertFalse(existed, "The hive table should not exist");
+    Assertions.assertFalse(existed, "The Hive table should not exist");
     Assertions.assertFalse(hdfs.exists(tableDirectory), "The table directory should not exist");
   }
 
@@ -1486,7 +1488,7 @@ public class CatalogHiveIT extends AbstractIT {
             TABLE_COMMENT,
             ImmutableMap.of(TABLE_TYPE, EXTERNAL_TABLE.name().toLowerCase(Locale.ROOT)),
             new Transform[] {Transforms.identity(columns[2].name())});
-    // Directly get table from hive metastore to check if the table is created successfully.
+    // Directly get table from Hive metastore to check if the table is created successfully.
     org.apache.hadoop.hive.metastore.api.Table hiveTab =
         hiveClientPool.run(client -> client.getTable(schemaName, tableName));
     checkTableReadWrite(hiveTab);
@@ -1511,14 +1513,15 @@ public class CatalogHiveIT extends AbstractIT {
             TABLE_COMMENT,
             createProperties(),
             new Transform[] {Transforms.identity(columns[2].name())});
-    // Directly get table from hive metastore to check if the table is created successfully.
+
+    // Directly get table from Hive metastore to check if the table is created successfully.
     org.apache.hadoop.hive.metastore.api.Table hiveTab =
         hiveClientPool.run(client -> client.getTable(schemaName, tableName));
     checkTableReadWrite(hiveTab);
     Assertions.assertEquals(MANAGED_TABLE.name(), hiveTab.getTableType());
     catalog.asTableCatalog().purgeTable(NameIdentifier.of(schemaName, tableName));
     Boolean existed = hiveClientPool.run(client -> client.tableExists(schemaName, tableName));
-    Assertions.assertFalse(existed, "The hive table should not exist");
+    Assertions.assertFalse(existed, "The Hive table should not exist");
     Path tableDirectory = new Path(hiveTab.getSd().getLocation());
     Assertions.assertFalse(hdfs.exists(tableDirectory), "The table directory should not exist");
     Path trashDirectory = hdfs.getTrashRoot(tableDirectory);
@@ -1536,7 +1539,8 @@ public class CatalogHiveIT extends AbstractIT {
             TABLE_COMMENT,
             ImmutableMap.of(TABLE_TYPE, EXTERNAL_TABLE.name().toLowerCase(Locale.ROOT)),
             new Transform[] {Transforms.identity(columns[2].name())});
-    // Directly get table from hive metastore to check if the table is created successfully.
+
+    // Directly get table from Hive metastore to check if the table is created successfully.
     org.apache.hadoop.hive.metastore.api.Table hiveTab =
         hiveClientPool.run(client -> client.getTable(schemaName, tableName));
     checkTableReadWrite(hiveTab);
@@ -1548,7 +1552,7 @@ public class CatalogHiveIT extends AbstractIT {
         () -> {
           tableCatalog.purgeTable(id);
         },
-        "Can't purge a external hive table");
+        "Can't purge a external Hive table");
 
     Boolean existed = hiveClientPool.run(client -> client.tableExists(schemaName, tableName));
     Assertions.assertTrue(existed, "The table should be still exist");
@@ -1569,7 +1573,7 @@ public class CatalogHiveIT extends AbstractIT {
             ImmutableMap.of(TABLE_TYPE, EXTERNAL_TABLE.name().toLowerCase(Locale.ROOT)),
             new Transform[] {Transforms.identity(columns[2].name())});
 
-    // Directly drop table from hive metastore.
+    // Directly drop table from Hive metastore.
     hiveClientPool.run(
         client -> {
           client.dropTable(schemaName, tableName, true, false, false);
@@ -1598,7 +1602,7 @@ public class CatalogHiveIT extends AbstractIT {
             ImmutableMap.of(TABLE_TYPE, EXTERNAL_TABLE.name().toLowerCase(Locale.ROOT)),
             new Transform[] {Transforms.identity(columns[2].name())});
 
-    // Directly drop table from hive metastore.
+    // Directly drop table from Hive metastore.
     hiveClientPool.run(
         client -> {
           client.dropTable(schemaName, tableName, true, false, true);

--- a/catalogs/catalog-hive/src/test/java/com/datastrato/gravitino/catalog/hive/integration/test/ProxyCatalogHiveIT.java
+++ b/catalogs/catalog-hive/src/test/java/com/datastrato/gravitino/catalog/hive/integration/test/ProxyCatalogHiveIT.java
@@ -106,7 +106,7 @@ public class ProxyCatalogHiveIT extends AbstractIT {
     HiveConf hiveConf = new HiveConf();
     hiveConf.set(HiveConf.ConfVars.METASTOREURIS.varname, HIVE_METASTORE_URIS);
 
-    // Check if hive client can connect to hive metastore
+    // Check if Hive client can connect to Hive metastore
     hiveClientPool = new HiveClientPool(1, hiveConf);
 
     Configuration conf = new Configuration();

--- a/catalogs/catalog-hive/src/test/java/com/datastrato/gravitino/catalog/hive/miniHMS/MiniHiveMetastore.java
+++ b/catalogs/catalog-hive/src/test/java/com/datastrato/gravitino/catalog/hive/miniHMS/MiniHiveMetastore.java
@@ -119,7 +119,7 @@ public class MiniHiveMetastore {
                     }
                   }));
     } catch (Exception e) {
-      throw new RuntimeException("Failed to setup local dir for hive metastore", e);
+      throw new RuntimeException("Failed to setup local dir for Hive metastore", e);
     }
   }
 
@@ -160,7 +160,7 @@ public class MiniHiveMetastore {
    * Starts a TestHiveMetastore with the default connection pool size (5) with the provided Hive
    * configuration.
    *
-   * @param conf The hive configuration to use.
+   * @param conf The Hive configuration to use.
    */
   public void start(HiveConf conf) {
     start(conf, DEFAULT_POOL_SIZE);
@@ -169,7 +169,7 @@ public class MiniHiveMetastore {
   /**
    * Starts a TestHiveMetastore with a provided connection pool size and Hive configuration.
    *
-   * @param conf The hive configuration to use.
+   * @param conf The Hive configuration to use.
    * @param poolSize The number of threads in the executor pool.
    */
   public void start(HiveConf conf, int poolSize) {

--- a/catalogs/catalog-jdbc-common/src/main/java/com/datastrato/gravitino/catalog/jdbc/JdbcCatalogOperations.java
+++ b/catalogs/catalog-jdbc-common/src/main/java/com/datastrato/gravitino/catalog/jdbc/JdbcCatalogOperations.java
@@ -73,11 +73,11 @@ import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** Operations for interacting with the Jdbc catalog in Gravitino. */
+/** Operations for interacting with the Jdbc catalog in Apache Gravitino. */
 public class JdbcCatalogOperations implements CatalogOperations, SupportsSchemas, TableCatalog {
 
   private static final String GRAVITINO_ATTRIBUTE_DOES_NOT_EXIST_MSG =
-      "The gravitino id attribute does not exist in properties";
+      "The Gravitino id attribute does not exist in properties";
 
   public static final Logger LOG = LoggerFactory.getLogger(JdbcCatalogOperations.class);
 
@@ -223,7 +223,7 @@ public class JdbcCatalogOperations implements CatalogOperations, SupportsSchemas
     String comment = load.comment();
     StringIdentifier id = StringIdentifier.fromComment(comment);
     if (id == null) {
-      LOG.warn("The comment {} does not contain gravitino id attribute", comment);
+      LOG.warn("The comment {} does not contain Gravitino id attribute", comment);
       return load;
     }
     Map<String, String> properties =
@@ -298,7 +298,7 @@ public class JdbcCatalogOperations implements CatalogOperations, SupportsSchemas
     StringIdentifier id = StringIdentifier.fromComment(comment);
     if (id == null) {
       LOG.warn(
-          "The table {} comment {} does not contain gravitino id attribute", tableName, comment);
+          "The table {} comment {} does not contain Gravitino id attribute", tableName, comment);
     } else {
       properties = StringIdentifier.newPropertiesWithId(id, properties);
       // Remove id from comment

--- a/catalogs/catalog-jdbc-doris/src/main/java/com/datastrato/gravitino/catalog/doris/DorisCatalog.java
+++ b/catalogs/catalog-jdbc-doris/src/main/java/com/datastrato/gravitino/catalog/doris/DorisCatalog.java
@@ -34,7 +34,7 @@ import com.datastrato.gravitino.connector.CatalogOperations;
 import com.datastrato.gravitino.connector.capability.Capability;
 import java.util.Map;
 
-/** Implementation of a Doris catalog in Gravitino. */
+/** Implementation of an Apache Doris catalog in Apache Gravitino. */
 public class DorisCatalog extends JdbcCatalog {
 
   @Override

--- a/catalogs/catalog-jdbc-doris/src/main/java/com/datastrato/gravitino/catalog/doris/converter/DorisExceptionConverter.java
+++ b/catalogs/catalog-jdbc-doris/src/main/java/com/datastrato/gravitino/catalog/doris/converter/DorisExceptionConverter.java
@@ -30,7 +30,7 @@ import com.google.common.annotations.VisibleForTesting;
 import java.sql.SQLException;
 import java.util.regex.Pattern;
 
-/** Exception converter to Gravitino exception for Doris. */
+/** Exception converter to Apache Gravitino exception for Apache Doris. */
 public class DorisExceptionConverter extends JdbcExceptionConverter {
 
   // see: https://doris.apache.org/docs/admin-manual/maint-monitor/doris-error-code/

--- a/catalogs/catalog-jdbc-doris/src/main/java/com/datastrato/gravitino/catalog/doris/converter/DorisTypeConverter.java
+++ b/catalogs/catalog-jdbc-doris/src/main/java/com/datastrato/gravitino/catalog/doris/converter/DorisTypeConverter.java
@@ -22,7 +22,7 @@ import com.datastrato.gravitino.catalog.jdbc.converter.JdbcTypeConverter;
 import com.datastrato.gravitino.rel.types.Type;
 import com.datastrato.gravitino.rel.types.Types;
 
-/** Type converter for Doris. */
+/** Type converter for Apache Doris. */
 public class DorisTypeConverter extends JdbcTypeConverter {
   static final String BOOLEAN = "boolean";
   static final String TINYINT = "tinyint";

--- a/catalogs/catalog-jdbc-doris/src/main/java/com/datastrato/gravitino/catalog/doris/operation/DorisDatabaseOperations.java
+++ b/catalogs/catalog-jdbc-doris/src/main/java/com/datastrato/gravitino/catalog/doris/operation/DorisDatabaseOperations.java
@@ -36,7 +36,7 @@ import java.util.Map;
 import java.util.Set;
 import org.apache.commons.lang3.StringUtils;
 
-/** Database operations for Doris. */
+/** Database operations for Apache Doris. */
 public class DorisDatabaseOperations extends JdbcDatabaseOperations {
   public static final String COMMENT_KEY = "comment";
 

--- a/catalogs/catalog-jdbc-doris/src/main/java/com/datastrato/gravitino/catalog/doris/operation/DorisTableOperations.java
+++ b/catalogs/catalog-jdbc-doris/src/main/java/com/datastrato/gravitino/catalog/doris/operation/DorisTableOperations.java
@@ -57,7 +57,7 @@ import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 
-/** Table operations for Doris. */
+/** Table operations for Apache Doris. */
 public class DorisTableOperations extends JdbcTableOperations {
   private static final String BACK_QUOTE = "`";
   private static final String DORIS_AUTO_INCREMENT = "AUTO_INCREMENT";
@@ -468,7 +468,7 @@ public class DorisTableOperations extends JdbcTableOperations {
     if (null != updateComment) {
       String newComment = updateComment.getNewComment();
       if (null == StringIdentifier.fromComment(newComment)) {
-        // Detect and add gravitino id.
+        // Detect and add Gravitino id.
         JdbcTable jdbcTable = getOrCreateTable(databaseName, tableName, lazyLoadTable);
         StringIdentifier identifier = StringIdentifier.fromComment(jdbcTable.comment());
         if (null != identifier) {

--- a/catalogs/catalog-jdbc-doris/src/test/java/com/datastrato/gravitino/catalog/doris/integration/test/CatalogDorisIT.java
+++ b/catalogs/catalog-jdbc-doris/src/test/java/com/datastrato/gravitino/catalog/doris/integration/test/CatalogDorisIT.java
@@ -247,7 +247,7 @@ public class CatalogDorisIT extends AbstractIT {
         .createTable(
             NameIdentifier.of(schemaName, tableName),
             createColumns(),
-            "Created by gravitino client",
+            "Created by Gravitino client",
             createTableProperties(),
             Transforms.EMPTY_TRANSFORM,
             createDistribution(),

--- a/catalogs/catalog-jdbc-mysql/src/main/java/com/datastrato/gravitino/catalog/mysql/MysqlCatalog.java
+++ b/catalogs/catalog-jdbc-mysql/src/main/java/com/datastrato/gravitino/catalog/mysql/MysqlCatalog.java
@@ -35,7 +35,7 @@ import com.datastrato.gravitino.connector.PropertiesMetadata;
 import com.datastrato.gravitino.connector.capability.Capability;
 import java.util.Map;
 
-/** Implementation of a Mysql catalog in Gravitino. */
+/** Implementation of a Mysql catalog in Apache Gravitino. */
 public class MysqlCatalog extends JdbcCatalog {
 
   private static final MysqlTablePropertiesMetadata TABLE_PROPERTIES_META =

--- a/catalogs/catalog-jdbc-mysql/src/main/java/com/datastrato/gravitino/catalog/mysql/converter/MysqlExceptionConverter.java
+++ b/catalogs/catalog-jdbc-mysql/src/main/java/com/datastrato/gravitino/catalog/mysql/converter/MysqlExceptionConverter.java
@@ -26,7 +26,7 @@ import com.datastrato.gravitino.exceptions.SchemaAlreadyExistsException;
 import com.datastrato.gravitino.exceptions.TableAlreadyExistsException;
 import java.sql.SQLException;
 
-/** Exception converter to Gravitino exception for MySQL. */
+/** Exception converter to Apache Gravitino exception for MySQL. */
 public class MysqlExceptionConverter extends JdbcExceptionConverter {
 
   @SuppressWarnings("FormatStringAnnotation")

--- a/catalogs/catalog-jdbc-mysql/src/main/java/com/datastrato/gravitino/catalog/mysql/operation/MysqlTableOperations.java
+++ b/catalogs/catalog-jdbc-mysql/src/main/java/com/datastrato/gravitino/catalog/mysql/operation/MysqlTableOperations.java
@@ -373,7 +373,7 @@ public class MysqlTableOperations extends JdbcTableOperations {
     if (null != updateComment) {
       String newComment = updateComment.getNewComment();
       if (null == StringIdentifier.fromComment(newComment)) {
-        // Detect and add gravitino id.
+        // Detect and add Gravitino id.
         JdbcTable jdbcTable = getOrCreateTable(databaseName, tableName, lazyLoadTable);
         StringIdentifier identifier = StringIdentifier.fromComment(jdbcTable.comment());
         if (null != identifier) {

--- a/catalogs/catalog-jdbc-mysql/src/test/java/com/datastrato/gravitino/catalog/mysql/integration/test/CatalogMysqlIT.java
+++ b/catalogs/catalog-jdbc-mysql/src/test/java/com/datastrato/gravitino/catalog/mysql/integration/test/CatalogMysqlIT.java
@@ -826,7 +826,7 @@ public class CatalogMysqlIT extends AbstractIT {
         .createTable(
             NameIdentifier.of(schemaName, tableName),
             createColumns(),
-            "Created by gravitino client",
+            "Created by Gravitino client",
             ImmutableMap.<String, String>builder().build());
 
     // Try to drop a database, and cascade equals to false, it should not be

--- a/catalogs/catalog-jdbc-postgresql/src/main/java/com/datastrato/gravitino/catalog/postgresql/operation/PostgreSqlTableOperations.java
+++ b/catalogs/catalog-jdbc-postgresql/src/main/java/com/datastrato/gravitino/catalog/postgresql/operation/PostgreSqlTableOperations.java
@@ -453,7 +453,7 @@ public class PostgreSqlTableOperations extends JdbcTableOperations {
       TableChange.UpdateComment updateComment, JdbcTable jdbcTable) {
     String newComment = updateComment.getNewComment();
     if (null == StringIdentifier.fromComment(newComment)) {
-      // Detect and add gravitino id.
+      // Detect and add Gravitino id.
       if (StringUtils.isNotEmpty(jdbcTable.comment())) {
         StringIdentifier identifier = StringIdentifier.fromComment(jdbcTable.comment());
         if (null != identifier) {
@@ -632,7 +632,7 @@ public class PostgreSqlTableOperations extends JdbcTableOperations {
     // Append position if available
     if (!(addColumn.getPosition() instanceof TableChange.Default)) {
       throw new IllegalArgumentException(
-          "PostgreSQL does not support column position in gravitino.");
+          "PostgreSQL does not support column position in Gravitino.");
     }
     result.add(columnDefinition.append(";").toString());
 

--- a/catalogs/catalog-kafka/src/main/java/com/datastrato/gravitino/catalog/kafka/KafkaCatalog.java
+++ b/catalogs/catalog-kafka/src/main/java/com/datastrato/gravitino/catalog/kafka/KafkaCatalog.java
@@ -25,7 +25,9 @@ import com.datastrato.gravitino.connector.PropertiesMetadata;
 import com.datastrato.gravitino.connector.capability.Capability;
 import java.util.Map;
 
-/** Kafka catalog is a messaging catalog that can manage topics on the Kafka messaging system. */
+/**
+ * Kafka catalog is a messaging catalog that can manage topics on the Apache Kafka messaging system.
+ */
 public class KafkaCatalog extends BaseCatalog<KafkaCatalog> {
 
   static final KafkaCatalogPropertiesMetadata CATALOG_PROPERTIES_METADATA =

--- a/catalogs/catalog-kafka/src/main/java/com/datastrato/gravitino/catalog/kafka/KafkaCatalogOperations.java
+++ b/catalogs/catalog-kafka/src/main/java/com/datastrato/gravitino/catalog/kafka/KafkaCatalogOperations.java
@@ -142,7 +142,7 @@ public class KafkaCatalogOperations implements CatalogOperations, SupportsSchema
     adminClientConfig.putAll(bypassConfigs);
     adminClientConfig.put(
         AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, config.get(BOOTSTRAP_SERVERS));
-    // use gravitino catalog id as the admin client id
+    // use Gravitino catalog id as the admin client id
     adminClientConfig.put(
         AdminClientConfig.CLIENT_ID_CONFIG,
         String.format(CLIENT_ID_TEMPLATE, config.get(ID_KEY), info.namespace(), info.name()));

--- a/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/IcebergCatalog.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/IcebergCatalog.java
@@ -24,7 +24,7 @@ import com.datastrato.gravitino.connector.PropertiesMetadata;
 import com.datastrato.gravitino.connector.capability.Capability;
 import java.util.Map;
 
-/** Implementation of an Iceberg catalog in Gravitino. */
+/** Implementation of an Apache Iceberg catalog in Apache Gravitino. */
 public class IcebergCatalog extends BaseCatalog<IcebergCatalog> {
 
   static final IcebergCatalogPropertiesMetadata CATALOG_PROPERTIES_META =

--- a/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/IcebergCatalogOperations.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/IcebergCatalogOperations.java
@@ -71,7 +71,7 @@ import org.apache.iceberg.rest.responses.UpdateNamespacePropertiesResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** Operations for interacting with the Iceberg catalog in Gravitino. */
+/** Operations for interacting with an Apache Iceberg catalog in Apache Gravitino. */
 public class IcebergCatalogOperations implements CatalogOperations, SupportsSchemas, TableCatalog {
 
   private static final String ICEBERG_TABLE_DOES_NOT_EXIST_MSG = "Iceberg table does not exist: %s";

--- a/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/IcebergColumn.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/IcebergColumn.java
@@ -21,7 +21,7 @@ package com.datastrato.gravitino.catalog.lakehouse.iceberg;
 import com.datastrato.gravitino.connector.BaseColumn;
 import lombok.EqualsAndHashCode;
 
-/** Represents a column in the Iceberg column. */
+/** Represents a column in an Apache Iceberg column. */
 @EqualsAndHashCode(callSuper = true)
 public class IcebergColumn extends BaseColumn {
 

--- a/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/IcebergHiveCachedClientPool.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/IcebergHiveCachedClientPool.java
@@ -71,11 +71,11 @@ import org.apache.thrift.TException;
  * }
  * }</pre>
  *
- * Why do we need to do this? Because the original client pool in iceberg uses a fixed username to
- * create the client pool (please see the key in the method clientPool()). Assuming the original
- * name is A and when a new user B tries to call the clientPool() method, it will use the connection
- * that belongs to A. This will not work with kerberos authentication as it will change the user
- * name.
+ * Why do we need to do this? Because the original client pool in Apache Iceberg uses a fixed
+ * username to create the client pool (please see the key in the method clientPool()). Assuming the
+ * original name is A and when a new user B tries to call the clientPool() method, it will use the
+ * connection that belongs to A. This will not work with kerberos authentication as it will change
+ * the user name.
  */
 public class IcebergHiveCachedClientPool
     implements ClientPool<IMetaStoreClient, TException>, Closeable {

--- a/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/IcebergSchema.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/IcebergSchema.java
@@ -26,7 +26,7 @@ import org.apache.commons.collections4.MapUtils;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.rest.requests.CreateNamespaceRequest;
 
-/** Represents an Iceberg Schema (Database) entity in the Iceberg schema. */
+/** Represents an Apache Iceberg Schema (Database) entity in the Iceberg schema. */
 @ToString
 public class IcebergSchema extends BaseSchema {
 

--- a/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/IcebergTable.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/IcebergTable.java
@@ -47,7 +47,7 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.rest.requests.CreateTableRequest;
 
-/** Represents an Iceberg Table entity in the Iceberg table. */
+/** Represents an Apache Iceberg Table entity in the Iceberg table. */
 @ToString
 @Getter
 public class IcebergTable extends BaseTable {
@@ -107,7 +107,7 @@ public class IcebergTable extends BaseTable {
   }
 
   /**
-   * Transforms the gravitino distribution to the distribution mode name of the Iceberg table.
+   * Transforms the Gravitino distribution to the distribution mode name of the Iceberg table.
    *
    * @param distribution The distribution of the table.
    * @return The distribution mode name of the iceberg table.

--- a/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/IcebergTablePropertiesMetadata.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/IcebergTablePropertiesMetadata.java
@@ -69,7 +69,7 @@ public class IcebergTablePropertiesMetadata extends BasePropertiesMetadata {
                 FORMAT_VERSION, "The Iceberg table format version, ", false, null, false, false),
             stringImmutablePropertyEntry(
                 PROVIDER,
-                "Iceberg provider for Iceberg table fileFormat, such as parquet, orc, avro, iceberg",
+                "Iceberg provider for Iceberg table fileFormat, such as Parquet, Orc, Avro, or Iceberg",
                 false,
                 null,
                 false,

--- a/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/authentication/kerberos/HiveBackendProxy.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/authentication/kerberos/HiveBackendProxy.java
@@ -58,7 +58,7 @@ public class HiveBackendProxy implements MethodInterceptor {
       proxyUser = UserGroupInformation.getCurrentUser();
 
       // Replace the original client pool with IcebergHiveCachedClientPool. Why do we need to do
-      // this? Because the original client pool in iceberg uses a fixed username to create the
+      // this? Because the original client pool in Iceberg uses a fixed username to create the
       // client pool, and it will not work with kerberos authentication. We need to create a new
       // client pool with the current user. For more, please see CachedClientPool#clientPool and
       // notice the value of `key`

--- a/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/converter/ConvertUtil.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/converter/ConvertUtil.java
@@ -30,7 +30,7 @@ import org.apache.iceberg.types.Types;
 public class ConvertUtil {
 
   /**
-   * Convert the Iceberg Table to the corresponding schema information in the Iceberg.
+   * Convert an Apache Iceberg Table to the corresponding schema information in the Iceberg.
    *
    * @param gravitinoTable Gravitino table of Iceberg.
    * @return Iceberg schema.
@@ -47,7 +47,7 @@ public class ConvertUtil {
    * Convert the nested field of Iceberg to the Iceberg column.
    *
    * @param nestedField Iceberg nested field.
-   * @return Gravitino iceberg column
+   * @return Gravitino Iceberg column
    */
   public static IcebergColumn fromNestedField(Types.NestedField nestedField) {
     return IcebergColumn.builder()
@@ -59,9 +59,9 @@ public class ConvertUtil {
   }
 
   /**
-   * Convert the Gravitino iceberg table to the Gravitino StructType
+   * Convert the Gravitino Iceberg table to the Gravitino StructType
    *
-   * @param icebergTable Gravitino iceberg table
+   * @param icebergTable Gravitino Iceberg table
    * @return Gravitino StructType
    */
   private static com.datastrato.gravitino.rel.types.Types.StructType toGravitinoStructType(

--- a/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/converter/DescribeIcebergSortOrderVisitor.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/converter/DescribeIcebergSortOrderVisitor.java
@@ -23,7 +23,7 @@ import org.apache.iceberg.NullOrder;
 import org.apache.iceberg.transforms.SortOrderVisitor;
 
 /**
- * Convert expressions of Iceberg SortOrders to function string.
+ * Convert expressions of Apache Iceberg SortOrders to function string.
  *
  * <p>Referred from org/apache/iceberg/spark/Spark3Util/DescribeSortOrderVisitor.java
  */

--- a/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/converter/FromIcebergPartitionSpec.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/converter/FromIcebergPartitionSpec.java
@@ -89,7 +89,7 @@ public class FromIcebergPartitionSpec implements PartitionSpecVisitor<Transform>
   }
 
   /**
-   * Transform assembled into gravitino.
+   * Transform assembled into Gravitino.
    *
    * @param partitionSpec Iceberg partition spec.
    * @param schema Iceberg schema.

--- a/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/converter/FromIcebergSortOrder.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/converter/FromIcebergSortOrder.java
@@ -33,7 +33,7 @@ import org.apache.iceberg.SortDirection;
 import org.apache.iceberg.transforms.SortOrderVisitor;
 
 /**
- * Implement iceberg sort order converter to gravitino sort order.
+ * Implement Apache Iceberg sort order converter to Apache Gravitino sort order.
  *
  * <p>Referred from core/src/main/java/org/apache/iceberg/spark/SortOrderToSpark.java
  */

--- a/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/converter/FromIcebergType.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/converter/FromIcebergType.java
@@ -26,7 +26,7 @@ import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.types.Types;
 
 /**
- * Implement a type converter to convert types in Iceberg.
+ * Implement a type converter to convert types in Apache Iceberg.
  *
  * <p>Referred from core/src/main/java/org/apache/iceberg/spark/TypeToSparkType.java
  */

--- a/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/converter/ToIcebergPartitionSpec.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/converter/ToIcebergPartitionSpec.java
@@ -25,15 +25,15 @@ import com.google.common.base.Preconditions;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 
-/** Convert Gravitino Transforms to Iceberg PartitionSpec. */
+/** Convert Apache Gravitino Transforms to an Apache Iceberg PartitionSpec. */
 public class ToIcebergPartitionSpec {
 
   private static final String DOT = ".";
 
   /**
-   * Convert iceberg table to iceberg partition spec through gravitino.
+   * Convert Iceberg table to Iceberg partition spec through Gravitino.
    *
-   * @param icebergTable the iceberg table.
+   * @param icebergTable the Iceberg table.
    * @return a PartitionSpec
    */
   public static PartitionSpec toPartitionSpec(IcebergTable icebergTable) {
@@ -42,7 +42,7 @@ public class ToIcebergPartitionSpec {
   }
 
   /**
-   * Converts gravitino transforms into a {@link PartitionSpec}.
+   * Converts Gravitino transforms into a {@link PartitionSpec}.
    *
    * @param schema the table schema
    * @param partitioning Gravitino Transforms

--- a/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/converter/ToIcebergSortOrder.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/converter/ToIcebergSortOrder.java
@@ -34,7 +34,7 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.expressions.UnboundTerm;
 
-/** Implement gravitino sort order converter to iceberg sort order. */
+/** Implement Apache Gravitino sort order converter to Apache Iceberg sort order. */
 public class ToIcebergSortOrder {
 
   private ToIcebergSortOrder() {}

--- a/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/converter/ToIcebergType.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/converter/ToIcebergType.java
@@ -24,7 +24,7 @@ import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 
 /**
- * Convert Gravitino types to iceberg types.
+ * Convert Apache Gravitino types to Apache Iceberg types.
  *
  * <p>Referred from core/src/main/java/org/apache/iceberg/spark/SparkTypeToType.java
  */

--- a/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/converter/ToIcebergTypeVisitor.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/converter/ToIcebergTypeVisitor.java
@@ -25,7 +25,7 @@ import com.google.common.collect.Lists;
 import java.util.List;
 
 /**
- * Type converter belonging to gravitino.
+ * Type converter belonging to Apache Gravitino.
  *
  * <p>Referred from core/src/main/java/org/apache/iceberg/spark/SparkTypeVisitor.java
  */
@@ -34,7 +34,7 @@ public class ToIcebergTypeVisitor<T> {
   /**
    * Traverse the Gravitino data type and convert the fields into Iceberg fields.
    *
-   * @param type Gravitino a data type in a gravitino.
+   * @param type Gravitino a data type in a Gravitino.
    * @param visitor Visitor of Iceberg type
    * @param <T> Iceberg type
    * @return Iceberg type

--- a/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/ops/IcebergTableOpsHelper.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/ops/IcebergTableOpsHelper.java
@@ -193,7 +193,7 @@ public class IcebergTableOpsHelper {
     if (parentName != null) {
       org.apache.iceberg.types.Type parent = icebergTableSchema.findType(parentName);
       Preconditions.checkArgument(
-          parent != null, "Couldn't find parent field: " + parentName + " in iceberg table");
+          parent != null, "Couldn't find parent field: " + parentName + " in Iceberg table");
       Preconditions.checkArgument(
           parent instanceof StructType,
           "Couldn't add column to non-struct field, name:"

--- a/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/web/metrics/IcebergMetricsStore.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/web/metrics/IcebergMetricsStore.java
@@ -24,7 +24,7 @@ import java.time.Instant;
 import java.util.Map;
 import org.apache.iceberg.metrics.MetricsReport;
 
-/** A store API to save Iceberg metrics. */
+/** A store API to save Apache Iceberg metrics. */
 public interface IcebergMetricsStore {
 
   /**

--- a/catalogs/catalog-lakehouse-iceberg/src/test/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/integration/test/IcebergRESTServiceIT.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/test/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/integration/test/IcebergRESTServiceIT.java
@@ -123,7 +123,7 @@ public class IcebergRESTServiceIT extends IcebergRESTServiceBaseIT {
     String properties = databaseInfo.getOrDefault("Properties", "");
     switch (catalogType) {
       case HIVE:
-        //  hive add more properties, like:
+        //  Hive add more properties, like:
         //  ((hive.metastore.database.owner,hive), (hive.metastore.database.owner-type,USER))
         Assertions.assertTrue(properties.contains("(ID,001), (Name,John)"));
         break;

--- a/catalogs/catalog-lakehouse-paimon/src/main/java/com/datastrato/gravitino/catalog/lakehouse/paimon/GravitinoPaimonColumn.java
+++ b/catalogs/catalog-lakehouse-paimon/src/main/java/com/datastrato/gravitino/catalog/lakehouse/paimon/GravitinoPaimonColumn.java
@@ -30,7 +30,7 @@ import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.RowType;
 
-/** Implementation of {@link Column} that represents a column in the Paimon column. */
+/** Implementation of {@link Column} that represents a column in the Apache Paimon column. */
 @EqualsAndHashCode(callSuper = true)
 public class GravitinoPaimonColumn extends BaseColumn {
 

--- a/catalogs/catalog-lakehouse-paimon/src/main/java/com/datastrato/gravitino/catalog/lakehouse/paimon/GravitinoPaimonTable.java
+++ b/catalogs/catalog-lakehouse-paimon/src/main/java/com/datastrato/gravitino/catalog/lakehouse/paimon/GravitinoPaimonTable.java
@@ -31,7 +31,10 @@ import org.apache.paimon.schema.Schema;
 import org.apache.paimon.table.Table;
 import org.apache.paimon.types.DataField;
 
-/** Implementation of {@link Table} that represents a Paimon Table entity in the Paimon table. */
+/**
+ * Implementation of {@link Table} that represents an Apache Paimon Table entity in the Paimon
+ * table.
+ */
 @ToString
 @Getter
 public class GravitinoPaimonTable extends BaseTable {

--- a/catalogs/catalog-lakehouse-paimon/src/main/java/com/datastrato/gravitino/catalog/lakehouse/paimon/PaimonCatalog.java
+++ b/catalogs/catalog-lakehouse-paimon/src/main/java/com/datastrato/gravitino/catalog/lakehouse/paimon/PaimonCatalog.java
@@ -25,7 +25,9 @@ import com.datastrato.gravitino.connector.PropertiesMetadata;
 import com.datastrato.gravitino.connector.capability.Capability;
 import java.util.Map;
 
-/** Implementation of {@link Catalog} that represents a Paimon catalog in Gravitino. */
+/**
+ * Implementation of {@link Catalog} that represents an Apache Paimon catalog in Apache Gravitino.
+ */
 public class PaimonCatalog extends BaseCatalog<PaimonCatalog> {
 
   static final PaimonCatalogPropertiesMetadata CATALOG_PROPERTIES_META =

--- a/catalogs/catalog-lakehouse-paimon/src/main/java/com/datastrato/gravitino/catalog/lakehouse/paimon/PaimonCatalogBackend.java
+++ b/catalogs/catalog-lakehouse-paimon/src/main/java/com/datastrato/gravitino/catalog/lakehouse/paimon/PaimonCatalogBackend.java
@@ -18,7 +18,7 @@
  */
 package com.datastrato.gravitino.catalog.lakehouse.paimon;
 
-/** The type of Paimon catalog backend. */
+/** The type of Apache Paimon catalog backend. */
 public enum PaimonCatalogBackend {
   FILESYSTEM
 }

--- a/catalogs/catalog-lakehouse-paimon/src/main/java/com/datastrato/gravitino/catalog/lakehouse/paimon/PaimonCatalogOperations.java
+++ b/catalogs/catalog-lakehouse-paimon/src/main/java/com/datastrato/gravitino/catalog/lakehouse/paimon/PaimonCatalogOperations.java
@@ -64,7 +64,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Implementation of {@link CatalogOperations} that represents operations for interacting with the
- * Paimon catalog in Gravitino.
+ * Apache Paimon catalog in Apache Gravitino.
  */
 public class PaimonCatalogOperations implements CatalogOperations, SupportsSchemas, TableCatalog {
 

--- a/catalogs/catalog-lakehouse-paimon/src/main/java/com/datastrato/gravitino/catalog/lakehouse/paimon/PaimonSchema.java
+++ b/catalogs/catalog-lakehouse-paimon/src/main/java/com/datastrato/gravitino/catalog/lakehouse/paimon/PaimonSchema.java
@@ -27,8 +27,8 @@ import java.util.Optional;
 import lombok.ToString;
 
 /**
- * Implementation of {@link Schema} that represents a Paimon Schema (Database) entity in the Paimon
- * schema.
+ * Implementation of {@link Schema} that represents an Apache Paimon Schema (Database) entity in the
+ * Paimon schema.
  */
 @ToString
 public class PaimonSchema extends BaseSchema {

--- a/catalogs/catalog-lakehouse-paimon/src/main/java/com/datastrato/gravitino/catalog/lakehouse/paimon/PaimonSchemaPropertiesMetadata.java
+++ b/catalogs/catalog-lakehouse-paimon/src/main/java/com/datastrato/gravitino/catalog/lakehouse/paimon/PaimonSchemaPropertiesMetadata.java
@@ -29,7 +29,8 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Implementation of {@link PropertiesMetadata} that represents Paimon schema properties metadata.
+ * Implementation of {@link PropertiesMetadata} that represents Apache Paimon schema properties
+ * metadata.
  */
 public class PaimonSchemaPropertiesMetadata extends BasePropertiesMetadata {
 

--- a/catalogs/catalog-lakehouse-paimon/src/main/java/com/datastrato/gravitino/catalog/lakehouse/paimon/PaimonTablePropertiesMetadata.java
+++ b/catalogs/catalog-lakehouse-paimon/src/main/java/com/datastrato/gravitino/catalog/lakehouse/paimon/PaimonTablePropertiesMetadata.java
@@ -29,7 +29,8 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Implementation of {@link PropertiesMetadata} that represents Paimon table properties metadata.
+ * Implementation of {@link PropertiesMetadata} that represents Apache Paimon table properties
+ * metadata.
  */
 public class PaimonTablePropertiesMetadata extends BasePropertiesMetadata {
 

--- a/catalogs/catalog-lakehouse-paimon/src/main/java/com/datastrato/gravitino/catalog/lakehouse/paimon/ops/PaimonCatalogOps.java
+++ b/catalogs/catalog-lakehouse-paimon/src/main/java/com/datastrato/gravitino/catalog/lakehouse/paimon/ops/PaimonCatalogOps.java
@@ -32,7 +32,7 @@ import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.schema.Schema;
 import org.apache.paimon.table.Table;
 
-/** Table operation proxy that handles table operations of an underlying Paimon catalog. */
+/** Table operation proxy that handles table operations of an underlying Apache Paimon catalog. */
 public class PaimonCatalogOps implements AutoCloseable {
 
   protected Catalog catalog;

--- a/clients/client-java/src/main/java/com/datastrato/gravitino/client/GravitinoAdminClient.java
+++ b/clients/client-java/src/main/java/com/datastrato/gravitino/client/GravitinoAdminClient.java
@@ -58,8 +58,8 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 /**
- * Gravitino Client for the administrator to interact with the Gravitino API, allowing the client to
- * list, load, create, and alter Metalakes.
+ * Apache Gravitino Client for the administrator to interact with the Gravitino API, allowing the
+ * client to list, load, create, and alter Metalakes.
  *
  * <p>Normal users should use {@link GravitinoClient} to connect with the Gravitino server.
  */

--- a/clients/client-java/src/main/java/com/datastrato/gravitino/client/GravitinoClient.java
+++ b/clients/client-java/src/main/java/com/datastrato/gravitino/client/GravitinoClient.java
@@ -29,8 +29,8 @@ import com.google.common.base.Preconditions;
 import java.util.Map;
 
 /**
- * Gravitino Client for an user to interact with the Gravitino API, allowing the client to list,
- * load, create, and alter Catalog.
+ * Apache Gravitino Client for an user to interact with the Gravitino API, allowing the client to
+ * list, load, create, and alter Catalog.
  *
  * <p>It uses an underlying {@link RESTClient} to send HTTP requests and receive responses from the
  * API.

--- a/clients/client-java/src/main/java/com/datastrato/gravitino/client/GravitinoMetalake.java
+++ b/clients/client-java/src/main/java/com/datastrato/gravitino/client/GravitinoMetalake.java
@@ -44,9 +44,9 @@ import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 
 /**
- * Gravitino Metalake is the top-level metadata repository for users. It contains a list of catalogs
- * as sub-level metadata collections. With {@link GravitinoMetalake}, users can list, create, load,
- * alter and drop a catalog with specified identifier.
+ * Apache Gravitino Metalake is the top-level metadata repository for users. It contains a list of
+ * catalogs as sub-level metadata collections. With {@link GravitinoMetalake}, users can list,
+ * create, load, alter and drop a catalog with specified identifier.
  */
 public class GravitinoMetalake extends MetalakeDTO implements SupportsCatalogs {
   private static final String API_METALAKES_CATALOGS_PATH = "api/metalakes/%s/catalogs/%s";

--- a/clients/client-java/src/main/java/com/datastrato/gravitino/client/GravitinoVersion.java
+++ b/clients/client-java/src/main/java/com/datastrato/gravitino/client/GravitinoVersion.java
@@ -24,7 +24,7 @@ import com.google.common.annotations.VisibleForTesting;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-/** Gravitino version information. */
+/** Apache Gravitino version information. */
 public class GravitinoVersion extends VersionDTO implements Comparable {
 
   private static final int VERSION_PART_NUMBER = 3;

--- a/clients/filesystem-hadoop3/src/main/java/com/datastrato/gravitino/filesystem/hadoop/GravitinoVirtualFileSystem.java
+++ b/clients/filesystem-hadoop3/src/main/java/com/datastrato/gravitino/filesystem/hadoop/GravitinoVirtualFileSystem.java
@@ -56,8 +56,8 @@ import org.slf4j.LoggerFactory;
 /**
  * {@link GravitinoVirtualFileSystem} is a virtual file system which users can access `fileset` and
  * other resources. It obtains the actual storage location corresponding to the resource from the
- * Gravitino server, and creates an independent file system for it to act as an agent for users to
- * access the underlying storage.
+ * Apache Gravitino server, and creates an independent file system for it to act as an agent for
+ * users to access the underlying storage.
  */
 public class GravitinoVirtualFileSystem extends FileSystem {
   private static final Logger Logger = LoggerFactory.getLogger(GravitinoVirtualFileSystem.class);

--- a/core/src/main/java/com/datastrato/gravitino/Entity.java
+++ b/core/src/main/java/com/datastrato/gravitino/Entity.java
@@ -24,7 +24,7 @@ import java.util.List;
 import java.util.Map;
 import lombok.Getter;
 
-/** This interface defines an entity within the Gravitino framework. */
+/** This interface defines an entity within the Apache Gravitino framework. */
 public interface Entity extends Serializable {
 
   // The below constants are used for virtual metalakes, catalogs and schemas

--- a/core/src/main/java/com/datastrato/gravitino/EntityAlreadyExistsException.java
+++ b/core/src/main/java/com/datastrato/gravitino/EntityAlreadyExistsException.java
@@ -24,7 +24,7 @@ import com.google.errorprone.annotations.FormatString;
 
 /**
  * Exception class indicating that an entity already exists. This exception is thrown when an
- * attempt is made to create an entity that already exists within the Gravitino framework.
+ * attempt is made to create an entity that already exists within the Apache Gravitino framework.
  */
 public class EntityAlreadyExistsException extends GravitinoRuntimeException {
 

--- a/core/src/main/java/com/datastrato/gravitino/EntitySerDeFactory.java
+++ b/core/src/main/java/com/datastrato/gravitino/EntitySerDeFactory.java
@@ -27,7 +27,7 @@ import org.slf4j.LoggerFactory;
 /**
  * This class is responsible for creating instances of EntitySerDe implementations. EntitySerDe
  * (Entity Serialization/Deserialization) implementations are used to serialize and deserialize
- * entities within the Gravitino framework.
+ * entities within the Apache Gravitino framework.
  */
 public class EntitySerDeFactory {
 

--- a/core/src/main/java/com/datastrato/gravitino/EntityStoreFactory.java
+++ b/core/src/main/java/com/datastrato/gravitino/EntityStoreFactory.java
@@ -26,7 +26,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * This class is responsible for creating instances of EntityStore implementations. EntityStore
- * implementations are used to store and manage entities within the Gravitino framework.
+ * implementations are used to store and manage entities within the Apache Gravitino framework.
  */
 public class EntityStoreFactory {
 

--- a/core/src/main/java/com/datastrato/gravitino/Field.java
+++ b/core/src/main/java/com/datastrato/gravitino/Field.java
@@ -20,7 +20,7 @@ package com.datastrato.gravitino;
 
 import lombok.EqualsAndHashCode;
 
-/** This class represents a field in the Gravitino framework. */
+/** This class represents a field in the Apache Gravitino framework. */
 @EqualsAndHashCode
 public class Field {
 

--- a/core/src/main/java/com/datastrato/gravitino/GravitinoEnv.java
+++ b/core/src/main/java/com/datastrato/gravitino/GravitinoEnv.java
@@ -60,7 +60,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /*
- * This class manages the Gravitino environment.
+ * This class manages the Apache Gravitino environment.
  */
 public class GravitinoEnv {
 

--- a/core/src/main/java/com/datastrato/gravitino/authorization/AccessControlManager.java
+++ b/core/src/main/java/com/datastrato/gravitino/authorization/AccessControlManager.java
@@ -37,7 +37,7 @@ import java.util.Map;
  * AccessControlManager is used for manage users, roles, admin, grant information, this class is an
  * entrance class for tenant management. This lock policy about this is as follows: First, admin
  * operations are prevented by one lock. Then, other operations are prevented by the other lock. For
- * non-admin operations, Gravitino doesn't choose metalake level lock. There are some reasons
+ * non-admin operations, Apache Gravitino doesn't choose metalake level lock. There are some reasons
  * mainly: First, the metalake can be renamed by users. It's hard to maintain a map with metalake as
  * the key. Second, the lock will be couped with life cycle of the metalake.
  */

--- a/core/src/main/java/com/datastrato/gravitino/connector/DataTypeConverter.java
+++ b/core/src/main/java/com/datastrato/gravitino/connector/DataTypeConverter.java
@@ -21,9 +21,9 @@ package com.datastrato.gravitino.connector;
 import com.datastrato.gravitino.rel.types.Type;
 
 /**
- * The interface for converting data types between Gravitino and catalogs. In most cases, the ToType
- * and FromType are the same. But in some cases, such as converting between Gravitino and JDBC
- * types, the ToType is String and the FromType is JdbcTypeBean.
+ * The interface for converting data types between Apache Gravitino and catalogs. In most cases, the
+ * ToType and FromType are the same. But in some cases, such as converting between Gravitino and
+ * JDBC types, the ToType is String and the FromType is JdbcTypeBean.
  *
  * @param <ToType> The Gravitino type will be converted to.
  * @param <FromType> The type will be converted to Gravitino type.

--- a/core/src/main/java/com/datastrato/gravitino/meta/SchemaEntity.java
+++ b/core/src/main/java/com/datastrato/gravitino/meta/SchemaEntity.java
@@ -29,7 +29,7 @@ import java.util.Collections;
 import java.util.Map;
 import lombok.ToString;
 
-/** A class representing a schema entity in Gravitino. */
+/** A class representing a schema entity in Apache Gravitino. */
 @ToString
 public class SchemaEntity implements Entity, Auditable, HasIdentifier {
 

--- a/core/src/main/java/com/datastrato/gravitino/meta/TableEntity.java
+++ b/core/src/main/java/com/datastrato/gravitino/meta/TableEntity.java
@@ -28,7 +28,7 @@ import com.google.common.collect.Maps;
 import java.util.Map;
 import lombok.ToString;
 
-/** A class representing a table entity in Gravitino. */
+/** A class representing a table entity in Apache Gravitino. */
 @ToString
 public class TableEntity implements Entity, Auditable, HasIdentifier {
 

--- a/core/src/main/java/com/datastrato/gravitino/meta/TopicEntity.java
+++ b/core/src/main/java/com/datastrato/gravitino/meta/TopicEntity.java
@@ -29,7 +29,7 @@ import java.util.Map;
 import java.util.Objects;
 import lombok.ToString;
 
-/** A class representing a topic metadata entity in Gravitino. */
+/** A class representing a topic metadata entity in Apache Gravitino. */
 @ToString
 public class TopicEntity implements Entity, Auditable, HasIdentifier {
   public static final Field ID =

--- a/core/src/main/java/com/datastrato/gravitino/meta/UserEntity.java
+++ b/core/src/main/java/com/datastrato/gravitino/meta/UserEntity.java
@@ -31,7 +31,7 @@ import java.util.Map;
 import java.util.Objects;
 import lombok.ToString;
 
-/** A class representing a user metadata entity in Gravitino. */
+/** A class representing a user metadata entity in Apache Gravitino. */
 @ToString
 public class UserEntity implements User, Entity, Auditable, HasIdentifier {
 

--- a/core/src/main/java/com/datastrato/gravitino/metalake/MetalakeManager.java
+++ b/core/src/main/java/com/datastrato/gravitino/metalake/MetalakeManager.java
@@ -41,7 +41,7 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** Manages Metalakes within the Gravitino system. */
+/** Manages Metalakes within the Apache Gravitino system. */
 public class MetalakeManager implements MetalakeDispatcher {
 
   private static final String METALAKE_DOES_NOT_EXIST_MSG = "Metalake %s does not exist";

--- a/core/src/main/java/com/datastrato/gravitino/storage/relational/converters/H2ExceptionConverter.java
+++ b/core/src/main/java/com/datastrato/gravitino/storage/relational/converters/H2ExceptionConverter.java
@@ -24,8 +24,8 @@ import java.io.IOException;
 import java.sql.SQLException;
 
 /**
- * Exception converter to Gravitino exception for H2. The definition of error codes can be found in
- * the document: <a href="https://h2database.com/javadoc/org/h2/api/ErrorCode.html"></a>
+ * Exception converter to Apache Gravitino exception for H2. The definition of error codes can be
+ * found in the document: <a href="https://h2database.com/javadoc/org/h2/api/ErrorCode.html"></a>
  */
 public class H2ExceptionConverter implements SQLExceptionConverter {
   /** It means found a duplicated primary key or unique key entry in H2. */

--- a/core/src/main/java/com/datastrato/gravitino/storage/relational/converters/MySQLExceptionConverter.java
+++ b/core/src/main/java/com/datastrato/gravitino/storage/relational/converters/MySQLExceptionConverter.java
@@ -24,8 +24,8 @@ import java.io.IOException;
 import java.sql.SQLException;
 
 /**
- * Exception converter to Gravitino exception for MySQL. The definition of error codes can be found
- * in the document: <a
+ * Exception converter to Apache Gravitino exception for MySQL. The definition of error codes can be
+ * found in the document: <a
  * href="https://dev.mysql.com/doc/connector-j/en/connector-j-reference-error-sqlstates.html"></a>
  */
 public class MySQLExceptionConverter implements SQLExceptionConverter {

--- a/core/src/main/java/com/datastrato/gravitino/storage/relational/converters/SQLExceptionConverter.java
+++ b/core/src/main/java/com/datastrato/gravitino/storage/relational/converters/SQLExceptionConverter.java
@@ -22,7 +22,7 @@ import com.datastrato.gravitino.Entity;
 import java.io.IOException;
 import java.sql.SQLException;
 
-/** Interface for converter JDBC SQL exceptions to Gravitino exceptions. */
+/** Interface for converter JDBC SQL exceptions to Apache Gravitino exceptions. */
 public interface SQLExceptionConverter {
   /**
    * Convert JDBC exception to GravitinoException.

--- a/dev/docker/tools/README.md
+++ b/dev/docker/tools/README.md
@@ -22,4 +22,4 @@ Because Docker Desktop for Mac does not provide access to container IP from host
 This can result in host(macOS) and containers not being able to access each other's internal services directly over IPs.
 The [mac-docker-connector](https://github.com/wenjunxiao/mac-docker-connector) provides the ability for the macOS host to directly access the docker container IP.
 Before running the integration tests, make sure to execute the `dev/docker/tools/mac-docker-connector.sh` script.
-> Developing Gravitino in a linux environment does not have this limitation and does not require executing the `mac-docker-connector.sh` script ahead of time.
+> Developing Apache Gravitino in a linux environment does not have this limitation and does not require executing the `mac-docker-connector.sh` script ahead of time.

--- a/docs/apache-hive-catalog.md
+++ b/docs/apache-hive-catalog.md
@@ -8,7 +8,7 @@ license: "This software is licensed under the Apache License version 2."
 
 ## Introduction
 
-Gravitino offers the capability to utilize [Apache Hive](https://hive.apache.org) as a catalog for metadata management.
+Apache Gravitino offers the capability to utilize [Apache Hive](https://hive.apache.org) as a catalog for metadata management.
 
 ### Requirements and limitations
 

--- a/docs/docker-image-details.md
+++ b/docs/docker-image-details.md
@@ -7,9 +7,9 @@ license: "This software is licensed under the Apache License version 2."
 
 # User Docker images
 
-There are two kinds of Docker images you can use: the Gravitino Docker image and playground Docker images.
+There are two kinds of Docker images you can use: the Apache Gravitino Docker image and playground Docker images.
 
-## Gravitino Docker image
+## Apache Gravitino Docker image
 
 You can deploy the service with the Gravitino Docker image.
 
@@ -91,7 +91,7 @@ Changelog
 
 You can use these kinds of Docker images to facilitate integration testing of all catalog and connector modules within Gravitino.
 
-## Gravitino CI Apache Hive image with kerberos enabled
+## Apache Gravitino CI Apache Hive image with kerberos enabled
 
 You can use this kind of image to test the catalog of Apache Hive with kerberos enable
 
@@ -112,7 +112,7 @@ Changelog
     - Set up a Hive cluster with kerberos enabled.
     - Install a KDC server and create a principal for Hive. For more please see [kerberos-hive](../dev/docker/kerberos-hive)
 
-## Gravitino CI Apache Hive image
+## Apache Gravitino CI Apache Hive image
 
 You can use this kind of image to test the catalog of Apache Hive.
 
@@ -183,7 +183,7 @@ Changelog
     - `10000` HiveServer2
     - `10002` HiveServer2 HTTP
 
-## Gravitino CI Trino image
+## Apache Gravitino CI Trino image
 
 You can use this image to test Trino.
 
@@ -210,7 +210,7 @@ Changelog
   - Expose ports:
     - `8080` Trino JDBC port
 
-## Gravitino CI Doris image
+## Apache Gravitino CI Doris image
 
 You can use this image to test Apache Doris.
 
@@ -238,7 +238,7 @@ Changelog
     - `8030` Doris FE HTTP port
     - `9030` Doris FE MySQL server port
 
-## Gravitino CI Apache Ranger image
+## Apache Gravitino CI Apache Ranger image
 
 You can use this image to control Trino's permissions.
 

--- a/docs/docker-image-details.md
+++ b/docs/docker-image-details.md
@@ -52,7 +52,7 @@ The playground consists of multiple Docker images.
 
 The Docker images of the playground have suitable configurations for users to experience.
 
-### Hive image
+### Apache Hive image
 
 Changelog
 

--- a/docs/expression.md
+++ b/docs/expression.md
@@ -1,5 +1,5 @@
 ---
-title: "Expression system of Gravitino"
+title: "Expression system of Apache Gravitino"
 slug: /expression
 date: 2024-02-02
 keyword: expression function field literal reference
@@ -9,7 +9,7 @@ license: This software is licensed under the Apache License version 2.
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-This page introduces the expression system of Gravitino. Expressions are vital component of metadata definition, through expressions, you can define [default values](./manage-relational-metadata-using-gravitino.md#table-column-default-value) for columns, function arguments for [function partitioning](./table-partitioning-bucketing-sort-order-indexes.md#table-partitioning), [bucketing](./table-partitioning-bucketing-sort-order-indexes.md#table-bucketing), and sort term of [sort ordering](./table-partitioning-bucketing-sort-order-indexes.md#sort-ordering) in tables.
+This page introduces the expression system of Apache Gravitino. Expressions are vital component of metadata definition, through expressions, you can define [default values](./manage-relational-metadata-using-gravitino.md#table-column-default-value) for columns, function arguments for [function partitioning](./table-partitioning-bucketing-sort-order-indexes.md#table-partitioning), [bucketing](./table-partitioning-bucketing-sort-order-indexes.md#table-bucketing), and sort term of [sort ordering](./table-partitioning-bucketing-sort-order-indexes.md#sort-ordering) in tables.
 Gravitino expression system divides expressions into three basic parts: field reference, literal, and function. Function expressions can contain field references, literals, and other function expressions.
 
 ## Field reference

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,10 +1,10 @@
 ---
-title: "Getting started with Gravitino"
+title: "Getting started with Apache Gravitino"
 slug: /getting-started
 license: "This software is licensed under the Apache License version 2."
 ---
 
-There are several options for getting started with Gravitino. Installing and configuring Hive and Trino can be a little complex, so if you are unfamiliar with the technologies it would be best to use Docker.
+There are several options for getting started with Apache Gravitino. Installing and configuring Hive and Trino can be a little complex, so if you are unfamiliar with the technologies it would be best to use Docker.
 
 If you want to download and install Gravitino:
 
@@ -12,7 +12,7 @@ If you want to download and install Gravitino:
   - Google Cloud Platform, see [Getting started on Google Cloud Platform](#getting-started-on-google-cloud-platform)
   - locally, see [Getting started locally](#getting-started-locally)
 
-If you have your own Gravitino setup and want to use Apache Hive: 
+If you have your own Apache Gravitino setup and want to use Apache Hive: 
 
   - on AWS or Google Cloud Platform, see [Installing Apache Hive on AWS or Google Cloud Platform](#installing-apache-hive-on-aws-or-google-cloud-platform)
   - locally, see [Installing Apache Hive locally](#installing-apache-hive-locally)
@@ -208,7 +208,7 @@ sudo docker start gravitino-container
 
 The same steps for installing Hive on AWS or Google Cloud Platform apply when installing it locally. Follow [Installing Apache Hive on AWS or Google Cloud Platform](#installing-apache-hive-on-aws-or-google-cloud-platform).
 
-## Installing Gravitino playground on AWS or Google Cloud Platform
+## Installing Apache Gravitino playground on AWS or Google Cloud Platform
 
 Gravitino provides a bundle of Docker images to launch a Gravitino playground, which
 includes Apache Hive, Apache Hadoop, Trino, MySQL, PostgreSQL, and Gravitino. You can use
@@ -226,11 +226,11 @@ You can install and run all the programs as Docker containers by using the
 [gravitino-playground](https://github.com/datastrato/gravitino-playground). For details about
 how to run the playground, see [how-to-use-the-playground](./how-to-use-the-playground.md)
 
-## Installing Gravitino playground locally
+## Installing Apache Gravitino playground locally
 
 The same steps for installing the playground on AWS or Google Cloud Platform apply when installing it locally. Follow [Installing Gravitino playground on AWS or Google Cloud Platform](#installing-gravitino-playground-on-aws-or-google-cloud-platform).
 
-## Using REST to interact with Gravitino
+## Using REST to interact with Apache Gravitino
 
 After starting the Gravitino distribution, issue REST commands to create and modify metadata. While you are using `localhost` in these examples, run these commands remotely via a hostname or IP address once you establish correct access.
 
@@ -291,7 +291,7 @@ After starting the Gravitino distribution, issue REST commands to create and mod
 
    Note that the metastore.uris property is used for the Hive catalog and needs updating if you change your configuration.
 
-## Accessing Gravitino on AWS externally
+## Accessing Apache Gravitino on AWS externally
 
 When you deploy Gravitino on AWS, accessing it externally requires some additional configuration due to how AWS networking works.
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -168,15 +168,15 @@ license: "This software is licensed under the Apache License version 2."
 
 - The port number on which a server listens for incoming connections.
 
-## Iceberg Hive catalog
+## Apache Iceberg Hive catalog
 
 - The **Iceberg Hive catalog** is a specialized metadata service designed for the Apache Iceberg table format, allowing external systems to interact with Iceberg metadata via a Hive metastore thrift client.
 
-## Iceberg REST catalog
+## Apache Iceberg REST catalog
 
 - The **Iceberg REST Catalog** is a specialized metadata service designed for the Apache Iceberg table format, allowing external systems to interact with Iceberg metadata via a RESTful API.
 
-## Iceberg JDBC catalog
+## Apache Iceberg JDBC catalog
 
 - The **Iceberg JDBC Catalog** is a specialized metadata service designed for the Apache Iceberg table format, allowing external systems to interact with Iceberg metadata using JDBC (Java Database Connectivity).
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,5 +1,5 @@
 ---
-title: "Gravitino Glossary"
+title: "Apache Gravitino Glossary"
 date: 2023-11-28
 license: "This software is licensed under the Apache License version 2."
 ---
@@ -144,11 +144,11 @@ license: "This software is licensed under the Apache License version 2."
 
 - A Gradle wrapper script, used for executing Gradle commands without installing Gradle separately.
 
-## Gravitino
+## Apache Gravitino
 
 - An open-source software platform created by Datastrato for high-performance, geo-distributed, and federated metadata lakes. Designed to manage metadata directly in different sources, types, and regions, providing unified metadata access for data and AI assets.
 
-## Gravitino configuration file (gravitino.conf)
+## Apache Gravitino configuration file (gravitino.conf)
 
 - The configuration file for the Gravitino server, located in the `conf` directory. It follows the standard property file format and contains settings for the Gravitino server.
 
@@ -364,7 +364,7 @@ license: "This software is licensed under the Apache License version 2."
 
 - A connector module for integrating Gravitino with Trino.
 
-## Trino Gravitino connector documentation
+## Trino Apache Gravitino connector documentation
 
 -  Documentation providing information on using the Trino connector to access metadata in Gravitino.
 

--- a/docs/gravitino-server-config.md
+++ b/docs/gravitino-server-config.md
@@ -1,5 +1,5 @@
 ---
-title: Gravitino configuration
+title: Apache Gravitino configuration
 slug: /gravitino-server-config
 keywords:
   - configuration
@@ -8,20 +8,20 @@ license: "This software is licensed under the Apache License version 2."
 
 ## Introduction
 
-Gravitino supports several configurations:
+Apache Gravitino supports several configurations:
 
 1. **Gravitino server configuration**: Used to start up the Gravitino server.
 2. **Gravitino catalog properties configuration**: Used to make default values for different catalogs.
 3. **Some other configurations**: Includes HDFS and other configurations.
 
-## Gravitino server configurations
+## Apache Gravitino server configurations
 
 You can customize the Gravitino server by editing the configuration file `gravitino.conf` in the `conf` directory. The default values are sufficient for most use cases.
 We strongly recommend that you read the following sections to understand the configuration file so you can change the default values to suit your specific situation and usage scenario.
 
 The `gravitino.conf` file lists the configuration items in the following table. It groups those items into the following categories:
 
-### Gravitino HTTP Server configuration
+### Apache Gravitino HTTP Server configuration
 
 | Configuration item                                    | Description                                                                                                                                                                           | Default value                                                                | Required | Since version |
 |-------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------|----------|---------------|
@@ -138,7 +138,7 @@ Refer to [security](security.md) for HTTPS and authentication configurations.
 |-------------------------------------------|------------------------------------------------------|---------------|----------|---------------|
 | `gravitino.metrics.timeSlidingWindowSecs` | The seconds of Gravitino metrics time sliding window | 60            | No       | 0.5.1         |
 
-## Gravitino catalog properties configuration
+## Apache Gravitino catalog properties configuration
 
 There are three types of catalog properties:
 

--- a/docs/hadoop-catalog.md
+++ b/docs/hadoop-catalog.md
@@ -12,7 +12,7 @@ Hadoop catalog is a fileset catalog that using Hadoop Compatible File System (HC
 the storage location of the fileset. Currently, it supports local filesystem and HDFS. For
 object storage like S3, GCS, and Azure Blob Storage, you can put the hadoop object store jar like
 hadoop-aws into the `$GRAVITINO_HOME/catalogs/hadoop/libs` directory to enable the support.
-Gravitino itself hasn't yet tested the object storage support, so if you have any issue,
+Apache Gravitino itself hasn't yet tested the object storage support, so if you have any issue,
 please create an [issue](https://github.com/datastrato/gravitino/issues).
 
 Note that Gravitino uses Hadoop 3 dependencies to build Hadoop catalog. Theoretically, it should be

--- a/docs/how-to-build.md
+++ b/docs/how-to-build.md
@@ -1,12 +1,12 @@
 ---
-title: How to build Gravitino
+title: How to build Apache Gravitino
 slug: /how-to-build
 license: "This software is licensed under the Apache License version 2."
 ---
 
 - [Prerequisites](#prerequisites)
 - [Quick start](#quick-start)
-- [How to Build Gravitino on Windows (Using WSL)](#how-to-build-gravitino-on-windows-using-wsl)
+- [How to Build Apache Gravitino on Windows (Using WSL)](#how-to-build-gravitino-on-windows-using-wsl)
 
 ## Prerequisites
 
@@ -165,7 +165,7 @@ If you want to contribute to this open-source project, please fork the project o
    `gravitino-trino-connector-{version}.tar.gz.sha256` under the `distribution` directory. You 
    can uncompress and deploy it to Trino to use the Gravitino Trino connector.
 
-## How to Build Gravitino on Windows (Using WSL)
+## How to Build Apache Gravitino on Windows (Using WSL)
 
 ### Download WSL (Ubuntu)
 
@@ -243,7 +243,7 @@ python3.11 --version
 
 These commands add a repository that provides the latest Python versions and then installs Python 3.11.
 
-### Download Gravitino Project to WSL
+### Download Apache Gravitino Project to WSL
 
 **On Ubuntu (WSL):**
 

--- a/docs/how-to-install.md
+++ b/docs/how-to-install.md
@@ -1,18 +1,18 @@
 ---
-title: How to install Gravitino
+title: How to install Apache Gravitino
 slug: /how-to-install
 license: "This software is licensed under the Apache License version 2."
 ---
 
-## Install Gravitino from scratch
+## Install Apache Gravitino from scratch
 
 :::note
-Gravitino supports running on Java 8, 11, and 17. Make sure you have Java installed and
+Apache Gravitino supports running on Java 8, 11, and 17. Make sure you have Java installed and
 `JAVA_HOME` configured correctly. To confirm the Java version, run the
 `${JAVA_HOME}/bin/java -version` command.
 :::
 
-### Get the Gravitino binary distribution package
+### Get the Apache Gravitino binary distribution package
 
 Before installing Gravitino, make sure you have the Gravitino binary distribution package. You can
 download the latest Gravitino binary distribution package from [GitHub](https://github.com/datastrato/gravitino/releases),
@@ -51,24 +51,24 @@ The Gravitino binary distribution package contains the following files:
 If you want to use the relational backend storage, you need to initialize the RDBMS firstly. For
 the details on how to initialize the RDBMS, please check [How to use relational backend storage](./how-to-use-relational-backend-storage.md).
 
-#### Configure the Gravitino server
+#### Configure the Apache Gravitino server
 
 The Gravitino server configuration file is `conf/gravitino.conf`. You can configure the Gravitino
 server by modifying this file. Basic configurations are already added to this file. All the
 configurations are listed in [Gravitino Server Configurations](./gravitino-server-config.md).
 
-#### Configure the Gravitino server log
+#### Configure the Apache Gravitino server log
 
 The Gravitino server log configuration file is `conf/log4j2.properties`. Gravitino uses Log4j2 as
 the Logging system. You can [Log4j2](https://logging.apache.org/log4j/2.x/) to
 do the log configuration.
 
-#### Configure the Gravitino server environment
+#### Configure the Apache Gravitino server environment
 
 The Gravitino server environment configuration file is `conf/gravitino-env.sh`. Gravitino exposes
 several environment variables. You can modify them in this file.
 
-#### Configure Gravitino catalogs
+#### Configure Apache Gravitino catalogs
 
 Gravitino supports multiple catalogs. You can configure the catalog-level configurations by
 modifying the related configuration file in the `catalogs/<catalog-provider>/conf` directory. The
@@ -96,7 +96,7 @@ Also, Gravitino supports loading catalog specific configurations from external f
 you can put your own `hive-site.xml` file in the `catalogs/hive/conf` directory, and Gravitino loads
 it automatically.
 
-#### Start Gravitino server
+#### Start Apache Gravitino server
 
 After configuring the Gravitino server, start the Gravitino server on daemon by running:
 
@@ -125,9 +125,9 @@ variable in the `conf/gravitino-env.sh` file. Then create a `Remote JVM Debug`
 configuration in `IntelliJ IDEA` and debug `gravitino.server.main`.
 :::
 
-## Install Gravitino using Docker
+## Install Apache Gravitino using Docker
 
-### Get the Gravitino Docker image
+### Get the Apache Gravitino Docker image
 
 Gravitino publishes the Docker image to [Docker Hub](https://hub.docker.com/r/datastrato/gravitino/tags).
 Run the Gravitino Docker image by running:
@@ -145,7 +145,7 @@ curl -v -X GET -H "Accept: application/vnd.gravitino.v1+json" -H "Content-Type: 
 
 to make sure Gravitino is running.
 
-## Install Gravitino using Docker compose
+## Install Apache Gravitino using Docker compose
 
 The published Gravitino Docker image only contains the Gravitino server with basic configurations. If
 you want to experience the whole Gravitino system with other components, use the Docker

--- a/docs/how-to-sign-releases.md
+++ b/docs/how-to-sign-releases.md
@@ -4,7 +4,7 @@ slug: /how-to-sign-releases
 license: "This software is licensed under the Apache License version 2."
 ---
 
-These instructions provide a guide to signing and verifying Gravitino releases to enhance the security of releases. A signed release enables people to confirm the author of the release and guarantees that the code hasn't been altered.
+These instructions provide a guide to signing and verifying Apache Gravitino releases to enhance the security of releases. A signed release enables people to confirm the author of the release and guarantees that the code hasn't been altered.
 
 ## Prerequisites
 

--- a/docs/how-to-test.md
+++ b/docs/how-to-test.md
@@ -1,10 +1,10 @@
 ---
-title: How to test Gravitino
+title: How to test Apache Gravitino
 slug: /how-to-test
 license: "This software is licensed under the Apache License version 2."
 ---
 
-Gravitino has two types of tests:
+Apache Gravitino has two types of tests:
 
   - Unit tests, focus on the functionalities of the specific class, module, or component.
   - Integration tests, end-to-end tests that cover the whole system.
@@ -54,7 +54,7 @@ Gravitino has two modes to run the integration tests, the default `embedded` mod
 Running the `./gradlew build` command triggers the build and runs the integration tests in embedded mode.
 :::
 
-### Deploy the Gravitino server and run the integration tests in deploy mode
+### Deploy the Apache Gravitino server and run the integration tests in deploy mode
 
 To deploy the Gravitino server locally to run the integration tests, follow these steps:
 
@@ -125,13 +125,13 @@ Using Gravitino IT Docker container to run all integration tests. [deploy test]
 Complete integration tests only run when all the required environments are met. Otherwise,
 only parts of them without the `gravitino-docker-test` tag run.
 
-## How to debug Gravitino server and integration tests in embedded mode
+## How to debug Apache Gravitino server and integration tests in embedded mode
 
 By default, the integration tests run in the embedded mode, in which `MiniGravitino` starts in the
 same process. Debugging `MiniGravitino` is simple and easy, you can modify any code in the
 Gravitino project and set breakpoints anywhere.
 
-## How to debug Gravitino server and integration tests in deploy mode
+## How to debug Apache Gravitino server and integration tests in deploy mode
 
 This mode is closer to the actual environment, but more complex to debug. To debug the Gravitino server code, follow these steps:
 

--- a/docs/how-to-use-gvfs.md
+++ b/docs/how-to-use-gvfs.md
@@ -1,12 +1,12 @@
 ---
-title: How to use Gravitino Virtual File System with Filesets
+title: How to use Apache Gravitino Virtual File System with Filesets
 slug: /how-to-use-gvfs
 license: "This software is licensed under the Apache License version 2."
 ---
 
 ## Introduction
 
-`Fileset` is a concept brought in by Gravitino, which is a logical collection of files and
+`Fileset` is a concept brought in by Apache Gravitino, which is a logical collection of files and
 directories, with `fileset` you can manage non-tabular data through Gravitino. For
 details, you can read [How to manage fileset metadata using Gravitino](./manage-fileset-metadata-using-gravitino.md).
 
@@ -94,7 +94,7 @@ You can configure these properties in two ways:
       </property>
     ```
 
-## How to use the Gravitino Virtual File System
+## How to use the Apache Gravitino Virtual File System
 
 First make sure to obtain the Gravitino Virtual File System runtime jar, which you can get in
 two ways:

--- a/docs/how-to-use-python-client.md
+++ b/docs/how-to-use-python-client.md
@@ -1,5 +1,5 @@
 ---
-title: "How to use Gravitino Python client"
+title: "How to use Apache Gravitino Python client"
 slug: /how-to-use-gravitino-python-client
 date: 2024-05-09
 keyword: Gravitino Python client
@@ -7,7 +7,7 @@ license: This software is licensed under the Apache License version 2.
 ---
 ## Introduction
 
-Gravitino is a high-performance, geo-distributed, and federated metadata lake.
+Apache Gravitino is a high-performance, geo-distributed, and federated metadata lake.
 It manages the metadata directly in different sources, types, and regions, also provides users
 the unified metadata access for data and AI assets.
 
@@ -23,7 +23,7 @@ First of all, You must have a Gravitino server set up and run, You can refer doc
 [How to install Gravitino](./how-to-install.md) to build Gravitino server from source code and
 install it in your local.
 
-### Gravitino Python client API
+### Apache Gravitino Python client API
 
 ```shell
 pip install gravitino
@@ -32,7 +32,7 @@ pip install gravitino
 1. [Manage metalake using Gravitino Python API](./manage-metalake-using-gravitino.md?language=python)
 2. [Manage fileset metadata using Gravitino Python API](./manage-fileset-metadata-using-gravitino.md?language=python)
 
-### Gravitino Fileset Example
+### Apache Gravitino Fileset Example
 
 We offer a playground environment to help you quickly understand how to use Gravitino Python
 client to manage non-tabular data on HDFS via Fileset in Gravitino. You can refer to the
@@ -63,7 +63,7 @@ contains the following code snippets:
 11. Drop this `Fileset.Type.EXTERNAL` type fileset and check if the fileset location was
     not deleted in HDFS.
 
-## How to development Gravitino Python Client
+## How to development Apache Gravitino Python Client
 
 You can ues any IDE to develop Gravitino Python Client. Directly open the client-python module project in the IDE.
 

--- a/docs/how-to-use-relational-backend-storage.md
+++ b/docs/how-to-use-relational-backend-storage.md
@@ -6,7 +6,7 @@ license: "This software is licensed under the Apache License version 2."
 
 ## Introduction
 
-Before the version `0.5.0`, Gravitino only supports KV backend storage to store metadata. Since
+Before the version `0.5.0`, Apache Gravitino only supports KV backend storage to store metadata. Since
 RDBMS is widely used in the industry, starting from the version `0.5.0`, Gravitino supports using
 RDBMS as relational backend storage to store metadata. This doc will guide you on how to use the
 relational backend storage in Gravitino.
@@ -61,7 +61,7 @@ Then please place it in the distribution package directory:
 ${GRAVITINO_HOME}/libs/
 ```
 
-### Step 4: Set up the Gravitino server configs
+### Step 4: Set up the Apache Gravitino server configs
 
 Find the server configuration file which name is `gravitino.conf` in the distribution package directory:
 

--- a/docs/how-to-use-the-playground.md
+++ b/docs/how-to-use-the-playground.md
@@ -184,7 +184,7 @@ WHERE e.employee_id = p.employee_id AND p.employee_id = s.employee_id
 GROUP BY e.employee_id,  given_name, family_name;
 ```
 
-### Using Iceberg REST service
+### Using Apache Iceberg REST service
 
 If you want to migrate your business from Hive to Iceberg. Some tables will use Hive, and the other tables will use Iceberg.
 Gravitino provides an Iceberg REST catalog service, too. You can use Spark to access REST catalog to write the table data.

--- a/docs/how-to-use-the-playground.md
+++ b/docs/how-to-use-the-playground.md
@@ -7,7 +7,7 @@ license: "This software is licensed under the Apache License version 2."
 
 ## Playground introduction
 
-The playground is a complete Gravitino Docker runtime environment with `Hive`, `HDFS`, `Trino`, `MySQL`, `PostgreSQL`, `Jupyter`, and a `Gravitino` server.
+The playground is a complete Apache Gravitino Docker runtime environment with `Hive`, `HDFS`, `Trino`, `MySQL`, `PostgreSQL`, `Jupyter`, and a `Gravitino` server.
 
 Depending on your network and computer, startup time may take 3-5 minutes. Once the playground environment has started, you can open [http://localhost:8090](http://localhost:8090) in a browser to access the Gravitino Web UI.
 
@@ -66,7 +66,7 @@ cd gravitino-playground
 ./launch-playground.sh hive|gravitino|trino|postgresql|mysql|spark|jupyter
 ```
 
-### Experiencing Gravitino Fileset with Jupyter
+### Experiencing Apache Gravitino Fileset with Jupyter
 
 We provide a Fileset playground environment to help you quickly understand how to use Gravitino
 Python client to manage non-tabular data on HDFS via fileset in Gravitino service.
@@ -97,7 +97,7 @@ contains the following code snippets:
 11. Drop this `Fileset.Type.EXTERNAL` type fileset and check if the fileset location was
     not deleted in HDFS.
 
-## Experiencing Gravitino with Trino SQL
+## Experiencing Apache Gravitino with Trino SQL
 
 1. Log in to the Gravitino playground Trino Docker container using the following command:
 

--- a/docs/iceberg-rest-service.md
+++ b/docs/iceberg-rest-service.md
@@ -58,7 +58,7 @@ Please refer to the following sections for details.
 The filter in `customFilters` should be a standard javax servlet filter.
 You can also specify filter parameters by setting configuration entries in the style `gravitino.auxService.iceberg-rest.<class name of filter>.param.<param name>=<value>`.
 
-### Iceberg metrics store configuration
+### Apache Iceberg metrics store configuration
 
 Gravitino provides a pluggable metrics store interface to store and delete Iceberg metrics. You can develop a class that implements `com.datastrato.gravitino.catalog.lakehouse.iceberg.web.metrics` and add the corresponding jar file to the Iceberg REST service classpath directory.
 
@@ -77,7 +77,7 @@ The Gravitino Iceberg REST catalog service uses the memory catalog backend by de
 specify a Hive or JDBC catalog backend for production environment.
 :::
 
-#### Hive backend configuration
+#### Apache Hive backend configuration
 
 | Configuration item                                       | Description                                                                                                                                  | Default value                                                                 | Required | Since Version |
 |----------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------|----------|---------------|

--- a/docs/iceberg-rest-service.md
+++ b/docs/iceberg-rest-service.md
@@ -8,7 +8,7 @@ license: "This software is licensed under the Apache License version 2."
 
 ## Background
 
-The Gravitino Iceberg REST Server follows the [Apache Iceberg REST API specification](https://github.com/apache/iceberg/blob/main/open-api/rest-catalog-open-api.yaml) and acts as an Iceberg REST catalog server.
+The Apache Gravitino Iceberg REST Server follows the [Apache Iceberg REST API specification](https://github.com/apache/iceberg/blob/main/open-api/rest-catalog-open-api.yaml) and acts as an Iceberg REST catalog server.
 
 ### Capabilities
 
@@ -23,7 +23,7 @@ Builds with Apache Iceberg `1.3.1`. The Apache Iceberg table format version is `
 Builds with Hadoop 2.10.x. There may be compatibility issues when accessing Hadoop 3.x clusters.
 :::
 
-## Gravitino Iceberg REST catalog service configuration
+## Apache Gravitino Iceberg REST catalog service configuration
 
 Assuming the Gravitino server is deployed in the `GRAVITINO_HOME` directory, you can locate the configuration options in [`$GRAVITINO_HOME/conf/gravitino.conf`](gravitino-server-config.md). There are four configuration properties for the Iceberg REST catalog service:
 
@@ -70,7 +70,7 @@ Gravitino provides a pluggable metrics store interface to store and delete Icebe
 | `gravitino.auxService.iceberg-rest.metricsQueueCapacity`   | The size of queue to store metrics temporally before storing to the persistent storage. Metrics will be dropped when queue is full. | 1000          | No       | 0.4.0         |
 
 
-### Gravitino Iceberg catalog backend configuration
+### Apache Gravitino Iceberg catalog backend configuration
 
 :::info
 The Gravitino Iceberg REST catalog service uses the memory catalog backend by default. You can 
@@ -123,7 +123,7 @@ The `clients` property for example:
 
 The Gravitino Iceberg REST catalog service adds the HDFS configuration files `core-site.xml` and `hdfs-site.xml` from the directory defined by `gravitino.auxService.iceberg-rest.classpath`, for example, `catalogs/lakehouse-iceberg/conf`, to the classpath.
 
-## Starting the Gravitino Iceberg REST catalog service
+## Starting the Apache Gravitino Iceberg REST catalog service
 
 To start the service:
 
@@ -139,7 +139,7 @@ curl  http://127.0.0.1:9001/iceberg/v1/config
 
 Normally you will see the output like `{"defaults":{},"overrides":{}}%`.
 
-## Exploring the Gravitino and Apache Iceberg REST catalog service with Apache Spark
+## Exploring the Apache Gravitino and Apache Iceberg REST catalog service with Apache Spark
 
 ### Deploying Apache Spark with Apache Iceberg support
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,12 +1,12 @@
 ---
-title: Gravitino overview
+title: Apache Gravitino overview
 slug: /
 license: "This software is licensed under the Apache License version 2."
 ---
 
-## What's Gravitino?
+## What's Apache Gravitino?
 
-Gravitino is a high-performance, geo-distributed, and federated metadata lake. It manages the
+Apache Gravitino is a high-performance, geo-distributed, and federated metadata lake. It manages the
 metadata directly in different sources, types, and regions. It also provides users with unified
 metadata access for data and AI assets.
 
@@ -43,7 +43,7 @@ To get started with Gravitino, see [Getting started](./getting-started.md) for t
 * [Running on Google Cloud Platform](./getting-started.md#getting-started-on-google-cloud-platform):
   a quick guide to starting and using Gravitino on GCP.
 
-## How to use Gravitino
+## How to use Apache Gravitino
 
 Gravitino provides two SDKs to manage metadata from different catalogs in a unified way: the
 REST API and the Java SDK. You can use either to manage metadata. See
@@ -84,7 +84,7 @@ Gravitino currently supports the following catalogs:
 Gravitino also provides an Iceberg REST catalog service for the Iceberg table format. See the
 [Iceberg REST catalog service](./iceberg-rest-service.md) for details.
 
-## Gravitino playground
+## Apache Gravitino playground
 
 To experience Gravitino with other components easily, Gravitino provides a playground to run. It
 integrates Apache Hadoop, Apache Hive, Trino, MySQL, PostgreSQL, and Gravitino together as a

--- a/docs/jdbc-doris-catalog.md
+++ b/docs/jdbc-doris-catalog.md
@@ -13,7 +13,7 @@ import TabItem from '@theme/TabItem';
 
 ## Introduction
 
-Gravitino provides the ability to manage [Apache Doris](https://doris.apache.org/) metadata through JDBC connection..
+Apache Gravitino provides the ability to manage [Apache Doris](https://doris.apache.org/) metadata through JDBC connection..
 
 :::caution
 Gravitino saves some system information in schema and table comments, like

--- a/docs/jdbc-mysql-catalog.md
+++ b/docs/jdbc-mysql-catalog.md
@@ -13,7 +13,7 @@ import TabItem from '@theme/TabItem';
 
 ## Introduction
 
-Gravitino provides the ability to manage MySQL metadata.
+Apache Gravitino provides the ability to manage MySQL metadata.
 
 :::caution
 Gravitino saves some system information in schema and table comment, like `(From Gravitino, DO NOT EDIT: gravitino.v1.uid1078334182909406185)`, please don't change or remove this message.

--- a/docs/jdbc-postgresql-catalog.md
+++ b/docs/jdbc-postgresql-catalog.md
@@ -13,7 +13,7 @@ import TabItem from '@theme/TabItem';
 
 ## Introduction
 
-Gravitino provides the ability to manage PostgreSQL metadata.
+Apache Gravitino provides the ability to manage PostgreSQL metadata.
 
 :::caution
 Gravitino saves some system information in schema and table comment, like `(From Gravitino, DO NOT EDIT: gravitino.v1.uid1078334182909406185)`, please don't change or remove this message.

--- a/docs/lakehouse-iceberg-catalog.md
+++ b/docs/lakehouse-iceberg-catalog.md
@@ -13,7 +13,7 @@ import TabItem from '@theme/TabItem';
 
 ## Introduction
 
-Gravitino provides the ability to manage Apache Iceberg metadata.
+Apache Gravitino provides the ability to manage Apache Iceberg metadata.
 
 ### Requirements and limitations
 

--- a/docs/manage-fileset-metadata-using-gravitino.md
+++ b/docs/manage-fileset-metadata-using-gravitino.md
@@ -9,7 +9,7 @@ license: This software is licensed under the Apache License version 2.
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-This page introduces how to manage fileset metadata in Gravitino. Filesets 
+This page introduces how to manage fileset metadata in Apache Gravitino. Filesets 
 are a collection of files and directories. Users can leverage
 filesets to manage non-tabular data like training datasets and other raw data.
 

--- a/docs/manage-messaging-metadata-using-gravitino.md
+++ b/docs/manage-messaging-metadata-using-gravitino.md
@@ -1,5 +1,5 @@
 ---
-title: "Manage massaging metadata using Gravitino"
+title: "Manage massaging metadata using Apache Gravitino"
 slug: /manage-massaging-metadata-using-gravitino
 date: 2024-4-22
 keyword: Gravitino massaging metadata manage
@@ -9,7 +9,7 @@ license: This software is licensed under the Apache License version 2.
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-This page introduces how to manage messaging metadata using Gravitino. Messaging metadata refers to 
+This page introduces how to manage messaging metadata using Apache Gravitino. Messaging metadata refers to 
 the topic metadata of the messaging system such as Apache Kafka, Apache Pulsar, Apache RocketMQ, etc.
 Through Gravitino, you can create, update, delete, and list topics via unified RESTful APIs or Java client.
 

--- a/docs/manage-metalake-using-gravitino.md
+++ b/docs/manage-metalake-using-gravitino.md
@@ -1,5 +1,5 @@
 ---
-title: "Manage metalake using Gravitino"
+title: "Manage metalake using Apache Gravitino"
 slug: /manage-metalake-using-gravitino
 date: 2023-12-10
 keyword: Gravitino metalake manage
@@ -9,7 +9,7 @@ license: This software is licensed under the Apache License version 2.
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-This page introduces how to manage metalake by Gravitino. Metalake is a tenant-like concept in
+This page introduces how to manage metalake by Apache Gravitino. Metalake is a tenant-like concept in
 Gravitino, all the catalogs, users and roles are under a metalake. Typically, a metalake is
 mapping to a organization or a company.
 

--- a/docs/manage-relational-metadata-using-gravitino.md
+++ b/docs/manage-relational-metadata-using-gravitino.md
@@ -1,5 +1,5 @@
 ---
-title: "Manage relational metadata using Gravitino"
+title: "Manage relational metadata using Apache Gravitino"
 slug: /manage-relational-metadata-using-gravitino
 date: 2023-12-10
 keyword: Gravitino relational metadata manage
@@ -9,7 +9,7 @@ license: This software is licensed under the Apache License version 2.
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-This page introduces how to manage relational metadata by Gravitino, relational metadata refers
+This page introduces how to manage relational metadata by Apache Gravitino, relational metadata refers
 to relational catalog, schema, table and partitions. Through Gravitino, you can create, edit, and
 delete relational metadata via unified REST APIs or Java client.
 
@@ -692,7 +692,7 @@ In order to create a table, you need to provide the following information:
 - Table column auto-increment (optional)
 - Table property (optional)
 
-#### Gravitino table column type
+#### Apache Gravitino table column type
 
 The following types that Gravitino supports:
 

--- a/docs/manage-table-partition-using-gravitino.md
+++ b/docs/manage-table-partition-using-gravitino.md
@@ -1,5 +1,5 @@
 ---
-title: "Manage table partition using Gravitino"
+title: "Manage table partition using Apache Gravitino"
 slug: /manage-table-partition-using-gravitino
 date: 2024-02-03
 keyword: table partition management
@@ -11,7 +11,7 @@ import TabItem from '@theme/TabItem';
 
 ## Introduction
 
-Although many catalogs inherently manage partitions automatically, there are scenarios where manual partition management is necessary. Usage scenarios like managing the TTL (Time-To-Live) of partition data, gathering statistics on partition metadata, and optimizing queries through partition pruning. For these reasons, Gravitino provides capabilities of partition management.
+Although many catalogs inherently manage partitions automatically, there are scenarios where manual partition management is necessary. Usage scenarios like managing the TTL (Time-To-Live) of partition data, gathering statistics on partition metadata, and optimizing queries through partition pruning. For these reasons, Apache Gravitino provides capabilities of partition management.
 
 ### Requirements and limitations
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,5 +1,5 @@
 ---
-title: Gravitino metrics
+title: Apache Gravitino metrics
 slug: /metrics
 keywords:
   - metrics
@@ -8,7 +8,7 @@ license: "This software is licensed under the Apache License version 2."
 
 ## Introduction
 
-Gravitino Metrics builds upon the [Dropwizard Metrics](https://metrics.dropwizard.io/). It exports these metrics through both JMX and an HTTP server, supporting JSON and Prometheus formats. You can retrieve them via HTTP requests, as illustrated below:
+Apache Gravitino Metrics builds upon the [Dropwizard Metrics](https://metrics.dropwizard.io/). It exports these metrics through both JMX and an HTTP server, supporting JSON and Prometheus formats. You can retrieve them via HTTP requests, as illustrated below:
 
 ```shell
 // Use Gravitino Server address or Iceberg REST server address to replace 127.0.0.1:8090

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -6,7 +6,7 @@ license: "This software is licensed under the Apache License version 2."
 
 ## Introduction
 
-Gravitino is a high-performance, geo-distributed, and federated metadata lake. It manages the
+Apache Gravitino is a high-performance, geo-distributed, and federated metadata lake. It manages the
 metadata directly in different sources, types, and regions. It also provides users with unified metadata access for data and AI assets.
 
 ![Gravitino Architecture](assets/gravitino-architecture.png)
@@ -70,7 +70,7 @@ assets like models, features, and others are under development.
 
 ## Terminology
 
-### The model of Gravitino
+### The model of Apache Gravitino
 
 ![Gravitino Model](assets/metadata-model.png)
 

--- a/docs/publish-docker-images.md
+++ b/docs/publish-docker-images.md
@@ -8,7 +8,7 @@ license: "This software is licensed under the Apache License version 2."
 
 ## Introduction
 
-The Gravitino project provides a set of Docker images to facilitate the publishing, development, and testing of the Gravitino project.
+The Apache Gravitino project provides a set of Docker images to facilitate the publishing, development, and testing of the Gravitino project.
 [Datastrato Docker Hub](https://hub.docker.com/u/datastrato) repository publishes the official Gravitino Docker images.
 
 ## Publish Docker images to Docker Hub
@@ -30,6 +30,6 @@ You can use GitHub actions to publish Docker images to the Docker Hub repository
 
 ![Publish Docker image](assets/publish-docker-image.png)
 
-## More details of Gravitino Docker images
+## More details of Apache Gravitino Docker images
 
 + [Gravitino Docker images](docker-image-details.md)

--- a/docs/security.md
+++ b/docs/security.md
@@ -7,7 +7,7 @@ license: "This software is licensed under the Apache License version 2."
 
 ## Authentication
 
-Gravitino supports two kinds of authentication mechanisms: simple and OAuth.
+Apache Gravitino supports two kinds of authentication mechanisms: simple and OAuth.
 
 ### Simple mode
 
@@ -183,7 +183,7 @@ If users choose to enable HTTPS, Gravitino won't provide the ability of HTTP ser
 
 Both the Gravitino server and Iceberg REST service can configure HTTPS.
 
-### Gravitino server's configuration
+### Apache Gravitino server's configuration
 
 | Configuration item                                  | Description                                                        | Default value | Required                                          | Since version |
 |-----------------------------------------------------|--------------------------------------------------------------------|---------------|---------------------------------------------------|---------------|

--- a/docs/security.md
+++ b/docs/security.md
@@ -200,7 +200,7 @@ Both the Gravitino server and Iceberg REST service can configure HTTPS.
 | `gravitino.server.webserver.trustStorePassword`     | Password to the trust store.                                       | (none)        | Yes if use HTTPS and the authentication of client | 0.3.0         |
 | `gravitino.server.webserver.trustStoreType`         | The type to the trust store.                                       | `JKS`         | No                                                | 0.3.0         |
 
-### Iceberg REST service's configuration
+### Apache Iceberg REST service's configuration
 
 | Configuration item                                         | Description                                                        | Default value | Required                                          | Since version |
 |------------------------------------------------------------|--------------------------------------------------------------------|---------------|---------------------------------------------------|---------------|
@@ -309,7 +309,7 @@ curl -v -X GET --cacert ./certificate.pem -H "Accept: application/vnd.gravitino.
 | `gravitino.server.webserver.exposedHeaders`        | A comma separated list of allowed HTTP headers exposed on the client. The default value is the empty list.                                                                                                                             | ``                                            | No       | 0.4.0         |
 | `gravitino.server.webserver.chainPreflight`        | If true chained preflight requests for normal handling (as an OPTION request). Otherwise, the filter responds to the preflight. The default is true.                                                                                   | `true`                                        | No       | 0.4.0         |
 
-### Iceberg REST service's configuration
+### Apache Iceberg REST service's configuration
 
 | Configuration item                                        | Description                                                                                                                                                                                                  | Default value                                 | Required | Since version |
 |-----------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------|----------|---------------|

--- a/docs/spark-connector/spark-catalog-hive.md
+++ b/docs/spark-connector/spark-catalog-hive.md
@@ -5,7 +5,7 @@ keyword: spark connector hive catalog
 license: "This software is licensed under the Apache License version 2."
 ---
 
-With the Gravitino Spark connector, accessing data or managing metadata in Hive catalogs becomes straightforward, enabling seamless federation queries across different Hive catalogs.
+With the Apache Gravitino Spark connector, accessing data or managing metadata in Hive catalogs becomes straightforward, enabling seamless federation queries across different Hive catalogs.
 
 ## Capabilities
 

--- a/docs/spark-connector/spark-catalog-iceberg.md
+++ b/docs/spark-connector/spark-catalog-iceberg.md
@@ -95,7 +95,7 @@ DESC EXTENDED employee;
 
 For more details about `CALL`, please refer to the [Spark Procedures description](https://iceberg.apache.org/docs/latest/spark-procedures/#spark-procedures) in Iceberg official document. 
 
-## Iceberg backend-catalog support
+## Apache Iceberg backend-catalog support
 - HiveCatalog
 - JdbcCatalog
 - RESTCatalog

--- a/docs/spark-connector/spark-catalog-iceberg.md
+++ b/docs/spark-connector/spark-catalog-iceberg.md
@@ -5,7 +5,7 @@ keyword: spark connector iceberg catalog
 license: "This software is licensed under the Apache License version 2."
 ---
 
-The Gravitino Spark connector offers the capability to read and write Iceberg tables, with the metadata managed by the Gravitino server. To enable the use of the Iceberg catalog within the Spark connector, you must set the configuration `spark.sql.gravitino.enableIcebergSupport` to `true` and download Iceberg Spark runtime jar to Spark classpath.
+The Apache Gravitino Spark connector offers the capability to read and write Iceberg tables, with the metadata managed by the Gravitino server. To enable the use of the Iceberg catalog within the Spark connector, you must set the configuration `spark.sql.gravitino.enableIcebergSupport` to `true` and download Iceberg Spark runtime jar to Spark classpath.
 
 ## Capabilities
 

--- a/docs/spark-connector/spark-connector.md
+++ b/docs/spark-connector/spark-connector.md
@@ -1,5 +1,5 @@
 ---
-title: "Gravitino Spark connector"
+title: "Apache Gravitino Spark connector"
 slug: /spark-connector/spark-connector
 keyword: spark connector federation query 
 license: "This software is licensed under the Apache License version 2."
@@ -7,7 +7,7 @@ license: "This software is licensed under the Apache License version 2."
 
 ## Overview
 
-The Gravitino Spark connector leverages the Spark DataSourceV2 interface to facilitate the management of diverse catalogs under Gravitino. This capability allows users to perform federation queries, accessing data from various catalogs through a unified interface and consistent access control.
+The Apache Gravitino Spark connector leverages the Spark DataSourceV2 interface to facilitate the management of diverse catalogs under Gravitino. This capability allows users to perform federation queries, accessing data from various catalogs through a unified interface and consistent access control.
 
 ## Capabilities
 

--- a/docs/trino-connector/catalog-hive.md
+++ b/docs/trino-connector/catalog-hive.md
@@ -1,5 +1,5 @@
 ---
-title: "Gravitino connector - Hive catalog"
+title: "Apache Gravitino connector - Hive catalog"
 slug: /trino-connector/catalog-hive
 keyword: gravitino connector trino
 license: "This software is licensed under the Apache License version 2."
@@ -40,7 +40,7 @@ per catalog:
 
 ### Create a schema 
 
-Users can create a schema with properties through Gravitino Trino connector as follows:
+Users can create a schema with properties through Apache Gravitino Trino connector as follows:
 
 ```SQL
 CREATE SCHEMA catalog.schema_name 

--- a/docs/trino-connector/catalog-iceberg.md
+++ b/docs/trino-connector/catalog-iceberg.md
@@ -1,5 +1,5 @@
 ---
-title: "Gravitino connector - Iceberg catalog"
+title: "Apache Gravitino connector - Iceberg catalog"
 slug: /trino-connector/catalog-iceberg
 keyword: gravitino connector trino
 license: "This software is licensed under the Apache License version 2."
@@ -22,7 +22,7 @@ To use Iceberg, you need:
 
 ### Create a schema
 
-Users can create a schema through Gravitino Trino connector as follows:
+Users can create a schema through Apache Gravitino Trino connector as follows:
 
 ```SQL
 CREATE SCHEMA "metalake.catalog".schema_name 

--- a/docs/trino-connector/catalog-mysql.md
+++ b/docs/trino-connector/catalog-mysql.md
@@ -1,5 +1,5 @@
 ---
-title: "Gravitino connector - MySQL catalog"
+title: "Apache Gravitino connector - MySQL catalog"
 slug: /trino-connector/catalog-mysql
 keyword: gravitino connector trino
 license: "This software is licensed under the Apache License version 2."
@@ -16,7 +16,7 @@ To connect to MySQL, you need:
 
 ## Create table
 
-At present, the Gravitino connector only supports basic MySQL table creation statements, which involve fields, null allowances, and comments. 
+At present, the Apache Gravitino connector only supports basic MySQL table creation statements, which involve fields, null allowances, and comments. 
 However, it does not support advanced features like primary keys, indexes, default values, and auto-increment.
 
 The Gravitino connector does not support `CREATE TABLE AS SELECT`.

--- a/docs/trino-connector/catalog-postgresql.md
+++ b/docs/trino-connector/catalog-postgresql.md
@@ -1,5 +1,5 @@
 ---
-title: "Gravitino connector - PostgreSQL catalog"
+title: "Apache Gravitino connector - PostgreSQL catalog"
 slug: /trino-connector/catalog-postgresql
 keyword: gravitino connector trino
 license: "This software is licensed under the Apache License version 2."
@@ -16,7 +16,7 @@ To connect to PostgreSQL, you need:
 
 ## Create table
 
-At present, the Gravitino connector only supports basic PostgreSQL table creation statements, which involve fields, null allowances, and comments. 
+At present, the Apache Gravitino connector only supports basic PostgreSQL table creation statements, which involve fields, null allowances, and comments. 
 However, it does not support advanced features like primary keys, indexes, default values, and auto-increment.
 
 The Gravitino connector does not support `CREATE TABLE AS SELECT`.

--- a/docs/trino-connector/configuration.md
+++ b/docs/trino-connector/configuration.md
@@ -1,5 +1,5 @@
 ---
-title: "Gravitino connector Configuration"
+title: "Apache Gravitino connector Configuration"
 slug: /trino-connector/configuration
 keyword: gravitino connector trino
 license: "This software is licensed under the Apache License version 2."

--- a/docs/trino-connector/development.md
+++ b/docs/trino-connector/development.md
@@ -1,11 +1,11 @@
 ---
-title: "Gravitino connector development"
+title: "Apache Gravitino connector development"
 slug: /trino-connector/development
 keyword: gravitino connector development 
 license: "This software is licensed under the Apache License version 2."
 ---
 
-This document is to guide users through the development of the Gravitino connector for Trino locally.
+This document is to guide users through the development of the Apache Gravitino connector for Trino locally.
 
 ## Prerequisites
 

--- a/docs/trino-connector/index.md
+++ b/docs/trino-connector/index.md
@@ -1,11 +1,11 @@
 ---
-title: "Gravitino connector index"
+title: "Apache Gravitino connector index"
 slug: /trino-connector/index
 keyword: gravitino connector trino
 license: "This software is licensed under the Apache License version 2."
 ---
 
-Gravitino connector index:
+Apache Gravitino connector index:
 
 - [Trino Support](trino-connector.md)
   - [Requirements](requirements.md)

--- a/docs/trino-connector/installation.md
+++ b/docs/trino-connector/installation.md
@@ -1,11 +1,11 @@
 ---
-title: "Gravitino connector installation"
+title: "Apache Gravitino connector installation"
 slug: /trino-connector/installation
 keyword: gravitino connector trino
 license: "This software is licensed under the Apache License version 2."
 ---
 
-To install the Gravitino connector, you should first deploy the Trino environment, and then install the Gravitino connector plugin into Trino.
+To install the Apache Gravitino connector, you should first deploy the Trino environment, and then install the Gravitino connector plugin into Trino.
 Please refer to the [Deploying Trino documentation](https://trino.io/docs/current/installation/deployment.html) and do the following steps:
 
 1. [Download](https://github.com/datastrato/gravitino/releases) the Gravitino connector tarball and unpack it.
@@ -46,7 +46,7 @@ docker run --name trino-gravitino -d -p 8080:8080 trinodb/trino:435
 Run `docker ps` to check whether the container is running.
 
 
-### Installing the Gravitino connector
+### Installing the Apache Gravitino connector
 
 Download the Gravitino connector tarball and unpack it.
 
@@ -86,7 +86,7 @@ discovery.uri=http://localhost:8080
 catalog.management=dynamic
 ```
 
-### Configuring the Gravitino connector
+### Configuring the Apache Gravitino connector
 
 Assuming you have now started the Gravitino server on the host `gravitino-server-host` and already created a metalake named `test`, if those have not been prepared, please refer to the [Gravitino getting started](../getting-started.md).
 
@@ -104,7 +104,7 @@ gravitino.simplify-catalog-names=true
 - The `gravitino.uri` defines the connection information about Gravitino server. Make sure your container can access the Gravitino server.
 - The `gravitino.simplify-catalog-names` setting omits the metalake prefix from catalog names when set to true. 
 
-Full configurations for Gravitino connector can be seen [here](configuration.md)
+Full configurations for Apache Gravitino connector can be seen [here](configuration.md)
 
 If you haven't created the metalake named `test`, you can use the following command to create it.
 
@@ -118,7 +118,7 @@ And then restart the Trino container to load the Gravitino connector.
 docker restart trino-gravitino
 ```
 
-### Verifying the Gravitino connector
+### Verifying the Apache Gravitino connector
 
 Use the Trino CLI to connect to the Trino container and run a query.
 

--- a/docs/trino-connector/requirements.md
+++ b/docs/trino-connector/requirements.md
@@ -1,11 +1,11 @@
 ---
-title: "Gravitino connector requirements"
+title: "Apache Gravitino connector requirements"
 slug: /trino-connector/requirements
 keyword: gravitino connector trino
 license: "This software is licensed under the Apache License version 2."
 ---
 
-To install and deploy the Gravitino connector, The following environmental setup is necessary:
+To install and deploy the Apache Gravitino connector, The following environmental setup is necessary:
 
 - Trino server version should be at least Trino-server-435.
   Other versions of Trino have not undergone thorough testing.

--- a/docs/trino-connector/sql-support.md
+++ b/docs/trino-connector/sql-support.md
@@ -1,11 +1,11 @@
 ---
-title: "Gravitino connector SQL support"
+title: "Apache Gravitino connector SQL support"
 slug: /trino-connector/sql-support
 keyword: gravitino connector trino
 license: "This software is licensed under the Apache License version 2."
 ---
 
-The connector provides read access and write access to data and metadata stored in Gravitino.
+The connector provides read access and write access to data and metadata stored in Apache Gravitino.
 
 ### Globally available statements
 

--- a/docs/trino-connector/supported-catalog.md
+++ b/docs/trino-connector/supported-catalog.md
@@ -1,11 +1,11 @@
 ---
-title: "Gravitino supported Catalogs"
+title: "Apache Gravitino supported Catalogs"
 slug: /trino-connector/supported-catalog
 keyword: gravitino connector trino
 license: "This software is licensed under the Apache License version 2."
 ---
 
-The catalogs currently supported by the Gravitino connector are as follows:
+The catalogs currently supported by the Apache Gravitino connector are as follows:
 
 - [Hive](catalog-hive.md)
 - [Iceberg](catalog-iceberg.md)
@@ -145,7 +145,7 @@ More trino connector configurations can refer to:
 - [MySQL catalog](https://trino.io/docs/current/connector/mysql.html#general-configuration-properties)
 - [PostgreSQL catalog](https://trino.io/docs/current/connector/postgresql.html#general-configuration-properties)
 
-## Data type mapping between Trino and Gravitino
+## Data type mapping between Trino and Apache Gravitino
 
 Gravitino connector supports the following data type conversions between Trino and Gravitino currently. Depending on the detailed catalog, Gravitino may not support some data types conversion for this specific catalog, for example,
 Hive does not support `TIME` data type.

--- a/docs/trino-connector/trino-connector.md
+++ b/docs/trino-connector/trino-connector.md
@@ -1,11 +1,11 @@
 ---
-title: "Gravitino connector"
+title: "Apache Gravitino connector"
 slug: /trino-connector/trino-connector
 keyword: gravitino connector trino
 license: "This software is licensed under the Apache License version 2."
 ---
 
-Trino can manage and access data using the Trino connector provided by `Gravitino`, commonly referred to as the `Gravitino connector`.
+Trino can manage and access data using the Trino connector provided by `Apache Gravitino`, commonly referred to as the `Gravitino connector`.
 After configuring the Gravitino connector in Trino, Trino can automatically load catalog metadata from Gravitino, allowing users to directly access these catalogs in Trino.
 Once integrated with Gravitino, Trino can operate on all Gravitino data without requiring additional configuration. 
 The Gravitino connector uses the [Trino dynamic catalog managed mechanism](https://trino.io/docs/current/admin/properties-catalog.html) to load catalogs.

--- a/docs/webui.md
+++ b/docs/webui.md
@@ -1,5 +1,5 @@
 ---
-title: 'Gravitino web UI'
+title: 'Apache Gravitino web UI'
 slug: /webui
 keyword: webui
 last_update:
@@ -8,7 +8,7 @@ last_update:
 license: 'This software is licensed under the Apache License version 2.'
 ---
 
-This document primarily outlines how users can manage metadata within Gravitino using the web UI, the graphical interface is accessible through a web browser as an alternative to writing code or using the REST interface.
+This document primarily outlines how users can manage metadata within Apache Gravitino using the web UI, the graphical interface is accessible through a web browser as an alternative to writing code or using the REST interface.
 
 Currently, you can integrate [OAuth settings](./security.md) to view, add, modify, and delete metalakes, create catalogs, and view catalogs, schemas, and tables, among other functions.
 

--- a/flink-connector/src/main/java/com/datastrato/gravitino/flink/connector/PropertiesConverter.java
+++ b/flink-connector/src/main/java/com/datastrato/gravitino/flink/connector/PropertiesConverter.java
@@ -23,7 +23,7 @@ import java.util.Map;
 import org.apache.flink.configuration.Configuration;
 
 /**
- * PropertiesConverter is used to convert properties between Flink properties and Gravitino
+ * PropertiesConverter is used to convert properties between Flink properties and Apache Gravitino
  * properties
  */
 public interface PropertiesConverter {

--- a/flink-connector/src/main/java/com/datastrato/gravitino/flink/connector/catalog/GravitinoCatalogManager.java
+++ b/flink-connector/src/main/java/com/datastrato/gravitino/flink/connector/catalog/GravitinoCatalogManager.java
@@ -29,7 +29,7 @@ import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** GravitinoCatalogManager is used to retrieve catalogs from Gravitino server. */
+/** GravitinoCatalogManager is used to retrieve catalogs from Apache Gravitino server. */
 public class GravitinoCatalogManager {
   private static final Logger LOG = LoggerFactory.getLogger(GravitinoCatalogManager.class);
   private static GravitinoCatalogManager gravitinoCatalogManager;

--- a/flink-connector/src/main/java/com/datastrato/gravitino/flink/connector/store/GravitinoCatalogStore.java
+++ b/flink-connector/src/main/java/com/datastrato/gravitino/flink/connector/store/GravitinoCatalogStore.java
@@ -36,7 +36,7 @@ import org.apache.flink.util.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** GravitinoCatalogStore is used to store catalog information to Gravitino server. */
+/** GravitinoCatalogStore is used to store catalog information to Apache Gravitino server. */
 public class GravitinoCatalogStore extends AbstractCatalogStore {
   private static final Logger LOG = LoggerFactory.getLogger(GravitinoCatalogStore.class);
   private final GravitinoCatalogManager gravitinoCatalogManager;

--- a/flink-connector/src/test/java/com/datastrato/gravitino/flink/connector/integration/test/hive/FlinkHiveCatalogIT.java
+++ b/flink-connector/src/test/java/com/datastrato/gravitino/flink/connector/integration/test/hive/FlinkHiveCatalogIT.java
@@ -252,7 +252,7 @@ public class FlinkHiveCatalogIT extends FlinkCommonIT {
     Assertions.assertEquals(
         numCatalogs + 1, tableEnv.listCatalogs().length, "Should create a new catalog");
 
-    // get the catalog from gravitino.
+    // get the catalog from Gravitino.
     Optional<Catalog> flinkHiveCatalog = tableEnv.getCatalog(catalogName);
     Assertions.assertTrue(flinkHiveCatalog.isPresent());
     Assertions.assertInstanceOf(GravitinoHiveCatalog.class, flinkHiveCatalog.get());

--- a/integration-test-common/src/test/java/com/datastrato/gravitino/integration/test/MiniGravitino.java
+++ b/integration-test-common/src/test/java/com/datastrato/gravitino/integration/test/MiniGravitino.java
@@ -53,8 +53,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * MiniGravitino is a mini Gravitino server for integration tests. It starts a Gravitino server in
- * the same JVM process.
+ * MiniGravitino is a mini Apache Gravitino server for integration tests. It starts a Gravitino
+ * server in the same JVM process.
  */
 public class MiniGravitino {
   private static final Logger LOG = LoggerFactory.getLogger(MiniGravitino.class);
@@ -76,7 +76,7 @@ public class MiniGravitino {
   }
 
   private void removeIcebergRestConfiguration(Properties properties) {
-    // Disable iceberg rest service
+    // Disable Iceberg REST service
     properties.remove(
         AuxiliaryServiceManager.GRAVITINO_AUX_SERVICE_PREFIX
             + AuxiliaryServiceManager.AUX_SERVICE_NAMES);

--- a/integration-test-common/src/test/java/com/datastrato/gravitino/integration/test/container/HiveContainer.java
+++ b/integration-test-common/src/test/java/com/datastrato/gravitino/integration/test/container/HiveContainer.java
@@ -89,7 +89,7 @@ public class HiveContainer extends BaseContainer {
   private void copyHiveLog() {
     try {
       String destPath = System.getenv("IT_PROJECT_DIR");
-      LOG.info("Copy hive log file to {}", destPath);
+      LOG.info("Copy Hive log file to {}", destPath);
 
       String hiveLogJarPath = "/hive.tar";
       String HdfsLogJarPath = "/hdfs.tar";
@@ -101,7 +101,7 @@ public class HiveContainer extends BaseContainer {
       container.copyFileFromContainer(hiveLogJarPath, destPath + File.separator + "hive.tar");
       container.copyFileFromContainer(HdfsLogJarPath, destPath + File.separator + "hdfs.tar");
     } catch (Exception e) {
-      LOG.warn("Can't copy hive log for:", e);
+      LOG.warn("Can't copy Hive log for:", e);
     }
   }
 

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/trino/TrinoConnectorIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/trino/TrinoConnectorIT.java
@@ -94,7 +94,7 @@ public class TrinoConnectorIT extends AbstractIT {
 
     containerSuite.startHiveContainer();
 
-    // Initial hive client
+    // Initial Hive client
     HiveConf hiveConf = new HiveConf();
     String hiveMetastoreUris =
         String.format(
@@ -103,7 +103,7 @@ public class TrinoConnectorIT extends AbstractIT {
             HiveContainer.HIVE_METASTORE_PORT);
     hiveConf.set(HiveConf.ConfVars.METASTOREURIS.varname, hiveMetastoreUris);
 
-    // Currently must first create metalake and catalog then start trino container
+    // Currently must first create metalake and catalog then start Trino container
     createMetalake();
     createCatalog();
 
@@ -835,7 +835,7 @@ public class TrinoConnectorIT extends AbstractIT {
       Assertions.fail("Trino fail to load catalogs created by gravitino: " + sql);
     }
 
-    // Because we assign 'hive.target-max-file-size' a wrong value, trino can't load the catalog
+    // Because we assign 'hive.target-max-file-size' a wrong value, Trino can't load the catalog
     String data = containerSuite.getTrinoContainer().executeQuerySQL(sql).get(0).get(0);
     Assertions.assertEquals(catalogName, data);
   }
@@ -875,7 +875,7 @@ public class TrinoConnectorIT extends AbstractIT {
     String sql = String.format("show catalogs like '%s'", catalogName);
     await().atLeast(6, TimeUnit.SECONDS);
 
-    // Because we assign 'hive.target-max-file-size' a wrong value, trino can't load the catalog
+    // Because we assign 'hive.target-max-file-size' a wrong value, Trino can't load the catalog
     Assertions.assertTrue(containerSuite.getTrinoContainer().executeQuerySQL(sql).isEmpty());
   }
 
@@ -941,11 +941,11 @@ public class TrinoConnectorIT extends AbstractIT {
 
     boolean success = checkTrinoHasLoaded(sql, 30);
     if (!success) {
-      Assertions.fail("Trino fail to load table created by gravitino: " + sql);
+      Assertions.fail("Trino fail to load table created by Gravitino: " + sql);
     }
 
     String data = containerSuite.getTrinoContainer().executeQuerySQL(sql).get(0).get(0);
-    LOG.info("create iceberg hive table sql is: {}", data);
+    LOG.info("create Iceberg Hive table SQL is: {}", data);
     // Iceberg does not contain any properties;
     Assertions.assertFalse(data.contains("key1"));
     Assertions.assertTrue(data.contains("partitioning = ARRAY['BinaryType']"));
@@ -1041,7 +1041,7 @@ public class TrinoConnectorIT extends AbstractIT {
     Assertions.assertTrue(checkTrinoHasLoaded(sql, 30));
 
     final String sql1 = String.format("drop schema %s.%s cascade", catalogName, schemaName);
-    // Will fail because the iceberg catalog does not support cascade drop
+    // Will fail because the Iceberg catalog does not support cascade drop
     TrinoContainer trinoContainer = containerSuite.getTrinoContainer();
     Assertions.assertThrows(
         RuntimeException.class,

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/trino/TrinoQueryITBase.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/trino/TrinoQueryITBase.java
@@ -45,10 +45,10 @@ import org.testcontainers.shaded.org.apache.commons.io.FileUtils;
 public class TrinoQueryITBase {
   private static final Logger LOG = LoggerFactory.getLogger(TrinoQueryITBase.class);
 
-  // Auto start docker containers and gravitino server
+  // Auto start docker containers and Gravitino server
   protected static boolean autoStart = true;
 
-  // Auto start gravitino server
+  // Auto start Gravitino server
   protected static boolean autoStartGravitino = true;
 
   protected static boolean started = false;

--- a/rfc/rfc-1/rfc-1.md
+++ b/rfc/rfc-1/rfc-1.md
@@ -48,7 +48,7 @@
 
 ### Schema Entities
 
-The schema system in Gravitino is organized like below:
+The schema system in Apache Gravitino is organized like below:
 
 ![Schema System](schema-overview.png)
 

--- a/rfc/rfc-3/Transaction-implementation-on-kv.md
+++ b/rfc/rfc-3/Transaction-implementation-on-kv.md
@@ -23,11 +23,9 @@
 | :------- |-------|------------|
 | v0.1     | Qi Yu | 21/11/2023 |
 
-
-
 ## Background
-Currently, our storage layer heavily relies on the transaction mechanism provided by key-value storage backend such as RocksDB to ensure reliability. However, some key-value pair databases do not support transaction operations, making it challenging for Gravitino to adapt to other
-KV databases such as Redis, Cassandra, Hbase, and so on.
+
+Currently, our storage layer heavily relies on the transaction mechanism provided by key-value storage backend such as RocksDB to ensure reliability. However, some key-value pair databases do not support transaction operations, making it challenging for Apache Gravitino to adapt to other KV databases such as Redis, Cassandra, Hbase, and so on.
 
 To make gravitino adapt different key-value stores, we need to eliminate transactional dependency and come up with alternative solutions.
 

--- a/server/src/main/java/com/datastrato/gravitino/server/web/filter/AccessControlNotAllowedFilter.java
+++ b/server/src/main/java/com/datastrato/gravitino/server/web/filter/AccessControlNotAllowedFilter.java
@@ -31,7 +31,7 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.Provider;
 
 /**
- * AccessControlNotAllowedFilter is used for filter the requests related to access control if
+ * AccessControlNotAllowedFilter is used for filter the requests related to access control if Apache
  * Gravitino doesn't enable authorization. The filter return 405 error code. You can refer to
  * https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/405. No methods will be returned in the
  * allow methods.

--- a/server/src/main/java/com/datastrato/gravitino/server/web/ui/WebUIFilter.java
+++ b/server/src/main/java/com/datastrato/gravitino/server/web/ui/WebUIFilter.java
@@ -27,7 +27,7 @@ import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 
-// This filter is used to serve static HTML files from the Gravitino WEB UI.
+// This filter is used to serve static HTML files from the Apache Gravitino WEB UI.
 // https://nextjs.org/docs/pages/building-your-application/deploying/static-exports#deploying
 public class WebUIFilter implements Filter {
   @Override

--- a/spark-connector/spark-common/src/main/java/com/datastrato/gravitino/spark/connector/PropertiesConverter.java
+++ b/spark-connector/spark-common/src/main/java/com/datastrato/gravitino/spark/connector/PropertiesConverter.java
@@ -23,7 +23,7 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.spark.sql.util.CaseInsensitiveStringMap;
 
-/** Interface for transforming properties between Gravitino and Spark. */
+/** Interface for transforming properties between Apache Gravitino and Apache Spark. */
 public interface PropertiesConverter {
   @VisibleForTesting String SPARK_PROPERTY_PREFIX = "spark.bypass.";
 

--- a/spark-connector/spark-common/src/main/java/com/datastrato/gravitino/spark/connector/SparkTypeConverter.java
+++ b/spark-connector/spark-common/src/main/java/com/datastrato/gravitino/spark/connector/SparkTypeConverter.java
@@ -46,7 +46,7 @@ import org.apache.spark.sql.types.StructType;
 import org.apache.spark.sql.types.TimestampType;
 import org.apache.spark.sql.types.VarcharType;
 
-/** Transform DataTypes between Gravitino and Spark. */
+/** Transform DataTypes between Apache Gravitino and Apache Spark. */
 public class SparkTypeConverter {
   public Type toGravitinoType(DataType sparkType) {
     if (sparkType instanceof ByteType) {

--- a/spark-connector/spark-common/src/main/java/com/datastrato/gravitino/spark/connector/catalog/BaseCatalog.java
+++ b/spark-connector/spark-common/src/main/java/com/datastrato/gravitino/spark/connector/catalog/BaseCatalog.java
@@ -56,7 +56,7 @@ import org.apache.spark.sql.types.StructType;
 import org.apache.spark.sql.util.CaseInsensitiveStringMap;
 
 /**
- * BaseCatalog acts as the foundational class for Spark CatalogManager registration, enabling
+ * BaseCatalog acts as the foundational class for Apache Spark CatalogManager registration, enabling
  * seamless integration of various data source catalogs within Spark's ecosystem. This class is
  * pivotal in bridging Spark with diverse data sources, ensuring a unified approach to data
  * management and manipulation across the platform.

--- a/spark-connector/spark-common/src/main/java/com/datastrato/gravitino/spark/connector/catalog/GravitinoCatalogManager.java
+++ b/spark-connector/spark-common/src/main/java/com/datastrato/gravitino/spark/connector/catalog/GravitinoCatalogManager.java
@@ -30,7 +30,7 @@ import java.util.concurrent.ExecutionException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** GravitinoCatalogManager is used to retrieve catalogs from Gravitino server. */
+/** GravitinoCatalogManager is used to retrieve catalogs from Apache Gravitino server. */
 public class GravitinoCatalogManager {
   private static final Logger LOG = LoggerFactory.getLogger(GravitinoCatalogManager.class);
   private static GravitinoCatalogManager gravitinoCatalogManager;

--- a/spark-connector/spark-common/src/main/java/com/datastrato/gravitino/spark/connector/hive/HivePropertiesConverter.java
+++ b/spark-connector/spark-common/src/main/java/com/datastrato/gravitino/spark/connector/hive/HivePropertiesConverter.java
@@ -32,7 +32,7 @@ import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.spark.sql.connector.catalog.TableCatalog;
 
-/** Transform hive catalog properties between Spark and Gravitino. */
+/** Transform Apache Hive catalog properties between Apache Spark and Apache Gravitino. */
 public class HivePropertiesConverter implements PropertiesConverter {
   public static class HivePropertiesConverterHolder {
     private static final HivePropertiesConverter INSTANCE = new HivePropertiesConverter();
@@ -44,7 +44,7 @@ public class HivePropertiesConverter implements PropertiesConverter {
     return HivePropertiesConverterHolder.INSTANCE;
   }
 
-  // Transform Spark hive file format to Gravitino hive file format
+  // Transform Spark Hive file format to Gravitino hive file format
   static final Map<String, String> fileFormatMap =
       ImmutableMap.of(
           "sequencefile", HivePropertiesConstants.GRAVITINO_HIVE_FORMAT_SEQUENCEFILE,
@@ -81,7 +81,7 @@ public class HivePropertiesConverter implements PropertiesConverter {
         StringUtils.isNotBlank(metastoreUri),
         "Couldn't get "
             + GravitinoSparkConfig.GRAVITINO_HIVE_METASTORE_URI
-            + " from hive catalog properties");
+            + " from Hive catalog properties");
     HashMap<String, String> all = new HashMap<>();
     all.put(GravitinoSparkConfig.SPARK_HIVE_METASTORE_URI, metastoreUri);
     return all;

--- a/spark-connector/spark-common/src/main/java/com/datastrato/gravitino/spark/connector/iceberg/GravitinoIcebergCatalog.java
+++ b/spark-connector/spark-common/src/main/java/com/datastrato/gravitino/spark/connector/iceberg/GravitinoIcebergCatalog.java
@@ -45,9 +45,9 @@ import org.apache.spark.sql.connector.iceberg.catalog.ProcedureCatalog;
 import org.apache.spark.sql.util.CaseInsensitiveStringMap;
 
 /**
- * The GravitinoIcebergCatalog class extends the BaseCatalog to integrate with the Iceberg table
- * format, providing specialized support for Iceberg-specific functionalities within Spark's
- * ecosystem. This implementation can further adapt to specific interfaces such as
+ * The GravitinoIcebergCatalog class extends the BaseCatalog to integrate with the Apache Iceberg
+ * table format, providing specialized support for Iceberg-specific functionalities within Apache
+ * Spark's ecosystem. This implementation can further adapt to specific interfaces such as
  * StagingTableCatalog and FunctionCatalog, allowing for advanced operations like table staging and
  * function management tailored to the needs of Iceberg tables.
  */

--- a/spark-connector/spark-common/src/main/java/com/datastrato/gravitino/spark/connector/iceberg/IcebergPropertiesConverter.java
+++ b/spark-connector/spark-common/src/main/java/com/datastrato/gravitino/spark/connector/iceberg/IcebergPropertiesConverter.java
@@ -25,7 +25,7 @@ import java.util.Locale;
 import java.util.Map;
 import org.apache.commons.lang3.StringUtils;
 
-/** Transform Iceberg catalog properties between Spark and Gravitino. */
+/** Transform Apache Iceberg catalog properties between Apache Spark and Apache Gravitino. */
 public class IcebergPropertiesConverter implements PropertiesConverter {
 
   public static class IcebergPropertiesConverterHolder {

--- a/spark-connector/spark-common/src/main/java/com/datastrato/gravitino/spark/connector/iceberg/SparkIcebergTable.java
+++ b/spark-connector/spark-common/src/main/java/com/datastrato/gravitino/spark/connector/iceberg/SparkIcebergTable.java
@@ -34,7 +34,7 @@ import org.apache.spark.sql.types.StructType;
 import org.apache.spark.sql.util.CaseInsensitiveStringMap;
 
 /**
- * For spark-connector in Iceberg, it explicitly uses SparkTable to identify whether it is an
+ * For spark-connector in Iceberg, it explicitly uses SparkTable to identify whether it is an Apache
  * Iceberg table, so the SparkIcebergTable must extend SparkTable.
  */
 public class SparkIcebergTable extends SparkTable {

--- a/spark-connector/spark-common/src/main/java/com/datastrato/gravitino/spark/connector/plugin/GravitinoDriverPlugin.java
+++ b/spark-connector/spark-common/src/main/java/com/datastrato/gravitino/spark/connector/plugin/GravitinoDriverPlugin.java
@@ -44,8 +44,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * GravitinoDriverPlugin creates GravitinoCatalogManager to fetch catalogs from Gravitino and
- * register Gravitino catalogs to Spark.
+ * GravitinoDriverPlugin creates GravitinoCatalogManager to fetch catalogs from Apache Gravitino and
+ * register Gravitino catalogs to Apache Spark.
  */
 public class GravitinoDriverPlugin implements DriverPlugin {
 

--- a/spark-connector/spark-common/src/main/java/com/datastrato/gravitino/spark/connector/plugin/GravitinoSparkPlugin.java
+++ b/spark-connector/spark-common/src/main/java/com/datastrato/gravitino/spark/connector/plugin/GravitinoSparkPlugin.java
@@ -22,7 +22,7 @@ import org.apache.spark.api.plugin.DriverPlugin;
 import org.apache.spark.api.plugin.ExecutorPlugin;
 import org.apache.spark.api.plugin.SparkPlugin;
 
-/** The entrypoint for Gravitino Spark connector. */
+/** The entrypoint for Apache Gravitino Spark connector. */
 public class GravitinoSparkPlugin implements SparkPlugin {
 
   @Override

--- a/spark-connector/spark-common/src/main/java/com/datastrato/gravitino/spark/connector/utils/GravitinoTableInfoHelper.java
+++ b/spark-connector/spark-common/src/main/java/com/datastrato/gravitino/spark/connector/utils/GravitinoTableInfoHelper.java
@@ -40,7 +40,7 @@ import org.apache.spark.sql.types.StructType;
 
 /**
  * GravitinoTableInfoHelper is a common helper class that is used to retrieve table info from the
- * Gravitino Server
+ * Apache Gravitino Server
  */
 public class GravitinoTableInfoHelper {
 

--- a/spark-connector/spark-common/src/test/java/com/datastrato/gravitino/spark/connector/integration/test/SparkCommonIT.java
+++ b/spark-connector/spark-common/src/test/java/com/datastrato/gravitino/spark/connector/integration/test/SparkCommonIT.java
@@ -122,7 +122,7 @@ public abstract class SparkCommonIT extends SparkEnvIT {
   // database after spark connector support Alter database xx set location command.
   @BeforeAll
   void initDefaultDatabase() throws IOException {
-    // In embedded mode, derby acts as the backend database for the hive metastore
+    // In embedded mode, derby acts as the backend database for the Hive metastore
     // and creates a directory named metastore_db to store metadata,
     // supporting only one connection at a time.
     // Previously, only SparkHiveCatalogIT accessed derby without any exceptions.

--- a/spark-connector/spark-common/src/test/java/com/datastrato/gravitino/spark/connector/integration/test/SparkEnvIT.java
+++ b/spark-connector/spark-common/src/test/java/com/datastrato/gravitino/spark/connector/integration/test/SparkEnvIT.java
@@ -89,7 +89,7 @@ public abstract class SparkEnvIT extends SparkUtilIT {
     initMetalakeAndCatalogs();
     initSparkEnv();
     LOG.info(
-        "Startup Spark env successfully, gravitino uri: {}, hive metastore uri: {}",
+        "Startup Spark env successfully, Gravitino uri: {}, Hive metastore uri: {}",
         gravitinoUri,
         hiveMetastoreUri);
   }

--- a/spark-connector/spark-common/src/test/java/com/datastrato/gravitino/spark/connector/integration/test/iceberg/SparkIcebergCatalogHiveBackendIT.java
+++ b/spark-connector/spark-common/src/test/java/com/datastrato/gravitino/spark/connector/integration/test/iceberg/SparkIcebergCatalogHiveBackendIT.java
@@ -24,7 +24,7 @@ import java.util.Map;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.TestInstance;
 
-/** This class use Iceberg HiveCatalog for backend catalog. */
+/** This class use Apache Iceberg HiveCatalog for backend catalog. */
 @Tag("gravitino-docker-test")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public abstract class SparkIcebergCatalogHiveBackendIT extends SparkIcebergCatalogIT {

--- a/spark-connector/spark-common/src/test/java/com/datastrato/gravitino/spark/connector/integration/test/iceberg/SparkIcebergCatalogRestBackendIT.java
+++ b/spark-connector/spark-common/src/test/java/com/datastrato/gravitino/spark/connector/integration/test/iceberg/SparkIcebergCatalogRestBackendIT.java
@@ -24,7 +24,9 @@ import java.util.Map;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.TestInstance;
 
-/** This class use Iceberg RESTCatalog for test, and the real backend catalog is HiveCatalog. */
+/**
+ * This class use Apache Iceberg RESTCatalog for test, and the real backend catalog is HiveCatalog.
+ */
 @Tag("gravitino-docker-test")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public abstract class SparkIcebergCatalogRestBackendIT extends SparkIcebergCatalogIT {

--- a/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/GravitinoConfig.java
+++ b/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/GravitinoConfig.java
@@ -45,7 +45,7 @@ public class GravitinoConfig {
   public static final String TRINO_CATALOG_STORE_DEFAULT_VALUE = "file";
   public static final String TRINO_CATALOG_MANAGEMENT_DEFAULT_VALUE = "static";
 
-  // The trino configuration of etc/config.properties
+  // The Trino configuration of etc/config.properties
   public static final TrinoConfig trinoConfig = new TrinoConfig();
 
   // Gravitino config keys

--- a/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/GravitinoConnector.java
+++ b/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/GravitinoConnector.java
@@ -40,8 +40,8 @@ import java.util.Set;
 
 /**
  * GravitinoConnector serves as the entry point for operations on the connector managed by Trino and
- * Gravitino. It provides a standard entry point for Trino connectors and delegates their operations
- * to internal connectors.
+ * Apache Gravitino. It provides a standard entry point for Trino connectors and delegates their
+ * operations to internal connectors.
  */
 public class GravitinoConnector implements Connector {
 

--- a/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/GravitinoConnectorFactory.java
+++ b/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/GravitinoConnectorFactory.java
@@ -62,13 +62,13 @@ public class GravitinoConnectorFactory implements ConnectorFactory {
   }
 
   /**
-   * This function call by trino creates a connector. It creates GravitinoSystemConnector at first.
+   * This function call by Trino creates a connector. It creates GravitinoSystemConnector at first.
    * Another time's it get GravitinoConnector by CatalogConnectorManager
    *
    * @param catalogName the connector name of catalog
    * @param requiredConfig the config of connector
-   * @param context trino connector context
-   * @return trino connector
+   * @param context Trino connector context
+   * @return Trino connector
    */
   @Override
   public Connector create(

--- a/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/GravitinoDataSourceProvider.java
+++ b/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/GravitinoDataSourceProvider.java
@@ -28,7 +28,7 @@ import io.trino.spi.connector.ConnectorTransactionHandle;
 import io.trino.spi.connector.DynamicFilter;
 import java.util.List;
 
-/** This class provides a ConnectorPageSource for trino read data from internal connector. */
+/** This class provides a ConnectorPageSource for Trino read data from internal connector. */
 public class GravitinoDataSourceProvider implements ConnectorPageSourceProvider {
 
   ConnectorPageSourceProvider internalPageSourceProvider;

--- a/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/GravitinoMetadata.java
+++ b/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/GravitinoMetadata.java
@@ -68,9 +68,9 @@ import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 
 /**
- * The GravitinoMetadata class provides operations for Gravitino metadata on the Gravitino server.
- * It also transforms the different metadata formats between Trino and Gravitino. Additionally, it
- * wraps the internal connector metadata for accessing data.
+ * The GravitinoMetadata class provides operations for Apache Gravitino metadata on the Gravitino
+ * server. It also transforms the different metadata formats between Trino and Gravitino.
+ * Additionally, it wraps the internal connector metadata for accessing data.
  */
 public class GravitinoMetadata implements ConnectorMetadata {
   // Handling metadata operations on gravitino server

--- a/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/GravitinoPageSinkProvider.java
+++ b/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/GravitinoPageSinkProvider.java
@@ -27,7 +27,7 @@ import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorTransactionHandle;
 import org.apache.commons.lang3.NotImplementedException;
 
-/** This class provides a ConnectorPageSink for trino to write data to internal connector. */
+/** This class provides a ConnectorPageSink for Trino to write data to internal connector. */
 public class GravitinoPageSinkProvider implements ConnectorPageSinkProvider {
 
   ConnectorPageSinkProvider pageSinkProvider;

--- a/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/GravitinoRecordSetProvider.java
+++ b/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/GravitinoRecordSetProvider.java
@@ -27,7 +27,7 @@ import io.trino.spi.connector.ConnectorTransactionHandle;
 import io.trino.spi.connector.RecordSet;
 import java.util.List;
 
-/** This class provides a RecordSet for trino read data from internal connector. */
+/** This class provides a RecordSet for Trino read data from internal connector. */
 public class GravitinoRecordSetProvider implements ConnectorRecordSetProvider {
 
   ConnectorRecordSetProvider internalRecordSetProvider;

--- a/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/GravitinoSplit.java
+++ b/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/GravitinoSplit.java
@@ -28,8 +28,8 @@ import io.trino.spi.connector.ConnectorSplit;
 import java.util.List;
 
 /**
- * The GravitinoFTransactionHandle is used to make Gravitino metadata operations transactional and
- * wrap the inner connector transaction for data access.
+ * The GravitinoFTransactionHandle is used to make Apache Gravitino metadata operations
+ * transactional and wrap the inner connector transaction for data access.
  */
 public class GravitinoSplit implements ConnectorSplit, GravitinoHandle<ConnectorSplit> {
 

--- a/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/GravitinoSplitSource.java
+++ b/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/GravitinoSplitSource.java
@@ -26,8 +26,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
 /**
- * The GravitinoFTransactionHandle is used to make Gravitino metadata operations transactional and
- * wrap the inner connector transaction for data access.
+ * The GravitinoFTransactionHandle is used to make Apache Gravitino metadata operations
+ * transactional and wrap the inner connector transaction for data access.
  */
 public class GravitinoSplitSource implements ConnectorSplitSource {
 

--- a/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/GravitinoTransactionHandle.java
+++ b/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/GravitinoTransactionHandle.java
@@ -25,8 +25,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.trino.spi.connector.ConnectorTransactionHandle;
 
 /**
- * The GravitinoFTransactionHandle is used to make Gravitino metadata operations transactional and
- * wrap the inner connector transaction for data access.
+ * The GravitinoFTransactionHandle is used to make Apache Gravitino metadata operations
+ * transactional and wrap the inner connector transaction for data access.
  */
 public class GravitinoTransactionHandle
     implements ConnectorTransactionHandle, GravitinoHandle<ConnectorTransactionHandle> {

--- a/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/catalog/CatalogConnectorContext.java
+++ b/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/catalog/CatalogConnectorContext.java
@@ -30,16 +30,16 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * The CatalogConnector serves as a communication bridge between the Gravitino connector and its
- * internal connectors. It manages the lifecycle, configuration, and runtime environment of internal
- * connectors.
+ * The CatalogConnector serves as a communication bridge between the Apache Gravitino connector and
+ * its internal connectors. It manages the lifecycle, configuration, and runtime environment of
+ * internal connectors.
  */
 public class CatalogConnectorContext {
 
   private final GravitinoCatalog catalog;
   private final GravitinoMetalake metalake;
 
-  // Connector communicates with trino
+  // Connector communicates with Trino
   private final GravitinoConnector connector;
 
   // Internal connector communicates with data storage

--- a/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/catalog/CatalogConnectorManager.java
+++ b/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/catalog/CatalogConnectorManager.java
@@ -53,7 +53,7 @@ import org.slf4j.LoggerFactory;
  * This class has the following main functions:
  *
  * <pre>
- * 1. Load catalogs from the Gravitino server and create
+ * 1. Load catalogs from the Apache Gravitino server and create
  * catalog contexts.
  * 2. Manage all catalog context instances, which primarily handle communication
  * with Trino through Gravitino connectors and inner connectors related to the engine.

--- a/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/catalog/CatalogConnectorMetadata.java
+++ b/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/catalog/CatalogConnectorMetadata.java
@@ -54,7 +54,7 @@ import java.util.List;
 import java.util.Map;
 import org.apache.commons.lang3.NotImplementedException;
 
-/** This class implements gravitino metadata operators. */
+/** This class implements Apache Gravitino metadata operators. */
 public class CatalogConnectorMetadata {
 
   private static final String CATALOG_DOES_NOT_EXIST_MSG = "Catalog does not exist";

--- a/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/catalog/CatalogConnectorMetadataAdapter.java
+++ b/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/catalog/CatalogConnectorMetadataAdapter.java
@@ -70,7 +70,7 @@ public class CatalogConnectorMetadataAdapter {
     return dataTypeTransformer;
   }
 
-  /** Transform gravitino table metadata to trino ConnectorTableMetadata */
+  /** Transform Gravitino table metadata to Trino ConnectorTableMetadata */
   public ConnectorTableMetadata getTableMetadata(GravitinoTable gravitinoTable) {
     SchemaTableName schemaTableName =
         new SchemaTableName(gravitinoTable.getSchemaName(), gravitinoTable.getName());
@@ -87,7 +87,7 @@ public class CatalogConnectorMetadataAdapter {
         Optional.ofNullable(gravitinoTable.getComment()));
   }
 
-  /** Transform trino ConnectorTableMetadata to gravitino table metadata */
+  /** Transform Trino ConnectorTableMetadata to Gravitino table metadata */
   public GravitinoTable createTable(ConnectorTableMetadata tableMetadata) {
     String tableName = tableMetadata.getTableSchema().getTable().getTableName();
     String schemaName = tableMetadata.getTableSchema().getTable().getSchemaName();
@@ -118,12 +118,12 @@ public class CatalogConnectorMetadataAdapter {
         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
   }
 
-  /** Transform trino schema metadata to gravitino schema metadata */
+  /** Transform Trino schema metadata to Gravitino schema metadata */
   public GravitinoSchema createSchema(String schemaName, Map<String, Object> properties) {
     return new GravitinoSchema(schemaName, toGravitinoSchemaProperties(properties), "");
   }
 
-  /** Transform gravitino column metadata to trino ColumnMetadata */
+  /** Transform Gravitino column metadata to Trino ColumnMetadata */
   public ColumnMetadata getColumnMetadata(GravitinoColumn column) {
     return ColumnMetadata.builder()
         .setName(column.getName())
@@ -135,15 +135,15 @@ public class CatalogConnectorMetadataAdapter {
         .build();
   }
 
-  /** Transform gravitino table properties to trino ConnectorTableProperties */
+  /** Transform Gravitino table properties to Trino ConnectorTableProperties */
   public ConnectorTableProperties getTableProperties(GravitinoTable table) {
     throw new NotImplementedException();
   }
 
-  /** Normalize gravitino attributes for trino */
+  /** Normalize Gravitino attributes for Trino */
   private Map<String, Object> normalizeProperties(
       Map<String, String> properties, List<PropertyMetadata<?>> propertyTemplate) {
-    // TODO yuhui redo this function once gravitino table properties are supported..
+    // TODO yuhui redo this function once Gravitino table properties are supported..
     // Trino only supports properties defined in the propertyTemplate.
     Map<String, Object> validProperties = new HashMap<>();
     for (PropertyMetadata<?> propertyMetadata : propertyTemplate) {
@@ -151,33 +151,33 @@ public class CatalogConnectorMetadataAdapter {
       if (properties.containsKey(name)) {
         validProperties.put(name, properties.get(name));
       } else {
-        LOG.warn("Property {} is not defined in trino, we will ignore it", name);
+        LOG.warn("Property {} is not defined in Trino, we will ignore it", name);
       }
     }
     return validProperties;
   }
 
-  /** Normalize gravitino table attributes for trino */
+  /** Normalize Gravitino table attributes for Trino */
   public Map<String, Object> toTrinoTableProperties(Map<String, String> properties) {
     return normalizeProperties(properties, tableProperties);
   }
 
-  /** Normalize gravitino schema attributes for trino */
+  /** Normalize Gravitino schema attributes for Trino */
   public Map<String, Object> toTrinoSchemaProperties(Map<String, String> properties) {
     return normalizeProperties(properties, schemaProperties);
   }
 
-  /** Normalize trino table attributes for gravitino */
+  /** Normalize Trino table attributes for Gravitino */
   public Map<String, String> toGravitinoTableProperties(Map<String, Object> properties) {
     return removeUnsetProperties(properties);
   }
 
-  /** Normalize trino schema attributes for gravitino */
+  /** Normalize Trino schema attributes for Gravitino */
   public Map<String, String> toGravitinoSchemaProperties(Map<String, Object> properties) {
     return removeUnsetProperties(properties);
   }
 
-  /** Remove trino unset attributes fro gravitino */
+  /** Remove Trino unset attributes for Gravitino */
   private Map<String, String> removeUnsetProperties(Map<String, Object> properties) {
     return properties.entrySet().stream()
         .filter(e -> e.getValue() != null)

--- a/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/catalog/CatalogRegister.java
+++ b/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/catalog/CatalogRegister.java
@@ -44,8 +44,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * This class dynamically register the Catalog managed by Gravitino into Trino using Trino CREATE
- * CATALOG statement. It allows the catalog to be used in Trino like a regular Trino catalog.
+ * This class dynamically register the Catalog managed by Apache Gravitino into Trino using Trino
+ * CREATE CATALOG statement. It allows the catalog to be used in Trino like a regular Trino catalog.
  */
 public class CatalogRegister {
 
@@ -147,7 +147,7 @@ public class CatalogRegister {
         if (!catalogContents.contains(GRAVITINO_DYNAMIC_CONNECTOR + "=true")) {
           throw new TrinoException(
               GRAVITINO_DUPLICATED_CATALOGS,
-              "Catalog already exists, the catalog is not created by gravitino");
+              "Catalog already exists, the catalog is not created by Gravitino");
         } else {
           throw new TrinoException(
               GRAVITINO_CATALOG_ALREADY_EXISTS,

--- a/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/catalog/hive/HiveCatalogPropertyConverter.java
+++ b/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/catalog/hive/HiveCatalogPropertyConverter.java
@@ -27,7 +27,7 @@ import org.apache.commons.collections4.bidimap.TreeBidiMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** Convert hive properties between trino and gravitino. */
+/** Convert Apache Hive properties between Trino and Apache Gravitino. */
 public class HiveCatalogPropertyConverter extends PropertyConverter {
 
   public static final Logger LOG = LoggerFactory.getLogger(HiveCatalogPropertyConverter.class);

--- a/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/catalog/hive/HiveConnectorAdapter.java
+++ b/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/catalog/hive/HiveConnectorAdapter.java
@@ -31,7 +31,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-/** Transforming Hive connector configuration and components into Gravitino connector. */
+/**
+ * Transforming Apache Hive connector configuration and components into Apache Gravitino connector.
+ */
 public class HiveConnectorAdapter implements CatalogConnectorAdapter {
 
   private final HasPropertyMeta propertyMetadata;

--- a/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/catalog/hive/HiveDataTypeTransformer.java
+++ b/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/catalog/hive/HiveDataTypeTransformer.java
@@ -26,7 +26,7 @@ import com.datastrato.gravitino.trino.connector.util.GeneralDataTypeTransformer;
 import io.trino.spi.TrinoException;
 import io.trino.spi.type.VarcharType;
 
-/** Type transformer between Hive and Trino */
+/** Type transformer between Apache Hive and Trino */
 public class HiveDataTypeTransformer extends GeneralDataTypeTransformer {
   // Max length of Hive varchar is 65535
   private static final int HIVE_VARCHAR_MAX_LENGTH = 65535;

--- a/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/catalog/hive/HiveMetadataAdapter.java
+++ b/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/catalog/hive/HiveMetadataAdapter.java
@@ -55,7 +55,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.ArrayUtils;
 
-/** Transforming gravitino hive metadata to trino. */
+/** Transforming Apache Gravitino Hive metadata to Trino. */
 public class HiveMetadataAdapter extends CatalogConnectorMetadataAdapter {
 
   private final PropertyConverter tableConverter;

--- a/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/catalog/hive/HivePropertyMeta.java
+++ b/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/catalog/hive/HivePropertyMeta.java
@@ -33,7 +33,7 @@ import io.trino.spi.session.PropertyMetadata;
 import io.trino.spi.type.ArrayType;
 import java.util.List;
 
-/** Implementation of {@link HasPropertyMeta} for Hive catalog. */
+/** Implementation of {@link HasPropertyMeta} for Apache Hive catalog. */
 public class HivePropertyMeta implements HasPropertyMeta {
 
   static final String HIVE_SCHEMA_LOCATION = "location";
@@ -151,7 +151,7 @@ public class HivePropertyMeta implements HasPropertyMeta {
   }
 
   // Hive catalog properties contain '.' and PropertyMetadata does not allow '.'
-  // Those configurations are referred from Trino hive connector
+  // Those configurations are referred from Trino Hive connector
   private static final List<PropertyMetadata<?>> CATALOG_PROPERTY_META =
       ImmutableList.of(
           enumProperty(

--- a/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/catalog/iceberg/IcebergConnectorAdapter.java
+++ b/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/catalog/iceberg/IcebergConnectorAdapter.java
@@ -29,7 +29,10 @@ import io.trino.spi.session.PropertyMetadata;
 import java.util.List;
 import java.util.Map;
 
-/** Transforming Iceberg connector configuration and components into Gravitino connector. */
+/**
+ * Transforming Apache Iceberg connector configuration and components into Apache Gravitino
+ * connector.
+ */
 public class IcebergConnectorAdapter implements CatalogConnectorAdapter {
 
   private final IcebergPropertyMeta propertyMetadata;

--- a/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/catalog/iceberg/IcebergDataTypeTransformer.java
+++ b/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/catalog/iceberg/IcebergDataTypeTransformer.java
@@ -28,7 +28,7 @@ import io.trino.spi.TrinoException;
 import io.trino.spi.type.VarbinaryType;
 import io.trino.spi.type.VarcharType;
 
-/** Type transformer between Iceberg and Trino */
+/** Type transformer between Apache Iceberg and Trino */
 public class IcebergDataTypeTransformer extends GeneralDataTypeTransformer {
 
   @Override

--- a/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/catalog/iceberg/IcebergMetadataAdapter.java
+++ b/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/catalog/iceberg/IcebergMetadataAdapter.java
@@ -46,7 +46,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.ArrayUtils;
 
-/** Transforming gravitino Iceberg metadata to trino. */
+/** Transforming Apache Gravitino Iceberg metadata to Trino. */
 public class IcebergMetadataAdapter extends CatalogConnectorMetadataAdapter {
 
   // Move all this logic to CatalogConnectorMetadataAdapter

--- a/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/catalog/jdbc/mysql/MySQLConnectorAdapter.java
+++ b/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/catalog/jdbc/mysql/MySQLConnectorAdapter.java
@@ -31,7 +31,7 @@ import io.trino.spi.session.PropertyMetadata;
 import java.util.List;
 import java.util.Map;
 
-/** Transforming MySQL connector configuration and components into Gravitino connector. */
+/** Transforming MySQL connector configuration and components into Apache Gravitino connector. */
 public class MySQLConnectorAdapter implements CatalogConnectorAdapter {
 
   private final PropertyConverter catalogConverter;

--- a/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/catalog/jdbc/mysql/MySQLMetadataAdapter.java
+++ b/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/catalog/jdbc/mysql/MySQLMetadataAdapter.java
@@ -31,7 +31,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-/** Transforming gravitino MySQL metadata to trino. */
+/** Transforming Apache Gravitino MySQL metadata to Trino. */
 public class MySQLMetadataAdapter extends CatalogConnectorMetadataAdapter {
 
   private final PropertyConverter tableConverter;
@@ -57,7 +57,7 @@ public class MySQLMetadataAdapter extends CatalogConnectorMetadataAdapter {
     return super.toTrinoTableProperties(objectMap);
   }
 
-  /** Transform trino ConnectorTableMetadata to gravitino table metadata */
+  /** Transform Trino ConnectorTableMetadata to Gravitino table metadata */
   @Override
   public GravitinoTable createTable(ConnectorTableMetadata tableMetadata) {
     String tableName = tableMetadata.getTableSchema().getTable().getTableName();

--- a/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/catalog/jdbc/postgresql/PostgreSQLConnectorAdapter.java
+++ b/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/catalog/jdbc/postgresql/PostgreSQLConnectorAdapter.java
@@ -28,7 +28,9 @@ import com.datastrato.gravitino.trino.connector.catalog.jdbc.JDBCCatalogProperty
 import com.datastrato.gravitino.trino.connector.metadata.GravitinoCatalog;
 import java.util.Map;
 
-/** Transforming PostgreSQL connector configuration and components into Gravitino connector. */
+/**
+ * Transforming PostgreSQL connector configuration and components into Apche Gravitino connector.
+ */
 public class PostgreSQLConnectorAdapter implements CatalogConnectorAdapter {
   private final PropertyConverter catalogConverter;
 

--- a/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/catalog/jdbc/postgresql/PostgreSQLMetadataAdapter.java
+++ b/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/catalog/jdbc/postgresql/PostgreSQLMetadataAdapter.java
@@ -22,7 +22,7 @@ import com.datastrato.gravitino.trino.connector.catalog.CatalogConnectorMetadata
 import io.trino.spi.session.PropertyMetadata;
 import java.util.List;
 
-/** Transforming gravitino PostgreSQL metadata to trino. */
+/** Transforming gravitino PostgreSQL metadata to Trino. */
 public class PostgreSQLMetadataAdapter extends CatalogConnectorMetadataAdapter {
 
   public PostgreSQLMetadataAdapter(

--- a/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/catalog/memory/MemoryConnectorAdapter.java
+++ b/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/catalog/memory/MemoryConnectorAdapter.java
@@ -30,8 +30,8 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Support trino Memory connector for testing. Transforming Memory connector configuration and
- * components into Gravitino connector.
+ * Support Trino Memory connector for testing. Transforming Memory connector configuration and
+ * components into Apache Gravitino connector.
  */
 public class MemoryConnectorAdapter implements CatalogConnectorAdapter {
 

--- a/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/metadata/GravitinoCatalog.java
+++ b/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/metadata/GravitinoCatalog.java
@@ -31,7 +31,7 @@ import java.time.Instant;
 import java.util.Map;
 import org.apache.commons.lang3.StringUtils;
 
-/** Help Gravitino connector access CatalogMetadata from gravitino client. */
+/** Help Apache Gravitino connector access CatalogMetadata from Gravitino client. */
 public class GravitinoCatalog {
 
   private static ObjectMapper objectMapper = new ObjectMapper();

--- a/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/metadata/GravitinoSchema.java
+++ b/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/metadata/GravitinoSchema.java
@@ -21,7 +21,7 @@ package com.datastrato.gravitino.trino.connector.metadata;
 import com.datastrato.gravitino.Schema;
 import java.util.Map;
 
-/** Help Gravitino connector access SchemaMetadata from gravitino client. */
+/** Help Apache Gravitino connector access SchemaMetadata from Gravitino client. */
 public class GravitinoSchema {
 
   private final String schemaName;

--- a/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/metadata/GravitinoTable.java
+++ b/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/metadata/GravitinoTable.java
@@ -33,7 +33,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-/** Help Gravitino connector access TableMetadata from gravitino client. */
+/** Help Apache Gravitino connector access TableMetadata from Gravitino client. */
 public class GravitinoTable {
   private final String schemaName;
   private final String tableName;

--- a/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/system/GravitinoSystemConnector.java
+++ b/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/system/GravitinoSystemConnector.java
@@ -48,9 +48,9 @@ import java.util.Set;
 
 /**
  * GravitinoSystemConnector is primarily used to drive the GravitinoCatalogManager to load catalog
- * connectors managed in the Gravitino server. After users configure the Gravitino connector through
- * Trino catalog configuration, a GravitinoSystemConnector is initially created. And it provides
- * some system tables and stored procedures of Gravitino connector.
+ * connectors managed in the Apache Gravitino server. After users configure the Gravitino connector
+ * through Trino catalog configuration, a GravitinoSystemConnector is initially created. And it
+ * provides some system tables and stored procedures of Gravitino connector.
  */
 public class GravitinoSystemConnector implements Connector {
 

--- a/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/system/GravitinoSystemConnectorMetadata.java
+++ b/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/system/GravitinoSystemConnectorMetadata.java
@@ -36,7 +36,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-/** An implementation of Gravitino System connector Metadata */
+/** An implementation of Apache Gravitino System connector Metadata */
 public class GravitinoSystemConnectorMetadata implements ConnectorMetadata {
 
   @Override

--- a/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/system/storedprocdure/GravitinoStoredProcedureFactory.java
+++ b/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/system/storedprocdure/GravitinoStoredProcedureFactory.java
@@ -60,7 +60,7 @@ public class GravitinoStoredProcedureFactory {
               } catch (Exception e) {
                 throw new TrinoException(
                     GRAVITINO_UNSUPPORTED_OPERATION,
-                    "Failed to initialize gravitino system procedures",
+                    "Failed to initialize Gravitino system procedures",
                     e);
               }
             })

--- a/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/util/GeneralDataTypeTransformer.java
+++ b/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/util/GeneralDataTypeTransformer.java
@@ -52,7 +52,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-/** This class is used to transform datatype between gravitino and trino */
+/** This class is used to transform datatype between Apache Gravitino and Trino */
 public class GeneralDataTypeTransformer {
 
   public Type getTrinoType(com.datastrato.gravitino.rel.types.Type type) {

--- a/web/README.md
+++ b/web/README.md
@@ -17,11 +17,11 @@
   under the License.
 -->
 
-# Gravitino Web UI
+# Apache Gravitino Web UI
 
 > **ℹ️ Tips**
 >
-> Under normal circumstances, you only need to visit [http://localhost:8090](http://localhost:8090) if you're just using the web UI to manage the Gravitino.
+> Under normal circumstances, you only need to visit [http://localhost:8090](http://localhost:8090) if you're just using the web UI to manage the Apache Gravitino.
 >
 > You don't need to start the web development mode. If you need to modify the web part of the code, you can refer to the following document content for development and testing.
 


### PR DESCRIPTION
<!--
### What changes were proposed in this pull request?

Changed ASF project names in the first instance and in titles to be in the correct form "Apache Foo". This include changed to documentation and code comments.

Fixed case of projects where needed e.g trino -> Trino, gravitino -> Gravitino, iceberg -> Iceberg etc etc

### Why are the changes needed?

To use the correct name for ASF projects.

Fix: #4064

### Does this PR introduce _any_ user-facing change?

None.

### How was this patch tested?

Built and non-integration test pass locally.
