### PR TITLE
[#3981]feat(flink-connector):Support alter table operation for hive

### DIFF
--- a/flink-connector/src/main/java/org/apache/gravitino/flink/connector/catalog/BaseCatalog.java
+++ b/flink-connector/src/main/java/org/apache/gravitino/flink/connector/catalog/BaseCatalog.java
@@ -20,6 +20,7 @@
 package org.apache.gravitino.flink.connector.catalog;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.MapDifference;
 import com.google.common.collect.Maps;
 import java.util.Arrays;
@@ -316,7 +317,9 @@ public abstract class BaseCatalog extends AbstractCatalog {
 
     NameIdentifier identifier =
         NameIdentifier.of(tablePath.getDatabaseName(), tablePath.getObjectName());
-    catalog().asTableCatalog().alterTable(identifier, getTableChanges(existingTable, newTable));
+    catalog()
+        .asTableCatalog()
+        .alterTable(identifier, getGravitinoTableChanges(existingTable, newTable));
   }
 
   @Override
@@ -345,7 +348,7 @@ public abstract class BaseCatalog extends AbstractCatalog {
 
     NameIdentifier identifier =
         NameIdentifier.of(tablePath.getDatabaseName(), tablePath.getObjectName());
-    catalog().asTableCatalog().alterTable(identifier, getTableChanges(tableChanges));
+    catalog().asTableCatalog().alterTable(identifier, getGravitinoTableChanges(tableChanges));
   }
 
   @Override
@@ -614,7 +617,9 @@ public abstract class BaseCatalog extends AbstractCatalog {
   }
 
   @VisibleForTesting
-  TableChange[] getTableChanges(CatalogBaseTable existingTable, CatalogBaseTable newTable) {
+  TableChange[] getGravitinoTableChanges(
+      CatalogBaseTable existingTable, CatalogBaseTable newTable) {
+    Preconditions.checkNotNull(newTable.getComment(), "The new comment should not be null");
     List<TableChange> changes = Lists.newArrayList();
     changes.addAll(optionsChanges(existingTable.getOptions(), newTable.getOptions()));
     if (!Objects.equals(newTable.getComment(), existingTable.getComment())) {
@@ -624,7 +629,8 @@ public abstract class BaseCatalog extends AbstractCatalog {
   }
 
   @VisibleForTesting
-  TableChange[] getTableChanges(List<org.apache.flink.table.catalog.TableChange> tableChanges) {
+  TableChange[] getGravitinoTableChanges(
+      List<org.apache.flink.table.catalog.TableChange> tableChanges) {
     List<TableChange> changes = Lists.newArrayList();
     for (org.apache.flink.table.catalog.TableChange change : tableChanges) {
       if (change instanceof org.apache.flink.table.catalog.TableChange.AddColumn) {

--- a/flink-connector/src/main/java/org/apache/gravitino/flink/connector/catalog/BaseCatalog.java
+++ b/flink-connector/src/main/java/org/apache/gravitino/flink/connector/catalog/BaseCatalog.java
@@ -25,6 +25,7 @@ import com.google.common.collect.Maps;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.commons.compress.utils.Lists;
@@ -68,6 +69,7 @@ import org.apache.gravitino.exceptions.SchemaAlreadyExistsException;
 import org.apache.gravitino.exceptions.TableAlreadyExistsException;
 import org.apache.gravitino.flink.connector.PartitionConverter;
 import org.apache.gravitino.flink.connector.PropertiesConverter;
+import org.apache.gravitino.flink.connector.utils.TableUtils;
 import org.apache.gravitino.flink.connector.utils.TypeUtils;
 import org.apache.gravitino.rel.Column;
 import org.apache.gravitino.rel.Table;
@@ -280,10 +282,70 @@ public abstract class BaseCatalog extends AbstractCatalog {
     }
   }
 
+  /**
+   * The method only is used to change the properties and comments. To alter columns, use the other
+   * alterTable API and provide a list of TableChange's.
+   *
+   * @param tablePath path of the table or view to be modified
+   * @param newTable the new table definition
+   * @param ignoreIfNotExists flag to specify behavior when the table or view does not exist: if set
+   *     to false, throw an exception, if set to true, do nothing.
+   * @throws TableNotExistException if the table not exists.
+   * @throws CatalogException in case of any runtime exception.
+   */
   @Override
-  public void alterTable(ObjectPath objectPath, CatalogBaseTable catalogBaseTable, boolean b)
+  public void alterTable(ObjectPath tablePath, CatalogBaseTable newTable, boolean ignoreIfNotExists)
       throws TableNotExistException, CatalogException {
-    throw new UnsupportedOperationException();
+    CatalogBaseTable existingTable;
+
+    try {
+      existingTable = this.getTable(tablePath);
+    } catch (TableNotExistException e) {
+      if (!ignoreIfNotExists) {
+        throw e;
+      }
+      return;
+    }
+
+    if (existingTable.getTableKind() != newTable.getTableKind()) {
+      throw new CatalogException(
+          String.format(
+              "Table types don't match. Existing table is '%s' and new table is '%s'.",
+              existingTable.getTableKind(), newTable.getTableKind()));
+    }
+
+    NameIdentifier identifier =
+        NameIdentifier.of(tablePath.getDatabaseName(), tablePath.getObjectName());
+    catalog().asTableCatalog().alterTable(identifier, getTableChanges(existingTable, newTable));
+  }
+
+  @Override
+  public void alterTable(
+      ObjectPath tablePath,
+      CatalogBaseTable newTable,
+      List<org.apache.flink.table.catalog.TableChange> tableChanges,
+      boolean ignoreIfNotExists)
+      throws TableNotExistException, CatalogException {
+    CatalogBaseTable existingTable;
+    try {
+      existingTable = this.getTable(tablePath);
+    } catch (TableNotExistException e) {
+      if (!ignoreIfNotExists) {
+        throw e;
+      }
+      return;
+    }
+
+    if (existingTable.getTableKind() != newTable.getTableKind()) {
+      throw new CatalogException(
+          String.format(
+              "Table types don't match. Existing table is '%s' and new table is '%s'.",
+              existingTable.getTableKind(), newTable.getTableKind()));
+    }
+
+    NameIdentifier identifier =
+        NameIdentifier.of(tablePath.getDatabaseName(), tablePath.getObjectName());
+    catalog().asTableCatalog().alterTable(identifier, getTableChanges(tableChanges));
   }
 
   @Override
@@ -468,6 +530,119 @@ public abstract class BaseCatalog extends AbstractCatalog {
         column.getDataType().getLogicalType().isNullable(),
         false,
         null);
+  }
+
+  private List<TableChange> optionsChanges(
+      Map<String, String> currentOptions, Map<String, String> updatedOptions) {
+    List<TableChange> optionsChanges = com.google.common.collect.Lists.newArrayList();
+    MapDifference<String, String> difference = Maps.difference(currentOptions, updatedOptions);
+    difference
+        .entriesOnlyOnLeft()
+        .forEach((key, value) -> optionsChanges.add(TableChange.removeProperty(key)));
+    difference
+        .entriesOnlyOnRight()
+        .forEach((key, value) -> optionsChanges.add(TableChange.setProperty(key, value)));
+    difference
+        .entriesDiffering()
+        .forEach(
+            (key, value) -> {
+              optionsChanges.add(TableChange.setProperty(key, value.rightValue()));
+            });
+    return optionsChanges;
+  }
+
+  private void removeProperty(
+      org.apache.flink.table.catalog.TableChange.ResetOption change, List<TableChange> changes) {
+    changes.add(TableChange.removeProperty(change.getKey()));
+  }
+
+  private void setProperty(
+      org.apache.flink.table.catalog.TableChange.SetOption change, List<TableChange> changes) {
+    changes.add(TableChange.setProperty(change.getKey(), change.getValue()));
+  }
+
+  private void dropColumn(
+      org.apache.flink.table.catalog.TableChange.DropColumn change, List<TableChange> changes) {
+    changes.add(TableChange.deleteColumn(new String[] {change.getColumnName()}, true));
+  }
+
+  private void addColumn(
+      org.apache.flink.table.catalog.TableChange.AddColumn change, List<TableChange> changes) {
+    changes.add(
+        TableChange.addColumn(
+            new String[] {change.getColumn().getName()},
+            TypeUtils.toGravitinoType(change.getColumn().getDataType().getLogicalType()),
+            change.getColumn().getComment().orElse(null),
+            TableUtils.toGravitinoColumnPosition(change.getPosition())));
+  }
+
+  private void modifyColumn(
+      org.apache.flink.table.catalog.TableChange change, List<TableChange> changes) {
+    if (change instanceof org.apache.flink.table.catalog.TableChange.ModifyColumnName) {
+      org.apache.flink.table.catalog.TableChange.ModifyColumnName modifyColumnName =
+          (org.apache.flink.table.catalog.TableChange.ModifyColumnName) change;
+      changes.add(
+          TableChange.renameColumn(
+              new String[] {modifyColumnName.getOldColumnName()},
+              modifyColumnName.getNewColumnName()));
+    } else if (change
+        instanceof org.apache.flink.table.catalog.TableChange.ModifyPhysicalColumnType) {
+      org.apache.flink.table.catalog.TableChange.ModifyPhysicalColumnType modifyColumnType =
+          (org.apache.flink.table.catalog.TableChange.ModifyPhysicalColumnType) change;
+      changes.add(
+          TableChange.updateColumnType(
+              new String[] {modifyColumnType.getOldColumn().getName()},
+              TypeUtils.toGravitinoType(modifyColumnType.getNewType().getLogicalType())));
+    } else if (change instanceof org.apache.flink.table.catalog.TableChange.ModifyColumnPosition) {
+      org.apache.flink.table.catalog.TableChange.ModifyColumnPosition modifyColumnPosition =
+          (org.apache.flink.table.catalog.TableChange.ModifyColumnPosition) change;
+      changes.add(
+          TableChange.updateColumnPosition(
+              new String[] {modifyColumnPosition.getOldColumn().getName()},
+              TableUtils.toGravitinoColumnPosition(modifyColumnPosition.getNewPosition())));
+    } else if (change instanceof org.apache.flink.table.catalog.TableChange.ModifyColumnComment) {
+      org.apache.flink.table.catalog.TableChange.ModifyColumnComment modifyColumnComment =
+          (org.apache.flink.table.catalog.TableChange.ModifyColumnComment) change;
+      changes.add(
+          TableChange.updateColumnComment(
+              new String[] {modifyColumnComment.getOldColumn().getName()},
+              modifyColumnComment.getNewComment()));
+    } else {
+      throw new IllegalArgumentException(
+          String.format("Not support ModifyColumn : %s", change.getClass()));
+    }
+  }
+
+  @VisibleForTesting
+  TableChange[] getTableChanges(CatalogBaseTable existingTable, CatalogBaseTable newTable) {
+    List<TableChange> changes = Lists.newArrayList();
+    changes.addAll(optionsChanges(existingTable.getOptions(), newTable.getOptions()));
+    if (!Objects.equals(newTable.getComment(), existingTable.getComment())) {
+      changes.add(TableChange.updateComment(newTable.getComment()));
+    }
+    return changes.toArray(new TableChange[0]);
+  }
+
+  @VisibleForTesting
+  TableChange[] getTableChanges(List<org.apache.flink.table.catalog.TableChange> tableChanges) {
+    List<TableChange> changes = Lists.newArrayList();
+    for (org.apache.flink.table.catalog.TableChange change : tableChanges) {
+      if (change instanceof org.apache.flink.table.catalog.TableChange.AddColumn) {
+        addColumn((org.apache.flink.table.catalog.TableChange.AddColumn) change, changes);
+      } else if (change instanceof org.apache.flink.table.catalog.TableChange.DropColumn) {
+        dropColumn((org.apache.flink.table.catalog.TableChange.DropColumn) change, changes);
+      } else if (change instanceof org.apache.flink.table.catalog.TableChange.ModifyColumn) {
+        modifyColumn(change, changes);
+      } else if (change instanceof org.apache.flink.table.catalog.TableChange.SetOption) {
+        setProperty((org.apache.flink.table.catalog.TableChange.SetOption) change, changes);
+      } else if (change instanceof org.apache.flink.table.catalog.TableChange.ResetOption) {
+        removeProperty((org.apache.flink.table.catalog.TableChange.ResetOption) change, changes);
+      } else {
+        throw new UnsupportedOperationException(
+            String.format("Not supported change : %s", change.getClass()));
+      }
+    }
+    return changes.toArray(new TableChange[0]);
   }
 
   @VisibleForTesting

--- a/flink-connector/src/main/java/org/apache/gravitino/flink/connector/utils/TableUtils.java
+++ b/flink-connector/src/main/java/org/apache/gravitino/flink/connector/utils/TableUtils.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.flink.connector.utils;
+
+import org.apache.gravitino.rel.TableChange;
+
+public class TableUtils {
+  private TableUtils() {}
+
+  public static TableChange.ColumnPosition toGravitinoColumnPosition(
+      org.apache.flink.table.catalog.TableChange.ColumnPosition columnPosition) {
+    if (columnPosition == null) {
+      return null;
+    }
+
+    if (columnPosition instanceof org.apache.flink.table.catalog.TableChange.First) {
+      return TableChange.ColumnPosition.first();
+    } else if (columnPosition instanceof org.apache.flink.table.catalog.TableChange.After) {
+      org.apache.flink.table.catalog.TableChange.After after =
+          (org.apache.flink.table.catalog.TableChange.After) columnPosition;
+      return TableChange.ColumnPosition.after(after.column());
+    } else {
+      throw new IllegalArgumentException(
+          String.format("Not support column position : %s", columnPosition.getClass()));
+    }
+  }
+}

--- a/flink-connector/src/main/java/org/apache/gravitino/flink/connector/utils/TypeUtils.java
+++ b/flink-connector/src/main/java/org/apache/gravitino/flink/connector/utils/TypeUtils.java
@@ -37,6 +37,8 @@ public class TypeUtils {
         return Types.DoubleType.get();
       case INTEGER:
         return Types.IntegerType.get();
+      case BIGINT:
+        return Types.LongType.get();
       default:
         throw new UnsupportedOperationException(
             "Not support type: " + logicalType.asSummaryString());
@@ -51,6 +53,8 @@ public class TypeUtils {
         return DataTypes.STRING();
       case INTEGER:
         return DataTypes.INT();
+      case LONG:
+        return DataTypes.BIGINT();
       default:
         throw new UnsupportedOperationException("Not support " + gravitinoType.toString());
     }

--- a/flink-connector/src/test/java/org/apache/gravitino/flink/connector/catalog/TestBaseCatalog.java
+++ b/flink-connector/src/test/java/org/apache/gravitino/flink/connector/catalog/TestBaseCatalog.java
@@ -99,7 +99,7 @@ public class TestBaseCatalog {
             org.apache.gravitino.rel.TableChange.removeProperty("key"));
 
     org.apache.gravitino.rel.TableChange[] gravitinoTableChanges =
-        mockCatalog.getTableChanges(tableChanges);
+        mockCatalog.getGravitinoTableChanges(tableChanges);
     Assertions.assertArrayEquals(expected.toArray(), gravitinoTableChanges);
   }
 
@@ -114,7 +114,7 @@ public class TestBaseCatalog {
         CatalogTable.of(
             schema, "new comment", ImmutableList.of(), ImmutableMap.of("key", "new value"));
     org.apache.gravitino.rel.TableChange[] tableChanges =
-        mockCatalog.getTableChanges(table, newTable);
+        mockCatalog.getGravitinoTableChanges(table, newTable);
     List<org.apache.gravitino.rel.TableChange> expected =
         ImmutableList.of(
             org.apache.gravitino.rel.TableChange.removeProperty("key2"),

--- a/flink-connector/src/test/java/org/apache/gravitino/flink/connector/catalog/TestBaseCatalog.java
+++ b/flink-connector/src/test/java/org/apache/gravitino/flink/connector/catalog/TestBaseCatalog.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.Schema;
+import org.apache.flink.table.catalog.AbstractCatalog;
 import org.apache.flink.table.catalog.CatalogBaseTable;
 import org.apache.flink.table.catalog.CatalogDatabase;
 import org.apache.flink.table.catalog.CatalogDatabaseImpl;
@@ -31,6 +32,7 @@ import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.Column;
 import org.apache.flink.table.catalog.TableChange;
 import org.apache.gravitino.SchemaChange;
+import org.apache.gravitino.flink.connector.PartitionConverter;
 import org.apache.gravitino.flink.connector.PropertiesConverter;
 import org.apache.gravitino.rel.types.Types;
 import org.junit.jupiter.api.Assertions;
@@ -136,6 +138,16 @@ class TestCatalog extends BaseCatalog {
 
   @Override
   protected PropertiesConverter getPropertiesConverter() {
+    return null;
+  }
+
+  @Override
+  protected PartitionConverter getPartitionConverter() {
+    return null;
+  }
+
+  @Override
+  protected AbstractCatalog realCatalog() {
     return null;
   }
 }

--- a/flink-connector/src/test/java/org/apache/gravitino/flink/connector/catalog/TestBaseCatalog.java
+++ b/flink-connector/src/test/java/org/apache/gravitino/flink/connector/catalog/TestBaseCatalog.java
@@ -113,10 +113,7 @@ public class TestBaseCatalog {
     org.apache.gravitino.rel.TableChange[] tableChanges =
         BaseCatalog.getGravitinoTableChanges(table, newTable);
     List<org.apache.gravitino.rel.TableChange> expected =
-        ImmutableList.of(
-            org.apache.gravitino.rel.TableChange.removeProperty("key2"),
-            org.apache.gravitino.rel.TableChange.setProperty("key", "new value"),
-            org.apache.gravitino.rel.TableChange.updateComment("new comment"));
+        ImmutableList.of(org.apache.gravitino.rel.TableChange.updateComment("new comment"));
     Assertions.assertArrayEquals(expected.toArray(), tableChanges);
   }
 }

--- a/flink-connector/src/test/java/org/apache/gravitino/flink/connector/integration/test/FlinkCommonIT.java
+++ b/flink-connector/src/test/java/org/apache/gravitino/flink/connector/integration/test/FlinkCommonIT.java
@@ -24,6 +24,7 @@ import static org.apache.gravitino.flink.connector.integration.test.utils.TestUt
 import static org.apache.gravitino.rel.expressions.transforms.Transforms.EMPTY_TRANSFORM;
 
 import com.google.common.collect.ImmutableMap;
+import java.util.Map;
 import java.util.Optional;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.ResultKind;
@@ -327,6 +328,216 @@ public abstract class FlinkCommonIT extends FlinkEnvIT {
           } catch (TableNotExistException e) {
             Assertions.fail(e);
           }
+        },
+        true);
+  }
+
+  @Test
+  public void testRenameColumn() {
+    String databaseName = "test_renam_column_db";
+    String tableName = "test_rename_column";
+    doWithSchema(
+        currentCatalog(),
+        databaseName,
+        catalog -> {
+          TableResult result =
+              sql(
+                  "CREATE TABLE %s "
+                      + "(user_id INT COMMENT 'USER_ID', "
+                      + " order_amount DOUBLE COMMENT 'ORDER_AMOUNT')"
+                      + " COMMENT 'test comment'",
+                  tableName);
+          TestUtils.assertTableResult(result, ResultKind.SUCCESS);
+
+          result = sql("ALTER TABLE %s RENAME user_id TO user_id_new", tableName);
+          TestUtils.assertTableResult(result, ResultKind.SUCCESS);
+
+          Column[] actual =
+              catalog
+                  .asTableCatalog()
+                  .loadTable(NameIdentifier.of(databaseName, tableName))
+                  .columns();
+          Column[] expected =
+              new Column[] {
+                Column.of("user_id_new", Types.IntegerType.get(), "USER_ID"),
+                Column.of("order_amount", Types.DoubleType.get(), "ORDER_AMOUNT")
+              };
+          assertColumns(expected, actual);
+        },
+        true);
+  }
+
+  @Test
+  public void testAlterTableAddColumn() {
+    String databaseName = "test_alter_table_add_column_db";
+    String tableName = "test_alter_table_add_column";
+    doWithSchema(
+        currentCatalog(),
+        databaseName,
+        catalog -> {
+          TableResult result =
+              sql(
+                  "CREATE TABLE %s "
+                      + "(user_id INT COMMENT 'USER_ID', "
+                      + " order_amount INT COMMENT 'ORDER_AMOUNT')"
+                      + " COMMENT 'test comment'",
+                  tableName);
+          TestUtils.assertTableResult(result, ResultKind.SUCCESS);
+          result = sql("ALTER TABLE %s ADD new_column_2 INT AFTER order_amount", tableName);
+          TestUtils.assertTableResult(result, ResultKind.SUCCESS);
+
+          Column[] actual =
+              catalog
+                  .asTableCatalog()
+                  .loadTable(NameIdentifier.of(databaseName, tableName))
+                  .columns();
+          Column[] expected =
+              new Column[] {
+                Column.of("user_id", Types.IntegerType.get(), "USER_ID"),
+                Column.of("order_amount", Types.IntegerType.get(), "ORDER_AMOUNT"),
+                Column.of("new_column_2", Types.IntegerType.get(), null),
+              };
+          assertColumns(expected, actual);
+        },
+        true);
+  }
+
+  @Test
+  public void testAlterTableDropColumn() {
+    String databaseName = "test_alter_table_drop_column_db";
+    String tableName = "test_alter_table_drop_column";
+    doWithSchema(
+        currentCatalog(),
+        databaseName,
+        catalog -> {
+          TableResult result =
+              sql(
+                  "CREATE TABLE %s "
+                      + "(user_id INT COMMENT 'USER_ID', "
+                      + " order_amount INT COMMENT 'ORDER_AMOUNT')"
+                      + " COMMENT 'test comment'",
+                  tableName);
+          TestUtils.assertTableResult(result, ResultKind.SUCCESS);
+          result = sql("ALTER TABLE %s DROP user_id", tableName);
+          TestUtils.assertTableResult(result, ResultKind.SUCCESS);
+          Column[] actual =
+              catalog
+                  .asTableCatalog()
+                  .loadTable(NameIdentifier.of(databaseName, tableName))
+                  .columns();
+          Column[] expected =
+              new Column[] {Column.of("order_amount", Types.IntegerType.get(), "ORDER_AMOUNT")};
+          assertColumns(expected, actual);
+        },
+        true);
+  }
+
+  @Test
+  public void testAlterTableAlterColumn() {
+    String databaseName = "test_alter_table_alter_column_db";
+    String tableName = "test_alter_table_rename_column";
+    doWithSchema(
+        currentCatalog(),
+        databaseName,
+        catalog -> {
+          TableResult result =
+              sql(
+                  "CREATE TABLE %s "
+                      + "(user_id BIGINT COMMENT 'USER_ID', "
+                      + " order_amount INT COMMENT 'ORDER_AMOUNT')"
+                      + " COMMENT 'test comment'"
+                      + " WITH ("
+                      + "'%s' = '%s')",
+                  tableName, "test key", "test value");
+          TestUtils.assertTableResult(result, ResultKind.SUCCESS);
+          result =
+              sql("ALTER TABLE %s MODIFY order_amount BIGINT COMMENT 'new comment2'", tableName);
+          TestUtils.assertTableResult(result, ResultKind.SUCCESS);
+          result =
+              sql(
+                  "ALTER TABLE %s MODIFY user_id BIGINT COMMENT 'new comment' AFTER order_amount",
+                  tableName);
+          TestUtils.assertTableResult(result, ResultKind.SUCCESS);
+          Column[] actual =
+              catalog
+                  .asTableCatalog()
+                  .loadTable(NameIdentifier.of(databaseName, tableName))
+                  .columns();
+          Column[] expected =
+              new Column[] {
+                Column.of("order_amount", Types.LongType.get(), "new comment2"),
+                Column.of("user_id", Types.LongType.get(), "new comment")
+              };
+          assertColumns(expected, actual);
+        },
+        true);
+  }
+
+  @Test
+  public void testRenameTable() {
+    String databaseName = "test_rename_table_db";
+    String tableName = "test_rename_table";
+    doWithSchema(
+        currentCatalog(),
+        databaseName,
+        catalog -> {
+          TableResult result =
+              sql(
+                  "CREATE TABLE %s "
+                      + "(user_id INT COMMENT 'USER_ID', "
+                      + " order_amount INT COMMENT 'ORDER_AMOUNT')"
+                      + " COMMENT 'test comment'",
+                  tableName);
+          TestUtils.assertTableResult(result, ResultKind.SUCCESS);
+          String newTableName = "new_rename_table_name";
+          result = sql("ALTER TABLE %s RENAME TO %s", tableName, newTableName);
+          TestUtils.assertTableResult(result, ResultKind.SUCCESS);
+          Assertions.assertFalse(
+              catalog.asTableCatalog().tableExists(NameIdentifier.of(databaseName, tableName)));
+          Assertions.assertTrue(
+              catalog.asTableCatalog().tableExists(NameIdentifier.of(databaseName, newTableName)));
+        },
+        true);
+  }
+
+  @Test
+  public void testAlterTableProperties() {
+    String databaseName = "test_alter_table_properties_db";
+    String tableName = "test_alter_table_properties";
+    doWithSchema(
+        currentCatalog(),
+        databaseName,
+        catalog -> {
+          TableResult result =
+              sql(
+                  "CREATE TABLE %s "
+                      + "(user_id INT COMMENT 'USER_ID', "
+                      + " order_amount INT COMMENT 'ORDER_AMOUNT')"
+                      + " COMMENT 'test comment'"
+                      + " WITH ("
+                      + "'%s' = '%s')",
+                  tableName, "key", "value");
+          TestUtils.assertTableResult(result, ResultKind.SUCCESS);
+          result = sql("ALTER TABLE %s SET ('key2' = 'value2', 'key' = 'value1')", tableName);
+          TestUtils.assertTableResult(result, ResultKind.SUCCESS);
+          Map<String, String> properties =
+              catalog
+                  .asTableCatalog()
+                  .loadTable(NameIdentifier.of(databaseName, tableName))
+                  .properties();
+
+          Assertions.assertEquals("value1", properties.get("key"));
+          Assertions.assertEquals("value2", properties.get("key2"));
+          result = sql("ALTER TABLE %s RESET ('key2')", tableName);
+          TestUtils.assertTableResult(result, ResultKind.SUCCESS);
+
+          properties =
+              catalog
+                  .asTableCatalog()
+                  .loadTable(NameIdentifier.of(databaseName, tableName))
+                  .properties();
+          Assertions.assertEquals("value1", properties.get("key"));
+          Assertions.assertNull(properties.get("key2"));
         },
         true);
   }

--- a/flink-connector/src/test/java/org/apache/gravitino/flink/connector/integration/test/FlinkCommonIT.java
+++ b/flink-connector/src/test/java/org/apache/gravitino/flink/connector/integration/test/FlinkCommonIT.java
@@ -433,7 +433,7 @@ public abstract class FlinkCommonIT extends FlinkEnvIT {
   }
 
   @Test
-  public void testAlterTableAlterColumn() {
+  public void testAlterColumnTypeAndChangeOrder() {
     String databaseName = "test_alter_table_alter_column_db";
     String tableName = "test_alter_table_rename_column";
     doWithSchema(

--- a/flink-connector/src/test/java/org/apache/gravitino/flink/connector/utils/TestTypeUtils.java
+++ b/flink-connector/src/test/java/org/apache/gravitino/flink/connector/utils/TestTypeUtils.java
@@ -21,6 +21,7 @@ package org.apache.gravitino.flink.connector.utils;
 
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.catalog.UnresolvedIdentifier;
+import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.DoubleType;
 import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.UnresolvedUserDefinedType;
@@ -37,6 +38,7 @@ public class TestTypeUtils {
         Types.StringType.get(), TypeUtils.toGravitinoType(new VarCharType(Integer.MAX_VALUE)));
     Assertions.assertEquals(Types.DoubleType.get(), TypeUtils.toGravitinoType(new DoubleType()));
     Assertions.assertEquals(Types.IntegerType.get(), TypeUtils.toGravitinoType(new IntType()));
+    Assertions.assertEquals(Types.LongType.get(), TypeUtils.toGravitinoType(new BigIntType()));
     Assertions.assertThrows(
         UnsupportedOperationException.class,
         () ->
@@ -49,6 +51,7 @@ public class TestTypeUtils {
     Assertions.assertEquals(DataTypes.DOUBLE(), TypeUtils.toFlinkType(Types.DoubleType.get()));
     Assertions.assertEquals(DataTypes.STRING(), TypeUtils.toFlinkType(Types.StringType.get()));
     Assertions.assertEquals(DataTypes.INT(), TypeUtils.toFlinkType(Types.IntegerType.get()));
+    Assertions.assertEquals(DataTypes.BIGINT(), TypeUtils.toFlinkType(Types.LongType.get()));
     Assertions.assertThrows(
         UnsupportedOperationException.class,
         () -> TypeUtils.toFlinkType(Types.UnparsedType.of("unknown")));


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

- Support alter table operation for hive table.

### Why are the changes needed?

- Fix: #3981 

### Does this PR introduce _any_ user-facing change?

- no

### How was this patch tested?

- add UTs
