### PR TITLE
[#4120] fix(catalog-jdbc): Set partitioning when loading JDBC tables

### DIFF
--- a/catalogs/catalog-jdbc-common/src/main/java/com/datastrato/gravitino/catalog/jdbc/JdbcCatalogOperations.java
+++ b/catalogs/catalog-jdbc-common/src/main/java/com/datastrato/gravitino/catalog/jdbc/JdbcCatalogOperations.java
@@ -312,6 +312,7 @@ public class JdbcCatalogOperations implements CatalogOperations, SupportsSchemas
         .withComment(comment)
         .withProperties(properties)
         .withIndexes(load.index())
+        .withPartitioning(load.partitioning())
         .build();
   }
 

--- a/catalogs/catalog-jdbc-common/src/main/java/com/datastrato/gravitino/catalog/jdbc/operation/JdbcTableOperations.java
+++ b/catalogs/catalog-jdbc-common/src/main/java/com/datastrato/gravitino/catalog/jdbc/operation/JdbcTableOperations.java
@@ -35,6 +35,7 @@ import com.datastrato.gravitino.rel.expressions.Expression;
 import com.datastrato.gravitino.rel.expressions.distributions.Distribution;
 import com.datastrato.gravitino.rel.expressions.literals.Literals;
 import com.datastrato.gravitino.rel.expressions.transforms.Transform;
+import com.datastrato.gravitino.rel.expressions.transforms.Transforms;
 import com.datastrato.gravitino.rel.indexes.Index;
 import com.datastrato.gravitino.rel.indexes.Indexes;
 import com.google.common.collect.Lists;
