### PR TITLE
feat: Calls to code marked @VisibleForTesting in production code

### DIFF
--- a/catalogs/catalog-lakehouse-paimon/src/main/java/org/apache/gravitino/catalog/lakehouse/paimon/utils/CatalogUtils.java
+++ b/catalogs/catalog-lakehouse-paimon/src/main/java/org/apache/gravitino/catalog/lakehouse/paimon/utils/CatalogUtils.java
@@ -46,7 +46,6 @@ public class CatalogUtils {
 
   private CatalogUtils() {}
 
-  @VisibleForTesting
   public static PaimonBackendCatalogWrapper loadCatalogBackend(PaimonConfig paimonConfig) {
     Map<String, String> allConfig = paimonConfig.getAllConfig();
     AuthenticationConfig authenticationConfig = new AuthenticationConfig(allConfig);


### PR DESCRIPTION
# Issue -> https://github.com/apache/gravitino/issues/4408

# Pull Request Description

**Title:** feat: Calls to code marked @VisibleForTesting in production code

**Description:**
This pull request addresses an issue where code marked with `@VisibleForTesting` was being called in production code. The `@VisibleForTesting` annotation is typically used to indicate that a method or class should only be accessed from within test code, and its presence in production code can lead to unintended consequences or misuse.

**Changes:**
- Removed the `@VisibleForTesting` annotation from the `loadCatalogBackend` method in `CatalogUtils`.

**Impact:**
- This change ensures that the `loadCatalogBackend` method is clearly marked for use in both production and test environments, aligning with its current usage.

---

By addressing the use of `@VisibleForTesting` annotations in production, this pull request improves code clarity and maintainability. 
