### PR TITLE
[#4583] improvement(CI): reduce Backend Integration Test jobs

### DIFF
--- a/.github/workflows/backend-integration-test.yml
+++ b/.github/workflows/backend-integration-test.yml
@@ -51,18 +51,23 @@ jobs:
     outputs:
       source_changes: ${{ steps.filter.outputs.source_changes }}
 
-  # Integration test for AMD64 architecture
-  test-amd64-arch:
+  test-on-push:
     needs: changes
-    if: needs.changes.outputs.source_changes == 'true'
+    if: (github.event_name == 'push' && needs.changes.outputs.source_changes == 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:
       matrix:
+        # Integration test for AMD64 architecture
         architecture: [linux/amd64]
         java-version: [ 8, 11, 17 ]
         test-mode: [ embedded, deploy ]
-        backend: [ mysql, h2]
+        include:
+          - test-mode: 'embedded'
+            backend: 'h2'
+          - test-mode: 'deploy'
+            backend: 'mysql'
+
     env:
       PLATFORM: ${{ matrix.architecture }}
     steps:
@@ -83,6 +88,75 @@ jobs:
 
       - name: Package Gravitino
         if : ${{ matrix.test-mode == 'deploy' }}
+        run: |
+          ./gradlew compileDistribution -x test -PjdkVersion=${{ matrix.java-version }}
+
+      - name: Free up disk space
+        run: |
+          dev/ci/util_free_space.sh
+
+      - name: Backend Integration Test
+        id: integrationTest
+        run: >
+          ./gradlew test -PskipTests -PtestMode=${{ matrix.test-mode }} -PjdkVersion=${{ matrix.java-version }} -P${{ matrix.backend }} -PskipWebITs -PskipDockerTests=false
+          -x :web:test -x :clients:client-python:test -x :flink-connector:test -x :spark-connector:test -x :spark-connector:spark-common:test 
+          -x :spark-connector:spark-3.3:test -x :spark-connector:spark-3.4:test -x :spark-connector:spark-3.5:test 
+          -x :spark-connector:spark-runtime-3.3:test -x :spark-connector:spark-runtime-3.4:test -x :spark-connector:spark-runtime-3.5:test
+
+      - name: Upload integrate tests reports
+        uses: actions/upload-artifact@v3
+        if: ${{ (failure() && steps.integrationTest.outcome == 'failure') || contains(github.event.pull_request.labels.*.name, 'upload log') }}
+        with:
+          name: integrate-test-reports-${{ matrix.java-version }}-${{ matrix.test-mode }}-${{ matrix.backend }}
+          path: |
+            build/reports
+            iceberg/iceberg-rest-server/build/*.log
+            integration-test/build/*.log
+            integration-test/build/*.tar
+            integration-test/build/trino-ci-container-log
+            distribution/package/logs/*.out
+            distribution/package/logs/*.log
+            catalogs/**/*.log
+            catalogs/**/*.tar
+            distribution/**/*.log
+
+  test-on-pr:
+    needs: changes
+    if: (github.event_name == 'pull_request' && needs.changes.outputs.source_changes == 'true')
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    strategy:
+      matrix:
+        # Integration test for AMD64 architecture
+        architecture: [ linux/amd64 ]
+        java-version: [ 17 ]
+        test-mode: [ embedded, deploy ]
+        include:
+          - test-mode: 'embedded'
+            backend: 'h2'
+          - test-mode: 'deploy'
+            backend: 'mysql'
+
+    env:
+      PLATFORM: ${{ matrix.architecture }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-java@v4
+        with:
+          java-version: ${{ matrix.java-version }}
+          distribution: 'temurin'
+          cache: 'gradle'
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Check required command
+        run: |
+          dev/ci/check_commands.sh
+
+      - name: Package Gravitino
+        if: ${{ matrix.test-mode == 'deploy' }}
         run: |
           ./gradlew compileDistribution -x test -PjdkVersion=${{ matrix.java-version }}
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

 - run h2 backend tests only if test-mode is embedded
 - run mysql backend tests only if test-mode is deploy
 - if it's a PR triggered, run jdk17 only
 - run multiple JDKs only if PR merged to main or branch-*

### Why are the changes needed?

Fix: #4583 

### Does this PR introduce _any_ user-facing change?

no

### How was this patch tested?

CI passed
