### PR TITLE
feat(oceanbase-catalog): Support schema operations for OceanBase JDBC catalog.

### DIFF
--- a/catalogs/catalog-jdbc-common/src/main/java/org/apache/gravitino/catalog/jdbc/operation/JdbcDatabaseOperations.java
+++ b/catalogs/catalog-jdbc-common/src/main/java/org/apache/gravitino/catalog/jdbc/operation/JdbcDatabaseOperations.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import javax.sql.DataSource;
+import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.gravitino.StringIdentifier;
 import org.apache.gravitino.catalog.jdbc.converter.JdbcExceptionConverter;
@@ -114,8 +115,15 @@ public abstract class JdbcDatabaseOperations implements DatabaseOperation {
    * @param properties The properties of the database.
    * @return the SQL statement to create a database with the given name and comment.
    */
-  protected abstract String generateCreateDatabaseSql(
-      String databaseName, String comment, Map<String, String> properties);
+  protected String generateCreateDatabaseSql(
+      String databaseName, String comment, Map<String, String> properties) {
+    String createDatabaseSql = String.format("CREATE DATABASE `%s`", databaseName);
+    if (MapUtils.isNotEmpty(properties)) {
+      throw new UnsupportedOperationException("Properties are not supported yet.");
+    }
+    LOG.info("Generated create database:{} sql: {}", databaseName, createDatabaseSql);
+    return createDatabaseSql;
+  }
 
   /**
    * @param databaseName The name of the database.
@@ -138,12 +146,6 @@ public abstract class JdbcDatabaseOperations implements DatabaseOperation {
     return false;
   }
 
-  /**
-   * Check whether support setting schema comment.
-   *
-   * @return true for all cases.
-   */
-  protected boolean supportSchemaComment() {
-    return true;
-  }
+  /** Check whether support setting schema comment. */
+  protected abstract boolean supportSchemaComment();
 }

--- a/catalogs/catalog-jdbc-common/src/main/java/org/apache/gravitino/catalog/jdbc/operation/JdbcDatabaseOperations.java
+++ b/catalogs/catalog-jdbc-common/src/main/java/org/apache/gravitino/catalog/jdbc/operation/JdbcDatabaseOperations.java
@@ -19,21 +19,27 @@
 
 package org.apache.gravitino.catalog.jdbc.operation;
 
+import com.google.common.collect.ImmutableMap;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import javax.sql.DataSource;
 import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.gravitino.StringIdentifier;
+import org.apache.gravitino.catalog.jdbc.JdbcSchema;
 import org.apache.gravitino.catalog.jdbc.converter.JdbcExceptionConverter;
 import org.apache.gravitino.catalog.jdbc.utils.JdbcConnectorUtils;
 import org.apache.gravitino.exceptions.NoSuchSchemaException;
 import org.apache.gravitino.exceptions.SchemaAlreadyExistsException;
+import org.apache.gravitino.meta.AuditInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -110,6 +116,9 @@ public abstract class JdbcDatabaseOperations implements DatabaseOperation {
   }
 
   /**
+   * The default implementation of this method is based on MySQL syntax, and if the catalog does not
+   * support MySQL syntax, this method needs to be rewritten.
+   *
    * @param databaseName The name of the database.
    * @param comment The comment of the database.
    * @param properties The properties of the database.
@@ -126,11 +135,61 @@ public abstract class JdbcDatabaseOperations implements DatabaseOperation {
   }
 
   /**
+   * The default implementation of this method is based on MySQL syntax, and if the catalog does not
+   * support MySQL syntax, this method needs to be rewritten.
+   *
    * @param databaseName The name of the database.
    * @param cascade cascade If set to true, drops all the tables in the schema as well.
    * @return the SQL statement to drop a database with the given name.
    */
