### PR TITLE
[#4210] Improvement: Removing redundant null check in TreeLockNode.java

### DIFF
--- a/core/src/main/java/org/apache/gravitino/lock/TreeLockNode.java
+++ b/core/src/main/java/org/apache/gravitino/lock/TreeLockNode.java
@@ -77,9 +77,11 @@ public class TreeLockNode {
       if (this == o) {
         return true;
       }
-      if (o == null || !(o instanceof ThreadIdentifier)) {
+      
+      if (!(o instanceof ThreadIdentifier)) {
         return false;
       }
+
       ThreadIdentifier that = (ThreadIdentifier) o;
       return Objects.equal(thread, that.thread) && Objects.equal(ident, that.ident);
     }

--- a/core/src/main/java/org/apache/gravitino/lock/TreeLockNode.java
+++ b/core/src/main/java/org/apache/gravitino/lock/TreeLockNode.java
@@ -77,11 +77,9 @@ public class TreeLockNode {
       if (this == o) {
         return true;
       }
-
       if (!(o instanceof ThreadIdentifier)) {
         return false;
       }
-
       ThreadIdentifier that = (ThreadIdentifier) o;
       return Objects.equal(thread, that.thread) && Objects.equal(ident, that.ident);
     }

--- a/core/src/main/java/org/apache/gravitino/lock/TreeLockNode.java
+++ b/core/src/main/java/org/apache/gravitino/lock/TreeLockNode.java
@@ -77,7 +77,7 @@ public class TreeLockNode {
       if (this == o) {
         return true;
       }
-      
+
       if (!(o instanceof ThreadIdentifier)) {
         return false;
       }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Removed the redundant null check in TreeLockNode, since 'instanceof' returns false for null values.

Fix: #4210 

### Does this PR introduce any user-facing change?
No need.

### How was this patch tested?
Existing tests.
