### PR TITLE
[#4695] Fix (python-client): Fix gradlew :clients:client-python:build failed if the package does not contain .git directory

### DIFF
--- a/clients/client-python/gravitino/constants/root.py
+++ b/clients/client-python/gravitino/constants/root.py
@@ -21,4 +21,5 @@ from pathlib import Path
 
 MODULE_NAME = "gravitino"
 PROJECT_HOME = Path(__file__).parent.parent.parent
+PROJECT_ROOT = PROJECT_HOME.parent.parent
 GRAVITINO_DIR = PROJECT_HOME / MODULE_NAME

--- a/clients/client-python/scripts/generate_version.py
+++ b/clients/client-python/scripts/generate_version.py
@@ -43,7 +43,6 @@ def get_git_commit_id():
                 commit_id = file.readline().strip()
         return commit_id
     except (FileNotFoundError, IOError) as e:
-        print(f"Warn: Failed to get git commit Id. {e}")
         return ""
 
 

--- a/clients/client-python/scripts/generate_version.py
+++ b/clients/client-python/scripts/generate_version.py
@@ -42,7 +42,7 @@ def get_git_commit_id():
             with open(git_path + ref_path, "r", encoding="utf-8") as file:
                 commit_id = file.readline().strip()
         return commit_id
-    except Exception as e:
+    except (FileNotFoundError, IOError) as e:
         print(f"Warn: Failed to get git commit Id. {e}")
         return ""
 

--- a/clients/client-python/scripts/generate_version.py
+++ b/clients/client-python/scripts/generate_version.py
@@ -37,9 +37,10 @@ def main():
         else:
             raise GravitinoRuntimeException("Can't find valid version info in setup.py")
 
-    git_commit = (
-        subprocess.check_output(["git", "rev-parse", "HEAD"]).decode("ascii").strip()
-    )
+    try:
+        git_commit = subprocess.check_output(["git", "rev-parse", "HEAD"], stderr=subprocess.STDOUT).decode("ascii").strip()
+    except subprocess.CalledProcessError:
+        git_commit = ""
 
     compile_date = datetime.now().strftime("%d/%m/%Y %H:%M:%S")
 

--- a/clients/client-python/scripts/generate_version.py
+++ b/clients/client-python/scripts/generate_version.py
@@ -42,7 +42,7 @@ def get_git_commit_id():
             with open(git_path + ref_path, "r", encoding="utf-8") as file:
                 commit_id = file.readline().strip()
         return commit_id
-    except (FileNotFoundError, IOError) as e:
+    except (FileNotFoundError, IOError):
         return ""
 
 

--- a/clients/client-python/scripts/generate_version.py
+++ b/clients/client-python/scripts/generate_version.py
@@ -17,15 +17,34 @@ specific language governing permissions and limitations
 under the License.
 """
 
+# coding=utf-8
+
 import re
 import configparser
-import subprocess
 from datetime import datetime
+from gravitino.constants.root import PROJECT_ROOT
 
 from gravitino.constants.version import Version, VERSION_INI, SETUP_FILE
 from gravitino.exceptions.base import GravitinoRuntimeException
 
 VERSION_PATTERN = r"version\s*=\s*['\"]([^'\"]+)['\"]"
+
+
+def get_git_commit_id():
+    try:
+        commit_id = ""
+        git_path = f"{PROJECT_ROOT}/.git/"
+        with open(git_path + "HEAD", "r", encoding="utf-8") as file:
+            ref = file.readline().strip()
+
+        if ref.startswith("ref:"):
+            ref_path = ref.split(" ")[1]
+            with open(git_path + ref_path, "r", encoding="utf-8") as file:
+                commit_id = file.readline().strip()
+        return commit_id
+    except Exception as e:
+        print(f"Warn: Failed to get git commit Id. {e}")
+        return ""
 
 
 def main():
@@ -37,10 +56,7 @@ def main():
         else:
             raise GravitinoRuntimeException("Can't find valid version info in setup.py")
 
-    try:
-        git_commit = subprocess.check_output(["git", "rev-parse", "HEAD"], stderr=subprocess.STDOUT).decode("ascii").strip()
-    except subprocess.CalledProcessError:
-        git_commit = ""
+    git_commit = get_git_commit_id()
 
     compile_date = datetime.now().strftime("%d/%m/%Y %H:%M:%S")
 


### PR DESCRIPTION

### What changes were proposed in this pull request?

Fix  gradlew :clients:client-python:build failed if the package does not contain .git directory

### Why are the changes needed?

Fix: #4695 

### Does this PR introduce _any_ user-facing change?

NO

### How was this patch tested?

Manually test
