### PR TITLE
[#4706] fix(build): Add license, notice, and other files to the binary artifact

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -571,6 +571,7 @@ tasks {
         from(projectDir.file("LICENSE.bin")) { into("package") }
         from(projectDir.file("NOTICE.bin")) { into("package") }
         from(projectDir.file("README.md")) { into("package") }
+        from(projectDir.file("DISCLAIMER_WIP.txt")) { into("package") }
         into(outputDir)
         rename { fileName ->
           fileName.replace(".bin", "")
@@ -616,6 +617,26 @@ tasks {
         from(projectDir.file("LICENSE.bin")) { into("${rootProject.name}-iceberg-rest-server") }
         from(projectDir.file("NOTICE.bin")) { into("${rootProject.name}-iceberg-rest-server") }
         from(projectDir.file("README.md")) { into("${rootProject.name}-iceberg-rest-server") }
+        from(projectDir.file("DISCLAIMER_WIP.txt")) { into("${rootProject.name}-iceberg-rest-server") }
+        into(outputDir)
+        rename { fileName ->
+          fileName.replace(".bin", "")
+        }
+      }
+    }
+  }
+
+  val compileTrinoConnector by registering {
+    dependsOn("trino-connector:copyLibs")
+    group = "gravitino distribution"
+    outputs.dir(projectDir.dir("distribution/${rootProject.name}-trino-connector"))
+    doLast {
+      copy {
+        from(projectDir.dir("licenses")) { into("${rootProject.name}-trino-connector/licenses") }
+        from(projectDir.file("LICENSE.bin")) { into("${rootProject.name}-trino-connector") }
+        from(projectDir.file("NOTICE.bin")) { into("${rootProject.name}-trino-connector") }
+        from(projectDir.file("README.md")) { into("${rootProject.name}-trino-connector") }
+        from(projectDir.file("DISCLAIMER_WIP.txt")) { into("${rootProject.name}-trino-connector") }
         into(outputDir)
         rename { fileName ->
           fileName.replace(".bin", "")
@@ -636,11 +657,11 @@ tasks {
   }
 
   val assembleTrinoConnector by registering(Tar::class) {
-    dependsOn("trino-connector:copyLibs")
+    dependsOn("compileTrinoConnector")
     group = "gravitino distribution"
     finalizedBy("checksumTrinoConnector")
     into("${rootProject.name}-trino-connector-$version")
-    from("trino-connector/build/libs")
+    from(compileTrinoConnector.map { it.outputs.files.single() })
     compression = Compression.GZIP
     archiveFileName.set("${rootProject.name}-trino-connector-$version.tar.gz")
     destinationDirectory.set(projectDir.dir("distribution"))

--- a/clients/client-python/MANIFEST.in
+++ b/clients/client-python/MANIFEST.in
@@ -19,4 +19,8 @@
 include requirements.txt
 include requirements-dev.txt
 include README.md
+include LICENSE
+include NOTICE
+include DISCLAIMER_WIP.txt
 include gravitino/version.ini
+graft licenses

--- a/clients/client-python/build.gradle.kts
+++ b/clients/client-python/build.gradle.kts
@@ -282,6 +282,16 @@ tasks {
       delete("README.md")
       generatePypiProjectHomePage()
       delete("dist")
+      copy {
+        from("${project.rootDir}/licenses") { into("licenses") }
+        from("${project.rootDir}/LICENSE.bin") { into("./") }
+        from("${project.rootDir}/NOTICE.bin") { into("./") }
+        from("${project.rootDir}/DISCLAIMER_WIP.txt") { into("./") }
+        into("${project.rootDir.path}/clients/client-python")
+        rename { fileName ->
+          fileName.replace(".bin", "")
+        }
+      }
     }
 
     venvExec = "python"
@@ -289,6 +299,10 @@ tasks {
 
     doLast {
       delete("README.md")
+      delete("licenses")
+      delete("LICENSE")
+      delete("NOTICE")
+      delete("DISCLAIMER_WIP.txt")
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to add several missing license, notice, and other files to the binary artifacts for Gravitino.

### Why are the changes needed?

To follow ASF's policy

Fix: #4706 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

N/A