@@ -199,11 +200,15 @@ public abstract class JdbcTableOperations implements TableOperation {
       List<Index> indexes = getIndexes(connection, databaseName, tableName);
       jdbcTableBuilder.withIndexes(indexes.toArray(new Index[0]));
 
-      // 4.Get table properties
+      // 4.Get partitioning
+      Transform[] tablePartitioning = getTablePartitioning(connection, databaseName, tableName);
+      jdbcTableBuilder.withPartitioning(tablePartitioning);
+
+      // 5.Get table properties
       Map<String, String> tableProperties = getTableProperties(connection, tableName);
       jdbcTableBuilder.withProperties(tableProperties);
 
-      // 5.Leave the information to the bottom layer to append the table
+      // 6.Leave the information to the bottom layer to append the table
       correctJdbcTableFields(connection, databaseName, tableName, jdbcTableBuilder);
       return jdbcTableBuilder.build();
     } catch (SQLException e) {
@@ -223,6 +228,11 @@ public abstract class JdbcTableOperations implements TableOperation {
   protected Map<String, String> getTableProperties(Connection connection, String tableName)
       throws SQLException {
     return Collections.emptyMap();
+  }
+
+  protected Transform[] getTablePartitioning(
+      Connection connection, String databaseName, String tableName) throws SQLException {
+    return Transforms.EMPTY_TRANSFORM;
   }
 
   protected boolean getAutoIncrementInfo(ResultSet resultSet) throws SQLException {

--- a/catalogs/catalog-jdbc-common/src/test/java/com/datastrato/gravitino/catalog/jdbc/TestJdbc.java
+++ b/catalogs/catalog-jdbc-common/src/test/java/com/datastrato/gravitino/catalog/jdbc/TestJdbc.java
@@ -29,6 +29,7 @@ import com.datastrato.gravitino.dto.rel.ColumnDTO;
 import com.datastrato.gravitino.dto.rel.expressions.LiteralDTO;
 import com.datastrato.gravitino.exceptions.NoSuchSchemaException;
 import com.datastrato.gravitino.rel.Column;
+import com.datastrato.gravitino.rel.expressions.transforms.Transform;
 import com.datastrato.gravitino.rel.indexes.Index;
 import com.datastrato.gravitino.utils.RandomNameUtils;
 import java.util.Arrays;
@@ -110,6 +111,7 @@ public abstract class TestJdbc {
       List<JdbcColumn> columns,
       Map<String, String> properties,
       Index[] indexes,
+      Transform[] partitioning,
       JdbcTable table) {
     Assertions.assertEquals(tableName, table.name());
     Assertions.assertEquals(tableComment, table.comment());
@@ -138,6 +140,7 @@ public abstract class TestJdbc {
         }
       }
     }
+    Assertions.assertTrue(Arrays.deepEquals(table.partitioning(), partitioning));
   }
 
   public static void assertColumn(Column expected, Column actual) {

--- a/catalogs/catalog-jdbc-doris/src/main/java/com/datastrato/gravitino/catalog/doris/operation/DorisTableOperations.java
+++ b/catalogs/catalog-jdbc-doris/src/main/java/com/datastrato/gravitino/catalog/doris/operation/DorisTableOperations.java
@@ -318,7 +318,7 @@ public class DorisTableOperations extends JdbcTableOperations {
     try (Statement statement = connection.createStatement();
         ResultSet result = statement.executeQuery(showCreateTableSql)) {
       StringBuilder createTableSql = new StringBuilder();
-      while (result.next()) {
+      if (result.next()) {
         createTableSql.append(result.getString("Create Table"));
       }
       Optional<Transform> transform =

--- a/catalogs/catalog-jdbc-doris/src/main/java/com/datastrato/gravitino/catalog/doris/operation/DorisTableOperations.java
+++ b/catalogs/catalog-jdbc-doris/src/main/java/com/datastrato/gravitino/catalog/doris/operation/DorisTableOperations.java
@@ -50,6 +50,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.commons.collections4.CollectionUtils;
@@ -174,12 +175,14 @@ public class DorisTableOperations extends JdbcTableOperations {
       // Check if the distribution column exists
       Arrays.stream(distribution.expressions())
           .forEach(
-              expression -> {
-                Preconditions.checkArgument(
-                    Arrays.stream(columns)
-                        .anyMatch(column -> column.name().equalsIgnoreCase(expression.toString())),
-                    "Distribution column " + expression + " does not exist in the table columns");
-              });
+              expression ->
+                  Preconditions.checkArgument(
+                      Arrays.stream(columns)
+                          .anyMatch(
+                              column -> column.name().equalsIgnoreCase(expression.toString())),
+                      "Distribution column "
+                          + expression
+                          + " does not exist in the table columns"));
     }
   }
 
@@ -305,6 +308,22 @@ public class DorisTableOperations extends JdbcTableOperations {
       return indexes;
     } catch (SQLException e) {
       throw exceptionMapper.toGravitinoException(e);
+    }
+  }
+
+  @Override
+  protected Transform[] getTablePartitioning(
+      Connection connection, String databaseName, String tableName) throws SQLException {
+    String showCreateTableSql = String.format("SHOW CREATE TABLE `%s`", tableName);
+    try (Statement statement = connection.createStatement();
+        ResultSet result = statement.executeQuery(showCreateTableSql)) {
+      StringBuilder createTableSql = new StringBuilder();
+      while (result.next()) {
+        createTableSql.append(result.getString("Create Table"));
+      }
+      Optional<Transform> transform =
+          DorisUtils.extractPartitionInfoFromSql(createTableSql.toString());
+      return transform.map(t -> new Transform[] {t}).orElse(Transforms.EMPTY_TRANSFORM);
     }
   }
 

--- a/catalogs/catalog-jdbc-doris/src/main/java/com/datastrato/gravitino/catalog/doris/utils/DorisUtils.java
+++ b/catalogs/catalog-jdbc-doris/src/main/java/com/datastrato/gravitino/catalog/doris/utils/DorisUtils.java
@@ -32,7 +32,8 @@ import org.slf4j.LoggerFactory;
 
 public final class DorisUtils {
   private static final Logger LOGGER = LoggerFactory.getLogger(DorisUtils.class);
-  private static final String PARTITION_BY = "PARTITION BY";
+  private static final Pattern PARTITION_INFO_PATTERN =
+      Pattern.compile("PARTITION BY \\b(LIST|RANGE)\\b\\((.+)\\)");
   private static final String LIST_PARTITION = "LIST";
   private static final String RANGE_PARTITION = "RANGE";
 
@@ -81,17 +82,12 @@ public final class DorisUtils {
     try {
       String[] lines = createTableSql.split("\n");
       for (String line : lines) {
-        if (line.contains(PARTITION_BY)) {
-          String partitionInfoString = line.trim().substring(PARTITION_BY.length() + 1);
-          int partitionColumnStartIndex = partitionInfoString.indexOf("(");
-          int partitionColumnEndIndex = partitionInfoString.indexOf(")");
-          String partitionType =
-              partitionInfoString.substring(0, partitionColumnStartIndex).toUpperCase();
+        Matcher matcher = PARTITION_INFO_PATTERN.matcher(line.trim());
+        if (matcher.matches()) {
+          String partitionType = matcher.group(1);
+          String partitionInfoString = matcher.group(2);
           String[] columns =
-              Arrays.stream(
-                      partitionInfoString
-                          .substring(partitionColumnStartIndex + 1, partitionColumnEndIndex)
-                          .split(", "))
+              Arrays.stream(partitionInfoString.split(", "))
                   .map(s -> s.substring(1, s.length() - 1))
                   .toArray(String[]::new);
           if (LIST_PARTITION.equals(partitionType)) {
@@ -100,9 +96,6 @@ public final class DorisUtils {
             return Optional.of(Transforms.list(filedNames));
           } else if (RANGE_PARTITION.equals(partitionType)) {
             return Optional.of(Transforms.range(new String[] {columns[0]}));
-          } else {
-            throw new RuntimeException(
-                "Cannot extract partition type from SQL:\n" + createTableSql);
           }
         }
       }

--- a/catalogs/catalog-jdbc-doris/src/test/java/com/datastrato/gravitino/catalog/doris/integration/test/CatalogDorisIT.java
+++ b/catalogs/catalog-jdbc-doris/src/test/java/com/datastrato/gravitino/catalog/doris/integration/test/CatalogDorisIT.java
@@ -360,12 +360,24 @@ public class CatalogDorisIT extends AbstractIT {
             indexes);
 
     ITUtils.assertionsTableInfo(
-        tableName, table_comment, Arrays.asList(columns), properties, indexes, createdTable);
+        tableName,
+        table_comment,
+        Arrays.asList(columns),
+        properties,
+        indexes,
+        Transforms.EMPTY_TRANSFORM,
+        createdTable);
 
     // load table
     Table loadTable = tableCatalog.loadTable(tableIdentifier);
     ITUtils.assertionsTableInfo(
-        tableName, table_comment, Arrays.asList(columns), properties, indexes, loadTable);
+        tableName,
+        table_comment,
+        Arrays.asList(columns),
+        properties,
+        indexes,
+        Transforms.EMPTY_TRANSFORM,
+        loadTable);
 
     // rename table
     String newTableName = GravitinoITUtils.genRandomName("new_table_name");
@@ -373,7 +385,13 @@ public class CatalogDorisIT extends AbstractIT {
     NameIdentifier newTableIdentifier = NameIdentifier.of(schemaName, newTableName);
     Table renamedTable = tableCatalog.loadTable(newTableIdentifier);
     ITUtils.assertionsTableInfo(
-        newTableName, table_comment, Arrays.asList(columns), properties, indexes, renamedTable);
+        newTableName,
+        table_comment,
+        Arrays.asList(columns),
+        properties,
+        indexes,
+        Transforms.EMPTY_TRANSFORM,
+        renamedTable);
   }
 
   @Test
@@ -515,7 +533,13 @@ public class CatalogDorisIT extends AbstractIT {
             indexes);
 
     ITUtils.assertionsTableInfo(
-        tableName, table_comment, Arrays.asList(columns), properties, indexes, createdTable);
+        tableName,
+        table_comment,
+        Arrays.asList(columns),
+        properties,
+        indexes,
+        Transforms.EMPTY_TRANSFORM,
+        createdTable);
 
     // Alter column type
     tableCatalog.alterTable(

--- a/catalogs/catalog-jdbc-doris/src/test/java/com/datastrato/gravitino/catalog/doris/operation/TestDorisTableOperations.java
+++ b/catalogs/catalog-jdbc-doris/src/test/java/com/datastrato/gravitino/catalog/doris/operation/TestDorisTableOperations.java
@@ -113,7 +113,8 @@ public class TestDorisTableOperations extends TestDoris {
     List<String> listTables = TABLE_OPERATIONS.listTables(databaseName);
     Assertions.assertTrue(listTables.contains(tableName));
     JdbcTable load = TABLE_OPERATIONS.load(databaseName, tableName);
-    assertionsTableInfo(tableName, tableComment, columns, properties, indexes, load);
+    assertionsTableInfo(
+        tableName, tableComment, columns, properties, indexes, Transforms.EMPTY_TRANSFORM, load);
 
     // rename table
     String newName = GravitinoITUtils.genRandomName("new_table");
@@ -161,7 +162,8 @@ public class TestDorisTableOperations extends TestDoris {
         distribution,
         indexes);
     JdbcTable load = TABLE_OPERATIONS.load(databaseName, tableName);
-    assertionsTableInfo(tableName, tableComment, columns, properties, indexes, load);
+    assertionsTableInfo(
+        tableName, tableComment, columns, properties, indexes, Transforms.EMPTY_TRANSFORM, load);
 
     TABLE_OPERATIONS.alterTable(
         databaseName,
@@ -191,6 +193,7 @@ public class TestDorisTableOperations extends TestDoris {
                     columns,
                     properties,
                     indexes,
+                    Transforms.EMPTY_TRANSFORM,
                     TABLE_OPERATIONS.load(databaseName, tableName)));
 
     String colNewComment = "new_comment";
@@ -212,7 +215,8 @@ public class TestDorisTableOperations extends TestDoris {
     columns.add(col_1);
     columns.add(col_2);
     columns.add(col_3);
-    assertionsTableInfo(tableName, tableComment, columns, properties, indexes, load);
+    assertionsTableInfo(
+        tableName, tableComment, columns, properties, indexes, Transforms.EMPTY_TRANSFORM, load);
 
     // add new column
     TABLE_OPERATIONS.alterTable(
@@ -238,6 +242,7 @@ public class TestDorisTableOperations extends TestDoris {
                     columns,
                     properties,
                     indexes,
+                    Transforms.EMPTY_TRANSFORM,
                     TABLE_OPERATIONS.load(databaseName, tableName)));
 
     // change column position
@@ -263,6 +268,7 @@ public class TestDorisTableOperations extends TestDoris {
                     columns,
                     properties,
                     indexes,
+                    Transforms.EMPTY_TRANSFORM,
                     TABLE_OPERATIONS.load(databaseName, tableName)));
 
     // drop column if exist
@@ -283,6 +289,7 @@ public class TestDorisTableOperations extends TestDoris {
                     columns,
                     properties,
                     indexes,
+                    Transforms.EMPTY_TRANSFORM,
                     TABLE_OPERATIONS.load(databaseName, tableName)));
 
     // delete column that does not exist
@@ -322,6 +329,7 @@ public class TestDorisTableOperations extends TestDoris {
                     columns,
                     properties,
                     newIndexes,
+                    Transforms.EMPTY_TRANSFORM,
                     TABLE_OPERATIONS.load(databaseName, tableName)));
 
     // test delete index
@@ -338,6 +346,7 @@ public class TestDorisTableOperations extends TestDoris {
                     columns,
                     properties,
                     indexes,
+                    Transforms.EMPTY_TRANSFORM,
                     TABLE_OPERATIONS.load(databaseName, tableName)));
   }
 
@@ -377,7 +386,14 @@ public class TestDorisTableOperations extends TestDoris {
         indexes);
 
     JdbcTable load = TABLE_OPERATIONS.load(databaseName, tableName);
-    assertionsTableInfo(tableName, tableComment, columns, Collections.emptyMap(), null, load);
+    assertionsTableInfo(
+        tableName,
+        tableComment,
+        columns,
+        Collections.emptyMap(),
+        null,
+        Transforms.EMPTY_TRANSFORM,
+        load);
   }
 
   @Test
