### PR TITLE
feat(oceanbase-jdbc-catalog)：Add full code to support non-partitioned tables for OceanBase-CE JDBC catalog

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -774,6 +774,7 @@ tasks {
       ":catalogs:catalog-jdbc-doris:copyLibAndConfig",
       ":catalogs:catalog-jdbc-mysql:copyLibAndConfig",
       ":catalogs:catalog-jdbc-postgresql:copyLibAndConfig",
+      ":catalogs:catalog-jdbc-oceanbase:copyLibAndConfig",
       ":catalogs:catalog-hadoop:copyLibAndConfig",
       ":catalogs:catalog-kafka:copyLibAndConfig"
     )

--- a/catalogs/catalog-jdbc-oceanbase/build.gradle.kts
+++ b/catalogs/catalog-jdbc-oceanbase/build.gradle.kts
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+description = "catalog-jdbc-oceanbase"
+
+plugins {
+  `maven-publish`
+  id("java")
+  id("idea")
+}
+
+dependencies {
+  implementation(project(":api")) {
+    exclude(group = "*")
+  }
+  implementation(project(":catalogs:catalog-jdbc-common")) {
+    exclude(group = "*")
+  }
+  implementation(project(":common")) {
+    exclude(group = "*")
+  }
+  implementation(project(":core")) {
+    exclude(group = "*")
+  }
+
+  implementation(libs.bundles.log4j)
+  implementation(libs.commons.collections4)
+  implementation(libs.commons.lang3)
+  implementation(libs.guava)
+
+  testImplementation(project(":catalogs:catalog-jdbc-common", "testArtifacts"))
+  testImplementation(project(":clients:client-java"))
+  testImplementation(project(":integration-test-common", "testArtifacts"))
+  testImplementation(project(":server"))
+  testImplementation(project(":server-common"))
+
+  testImplementation(libs.junit.jupiter.api)
+  testImplementation(libs.junit.jupiter.params)
+  testImplementation(libs.mysql.driver)
+  testImplementation(libs.testcontainers)
+  testImplementation(libs.testcontainers.mysql)
+
+  testRuntimeOnly(libs.junit.jupiter.engine)
+}
+
+tasks {
+  val runtimeJars by registering(Copy::class) {
+    from(configurations.runtimeClasspath)
+    into("build/libs")
+  }
+  val copyCatalogLibs by registering(Copy::class) {
+    dependsOn("jar", "runtimeJars")
+    from("build/libs") {
+      exclude("guava-*.jar")
+      exclude("log4j-*.jar")
+      exclude("slf4j-*.jar")
+    }
+    into("$rootDir/distribution/package/catalogs/jdbc-oceanbase/libs")
+  }
+
+  val copyCatalogConfig by registering(Copy::class) {
+    from("src/main/resources")
+    into("$rootDir/distribution/package/catalogs/jdbc-oceanbase/conf")
+
+    include("jdbc-oceanbase.conf")
+
+    exclude { details ->
+      details.file.isDirectory()
+    }
+
+    fileMode = 0b111101101
+  }
+
+  register("copyLibAndConfig", Copy::class) {
+    dependsOn(copyCatalogLibs, copyCatalogConfig)
+  }
+}
+
+tasks.test {
+  val skipUTs = project.hasProperty("skipTests")
+  if (skipUTs) {
+    // Only run integration tests
+    include("**/integration/**")
+  }
+  val skipITs = project.hasProperty("skipITs")
+  if (skipITs) {
+    // Exclude integration tests
+    exclude("**/integration/**")
+  } else {
+    dependsOn(tasks.jar)
+  }
+}
+
+tasks.getByName("generateMetadataFileForMavenJavaPublication") {
+  dependsOn("runtimeJars")
+}

--- a/catalogs/catalog-jdbc-oceanbase/src/main/java/org/apache/gravitino/catalog/oceanbase/OceanBaseCatalog.java
+++ b/catalogs/catalog-jdbc-oceanbase/src/main/java/org/apache/gravitino/catalog/oceanbase/OceanBaseCatalog.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog.oceanbase;
+
+import java.util.Map;
+import org.apache.gravitino.catalog.jdbc.JdbcCatalog;
+import org.apache.gravitino.catalog.jdbc.JdbcCatalogOperations;
+import org.apache.gravitino.catalog.jdbc.converter.JdbcColumnDefaultValueConverter;
+import org.apache.gravitino.catalog.jdbc.converter.JdbcExceptionConverter;
+import org.apache.gravitino.catalog.jdbc.converter.JdbcTypeConverter;
+import org.apache.gravitino.catalog.jdbc.operation.JdbcDatabaseOperations;
+import org.apache.gravitino.catalog.jdbc.operation.JdbcTableOperations;
+import org.apache.gravitino.catalog.oceanbase.converter.OceanBaseColumnDefaultValueConverter;
+import org.apache.gravitino.catalog.oceanbase.converter.OceanBaseExceptionConverter;
+import org.apache.gravitino.catalog.oceanbase.converter.OceanBaseTypeConverter;
+import org.apache.gravitino.catalog.oceanbase.operation.OceanBaseDatabaseOperations;
+import org.apache.gravitino.catalog.oceanbase.operation.OceanBaseTableOperations;
+import org.apache.gravitino.connector.CatalogOperations;
+import org.apache.gravitino.connector.capability.Capability;
+
+/** Implementation of a OceanBase catalog in Apache Gravitino. */
+public class OceanBaseCatalog extends JdbcCatalog {
+
+  @Override
+  public String shortName() {
+    return "jdbc-oceanbase";
+  }
+
+  @Override
+  protected CatalogOperations newOps(Map<String, String> config) {
+    return new JdbcCatalogOperations(
+        createExceptionConverter(),
+        createJdbcTypeConverter(),
+        createJdbcDatabaseOperations(),
+        createJdbcTableOperations(),
+        createJdbcColumnDefaultValueConverter());
+  }
+
+  @Override
+  public Capability newCapability() {
+    return new OceanBaseCatalogCapability();
+  }
+
+  @Override
+  protected JdbcExceptionConverter createExceptionConverter() {
+    return new OceanBaseExceptionConverter();
+  }
+
+  @Override
+  protected JdbcTypeConverter createJdbcTypeConverter() {
+    return new OceanBaseTypeConverter();
+  }
+
+  @Override
+  protected JdbcDatabaseOperations createJdbcDatabaseOperations() {
+    return new OceanBaseDatabaseOperations();
+  }
+
+  @Override
+  protected JdbcTableOperations createJdbcTableOperations() {
+    return new OceanBaseTableOperations();
+  }
+
+  @Override
+  protected JdbcColumnDefaultValueConverter createJdbcColumnDefaultValueConverter() {
+    return new OceanBaseColumnDefaultValueConverter();
+  }
+}

--- a/catalogs/catalog-jdbc-oceanbase/src/main/java/org/apache/gravitino/catalog/oceanbase/OceanBaseCatalogCapability.java
+++ b/catalogs/catalog-jdbc-oceanbase/src/main/java/org/apache/gravitino/catalog/oceanbase/OceanBaseCatalogCapability.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog.oceanbase;
+
+import org.apache.gravitino.connector.capability.Capability;
+import org.apache.gravitino.connector.capability.CapabilityResult;
+
+public class OceanBaseCatalogCapability implements Capability {
+  /**
+   * Regular expression explanation: ^[\w\p{L}-$/=]{1,64}$
+   *
+   * <p>^ - Start of the string
+   *
+   * <p>[\w\p{L}-$/=]{1,64} - Consist of 1 to 64 characters of letters (both cases), digits,
+   * underscores, any kind of letter from any language, hyphens, dollar signs, slashes or equal
+   * signs
+   *
+   * <p>\w - matches [a-zA-Z0-9_]
+   *
+   * <p>\p{L} - matches any kind of letter from any language
+   *
+   * <p>$ - End of the string
+   */
+  public static final String OCEANBASE_NAME_PATTERN = "^[\\w\\p{L}-$/=]{1,64}$";
+
+  @Override
+  public CapabilityResult specificationOnName(Scope scope, String name) {
+    if (!name.matches(OCEANBASE_NAME_PATTERN)) {
+      return CapabilityResult.unsupported(
+          String.format("The %s name '%s' is illegal.", scope, name));
+    }
+    return CapabilityResult.SUPPORTED;
+  }
+}

--- a/catalogs/catalog-jdbc-oceanbase/src/main/java/org/apache/gravitino/catalog/oceanbase/converter/OceanBaseColumnDefaultValueConverter.java
+++ b/catalogs/catalog-jdbc-oceanbase/src/main/java/org/apache/gravitino/catalog/oceanbase/converter/OceanBaseColumnDefaultValueConverter.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog.oceanbase.converter;
+
+import static org.apache.gravitino.rel.Column.DEFAULT_VALUE_NOT_SET;
+import static org.apache.gravitino.rel.Column.DEFAULT_VALUE_OF_CURRENT_TIMESTAMP;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.Objects;
+import org.apache.gravitino.catalog.jdbc.converter.JdbcColumnDefaultValueConverter;
+import org.apache.gravitino.catalog.jdbc.converter.JdbcTypeConverter;
+import org.apache.gravitino.rel.expressions.Expression;
+import org.apache.gravitino.rel.expressions.UnparsedExpression;
+import org.apache.gravitino.rel.expressions.literals.Literals;
+import org.apache.gravitino.rel.types.Decimal;
+import org.apache.gravitino.rel.types.Types;
+
+public class OceanBaseColumnDefaultValueConverter extends JdbcColumnDefaultValueConverter {
+
+  @Override
+  public Expression toGravitino(
+      JdbcTypeConverter.JdbcTypeBean type,
+      String columnDefaultValue,
+      boolean isExpression,
+      boolean nullable) {
+    if (Objects.isNull(columnDefaultValue)) {
+      return nullable ? Literals.NULL : DEFAULT_VALUE_NOT_SET;
+    }
+
+    if (columnDefaultValue.equalsIgnoreCase(NULL)) {
+      return Literals.NULL;
+    }
+
+    if (isExpression) {
+      if (columnDefaultValue.equals(CURRENT_TIMESTAMP)) {
+        return DEFAULT_VALUE_OF_CURRENT_TIMESTAMP;
+      }
+      // The parsing of OceanBase expressions is complex, so we are not currently undertaking the
+      // parsing.
+      return UnparsedExpression.of(columnDefaultValue);
+    }
+
+    switch (type.getTypeName().toLowerCase()) {
+      case OceanBaseTypeConverter.TINYINT:
+        return Literals.byteLiteral(Byte.valueOf(columnDefaultValue));
+      case OceanBaseTypeConverter.TINYINT_UNSIGNED:
+        return Literals.unsignedByteLiteral(Short.valueOf(columnDefaultValue));
+      case OceanBaseTypeConverter.SMALLINT:
+        return Literals.shortLiteral(Short.valueOf(columnDefaultValue));
+      case OceanBaseTypeConverter.SMALLINT_UNSIGNED:
+        return Literals.unsignedShortLiteral(Integer.valueOf(columnDefaultValue));
+      case OceanBaseTypeConverter.INT:
+        return Literals.integerLiteral(Integer.valueOf(columnDefaultValue));
+      case OceanBaseTypeConverter.INT_UNSIGNED:
+        return Literals.unsignedIntegerLiteral(Long.valueOf(columnDefaultValue));
+      case OceanBaseTypeConverter.BIGINT:
+        return Literals.longLiteral(Long.valueOf(columnDefaultValue));
+      case OceanBaseTypeConverter.BIGINT_UNSIGNED:
+        return Literals.unsignedLongLiteral(Decimal.of(columnDefaultValue));
+      case OceanBaseTypeConverter.FLOAT:
+        return Literals.floatLiteral(Float.valueOf(columnDefaultValue));
+      case OceanBaseTypeConverter.DOUBLE:
+        return Literals.doubleLiteral(Double.valueOf(columnDefaultValue));
+      case OceanBaseTypeConverter.NUMBER:
+      case OceanBaseTypeConverter.NUMERIC:
+      case OceanBaseTypeConverter.DECIMAL:
+        return Literals.decimalLiteral(
+            Decimal.of(
+                columnDefaultValue,
+                Integer.parseInt(type.getColumnSize()),
+                Integer.parseInt(type.getScale())));
+      case JdbcTypeConverter.DATE:
+        return Literals.dateLiteral(LocalDate.parse(columnDefaultValue, DATE_FORMATTER));
+      case JdbcTypeConverter.TIME:
+        return Literals.timeLiteral(LocalTime.parse(columnDefaultValue, DATE_TIME_FORMATTER));
+      case JdbcTypeConverter.TIMESTAMP:
+      case OceanBaseTypeConverter.DATETIME:
+        return CURRENT_TIMESTAMP.equals(columnDefaultValue)
+            ? DEFAULT_VALUE_OF_CURRENT_TIMESTAMP
+            : Literals.timestampLiteral(
+                LocalDateTime.parse(columnDefaultValue, DATE_TIME_FORMATTER));
+      case JdbcTypeConverter.VARCHAR:
+        return Literals.of(
+            columnDefaultValue, Types.VarCharType.of(Integer.parseInt(type.getColumnSize())));
+      case OceanBaseTypeConverter.CHAR:
+        return Literals.of(
+            columnDefaultValue, Types.FixedCharType.of(Integer.parseInt(type.getColumnSize())));
+      case OceanBaseTypeConverter.JSON:
+      case JdbcTypeConverter.TEXT:
+        return Literals.stringLiteral(columnDefaultValue);
+      default:
+        return UnparsedExpression.of(columnDefaultValue);
+    }
+  }
+}

--- a/catalogs/catalog-jdbc-oceanbase/src/main/java/org/apache/gravitino/catalog/oceanbase/converter/OceanBaseExceptionConverter.java
+++ b/catalogs/catalog-jdbc-oceanbase/src/main/java/org/apache/gravitino/catalog/oceanbase/converter/OceanBaseExceptionConverter.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog.oceanbase.converter;
+
+import java.sql.SQLException;
+import org.apache.gravitino.catalog.jdbc.converter.JdbcExceptionConverter;
+import org.apache.gravitino.exceptions.GravitinoRuntimeException;
+import org.apache.gravitino.exceptions.NoSuchSchemaException;
+import org.apache.gravitino.exceptions.NoSuchTableException;
+import org.apache.gravitino.exceptions.SchemaAlreadyExistsException;
+import org.apache.gravitino.exceptions.TableAlreadyExistsException;
+
+/** Exception converter to Apache Gravitino exception for OceanBase. */
+public class OceanBaseExceptionConverter extends JdbcExceptionConverter {
+
+  @SuppressWarnings("FormatStringAnnotation")
+  @Override
+  public GravitinoRuntimeException toGravitinoException(SQLException se) {
+    switch (se.getErrorCode()) {
+      case 1007:
+        return new SchemaAlreadyExistsException(se, se.getMessage());
+      case 1050:
+        return new TableAlreadyExistsException(se, se.getMessage());
+      case 1008:
+      case 1049:
+        return new NoSuchSchemaException(se, se.getMessage());
+      case 1146:
+      case 1051:
+        return new NoSuchTableException(se, se.getMessage());
+      default:
+        return new GravitinoRuntimeException(se, se.getMessage());
+    }
+  }
+}

