### PR TITLE
[#3929] fix(trino-connector): Fix the jdbc-postgresql/00004_query_pushdown.sql under catalog pg failed

### DIFF
--- a/integration-test/src/test/resources/trino-ci-testset/testsets/jdbc-postgresql/00004_query_pushdown.txt
+++ b/integration-test/src/test/resources/trino-ci-testset/testsets/jdbc-postgresql/00004_query_pushdown.txt
@@ -40,7 +40,7 @@ INSERT: 15000 rows
 
 "Trino version: %
 %
-    TableScan[table = gt_postgresql:gt_db1.orders->Query[SELECT % INNER JOIN %] limit=10 columns=%]
+    TableScan[table = gt_postgresql:gt_db1.%->Query[SELECT % INNER JOIN %] limit=10 columns=%]
 %
 "
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix the jdbc-postgresql/00004_query_pushdown.sql under catalog pg failed. Because the explain result of the join query has random left and right table. 

### Why are the changes needed?

Fix: #3929

### Does this PR introduce _any_ user-facing change?

NO

### How was this patch tested?

Exist testers
