### PR TITLE
[#4999] feat(catalog): make `cloud.name` and `cloud.region-code` mutable.

### DIFF
--- a/catalogs/catalog-hive/src/test/java/org/apache/gravitino/catalog/hive/TestHiveCatalogOperations.java
+++ b/catalogs/catalog-hive/src/test/java/org/apache/gravitino/catalog/hive/TestHiveCatalogOperations.java
@@ -103,7 +103,9 @@ class TestHiveCatalogOperations {
     Assertions.assertFalse(propertyEntryMap.get(CHECK_INTERVAL_SEC).isRequired());
     Assertions.assertFalse(propertyEntryMap.get(FETCH_TIMEOUT_SEC).isRequired());
     Assertions.assertFalse(propertyEntryMap.get(CLOUD_NAME).isRequired());
+    Assertions.assertFalse(propertyEntryMap.get(CLOUD_NAME).isImmutable());
     Assertions.assertFalse(propertyEntryMap.get(CLOUD_REGION_CODE).isRequired());
+    Assertions.assertFalse(propertyEntryMap.get(CLOUD_REGION_CODE).isImmutable());
   }
 
   @Test

--- a/clients/client-java/src/test/java/org/apache/gravitino/client/integration/test/CatalogIT.java
+++ b/clients/client-java/src/test/java/org/apache/gravitino/client/integration/test/CatalogIT.java
@@ -300,4 +300,34 @@ public class CatalogIT extends AbstractIT {
 
     metalake.dropCatalog(catalogName);
   }
+
+  @Test
+  public void testAlterCatalogProperties() {
+    String cloudName = "aws";
+    String alterCloudName = "azure";
+    String regionCode = "us-east-1";
+    String alterRegionCode = "us-west-2";
+
+    String catalogName = GravitinoITUtils.genRandomName("test_catalog");
+    ImmutableMap<String, String> props =
+        ImmutableMap.of(Catalog.CLOUD_NAME, cloudName, Catalog.CLOUD_REGION_CODE, regionCode);
+    Catalog catalog =
+        metalake.createCatalog(
+            catalogName, Catalog.Type.FILESET, "hadoop", "catalog comment", props);
+    Assertions.assertTrue(metalake.catalogExists(catalogName));
+    Assertions.assertFalse(catalog.properties().isEmpty());
+    Assertions.assertEquals(cloudName, catalog.properties().get(Catalog.CLOUD_NAME));
+    Assertions.assertEquals(regionCode, catalog.properties().get(Catalog.CLOUD_REGION_CODE));
+
+    Catalog alteredCatalog =
+        metalake.alterCatalog(
+            catalogName,
+            CatalogChange.setProperty(Catalog.CLOUD_NAME, alterCloudName),
+            CatalogChange.setProperty(Catalog.CLOUD_REGION_CODE, alterRegionCode));
+
+    Assertions.assertEquals(alterCloudName, alteredCatalog.properties().get(Catalog.CLOUD_NAME));
+    Assertions.assertEquals(
+        alterRegionCode, alteredCatalog.properties().get(Catalog.CLOUD_REGION_CODE));
+    metalake.dropCatalog(catalogName);
+  }
 }

--- a/core/src/main/java/org/apache/gravitino/connector/BaseCatalogPropertiesMetadata.java
+++ b/core/src/main/java/org/apache/gravitino/connector/BaseCatalogPropertiesMetadata.java
@@ -63,7 +63,7 @@ public abstract class BaseCatalogPropertiesMetadata extends BasePropertiesMetada
                   CLOUD_NAME,
                   "The cloud that the catalog is running on",
                   false /* required */,
-                  true /* immutable */,
+                  false /* immutable */,
                   Catalog.CloudName.class,
                   null /* The default value does not work because if the user does not set it, this property will not be displayed */,
                   false /* hidden */,
@@ -71,7 +71,7 @@ public abstract class BaseCatalogPropertiesMetadata extends BasePropertiesMetada
               PropertyEntry.stringOptionalPropertyEntry(
                   CLOUD_REGION_CODE,
                   "The region code of the cloud that the catalog is running on",
-                  false /* required */,
+                  false /* immutable */,
                   null /* The default value does not work because if the user does not set it, this property will not be displayed */,
                   false /* hidden */)),
           PropertyEntry::getName);


### PR DESCRIPTION
### What changes were proposed in this pull request?

Make catalog property `cloud.name` and `cloud.region-code` mutable.

### Why are the changes needed?

As #4999 mentioned, the `cloud.name` and `cloud.region-code` may change after first creation.

Fix: #4999 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Related integration tests have been added in this PR.