--- a/catalogs/catalog-jdbc-oceanbase/src/main/java/org/apache/gravitino/catalog/oceanbase/converter/OceanBaseTypeConverter.java
+++ b/catalogs/catalog-jdbc-oceanbase/src/main/java/org/apache/gravitino/catalog/oceanbase/converter/OceanBaseTypeConverter.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog.oceanbase.converter;
+
+import org.apache.gravitino.catalog.jdbc.converter.JdbcTypeConverter;
+import org.apache.gravitino.rel.types.Type;
+import org.apache.gravitino.rel.types.Types;
+
+/** Type converter for OceanBase. */
+public class OceanBaseTypeConverter extends JdbcTypeConverter {
+
+  static final String TINYINT = "tinyint";
+  static final String TINYINT_UNSIGNED = "tinyint unsigned";
+  static final String SMALLINT = "smallint";
+  static final String SMALLINT_UNSIGNED = "smallint unsigned";
+  static final String INT = "int";
+  static final String INT_UNSIGNED = "int unsigned";
+  static final String BIGINT = "bigint";
+  static final String BIGINT_UNSIGNED = "bigint unsigned";
+  static final String FLOAT = "float";
+  static final String DOUBLE = "double";
+  static final String DECIMAL = "decimal";
+  static final String NUMBER = "number";
+  static final String NUMERIC = "numeric";
+  static final String CHAR = "char";
+  static final String BINARY = "binary";
+  static final String DATETIME = "datetime";
+  static final String JSON = "json";
+
+  @Override
+  public Type toGravitino(JdbcTypeBean typeBean) {
+    switch (typeBean.getTypeName().toLowerCase()) {
+      case TINYINT:
+        return Types.ByteType.get();
+      case TINYINT_UNSIGNED:
+        return Types.ByteType.unsigned();
+      case SMALLINT:
+        return Types.ShortType.get();
+      case SMALLINT_UNSIGNED:
+        return Types.ShortType.unsigned();
+      case INT:
+        return Types.IntegerType.get();
+      case INT_UNSIGNED:
+        return Types.IntegerType.unsigned();
+      case BIGINT:
+        return Types.LongType.get();
+      case BIGINT_UNSIGNED:
+        return Types.LongType.unsigned();
+      case FLOAT:
+        return Types.FloatType.get();
+      case DOUBLE:
+        return Types.DoubleType.get();
+      case DATE:
+        return Types.DateType.get();
+      case TIME:
+        return Types.TimeType.get();
+      case TIMESTAMP:
+        return Types.TimestampType.withTimeZone();
+      case DATETIME:
+        return Types.TimestampType.withoutTimeZone();
+      case NUMBER:
+      case NUMERIC:
+      case DECIMAL:
+        return Types.DecimalType.of(
+            Integer.parseInt(typeBean.getColumnSize()), Integer.parseInt(typeBean.getScale()));
+      case VARCHAR:
+        return Types.VarCharType.of(Integer.parseInt(typeBean.getColumnSize()));
+      case CHAR:
+        return Types.FixedCharType.of(Integer.parseInt(typeBean.getColumnSize()));
+      case JSON:
+      case TEXT:
+        return Types.StringType.get();
+      case BINARY:
+        return Types.BinaryType.get();
+      default:
+        return Types.ExternalType.of(typeBean.getTypeName());
+    }
+  }
+
+  @Override
+  public String fromGravitino(Type type) {
+    if (type instanceof Types.ByteType) {
+      if (((Types.ByteType) type).signed()) {
+        return TINYINT;
+      } else {
+        return TINYINT_UNSIGNED;
+      }
+    } else if (type instanceof Types.ShortType) {
+      if (((Types.ShortType) type).signed()) {
+        return SMALLINT;
+      } else {
+        return SMALLINT_UNSIGNED;
+      }
+    } else if (type instanceof Types.IntegerType) {
+      if (((Types.IntegerType) type).signed()) {
+        return INT;
+      } else {
+        return INT_UNSIGNED;
+      }
+    } else if (type instanceof Types.LongType) {
+      if (((Types.LongType) type).signed()) {
+        return BIGINT;
+      } else {
+        return BIGINT_UNSIGNED;
+      }
+    } else if (type instanceof Types.FloatType) {
+      return type.simpleString();
+    } else if (type instanceof Types.DoubleType) {
+      return type.simpleString();
+    } else if (type instanceof Types.BooleanType) {
+      return type.simpleString();
+    } else if (type instanceof Types.StringType) {
+      return TEXT;
+    } else if (type instanceof Types.DateType) {
+      return type.simpleString();
+    } else if (type instanceof Types.TimeType) {
+      return type.simpleString();
+    } else if (type instanceof Types.TimestampType) {
+      return ((Types.TimestampType) type).hasTimeZone() ? TIMESTAMP : DATETIME;
+    } else if (type instanceof Types.DecimalType) {
+      return type.simpleString();
+    } else if (type instanceof Types.VarCharType) {
+      return type.simpleString();
+    } else if (type instanceof Types.FixedCharType) {
+      return type.simpleString();
+    } else if (type instanceof Types.BinaryType) {
+      return type.simpleString();
+    } else if (type instanceof Types.ExternalType) {
+      return ((Types.ExternalType) type).catalogString();
+    }
+    throw new IllegalArgumentException(
+        String.format("Couldn't convert Gravitino type %s to OceanBase type", type.simpleString()));
+  }
+}

--- a/catalogs/catalog-jdbc-oceanbase/src/main/java/org/apache/gravitino/catalog/oceanbase/operation/OceanBaseDatabaseOperations.java
+++ b/catalogs/catalog-jdbc-oceanbase/src/main/java/org/apache/gravitino/catalog/oceanbase/operation/OceanBaseDatabaseOperations.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog.oceanbase.operation;
+
+import com.google.common.collect.ImmutableMap;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import org.apache.commons.collections4.MapUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.gravitino.StringIdentifier;
+import org.apache.gravitino.catalog.jdbc.JdbcSchema;
+import org.apache.gravitino.catalog.jdbc.operation.JdbcDatabaseOperations;
+import org.apache.gravitino.exceptions.NoSuchSchemaException;
+import org.apache.gravitino.meta.AuditInfo;
+
+/** Database operations for OceanBase. */
+public class OceanBaseDatabaseOperations extends JdbcDatabaseOperations {
+
+  public static final Set<String> SYS_OCEANBASE_DATABASE_NAMES = createSysOceanBaseDatabaseNames();
+
+  private static Set<String> createSysOceanBaseDatabaseNames() {
+    Set<String> set = new HashSet<>();
+    set.add("information_schema");
+    set.add("mysql");
+    set.add("sys");
+    set.add("oceanbase");
+    return Collections.unmodifiableSet(set);
+  }
+
+  @Override
+  public String generateCreateDatabaseSql(
+      String databaseName, String comment, Map<String, String> properties) {
+    String originComment = StringIdentifier.removeIdFromComment(comment);
+    if (StringUtils.isNotEmpty(originComment)) {
+      throw new UnsupportedOperationException(
+          "OceanBase doesn't support set schema comment: " + originComment);
+    }
+
+    String createDatabaseSql = String.format("CREATE DATABASE `%s`", databaseName);
+    // Append options
+    if (MapUtils.isNotEmpty(properties)) {
+      throw new UnsupportedOperationException("Properties are not supported yet");
+    }
+    LOG.info("Generated create database:{} sql: {}", databaseName, createDatabaseSql);
+    return createDatabaseSql;
+  }
+
+  @Override
+  public String generateDropDatabaseSql(String databaseName, boolean cascade) {
+    final String dropDatabaseSql = String.format("DROP DATABASE `%s`", databaseName);
+    if (cascade) {
+      return dropDatabaseSql;
+    }
+
+    try (final Connection connection = this.dataSource.getConnection()) {
+      String query = String.format("SHOW TABLES IN `%s`", databaseName);
+      try (Statement statement = connection.createStatement()) {
+        // Execute the query and check if there exists any tables in the database
+        try (ResultSet resultSet = statement.executeQuery(query)) {
+          if (resultSet.next()) {
+            throw new IllegalStateException(
+                String.format(
+                    "Database %s is not empty, the value of cascade should be true.",
+                    databaseName));
+          }
+        }
+      }
+    } catch (SQLException sqlException) {
+      throw this.exceptionMapper.toGravitinoException(sqlException);
+    }
+    return dropDatabaseSql;
+  }
+
+  @Override
+  public JdbcSchema load(String databaseName) throws NoSuchSchemaException {
+    List<String> allDatabases = listDatabases();
+    String dbName =
+        allDatabases.stream()
+            .filter(db -> db.equals(databaseName))
+            .findFirst()
+            .orElseThrow(
+                () -> new NoSuchSchemaException("Database %s could not be found", databaseName));
+
+    return JdbcSchema.builder()
+        .withName(dbName)
+        .withProperties(ImmutableMap.of())
+        .withAuditInfo(AuditInfo.EMPTY)
+        .build();
+  }
+
+  @Override
+  protected boolean isSystemDatabase(String dbName) {
+    return SYS_OCEANBASE_DATABASE_NAMES.contains(dbName.toLowerCase(Locale.ROOT));
+  }
+}

