### PR TITLE
[#4530] improvement(kafka-catalog): reduce kafka catalog libs size from 91MB to 17MB

### DIFF
--- a/catalogs/catalog-kafka/build.gradle.kts
+++ b/catalogs/catalog-kafka/build.gradle.kts
@@ -65,7 +65,11 @@ tasks {
 
   val copyCatalogLibs by registering(Copy::class) {
     dependsOn(jar, runtimeJars)
-    from("build/libs")
+    from("build/libs") {
+      exclude("guava-*.jar")
+      exclude("log4j-*.jar")
+      exclude("slf4j-*.jar")
+    }
     into("$rootDir/distribution/package/catalogs/kafka/libs")
   }
 

--- a/catalogs/catalog-kafka/build.gradle.kts
+++ b/catalogs/catalog-kafka/build.gradle.kts
@@ -25,9 +25,15 @@ plugins {
 }
 
 dependencies {
-  implementation(project(":api"))
-  implementation(project(":core"))
-  implementation(project(":common"))
+  implementation(project(":api")) {
+    exclude("*")
+  }
+  implementation(project(":core")) {
+    exclude("*")
+  }
+  implementation(project(":common")) {
+    exclude("*")
+  }
 
   testImplementation(project(":clients:client-java"))
   testImplementation(project(":integration-test-common", "testArtifacts"))


### PR DESCRIPTION
### What changes were proposed in this pull request?

remove some unnecessary dependencies

### Why are the changes needed?

Fix: #4530 

### Does this PR introduce _any_ user-facing change?

no

### How was this patch tested?

CI passed
