### PR TITLE
[#4329] improvement(build): fix get commit id failed as a submodule

### DIFF
--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -52,13 +52,20 @@ dependencies {
 fun getGitCommitId(): String {
   var gitCommitId: String
   try {
-    val gitFolder = rootDir.path + "/.git/"
-    val head = File(gitFolder + "HEAD").readText().split(":")
+    val gitPath = File(rootDir.path, ".git")
+    val gitFolder = if (gitPath.isDirectory) {
+      gitPath
+    } else {
+      val content = gitPath.readText().trim()
+      File(rootDir.path, content.substringAfter("gitdir: ").trim())
+    }
+
+    val head = File(gitFolder, "HEAD").readText().split(":")
     val isCommit = head.size == 1
     gitCommitId = if (isCommit) {
       head[0].trim()
     } else {
-      val refHead = File(gitFolder + head[1].trim())
+      val refHead = File(gitFolder, head[1].trim())
       refHead.readText().trim()
     }
   } catch (e: Exception) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

fix get commit id failed as a submodule

### Why are the changes needed?

when the project is a submodule, the `.git` is a file, not a directory,  we should handle the case

Fix: #4329 

### Does this PR introduce _any_ user-facing change?

no

### How was this patch tested?

test locally by hand