--- a/catalogs/catalog-jdbc-oceanbase/src/main/java/org/apache/gravitino/catalog/oceanbase/operation/OceanBaseTableOperations.java
+++ b/catalogs/catalog-jdbc-oceanbase/src/main/java/org/apache/gravitino/catalog/oceanbase/operation/OceanBaseTableOperations.java
@@ -1,0 +1,739 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog.oceanbase.operation;
+
+import static org.apache.gravitino.rel.Column.DEFAULT_VALUE_NOT_SET;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.MapUtils;
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.BooleanUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.gravitino.StringIdentifier;
+import org.apache.gravitino.catalog.jdbc.JdbcColumn;
+import org.apache.gravitino.catalog.jdbc.JdbcTable;
+import org.apache.gravitino.catalog.jdbc.operation.JdbcTableOperations;
+import org.apache.gravitino.catalog.jdbc.utils.JdbcConnectorUtils;
+import org.apache.gravitino.exceptions.NoSuchColumnException;
+import org.apache.gravitino.exceptions.NoSuchSchemaException;
+import org.apache.gravitino.exceptions.NoSuchTableException;
+import org.apache.gravitino.rel.Column;
+import org.apache.gravitino.rel.TableChange;
+import org.apache.gravitino.rel.expressions.distributions.Distribution;
+import org.apache.gravitino.rel.expressions.transforms.Transform;
+import org.apache.gravitino.rel.indexes.Index;
+import org.apache.gravitino.rel.indexes.Indexes;
+import org.apache.gravitino.rel.types.Types;
+
+/** Table operations for OceanBase. */
+public class OceanBaseTableOperations extends JdbcTableOperations {
+
+  public static final String BACK_QUOTE = "`";
+  public static final String OCEANBASE_AUTO_INCREMENT = "AUTO_INCREMENT";
+  private static final String OCEANBASE_NOT_SUPPORT_NESTED_COLUMN_MSG =
+      "OceanBase does not support nested column names.";
+
+  @Override
+  public List<String> listTables(String databaseName) throws NoSuchSchemaException {
+    final List<String> names = Lists.newArrayList();
+
+    try (Connection connection = getConnection(databaseName);
+        ResultSet tables = getTables(connection)) {
+      while (tables.next()) {
+        if (Objects.equals(tables.getString("TABLE_CAT"), databaseName)) {
+          names.add(tables.getString("TABLE_NAME"));
+        }
+      }
+      LOG.info("Finished listing tables size {} for database name {} ", names.size(), databaseName);
+      return names;
+    } catch (final SQLException se) {
+      throw this.exceptionMapper.toGravitinoException(se);
+    }
+  }
+
+  @Override
+  public JdbcTable load(String databaseName, String tableName) throws NoSuchTableException {
+    return super.load(databaseName, tableName.toLowerCase());
+  }
+
+  @Override
+  protected String generateCreateTableSql(
+      String tableName,
+      JdbcColumn[] columns,
+      String comment,
+      Map<String, String> properties,
+      Transform[] partitioning,
+      Distribution distribution,
+      Index[] indexes) {
+    if (ArrayUtils.isNotEmpty(partitioning)) {
+      throw new UnsupportedOperationException(
+          "Currently we do not support Partitioning in oceanbase");
+    }
+
+    validateIncrementCol(columns, indexes);
+    StringBuilder sqlBuilder = new StringBuilder();
+    sqlBuilder.append(String.format("CREATE TABLE `%s` (\n", tableName));
+
+    // Add columns
+    for (int i = 0; i < columns.length; i++) {
+      JdbcColumn column = columns[i];
+      sqlBuilder
+          .append(SPACE)
+          .append(SPACE)
+          .append(BACK_QUOTE)
+          .append(column.name())
+          .append(BACK_QUOTE);
+
+      appendColumnDefinition(column, sqlBuilder);
+      // Add a comma for the next column, unless it's the last one
+      if (i < columns.length - 1) {
+        sqlBuilder.append(",\n");
+      }
+    }
+
+    appendIndexesSql(indexes, sqlBuilder);
+
+    sqlBuilder.append("\n)");
+
+    // Add table comment if specified
+    if (StringUtils.isNotEmpty(comment)) {
+      sqlBuilder.append(" COMMENT='").append(comment).append("'");
+    }
+
+    // Add table properties if any
+    if (MapUtils.isNotEmpty(properties)) {
+      sqlBuilder.append(
+          properties.entrySet().stream()
+              .map(entry -> String.format("%s = %s", entry.getKey(), entry.getValue()))
+              .collect(Collectors.joining(",\n", "\n", "")));
+    }
+
+    // TODO: Add partition info if necessary.
+
+    // Return the generated SQL statement
+    String result = sqlBuilder.append(";").toString();
+
+    LOG.info("Generated create table:{} sql: {}", tableName, result);
+    return result;
+  }
+
+  /**
+   * The auto-increment column will be verified. There can only be one auto-increment column and it
+   * must be the primary key or unique index.
+   *
+   * @param columns jdbc column
+   * @param indexes table indexes
+   */
+  private static void validateIncrementCol(JdbcColumn[] columns, Index[] indexes) {
+    // Check auto increment column
+    List<JdbcColumn> autoIncrementCols =
+        Arrays.stream(columns).filter(Column::autoIncrement).collect(Collectors.toList());
+    String autoIncrementColsStr =
+        autoIncrementCols.stream().map(JdbcColumn::name).collect(Collectors.joining(",", "[", "]"));
+    Preconditions.checkArgument(
+        autoIncrementCols.size() <= 1,
+        "Only one column can be auto-incremented. There are multiple auto-increment columns in your table: "
+            + autoIncrementColsStr);
+    if (!autoIncrementCols.isEmpty()) {
+      Optional<Index> existAutoIncrementColIndexOptional =
+          Arrays.stream(indexes)
+              .filter(
+                  index ->
+                      Arrays.stream(index.fieldNames())
+                          .flatMap(Arrays::stream)
+                          .anyMatch(
+                              s ->
+                                  StringUtils.equalsIgnoreCase(autoIncrementCols.get(0).name(), s)))
+              .filter(
+                  index ->
+                      index.type() == Index.IndexType.PRIMARY_KEY
+                          || index.type() == Index.IndexType.UNIQUE_KEY)
+              .findAny();
+      Preconditions.checkArgument(
+          existAutoIncrementColIndexOptional.isPresent(),
+          "Incorrect table definition; there can be only one auto column and it must be defined as a key");
+    }
+  }
+
+  public static void appendIndexesSql(Index[] indexes, StringBuilder sqlBuilder) {
+    for (Index index : indexes) {
+      String fieldStr = getIndexFieldStr(index.fieldNames());
+      sqlBuilder.append(",\n");
+      switch (index.type()) {
+        case PRIMARY_KEY:
+          if (null != index.name()
+              && !StringUtils.equalsIgnoreCase(
+                  index.name(), Indexes.DEFAULT_MYSQL_PRIMARY_KEY_NAME)) {
+            throw new IllegalArgumentException("Primary key name must be PRIMARY in OceanBase");
+          }
+          sqlBuilder.append("CONSTRAINT ").append("PRIMARY KEY (").append(fieldStr).append(")");
+          break;
+        case UNIQUE_KEY:
+          sqlBuilder.append("CONSTRAINT ");
+          if (null != index.name()) {
+            sqlBuilder.append(BACK_QUOTE).append(index.name()).append(BACK_QUOTE);
+          }
+          sqlBuilder.append(" UNIQUE (").append(fieldStr).append(")");
+          break;
+        default:
+          throw new IllegalArgumentException("OceanBase doesn't support index : " + index.type());
+      }
+    }
+  }
+
+  private static String getIndexFieldStr(String[][] fieldNames) {
+    return Arrays.stream(fieldNames)
+        .map(
+            colNames -> {
+              if (colNames.length > 1) {
+                throw new IllegalArgumentException(
+                    "Index does not support complex fields in OceanBase");
+              }
+              return BACK_QUOTE + colNames[0] + BACK_QUOTE;
+            })
+        .collect(Collectors.joining(", "));
+  }
+
+  @Override
+  protected boolean getAutoIncrementInfo(ResultSet resultSet) throws SQLException {
+    return "YES".equalsIgnoreCase(resultSet.getString("IS_AUTOINCREMENT"));
+  }
+
+  @Override
+  protected Map<String, String> getTableProperties(Connection connection, String tableName)
+      throws SQLException {
+    try (PreparedStatement statement = connection.prepareStatement("SHOW TABLE STATUS LIKE ?")) {
+      statement.setString(1, tableName);
+      try (ResultSet resultSet = statement.executeQuery()) {
+        while (resultSet.next()) {
+          String name = resultSet.getString("NAME");
+          if (Objects.equals(name, tableName)) {
+            return Collections.unmodifiableMap(
+                new HashMap<String, String>() {
+                  {
+                    put(COMMENT, resultSet.getString(COMMENT));
+                    String autoIncrement = resultSet.getString("AUTO_INCREMENT");
+                    if (StringUtils.isNotEmpty(autoIncrement)) {
+                      put("AUTO_INCREMENT", autoIncrement);
+                    }
+                  }
+                });
+          }
+        }
+
+        throw new NoSuchTableException(
+            "Table %s does not exist in %s.", tableName, connection.getCatalog());
+      }
+    }
+  }
+
+  protected void correctJdbcTableFields(
+      Connection connection, String databaseName, String tableName, JdbcTable.Builder tableBuilder)
+      throws SQLException {
+    if (StringUtils.isEmpty(tableBuilder.comment())) {
+      tableBuilder.withComment(
+          tableBuilder.properties().getOrDefault(COMMENT, tableBuilder.comment()));
+    }
+  }
+
+  @Override
+  protected String generateRenameTableSql(String oldTableName, String newTableName) {
+    return String.format("RENAME TABLE `%s` TO `%s`", oldTableName, newTableName);
+  }
+
+  @Override
+  protected String generateDropTableSql(String tableName) {
+    return String.format("DROP TABLE `%s`", tableName);
+  }
+
+  @Override
+  protected String generatePurgeTableSql(String tableName) {
+    return String.format("TRUNCATE TABLE `%s`", tableName);
+  }
+
+  @Override
+  public void alterTable(String databaseName, String tableName, TableChange... changes)
+      throws NoSuchTableException {
+    LOG.info("Attempting to alter table {} from database {}", tableName, databaseName);
+    try (Connection connection = getConnection(databaseName)) {
+      for (TableChange change : changes) {
+        String sql = generateAlterTableSql(databaseName, tableName, change);
+        if (StringUtils.isEmpty(sql)) {
+          LOG.info("No changes to alter table {} from database {}", tableName, databaseName);
+          return;
+        }
+        JdbcConnectorUtils.executeUpdate(connection, sql);
+      }
+      LOG.info("Alter table {} from database {}", tableName, databaseName);
+    } catch (final SQLException se) {
+      throw this.exceptionMapper.toGravitinoException(se);
+    }
+  }
+
+  @Override
+  protected String generateAlterTableSql(
+      String databaseName, String tableName, TableChange... changes) {
+    // Not all operations require the original table information, so lazy loading is used here
+    JdbcTable lazyLoadTable = null;
+    TableChange.UpdateComment updateComment = null;
+    List<TableChange.SetProperty> setProperties = new ArrayList<>();
+    List<String> alterSql = new ArrayList<>();
+    for (int i = 0; i < changes.length; i++) {
+      TableChange change = changes[i];
+      if (change instanceof TableChange.UpdateComment) {
+        updateComment = (TableChange.UpdateComment) change;
+      } else if (change instanceof TableChange.SetProperty) {
+        // The set attribute needs to be added at the end.
+        setProperties.add(((TableChange.SetProperty) change));
+      } else if (change instanceof TableChange.RemoveProperty) {
+        // OceanBase does not support deleting table attributes, it can be replaced by Set Property
+        throw new IllegalArgumentException("Remove property is not supported yet");
+      } else if (change instanceof TableChange.AddColumn) {
+        TableChange.AddColumn addColumn = (TableChange.AddColumn) change;
+        lazyLoadTable = getOrCreateTable(databaseName, tableName, lazyLoadTable);
+        alterSql.add(addColumnFieldDefinition(addColumn));
+      } else if (change instanceof TableChange.RenameColumn) {
+        lazyLoadTable = getOrCreateTable(databaseName, tableName, lazyLoadTable);
+        TableChange.RenameColumn renameColumn = (TableChange.RenameColumn) change;
+        alterSql.add(renameColumnFieldDefinition(renameColumn, lazyLoadTable));
+      } else if (change instanceof TableChange.UpdateColumnDefaultValue) {
+        lazyLoadTable = getOrCreateTable(databaseName, tableName, lazyLoadTable);
+        TableChange.UpdateColumnDefaultValue updateColumnDefaultValue =
+            (TableChange.UpdateColumnDefaultValue) change;
+        alterSql.add(
+            updateColumnDefaultValueFieldDefinition(updateColumnDefaultValue, lazyLoadTable));
+      } else if (change instanceof TableChange.UpdateColumnType) {
+        lazyLoadTable = getOrCreateTable(databaseName, tableName, lazyLoadTable);
+        TableChange.UpdateColumnType updateColumnType = (TableChange.UpdateColumnType) change;
+        alterSql.add(updateColumnTypeFieldDefinition(updateColumnType, lazyLoadTable));
+      } else if (change instanceof TableChange.UpdateColumnComment) {
+        lazyLoadTable = getOrCreateTable(databaseName, tableName, lazyLoadTable);
+        TableChange.UpdateColumnComment updateColumnComment =
+            (TableChange.UpdateColumnComment) change;
+        alterSql.add(updateColumnCommentFieldDefinition(updateColumnComment, lazyLoadTable));
+      } else if (change instanceof TableChange.UpdateColumnPosition) {
+        lazyLoadTable = getOrCreateTable(databaseName, tableName, lazyLoadTable);
+        TableChange.UpdateColumnPosition updateColumnPosition =
+            (TableChange.UpdateColumnPosition) change;
+        alterSql.add(updateColumnPositionFieldDefinition(updateColumnPosition, lazyLoadTable));
+      } else if (change instanceof TableChange.DeleteColumn) {
+        TableChange.DeleteColumn deleteColumn = (TableChange.DeleteColumn) change;
+        lazyLoadTable = getOrCreateTable(databaseName, tableName, lazyLoadTable);
+        String deleteColSql = deleteColumnFieldDefinition(deleteColumn, lazyLoadTable);
+        if (StringUtils.isNotEmpty(deleteColSql)) {
+          alterSql.add(deleteColSql);
+        }
+      } else if (change instanceof TableChange.UpdateColumnNullability) {
+        lazyLoadTable = getOrCreateTable(databaseName, tableName, lazyLoadTable);
+        alterSql.add(
+            updateColumnNullabilityDefinition(
+                (TableChange.UpdateColumnNullability) change, lazyLoadTable));
+      } else if (change instanceof TableChange.AddIndex) {
+        alterSql.add(addIndexDefinition((TableChange.AddIndex) change));
+      } else if (change instanceof TableChange.DeleteIndex) {
+        lazyLoadTable = getOrCreateTable(databaseName, tableName, lazyLoadTable);
+        alterSql.add(deleteIndexDefinition(lazyLoadTable, (TableChange.DeleteIndex) change));
+      } else if (change instanceof TableChange.UpdateColumnAutoIncrement) {
+        lazyLoadTable = getOrCreateTable(databaseName, tableName, lazyLoadTable);
+        alterSql.add(
+            updateColumnAutoIncrementDefinition(
+                lazyLoadTable, (TableChange.UpdateColumnAutoIncrement) change));
+      } else {
+        throw new IllegalArgumentException(
+            "Unsupported table change type: " + change.getClass().getName());
+      }
+    }
+    if (!setProperties.isEmpty()) {
+      alterSql.add(generateTableProperties(setProperties));
+    }
+
+    // Last modified comment
+    if (null != updateComment) {
+      String newComment = updateComment.getNewComment();
+      if (null == StringIdentifier.fromComment(newComment)) {
+        // Detect and add Gravitino id.
+        JdbcTable jdbcTable = getOrCreateTable(databaseName, tableName, lazyLoadTable);
+        StringIdentifier identifier = StringIdentifier.fromComment(jdbcTable.comment());
+        if (null != identifier) {
+          newComment = StringIdentifier.addToComment(identifier, newComment);
+        }
+      }
+      alterSql.add("COMMENT '" + newComment + "'");
+    }
+
+    if (!setProperties.isEmpty()) {
+      alterSql.add(generateTableProperties(setProperties));
+    }
+
+    if (CollectionUtils.isEmpty(alterSql)) {
+      return "";
+    }
+    // Return the generated SQL statement
+    String result = "ALTER TABLE `" + tableName + "`\n" + String.join(",\n", alterSql) + ";";
+    LOG.info("Generated alter table:{} sql: {}", databaseName + "." + tableName, result);
+    return result;
+  }
+
+  private String updateColumnAutoIncrementDefinition(
+      JdbcTable table, TableChange.UpdateColumnAutoIncrement change) {
+    if (change.fieldName().length > 1) {
+      throw new UnsupportedOperationException("Nested column names are not supported");
+    }
+    String col = change.fieldName()[0];
+    JdbcColumn column = getJdbcColumnFromTable(table, col);
+    if (change.isAutoIncrement()) {
+      Preconditions.checkArgument(
+          Types.allowAutoIncrement(column.dataType()),
+          "Auto increment is not allowed, type: " + column.dataType());
+    }
+    JdbcColumn updateColumn =
+        JdbcColumn.builder()
+            .withName(col)
+            .withDefaultValue(column.defaultValue())
+            .withNullable(column.nullable())
+            .withType(column.dataType())
+            .withComment(column.comment())
+            .withAutoIncrement(change.isAutoIncrement())
+            .build();
+    return MODIFY_COLUMN
+        + BACK_QUOTE
+        + col
+        + BACK_QUOTE
+        + appendColumnDefinition(updateColumn, new StringBuilder());
+  }
+
+  @VisibleForTesting
+  static String deleteIndexDefinition(
+      JdbcTable lazyLoadTable, TableChange.DeleteIndex deleteIndex) {
+    if (deleteIndex.isIfExists()) {
+      if (Arrays.stream(lazyLoadTable.index())
+          .anyMatch(index -> index.name().equals(deleteIndex.getName()))) {
+        throw new IllegalArgumentException("Index does not exist");
+      }
+    }
+    return "DROP INDEX " + BACK_QUOTE + deleteIndex.getName() + BACK_QUOTE;
+  }
+
+  private String updateColumnNullabilityDefinition(
+      TableChange.UpdateColumnNullability change, JdbcTable table) {
+    validateUpdateColumnNullable(change, table);
+    String col = change.fieldName()[0];
+    JdbcColumn column = getJdbcColumnFromTable(table, col);
+    JdbcColumn updateColumn =
+        JdbcColumn.builder()
+            .withName(col)
+            .withDefaultValue(column.defaultValue())
+            .withNullable(change.nullable())
+            .withType(column.dataType())
+            .withComment(column.comment())
+            .withAutoIncrement(column.autoIncrement())
+            .build();
+    return MODIFY_COLUMN
+        + BACK_QUOTE
+        + col
+        + BACK_QUOTE
+        + appendColumnDefinition(updateColumn, new StringBuilder());
+  }
+
+  @VisibleForTesting
+  static String addIndexDefinition(TableChange.AddIndex addIndex) {
+    StringBuilder sqlBuilder = new StringBuilder();
+    sqlBuilder.append("ADD ");
+    switch (addIndex.getType()) {
+      case PRIMARY_KEY:
+        if (null != addIndex.getName()
+            && !StringUtils.equalsIgnoreCase(
+                addIndex.getName(), Indexes.DEFAULT_MYSQL_PRIMARY_KEY_NAME)) {
+          throw new IllegalArgumentException("Primary key name must be PRIMARY in OceanBase");
+        }
+        sqlBuilder.append("PRIMARY KEY ");
+        break;
+      case UNIQUE_KEY:
+        sqlBuilder
+            .append("UNIQUE INDEX ")
+            .append(BACK_QUOTE)
+            .append(addIndex.getName())
+            .append(BACK_QUOTE);
+        break;
+      default:
+        break;
+    }
+    sqlBuilder.append(" (").append(getIndexFieldStr(addIndex.getFieldNames())).append(")");
+    return sqlBuilder.toString();
+  }
+
+  private String generateTableProperties(List<TableChange.SetProperty> setProperties) {
+    return setProperties.stream()
+        .map(
+            setProperty ->
+                String.format("%s = %s", setProperty.getProperty(), setProperty.getValue()))
+        .collect(Collectors.joining(",\n"));
+  }
+
+  @Override
+  protected JdbcTable getOrCreateTable(
+      String databaseName, String tableName, JdbcTable lazyLoadCreateTable) {
+    return null != lazyLoadCreateTable ? lazyLoadCreateTable : load(databaseName, tableName);
+  }
+
+  private String updateColumnCommentFieldDefinition(
+      TableChange.UpdateColumnComment updateColumnComment, JdbcTable jdbcTable) {
+    String newComment = updateColumnComment.getNewComment();
+    if (updateColumnComment.fieldName().length > 1) {
+      throw new UnsupportedOperationException(OCEANBASE_NOT_SUPPORT_NESTED_COLUMN_MSG);
+    }
+    String col = updateColumnComment.fieldName()[0];
+    JdbcColumn column = getJdbcColumnFromTable(jdbcTable, col);
+    JdbcColumn updateColumn =
+        JdbcColumn.builder()
+            .withName(col)
+            .withDefaultValue(column.defaultValue())
+            .withNullable(column.nullable())
+            .withType(column.dataType())
+            .withComment(newComment)
+            .withAutoIncrement(column.autoIncrement())
+            .build();
+    return MODIFY_COLUMN
+        + BACK_QUOTE
+        + col
+        + BACK_QUOTE
+        + appendColumnDefinition(updateColumn, new StringBuilder());
+  }
+
+  private String addColumnFieldDefinition(TableChange.AddColumn addColumn) {
+    String dataType = typeConverter.fromGravitino(addColumn.getDataType());
+    if (addColumn.fieldName().length > 1) {
+      throw new UnsupportedOperationException(OCEANBASE_NOT_SUPPORT_NESTED_COLUMN_MSG);
+    }
+    String col = addColumn.fieldName()[0];
+
+    StringBuilder columnDefinition = new StringBuilder();
+    columnDefinition
+        .append("ADD COLUMN ")
+        .append(BACK_QUOTE)
+        .append(col)
+        .append(BACK_QUOTE)
+        .append(SPACE)
+        .append(dataType)
+        .append(SPACE);
+
+    if (addColumn.isAutoIncrement()) {
+      Preconditions.checkArgument(
+          Types.allowAutoIncrement(addColumn.getDataType()),
+          "Auto increment is not allowed, type: " + addColumn.getDataType());
+      columnDefinition.append(OCEANBASE_AUTO_INCREMENT).append(SPACE);
+    }
+
+    if (!addColumn.isNullable()) {
+      columnDefinition.append("NOT NULL ");
+    }
+    // Append comment if available
+    if (StringUtils.isNotEmpty(addColumn.getComment())) {
+      columnDefinition.append("COMMENT '").append(addColumn.getComment()).append("' ");
+    }
+
+    // Append default value if available
+    if (!Column.DEFAULT_VALUE_NOT_SET.equals(addColumn.getDefaultValue())) {
+      columnDefinition
+          .append("DEFAULT ")
+          .append(columnDefaultValueConverter.fromGravitino(addColumn.getDefaultValue()))
+          .append(SPACE);
+    }
+
+    // Append position if available
+    if (addColumn.getPosition() instanceof TableChange.First) {
+      columnDefinition.append("FIRST");
+    } else if (addColumn.getPosition() instanceof TableChange.After) {
+      TableChange.After afterPosition = (TableChange.After) addColumn.getPosition();
+      columnDefinition
+          .append(AFTER)
+          .append(BACK_QUOTE)
+          .append(afterPosition.getColumn())
+          .append(BACK_QUOTE);
+    } else if (addColumn.getPosition() instanceof TableChange.Default) {
+      // do nothing, follow the default behavior of oceanbase
+    } else {
+      throw new IllegalArgumentException("Invalid column position.");
+    }
+    return columnDefinition.toString();
+  }
+
+  private String renameColumnFieldDefinition(
+      TableChange.RenameColumn renameColumn, JdbcTable jdbcTable) {
+    if (renameColumn.fieldName().length > 1) {
+      throw new UnsupportedOperationException(OCEANBASE_NOT_SUPPORT_NESTED_COLUMN_MSG);
+    }
+
+    String oldColumnName = renameColumn.fieldName()[0];
+    String newColumnName = renameColumn.getNewName();
+    JdbcColumn column = getJdbcColumnFromTable(jdbcTable, oldColumnName);
+    StringBuilder sqlBuilder =
+        new StringBuilder(
+            "CHANGE COLUMN "
+                + BACK_QUOTE
+                + oldColumnName
+                + BACK_QUOTE
+                + SPACE
+                + BACK_QUOTE
+                + newColumnName
+                + BACK_QUOTE);
+    JdbcColumn newColumn =
+        JdbcColumn.builder()
+            .withName(newColumnName)
+            .withType(column.dataType())
+            .withComment(column.comment())
+            .withDefaultValue(column.defaultValue())
+            .withNullable(column.nullable())
+            .withAutoIncrement(column.autoIncrement())
+            .build();
+    return appendColumnDefinition(newColumn, sqlBuilder).toString();
+  }
+
+  private String updateColumnPositionFieldDefinition(
+      TableChange.UpdateColumnPosition updateColumnPosition, JdbcTable jdbcTable) {
+    if (updateColumnPosition.fieldName().length > 1) {
+      throw new UnsupportedOperationException(OCEANBASE_NOT_SUPPORT_NESTED_COLUMN_MSG);
+    }
+    String col = updateColumnPosition.fieldName()[0];
+    JdbcColumn column = getJdbcColumnFromTable(jdbcTable, col);
+    StringBuilder columnDefinition = new StringBuilder();
+    columnDefinition.append(MODIFY_COLUMN).append(col);
+    appendColumnDefinition(column, columnDefinition);
+    if (updateColumnPosition.getPosition() instanceof TableChange.First) {
+      columnDefinition.append("FIRST");
+    } else if (updateColumnPosition.getPosition() instanceof TableChange.After) {
+      TableChange.After afterPosition = (TableChange.After) updateColumnPosition.getPosition();
+      columnDefinition.append(AFTER).append(afterPosition.getColumn());
+    } else {
+      Arrays.stream(jdbcTable.columns())
+          .reduce((column1, column2) -> column2)
+          .map(Column::name)
+          .ifPresent(s -> columnDefinition.append(AFTER).append(s));
+    }
+    return columnDefinition.toString();
+  }
+
+  private String deleteColumnFieldDefinition(
+      TableChange.DeleteColumn deleteColumn, JdbcTable jdbcTable) {
+    if (deleteColumn.fieldName().length > 1) {
+      throw new UnsupportedOperationException(OCEANBASE_NOT_SUPPORT_NESTED_COLUMN_MSG);
+    }
+    String col = deleteColumn.fieldName()[0];
+    boolean colExists = true;
+    try {
+      getJdbcColumnFromTable(jdbcTable, col);
+    } catch (NoSuchColumnException noSuchColumnException) {
+      colExists = false;
+    }
+    if (!colExists) {
+      if (BooleanUtils.isTrue(deleteColumn.getIfExists())) {
+        return "";
+      } else {
+        throw new IllegalArgumentException("Delete column does not exist: " + col);
+      }
+    }
+    return "DROP COLUMN " + BACK_QUOTE + col + BACK_QUOTE;
+  }
+
+  private String updateColumnDefaultValueFieldDefinition(
+      TableChange.UpdateColumnDefaultValue updateColumnDefaultValue, JdbcTable jdbcTable) {
+    if (updateColumnDefaultValue.fieldName().length > 1) {
+      throw new UnsupportedOperationException(OCEANBASE_NOT_SUPPORT_NESTED_COLUMN_MSG);
+    }
+    String col = updateColumnDefaultValue.fieldName()[0];
+    JdbcColumn column = getJdbcColumnFromTable(jdbcTable, col);
+    StringBuilder sqlBuilder = new StringBuilder(MODIFY_COLUMN + col);
+    JdbcColumn newColumn =
+        JdbcColumn.builder()
+            .withName(col)
+            .withType(column.dataType())
+            .withNullable(column.nullable())
+            .withComment(column.comment())
+            .withDefaultValue(updateColumnDefaultValue.getNewDefaultValue())
+            .build();
+    return appendColumnDefinition(newColumn, sqlBuilder).toString();
+  }
+
+  private String updateColumnTypeFieldDefinition(
+      TableChange.UpdateColumnType updateColumnType, JdbcTable jdbcTable) {
+    if (updateColumnType.fieldName().length > 1) {
+      throw new UnsupportedOperationException(OCEANBASE_NOT_SUPPORT_NESTED_COLUMN_MSG);
+    }
+    String col = updateColumnType.fieldName()[0];
+    JdbcColumn column = getJdbcColumnFromTable(jdbcTable, col);
+    StringBuilder sqlBuilder = new StringBuilder(MODIFY_COLUMN + col);
+    JdbcColumn newColumn =
+        JdbcColumn.builder()
+            .withName(col)
+            .withType(updateColumnType.getNewDataType())
+            .withComment(column.comment())
+            .withDefaultValue(DEFAULT_VALUE_NOT_SET)
+            .withNullable(column.nullable())
+            .withAutoIncrement(column.autoIncrement())
+            .build();
+    return appendColumnDefinition(newColumn, sqlBuilder).toString();
+  }
+
+  private StringBuilder appendColumnDefinition(JdbcColumn column, StringBuilder sqlBuilder) {
+    // Add data type
+    sqlBuilder.append(SPACE).append(typeConverter.fromGravitino(column.dataType())).append(SPACE);
+
+    // Add NOT NULL if the column is marked as such
+    if (column.nullable()) {
+      sqlBuilder.append("NULL ");
+    } else {
+      sqlBuilder.append("NOT NULL ");
+    }
+
+    // Add DEFAULT value if specified
+    if (!DEFAULT_VALUE_NOT_SET.equals(column.defaultValue())) {
+      sqlBuilder
+          .append("DEFAULT ")
+          .append(columnDefaultValueConverter.fromGravitino(column.defaultValue()))
+          .append(SPACE);
+    }
+
+    // Add column auto_increment if specified
+    if (column.autoIncrement()) {
+      sqlBuilder.append(OCEANBASE_AUTO_INCREMENT).append(" ");
+    }
+
+    // Add column comment if specified
+    if (StringUtils.isNotEmpty(column.comment())) {
+      sqlBuilder.append("COMMENT '").append(column.comment()).append("' ");
+    }
+    return sqlBuilder;
+  }
+}

