### PR TITLE
[#4664] fix(server): Add the missing annotations fo access control interfaces

### DIFF
--- a/conf/gravitino.conf.template
+++ b/conf/gravitino.conf.template
@@ -63,7 +63,7 @@ gravitino.catalog.cache.evictionIntervalMs = 3600000
 # Whether Gravitino enable authorization or not
 gravitino.authorization.enable = false
 # The admins of Gravitino service, multiple admins are spitted by comma.
-gravitino.authorization.serviceAdmin = anonymous
+gravitino.authorization.serviceAdmins= anonymous
 
 # THE CONFIGURATION FOR AUXILIARY SERVICE
 # Auxiliary service names, separate by ','

--- a/conf/gravitino.conf.template
+++ b/conf/gravitino.conf.template
@@ -59,6 +59,12 @@ gravitino.entity.store.relational.jdbcPassword = gravitino
 # The interval in milliseconds to evict the catalog cache
 gravitino.catalog.cache.evictionIntervalMs = 3600000
 
+# THE CONFIGURATION FOR authorization
+# Whether Gravitino enable authorization or not
+gravitino.authorization.enable = false
+# The admins of Gravitino service, multiple admins are spitted by comma.
+gravitino.authorization.serviceAdmin = anonymous
+
 # THE CONFIGURATION FOR AUXILIARY SERVICE
 # Auxiliary service names, separate by ','
 gravitino.auxService.names = iceberg-rest

--- a/conf/gravitino.conf.template
+++ b/conf/gravitino.conf.template
@@ -63,7 +63,7 @@ gravitino.catalog.cache.evictionIntervalMs = 3600000
 # Whether Gravitino enable authorization or not
 gravitino.authorization.enable = false
 # The admins of Gravitino service, multiple admins are spitted by comma.
-gravitino.authorization.serviceAdmins= anonymous
+gravitino.authorization.serviceAdmins = anonymous
 
 # THE CONFIGURATION FOR AUXILIARY SERVICE
 # Auxiliary service names, separate by ','

--- a/docs/security/access-control.md
+++ b/docs/security/access-control.md
@@ -244,7 +244,7 @@ The related configuration is as follows.
 | Configuration item                       | Description                                                            | Default value | Required                         | Since Version |
 |------------------------------------------|------------------------------------------------------------------------|---------------|----------------------------------|---------------|
 | `gravitino.authorization.enable`         | Whether Gravitino enable authorization or not.                         | false         | No                               | 0.5.0         |
-| `gravitino.authorization.serviceAdmins`  | The admins of Gravitino service, Multiple admins are spitted by comma. | (none)        | Yes if enables the authorization | 0.5.0         |
+| `gravitino.authorization.serviceAdmins`  | The admins of Gravitino service, multiple admins are spitted by comma. | (none)        | Yes if enables the authorization | 0.5.0         |
 
 
 ## User Operation

--- a/docs/security/access-control.md
+++ b/docs/security/access-control.md
@@ -259,7 +259,7 @@ You should add the user to your metalake before you use the authorization.
 ```shell
 curl -X POST -H "Accept: application/vnd.gravitino.v1+json" \
 -H "Content-Type: application/json" -d '{
-  "name": "user1",
+  "name": "user1"
 }' http://localhost:8090/api/metalakes/test/users
 ```
 
@@ -335,7 +335,7 @@ You should add the group to your metalake before you use the authorization.
 ```shell
 curl -X POST -H "Accept: application/vnd.gravitino.v1+json" \
 -H "Content-Type: application/json" -d '{
-  "name": "group1",
+  "name": "group1"
 }' http://localhost:8090/api/metalakes/test/groups
 ```
 
@@ -412,7 +412,7 @@ You can create a role by given properties.
 curl -X POST -H "Accept: application/vnd.gravitino.v1+json" \
 -H "Content-Type: application/json" -d '{
    "name": "role1",
-   "properties": {"k1", "v1"}
+   "properties": {"k1": "v1"},
    "securableObjects": [
           {
              "fullName": "catalog1.schema1.table1",
@@ -459,7 +459,7 @@ You can get a role by its name.
 
 ```shell
 curl -X GET -H "Accept: application/vnd.gravitino.v1+json" \
--H "Content-Type: application/json" -d http://localhost:8090/api/metalakes/test/roles/role1
+-H "Content-Type: application/json"  http://localhost:8090/api/metalakes/test/roles/role1
 ```
 
 </TabItem>
@@ -511,7 +511,7 @@ You can grant specific roles to a user.
 curl -X PUT -H "Accept: application/vnd.gravitino.v1+json" \
 -H "Content-Type: application/json" -d '{
     "roleNames": ["role1"]
-}'http://localhost:8090/api/metalakes/test/permissions/users/user1/grant
+}' http://localhost:8090/api/metalakes/test/permissions/users/user1/grant
 ```
 
 </TabItem>
@@ -536,7 +536,7 @@ You can revoke specific roles from a user.
 curl -X PUT -H "Accept: application/vnd.gravitino.v1+json" \
 -H "Content-Type: application/json" -d '{
     "roleNames": ["role1"]
-}'http://localhost:8090/api/metalakes/test/permissions/users/user1/revoke
+}' http://localhost:8090/api/metalakes/test/permissions/users/user1/revoke
 ```
 
 </TabItem>
@@ -562,7 +562,7 @@ You can grant specific roles to a group.
 curl -X PUT -H "Accept: application/vnd.gravitino.v1+json" \
 -H "Content-Type: application/json" -d '{
     "roleNames": ["role1"]
-}'http://localhost:8090/api/metalakes/test/permissions/groups/group1/grant
+}' http://localhost:8090/api/metalakes/test/permissions/groups/group1/grant
 ```
 
 </TabItem>
@@ -587,7 +587,7 @@ You can revoke specific roles from a group.
 curl -X PUT -H "Accept: application/vnd.gravitino.v1+json" \
 -H "Content-Type: application/json" -d '{
     "roleNames": ["role1"]
-}'http://localhost:8090/api/metalakes/test/permissions/groups/group1/revoke
+}' http://localhost:8090/api/metalakes/test/permissions/groups/group1/revoke
 ```
 
 </TabItem>
