### PR TITLE
 [#4002] Improvement(gradle): remove skipPyClientITs parameter in Gradle

### DIFF
--- a/clients/client-python/build.gradle.kts
+++ b/clients/client-python/build.gradle.kts
@@ -249,15 +249,14 @@ tasks {
 
   val test by registering(VenvTask::class) {
     val skipUTs = project.hasProperty("skipTests")
-    val skipPyClientITs = project.hasProperty("skipPyClientITs")
     val skipITs = project.hasProperty("skipITs")
-    val skipAllTests = skipUTs && (skipITs || skipPyClientITs)
+    val skipAllTests = skipUTs && skipITs
     if (!skipAllTests) {
       dependsOn(pipInstall, pylint)
       if (!skipUTs) {
         dependsOn(unitTests)
       }
-      if (!skipITs && !skipPyClientITs) {
+      if (!skipITs) {
         dependsOn(integrationTest)
       }
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?

remove duplicated  `skipPyClientITs` parameter in Gradle

### Why are the changes needed?

Fix: #4002

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?
set `skipITs=false` to run integration test
