### PR TITLE
[#5094] Fix(catalog-lakehouse-paimon): make some table properties from reserved to immutable

### DIFF
--- a/catalogs/catalog-lakehouse-paimon/src/main/java/org/apache/gravitino/catalog/lakehouse/paimon/PaimonTablePropertiesMetadata.java
+++ b/catalogs/catalog-lakehouse-paimon/src/main/java/org/apache/gravitino/catalog/lakehouse/paimon/PaimonTablePropertiesMetadata.java
@@ -18,6 +18,7 @@
  */
 package org.apache.gravitino.catalog.lakehouse.paimon;
 
+import static org.apache.gravitino.connector.PropertyEntry.stringImmutablePropertyEntry;
 import static org.apache.gravitino.connector.PropertyEntry.stringReservedPropertyEntry;
 
 import com.google.common.collect.ImmutableList;
@@ -51,9 +52,12 @@ public class PaimonTablePropertiesMetadata extends BasePropertiesMetadata {
             stringReservedPropertyEntry(COMMENT, "The table comment", true),
             stringReservedPropertyEntry(OWNER, "The table owner", false),
             stringReservedPropertyEntry(BUCKET_KEY, "The table bucket key", false),
-            stringReservedPropertyEntry(MERGE_ENGINE, "The table merge engine", false),
-            stringReservedPropertyEntry(SEQUENCE_FIELD, "The table sequence field", false),
-            stringReservedPropertyEntry(ROWKIND_FIELD, "The table rowkind field", false),
+            stringImmutablePropertyEntry(
+                MERGE_ENGINE, "The table merge engine", false, null, false, false),
+            stringImmutablePropertyEntry(
+                SEQUENCE_FIELD, "The table sequence field", false, null, false, false),
+            stringImmutablePropertyEntry(
+                ROWKIND_FIELD, "The table rowkind field", false, null, false, false),
             stringReservedPropertyEntry(PRIMARY_KEY, "The table primary key", false),
             stringReservedPropertyEntry(PARTITION, "The table partition", false));
     PROPERTIES_METADATA = Maps.uniqueIndex(propertyEntries, PropertyEntry::getName);

--- a/docs/lakehouse-paimon-catalog.md
+++ b/docs/lakehouse-paimon-catalog.md
@@ -168,11 +168,16 @@ The Gravitino server doesn't allow passing the following reserved fields.
 | `comment`                          | The table comment.                                           |
 | `owner`                            | The table owner.                                             |
 | `bucket-key`                       | The table bucket-key.                                        |
+| `primary-key`                      | The table primary-key.                                       |
+| `partition`                        | The table partition.                                         |
+
+The Gravitino server doesn't allow the following immutable fields to be modified, but allows them to be specified when creating a new table.
+
+| Configuration item                 | Description                                                  |
+|------------------------------------|--------------------------------------------------------------|
 | `merge-engine`                     | The table merge-engine.                                      |
 | `sequence.field`                   | The table sequence.field.                                    |
 | `rowkind.field`                    | The table rowkind.field.                                     |
-| `primary-key`                      | The table primary-key.                                       |
-| `partition`                        | The table partition.                                         |
 
 ### Table operations
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

make some table properties from reserved to immutable.

```
merge-engine
sequence.field
rowkind.field
```

### Why are the changes needed?

these table properties are immutable in Paimon.

Fix: https://github.com/apache/gravitino/issues/5094

### Does this PR introduce _any_ user-facing change?
updated related doc.

### How was this patch tested?
modified UT.
