### PR TITLE
[MINOR] improve(CI): Increase the Python timeout minutes to 45 minutes

### DIFF
--- a/.github/workflows/python-integration-test.yml
+++ b/.github/workflows/python-integration-test.yml
@@ -48,7 +48,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.source_changes == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     strategy:
       matrix:
         # Integration test for AMD64 architecture


### PR DESCRIPTION
### What changes were proposed in this pull request?

Change the Python CI time to 45 minutes to reduce the chances of CI failure.

### Why are the changes needed?

Current Python CI running time will hit the timeout and fail the CI, so increasing CI timeout to mitigate the failures.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

CI.