--- a/catalogs/catalog-jdbc-oceanbase/src/main/resources/META-INF/services/org.apache.gravitino.CatalogProvider
+++ b/catalogs/catalog-jdbc-oceanbase/src/main/resources/META-INF/services/org.apache.gravitino.CatalogProvider
@@ -1,0 +1,19 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+org.apache.gravitino.catalog.oceanbase.OceanBaseCatalog

--- a/catalogs/catalog-jdbc-oceanbase/src/main/resources/jdbc-oceanbase.conf
+++ b/catalogs/catalog-jdbc-oceanbase/src/main/resources/jdbc-oceanbase.conf
@@ -1,0 +1,22 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# jdbc-url = jdbc:mysql://localhost:2881/
+# jdbc-user = oceanbase
+# jdbc-password = oceanbase
+# jdbc-driver = com.mysql.jdbc.Driver

--- a/catalogs/catalog-jdbc-oceanbase/src/test/java/org/apache/gravitino/catalog/oceanbase/converter/TestOceanBaseTypeConverter.java
+++ b/catalogs/catalog-jdbc-oceanbase/src/test/java/org/apache/gravitino/catalog/oceanbase/converter/TestOceanBaseTypeConverter.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog.oceanbase.converter;
+
+import static org.apache.gravitino.catalog.jdbc.converter.JdbcTypeConverter.DATE;
+import static org.apache.gravitino.catalog.jdbc.converter.JdbcTypeConverter.TEXT;
+import static org.apache.gravitino.catalog.jdbc.converter.JdbcTypeConverter.TIME;
+import static org.apache.gravitino.catalog.jdbc.converter.JdbcTypeConverter.TIMESTAMP;
+import static org.apache.gravitino.catalog.jdbc.converter.JdbcTypeConverter.VARCHAR;
+import static org.apache.gravitino.catalog.oceanbase.converter.OceanBaseTypeConverter.BIGINT;
+import static org.apache.gravitino.catalog.oceanbase.converter.OceanBaseTypeConverter.BINARY;
+import static org.apache.gravitino.catalog.oceanbase.converter.OceanBaseTypeConverter.CHAR;
+import static org.apache.gravitino.catalog.oceanbase.converter.OceanBaseTypeConverter.DATETIME;
+import static org.apache.gravitino.catalog.oceanbase.converter.OceanBaseTypeConverter.DECIMAL;
+import static org.apache.gravitino.catalog.oceanbase.converter.OceanBaseTypeConverter.DOUBLE;
+import static org.apache.gravitino.catalog.oceanbase.converter.OceanBaseTypeConverter.FLOAT;
+import static org.apache.gravitino.catalog.oceanbase.converter.OceanBaseTypeConverter.INT;
+import static org.apache.gravitino.catalog.oceanbase.converter.OceanBaseTypeConverter.JSON;
+import static org.apache.gravitino.catalog.oceanbase.converter.OceanBaseTypeConverter.TINYINT;
+
+import org.apache.gravitino.catalog.jdbc.converter.JdbcTypeConverter;
+import org.apache.gravitino.rel.types.Type;
+import org.apache.gravitino.rel.types.Types;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test class for {@link org.apache.gravitino.catalog.oceanbase.converter.OceanBaseTypeConverter}
+ */
+public class TestOceanBaseTypeConverter {
+
+  private static final OceanBaseTypeConverter MYSQL_TYPE_CONVERTER = new OceanBaseTypeConverter();
+  private static final String USER_DEFINED_TYPE = "user-defined";
+
+  @Test
+  public void testToGravitinoType() {
+    checkJdbcTypeToGravitinoType(Types.ByteType.get(), TINYINT, null, null);
+    checkJdbcTypeToGravitinoType(Types.IntegerType.get(), INT, null, null);
+    checkJdbcTypeToGravitinoType(Types.LongType.get(), BIGINT, null, null);
+    checkJdbcTypeToGravitinoType(Types.FloatType.get(), FLOAT, null, null);
+    checkJdbcTypeToGravitinoType(Types.DoubleType.get(), DOUBLE, null, null);
+    checkJdbcTypeToGravitinoType(Types.DateType.get(), DATE, null, null);
+    checkJdbcTypeToGravitinoType(Types.TimeType.get(), TIME, null, null);
+    checkJdbcTypeToGravitinoType(Types.TimestampType.withoutTimeZone(), DATETIME, null, null);
+    checkJdbcTypeToGravitinoType(Types.TimestampType.withTimeZone(), TIMESTAMP, null, null);
+    checkJdbcTypeToGravitinoType(Types.DecimalType.of(10, 2), DECIMAL, "10", "2");
+    checkJdbcTypeToGravitinoType(Types.VarCharType.of(20), VARCHAR, "20", null);
+    checkJdbcTypeToGravitinoType(Types.FixedCharType.of(20), CHAR, "20", null);
+    checkJdbcTypeToGravitinoType(Types.StringType.get(), TEXT, null, null);
+    checkJdbcTypeToGravitinoType(Types.StringType.get(), JSON, null, null);
+    checkJdbcTypeToGravitinoType(Types.BinaryType.get(), BINARY, null, null);
+    checkJdbcTypeToGravitinoType(
+        Types.ExternalType.of(USER_DEFINED_TYPE), USER_DEFINED_TYPE, null, null);
+  }
+
+  @Test
+  public void testFromGravitinoType() {
+    checkGravitinoTypeToJdbcType(TINYINT, Types.ByteType.get());
+    checkGravitinoTypeToJdbcType(INT, Types.IntegerType.get());
+    checkGravitinoTypeToJdbcType(BIGINT, Types.LongType.get());
+    checkGravitinoTypeToJdbcType(FLOAT, Types.FloatType.get());
+    checkGravitinoTypeToJdbcType(DOUBLE, Types.DoubleType.get());
+    checkGravitinoTypeToJdbcType(DATE, Types.DateType.get());
+    checkGravitinoTypeToJdbcType(TIME, Types.TimeType.get());
+    checkGravitinoTypeToJdbcType(TIMESTAMP, Types.TimestampType.withTimeZone());
+    checkGravitinoTypeToJdbcType(DATETIME, Types.TimestampType.withoutTimeZone());
+    checkGravitinoTypeToJdbcType(DECIMAL + "(10,2)", Types.DecimalType.of(10, 2));
+    checkGravitinoTypeToJdbcType(VARCHAR + "(20)", Types.VarCharType.of(20));
+    checkGravitinoTypeToJdbcType(CHAR + "(20)", Types.FixedCharType.of(20));
+    checkGravitinoTypeToJdbcType(TEXT, Types.StringType.get());
+    checkGravitinoTypeToJdbcType(BINARY, Types.BinaryType.get());
+    checkGravitinoTypeToJdbcType(USER_DEFINED_TYPE, Types.ExternalType.of(USER_DEFINED_TYPE));
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> MYSQL_TYPE_CONVERTER.fromGravitino(Types.UnparsedType.of(USER_DEFINED_TYPE)));
+  }
+
+  protected void checkGravitinoTypeToJdbcType(String jdbcTypeName, Type gravitinoType) {
+    Assertions.assertEquals(jdbcTypeName, MYSQL_TYPE_CONVERTER.fromGravitino(gravitinoType));
+  }
+
+  protected void checkJdbcTypeToGravitinoType(
+      Type gravitinoType, String jdbcTypeName, String columnSize, String scale) {
+    JdbcTypeConverter.JdbcTypeBean typeBean = createTypeBean(jdbcTypeName, columnSize, scale);
+    Assertions.assertEquals(gravitinoType, MYSQL_TYPE_CONVERTER.toGravitino(typeBean));
+  }
+
+  protected static JdbcTypeConverter.JdbcTypeBean createTypeBean(
+      String typeName, String columnSize, String scale) {
+    return new JdbcTypeConverter.JdbcTypeBean(typeName) {
+      {
+        setColumnSize(columnSize);
+        setScale(scale);
+      }
+    };
+  }
+}

