### PR TITLE
[#4984] improvement(core, doris): Add the random distribution strategy

### DIFF
--- a/api/src/main/java/org/apache/gravitino/rel/expressions/distributions/Distributions.java
+++ b/api/src/main/java/org/apache/gravitino/rel/expressions/distributions/Distributions.java
@@ -63,6 +63,17 @@ public class Distributions {
   }
 
   /**
+   * Create a distribution by randomly distributing the data across the number of buckets.
+   *
+   * @param number The number of buckets
+   * @param expressions The expressions to distribute by
+   * @return The created random distribution
+   */
+  public static Distribution random(int number, Expression... expressions) {
+    return new DistributionImpl(Strategy.RANDOM, number, expressions);
+  }
+
+  /**
    * Create a distribution by the given strategy.
    *
    * @param strategy The strategy to use

--- a/api/src/main/java/org/apache/gravitino/rel/expressions/distributions/Strategy.java
+++ b/api/src/main/java/org/apache/gravitino/rel/expressions/distributions/Strategy.java
@@ -50,7 +50,10 @@ public enum Strategy {
   RANGE,
 
   /** Distributes data evenly across partitions. */
-  EVEN;
+  EVEN,
+
+  /** Distributes data randomly across partitions or table. */
+  RANDOM;
 
   /**
    * Get the distribution strategy by name.

--- a/catalogs/catalog-jdbc-doris/src/main/java/org/apache/gravitino/catalog/doris/operation/DorisTableOperations.java
+++ b/catalogs/catalog-jdbc-doris/src/main/java/org/apache/gravitino/catalog/doris/operation/DorisTableOperations.java
@@ -150,7 +150,7 @@ public class DorisTableOperations extends JdbcTableOperations {
               .map(column -> BACK_QUOTE + column.toString() + BACK_QUOTE)
               .collect(Collectors.joining(", ")));
       sqlBuilder.append(")");
-    } else if (distribution.strategy() == Strategy.EVEN) {
+    } else if (distribution.strategy() == Strategy.RANDOM) {
       sqlBuilder.append(NEW_LINE).append(" DISTRIBUTED BY ").append("RANDOM");
     }
 
@@ -220,8 +220,8 @@ public class DorisTableOperations extends JdbcTableOperations {
     Preconditions.checkArgument(null != distribution, "Doris must set distribution");
 
     Preconditions.checkArgument(
-        Strategy.HASH == distribution.strategy() || Strategy.EVEN == distribution.strategy(),
-        "Doris only supports HASH or EVEN distribution strategy");
+        Strategy.HASH == distribution.strategy() || Strategy.RANDOM == distribution.strategy(),
+        "Doris only supports HASH or RANDOM distribution strategy");
 
     if (distribution.strategy() == Strategy.HASH) {
       // Check if the distribution column exists

--- a/catalogs/catalog-jdbc-doris/src/test/java/org/apache/gravitino/catalog/doris/operation/TestDorisTableOperations.java
+++ b/catalogs/catalog-jdbc-doris/src/test/java/org/apache/gravitino/catalog/doris/operation/TestDorisTableOperations.java
@@ -95,6 +95,43 @@ public class TestDorisTableOperations extends TestDoris {
   }
 
   @Test
+  void testRandomDistribution() {
+    String tableName = GravitinoITUtils.genRandomName("doris_basic_test_table");
+    String tableComment = "test_comment";
+    List<JdbcColumn> columns = new ArrayList<>();
+    JdbcColumn col_1 =
+        JdbcColumn.builder().withName("col_1").withType(INT).withComment("id").build();
+    columns.add(col_1);
+    JdbcColumn col_2 =
+        JdbcColumn.builder().withName("col_2").withType(VARCHAR_255).withComment("col_2").build();
+    columns.add(col_2);
+    JdbcColumn col_3 =
+        JdbcColumn.builder().withName("col_3").withType(VARCHAR_255).withComment("col_3").build();
+    columns.add(col_3);
+    Map<String, String> properties = new HashMap<>();
+
+    Distribution distribution =
+        Distributions.random(DEFAULT_BUCKET_SIZE, NamedReference.field("col_1"));
+    Index[] indexes = new Index[] {};
+
+    // create table
+    TABLE_OPERATIONS.create(
+        databaseName,
+        tableName,
+        columns.toArray(new JdbcColumn[0]),
+        tableComment,
+        createProperties(),
+        null,
+        distribution,
+        indexes);
+    List<String> listTables = TABLE_OPERATIONS.listTables(databaseName);
+    assertTrue(listTables.contains(tableName));
+    JdbcTable load = TABLE_OPERATIONS.load(databaseName, tableName);
+    assertionsTableInfo(
+        tableName, tableComment, columns, properties, indexes, Transforms.EMPTY_TRANSFORM, load);
+  }
+
+  @Test
   public void testBasicTableOperation() {
     String tableName = GravitinoITUtils.genRandomName("doris_basic_test_table");
     String tableComment = "test_comment";


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add the random strategy instead of `even` for Distribution

### Why are the changes needed?

Doris support `random` distribution instead of `even`. This PR is a part of the fix for https://github.com/datastrato/unified-catalog-ui/issues/45#event-14337721711

Fix: #4984 

### Does this PR introduce _any_ user-facing change?

N/A.

### How was this patch tested?

IT