### PR TITLE
[draf] unify drop catalog and metalake

### DIFF
--- a/api/src/main/java/org/apache/gravitino/Catalog.java
+++ b/api/src/main/java/org/apache/gravitino/Catalog.java
@@ -97,6 +97,9 @@ public interface Catalog extends Auditable {
    */
   String PROPERTY_PACKAGE = "package";
 
+  /** The property indicating the metalake is in use. */
+  String PROPERTY_IN_USE = "in-use";
+
   /**
    * The property to specify the cloud that the catalog is running on. The value should be one of
    * the {@link CloudName}.

--- a/api/src/main/java/org/apache/gravitino/Metalake.java
+++ b/api/src/main/java/org/apache/gravitino/Metalake.java
@@ -28,6 +28,9 @@ import org.apache.gravitino.annotation.Evolving;
 @Evolving
 public interface Metalake extends Auditable {
 
+  /** The property indicating the metalake is in use. */
+  String PROPERTY_IN_USE = "in-use";
+
   /**
    * The name of the metalake.
    *

--- a/api/src/main/java/org/apache/gravitino/exceptions/EntityInUseException.java
+++ b/api/src/main/java/org/apache/gravitino/exceptions/EntityInUseException.java
@@ -1,0 +1,18 @@
+package org.apache.gravitino.exceptions;
+
+import com.google.errorprone.annotations.FormatMethod;
+import com.google.errorprone.annotations.FormatString;
+
+/** Exception thrown when an entity is in use and cannot be deleted. */
+public class EntityInUseException extends GravitinoRuntimeException {
+  /**
+   * Constructs a new exception with the specified detail message.
+   *
+   * @param message the detail message.
+   * @param args the arguments to the message.
+   */
+  @FormatMethod
+  public EntityInUseException(@FormatString String message, Object... args) {
+    super(message, args);
+  }
+}

--- a/api/src/main/java/org/apache/gravitino/exceptions/NonInUseEntityException.java
+++ b/api/src/main/java/org/apache/gravitino/exceptions/NonInUseEntityException.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.exceptions;
+
+import com.google.errorprone.annotations.FormatMethod;
+import com.google.errorprone.annotations.FormatString;
+
+/** An exception thrown when operating on a non-in-use entity. */
+public class NonInUseEntityException extends GravitinoRuntimeException {
+  /**
+   * Constructs a new exception with the specified detail message.
+   *
+   * @param message the detail message.
+   * @param args the arguments to the message.
+   */
+  @FormatMethod
+  public NonInUseEntityException(@FormatString String message, Object... args) {
+    super(message, args);
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/StringIdentifier.java
+++ b/core/src/main/java/org/apache/gravitino/StringIdentifier.java
@@ -21,7 +21,6 @@ package org.apache.gravitino;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Maps;
 import java.util.Collections;
 import java.util.Map;
 import java.util.regex.Matcher;
@@ -127,27 +126,6 @@ public class StringIdentifier {
         .putAll(properties)
         .put(ID_KEY, stringId.toString())
         .build();
-  }
-
-  /**
-   * Remove StringIdentifier from properties.
-   *
-   * @param properties the properties to remove the string identifier from.
-   * @return the properties with the string identifier removed.
-   */
-  public static Map<String, String> newPropertiesWithoutId(Map<String, String> properties) {
-    if (properties == null) {
-      return null;
-    }
-
-    if (!properties.containsKey(ID_KEY)) {
-      return Collections.unmodifiableMap(properties);
-    }
-
-    Map<String, String> copy = Maps.newHashMap(properties);
-    copy.remove(ID_KEY);
-
-    return ImmutableMap.<String, String>builder().putAll(copy).build();
   }
 
   public static StringIdentifier fromProperties(Map<String, String> properties) {

--- a/core/src/main/java/org/apache/gravitino/catalog/SupportsCatalogs.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/SupportsCatalogs.java
@@ -26,8 +26,10 @@ import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
 import org.apache.gravitino.annotation.Evolving;
 import org.apache.gravitino.exceptions.CatalogAlreadyExistsException;
+import org.apache.gravitino.exceptions.EntityInUseException;
 import org.apache.gravitino.exceptions.NoSuchCatalogException;
 import org.apache.gravitino.exceptions.NoSuchMetalakeException;
+import org.apache.gravitino.exceptions.NonEmptyEntityException;
 
 /**
  * Interface for supporting catalogs. It includes methods for listing, loading, creating, altering
@@ -115,12 +117,42 @@ public interface SupportsCatalogs {
       throws NoSuchCatalogException, IllegalArgumentException;
 
   /**
-   * Drop a catalog with specified identifier.
+   * Drop a catalog with specified identifier. Please make sure:
+   *
+   * <ul>
+   *   <li>There is no schema in the catalog. Otherwise, a {@link NonEmptyEntityException} will be
+   *       thrown.
+   *   <li>The method {@link #inactivateCatalog(NameIdentifier)} has been called before dropping the
+   *       catalog.
+   * </ul>
+   *
+   * It is equivalent to calling {@code dropCatalog(ident, false)}.
    *
    * @param ident the identifier of the catalog.
    * @return True if the catalog was dropped, false if the catalog does not exist.
+   * @throws NonEmptyEntityException If the catalog is not empty.
+   * @throws EntityInUseException If the catalog is in use.
    */
-  boolean dropCatalog(NameIdentifier ident);
+  boolean dropCatalog(NameIdentifier ident) throws NonEmptyEntityException, EntityInUseException;
+
+  /**
+   * Drop a catalog with specified identifier. If the force flag is true, it will:
+   *
+   * <ul>
+   *   <li>Cascade drop all sub-entities (schemas, tables, etc.) of the catalog in Gravitino store.
+   *   <li>Drop the catalog even if it is in use.
+   *   <li>External resources (e.g. database, table, etc.) associated with sub-entities will not be
+   *       dropped unless it is managed (such as managed fileset).
+   * </ul>
+   *
+   * @param ident The identifier of the catalog.
+   * @param force Whether to force the drop.
+   * @return True if the catalog was dropped, false if the catalog does not exist.
+   * @throws NonEmptyEntityException If the catalog is not empty and force is false.
+   * @throws EntityInUseException If the catalog is in use and force is false.
+   */
+  boolean dropCatalog(NameIdentifier ident, boolean force)
+      throws NonEmptyEntityException, EntityInUseException;
 
   /**
    * Test whether the catalog with specified parameters can be connected to before creating it.
@@ -139,4 +171,29 @@ public interface SupportsCatalogs {
       String comment,
       Map<String, String> properties)
       throws Exception;
+
+  /**
+   * Activate a catalog. If the catalog is already active, this method does nothing.
+   *
+   * @param ident The identifier of the catalog.
+   * @throws NoSuchCatalogException If the catalog does not exist.
+   */
+  void activateCatalog(NameIdentifier ident) throws NoSuchCatalogException;
+
+  /**
+   * Inactivate a catalog. If the catalog is already inactive, this method does nothing. Once a
+   * catalog is inactivated:
+   *
+   * <ul>
+   *   <li>It can only be listed, loaded, dropped, or activated.
+   *   <li>Any other operations on the catalog will throw an {@link
+   *       org.apache.gravitino.exceptions.NonInUseEntityException}.
+   *   <li>Any operation on the sub-entities (schemas, tables, etc.) will throw an {@link
+   *       org.apache.gravitino.exceptions.NonInUseEntityException}.
+   * </ul>
+   *
+   * @param ident The identifier of the catalog.
+   * @throws NoSuchCatalogException If the catalog does not exist.
+   */
+  void inactivateCatalog(NameIdentifier ident) throws NoSuchCatalogException;
 }

--- a/core/src/main/java/org/apache/gravitino/connector/BaseCatalogPropertiesMetadata.java
+++ b/core/src/main/java/org/apache/gravitino/connector/BaseCatalogPropertiesMetadata.java
@@ -21,6 +21,7 @@ package org.apache.gravitino.connector;
 
 import static org.apache.gravitino.Catalog.CLOUD_NAME;
 import static org.apache.gravitino.Catalog.CLOUD_REGION_CODE;
+import static org.apache.gravitino.Catalog.PROPERTY_IN_USE;
 import static org.apache.gravitino.Catalog.PROPERTY_PACKAGE;
 
 import com.google.common.base.Preconditions;
@@ -73,6 +74,11 @@ public abstract class BaseCatalogPropertiesMetadata extends BasePropertiesMetada
                   "The region code of the cloud that the catalog is running on",
                   false /* required */,
                   null /* The default value does not work because if the user does not set it, this property will not be displayed */,
+                  false /* hidden */),
+              PropertyEntry.booleanReservedPropertyEntry(
+                  PROPERTY_IN_USE,
+                  "The property indicating the catalog is in use",
+                  true /* default value */,
                   false /* hidden */)),
           PropertyEntry::getName);
 

