### PR TITLE
[#4153] fix(ui): Reset table props when reset tables data

### DIFF
--- a/web/src/lib/store/metalakes/index.js
+++ b/web/src/lib/store/metalakes/index.js
@@ -937,6 +937,7 @@ export const appMetalakesSlice = createSlice({
     },
     resetTableData(state, action) {
       state.tableData = []
+      state.tableProps = []
     },
     resetTree(state, action) {
       state.metalakeTree = []


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?
Root cause: It will reset when get a table details data, and need to reset table props too
Reset table props when reset tables data
<img width="1449" alt="image" src="https://github.com/user-attachments/assets/32feea3f-ff66-4d87-8a60-a71402e4eeb1">


### Why are the changes needed?
N/A

Fix: #4153

### Does this PR introduce _any_ user-facing change?
N/A

### How was this patch tested?
manually operated
