### PR TITLE
[#3766] improvement(client-python): Fix broad-exception-caught Pylint rule for client-python

### DIFF
--- a/clients/client-python/gravitino/catalog/base_schema_catalog.py
+++ b/clients/client-python/gravitino/catalog/base_schema_catalog.py
@@ -199,21 +199,17 @@ class BaseSchemaCatalog(CatalogDTO, SupportsSchemas):
         Returns:
              true if the schema is dropped successfully, false otherwise.
         """
-        try:
-            params = {"cascade": str(cascade)}
-            resp = self.rest_client.delete(
-                BaseSchemaCatalog.format_schema_request_path(self._schema_namespace())
-                + "/"
-                + encode_string(schema_name),
-                params=params,
-                error_handler=SCHEMA_ERROR_HANDLER,
-            )
-            drop_resp = DropResponse.from_json(resp.body, infer_missing=True)
-            drop_resp.validate()
-            return drop_resp.dropped()
-        except Exception:
-            logger.warning("Failed to drop schema %s", schema_name)
-            return False
+        params = {"cascade": str(cascade)}
+        resp = self.rest_client.delete(
+            BaseSchemaCatalog.format_schema_request_path(self._schema_namespace())
+            + "/"
+            + encode_string(schema_name),
+            params=params,
+            error_handler=SCHEMA_ERROR_HANDLER,
+        )
+        drop_resp = DropResponse.from_json(resp.body, infer_missing=True)
+        drop_resp.validate()
+        return drop_resp.dropped()
 
     def _schema_namespace(self) -> Namespace:
         return Namespace.of(self._catalog_namespace.level(0), self.name())

--- a/clients/client-python/gravitino/catalog/fileset_catalog.py
+++ b/clients/client-python/gravitino/catalog/fileset_catalog.py
@@ -223,22 +223,18 @@ class FilesetCatalog(BaseSchemaCatalog):
         Returns:
              true If the fileset is dropped, false the fileset did not exist.
         """
-        try:
-            self.check_fileset_name_identifier(ident)
+        self.check_fileset_name_identifier(ident)
 
-            full_namespace = self._get_fileset_full_namespace(ident.namespace())
+        full_namespace = self._get_fileset_full_namespace(ident.namespace())
 
-            resp = self.rest_client.delete(
-                f"{self.format_fileset_request_path(full_namespace)}/{ident.name()}",
-                error_handler=FILESET_ERROR_HANDLER,
-            )
-            drop_resp = DropResponse.from_json(resp.body, infer_missing=True)
-            drop_resp.validate()
+        resp = self.rest_client.delete(
+            f"{self.format_fileset_request_path(full_namespace)}/{ident.name()}",
+            error_handler=FILESET_ERROR_HANDLER,
+        )
+        drop_resp = DropResponse.from_json(resp.body, infer_missing=True)
+        drop_resp.validate()
 
-            return drop_resp.dropped()
-        except Exception as e:
-            logger.warning("Failed to drop fileset %s: %s", ident, e)
-            return False
+        return drop_resp.dropped()
 
     @staticmethod
     def check_fileset_namespace(namespace: Namespace):

--- a/clients/client-python/gravitino/client/gravitino_admin_client.py
+++ b/clients/client-python/gravitino/client/gravitino_admin_client.py
@@ -123,14 +123,11 @@ class GravitinoAdminClient(GravitinoClientBase):
         Returns:
             True if the Metalake was successfully dropped, false otherwise.
         """
-        try:
-            resp = self._rest_client.delete(
-                self.API_METALAKES_IDENTIFIER_PATH + name,
-                error_handler=METALAKE_ERROR_HANDLER,
-            )
-            drop_response = DropResponse.from_json(resp.body, infer_missing=True)
 
-            return drop_response.dropped()
-        except Exception:
-            logger.warning("Failed to drop metalake %s", name)
-            return False
+        resp = self._rest_client.delete(
+            self.API_METALAKES_IDENTIFIER_PATH + name,
+            error_handler=METALAKE_ERROR_HANDLER,
+        )
+        drop_response = DropResponse.from_json(resp.body, infer_missing=True)
+
+        return drop_response.dropped()

--- a/clients/client-python/gravitino/client/gravitino_client_base.py
+++ b/clients/client-python/gravitino/client/gravitino_client_base.py
@@ -138,10 +138,7 @@ class GravitinoClientBase:
     def close(self):
         """Closes the GravitinoClient and releases any underlying resources."""
         if self._rest_client is not None:
-            try:
-                self._rest_client.close()
-            except Exception as e:
-                logger.warning("Failed to close the HTTP REST client: %s", e)
+            self._rest_client.close()
 
     def check_metalake_name(self, metalake_name: str):
         identifier = NameIdentifier.parse(metalake_name)

--- a/clients/client-python/gravitino/client/gravitino_metalake.py
+++ b/clients/client-python/gravitino/client/gravitino_metalake.py
@@ -196,14 +196,10 @@ class GravitinoMetalake(MetalakeDTO):
         Returns:
             true if the catalog is dropped successfully, false otherwise.
         """
-        try:
-            url = self.API_METALAKES_CATALOGS_PATH.format(self.name(), name)
-            response = self.rest_client.delete(url, error_handler=CATALOG_ERROR_HANDLER)
+        url = self.API_METALAKES_CATALOGS_PATH.format(self.name(), name)
+        response = self.rest_client.delete(url, error_handler=CATALOG_ERROR_HANDLER)
 
-            drop_response = DropResponse.from_json(response.body, infer_missing=True)
-            drop_response.validate()
+        drop_response = DropResponse.from_json(response.body, infer_missing=True)
+        drop_response.validate()
 
-            return drop_response.dropped()
-        except Exception:
-            logger.warning("Failed to drop catalog %s", name)
-            return False
+        return drop_response.dropped()

--- a/clients/client-python/gravitino/exceptions/base.py
+++ b/clients/client-python/gravitino/exceptions/base.py
@@ -91,6 +91,10 @@ class NotEmptyException(GravitinoRuntimeException):
     """Base class for all exceptions thrown when a resource is not empty."""
 
 
+class NonEmptySchemaException(GravitinoRuntimeException):
+    """Exception thrown when a namespace is not empty."""
+
+
 class UnsupportedOperationException(GravitinoRuntimeException):
     """Base class for all exceptions thrown when an operation is unsupported"""
 

--- a/clients/client-python/gravitino/exceptions/base.py
+++ b/clients/client-python/gravitino/exceptions/base.py
@@ -91,7 +91,7 @@ class NotEmptyException(GravitinoRuntimeException):
     """Base class for all exceptions thrown when a resource is not empty."""
 
 
-class NonEmptySchemaException(GravitinoRuntimeException):
+class NonEmptySchemaException(NotEmptyException):
     """Exception thrown when a namespace is not empty."""
 
 

--- a/clients/client-python/gravitino/exceptions/handlers/schema_error_handler.py
+++ b/clients/client-python/gravitino/exceptions/handlers/schema_error_handler.py
@@ -24,6 +24,7 @@ from gravitino.exceptions.base import (
     NoSuchCatalogException,
     NoSuchSchemaException,
     SchemaAlreadyExistsException,
+    NonEmptySchemaException,
 )
 
 
@@ -42,6 +43,9 @@ class SchemaErrorHandler(RestErrorHandler):
                 raise NoSuchSchemaException(error_message)
         if code == ErrorConstants.ALREADY_EXISTS_CODE:
             raise SchemaAlreadyExistsException(error_message)
+
+        if code == ErrorConstants.NON_EMPTY_CODE:
+            raise NonEmptySchemaException(error_message)
 
         super().handle(error_response)
 

--- a/clients/client-python/pylintrc
+++ b/clients/client-python/pylintrc
@@ -38,7 +38,6 @@ disable=missing-class-docstring,
         fixme,          
         unnecessary-pass,               
         missing-timeout,                #TODO-fix
-        broad-exception-caught,         #TODO-fix    
         duplicate-code,                 #TODO-fix
         too-many-arguments,             #TODO-fix
 

--- a/clients/client-python/tests/integration/hdfs_container.py
+++ b/clients/client-python/tests/integration/hdfs_container.py
@@ -24,7 +24,7 @@ import time
 
 import docker
 from docker import types as tp
-from docker.errors import NotFound
+from docker.errors import NotFound, DockerException
 
 from gravitino.exceptions.base import GravitinoRuntimeException
 from gravitino.exceptions.base import InternalError
@@ -50,7 +50,7 @@ async def check_hdfs_status(hdfs_container):
             else:
                 logger.info("HDFS startup successfully!")
                 return True
-        except Exception as e:
+        except DockerException as e:
             logger.error(
                 "Exception occurred while checking HDFS container status: %s", e
             )

--- a/clients/client-python/tests/integration/test_catalog.py
+++ b/clients/client-python/tests/integration/test_catalog.py
@@ -77,22 +77,26 @@ class TestCatalog(IntegrationTestEnv):
         )
 
     def clean_test_data(self):
