### PR TITLE
[#4542] fix(catalog-postgresql): Fix the problem that Gravitino is unable to drop upper-case PG schema.

### DIFF
--- a/catalogs/catalog-jdbc-postgresql/src/main/java/org/apache/gravitino/catalog/postgresql/operation/PostgreSqlSchemaOperations.java
+++ b/catalogs/catalog-jdbc-postgresql/src/main/java/org/apache/gravitino/catalog/postgresql/operation/PostgreSqlSchemaOperations.java
@@ -151,7 +151,8 @@ public class PostgreSqlSchemaOperations extends JdbcDatabaseOperations {
 
   @Override
   public String generateDropDatabaseSql(String schema, boolean cascade) {
-    StringBuilder sqlBuilder = new StringBuilder(String.format("DROP SCHEMA %s", schema));
+    StringBuilder sqlBuilder =
+        new StringBuilder(String.format("DROP SCHEMA %s%s%s", PG_QUOTE, schema, PG_QUOTE));
     if (cascade) {
       sqlBuilder.append(" CASCADE");
     }

--- a/catalogs/catalog-jdbc-postgresql/src/test/java/org/apache/gravitino/catalog/postgresql/integration/test/CatalogPostgreSqlIT.java
+++ b/catalogs/catalog-jdbc-postgresql/src/test/java/org/apache/gravitino/catalog/postgresql/integration/test/CatalogPostgreSqlIT.java
@@ -324,6 +324,17 @@ public class CatalogPostgreSqlIT extends AbstractIT {
     Optional<Column> column =
         Arrays.stream(t.columns()).filter(c -> c.name().equals("binary")).findFirst();
     Assertions.assertTrue(column.isPresent());
+
+    boolean result = tableCatalog.dropTable(tableIdentifier);
+    Assertions.assertTrue(result);
+
+    Assertions.assertThrows(Exception.class, () -> tableCatalog.loadTable(tableIdentifier));
+
+    // Test drop schema with upper-case name
+    result = catalog.asSchemas().dropSchema(schemaN, false);
+
+    // Test whether drop the schema succussfully.
+    Assertions.assertTrue(result);
   }
 
   private Map<String, String> createProperties() {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Double quote the schema name in the drop sentence to support removing upper-case schema 

### Why are the changes needed?

It's a bug. 

Fix: #4542 

### Does this PR introduce _any_ user-facing change?

N/A.

### How was this patch tested?

Add IT.