-  protected abstract String generateDropDatabaseSql(String databaseName, boolean cascade);
+  protected String generateDropDatabaseSql(String databaseName, boolean cascade) {
+    final String dropDatabaseSql = String.format("DROP DATABASE `%s`", databaseName);
+    if (cascade) {
+      return dropDatabaseSql;
+    }
+
+    try (final Connection connection = this.dataSource.getConnection()) {
+      String query = String.format("SHOW TABLES IN `%s`", databaseName);
+      try (Statement statement = connection.createStatement()) {
+        // Execute the query and check if there exists any tables in the database
+        try (ResultSet resultSet = statement.executeQuery(query)) {
+          if (resultSet.next()) {
+            throw new IllegalStateException(
+                String.format(
+                    "Database %s is not empty, the value of cascade should be true.",
+                    databaseName));
+          }
+        }
+      }
+    } catch (SQLException sqlException) {
+      throw this.exceptionMapper.toGravitinoException(sqlException);
+    }
+    return dropDatabaseSql;
+  }
+
+  /**
+   * The default implementation of this method is based on MySQL syntax, and if the catalog does not
+   * support MySQL syntax, this method needs to be rewritten.
+   *
+   * @param databaseName The name of the database to check.
+   * @return information object of the JDBC database.
+   */
+  @Override
+  public JdbcSchema load(String databaseName) throws NoSuchSchemaException {
+    List<String> allDatabases = listDatabases();
+    String dbName =
+        allDatabases.stream()
+            .filter(db -> db.equals(databaseName))
+            .findFirst()
+            .orElseThrow(
+                () -> new NoSuchSchemaException("Database %s could not be found", databaseName));
+
+    return JdbcSchema.builder()
+        .withName(dbName)
+        .withProperties(ImmutableMap.of())
+        .withAuditInfo(AuditInfo.EMPTY)
+        .build();
+  }
 
   protected Connection getConnection() throws SQLException {
     return dataSource.getConnection();
@@ -140,12 +199,15 @@ public abstract class JdbcDatabaseOperations implements DatabaseOperation {
    * Check whether it is a system database.
    *
    * @param dbName The name of the database.
-   * @return false for all cases.
+   * @return whether it is a system database.
    */
   protected boolean isSystemDatabase(String dbName) {
-    return false;
+    return createSysDatabaseNameSet().contains(dbName.toLowerCase(Locale.ROOT));
   }
 
   /** Check whether support setting schema comment. */
   protected abstract boolean supportSchemaComment();
+
+  /** Create a set of system database names. */
+  protected abstract Set<String> createSysDatabaseNameSet();
 }

--- a/catalogs/catalog-jdbc-common/src/test/java/org/apache/gravitino/catalog/jdbc/operation/SqliteDatabaseOperations.java
+++ b/catalogs/catalog-jdbc-common/src/test/java/org/apache/gravitino/catalog/jdbc/operation/SqliteDatabaseOperations.java
@@ -24,9 +24,11 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.commons.io.FileUtils;
 import org.apache.gravitino.catalog.jdbc.JdbcSchema;
@@ -89,6 +91,16 @@ public class SqliteDatabaseOperations extends JdbcDatabaseOperations {
       return JdbcSchema.builder().withName(databaseName).withAuditInfo(AuditInfo.EMPTY).build();
     }
     return null;
+  }
+
+  @Override
+  protected boolean supportSchemaComment() {
+    return false;
+  }
+
+  @Override
+  protected Set<String> createSysDatabaseNameSet() {
+    return Collections.emptySet();
   }
 
   @Override

--- a/catalogs/catalog-jdbc-doris/src/main/java/org/apache/gravitino/catalog/doris/operation/DorisDatabaseOperations.java
+++ b/catalogs/catalog-jdbc-doris/src/main/java/org/apache/gravitino/catalog/doris/operation/DorisDatabaseOperations.java
@@ -140,4 +140,9 @@ public class DorisDatabaseOperations extends JdbcDatabaseOperations {
   protected boolean isSystemDatabase(String dbName) {
     return DORIS_SYSTEM_DATABASE_NAMES.contains(dbName);
   }
+
+  @Override
+  protected boolean supportSchemaComment() {
+    return true;
+  }
 }