@@ -470,6 +486,7 @@ public class TestDorisTableOperations extends TestDoris {
         columns,
         Collections.emptyMap(),
         null,
+        rangePartition,
         rangePartitionTable);
 
     // create table with list partition
@@ -492,6 +509,7 @@ public class TestDorisTableOperations extends TestDoris {
         columns,
         Collections.emptyMap(),
         null,
+        listPartition,
         listPartitionTable);
   }
 }

--- a/catalogs/catalog-jdbc-doris/src/test/java/com/datastrato/gravitino/catalog/doris/utils/TestDorisUtils.java
+++ b/catalogs/catalog-jdbc-doris/src/test/java/com/datastrato/gravitino/catalog/doris/utils/TestDorisUtils.java
@@ -18,9 +18,12 @@
  */
 package com.datastrato.gravitino.catalog.doris.utils;
 
+import com.datastrato.gravitino.rel.expressions.transforms.Transform;
+import com.datastrato.gravitino.rel.expressions.transforms.Transforms;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -80,5 +83,35 @@ public class TestDorisUtils {
     result = DorisUtils.extractPropertiesFromSql(createTableSql);
     Assertions.assertEquals("value1", result.get("property1"));
     Assertions.assertEquals("comment", result.get("comment"));
+  }
+
+  @Test
+  public void testExtractPartitionInfoFromSql() {
+    // test range partition
+    String createTableSql =
+        "CREATE TABLE `testTable` (\n`col1` date NOT NULL\n) ENGINE=OLAP\n PARTITION BY RANGE(`col1`)()\n DISTRIBUTED BY HASH(`col1`) BUCKETS 2";
+    Optional<Transform> transform = DorisUtils.extractPartitionInfoFromSql(createTableSql);
+    Assertions.assertTrue(transform.isPresent());
+    Assertions.assertEquals(Transforms.range(new String[] {"col1"}), transform.get());
+
+    // test list partition
+    createTableSql =
+        "CREATE TABLE `testTable` (\n`col1` int(11) NOT NULL\n) ENGINE=OLAP\n PARTITION BY LIST(`col1`)()\n DISTRIBUTED BY HASH(`col1`) BUCKETS 2";
+    transform = DorisUtils.extractPartitionInfoFromSql(createTableSql);
+    Assertions.assertTrue(transform.isPresent());
+    Assertions.assertEquals(Transforms.list(new String[][] {{"col1"}}), transform.get());
+
+    // test multi-column list partition
+    createTableSql =
+        "CREATE TABLE `testTable` (\n`col1` date NOT NULL,\n`col2` int(11) NOT NULL\n) ENGINE=OLAP\n PARTITION BY LIST(`col1`, `col2`)()\n DISTRIBUTED BY HASH(`col1`) BUCKETS 2";
+    transform = DorisUtils.extractPartitionInfoFromSql(createTableSql);
+    Assertions.assertTrue(transform.isPresent());
+    Assertions.assertEquals(Transforms.list(new String[][] {{"col1"}, {"col2"}}), transform.get());
+
+    // test non-partitioned table
+    createTableSql =
+        "CREATE TABLE `testTable` (\n`testColumn` STRING NOT NULL COMMENT 'test comment'\n) ENGINE=OLAP\nCOMMENT \"test comment\"";
+    transform = DorisUtils.extractPartitionInfoFromSql(createTableSql);
+    Assertions.assertFalse(transform.isPresent());
   }
 }

