### PR TITLE
[HOTFIX] fix(openapi): fix the env of openAPI lint plugin

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,6 +45,7 @@ jobs:
               - trino-connector/**
               - web/**
               - docs/open-api/**
+              - docs/build.gradle.kts
               - build.gradle.kts
               - gradle.properties
               - gradlew

--- a/docs/build.gradle.kts
+++ b/docs/build.gradle.kts
@@ -17,11 +17,18 @@
  * under the License.
  */
 
+import com.github.gradle.node.NodeExtension
 import com.github.gradle.node.npm.task.NpxTask
+
+configure<NodeExtension> {
+  version = "21.6.1"
+  npmVersion = "10.2.4"
+  download = true
+}
 
 tasks {
   val lintOpenAPI by registering(NpxTask::class) {
-    command.set("@redocly/cli@1.5.0")
+    command.set("@redocly/cli@1.23.1")
     args.set(listOf("lint", "--extends=recommended-strict", "${project.projectDir}/open-api/openapi.yaml"))
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

 - update redocly/cli version from 1.5.0 to 1.23.1
 - fixed the node version to 21.6.1
 - fixed the npm version to 10.2.4

### Why are the changes needed?

redocly/cli failed at version 1.5.0

### Does this PR introduce _any_ user-facing change?

no

### How was this patch tested?

build CI passed
