### PR TITLE
[#5154] refactor(drop-metalake): re-define drop metalake

### DIFF
--- a/api/src/main/java/org/apache/gravitino/Metalake.java
+++ b/api/src/main/java/org/apache/gravitino/Metalake.java
@@ -29,6 +29,9 @@ import org.apache.gravitino.authorization.SupportsRoles;
 @Evolving
 public interface Metalake extends Auditable {
 
+  /** The property indicating the metalake is in use. */
+  String PROPERTY_IN_USE = "in-use";
+
   /**
    * The name of the metalake.
    *

--- a/api/src/main/java/org/apache/gravitino/SupportsMetalakes.java
+++ b/api/src/main/java/org/apache/gravitino/SupportsMetalakes.java
@@ -21,7 +21,10 @@ package org.apache.gravitino;
 import java.util.Map;
 import org.apache.gravitino.annotation.Evolving;
 import org.apache.gravitino.exceptions.MetalakeAlreadyExistsException;
+import org.apache.gravitino.exceptions.MetalakeInUseException;
+import org.apache.gravitino.exceptions.MetalakeNotInUseException;
 import org.apache.gravitino.exceptions.NoSuchMetalakeException;
+import org.apache.gravitino.exceptions.NonEmptyEntityException;
 
 /**
  * Client interface for supporting metalakes. It includes methods for listing, loading, creating,
@@ -38,7 +41,7 @@ public interface SupportsMetalakes {
   Metalake[] listMetalakes();
 
   /**
-   * Load a metalake by its identifier.
+   * Load a metalake by its name.
    *
    * @param name the name of the metalake.
    * @return The metalake.
@@ -62,7 +65,7 @@ public interface SupportsMetalakes {
   }
 
   /**
-   * Create a metalake with specified identifier.
+   * Create a metalake with specified name, comment and properties.
    *
    * @param name The name of the metalake.
    * @param comment The comment of the metalake.
@@ -74,7 +77,7 @@ public interface SupportsMetalakes {
       throws MetalakeAlreadyExistsException;
 
   /**
-   * Alter a metalake with specified identifier.
+   * Alter a metalake with specified metalake name and changes.
    *
    * @param name The name of the metalake.
    * @param changes The changes to apply.
@@ -86,10 +89,69 @@ public interface SupportsMetalakes {
       throws NoSuchMetalakeException, IllegalArgumentException;
 
   /**
-   * Drop a metalake with specified identifier.
+   * Drop a metalake with specified name. Please make sure:
    *
-   * @param name The identifier of the metalake.
+   * <ul>
+   *   <li>There is no catalog in the metalake. Otherwise, a {@link NonEmptyEntityException} will be
+   *       thrown.
+   *   <li>The method {@link #disableMetalake(String)} has been called before dropping the metalake.
+   *       Otherwise, a {@link MetalakeInUseException} will be thrown.
+   * </ul>
+   *
+   * It is equivalent to calling {@code dropMetalake(ident, false)}.
+   *
+   * @param name The name of the metalake.
    * @return True if the metalake was dropped, false if the metalake does not exist.
+   * @throws NonEmptyEntityException If the metalake is not empty.
+   * @throws MetalakeInUseException If the metalake is in use.
    */
-  boolean dropMetalake(String name);
+  default boolean dropMetalake(String name) throws NonEmptyEntityException, MetalakeInUseException {
+    return dropMetalake(name, false);
+  }
+
+  /**
+   * Drop a metalake with specified name. If the force flag is true, it will:
+   *
+   * <ul>
+   *   <li>Cascade drop all sub-entities (tags, catalogs, schemas, tables, etc.) of the metalake in
+   *       Gravitino store.
+   *   <li>Drop the metalake even if it is in use.
+   *   <li>External resources (e.g. database, table, etc.) associated with sub-entities will not be
+   *       deleted unless it is managed (such as managed fileset).
+   * </ul>
+   *
+   * If the force flag is false, it is equivalent to calling {@link #dropMetalake(String)}.
+   *
+   * @param name The name of the metalake.
+   * @param force Whether to force the drop.
+   * @return True if the metalake was dropped, false if the metalake does not exist.
+   * @throws NonEmptyEntityException If the metalake is not empty and force is false.
+   * @throws MetalakeInUseException If the metalake is in use and force is false.
+   */
+  boolean dropMetalake(String name, boolean force)
+      throws NonEmptyEntityException, MetalakeInUseException;
+
+  /**
+   * Enable a metalake. If the metalake is already in use, this method does nothing.
+   *
+   * @param name The name of the metalake.
+   * @throws NoSuchMetalakeException If the metalake does not exist.
+   */
+  void enableMetalake(String name) throws NoSuchMetalakeException;
+
+  /**
+   * Disable a metalake. If the metalake is already disabled, this method does nothing. Once a
+   * metalake is disable:
+   *
+   * <ul>
+   *   <li>It can only be listed, loaded, dropped, or enable.
+   *   <li>Any other operations on the metalake will throw an {@link MetalakeNotInUseException}.
+   *   <li>Any operation on the sub-entities (catalogs, schemas, tables, etc.) will throw an {@link
+   *       MetalakeNotInUseException}.
+   * </ul>
+   *
+   * @param name The name of the metalake.
+   * @throws NoSuchMetalakeException If the metalake does not exist.
+   */
+  void disableMetalake(String name) throws NoSuchMetalakeException;
 }

--- a/api/src/main/java/org/apache/gravitino/SupportsMetalakes.java
+++ b/api/src/main/java/org/apache/gravitino/SupportsMetalakes.java
@@ -98,7 +98,7 @@ public interface SupportsMetalakes {
    *       Otherwise, a {@link MetalakeInUseException} will be thrown.
    * </ul>
    *
-   * It is equivalent to calling {@code dropMetalake(ident, false)}.
+   * It is equivalent to calling {@code dropMetalake(name, false)}.
    *
    * @param name The name of the metalake.
    * @return True if the metalake was dropped, false if the metalake does not exist.

--- a/api/src/main/java/org/apache/gravitino/exceptions/MetalakeInUseException.java
+++ b/api/src/main/java/org/apache/gravitino/exceptions/MetalakeInUseException.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.exceptions;
+
+import com.google.errorprone.annotations.FormatMethod;
+import com.google.errorprone.annotations.FormatString;
+
+/** Exception thrown when a metalake is in use and cannot be deleted. */
+public class MetalakeInUseException extends InUseException {
+  /**
+   * Constructs a new exception with the specified detail message.
+   *
+   * @param message the detail message.
+   * @param args the arguments to the message.
+   */
+  @FormatMethod
+  public MetalakeInUseException(@FormatString String message, Object... args) {
+    super(message, args);
+  }
+}

--- a/api/src/main/java/org/apache/gravitino/exceptions/MetalakeNotInUseException.java
+++ b/api/src/main/java/org/apache/gravitino/exceptions/MetalakeNotInUseException.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.exceptions;
+
+import com.google.errorprone.annotations.FormatMethod;
+import com.google.errorprone.annotations.FormatString;
+
+/** An exception thrown when operating on a metalake that is not in use. */
+public class MetalakeNotInUseException extends NotInUseException {
+  /**
+   * Constructs a new exception with the specified detail message.
+   *
+   * @param message the detail message.
+   * @param args the arguments to the message.
+   */
+  @FormatMethod
+  public MetalakeNotInUseException(@FormatString String message, Object... args) {
+    super(message, args);
+  }
+}

--- a/authorizations/authorization-ranger/src/test/java/org/apache/gravitino/authorization/ranger/integration/test/RangerHiveE2EIT.java
+++ b/authorizations/authorization-ranger/src/test/java/org/apache/gravitino/authorization/ranger/integration/test/RangerHiveE2EIT.java
@@ -191,6 +191,7 @@ public class RangerHiveE2EIT extends BaseIT {
               }));
       Arrays.stream(metalake.listCatalogs())
           .forEach((catalogName -> metalake.dropCatalog(catalogName, true)));
+      client.disableMetalake(metalakeName);
       client.dropMetalake(metalakeName);
     }
     if (sparkSession != null) {
@@ -269,10 +270,9 @@ public class RangerHiveE2EIT extends BaseIT {
     GravitinoMetalake[] gravitinoMetalakes = client.listMetalakes();
     Assertions.assertEquals(0, gravitinoMetalakes.length);
 
-    GravitinoMetalake createdMetalake =
-        client.createMetalake(metalakeName, "comment", Collections.emptyMap());
+    client.createMetalake(metalakeName, "comment", Collections.emptyMap());
     GravitinoMetalake loadMetalake = client.loadMetalake(metalakeName);
-    Assertions.assertEquals(createdMetalake, loadMetalake);
+    Assertions.assertEquals(metalakeName, loadMetalake.name());
 
     metalake = loadMetalake;
   }

--- a/catalogs/catalog-hadoop/src/test/java/org/apache/gravitino/catalog/hadoop/integration/test/HadoopCatalogIT.java
+++ b/catalogs/catalog-hadoop/src/test/java/org/apache/gravitino/catalog/hadoop/integration/test/HadoopCatalogIT.java
@@ -88,7 +88,7 @@ public class HadoopCatalogIT extends BaseIT {
     Catalog catalog = metalake.loadCatalog(catalogName);
     catalog.asSchemas().dropSchema(schemaName, true);
     metalake.dropCatalog(catalogName, true);
-    client.dropMetalake(metalakeName);
+    client.dropMetalake(metalakeName, true);
     if (fileSystem != null) {
       fileSystem.close();
     }
@@ -104,10 +104,9 @@ public class HadoopCatalogIT extends BaseIT {
     GravitinoMetalake[] gravitinoMetalakes = client.listMetalakes();
     Assertions.assertEquals(0, gravitinoMetalakes.length);
 
-    GravitinoMetalake createdMetalake =
-        client.createMetalake(metalakeName, "comment", Collections.emptyMap());
+    client.createMetalake(metalakeName, "comment", Collections.emptyMap());
     GravitinoMetalake loadMetalake = client.loadMetalake(metalakeName);
-    Assertions.assertEquals(createdMetalake, loadMetalake);
+    Assertions.assertEquals(metalakeName, loadMetalake.name());
 
     metalake = loadMetalake;
   }

--- a/catalogs/catalog-hadoop/src/test/java/org/apache/gravitino/catalog/hadoop/integration/test/HadoopUserAuthenticationIT.java
+++ b/catalogs/catalog-hadoop/src/test/java/org/apache/gravitino/catalog/hadoop/integration/test/HadoopUserAuthenticationIT.java
@@ -654,6 +654,6 @@ public class HadoopUserAuthenticationIT extends BaseIT {
     catalog.asFilesetCatalog().dropFileset(NameIdentifier.of(SCHEMA_NAME, filesetName));
     catalog.asSchemas().dropSchema(SCHEMA_NAME, true);
     gravitinoMetalake.dropCatalog(catalogName, true);
-    adminClient.dropMetalake(metalakeName);
+    adminClient.dropMetalake(metalakeName, true);
   }
 }

--- a/catalogs/catalog-hadoop/src/test/java/org/apache/gravitino/catalog/hadoop/integration/test/HadoopUserImpersonationIT.java
+++ b/catalogs/catalog-hadoop/src/test/java/org/apache/gravitino/catalog/hadoop/integration/test/HadoopUserImpersonationIT.java
@@ -258,10 +258,9 @@ public class HadoopUserImpersonationIT extends BaseIT {
     GravitinoMetalake[] gravitinoMetalakes = client.listMetalakes();
     Assertions.assertEquals(0, gravitinoMetalakes.length);
 
-    GravitinoMetalake createdMetalake =
-        client.createMetalake(metalakeName, "comment", Collections.emptyMap());
+    client.createMetalake(metalakeName, "comment", Collections.emptyMap());
     GravitinoMetalake loadMetalake = client.loadMetalake(metalakeName);
-    Assertions.assertEquals(createdMetalake, loadMetalake);
+    Assertions.assertEquals(metalakeName, loadMetalake.name());
 
     metalake = loadMetalake;
   }

--- a/catalogs/catalog-hive/src/test/java/org/apache/gravitino/catalog/hive/integration/test/CatalogHiveIT.java
+++ b/catalogs/catalog-hive/src/test/java/org/apache/gravitino/catalog/hive/integration/test/CatalogHiveIT.java
@@ -229,7 +229,7 @@ public class CatalogHiveIT extends BaseIT {
               }));
       Arrays.stream(metalake.listCatalogs())
           .forEach((catalogName -> metalake.dropCatalog(catalogName, true)));
