### PR TITLE
[MINOR] Use Debian as gravitino basic image ,otherwise lack of basic tools like 'wget','apt-get'

### DIFF
--- a/dev/docker/gravitino/Dockerfile
+++ b/dev/docker/gravitino/Dockerfile
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-FROM openjdk:17
+FROM openjdk:17-jdk-buster
 LABEL maintainer="dev@gravitino.apache.org"
 
 WORKDIR /root/gravitino


### PR DESCRIPTION
### What changes were proposed in this pull request?

Use the linux distribution include basic tools like wget ,apt-get as basic image
The Debian linux distribution include basic tools like wget ,apt-get. While oracle linux use the YUM package manager, use yum command to install packages.

### Why are the changes needed?

Gravitino docker used to build based on Debian, change to oracle linux is not consistent.

openjdk:17 ,it build from oraclelinux:8-slim  
https://hub.docker.com/layers/library/openjdk/17/images/sha256-98f0304b3a3b7c12ce641177a99d1f3be56f532473a528fda38d53d519cafb13?context=explore

openjdk:17-jdk-buster, it build from debian:10, 10.12, buster, buster-20220418  https://hub.docker.com/layers/library/openjdk/17-jdk-buster/images/sha256-e462f39f589395ce928db22f3c8ea2ca83ade3f78a0227133b5ffebfa0289ab0?context=explore

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

Run script on local:
```
./dev/docker/build-docker.sh --platform all --type gravitino --image datastrato/gravitino --tag 0.6.0-SNAPSHOT-268 --latest
```