--- a/catalogs/catalog-jdbc-oceanbase/src/test/java/org/apache/gravitino/catalog/oceanbase/operation/TestOceanBase.java
+++ b/catalogs/catalog-jdbc-oceanbase/src/test/java/org/apache/gravitino/catalog/oceanbase/operation/TestOceanBase.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog.oceanbase.operation;
+
+import com.google.common.collect.Maps;
+import java.util.Collections;
+import java.util.Map;
+import org.apache.gravitino.catalog.jdbc.TestJdbc;
+import org.apache.gravitino.catalog.jdbc.config.JdbcConfig;
+import org.apache.gravitino.catalog.jdbc.utils.DataSourceUtils;
+import org.apache.gravitino.catalog.oceanbase.converter.OceanBaseColumnDefaultValueConverter;
+import org.apache.gravitino.catalog.oceanbase.converter.OceanBaseExceptionConverter;
+import org.apache.gravitino.catalog.oceanbase.converter.OceanBaseTypeConverter;
+import org.apache.gravitino.integration.test.container.ContainerSuite;
+import org.apache.gravitino.integration.test.container.OceanBaseContainer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+
+public class TestOceanBase extends TestJdbc {
+  private static final ContainerSuite containerSuite = ContainerSuite.getInstance();
+  protected static final String DRIVER_CLASS_NAME = "com.mysql.jdbc.Driver";
+
+  @BeforeAll
+  public static void startup() {
+    containerSuite.startOceanBaseContainer();
+
+    DATA_SOURCE = DataSourceUtils.createDataSource(getOceanBaseCatalogProperties());
+
+    DATABASE_OPERATIONS = new OceanBaseDatabaseOperations();
+    TABLE_OPERATIONS = new OceanBaseTableOperations();
+    JDBC_EXCEPTION_CONVERTER = new OceanBaseExceptionConverter();
+    DATABASE_OPERATIONS.initialize(DATA_SOURCE, JDBC_EXCEPTION_CONVERTER, Collections.emptyMap());
+    TABLE_OPERATIONS.initialize(
+        DATA_SOURCE,
+        JDBC_EXCEPTION_CONVERTER,
+        new OceanBaseTypeConverter(),
+        new OceanBaseColumnDefaultValueConverter(),
+        Collections.emptyMap());
+  }
+
+  // Overwrite the stop method to close the data source and stop the container
+  @AfterAll
+  public static void stop() {
+    DataSourceUtils.closeDataSource(DATA_SOURCE);
+    if (null != CONTAINER) {
+      CONTAINER.stop();
+    }
+  }
+
+  private static Map<String, String> getOceanBaseCatalogProperties() {
+    Map<String, String> catalogProperties = Maps.newHashMap();
+
+    OceanBaseContainer oceanBaseContainer = containerSuite.getOceanBaseContainer();
+
+    String jdbcUrl = oceanBaseContainer.getJdbcUrl();
+
+    catalogProperties.put(JdbcConfig.JDBC_URL.getKey(), jdbcUrl);
+    catalogProperties.put(JdbcConfig.JDBC_DRIVER.getKey(), DRIVER_CLASS_NAME);
+    catalogProperties.put(JdbcConfig.USERNAME.getKey(), OceanBaseContainer.USER_NAME);
+    catalogProperties.put(JdbcConfig.PASSWORD.getKey(), OceanBaseContainer.PASSWORD);
+
+    return catalogProperties;
+  }
+}

--- a/catalogs/catalog-jdbc-oceanbase/src/test/java/org/apache/gravitino/catalog/oceanbase/operation/TestOceanBaseDatabaseOperations.java
+++ b/catalogs/catalog-jdbc-oceanbase/src/test/java/org/apache/gravitino/catalog/oceanbase/operation/TestOceanBaseDatabaseOperations.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog.oceanbase.operation;
+
+import static org.apache.gravitino.catalog.oceanbase.operation.OceanBaseDatabaseOperations.SYS_OCEANBASE_DATABASE_NAMES;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.gravitino.catalog.jdbc.JdbcColumn;
+import org.apache.gravitino.rel.expressions.distributions.Distributions;
+import org.apache.gravitino.rel.expressions.transforms.Transform;
+import org.apache.gravitino.rel.indexes.Index;
+import org.apache.gravitino.rel.types.Types;
+import org.apache.gravitino.utils.RandomNameUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("gravitino-docker-test")
+public class TestOceanBaseDatabaseOperations extends TestOceanBase {
+
+  @Test
+  public void testBaseOperationDatabase() {
+    String databaseName = RandomNameUtils.genRandomName("ct_db");
+    Map<String, String> properties = new HashMap<>();
+    // OceanBase database creation does not support incoming comments.
+    String comment = null;
+    List<String> databases = DATABASE_OPERATIONS.listDatabases();
+    SYS_OCEANBASE_DATABASE_NAMES.forEach(
+        sysOceanBaseDatabaseName ->
+            Assertions.assertFalse(databases.contains(sysOceanBaseDatabaseName)));
+    testBaseOperation(databaseName, properties, comment);
+    testDropDatabase(databaseName);
+  }
+
+  @Test
+  void testDropTableWithSpecificName() {
+    String databaseName = RandomNameUtils.genRandomName("ct_db") + "-abc-" + "end";
+    Map<String, String> properties = new HashMap<>();
+    DATABASE_OPERATIONS.create(databaseName, null, properties);
+    DATABASE_OPERATIONS.delete(databaseName, false);
+
+    databaseName = RandomNameUtils.genRandomName("ct_db") + "--------end";
+    DATABASE_OPERATIONS.create(databaseName, null, properties);
+
+    String tableName = RandomStringUtils.randomAlphabetic(16) + "_op_table";
+    String tableComment = "test_comment";
+    List<JdbcColumn> columns = new ArrayList<>();
+    columns.add(
+        JdbcColumn.builder()
+            .withName("col_1")
+            .withType(Types.VarCharType.of(100))
+            .withComment("test_comment")
+            .withNullable(true)
+            .build());
+
+    TABLE_OPERATIONS.create(
+        databaseName,
+        tableName,
+        columns.toArray(new JdbcColumn[0]),
+        tableComment,
+        properties,
+        new Transform[0],
+        Distributions.NONE,
+        new Index[0]);
+    DATABASE_OPERATIONS.delete(databaseName, true);
+  }
+}

