### PR TITLE
[#4322] fix: python-client module import error

### DIFF
--- a/.github/workflows/python-integration-test.yml
+++ b/.github/workflows/python-integration-test.yml
@@ -24,6 +24,7 @@ jobs:
             source_changes:
               - .github/**
               - api/**
+              - catalogs/catalog-hadoop/**
               - clients/client-python/**
               - common/**
               - conf/**
@@ -46,7 +47,6 @@ jobs:
         java-version: [ 8 ]
     env:
       PLATFORM: ${{ matrix.architecture }}
-      PYTHONPATH: ${{ github.workspace }}/clients/client-python
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/python-integration-test.yml
+++ b/.github/workflows/python-integration-test.yml
@@ -46,6 +46,7 @@ jobs:
         java-version: [ 8 ]
     env:
       PLATFORM: ${{ matrix.architecture }}
+      PYTHONPATH: ${{ github.workspace }}/clients/client-python
     steps:
       - uses: actions/checkout@v3
 

--- a/clients/client-python/build.gradle.kts
+++ b/clients/client-python/build.gradle.kts
@@ -213,16 +213,19 @@ tasks {
     if (dockerTest) {
       dependsOn("verifyHadoopPack")
       envMap.putAll(mapOf(
-          "HADOOP_VERSION" to hadoopVersion,
-          "PYTHON_BUILD_PATH" to project.rootDir.path + "/clients/client-python/build"
+        "HADOOP_VERSION" to hadoopVersion,
+        "PYTHON_BUILD_PATH" to project.rootDir.path + "/clients/client-python/build"
       ))
     }
     envMap.putAll(mapOf(
-        "PROJECT_VERSION" to project.version,
-        "GRAVITINO_HOME" to project.rootDir.path + "/distribution/package",
-        "START_EXTERNAL_GRAVITINO" to "true",
-        "DOCKER_TEST" to dockerTest.toString(),
-        "GRAVITINO_CI_HIVE_DOCKER_IMAGE" to "datastrato/gravitino-ci-hive:0.1.13",
+      "PROJECT_VERSION" to project.version,
+      "GRAVITINO_HOME" to project.rootDir.path + "/distribution/package",
+      "START_EXTERNAL_GRAVITINO" to "true",
+      "DOCKER_TEST" to dockerTest.toString(),
+      "GRAVITINO_CI_HIVE_DOCKER_IMAGE" to "datastrato/gravitino-ci-hive:0.1.13",
+      // Set the PYTHONPATH to the client-python directory, make sure the tests can import the
+      // modules from the client-python directory.
+      "PYTHONPATH" to "${project.rootDir.path}/clients/client-python"
     ))
     environment = envMap
 
@@ -243,6 +246,12 @@ tasks {
     venvExec = "coverage"
     args = listOf("run", "--branch", "-m", "unittest")
     workingDir = projectDir.resolve("./tests/unittests")
+
+    environment = mapOf(
+      // Set the PYTHONPATH to the client-python directory, make sure the tests can import the
+      // modules from the client-python directory.
+      "PYTHONPATH" to "${project.rootDir.path}/clients/client-python"
+    )
 
     finalizedBy(unitCoverageReport)
   }

--- a/clients/client-python/tests/unittests/test_name_identifier.py
+++ b/clients/client-python/tests/unittests/test_name_identifier.py
@@ -37,7 +37,6 @@ class TestNameIdentifier(unittest.TestCase):
         self.assertNotEqual("test2", identifier_dict.get(name_identifier1))
 
     def test_from_json_name_identifier(self):
-
         test_name = "test_name_identifier"
         test_namespace_levels = ["1", "2", "3", "4"]
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add `PYTHONPATH` environment and point Gravitino Python client path in the CI workflow.
Make Python search for module in the correct path.

### Why are the changes needed?


Fix: #4322

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

CI Passed
