### PR TITLE
[#3685] Improvement: revisit all the purgeXXX implementations to have a consistent behavior

### DIFF
--- a/api/src/main/java/com/datastrato/gravitino/rel/SupportsPartitions.java
+++ b/api/src/main/java/com/datastrato/gravitino/rel/SupportsPartitions.java
@@ -94,7 +94,7 @@ public interface SupportsPartitions {
    * Drop a partition with specified name.
    *
    * @param partitionName the name of the partition
-   * @return true if a partition was deleted successfully, false if the partition does not exist.
+   * @return true if the partition is deleted successfully, false if the partition does not exist.
    */
   boolean dropPartition(String partitionName);
 
@@ -104,12 +104,10 @@ public interface SupportsPartitions {
    * purging partitions, {@link UnsupportedOperationException} is thrown.
    *
    * @param partitionName The name of the partition.
-   * @return true if a partition was deleted, false if the partition did not exist.
-   * @throws NoSuchPartitionException If the partition does not exist.
+   * @return true if the partition is purged, false if the partition does not exist.
    * @throws UnsupportedOperationException If partition purging is not supported.
    */
-  default boolean purgePartition(String partitionName)
-      throws NoSuchPartitionException, UnsupportedOperationException {
+  default boolean purgePartition(String partitionName) throws UnsupportedOperationException {
     throw new UnsupportedOperationException("Partition purging is not supported");
   }
 }

--- a/api/src/main/java/com/datastrato/gravitino/rel/TableCatalog.java
+++ b/api/src/main/java/com/datastrato/gravitino/rel/TableCatalog.java
@@ -268,7 +268,7 @@ public interface TableCatalog {
    * is removed.
    *
    * @param ident A table identifier.
-   * @return True if the table was dropped, false if the table did not exist.
+   * @return True if the table is dropped, false if the table does not exist.
    */
   boolean dropTable(NameIdentifier ident);
 
@@ -282,7 +282,7 @@ public interface TableCatalog {
    * implementation throws an {@link UnsupportedOperationException}.
    *
    * @param ident A table identifier.
-   * @return True if the table was purged, false if the table does not exist.
+   * @return True if the table is purged, false if the table does not exist.
    * @throws UnsupportedOperationException If the catalog does not support to purge a table.
    */
   default boolean purgeTable(NameIdentifier ident) throws UnsupportedOperationException {

--- a/api/src/main/java/com/datastrato/gravitino/rel/TableCatalog.java
+++ b/api/src/main/java/com/datastrato/gravitino/rel/TableCatalog.java
@@ -282,7 +282,7 @@ public interface TableCatalog {
    * implementation throws an {@link UnsupportedOperationException}.
    *
    * @param ident A table identifier.
-   * @return True if the table was purged, false if the table did not exist.
+   * @return True if the table was purged, false if the table does not exist.
    * @throws UnsupportedOperationException If the catalog does not support to purge a table.
    */
   default boolean purgeTable(NameIdentifier ident) throws UnsupportedOperationException {

--- a/catalogs/catalog-hive/src/main/java/com/datastrato/gravitino/catalog/hive/HiveCatalogOperations.java
+++ b/catalogs/catalog-hive/src/main/java/com/datastrato/gravitino/catalog/hive/HiveCatalogOperations.java
@@ -1080,10 +1080,14 @@ public class HiveCatalogOperations implements CatalogOperations, SupportsSchemas
    */
   @Override
   public boolean purgeTable(NameIdentifier tableIdent) throws UnsupportedOperationException {
-    if (isExternalTable(tableIdent)) {
-      throw new UnsupportedOperationException("Can't purge a external hive table");
-    } else {
-      return dropHiveTable(tableIdent, true, true);
+    try {
+      if (isExternalTable(tableIdent)) {
+        throw new UnsupportedOperationException("Can't purge a external hive table");
+      } else {
+        return dropHiveTable(tableIdent, true, true);
+      }
+    } catch (NoSuchTableException e) {
+      return false;
     }
   }
 

--- a/catalogs/catalog-hive/src/test/java/com/datastrato/gravitino/catalog/hive/TestHiveTable.java
+++ b/catalogs/catalog-hive/src/test/java/com/datastrato/gravitino/catalog/hive/TestHiveTable.java
@@ -549,6 +549,10 @@ public class TestHiveTable extends MiniHiveMetastoreService {
     Assertions.assertTrue(hiveCatalogOperations.tableExists(tableIdentifier));
     hiveCatalogOperations.purgeTable(tableIdentifier);
     Assertions.assertFalse(hiveCatalogOperations.tableExists(tableIdentifier));
+    // purging non-exist table should return false
+    Assertions.assertFalse(
+        hiveCatalogOperations.purgeTable(tableIdentifier),
+        "The table should not be found in the catalog");
   }
 
   @Test

--- a/catalogs/catalog-hive/src/test/java/com/datastrato/gravitino/catalog/hive/integration/test/CatalogHiveIT.java
+++ b/catalogs/catalog-hive/src/test/java/com/datastrato/gravitino/catalog/hive/integration/test/CatalogHiveIT.java
@@ -1522,6 +1522,10 @@ public class CatalogHiveIT extends AbstractIT {
     catalog.asTableCatalog().purgeTable(NameIdentifier.of(schemaName, tableName));
     Boolean existed = hiveClientPool.run(client -> client.tableExists(schemaName, tableName));
     Assertions.assertFalse(existed, "The Hive table should not exist");
+    // purging non-exist table should return false
+    Assertions.assertFalse(
+        catalog.asTableCatalog().purgeTable(NameIdentifier.of(schemaName, tableName)),
+        "The table should not be found in the catalog");
     Path tableDirectory = new Path(hiveTab.getSd().getLocation());
     Assertions.assertFalse(hdfs.exists(tableDirectory), "The table directory should not exist");
     Path trashDirectory = hdfs.getTrashRoot(tableDirectory);

--- a/catalogs/catalog-jdbc-common/src/main/java/com/datastrato/gravitino/catalog/jdbc/JdbcCatalogOperations.java
+++ b/catalogs/catalog-jdbc-common/src/main/java/com/datastrato/gravitino/catalog/jdbc/JdbcCatalogOperations.java
@@ -442,8 +442,7 @@ public class JdbcCatalogOperations implements CatalogOperations, SupportsSchemas
   @Override
   public boolean purgeTable(NameIdentifier tableIdent) throws UnsupportedOperationException {
     String databaseName = NameIdentifier.of(tableIdent.namespace().levels()).name();
-    tableOperation.purge(databaseName, tableIdent.name());
-    return true;
+    return tableOperation.purge(databaseName, tableIdent.name());
   }
 
   /**

--- a/catalogs/catalog-jdbc-common/src/main/java/com/datastrato/gravitino/catalog/jdbc/operation/JdbcTableOperations.java
+++ b/catalogs/catalog-jdbc-common/src/main/java/com/datastrato/gravitino/catalog/jdbc/operation/JdbcTableOperations.java
@@ -266,7 +266,16 @@ public abstract class JdbcTableOperations implements TableOperation {
   }
 
   @Override
-  public void purge(String databaseName, String tableName) throws NoSuchTableException {
+  public boolean purge(String databaseName, String tableName) {
+    try {
+      purgeTable(databaseName, tableName);
+    } catch (NoSuchTableException | NoSuchSchemaException e) {
+      return false;
+    }
+    return true;
+  }
+
+  protected void purgeTable(String databaseName, String tableName) {
     LOG.info("Attempting to purge table {} from database {}", tableName, databaseName);
     try (Connection connection = getConnection(databaseName)) {
       JdbcConnectorUtils.executeUpdate(connection, generatePurgeTableSql(tableName));

--- a/catalogs/catalog-jdbc-common/src/main/java/com/datastrato/gravitino/catalog/jdbc/operation/TableOperation.java
+++ b/catalogs/catalog-jdbc-common/src/main/java/com/datastrato/gravitino/catalog/jdbc/operation/TableOperation.java
@@ -113,5 +113,5 @@ public interface TableOperation {
    * @param databaseName The name of the database.
    * @param tableName The name of the table.
    */
-  void purge(String databaseName, String tableName) throws NoSuchTableException;
+  boolean purge(String databaseName, String tableName);
 }

--- a/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/IcebergCatalogOperations.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/IcebergCatalogOperations.java
@@ -547,6 +547,8 @@ public class IcebergCatalogOperations implements CatalogOperations, SupportsSche
     } catch (org.apache.iceberg.exceptions.NoSuchTableException e) {
       LOG.warn("Iceberg table {} does not exist", tableIdent.name());
       return false;
+    } catch (Exception e) {
+      throw new RuntimeException(e);
     }
   }
 

--- a/clients/client-java/src/main/java/com/datastrato/gravitino/client/RelationalCatalog.java
+++ b/clients/client-java/src/main/java/com/datastrato/gravitino/client/RelationalCatalog.java
@@ -237,7 +237,7 @@ public class RelationalCatalog extends BaseSchemaCatalog implements TableCatalog
    * Purge the table with specified identifier.
    *
    * @param ident The identifier of the table, which should be "schema.table" format.
-   * @return true if the table is purged successfully, false otherwise.
+   * @return true if the table is purged successfully, false if the table does not exist.
    */
   @Override
   public boolean purgeTable(NameIdentifier ident) throws UnsupportedOperationException {
@@ -246,21 +246,15 @@ public class RelationalCatalog extends BaseSchemaCatalog implements TableCatalog
     Namespace fullNamespace = getTableFullNamespace(ident.namespace());
     Map<String, String> params = new HashMap<>();
     params.put("purge", "true");
-    try {
-      DropResponse resp =
-          restClient.delete(
-              formatTableRequestPath(fullNamespace) + "/" + RESTUtils.encodeString(ident.name()),
-              params,
-              DropResponse.class,
-              Collections.emptyMap(),
-              ErrorHandlers.tableErrorHandler());
-      resp.validate();
-      return resp.dropped();
-    } catch (UnsupportedOperationException e) {
-      throw e;
-    } catch (Exception e) {
-      return false;
-    }
+    DropResponse resp =
+        restClient.delete(
+            formatTableRequestPath(fullNamespace) + "/" + RESTUtils.encodeString(ident.name()),
+            params,
+            DropResponse.class,
+            Collections.emptyMap(),
+            ErrorHandlers.tableErrorHandler());
+    resp.validate();
+    return resp.dropped();
   }
 
   @VisibleForTesting

--- a/clients/client-java/src/test/java/com/datastrato/gravitino/client/TestRelationalCatalog.java
+++ b/clients/client-java/src/test/java/com/datastrato/gravitino/client/TestRelationalCatalog.java
@@ -1124,7 +1124,7 @@ public class TestRelationalCatalog extends TestBase {
 
     Throwable exception =
         Assertions.assertThrows(
-            RuntimeException.class, () -> catalog.asTableCatalog().dropTable(tableId));
+            RuntimeException.class, () -> catalog.asTableCatalog().purgeTable(tableId));
     Assertions.assertTrue(exception.getMessage().contains("internal error"));
   }
 

--- a/clients/client-java/src/test/java/com/datastrato/gravitino/client/TestRelationalCatalog.java
+++ b/clients/client-java/src/test/java/com/datastrato/gravitino/client/TestRelationalCatalog.java
@@ -1122,7 +1122,10 @@ public class TestRelationalCatalog extends TestBase {
     ErrorResponse errorResp = ErrorResponse.internalError("internal error");
     buildMockResource(Method.DELETE, tablePath, null, errorResp, SC_INTERNAL_SERVER_ERROR);
 
-    Assertions.assertFalse(catalog.asTableCatalog().purgeTable(tableId));
+    Throwable exception =
+        Assertions.assertThrows(
+            RuntimeException.class, () -> catalog.asTableCatalog().dropTable(tableId));
+    Assertions.assertTrue(exception.getMessage().contains("internal error"));
   }
 
   @Test

--- a/core/src/main/java/com/datastrato/gravitino/catalog/PartitionDispatcher.java
+++ b/core/src/main/java/com/datastrato/gravitino/catalog/PartitionDispatcher.java
@@ -99,7 +99,7 @@ public interface PartitionDispatcher {
    *
    * @param tableIdent The identifier of the table.
    * @param partitionName The name of the partition.
-   * @return True if the partition was purged, false if the partition does not exist.
+   * @return True if the partition is purged, false if the partition does not exist.
    * @throws UnsupportedOperationException If partition purging is not supported.
    */
   default boolean purgePartition(NameIdentifier tableIdent, String partitionName)

--- a/core/src/main/java/com/datastrato/gravitino/catalog/TableOperationDispatcher.java
+++ b/core/src/main/java/com/datastrato/gravitino/catalog/TableOperationDispatcher.java
@@ -347,7 +347,7 @@ public class TableOperationDispatcher extends OperationDispatcher implements Tab
    * implementation throws an {@link UnsupportedOperationException}.
    *
    * @param ident A table identifier.
-   * @return True if the table was purged, false if the table does not exist.
+   * @return True if the table is purged, false if the table does not exist.
    * @throws UnsupportedOperationException If the catalog does not support to purge a table.
    * @throws RuntimeException If an error occurs while purging the table.
    */

--- a/core/src/main/java/com/datastrato/gravitino/catalog/TableOperationDispatcher.java
+++ b/core/src/main/java/com/datastrato/gravitino/catalog/TableOperationDispatcher.java
@@ -347,7 +347,7 @@ public class TableOperationDispatcher extends OperationDispatcher implements Tab
    * implementation throws an {@link UnsupportedOperationException}.
    *
    * @param ident A table identifier.
-   * @return True if the table was purged, false if the table did not exist.
+   * @return True if the table was purged, false if the table does not exist.
    * @throws UnsupportedOperationException If the catalog does not support to purge a table.
    * @throws RuntimeException If an error occurs while purging the table.
    */


### PR DESCRIPTION
### What changes were proposed in this pull request?
When purging tables, return `True` if the target was purged, and `False` if the target does not exist.

### Why are the changes needed?
Fix: #3685

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
ITs and UTs.