--- a/catalogs/catalog-jdbc-doris/src/test/java/com/datastrato/gravitino/catalog/doris/utils/TestDorisUtils.java
+++ b/catalogs/catalog-jdbc-doris/src/test/java/com/datastrato/gravitino/catalog/doris/utils/TestDorisUtils.java
@@ -89,21 +89,21 @@ public class TestDorisUtils {
   public void testExtractPartitionInfoFromSql() {
     // test range partition
     String createTableSql =
-        "CREATE TABLE `testTable` (\n`col1` date NOT NULL\n) ENGINE=OLAP\n PARTITION BY RANGE(`col1`)()\n DISTRIBUTED BY HASH(`col1`) BUCKETS 2";
+        "CREATE TABLE `testTable` (\n`col1` date NOT NULL\n) ENGINE=OLAP\n PARTITION BY RANGE(`col1`)\n()\n DISTRIBUTED BY HASH(`col1`) BUCKETS 2";
     Optional<Transform> transform = DorisUtils.extractPartitionInfoFromSql(createTableSql);
     Assertions.assertTrue(transform.isPresent());
     Assertions.assertEquals(Transforms.range(new String[] {"col1"}), transform.get());
 
     // test list partition
     createTableSql =
-        "CREATE TABLE `testTable` (\n`col1` int(11) NOT NULL\n) ENGINE=OLAP\n PARTITION BY LIST(`col1`)()\n DISTRIBUTED BY HASH(`col1`) BUCKETS 2";
+        "CREATE TABLE `testTable` (\n`col1` int(11) NOT NULL\n) ENGINE=OLAP\n PARTITION BY LIST(`col1`)\n()\n DISTRIBUTED BY HASH(`col1`) BUCKETS 2";
     transform = DorisUtils.extractPartitionInfoFromSql(createTableSql);
     Assertions.assertTrue(transform.isPresent());
     Assertions.assertEquals(Transforms.list(new String[][] {{"col1"}}), transform.get());
 
     // test multi-column list partition
     createTableSql =
-        "CREATE TABLE `testTable` (\n`col1` date NOT NULL,\n`col2` int(11) NOT NULL\n) ENGINE=OLAP\n PARTITION BY LIST(`col1`, `col2`)()\n DISTRIBUTED BY HASH(`col1`) BUCKETS 2";
+        "CREATE TABLE `testTable` (\n`col1` date NOT NULL,\n`col2` int(11) NOT NULL\n) ENGINE=OLAP\n PARTITION BY LIST(`col1`, `col2`)\n()\n DISTRIBUTED BY HASH(`col1`) BUCKETS 2";
     transform = DorisUtils.extractPartitionInfoFromSql(createTableSql);
     Assertions.assertTrue(transform.isPresent());
     Assertions.assertEquals(Transforms.list(new String[][] {{"col1"}, {"col2"}}), transform.get());

--- a/catalogs/catalog-jdbc-mysql/src/test/java/com/datastrato/gravitino/catalog/mysql/integration/test/CatalogMysqlIT.java
+++ b/catalogs/catalog-jdbc-mysql/src/test/java/com/datastrato/gravitino/catalog/mysql/integration/test/CatalogMysqlIT.java
@@ -885,10 +885,22 @@ public class CatalogMysqlIT extends AbstractIT {
             new SortOrder[0],
             indexes);
     ITUtils.assertionsTableInfo(
-        tableName, table_comment, Arrays.asList(newColumns), properties, indexes, createdTable);
+        tableName,
+        table_comment,
+        Arrays.asList(newColumns),
+        properties,
+        indexes,
+        Transforms.EMPTY_TRANSFORM,
+        createdTable);
     Table table = tableCatalog.loadTable(tableIdentifier);
     ITUtils.assertionsTableInfo(
-        tableName, table_comment, Arrays.asList(newColumns), properties, indexes, table);
+        tableName,
+        table_comment,
+        Arrays.asList(newColumns),
+        properties,
+        indexes,
+        Transforms.EMPTY_TRANSFORM,
+        table);
 
     NameIdentifier id = NameIdentifier.of(schemaName, "test_failed");
     Index[] indexes2 =
@@ -985,10 +997,22 @@ public class CatalogMysqlIT extends AbstractIT {
             indexes);
     // Test create auto increment key success.
     ITUtils.assertionsTableInfo(
-        tableName, table_comment, Arrays.asList(newColumns), properties, indexes, createdTable);
+        tableName,
+        table_comment,
+        Arrays.asList(newColumns),
+        properties,
+        indexes,
+        Transforms.EMPTY_TRANSFORM,
+        createdTable);
     Table table = tableCatalog.loadTable(tableIdentifier);
     ITUtils.assertionsTableInfo(
-        tableName, table_comment, Arrays.asList(newColumns), properties, indexes, table);
+        tableName,
+        table_comment,
+        Arrays.asList(newColumns),
+        properties,
+        indexes,
+        Transforms.EMPTY_TRANSFORM,
+        table);
 
     // Test alter table. auto increment exist.
     // UpdateColumnType
@@ -1005,7 +1029,13 @@ public class CatalogMysqlIT extends AbstractIT {
           col5
         };
     ITUtils.assertionsTableInfo(
-        tableName, table_comment, Arrays.asList(alterColumns), properties, indexes, table);
+        tableName,
+        table_comment,
+        Arrays.asList(alterColumns),
+        properties,
+        indexes,
+        Transforms.EMPTY_TRANSFORM,
+        table);
 
     // UpdateColumnComment
     tableCatalog.alterTable(
@@ -1020,7 +1050,13 @@ public class CatalogMysqlIT extends AbstractIT {
           col5
         };
     ITUtils.assertionsTableInfo(
-        tableName, table_comment, Arrays.asList(alterColumns), properties, indexes, table);
+        tableName,
+        table_comment,
+        Arrays.asList(alterColumns),
+        properties,
+        indexes,
+        Transforms.EMPTY_TRANSFORM,
+        table);
 
     // RenameColumn
     tableCatalog.alterTable(
@@ -1040,7 +1076,13 @@ public class CatalogMysqlIT extends AbstractIT {
           Indexes.unique("u1_key", new String[][] {{"col_2"}, {"col_3"}})
         };
     ITUtils.assertionsTableInfo(
-        tableName, table_comment, Arrays.asList(alterColumns), properties, indexes, table);
+        tableName,
+        table_comment,
+        Arrays.asList(alterColumns),
+        properties,
+        indexes,
+        Transforms.EMPTY_TRANSFORM,
+        table);
 
     tableCatalog.dropTable(tableIdentifier);
 
@@ -1217,22 +1259,46 @@ public class CatalogMysqlIT extends AbstractIT {
     Table t1 = tableCatalog.loadTable(NameIdentifier.of(schemaName, t1_name));
     Arrays.stream(t1.columns()).anyMatch(c -> Objects.equals(c.name(), "t112"));
     ITUtils.assertionsTableInfo(
-        t1_name, table_comment, Arrays.asList(t1_col), properties, t1_indexes, t1);
+        t1_name,
+        table_comment,
+        Arrays.asList(t1_col),
+        properties,
+        t1_indexes,
+        Transforms.EMPTY_TRANSFORM,
+        t1);
 
     Table t2 = tableCatalog.loadTable(NameIdentifier.of(schemaName, t2_name));
     Arrays.stream(t2.columns()).anyMatch(c -> Objects.equals(c.name(), "t212"));
     ITUtils.assertionsTableInfo(
-        t2_name, table_comment, Arrays.asList(t2_col), properties, t2_indexes, t2);
+        t2_name,
+        table_comment,
+        Arrays.asList(t2_col),
+        properties,
+        t2_indexes,
+        Transforms.EMPTY_TRANSFORM,
+        t2);
 
     Table t3 = tableCatalog.loadTable(NameIdentifier.of(schemaName, t3_name));
     Arrays.stream(t3.columns()).anyMatch(c -> Objects.equals(c.name(), "t_12"));
     ITUtils.assertionsTableInfo(
-        t3_name, table_comment, Arrays.asList(t3_col), properties, t3_indexes, t3);
+        t3_name,
+        table_comment,
+        Arrays.asList(t3_col),
+        properties,
+        t3_indexes,
+        Transforms.EMPTY_TRANSFORM,
+        t3);
 
     Table t4 = tableCatalog.loadTable(NameIdentifier.of(schemaName, t4_name));
     Arrays.stream(t4.columns()).anyMatch(c -> Objects.equals(c.name(), "_1__"));
     ITUtils.assertionsTableInfo(
-        t4_name, table_comment, Arrays.asList(t4_col), properties, t4_indexes, t4);
+        t4_name,
+        table_comment,
+        Arrays.asList(t4_col),
+        properties,
+        t4_indexes,
+        Transforms.EMPTY_TRANSFORM,
+        t4);
   }
 
   @Test
