### PR TITLE
[#4059] feat(iceberg-rest-server): support Iceberg REST server docker image

### DIFF
--- a/dev/docker/build-docker.sh
+++ b/dev/docker/build-docker.sh
@@ -27,7 +27,7 @@ usage() {
   cat << EOF
 Usage:
 
-./build-docker.sh --platform [all|linux/amd64|linux/arm64] --type [gravitino|hive|kerberos-hive|trino|doris|ranger] --image {image_name} --tag {tag_name} --latest
+./build-docker.sh --platform [all|linux/amd64|linux/arm64] --type [gravitino|hive|kerberos-hive|trino|doris|ranger|iceberg-rest-server] --image {image_name} --tag {tag_name} --latest
 
 Notice: You shouldn't use 'all' for the platform if you don't use the Github action to publish the Docker image.
 EOF
@@ -113,6 +113,8 @@ elif [ "${component_type}" == "doris" ]; then
 elif [ "${component_type}" == "ranger" ]; then
   . ${script_dir}/ranger/ranger-dependency.sh
   build_args="--build-arg RANGER_PACKAGE_NAME=${RANGER_PACKAGE_NAME} --build-arg MYSQL_CONNECTOR_PACKAGE_NAME=${MYSQL_CONNECTOR_PACKAGE_NAME} --build-arg LOG4JDBC_PACKAGE_NAME=${LOG4JDBC_PACKAGE_NAME} --build-arg RANGER_VERSION=${RANGER_VERSION}"
+elif [ "${component_type}" == "iceberg-rest-server" ]; then
+  . ${script_dir}/iceberg-rest-server/iceberg-rest-server-dependency.sh
 else
   echo "ERROR : ${component_type} is not a valid component type"
   usage

--- a/dev/docker/gravitino/Dockerfile
+++ b/dev/docker/gravitino/Dockerfile
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-FROM openjdk:8-jdk-buster
+FROM openjdk:17
 LABEL maintainer="dev@gravitino.apache.org"
 
 WORKDIR /root/gravitino

--- a/dev/docker/iceberg-rest-server/Dockerfile
+++ b/dev/docker/iceberg-rest-server/Dockerfile
@@ -17,7 +17,7 @@
 # under the License.
 #
 FROM openjdk:8-jdk-buster
-LABEL maintainer="support@datastrato.com"
+LABEL maintainer="dev@gravitino.apache.org"
 
 WORKDIR /root/gravitino-iceberg-rest-server
 

--- a/dev/docker/iceberg-rest-server/Dockerfile
+++ b/dev/docker/iceberg-rest-server/Dockerfile
@@ -16,7 +16,8 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-FROM openjdk:8-jdk-buster
+FROM openjdk:17
+
 LABEL maintainer="dev@gravitino.apache.org"
 
 WORKDIR /root/gravitino-iceberg-rest-server

--- a/dev/docker/iceberg-rest-server/Dockerfile
+++ b/dev/docker/iceberg-rest-server/Dockerfile
@@ -19,10 +19,10 @@
 FROM openjdk:8-jdk-buster
 LABEL maintainer="support@datastrato.com"
 
-WORKDIR /root/iceberg-rest-server
+WORKDIR /root/gravitino-iceberg-rest-server
 
-COPY packages/iceberg-rest-server /root/iceberg-rest-server
+COPY packages/gravitino-iceberg-rest-server /root/gravitino-iceberg-rest-server
 
 EXPOSE 9001
 
-ENTRYPOINT ["/bin/bash", "/root/iceberg-rest-server/bin/iceberg-rest-server.sh", "start"]
+ENTRYPOINT ["/bin/bash", "/root/gravitino-iceberg-rest-server/bin/gravitino-iceberg-rest-server.sh", "start"]

--- a/dev/docker/iceberg-rest-server/Dockerfile
+++ b/dev/docker/iceberg-rest-server/Dockerfile
@@ -1,0 +1,28 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+FROM openjdk:8-jdk-buster
+LABEL maintainer="support@datastrato.com"
+
+WORKDIR /root/iceberg-rest-server
+
+COPY packages/iceberg-rest-server /root/iceberg-rest-server
+
+EXPOSE 9001
+
+ENTRYPOINT ["/bin/bash", "/root/iceberg-rest-server/bin/iceberg-rest-server.sh", "start"]

--- a/dev/docker/iceberg-rest-server/iceberg-rest-server-dependency.sh
+++ b/dev/docker/iceberg-rest-server/iceberg-rest-server-dependency.sh
@@ -18,24 +18,24 @@
 # under the License.
 #
 set -ex
-script_dir="$(dirname "${BASH_SOURCE-$0}")"
-script_dir="$(cd "${script_dir}">/dev/null; pwd)"
-gravitino_home="$(cd "${script_dir}/../../..">/dev/null; pwd)"
+iceberg_rest_server_dir="$(dirname "${BASH_SOURCE-$0}")"
+iceberg_rest_server_dir="$(cd "${iceberg_rest_server_dir}">/dev/null; pwd)"
+gravitino_home="$(cd "${iceberg_rest_server_dir}/../../..">/dev/null; pwd)"
 
 # Prepare compile Iceberg REST server packages
 cd ${gravitino_home}
 ./gradlew clean assembleIcebergRESTServer -x test
 
 # Removed old packages, Avoid multiple re-executions using the wrong file
-rm -rf "${script_dir}/packages"
-mkdir -p "${script_dir}/packages"
+rm -rf "${iceberg_rest_server_dir}/packages"
+mkdir -p "${iceberg_rest_server_dir}/packages"
 
 cd distribution
 tar xfz gravitino-iceberg-rest-server-*.tar.gz
-cp -r gravitino-iceberg-rest-server*-bin ${script_dir}/packages/gravitino-iceberg-rest-server
+cp -r gravitino-iceberg-rest-server*-bin ${iceberg_rest_server_dir}/packages/gravitino-iceberg-rest-server
 
 # Keeping the container running at all times
-cat <<EOF >> "${script_dir}/packages/gravitino-iceberg-rest-server/bin/gravitino-iceberg-rest-server.sh"
+cat <<EOF >> "${iceberg_rest_server_dir}/packages/gravitino-iceberg-rest-server/bin/gravitino-iceberg-rest-server.sh"
 
 # Keeping a process running in the background
 tail -f /dev/null

--- a/dev/docker/iceberg-rest-server/iceberg-rest-server-dependency.sh
+++ b/dev/docker/iceberg-rest-server/iceberg-rest-server-dependency.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+set -ex
+script_dir="$(dirname "${BASH_SOURCE-$0}")"
+script_dir="$(cd "${script_dir}">/dev/null; pwd)"
+gravitino_home="$(cd "${script_dir}/../../..">/dev/null; pwd)"
+
+# Prepare compile Iceberg REST server packages
+cd ${gravitino_home}
+./gradlew clean assembleIcebergRESTServer -x test
+
+# Removed old packages, Avoid multiple re-executions using the wrong file
+rm -rf "${script_dir}/packages"
+mkdir -p "${script_dir}/packages"
+
+cd distribution
+tar xfz gravitino-iceberg-rest-server-*.tar.gz
+cp -r gravitino-iceberg-rest-server*-bin ${script_dir}/packages/iceberg-rest-server
+
+# Keeping the container running at all times
+cat <<EOF >> "${script_dir}/packages/iceberg-rest-server/bin/iceberg-rest-server.sh"
+
+# Keeping a process running in the background
+tail -f /dev/null
+EOF

--- a/dev/docker/iceberg-rest-server/iceberg-rest-server-dependency.sh
+++ b/dev/docker/iceberg-rest-server/iceberg-rest-server-dependency.sh
@@ -22,11 +22,11 @@ iceberg_rest_server_dir="$(dirname "${BASH_SOURCE-$0}")"
 iceberg_rest_server_dir="$(cd "${iceberg_rest_server_dir}">/dev/null; pwd)"
 gravitino_home="$(cd "${iceberg_rest_server_dir}/../../..">/dev/null; pwd)"
 
-# Prepare compile Iceberg REST server packages
+# Prepare the Iceberg REST server packages
 cd ${gravitino_home}
 ./gradlew clean assembleIcebergRESTServer -x test
 
-# Removed old packages, Avoid multiple re-executions using the wrong file
+# Removed old packages 
 rm -rf "${iceberg_rest_server_dir}/packages"
 mkdir -p "${iceberg_rest_server_dir}/packages"
 

--- a/dev/docker/iceberg-rest-server/iceberg-rest-server-dependency.sh
+++ b/dev/docker/iceberg-rest-server/iceberg-rest-server-dependency.sh
@@ -32,10 +32,10 @@ mkdir -p "${script_dir}/packages"
 
 cd distribution
 tar xfz gravitino-iceberg-rest-server-*.tar.gz
-cp -r gravitino-iceberg-rest-server*-bin ${script_dir}/packages/iceberg-rest-server
+cp -r gravitino-iceberg-rest-server*-bin ${script_dir}/packages/gravitino-iceberg-rest-server
 
 # Keeping the container running at all times
-cat <<EOF >> "${script_dir}/packages/iceberg-rest-server/bin/iceberg-rest-server.sh"
+cat <<EOF >> "${script_dir}/packages/gravitino-iceberg-rest-server/bin/gravitino-iceberg-rest-server.sh"
 
 # Keeping a process running in the background
 tail -f /dev/null

--- a/docs/docker-image-details.md
+++ b/docs/docker-image-details.md
@@ -7,8 +7,6 @@ license: "This software is licensed under the Apache License version 2."
 
 # User Docker images
 
-There are two kinds of Docker images you can use: the Apache Gravitino Docker image and playground Docker images.
-
 ## Apache Gravitino Docker image
 
 You can deploy the service with the Gravitino Docker image.
@@ -42,6 +40,24 @@ Changelog
   - Gravitino Server
   - Expose ports:
     - `8090` Gravitino Web UI
+    - `9001` Iceberg REST service
+
+## Gravitino Iceberg REST server Docker image
+
+You can deploy the standalone Gravitino Iceberg REST server with the Docker image.
+
+Container startup commands
+
+```shell
+docker run --rm -d -p 9001:9001 datastrato/gravitino-iceberg-rest-server
+```
+
+Changelog
+
+- gravitino-iceberg-rest-server:0.6.0
+  - Docker image `datastrato/gravitino-iceberg-rest-server:0.6.0`
+  - Gravitino Iceberg REST Server with memory catalog backend.
+  - Expose ports:
     - `9001` Iceberg REST service
 
 ## Playground Docker image

--- a/docs/docker-image-details.md
+++ b/docs/docker-image-details.md
@@ -42,7 +42,7 @@ Changelog
     - `8090` Gravitino Web UI
     - `9001` Iceberg REST service
 
-## Gravitino Iceberg REST server Docker image
+## Apache Gravitino Iceberg REST server Docker image
 
 You can deploy the standalone Gravitino Iceberg REST server with the Docker image.
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
add gravitino iceberg rest service docker image

### Why are the changes needed?
1. setup Gravition Iceberg REST service easily for test
2. user could add customer changes and setup a new docker image for product.

Fix: #4059 

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?

in local machine, setup docker image and check it works