### PR TITLE
[#5042] fix(ui): show the expend arrow when reload tree node

### DIFF
--- a/web/web/src/app/metalakes/metalake/MetalakeTree.js
+++ b/web/web/src/app/metalakes/metalake/MetalakeTree.js
@@ -111,7 +111,7 @@ const MetalakeTree = props => {
         break
       }
       default:
-        dispatch(setIntoTreeNodeWithFetch({ key: nodeProps.data.key }))
+        dispatch(setIntoTreeNodeWithFetch({ key: nodeProps.data.key, reload: true }))
     }
   }
 

--- a/web/web/src/lib/store/metalakes/index.js
+++ b/web/web/src/lib/store/metalakes/index.js
@@ -151,6 +151,7 @@ export const setIntoTreeNodeWithFetch = createAsyncThunk(
             reloadedKeys.push(`{{${metalake}}}{{${catalog}}}{{${type}}}{{${schemaItem.name}}}`)
           }
         }
+
         return {
           ...schemaItem,
           node: 'schema',

--- a/web/web/src/lib/store/metalakes/index.js
+++ b/web/web/src/lib/store/metalakes/index.js
@@ -96,7 +96,7 @@ export const updateMetalake = createAsyncThunk('appMetalakes/updateMetalake', as
 
 export const setIntoTreeNodeWithFetch = createAsyncThunk(
   'appMetalakes/setIntoTreeNodeWithFetch',
-  async ({ key }, { getState, dispatch }) => {
+  async ({ key, reload }, { getState, dispatch }) => {
     let result = {
       key,
       data: [],
@@ -137,20 +137,41 @@ export const setIntoTreeNodeWithFetch = createAsyncThunk(
       }
 
       const { identifiers = [] } = res
+      const expandedKeys = getState().metalakes.expandedNodes
+      const loadedNodes = getState().metalakes.loadedNodes
+      let reloadedEpxpandedKeys = []
+      let reloadedKeys = []
 
       result.data = identifiers.map(schemaItem => {
+        if (reload) {
+          if (expandedKeys.includes(`{{${metalake}}}{{${catalog}}}{{${type}}}{{${schemaItem.name}}}`)) {
+            reloadedEpxpandedKeys.push(`{{${metalake}}}{{${catalog}}}{{${type}}}{{${schemaItem.name}}}`)
+          }
+          if (loadedNodes.includes(`{{${metalake}}}{{${catalog}}}{{${type}}}{{${schemaItem.name}}}`)) {
+            reloadedKeys.push(`{{${metalake}}}{{${catalog}}}{{${type}}}{{${schemaItem.name}}}`)
+          }
+        }
         return {
           ...schemaItem,
           node: 'schema',
           id: `{{${metalake}}}{{${catalog}}}{{${type}}}{{${schemaItem.name}}}`,
           key: `{{${metalake}}}{{${catalog}}}{{${type}}}{{${schemaItem.name}}}`,
           path: `?${new URLSearchParams({ metalake, catalog, type, schema: schemaItem.name }).toString()}`,
+          isLeaf: reload ? false : undefined,
           name: schemaItem.name,
           title: schemaItem.name,
           tables: [],
           children: []
         }
       })
+      if (reloadedEpxpandedKeys.length > 0) {
+        const epxpanded = expandedKeys.filter(key => !reloadedEpxpandedKeys.includes(key))
+        dispatch(resetExpandNode(epxpanded))
+      }
+      if (reloadedKeys.length > 0) {
+        const loaded = loadedNodes.filter(key => !reloadedKeys.includes(key))
+        dispatch(setLoadedNodes(loaded))
+      }
     } else if (pathArr.length === 4 && type === 'relational') {
       const [err, res] = await to(getTablesApi({ metalake, catalog, schema }))
 
@@ -933,7 +954,7 @@ export const appMetalakesSlice = createSlice({
       state.expandedNodes = expandedNodes
     },
     resetExpandNode(state, action) {
-      state.expandedNodes = []
+      state.expandedNodes = action.payload || []
     },
     resetTableData(state, action) {
       state.tableData = []

--- a/web/web/src/lib/utils/index.js
+++ b/web/web/src/lib/utils/index.js
@@ -144,12 +144,14 @@ export const updateTreeData = (list = [], key, children = []) => {
     if (node.key === key) {
       return {
         ...node,
+        isLeaf: children?.length === 0,
         children
       }
     }
-    if (node.children) {
+    if (node.children && node.children.length > 0) {
       return {
         ...node,
+        isLeaf: node.children.length === 0,
         children: updateTreeData(node.children, key, children)
       }
     }


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?
show the expend arrow when reload tree node
<img width="707" alt="image" src="https://github.com/user-attachments/assets/338655e6-03ac-4fec-a6fd-05756cfcaced">
<img width="614" alt="image" src="https://github.com/user-attachments/assets/70e1669c-4faa-45ed-aa86-c6ff7195a091">
<img width="633" alt="image" src="https://github.com/user-attachments/assets/df09f9a5-18b0-4b47-a4e8-418c88a6cff8">


### Why are the changes needed?
show the correct info after reload tree node

Fix: #5042

### Does this PR introduce _any_ user-facing change?
N/A

### How was this patch tested?
manually
