### PR TITLE
[#4253] fix(gradle): fix compileDistribution failed

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -700,8 +700,8 @@ tasks {
         !it.name.startsWith("filesystem") &&
         !it.name.startsWith("spark") &&
         !it.name.startsWith("iceberg") &&
+        !it.name.startsWith("integration-test") &&
         it.name != "trino-connector" &&
-        it.name != "integration-test" &&
         it.name != "bundled-catalog" &&
         it.name != "flink-connector"
       ) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

exclude `integration-test-common` when compileDistribution

### Why are the changes needed?

Fix: #4253 

### Does this PR introduce _any_ user-facing change?

no

### How was this patch tested?

run `./gradlew compileDistribution` by hand
