### PR TITLE
[#5112] feat(core): support pre event for event listener systems

### DIFF
--- a/core/src/main/java/org/apache/gravitino/listener/EventBus.java
+++ b/core/src/main/java/org/apache/gravitino/listener/EventBus.java
@@ -78,10 +78,10 @@ public class EventBus {
   }
 
   private void dispatchPostEvent(Event postEvent) {
-    eventListeners.forEach(postEventListener -> postEventListener.onPostEvent(postEvent));
+    eventListeners.forEach(eventListener -> eventListener.onPostEvent(postEvent));
   }
 
   private void dispatchPreEvent(PreEvent preEvent) throws ForbiddenException {
-    eventListeners.forEach(preEventListener -> preEventListener.onPreEvent(preEvent));
+    eventListeners.forEach(eventListener -> eventListener.onPreEvent(preEvent));
   }
 }

--- a/core/src/main/java/org/apache/gravitino/listener/EventBus.java
+++ b/core/src/main/java/org/apache/gravitino/listener/EventBus.java
@@ -21,8 +21,11 @@ package org.apache.gravitino.listener;
 
 import com.google.common.annotations.VisibleForTesting;
 import java.util.List;
+import org.apache.gravitino.exceptions.ForbiddenException;
 import org.apache.gravitino.listener.api.EventListenerPlugin;
+import org.apache.gravitino.listener.api.event.BaseEvent;
 import org.apache.gravitino.listener.api.event.Event;
+import org.apache.gravitino.listener.api.event.PreEvent;
 
 /**
  * The {@code EventBus} class serves as a mechanism to dispatch events to registered listeners. It
@@ -34,26 +37,32 @@ public class EventBus {
   // EventListenerPluginWrapper,
   // which are meant for synchronous event listening, or AsyncQueueListener, designed for
   // asynchronous event processing.
-  private final List<EventListenerPlugin> postEventListeners;
+  private final List<EventListenerPlugin> eventListeners;
 
   /**
    * Constructs an EventBus with a predefined list of event listeners.
    *
-   * @param postEventListeners A list of {@link EventListenerPlugin} instances that are to be
-   *     registered with this EventBus for event dispatch.
+   * @param eventListeners A list of {@link EventListenerPlugin} instances that are to be registered
+   *     with this EventBus for event dispatch.
    */
-  public EventBus(List<EventListenerPlugin> postEventListeners) {
-    this.postEventListeners = postEventListeners;
+  public EventBus(List<EventListenerPlugin> eventListeners) {
+    this.eventListeners = eventListeners;
   }
 
   /**
    * Dispatches an event to all registered listeners. Each listener processes the event based on its
    * implementation, which could be either synchronous or asynchronous.
    *
-   * @param event The event to be dispatched to all registered listeners.
+   * @param baseEvent The event to be dispatched to all registered listeners.
    */
-  public void dispatchEvent(Event event) {
-    postEventListeners.forEach(postEventListener -> postEventListener.onPostEvent(event));
+  public void dispatchEvent(BaseEvent baseEvent) {
+    if (baseEvent instanceof PreEvent) {
+      dispatchPreEvent((PreEvent) baseEvent);
+    } else if (baseEvent instanceof Event) {
+      dispatchPostEvent((Event) baseEvent);
+    } else {
+      throw new RuntimeException("Unknown event type:" + baseEvent.getClass().getSimpleName());
+    }
   }
 
   /**
@@ -64,7 +73,15 @@ public class EventBus {
    *     EventBus.
    */
   @VisibleForTesting
-  List<EventListenerPlugin> getPostEventListeners() {
-    return postEventListeners;
+  List<EventListenerPlugin> getEventListeners() {
+    return eventListeners;
+  }
+
+  private void dispatchPostEvent(Event postEvent) {
+    eventListeners.forEach(postEventListener -> postEventListener.onPostEvent(postEvent));
+  }
+
+  private void dispatchPreEvent(PreEvent preEvent) throws ForbiddenException {
+    eventListeners.forEach(preEventListener -> preEventListener.onPreEvent(preEvent));
   }
 }

--- a/core/src/main/java/org/apache/gravitino/listener/EventListenerPluginWrapper.java
+++ b/core/src/main/java/org/apache/gravitino/listener/EventListenerPluginWrapper.java
@@ -23,6 +23,7 @@ import com.google.common.annotations.VisibleForTesting;
 import java.util.Map;
 import org.apache.gravitino.exceptions.ForbiddenException;
 import org.apache.gravitino.listener.api.EventListenerPlugin;
+import org.apache.gravitino.listener.api.event.BaseEvent;
 import org.apache.gravitino.listener.api.event.Event;
 import org.apache.gravitino.listener.api.event.PreEvent;
 import org.slf4j.Logger;
@@ -69,11 +70,7 @@ public class EventListenerPluginWrapper implements EventListenerPlugin {
     try {
       userEventListener.onPostEvent(event);
     } catch (Exception e) {
-      LOG.warn(
-          "Event listener {} process post event {} failed,",
-          listenerName,
-          event.getClass().getSimpleName(),
-          e);
+      printExceptionInEventProcess(listenerName, event, e);
     }
   }
 
@@ -84,28 +81,29 @@ public class EventListenerPluginWrapper implements EventListenerPlugin {
     } catch (ForbiddenException e) {
       if (Mode.SYNC.equals(mode())) {
         LOG.warn(
-            "Event listener {} process pre event {} failed, will skip the operation.",
+            "Event listener {} process pre event {} throws ForbiddenException, will skip the "
+                + "operation.",
             listenerName,
             preEvent.getClass().getSimpleName(),
             e);
         throw e;
       }
-      LOG.warn(
-          "Event listener {} process pre event {} failed,",
-          listenerName,
-          preEvent.getClass().getSimpleName(),
-          e);
+      printExceptionInEventProcess(listenerName, preEvent, e);
     } catch (Exception e) {
-      LOG.warn(
-          "Event listener {} process pre event {} failed,",
-          listenerName,
-          preEvent.getClass().getSimpleName(),
-          e);
+      printExceptionInEventProcess(listenerName, preEvent, e);
     }
   }
 
   @VisibleForTesting
   EventListenerPlugin getUserEventListener() {
     return userEventListener;
+  }
+
+  private void printExceptionInEventProcess(String listenerName, BaseEvent baseEvent, Exception e) {
+    LOG.warn(
+        "Event listener {} process event {} failed,",
+        listenerName,
+        baseEvent.getClass().getSimpleName(),
+        e);
   }
 }