@@ -1376,10 +1442,22 @@ public class CatalogMysqlIT extends AbstractIT {
             new SortOrder[0],
             indexes);
     ITUtils.assertionsTableInfo(
-        "tableName", table_comment, Arrays.asList(newColumns), properties, indexes, createdTable);
+        "tableName",
+        table_comment,
+        Arrays.asList(newColumns),
+        properties,
+        indexes,
+        Transforms.EMPTY_TRANSFORM,
+        createdTable);
     Table table = tableCatalog.loadTable(tableIdentifier);
     ITUtils.assertionsTableInfo(
-        "tableName", table_comment, Arrays.asList(newColumns), properties, indexes, table);
+        "tableName",
+        table_comment,
+        Arrays.asList(newColumns),
+        properties,
+        indexes,
+        Transforms.EMPTY_TRANSFORM,
+        table);
 
     // Test create table with same name but different case
     NameIdentifier tableIdentifier2 = NameIdentifier.of(schemaName, "TABLENAME");
@@ -1400,7 +1478,13 @@ public class CatalogMysqlIT extends AbstractIT {
 
     table = tableCatalog.loadTable(tableIdentifier2);
     ITUtils.assertionsTableInfo(
-        "TABLENAME", table_comment, Arrays.asList(newColumns), properties, indexes, table);
+        "TABLENAME",
+        table_comment,
+        Arrays.asList(newColumns),
+        properties,
+        indexes,
+        Transforms.EMPTY_TRANSFORM,
+        table);
   }
 
   @Test
@@ -1606,7 +1690,13 @@ public class CatalogMysqlIT extends AbstractIT {
           Indexes.createMysqlPrimaryKey(new String[][] {{"col_1"}})
         };
     ITUtils.assertionsTableInfo(
-        tableName, table_comment, Arrays.asList(newColumns), createProperties(), indexes, table);
+        tableName,
+        table_comment,
+        Arrays.asList(newColumns),
+        createProperties(),
+        indexes,
+        Transforms.EMPTY_TRANSFORM,
+        table);
 
     // delete index and add new column and index.
     tableCatalog.alterTable(
@@ -1627,7 +1717,13 @@ public class CatalogMysqlIT extends AbstractIT {
     Column col4 = Column.of("col_4", Types.VarCharType.of(255), null, true, false, null);
     newColumns = new Column[] {col1, col2, col3, col4};
     ITUtils.assertionsTableInfo(
-        tableName, table_comment, Arrays.asList(newColumns), createProperties(), indexes, table);
+        tableName,
+        table_comment,
+        Arrays.asList(newColumns),
+        createProperties(),
+        indexes,
+        Transforms.EMPTY_TRANSFORM,
+        table);
 
     // Add a previously existing index
     tableCatalog.alterTable(
@@ -1646,7 +1742,13 @@ public class CatalogMysqlIT extends AbstractIT {
         };
     table = tableCatalog.loadTable(NameIdentifier.of(schemaName, tableName));
     ITUtils.assertionsTableInfo(
-        tableName, table_comment, Arrays.asList(newColumns), createProperties(), indexes, table);
+        tableName,
+        table_comment,
+        Arrays.asList(newColumns),
+        createProperties(),
+        indexes,
+        Transforms.EMPTY_TRANSFORM,
+        table);
   }
 
   @Test
@@ -1712,7 +1814,13 @@ public class CatalogMysqlIT extends AbstractIT {
     Index[] indices = new Index[] {Indexes.createMysqlPrimaryKey(new String[][] {{"col_6"}})};
     newColumns = new Column[] {col1, col2, col3, col4, col5, col6};
     ITUtils.assertionsTableInfo(
-        tableName, table_comment, Arrays.asList(newColumns), properties, indices, table);
+        tableName,
+        table_comment,
+        Arrays.asList(newColumns),
+        properties,
+        indices,
+        Transforms.EMPTY_TRANSFORM,
+        table);
 
     // Test the auto-increment property of modified fields
     tableCatalog.alterTable(
@@ -1722,7 +1830,13 @@ public class CatalogMysqlIT extends AbstractIT {
     indices = new Index[] {Indexes.createMysqlPrimaryKey(new String[][] {{"col_6"}})};
     newColumns = new Column[] {col1, col2, col3, col4, col5, col6};
     ITUtils.assertionsTableInfo(
-        tableName, table_comment, Arrays.asList(newColumns), properties, indices, table);
+        tableName,
+        table_comment,
+        Arrays.asList(newColumns),
+        properties,
+        indices,
+        Transforms.EMPTY_TRANSFORM,
+        table);
 
     // Add the auto-increment attribute to the field
     tableCatalog.alterTable(
@@ -1732,7 +1846,13 @@ public class CatalogMysqlIT extends AbstractIT {
     indices = new Index[] {Indexes.createMysqlPrimaryKey(new String[][] {{"col_6"}})};
     newColumns = new Column[] {col1, col2, col3, col4, col5, col6};
     ITUtils.assertionsTableInfo(
-        tableName, table_comment, Arrays.asList(newColumns), properties, indices, table);
+        tableName,
+        table_comment,
+        Arrays.asList(newColumns),
+        properties,
+        indices,
+        Transforms.EMPTY_TRANSFORM,
+        table);
   }
 
   @Test
@@ -1778,6 +1898,7 @@ public class CatalogMysqlIT extends AbstractIT {
         Arrays.asList(newColumns),
         properties,
         Indexes.EMPTY_INDEXES,
+        Transforms.EMPTY_TRANSFORM,
         table);
   }
 

--- a/catalogs/catalog-jdbc-mysql/src/test/java/com/datastrato/gravitino/catalog/mysql/operation/TestMysqlTableOperations.java
+++ b/catalogs/catalog-jdbc-mysql/src/test/java/com/datastrato/gravitino/catalog/mysql/operation/TestMysqlTableOperations.java
@@ -28,6 +28,7 @@ import com.datastrato.gravitino.rel.Column;
 import com.datastrato.gravitino.rel.TableChange;
 import com.datastrato.gravitino.rel.expressions.distributions.Distributions;
 import com.datastrato.gravitino.rel.expressions.literals.Literals;
+import com.datastrato.gravitino.rel.expressions.transforms.Transforms;
 import com.datastrato.gravitino.rel.indexes.Index;
 import com.datastrato.gravitino.rel.indexes.Indexes;
 import com.datastrato.gravitino.rel.types.Decimal;
