### PR TITLE
[Minor] fix(license): Fix the license problem for Javax Activation

### DIFF
--- a/LICENSE.bin
+++ b/LICENSE.bin
@@ -460,3 +460,8 @@
 
    AOP Alliance
    XZ For Java
+
+   This product bundles various third-party components also under the
+   COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) license
+
+   Javax Activation


### PR DESCRIPTION


### What changes were proposed in this pull request?

Add the corresponding license for Javax Activation to `LICENSE.BIN`

### Why are the changes needed?

To make it more compliance.

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

N/A