+        self.gravitino_client = GravitinoClient(
+            uri="http://localhost:8090", metalake_name=self.metalake_name
+        )
         try:
-            self.gravitino_client = GravitinoClient(
-                uri="http://localhost:8090", metalake_name=self.metalake_name
-            )
             logger.info(
                 "Drop catalog %s[%s]",
                 self.catalog_ident,
                 self.gravitino_client.drop_catalog(name=self.catalog_name),
             )
+        except GravitinoRuntimeException:
+            logger.warning("Failed to drop catalog %s", self.catalog_name)
+
+        try:
             logger.info(
                 "Drop metalake %s[%s]",
                 self.metalake_name,
                 self.gravitino_admin_client.drop_metalake(self.metalake_name),
             )
-        except GravitinoRuntimeException as e:
-            logger.error("Clean test data failed: %s", e)
+        except GravitinoRuntimeException:
+            logger.warning("Failed to drop metalake %s", self.metalake_name)
 
     def test_list_catalogs(self):
         self.create_catalog(self.catalog_name)

--- a/clients/client-python/tests/integration/test_catalog.py
+++ b/clients/client-python/tests/integration/test_catalog.py
@@ -28,6 +28,7 @@ from gravitino import (
 )
 from gravitino.api.catalog_change import CatalogChange
 from gravitino.exceptions.base import (
+    GravitinoRuntimeException,
     CatalogAlreadyExistsException,
     NoSuchCatalogException,
 )
