### PR TITLE
[#4129] improvement(core): Support hold multiple tree lock within a thread at the same time

### DIFF
--- a/core/src/main/java/com/datastrato/gravitino/lock/LockManager.java
+++ b/core/src/main/java/com/datastrato/gravitino/lock/LockManager.java
@@ -132,12 +132,12 @@ public class LockManager {
     // Check self
     node.getHoldingThreadTimestamp()
         .forEach(
-            (thread, ts) -> {
+            (threadIdentifier, ts) -> {
               // If the thread is holding the lock for more than 30 seconds, we will log it.
               if (System.currentTimeMillis() - ts > 30000) {
                 LOG.warn(
-                    "Dead lock detected for thread {} on node {}, threads that holding the node: {} ",
-                    thread,
+                    "Dead lock detected for thread with identifier {} on node {}, threads that holding the node: {} ",
+                    threadIdentifier,
                     node,
                     node.getHoldingThreadTimestamp());
               }

--- a/core/src/main/java/com/datastrato/gravitino/lock/TreeLock.java
+++ b/core/src/main/java/com/datastrato/gravitino/lock/TreeLock.java
@@ -104,8 +104,17 @@ public class TreeLock {
       try {
         treeLockNode.lock(type);
         heldLocks.push(Pair.of(treeLockNode, type));
+
+        treeLockNode.addHoldingThreadTimestamp(
+            Thread.currentThread(), identifier, System.currentTimeMillis());
         if (LOG.isTraceEnabled()) {
-          LOG.trace("Locked node: {}, lock type: {}", treeLockNode, type);
+          LOG.trace(
+              "Node {} has been lock with '{}' lock, hold by {} with ident '{}' at {}",
+              this,
+              lockType,
+              Thread.currentThread(),
+              identifier,
+              System.currentTimeMillis());
         }
       } catch (Exception e) {
         LOG.error(
@@ -140,8 +149,16 @@ public class TreeLock {
       TreeLockNode current = pair.getLeft();
       LockType type = pair.getRight();
       current.unlock(type);
+
+      long holdStartTime = current.removeHoldingThreadTimestamp(Thread.currentThread(), identifier);
       if (LOG.isTraceEnabled()) {
-        LOG.trace("Unlocked node: {}, lock type: {}", current, type);
+        LOG.trace(
+            "Node {} has been unlock with '{}' lock, hold by {} with ident '{}' for {} ms",
+            this,
+            lockType,
+            Thread.currentThread(),
+            identifier,
+            System.currentTimeMillis() - holdStartTime);
       }
     }
 

--- a/core/src/test/java/com/datastrato/gravitino/lock/TestTreeLockUtils.java
+++ b/core/src/test/java/com/datastrato/gravitino/lock/TestTreeLockUtils.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.datastrato.gravitino.lock;
+
+import static com.datastrato.gravitino.Configs.TREE_LOCK_CLEAN_INTERVAL;
+import static com.datastrato.gravitino.Configs.TREE_LOCK_MAX_NODE_IN_MEMORY;
+import static com.datastrato.gravitino.Configs.TREE_LOCK_MIN_NODE_IN_MEMORY;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+import com.datastrato.gravitino.Config;
+import com.datastrato.gravitino.GravitinoEnv;
+import com.datastrato.gravitino.NameIdentifier;
+import org.apache.commons.lang3.reflect.FieldUtils;
+import org.junit.jupiter.api.Test;
+
+public class TestTreeLockUtils {
+
+  @Test
+  void testHolderMultipleLock() throws Exception {
+    Config config = mock(Config.class);
+    doReturn(100000L).when(config).get(TREE_LOCK_MAX_NODE_IN_MEMORY);
+    doReturn(1000L).when(config).get(TREE_LOCK_MIN_NODE_IN_MEMORY);
+    doReturn(36000L).when(config).get(TREE_LOCK_CLEAN_INTERVAL);
+    FieldUtils.writeField(GravitinoEnv.getInstance(), "lockManager", new LockManager(config), true);
+
+    TreeLockUtils.doWithTreeLock(
+        NameIdentifier.of("test"),
+        LockType.READ,
+        () ->
+            TreeLockUtils.doWithTreeLock(
+                NameIdentifier.of("test", "test1"), LockType.WRITE, () -> null));
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add the value of the name identifier in the holdingThreadTimestamp to support holding multiple tree lock at the same time.

### Why are the changes needed?

To support more user sceanrio

Fix: #4129 

### Does this PR introduce _any_ user-facing change?

N/A.

### How was this patch tested?

Add new test class `TestTreeLockUtils`
