### PR TITLE
[#4300] improvement(Mysql&PG catalog): use UnparsedExpression to represent unparsed column default value

### DIFF
--- a/api/src/main/java/org/apache/gravitino/rel/expressions/UnparsedExpression.java
+++ b/api/src/main/java/org/apache/gravitino/rel/expressions/UnparsedExpression.java
@@ -77,5 +77,10 @@ public interface UnparsedExpression extends Expression {
     public int hashCode() {
       return Objects.hash(unparsedExpression);
     }
+
+    @Override
+    public String toString() {
+      return "UnparsedExpressionImpl{" + "unparsedExpression='" + unparsedExpression + '\'' + '}';
+    }
   }
 }

--- a/catalogs/catalog-jdbc-mysql/src/main/java/org/apache/gravitino/catalog/mysql/converter/MysqlColumnDefaultValueConverter.java
+++ b/catalogs/catalog-jdbc-mysql/src/main/java/org/apache/gravitino/catalog/mysql/converter/MysqlColumnDefaultValueConverter.java
@@ -60,12 +60,20 @@ public class MysqlColumnDefaultValueConverter extends JdbcColumnDefaultValueConv
     switch (type.getTypeName().toLowerCase()) {
       case MysqlTypeConverter.TINYINT:
         return Literals.byteLiteral(Byte.valueOf(columnDefaultValue));
+      case MysqlTypeConverter.TINYINT_UNSIGNED:
+        return Literals.unsignedByteLiteral(Short.valueOf(columnDefaultValue));
       case MysqlTypeConverter.SMALLINT:
         return Literals.shortLiteral(Short.valueOf(columnDefaultValue));
+      case MysqlTypeConverter.SMALLINT_UNSIGNED:
+        return Literals.unsignedShortLiteral(Integer.valueOf(columnDefaultValue));
       case MysqlTypeConverter.INT:
         return Literals.integerLiteral(Integer.valueOf(columnDefaultValue));
+      case MysqlTypeConverter.INT_UNSIGNED:
+        return Literals.unsignedIntegerLiteral(Long.valueOf(columnDefaultValue));
       case MysqlTypeConverter.BIGINT:
         return Literals.longLiteral(Long.valueOf(columnDefaultValue));
+      case MysqlTypeConverter.BIGINT_UNSIGNED:
+        return Literals.unsignedLongLiteral(Decimal.of(columnDefaultValue));
       case MysqlTypeConverter.FLOAT:
         return Literals.floatLiteral(Float.valueOf(columnDefaultValue));
       case MysqlTypeConverter.DOUBLE:
@@ -95,7 +103,7 @@ public class MysqlColumnDefaultValueConverter extends JdbcColumnDefaultValueConv
       case JdbcTypeConverter.TEXT:
         return Literals.stringLiteral(columnDefaultValue);
       default:
-        throw new IllegalArgumentException("Unknown data type for literal: " + type);
+        return UnparsedExpression.of(columnDefaultValue);
     }
   }
 }

