### PR TITLE
[#3817] fix(catalog-postgresql): Fix bugs when creating a schema or table using upper-case name.

### DIFF
--- a/catalogs/catalog-jdbc-postgresql/src/main/java/org/apache/gravitino/catalog/postgresql/operation/PostgreSqlTableOperations.java
+++ b/catalogs/catalog-jdbc-postgresql/src/main/java/org/apache/gravitino/catalog/postgresql/operation/PostgreSqlTableOperations.java
@@ -159,7 +159,9 @@ public class PostgreSqlTableOperations extends JdbcTableOperations {
       sqlBuilder
           .append(NEW_LINE)
           .append(TABLE_COMMENT)
+          .append(PG_QUOTE)
           .append(tableName)
+          .append(PG_QUOTE)
           .append(IS)
           .append(comment)
           .append("';");
@@ -171,9 +173,13 @@ public class PostgreSqlTableOperations extends JdbcTableOperations {
                 sqlBuilder
                     .append(NEW_LINE)
                     .append(COLUMN_COMMENT)
+                    .append(PG_QUOTE)
                     .append(tableName)
+                    .append(PG_QUOTE)
                     .append(".")
+                    .append(PG_QUOTE)
                     .append(jdbcColumn.name())
+                    .append(PG_QUOTE)
                     .append(IS)
                     .append(jdbcColumn.comment())
                     .append("';"));

--- a/catalogs/catalog-jdbc-postgresql/src/test/java/org/apache/gravitino/catalog/postgresql/integration/test/CatalogPostgreSqlIT.java
+++ b/catalogs/catalog-jdbc-postgresql/src/test/java/org/apache/gravitino/catalog/postgresql/integration/test/CatalogPostgreSqlIT.java
@@ -292,6 +292,42 @@ public class CatalogPostgreSqlIT extends AbstractIT {
     Assertions.assertTrue(column.isPresent());
   }
 
+  @Test
+  void testCreateUpperCaseSchemaAndTable() {
+    // Create table from Gravitino API
+    Column[] columns = columnsWithSpecialNames();
+
+    String tableN = GravitinoITUtils.genRandomName("postgresql_it_table").toUpperCase();
+    String schemaN = GravitinoITUtils.genRandomName("postgresql_it_schema").toUpperCase();
+
+    // Create a schema with upper case name
+    Schema schema =
+        catalog.asSchemas().createSchema(schemaN, schema_comment, Collections.EMPTY_MAP);
+    System.out.println(schema);
+    NameIdentifier tableIdentifier = NameIdentifier.of(schemaN, tableN);
+    Distribution distribution = Distributions.NONE;
+
+    SortOrder[] sortOrders = new SortOrder[0];
+    Transform[] partitioning = Transforms.EMPTY_TRANSFORM;
+
+    Map<String, String> properties = createProperties();
+    TableCatalog tableCatalog = catalog.asTableCatalog();
+    // Create a table with upper case name
+    tableCatalog.createTable(
+        tableIdentifier,
+        columns,
+        table_comment,
+        properties,
+        partitioning,
+        distribution,
+        sortOrders);
+
+    Table t = tableCatalog.loadTable(tableIdentifier);
+    Optional<Column> column =
+        Arrays.stream(t.columns()).filter(c -> c.name().equals("binary")).findFirst();
+    Assertions.assertTrue(column.isPresent());
+  }
+
   private Map<String, String> createProperties() {
     Map<String, String> properties = Maps.newHashMap();
     return properties;

--- a/catalogs/catalog-jdbc-postgresql/src/test/java/org/apache/gravitino/catalog/postgresql/integration/test/CatalogPostgreSqlIT.java
+++ b/catalogs/catalog-jdbc-postgresql/src/test/java/org/apache/gravitino/catalog/postgresql/integration/test/CatalogPostgreSqlIT.java
@@ -301,9 +301,7 @@ public class CatalogPostgreSqlIT extends AbstractIT {
     String schemaN = GravitinoITUtils.genRandomName("postgresql_it_schema").toUpperCase();
 
     // Create a schema with upper case name
-    Schema schema =
-        catalog.asSchemas().createSchema(schemaN, schema_comment, Collections.EMPTY_MAP);
-    System.out.println(schema);
+    catalog.asSchemas().createSchema(schemaN, schema_comment, Collections.EMPTY_MAP);
     NameIdentifier tableIdentifier = NameIdentifier.of(schemaN, tableN);
     Distribution distribution = Distributions.NONE;
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Double quote table name or schema name to support upper case name.

### Why are the changes needed?

It's a bug needs to be fixed.

Fix: #3817 

### Does this PR introduce _any_ user-facing change?

N/A.

### How was this patch tested?

Add IT.
