### PR TITLE
[#4148] fix(Kafka-catalog): improve readability of hint message

### DIFF
--- a/web/src/lib/utils/initial.js
+++ b/web/src/lib/utils/initial.js
@@ -41,7 +41,7 @@ export const messagingProviders = [
         key: 'bootstrap.servers',
         value: '',
         required: true,
-        description: 'The Apache Kafka broker(s) to connect to, allowing for multiple brokers by comma-separating them'
+        description: 'The Apache Kafka brokers to connect to, allowing for multiple brokers separated by commas'
       }
     ]
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Improved the readability of the hint message for the Apache Kafka catalog. The updated hint message is now:
"The Apache Kafka brokers to connect to, allowing for multiple brokers separated by commas"

### Why are the changes needed?

The previous hint message was unclear and less readable. The new message provides a clearer instruction to the users, enhancing the user experience.

Fix: #4148

### Does this PR introduce _any_ user-facing change?

_No_

### How was this patch tested?

_No need_