@@ -90,7 +91,7 @@ class TestCatalog(IntegrationTestEnv):
                 self.metalake_name,
                 self.gravitino_admin_client.drop_metalake(self.metalake_name),
             )
-        except Exception as e:
+        except GravitinoRuntimeException as e:
             logger.error("Clean test data failed: %s", e)
 
     def test_list_catalogs(self):

--- a/clients/client-python/tests/integration/test_fileset_catalog.py
+++ b/clients/client-python/tests/integration/test_fileset_catalog.py
@@ -29,7 +29,7 @@ from gravitino import (
     Fileset,
     FilesetChange,
 )
-from gravitino.exceptions.base import NoSuchFilesetException
+from gravitino.exceptions.base import NoSuchFilesetException, GravitinoRuntimeException
 from tests.integration.integration_test_env import IntegrationTestEnv
 
 logger = logging.getLogger(__name__)
@@ -109,7 +109,7 @@ class TestFilesetCatalog(IntegrationTestEnv):
                 self.metalake_name,
                 self.gravitino_admin_client.drop_metalake(self.metalake_name),
             )
-        except Exception as e:
+        except GravitinoRuntimeException as e:
             logger.error("Clean test data failed: %s", e)
 
     def init_test_env(self):

--- a/clients/client-python/tests/integration/test_fileset_catalog.py
+++ b/clients/client-python/tests/integration/test_fileset_catalog.py
@@ -77,21 +77,30 @@ class TestFilesetCatalog(IntegrationTestEnv):
         self.clean_test_data()
 
     def clean_test_data(self):
+
+        self.gravitino_client = GravitinoClient(
+            uri="http://localhost:8090", metalake_name=self.metalake_name
+        )
+        catalog = self.gravitino_client.load_catalog(name=self.catalog_name)
         try:
-            self.gravitino_client = GravitinoClient(
-                uri="http://localhost:8090", metalake_name=self.metalake_name
-            )
-            catalog = self.gravitino_client.load_catalog(name=self.catalog_name)
             logger.info(
                 "Drop fileset %s[%s]",
                 self.fileset_ident,
                 catalog.as_fileset_catalog().drop_fileset(ident=self.fileset_ident),
             )
+        except GravitinoRuntimeException:
+            logger.warning("Failed to drop fileset %s", self.fileset_ident)
+
+        try:
             logger.info(
                 "Drop fileset %s[%s]",
                 self.fileset_new_ident,
                 catalog.as_fileset_catalog().drop_fileset(ident=self.fileset_new_ident),
             )
