### PR TITLE
[#4772][#4766] improve(pydoc): Remove compile path in the python client docs

### DIFF
--- a/clients/client-python/scripts/generate_doc.py
+++ b/clients/client-python/scripts/generate_doc.py
@@ -22,7 +22,7 @@ import os
 import shutil
 
 from gravitino.constants.doc import DOC_DIR
-from gravitino.constants.root import GRAVITINO_DIR, MODULE_NAME
+from gravitino.constants.root import GRAVITINO_DIR, MODULE_NAME, PROJECT_ROOT
 
 if __name__ == "__main__":
 
@@ -40,3 +40,15 @@ if __name__ == "__main__":
 
     # Write doc for submodules
     pydoc.writedocs(GRAVITINO_DIR.as_posix(), MODULE_NAME + ".")
+
+    # Remove compile path in the python client docs
+    for root, _, files in os.walk(DOC_DIR):
+        for file in files:
+            file_path = os.path.join(root, file)
+            with open(file_path, "r", encoding="utf-8") as f:
+                content = f.read()
+            content = content.replace(
+                f"PosixPath('{PROJECT_ROOT.parent}", "PosixPath('"
+            )
+            with open(file_path, "w", encoding="utf-8") as f:
+                f.write(content)


### PR DESCRIPTION
### What changes were proposed in this pull request?

Remove compile path in the python client docs.

### Why are the changes needed?

#### Before
<img width="1557" alt="image" src="https://github.com/user-attachments/assets/58ae05dc-2111-410b-83d9-5289a70ea2fd">

#### After
<img width="566" alt="image" src="https://github.com/user-attachments/assets/84630b60-0877-4057-b142-3c6361481d89">


Fix: #4772
Fix: #4766 

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

CI passed.
