### PR TITLE
[#5066] refactor(drop-catalog): re-define drop catalog

### DIFF
--- a/api/src/main/java/org/apache/gravitino/Catalog.java
+++ b/api/src/main/java/org/apache/gravitino/Catalog.java
@@ -98,6 +98,9 @@ public interface Catalog extends Auditable {
    */
   String PROPERTY_PACKAGE = "package";
 
+  /** The property indicating the catalog is in use. */
+  String PROPERTY_IN_USE = "in-use";
+
   /**
    * The property to specify the cloud that the catalog is running on. The value should be one of
    * the {@link CloudName}.

--- a/api/src/main/java/org/apache/gravitino/Catalog.java
+++ b/api/src/main/java/org/apache/gravitino/Catalog.java
@@ -98,7 +98,7 @@ public interface Catalog extends Auditable {
    */
   String PROPERTY_PACKAGE = "package";
 
-  /** The property indicating the catalog is in use. */
+  /** The property indicates the catalog is in use. */
   String PROPERTY_IN_USE = "in-use";
 
   /**

--- a/api/src/main/java/org/apache/gravitino/SupportsCatalogs.java
+++ b/api/src/main/java/org/apache/gravitino/SupportsCatalogs.java
@@ -25,6 +25,7 @@ import org.apache.gravitino.exceptions.EntityInUseException;
 import org.apache.gravitino.exceptions.NoSuchCatalogException;
 import org.apache.gravitino.exceptions.NoSuchMetalakeException;
 import org.apache.gravitino.exceptions.NonEmptyEntityException;
+import org.apache.gravitino.exceptions.NotInUseEntityException;
 
 /**
  * Client interface for supporting catalogs. It includes methods for listing, loading, creating,
@@ -166,10 +167,9 @@ public interface SupportsCatalogs {
    *
    * <ul>
    *   <li>It can only be listed, loaded, dropped, or activated.
-   *   <li>Any other operations on the catalog will throw an {@link
-   *       org.apache.gravitino.exceptions.NonInUseEntityException}.
+   *   <li>Any other operations on the catalog will throw an {@link NotInUseEntityException}.
    *   <li>Any operation on the sub-entities (schemas, tables, etc.) will throw an {@link
-   *       org.apache.gravitino.exceptions.NonInUseEntityException}.
+   *       NotInUseEntityException}.
    * </ul>
    *
    * @param catalogName The identifier of the catalog.

--- a/api/src/main/java/org/apache/gravitino/SupportsCatalogs.java
+++ b/api/src/main/java/org/apache/gravitino/SupportsCatalogs.java
@@ -154,7 +154,7 @@ public interface SupportsCatalogs {
       throws NonEmptyEntityException, CatalogInUseException;
 
   /**
-   * Enable a catalog. If the catalog is already enable, this method does nothing.
+   * Enable a catalog. If the catalog is already enabled, this method does nothing.
    *
    * @param catalogName The identifier of the catalog.
    * @throws NoSuchCatalogException If the catalog does not exist.

--- a/api/src/main/java/org/apache/gravitino/SupportsCatalogs.java
+++ b/api/src/main/java/org/apache/gravitino/SupportsCatalogs.java
@@ -21,8 +21,10 @@ package org.apache.gravitino;
 import java.util.Map;
 import org.apache.gravitino.annotation.Evolving;
 import org.apache.gravitino.exceptions.CatalogAlreadyExistsException;
+import org.apache.gravitino.exceptions.EntityInUseException;
 import org.apache.gravitino.exceptions.NoSuchCatalogException;
 import org.apache.gravitino.exceptions.NoSuchMetalakeException;
+import org.apache.gravitino.exceptions.NonEmptyEntityException;
 
 /**
  * Client interface for supporting catalogs. It includes methods for listing, loading, creating,
@@ -48,9 +50,9 @@ public interface SupportsCatalogs {
   Catalog[] listCatalogsInfo() throws NoSuchMetalakeException;
 
   /**
-   * Load a catalog by its identifier.
+   * Load a catalog by its name.
    *
-   * @param catalogName the identifier of the catalog.
+   * @param catalogName the name of the catalog.
    * @return The catalog.
    * @throws NoSuchCatalogException If the catalog does not exist.
    */
@@ -59,7 +61,7 @@ public interface SupportsCatalogs {
   /**
    * Check if a catalog exists.
    *
-   * @param catalogName The identifier of the catalog.
+   * @param catalogName The name of the catalog.
    * @return True if the catalog exists, false otherwise.
    */
   default boolean catalogExists(String catalogName) {
@@ -72,7 +74,7 @@ public interface SupportsCatalogs {
   }
 
   /**
-   * Create a catalog with specified identifier.
+   * Create a catalog with specified catalog name, type, provider, comment, and properties.
    *
    * <p>The parameter "provider" is a short name of the catalog, used to tell Gravitino which
    * catalog should be created. The short name should be the same as the {@link CatalogProvider}
@@ -96,9 +98,9 @@ public interface SupportsCatalogs {
       throws NoSuchMetalakeException, CatalogAlreadyExistsException;
 
   /**
-   * Alter a catalog with specified identifier.
+   * Alter a catalog with specified catalog name and changes.
    *
-   * @param catalogName the identifier of the catalog.
+   * @param catalogName the name of the catalog.
    * @param changes the changes to apply to the catalog.
    * @return The altered catalog.
    * @throws NoSuchCatalogException If the catalog does not exist.
@@ -108,12 +110,72 @@ public interface SupportsCatalogs {
       throws NoSuchCatalogException, IllegalArgumentException;
 
   /**
-   * Drop a catalog with specified identifier.
+   * Drop a catalog with specified name. Please make sure:
+   *
+   * <ul>
+   *   <li>There is no schema in the catalog. Otherwise, a {@link NonEmptyEntityException} will be
+   *       thrown.
+   *   <li>The method {@link #deactivateCatalog(String)} has been called before dropping the
+   *       catalog. Otherwise, a {@link EntityInUseException} will be thrown.
+   * </ul>
+   *
+   * It is equivalent to calling {@code dropCatalog(ident, false)}.
    *
    * @param catalogName the name of the catalog.
-   * @return True if the catalog was dropped, false otherwise.
+   * @return True if the catalog was dropped, false if the catalog does not exist.
+   * @throws NonEmptyEntityException If the catalog is not empty.
+   * @throws EntityInUseException If the catalog is in use.
    */
-  boolean dropCatalog(String catalogName);
+  default boolean dropCatalog(String catalogName)
+      throws NonEmptyEntityException, EntityInUseException {
+    return dropCatalog(catalogName, false);
+  }
+
+  /**
+   * Drop a catalog with specified name. If the force flag is true, it will:
+   *
+   * <ul>
+   *   <li>Cascade drop all sub-entities (schemas, tables, etc.) of the catalog in Gravitino store.
+   *   <li>Drop the catalog even if it is in use.
+   *   <li>External resources (e.g. database, table, etc.) associated with sub-entities will not be
+   *       dropped unless it is managed (such as managed fileset).
+   * </ul>
+   *
+   * If the force flag is false, it is equivalent to calling {@link #dropCatalog(String)}.
+   *
+   * @param catalogName The identifier of the catalog.
+   * @param force Whether to force the drop.
+   * @return True if the catalog was dropped, false if the catalog does not exist.
+   * @throws NonEmptyEntityException If the catalog is not empty and force is false.
+   * @throws EntityInUseException If the catalog is in use and force is false.
+   */
+  boolean dropCatalog(String catalogName, boolean force)
+      throws NonEmptyEntityException, EntityInUseException;
+
+  /**
+   * Activate a catalog. If the catalog is already activated, this method does nothing.
+   *
+   * @param catalogName The identifier of the catalog.
+   * @throws NoSuchCatalogException If the catalog does not exist.
+   */
+  void activateCatalog(String catalogName) throws NoSuchCatalogException;
+
+  /**
+   * Deactivate a catalog. If the catalog is already deactivated, this method does nothing. Once a
+   * catalog is deactivated:
+   *
+   * <ul>
+   *   <li>It can only be listed, loaded, dropped, or activated.
+   *   <li>Any other operations on the catalog will throw an {@link
+   *       org.apache.gravitino.exceptions.NonInUseEntityException}.
+   *   <li>Any operation on the sub-entities (schemas, tables, etc.) will throw an {@link
+   *       org.apache.gravitino.exceptions.NonInUseEntityException}.
+   * </ul>
+   *
+   * @param catalogName The identifier of the catalog.
+   * @throws NoSuchCatalogException If the catalog does not exist.
+   */
+  void deactivateCatalog(String catalogName) throws NoSuchCatalogException;
 
   /**
    * Test whether the catalog with specified parameters can be connected to before creating it.

--- a/api/src/main/java/org/apache/gravitino/SupportsCatalogs.java
+++ b/api/src/main/java/org/apache/gravitino/SupportsCatalogs.java
@@ -116,8 +116,8 @@ public interface SupportsCatalogs {
    * <ul>
    *   <li>There is no schema in the catalog. Otherwise, a {@link NonEmptyEntityException} will be
    *       thrown.
-   *   <li>The method {@link #deactivateCatalog(String)} has been called before dropping the
-   *       catalog. Otherwise, a {@link CatalogInUseException} will be thrown.
+   *   <li>The method {@link #disableCatalog(String)} has been called before dropping the catalog.
+   *       Otherwise, a {@link CatalogInUseException} will be thrown.
    * </ul>
    *
    * It is equivalent to calling {@code dropCatalog(ident, false)}.
@@ -154,19 +154,19 @@ public interface SupportsCatalogs {
       throws NonEmptyEntityException, CatalogInUseException;
 
   /**
-   * Activate a catalog. If the catalog is already activated, this method does nothing.
+   * Enable a catalog. If the catalog is already enable, this method does nothing.
    *
    * @param catalogName The identifier of the catalog.
    * @throws NoSuchCatalogException If the catalog does not exist.
    */
-  void activateCatalog(String catalogName) throws NoSuchCatalogException;
+  void enableCatalog(String catalogName) throws NoSuchCatalogException;
 
   /**
-   * Deactivate a catalog. If the catalog is already deactivated, this method does nothing. Once a
-   * catalog is deactivated:
+   * Disable a catalog. If the catalog is already disabled, this method does nothing. Once a catalog
+   * is disabled:
    *
    * <ul>
-   *   <li>It can only be listed, loaded, dropped, or activated.
+   *   <li>It can only be listed, loaded, dropped, or disable.
    *   <li>Any other operations on the catalog will throw an {@link CatalogNotInUseException}.
    *   <li>Any operation on the sub-entities (schemas, tables, etc.) will throw an {@link
    *       CatalogNotInUseException}.
@@ -175,7 +175,7 @@ public interface SupportsCatalogs {
    * @param catalogName The identifier of the catalog.
    * @throws NoSuchCatalogException If the catalog does not exist.
    */
-  void deactivateCatalog(String catalogName) throws NoSuchCatalogException;
+  void disableCatalog(String catalogName) throws NoSuchCatalogException;
 
   /**
    * Test whether the catalog with specified parameters can be connected to before creating it.

--- a/api/src/main/java/org/apache/gravitino/SupportsCatalogs.java
+++ b/api/src/main/java/org/apache/gravitino/SupportsCatalogs.java
@@ -21,11 +21,11 @@ package org.apache.gravitino;
 import java.util.Map;
 import org.apache.gravitino.annotation.Evolving;
 import org.apache.gravitino.exceptions.CatalogAlreadyExistsException;
-import org.apache.gravitino.exceptions.EntityInUseException;
+import org.apache.gravitino.exceptions.CatalogInUseException;
+import org.apache.gravitino.exceptions.CatalogNotInUseException;
 import org.apache.gravitino.exceptions.NoSuchCatalogException;
 import org.apache.gravitino.exceptions.NoSuchMetalakeException;
 import org.apache.gravitino.exceptions.NonEmptyEntityException;
-import org.apache.gravitino.exceptions.NotInUseEntityException;
 
 /**
  * Client interface for supporting catalogs. It includes methods for listing, loading, creating,
@@ -117,7 +117,7 @@ public interface SupportsCatalogs {
    *   <li>There is no schema in the catalog. Otherwise, a {@link NonEmptyEntityException} will be
    *       thrown.
    *   <li>The method {@link #deactivateCatalog(String)} has been called before dropping the
-   *       catalog. Otherwise, a {@link EntityInUseException} will be thrown.
+   *       catalog. Otherwise, a {@link CatalogInUseException} will be thrown.
    * </ul>
    *
    * It is equivalent to calling {@code dropCatalog(ident, false)}.
@@ -125,10 +125,10 @@ public interface SupportsCatalogs {
    * @param catalogName the name of the catalog.
    * @return True if the catalog was dropped, false if the catalog does not exist.
    * @throws NonEmptyEntityException If the catalog is not empty.
-   * @throws EntityInUseException If the catalog is in use.
+   * @throws CatalogInUseException If the catalog is in use.
    */
   default boolean dropCatalog(String catalogName)
-      throws NonEmptyEntityException, EntityInUseException {
+      throws NonEmptyEntityException, CatalogInUseException {
     return dropCatalog(catalogName, false);
   }
 
@@ -148,10 +148,10 @@ public interface SupportsCatalogs {
    * @param force Whether to force the drop.
    * @return True if the catalog was dropped, false if the catalog does not exist.
    * @throws NonEmptyEntityException If the catalog is not empty and force is false.
-   * @throws EntityInUseException If the catalog is in use and force is false.
+   * @throws CatalogInUseException If the catalog is in use and force is false.
    */
   boolean dropCatalog(String catalogName, boolean force)
-      throws NonEmptyEntityException, EntityInUseException;
+      throws NonEmptyEntityException, CatalogInUseException;
 
   /**
    * Activate a catalog. If the catalog is already activated, this method does nothing.
@@ -167,9 +167,9 @@ public interface SupportsCatalogs {
    *
    * <ul>
    *   <li>It can only be listed, loaded, dropped, or activated.
-   *   <li>Any other operations on the catalog will throw an {@link NotInUseEntityException}.
+   *   <li>Any other operations on the catalog will throw an {@link CatalogNotInUseException}.
    *   <li>Any operation on the sub-entities (schemas, tables, etc.) will throw an {@link
-   *       NotInUseEntityException}.
+   *       CatalogNotInUseException}.
    * </ul>
    *
    * @param catalogName The identifier of the catalog.

--- a/api/src/main/java/org/apache/gravitino/exceptions/CatalogInUseException.java
+++ b/api/src/main/java/org/apache/gravitino/exceptions/CatalogInUseException.java
@@ -21,8 +21,8 @@ package org.apache.gravitino.exceptions;
 import com.google.errorprone.annotations.FormatMethod;
 import com.google.errorprone.annotations.FormatString;
 
-/** Exception thrown when an entity is in use and cannot be deleted. */
-public class EntityInUseException extends GravitinoRuntimeException {
+/** Exception thrown when a catalog is in use and cannot be deleted. */
+public class CatalogInUseException extends InUseException {
   /**
    * Constructs a new exception with the specified detail message.
    *
@@ -30,7 +30,7 @@ public class EntityInUseException extends GravitinoRuntimeException {
    * @param args the arguments to the message.
    */
   @FormatMethod
-  public EntityInUseException(@FormatString String message, Object... args) {
+  public CatalogInUseException(@FormatString String message, Object... args) {
     super(message, args);
   }
 }

--- a/api/src/main/java/org/apache/gravitino/exceptions/CatalogNotInUseException.java
+++ b/api/src/main/java/org/apache/gravitino/exceptions/CatalogNotInUseException.java
@@ -21,8 +21,8 @@ package org.apache.gravitino.exceptions;
 import com.google.errorprone.annotations.FormatMethod;
 import com.google.errorprone.annotations.FormatString;
 
-/** An exception thrown when operating on a non-in-use entity. */
-public class NotInUseEntityException extends GravitinoRuntimeException {
+/** An exception thrown when operating on a catalog that is not in use. */
+public class CatalogNotInUseException extends NotInUseException {
   /**
    * Constructs a new exception with the specified detail message.
    *
@@ -30,7 +30,7 @@ public class NotInUseEntityException extends GravitinoRuntimeException {
    * @param args the arguments to the message.
    */
   @FormatMethod
-  public NotInUseEntityException(@FormatString String message, Object... args) {
+  public CatalogNotInUseException(@FormatString String message, Object... args) {
     super(message, args);
   }
 }

--- a/api/src/main/java/org/apache/gravitino/exceptions/EntityInUseException.java
+++ b/api/src/main/java/org/apache/gravitino/exceptions/EntityInUseException.java
@@ -16,23 +16,21 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.gravitino.server.web.rest;
+package org.apache.gravitino.exceptions;
 
-public enum OperationType {
-  LIST,
-  CREATE,
-  LOAD,
-  ALTER,
-  DROP,
-  ACTIVATE,
-  DEACTIVATE,
-  /** This is a special operation type that is used to get a partition from a table. */
-  GET,
-  ADD,
-  REMOVE,
-  DELETE,
-  GRANT,
-  REVOKE,
-  ASSOCIATE,
-  SET,
+import com.google.errorprone.annotations.FormatMethod;
+import com.google.errorprone.annotations.FormatString;
+
+/** Exception thrown when an entity is in use and cannot be deleted. */
+public class EntityInUseException extends GravitinoRuntimeException {
+  /**
+   * Constructs a new exception with the specified detail message.
+   *
+   * @param message the detail message.
+   * @param args the arguments to the message.
+   */
+  @FormatMethod
+  public EntityInUseException(@FormatString String message, Object... args) {
+    super(message, args);
+  }
 }

--- a/api/src/main/java/org/apache/gravitino/exceptions/InUseException.java
+++ b/api/src/main/java/org/apache/gravitino/exceptions/InUseException.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.exceptions;
+
+import com.google.errorprone.annotations.FormatMethod;
+import com.google.errorprone.annotations.FormatString;
+
+/** Exception thrown when a resource is in use and cannot be deleted. */
+public class InUseException extends GravitinoRuntimeException {
+  /**
+   * Constructs a new exception with the specified detail message.
+   *
+   * @param message the detail message.
+   * @param args the arguments to the message.
+   */
+  @FormatMethod
+  public InUseException(@FormatString String message, Object... args) {
+    super(message, args);
+  }
+}

--- a/api/src/main/java/org/apache/gravitino/exceptions/NonInUseEntityException.java
+++ b/api/src/main/java/org/apache/gravitino/exceptions/NonInUseEntityException.java
@@ -16,23 +16,21 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.gravitino.server.web.rest;
+package org.apache.gravitino.exceptions;
 
-public enum OperationType {
-  LIST,
-  CREATE,
-  LOAD,
-  ALTER,
-  DROP,
-  ACTIVATE,
-  DEACTIVATE,
-  /** This is a special operation type that is used to get a partition from a table. */
-  GET,
-  ADD,
-  REMOVE,
-  DELETE,
-  GRANT,
-  REVOKE,
-  ASSOCIATE,
-  SET,
+import com.google.errorprone.annotations.FormatMethod;
+import com.google.errorprone.annotations.FormatString;
+
+/** An exception thrown when operating on a non-in-use entity. */
+public class NonInUseEntityException extends GravitinoRuntimeException {
+  /**
+   * Constructs a new exception with the specified detail message.
+   *
+   * @param message the detail message.
+   * @param args the arguments to the message.
+   */
+  @FormatMethod
+  public NonInUseEntityException(@FormatString String message, Object... args) {
+    super(message, args);
+  }
 }

--- a/api/src/main/java/org/apache/gravitino/exceptions/NotInUseEntityException.java
+++ b/api/src/main/java/org/apache/gravitino/exceptions/NotInUseEntityException.java
@@ -22,7 +22,7 @@ import com.google.errorprone.annotations.FormatMethod;
 import com.google.errorprone.annotations.FormatString;
 
 /** An exception thrown when operating on a non-in-use entity. */
-public class NonInUseEntityException extends GravitinoRuntimeException {
+public class NotInUseEntityException extends GravitinoRuntimeException {
   /**
    * Constructs a new exception with the specified detail message.
    *
@@ -30,7 +30,7 @@ public class NonInUseEntityException extends GravitinoRuntimeException {
    * @param args the arguments to the message.
    */
   @FormatMethod
-  public NonInUseEntityException(@FormatString String message, Object... args) {
+  public NotInUseEntityException(@FormatString String message, Object... args) {
     super(message, args);
   }
 }

--- a/api/src/main/java/org/apache/gravitino/exceptions/NotInUseException.java
+++ b/api/src/main/java/org/apache/gravitino/exceptions/NotInUseException.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.exceptions;
+
+import com.google.errorprone.annotations.FormatMethod;
+import com.google.errorprone.annotations.FormatString;
+
+/** An exception thrown when operating on a resource that is not in use. */
+public class NotInUseException extends GravitinoRuntimeException {
+  /**
+   * Constructs a new exception with the specified detail message.
+   *
+   * @param message the detail message.
+   * @param args the arguments to the message.
+   */
+  @FormatMethod
+  public NotInUseException(@FormatString String message, Object... args) {
+    super(message, args);
+  }
+}

--- a/authorizations/authorization-ranger/src/test/java/org/apache/gravitino/authorization/ranger/integration/test/RangerHiveE2EIT.java
+++ b/authorizations/authorization-ranger/src/test/java/org/apache/gravitino/authorization/ranger/integration/test/RangerHiveE2EIT.java
@@ -190,10 +190,7 @@ public class RangerHiveE2EIT extends BaseIT {
                 catalog.asSchemas().dropSchema(schema, true);
               }));
       Arrays.stream(metalake.listCatalogs())
-          .forEach(
-              (catalogName -> {
-                metalake.dropCatalog(catalogName);
-              }));
+          .forEach((catalogName -> metalake.dropCatalog(catalogName, true)));
       client.dropMetalake(metalakeName);
     }
     if (sparkSession != null) {

--- a/catalogs/catalog-hadoop/src/main/java/org/apache/gravitino/catalog/hadoop/SecureHadoopCatalogOperations.java
+++ b/catalogs/catalog-hadoop/src/main/java/org/apache/gravitino/catalog/hadoop/SecureHadoopCatalogOperations.java
@@ -156,6 +156,10 @@ public class SecureHadoopCatalogOperations
       UserContext.clearUserContext(ident);
 
       return r;
+    } catch (NoSuchEntityException e) {
+      LOG.warn("Schema {} does not exist", ident);
+      return false;
+
     } catch (IOException ioe) {
       throw new RuntimeException("Failed to delete schema " + ident, ioe);
     }

--- a/catalogs/catalog-hadoop/src/test/java/org/apache/gravitino/catalog/hadoop/integration/test/HadoopCatalogIT.java
+++ b/catalogs/catalog-hadoop/src/test/java/org/apache/gravitino/catalog/hadoop/integration/test/HadoopCatalogIT.java
@@ -89,7 +89,7 @@ public class HadoopCatalogIT extends BaseIT {
   public void stop() throws IOException {
     Catalog catalog = metalake.loadCatalog(catalogName);
     catalog.asSchemas().dropSchema(schemaName, true);
-    metalake.dropCatalog(catalogName);
+    metalake.dropCatalog(catalogName, true);
     client.dropMetalake(metalakeName);
     if (hdfs != null) {
       hdfs.close();
@@ -162,7 +162,7 @@ public class HadoopCatalogIT extends BaseIT {
 
     Assertions.assertEquals(newLocation, modifiedCatalog.properties().get("location"));
 
-    metalake.dropCatalog(catalogName);
+    metalake.dropCatalog(catalogName, true);
   }
 
   @Test
@@ -608,7 +608,7 @@ public class HadoopCatalogIT extends BaseIT {
         filesetCatalog.asSchemas().schemaExists(schemaName), "schema should not be exists");
 
     // Drop the catalog.
-    dropped = metalake.dropCatalog(catalogName);
+    dropped = metalake.dropCatalog(catalogName, true);
     Assertions.assertTrue(dropped, "catalog should be dropped");
     Assertions.assertFalse(metalake.catalogExists(catalogName), "catalog should not be exists");
   }

--- a/catalogs/catalog-hadoop/src/test/java/org/apache/gravitino/catalog/hadoop/integration/test/HadoopUserAuthenticationIT.java
+++ b/catalogs/catalog-hadoop/src/test/java/org/apache/gravitino/catalog/hadoop/integration/test/HadoopUserAuthenticationIT.java
@@ -653,7 +653,7 @@ public class HadoopUserAuthenticationIT extends BaseIT {
 
     catalog.asFilesetCatalog().dropFileset(NameIdentifier.of(SCHEMA_NAME, filesetName));
     catalog.asSchemas().dropSchema(SCHEMA_NAME, true);
-    gravitinoMetalake.dropCatalog(catalogName);
+    gravitinoMetalake.dropCatalog(catalogName, true);
     adminClient.dropMetalake(metalakeName);
   }
 }

--- a/catalogs/catalog-hive/src/test/java/org/apache/gravitino/catalog/hive/TestHiveCatalogOperations.java
+++ b/catalogs/catalog-hive/src/test/java/org/apache/gravitino/catalog/hive/TestHiveCatalogOperations.java
@@ -22,6 +22,7 @@ package org.apache.gravitino.catalog.hive;
 import static org.apache.gravitino.Catalog.AUTHORIZATION_PROVIDER;
 import static org.apache.gravitino.Catalog.CLOUD_NAME;
 import static org.apache.gravitino.Catalog.CLOUD_REGION_CODE;
+import static org.apache.gravitino.Catalog.PROPERTY_IN_USE;
 import static org.apache.gravitino.catalog.hive.HiveCatalogPropertiesMeta.CHECK_INTERVAL_SEC;
 import static org.apache.gravitino.catalog.hive.HiveCatalogPropertiesMeta.CLIENT_POOL_CACHE_EVICTION_INTERVAL_MS;
 import static org.apache.gravitino.catalog.hive.HiveCatalogPropertiesMeta.CLIENT_POOL_SIZE;
@@ -73,10 +74,11 @@ class TestHiveCatalogOperations {
     Map<String, PropertyEntry<?>> propertyEntryMap =
         HIVE_PROPERTIES_METADATA.catalogPropertiesMetadata().propertyEntries();
 
-    Assertions.assertEquals(20, propertyEntryMap.size());
+    Assertions.assertEquals(21, propertyEntryMap.size());
     Assertions.assertTrue(propertyEntryMap.containsKey(METASTORE_URIS));
     Assertions.assertTrue(propertyEntryMap.containsKey(Catalog.PROPERTY_PACKAGE));
     Assertions.assertTrue(propertyEntryMap.containsKey(BaseCatalog.CATALOG_OPERATION_IMPL));
+    Assertions.assertTrue(propertyEntryMap.containsKey(PROPERTY_IN_USE));
     Assertions.assertTrue(propertyEntryMap.containsKey(AUTHORIZATION_PROVIDER));
     Assertions.assertTrue(propertyEntryMap.containsKey(CLIENT_POOL_SIZE));
     Assertions.assertTrue(propertyEntryMap.containsKey(IMPERSONATION_ENABLE));

--- a/catalogs/catalog-hive/src/test/java/org/apache/gravitino/catalog/hive/integration/test/CatalogHiveIT.java
+++ b/catalogs/catalog-hive/src/test/java/org/apache/gravitino/catalog/hive/integration/test/CatalogHiveIT.java
@@ -228,10 +228,7 @@ public class CatalogHiveIT extends BaseIT {
                 catalog.asSchemas().dropSchema(schema, true);
               }));
       Arrays.stream(metalake.listCatalogs())
-          .forEach(
-              (catalogName -> {
-                metalake.dropCatalog(catalogName);
-              }));
+          .forEach((catalogName -> metalake.dropCatalog(catalogName, true)));
       client.dropMetalake(metalakeName);
     }
     if (hiveClientPool != null) {
@@ -1672,7 +1669,7 @@ public class CatalogHiveIT extends BaseIT {
         });
 
     newCatalog.asSchemas().dropSchema("schema", true);
-    metalake.dropCatalog(nameOfCatalog);
+    metalake.dropCatalog(nameOfCatalog, true);
   }
 
   private void createCatalogWithCustomOperation(String catalogName, String customImpl) {

--- a/catalogs/catalog-hive/src/test/java/org/apache/gravitino/catalog/hive/integration/test/HiveUserAuthenticationIT.java
+++ b/catalogs/catalog-hive/src/test/java/org/apache/gravitino/catalog/hive/integration/test/HiveUserAuthenticationIT.java
@@ -269,7 +269,7 @@ public class HiveUserAuthenticationIT extends BaseIT {
     Assertions.assertFalse(catalog.asSchemas().schemaExists(SCHEMA_NAME));
 
     // Drop catalog
-    Assertions.assertTrue(gravitinoMetalake.dropCatalog(CATALOG_NAME));
+    Assertions.assertTrue(gravitinoMetalake.dropCatalog(CATALOG_NAME, true));
   }
 
   @AfterAll

--- a/catalogs/catalog-jdbc-doris/src/test/java/org/apache/gravitino/catalog/doris/integration/test/CatalogDorisIT.java
+++ b/catalogs/catalog-jdbc-doris/src/test/java/org/apache/gravitino/catalog/doris/integration/test/CatalogDorisIT.java
@@ -125,7 +125,7 @@ public class CatalogDorisIT extends BaseIT {
   @AfterAll
   public void stop() {
     clearTableAndSchema();
-    metalake.dropCatalog(catalogName);
+    metalake.dropCatalog(catalogName, true);
     client.dropMetalake(metalakeName);
   }
 

--- a/catalogs/catalog-jdbc-mysql/src/test/java/org/apache/gravitino/catalog/mysql/integration/test/AuditCatalogMysqlIT.java
+++ b/catalogs/catalog-jdbc-mysql/src/test/java/org/apache/gravitino/catalog/mysql/integration/test/AuditCatalogMysqlIT.java
@@ -95,7 +95,7 @@ public class AuditCatalogMysqlIT extends BaseIT {
     Assertions.assertEquals(expectUser, catalog.auditInfo().creator());
     Assertions.assertEquals(expectUser, catalog.auditInfo().lastModifier());
 
-    metalake.dropCatalog(catalogName);
+    metalake.dropCatalog(catalogName, true);
   }
 
   @Test
@@ -109,7 +109,7 @@ public class AuditCatalogMysqlIT extends BaseIT {
     Assertions.assertNull(schema.auditInfo().lastModifier());
 
     catalog.asSchemas().dropSchema(schemaName, true);
-    metalake.dropCatalog(catalogName);
+    metalake.dropCatalog(catalogName, true);
   }
 
   @Test
@@ -144,7 +144,7 @@ public class AuditCatalogMysqlIT extends BaseIT {
 
     catalog.asTableCatalog().dropTable(NameIdentifier.of(schemaName, tableName));
     catalog.asSchemas().dropSchema(schemaName, true);
-    metalake.dropCatalog(catalogName);
+    metalake.dropCatalog(catalogName, true);
   }
 
   private static Catalog createCatalog(String catalogName) throws SQLException {

--- a/catalogs/catalog-jdbc-mysql/src/test/java/org/apache/gravitino/catalog/mysql/integration/test/CatalogMysqlIT.java
+++ b/catalogs/catalog-jdbc-mysql/src/test/java/org/apache/gravitino/catalog/mysql/integration/test/CatalogMysqlIT.java
@@ -142,7 +142,7 @@ public class CatalogMysqlIT extends BaseIT {
   @AfterAll
   public void stop() {
     clearTableAndSchema();
-    metalake.deactivateCatalog(catalogName);
+    metalake.disableCatalog(catalogName);
     metalake.dropCatalog(catalogName);
     client.dropMetalake(metalakeName);
     mysqlService.close();

--- a/catalogs/catalog-jdbc-mysql/src/test/java/org/apache/gravitino/catalog/mysql/integration/test/CatalogMysqlIT.java
+++ b/catalogs/catalog-jdbc-mysql/src/test/java/org/apache/gravitino/catalog/mysql/integration/test/CatalogMysqlIT.java
@@ -142,6 +142,7 @@ public class CatalogMysqlIT extends BaseIT {
   @AfterAll
   public void stop() {
     clearTableAndSchema();
+    metalake.deactivateCatalog(catalogName);
     metalake.dropCatalog(catalogName);
     client.dropMetalake(metalakeName);
     mysqlService.close();
@@ -1987,6 +1988,6 @@ public class CatalogMysqlIT extends BaseIT {
     Assertions.assertDoesNotThrow(() -> loadCatalog.asSchemas().createSchema("test", "", null));
 
     loadCatalog.asSchemas().dropSchema("test", true);
-    metalake.dropCatalog(testCatalogName);
+    metalake.dropCatalog(testCatalogName, true);
   }
 }

--- a/catalogs/catalog-jdbc-postgresql/src/test/java/org/apache/gravitino/catalog/postgresql/integration/test/CatalogPostgreSqlIT.java
+++ b/catalogs/catalog-jdbc-postgresql/src/test/java/org/apache/gravitino/catalog/postgresql/integration/test/CatalogPostgreSqlIT.java
@@ -128,7 +128,7 @@ public class CatalogPostgreSqlIT extends BaseIT {
     for (String schemaName : schemaNames) {
       catalog.asSchemas().dropSchema(schemaName, true);
     }
-    metalake.deactivateCatalog(catalogName);
+    metalake.disableCatalog(catalogName);
     metalake.dropCatalog(catalogName);
     client.dropMetalake(metalakeName);
     postgreSqlService.close();

--- a/catalogs/catalog-jdbc-postgresql/src/test/java/org/apache/gravitino/catalog/postgresql/integration/test/CatalogPostgreSqlIT.java
+++ b/catalogs/catalog-jdbc-postgresql/src/test/java/org/apache/gravitino/catalog/postgresql/integration/test/CatalogPostgreSqlIT.java
@@ -128,6 +128,7 @@ public class CatalogPostgreSqlIT extends BaseIT {
     for (String schemaName : schemaNames) {
       catalog.asSchemas().dropSchema(schemaName, true);
     }
+    metalake.deactivateCatalog(catalogName);
     metalake.dropCatalog(catalogName);
     client.dropMetalake(metalakeName);
     postgreSqlService.close();

--- a/catalogs/catalog-kafka/src/test/java/org/apache/gravitino/catalog/kafka/integration/test/CatalogKafkaIT.java
+++ b/catalogs/catalog-kafka/src/test/java/org/apache/gravitino/catalog/kafka/integration/test/CatalogKafkaIT.java
@@ -123,7 +123,7 @@ public class CatalogKafkaIT extends BaseIT {
     Arrays.stream(metalake.listCatalogs())
         .forEach(
             (catalogName -> {
-              metalake.deactivateCatalog(catalogName);
+              metalake.disableCatalog(catalogName);
               metalake.dropCatalog(catalogName);
             }));
     client.dropMetalake(METALAKE_NAME);

--- a/catalogs/catalog-kafka/src/test/java/org/apache/gravitino/catalog/kafka/integration/test/CatalogKafkaIT.java
+++ b/catalogs/catalog-kafka/src/test/java/org/apache/gravitino/catalog/kafka/integration/test/CatalogKafkaIT.java
@@ -123,6 +123,7 @@ public class CatalogKafkaIT extends BaseIT {
     Arrays.stream(metalake.listCatalogs())
         .forEach(
             (catalogName -> {
+              metalake.deactivateCatalog(catalogName);
               metalake.dropCatalog(catalogName);
             }));
     client.dropMetalake(METALAKE_NAME);
@@ -171,7 +172,7 @@ public class CatalogKafkaIT extends BaseIT {
     Assertions.assertFalse(alteredCatalog.properties().containsKey("key1"));
 
     // test drop catalog
-    boolean dropped = metalake.dropCatalog(catalogName);
+    boolean dropped = metalake.dropCatalog(catalogName, true);
     Assertions.assertTrue(dropped);
     Exception exception =
         Assertions.assertThrows(

--- a/catalogs/catalog-lakehouse-hudi/src/test/java/org/apache/gravitino/catalog/lakehouse/hudi/integration/test/HudiCatalogHMSIT.java
+++ b/catalogs/catalog-lakehouse-hudi/src/test/java/org/apache/gravitino/catalog/lakehouse/hudi/integration/test/HudiCatalogHMSIT.java
@@ -18,12 +18,14 @@
  */
 package org.apache.gravitino.catalog.lakehouse.hudi.integration.test;
 
+import static org.apache.gravitino.Catalog.PROPERTY_IN_USE;
 import static org.apache.gravitino.catalog.lakehouse.hudi.HudiCatalogPropertiesMetadata.CATALOG_BACKEND;
 import static org.apache.gravitino.catalog.lakehouse.hudi.HudiCatalogPropertiesMetadata.URI;
 import static org.apache.gravitino.catalog.lakehouse.hudi.HudiSchemaPropertiesMetadata.LOCATION;
 
 import com.google.common.collect.ImmutableMap;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -146,7 +148,9 @@ public class HudiCatalogHMSIT extends BaseIT {
     Assertions.assertEquals(Catalog.Type.RELATIONAL, catalog.type());
     Assertions.assertEquals("lakehouse-hudi", catalog.provider());
     Assertions.assertEquals(comment, catalog.comment());
-    Assertions.assertEquals(properties, catalog.properties());
+    Map<String, String> expectedProperties = new HashMap<>(properties);
+    expectedProperties.put(PROPERTY_IN_USE, "true");
+    Assertions.assertEquals(expectedProperties, catalog.properties());
 
     // test list
     String[] catalogs = metalake.listCatalogs();

--- a/catalogs/catalog-lakehouse-iceberg/src/test/java/org/apache/gravitino/catalog/lakehouse/iceberg/integration/test/CatalogIcebergBaseIT.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/test/java/org/apache/gravitino/catalog/lakehouse/iceberg/integration/test/CatalogIcebergBaseIT.java
@@ -138,6 +138,7 @@ public abstract class CatalogIcebergBaseIT extends BaseIT {
   public void stop() throws Exception {
     try {
       clearTableAndSchema();
+      metalake.deactivateCatalog(catalogName);
       metalake.dropCatalog(catalogName);
       client.dropMetalake(metalakeName);
     } finally {

--- a/catalogs/catalog-lakehouse-iceberg/src/test/java/org/apache/gravitino/catalog/lakehouse/iceberg/integration/test/CatalogIcebergBaseIT.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/test/java/org/apache/gravitino/catalog/lakehouse/iceberg/integration/test/CatalogIcebergBaseIT.java
@@ -138,7 +138,7 @@ public abstract class CatalogIcebergBaseIT extends BaseIT {
   public void stop() throws Exception {
     try {
       clearTableAndSchema();
-      metalake.deactivateCatalog(catalogName);
+      metalake.disableCatalog(catalogName);
       metalake.dropCatalog(catalogName);
       client.dropMetalake(metalakeName);
     } finally {

--- a/catalogs/catalog-lakehouse-iceberg/src/test/java/org/apache/gravitino/catalog/lakehouse/iceberg/integration/test/CatalogIcebergHiveIT.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/test/java/org/apache/gravitino/catalog/lakehouse/iceberg/integration/test/CatalogIcebergHiveIT.java
@@ -77,6 +77,6 @@ public class CatalogIcebergHiveIT extends CatalogIcebergBaseIT {
         () -> createdCatalog.asSchemas().createSchema("schema1", "", null));
 
     createdCatalog.asSchemas().dropSchema("schema1", false);
-    metalake.dropCatalog(catalogNm);
+    metalake.dropCatalog(catalogNm, true);
   }
 }

--- a/catalogs/catalog-lakehouse-iceberg/src/test/java/org/apache/gravitino/catalog/lakehouse/iceberg/integration/test/CatalogIcebergKerberosHiveIT.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/test/java/org/apache/gravitino/catalog/lakehouse/iceberg/integration/test/CatalogIcebergKerberosHiveIT.java
@@ -292,7 +292,7 @@ public class CatalogIcebergKerberosHiveIT extends BaseIT {
     Assertions.assertFalse(catalog.asSchemas().schemaExists(SCHEMA_NAME));
 
     // Drop catalog
-    Assertions.assertDoesNotThrow(() -> gravitinoMetalake.deactivateCatalog(CATALOG_NAME));
+    Assertions.assertDoesNotThrow(() -> gravitinoMetalake.disableCatalog(CATALOG_NAME));
     Assertions.assertTrue(gravitinoMetalake.dropCatalog(CATALOG_NAME));
   }
 

--- a/catalogs/catalog-lakehouse-iceberg/src/test/java/org/apache/gravitino/catalog/lakehouse/iceberg/integration/test/CatalogIcebergKerberosHiveIT.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/test/java/org/apache/gravitino/catalog/lakehouse/iceberg/integration/test/CatalogIcebergKerberosHiveIT.java
@@ -292,6 +292,7 @@ public class CatalogIcebergKerberosHiveIT extends BaseIT {
     Assertions.assertFalse(catalog.asSchemas().schemaExists(SCHEMA_NAME));
 
     // Drop catalog
+    Assertions.assertDoesNotThrow(() -> gravitinoMetalake.deactivateCatalog(CATALOG_NAME));
     Assertions.assertTrue(gravitinoMetalake.dropCatalog(CATALOG_NAME));
   }
 

--- a/catalogs/catalog-lakehouse-paimon/src/test/java/org/apache/gravitino/catalog/lakehouse/paimon/integration/test/CatalogPaimonBaseIT.java
+++ b/catalogs/catalog-lakehouse-paimon/src/test/java/org/apache/gravitino/catalog/lakehouse/paimon/integration/test/CatalogPaimonBaseIT.java
@@ -136,6 +136,7 @@ public abstract class CatalogPaimonBaseIT extends BaseIT {
   @AfterAll
   public void stop() {
     clearTableAndSchema();
+    metalake.deactivateCatalog(catalogName);
     metalake.dropCatalog(catalogName);
     client.dropMetalake(metalakeName);
     if (spark != null) {

--- a/catalogs/catalog-lakehouse-paimon/src/test/java/org/apache/gravitino/catalog/lakehouse/paimon/integration/test/CatalogPaimonBaseIT.java
+++ b/catalogs/catalog-lakehouse-paimon/src/test/java/org/apache/gravitino/catalog/lakehouse/paimon/integration/test/CatalogPaimonBaseIT.java
@@ -136,7 +136,7 @@ public abstract class CatalogPaimonBaseIT extends BaseIT {
   @AfterAll
   public void stop() {
     clearTableAndSchema();
-    metalake.deactivateCatalog(catalogName);
+    metalake.disableCatalog(catalogName);
     metalake.dropCatalog(catalogName);
     client.dropMetalake(metalakeName);
     if (spark != null) {

--- a/catalogs/catalog-lakehouse-paimon/src/test/java/org/apache/gravitino/catalog/lakehouse/paimon/integration/test/CatalogPaimonKerberosFilesystemIT.java
+++ b/catalogs/catalog-lakehouse-paimon/src/test/java/org/apache/gravitino/catalog/lakehouse/paimon/integration/test/CatalogPaimonKerberosFilesystemIT.java
@@ -271,7 +271,7 @@ public class CatalogPaimonKerberosFilesystemIT extends BaseIT {
     Assertions.assertFalse(catalog.asSchemas().schemaExists(SCHEMA_NAME));
 
     // Drop catalog
-    Assertions.assertTrue(gravitinoMetalake.dropCatalog(CATALOG_NAME));
+    Assertions.assertTrue(gravitinoMetalake.dropCatalog(CATALOG_NAME, true));
 
     // Drop warehouse path
     kerberosHiveContainer.executeInContainer(

--- a/clients/client-java/src/main/java/org/apache/gravitino/client/ErrorHandlers.java
+++ b/clients/client-java/src/main/java/org/apache/gravitino/client/ErrorHandlers.java
@@ -28,8 +28,9 @@ import org.apache.gravitino.dto.responses.OAuth2ErrorResponse;
 import org.apache.gravitino.exceptions.AlreadyExistsException;
 import org.apache.gravitino.exceptions.BadRequestException;
 import org.apache.gravitino.exceptions.CatalogAlreadyExistsException;
+import org.apache.gravitino.exceptions.CatalogInUseException;
+import org.apache.gravitino.exceptions.CatalogNotInUseException;
 import org.apache.gravitino.exceptions.ConnectionFailedException;
-import org.apache.gravitino.exceptions.EntityInUseException;
 import org.apache.gravitino.exceptions.FilesetAlreadyExistsException;
 import org.apache.gravitino.exceptions.ForbiddenException;
 import org.apache.gravitino.exceptions.GroupAlreadyExistsException;
@@ -49,7 +50,7 @@ import org.apache.gravitino.exceptions.NoSuchTopicException;
 import org.apache.gravitino.exceptions.NoSuchUserException;
 import org.apache.gravitino.exceptions.NonEmptySchemaException;
 import org.apache.gravitino.exceptions.NotFoundException;
-import org.apache.gravitino.exceptions.NotInUseEntityException;
+import org.apache.gravitino.exceptions.NotInUseException;
 import org.apache.gravitino.exceptions.PartitionAlreadyExistsException;
 import org.apache.gravitino.exceptions.RESTException;
 import org.apache.gravitino.exceptions.RoleAlreadyExistsException;
@@ -273,8 +274,13 @@ public class ErrorHandlers {
         case ErrorConstants.UNSUPPORTED_OPERATION_CODE:
           throw new UnsupportedOperationException(errorMessage);
 
-        case ErrorConstants.NOT_IN_USE_ENTITY_CODE:
-          throw new NotInUseEntityException(errorMessage);
+        case ErrorConstants.NOT_IN_USE_CODE:
+          if (errorResponse.getType().equals(CatalogNotInUseException.class.getSimpleName())) {
+            throw new CatalogNotInUseException(errorMessage);
+
+          } else {
+            throw new NotInUseException(errorMessage);
+          }
 
         default:
           super.accept(errorResponse);
@@ -316,8 +322,8 @@ public class ErrorHandlers {
         case ErrorConstants.FORBIDDEN_CODE:
           throw new ForbiddenException(errorMessage);
 
-        case ErrorConstants.NOT_IN_USE_ENTITY_CODE:
-          throw new NotInUseEntityException(errorMessage);
+        case ErrorConstants.NOT_IN_USE_CODE:
+          throw new CatalogNotInUseException(errorMessage);
 
         default:
           super.accept(errorResponse);
@@ -359,8 +365,8 @@ public class ErrorHandlers {
         case ErrorConstants.FORBIDDEN_CODE:
           throw new ForbiddenException(errorMessage);
 
-        case ErrorConstants.NOT_IN_USE_ENTITY_CODE:
-          throw new NotInUseEntityException(errorMessage);
+        case ErrorConstants.NOT_IN_USE_CODE:
+          throw new CatalogNotInUseException(errorMessage);
 
         case ErrorConstants.INTERNAL_ERROR_CODE:
           throw new RuntimeException(errorMessage);
@@ -405,11 +411,11 @@ public class ErrorHandlers {
         case ErrorConstants.INTERNAL_ERROR_CODE:
           throw new RuntimeException(errorMessage);
 
-        case ErrorConstants.ENTITY_IN_USE_CODE:
-          throw new EntityInUseException(errorMessage);
+        case ErrorConstants.IN_USE_CODE:
+          throw new CatalogInUseException(errorMessage);
 
-        case ErrorConstants.NOT_IN_USE_ENTITY_CODE:
-          throw new NotInUseEntityException(errorMessage);
+        case ErrorConstants.NOT_IN_USE_CODE:
+          throw new CatalogNotInUseException(errorMessage);
 
         default:
           super.accept(errorResponse);
@@ -529,8 +535,8 @@ public class ErrorHandlers {
         case ErrorConstants.INTERNAL_ERROR_CODE:
           throw new RuntimeException(errorMessage);
 
-        case ErrorConstants.NOT_IN_USE_ENTITY_CODE:
-          throw new NotInUseEntityException(errorMessage);
+        case ErrorConstants.NOT_IN_USE_CODE:
+          throw new CatalogNotInUseException(errorMessage);
 
         default:
           super.accept(errorResponse);
@@ -570,8 +576,8 @@ public class ErrorHandlers {
         case ErrorConstants.INTERNAL_ERROR_CODE:
           throw new RuntimeException(errorMessage);
 
-        case ErrorConstants.NOT_IN_USE_ENTITY_CODE:
-          throw new NotInUseEntityException(errorMessage);
+        case ErrorConstants.NOT_IN_USE_CODE:
+          throw new CatalogNotInUseException(errorMessage);
 
         default:
           super.accept(errorResponse);

--- a/clients/client-java/src/main/java/org/apache/gravitino/client/ErrorHandlers.java
+++ b/clients/client-java/src/main/java/org/apache/gravitino/client/ErrorHandlers.java
@@ -48,8 +48,8 @@ import org.apache.gravitino.exceptions.NoSuchTagException;
 import org.apache.gravitino.exceptions.NoSuchTopicException;
 import org.apache.gravitino.exceptions.NoSuchUserException;
 import org.apache.gravitino.exceptions.NonEmptySchemaException;
-import org.apache.gravitino.exceptions.NonInUseEntityException;
 import org.apache.gravitino.exceptions.NotFoundException;
+import org.apache.gravitino.exceptions.NotInUseEntityException;
 import org.apache.gravitino.exceptions.PartitionAlreadyExistsException;
 import org.apache.gravitino.exceptions.RESTException;
 import org.apache.gravitino.exceptions.RoleAlreadyExistsException;
@@ -273,8 +273,8 @@ public class ErrorHandlers {
         case ErrorConstants.UNSUPPORTED_OPERATION_CODE:
           throw new UnsupportedOperationException(errorMessage);
 
-        case ErrorConstants.NON_IN_USE_ENTITY_CODE:
-          throw new NonInUseEntityException(errorMessage);
+        case ErrorConstants.NOT_IN_USE_ENTITY_CODE:
+          throw new NotInUseEntityException(errorMessage);
 
         default:
           super.accept(errorResponse);
@@ -316,8 +316,8 @@ public class ErrorHandlers {
         case ErrorConstants.FORBIDDEN_CODE:
           throw new ForbiddenException(errorMessage);
 
-        case ErrorConstants.NON_IN_USE_ENTITY_CODE:
-          throw new NonInUseEntityException(errorMessage);
+        case ErrorConstants.NOT_IN_USE_ENTITY_CODE:
+          throw new NotInUseEntityException(errorMessage);
 
         default:
           super.accept(errorResponse);
@@ -359,8 +359,8 @@ public class ErrorHandlers {
         case ErrorConstants.FORBIDDEN_CODE:
           throw new ForbiddenException(errorMessage);
 
-        case ErrorConstants.NON_IN_USE_ENTITY_CODE:
-          throw new NonInUseEntityException(errorMessage);
+        case ErrorConstants.NOT_IN_USE_ENTITY_CODE:
+          throw new NotInUseEntityException(errorMessage);
 
         case ErrorConstants.INTERNAL_ERROR_CODE:
           throw new RuntimeException(errorMessage);
@@ -408,8 +408,8 @@ public class ErrorHandlers {
         case ErrorConstants.ENTITY_IN_USE_CODE:
           throw new EntityInUseException(errorMessage);
 
-        case ErrorConstants.NON_IN_USE_ENTITY_CODE:
-          throw new NonInUseEntityException(errorMessage);
+        case ErrorConstants.NOT_IN_USE_ENTITY_CODE:
+          throw new NotInUseEntityException(errorMessage);
 
         default:
           super.accept(errorResponse);
@@ -529,8 +529,8 @@ public class ErrorHandlers {
         case ErrorConstants.INTERNAL_ERROR_CODE:
           throw new RuntimeException(errorMessage);
 
-        case ErrorConstants.NON_IN_USE_ENTITY_CODE:
-          throw new NonInUseEntityException(errorMessage);
+        case ErrorConstants.NOT_IN_USE_ENTITY_CODE:
+          throw new NotInUseEntityException(errorMessage);
 
         default:
           super.accept(errorResponse);
@@ -570,8 +570,8 @@ public class ErrorHandlers {
         case ErrorConstants.INTERNAL_ERROR_CODE:
           throw new RuntimeException(errorMessage);
 
-        case ErrorConstants.NON_IN_USE_ENTITY_CODE:
-          throw new NonInUseEntityException(errorMessage);
+        case ErrorConstants.NOT_IN_USE_ENTITY_CODE:
+          throw new NotInUseEntityException(errorMessage);
 
         default:
           super.accept(errorResponse);

--- a/clients/client-java/src/main/java/org/apache/gravitino/client/ErrorHandlers.java
+++ b/clients/client-java/src/main/java/org/apache/gravitino/client/ErrorHandlers.java
@@ -29,6 +29,7 @@ import org.apache.gravitino.exceptions.AlreadyExistsException;
 import org.apache.gravitino.exceptions.BadRequestException;
 import org.apache.gravitino.exceptions.CatalogAlreadyExistsException;
 import org.apache.gravitino.exceptions.ConnectionFailedException;
+import org.apache.gravitino.exceptions.EntityInUseException;
 import org.apache.gravitino.exceptions.FilesetAlreadyExistsException;
 import org.apache.gravitino.exceptions.ForbiddenException;
 import org.apache.gravitino.exceptions.GroupAlreadyExistsException;
@@ -47,6 +48,7 @@ import org.apache.gravitino.exceptions.NoSuchTagException;
 import org.apache.gravitino.exceptions.NoSuchTopicException;
 import org.apache.gravitino.exceptions.NoSuchUserException;
 import org.apache.gravitino.exceptions.NonEmptySchemaException;
+import org.apache.gravitino.exceptions.NonInUseEntityException;
 import org.apache.gravitino.exceptions.NotFoundException;
 import org.apache.gravitino.exceptions.PartitionAlreadyExistsException;
 import org.apache.gravitino.exceptions.RESTException;
@@ -271,6 +273,9 @@ public class ErrorHandlers {
         case ErrorConstants.UNSUPPORTED_OPERATION_CODE:
           throw new UnsupportedOperationException(errorMessage);
 
+        case ErrorConstants.NON_IN_USE_ENTITY_CODE:
+          throw new NonInUseEntityException(errorMessage);
+
         default:
           super.accept(errorResponse);
       }
@@ -311,6 +316,9 @@ public class ErrorHandlers {
         case ErrorConstants.FORBIDDEN_CODE:
           throw new ForbiddenException(errorMessage);
 
+        case ErrorConstants.NON_IN_USE_ENTITY_CODE:
+          throw new NonInUseEntityException(errorMessage);
+
         default:
           super.accept(errorResponse);
       }
@@ -350,6 +358,9 @@ public class ErrorHandlers {
 
         case ErrorConstants.FORBIDDEN_CODE:
           throw new ForbiddenException(errorMessage);
+
+        case ErrorConstants.NON_IN_USE_ENTITY_CODE:
+          throw new NonInUseEntityException(errorMessage);
 
         case ErrorConstants.INTERNAL_ERROR_CODE:
           throw new RuntimeException(errorMessage);
@@ -393,6 +404,12 @@ public class ErrorHandlers {
 
         case ErrorConstants.INTERNAL_ERROR_CODE:
           throw new RuntimeException(errorMessage);
+
+        case ErrorConstants.ENTITY_IN_USE_CODE:
+          throw new EntityInUseException(errorMessage);
+
+        case ErrorConstants.NON_IN_USE_ENTITY_CODE:
+          throw new NonInUseEntityException(errorMessage);
 
         default:
           super.accept(errorResponse);
@@ -512,6 +529,9 @@ public class ErrorHandlers {
         case ErrorConstants.INTERNAL_ERROR_CODE:
           throw new RuntimeException(errorMessage);
 
+        case ErrorConstants.NON_IN_USE_ENTITY_CODE:
+          throw new NonInUseEntityException(errorMessage);
+
         default:
           super.accept(errorResponse);
       }
@@ -549,6 +569,9 @@ public class ErrorHandlers {
 
         case ErrorConstants.INTERNAL_ERROR_CODE:
           throw new RuntimeException(errorMessage);
+
+        case ErrorConstants.NON_IN_USE_ENTITY_CODE:
+          throw new NonInUseEntityException(errorMessage);
 
         default:
           super.accept(errorResponse);

--- a/clients/client-java/src/main/java/org/apache/gravitino/client/ErrorHandlers.java
+++ b/clients/client-java/src/main/java/org/apache/gravitino/client/ErrorHandlers.java
@@ -35,6 +35,7 @@ import org.apache.gravitino.exceptions.FilesetAlreadyExistsException;
 import org.apache.gravitino.exceptions.ForbiddenException;
 import org.apache.gravitino.exceptions.GroupAlreadyExistsException;
 import org.apache.gravitino.exceptions.IllegalPrivilegeException;
+import org.apache.gravitino.exceptions.InUseException;
 import org.apache.gravitino.exceptions.MetalakeAlreadyExistsException;
 import org.apache.gravitino.exceptions.NoSuchCatalogException;
 import org.apache.gravitino.exceptions.NoSuchFilesetException;
@@ -323,7 +324,12 @@ public class ErrorHandlers {
           throw new ForbiddenException(errorMessage);
 
         case ErrorConstants.NOT_IN_USE_CODE:
-          throw new CatalogNotInUseException(errorMessage);
+          if (errorResponse.getType().equals(CatalogNotInUseException.class.getSimpleName())) {
+            throw new CatalogNotInUseException(errorMessage);
+
+          } else {
+            throw new NotInUseException(errorMessage);
+          }
 
         default:
           super.accept(errorResponse);
@@ -366,7 +372,12 @@ public class ErrorHandlers {
           throw new ForbiddenException(errorMessage);
 
         case ErrorConstants.NOT_IN_USE_CODE:
-          throw new CatalogNotInUseException(errorMessage);
+          if (errorResponse.getType().equals(CatalogNotInUseException.class.getSimpleName())) {
+            throw new CatalogNotInUseException(errorMessage);
+
+          } else {
+            throw new NotInUseException(errorMessage);
+          }
 
         case ErrorConstants.INTERNAL_ERROR_CODE:
           throw new RuntimeException(errorMessage);
@@ -412,10 +423,20 @@ public class ErrorHandlers {
           throw new RuntimeException(errorMessage);
 
         case ErrorConstants.IN_USE_CODE:
-          throw new CatalogInUseException(errorMessage);
+          if (errorResponse.getType().equals(CatalogInUseException.class.getSimpleName())) {
+            throw new CatalogInUseException(errorMessage);
+
+          } else {
+            throw new InUseException(errorMessage);
+          }
 
         case ErrorConstants.NOT_IN_USE_CODE:
-          throw new CatalogNotInUseException(errorMessage);
+          if (errorResponse.getType().equals(CatalogNotInUseException.class.getSimpleName())) {
+            throw new CatalogNotInUseException(errorMessage);
+
+          } else {
+            throw new NotInUseException(errorMessage);
+          }
 
         default:
           super.accept(errorResponse);
@@ -536,7 +557,12 @@ public class ErrorHandlers {
           throw new RuntimeException(errorMessage);
 
         case ErrorConstants.NOT_IN_USE_CODE:
-          throw new CatalogNotInUseException(errorMessage);
+          if (errorResponse.getType().equals(CatalogNotInUseException.class.getSimpleName())) {
+            throw new CatalogNotInUseException(errorMessage);
+
+          } else {
+            throw new NotInUseException(errorMessage);
+          }
 
         default:
           super.accept(errorResponse);
@@ -577,7 +603,12 @@ public class ErrorHandlers {
           throw new RuntimeException(errorMessage);
 
         case ErrorConstants.NOT_IN_USE_CODE:
-          throw new CatalogNotInUseException(errorMessage);
+          if (errorResponse.getType().equals(CatalogNotInUseException.class.getSimpleName())) {
+            throw new CatalogNotInUseException(errorMessage);
+
+          } else {
+            throw new NotInUseException(errorMessage);
+          }
 
         default:
           super.accept(errorResponse);

--- a/clients/client-java/src/main/java/org/apache/gravitino/client/GravitinoClient.java
+++ b/clients/client-java/src/main/java/org/apache/gravitino/client/GravitinoClient.java
@@ -34,7 +34,7 @@ import org.apache.gravitino.authorization.Role;
 import org.apache.gravitino.authorization.SecurableObject;
 import org.apache.gravitino.authorization.User;
 import org.apache.gravitino.exceptions.CatalogAlreadyExistsException;
-import org.apache.gravitino.exceptions.EntityInUseException;
+import org.apache.gravitino.exceptions.CatalogInUseException;
 import org.apache.gravitino.exceptions.GroupAlreadyExistsException;
 import org.apache.gravitino.exceptions.IllegalPrivilegeException;
 import org.apache.gravitino.exceptions.NoSuchCatalogException;
@@ -130,7 +130,7 @@ public class GravitinoClient extends GravitinoClientBase
 
   @Override
   public boolean dropCatalog(String catalogName, boolean force)
-      throws NonEmptyEntityException, EntityInUseException {
+      throws NonEmptyEntityException, CatalogInUseException {
     return getMetalake().dropCatalog(catalogName, force);
   }
 

--- a/clients/client-java/src/main/java/org/apache/gravitino/client/GravitinoClient.java
+++ b/clients/client-java/src/main/java/org/apache/gravitino/client/GravitinoClient.java
@@ -135,13 +135,13 @@ public class GravitinoClient extends GravitinoClientBase
   }
 
   @Override
-  public void activateCatalog(String catalogName) throws NoSuchCatalogException {
-    getMetalake().activateCatalog(catalogName);
+  public void enableCatalog(String catalogName) throws NoSuchCatalogException {
+    getMetalake().enableCatalog(catalogName);
   }
 
   @Override
-  public void deactivateCatalog(String catalogName) throws NoSuchCatalogException {
-    getMetalake().deactivateCatalog(catalogName);
+  public void disableCatalog(String catalogName) throws NoSuchCatalogException {
+    getMetalake().disableCatalog(catalogName);
   }
 
   /**

--- a/clients/client-java/src/main/java/org/apache/gravitino/client/GravitinoClient.java
+++ b/clients/client-java/src/main/java/org/apache/gravitino/client/GravitinoClient.java
@@ -34,6 +34,7 @@ import org.apache.gravitino.authorization.Role;
 import org.apache.gravitino.authorization.SecurableObject;
 import org.apache.gravitino.authorization.User;
 import org.apache.gravitino.exceptions.CatalogAlreadyExistsException;
+import org.apache.gravitino.exceptions.EntityInUseException;
 import org.apache.gravitino.exceptions.GroupAlreadyExistsException;
 import org.apache.gravitino.exceptions.IllegalPrivilegeException;
 import org.apache.gravitino.exceptions.NoSuchCatalogException;
@@ -43,6 +44,7 @@ import org.apache.gravitino.exceptions.NoSuchMetalakeException;
 import org.apache.gravitino.exceptions.NoSuchRoleException;
 import org.apache.gravitino.exceptions.NoSuchTagException;
 import org.apache.gravitino.exceptions.NoSuchUserException;
+import org.apache.gravitino.exceptions.NonEmptyEntityException;
 import org.apache.gravitino.exceptions.NotFoundException;
 import org.apache.gravitino.exceptions.RoleAlreadyExistsException;
 import org.apache.gravitino.exceptions.TagAlreadyExistsException;
@@ -127,8 +129,19 @@ public class GravitinoClient extends GravitinoClientBase
   }
 
   @Override
-  public boolean dropCatalog(String catalogName) {
-    return getMetalake().dropCatalog(catalogName);
+  public boolean dropCatalog(String catalogName, boolean force)
+      throws NonEmptyEntityException, EntityInUseException {
+    return getMetalake().dropCatalog(catalogName, force);
+  }
+
+  @Override
+  public void activateCatalog(String catalogName) throws NoSuchCatalogException {
+    getMetalake().activateCatalog(catalogName);
+  }
+
+  @Override
+  public void deactivateCatalog(String catalogName) throws NoSuchCatalogException {
+    getMetalake().deactivateCatalog(catalogName);
   }
 
   /**

--- a/clients/client-java/src/main/java/org/apache/gravitino/client/GravitinoMetalake.java
+++ b/clients/client-java/src/main/java/org/apache/gravitino/client/GravitinoMetalake.java
@@ -77,6 +77,7 @@ import org.apache.gravitino.dto.responses.TagResponse;
 import org.apache.gravitino.dto.responses.UserListResponse;
 import org.apache.gravitino.dto.responses.UserResponse;
 import org.apache.gravitino.exceptions.CatalogAlreadyExistsException;
+import org.apache.gravitino.exceptions.EntityInUseException;
 import org.apache.gravitino.exceptions.GroupAlreadyExistsException;
 import org.apache.gravitino.exceptions.IllegalPrivilegeException;
 import org.apache.gravitino.exceptions.NoSuchCatalogException;
@@ -86,6 +87,7 @@ import org.apache.gravitino.exceptions.NoSuchMetalakeException;
 import org.apache.gravitino.exceptions.NoSuchRoleException;
 import org.apache.gravitino.exceptions.NoSuchTagException;
 import org.apache.gravitino.exceptions.NoSuchUserException;
+import org.apache.gravitino.exceptions.NonEmptyEntityException;
 import org.apache.gravitino.exceptions.NotFoundException;
 import org.apache.gravitino.exceptions.RoleAlreadyExistsException;
 import org.apache.gravitino.exceptions.TagAlreadyExistsException;
@@ -261,21 +263,68 @@ public class GravitinoMetalake extends MetalakeDTO
   }
 
   /**
-   * Drop the catalog with specified identifier.
+   * Drop a catalog with specified name. If the force flag is true, it will:
    *
-   * @param catalogName the name of the catalog.
-   * @return true if the catalog is dropped successfully, false if the catalog does not exist.
+   * <ul>
+   *   <li>Cascade drop all sub-entities (schemas, tables, etc.) of the catalog in Gravitino store.
+   *   <li>Drop the catalog even if it is in use.
+   *   <li>External resources (e.g. database, table, etc.) associated with sub-entities will not be
+   *       dropped unless it is managed (such as managed fileset).
+   * </ul>
+   *
+   * @param catalogName The identifier of the catalog.
+   * @param force Whether to force the drop.
+   * @return True if the catalog was dropped, false if the catalog does not exist.
+   * @throws NonEmptyEntityException If the catalog is not empty and force is false.
+   * @throws EntityInUseException If the catalog is in use and force is false.
    */
   @Override
-  public boolean dropCatalog(String catalogName) {
+  public boolean dropCatalog(String catalogName, boolean force)
+      throws NonEmptyEntityException, EntityInUseException {
+    Map<String, String> params = new HashMap<>();
+    params.put("force", String.valueOf(force));
+
     DropResponse resp =
         restClient.delete(
             String.format(API_METALAKES_CATALOGS_PATH, this.name(), catalogName),
+            params,
             DropResponse.class,
             Collections.emptyMap(),
             ErrorHandlers.catalogErrorHandler());
     resp.validate();
     return resp.dropped();
+  }
+
+  @Override
+  public void activateCatalog(String catalogName) throws NoSuchCatalogException {
+    ErrorResponse resp =
+        restClient.get(
+            String.format(API_METALAKES_CATALOGS_PATH, this.name(), catalogName) + "/activate",
+            ErrorResponse.class,
+            Collections.emptyMap(),
+            ErrorHandlers.catalogErrorHandler());
+
+    if (resp.getCode() == 0) {
+      return;
+    }
+
+    ErrorHandlers.catalogErrorHandler().accept(resp);
+  }
+
+  @Override
+  public void deactivateCatalog(String catalogName) throws NoSuchCatalogException {
+    ErrorResponse resp =
+        restClient.get(
+            String.format(API_METALAKES_CATALOGS_PATH, this.name(), catalogName) + "/deactivate",
+            ErrorResponse.class,
+            Collections.emptyMap(),
+            ErrorHandlers.catalogErrorHandler());
+
+    if (resp.getCode() == 0) {
+      return;
+    }
+
+    ErrorHandlers.catalogErrorHandler().accept(resp);
   }
 
   /**

--- a/clients/client-java/src/main/java/org/apache/gravitino/client/GravitinoMetalake.java
+++ b/clients/client-java/src/main/java/org/apache/gravitino/client/GravitinoMetalake.java
@@ -77,7 +77,7 @@ import org.apache.gravitino.dto.responses.TagResponse;
 import org.apache.gravitino.dto.responses.UserListResponse;
 import org.apache.gravitino.dto.responses.UserResponse;
 import org.apache.gravitino.exceptions.CatalogAlreadyExistsException;
-import org.apache.gravitino.exceptions.EntityInUseException;
+import org.apache.gravitino.exceptions.CatalogInUseException;
 import org.apache.gravitino.exceptions.GroupAlreadyExistsException;
 import org.apache.gravitino.exceptions.IllegalPrivilegeException;
 import org.apache.gravitino.exceptions.NoSuchCatalogException;
@@ -276,11 +276,11 @@ public class GravitinoMetalake extends MetalakeDTO
    * @param force Whether to force the drop.
    * @return True if the catalog was dropped, false if the catalog does not exist.
    * @throws NonEmptyEntityException If the catalog is not empty and force is false.
-   * @throws EntityInUseException If the catalog is in use and force is false.
+   * @throws CatalogInUseException If the catalog is in use and force is false.
    */
   @Override
   public boolean dropCatalog(String catalogName, boolean force)
-      throws NonEmptyEntityException, EntityInUseException {
+      throws NonEmptyEntityException, CatalogInUseException {
     Map<String, String> params = new HashMap<>();
     params.put("force", String.valueOf(force));
 

--- a/clients/client-java/src/main/java/org/apache/gravitino/client/GravitinoMetalake.java
+++ b/clients/client-java/src/main/java/org/apache/gravitino/client/GravitinoMetalake.java
@@ -296,7 +296,7 @@ public class GravitinoMetalake extends MetalakeDTO
   }
 
   @Override
-  public void activateCatalog(String catalogName) throws NoSuchCatalogException {
+  public void enableCatalog(String catalogName) throws NoSuchCatalogException {
     ErrorResponse resp =
         restClient.get(
             String.format(API_METALAKES_CATALOGS_PATH, this.name(), catalogName) + "/activate",
@@ -312,10 +312,10 @@ public class GravitinoMetalake extends MetalakeDTO
   }
 
   @Override
-  public void deactivateCatalog(String catalogName) throws NoSuchCatalogException {
+  public void disableCatalog(String catalogName) throws NoSuchCatalogException {
     ErrorResponse resp =
         restClient.get(
-            String.format(API_METALAKES_CATALOGS_PATH, this.name(), catalogName) + "/deactivate",
+            String.format(API_METALAKES_CATALOGS_PATH, this.name(), catalogName) + "/disable",
             ErrorResponse.class,
             Collections.emptyMap(),
             ErrorHandlers.catalogErrorHandler());

--- a/clients/client-java/src/main/java/org/apache/gravitino/client/GravitinoMetalake.java
+++ b/clients/client-java/src/main/java/org/apache/gravitino/client/GravitinoMetalake.java
@@ -46,6 +46,7 @@ import org.apache.gravitino.dto.AuditDTO;
 import org.apache.gravitino.dto.MetalakeDTO;
 import org.apache.gravitino.dto.authorization.SecurableObjectDTO;
 import org.apache.gravitino.dto.requests.CatalogCreateRequest;
+import org.apache.gravitino.dto.requests.CatalogSetRequest;
 import org.apache.gravitino.dto.requests.CatalogUpdateRequest;
 import org.apache.gravitino.dto.requests.CatalogUpdatesRequest;
 import org.apache.gravitino.dto.requests.GroupAddRequest;
@@ -297,9 +298,12 @@ public class GravitinoMetalake extends MetalakeDTO
 
   @Override
   public void enableCatalog(String catalogName) throws NoSuchCatalogException {
+    CatalogSetRequest req = new CatalogSetRequest(true);
+
     ErrorResponse resp =
-        restClient.get(
-            String.format(API_METALAKES_CATALOGS_PATH, this.name(), catalogName) + "/activate",
+        restClient.patch(
+            String.format(API_METALAKES_CATALOGS_PATH, this.name(), catalogName),
+            req,
             ErrorResponse.class,
             Collections.emptyMap(),
             ErrorHandlers.catalogErrorHandler());
@@ -313,9 +317,12 @@ public class GravitinoMetalake extends MetalakeDTO
 
   @Override
   public void disableCatalog(String catalogName) throws NoSuchCatalogException {
+    CatalogSetRequest req = new CatalogSetRequest(false);
+
     ErrorResponse resp =
-        restClient.get(
-            String.format(API_METALAKES_CATALOGS_PATH, this.name(), catalogName) + "/disable",
+        restClient.patch(
+            String.format(API_METALAKES_CATALOGS_PATH, this.name(), catalogName),
+            req,
             ErrorResponse.class,
             Collections.emptyMap(),
             ErrorHandlers.catalogErrorHandler());

--- a/clients/client-java/src/main/java/org/apache/gravitino/client/HTTPClient.java
+++ b/clients/client-java/src/main/java/org/apache/gravitino/client/HTTPClient.java
@@ -562,6 +562,31 @@ public class HTTPClient implements RESTClient {
   }
 
   /**
+   * Sends an HTTP PATCH request to the specified path with the provided request body and processes
+   * the response with support for response headers.
+   *
+   * @param path The URL path to send the PATCH request to.
+   * @param body The REST request to place in the request body.
+   * @param responseType The class type of the response for deserialization (Must be registered with
+   *     the ObjectMapper).
+   * @param headers A map of request headers (key-value pairs) to include in the request (can be
+   *     null).
+   * @param errorHandler The error handler delegated for HTTP responses, which handles server error
+   *     responses.
+   * @return The response entity parsed and converted to its type T.
+   * @param <T> The class type of the response for deserialization.
+   */
+  @Override
+  public <T extends RESTResponse> T patch(
+      String path,
+      RESTRequest body,
+      Class<T> responseType,
+      Map<String, String> headers,
+      Consumer<ErrorResponse> errorHandler) {
+    return execute(Method.PATCH, path, null, body, responseType, headers, errorHandler);
+  }
+
+  /**
    * Sends an HTTP DELETE request to the specified path without query parameters and processes the
    * response.
    *

--- a/clients/client-java/src/main/java/org/apache/gravitino/client/RESTClient.java
+++ b/clients/client-java/src/main/java/org/apache/gravitino/client/RESTClient.java
@@ -380,6 +380,24 @@ public interface RESTClient extends Closeable {
       Consumer<ErrorResponse> errorHandler);
 
   /**
+   * Perform a PATCH request on the specified path with given information.
+   *
+   * @param path The path to be requested.
+   * @param body The request body to be included in the PATCH request.
+   * @param responseType The class representing the type of the response.
+   * @param headers The headers to be included in the request.
+   * @param errorHandler The consumer for handling error responses.
+   * @return The response of the PATCH request.
+   * @param <T> The type of the response.
+   */
+  <T extends RESTResponse> T patch(
+      String path,
+      RESTRequest body,
+      Class<T> responseType,
+      Map<String, String> headers,
+      Consumer<ErrorResponse> errorHandler);
+
+  /**
    * Perform a POST request with form data on the specified path with the given information.
    *
    * @param path The path to be requested.

--- a/clients/client-java/src/test/java/org/apache/gravitino/client/TestGravitinoMetalake.java
+++ b/clients/client-java/src/test/java/org/apache/gravitino/client/TestGravitinoMetalake.java
@@ -400,7 +400,7 @@ public class TestGravitinoMetalake extends TestBase {
 
     DropResponse resp = new DropResponse(true);
     buildMockResource(Method.DELETE, path, null, resp, HttpStatus.SC_OK);
-    boolean dropped = gravitinoClient.dropCatalog(catalogName);
+    boolean dropped = gravitinoClient.dropCatalog(catalogName, true);
     Assertions.assertTrue(dropped, "catalog should be dropped");
 
     // Test return false

--- a/clients/client-java/src/test/java/org/apache/gravitino/client/integration/test/CatalogIT.java
+++ b/clients/client-java/src/test/java/org/apache/gravitino/client/integration/test/CatalogIT.java
@@ -35,8 +35,8 @@ import org.apache.gravitino.SchemaChange;
 import org.apache.gravitino.SupportsSchemas;
 import org.apache.gravitino.client.GravitinoMetalake;
 import org.apache.gravitino.exceptions.CatalogAlreadyExistsException;
-import org.apache.gravitino.exceptions.EntityInUseException;
-import org.apache.gravitino.exceptions.NotInUseEntityException;
+import org.apache.gravitino.exceptions.CatalogInUseException;
+import org.apache.gravitino.exceptions.CatalogNotInUseException;
 import org.apache.gravitino.file.FilesetCatalog;
 import org.apache.gravitino.file.FilesetChange;
 import org.apache.gravitino.integration.test.container.ContainerSuite;
@@ -145,7 +145,7 @@ public class CatalogIT extends BaseIT {
 
     Exception exception =
         Assertions.assertThrows(
-            EntityInUseException.class, () -> metalake.dropCatalog(catalogName));
+            CatalogInUseException.class, () -> metalake.dropCatalog(catalogName));
     Assertions.assertTrue(
         exception.getMessage().contains("please deactivate it first or use force option"),
         exception.getMessage());
@@ -165,7 +165,7 @@ public class CatalogIT extends BaseIT {
 
     Exception exception =
         Assertions.assertThrows(
-            EntityInUseException.class, () -> metalake.dropCatalog(catalogName));
+            CatalogInUseException.class, () -> metalake.dropCatalog(catalogName));
     Assertions.assertTrue(
         exception.getMessage().contains("please deactivate it first or use force option"),
         exception.getMessage());
@@ -176,42 +176,42 @@ public class CatalogIT extends BaseIT {
 
     exception =
         Assertions.assertThrows(
-            NotInUseEntityException.class,
+            CatalogNotInUseException.class,
             () -> metalake.alterCatalog(catalogName, CatalogChange.updateComment("new comment")));
     Assertions.assertTrue(
         exception.getMessage().contains("please activate it first"), exception.getMessage());
 
     // test schema operations under non-in-use catalog
     SupportsSchemas schemaOps = loadedCatalog.asSchemas();
-    Assertions.assertThrows(NotInUseEntityException.class, schemaOps::listSchemas);
+    Assertions.assertThrows(CatalogNotInUseException.class, schemaOps::listSchemas);
     Assertions.assertThrows(
-        NotInUseEntityException.class, () -> schemaOps.createSchema("dummy", null, null));
-    Assertions.assertThrows(NotInUseEntityException.class, () -> schemaOps.loadSchema("dummy"));
+        CatalogNotInUseException.class, () -> schemaOps.createSchema("dummy", null, null));
+    Assertions.assertThrows(CatalogNotInUseException.class, () -> schemaOps.loadSchema("dummy"));
     Assertions.assertThrows(
-        NotInUseEntityException.class,
+        CatalogNotInUseException.class,
         () -> schemaOps.alterSchema("dummy", SchemaChange.removeProperty("dummy")));
     Assertions.assertThrows(
-        NotInUseEntityException.class, () -> schemaOps.dropSchema("dummy", false));
+        CatalogNotInUseException.class, () -> schemaOps.dropSchema("dummy", false));
 
     // test fileset operations under non-in-use catalog
     FilesetCatalog filesetOps = loadedCatalog.asFilesetCatalog();
     Assertions.assertThrows(
-        NotInUseEntityException.class, () -> filesetOps.listFilesets(Namespace.of("dummy")));
+        CatalogNotInUseException.class, () -> filesetOps.listFilesets(Namespace.of("dummy")));
     Assertions.assertThrows(
-        NotInUseEntityException.class,
+        CatalogNotInUseException.class,
         () -> filesetOps.loadFileset(NameIdentifier.of("dummy", "dummy")));
     Assertions.assertThrows(
-        NotInUseEntityException.class,
+        CatalogNotInUseException.class,
         () ->
             filesetOps.createFileset(NameIdentifier.of("dummy", "dummy"), null, null, null, null));
     Assertions.assertThrows(
-        NotInUseEntityException.class,
+        CatalogNotInUseException.class,
         () -> filesetOps.dropFileset(NameIdentifier.of("dummy", "dummy")));
     Assertions.assertThrows(
-        NotInUseEntityException.class,
+        CatalogNotInUseException.class,
         () -> filesetOps.getFileLocation(NameIdentifier.of("dummy", "dummy"), "dummy"));
     Assertions.assertThrows(
-        NotInUseEntityException.class,
+        CatalogNotInUseException.class,
         () ->
             filesetOps.alterFileset(
                 NameIdentifier.of("dummy", "dummy"), FilesetChange.removeComment()));

--- a/clients/client-java/src/test/java/org/apache/gravitino/client/integration/test/CatalogIT.java
+++ b/clients/client-java/src/test/java/org/apache/gravitino/client/integration/test/CatalogIT.java
@@ -179,7 +179,7 @@ public class CatalogIT extends BaseIT {
             CatalogNotInUseException.class,
             () -> metalake.alterCatalog(catalogName, CatalogChange.updateComment("new comment")));
     Assertions.assertTrue(
-        exception.getMessage().contains("please activate it first"), exception.getMessage());
+        exception.getMessage().contains("please enable it first"), exception.getMessage());
 
     // test schema operations under non-in-use catalog
     SupportsSchemas schemaOps = loadedCatalog.asSchemas();

--- a/clients/client-java/src/test/java/org/apache/gravitino/client/integration/test/CatalogIT.java
+++ b/clients/client-java/src/test/java/org/apache/gravitino/client/integration/test/CatalogIT.java
@@ -147,10 +147,10 @@ public class CatalogIT extends BaseIT {
         Assertions.assertThrows(
             CatalogInUseException.class, () -> metalake.dropCatalog(catalogName));
     Assertions.assertTrue(
-        exception.getMessage().contains("please deactivate it first or use force option"),
+        exception.getMessage().contains("please disable it first or use force option"),
         exception.getMessage());
 
-    Assertions.assertDoesNotThrow(() -> metalake.deactivateCatalog(catalogName));
+    Assertions.assertDoesNotThrow(() -> metalake.disableCatalog(catalogName));
     Assertions.assertTrue(metalake.dropCatalog(catalogName), "catalog should be dropped");
     Assertions.assertFalse(metalake.dropCatalog(catalogName), "catalog should be non-existent");
   }
@@ -167,10 +167,10 @@ public class CatalogIT extends BaseIT {
         Assertions.assertThrows(
             CatalogInUseException.class, () -> metalake.dropCatalog(catalogName));
     Assertions.assertTrue(
-        exception.getMessage().contains("please deactivate it first or use force option"),
+        exception.getMessage().contains("please disable it first or use force option"),
         exception.getMessage());
 
-    Assertions.assertDoesNotThrow(() -> metalake.deactivateCatalog(catalogName));
+    Assertions.assertDoesNotThrow(() -> metalake.disableCatalog(catalogName));
     Catalog loadedCatalog = metalake.loadCatalog(catalogName);
     Assertions.assertEquals("false", loadedCatalog.properties().get(PROPERTY_IN_USE));
 
@@ -235,7 +235,7 @@ public class CatalogIT extends BaseIT {
     Assertions.assertEquals("hadoop", catalog.provider());
     Assertions.assertEquals("catalog comment", catalog.comment());
     Assertions.assertEquals("true", catalog.properties().get(PROPERTY_IN_USE));
-    metalake.deactivateCatalog(catalogName);
+    metalake.disableCatalog(catalogName);
     metalake.dropCatalog(catalogName);
 
     // test cloud related properties
@@ -266,7 +266,7 @@ public class CatalogIT extends BaseIT {
     Assertions.assertFalse(catalog.properties().isEmpty());
     Assertions.assertEquals("aws", catalog.properties().get("cloud.name"));
     Assertions.assertEquals("us-west-2", catalog.properties().get("cloud.region-code"));
-    metalake.deactivateCatalog(catalogName);
+    metalake.disableCatalog(catalogName);
     metalake.dropCatalog(catalogName);
   }
 
@@ -286,7 +286,7 @@ public class CatalogIT extends BaseIT {
     Assertions.assertEquals("这是中文comment", catalog.comment());
     Assertions.assertTrue(catalog.properties().containsKey("metastore.uris"));
 
-    metalake.deactivateCatalog(catalogName);
+    metalake.disableCatalog(catalogName);
     metalake.dropCatalog(catalogName);
   }
 
@@ -319,10 +319,10 @@ public class CatalogIT extends BaseIT {
     Assertions.assertTrue(ArrayUtils.contains(catalogs, relCatalog));
     Assertions.assertTrue(ArrayUtils.contains(catalogs, fileCatalog));
 
-    metalake.deactivateCatalog(relCatalogName);
+    metalake.disableCatalog(relCatalogName);
     metalake.dropCatalog(relCatalogName);
 
-    metalake.deactivateCatalog(fileCatalogName);
+    metalake.disableCatalog(fileCatalogName);
     metalake.dropCatalog(fileCatalogName);
   }
 
@@ -358,7 +358,7 @@ public class CatalogIT extends BaseIT {
     Assertions.assertEquals("catalog comment", catalog.comment());
     Assertions.assertTrue(catalog.properties().containsKey("package"));
 
-    metalake.deactivateCatalog(catalogName);
+    metalake.disableCatalog(catalogName);
     metalake.dropCatalog(catalogName);
 
     // Test using invalid package path
@@ -392,7 +392,7 @@ public class CatalogIT extends BaseIT {
         metalake.alterCatalog(catalogName, CatalogChange.updateComment("new catalog comment"));
     Assertions.assertEquals("new catalog comment", updatedCatalog.comment());
 
-    metalake.deactivateCatalog(catalogName);
+    metalake.disableCatalog(catalogName);
     metalake.dropCatalog(catalogName);
   }
 
@@ -423,7 +423,7 @@ public class CatalogIT extends BaseIT {
     Assertions.assertEquals(alterCloudName, alteredCatalog.properties().get(Catalog.CLOUD_NAME));
     Assertions.assertEquals(
         alterRegionCode, alteredCatalog.properties().get(Catalog.CLOUD_REGION_CODE));
-    metalake.deactivateCatalog(catalogName);
+    metalake.disableCatalog(catalogName);
     metalake.dropCatalog(catalogName);
   }
 }

--- a/clients/client-java/src/test/java/org/apache/gravitino/client/integration/test/CatalogIT.java
+++ b/clients/client-java/src/test/java/org/apache/gravitino/client/integration/test/CatalogIT.java
@@ -36,7 +36,7 @@ import org.apache.gravitino.SupportsSchemas;
 import org.apache.gravitino.client.GravitinoMetalake;
 import org.apache.gravitino.exceptions.CatalogAlreadyExistsException;
 import org.apache.gravitino.exceptions.EntityInUseException;
-import org.apache.gravitino.exceptions.NonInUseEntityException;
+import org.apache.gravitino.exceptions.NotInUseEntityException;
 import org.apache.gravitino.file.FilesetCatalog;
 import org.apache.gravitino.file.FilesetChange;
 import org.apache.gravitino.integration.test.container.ContainerSuite;
@@ -176,42 +176,42 @@ public class CatalogIT extends BaseIT {
 
     exception =
         Assertions.assertThrows(
-            NonInUseEntityException.class,
+            NotInUseEntityException.class,
             () -> metalake.alterCatalog(catalogName, CatalogChange.updateComment("new comment")));
     Assertions.assertTrue(
         exception.getMessage().contains("please activate it first"), exception.getMessage());
 
     // test schema operations under non-in-use catalog
     SupportsSchemas schemaOps = loadedCatalog.asSchemas();
-    Assertions.assertThrows(NonInUseEntityException.class, schemaOps::listSchemas);
+    Assertions.assertThrows(NotInUseEntityException.class, schemaOps::listSchemas);
     Assertions.assertThrows(
-        NonInUseEntityException.class, () -> schemaOps.createSchema("dummy", null, null));
-    Assertions.assertThrows(NonInUseEntityException.class, () -> schemaOps.loadSchema("dummy"));
+        NotInUseEntityException.class, () -> schemaOps.createSchema("dummy", null, null));
+    Assertions.assertThrows(NotInUseEntityException.class, () -> schemaOps.loadSchema("dummy"));
     Assertions.assertThrows(
-        NonInUseEntityException.class,
+        NotInUseEntityException.class,
         () -> schemaOps.alterSchema("dummy", SchemaChange.removeProperty("dummy")));
     Assertions.assertThrows(
-        NonInUseEntityException.class, () -> schemaOps.dropSchema("dummy", false));
+        NotInUseEntityException.class, () -> schemaOps.dropSchema("dummy", false));
 
     // test fileset operations under non-in-use catalog
     FilesetCatalog filesetOps = loadedCatalog.asFilesetCatalog();
     Assertions.assertThrows(
-        NonInUseEntityException.class, () -> filesetOps.listFilesets(Namespace.of("dummy")));
+        NotInUseEntityException.class, () -> filesetOps.listFilesets(Namespace.of("dummy")));
     Assertions.assertThrows(
-        NonInUseEntityException.class,
+        NotInUseEntityException.class,
         () -> filesetOps.loadFileset(NameIdentifier.of("dummy", "dummy")));
     Assertions.assertThrows(
-        NonInUseEntityException.class,
+        NotInUseEntityException.class,
         () ->
             filesetOps.createFileset(NameIdentifier.of("dummy", "dummy"), null, null, null, null));
     Assertions.assertThrows(
-        NonInUseEntityException.class,
+        NotInUseEntityException.class,
         () -> filesetOps.dropFileset(NameIdentifier.of("dummy", "dummy")));
     Assertions.assertThrows(
-        NonInUseEntityException.class,
+        NotInUseEntityException.class,
         () -> filesetOps.getFileLocation(NameIdentifier.of("dummy", "dummy"), "dummy"));
     Assertions.assertThrows(
-        NonInUseEntityException.class,
+        NotInUseEntityException.class,
         () ->
             filesetOps.alterFileset(
                 NameIdentifier.of("dummy", "dummy"), FilesetChange.removeComment()));

--- a/clients/client-java/src/test/java/org/apache/gravitino/client/integration/test/CatalogIT.java
+++ b/clients/client-java/src/test/java/org/apache/gravitino/client/integration/test/CatalogIT.java
@@ -19,6 +19,8 @@
 
 package org.apache.gravitino.client.integration.test;
 
+import static org.apache.gravitino.Catalog.PROPERTY_IN_USE;
+
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import java.io.File;
@@ -27,8 +29,16 @@ import java.util.Map;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.gravitino.Catalog;
 import org.apache.gravitino.CatalogChange;
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.Namespace;
+import org.apache.gravitino.SchemaChange;
+import org.apache.gravitino.SupportsSchemas;
 import org.apache.gravitino.client.GravitinoMetalake;
 import org.apache.gravitino.exceptions.CatalogAlreadyExistsException;
+import org.apache.gravitino.exceptions.EntityInUseException;
+import org.apache.gravitino.exceptions.NonInUseEntityException;
+import org.apache.gravitino.file.FilesetCatalog;
+import org.apache.gravitino.file.FilesetChange;
 import org.apache.gravitino.integration.test.container.ContainerSuite;
 import org.apache.gravitino.integration.test.container.HiveContainer;
 import org.apache.gravitino.integration.test.util.BaseIT;
@@ -110,7 +120,7 @@ public class CatalogIT extends BaseIT {
     Assertions.assertEquals("catalog comment", catalog.comment());
     Assertions.assertTrue(catalog.properties().containsKey("metastore.uris"));
 
-    metalake.dropCatalog(catalogName);
+    metalake.dropCatalog(catalogName, true);
   }
 
   @Test
@@ -120,9 +130,9 @@ public class CatalogIT extends BaseIT {
 
     Map<String, String> properties = Maps.newHashMap();
     properties.put("metastore.uris", hmsUri);
-    Catalog catalog =
-        metalake.createCatalog(
-            catalogName, Catalog.Type.RELATIONAL, "hive", "catalog comment", properties);
+    metalake.createCatalog(
+        catalogName, Catalog.Type.RELATIONAL, "hive", "catalog comment", properties);
+    Catalog catalog = metalake.loadCatalog(catalogName);
     Assertions.assertTrue(metalake.catalogExists(catalogName));
     Assertions.assertEquals(catalogName, catalog.name());
 
@@ -132,6 +142,79 @@ public class CatalogIT extends BaseIT {
             metalake.createCatalog(
                 catalogName, Catalog.Type.RELATIONAL, "hive", "catalog comment", properties));
     Assertions.assertTrue(metalake.catalogExists(catalogName));
+
+    Exception exception =
+        Assertions.assertThrows(
+            EntityInUseException.class, () -> metalake.dropCatalog(catalogName));
+    Assertions.assertTrue(
+        exception.getMessage().contains("please deactivate it first or use force option"),
+        exception.getMessage());
+
+    Assertions.assertDoesNotThrow(() -> metalake.deactivateCatalog(catalogName));
+    Assertions.assertTrue(metalake.dropCatalog(catalogName), "catalog should be dropped");
+    Assertions.assertFalse(metalake.dropCatalog(catalogName), "catalog should be non-existent");
+  }
+
+  @Test
+  public void testCatalogAvailable() {
+    String catalogName = GravitinoITUtils.genRandomName("test_catalog");
+    Catalog catalog =
+        metalake.createCatalog(
+            catalogName, Catalog.Type.FILESET, "hadoop", "catalog comment", ImmutableMap.of());
+    Assertions.assertEquals("true", catalog.properties().get(PROPERTY_IN_USE));
+
+    Exception exception =
+        Assertions.assertThrows(
+            EntityInUseException.class, () -> metalake.dropCatalog(catalogName));
+    Assertions.assertTrue(
+        exception.getMessage().contains("please deactivate it first or use force option"),
+        exception.getMessage());
+
+    Assertions.assertDoesNotThrow(() -> metalake.deactivateCatalog(catalogName));
+    Catalog loadedCatalog = metalake.loadCatalog(catalogName);
+    Assertions.assertEquals("false", loadedCatalog.properties().get(PROPERTY_IN_USE));
+
+    exception =
+        Assertions.assertThrows(
+            NonInUseEntityException.class,
+            () -> metalake.alterCatalog(catalogName, CatalogChange.updateComment("new comment")));
+    Assertions.assertTrue(
+        exception.getMessage().contains("please activate it first"), exception.getMessage());
+
+    // test schema operations under non-in-use catalog
+    SupportsSchemas schemaOps = loadedCatalog.asSchemas();
+    Assertions.assertThrows(NonInUseEntityException.class, schemaOps::listSchemas);
+    Assertions.assertThrows(
+        NonInUseEntityException.class, () -> schemaOps.createSchema("dummy", null, null));
+    Assertions.assertThrows(NonInUseEntityException.class, () -> schemaOps.loadSchema("dummy"));
+    Assertions.assertThrows(
+        NonInUseEntityException.class,
+        () -> schemaOps.alterSchema("dummy", SchemaChange.removeProperty("dummy")));
+    Assertions.assertThrows(
+        NonInUseEntityException.class, () -> schemaOps.dropSchema("dummy", false));
+
+    // test fileset operations under non-in-use catalog
+    FilesetCatalog filesetOps = loadedCatalog.asFilesetCatalog();
+    Assertions.assertThrows(
+        NonInUseEntityException.class, () -> filesetOps.listFilesets(Namespace.of("dummy")));
+    Assertions.assertThrows(
+        NonInUseEntityException.class,
+        () -> filesetOps.loadFileset(NameIdentifier.of("dummy", "dummy")));
+    Assertions.assertThrows(
+        NonInUseEntityException.class,
+        () ->
+            filesetOps.createFileset(NameIdentifier.of("dummy", "dummy"), null, null, null, null));
+    Assertions.assertThrows(
+        NonInUseEntityException.class,
+        () -> filesetOps.dropFileset(NameIdentifier.of("dummy", "dummy")));
+    Assertions.assertThrows(
+        NonInUseEntityException.class,
+        () -> filesetOps.getFileLocation(NameIdentifier.of("dummy", "dummy"), "dummy"));
+    Assertions.assertThrows(
+        NonInUseEntityException.class,
+        () ->
+            filesetOps.alterFileset(
+                NameIdentifier.of("dummy", "dummy"), FilesetChange.removeComment()));
 
     Assertions.assertTrue(metalake.dropCatalog(catalogName), "catalog should be dropped");
     Assertions.assertFalse(metalake.dropCatalog(catalogName), "catalog should be non-existent");
@@ -151,7 +234,8 @@ public class CatalogIT extends BaseIT {
     Assertions.assertEquals(Catalog.Type.FILESET, catalog.type());
     Assertions.assertEquals("hadoop", catalog.provider());
     Assertions.assertEquals("catalog comment", catalog.comment());
-    Assertions.assertTrue(catalog.properties().isEmpty());
+    Assertions.assertEquals("true", catalog.properties().get(PROPERTY_IN_USE));
+    metalake.deactivateCatalog(catalogName);
     metalake.dropCatalog(catalogName);
 
     // test cloud related properties
@@ -182,6 +266,7 @@ public class CatalogIT extends BaseIT {
     Assertions.assertFalse(catalog.properties().isEmpty());
     Assertions.assertEquals("aws", catalog.properties().get("cloud.name"));
     Assertions.assertEquals("us-west-2", catalog.properties().get("cloud.region-code"));
+    metalake.deactivateCatalog(catalogName);
     metalake.dropCatalog(catalogName);
   }
 
@@ -201,6 +286,7 @@ public class CatalogIT extends BaseIT {
     Assertions.assertEquals("这是中文comment", catalog.comment());
     Assertions.assertTrue(catalog.properties().containsKey("metastore.uris"));
 
+    metalake.deactivateCatalog(catalogName);
     metalake.dropCatalog(catalogName);
   }
 
@@ -209,22 +295,18 @@ public class CatalogIT extends BaseIT {
     String relCatalogName = GravitinoITUtils.genRandomName("rel_catalog_");
     Map<String, String> properties = Maps.newHashMap();
     properties.put("metastore.uris", hmsUri);
-    Catalog relCatalog =
-        metalake.createCatalog(
-            relCatalogName,
-            Catalog.Type.RELATIONAL,
-            "hive",
-            "relational catalog comment",
-            properties);
+    metalake.createCatalog(
+        relCatalogName, Catalog.Type.RELATIONAL, "hive", "relational catalog comment", properties);
+    Catalog relCatalog = metalake.loadCatalog(relCatalogName);
 
     String fileCatalogName = GravitinoITUtils.genRandomName("file_catalog_");
-    Catalog fileCatalog =
-        metalake.createCatalog(
-            fileCatalogName,
-            Catalog.Type.FILESET,
-            "hadoop",
-            "file catalog comment",
-            Collections.emptyMap());
+    metalake.createCatalog(
+        fileCatalogName,
+        Catalog.Type.FILESET,
+        "hadoop",
+        "file catalog comment",
+        Collections.emptyMap());
+    Catalog fileCatalog = metalake.loadCatalog(fileCatalogName);
 
     Catalog[] catalogs = metalake.listCatalogsInfo();
     for (Catalog catalog : catalogs) {
@@ -237,7 +319,10 @@ public class CatalogIT extends BaseIT {
     Assertions.assertTrue(ArrayUtils.contains(catalogs, relCatalog));
     Assertions.assertTrue(ArrayUtils.contains(catalogs, fileCatalog));
 
+    metalake.deactivateCatalog(relCatalogName);
     metalake.dropCatalog(relCatalogName);
+
+    metalake.deactivateCatalog(fileCatalogName);
     metalake.dropCatalog(fileCatalogName);
   }
 
@@ -273,6 +358,7 @@ public class CatalogIT extends BaseIT {
     Assertions.assertEquals("catalog comment", catalog.comment());
     Assertions.assertTrue(catalog.properties().containsKey("package"));
 
+    metalake.deactivateCatalog(catalogName);
     metalake.dropCatalog(catalogName);
 
     // Test using invalid package path
@@ -300,12 +386,13 @@ public class CatalogIT extends BaseIT {
     Assertions.assertTrue(metalake.catalogExists(catalogName));
 
     Assertions.assertEquals(catalogName, catalog.name());
-    Assertions.assertEquals(null, catalog.comment());
+    Assertions.assertNull(catalog.comment());
 
     Catalog updatedCatalog =
         metalake.alterCatalog(catalogName, CatalogChange.updateComment("new catalog comment"));
     Assertions.assertEquals("new catalog comment", updatedCatalog.comment());
 
+    metalake.deactivateCatalog(catalogName);
     metalake.dropCatalog(catalogName);
   }
 
@@ -336,6 +423,7 @@ public class CatalogIT extends BaseIT {
     Assertions.assertEquals(alterCloudName, alteredCatalog.properties().get(Catalog.CLOUD_NAME));
     Assertions.assertEquals(
         alterRegionCode, alteredCatalog.properties().get(Catalog.CLOUD_REGION_CODE));
+    metalake.deactivateCatalog(catalogName);
     metalake.dropCatalog(catalogName);
   }
 }

--- a/clients/client-java/src/test/java/org/apache/gravitino/client/integration/test/TagIT.java
+++ b/clients/client-java/src/test/java/org/apache/gravitino/client/integration/test/TagIT.java
@@ -111,7 +111,7 @@ public class TagIT extends BaseIT {
   public void tearDown() {
     relationalCatalog.asTableCatalog().dropTable(NameIdentifier.of(schema.name(), table.name()));
     relationalCatalog.asSchemas().dropSchema(schema.name(), true);
-    metalake.dropCatalog(relationalCatalog.name());
+    metalake.dropCatalog(relationalCatalog.name(), true);
     client.dropMetalake(metalakeName);
 
     if (client != null) {

--- a/clients/client-java/src/test/java/org/apache/gravitino/client/integration/test/authorization/CheckCurrentUserIT.java
+++ b/clients/client-java/src/test/java/org/apache/gravitino/client/integration/test/authorization/CheckCurrentUserIT.java
@@ -146,7 +146,7 @@ public class CheckCurrentUserIT extends BaseIT {
                 .createTopic(topicIdent, "comment", null, Collections.emptyMap()));
     catalog.asTopicCatalog().dropTopic(topicIdent);
 
-    metalake.dropCatalog(catalogName);
+    metalake.dropCatalog(catalogName, true);
   }
 
   @Test
@@ -191,7 +191,7 @@ public class CheckCurrentUserIT extends BaseIT {
     // Clean up
     catalog.asFilesetCatalog().dropFileset(fileIdent);
     catalog.asSchemas().dropSchema("schema", true);
-    metalake.dropCatalog(catalogName);
+    metalake.dropCatalog(catalogName, true);
   }
 
   @Test
@@ -268,6 +268,6 @@ public class CheckCurrentUserIT extends BaseIT {
     // Clean up
     catalog.asTableCatalog().dropTable(tableIdent);
     catalog.asSchemas().dropSchema("schema", true);
-    metalake.dropCatalog(catalogName);
+    metalake.dropCatalog(catalogName, true);
   }
 }

--- a/clients/client-java/src/test/java/org/apache/gravitino/client/integration/test/authorization/OwnerIT.java
+++ b/clients/client-java/src/test/java/org/apache/gravitino/client/integration/test/authorization/OwnerIT.java
@@ -168,7 +168,7 @@ public class OwnerIT extends BaseIT {
     // Clean up
     catalog.asFilesetCatalog().dropFileset(fileIdent);
     catalog.asSchemas().dropSchema("schema_owner", true);
-    metalake.dropCatalog(catalogNameA);
+    metalake.dropCatalog(catalogNameA, true);
     client.dropMetalake(metalakeNameA);
   }
 
@@ -219,7 +219,7 @@ public class OwnerIT extends BaseIT {
 
     // Clean up
     catalogB.asTopicCatalog().dropTopic(topicIdent);
-    metalake.dropCatalog(catalogNameB);
+    metalake.dropCatalog(catalogNameB, true);
     client.dropMetalake(metalakeNameB);
   }
 
@@ -320,7 +320,7 @@ public class OwnerIT extends BaseIT {
     // Clean up
     catalog.asTableCatalog().dropTable(tableIdent);
     catalog.asSchemas().dropSchema("schema_owner", true);
-    metalake.dropCatalog(catalogNameD);
+    metalake.dropCatalog(catalogNameD, true);
     client.dropMetalake(metalakeNameD);
   }
 

--- a/clients/client-python/gravitino/client/gravitino_client.py
+++ b/clients/client-python/gravitino/client/gravitino_client.py
@@ -89,5 +89,11 @@ class GravitinoClient(GravitinoClientBase):
     def alter_catalog(self, name: str, *changes: CatalogChange):
         return self.get_metalake().alter_catalog(name, *changes)
 
-    def drop_catalog(self, name: str):
-        return self.get_metalake().drop_catalog(name)
+    def drop_catalog(self, name: str, force: bool = False) -> bool:
+        return self.get_metalake().drop_catalog(name, force)
+
+    def activate_catalog(self, name: str):
+        return self.get_metalake().activate_catalog(name)
+
+    def deactivate_catalog(self, name: str):
+        return self.get_metalake().deactivate_catalog(name)

--- a/clients/client-python/gravitino/client/gravitino_client.py
+++ b/clients/client-python/gravitino/client/gravitino_client.py
@@ -92,8 +92,8 @@ class GravitinoClient(GravitinoClientBase):
     def drop_catalog(self, name: str, force: bool = False) -> bool:
         return self.get_metalake().drop_catalog(name, force)
 
-    def activate_catalog(self, name: str):
-        return self.get_metalake().activate_catalog(name)
+    def enable_catalog(self, name: str):
+        return self.get_metalake().enable_catalog(name)
 
-    def deactivate_catalog(self, name: str):
-        return self.get_metalake().deactivate_catalog(name)
+    def disable_catalog(self, name: str):
+        return self.get_metalake().disable_catalog(name)

--- a/clients/client-python/gravitino/client/gravitino_metalake.py
+++ b/clients/client-python/gravitino/client/gravitino_metalake.py
@@ -185,19 +185,47 @@ class GravitinoMetalake(MetalakeDTO):
             self.name(), catalog_response.catalog(), self.rest_client
         )
 
-    def drop_catalog(self, name: str) -> bool:
+    def drop_catalog(self, name: str, force: bool = False) -> bool:
         """Drop the catalog with specified name.
 
         Args:
-            name the name of the catalog.
+            name: the name of the catalog.
+            force: whether to force drop the catalog.
 
         Returns:
-            true if the catalog is dropped successfully, false otherwise.
+            true if the catalog is dropped successfully, false if the catalog does not exist.
         """
+        params = {"force": str(force)}
         url = self.API_METALAKES_CATALOGS_PATH.format(self.name(), name)
-        response = self.rest_client.delete(url, error_handler=CATALOG_ERROR_HANDLER)
+        response = self.rest_client.delete(
+            url, params=params, error_handler=CATALOG_ERROR_HANDLER
+        )
 
         drop_response = DropResponse.from_json(response.body, infer_missing=True)
         drop_response.validate()
 
         return drop_response.dropped()
+
+    def activate_catalog(self, name: str):
+        """Activate the catalog with specified name. If the catalog is already activated, this method does nothing.
+
+        Args:
+            name: the name of the catalog.
+
+        Raises:
+            NoSuchCatalogException if the catalog with specified name does not exist.
+        """
+        url = self.API_METALAKES_CATALOGS_PATH.format(self.name(), name) + "/activate"
+        self.rest_client.get(url, error_handler=CATALOG_ERROR_HANDLER)
+
+    def deactivate_catalog(self, name: str):
+        """Deactivate the catalog with specified name. If the catalog is already deactivated, this method does nothing.
+
+        Args:
+            name: the name of the catalog.
+
+        Raises:
+            NoSuchCatalogException if the catalog with specified name does not exist.
+        """
+        url = self.API_METALAKES_CATALOGS_PATH.format(self.name(), name) + "/deactivate"
+        self.rest_client.get(url, error_handler=CATALOG_ERROR_HANDLER)

--- a/clients/client-python/gravitino/client/gravitino_metalake.py
+++ b/clients/client-python/gravitino/client/gravitino_metalake.py
@@ -23,6 +23,7 @@ from gravitino.api.catalog_change import CatalogChange
 from gravitino.dto.dto_converters import DTOConverters
 from gravitino.dto.metalake_dto import MetalakeDTO
 from gravitino.dto.requests.catalog_create_request import CatalogCreateRequest
+from gravitino.dto.requests.catalog_set_request import CatalogSetRequest
 from gravitino.dto.requests.catalog_updates_request import CatalogUpdatesRequest
 from gravitino.dto.responses.catalog_list_response import CatalogListResponse
 from gravitino.dto.responses.catalog_response import CatalogResponse
@@ -215,8 +216,14 @@ class GravitinoMetalake(MetalakeDTO):
         Raises:
             NoSuchCatalogException if the catalog with specified name does not exist.
         """
-        url = self.API_METALAKES_CATALOGS_PATH.format(self.name(), name) + "/enable"
-        self.rest_client.get(url, error_handler=CATALOG_ERROR_HANDLER)
+
+        catalog_enable_request = CatalogSetRequest(in_use=True)
+        catalog_enable_request.validate()
+
+        url = self.API_METALAKES_CATALOGS_PATH.format(self.name(), name)
+        self.rest_client.patch(
+            url, json=catalog_enable_request, error_handler=CATALOG_ERROR_HANDLER
+        )
 
     def disable_catalog(self, name: str):
         """Disable the catalog with specified name. If the catalog is already disabled, this method does nothing.
@@ -227,5 +234,11 @@ class GravitinoMetalake(MetalakeDTO):
         Raises:
             NoSuchCatalogException if the catalog with specified name does not exist.
         """
-        url = self.API_METALAKES_CATALOGS_PATH.format(self.name(), name) + "/disable"
-        self.rest_client.get(url, error_handler=CATALOG_ERROR_HANDLER)
+
+        catalog_disable_request = CatalogSetRequest(in_use=False)
+        catalog_disable_request.validate()
+
+        url = self.API_METALAKES_CATALOGS_PATH.format(self.name(), name)
+        self.rest_client.patch(
+            url, json=catalog_disable_request, error_handler=CATALOG_ERROR_HANDLER
+        )

--- a/clients/client-python/gravitino/client/gravitino_metalake.py
+++ b/clients/client-python/gravitino/client/gravitino_metalake.py
@@ -206,8 +206,8 @@ class GravitinoMetalake(MetalakeDTO):
 
         return drop_response.dropped()
 
-    def activate_catalog(self, name: str):
-        """Activate the catalog with specified name. If the catalog is already activated, this method does nothing.
+    def enable_catalog(self, name: str):
+        """Enable the catalog with specified name. If the catalog is already in use, this method does nothing.
 
         Args:
             name: the name of the catalog.
@@ -215,11 +215,11 @@ class GravitinoMetalake(MetalakeDTO):
         Raises:
             NoSuchCatalogException if the catalog with specified name does not exist.
         """
-        url = self.API_METALAKES_CATALOGS_PATH.format(self.name(), name) + "/activate"
+        url = self.API_METALAKES_CATALOGS_PATH.format(self.name(), name) + "/enable"
         self.rest_client.get(url, error_handler=CATALOG_ERROR_HANDLER)
 
-    def deactivate_catalog(self, name: str):
-        """Deactivate the catalog with specified name. If the catalog is already deactivated, this method does nothing.
+    def disable_catalog(self, name: str):
+        """Disable the catalog with specified name. If the catalog is already disabled, this method does nothing.
 
         Args:
             name: the name of the catalog.
@@ -227,5 +227,5 @@ class GravitinoMetalake(MetalakeDTO):
         Raises:
             NoSuchCatalogException if the catalog with specified name does not exist.
         """
-        url = self.API_METALAKES_CATALOGS_PATH.format(self.name(), name) + "/deactivate"
+        url = self.API_METALAKES_CATALOGS_PATH.format(self.name(), name) + "/disable"
         self.rest_client.get(url, error_handler=CATALOG_ERROR_HANDLER)

--- a/clients/client-python/gravitino/constants/error.py
+++ b/clients/client-python/gravitino/constants/error.py
@@ -56,6 +56,12 @@ class ErrorConstants(IntEnum):
     # Error codes for connect to catalog failed.
     CONNECTION_FAILED_CODE = 1007
 
+    # Error codes for operation on a no in use entity.
+    NON_IN_USE_ENTITY_CODE = 1009
+
+    # Error codes for drop an in use entity.
+    ENTITY_IN_USE_CODE = 1010
+
     # Error codes for invalid state.
     UNKNOWN_ERROR_CODE = 1100
 

--- a/clients/client-python/gravitino/constants/error.py
+++ b/clients/client-python/gravitino/constants/error.py
@@ -57,10 +57,10 @@ class ErrorConstants(IntEnum):
     CONNECTION_FAILED_CODE = 1007
 
     # Error codes for operation on a no in use entity.
-    NON_IN_USE_ENTITY_CODE = 1009
+    NOT_IN_USE_CODE = 1009
 
     # Error codes for drop an in use entity.
-    ENTITY_IN_USE_CODE = 1010
+    IN_USE_CODE = 1010
 
     # Error codes for invalid state.
     UNKNOWN_ERROR_CODE = 1100

--- a/clients/client-python/gravitino/dto/requests/catalog_set_request.py
+++ b/clients/client-python/gravitino/dto/requests/catalog_set_request.py
@@ -1,0 +1,41 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from dataclasses import dataclass, field
+
+from dataclasses_json import config
+
+from gravitino.rest.rest_message import RESTRequest
+
+
+@dataclass
+class CatalogSetRequest(RESTRequest):
+    """Represents a request to set a catalog in use."""
+
+    _in_use: bool = field(metadata=config(field_name="inUse"))
+
+    def __init__(self, in_use: bool):
+        self._in_use = in_use
+
+    def validate(self):
+        """Validates the fields of the request.
+
+        Raises:
+            IllegalArgumentException if in_use is not set.
+        """
+        if self._in_use is None:
+            raise ValueError('"in_use" field is required and cannot be empty')

--- a/clients/client-python/gravitino/exceptions/base.py
+++ b/clients/client-python/gravitino/exceptions/base.py
@@ -111,3 +111,11 @@ class UnauthorizedException(GravitinoRuntimeException):
 
 class BadRequestException(GravitinoRuntimeException):
     """An exception thrown when the request is invalid."""
+
+
+class EntityInUseException(GravitinoRuntimeException):
+    """An Exception thrown when an entity is in use and cannot be deleted."""
+
+
+class NonInUseEntityException(GravitinoRuntimeException):
+    """An exception thrown when operating on a non-in-use entity."""

--- a/clients/client-python/gravitino/exceptions/base.py
+++ b/clients/client-python/gravitino/exceptions/base.py
@@ -93,6 +93,22 @@ class NonEmptySchemaException(NotEmptyException):
     """Exception thrown when a namespace is not empty."""
 
 
+class InUseException(GravitinoRuntimeException):
+    """Base class for all exceptions thrown when an entity is in use and cannot be deleted."""
+
+
+class CatalogInUseException(InUseException):
+    """An Exception thrown when a catalog is in use and cannot be deleted."""
+
+
+class NotInUseException(GravitinoRuntimeException):
+    """Base class for all exceptions thrown when an entity is not in use."""
+
+
+class CatalogNotInUseException(NotInUseException):
+    """An exception thrown when operating on not in use catalog."""
+
+
 class UnsupportedOperationException(GravitinoRuntimeException):
     """Base class for all exceptions thrown when an operation is unsupported"""
 
@@ -111,11 +127,3 @@ class UnauthorizedException(GravitinoRuntimeException):
 
 class BadRequestException(GravitinoRuntimeException):
     """An exception thrown when the request is invalid."""
-
-
-class EntityInUseException(GravitinoRuntimeException):
-    """An Exception thrown when an entity is in use and cannot be deleted."""
-
-
-class NonInUseEntityException(GravitinoRuntimeException):
-    """An exception thrown when operating on a non-in-use entity."""

--- a/clients/client-python/gravitino/exceptions/handlers/catalog_error_handler.py
+++ b/clients/client-python/gravitino/exceptions/handlers/catalog_error_handler.py
@@ -20,9 +20,11 @@ from gravitino.dto.responses.error_response import ErrorResponse
 from gravitino.exceptions.handlers.rest_error_handler import RestErrorHandler
 from gravitino.exceptions.base import (
     ConnectionFailedException,
+    EntityInUseException,
     NoSuchMetalakeException,
     NoSuchCatalogException,
     CatalogAlreadyExistsException,
+    NonInUseEntityException,
 )
 
 
@@ -36,13 +38,21 @@ class CatalogErrorHandler(RestErrorHandler):
 
         if code == ErrorConstants.CONNECTION_FAILED_CODE:
             raise ConnectionFailedException(error_message)
+
         if code == ErrorConstants.NOT_FOUND_CODE:
             if exception_type == NoSuchMetalakeException.__name__:
                 raise NoSuchMetalakeException(error_message)
             if exception_type == NoSuchCatalogException.__name__:
                 raise NoSuchCatalogException(error_message)
+
         if code == ErrorConstants.ALREADY_EXISTS_CODE:
             raise CatalogAlreadyExistsException(error_message)
+
+        if code == ErrorConstants.ENTITY_IN_USE_CODE:
+            raise EntityInUseException(error_message)
+
+        if code == ErrorConstants.NON_IN_USE_ENTITY_CODE:
+            raise NonInUseEntityException(error_message)
 
         super().handle(error_response)
 

--- a/clients/client-python/gravitino/exceptions/handlers/catalog_error_handler.py
+++ b/clients/client-python/gravitino/exceptions/handlers/catalog_error_handler.py
@@ -20,11 +20,11 @@ from gravitino.dto.responses.error_response import ErrorResponse
 from gravitino.exceptions.handlers.rest_error_handler import RestErrorHandler
 from gravitino.exceptions.base import (
     ConnectionFailedException,
-    EntityInUseException,
+    CatalogInUseException,
     NoSuchMetalakeException,
     NoSuchCatalogException,
     CatalogAlreadyExistsException,
-    NonInUseEntityException,
+    CatalogNotInUseException,
 )
 
 
@@ -48,11 +48,13 @@ class CatalogErrorHandler(RestErrorHandler):
         if code == ErrorConstants.ALREADY_EXISTS_CODE:
             raise CatalogAlreadyExistsException(error_message)
 
-        if code == ErrorConstants.ENTITY_IN_USE_CODE:
-            raise EntityInUseException(error_message)
+        if code == ErrorConstants.IN_USE_CODE:
+            if exception_type == CatalogInUseException.__name__:
+                raise CatalogInUseException(error_message)
 
-        if code == ErrorConstants.NON_IN_USE_ENTITY_CODE:
-            raise NonInUseEntityException(error_message)
+        if code == ErrorConstants.NOT_IN_USE_CODE:
+            if exception_type == CatalogNotInUseException.__name__:
+                raise CatalogNotInUseException(error_message)
 
         super().handle(error_response)
 

--- a/clients/client-python/gravitino/exceptions/handlers/fileset_error_handler.py
+++ b/clients/client-python/gravitino/exceptions/handlers/fileset_error_handler.py
@@ -18,7 +18,11 @@
 from gravitino.constants.error import ErrorConstants
 from gravitino.dto.responses.error_response import ErrorResponse
 from gravitino.exceptions.handlers.rest_error_handler import RestErrorHandler
-from gravitino.exceptions.base import NoSuchFilesetException, NoSuchSchemaException
+from gravitino.exceptions.base import (
+    NoSuchFilesetException,
+    NoSuchSchemaException,
+    NonInUseEntityException,
+)
 
 
 class FilesetErrorHandler(RestErrorHandler):
@@ -34,6 +38,9 @@ class FilesetErrorHandler(RestErrorHandler):
                 raise NoSuchSchemaException(error_message)
             if exception_type == NoSuchFilesetException.__name__:
                 raise NoSuchFilesetException(error_message)
+
+        if code == ErrorConstants.NON_IN_USE_ENTITY_CODE:
+            raise NonInUseEntityException(error_message)
 
         super().handle(error_response)
 

--- a/clients/client-python/gravitino/exceptions/handlers/fileset_error_handler.py
+++ b/clients/client-python/gravitino/exceptions/handlers/fileset_error_handler.py
@@ -21,7 +21,7 @@ from gravitino.exceptions.handlers.rest_error_handler import RestErrorHandler
 from gravitino.exceptions.base import (
     NoSuchFilesetException,
     NoSuchSchemaException,
-    NonInUseEntityException,
+    CatalogNotInUseException,
 )
 
 
@@ -39,8 +39,8 @@ class FilesetErrorHandler(RestErrorHandler):
             if exception_type == NoSuchFilesetException.__name__:
                 raise NoSuchFilesetException(error_message)
 
-        if code == ErrorConstants.NON_IN_USE_ENTITY_CODE:
-            raise NonInUseEntityException(error_message)
+        if code == ErrorConstants.NOT_IN_USE_CODE:
+            raise CatalogNotInUseException(error_message)
 
         super().handle(error_response)
 

--- a/clients/client-python/gravitino/exceptions/handlers/schema_error_handler.py
+++ b/clients/client-python/gravitino/exceptions/handlers/schema_error_handler.py
@@ -21,6 +21,7 @@ from gravitino.exceptions.handlers.rest_error_handler import RestErrorHandler
 from gravitino.exceptions.base import (
     NoSuchCatalogException,
     NoSuchSchemaException,
+    NonInUseEntityException,
     SchemaAlreadyExistsException,
     NonEmptySchemaException,
 )
@@ -39,11 +40,15 @@ class SchemaErrorHandler(RestErrorHandler):
                 raise NoSuchCatalogException(error_message)
             if exception_type == NoSuchSchemaException.__name__:
                 raise NoSuchSchemaException(error_message)
+
         if code == ErrorConstants.ALREADY_EXISTS_CODE:
             raise SchemaAlreadyExistsException(error_message)
 
         if code == ErrorConstants.NON_EMPTY_CODE:
             raise NonEmptySchemaException(error_message)
+
+        if code == ErrorConstants.NON_IN_USE_ENTITY_CODE:
+            raise NonInUseEntityException(error_message)
 
         super().handle(error_response)
 

--- a/clients/client-python/gravitino/exceptions/handlers/schema_error_handler.py
+++ b/clients/client-python/gravitino/exceptions/handlers/schema_error_handler.py
@@ -21,7 +21,7 @@ from gravitino.exceptions.handlers.rest_error_handler import RestErrorHandler
 from gravitino.exceptions.base import (
     NoSuchCatalogException,
     NoSuchSchemaException,
-    NonInUseEntityException,
+    CatalogNotInUseException,
     SchemaAlreadyExistsException,
     NonEmptySchemaException,
 )
@@ -47,8 +47,8 @@ class SchemaErrorHandler(RestErrorHandler):
         if code == ErrorConstants.NON_EMPTY_CODE:
             raise NonEmptySchemaException(error_message)
 
-        if code == ErrorConstants.NON_IN_USE_ENTITY_CODE:
-            raise NonInUseEntityException(error_message)
+        if code == ErrorConstants.NOT_IN_USE_CODE:
+            raise CatalogNotInUseException(error_message)
 
         super().handle(error_response)
 

--- a/clients/client-python/gravitino/utils/http_client.py
+++ b/clients/client-python/gravitino/utils/http_client.py
@@ -240,6 +240,11 @@ class HTTPClient:
             "put", endpoint, json=json, error_handler=error_handler, **kwargs
         )
 
+    def patch(self, endpoint, json=None, error_handler=None, **kwargs):
+        return self._request(
+            "patch", endpoint, json=json, error_handler=error_handler, **kwargs
+        )
+
     def post_form(self, endpoint, data=None, error_handler=None, **kwargs):
         return self._request(
             "post", endpoint, data=data, error_handler=error_handler, **kwargs

--- a/clients/client-python/tests/integration/auth/test_auth_common.py
+++ b/clients/client-python/tests/integration/auth/test_auth_common.py
@@ -92,7 +92,7 @@ class TestCommonAuth:
             logger.info(
                 "Drop catalog %s[%s]",
                 self.catalog_ident,
-                self.gravitino_client.drop_catalog(name=self.catalog_name),
+                self.gravitino_client.drop_catalog(name=self.catalog_name, force=True),
             )
         except GravitinoRuntimeException:
             logger.warning("Failed to drop catalog %s", self.catalog_name)

--- a/clients/client-python/tests/integration/test_catalog.py
+++ b/clients/client-python/tests/integration/test_catalog.py
@@ -145,9 +145,8 @@ class TestCatalog(IntegrationTestEnv):
 
     def test_drop_catalog(self):
         self.create_catalog(self.catalog_name)
-        self.assertTrue(
-            self.gravitino_client.drop_catalog(name=self.catalog_name, force=True)
-        )
+        self.gravitino_client.disable_catalog(self.catalog_name)
+        self.assertTrue(self.gravitino_client.drop_catalog(name=self.catalog_name))
 
     def test_list_catalogs_info(self):
         self.create_catalog(self.catalog_name)

--- a/clients/client-python/tests/integration/test_catalog.py
+++ b/clients/client-python/tests/integration/test_catalog.py
@@ -43,6 +43,7 @@ class TestCatalog(IntegrationTestEnv):
     catalog_comment: str = "catalogComment"
     catalog_location_prop: str = "location"  # Fileset Catalog must set `location`
     catalog_provider: str = "hadoop"
+    catalog_in_use_prop: str = "in-use"
 
     catalog_ident: NameIdentifier = NameIdentifier.of(metalake_name, catalog_name)
 
@@ -82,7 +83,7 @@ class TestCatalog(IntegrationTestEnv):
             logger.info(
                 "Drop catalog %s[%s]",
                 self.catalog_ident,
-                self.gravitino_client.drop_catalog(name=self.catalog_name),
+                self.gravitino_client.drop_catalog(name=self.catalog_name, force=True),
             )
         except GravitinoRuntimeException:
             logger.warning("Failed to drop catalog %s", self.catalog_name)
@@ -105,7 +106,11 @@ class TestCatalog(IntegrationTestEnv):
         catalog = self.create_catalog(self.catalog_name)
         self.assertEqual(catalog.name(), self.catalog_name)
         self.assertEqual(
-            catalog.properties(), {self.catalog_location_prop: "/tmp/test_schema"}
+            catalog.properties(),
+            {
+                self.catalog_location_prop: "/tmp/test_schema",
+                self.catalog_in_use_prop: "true",
+            },
         )
 
     def test_failed_create_catalog(self):
@@ -140,7 +145,9 @@ class TestCatalog(IntegrationTestEnv):
 
     def test_drop_catalog(self):
         self.create_catalog(self.catalog_name)
-        self.assertTrue(self.gravitino_client.drop_catalog(name=self.catalog_name))
+        self.assertTrue(
+            self.gravitino_client.drop_catalog(name=self.catalog_name, force=True)
+        )
 
     def test_list_catalogs_info(self):
         self.create_catalog(self.catalog_name)
@@ -154,7 +161,11 @@ class TestCatalog(IntegrationTestEnv):
         self.assertEqual(catalog.name(), self.catalog_name)
         self.assertEqual(catalog.comment(), self.catalog_comment)
         self.assertEqual(
-            catalog.properties(), {self.catalog_location_prop: "/tmp/test_schema"}
+            catalog.properties(),
+            {
+                self.catalog_location_prop: "/tmp/test_schema",
+                self.catalog_in_use_prop: "true",
+            },
         )
         self.assertEqual(catalog.audit_info().creator(), "anonymous")
 

--- a/clients/client-python/tests/integration/test_fileset_catalog.py
+++ b/clients/client-python/tests/integration/test_fileset_catalog.py
@@ -119,7 +119,7 @@ class TestFilesetCatalog(IntegrationTestEnv):
             logger.info(
                 "Drop catalog %s[%s]",
                 self.catalog_ident,
-                self.gravitino_client.drop_catalog(name=self.catalog_name),
+                self.gravitino_client.drop_catalog(name=self.catalog_name, force=True),
             )
         except GravitinoRuntimeException:
             logger.warning("Failed to drop catalog %s", self.catalog_name)

--- a/clients/client-python/tests/integration/test_gvfs_with_hdfs.py
+++ b/clients/client-python/tests/integration/test_gvfs_with_hdfs.py
@@ -193,7 +193,7 @@ class TestGvfsWithHDFS(IntegrationTestEnv):
             logger.info(
                 "Drop catalog %s[%s]",
                 cls.catalog_name,
-                cls.gravitino_client.drop_catalog(name=cls.catalog_name),
+                cls.gravitino_client.drop_catalog(name=cls.catalog_name, force=True),
             )
         except GravitinoRuntimeException:
             logger.warning("Failed to drop catalog %s", cls.catalog_name)

--- a/clients/client-python/tests/integration/test_schema.py
+++ b/clients/client-python/tests/integration/test_schema.py
@@ -119,7 +119,7 @@ class TestSchema(IntegrationTestEnv):
             logger.info(
                 "Drop catalog %s[%s]",
                 self.catalog_ident,
-                self.gravitino_client.drop_catalog(name=self.catalog_name),
+                self.gravitino_client.drop_catalog(name=self.catalog_name, force=True),
             )
         except GravitinoRuntimeException:
             logger.warning("Failed to drop catalog %s", self.catalog_name)

--- a/clients/filesystem-hadoop3/src/test/java/org/apache/gravitino/filesystem/hadoop/integration/test/GravitinoVirtualFileSystemIT.java
+++ b/clients/filesystem-hadoop3/src/test/java/org/apache/gravitino/filesystem/hadoop/integration/test/GravitinoVirtualFileSystemIT.java
@@ -90,7 +90,7 @@ public class GravitinoVirtualFileSystemIT extends BaseIT {
   public void tearDown() throws IOException {
     Catalog catalog = metalake.loadCatalog(catalogName);
     catalog.asSchemas().dropSchema(schemaName, true);
-    metalake.dropCatalog(catalogName);
+    metalake.dropCatalog(catalogName, true);
     client.dropMetalake(metalakeName);
 
     if (client != null) {

--- a/common/src/main/java/org/apache/gravitino/dto/requests/CatalogSetRequest.java
+++ b/common/src/main/java/org/apache/gravitino/dto/requests/CatalogSetRequest.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.dto.requests;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+import org.apache.gravitino.rest.RESTRequest;
+
+/** Represents a request to set a catalog in use. */
+@Getter
+@EqualsAndHashCode
+@ToString
+public class CatalogSetRequest implements RESTRequest {
+
+  @JsonProperty("inUse")
+  private final boolean inUse;
+
+  /** Default constructor for CatalogSetRequest. */
+  public CatalogSetRequest() {
+    this(false);
+  }
+
+  /**
+   * Constructor for CatalogSetRequest.
+   *
+   * @param inUse The in use status to set.
+   */
+  public CatalogSetRequest(boolean inUse) {
+    this.inUse = inUse;
+  }
+
+  /**
+   * Validates the request. No validation needed.
+   *
+   * @throws IllegalArgumentException If the request is invalid.
+   */
+  @Override
+  public void validate() throws IllegalArgumentException {
+    // No validation needed
+  }
+}

--- a/common/src/main/java/org/apache/gravitino/dto/responses/ErrorConstants.java
+++ b/common/src/main/java/org/apache/gravitino/dto/responses/ErrorConstants.java
@@ -49,10 +49,10 @@ public class ErrorConstants {
   public static final int FORBIDDEN_CODE = 1008;
 
   /** Error codes for operation on a no in use entity. */
-  public static final int NOT_IN_USE_ENTITY_CODE = 1009;
+  public static final int NOT_IN_USE_CODE = 1009;
 
   /** Error codes for drop an in use entity. */
-  public static final int ENTITY_IN_USE_CODE = 1010;
+  public static final int IN_USE_CODE = 1010;
 
   /** Error codes for invalid state. */
   public static final int UNKNOWN_ERROR_CODE = 1100;

--- a/common/src/main/java/org/apache/gravitino/dto/responses/ErrorConstants.java
+++ b/common/src/main/java/org/apache/gravitino/dto/responses/ErrorConstants.java
@@ -48,6 +48,12 @@ public class ErrorConstants {
   /** Error codes for forbidden operation. */
   public static final int FORBIDDEN_CODE = 1008;
 
+  /** Error codes for operation on a no in use entity. */
+  public static final int NON_IN_USE_ENTITY_CODE = 1009;
+
+  /** Error codes for drop an in use entity. */
+  public static final int ENTITY_IN_USE_CODE = 1010;
+
   /** Error codes for invalid state. */
   public static final int UNKNOWN_ERROR_CODE = 1100;
 

--- a/common/src/main/java/org/apache/gravitino/dto/responses/ErrorConstants.java
+++ b/common/src/main/java/org/apache/gravitino/dto/responses/ErrorConstants.java
@@ -49,7 +49,7 @@ public class ErrorConstants {
   public static final int FORBIDDEN_CODE = 1008;
 
   /** Error codes for operation on a no in use entity. */
-  public static final int NON_IN_USE_ENTITY_CODE = 1009;
+  public static final int NOT_IN_USE_ENTITY_CODE = 1009;
 
   /** Error codes for drop an in use entity. */
   public static final int ENTITY_IN_USE_CODE = 1010;

--- a/common/src/main/java/org/apache/gravitino/dto/responses/ErrorResponse.java
+++ b/common/src/main/java/org/apache/gravitino/dto/responses/ErrorResponse.java
@@ -235,6 +235,32 @@ public class ErrorResponse extends BaseResponse {
   }
 
   /**
+   * Create a new entity in use error instance of {@link ErrorResponse}.
+   *
+   * @param type The type of the error.
+   * @param message The message of the error.
+   * @param throwable The throwable that caused the error.
+   * @return The new instance.
+   */
+  public static ErrorResponse nonInUse(String type, String message, Throwable throwable) {
+    return new ErrorResponse(
+        ErrorConstants.NON_IN_USE_ENTITY_CODE, type, message, getStackTrace(throwable));
+  }
+
+  /**
+   * Create a new entity in use error instance of {@link ErrorResponse}.
+   *
+   * @param type The type of the error.
+   * @param message The message of the error.
+   * @param throwable The throwable that caused the error.
+   * @return The new instance.
+   */
+  public static ErrorResponse inUse(String type, String message, Throwable throwable) {
+    return new ErrorResponse(
+        ErrorConstants.ENTITY_IN_USE_CODE, type, message, getStackTrace(throwable));
+  }
+
+  /**
    * Create a new non-empty error instance of {@link ErrorResponse}.
    *
    * @param type The type of the error.

--- a/common/src/main/java/org/apache/gravitino/dto/responses/ErrorResponse.java
+++ b/common/src/main/java/org/apache/gravitino/dto/responses/ErrorResponse.java
@@ -242,9 +242,9 @@ public class ErrorResponse extends BaseResponse {
    * @param throwable The throwable that caused the error.
    * @return The new instance.
    */
-  public static ErrorResponse nonInUse(String type, String message, Throwable throwable) {
+  public static ErrorResponse notInUse(String type, String message, Throwable throwable) {
     return new ErrorResponse(
-        ErrorConstants.NON_IN_USE_ENTITY_CODE, type, message, getStackTrace(throwable));
+        ErrorConstants.NOT_IN_USE_ENTITY_CODE, type, message, getStackTrace(throwable));
   }
 
   /**

--- a/common/src/main/java/org/apache/gravitino/dto/responses/ErrorResponse.java
+++ b/common/src/main/java/org/apache/gravitino/dto/responses/ErrorResponse.java
@@ -244,7 +244,7 @@ public class ErrorResponse extends BaseResponse {
    */
   public static ErrorResponse notInUse(String type, String message, Throwable throwable) {
     return new ErrorResponse(
-        ErrorConstants.NOT_IN_USE_ENTITY_CODE, type, message, getStackTrace(throwable));
+        ErrorConstants.NOT_IN_USE_CODE, type, message, getStackTrace(throwable));
   }
 
   /**
@@ -256,8 +256,7 @@ public class ErrorResponse extends BaseResponse {
    * @return The new instance.
    */
   public static ErrorResponse inUse(String type, String message, Throwable throwable) {
-    return new ErrorResponse(
-        ErrorConstants.ENTITY_IN_USE_CODE, type, message, getStackTrace(throwable));
+    return new ErrorResponse(ErrorConstants.IN_USE_CODE, type, message, getStackTrace(throwable));
   }
 
   /**

--- a/core/src/main/java/org/apache/gravitino/GravitinoEnv.java
+++ b/core/src/main/java/org/apache/gravitino/GravitinoEnv.java
@@ -366,14 +366,18 @@ public class GravitinoEnv {
     // create and initialize a random id generator
     this.idGenerator = new RandomIdGenerator();
 
-    // Create and initialize metalake related modules
+    // Create and initialize metalake related modules, the operation chain is:
+    // MetalakeEventDispatcher -> MetalakeNormalizeDispatcher -> MetalakeHookDispatcher ->
+    // MetalakeManager
     MetalakeDispatcher metalakeManager = new MetalakeManager(entityStore, idGenerator);
     MetalakeHookDispatcher metalakeHookDispatcher = new MetalakeHookDispatcher(metalakeManager);
     MetalakeNormalizeDispatcher metalakeNormalizeDispatcher =
         new MetalakeNormalizeDispatcher(metalakeHookDispatcher);
     this.metalakeDispatcher = new MetalakeEventDispatcher(eventBus, metalakeNormalizeDispatcher);
 
-    // Create and initialize Catalog related modules
+    // Create and initialize Catalog related modules, the operation chain is:
+    // CatalogEventDispatcher -> CatalogNormalizeDispatcher -> CatalogHookDispatcher ->
+    // CatalogManager
     this.catalogManager = new CatalogManager(config, entityStore, idGenerator);
     CatalogHookDispatcher catalogHookDispatcher = new CatalogHookDispatcher(catalogManager);
     CatalogNormalizeDispatcher catalogNormalizeDispatcher =

--- a/core/src/main/java/org/apache/gravitino/catalog/CatalogManager.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/CatalogManager.java
@@ -79,13 +79,13 @@ import org.apache.gravitino.connector.PropertyEntry;
 import org.apache.gravitino.connector.SupportsSchemas;
 import org.apache.gravitino.connector.capability.Capability;
 import org.apache.gravitino.exceptions.CatalogAlreadyExistsException;
-import org.apache.gravitino.exceptions.EntityInUseException;
+import org.apache.gravitino.exceptions.CatalogInUseException;
+import org.apache.gravitino.exceptions.CatalogNotInUseException;
 import org.apache.gravitino.exceptions.GravitinoRuntimeException;
 import org.apache.gravitino.exceptions.NoSuchCatalogException;
 import org.apache.gravitino.exceptions.NoSuchEntityException;
 import org.apache.gravitino.exceptions.NoSuchMetalakeException;
 import org.apache.gravitino.exceptions.NonEmptyEntityException;
-import org.apache.gravitino.exceptions.NotInUseEntityException;
 import org.apache.gravitino.file.FilesetCatalog;
 import org.apache.gravitino.messaging.TopicCatalog;
 import org.apache.gravitino.meta.AuditInfo;
@@ -490,7 +490,7 @@ public class CatalogManager implements CatalogDispatcher, Closeable {
 
   @Override
   public void activateCatalog(NameIdentifier ident)
-      throws NoSuchCatalogException, NotInUseEntityException {
+      throws NoSuchCatalogException, CatalogNotInUseException {
     try {
       if (catalogInUse(store, ident)) {
         return;
@@ -559,7 +559,7 @@ public class CatalogManager implements CatalogDispatcher, Closeable {
   public Catalog alterCatalog(NameIdentifier ident, CatalogChange... changes)
       throws NoSuchCatalogException, IllegalArgumentException {
     if (!catalogInUse(store, ident)) {
-      throw new NotInUseEntityException(
+      throw new CatalogNotInUseException(
           "Catalog %s is not in use, please activate it first", ident);
     }
 
@@ -628,11 +628,11 @@ public class CatalogManager implements CatalogDispatcher, Closeable {
 
   @Override
   public boolean dropCatalog(NameIdentifier ident, boolean force)
-      throws NonEmptyEntityException, EntityInUseException {
+      throws NonEmptyEntityException, CatalogInUseException {
     try {
       boolean catalogInUse = catalogInUse(store, ident);
       if (catalogInUse && !force) {
-        throw new EntityInUseException(
+        throw new CatalogInUseException(
             "Catalog %s is in use, please deactivate it first or use force option", ident);
       }
 

--- a/core/src/main/java/org/apache/gravitino/catalog/CatalogManager.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/CatalogManager.java
@@ -489,7 +489,7 @@ public class CatalogManager implements CatalogDispatcher, Closeable {
   }
 
   @Override
-  public void activateCatalog(NameIdentifier ident)
+  public void enableCatalog(NameIdentifier ident)
       throws NoSuchCatalogException, CatalogNotInUseException {
     try {
       if (catalogInUse(store, ident)) {
@@ -518,7 +518,7 @@ public class CatalogManager implements CatalogDispatcher, Closeable {
   }
 
   @Override
-  public void deactivateCatalog(NameIdentifier ident) throws NoSuchCatalogException {
+  public void disableCatalog(NameIdentifier ident) throws NoSuchCatalogException {
     try {
       if (!catalogInUse(store, ident)) {
         return;
@@ -559,8 +559,7 @@ public class CatalogManager implements CatalogDispatcher, Closeable {
   public Catalog alterCatalog(NameIdentifier ident, CatalogChange... changes)
       throws NoSuchCatalogException, IllegalArgumentException {
     if (!catalogInUse(store, ident)) {
-      throw new CatalogNotInUseException(
-          "Catalog %s is not in use, please activate it first", ident);
+      throw new CatalogNotInUseException("Catalog %s is not in use, please enable it first", ident);
     }
 
     // There could be a race issue that someone is using the catalog from cache while we are
@@ -633,7 +632,7 @@ public class CatalogManager implements CatalogDispatcher, Closeable {
       boolean catalogInUse = catalogInUse(store, ident);
       if (catalogInUse && !force) {
         throw new CatalogInUseException(
-            "Catalog %s is in use, please deactivate it first or use force option", ident);
+            "Catalog %s is in use, please disable it first or use force option", ident);
       }
 
       List<SchemaEntity> schemas =
@@ -652,8 +651,8 @@ public class CatalogManager implements CatalogDispatcher, Closeable {
 
       // If reached here, it implies that the catalog is not in use or force is true.
       if (catalogInUse) {
-        // force is true, deactivate the catalog first
-        deactivateCatalog(ident);
+        // force is true, disable the catalog first
+        disableCatalog(ident);
       }
 
       catalogCache.invalidate(ident);

--- a/core/src/main/java/org/apache/gravitino/catalog/CatalogManager.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/CatalogManager.java
@@ -22,6 +22,7 @@ import static org.apache.gravitino.Catalog.PROPERTY_IN_USE;
 import static org.apache.gravitino.StringIdentifier.DUMMY_ID;
 import static org.apache.gravitino.catalog.PropertiesMetadataHelpers.validatePropertyForAlter;
 import static org.apache.gravitino.catalog.PropertiesMetadataHelpers.validatePropertyForCreate;
+import static org.apache.gravitino.connector.BaseCatalogPropertiesMetadata.BASIC_CATALOG_PROPERTIES_METADATA;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
@@ -71,10 +72,8 @@ import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
 import org.apache.gravitino.StringIdentifier;
 import org.apache.gravitino.connector.BaseCatalog;
-import org.apache.gravitino.connector.BaseCatalogPropertiesMetadata;
 import org.apache.gravitino.connector.CatalogOperations;
 import org.apache.gravitino.connector.HasPropertyMetadata;
-import org.apache.gravitino.connector.PropertiesMetadata;
 import org.apache.gravitino.connector.PropertyEntry;
 import org.apache.gravitino.connector.SupportsSchemas;
 import org.apache.gravitino.connector.capability.Capability;
@@ -106,13 +105,6 @@ public class CatalogManager implements CatalogDispatcher, Closeable {
 
   private static final String CATALOG_DOES_NOT_EXIST_MSG = "Catalog %s does not exist";
   private static final String METALAKE_DOES_NOT_EXIST_MSG = "Metalake %s does not exist";
-  private static final PropertiesMetadata BASIC_CATALOG_PROPERTIES_METADATA =
-      new BaseCatalogPropertiesMetadata() {
-        @Override
-        protected Map<String, PropertyEntry<?>> specificPropertyEntries() {
-          return Collections.emptyMap();
-        }
-      };
 
   private static final Logger LOG = LoggerFactory.getLogger(CatalogManager.class);
 

--- a/core/src/main/java/org/apache/gravitino/catalog/CatalogManager.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/CatalogManager.java
@@ -642,12 +642,6 @@ public class CatalogManager implements CatalogDispatcher, Closeable {
         }
       }
 
-      // If reached here, it implies that the catalog is not in use or force is true.
-      if (catalogInUse) {
-        // force is true, disable the catalog first
-        disableCatalog(ident);
-      }
-
       catalogCache.invalidate(ident);
       return store.delete(ident, EntityType.CATALOG, true);
 

--- a/core/src/main/java/org/apache/gravitino/catalog/CatalogManager.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/CatalogManager.java
@@ -18,8 +18,8 @@
  */
 package org.apache.gravitino.catalog;
 
+import static org.apache.gravitino.Catalog.PROPERTY_IN_USE;
 import static org.apache.gravitino.StringIdentifier.DUMMY_ID;
-import static org.apache.gravitino.StringIdentifier.ID_KEY;
 import static org.apache.gravitino.catalog.PropertiesMetadataHelpers.validatePropertyForAlter;
 import static org.apache.gravitino.catalog.PropertiesMetadataHelpers.validatePropertyForCreate;
 
@@ -31,7 +31,6 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import com.google.common.collect.Multimaps;
 import com.google.common.collect.Streams;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import java.io.Closeable;
@@ -45,6 +44,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.ServiceLoader;
@@ -52,6 +52,7 @@ import java.util.Set;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
@@ -70,16 +71,21 @@ import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
 import org.apache.gravitino.StringIdentifier;
 import org.apache.gravitino.connector.BaseCatalog;
+import org.apache.gravitino.connector.BaseCatalogPropertiesMetadata;
 import org.apache.gravitino.connector.CatalogOperations;
 import org.apache.gravitino.connector.HasPropertyMetadata;
+import org.apache.gravitino.connector.PropertiesMetadata;
 import org.apache.gravitino.connector.PropertyEntry;
 import org.apache.gravitino.connector.SupportsSchemas;
 import org.apache.gravitino.connector.capability.Capability;
 import org.apache.gravitino.exceptions.CatalogAlreadyExistsException;
+import org.apache.gravitino.exceptions.EntityInUseException;
 import org.apache.gravitino.exceptions.GravitinoRuntimeException;
 import org.apache.gravitino.exceptions.NoSuchCatalogException;
 import org.apache.gravitino.exceptions.NoSuchEntityException;
 import org.apache.gravitino.exceptions.NoSuchMetalakeException;
+import org.apache.gravitino.exceptions.NonEmptyEntityException;
+import org.apache.gravitino.exceptions.NonInUseEntityException;
 import org.apache.gravitino.file.FilesetCatalog;
 import org.apache.gravitino.messaging.TopicCatalog;
 import org.apache.gravitino.meta.AuditInfo;
@@ -100,8 +106,21 @@ public class CatalogManager implements CatalogDispatcher, Closeable {
 
   private static final String CATALOG_DOES_NOT_EXIST_MSG = "Catalog %s does not exist";
   private static final String METALAKE_DOES_NOT_EXIST_MSG = "Metalake %s does not exist";
+  private static final PropertiesMetadata BASIC_CATALOG_PROPERTIES_METADATA =
+      new BaseCatalogPropertiesMetadata() {
+        @Override
+        protected Map<String, PropertyEntry<?>> specificPropertyEntries() {
+          return Collections.emptyMap();
+        }
+      };
 
   private static final Logger LOG = LoggerFactory.getLogger(CatalogManager.class);
+
+  public static boolean catalogInUse(EntityStore store, NameIdentifier ident)
+      throws NoSuchMetalakeException, NoSuchCatalogException {
+    // todo: check if the metalake is in use
+    return getInUseValue(store, ident);
+  }
 
   /** Wrapper class for a catalog instance and its class loader. */
   public static class CatalogWrapper {
@@ -295,15 +314,10 @@ public class CatalogManager implements CatalogDispatcher, Closeable {
       List<CatalogEntity> catalogEntities =
           store.list(namespace, CatalogEntity.class, EntityType.CATALOG);
 
-      // Using provider as key to avoid loading the same type catalog instance multiple times
-      Map<String, Set<String>> hiddenProps = new HashMap<>();
-      Multimaps.index(catalogEntities, CatalogEntity::getProvider)
-          .asMap()
-          .forEach((p, e) -> hiddenProps.put(p, getHiddenPropertyNames(e.iterator().next())));
-
       return catalogEntities.stream()
-          .map(e -> e.toCatalogInfoWithoutHiddenProps(hiddenProps.get(e.getProvider())))
+          .map(e -> e.toCatalogInfoWithResolvedProps(getResolvedProperties(e)))
           .toArray(Catalog[]::new);
+
     } catch (IOException ioe) {
       LOG.error("Failed to list catalogs in metalake {}", metalakeIdent, ioe);
       throw new RuntimeException(ioe);
@@ -375,7 +389,7 @@ public class CatalogManager implements CatalogDispatcher, Closeable {
       }
 
       store.put(e, false /* overwrite */);
-      CatalogWrapper wrapper = catalogCache.get(ident, id -> createCatalogWrapper(e));
+      CatalogWrapper wrapper = catalogCache.get(ident, id -> createCatalogWrapper(e, mergedConfig));
 
       needClean = false;
       return wrapper.catalog;
@@ -457,7 +471,7 @@ public class CatalogManager implements CatalogDispatcher, Closeable {
                       .build())
               .build();
 
-      CatalogWrapper wrapper = createCatalogWrapper(dummyEntity);
+      CatalogWrapper wrapper = createCatalogWrapper(dummyEntity, mergedConfig);
       wrapper.doWithCatalogOps(
           c -> {
             c.testConnection(ident, type, provider, comment, mergedConfig);
@@ -474,6 +488,65 @@ public class CatalogManager implements CatalogDispatcher, Closeable {
     }
   }
 
+  @Override
+  public void activateCatalog(NameIdentifier ident)
+      throws NoSuchCatalogException, NonInUseEntityException {
+    try {
+      boolean inUse = catalogInUse(store, ident);
+      if (!inUse) {
+        store.update(
+            ident,
+            CatalogEntity.class,
+            EntityType.CATALOG,
+            catalog -> {
+              CatalogEntity.Builder newCatalogBuilder =
+                  newCatalogBuilder(ident.namespace(), catalog);
+
+              Map<String, String> newProps =
+                  catalog.getProperties() == null
+                      ? new HashMap<>()
+                      : new HashMap<>(catalog.getProperties());
+              newProps.put(PROPERTY_IN_USE, "true");
+              newCatalogBuilder.withProperties(newProps);
+
+              return newCatalogBuilder.build();
+            });
+      }
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public void deactivateCatalog(NameIdentifier ident) throws NoSuchCatalogException {
+    try {
+      boolean inUse = catalogInUse(store, ident);
+      if (inUse) {
+        store.update(
+            ident,
+            CatalogEntity.class,
+            EntityType.CATALOG,
+            catalog -> {
+              CatalogEntity.Builder newCatalogBuilder =
+                  newCatalogBuilder(ident.namespace(), catalog);
+
+              Map<String, String> newProps =
+                  catalog.getProperties() == null
+                      ? new HashMap<>()
+                      : new HashMap<>(catalog.getProperties());
+              newProps.put(PROPERTY_IN_USE, "false");
+              newCatalogBuilder.withProperties(newProps);
+
+              return newCatalogBuilder.build();
+            });
+        catalogCache.invalidate(ident);
+      }
+
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
   /**
    * Alters an existing catalog with the specified changes.
    *
@@ -486,6 +559,11 @@ public class CatalogManager implements CatalogDispatcher, Closeable {
   @Override
   public Catalog alterCatalog(NameIdentifier ident, CatalogChange... changes)
       throws NoSuchCatalogException, IllegalArgumentException {
+    if (!catalogInUse(store, ident)) {
+      throw new NonInUseEntityException(
+          "Catalog %s is not in use, please activate it first", ident);
+    }
+
     // There could be a race issue that someone is using the catalog from cache while we are
     // updating it.
 
@@ -519,22 +597,7 @@ public class CatalogManager implements CatalogDispatcher, Closeable {
               EntityType.CATALOG,
               catalog -> {
                 CatalogEntity.Builder newCatalogBuilder =
-                    CatalogEntity.builder()
-                        .withId(catalog.id())
-                        .withName(catalog.name())
-                        .withNamespace(ident.namespace())
-                        .withType(catalog.getType())
-                        .withProvider(catalog.getProvider())
-                        .withComment(catalog.getComment());
-
-                AuditInfo newInfo =
-                    AuditInfo.builder()
-                        .withCreator(catalog.auditInfo().creator())
-                        .withCreateTime(catalog.auditInfo().createTime())
-                        .withLastModifier(PrincipalUtils.getCurrentPrincipal().getName())
-                        .withLastModifiedTime(Instant.now())
-                        .build();
-                newCatalogBuilder.withAuditInfo(newInfo);
+                    newCatalogBuilder(ident.namespace(), catalog);
 
                 Map<String, String> newProps =
                     catalog.getProperties() == null
@@ -544,8 +607,10 @@ public class CatalogManager implements CatalogDispatcher, Closeable {
 
                 return newCatalogBuilder.build();
               });
-      return catalogCache.get(
-              updatedCatalog.nameIdentifier(), id -> createCatalogWrapper(updatedCatalog))
+      return Objects.requireNonNull(
+              catalogCache.get(
+                  updatedCatalog.nameIdentifier(),
+                  id -> createCatalogWrapper(updatedCatalog, null)))
           .catalog;
 
     } catch (NoSuchEntityException ne) {
@@ -562,38 +627,44 @@ public class CatalogManager implements CatalogDispatcher, Closeable {
     }
   }
 
-  /**
-   * Drops (deletes) the catalog with the specified identifier.
-   *
-   * @param ident The identifier of the catalog to drop.
-   * @return {@code true} if the catalog was successfully dropped, {@code false} otherwise.
-   */
   @Override
-  public boolean dropCatalog(NameIdentifier ident) {
-    // There could be a race issue that someone is using the catalog while we are dropping it.
-    catalogCache.invalidate(ident);
-
+  public boolean dropCatalog(NameIdentifier ident, boolean force)
+      throws NonEmptyEntityException, EntityInUseException {
     try {
-      CatalogEntity catalogEntity = store.get(ident, EntityType.CATALOG, CatalogEntity.class);
-      if (catalogEntity.getProvider().equals("kafka")) {
-        // Kafka catalog needs to cascade drop the default schema
-        List<SchemaEntity> schemas =
-            store.list(
-                Namespace.of(ident.namespace().level(0), ident.name()),
-                SchemaEntity.class,
-                EntityType.SCHEMA);
-        // If there is only one schema, it must be the default schema, because we don't allow to
-        // drop the default schema.
-        if (schemas.size() == 1) {
-          return store.delete(ident, EntityType.CATALOG, true);
-        }
+      boolean catalogInUse = catalogInUse(store, ident);
+      if (catalogInUse && !force) {
+        throw new EntityInUseException(
+            "Catalog %s is in use, please deactivate it first or use force option", ident);
       }
-      return store.delete(ident, EntityType.CATALOG);
-    } catch (NoSuchEntityException e) {
+
+      List<SchemaEntity> schemas =
+          store.list(
+              Namespace.of(ident.namespace().level(0), ident.name()),
+              SchemaEntity.class,
+              EntityType.SCHEMA);
+      CatalogEntity catalogEntity = store.get(ident, EntityType.CATALOG, CatalogEntity.class);
+
+      if (!schemas.isEmpty()
+          && !force
+          && (!catalogEntity.getProvider().equals("kafka") || schemas.size() > 1)) {
+        throw new NonEmptyEntityException(
+            "Catalog %s has schemas, please drop them first or use force option", ident);
+      }
+
+      // If reached here, it implies that the catalog is not in use or force is true.
+      if (catalogInUse) {
+        // force is true, deactivate the catalog first
+        deactivateCatalog(ident);
+      }
+
+      catalogCache.invalidate(ident);
+      return store.delete(ident, EntityType.CATALOG, true);
+
+    } catch (NoSuchMetalakeException | NoSuchCatalogException ignored) {
       return false;
-    } catch (IOException ioe) {
-      LOG.error("Failed to drop catalog {}", ident, ioe);
-      throw new RuntimeException(ioe);
+
+    } catch (IOException e) {
+      throw new RuntimeException(e);
     }
   }
 
@@ -607,6 +678,44 @@ public class CatalogManager implements CatalogDispatcher, Closeable {
    */
   public CatalogWrapper loadCatalogAndWrap(NameIdentifier ident) throws NoSuchCatalogException {
     return catalogCache.get(ident, this::loadCatalogInternal);
+  }
+
+  private static boolean getInUseValue(EntityStore store, NameIdentifier catalogIdent) {
+    try {
+      CatalogEntity catalogEntity =
+          store.get(catalogIdent, EntityType.CATALOG, CatalogEntity.class);
+      return (boolean)
+          BASIC_CATALOG_PROPERTIES_METADATA.getOrDefault(
+              catalogEntity.getProperties(), PROPERTY_IN_USE);
+
+    } catch (NoSuchEntityException e) {
+      LOG.warn("Catalog {} does not exist", catalogIdent, e);
+      throw new NoSuchCatalogException(CATALOG_DOES_NOT_EXIST_MSG, catalogIdent);
+
+    } catch (IOException e) {
+      LOG.error("Failed to do store operation", e);
+      throw new RuntimeException(e);
+    }
+  }
+
+  private CatalogEntity.Builder newCatalogBuilder(Namespace namespace, CatalogEntity catalog) {
+    CatalogEntity.Builder builder =
+        CatalogEntity.builder()
+            .withId(catalog.id())
+            .withName(catalog.name())
+            .withNamespace(namespace)
+            .withType(catalog.getType())
+            .withProvider(catalog.getProvider())
+            .withComment(catalog.getComment());
+
+    AuditInfo newInfo =
+        AuditInfo.builder()
+            .withCreator(catalog.auditInfo().creator())
+            .withCreateTime(catalog.auditInfo().createTime())
+            .withLastModifier(PrincipalUtils.getCurrentPrincipal().getName())
+            .withLastModifiedTime(Instant.now())
+            .build();
+    return builder.withAuditInfo(newInfo);
   }
 
   private Map<String, String> buildCatalogConf(String provider, Map<String, String> properties) {
@@ -650,7 +759,7 @@ public class CatalogManager implements CatalogDispatcher, Closeable {
   private CatalogWrapper loadCatalogInternal(NameIdentifier ident) throws NoSuchCatalogException {
     try {
       CatalogEntity entity = store.get(ident, EntityType.CATALOG, CatalogEntity.class);
-      return createCatalogWrapper(entity);
+      return createCatalogWrapper(entity, null);
 
     } catch (NoSuchEntityException ne) {
       LOG.warn("Catalog {} does not exist", ident, ne);
@@ -662,7 +771,16 @@ public class CatalogManager implements CatalogDispatcher, Closeable {
     }
   }
 
-  private CatalogWrapper createCatalogWrapper(CatalogEntity entity) {
+  /**
+   * Create a catalog wrapper from the catalog entity and validate the given properties for
+   * creation. The properties can be null if it is not needed to validate.
+   *
+   * @param entity The catalog entity.
+   * @param propsToValidate The properties to validate.
+   * @return The created catalog wrapper.
+   */
+  private CatalogWrapper createCatalogWrapper(
+      CatalogEntity entity, @Nullable Map<String, String> propsToValidate) {
     Map<String, String> conf = entity.getProperties();
     String provider = entity.getProvider();
 
@@ -673,9 +791,7 @@ public class CatalogManager implements CatalogDispatcher, Closeable {
     // Validate catalog properties and initialize the config
     classLoader.withClassLoader(
         cl -> {
-          Map<String, String> configWithoutId = Maps.newHashMap(conf);
-          configWithoutId.remove(ID_KEY);
-          validatePropertyForCreate(catalog.catalogPropertiesMetadata(), configWithoutId);
+          validatePropertyForCreate(catalog.catalogPropertiesMetadata(), propsToValidate);
 
           // Call wrapper.catalog.properties() to make BaseCatalog#properties in IsolatedClassLoader
           // not null. Why do we do this? Because wrapper.catalog.properties() needs to be called in
@@ -689,6 +805,23 @@ public class CatalogManager implements CatalogDispatcher, Closeable {
         IllegalArgumentException.class);
 
     return wrapper;
+  }
+
+  /**
+   * get the resolved properties (filter out the hidden properties and add some required default
+   * properties) of the catalog entity.
+   *
+   * @param entity The catalog entity.
+   * @return The resolved properties.
+   */
+  private Map<String, String> getResolvedProperties(CatalogEntity entity) {
+    Map<String, String> conf = entity.getProperties();
+    String provider = entity.getProvider();
+
+    try (IsolatedClassLoader classLoader = createClassLoader(provider, conf)) {
+      BaseCatalog<?> catalog = createBaseCatalog(classLoader, entity);
+      return classLoader.withClassLoader(cl -> catalog.properties(), RuntimeException.class);
+    }
   }
 
   private Set<String> getHiddenPropertyNames(CatalogEntity entity) {

--- a/core/src/main/java/org/apache/gravitino/catalog/CatalogManager.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/CatalogManager.java
@@ -634,11 +634,12 @@ public class CatalogManager implements CatalogDispatcher, Closeable {
               EntityType.SCHEMA);
       CatalogEntity catalogEntity = store.get(ident, EntityType.CATALOG, CatalogEntity.class);
 
-      if (!schemas.isEmpty()
-          && !force
-          && (!catalogEntity.getProvider().equals("kafka") || schemas.size() > 1)) {
-        throw new NonEmptyEntityException(
-            "Catalog %s has schemas, please drop them first or use force option", ident);
+      if (!schemas.isEmpty() && !force) {
+        // the Kafka catalog is special, it includes a default schema
+        if (!catalogEntity.getProvider().equals("kafka") || schemas.size() > 1) {
+          throw new NonEmptyEntityException(
+              "Catalog %s has schemas, please drop them first or use force option", ident);
+        }
       }
 
       // If reached here, it implies that the catalog is not in use or force is true.

--- a/core/src/main/java/org/apache/gravitino/catalog/CatalogNormalizeDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/CatalogNormalizeDispatcher.java
@@ -125,13 +125,13 @@ public class CatalogNormalizeDispatcher implements CatalogDispatcher {
   }
 
   @Override
-  public void activateCatalog(NameIdentifier ident) throws NoSuchCatalogException {
-    dispatcher.activateCatalog(ident);
+  public void enableCatalog(NameIdentifier ident) throws NoSuchCatalogException {
+    dispatcher.enableCatalog(ident);
   }
 
   @Override
-  public void deactivateCatalog(NameIdentifier ident) throws NoSuchCatalogException {
-    dispatcher.deactivateCatalog(ident);
+  public void disableCatalog(NameIdentifier ident) throws NoSuchCatalogException {
+    dispatcher.disableCatalog(ident);
   }
 
   private void validateCatalogName(String name) throws IllegalArgumentException {

--- a/core/src/main/java/org/apache/gravitino/catalog/CatalogNormalizeDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/CatalogNormalizeDispatcher.java
@@ -30,7 +30,7 @@ import org.apache.gravitino.MetadataObjects;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
 import org.apache.gravitino.exceptions.CatalogAlreadyExistsException;
-import org.apache.gravitino.exceptions.EntityInUseException;
+import org.apache.gravitino.exceptions.CatalogInUseException;
 import org.apache.gravitino.exceptions.NoSuchCatalogException;
 import org.apache.gravitino.exceptions.NoSuchMetalakeException;
 import org.apache.gravitino.exceptions.NonEmptyEntityException;
@@ -108,7 +108,7 @@ public class CatalogNormalizeDispatcher implements CatalogDispatcher {
 
   @Override
   public boolean dropCatalog(NameIdentifier ident, boolean force)
-      throws NonEmptyEntityException, EntityInUseException {
+      throws NonEmptyEntityException, CatalogInUseException {
     return dispatcher.dropCatalog(ident, force);
   }
 

--- a/core/src/main/java/org/apache/gravitino/catalog/CatalogNormalizeDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/CatalogNormalizeDispatcher.java
@@ -30,8 +30,10 @@ import org.apache.gravitino.MetadataObjects;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
 import org.apache.gravitino.exceptions.CatalogAlreadyExistsException;
+import org.apache.gravitino.exceptions.EntityInUseException;
 import org.apache.gravitino.exceptions.NoSuchCatalogException;
 import org.apache.gravitino.exceptions.NoSuchMetalakeException;
+import org.apache.gravitino.exceptions.NonEmptyEntityException;
 
 public class CatalogNormalizeDispatcher implements CatalogDispatcher {
   private static final Set<String> RESERVED_WORDS =
@@ -105,6 +107,12 @@ public class CatalogNormalizeDispatcher implements CatalogDispatcher {
   }
 
   @Override
+  public boolean dropCatalog(NameIdentifier ident, boolean force)
+      throws NonEmptyEntityException, EntityInUseException {
+    return dispatcher.dropCatalog(ident, force);
+  }
+
+  @Override
   public void testConnection(
       NameIdentifier ident,
       Catalog.Type type,
@@ -114,6 +122,16 @@ public class CatalogNormalizeDispatcher implements CatalogDispatcher {
       throws Exception {
     validateCatalogName(ident.name());
     dispatcher.testConnection(ident, type, provider, comment, properties);
+  }
+
+  @Override
+  public void activateCatalog(NameIdentifier ident) throws NoSuchCatalogException {
+    dispatcher.activateCatalog(ident);
+  }
+
+  @Override
+  public void deactivateCatalog(NameIdentifier ident) throws NoSuchCatalogException {
+    dispatcher.deactivateCatalog(ident);
   }
 
   private void validateCatalogName(String name) throws IllegalArgumentException {

--- a/core/src/main/java/org/apache/gravitino/catalog/OperationDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/OperationDispatcher.java
@@ -95,8 +95,7 @@ public abstract class OperationDispatcher {
       NameIdentifier ident, ThrowableFunction<CatalogManager.CatalogWrapper, R> fn, Class<E> ex)
       throws E {
     if (!catalogInUse(store, ident)) {
-      throw new CatalogNotInUseException(
-          "Catalog %s is not in use, please activate it first", ident);
+      throw new CatalogNotInUseException("Catalog %s is not in use, please enable it first", ident);
     }
 
     try {
@@ -120,8 +119,7 @@ public abstract class OperationDispatcher {
       Class<E2> ex2)
       throws E1, E2 {
     if (!catalogInUse(store, ident)) {
-      throw new CatalogNotInUseException(
-          "Catalog %s is not in use, please activate it first", ident);
+      throw new CatalogNotInUseException("Catalog %s is not in use, please enable it first", ident);
     }
 
     try {

--- a/core/src/main/java/org/apache/gravitino/catalog/OperationDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/OperationDispatcher.java
@@ -36,7 +36,7 @@ import org.apache.gravitino.connector.HasPropertyMetadata;
 import org.apache.gravitino.connector.PropertiesMetadata;
 import org.apache.gravitino.connector.capability.Capability;
 import org.apache.gravitino.exceptions.NoSuchEntityException;
-import org.apache.gravitino.exceptions.NonInUseEntityException;
+import org.apache.gravitino.exceptions.NotInUseEntityException;
 import org.apache.gravitino.file.FilesetChange;
 import org.apache.gravitino.messaging.TopicChange;
 import org.apache.gravitino.rel.SupportsPartitions;
@@ -95,7 +95,7 @@ public abstract class OperationDispatcher {
       NameIdentifier ident, ThrowableFunction<CatalogManager.CatalogWrapper, R> fn, Class<E> ex)
       throws E {
     if (!catalogInUse(store, ident)) {
-      throw new NonInUseEntityException(
+      throw new NotInUseEntityException(
           "Catalog %s is not in use, please activate it first", ident);
     }
 
@@ -120,7 +120,7 @@ public abstract class OperationDispatcher {
       Class<E2> ex2)
       throws E1, E2 {
     if (!catalogInUse(store, ident)) {
-      throw new NonInUseEntityException(
+      throw new NotInUseEntityException(
           "Catalog %s is not in use, please activate it first", ident);
     }
 

--- a/core/src/main/java/org/apache/gravitino/catalog/OperationDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/OperationDispatcher.java
@@ -35,8 +35,8 @@ import org.apache.gravitino.StringIdentifier;
 import org.apache.gravitino.connector.HasPropertyMetadata;
 import org.apache.gravitino.connector.PropertiesMetadata;
 import org.apache.gravitino.connector.capability.Capability;
+import org.apache.gravitino.exceptions.CatalogNotInUseException;
 import org.apache.gravitino.exceptions.NoSuchEntityException;
-import org.apache.gravitino.exceptions.NotInUseEntityException;
 import org.apache.gravitino.file.FilesetChange;
 import org.apache.gravitino.messaging.TopicChange;
 import org.apache.gravitino.rel.SupportsPartitions;
@@ -95,7 +95,7 @@ public abstract class OperationDispatcher {
       NameIdentifier ident, ThrowableFunction<CatalogManager.CatalogWrapper, R> fn, Class<E> ex)
       throws E {
     if (!catalogInUse(store, ident)) {
-      throw new NotInUseEntityException(
+      throw new CatalogNotInUseException(
           "Catalog %s is not in use, please activate it first", ident);
     }
 
@@ -120,7 +120,7 @@ public abstract class OperationDispatcher {
       Class<E2> ex2)
       throws E1, E2 {
     if (!catalogInUse(store, ident)) {
-      throw new NotInUseEntityException(
+      throw new CatalogNotInUseException(
           "Catalog %s is not in use, please activate it first", ident);
     }
 

--- a/core/src/main/java/org/apache/gravitino/catalog/SupportsCatalogs.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/SupportsCatalogs.java
@@ -123,7 +123,7 @@ public interface SupportsCatalogs {
    * <ul>
    *   <li>There is no schema in the catalog. Otherwise, a {@link NonEmptyEntityException} will be
    *       thrown.
-   *   <li>The method {@link #deactivateCatalog(NameIdentifier)} has been called before dropping the
+   *   <li>The method {@link #disableCatalog(NameIdentifier)} has been called before dropping the
    *       catalog.
    * </ul>
    *
@@ -177,21 +177,20 @@ public interface SupportsCatalogs {
       throws Exception;
 
   /**
-   * Activate a catalog. If the catalog is already active, this method does nothing.
+   * Enable a catalog. If the catalog is already enable, this method does nothing.
    *
    * @param ident The identifier of the catalog.
    * @throws NoSuchCatalogException If the catalog does not exist.
-   * @throws CatalogNotInUseException If its parent metalake is not active.
+   * @throws CatalogNotInUseException If its parent metalake is not in use.
    */
-  void activateCatalog(NameIdentifier ident)
-      throws NoSuchCatalogException, CatalogNotInUseException;
+  void enableCatalog(NameIdentifier ident) throws NoSuchCatalogException, CatalogNotInUseException;
 
   /**
-   * Deactivate a catalog. If the catalog is already deactivated, this method does nothing. Once a
-   * catalog is deactivated:
+   * Disable a catalog. If the catalog is already disabled, this method does nothing. Once a catalog
+   * is disabled:
    *
    * <ul>
-   *   <li>It can only be listed, loaded, dropped, or activated.
+   *   <li>It can only be listed, loaded, dropped, or disable.
    *   <li>Any other operations on the catalog will throw an {@link CatalogNotInUseException}.
    *   <li>Any operation on the sub-entities (schemas, tables, etc.) will throw an {@link
    *       CatalogNotInUseException}.
@@ -200,5 +199,5 @@ public interface SupportsCatalogs {
    * @param ident The identifier of the catalog.
    * @throws NoSuchCatalogException If the catalog does not exist.
    */
-  void deactivateCatalog(NameIdentifier ident) throws NoSuchCatalogException;
+  void disableCatalog(NameIdentifier ident) throws NoSuchCatalogException;
 }

--- a/core/src/main/java/org/apache/gravitino/catalog/SupportsCatalogs.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/SupportsCatalogs.java
@@ -30,7 +30,7 @@ import org.apache.gravitino.exceptions.EntityInUseException;
 import org.apache.gravitino.exceptions.NoSuchCatalogException;
 import org.apache.gravitino.exceptions.NoSuchMetalakeException;
 import org.apache.gravitino.exceptions.NonEmptyEntityException;
-import org.apache.gravitino.exceptions.NonInUseEntityException;
+import org.apache.gravitino.exceptions.NotInUseEntityException;
 
 /**
  * Interface for supporting catalogs. It includes methods for listing, loading, creating, altering
@@ -181,9 +181,9 @@ public interface SupportsCatalogs {
    *
    * @param ident The identifier of the catalog.
    * @throws NoSuchCatalogException If the catalog does not exist.
-   * @throws NonInUseEntityException If its parent metalake is not active.
+   * @throws NotInUseEntityException If its parent metalake is not active.
    */
-  void activateCatalog(NameIdentifier ident) throws NoSuchCatalogException, NonInUseEntityException;
+  void activateCatalog(NameIdentifier ident) throws NoSuchCatalogException, NotInUseEntityException;
 
   /**
    * Deactivate a catalog. If the catalog is already deactivated, this method does nothing. Once a
@@ -191,10 +191,9 @@ public interface SupportsCatalogs {
    *
    * <ul>
    *   <li>It can only be listed, loaded, dropped, or activated.
-   *   <li>Any other operations on the catalog will throw an {@link
-   *       org.apache.gravitino.exceptions.NonInUseEntityException}.
+   *   <li>Any other operations on the catalog will throw an {@link NotInUseEntityException}.
    *   <li>Any operation on the sub-entities (schemas, tables, etc.) will throw an {@link
-   *       org.apache.gravitino.exceptions.NonInUseEntityException}.
+   *       NotInUseEntityException}.
    * </ul>
    *
    * @param ident The identifier of the catalog.

--- a/core/src/main/java/org/apache/gravitino/catalog/SupportsCatalogs.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/SupportsCatalogs.java
@@ -26,8 +26,11 @@ import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
 import org.apache.gravitino.annotation.Evolving;
 import org.apache.gravitino.exceptions.CatalogAlreadyExistsException;
+import org.apache.gravitino.exceptions.EntityInUseException;
 import org.apache.gravitino.exceptions.NoSuchCatalogException;
 import org.apache.gravitino.exceptions.NoSuchMetalakeException;
+import org.apache.gravitino.exceptions.NonEmptyEntityException;
+import org.apache.gravitino.exceptions.NonInUseEntityException;
 
 /**
  * Interface for supporting catalogs. It includes methods for listing, loading, creating, altering
@@ -115,12 +118,45 @@ public interface SupportsCatalogs {
       throws NoSuchCatalogException, IllegalArgumentException;
 
   /**
-   * Drop a catalog with specified identifier.
+   * Drop a catalog with specified identifier. Please make sure:
+   *
+   * <ul>
+   *   <li>There is no schema in the catalog. Otherwise, a {@link NonEmptyEntityException} will be
+   *       thrown.
+   *   <li>The method {@link #deactivateCatalog(NameIdentifier)} has been called before dropping the
+   *       catalog.
+   * </ul>
+   *
+   * It is equivalent to calling {@code dropCatalog(ident, false)}.
    *
    * @param ident the identifier of the catalog.
    * @return True if the catalog was dropped, false if the catalog does not exist.
+   * @throws NonEmptyEntityException If the catalog is not empty.
+   * @throws EntityInUseException If the catalog is in use.
    */
-  boolean dropCatalog(NameIdentifier ident);
+  default boolean dropCatalog(NameIdentifier ident)
+      throws NonEmptyEntityException, EntityInUseException {
+    return dropCatalog(ident, false);
+  }
+
+  /**
+   * Drop a catalog with specified identifier. If the force flag is true, it will:
+   *
+   * <ul>
+   *   <li>Cascade drop all sub-entities (schemas, tables, etc.) of the catalog in Gravitino store.
+   *   <li>Drop the catalog even if it is in use.
+   *   <li>External resources (e.g. database, table, etc.) associated with sub-entities will not be
+   *       dropped unless it is managed (such as managed fileset).
+   * </ul>
+   *
+   * @param ident The identifier of the catalog.
+   * @param force Whether to force the drop.
+   * @return True if the catalog was dropped, false if the catalog does not exist.
+   * @throws NonEmptyEntityException If the catalog is not empty and force is false.
+   * @throws EntityInUseException If the catalog is in use and force is false.
+   */
+  boolean dropCatalog(NameIdentifier ident, boolean force)
+      throws NonEmptyEntityException, EntityInUseException;
 
   /**
    * Test whether the catalog with specified parameters can be connected to before creating it.
@@ -139,4 +175,30 @@ public interface SupportsCatalogs {
       String comment,
       Map<String, String> properties)
       throws Exception;
+
+  /**
+   * Activate a catalog. If the catalog is already active, this method does nothing.
+   *
+   * @param ident The identifier of the catalog.
+   * @throws NoSuchCatalogException If the catalog does not exist.
+   * @throws NonInUseEntityException If its parent metalake is not active.
+   */
+  void activateCatalog(NameIdentifier ident) throws NoSuchCatalogException, NonInUseEntityException;
+
+  /**
+   * Deactivate a catalog. If the catalog is already deactivated, this method does nothing. Once a
+   * catalog is deactivated:
+   *
+   * <ul>
+   *   <li>It can only be listed, loaded, dropped, or activated.
+   *   <li>Any other operations on the catalog will throw an {@link
+   *       org.apache.gravitino.exceptions.NonInUseEntityException}.
+   *   <li>Any operation on the sub-entities (schemas, tables, etc.) will throw an {@link
+   *       org.apache.gravitino.exceptions.NonInUseEntityException}.
+   * </ul>
+   *
+   * @param ident The identifier of the catalog.
+   * @throws NoSuchCatalogException If the catalog does not exist.
+   */
+  void deactivateCatalog(NameIdentifier ident) throws NoSuchCatalogException;
 }

--- a/core/src/main/java/org/apache/gravitino/catalog/SupportsCatalogs.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/SupportsCatalogs.java
@@ -26,11 +26,11 @@ import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
 import org.apache.gravitino.annotation.Evolving;
 import org.apache.gravitino.exceptions.CatalogAlreadyExistsException;
-import org.apache.gravitino.exceptions.EntityInUseException;
+import org.apache.gravitino.exceptions.CatalogInUseException;
+import org.apache.gravitino.exceptions.CatalogNotInUseException;
 import org.apache.gravitino.exceptions.NoSuchCatalogException;
 import org.apache.gravitino.exceptions.NoSuchMetalakeException;
 import org.apache.gravitino.exceptions.NonEmptyEntityException;
-import org.apache.gravitino.exceptions.NotInUseEntityException;
 
 /**
  * Interface for supporting catalogs. It includes methods for listing, loading, creating, altering
@@ -132,10 +132,10 @@ public interface SupportsCatalogs {
    * @param ident the identifier of the catalog.
    * @return True if the catalog was dropped, false if the catalog does not exist.
    * @throws NonEmptyEntityException If the catalog is not empty.
-   * @throws EntityInUseException If the catalog is in use.
+   * @throws CatalogInUseException If the catalog is in use.
    */
   default boolean dropCatalog(NameIdentifier ident)
-      throws NonEmptyEntityException, EntityInUseException {
+      throws NonEmptyEntityException, CatalogInUseException {
     return dropCatalog(ident, false);
   }
 
@@ -153,10 +153,10 @@ public interface SupportsCatalogs {
    * @param force Whether to force the drop.
    * @return True if the catalog was dropped, false if the catalog does not exist.
    * @throws NonEmptyEntityException If the catalog is not empty and force is false.
-   * @throws EntityInUseException If the catalog is in use and force is false.
+   * @throws CatalogInUseException If the catalog is in use and force is false.
    */
   boolean dropCatalog(NameIdentifier ident, boolean force)
-      throws NonEmptyEntityException, EntityInUseException;
+      throws NonEmptyEntityException, CatalogInUseException;
 
   /**
    * Test whether the catalog with specified parameters can be connected to before creating it.
@@ -181,9 +181,10 @@ public interface SupportsCatalogs {
    *
    * @param ident The identifier of the catalog.
    * @throws NoSuchCatalogException If the catalog does not exist.
-   * @throws NotInUseEntityException If its parent metalake is not active.
+   * @throws CatalogNotInUseException If its parent metalake is not active.
    */
-  void activateCatalog(NameIdentifier ident) throws NoSuchCatalogException, NotInUseEntityException;
+  void activateCatalog(NameIdentifier ident)
+      throws NoSuchCatalogException, CatalogNotInUseException;
 
   /**
    * Deactivate a catalog. If the catalog is already deactivated, this method does nothing. Once a
@@ -191,9 +192,9 @@ public interface SupportsCatalogs {
    *
    * <ul>
    *   <li>It can only be listed, loaded, dropped, or activated.
-   *   <li>Any other operations on the catalog will throw an {@link NotInUseEntityException}.
+   *   <li>Any other operations on the catalog will throw an {@link CatalogNotInUseException}.
    *   <li>Any operation on the sub-entities (schemas, tables, etc.) will throw an {@link
-   *       NotInUseEntityException}.
+   *       CatalogNotInUseException}.
    * </ul>
    *
    * @param ident The identifier of the catalog.

--- a/core/src/main/java/org/apache/gravitino/catalog/SupportsCatalogs.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/SupportsCatalogs.java
@@ -177,7 +177,7 @@ public interface SupportsCatalogs {
       throws Exception;
 
   /**
-   * Enable a catalog. If the catalog is already enable, this method does nothing.
+   * Enable a catalog. If the catalog is already enabled, this method does nothing.
    *
    * @param ident The identifier of the catalog.
    * @throws NoSuchCatalogException If the catalog does not exist.

--- a/core/src/main/java/org/apache/gravitino/connector/BaseCatalog.java
+++ b/core/src/main/java/org/apache/gravitino/connector/BaseCatalog.java
@@ -342,6 +342,9 @@ public abstract class BaseCatalog<T extends BaseCatalog>
           tempProperties
               .entrySet()
               .removeIf(entry -> catalogPropertiesMetadata().isHiddenProperty(entry.getKey()));
+          tempProperties.putIfAbsent(
+              PROPERTY_IN_USE,
+              catalogPropertiesMetadata().getDefaultValue(PROPERTY_IN_USE).toString());
           properties = tempProperties;
         }
       }

--- a/core/src/main/java/org/apache/gravitino/connector/BaseCatalogPropertiesMetadata.java
+++ b/core/src/main/java/org/apache/gravitino/connector/BaseCatalogPropertiesMetadata.java
@@ -21,6 +21,7 @@ package org.apache.gravitino.connector;
 
 import static org.apache.gravitino.Catalog.CLOUD_NAME;
 import static org.apache.gravitino.Catalog.CLOUD_REGION_CODE;
+import static org.apache.gravitino.Catalog.PROPERTY_IN_USE;
 import static org.apache.gravitino.Catalog.PROPERTY_PACKAGE;
 
 import com.google.common.base.Preconditions;
@@ -73,6 +74,11 @@ public abstract class BaseCatalogPropertiesMetadata extends BasePropertiesMetada
                   "The region code of the cloud that the catalog is running on",
                   false /* immutable */,
                   null /* The default value does not work because if the user does not set it, this property will not be displayed */,
+                  false /* hidden */),
+              PropertyEntry.booleanReservedPropertyEntry(
+                  PROPERTY_IN_USE,
+                  "The property indicating the catalog is in use",
+                  true /* default value */,
                   false /* hidden */)),
           PropertyEntry::getName);
 

--- a/core/src/main/java/org/apache/gravitino/connector/BaseCatalogPropertiesMetadata.java
+++ b/core/src/main/java/org/apache/gravitino/connector/BaseCatalogPropertiesMetadata.java
@@ -28,12 +28,21 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
+import java.util.Collections;
 import java.util.Map;
 import org.apache.gravitino.Catalog;
 import org.apache.gravitino.annotation.Evolving;
 
 @Evolving
 public abstract class BaseCatalogPropertiesMetadata extends BasePropertiesMetadata {
+
+  public static final PropertiesMetadata BASIC_CATALOG_PROPERTIES_METADATA =
+      new BaseCatalogPropertiesMetadata() {
+        @Override
+        protected Map<String, PropertyEntry<?>> specificPropertyEntries() {
+          return Collections.emptyMap();
+        }
+      };
 
   // The basic property entries for catalog entities
   private static final Map<String, PropertyEntry<?>> BASIC_CATALOG_PROPERTY_ENTRIES =

--- a/core/src/main/java/org/apache/gravitino/hook/CatalogHookDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/hook/CatalogHookDispatcher.java
@@ -36,7 +36,7 @@ import org.apache.gravitino.exceptions.EntityInUseException;
 import org.apache.gravitino.exceptions.NoSuchCatalogException;
 import org.apache.gravitino.exceptions.NoSuchMetalakeException;
 import org.apache.gravitino.exceptions.NonEmptyEntityException;
-import org.apache.gravitino.exceptions.NonInUseEntityException;
+import org.apache.gravitino.exceptions.NotInUseEntityException;
 import org.apache.gravitino.utils.NameIdentifierUtil;
 import org.apache.gravitino.utils.PrincipalUtils;
 
@@ -131,7 +131,7 @@ public class CatalogHookDispatcher implements CatalogDispatcher {
 
   @Override
   public void activateCatalog(NameIdentifier ident)
-      throws NoSuchCatalogException, NonInUseEntityException {
+      throws NoSuchCatalogException, NotInUseEntityException {
     dispatcher.activateCatalog(ident);
   }
 

--- a/core/src/main/java/org/apache/gravitino/hook/CatalogHookDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/hook/CatalogHookDispatcher.java
@@ -32,11 +32,11 @@ import org.apache.gravitino.authorization.OwnerManager;
 import org.apache.gravitino.catalog.CatalogDispatcher;
 import org.apache.gravitino.connector.BaseCatalog;
 import org.apache.gravitino.exceptions.CatalogAlreadyExistsException;
-import org.apache.gravitino.exceptions.EntityInUseException;
+import org.apache.gravitino.exceptions.CatalogInUseException;
+import org.apache.gravitino.exceptions.CatalogNotInUseException;
 import org.apache.gravitino.exceptions.NoSuchCatalogException;
 import org.apache.gravitino.exceptions.NoSuchMetalakeException;
 import org.apache.gravitino.exceptions.NonEmptyEntityException;
-import org.apache.gravitino.exceptions.NotInUseEntityException;
 import org.apache.gravitino.utils.NameIdentifierUtil;
 import org.apache.gravitino.utils.PrincipalUtils;
 
@@ -114,7 +114,7 @@ public class CatalogHookDispatcher implements CatalogDispatcher {
 
   @Override
   public boolean dropCatalog(NameIdentifier ident, boolean force)
-      throws NonEmptyEntityException, EntityInUseException {
+      throws NonEmptyEntityException, CatalogInUseException {
     return dispatcher.dropCatalog(ident, force);
   }
 
@@ -131,7 +131,7 @@ public class CatalogHookDispatcher implements CatalogDispatcher {
 
   @Override
   public void activateCatalog(NameIdentifier ident)
-      throws NoSuchCatalogException, NotInUseEntityException {
+      throws NoSuchCatalogException, CatalogNotInUseException {
     dispatcher.activateCatalog(ident);
   }
 

--- a/core/src/main/java/org/apache/gravitino/hook/CatalogHookDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/hook/CatalogHookDispatcher.java
@@ -32,8 +32,11 @@ import org.apache.gravitino.authorization.OwnerManager;
 import org.apache.gravitino.catalog.CatalogDispatcher;
 import org.apache.gravitino.connector.BaseCatalog;
 import org.apache.gravitino.exceptions.CatalogAlreadyExistsException;
+import org.apache.gravitino.exceptions.EntityInUseException;
 import org.apache.gravitino.exceptions.NoSuchCatalogException;
 import org.apache.gravitino.exceptions.NoSuchMetalakeException;
+import org.apache.gravitino.exceptions.NonEmptyEntityException;
+import org.apache.gravitino.exceptions.NonInUseEntityException;
 import org.apache.gravitino.utils.NameIdentifierUtil;
 import org.apache.gravitino.utils.PrincipalUtils;
 
@@ -110,6 +113,12 @@ public class CatalogHookDispatcher implements CatalogDispatcher {
   }
 
   @Override
+  public boolean dropCatalog(NameIdentifier ident, boolean force)
+      throws NonEmptyEntityException, EntityInUseException {
+    return dispatcher.dropCatalog(ident, force);
+  }
+
+  @Override
   public void testConnection(
       NameIdentifier ident,
       Catalog.Type type,
@@ -118,6 +127,17 @@ public class CatalogHookDispatcher implements CatalogDispatcher {
       Map<String, String> properties)
       throws Exception {
     dispatcher.testConnection(ident, type, provider, comment, properties);
+  }
+
+  @Override
+  public void activateCatalog(NameIdentifier ident)
+      throws NoSuchCatalogException, NonInUseEntityException {
+    dispatcher.activateCatalog(ident);
+  }
+
+  @Override
+  public void deactivateCatalog(NameIdentifier ident) throws NoSuchCatalogException {
+    dispatcher.deactivateCatalog(ident);
   }
 
   @Override

--- a/core/src/main/java/org/apache/gravitino/hook/CatalogHookDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/hook/CatalogHookDispatcher.java
@@ -130,14 +130,14 @@ public class CatalogHookDispatcher implements CatalogDispatcher {
   }
 
   @Override
-  public void activateCatalog(NameIdentifier ident)
+  public void enableCatalog(NameIdentifier ident)
       throws NoSuchCatalogException, CatalogNotInUseException {
-    dispatcher.activateCatalog(ident);
+    dispatcher.enableCatalog(ident);
   }
 
   @Override
-  public void deactivateCatalog(NameIdentifier ident) throws NoSuchCatalogException {
-    dispatcher.deactivateCatalog(ident);
+  public void disableCatalog(NameIdentifier ident) throws NoSuchCatalogException {
+    dispatcher.disableCatalog(ident);
   }
 
   @Override

--- a/core/src/main/java/org/apache/gravitino/listener/CatalogEventDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/listener/CatalogEventDispatcher.java
@@ -30,7 +30,7 @@ import org.apache.gravitino.exceptions.EntityInUseException;
 import org.apache.gravitino.exceptions.NoSuchCatalogException;
 import org.apache.gravitino.exceptions.NoSuchMetalakeException;
 import org.apache.gravitino.exceptions.NonEmptyEntityException;
-import org.apache.gravitino.exceptions.NonInUseEntityException;
+import org.apache.gravitino.exceptions.NotInUseEntityException;
 import org.apache.gravitino.listener.api.event.AlterCatalogEvent;
 import org.apache.gravitino.listener.api.event.AlterCatalogFailureEvent;
 import org.apache.gravitino.listener.api.event.CreateCatalogEvent;
@@ -176,7 +176,7 @@ public class CatalogEventDispatcher implements CatalogDispatcher {
 
   @Override
   public void activateCatalog(NameIdentifier ident)
-      throws NoSuchCatalogException, NonInUseEntityException {
+      throws NoSuchCatalogException, NotInUseEntityException {
     // todo: support activate catalog event
     dispatcher.activateCatalog(ident);
   }

--- a/core/src/main/java/org/apache/gravitino/listener/CatalogEventDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/listener/CatalogEventDispatcher.java
@@ -26,11 +26,11 @@ import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
 import org.apache.gravitino.catalog.CatalogDispatcher;
 import org.apache.gravitino.exceptions.CatalogAlreadyExistsException;
-import org.apache.gravitino.exceptions.EntityInUseException;
+import org.apache.gravitino.exceptions.CatalogInUseException;
+import org.apache.gravitino.exceptions.CatalogNotInUseException;
 import org.apache.gravitino.exceptions.NoSuchCatalogException;
 import org.apache.gravitino.exceptions.NoSuchMetalakeException;
 import org.apache.gravitino.exceptions.NonEmptyEntityException;
-import org.apache.gravitino.exceptions.NotInUseEntityException;
 import org.apache.gravitino.listener.api.event.AlterCatalogEvent;
 import org.apache.gravitino.listener.api.event.AlterCatalogFailureEvent;
 import org.apache.gravitino.listener.api.event.CreateCatalogEvent;
@@ -149,7 +149,7 @@ public class CatalogEventDispatcher implements CatalogDispatcher {
 
   @Override
   public boolean dropCatalog(NameIdentifier ident, boolean force)
-      throws NonEmptyEntityException, EntityInUseException {
+      throws NonEmptyEntityException, CatalogInUseException {
     try {
       boolean isExists = dispatcher.dropCatalog(ident, force);
       eventBus.dispatchEvent(
@@ -176,7 +176,7 @@ public class CatalogEventDispatcher implements CatalogDispatcher {
 
   @Override
   public void activateCatalog(NameIdentifier ident)
-      throws NoSuchCatalogException, NotInUseEntityException {
+      throws NoSuchCatalogException, CatalogNotInUseException {
     // todo: support activate catalog event
     dispatcher.activateCatalog(ident);
   }

--- a/core/src/main/java/org/apache/gravitino/listener/CatalogEventDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/listener/CatalogEventDispatcher.java
@@ -175,15 +175,15 @@ public class CatalogEventDispatcher implements CatalogDispatcher {
   }
 
   @Override
-  public void activateCatalog(NameIdentifier ident)
+  public void enableCatalog(NameIdentifier ident)
       throws NoSuchCatalogException, CatalogNotInUseException {
     // todo: support activate catalog event
-    dispatcher.activateCatalog(ident);
+    dispatcher.enableCatalog(ident);
   }
 
   @Override
-  public void deactivateCatalog(NameIdentifier ident) throws NoSuchCatalogException {
-    // todo: support deactivate catalog event
-    dispatcher.deactivateCatalog(ident);
+  public void disableCatalog(NameIdentifier ident) throws NoSuchCatalogException {
+    // todo: support disable catalog event
+    dispatcher.disableCatalog(ident);
   }
 }

--- a/core/src/main/java/org/apache/gravitino/listener/CatalogEventDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/listener/CatalogEventDispatcher.java
@@ -26,8 +26,11 @@ import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
 import org.apache.gravitino.catalog.CatalogDispatcher;
 import org.apache.gravitino.exceptions.CatalogAlreadyExistsException;
+import org.apache.gravitino.exceptions.EntityInUseException;
 import org.apache.gravitino.exceptions.NoSuchCatalogException;
 import org.apache.gravitino.exceptions.NoSuchMetalakeException;
+import org.apache.gravitino.exceptions.NonEmptyEntityException;
+import org.apache.gravitino.exceptions.NonInUseEntityException;
 import org.apache.gravitino.listener.api.event.AlterCatalogEvent;
 import org.apache.gravitino.listener.api.event.AlterCatalogFailureEvent;
 import org.apache.gravitino.listener.api.event.CreateCatalogEvent;
@@ -145,9 +148,10 @@ public class CatalogEventDispatcher implements CatalogDispatcher {
   }
 
   @Override
-  public boolean dropCatalog(NameIdentifier ident) {
+  public boolean dropCatalog(NameIdentifier ident, boolean force)
+      throws NonEmptyEntityException, EntityInUseException {
     try {
-      boolean isExists = dispatcher.dropCatalog(ident);
+      boolean isExists = dispatcher.dropCatalog(ident, force);
       eventBus.dispatchEvent(
           new DropCatalogEvent(PrincipalUtils.getCurrentUserName(), ident, isExists));
       return isExists;
@@ -168,5 +172,18 @@ public class CatalogEventDispatcher implements CatalogDispatcher {
       throws Exception {
     // TODO: Support event dispatching for testConnection
     dispatcher.testConnection(ident, type, provider, comment, properties);
+  }
+
+  @Override
+  public void activateCatalog(NameIdentifier ident)
+      throws NoSuchCatalogException, NonInUseEntityException {
+    // todo: support activate catalog event
+    dispatcher.activateCatalog(ident);
+  }
+
+  @Override
+  public void deactivateCatalog(NameIdentifier ident) throws NoSuchCatalogException {
+    // todo: support deactivate catalog event
+    dispatcher.deactivateCatalog(ident);
   }
 }

--- a/core/src/main/java/org/apache/gravitino/meta/CatalogEntity.java
+++ b/core/src/main/java/org/apache/gravitino/meta/CatalogEntity.java
@@ -146,6 +146,11 @@ public class CatalogEntity implements Entity, Auditable, HasIdentifier {
         id, name, type, provider, comment, filteredProperties, auditInfo, namespace);
   }
 
+  public CatalogInfo toCatalogInfoWithResolvedProps(Map<String, String> resolvedProperties) {
+    return new CatalogInfo(
+        id, name, type, provider, comment, resolvedProperties, auditInfo, namespace);
+  }
+
   /** Builder class for creating instances of {@link CatalogEntity}. */
   public static class Builder {
 

--- a/core/src/test/java/org/apache/gravitino/TestCatalog.java
+++ b/core/src/test/java/org/apache/gravitino/TestCatalog.java
@@ -23,7 +23,7 @@ import static org.apache.gravitino.connector.TestCatalogOperations.FAIL_CREATE;
 import com.google.common.collect.ImmutableMap;
 import java.util.Map;
 import org.apache.gravitino.connector.BaseCatalog;
-import org.apache.gravitino.connector.BasePropertiesMetadata;
+import org.apache.gravitino.connector.BaseCatalogPropertiesMetadata;
 import org.apache.gravitino.connector.CatalogOperations;
 import org.apache.gravitino.connector.PropertiesMetadata;
 import org.apache.gravitino.connector.PropertyEntry;
@@ -68,7 +68,7 @@ public class TestCatalog extends BaseCatalog<TestCatalog> {
 
   @Override
   public PropertiesMetadata catalogPropertiesMetadata() throws UnsupportedOperationException {
-    return new BasePropertiesMetadata() {
+    return new BaseCatalogPropertiesMetadata() {
       @Override
       protected Map<String, PropertyEntry<?>> specificPropertyEntries() {
         return ImmutableMap.<String, PropertyEntry<?>>builder()
@@ -113,15 +113,6 @@ public class TestCatalog extends BaseCatalog<TestCatalog> {
                     false,
                     false,
                     false,
-                    false,
-                    false))
-            .put(
-                AUTHORIZATION_PROVIDER,
-                PropertyEntry.stringImmutablePropertyEntry(
-                    Catalog.AUTHORIZATION_PROVIDER,
-                    "The name of the authorization provider for Gravitino",
-                    false,
-                    null,
                     false,
                     false))
             .build();

--- a/core/src/test/java/org/apache/gravitino/catalog/TestCatalogManager.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestCatalogManager.java
@@ -35,7 +35,7 @@ import org.apache.gravitino.EntityStore;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
 import org.apache.gravitino.exceptions.CatalogAlreadyExistsException;
-import org.apache.gravitino.exceptions.EntityInUseException;
+import org.apache.gravitino.exceptions.CatalogInUseException;
 import org.apache.gravitino.exceptions.NoSuchCatalogException;
 import org.apache.gravitino.exceptions.NoSuchMetalakeException;
 import org.apache.gravitino.meta.AuditInfo;
@@ -457,7 +457,7 @@ public class TestCatalogManager {
     // Test drop catalog
     Exception exception =
         Assertions.assertThrows(
-            EntityInUseException.class, () -> catalogManager.dropCatalog(ident));
+            CatalogInUseException.class, () -> catalogManager.dropCatalog(ident));
     Assertions.assertTrue(exception.getMessage().contains("Catalog metalake.test41 is in use"));
 
     Assertions.assertDoesNotThrow(() -> catalogManager.deactivateCatalog(ident));

--- a/core/src/test/java/org/apache/gravitino/catalog/TestCatalogManager.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestCatalogManager.java
@@ -35,6 +35,7 @@ import org.apache.gravitino.EntityStore;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
 import org.apache.gravitino.exceptions.CatalogAlreadyExistsException;
+import org.apache.gravitino.exceptions.EntityInUseException;
 import org.apache.gravitino.exceptions.NoSuchCatalogException;
 import org.apache.gravitino.exceptions.NoSuchMetalakeException;
 import org.apache.gravitino.meta.AuditInfo;
@@ -454,6 +455,12 @@ public class TestCatalogManager {
     catalogManager.createCatalog(ident, Catalog.Type.RELATIONAL, provider, comment, props);
 
     // Test drop catalog
+    Exception exception =
+        Assertions.assertThrows(
+            EntityInUseException.class, () -> catalogManager.dropCatalog(ident));
+    Assertions.assertTrue(exception.getMessage().contains("Catalog metalake.test41 is in use"));
+
+    Assertions.assertDoesNotThrow(() -> catalogManager.deactivateCatalog(ident));
     boolean dropped = catalogManager.dropCatalog(ident);
     Assertions.assertTrue(dropped);
 

--- a/core/src/test/java/org/apache/gravitino/catalog/TestCatalogManager.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestCatalogManager.java
@@ -460,7 +460,7 @@ public class TestCatalogManager {
             CatalogInUseException.class, () -> catalogManager.dropCatalog(ident));
     Assertions.assertTrue(exception.getMessage().contains("Catalog metalake.test41 is in use"));
 
-    Assertions.assertDoesNotThrow(() -> catalogManager.deactivateCatalog(ident));
+    Assertions.assertDoesNotThrow(() -> catalogManager.disableCatalog(ident));
     boolean dropped = catalogManager.dropCatalog(ident);
     Assertions.assertTrue(dropped);
 

--- a/core/src/test/java/org/apache/gravitino/catalog/TestSchemaOperationDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestSchemaOperationDispatcher.java
@@ -23,6 +23,7 @@ import static org.apache.gravitino.StringIdentifier.ID_KEY;
 import static org.apache.gravitino.TestBasePropertiesMetadata.COMMENT_KEY;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -151,7 +152,9 @@ public class TestSchemaOperationDispatcher extends TestOperationDispatcher {
     Assertions.assertEquals(AuthConstants.ANONYMOUS_USER, loadedSchema.auditInfo().creator());
 
     // Case 2: Test if the schema is not found in entity store
-    doThrow(new NoSuchEntityException("mock error")).when(entityStore).get(any(), any(), any());
+    doThrow(new NoSuchEntityException("mock error"))
+        .when(entityStore)
+        .get(any(), eq(Entity.EntityType.SCHEMA), any());
     entityStore.delete(schemaIdent, Entity.EntityType.SCHEMA);
     Schema loadedSchema1 = dispatcher.loadSchema(schemaIdent);
     Assertions.assertEquals(schema.name(), loadedSchema1.name());
@@ -165,7 +168,7 @@ public class TestSchemaOperationDispatcher extends TestOperationDispatcher {
 
     // Case 3: Test if entity store is failed to get the schema entity
     reset(entityStore);
-    doThrow(new IOException()).when(entityStore).get(any(), any(), any());
+    doThrow(new IOException()).when(entityStore).get(any(), eq(Entity.EntityType.SCHEMA), any());
     entityStore.delete(schemaIdent, Entity.EntityType.SCHEMA);
     Schema loadedSchema2 = dispatcher.loadSchema(schemaIdent);
     // Succeed to import the topic entity
@@ -189,7 +192,7 @@ public class TestSchemaOperationDispatcher extends TestOperationDispatcher {
                     .withCreateTime(Instant.now())
                     .build())
             .build();
-    doReturn(unmatchedEntity).when(entityStore).get(any(), any(), any());
+    doReturn(unmatchedEntity).when(entityStore).get(any(), eq(Entity.EntityType.SCHEMA), any());
     Schema loadedSchema3 = dispatcher.loadSchema(schemaIdent);
     // Succeed to import the schema entity
     reset(entityStore);

--- a/core/src/test/java/org/apache/gravitino/catalog/TestTableOperationDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestTableOperationDispatcher.java
@@ -27,6 +27,7 @@ import static org.apache.gravitino.StringIdentifier.ID_KEY;
 import static org.apache.gravitino.TestBasePropertiesMetadata.COMMENT_KEY;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -45,6 +46,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.gravitino.Config;
+import org.apache.gravitino.Entity;
 import org.apache.gravitino.GravitinoEnv;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
@@ -195,7 +197,9 @@ public class TestTableOperationDispatcher extends TestOperationDispatcher {
     reset(entityStore);
     entityStore.delete(tableIdent1, TABLE);
     entityStore.delete(NameIdentifier.of(tableNs.levels()), SCHEMA);
-    doThrow(new NoSuchEntityException("")).when(entityStore).get(any(), any(), any());
+    doThrow(new NoSuchEntityException(""))
+        .when(entityStore)
+        .get(any(), eq(Entity.EntityType.TABLE), any());
     Table loadedTable2 = tableOperationDispatcher.loadTable(tableIdent1);
     // Succeed to import the topic entity
     Assertions.assertTrue(entityStore.exists(NameIdentifier.of(tableNs.levels()), SCHEMA));
@@ -207,7 +211,7 @@ public class TestTableOperationDispatcher extends TestOperationDispatcher {
     reset(entityStore);
     entityStore.delete(tableIdent1, TABLE);
     entityStore.delete(NameIdentifier.of(tableNs.levels()), SCHEMA);
-    doThrow(new IOException()).when(entityStore).get(any(), any(), any());
+    doThrow(new IOException()).when(entityStore).get(any(), eq(Entity.EntityType.TABLE), any());
     Table loadedTable3 = tableOperationDispatcher.loadTable(tableIdent1);
     // Succeed to import the topic entity
     Assertions.assertTrue(entityStore.exists(NameIdentifier.of(tableNs.levels()), SCHEMA));
@@ -225,7 +229,7 @@ public class TestTableOperationDispatcher extends TestOperationDispatcher {
             .withAuditInfo(
                 AuditInfo.builder().withCreator("gravitino").withCreateTime(Instant.now()).build())
             .build();
-    doReturn(tableEntity).when(entityStore).get(any(), any(), any());
+    doReturn(tableEntity).when(entityStore).get(any(), eq(Entity.EntityType.TABLE), any());
     Table loadedTable4 = tableOperationDispatcher.loadTable(tableIdent1);
     // Succeed to import the topic entity
     reset(entityStore);

--- a/core/src/test/java/org/apache/gravitino/catalog/TestTopicOperationDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestTopicOperationDispatcher.java
@@ -26,6 +26,7 @@ import static org.apache.gravitino.StringIdentifier.ID_KEY;
 import static org.apache.gravitino.TestBasePropertiesMetadata.COMMENT_KEY;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -127,7 +128,9 @@ public class TestTopicOperationDispatcher extends TestOperationDispatcher {
     reset(entityStore);
     entityStore.delete(topicIdent1, Entity.EntityType.TOPIC);
     entityStore.delete(NameIdentifier.of(topicNs.levels()), SCHEMA);
-    doThrow(new NoSuchEntityException("")).when(entityStore).get(any(), any(), any());
+    doThrow(new NoSuchEntityException(""))
+        .when(entityStore)
+        .get(any(), eq(Entity.EntityType.TOPIC), any());
     Topic loadedTopic2 = topicOperationDispatcher.loadTopic(topicIdent1);
     // Succeed to import the topic entity
     Assertions.assertTrue(entityStore.exists(topicIdent1, Entity.EntityType.TOPIC));
@@ -139,7 +142,7 @@ public class TestTopicOperationDispatcher extends TestOperationDispatcher {
     reset(entityStore);
     entityStore.delete(topicIdent1, Entity.EntityType.TOPIC);
     entityStore.delete(NameIdentifier.of(topicNs.levels()), SCHEMA);
-    doThrow(new IOException()).when(entityStore).get(any(), any(), any());
+    doThrow(new IOException()).when(entityStore).get(any(), eq(Entity.EntityType.TOPIC), any());
     Topic loadedTopic3 = topicOperationDispatcher.loadTopic(topicIdent1);
     // Succeed to import the topic entity
     Assertions.assertTrue(entityStore.exists(NameIdentifier.of(topicNs.levels()), SCHEMA));
@@ -157,7 +160,7 @@ public class TestTopicOperationDispatcher extends TestOperationDispatcher {
             .withAuditInfo(
                 AuditInfo.builder().withCreator("gravitino").withCreateTime(Instant.now()).build())
             .build();
-    doReturn(unmatchedEntity).when(entityStore).get(any(), any(), any());
+    doReturn(unmatchedEntity).when(entityStore).get(any(), eq(Entity.EntityType.TOPIC), any());
     Topic loadedTopic4 = topicOperationDispatcher.loadTopic(topicIdent1);
     // Succeed to import the topic entity
     reset(entityStore);

--- a/core/src/test/java/org/apache/gravitino/listener/api/event/TestCatalogEvent.java
+++ b/core/src/test/java/org/apache/gravitino/listener/api/event/TestCatalogEvent.java
@@ -19,6 +19,7 @@
 
 package org.apache.gravitino.listener.api.event;
 
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -243,7 +244,7 @@ public class TestCatalogEvent {
             any(Map.class)))
         .thenReturn(catalog);
     when(dispatcher.loadCatalog(any(NameIdentifier.class))).thenReturn(catalog);
-    when(dispatcher.dropCatalog(any(NameIdentifier.class))).thenReturn(true);
+    when(dispatcher.dropCatalog(any(NameIdentifier.class), anyBoolean())).thenReturn(true);
     when(dispatcher.listCatalogs(any(Namespace.class))).thenReturn(null);
     when(dispatcher.alterCatalog(any(NameIdentifier.class), any(CatalogChange.class)))
         .thenReturn(catalog);

--- a/flink-connector/flink/src/main/java/org/apache/gravitino/flink/connector/catalog/GravitinoCatalogManager.java
+++ b/flink-connector/flink/src/main/java/org/apache/gravitino/flink/connector/catalog/GravitinoCatalogManager.java
@@ -134,7 +134,7 @@ public class GravitinoCatalogManager {
    * @return boolean
    */
   public boolean dropCatalog(String catalogName) {
-    return metalake.dropCatalog(catalogName);
+    return metalake.dropCatalog(catalogName, true);
   }
 
   /**

--- a/flink-connector/flink/src/test/java/org/apache/gravitino/flink/connector/integration/test/hive/FlinkHiveCatalogIT.java
+++ b/flink-connector/flink/src/test/java/org/apache/gravitino/flink/connector/integration/test/hive/FlinkHiveCatalogIT.java
@@ -79,7 +79,7 @@ public class FlinkHiveCatalogIT extends FlinkCommonIT {
   @AfterAll
   static void hiveStop() {
     Preconditions.checkNotNull(metalake);
-    metalake.dropCatalog(DEFAULT_HIVE_CATALOG);
+    metalake.dropCatalog(DEFAULT_HIVE_CATALOG, true);
   }
 
   protected static void initDefaultHiveCatalog() {

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,4 +40,4 @@ defaultScalaVersion = 2.12
 pythonVersion = 3.8
 
 # skipDockerTests is used to skip the tests that require Docker to be running.
-skipDockerTests = false
+skipDockerTests = true

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,4 +40,4 @@ defaultScalaVersion = 2.12
 pythonVersion = 3.8
 
 # skipDockerTests is used to skip the tests that require Docker to be running.
-skipDockerTests = true
+skipDockerTests = false

--- a/server/src/main/java/org/apache/gravitino/server/web/Utils.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/Utils.java
@@ -122,11 +122,11 @@ public class Utils {
         .build();
   }
 
-  public static Response nonInUse(String message, Throwable throwable) {
-    return nonInUse(throwable.getClass().getSimpleName(), message, throwable);
+  public static Response notInUse(String message, Throwable throwable) {
+    return notInUse(throwable.getClass().getSimpleName(), message, throwable);
   }
 
-  public static Response nonInUse(String type, String message, Throwable throwable) {
+  public static Response notInUse(String type, String message, Throwable throwable) {
     return Response.status(Response.Status.CONFLICT)
         .entity(ErrorResponse.notInUse(type, message, throwable))
         .type(MediaType.APPLICATION_JSON)

--- a/server/src/main/java/org/apache/gravitino/server/web/Utils.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/Utils.java
@@ -122,6 +122,28 @@ public class Utils {
         .build();
   }
 
+  public static Response nonInUse(String message, Throwable throwable) {
+    return nonInUse(throwable.getClass().getSimpleName(), message, throwable);
+  }
+
+  public static Response nonInUse(String type, String message, Throwable throwable) {
+    return Response.status(Response.Status.CONFLICT)
+        .entity(ErrorResponse.nonInUse(type, message, throwable))
+        .type(MediaType.APPLICATION_JSON)
+        .build();
+  }
+
+  public static Response inUse(String message, Throwable throwable) {
+    return inUse(throwable.getClass().getSimpleName(), message, throwable);
+  }
+
+  public static Response inUse(String type, String message, Throwable throwable) {
+    return Response.status(Response.Status.CONFLICT)
+        .entity(ErrorResponse.inUse(type, message, throwable))
+        .type(MediaType.APPLICATION_JSON)
+        .build();
+  }
+
   public static Response nonEmpty(String type, String message) {
     return nonEmpty(type, message, null);
   }

--- a/server/src/main/java/org/apache/gravitino/server/web/Utils.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/Utils.java
@@ -128,7 +128,7 @@ public class Utils {
 
   public static Response nonInUse(String type, String message, Throwable throwable) {
     return Response.status(Response.Status.CONFLICT)
-        .entity(ErrorResponse.nonInUse(type, message, throwable))
+        .entity(ErrorResponse.notInUse(type, message, throwable))
         .type(MediaType.APPLICATION_JSON)
         .build();
   }

--- a/server/src/main/java/org/apache/gravitino/server/web/rest/CatalogOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/CatalogOperations.java
@@ -202,7 +202,7 @@ public class CatalogOperations {
             NameIdentifier ident = NameIdentifierUtil.ofCatalog(metalake, catalogName);
             TreeLockUtils.doWithTreeLock(
                 NameIdentifierUtil.ofMetalake(metalake),
-                LockType.READ,
+                LockType.WRITE,
                 () -> {
                   catalogDispatcher.activateCatalog(ident);
                   return null;
@@ -234,7 +234,7 @@ public class CatalogOperations {
             NameIdentifier ident = NameIdentifierUtil.ofCatalog(metalake, catalogName);
             TreeLockUtils.doWithTreeLock(
                 NameIdentifierUtil.ofMetalake(metalake),
-                LockType.READ,
+                LockType.WRITE,
                 () -> {
                   catalogDispatcher.deactivateCatalog(ident);
                   return null;

--- a/server/src/main/java/org/apache/gravitino/server/web/rest/CatalogOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/CatalogOperations.java
@@ -26,6 +26,7 @@ import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
+import javax.ws.rs.PATCH;
 import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
@@ -41,6 +42,7 @@ import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
 import org.apache.gravitino.catalog.CatalogDispatcher;
 import org.apache.gravitino.dto.requests.CatalogCreateRequest;
+import org.apache.gravitino.dto.requests.CatalogSetRequest;
 import org.apache.gravitino.dto.requests.CatalogUpdateRequest;
 import org.apache.gravitino.dto.requests.CatalogUpdatesRequest;
 import org.apache.gravitino.dto.responses.BaseResponse;
@@ -187,14 +189,16 @@ public class CatalogOperations {
     }
   }
 
-  @GET
-  @Path("{catalog}/enable")
+  @PATCH
+  @Path("{catalog}")
   @Produces("application/vnd.gravitino.v1+json")
-  @Timed(name = "enable-catalog." + MetricNames.HTTP_PROCESS_DURATION, absolute = true)
-  @ResponseMetered(name = "enable-catalog", absolute = true)
-  public Response enableCatalog(
-      @PathParam("metalake") String metalake, @PathParam("catalog") String catalogName) {
-    LOG.info("Received enable request for catalog: {}.{}", metalake, catalogName);
+  @Timed(name = "set-catalog." + MetricNames.HTTP_PROCESS_DURATION, absolute = true)
+  @ResponseMetered(name = "set-catalog", absolute = true)
+  public Response setCatalog(
+      @PathParam("metalake") String metalake,
+      @PathParam("catalog") String catalogName,
+      CatalogSetRequest request) {
+    LOG.info("Received set request for catalog: {}.{}", metalake, catalogName);
     try {
       return Utils.doAs(
           httpRequest,
@@ -204,50 +208,30 @@ public class CatalogOperations {
                 NameIdentifierUtil.ofMetalake(metalake),
                 LockType.WRITE,
                 () -> {
-                  catalogDispatcher.enableCatalog(ident);
+                  if (request.isInUse()) {
+                    catalogDispatcher.enableCatalog(ident);
+                  } else {
+                    catalogDispatcher.disableCatalog(ident);
+                  }
                   return null;
                 });
             Response response = Utils.ok(new BaseResponse());
-            LOG.info("Successfully enable catalog: {}.{}", metalake, catalogName);
+            LOG.info(
+                "Successfully {} catalog: {}.{}",
+                request.isInUse() ? "enable" : "disable",
+                metalake,
+                catalogName);
             return response;
           });
 
     } catch (Exception e) {
-      LOG.info("Failed to enable catalog: {}.{}", metalake, catalogName);
+      LOG.info(
+          "Failed to {} catalog: {}.{}",
+          request.isInUse() ? "enable" : "disable",
+          metalake,
+          catalogName);
       return ExceptionHandlers.handleCatalogException(
           OperationType.ENABLE, catalogName, metalake, e);
-    }
-  }
-
-  @GET
-  @Path("{catalog}/disable")
-  @Produces("disable/vnd.gravitino.v1+json")
-  @Timed(name = "disable-catalog." + MetricNames.HTTP_PROCESS_DURATION, absolute = true)
-  @ResponseMetered(name = "disable-catalog", absolute = true)
-  public Response disableCatalog(
-      @PathParam("metalake") String metalake, @PathParam("catalog") String catalogName) {
-    LOG.info("Received disable request for catalog: {}.{}", metalake, catalogName);
-    try {
-      return Utils.doAs(
-          httpRequest,
-          () -> {
-            NameIdentifier ident = NameIdentifierUtil.ofCatalog(metalake, catalogName);
-            TreeLockUtils.doWithTreeLock(
-                NameIdentifierUtil.ofMetalake(metalake),
-                LockType.WRITE,
-                () -> {
-                  catalogDispatcher.disableCatalog(ident);
-                  return null;
-                });
-            Response response = Utils.ok(new BaseResponse());
-            LOG.info("Successfully disable catalog: {}.{}", metalake, catalogName);
-            return response;
-          });
-
-    } catch (Exception e) {
-      LOG.info("Failed to disable catalog: {}.{}", metalake, catalogName);
-      return ExceptionHandlers.handleCatalogException(
-          OperationType.DISABLE, catalogName, metalake, e);
     }
   }
 

--- a/server/src/main/java/org/apache/gravitino/server/web/rest/CatalogOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/CatalogOperations.java
@@ -188,13 +188,13 @@ public class CatalogOperations {
   }
 
   @GET
-  @Path("{catalog}/activate")
+  @Path("{catalog}/enable")
   @Produces("application/vnd.gravitino.v1+json")
-  @Timed(name = "activate-catalog." + MetricNames.HTTP_PROCESS_DURATION, absolute = true)
-  @ResponseMetered(name = "activate-catalog", absolute = true)
-  public Response activateCatalog(
+  @Timed(name = "enable-catalog." + MetricNames.HTTP_PROCESS_DURATION, absolute = true)
+  @ResponseMetered(name = "enable-catalog", absolute = true)
+  public Response enableCatalog(
       @PathParam("metalake") String metalake, @PathParam("catalog") String catalogName) {
-    LOG.info("Received activate request for catalog: {}.{}", metalake, catalogName);
+    LOG.info("Received enable request for catalog: {}.{}", metalake, catalogName);
     try {
       return Utils.doAs(
           httpRequest,
@@ -204,29 +204,29 @@ public class CatalogOperations {
                 NameIdentifierUtil.ofMetalake(metalake),
                 LockType.WRITE,
                 () -> {
-                  catalogDispatcher.activateCatalog(ident);
+                  catalogDispatcher.enableCatalog(ident);
                   return null;
                 });
             Response response = Utils.ok(new BaseResponse());
-            LOG.info("Successfully activate catalog: {}.{}", metalake, catalogName);
+            LOG.info("Successfully enable catalog: {}.{}", metalake, catalogName);
             return response;
           });
 
     } catch (Exception e) {
-      LOG.info("Failed to activate catalog: {}.{}", metalake, catalogName);
+      LOG.info("Failed to enable catalog: {}.{}", metalake, catalogName);
       return ExceptionHandlers.handleCatalogException(
-          OperationType.ACTIVATE, catalogName, metalake, e);
+          OperationType.ENABLE, catalogName, metalake, e);
     }
   }
 
   @GET
-  @Path("{catalog}/deactivate")
-  @Produces("application/vnd.gravitino.v1+json")
-  @Timed(name = "deactivate-catalog." + MetricNames.HTTP_PROCESS_DURATION, absolute = true)
-  @ResponseMetered(name = "deactivate-catalog", absolute = true)
-  public Response deactivateCatalog(
+  @Path("{catalog}/disable")
+  @Produces("disable/vnd.gravitino.v1+json")
+  @Timed(name = "disable-catalog." + MetricNames.HTTP_PROCESS_DURATION, absolute = true)
+  @ResponseMetered(name = "disable-catalog", absolute = true)
+  public Response disableCatalog(
       @PathParam("metalake") String metalake, @PathParam("catalog") String catalogName) {
-    LOG.info("Received deactivate request for catalog: {}.{}", metalake, catalogName);
+    LOG.info("Received disable request for catalog: {}.{}", metalake, catalogName);
     try {
       return Utils.doAs(
           httpRequest,
@@ -236,18 +236,18 @@ public class CatalogOperations {
                 NameIdentifierUtil.ofMetalake(metalake),
                 LockType.WRITE,
                 () -> {
-                  catalogDispatcher.deactivateCatalog(ident);
+                  catalogDispatcher.disableCatalog(ident);
                   return null;
                 });
             Response response = Utils.ok(new BaseResponse());
-            LOG.info("Successfully deactivate catalog: {}.{}", metalake, catalogName);
+            LOG.info("Successfully disable catalog: {}.{}", metalake, catalogName);
             return response;
           });
 
     } catch (Exception e) {
-      LOG.info("Failed to deactivate catalog: {}.{}", metalake, catalogName);
+      LOG.info("Failed to disable catalog: {}.{}", metalake, catalogName);
       return ExceptionHandlers.handleCatalogException(
-          OperationType.DEACTIVATE, catalogName, metalake, e);
+          OperationType.DISABLE, catalogName, metalake, e);
     }
   }
 

--- a/server/src/main/java/org/apache/gravitino/server/web/rest/ExceptionHandlers.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/ExceptionHandlers.java
@@ -24,8 +24,9 @@ import javax.ws.rs.core.Response;
 import org.apache.gravitino.dto.responses.ErrorResponse;
 import org.apache.gravitino.exceptions.AlreadyExistsException;
 import org.apache.gravitino.exceptions.CatalogAlreadyExistsException;
+import org.apache.gravitino.exceptions.CatalogInUseException;
+import org.apache.gravitino.exceptions.CatalogNotInUseException;
 import org.apache.gravitino.exceptions.ConnectionFailedException;
-import org.apache.gravitino.exceptions.EntityInUseException;
 import org.apache.gravitino.exceptions.FilesetAlreadyExistsException;
 import org.apache.gravitino.exceptions.ForbiddenException;
 import org.apache.gravitino.exceptions.GroupAlreadyExistsException;
@@ -33,7 +34,6 @@ import org.apache.gravitino.exceptions.MetalakeAlreadyExistsException;
 import org.apache.gravitino.exceptions.NoSuchMetalakeException;
 import org.apache.gravitino.exceptions.NonEmptySchemaException;
 import org.apache.gravitino.exceptions.NotFoundException;
-import org.apache.gravitino.exceptions.NotInUseEntityException;
 import org.apache.gravitino.exceptions.PartitionAlreadyExistsException;
 import org.apache.gravitino.exceptions.RoleAlreadyExistsException;
 import org.apache.gravitino.exceptions.SchemaAlreadyExistsException;
@@ -180,8 +180,8 @@ public class ExceptionHandlers {
       } else if (e instanceof UnsupportedOperationException) {
         return Utils.unsupportedOperation(errorMsg, e);
 
-      } else if (e instanceof NotInUseEntityException) {
-        return Utils.nonInUse(errorMsg, e);
+      } else if (e instanceof CatalogNotInUseException) {
+        return Utils.notInUse(errorMsg, e);
 
       } else {
         return super.handle(op, partition, table, e);
@@ -221,8 +221,8 @@ public class ExceptionHandlers {
       } else if (e instanceof ForbiddenException) {
         return Utils.forbidden(errorMsg, e);
 
-      } else if (e instanceof NotInUseEntityException) {
-        return Utils.nonInUse(errorMsg, e);
+      } else if (e instanceof CatalogNotInUseException) {
+        return Utils.notInUse(errorMsg, e);
 
       } else {
         return super.handle(op, table, schema, e);
@@ -265,8 +265,8 @@ public class ExceptionHandlers {
       } else if (e instanceof ForbiddenException) {
         return Utils.forbidden(errorMsg, e);
 
-      } else if (e instanceof NotInUseEntityException) {
-        return Utils.nonInUse(errorMsg, e);
+      } else if (e instanceof CatalogNotInUseException) {
+        return Utils.notInUse(errorMsg, e);
 
       } else {
         return super.handle(op, schema, catalog, e);
@@ -306,10 +306,10 @@ public class ExceptionHandlers {
       } else if (e instanceof CatalogAlreadyExistsException) {
         return Utils.alreadyExists(errorMsg, e);
 
-      } else if (e instanceof NotInUseEntityException) {
-        return Utils.nonInUse(errorMsg, e);
+      } else if (e instanceof CatalogNotInUseException) {
+        return Utils.notInUse(errorMsg, e);
 
-      } else if (e instanceof EntityInUseException) {
+      } else if (e instanceof CatalogInUseException) {
         return Utils.inUse(errorMsg, e);
 
       } else {
@@ -377,8 +377,8 @@ public class ExceptionHandlers {
       } else if (e instanceof ForbiddenException) {
         return Utils.forbidden(errorMsg, e);
 
-      } else if (e instanceof NotInUseEntityException) {
-        return Utils.nonInUse(errorMsg, e);
+      } else if (e instanceof CatalogNotInUseException) {
+        return Utils.notInUse(errorMsg, e);
 
       } else {
         return super.handle(op, fileset, schema, e);

--- a/server/src/main/java/org/apache/gravitino/server/web/rest/ExceptionHandlers.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/ExceptionHandlers.java
@@ -32,8 +32,8 @@ import org.apache.gravitino.exceptions.GroupAlreadyExistsException;
 import org.apache.gravitino.exceptions.MetalakeAlreadyExistsException;
 import org.apache.gravitino.exceptions.NoSuchMetalakeException;
 import org.apache.gravitino.exceptions.NonEmptySchemaException;
-import org.apache.gravitino.exceptions.NonInUseEntityException;
 import org.apache.gravitino.exceptions.NotFoundException;
+import org.apache.gravitino.exceptions.NotInUseEntityException;
 import org.apache.gravitino.exceptions.PartitionAlreadyExistsException;
 import org.apache.gravitino.exceptions.RoleAlreadyExistsException;
 import org.apache.gravitino.exceptions.SchemaAlreadyExistsException;
@@ -180,7 +180,7 @@ public class ExceptionHandlers {
       } else if (e instanceof UnsupportedOperationException) {
         return Utils.unsupportedOperation(errorMsg, e);
 
-      } else if (e instanceof NonInUseEntityException) {
+      } else if (e instanceof NotInUseEntityException) {
         return Utils.nonInUse(errorMsg, e);
 
       } else {
@@ -221,7 +221,7 @@ public class ExceptionHandlers {
       } else if (e instanceof ForbiddenException) {
         return Utils.forbidden(errorMsg, e);
 
-      } else if (e instanceof NonInUseEntityException) {
+      } else if (e instanceof NotInUseEntityException) {
         return Utils.nonInUse(errorMsg, e);
 
       } else {
@@ -265,7 +265,7 @@ public class ExceptionHandlers {
       } else if (e instanceof ForbiddenException) {
         return Utils.forbidden(errorMsg, e);
 
-      } else if (e instanceof NonInUseEntityException) {
+      } else if (e instanceof NotInUseEntityException) {
         return Utils.nonInUse(errorMsg, e);
 
       } else {
@@ -306,7 +306,7 @@ public class ExceptionHandlers {
       } else if (e instanceof CatalogAlreadyExistsException) {
         return Utils.alreadyExists(errorMsg, e);
 
-      } else if (e instanceof NonInUseEntityException) {
+      } else if (e instanceof NotInUseEntityException) {
         return Utils.nonInUse(errorMsg, e);
 
       } else if (e instanceof EntityInUseException) {
@@ -377,7 +377,7 @@ public class ExceptionHandlers {
       } else if (e instanceof ForbiddenException) {
         return Utils.forbidden(errorMsg, e);
 
-      } else if (e instanceof NonInUseEntityException) {
+      } else if (e instanceof NotInUseEntityException) {
         return Utils.nonInUse(errorMsg, e);
 
       } else {

--- a/server/src/main/java/org/apache/gravitino/server/web/rest/ExceptionHandlers.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/ExceptionHandlers.java
@@ -25,12 +25,14 @@ import org.apache.gravitino.dto.responses.ErrorResponse;
 import org.apache.gravitino.exceptions.AlreadyExistsException;
 import org.apache.gravitino.exceptions.CatalogAlreadyExistsException;
 import org.apache.gravitino.exceptions.ConnectionFailedException;
+import org.apache.gravitino.exceptions.EntityInUseException;
 import org.apache.gravitino.exceptions.FilesetAlreadyExistsException;
 import org.apache.gravitino.exceptions.ForbiddenException;
 import org.apache.gravitino.exceptions.GroupAlreadyExistsException;
 import org.apache.gravitino.exceptions.MetalakeAlreadyExistsException;
 import org.apache.gravitino.exceptions.NoSuchMetalakeException;
 import org.apache.gravitino.exceptions.NonEmptySchemaException;
+import org.apache.gravitino.exceptions.NonInUseEntityException;
 import org.apache.gravitino.exceptions.NotFoundException;
 import org.apache.gravitino.exceptions.PartitionAlreadyExistsException;
 import org.apache.gravitino.exceptions.RoleAlreadyExistsException;
@@ -178,6 +180,9 @@ public class ExceptionHandlers {
       } else if (e instanceof UnsupportedOperationException) {
         return Utils.unsupportedOperation(errorMsg, e);
 
+      } else if (e instanceof NonInUseEntityException) {
+        return Utils.nonInUse(errorMsg, e);
+
       } else {
         return super.handle(op, partition, table, e);
       }
@@ -215,6 +220,9 @@ public class ExceptionHandlers {
 
       } else if (e instanceof ForbiddenException) {
         return Utils.forbidden(errorMsg, e);
+
+      } else if (e instanceof NonInUseEntityException) {
+        return Utils.nonInUse(errorMsg, e);
 
       } else {
         return super.handle(op, table, schema, e);
@@ -257,6 +265,9 @@ public class ExceptionHandlers {
       } else if (e instanceof ForbiddenException) {
         return Utils.forbidden(errorMsg, e);
 
+      } else if (e instanceof NonInUseEntityException) {
+        return Utils.nonInUse(errorMsg, e);
+
       } else {
         return super.handle(op, schema, catalog, e);
       }
@@ -294,6 +305,12 @@ public class ExceptionHandlers {
 
       } else if (e instanceof CatalogAlreadyExistsException) {
         return Utils.alreadyExists(errorMsg, e);
+
+      } else if (e instanceof NonInUseEntityException) {
+        return Utils.nonInUse(errorMsg, e);
+
+      } else if (e instanceof EntityInUseException) {
+        return Utils.inUse(errorMsg, e);
 
       } else {
         return super.handle(op, catalog, metalake, e);
@@ -359,6 +376,9 @@ public class ExceptionHandlers {
 
       } else if (e instanceof ForbiddenException) {
         return Utils.forbidden(errorMsg, e);
+
+      } else if (e instanceof NonInUseEntityException) {
+        return Utils.nonInUse(errorMsg, e);
 
       } else {
         return super.handle(op, fileset, schema, e);

--- a/server/src/main/java/org/apache/gravitino/server/web/rest/OperationType.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/OperationType.java
@@ -24,8 +24,8 @@ public enum OperationType {
   LOAD,
   ALTER,
   DROP,
-  ACTIVATE,
-  DEACTIVATE,
+  ENABLE,
+  DISABLE,
   /** This is a special operation type that is used to get a partition from a table. */
   GET,
   ADD,

--- a/server/src/test/java/org/apache/gravitino/server/web/rest/TestCatalog.java
+++ b/server/src/test/java/org/apache/gravitino/server/web/rest/TestCatalog.java
@@ -18,26 +18,18 @@
  */
 package org.apache.gravitino.server.web.rest;
 
+import static org.apache.gravitino.connector.BaseCatalogPropertiesMetadata.BASIC_CATALOG_PROPERTIES_METADATA;
+
 import java.io.IOException;
-import java.util.Collections;
 import java.util.Map;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.connector.BaseCatalog;
-import org.apache.gravitino.connector.BaseCatalogPropertiesMetadata;
 import org.apache.gravitino.connector.CatalogInfo;
 import org.apache.gravitino.connector.CatalogOperations;
 import org.apache.gravitino.connector.HasPropertyMetadata;
 import org.apache.gravitino.connector.PropertiesMetadata;
-import org.apache.gravitino.connector.PropertyEntry;
 
 public class TestCatalog extends BaseCatalog<TestCatalog> {
-  private static final PropertiesMetadata PROPERTIES_METADATA =
-      new BaseCatalogPropertiesMetadata() {
-        @Override
-        protected Map<String, PropertyEntry<?>> specificPropertyEntries() {
-          return Collections.emptyMap();
-        }
-      };
 
   @Override
   public String shortName() {
@@ -69,6 +61,6 @@ public class TestCatalog extends BaseCatalog<TestCatalog> {
 
   @Override
   public PropertiesMetadata catalogPropertiesMetadata() throws UnsupportedOperationException {
-    return PROPERTIES_METADATA;
+    return BASIC_CATALOG_PROPERTIES_METADATA;
   }
 }

--- a/server/src/test/java/org/apache/gravitino/server/web/rest/TestCatalog.java
+++ b/server/src/test/java/org/apache/gravitino/server/web/rest/TestCatalog.java
@@ -18,18 +18,26 @@
  */
 package org.apache.gravitino.server.web.rest;
 
-import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.Map;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.connector.BaseCatalog;
+import org.apache.gravitino.connector.BaseCatalogPropertiesMetadata;
 import org.apache.gravitino.connector.CatalogInfo;
 import org.apache.gravitino.connector.CatalogOperations;
 import org.apache.gravitino.connector.HasPropertyMetadata;
 import org.apache.gravitino.connector.PropertiesMetadata;
+import org.apache.gravitino.connector.PropertyEntry;
 
 public class TestCatalog extends BaseCatalog<TestCatalog> {
-  private static final PropertiesMetadata PROPERTIES_METADATA = ImmutableMap::of;
+  private static final PropertiesMetadata PROPERTIES_METADATA =
+      new BaseCatalogPropertiesMetadata() {
+        @Override
+        protected Map<String, PropertyEntry<?>> specificPropertyEntries() {
+          return Collections.emptyMap();
+        }
+      };
 
   @Override
   public String shortName() {

--- a/server/src/test/java/org/apache/gravitino/server/web/rest/TestCatalogOperations.java
+++ b/server/src/test/java/org/apache/gravitino/server/web/rest/TestCatalogOperations.java
@@ -19,10 +19,12 @@
 package org.apache.gravitino.server.web.rest;
 
 import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
+import static org.apache.gravitino.Catalog.PROPERTY_IN_USE;
 import static org.apache.gravitino.Configs.TREE_LOCK_CLEAN_INTERVAL;
 import static org.apache.gravitino.Configs.TREE_LOCK_MAX_NODE_IN_MEMORY;
 import static org.apache.gravitino.Configs.TREE_LOCK_MIN_NODE_IN_MEMORY;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -184,13 +186,15 @@ public class TestCatalogOperations extends JerseyTest {
     Assertions.assertEquals("catalog1", catalogDTO1.name());
     Assertions.assertEquals(Catalog.Type.RELATIONAL, catalogDTO1.type());
     Assertions.assertEquals("comment", catalogDTO1.comment());
-    Assertions.assertEquals(ImmutableMap.of("key", "value"), catalogDTO1.properties());
+    Assertions.assertEquals(
+        ImmutableMap.of("key", "value", PROPERTY_IN_USE, "true"), catalogDTO1.properties());
 
     CatalogDTO catalogDTO2 = catalogDTOs[1];
     Assertions.assertEquals("catalog2", catalogDTO2.name());
     Assertions.assertEquals(Catalog.Type.RELATIONAL, catalogDTO2.type());
     Assertions.assertEquals("comment", catalogDTO2.comment());
-    Assertions.assertEquals(ImmutableMap.of("key", "value"), catalogDTO2.properties());
+    Assertions.assertEquals(
+        ImmutableMap.of("key", "value", PROPERTY_IN_USE, "true"), catalogDTO2.properties());
 
     doThrow(new NoSuchMetalakeException("mock error")).when(manager).listCatalogsInfo(any());
     Response resp1 =
@@ -237,7 +241,8 @@ public class TestCatalogOperations extends JerseyTest {
     Assertions.assertEquals("catalog1", catalogDTO.name());
     Assertions.assertEquals(Catalog.Type.RELATIONAL, catalogDTO.type());
     Assertions.assertEquals("comment", catalogDTO.comment());
-    Assertions.assertEquals(ImmutableMap.of("key", "value"), catalogDTO.properties());
+    Assertions.assertEquals(
+        ImmutableMap.of("key", "value", PROPERTY_IN_USE, "true"), catalogDTO.properties());
 
     // Test throw NoSuchMetalakeException
     doThrow(new NoSuchMetalakeException("mock error"))
@@ -351,7 +356,8 @@ public class TestCatalogOperations extends JerseyTest {
     Assertions.assertEquals("catalog1", catalogDTO.name());
     Assertions.assertEquals(Catalog.Type.RELATIONAL, catalogDTO.type());
     Assertions.assertEquals("comment", catalogDTO.comment());
-    Assertions.assertEquals(ImmutableMap.of("key", "value"), catalogDTO.properties());
+    Assertions.assertEquals(
+        ImmutableMap.of("key", "value", PROPERTY_IN_USE, "true"), catalogDTO.properties());
 
     // Test throw NoSuchMetalakeException
     doThrow(new NoSuchMetalakeException("mock error")).when(manager).loadCatalog(any());
@@ -420,7 +426,8 @@ public class TestCatalogOperations extends JerseyTest {
     Assertions.assertEquals("catalog2", catalogDTO.name());
     Assertions.assertEquals(Catalog.Type.RELATIONAL, catalogDTO.type());
     Assertions.assertEquals("comment", catalogDTO.comment());
-    Assertions.assertEquals(ImmutableMap.of("key", "value"), catalogDTO.properties());
+    Assertions.assertEquals(
+        ImmutableMap.of("key", "value", PROPERTY_IN_USE, "true"), catalogDTO.properties());
 
     // Test throw NoSuchCatalogException
     doThrow(new NoSuchCatalogException("mock error")).when(manager).alterCatalog(any(), any());
@@ -468,7 +475,7 @@ public class TestCatalogOperations extends JerseyTest {
 
   @Test
   public void testDropCatalog() {
-    when(manager.dropCatalog(any())).thenReturn(true);
+    when(manager.dropCatalog(any(), anyBoolean())).thenReturn(true);
 
     Response resp =
         target("/metalakes/metalake1/catalogs/catalog1")
@@ -481,8 +488,8 @@ public class TestCatalogOperations extends JerseyTest {
     Assertions.assertEquals(0, dropResponse.getCode());
     Assertions.assertTrue(dropResponse.dropped());
 
-    // Test when failed to drop catalog
-    when(manager.dropCatalog(any())).thenReturn(false);
+    // Test catalog does not exist
+    when(manager.dropCatalog(any(), anyBoolean())).thenReturn(false);
 
     Response resp2 =
         target("/metalakes/metalake1/catalogs/catalog1")
@@ -496,7 +503,7 @@ public class TestCatalogOperations extends JerseyTest {
     Assertions.assertFalse(dropResponse2.dropped());
 
     // Test throw internal RuntimeException
-    doThrow(new RuntimeException("mock error")).when(manager).dropCatalog(any());
+    doThrow(new RuntimeException("mock error")).when(manager).dropCatalog(any(), anyBoolean());
     Response resp3 =
         target("/metalakes/metalake1/catalogs/catalog1")
             .request(MediaType.APPLICATION_JSON_TYPE)

--- a/server/src/test/java/org/apache/gravitino/server/web/rest/TestCatalogOperations.java
+++ b/server/src/test/java/org/apache/gravitino/server/web/rest/TestCatalogOperations.java
@@ -50,6 +50,7 @@ import org.apache.gravitino.catalog.CatalogDispatcher;
 import org.apache.gravitino.catalog.CatalogManager;
 import org.apache.gravitino.dto.CatalogDTO;
 import org.apache.gravitino.dto.requests.CatalogCreateRequest;
+import org.apache.gravitino.dto.requests.CatalogSetRequest;
 import org.apache.gravitino.dto.requests.CatalogUpdateRequest;
 import org.apache.gravitino.dto.requests.CatalogUpdatesRequest;
 import org.apache.gravitino.dto.responses.BaseResponse;
@@ -67,6 +68,7 @@ import org.apache.gravitino.meta.AuditInfo;
 import org.apache.gravitino.meta.CatalogEntity;
 import org.apache.gravitino.rest.RESTUtils;
 import org.glassfish.hk2.utilities.binding.AbstractBinder;
+import org.glassfish.jersey.client.HttpUrlConnectorProvider;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.test.JerseyTest;
 import org.glassfish.jersey.test.TestProperties;
@@ -515,6 +517,37 @@ public class TestCatalogOperations extends JerseyTest {
     ErrorResponse errorResponse = resp3.readEntity(ErrorResponse.class);
     Assertions.assertEquals(ErrorConstants.INTERNAL_ERROR_CODE, errorResponse.getCode());
     Assertions.assertEquals(RuntimeException.class.getSimpleName(), errorResponse.getType());
+  }
+
+  @Test
+  public void testSetCatalog() {
+    CatalogSetRequest req = new CatalogSetRequest(true);
+    doNothing().when(manager).enableCatalog(any());
+
+    Response resp =
+        target("/metalakes/metalake1/catalogs/catalog1")
+            .property(HttpUrlConnectorProvider.SET_METHOD_WORKAROUND, true)
+            .request(MediaType.APPLICATION_JSON_TYPE)
+            .accept("application/vnd.gravitino.v1+json")
+            .method("PATCH", Entity.entity(req, MediaType.APPLICATION_JSON_TYPE));
+
+    Assertions.assertEquals(Response.Status.OK.getStatusCode(), resp.getStatus());
+    BaseResponse baseResponse = resp.readEntity(BaseResponse.class);
+    Assertions.assertEquals(0, baseResponse.getCode());
+
+    req = new CatalogSetRequest(false);
+    doNothing().when(manager).disableCatalog(any());
+
+    resp =
+        target("/metalakes/metalake1/catalogs/catalog1")
+            .property(HttpUrlConnectorProvider.SET_METHOD_WORKAROUND, true)
+            .request(MediaType.APPLICATION_JSON_TYPE)
+            .accept("application/vnd.gravitino.v1+json")
+            .method("PATCH", Entity.entity(req, MediaType.APPLICATION_JSON_TYPE));
+
+    Assertions.assertEquals(Response.Status.OK.getStatusCode(), resp.getStatus());
+    baseResponse = resp.readEntity(BaseResponse.class);
+    Assertions.assertEquals(0, baseResponse.getCode());
   }
 
   private static TestCatalog buildCatalog(String metalake, String catalogName) {

--- a/trino-connector/integration-test/src/test/java/org/apache/gravitino/trino/connector/integration/test/TrinoConnectorIT.java
+++ b/trino-connector/integration-test/src/test/java/org/apache/gravitino/trino/connector/integration/test/TrinoConnectorIT.java
@@ -1372,7 +1372,7 @@ public class TrinoConnectorIT extends BaseIT {
       boolean success = checkTrinoHasLoaded(sql, 30);
       Assertions.assertTrue(success, "Trino should load the catalog: " + sql);
 
-      createdMetalake.deactivateCatalog(catalogName);
+      createdMetalake.disableCatalog(catalogName);
       createdMetalake.dropCatalog(catalogName);
       // We need to test we can't load this catalog any more by Trino.
       success = checkTrinoHasRemoved(sql, 30);

--- a/trino-connector/integration-test/src/test/java/org/apache/gravitino/trino/connector/integration/test/TrinoConnectorIT.java
+++ b/trino-connector/integration-test/src/test/java/org/apache/gravitino/trino/connector/integration/test/TrinoConnectorIT.java
@@ -1372,6 +1372,7 @@ public class TrinoConnectorIT extends BaseIT {
       boolean success = checkTrinoHasLoaded(sql, 30);
       Assertions.assertTrue(success, "Trino should load the catalog: " + sql);
 
+      createdMetalake.deactivateCatalog(catalogName);
       createdMetalake.dropCatalog(catalogName);
       // We need to test we can't load this catalog any more by Trino.
       success = checkTrinoHasRemoved(sql, 30);

--- a/trino-connector/integration-test/src/test/java/org/apache/gravitino/trino/connector/integration/test/TrinoQueryITBase.java
+++ b/trino-connector/integration-test/src/test/java/org/apache/gravitino/trino/connector/integration/test/TrinoQueryITBase.java
@@ -232,6 +232,7 @@ public class TrinoQueryITBase {
               LOG.info("Drop schema \"{}.{}\".{}", metalakeName, catalogName, schema);
             });
 
+    metalake.deactivateCatalog(catalogName);
     metalake.dropCatalog(catalogName);
     LOG.info("Drop catalog \"{}.{}\"", metalakeName, catalogName);
   }

--- a/trino-connector/integration-test/src/test/java/org/apache/gravitino/trino/connector/integration/test/TrinoQueryITBase.java
+++ b/trino-connector/integration-test/src/test/java/org/apache/gravitino/trino/connector/integration/test/TrinoQueryITBase.java
@@ -232,7 +232,7 @@ public class TrinoQueryITBase {
               LOG.info("Drop schema \"{}.{}\".{}", metalakeName, catalogName, schema);
             });
 
-    metalake.deactivateCatalog(catalogName);
+    metalake.disableCatalog(catalogName);
     metalake.dropCatalog(catalogName);
     LOG.info("Drop catalog \"{}.{}\"", metalakeName, catalogName);
   }

--- a/trino-connector/integration-test/src/test/resources/trino-ci-testset/testsets/jdbc-mysql/00008_alter_catalog.txt
+++ b/trino-connector/integration-test/src/test/resources/trino-ci-testset/testsets/jdbc-mysql/00008_alter_catalog.txt
@@ -1,17 +1,17 @@
 CALL
 
-"gt_mysql_xxx1","jdbc-mysql","{""jdbc-driver"":""com.mysql.cj.jdbc.Driver"",""jdbc-password"":""ds123"",""jdbc-url"":""jdbc:mysql://%/?useSSL=false"",""jdbc-user"":""trino""}"
+"gt_mysql_xxx1","jdbc-mysql","{""in-use"":""true"",""jdbc-driver"":""com.mysql.cj.jdbc.Driver"",""jdbc-password"":""ds123"",""jdbc-url"":""jdbc:mysql://%/?useSSL=false"",""jdbc-user"":""trino""}"
 
 CALL
 
-"gt_mysql_xxx1","jdbc-mysql","{""jdbc-driver"":""com.mysql.cj.jdbc.Driver"",""jdbc-password"":""ds123"",""jdbc-url"":""jdbc:mysql://%/?useSSL=false"",""jdbc-user"":""trino"",""test_key"":""test_value"",""trino.bypass.join-pushdown.strategy"":""EAGER""}"
+"gt_mysql_xxx1","jdbc-mysql","{""in-use"":""true"",""jdbc-driver"":""com.mysql.cj.jdbc.Driver"",""jdbc-password"":""ds123"",""jdbc-url"":""jdbc:mysql://%/?useSSL=false"",""jdbc-user"":""trino"",""test_key"":""test_value"",""trino.bypass.join-pushdown.strategy"":""EAGER""}"
 
 CALL
 
-"gt_mysql_xxx1","jdbc-mysql","{""jdbc-driver"":""com.mysql.cj.jdbc.Driver"",""jdbc-password"":""ds123"",""jdbc-url"":""jdbc:mysql://%/?useSSL=false"",""jdbc-user"":""trino"",""test_key"":""test_value""}"
+"gt_mysql_xxx1","jdbc-mysql","{""in-use"":""true"",""jdbc-driver"":""com.mysql.cj.jdbc.Driver"",""jdbc-password"":""ds123"",""jdbc-url"":""jdbc:mysql://%/?useSSL=false"",""jdbc-user"":""trino"",""test_key"":""test_value""}"
 
 CALL
 
-"gt_mysql_xxx1","jdbc-mysql","{""jdbc-driver"":""com.mysql.cj.jdbc.Driver"",""jdbc-password"":""ds123"",""jdbc-url"":""jdbc:mysql://%/?useSSL=false"",""jdbc-user"":""trino"",""trino.bypass.join-pushdown.strategy"":""EAGER""}"
+"gt_mysql_xxx1","jdbc-mysql","{""in-use"":""true"",""jdbc-driver"":""com.mysql.cj.jdbc.Driver"",""jdbc-password"":""ds123"",""jdbc-url"":""jdbc:mysql://%/?useSSL=false"",""jdbc-user"":""trino"",""trino.bypass.join-pushdown.strategy"":""EAGER""}"
 
 CALL

--- a/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/system/storedprocdure/DropCatalogStoredProcedure.java
+++ b/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/system/storedprocdure/DropCatalogStoredProcedure.java
@@ -79,12 +79,7 @@ public class DropCatalogStoredProcedure extends GravitinoStoredProcedure {
             GravitinoErrorCode.GRAVITINO_CATALOG_NOT_EXISTS,
             "Catalog " + NameIdentifier.of(metalake, catalogName) + " not exists.");
       }
-      boolean dropped = catalogConnector.getMetalake().dropCatalog(catalogName);
-      if (!dropped) {
-        throw new TrinoException(
-            GravitinoErrorCode.GRAVITINO_UNSUPPORTED_OPERATION,
-            "Failed to drop no empty catalog " + catalogName);
-      }
+      catalogConnector.getMetalake().dropCatalog(catalogName, true);
 
       catalogConnectorManager.loadMetalakeSync();
 

--- a/trino-connector/trino-connector/src/test/java/org/apache/gravitino/trino/connector/GravitinoMockServer.java
+++ b/trino-connector/trino-connector/src/test/java/org/apache/gravitino/trino/connector/GravitinoMockServer.java
@@ -164,7 +164,7 @@ public class GravitinoMockServer implements AutoCloseable {
               }
             });
 
-    when(metaLake.dropCatalog(anyString()))
+    when(metaLake.dropCatalog(anyString(), anyBoolean()))
         .thenAnswer(
             new Answer<Boolean>() {
               @Override

--- a/web/web/src/lib/api/catalogs/index.js
+++ b/web/web/src/lib/api/catalogs/index.js
@@ -27,7 +27,7 @@ const Apis = {
   UPDATE: ({ metalake, catalog }) =>
     `/api/metalakes/${encodeURIComponent(metalake)}/catalogs/${encodeURIComponent(catalog)}`,
   DELETE: ({ metalake, catalog }) =>
-    `/api/metalakes/${encodeURIComponent(metalake)}/catalogs/${encodeURIComponent(catalog)}`
+    `/api/metalakes/${encodeURIComponent(metalake)}/catalogs/${encodeURIComponent(catalog)}?force=true`
 }
 
 export const getCatalogsApi = params => {


### PR DESCRIPTION
### What changes were proposed in this pull request?

 - Add an `in-use` property to the catalog with the default value of true.
 - Only empty catalog with `in-use=false` can be dropped.
 - User can use `dorce` option to drop catalog 
 - More drop catalog limitations please see the JavaDoc of `dropCatalog` in API module

### Why are the changes needed?

Fix: #5066 

### Does this PR introduce _any_ user-facing change?

yes, users now can not drop an in used catalog

### How was this patch tested?

tests added
