### PR TITLE
[#4279] feat(client-python): Add the `getFileLocation` interface code skeleton in Python Client

### DIFF
--- a/clients/client-python/gravitino/audit/__init__.py
+++ b/clients/client-python/gravitino/audit/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/clients/client-python/gravitino/audit/caller_context.py
+++ b/clients/client-python/gravitino/audit/caller_context.py
@@ -21,7 +21,7 @@ caller_context_holder = threading.local()
 
 
 class CallerContext:
-    """A class defining the caller context for auditing coarse granularity operations."""
+    """A class defining the caller context for auditing coarse-grained operations."""
 
     _context: Dict[str, str]
 

--- a/clients/client-python/gravitino/audit/caller_context.py
+++ b/clients/client-python/gravitino/audit/caller_context.py
@@ -1,0 +1,71 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import threading
+from typing import Dict
+
+caller_context_holder = threading.local()
+
+
+class CallerContext:
+    """A class defining the caller context for auditing coarse granularity operations."""
+
+    _context: Dict[str, str]
+
+    def __init__(self, context: Dict[str, str]):
+        """Initialize the CallerContext.
+
+        Args:
+            context: The context dict.
+        """
+        self._context = context
+
+    def context(self) -> Dict[str, str]:
+        """Returns the context dict in the caller context.
+
+        Returns:
+             The context dict.
+        """
+        return self._context
+
+
+class CallerContextHolder:
+    """A thread local holder for the CallerContext."""
+
+    @staticmethod
+    def set(context: CallerContext):
+        """Set the CallerContext in the thread local.
+
+        Args:
+             context: The CallerContext to set.
+        """
+        caller_context_holder.caller_context = context
+
+    @staticmethod
+    def get():
+        """Get the CallerContext from the thread local.
+
+        Returns:
+             The CallerContext.
+        """
+        if not hasattr(caller_context_holder, "caller_context"):
+            return None
+        return caller_context_holder.caller_context
+
+    @staticmethod
+    def remove():
+        """Remove the CallerContext from the thread local."""
+        del caller_context_holder.caller_context

--- a/clients/client-python/gravitino/audit/fileset_audit_constants.py
+++ b/clients/client-python/gravitino/audit/fileset_audit_constants.py
@@ -1,0 +1,28 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+
+class FilesetAuditConstants:
+    """Constants used for fileset data operation audits."""
+
+    HTTP_HEADER_INTERNAL_CLIENT_TYPE = "InternalClientType"
+    """The HTTP header used to pass the internal client type.
+    """
+
+    HTTP_HEADER_FILESET_DATA_OPERATION = "FilesetDataOperation"
+    """The HTTP header used to pass the fileset data operation.
+    """

--- a/clients/client-python/gravitino/audit/fileset_data_operation.py
+++ b/clients/client-python/gravitino/audit/fileset_data_operation.py
@@ -21,59 +21,59 @@ class FilesetDataOperation(Enum):
     """An enum class containing fileset data operations that supported."""
 
     CREATE = "CREATE"
-    """ Create a new file.
+    """Creates a new file.
     """
 
     OPEN = "OPEN"
-    """Open a file.
+    """Opens a file.
     """
 
     APPEND = "APPEND"
-    """Append some content into a file.
+    """Appends some content into a file.
     """
 
     RENAME = "RENAME"
-    """Rename a file or a directory.
+    """Renames a file or a directory.
     """
 
     DELETE = "DELETE"
-    """Delete a file or a directory.
+    """Deletes a file or a directory.
     """
 
     GET_FILE_STATUS = "GET_FILE_STATUS"
-    """Get a file status from a file or a directory.
+    """Gets a file status from a file or a directory.
     """
 
     LIST_STATUS = "LIST_STATUS"
-    """List file statuses under a directory.
+    """Lists file statuses under a directory.
     """
 
     MKDIRS = "MKDIRS"
-    """Create a directory.
+    """Creates a directory.
     """
 
     EXISTS = "EXISTS"
-    """Check if a file or a directory exists.
+    """Checks if a file or a directory exists.
     """
 
     CREATED_TIME = "CREATED_TIME"
-    """Get the created time of a file.
+    """Gets the created time of a file.
     """
 
     MODIFIED_TIME = "MODIFIED_TIME"
-    """Get the modified time of a file.
+    """Gets the modified time of a file.
     """
 
     COPY_FILE = "COPY_FILE"
-    """Copy a file.
+    """Copies a file.
     """
 
     CAT_FILE = "CAT_FILE"
-    """Get the content of a file.
+    """Gets the content of a file.
     """
 
     GET_FILE = "GET_FILE"
-    """Copy a remote file to local.
+    """Copies a remote file to local.
     """
 
     UNKNOWN = "UNKNOWN"

--- a/clients/client-python/gravitino/audit/fileset_data_operation.py
+++ b/clients/client-python/gravitino/audit/fileset_data_operation.py
@@ -1,0 +1,81 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from enum import Enum
+
+
+class FilesetDataOperation(Enum):
+    """An enum class containing fileset data operations that supported."""
+
+    CREATE = "CREATE"
+    """ This data operation means that create a new file.
+    """
+
+    OPEN = "OPEN"
+    """This data operation means that open a file.
+    """
+
+    APPEND = "APPEND"
+    """This data operation means that append some content into a file.
+    """
+
+    RENAME = "RENAME"
+    """This data operation means that rename a file or a directory.
+    """
+
+    DELETE = "DELETE"
+    """This data operation means that delete a file or a directory.
+    """
+
+    GET_FILE_STATUS = "GET_FILE_STATUS"
+    """This data operation means that get a file status from a file or a directory.
+    """
+
+    LIST_STATUS = "LIST_STATUS"
+    """This data operation means that list file statuses under a directory.
+    """
+
+    MKDIRS = "MKDIRS"
+    """This data operation means that create a directory.
+    """
+
+    EXISTS = "EXISTS"
+    """This data operation means that check if a file or a directory exists.
+    """
+
+    CREATED_TIME = "CREATED_TIME"
+    """This data operation means that get the created time of a file.
+    """
+
+    MODIFIED_TIME = "MODIFIED_TIME"
+    """This data operation means that get the modified time of a file.
+    """
+
+    COPY_FILE = "COPY_FILE"
+    """This data operation means that copy a file.
+    """
+
+    CAT_FILE = "CAT_FILE"
+    """This data operation means that get the content of a file.
+    """
+
+    GET_FILE = "GET_FILE"
+    """This data operation means that copy a remote file to local.
+    """
+
+    UNKNOWN = "UNKNOWN"
+    """This data operation means that it is an unknown data operation.
+    """

--- a/clients/client-python/gravitino/audit/fileset_data_operation.py
+++ b/clients/client-python/gravitino/audit/fileset_data_operation.py
@@ -21,61 +21,61 @@ class FilesetDataOperation(Enum):
     """An enum class containing fileset data operations that supported."""
 
     CREATE = "CREATE"
-    """ This data operation means that create a new file.
+    """ Create a new file.
     """
 
     OPEN = "OPEN"
-    """This data operation means that open a file.
+    """Open a file.
     """
 
     APPEND = "APPEND"
-    """This data operation means that append some content into a file.
+    """Append some content into a file.
     """
 
     RENAME = "RENAME"
-    """This data operation means that rename a file or a directory.
+    """Rename a file or a directory.
     """
 
     DELETE = "DELETE"
-    """This data operation means that delete a file or a directory.
+    """Delete a file or a directory.
     """
 
     GET_FILE_STATUS = "GET_FILE_STATUS"
-    """This data operation means that get a file status from a file or a directory.
+    """Get a file status from a file or a directory.
     """
 
     LIST_STATUS = "LIST_STATUS"
-    """This data operation means that list file statuses under a directory.
+    """List file statuses under a directory.
     """
 
     MKDIRS = "MKDIRS"
-    """This data operation means that create a directory.
+    """Create a directory.
     """
 
     EXISTS = "EXISTS"
-    """This data operation means that check if a file or a directory exists.
+    """Check if a file or a directory exists.
     """
 
     CREATED_TIME = "CREATED_TIME"
-    """This data operation means that get the created time of a file.
+    """Get the created time of a file.
     """
 
     MODIFIED_TIME = "MODIFIED_TIME"
-    """This data operation means that get the modified time of a file.
+    """Get the modified time of a file.
     """
 
     COPY_FILE = "COPY_FILE"
-    """This data operation means that copy a file.
+    """Copy a file.
     """
 
     CAT_FILE = "CAT_FILE"
-    """This data operation means that get the content of a file.
+    """Get the content of a file.
     """
 
     GET_FILE = "GET_FILE"
-    """This data operation means that copy a remote file to local.
+    """Copy a remote file to local.
     """
 
     UNKNOWN = "UNKNOWN"
-    """This data operation means that it is an unknown data operation.
+    """Unknown data operation.
     """

--- a/clients/client-python/gravitino/audit/internal_client_type.py
+++ b/clients/client-python/gravitino/audit/internal_client_type.py
@@ -1,0 +1,35 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from enum import Enum
+
+
+class InternalClientType(Enum):
+    """An enum class containing internal client type that supported."""
+
+    HADOOP_GVFS = "HADOOP_GVFS"
+    """The client type is `org.apache.gravitino.filesystem.hadoop.GravitinoVirtualFileSystem` which in
+    the filesystem-hadoop3 module.
+    """
+
+    PYTHON_GVFS = "PYTHON_GVFS"
+    """The client type is `gravitino.filesystem.gvfs.GravitinoVirtualFileSystem` which in the
+    client-python module.
+    """
+
+    UNKNOWN = "UNKNOWN"
+    """The client type is unknown.
+    """

--- a/clients/client-python/gravitino/catalog/fileset_catalog.py
+++ b/clients/client-python/gravitino/catalog/fileset_catalog.py
@@ -234,6 +234,18 @@ class FilesetCatalog(BaseSchemaCatalog):
 
         return drop_resp.dropped()
 
+    def get_file_location(self, ident: NameIdentifier, sub_path: str) -> str:
+        """Get the actual location of a file or directory based on the storage location of Fileset and the sub path.
+
+        Args:
+             ident: A fileset identifier, which should be "schema.fileset" format.
+             sub_path: The sub path of the file or directory.
+
+        Returns:
+             The actual location of the file or directory.
+        """
+        raise NotImplementedError("Not implemented yet")
+
     @staticmethod
     def check_fileset_namespace(namespace: Namespace):
         Namespace.check(

--- a/clients/client-python/gravitino/dto/responses/file_location_response.py
+++ b/clients/client-python/gravitino/dto/responses/file_location_response.py
@@ -1,0 +1,42 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from dataclasses import dataclass, field
+
+from dataclasses_json import config
+from gravitino.dto.responses.base_response import BaseResponse
+from gravitino.exceptions.base import IllegalArgumentException
+
+
+@dataclass
+class FileLocationResponse(BaseResponse):
+    """Response for the actual file location."""
+
+    _file_location: str = field(metadata=config(field_name="fileLocation"))
+
+    def file_location(self) -> str:
+        return self._file_location
+
+    def validate(self):
+        """Validates the response data.
+
+        Raises:
+            IllegalArgumentException if file location is not set.
+        """
+        super().validate()
+        if self._file_location is None or len(self.file_location()) == 0:
+            raise IllegalArgumentException("file location must not be null")

--- a/clients/client-python/tests/unittests/audit/__init__.py
+++ b/clients/client-python/tests/unittests/audit/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/clients/client-python/tests/unittests/audit/test_caller_context.py
+++ b/clients/client-python/tests/unittests/audit/test_caller_context.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import threading
 import unittest
 from typing import Dict
 
@@ -23,12 +24,40 @@ from gravitino.audit.caller_context import CallerContextHolder, CallerContext
 class TestCallerContext(unittest.TestCase):
 
     def test_caller_context(self):
+        thread_names_and_values = [
+            ("Thread1", {"k1": "v1", "k2": "v2"}),
+            ("Thread2", {"k11": "v11", "k21": "v21"}),
+        ]
+        test_threads = []
+        for thread_name, value in thread_names_and_values:
+            t = threading.Thread(
+                target=self._set_thread_local_context, args=(thread_name, value)
+            )
+            t.start()
+            test_threads.append(t)
+
+        for t in test_threads:
+            t.join()
+
+    def _set_thread_local_context(self, thread_name, context: Dict[str, str]):
+        caller_context: CallerContext = CallerContext(context)
+        CallerContextHolder.set(caller_context)
+
         try:
-            context: Dict = {"k1": "v1", "k2": "v2"}
-            caller_context: CallerContext = CallerContext(context)
-            CallerContextHolder.set(caller_context)
-            self.assertEqual(CallerContextHolder.get().context()["k1"], context["k1"])
-            self.assertEqual(CallerContextHolder.get().context()["k2"], context["k2"])
+            if thread_name == "Thread1":
+                self.assertEqual(
+                    CallerContextHolder.get().context()["k1"], context["k1"]
+                )
+                self.assertEqual(
+                    CallerContextHolder.get().context()["k2"], context["k2"]
+                )
+            if thread_name == "Thread2":
+                self.assertEqual(
+                    CallerContextHolder.get().context()["k11"], context["k11"]
+                )
+                self.assertEqual(
+                    CallerContextHolder.get().context()["k21"], context["k21"]
+                )
         finally:
             CallerContextHolder.remove()
 

--- a/clients/client-python/tests/unittests/audit/test_caller_context.py
+++ b/clients/client-python/tests/unittests/audit/test_caller_context.py
@@ -1,0 +1,35 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import unittest
+from typing import Dict
+
+from gravitino.audit.caller_context import CallerContextHolder, CallerContext
+
+
+class TestCallerContext(unittest.TestCase):
+
+    def test_caller_context(self):
+        try:
+            context: Dict = {"k1": "v1", "k2": "v2"}
+            caller_context: CallerContext = CallerContext(context)
+            CallerContextHolder.set(caller_context)
+            self.assertEqual(CallerContextHolder.get().context()["k1"], context["k1"])
+            self.assertEqual(CallerContextHolder.get().context()["k2"], context["k2"])
+        finally:
+            CallerContextHolder.remove()
+
+        self.assertIsNone(CallerContextHolder.get())

--- a/clients/client-python/tests/unittests/test_responses.py
+++ b/clients/client-python/tests/unittests/test_responses.py
@@ -1,0 +1,41 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import json
+import unittest
+
+from gravitino.dto.responses.file_location_response import FileLocationResponse
+from gravitino.exceptions.base import IllegalArgumentException
+
+
+class TestResponses(unittest.TestCase):
+    def test_file_location_response(self):
+        json_data = {"code": 0, "fileLocation": "file:/test/1"}
+        json_str = json.dumps(json_data)
+        file_location_resp: FileLocationResponse = FileLocationResponse.from_json(
+            json_str
+        )
+        self.assertEqual(file_location_resp.file_location(), "file:/test/1")
+        file_location_resp.validate()
+
+    def test_file_location_response_exception(self):
+        json_data = {"code": 0, "fileLocation": ""}
+        json_str = json.dumps(json_data)
+        file_location_resp: FileLocationResponse = FileLocationResponse.from_json(
+            json_str
+        )
+        with self.assertRaises(IllegalArgumentException):
+            file_location_resp.validate()

--- a/common/src/main/java/org/apache/gravitino/audit/CallerContext.java
+++ b/common/src/main/java/org/apache/gravitino/audit/CallerContext.java
@@ -24,7 +24,7 @@ import com.google.common.base.Preconditions;
 import java.util.Map;
 
 /**
- * A class defining the caller context for auditing coarse granularity operations.
+ * A class defining the caller context for auditing coarse-grained operations.
  *
  * <p>Reference:
  *

--- a/common/src/main/java/org/apache/gravitino/audit/FilesetDataOperation.java
+++ b/common/src/main/java/org/apache/gravitino/audit/FilesetDataOperation.java
@@ -21,41 +21,41 @@ package org.apache.gravitino.audit;
 
 /** An enum class containing fileset data operations that supported. */
 public enum FilesetDataOperation {
-  /** This data operation means that create a new file. */
+  /** Create a new file. */
   CREATE,
-  /** This data operation means that open a file. */
+  /** Open a file. */
   OPEN,
-  /** This data operation means that append some content into a file. */
+  /** Append some content into a file. */
   APPEND,
-  /** This data operation means that rename a file or a directory. */
+  /** Rename a file or a directory. */
   RENAME,
-  /** This data operation means that delete a file or a directory. */
+  /** Delete a file or a directory. */
   DELETE,
-  /** This data operation means that get a file status from a file or a directory. */
+  /** Get a file status from a file or a directory. */
   GET_FILE_STATUS,
-  /** This data operation means that list file statuses under a directory. */
+  /** List file statuses under a directory. */
   LIST_STATUS,
-  /** This data operation means that create a directory. */
+  /** Create a directory. */
   MKDIRS,
-  /** This data operation means that get the default replication of a file system. */
+  /** Get the default replication of a file system. */
   GET_DEFAULT_REPLICATION,
-  /** This data operation means that get the default block size of a file system. */
+  /** Get the default block size of a file system. */
   GET_DEFAULT_BLOCK_SIZE,
-  /** This data operation means that set current working directory. */
+  /** Set current working directory. */
   SET_WORKING_DIR,
-  /** This data operation means that get the current working directory. */
+  /** Get the current working directory. */
   EXISTS,
-  /** This data operation means that get the created time of a file. */
+  /** Get the created time of a file. */
   CREATED_TIME,
-  /** This data operation means that get the modified time of a file. */
+  /** Get the modified time of a file. */
   MODIFIED_TIME,
-  /** This data operation means that copy a file. */
+  /** Copy a file. */
   COPY_FILE,
-  /** This data operation means that get the content of a file. */
+  /** Get the content of a file. */
   CAT_FILE,
-  /** This data operation means that copy a remote file to local. */
+  /** Copy a remote file to local. */
   GET_FILE,
-  /** This data operation means that it is an unknown data operation. */
+  /** Unknown data operation. */
   UNKNOWN;
 
   /**

--- a/common/src/main/java/org/apache/gravitino/audit/FilesetDataOperation.java
+++ b/common/src/main/java/org/apache/gravitino/audit/FilesetDataOperation.java
@@ -43,6 +43,18 @@ public enum FilesetDataOperation {
   GET_DEFAULT_BLOCK_SIZE,
   /** This data operation means that set current working directory. */
   SET_WORKING_DIR,
+  /** This data operation means that get the current working directory. */
+  EXISTS,
+  /** This data operation means that get the created time of a file. */
+  CREATED_TIME,
+  /** This data operation means that get the modified time of a file. */
+  MODIFIED_TIME,
+  /** This data operation means that copy a file. */
+  COPY_FILE,
+  /** This data operation means that get the content of a file. */
+  CAT_FILE,
+  /** This data operation means that copy a remote file to local. */
+  GET_FILE,
   /** This data operation means that it is an unknown data operation. */
   UNKNOWN;
 

--- a/common/src/main/java/org/apache/gravitino/audit/FilesetDataOperation.java
+++ b/common/src/main/java/org/apache/gravitino/audit/FilesetDataOperation.java
@@ -21,39 +21,39 @@ package org.apache.gravitino.audit;
 
 /** An enum class containing fileset data operations that supported. */
 public enum FilesetDataOperation {
-  /** Create a new file. */
+  /** Creates a new file. */
   CREATE,
-  /** Open a file. */
+  /** Opens a file. */
   OPEN,
-  /** Append some content into a file. */
+  /** Appends some content into a file. */
   APPEND,
-  /** Rename a file or a directory. */
+  /** Renames a file or a directory. */
   RENAME,
-  /** Delete a file or a directory. */
+  /** Deletes a file or a directory. */
   DELETE,
-  /** Get a file status from a file or a directory. */
+  /** Gets a file status from a file or a directory. */
   GET_FILE_STATUS,
-  /** List file statuses under a directory. */
+  /** Lists file statuses under a directory. */
   LIST_STATUS,
-  /** Create a directory. */
+  /** Creates a directory. */
   MKDIRS,
-  /** Get the default replication of a file system. */
+  /** Gets the default replication of a file system. */
   GET_DEFAULT_REPLICATION,
-  /** Get the default block size of a file system. */
+  /** Gets the default block size of a file system. */
   GET_DEFAULT_BLOCK_SIZE,
-  /** Set current working directory. */
+  /** Sets current working directory. */
   SET_WORKING_DIR,
-  /** Get the current working directory. */
+  /** Gets the current working directory. */
   EXISTS,
-  /** Get the created time of a file. */
+  /** Gets the created time of a file. */
   CREATED_TIME,
-  /** Get the modified time of a file. */
+  /** Gets the modified time of a file. */
   MODIFIED_TIME,
-  /** Copy a file. */
+  /** Copies a file. */
   COPY_FILE,
-  /** Get the content of a file. */
+  /** Gets the content of a file. */
   CAT_FILE,
-  /** Copy a remote file to local. */
+  /** Copies a remote file to local. */
   GET_FILE,
   /** Unknown data operation. */
   UNKNOWN;


### PR DESCRIPTION
### What changes were proposed in this pull request?

Added an interface code skeleton in Python Client for obtaining the file location so that the client can report some necessary information for the server to audit and simplify some check logics in Python GVFS later. Depend on #4320.

### Why are the changes needed?

Fix: #4279 

### How was this patch tested?

Add UTs and ITs.
