### PR TITLE
[#4685] fix docs img inline style issue

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -335,5 +335,5 @@ After completing these steps, you should be able to access the Gravitino REST in
 
 This document is just the beginning. You're welcome to customize your Gravitino setup based on your requirements and to explore the vast possibilities this powerful tool offers. If you encounter any issues or have questions, you can always connect with the Gravitino community for assistance.
 
-<img src="https://analytics.apache.org/matomo.php?idsite=62&rec=1&bots=1&action_name=GettingStarted" style="border:0;" alt="" />
+<img src="https://analytics.apache.org/matomo.php?idsite=62&rec=1&bots=1&action_name=GettingStarted" style={{ border: 0 }} alt="" />
 

--- a/docs/how-to-build.md
+++ b/docs/how-to-build.md
@@ -269,4 +269,4 @@ Building the Gravitino project compiles the necessary components, and starting t
 
 For instructions on how to run the project using VSCode or IntelliJ on Windows, please refer to [CONTRIBUTING.md](https://github.com/apache/gravitino/blob/main/CONTRIBUTING.md).
 
-<img src="https://analytics.apache.org/matomo.php?idsite=62&rec=1&bots=1&action_name=HowToBuild" style="border:0;" alt="" />
+<img src="https://analytics.apache.org/matomo.php?idsite=62&rec=1&bots=1&action_name=HowToBuild" style={{ border: 0 }} alt="" />

--- a/docs/how-to-install.md
+++ b/docs/how-to-install.md
@@ -171,4 +171,4 @@ For the details, review the
 [Gravitino playground repository](https://github.com/apache/gravitino-playground) and
 [playground example](./how-to-use-the-playground.md).
 
-<img src="https://analytics.apache.org/matomo.php?idsite=62&rec=1&bots=1&action_name=HowToInstall" style="border:0;" alt="" />
+<img src="https://analytics.apache.org/matomo.php?idsite=62&rec=1&bots=1&action_name=HowToInstall" style={{ border: 0 }} alt="" />

--- a/docs/how-to-upgrade.md
+++ b/docs/how-to-upgrade.md
@@ -110,4 +110,4 @@ upgraded schema, e.g. if you upgraded the schema to Gravitino 0.8.0 then
 you will want to compare your schema dump against the contents of
 `schema-0.8.0-<type>.sql`
 
-<img src="https://analytics.apache.org/matomo.php?idsite=62&rec=1&bots=1&action_name=HowToUpgrade" style="border:0;" alt="" />
+<img src="https://analytics.apache.org/matomo.php?idsite=62&rec=1&bots=1&action_name=HowToUpgrade" style={{ border: 0 }} alt="" />

--- a/docs/how-to-use-the-playground.md
+++ b/docs/how-to-use-the-playground.md
@@ -236,4 +236,4 @@ select * from catalog_hive.sales.customers
 union
 select * from catalog_iceberg.sales.customers;
 ```
-<img src="https://analytics.apache.org/matomo.php?idsite=62&rec=1&bots=1&action_name=HowtoUsePlayground" style="border:0;" alt="" />
+<img src="https://analytics.apache.org/matomo.php?idsite=62&rec=1&bots=1&action_name=HowtoUsePlayground" style={{ border: 0 }} alt="" />

--- a/docs/index.md
+++ b/docs/index.md
@@ -179,4 +179,4 @@ Gravitino provides security configurations for Gravitino, including HTTPS, authe
   also lists the change logs of Gravitino CI Docker images and release images.
 * [How to upgrade Gravitino](./how-to-upgrade.md): a guide to upgrading the schema of Gravitino storage backend from one release version to another.
 
-<img src="https://analytics.apache.org/matomo.php?idsite=62&rec=1&bots=1&action_name=Overview" style="border:0;" alt="" />
+<img src="https://analytics.apache.org/matomo.php?idsite=62&rec=1&bots=1&action_name=Overview" style={{ border: 0 }} alt="" />


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?
make sure to set inline styles in my React application for img and show the content of docs
<img width="1917" alt="image" src="https://github.com/user-attachments/assets/a52458f5-cbef-4a6e-9ece-7fade2b32ccb">


### Why are the changes needed?
N/A

Fix: #4685

### Does this PR introduce _any_ user-facing change?
N/A

### How was this patch tested?
N/A
