### PR TITLE
[#4657] Improvement (docs): Add documentation for the Gravitino-Trino connector running on AWS S3.

### DIFF
--- a/docs/trino-connector/catalog-hive.md
+++ b/docs/trino-connector/catalog-hive.md
@@ -306,7 +306,7 @@ replacing hdfs_user with the appropriate username:
 ## S3
 
 When using AWS S3 within the Hive catalog, users need to configure the Trino Hive connector's
-AWS S3-related properties in the catalog's properteis. For specific guidance, please refer to the documentation
+AWS S3-related properties in the catalog's properteis. Please refer to the documentation
 of [Hive connector with Amazon S3](https://trino.io/docs/435/connector/hive-s3.html).
 
 To create a Hive catalog with AWS S3 configuration in the Trino CLI, use the following command:

--- a/docs/trino-connector/catalog-hive.md
+++ b/docs/trino-connector/catalog-hive.md
@@ -319,7 +319,7 @@ call gravitino.system.create_catalog(
     array['metastore.uris',
         'trino.bypass.hive.s3.aws-access-key', 'trino.bypass.hive.s3.aws-secret-key', 'trino.bypass.hive.s3.region'
     ],
-    array['thrift://hive:9083', 'XXXX', 'XXX', 'XXX']
+    array['thrift://hive:9083', '<aws-access-key>', '<aws-secret-key>', '<region>']
   )
 );
 ```

--- a/docs/trino-connector/catalog-hive.md
+++ b/docs/trino-connector/catalog-hive.md
@@ -290,9 +290,9 @@ DROP TABLE hive_test.database_01.table_01;
 
 ## HDFS config and permissions
 
-For basic setups, Apache Gravitino Trino connector configures the HDFS client by the catalog configurations.
-It is support to config the `hdfs-site.xml` and `core-site.xml` files to the HDFS client by the configuration
-`trino.bypass.hive.config.resources` in the catalog configurations.
+For basic setups, the Apache Gravitino Trino connector configures the HDFS client
+using catalog configurations. It supports configuring the HDFS client with `hdfs-site.xml`
+and `core-site.xml` files via the `trino.bypass.hive.config.resources` setting in the catalog configurations.
 
 Before running any `Insert` statements for Hive tables in Trino,
 you must check that the user Trino is using to access HDFS has access to the Hive warehouse directory.
@@ -305,11 +305,11 @@ replacing hdfs_user with the appropriate username:
 
 ## S3
 
-Uses can use AWS S3 storage in the Hive catalog. The AWS S3 configuration of Trino Hive connector can reference to
-[Hive connector with Amazon S3](https://trino.io/docs/435/connector/hive-s3.html).
-The configurations can config by the Hive catalog properties with the `trino.bypass.` prefix.
+When using AWS S3 within the Hive catalog, users need to configure the Trino Hive connector's
+AWS S3-related properties in the catalog's properteis. For specific guidance, please refer to the documentation
+of [Hive connector with Amazon S3](https://trino.io/docs/435/connector/hive-s3.html).
 
-Create a Hive catalog with the AWS S3 configuration in the Trino cli:
+To create a Hive catalog with AWS S3 configuration in the Trino CLI, use the following command:
 
 ```sql
 call gravitino.system.create_catalog(
@@ -324,10 +324,10 @@ call gravitino.system.create_catalog(
 );
 ```
 
-- The configurations of `trino.bypass.hive.s3.aws-access-key`, `trino.bypass.hive.s3.aws-secret-key`, `trino.bypass.hive.s3.region`
-are the required the configurations use by the Apache Gravitino Trino connector.
+- The settings for `trino.bypass.hive.s3.aws-access-key`, `trino.bypass.hive.s3.aws-secret-key` and `trino.bypass.hive.s3.region`
+are required by the Apache Gravitino Trino connector.
 
-When the Hive catalog created successfully, you can create  schemas and tables by the following command.
+Once the Hive catalog is successfully created, users can create schemas and tables as follows:
 
 ```sql
 CREATE SCHEMA gt_hive.gt_db02
@@ -339,9 +339,10 @@ CREATE TABLE gt_hive.gt_db02.tb01 (
 );
 ```
 
-The `location` is the storage path of AWS s3.
-After that, you can use the table read and write the data in AWS S3.
+The `location` specifies the AWS S3 storage path.
+
+After running the command, the tables are ready for data reading and writing operations on AWS S3.
 
 :::note
-The Hive Metastore service used by the Hive catalog should support AWS s3.
+Ensure the Hive Metastore service used by the Hive catalog supports AWS S3.
 :::

--- a/docs/trino-connector/catalog-iceberg.md
+++ b/docs/trino-connector/catalog-iceberg.md
@@ -32,8 +32,8 @@ CREATE SCHEMA catalog.schema_name
 
 ### Create table
 
-The Gravitino Trino connector currently supports basic Iceberg table creation statements, such as defining fields,
-allowing null values, and adding comments. The Gravitino Trino connector does not support `CREATE TABLE AS SELECT`.
+The Apache Gravitino Trino connector currently supports basic Iceberg table creation statements, such as defining fields,
+allowing null values, and adding comments. The Apache Gravitino Trino connector does not support `CREATE TABLE AS SELECT`.
 
 The following example shows how to create a table in the Iceberg catalog:
 
@@ -57,7 +57,7 @@ Support for the following alter table operations:
 
 ## Select
 
-The Gravitino Trino connector supports most SELECT statements, allowing the execution of queries successfully.
+The Apache Gravitino Trino connector supports most SELECT statements, allowing the execution of queries successfully.
 Currently, it doesn't support certain query optimizations, such as pushdown and pruning functionalities.
 
 ## Table and Schema properties
@@ -92,10 +92,10 @@ Reserved properties: A reserved property is one can't be set by users but can be
 
 ## Basic usage examples
 
-You need to do the following steps before you can use the Iceberg catalog in Trino through Gravitino.
+You need to do the following steps before you can use the Iceberg catalog in Trino through Apache Gravitino.
 
-- Create a metalake and catalog in Gravitino. Assuming that the metalake name is `test` and the catalog name is `iceberg_test`,
-then you can use the following code to create them in Gravitino:
+- Create a metalake and catalog in Apache Gravitino. Assuming that the metalake name is `test` and the catalog name is `iceberg_test`,
+then you can use the following code to create them in Apache Gravitino:
 
 ```bash
 curl -X POST -H "Content-Type: application/json" \
@@ -125,7 +125,7 @@ For More information about the Iceberg catalog, please refer to [Iceberg catalog
 
 Use the Trino CLI to connect to the Trino container and run a query.
 
-Listing all Gravitino managed catalogs:
+Listing all Apache Gravitino managed catalogs:
 
 ```sql 
 SHOW CATALOGS;
@@ -146,7 +146,7 @@ Query 20231017_082503_00018_6nt3n, FINISHED, 1 node
 ```
 
 The `gravitino` catalog is a catalog defined By Trino catalog configuration. 
-The `iceberg_test` catalog is the catalog created by you in Gravitino.
+The `iceberg_test` catalog is the catalog created by you in Apache Gravitino.
 Other catalogs are regular user-configured Trino catalogs.
 
 ### Creating tables and schemas
@@ -236,3 +236,51 @@ replacing hdfs_user with the appropriate username:
 ```text
 -DHADOOP_USER_NAME=hdfs_user
 ```
+
+## S3
+
+Uses can use AWS S3 storage in the Iceberg catalog. The AWS S3 configuration of Trino Iceberg connector can reference to
+[Hive connector with Amazon S3](https://trino.io/docs/435/connector/hive-s3.html).
+The configurations can config by the Iceberg catalog properties with the `trino.bypass.` prefix.
+
+Create an Iceberg catalog with the AWS S3 configuration in the Trino cli:
+
+```sql
+call gravitino.system.create_catalog(
+    'gt_iceberg',
+    'lakehouse-iceberg',
+    map(
+        array['uri', 'catalog-backend', 'warehouse',
+          'trino.bypass.hive.s3.aws-access-key', 'trino.bypass.hive.s3.aws-secret-key', 'trino.bypass.hive.s3.region',
+          's3-access-key-id', 's3-secret-access-key', 's3-region', 'io-impl'
+        ],
+        array['thrift://hive:9083', 'hive', 's3a://trino-test-ice/dw2',
+        'xxx', 'xxx', 'xxx',
+        'xxx', 'xxx', 'xxx', 'org.apache.iceberg.aws.s3.S3FileIO']
+    )
+);
+```
+
+- The configurations of `trino.bypass.hive.s3.aws-access-key`, `trino.bypass.hive.s3.aws-secret-key`, `trino.bypass.hive.s3.region`
+are the required the configurations use by the Apache Gravitino Trino connector.
+- The configurations of `s3-access-key-id`, `s3-secret-access-key`, `io-impl` and `s3-region`.
+is the required the configuration of the [Apache Gravitino Iceberg catalog](../lakehouse-iceberg-catalog.md#S3).
+- The `location` is the storage path of AWS s3. You need make sure the directory in AWS S3 is exists.
+
+When the Iceberg catalog created successfully, you can create schemas and tables by the following command.
+
+```sql
+CREATE SCHEMA gt_iceberg.gt_db03;
+
+CREATE TABLE gt_iceberg.gt_db03.tb01 (
+    name varchar,
+    salary int
+);
+```
+
+After that, you can use the table read and write the data in AWS S3.
+
+:::note
+The Iceberg catalog module in the Apache Gravitino server should Add AWS s3 support.
+Please refer to [Apache Gravitino Iceberg catalog](../lakehouse-iceberg-catalog.md#S3).
+:::

--- a/docs/trino-connector/catalog-iceberg.md
+++ b/docs/trino-connector/catalog-iceberg.md
@@ -239,7 +239,7 @@ replacing hdfs_user with the appropriate username:
 
 ## S3
 
-When using AWS S3 within the Iceberg catalog,users need to configure the Trino Iceberg connector's
+When using AWS S3 within the Iceberg catalog, users need to configure the Trino Iceberg connector's
 AWS S3-related properties in the catalog's properties. For specific guidance, please refer to the documentation
 of [Hive connector with Amazon S3](https://trino.io/docs/435/connector/hive-s3.html).
 These configurations must use the `trino.bypass.` prefix in the Iceberg catalog's attributes to be effective.

--- a/docs/trino-connector/catalog-iceberg.md
+++ b/docs/trino-connector/catalog-iceberg.md
@@ -256,8 +256,8 @@ call gravitino.system.create_catalog(
           's3-access-key-id', 's3-secret-access-key', 's3-region', 'io-impl'
         ],
         array['thrift://hive:9083', 'hive', 's3a://trino-test-ice/dw2',
-        'xxx', 'xxx', 'xxx',
-        'xxx', 'xxx', 'xxx', 'org.apache.iceberg.aws.s3.S3FileIO']
+        '<aws-access-key>', '<aws-secret-key>', '<region>',
+        '<aws-access-key>', '<aws-secret-key>', '<region>', 'org.apache.iceberg.aws.s3.S3FileIO']
     )
 );
 ```

--- a/docs/trino-connector/catalog-iceberg.md
+++ b/docs/trino-connector/catalog-iceberg.md
@@ -239,11 +239,12 @@ replacing hdfs_user with the appropriate username:
 
 ## S3
 
-Uses can use AWS S3 storage in the Iceberg catalog. The AWS S3 configuration of Trino Iceberg connector can reference to
-[Hive connector with Amazon S3](https://trino.io/docs/435/connector/hive-s3.html).
-The configurations can config by the Iceberg catalog properties with the `trino.bypass.` prefix.
+When using AWS S3 within the Iceberg catalog,users need to configure the Trino Iceberg connector's
+AWS S3-related properties in the catalog's properties. For specific guidance, please refer to the documentation
+of [Hive connector with Amazon S3](https://trino.io/docs/435/connector/hive-s3.html).
+These configurations must use the `trino.bypass.` prefix in the Iceberg catalog's attributes to be effective.
 
-Create an Iceberg catalog with the AWS S3 configuration in the Trino cli:
+To create an Iceberg catalog with AWS S3 configuration in the Trino CLI, use the following command:
 
 ```sql
 call gravitino.system.create_catalog(
@@ -262,12 +263,12 @@ call gravitino.system.create_catalog(
 ```
 
 - The configurations of `trino.bypass.hive.s3.aws-access-key`, `trino.bypass.hive.s3.aws-secret-key`, `trino.bypass.hive.s3.region`
-are the required the configurations use by the Apache Gravitino Trino connector.
+are the required the configurations for the Apache Gravitino Trino connector.
 - The configurations of `s3-access-key-id`, `s3-secret-access-key`, `io-impl` and `s3-region`.
-is the required the configuration of the [Apache Gravitino Iceberg catalog](../lakehouse-iceberg-catalog.md#S3).
-- The `location` is the storage path of AWS s3. You need make sure the directory in AWS S3 is exists.
+are the required the configurations for the [Apache Gravitino Iceberg catalog](../lakehouse-iceberg-catalog.md#S3).
+- The `location` specifies the storage path on AWS S3. Ensure that the specified directory exists on AWS S3 before proceeding.
 
-When the Iceberg catalog created successfully, you can create schemas and tables by the following command.
+Once the Iceberg catalog is successfully created, users can create schemas and tables as follows:
 
 ```sql
 CREATE SCHEMA gt_iceberg.gt_db03;
@@ -278,9 +279,9 @@ CREATE TABLE gt_iceberg.gt_db03.tb01 (
 );
 ```
 
-After that, you can use the table read and write the data in AWS S3.
+After running the command, the tables are ready for data reading and writing operations on AWS S3.
 
 :::note
-The Iceberg catalog module in the Apache Gravitino server should Add AWS s3 support.
+TThe Iceberg catalog module in the Apache Gravitino server should add AWS S3 support.
 Please refer to [Apache Gravitino Iceberg catalog](../lakehouse-iceberg-catalog.md#S3).
 :::

--- a/docs/trino-connector/catalog-iceberg.md
+++ b/docs/trino-connector/catalog-iceberg.md
@@ -240,7 +240,7 @@ replacing hdfs_user with the appropriate username:
 ## S3
 
 When using AWS S3 within the Iceberg catalog, users need to configure the Trino Iceberg connector's
-AWS S3-related properties in the catalog's properties. For specific guidance, please refer to the documentation
+AWS S3-related properties in the catalog's properties. Please refer to the documentation
 of [Hive connector with Amazon S3](https://trino.io/docs/435/connector/hive-s3.html).
 These configurations must use the `trino.bypass.` prefix in the Iceberg catalog's attributes to be effective.
 


### PR DESCRIPTION

### What changes were proposed in this pull request?

Add documentation for the Gravitino-Trino connector running on AWS S3. 
The Hive catalog and Iceberg catalog support S3

### Why are the changes needed?

Fix: #4657

### Does this PR introduce _any_ user-facing change?

Update docs

### How was this patch tested?

NO