@@ -642,7 +642,7 @@ curl -X PUT -H "Accept: application/vnd.gravitino.v1+json" \
 -H "Content-Type: application/json" -d '{
     "name": "user1",
     "type": "USER"
-}'http://localhost:8090/api/metalakes/test/owners/table/catalog1.schema1.table1
+}' http://localhost:8090/api/metalakes/test/owners/table/catalog1.schema1.table1
 ```
 
 </TabItem>

--- a/server-common/src/main/java/org/apache/gravitino/server/authorization/NameBindings.java
+++ b/server-common/src/main/java/org/apache/gravitino/server/authorization/NameBindings.java
@@ -24,8 +24,10 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import javax.ws.rs.NameBinding;
 
+/* This class is used for Jersey filters to bind operations with the filters which need. */
 public class NameBindings {
 
+  /* This annotation will bind all access control related operations */
   @NameBinding
   @Target({ElementType.TYPE, ElementType.METHOD})
   @Retention(RetentionPolicy.RUNTIME)

--- a/server/src/main/java/org/apache/gravitino/server/web/rest/PermissionOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/PermissionOperations.java
@@ -40,8 +40,10 @@ import org.apache.gravitino.dto.util.DTOConverters;
 import org.apache.gravitino.lock.LockType;
 import org.apache.gravitino.lock.TreeLockUtils;
 import org.apache.gravitino.metrics.MetricNames;
+import org.apache.gravitino.server.authorization.NameBindings;
 import org.apache.gravitino.server.web.Utils;
 
+@NameBindings.AccessControlInterfaces
 @Path("/metalakes/{metalake}/permissions")
 public class PermissionOperations {
 

--- a/server/src/main/java/org/apache/gravitino/server/web/rest/RoleOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/RoleOperations.java
@@ -50,10 +50,12 @@ import org.apache.gravitino.exceptions.NoSuchMetadataObjectException;
 import org.apache.gravitino.lock.LockType;
 import org.apache.gravitino.lock.TreeLockUtils;
 import org.apache.gravitino.metrics.MetricNames;
+import org.apache.gravitino.server.authorization.NameBindings;
 import org.apache.gravitino.server.web.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@NameBindings.AccessControlInterfaces
 @Path("/metalakes/{metalake}/roles")
 public class RoleOperations {
   private static final Logger LOG = LoggerFactory.getLogger(RoleOperations.class);


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add the missing annotations for access control interfaces.
Fix the document by the way.

### Why are the changes needed?

Fix: #4664

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
By hand.
