### PR TITLE
[#4586] fix(filesystem): Fix convert the actual path which storage location end with slash

### DIFF
--- a/clients/client-python/gravitino/filesystem/gvfs.py
+++ b/clients/client-python/gravitino/filesystem/gvfs.py
@@ -658,9 +658,11 @@ class GravitinoVirtualFileSystem(fsspec.AbstractFileSystem):
             sub_path = virtual_path[len(virtual_location) :]
             # For example, if the virtual path is `gvfs://fileset/catalog/schema/test_fileset/ttt`,
             # and the storage location is `hdfs://cluster:8020/user/`,
-            # we should replace `gvfs://fileset/catalog/schema/test_fileset` with `hdfs://localhost:8020/`.
+            # we should replace `gvfs://fileset/catalog/schema/test_fileset`
+            # with `hdfs://localhost:8020/user` which truncates the tailing slash.
             # If the storage location is `hdfs://cluster:8020/user`,
-            # we can replace `gvfs://fileset/catalog/schema/test_fileset` with `hdfs://localhost:8020` directly.
+            # we can replace `gvfs://fileset/catalog/schema/test_fileset`
+            # with `hdfs://localhost:8020/user` directly.
             if sub_path.startswith(self.SLASH):
                 new_storage_location = storage_location[:-1]
             else:

--- a/clients/client-python/tests/unittests/test_gvfs_with_local.py
+++ b/clients/client-python/tests/unittests/test_gvfs_with_local.py
@@ -17,7 +17,7 @@ specific language governing permissions and limitations
 under the License.
 """
 
-# pylint: disable=protected-access,too-many-lines
+# pylint: disable=protected-access,too-many-lines,too-many-locals
 
 import base64
 import os
@@ -25,6 +25,7 @@ import random
 import string
 import time
 import unittest
+from unittest import mock
 from unittest.mock import patch
 
 import pandas
@@ -34,7 +35,7 @@ import pyarrow.parquet as pq
 from fsspec.implementations.local import LocalFileSystem
 from llama_index.core import SimpleDirectoryReader
 
-from gravitino import gvfs
+from gravitino import gvfs, Fileset
 from gravitino import NameIdentifier
 from gravitino.auth.auth_constants import AuthConstants
 from gravitino.dto.audit_dto import AuditDTO
@@ -796,6 +797,44 @@ class TestLocalFilesystem(unittest.TestCase):
             "fileset/test_catalog/test_schema/test_f1/actual_path", virtual_path
         )
 
+        # test storage location without "/"
+        actual_path = "/tmp/test_convert_actual_path/sub_dir/1.parquet"
+        storage_location1 = "file:/tmp/test_convert_actual_path"
+        mock_fileset1: Fileset = mock.Mock(spec=Fileset)
+        mock_fileset1.storage_location.return_value = storage_location1
+
+        mock_fileset_context1: FilesetContext = mock.Mock(spec=FilesetContext)
+        mock_fileset_context1.get_storage_type.return_value = StorageType.LOCAL
+        mock_fileset_context1.get_name_identifier.return_value = NameIdentifier.of(
+            "test_metalake", "catalog", "schema", "test_convert_actual_path"
+        )
+        mock_fileset_context1.get_fileset.return_value = mock_fileset1
+
+        virtual_path = fs._convert_actual_path(actual_path, mock_fileset_context1)
+        self.assertEqual(
+            "fileset/catalog/schema/test_convert_actual_path/sub_dir/1.parquet",
+            virtual_path,
+        )
+
+        # test storage location with "/"
+        actual_path = "/tmp/test_convert_actual_path/sub_dir/1.parquet"
+        storage_location2 = "file:/tmp/test_convert_actual_path/"
+        mock_fileset2: Fileset = mock.Mock(spec=Fileset)
+        mock_fileset2.storage_location.return_value = storage_location2
+
+        mock_fileset_context2: FilesetContext = mock.Mock(spec=FilesetContext)
+        mock_fileset_context2.get_storage_type.return_value = StorageType.LOCAL
+        mock_fileset_context2.get_name_identifier.return_value = NameIdentifier.of(
+            "test_metalake", "catalog", "schema", "test_convert_actual_path"
+        )
+        mock_fileset_context2.get_fileset.return_value = mock_fileset2
+
+        virtual_path = fs._convert_actual_path(actual_path, mock_fileset_context2)
+        self.assertEqual(
+            "fileset/catalog/schema/test_convert_actual_path/sub_dir/1.parquet",
+            virtual_path,
+        )
+
     def test_convert_info(self, *mock_methods3):
         # test convert actual hdfs path
         audit_dto = AuditDTO(
@@ -1031,3 +1070,107 @@ class TestLocalFilesystem(unittest.TestCase):
                 self.assertEqual(row[1], "19")
             elif row[0] == "D":
                 self.assertEqual(row[1], "18")
+
+    @patch(
+        "gravitino.catalog.fileset_catalog.FilesetCatalog.load_fileset",
+        return_value=mock_base.mock_load_fileset(
+            "test_location_with_tailing_slash",
+            f"{_fileset_dir}/test_location_with_tailing_slash/",
+        ),
+    )
+    def test_location_with_tailing_slash(self, *mock_methods):
+        local_fs = LocalFileSystem()
+        # storage location is ending with a "/"
+        fileset_storage_location = (
+            f"{self._fileset_dir}/test_location_with_tailing_slash/"
+        )
+        fileset_virtual_location = (
+            "fileset/fileset_catalog/tmp/test_location_with_tailing_slash"
+        )
+        local_fs.mkdir(fileset_storage_location)
+        sub_dir_path = f"{fileset_storage_location}test_1"
+        local_fs.mkdir(sub_dir_path)
+        self.assertTrue(local_fs.exists(sub_dir_path))
+        sub_file_path = f"{sub_dir_path}/test_file_1.par"
+        local_fs.touch(sub_file_path)
+        self.assertTrue(local_fs.exists(sub_file_path))
+
+        fs = gvfs.GravitinoVirtualFileSystem(
+            server_uri="http://localhost:9090", metalake_name="metalake_demo"
+        )
+        self.assertTrue(fs.exists(fileset_virtual_location))
+
+        dir_virtual_path = fileset_virtual_location + "/test_1"
+        dir_info = fs.info(dir_virtual_path)
+        self.assertEqual(dir_info["name"], dir_virtual_path)
+
+        file_virtual_path = fileset_virtual_location + "/test_1/test_file_1.par"
+        file_info = fs.info(file_virtual_path)
+        self.assertEqual(file_info["name"], file_virtual_path)
+
+        file_status = fs.ls(fileset_virtual_location, detail=True)
+        for status in file_status:
+            if status["name"].endswith("test_1"):
+                self.assertEqual(status["name"], dir_virtual_path)
+            elif status["name"].endswith("test_file_1.par"):
+                self.assertEqual(status["name"], file_virtual_path)
+            else:
+                raise GravitinoRuntimeException("Unexpected file found")
+
+    def test_get_actual_path_by_ident(self, *mock_methods):
+        ident1 = NameIdentifier.of(
+            "test_metalake", "catalog", "schema", "test_get_actual_path_by_ident"
+        )
+        storage_type = gvfs.StorageType.LOCAL
+        local_fs = LocalFileSystem()
+
+        fs = gvfs.GravitinoVirtualFileSystem(
+            server_uri="http://localhost:9090", metalake_name="metalake_demo"
+        )
+
+        # test storage location end with "/"
+        storage_location_1 = f"{self._fileset_dir}/test_get_actual_path_by_ident/"
+        # virtual path end with "/"
+        virtual_path1 = "fileset/catalog/schema/test_get_actual_path_by_ident/"
+        local_fs.mkdir(storage_location_1)
+        self.assertTrue(local_fs.exists(storage_location_1))
+
+        mock_fileset1: Fileset = mock.Mock(spec=Fileset)
+        mock_fileset1.storage_location.return_value = storage_location_1
+
+        actual_path1 = fs._get_actual_path_by_ident(
+            ident1, mock_fileset1, local_fs, storage_type, virtual_path1
+        )
+        self.assertEqual(actual_path1, storage_location_1)
+
+        # virtual path end without "/"
+        virtual_path2 = "fileset/catalog/schema/test_get_actual_path_by_ident"
+        actual_path2 = fs._get_actual_path_by_ident(
+            ident1, mock_fileset1, local_fs, storage_type, virtual_path2
+        )
+        self.assertEqual(actual_path2, storage_location_1)
+
+        # test storage location end without "/"
+        ident2 = NameIdentifier.of(
+            "test_metalake", "catalog", "schema", "test_without_slash"
+        )
+        storage_location_2 = f"{self._fileset_dir}/test_without_slash"
+        # virtual path end with "/"
+        virtual_path3 = "fileset/catalog/schema/test_without_slash/"
+        local_fs.mkdir(storage_location_2)
+        self.assertTrue(local_fs.exists(storage_location_2))
+
+        mock_fileset2: Fileset = mock.Mock(spec=Fileset)
+        mock_fileset2.storage_location.return_value = storage_location_2
+
+        actual_path3 = fs._get_actual_path_by_ident(
+            ident2, mock_fileset2, local_fs, storage_type, virtual_path3
+        )
+        self.assertEqual(actual_path3, f"{storage_location_2}/")
+
+        # virtual path end without "/"
+        virtual_path4 = "fileset/catalog/schema/test_without_slash"
+        actual_path4 = fs._get_actual_path_by_ident(
+            ident2, mock_fileset2, local_fs, storage_type, virtual_path4
+        )
+        self.assertEqual(actual_path4, storage_location_2)

--- a/clients/filesystem-hadoop3/src/main/java/org/apache/gravitino/filesystem/hadoop/GravitinoVirtualFileSystem.java
+++ b/clients/filesystem-hadoop3/src/main/java/org/apache/gravitino/filesystem/hadoop/GravitinoVirtualFileSystem.java
@@ -303,10 +303,10 @@ public class GravitinoVirtualFileSystem extends FileSystem {
           // For example, if the virtual path is `gvfs://fileset/catalog/schema/test_fileset/ttt`,
           // and the storage location is `hdfs://cluster:8020/user/`,
           // we should replace `gvfs://fileset/catalog/schema/test_fileset` with
-          // `hdfs://localhost:8020/`.
+          // `hdfs://localhost:8020/user` which truncates the tailing slash.
           // If the storage location is `hdfs://cluster:8020/user`,
           // we can replace `gvfs://fileset/catalog/schema/test_fileset` with
-          // `hdfs://localhost:8020` directly.
+          // `hdfs://localhost:8020/user` directly.
           if (subPath.startsWith(SLASH)) {
             return new Path(
                 virtualPath.replaceFirst(

--- a/clients/filesystem-hadoop3/src/main/java/org/apache/gravitino/filesystem/hadoop/GravitinoVirtualFileSystem.java
+++ b/clients/filesystem-hadoop3/src/main/java/org/apache/gravitino/filesystem/hadoop/GravitinoVirtualFileSystem.java
@@ -320,7 +320,8 @@ public class GravitinoVirtualFileSystem extends FileSystem {
     }
   }
 
-  private FileStatus convertFileStatusPathPrefix(
+  @VisibleForTesting
+  FileStatus convertFileStatusPathPrefix(
       FileStatus fileStatus, String actualPrefix, String virtualPrefix) {
     String filePath = fileStatus.getPath().toString();
     Preconditions.checkArgument(
@@ -328,6 +329,11 @@ public class GravitinoVirtualFileSystem extends FileSystem {
         "Path %s doesn't start with prefix \"%s\".",
         filePath,
         actualPrefix);
+    // if the storage location is end with "/",
+    // we should fill virtual prefix end with "/"
+    if (actualPrefix.endsWith("/") && !virtualPrefix.endsWith("/")) {
+      virtualPrefix += "/";
+    }
     Path path = new Path(filePath.replaceFirst(actualPrefix, virtualPrefix));
     fileStatus.setPath(path);
 
@@ -491,7 +497,7 @@ public class GravitinoVirtualFileSystem extends FileSystem {
     FileStatus fileStatus = context.getFileSystem().getFileStatus(context.getActualPath());
     return convertFileStatusPathPrefix(
         fileStatus,
-        context.getFileset().storageLocation(),
+        new Path(context.getFileset().storageLocation()).toString(),
         getVirtualLocation(context.getIdentifier(), true));
   }
 

--- a/clients/filesystem-hadoop3/src/main/java/org/apache/gravitino/filesystem/hadoop/GravitinoVirtualFileSystem.java
+++ b/clients/filesystem-hadoop3/src/main/java/org/apache/gravitino/filesystem/hadoop/GravitinoVirtualFileSystem.java
@@ -74,6 +74,7 @@ public class GravitinoVirtualFileSystem extends FileSystem {
   //     /fileset_catalog/fileset_schema/fileset1/sub_dir/
   private static final Pattern IDENTIFIER_PATTERN =
       Pattern.compile("^(?:gvfs://fileset)?/([^/]+)/([^/]+)/([^/]+)(?>/[^/]+)*/?$");
+  private static final String SLASH = "/";
 
   @Override
   public void initialize(URI name, Configuration configuration) throws IOException {
@@ -277,7 +278,8 @@ public class GravitinoVirtualFileSystem extends FileSystem {
         identifier.name());
   }
 
-  private Path getActualPathByIdentifier(
+  @VisibleForTesting
+  Path getActualPathByIdentifier(
       NameIdentifier identifier, Pair<Fileset, FileSystem> filesetPair, Path path) {
     String virtualPath = path.toString();
     boolean withScheme =
@@ -294,7 +296,27 @@ public class GravitinoVirtualFileSystem extends FileSystem {
 
         return new Path(storageLocation);
       } else {
-        return new Path(virtualPath.replaceFirst(virtualLocation, storageLocation));
+        // if the storage location ends with "/",
+        // we should handle the conversion specially
+        if (storageLocation.endsWith(SLASH)) {
+          String subPath = virtualPath.substring(virtualLocation.length());
+          // For example, if the virtual path is `gvfs://fileset/catalog/schema/test_fileset/ttt`,
+          // and the storage location is `hdfs://cluster:8020/user/`,
+          // we should replace `gvfs://fileset/catalog/schema/test_fileset` with
+          // `hdfs://localhost:8020/`.
+          // If the storage location is `hdfs://cluster:8020/user`,
+          // we can replace `gvfs://fileset/catalog/schema/test_fileset` with
+          // `hdfs://localhost:8020` directly.
+          if (subPath.startsWith(SLASH)) {
+            return new Path(
+                virtualPath.replaceFirst(
+                    virtualLocation, storageLocation.substring(0, storageLocation.length() - 1)));
+          } else {
+            return new Path(virtualPath.replaceFirst(virtualLocation, storageLocation));
+          }
+        } else {
+          return new Path(virtualPath.replaceFirst(virtualLocation, storageLocation));
+        }
       }
     } catch (Exception e) {
       throw new RuntimeException(
@@ -330,11 +352,14 @@ public class GravitinoVirtualFileSystem extends FileSystem {
         filePath,
         actualPrefix);
     // if the storage location is end with "/",
-    // we should fill virtual prefix end with "/"
-    if (actualPrefix.endsWith("/") && !virtualPrefix.endsWith("/")) {
-      virtualPrefix += "/";
-    }
-    Path path = new Path(filePath.replaceFirst(actualPrefix, virtualPrefix));
+    // we should truncate this to avoid replace issues.
+    Path path =
+        new Path(
+            filePath.replaceFirst(
+                actualPrefix.endsWith(SLASH) && !virtualPrefix.endsWith(SLASH)
+                    ? actualPrefix.substring(0, actualPrefix.length() - 1)
+                    : actualPrefix,
+                virtualPrefix));
     fileStatus.setPath(path);
 
     return fileStatus;


### PR DESCRIPTION
### What changes were proposed in this pull request?

When the storage location of fileset has a trailing slash, the problem of not finding files may occur when traversing the directory using like the hadoop command: `hadoop dfs -ls -R gvfs://fileset/catalog/tmp/test/`. This PR detects the trailing slash when converting to a virtual path and aligns the prefix to be replaced.

### Why are the changes needed?

Fix: #4586 

### How was this patch tested?

Add some UTs and test shell command locally.
![image](https://github.com/user-attachments/assets/116adfb2-d4e1-49e9-8f4f-3edde166e1f4)
