### PR TITLE
[#4157] fix(doc): Fix the doc format in `how-to-build`

### DIFF
--- a/docs/how-to-build.md
+++ b/docs/how-to-build.md
@@ -40,7 +40,7 @@ license: "This software is licensed under the Apache License version 2."
 
 1. Clone the Gravitino project.
 
-If you want to contribute to this open-source project, please fork the project on GitHub first. After forking, clone the forked project to your local environment, make your changes, and submit a pull request (PR).
+    If you want to contribute to this open-source project, please fork the project on GitHub first. After forking, clone the forked project to your local environment, make your changes, and submit a pull request (PR).
 
     ```shell
     git clone git@github.com:apache/gravitino.git


### PR DESCRIPTION
### What changes were proposed in this pull request?

[#4157] fix(doc): Fix the doc format in `how-to-build`

### Why are the changes needed?

https://github.com/apache/gravitino/blob/main/docs/how-to-build.md#quick-start

The code block should only show the `git clone git@github.com:apache/gravitino.git`

<img width="1159" alt="img" src="https://github.com/user-attachments/assets/ac00cf90-85a5-4ad7-8c3e-ae24ccd4abe8">


Fix: #4157 

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

The doc format is fine in my dev branch.

https://github.com/1996fanrui/gravitino/blob/4157/fix-doc-format/docs/how-to-build.md#quick-start

<img width="1061" alt="img2" src="https://github.com/user-attachments/assets/d54634f7-1bd8-4df8-9ea2-9537a71c0bcc">

