### PR TITLE
[#3737] feat(core): support partition event for event listener

### DIFF
--- a/core/src/main/java/org/apache/gravitino/GravitinoEnv.java
+++ b/core/src/main/java/org/apache/gravitino/GravitinoEnv.java
@@ -44,6 +44,7 @@ import org.apache.gravitino.listener.EventBus;
 import org.apache.gravitino.listener.EventListenerManager;
 import org.apache.gravitino.listener.FilesetEventDispatcher;
 import org.apache.gravitino.listener.MetalakeEventDispatcher;
+import org.apache.gravitino.listener.PartitionEventDispatcher;
 import org.apache.gravitino.listener.SchemaEventDispatcher;
 import org.apache.gravitino.listener.TableEventDispatcher;
 import org.apache.gravitino.listener.TopicEventDispatcher;
@@ -180,6 +181,11 @@ public class GravitinoEnv {
     return tableDispatcher;
   }
 
+  /**
+   * Get the PartitionDispatcher associated with the Gravitino environment.
+   *
+   * @return The PartitionDispatcher instance.
+   */
   public PartitionDispatcher partitionDispatcher() {
     return partitionDispatcher;
   }
@@ -336,9 +342,9 @@ public class GravitinoEnv {
 
     PartitionOperationDispatcher partitionOperationDispatcher =
         new PartitionOperationDispatcher(catalogManager, entityStore, idGenerator);
-    // todo: support PartitionEventDispatcher
-    this.partitionDispatcher =
+    PartitionNormalizeDispatcher partitionNormalizeDispatcher =
         new PartitionNormalizeDispatcher(partitionOperationDispatcher, catalogManager);
+    this.partitionDispatcher = new PartitionEventDispatcher(eventBus, partitionNormalizeDispatcher);
 
     FilesetOperationDispatcher filesetOperationDispatcher =
         new FilesetOperationDispatcher(catalogManager, entityStore, idGenerator);

--- a/core/src/main/java/org/apache/gravitino/listener/PartitionEventDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/listener/PartitionEventDispatcher.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.listener;
+
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.catalog.PartitionDispatcher;
+import org.apache.gravitino.exceptions.NoSuchPartitionException;
+import org.apache.gravitino.exceptions.PartitionAlreadyExistsException;
+import org.apache.gravitino.listener.api.event.AddPartitionEvent;
+import org.apache.gravitino.listener.api.event.AddPartitionFailureEvent;
+import org.apache.gravitino.listener.api.event.DropPartitionEvent;
+import org.apache.gravitino.listener.api.event.DropPartitionFailureEvent;
+import org.apache.gravitino.listener.api.event.GetPartitionEvent;
+import org.apache.gravitino.listener.api.event.GetPartitionFailureEvent;
+import org.apache.gravitino.listener.api.event.ListPartitionEvent;
+import org.apache.gravitino.listener.api.event.ListPartitionFailureEvent;
+import org.apache.gravitino.listener.api.event.ListPartitionNamesEvent;
+import org.apache.gravitino.listener.api.event.ListPartitionNamesFailureEvent;
+import org.apache.gravitino.listener.api.event.PartitionExistsEvent;
+import org.apache.gravitino.listener.api.event.PartitionExistsFailureEvent;
+import org.apache.gravitino.listener.api.event.PurgePartitionEvent;
+import org.apache.gravitino.listener.api.event.PurgePartitionFailureEvent;
+import org.apache.gravitino.listener.api.info.partitions.PartitionInfo;
+import org.apache.gravitino.rel.partitions.Partition;
+import org.apache.gravitino.utils.PrincipalUtils;
+
+/**
+ * {@code PartitionEventDispatcher} is a decorator for {@link PartitionDispatcher} that not only
+ * delegates partition operations to the underlying partition dispatcher but also dispatches
+ * corresponding events to an {@link org.apache.gravitino.listener.EventBus} after each operation is
+ * completed. This allows for event-driven workflows or monitoring of partition operations.
+ */
+public class PartitionEventDispatcher implements PartitionDispatcher {
+  private final EventBus eventBus;
+  private final PartitionDispatcher dispatcher;
+
+  /**
+   * Constructs a PartitionEventDispatcher with a specified EventBus and PartitionDispatcher.
+   *
+   * @param eventBus The EventBus to which events will be dispatched.
+   * @param dispatcher The underlying {@link PartitionDispatcher} that will perform the actual
+   *     partition operations.
+   */
+  public PartitionEventDispatcher(EventBus eventBus, PartitionDispatcher dispatcher) {
+    this.eventBus = eventBus;
+    this.dispatcher = dispatcher;
+  }
+
+  @Override
+  public Partition addPartition(NameIdentifier ident, Partition partition)
+      throws NoSuchPartitionException, PartitionAlreadyExistsException {
+    try {
+      Partition newPartition = dispatcher.addPartition(ident, partition);
+      eventBus.dispatchEvent(
+          new AddPartitionEvent(
+              PrincipalUtils.getCurrentUserName(), ident, PartitionInfo.of(newPartition)));
+      return newPartition;
+    } catch (Exception e) {
+      PartitionInfo createdPartitionInfo = PartitionInfo.of(partition);
+      eventBus.dispatchEvent(
+          new AddPartitionFailureEvent(
+              PrincipalUtils.getCurrentUserName(), ident, e, createdPartitionInfo));
+      throw e;
+    }
+  }
+
+  @Override
+  public Partition getPartition(NameIdentifier ident, String partitionName)
+      throws NoSuchPartitionException {
+    try {
+      Partition partition = dispatcher.getPartition(ident, partitionName);
+      eventBus.dispatchEvent(
+          new GetPartitionEvent(
+              PrincipalUtils.getCurrentUserName(), ident, PartitionInfo.of(partition)));
+      return partition;
+    } catch (Exception e) {
+      eventBus.dispatchEvent(
+          new GetPartitionFailureEvent(
+              PrincipalUtils.getCurrentUserName(), ident, e, partitionName));
+      throw e;
+    }
+  }
+
+  @Override
+  public boolean dropPartition(NameIdentifier ident, String partitionName) {
+    try {
+      boolean isExists = dispatcher.dropPartition(ident, partitionName);
+      eventBus.dispatchEvent(
+          new DropPartitionEvent(
+              PrincipalUtils.getCurrentUserName(), ident, isExists, partitionName));
+      return isExists;
+    } catch (Exception e) {
+      eventBus.dispatchEvent(
+          new DropPartitionFailureEvent(
+              PrincipalUtils.getCurrentUserName(), ident, e, partitionName));
+      throw e;
+    }
+  }
+
+  @Override
+  public Partition[] listPartitions(NameIdentifier ident) {
+    try {
+      Partition[] listPartitions = dispatcher.listPartitions(ident);
+      eventBus.dispatchEvent(new ListPartitionEvent(PrincipalUtils.getCurrentUserName(), ident));
+      return listPartitions;
+    } catch (Exception e) {
+      eventBus.dispatchEvent(
+          new ListPartitionFailureEvent(PrincipalUtils.getCurrentUserName(), ident, e));
+      throw e;
+    }
+  }
+
+  @Override
+  public String[] listPartitionNames(NameIdentifier ident) {
+    try {
+      String[] listPartitionNames = dispatcher.listPartitionNames(ident);
+      eventBus.dispatchEvent(
+          new ListPartitionNamesEvent(PrincipalUtils.getCurrentUserName(), ident));
+      return listPartitionNames;
+    } catch (Exception e) {
+      eventBus.dispatchEvent(
+          new ListPartitionNamesFailureEvent(PrincipalUtils.getCurrentUserName(), ident, e));
+      throw e;
+    }
+  }
+
+  @Override
+  public boolean partitionExists(NameIdentifier ident, String partitionName) {
+    try {
+      boolean isExists = dispatcher.partitionExists(ident, partitionName);
+      eventBus.dispatchEvent(
+          new PartitionExistsEvent(
+              PrincipalUtils.getCurrentUserName(), ident, isExists, partitionName));
+      return isExists;
+    } catch (Exception e) {
+      eventBus.dispatchEvent(
+          new PartitionExistsFailureEvent(
+              PrincipalUtils.getCurrentUserName(), ident, e, partitionName));
+      throw e;
+    }
+  }
+
+  @Override
+  public boolean purgePartition(NameIdentifier ident, String partitionName) {
+    try {
+      boolean isExists = dispatcher.purgePartition(ident, partitionName);
+      eventBus.dispatchEvent(
+          new PurgePartitionEvent(
+              PrincipalUtils.getCurrentUserName(), ident, isExists, partitionName));
+      return isExists;
+    } catch (Exception e) {
+      eventBus.dispatchEvent(
+          new PurgePartitionFailureEvent(
+              PrincipalUtils.getCurrentUserName(), ident, e, partitionName));
+      throw e;
+    }
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/AddPartitionEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/AddPartitionEvent.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.listener.api.event;
+
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.annotation.DeveloperApi;
+import org.apache.gravitino.listener.api.info.partitions.PartitionInfo;
+
+/** Represents an event that is activated upon the successful creation of a partition. */
+@DeveloperApi
+public class AddPartitionEvent extends PartitionEvent {
+  private final PartitionInfo createdPartitionInfo;
+
+  /**
+   * Constructs an instance of {@code AddPartitionEvent}, capturing essential details about the
+   * successful creation of a partition.
+   *
+   * @param user The username of the individual who initiated the add partition.
+   * @param identifier The unique identifier of the partition that was created.
+   * @param createdPartitionInfo The final state of the partition post-creation.
+   */
+  public AddPartitionEvent(
+      String user, NameIdentifier identifier, PartitionInfo createdPartitionInfo) {
+    super(user, identifier);
+    this.createdPartitionInfo = createdPartitionInfo;
+  }
+
+  /**
+   * Provides the final state of the partition as it is presented to the user following the
+   * successful creation.
+   *
+   * @return A {@link PartitionInfo} object that encapsulates the detailed characteristics of the
+   *     newly created partition.
+   */
+  public PartitionInfo createdPartitionInfo() {
+    return createdPartitionInfo;
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/AddPartitionFailureEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/AddPartitionFailureEvent.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.listener.api.event;
+
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.annotation.DeveloperApi;
+import org.apache.gravitino.listener.api.info.partitions.PartitionInfo;
+
+/**
+ * Represents an event that is generated when an attempt to add a partition fails due to an
+ * exception.
+ */
+@DeveloperApi
+public final class AddPartitionFailureEvent extends PartitionFailureEvent {
+  private final PartitionInfo createdPartitionInfo;
+
+  /**
+   * Constructs a {@code AddPartitionFailureEvent} instance, capturing detailed information about
+   * the failed add partition attempt.
+   *
+   * @param user The user who initiated the add partition operation.
+   * @param identifier The identifier of the partition that was attempted to be created.
+   * @param exception The exception that was thrown during the add partition operation, providing
+   *     insight into what went wrong.
+   * @param createdPartitionInfo The original request information used to attempt to add the
+   *     partition. This includes details such as the intended partition schema, properties, and
+   *     other configuration options that were specified.
+   */
+  public AddPartitionFailureEvent(
+      String user,
+      NameIdentifier identifier,
+      Exception exception,
+      PartitionInfo createdPartitionInfo) {
+    super(user, identifier, exception);
+    this.createdPartitionInfo = createdPartitionInfo;
+  }
+
+  /**
+   * Retrieves the original request information for the attempted add partition.
+   *
+   * @return The {@link PartitionInfo} instance representing the request information for the failed
+   *     add partition attempt.
+   */
+  public PartitionInfo createdPartitionInfo() {
+    return createdPartitionInfo;
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/DropPartitionEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/DropPartitionEvent.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.listener.api.event;
+
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.annotation.DeveloperApi;
+
+/** Represents an event that is generated after a partition is successfully dropped. */
+@DeveloperApi
+public final class DropPartitionEvent extends PartitionEvent {
+  private final boolean isExists;
+  private final String partitionName;
+
+  /**
+   * Constructs a new {@code DropPartitionEvent} instance, encapsulating information about the
+   * outcome of a partition drop operation.
+   *
+   * @param user The user who initiated the drop partition operation.
+   * @param identifier The identifier of the partition that was attempted to be dropped.
+   * @param isExists A boolean flag indicating whether the partition existed at the time of the drop
+   *     operation.
+   * @param partitionName The name of the partition.
+   */
+  public DropPartitionEvent(
+      String user, NameIdentifier identifier, boolean isExists, String partitionName) {
+    super(user, identifier);
+    this.isExists = isExists;
+    this.partitionName = partitionName;
+  }
+
+  /**
+   * Retrieves the existence status of the partition at the time of the drop operation.
+   *
+   * @return A boolean value indicating whether the partition existed. {@code true} if the partition
+   *     existed, otherwise {@code false}.
+   */
+  public boolean isExists() {
+    return isExists;
+  }
+
+  /**
+   * Retrieves the existence status of the partition at the time of the drop operation.
+   *
+   * @return A string value indicating the name of the partition.
+   */
+  public String partitionName() {
+    return partitionName;
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/DropPartitionFailureEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/DropPartitionFailureEvent.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.listener.api.event;
+
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.annotation.DeveloperApi;
+
+/**
+ * Represents an event that is generated when an attempt to drop a partition fails due to an
+ * exception.
+ */
+@DeveloperApi
+public final class DropPartitionFailureEvent extends PartitionFailureEvent {
+  private final String partitionName;
+
+  /**
+   * Constructs a new {@code DropPartitionFailureEvent} instance, capturing detailed information
+   * about the failed attempt to drop a partition.
+   *
+   * @param user The user who initiated the drop partition operation.
+   * @param identifier The identifier of the partition that the operation attempted to drop.
+   * @param exception The exception that was thrown during the drop partition operation, offering
+   *     insights into what went wrong and why the operation failed.
+   * @param partitionName The name of the partition.
+   */
+  public DropPartitionFailureEvent(
+      String user, NameIdentifier identifier, Exception exception, String partitionName) {
+    super(user, identifier, exception);
+    this.partitionName = partitionName;
+  }
+
+  /**
+   * Retrieves the existence status of the partition at the time of the drop operation.
+   *
+   * @return A string value indicating the name of the partition.
+   */
+  public String partitionName() {
+    return partitionName;
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/GetPartitionEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/GetPartitionEvent.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.listener.api.event;
+
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.annotation.DeveloperApi;
+import org.apache.gravitino.listener.api.info.partitions.PartitionInfo;
+
+/** Represents an event that is activated upon the successful get operation of a partition. */
+@DeveloperApi
+public class GetPartitionEvent extends PartitionEvent {
+  private final PartitionInfo partitionInfo;
+
+  /**
+   * Constructs an instance of {@code GetPartitionEvent}, capturing essential details about the
+   * successful get a partition.
+   *
+   * @param user The username of the individual who initiated the get partition.
+   * @param identifier The unique identifier of the partition that was gotten.
+   * @param partitionInfo The final state of the partition.
+   */
+  public GetPartitionEvent(String user, NameIdentifier identifier, PartitionInfo partitionInfo) {
+    super(user, identifier);
+    this.partitionInfo = partitionInfo;
+  }
+
+  /**
+   * Provides the final state of the partition as it is presented to the user following the
+   * successful creation.
+   *
+   * @return A {@link PartitionInfo} object that encapsulates the detailed characteristics of the
+   *     newly gotten partition.
+   */
+  public PartitionInfo partitionInfo() {
+    return partitionInfo;
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/GetPartitionEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/GetPartitionEvent.java
@@ -43,7 +43,7 @@ public class GetPartitionEvent extends PartitionEvent {
 
   /**
    * Provides the final state of the partition as it is presented to the user following the
-   * successful creation.
+   * successful get operation of a partition.
    *
    * @return A {@link PartitionInfo} object that encapsulates the detailed characteristics of the
    *     newly gotten partition.

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/GetPartitionFailureEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/GetPartitionFailureEvent.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.listener.api.event;
+
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.annotation.DeveloperApi;
+
+/**
+ * Represents an event that is generated when an attempt to get a partition fails due to an
+ * exception.
+ */
+@DeveloperApi
+public final class GetPartitionFailureEvent extends PartitionFailureEvent {
+  private final String partitionName;
+
+  /**
+   * Constructs a {@code GetPartitionFailureEvent} instance, capturing detailed information about
+   * the failed get partition attempt.
+   *
+   * @param user The user who initiated the get partition operation.
+   * @param identifier The identifier of the partition that was attempted to be gotten.
+   * @param exception The exception that was thrown during the get partition operation, providing
+   *     insight into what went wrong.
+   */
+  public GetPartitionFailureEvent(
+      String user, NameIdentifier identifier, Exception exception, String partitionName) {
+    super(user, identifier, exception);
+    this.partitionName = partitionName;
+  }
+
+  /**
+   * Retrieves the existence status of the partition at the time of the purge operation.
+   *
+   * @return A string value indicating the name of the partition.
+   */
+  public String partitionName() {
+    return partitionName;
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/ListPartitionEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/ListPartitionEvent.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.listener.api.event;
+
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.annotation.DeveloperApi;
+
+/** Represents an event that is triggered upon the successful list of partitions. */
+@DeveloperApi
+public final class ListPartitionEvent extends PartitionEvent {
+  /**
+   * Constructs an instance of {@code ListPartitionEvent}.
+   *
+   * @param user The username of the individual who initiated the partition listing.
+   * @param ident The identifier from which partitions were listed.
+   */
+  public ListPartitionEvent(String user, NameIdentifier ident) {
+    super(user, ident);
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/ListPartitionFailureEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/ListPartitionFailureEvent.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.listener.api.event;
+
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.annotation.DeveloperApi;
+
+/**
+ * Represents an event that is triggered when an attempt to list partitions within a namespace fails
+ * due to an exception.
+ */
+@DeveloperApi
+public final class ListPartitionFailureEvent extends PartitionFailureEvent {
+  /**
+   * Constructs a {@code ListPartitionFailureEvent} instance.
+   *
+   * @param user The username of the individual who initiated the operation to list partitions.
+   * @param ident The identifier from which partitions were listed.
+   * @param exception The exception encountered during the attempt to list partitions.
+   */
+  public ListPartitionFailureEvent(String user, NameIdentifier ident, Exception exception) {
+    super(user, ident, exception);
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/ListPartitionNamesEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/ListPartitionNamesEvent.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.listener.api.event;
+
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.annotation.DeveloperApi;
+
+/** Represents an event that is triggered upon the successful list of partitions. */
+@DeveloperApi
+public final class ListPartitionNamesEvent extends PartitionEvent {
+  /**
+   * Constructs an instance of {@code ListPartitionNamesEvent}.
+   *
+   * @param user The username of the individual who initiated the partition listing.
+   * @param ident The identifier from which partitions were listed.
+   */
+  public ListPartitionNamesEvent(String user, NameIdentifier ident) {
+    super(user, ident);
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/ListPartitionNamesFailureEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/ListPartitionNamesFailureEvent.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.listener.api.event;
+
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.annotation.DeveloperApi;
+
+/**
+ * Represents an event that is triggered when an attempt to list partitions within a namespace fails
+ * due to an exception.
+ */
+@DeveloperApi
+public final class ListPartitionNamesFailureEvent extends PartitionFailureEvent {
+  /**
+   * Constructs a {@code ListPartitionNamesFailureEvent} instance.
+   *
+   * @param user The username of the individual who initiated the operation to list partitions.
+   * @param ident The identifier from which partitions were listed.
+   * @param exception The exception encountered during the attempt to list partitions.
+   */
+  public ListPartitionNamesFailureEvent(String user, NameIdentifier ident, Exception exception) {
+    super(user, ident, exception);
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/PartitionEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/PartitionEvent.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.listener.api.event;
+
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.annotation.DeveloperApi;
+
+/**
+ * Represents an abstract base class for events related to Partition operations. This class extends
+ * {@link Event} to provide a more specific context involving operations on Partitions, such as
+ * creation, deletion, or modification. It captures essential information including the user
+ * performing the operation and the identifier of the Partition being operated on.
+ */
+@DeveloperApi
+public abstract class PartitionEvent extends Event {
+  /**
+   * Constructs a new {@code PartitionEvent} with the specified user and Partition identifier.
+   *
+   * @param user The user responsible for triggering the Partition operation.
+   * @param identifier The identifier of the Partition involved in the operation.
+   */
+  protected PartitionEvent(String user, NameIdentifier identifier) {
+    super(user, identifier);
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/PartitionExistsEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/PartitionExistsEvent.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.listener.api.event;
+
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.annotation.DeveloperApi;
+
+/**
+ * Represents an event that is activated upon the successful check existing operation of a
+ * partition.
+ */
+@DeveloperApi
+public class PartitionExistsEvent extends PartitionEvent {
+  private final boolean isExists;
+  private final String partitionName;
+
+  /**
+   * Constructs an instance of {@code PartitionExistsEvent}, capturing essential details about the
+   * successful get a partition.
+   *
+   * @param user The username of the individual who initiated the check existion operation of a
+   *     partition.
+   * @param identifier The unique identifier of the partition that was gotten.
+   * @param isExists A boolean indicator reflecting whether the partition was present in the table
+   *     at the time of the check existing operation.
+   * @param partitionName The name of the partition.
+   */
+  public PartitionExistsEvent(
+      String user, NameIdentifier identifier, boolean isExists, String partitionName) {
+    super(user, identifier);
+    this.isExists = isExists;
+    this.partitionName = partitionName;
+  }
+
+  /**
+   * Retrieves the status of the partition's existence at the time of the exist check operation.
+   *
+   * @return A boolean value indicating the partition's existence status. {@code true} signifies
+   *     that the partition was present before the operation, {@code false} indicates it was not.
+   */
+  public boolean isExists() {
+    return isExists;
+  }
+
+  /**
+   * Retrieves the existence status of the partition at the time of the exist check operation.
+   *
+   * @return A string value indicating the name of the partition.
+   */
+  public String partitionName() {
+    return partitionName;
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/PartitionExistsFailureEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/PartitionExistsFailureEvent.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.listener.api.event;
+
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.annotation.DeveloperApi;
+
+/**
+ * Represents an event that is generated when an attempt to get a partition fails due to an
+ * exception.
+ */
+@DeveloperApi
+public final class PartitionExistsFailureEvent extends PartitionFailureEvent {
+  private final String partitionName;
+
+  /**
+   * Constructs a {@code PartitionExistsFailureEvent} instance, capturing detailed information about
+   * the failed partition exist check attempt.
+   *
+   * @param user The user who initiated the partition exist check operation.
+   * @param identifier The identifier of the partition that was attempted to be gotten.
+   * @param exception The exception that was thrown during the partition exist check operation,
+   *     providing insight into what went wrong.
+   */
+  public PartitionExistsFailureEvent(
+      String user, NameIdentifier identifier, Exception exception, String partitionName) {
+    super(user, identifier, exception);
+    this.partitionName = partitionName;
+  }
+
+  /**
+   * Retrieves the existence status of the partition at the time of the exist check operation.
+   *
+   * @return A string value indicating the name of the partition.
+   */
+  public String partitionName() {
+    return partitionName;
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/PartitionFailureEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/PartitionFailureEvent.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.listener.api.event;
+
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.annotation.DeveloperApi;
+
+/**
+ * An abstract class representing events that are triggered when a Partition operation fails due to
+ * an exception. This class extends {@link FailureEvent} to provide a more specific context related
+ * to Partition operations, encapsulating details about the user who initiated the operation, the
+ * identifier of the Partition involved, and the exception that led to the failure.
+ */
+@DeveloperApi
+public abstract class PartitionFailureEvent extends FailureEvent {
+  /**
+   * Constructs a new {@code PartitionFailureEvent} instance, capturing information about the failed
+   * Partition operation.
+   *
+   * @param user The user associated with the failed Partition operation.
+   * @param identifier The identifier of the Partition that was involved in the failed operation.
+   * @param exception The exception that was thrown during the Partition operation, indicating the
+   *     cause of the failure.
+   */
+  protected PartitionFailureEvent(String user, NameIdentifier identifier, Exception exception) {
+    super(user, identifier, exception);
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/PurgePartitionEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/PurgePartitionEvent.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.listener.api.event;
+
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.annotation.DeveloperApi;
+
+/** Represents an event that occurs after a partition is successfully purged from the table. */
+@DeveloperApi
+public final class PurgePartitionEvent extends PartitionEvent {
+  private final boolean isExists;
+  private final String partitionName;
+
+  /**
+   * Constructs a new {@code PurgePartitionEvent} instance.
+   *
+   * @param user The user who initiated the purge partition operation.
+   * @param identifier The identifier of the partition that was targeted for purging.
+   * @param isExists A boolean indicator reflecting whether the partition was present in the table
+   *     at the time of the purge operation.
+   * @param partitionName The name of the partition.
+   */
+  public PurgePartitionEvent(
+      String user, NameIdentifier identifier, boolean isExists, String partitionName) {
+    super(user, identifier);
+    this.isExists = isExists;
+    this.partitionName = partitionName;
+  }
+
+  /**
+   * Retrieves the status of the partition's existence at the time of the purge operation.
+   *
+   * @return A boolean value indicating the partition's existence status. {@code true} signifies
+   *     that the partition was present before the operation, {@code false} indicates it was not.
+   */
+  public boolean isExists() {
+    return isExists;
+  }
+
+  /**
+   * Retrieves the existence status of the partition at the time of the purge operation.
+   *
+   * @return A string value indicating the name of the partition.
+   */
+  public String partitionName() {
+    return partitionName;
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/PurgePartitionFailureEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/PurgePartitionFailureEvent.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.listener.api.event;
+
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.annotation.DeveloperApi;
+
+/**
+ * Represents an event triggered when an attempt to purge a partition from the table fails due to an
+ * exception.
+ */
+@DeveloperApi
+public final class PurgePartitionFailureEvent extends PartitionFailureEvent {
+  private final String partitionName;
+
+  /**
+   * Constructs a new {@code PurgePartitionFailureEvent} instance.
+   *
+   * @param user The user who initiated the partition purge operation.
+   * @param identifier The identifier of the partition intended to be purged.
+   * @param exception The exception encountered during the partition purge operation, providing
+   *     insights into the reasons behind the operation's failure.
+   * @param partitionName The name of the partition.
+   */
+  public PurgePartitionFailureEvent(
+      String user, NameIdentifier identifier, Exception exception, String partitionName) {
+    super(user, identifier, exception);
+    this.partitionName = partitionName;
+  }
+
+  /**
+   * Retrieves the existence status of the partition at the time of the purge operation.
+   *
+   * @return A string value indicating the name of the partition.
+   */
+  public String partitionName() {
+    return partitionName;
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/listener/api/info/partitions/IdentityPartitionInfo.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/info/partitions/IdentityPartitionInfo.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.listener.api.info.partitions;
+
+import java.util.Map;
+import org.apache.gravitino.annotation.DeveloperApi;
+import org.apache.gravitino.rel.expressions.literals.Literal;
+
+/**
+ * An identity partition represents a result of identity partitioning. For example, for Hive
+ * partition
+ *
+ * <pre>`PARTITION (dt='2008-08-08',country='us')`</pre>
+ *
+ * its partition name is "dt=2008-08-08/country=us", field names are [["dt"], ["country"]] and
+ * values are ["2008-08-08", "us"].
+ */
+@DeveloperApi
+public final class IdentityPartitionInfo extends PartitionInfo {
+  private final String[][] fieldNames;
+  private final Literal<?>[] values;
+
+  /**
+   * Constructs IdentityPartitionInfo with specified details.
+   *
+   * @param name The name of the Partition.
+   * @param fieldNames The field names of the identity partition.
+   * @param values The values of the identity partition.
+   * @param properties A map of properties associated with the Partition.
+   */
+  public IdentityPartitionInfo(
+      String name, String[][] fieldNames, Literal<?>[] values, Map<String, String> properties) {
+    super(name, properties);
+    this.fieldNames = fieldNames;
+    this.values = values;
+  }
+
+  /**
+   * The field names of the identity partition.
+   *
+   * @return The field names of the identity partition.
+   */
+  public String[][] fieldNames() {
+    return fieldNames;
+  }
+
+  /**
+   * The values of the identity partition.
+   *
+   * @return The values of the identity partition.
+   */
+  public Literal<?>[] values() {
+    return values;
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/listener/api/info/partitions/ListPartitionInfo.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/info/partitions/ListPartitionInfo.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.listener.api.info.partitions;
+
+import java.util.Map;
+import org.apache.gravitino.annotation.DeveloperApi;
+import org.apache.gravitino.rel.expressions.literals.Literal;
+
+/**
+ * A list partition represents a result of list partitioning. For example, for list partition
+ *
+ * <pre>
+ *     `PARTITION p202204_California VALUES IN (
+ *       ("2022-04-01", "Los Angeles"),
+ *       ("2022-04-01", "San Francisco")
+ *     )`
+ *     </pre>
+ *
+ * its name is "p202204_California" and lists are [["2022-04-01","Los Angeles"], ["2022-04-01", "San
+ * Francisco"]].
+ */
+@DeveloperApi
+public final class ListPartitionInfo extends PartitionInfo {
+  private final Literal<?>[][] lists;
+
+  /**
+   * Constructs ListPartitionInfo with specified details.
+   *
+   * @param name The name of the Partition.
+   * @param properties A map of properties associated with the Partition.
+   * @param lists The values of the list partition.
+   */
+  public ListPartitionInfo(String name, Map<String, String> properties, Literal<?>[][] lists) {
+    super(name, properties);
+    this.lists = lists;
+  }
+
+  /**
+   * Returns the values of the list partition.
+   *
+   * @return the values of the list partition.
+   */
+  public Literal<?>[][] lists() {
+    return lists;
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/listener/api/info/partitions/PartitionInfo.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/info/partitions/PartitionInfo.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.listener.api.info.partitions;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import org.apache.gravitino.annotation.DeveloperApi;
+import org.apache.gravitino.exceptions.GravitinoRuntimeException;
+import org.apache.gravitino.rel.partitions.IdentityPartition;
+import org.apache.gravitino.rel.partitions.ListPartition;
+import org.apache.gravitino.rel.partitions.Partition;
+import org.apache.gravitino.rel.partitions.RangePartition;
+
+/**
+ * Provides access to metadata about a Partition instance, designed for use by event listeners. This
+ * class encapsulates the essential attributes of a Partition, including its name and properties
+ * information.
+ */
+@DeveloperApi
+public abstract class PartitionInfo {
+  private String name;
+  private Map<String, String> properties;
+
+  /**
+   * Directly constructs PartitionInfo with specified details.
+   *
+   * @param name The name of the Partition.
+   * @param properties A map of properties associated with the Partition.
+   */
+  protected PartitionInfo(String name, Map<String, String> properties) {
+    this.name = name;
+    this.properties = properties == null ? ImmutableMap.of() : ImmutableMap.copyOf(properties);
+  }
+
+  /**
+   * Returns the name of the Partition.
+   *
+   * @return The Partition's name.
+   */
+  public String name() {
+    return name;
+  }
+
+  /**
+   * Returns the properties of the Partition.
+   *
+   * @return A map of Partition properties.
+   */
+  public Map<String, String> properties() {
+    return properties;
+  }
+
+  /**
+   * Returns the instance of the PartitionInfo.
+   *
+   * @return A instance of the PartitionInfo
+   */
+  public static PartitionInfo of(Partition partition) {
+    if (partition instanceof IdentityPartition) {
+      IdentityPartition identityPartition = (IdentityPartition) partition;
+      return new IdentityPartitionInfo(
+          identityPartition.name(),
+          identityPartition.fieldNames(),
+          identityPartition.values(),
+          identityPartition.properties());
+    } else if (partition instanceof ListPartition) {
+      ListPartition listPartition = (ListPartition) partition;
+      return new ListPartitionInfo(
+          listPartition.name(), listPartition.properties(), listPartition.lists());
+    } else if (partition instanceof RangePartition) {
+      RangePartition rangePartition = (RangePartition) partition;
+      return new RangePartitionInfo(
+          rangePartition.name(),
+          rangePartition.upper(),
+          rangePartition.lower(),
+          rangePartition.properties());
+    } else {
+      throw new GravitinoRuntimeException("Invalid instance of PartitionInfo");
+    }
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/listener/api/info/partitions/RangePartitionInfo.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/info/partitions/RangePartitionInfo.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.listener.api.info.partitions;
+
+import java.util.Map;
+import org.apache.gravitino.annotation.DeveloperApi;
+import org.apache.gravitino.rel.expressions.literals.Literal;
+
+/**
+ * A range partition represents a result of range partitioning. For example, for range partition
+ *
+ * <pre>`PARTITION p20200321 VALUES LESS THAN ("2020-03-22")`</pre>
+ *
+ * its upper bound is "2020-03-22" and its lower bound is null.
+ */
+@DeveloperApi
+public final class RangePartitionInfo extends PartitionInfo {
+  private final Literal<?> upper;
+  private final Literal<?> lower;
+
+  /**
+   * Constructs RangePartitionInfo with specified details.
+   *
+   * @param name The name of the Partition.
+   * @param upper The upper bound of the partition.
+   * @param lower The lower bound of the partition.
+   * @param properties A map of properties associated with the Partition.
+   */
+  public RangePartitionInfo(
+      String name, Literal<?> upper, Literal<?> lower, Map<String, String> properties) {
+    super(name, properties);
+    this.upper = upper;
+    this.lower = lower;
+  }
+
+  /**
+   * The upper bound of the partition.
+   *
+   * @return The upper bound of the partition.
+   */
+  public Literal<?> upper() {
+    return upper;
+  }
+
+  /**
+   * The lower bound of the partition.
+   *
+   * @return The lower bound of the partition.
+   */
+  public Literal<?> lower() {
+    return lower;
+  }
+}

--- a/core/src/test/java/org/apache/gravitino/listener/api/event/TestPartitionEvent.java
+++ b/core/src/test/java/org/apache/gravitino/listener/api/event/TestPartitionEvent.java
@@ -1,0 +1,300 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.listener.api.event;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+import java.time.LocalDate;
+import java.util.Arrays;
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.catalog.PartitionDispatcher;
+import org.apache.gravitino.exceptions.GravitinoRuntimeException;
+import org.apache.gravitino.listener.DummyEventListener;
+import org.apache.gravitino.listener.EventBus;
+import org.apache.gravitino.listener.PartitionEventDispatcher;
+import org.apache.gravitino.listener.api.info.partitions.IdentityPartitionInfo;
+import org.apache.gravitino.listener.api.info.partitions.ListPartitionInfo;
+import org.apache.gravitino.listener.api.info.partitions.PartitionInfo;
+import org.apache.gravitino.listener.api.info.partitions.RangePartitionInfo;
+import org.apache.gravitino.rel.expressions.literals.Literal;
+import org.apache.gravitino.rel.expressions.literals.Literals;
+import org.apache.gravitino.rel.partitions.IdentityPartition;
+import org.apache.gravitino.rel.partitions.ListPartition;
+import org.apache.gravitino.rel.partitions.Partition;
+import org.apache.gravitino.rel.partitions.Partitions;
+import org.apache.gravitino.rel.partitions.RangePartition;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+
+@TestInstance(Lifecycle.PER_CLASS)
+public class TestPartitionEvent {
+  private PartitionDispatcher dispatcher;
+  private PartitionDispatcher failureDispatcher;
+  private DummyEventListener dummyEventListener;
+  private Partition partition;
+
+  @BeforeAll
+  void init() {
+    this.partition = mockPartition();
+    this.dummyEventListener = new DummyEventListener();
+    EventBus eventBus = new EventBus(Arrays.asList(dummyEventListener));
+    PartitionDispatcher partitionDispatcher = mockPartitionDispatcher();
+    this.dispatcher = new PartitionEventDispatcher(eventBus, partitionDispatcher);
+    PartitionDispatcher partitionExceptionDispatcher = mockExceptionPartitionDispatcher();
+    this.failureDispatcher = new PartitionEventDispatcher(eventBus, partitionExceptionDispatcher);
+  }
+
+  @Test
+  void testCreatePartitionInfo() {
+    Partition partition =
+        Partitions.range("p0", Literals.NULL, Literals.integerLiteral(6), Maps.newHashMap());
+    PartitionInfo partitionInfo = PartitionInfo.of(partition);
+    checkPartitionInfo(partitionInfo, partition);
+
+    partition =
+        Partitions.list(
+            "p202204_California",
+            new Literal[][] {
+              {
+                Literals.dateLiteral(LocalDate.parse("2022-04-01")),
+                Literals.stringLiteral("Los Angeles")
+              },
+              {
+                Literals.dateLiteral(LocalDate.parse("2022-04-01")),
+                Literals.stringLiteral("San Francisco")
+              }
+            },
+            Maps.newHashMap());
+    partitionInfo = PartitionInfo.of(partition);
+    checkPartitionInfo(partitionInfo, partition);
+
+    partition =
+        Partitions.identity(
+            "dt=2008-08-08/country=us",
+            new String[][] {{"dt"}, {"country"}},
+            new Literal[] {
+              Literals.dateLiteral(LocalDate.parse("2008-08-08")), Literals.stringLiteral("us")
+            },
+            ImmutableMap.of("location", "/user/hive/warehouse/tpch_flat_orc_2.db/orders"));
+    partitionInfo = PartitionInfo.of(partition);
+    checkPartitionInfo(partitionInfo, partition);
+
+    Assertions.assertThrowsExactly(GravitinoRuntimeException.class, () -> PartitionInfo.of(null));
+  }
+
+  @Test
+  void testAddPartitionEvent() {
+    NameIdentifier identifier = NameIdentifier.of("metalake", "catalog", "schema", "table");
+    dispatcher.addPartition(identifier, partition);
+    Event event = dummyEventListener.popEvent();
+    Assertions.assertEquals(identifier, event.identifier());
+    Assertions.assertEquals(AddPartitionEvent.class, event.getClass());
+    PartitionInfo partitionInfo = ((AddPartitionEvent) event).createdPartitionInfo();
+    checkPartitionInfo(partitionInfo, partition);
+  }
+
+  @Test
+  void testDropPartitionEvent() {
+    NameIdentifier identifier = NameIdentifier.of("metalake", "catalog", "schema", "table");
+    dispatcher.dropPartition(identifier, partition.name());
+    Event event = dummyEventListener.popEvent();
+    Assertions.assertEquals(identifier, event.identifier());
+    Assertions.assertEquals(DropPartitionEvent.class, event.getClass());
+    Assertions.assertEquals(false, ((DropPartitionEvent) event).isExists());
+  }
+
+  @Test
+  void testPartitionExistsEvent() {
+    NameIdentifier identifier = NameIdentifier.of("metalake", "catalog", "schema", "table");
+    dispatcher.partitionExists(identifier, partition.name());
+    Event event = dummyEventListener.popEvent();
+    Assertions.assertEquals(identifier, event.identifier());
+    Assertions.assertEquals(PartitionExistsEvent.class, event.getClass());
+    Assertions.assertEquals(false, ((PartitionExistsEvent) event).isExists());
+  }
+
+  @Test
+  void testListPartitionEvent() {
+    NameIdentifier identifier = NameIdentifier.of("metalake", "catalog", "schema", "table");
+    dispatcher.listPartitions(identifier);
+    Event event = dummyEventListener.popEvent();
+    Assertions.assertEquals(identifier, event.identifier());
+    Assertions.assertEquals(ListPartitionEvent.class, event.getClass());
+    Assertions.assertEquals(identifier, ((ListPartitionEvent) event).identifier());
+  }
+
+  @Test
+  void testListPartitionNamesEvent() {
+    NameIdentifier identifier = NameIdentifier.of("metalake", "catalog", "schema", "table");
+    dispatcher.listPartitionNames(identifier);
+    Event event = dummyEventListener.popEvent();
+    Assertions.assertEquals(identifier, event.identifier());
+    Assertions.assertEquals(ListPartitionNamesEvent.class, event.getClass());
+    Assertions.assertEquals(identifier, ((ListPartitionNamesEvent) event).identifier());
+  }
+
+  @Test
+  void testPurgePartitionEvent() {
+    NameIdentifier identifier = NameIdentifier.of("metalake", "catalog", "schema", "table");
+    dispatcher.purgePartition(identifier, partition.name());
+    Event event = dummyEventListener.popEvent();
+    Assertions.assertEquals(identifier, event.identifier());
+    Assertions.assertEquals(PurgePartitionEvent.class, event.getClass());
+    Assertions.assertEquals(identifier, ((PurgePartitionEvent) event).identifier());
+  }
+
+  @Test
+  void testAddPartitionFailureEvent() {
+    NameIdentifier identifier = NameIdentifier.of("metalake", "catalog", "schema", "table");
+    Assertions.assertThrowsExactly(
+        GravitinoRuntimeException.class,
+        () -> failureDispatcher.addPartition(identifier, partition));
+    Event event = dummyEventListener.popEvent();
+    Assertions.assertEquals(AddPartitionFailureEvent.class, event.getClass());
+    Assertions.assertEquals(
+        GravitinoRuntimeException.class, ((AddPartitionFailureEvent) event).exception().getClass());
+    checkPartitionInfo(((AddPartitionFailureEvent) event).createdPartitionInfo(), partition);
+    Assertions.assertEquals(identifier, event.identifier());
+  }
+
+  @Test
+  void testDropPartitionFailureEvent() {
+    NameIdentifier identifier = NameIdentifier.of("metalake", "catalog", "schema", "table");
+    Assertions.assertThrowsExactly(
+        GravitinoRuntimeException.class,
+        () -> failureDispatcher.dropPartition(identifier, partition.name()));
+    Event event = dummyEventListener.popEvent();
+    Assertions.assertEquals(DropPartitionFailureEvent.class, event.getClass());
+    Assertions.assertEquals(
+        GravitinoRuntimeException.class,
+        ((DropPartitionFailureEvent) event).exception().getClass());
+    Assertions.assertEquals(identifier, event.identifier());
+  }
+
+  @Test
+  void testPartitionExistsFailureEvent() {
+    NameIdentifier identifier = NameIdentifier.of("metalake", "catalog", "schema", "table");
+    Assertions.assertThrowsExactly(
+        GravitinoRuntimeException.class,
+        () -> failureDispatcher.partitionExists(identifier, partition.name()));
+    Event event = dummyEventListener.popEvent();
+    Assertions.assertEquals(PartitionExistsFailureEvent.class, event.getClass());
+    Assertions.assertEquals(
+        GravitinoRuntimeException.class,
+        ((PartitionExistsFailureEvent) event).exception().getClass());
+    Assertions.assertEquals(identifier, event.identifier());
+  }
+
+  @Test
+  void testListPartitionFailureEvent() {
+    NameIdentifier identifier = NameIdentifier.of("metalake", "catalog", "schema", "table");
+    Assertions.assertThrowsExactly(
+        GravitinoRuntimeException.class, () -> failureDispatcher.listPartitions(identifier));
+    Event event = dummyEventListener.popEvent();
+    Assertions.assertEquals(ListPartitionFailureEvent.class, event.getClass());
+    Assertions.assertEquals(
+        GravitinoRuntimeException.class,
+        ((ListPartitionFailureEvent) event).exception().getClass());
+    Assertions.assertEquals(identifier, ((ListPartitionFailureEvent) event).identifier());
+  }
+
+  @Test
+  void testListPartitionNamesFailureEvent() {
+    NameIdentifier identifier = NameIdentifier.of("metalake", "catalog", "schema", "table");
+    Assertions.assertThrowsExactly(
+        GravitinoRuntimeException.class, () -> failureDispatcher.listPartitionNames(identifier));
+    Event event = dummyEventListener.popEvent();
+    Assertions.assertEquals(ListPartitionNamesFailureEvent.class, event.getClass());
+    Assertions.assertEquals(
+        GravitinoRuntimeException.class,
+        ((ListPartitionNamesFailureEvent) event).exception().getClass());
+    Assertions.assertEquals(identifier, ((ListPartitionNamesFailureEvent) event).identifier());
+  }
+
+  @Test
+  void testPurgePartitionFailureEvent() {
+    NameIdentifier identifier = NameIdentifier.of("metalake", "catalog", "schema", "table");
+    Assertions.assertThrowsExactly(
+        GravitinoRuntimeException.class,
+        () -> failureDispatcher.purgePartition(identifier, partition.name()));
+    Event event = dummyEventListener.popEvent();
+    Assertions.assertEquals(PurgePartitionFailureEvent.class, event.getClass());
+    Assertions.assertEquals(
+        GravitinoRuntimeException.class,
+        ((PurgePartitionFailureEvent) event).exception().getClass());
+    Assertions.assertEquals(identifier, event.identifier());
+  }
+
+  private void checkPartitionInfo(PartitionInfo partitionInfo, Partition partition) {
+    Assertions.assertEquals(partition.name(), partitionInfo.name());
+    Assertions.assertEquals(partition.properties(), partitionInfo.properties());
+
+    if (partitionInfo instanceof ListPartitionInfo) {
+      Assertions.assertEquals(
+          ((ListPartition) partition).lists(), ((ListPartitionInfo) partitionInfo).lists());
+    } else if (partitionInfo instanceof IdentityPartitionInfo) {
+      Assertions.assertEquals(
+          ((IdentityPartition) partition).fieldNames(),
+          ((IdentityPartitionInfo) partitionInfo).fieldNames());
+      Assertions.assertEquals(
+          ((IdentityPartition) partition).values(),
+          ((IdentityPartitionInfo) partitionInfo).values());
+    } else if (partitionInfo instanceof RangePartitionInfo) {
+      Assertions.assertEquals(
+          ((RangePartition) partition).upper(), ((RangePartitionInfo) partitionInfo).upper());
+      Assertions.assertEquals(
+          ((RangePartition) partition).lower(), ((RangePartitionInfo) partitionInfo).lower());
+    }
+  }
+
+  private Partition mockPartition() {
+    Partition partition =
+        Partitions.range("p0", Literals.NULL, Literals.integerLiteral(6), Maps.newHashMap());
+    return partition;
+  }
+
+  private PartitionDispatcher mockPartitionDispatcher() {
+    PartitionDispatcher dispatcher = mock(PartitionDispatcher.class);
+    when(dispatcher.addPartition(any(NameIdentifier.class), any(Partition.class)))
+        .thenReturn(partition);
+    when(dispatcher.getPartition(any(NameIdentifier.class), any(String.class)))
+        .thenReturn(partition);
+    when(dispatcher.listPartitionNames(any(NameIdentifier.class))).thenReturn(null);
+    when(dispatcher.listPartitions(any(NameIdentifier.class))).thenReturn(null);
+    return dispatcher;
+  }
+
+  private PartitionDispatcher mockExceptionPartitionDispatcher() {
+    PartitionDispatcher dispatcher =
+        mock(
+            PartitionDispatcher.class,
+            invocation -> {
+              throw new GravitinoRuntimeException("Exception for all methods");
+            });
+    return dispatcher;
+  }
+}


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?
* create a PartitionEventDispatcher in GravitinoEnv, which hacks partition operation and generate event to event listener. the system will auto inject PartitionEventDispatcher to PartitionOperations
* create corresponding event like addPartitionEvent getPartitionEvent
* add test , please refer to TestCatalogEvent

### Why are the changes needed?
Fix: [[Subtask] support partition event for event listener #3737](https://github.com/apache/gravitino/issues/3737)

### Does this PR introduce _any_ user-facing change?
  1. no

### How was this patch tested?
  1. Add UTs
