### PR TITLE
[MINOR] CI: Add auto cherry-pick to branch-0.6 and remove self token

### DIFF
--- a/.github/workflows/auto-cherry-pick.yml
+++ b/.github/workflows/auto-cherry-pick.yml
@@ -7,24 +7,6 @@ on:
     types: ["closed"]
 
 jobs:
-  cherry_pick_branch_0_4:
-    runs-on: ubuntu-latest
-    name: Cherry pick into branch_0.4
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'branch-0.4') && github.event.pull_request.merged == true }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: Cherry pick into branch-0.4
-        uses: carloscastrojumo/github-cherry-pick-action@v1.0.9
-        with:
-          branch: branch-0.4
-          labels: |
-            cherry-pick
-          reviewers: |
-            jerryshao
-
   cherry_pick_branch_0_5:
     runs-on: ubuntu-latest
     name: Cherry pick into branch_0.5
@@ -46,7 +28,7 @@ jobs:
   cherry_pick_branch_0_6:
     runs-on: ubuntu-latest
     name: Cherry pick into branch_0.6
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'branch-0.5') && github.event.pull_request.merged == true }}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'branch-0.6') && github.event.pull_request.merged == true }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -56,6 +38,25 @@ jobs:
         uses: carloscastrojumo/github-cherry-pick-action@v1.0.9
         with:
           branch: branch-0.6
+          labels: |
+            cherry-pick
+          reviewers: |
+            jerryshao
+
+
+  cherry_pick_branch_0_7:
+    runs-on: ubuntu-latest
+    name: Cherry pick into branch_0.7
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'branch-0.7') && github.event.pull_request.merged == true }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Cherry pick into branch-0.7
+        uses: carloscastrojumo/github-cherry-pick-action@v1.0.9
+        with:
+          branch: branch-0.7
           labels: |
             cherry-pick
           reviewers: |

--- a/.github/workflows/auto-cherry-pick.yml
+++ b/.github/workflows/auto-cherry-pick.yml
@@ -7,25 +7,6 @@ on:
     types: ["closed"]
 
 jobs:
-  cherry_pick_branch_0_3:
-    runs-on: ubuntu-latest
-    name: Cherry pick into branch_0.3
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'branch-0.3') && github.event.pull_request.merged == true }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: Cherry pick into branch-0.3
-        uses: carloscastrojumo/github-cherry-pick-action@v1.0.9
-        with:
-          token: ${{ secrets.BOT_TOKEN }}
-          branch: branch-0.3
-          labels: |
-            cherry-pick
-          reviewers: |
-            jerryshao
-
   cherry_pick_branch_0_4:
     runs-on: ubuntu-latest
     name: Cherry pick into branch_0.4
@@ -38,7 +19,6 @@ jobs:
       - name: Cherry pick into branch-0.4
         uses: carloscastrojumo/github-cherry-pick-action@v1.0.9
         with:
-          token: ${{ secrets.BOT_TOKEN }}
           branch: branch-0.4
           labels: |
             cherry-pick
@@ -57,8 +37,25 @@ jobs:
       - name: Cherry pick into branch-0.5
         uses: carloscastrojumo/github-cherry-pick-action@v1.0.9
         with:
-          token: ${{ secrets.BOT_TOKEN }}
           branch: branch-0.5
+          labels: |
+            cherry-pick
+          reviewers: |
+            jerryshao
+
+  cherry_pick_branch_0_6:
+    runs-on: ubuntu-latest
+    name: Cherry pick into branch_0.6
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'branch-0.5') && github.event.pull_request.merged == true }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Cherry pick into branch-0.6
+        uses: carloscastrojumo/github-cherry-pick-action@v1.0.9
+        with:
+          branch: branch-0.6
           labels: |
             cherry-pick
           reviewers: |


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to add auto cherry-pick support for branch-0.6, also removing the self token to use github token to make it work.

### Why are the changes needed?

To support auto cherry-pick for branch-0.6.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Test on Github CI.