### PR TITLE
[#3570] fix(integration-test): Fix possible command inject vulnerability in ProcessBuilder

### DIFF
--- a/integration-test-common/src/test/java/org/apache/gravitino/integration/test/util/CommandExecutor.java
+++ b/integration-test-common/src/test/java/org/apache/gravitino/integration/test/util/CommandExecutor.java
@@ -47,10 +47,9 @@ public class CommandExecutor {
       Map<String, String> env) {
     List<String> subCommandsAsList = new ArrayList<>(Arrays.asList(command));
     String mergedCommand = StringUtils.join(subCommandsAsList, " ");
-
     LOG.info("Sending command \"{}\" to localhost", mergedCommand);
 
-    ProcessBuilder processBuilder = new ProcessBuilder(command);
+    ProcessBuilder processBuilder = new ProcessBuilder(subCommandsAsList);
     processBuilder.environment().putAll(env);
     Process process = null;
     try {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix potential command inject bugs in `ProcessBuilder`.   Passing a single string as the parameter of `ProcessBuilder` will lead to the command inject vulnerability, for example, if the value of the command is `ls -al ;rm -rf`, then it will launch a process that will execute `ls -al` first and then `rm -rf`.

However, If we split the command to a list like `['ls', '-al', ';rm', "-rf"]`, the list will view as a single command and values start from `-al` will be viewed the parameter as the command `ls` , so command `rm -rf` will not take effect. 



### Why are the changes needed?

To fix the bug.

Fix: #3570

### Does this PR introduce _any_ user-facing change?

N/A.

### How was this patch tested?

Existing  IT.