### PR TITLE
[#4134] docs: fix typo in table column types documentation

### DIFF
--- a/docs/lakehouse-iceberg-catalog.md
+++ b/docs/lakehouse-iceberg-catalog.md
@@ -209,7 +209,7 @@ Apache Iceberg doesn't support Gravitino `EvenDistribution` type.
 
 | Gravitino Type              | Apache Iceberg Type         |
 |-----------------------------|-----------------------------|
-| `Sturct`                    | `Struct`                    |
+| `Struct`                    | `Struct`                    |
 | `Map`                       | `Map`                       |
 | `Array`                     | `Array`                     |
 | `Boolean`                   | `Boolean`                   |


### PR DESCRIPTION
### What changes were proposed in this pull request?

This pull request fixes a typo in the "Gravitino Type" column of the "Table column types" section. The word "Sturct" is corrected to "Struct".

### Why are the changes needed?

This change is needed to correct the spelling of the type name "Struct", ensuring consistency and clarity.

Fix: #4134

### Does this PR introduce _any_ user-facing change?

No, this PR does not introduce any user-facing changes.

### How was this patch tested?

No additional tests are required.
