### PR TITLE
[MINOR] fix: wrong tag on `CatalogPaimonKerberosFilesystemIT`

### DIFF
--- a/catalogs/catalog-lakehouse-paimon/src/test/java/org/apache/gravitino/catalog/lakehouse/paimon/integration/test/CatalogPaimonKerberosFilesystemIT.java
+++ b/catalogs/catalog-lakehouse-paimon/src/test/java/org/apache/gravitino/catalog/lakehouse/paimon/integration/test/CatalogPaimonKerberosFilesystemIT.java
@@ -59,7 +59,7 @@ import org.junit.jupiter.api.TestInstance;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@Tag("gravitino-docker-it")
+@Tag("gravitino-docker-test")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class CatalogPaimonKerberosFilesystemIT extends AbstractIT {
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

correct tag from `gravitino-docker-it` to `gravitino-docker-test` on the class `CatalogPaimonKerberosFilesystemIT`

### Why are the changes needed?

should be `gravitino-docker-test`

### Does this PR introduce _any_ user-facing change?

no

### How was this patch tested?

test locally, default build should not run `CatalogPaimonKerberosFilesystemIT`
