### PR TITLE
Blank comment is allowed for metalake and catalog updating.

### DIFF
--- a/common/src/main/java/org/apache/gravitino/dto/requests/CatalogUpdateRequest.java
+++ b/common/src/main/java/org/apache/gravitino/dto/requests/CatalogUpdateRequest.java
@@ -124,9 +124,7 @@ public interface CatalogUpdateRequest extends RESTRequest {
      */
     @Override
     public void validate() throws IllegalArgumentException {
-      Preconditions.checkArgument(
-          StringUtils.isNotBlank(newComment),
-          "\"newComment\" field is required and cannot be empty");
+      return;
     }
 
     @Override

--- a/common/src/main/java/org/apache/gravitino/dto/requests/MetalakeUpdateRequest.java
+++ b/common/src/main/java/org/apache/gravitino/dto/requests/MetalakeUpdateRequest.java
@@ -124,9 +124,7 @@ public interface MetalakeUpdateRequest extends RESTRequest {
      */
     @Override
     public void validate() throws IllegalArgumentException {
-      Preconditions.checkArgument(
-          StringUtils.isNotBlank(newComment),
-          "\"newComment\" field is required and cannot be empty");
+      return;
     }
 
     @Override


### PR DESCRIPTION

### What changes were proposed in this pull request?

We should keep the same behavior for metalake & catalog updating with creating to allow blank comment input.

### Why are the changes needed?

(Please clarify why the changes are needed. For instance,

Fix: #4921

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

1. In Gravitino UI select one metalake or catalog to do update operation, you can input blank comment and save succeed.
2. Using /api/metalakes or /api/catalogs API call to do metalake or catalog update operation, you can input "newComment":"" in request data area and the succeed response return. 