@@ -107,7 +108,8 @@ public class TestMysqlTableOperations extends TestMysql {
 
     // load table
     JdbcTable load = TABLE_OPERATIONS.load(TEST_DB_NAME.toString(), tableName);
-    assertionsTableInfo(tableName, tableComment, columns, properties, indexes, load);
+    assertionsTableInfo(
+        tableName, tableComment, columns, properties, indexes, Transforms.EMPTY_TRANSFORM, load);
 
     // rename table
     String newName = "new_table";
@@ -146,7 +148,8 @@ public class TestMysqlTableOperations extends TestMysql {
             add(columns.get(3));
           }
         };
-    assertionsTableInfo(newName, tableComment, alterColumns, properties, indexes, load);
+    assertionsTableInfo(
+        newName, tableComment, alterColumns, properties, indexes, Transforms.EMPTY_TRANSFORM, load);
 
     // Detect unsupported properties
     TableChange setProperty = TableChange.setProperty(MYSQL_ENGINE_KEY, "ABC");
@@ -164,7 +167,8 @@ public class TestMysqlTableOperations extends TestMysql {
         newName,
         TableChange.deleteColumn(new String[] {newColumn.name()}, true));
     load = TABLE_OPERATIONS.load(TEST_DB_NAME.toString(), newName);
-    assertionsTableInfo(newName, tableComment, columns, properties, indexes, load);
+    assertionsTableInfo(
+        newName, tableComment, columns, properties, indexes, Transforms.EMPTY_TRANSFORM, load);
 
     TableChange deleteColumn = TableChange.deleteColumn(new String[] {newColumn.name()}, false);
     IllegalArgumentException illegalArgumentException =
@@ -241,7 +245,8 @@ public class TestMysqlTableOperations extends TestMysql {
         Distributions.NONE,
         indexes);
     JdbcTable load = TABLE_OPERATIONS.load(TEST_DB_NAME.toString(), tableName);
-    assertionsTableInfo(tableName, tableComment, columns, properties, indexes, load);
+    assertionsTableInfo(
+        tableName, tableComment, columns, properties, indexes, Transforms.EMPTY_TRANSFORM, load);
 
     TABLE_OPERATIONS.alterTable(
         TEST_DB_NAME.toString(),
@@ -264,7 +269,8 @@ public class TestMysqlTableOperations extends TestMysql {
     columns.add(col_1);
     columns.add(col_2);
     columns.add(col_3);
-    assertionsTableInfo(tableName, tableComment, columns, properties, indexes, load);
+    assertionsTableInfo(
+        tableName, tableComment, columns, properties, indexes, Transforms.EMPTY_TRANSFORM, load);
 
     String newComment = "new_comment";
     // update table comment and column comment
@@ -300,7 +306,8 @@ public class TestMysqlTableOperations extends TestMysql {
     columns.add(col_1);
     columns.add(col_2);
     columns.add(col_3);
-    assertionsTableInfo(tableName, tableComment, columns, properties, indexes, load);
+    assertionsTableInfo(
+        tableName, tableComment, columns, properties, indexes, Transforms.EMPTY_TRANSFORM, load);
 
     String newColName_1 = "new_col_1";
     String newColName_2 = "new_col_2";
@@ -340,7 +347,8 @@ public class TestMysqlTableOperations extends TestMysql {
     columns.add(col_1);
     columns.add(col_2);
     columns.add(col_3);
-    assertionsTableInfo(tableName, tableComment, columns, properties, indexes, load);
+    assertionsTableInfo(
+        tableName, tableComment, columns, properties, indexes, Transforms.EMPTY_TRANSFORM, load);
 
     newComment = "txt3";
     String newCol2Comment = "xxx";
@@ -391,7 +399,8 @@ public class TestMysqlTableOperations extends TestMysql {
             .withDefaultValue(Literals.of("hello world", VARCHAR))
             .withNullable(true)
             .build());
-    assertionsTableInfo(tableName, newComment, columns, properties, indexes, load);
+    assertionsTableInfo(
+        tableName, newComment, columns, properties, indexes, Transforms.EMPTY_TRANSFORM, load);
 
     // `new_col_2` varchar(255) NOT NULL DEFAULT 'hello world' COMMENT 'xxx' ,
     // `col_3` varchar(255) NULL DEFAULT NULL COMMENT 'name' ,
@@ -432,7 +441,8 @@ public class TestMysqlTableOperations extends TestMysql {
     columns.add(col_5);
     columns.add(col_1);
 
-    assertionsTableInfo(tableName, newComment, columns, properties, indexes, load);
+    assertionsTableInfo(
+        tableName, newComment, columns, properties, indexes, Transforms.EMPTY_TRANSFORM, load);
 
     TableChange updateColumn =
         TableChange.updateColumnNullability(new String[] {col3.name()}, !col3.nullable());
@@ -501,7 +511,8 @@ public class TestMysqlTableOperations extends TestMysql {
         indexes);
 
     JdbcTable loaded = TABLE_OPERATIONS.load(TEST_DB_NAME.toString(), tableName);
-    assertionsTableInfo(tableName, tableComment, columns, properties, indexes, loaded);
+    assertionsTableInfo(
+        tableName, tableComment, columns, properties, indexes, Transforms.EMPTY_TRANSFORM, loaded);
 
     TABLE_OPERATIONS.alterTable(
         TEST_DB_NAME.toString(),
@@ -585,7 +596,8 @@ public class TestMysqlTableOperations extends TestMysql {
         indexes);
 
     JdbcTable loaded = TABLE_OPERATIONS.load(TEST_DB_NAME.toString(), tableName);
-    assertionsTableInfo(tableName, tableComment, columns, properties, indexes, loaded);
+    assertionsTableInfo(
+        tableName, tableComment, columns, properties, indexes, Transforms.EMPTY_TRANSFORM, loaded);
   }
 
   @Test
@@ -683,7 +695,14 @@ public class TestMysqlTableOperations extends TestMysql {
         Indexes.EMPTY_INDEXES);
 
     JdbcTable load = TABLE_OPERATIONS.load(TEST_DB_NAME.toString(), tableName);
-    assertionsTableInfo(tableName, tableComment, columns, Collections.emptyMap(), null, load);
+    assertionsTableInfo(
+        tableName,
+        tableComment,
+        columns,
+        Collections.emptyMap(),
+        null,
+        Transforms.EMPTY_TRANSFORM,
+        load);
   }
 
   @Test
@@ -861,6 +880,7 @@ public class TestMysqlTableOperations extends TestMysql {
         Arrays.stream(columns).collect(Collectors.toList()),
         properties,
         indexes,
+        Transforms.EMPTY_TRANSFORM,
         table);
     TABLE_OPERATIONS.drop(TEST_DB_NAME.toString(), tableName);
 
@@ -887,6 +907,7 @@ public class TestMysqlTableOperations extends TestMysql {
         Arrays.stream(columns).collect(Collectors.toList()),
         properties,
         indexes,
+        Transforms.EMPTY_TRANSFORM,
         table);
     TABLE_OPERATIONS.drop(TEST_DB_NAME.toString(), tableName);
 
@@ -909,6 +930,7 @@ public class TestMysqlTableOperations extends TestMysql {
         Arrays.stream(columns).collect(Collectors.toList()),
         properties,
         indexes,
+        Transforms.EMPTY_TRANSFORM,
         table);
     TABLE_OPERATIONS.drop(TEST_DB_NAME.toString(), tableName);
 

--- a/catalogs/catalog-jdbc-postgresql/src/test/java/com/datastrato/gravitino/catalog/postgresql/integration/test/CatalogPostgreSqlIT.java
+++ b/catalogs/catalog-jdbc-postgresql/src/test/java/com/datastrato/gravitino/catalog/postgresql/integration/test/CatalogPostgreSqlIT.java
@@ -698,10 +698,22 @@ public class CatalogPostgreSqlIT extends AbstractIT {
             new SortOrder[0],
             indexes);
     ITUtils.assertionsTableInfo(
-        tableName, table_comment, Arrays.asList(newColumns), properties, indexes, createdTable);
+        tableName,
+        table_comment,
+        Arrays.asList(newColumns),
+        properties,
+        indexes,
+        Transforms.EMPTY_TRANSFORM,
+        createdTable);
     Table table = tableCatalog.loadTable(tableIdentifier);
     ITUtils.assertionsTableInfo(
-        tableName, table_comment, Arrays.asList(newColumns), properties, indexes, table);
+        tableName,
+        table_comment,
+        Arrays.asList(newColumns),
+        properties,
+        indexes,
+        Transforms.EMPTY_TRANSFORM,
+        table);
 
     // Test create index complex fields fail.
     NameIdentifier id = NameIdentifier.of(schemaName, "test_failed");
@@ -1059,22 +1071,46 @@ public class CatalogPostgreSqlIT extends AbstractIT {
     Table t1 = tableCatalog.loadTable(NameIdentifier.of(schemaName, t1_name));
     Arrays.stream(t1.columns()).anyMatch(c -> Objects.equals(c.name(), "t112"));
     ITUtils.assertionsTableInfo(
-        t1_name, table_comment, Arrays.asList(t1_col), properties, t1_indexes, t1);
+        t1_name,
+        table_comment,
+        Arrays.asList(t1_col),
+        properties,
+        t1_indexes,
+        Transforms.EMPTY_TRANSFORM,
+        t1);
 
     Table t2 = tableCatalog.loadTable(NameIdentifier.of(schemaName, t2_name));
     Arrays.stream(t2.columns()).anyMatch(c -> Objects.equals(c.name(), "t212"));
     ITUtils.assertionsTableInfo(
-        t2_name, table_comment, Arrays.asList(t2_col), properties, t2_indexes, t2);
+        t2_name,
+        table_comment,
+        Arrays.asList(t2_col),
+        properties,
+        t2_indexes,
+        Transforms.EMPTY_TRANSFORM,
+        t2);
 
     Table t3 = tableCatalog.loadTable(NameIdentifier.of(schemaName, t3_name));
     Arrays.stream(t3.columns()).anyMatch(c -> Objects.equals(c.name(), "t_12"));
     ITUtils.assertionsTableInfo(
-        t3_name, table_comment, Arrays.asList(t3_col), properties, t3_indexes, t3);
+        t3_name,
+        table_comment,
+        Arrays.asList(t3_col),
+        properties,
+        t3_indexes,
+        Transforms.EMPTY_TRANSFORM,
+        t3);
 
     Table t4 = tableCatalog.loadTable(NameIdentifier.of(schemaName, t4_name));
     Arrays.stream(t4.columns()).anyMatch(c -> Objects.equals(c.name(), "_1__"));
     ITUtils.assertionsTableInfo(
-        t4_name, table_comment, Arrays.asList(t4_col), properties, t4_indexes, t4);
+        t4_name,
+        table_comment,
+        Arrays.asList(t4_col),
+        properties,
+        t4_indexes,
+        Transforms.EMPTY_TRANSFORM,
+        t4);
   }
 
   @Test