--- a/catalogs/catalog-jdbc-oceanbase/src/test/java/org/apache/gravitino/catalog/oceanbase/operation/TestOceanBaseTableOperations.java
+++ b/catalogs/catalog-jdbc-oceanbase/src/test/java/org/apache/gravitino/catalog/oceanbase/operation/TestOceanBaseTableOperations.java
@@ -1,0 +1,997 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog.oceanbase.operation;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.gravitino.catalog.jdbc.JdbcColumn;
+import org.apache.gravitino.catalog.jdbc.JdbcTable;
+import org.apache.gravitino.rel.Column;
+import org.apache.gravitino.rel.TableChange;
+import org.apache.gravitino.rel.expressions.distributions.Distributions;
+import org.apache.gravitino.rel.expressions.literals.Literals;
+import org.apache.gravitino.rel.expressions.transforms.Transforms;
+import org.apache.gravitino.rel.indexes.Index;
+import org.apache.gravitino.rel.indexes.Indexes;
+import org.apache.gravitino.rel.types.Decimal;
+import org.apache.gravitino.rel.types.Type;
+import org.apache.gravitino.rel.types.Types;
+import org.apache.gravitino.utils.RandomNameUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("gravitino-docker-test")
+public class TestOceanBaseTableOperations extends TestOceanBase {
+  private static Type VARCHAR = Types.VarCharType.of(255);
+  private static Type INT = Types.IntegerType.get();
+
+  @BeforeAll
+  public static void setUp() {
+    DATABASE_OPERATIONS.create(TEST_DB_NAME, null, new HashMap<>());
+  }
+
+  @Test
+  public void testOperationTable() {
+    String tableName = RandomStringUtils.randomAlphabetic(16).toLowerCase() + "_op_table";
+    String tableComment = "test_comment";
+    List<JdbcColumn> columns = new ArrayList<>();
+    columns.add(
+        JdbcColumn.builder()
+            .withName("col_1")
+            .withType(VARCHAR)
+            .withComment("test_comment")
+            .withNullable(true)
+            .build());
+    columns.add(
+        JdbcColumn.builder()
+            .withName("col_2")
+            .withType(INT)
+            .withNullable(false)
+            .withComment("set primary key")
+            .build());
+    columns.add(
+        JdbcColumn.builder()
+            .withName("col_3")
+            .withType(INT)
+            .withNullable(true)
+            .withDefaultValue(Literals.NULL)
+            .build());
+    columns.add(
+        JdbcColumn.builder()
+            .withName("col_4")
+            .withType(VARCHAR)
+            .withDefaultValue(Literals.of("hello world", VARCHAR))
+            .withNullable(false)
+            .build());
+    Map<String, String> properties = new HashMap<>();
+
+    Index[] indexes = new Index[] {Indexes.unique("test", new String[][] {{"col_1"}, {"col_2"}})};
+    // create table
+    TABLE_OPERATIONS.create(
+        TEST_DB_NAME,
+        tableName,
+        columns.toArray(new JdbcColumn[0]),
+        tableComment,
+        properties,
+        null,
+        Distributions.NONE,
+        indexes);
+
+    // list table
+    List<String> tables = TABLE_OPERATIONS.listTables(TEST_DB_NAME);
+    Assertions.assertTrue(tables.contains(tableName));
+
+    // load table
+    JdbcTable load = TABLE_OPERATIONS.load(TEST_DB_NAME, tableName);
+    assertionsTableInfo(
+        tableName, tableComment, columns, properties, indexes, Transforms.EMPTY_TRANSFORM, load);
+
+    // rename table
+    String newName = "new_table";
+    Assertions.assertDoesNotThrow(() -> TABLE_OPERATIONS.rename(TEST_DB_NAME, tableName, newName));
+    Assertions.assertDoesNotThrow(() -> TABLE_OPERATIONS.load(TEST_DB_NAME, newName));
+
+    // alter table
+    JdbcColumn newColumn =
+        JdbcColumn.builder()
+            .withName("col_5")
+            .withType(VARCHAR)
+            .withComment("new_add")
+            .withNullable(true)
+            .withDefaultValue(Literals.of("hello test", VARCHAR))
+            .build();
+    TABLE_OPERATIONS.alterTable(
+        TEST_DB_NAME,
+        newName,
+        TableChange.addColumn(
+            new String[] {newColumn.name()},
+            newColumn.dataType(),
+            newColumn.comment(),
+            TableChange.ColumnPosition.after("col_1"),
+            newColumn.defaultValue()));
+    load = TABLE_OPERATIONS.load(TEST_DB_NAME, newName);
+    List<JdbcColumn> alterColumns =
+        new ArrayList<JdbcColumn>() {
+          {
+            add(columns.get(0));
+            add(newColumn);
+            add(columns.get(1));
+            add(columns.get(2));
+            add(columns.get(3));
+          }
+        };
+    assertionsTableInfo(
+        newName, tableComment, alterColumns, properties, indexes, Transforms.EMPTY_TRANSFORM, load);
+
+    // delete column
+    TABLE_OPERATIONS.alterTable(
+        TEST_DB_NAME, newName, TableChange.deleteColumn(new String[] {newColumn.name()}, true));
+    load = TABLE_OPERATIONS.load(TEST_DB_NAME, newName);
+    assertionsTableInfo(
+        newName, tableComment, columns, properties, indexes, Transforms.EMPTY_TRANSFORM, load);
+
+    TableChange deleteColumn = TableChange.deleteColumn(new String[] {newColumn.name()}, false);
+    IllegalArgumentException illegalArgumentException =
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () -> TABLE_OPERATIONS.alterTable(TEST_DB_NAME, newName, deleteColumn));
+    Assertions.assertEquals(
+        "Delete column does not exist: " + newColumn.name(), illegalArgumentException.getMessage());
+    Assertions.assertDoesNotThrow(
+        () ->
+            TABLE_OPERATIONS.alterTable(
+                TEST_DB_NAME,
+                newName,
+                TableChange.deleteColumn(new String[] {newColumn.name()}, true)));
+
+    TABLE_OPERATIONS.alterTable(
+        TEST_DB_NAME, newName, TableChange.deleteColumn(new String[] {newColumn.name()}, true));
+    Assertions.assertTrue(TABLE_OPERATIONS.drop(TEST_DB_NAME, newName), "table should be dropped");
+    Assertions.assertFalse(
+        TABLE_OPERATIONS.drop(TEST_DB_NAME, newName), "table should be non-existent");
+  }
+
+  @Test
+  public void testAlterTable() {
+    String tableName = RandomStringUtils.randomAlphabetic(16).toLowerCase() + "_al_table";
+    String tableComment = "test_comment";
+    List<JdbcColumn> columns = new ArrayList<>();
+    JdbcColumn col_1 =
+        JdbcColumn.builder()
+            .withName("col_1")
+            .withType(INT)
+            .withComment("id")
+            .withNullable(false)
+            .build();
+    columns.add(col_1);
+    JdbcColumn col_2 =
+        JdbcColumn.builder()
+            .withName("col_2")
+            .withType(VARCHAR)
+            .withComment("name")
+            .withDefaultValue(Literals.of("hello world", VARCHAR))
+            .withNullable(false)
+            .build();
+    columns.add(col_2);
+    JdbcColumn col_3 =
+        JdbcColumn.builder()
+            .withName("col_3")
+            .withType(VARCHAR)
+            .withComment("name")
+            .withDefaultValue(Literals.NULL)
+            .build();
+    // `col_1` int NOT NULL COMMENT 'id' ,
+    // `col_2` varchar(255) NOT NULL DEFAULT 'hello world' COMMENT 'name' ,
+    // `col_3` varchar(255) NULL DEFAULT NULL COMMENT 'name' ,
+    columns.add(col_3);
+    Map<String, String> properties = new HashMap<>();
+
+    Index[] indexes =
+        new Index[] {
+          Indexes.createMysqlPrimaryKey(new String[][] {{"col_1"}, {"col_2"}}),
+          Indexes.unique("uk_2", new String[][] {{"col_1"}, {"col_2"}})
+        };
+    // create table
+    TABLE_OPERATIONS.create(
+        TEST_DB_NAME,
+        tableName,
+        columns.toArray(new JdbcColumn[0]),
+        tableComment,
+        properties,
+        null,
+        Distributions.NONE,
+        indexes);
+    JdbcTable load = TABLE_OPERATIONS.load(TEST_DB_NAME, tableName);
+    assertionsTableInfo(
+        tableName, tableComment, columns, properties, indexes, Transforms.EMPTY_TRANSFORM, load);
+
+    TABLE_OPERATIONS.alterTable(
+        TEST_DB_NAME,
+        tableName,
+        TableChange.updateColumnType(new String[] {col_1.name()}, VARCHAR));
+
+    load = TABLE_OPERATIONS.load(TEST_DB_NAME, tableName);
+
+    // After modifying the type, some attributes of the corresponding column are not
+    // supported.
+    columns.clear();
+    col_1 =
+        JdbcColumn.builder()
+            .withName(col_1.name())
+            .withType(VARCHAR)
+            .withComment(col_1.comment())
+            .withNullable(col_1.nullable())
+            .withDefaultValue(col_1.defaultValue())
+            .build();
+    columns.add(col_1);
+    columns.add(col_2);
+    columns.add(col_3);
+    assertionsTableInfo(
+        tableName, tableComment, columns, properties, indexes, Transforms.EMPTY_TRANSFORM, load);
+
+    String newComment = "new_comment";
+    // update table comment and column comment
+    // `col_1` int NOT NULL COMMENT 'id' ,
+    // `col_2` varchar(255) NOT NULL DEFAULT 'hello world' COMMENT 'new_comment' ,
+    // `col_3` varchar(255) NULL DEFAULT NULL COMMENT 'name' ,
+    TABLE_OPERATIONS.alterTable(
+        TEST_DB_NAME,
+        tableName,
+        TableChange.updateColumnType(new String[] {col_1.name()}, INT),
+        TableChange.updateColumnComment(new String[] {col_2.name()}, newComment));
+    load = TABLE_OPERATIONS.load(TEST_DB_NAME, tableName);
+
+    columns.clear();
+    col_1 =
+        JdbcColumn.builder()
+            .withName(col_1.name())
+            .withType(INT)
+            .withComment(col_1.comment())
+            .withAutoIncrement(col_1.autoIncrement())
+            .withNullable(col_1.nullable())
+            .withDefaultValue(col_1.defaultValue())
+            .build();
+    col_2 =
+        JdbcColumn.builder()
+            .withName(col_2.name())
+            .withType(col_2.dataType())
+            .withComment(newComment)
+            .withAutoIncrement(col_2.autoIncrement())
+            .withNullable(col_2.nullable())
+            .withDefaultValue(col_2.defaultValue())
+            .build();
+    columns.add(col_1);
+    columns.add(col_2);
+    columns.add(col_3);
+    assertionsTableInfo(
+        tableName, tableComment, columns, properties, indexes, Transforms.EMPTY_TRANSFORM, load);
+
+    String newColName_1 = "new_col_1";
+    String newColName_2 = "new_col_2";
+    // rename column
+    // update table comment and column comment
+    // `new_col_1` int NOT NULL COMMENT 'id' ,
+    // `new_col_2` varchar(255) NOT NULL DEFAULT 'hello world' COMMENT 'new_comment'
+    // ,
+    // `col_3` varchar(255) NULL DEFAULT NULL COMMENT 'name' ,
+    TABLE_OPERATIONS.alterTable(
+        TEST_DB_NAME,
+        tableName,
+        TableChange.renameColumn(new String[] {col_1.name()}, newColName_1),
+        TableChange.renameColumn(new String[] {col_2.name()}, newColName_2));
+
+    load = TABLE_OPERATIONS.load(TEST_DB_NAME, tableName);
+
+    columns.clear();
+    col_1 =
+        JdbcColumn.builder()
+            .withName(newColName_1)
+            .withType(col_1.dataType())
+            .withComment(col_1.comment())
+            .withAutoIncrement(col_1.autoIncrement())
+            .withNullable(col_1.nullable())
+            .withDefaultValue(col_1.defaultValue())
+            .build();
+    col_2 =
+        JdbcColumn.builder()
+            .withName(newColName_2)
+            .withType(col_2.dataType())
+            .withComment(col_2.comment())
+            .withAutoIncrement(col_2.autoIncrement())
+            .withNullable(col_2.nullable())
+            .withDefaultValue(col_2.defaultValue())
+            .build();
+    columns.add(col_1);
+    columns.add(col_2);
+    columns.add(col_3);
+    assertionsTableInfo(
+        tableName, tableComment, columns, properties, indexes, Transforms.EMPTY_TRANSFORM, load);
+
+    newComment = "txt3";
+    String newCol2Comment = "xxx";
+    // update column position add column、set table properties
+    // `new_col_2` varchar(255) NOT NULL DEFAULT 'hello world' COMMENT 'xxx' ,
+    // `new_col_1` int NOT NULL COMMENT 'id' ,
+    // `col_3` varchar(255) NULL DEFAULT NULL COMMENT 'name' ,
+    // `col_4` varchar(255) NOT NULL COMMENT 'txt4' ,
+    // `col_5` varchar(255) COMMENT 'hello world' DEFAULT 'hello world' ,
+    TABLE_OPERATIONS.alterTable(
+        TEST_DB_NAME,
+        tableName,
+        TableChange.updateColumnPosition(
+            new String[] {newColName_1}, TableChange.ColumnPosition.after(newColName_2)),
+        TableChange.addColumn(new String[] {"col_4"}, VARCHAR, "txt4", false),
+        TableChange.updateColumnComment(new String[] {newColName_2}, newCol2Comment),
+        TableChange.addColumn(
+            new String[] {"col_5"}, VARCHAR, "txt5", Literals.of("hello world", VARCHAR)));
+    TABLE_OPERATIONS.alterTable(TEST_DB_NAME, tableName, TableChange.updateComment(newComment));
+    load = TABLE_OPERATIONS.load(TEST_DB_NAME, tableName);
+
+    columns.clear();
+
+    columns.add(
+        JdbcColumn.builder()
+            .withName(col_2.name())
+            .withType(col_2.dataType())
+            .withComment(newCol2Comment)
+            .withAutoIncrement(col_2.autoIncrement())
+            .withDefaultValue(col_2.defaultValue())
+            .withNullable(col_2.nullable())
+            .build());
+    columns.add(col_1);
+    columns.add(col_3);
+    columns.add(
+        JdbcColumn.builder()
+            .withName("col_4")
+            .withType(VARCHAR)
+            .withComment("txt4")
+            .withDefaultValue(Column.DEFAULT_VALUE_NOT_SET)
+            .withNullable(false)
+            .build());
+    columns.add(
+        JdbcColumn.builder()
+            .withName("col_5")
+            .withType(VARCHAR)
+            .withComment("txt5")
+            .withDefaultValue(Literals.of("hello world", VARCHAR))
+            .withNullable(true)
+            .build());
+    assertionsTableInfo(
+        tableName, newComment, columns, properties, indexes, Transforms.EMPTY_TRANSFORM, load);
+
+    // `new_col_2` varchar(255) NOT NULL DEFAULT 'hello world' COMMENT 'xxx' ,
+    // `col_3` varchar(255) NULL DEFAULT NULL COMMENT 'name' ,
+    // `col_4` varchar(255) NULL COMMENT 'txt4' ,
+    // `col_5` varchar(255) COMMENT 'hello world' DEFAULT 'hello world' ,
+    // `new_col_1` int NOT NULL COMMENT 'id' ,
+    TABLE_OPERATIONS.alterTable(
+        TEST_DB_NAME,
+        tableName,
+        TableChange.updateColumnPosition(new String[] {columns.get(1).name()}, null),
+        TableChange.updateColumnNullability(
+            new String[] {columns.get(3).name()}, !columns.get(3).nullable()));
+
+    load = TABLE_OPERATIONS.load(TEST_DB_NAME, tableName);
+    col_1 = columns.remove(1);
+    JdbcColumn col3 = columns.remove(1);
+    JdbcColumn col_4 = columns.remove(1);
+    JdbcColumn col_5 = columns.remove(1);
+    columns.clear();
+
+    columns.add(
+        JdbcColumn.builder()
+            .withName("new_col_2")
+            .withType(VARCHAR)
+            .withNullable(false)
+            .withComment("xxx")
+            .withDefaultValue(Literals.of("hello world", VARCHAR))
+            .build());
+    columns.add(col3);
+    columns.add(
+        JdbcColumn.builder()
+            .withName(col_4.name())
+            .withType(col_4.dataType())
+            .withNullable(!col_4.nullable())
+            .withComment(col_4.comment())
+            .withDefaultValue(col_4.defaultValue())
+            .build());
+    columns.add(col_5);
+    columns.add(col_1);
+
+    assertionsTableInfo(
+        tableName, newComment, columns, properties, indexes, Transforms.EMPTY_TRANSFORM, load);
+
+    TableChange updateColumn =
+        TableChange.updateColumnNullability(new String[] {col3.name()}, !col3.nullable());
+    IllegalArgumentException exception =
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () -> TABLE_OPERATIONS.alterTable(TEST_DB_NAME, tableName, updateColumn));
+    Assertions.assertTrue(
+        exception.getMessage().contains("with null default value cannot be changed to not null"));
+  }
+
+  @Test
+  public void testAlterTableUpdateColumnDefaultValue() {
+    String tableName = RandomNameUtils.genRandomName("properties_table_");
+    String tableComment = "test_comment";
+    List<JdbcColumn> columns = new ArrayList<>();
+    columns.add(
+        JdbcColumn.builder()
+            .withName("col_1")
+            .withType(Types.DecimalType.of(10, 2))
+            .withComment("test_decimal")
+            .withNullable(false)
+            .withDefaultValue(Literals.decimalLiteral(Decimal.of("0.00", 10, 2)))
+            .build());
+    columns.add(
+        JdbcColumn.builder()
+            .withName("col_2")
+            .withType(Types.LongType.get())
+            .withNullable(false)
+            .withDefaultValue(Literals.longLiteral(0L))
+            .withComment("long type")
+            .build());
+    columns.add(
+        JdbcColumn.builder()
+            .withName("col_3")
+            .withType(Types.TimestampType.withoutTimeZone())
+            .withNullable(false)
+            .withComment("timestamp")
+            .withDefaultValue(Literals.timestampLiteral(LocalDateTime.parse("2013-01-01T00:00:00")))
+            .build());
+    columns.add(
+        JdbcColumn.builder()
+            .withName("col_4")
+            .withType(Types.VarCharType.of(255))
+            .withNullable(false)
+            .withComment("varchar")
+            .withDefaultValue(Literals.of("hello", Types.VarCharType.of(255)))
+            .build());
+    Map<String, String> properties = new HashMap<>();
+
+    Index[] indexes =
+        new Index[] {
+          Indexes.createMysqlPrimaryKey(new String[][] {{"col_2"}}),
+          Indexes.unique("uk_col_4", new String[][] {{"col_4"}})
+        };
+    // create table
+    TABLE_OPERATIONS.create(
+        TEST_DB_NAME,
+        tableName,
+        columns.toArray(new JdbcColumn[0]),
+        tableComment,
+        properties,
+        null,
+        Distributions.NONE,
+        indexes);
+
+    JdbcTable loaded = TABLE_OPERATIONS.load(TEST_DB_NAME, tableName);
+    assertionsTableInfo(
+        tableName, tableComment, columns, properties, indexes, Transforms.EMPTY_TRANSFORM, loaded);
+
+    TABLE_OPERATIONS.alterTable(
+        TEST_DB_NAME,
+        tableName,
+        TableChange.updateColumnDefaultValue(
+            new String[] {columns.get(0).name()},
+            Literals.decimalLiteral(Decimal.of("1.23", 10, 2))),
+        TableChange.updateColumnDefaultValue(
+            new String[] {columns.get(1).name()}, Literals.longLiteral(1L)),
+        TableChange.updateColumnDefaultValue(
+            new String[] {columns.get(2).name()},
+            Literals.timestampLiteral(LocalDateTime.parse("2024-04-01T00:00:00"))),
+        TableChange.updateColumnDefaultValue(
+            new String[] {columns.get(3).name()}, Literals.of("world", Types.VarCharType.of(255))));
+
+    loaded = TABLE_OPERATIONS.load(TEST_DB_NAME, tableName);
+    Assertions.assertEquals(
+        Literals.decimalLiteral(Decimal.of("1.234", 10, 2)), loaded.columns()[0].defaultValue());
+    Assertions.assertEquals(Literals.longLiteral(1L), loaded.columns()[1].defaultValue());
+    Assertions.assertEquals(
+        Literals.timestampLiteral(LocalDateTime.parse("2024-04-01T00:00:00")),
+        loaded.columns()[2].defaultValue());
+    Assertions.assertEquals(
+        Literals.of("world", Types.VarCharType.of(255)), loaded.columns()[3].defaultValue());
+  }
+
+  @Test
+  public void testCreateAndLoadTable() {
+    String tableName = RandomStringUtils.randomAlphabetic(16).toLowerCase() + "_cl_table";
+    String tableComment = "test_comment";
+    List<JdbcColumn> columns = new ArrayList<>();
+    columns.add(
+        JdbcColumn.builder()
+            .withName("col_1")
+            .withType(Types.DecimalType.of(10, 2))
+            .withComment("test_decimal")
+            .withNullable(false)
+            .withDefaultValue(Literals.decimalLiteral(Decimal.of("0.00", 10, 2)))
+            .build());
+    columns.add(
+        JdbcColumn.builder()
+            .withName("col_2")
+            .withType(Types.LongType.get())
+            .withNullable(false)
+            .withDefaultValue(Literals.longLiteral(0L))
+            .withComment("long type")
+            .build());
+    columns.add(
+        JdbcColumn.builder()
+            .withName("col_3")
+            .withType(Types.TimestampType.withoutTimeZone())
+            .withNullable(false)
+            .withComment("timestamp")
+            .withDefaultValue(Literals.timestampLiteral(LocalDateTime.parse("2013-01-01T00:00:00")))
+            .build());
+    columns.add(
+        JdbcColumn.builder()
+            .withName("col_4")
+            .withType(Types.DateType.get())
+            .withNullable(true)
+            .withComment("date")
+            .withDefaultValue(Column.DEFAULT_VALUE_NOT_SET)
+            .build());
+    Map<String, String> properties = new HashMap<>();
+
+    Index[] indexes =
+        new Index[] {
+          Indexes.createMysqlPrimaryKey(new String[][] {{"col_2"}}),
+          Indexes.unique("uk_col_4", new String[][] {{"col_4"}})
+        };
+    // create table
+    TABLE_OPERATIONS.create(
+        TEST_DB_NAME,
+        tableName,
+        columns.toArray(new JdbcColumn[0]),
+        tableComment,
+        properties,
+        null,
+        Distributions.NONE,
+        indexes);
+
+    JdbcTable loaded = TABLE_OPERATIONS.load(TEST_DB_NAME, tableName);
+    assertionsTableInfo(
+        tableName, tableComment, columns, properties, indexes, Transforms.EMPTY_TRANSFORM, loaded);
+  }
+
+  @Test
+  public void testCreateAllTypeTable() {
+    String tableName = RandomNameUtils.genRandomName("type_table_");
+    String tableComment = "test_comment";
+    List<JdbcColumn> columns = new ArrayList<>();
+    columns.add(
+        JdbcColumn.builder()
+            .withName("col_1")
+            .withType(Types.ByteType.get())
+            .withNullable(false)
+            .build());
+    columns.add(
+        JdbcColumn.builder()
+            .withName("col_2")
+            .withType(Types.ShortType.get())
+            .withNullable(true)
+            .build());
+    columns.add(JdbcColumn.builder().withName("col_3").withType(INT).withNullable(false).build());
+    columns.add(
+        JdbcColumn.builder()
+            .withName("col_4")
+            .withType(Types.LongType.get())
+            .withNullable(false)
+            .build());
+    columns.add(
+        JdbcColumn.builder()
+            .withName("col_5")
+            .withType(Types.FloatType.get())
+            .withNullable(false)
+            .build());
+    columns.add(
+        JdbcColumn.builder()
+            .withName("col_6")
+            .withType(Types.DoubleType.get())
+            .withNullable(false)
+            .build());
+    columns.add(
+        JdbcColumn.builder()
+            .withName("col_7")
+            .withType(Types.DateType.get())
+            .withNullable(false)
+            .build());
+    columns.add(
+        JdbcColumn.builder()
+            .withName("col_8")
+            .withType(Types.TimeType.get())
+            .withNullable(false)
+            .build());
+    columns.add(
+        JdbcColumn.builder()
+            .withName("col_9")
+            .withType(Types.TimestampType.withoutTimeZone())
+            .withNullable(false)
+            .build());
+    columns.add(
+        JdbcColumn.builder().withName("col_10").withType(Types.DecimalType.of(10, 2)).build());
+    columns.add(
+        JdbcColumn.builder().withName("col_11").withType(VARCHAR).withNullable(false).build());
+    columns.add(
+        JdbcColumn.builder()
+            .withName("col_12")
+            .withType(Types.FixedCharType.of(10))
+            .withNullable(false)
+            .build());
+    columns.add(
+        JdbcColumn.builder()
+            .withName("col_13")
+            .withType(Types.StringType.get())
+            .withNullable(false)
+            .build());
+    columns.add(
+        JdbcColumn.builder()
+            .withName("col_14")
+            .withType(Types.BinaryType.get())
+            .withNullable(false)
+            .build());
+    columns.add(
+        JdbcColumn.builder()
+            .withName("col_15")
+            .withType(Types.FixedCharType.of(10))
+            .withNullable(false)
+            .build());
+
+    // create table
+    TABLE_OPERATIONS.create(
+        TEST_DB_NAME,
+        tableName,
+        columns.toArray(new JdbcColumn[0]),
+        tableComment,
+        Collections.emptyMap(),
+        null,
+        Distributions.NONE,
+        Indexes.EMPTY_INDEXES);
+
+    JdbcTable load = TABLE_OPERATIONS.load(TEST_DB_NAME, tableName);
+    assertionsTableInfo(
+        tableName,
+        tableComment,
+        columns,
+        Collections.emptyMap(),
+        null,
+        Transforms.EMPTY_TRANSFORM,
+        load);
+  }
+
+  @Test
+  public void testCreateNotSupportTypeTable() {
+    String tableName = RandomNameUtils.genRandomName("type_table_");
+    String tableComment = "test_comment";
+    List<JdbcColumn> columns = new ArrayList<>();
+    List<Type> notSupportType =
+        Arrays.asList(
+            Types.FixedType.of(10),
+            Types.IntervalDayType.get(),
+            Types.IntervalYearType.get(),
+            Types.UUIDType.get(),
+            Types.ListType.of(Types.DateType.get(), true),
+            Types.MapType.of(Types.StringType.get(), Types.IntegerType.get(), true),
+            Types.UnionType.of(Types.IntegerType.get()),
+            Types.StructType.of(
+                Types.StructType.Field.notNullField("col_1", Types.IntegerType.get())));
+
+    for (Type type : notSupportType) {
+      columns.clear();
+      columns.add(
+          JdbcColumn.builder().withName("col_1").withType(type).withNullable(false).build());
+
+      JdbcColumn[] jdbcCols = columns.toArray(new JdbcColumn[0]);
+      Map<String, String> emptyMap = Collections.emptyMap();
+      IllegalArgumentException illegalArgumentException =
+          Assertions.assertThrows(
+              IllegalArgumentException.class,
+              () -> {
+                TABLE_OPERATIONS.create(
+                    TEST_DB_NAME,
+                    tableName,
+                    jdbcCols,
+                    tableComment,
+                    emptyMap,
+                    null,
+                    Distributions.NONE,
+                    Indexes.EMPTY_INDEXES);
+              });
+      System.out.println(illegalArgumentException.getMessage());
+      Assertions.assertTrue(
+          illegalArgumentException
+              .getMessage()
+              .contains(
+                  String.format(
+                      "Couldn't convert Gravitino type %s to OceanBase type",
+                      type.simpleString())));
+    }
+  }
+
+  @Test
+  public void testCreateMultipleTables() {
+    String test_table_1 = "test_table_1";
+    TABLE_OPERATIONS.create(
+        TEST_DB_NAME,
+        test_table_1,
+        new JdbcColumn[] {
+          JdbcColumn.builder()
+              .withName("col_1")
+              .withType(Types.DecimalType.of(10, 2))
+              .withComment("test_decimal")
+              .withNullable(false)
+              .withDefaultValue(Literals.decimalLiteral(Decimal.of("0.00")))
+              .build()
+        },
+        "test_comment",
+        null,
+        null,
+        Distributions.NONE,
+        Indexes.EMPTY_INDEXES);
+
+    String testDb = "test_db_2";
+
+    DATABASE_OPERATIONS.create(testDb, null, null);
+    List<String> tables = TABLE_OPERATIONS.listTables(testDb);
+    Assertions.assertFalse(tables.contains(test_table_1));
+
+    String test_table_2 = "test_table_2";
+    TABLE_OPERATIONS.create(
+        testDb,
+        test_table_2,
+        new JdbcColumn[] {
+          JdbcColumn.builder()
+              .withName("col_1")
+              .withType(Types.DecimalType.of(10, 2))
+              .withComment("test_decimal")
+              .withNullable(false)
+              .withDefaultValue(Literals.decimalLiteral(Decimal.of("0.00")))
+              .build()
+        },
+        "test_comment",
+        null,
+        null,
+        Distributions.NONE,
+        Indexes.EMPTY_INDEXES);
+
+    tables = TABLE_OPERATIONS.listTables(TEST_DB_NAME);
+    Assertions.assertFalse(tables.contains(test_table_2));
+  }
+
+  @Test
+  public void testAutoIncrement() {
+    String tableName = "test_increment_table_1";
+    String comment = "test_comment";
+    Map<String, String> properties =
+        new HashMap<String, String>() {
+          {
+            put("AUTO_INCREMENT", "10");
+          }
+        };
+    JdbcColumn[] columns = {
+      JdbcColumn.builder()
+          .withName("col_1")
+          .withType(Types.LongType.get())
+          .withComment("id")
+          .withAutoIncrement(true)
+          .withNullable(false)
+          .build(),
+      JdbcColumn.builder()
+          .withName("col_2")
+          .withType(Types.VarCharType.of(255))
+          .withComment("city")
+          .withNullable(false)
+          .build(),
+      JdbcColumn.builder()
+          .withName("col_3")
+          .withType(Types.VarCharType.of(255))
+          .withComment("name")
+          .withNullable(false)
+          .build()
+    };
+    // Test create increment key for unique index.
+    Index[] indexes =
+        new Index[] {
+          Indexes.createMysqlPrimaryKey(new String[][] {{"col_2"}}),
+          Indexes.unique("uk_1", new String[][] {{"col_1"}})
+        };
+    TABLE_OPERATIONS.create(
+        TEST_DB_NAME, tableName, columns, comment, properties, null, Distributions.NONE, indexes);
+
+    JdbcTable table = TABLE_OPERATIONS.load(TEST_DB_NAME, tableName);
+    assertionsTableInfo(
+        tableName,
+        comment,
+        Arrays.stream(columns).collect(Collectors.toList()),
+        properties,
+        indexes,
+        Transforms.EMPTY_TRANSFORM,
+        table);
+    TABLE_OPERATIONS.drop(TEST_DB_NAME, tableName);
+
+    // Test create increment key for primary index.
+    indexes =
+        new Index[] {
+          Indexes.createMysqlPrimaryKey(new String[][] {{"col_1"}}),
+          Indexes.unique("uk_2", new String[][] {{"col_2"}})
+        };
+    TABLE_OPERATIONS.create(
+        TEST_DB_NAME, tableName, columns, comment, properties, null, Distributions.NONE, indexes);
+
+    table = TABLE_OPERATIONS.load(TEST_DB_NAME, tableName);
+    assertionsTableInfo(
+        tableName,
+        comment,
+        Arrays.stream(columns).collect(Collectors.toList()),
+        properties,
+        indexes,
+        Transforms.EMPTY_TRANSFORM,
+        table);
+    TABLE_OPERATIONS.drop(TEST_DB_NAME, tableName);
+
+    // Test create increment key for col_1 + col_3 uk.
+    indexes = new Index[] {Indexes.unique("uk_2_3", new String[][] {{"col_1"}, {"col_3"}})};
+    TABLE_OPERATIONS.create(
+        TEST_DB_NAME, tableName, columns, comment, properties, null, Distributions.NONE, indexes);
+
+    table = TABLE_OPERATIONS.load(TEST_DB_NAME, tableName);
+    assertionsTableInfo(
+        tableName,
+        comment,
+        Arrays.stream(columns).collect(Collectors.toList()),
+        properties,
+        indexes,
+        Transforms.EMPTY_TRANSFORM,
+        table);
+    TABLE_OPERATIONS.drop(TEST_DB_NAME, tableName);
+
+    // Test create auto increment fail
+    IllegalArgumentException exception =
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                TABLE_OPERATIONS.create(
+                    TEST_DB_NAME,
+                    tableName,
+                    columns,
+                    comment,
+                    properties,
+                    null,
+                    Distributions.NONE,
+                    Indexes.EMPTY_INDEXES));
+    Assertions.assertTrue(
+        StringUtils.contains(
+            exception.getMessage(),
+            "Incorrect table definition; there can be only one auto column and it must be defined as a key"));
+
+    // Test create many auto increment col
+    JdbcColumn[] newColumns = {
+      columns[0],
+      columns[1],
+      columns[2],
+      JdbcColumn.builder()
+          .withName("col_4")
+          .withType(Types.IntegerType.get())
+          .withComment("test_id")
+          .withAutoIncrement(true)
+          .withNullable(false)
+          .build()
+    };
+
+    final Index[] primaryIndex =
+        new Index[] {Indexes.createMysqlPrimaryKey(new String[][] {{"col_1"}, {"col_4"}})};
+    exception =
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                TABLE_OPERATIONS.create(
+                    TEST_DB_NAME,
+                    tableName,
+                    newColumns,
+                    comment,
+                    properties,
+                    null,
+                    Distributions.NONE,
+                    primaryIndex));
+    Assertions.assertTrue(
+        StringUtils.contains(
+            exception.getMessage(),
+            "Only one column can be auto-incremented. There are multiple auto-increment columns in your table: [col_1,col_4]"));
+  }
+
+  @Test
+  public void testAppendIndexesBuilder() {
+    Index[] indexes =
+        new Index[] {
+          Indexes.createMysqlPrimaryKey(new String[][] {{"col_2"}, {"col_1"}}),
+          Indexes.unique("uk_col_4", new String[][] {{"col_4"}}),
+          Indexes.unique("uk_col_5", new String[][] {{"col_4"}, {"col_5"}}),
+          Indexes.unique("uk_col_6", new String[][] {{"col_4"}, {"col_5"}, {"col_6"}})
+        };
+    StringBuilder sql = new StringBuilder();
+    OceanBaseTableOperations.appendIndexesSql(indexes, sql);
+    String expectedStr =
+        ",\n"
+            + "CONSTRAINT PRIMARY KEY (`col_2`, `col_1`),\n"
+            + "CONSTRAINT `uk_col_4` UNIQUE (`col_4`),\n"
+            + "CONSTRAINT `uk_col_5` UNIQUE (`col_4`, `col_5`),\n"
+            + "CONSTRAINT `uk_col_6` UNIQUE (`col_4`, `col_5`, `col_6`)";
+    Assertions.assertEquals(expectedStr, sql.toString());
+
+    indexes =
+        new Index[] {
+          Indexes.unique("uk_1", new String[][] {{"col_4"}}),
+          Indexes.unique("uk_2", new String[][] {{"col_4"}, {"col_3"}}),
+          Indexes.createMysqlPrimaryKey(new String[][] {{"col_2"}, {"col_1"}, {"col_3"}}),
+          Indexes.unique("uk_3", new String[][] {{"col_4"}, {"col_5"}, {"col_6"}, {"col_7"}})
+        };
+    sql = new StringBuilder();
+    OceanBaseTableOperations.appendIndexesSql(indexes, sql);
+    expectedStr =
+        ",\n"
+            + "CONSTRAINT `uk_1` UNIQUE (`col_4`),\n"
+            + "CONSTRAINT `uk_2` UNIQUE (`col_4`, `col_3`),\n"
+            + "CONSTRAINT PRIMARY KEY (`col_2`, `col_1`, `col_3`),\n"
+            + "CONSTRAINT `uk_3` UNIQUE (`col_4`, `col_5`, `col_6`, `col_7`)";
+    Assertions.assertEquals(expectedStr, sql.toString());
+  }
+
+  @Test
+  public void testOperationIndexDefinition() {
+    TableChange.AddIndex failIndex =
+        new TableChange.AddIndex(Index.IndexType.PRIMARY_KEY, "pk_1", new String[][] {{"col_1"}});
+    IllegalArgumentException illegalArgumentException =
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () -> OceanBaseTableOperations.addIndexDefinition(failIndex));
+    Assertions.assertTrue(
+        illegalArgumentException
+            .getMessage()
+            .contains("Primary key name must be PRIMARY in OceanBase"));
+
+    TableChange.AddIndex successIndex =
+        new TableChange.AddIndex(
+            Index.IndexType.UNIQUE_KEY, "uk_1", new String[][] {{"col_1"}, {"col_2"}});
+    String sql = OceanBaseTableOperations.addIndexDefinition(successIndex);
+    Assertions.assertEquals("ADD UNIQUE INDEX `uk_1` (`col_1`, `col_2`)", sql);
+
+    successIndex =
+        new TableChange.AddIndex(
+            Index.IndexType.PRIMARY_KEY,
+            Indexes.DEFAULT_MYSQL_PRIMARY_KEY_NAME,
+            new String[][] {{"col_1"}, {"col_2"}});
+    sql = OceanBaseTableOperations.addIndexDefinition(successIndex);
+    Assertions.assertEquals("ADD PRIMARY KEY  (`col_1`, `col_2`)", sql);
+
+    TableChange.DeleteIndex deleteIndex = new TableChange.DeleteIndex("uk_1", false);
+    sql = OceanBaseTableOperations.deleteIndexDefinition(null, deleteIndex);
+    Assertions.assertEquals("DROP INDEX `uk_1`", sql);
+  }
+}

