### PR TITLE
[#4895]  docs(iceberg): add document for support not managed storages for Iceberg

### DIFF
--- a/docs/iceberg-rest-service.md
+++ b/docs/iceberg-rest-service.md
@@ -18,10 +18,7 @@ The Apache Gravitino Iceberg REST Server follows the [Apache Iceberg REST API sp
   - multi table transaction
   - pagination
 - Works as a catalog proxy, supporting `Hive` and `JDBC` as catalog backend.
-- Supports multi storage.
-  - HDFS
-  - S3
-  - OSS
+- Supports diverse storage like `S3`, `HDFS`, `OSS`, and provides the capability to support other storages.
 - Supports OAuth2 and HTTPS.
 - Provides a pluggable metrics store interface to store and delete Iceberg metrics.
 
@@ -160,6 +157,20 @@ You should place HDFS configuration file to the classpath of the Iceberg REST se
 
 :::info
 Builds with Hadoop 2.10.x. There may be compatibility issues when accessing Hadoop 3.x clusters.
+:::
+
+#### Other storages
+
+For storages that are not inherently integrated into Gravitino Iceberg REST service, you can manage them effectively through custom catalog properties.
+
+| Configuration item               | Description                                                                             | Default value | Required | Since Version |
+|----------------------------------|-----------------------------------------------------------------------------------------|---------------|----------|---------------|
+| `gravitino.iceberg-rest.io-impl` | The IO implementation for `FileIO` in Iceberg, please use the full qualified classname. | (none)        | No       | 0.6.0         |
+
+To pass custom properties such as `security-token` to your custom FileIO, you can directly configure it using the property `gravitino.iceberg-rest.security-token`. This security-token will be included in the properties when the initialize method of `FileIO` is invoked.
+
+:::info
+Please set the `gravitino.iceberg-rest.warehouse` parameter to `{storage_prefix}://{bucket_name}/${prefix_name}`. Additionally, download corresponding jars in the classpath of Iceberg REST server, `iceberg-rest-server/libs` for the auxiliary server, `libs` for the standalone server.
 :::
 
 ### Catalog backend configuration
@@ -337,7 +348,7 @@ For example, we can configure Spark catalog options to use Gravitino Iceberg RES
 --conf spark.sql.catalog.rest.uri=http://127.0.0.1:9001/iceberg/
 ```
 
-You may need to adjust the Iceberg Spark runtime jar file name according to the real version number in your environment. If you want to access the data stored in cloud, you need to download corresponding jars (please refer to the cloud storage part) and place it in the classpath of Spark, no extra config is needed because related properties is transferred from Iceberg REST server to Iceberg REST client automatically. 
+You may need to adjust the Iceberg Spark runtime jar file name according to the real version number in your environment. If you want to access the data stored in cloud, you need to download corresponding jars (please refer to the cloud storage part) and place it in the classpath of Spark, no extra config is needed because related properties is transferred from Iceberg REST server to Iceberg REST client automatically.  For other storages not managed by Gravitino, you could specify the configuration explicitly to initialize the `FileIO` implementation, like `spark.sql.catalog.${catalog_name}.${configuration_key}`.
 
 ### Exploring Apache Iceberg with Apache Spark SQL
 

--- a/docs/iceberg-rest-service.md
+++ b/docs/iceberg-rest-service.md
@@ -348,7 +348,7 @@ For example, we can configure Spark catalog options to use Gravitino Iceberg RES
 --conf spark.sql.catalog.rest.uri=http://127.0.0.1:9001/iceberg/
 ```
 
-You may need to adjust the Iceberg Spark runtime jar file name according to the real version number in your environment. If you want to access the data stored in cloud, you need to download corresponding jars (please refer to the cloud storage part) and place it in the classpath of Spark, no extra config is needed because related properties is transferred from Iceberg REST server to Iceberg REST client automatically.  For other storages not managed by Gravitino, you could specify the configuration explicitly to initialize the `FileIO` implementation, like `spark.sql.catalog.${catalog_name}.${configuration_key}`.
+You may need to adjust the Iceberg Spark runtime jar file name according to the real version number in your environment. If you want to access the data stored in cloud, you need to download corresponding jars (please refer to the cloud storage part) and place it in the classpath of Spark, no extra config is needed because related properties is transferred from Iceberg REST server to Iceberg REST client automatically.  For other storages not managed by Gravitino, the properties wouldn't transfer from the server to client automatically, if you want to pass custom properties to initialize `FileIO`, you could add it by `spark.sql.catalog.${iceberg_catalog_name}.${configuration_key}` = `{property_value}`.
 
 ### Exploring Apache Iceberg with Apache Spark SQL
 

--- a/docs/iceberg-rest-service.md
+++ b/docs/iceberg-rest-service.md
@@ -167,7 +167,7 @@ For other storages that are not managed by Gravitino directly, you can manage th
 |----------------------------------|-----------------------------------------------------------------------------------------|---------------|----------|---------------|
 | `gravitino.iceberg-rest.io-impl` | The IO implementation for `FileIO` in Iceberg, please use the full qualified classname. | (none)        | No       | 0.6.0         |
 
-To pass custom properties such as `security-token` to your custom `FileIO`, you can directly configure it by `gravitino.iceberg-rest.security-token`. This security-token will be included in the properties when the initialize method of `FileIO` is invoked.
+To pass custom properties such as `security-token` to your custom `FileIO`, you can directly configure it by `gravitino.iceberg-rest.security-token`. `security-token` will be included in the properties when the initialize method of `FileIO` is invoked.
 
 :::info
 Please set the `gravitino.iceberg-rest.warehouse` parameter to `{storage_prefix}://{bucket_name}/${prefix_name}`. Additionally, download corresponding jars in the classpath of Iceberg REST server, `iceberg-rest-server/libs` for the auxiliary server, `libs` for the standalone server.

--- a/docs/iceberg-rest-service.md
+++ b/docs/iceberg-rest-service.md
@@ -18,7 +18,7 @@ The Apache Gravitino Iceberg REST Server follows the [Apache Iceberg REST API sp
   - multi table transaction
   - pagination
 - Works as a catalog proxy, supporting `Hive` and `JDBC` as catalog backend.
-- Supports diverse storage like `S3`, `HDFS`, `OSS`, and provides the capability to support other storages.
+- Supports different storages like `S3`, `HDFS`, `OSS`, `GCS` and provides the capability to support other storages.
 - Supports OAuth2 and HTTPS.
 - Provides a pluggable metrics store interface to store and delete Iceberg metrics.
 
@@ -161,7 +161,7 @@ Builds with Hadoop 2.10.x. There may be compatibility issues when accessing Hado
 
 #### Other storages
 
-For other storages that are managed by Gravitino directly, you can manage them through custom catalog properties.
+For other storages that are not managed by Gravitino directly, you can manage them through custom catalog properties.
 
 | Configuration item               | Description                                                                             | Default value | Required | Since Version |
 |----------------------------------|-----------------------------------------------------------------------------------------|---------------|----------|---------------|
@@ -348,7 +348,9 @@ For example, we can configure Spark catalog options to use Gravitino Iceberg RES
 --conf spark.sql.catalog.rest.uri=http://127.0.0.1:9001/iceberg/
 ```
 
-You may need to adjust the Iceberg Spark runtime jar file name according to the real version number in your environment. If you want to access the data stored in cloud, you need to download corresponding jars (please refer to the cloud storage part) and place it in the classpath of Spark, no extra config is needed because related properties is transferred from Iceberg REST server to Iceberg REST client automatically.  For other storages not managed by Gravitino, the properties wouldn't transfer from the server to client automatically, if you want to pass custom properties to initialize `FileIO`, you could add it by `spark.sql.catalog.${iceberg_catalog_name}.${configuration_key}` = `{property_value}`.
+You may need to adjust the Iceberg Spark runtime jar file name according to the real version number in your environment. If you want to access the data stored in cloud, you need to download corresponding jars (please refer to the cloud storage part) and place it in the classpath of Spark, no extra config is needed because related properties is transferred from Iceberg REST server to Iceberg REST client automatically.
+
+For other storages not managed by Gravitino, the properties wouldn't transfer from the server to client automatically, if you want to pass custom properties to initialize `FileIO`, you could add it by `spark.sql.catalog.${iceberg_catalog_name}.${configuration_key}` = `{property_value}`.
 
 ### Exploring Apache Iceberg with Apache Spark SQL
 

--- a/docs/iceberg-rest-service.md
+++ b/docs/iceberg-rest-service.md
@@ -161,13 +161,13 @@ Builds with Hadoop 2.10.x. There may be compatibility issues when accessing Hado
 
 #### Other storages
 
-For storages that are not inherently integrated into Gravitino Iceberg REST service, you can manage them effectively through custom catalog properties.
+For other storages that are managed by Gravitino directly, you can manage them through custom catalog properties.
 
 | Configuration item               | Description                                                                             | Default value | Required | Since Version |
 |----------------------------------|-----------------------------------------------------------------------------------------|---------------|----------|---------------|
 | `gravitino.iceberg-rest.io-impl` | The IO implementation for `FileIO` in Iceberg, please use the full qualified classname. | (none)        | No       | 0.6.0         |
 
-To pass custom properties such as `security-token` to your custom FileIO, you can directly configure it using the property `gravitino.iceberg-rest.security-token`. This security-token will be included in the properties when the initialize method of `FileIO` is invoked.
+To pass custom properties such as `security-token` to your custom `FileIO`, you can directly configure it by `gravitino.iceberg-rest.security-token`. This security-token will be included in the properties when the initialize method of `FileIO` is invoked.
 
 :::info
 Please set the `gravitino.iceberg-rest.warehouse` parameter to `{storage_prefix}://{bucket_name}/${prefix_name}`. Additionally, download corresponding jars in the classpath of Iceberg REST server, `iceberg-rest-server/libs` for the auxiliary server, `libs` for the standalone server.

--- a/docs/lakehouse-iceberg-catalog.md
+++ b/docs/lakehouse-iceberg-catalog.md
@@ -121,13 +121,13 @@ Please set `warehouse` to `gs://{bucket_name}/${prefix_name}`, and download [Ice
 
 #### Other storages
 
-For storages that are not inherently integrated into Gravitino Iceberg REST service, you can manage them effectively through custom catalog properties.
+For other storages that are managed by Gravitino directly, you can manage them through custom catalog properties.
 
 | Configuration item | Description                                                                             | Default value | Required | Since Version |
 |--------------------|-----------------------------------------------------------------------------------------|---------------|----------|---------------|
 | `io-impl`          | The IO implementation for `FileIO` in Iceberg, please use the full qualified classname. | (none)        | No       | 0.6.0         |
 
-For other custom properties like `security-token` to pass to `FileIO`, you could config it directly by `gravitino.bypass.security-token`.
+To pass custom properties such as `security-token` to your custom `FileIO`, you can directly configure it by `gravitino.bypass.security-token`. This security-token will be included in the properties when the initialize method of `FileIO` is invoked.
 
 :::info
 Please set the `warehouse` parameter to `{storage_prefix}://{bucket_name}/${prefix_name}`. Additionally, download corresponding jars in the `catalogs/lakehouse-iceberg/libs/` directory.

--- a/docs/lakehouse-iceberg-catalog.md
+++ b/docs/lakehouse-iceberg-catalog.md
@@ -121,7 +121,7 @@ Please set `warehouse` to `gs://{bucket_name}/${prefix_name}`, and download [Ice
 
 #### Other storages
 
-For other storages that are managed by Gravitino directly, you can manage them through custom catalog properties.
+For other storages that are not managed by Gravitino directly, you can manage them through custom catalog properties.
 
 | Configuration item | Description                                                                             | Default value | Required | Since Version |
 |--------------------|-----------------------------------------------------------------------------------------|---------------|----------|---------------|

--- a/docs/lakehouse-iceberg-catalog.md
+++ b/docs/lakehouse-iceberg-catalog.md
@@ -127,7 +127,7 @@ For other storages that are not managed by Gravitino directly, you can manage th
 |--------------------|-----------------------------------------------------------------------------------------|---------------|----------|---------------|
 | `io-impl`          | The IO implementation for `FileIO` in Iceberg, please use the full qualified classname. | (none)        | No       | 0.6.0         |
 
-To pass custom properties such as `security-token` to your custom `FileIO`, you can directly configure it by `gravitino.bypass.security-token`. This security-token will be included in the properties when the initialize method of `FileIO` is invoked.
+To pass custom properties such as `security-token` to your custom `FileIO`, you can directly configure it by `gravitino.bypass.security-token`. `security-token` will be included in the properties when the initialize method of `FileIO` is invoked.
 
 :::info
 Please set the `warehouse` parameter to `{storage_prefix}://{bucket_name}/${prefix_name}`. Additionally, download corresponding jars in the `catalogs/lakehouse-iceberg/libs/` directory.

--- a/docs/lakehouse-iceberg-catalog.md
+++ b/docs/lakehouse-iceberg-catalog.md
@@ -119,6 +119,20 @@ Please make sure the credential file is accessible by Gravitino, like using `exp
 Please set `warehouse` to `gs://{bucket_name}/${prefix_name}`, and download [Iceberg gcp bundle jar](https://mvnrepository.com/artifact/org.apache.iceberg/iceberg-gcp-bundle) and place it to `catalogs/lakehouse-iceberg/libs/`.
 :::
 
+#### Other storages
+
+For storages that are not inherently integrated into Gravitino Iceberg REST service, you can manage them effectively through custom catalog properties.
+
+| Configuration item | Description                                                                             | Default value | Required | Since Version |
+|--------------------|-----------------------------------------------------------------------------------------|---------------|----------|---------------|
+| `io-impl`          | The IO implementation for `FileIO` in Iceberg, please use the full qualified classname. | (none)        | No       | 0.6.0         |
+
+For other custom properties like `security-token` to pass to `FileIO`, you could config it directly by `gravitino.bypass.security-token`.
+
+:::info
+Please set the `warehouse` parameter to `{storage_prefix}://{bucket_name}/${prefix_name}`. Additionally, download corresponding jars in the `catalogs/lakehouse-iceberg/libs/` directory.
+:::
+
 #### Catalog backend security
 
 Users can use the following properties to configure the security of the catalog backend if needed. For example, if you are using a Kerberos Hive catalog backend, you must set `authentication.type` to `Kerberos` and provide `authentication.kerberos.principal` and `authentication.kerberos.keytab-uri`.

--- a/docs/spark-connector/spark-catalog-iceberg.md
+++ b/docs/spark-connector/spark-catalog-iceberg.md
@@ -135,4 +135,4 @@ No extra configuration is needed. Please make sure the credential file is access
 
 ### Other storage
 
-You need to add custom configuration with the format `spark.sql.catalog.${iceberg_catalog_name}.{configuration_key}`. Additionally, place corresponding jars which implement `FileIO` in the classpath of Spark.
+You may need to add custom configurations with the format `spark.sql.catalog.${iceberg_catalog_name}.{configuration_key}`. Additionally, place corresponding jars which implement `FileIO` in the classpath of Spark.

--- a/docs/spark-connector/spark-catalog-iceberg.md
+++ b/docs/spark-connector/spark-catalog-iceberg.md
@@ -132,3 +132,7 @@ You need to add OSS secret key to the Spark configuration using `spark.sql.catal
 ### GCS
 
 No extra configuration is needed. Please make sure the credential file is accessible by Spark, like using `export GOOGLE_APPLICATION_CREDENTIALS=/xx/application_default_credentials.json`, and download [Iceberg gcp bundle](https://mvnrepository.com/artifact/org.apache.iceberg/iceberg-gcp-bundle) and place it to the classpath of Spark.
+
+### Other storage
+
+You need to add custom configuration with the format `spark.sql.catalog.${iceberg_catalog_name}.{configuration_key}`. Additionally, place corresponding jars which implement `FileIO` in the classpath of Spark.


### PR DESCRIPTION
### What changes were proposed in this pull request?

For other storage not build in with Gravitino, we should add a document about how to run it

### Why are the changes needed?

Fix: #4895 

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
existing tests