### PR TITLE
[#4959] feat(Iceberg): support Iceberg REST extend API

### DIFF
--- a/docs/iceberg-rest-service.md
+++ b/docs/iceberg-rest-service.md
@@ -75,7 +75,6 @@ Please note that, it only takes affect in `gravitino.conf`, you don't need to sp
 | `gravitino.iceberg-rest.responseHeaderSize`      | The maximum size of an HTTP response.                                                                                                                                                                                                                | `131072`                                                                     | No       | 0.2.0         |
 | `gravitino.iceberg-rest.customFilters`           | Comma-separated list of filter class names to apply to the APIs.                                                                                                                                                                                     | (none)                                                                       | No       | 0.4.0         |
 
-
 The filter in `customFilters` should be a standard javax servlet filter.
 You can also specify filter parameters by setting configuration entries in the style `gravitino.iceberg-rest.<class name of filter>.param.<param name>=<value>`.
 
@@ -301,6 +300,13 @@ Gravitino provides a pluggable metrics store interface to store and delete Icebe
 | `gravitino.iceberg-rest.metricsStore`           | The Iceberg metrics storage class name.                                                                                             | (none)        | No       | 0.4.0         |
 | `gravitino.iceberg-rest.metricsStoreRetainDays` | The days to retain Iceberg metrics in store, the value not greater than 0 means retain forever.                                     | -1            | No       | 0.4.0         |
 | `gravitino.iceberg-rest.metricsQueueCapacity`   | The size of queue to store metrics temporally before storing to the persistent storage. Metrics will be dropped when queue is full. | 1000          | No       | 0.4.0         |
+
+### Misc configurations
+
+| Configuration item                          | Description                                                  | Default value | Required | Since Version |
+|---------------------------------------------|--------------------------------------------------------------|---------------|----------|---------------|
+| `gravitino.iceberg-rest.extension-packages` | Comma-separated list of Iceberg REST API packages to expand. | (none)        | No       | 0.7.0         |
+
 
 ## Starting the Iceberg REST server
 

--- a/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/IcebergConfig.java
+++ b/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/IcebergConfig.java
@@ -20,6 +20,8 @@
 package org.apache.gravitino.iceberg.common;
 
 import com.google.common.collect.ImmutableMap;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import org.apache.commons.lang3.StringUtils;
@@ -221,6 +223,14 @@ public class IcebergConfig extends Config implements OverwriteDefaultConfig {
           .version(ConfigConstants.VERSION_0_7_0)
           .stringConf()
           .create();
+
+  public static final ConfigEntry<List<String>> REST_API_EXTENSION_PACKAGES =
+      new ConfigBuilder("extension-packages")
+          .doc("Comma-separated list of Iceberg REST API packages to expand")
+          .version(ConfigConstants.VERSION_0_7_0)
+          .stringConf()
+          .toSequence()
+          .createWithDefault(Collections.emptyList());
 
   public String getJdbcDriver() {
     return get(JDBC_DRIVER);

--- a/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/IcebergConfig.java
+++ b/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/IcebergConfig.java
@@ -19,6 +19,7 @@
 
 package org.apache.gravitino.iceberg.common;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import java.util.Collections;
 import java.util.List;
@@ -38,6 +39,7 @@ import org.apache.gravitino.storage.S3Properties;
 public class IcebergConfig extends Config implements OverwriteDefaultConfig {
 
   public static final String ICEBERG_CONFIG_PREFIX = "gravitino.iceberg-rest.";
+  @VisibleForTesting public static final String ICEBERG_EXTENSION_PACKAGES = "extension-packages";
 
   public static final int DEFAULT_ICEBERG_REST_SERVICE_HTTP_PORT = 9001;
   public static final int DEFAULT_ICEBERG_REST_SERVICE_HTTPS_PORT = 9433;
@@ -225,7 +227,7 @@ public class IcebergConfig extends Config implements OverwriteDefaultConfig {
           .create();
 
   public static final ConfigEntry<List<String>> REST_API_EXTENSION_PACKAGES =
-      new ConfigBuilder("extension-packages")
+      new ConfigBuilder(ICEBERG_EXTENSION_PACKAGES)
           .doc("Comma-separated list of Iceberg REST API packages to expand")
           .version(ConfigConstants.VERSION_0_7_0)
           .stringConf()

--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/RESTService.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/RESTService.java
@@ -18,6 +18,8 @@
  */
 package org.apache.gravitino.iceberg;
 
+import com.google.common.collect.Lists;
+import java.util.List;
 import java.util.Map;
 import javax.servlet.Servlet;
 import org.apache.gravitino.GravitinoEnv;
@@ -47,6 +49,8 @@ public class RESTService implements GravitinoAuxiliaryService {
 
   public static final String SERVICE_NAME = "iceberg-rest";
   public static final String ICEBERG_SPEC = "/iceberg/*";
+  private static final String ICEBERG_REST_SPEC_PACKAGE =
+      "org.apache.gravitino.iceberg.service.rest";
 
   private IcebergCatalogWrapperManager icebergCatalogWrapperManager;
   private IcebergMetricsManager icebergMetricsManager;
@@ -58,7 +62,7 @@ public class RESTService implements GravitinoAuxiliaryService {
     server.initialize(serverConfig, SERVICE_NAME, false /* shouldEnableUI */);
 
     ResourceConfig config = new ResourceConfig();
-    config.packages("org.apache.gravitino.iceberg.service.rest");
+    config.packages(getIcebergRESTPackages(icebergConfig));
 
     config.register(IcebergObjectMapperProvider.class).register(JacksonFeature.class);
     config.register(IcebergExceptionMapper.class);
@@ -126,5 +130,11 @@ public class RESTService implements GravitinoAuxiliaryService {
     if (server != null) {
       server.join();
     }
+  }
+
+  private String[] getIcebergRESTPackages(IcebergConfig icebergConfig) {
+    List<String> packages = Lists.newArrayList(ICEBERG_REST_SPEC_PACKAGE);
+    packages.addAll(icebergConfig.get(IcebergConfig.REST_API_EXTENSION_PACKAGES));
+    return packages.toArray(new String[0]);
   }
 }

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/integration/test/TestIcebergExtendAPI.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/integration/test/TestIcebergExtendAPI.java
@@ -53,7 +53,6 @@ public class TestIcebergExtendAPI {
     this.icebergRESTServerManager = IcebergRESTServerManager.create();
     registerIcebergExtensionPackages();
     icebergRESTServerManager.startIcebergRESTServer();
-    icebergRESTServerManager.getServerConfig();
     this.uri = String.format("http://127.0.0.1:%d/iceberg", getServerPort());
     LOG.info("Gravitino Iceberg REST server started, uri: {}", uri);
   }

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/integration/test/TestIcebergExtendAPI.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/integration/test/TestIcebergExtendAPI.java
@@ -1,0 +1,92 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.apache.gravitino.iceberg.integration.test;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.gravitino.iceberg.common.IcebergConfig;
+import org.apache.gravitino.iceberg.integration.test.util.IcebergRESTServerManager;
+import org.apache.gravitino.iceberg.service.extension.HelloOperations;
+import org.apache.gravitino.iceberg.service.extension.HelloResponse;
+import org.apache.gravitino.server.web.JettyServerConfig;
+import org.apache.iceberg.rest.ErrorHandlers;
+import org.apache.iceberg.rest.HTTPClient;
+import org.apache.iceberg.rest.RESTClient;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.jupiter.api.condition.EnabledIf;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.shaded.com.google.common.collect.ImmutableMap;
+
+@TestInstance(Lifecycle.PER_CLASS)
+// We couldn't add REST extension package jar in deploy mode, so just test embedded mode.
+@EnabledIf("org.apache.gravitino.integration.test.util.ITUtils#isEmbedded")
+public class TestIcebergExtendAPI {
+  public static final Logger LOG = LoggerFactory.getLogger(TestIcebergExtendAPI.class);
+  private IcebergRESTServerManager icebergRESTServerManager;
+  private String uri;
+
+  @BeforeAll
+  void initIcebergTestEnv() throws Exception {
+    this.icebergRESTServerManager = IcebergRESTServerManager.create();
+    registerIcebergExtensionPackages();
+    icebergRESTServerManager.startIcebergRESTServer();
+    icebergRESTServerManager.getServerConfig();
+    this.uri = String.format("http://127.0.0.1:%d/iceberg", getServerPort());
+    LOG.info("Gravitino Iceberg REST server started, uri: {}", uri);
+  }
+
+  @AfterAll
+  void stopIcebergTestEnv() {
+    icebergRESTServerManager.stopIcebergRESTServer();
+  }
+
+  @Test
+  void testExtendAPI() {
+    RESTClient client = HTTPClient.builder(ImmutableMap.of()).uri(uri).build();
+    HelloResponse helloResponse =
+        client.get(
+            HelloOperations.HELLO_URI_PATH,
+            HelloResponse.class,
+            new HashMap<String, String>(),
+            ErrorHandlers.defaultErrorHandler());
+    Assertions.assertEquals(HelloOperations.HELLO_MSG, helloResponse.msg());
+  }
+
+  private void registerIcebergExtensionPackages() {
+    Map<String, String> config =
+        ImmutableMap.of(
+            IcebergConfig.ICEBERG_CONFIG_PREFIX + IcebergConfig.ICEBERG_EXTENSION_PACKAGES,
+            HelloOperations.class.getPackage().getName());
+    icebergRESTServerManager.registerCustomConfigs(config);
+  }
+
+  private int getServerPort() {
+    JettyServerConfig jettyServerConfig =
+        JettyServerConfig.fromConfig(
+            icebergRESTServerManager.getServerConfig(), IcebergConfig.ICEBERG_CONFIG_PREFIX);
+    return jettyServerConfig.getHttpPort();
+  }
+}

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/extension/HelloOperations.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/extension/HelloOperations.java
@@ -1,0 +1,49 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.apache.gravitino.iceberg.service.extension;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import org.apache.gravitino.iceberg.service.IcebergRestUtils;
+
+@Path("/hello")
+@Consumes(MediaType.APPLICATION_JSON)
+@Produces(MediaType.APPLICATION_JSON)
+public class HelloOperations {
+  public static final String HELLO_URI_PATH = "hello";
+
+  public static final String HELLO_MSG = "hello";
+
+  @SuppressWarnings("UnusedVariable")
+  @Context
+  private HttpServletRequest httpRequest;
+
+  @GET
+  @Produces(MediaType.APPLICATION_JSON)
+  public Response hello() {
+    return IcebergRestUtils.ok(new HelloResponse(HELLO_MSG));
+  }
+}

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/extension/HelloResponse.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/extension/HelloResponse.java
@@ -1,0 +1,41 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.apache.gravitino.iceberg.service.extension;
+
+import org.apache.iceberg.rest.RESTResponse;
+
+public class HelloResponse implements RESTResponse {
+
+  private String msg;
+
+  // Required for Jackson deserialization
+  public HelloResponse() {}
+
+  public HelloResponse(String msg) {
+    this.msg = msg;
+  }
+
+  @Override
+  public void validate() throws IllegalArgumentException {}
+
+  public String msg() {
+    return msg;
+  }
+}

--- a/integration-test-common/src/test/java/org/apache/gravitino/integration/test/util/ITUtils.java
+++ b/integration-test-common/src/test/java/org/apache/gravitino/integration/test/util/ITUtils.java
@@ -30,6 +30,7 @@ import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Properties;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.ArrayUtils;
@@ -173,6 +174,15 @@ public class ITUtils {
               ((IdentityPartitionDTO) expected).values(),
               ((IdentityPartitionDTO) actual).values()));
     }
+  }
+
+  public static boolean isEmbedded() {
+    String mode =
+        System.getProperty(TEST_MODE) == null
+            ? EMBEDDED_TEST_MODE
+            : System.getProperty(ITUtils.TEST_MODE);
+
+    return Objects.equals(mode, ITUtils.EMBEDDED_TEST_MODE);
   }
 
   private ITUtils() {}


### PR DESCRIPTION
### What changes were proposed in this pull request?

support Iceberg REST extend API

### Why are the changes needed?

Fix: #4959 

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
1.  add new operation classes with new URI PATH to `org.apache.gravitino.iceberg.service.rest2`
2. config `gravitino.iceberg-rest.extension-packages` to  `org.apache.gravitino.iceberg.service.rest2`
3. start Gravitino IcebergRESTServer
4. check new URI is accessable.