### PR TITLE
[#4195] improvement(core): Decouple `OperationDispatcher` from `NormalizeDispatcher`

### DIFF
--- a/core/src/main/java/org/apache/gravitino/GravitinoEnv.java
+++ b/core/src/main/java/org/apache/gravitino/GravitinoEnv.java
@@ -154,30 +154,31 @@ public class GravitinoEnv {
     SchemaOperationDispatcher schemaOperationDispatcher =
         new SchemaOperationDispatcher(catalogManager, entityStore, idGenerator);
     SchemaNormalizeDispatcher schemaNormalizeDispatcher =
-        new SchemaNormalizeDispatcher(schemaOperationDispatcher);
+        new SchemaNormalizeDispatcher(schemaOperationDispatcher, catalogManager);
     this.schemaDispatcher = new SchemaEventDispatcher(eventBus, schemaNormalizeDispatcher);
 
     TableOperationDispatcher tableOperationDispatcher =
         new TableOperationDispatcher(catalogManager, entityStore, idGenerator);
     TableNormalizeDispatcher tableNormalizeDispatcher =
-        new TableNormalizeDispatcher(tableOperationDispatcher);
+        new TableNormalizeDispatcher(tableOperationDispatcher, catalogManager);
     this.tableDispatcher = new TableEventDispatcher(eventBus, tableNormalizeDispatcher);
 
     PartitionOperationDispatcher partitionOperationDispatcher =
         new PartitionOperationDispatcher(catalogManager, entityStore, idGenerator);
     // todo: support PartitionEventDispatcher
-    this.partitionDispatcher = new PartitionNormalizeDispatcher(partitionOperationDispatcher);
+    this.partitionDispatcher =
+        new PartitionNormalizeDispatcher(partitionOperationDispatcher, catalogManager);
 
     FilesetOperationDispatcher filesetOperationDispatcher =
         new FilesetOperationDispatcher(catalogManager, entityStore, idGenerator);
     FilesetNormalizeDispatcher filesetNormalizeDispatcher =
-        new FilesetNormalizeDispatcher(filesetOperationDispatcher);
+        new FilesetNormalizeDispatcher(filesetOperationDispatcher, catalogManager);
     this.filesetDispatcher = new FilesetEventDispatcher(eventBus, filesetNormalizeDispatcher);
 
     TopicOperationDispatcher topicOperationDispatcher =
         new TopicOperationDispatcher(catalogManager, entityStore, idGenerator);
     TopicNormalizeDispatcher topicNormalizeDispatcher =
-        new TopicNormalizeDispatcher(topicOperationDispatcher);
+        new TopicNormalizeDispatcher(topicOperationDispatcher, catalogManager);
     this.topicDispatcher = new TopicEventDispatcher(eventBus, topicNormalizeDispatcher);
 
     // Create and initialize access control related modules

--- a/core/src/main/java/org/apache/gravitino/catalog/FilesetNormalizeDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/FilesetNormalizeDispatcher.java
@@ -20,8 +20,10 @@ package org.apache.gravitino.catalog;
 
 import static org.apache.gravitino.catalog.CapabilityHelpers.applyCapabilities;
 import static org.apache.gravitino.catalog.CapabilityHelpers.applyCaseSensitive;
+import static org.apache.gravitino.catalog.CapabilityHelpers.getCapability;
 
 import java.util.Map;
+import org.apache.commons.lang3.ArrayUtils;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
 import org.apache.gravitino.connector.capability.Capability;
@@ -32,35 +34,35 @@ import org.apache.gravitino.file.Fileset;
 import org.apache.gravitino.file.FilesetChange;
 
 public class FilesetNormalizeDispatcher implements FilesetDispatcher {
+  private final CatalogManager catalogManager;
+  private final FilesetDispatcher dispatcher;
 
-  private final FilesetOperationDispatcher dispatcher;
-
-  public FilesetNormalizeDispatcher(FilesetOperationDispatcher dispatcher) {
+  public FilesetNormalizeDispatcher(FilesetDispatcher dispatcher, CatalogManager catalogManager) {
     this.dispatcher = dispatcher;
+    this.catalogManager = catalogManager;
   }
 
   @Override
   public NameIdentifier[] listFilesets(Namespace namespace) throws NoSuchSchemaException {
     // The constraints of the name spec may be more strict than underlying catalog,
     // and for compatibility reasons, we only apply case-sensitive capabilities here.
-    Namespace caseSensitiveNs = applyCaseSensitive(namespace, Capability.Scope.FILESET, dispatcher);
+    Namespace caseSensitiveNs = normalizeCaseSensitive(namespace);
     NameIdentifier[] identifiers = dispatcher.listFilesets(caseSensitiveNs);
-    return applyCaseSensitive(identifiers, Capability.Scope.FILESET, dispatcher);
+    return normalizeCaseSensitive(identifiers);
   }
 
   @Override
   public Fileset loadFileset(NameIdentifier ident) throws NoSuchFilesetException {
     // The constraints of the name spec may be more strict than underlying catalog,
     // and for compatibility reasons, we only apply case-sensitive capabilities here.
-    return dispatcher.loadFileset(applyCaseSensitive(ident, Capability.Scope.FILESET, dispatcher));
+    return dispatcher.loadFileset(normalizeCaseSensitive(ident));
   }
 
   @Override
   public boolean filesetExists(NameIdentifier ident) {
     // The constraints of the name spec may be more strict than underlying catalog,
     // and for compatibility reasons, we only apply case-sensitive capabilities here.
-    return dispatcher.filesetExists(
-        applyCaseSensitive(ident, Capability.Scope.FILESET, dispatcher));
+    return dispatcher.filesetExists(normalizeCaseSensitive(ident));
   }
 
   @Override
@@ -78,23 +80,41 @@ public class FilesetNormalizeDispatcher implements FilesetDispatcher {
   @Override
   public Fileset alterFileset(NameIdentifier ident, FilesetChange... changes)
       throws NoSuchFilesetException, IllegalArgumentException {
-    Capability capability = dispatcher.getCatalogCapability(ident);
+    Capability capability = getCapability(ident, catalogManager);
     return dispatcher.alterFileset(
         // The constraints of the name spec may be more strict than underlying catalog,
         // and for compatibility reasons, we only apply case-sensitive capabilities here.
-        applyCaseSensitive(ident, Capability.Scope.FILESET, dispatcher),
-        applyCapabilities(capability, changes));
+        normalizeCaseSensitive(ident), applyCapabilities(capability, changes));
   }
 
   @Override
   public boolean dropFileset(NameIdentifier ident) {
     // The constraints of the name spec may be more strict than underlying catalog,
     // and for compatibility reasons, we only apply case-sensitive capabilities here.
-    return dispatcher.dropFileset(applyCaseSensitive(ident, Capability.Scope.FILESET, dispatcher));
+    return dispatcher.dropFileset(normalizeCaseSensitive(ident));
   }
 
   private NameIdentifier normalizeNameIdentifier(NameIdentifier ident) {
-    Capability capability = dispatcher.getCatalogCapability(ident);
-    return applyCapabilities(ident, Capability.Scope.FILESET, capability);
+    Capability capabilities = getCapability(ident, catalogManager);
+    return applyCapabilities(ident, Capability.Scope.FILESET, capabilities);
+  }
+
+  private Namespace normalizeCaseSensitive(Namespace namespace) {
+    Capability capabilities = getCapability(NameIdentifier.of(namespace.levels()), catalogManager);
+    return applyCaseSensitive(namespace, Capability.Scope.FILESET, capabilities);
+  }
+
+  private NameIdentifier normalizeCaseSensitive(NameIdentifier filesetIdent) {
+    Capability capabilities = getCapability(filesetIdent, catalogManager);
+    return applyCaseSensitive(filesetIdent, Capability.Scope.FILESET, capabilities);
+  }
+
+  private NameIdentifier[] normalizeCaseSensitive(NameIdentifier[] filesetIdents) {
+    if (ArrayUtils.isEmpty(filesetIdents)) {
+      return filesetIdents;
+    }
+
+    Capability capabilities = getCapability(filesetIdents[0], catalogManager);
+    return applyCaseSensitive(filesetIdents, Capability.Scope.FILESET, capabilities);
   }
 }

--- a/core/src/main/java/org/apache/gravitino/catalog/FilesetOperationDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/FilesetOperationDispatcher.java
@@ -19,6 +19,7 @@
 package org.apache.gravitino.catalog;
 
 import static org.apache.gravitino.catalog.PropertiesMetadataHelpers.validatePropertyForCreate;
+import static org.apache.gravitino.utils.NameIdentifierUtil.getCatalogIdentifier;
 
 import java.util.Map;
 import org.apache.gravitino.EntityStore;

--- a/core/src/main/java/org/apache/gravitino/catalog/SchemaOperationDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/SchemaOperationDispatcher.java
@@ -20,6 +20,7 @@ package org.apache.gravitino.catalog;
 
 import static org.apache.gravitino.Entity.EntityType.SCHEMA;
 import static org.apache.gravitino.catalog.PropertiesMetadataHelpers.validatePropertyForCreate;
+import static org.apache.gravitino.utils.NameIdentifierUtil.getCatalogIdentifier;
 
 import java.time.Instant;
 import java.util.Map;

--- a/core/src/main/java/org/apache/gravitino/catalog/TableOperationDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/TableOperationDispatcher.java
@@ -22,6 +22,7 @@ import static org.apache.gravitino.Entity.EntityType.TABLE;
 import static org.apache.gravitino.catalog.CapabilityHelpers.applyCapabilities;
 import static org.apache.gravitino.catalog.PropertiesMetadataHelpers.validatePropertyForCreate;
 import static org.apache.gravitino.rel.expressions.transforms.Transforms.EMPTY_TRANSFORM;
+import static org.apache.gravitino.utils.NameIdentifierUtil.getCatalogIdentifier;
 
 import java.time.Instant;
 import java.util.Arrays;

--- a/core/src/main/java/org/apache/gravitino/catalog/TopicOperationDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/TopicOperationDispatcher.java
@@ -21,6 +21,7 @@ package org.apache.gravitino.catalog;
 import static org.apache.gravitino.Entity.EntityType.TOPIC;
 import static org.apache.gravitino.StringIdentifier.fromProperties;
 import static org.apache.gravitino.catalog.PropertiesMetadataHelpers.validatePropertyForCreate;
+import static org.apache.gravitino.utils.NameIdentifierUtil.getCatalogIdentifier;
 
 import java.time.Instant;
 import java.util.Map;

--- a/core/src/main/java/org/apache/gravitino/utils/NameIdentifierUtil.java
+++ b/core/src/main/java/org/apache/gravitino/utils/NameIdentifierUtil.java
@@ -22,10 +22,15 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.errorprone.annotations.FormatMethod;
 import com.google.errorprone.annotations.FormatString;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.apache.gravitino.Entity;
 import org.apache.gravitino.MetadataObject;
 import org.apache.gravitino.MetadataObjects;
 import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.Namespace;
 import org.apache.gravitino.exceptions.IllegalNameIdentifierException;
 import org.apache.gravitino.exceptions.IllegalNamespaceException;
 
@@ -115,6 +120,33 @@ public class NameIdentifierUtil {
   public static NameIdentifier ofTopic(
       String metalake, String catalog, String schema, String topic) {
     return NameIdentifier.of(metalake, catalog, schema, topic);
+  }
+
+  /**
+   * Try to get the catalog {@link NameIdentifier} from the given {@link NameIdentifier}.
+   *
+   * @param ident The {@link NameIdentifier} to check.
+   * @return The catalog {@link NameIdentifier}
+   * @throws IllegalNameIdentifierException If the given {@link NameIdentifier} does not include
+   *     catalog name
+   */
+  public static NameIdentifier getCatalogIdentifier(NameIdentifier ident)
+      throws IllegalNameIdentifierException {
+    NameIdentifier.check(
+        ident.name() != null, "The name variable in the NameIdentifier must have value.");
+    Namespace.check(
+        ident.namespace() != null && !ident.namespace().isEmpty(),
+        "Catalog namespace must be non-null and have 1 level, the input namespace is %s",
+        ident.namespace());
+
+    List<String> allElems =
+        Stream.concat(Arrays.stream(ident.namespace().levels()), Stream.of(ident.name()))
+            .collect(Collectors.toList());
+    if (allElems.size() < 2) {
+      throw new IllegalNameIdentifierException(
+          "Cannot create a catalog NameIdentifier less than two elements.");
+    }
+    return NameIdentifier.of(allElems.get(0), allElems.get(1));
   }
 
   /**

--- a/core/src/test/java/org/apache/gravitino/catalog/TestFilesetNormalizeDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestFilesetNormalizeDispatcher.java
@@ -40,9 +40,11 @@ public class TestFilesetNormalizeDispatcher extends TestOperationDispatcher {
   public static void initialize() throws IOException {
     TestFilesetOperationDispatcher.initialize();
     filesetNormalizeDispatcher =
-        new FilesetNormalizeDispatcher(TestFilesetOperationDispatcher.filesetOperationDispatcher);
+        new FilesetNormalizeDispatcher(
+            TestFilesetOperationDispatcher.filesetOperationDispatcher, catalogManager);
     schemaNormalizeDispatcher =
-        new SchemaNormalizeDispatcher(TestFilesetOperationDispatcher.schemaOperationDispatcher);
+        new SchemaNormalizeDispatcher(
+            TestFilesetOperationDispatcher.schemaOperationDispatcher, catalogManager);
   }
 
   @Test

--- a/core/src/test/java/org/apache/gravitino/catalog/TestOperationDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestOperationDispatcher.java
@@ -19,6 +19,7 @@
 package org.apache.gravitino.catalog;
 
 import static org.apache.gravitino.TestFilesetPropertiesMetadata.TEST_FILESET_HIDDEN_KEY;
+import static org.apache.gravitino.utils.NameIdentifierUtil.getCatalogIdentifier;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.reset;
@@ -108,22 +109,20 @@ public abstract class TestOperationDispatcher {
 
   @Test
   public void testGetCatalogIdentifier() {
-    OperationDispatcher dispatcher = new OperationDispatcher(null, null, null) {};
-
     NameIdentifier id1 = NameIdentifier.of("a");
-    assertThrows(IllegalNamespaceException.class, () -> dispatcher.getCatalogIdentifier(id1));
+    assertThrows(IllegalNamespaceException.class, () -> getCatalogIdentifier(id1));
 
     NameIdentifier id2 = NameIdentifier.of("a", "b");
-    assertEquals(dispatcher.getCatalogIdentifier(id2), NameIdentifier.of("a", "b"));
+    assertEquals(getCatalogIdentifier(id2), NameIdentifier.of("a", "b"));
 
     NameIdentifier id3 = NameIdentifier.of("a", "b", "c");
-    assertEquals(dispatcher.getCatalogIdentifier(id3), NameIdentifier.of("a", "b"));
+    assertEquals(getCatalogIdentifier(id3), NameIdentifier.of("a", "b"));
 
     NameIdentifier id4 = NameIdentifier.of("a", "b", "c", "d");
-    assertEquals(dispatcher.getCatalogIdentifier(id4), NameIdentifier.of("a", "b"));
+    assertEquals(getCatalogIdentifier(id4), NameIdentifier.of("a", "b"));
 
     NameIdentifier id5 = NameIdentifier.of("a", "b", "c", "d", "e");
-    assertEquals(dispatcher.getCatalogIdentifier(id5), NameIdentifier.of("a", "b"));
+    assertEquals(getCatalogIdentifier(id5), NameIdentifier.of("a", "b"));
   }
 
   void testProperties(Map<String, String> expectedProps, Map<String, String> testProps) {

--- a/core/src/test/java/org/apache/gravitino/catalog/TestPartitionNormalizeDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestPartitionNormalizeDispatcher.java
@@ -43,7 +43,7 @@ public class TestPartitionNormalizeDispatcher extends TestOperationDispatcher {
     TestPartitionOperationDispatcher.prepareTable();
     partitionNormalizeDispatcher =
         new PartitionNormalizeDispatcher(
-            TestPartitionOperationDispatcher.partitionOperationDispatcher);
+            TestPartitionOperationDispatcher.partitionOperationDispatcher, catalogManager);
     NameIdentifier schemaIdent = NameIdentifierUtil.ofSchema(metalake, catalog, SCHEMA);
     TestPartitionOperationDispatcher.schemaOperationDispatcher.createSchema(
         schemaIdent, "comment", null);

--- a/core/src/test/java/org/apache/gravitino/catalog/TestSchemaNormalizeDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestSchemaNormalizeDispatcher.java
@@ -37,7 +37,7 @@ public class TestSchemaNormalizeDispatcher extends TestOperationDispatcher {
   public static void initialize() throws IOException, IllegalAccessException {
     TestSchemaOperationDispatcher.initialize();
     schemaNormalizeDispatcher =
-        new SchemaNormalizeDispatcher(TestSchemaOperationDispatcher.dispatcher);
+        new SchemaNormalizeDispatcher(TestSchemaOperationDispatcher.dispatcher, catalogManager);
   }
 
   @Test

--- a/core/src/test/java/org/apache/gravitino/catalog/TestTableNormalizeDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestTableNormalizeDispatcher.java
@@ -56,9 +56,11 @@ public class TestTableNormalizeDispatcher extends TestOperationDispatcher {
   public static void initialize() throws IOException, IllegalAccessException {
     TestTableOperationDispatcher.initialize();
     tableNormalizeDispatcher =
-        new TableNormalizeDispatcher(TestTableOperationDispatcher.tableOperationDispatcher);
+        new TableNormalizeDispatcher(
+            TestTableOperationDispatcher.tableOperationDispatcher, catalogManager);
     schemaNormalizeDispatcher =
-        new SchemaNormalizeDispatcher(TestTableOperationDispatcher.schemaOperationDispatcher);
+        new SchemaNormalizeDispatcher(
+            TestTableOperationDispatcher.schemaOperationDispatcher, catalogManager);
   }
 
   @Test

--- a/core/src/test/java/org/apache/gravitino/catalog/TestTopicNormalizeDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestTopicNormalizeDispatcher.java
@@ -38,9 +38,11 @@ public class TestTopicNormalizeDispatcher extends TestOperationDispatcher {
   public static void initialize() throws IOException, IllegalAccessException {
     TestTopicOperationDispatcher.initialize();
     schemaNormalizeDispatcher =
-        new SchemaNormalizeDispatcher(TestTopicOperationDispatcher.schemaOperationDispatcher);
+        new SchemaNormalizeDispatcher(
+            TestTopicOperationDispatcher.schemaOperationDispatcher, catalogManager);
     topicNormalizeDispatcher =
-        new TopicNormalizeDispatcher(TestTopicOperationDispatcher.topicOperationDispatcher);
+        new TopicNormalizeDispatcher(
+            TestTopicOperationDispatcher.topicOperationDispatcher, catalogManager);
   }
 
   @Test


### PR DESCRIPTION
### What changes were proposed in this pull request?

 - Decouple `OperationDispatcher` from `NormalizeDispatcher`
 - move `getCatalogCapability` method from `OperationDispatcher` to `CapabilityHelpers`

### Why are the changes needed?

Fix: #4195 

### Does this PR introduce _any_ user-facing change?

no

### How was this patch tested?

existing tests
