### PR TITLE
[#5175] docs: add playgound information in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,9 +81,13 @@ Please see [How to build Gravitino](docs/how-to-build.md) for details on buildin
 
 ## Quick start
 
-### Configure and start the Apache Gravitino server
+### Use Gravitino playground
 
-If you already have a binary distribution package, go to the decompressed package directory.
+This is the most recommended way: Gravitino provides a docker-compose based playground to quickly experience the whole system together with other components. Clone or download the [Gravitino playground repository](https://github.com/apache/gravitino-playground) and then follow the [README](https://github.com/apache/gravitino-playground/blob/main/README.md), you will have all then.
+
+### Configure and start Gravitino server in local
+
+If you want to start Gravitino in your machine, download a binary package from the [download page](https://gravitino.apache.org/downloads), and then decompressed the package.
 
 Before starting the Gravitino server, please configure the Gravitino server configuration file. The
 configuration file, `gravitino.conf`, is in the `conf` directory and follows the standard property file format. You can modify the configuration within this file.


### PR DESCRIPTION
### What changes were proposed in this pull request?

Some users suggest us to add the playgound link to Gravitino homepage as well as code repository, so that a new user can quickly know there is such a quick way to evaluate Gravitino.

### Why are the changes needed?

To improve the user experience, especially for new user.

Fix: #5175

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Reviewed the doc in local.
