### PR TITLE
[#4637] improvement: Rename the table `securable_object_meta` field `entity_id` to `metadata_object_id`

### DIFF
--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/RoleMetaMapper.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/RoleMetaMapper.java
@@ -98,7 +98,7 @@ public interface RoleMetaMapper {
           + " ro JOIN "
           + SecurableObjectMapper.SECURABLE_OBJECT_TABLE_NAME
           + " se ON ro.role_id = se.role_id"
-          + " WHERE se.entity_id = #{metadataObjectId}"
+          + " WHERE se.metadata_object_id = #{metadataObjectId}"
           + " AND se.type = #{metadataObjectType}"
           + " AND ro.deleted_at = 0 AND se.deleted_at = 0")
   List<RolePO> listRolesByMetadataObjectIdAndType(

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/SecurableObjectMapper.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/SecurableObjectMapper.java
@@ -43,12 +43,12 @@ public interface SecurableObjectMapper {
     "<script>",
     "INSERT INTO "
         + SECURABLE_OBJECT_TABLE_NAME
-        + "(role_id, entity_id, type, privilege_names, privilege_conditions, "
+        + "(role_id, metadata_object_id, type, privilege_names, privilege_conditions, "
         + " current_version, last_version, deleted_at)"
         + " VALUES ",
     "<foreach collection='securableObjects' item='item' separator=','>",
     "(#{item.roleId},"
-        + " #{item.entityId},"
+        + " #{item.metadataObjectId},"
         + " #{item.type},"
         + " #{item.privilegeNames},"
         + " #{item.privilegeConditions},"
@@ -81,7 +81,7 @@ public interface SecurableObjectMapper {
   void softDeleteRoleMetasByMetalakeId(@Param("metalakeId") Long metalakeId);
 
   @Select(
-      "SELECT role_id as roleId, entity_id as entityId,"
+      "SELECT role_id as roleId, metadata_object_id as metadataObjectId,"
           + " type as type, privilege_names as privilegeNames,"
           + " privilege_conditions as privilegeConditions, current_version as currentVersion,"
           + " last_version as lastVersion, deleted_at as deletedAt"

--- a/core/src/main/java/org/apache/gravitino/storage/relational/po/SecurableObjectPO.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/po/SecurableObjectPO.java
@@ -24,7 +24,7 @@ import com.google.common.base.Preconditions;
 public class SecurableObjectPO {
 
   private Long roleId;
-  private Long entityId;
+  private Long metadataObjectId;
   private String type;
   private String privilegeNames;
   private String privilegeConditions;
@@ -36,8 +36,8 @@ public class SecurableObjectPO {
     return roleId;
   }
 
-  public Long getEntityId() {
-    return entityId;
+  public Long getMetadataObjectId() {
+    return metadataObjectId;
   }
 
   public String getType() {
@@ -74,7 +74,7 @@ public class SecurableObjectPO {
     }
     SecurableObjectPO securableObjectPO = (SecurableObjectPO) o;
     return Objects.equal(getRoleId(), securableObjectPO.getRoleId())
-        && Objects.equal(getEntityId(), securableObjectPO.getEntityId())
+        && Objects.equal(getMetadataObjectId(), securableObjectPO.getMetadataObjectId())
         && Objects.equal(getType(), securableObjectPO.getType())
         && Objects.equal(getPrivilegeConditions(), securableObjectPO.getPrivilegeConditions())
         && Objects.equal(getPrivilegeNames(), securableObjectPO.getPrivilegeNames())
@@ -87,7 +87,7 @@ public class SecurableObjectPO {
   public int hashCode() {
     return Objects.hashCode(
         getRoleId(),
-        getEntityId(),
+        getMetadataObjectId(),
         getType(),
         getPrivilegeNames(),
         getPrivilegeConditions(),
@@ -108,8 +108,8 @@ public class SecurableObjectPO {
       return this;
     }
 
-    public Builder withEntityId(long entityId) {
-      securableObjectPO.entityId = entityId;
+    public Builder withMetadataObjectId(long metadataObjectId) {
+      securableObjectPO.metadataObjectId = metadataObjectId;
       return this;
     }
 

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/RoleMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/RoleMetaService.java
@@ -120,7 +120,7 @@ public class RoleMetaService {
     for (SecurableObjectPO securableObjectPO : securableObjectPOs) {
       String fullName =
           MetadataObjectService.getMetadataObjectFullName(
-              securableObjectPO.getType(), securableObjectPO.getEntityId());
+              securableObjectPO.getType(), securableObjectPO.getMetadataObjectId());
       if (fullName != null) {
         securableObjects.add(
             POConverters.fromSecurableObjectPO(
@@ -128,7 +128,7 @@ public class RoleMetaService {
       } else {
         LOG.info(
             "The securable object {} {} may be deleted",
-            securableObjectPO.getEntityId(),
+            securableObjectPO.getMetadataObjectId(),
             securableObjectPO.getType());
       }
     }
@@ -154,7 +154,7 @@ public class RoleMetaService {
         SecurableObjectPO.Builder objectBuilder =
             POConverters.initializeSecurablePOBuilderWithVersion(
                 roleEntity.id(), object, getEntityType(object));
-        objectBuilder.withEntityId(
+        objectBuilder.withMetadataObjectId(
             MetadataObjectService.getMetadataObjectId(
                 metalakeId, object.fullName(), object.type()));
         securableObjectPOs.add(objectBuilder.build());

--- a/scripts/h2/schema-0.6.0-h2.sql
+++ b/scripts/h2/schema-0.6.0-h2.sql
@@ -168,7 +168,7 @@ CREATE TABLE IF NOT EXISTS `role_meta` (
 CREATE TABLE IF NOT EXISTS `role_meta_securable_object` (
     `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'auto increment id',
     `role_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'role id',
-    `entity_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'securable object entity id',
+    `metadata_object_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'securable object entity id',
     `type`  VARCHAR(128) NOT NULL COMMENT 'securable object type',
     `privilege_names` VARCHAR(256) NOT NULL COMMENT 'securable object privilege names',
     `privilege_conditions` VARCHAR(256) NOT NULL COMMENT 'securable object privilege conditions',
@@ -177,7 +177,7 @@ CREATE TABLE IF NOT EXISTS `role_meta_securable_object` (
     `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'securable object deleted at',
     PRIMARY KEY (`id`),
     KEY `idx_obj_rid` (`role_id`),
-    KEY `idx_obj_eid` (`entity_id`)
+    KEY `idx_obj_eid` (`metadata_object_id`)
     ) ENGINE=InnoDB;
 
 CREATE TABLE IF NOT EXISTS `user_role_rel` (

--- a/scripts/mysql/schema-0.6.0-mysql.sql
+++ b/scripts/mysql/schema-0.6.0-mysql.sql
@@ -160,7 +160,7 @@ CREATE TABLE IF NOT EXISTS `role_meta` (
 CREATE TABLE IF NOT EXISTS `role_meta_securable_object` (
     `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'auto increment id',
     `role_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'role id',
-    `entity_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'The entity id of securable object',
+    `metadata_object_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'The entity id of securable object',
     `type`  VARCHAR(128) NOT NULL COMMENT 'securable object type',
     `privilege_names` VARCHAR(256) NOT NULL COMMENT 'securable object privilege names',
     `privilege_conditions` VARCHAR(256) NOT NULL COMMENT 'securable object privilege conditions',
@@ -169,7 +169,7 @@ CREATE TABLE IF NOT EXISTS `role_meta_securable_object` (
     `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'securable object deleted at',
     PRIMARY KEY (`id`),
     KEY `idx_obj_rid` (`role_id`),
-    KEY `idx_obj_eid` (`entity_id`)
+    KEY `idx_obj_eid` (`metadata_object_id`)
     ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'securable object meta';
 
 CREATE TABLE IF NOT EXISTS `user_role_rel` (

--- a/scripts/mysql/upgrade-0.5.0-to-0.6.0-mysql.sql
+++ b/scripts/mysql/upgrade-0.5.0-to-0.6.0-mysql.sql
@@ -24,7 +24,7 @@ ALTER TABLE `role_meta` MODIFY COLUMN `privilege_conditions` VARCHAR(64) NOT NUL
 CREATE TABLE IF NOT EXISTS `role_meta_securable_object` (
     `id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'securable object id',
     `role_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'role id',
-    `entity_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'The entity id of securable object',
+    `metadata_object_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'The entity id of securable object',
     `type`  VARCHAR(128) NOT NULL COMMENT 'securable object type',
     `privilege_names` VARCHAR(256) NOT NULL COMMENT 'securable object privilege names',
     `privilege_conditions` VARCHAR(256) NOT NULL COMMENT 'securable object privilege conditions',
@@ -33,7 +33,7 @@ CREATE TABLE IF NOT EXISTS `role_meta_securable_object` (
     `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'securable object deleted at',
     PRIMARY KEY (`id`),
     KEY `idx_obj_rid` (`role_id`),
-    KEY `idx_obj_eid` (`entity_id`)
+    KEY `idx_obj_eid` (`metadata_object_id`)
     ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'securable object meta';
 
 CREATE TABLE IF NOT EXISTS `tag_meta` (


### PR DESCRIPTION
### What changes were proposed in this pull request?

Rename the table securable_object_meta field entity_id to metadata_object_id

### Why are the changes needed?

Fix: #4637

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Existing UTs.
