### PR TITLE
[#4112] feat(API, client): Add fileset comment removal operations

### DIFF
--- a/api/src/main/java/com/datastrato/gravitino/file/FilesetChange.java
+++ b/api/src/main/java/com/datastrato/gravitino/file/FilesetChange.java
@@ -75,7 +75,7 @@ public interface FilesetChange {
    * @return The fileset change.
    */
   static FilesetChange removeComment() {
-    return new RemoveComment();
+    return RemoveComment.getInstance();
   }
 
   /** A fileset change to rename the fileset. */
@@ -312,7 +312,11 @@ public interface FilesetChange {
 
   /** A fileset change to remove comment from the fileset. */
   final class RemoveComment implements FilesetChange {
-    private RemoveComment() {}
+    private static final RemoveComment INSTANCE = new RemoveComment();
+
+    private static RemoveComment getInstance() {
+      return INSTANCE;
+    }
 
     /**
      * Compares this RemoveComment instance with another object for equality. Two instances are

--- a/api/src/main/java/com/datastrato/gravitino/file/FilesetChange.java
+++ b/api/src/main/java/com/datastrato/gravitino/file/FilesetChange.java
@@ -69,6 +69,15 @@ public interface FilesetChange {
     return new RemoveProperty(property);
   }
 
+  /**
+   * Creates a new fileset change to remove comment from the fileset.
+   *
+   * @return The fileset change.
+   */
+  static FilesetChange removeComment() {
+    return new RemoveComment();
+  }
+
   /** A fileset change to rename the fileset. */
   final class RenameFileset implements FilesetChange {
     private final String newName;
@@ -298,6 +307,46 @@ public interface FilesetChange {
     @Override
     public String toString() {
       return "REMOVEPROPERTY " + property;
+    }
+  }
+
+  /** A fileset change to remove comment from the fileset. */
+  final class RemoveComment implements FilesetChange {
+    private RemoveComment() {}
+
+    /**
+     * Compares this RemoveComment instance with another object for equality. Two instances are
+     * considered equal if they are RemoveComment instance.
+     *
+     * @param o The object to compare with this instance.
+     * @return true if the given object represents remove comment change; false otherwise.
+     */
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      return o != null && getClass() == o.getClass();
+    }
+
+    /**
+     * Generates a hash code for this RemoveComment instance. The hash code is based on the
+     * RemoveComment instance name.
+     *
+     * @return A hash code value for instance.
+     */
+    @Override
+    public int hashCode() {
+      return Objects.hash("REMOVECOMMENT");
+    }
+
+    /**
+     * Provides a string representation of the RemoveComment instance. This string format includes
+     * the class name.
+     *
+     * @return A string summary of the comment removal operation.
+     */
+    @Override
+    public String toString() {
+      return "REMOVECOMMENT";
     }
   }
 }

--- a/catalogs/catalog-hadoop/src/main/java/com/datastrato/gravitino/catalog/hadoop/HadoopCatalogOperations.java
+++ b/catalogs/catalog-hadoop/src/main/java/com/datastrato/gravitino/catalog/hadoop/HadoopCatalogOperations.java
@@ -597,6 +597,8 @@ public class HadoopCatalogOperations implements CatalogOperations, SupportsSchem
         newName = ((FilesetChange.RenameFileset) change).getNewName();
       } else if (change instanceof FilesetChange.UpdateFilesetComment) {
         newComment = ((FilesetChange.UpdateFilesetComment) change).getNewComment();
+      } else if (change instanceof FilesetChange.RemoveComment) {
+        newComment = null;
       } else {
         throw new IllegalArgumentException(
             "Unsupported fileset change: " + change.getClass().getSimpleName());

--- a/catalogs/catalog-hadoop/src/test/java/com/datastrato/gravitino/catalog/hadoop/TestHadoopCatalogOperations.java
+++ b/catalogs/catalog-hadoop/src/test/java/com/datastrato/gravitino/catalog/hadoop/TestHadoopCatalogOperations.java
@@ -680,6 +680,29 @@ public class TestHadoopCatalogOperations {
     }
   }
 
+  @Test
+  public void testRemoveFilesetComment() throws IOException {
+    String schemaName = "schema27";
+    String comment = "comment27";
+    String schemaPath = TEST_ROOT_PATH + "/" + schemaName;
+    createSchema(schemaName, comment, null, schemaPath);
+
+    String name = "fileset27";
+    Fileset fileset = createFileset(name, schemaName, comment, Fileset.Type.MANAGED, null, null);
+
+    FilesetChange change1 = FilesetChange.removeComment();
+    try (HadoopCatalogOperations ops = new HadoopCatalogOperations(store)) {
+      ops.initialize(Maps.newHashMap(), null, HADOOP_PROPERTIES_METADATA);
+      NameIdentifier filesetIdent = NameIdentifier.of("m1", "c1", schemaName, name);
+
+      Fileset fileset1 = ops.alterFileset(filesetIdent, change1);
+      Assertions.assertEquals(name, fileset1.name());
+      Assertions.assertEquals(Fileset.Type.MANAGED, fileset1.type());
+      Assertions.assertNull(fileset1.comment());
+      Assertions.assertEquals(fileset.storageLocation(), fileset1.storageLocation());
+    }
+  }
+
   private static Stream<Arguments> locationArguments() {
     return Stream.of(
         // Honor the catalog location

--- a/catalogs/catalog-hadoop/src/test/java/com/datastrato/gravitino/catalog/hadoop/integration/test/HadoopCatalogIT.java
+++ b/catalogs/catalog-hadoop/src/test/java/com/datastrato/gravitino/catalog/hadoop/integration/test/HadoopCatalogIT.java
@@ -530,6 +530,35 @@ public class HadoopCatalogIT extends AbstractIT {
   }
 
   @Test
+  public void testFilesetRemoveComment() throws IOException {
+    // create fileset
+    String filesetName = "test_remove_fileset_comment";
+    String storageLocation = storageLocation(filesetName);
+
+    createFileset(
+        filesetName, "comment", Fileset.Type.MANAGED, storageLocation, ImmutableMap.of("k1", "v1"));
+    assertFilesetExists(filesetName);
+
+    // remove fileset comment
+    Fileset newFileset =
+        catalog
+            .asFilesetCatalog()
+            .alterFileset(
+                NameIdentifier.of(schemaName, filesetName), FilesetChange.removeComment());
+    assertFilesetExists(filesetName);
+
+    // verify fileset is updated
+    Assertions.assertNotNull(newFileset, "fileset should be created");
+    Assertions.assertNull(newFileset.comment(), "comment should be removed");
+    Assertions.assertEquals(Fileset.Type.MANAGED, newFileset.type(), "type should not be changed");
+    Assertions.assertEquals(
+        storageLocation, newFileset.storageLocation(), "storage location should not be changed");
+    Assertions.assertEquals(1, newFileset.properties().size(), "properties should not be changed");
+    Assertions.assertEquals(
+        "v1", newFileset.properties().get("k1"), "properties should not be changed");
+  }
+
+  @Test
   public void testDropCatalogWithEmptySchema() {
     String catalogName =
         GravitinoITUtils.genRandomName("test_drop_catalog_with_empty_schema_catalog");

--- a/clients/client-java/src/main/java/com/datastrato/gravitino/client/DTOConverters.java
+++ b/clients/client-java/src/main/java/com/datastrato/gravitino/client/DTOConverters.java
@@ -207,6 +207,8 @@ class DTOConverters {
     } else if (change instanceof FilesetChange.UpdateFilesetComment) {
       return new FilesetUpdateRequest.UpdateFilesetCommentRequest(
           ((FilesetChange.UpdateFilesetComment) change).getNewComment());
+    } else if (change instanceof FilesetChange.RemoveComment) {
+      return new FilesetUpdateRequest.RemoveFilesetCommentRequest();
     } else if (change instanceof FilesetChange.SetProperty) {
       return new FilesetUpdateRequest.SetFilesetPropertiesRequest(
           ((FilesetChange.SetProperty) change).getProperty(),

--- a/clients/client-java/src/test/java/com/datastrato/gravitino/client/TestFilesetCatalog.java
+++ b/clients/client-java/src/test/java/com/datastrato/gravitino/client/TestFilesetCatalog.java
@@ -362,6 +362,16 @@ public class TestFilesetCatalog extends TestBase {
     Fileset res3 = catalog.asFilesetCatalog().alterFileset(fileset, req3.filesetChange());
     assertFileset(mockFileset3, res3);
 
+    // Test remove fileset comment
+    FilesetUpdateRequest req4 = new FilesetUpdateRequest.RemoveFilesetCommentRequest();
+    FilesetDTO mockFileset4 =
+        mockFilesetDTO("new name", Fileset.Type.MANAGED, null, "mock location", ImmutableMap.of());
+    FilesetResponse resp4 = new FilesetResponse(mockFileset4);
+    buildMockResource(
+        Method.PUT, filesetPath, new FilesetUpdatesRequest(ImmutableList.of(req4)), resp4, SC_OK);
+    Fileset res4 = catalog.asFilesetCatalog().alterFileset(fileset, req4.filesetChange());
+    assertFileset(mockFileset4, res4);
+
     // Test NoSuchFilesetException
     ErrorResponse errResp =
         ErrorResponse.notFound(NoSuchFilesetException.class.getSimpleName(), "fileset not found");

--- a/clients/client-python/gravitino/api/fileset_change.py
+++ b/clients/client-python/gravitino/api/fileset_change.py
@@ -77,6 +77,15 @@ class FilesetChange(ABC):
         """
         return FilesetChange.RemoveProperty(fileset_property)
 
+    @staticmethod
+    def remove_comment():
+        """Creates a new fileset change to remove comment from the fileset.
+
+        Returns:
+            The fileset change.
+        """
+        return FilesetChange.RemoveComment()
+
     @dataclass
     class RenameFileset:
         """A fileset change to rename the fileset."""
@@ -269,3 +278,37 @@ class FilesetChange(ABC):
                  A string summary of the property removal operation.
             """
             return f"REMOVEPROPERTY {self._property}"
+
+    @dataclass
+    class RemoveComment:
+        """A fileset change to remove comment from the fileset."""
+
+        def __eq__(self, other) -> bool:
+            """Compares this RemoveComment instance with another object for equality.
+            Two instances are considered equal if they are RemoveComment instance.
+
+            Args:
+                 other: The object to compare with this instance.
+
+            Returns:
+                 true if the given object represents the comment removal; false otherwise.
+            """
+            return isinstance(other, FilesetChange.RemoveComment)
+
+        def __hash__(self):
+            """Generates a hash code for this RemoveComment instance.
+            The hash code is based on the RemoveComment instance name.
+
+            Returns:
+                 A hash code value for comment removal operation.
+            """
+            return hash("REMOVECOMMENT")
+
+        def __str__(self):
+            """Provides a string representation of the RemoveComment instance.
+            This string format includes the class name.
+
+            Returns:
+                 A string summary of the comment removal operation.
+            """
+            return "REMOVECOMMENT"

--- a/clients/client-python/gravitino/catalog/fileset_catalog.py
+++ b/clients/client-python/gravitino/catalog/fileset_catalog.py
@@ -280,4 +280,6 @@ class FilesetCatalog(BaseSchemaCatalog):
             )
         if isinstance(change, FilesetChange.RemoveProperty):
             return FilesetUpdateRequest.RemoveFilesetPropertyRequest(change.property())
+        if isinstance(change, FilesetChange.RemoveComment):
+            return FilesetUpdateRequest.RemoveFilesetCommentRequest()
         raise ValueError(f"Unknown change type: {type(change).__name__}")

--- a/clients/client-python/gravitino/dto/requests/fileset_update_request.py
+++ b/clients/client-python/gravitino/dto/requests/fileset_update_request.py
@@ -159,7 +159,7 @@ class FilesetUpdateRequest:
         def validate(self):
             """Validates the fields of the request.
 
-               always pass
+            always pass
             """
             pass
 

--- a/clients/client-python/gravitino/dto/requests/fileset_update_request.py
+++ b/clients/client-python/gravitino/dto/requests/fileset_update_request.py
@@ -148,3 +148,20 @@ class FilesetUpdateRequest:
 
         def fileset_change(self):
             return FilesetChange.remove_property(self._property)
+
+    @dataclass
+    class RemoveFilesetCommentRequest(FilesetUpdateRequestBase):
+        """Represents a request to remove comment from a Fileset."""
+
+        def __init__(self):
+            super().__init__("removeComment")
+
+        def validate(self):
+            """Validates the fields of the request.
+
+               always pass
+            """
+            pass
+
+        def fileset_change(self):
+            return FilesetChange.remove_comment()

--- a/clients/client-python/tests/integration/test_fileset_catalog.py
+++ b/clients/client-python/tests/integration/test_fileset_catalog.py
@@ -182,12 +182,16 @@ class TestFilesetCatalog(IntegrationTestEnv):
 
     def test_alter_fileset(self):
         self.create_fileset()
-        fileset_propertie_new_value = self.fileset_properties_value2 + "_new"
+        fileset_properties_new_value = self.fileset_properties_value2 + "_new"
+        fileset_new_comment = self.fileset_comment + "_new"
 
         changes = (
             FilesetChange.remove_property(self.fileset_properties_key1),
             FilesetChange.set_property(
-                self.fileset_properties_key2, fileset_propertie_new_value
+                self.fileset_properties_key2, fileset_properties_new_value
+            ),
+            FilesetChange.update_comment(
+                fileset_new_comment
             ),
         )
         catalog = self.gravitino_client.load_catalog(name=self.catalog_name)
@@ -196,6 +200,17 @@ class TestFilesetCatalog(IntegrationTestEnv):
         )
         self.assertEqual(
             fileset_new.properties().get(self.fileset_properties_key2),
-            fileset_propertie_new_value,
+            fileset_properties_new_value,
         )
         self.assertTrue(self.fileset_properties_key1 not in fileset_new.properties())
+        self.assertEqual(
+            fileset_new.comment(),
+            fileset_new_comment
+        )
+
+        fileset_comment_removed = catalog.as_fileset_catalog().alter_fileset(
+            self.fileset_ident, FilesetChange.remove_comment()
+        )
+        self.assertEqual(fileset_comment_removed.ident(), self.fileset_ident)
+        self.assertIsNone(fileset_comment_removed.comment())
+

--- a/clients/client-python/tests/integration/test_fileset_catalog.py
+++ b/clients/client-python/tests/integration/test_fileset_catalog.py
@@ -190,9 +190,7 @@ class TestFilesetCatalog(IntegrationTestEnv):
             FilesetChange.set_property(
                 self.fileset_properties_key2, fileset_properties_new_value
             ),
-            FilesetChange.update_comment(
-                fileset_new_comment
-            ),
+            FilesetChange.update_comment(fileset_new_comment),
         )
         catalog = self.gravitino_client.load_catalog(name=self.catalog_name)
         fileset_new = catalog.as_fileset_catalog().alter_fileset(
@@ -203,14 +201,10 @@ class TestFilesetCatalog(IntegrationTestEnv):
             fileset_properties_new_value,
         )
         self.assertTrue(self.fileset_properties_key1 not in fileset_new.properties())
-        self.assertEqual(
-            fileset_new.comment(),
-            fileset_new_comment
-        )
+        self.assertEqual(fileset_new.comment(), fileset_new_comment)
 
         fileset_comment_removed = catalog.as_fileset_catalog().alter_fileset(
             self.fileset_ident, FilesetChange.remove_comment()
         )
-        self.assertEqual(fileset_comment_removed.ident(), self.fileset_ident)
+        self.assertEqual(fileset_comment_removed.name(), self.fileset_name)
         self.assertIsNone(fileset_comment_removed.comment())
-

--- a/common/src/main/java/com/datastrato/gravitino/dto/requests/FilesetUpdateRequest.java
+++ b/common/src/main/java/com/datastrato/gravitino/dto/requests/FilesetUpdateRequest.java
@@ -41,6 +41,9 @@ import org.apache.commons.lang3.StringUtils;
       value = FilesetUpdateRequest.UpdateFilesetCommentRequest.class,
       name = "updateComment"),
   @JsonSubTypes.Type(
+      value = FilesetUpdateRequest.RemoveFilesetCommentRequest.class,
+      name = "removeComment"),
+  @JsonSubTypes.Type(
       value = FilesetUpdateRequest.SetFilesetPropertiesRequest.class,
       name = "setProperty"),
   @JsonSubTypes.Type(
@@ -179,5 +182,26 @@ public interface FilesetUpdateRequest extends RESTRequest {
       Preconditions.checkArgument(
           StringUtils.isNotBlank(property), "\"property\" field is required and cannot be empty");
     }
+  }
+
+  /** The fileset update request for removing the comment of a fileset. */
+  @EqualsAndHashCode
+  @NoArgsConstructor(force = true)
+  @ToString
+  class RemoveFilesetCommentRequest implements FilesetUpdateRequest {
+
+    /** @return The fileset change. */
+    @Override
+    public FilesetChange filesetChange() {
+      return FilesetChange.removeComment();
+    }
+
+    /**
+     * Validates the request.
+     *
+     * @throws IllegalArgumentException if the request is invalid.
+     */
+    @Override
+    public void validate() throws IllegalArgumentException {}
   }
 }

--- a/core/src/test/java/com/datastrato/gravitino/catalog/TestFilesetOperationDispatcher.java
+++ b/core/src/test/java/com/datastrato/gravitino/catalog/TestFilesetOperationDispatcher.java
@@ -130,6 +130,18 @@ public class TestFilesetOperationDispatcher extends TestOperationDispatcher {
     Map<String, String> expectedProps = ImmutableMap.of("k2", "v2", "k3", "v3");
     testProperties(expectedProps, alteredFileset.properties());
 
+    FilesetChange[] changes2 = new FilesetChange[] {FilesetChange.updateComment("new comment")};
+
+    Fileset alteredFileset2 = filesetOperationDispatcher.alterFileset(filesetIdent1, changes2);
+    Assertions.assertEquals(fileset1.name(), alteredFileset2.name());
+    Assertions.assertEquals("new comment", alteredFileset2.comment());
+
+    FilesetChange[] changes3 = new FilesetChange[] {FilesetChange.removeComment()};
+
+    Fileset alteredFileset3 = filesetOperationDispatcher.alterFileset(filesetIdent1, changes3);
+    Assertions.assertEquals(fileset1.name(), alteredFileset3.name());
+    Assertions.assertNull(alteredFileset3.comment());
+
     // Test immutable fileset properties
     FilesetChange[] illegalChange = new FilesetChange[] {FilesetChange.setProperty(ID_KEY, "test")};
     testPropertyException(

--- a/core/src/test/java/com/datastrato/gravitino/connector/TestCatalogOperations.java
+++ b/core/src/test/java/com/datastrato/gravitino/connector/TestCatalogOperations.java
@@ -378,6 +378,7 @@ public class TestCatalogOperations
     Map<String, String> newProps =
         fileset.properties() != null ? Maps.newHashMap(fileset.properties()) : Maps.newHashMap();
     NameIdentifier newIdent = ident;
+    String newComment = fileset.comment();
 
     for (FilesetChange change : changes) {
       if (change instanceof FilesetChange.SetProperty) {
@@ -393,6 +394,10 @@ public class TestCatalogOperations
           throw new FilesetAlreadyExistsException("Fileset %s already exists", ident);
         }
         filesets.remove(ident);
+      } else if (change instanceof FilesetChange.UpdateFilesetComment) {
+        newComment = ((FilesetChange.UpdateFilesetComment) change).getNewComment();
+      } else if (change instanceof FilesetChange.RemoveComment) {
+        newComment = null;
       } else {
         throw new IllegalArgumentException("Unsupported fileset change: " + change);
       }
@@ -401,7 +406,7 @@ public class TestCatalogOperations
     TestFileset updatedFileset =
         TestFileset.builder()
             .withName(newIdent.name())
-            .withComment(fileset.comment())
+            .withComment(newComment)
             .withProperties(newProps)
             .withAuditInfo(updatedAuditInfo)
             .withType(fileset.type())

--- a/docs/manage-fileset-metadata-using-gravitino.md
+++ b/docs/manage-fileset-metadata-using-gravitino.md
@@ -395,6 +395,7 @@ Currently, Gravitino supports the following changes to a fileset:
 | Update a comment                     | `{"@type":"updateComment","newComment":"new_comment"}`       | `FilesetChange.updateComment("new_comment")`  |
 | Set a fileset property             | `{"@type":"setProperty","property":"key1","value":"value1"}` | `FilesetChange.setProperty("key1", "value1")` |
 | Remove a fileset property          | `{"@type":"removeProperty","property":"key1"}`               | `FilesetChange.removeProperty("key1")`        |
+| Remove comment                     | `{"@type":"removeComment"}`                                  | `FilesetChange.removeComment()`               |
 
 ### Drop a fileset
 

--- a/docs/open-api/filesets.yaml
+++ b/docs/open-api/filesets.yaml
@@ -325,6 +325,20 @@ components:
         "property": "key1"
       }
 
+    RemoveFilesetCommentRequest:
+      type: object
+      required:
+        - "@type"
+      properties:
+        "@type":
+          type: string
+          description: The type of the update
+          enum:
+            - removeComment
+      example: {
+        "@type": "removeComment"
+      }
+
   responses:
     FilesetResponse:
       description: The response of fileset object

--- a/server/src/test/java/com/datastrato/gravitino/server/web/rest/TestFilesetOperations.java
+++ b/server/src/test/java/com/datastrato/gravitino/server/web/rest/TestFilesetOperations.java
@@ -362,6 +362,14 @@ public class TestFilesetOperations extends JerseyTest {
   }
 
   @Test
+  public void testRemoveFilesetComment() {
+    FilesetUpdateRequest req = new FilesetUpdateRequest.RemoveFilesetCommentRequest();
+    Fileset fileset =
+        mockFileset("fileset1", Fileset.Type.MANAGED, null, "mock location", ImmutableMap.of());
+    assertUpdateFileset(new FilesetUpdatesRequest(ImmutableList.of(req)), fileset);
+  }
+
+  @Test
   public void testMultiUpdateRequest() {
     FilesetUpdateRequest req = new FilesetUpdateRequest.RenameFilesetRequest("new name");
     FilesetUpdateRequest req1 = new FilesetUpdateRequest.UpdateFilesetCommentRequest("new comment");
@@ -371,16 +379,15 @@ public class TestFilesetOperations extends JerseyTest {
     FilesetUpdateRequest req4 = new FilesetUpdateRequest.SetFilesetPropertiesRequest("k2", "v2");
     // remove k2
     FilesetUpdateRequest req5 = new FilesetUpdateRequest.RemoveFilesetPropertiesRequest("k2");
+    // remove comment
+    FilesetUpdateRequest req6 = new FilesetUpdateRequest.RemoveFilesetCommentRequest();
 
     Fileset fileset =
         mockFileset(
-            "new name",
-            Fileset.Type.MANAGED,
-            "new comment",
-            "mock location",
-            ImmutableMap.of("k1", "v2"));
+            "new name", Fileset.Type.MANAGED, null, "mock location", ImmutableMap.of("k1", "v2"));
     assertUpdateFileset(
-        new FilesetUpdatesRequest(ImmutableList.of(req, req1, req2, req3, req4, req5)), fileset);
+        new FilesetUpdatesRequest(ImmutableList.of(req, req1, req2, req3, req4, req5, req6)),
+        fileset);
   }
 
   @Test


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add fileset commet removal operations: FilesetChange.RemoveComment

Fix: #4112

### Why are the changes needed?
Fileset can be created without comment now, when user added a comment to fileset, they should be allowed to retract the comment.

Like other FilesetChange, FilesetChange.RemoveComment can be used for **alterFileset()** method

### Does this PR introduce _any_ user-facing change?

User can add new changes for fileset:
``` 
Fileset fileset = catalog.asFilesetCatalog().alterFileset(
                NameIdentifier.of(metaLakeName, catalogName, schemaName, filesetName),
                FilesetChange.removeComment());
```

or use update fileset http request: 
```
updates": [
    {
      "@type": "removeComment"
    }
]
```

### How was this patch tested?

Create a fileset with comment, then use java/python client, or http requeset to remove comment and check the result
