### PR TITLE
fix(authorization-ranger):the descr field of ranger table x_group is not null

### DIFF
--- a/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/RangerAuthorizationPlugin.java
+++ b/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/RangerAuthorizationPlugin.java
@@ -383,7 +383,8 @@ public abstract class RangerAuthorizationPlugin
 
   @Override
   public Boolean onGroupAdded(Group group) throws RuntimeException {
-    return rangerClient.createGroup(VXGroup.builder().withName(group.name()).withDescription(group.name()).build());
+    return rangerClient.createGroup(
+        VXGroup.builder().withName(group.name()).withDescription(group.name()).build());
   }
 
   @Override

--- a/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/RangerAuthorizationPlugin.java
+++ b/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/RangerAuthorizationPlugin.java
@@ -383,7 +383,7 @@ public abstract class RangerAuthorizationPlugin
 
   @Override
   public Boolean onGroupAdded(Group group) throws RuntimeException {
-    return rangerClient.createGroup(VXGroup.builder().withName(group.name()).build());
+    return rangerClient.createGroup(VXGroup.builder().withName(group.name()).withDescription(group.name()).build());
   }
 
   @Override

--- a/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/reference/VXGroup.java
+++ b/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/reference/VXGroup.java
@@ -91,6 +91,11 @@ public class VXGroup extends VXDataObject implements java.io.Serializable {
       return this;
     }
 
+    public Builder withDescription(String description) {
+      vxGroup.description = description;
+      return this;
+    }
+
     public VXGroup build() {
       return vxGroup;
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?

When calling the ranger CREATE_GROUP api, the desc field cannot be null

### Why are the changes needed?

When calling the ranger CREATE_GROUP api,  ranger response is error.

### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

yes, by hand.
