### PR TITLE
[#4476] feat(iceberg):  rename IcebergTableOps to IcebergCatalogWrapper

### DIFF
--- a/catalogs/catalog-lakehouse-iceberg/src/main/java/org/apache/gravitino/catalog/lakehouse/iceberg/IcebergCatalogOperations.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/main/java/org/apache/gravitino/catalog/lakehouse/iceberg/IcebergCatalogOperations.java
@@ -82,8 +82,7 @@ public class IcebergCatalogOperations implements CatalogOperations, SupportsSche
 
   public static final Logger LOG = LoggerFactory.getLogger(IcebergCatalogOperations.class);
 
-  @VisibleForTesting
-  IcebergCatalogWrapper icebergCatalogWrapper;
+  @VisibleForTesting IcebergCatalogWrapper icebergCatalogWrapper;
 
   private IcebergCatalogWrapperHelper icebergCatalogWrapperHelper;
 
@@ -115,8 +114,8 @@ public class IcebergCatalogOperations implements CatalogOperations, SupportsSche
     IcebergConfig icebergConfig = new IcebergConfig(resultConf);
 
     this.icebergCatalogWrapper = new IcebergCatalogWrapper(icebergConfig);
-    this.icebergCatalogWrapperHelper = new IcebergCatalogWrapperHelper(
-        icebergCatalogWrapper.getCatalog());
+    this.icebergCatalogWrapperHelper =
+        new IcebergCatalogWrapperHelper(icebergCatalogWrapper.getCatalog());
   }
 
   /** Closes the Iceberg catalog and releases the associated client pool. */
