### PR TITLE
Fix potential NullPointerException in UserContext by adding null check for parentContext.

### DIFF
--- a/catalogs/catalog-hadoop/src/main/java/org/apache/gravitino/catalog/hadoop/authentication/UserContext.java
+++ b/catalogs/catalog-hadoop/src/main/java/org/apache/gravitino/catalog/hadoop/authentication/UserContext.java
@@ -123,6 +123,8 @@ public abstract class UserContext implements Closeable {
       addUserContext(nameIdentifier, simpleUserContext);
       return simpleUserContext;
     } else if (authenticationType == AuthenticationType.KERBEROS) {
+      // if the kerberos authentication is inherited from the parent context, we will use the
+      // parent context's kerberos configuration.
       // Improvement: Check if parentContext is not null before using it
       if (parentContext != null && authenticationConfig.isSimpleAuth()) {
         KerberosUserContext kerberosUserContext = ((KerberosUserContext) parentContext).deepCopy();

--- a/catalogs/catalog-hadoop/src/main/java/org/apache/gravitino/catalog/hadoop/authentication/UserContext.java
+++ b/catalogs/catalog-hadoop/src/main/java/org/apache/gravitino/catalog/hadoop/authentication/UserContext.java
@@ -125,7 +125,6 @@ public abstract class UserContext implements Closeable {
     } else if (authenticationType == AuthenticationType.KERBEROS) {
       // if the kerberos authentication is inherited from the parent context, we will use the
       // parent context's kerberos configuration.
-      // Improvement: Check if parentContext is not null before using it
       if (parentContext != null && authenticationConfig.isSimpleAuth()) {
         KerberosUserContext kerberosUserContext = ((KerberosUserContext) parentContext).deepCopy();
         kerberosUserContext.setEnableUserImpersonation(enableUserImpersonation);

--- a/catalogs/catalog-hadoop/src/main/java/org/apache/gravitino/catalog/hadoop/authentication/UserContext.java
+++ b/catalogs/catalog-hadoop/src/main/java/org/apache/gravitino/catalog/hadoop/authentication/UserContext.java
@@ -123,9 +123,8 @@ public abstract class UserContext implements Closeable {
       addUserContext(nameIdentifier, simpleUserContext);
       return simpleUserContext;
     } else if (authenticationType == AuthenticationType.KERBEROS) {
-      // if the kerberos authentication is inherited from the parent context, we will use the
-      // parent context's kerberos configuration.
-      if (authenticationConfig.isSimpleAuth()) {
+      // Improvement: Check if parentContext is not null before using it
+      if (parentContext != null && authenticationConfig.isSimpleAuth()) {
         KerberosUserContext kerberosUserContext = ((KerberosUserContext) parentContext).deepCopy();
         kerberosUserContext.setEnableUserImpersonation(enableUserImpersonation);
         addUserContext(nameIdentifier, kerberosUserContext);


### PR DESCRIPTION
Title: [#4331] fix: add null check for parentContext in UserContext

### What changes were proposed in this pull request?

This pull request adds a null check for the parentContext variable in the getUserContext method of UserContext.java. This ensures that a NullPointerException is avoided when deepCopy() is called on parentContext.


### Why are the changes needed?

The change is needed to prevent a potential NullPointerException if parentContext is null. Adding this check makes the code more reliable.

Fix: #4331 

### Does this PR introduce _any_ user-facing change?

No, this change does not introduce any user-facing changes.

### How was this patch tested?

The change was reviewed to ensure that the null check effectively prevents the issue. No new tests were needed, as this is a preventive fix.
