### PR TITLE
Issue #4305 Added default statements to 4 switch case statements

### DIFF
--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/FilesetMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/FilesetMetaService.java
@@ -319,6 +319,8 @@ public class FilesetMetaService {
               SchemaMetaService.getInstance().getSchemaIdByCatalogIdAndName(parentEntityId, name);
           builder.withSchemaId(parentEntityId);
           break;
+        default:
+          throw new IllegalArgumentException("Unsupported namespace level: " + level);
       }
     }
   }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/SchemaMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/SchemaMetaService.java
@@ -275,6 +275,8 @@ public class SchemaMetaService {
                   .getCatalogIdByMetalakeIdAndName(parentEntityId, name);
           builder.withCatalogId(parentEntityId);
           break;
+        default:
+          throw new IllegalArgumentException("Unsupported namespace level: " + level);          
       }
     }
   }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/TableMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/TableMetaService.java
@@ -226,6 +226,8 @@ public class TableMetaService {
               SchemaMetaService.getInstance().getSchemaIdByCatalogIdAndName(parentEntityId, name);
           builder.withSchemaId(parentEntityId);
           break;
+        default:
+          throw new IllegalArgumentException("Unsupported namespace level: " + level);                    
       }
     }
   }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/TopicMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/TopicMetaService.java
@@ -171,6 +171,8 @@ public class TopicMetaService {
               SchemaMetaService.getInstance().getSchemaIdByCatalogIdAndName(parentEntityId, name);
           builder.withSchemaId(parentEntityId);
           break;
+        default:
+          throw new IllegalArgumentException("Unsupported namespace level: " + level);          
       }
     }
   }


### PR DESCRIPTION
#4305 Improvement : switch statements missing default
- "[MINOR]:
     - "1 : Added default statement to the switch statement in core\src\main\java\org\apache\gravitino\storage\relational\service\FilesetMetaService.java file."
     - "2 : Added default statement to the switch statement in core\src\main\java\org\apache\gravitino\storage\relational\service\TableMetaService.java"
     - "3 : Added default statement to the switch statement in core\src\main\java\org\apache\gravitino\storage\relational\service\TopicMetaService.java " 
     - "4 : Added default statement to the switch statement in core\src\main\java\org\apache\gravitino\storage\relational\service\SchemaMetaService.java"
     

### Does this PR introduce _any_ user-facing change?
No