### PR TITLE
[#4165] improvement(Filesystem): Improve the potential storage replication issues in Hadoop GVFS

### DIFF
--- a/clients/filesystem-hadoop3/src/main/java/org/apache/gravitino/filesystem/hadoop/GravitinoVirtualFileSystem.java
+++ b/clients/filesystem-hadoop3/src/main/java/org/apache/gravitino/filesystem/hadoop/GravitinoVirtualFileSystem.java
@@ -516,6 +516,18 @@ public class GravitinoVirtualFileSystem extends FileSystem {
   }
 
   @Override
+  public short getDefaultReplication(Path f) {
+    FilesetContext context = getFilesetContext(f);
+    return context.getFileSystem().getDefaultReplication(context.getActualPath());
+  }
+
+  @Override
+  public long getDefaultBlockSize(Path f) {
+    FilesetContext context = getFilesetContext(f);
+    return context.getFileSystem().getDefaultBlockSize(context.getActualPath());
+  }
+
+  @Override
   public synchronized void close() throws IOException {
     // close all actual FileSystems
     for (Pair<Fileset, FileSystem> filesetPair : filesetCache.asMap().values()) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Currently, Hadoop GVFS does not implement the `getDefaultBlockSize(Path f)` and `getBlockSize(Path f)` methods, which will result in the use of the FileSystem default values, causing the storage replicas to not meet expectations.

### Why are the changes needed?

Fix: #4165 