--- a/core/src/main/java/org/apache/gravitino/listener/api/EventListenerPlugin.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/EventListenerPlugin.java
@@ -111,14 +111,13 @@ public interface EventListenerPlugin {
   /**
    * Handles pre events generated before the operation.
    *
-   * <p>This method provides a hook for pre-operation event processing, any changes you make to the
-   * resources during the event will be reflected in the operations that follow the event listener
-   * is SYNC mode.
+   * <p> This method handles pre-operation events in SYNC or ASYNC mode, any changes to resources in
+   * the event will inflect the subsequent operations.
    *
    * @param preEvent The pre event to be processed.
    * @throws ForbiddenException The operation will be skipped if and only if throwing {@code
    *     org.apache.gravitino.exceptions.ForbiddenException} and the event listener is SYNC mode,
-   *     the exception will be ignored on other conditions.
+   *     the exception will be ignored in other conditions.
    */
   default void onPreEvent(PreEvent preEvent) throws ForbiddenException {}
 

--- a/core/src/main/java/org/apache/gravitino/listener/api/EventListenerPlugin.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/EventListenerPlugin.java
@@ -21,7 +21,9 @@ package org.apache.gravitino.listener.api;
 
 import java.util.Map;
 import org.apache.gravitino.annotation.DeveloperApi;
+import org.apache.gravitino.exceptions.ForbiddenException;
 import org.apache.gravitino.listener.api.event.Event;
+import org.apache.gravitino.listener.api.event.PreEvent;
 
 /**
  * Defines an interface for event listeners that manage the lifecycle and state of a plugin,
@@ -95,17 +97,30 @@ public interface EventListenerPlugin {
   void stop() throws RuntimeException;
 
   /**
-   * Handles events generated after the completion of an operation. Implementers are responsible for
-   * processing these events, which may involve additional logic to respond to the operation
-   * outcomes.
+   * Handles events generated after the completion of an operation.
    *
-   * <p>This method provides a hook for post-operation event processing, allowing plugins to react
-   * or adapt based on the event details.
+   * <p>This method provides a hook for post-operation event processing, you couldn't change the
+   * resource in the event.
    *
-   * @param event The event to be processed.
-   * @throws RuntimeException Indicates issues encountered during event processing.
+   * @param postEvent The post event to be processed.
+   * @throws RuntimeException Indicates issues encountered during event processing, this has no
+   *     affect to the operation.
    */
-  void onPostEvent(Event event) throws RuntimeException;
+  default void onPostEvent(Event postEvent) throws RuntimeException {}
+
+  /**
+   * Handles pre events generated before the operation.
+   *
+   * <p>This method provides a hook for pre-operation event processing, any changes you make to the
+   * resources during the event will be reflected in the operations that follow the event listener
+   * is SYNC mode.
+   *
+   * @param preEvent The pre event to be processed.
+   * @throws ForbiddenException The operation will be skipped if and only if throwing {@code
+   *     org.apache.gravitino.exceptions.ForbiddenException} and the event listener is SYNC mode,
+   *     the exception will be ignored on other conditions.
+   */
+  default void onPreEvent(PreEvent preEvent) throws ForbiddenException {}
 
   /**
    * Specifies the default operational mode for event processing by the plugin. The default

--- a/core/src/main/java/org/apache/gravitino/listener/api/EventListenerPlugin.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/EventListenerPlugin.java
@@ -97,7 +97,7 @@ public interface EventListenerPlugin {
   void stop() throws RuntimeException;
 
   /**
-   * Handles events generated after the completion of an operation.
+   * Handle post-events generated after the completion of an operation.
    *
    * <p>This method provides a hook for post-operation event processing, you couldn't change the
    * resource in the event.
@@ -109,15 +109,15 @@ public interface EventListenerPlugin {
   default void onPostEvent(Event postEvent) throws RuntimeException {}
 
   /**
-   * Handles pre events generated before the operation.
+   * Handle pre-events generated before the operation.
    *
    * <p>This method handles pre-operation events in SYNC or ASYNC mode, any changes to resources in
-   * the event will inflect the subsequent operations.
+   * the event will affect the subsequent operations.
    *
    * @param preEvent The pre event to be processed.
-   * @throws ForbiddenException The operation will be skipped if and only if throwing {@code
-   *     org.apache.gravitino.exceptions.ForbiddenException} and the event listener is SYNC mode,
-   *     the exception will be ignored in other conditions.
+   * @throws ForbiddenException The subsequent operation will be skipped if and only if the event
+   *     listener throwing {@code org.apache.gravitino.exceptions.ForbiddenException} and the event
+   *     listener is SYNC mode, the exception will be ignored and logged only in other conditions.
    */
   default void onPreEvent(PreEvent preEvent) throws ForbiddenException {}
 

--- a/core/src/main/java/org/apache/gravitino/listener/api/EventListenerPlugin.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/EventListenerPlugin.java
@@ -111,7 +111,7 @@ public interface EventListenerPlugin {
   /**
    * Handles pre events generated before the operation.
    *
-   * <p> This method handles pre-operation events in SYNC or ASYNC mode, any changes to resources in
+   * <p>This method handles pre-operation events in SYNC or ASYNC mode, any changes to resources in
    * the event will inflect the subsequent operations.
    *
    * @param preEvent The pre event to be processed.

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/BaseEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/BaseEvent.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.listener.api.event;
+
+import javax.annotation.Nullable;
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.annotation.DeveloperApi;
+
+/**
+ * The abstract base class for all events. It encapsulates common information such as the user who
+ * generated the event and the identifier for the resource associated with the event. Subclasses
+ * should provide specific details related to their individual event types.
+ */
+@DeveloperApi
+public abstract class BaseEvent {
+  private final String user;
+  @Nullable private final NameIdentifier identifier;
+  private final long eventTime;
+
+  /**
+   * Constructs an Event instance with the specified user and resource identifier details.
+   *
+   * @param user The user associated with this event. It provides context about who triggered the
+   *     event.
+   * @param identifier The resource identifier associated with this event. This may refer to various
+   *     types of resources such as a metalake, catalog, schema, or table, etc.
+   */
+  protected BaseEvent(String user, NameIdentifier identifier) {
+    this.user = user;
+    this.identifier = identifier;
+    this.eventTime = System.currentTimeMillis();
+  }
+
+  /**
+   * Retrieves the user associated with this event.
+   *
+   * @return A string representing the user associated with this event.
+   */
+  public String user() {
+    return user;
+  }
+
+  /**
+   * Retrieves the resource identifier associated with this event.
+   *
+   * <p>For list operations within a namespace, the identifier is the identifier corresponds to that
+   * namespace. For metalake list operation, identifier is null.
+   *
+   * @return A NameIdentifier object that represents the resource, like a metalake, catalog, schema,
+   *     table, etc., associated with the event.
+   */
+  @Nullable
+  public NameIdentifier identifier() {
+    return identifier;
+  }
+
+  /**
+   * Returns the timestamp when the event was created.
+   *
+   * @return The event creation time in milliseconds since epoch.
+   */
+  public long eventTime() {
+    return eventTime;
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/Event.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/Event.java
@@ -19,64 +19,13 @@
 
 package org.apache.gravitino.listener.api.event;
 
-import javax.annotation.Nullable;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.annotation.DeveloperApi;
 
-/**
- * The abstract base class for all events. It encapsulates common information such as the user who
- * generated the event and the identifier for the resource associated with the event. Subclasses
- * should provide specific details related to their individual event types.
- */
+/** Represents a post event. */
 @DeveloperApi
-public abstract class Event {
-  private final String user;
-  @Nullable private final NameIdentifier identifier;
-  private final long eventTime;
-
-  /**
-   * Constructs an Event instance with the specified user and resource identifier details.
-   *
-   * @param user The user associated with this event. It provides context about who triggered the
-   *     event.
-   * @param identifier The resource identifier associated with this event. This may refer to various
-   *     types of resources such as a metalake, catalog, schema, or table, etc.
-   */
+public abstract class Event extends BaseEvent {
   protected Event(String user, NameIdentifier identifier) {
-    this.user = user;
-    this.identifier = identifier;
-    this.eventTime = System.currentTimeMillis();
-  }
-
-  /**
-   * Retrieves the user associated with this event.
-   *
-   * @return A string representing the user associated with this event.
-   */
-  public String user() {
-    return user;
-  }
-
-  /**
-   * Retrieves the resource identifier associated with this event.
-   *
-   * <p>For list operations within a namespace, the identifier is the identifier corresponds to that
-   * namespace. For metalake list operation, identifier is null.
-   *
-   * @return A NameIdentifier object that represents the resource, like a metalake, catalog, schema,
-   *     table, etc., associated with the event.
-   */
-  @Nullable
-  public NameIdentifier identifier() {
-    return identifier;
-  }
-
-  /**
-   * Returns the timestamp when the event was created.
-   *
-   * @return The event creation time in milliseconds since epoch.
-   */
-  public long eventTime() {
-    return eventTime;
+    super(user, identifier);
   }
 }

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/PreEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/PreEvent.java
@@ -1,0 +1,31 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.apache.gravitino.listener.api.event;
+
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.annotation.DeveloperApi;
+
+/** Represents a pre event. */
+@DeveloperApi
+public abstract class PreEvent extends BaseEvent {
+  protected PreEvent(String user, NameIdentifier identifier) {
+    super(user, identifier);
+  }
+}

--- a/core/src/test/java/org/apache/gravitino/listener/DummyEventListener.java
+++ b/core/src/test/java/org/apache/gravitino/listener/DummyEventListener.java
@@ -67,14 +67,9 @@ public class DummyEventListener implements EventListenerPlugin {
     return Mode.SYNC;
   }
 
-  public Event popEvent() {
+  public Event popPostEvent() {
     Assertions.assertTrue(postEvents.size() > 0, "No events to pop");
     return postEvents.removeLast();
-  }
-
-  public PreEvent popPreEvent() {
-    Assertions.assertTrue(preEvents.size() > 0, "No events to pop");
-    return preEvents.removeLast();
   }
 
   public static class DummyAsyncEventListener extends DummyEventListener {

--- a/core/src/test/java/org/apache/gravitino/listener/TestEventListenerManager.java
+++ b/core/src/test/java/org/apache/gravitino/listener/TestEventListenerManager.java
@@ -61,7 +61,7 @@ public class TestEventListenerManager {
       new DummyPreEvent("user3", NameIdentifier.of("a3", "b3"));
 
   public static final DummyPreEvent DUMMY_EXCEPTION_PRE_EVENT_INSTANCE =
-      new DummyPreEvent("user3", NameIdentifier.of("a3", "b3"));
+      new DummyPreEvent("user4", NameIdentifier.of("a4", "b4"));
 
   @Test
   void testSyncListener() {

--- a/core/src/test/java/org/apache/gravitino/listener/api/event/TestCatalogEvent.java
+++ b/core/src/test/java/org/apache/gravitino/listener/api/event/TestCatalogEvent.java
@@ -65,7 +65,7 @@ public class TestCatalogEvent {
     NameIdentifier identifier = NameIdentifier.of("metalake", catalog.name());
     dispatcher.createCatalog(
         identifier, catalog.type(), catalog.provider(), catalog.comment(), catalog.properties());
-    Event event = dummyEventListener.popEvent();
+    Event event = dummyEventListener.popPostEvent();
     Assertions.assertEquals(identifier, event.identifier());
     Assertions.assertEquals(CreateCatalogEvent.class, event.getClass());
     CatalogInfo catalogInfo = ((CreateCatalogEvent) event).createdCatalogInfo();
@@ -76,7 +76,7 @@ public class TestCatalogEvent {
   void testLoadCatalogEvent() {
     NameIdentifier identifier = NameIdentifier.of("metalake", catalog.name());
     dispatcher.loadCatalog(identifier);
-    Event event = dummyEventListener.popEvent();
+    Event event = dummyEventListener.popPostEvent();
     Assertions.assertEquals(identifier, event.identifier());
     Assertions.assertEquals(LoadCatalogEvent.class, event.getClass());
     CatalogInfo catalogInfo = ((LoadCatalogEvent) event).loadedCatalogInfo();
@@ -88,7 +88,7 @@ public class TestCatalogEvent {
     NameIdentifier identifier = NameIdentifier.of("metalake", catalog.name());
     CatalogChange catalogChange = CatalogChange.setProperty("a", "b");
     dispatcher.alterCatalog(identifier, catalogChange);
-    Event event = dummyEventListener.popEvent();
+    Event event = dummyEventListener.popPostEvent();
     Assertions.assertEquals(identifier, event.identifier());
     Assertions.assertEquals(AlterCatalogEvent.class, event.getClass());
     CatalogInfo catalogInfo = ((AlterCatalogEvent) event).updatedCatalogInfo();
@@ -102,7 +102,7 @@ public class TestCatalogEvent {
   void testDropCatalogEvent() {
     NameIdentifier identifier = NameIdentifier.of("metalake", catalog.name());
     dispatcher.dropCatalog(identifier);
-    Event event = dummyEventListener.popEvent();
+    Event event = dummyEventListener.popPostEvent();
     Assertions.assertEquals(identifier, event.identifier());
     Assertions.assertEquals(DropCatalogEvent.class, event.getClass());
     Assertions.assertEquals(true, ((DropCatalogEvent) event).isExists());
@@ -112,7 +112,7 @@ public class TestCatalogEvent {
   void testListCatalogEvent() {
     Namespace namespace = Namespace.of("metalake");
     dispatcher.listCatalogs(namespace);
-    Event event = dummyEventListener.popEvent();
+    Event event = dummyEventListener.popPostEvent();
     Assertions.assertEquals(namespace.toString(), event.identifier().toString());
     Assertions.assertEquals(ListCatalogEvent.class, event.getClass());
     Assertions.assertEquals(namespace, ((ListCatalogEvent) event).namespace());
@@ -122,7 +122,7 @@ public class TestCatalogEvent {
   void testListCatalogInfoEvent() {
     Namespace namespace = Namespace.of("metalake");
     dispatcher.listCatalogsInfo(namespace);
-    Event event = dummyEventListener.popEvent();
+    Event event = dummyEventListener.popPostEvent();
     Assertions.assertEquals(namespace.toString(), event.identifier().toString());
     Assertions.assertEquals(ListCatalogEvent.class, event.getClass());
     Assertions.assertEquals(namespace, ((ListCatalogEvent) event).namespace());
@@ -140,7 +140,7 @@ public class TestCatalogEvent {
                 catalog.provider(),
                 catalog.comment(),
                 catalog.properties()));
-    Event event = dummyEventListener.popEvent();
+    Event event = dummyEventListener.popPostEvent();
     Assertions.assertEquals(identifier, event.identifier());
     Assertions.assertEquals(CreateCatalogFailureEvent.class, event.getClass());
     Assertions.assertEquals(
@@ -154,7 +154,7 @@ public class TestCatalogEvent {
     NameIdentifier identifier = NameIdentifier.of("metalake", "catalog");
     Assertions.assertThrowsExactly(
         GravitinoRuntimeException.class, () -> failureDispatcher.loadCatalog(identifier));
-    Event event = dummyEventListener.popEvent();
+    Event event = dummyEventListener.popPostEvent();
     Assertions.assertEquals(identifier, event.identifier());
     Assertions.assertEquals(LoadCatalogFailureEvent.class, event.getClass());
     Assertions.assertEquals(
@@ -168,7 +168,7 @@ public class TestCatalogEvent {
     Assertions.assertThrowsExactly(
         GravitinoRuntimeException.class,
         () -> failureDispatcher.alterCatalog(identifier, catalogChange));
-    Event event = dummyEventListener.popEvent();
+    Event event = dummyEventListener.popPostEvent();
     Assertions.assertEquals(identifier, event.identifier());
     Assertions.assertEquals(AlterCatalogFailureEvent.class, event.getClass());
     Assertions.assertEquals(
@@ -183,7 +183,7 @@ public class TestCatalogEvent {
     NameIdentifier identifier = NameIdentifier.of("metalake", "catalog");
     Assertions.assertThrowsExactly(
         GravitinoRuntimeException.class, () -> failureDispatcher.dropCatalog(identifier));
-    Event event = dummyEventListener.popEvent();
+    Event event = dummyEventListener.popPostEvent();
     Assertions.assertEquals(identifier, event.identifier());
     Assertions.assertEquals(DropCatalogFailureEvent.class, event.getClass());
     Assertions.assertEquals(
@@ -195,7 +195,7 @@ public class TestCatalogEvent {
     Namespace namespace = Namespace.of("metalake", "catalog");
     Assertions.assertThrowsExactly(
         GravitinoRuntimeException.class, () -> failureDispatcher.listCatalogs(namespace));
-    Event event = dummyEventListener.popEvent();
+    Event event = dummyEventListener.popPostEvent();
     Assertions.assertEquals(ListCatalogFailureEvent.class, event.getClass());
     Assertions.assertEquals(
         GravitinoRuntimeException.class, ((ListCatalogFailureEvent) event).exception().getClass());
@@ -207,7 +207,7 @@ public class TestCatalogEvent {
     Namespace namespace = Namespace.of("metalake", "catalog");
     Assertions.assertThrowsExactly(
         GravitinoRuntimeException.class, () -> failureDispatcher.listCatalogsInfo(namespace));
-    Event event = dummyEventListener.popEvent();
+    Event event = dummyEventListener.popPostEvent();
     Assertions.assertEquals(ListCatalogFailureEvent.class, event.getClass());
     Assertions.assertEquals(
         GravitinoRuntimeException.class, ((ListCatalogFailureEvent) event).exception().getClass());

--- a/core/src/test/java/org/apache/gravitino/listener/api/event/TestFilesetEvent.java
+++ b/core/src/test/java/org/apache/gravitino/listener/api/event/TestFilesetEvent.java
@@ -75,7 +75,7 @@ public class TestFilesetEvent {
         fileset.type(),
         fileset.storageLocation(),
         fileset.properties());
-    Event event = dummyEventListener.popEvent();
+    Event event = dummyEventListener.popPostEvent();
     Assertions.assertEquals(identifier, event.identifier());
     Assertions.assertEquals(CreateFilesetEvent.class, event.getClass());
     FilesetInfo filesetInfo = ((CreateFilesetEvent) event).createdFilesetInfo();
@@ -86,7 +86,7 @@ public class TestFilesetEvent {
   void testLoadFilesetEvent() {
     NameIdentifier identifier = NameIdentifier.of("metalake", "catalog", fileset.name());
     dispatcher.loadFileset(identifier);
-    Event event = dummyEventListener.popEvent();
+    Event event = dummyEventListener.popPostEvent();
     Assertions.assertEquals(identifier, event.identifier());
     Assertions.assertEquals(LoadFilesetEvent.class, event.getClass());
     FilesetInfo filesetInfo = ((LoadFilesetEvent) event).loadedFilesetInfo();
@@ -98,7 +98,7 @@ public class TestFilesetEvent {
     NameIdentifier identifier = NameIdentifier.of("metalake", "catalog", fileset.name());
     FilesetChange change = FilesetChange.setProperty("a", "b");
     dispatcher.alterFileset(identifier, change);
-    Event event = dummyEventListener.popEvent();
+    Event event = dummyEventListener.popPostEvent();
     Assertions.assertEquals(identifier, event.identifier());
     Assertions.assertEquals(AlterFilesetEvent.class, event.getClass());
     FilesetInfo filesetInfo = ((AlterFilesetEvent) event).updatedFilesetInfo();
@@ -111,7 +111,7 @@ public class TestFilesetEvent {
   void testDropFilesetEvent() {
     NameIdentifier identifier = NameIdentifier.of("metalake", "catalog", fileset.name());
     dispatcher.dropFileset(identifier);
-    Event event = dummyEventListener.popEvent();
+    Event event = dummyEventListener.popPostEvent();
     Assertions.assertEquals(identifier, event.identifier());
     Assertions.assertEquals(DropFilesetEvent.class, event.getClass());
     Assertions.assertTrue(((DropFilesetEvent) event).isExists());
@@ -121,7 +121,7 @@ public class TestFilesetEvent {
   void testListFilesetEvent() {
     Namespace namespace = Namespace.of("metalake", "catalog");
     dispatcher.listFilesets(namespace);
-    Event event = dummyEventListener.popEvent();
+    Event event = dummyEventListener.popPostEvent();
     Assertions.assertEquals(namespace.toString(), event.identifier().toString());
     Assertions.assertEquals(ListFilesetEvent.class, event.getClass());
     Assertions.assertEquals(namespace, ((ListFilesetEvent) event).namespace());
@@ -136,7 +136,7 @@ public class TestFilesetEvent {
         fileset.type(),
         fileset.storageLocation(),
         fileset.properties());
-    Event event = dummyEventListener.popEvent();
+    Event event = dummyEventListener.popPostEvent();
     Assertions.assertEquals(identifier, event.identifier());
     Assertions.assertEquals(CreateFilesetEvent.class, event.getClass());
     FilesetInfo filesetInfo = ((CreateFilesetEvent) event).createdFilesetInfo();
@@ -152,7 +152,7 @@ public class TestFilesetEvent {
     CallerContext callerContext = CallerContext.builder().withContext(contextMap).build();
     CallerContext.CallerContextHolder.set(callerContext);
     String fileLocation = dispatcher.getFileLocation(identifier, "test");
-    Event event1 = dummyEventListener.popEvent();
+    Event event1 = dummyEventListener.popPostEvent();
     Assertions.assertEquals(identifier, event1.identifier());
     Assertions.assertEquals(GetFileLocationEvent.class, event1.getClass());
     String actualFileLocation = ((GetFileLocationEvent) event1).actualFileLocation();
@@ -180,7 +180,7 @@ public class TestFilesetEvent {
                 fileset.type(),
                 fileset.storageLocation(),
                 fileset.properties()));
-    Event event = dummyEventListener.popEvent();
+    Event event = dummyEventListener.popPostEvent();
     Assertions.assertEquals(identifier, event.identifier());
     Assertions.assertEquals(CreateFilesetFailureEvent.class, event.getClass());
     Assertions.assertEquals(
@@ -194,7 +194,7 @@ public class TestFilesetEvent {
     NameIdentifier identifier = NameIdentifier.of("metalake", "catalog", "fileset");
     Assertions.assertThrowsExactly(
         GravitinoRuntimeException.class, () -> failureDispatcher.loadFileset(identifier));
-    Event event = dummyEventListener.popEvent();
+    Event event = dummyEventListener.popPostEvent();
     Assertions.assertEquals(identifier, event.identifier());
     Assertions.assertEquals(LoadFilesetFailureEvent.class, event.getClass());
     Assertions.assertEquals(
@@ -207,7 +207,7 @@ public class TestFilesetEvent {
     FilesetChange change = FilesetChange.setProperty("a", "b");
     Assertions.assertThrowsExactly(
         GravitinoRuntimeException.class, () -> failureDispatcher.alterFileset(identifier, change));
-    Event event = dummyEventListener.popEvent();
+    Event event = dummyEventListener.popPostEvent();
     Assertions.assertEquals(identifier, event.identifier());
     Assertions.assertEquals(AlterFilesetFailureEvent.class, event.getClass());
     Assertions.assertEquals(
@@ -221,7 +221,7 @@ public class TestFilesetEvent {
     NameIdentifier identifier = NameIdentifier.of("metalake", "catalog", "fileset");
     Assertions.assertThrowsExactly(
         GravitinoRuntimeException.class, () -> failureDispatcher.dropFileset(identifier));
-    Event event = dummyEventListener.popEvent();
+    Event event = dummyEventListener.popPostEvent();
     Assertions.assertEquals(identifier, event.identifier());
     Assertions.assertEquals(DropFilesetFailureEvent.class, event.getClass());
     Assertions.assertEquals(
@@ -233,7 +233,7 @@ public class TestFilesetEvent {
     Namespace namespace = Namespace.of("metalake", "catalog");
     Assertions.assertThrowsExactly(
         GravitinoRuntimeException.class, () -> failureDispatcher.listFilesets(namespace));
-    Event event = dummyEventListener.popEvent();
+    Event event = dummyEventListener.popPostEvent();
     Assertions.assertEquals(namespace.toString(), event.identifier().toString());
     Assertions.assertEquals(ListFilesetFailureEvent.class, event.getClass());
     Assertions.assertEquals(
@@ -247,7 +247,7 @@ public class TestFilesetEvent {
     Assertions.assertThrowsExactly(
         GravitinoRuntimeException.class,
         () -> failureDispatcher.getFileLocation(identifier, "/test"));
-    Event event = dummyEventListener.popEvent();
+    Event event = dummyEventListener.popPostEvent();
     Assertions.assertEquals(identifier, event.identifier());
     Assertions.assertEquals(GetFileLocationFailureEvent.class, event.getClass());
     Assertions.assertEquals(

--- a/core/src/test/java/org/apache/gravitino/listener/api/event/TestMetalakeEvent.java
+++ b/core/src/test/java/org/apache/gravitino/listener/api/event/TestMetalakeEvent.java
@@ -63,7 +63,7 @@ public class TestMetalakeEvent {
   void testCreateMetalakeEvent() {
     NameIdentifier identifier = NameIdentifier.of("metalake");
     dispatcher.createMetalake(identifier, metalake.comment(), metalake.properties());
-    Event event = dummyEventListener.popEvent();
+    Event event = dummyEventListener.popPostEvent();
     Assertions.assertEquals(identifier, event.identifier());
     Assertions.assertEquals(CreateMetalakeEvent.class, event.getClass());
     MetalakeInfo metalakeInfo = ((CreateMetalakeEvent) event).createdMetalakeInfo();
@@ -74,7 +74,7 @@ public class TestMetalakeEvent {
   void testLoadMetalakeEvent() {
     NameIdentifier identifier = NameIdentifier.of("metalake");
     dispatcher.loadMetalake(identifier);
-    Event event = dummyEventListener.popEvent();
+    Event event = dummyEventListener.popPostEvent();
     Assertions.assertEquals(identifier, event.identifier());
     Assertions.assertEquals(LoadMetalakeEvent.class, event.getClass());
     MetalakeInfo metalakeInfo = ((LoadMetalakeEvent) event).loadedMetalakeInfo();
@@ -86,7 +86,7 @@ public class TestMetalakeEvent {
     NameIdentifier identifier = NameIdentifier.of("metalake");
     MetalakeChange metalakeChange = MetalakeChange.setProperty("a", "b");
     dispatcher.alterMetalake(identifier, metalakeChange);
-    Event event = dummyEventListener.popEvent();
+    Event event = dummyEventListener.popPostEvent();
     Assertions.assertEquals(identifier, event.identifier());
     Assertions.assertEquals(AlterMetalakeEvent.class, event.getClass());
     MetalakeInfo metalakeInfo = ((AlterMetalakeEvent) event).updatedMetalakeInfo();
@@ -100,7 +100,7 @@ public class TestMetalakeEvent {
   void testDropMetalakeEvent() {
     NameIdentifier identifier = NameIdentifier.of("metalake");
     dispatcher.dropMetalake(identifier);
-    Event event = dummyEventListener.popEvent();
+    Event event = dummyEventListener.popPostEvent();
     Assertions.assertEquals(identifier, event.identifier());
     Assertions.assertEquals(DropMetalakeEvent.class, event.getClass());
     Assertions.assertTrue(((DropMetalakeEvent) event).isExists());
@@ -109,7 +109,7 @@ public class TestMetalakeEvent {
   @Test
   void testListMetalakeEvent() {
     dispatcher.listMetalakes();
-    Event event = dummyEventListener.popEvent();
+    Event event = dummyEventListener.popPostEvent();
     Assertions.assertNull(event.identifier());
     Assertions.assertEquals(ListMetalakeEvent.class, event.getClass());
   }
@@ -122,7 +122,7 @@ public class TestMetalakeEvent {
         () ->
             failureDispatcher.createMetalake(
                 identifier, metalake.comment(), metalake.properties()));
-    Event event = dummyEventListener.popEvent();
+    Event event = dummyEventListener.popPostEvent();
     Assertions.assertEquals(identifier, event.identifier());
     Assertions.assertEquals(CreateMetalakeFailureEvent.class, event.getClass());
     Assertions.assertEquals(
@@ -136,7 +136,7 @@ public class TestMetalakeEvent {
     NameIdentifier identifier = NameIdentifier.of(metalake.name());
     Assertions.assertThrowsExactly(
         GravitinoRuntimeException.class, () -> failureDispatcher.loadMetalake(identifier));
-    Event event = dummyEventListener.popEvent();
+    Event event = dummyEventListener.popPostEvent();
     Assertions.assertEquals(identifier, event.identifier());
     Assertions.assertEquals(LoadMetalakeFailureEvent.class, event.getClass());
     Assertions.assertEquals(
@@ -150,7 +150,7 @@ public class TestMetalakeEvent {
     Assertions.assertThrowsExactly(
         GravitinoRuntimeException.class,
         () -> failureDispatcher.alterMetalake(identifier, metalakeChange));
-    Event event = dummyEventListener.popEvent();
+    Event event = dummyEventListener.popPostEvent();
     Assertions.assertEquals(identifier, event.identifier());
     Assertions.assertEquals(AlterMetalakeFailureEvent.class, event.getClass());
     Assertions.assertEquals(
@@ -166,7 +166,7 @@ public class TestMetalakeEvent {
     NameIdentifier identifier = NameIdentifier.of(metalake.name());
     Assertions.assertThrowsExactly(
         GravitinoRuntimeException.class, () -> failureDispatcher.dropMetalake(identifier));
-    Event event = dummyEventListener.popEvent();
+    Event event = dummyEventListener.popPostEvent();
     Assertions.assertEquals(identifier, event.identifier());
     Assertions.assertEquals(DropMetalakeFailureEvent.class, event.getClass());
     Assertions.assertEquals(
@@ -177,7 +177,7 @@ public class TestMetalakeEvent {
   void testListMetalakeFailureEvent() {
     Assertions.assertThrowsExactly(
         GravitinoRuntimeException.class, () -> failureDispatcher.listMetalakes());
-    Event event = dummyEventListener.popEvent();
+    Event event = dummyEventListener.popPostEvent();
     Assertions.assertNull(event.identifier());
     Assertions.assertEquals(ListMetalakeFailureEvent.class, event.getClass());
     Assertions.assertEquals(

--- a/core/src/test/java/org/apache/gravitino/listener/api/event/TestPartitionEvent.java
+++ b/core/src/test/java/org/apache/gravitino/listener/api/event/TestPartitionEvent.java
@@ -110,7 +110,7 @@ public class TestPartitionEvent {
   void testAddPartitionEvent() {
     NameIdentifier identifier = NameIdentifier.of("metalake", "catalog", "schema", "table");
     dispatcher.addPartition(identifier, partition);
-    Event event = dummyEventListener.popEvent();
+    Event event = dummyEventListener.popPostEvent();
     Assertions.assertEquals(identifier, event.identifier());
     Assertions.assertEquals(AddPartitionEvent.class, event.getClass());
     PartitionInfo partitionInfo = ((AddPartitionEvent) event).createdPartitionInfo();
@@ -121,7 +121,7 @@ public class TestPartitionEvent {
   void testDropPartitionEvent() {
     NameIdentifier identifier = NameIdentifier.of("metalake", "catalog", "schema", "table");
     dispatcher.dropPartition(identifier, partition.name());
-    Event event = dummyEventListener.popEvent();
+    Event event = dummyEventListener.popPostEvent();
     Assertions.assertEquals(identifier, event.identifier());
     Assertions.assertEquals(DropPartitionEvent.class, event.getClass());
     Assertions.assertEquals(false, ((DropPartitionEvent) event).isExists());
@@ -131,7 +131,7 @@ public class TestPartitionEvent {
   void testPartitionExistsEvent() {
     NameIdentifier identifier = NameIdentifier.of("metalake", "catalog", "schema", "table");
     dispatcher.partitionExists(identifier, partition.name());
-    Event event = dummyEventListener.popEvent();
+    Event event = dummyEventListener.popPostEvent();
     Assertions.assertEquals(identifier, event.identifier());
     Assertions.assertEquals(PartitionExistsEvent.class, event.getClass());
     Assertions.assertEquals(false, ((PartitionExistsEvent) event).isExists());
@@ -141,7 +141,7 @@ public class TestPartitionEvent {
   void testListPartitionEvent() {
     NameIdentifier identifier = NameIdentifier.of("metalake", "catalog", "schema", "table");
     dispatcher.listPartitions(identifier);
-    Event event = dummyEventListener.popEvent();
+    Event event = dummyEventListener.popPostEvent();
     Assertions.assertEquals(identifier, event.identifier());
     Assertions.assertEquals(ListPartitionEvent.class, event.getClass());
     Assertions.assertEquals(identifier, ((ListPartitionEvent) event).identifier());
@@ -151,7 +151,7 @@ public class TestPartitionEvent {
   void testListPartitionNamesEvent() {
     NameIdentifier identifier = NameIdentifier.of("metalake", "catalog", "schema", "table");
     dispatcher.listPartitionNames(identifier);
-    Event event = dummyEventListener.popEvent();
+    Event event = dummyEventListener.popPostEvent();
     Assertions.assertEquals(identifier, event.identifier());
     Assertions.assertEquals(ListPartitionNamesEvent.class, event.getClass());
     Assertions.assertEquals(identifier, ((ListPartitionNamesEvent) event).identifier());
@@ -161,7 +161,7 @@ public class TestPartitionEvent {
   void testPurgePartitionEvent() {
     NameIdentifier identifier = NameIdentifier.of("metalake", "catalog", "schema", "table");
     dispatcher.purgePartition(identifier, partition.name());
-    Event event = dummyEventListener.popEvent();
+    Event event = dummyEventListener.popPostEvent();
     Assertions.assertEquals(identifier, event.identifier());
     Assertions.assertEquals(PurgePartitionEvent.class, event.getClass());
     Assertions.assertEquals(identifier, ((PurgePartitionEvent) event).identifier());
@@ -173,7 +173,7 @@ public class TestPartitionEvent {
     Assertions.assertThrowsExactly(
         GravitinoRuntimeException.class,
         () -> failureDispatcher.addPartition(identifier, partition));
-    Event event = dummyEventListener.popEvent();
+    Event event = dummyEventListener.popPostEvent();
     Assertions.assertEquals(AddPartitionFailureEvent.class, event.getClass());
     Assertions.assertEquals(
         GravitinoRuntimeException.class, ((AddPartitionFailureEvent) event).exception().getClass());
@@ -187,7 +187,7 @@ public class TestPartitionEvent {
     Assertions.assertThrowsExactly(
         GravitinoRuntimeException.class,
         () -> failureDispatcher.dropPartition(identifier, partition.name()));
-    Event event = dummyEventListener.popEvent();
+    Event event = dummyEventListener.popPostEvent();
     Assertions.assertEquals(DropPartitionFailureEvent.class, event.getClass());
     Assertions.assertEquals(
         GravitinoRuntimeException.class,
@@ -201,7 +201,7 @@ public class TestPartitionEvent {
     Assertions.assertThrowsExactly(
         GravitinoRuntimeException.class,
         () -> failureDispatcher.partitionExists(identifier, partition.name()));
-    Event event = dummyEventListener.popEvent();
+    Event event = dummyEventListener.popPostEvent();
     Assertions.assertEquals(PartitionExistsFailureEvent.class, event.getClass());
     Assertions.assertEquals(
         GravitinoRuntimeException.class,
@@ -214,7 +214,7 @@ public class TestPartitionEvent {
     NameIdentifier identifier = NameIdentifier.of("metalake", "catalog", "schema", "table");
     Assertions.assertThrowsExactly(
         GravitinoRuntimeException.class, () -> failureDispatcher.listPartitions(identifier));
-    Event event = dummyEventListener.popEvent();
+    Event event = dummyEventListener.popPostEvent();
     Assertions.assertEquals(ListPartitionFailureEvent.class, event.getClass());
     Assertions.assertEquals(
         GravitinoRuntimeException.class,
@@ -227,7 +227,7 @@ public class TestPartitionEvent {
     NameIdentifier identifier = NameIdentifier.of("metalake", "catalog", "schema", "table");
     Assertions.assertThrowsExactly(
         GravitinoRuntimeException.class, () -> failureDispatcher.listPartitionNames(identifier));
-    Event event = dummyEventListener.popEvent();
+    Event event = dummyEventListener.popPostEvent();
     Assertions.assertEquals(ListPartitionNamesFailureEvent.class, event.getClass());
     Assertions.assertEquals(
         GravitinoRuntimeException.class,
@@ -241,7 +241,7 @@ public class TestPartitionEvent {
     Assertions.assertThrowsExactly(
         GravitinoRuntimeException.class,
         () -> failureDispatcher.purgePartition(identifier, partition.name()));
-    Event event = dummyEventListener.popEvent();
+    Event event = dummyEventListener.popPostEvent();
     Assertions.assertEquals(PurgePartitionFailureEvent.class, event.getClass());
     Assertions.assertEquals(
         GravitinoRuntimeException.class,

--- a/core/src/test/java/org/apache/gravitino/listener/api/event/TestSchemaEvent.java
+++ b/core/src/test/java/org/apache/gravitino/listener/api/event/TestSchemaEvent.java
@@ -66,7 +66,7 @@ public class TestSchemaEvent {
   void testCreateSchemaEvent() {
     NameIdentifier identifier = NameIdentifier.of("metalake", "catalog", "schema");
     dispatcher.createSchema(identifier, "", ImmutableMap.of());
-    Event event = dummyEventListener.popEvent();
+    Event event = dummyEventListener.popPostEvent();
     Assertions.assertEquals(identifier, event.identifier());
     Assertions.assertEquals(CreateSchemaEvent.class, event.getClass());
     SchemaInfo schemaInfo = ((CreateSchemaEvent) event).createdSchemaInfo();
@@ -77,7 +77,7 @@ public class TestSchemaEvent {
   void testLoadSchemaEvent() {
     NameIdentifier identifier = NameIdentifier.of("metalake", "catalog", "schema");
     dispatcher.loadSchema(identifier);
-    Event event = dummyEventListener.popEvent();
+    Event event = dummyEventListener.popPostEvent();
     Assertions.assertEquals(identifier, event.identifier());
     Assertions.assertEquals(LoadSchemaEvent.class, event.getClass());
     SchemaInfo schemaInfo = ((LoadSchemaEvent) event).loadedSchemaInfo();
@@ -88,7 +88,7 @@ public class TestSchemaEvent {
   void testListSchemaEvent() {
     Namespace namespace = Namespace.of("metalake", "catalog");
     dispatcher.listSchemas(namespace);
-    Event event = dummyEventListener.popEvent();
+    Event event = dummyEventListener.popPostEvent();
     Assertions.assertEquals(ListSchemaEvent.class, event.getClass());
     Assertions.assertEquals(namespace, ((ListSchemaEvent) event).namespace());
   }
@@ -98,7 +98,7 @@ public class TestSchemaEvent {
     SchemaChange schemaChange = SchemaChange.setProperty("a", "b");
     NameIdentifier identifier = NameIdentifier.of("metalake", "catalog", "schema");
     dispatcher.alterSchema(identifier, schemaChange);
-    Event event = dummyEventListener.popEvent();
+    Event event = dummyEventListener.popPostEvent();
 
     Assertions.assertEquals(identifier, event.identifier());
     Assertions.assertEquals(AlterSchemaEvent.class, event.getClass());
@@ -113,7 +113,7 @@ public class TestSchemaEvent {
   void testDropSchemaEvent() {
     NameIdentifier identifier = NameIdentifier.of("metalake", "catalog", "schema");
     dispatcher.dropSchema(identifier, true);
-    Event event = dummyEventListener.popEvent();
+    Event event = dummyEventListener.popPostEvent();
     Assertions.assertEquals(identifier, event.identifier());
     Assertions.assertEquals(DropSchemaEvent.class, event.getClass());
     Assertions.assertEquals(true, ((DropSchemaEvent) event).cascade());
@@ -126,7 +126,7 @@ public class TestSchemaEvent {
     Assertions.assertThrowsExactly(
         GravitinoRuntimeException.class,
         () -> failureDispatcher.createSchema(identifier, schema.comment(), schema.properties()));
-    Event event = dummyEventListener.popEvent();
+    Event event = dummyEventListener.popPostEvent();
     Assertions.assertEquals(identifier, event.identifier());
     Assertions.assertEquals(CreateSchemaFailureEvent.class, event.getClass());
     Assertions.assertEquals(
@@ -139,7 +139,7 @@ public class TestSchemaEvent {
     NameIdentifier identifier = NameIdentifier.of("metalake", "catalog", "schema");
     Assertions.assertThrowsExactly(
         GravitinoRuntimeException.class, () -> failureDispatcher.loadSchema(identifier));
-    Event event = dummyEventListener.popEvent();
+    Event event = dummyEventListener.popPostEvent();
     Assertions.assertEquals(identifier, event.identifier());
     Assertions.assertEquals(LoadSchemaFailureEvent.class, event.getClass());
     Assertions.assertEquals(
@@ -154,7 +154,7 @@ public class TestSchemaEvent {
     Assertions.assertThrowsExactly(
         GravitinoRuntimeException.class,
         () -> failureDispatcher.alterSchema(identifier, schemaChange));
-    Event event = dummyEventListener.popEvent();
+    Event event = dummyEventListener.popPostEvent();
     Assertions.assertEquals(identifier, event.identifier());
     Assertions.assertEquals(AlterSchemaFailureEvent.class, event.getClass());
     Assertions.assertEquals(
@@ -168,7 +168,7 @@ public class TestSchemaEvent {
     NameIdentifier identifier = NameIdentifier.of("metalake", "catalog", "schema");
     Assertions.assertThrowsExactly(
         GravitinoRuntimeException.class, () -> failureDispatcher.dropSchema(identifier, true));
-    Event event = dummyEventListener.popEvent();
+    Event event = dummyEventListener.popPostEvent();
     Assertions.assertEquals(identifier, event.identifier());
     Assertions.assertEquals(DropSchemaFailureEvent.class, event.getClass());
     Assertions.assertEquals(
@@ -181,7 +181,7 @@ public class TestSchemaEvent {
     Namespace namespace = Namespace.of("metalake", "catalog");
     Assertions.assertThrowsExactly(
         GravitinoRuntimeException.class, () -> failureDispatcher.listSchemas(namespace));
-    Event event = dummyEventListener.popEvent();
+    Event event = dummyEventListener.popPostEvent();
     Assertions.assertEquals(namespace.toString(), event.identifier().toString());
     Assertions.assertEquals(ListSchemaFailureEvent.class, event.getClass());
     Assertions.assertEquals(

--- a/core/src/test/java/org/apache/gravitino/listener/api/event/TestTableEvent.java
+++ b/core/src/test/java/org/apache/gravitino/listener/api/event/TestTableEvent.java
@@ -84,7 +84,7 @@ public class TestTableEvent {
         table.distribution(),
         table.sortOrder(),
         table.index());
-    Event event = dummyEventListener.popEvent();
+    Event event = dummyEventListener.popPostEvent();
     Assertions.assertEquals(identifier, event.identifier());
     Assertions.assertEquals(CreateTableEvent.class, event.getClass());
     TableInfo tableInfo = ((CreateTableEvent) event).createdTableInfo();
@@ -95,7 +95,7 @@ public class TestTableEvent {
   void testLoadTableEvent() {
     NameIdentifier identifier = NameIdentifier.of("metalake", "catalog", table.name());
     dispatcher.loadTable(identifier);
-    Event event = dummyEventListener.popEvent();
+    Event event = dummyEventListener.popPostEvent();
     Assertions.assertEquals(identifier, event.identifier());
     Assertions.assertEquals(LoadTableEvent.class, event.getClass());
     TableInfo tableInfo = ((LoadTableEvent) event).loadedTableInfo();
@@ -107,7 +107,7 @@ public class TestTableEvent {
     NameIdentifier identifier = NameIdentifier.of("metalake", "catalog", table.name());
     TableChange change = TableChange.setProperty("a", "b");
     dispatcher.alterTable(identifier, change);
-    Event event = dummyEventListener.popEvent();
+    Event event = dummyEventListener.popPostEvent();
     Assertions.assertEquals(identifier, event.identifier());
     Assertions.assertEquals(AlterTableEvent.class, event.getClass());
     TableInfo tableInfo = ((AlterTableEvent) event).updatedTableInfo();
@@ -120,7 +120,7 @@ public class TestTableEvent {
   void testDropTableEvent() {
     NameIdentifier identifier = NameIdentifier.of("metalake", "catalog", table.name());
     dispatcher.dropTable(identifier);
-    Event event = dummyEventListener.popEvent();
+    Event event = dummyEventListener.popPostEvent();
     Assertions.assertEquals(identifier, event.identifier());
     Assertions.assertEquals(DropTableEvent.class, event.getClass());
     Assertions.assertEquals(true, ((DropTableEvent) event).isExists());
@@ -130,7 +130,7 @@ public class TestTableEvent {
   void testPurgeTableEvent() {
     NameIdentifier identifier = NameIdentifier.of("metalake", "catalog", table.name());
     dispatcher.purgeTable(identifier);
-    Event event = dummyEventListener.popEvent();
+    Event event = dummyEventListener.popPostEvent();
     Assertions.assertEquals(identifier, event.identifier());
     Assertions.assertEquals(PurgeTableEvent.class, event.getClass());
     Assertions.assertEquals(true, ((PurgeTableEvent) event).isExists());
@@ -140,7 +140,7 @@ public class TestTableEvent {
   void testListTableEvent() {
     Namespace namespace = Namespace.of("metalake", "catalog");
     dispatcher.listTables(namespace);
-    Event event = dummyEventListener.popEvent();
+    Event event = dummyEventListener.popPostEvent();
     Assertions.assertEquals(namespace.toString(), event.identifier().toString());
     Assertions.assertEquals(ListTableEvent.class, event.getClass());
     Assertions.assertEquals(namespace, ((ListTableEvent) event).namespace());
@@ -161,7 +161,7 @@ public class TestTableEvent {
                 table.distribution(),
                 table.sortOrder(),
                 table.index()));
-    Event event = dummyEventListener.popEvent();
+    Event event = dummyEventListener.popPostEvent();
     Assertions.assertEquals(identifier, event.identifier());
     Assertions.assertEquals(CreateTableFailureEvent.class, event.getClass());
     Assertions.assertEquals(
@@ -174,7 +174,7 @@ public class TestTableEvent {
     NameIdentifier identifier = NameIdentifier.of("metalake", "table", table.name());
     Assertions.assertThrowsExactly(
         GravitinoRuntimeException.class, () -> failureDispatcher.loadTable(identifier));
-    Event event = dummyEventListener.popEvent();
+    Event event = dummyEventListener.popPostEvent();
     Assertions.assertEquals(identifier, event.identifier());
     Assertions.assertEquals(LoadTableFailureEvent.class, event.getClass());
     Assertions.assertEquals(
@@ -187,7 +187,7 @@ public class TestTableEvent {
     TableChange change = TableChange.setProperty("a", "b");
     Assertions.assertThrowsExactly(
         GravitinoRuntimeException.class, () -> failureDispatcher.alterTable(identifier, change));
-    Event event = dummyEventListener.popEvent();
+    Event event = dummyEventListener.popPostEvent();
     Assertions.assertEquals(identifier, event.identifier());
     Assertions.assertEquals(AlterTableFailureEvent.class, event.getClass());
     Assertions.assertEquals(
@@ -201,7 +201,7 @@ public class TestTableEvent {
     NameIdentifier identifier = NameIdentifier.of("metalake", "table", table.name());
     Assertions.assertThrowsExactly(
         GravitinoRuntimeException.class, () -> failureDispatcher.dropTable(identifier));
-    Event event = dummyEventListener.popEvent();
+    Event event = dummyEventListener.popPostEvent();
     Assertions.assertEquals(identifier, event.identifier());
     Assertions.assertEquals(DropTableFailureEvent.class, event.getClass());
     Assertions.assertEquals(
@@ -213,7 +213,7 @@ public class TestTableEvent {
     NameIdentifier identifier = NameIdentifier.of("metalake", "table", table.name());
     Assertions.assertThrowsExactly(
         GravitinoRuntimeException.class, () -> failureDispatcher.purgeTable(identifier));
-    Event event = dummyEventListener.popEvent();
+    Event event = dummyEventListener.popPostEvent();
     Assertions.assertEquals(identifier, event.identifier());
     Assertions.assertEquals(PurgeTableFailureEvent.class, event.getClass());
     Assertions.assertEquals(
@@ -225,7 +225,7 @@ public class TestTableEvent {
     Namespace namespace = Namespace.of("metalake", "catalog");
     Assertions.assertThrowsExactly(
         GravitinoRuntimeException.class, () -> failureDispatcher.listTables(namespace));
-    Event event = dummyEventListener.popEvent();
+    Event event = dummyEventListener.popPostEvent();
     Assertions.assertEquals(namespace.toString(), event.identifier().toString());
     Assertions.assertEquals(ListTableFailureEvent.class, event.getClass());
     Assertions.assertEquals(

--- a/core/src/test/java/org/apache/gravitino/listener/api/event/TestTopicEvent.java
+++ b/core/src/test/java/org/apache/gravitino/listener/api/event/TestTopicEvent.java
@@ -65,7 +65,7 @@ public class TestTopicEvent {
   void testCreateTopicEvent() {
     NameIdentifier identifier = NameIdentifier.of("metalake", "catalog", "topic");
     dispatcher.createTopic(identifier, topic.comment(), null, topic.properties());
-    Event event = dummyEventListener.popEvent();
+    Event event = dummyEventListener.popPostEvent();
     Assertions.assertEquals(identifier, event.identifier());
     Assertions.assertEquals(CreateTopicEvent.class, event.getClass());
     TopicInfo topicInfo = ((CreateTopicEvent) event).createdTopicInfo();
@@ -76,7 +76,7 @@ public class TestTopicEvent {
   void testLoadTopicEvent() {
     NameIdentifier identifier = NameIdentifier.of("metalake", "catalog", "topic");
     dispatcher.loadTopic(identifier);
-    Event event = dummyEventListener.popEvent();
+    Event event = dummyEventListener.popPostEvent();
     Assertions.assertEquals(identifier, event.identifier());
     Assertions.assertEquals(LoadTopicEvent.class, event.getClass());
     TopicInfo topicInfo = ((LoadTopicEvent) event).loadedTopicInfo();
@@ -88,7 +88,7 @@ public class TestTopicEvent {
     NameIdentifier identifier = NameIdentifier.of("metalake", "catalog", "topic");
     TopicChange topicChange = TopicChange.setProperty("a", "b");
     dispatcher.alterTopic(identifier, topicChange);
-    Event event = dummyEventListener.popEvent();
+    Event event = dummyEventListener.popPostEvent();
     Assertions.assertEquals(identifier, event.identifier());
     Assertions.assertEquals(AlterTopicEvent.class, event.getClass());
     TopicInfo topicInfo = ((AlterTopicEvent) event).updatedTopicInfo();
@@ -101,7 +101,7 @@ public class TestTopicEvent {
   void testDropTopicEvent() {
     NameIdentifier identifier = NameIdentifier.of("metalake", "catalog", "topic");
     dispatcher.dropTopic(identifier);
-    Event event = dummyEventListener.popEvent();
+    Event event = dummyEventListener.popPostEvent();
     Assertions.assertEquals(identifier, event.identifier());
     Assertions.assertEquals(DropTopicEvent.class, event.getClass());
     Assertions.assertEquals(true, ((DropTopicEvent) event).isExists());
@@ -111,7 +111,7 @@ public class TestTopicEvent {
   void testListTopicEvent() {
     Namespace namespace = Namespace.of("metalake", "catalog");
     dispatcher.listTopics(namespace);
-    Event event = dummyEventListener.popEvent();
+    Event event = dummyEventListener.popPostEvent();
     Assertions.assertEquals(namespace.toString(), event.identifier().toString());
     Assertions.assertEquals(ListTopicEvent.class, event.getClass());
     Assertions.assertEquals(namespace, ((ListTopicEvent) event).namespace());
@@ -123,7 +123,7 @@ public class TestTopicEvent {
     Assertions.assertThrowsExactly(
         GravitinoRuntimeException.class,
         () -> failureDispatcher.createTopic(identifier, topic.comment(), null, topic.properties()));
-    Event event = dummyEventListener.popEvent();
+    Event event = dummyEventListener.popPostEvent();
     Assertions.assertEquals(identifier, event.identifier());
     Assertions.assertEquals(CreateTopicFailureEvent.class, event.getClass());
     Assertions.assertEquals(
@@ -136,7 +136,7 @@ public class TestTopicEvent {
     NameIdentifier identifier = NameIdentifier.of("metalake", "catalog", "topic");
     Assertions.assertThrowsExactly(
         GravitinoRuntimeException.class, () -> failureDispatcher.loadTopic(identifier));
-    Event event = dummyEventListener.popEvent();
+    Event event = dummyEventListener.popPostEvent();
     Assertions.assertEquals(identifier, event.identifier());
     Assertions.assertEquals(LoadTopicFailureEvent.class, event.getClass());
     Assertions.assertEquals(
@@ -150,7 +150,7 @@ public class TestTopicEvent {
     Assertions.assertThrowsExactly(
         GravitinoRuntimeException.class,
         () -> failureDispatcher.alterTopic(identifier, topicChange));
-    Event event = dummyEventListener.popEvent();
+    Event event = dummyEventListener.popPostEvent();
     Assertions.assertEquals(identifier, event.identifier());
     Assertions.assertEquals(AlterTopicFailureEvent.class, event.getClass());
     Assertions.assertEquals(
@@ -164,7 +164,7 @@ public class TestTopicEvent {
     NameIdentifier identifier = NameIdentifier.of("metalake", "catalog", "topic");
     Assertions.assertThrowsExactly(
         GravitinoRuntimeException.class, () -> failureDispatcher.dropTopic(identifier));
-    Event event = dummyEventListener.popEvent();
+    Event event = dummyEventListener.popPostEvent();
     Assertions.assertEquals(identifier, event.identifier());
     Assertions.assertEquals(DropTopicFailureEvent.class, event.getClass());
     Assertions.assertEquals(
@@ -176,7 +176,7 @@ public class TestTopicEvent {
     Namespace namespace = Namespace.of("metalake", "catalog");
     Assertions.assertThrowsExactly(
         GravitinoRuntimeException.class, () -> failureDispatcher.listTopics(namespace));
-    Event event = dummyEventListener.popEvent();
+    Event event = dummyEventListener.popPostEvent();
     Assertions.assertEquals(namespace.toString(), event.identifier().toString());
     Assertions.assertEquals(ListTopicFailureEvent.class, event.getClass());
     Assertions.assertEquals(


### PR DESCRIPTION
### What changes were proposed in this pull request?
support pre event for event listener systems
1. add  new `PreEvent` to represent Pre event and only `SYNC` event listeners could process `PreEvent`
2. keep `Event` as post event to keep compatibility.
3. `EventBus` dispatch event to corresponding event listeners.

### Why are the changes needed?
Fix: #5112 

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
add UT