### PR TITLE
[#4191]Improvement: In CatalogConnectorManager.java to catch execption in loadMetalake function.

### DIFF
--- a/trino-connector/src/main/java/org/apache/gravitino/trino/connector/catalog/CatalogConnectorManager.java
+++ b/trino-connector/src/main/java/org/apache/gravitino/trino/connector/catalog/CatalogConnectorManager.java
@@ -133,11 +133,8 @@ public class CatalogConnectorManager {
           LOG.error("Load Metalake {} failed.", usedMetalake, e);
         }
       }
-    } catch (OutOfMemoryError outOfMemoryError) {
-      LOG.error("Out of memory error when loading metalake", outOfMemoryError);
-      System.exit(-1);
-    } catch (InternalError internalError) {
-      LOG.error("Internal error when loading metalake", internalError);
+    } catch (Exception e) {
+      LOG.error("Error when loading metalake", e);
       System.exit(-1);
     }
   }

--- a/trino-connector/src/main/java/org/apache/gravitino/trino/connector/catalog/CatalogConnectorManager.java
+++ b/trino-connector/src/main/java/org/apache/gravitino/trino/connector/catalog/CatalogConnectorManager.java
@@ -133,8 +133,11 @@ public class CatalogConnectorManager {
           LOG.error("Load Metalake {} failed.", usedMetalake, e);
         }
       }
-    } catch (Throwable t) {
-      LOG.error("Fatal errors when loading metalake", t);
+    } catch (OutOfMemoryError outOfMemoryError) {
+      LOG.error("Out of memory error when loading metalake", outOfMemoryError);
+      System.exit(-1);
+    } catch (InternalError internalError) {
+      LOG.error("Internal error when loading metalake", internalError);
       System.exit(-1);
     }
   }


### PR DESCRIPTION

### What changes were proposed in this pull request?

Catching exceptions of OutOfMemoryError and InternalError for method loadMetalake of CatalogConnectorManager.

### Why are the changes needed?

Fix: #4191 

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?

