### PR TITLE
 [#4184] Improvement: Moved DEFAULT_IMPERSONATION_ENABLE from KerberosConfig to AuthenticationConfig

### DIFF
--- a/catalogs/catalog-hadoop/src/main/java/org/apache/gravitino/catalog/hadoop/authentication/AuthenticationConfig.java
+++ b/catalogs/catalog-hadoop/src/main/java/org/apache/gravitino/catalog/hadoop/authentication/AuthenticationConfig.java
@@ -74,7 +74,7 @@ public class AuthenticationConfig extends Config {
                   "Whether to enable impersonation for the Hadoop catalog",
                   false,
                   true,
-                  KerberosConfig.DEFAULT_IMPERSONATION_ENABLE,
+                  KERBEROS_DEFAULT_IMPERSONATION_ENABLE,
                   false,
                   false))
           .put(

--- a/catalogs/catalog-hadoop/src/main/java/org/apache/gravitino/catalog/hadoop/authentication/AuthenticationConfig.java
+++ b/catalogs/catalog-hadoop/src/main/java/org/apache/gravitino/catalog/hadoop/authentication/AuthenticationConfig.java
@@ -22,7 +22,6 @@ package org.apache.gravitino.catalog.hadoop.authentication;
 import com.google.common.collect.ImmutableMap;
 import java.util.Map;
 import org.apache.gravitino.Config;
-import org.apache.gravitino.catalog.hadoop.authentication.kerberos.KerberosConfig;
 import org.apache.gravitino.config.ConfigBuilder;
 import org.apache.gravitino.config.ConfigConstants;
 import org.apache.gravitino.config.ConfigEntry;

--- a/catalogs/catalog-hadoop/src/main/java/org/apache/gravitino/catalog/hadoop/authentication/AuthenticationConfig.java
+++ b/catalogs/catalog-hadoop/src/main/java/org/apache/gravitino/catalog/hadoop/authentication/AuthenticationConfig.java
@@ -35,6 +35,8 @@ public class AuthenticationConfig extends Config {
 
   public static final String IMPERSONATION_ENABLE_KEY = "authentication.impersonation-enable";
 
+  public static final boolean KERBEROS_DEFAULT_IMPERSONATION_ENABLE = false;
+
   public AuthenticationConfig(Map<String, String> properties) {
     super(false);
     loadFromMap(properties, k -> true);
@@ -53,7 +55,7 @@ public class AuthenticationConfig extends Config {
           .doc("Whether to enable impersonation for the Hadoop catalog")
           .version(ConfigConstants.VERSION_0_5_1)
           .booleanConf()
-          .createWithDefault(KerberosConfig.DEFAULT_IMPERSONATION_ENABLE);
+          .createWithDefault(KERBEROS_DEFAULT_IMPERSONATION_ENABLE);
 
   public String getAuthType() {
     return get(AUTH_TYPE_ENTRY);

--- a/catalogs/catalog-hadoop/src/main/java/org/apache/gravitino/catalog/hadoop/authentication/kerberos/KerberosConfig.java
+++ b/catalogs/catalog-hadoop/src/main/java/org/apache/gravitino/catalog/hadoop/authentication/kerberos/KerberosConfig.java
@@ -38,8 +38,6 @@ public class KerberosConfig extends AuthenticationConfig {
   public static final String FETCH_TIMEOUT_SEC_KEY =
       "authentication.kerberos.keytab-fetch-timeout-sec";
 
-  public static final boolean DEFAULT_IMPERSONATION_ENABLE = false;
-
   public static final ConfigEntry<String> PRINCIPAL_ENTRY =
       new ConfigBuilder(PRINCIPAL_KEY)
           .doc("The principal of the Kerberos connection")


### PR DESCRIPTION
<!--
1. Title: [#4184] Improvement: Moved DEFAULT_IMPERSONATION_ENABLE from KerberosConfig to AuthenticationConfig
 
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Enhancements to the utilization and placement of KerberosConfig.DEFAULT_IMPERSONATION_ENABLE

### Why are the changes needed?

Referencing a member of a subclass during initialisation, may give unexpected results because the child class might not have been initialised yet.

Fix: #4184

### Does this PR introduce _any_ user-facing change?

No


Let me know if you have any suggestions.