### PR TITLE
[#4089] fix(hive catalog): the problem of slow acquisition of hive table list

### DIFF
--- a/catalogs/catalog-hive/src/main/java/org/apache/gravitino/catalog/hive/HiveCatalogOperations.java
+++ b/catalogs/catalog-hive/src/main/java/org/apache/gravitino/catalog/hive/HiveCatalogOperations.java
@@ -539,9 +539,12 @@ public class HiveCatalogOperations implements CatalogOperations, SupportsSchemas
       // those names we can obtain metadata for each individual table and get the type we needed.
       List<String> allTables = clientPool.run(c -> c.getAllTables(schemaIdent.name()));
       if (!listAllTables) {
-        // The reason for using the listTableNamesByFilter function is that the getTableObjectiesByName
-        // function has poor performance. Currently, we only focus on the iceberg table. In the future,
-        // if necessary, we will need to filter out other tables such as hudi. In addition, the current
+        // The reason for using the listTableNamesByFilter function is that the
+        // getTableObjectiesByName
+        // function has poor performance. Currently, we only focus on the iceberg table. In the
+        // future,
+        // if necessary, we will need to filter out other tables such as hudi. In addition, the
+        // current
         // return also includes tables of type VIRTUAL-VIEW.
         String filter =
             String.format(

--- a/catalogs/catalog-hive/src/main/java/org/apache/gravitino/catalog/hive/HiveCatalogOperations.java
+++ b/catalogs/catalog-hive/src/main/java/org/apache/gravitino/catalog/hive/HiveCatalogOperations.java
@@ -539,6 +539,10 @@ public class HiveCatalogOperations implements CatalogOperations, SupportsSchemas
       // those names we can obtain metadata for each individual table and get the type we needed.
       List<String> allTables = clientPool.run(c -> c.getAllTables(schemaIdent.name()));
       if (!listAllTables) {
+        // The reason for using the listTableNamesByFilter function is that the getTableObjectiesByName
+        // function has poor performance. Currently, we only focus on the iceberg table. In the future,
+        // if necessary, we will need to filter out other tables such as hudi. In addition, the current
+        // return also includes tables of type VIRTUAL-VIEW.
         String filter =
             String.format(
                 "%stable_type = \"ICEBERG\"", hive_metastoreConstants.HIVE_FILTER_FIELD_PARAMS);

--- a/catalogs/catalog-hive/src/main/java/org/apache/gravitino/catalog/hive/HiveCatalogOperations.java
+++ b/catalogs/catalog-hive/src/main/java/org/apache/gravitino/catalog/hive/HiveCatalogOperations.java
@@ -115,7 +115,10 @@ public class HiveCatalogOperations implements CatalogOperations, SupportsSchemas
   private ScheduledThreadPoolExecutor checkTgtExecutor;
   private String kerberosRealm;
   private ProxyPlugin proxyPlugin;
-  boolean listAllTables = true;
+  private boolean listAllTables = true;
+  // The maximum number of tables that can be returned by the listTableNamesByFilter function.
+  // The default value is -1, which means that all tables are returned.
+  private static final short MAX_TABLES = -1;
 
   // Map that maintains the mapping of keys in Gravitino to that in Hive, for example, users
   // will only need to set the configuration 'METASTORE_URL' in Gravitino and Gravitino will change
@@ -548,7 +551,7 @@ public class HiveCatalogOperations implements CatalogOperations, SupportsSchemas
             clientPool.run(
                 c ->
                     c.listTableNamesByFilter(
-                        schemaIdent.name(), icebergAndPaimonFilter, (short) -1));
+                        schemaIdent.name(), icebergAndPaimonFilter, MAX_TABLES));
         allTables.removeAll(icebergAndPaimonTables);
 
         // filter out the Hudi tables

--- a/catalogs/catalog-hive/src/main/java/org/apache/gravitino/catalog/hive/HiveCatalogOperations.java
+++ b/catalogs/catalog-hive/src/main/java/org/apache/gravitino/catalog/hive/HiveCatalogOperations.java
@@ -560,7 +560,7 @@ public class HiveCatalogOperations implements CatalogOperations, SupportsSchemas
                 "%sprovider like \"hudi\"", hive_metastoreConstants.HIVE_FILTER_FIELD_PARAMS);
         List<String> hudiTables =
             clientPool.run(
-                c -> c.listTableNamesByFilter(schemaIdent.name(), hudiFilter, (short) -1));
+                c -> c.listTableNamesByFilter(schemaIdent.name(), hudiFilter, MAX_TABLES));
         removeHudiTables(allTables, hudiTables);
       }
       return allTables.stream()

--- a/catalogs/catalog-hive/src/test/java/org/apache/gravitino/catalog/hive/integration/test/CatalogHiveIT.java
+++ b/catalogs/catalog-hive/src/test/java/org/apache/gravitino/catalog/hive/integration/test/CatalogHiveIT.java
@@ -52,6 +52,7 @@ import org.apache.gravitino.Catalog;
 import org.apache.gravitino.CatalogChange;
 import org.apache.gravitino.MetalakeChange;
 import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.Namespace;
 import org.apache.gravitino.Schema;
 import org.apache.gravitino.SchemaChange;
 import org.apache.gravitino.SupportsSchemas;