+        except GravitinoRuntimeException:
+            logger.warning("Failed to drop fileset %s", self.fileset_new_ident)
+
+        try:
             logger.info(
                 "Drop schema %s[%s]",
                 self.schema_ident,
@@ -99,18 +108,26 @@ class TestFilesetCatalog(IntegrationTestEnv):
                     schema_name=self.schema_name, cascade=True
                 ),
             )
+        except GravitinoRuntimeException:
+            logger.warning("Failed to drop schema %s", self.schema_name)
+
+        try:
             logger.info(
                 "Drop catalog %s[%s]",
                 self.catalog_ident,
                 self.gravitino_client.drop_catalog(name=self.catalog_name),
             )
+        except GravitinoRuntimeException:
+            logger.warning("Failed to drop catalog %s", self.catalog_name)
+
+        try:
             logger.info(
                 "Drop metalake %s[%s]",
                 self.metalake_name,
                 self.gravitino_admin_client.drop_metalake(self.metalake_name),
             )
-        except GravitinoRuntimeException as e:
-            logger.error("Clean test data failed: %s", e)
+        except GravitinoRuntimeException:
+            logger.warning("Failed to drop metalake %s", self.metalake_name)
 
     def init_test_env(self):
         self.gravitino_admin_client.create_metalake(

--- a/clients/client-python/tests/integration/test_gvfs_with_hdfs.py
+++ b/clients/client-python/tests/integration/test_gvfs_with_hdfs.py
@@ -160,16 +160,21 @@ class TestGvfsWithHDFS(IntegrationTestEnv):
 
     @classmethod
     def _clean_test_data(cls):
+        cls.gravitino_client = GravitinoClient(
+            uri="http://localhost:8090", metalake_name=cls.metalake_name
+        )
+        catalog = cls.gravitino_client.load_catalog(name=cls.catalog_name)
+
         try:
-            cls.gravitino_client = GravitinoClient(
-                uri="http://localhost:8090", metalake_name=cls.metalake_name
-            )
-            catalog = cls.gravitino_client.load_catalog(name=cls.catalog_name)
             logger.info(
                 "Drop fileset %s[%s]",
                 cls.fileset_ident,
                 catalog.as_fileset_catalog().drop_fileset(ident=cls.fileset_ident),
             )
+        except GravitinoRuntimeException:
+            logger.warning("Failed to drop fileset %s", cls.fileset_ident)
+
+        try:
             logger.info(
                 "Drop schema %s[%s]",
                 cls.schema_ident,
@@ -177,18 +182,26 @@ class TestGvfsWithHDFS(IntegrationTestEnv):
                     schema_name=cls.schema_name, cascade=True
                 ),
             )
+        except GravitinoRuntimeException:
+            logger.warning("Failed to drop schema %s", cls.schema_name)
+
+        try:
             logger.info(
                 "Drop catalog %s[%s]",
                 cls.catalog_name,
                 cls.gravitino_client.drop_catalog(name=cls.catalog_name),
             )
+        except GravitinoRuntimeException:
+            logger.warning("Failed to drop catalog %s", cls.catalog_name)
+
+        try:
             logger.info(
                 "Drop metalake %s[%s]",
                 cls.metalake_name,
                 cls.gravitino_admin_client.drop_metalake(cls.metalake_name),
             )
-        except GravitinoRuntimeException as e:
-            logger.error("Clean test data failed: %s", e)
+        except GravitinoRuntimeException:
+            logger.warning("Failed to drop metalake %s", cls.metalake_name)
 
     def test_simple_auth(self):
         options = {"auth_type": "simple"}

--- a/clients/client-python/tests/integration/test_gvfs_with_hdfs.py
+++ b/clients/client-python/tests/integration/test_gvfs_with_hdfs.py
@@ -187,7 +187,7 @@ class TestGvfsWithHDFS(IntegrationTestEnv):
                 cls.metalake_name,
                 cls.gravitino_admin_client.drop_metalake(cls.metalake_name),
             )
-        except Exception as e:
+        except GravitinoRuntimeException as e:
             logger.error("Clean test data failed: %s", e)
 
     def test_simple_auth(self):