--- a/catalogs/catalog-jdbc-mysql/src/test/java/org/apache/gravitino/catalog/mysql/integration/test/CatalogMysqlIT.java
+++ b/catalogs/catalog-jdbc-mysql/src/test/java/org/apache/gravitino/catalog/mysql/integration/test/CatalogMysqlIT.java
@@ -484,18 +484,18 @@ public class CatalogMysqlIT extends AbstractIT {
             + "  int_col_1 int default 0x01AF,\n"
             + "  int_col_2 int default (rand()),\n"
             + "  int_col_3 int default '3.321',\n"
+            + "  unsigned_int_col_1 INT UNSIGNED default 1,\n"
+            + "  unsigned_bigint_col_1 BIGINT(20) UNSIGNED UNSIGNED default 0,\n"
             + "  double_col_1 double default 123.45,\n"
             + "  varchar20_col_1 varchar(20) default (10),\n"
             + "  varchar100_col_1 varchar(100) default 'CURRENT_TIMESTAMP',\n"
             + "  varchar200_col_1 varchar(200) default 'curdate()',\n"
             + "  varchar200_col_2 varchar(200) default (curdate()),\n"
             + "  varchar200_col_3 varchar(200) default (CURRENT_TIMESTAMP),\n"
-            // todo: uncomment when we support datetime type
-            + "  /* we don't support datetime type now\n"
             + "  datetime_col_1 datetime default CURRENT_TIMESTAMP,\n"
             + "  datetime_col_2 datetime default current_timestamp,\n"
             + "  datetime_col_3 datetime default null,\n"
-            + "  datetime_col_4 datetime default 19830905, */\n"
+            + "  datetime_col_4 datetime default 19830905,\n"
             + "  date_col_1 date default (CURRENT_DATE),\n"
             + "  date_col_2 date,\n"
             + "  date_col_3 date DEFAULT (CURRENT_DATE + INTERVAL 1 YEAR),\n"
@@ -503,7 +503,8 @@ public class CatalogMysqlIT extends AbstractIT {
             + "  date_col_5 date DEFAULT '2024-04-01',\n"
             + "  timestamp_col_1 timestamp default '2012-12-31 11:30:45',\n"
             + "  timestamp_col_2 timestamp default 19830905,\n"
-            + "  decimal_6_2_col_1 decimal(6, 2) default 1.2\n"
+            + "  decimal_6_2_col_1 decimal(6, 2) default 1.2,\n"
+            + "  bit_col_1 bit default b'1'\n"
             + ");\n";
 
     mysqlService.executeQuery(sql);
@@ -520,6 +521,13 @@ public class CatalogMysqlIT extends AbstractIT {
           break;
         case "int_col_3":
           Assertions.assertEquals(Literals.integerLiteral(3), column.defaultValue());
+          break;
+        case "unsigned_int_col_1":
+          Assertions.assertEquals(Literals.unsignedIntegerLiteral(1L), column.defaultValue());
+          break;
+        case "unsigned_bigint_col_1":
+          Assertions.assertEquals(
+              Literals.unsignedLongLiteral(Decimal.of("0")), column.defaultValue());
           break;
         case "double_col_1":
           Assertions.assertEquals(Literals.doubleLiteral(123.45), column.defaultValue());
@@ -539,6 +547,17 @@ public class CatalogMysqlIT extends AbstractIT {
           break;
         case "varchar200_col_3":
           Assertions.assertEquals(UnparsedExpression.of("now()"), column.defaultValue());
+          break;
+        case "datetime_col_1":
+        case "datetime_col_2":
+          Assertions.assertEquals(DEFAULT_VALUE_OF_CURRENT_TIMESTAMP, column.defaultValue());
+          break;
+        case "datetime_col_3":
+          Assertions.assertEquals(Literals.NULL, column.defaultValue());
+          break;
+        case "datetime_col_4":
+          Assertions.assertEquals(
+              Literals.timestampLiteral("1983-09-05T00:00"), column.defaultValue());
           break;
         case "date_col_1":
           Assertions.assertEquals(UnparsedExpression.of("curdate()"), column.defaultValue());
@@ -569,8 +588,15 @@ public class CatalogMysqlIT extends AbstractIT {
           Assertions.assertEquals(
               Literals.decimalLiteral(Decimal.of("1.2", 6, 2)), column.defaultValue());
           break;
+        case "bit_col_1":
+          Assertions.assertEquals(UnparsedExpression.of("b'1'"), column.defaultValue());
+          break;
         default:
-          Assertions.fail("Unexpected column name: " + column.name());
+          Assertions.fail(
+              "Unexpected column name: "
+                  + column.name()
+                  + ", default value: "
+                  + column.defaultValue());
       }
     }
   }

--- a/catalogs/catalog-jdbc-postgresql/src/main/java/org/apache/gravitino/catalog/postgresql/converter/PostgreSqlColumnDefaultValueConverter.java
+++ b/catalogs/catalog-jdbc-postgresql/src/main/java/org/apache/gravitino/catalog/postgresql/converter/PostgreSqlColumnDefaultValueConverter.java
@@ -67,10 +67,6 @@ public class PostgreSqlColumnDefaultValueConverter extends JdbcColumnDefaultValu
       if (columnDefaultValue.equals(CURRENT_TIMESTAMP)) {
         return DEFAULT_VALUE_OF_CURRENT_TIMESTAMP;
       }
-      if (e instanceof IllegalArgumentException
-          && e.getMessage().contains("Unknown data type for literal")) {
-        throw e;
-      }
       return UnparsedExpression.of(columnDefaultValue);
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

use UnparsedExpression to represent unpared column default value

### Why are the changes needed?

Fix: #4300 

### Does this PR introduce _any_ user-facing change?

yes, when loading a PG or MySQL table with an unparsed column default value, will use an UnparsedExpression instead of throw a exception

### How was this patch tested?

modified tests
