### PR TITLE
[#4525] improvement(catalog-hadoop): Shrink Hadoop catalog binary package size.

### DIFF
--- a/catalogs/catalog-hadoop/build.gradle.kts
+++ b/catalogs/catalog-hadoop/build.gradle.kts
@@ -25,11 +25,17 @@ plugins {
 }
 
 dependencies {
-  implementation(project(":api"))
-  implementation(project(":core"))
-  implementation(project(":common"))
+  implementation(project(":api")) {
+    exclude(group = "*")
+  }
 
-  implementation(libs.guava)
+  implementation(project(":core")) {
+    exclude(group = "*")
+  }
+  implementation(project(":common")) {
+    exclude(group = "*")
+  }
+
   implementation(libs.hadoop3.common) {
     exclude("com.sun.jersey")
     exclude("javax.servlet", "servlet-api")
@@ -38,8 +44,15 @@ dependencies {
   implementation(libs.hadoop3.hdfs) {
     exclude("com.sun.jersey")
     exclude("javax.servlet", "servlet-api")
+    exclude("com.google.guava", "guava")
+    exclude("commons-io", "commons-io")
   }
-  implementation(libs.hadoop3.client)
+  implementation(libs.hadoop3.client) {
+    exclude("org.apache.hadoop", "hadoop-mapreduce-client-core")
+    exclude("org.apache.hadoop", "hadoop-mapreduce-client-jobclient")
+    exclude("org.apache.hadoop", "hadoop-yarn-api")
+    exclude("org.apache.hadoop", "hadoop-yarn-client")
+  }
 
   implementation(libs.slf4j.api)
 


### PR DESCRIPTION


### What changes were proposed in this pull request?

Remove some unused dependencies to reduce hadoop catalog package size to 44MB

### Why are the changes needed?

Reduce the size of the total release package. 

Fix: #4525 

### Does this PR introduce _any_ user-facing change?

N/A.

### How was this patch tested?

Exist UT and IT.
