### PR TITLE
[MINOR] improvement(mysql-catalog): Reduce possible keyword conflict in table creation for MySQL catalog.

### DIFF
--- a/catalogs/catalog-jdbc-mysql/src/main/java/org/apache/gravitino/catalog/mysql/operation/MysqlTableOperations.java
+++ b/catalogs/catalog-jdbc-mysql/src/main/java/org/apache/gravitino/catalog/mysql/operation/MysqlTableOperations.java
@@ -619,7 +619,7 @@ public class MysqlTableOperations extends JdbcTableOperations {
     String col = updateColumnPosition.fieldName()[0];
     JdbcColumn column = getJdbcColumnFromTable(jdbcTable, col);
     StringBuilder columnDefinition = new StringBuilder();
-    columnDefinition.append(MODIFY_COLUMN).append(col);
+    columnDefinition.append(MODIFY_COLUMN).append(quote(col));
     appendColumnDefinition(column, columnDefinition);
     if (updateColumnPosition.getPosition() instanceof TableChange.First) {
       columnDefinition.append("FIRST");
@@ -664,7 +664,7 @@ public class MysqlTableOperations extends JdbcTableOperations {
     }
     String col = updateColumnDefaultValue.fieldName()[0];
     JdbcColumn column = getJdbcColumnFromTable(jdbcTable, col);
-    StringBuilder sqlBuilder = new StringBuilder(MODIFY_COLUMN + col);
+    StringBuilder sqlBuilder = new StringBuilder(MODIFY_COLUMN + quote(col));
     JdbcColumn newColumn =
         JdbcColumn.builder()
             .withName(col)
@@ -683,7 +683,7 @@ public class MysqlTableOperations extends JdbcTableOperations {
     }
     String col = updateColumnType.fieldName()[0];
     JdbcColumn column = getJdbcColumnFromTable(jdbcTable, col);
-    StringBuilder sqlBuilder = new StringBuilder(MODIFY_COLUMN + col);
+    StringBuilder sqlBuilder = new StringBuilder(MODIFY_COLUMN + quote(col));
     JdbcColumn newColumn =
         JdbcColumn.builder()
             .withName(col)
@@ -725,5 +725,9 @@ public class MysqlTableOperations extends JdbcTableOperations {
       sqlBuilder.append("COMMENT '").append(column.comment()).append("' ");
     }
     return sqlBuilder;
+  }
+
+  private static String quote(String name) {
+    return BACK_QUOTE + name + BACK_QUOTE;
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

backquote column name when altering table. 

### Why are the changes needed?

To avoid cases where the column name is a keyword. 


### Does this PR introduce _any_ user-facing change?

N/A.

### How was this patch tested?

Existing test. 