@@ -611,6 +612,21 @@ public class CatalogHiveIT extends BaseIT {
               tableCatalog.alterTable(id, change);
             });
     Assertions.assertTrue(exception.getMessage().contains("cannot be set"));
+  }
+
+  @Test
+  public void testListTables() {
+    // mock iceberg table and hudi table
+    NameIdentifier icebergTable = NameIdentifier.of(schemaName, "iceberg_table");
+    NameIdentifier hudiTable = NameIdentifier.of(schemaName, "hudi_table");
+    catalog
+        .asTableCatalog()
+        .createTable(icebergTable, createColumns(), null, ImmutableMap.of("table_type", "ICEBERG"));
+    catalog
+        .asTableCatalog()
+        .createTable(hudiTable, createColumns(), null, ImmutableMap.of("provider", "hudi"));
+    NameIdentifier[] tables = catalog.asTableCatalog().listTables(Namespace.of(schemaName));
+    Assertions.assertEquals(0, tables.length);
   }
 
   @Test

--- a/catalogs/catalog-hive/src/test/java/org/apache/gravitino/catalog/hive/integration/test/CatalogHiveIT.java
+++ b/catalogs/catalog-hive/src/test/java/org/apache/gravitino/catalog/hive/integration/test/CatalogHiveIT.java
@@ -616,12 +616,16 @@ public class CatalogHiveIT extends BaseIT {
 
   @Test
   public void testListTables() {
-    // mock iceberg table and hudi table
+    // mock iceberg, paimon, and hudi tables
     NameIdentifier icebergTable = NameIdentifier.of(schemaName, "iceberg_table");
+    NameIdentifier paimonTable = NameIdentifier.of(schemaName, "paimon_table");
     NameIdentifier hudiTable = NameIdentifier.of(schemaName, "hudi_table");
     catalog
         .asTableCatalog()
         .createTable(icebergTable, createColumns(), null, ImmutableMap.of("table_type", "ICEBERG"));
+    catalog
+        .asTableCatalog()
+        .createTable(paimonTable, createColumns(), null, ImmutableMap.of("table_type", "PAIMON"));
     catalog
         .asTableCatalog()
         .createTable(hudiTable, createColumns(), null, ImmutableMap.of("provider", "hudi"));

--- a/docs/apache-hive-catalog.md
+++ b/docs/apache-hive-catalog.md
@@ -44,7 +44,10 @@ Besides the [common catalog properties](./gravitino-server-config.md#gravitino-c
 | `list-all-tables`                        | Lists all tables in a database, including non-Hive tables, such as Iceberg, Hudi, etc.                                                                                                                                                              | false         | No                           | 0.5.1         |
 
 :::note
-For `list-all-tables=false`, the Hive catalog will filter out Iceberg tables by table property `table_type=ICEBERG` and filter out Hudi tables by table property `provider=hudi`.
+For `list-all-tables=false`, the Hive catalog will filter out:
+- Iceberg tables by table property `table_type=ICEBERG`
+- Paimon tables by table property `table_type=PAINMON`
+- Hudi tables by table property `provider=hudi`
 :::
 
 When you use the Gravitino with Trino. You can pass the Trino Hive connector configuration using prefix `trino.bypass.`. For example, using `trino.bypass.hive.config.resources` to pass the `hive.config.resources` to the Gravitino Hive catalog in Trino runtime.

--- a/docs/apache-hive-catalog.md
+++ b/docs/apache-hive-catalog.md
@@ -41,7 +41,11 @@ Besides the [common catalog properties](./gravitino-server-config.md#gravitino-c
 | `kerberos.keytab-uri`                    | The uri of key tab for the catalog. Now supported protocols are `https`, `http`, `ftp`, `file`.                                                                                                                                                     | (none)        | required if you use kerberos | 0.4.0         |
 | `kerberos.check-interval-sec`            | The interval to check validness of the principal                                                                                                                                                                                                    | 60            | No                           | 0.4.0         |
 | `kerberos.keytab-fetch-timeout-sec`      | The timeout to fetch key tab                                                                                                                                                                                                                        | 60            | No                           | 0.4.0         |
-| `list-all-tables`                        | Lists all tables in a database, including non-Hive tables, such as Iceberg, etc                                                                                                                                                                     | false         | No                           | 0.5.1         |
+| `list-all-tables`                        | Lists all tables in a database, including non-Hive tables, such as Iceberg, Hudi, etc.                                                                                                                                                              | false         | No                           | 0.5.1         |
+
+:::note
+For `list-all-tables=false`, the Hive catalog will filter out Iceberg tables by table property `table_type=ICEBERG` and filter out Hudi tables by table property `provider=hudi`.
+:::
 
 When you use the Gravitino with Trino. You can pass the Trino Hive connector configuration using prefix `trino.bypass.`. For example, using `trino.bypass.hive.config.resources` to pass the `hive.config.resources` to the Gravitino Hive catalog in Trino runtime.
 


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

the problem of slow acquisition of hive table list.
Using listTableNamesByFilter replace the getTableObjectsByName method.


### Why are the changes needed?

I found that list-table will takes 300s when a schema has 5000 tables .

Fix: #4089 

### Does this PR introduce _any_ user-facing change?

no

### How was this patch tested?

Manual testing