--- a/catalogs/catalog-jdbc-oceanbase/src/test/resources/log4j2.properties
+++ b/catalogs/catalog-jdbc-oceanbase/src/test/resources/log4j2.properties
@@ -1,0 +1,70 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# Set to debug or trace if log4j initialization is failing
+status = info
+
+# Name of the configuration
+name = ConsoleLogConfig
+
+# Console appender configuration
+appender.console.type = Console
+appender.console.name = consoleLogger
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} %-5p [%t] %c{1}:%L - %m%n
+
+# Log files location
+property.logPath = ${sys:gravitino.log.path:-build/catalog-jdbc-mysql-integration-test.log}
+
+# File appender configuration
+appender.file.type = File
+appender.file.name = fileLogger
+appender.file.fileName = ${logPath}
+appender.file.layout.type = PatternLayout
+appender.file.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} %-5p [%t] %c{1}:%L - %m%n
+
+# Root logger level
+rootLogger.level = info
+
+# Root logger referring to console and file appenders
+rootLogger.appenderRef.stdout.ref = consoleLogger
+rootLogger.appenderRef.file.ref = fileLogger
+
+# File appender configuration for testcontainers
+appender.testcontainersFile.type = File
+appender.testcontainersFile.name = testcontainersLogger
+appender.testcontainersFile.fileName = build/testcontainers.log
+appender.testcontainersFile.layout.type = PatternLayout
+appender.testcontainersFile.layout.pattern = %d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %-5p %c - %m%n
+
+# Logger for testcontainers
+logger.testcontainers.name = org.testcontainers
+logger.testcontainers.level = debug
+logger.testcontainers.appenderRef.file.ref = testcontainersLogger
+
+logger.tc.name = tc
+logger.tc.level = debug
+logger.tc.appenderRef.file.ref = testcontainersLogger
+
+logger.docker.name = com.github.dockerjava
+logger.docker.level = warn
+logger.docker.appenderRef.file.ref = testcontainersLogger
+
+logger.http.name = com.github.dockerjava.zerodep.shaded.org.apache.hc.client5.http.wire
+logger.http.level = off

