### PR TITLE
[#4078] fix(CI): apt purge pop error "E: Unable to locate package" in some ubuntu vm

### DIFF
--- a/dev/ci/util_free_space.sh
+++ b/dev/ci/util_free_space.sh
@@ -49,6 +49,16 @@ if [ "${GITHUB_ACTIONS}" = "true" ]; then
   sudo rm -rf /opt/hostedtoolcache/PyPy || :
   # 376MB
   sudo rm -rf /opt/hostedtoolcache/node || :
+  # Add Google Chrome and Microsoft Edge repository if not found
+  if ! grep -q "http://dl.google.com/linux/chrome/deb/" /etc/apt/sources.list.d/*.list 2>/dev/null; then
+    wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/google-linux-signing-key.gpg > /dev/null
+    sudo sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
+  fi
+  if ! grep -q "https://packages.microsoft.com/repos/edge" /etc/apt/sources.list.d/*.list 2>/dev/null; then
+    wget -q -O - https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/microsoft.asc.gpg > /dev/null
+    sudo add-apt-repository "deb [arch=amd64] https://packages.microsoft.com/repos/edge stable main" -y
+  fi
+  sudo apt-get update
   # Remove Web browser packages
   sudo apt purge -y \
     firefox \

--- a/dev/ci/util_free_space.sh
+++ b/dev/ci/util_free_space.sh
@@ -49,20 +49,15 @@ if [ "${GITHUB_ACTIONS}" = "true" ]; then
   sudo rm -rf /opt/hostedtoolcache/PyPy || :
   # 376MB
   sudo rm -rf /opt/hostedtoolcache/node || :
-  # Add Google Chrome and Microsoft Edge repository if not found
-  if ! grep -q "http://dl.google.com/linux/chrome/deb/" /etc/apt/sources.list.d/*.list 2>/dev/null; then
-    wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/google-linux-signing-key.gpg > /dev/null
-    sudo sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
-  fi
-  if ! grep -q "https://packages.microsoft.com/repos/edge" /etc/apt/sources.list.d/*.list 2>/dev/null; then
-    wget -q -O - https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/microsoft.asc.gpg > /dev/null
-    sudo add-apt-repository "deb [arch=amd64] https://packages.microsoft.com/repos/edge stable main" -y
-  fi
-  sudo apt-get update
   # Remove Web browser packages
-  sudo apt purge -y \
-    firefox \
-    google-chrome-stable \
-    microsoft-edge-stable
+  if dpkg-query -l firefox;then
+    sudo apt purge -y firefox
+  fi
+  if dpkg-query -l google-chrome-stable;then
+    sudo apt purge -y google-chrome-stable
+  fi
+  if dpkg-query -l microsoft-edge-stable;then
+    sudo apt purge -y microsoft-edge-stable
+  fi
   df -h
 fi


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix issue:
```
sudo apt purge -y \
    firefox \
    google-chrome-stable \
    microsoft-edge-stable
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
E: Unable to locate package google-chrome-stable
E: Unable to locate package microsoft-edge-stable
```
### Why are the changes needed?

Fix: #4078 

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

CI