### PR TITLE
[#4960] fix(server): hive metastore authentication failed when checking whether securable object exists in createRole() method

### DIFF
--- a/server/src/main/java/org/apache/gravitino/server/web/rest/RoleOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/RoleOperations.java
@@ -96,14 +96,12 @@ public class RoleOperations {
   @ResponseMetered(name = "create-role", absolute = true)
   public Response createRole(@PathParam("metalake") String metalake, RoleCreateRequest request) {
     try {
-
-      for (SecurableObjectDTO object : request.getSecurableObjects()) {
-        checkSecurableObject(metalake, object);
-      }
-
       return Utils.doAs(
           httpRequest,
           () -> {
+            for (SecurableObjectDTO object : request.getSecurableObjects()) {
+              checkSecurableObject(metalake, object);
+            }
             List<SecurableObject> securableObjects =
                 Arrays.stream(request.getSecurableObjects())
                     .map(


### PR DESCRIPTION
### What changes were proposed in this pull request?

put the check code into the code block Utils.doAs.

### Why are the changes needed?

Fix: #4960 

### Does this PR introduce _any_ user-facing change?

Passing identity authentication information when checking hive resource

### How was this patch tested?

yes,finish functional test By hand, based on the hive meatasotre with kerberos authentication enabled

