### PR TITLE
[#4424] Improvement (trino-connector): Upgrade the Hive image version for the Trino tester.

### DIFF
--- a/.github/workflows/backend-integration-test.yml
+++ b/.github/workflows/backend-integration-test.yml
@@ -108,8 +108,7 @@ jobs:
             iceberg/iceberg-rest-server/build/*.log
             integration-test/build/*.log
             integration-test/build/*.tar
-            integration-test/build/trino-ci-container-log/hive/*.*
-            integration-test/build/trino-ci-container-log/hdfs/*.*
+            integration-test/build/trino-ci-container-log
             distribution/package/logs/*.out
             distribution/package/logs/*.log
             catalogs/**/*.log

--- a/.github/workflows/cron-integration-test.yml
+++ b/.github/workflows/cron-integration-test.yml
@@ -96,8 +96,7 @@ jobs:
             iceberg/iceberg-rest-server/build/*.log
             integration-test/build/*.log
             integration-test/build/*.tar
-            integration-test/build/trino-ci-container-log/hive/*.*
-            integration-test/build/trino-ci-container-log/hdfs/*.*
+            integration-test/build/trino-ci-container-log
             distribution/package/logs/*.out
             distribution/package/logs/*.log
             catalogs/**/*.log

--- a/integration-test/trino-it/docker-compose.yaml
+++ b/integration-test/trino-it/docker-compose.yaml
@@ -17,7 +17,6 @@
 # under the License.
 
 #
-version: '3.0'
 services:
 
   hive:
@@ -30,8 +29,6 @@ services:
     entrypoint:  /bin/bash /tmp/hive/init.sh
     volumes:
       - ./init/hive:/tmp/hive
-      - ../build/trino-ci-container-log/hive:/tmp/root
-      - ../build/trino-ci-container-log/hdfs:/usr/local/hadoop/logs
     healthcheck:
       test: ["CMD", "/tmp/check-status.sh"]
       interval: 10s

--- a/integration-test/trino-it/docker-compose.yaml
+++ b/integration-test/trino-it/docker-compose.yaml
@@ -21,7 +21,7 @@ version: '3.0'
 services:
 
   hive:
-    image: datastrato/gravitino-ci-hive:0.1.12
+    image: datastrato/gravitino-ci-hive:0.1.13
     networks:
       - trino-net
     container_name: trino-ci-hive

--- a/integration-test/trino-it/init/hive/init.sh
+++ b/integration-test/trino-it/init/hive/init.sh
@@ -19,6 +19,6 @@
 #
 
 IP=$(hostname -I | awk '{print $1}')
-sed -i "s|<value>hdfs://localhost:9000|<value>hdfs://${IP}:9000|g" /usr/local/hive/conf/hive-site.xml
+sed -i "s|<value>hdfs://__REPLACE__HOST_NAME:9000|<value>hdfs://${IP}:9000|g" ${HIVE_TMP_CONF_DIR}/hive-site.xml
 
 /bin/bash /usr/local/sbin/start.sh

--- a/integration-test/trino-it/launch.sh
+++ b/integration-test/trino-it/launch.sh
@@ -70,8 +70,3 @@ done
 
 
 echo "All docker compose service is now available."
-
-# change the hive container's logs directory permission
-docker exec trino-ci-hive chown -R `id -u`:`id -g` /tmp/root
-docker exec trino-ci-hive chown -R `id -u`:`id -g` /usr/local/hadoop/logs
-

--- a/integration-test/trino-it/shutdown.sh
+++ b/integration-test/trino-it/shutdown.sh
@@ -20,13 +20,8 @@
 #
 cd "$(dirname "$0")"
 
-# change the hive container's logs directory permission
-docker exec trino-ci-hive chown -R `id -u`:`id -g` /tmp/root
-docker exec trino-ci-hive chown -R `id -u`:`id -g` /usr/local/hadoop/logs
-
-# for trace file permission
-ls -l ../build/trino-ci-container-log
-ls -l ../build/trino-ci-container-log/hive
-ls -l ../build/trino-ci-container-log/hdfs
+LOG_DIR=../build/trino-ci-container-log
+docker cp trino-ci-hive:/usr/local/hadoop/logs $LOG_DIR/hdfs
+docker cp trino-ci-hive:/tmp/root $LOG_DIR/hive
 
 docker compose down


### PR DESCRIPTION

### What changes were proposed in this pull request?

Upgrade the Hive image version to 0.1.13 for the Trino tester.

### Why are the changes needed?

Fix: #4424 

### Does this PR introduce _any_ user-facing change?

NO

### How was this patch tested?

NO