--- a/clients/client-python/tests/integration/test_metalake.py
+++ b/clients/client-python/tests/integration/test_metalake.py
@@ -24,6 +24,7 @@ from gravitino import GravitinoAdminClient, GravitinoMetalake, MetalakeChange
 from gravitino.dto.dto_converters import DTOConverters
 from gravitino.dto.requests.metalake_updates_request import MetalakeUpdatesRequest
 from gravitino.exceptions.base import (
+    GravitinoRuntimeException,
     NoSuchMetalakeException,
     MetalakeAlreadyExistsException,
 )
@@ -54,16 +55,23 @@ class TestMetalake(IntegrationTestEnv):
         self.clean_test_data()
 
     def clean_test_data(self):
-        logger.info(
-            "Drop metalake %s[%s]",
-            self.metalake_name,
-            self.drop_metalake(self.metalake_name),
-        )
-        logger.info(
-            "Drop metalake %s[%s]",
-            self.metalake_new_name,
-            self.drop_metalake(self.metalake_new_name),
-        )
+        try:
+            logger.info(
+                "Drop metalake %s[%s]",
+                self.metalake_name,
+                self.drop_metalake(self.metalake_name),
+            )
+        except GravitinoRuntimeException:
+            logger.warning("Failed to drop metalake %s", self.metalake_name)
+
+        try:
+            logger.info(
+                "Drop metalake %s[%s]",
+                self.metalake_new_name,
+                self.drop_metalake(self.metalake_new_name),
+            )
+        except GravitinoRuntimeException:
+            logger.warning("Failed to drop metalake %s", self.metalake_new_name)
 
     def test_create_metalake(self):
         metalake = self.create_metalake(self.metalake_name)

--- a/clients/client-python/tests/integration/test_schema.py
+++ b/clients/client-python/tests/integration/test_schema.py
@@ -30,6 +30,7 @@ from gravitino import (
     Schema,
 )
 from gravitino.exceptions.base import (
+    GravitinoRuntimeException,
     NoSuchSchemaException,
     SchemaAlreadyExistsException,
 )
@@ -119,7 +120,7 @@ class TestSchema(IntegrationTestEnv):
                 self.metalake_name,
                 self.gravitino_admin_client.drop_metalake(self.metalake_name),
             )
-        except Exception as e:
+        except GravitinoRuntimeException as e:
             logger.error("Clean test data failed: %s", e)
 
     def create_schema(self) -> Schema:

--- a/clients/client-python/tests/integration/test_schema.py
+++ b/clients/client-python/tests/integration/test_schema.py
@@ -95,33 +95,45 @@ class TestSchema(IntegrationTestEnv):
         )
 
     def clean_test_data(self):
+        self.gravitino_client = GravitinoClient(
+            uri="http://localhost:8090", metalake_name=self.metalake_name
+        )
+        catalog = self.gravitino_client.load_catalog(name=self.catalog_name)
         try:
-            self.gravitino_client = GravitinoClient(
-                uri="http://localhost:8090", metalake_name=self.metalake_name
-            )
-            catalog = self.gravitino_client.load_catalog(name=self.catalog_name)
             logger.info(
                 "Drop schema %s[%s]",
                 self.schema_ident,
                 catalog.as_schemas().drop_schema(self.schema_name, cascade=True),
             )
+        except GravitinoRuntimeException:
+            logger.warning("Failed to drop schema %s", self.schema_name)
+
+        try:
             logger.info(
                 "Drop schema %s[%s]",
                 self.schema_new_ident,
                 catalog.as_schemas().drop_schema(self.schema_new_name, cascade=True),
             )
+        except GravitinoRuntimeException:
+            logger.warning("Failed to drop schema %s", self.schema_new_name)
+
+        try:
             logger.info(
                 "Drop catalog %s[%s]",
                 self.catalog_ident,
                 self.gravitino_client.drop_catalog(name=self.catalog_name),
             )
+        except GravitinoRuntimeException:
+            logger.warning("Failed to drop catalog %s", self.catalog_name)
+
+        try:
             logger.info(
                 "Drop metalake %s[%s]",
                 self.metalake_name,
                 self.gravitino_admin_client.drop_metalake(self.metalake_name),
             )
-        except GravitinoRuntimeException as e:
-            logger.error("Clean test data failed: %s", e)
+        except GravitinoRuntimeException:
+            logger.warning("Failed to drop metalake %s", self.metalake_name)
 
     def create_schema(self) -> Schema:
         catalog = self.gravitino_client.load_catalog(name=self.catalog_name)

