### PR TITLE
[#4506] fix(UI): Hide jdbc-password value in details page

### DIFF
--- a/web/src/app/metalakes/metalake/rightContent/tabsContent/detailsView/DetailsView.js
+++ b/web/src/app/metalakes/metalake/rightContent/tabsContent/detailsView/DetailsView.js
@@ -196,7 +196,7 @@ const DetailsView = () => {
                                 : `props-value-${item.key}`
                             }
                           >
-                            {item.value}
+                            {item.key === 'jdbc-password' ? '[HIDDEN]' : item.value}
                           </div>
                         </Typography>
                       </TableCell>

--- a/web/src/components/DetailsDrawer.js
+++ b/web/src/components/DetailsDrawer.js
@@ -206,7 +206,7 @@ const DetailsDrawer = props => {
                         data-refer={`details-props-value-${item.value}`}
                         data-prev-refer={`details-props-key-${item.key}`}
                       >
-                        {item.value}
+                        {item.key === 'jdbc-password' ? '[HIDDEN]' : item.value}
                       </TableCell>
                     </TableRow>
                   )


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Hide jdbc-password value in details page.

### Why are the changes needed?

Fix: #4506 

### Does this PR introduce _any_ user-facing change?

Jdbc-password value is not palintext now.

### How was this patch tested?

![Screenshot from 2024-08-16 15-31-53](https://github.com/user-attachments/assets/75cb2a83-8145-41be-9be5-19a7a4add336)
![Screenshot from 2024-08-16 15-21-04](https://github.com/user-attachments/assets/63e34fee-fef1-4fa6-a93c-ac028b2d04b3)
