### PR TITLE
[Minor] improvement(CI): Fix backend tests fail occasionally as a result of CI pipeline timeout.

### DIFF
--- a/.github/workflows/backend-integration-test.yml
+++ b/.github/workflows/backend-integration-test.yml
@@ -56,7 +56,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.source_changes == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 90
     strategy:
       matrix:
         architecture: [linux/amd64]


### PR DESCRIPTION
### What changes were proposed in this pull request?

Increase the timeout time for backend integration tests from 60 minutes to 90 minutes

### Why are the changes needed?

Accordingly tests from https://github.com/apache/gravitino/actions/runs/10552034338/job/29230290884?pr=4260, the backend integration could take up to 60 minutes, which is more than the maximum time allowed.  

<img width="1955" alt="image" src="https://github.com/user-attachments/assets/d19aa313-9ecb-4b3b-b00a-218b804d9400">



**The root cause could be that MySQL's backend is relatively slow in some cases, so more tests are needed for information needs.**


### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

N/A.
