### PR TITLE
[#3799]feat(doc): Add documents to note to users the limits of OpenCSVSerde

### DIFF
--- a/docs/spark-connector/spark-catalog-hive.md
+++ b/docs/spark-connector/spark-catalog-hive.md
@@ -19,6 +19,11 @@ Supports most DDL and DML operations in SparkSQL, except such operations:
 - `CREATE TABLE LIKE` clause
 - `TRUCATE TABLE` clause
 
+
+:::info
+There are some limits for tables whose row format serde is `org.apache.hadoop.hive.serde2.OpenCSVSerde`. Due to HIVE-13709, the table's scheme may mismatch between Gravitino and Hive Metastore. Please make sure all fields are string type if used.
+:::
+
 ## Requirement
 
 * Hive metastore 2.x

--- a/docs/spark-connector/spark-catalog-hive.md
+++ b/docs/spark-connector/spark-catalog-hive.md
@@ -21,7 +21,7 @@ Supports most DDL and DML operations in SparkSQL, except such operations:
 
 
 :::info
-There are some limits for tables whose row format serde is `org.apache.hadoop.hive.serde2.OpenCSVSerde`. Due to HIVE-13709, the table's scheme may mismatch between Gravitino and Hive Metastore. Please make sure all fields are string type if used.
+Don't support reading and writing tables with `org.apache.hadoop.hive.serde2.OpenCSVSerde` row format.
 :::
 
 ## Requirement


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Add documents to note to users the limits of OpenCSVSerde in spark-catalog-hive.md

### Why are the changes needed?

Fix: #3799

