### PR TITLE
[#4540] fix(core): Support alter tag with null comment

### DIFF
--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/TagMetaMapper.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/TagMetaMapper.java
@@ -162,7 +162,7 @@ public interface TagMetaMapper {
           + " WHERE tag_id = #{oldTagMeta.tagId}"
           + " AND metalake_id = #{oldTagMeta.metalakeId}"
           + " AND tag_name = #{oldTagMeta.tagName}"
-          + " AND tag_comment = #{oldTagMeta.comment}"
+          + " AND (tag_comment IS NULL OR tag_comment = #{oldTagMeta.comment})"
           + " AND properties = #{oldTagMeta.properties}"
           + " AND audit_info = #{oldTagMeta.auditInfo}"
           + " AND current_version = #{oldTagMeta.currentVersion}"

--- a/integration-test/src/test/java/org/apache/gravitino/integration/test/TagIT.java
+++ b/integration-test/src/test/java/org/apache/gravitino/integration/test/TagIT.java
@@ -251,8 +251,9 @@ public class TagIT extends AbstractIT {
     TagChange setProperty4 = TagChange.setProperty("k5", "v5");
     TagChange removeProperty3 = TagChange.removeProperty("k4");
 
-    Tag alteredTag5 = metalake.alterTag(
-        tagName1, rename1, updateComment1, setProperty3, setProperty4, removeProperty3);
+    Tag alteredTag5 =
+        metalake.alterTag(
+            tagName1, rename1, updateComment1, setProperty3, setProperty4, removeProperty3);
     Assertions.assertEquals(newTagName1, alteredTag5.name());
     Assertions.assertEquals("new comment1", alteredTag5.comment());
     Assertions.assertEquals(ImmutableMap.of("k5", "v5"), alteredTag5.properties());

--- a/integration-test/src/test/java/org/apache/gravitino/integration/test/TagIT.java
+++ b/integration-test/src/test/java/org/apache/gravitino/integration/test/TagIT.java
@@ -182,6 +182,16 @@ public class TagIT extends AbstractIT {
     Set<Tag> tags = Sets.newHashSet(metalake.listTagsInfo());
     Set<Tag> expectedTags = Sets.newHashSet(tag, tag1);
     Assertions.assertEquals(expectedTags, tags);
+
+    // Test null comment and properties
+    String tagName2 = GravitinoITUtils.genRandomName("tag_it_tag2");
+    Tag tag2 = metalake.createTag(tagName2, null, null);
+    Assertions.assertEquals(tagName2, tag2.name());
+    Assertions.assertNull(tag2.comment());
+    Assertions.assertEquals(Collections.emptyMap(), tag2.properties());
+
+    Tag tag3 = metalake.getTag(tagName2);
+    Assertions.assertEquals(tag2, tag3);
   }
 
   @Test
@@ -228,6 +238,25 @@ public class TagIT extends AbstractIT {
     // Test throw NoSuchTagException
     Assertions.assertThrows(
         NoSuchTagException.class, () -> metalake.alterTag("non-existed-tag", rename));
+
+    // Test alter tag on no comment and properties
+    String tagName1 = GravitinoITUtils.genRandomName("tag_it_tag1");
+    metalake.createTag(tagName1, null, null);
+
+    // Test rename and update comment
+    String newTagName1 = GravitinoITUtils.genRandomName("tag_it_tag_new1");
+    TagChange rename1 = TagChange.rename(newTagName1);
+    TagChange updateComment1 = TagChange.updateComment("new comment1");
+    TagChange setProperty3 = TagChange.setProperty("k4", "v4");
+    TagChange setProperty4 = TagChange.setProperty("k5", "v5");
+    TagChange removeProperty3 = TagChange.removeProperty("k4");
+
+    Tag alteredTag5 = metalake.alterTag(
+        tagName1, rename1, updateComment1, setProperty3, setProperty4, removeProperty3);
+    Assertions.assertEquals(newTagName1, alteredTag5.name());
+    Assertions.assertEquals("new comment1", alteredTag5.comment());
+    Assertions.assertEquals(ImmutableMap.of("k5", "v5"), alteredTag5.properties());
+    Assertions.assertFalse(alteredTag5.inherited().isPresent());
   }
 
   @Test


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add NULL check for tag comment 

### Why are the changes needed?

Fix: #4540 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Add IT.
