### PR TITLE
[#4584]feat(catalog-iceberg) Support loading custom catalog as backend in Gravitino Iceberg catalog

### DIFF
--- a/catalogs/catalog-common/src/main/java/org/apache/gravitino/catalog/lakehouse/iceberg/IcebergPropertiesUtils.java
+++ b/catalogs/catalog-common/src/main/java/org/apache/gravitino/catalog/lakehouse/iceberg/IcebergPropertiesUtils.java
@@ -32,6 +32,7 @@ public class IcebergPropertiesUtils {
   static {
     Map<String, String> map = new HashMap();
     map.put(IcebergConstants.CATALOG_BACKEND, IcebergConstants.CATALOG_BACKEND);
+    map.put(IcebergConstants.CATALOG_BACKEND_IMPL, IcebergConstants.CATALOG_BACKEND_IMPL);
     map.put(IcebergConstants.GRAVITINO_JDBC_DRIVER, IcebergConstants.GRAVITINO_JDBC_DRIVER);
     map.put(IcebergConstants.GRAVITINO_JDBC_USER, IcebergConstants.ICEBERG_JDBC_USER);
     map.put(IcebergConstants.GRAVITINO_JDBC_PASSWORD, IcebergConstants.ICEBERG_JDBC_PASSWORD);

--- a/catalogs/catalog-lakehouse-iceberg/src/main/java/org/apache/gravitino/catalog/lakehouse/iceberg/IcebergCatalogPropertiesMetadata.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/main/java/org/apache/gravitino/catalog/lakehouse/iceberg/IcebergCatalogPropertiesMetadata.java
@@ -36,6 +36,7 @@ import org.apache.gravitino.iceberg.common.authentication.kerberos.KerberosConfi
 
 public class IcebergCatalogPropertiesMetadata extends BaseCatalogPropertiesMetadata {
   public static final String CATALOG_BACKEND = IcebergConstants.CATALOG_BACKEND;
+  public static final String CATALOG_BACKEND_IMPL = IcebergConstants.CATALOG_BACKEND_IMPL;
   public static final String GRAVITINO_JDBC_USER = IcebergConstants.GRAVITINO_JDBC_USER;
   public static final String GRAVITINO_JDBC_PASSWORD = IcebergConstants.GRAVITINO_JDBC_PASSWORD;
   public static final String WAREHOUSE = IcebergConstants.WAREHOUSE;
@@ -70,6 +71,12 @@ public class IcebergCatalogPropertiesMetadata extends BaseCatalogPropertiesMetad
                 null /* defaultValue */,
                 false /* hidden */,
                 false /* reserved */),
+            stringOptionalPropertyEntry(
+                CATALOG_BACKEND_IMPL,
+                "Iceberg catalog implement",
+                true /* immutable */,
+                null /* defaultValue */,
+                false /* hidden */),
             stringRequiredPropertyEntry(
                 URI, "Iceberg catalog uri config", false /* immutable */, false /* hidden */),
             stringRequiredPropertyEntry(

--- a/catalogs/catalog-lakehouse-iceberg/src/test/java/org/apache/gravitino/catalog/lakehouse/iceberg/TestIcebergCatalog.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/test/java/org/apache/gravitino/catalog/lakehouse/iceberg/TestIcebergCatalog.java
@@ -139,6 +139,16 @@ public class TestIcebergCatalog {
 
       Assertions.assertTrue(
           throwable.getMessage().contains(IcebergCatalogPropertiesMetadata.CATALOG_BACKEND));
+
+      Map<String, String> map4 = Maps.newHashMap();
+      map4.put(IcebergCatalogPropertiesMetadata.CATALOG_BACKEND, "custom");
+      map4.put(IcebergCatalogPropertiesMetadata.URI, "127.0.0.1");
+      map4.put(IcebergCatalogPropertiesMetadata.WAREHOUSE, "test");
+      map4.put(IcebergCatalogPropertiesMetadata.CATALOG_BACKEND_IMPL, "test");
+      Assertions.assertDoesNotThrow(
+          () -> {
+            PropertiesMetadataHelpers.validatePropertyForCreate(metadata, map4);
+          });
     }
   }
 }


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Support loading custom catalog as backend in Gravitino Iceberg catalog

### Why are the changes needed?

Fix: #4584

### Does this PR introduce _any_ user-facing change?

add a property key

### How was this patch tested?

add UT
manual test