@@ -1244,10 +1280,17 @@ public class CatalogPostgreSqlIT extends AbstractIT {
         Arrays.asList(newColumns),
         properties,
         indexes,
+        Transforms.EMPTY_TRANSFORM,
         createdTable);
     Table table = tableCatalog.loadTable(tableIdentifier);
     ITUtils.assertionsTableInfo(
-        "tablename", "low case table name", Arrays.asList(newColumns), properties, indexes, table);
+        "tablename",
+        "low case table name",
+        Arrays.asList(newColumns),
+        properties,
+        indexes,
+        Transforms.EMPTY_TRANSFORM,
+        table);
 
     // Test create table with same name but different case
     NameIdentifier tableIdentifier2 = NameIdentifier.of(schemaName, "TABLENAME");
@@ -1484,7 +1527,13 @@ public class CatalogPostgreSqlIT extends AbstractIT {
           Indexes.primary("pk1_key", new String[][] {{"col_1"}})
         };
     ITUtils.assertionsTableInfo(
-        tableName, table_comment, Arrays.asList(newColumns), createProperties(), indexes, table);
+        tableName,
+        table_comment,
+        Arrays.asList(newColumns),
+        createProperties(),
+        indexes,
+        Transforms.EMPTY_TRANSFORM,
+        table);
 
     // delete index and add new column and index.
     tableCatalog.alterTable(
@@ -1505,7 +1554,13 @@ public class CatalogPostgreSqlIT extends AbstractIT {
     Column col4 = Column.of("col_4", Types.VarCharType.of(255), null, true, false, null);
     newColumns = new Column[] {col1, col2, col3, col4};
     ITUtils.assertionsTableInfo(
-        tableName, table_comment, Arrays.asList(newColumns), createProperties(), indexes, table);
+        tableName,
+        table_comment,
+        Arrays.asList(newColumns),
+        createProperties(),
+        indexes,
+        Transforms.EMPTY_TRANSFORM,
+        table);
 
     // Add a previously existing index
     tableCatalog.alterTable(
@@ -1524,7 +1579,13 @@ public class CatalogPostgreSqlIT extends AbstractIT {
         };
     table = tableCatalog.loadTable(NameIdentifier.of(schemaName, tableName));
     ITUtils.assertionsTableInfo(
-        tableName, table_comment, Arrays.asList(newColumns), createProperties(), indexes, table);
+        tableName,
+        table_comment,
+        Arrays.asList(newColumns),
+        createProperties(),
+        indexes,
+        Transforms.EMPTY_TRANSFORM,
+        table);
   }
 
   @Test
@@ -1568,6 +1629,7 @@ public class CatalogPostgreSqlIT extends AbstractIT {
         Arrays.asList(newColumns),
         properties,
         Indexes.EMPTY_INDEXES,
+        Transforms.EMPTY_TRANSFORM,
         table);
 
     // Test drop auto increment column
@@ -1582,6 +1644,7 @@ public class CatalogPostgreSqlIT extends AbstractIT {
         Arrays.asList(newColumns),
         properties,
         Indexes.EMPTY_INDEXES,
+        Transforms.EMPTY_TRANSFORM,
         table);
 
     // Test add auto increment column
