### PR TITLE
[3844]fix(catalog-mysql) Add the version checking for the MYSQL JDBC driver

### DIFF
--- a/catalogs/catalog-jdbc-common/src/main/java/org/apache/gravitino/catalog/jdbc/MySQLProtocolCompatibleCatalogOperations.java
+++ b/catalogs/catalog-jdbc-common/src/main/java/org/apache/gravitino/catalog/jdbc/MySQLProtocolCompatibleCatalogOperations.java
@@ -33,6 +33,8 @@ public class MySQLProtocolCompatibleCatalogOperations extends JdbcCatalogOperati
   private static final Logger LOG =
       LoggerFactory.getLogger(MySQLProtocolCompatibleCatalogOperations.class);
 
+  private static final int MYSQL_JDBC_DRIVER_MINIMAL_SUPPORT_VERSION = 8;
+
   public MySQLProtocolCompatibleCatalogOperations(
       JdbcExceptionConverter exceptionConverter,
       JdbcTypeConverter jdbcTypeConverter,
@@ -45,6 +47,18 @@ public class MySQLProtocolCompatibleCatalogOperations extends JdbcCatalogOperati
         databaseOperation,
         tableOperation,
         columnDefaultValueConverter);
+  }
+
+  @Override
+  public boolean checkJDBCDriverVersion() {
+    JDBCDriverInfo driverInfo = getDiverInfo();
+    if (driverInfo.majorVersion < MYSQL_JDBC_DRIVER_MINIMAL_SUPPORT_VERSION) {
+      throw new RuntimeException(
+          String.format(
+              "Mysql catalog does not support the version %s, minimal required version is 8.0",
+              driverInfo.version));
+    }
+    return true;
   }
 
   @Override

--- a/catalogs/catalog-jdbc-common/src/main/java/org/apache/gravitino/catalog/jdbc/MySQLProtocolCompatibleCatalogOperations.java
+++ b/catalogs/catalog-jdbc-common/src/main/java/org/apache/gravitino/catalog/jdbc/MySQLProtocolCompatibleCatalogOperations.java
@@ -55,7 +55,7 @@ public class MySQLProtocolCompatibleCatalogOperations extends JdbcCatalogOperati
     if (driverInfo.majorVersion < MYSQL_JDBC_DRIVER_MINIMAL_SUPPORT_VERSION) {
       throw new RuntimeException(
           String.format(
-              "Mysql catalog does not support the version %s, minimal required version is 8.0",
+              "Mysql catalog does not support the jdbc driver version %s, minimal required version is 8.0",
               driverInfo.version));
     }
     return true;

--- a/catalogs/catalog-jdbc-mysql/src/test/java/org/apache/gravitino/catalog/mysql/operation/TestMysql.java
+++ b/catalogs/catalog-jdbc-mysql/src/test/java/org/apache/gravitino/catalog/mysql/operation/TestMysql.java
@@ -58,7 +58,7 @@ public class TestMysql extends TestJdbc {
         Collections.emptyMap());
   }
 
-  private static Map<String, String> getMySQLCatalogProperties() throws SQLException {
+  protected static Map<String, String> getMySQLCatalogProperties() throws SQLException {
     Map<String, String> catalogProperties = Maps.newHashMap();
 
     MySQLContainer mySQLContainer = containerSuite.getMySQLContainer();

--- a/catalogs/catalog-jdbc-mysql/src/test/java/org/apache/gravitino/catalog/mysql/operation/TestMysqlCatalogOperations.java
+++ b/catalogs/catalog-jdbc-mysql/src/test/java/org/apache/gravitino/catalog/mysql/operation/TestMysqlCatalogOperations.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog.mysql.operation;
+
+import java.sql.SQLException;
+import org.apache.gravitino.catalog.jdbc.MySQLProtocolCompatibleCatalogOperations;
+import org.apache.gravitino.catalog.mysql.MysqlCatalog;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("gravitino-docker-test")
+public class TestMysqlCatalogOperations extends TestMysql {
+
+  @Test
+  public void testCheckJDBCDriver() throws SQLException {
+    MySQLProtocolCompatibleCatalogOperations catalogOperations =
+        new MySQLProtocolCompatibleCatalogOperations(
+            null, null, DATABASE_OPERATIONS, TABLE_OPERATIONS, null);
+    catalogOperations.initialize(getMySQLCatalogProperties(), null, new MysqlCatalog());
+  }
+}


### PR DESCRIPTION

### What changes were proposed in this pull request?

Add the version checking for the MYSQL JDBC driver, if failed throw an exception

### Why are the changes needed?

Fix: #3844 

### Does this PR introduce _any_ user-facing change?

NO

### How was this patch tested?

UT and manually test
