### PR TITLE
[#4298]fix(flink-connector): fix scala version in flink connector

### DIFF
--- a/flink-connector/build.gradle.kts
+++ b/flink-connector/build.gradle.kts
@@ -27,7 +27,13 @@ repositories {
 }
 
 val flinkVersion: String = libs.versions.flink.get()
-val scalaVersion: String = project.properties["scalaVersion"] as? String ?: extra["defaultScalaVersion"].toString()
+
+// The Flink only support scala 2.12, and all scala api will be removed in a future version.
+// You can find more detail at the following issues:
+// https://issues.apache.org/jira/browse/FLINK-23986,
+// https://issues.apache.org/jira/browse/FLINK-20845,
+// https://issues.apache.org/jira/browse/FLINK-13414.
+val scalaVersion: String = "2.12"
 val artifactName = "gravitino-${project.name}-$scalaVersion"
 
 dependencies {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -54,13 +54,14 @@ if (scalaVersion == "2.12") {
   include("spark-connector:spark-3.3", "spark-connector:spark-runtime-3.3")
   project(":spark-connector:spark-3.3").projectDir = file("spark-connector/v3.3/spark")
   project(":spark-connector:spark-runtime-3.3").projectDir = file("spark-connector/v3.3/spark-runtime")
+  // flink only support scala 2.12
+  include("flink-connector")
 }
 include("spark-connector:spark-3.4", "spark-connector:spark-runtime-3.4", "spark-connector:spark-3.5", "spark-connector:spark-runtime-3.5")
 project(":spark-connector:spark-3.4").projectDir = file("spark-connector/v3.4/spark")
 project(":spark-connector:spark-runtime-3.4").projectDir = file("spark-connector/v3.4/spark-runtime")
 project(":spark-connector:spark-3.5").projectDir = file("spark-connector/v3.5/spark")
 project(":spark-connector:spark-runtime-3.5").projectDir = file("spark-connector/v3.5/spark-runtime")
-include("flink-connector")
 include("web")
 include("docs")
 include("integration-test-common")


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Flink only supports Scala 2.12. All scala API will removed in the future version.

https://issues.apache.org/jira/browse/FLINK-23986
https://issues.apache.org/jira/browse/FLINK-20845
https://issues.apache.org/jira/browse/FLINK-13414

### Why are the changes needed?


Fix: #4298

### Does this PR introduce _any_ user-facing change?

- no

### How was this patch tested?

- `./gradlew flink-connector:publishToMavenLocal -PdefaultScalaVersion=2.13 `

![image](https://github.com/user-attachments/assets/fa99b4f1-e5fd-49f6-a295-944b95c6b7b8)