--- a/integration-test-common/src/test/java/org/apache/gravitino/integration/test/container/OceanBaseContainer.java
+++ b/integration-test-common/src/test/java/org/apache/gravitino/integration/test/container/OceanBaseContainer.java
@@ -1,0 +1,159 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.integration.test.container;
+
+import static java.lang.String.format;
+import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
+
+import com.google.common.collect.ImmutableSet;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.time.Duration;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import org.rnorth.ducttape.Preconditions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.wait.strategy.Wait;
+
+public class OceanBaseContainer extends BaseContainer {
+  public static final Logger LOG = LoggerFactory.getLogger(OceanBaseContainer.class);
+
+  public static final String DEFAULT_IMAGE = "oceanbase/oceanbase-ce:4.2.1-lts";
+  public static final String HOST_NAME = "gravitino-ci-oceanbase";
+  public static final int OCEANBASE_PORT = 2881;
+  public static final String USER_NAME = "root@test";
+  public static final String PASSWORD = "123456";
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  protected OceanBaseContainer(
+      String image,
+      String hostName,
+      Set<Integer> ports,
+      Map<String, String> extraHosts,
+      Map<String, String> filesToMount,
+      Map<String, String> envVars,
+      Optional<Network> network) {
+    super(image, hostName, ports, extraHosts, filesToMount, envVars, network);
+  }
+
+  @Override
+  protected void setupContainer() {
+    super.setupContainer();
+    withLogConsumer(new PrintingContainerLog(format("%-14s| ", "OceanBaseContainer")));
+    waitingForLog();
+    withStartupTimeout(Duration.ofMinutes(6));
+  }
+
+  @Override
+  public void start() {
+    super.start();
+    Preconditions.check("OceanBase container startup failed!", checkContainerStatus(5));
+  }
+
+  @Override
+  protected boolean checkContainerStatus(int retryLimit) {
+    String oceanBaseJdbcUrl = format("jdbc:mysql://%s:%d", "localhost", getMappedPort());
+    LOG.info("OceanBase url is {}", oceanBaseJdbcUrl);
+
+    await()
+        .atMost(30, TimeUnit.SECONDS)
+        .pollInterval(30 / retryLimit, TimeUnit.SECONDS)
+        .until(
+            () -> {
+              try (Connection connection =
+                      DriverManager.getConnection(oceanBaseJdbcUrl, "root@sys", PASSWORD);
+                  Statement statement = connection.createStatement()) {
+
+                // check if OceanBase server is ready
+                String query = "SELECT stop_time,status FROM oceanbase.DBA_OB_SERVERS;";
+                try (ResultSet resultSet = statement.executeQuery(query)) {
+                  while (resultSet.next()) {
+                    String stopTime = resultSet.getString("stop_time");
+                    String status = resultSet.getString("status");
+
+                    if (stopTime == null && "ACTIVE".equals(status)) {
+                      LOG.info("OceanBase container startup success!");
+                      return true;
+                    }
+                  }
+                }
+                LOG.info("OceanBase container is not ready yet!");
+              } catch (Exception e) {
+                LOG.error(e.getMessage(), e);
+              }
+              return false;
+            });
+
+    return true;
+  }
+
+  public void waitingForLog() {
+    super.container.waitingFor(Wait.forLogMessage(".*boot success!.*", 1));
+  }
+
+  public String getUsername() {
+    return USER_NAME;
+  }
+
+  public String getPassword() {
+    return PASSWORD;
+  }
+
+  public int getMappedPort() {
+    return getMappedPort(OCEANBASE_PORT);
+  }
+
+  public String getJdbcUrl() {
+    return format("jdbc:mysql://%s:%d", getContainerIpAddress(), OCEANBASE_PORT);
+  }
+
+  public String getJdbcUrl(String testDatabaseName) {
+    return format(
+        "jdbc:mysql://%s:%d/%s", getContainerIpAddress(), OCEANBASE_PORT, testDatabaseName);
+  }
+
+  public String getDriverClassName(String testDatabaseName) throws SQLException {
+    return DriverManager.getDriver(getJdbcUrl(testDatabaseName)).getClass().getName();
+  }
+
+  public static class Builder extends BaseContainer.Builder<Builder, OceanBaseContainer> {
+
+    private Builder() {
+      this.image = DEFAULT_IMAGE;
+      this.hostName = HOST_NAME;
+      this.exposePorts = ImmutableSet.of(OCEANBASE_PORT);
+    }
+
+    @Override
+    public OceanBaseContainer build() {
+      return new OceanBaseContainer(
+          image, hostName, exposePorts, extraHosts, filesToMount, envVars, network);
+    }
+  }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -35,7 +35,8 @@ include(
   "catalogs:catalog-jdbc-common",
   "catalogs:catalog-jdbc-doris",
   "catalogs:catalog-jdbc-mysql",
-  "catalogs:catalog-jdbc-postgresql"
+  "catalogs:catalog-jdbc-postgresql",
+  "catalogs:catalog-jdbc-oceanbase"
 )
 include("catalogs:catalog-hadoop")
 include("catalogs:catalog-kafka")


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

- add catalog-jdbc-oceanbase module
- add full code to support non-partitioned tables

### Why are the changes needed?

Fix: #4906 

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?

Unit tests have been added, integration tests will be added later.
  