-      client.dropMetalake(metalakeName);
+      client.dropMetalake(metalakeName, true);
     }
     if (hiveClientPool != null) {
       hiveClientPool.close();
@@ -264,10 +264,9 @@ public class CatalogHiveIT extends BaseIT {
     GravitinoMetalake[] gravitinoMetalakes = client.listMetalakes();
     Assertions.assertEquals(0, gravitinoMetalakes.length);
 
-    GravitinoMetalake createdMetalake =
-        client.createMetalake(metalakeName, "comment", Collections.emptyMap());
+    client.createMetalake(metalakeName, "comment", Collections.emptyMap());
     GravitinoMetalake loadMetalake = client.loadMetalake(metalakeName);
-    Assertions.assertEquals(createdMetalake, loadMetalake);
+    Assertions.assertEquals(metalakeName, loadMetalake.name());
 
     metalake = loadMetalake;
   }
@@ -1429,8 +1428,8 @@ public class CatalogHiveIT extends BaseIT {
     client.createMetalake(metalakeName1, "comment", Collections.emptyMap());
     client.createMetalake(metalakeName2, "comment", Collections.emptyMap());
 
-    client.dropMetalake(metalakeName1);
-    client.dropMetalake(metalakeName2);
+    client.dropMetalake(metalakeName1, true);
+    client.dropMetalake(metalakeName2, true);
 
     client.createMetalake(metalakeName1, "comment", Collections.emptyMap());
 

--- a/catalogs/catalog-hive/src/test/java/org/apache/gravitino/catalog/hive/integration/test/ProxyCatalogHiveIT.java
+++ b/catalogs/catalog-hive/src/test/java/org/apache/gravitino/catalog/hive/integration/test/ProxyCatalogHiveIT.java
@@ -389,10 +389,9 @@ public class ProxyCatalogHiveIT extends BaseIT {
     GravitinoMetalake[] gravitinoMetalakes = client.listMetalakes();
     Assertions.assertEquals(0, gravitinoMetalakes.length);
 
-    GravitinoMetalake createdMetalake =
-        client.createMetalake(METALAKE_NAME, "comment", Collections.emptyMap());
+    client.createMetalake(METALAKE_NAME, "comment", Collections.emptyMap());
     GravitinoMetalake loadMetalake = client.loadMetalake(METALAKE_NAME);
-    Assertions.assertEquals(createdMetalake, loadMetalake);
+    Assertions.assertEquals(METALAKE_NAME, loadMetalake.name());
 
     metalake = loadMetalake;
   }

--- a/catalogs/catalog-jdbc-doris/src/test/java/org/apache/gravitino/catalog/doris/integration/test/CatalogDorisIT.java
+++ b/catalogs/catalog-jdbc-doris/src/test/java/org/apache/gravitino/catalog/doris/integration/test/CatalogDorisIT.java
@@ -126,7 +126,7 @@ public class CatalogDorisIT extends BaseIT {
   public void stop() {
     clearTableAndSchema();
     metalake.dropCatalog(catalogName, true);
-    client.dropMetalake(metalakeName);
+    client.dropMetalake(metalakeName, true);
   }
 
   @AfterEach
@@ -143,10 +143,9 @@ public class CatalogDorisIT extends BaseIT {
     GravitinoMetalake[] gravitinoMetaLakes = client.listMetalakes();
     assertEquals(0, gravitinoMetaLakes.length);
 
-    GravitinoMetalake createdMetalake =
-        client.createMetalake(metalakeName, "comment", Collections.emptyMap());
+    client.createMetalake(metalakeName, "comment", Collections.emptyMap());
     GravitinoMetalake loadMetalake = client.loadMetalake(metalakeName);
-    assertEquals(createdMetalake, loadMetalake);
+    assertEquals(metalakeName, loadMetalake.name());
 
     metalake = loadMetalake;
   }

--- a/catalogs/catalog-jdbc-mysql/src/test/java/org/apache/gravitino/catalog/mysql/integration/test/AuditCatalogMysqlIT.java
+++ b/catalogs/catalog-jdbc-mysql/src/test/java/org/apache/gravitino/catalog/mysql/integration/test/AuditCatalogMysqlIT.java
@@ -77,7 +77,7 @@ public class AuditCatalogMysqlIT extends BaseIT {
 
   @AfterAll
   public void stopIntegrationTest() throws IOException, InterruptedException {
-    client.dropMetalake(metalakeName);
+    client.dropMetalake(metalakeName, true);
     mysqlService.close();
     super.stopIntegrationTest();
   }
@@ -169,10 +169,9 @@ public class AuditCatalogMysqlIT extends BaseIT {
     GravitinoMetalake[] gravitinoMetalakes = client.listMetalakes();
     Assertions.assertEquals(0, gravitinoMetalakes.length);
 
-    GravitinoMetalake createdMetalake =
-        client.createMetalake(metalakeName, "comment", Collections.emptyMap());
+    client.createMetalake(metalakeName, "comment", Collections.emptyMap());
     GravitinoMetalake loadMetalake = client.loadMetalake(metalakeName);
-    Assertions.assertEquals(createdMetalake, loadMetalake);
+    Assertions.assertEquals(metalakeName, loadMetalake.name());
     metalake = loadMetalake;
   }
 }

--- a/catalogs/catalog-jdbc-mysql/src/test/java/org/apache/gravitino/catalog/mysql/integration/test/CatalogMysqlIT.java
+++ b/catalogs/catalog-jdbc-mysql/src/test/java/org/apache/gravitino/catalog/mysql/integration/test/CatalogMysqlIT.java
@@ -144,6 +144,7 @@ public class CatalogMysqlIT extends BaseIT {
     clearTableAndSchema();
     metalake.disableCatalog(catalogName);
     metalake.dropCatalog(catalogName);
+    client.disableMetalake(metalakeName);
     client.dropMetalake(metalakeName);
     mysqlService.close();
   }
@@ -167,10 +168,9 @@ public class CatalogMysqlIT extends BaseIT {
     GravitinoMetalake[] gravitinoMetalakes = client.listMetalakes();
     Assertions.assertEquals(0, gravitinoMetalakes.length);
 
-    GravitinoMetalake createdMetalake =
-        client.createMetalake(metalakeName, "comment", Collections.emptyMap());
+    client.createMetalake(metalakeName, "comment", Collections.emptyMap());
     GravitinoMetalake loadMetalake = client.loadMetalake(metalakeName);
-    Assertions.assertEquals(createdMetalake, loadMetalake);
+    Assertions.assertEquals(metalakeName, loadMetalake.name());
 
     metalake = loadMetalake;
   }

--- a/catalogs/catalog-jdbc-postgresql/src/test/java/org/apache/gravitino/catalog/postgresql/integration/test/CatalogPostgreSqlIT.java
+++ b/catalogs/catalog-jdbc-postgresql/src/test/java/org/apache/gravitino/catalog/postgresql/integration/test/CatalogPostgreSqlIT.java
@@ -130,6 +130,7 @@ public class CatalogPostgreSqlIT extends BaseIT {
     }
     metalake.disableCatalog(catalogName);
     metalake.dropCatalog(catalogName);
+    client.disableMetalake(metalakeName);
     client.dropMetalake(metalakeName);
     postgreSqlService.close();
   }
@@ -153,10 +154,9 @@ public class CatalogPostgreSqlIT extends BaseIT {
     GravitinoMetalake[] gravitinoMetalakes = client.listMetalakes();
     Assertions.assertEquals(0, gravitinoMetalakes.length);
 
-    GravitinoMetalake createdMetalake =
-        client.createMetalake(metalakeName, "comment", Collections.emptyMap());
+    client.createMetalake(metalakeName, "comment", Collections.emptyMap());
     GravitinoMetalake loadMetalake = client.loadMetalake(metalakeName);
-    Assertions.assertEquals(createdMetalake, loadMetalake);
+    Assertions.assertEquals(metalakeName, loadMetalake.name());
 
     metalake = loadMetalake;
   }

--- a/catalogs/catalog-kafka/src/test/java/org/apache/gravitino/catalog/kafka/integration/test/CatalogKafkaIT.java
+++ b/catalogs/catalog-kafka/src/test/java/org/apache/gravitino/catalog/kafka/integration/test/CatalogKafkaIT.java
@@ -126,6 +126,7 @@ public class CatalogKafkaIT extends BaseIT {
               metalake.disableCatalog(catalogName);
               metalake.dropCatalog(catalogName);
             }));
