### PR TITLE
[#4389]  fix(iceberg-rest-server): add conf directory to classpath if starting standalone Iceberg REST catalog server in Gravitino package

### DIFF
--- a/bin/common.sh
+++ b/bin/common.sh
@@ -90,6 +90,12 @@ function addJarInDir(){
   fi
 }
 
+function addDirToClasspath(){
+  if [[ -d "${1}" ]]; then
+    GRAVITINO_CLASSPATH="${1}:${GRAVITINO_CLASSPATH}"
+  fi
+}
+
 if [[ -z "${GRAVITINO_MEM}" ]]; then
   export GRAVITINO_MEM="-Xmx1024m"
 fi

--- a/bin/gravitino-iceberg-rest-server.sh
+++ b/bin/gravitino-iceberg-rest-server.sh
@@ -180,6 +180,7 @@ fi
 
 if [ -d "${GRAVITINO_HOME}/iceberg-rest-server/libs" ]; then
   addJarInDir "${GRAVITINO_HOME}/iceberg-rest-server/libs"
+  addDirToClasspath "${GRAVITINO_HOME}/iceberg-rest-server/conf"
 else
   addJarInDir "${GRAVITINO_HOME}/libs"
 fi


### PR DESCRIPTION
### What changes were proposed in this pull request?
add conf directory to classpath if starting standalone Iceberg REST catalog server in Gravitino package

### Why are the changes needed?

Fix: #4389 

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
start Iceberg REST server and check classpath