--- a/core/src/main/java/org/apache/gravitino/meta/BaseMetalake.java
+++ b/core/src/main/java/org/apache/gravitino/meta/BaseMetalake.java
@@ -25,13 +25,13 @@ import javax.annotation.Nullable;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
-import org.apache.gravitino.Audit;
 import org.apache.gravitino.Auditable;
 import org.apache.gravitino.Entity;
 import org.apache.gravitino.Field;
 import org.apache.gravitino.HasIdentifier;
 import org.apache.gravitino.Metalake;
-import org.apache.gravitino.StringIdentifier;
+import org.apache.gravitino.connector.PropertiesMetadata;
+import org.apache.gravitino.metalake.MetalakePropertiesMetadata;
 
 /** Base implementation of a Metalake entity. */
 @EqualsAndHashCode
@@ -51,6 +51,8 @@ public class BaseMetalake implements Metalake, Entity, Auditable, HasIdentifier 
   /** The required field for the schema version of the metalake. */
   public static final Field SCHEMA_VERSION =
       Field.required("version", SchemaVersion.class, "The version of the schema for the metalake");
+
+  public static final PropertiesMetadata PROPERTIES_METADATA = new MetalakePropertiesMetadata();
 
   private Long id;
 
@@ -87,10 +89,10 @@ public class BaseMetalake implements Metalake, Entity, Auditable, HasIdentifier 
   /**
    * The audit information of the metalake.
    *
-   * @return The audit information as an {@link Audit} instance.
+   * @return The audit information as an {@link AuditInfo} instance.
    */
   @Override