@@ -1596,6 +1659,7 @@ public class CatalogPostgreSqlIT extends AbstractIT {
         Arrays.asList(newColumns),
         properties,
         Indexes.EMPTY_INDEXES,
+        Transforms.EMPTY_TRANSFORM,
         table);
   }
 
@@ -1643,6 +1707,7 @@ public class CatalogPostgreSqlIT extends AbstractIT {
         Arrays.asList(newColumns),
         properties,
         Indexes.EMPTY_INDEXES,
+        Transforms.EMPTY_TRANSFORM,
         table);
   }
 

--- a/catalogs/catalog-jdbc-postgresql/src/test/java/com/datastrato/gravitino/catalog/postgresql/operation/TestPostgreSqlTableOperations.java
+++ b/catalogs/catalog-jdbc-postgresql/src/test/java/com/datastrato/gravitino/catalog/postgresql/operation/TestPostgreSqlTableOperations.java
@@ -30,6 +30,7 @@ import com.datastrato.gravitino.exceptions.NoSuchTableException;
 import com.datastrato.gravitino.rel.TableChange;
 import com.datastrato.gravitino.rel.expressions.distributions.Distributions;
 import com.datastrato.gravitino.rel.expressions.literals.Literals;
+import com.datastrato.gravitino.rel.expressions.transforms.Transforms;
 import com.datastrato.gravitino.rel.indexes.Index;
 import com.datastrato.gravitino.rel.indexes.Indexes;
 import com.datastrato.gravitino.rel.types.Type;
@@ -101,7 +102,8 @@ public class TestPostgreSqlTableOperations extends TestPostgreSql {
 
     // load table
     JdbcTable load = TABLE_OPERATIONS.load(TEST_DB_NAME, tableName);
-    assertionsTableInfo(tableName, tableComment, columns, properties, null, load);
+    assertionsTableInfo(
+        tableName, tableComment, columns, properties, null, Transforms.EMPTY_TRANSFORM, load);
 
     // rename table
     String newName = "new_table";
@@ -165,7 +167,8 @@ public class TestPostgreSqlTableOperations extends TestPostgreSql {
             .build());
     alterColumns.add(newColumn);
     alterColumns.add(newColumn1);
-    assertionsTableInfo(newName, tableComment, alterColumns, properties, null, load);
+    assertionsTableInfo(
+        newName, tableComment, alterColumns, properties, null, Transforms.EMPTY_TRANSFORM, load);
 
     TABLE_OPERATIONS.alterTable(
         TEST_DB_NAME,
@@ -198,7 +201,8 @@ public class TestPostgreSqlTableOperations extends TestPostgreSql {
             .build());
     alterColumns.add(newColumn);
     alterColumns.add(newColumn1);
-    assertionsTableInfo(newName, tableComment, alterColumns, properties, null, load);
+    assertionsTableInfo(
+        newName, tableComment, alterColumns, properties, null, Transforms.EMPTY_TRANSFORM, load);
 
     // alter column Nullability
     TABLE_OPERATIONS.alterTable(
@@ -229,7 +233,8 @@ public class TestPostgreSqlTableOperations extends TestPostgreSql {
             .build());
     alterColumns.add(newColumn);
     alterColumns.add(newColumn1);
-    assertionsTableInfo(newName, tableComment, alterColumns, properties, null, load);
+    assertionsTableInfo(
+        newName, tableComment, alterColumns, properties, null, Transforms.EMPTY_TRANSFORM, load);
 
     // delete column
     TABLE_OPERATIONS.alterTable(
@@ -241,7 +246,8 @@ public class TestPostgreSqlTableOperations extends TestPostgreSql {
     load = TABLE_OPERATIONS.load(TEST_DB_NAME, newName);
     alterColumns.remove(newColumn);
     alterColumns.remove(newColumn1);
-    assertionsTableInfo(newName, tableComment, alterColumns, properties, null, load);
+    assertionsTableInfo(
+        newName, tableComment, alterColumns, properties, null, Transforms.EMPTY_TRANSFORM, load);
 
     TableChange deleteColumn = TableChange.deleteColumn(new String[] {newColumn.name()}, false);
     IllegalArgumentException illegalArgumentException =
@@ -366,7 +372,14 @@ public class TestPostgreSqlTableOperations extends TestPostgreSql {
         Indexes.EMPTY_INDEXES);
 
     JdbcTable load = TABLE_OPERATIONS.load(TEST_DB_NAME, tableName);
-    assertionsTableInfo(tableName, tableComment, columns, Collections.emptyMap(), null, load);
+    assertionsTableInfo(
+        tableName,
+        tableComment,
+        columns,
+        Collections.emptyMap(),
+        null,
+        Transforms.EMPTY_TRANSFORM,
+        load);
   }
 
   @Test
@@ -507,7 +520,8 @@ public class TestPostgreSqlTableOperations extends TestPostgreSql {
 
     // load table
     JdbcTable load = TABLE_OPERATIONS.load(TEST_DB_NAME, tableName);
-    assertionsTableInfo(tableName, tableComment, columns, properties, null, load);
+    assertionsTableInfo(
+        tableName, tableComment, columns, properties, null, Transforms.EMPTY_TRANSFORM, load);
 
     columns.clear();
     columns.add(
@@ -603,7 +617,8 @@ public class TestPostgreSqlTableOperations extends TestPostgreSql {
         indexes);
 
     JdbcTable load = TABLE_OPERATIONS.load(TEST_DB_NAME, tableName);
-    assertionsTableInfo(tableName, tableComment, columns, properties, indexes, load);
+    assertionsTableInfo(
+        tableName, tableComment, columns, properties, indexes, Transforms.EMPTY_TRANSFORM, load);
 
     TABLE_OPERATIONS.drop(TEST_DB_NAME, tableName);
 

--- a/integration-test-common/src/test/java/com/datastrato/gravitino/integration/test/util/ITUtils.java
+++ b/integration-test-common/src/test/java/com/datastrato/gravitino/integration/test/util/ITUtils.java
@@ -24,6 +24,7 @@ import com.datastrato.gravitino.dto.rel.ColumnDTO;
 import com.datastrato.gravitino.dto.rel.expressions.LiteralDTO;
 import com.datastrato.gravitino.rel.Column;
 import com.datastrato.gravitino.rel.Table;
+import com.datastrato.gravitino.rel.expressions.transforms.Transform;
 import com.datastrato.gravitino.rel.indexes.Index;
 import java.io.File;
 import java.io.IOException;
@@ -85,6 +86,7 @@ public class ITUtils {
       List<Column> columns,
       Map<String, String> properties,
       Index[] indexes,
+      Transform[] partitioning,
       Table table) {
     Assertions.assertEquals(tableName, table.name());
     Assertions.assertEquals(tableComment, table.comment());
@@ -114,6 +116,7 @@ public class ITUtils {
         }
       }
     }
+    Assertions.assertTrue(Arrays.deepEquals(table.partitioning(), partitioning));
   }
 
   public static void assertColumn(Column expected, Column actual) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Set partitioning when loading JDBC tables.

### Why are the changes needed?

Fix: #4120 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

UT & IT.
