### PR TITLE
[#4211] improvement(catalog-jdbc-mysql): Validated databaseName preve…

### DIFF
--- a/catalogs/catalog-jdbc-mysql/src/main/java/org/apache/gravitino/catalog/mysql/operation/MysqlDatabaseOperations.java
+++ b/catalogs/catalog-jdbc-mysql/src/main/java/org/apache/gravitino/catalog/mysql/operation/MysqlDatabaseOperations.java
@@ -23,12 +23,8 @@ import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
+
 import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.gravitino.StringIdentifier;
@@ -75,6 +71,7 @@ public class MysqlDatabaseOperations extends JdbcDatabaseOperations {
 
   @Override
   public String generateDropDatabaseSql(String databaseName, boolean cascade) {
+    validateDatabaseName(databaseName);
     final String dropDatabaseSql = "DROP DATABASE `" + databaseName + "`";
     if (cascade) {
       return dropDatabaseSql;
@@ -119,5 +116,11 @@ public class MysqlDatabaseOperations extends JdbcDatabaseOperations {
   @Override
   protected boolean isSystemDatabase(String dbName) {
     return SYS_MYSQL_DATABASE_NAMES.contains(dbName.toLowerCase(Locale.ROOT));
+  }
+
+  public void validateDatabaseName(String databaseName){
+    if(Objects.isNull(databaseName) || databaseName.trim().isEmpty()){
+      throw new IllegalArgumentException("Database name cannot be null or empty.");
+    }
   }
 }


### PR DESCRIPTION
…nting possible SQL injection in MysqlDatabaseOperations.java

<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

databaseName in generateDropDatabaseSql method inside MysqlDatabaseOperations.java is not validated making the code vulnerable to SQL injection.
The PR has validation for databaseName ( Null and empty check) 

### Why are the changes needed?

To prevent possible SQL injection

Fix: #4211 

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?
N/A
