### PR TITLE
[MINOR] Fix the license headers in Java files

### DIFF
--- a/catalogs/catalog-jdbc-mysql/src/test/java/org/apache/gravitino/catalog/mysql/integration/test/CatalogMysqlDriverIT.java
+++ b/catalogs/catalog-jdbc-mysql/src/test/java/org/apache/gravitino/catalog/mysql/integration/test/CatalogMysqlDriverIT.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/catalogs/catalog-jdbc-mysql/src/test/java/org/apache/gravitino/catalog/mysql/integration/test/CatalogMysqlVersion5IT.java
+++ b/catalogs/catalog-jdbc-mysql/src/test/java/org/apache/gravitino/catalog/mysql/integration/test/CatalogMysqlVersion5IT.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/catalogs/catalog-jdbc-postgresql/src/test/java/org/apache/gravitino/catalog/postgresql/integration/test/CatalogPostgreSqlVersion12IT.java
+++ b/catalogs/catalog-jdbc-postgresql/src/test/java/org/apache/gravitino/catalog/postgresql/integration/test/CatalogPostgreSqlVersion12IT.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/catalogs/catalog-jdbc-postgresql/src/test/java/org/apache/gravitino/catalog/postgresql/integration/test/CatalogPostgreSqlVersion14IT.java
+++ b/catalogs/catalog-jdbc-postgresql/src/test/java/org/apache/gravitino/catalog/postgresql/integration/test/CatalogPostgreSqlVersion14IT.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/catalogs/catalog-jdbc-postgresql/src/test/java/org/apache/gravitino/catalog/postgresql/integration/test/CatalogPostgreSqlVersion15IT.java
+++ b/catalogs/catalog-jdbc-postgresql/src/test/java/org/apache/gravitino/catalog/postgresql/integration/test/CatalogPostgreSqlVersion15IT.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/catalogs/catalog-jdbc-postgresql/src/test/java/org/apache/gravitino/catalog/postgresql/integration/test/CatalogPostgreSqlVersion16IT.java
+++ b/catalogs/catalog-jdbc-postgresql/src/test/java/org/apache/gravitino/catalog/postgresql/integration/test/CatalogPostgreSqlVersion16IT.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/clients/client-java/src/main/java/org/apache/gravitino/client/ObjectMapperProvider.java
+++ b/clients/client-java/src/main/java/org/apache/gravitino/client/ObjectMapperProvider.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/catalog/CatalogDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/CatalogDispatcher.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/catalog/FilesetDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/FilesetDispatcher.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/catalog/SchemaDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/SchemaDispatcher.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/catalog/TableDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/TableDispatcher.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/catalog/TopicDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/TopicDispatcher.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/listener/AsyncQueueListener.java
+++ b/core/src/main/java/org/apache/gravitino/listener/AsyncQueueListener.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/listener/CatalogEventDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/listener/CatalogEventDispatcher.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/listener/EventBus.java
+++ b/core/src/main/java/org/apache/gravitino/listener/EventBus.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/listener/EventListenerConfig.java
+++ b/core/src/main/java/org/apache/gravitino/listener/EventListenerConfig.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/listener/EventListenerManager.java
+++ b/core/src/main/java/org/apache/gravitino/listener/EventListenerManager.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/listener/EventListenerPluginWrapper.java
+++ b/core/src/main/java/org/apache/gravitino/listener/EventListenerPluginWrapper.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/listener/FilesetEventDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/listener/FilesetEventDispatcher.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/listener/MetalakeEventDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/listener/MetalakeEventDispatcher.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/listener/SchemaEventDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/listener/SchemaEventDispatcher.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/listener/TableEventDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/listener/TableEventDispatcher.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/listener/TopicEventDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/listener/TopicEventDispatcher.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/listener/api/EventListenerPlugin.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/EventListenerPlugin.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/AlterCatalogEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/AlterCatalogEvent.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/AlterCatalogFailureEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/AlterCatalogFailureEvent.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/AlterFilesetEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/AlterFilesetEvent.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/AlterFilesetFailureEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/AlterFilesetFailureEvent.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/AlterMetalakeEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/AlterMetalakeEvent.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/AlterMetalakeFailureEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/AlterMetalakeFailureEvent.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/AlterSchemaEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/AlterSchemaEvent.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/AlterSchemaFailureEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/AlterSchemaFailureEvent.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/AlterTableEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/AlterTableEvent.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/AlterTableFailureEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/AlterTableFailureEvent.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/AlterTopicEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/AlterTopicEvent.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/AlterTopicFailureEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/AlterTopicFailureEvent.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/CatalogEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/CatalogEvent.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/CatalogFailureEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/CatalogFailureEvent.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/CreateCatalogEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/CreateCatalogEvent.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/CreateCatalogFailureEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/CreateCatalogFailureEvent.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/CreateFilesetEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/CreateFilesetEvent.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/CreateFilesetFailureEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/CreateFilesetFailureEvent.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/CreateMetalakeEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/CreateMetalakeEvent.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/CreateMetalakeFailureEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/CreateMetalakeFailureEvent.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/CreateSchemaEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/CreateSchemaEvent.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/CreateSchemaFailureEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/CreateSchemaFailureEvent.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/CreateTableEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/CreateTableEvent.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/CreateTableFailureEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/CreateTableFailureEvent.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/CreateTopicEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/CreateTopicEvent.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/CreateTopicFailureEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/CreateTopicFailureEvent.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/DropCatalogEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/DropCatalogEvent.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/DropCatalogFailureEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/DropCatalogFailureEvent.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/DropFilesetEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/DropFilesetEvent.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/DropFilesetFailureEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/DropFilesetFailureEvent.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/DropMetalakeEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/DropMetalakeEvent.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/DropMetalakeFailureEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/DropMetalakeFailureEvent.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/DropSchemaEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/DropSchemaEvent.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/DropSchemaFailureEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/DropSchemaFailureEvent.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/DropTableEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/DropTableEvent.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/DropTableFailureEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/DropTableFailureEvent.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/DropTopicEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/DropTopicEvent.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/DropTopicFailureEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/DropTopicFailureEvent.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/Event.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/Event.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/FailureEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/FailureEvent.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/FilesetEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/FilesetEvent.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/FilesetFailureEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/FilesetFailureEvent.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/ListCatalogEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/ListCatalogEvent.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/ListCatalogFailureEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/ListCatalogFailureEvent.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/ListFilesetEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/ListFilesetEvent.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/ListFilesetFailureEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/ListFilesetFailureEvent.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/ListMetalakeEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/ListMetalakeEvent.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/ListMetalakeFailureEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/ListMetalakeFailureEvent.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/ListSchemaEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/ListSchemaEvent.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/ListSchemaFailureEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/ListSchemaFailureEvent.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/ListTableEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/ListTableEvent.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/ListTableFailureEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/ListTableFailureEvent.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/ListTopicEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/ListTopicEvent.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/ListTopicFailureEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/ListTopicFailureEvent.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/LoadCatalogEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/LoadCatalogEvent.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/LoadCatalogFailureEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/LoadCatalogFailureEvent.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/LoadFilesetEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/LoadFilesetEvent.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/LoadFilesetFailureEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/LoadFilesetFailureEvent.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/LoadMetalakeEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/LoadMetalakeEvent.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/LoadMetalakeFailureEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/LoadMetalakeFailureEvent.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/LoadSchemaEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/LoadSchemaEvent.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/LoadSchemaFailureEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/LoadSchemaFailureEvent.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/LoadTableEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/LoadTableEvent.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/LoadTableFailureEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/LoadTableFailureEvent.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/LoadTopicEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/LoadTopicEvent.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/LoadTopicFailureEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/LoadTopicFailureEvent.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/MetalakeEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/MetalakeEvent.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/MetalakeFailureEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/MetalakeFailureEvent.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/PurgeTableEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/PurgeTableEvent.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/PurgeTableFailureEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/PurgeTableFailureEvent.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/SchemaEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/SchemaEvent.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/SchemaFailureEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/SchemaFailureEvent.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/TableEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/TableEvent.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/TableFailureEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/TableFailureEvent.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/TopicEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/TopicEvent.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/TopicFailureEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/TopicFailureEvent.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/listener/api/info/FilesetInfo.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/info/FilesetInfo.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/listener/api/info/MetalakeInfo.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/info/MetalakeInfo.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/listener/api/info/SchemaInfo.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/info/SchemaInfo.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/listener/api/info/TableInfo.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/info/TableInfo.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/listener/api/info/TopicInfo.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/info/TopicInfo.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/main/java/org/apache/gravitino/metalake/MetalakeDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/metalake/MetalakeDispatcher.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/test/java/org/apache/gravitino/catalog/DummyCatalogOperations.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/DummyCatalogOperations.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/test/java/org/apache/gravitino/catalog/TestBaseCatalog.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestBaseCatalog.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/test/java/org/apache/gravitino/listener/DummyEventListener.java
+++ b/core/src/test/java/org/apache/gravitino/listener/DummyEventListener.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/test/java/org/apache/gravitino/listener/TestEventListenerManager.java
+++ b/core/src/test/java/org/apache/gravitino/listener/TestEventListenerManager.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/test/java/org/apache/gravitino/listener/api/event/TestCatalogEvent.java
+++ b/core/src/test/java/org/apache/gravitino/listener/api/event/TestCatalogEvent.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/test/java/org/apache/gravitino/listener/api/event/TestFilesetEvent.java
+++ b/core/src/test/java/org/apache/gravitino/listener/api/event/TestFilesetEvent.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/test/java/org/apache/gravitino/listener/api/event/TestMetalakeEvent.java
+++ b/core/src/test/java/org/apache/gravitino/listener/api/event/TestMetalakeEvent.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/test/java/org/apache/gravitino/listener/api/event/TestSchemaEvent.java
+++ b/core/src/test/java/org/apache/gravitino/listener/api/event/TestSchemaEvent.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/test/java/org/apache/gravitino/listener/api/event/TestTableEvent.java
+++ b/core/src/test/java/org/apache/gravitino/listener/api/event/TestTableEvent.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/core/src/test/java/org/apache/gravitino/listener/api/event/TestTopicEvent.java
+++ b/core/src/test/java/org/apache/gravitino/listener/api/event/TestTopicEvent.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/server-common/src/main/java/org/apache/gravitino/server/web/OverwriteDefaultConfig.java
+++ b/server-common/src/main/java/org/apache/gravitino/server/web/OverwriteDefaultConfig.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/ConnectorConstants.java
+++ b/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/ConnectorConstants.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/GravitinoSparkConfig.java
+++ b/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/GravitinoSparkConfig.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/PropertiesConverter.java
+++ b/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/PropertiesConverter.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/SparkTableChangeConverter.java
+++ b/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/SparkTableChangeConverter.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/SparkTransformConverter.java
+++ b/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/SparkTransformConverter.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/SparkTypeConverter.java
+++ b/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/SparkTypeConverter.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/catalog/BaseCatalog.java
+++ b/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/catalog/BaseCatalog.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/hive/GravitinoHiveCatalog.java
+++ b/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/hive/GravitinoHiveCatalog.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/hive/HivePropertiesConstants.java
+++ b/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/hive/HivePropertiesConstants.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/hive/HivePropertiesConverter.java
+++ b/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/hive/HivePropertiesConverter.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/hive/SparkHiveTable.java
+++ b/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/hive/SparkHiveTable.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/iceberg/GravitinoIcebergCatalog.java
+++ b/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/iceberg/GravitinoIcebergCatalog.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/iceberg/IcebergPropertiesConstants.java
+++ b/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/iceberg/IcebergPropertiesConstants.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/iceberg/IcebergPropertiesConverter.java
+++ b/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/iceberg/IcebergPropertiesConverter.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/iceberg/SparkIcebergTable.java
+++ b/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/iceberg/SparkIcebergTable.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/plugin/GravitinoDriverPlugin.java
+++ b/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/plugin/GravitinoDriverPlugin.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/plugin/GravitinoSparkPlugin.java
+++ b/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/plugin/GravitinoSparkPlugin.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/utils/ConnectorUtil.java
+++ b/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/utils/ConnectorUtil.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/utils/GravitinoTableInfoHelper.java
+++ b/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/utils/GravitinoTableInfoHelper.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/version/CatalogNameAdaptor.java
+++ b/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/version/CatalogNameAdaptor.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/spark-connector/spark-common/src/test/java/org/apache/gravitino/spark/connector/TestSparkTransformConverter.java
+++ b/spark-connector/spark-common/src/test/java/org/apache/gravitino/spark/connector/TestSparkTransformConverter.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/spark-connector/spark-common/src/test/java/org/apache/gravitino/spark/connector/TestSparkTypeConverter.java
+++ b/spark-connector/spark-common/src/test/java/org/apache/gravitino/spark/connector/TestSparkTypeConverter.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/spark-connector/spark-common/src/test/java/org/apache/gravitino/spark/connector/catalog/TestTransformTableChange.java
+++ b/spark-connector/spark-common/src/test/java/org/apache/gravitino/spark/connector/catalog/TestTransformTableChange.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/spark-connector/spark-common/src/test/java/org/apache/gravitino/spark/connector/hive/TestHivePropertiesConverter.java
+++ b/spark-connector/spark-common/src/test/java/org/apache/gravitino/spark/connector/hive/TestHivePropertiesConverter.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/spark-connector/spark-common/src/test/java/org/apache/gravitino/spark/connector/iceberg/TestIcebergPropertiesConverter.java
+++ b/spark-connector/spark-common/src/test/java/org/apache/gravitino/spark/connector/iceberg/TestIcebergPropertiesConverter.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/spark-connector/spark-common/src/test/java/org/apache/gravitino/spark/connector/integration/test/SparkEnvIT.java
+++ b/spark-connector/spark-common/src/test/java/org/apache/gravitino/spark/connector/integration/test/SparkEnvIT.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/spark-connector/spark-common/src/test/java/org/apache/gravitino/spark/connector/integration/test/util/SparkMetadataColumnInfo.java
+++ b/spark-connector/spark-common/src/test/java/org/apache/gravitino/spark/connector/integration/test/util/SparkMetadataColumnInfo.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/spark-connector/spark-common/src/test/java/org/apache/gravitino/spark/connector/integration/test/util/SparkTableInfo.java
+++ b/spark-connector/spark-common/src/test/java/org/apache/gravitino/spark/connector/integration/test/util/SparkTableInfo.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/spark-connector/spark-common/src/test/java/org/apache/gravitino/spark/connector/integration/test/util/SparkTableInfoChecker.java
+++ b/spark-connector/spark-common/src/test/java/org/apache/gravitino/spark/connector/integration/test/util/SparkTableInfoChecker.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/spark-connector/spark-common/src/test/java/org/apache/gravitino/spark/connector/utils/TestConnectorUtil.java
+++ b/spark-connector/spark-common/src/test/java/org/apache/gravitino/spark/connector/utils/TestConnectorUtil.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/spark-connector/v3.4/spark/src/main/java/org/apache/gravitino/spark/connector/SparkTableChangeConverter34.java
+++ b/spark-connector/v3.4/spark/src/main/java/org/apache/gravitino/spark/connector/SparkTableChangeConverter34.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/spark-connector/v3.4/spark/src/main/java/org/apache/gravitino/spark/connector/SparkTypeConverter34.java
+++ b/spark-connector/v3.4/spark/src/main/java/org/apache/gravitino/spark/connector/SparkTypeConverter34.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/spark-connector/v3.4/spark/src/main/java/org/apache/gravitino/spark/connector/hive/GravitinoHiveCatalogSpark34.java
+++ b/spark-connector/v3.4/spark/src/main/java/org/apache/gravitino/spark/connector/hive/GravitinoHiveCatalogSpark34.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/spark-connector/v3.4/spark/src/main/java/org/apache/gravitino/spark/connector/iceberg/GravitinoIcebergCatalogSpark34.java
+++ b/spark-connector/v3.4/spark/src/main/java/org/apache/gravitino/spark/connector/iceberg/GravitinoIcebergCatalogSpark34.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/spark-connector/v3.5/spark/src/main/java/org/apache/gravitino/spark/connector/hive/GravitinoHiveCatalogSpark35.java
+++ b/spark-connector/v3.5/spark/src/main/java/org/apache/gravitino/spark/connector/hive/GravitinoHiveCatalogSpark35.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/spark-connector/v3.5/spark/src/main/java/org/apache/gravitino/spark/connector/iceberg/GravitinoIcebergCatalogSpark35.java
+++ b/spark-connector/v3.5/spark/src/main/java/org/apache/gravitino/spark/connector/iceberg/GravitinoIcebergCatalogSpark35.java
@@ -1,4 +1,5 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix the license headers in Java files.

### Why are the changes needed?

The license headers of many Java files are missing the opening statements.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Not necessary.
