### PR TITLE
[HOTFIX]  fix spotless check error

### DIFF
--- a/clients/client-java/src/main/java/org/apache/gravitino/client/GravitinoClientBase.java
+++ b/clients/client-java/src/main/java/org/apache/gravitino/client/GravitinoClientBase.java
@@ -153,7 +153,7 @@ public abstract class GravitinoClientBase implements Closeable {
    * Retrieves the version of the Gravitino API.
    *
    * @deprecated This method is deprecated because it is a duplicate of {@link #serverVersion()}.
-   *             Use {@link #serverVersion()} instead for clarity and consistency.
+   *     Use {@link #serverVersion()} instead for clarity and consistency.
    */
   @Deprecated
   @InlineMe(replacement = "this.serverVersion()")

--- a/clients/client-java/src/main/java/org/apache/gravitino/client/GravitinoClientBase.java
+++ b/clients/client-java/src/main/java/org/apache/gravitino/client/GravitinoClientBase.java
@@ -152,6 +152,7 @@ public abstract class GravitinoClientBase implements Closeable {
   /**
    * Retrieves the version of the Gravitino API.
    *
+   * @return A GravitinoVersion instance representing the version of the Gravitino API.
    * @deprecated This method is deprecated because it is a duplicate of {@link #serverVersion()}.
    *     Use {@link #serverVersion()} instead for clarity and consistency.
    */


### PR DESCRIPTION
### What changes were proposed in this pull request?
fix splot check error

### Why are the changes needed?
ci failed for spotless check, introduced by #4338 
```
Execution failed for task ':clients:client-java:spotlessJavaCheck'.
> The following files had format violations:
      src/main/java/org/apache/gravitino/client/GravitinoClientBase.java
          @@ -153,7 +153,7 @@
           ···*·Retrieves·the·version·of·the·Gravitino·API.
           ···*
           ···*·@deprecated·This·method·is·deprecated·because·it·is·a·duplicate·of·{@link·#serverVersion()}.
          -···*·············Use·{@link·#serverVersion()}·instead·for·clarity·and·consistency.
          +···*·····Use·{@link·#serverVersion()}·instead·for·clarity·and·consistency.
           ···*/
           ··@Deprecated
           ··@InlineMe(replacement·=·"this.serverVersion()")
  Run './gradlew :clients:client-java:spotlessApply' to fix these violations.
```

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
existing tests