### PR TITLE
[#4332]Improve(trino-connector): Make the CatalogConnectorContext.Builder's functions to public

### DIFF
--- a/trino-connector/src/main/java/org/apache/gravitino/trino/connector/GravitinoConnectorFactory.java
+++ b/trino-connector/src/main/java/org/apache/gravitino/trino/connector/GravitinoConnectorFactory.java
@@ -89,7 +89,7 @@ public class GravitinoConnectorFactory implements ConnectorFactory {
 
           gravitinoSystemTableFactory = new GravitinoSystemTableFactory(catalogConnectorManager);
         } catch (Exception e) {
-          String message = "Initialization of the GravitinoConnector failed" + e.getMessage();
+          String message = "Initialization of the GravitinoConnector failed " + e.getMessage();
           LOG.error(message);
           throw new TrinoException(GRAVITINO_RUNTIME_ERROR, message, e);
         }
@@ -141,7 +141,7 @@ public class GravitinoConnectorFactory implements ConnectorFactory {
       return (CatalogConnectorFactory) obj;
     } catch (Exception e) {
       throw new TrinoException(
-          GRAVITINO_RUNTIME_ERROR, "Can not create CatalogConnectorFactory", e);
+          GRAVITINO_RUNTIME_ERROR, "Can not create CatalogConnectorFactory ", e);
     }
   }
 }

--- a/trino-connector/src/main/java/org/apache/gravitino/trino/connector/catalog/CatalogConnectorContext.java
+++ b/trino-connector/src/main/java/org/apache/gravitino/trino/connector/catalog/CatalogConnectorContext.java
@@ -96,13 +96,13 @@ public class CatalogConnectorContext {
     return adapter.getMetadataAdapter();
   }
 
-  static class Builder {
+  public static class Builder {
     private final CatalogConnectorAdapter connectorAdapter;
     private GravitinoCatalog catalog;
     private GravitinoMetalake metalake;
     private ConnectorContext context;
 
-    Builder(CatalogConnectorAdapter connectorAdapter) {
+    public Builder(CatalogConnectorAdapter connectorAdapter) {
       this.connectorAdapter = connectorAdapter;
     }
 
@@ -115,17 +115,17 @@ public class CatalogConnectorContext {
       return new Builder(connectorAdapter, catalog);
     }
 
-    Builder withMetalake(GravitinoMetalake metalake) {
+    public Builder withMetalake(GravitinoMetalake metalake) {
       this.metalake = metalake;
       return this;
     }
 
-    Builder withContext(ConnectorContext context) {
+    public Builder withContext(ConnectorContext context) {
       this.context = context;
       return this;
     }
 
-    CatalogConnectorContext build() throws Exception {
+    public CatalogConnectorContext build() throws Exception {
       Preconditions.checkArgument(metalake != null, "metalake is not null");
       Preconditions.checkArgument(catalog != null, "catalog is not null");
       Preconditions.checkArgument(context != null, "context is not null");

--- a/trino-connector/src/main/java/org/apache/gravitino/trino/connector/catalog/DefaultCatalogConnectorFactory.java
+++ b/trino-connector/src/main/java/org/apache/gravitino/trino/connector/catalog/DefaultCatalogConnectorFactory.java
@@ -48,6 +48,7 @@ public class DefaultCatalogConnectorFactory implements CatalogConnectorFactory {
         "jdbc-mysql", new CatalogConnectorContext.Builder(new MySQLConnectorAdapter()));
     catalogBuilders.put(
         "jdbc-postgresql", new CatalogConnectorContext.Builder(new PostgreSQLConnectorAdapter()));
+    LOG.info("Start the DefaultCatalogConnectorFactory");
   }
 
   public CatalogConnectorContext.Builder createCatalogConnectorContextBuilder(


### PR DESCRIPTION
### What changes were proposed in this pull request?

Make the CatalogConnectorContext.Builder's functions to public. Users can extend the CatalogConnectorFactory outside the package.

### Why are the changes needed?

Fix: #4332 

### Does this PR introduce _any_ user-facing change?

NO

### How was this patch tested?

NO
