### PR TITLE
[MINOR] fix: remove chmod in Dockerfile to decrease image size

### DIFF
--- a/catalogs/catalog-jdbc-doris/build.gradle.kts
+++ b/catalogs/catalog-jdbc-doris/build.gradle.kts
@@ -84,7 +84,7 @@ tasks {
 tasks.test {
   val skipUTs = project.hasProperty("skipTests")
   doFirst {
-    environment("GRAVITINO_CI_DORIS_DOCKER_IMAGE", "datastrato/gravitino-ci-doris:0.1.4")
+    environment("GRAVITINO_CI_DORIS_DOCKER_IMAGE", "datastrato/gravitino-ci-doris:0.1.5")
   }
 
   if (skipUTs) {

--- a/dev/docker/doris/Dockerfile
+++ b/dev/docker/doris/Dockerfile
@@ -56,8 +56,7 @@ RUN ARCH=$(uname -m) && \
 #################################################################################
 ## add files
 ADD packages/doris-${TARGETARCH}.tar.xz /opt/
-RUN ln -s /opt/apache-doris-${DORIS_VERSION}-bin-* ${DORIS_HOME} && \
-    chmod 755 "${DORIS_BE_HOME}/lib/doris_be"
+RUN ln -s /opt/apache-doris-${DORIS_VERSION}-bin-* ${DORIS_HOME}
 
 COPY start.sh ${DORIS_HOME}
 

--- a/docs/docker-image-details.md
+++ b/docs/docker-image-details.md
@@ -215,6 +215,8 @@ Changelog
 You can use this image to test Apache Doris.
 
 Changelog
+- gravitino-ci-doris:0.1.5
+  - Remove the chmod command in the Dockerfile to decrease the size of the Docker image.
 
 - gravitino-ci-doris:0.1.4
   - remove chmod in start.sh to accelerate the startup speed

--- a/integration-test/build.gradle.kts
+++ b/integration-test/build.gradle.kts
@@ -160,7 +160,7 @@ tasks.test {
       environment("GRAVITINO_CI_HIVE_DOCKER_IMAGE", "datastrato/gravitino-ci-hive:0.1.12")
       environment("GRAVITINO_CI_TRINO_DOCKER_IMAGE", "datastrato/gravitino-ci-trino:0.1.5")
       environment("GRAVITINO_CI_KAFKA_DOCKER_IMAGE", "apache/kafka:3.7.0")
-      environment("GRAVITINO_CI_DORIS_DOCKER_IMAGE", "datastrato/gravitino-ci-doris:0.1.4")
+      environment("GRAVITINO_CI_DORIS_DOCKER_IMAGE", "datastrato/gravitino-ci-doris:0.1.5")
       environment("GRAVITINO_CI_RANGER_DOCKER_IMAGE", "datastrato/gravitino-ci-ranger:0.1.0")
 
       copy {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Decrease the size of the Docker image in ARM arch.

### Why are the changes needed?

chmod makes Docker image increase to 8.89GB, but it's not necessary for user root.

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

Mannual/CI
