### PR TITLE
[#5145] improvement(flink-connector): Shrink the flink-connector-runtime lib size from 84MB to 16MB

### DIFF
--- a/flink-connector/flink-runtime/build.gradle.kts
+++ b/flink-connector/flink-runtime/build.gradle.kts
@@ -56,7 +56,6 @@ tasks.withType<ShadowJar>(ShadowJar::class.java) {
   relocate("com.google", "org.apache.gravitino.shaded.com.google")
   relocate("google", "org.apache.gravitino.shaded.google")
   relocate("org.apache.hc", "org.apache.gravitino.shaded.org.apache.hc")
-  relocate("org.apache.commons", "org.apache.gravitino.shaded.org.apache.commons")
 }
 
 publishing {

--- a/flink-connector/flink-runtime/build.gradle.kts
+++ b/flink-connector/flink-runtime/build.gradle.kts
@@ -66,6 +66,11 @@ publishing {
   }
 }
 
+tasks.register<Copy>("copy") {
+  from(configurations.runtimeClasspath)
+  into("build/libs-runtime")
+}
+
 tasks.jar {
   dependsOn(tasks.named("shadowJar"))
   archiveClassifier.set("empty")

--- a/flink-connector/flink-runtime/build.gradle.kts
+++ b/flink-connector/flink-runtime/build.gradle.kts
@@ -66,11 +66,6 @@ publishing {
   }
 }
 
-tasks.register<Copy>("copy") {
-  from(configurations.runtimeClasspath)
-  into("build/libs-runtime")
-}
-
 tasks.jar {
   dependsOn(tasks.named("shadowJar"))
   archiveClassifier.set("empty")

--- a/flink-connector/flink/build.gradle.kts
+++ b/flink-connector/flink/build.gradle.kts
@@ -38,18 +38,10 @@ val scalaVersion: String = "2.12"
 val artifactName = "${rootProject.name}-flink-${flinkMajorVersion}_$scalaVersion"
 
 dependencies {
-  implementation(project(":api"))
   implementation(project(":catalogs:catalog-common"))
-  implementation(project(":common"))
-
-  compileOnly(libs.bundles.log4j)
-  implementation(libs.commons.lang3)
   implementation(libs.guava)
-  implementation(libs.httpclient5)
-  implementation(libs.jackson.databind)
-  implementation(libs.jackson.annotations)
-  implementation(libs.jackson.datatype.jdk8)
-  implementation(libs.jackson.datatype.jsr310)
+
+  compileOnly(project(":clients:client-java-runtime", configuration = "shadow"))
 
   compileOnly("org.apache.flink:flink-connector-hive_$scalaVersion:$flinkVersion")
   compileOnly("org.apache.flink:flink-table-common:$flinkVersion")
@@ -76,13 +68,13 @@ dependencies {
     exclude("org.slf4j")
   }
 
-  // replace with client-java-runtime in flink connector runtime
-  compileOnly(project(":clients:client-java"))
-
   testAnnotationProcessor(libs.lombok)
-
   testCompileOnly(libs.lombok)
+
+  testImplementation(project(":api"))
   testImplementation(project(":clients:client-java"))
+  testImplementation(project(":core"))
+  testImplementation(project(":common"))
   testImplementation(project(":integration-test-common", "testArtifacts"))
   testImplementation(project(":server"))
   testImplementation(project(":server-common"))


### PR DESCRIPTION
### What changes were proposed in this pull request?

- shrink the flink-connector-runtime jar.
- Change client-java scope from implementation to CompileOnly  in flink module.
- use the client-java-runtime in flink-connector-runtime.

### Why are the changes needed?
Fix: #5145 


- The flink-connector-runtime jar is much big as mentioned in https://github.com/apache/gravitino/pull/4791#discussion_r1738193021.


### Does this PR introduce _any_ user-facing change?

- no

### How was this patch tested?

- local test
