### PR TITLE
[apache#4960] fix(server): hive metastore authentication failed when checking whether securable object exists in createRole() method

### DIFF
--- a/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/RangerAuthorizationPlugin.java
+++ b/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/RangerAuthorizationPlugin.java
@@ -383,7 +383,7 @@ public class RangerAuthorizationPlugin implements AuthorizationPlugin {
 
   @Override
   public Boolean onGroupAdded(Group group) throws RuntimeException {
-    return rangerClient.createGroup(VXGroup.builder().withName(group.name()).build());
+    return rangerClient.createGroup(VXGroup.builder().withName(group.name()).withDescription(group.name()).build());
   }
 
   @Override

--- a/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/reference/VXGroup.java
+++ b/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/reference/VXGroup.java
@@ -91,6 +91,11 @@ public class VXGroup extends VXDataObject implements java.io.Serializable {
       return this;
     }
 
+    public Builder withDescription(String description) {
+      vxGroup.description = description;
+      return this;
+    }
+
     public VXGroup build() {
       return vxGroup;
     }

--- a/server/src/main/java/org/apache/gravitino/server/web/rest/RoleOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/RoleOperations.java
@@ -96,14 +96,12 @@ public class RoleOperations {
   @ResponseMetered(name = "create-role", absolute = true)
   public Response createRole(@PathParam("metalake") String metalake, RoleCreateRequest request) {
     try {
-
-      for (SecurableObjectDTO object : request.getSecurableObjects()) {
-        checkSecurableObject(metalake, object);
-      }
-
       return Utils.doAs(
           httpRequest,
           () -> {
+            for (SecurableObjectDTO object : request.getSecurableObjects()) {
+              checkSecurableObject(metalake, object);
+            }
             List<SecurableObject> securableObjects =
                 Arrays.stream(request.getSecurableObjects())
                     .map(


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

put the check code into the code block Utils.doAs.

### Why are the changes needed?

Fix: #4960

### Does this PR introduce _any_ user-facing change?

Passing identity authentication information when checking hive resource

### How was this patch tested?

yes,finish functional test , based on the hive meatasotre with kerberos authentication enabled
