### PR TITLE
[MINOR] fix(build): Add gradle.kts to iceberg parent module

### DIFF
--- a/iceberg/build.gradle.kts
+++ b/iceberg/build.gradle.kts
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+tasks.all {
+    enabled = false
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add gradle.kts to iceberg parent module so that it will not generate any empty jars.

### Why are the changes needed?

Fix publishing issue.


### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

local build test
