### PR TITLE
[#4759] feat(auth-ranger): Use Spark verify Ranger authorization Hive

### DIFF
--- a/authorizations/authorization-ranger/build.gradle.kts
+++ b/authorizations/authorization-ranger/build.gradle.kts
@@ -24,6 +24,10 @@ plugins {
   id("idea")
 }
 
+val scalaVersion: String = project.properties["scalaVersion"] as? String ?: extra["defaultScalaVersion"].toString()
+val sparkVersion: String = libs.versions.spark35.get()
+val kyuubiVersion: String = libs.versions.kyuubi4spark35.get()
+
 dependencies {
   implementation(project(":api")) {
     exclude(group = "*")
@@ -69,24 +73,30 @@ dependencies {
   testImplementation(libs.mockito.core)
   testImplementation(libs.testcontainers)
   testRuntimeOnly(libs.junit.jupiter.engine)
-  testImplementation(libs.ranger.intg) {
-    exclude("org.apache.hive", "hive-storage-api")
-    exclude("org.apache.lucene")
-    exclude("org.apache.solr")
-    exclude("org.apache.kafka")
-    exclude("org.eclipse.jetty")
-    exclude("org.elasticsearch")
-    exclude("org.elasticsearch.client")
-    exclude("org.elasticsearch.plugin")
-    exclude("javax.ws.rs")
-    exclude("org.apache.ranger", "ranger-plugin-classloader")
-  }
-  testImplementation(libs.hive2.jdbc) {
-    exclude("org.slf4j")
-    exclude("org.eclipse.jetty.aggregate")
-  }
   testImplementation(libs.mysql.driver)
   testImplementation(libs.postgresql.driver)
+  testImplementation(libs.postgresql.driver)
+  testImplementation("org.apache.spark:spark-hive_$scalaVersion:$sparkVersion")
+  testImplementation("org.apache.spark:spark-sql_$scalaVersion:$sparkVersion") {
+    exclude("org.apache.avro")
+    exclude("org.apache.hadoop")
+    exclude("org.apache.zookeeper")
+    exclude("io.dropwizard.metrics")
+    exclude("org.rocksdb")
+  }
+  testImplementation("org.apache.kyuubi:kyuubi-spark-authz_$scalaVersion:$kyuubiVersion") {
+    exclude("com.sun.jersey")
+  }
+  testImplementation(libs.hadoop3.client)
+  testImplementation(libs.hadoop3.common) {
+    exclude("com.sun.jersey")
+    exclude("javax.servlet", "servlet-api")
+  }
+  testImplementation(libs.hadoop3.hdfs) {
+    exclude("com.sun.jersey")
+    exclude("javax.servlet", "servlet-api")
+    exclude("io.netty")
+  }
 }
 
 tasks {

--- a/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/RangerHelper.java
+++ b/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/RangerHelper.java
@@ -36,6 +36,7 @@ import org.apache.gravitino.authorization.Privilege;
 import org.apache.gravitino.authorization.SecurableObject;
 import org.apache.gravitino.authorization.SecurableObjects;
 import org.apache.gravitino.exceptions.AuthorizationPluginException;
+import org.apache.ranger.RangerClient;
 import org.apache.ranger.RangerServiceException;
 import org.apache.ranger.plugin.model.RangerPolicy;
 import org.apache.ranger.plugin.model.RangerRole;
@@ -60,12 +61,12 @@ public class RangerHelper {
   /** The policy search keys */
   private final List<String> policyResourceDefines;
 
-  private final RangerClientExtension rangerClient;
+  private final RangerClient rangerClient;
   private final String rangerAdminName;
   private final String rangerServiceName;
 
   public RangerHelper(
-      RangerClientExtension rangerClient,
+      RangerClient rangerClient,
       String rangerAdminName,
       String rangerServiceName,
       Map<Privilege.Name, Set<RangerPrivilege>> privilegesMapping,

--- a/authorizations/authorization-ranger/src/test/java/org/apache/gravitino/authorization/ranger/integration/test/RangerHiveE2EIT.java
+++ b/authorizations/authorization-ranger/src/test/java/org/apache/gravitino/authorization/ranger/integration/test/RangerHiveE2EIT.java
@@ -19,7 +19,8 @@
 package org.apache.gravitino.authorization.ranger.integration.test;
 
 import static org.apache.gravitino.Catalog.AUTHORIZATION_PROVIDER;
-import static org.apache.gravitino.connector.AuthorizationPropertiesMeta.RANGER_ADMIN_URL;
+import static org.apache.gravitino.authorization.ranger.integration.test.RangerITEnv.currentFunName;
+import static org.apache.gravitino.catalog.hive.HiveConstants.IMPERSONATION_ENABLE;
 import static org.apache.gravitino.connector.AuthorizationPropertiesMeta.RANGER_AUTH_TYPE;
 import static org.apache.gravitino.connector.AuthorizationPropertiesMeta.RANGER_PASSWORD;
 import static org.apache.gravitino.connector.AuthorizationPropertiesMeta.RANGER_SERVICE_NAME;
@@ -29,17 +30,21 @@ import static org.apache.gravitino.integration.test.container.RangerContainer.RA
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
+import org.apache.commons.io.FileUtils;
 import org.apache.gravitino.Catalog;
 import org.apache.gravitino.Configs;
 import org.apache.gravitino.MetadataObject;
-import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Schema;
-import org.apache.gravitino.auth.AuthConstants;
+import org.apache.gravitino.auth.AuthenticatorType;
 import org.apache.gravitino.authorization.Privileges;
-import org.apache.gravitino.authorization.Role;
 import org.apache.gravitino.authorization.SecurableObject;
 import org.apache.gravitino.authorization.SecurableObjects;
 import org.apache.gravitino.authorization.ranger.RangerAuthorizationHivePlugin;
@@ -51,18 +56,12 @@ import org.apache.gravitino.integration.test.container.HiveContainer;
 import org.apache.gravitino.integration.test.container.RangerContainer;
 import org.apache.gravitino.integration.test.util.AbstractIT;
 import org.apache.gravitino.integration.test.util.GravitinoITUtils;
-import org.apache.gravitino.rel.Column;
-import org.apache.gravitino.rel.Table;
-import org.apache.gravitino.rel.expressions.NamedReference;
-import org.apache.gravitino.rel.expressions.distributions.Distribution;
-import org.apache.gravitino.rel.expressions.distributions.Distributions;
-import org.apache.gravitino.rel.expressions.distributions.Strategy;
-import org.apache.gravitino.rel.expressions.sorts.NullOrdering;
-import org.apache.gravitino.rel.expressions.sorts.SortDirection;
-import org.apache.gravitino.rel.expressions.sorts.SortOrder;
-import org.apache.gravitino.rel.expressions.sorts.SortOrders;
-import org.apache.gravitino.rel.expressions.transforms.Transforms;
-import org.apache.gravitino.rel.types.Types;
+import org.apache.gravitino.meta.AuditInfo;
+import org.apache.gravitino.meta.RoleEntity;
+import org.apache.gravitino.meta.UserEntity;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
@@ -77,63 +76,195 @@ public class RangerHiveE2EIT extends AbstractIT {
 
   private static RangerAuthorizationPlugin rangerAuthPlugin;
   public static final String metalakeName =
-      GravitinoITUtils.genRandomName("RangerHiveAuthIT_metalake").toLowerCase();
+      GravitinoITUtils.genRandomName("RangerHiveE2EIT_metalake").toLowerCase();
   public static final String catalogName =
-      GravitinoITUtils.genRandomName("RangerHiveAuthIT_catalog").toLowerCase();
+      GravitinoITUtils.genRandomName("RangerHiveE2EIT_catalog").toLowerCase();
   public static final String schemaName =
-      GravitinoITUtils.genRandomName("RangerHiveAuthIT_schema").toLowerCase();
-  public static final String tableName =
-      GravitinoITUtils.genRandomName("RangerHiveAuthIT_table").toLowerCase();
-
-  public static final String HIVE_COL_NAME1 = "hive_col_name1";
-  public static final String HIVE_COL_NAME2 = "hive_col_name2";
-  public static final String HIVE_COL_NAME3 = "hive_col_name3";
+      GravitinoITUtils.genRandomName("RangerHiveE2EIT_schema").toLowerCase();
 
   private static GravitinoMetalake metalake;
   private static Catalog catalog;
   private static final String provider = "hive";
   private static String HIVE_METASTORE_URIS;
 
+  private static SparkSession sparkSession = null;
+  private final AuditInfo auditInfo =
+      AuditInfo.builder().withCreator("test").withCreateTime(Instant.now()).build();
+  private static final String HADOOP_USER_NAME = "HADOOP_USER_NAME";
+  private static final String TEST_USER_NAME = "e2e_it_user";
+
+  private static final String SQL_SHOW_DATABASES =
+      String.format("SHOW DATABASES like '%s'", schemaName);
+
+  private static String RANGER_ADMIN_URL = null;
+
   @BeforeAll
   public static void startIntegrationTest() throws Exception {
+    // Enable Gravitino Authorization mode
     Map<String, String> configs = Maps.newHashMap();
     configs.put(Configs.ENABLE_AUTHORIZATION.getKey(), String.valueOf(true));
-    configs.put(Configs.SERVICE_ADMINS.getKey(), AuthConstants.ANONYMOUS_USER);
+    configs.put(Configs.SERVICE_ADMINS.getKey(), RangerITEnv.HADOOP_USER_NAME);
+    configs.put(Configs.AUTHENTICATORS.getKey(), AuthenticatorType.SIMPLE.name().toLowerCase());
+    configs.put("SimpleAuthUserName", TEST_USER_NAME);
     registerCustomConfigs(configs);
     AbstractIT.startIntegrationTest();
 
     RangerITEnv.setup();
-    containerSuite.startHiveContainer();
+    RangerITEnv.startHiveRangerContainer();
+
+    RANGER_ADMIN_URL =
+        String.format(
+            "http://%s:%d",
+            containerSuite.getRangerContainer().getContainerIpAddress(), RANGER_SERVER_PORT);
+
     HIVE_METASTORE_URIS =
         String.format(
             "thrift://%s:%d",
-            containerSuite.getHiveContainer().getContainerIpAddress(),
+            containerSuite.getHiveRangerContainer().getContainerIpAddress(),
             HiveContainer.HIVE_METASTORE_PORT);
+
+    generateRangerSparkSecurityXML();
+
+    sparkSession =
+        SparkSession.builder()
+            .master("local[1]")
+            .appName("Ranger Hive E2E integration test")
+            .config("hive.metastore.uris", HIVE_METASTORE_URIS)
+            .config(
+                "spark.sql.warehouse.dir",
+                String.format(
+                    "hdfs://%s:%d/user/hive/warehouse",
+                    containerSuite.getHiveRangerContainer().getContainerIpAddress(),
+                    HiveContainer.HDFS_DEFAULTFS_PORT))
+            .config("spark.sql.storeAssignmentPolicy", "LEGACY")
+            .config("mapreduce.input.fileinputformat.input.dir.recursive", "true")
+            .config(
+                "spark.sql.extensions",
+                "org.apache.kyuubi.plugin.spark.authz.ranger.RangerSparkExtension")
+            .enableHiveSupport()
+            .getOrCreate();
 
     createMetalake();
     createCatalogAndRangerAuthPlugin();
-    createSchema();
-    createHiveTable();
+  }
+
+  private static void generateRangerSparkSecurityXML() throws IOException {
+    String templatePath =
+        String.join(
+            File.separator,
+            System.getenv("GRAVITINO_ROOT_DIR"),
+            "authorizations",
+            "authorization-ranger",
+            "src",
+            "test",
+            "resources",
+            "ranger-spark-security.xml.template");
+    String xmlPath =
+        String.join(
+            File.separator,
+            System.getenv("GRAVITINO_ROOT_DIR"),
+            "authorizations",
+            "authorization-ranger",
+            "build",
+            "resources",
+            "test",
+            "ranger-spark-security.xml");
+
+    String templateContext =
+        FileUtils.readFileToString(new File(templatePath), StandardCharsets.UTF_8);
+    templateContext =
+        templateContext
+            .replace("__REPLACE__RANGER_ADMIN_URL", RANGER_ADMIN_URL)
+            .replace("__REPLACE__RANGER_HIVE_REPO_NAME", RangerITEnv.RANGER_HIVE_REPO_NAME);
+    FileUtils.writeStringToFile(new File(xmlPath), templateContext, StandardCharsets.UTF_8);
   }
 
   @AfterAll
   public static void stop() throws IOException {
+    if (client != null) {
+      Arrays.stream(catalog.asSchemas().listSchemas())
+          .filter(schema -> !schema.equals("default"))
+          .forEach(
+              (schema -> {
+                catalog.asSchemas().dropSchema(schema, true);
+              }));
+      Arrays.stream(metalake.listCatalogs())
+          .forEach(
+              (catalogName -> {
+                metalake.dropCatalog(catalogName);
+              }));
+      client.dropMetalake(metalakeName);
+    }
+    if (sparkSession != null) {
+      sparkSession.close();
+    }
+    try {
+      closer.close();
+    } catch (Exception e) {
+      LOG.error("Failed to close CloseableGroup", e);
+    }
+
     AbstractIT.client = null;
   }
 
   @Test
-  void testCreateRole() {
-    String roleName = RangerITEnv.currentFunName();
-    Map<String, String> properties = Maps.newHashMap();
-    properties.put("k1", "v1");
+  void testAllowUseSchemaPrivilege() throws InterruptedException {
+    // First, create a schema use Gravitino client
+    createSchema();
 
-    SecurableObject table1 =
+    // Use Spark to show this databases(schema)
+    Dataset dataset1 = sparkSession.sql(SQL_SHOW_DATABASES);
+    dataset1.show();
+    List<Row> rows1 = dataset1.collectAsList();
+    // The schema should not be shown, because the user does not have the permission
+    Assertions.assertEquals(
+        0, rows1.stream().filter(row -> row.getString(0).equals(schemaName)).count());
+
+    // Create a role with CREATE_SCHEMA privilege
+    SecurableObject securableObject1 =
         SecurableObjects.parse(
-            String.format("%s.%s.%s", catalogName, schemaName, tableName),
-            MetadataObject.Type.TABLE,
-            Lists.newArrayList(Privileges.SelectTable.allow()));
-    Role role = metalake.createRole(roleName, properties, Lists.newArrayList(table1));
-    RangerITEnv.verifyRoleInRanger(rangerAuthPlugin, role);
+            String.format("%s.%s", catalogName, schemaName),
+            MetadataObject.Type.SCHEMA,
+            Lists.newArrayList(Privileges.CreateSchema.allow()));
+    RoleEntity role =
+        RoleEntity.builder()
+            .withId(1L)
+            .withName(currentFunName())
+            .withAuditInfo(auditInfo)
+            .withSecurableObjects(Lists.newArrayList(securableObject1))
+            .build();
+    rangerAuthPlugin.onRoleCreated(role);
+
+    // Granted this role to the spark execution user `HADOOP_USER_NAME`
+    String userName1 = System.getenv(HADOOP_USER_NAME);
+    UserEntity userEntity1 =
+        UserEntity.builder()
+            .withId(1L)
+            .withName(userName1)
+            .withRoleNames(Collections.emptyList())
+            .withRoleIds(Collections.emptyList())
+            .withAuditInfo(auditInfo)
+            .build();
+    Assertions.assertTrue(
+        rangerAuthPlugin.onGrantedRolesToUser(Lists.newArrayList(role), userEntity1));
+
+    // After Ranger Authorization, Must wait a period of time for the Ranger Spark plugin to update
+    // the policy Sleep time must be greater than the policy update interval
+    // (ranger.plugin.spark.policy.pollIntervalMs) in the
+    // `resources/ranger-spark-security.xml.template`
+    Thread.sleep(1000L);
+
+    // Use Spark to show this databases(schema) again
+    Dataset dataset2 = sparkSession.sql(SQL_SHOW_DATABASES);
+    dataset2.show(100, 100);
+    List<Row> rows2 = dataset2.collectAsList();
+    rows2.stream()
+        .filter(row -> row.getString(0).equals(schemaName))
+        .findFirst()
+        .orElseThrow(() -> new IllegalStateException("Database not found: " + schemaName));
+    // The schema should be shown, because the user has the permission
+    Assertions.assertEquals(
+        1, rows2.stream().filter(row -> row.getString(0).equals(schemaName)).count());
   }
 
   private static void createMetalake() {
@@ -153,31 +284,34 @@ public class RangerHiveE2EIT extends AbstractIT {
         RangerAuthorizationHivePlugin.getInstance(
             ImmutableMap.of(
                 AuthorizationPropertiesMeta.RANGER_ADMIN_URL,
-                String.format(
-                    "http://%s:%d",
-                    containerSuite.getRangerContainer().getContainerIpAddress(),
-                    RangerContainer.RANGER_SERVER_PORT),
-                AuthorizationPropertiesMeta.RANGER_AUTH_TYPE,
+                RANGER_ADMIN_URL,
+                RANGER_AUTH_TYPE,
                 RangerContainer.authType,
-                AuthorizationPropertiesMeta.RANGER_USERNAME,
+                RANGER_USERNAME,
                 RangerContainer.rangerUserName,
-                AuthorizationPropertiesMeta.RANGER_PASSWORD,
+                RANGER_PASSWORD,
                 RangerContainer.rangerPassword,
-                AuthorizationPropertiesMeta.RANGER_SERVICE_NAME,
+                RANGER_SERVICE_NAME,
                 RangerITEnv.RANGER_HIVE_REPO_NAME));
 
-    Map<String, String> properties = Maps.newHashMap();
-    properties.put(HiveConstants.METASTORE_URIS, HIVE_METASTORE_URIS);
-    properties.put(AUTHORIZATION_PROVIDER, "ranger");
-    properties.put(RANGER_SERVICE_NAME, RangerITEnv.RANGER_HIVE_REPO_NAME);
-    properties.put(
-        RANGER_ADMIN_URL,
-        String.format(
-            "http://localhost:%s",
-            containerSuite.getRangerContainer().getMappedPort(RANGER_SERVER_PORT)));
-    properties.put(RANGER_AUTH_TYPE, RangerContainer.authType);
-    properties.put(RANGER_USERNAME, RangerContainer.rangerUserName);
-    properties.put(RANGER_PASSWORD, RangerContainer.rangerPassword);
+    Map<String, String> properties =
+        ImmutableMap.of(
+            HiveConstants.METASTORE_URIS,
+            HIVE_METASTORE_URIS,
+            IMPERSONATION_ENABLE,
+            "true",
+            AUTHORIZATION_PROVIDER,
+            "ranger",
+            RANGER_SERVICE_NAME,
+            RangerITEnv.RANGER_HIVE_REPO_NAME,
+            AuthorizationPropertiesMeta.RANGER_ADMIN_URL,
+            RANGER_ADMIN_URL,
+            RANGER_AUTH_TYPE,
+            RangerContainer.authType,
+            RANGER_USERNAME,
+            RangerContainer.rangerUserName,
+            RANGER_PASSWORD,
+            RangerContainer.rangerPassword);
 
     metalake.createCatalog(catalogName, Catalog.Type.RELATIONAL, provider, "comment", properties);
     catalog = metalake.loadCatalog(catalogName);
@@ -192,7 +326,7 @@ public class RangerHiveE2EIT extends AbstractIT {
         "location",
         String.format(
             "hdfs://%s:%d/user/hive/warehouse/%s.db",
-            containerSuite.getHiveContainer().getContainerIpAddress(),
+            containerSuite.getHiveRangerContainer().getContainerIpAddress(),
             HiveContainer.HDFS_DEFAULTFS_PORT,
             schemaName.toLowerCase()));
     String comment = "comment";
@@ -200,43 +334,5 @@ public class RangerHiveE2EIT extends AbstractIT {
     catalog.asSchemas().createSchema(schemaName, comment, properties);
     Schema loadSchema = catalog.asSchemas().loadSchema(schemaName);
     Assertions.assertEquals(schemaName.toLowerCase(), loadSchema.name());
-  }
-
-  public static void createHiveTable() {
-    // Create table from Gravitino API
-    Column[] columns = createColumns();
-    NameIdentifier nameIdentifier = NameIdentifier.of(schemaName, tableName);
-
-    Distribution distribution =
-        Distributions.of(Strategy.EVEN, 10, NamedReference.field(HIVE_COL_NAME1));
-
-    final SortOrder[] sortOrders =
-        new SortOrder[] {
-          SortOrders.of(
-              NamedReference.field(HIVE_COL_NAME2),
-              SortDirection.DESCENDING,
-              NullOrdering.NULLS_FIRST)
-        };
-
-    Map<String, String> properties = ImmutableMap.of("key1", "val1", "key2", "val2");
-    Table createdTable =
-        catalog
-            .asTableCatalog()
-            .createTable(
-                nameIdentifier,
-                columns,
-                "table_comment",
-                properties,
-                Transforms.EMPTY_TRANSFORM,
-                distribution,
-                sortOrders);
-    LOG.info("Table created: {}", createdTable);
-  }
-
-  private static Column[] createColumns() {
-    Column col1 = Column.of(HIVE_COL_NAME1, Types.ByteType.get(), "col_1_comment");
-    Column col2 = Column.of(HIVE_COL_NAME2, Types.DateType.get(), "col_2_comment");
-    Column col3 = Column.of(HIVE_COL_NAME3, Types.StringType.get(), "col_3_comment");
-    return new Column[] {col1, col2, col3};
   }
 }

--- a/authorizations/authorization-ranger/src/test/resources/log4j2.properties
+++ b/authorizations/authorization-ranger/src/test/resources/log4j2.properties
@@ -1,0 +1,73 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# Set to debug or trace if log4j initialization is failing
+status = info
+
+# Name of the configuration
+name = ConsoleLogConfig
+
+# Console appender configuration
+appender.console.type = Console
+appender.console.name = consoleLogger
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} %-5p [%t] %c{1}:%L - %m%n
+
+# Log files location
+property.logPath = ${sys:gravitino.log.path:-build/authorization-ranger-integration-test.log}
+
+# File appender configuration
+appender.file.type = File
+appender.file.name = fileLogger
+appender.file.fileName = ${logPath}
+appender.file.layout.type = PatternLayout
+appender.file.layout.pattern = %d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %-5p %c - %m%n
+
+# Root logger level
+rootLogger.level = info
+
+# Root logger referring to console and file appenders
+rootLogger.appenderRef.stdout.ref = consoleLogger
+rootLogger.appenderRef.file.ref = fileLogger
+
+# File appender configuration for testcontainers
+appender.testcontainersFile.type = File
+appender.testcontainersFile.name = testcontainersLogger
+appender.testcontainersFile.fileName = build/testcontainers.log
+appender.testcontainersFile.layout.type = PatternLayout
+appender.testcontainersFile.layout.pattern = %d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %-5p %c - %m%n
+
+# Logger for testcontainers
+logger.testcontainers.name = org.testcontainers
+logger.testcontainers.level = debug
+logger.testcontainers.additivity = false
+logger.testcontainers.appenderRef.file.ref = testcontainersLogger
+
+logger.tc.name = tc
+logger.tc.level = debug
+logger.tc.additivity = false
+logger.tc.appenderRef.file.ref = testcontainersLogger
+
+logger.docker.name = com.github.dockerjava
+logger.docker.level = warn
+logger.docker.additivity = false
+logger.docker.appenderRef.file.ref = testcontainersLogger
+
+logger.http.name = com.github.dockerjava.zerodep.shaded.org.apache.hc.client5.http.wire
+logger.http.level = off

--- a/authorizations/authorization-ranger/src/test/resources/ranger-spark-security.xml.template
+++ b/authorizations/authorization-ranger/src/test/resources/ranger-spark-security.xml.template
@@ -1,0 +1,45 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+  -->
+<configuration>
+    <property>
+        <name>ranger.plugin.spark.policy.rest.url</name>
+        <value>__REPLACE__RANGER_ADMIN_URL</value>
+    </property>
+
+    <property>
+        <name>ranger.plugin.spark.service.name</name>
+        <value>__REPLACE__RANGER_HIVE_REPO_NAME</value>
+    </property>
+
+    <property>
+        <name>ranger.plugin.spark.policy.cache.dir</name>
+        <value>/tmp/policycache</value>
+    </property>
+
+    <property>
+        <name>ranger.plugin.spark.policy.pollIntervalMs</name>
+        <value>500</value>
+    </property>
+
+    <property>
+        <name>ranger.plugin.spark.policy.source.impl</name>
+        <value>org.apache.ranger.admin.client.RangerAdminRESTClient</value>
+    </property>
+
+</configuration>

--- a/integration-test-common/build.gradle.kts
+++ b/integration-test-common/build.gradle.kts
@@ -32,7 +32,6 @@ dependencies {
   testImplementation(project(":core"))
   testImplementation(project(":server"))
   testImplementation(project(":server-common"))
-  testImplementation(project(":authorizations:authorization-ranger"))
   testImplementation(libs.bundles.jetty)
   testImplementation(libs.bundles.jersey)
   testImplementation(libs.bundles.jwt)

--- a/integration-test-common/src/test/java/org/apache/gravitino/integration/test/container/RangerContainer.java
+++ b/integration-test-common/src/test/java/org/apache/gravitino/integration/test/container/RangerContainer.java
@@ -25,7 +25,7 @@ import com.google.common.collect.ImmutableSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import org.apache.gravitino.authorization.ranger.RangerClientExtension;
+import org.apache.ranger.RangerClient;
 import org.apache.ranger.RangerServiceException;
 import org.rnorth.ducttape.Preconditions;
 import org.slf4j.Logger;
@@ -38,7 +38,7 @@ public class RangerContainer extends BaseContainer {
   public static final String DEFAULT_IMAGE = System.getenv("GRAVITINO_CI_RANGER_DOCKER_IMAGE");
   public static final String HOST_NAME = "gravitino-ci-ranger";
   public static final int RANGER_SERVER_PORT = 6080;
-  public RangerClientExtension rangerClient;
+  public RangerClient rangerClient;
   private String rangerUrl;
 
   /**
@@ -83,7 +83,7 @@ public class RangerContainer extends BaseContainer {
     super.start();
 
     rangerUrl = String.format("http://localhost:%s", this.getMappedPort(RANGER_SERVER_PORT));
-    rangerClient = new RangerClientExtension(rangerUrl, authType, rangerUserName, rangerPassword);
+    rangerClient = new RangerClient(rangerUrl, authType, rangerUserName, rangerPassword, null);
 
     Preconditions.check("Ranger container startup failed!", checkContainerStatus(10));
   }

--- a/integration-test-common/src/test/java/org/apache/gravitino/integration/test/util/AbstractIT.java
+++ b/integration-test-common/src/test/java/org/apache/gravitino/integration/test/util/AbstractIT.java
@@ -340,7 +340,12 @@ public class AbstractIT {
     if (authenticators.contains(AuthenticatorType.OAUTH.name().toLowerCase())) {
       client = GravitinoAdminClient.builder(serverUri).withOAuth(mockDataProvider).build();
     } else if (authenticators.contains(AuthenticatorType.SIMPLE.name().toLowerCase())) {
-      client = GravitinoAdminClient.builder(serverUri).withSimpleAuth().build();
+      String userName = customConfigs.get("SimpleAuthUserName");
+      if (userName != null) {
+        client = GravitinoAdminClient.builder(serverUri).withSimpleAuth(userName).build();
+      } else {
+        client = GravitinoAdminClient.builder(serverUri).withSimpleAuth().build();
+      }
     } else if (authenticators.contains(AuthenticatorType.KERBEROS.name().toLowerCase())) {
       serverUri = "http://localhost:" + jettyServerConfig.getHttpPort();
       client = null;


### PR DESCRIPTION
### What changes were proposed in this pull request?

1. Shadow integration-test-common module.
2. Add Ranger authorization Hive IT, use Spark to verify Ranger authorization Hive.

### Why are the changes needed?

Fix: #4759

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

CI Passed.