### PR TITLE
[#4151] improvement(api): Support for setting arbitrary username in the constructor of class SimpleTokenProvider

### DIFF
--- a/clients/client-java/src/main/java/com/datastrato/gravitino/client/GravitinoClientBase.java
+++ b/clients/client-java/src/main/java/com/datastrato/gravitino/client/GravitinoClientBase.java
@@ -219,6 +219,17 @@ public abstract class GravitinoClientBase implements Closeable {
     }
 
     /**
+     * Sets the simple mode authentication for Gravitino with the given username.
+     *
+     * @param username The username for the simple mode authentication.
+     * @return This Builder instance for method chaining.
+     */
+    public Builder<T> withSimpleAuth(String username) {
+      this.authDataProvider = new SimpleTokenProvider(username);
+      return this;
+    }
+
+    /**
      * Optional, set a flag to verify the client is supported to connector the server
      *
      * @return This Builder instance for method chaining.

--- a/clients/client-java/src/main/java/com/datastrato/gravitino/client/SimpleTokenProvider.java
+++ b/clients/client-java/src/main/java/com/datastrato/gravitino/client/SimpleTokenProvider.java
@@ -20,6 +20,7 @@
 package com.datastrato.gravitino.client;
 
 import com.datastrato.gravitino.auth.AuthConstants;
+import com.google.common.base.Preconditions;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
@@ -38,6 +39,17 @@ final class SimpleTokenProvider implements AuthDataProvider {
       gravitinoUser = System.getProperty("user.name");
     }
     String userInformation = gravitinoUser + ":dummy";
+    this.token =
+        (AuthConstants.AUTHORIZATION_BASIC_HEADER
+                + new String(
+                    Base64.getEncoder().encode(userInformation.getBytes(StandardCharsets.UTF_8)),
+                    StandardCharsets.UTF_8))
+            .getBytes(StandardCharsets.UTF_8);
+  }
+
+  public SimpleTokenProvider(String userName) {
+    Preconditions.checkArgument(userName != null, "userName cannot be null");
+    String userInformation = userName + ":dummy";
     this.token =
         (AuthConstants.AUTHORIZATION_BASIC_HEADER
                 + new String(

--- a/clients/client-java/src/test/java/com/datastrato/gravitino/client/TestSimpleTokenProvider.java
+++ b/clients/client-java/src/test/java/com/datastrato/gravitino/client/TestSimpleTokenProvider.java
@@ -50,4 +50,23 @@ public class TestSimpleTokenProvider {
       }
     }
   }
+
+  @Test
+  public void testAuthenticationWithUserName() throws IOException {
+    String userName = "testUser";
+    try (AuthDataProvider provider = new SimpleTokenProvider(userName)) {
+      Assertions.assertTrue(provider.hasTokenData());
+      String token = new String(provider.getTokenData(), StandardCharsets.UTF_8);
+      Assertions.assertTrue(token.startsWith(AuthConstants.AUTHORIZATION_BASIC_HEADER));
+      String tokenString =
+          new String(
+              Base64.getDecoder()
+                  .decode(
+                      token
+                          .substring(AuthConstants.AUTHORIZATION_BASIC_HEADER.length())
+                          .getBytes(StandardCharsets.UTF_8)),
+              StandardCharsets.UTF_8);
+      Assertions.assertEquals(userName + ":dummy", tokenString);
+    }
+  }
 }


### PR DESCRIPTION


### What changes were proposed in this pull request?

Support setting any username in SimpleTokenProvider.

### Why are the changes needed?

For better uses

Fix: #4151

### Does this PR introduce _any_ user-facing change?

Yes

### How was this patch tested?

UT