--- a/clients/client-python/tests/integration/test_simple_auth_client.py
+++ b/clients/client-python/tests/integration/test_simple_auth_client.py
@@ -75,13 +75,17 @@ class TestSimpleAuthClient(IntegrationTestEnv):
         self.clean_test_data()
 
     def clean_test_data(self):
+        catalog = self.gravitino_client.load_catalog(name=self.catalog_name)
         try:
-            catalog = self.gravitino_client.load_catalog(name=self.catalog_name)
             logger.info(
                 "Drop fileset %s[%s]",
                 self.fileset_ident,
                 catalog.as_fileset_catalog().drop_fileset(ident=self.fileset_ident),
             )
+        except GravitinoRuntimeException:
+            logger.warning("Failed to drop fileset %s", self.fileset_ident)
+
+        try:
             logger.info(
                 "Drop schema %s[%s]",
                 self.schema_ident,
@@ -89,20 +93,28 @@ class TestSimpleAuthClient(IntegrationTestEnv):
                     schema_name=self.schema_name, cascade=True
                 ),
             )
+        except GravitinoRuntimeException:
+            logger.warning("Failed to drop schema %s", self.schema_name)
+
+        try:
             logger.info(
                 "Drop catalog %s[%s]",
                 self.catalog_ident,
                 self.gravitino_client.drop_catalog(name=self.catalog_name),
             )
+        except GravitinoRuntimeException:
+            logger.warning("Failed to drop catalog %s", self.catalog_name)
+
+        try:
             logger.info(
                 "Drop metalake %s[%s]",
                 self.metalake_name,
                 self.gravitino_admin_client.drop_metalake(self.metalake_name),
             )
-        except GravitinoRuntimeException as e:
-            logger.error("Clean test data failed: %s", e)
-        finally:
-            os.environ["GRAVITINO_USER"] = ""
+        except GravitinoRuntimeException:
+            logger.warning("Failed to drop metalake %s", self.metalake_name)
+
+        os.environ["GRAVITINO_USER"] = ""
 
     def init_test_env(self):
         self.gravitino_admin_client.create_metalake(

--- a/clients/client-python/tests/integration/test_simple_auth_client.py
+++ b/clients/client-python/tests/integration/test_simple_auth_client.py
@@ -30,6 +30,7 @@ from gravitino import (
     Fileset,
 )
 from gravitino.auth.simple_auth_provider import SimpleAuthProvider
+from gravitino.exceptions.base import GravitinoRuntimeException
 from tests.integration.integration_test_env import IntegrationTestEnv
 
 logger = logging.getLogger(__name__)
@@ -98,7 +99,7 @@ class TestSimpleAuthClient(IntegrationTestEnv):
                 self.metalake_name,
                 self.gravitino_admin_client.drop_metalake(self.metalake_name),
             )
-        except Exception as e:
+        except GravitinoRuntimeException as e:
             logger.error("Clean test data failed: %s", e)
         finally:
             os.environ["GRAVITINO_USER"] = ""

--- a/clients/client-python/tests/unittests/test_error_handler.py
+++ b/clients/client-python/tests/unittests/test_error_handler.py
@@ -32,6 +32,7 @@ from gravitino.exceptions.base import (
     IllegalArgumentException,
     AlreadyExistsException,
     NotEmptyException,
+    NonEmptySchemaException,
     SchemaAlreadyExistsException,
     UnsupportedOperationException,
     ConnectionFailedException,
@@ -217,9 +218,11 @@ class TestErrorHandler(unittest.TestCase):
                 )
             )
 
-        with self.assertRaises(NotEmptyException):
+        with self.assertRaises(NonEmptySchemaException):
             SCHEMA_ERROR_HANDLER.handle(
-                ErrorResponse.generate_error_response(NotEmptyException, "mock error")
+                ErrorResponse.generate_error_response(
+                    NonEmptySchemaException, "mock error"
+                )
             )
 
         with self.assertRaises(UnsupportedOperationException):


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

* Remove all explicit `Exception`
* Modify some logic of tests to handle this modification

### Why are the changes needed?

Fix: #3766 

### Does this PR introduce _any_ user-facing change?

* drop schema
* drop catalog
* drop fileset
* drop metalake

Now these APIs will raise exceptions directly, instead of handling exceptions internally.

### How was this patch tested?

`./gradlew client:client-python:test`
