### PR TITLE
[#4851] fix: make `TestHiveTableOperations` setup independently

### DIFF
--- a/catalogs/catalog-hive/src/test/java/org/apache/gravitino/catalog/hive/TestHiveTable.java
+++ b/catalogs/catalog-hive/src/test/java/org/apache/gravitino/catalog/hive/TestHiveTable.java
@@ -73,21 +73,25 @@ public class TestHiveTable extends MiniHiveMetastoreService {
   private static void setup() {
     hiveCatalog = initHiveCatalog();
     hiveCatalogOperations = (HiveCatalogOperations) hiveCatalog.ops();
-    hiveSchema = initHiveSchema(hiveCatalog);
+    hiveSchema = initHiveSchema();
   }
 
   @AfterEach
   private void resetSchema() {
     hiveCatalogOperations.dropSchema(schemaIdent, true);
-    hiveSchema = initHiveSchema(hiveCatalog);
+    hiveSchema = initHiveSchema();
   }
 
-  protected static HiveSchema initHiveSchema(HiveCatalog hiveCatalog) {
+  protected static HiveSchema initHiveSchema() {
+    return initHiveSchema(hiveCatalogOperations);
+  }
+
+  protected static HiveSchema initHiveSchema(HiveCatalogOperations ops) {
     Map<String, String> properties = Maps.newHashMap();
     properties.put("key1", "val1");
     properties.put("key2", "val2");
 
-    return hiveCatalogOperations.createSchema(schemaIdent, HIVE_COMMENT, properties);
+    return ops.createSchema(schemaIdent, HIVE_COMMENT, properties);
   }
 
   protected static HiveCatalog initHiveCatalog() {

--- a/catalogs/catalog-hive/src/test/java/org/apache/gravitino/catalog/hive/TestHiveTableOperations.java
+++ b/catalogs/catalog-hive/src/test/java/org/apache/gravitino/catalog/hive/TestHiveTableOperations.java
@@ -59,7 +59,7 @@ public class TestHiveTableOperations extends MiniHiveMetastoreService {
   public static void setup() {
     hiveCatalog = initHiveCatalog();
     hiveCatalogOperations = (HiveCatalogOperations) hiveCatalog.ops();
-    initHiveSchema(hiveCatalog);
+    initHiveSchema(hiveCatalogOperations);
     hiveTable = createPartitionedTable();
 
     // add partition: city=0/dt=2020-01-01


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

`TestHiveTableOperations` can be tested before `TestHiveTable` initialized.
Make `TestHiveTableOperations::steup()` run alone.

### Why are the changes needed?

When we try to just run `gradle :catalogs:catalog-hive:test --tests 'org.apache.gravitino.catalog.hive.TestHiveTableOperations'`, `TestHiveTableOperations` needs static variables which must be initialized ahead, and it can't be run alone.

Fix: #4851 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Refactor of unit test setup, local unit tests have passed.
