### PR TITLE
[#4202] feat(trino-connector): Add addition parameters in TrinoQueryTestTool

### DIFF
--- a/integration-test/src/test/java/org/apache/gravitino/integration/test/trino/TrinoQueryIT.java
+++ b/integration-test/src/test/java/org/apache/gravitino/integration/test/trino/TrinoQueryIT.java
@@ -64,7 +64,7 @@ public class TrinoQueryIT extends TrinoQueryITBase {
 
   private static int testParallelism = 2;
 
-  private static Map<String, String> queryParams = new HashMap<>();
+  protected static Map<String, String> queryParams = new HashMap<>();
 
   public static Set<String> ciTestsets = new HashSet<>();
 

--- a/integration-test/src/test/java/org/apache/gravitino/integration/test/trino/TrinoQueryIT.java
+++ b/integration-test/src/test/java/org/apache/gravitino/integration/test/trino/TrinoQueryIT.java
@@ -54,19 +54,19 @@ import org.slf4j.LoggerFactory;
 public class TrinoQueryIT extends TrinoQueryITBase {
   private static final Logger LOG = LoggerFactory.getLogger(TrinoQueryIT.class);
 
-  protected static String testsetsDir = "";
-  protected AtomicInteger passCount = new AtomicInteger(0);
-  protected AtomicInteger totalCount = new AtomicInteger(0);
-  protected static boolean exitOnFailed = true;
+  static String testsetsDir = "";
+  AtomicInteger passCount = new AtomicInteger(0);
+  AtomicInteger totalCount = new AtomicInteger(0);
+  static boolean exitOnFailed = true;
 
   // key: tester name, value: tester result
   private static Map<String, TestStatus> allTestStatus = new TreeMap<>();
 
   private static int testParallelism = 2;
 
-  protected static Map<String, String> queryParams = new HashMap<>();
+  static Map<String, String> queryParams = new HashMap<>();
 
-  public static Set<String> ciTestsets = new HashSet<>();
+  static Set<String> ciTestsets = new HashSet<>();
 
   static {
     testsetsDir = TrinoQueryIT.class.getClassLoader().getResource("trino-ci-testset").getPath();

--- a/integration-test/src/test/java/org/apache/gravitino/integration/test/trino/TrinoQueryTestTool.java
+++ b/integration-test/src/test/java/org/apache/gravitino/integration/test/trino/TrinoQueryTestTool.java
@@ -73,6 +73,9 @@ public class TrinoQueryTestTool {
       options.addOption("tester_id", true, "Specify the tester file name prefix to select to test");
       options.addOption("catalog", true, "Specify the catalog name to test");
 
+      options.addOption("params", true, "Addition parameters that can replace the value of ${key} in the testers contents, " +
+              "example: --params=key1,v1;key2,v2");
+
       options.addOption("help", false, "Print this help message");
 
       CommandLineParser parser = new PosixParser();
@@ -113,7 +116,7 @@ public class TrinoQueryTestTool {
             break;
           default:
             System.out.println("The value of --auto must be 'all', 'gravitino' or 'none'");
-            return;
+            System.exit(1);
         }
       }
 
@@ -138,6 +141,21 @@ public class TrinoQueryTestTool {
       String postgresqlUri = commandLine.getOptionValue("postgresql_uri");
       TrinoQueryIT.postgresqlUri =
           Strings.isBlank(postgresqlUri) ? TrinoQueryIT.postgresqlUri : postgresqlUri;
+
+      String params = commandLine.getOptionValue("params");
+      if (Strings.isNotBlank(params)) {
+        for (String param : params.split(";")) {
+          String[] split = param.split(",");
+          String key = split[0].trim();
+          String value = split[1].trim();
+          if (Strings.isNotBlank(key) && Strings.isNotBlank(value)) {
+            TrinoQueryIT.queryParams.put(key, value);
+          } else {
+            System.out.println("Invalid parameters:" + param + "The format should like --params=key1,v1;key2,v2");
+            System.exit(1);
+          }
+        }
+      }
 
       String testSet = commandLine.getOptionValue("test_set");
       String testerId = commandLine.getOptionValue("tester_id", "");

--- a/integration-test/src/test/java/org/apache/gravitino/integration/test/trino/TrinoQueryTestTool.java
+++ b/integration-test/src/test/java/org/apache/gravitino/integration/test/trino/TrinoQueryTestTool.java
@@ -76,7 +76,7 @@ public class TrinoQueryTestTool {
       options.addOption(
           "params",
           true,
-          "Addition parameters that can replace the value of ${key} in the testers contents, "
+          "Additional parameters that can replace the value of ${key} in the testers contents, "
               + "example: --params=key1,v1;key2,v2");
 
       options.addOption("help", false, "Print this help message");

--- a/integration-test/src/test/java/org/apache/gravitino/integration/test/trino/TrinoQueryTestTool.java
+++ b/integration-test/src/test/java/org/apache/gravitino/integration/test/trino/TrinoQueryTestTool.java
@@ -73,8 +73,11 @@ public class TrinoQueryTestTool {
       options.addOption("tester_id", true, "Specify the tester file name prefix to select to test");
       options.addOption("catalog", true, "Specify the catalog name to test");
 
-      options.addOption("params", true, "Addition parameters that can replace the value of ${key} in the testers contents, " +
-              "example: --params=key1,v1;key2,v2");
+      options.addOption(
+          "params",
+          true,
+          "Addition parameters that can replace the value of ${key} in the testers contents, "
+              + "example: --params=key1,v1;key2,v2");
 
       options.addOption("help", false, "Print this help message");
 
@@ -151,7 +154,8 @@ public class TrinoQueryTestTool {
           if (Strings.isNotBlank(key) && Strings.isNotBlank(value)) {
             TrinoQueryIT.queryParams.put(key, value);
           } else {
-            System.out.println("Invalid parameters:" + param + "The format should like --params=key1,v1;key2,v2");
+            System.out.println(
+                "Invalid parameters:" + param + "The format should like --params=key1,v1;key2,v2");
             System.exit(1);
           }
         }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add addition parameters in TrinoQueryTestTool
You need to passing the arguments like : --params=key1,value1;key2,value2... on run the TrinoQueryTestTool 
### Why are the changes needed?

Fix: #4202 

### Does this PR introduce _any_ user-facing change?

Update the command output and error information of TrinoQueryTestTool

### How was this patch tested?

Manually Test
