### PR TITLE
[#4662] improve(IT): Add ranger authorization Hive E2E test

### DIFF
--- a/.github/workflows/access-control-integration-test.yml
+++ b/.github/workflows/access-control-integration-test.yml
@@ -1,0 +1,96 @@
+name: Access Control Integration Test
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push or pull request events but only for the "main" branch
+  push:
+    branches: [ "main", "branch-*" ]
+  pull_request:
+    branches: [ "main", "branch-*" ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  changes:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            source_changes:
+              - api/**
+              - authorizations/**
+              - catalogs/**
+              - clients/client-java/**
+              - clients/client-java-runtime/**
+              - common/**
+              - core/**
+              - integration-test-common/**
+              - server/**
+              - server-common/**
+    outputs:
+      source_changes: ${{ steps.filter.outputs.source_changes }}
+
+  # Integration test for AMD64 architecture
+  test-amd64-arch:
+    needs: changes
+    if: needs.changes.outputs.source_changes == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    strategy:
+      matrix:
+        # Integration test for AMD64 architecture
+        architecture: [linux/amd64]
+        java-version: [ 17 ]
+        test-mode: [ embedded, deploy ]
+        include:
+          - test-mode: 'embedded'
+            backend: 'h2'
+          - test-mode: 'deploy'
+            backend: 'mysql'
+
+    env:
+      PLATFORM: ${{ matrix.architecture }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-java@v4
+        with:
+          java-version: ${{ matrix.java-version }}
+          distribution: 'temurin'
+          cache: 'gradle'
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Check required command
+        run: |
+          dev/ci/check_commands.sh
+
+      - name: Package Gravitino
+        if : ${{ matrix.test-mode == 'deploy' }}
+        run: |
+          ./gradlew compileDistribution -x test -PjdkVersion=${{ matrix.java-version }}
+
+      - name: Free up disk space
+        run: |
+          dev/ci/util_free_space.sh
+
+      - name: Authorization Integration Test (JDK${{ matrix.java-version }}-${{ matrix.test-mode }}-${{ matrix.backend }})
+        id: integrationTest
+        run: |
+          ./gradlew -PskipTests -PtestMode=${{ matrix.test-mode }} -PjdbcBackend=${{ matrix.backend }} -PjdkVersion=${{ matrix.java-version }} -PskipDockerTests=false :authorizations:authorization-ranger:test --tests "org.apache.gravitino.authorization.ranger.integration.test.**"
+
+      - name: Upload integrate tests reports
+        uses: actions/upload-artifact@v3
+        if: ${{ (failure() && steps.integrationTest.outcome == 'failure') || contains(github.event.pull_request.labels.*.name, 'upload log') }}
+        with:
+          name: authorizations-integrate-test-reports-${{ matrix.java-version }}
+          path: |
+            build/reports
+            distribution/package/logs/gravitino-server.out
+            distribution/package/logs/gravitino-server.log

--- a/.github/workflows/backend-integration-test.yml
+++ b/.github/workflows/backend-integration-test.yml
@@ -90,13 +90,84 @@ jobs:
         run: |
           dev/ci/util_free_space.sh
 
-      - name: Backend Integration Test(JDK${{ matrix.java-version }}-${{ matrix.test-mode }}-${{ matrix.backend }})
+      - name: Backend Integration Test (JDK${{ matrix.java-version }}-${{ matrix.test-mode }}-${{ matrix.backend }})
         id: integrationTest
         run: >
           ./gradlew test -PskipTests -PtestMode=${{ matrix.test-mode }} -PjdkVersion=${{ matrix.java-version }} -PjdbcBackend=${{ matrix.backend }} -PskipWebITs -PskipDockerTests=false
           -x :web:test -x :clients:client-python:test -x :flink-connector:test -x :spark-connector:test -x :spark-connector:spark-common:test 
           -x :spark-connector:spark-3.3:test -x :spark-connector:spark-3.4:test -x :spark-connector:spark-3.5:test 
           -x :spark-connector:spark-runtime-3.3:test -x :spark-connector:spark-runtime-3.4:test -x :spark-connector:spark-runtime-3.5:test
+          -x :authorizations:authorization-ranger:test
+
+      - name: Upload integrate tests reports
+        uses: actions/upload-artifact@v3
+        if: ${{ (failure() && steps.integrationTest.outcome == 'failure') || contains(github.event.pull_request.labels.*.name, 'upload log') }}
+        with:
+          name: integrate-test-reports-${{ matrix.java-version }}-${{ matrix.test-mode }}-${{ matrix.backend }}
+          path: |
+            build/reports
+            iceberg/iceberg-rest-server/build/*.log
+            integration-test/build/*.log
+            integration-test/build/*.tar
+            integration-test/build/trino-ci-container-log
+            distribution/package/logs/*.out
+            distribution/package/logs/*.log
+            catalogs/**/*.log
+            catalogs/**/*.tar
+            distribution/**/*.log
+
+  test-on-pr:
+    needs: changes
+    if: (github.event_name == 'pull_request' && needs.changes.outputs.source_changes == 'true')
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    strategy:
+      matrix:
+        # Integration test for AMD64 architecture
+        architecture: [ linux/amd64 ]
+        java-version: [ 17 ]
+        test-mode: [ embedded, deploy ]
+        include:
+          - test-mode: 'embedded'
+            backend: 'h2'
+          - test-mode: 'deploy'
+            backend: 'mysql'
+
+    env:
+      PLATFORM: ${{ matrix.architecture }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-java@v4
+        with:
+          java-version: ${{ matrix.java-version }}
+          distribution: 'temurin'
+          cache: 'gradle'
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Check required command
+        run: |
+          dev/ci/check_commands.sh
+
+      - name: Package Gravitino
+        if: ${{ matrix.test-mode == 'deploy' }}
+        run: |
+          ./gradlew compileDistribution -x test -PjdkVersion=${{ matrix.java-version }}
+
+      - name: Free up disk space
+        run: |
+          dev/ci/util_free_space.sh
+
+      - name: Backend Integration Test (JDK${{ matrix.java-version }}-${{ matrix.test-mode }}-${{ matrix.backend }})
+        id: integrationTest
+        run: >
+          ./gradlew test -PskipTests -PtestMode=${{ matrix.test-mode }} -PjdkVersion=${{ matrix.java-version }} -PjdbcBackend=${{ matrix.backend }} -PskipWebITs -PskipDockerTests=false
+          -x :web:test -x :clients:client-python:test -x :flink-connector:test -x :spark-connector:test -x :spark-connector:spark-common:test 
+          -x :spark-connector:spark-3.3:test -x :spark-connector:spark-3.4:test -x :spark-connector:spark-3.5:test 
+          -x :spark-connector:spark-runtime-3.3:test -x :spark-connector:spark-runtime-3.4:test -x :spark-connector:spark-runtime-3.5:test
+          -x :authorizations:authorization-ranger:test
 
       - name: Upload integrate tests reports
         uses: actions/upload-artifact@v3

--- a/LICENSE.bin
+++ b/LICENSE.bin
@@ -310,6 +310,8 @@
    Apache Yetus - Audience Annotations
    Apache Kerby
    Apache Kyuubi
+   Apache Ranger
+   Apache Ranger intg
    Jackson JSON processor
    DataNucleus
    Modernizer Maven Plugin
@@ -364,7 +366,7 @@
 
    This product bundles various third-party components also under the
    BSD license
-   
+
    JSR305
    LevelDB JNI
    RocksDB JNI
@@ -446,6 +448,7 @@
    Jakarta RESTful WS API
    Jakarta XML Binding API
    JavaServer Pages(TM) API
+   Javax WS RS API
    HK2 API Module
    HK2 Service Locator
    HK2 Utils

--- a/NOTICE.bin
+++ b/NOTICE.bin
@@ -22,6 +22,9 @@ Copyright 2008-2023 The Apache Software Foundation
 Apache Zeppelin
 Copyright 2016-2023 The Apache Software Foundation
 
+Apache Ranger
+Copyright 2014-2024 The Apache Software Foundation
+
 Apache Hadoop
 Copyright 2006 and onwards The Apache Software Foundation.
 

--- a/authorizations/authorization-ranger/src/test/java/org/apache/gravitino/authorization/ranger/integration/test/RangerHiveE2EIT.java
+++ b/authorizations/authorization-ranger/src/test/java/org/apache/gravitino/authorization/ranger/integration/test/RangerHiveE2EIT.java
@@ -1,0 +1,242 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.authorization.ranger.integration.test;
+
+import static org.apache.gravitino.Catalog.AUTHORIZATION_PROVIDER;
+import static org.apache.gravitino.connector.AuthorizationPropertiesMeta.RANGER_ADMIN_URL;
+import static org.apache.gravitino.connector.AuthorizationPropertiesMeta.RANGER_AUTH_TYPE;
+import static org.apache.gravitino.connector.AuthorizationPropertiesMeta.RANGER_PASSWORD;
+import static org.apache.gravitino.connector.AuthorizationPropertiesMeta.RANGER_SERVICE_NAME;
+import static org.apache.gravitino.connector.AuthorizationPropertiesMeta.RANGER_USERNAME;
+import static org.apache.gravitino.integration.test.container.RangerContainer.RANGER_SERVER_PORT;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+import org.apache.gravitino.Catalog;
+import org.apache.gravitino.Configs;
+import org.apache.gravitino.MetadataObject;
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.Schema;
+import org.apache.gravitino.auth.AuthConstants;
+import org.apache.gravitino.authorization.Privileges;
+import org.apache.gravitino.authorization.Role;
+import org.apache.gravitino.authorization.SecurableObject;
+import org.apache.gravitino.authorization.SecurableObjects;
+import org.apache.gravitino.authorization.ranger.RangerAuthorizationPlugin;
+import org.apache.gravitino.catalog.hive.HiveConstants;
+import org.apache.gravitino.client.GravitinoMetalake;
+import org.apache.gravitino.connector.AuthorizationPropertiesMeta;
+import org.apache.gravitino.integration.test.container.HiveContainer;
+import org.apache.gravitino.integration.test.container.RangerContainer;
+import org.apache.gravitino.integration.test.util.AbstractIT;
+import org.apache.gravitino.integration.test.util.GravitinoITUtils;
+import org.apache.gravitino.rel.Column;
+import org.apache.gravitino.rel.Table;
+import org.apache.gravitino.rel.expressions.NamedReference;
+import org.apache.gravitino.rel.expressions.distributions.Distribution;
+import org.apache.gravitino.rel.expressions.distributions.Distributions;
+import org.apache.gravitino.rel.expressions.distributions.Strategy;
+import org.apache.gravitino.rel.expressions.sorts.NullOrdering;
+import org.apache.gravitino.rel.expressions.sorts.SortDirection;
+import org.apache.gravitino.rel.expressions.sorts.SortOrder;
+import org.apache.gravitino.rel.expressions.sorts.SortOrders;
+import org.apache.gravitino.rel.expressions.transforms.Transforms;
+import org.apache.gravitino.rel.types.Types;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Tag("gravitino-docker-test")
+public class RangerHiveE2EIT extends AbstractIT {
+  private static final Logger LOG = LoggerFactory.getLogger(RangerHiveE2EIT.class);
+
+  private static RangerAuthorizationPlugin rangerAuthPlugin;
+  public static final String metalakeName =
+      GravitinoITUtils.genRandomName("RangerHiveAuthIT_metalake").toLowerCase();
+  public static final String catalogName =
+      GravitinoITUtils.genRandomName("RangerHiveAuthIT_catalog").toLowerCase();
+  public static final String schemaName =
+      GravitinoITUtils.genRandomName("RangerHiveAuthIT_schema").toLowerCase();
+  public static final String tableName =
+      GravitinoITUtils.genRandomName("RangerHiveAuthIT_table").toLowerCase();
+
+  public static final String HIVE_COL_NAME1 = "hive_col_name1";
+  public static final String HIVE_COL_NAME2 = "hive_col_name2";
+  public static final String HIVE_COL_NAME3 = "hive_col_name3";
+
+  private static GravitinoMetalake metalake;
+  private static Catalog catalog;
+  private static final String provider = "hive";
+  private static String HIVE_METASTORE_URIS;
+
+  @BeforeAll
+  public static void startIntegrationTest() throws Exception {
+    Map<String, String> configs = Maps.newHashMap();
+    configs.put(Configs.ENABLE_AUTHORIZATION.getKey(), String.valueOf(true));
+    configs.put(Configs.SERVICE_ADMINS.getKey(), AuthConstants.ANONYMOUS_USER);
+    registerCustomConfigs(configs);
+    AbstractIT.startIntegrationTest();
+
+    RangerITEnv.setup();
+    containerSuite.startHiveContainer();
+    HIVE_METASTORE_URIS =
+        String.format(
+            "thrift://%s:%d",
+            containerSuite.getHiveContainer().getContainerIpAddress(),
+            HiveContainer.HIVE_METASTORE_PORT);
+
+    createMetalake();
+    createCatalogAndRangerAuthPlugin();
+    createSchema();
+    createHiveTable();
+  }
+
+  @AfterAll
+  public static void stop() throws IOException {
+    AbstractIT.client = null;
+  }
+
+  @Test
+  void testCreateRole() {
+    String roleName = RangerITEnv.currentFunName();
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put("k1", "v1");
+
+    SecurableObject table1 =
+        SecurableObjects.parse(
+            String.format("%s.%s.%s", catalogName, schemaName, tableName),
+            MetadataObject.Type.TABLE,
+            Lists.newArrayList(Privileges.SelectTable.allow()));
+    Role role = metalake.createRole(roleName, properties, Lists.newArrayList(table1));
+    RangerITEnv.verifyRoleInRanger(rangerAuthPlugin, role);
+  }
+
+  private static void createMetalake() {
+    GravitinoMetalake[] gravitinoMetalakes = client.listMetalakes();
+    Assertions.assertEquals(0, gravitinoMetalakes.length);
+
+    GravitinoMetalake createdMetalake =
+        client.createMetalake(metalakeName, "comment", Collections.emptyMap());
+    GravitinoMetalake loadMetalake = client.loadMetalake(metalakeName);
+    Assertions.assertEquals(createdMetalake, loadMetalake);
+
+    metalake = loadMetalake;
+  }
+
+  private static void createCatalogAndRangerAuthPlugin() {
+    rangerAuthPlugin =
+        new RangerAuthorizationPlugin(
+            "hive",
+            ImmutableMap.of(
+                AuthorizationPropertiesMeta.RANGER_ADMIN_URL,
+                String.format(
+                    "http://%s:%d",
+                    containerSuite.getRangerContainer().getContainerIpAddress(),
+                    RangerContainer.RANGER_SERVER_PORT),
+                AuthorizationPropertiesMeta.RANGER_AUTH_TYPE,
+                RangerContainer.authType,
+                AuthorizationPropertiesMeta.RANGER_USERNAME,
+                RangerContainer.rangerUserName,
+                AuthorizationPropertiesMeta.RANGER_PASSWORD,
+                RangerContainer.rangerPassword,
+                AuthorizationPropertiesMeta.RANGER_SERVICE_NAME,
+                RangerITEnv.RANGER_HIVE_REPO_NAME));
+
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put(HiveConstants.METASTORE_URIS, HIVE_METASTORE_URIS);
+    properties.put(AUTHORIZATION_PROVIDER, "ranger");
+    properties.put(RANGER_SERVICE_NAME, RangerITEnv.RANGER_HIVE_REPO_NAME);
+    properties.put(
+        RANGER_ADMIN_URL,
+        String.format(
+            "http://localhost:%s",
+            containerSuite.getRangerContainer().getMappedPort(RANGER_SERVER_PORT)));
+    properties.put(RANGER_AUTH_TYPE, RangerContainer.authType);
+    properties.put(RANGER_USERNAME, RangerContainer.rangerUserName);
+    properties.put(RANGER_PASSWORD, RangerContainer.rangerPassword);
+
+    metalake.createCatalog(catalogName, Catalog.Type.RELATIONAL, provider, "comment", properties);
+    catalog = metalake.loadCatalog(catalogName);
+    LOG.info("Catalog created: {}", catalog);
+  }
+
+  private static void createSchema() {
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put("key1", "val1");
+    properties.put("key2", "val2");
+    properties.put(
+        "location",
+        String.format(
+            "hdfs://%s:%d/user/hive/warehouse/%s.db",
+            containerSuite.getHiveContainer().getContainerIpAddress(),
+            HiveContainer.HDFS_DEFAULTFS_PORT,
+            schemaName.toLowerCase()));
+    String comment = "comment";
+
+    catalog.asSchemas().createSchema(schemaName, comment, properties);
+    Schema loadSchema = catalog.asSchemas().loadSchema(schemaName);
+    Assertions.assertEquals(schemaName.toLowerCase(), loadSchema.name());
+  }
+
+  public static void createHiveTable() {
+    // Create table from Gravitino API
+    Column[] columns = createColumns();
+    NameIdentifier nameIdentifier = NameIdentifier.of(schemaName, tableName);
+
+    Distribution distribution =
+        Distributions.of(Strategy.EVEN, 10, NamedReference.field(HIVE_COL_NAME1));
+
+    final SortOrder[] sortOrders =
+        new SortOrder[] {
+          SortOrders.of(
+              NamedReference.field(HIVE_COL_NAME2),
+              SortDirection.DESCENDING,
+              NullOrdering.NULLS_FIRST)
+        };
+
+    Map<String, String> properties = ImmutableMap.of("key1", "val1", "key2", "val2");
+    Table createdTable =
+        catalog
+            .asTableCatalog()
+            .createTable(
+                nameIdentifier,
+                columns,
+                "table_comment",
+                properties,
+                Transforms.EMPTY_TRANSFORM,
+                distribution,
+                sortOrders);
+    LOG.info("Table created: {}", createdTable);
+  }
+
+  private static Column[] createColumns() {
+    Column col1 = Column.of(HIVE_COL_NAME1, Types.ByteType.get(), "col_1_comment");
+    Column col2 = Column.of(HIVE_COL_NAME2, Types.DateType.get(), "col_2_comment");
+    Column col3 = Column.of(HIVE_COL_NAME3, Types.StringType.get(), "col_3_comment");
+    return new Column[] {col1, col2, col3};
+  }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -543,7 +543,7 @@ tasks {
   val outputDir = projectDir.dir("distribution")
 
   val compileDistribution by registering {
-    dependsOn("copySubprojectDependencies", "copyCatalogLibAndConfigs", "copySubprojectLib", "iceberg:iceberg-rest-server:copyLibAndConfigs")
+    dependsOn("copySubprojectDependencies", "copyCatalogLibAndConfigs", "copyAuthorizationLibAndConfigs", "copySubprojectLib", "iceberg:iceberg-rest-server:copyLibAndConfigs")
 
     group = "gravitino distribution"
     outputs.dir(projectDir.dir("distribution/package"))
@@ -713,6 +713,7 @@ tasks {
   register("copySubprojectDependencies", Copy::class) {
     subprojects.forEach() {
       if (!it.name.startsWith("catalog") &&
+        !it.name.startsWith("authorization") &&
         !it.name.startsWith("client") && !it.name.startsWith("filesystem") && !it.name.startsWith("spark") && !it.name.startsWith("iceberg") && it.name != "trino-connector" &&
         it.name != "integration-test" && it.name != "bundled-catalog" && it.name != "flink-connector"
       ) {
@@ -726,20 +727,16 @@ tasks {
     subprojects.forEach() {
       if (!it.name.startsWith("catalog") &&
         !it.name.startsWith("client") &&
+        !it.name.startsWith("authorization") &&
         !it.name.startsWith("filesystem") &&
         !it.name.startsWith("spark") &&
         !it.name.startsWith("iceberg") &&
         !it.name.startsWith("integration-test") &&
-        it.name != "authorizations" &&
         it.name != "trino-connector" &&
         it.name != "bundled-catalog" &&
         it.name != "flink-connector"
       ) {
-        if (it.name.startsWith("authorization-")) {
-          dependsOn(":authorizations:${it.name}:build")
-        } else {
-          dependsOn("${it.name}:build")
-        }
+        dependsOn("${it.name}:build")
         from("${it.name}/build/libs")
         into("distribution/package/libs")
         include("*.jar")
@@ -757,7 +754,13 @@ tasks {
       ":catalogs:catalog-jdbc-mysql:copyLibAndConfig",
       ":catalogs:catalog-jdbc-postgresql:copyLibAndConfig",
       ":catalogs:catalog-hadoop:copyLibAndConfig",
-      "catalogs:catalog-kafka:copyLibAndConfig"
+      ":catalogs:catalog-kafka:copyLibAndConfig"
+    )
+  }
+
+  register("copyAuthorizationLibAndConfigs", Copy::class) {
+    dependsOn(
+      ":authorizations:authorization-ranger:copyLibAndConfig"
     )
   }
 

--- a/catalogs/catalog-jdbc-common/src/main/java/org/apache/gravitino/catalog/jdbc/JdbcCatalogPropertiesMetadata.java
+++ b/catalogs/catalog-jdbc-common/src/main/java/org/apache/gravitino/catalog/jdbc/JdbcCatalogPropertiesMetadata.java
@@ -23,6 +23,7 @@ import static org.apache.gravitino.connector.PropertyEntry.stringOptionalPropert
 import static org.apache.gravitino.connector.PropertyEntry.stringPropertyEntry;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import java.util.List;
 import java.util.Map;
@@ -94,7 +95,11 @@ public class JdbcCatalogPropertiesMetadata extends BaseCatalogPropertiesMetadata
                 JdbcConfig.POOL_MAX_SIZE.getDefaultValue(),
                 true /* hidden */,
                 false /* reserved */));
-    PROPERTIES_METADATA = Maps.uniqueIndex(propertyEntries, PropertyEntry::getName);
+    PROPERTIES_METADATA =
+        ImmutableMap.<String, PropertyEntry<?>>builder()
+            .putAll(BASIC_CATALOG_PROPERTY_ENTRIES)
+            .putAll(Maps.uniqueIndex(propertyEntries, PropertyEntry::getName))
+            .build();
   }
 
   @Override

--- a/catalogs/catalog-kafka/src/main/java/org/apache/gravitino/catalog/kafka/KafkaCatalogPropertiesMetadata.java
+++ b/catalogs/catalog-kafka/src/main/java/org/apache/gravitino/catalog/kafka/KafkaCatalogPropertiesMetadata.java
@@ -18,7 +18,7 @@
  */
 package org.apache.gravitino.catalog.kafka;
 
-import java.util.Collections;
+import com.google.common.collect.ImmutableMap;
 import java.util.Map;
 import org.apache.gravitino.connector.BaseCatalogPropertiesMetadata;
 import org.apache.gravitino.connector.PropertyEntry;
@@ -30,13 +30,17 @@ public class KafkaCatalogPropertiesMetadata extends BaseCatalogPropertiesMetadat
   public static final String BOOTSTRAP_SERVERS = "bootstrap.servers";
 
   private static final Map<String, PropertyEntry<?>> KAFKA_CATALOG_PROPERTY_ENTRIES =
-      Collections.singletonMap(
-          BOOTSTRAP_SERVERS,
-          PropertyEntry.stringRequiredPropertyEntry(
+      ImmutableMap.<String, PropertyEntry<?>>builder()
+          .put(
               BOOTSTRAP_SERVERS,
-              "The Kafka broker(s) to connect to, allowing for multiple brokers by comma-separating them",
-              false /* immutable */,
-              false /* hidden */));
+              PropertyEntry.stringRequiredPropertyEntry(
+                  BOOTSTRAP_SERVERS,
+                  "The Kafka broker(s) to connect to, allowing for multiple brokers by "
+                      + "comma-separating them",
+                  false /* immutable */,
+                  false /* hidden */))
+          .putAll(BASIC_CATALOG_PROPERTY_ENTRIES)
+          .build();
 
   @Override
   protected Map<String, PropertyEntry<?>> specificPropertyEntries() {

--- a/core/src/main/java/org/apache/gravitino/connector/BaseCatalog.java
+++ b/core/src/main/java/org/apache/gravitino/connector/BaseCatalog.java
@@ -38,6 +38,7 @@ import org.apache.gravitino.connector.authorization.AuthorizationProvider;
 import org.apache.gravitino.connector.authorization.BaseAuthorization;
 import org.apache.gravitino.connector.capability.Capability;
 import org.apache.gravitino.meta.CatalogEntity;
+import org.apache.gravitino.utils.IsolatedClassLoader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -181,51 +182,52 @@ public abstract class BaseCatalog<T extends BaseCatalog>
 
   public AuthorizationPlugin getAuthorizationPlugin() {
     if (authorization == null) {
-      synchronized (this) {
-        if (authorization == null) {
-          BaseAuthorization<?> baseAuthorization = createAuthorizationPluginInstance();
-          if (baseAuthorization == null) {
-            return null;
-          }
-          authorization = baseAuthorization;
-        }
-      }
+      return null;
     }
     return authorization.plugin(provider(), this.conf);
   }
 
-  private BaseAuthorization<?> createAuthorizationPluginInstance() {
-    String authorizationProvider =
-        catalogPropertiesMetadata().containsProperty(AUTHORIZATION_PROVIDER)
-            ? (String) catalogPropertiesMetadata().getOrDefault(conf, AUTHORIZATION_PROVIDER)
-            : null;
+  public void initAuthorizationPluginInstance(IsolatedClassLoader classLoader) {
+    if (authorization != null) {
+      return;
+    }
 
+    String authorizationProvider =
+        (String) catalogPropertiesMetadata().getOrDefault(conf, AUTHORIZATION_PROVIDER);
     if (authorizationProvider == null) {
       LOG.info("Authorization provider is not set!");
-      return null;
+      return;
     }
 
-    ServiceLoader<AuthorizationProvider> loader =
-        ServiceLoader.load(
-            AuthorizationProvider.class, Thread.currentThread().getContextClassLoader());
-
-    List<Class<? extends AuthorizationProvider>> providers =
-        Streams.stream(loader.iterator())
-            .filter(p -> p.shortName().equalsIgnoreCase(authorizationProvider))
-            .map(AuthorizationProvider::getClass)
-            .collect(Collectors.toList());
-    if (providers.isEmpty()) {
-      throw new IllegalArgumentException(
-          "No authorization provider found for: " + authorizationProvider);
-    } else if (providers.size() > 1) {
-      throw new IllegalArgumentException(
-          "Multiple authorization providers found for: " + authorizationProvider);
-    }
     try {
-      return (BaseAuthorization<?>)
-          Iterables.getOnlyElement(providers).getDeclaredConstructor().newInstance();
+      authorization =
+          classLoader.withClassLoader(
+              cl -> {
+                try {
+                  ServiceLoader<AuthorizationProvider> loader =
+                      ServiceLoader.load(AuthorizationProvider.class, cl);
+
+                  List<Class<? extends AuthorizationProvider>> providers =
+                      Streams.stream(loader.iterator())
+                          .filter(p -> p.shortName().equalsIgnoreCase(authorizationProvider))
+                          .map(AuthorizationProvider::getClass)
+                          .collect(Collectors.toList());
+                  if (providers.isEmpty()) {
+                    throw new IllegalArgumentException(
+                        "No authorization provider found for: " + authorizationProvider);
+                  } else if (providers.size() > 1) {
+                    throw new IllegalArgumentException(
+                        "Multiple authorization providers found for: " + authorizationProvider);
+                  }
+                  return (BaseAuthorization<?>)
+                      Iterables.getOnlyElement(providers).getDeclaredConstructor().newInstance();
+                } catch (Exception e) {
+                  LOG.error("Failed to create authorization instance", e);
+                  throw new RuntimeException(e);
+                }
+              });
     } catch (Exception e) {
-      LOG.error("Failed to create authorization instance", e);
+      LOG.error("Failed to load authorization with class loader", e);
       throw new RuntimeException(e);
     }
   }

--- a/core/src/test/java/org/apache/gravitino/connector/authorization/TestAuthorization.java
+++ b/core/src/test/java/org/apache/gravitino/connector/authorization/TestAuthorization.java
@@ -20,6 +20,7 @@ package org.apache.gravitino.connector.authorization;
 
 import com.google.common.collect.ImmutableMap;
 import java.time.Instant;
+import java.util.Collections;
 import org.apache.gravitino.Catalog;
 import org.apache.gravitino.Namespace;
 import org.apache.gravitino.TestCatalog;
@@ -27,6 +28,7 @@ import org.apache.gravitino.connector.authorization.mysql.TestMySQLAuthorization
 import org.apache.gravitino.connector.authorization.ranger.TestRangerAuthorizationPlugin;
 import org.apache.gravitino.meta.AuditInfo;
 import org.apache.gravitino.meta.CatalogEntity;
+import org.apache.gravitino.utils.IsolatedClassLoader;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -54,6 +56,10 @@ public class TestAuthorization {
         new TestCatalog()
             .withCatalogConf(ImmutableMap.of(Catalog.AUTHORIZATION_PROVIDER, "ranger"))
             .withCatalogEntity(hiveCatalogEntity);
+    IsolatedClassLoader isolatedClassLoader =
+        new IsolatedClassLoader(
+            Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
+    hiveCatalog.initAuthorizationPluginInstance(isolatedClassLoader);
 
     CatalogEntity mySQLEntity =
         CatalogEntity.builder()
@@ -69,6 +75,7 @@ public class TestAuthorization {
         new TestCatalog()
             .withCatalogConf(ImmutableMap.of(Catalog.AUTHORIZATION_PROVIDER, "mysql"))
             .withCatalogEntity(mySQLEntity);
+    mySQLCatalog.initAuthorizationPluginInstance(isolatedClassLoader);
   }
 
   @Test

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -79,6 +79,7 @@ flink = "1.18.0"
 cglib = "2.2"
 ranger = "2.4.0"
 javax-jaxb-api = "2.3.1"
+javax-ws-rs-api = "2.1.1"
 protobuf-plugin = "0.9.2"
 spotless-plugin = '6.11.0'
 gradle-extensions-plugin = '1.74'
@@ -196,6 +197,7 @@ cglib = { group = "cglib", name = "cglib", version.ref = "cglib"}
 
 ranger-intg = { group = "org.apache.ranger", name = "ranger-intg", version.ref = "ranger" }
 javax-jaxb-api = { group = "javax.xml.bind", name = "jaxb-api", version.ref = "javax-jaxb-api" }
+javax-ws-rs-api = { group = "javax.ws.rs", name = "javax.ws.rs-api", version.ref = "javax-ws-rs-api" }
 selenium = { group = "org.seleniumhq.selenium", name = "selenium-java", version.ref = "selenium" }
 rauschig = { group = "org.rauschig", name = "jarchivelib", version.ref = "rauschig" }
 mybatis = { group = "org.mybatis", name = "mybatis", version.ref = "mybatis"}

--- a/integration-test-common/src/test/java/org/apache/gravitino/integration/test/container/MySQLContainer.java
+++ b/integration-test-common/src/test/java/org/apache/gravitino/integration/test/container/MySQLContainer.java
@@ -129,7 +129,7 @@ public class MySQLContainer extends BaseContainer {
       statement.execute(query);
       LOG.info(String.format("MySQL container database %s has been created", testDatabaseName));
     } catch (Exception e) {
-      LOG.error(e.getMessage(), e);
+      throw new RuntimeException("Failed to create database", e);
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

1. Use an isolated class loader to create an authorization Ranger plugin.
2. Add authorization for Hive E2E tests using Ranger via Gravitino RESTful access control.
3. Copy the authorization ranger jar to the `distribution/package/authorizations/ranger/libs`.
4. Add `Apache Ranger` to license.bin

### Why are the changes needed?

#4662 

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

CI