@@ -142,7 +141,9 @@ public class IcebergCatalogOperations implements CatalogOperations, SupportsSche
   public NameIdentifier[] listSchemas(Namespace namespace) throws NoSuchCatalogException {
     try {
       List<org.apache.iceberg.catalog.Namespace> namespaces =
-          icebergCatalogWrapper.listNamespace(IcebergCatalogWrapperHelper.getIcebergNamespace()).namespaces();
+          icebergCatalogWrapper
+              .listNamespace(IcebergCatalogWrapperHelper.getIcebergNamespace())
+              .namespaces();
 
       return namespaces.stream()
           .map(icebergNamespace -> NameIdentifier.of(namespace, icebergNamespace.toString()))
@@ -181,7 +182,8 @@ public class IcebergCatalogOperations implements CatalogOperations, SupportsSche
                       .build())
               .build();
       icebergCatalogWrapper.createNamespace(
-          createdSchema.toCreateRequest(IcebergCatalogWrapperHelper.getIcebergNamespace(ident.name())));
+          createdSchema.toCreateRequest(
+              IcebergCatalogWrapperHelper.getIcebergNamespace(ident.name())));
       LOG.info(
           "Created Iceberg schema (database) {} in Iceberg\ncurrentUser:{} \ncomment: {} \nmetadata: {}",
           ident.name(),
@@ -213,7 +215,8 @@ public class IcebergCatalogOperations implements CatalogOperations, SupportsSche
   public IcebergSchema loadSchema(NameIdentifier ident) throws NoSuchSchemaException {
     try {
       GetNamespaceResponse response =
-          icebergCatalogWrapper.loadNamespace(IcebergCatalogWrapperHelper.getIcebergNamespace(ident.name()));
+          icebergCatalogWrapper.loadNamespace(
+              IcebergCatalogWrapperHelper.getIcebergNamespace(ident.name()));
       IcebergSchema icebergSchema =
           IcebergSchema.builder()
               .withName(ident.name())
@@ -246,7 +249,8 @@ public class IcebergCatalogOperations implements CatalogOperations, SupportsSche
       throws NoSuchSchemaException {
     try {
       GetNamespaceResponse response =
-          icebergCatalogWrapper.loadNamespace(IcebergCatalogWrapperHelper.getIcebergNamespace(ident.name()));
+          icebergCatalogWrapper.loadNamespace(
+              IcebergCatalogWrapperHelper.getIcebergNamespace(ident.name()));
       Map<String, String> metadata = response.properties();
       List<String> removals = new ArrayList<>();
       Map<String, String> updates = new HashMap<>();
@@ -308,7 +312,8 @@ public class IcebergCatalogOperations implements CatalogOperations, SupportsSche
   public boolean dropSchema(NameIdentifier ident, boolean cascade) throws NonEmptySchemaException {
     Preconditions.checkArgument(!cascade, "Iceberg does not support cascading delete operations.");
     try {
-      icebergCatalogWrapper.dropNamespace(IcebergCatalogWrapperHelper.getIcebergNamespace(ident.name()));
+      icebergCatalogWrapper.dropNamespace(
+          IcebergCatalogWrapperHelper.getIcebergNamespace(ident.name()));
       LOG.info("Dropped Iceberg schema (database) {}", ident.name());
       return true;
     } catch (NamespaceNotEmptyException e) {
@@ -338,7 +343,8 @@ public class IcebergCatalogOperations implements CatalogOperations, SupportsSche
 
     try {
       ListTablesResponse listTablesResponse =
-          icebergCatalogWrapper.listTable(IcebergCatalogWrapperHelper.getIcebergNamespace(namespace));
+          icebergCatalogWrapper.listTable(
+              IcebergCatalogWrapperHelper.getIcebergNamespace(namespace));
       return listTablesResponse.identifiers().stream()
           .map(
               tableIdentifier ->
@@ -361,7 +367,8 @@ public class IcebergCatalogOperations implements CatalogOperations, SupportsSche
     try {
 
       LoadTableResponse tableResponse =
-          icebergCatalogWrapper.loadTable(IcebergCatalogWrapperHelper.buildIcebergTableIdentifier(tableIdent));
+          icebergCatalogWrapper.loadTable(
+              IcebergCatalogWrapperHelper.buildIcebergTableIdentifier(tableIdent));
       IcebergTable icebergTable =
           IcebergTable.fromIcebergTable(tableResponse.tableMetadata(), tableIdent.name());
 
@@ -455,7 +462,8 @@ public class IcebergCatalogOperations implements CatalogOperations, SupportsSche
   @Override
   public boolean dropTable(NameIdentifier tableIdent) {
     try {
-      icebergCatalogWrapper.dropTable(IcebergCatalogWrapperHelper.buildIcebergTableIdentifier(tableIdent));
+      icebergCatalogWrapper.dropTable(
+          IcebergCatalogWrapperHelper.buildIcebergTableIdentifier(tableIdent));
       LOG.info("Dropped Iceberg table {}", tableIdent.name());
       return true;
     } catch (org.apache.iceberg.exceptions.NoSuchTableException e) {

--- a/catalogs/catalog-lakehouse-iceberg/src/main/java/org/apache/gravitino/catalog/lakehouse/iceberg/IcebergCatalogOperations.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/main/java/org/apache/gravitino/catalog/lakehouse/iceberg/IcebergCatalogOperations.java
@@ -37,7 +37,7 @@ import org.apache.gravitino.Catalog;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
 import org.apache.gravitino.SchemaChange;
-import org.apache.gravitino.catalog.lakehouse.iceberg.ops.IcebergTableOpsHelper;
+import org.apache.gravitino.catalog.lakehouse.iceberg.ops.IcebergCatalogWrapperHelper;
 import org.apache.gravitino.connector.CatalogInfo;
 import org.apache.gravitino.connector.CatalogOperations;
 import org.apache.gravitino.connector.HasPropertyMetadata;
@@ -50,8 +50,8 @@ import org.apache.gravitino.exceptions.NonEmptySchemaException;
 import org.apache.gravitino.exceptions.SchemaAlreadyExistsException;
 import org.apache.gravitino.exceptions.TableAlreadyExistsException;
 import org.apache.gravitino.iceberg.common.IcebergConfig;
-import org.apache.gravitino.iceberg.common.ops.IcebergTableOps;
-import org.apache.gravitino.iceberg.common.ops.IcebergTableOps.IcebergTableChange;
+import org.apache.gravitino.iceberg.common.ops.IcebergCatalogWrapper;
+import org.apache.gravitino.iceberg.common.ops.IcebergCatalogWrapper.IcebergTableChange;
 import org.apache.gravitino.meta.AuditInfo;
 import org.apache.gravitino.rel.Column;
 import org.apache.gravitino.rel.Table;
@@ -82,9 +82,10 @@ public class IcebergCatalogOperations implements CatalogOperations, SupportsSche
 
   public static final Logger LOG = LoggerFactory.getLogger(IcebergCatalogOperations.class);
 
-  @VisibleForTesting IcebergTableOps icebergTableOps;
+  @VisibleForTesting
+  IcebergCatalogWrapper icebergCatalogWrapper;
 
-  private IcebergTableOpsHelper icebergTableOpsHelper;
+  private IcebergCatalogWrapperHelper icebergCatalogWrapperHelper;
 
   /**
    * Initializes the Iceberg catalog operations with the provided configuration.
@@ -113,16 +114,17 @@ public class IcebergCatalogOperations implements CatalogOperations, SupportsSche
     }
     IcebergConfig icebergConfig = new IcebergConfig(resultConf);
 
-    this.icebergTableOps = new IcebergTableOps(icebergConfig);
-    this.icebergTableOpsHelper = new IcebergTableOpsHelper(icebergTableOps.getCatalog());
+    this.icebergCatalogWrapper = new IcebergCatalogWrapper(icebergConfig);
+    this.icebergCatalogWrapperHelper = new IcebergCatalogWrapperHelper(
+        icebergCatalogWrapper.getCatalog());
   }
 
   /** Closes the Iceberg catalog and releases the associated client pool. */
   @Override
   public void close() {
-    if (null != icebergTableOps) {
+    if (null != icebergCatalogWrapper) {
       try {
-        icebergTableOps.close();
+        icebergCatalogWrapper.close();
       } catch (Exception e) {
         LOG.warn("Failed to close Iceberg catalog", e);
       }
@@ -140,7 +142,7 @@ public class IcebergCatalogOperations implements CatalogOperations, SupportsSche
   public NameIdentifier[] listSchemas(Namespace namespace) throws NoSuchCatalogException {
     try {
       List<org.apache.iceberg.catalog.Namespace> namespaces =
-          icebergTableOps.listNamespace(IcebergTableOpsHelper.getIcebergNamespace()).namespaces();
+          icebergCatalogWrapper.listNamespace(IcebergCatalogWrapperHelper.getIcebergNamespace()).namespaces();
 
       return namespaces.stream()
           .map(icebergNamespace -> NameIdentifier.of(namespace, icebergNamespace.toString()))
@@ -178,8 +180,8 @@ public class IcebergCatalogOperations implements CatalogOperations, SupportsSche
                       .withCreateTime(Instant.now())
                       .build())
               .build();
-      icebergTableOps.createNamespace(
-          createdSchema.toCreateRequest(IcebergTableOpsHelper.getIcebergNamespace(ident.name())));
+      icebergCatalogWrapper.createNamespace(
+          createdSchema.toCreateRequest(IcebergCatalogWrapperHelper.getIcebergNamespace(ident.name())));
       LOG.info(
           "Created Iceberg schema (database) {} in Iceberg\ncurrentUser:{} \ncomment: {} \nmetadata: {}",
           ident.name(),
@@ -211,7 +213,7 @@ public class IcebergCatalogOperations implements CatalogOperations, SupportsSche
   public IcebergSchema loadSchema(NameIdentifier ident) throws NoSuchSchemaException {
     try {
       GetNamespaceResponse response =
-          icebergTableOps.loadNamespace(IcebergTableOpsHelper.getIcebergNamespace(ident.name()));
+          icebergCatalogWrapper.loadNamespace(IcebergCatalogWrapperHelper.getIcebergNamespace(ident.name()));
       IcebergSchema icebergSchema =
           IcebergSchema.builder()
               .withName(ident.name())
@@ -244,7 +246,7 @@ public class IcebergCatalogOperations implements CatalogOperations, SupportsSche
       throws NoSuchSchemaException {
     try {
       GetNamespaceResponse response =
-          icebergTableOps.loadNamespace(IcebergTableOpsHelper.getIcebergNamespace(ident.name()));
+          icebergCatalogWrapper.loadNamespace(IcebergCatalogWrapperHelper.getIcebergNamespace(ident.name()));
       Map<String, String> metadata = response.properties();
       List<String> removals = new ArrayList<>();
       Map<String, String> updates = new HashMap<>();
@@ -278,8 +280,8 @@ public class IcebergCatalogOperations implements CatalogOperations, SupportsSche
       UpdateNamespacePropertiesRequest updateNamespacePropertiesRequest =
           UpdateNamespacePropertiesRequest.builder().updateAll(updates).removeAll(removals).build();
       UpdateNamespacePropertiesResponse updateNamespacePropertiesResponse =
-          icebergTableOps.updateNamespaceProperties(
-              IcebergTableOpsHelper.getIcebergNamespace(ident.name()),
+          icebergCatalogWrapper.updateNamespaceProperties(
+              IcebergCatalogWrapperHelper.getIcebergNamespace(ident.name()),
               updateNamespacePropertiesRequest);
       LOG.info(
           "Altered Iceberg schema (database) {}. UpdateResponse:\n{}",
@@ -306,7 +308,7 @@ public class IcebergCatalogOperations implements CatalogOperations, SupportsSche
   public boolean dropSchema(NameIdentifier ident, boolean cascade) throws NonEmptySchemaException {
     Preconditions.checkArgument(!cascade, "Iceberg does not support cascading delete operations.");
     try {
-      icebergTableOps.dropNamespace(IcebergTableOpsHelper.getIcebergNamespace(ident.name()));
+      icebergCatalogWrapper.dropNamespace(IcebergCatalogWrapperHelper.getIcebergNamespace(ident.name()));
       LOG.info("Dropped Iceberg schema (database) {}", ident.name());
       return true;
     } catch (NamespaceNotEmptyException e) {
@@ -336,7 +338,7 @@ public class IcebergCatalogOperations implements CatalogOperations, SupportsSche
 
     try {
       ListTablesResponse listTablesResponse =
-          icebergTableOps.listTable(IcebergTableOpsHelper.getIcebergNamespace(namespace));
+          icebergCatalogWrapper.listTable(IcebergCatalogWrapperHelper.getIcebergNamespace(namespace));
       return listTablesResponse.identifiers().stream()
           .map(
               tableIdentifier ->
@@ -359,7 +361,7 @@ public class IcebergCatalogOperations implements CatalogOperations, SupportsSche
     try {
 
       LoadTableResponse tableResponse =
-          icebergTableOps.loadTable(IcebergTableOpsHelper.buildIcebergTableIdentifier(tableIdent));
+          icebergCatalogWrapper.loadTable(IcebergCatalogWrapperHelper.buildIcebergTableIdentifier(tableIdent));
       IcebergTable icebergTable =
           IcebergTable.fromIcebergTable(tableResponse.tableMetadata(), tableIdent.name());
 
@@ -408,9 +410,9 @@ public class IcebergCatalogOperations implements CatalogOperations, SupportsSche
     try {
       String[] levels = tableIdent.namespace().levels();
       IcebergTableChange icebergTableChange =
-          icebergTableOpsHelper.buildIcebergTableChanges(
+          icebergCatalogWrapperHelper.buildIcebergTableChanges(
               NameIdentifier.of(levels[levels.length - 1], tableIdent.name()), changes);
-      LoadTableResponse loadTableResponse = icebergTableOps.updateTable(icebergTableChange);
+      LoadTableResponse loadTableResponse = icebergCatalogWrapper.updateTable(icebergTableChange);
       loadTableResponse.validate();
       return IcebergTable.fromIcebergTable(loadTableResponse.tableMetadata(), tableIdent.name());
     } catch (org.apache.iceberg.exceptions.NoSuchTableException e) {
@@ -432,12 +434,12 @@ public class IcebergCatalogOperations implements CatalogOperations, SupportsSche
     try {
       RenameTableRequest renameTableRequest =
           RenameTableRequest.builder()
-              .withSource(IcebergTableOpsHelper.buildIcebergTableIdentifier(tableIdent))
+              .withSource(IcebergCatalogWrapperHelper.buildIcebergTableIdentifier(tableIdent))
               .withDestination(
-                  IcebergTableOpsHelper.buildIcebergTableIdentifier(
+                  IcebergCatalogWrapperHelper.buildIcebergTableIdentifier(
                       tableIdent.namespace(), renameTable.getNewName()))
               .build();
-      icebergTableOps.renameTable(renameTableRequest);
+      icebergCatalogWrapper.renameTable(renameTableRequest);
       return loadTable(NameIdentifier.of(tableIdent.namespace(), renameTable.getNewName()));
     } catch (org.apache.iceberg.exceptions.NoSuchTableException e) {
       throw new NoSuchTableException(e, ICEBERG_TABLE_DOES_NOT_EXIST_MSG, tableIdent.name());
@@ -453,7 +455,7 @@ public class IcebergCatalogOperations implements CatalogOperations, SupportsSche
   @Override
   public boolean dropTable(NameIdentifier tableIdent) {
     try {
-      icebergTableOps.dropTable(IcebergTableOpsHelper.buildIcebergTableIdentifier(tableIdent));
+      icebergCatalogWrapper.dropTable(IcebergCatalogWrapperHelper.buildIcebergTableIdentifier(tableIdent));
       LOG.info("Dropped Iceberg table {}", tableIdent.name());
       return true;
     } catch (org.apache.iceberg.exceptions.NoSuchTableException e) {
@@ -522,8 +524,8 @@ public class IcebergCatalogOperations implements CatalogOperations, SupportsSche
               .build();
 
       LoadTableResponse loadTableResponse =
-          icebergTableOps.createTable(
-              IcebergTableOpsHelper.getIcebergNamespace(schemaIdent.name()),
+          icebergCatalogWrapper.createTable(
+              IcebergCatalogWrapperHelper.getIcebergNamespace(schemaIdent.name()),
               createdTable.toCreateTableRequest());
       loadTableResponse.validate();
 
@@ -545,7 +547,7 @@ public class IcebergCatalogOperations implements CatalogOperations, SupportsSche
   public boolean purgeTable(NameIdentifier tableIdent) throws UnsupportedOperationException {
     try {
       String schema = NameIdentifier.of(tableIdent.namespace().levels()).name();
-      icebergTableOps.purgeTable(TableIdentifier.of(schema, tableIdent.name()));
+      icebergCatalogWrapper.purgeTable(TableIdentifier.of(schema, tableIdent.name()));
       LOG.info("Purge Iceberg table {}", tableIdent.name());
       return true;
     } catch (org.apache.iceberg.exceptions.NoSuchTableException e) {
@@ -573,7 +575,7 @@ public class IcebergCatalogOperations implements CatalogOperations, SupportsSche
       String comment,
       Map<String, String> properties) {
     try {
-      icebergTableOps.listNamespace(IcebergTableOpsHelper.getIcebergNamespace());
+      icebergCatalogWrapper.listNamespace(IcebergCatalogWrapperHelper.getIcebergNamespace());
     } catch (Exception e) {
       throw new ConnectionFailedException(
           e, "Failed to run listNamespace on Iceberg catalog: %s", e.getMessage());

--- a/catalogs/catalog-lakehouse-iceberg/src/main/java/org/apache/gravitino/catalog/lakehouse/iceberg/ops/IcebergCatalogWrapperHelper.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/main/java/org/apache/gravitino/catalog/lakehouse/iceberg/ops/IcebergCatalogWrapperHelper.java
@@ -29,7 +29,7 @@ import java.util.List;
 import java.util.Set;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.catalog.lakehouse.iceberg.converter.IcebergDataTypeConverter;
-import org.apache.gravitino.iceberg.common.ops.IcebergTableOps.IcebergTableChange;
+import org.apache.gravitino.iceberg.common.ops.IcebergCatalogWrapper.IcebergTableChange;
 import org.apache.gravitino.rel.TableChange;
 import org.apache.gravitino.rel.TableChange.AddColumn;
 import org.apache.gravitino.rel.TableChange.After;
@@ -55,7 +55,7 @@ import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.types.Type.PrimitiveType;
 import org.apache.iceberg.types.Types.NestedField;
 
-public class IcebergTableOpsHelper {
+public class IcebergCatalogWrapperHelper {
   @VisibleForTesting public static final Joiner DOT = Joiner.on(".");
   private static final Set<String> IcebergReservedProperties =
       ImmutableSet.of(
@@ -68,7 +68,7 @@ public class IcebergTableOpsHelper {
 
   private Catalog icebergCatalog;
 
-  public IcebergTableOpsHelper(Catalog icebergCatalog) {
+  public IcebergCatalogWrapperHelper(Catalog icebergCatalog) {
     this.icebergCatalog = icebergCatalog;
   }
 

--- a/catalogs/catalog-lakehouse-iceberg/src/test/java/org/apache/gravitino/catalog/lakehouse/iceberg/TestIcebergCatalog.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/test/java/org/apache/gravitino/catalog/lakehouse/iceberg/TestIcebergCatalog.java
@@ -30,7 +30,7 @@ import org.apache.gravitino.catalog.PropertiesMetadataHelpers;
 import org.apache.gravitino.connector.CatalogOperations;
 import org.apache.gravitino.connector.HasPropertyMetadata;
 import org.apache.gravitino.connector.PropertiesMetadata;
-import org.apache.gravitino.iceberg.common.ops.IcebergTableOps;
+import org.apache.gravitino.iceberg.common.ops.IcebergCatalogWrapper;
 import org.apache.gravitino.meta.AuditInfo;
 import org.apache.gravitino.meta.CatalogEntity;
 import org.apache.iceberg.rest.responses.ListNamespacesResponse;
@@ -87,10 +87,10 @@ public class TestIcebergCatalog {
     CatalogOperations catalogOperations = icebergCatalog.ops();
     Assertions.assertTrue(catalogOperations instanceof IcebergCatalogOperations);
 
-    IcebergTableOps icebergTableOps =
-        ((IcebergCatalogOperations) catalogOperations).icebergTableOps;
+    IcebergCatalogWrapper icebergCatalogWrapper =
+        ((IcebergCatalogOperations) catalogOperations).icebergCatalogWrapper;
     ListNamespacesResponse listNamespacesResponse =
-        icebergTableOps.listNamespace(org.apache.iceberg.catalog.Namespace.empty());
+        icebergCatalogWrapper.listNamespace(org.apache.iceberg.catalog.Namespace.empty());
     Assertions.assertTrue(listNamespacesResponse.namespaces().isEmpty());
   }
 

--- a/catalogs/catalog-lakehouse-iceberg/src/test/java/org/apache/gravitino/catalog/lakehouse/iceberg/integration/test/CatalogIcebergBaseIT.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/test/java/org/apache/gravitino/catalog/lakehouse/iceberg/integration/test/CatalogIcebergBaseIT.java
@@ -49,7 +49,7 @@ import org.apache.gravitino.SupportsSchemas;
 import org.apache.gravitino.auth.AuthConstants;
 import org.apache.gravitino.catalog.lakehouse.iceberg.IcebergSchemaPropertiesMetadata;
 import org.apache.gravitino.catalog.lakehouse.iceberg.IcebergTable;
-import org.apache.gravitino.catalog.lakehouse.iceberg.ops.IcebergTableOpsHelper;
+import org.apache.gravitino.catalog.lakehouse.iceberg.ops.IcebergCatalogWrapperHelper;
 import org.apache.gravitino.client.GravitinoMetalake;
 import org.apache.gravitino.dto.util.DTOConverters;
 import org.apache.gravitino.exceptions.NoSuchSchemaException;
@@ -284,7 +284,7 @@ public abstract class CatalogIcebergBaseIT extends AbstractIT {
     Assertions.assertTrue(schemaNames.contains(schemaName));
 
     List<org.apache.iceberg.catalog.Namespace> icebergNamespaces =
-        icebergSupportsNamespaces.listNamespaces(IcebergTableOpsHelper.getIcebergNamespace());
+        icebergSupportsNamespaces.listNamespaces(IcebergCatalogWrapperHelper.getIcebergNamespace());
     schemaNames =
         icebergNamespaces.stream().map(ns -> ns.level(ns.length() - 1)).collect(Collectors.toSet());
     Assertions.assertTrue(schemaNames.contains(schemaName));
@@ -298,7 +298,7 @@ public abstract class CatalogIcebergBaseIT extends AbstractIT {
     Assertions.assertTrue(schemaNames.contains(testSchemaName));
 
     icebergNamespaces =
-        icebergSupportsNamespaces.listNamespaces(IcebergTableOpsHelper.getIcebergNamespace());
+        icebergSupportsNamespaces.listNamespaces(IcebergCatalogWrapperHelper.getIcebergNamespace());
     schemaNames =
         icebergNamespaces.stream().map(ns -> ns.level(ns.length() - 1)).collect(Collectors.toSet());
     Assertions.assertTrue(schemaNames.contains(testSchemaName));
@@ -311,7 +311,7 @@ public abstract class CatalogIcebergBaseIT extends AbstractIT {
 
     Map<String, String> hiveCatalogProps =
         icebergSupportsNamespaces.loadNamespaceMetadata(
-            IcebergTableOpsHelper.getIcebergNamespace(schemaIdent.name()));
+            IcebergCatalogWrapperHelper.getIcebergNamespace(schemaIdent.name()));
     Assertions.assertTrue(hiveCatalogProps.containsKey("t1"));
 
     Map<String, String> emptyMap = Collections.emptyMap();
@@ -324,7 +324,7 @@ public abstract class CatalogIcebergBaseIT extends AbstractIT {
     Assertions.assertThrows(
         NoSuchSchemaException.class, () -> schemas.loadSchema(schemaIdent.name()));
     org.apache.iceberg.catalog.Namespace icebergNamespace =
-        IcebergTableOpsHelper.getIcebergNamespace(schemaIdent.name());
+        IcebergCatalogWrapperHelper.getIcebergNamespace(schemaIdent.name());
     Assertions.assertThrows(
         NoSuchNamespaceException.class,
         () -> {
@@ -359,7 +359,7 @@ public abstract class CatalogIcebergBaseIT extends AbstractIT {
     Assertions.assertFalse(schemas.dropSchema(schemaIdent.name(), false));
     Assertions.assertFalse(tableCatalog.dropTable(table));
     icebergNamespaces =
-        icebergSupportsNamespaces.listNamespaces(IcebergTableOpsHelper.getIcebergNamespace());
+        icebergSupportsNamespaces.listNamespaces(IcebergCatalogWrapperHelper.getIcebergNamespace());
     schemaNames =
         icebergNamespaces.stream().map(ns -> ns.level(ns.length() - 1)).collect(Collectors.toSet());
     Assertions.assertTrue(schemaNames.contains(schemaName));
@@ -442,7 +442,7 @@ public abstract class CatalogIcebergBaseIT extends AbstractIT {
     // catalog load check
     org.apache.iceberg.Table table =
         icebergCatalog.loadTable(
-            IcebergTableOpsHelper.buildIcebergTableIdentifier(tableIdentifier));
+            IcebergCatalogWrapperHelper.buildIcebergTableIdentifier(tableIdentifier));
     Assertions.assertEquals(tableName, table.name().substring(table.name().lastIndexOf(".") + 1));
     Assertions.assertEquals(
         table_comment, table.properties().get(IcebergTable.ICEBERG_COMMENT_FIELD_NAME));
@@ -514,7 +514,7 @@ public abstract class CatalogIcebergBaseIT extends AbstractIT {
 
     org.apache.iceberg.Table table =
         icebergCatalog.loadTable(
-            IcebergTableOpsHelper.buildIcebergTableIdentifier(tableIdentifier));
+            IcebergCatalogWrapperHelper.buildIcebergTableIdentifier(tableIdentifier));
     org.apache.iceberg.Schema icebergSchema = table.schema();
     Assertions.assertEquals("iceberg_column_1", icebergSchema.columns().get(0).name());
     Assertions.assertEquals(
@@ -550,7 +550,7 @@ public abstract class CatalogIcebergBaseIT extends AbstractIT {
     Assertions.assertEquals("table_1", nameIdentifiers[0].name());
 
     List<TableIdentifier> tableIdentifiers =
-        icebergCatalog.listTables(IcebergTableOpsHelper.getIcebergNamespace(schemaName));
+        icebergCatalog.listTables(IcebergCatalogWrapperHelper.getIcebergNamespace(schemaName));
     Assertions.assertEquals(1, tableIdentifiers.size());
     Assertions.assertEquals("table_1", tableIdentifiers.get(0).name());
 
@@ -569,7 +569,7 @@ public abstract class CatalogIcebergBaseIT extends AbstractIT {
     Assertions.assertEquals("table_2", nameIdentifiers[1].name());
 
     tableIdentifiers =
-        icebergCatalog.listTables(IcebergTableOpsHelper.getIcebergNamespace(schemaName));
+        icebergCatalog.listTables(IcebergCatalogWrapperHelper.getIcebergNamespace(schemaName));
     Assertions.assertEquals(2, tableIdentifiers.size());
     Assertions.assertEquals("table_1", tableIdentifiers.get(0).name());
     Assertions.assertEquals("table_2", tableIdentifiers.get(1).name());
@@ -585,7 +585,7 @@ public abstract class CatalogIcebergBaseIT extends AbstractIT {
     Assertions.assertEquals(0, nameIdentifiers.length);
 
     tableIdentifiers =
-        icebergCatalog.listTables(IcebergTableOpsHelper.getIcebergNamespace(schemaName));
+        icebergCatalog.listTables(IcebergCatalogWrapperHelper.getIcebergNamespace(schemaName));
     Assertions.assertEquals(0, tableIdentifiers.size());
   }
 

--- a/catalogs/catalog-lakehouse-iceberg/src/test/java/org/apache/gravitino/catalog/lakehouse/iceberg/ops/TestIcebergTableUpdate.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/test/java/org/apache/gravitino/catalog/lakehouse/iceberg/ops/TestIcebergTableUpdate.java
@@ -80,8 +80,8 @@ public class TestIcebergTableUpdate {
   @BeforeEach
   public void init() {
     icebergCatalogWrapper = new IcebergCatalogWrapper();
-    icebergCatalogWrapperHelper = new IcebergCatalogWrapperHelper(
-        icebergCatalogWrapper.getCatalog());
+    icebergCatalogWrapperHelper =
+        new IcebergCatalogWrapperHelper(icebergCatalogWrapper.getCatalog());
     createNamespace(TEST_NAMESPACE_NAME);
     createTable(TEST_NAMESPACE_NAME, TEST_TABLE_NAME);
   }
@@ -480,9 +480,11 @@ public class TestIcebergTableUpdate {
         "a.b", IcebergCatalogWrapperHelper.getParentName(new String[] {"a", "b", "c"}));
 
     Assertions.assertEquals("a", IcebergCatalogWrapperHelper.getLeafName(new String[] {"a"}));
-    Assertions.assertEquals("c", IcebergCatalogWrapperHelper.getLeafName(new String[] {"a", "b", "c"}));
+    Assertions.assertEquals(
+        "c", IcebergCatalogWrapperHelper.getLeafName(new String[] {"a", "b", "c"}));
 
-    Assertions.assertEquals("p", IcebergCatalogWrapperHelper.getSiblingName(new String[] {"a"}, "p"));
+    Assertions.assertEquals(
+        "p", IcebergCatalogWrapperHelper.getSiblingName(new String[] {"a"}, "p"));
     Assertions.assertEquals(
         "a.b.p", IcebergCatalogWrapperHelper.getSiblingName(new String[] {"a", "b", "c"}, "p"));
   }

--- a/catalogs/catalog-lakehouse-iceberg/src/test/java/org/apache/gravitino/catalog/lakehouse/iceberg/ops/TestIcebergTableUpdate.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/test/java/org/apache/gravitino/catalog/lakehouse/iceberg/ops/TestIcebergTableUpdate.java
@@ -21,8 +21,8 @@ package org.apache.gravitino.catalog.lakehouse.iceberg.ops;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.gravitino.NameIdentifier;
-import org.apache.gravitino.iceberg.common.ops.IcebergTableOps;
-import org.apache.gravitino.iceberg.common.ops.IcebergTableOps.IcebergTableChange;
+import org.apache.gravitino.iceberg.common.ops.IcebergCatalogWrapper;
+import org.apache.gravitino.iceberg.common.ops.IcebergCatalogWrapper.IcebergTableChange;
 import org.apache.gravitino.rel.TableChange;
 import org.apache.gravitino.rel.TableChange.ColumnPosition;
 import org.apache.gravitino.rel.types.Types;
@@ -44,8 +44,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class TestIcebergTableUpdate {
-  private IcebergTableOps icebergTableOps = null;
-  private IcebergTableOpsHelper icebergTableOpsHelper = null;
+  private IcebergCatalogWrapper icebergCatalogWrapper = null;
+  private IcebergCatalogWrapperHelper icebergCatalogWrapperHelper = null;
   private static final String TEST_NAMESPACE_NAME = "gravitino_test_namespace";
   private static final String TEST_TABLE_NAME = "gravitino_test_table";
 
@@ -79,8 +79,9 @@ public class TestIcebergTableUpdate {
 
   @BeforeEach
   public void init() {
-    icebergTableOps = new IcebergTableOps();
-    icebergTableOpsHelper = new IcebergTableOpsHelper(icebergTableOps.getCatalog());
+    icebergCatalogWrapper = new IcebergCatalogWrapper();
+    icebergCatalogWrapperHelper = new IcebergCatalogWrapperHelper(
+        icebergCatalogWrapper.getCatalog());
     createNamespace(TEST_NAMESPACE_NAME);
     createTable(TEST_NAMESPACE_NAME, TEST_TABLE_NAME);
   }
@@ -88,21 +89,22 @@ public class TestIcebergTableUpdate {
   public LoadTableResponse updateTable(
       NameIdentifier gravitinoNameIdentifier, TableChange... gravitinoTableChanges) {
     IcebergTableChange icebergTableChange =
-        icebergTableOpsHelper.buildIcebergTableChanges(
+        icebergCatalogWrapperHelper.buildIcebergTableChanges(
             gravitinoNameIdentifier, gravitinoTableChanges);
-    return icebergTableOps.updateTable(icebergTableChange);
+    return icebergCatalogWrapper.updateTable(icebergTableChange);
   }
 
   private void createNamespace(String namespace) {
-    icebergTableOps.createNamespace(
+    icebergCatalogWrapper.createNamespace(
         CreateNamespaceRequest.builder().withNamespace(Namespace.of(namespace)).build());
   }
 
   private void createTable(String namespace, String tableName) {
     CreateTableRequest createTableRequest =
         CreateTableRequest.builder().withName(tableName).withSchema(tableSchema).build();
-    icebergTableOps.createTable(Namespace.of(namespace), createTableRequest);
-    Assertions.assertTrue(icebergTableOps.tableExists(TableIdentifier.of(namespace, tableName)));
+    icebergCatalogWrapper.createTable(Namespace.of(namespace), createTableRequest);
+    Assertions.assertTrue(
+        icebergCatalogWrapper.tableExists(TableIdentifier.of(namespace, tableName)));
   }
 
   @Test
@@ -119,7 +121,7 @@ public class TestIcebergTableUpdate {
     String testPropertyKey = "test_property_key";
     String testPropertyValue = "test_property_value";
     String testPropertyNewValue = "test_property_new_value";
-    LoadTableResponse loadTableResponse = icebergTableOps.loadTable(icebergIdentifier);
+    LoadTableResponse loadTableResponse = icebergCatalogWrapper.loadTable(icebergIdentifier);
     Assertions.assertFalse(
         loadTableResponse.tableMetadata().properties().containsKey(testPropertyKey));
 
@@ -141,7 +143,7 @@ public class TestIcebergTableUpdate {
     Assertions.assertFalse(
         loadTableResponse.tableMetadata().properties().containsKey(testPropertyKey));
 
-    IcebergTableOpsHelper.getIcebergReservedProperties().stream()
+    IcebergCatalogWrapperHelper.getIcebergReservedProperties().stream()
         .forEach(
             property -> {
               TableChange setProperty1 = TableChange.setProperty(property, "test_v");
@@ -149,7 +151,7 @@ public class TestIcebergTableUpdate {
                   IllegalArgumentException.class, () -> updateTable(identifier, setProperty1));
             });
 
-    IcebergTableOpsHelper.getIcebergReservedProperties().stream()
+    IcebergCatalogWrapperHelper.getIcebergReservedProperties().stream()
         .forEach(
             property -> {
               TableChange removeProperty1 = TableChange.removeProperty(property);
@@ -208,7 +210,7 @@ public class TestIcebergTableUpdate {
             loadTableResponse
                 .tableMetadata()
                 .schema()
-                .findType(IcebergTableOpsHelper.DOT.join(fourthField[0], "element"));
+                .findType(IcebergCatalogWrapperHelper.DOT.join(fourthField[0], "element"));
     Assertions.assertEquals("struct_after", t.fields().get(1).name());
 
     // add to struct first
@@ -224,7 +226,7 @@ public class TestIcebergTableUpdate {
             loadTableResponse
                 .tableMetadata()
                 .schema()
-                .findType(IcebergTableOpsHelper.DOT.join(fourthField[0], "element"));
+                .findType(IcebergCatalogWrapperHelper.DOT.join(fourthField[0], "element"));
     Assertions.assertEquals("struct_first", t.fields().get(0).name());
 
     // add to struct last
@@ -237,7 +239,7 @@ public class TestIcebergTableUpdate {
             loadTableResponse
                 .tableMetadata()
                 .schema()
-                .findType(IcebergTableOpsHelper.DOT.join(fourthField[0], "element"));
+                .findType(IcebergCatalogWrapperHelper.DOT.join(fourthField[0], "element"));
     Assertions.assertEquals("struct_last", t.fields().get(t.fields().size() - 1).name());
 
     // add column exists
@@ -286,7 +288,7 @@ public class TestIcebergTableUpdate {
     loadTableResponse = updateTable(identifier, deleteColumn);
     Schema schema = loadTableResponse.tableMetadata().schema();
     Assertions.assertTrue(
-        schema.findType(IcebergTableOpsHelper.DOT.join(deleteColumnArray)) == null);
+        schema.findType(IcebergCatalogWrapperHelper.DOT.join(deleteColumnArray)) == null);
 
     deleteColumn = TableChange.deleteColumn(notExistField, true);
     // no exception
@@ -341,7 +343,7 @@ public class TestIcebergTableUpdate {
             loadTableResponse
                 .tableMetadata()
                 .schema()
-                .findType(IcebergTableOpsHelper.DOT.join(fourthField[0], "element"));
+                .findType(IcebergCatalogWrapperHelper.DOT.join(fourthField[0], "element"));
     Assertions.assertEquals(LongType.get(), t.fields().get(0).type());
 
     TableChange updateColumnType2 =
@@ -368,7 +370,7 @@ public class TestIcebergTableUpdate {
             loadTableResponse
                 .tableMetadata()
                 .schema()
-                .findType(IcebergTableOpsHelper.DOT.join(fourthField[0], "element"));
+                .findType(IcebergCatalogWrapperHelper.DOT.join(fourthField[0], "element"));
     Assertions.assertEquals(newColumnName, t.fields().get(0).name());
 
     TableChange renameColumn2 = TableChange.renameColumn(notExistField, newColumnName);
@@ -414,7 +416,7 @@ public class TestIcebergTableUpdate {
             loadTableResponse
                 .tableMetadata()
                 .schema()
-                .findType(IcebergTableOpsHelper.DOT.join(fourthField[0], "element"));
+                .findType(IcebergCatalogWrapperHelper.DOT.join(fourthField[0], "element"));
     Assertions.assertEquals("struct_map", structType.fields().get(0).name());
     Assertions.assertEquals("struct_int", structType.fields().get(1).name());
 
@@ -428,7 +430,7 @@ public class TestIcebergTableUpdate {
             loadTableResponse
                 .tableMetadata()
                 .schema()
-                .findType(IcebergTableOpsHelper.DOT.join(fourthField[0], "element"));
+                .findType(IcebergCatalogWrapperHelper.DOT.join(fourthField[0], "element"));
     Assertions.assertEquals("struct_int", structType.fields().get(0).name());
     Assertions.assertEquals("struct_map", structType.fields().get(1).name());
 
@@ -473,15 +475,15 @@ public class TestIcebergTableUpdate {
 
   @Test
   void testGetFieldName() {
-    Assertions.assertEquals(null, IcebergTableOpsHelper.getParentName(new String[] {"a"}));
+    Assertions.assertEquals(null, IcebergCatalogWrapperHelper.getParentName(new String[] {"a"}));
     Assertions.assertEquals(
-        "a.b", IcebergTableOpsHelper.getParentName(new String[] {"a", "b", "c"}));
+        "a.b", IcebergCatalogWrapperHelper.getParentName(new String[] {"a", "b", "c"}));
 
-    Assertions.assertEquals("a", IcebergTableOpsHelper.getLeafName(new String[] {"a"}));
-    Assertions.assertEquals("c", IcebergTableOpsHelper.getLeafName(new String[] {"a", "b", "c"}));
+    Assertions.assertEquals("a", IcebergCatalogWrapperHelper.getLeafName(new String[] {"a"}));
+    Assertions.assertEquals("c", IcebergCatalogWrapperHelper.getLeafName(new String[] {"a", "b", "c"}));
 
-    Assertions.assertEquals("p", IcebergTableOpsHelper.getSiblingName(new String[] {"a"}, "p"));
+    Assertions.assertEquals("p", IcebergCatalogWrapperHelper.getSiblingName(new String[] {"a"}, "p"));
     Assertions.assertEquals(
-        "a.b.p", IcebergTableOpsHelper.getSiblingName(new String[] {"a", "b", "c"}, "p"));
+        "a.b.p", IcebergCatalogWrapperHelper.getSiblingName(new String[] {"a", "b", "c"}, "p"));
   }
 }

--- a/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/IcebergConfig.java
+++ b/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/IcebergConfig.java
@@ -201,7 +201,7 @@ public class IcebergConfig extends Config implements OverwriteDefaultConfig {
   public static final ConfigEntry<String> ICEBERG_REST_CATALOG_PROVIDER =
       new ConfigBuilder(IcebergConstants.ICEBERG_REST_CATALOG_PROVIDER)
           .doc(
-              "Catalog provider class name, you can develop a class that implements `IcebergTableOpsProvider` and add the corresponding jar file to the Iceberg REST service classpath directory.")
+              "Catalog provider class name, you can develop a class that implements `IcebergCatalogWrapperProvider` and add the corresponding jar file to the Iceberg REST service classpath directory.")
           .version(ConfigConstants.VERSION_0_7_0)
           .stringConf()
           .createWithDefault("config-based-provider");

--- a/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/ops/IcebergCatalogWrapper.java
+++ b/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/ops/IcebergCatalogWrapper.java
@@ -59,9 +59,9 @@ import org.apache.iceberg.rest.responses.UpdateNamespacePropertiesResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class IcebergTableOps implements AutoCloseable {
+public class IcebergCatalogWrapper implements AutoCloseable {
 
-  public static final Logger LOG = LoggerFactory.getLogger(IcebergTableOps.class);
+  public static final Logger LOG = LoggerFactory.getLogger(IcebergCatalogWrapper.class);
 
   @Getter protected Catalog catalog;
   private SupportsNamespaces asNamespaceCatalog;
@@ -80,7 +80,7 @@ public class IcebergTableOps implements AutoCloseable {
           IcebergConstants.ICEBERG_OSS_ACCESS_KEY_ID,
           IcebergConstants.ICEBERG_OSS_ACCESS_KEY_SECRET);
 
-  public IcebergTableOps(IcebergConfig icebergConfig) {
+  public IcebergCatalogWrapper(IcebergConfig icebergConfig) {
     this.catalogBackend =
         IcebergCatalogBackend.valueOf(
             icebergConfig.get(IcebergConfig.CATALOG_BACKEND).toUpperCase(Locale.ROOT));
@@ -101,7 +101,7 @@ public class IcebergTableOps implements AutoCloseable {
     this.catalogPropertiesMap = icebergConfig.getIcebergCatalogProperties();
   }
 
-  public IcebergTableOps() {
+  public IcebergCatalogWrapper() {
     this(new IcebergConfig(Collections.emptyMap()));
   }
 

--- a/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/ops/IcebergCatalogWrapperProvider.java
+++ b/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/ops/IcebergCatalogWrapperProvider.java
@@ -21,10 +21,10 @@ package org.apache.gravitino.iceberg.common.ops;
 import java.util.Map;
 
 /**
- * IcebergTableOpsProvider is an interface defining how Iceberg REST catalog server gets Iceberg
+ * IcebergCatalogWrapperProvider is an interface defining how Iceberg REST catalog server gets Iceberg
  * catalogs.
  */
-public interface IcebergTableOpsProvider {
+public interface IcebergCatalogWrapperProvider {
 
   /**
    * @param properties The parameters for creating Provider which from configurations whose prefix
@@ -34,7 +34,7 @@ public interface IcebergTableOpsProvider {
 
   /**
    * @param catalogName a param send by clients.
-   * @return the instance of IcebergTableOps.
+   * @return the instance of IcebergCatalogWrapper.
    */
-  IcebergTableOps getIcebergTableOps(String catalogName);
+  IcebergCatalogWrapper getIcebergTableOps(String catalogName);
 }

--- a/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/ops/IcebergCatalogWrapperProvider.java
+++ b/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/ops/IcebergCatalogWrapperProvider.java
@@ -21,8 +21,8 @@ package org.apache.gravitino.iceberg.common.ops;
 import java.util.Map;
 
 /**
- * IcebergCatalogWrapperProvider is an interface defining how Iceberg REST catalog server gets Iceberg
- * catalogs.
+ * IcebergCatalogWrapperProvider is an interface defining how Iceberg REST catalog server gets
+ * Iceberg catalogs.
  */
 public interface IcebergCatalogWrapperProvider {
 

--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/RESTService.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/RESTService.java
@@ -23,9 +23,9 @@ import javax.servlet.Servlet;
 import org.apache.gravitino.GravitinoEnv;
 import org.apache.gravitino.auxiliary.GravitinoAuxiliaryService;
 import org.apache.gravitino.iceberg.common.IcebergConfig;
+import org.apache.gravitino.iceberg.service.IcebergCatalogWrapperManager;
 import org.apache.gravitino.iceberg.service.IcebergExceptionMapper;
 import org.apache.gravitino.iceberg.service.IcebergObjectMapperProvider;
-import org.apache.gravitino.iceberg.service.IcebergTableOpsManager;
 import org.apache.gravitino.iceberg.service.metrics.IcebergMetricsManager;
 import org.apache.gravitino.metrics.MetricsSystem;
 import org.apache.gravitino.metrics.source.MetricsSource;
@@ -48,7 +48,7 @@ public class RESTService implements GravitinoAuxiliaryService {
   public static final String SERVICE_NAME = "iceberg-rest";
   public static final String ICEBERG_SPEC = "/iceberg/*";
 
-  private IcebergTableOpsManager icebergTableOpsManager;
+  private IcebergCatalogWrapperManager icebergCatalogWrapperManager;
   private IcebergMetricsManager icebergMetricsManager;
 
   private void initServer(IcebergConfig icebergConfig) {
@@ -66,13 +66,13 @@ public class RESTService implements GravitinoAuxiliaryService {
         new HttpServerMetricsSource(MetricsSource.ICEBERG_REST_SERVER_METRIC_NAME, config, server);
     metricsSystem.register(httpServerMetricsSource);
 
-    icebergTableOpsManager = new IcebergTableOpsManager(icebergConfig.getAllConfig());
+    icebergCatalogWrapperManager = new IcebergCatalogWrapperManager(icebergConfig.getAllConfig());
     icebergMetricsManager = new IcebergMetricsManager(icebergConfig);
     config.register(
         new AbstractBinder() {
           @Override
           protected void configure() {
-            bind(icebergTableOpsManager).to(IcebergTableOpsManager.class).ranked(1);
+            bind(icebergCatalogWrapperManager).to(IcebergCatalogWrapperManager.class).ranked(1);
             bind(icebergMetricsManager).to(IcebergMetricsManager.class).ranked(1);
           }
         });
@@ -114,8 +114,8 @@ public class RESTService implements GravitinoAuxiliaryService {
       server.stop();
       LOG.info("Iceberg REST service stopped");
     }
-    if (icebergTableOpsManager != null) {
-      icebergTableOpsManager.close();
+    if (icebergCatalogWrapperManager != null) {
+      icebergCatalogWrapperManager.close();
     }
     if (icebergMetricsManager != null) {
       icebergMetricsManager.close();

--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/provider/ConfigBasedIcebergCatalogWrapperProvider.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/provider/ConfigBasedIcebergCatalogWrapperProvider.java
@@ -24,8 +24,8 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import org.apache.gravitino.catalog.lakehouse.iceberg.IcebergConstants;
 import org.apache.gravitino.iceberg.common.IcebergConfig;
-import org.apache.gravitino.iceberg.common.ops.IcebergTableOps;
-import org.apache.gravitino.iceberg.common.ops.IcebergTableOpsProvider;
+import org.apache.gravitino.iceberg.common.ops.IcebergCatalogWrapper;
+import org.apache.gravitino.iceberg.common.ops.IcebergCatalogWrapperProvider;
 import org.apache.gravitino.utils.MapUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -40,9 +40,10 @@ import org.slf4j.LoggerFactory;
  * gravitino.iceberg-rest.catalog.hive_proxy.catalog-backend = hive
  * gravitino.iceberg-rest.catalog.hive_proxy.uri = thrift://{host}:{port} ...
  */
-public class ConfigBasedIcebergTableOpsProvider implements IcebergTableOpsProvider {
+public class ConfigBasedIcebergCatalogWrapperProvider implements
+    IcebergCatalogWrapperProvider {
   public static final Logger LOG =
-      LoggerFactory.getLogger(ConfigBasedIcebergTableOpsProvider.class);
+      LoggerFactory.getLogger(ConfigBasedIcebergCatalogWrapperProvider.class);
 
   public static final String CONFIG_BASE_ICEBERG_TABLE_OPS_PROVIDER_NAME = "config-based-provider";
 
@@ -68,14 +69,14 @@ public class ConfigBasedIcebergTableOpsProvider implements IcebergTableOpsProvid
   }
 
   @Override
-  public IcebergTableOps getIcebergTableOps(String catalogName) {
+  public IcebergCatalogWrapper getIcebergTableOps(String catalogName) {
     IcebergConfig icebergConfig = this.catalogConfigs.get(catalogName);
     if (icebergConfig == null) {
       String errorMsg = String.format("%s can not match any catalog", catalogName);
       LOG.warn(errorMsg);
       throw new RuntimeException(errorMsg);
     }
-    return new IcebergTableOps(icebergConfig);
+    return new IcebergCatalogWrapper(icebergConfig);
   }
 
   private Optional<String> getCatalogName(String catalogConfigKey) {

--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/provider/ConfigBasedIcebergCatalogWrapperProvider.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/provider/ConfigBasedIcebergCatalogWrapperProvider.java
@@ -40,8 +40,7 @@ import org.slf4j.LoggerFactory;
  * gravitino.iceberg-rest.catalog.hive_proxy.catalog-backend = hive
  * gravitino.iceberg-rest.catalog.hive_proxy.uri = thrift://{host}:{port} ...
  */
-public class ConfigBasedIcebergCatalogWrapperProvider implements
-    IcebergCatalogWrapperProvider {
+public class ConfigBasedIcebergCatalogWrapperProvider implements IcebergCatalogWrapperProvider {
   public static final Logger LOG =
       LoggerFactory.getLogger(ConfigBasedIcebergCatalogWrapperProvider.class);
 

--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/provider/GravitinoBasedIcebergCatalogWrapperProvider.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/provider/GravitinoBasedIcebergCatalogWrapperProvider.java
@@ -27,8 +27,8 @@ import org.apache.gravitino.catalog.lakehouse.iceberg.IcebergConstants;
 import org.apache.gravitino.catalog.lakehouse.iceberg.IcebergPropertiesUtils;
 import org.apache.gravitino.client.GravitinoAdminClient;
 import org.apache.gravitino.iceberg.common.IcebergConfig;
-import org.apache.gravitino.iceberg.common.ops.IcebergTableOps;
-import org.apache.gravitino.iceberg.common.ops.IcebergTableOpsProvider;
+import org.apache.gravitino.iceberg.common.ops.IcebergCatalogWrapper;
+import org.apache.gravitino.iceberg.common.ops.IcebergCatalogWrapperProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,10 +39,10 @@ import org.slf4j.LoggerFactory;
  *
  * <p>The catalogName is iceberg_catalog
  */
-public class GravitinoBasedIcebergTableOpsProvider
-    implements IcebergTableOpsProvider, AutoCloseable {
+public class GravitinoBasedIcebergCatalogWrapperProvider
+    implements IcebergCatalogWrapperProvider, AutoCloseable {
   public static final Logger LOG =
-      LoggerFactory.getLogger(GravitinoBasedIcebergTableOpsProvider.class);
+      LoggerFactory.getLogger(GravitinoBasedIcebergCatalogWrapperProvider.class);
 
   public static final String GRAVITINO_BASE_ICEBERG_TABLE_OPS_PROVIDER_NAME =
       "gravitino-based-provider";
@@ -66,7 +66,7 @@ public class GravitinoBasedIcebergTableOpsProvider
   }
 
   @Override
-  public IcebergTableOps getIcebergTableOps(String catalogName) {
+  public IcebergCatalogWrapper getIcebergTableOps(String catalogName) {
     Preconditions.checkArgument(
         StringUtils.isNotBlank(catalogName), "blank catalogName is illegal");
     Preconditions.checkArgument(
@@ -81,7 +81,7 @@ public class GravitinoBasedIcebergTableOpsProvider
 
     Map<String, String> properties =
         IcebergPropertiesUtils.toIcebergCatalogProperties(catalog.properties());
-    return new IcebergTableOps(new IcebergConfig(properties));
+    return new IcebergCatalogWrapper(new IcebergConfig(properties));
   }
 
   @VisibleForTesting

--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/IcebergCatalogWrapperManager.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/IcebergCatalogWrapperManager.java
@@ -44,7 +44,8 @@ public class IcebergCatalogWrapperManager implements AutoCloseable {
       ImmutableMap.of(
           ConfigBasedIcebergCatalogWrapperProvider.CONFIG_BASE_ICEBERG_TABLE_OPS_PROVIDER_NAME,
           ConfigBasedIcebergCatalogWrapperProvider.class.getCanonicalName(),
-          GravitinoBasedIcebergCatalogWrapperProvider.GRAVITINO_BASE_ICEBERG_TABLE_OPS_PROVIDER_NAME,
+          GravitinoBasedIcebergCatalogWrapperProvider
+              .GRAVITINO_BASE_ICEBERG_TABLE_OPS_PROVIDER_NAME,
           GravitinoBasedIcebergCatalogWrapperProvider.class.getCanonicalName());
 
   private final Cache<String, IcebergCatalogWrapper> icebergTableOpsCache;

--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/metrics/IcebergMetricsManager.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/metrics/IcebergMetricsManager.java
@@ -30,14 +30,14 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import org.apache.gravitino.iceberg.common.IcebergConfig;
-import org.apache.gravitino.iceberg.common.ops.IcebergTableOps;
+import org.apache.gravitino.iceberg.common.ops.IcebergCatalogWrapper;
 import org.apache.gravitino.iceberg.service.IcebergRestUtils;
 import org.apache.iceberg.metrics.MetricsReport;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class IcebergMetricsManager {
-  private static final Logger LOG = LoggerFactory.getLogger(IcebergTableOps.class);
+  private static final Logger LOG = LoggerFactory.getLogger(IcebergCatalogWrapper.class);
 
   // Register IcebergMetricsStore's short name to its full qualified class name in the map. So
   // that user doesn't need to specify the full qualified class name when creating an

--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/rest/IcebergNamespaceOperations.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/rest/IcebergNamespaceOperations.java
@@ -64,8 +64,7 @@ public class IcebergNamespaceOperations {
   private HttpServletRequest httpRequest;
 
   @Inject
-  public IcebergNamespaceOperations(
-      IcebergCatalogWrapperManager icebergCatalogWrapperManager) {
+  public IcebergNamespaceOperations(IcebergCatalogWrapperManager icebergCatalogWrapperManager) {
     this.icebergCatalogWrapperManager = icebergCatalogWrapperManager;
   }
 
@@ -90,7 +89,9 @@ public class IcebergNamespaceOperations {
   public Response loadNamespace(
       @PathParam("prefix") String prefix, @PathParam("namespace") String namespace) {
     GetNamespaceResponse getNamespaceResponse =
-        icebergCatalogWrapperManager.getOps(prefix).loadNamespace(RESTUtil.decodeNamespace(namespace));
+        icebergCatalogWrapperManager
+            .getOps(prefix)
+            .loadNamespace(RESTUtil.decodeNamespace(namespace));
     return IcebergRestUtils.ok(getNamespaceResponse);
   }
 

--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/rest/IcebergNamespaceOperations.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/rest/IcebergNamespaceOperations.java
@@ -34,8 +34,8 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import org.apache.gravitino.iceberg.service.IcebergCatalogWrapperManager;
 import org.apache.gravitino.iceberg.service.IcebergRestUtils;
-import org.apache.gravitino.iceberg.service.IcebergTableOpsManager;
 import org.apache.gravitino.metrics.MetricNames;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.rest.RESTUtil;
@@ -57,15 +57,16 @@ public class IcebergNamespaceOperations {
 
   private static final Logger LOG = LoggerFactory.getLogger(IcebergNamespaceOperations.class);
 
-  private IcebergTableOpsManager icebergTableOpsManager;
+  private IcebergCatalogWrapperManager icebergCatalogWrapperManager;
 
   @SuppressWarnings("UnusedVariable")
   @Context
   private HttpServletRequest httpRequest;
 
   @Inject
-  public IcebergNamespaceOperations(IcebergTableOpsManager icebergTableOpsManager) {
-    this.icebergTableOpsManager = icebergTableOpsManager;
+  public IcebergNamespaceOperations(
+      IcebergCatalogWrapperManager icebergCatalogWrapperManager) {
+    this.icebergCatalogWrapperManager = icebergCatalogWrapperManager;
   }
 
   @GET
@@ -77,7 +78,7 @@ public class IcebergNamespaceOperations {
     Namespace parentNamespace =
         parent.isEmpty() ? Namespace.empty() : RESTUtil.decodeNamespace(parent);
     ListNamespacesResponse response =
-        icebergTableOpsManager.getOps(prefix).listNamespace(parentNamespace);
+        icebergCatalogWrapperManager.getOps(prefix).listNamespace(parentNamespace);
     return IcebergRestUtils.ok(response);
   }
 
@@ -89,7 +90,7 @@ public class IcebergNamespaceOperations {
   public Response loadNamespace(
       @PathParam("prefix") String prefix, @PathParam("namespace") String namespace) {
     GetNamespaceResponse getNamespaceResponse =
-        icebergTableOpsManager.getOps(prefix).loadNamespace(RESTUtil.decodeNamespace(namespace));
+        icebergCatalogWrapperManager.getOps(prefix).loadNamespace(RESTUtil.decodeNamespace(namespace));
     return IcebergRestUtils.ok(getNamespaceResponse);
   }
 
@@ -102,7 +103,7 @@ public class IcebergNamespaceOperations {
       @PathParam("prefix") String prefix, @PathParam("namespace") String namespace) {
     // todo check if table exists in namespace after table ops is added
     LOG.info("Drop Iceberg namespace: {}, prefix: {}", namespace, prefix);
-    icebergTableOpsManager.getOps(prefix).dropNamespace(RESTUtil.decodeNamespace(namespace));
+    icebergCatalogWrapperManager.getOps(prefix).dropNamespace(RESTUtil.decodeNamespace(namespace));
     return IcebergRestUtils.noContent();
   }
 
@@ -114,7 +115,7 @@ public class IcebergNamespaceOperations {
       @PathParam("prefix") String prefix, CreateNamespaceRequest namespaceRequest) {
     LOG.info("Create Iceberg namespace: {}, prefix: {}", namespaceRequest, prefix);
     CreateNamespaceResponse response =
-        icebergTableOpsManager.getOps(prefix).createNamespace(namespaceRequest);
+        icebergCatalogWrapperManager.getOps(prefix).createNamespace(namespaceRequest);
     return IcebergRestUtils.ok(response);
   }
 
@@ -129,7 +130,7 @@ public class IcebergNamespaceOperations {
       UpdateNamespacePropertiesRequest request) {
     LOG.info("Update Iceberg namespace: {}, request: {}, prefix: {}", namespace, request, prefix);
     UpdateNamespacePropertiesResponse response =
-        icebergTableOpsManager
+        icebergCatalogWrapperManager
             .getOps(prefix)
             .updateNamespaceProperties(RESTUtil.decodeNamespace(namespace), request);
     return IcebergRestUtils.ok(response);
@@ -146,7 +147,7 @@ public class IcebergNamespaceOperations {
       RegisterTableRequest request) {
     LOG.info("Register table, namespace: {}, request: {}", namespace, request);
     LoadTableResponse response =
-        icebergTableOpsManager
+        icebergCatalogWrapperManager
             .getOps(prefix)
             .registerTable(RESTUtil.decodeNamespace(namespace), request);
     return IcebergRestUtils.ok(response);

--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/rest/IcebergTableOperations.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/rest/IcebergTableOperations.java
@@ -68,7 +68,8 @@ public class IcebergTableOperations {
 
   @Inject
   public IcebergTableOperations(
-      IcebergCatalogWrapperManager icebergCatalogWrapperManager, IcebergMetricsManager icebergMetricsManager) {
+      IcebergCatalogWrapperManager icebergCatalogWrapperManager,
+      IcebergMetricsManager icebergMetricsManager) {
     this.icebergCatalogWrapperManager = icebergCatalogWrapperManager;
     this.icebergObjectMapper = IcebergObjectMapper.getInstance();
     this.icebergMetricsManager = icebergMetricsManager;
@@ -122,7 +123,9 @@ public class IcebergTableOperations {
     TableIdentifier tableIdentifier =
         TableIdentifier.of(RESTUtil.decodeNamespace(namespace), table);
     return IcebergRestUtils.ok(
-        icebergCatalogWrapperManager.getOps(prefix).updateTable(tableIdentifier, updateTableRequest));
+        icebergCatalogWrapperManager
+            .getOps(prefix)
+            .updateTable(tableIdentifier, updateTableRequest));
   }
 
   @DELETE
@@ -163,7 +166,8 @@ public class IcebergTableOperations {
     // todo support snapshots
     TableIdentifier tableIdentifier =
         TableIdentifier.of(RESTUtil.decodeNamespace(namespace), table);
-    return IcebergRestUtils.ok(icebergCatalogWrapperManager.getOps(prefix).loadTable(tableIdentifier));
+    return IcebergRestUtils.ok(
+        icebergCatalogWrapperManager.getOps(prefix).loadTable(tableIdentifier));
   }
 
   @HEAD

--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/rest/IcebergTableRenameOperations.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/rest/IcebergTableRenameOperations.java
@@ -30,8 +30,8 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import org.apache.gravitino.iceberg.service.IcebergCatalogWrapperManager;
 import org.apache.gravitino.iceberg.service.IcebergRestUtils;
-import org.apache.gravitino.iceberg.service.IcebergTableOpsManager;
 import org.apache.gravitino.metrics.MetricNames;
 import org.apache.iceberg.rest.requests.RenameTableRequest;
 
@@ -44,11 +44,12 @@ public class IcebergTableRenameOperations {
   @Context
   private HttpServletRequest httpRequest;
 
-  private IcebergTableOpsManager icebergTableOpsManager;
+  private IcebergCatalogWrapperManager icebergCatalogWrapperManager;
 
   @Inject
-  public IcebergTableRenameOperations(IcebergTableOpsManager icebergTableOpsManager) {
-    this.icebergTableOpsManager = icebergTableOpsManager;
+  public IcebergTableRenameOperations(
+      IcebergCatalogWrapperManager icebergCatalogWrapperManager) {
+    this.icebergCatalogWrapperManager = icebergCatalogWrapperManager;
   }
 
   @POST
@@ -57,7 +58,7 @@ public class IcebergTableRenameOperations {
   @ResponseMetered(name = "rename-table", absolute = true)
   public Response renameTable(
       @PathParam("prefix") String prefix, RenameTableRequest renameTableRequest) {
-    icebergTableOpsManager.getOps(prefix).renameTable(renameTableRequest);
+    icebergCatalogWrapperManager.getOps(prefix).renameTable(renameTableRequest);
     return IcebergRestUtils.okWithoutContent();
   }
 }

--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/rest/IcebergTableRenameOperations.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/rest/IcebergTableRenameOperations.java
@@ -47,8 +47,7 @@ public class IcebergTableRenameOperations {
   private IcebergCatalogWrapperManager icebergCatalogWrapperManager;
 
   @Inject
-  public IcebergTableRenameOperations(
-      IcebergCatalogWrapperManager icebergCatalogWrapperManager) {
+  public IcebergTableRenameOperations(IcebergCatalogWrapperManager icebergCatalogWrapperManager) {
     this.icebergCatalogWrapperManager = icebergCatalogWrapperManager;
   }
 

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/provider/TestConfigBasedIcebergCatalogWrapperProvider.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/provider/TestConfigBasedIcebergCatalogWrapperProvider.java
@@ -58,7 +58,8 @@ public class TestConfigBasedIcebergCatalogWrapperProvider {
     config.put("catalog-backend", "memory");
     config.put("warehouse", "/tmp/");
 
-    ConfigBasedIcebergCatalogWrapperProvider provider = new ConfigBasedIcebergCatalogWrapperProvider();
+    ConfigBasedIcebergCatalogWrapperProvider provider =
+        new ConfigBasedIcebergCatalogWrapperProvider();
     provider.initialize(config);
 
     IcebergConfig hiveIcebergConfig = provider.catalogConfigs.get(hiveCatalogName);
@@ -101,7 +102,8 @@ public class TestConfigBasedIcebergCatalogWrapperProvider {
   @ParameterizedTest
   @ValueSource(strings = {"", "not_match"})
   public void testInvalidIcebergTableOps(String catalogName) {
-    ConfigBasedIcebergCatalogWrapperProvider provider = new ConfigBasedIcebergCatalogWrapperProvider();
+    ConfigBasedIcebergCatalogWrapperProvider provider =
+        new ConfigBasedIcebergCatalogWrapperProvider();
     provider.initialize(Maps.newHashMap());
 
     Assertions.assertThrowsExactly(

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/provider/TestConfigBasedIcebergCatalogWrapperProvider.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/provider/TestConfigBasedIcebergCatalogWrapperProvider.java
@@ -22,7 +22,7 @@ import com.google.common.collect.Maps;
 import java.util.Map;
 import org.apache.gravitino.catalog.lakehouse.iceberg.IcebergConstants;
 import org.apache.gravitino.iceberg.common.IcebergConfig;
-import org.apache.gravitino.iceberg.common.ops.IcebergTableOps;
+import org.apache.gravitino.iceberg.common.ops.IcebergCatalogWrapper;
 import org.apache.iceberg.hive.HiveCatalog;
 import org.apache.iceberg.inmemory.InMemoryCatalog;
 import org.apache.iceberg.jdbc.JdbcCatalog;
@@ -31,7 +31,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-public class TestConfigBasedIcebergTableOpsProvider {
+public class TestConfigBasedIcebergCatalogWrapperProvider {
   @Test
   public void testValidIcebergTableOps() {
     String hiveCatalogName = "hive_backend";
@@ -58,15 +58,15 @@ public class TestConfigBasedIcebergTableOpsProvider {
     config.put("catalog-backend", "memory");
     config.put("warehouse", "/tmp/");
 
-    ConfigBasedIcebergTableOpsProvider provider = new ConfigBasedIcebergTableOpsProvider();
+    ConfigBasedIcebergCatalogWrapperProvider provider = new ConfigBasedIcebergCatalogWrapperProvider();
     provider.initialize(config);
 
     IcebergConfig hiveIcebergConfig = provider.catalogConfigs.get(hiveCatalogName);
     IcebergConfig jdbcIcebergConfig = provider.catalogConfigs.get(jdbcCatalogName);
     IcebergConfig defaultIcebergConfig = provider.catalogConfigs.get(defaultCatalogName);
-    IcebergTableOps hiveOps = provider.getIcebergTableOps(hiveCatalogName);
-    IcebergTableOps jdbcOps = provider.getIcebergTableOps(jdbcCatalogName);
-    IcebergTableOps defaultOps = provider.getIcebergTableOps(defaultCatalogName);
+    IcebergCatalogWrapper hiveOps = provider.getIcebergTableOps(hiveCatalogName);
+    IcebergCatalogWrapper jdbcOps = provider.getIcebergTableOps(jdbcCatalogName);
+    IcebergCatalogWrapper defaultOps = provider.getIcebergTableOps(defaultCatalogName);
 
     Assertions.assertEquals(
         hiveCatalogName, hiveIcebergConfig.get(IcebergConfig.CATALOG_BACKEND_NAME));
@@ -101,7 +101,7 @@ public class TestConfigBasedIcebergTableOpsProvider {
   @ParameterizedTest
   @ValueSource(strings = {"", "not_match"})
   public void testInvalidIcebergTableOps(String catalogName) {
-    ConfigBasedIcebergTableOpsProvider provider = new ConfigBasedIcebergTableOpsProvider();
+    ConfigBasedIcebergCatalogWrapperProvider provider = new ConfigBasedIcebergCatalogWrapperProvider();
     provider.initialize(Maps.newHashMap());
 
     Assertions.assertThrowsExactly(

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/provider/TestGravitinoBasedIcebergCatalogWrapperProvider.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/provider/TestGravitinoBasedIcebergCatalogWrapperProvider.java
@@ -23,14 +23,14 @@ import org.apache.gravitino.Catalog;
 import org.apache.gravitino.catalog.lakehouse.iceberg.IcebergConstants;
 import org.apache.gravitino.client.GravitinoAdminClient;
 import org.apache.gravitino.client.GravitinoMetalake;
-import org.apache.gravitino.iceberg.common.ops.IcebergTableOps;
+import org.apache.gravitino.iceberg.common.ops.IcebergCatalogWrapper;
 import org.apache.iceberg.hive.HiveCatalog;
 import org.apache.iceberg.jdbc.JdbcCatalog;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-public class TestGravitinoBasedIcebergTableOpsProvider {
+public class TestGravitinoBasedIcebergCatalogWrapperProvider {
   @Test
   public void testValidIcebergTableOps() {
     String hiveCatalogName = "hive_backend";
@@ -71,13 +71,13 @@ public class TestGravitinoBasedIcebergTableOpsProvider {
               }
             });
 
-    GravitinoBasedIcebergTableOpsProvider provider = new GravitinoBasedIcebergTableOpsProvider();
+    GravitinoBasedIcebergCatalogWrapperProvider provider = new GravitinoBasedIcebergCatalogWrapperProvider();
     GravitinoAdminClient client = Mockito.mock(GravitinoAdminClient.class);
     Mockito.when(client.loadMetalake(Mockito.any())).thenReturn(gravitinoMetalake);
     provider.setClient(client);
 
-    IcebergTableOps hiveOps = provider.getIcebergTableOps(hiveCatalogName);
-    IcebergTableOps jdbcOps = provider.getIcebergTableOps(jdbcCatalogName);
+    IcebergCatalogWrapper hiveOps = provider.getIcebergTableOps(hiveCatalogName);
+    IcebergCatalogWrapper jdbcOps = provider.getIcebergTableOps(jdbcCatalogName);
 
     Assertions.assertEquals(hiveCatalogName, hiveOps.getCatalog().name());
     Assertions.assertEquals(jdbcCatalogName, jdbcOps.getCatalog().name());
@@ -100,7 +100,7 @@ public class TestGravitinoBasedIcebergTableOpsProvider {
     GravitinoAdminClient client = Mockito.mock(GravitinoAdminClient.class);
     Mockito.when(client.loadMetalake(Mockito.any())).thenReturn(gravitinoMetalake);
 
-    GravitinoBasedIcebergTableOpsProvider provider = new GravitinoBasedIcebergTableOpsProvider();
+    GravitinoBasedIcebergCatalogWrapperProvider provider = new GravitinoBasedIcebergCatalogWrapperProvider();
     provider.setClient(client);
 
     Assertions.assertThrowsExactly(

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/provider/TestGravitinoBasedIcebergCatalogWrapperProvider.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/provider/TestGravitinoBasedIcebergCatalogWrapperProvider.java
@@ -71,7 +71,8 @@ public class TestGravitinoBasedIcebergCatalogWrapperProvider {
               }
             });
 
-    GravitinoBasedIcebergCatalogWrapperProvider provider = new GravitinoBasedIcebergCatalogWrapperProvider();
+    GravitinoBasedIcebergCatalogWrapperProvider provider =
+        new GravitinoBasedIcebergCatalogWrapperProvider();
     GravitinoAdminClient client = Mockito.mock(GravitinoAdminClient.class);
     Mockito.when(client.loadMetalake(Mockito.any())).thenReturn(gravitinoMetalake);
     provider.setClient(client);
@@ -100,7 +101,8 @@ public class TestGravitinoBasedIcebergCatalogWrapperProvider {
     GravitinoAdminClient client = Mockito.mock(GravitinoAdminClient.class);
     Mockito.when(client.loadMetalake(Mockito.any())).thenReturn(gravitinoMetalake);
 
-    GravitinoBasedIcebergCatalogWrapperProvider provider = new GravitinoBasedIcebergCatalogWrapperProvider();
+    GravitinoBasedIcebergCatalogWrapperProvider provider =
+        new GravitinoBasedIcebergCatalogWrapperProvider();
     provider.setClient(client);
 
     Assertions.assertThrowsExactly(

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/TestIcebergCatalogWrapperManager.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/TestIcebergCatalogWrapperManager.java
@@ -21,12 +21,12 @@ package org.apache.gravitino.iceberg.service;
 import com.google.common.collect.Maps;
 import java.util.Map;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.gravitino.iceberg.common.ops.IcebergTableOps;
+import org.apache.gravitino.iceberg.common.ops.IcebergCatalogWrapper;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-public class TestIcebergTableOpsManager {
+public class TestIcebergCatalogWrapperManager {
 
   private static final String DEFAULT_CATALOG = "memory";
 
@@ -39,9 +39,9 @@ public class TestIcebergTableOpsManager {
     }
     Map<String, String> config = Maps.newHashMap();
     config.put(String.format("catalog.%s.catalog-backend-name", prefix), prefix);
-    IcebergTableOpsManager manager = new IcebergTableOpsManager(config);
+    IcebergCatalogWrapperManager manager = new IcebergCatalogWrapperManager(config);
 
-    IcebergTableOps ops = manager.getOps(rawPrefix);
+    IcebergCatalogWrapper ops = manager.getOps(rawPrefix);
 
     if (StringUtils.isBlank(prefix)) {
       Assertions.assertEquals(ops.getCatalog().name(), DEFAULT_CATALOG);
@@ -55,7 +55,7 @@ public class TestIcebergTableOpsManager {
       strings = {"hello", "\\\n\t\\\'", "\u0024", "\100", "[_~", "__gravitino_default_catalog/"})
   public void testInvalidGetOps(String rawPrefix) {
     Map<String, String> config = Maps.newHashMap();
-    IcebergTableOpsManager manager = new IcebergTableOpsManager(config);
+    IcebergCatalogWrapperManager manager = new IcebergCatalogWrapperManager(config);
 
     Assertions.assertThrowsExactly(IllegalArgumentException.class, () -> manager.getOps(rawPrefix));
   }

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/ConfigBasedIcebergCatalogWrapperProviderForTest.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/ConfigBasedIcebergCatalogWrapperProviderForTest.java
@@ -18,12 +18,13 @@
  */
 package org.apache.gravitino.iceberg.service.rest;
 
-import org.apache.gravitino.iceberg.common.ops.IcebergTableOps;
-import org.apache.gravitino.iceberg.provider.ConfigBasedIcebergTableOpsProvider;
+import org.apache.gravitino.iceberg.common.ops.IcebergCatalogWrapper;
+import org.apache.gravitino.iceberg.provider.ConfigBasedIcebergCatalogWrapperProvider;
 
-public class ConfigBasedIcebergTableOpsProviderForTest extends ConfigBasedIcebergTableOpsProvider {
+public class ConfigBasedIcebergCatalogWrapperProviderForTest extends
+    ConfigBasedIcebergCatalogWrapperProvider {
   @Override
-  public IcebergTableOps getIcebergTableOps(String prefix) {
-    return new IcebergTableOpsForTest();
+  public IcebergCatalogWrapper getIcebergTableOps(String prefix) {
+    return new IcebergCatalogWrapperForTest();
   }
 }

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/ConfigBasedIcebergCatalogWrapperProviderForTest.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/ConfigBasedIcebergCatalogWrapperProviderForTest.java
@@ -21,8 +21,8 @@ package org.apache.gravitino.iceberg.service.rest;
 import org.apache.gravitino.iceberg.common.ops.IcebergCatalogWrapper;
 import org.apache.gravitino.iceberg.provider.ConfigBasedIcebergCatalogWrapperProvider;
 
-public class ConfigBasedIcebergCatalogWrapperProviderForTest extends
-    ConfigBasedIcebergCatalogWrapperProvider {
+public class ConfigBasedIcebergCatalogWrapperProviderForTest
+    extends ConfigBasedIcebergCatalogWrapperProvider {
   @Override
   public IcebergCatalogWrapper getIcebergTableOps(String prefix) {
     return new IcebergCatalogWrapperForTest();

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/IcebergCatalogWrapperForTest.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/IcebergCatalogWrapperForTest.java
@@ -18,7 +18,7 @@
  */
 package org.apache.gravitino.iceberg.service.rest;
 
-import org.apache.gravitino.iceberg.common.ops.IcebergTableOps;
+import org.apache.gravitino.iceberg.common.ops.IcebergCatalogWrapper;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.TableMetadata;
@@ -30,7 +30,7 @@ import org.apache.iceberg.types.Types.NestedField;
 import org.apache.iceberg.types.Types.StringType;
 import org.testcontainers.shaded.com.google.common.collect.ImmutableMap;
 
-public class IcebergTableOpsForTest extends IcebergTableOps {
+public class IcebergCatalogWrapperForTest extends IcebergCatalogWrapper {
   @Override
   public LoadTableResponse registerTable(Namespace namespace, RegisterTableRequest request) {
     if (request.name().contains("fail")) {

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/IcebergRestTestUtil.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/IcebergRestTestUtil.java
@@ -74,7 +74,8 @@ public class IcebergRestTestUtil {
       catalogConf.put(
           IcebergConstants.ICEBERG_REST_CATALOG_PROVIDER,
           ConfigBasedIcebergCatalogWrapperProviderForTest.class.getName());
-      IcebergCatalogWrapperManager icebergCatalogWrapperManager = new IcebergCatalogWrapperManager(catalogConf);
+      IcebergCatalogWrapperManager icebergCatalogWrapperManager =
+          new IcebergCatalogWrapperManager(catalogConf);
 
       IcebergMetricsManager icebergMetricsManager = new IcebergMetricsManager(new IcebergConfig());
       resourceConfig.register(

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/IcebergRestTestUtil.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/IcebergRestTestUtil.java
@@ -25,9 +25,9 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.apache.gravitino.catalog.lakehouse.iceberg.IcebergConstants;
 import org.apache.gravitino.iceberg.common.IcebergConfig;
+import org.apache.gravitino.iceberg.service.IcebergCatalogWrapperManager;
 import org.apache.gravitino.iceberg.service.IcebergExceptionMapper;
 import org.apache.gravitino.iceberg.service.IcebergObjectMapperProvider;
-import org.apache.gravitino.iceberg.service.IcebergTableOpsManager;
 import org.apache.gravitino.iceberg.service.metrics.IcebergMetricsManager;
 import org.glassfish.hk2.utilities.binding.AbstractBinder;
 import org.glassfish.jersey.jackson.JacksonFeature;
@@ -73,15 +73,15 @@ public class IcebergRestTestUtil {
       catalogConf.put(String.format("catalog.%s.catalog-backend-name", PREFIX), PREFIX);
       catalogConf.put(
           IcebergConstants.ICEBERG_REST_CATALOG_PROVIDER,
-          ConfigBasedIcebergTableOpsProviderForTest.class.getName());
-      IcebergTableOpsManager icebergTableOpsManager = new IcebergTableOpsManager(catalogConf);
+          ConfigBasedIcebergCatalogWrapperProviderForTest.class.getName());
+      IcebergCatalogWrapperManager icebergCatalogWrapperManager = new IcebergCatalogWrapperManager(catalogConf);
 
       IcebergMetricsManager icebergMetricsManager = new IcebergMetricsManager(new IcebergConfig());
       resourceConfig.register(
           new AbstractBinder() {
             @Override
             protected void configure() {
-              bind(icebergTableOpsManager).to(IcebergTableOpsManager.class).ranked(2);
+              bind(icebergCatalogWrapperManager).to(IcebergCatalogWrapperManager.class).ranked(2);
               bind(icebergMetricsManager).to(IcebergMetricsManager.class).ranked(2);
             }
           });


### PR DESCRIPTION
### What changes were proposed in this pull request?

The name of `IcebergTableOps` is not accurate, rename to `IcebergCatalogWrapper`

### Why are the changes needed?

Fix: #4476 

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
existing tests