### PR TITLE
[#4735] improvement(core): Optimize the thrown duplicated entry error message

### DIFF
--- a/core/src/main/java/org/apache/gravitino/storage/relational/converters/H2ExceptionConverter.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/converters/H2ExceptionConverter.java
@@ -37,7 +37,8 @@ public class H2ExceptionConverter implements SQLExceptionConverter {
       throws IOException {
     switch (se.getErrorCode()) {
       case DUPLICATED_ENTRY_ERROR_CODE:
-        throw new EntityAlreadyExistsException(se, se.getMessage());
+        throw new EntityAlreadyExistsException(
+            se, "The %s entity: %s already exists.", type.name(), name);
       default:
         throw new IOException(se);
     }

--- a/core/src/test/java/org/apache/gravitino/storage/relational/converters/TestH2ExceptionConverter.java
+++ b/core/src/test/java/org/apache/gravitino/storage/relational/converters/TestH2ExceptionConverter.java
@@ -18,30 +18,22 @@
  */
 package org.apache.gravitino.storage.relational.converters;
 
-import java.io.IOException;
 import java.sql.SQLException;
 import org.apache.gravitino.Entity;
 import org.apache.gravitino.EntityAlreadyExistsException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
-/**
- * Exception converter to Apache Gravitino exception for MySQL. The definition of error codes can be
- * found in the document: <a
- * href="https://dev.mysql.com/doc/connector-j/en/connector-j-reference-error-sqlstates.html"></a>
- */
-public class MySQLExceptionConverter implements SQLExceptionConverter {
-  /** It means found a duplicated primary key or unique key entry in MySQL. */
-  private static final int DUPLICATED_ENTRY_ERROR_CODE = 1062;
-
-  @SuppressWarnings("FormatStringAnnotation")
-  @Override
-  public void toGravitinoException(SQLException se, Entity.EntityType type, String name)
-      throws IOException {
-    switch (se.getErrorCode()) {
-      case DUPLICATED_ENTRY_ERROR_CODE:
-        throw new EntityAlreadyExistsException(
-            se, "The %s entity: %s already exists.", type.name(), name);
-      default:
-        throw new IOException(se);
-    }
+public class TestH2ExceptionConverter {
+  @Test
+  public void testConvertDuplicatedEntryException() {
+    SQLException mockException = Mockito.mock(SQLException.class);
+    Mockito.when(mockException.getErrorCode()).thenReturn(23505);
+    H2ExceptionConverter converter = new H2ExceptionConverter();
+    Assertions.assertThrows(
+        EntityAlreadyExistsException.class,
+        () -> converter.toGravitinoException(mockException, Entity.EntityType.METALAKE, "test"),
+        String.format("The %s entity: %s already exists.", Entity.EntityType.METALAKE, "test"));
   }
 }

--- a/core/src/test/java/org/apache/gravitino/storage/relational/converters/TestMySQLExceptionConverter.java
+++ b/core/src/test/java/org/apache/gravitino/storage/relational/converters/TestMySQLExceptionConverter.java
@@ -18,30 +18,23 @@
  */
 package org.apache.gravitino.storage.relational.converters;
 
-import java.io.IOException;
 import java.sql.SQLException;
 import org.apache.gravitino.Entity;
 import org.apache.gravitino.EntityAlreadyExistsException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
-/**
- * Exception converter to Apache Gravitino exception for MySQL. The definition of error codes can be
- * found in the document: <a
- * href="https://dev.mysql.com/doc/connector-j/en/connector-j-reference-error-sqlstates.html"></a>
- */
-public class MySQLExceptionConverter implements SQLExceptionConverter {
-  /** It means found a duplicated primary key or unique key entry in MySQL. */
-  private static final int DUPLICATED_ENTRY_ERROR_CODE = 1062;
+public class TestMySQLExceptionConverter {
 
-  @SuppressWarnings("FormatStringAnnotation")
-  @Override
-  public void toGravitinoException(SQLException se, Entity.EntityType type, String name)
-      throws IOException {
-    switch (se.getErrorCode()) {
-      case DUPLICATED_ENTRY_ERROR_CODE:
-        throw new EntityAlreadyExistsException(
-            se, "The %s entity: %s already exists.", type.name(), name);
-      default:
-        throw new IOException(se);
-    }
+  @Test
+  public void testConvertDuplicatedEntryException() {
+    SQLException mockException = Mockito.mock(SQLException.class);
+    Mockito.when(mockException.getErrorCode()).thenReturn(1062);
+    MySQLExceptionConverter converter = new MySQLExceptionConverter();
+    Assertions.assertThrows(
+        EntityAlreadyExistsException.class,
+        () -> converter.toGravitinoException(mockException, Entity.EntityType.METALAKE, "test"),
+        String.format("The %s entity: %s already exists.", Entity.EntityType.METALAKE, "test"));
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Optimize the exception message of `SQLException` thrown in UI when duplicate entities occurs.
![image](https://github.com/user-attachments/assets/df74c64e-097a-4845-9ec7-cf914934b26d)

### Why are the changes needed?

Fix: #4735 

### How was this patch tested?

Add some UTs.