--- a/catalogs/catalog-jdbc-doris/src/main/java/org/apache/gravitino/catalog/doris/operation/DorisDatabaseOperations.java
+++ b/catalogs/catalog-jdbc-doris/src/main/java/org/apache/gravitino/catalog/doris/operation/DorisDatabaseOperations.java
@@ -40,9 +40,6 @@ import org.apache.gravitino.meta.AuditInfo;
 public class DorisDatabaseOperations extends JdbcDatabaseOperations {
   public static final String COMMENT_KEY = "comment";
 
-  private static final Set<String> DORIS_SYSTEM_DATABASE_NAMES =
-      ImmutableSet.of("information_schema");
-
   @Override
   public String generateCreateDatabaseSql(
       String databaseName, String comment, Map<String, String> properties) {
@@ -137,12 +134,12 @@ public class DorisDatabaseOperations extends JdbcDatabaseOperations {
   }
 
   @Override
-  protected boolean isSystemDatabase(String dbName) {
-    return DORIS_SYSTEM_DATABASE_NAMES.contains(dbName);
+  protected boolean supportSchemaComment() {
+    return true;
   }
 
   @Override
-  protected boolean supportSchemaComment() {
-    return true;
+  protected Set<String> createSysDatabaseNameSet() {
+    return ImmutableSet.of("information_schema");
   }
 }

--- a/catalogs/catalog-jdbc-mysql/src/main/java/org/apache/gravitino/catalog/mysql/operation/MysqlDatabaseOperations.java
+++ b/catalogs/catalog-jdbc-mysql/src/main/java/org/apache/gravitino/catalog/mysql/operation/MysqlDatabaseOperations.java
@@ -18,85 +18,20 @@
  */
 package org.apache.gravitino.catalog.mysql.operation;
 
-import com.google.common.collect.ImmutableMap;
-import java.sql.Connection;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Statement;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Locale;
+import com.google.common.collect.ImmutableSet;
 import java.util.Set;
-import org.apache.gravitino.catalog.jdbc.JdbcSchema;
 import org.apache.gravitino.catalog.jdbc.operation.JdbcDatabaseOperations;
-import org.apache.gravitino.exceptions.NoSuchSchemaException;
-import org.apache.gravitino.meta.AuditInfo;
 
 /** Database operations for MySQL. */
 public class MysqlDatabaseOperations extends JdbcDatabaseOperations {
 
-  public static final Set<String> SYS_MYSQL_DATABASE_NAMES = createSysMysqlDatabaseNames();
-
-  private static Set<String> createSysMysqlDatabaseNames() {
-    Set<String> set = new HashSet<>();
-    set.add("information_schema");
-    set.add("mysql");
-    set.add("performance_schema");
-    set.add("sys");
-    return Collections.unmodifiableSet(set);
-  }
-
-  @Override
-  public String generateDropDatabaseSql(String databaseName, boolean cascade) {
-    final String dropDatabaseSql = "DROP DATABASE `" + databaseName + "`";
-    if (cascade) {
-      return dropDatabaseSql;
-    }
-
-    try (final Connection connection = this.dataSource.getConnection()) {
-      String query = "SHOW TABLES IN `" + databaseName + "`";
-      try (Statement statement = connection.createStatement()) {
-        // Execute the query and check if there exists any tables in the database
-        try (ResultSet resultSet = statement.executeQuery(query)) {
-          if (resultSet.next()) {
-            throw new IllegalStateException(
-                String.format(
-                    "Database %s is not empty, the value of cascade should be true.",
-                    databaseName));
-          }
-        }
-      }
-    } catch (SQLException sqlException) {
-      throw this.exceptionMapper.toGravitinoException(sqlException);
-    }
-    return dropDatabaseSql;
-  }
-
-  @Override
-  public JdbcSchema load(String databaseName) throws NoSuchSchemaException {
-    List<String> allDatabases = listDatabases();
-    String dbName =
-        allDatabases.stream()
-            .filter(db -> db.equals(databaseName))
-            .findFirst()
-            .orElseThrow(
-                () -> new NoSuchSchemaException("Database %s could not be found", databaseName));
-
-    return JdbcSchema.builder()
-        .withName(dbName)
-        .withProperties(ImmutableMap.of())
-        .withAuditInfo(AuditInfo.EMPTY)
-        .build();
-  }
-
-  @Override
-  protected boolean isSystemDatabase(String dbName) {
-    return SYS_MYSQL_DATABASE_NAMES.contains(dbName.toLowerCase(Locale.ROOT));
-  }
-
   @Override
   protected boolean supportSchemaComment() {
     return false;
+  }
+
+  @Override
+  protected Set<String> createSysDatabaseNameSet() {
+    return ImmutableSet.of("information_schema", "mysql", "sys", "performance_schema");
   }
 }

--- a/catalogs/catalog-jdbc-mysql/src/main/java/org/apache/gravitino/catalog/mysql/operation/MysqlDatabaseOperations.java
+++ b/catalogs/catalog-jdbc-mysql/src/main/java/org/apache/gravitino/catalog/mysql/operation/MysqlDatabaseOperations.java
@@ -27,9 +27,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 import java.util.Set;
-import org.apache.commons.collections4.MapUtils;
 import org.apache.gravitino.catalog.jdbc.JdbcSchema;
 import org.apache.gravitino.catalog.jdbc.operation.JdbcDatabaseOperations;
 import org.apache.gravitino.exceptions.NoSuchSchemaException;
@@ -47,22 +45,6 @@ public class MysqlDatabaseOperations extends JdbcDatabaseOperations {
     set.add("performance_schema");
     set.add("sys");
     return Collections.unmodifiableSet(set);
-  }
-
-  @Override
-  public String generateCreateDatabaseSql(
-      String databaseName, String comment, Map<String, String> properties) {
-    StringBuilder sqlBuilder = new StringBuilder("CREATE DATABASE ");
-    // Append database name
-    sqlBuilder.append("`").append(databaseName).append("`");
-    // Append options
-    if (MapUtils.isNotEmpty(properties)) {
-      // TODO #804 Properties will be unified in the future.
-      throw new UnsupportedOperationException("Properties are not supported yet");
-    }
-    String result = sqlBuilder.toString();
-    LOG.info("Generated create database:{} sql: {}", databaseName, result);
-    return result;
   }
 
   @Override

--- a/catalogs/catalog-jdbc-mysql/src/main/java/org/apache/gravitino/catalog/mysql/operation/MysqlDatabaseOperations.java
+++ b/catalogs/catalog-jdbc-mysql/src/main/java/org/apache/gravitino/catalog/mysql/operation/MysqlDatabaseOperations.java
@@ -30,8 +30,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import org.apache.commons.collections4.MapUtils;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.gravitino.StringIdentifier;
 import org.apache.gravitino.catalog.jdbc.JdbcSchema;
 import org.apache.gravitino.catalog.jdbc.operation.JdbcDatabaseOperations;
 import org.apache.gravitino.exceptions.NoSuchSchemaException;
@@ -54,13 +52,7 @@ public class MysqlDatabaseOperations extends JdbcDatabaseOperations {
   @Override
   public String generateCreateDatabaseSql(
       String databaseName, String comment, Map<String, String> properties) {
-    String originComment = StringIdentifier.removeIdFromComment(comment);
-    if (StringUtils.isNotEmpty(originComment)) {
-      throw new UnsupportedOperationException(
-          "MySQL doesn't support set schema comment: " + originComment);
-    }
     StringBuilder sqlBuilder = new StringBuilder("CREATE DATABASE ");
-
     // Append database name
     sqlBuilder.append("`").append(databaseName).append("`");
     // Append options
@@ -119,5 +111,10 @@ public class MysqlDatabaseOperations extends JdbcDatabaseOperations {
   @Override
   protected boolean isSystemDatabase(String dbName) {
     return SYS_MYSQL_DATABASE_NAMES.contains(dbName.toLowerCase(Locale.ROOT));
+  }
+
+  @Override
+  protected boolean supportSchemaComment() {
+    return false;
   }
 }

--- a/catalogs/catalog-jdbc-mysql/src/test/java/org/apache/gravitino/catalog/mysql/integration/test/CatalogMysqlIT.java
+++ b/catalogs/catalog-jdbc-mysql/src/test/java/org/apache/gravitino/catalog/mysql/integration/test/CatalogMysqlIT.java
@@ -1148,7 +1148,7 @@ public class CatalogMysqlIT extends AbstractIT {
             UnsupportedOperationException.class,
             () -> catalog.asSchemas().createSchema(testSchemaName, "comment", null));
     Assertions.assertTrue(
-        exception.getMessage().contains("MySQL doesn't support set schema comment: comment"));
+        exception.getMessage().contains("Doesn't support setting schema comment: comment"));
 
     // test null comment
     String testSchemaName2 = "test2";

--- a/catalogs/catalog-jdbc-mysql/src/test/java/org/apache/gravitino/catalog/mysql/operation/TestMysqlDatabaseOperations.java
+++ b/catalogs/catalog-jdbc-mysql/src/test/java/org/apache/gravitino/catalog/mysql/operation/TestMysqlDatabaseOperations.java
@@ -18,8 +18,6 @@
  */
 package org.apache.gravitino.catalog.mysql.operation;
 
-import static org.apache.gravitino.catalog.mysql.operation.MysqlDatabaseOperations.SYS_MYSQL_DATABASE_NAMES;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -45,8 +43,11 @@ public class TestMysqlDatabaseOperations extends TestMysql {
     // Mysql database creation does not support incoming comments.
     String comment = null;
     List<String> databases = DATABASE_OPERATIONS.listDatabases();
-    SYS_MYSQL_DATABASE_NAMES.forEach(
-        sysMysqlDatabaseName -> Assertions.assertFalse(databases.contains(sysMysqlDatabaseName)));
+    ((MysqlDatabaseOperations) DATABASE_OPERATIONS)
+        .createSysDatabaseNameSet()
+        .forEach(
+            sysMysqlDatabaseName ->
+                Assertions.assertFalse(databases.contains(sysMysqlDatabaseName)));
     testBaseOperation(databaseName, properties, comment);
     testDropDatabase(databaseName);
   }

--- a/catalogs/catalog-jdbc-oceanbase/build.gradle.kts
+++ b/catalogs/catalog-jdbc-oceanbase/build.gradle.kts
@@ -45,4 +45,66 @@ dependencies {
   implementation(libs.commons.collections4)
   implementation(libs.commons.lang3)
   implementation(libs.guava)
+
+  testImplementation(project(":catalogs:catalog-jdbc-common", "testArtifacts"))
+  testImplementation(project(":clients:client-java"))
+  testImplementation(project(":integration-test-common", "testArtifacts"))
+  testImplementation(project(":server"))
+  testImplementation(project(":server-common"))
+
+  testImplementation(libs.junit.jupiter.api)
+  testImplementation(libs.junit.jupiter.params)
+  testImplementation(libs.mysql.driver)
+  testImplementation(libs.testcontainers)
+  testImplementation(libs.testcontainers.mysql)
+
+  testRuntimeOnly(libs.junit.jupiter.engine)
+}
+
+tasks {
+  val runtimeJars by registering(Copy::class) {
+    from(configurations.runtimeClasspath)
+    into("build/libs")
+  }
+
+  val copyCatalogLibs by registering(Copy::class) {
+    dependsOn("jar", "runtimeJars")
+    from("build/libs") {
+      exclude("guava-*.jar")
+      exclude("log4j-*.jar")
+      exclude("slf4j-*.jar")
+    }
+    into("$rootDir/distribution/package/catalogs/jdbc-oceanbase/libs")
+  }
+
+  val copyCatalogConfig by registering(Copy::class) {
+    from("src/main/resources")
+    into("$rootDir/distribution/package/catalogs/jdbc-oceanbase/conf")
+
+    include("jdbc-oceanbase.conf")
+
+    exclude { details ->
+      details.file.isDirectory()
+    }
+
+    fileMode = 0b111101101
+  }
+
+  register("copyLibAndConfig", Copy::class) {
+    dependsOn(copyCatalogLibs, copyCatalogConfig)
+  }
+}
+
+tasks.test {
+  val skipITs = project.hasProperty("skipITs")
+  if (skipITs) {
+    // Exclude integration tests
+    exclude("**/integration/test/**")
+  } else {
+    dependsOn(tasks.jar)
+  }
+}
+
+tasks.getByName("generateMetadataFileForMavenJavaPublication") {
+  dependsOn("runtimeJars")
 }

--- a/catalogs/catalog-jdbc-oceanbase/src/main/java/org/apache/gravitino/catalog/oceanbase/operation/OceanBaseDatabaseOperations.java
+++ b/catalogs/catalog-jdbc-oceanbase/src/main/java/org/apache/gravitino/catalog/oceanbase/operation/OceanBaseDatabaseOperations.java
@@ -30,8 +30,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import org.apache.commons.collections4.MapUtils;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.gravitino.StringIdentifier;
 import org.apache.gravitino.catalog.jdbc.JdbcSchema;
 import org.apache.gravitino.catalog.jdbc.operation.JdbcDatabaseOperations;
 import org.apache.gravitino.exceptions.NoSuchSchemaException;
@@ -54,13 +52,6 @@ public class OceanBaseDatabaseOperations extends JdbcDatabaseOperations {
   @Override
   public String generateCreateDatabaseSql(
       String databaseName, String comment, Map<String, String> properties) {
-
-    String originComment = StringIdentifier.removeIdFromComment(comment);
-    if (StringUtils.isNotEmpty(originComment)) {
-      throw new UnsupportedOperationException(
-          "OceanBase doesn't support set schema comment: " + originComment);
-    }
-
     String createDatabaseSql = String.format("CREATE DATABASE `%s`", databaseName);
     // Append options
     if (MapUtils.isNotEmpty(properties)) {
@@ -116,5 +107,10 @@ public class OceanBaseDatabaseOperations extends JdbcDatabaseOperations {
   @Override
   protected boolean isSystemDatabase(String dbName) {
     return SYS_OCEANBASE_DATABASE_NAMES.contains(dbName.toLowerCase(Locale.ROOT));
+  }
+
+  @Override
+  protected boolean supportSchemaComment() {
+    return false;
   }
 }

--- a/catalogs/catalog-jdbc-oceanbase/src/main/java/org/apache/gravitino/catalog/oceanbase/operation/OceanBaseDatabaseOperations.java
+++ b/catalogs/catalog-jdbc-oceanbase/src/main/java/org/apache/gravitino/catalog/oceanbase/operation/OceanBaseDatabaseOperations.java
@@ -27,9 +27,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 import java.util.Set;
-import org.apache.commons.collections4.MapUtils;
 import org.apache.gravitino.catalog.jdbc.JdbcSchema;
 import org.apache.gravitino.catalog.jdbc.operation.JdbcDatabaseOperations;
 import org.apache.gravitino.exceptions.NoSuchSchemaException;
@@ -47,18 +45,6 @@ public class OceanBaseDatabaseOperations extends JdbcDatabaseOperations {
     set.add("sys");
     set.add("oceanbase");
     return Collections.unmodifiableSet(set);
-  }
-
-  @Override
-  public String generateCreateDatabaseSql(
-      String databaseName, String comment, Map<String, String> properties) {
-    String createDatabaseSql = String.format("CREATE DATABASE `%s`", databaseName);
-    // Append options
-    if (MapUtils.isNotEmpty(properties)) {
-      throw new UnsupportedOperationException("Properties are not supported yet.");
-    }
-    LOG.info("Generated create database:{} sql: {}", databaseName, createDatabaseSql);
-    return createDatabaseSql;
   }
 
   @Override

--- a/catalogs/catalog-jdbc-oceanbase/src/test/java/org/apache/gravitino/catalog/oceanbase/operation/TestOceanBase.java
+++ b/catalogs/catalog-jdbc-oceanbase/src/test/java/org/apache/gravitino/catalog/oceanbase/operation/TestOceanBase.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog.oceanbase.operation;
+
+import com.google.common.collect.Maps;
+import java.util.Collections;
+import java.util.Map;
+import org.apache.gravitino.catalog.jdbc.TestJdbc;
+import org.apache.gravitino.catalog.jdbc.config.JdbcConfig;
+import org.apache.gravitino.catalog.jdbc.utils.DataSourceUtils;
+import org.apache.gravitino.catalog.oceanbase.converter.OceanBaseColumnDefaultValueConverter;
+import org.apache.gravitino.catalog.oceanbase.converter.OceanBaseExceptionConverter;
+import org.apache.gravitino.catalog.oceanbase.converter.OceanBaseTypeConverter;
+import org.apache.gravitino.integration.test.container.ContainerSuite;
+import org.apache.gravitino.integration.test.container.OceanBaseContainer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+
+public class TestOceanBase extends TestJdbc {
+  private static final ContainerSuite containerSuite = ContainerSuite.getInstance();
+  protected static final String DRIVER_CLASS_NAME = "com.mysql.jdbc.Driver";
+
+  @BeforeAll
+  public static void startup() {
+    containerSuite.startOceanBaseContainer();
+
+    DATA_SOURCE = DataSourceUtils.createDataSource(getOceanBaseCatalogProperties());
+
+    DATABASE_OPERATIONS = new OceanBaseDatabaseOperations();
+    TABLE_OPERATIONS = new OceanBaseTableOperations();
+    JDBC_EXCEPTION_CONVERTER = new OceanBaseExceptionConverter();
+    DATABASE_OPERATIONS.initialize(DATA_SOURCE, JDBC_EXCEPTION_CONVERTER, Collections.emptyMap());
+    TABLE_OPERATIONS.initialize(
+        DATA_SOURCE,
+        JDBC_EXCEPTION_CONVERTER,
+        new OceanBaseTypeConverter(),
+        new OceanBaseColumnDefaultValueConverter(),
+        Collections.emptyMap());
+  }
+
+  // Overwrite the stop method to close the data source and stop the container
+  @AfterAll
+  public static void stop() {
+    DataSourceUtils.closeDataSource(DATA_SOURCE);
+    if (null != CONTAINER) {
+      CONTAINER.stop();
+    }
+  }
+
+  private static Map<String, String> getOceanBaseCatalogProperties() {
+    Map<String, String> catalogProperties = Maps.newHashMap();
+
+    OceanBaseContainer oceanBaseContainer = containerSuite.getOceanBaseContainer();
+
+    String jdbcUrl = oceanBaseContainer.getJdbcUrl();
+
+    catalogProperties.put(JdbcConfig.JDBC_URL.getKey(), jdbcUrl);
+    catalogProperties.put(JdbcConfig.JDBC_DRIVER.getKey(), DRIVER_CLASS_NAME);
+    catalogProperties.put(JdbcConfig.USERNAME.getKey(), OceanBaseContainer.USER_NAME);
+    catalogProperties.put(JdbcConfig.PASSWORD.getKey(), OceanBaseContainer.PASSWORD);
+
+    return catalogProperties;
+  }
+}

--- a/catalogs/catalog-jdbc-oceanbase/src/test/java/org/apache/gravitino/catalog/oceanbase/operation/TestOceanBaseDatabaseOperations.java
+++ b/catalogs/catalog-jdbc-oceanbase/src/test/java/org/apache/gravitino/catalog/oceanbase/operation/TestOceanBaseDatabaseOperations.java
@@ -18,8 +18,6 @@
  */
 package org.apache.gravitino.catalog.oceanbase.operation;
 
-import static org.apache.gravitino.catalog.oceanbase.operation.OceanBaseDatabaseOperations.SYS_OCEANBASE_DATABASE_NAMES;
-
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -38,9 +36,11 @@ public class TestOceanBaseDatabaseOperations extends TestOceanBase {
     // OceanBase database creation does not support incoming comments.
     String comment = null;
     List<String> databases = DATABASE_OPERATIONS.listDatabases();
-    SYS_OCEANBASE_DATABASE_NAMES.forEach(
-        sysOceanBaseDatabaseName ->
-            Assertions.assertFalse(databases.contains(sysOceanBaseDatabaseName)));
+    ((OceanBaseDatabaseOperations) DATABASE_OPERATIONS)
+        .createSysDatabaseNameSet()
+        .forEach(
+            sysOceanBaseDatabaseName ->
+                Assertions.assertFalse(databases.contains(sysOceanBaseDatabaseName)));
     testBaseOperation(databaseName, properties, comment);
   }
 

--- a/catalogs/catalog-jdbc-oceanbase/src/test/java/org/apache/gravitino/catalog/oceanbase/operation/TestOceanBaseDatabaseOperations.java
+++ b/catalogs/catalog-jdbc-oceanbase/src/test/java/org/apache/gravitino/catalog/oceanbase/operation/TestOceanBaseDatabaseOperations.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog.oceanbase.operation;
+
+import static org.apache.gravitino.catalog.oceanbase.operation.OceanBaseDatabaseOperations.SYS_OCEANBASE_DATABASE_NAMES;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.gravitino.utils.RandomNameUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("gravitino-docker-test")
+public class TestOceanBaseDatabaseOperations extends TestOceanBase {
+
+  @Test
+  public void testBaseOperationDatabase() {
+    String databaseName = RandomNameUtils.genRandomName("ct_db");
+    Map<String, String> properties = new HashMap<>();
+    // OceanBase database creation does not support incoming comments.
+    String comment = null;
+    List<String> databases = DATABASE_OPERATIONS.listDatabases();
+    SYS_OCEANBASE_DATABASE_NAMES.forEach(
+        sysOceanBaseDatabaseName ->
+            Assertions.assertFalse(databases.contains(sysOceanBaseDatabaseName)));
+    testBaseOperation(databaseName, properties, comment);
+  }
+
+  @Test
+  void testDropDatabaseWithSpecificName() {
+    String databaseName = RandomNameUtils.genRandomName("ct_db") + "-abc-" + "end";
+    Map<String, String> properties = new HashMap<>();
+    DATABASE_OPERATIONS.create(databaseName, null, properties);
+    Assertions.assertTrue(DATABASE_OPERATIONS.delete(databaseName, false));
+  }
+}

--- a/catalogs/catalog-jdbc-postgresql/src/main/java/org/apache/gravitino/catalog/postgresql/operation/PostgreSqlSchemaOperations.java
+++ b/catalogs/catalog-jdbc-postgresql/src/main/java/org/apache/gravitino/catalog/postgresql/operation/PostgreSqlSchemaOperations.java
@@ -20,6 +20,7 @@ package org.apache.gravitino.catalog.postgresql.operation;
 
 import static org.apache.gravitino.catalog.postgresql.operation.PostgreSqlTableOperations.PG_QUOTE;
 
+import com.google.common.collect.ImmutableSet;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.PreparedStatement;
@@ -27,9 +28,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -45,16 +44,6 @@ import org.apache.gravitino.meta.AuditInfo;
 
 /** Database operations for PostgreSQL. */
 public class PostgreSqlSchemaOperations extends JdbcDatabaseOperations {
-
-  public static final Set<String> SYS_PG_DATABASE_NAMES =
-      Collections.unmodifiableSet(
-          new HashSet<String>() {
-            {
-              add("pg_toast");
-              add("pg_catalog");
-              add("information_schema");
-            }
-          });
 
   private String database;
 
@@ -167,13 +156,13 @@ public class PostgreSqlSchemaOperations extends JdbcDatabaseOperations {
   }
 
   @Override
-  protected boolean isSystemDatabase(String dbName) {
-    return SYS_PG_DATABASE_NAMES.contains(dbName.toLowerCase(Locale.ROOT));
+  protected boolean supportSchemaComment() {
+    return true;
   }
 
   @Override
-  protected boolean supportSchemaComment() {
-    return true;
+  protected Set<String> createSysDatabaseNameSet() {
+    return ImmutableSet.of("pg_toast", "pg_catalog", "information_schema");
   }
 
   private String getShowSchemaCommentSql(String schema) {

--- a/catalogs/catalog-jdbc-postgresql/src/main/java/org/apache/gravitino/catalog/postgresql/operation/PostgreSqlSchemaOperations.java
+++ b/catalogs/catalog-jdbc-postgresql/src/main/java/org/apache/gravitino/catalog/postgresql/operation/PostgreSqlSchemaOperations.java
@@ -171,6 +171,11 @@ public class PostgreSqlSchemaOperations extends JdbcDatabaseOperations {
     return SYS_PG_DATABASE_NAMES.contains(dbName.toLowerCase(Locale.ROOT));
   }
 
+  @Override
+  protected boolean supportSchemaComment() {
+    return true;
+  }
+
   private String getShowSchemaCommentSql(String schema) {
     return String.format(
         "SELECT obj_description(n.oid, 'pg_namespace') AS comment\n"

--- a/catalogs/catalog-jdbc-postgresql/src/test/java/org/apache/gravitino/catalog/postgresql/operation/TestPostgreSqlSchemaOperations.java
+++ b/catalogs/catalog-jdbc-postgresql/src/test/java/org/apache/gravitino/catalog/postgresql/operation/TestPostgreSqlSchemaOperations.java
@@ -18,8 +18,6 @@
  */
 package org.apache.gravitino.catalog.postgresql.operation;
 
-import static org.apache.gravitino.catalog.postgresql.operation.PostgreSqlSchemaOperations.SYS_PG_DATABASE_NAMES;
-
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.HashMap;
@@ -49,8 +47,10 @@ public class TestPostgreSqlSchemaOperations extends TestPostgreSql {
     String comment = null;
     List<String> initDatabases = DATABASE_OPERATIONS.listDatabases();
 
-    SYS_PG_DATABASE_NAMES.forEach(
-        sysPgDatabaseName -> Assertions.assertFalse(initDatabases.contains(sysPgDatabaseName)));
+    ((PostgreSqlSchemaOperations) DATABASE_OPERATIONS)
+        .createSysDatabaseNameSet()
+        .forEach(
+            sysPgDatabaseName -> Assertions.assertFalse(initDatabases.contains(sysPgDatabaseName)));
 
     testBaseOperation(databaseName, properties, comment);
     // delete database.

--- a/integration-test-common/src/test/java/org/apache/gravitino/integration/test/container/OceanBaseContainer.java
+++ b/integration-test-common/src/test/java/org/apache/gravitino/integration/test/container/OceanBaseContainer.java
@@ -1,0 +1,160 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.integration.test.container;
+
+import static java.lang.String.format;
+import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
+
+import com.google.common.collect.ImmutableSet;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.time.Duration;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import org.rnorth.ducttape.Preconditions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.wait.strategy.Wait;
+
+public class OceanBaseContainer extends BaseContainer {
+  public static final Logger LOG = LoggerFactory.getLogger(OceanBaseContainer.class);
+
+  public static final String DEFAULT_IMAGE = "oceanbase/oceanbase-ce:4.2.1-lts";
+  public static final String HOST_NAME = "gravitino-ci-oceanbase";
+  public static final int OCEANBASE_PORT = 2881;
+  public static final String USER_NAME = "root@test";
+  public static final String PASSWORD = "123456";
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  protected OceanBaseContainer(
+      String image,
+      String hostName,
+      Set<Integer> ports,
+      Map<String, String> extraHosts,
+      Map<String, String> filesToMount,
+      Map<String, String> envVars,
+      Optional<Network> network) {
+    super(image, hostName, ports, extraHosts, filesToMount, envVars, network);
+  }
+
+  @Override
+  protected void setupContainer() {
+    super.setupContainer();
+    withLogConsumer(new PrintingContainerLog(format("%-14s| ", "OceanBaseContainer")));
+    waitingForLog();
+    withStartupTimeout(Duration.ofMinutes(6));
+  }
+
+  @Override
+  public void start() {
+    super.start();
+    Preconditions.check("OceanBase container startup failed!", checkContainerStatus(5));
+  }
+
+  @Override
+  protected boolean checkContainerStatus(int retryLimit) {
+    String oceanBaseJdbcUrl = format("jdbc:mysql://%s:%d", "localhost", getMappedPort());
+    LOG.info("OceanBase url is {}", oceanBaseJdbcUrl);
+
+    await()
+        .atMost(30, TimeUnit.SECONDS)
+        .pollInterval(30 / retryLimit, TimeUnit.SECONDS)
+        .until(
+            () -> {
+              try (Connection connection =
+                      DriverManager.getConnection(oceanBaseJdbcUrl, "root@sys", PASSWORD);
+                  Statement statement = connection.createStatement()) {
+
+                // check if OceanBase server is ready
+                String query = "SELECT stop_time,status FROM oceanbase.DBA_OB_SERVERS;";
+                try (ResultSet resultSet = statement.executeQuery(query)) {
+                  while (resultSet.next()) {
+                    String stopTime = resultSet.getString("stop_time");
+                    String status = resultSet.getString("status");
+
+                    if (Objects.isNull(stopTime) && "ACTIVE".equals(status)) {
+                      LOG.info("OceanBase container startup success!");
+                      return true;
+                    }
+                  }
+                }
+                LOG.info("OceanBase container is not ready yet!");
+              } catch (Exception e) {
+                LOG.error(e.getMessage(), e);
+              }
+              return false;
+            });
+
+    return true;
+  }
+
+  public void waitingForLog() {
+    super.container.waitingFor(Wait.forLogMessage(".*boot success!.*", 1));
+  }
+
+  public String getUsername() {
+    return USER_NAME;
+  }
+
+  public String getPassword() {
+    return PASSWORD;
+  }
+
+  public int getMappedPort() {
+    return getMappedPort(OCEANBASE_PORT);
+  }
+
+  public String getJdbcUrl() {
+    return format("jdbc:mysql://%s:%d", getContainerIpAddress(), OCEANBASE_PORT);
+  }
+
+  public String getJdbcUrl(String testDatabaseName) {
+    return format(
+        "jdbc:mysql://%s:%d/%s", getContainerIpAddress(), OCEANBASE_PORT, testDatabaseName);
+  }
+
+  public String getDriverClassName(String testDatabaseName) throws SQLException {
+    return DriverManager.getDriver(getJdbcUrl(testDatabaseName)).getClass().getName();
+  }
+
+  public static class Builder extends BaseContainer.Builder<Builder, OceanBaseContainer> {
+
+    private Builder() {
+      this.image = DEFAULT_IMAGE;
+      this.hostName = HOST_NAME;
+      this.exposePorts = ImmutableSet.of(OCEANBASE_PORT);
+    }
+
+    @Override
+    public OceanBaseContainer build() {
+      return new OceanBaseContainer(
+          image, hostName, exposePorts, extraHosts, filesToMount, envVars, network);
+    }
+  }
+}


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

- Support schema operations for OceanBase JDBC catalog.
- Add OceanBaseContainer to test schema operations.

### Why are the changes needed?

Fix: #4990 

### Does this PR introduce _any_ user-facing change?

no

### How was this patch tested?

Add unit test: TestOceanBaseDatabaseOperations.