### PR TITLE
[#4351] [improvement] UI: Switch catalog properties from immutable to mutable

### DIFF
--- a/web/src/app/metalakes/metalake/rightContent/CreateCatalogDialog.js
+++ b/web/src/app/metalakes/metalake/rightContent/CreateCatalogDialog.js
@@ -376,7 +376,7 @@ const CreateCatalogDialog = props => {
       propsItems = propsItems.map((it, idx) => {
         let propItem = {
           ...it,
-          disabled: true
+          disabled: it.key === 'catalog-backend' && type === 'update'
         }
 
         const findProp = Object.keys(properties).find(i => i === it.key)
@@ -394,8 +394,7 @@ const CreateCatalogDialog = props => {
         if (findPropIndex === -1) {
           let propItem = {
             key: item,
-            value: properties[item],
-            disabled: data.type === 'fileset' && item === 'location' && type === 'update'
+            value: properties[item]
           }
           propsItems.push(propItem)
         }


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?
switch catalog properties value input disable to enable
hive catalog before: 
<img width="623" alt="Pasted Graphic" src="https://github.com/user-attachments/assets/77472113-ddd8-4051-825a-21bbaaf07bdd">
hive catalog after:
<img width="708" alt="Pasted Graphic 1" src="https://github.com/user-attachments/assets/d08634da-0044-452d-9ded-ff186aae3507">

Iceberg catalog before: 
<img width="623" alt="Pasted Graphic 2" src="https://github.com/user-attachments/assets/3ecca557-6b2d-42ab-8d0f-115044fe97b3">
iceberg catalog after:
<img width="588" alt="Pasted Graphic 3" src="https://github.com/user-attachments/assets/5585d55c-4bec-42c3-b496-eaf75dc55e9f">

pg catalog before:
<img width="580" alt="Pasted Graphic 6" src="https://github.com/user-attachments/assets/334abb54-ad33-42b5-9d96-6f3d7fdded19">
pg catalog after:
<img width="594" alt="Pasted Graphic 7" src="https://github.com/user-attachments/assets/4aca0e85-8ba2-4bbe-a19b-58c52685ae42">


kafka catalog before: 
<img width="605" alt="Pasted Graphic 4" src="https://github.com/user-attachments/assets/37f1938d-90df-45ff-81bf-7081238921db">
kafka catalog after:
<img width="592" alt="Pasted Graphic 5" src="https://github.com/user-attachments/assets/4dd7e321-dd6a-4e86-8e5d-dae6d601fbf7">

fileset catalog before:
<img width="607" alt="Pasted Graphic 8" src="https://github.com/user-attachments/assets/1b430711-f494-4b87-89a2-ea9c774c381c">
fileset catalog after:
<img width="618" alt="Pasted Graphic 9" src="https://github.com/user-attachments/assets/04ce17cb-5eac-4f25-b1e0-e309db2a1103">


### Why are the changes needed?
make the change by the [PR](https://github.com/apache/gravitino/pull/4262) merged

Fix: #4351

### Does this PR introduce _any_ user-facing change?
N/A

### How was this patch tested?
manual
