### PR TITLE
[#5152] fix(oceanbase-catalog): OB catalog UTs failed on Mac

### DIFF
--- a/integration-test-common/src/test/java/org/apache/gravitino/integration/test/container/BaseContainer.java
+++ b/integration-test-common/src/test/java/org/apache/gravitino/integration/test/container/BaseContainer.java
@@ -24,6 +24,7 @@ import static org.testcontainers.utility.MountableFile.forHostPath;
 import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.command.InspectContainerResponse;
 import com.github.dockerjava.api.model.ContainerNetwork;
+import com.github.dockerjava.api.model.Ulimit;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -79,8 +80,8 @@ public abstract class BaseContainer implements AutoCloseable {
                 cmd ->
                     cmd.getHostConfig()
                         .withSysctls(
-                            Collections.singletonMap(
-                                "net.ipv4.ip_local_port_range", "20000 40000")));
+                            Collections.singletonMap("net.ipv4.ip_local_port_range", "20000 40000"))
+                        .withUlimits(new Ulimit[] {new Ulimit("nproc", 120000L, 120000L)}));
     this.ports = requireNonNull(ports, "ports is null");
     this.hostName = requireNonNull(hostName, "hostName is null");
     this.extraHosts = extraHosts;


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

The max user processes in the OB catalog unit tests should be larger than 120000

### Why are the changes needed?

Fix: #5152

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

./gradlew :catalogs:catalog-jdbc-oceanbase:test -PskipDockerTests=false 


