### PR TITLE
[#4181]Improvement: Support setting gradle property skipDockerTests by environment variant

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -690,8 +690,14 @@ fun printDockerCheckInfo() {
   val dockerRunning = project.extra["dockerRunning"] as? Boolean ?: false
   val macDockerConnector = project.extra["macDockerConnector"] as? Boolean ?: false
   val isOrbStack = project.extra["isOrbStack"] as? Boolean ?: false
-
-  if (extra["skipDockerTests"].toString().toBoolean()) {
+  val skipDockerTests = if (extra["skipDockerTests"].toString().toBoolean()) {
+    // Read the environment variable (SKIP_DOCKER_TESTS) when skipDockerTests is true
+    // which means users can enable the docker tests by setting the gradle properties or the environment variable.
+    System.getenv("SKIP_DOCKER_TESTS")?.toBoolean() ?: true
+  } else {
+    false
+  }
+  if (skipDockerTests) {
     project.extra["dockerTest"] = false
   } else if (OperatingSystem.current().isMacOsX() &&
     dockerRunning &&

--- a/docs/how-to-build.md
+++ b/docs/how-to-build.md
@@ -26,8 +26,8 @@ license: "This software is licensed under the Apache License version 2."
 + Gravitino uses the Gradle Java Toolchain to detect and manage JDK versions, it checks the
   installed JDK by running the `./gradlew javaToolchains` command. See [Gradle Java Toolchain](https://docs.gradle.org/current/userguide/toolchains.html#sec:java_toolchain).
 + Gravitino excludes all Docker-related tests by default. To run Docker related tests, make sure you have installed
-  Docker in your environment and set `skipDockerTests=false` in the `gradle.properties` file (or
-  use `-PskipDockerTests=false` in the command). Otherwise, all Docker required tests will skip.
+  Docker in your environment and either (1) set `skipDockerTests=false` in the `gradle.properties` file (or
+  use `-PskipDockerTests=false` in the command) or (2) `export SKIP_DOCKER_TESTS=false` in shell. Otherwise, all Docker required tests will skip.
 + macOS uses `docker-connector` to make the Gravitino Trino connector work with Docker
   for macOS. See [docker-connector](https://github.com/wenjunxiao/mac-docker-connector), `$GRAVITINO_HOME/dev/docker/tools/mac-docker-connector.sh`, and
   `$GRAVITINO_HOME/dev/docker/tools/README.md` for more details.


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Read the environment variable (if exists) when -PskipDockerTests is not specified.

### Why are the changes needed?

Fix: #4181 

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

```
export SKIP_DOCKER_TESTS=false
./gradlew build
# check docket tests are running
```
