### PR TITLE
[#3985] fix(hadooop-catalog): Create fileset catalog with empty location property success, but can't list schema of the catalog

### DIFF
--- a/catalogs/catalog-hadoop/src/main/java/org/apache/gravitino/catalog/hadoop/HadoopCatalogOperations.java
+++ b/catalogs/catalog-hadoop/src/main/java/org/apache/gravitino/catalog/hadoop/HadoopCatalogOperations.java
@@ -136,9 +136,9 @@ public class HadoopCatalogOperations implements CatalogOperations, SupportsSchem
 
     initAuthentication(conf, hadoopConf);
     this.catalogStorageLocation =
-            StringUtils.isNotBlank(catalogLocation)
-                    ? Optional.of(catalogLocation).map(Path::new)
-                    : Optional.empty();
+        StringUtils.isNotBlank(catalogLocation)
+            ? Optional.of(catalogLocation).map(Path::new)
+            : Optional.empty();
   }
 
   private void initAuthentication(Map<String, String> conf, Configuration hadoopConf) {

--- a/catalogs/catalog-hadoop/src/main/java/org/apache/gravitino/catalog/hadoop/HadoopCatalogOperations.java
+++ b/catalogs/catalog-hadoop/src/main/java/org/apache/gravitino/catalog/hadoop/HadoopCatalogOperations.java
@@ -135,7 +135,10 @@ public class HadoopCatalogOperations implements CatalogOperations, SupportsSchem
     conf.forEach(hadoopConf::set);
 
     initAuthentication(conf, hadoopConf);
-    this.catalogStorageLocation = Optional.ofNullable(catalogLocation).map(Path::new);
+    this.catalogStorageLocation =
+            StringUtils.isNotBlank(catalogLocation)
+                    ? Optional.of(catalogLocation).map(Path::new)
+                    : Optional.empty();
   }
 
   private void initAuthentication(Map<String, String> conf, Configuration hadoopConf) {

--- a/catalogs/catalog-hadoop/src/test/java/org/apache/gravitino/catalog/hadoop/TestHadoopCatalogOperations.java
+++ b/catalogs/catalog-hadoop/src/test/java/org/apache/gravitino/catalog/hadoop/TestHadoopCatalogOperations.java
@@ -240,8 +240,9 @@ public class TestHadoopCatalogOperations {
     Assertions.assertEquals(comment, schema.comment());
 
     Throwable exception =
-            Assertions.assertThrows(
-                    SchemaAlreadyExistsException.class, () -> createSchema(name, comment, catalogPath, null));
+        Assertions.assertThrows(
+            SchemaAlreadyExistsException.class,
+            () -> createSchema(name, comment, catalogPath, null));
     Assertions.assertEquals("Schema m1.c1.schema28 already exists", exception.getMessage());
   }
 

--- a/catalogs/catalog-hadoop/src/test/java/org/apache/gravitino/catalog/hadoop/TestHadoopCatalogOperations.java
+++ b/catalogs/catalog-hadoop/src/test/java/org/apache/gravitino/catalog/hadoop/TestHadoopCatalogOperations.java
@@ -231,6 +231,21 @@ public class TestHadoopCatalogOperations {
   }
 
   @Test
+  public void testCreateSchemaWithEmptyCatalogLocation() throws IOException {
+    String name = "schema28";
+    String comment = "comment28";
+    String catalogPath = "";
+    Schema schema = createSchema(name, comment, catalogPath, null);
+    Assertions.assertEquals(name, schema.name());
+    Assertions.assertEquals(comment, schema.comment());
+
+    Throwable exception =
+            Assertions.assertThrows(
+                    SchemaAlreadyExistsException.class, () -> createSchema(name, comment, catalogPath, null));
+    Assertions.assertEquals("Schema m1.c1.schema28 already exists", exception.getMessage());
+  }
+
+  @Test
   public void testCreateSchemaWithCatalogLocation() throws IOException {
     String name = "schema12";
     String comment = "comment12";


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Check if the catalogLocation is empty when initializing

### Why are the changes needed?

Fix: #3985 

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Existing pipeline.

Before
<img width="1480" alt="image" src="https://github.com/user-attachments/assets/42003bf4-f6a2-4729-98fc-bf139a811daf">

After
<img width="865" alt="image" src="https://github.com/user-attachments/assets/531dbc3b-7ad3-4949-8910-ea99bb31baa1">