-  public Audit auditInfo() {
+  public AuditInfo auditInfo() {
     return auditInfo;
   }
 
@@ -141,7 +143,15 @@ public class BaseMetalake implements Metalake, Entity, Auditable, HasIdentifier 
    */
   @Override
   public Map<String, String> properties() {
-    return StringIdentifier.newPropertiesWithoutId(properties);
+    return properties;
+  }
+
+  public PropertiesMetadata propertiesMetadata() {
+    return PROPERTIES_METADATA;
+  }
+
+  public boolean inUse() {
+    return (boolean) propertiesMetadata().getOrDefault(properties(), PROPERTY_IN_USE);
   }
 
   /** Builder class for creating instances of {@link BaseMetalake}. */

--- a/core/src/main/java/org/apache/gravitino/metalake/MetalakePropertiesMetadata.java
+++ b/core/src/main/java/org/apache/gravitino/metalake/MetalakePropertiesMetadata.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.metalake;
+
+import static org.apache.gravitino.Metalake.PROPERTY_IN_USE;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Maps;
+import java.util.List;
+import java.util.Map;
+import org.apache.gravitino.connector.PropertiesMetadata;
+import org.apache.gravitino.connector.PropertyEntry;
+
+public class MetalakePropertiesMetadata implements PropertiesMetadata {
+
+  private static final Map<String, PropertyEntry<?>> PROPERTY_ENTRIES;
+
+  static {
+    List<PropertyEntry<?>> propertyEntries =
+        ImmutableList.of(
+            PropertyEntry.booleanReservedPropertyEntry(
+                PROPERTY_IN_USE,
+                "The property indicating the catalog is in use",
+                true /* default value */,
+                false /* hidden */));
+
+    PROPERTY_ENTRIES = Maps.uniqueIndex(propertyEntries, PropertyEntry::getName);
+  }
+
+  @Override
+  public Map<String, PropertyEntry<?>> propertyEntries() {
+    return PROPERTY_ENTRIES;
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/metalake/SupportsMetalakes.java
+++ b/core/src/main/java/org/apache/gravitino/metalake/SupportsMetalakes.java
@@ -23,8 +23,10 @@ import org.apache.gravitino.Metalake;
 import org.apache.gravitino.MetalakeChange;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.annotation.Evolving;
+import org.apache.gravitino.exceptions.EntityInUseException;
 import org.apache.gravitino.exceptions.MetalakeAlreadyExistsException;
 import org.apache.gravitino.exceptions.NoSuchMetalakeException;
+import org.apache.gravitino.exceptions.NonEmptyEntityException;
 
 /**
  * Interface for supporting metalakes. It includes methods for listing, loading, creating, altering
@@ -89,10 +91,69 @@ public interface SupportsMetalakes {
       throws NoSuchMetalakeException, IllegalArgumentException;
 
   /**
-   * Drop a metalake with specified identifier.
+   * Drop a metalake with specified identifier. Please make sure:
+   *
+   * <ul>
+   *   <li>There is no catalog in the metalake. Otherwise, a {@link NonEmptyEntityException} will be
+   *       thrown.
+   *   <li>The method {@link #inactivateMetalake(NameIdentifier)} has been called before dropping
+   *       the metalake. Otherwise, a {@link EntityInUseException} will be thrown.
+   * </ul>
+   *
+   * It is equivalent to calling {@code dropMetalake(ident, false)}.
    *
    * @param ident The identifier of the metalake.
    * @return True if the metalake was dropped, false if the metalake does not exist.
+   * @throws NonEmptyEntityException If the metalake is not empty.
+   * @throws EntityInUseException If the metalake is in use.
    */
-  boolean dropMetalake(NameIdentifier ident);
+  default boolean dropMetalake(NameIdentifier ident)
+      throws NonEmptyEntityException, EntityInUseException {
+    return dropMetalake(ident, false);
+  }
+
+  /**
+   * Drop a metalake with specified identifier. If the force flag is true, it will:
+   *
+   * <ul>
+   *   <li>Cascade drop all sub-entities (tags, catalogs, schemas, tables, etc.) of the metalake in
+   *       Gravitino store.
+   *   <li>Drop the metalake even if it is in use.
+   *   <li>External resources (e.g. database, table, etc.) associated with sub-entities will not be
+   *       deleted unless it is managed (such as managed fileset).
+   * </ul>
+   *
+   * @param ident The identifier of the metalake.
+   * @param force Whether to force the drop.
+   * @return True if the metalake was dropped, false if the metalake does not exist.
+   * @throws NonEmptyEntityException If the metalake is not empty and force is false.
+   * @throws EntityInUseException If the metalake is in use and force is false.
+   */
+  boolean dropMetalake(NameIdentifier ident, boolean force)
+      throws NonEmptyEntityException, EntityInUseException;
+
+  /**
+   * Activate a metalake. If the metalake is already active, this method does nothing.
+   *
+   * @param ident The identifier of the metalake.
+   * @throws NoSuchMetalakeException If the metalake does not exist.
+   */
+  void activateMetalake(NameIdentifier ident) throws NoSuchMetalakeException;
+
+  /**
+   * Inactivate a metalake. If the metalake is already inactive, this method does nothing. Once a
+   * metalake is inactivated:
+   *
+   * <ul>
+   *   <li>It can only be listed, loaded, dropped, or activated.
+   *   <li>Any other operations on the metalake will throw an {@link
+   *       org.apache.gravitino.exceptions.NonInUseEntityException}.
+   *   <li>Any operation on the sub-entities (catalogs, schemas, tables, etc.) will throw an {@link
+   *       org.apache.gravitino.exceptions.NonInUseEntityException}.
+   * </ul>
+   *
+   * @param ident The identifier of the metalake.
+   * @throws NoSuchMetalakeException If the metalake does not exist.
+   */
+  void inactivateMetalake(NameIdentifier ident) throws NoSuchMetalakeException;
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

 - add `in-use` property to metalake and catalog
 - add `in-use` to drop catalog/metalake APIs
 - add `inactivate()` and `activate()` API for metalake and catalog
 - new definition for drop matalake/catalog

### Why are the changes needed?

unify drop catalog and metalake


### Does this PR introduce _any_ user-facing change?

yes

### How was this patch tested?

tests added
