### PR TITLE
[#4439] fix: add **/*.out in list of exclusions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -466,6 +466,7 @@ tasks.rat {
     "dev/docker/**/*.conf",
     "dev/docker/kerberos-hive/kadm5.acl",
     "**/*.log",
+    "**/*.out",
     "**/testsets",
     "**/licenses/*.txt",
     "**/licenses/*.md",


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Add `**/*.out` to the list of exclusions will skip the licence check on the *.out file.

### Why are the changes needed?

Fix: #4439

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

No