### PR TITLE
[#5082] fix(catalog): fix clean bug after create catalog failed

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -513,6 +513,7 @@ tasks.rat {
     "ROADMAP.md",
     "clients/client-python/.pytest_cache/*",
     "clients/client-python/.venv/*",
+    "clients/client-python/venv/*",
     "clients/client-python/apache_gravitino.egg-info/*",
     "clients/client-python/gravitino/utils/http_client.py",
     "clients/client-python/tests/unittests/htmlcov/*",

--- a/clients/client-java/src/test/java/org/apache/gravitino/client/integration/test/CatalogIT.java
+++ b/clients/client-java/src/test/java/org/apache/gravitino/client/integration/test/CatalogIT.java
@@ -28,6 +28,7 @@ import org.apache.commons.lang3.ArrayUtils;
 import org.apache.gravitino.Catalog;
 import org.apache.gravitino.CatalogChange;
 import org.apache.gravitino.client.GravitinoMetalake;
+import org.apache.gravitino.exceptions.CatalogAlreadyExistsException;
 import org.apache.gravitino.integration.test.container.ContainerSuite;
 import org.apache.gravitino.integration.test.container.HiveContainer;
 import org.apache.gravitino.integration.test.util.AbstractIT;
@@ -124,6 +125,13 @@ public class CatalogIT extends AbstractIT {
             catalogName, Catalog.Type.RELATIONAL, "hive", "catalog comment", properties);
     Assertions.assertTrue(metalake.catalogExists(catalogName));
     Assertions.assertEquals(catalogName, catalog.name());
+
+    Assertions.assertThrows(
+        CatalogAlreadyExistsException.class,
+        () ->
+            metalake.createCatalog(
+                catalogName, Catalog.Type.RELATIONAL, "hive", "catalog comment", properties));
+    Assertions.assertTrue(metalake.catalogExists(catalogName));
 
     Assertions.assertTrue(metalake.dropCatalog(catalogName), "catalog should be dropped");
     Assertions.assertFalse(metalake.dropCatalog(catalogName), "catalog should be non-existent");

--- a/core/src/test/java/org/apache/gravitino/catalog/TestCatalogManager.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestCatalogManager.java
@@ -269,10 +269,10 @@ public class TestCatalogManager {
 
     // test before creation
     Assertions.assertThrows(
-        NoSuchMetalakeException.class,
+        CatalogAlreadyExistsException.class,
         () ->
             catalogManager.testConnection(
-                ident2, Catalog.Type.RELATIONAL, provider, "comment", props));
+                ident, Catalog.Type.RELATIONAL, provider, "comment", props));
 
     // Test create with duplicated name
     Throwable exception2 =
@@ -309,7 +309,8 @@ public class TestCatalogManager {
                 catalogManager.createCatalog(
                     failedIdent, Catalog.Type.RELATIONAL, provider, "comment", props));
     Assertions.assertTrue(
-        exception4.getMessage().contains("Properties are reserved and cannot be set"));
+        exception4.getMessage().contains("Properties are reserved and cannot be set"),
+        exception4.getMessage());
     Assertions.assertNull(catalogManager.catalogCache.getIfPresent(failedIdent));
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

 - not clean catalog if catalog already exists

### Why are the changes needed?

we will clean the catalog when the creation fails, but if the catalog already exists it will also be dropped which is unexpected.

Fix: #5082 

### Does this PR introduce _any_ user-facing change?

no

### How was this patch tested?

tests added