+    client.disableMetalake(METALAKE_NAME);
     client.dropMetalake(METALAKE_NAME);
     if (adminClient != null) {
       adminClient.close();
@@ -554,10 +555,9 @@ public class CatalogKafkaIT extends BaseIT {
   }
 
   private void createMetalake() {
-    GravitinoMetalake createdMetalake =
-        client.createMetalake(METALAKE_NAME, "comment", Collections.emptyMap());
+    client.createMetalake(METALAKE_NAME, "comment", Collections.emptyMap());
     GravitinoMetalake loadMetalake = client.loadMetalake(METALAKE_NAME);
-    Assertions.assertEquals(createdMetalake, loadMetalake);
+    Assertions.assertEquals(METALAKE_NAME, loadMetalake.name());
 
     metalake = loadMetalake;
   }

--- a/catalogs/catalog-lakehouse-iceberg/src/test/java/org/apache/gravitino/catalog/lakehouse/iceberg/integration/test/CatalogIcebergBaseIT.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/test/java/org/apache/gravitino/catalog/lakehouse/iceberg/integration/test/CatalogIcebergBaseIT.java
@@ -140,6 +140,7 @@ public abstract class CatalogIcebergBaseIT extends BaseIT {
       clearTableAndSchema();
       metalake.disableCatalog(catalogName);
       metalake.dropCatalog(catalogName);
+      client.disableMetalake(metalakeName);
       client.dropMetalake(metalakeName);
     } finally {
       if (spark != null) {
@@ -197,10 +198,9 @@ public abstract class CatalogIcebergBaseIT extends BaseIT {
     GravitinoMetalake[] gravitinoMetalakes = client.listMetalakes();
     Assertions.assertEquals(0, gravitinoMetalakes.length);
 
-    GravitinoMetalake createdMetalake =
-        client.createMetalake(metalakeName, "comment", Collections.emptyMap());
+    client.createMetalake(metalakeName, "comment", Collections.emptyMap());
     GravitinoMetalake loadMetalake = client.loadMetalake(metalakeName);
-    Assertions.assertEquals(createdMetalake, loadMetalake);
+    Assertions.assertEquals(metalakeName, loadMetalake.name());
 
     metalake = loadMetalake;
   }

--- a/catalogs/catalog-lakehouse-paimon/src/test/java/org/apache/gravitino/catalog/lakehouse/paimon/integration/test/CatalogPaimonBaseIT.java
+++ b/catalogs/catalog-lakehouse-paimon/src/test/java/org/apache/gravitino/catalog/lakehouse/paimon/integration/test/CatalogPaimonBaseIT.java
@@ -138,6 +138,7 @@ public abstract class CatalogPaimonBaseIT extends BaseIT {
     clearTableAndSchema();
     metalake.disableCatalog(catalogName);
     metalake.dropCatalog(catalogName);
+    client.disableMetalake(metalakeName);
     client.dropMetalake(metalakeName);
     if (spark != null) {
       spark.close();
@@ -878,10 +879,9 @@ public abstract class CatalogPaimonBaseIT extends BaseIT {
   }
 
   private void createMetalake() {
-    GravitinoMetalake createdMetalake =
-        client.createMetalake(metalakeName, "comment", Collections.emptyMap());
+    client.createMetalake(metalakeName, "comment", Collections.emptyMap());
     GravitinoMetalake loadMetalake = client.loadMetalake(metalakeName);
-    Assertions.assertEquals(createdMetalake, loadMetalake);
+    Assertions.assertEquals(metalakeName, loadMetalake.name());
 
     metalake = loadMetalake;
   }

--- a/clients/client-java/src/main/java/org/apache/gravitino/client/ErrorHandlers.java
+++ b/clients/client-java/src/main/java/org/apache/gravitino/client/ErrorHandlers.java
@@ -37,6 +37,8 @@ import org.apache.gravitino.exceptions.GroupAlreadyExistsException;
 import org.apache.gravitino.exceptions.IllegalPrivilegeException;
 import org.apache.gravitino.exceptions.InUseException;
 import org.apache.gravitino.exceptions.MetalakeAlreadyExistsException;
+import org.apache.gravitino.exceptions.MetalakeInUseException;
+import org.apache.gravitino.exceptions.MetalakeNotInUseException;
 import org.apache.gravitino.exceptions.NoSuchCatalogException;
 import org.apache.gravitino.exceptions.NoSuchFilesetException;
 import org.apache.gravitino.exceptions.NoSuchGroupException;
@@ -279,6 +281,11 @@ public class ErrorHandlers {
           if (errorResponse.getType().equals(CatalogNotInUseException.class.getSimpleName())) {
             throw new CatalogNotInUseException(errorMessage);
 
+          } else if (errorResponse
+              .getType()
+              .equals(MetalakeNotInUseException.class.getSimpleName())) {
+            throw new MetalakeNotInUseException(errorMessage);
+
           } else {
             throw new NotInUseException(errorMessage);
           }
@@ -327,6 +334,11 @@ public class ErrorHandlers {
           if (errorResponse.getType().equals(CatalogNotInUseException.class.getSimpleName())) {
             throw new CatalogNotInUseException(errorMessage);
 
+          } else if (errorResponse
+              .getType()
+              .equals(MetalakeNotInUseException.class.getSimpleName())) {
+            throw new MetalakeNotInUseException(errorMessage);
+
           } else {
             throw new NotInUseException(errorMessage);
           }
@@ -374,6 +386,11 @@ public class ErrorHandlers {
         case ErrorConstants.NOT_IN_USE_CODE:
           if (errorResponse.getType().equals(CatalogNotInUseException.class.getSimpleName())) {
             throw new CatalogNotInUseException(errorMessage);
+
+          } else if (errorResponse
+              .getType()
+              .equals(MetalakeNotInUseException.class.getSimpleName())) {
+            throw new MetalakeNotInUseException(errorMessage);
 
           } else {
             throw new NotInUseException(errorMessage);
@@ -426,6 +443,9 @@ public class ErrorHandlers {
           if (errorResponse.getType().equals(CatalogInUseException.class.getSimpleName())) {
             throw new CatalogInUseException(errorMessage);
 
+          } else if (errorResponse.getType().equals(MetalakeInUseException.class.getSimpleName())) {
+            throw new MetalakeInUseException(errorMessage);
+
           } else {
             throw new InUseException(errorMessage);
           }
@@ -433,6 +453,11 @@ public class ErrorHandlers {
         case ErrorConstants.NOT_IN_USE_CODE:
           if (errorResponse.getType().equals(CatalogNotInUseException.class.getSimpleName())) {
             throw new CatalogNotInUseException(errorMessage);
+
+          } else if (errorResponse
+              .getType()
+              .equals(MetalakeNotInUseException.class.getSimpleName())) {
+            throw new MetalakeNotInUseException(errorMessage);
 
           } else {
             throw new NotInUseException(errorMessage);
@@ -465,6 +490,9 @@ public class ErrorHandlers {
 
         case ErrorConstants.INTERNAL_ERROR_CODE:
           throw new RuntimeException(errorMessage);
+
+        case ErrorConstants.IN_USE_CODE:
+          throw new MetalakeInUseException(errorMessage);
 
         default:
           super.accept(errorResponse);
@@ -560,6 +588,11 @@ public class ErrorHandlers {
           if (errorResponse.getType().equals(CatalogNotInUseException.class.getSimpleName())) {
             throw new CatalogNotInUseException(errorMessage);
 
+          } else if (errorResponse
+              .getType()
+              .equals(MetalakeNotInUseException.class.getSimpleName())) {
+            throw new MetalakeNotInUseException(errorMessage);
+
           } else {
             throw new NotInUseException(errorMessage);
           }
@@ -606,6 +639,11 @@ public class ErrorHandlers {
           if (errorResponse.getType().equals(CatalogNotInUseException.class.getSimpleName())) {
             throw new CatalogNotInUseException(errorMessage);
 
+          } else if (errorResponse
+              .getType()
+              .equals(MetalakeNotInUseException.class.getSimpleName())) {
+            throw new MetalakeNotInUseException(errorMessage);
+
           } else {
             throw new NotInUseException(errorMessage);
           }
@@ -645,6 +683,9 @@ public class ErrorHandlers {
         case ErrorConstants.UNSUPPORTED_OPERATION_CODE:
           throw new UnsupportedOperationException(errorMessage);
 
+        case ErrorConstants.NOT_IN_USE_CODE:
+          throw new MetalakeNotInUseException(errorMessage);
+
         case ErrorConstants.INTERNAL_ERROR_CODE:
           throw new RuntimeException(errorMessage);
 
@@ -682,6 +723,9 @@ public class ErrorHandlers {
 
         case ErrorConstants.UNSUPPORTED_OPERATION_CODE:
           throw new UnsupportedOperationException(errorMessage);
+
+        case ErrorConstants.NOT_IN_USE_CODE:
+          throw new MetalakeNotInUseException(errorMessage);
 
         case ErrorConstants.INTERNAL_ERROR_CODE:
           throw new RuntimeException(errorMessage);
@@ -732,6 +776,9 @@ public class ErrorHandlers {
         case ErrorConstants.FORBIDDEN_CODE:
           throw new ForbiddenException(errorMessage);
 
+        case ErrorConstants.NOT_IN_USE_CODE:
+          throw new MetalakeNotInUseException(errorMessage);
+
         case ErrorConstants.INTERNAL_ERROR_CODE:
           throw new RuntimeException(errorMessage);
 
@@ -780,6 +827,9 @@ public class ErrorHandlers {
         case ErrorConstants.UNSUPPORTED_OPERATION_CODE:
           throw new UnsupportedOperationException(errorMessage);
 
+        case ErrorConstants.NOT_IN_USE_CODE:
+          throw new MetalakeNotInUseException(errorMessage);
+
         case ErrorConstants.INTERNAL_ERROR_CODE:
           throw new RuntimeException(errorMessage);
 
@@ -823,6 +873,9 @@ public class ErrorHandlers {
             throw new AlreadyExistsException(errorMessage);
           }
 
+        case ErrorConstants.NOT_IN_USE_CODE:
+          throw new MetalakeNotInUseException(errorMessage);
+
         case ErrorConstants.INTERNAL_ERROR_CODE:
           throw new RuntimeException(errorMessage);
 
@@ -855,6 +908,9 @@ public class ErrorHandlers {
 
         case ErrorConstants.UNSUPPORTED_OPERATION_CODE:
           throw new UnsupportedOperationException(errorMessage);
+
+        case ErrorConstants.NOT_IN_USE_CODE:
+          throw new MetalakeNotInUseException(errorMessage);
 
         case ErrorConstants.INTERNAL_ERROR_CODE:
           throw new RuntimeException(errorMessage);

--- a/clients/client-java/src/main/java/org/apache/gravitino/client/GravitinoAdminClient.java
+++ b/clients/client-java/src/main/java/org/apache/gravitino/client/GravitinoAdminClient.java
@@ -29,6 +29,7 @@ import java.util.stream.Collectors;
 import org.apache.gravitino.MetalakeChange;
 import org.apache.gravitino.SupportsMetalakes;
 import org.apache.gravitino.dto.requests.MetalakeCreateRequest;
+import org.apache.gravitino.dto.requests.MetalakeSetRequest;
 import org.apache.gravitino.dto.requests.MetalakeUpdateRequest;
 import org.apache.gravitino.dto.requests.MetalakeUpdatesRequest;
 import org.apache.gravitino.dto.responses.DropResponse;
@@ -187,9 +188,12 @@ public class GravitinoAdminClient extends GravitinoClientBase implements Support
 
   @Override
   public void enableMetalake(String name) throws NoSuchMetalakeException {
+    MetalakeSetRequest req = new MetalakeSetRequest(true);
+
     ErrorResponse resp =
-        restClient.get(
-            API_METALAKES_IDENTIFIER_PATH + name + "/activate",
+        restClient.patch(
+            API_METALAKES_IDENTIFIER_PATH + name,
+            req,
             ErrorResponse.class,
             Collections.emptyMap(),
             ErrorHandlers.metalakeErrorHandler());
@@ -203,9 +207,12 @@ public class GravitinoAdminClient extends GravitinoClientBase implements Support
 
   @Override
   public void disableMetalake(String name) throws NoSuchMetalakeException {
+    MetalakeSetRequest req = new MetalakeSetRequest(false);
+
     ErrorResponse resp =
-        restClient.get(
-            API_METALAKES_IDENTIFIER_PATH + name + "/deactivate",
+        restClient.patch(
+            API_METALAKES_IDENTIFIER_PATH + name,
+            req,
             ErrorResponse.class,
             Collections.emptyMap(),
             ErrorHandlers.metalakeErrorHandler());

--- a/clients/client-java/src/main/java/org/apache/gravitino/client/GravitinoAdminClient.java
+++ b/clients/client-java/src/main/java/org/apache/gravitino/client/GravitinoAdminClient.java
@@ -22,6 +22,7 @@ package org.apache.gravitino.client;
 import com.google.common.base.Preconditions;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -31,10 +32,13 @@ import org.apache.gravitino.dto.requests.MetalakeCreateRequest;
 import org.apache.gravitino.dto.requests.MetalakeUpdateRequest;
 import org.apache.gravitino.dto.requests.MetalakeUpdatesRequest;
 import org.apache.gravitino.dto.responses.DropResponse;
+import org.apache.gravitino.dto.responses.ErrorResponse;
 import org.apache.gravitino.dto.responses.MetalakeListResponse;
 import org.apache.gravitino.dto.responses.MetalakeResponse;
 import org.apache.gravitino.exceptions.MetalakeAlreadyExistsException;
+import org.apache.gravitino.exceptions.MetalakeInUseException;
 import org.apache.gravitino.exceptions.NoSuchMetalakeException;
+import org.apache.gravitino.exceptions.NonEmptyEntityException;
 
 /**
  * Apache Gravitino Client for the administrator to interact with the Gravitino API, allowing the
@@ -145,22 +149,72 @@ public class GravitinoAdminClient extends GravitinoClientBase implements Support
   }
 
   /**
-   * Drops a specific Metalake using the Gravitino API.
+   * Drop a metalake with specified name. If the force flag is true, it will:
    *
-   * @param name The name of the Metalake to be dropped.
-   * @return True if the Metalake was successfully dropped, false if the Metalake does not exist.
+   * <ul>
+   *   <li>Cascade drop all sub-entities (tags, catalogs, schemas, tables, etc.) of the metalake in
+   *       Gravitino store.
+   *   <li>Drop the metalake even if it is in use.
+   *   <li>External resources (e.g. database, table, etc.) associated with sub-entities will not be
+   *       deleted unless it is managed (such as managed fileset).
+   * </ul>
+   *
+   * If the force flag is false, it is equivalent to calling {@link #dropMetalake(String)}.
+   *
+   * @param name The name of the metalake.
+   * @param force Whether to force the drop.
+   * @return True if the metalake was dropped, false if the metalake does not exist.
+   * @throws NonEmptyEntityException If the metalake is not empty and force is false.
+   * @throws MetalakeInUseException If the metalake is in use and force is false.
    */
   @Override
-  public boolean dropMetalake(String name) {
+  public boolean dropMetalake(String name, boolean force)
+      throws NonEmptyEntityException, MetalakeInUseException {
     checkMetalakeName(name);
+    Map<String, String> params = new HashMap<>();
+    params.put("force", String.valueOf(force));
+
     DropResponse resp =
         restClient.delete(
             API_METALAKES_IDENTIFIER_PATH + name,
+            params,
             DropResponse.class,
             Collections.emptyMap(),
             ErrorHandlers.metalakeErrorHandler());
     resp.validate();
     return resp.dropped();
+  }
+
+  @Override
+  public void enableMetalake(String name) throws NoSuchMetalakeException {
+    ErrorResponse resp =
+        restClient.get(
+            API_METALAKES_IDENTIFIER_PATH + name + "/activate",
+            ErrorResponse.class,
+            Collections.emptyMap(),
+            ErrorHandlers.metalakeErrorHandler());
+
+    if (resp.getCode() == 0) {
+      return;
+    }
+
+    ErrorHandlers.metalakeErrorHandler().accept(resp);
+  }
+
+  @Override
+  public void disableMetalake(String name) throws NoSuchMetalakeException {
+    ErrorResponse resp =
+        restClient.get(
+            API_METALAKES_IDENTIFIER_PATH + name + "/deactivate",
+            ErrorResponse.class,
+            Collections.emptyMap(),
+            ErrorHandlers.metalakeErrorHandler());
+
+    if (resp.getCode() == 0) {
+      return;
+    }
+
+    ErrorHandlers.metalakeErrorHandler().accept(resp);
   }
 
   /**

--- a/clients/client-java/src/test/java/org/apache/gravitino/client/integration/test/AuditIT.java
+++ b/clients/client-java/src/test/java/org/apache/gravitino/client/integration/test/AuditIT.java
@@ -60,6 +60,7 @@ public class AuditIT extends BaseIT {
     metaLake = client.alterMetalake(metalakeAuditName, changes);
     Assertions.assertEquals(expectUser, metaLake.auditInfo().creator());
     Assertions.assertEquals(expectUser, metaLake.auditInfo().lastModifier());
+    Assertions.assertDoesNotThrow(() -> client.disableMetalake(newName));
     Assertions.assertTrue(client.dropMetalake(newName), "metaLake should be dropped");
     Assertions.assertFalse(client.dropMetalake(newName), "metalake should be non-existent");
   }

--- a/clients/client-java/src/test/java/org/apache/gravitino/client/integration/test/CatalogIT.java
+++ b/clients/client-java/src/test/java/org/apache/gravitino/client/integration/test/CatalogIT.java
@@ -81,7 +81,7 @@ public class CatalogIT extends BaseIT {
 
   @AfterAll
   public void tearDown() {
-    client.dropMetalake(metalakeName);
+    client.dropMetalake(metalakeName, true);
 
     if (client != null) {
       client.close();

--- a/clients/client-java/src/test/java/org/apache/gravitino/client/integration/test/MetalakeIT.java
+++ b/clients/client-java/src/test/java/org/apache/gravitino/client/integration/test/MetalakeIT.java
@@ -18,6 +18,7 @@
  */
 package org.apache.gravitino.client.integration.test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -182,6 +183,7 @@ public class MetalakeIT extends BaseIT {
   public void testDropMetalakes() {
     GravitinoMetalake metalakeA =
         client.createMetalake(metalakeNameA, "metalake A comment", Collections.emptyMap());
+    assertDoesNotThrow(() -> client.disableMetalake(metalakeA.name()));
     assertTrue(client.dropMetalake(metalakeA.name()), "metaLake should be dropped");
     NameIdentifier id = NameIdentifier.of(metalakeNameA);
     assertThrows(
@@ -205,12 +207,13 @@ public class MetalakeIT extends BaseIT {
         new MetalakeChange[] {MetalakeChange.updateComment("new metalake comment")};
     GravitinoMetalake updatedMetalake = client.alterMetalake(metalakeNameA, changes);
     assertEquals("new metalake comment", updatedMetalake.comment());
-    client.dropMetalake(metalakeNameA);
+    assertTrue(client.dropMetalake(metalakeNameA, true));
   }
 
   public void dropMetalakes() {
     GravitinoMetalake[] metaLakes = client.listMetalakes();
     for (GravitinoMetalake metalake : metaLakes) {
+      assertDoesNotThrow(() -> client.disableMetalake(metalake.name()));
       assertTrue(client.dropMetalake(metalake.name()));
     }
 

--- a/clients/client-java/src/test/java/org/apache/gravitino/client/integration/test/TagIT.java
+++ b/clients/client-java/src/test/java/org/apache/gravitino/client/integration/test/TagIT.java
@@ -112,7 +112,7 @@ public class TagIT extends BaseIT {
     relationalCatalog.asTableCatalog().dropTable(NameIdentifier.of(schema.name(), table.name()));
     relationalCatalog.asSchemas().dropSchema(schema.name(), true);
     metalake.dropCatalog(relationalCatalog.name(), true);
-    client.dropMetalake(metalakeName);
+    client.dropMetalake(metalakeName, true);
 
     if (client != null) {
       client.close();

--- a/clients/client-java/src/test/java/org/apache/gravitino/client/integration/test/authorization/AccessControlNotAllowIT.java
+++ b/clients/client-java/src/test/java/org/apache/gravitino/client/integration/test/authorization/AccessControlNotAllowIT.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.gravitino.integration.test.authorization;
+package org.apache.gravitino.client.integration.test.authorization;
 
 import com.google.common.collect.Lists;
 import java.util.Collections;
@@ -148,6 +148,7 @@ public class AccessControlNotAllowIT extends BaseIT {
     Assertions.assertTrue(
         e.getMessage().contains("You should set 'gravitino.authorization.enable'"));
 
+    client.disableMetalake(metalakeTestName);
     client.dropMetalake(metalakeTestName);
   }
 }

--- a/clients/client-java/src/test/java/org/apache/gravitino/client/integration/test/authorization/CheckCurrentUserIT.java
+++ b/clients/client-java/src/test/java/org/apache/gravitino/client/integration/test/authorization/CheckCurrentUserIT.java
@@ -98,7 +98,7 @@ public class CheckCurrentUserIT extends BaseIT {
   @AfterAll
   public void tearDown() {
     if (client != null) {
-      client.dropMetalake(metalakeName);
+      client.dropMetalake(metalakeName, true);
       client.close();
       client = null;
     }

--- a/clients/client-java/src/test/java/org/apache/gravitino/client/integration/test/authorization/OwnerIT.java
+++ b/clients/client-java/src/test/java/org/apache/gravitino/client/integration/test/authorization/OwnerIT.java
@@ -169,7 +169,7 @@ public class OwnerIT extends BaseIT {
     catalog.asFilesetCatalog().dropFileset(fileIdent);
     catalog.asSchemas().dropSchema("schema_owner", true);
     metalake.dropCatalog(catalogNameA, true);
-    client.dropMetalake(metalakeNameA);
+    client.dropMetalake(metalakeNameA, true);
   }
 
   @Test
@@ -220,7 +220,7 @@ public class OwnerIT extends BaseIT {
     // Clean up
     catalogB.asTopicCatalog().dropTopic(topicIdent);
     metalake.dropCatalog(catalogNameB, true);
-    client.dropMetalake(metalakeNameB);
+    client.dropMetalake(metalakeNameB, true);
   }
 
   @Test
@@ -255,7 +255,7 @@ public class OwnerIT extends BaseIT {
 
     // Clean up
     metalake.deleteRole("role_owner");
-    client.dropMetalake(metalakeNameC);
+    client.dropMetalake(metalakeNameC, true);
   }
 
   @Test
@@ -321,7 +321,7 @@ public class OwnerIT extends BaseIT {
     catalog.asTableCatalog().dropTable(tableIdent);
     catalog.asSchemas().dropSchema("schema_owner", true);
     metalake.dropCatalog(catalogNameD, true);
-    client.dropMetalake(metalakeNameD);
+    client.dropMetalake(metalakeNameD, true);
   }
 
   @Test
@@ -352,6 +352,6 @@ public class OwnerIT extends BaseIT {
         () -> metalake.setOwner(metalakeObject, "not-existed", Owner.Type.USER));
 
     // Cleanup
-    client.dropMetalake(metalakeNameE);
+    client.dropMetalake(metalakeNameE, true);
   }
 }

--- a/clients/client-python/gravitino/dto/requests/metalake_set_request.py
+++ b/clients/client-python/gravitino/dto/requests/metalake_set_request.py
@@ -1,0 +1,41 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from dataclasses import dataclass, field
+
+from dataclasses_json import config
+
+from gravitino.rest.rest_message import RESTRequest
+
+
+@dataclass
+class MetalakeSetRequest(RESTRequest):
+    """Represents a request to set a metalake in use status."""
+
+    _in_use: bool = field(metadata=config(field_name="inUse"))
+
+    def __init__(self, in_use: bool):
+        self._in_use = in_use
+
+    def validate(self):
+        """Validates the fields of the request.
+
+        Raises:
+            IllegalArgumentException if in_use is not set.
+        """
+        if self._in_use is None:
+            raise ValueError('"in_use" field is required and cannot be empty')

--- a/clients/client-python/gravitino/exceptions/base.py
+++ b/clients/client-python/gravitino/exceptions/base.py
@@ -97,12 +97,20 @@ class InUseException(GravitinoRuntimeException):
     """Base class for all exceptions thrown when an entity is in use and cannot be deleted."""
 
 
+class MetalakeInUseException(InUseException):
+    """An exception thrown when a metalake is in use and cannot be deleted."""
+
+
 class CatalogInUseException(InUseException):
     """An Exception thrown when a catalog is in use and cannot be deleted."""
 
 
 class NotInUseException(GravitinoRuntimeException):
     """Base class for all exceptions thrown when an entity is not in use."""
+
+
+class MetalakeNotInUseException(NotInUseException):
+    """An exception thrown when operating on not in use metalake."""
 
 
 class CatalogNotInUseException(NotInUseException):

--- a/clients/client-python/gravitino/exceptions/handlers/metalake_error_handler.py
+++ b/clients/client-python/gravitino/exceptions/handlers/metalake_error_handler.py
@@ -21,6 +21,8 @@ from gravitino.exceptions.handlers.rest_error_handler import RestErrorHandler
 from gravitino.exceptions.base import (
     NoSuchMetalakeException,
     MetalakeAlreadyExistsException,
+    MetalakeInUseException,
+    MetalakeNotInUseException,
 )
 
 
@@ -33,8 +35,15 @@ class MetalakeErrorHandler(RestErrorHandler):
 
         if code == ErrorConstants.NOT_FOUND_CODE:
             raise NoSuchMetalakeException(error_message)
+
         if code == ErrorConstants.ALREADY_EXISTS_CODE:
             raise MetalakeAlreadyExistsException(error_message)
+
+        if code == ErrorConstants.IN_USE_CODE:
+            raise MetalakeInUseException(error_message)
+
+        if code == ErrorConstants.NOT_IN_USE_CODE:
+            raise MetalakeNotInUseException(error_message)
 
         super().handle(error_response)
 

--- a/clients/client-python/tests/integration/auth/test_auth_common.py
+++ b/clients/client-python/tests/integration/auth/test_auth_common.py
@@ -101,7 +101,9 @@ class TestCommonAuth:
             logger.info(
                 "Drop metalake %s[%s]",
                 self.metalake_name,
-                self.gravitino_admin_client.drop_metalake(self.metalake_name),
+                self.gravitino_admin_client.drop_metalake(
+                    self.metalake_name, force=True
+                ),
             )
         except GravitinoRuntimeException:
             logger.warning("Failed to drop metalake %s", self.metalake_name)

--- a/clients/client-python/tests/integration/test_catalog.py
+++ b/clients/client-python/tests/integration/test_catalog.py
@@ -92,7 +92,9 @@ class TestCatalog(IntegrationTestEnv):
             logger.info(
                 "Drop metalake %s[%s]",
                 self.metalake_name,
-                self.gravitino_admin_client.drop_metalake(self.metalake_name),
+                self.gravitino_admin_client.drop_metalake(
+                    self.metalake_name, force=True
+                ),
             )
         except GravitinoRuntimeException:
             logger.warning("Failed to drop metalake %s", self.metalake_name)

--- a/clients/client-python/tests/integration/test_fileset_catalog.py
+++ b/clients/client-python/tests/integration/test_fileset_catalog.py
@@ -128,7 +128,9 @@ class TestFilesetCatalog(IntegrationTestEnv):
             logger.info(
                 "Drop metalake %s[%s]",
                 self.metalake_name,
-                self.gravitino_admin_client.drop_metalake(self.metalake_name),
+                self.gravitino_admin_client.drop_metalake(
+                    self.metalake_name, force=True
+                ),
             )
         except GravitinoRuntimeException:
             logger.warning("Failed to drop metalake %s", self.metalake_name)

--- a/clients/client-python/tests/integration/test_metalake.py
+++ b/clients/client-python/tests/integration/test_metalake.py
@@ -118,7 +118,7 @@ class TestMetalake(IntegrationTestEnv):
         self.assertTrue(self.metalake_properties_key1 not in metalake.properties())
 
     def drop_metalake(self, metalake_name: str) -> bool:
-        return self.gravitino_admin_client.drop_metalake(metalake_name)
+        return self.gravitino_admin_client.drop_metalake(metalake_name, True)
 
     def test_drop_metalake(self):
         self.create_metalake(self.metalake_name)
@@ -152,7 +152,9 @@ class TestMetalake(IntegrationTestEnv):
         self.assertIsNotNone(metalake)
         self.assertEqual(metalake.name(), self.metalake_name)
         self.assertEqual(metalake.comment(), self.metalake_comment)
-        self.assertEqual(metalake.properties(), self.metalake_properties)
+        self.assertEqual(
+            metalake.properties(), {**self.metalake_properties, "in-use": "true"}
+        )
         self.assertEqual(metalake.audit_info().creator(), "anonymous")
 
     def test_failed_load_metalakes(self):

--- a/clients/client-python/tests/integration/test_schema.py
+++ b/clients/client-python/tests/integration/test_schema.py
@@ -128,7 +128,9 @@ class TestSchema(IntegrationTestEnv):
             logger.info(
                 "Drop metalake %s[%s]",
                 self.metalake_name,
-                self.gravitino_admin_client.drop_metalake(self.metalake_name),
+                self.gravitino_admin_client.drop_metalake(
+                    self.metalake_name, force=True
+                ),
             )
         except GravitinoRuntimeException:
             logger.warning("Failed to drop metalake %s", self.metalake_name)

--- a/clients/filesystem-hadoop3/src/test/java/org/apache/gravitino/filesystem/hadoop/integration/test/GravitinoVirtualFileSystemIT.java
+++ b/clients/filesystem-hadoop3/src/test/java/org/apache/gravitino/filesystem/hadoop/integration/test/GravitinoVirtualFileSystemIT.java
@@ -92,7 +92,7 @@ public class GravitinoVirtualFileSystemIT extends BaseIT {
     Catalog catalog = metalake.loadCatalog(catalogName);
     catalog.asSchemas().dropSchema(schemaName, true);
     metalake.dropCatalog(catalogName, true);
-    client.dropMetalake(metalakeName);
+    client.dropMetalake(metalakeName, true);
 
     if (client != null) {
       client.close();

--- a/common/src/main/java/org/apache/gravitino/dto/requests/MetalakeSetRequest.java
+++ b/common/src/main/java/org/apache/gravitino/dto/requests/MetalakeSetRequest.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.dto.requests;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+import org.apache.gravitino.rest.RESTRequest;
+
+/** Represents a request to set a Metalake in use. */
+@Getter
+@EqualsAndHashCode
+@ToString
+public class MetalakeSetRequest implements RESTRequest {
+
+  private final boolean inUse;
+
+  /** Default constructor for MetalakeSetRequest. */
+  public MetalakeSetRequest() {
+    this(false);
+  }
+
+  /**
+   * Constructor for MetalakeSetRequest.
+   *
+   * @param inUse The in use status to set.
+   */
+  public MetalakeSetRequest(boolean inUse) {
+    this.inUse = inUse;
+  }
+
+  /**
+   * Validates the request. No validation needed.
+   *
+   * @throws IllegalArgumentException If the request is invalid.
+   */
+  @Override
+  public void validate() throws IllegalArgumentException {
+    // No validation needed
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/authorization/AuthorizationUtils.java
+++ b/core/src/main/java/org/apache/gravitino/authorization/AuthorizationUtils.java
@@ -19,14 +19,12 @@
 package org.apache.gravitino.authorization;
 
 import com.google.common.collect.Sets;
-import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Consumer;
 import org.apache.gravitino.Catalog;
 import org.apache.gravitino.Entity;
-import org.apache.gravitino.EntityStore;
 import org.apache.gravitino.GravitinoEnv;
 import org.apache.gravitino.MetadataObject;
 import org.apache.gravitino.NameIdentifier;
@@ -40,12 +38,9 @@ import org.apache.gravitino.exceptions.ForbiddenException;
 import org.apache.gravitino.exceptions.IllegalPrivilegeException;
 import org.apache.gravitino.exceptions.NoSuchCatalogException;
 import org.apache.gravitino.exceptions.NoSuchMetadataObjectException;
-import org.apache.gravitino.exceptions.NoSuchMetalakeException;
 import org.apache.gravitino.exceptions.NoSuchUserException;
 import org.apache.gravitino.utils.MetadataObjectUtil;
 import org.apache.gravitino.utils.NameIdentifierUtil;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /* The utilization class of authorization module*/
 public class AuthorizationUtils {
@@ -53,8 +48,6 @@ public class AuthorizationUtils {
   static final String USER_DOES_NOT_EXIST_MSG = "User %s does not exist in th metalake %s";
   static final String GROUP_DOES_NOT_EXIST_MSG = "Group %s does not exist in th metalake %s";
   static final String ROLE_DOES_NOT_EXIST_MSG = "Role %s does not exist in th metalake %s";
-  private static final Logger LOG = LoggerFactory.getLogger(AuthorizationUtils.class);
-  private static final String METALAKE_DOES_NOT_EXIST_MSG = "Metalake %s does not exist";
 
   private static final Set<Privilege.Name> FILESET_PRIVILEGES =
       Sets.immutableEnumSet(
@@ -67,21 +60,6 @@ public class AuthorizationUtils {
           Privilege.Name.CREATE_TOPIC, Privilege.Name.PRODUCE_TOPIC, Privilege.Name.CONSUME_TOPIC);
 
   private AuthorizationUtils() {}
-
-  static void checkMetalakeExists(String metalake) throws NoSuchMetalakeException {
-    try {
-      EntityStore store = GravitinoEnv.getInstance().entityStore();
-
-      NameIdentifier metalakeIdent = NameIdentifier.of(metalake);
-      if (!store.exists(metalakeIdent, Entity.EntityType.METALAKE)) {
-        LOG.warn("Metalake {} does not exist", metalakeIdent);
-        throw new NoSuchMetalakeException(METALAKE_DOES_NOT_EXIST_MSG, metalakeIdent);
-      }
-    } catch (IOException e) {
-      LOG.error("Failed to do storage operation", e);
-      throw new RuntimeException(e);
-    }
-  }
 
   public static void checkCurrentUser(String metalake, String user) {
     try {

--- a/core/src/main/java/org/apache/gravitino/authorization/UserGroupManager.java
+++ b/core/src/main/java/org/apache/gravitino/authorization/UserGroupManager.java
@@ -18,6 +18,8 @@
  */
 package org.apache.gravitino.authorization;
 
+import static org.apache.gravitino.metalake.MetalakeManager.checkMetalake;
+
 import com.google.common.collect.Lists;
 import java.io.IOException;
 import java.time.Instant;
@@ -27,6 +29,7 @@ import org.apache.gravitino.Entity;
 import org.apache.gravitino.Entity.EntityType;
 import org.apache.gravitino.EntityAlreadyExistsException;
 import org.apache.gravitino.EntityStore;
+import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
 import org.apache.gravitino.exceptions.GroupAlreadyExistsException;
 import org.apache.gravitino.exceptions.NoSuchEntityException;
@@ -62,7 +65,7 @@ class UserGroupManager {
 
   User addUser(String metalake, String name) throws UserAlreadyExistsException {
     try {
-      AuthorizationUtils.checkMetalakeExists(metalake);
+      checkMetalake(NameIdentifier.of(metalake), store);
       UserEntity userEntity =
           UserEntity.builder()
               .withId(idGenerator.nextId())
@@ -90,7 +93,7 @@ class UserGroupManager {
 
   boolean removeUser(String metalake, String user) {
     try {
-      AuthorizationUtils.checkMetalakeExists(metalake);
+      checkMetalake(NameIdentifier.of(metalake), store);
       return store.delete(AuthorizationUtils.ofUser(metalake, user), Entity.EntityType.USER);
     } catch (IOException ioe) {
       LOG.error(
@@ -101,7 +104,7 @@ class UserGroupManager {
 
   User getUser(String metalake, String user) throws NoSuchUserException {
     try {
-      AuthorizationUtils.checkMetalakeExists(metalake);
+      checkMetalake(NameIdentifier.of(metalake), store);
       return store.get(
           AuthorizationUtils.ofUser(metalake, user), Entity.EntityType.USER, UserEntity.class);
 
@@ -127,7 +130,7 @@ class UserGroupManager {
 
   Group addGroup(String metalake, String group) throws GroupAlreadyExistsException {
     try {
-      AuthorizationUtils.checkMetalakeExists(metalake);
+      checkMetalake(NameIdentifier.of(metalake), store);
       GroupEntity groupEntity =
           GroupEntity.builder()
               .withId(idGenerator.nextId())
@@ -155,7 +158,7 @@ class UserGroupManager {
 
   boolean removeGroup(String metalake, String group) {
     try {
-      AuthorizationUtils.checkMetalakeExists(metalake);
+      checkMetalake(NameIdentifier.of(metalake), store);
       return store.delete(AuthorizationUtils.ofGroup(metalake, group), Entity.EntityType.GROUP);
     } catch (IOException ioe) {
       LOG.error(
@@ -169,7 +172,7 @@ class UserGroupManager {
 
   Group getGroup(String metalake, String group) {
     try {
-      AuthorizationUtils.checkMetalakeExists(metalake);
+      checkMetalake(NameIdentifier.of(metalake), store);
 
       return store.get(
           AuthorizationUtils.ofGroup(metalake, group), Entity.EntityType.GROUP, GroupEntity.class);
@@ -194,7 +197,7 @@ class UserGroupManager {
 
   private User[] listUsersInternal(String metalake, boolean allFields) {
     try {
-      AuthorizationUtils.checkMetalakeExists(metalake);
+      checkMetalake(NameIdentifier.of(metalake), store);
 
       Namespace namespace = AuthorizationUtils.ofUserNamespace(metalake);
       return store
@@ -211,7 +214,7 @@ class UserGroupManager {
 
   private Group[] listGroupInternal(String metalake, boolean allFields) {
     try {
-      AuthorizationUtils.checkMetalakeExists(metalake);
+      checkMetalake(NameIdentifier.of(metalake), store);
       Namespace namespace = AuthorizationUtils.ofGroupNamespace(metalake);
       return store
           .list(namespace, GroupEntity.class, EntityType.GROUP, allFields)

--- a/core/src/main/java/org/apache/gravitino/catalog/CatalogManager.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/CatalogManager.java
@@ -116,7 +116,7 @@ public class CatalogManager implements CatalogDispatcher, Closeable {
     NameIdentifier metalakeIdent = NameIdentifier.of(ident.namespace().levels());
     checkMetalake(metalakeIdent, store);
 
-    if (!getInUseValue(store, ident)) {
+    if (!getCatalogInUseValue(store, ident)) {
       throw new CatalogNotInUseException("Catalog %s is not in use, please enable it first", ident);
     }
   }
@@ -677,10 +677,10 @@ public class CatalogManager implements CatalogDispatcher, Closeable {
   private static boolean catalogInUse(EntityStore store, NameIdentifier ident)
       throws NoSuchMetalakeException, NoSuchCatalogException {
     NameIdentifier metalakeIdent = NameIdentifier.of(ident.namespace().levels());
-    return metalakeInUse(store, metalakeIdent) && getInUseValue(store, ident);
+    return metalakeInUse(store, metalakeIdent) && getCatalogInUseValue(store, ident);
   }
 
-  private static boolean getInUseValue(EntityStore store, NameIdentifier catalogIdent) {
+  private static boolean getCatalogInUseValue(EntityStore store, NameIdentifier catalogIdent) {
     try {
       CatalogEntity catalogEntity =
           store.get(catalogIdent, EntityType.CATALOG, CatalogEntity.class);

--- a/core/src/main/java/org/apache/gravitino/catalog/OperationDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/OperationDispatcher.java
@@ -18,7 +18,7 @@
  */
 package org.apache.gravitino.catalog;
 
-import static org.apache.gravitino.catalog.CatalogManager.catalogInUse;
+import static org.apache.gravitino.catalog.CatalogManager.checkCatalogInUse;
 import static org.apache.gravitino.catalog.PropertiesMetadataHelpers.validatePropertyForAlter;
 import static org.apache.gravitino.utils.NameIdentifierUtil.getCatalogIdentifier;
 
@@ -35,7 +35,6 @@ import org.apache.gravitino.StringIdentifier;
 import org.apache.gravitino.connector.HasPropertyMetadata;
 import org.apache.gravitino.connector.PropertiesMetadata;
 import org.apache.gravitino.connector.capability.Capability;
-import org.apache.gravitino.exceptions.CatalogNotInUseException;
 import org.apache.gravitino.exceptions.NoSuchEntityException;
 import org.apache.gravitino.file.FilesetChange;
 import org.apache.gravitino.messaging.TopicChange;
@@ -94,9 +93,7 @@ public abstract class OperationDispatcher {
   protected <R, E extends Throwable> R doWithCatalog(
       NameIdentifier ident, ThrowableFunction<CatalogManager.CatalogWrapper, R> fn, Class<E> ex)
       throws E {
-    if (!catalogInUse(store, ident)) {
-      throw new CatalogNotInUseException("Catalog %s is not in use, please enable it first", ident);
-    }
+    checkCatalogInUse(store, ident);
 
     try {
       CatalogManager.CatalogWrapper c = catalogManager.loadCatalogAndWrap(ident);
@@ -118,9 +115,7 @@ public abstract class OperationDispatcher {
       Class<E1> ex1,
       Class<E2> ex2)
       throws E1, E2 {
-    if (!catalogInUse(store, ident)) {
-      throw new CatalogNotInUseException("Catalog %s is not in use, please enable it first", ident);
-    }
+    checkCatalogInUse(store, ident);
 
     try {
       CatalogManager.CatalogWrapper c = catalogManager.loadCatalogAndWrap(ident);

--- a/core/src/main/java/org/apache/gravitino/connector/PropertiesMetadata.java
+++ b/core/src/main/java/org/apache/gravitino/connector/PropertiesMetadata.java
@@ -89,7 +89,7 @@ public interface PropertiesMetadata {
       throw new IllegalArgumentException("Property is not defined: " + propertyName);
     }
 
-    if (properties.containsKey(propertyName)) {
+    if (properties != null && properties.containsKey(propertyName)) {
       return propertyEntries().get(propertyName).decode(properties.get(propertyName));
     }
     return propertyEntries().get(propertyName).getDefaultValue();

--- a/core/src/main/java/org/apache/gravitino/hook/MetalakeHookDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/hook/MetalakeHookDispatcher.java
@@ -28,7 +28,9 @@ import org.apache.gravitino.authorization.AccessControlDispatcher;
 import org.apache.gravitino.authorization.Owner;
 import org.apache.gravitino.authorization.OwnerManager;
 import org.apache.gravitino.exceptions.MetalakeAlreadyExistsException;
+import org.apache.gravitino.exceptions.MetalakeInUseException;
 import org.apache.gravitino.exceptions.NoSuchMetalakeException;
+import org.apache.gravitino.exceptions.NonEmptyEntityException;
 import org.apache.gravitino.metalake.MetalakeDispatcher;
 import org.apache.gravitino.utils.NameIdentifierUtil;
 import org.apache.gravitino.utils.PrincipalUtils;
@@ -87,8 +89,19 @@ public class MetalakeHookDispatcher implements MetalakeDispatcher {
   }
 
   @Override
-  public boolean dropMetalake(NameIdentifier ident) {
-    return dispatcher.dropMetalake(ident);
+  public boolean dropMetalake(NameIdentifier ident, boolean force)
+      throws NonEmptyEntityException, MetalakeInUseException {
+    return dispatcher.dropMetalake(ident, force);
+  }
+
+  @Override
+  public void enableMetalake(NameIdentifier ident) throws NoSuchMetalakeException {
+    dispatcher.enableMetalake(ident);
+  }
+
+  @Override
+  public void disableMetalake(NameIdentifier ident) throws NoSuchMetalakeException {
+    dispatcher.disableMetalake(ident);
   }
 
   @Override

--- a/core/src/main/java/org/apache/gravitino/listener/CatalogEventDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/listener/CatalogEventDispatcher.java
@@ -177,7 +177,7 @@ public class CatalogEventDispatcher implements CatalogDispatcher {
   @Override
   public void enableCatalog(NameIdentifier ident)
       throws NoSuchCatalogException, CatalogNotInUseException {
-    // todo: support activate catalog event
+    // todo: support enable catalog event
     dispatcher.enableCatalog(ident);
   }
 

--- a/core/src/main/java/org/apache/gravitino/listener/MetalakeEventDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/listener/MetalakeEventDispatcher.java
@@ -24,7 +24,9 @@ import org.apache.gravitino.Metalake;
 import org.apache.gravitino.MetalakeChange;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.exceptions.MetalakeAlreadyExistsException;
+import org.apache.gravitino.exceptions.MetalakeInUseException;
 import org.apache.gravitino.exceptions.NoSuchMetalakeException;
+import org.apache.gravitino.exceptions.NonEmptyEntityException;
 import org.apache.gravitino.listener.api.event.AlterMetalakeEvent;
 import org.apache.gravitino.listener.api.event.AlterMetalakeFailureEvent;
 import org.apache.gravitino.listener.api.event.CreateMetalakeEvent;
@@ -129,9 +131,10 @@ public class MetalakeEventDispatcher implements MetalakeDispatcher {
   }
 
   @Override
-  public boolean dropMetalake(NameIdentifier ident) {
+  public boolean dropMetalake(NameIdentifier ident, boolean force)
+      throws NonEmptyEntityException, MetalakeInUseException {
     try {
-      boolean isExists = dispatcher.dropMetalake(ident);
+      boolean isExists = dispatcher.dropMetalake(ident, force);
       eventBus.dispatchEvent(
           new DropMetalakeEvent(PrincipalUtils.getCurrentUserName(), ident, isExists));
       return isExists;
@@ -140,5 +143,17 @@ public class MetalakeEventDispatcher implements MetalakeDispatcher {
           new DropMetalakeFailureEvent(PrincipalUtils.getCurrentUserName(), ident, e));
       throw e;
     }
+  }
+
+  @Override
+  public void enableMetalake(NameIdentifier ident) throws NoSuchMetalakeException {
+    // todo: support activate metalake event
+    dispatcher.enableMetalake(ident);
+  }
+
+  @Override
+  public void disableMetalake(NameIdentifier ident) throws NoSuchMetalakeException {
+    // todo: support deactivate metalake event
+    dispatcher.disableMetalake(ident);
   }
 }

--- a/core/src/main/java/org/apache/gravitino/listener/MetalakeEventDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/listener/MetalakeEventDispatcher.java
@@ -147,13 +147,13 @@ public class MetalakeEventDispatcher implements MetalakeDispatcher {
 
   @Override
   public void enableMetalake(NameIdentifier ident) throws NoSuchMetalakeException {
-    // todo: support activate metalake event
+    // todo: support enable metalake event
     dispatcher.enableMetalake(ident);
   }
 
   @Override
   public void disableMetalake(NameIdentifier ident) throws NoSuchMetalakeException {
-    // todo: support deactivate metalake event
+    // todo: support disable metalake event
     dispatcher.disableMetalake(ident);
   }
 }

--- a/core/src/main/java/org/apache/gravitino/meta/BaseMetalake.java
+++ b/core/src/main/java/org/apache/gravitino/meta/BaseMetalake.java
@@ -25,13 +25,13 @@ import javax.annotation.Nullable;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
-import org.apache.gravitino.Audit;
 import org.apache.gravitino.Auditable;
 import org.apache.gravitino.Entity;
 import org.apache.gravitino.Field;
 import org.apache.gravitino.HasIdentifier;
 import org.apache.gravitino.Metalake;
-import org.apache.gravitino.StringIdentifier;
+import org.apache.gravitino.connector.PropertiesMetadata;
+import org.apache.gravitino.metalake.MetalakePropertiesMetadata;
 
 /** Base implementation of a Metalake entity. */
 @EqualsAndHashCode
@@ -51,6 +51,8 @@ public class BaseMetalake implements Metalake, Entity, Auditable, HasIdentifier 
   /** The required field for the schema version of the metalake. */
   public static final Field SCHEMA_VERSION =
       Field.required("version", SchemaVersion.class, "The version of the schema for the metalake");
+
+  public static final PropertiesMetadata PROPERTIES_METADATA = new MetalakePropertiesMetadata();
 
   private Long id;
 
@@ -87,10 +89,10 @@ public class BaseMetalake implements Metalake, Entity, Auditable, HasIdentifier 
   /**
    * The audit information of the metalake.
    *
-   * @return The audit information as an {@link Audit} instance.
+   * @return The audit information as an {@link AuditInfo} instance.
    */
   @Override
-  public Audit auditInfo() {
+  public AuditInfo auditInfo() {
     return auditInfo;
   }
 
@@ -141,7 +143,11 @@ public class BaseMetalake implements Metalake, Entity, Auditable, HasIdentifier 
    */
   @Override
   public Map<String, String> properties() {
-    return StringIdentifier.newPropertiesWithoutId(properties);
+    return properties;
+  }
+
+  public PropertiesMetadata propertiesMetadata() {
+    return PROPERTIES_METADATA;
   }
 
   /** Builder class for creating instances of {@link BaseMetalake}. */

--- a/core/src/main/java/org/apache/gravitino/metalake/MetalakeManager.java
+++ b/core/src/main/java/org/apache/gravitino/metalake/MetalakeManager.java
@@ -18,9 +18,12 @@
  */
 package org.apache.gravitino.metalake;
 
+import static org.apache.gravitino.Metalake.PROPERTY_IN_USE;
+
 import com.google.common.collect.Maps;
 import java.io.IOException;
 import java.time.Instant;
+import java.util.List;
 import java.util.Map;
 import org.apache.gravitino.Entity.EntityType;
 import org.apache.gravitino.EntityAlreadyExistsException;
@@ -28,13 +31,16 @@ import org.apache.gravitino.EntityStore;
 import org.apache.gravitino.MetalakeChange;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
-import org.apache.gravitino.StringIdentifier;
 import org.apache.gravitino.exceptions.AlreadyExistsException;
 import org.apache.gravitino.exceptions.MetalakeAlreadyExistsException;
+import org.apache.gravitino.exceptions.MetalakeInUseException;
+import org.apache.gravitino.exceptions.MetalakeNotInUseException;
 import org.apache.gravitino.exceptions.NoSuchEntityException;
 import org.apache.gravitino.exceptions.NoSuchMetalakeException;
+import org.apache.gravitino.exceptions.NonEmptyEntityException;
 import org.apache.gravitino.meta.AuditInfo;
 import org.apache.gravitino.meta.BaseMetalake;
+import org.apache.gravitino.meta.CatalogEntity;
 import org.apache.gravitino.meta.SchemaVersion;
 import org.apache.gravitino.storage.IdGenerator;
 import org.apache.gravitino.utils.PrincipalUtils;
@@ -64,6 +70,48 @@ public class MetalakeManager implements MetalakeDispatcher {
   }
 
   /**
+   * Check whether the metalake is available
+   *
+   * @param ident The identifier of the Metalake to check.
+   * @param store The EntityStore to use for managing Metalakes.
+   * @throws NoSuchMetalakeException If the Metalake with the given identifier does not exist.
+   * @throws MetalakeNotInUseException If the Metalake is not in use.
+   */
+  public static void checkMetalake(NameIdentifier ident, EntityStore store)
+      throws NoSuchMetalakeException, MetalakeNotInUseException {
+    boolean metalakeInUse = metalakeInUse(store, ident);
+    if (!metalakeInUse) {
+      throw new MetalakeNotInUseException(
+          "Metalake %s is not in use, please activate it first", ident);
+    }
+  }
+
+  /**
+   * Return true if the metalake is in used, false otherwise.
+   *
+   * @param store The EntityStore to use for managing Metalakes.
+   * @param ident The identifier of the Metalake to check.
+   * @return True if the metalake is in use, false otherwise.
+   * @throws NoSuchMetalakeException If the Metalake with the given identifier does not exist.
+   */
+  public static boolean metalakeInUse(EntityStore store, NameIdentifier ident)
+      throws NoSuchMetalakeException {
+    try {
+      BaseMetalake metalake = store.get(ident, EntityType.METALAKE, BaseMetalake.class);
+      return (boolean)
+          metalake.propertiesMetadata().getOrDefault(metalake.properties(), PROPERTY_IN_USE);
+
+    } catch (NoSuchEntityException e) {
+      LOG.warn("Metalake {} does not exist", ident, e);
+      throw new NoSuchMetalakeException(METALAKE_DOES_NOT_EXIST_MSG, ident);
+
+    } catch (IOException e) {
+      LOG.error("Failed to do store operation", e);
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
    * Lists all available Metalakes.
    *
    * @return An array of Metalake instances representing the available Metalakes.
@@ -72,8 +120,9 @@ public class MetalakeManager implements MetalakeDispatcher {
   @Override
   public BaseMetalake[] listMetalakes() {
     try {
-      return store.list(Namespace.empty(), BaseMetalake.class, EntityType.METALAKE).stream()
-          .toArray(BaseMetalake[]::new);
+      return store
+          .list(Namespace.empty(), BaseMetalake.class, EntityType.METALAKE)
+          .toArray(new BaseMetalake[0]);
     } catch (IOException ioe) {
       LOG.error("Listing Metalakes failed due to storage issues.", ioe);
       throw new RuntimeException(ioe);
@@ -116,14 +165,13 @@ public class MetalakeManager implements MetalakeDispatcher {
       NameIdentifier ident, String comment, Map<String, String> properties)
       throws MetalakeAlreadyExistsException {
     long uid = idGenerator.nextId();
-    StringIdentifier stringId = StringIdentifier.fromId(uid);
 
     BaseMetalake metalake =
         BaseMetalake.builder()
             .withId(uid)
             .withName(ident.name())
             .withComment(comment)
-            .withProperties(StringIdentifier.newPropertiesWithId(stringId, properties))
+            .withProperties(properties)
             .withVersion(SchemaVersion.V_0_1)
             .withAuditInfo(
                 AuditInfo.builder()
@@ -158,28 +206,17 @@ public class MetalakeManager implements MetalakeDispatcher {
   public BaseMetalake alterMetalake(NameIdentifier ident, MetalakeChange... changes)
       throws NoSuchMetalakeException, IllegalArgumentException {
     try {
+      if (!metalakeInUse(store, ident)) {
+        throw new MetalakeNotInUseException(
+            "Metalake %s is not in use, please activate it first", ident);
+      }
+
       return store.update(
           ident,
           BaseMetalake.class,
           EntityType.METALAKE,
           metalake -> {
-            BaseMetalake.Builder builder =
-                BaseMetalake.builder()
-                    .withId(metalake.id())
-                    .withName(metalake.name())
-                    .withComment(metalake.comment())
-                    .withProperties(metalake.properties())
-                    .withVersion(metalake.getVersion());
-
-            AuditInfo newInfo =
-                AuditInfo.builder()
-                    .withCreator(metalake.auditInfo().creator())
-                    .withCreateTime(metalake.auditInfo().createTime())
-                    .withLastModifier(
-                        metalake.auditInfo().creator()) /*TODO: Use real user later on.  */
-                    .withLastModifiedTime(Instant.now())
-                    .build();
-            builder.withAuditInfo(newInfo);
+            BaseMetalake.Builder builder = newMetalakeBuilder(metalake);
 
             Map<String, String> newProps =
                 metalake.properties() == null
@@ -204,21 +241,110 @@ public class MetalakeManager implements MetalakeDispatcher {
     }
   }
 
-  /**
-   * Deletes a Metalake.
-   *
-   * @param ident The identifier of the Metalake to be deleted.
-   * @return `true` if the Metalake was successfully deleted, `false` otherwise.
-   * @throws RuntimeException If deleting the Metalake encounters storage issues.
-   */
   @Override
-  public boolean dropMetalake(NameIdentifier ident) {
+  public boolean dropMetalake(NameIdentifier ident, boolean force)
+      throws NonEmptyEntityException, MetalakeInUseException {
     try {
-      return store.delete(ident, EntityType.METALAKE);
-    } catch (IOException ioe) {
-      LOG.error("Deleting metalake {} failed due to storage issues", ident, ioe);
-      throw new RuntimeException(ioe);
+      boolean inUse = metalakeInUse(store, ident);
+      if (inUse && !force) {
+        throw new MetalakeInUseException(
+            "Metalake %s is in use, please deactivate it first or use force option", ident);
+      }
+
+      List<CatalogEntity> catalogEntities =
+          store.list(Namespace.of(ident.name()), CatalogEntity.class, EntityType.CATALOG);
+      if (!catalogEntities.isEmpty() && !force) {
+        throw new NonEmptyEntityException(
+            "Metalake %s has catalogs, please drop them first or use force option", ident);
+      }
+
+      // If reached here, it implies that the metalake is not in use or force is true.
+      if (inUse) {
+        // force is true, so deactivate the metalake first.
+        disableMetalake(ident);
+      }
+
+      return store.delete(ident, EntityType.METALAKE, true);
+    } catch (NoSuchMetalakeException e) {
+      return false;
+
+    } catch (IOException e) {
+      throw new RuntimeException(e);
     }
+  }
+
+  @Override
+  public void enableMetalake(NameIdentifier ident) throws NoSuchMetalakeException {
+    try {
+
+      boolean inUse = metalakeInUse(store, ident);
+      if (!inUse) {
+        store.update(
+            ident,
+            BaseMetalake.class,
+            EntityType.METALAKE,
+            metalake -> {
+              BaseMetalake.Builder builder = newMetalakeBuilder(metalake);
+
+              Map<String, String> newProps =
+                  metalake.properties() == null
+                      ? Maps.newHashMap()
+                      : Maps.newHashMap(metalake.properties());
+              newProps.put(PROPERTY_IN_USE, "true");
+              builder.withProperties(newProps);
+
+              return builder.build();
+            });
+      }
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public void disableMetalake(NameIdentifier ident) throws NoSuchMetalakeException {
+    try {
+      boolean inUse = metalakeInUse(store, ident);
+      if (inUse) {
+        store.update(
+            ident,
+            BaseMetalake.class,
+            EntityType.METALAKE,
+            metalake -> {
+              BaseMetalake.Builder builder = newMetalakeBuilder(metalake);
+
+              Map<String, String> newProps =
+                  metalake.properties() == null
+                      ? Maps.newHashMap()
+                      : Maps.newHashMap(metalake.properties());
+              newProps.put(PROPERTY_IN_USE, "false");
+              builder.withProperties(newProps);
+
+              return builder.build();
+            });
+      }
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private BaseMetalake.Builder newMetalakeBuilder(BaseMetalake metalake) {
+    BaseMetalake.Builder builder =
+        BaseMetalake.builder()
+            .withId(metalake.id())
+            .withName(metalake.name())
+            .withComment(metalake.comment())
+            .withProperties(metalake.properties())
+            .withVersion(metalake.getVersion());
+
+    AuditInfo newInfo =
+        AuditInfo.builder()
+            .withCreator(metalake.auditInfo().creator())
+            .withCreateTime(metalake.auditInfo().createTime())
+            .withLastModifier(metalake.auditInfo().creator()) /*TODO: Use real user later on.  */
+            .withLastModifiedTime(Instant.now())
+            .build();
+    return builder.withAuditInfo(newInfo);
   }
 
   /**

--- a/core/src/main/java/org/apache/gravitino/metalake/MetalakeManager.java
+++ b/core/src/main/java/org/apache/gravitino/metalake/MetalakeManager.java
@@ -82,7 +82,7 @@ public class MetalakeManager implements MetalakeDispatcher {
     boolean metalakeInUse = metalakeInUse(store, ident);
     if (!metalakeInUse) {
       throw new MetalakeNotInUseException(
-          "Metalake %s is not in use, please activate it first", ident);
+          "Metalake %s is not in use, please enable it first", ident);
     }
   }
 
@@ -208,7 +208,7 @@ public class MetalakeManager implements MetalakeDispatcher {
     try {
       if (!metalakeInUse(store, ident)) {
         throw new MetalakeNotInUseException(
-            "Metalake %s is not in use, please activate it first", ident);
+            "Metalake %s is not in use, please enable it first", ident);
       }
 
       return store.update(
@@ -248,7 +248,7 @@ public class MetalakeManager implements MetalakeDispatcher {
       boolean inUse = metalakeInUse(store, ident);
       if (inUse && !force) {
         throw new MetalakeInUseException(
-            "Metalake %s is in use, please deactivate it first or use force option", ident);
+            "Metalake %s is in use, please disable it first or use force option", ident);
       }
 
       List<CatalogEntity> catalogEntities =
@@ -256,12 +256,6 @@ public class MetalakeManager implements MetalakeDispatcher {
       if (!catalogEntities.isEmpty() && !force) {
         throw new NonEmptyEntityException(
             "Metalake %s has catalogs, please drop them first or use force option", ident);
-      }
-
-      // If reached here, it implies that the metalake is not in use or force is true.
-      if (inUse) {
-        // force is true, so deactivate the metalake first.
-        disableMetalake(ident);
       }
 
       return store.delete(ident, EntityType.METALAKE, true);

--- a/core/src/main/java/org/apache/gravitino/metalake/MetalakePropertiesMetadata.java
+++ b/core/src/main/java/org/apache/gravitino/metalake/MetalakePropertiesMetadata.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.metalake;
+
+import static org.apache.gravitino.Metalake.PROPERTY_IN_USE;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Maps;
+import java.util.List;
+import java.util.Map;
+import org.apache.gravitino.connector.PropertiesMetadata;
+import org.apache.gravitino.connector.PropertyEntry;
+
+public class MetalakePropertiesMetadata implements PropertiesMetadata {
+
+  private static final Map<String, PropertyEntry<?>> PROPERTY_ENTRIES;
+
+  static {
+    List<PropertyEntry<?>> propertyEntries =
+        ImmutableList.of(
+            PropertyEntry.booleanReservedPropertyEntry(
+                PROPERTY_IN_USE,
+                "The property indicating the catalog is in use",
+                true /* default value */,
+                false /* hidden */));
+
+    PROPERTY_ENTRIES = Maps.uniqueIndex(propertyEntries, PropertyEntry::getName);
+  }
+
+  @Override
+  public Map<String, PropertyEntry<?>> propertyEntries() {
+    return PROPERTY_ENTRIES;
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/proto/BaseMetalakeSerDe.java
+++ b/core/src/main/java/org/apache/gravitino/proto/BaseMetalakeSerDe.java
@@ -20,7 +20,6 @@
 package org.apache.gravitino.proto;
 
 import org.apache.gravitino.Namespace;
-import org.apache.gravitino.meta.AuditInfo;
 
 /** A class for serializing and deserializing BaseMetalake objects. */
 class BaseMetalakeSerDe implements ProtoSerDe<org.apache.gravitino.meta.BaseMetalake, Metalake> {
@@ -38,7 +37,7 @@ class BaseMetalakeSerDe implements ProtoSerDe<org.apache.gravitino.meta.BaseMeta
         Metalake.newBuilder()
             .setId(baseMetalake.id())
             .setName(baseMetalake.name())
-            .setAuditInfo(new AuditInfoSerDe().serialize((AuditInfo) baseMetalake.auditInfo()));
+            .setAuditInfo(new AuditInfoSerDe().serialize(baseMetalake.auditInfo()));
 
     if (baseMetalake.comment() != null) {
       builder.setComment(baseMetalake.comment());

--- a/core/src/main/java/org/apache/gravitino/tag/TagManager.java
+++ b/core/src/main/java/org/apache/gravitino/tag/TagManager.java
@@ -18,6 +18,8 @@
  */
 package org.apache.gravitino.tag;
 
+import static org.apache.gravitino.metalake.MetalakeManager.checkMetalake;
+
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
@@ -35,7 +37,6 @@ import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
 import org.apache.gravitino.exceptions.NoSuchEntityException;
 import org.apache.gravitino.exceptions.NoSuchMetadataObjectException;
-import org.apache.gravitino.exceptions.NoSuchMetalakeException;
 import org.apache.gravitino.exceptions.NoSuchTagException;
 import org.apache.gravitino.exceptions.NotFoundException;
 import org.apache.gravitino.exceptions.TagAlreadyAssociatedException;
@@ -93,7 +94,7 @@ public class TagManager {
         NameIdentifier.of(ofTagNamespace(metalake).levels()),
         LockType.READ,
         () -> {
-          checkMetalakeExists(metalake, entityStore);
+          checkMetalake(NameIdentifier.of(metalake), entityStore);
 
           try {
             return entityStore
@@ -114,7 +115,7 @@ public class TagManager {
         NameIdentifier.of(ofTagNamespace(metalake).levels()),
         LockType.WRITE,
         () -> {
-          checkMetalakeExists(metalake, entityStore);
+          checkMetalake(NameIdentifier.of(metalake), entityStore);
 
           TagEntity tagEntity =
               TagEntity.builder()
@@ -148,7 +149,7 @@ public class TagManager {
         ofTagIdent(metalake, name),
         LockType.READ,
         () -> {
-          checkMetalakeExists(metalake, entityStore);
+          checkMetalake(NameIdentifier.of(metalake), entityStore);
 
           try {
             return entityStore.get(
@@ -169,7 +170,7 @@ public class TagManager {
         NameIdentifier.of(ofTagNamespace(metalake).levels()),
         LockType.WRITE,
         () -> {
-          checkMetalakeExists(metalake, entityStore);
+          checkMetalake(NameIdentifier.of(metalake), entityStore);
 
           try {
             return entityStore.update(
@@ -195,7 +196,7 @@ public class TagManager {
         NameIdentifier.of(ofTagNamespace(metalake).levels()),
         LockType.WRITE,
         () -> {
-          checkMetalakeExists(metalake, entityStore);
+          checkMetalake(NameIdentifier.of(metalake), entityStore);
 
           try {
             return entityStore.delete(ofTagIdent(metalake, name), Entity.EntityType.TAG);
@@ -213,7 +214,7 @@ public class TagManager {
         tagId,
         LockType.READ,
         () -> {
-          checkMetalakeExists(metalake, entityStore);
+          checkMetalake(NameIdentifier.of(metalake), entityStore);
 
           try {
             if (!entityStore.exists(tagId, Entity.EntityType.TAG)) {
@@ -354,19 +355,6 @@ public class TagManager {
                     throw new RuntimeException(e);
                   }
                 }));
-  }
-
-  private static void checkMetalakeExists(String metalake, EntityStore entityStore) {
-    try {
-      NameIdentifier metalakeIdent = NameIdentifier.of(metalake);
-      if (!entityStore.exists(metalakeIdent, Entity.EntityType.METALAKE)) {
-        LOG.warn("Metalake {} does not exist", metalakeIdent);
-        throw new NoSuchMetalakeException("Metalake %s does not exist", metalakeIdent);
-      }
-    } catch (IOException ioe) {
-      LOG.error("Failed to check if metalake exists", ioe);
-      throw new RuntimeException(ioe);
-    }
   }
 
   public static Namespace ofTagNamespace(String metalake) {

--- a/core/src/test/java/org/apache/gravitino/listener/api/event/TestMetalakeEvent.java
+++ b/core/src/test/java/org/apache/gravitino/listener/api/event/TestMetalakeEvent.java
@@ -19,6 +19,7 @@
 
 package org.apache.gravitino.listener.api.event;
 
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -205,7 +206,7 @@ public class TestMetalakeEvent {
     when(dispatcher.createMetalake(any(NameIdentifier.class), any(String.class), any(Map.class)))
         .thenReturn(metalake);
     when(dispatcher.loadMetalake(any(NameIdentifier.class))).thenReturn(metalake);
-    when(dispatcher.dropMetalake(any(NameIdentifier.class))).thenReturn(true);
+    when(dispatcher.dropMetalake(any(NameIdentifier.class), anyBoolean())).thenReturn(true);
     when(dispatcher.listMetalakes()).thenReturn(null);
     when(dispatcher.alterMetalake(any(NameIdentifier.class), any(MetalakeChange.class)))
         .thenReturn(metalake);

--- a/core/src/test/java/org/apache/gravitino/metalake/TestMetalakeManager.java
+++ b/core/src/test/java/org/apache/gravitino/metalake/TestMetalakeManager.java
@@ -173,6 +173,7 @@ public class TestMetalakeManager {
     Assertions.assertEquals("comment", metalake.comment());
     testProperties(props, metalake.properties());
 
+    metalakeManager.disableMetalake(ident);
     boolean dropped = metalakeManager.dropMetalake(ident);
     Assertions.assertTrue(dropped, "metalake should be dropped");
 

--- a/core/src/test/java/org/apache/gravitino/storage/TestEntityStorage.java
+++ b/core/src/test/java/org/apache/gravitino/storage/TestEntityStorage.java
@@ -695,9 +695,7 @@ public class TestEntityStorage {
       // metalake
       BaseMetalake metalakeNew =
           createBaseMakeLake(
-              RandomIdGenerator.INSTANCE.nextId(),
-              metalake.name(),
-              (AuditInfo) metalake.auditInfo());
+              RandomIdGenerator.INSTANCE.nextId(), metalake.name(), metalake.auditInfo());
       store.put(metalakeNew);
       // catalog
       CatalogEntity catalogNew =
@@ -976,7 +974,7 @@ public class TestEntityStorage {
           NameIdentifier.of("metalake1"),
           BaseMetalake.class,
           Entity.EntityType.METALAKE,
-          e -> createBaseMakeLake(metalake1New.id(), "metalake2", (AuditInfo) e.auditInfo()));
+          e -> createBaseMakeLake(metalake1New.id(), "metalake2", e.auditInfo()));
 
       // Rename metalake3 --> metalake1
       BaseMetalake metalake3New1 =
@@ -986,7 +984,7 @@ public class TestEntityStorage {
           NameIdentifier.of("metalake3"),
           BaseMetalake.class,
           Entity.EntityType.METALAKE,
-          e -> createBaseMakeLake(metalake3New1.id(), "metalake1", (AuditInfo) e.auditInfo()));
+          e -> createBaseMakeLake(metalake3New1.id(), "metalake1", e.auditInfo()));
 
       // Rename metalake3 --> metalake2
       BaseMetalake metalake3New2 =
@@ -998,7 +996,7 @@ public class TestEntityStorage {
           NameIdentifier.of("metalake3"),
           BaseMetalake.class,
           Entity.EntityType.METALAKE,
-          e -> createBaseMakeLake(metalake3New2.id(), "metalake2", (AuditInfo) e.auditInfo()));
+          e -> createBaseMakeLake(metalake3New2.id(), "metalake2", e.auditInfo()));
 
       // Finally, only metalake2 and metalake1 are left.
       Assertions.assertDoesNotThrow(

--- a/server/src/main/java/org/apache/gravitino/server/web/rest/ExceptionHandlers.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/ExceptionHandlers.java
@@ -24,16 +24,18 @@ import javax.ws.rs.core.Response;
 import org.apache.gravitino.dto.responses.ErrorResponse;
 import org.apache.gravitino.exceptions.AlreadyExistsException;
 import org.apache.gravitino.exceptions.CatalogAlreadyExistsException;
-import org.apache.gravitino.exceptions.CatalogInUseException;
-import org.apache.gravitino.exceptions.CatalogNotInUseException;
 import org.apache.gravitino.exceptions.ConnectionFailedException;
 import org.apache.gravitino.exceptions.FilesetAlreadyExistsException;
 import org.apache.gravitino.exceptions.ForbiddenException;
 import org.apache.gravitino.exceptions.GroupAlreadyExistsException;
+import org.apache.gravitino.exceptions.InUseException;
 import org.apache.gravitino.exceptions.MetalakeAlreadyExistsException;
+import org.apache.gravitino.exceptions.MetalakeInUseException;
+import org.apache.gravitino.exceptions.MetalakeNotInUseException;
 import org.apache.gravitino.exceptions.NoSuchMetalakeException;
 import org.apache.gravitino.exceptions.NonEmptySchemaException;
 import org.apache.gravitino.exceptions.NotFoundException;
+import org.apache.gravitino.exceptions.NotInUseException;
 import org.apache.gravitino.exceptions.PartitionAlreadyExistsException;
 import org.apache.gravitino.exceptions.RoleAlreadyExistsException;
 import org.apache.gravitino.exceptions.SchemaAlreadyExistsException;
@@ -131,6 +133,9 @@ public class ExceptionHandlers {
     } else if (e instanceof AlreadyExistsException) {
       response = ErrorResponse.alreadyExists(e.getClass().getSimpleName(), e.getMessage(), e);
 
+    } else if (e instanceof NotInUseException) {
+      response = ErrorResponse.notInUse(e.getClass().getSimpleName(), e.getMessage(), e);
+
     } else {
       return Utils.internalError(e.getMessage(), e);
     }
@@ -180,7 +185,7 @@ public class ExceptionHandlers {
       } else if (e instanceof UnsupportedOperationException) {
         return Utils.unsupportedOperation(errorMsg, e);
 
-      } else if (e instanceof CatalogNotInUseException) {
+      } else if (e instanceof NotInUseException) {
         return Utils.notInUse(errorMsg, e);
 
       } else {
@@ -221,7 +226,7 @@ public class ExceptionHandlers {
       } else if (e instanceof ForbiddenException) {
         return Utils.forbidden(errorMsg, e);
 
-      } else if (e instanceof CatalogNotInUseException) {
+      } else if (e instanceof NotInUseException) {
         return Utils.notInUse(errorMsg, e);
 
       } else {
@@ -265,7 +270,7 @@ public class ExceptionHandlers {
       } else if (e instanceof ForbiddenException) {
         return Utils.forbidden(errorMsg, e);
 
-      } else if (e instanceof CatalogNotInUseException) {
+      } else if (e instanceof NotInUseException) {
         return Utils.notInUse(errorMsg, e);
 
       } else {
@@ -306,10 +311,10 @@ public class ExceptionHandlers {
       } else if (e instanceof CatalogAlreadyExistsException) {
         return Utils.alreadyExists(errorMsg, e);
 
-      } else if (e instanceof CatalogNotInUseException) {
+      } else if (e instanceof NotInUseException) {
         return Utils.notInUse(errorMsg, e);
 
-      } else if (e instanceof CatalogInUseException) {
+      } else if (e instanceof InUseException) {
         return Utils.inUse(errorMsg, e);
 
       } else {
@@ -342,6 +347,12 @@ public class ExceptionHandlers {
 
       } else if (e instanceof NoSuchMetalakeException) {
         return Utils.notFound(errorMsg, e);
+
+      } else if (e instanceof MetalakeNotInUseException) {
+        return Utils.notInUse(errorMsg, e);
+
+      } else if (e instanceof MetalakeInUseException) {
+        return Utils.inUse(errorMsg, e);
 
       } else {
         return super.handle(op, metalake, parent, e);
@@ -377,7 +388,7 @@ public class ExceptionHandlers {
       } else if (e instanceof ForbiddenException) {
         return Utils.forbidden(errorMsg, e);
 
-      } else if (e instanceof CatalogNotInUseException) {
+      } else if (e instanceof NotInUseException) {
         return Utils.notInUse(errorMsg, e);
 
       } else {
@@ -418,6 +429,9 @@ public class ExceptionHandlers {
       } else if (e instanceof UserAlreadyExistsException) {
         return Utils.alreadyExists(errorMsg, e);
 
+      } else if (e instanceof NotInUseException) {
+        return Utils.notInUse(errorMsg, e);
+
       } else {
         return super.handle(op, user, metalake, e);
       }
@@ -449,6 +463,9 @@ public class ExceptionHandlers {
 
       } else if (e instanceof GroupAlreadyExistsException) {
         return Utils.alreadyExists(errorMsg, e);
+
+      } else if (e instanceof NotInUseException) {
+        return Utils.notInUse(errorMsg, e);
 
       } else {
         return super.handle(op, group, metalake, e);
@@ -485,6 +502,9 @@ public class ExceptionHandlers {
       } else if (e instanceof ForbiddenException) {
         return Utils.forbidden(errorMsg, e);
 
+      } else if (e instanceof NotInUseException) {
+        return Utils.notInUse(errorMsg, e);
+
       } else {
         return super.handle(op, role, metalake, e);
       }
@@ -518,6 +538,10 @@ public class ExceptionHandlers {
 
       } else if (e instanceof ForbiddenException) {
         return Utils.forbidden(errorMsg, e);
+
+      } else if (e instanceof NotInUseException) {
+        return Utils.notInUse(errorMsg, e);
+
       } else {
         return super.handle(op, topic, schema, e);
       }
@@ -581,6 +605,9 @@ public class ExceptionHandlers {
       } else if (e instanceof NotFoundException) {
         return Utils.notFound(errorMsg, e);
 
+      } else if (e instanceof NotInUseException) {
+        return Utils.notInUse(errorMsg, e);
+
       } else {
         return super.handle(op, roles, parent, e);
       }
@@ -616,6 +643,9 @@ public class ExceptionHandlers {
       } else if (e instanceof TagAlreadyAssociatedException) {
         return Utils.alreadyExists(errorMsg, e);
 
+      } else if (e instanceof NotInUseException) {
+        return Utils.notInUse(errorMsg, e);
+
       } else {
         return super.handle(op, tag, parent, e);
       }
@@ -643,6 +673,10 @@ public class ExceptionHandlers {
 
       } else if (e instanceof NotFoundException) {
         return Utils.notFound(errorMsg, e);
+
+      } else if (e instanceof NotInUseException) {
+        return Utils.notInUse(errorMsg, e);
+
       } else {
         return super.handle(op, name, parent, e);
       }

--- a/server/src/main/java/org/apache/gravitino/server/web/rest/MetalakeOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/MetalakeOperations.java
@@ -25,12 +25,15 @@ import javax.inject.Inject;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
+import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
+import javax.ws.rs.PATCH;
 import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -40,8 +43,10 @@ import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
 import org.apache.gravitino.dto.MetalakeDTO;
 import org.apache.gravitino.dto.requests.MetalakeCreateRequest;
+import org.apache.gravitino.dto.requests.MetalakeSetRequest;
 import org.apache.gravitino.dto.requests.MetalakeUpdateRequest;
 import org.apache.gravitino.dto.requests.MetalakeUpdatesRequest;
+import org.apache.gravitino.dto.responses.BaseResponse;
 import org.apache.gravitino.dto.responses.DropResponse;
 import org.apache.gravitino.dto.responses.MetalakeListResponse;
 import org.apache.gravitino.dto.responses.MetalakeResponse;
@@ -149,6 +154,101 @@ public class MetalakeOperations {
     }
   }
 
+  @PATCH
+  @Path("{name}")
+  @Produces("application/vnd.gravitino.v1+json")
+  @Timed(name = "set-metalake." + MetricNames.HTTP_PROCESS_DURATION, absolute = true)
+  @ResponseMetered(name = "set-metalake", absolute = true)
+  public Response setMetalake(@PathParam("name") String metalakeName, MetalakeSetRequest request) {
+    LOG.info("Received set request for metalake: {}", metalakeName);
+    try {
+      return Utils.doAs(
+          httpRequest,
+          () -> {
+            NameIdentifier identifier = NameIdentifierUtil.ofMetalake(metalakeName);
+            TreeLockUtils.doWithTreeLock(
+                identifier,
+                LockType.WRITE,
+                () -> {
+                  if (request.isInUse()) {
+                    metalakeDispatcher.enableMetalake(identifier);
+                  } else {
+                    metalakeDispatcher.disableMetalake(identifier);
+                  }
+                  return null;
+                });
+            Response response = Utils.ok(new BaseResponse());
+            LOG.info(
+                "Successfully {} metalake: {}",
+                request.isInUse() ? "enable" : "disable",
+                metalakeName);
+            return response;
+          });
+
+    } catch (Exception e) {
+      LOG.info("Failed to {} metalake: {}", request.isInUse() ? "enable" : "disable", metalakeName);
+      return ExceptionHandlers.handleMetalakeException(OperationType.LOAD, metalakeName, e);
+    }
+  }
+
+  @GET
+  @Path("{name}/activate")
+  @Produces("application/vnd.gravitino.v1+json")
+  @Timed(name = "activate-metalake." + MetricNames.HTTP_PROCESS_DURATION, absolute = true)
+  @ResponseMetered(name = "activate-metalake", absolute = true)
+  public Response activateMetalake(@PathParam("name") String metalakeName) {
+    LOG.info("Received activate request for metalake: {}", metalakeName);
+    try {
+      return Utils.doAs(
+          httpRequest,
+          () -> {
+            NameIdentifier identifier = NameIdentifierUtil.ofMetalake(metalakeName);
+            TreeLockUtils.doWithTreeLock(
+                identifier,
+                LockType.READ,
+                () -> {
+                  metalakeDispatcher.enableMetalake(identifier);
+                  return null;
+                });
+            Response response = Utils.ok(new BaseResponse());
+            LOG.info("Metalake activated: {}", metalakeName);
+            return response;
+          });
+
+    } catch (Exception e) {
+      return ExceptionHandlers.handleMetalakeException(OperationType.LOAD, metalakeName, e);
+    }
+  }
+
+  @GET
+  @Path("{name}/deactivate")
+  @Produces("application/vnd.gravitino.v1+json")
+  @Timed(name = "deactivate-metalake." + MetricNames.HTTP_PROCESS_DURATION, absolute = true)
+  @ResponseMetered(name = "deactivate-metalake", absolute = true)
+  public Response deactivateMetalake(@PathParam("name") String metalakeName) {
+    LOG.info("Received deactivate request for metalake: {}", metalakeName);
+    try {
+      return Utils.doAs(
+          httpRequest,
+          () -> {
+            NameIdentifier identifier = NameIdentifierUtil.ofMetalake(metalakeName);
+            TreeLockUtils.doWithTreeLock(
+                identifier,
+                LockType.READ,
+                () -> {
+                  metalakeDispatcher.disableMetalake(identifier);
+                  return null;
+                });
+            Response response = Utils.ok(new BaseResponse());
+            LOG.info("Metalake deactivated: {}", metalakeName);
+            return response;
+          });
+
+    } catch (Exception e) {
+      return ExceptionHandlers.handleMetalakeException(OperationType.LOAD, metalakeName, e);
+    }
+  }
+
   @PUT
   @Path("{name}")
   @Produces("application/vnd.gravitino.v1+json")
@@ -186,7 +286,9 @@ public class MetalakeOperations {
   @Produces("application/vnd.gravitino.v1+json")
   @Timed(name = "drop-metalake." + MetricNames.HTTP_PROCESS_DURATION, absolute = true)
   @ResponseMetered(name = "drop-metalake", absolute = true)
-  public Response dropMetalake(@PathParam("name") String metalakeName) {
+  public Response dropMetalake(
+      @PathParam("name") String metalakeName,
+      @DefaultValue("false") @QueryParam("force") boolean force) {
     LOG.info("Received drop metalake request for metalake: {}", metalakeName);
     try {
       return Utils.doAs(
@@ -195,7 +297,7 @@ public class MetalakeOperations {
             NameIdentifier identifier = NameIdentifierUtil.ofMetalake(metalakeName);
             boolean dropped =
                 TreeLockUtils.doWithRootTreeLock(
-                    LockType.WRITE, () -> metalakeDispatcher.dropMetalake(identifier));
+                    LockType.WRITE, () -> metalakeDispatcher.dropMetalake(identifier, force));
             if (!dropped) {
               LOG.warn("Failed to drop metalake by name {}", metalakeName);
             }

--- a/server/src/main/java/org/apache/gravitino/server/web/rest/MetalakeOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/MetalakeOperations.java
@@ -191,64 +191,6 @@ public class MetalakeOperations {
     }
   }
 
-  @GET
-  @Path("{name}/activate")
-  @Produces("application/vnd.gravitino.v1+json")
-  @Timed(name = "activate-metalake." + MetricNames.HTTP_PROCESS_DURATION, absolute = true)
-  @ResponseMetered(name = "activate-metalake", absolute = true)
-  public Response activateMetalake(@PathParam("name") String metalakeName) {
-    LOG.info("Received activate request for metalake: {}", metalakeName);
-    try {
-      return Utils.doAs(
-          httpRequest,
-          () -> {
-            NameIdentifier identifier = NameIdentifierUtil.ofMetalake(metalakeName);
-            TreeLockUtils.doWithTreeLock(
-                identifier,
-                LockType.READ,
-                () -> {
-                  metalakeDispatcher.enableMetalake(identifier);
-                  return null;
-                });
-            Response response = Utils.ok(new BaseResponse());
-            LOG.info("Metalake activated: {}", metalakeName);
-            return response;
-          });
-
-    } catch (Exception e) {
-      return ExceptionHandlers.handleMetalakeException(OperationType.LOAD, metalakeName, e);
-    }
-  }
-
-  @GET
-  @Path("{name}/deactivate")
-  @Produces("application/vnd.gravitino.v1+json")
-  @Timed(name = "deactivate-metalake." + MetricNames.HTTP_PROCESS_DURATION, absolute = true)
-  @ResponseMetered(name = "deactivate-metalake", absolute = true)
-  public Response deactivateMetalake(@PathParam("name") String metalakeName) {
-    LOG.info("Received deactivate request for metalake: {}", metalakeName);
-    try {
-      return Utils.doAs(
-          httpRequest,
-          () -> {
-            NameIdentifier identifier = NameIdentifierUtil.ofMetalake(metalakeName);
-            TreeLockUtils.doWithTreeLock(
-                identifier,
-                LockType.READ,
-                () -> {
-                  metalakeDispatcher.disableMetalake(identifier);
-                  return null;
-                });
-            Response response = Utils.ok(new BaseResponse());
-            LOG.info("Metalake deactivated: {}", metalakeName);
-            return response;
-          });
-
-    } catch (Exception e) {
-      return ExceptionHandlers.handleMetalakeException(OperationType.LOAD, metalakeName, e);
-    }
-  }
-
   @PUT
   @Path("{name}")
   @Produces("application/vnd.gravitino.v1+json")

--- a/server/src/test/java/org/apache/gravitino/server/web/rest/TestMetalakeOperations.java
+++ b/server/src/test/java/org/apache/gravitino/server/web/rest/TestMetalakeOperations.java
@@ -22,6 +22,7 @@ import static org.apache.gravitino.Configs.TREE_LOCK_CLEAN_INTERVAL;
 import static org.apache.gravitino.Configs.TREE_LOCK_MAX_NODE_IN_MEMORY;
 import static org.apache.gravitino.Configs.TREE_LOCK_MIN_NODE_IN_MEMORY;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -381,7 +382,7 @@ public class TestMetalakeOperations extends JerseyTest {
 
   @Test
   public void testDropMetalake() {
-    when(metalakeManager.dropMetalake(any())).thenReturn(true);
+    when(metalakeManager.dropMetalake(any(), anyBoolean())).thenReturn(true);
     Response resp =
         target("/metalakes/test")
             .request(MediaType.APPLICATION_JSON_TYPE)
@@ -396,7 +397,7 @@ public class TestMetalakeOperations extends JerseyTest {
     Assertions.assertTrue(dropped);
 
     // Test when failed to drop metalake
-    when(metalakeManager.dropMetalake(any())).thenReturn(false);
+    when(metalakeManager.dropMetalake(any(), anyBoolean())).thenReturn(false);
     Response resp2 =
         target("/metalakes/test")
             .request(MediaType.APPLICATION_JSON_TYPE)
@@ -408,7 +409,9 @@ public class TestMetalakeOperations extends JerseyTest {
     Assertions.assertFalse(dropResponse2.dropped());
 
     // Test throw an exception when deleting tenant.
-    doThrow(new RuntimeException("Internal error")).when(metalakeManager).dropMetalake(any());
+    doThrow(new RuntimeException("Internal error"))
+        .when(metalakeManager)
+        .dropMetalake(any(), anyBoolean());
 
     Response resp1 =
         target("/metalakes/test")

--- a/trino-connector/integration-test/src/test/java/org/apache/gravitino/trino/connector/integration/test/TrinoQueryITBase.java
+++ b/trino-connector/integration-test/src/test/java/org/apache/gravitino/trino/connector/integration/test/TrinoQueryITBase.java
@@ -156,7 +156,7 @@ public class TrinoQueryITBase {
     if (!exists) {
       return;
     }
-    gravitinoClient.dropMetalake(metalakeName);
+    gravitinoClient.dropMetalake(metalakeName, true);
   }
 
   private static void createCatalog(

--- a/web/web/src/lib/api/metalakes/index.js
+++ b/web/web/src/lib/api/metalakes/index.js
@@ -47,7 +47,7 @@ export const createMetalakeApi = data => {
 
 export const deleteMetalakeApi = name => {
   return defHttp.delete({
-    url: `${Apis.DELETE}/${name}`
+    url: `${Apis.DELETE}/${name}?force=true`
   })
 }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

 - Add an in-use property to the metalake with the default value of true.
 - Only empty metalake with in-use=false can be dropped when `force=false`
 - User can use `dorce` option to drop metalake
 - More drop metalake limitations please see the JavaDoc of `dropMetalake` in API module

### Why are the changes needed?

Fix: #5154 

### Does this PR introduce _any_ user-facing change?

yes, users now can not drop an in used metalake

### How was this patch tested?

tests added
