### PR TITLE
[#5196] improve(auth-ranger): Refactor RangerSecurableObject class

### DIFF
--- a/api/src/main/java/org/apache/gravitino/MetadataObjects.java
+++ b/api/src/main/java/org/apache/gravitino/MetadataObjects.java
@@ -49,7 +49,8 @@ public class MetadataObjects {
     Preconditions.checkArgument(name != null, "Cannot create a metadata object with null name");
     Preconditions.checkArgument(type != null, "Cannot create a metadata object with no type");
 
-    return new MetadataObjectImpl(parent, name, type);
+    String fullName = parent == null ? name : DOT_JOINER.join(parent, name);
+    return parse(fullName, type);
   }
 
   /**
@@ -159,7 +160,7 @@ public class MetadataObjects {
    * @param names The names of the metadata object
    * @return The parent full name if it exists, otherwise null
    */
-  public static String getParentFullName(List<String> names) {
+  private static String getParentFullName(List<String> names) {
     if (names.size() <= 1) {
       return null;
     }

--- a/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/RangerAuthorizationHivePlugin.java
+++ b/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/RangerAuthorizationHivePlugin.java
@@ -65,9 +65,7 @@ public class RangerAuthorizationHivePlugin extends RangerAuthorizationPlugin {
   public void validateRangerMetadataObject(List<String> names, RangerMetadataObject.Type type)
       throws IllegalArgumentException {
     Preconditions.checkArgument(
-        names != null, "Cannot create a Ranger metadata object with null names");
-    Preconditions.checkArgument(
-        !names.isEmpty(), "Cannot create a Ranger metadata object with no names");
+        names != null && !names.isEmpty(), "Cannot create a Ranger metadata object with no names");
     Preconditions.checkArgument(
         names.size() <= 3,
         "Cannot create a Ranger metadata object with the name length which is greater than 3");

--- a/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/RangerAuthorizationHivePlugin.java
+++ b/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/RangerAuthorizationHivePlugin.java
@@ -60,9 +60,10 @@ public class RangerAuthorizationHivePlugin extends RangerAuthorizationPlugin {
     return instance;
   }
 
+  /** Validate different Ranger metadata object */
   @Override
-  public RangerSecurableObject generateRangerSecurableObject(
-      List<String> names, RangerMetadataObject.Type type, Set<RangerPrivilege> privileges) {
+  public void validateRangerMetadataObject(List<String> names, RangerMetadataObject.Type type)
+      throws IllegalArgumentException {
     Preconditions.checkArgument(
         names != null, "Cannot create a Ranger metadata object with null names");
     Preconditions.checkArgument(
@@ -88,15 +89,6 @@ public class RangerAuthorizationHivePlugin extends RangerAuthorizationPlugin {
     for (String name : names) {
       RangerMetadataObjects.checkName(name);
     }
-
-    RangerMetadataObject metadataObject =
-        new RangerMetadataObjects.RangerMetadataObjectImpl(
-            RangerMetadataObjects.getParentFullName(names),
-            RangerMetadataObjects.getLastName(names),
-            type);
-
-    return new RangerSecurableObjects.RangerSecurableObjectImpl(
-        metadataObject.parent(), metadataObject.name(), metadataObject.type(), privileges);
   }
 
   @Override

--- a/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/RangerAuthorizationHivePlugin.java
+++ b/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/RangerAuthorizationHivePlugin.java
@@ -110,10 +110,10 @@ public class RangerAuthorizationHivePlugin extends RangerAuthorizationPlugin {
   }
 
   /** Translate the Gravitino securable object to the Ranger owner securable object. */
-  public List<RangerSecurableObject> translateOwner(MetadataObject metadataObject) {
+  public List<RangerSecurableObject> translateOwner(MetadataObject gravitinoMetadataObject) {
     List<RangerSecurableObject> rangerSecurableObjects = new ArrayList<>();
 
-    switch (metadataObject.type()) {
+    switch (gravitinoMetadataObject.type()) {
       case METALAKE:
       case CATALOG:
         // Add `*` for the SCHEMA permission
@@ -142,20 +142,21 @@ public class RangerAuthorizationHivePlugin extends RangerAuthorizationPlugin {
         // Add `{schema}` for the SCHEMA permission
         rangerSecurableObjects.add(
             RangerSecurableObjects.of(
-                ImmutableList.of(metadataObject.name() /*Schema name*/),
+                ImmutableList.of(gravitinoMetadataObject.name() /*Schema name*/),
                 MetadataObject.Type.SCHEMA,
                 ownerMappingRule()));
         // Add `{schema}.*` for the TABLE permission
         rangerSecurableObjects.add(
             RangerSecurableObjects.of(
-                ImmutableList.of(metadataObject.name() /*Schema name*/, RangerHelper.RESOURCE_ALL),
+                ImmutableList.of(
+                    gravitinoMetadataObject.name() /*Schema name*/, RangerHelper.RESOURCE_ALL),
                 MetadataObject.Type.TABLE,
                 ownerMappingRule()));
         // Add `{schema}.*.*` for the COLUMN permission
         rangerSecurableObjects.add(
             RangerSecurableObjects.of(
                 ImmutableList.of(
-                    metadataObject.name() /*Schema name*/,
+                    gravitinoMetadataObject.name() /*Schema name*/,
                     RangerHelper.RESOURCE_ALL,
                     RangerHelper.RESOURCE_ALL),
                 MetadataObject.Type.COLUMN,
@@ -165,14 +166,14 @@ public class RangerAuthorizationHivePlugin extends RangerAuthorizationPlugin {
         // Add `{schema}.{table}` for the TABLE permission
         rangerSecurableObjects.add(
             RangerSecurableObjects.of(
-                convertToRangerMetadataObject(metadataObject),
+                convertToRangerMetadataObject(gravitinoMetadataObject),
                 MetadataObject.Type.TABLE,
                 ownerMappingRule()));
         // Add `{schema}.{table}.*` for the COLUMN permission
         rangerSecurableObjects.add(
             RangerSecurableObjects.of(
                 Stream.concat(
-                        convertToRangerMetadataObject(metadataObject).stream(),
+                        convertToRangerMetadataObject(gravitinoMetadataObject).stream(),
                         Stream.of(RangerHelper.RESOURCE_ALL))
                     .collect(Collectors.toList()),
                 MetadataObject.Type.COLUMN,
@@ -181,7 +182,7 @@ public class RangerAuthorizationHivePlugin extends RangerAuthorizationPlugin {
       default:
         throw new AuthorizationPluginException(
             "The owner privilege is not supported for the securable object: %s",
-            metadataObject.type());
+            gravitinoMetadataObject.type());
     }
 
     return rangerSecurableObjects;

--- a/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/RangerAuthorizationPlugin.java
+++ b/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/RangerAuthorizationPlugin.java
@@ -38,7 +38,7 @@ import org.apache.gravitino.authorization.Role;
 import org.apache.gravitino.authorization.RoleChange;
 import org.apache.gravitino.authorization.SecurableObject;
 import org.apache.gravitino.authorization.User;
-import org.apache.gravitino.authorization.ranger.RangerSecurableObjects.RangerSecurableObjectImplementor;
+import org.apache.gravitino.authorization.ranger.RangerMetadataObjects.RangerMetadataObjectRule;
 import org.apache.gravitino.authorization.ranger.reference.VXGroup;
 import org.apache.gravitino.authorization.ranger.reference.VXGroupList;
 import org.apache.gravitino.authorization.ranger.reference.VXUser;
@@ -68,9 +68,7 @@ import org.slf4j.LoggerFactory;
  * implement Gravitino Owner concept. <br>
  */
 public abstract class RangerAuthorizationPlugin
-    implements AuthorizationPlugin,
-        RangerPrivilegesMappingProvider,
-        RangerSecurableObjectImplementor {
+    implements AuthorizationPlugin, RangerPrivilegesMappingProvider, RangerMetadataObjectRule {
   private static final Logger LOG = LoggerFactory.getLogger(RangerAuthorizationPlugin.class);
 
   protected final String rangerServiceName;
@@ -662,6 +660,19 @@ public abstract class RangerAuthorizationPlugin
 
   @Override
   public void close() throws IOException {}
+
+  /** Generate different Ranger securable object */
+  public RangerSecurableObject generateRangerSecurableObject(
+      List<String> names, RangerMetadataObject.Type type, Set<RangerPrivilege> privileges) {
+    validateRangerMetadataObject(names, type);
+    RangerMetadataObject metadataObject =
+        new RangerMetadataObjects.RangerMetadataObjectImpl(
+            RangerMetadataObjects.getParentFullName(names),
+            RangerMetadataObjects.getLastName(names),
+            type);
+    return new RangerSecurableObjects.RangerSecurableObjectImpl(
+        metadataObject.parent(), metadataObject.name(), metadataObject.type(), privileges);
+  }
 
   public boolean validAuthorizationOperation(List<SecurableObject> securableObjects) {
     return securableObjects.stream()

--- a/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/RangerAuthorizationPlugin.java
+++ b/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/RangerAuthorizationPlugin.java
@@ -660,7 +660,7 @@ public abstract class RangerAuthorizationPlugin
   @Override
   public void close() throws IOException {}
 
-  boolean validAuthorizationOperation(List<SecurableObject> securableObjects) {
+  public boolean validAuthorizationOperation(List<SecurableObject> securableObjects) {
     return securableObjects.stream()
         .allMatch(
             securableObject -> {

--- a/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/RangerAuthorizationPlugin.java
+++ b/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/RangerAuthorizationPlugin.java
@@ -38,7 +38,6 @@ import org.apache.gravitino.authorization.Role;
 import org.apache.gravitino.authorization.RoleChange;
 import org.apache.gravitino.authorization.SecurableObject;
 import org.apache.gravitino.authorization.User;
-import org.apache.gravitino.authorization.ranger.RangerMetadataObjects.RangerMetadataObjectRule;
 import org.apache.gravitino.authorization.ranger.reference.VXGroup;
 import org.apache.gravitino.authorization.ranger.reference.VXGroupList;
 import org.apache.gravitino.authorization.ranger.reference.VXUser;

--- a/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/RangerAuthorizationPlugin.java
+++ b/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/RangerAuthorizationPlugin.java
@@ -38,6 +38,7 @@ import org.apache.gravitino.authorization.Role;
 import org.apache.gravitino.authorization.RoleChange;
 import org.apache.gravitino.authorization.SecurableObject;
 import org.apache.gravitino.authorization.User;
+import org.apache.gravitino.authorization.ranger.RangerSecurableObjects.RangerSecurableObjectImplementor;
 import org.apache.gravitino.authorization.ranger.reference.VXGroup;
 import org.apache.gravitino.authorization.ranger.reference.VXGroupList;
 import org.apache.gravitino.authorization.ranger.reference.VXUser;
@@ -67,7 +68,9 @@ import org.slf4j.LoggerFactory;
  * implement Gravitino Owner concept. <br>
  */
 public abstract class RangerAuthorizationPlugin
-    implements AuthorizationPlugin, RangerPrivilegesMappingProvider {
+    implements AuthorizationPlugin,
+        RangerPrivilegesMappingProvider,
+        RangerSecurableObjectImplementor {
   private static final Logger LOG = LoggerFactory.getLogger(RangerAuthorizationPlugin.class);
 
   protected final String rangerServiceName;

--- a/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/RangerMetadataObject.java
+++ b/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/RangerMetadataObject.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.authorization.ranger;
+
+import java.util.List;
+import javax.annotation.Nullable;
+import org.apache.gravitino.MetadataObject;
+import org.apache.gravitino.annotation.Unstable;
+
+/**
+ * The Ranger MetadataObject is the basic unit of the Gravitino system. It represents the Apache
+ * Ranger metadata object in the Apache Gravitino system. The object can be a catalog, schema,
+ * table, column, etc.
+ */
+@Unstable
+public interface RangerMetadataObject {
+  /**
+   * The type of object in the Ranger system. Every type will map one kind of the entity of the
+   * Gravitino type system.
+   */
+  enum Type {
+    /** A schema is a sub collection of the catalog. The schema can contain tables, columns, etc. */
+    SCHEMA(MetadataObject.Type.SCHEMA),
+    /** A table is mapped the table of relational data sources like Apache Hive, MySQL, etc. */
+    TABLE(MetadataObject.Type.TABLE),
+    /** A column is a sub-collection of the table that represents a group of same type data. */
+    COLUMN(MetadataObject.Type.COLUMN);
+
+    private final MetadataObject.Type metadataType;
+
+    Type(MetadataObject.Type type) {
+      this.metadataType = type;
+    }
+
+    public MetadataObject.Type getMetadataType() {
+      return metadataType;
+    }
+
+    public static Type fromMetadataType(MetadataObject.Type metadataType) {
+      for (Type type : Type.values()) {
+        if (type.getMetadataType() == metadataType) {
+          return type;
+        }
+      }
+      throw new IllegalArgumentException(
+          "No matching RangerMetadataObject.Type for " + metadataType);
+    }
+  }
+
+  /**
+   * The parent full name of the object. If the object doesn't have parent, this method will return
+   * null.
+   *
+   * @return The parent full name of the object.
+   */
+  @Nullable
+  String parent();
+
+  /**
+   * The name of th object.
+   *
+   * @return The name of the object.
+   */
+  String name();
+
+  /**
+   * The all name list of th object.
+   *
+   * @return The name list of the object.
+   */
+  List<String> names();
+
+  /**
+   * The full name of th object. Full name will be separated by "." to represent a string identifier
+   * of the object, like catalog, catalog.table, etc.
+   *
+   * @return The name of the object.
+   */
+  default String fullName() {
+    if (parent() == null) {
+      return name();
+    } else {
+      return parent() + "." + name();
+    }
+  }
+
+  /**
+   * The type of the object.
+   *
+   * @return The type of the object.
+   */
+  Type type();
+}

--- a/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/RangerMetadataObjectRule.java
+++ b/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/RangerMetadataObjectRule.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.gravitino.authorization.ranger;
 
 import java.util.List;

--- a/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/RangerMetadataObjectRule.java
+++ b/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/RangerMetadataObjectRule.java
@@ -1,0 +1,10 @@
+package org.apache.gravitino.authorization.ranger;
+
+import java.util.List;
+
+/** Different underlying datasource have different Ranger metadata object rules */
+interface RangerMetadataObjectRule {
+  /** Validate different underlying datasource Ranger metadata object */
+  void validateRangerMetadataObject(List<String> names, RangerMetadataObject.Type type)
+      throws IllegalArgumentException;
+}

--- a/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/RangerMetadataObjects.java
+++ b/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/RangerMetadataObjects.java
@@ -55,13 +55,6 @@ public class RangerMetadataObjects {
     Preconditions.checkArgument(name != null, "Cannot create a metadata object with null name");
   }
 
-  /** Different underlying datasource have different Ranger securable object rules */
-  interface RangerMetadataObjectRule {
-    /** Validate different underlying datasource Ranger metadata object */
-    void validateRangerMetadataObject(List<String> names, RangerMetadataObject.Type type)
-        throws IllegalArgumentException;
-  }
-
   /** The implementation of the {@link MetadataObject}. */
   public static class RangerMetadataObjectImpl implements RangerMetadataObject {
     private final String name;

--- a/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/RangerMetadataObjects.java
+++ b/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/RangerMetadataObjects.java
@@ -34,46 +34,6 @@ public class RangerMetadataObjects {
   private RangerMetadataObjects() {}
 
   /**
-   * Create the Ranger metadata object with the given names and Gravitino type.
-   *
-   * @param names The names of the Gravitino metadata object
-   * @param type The type of the Gravitino metadata object
-   * @return The created Ranger metadata object
-   */
-  public static RangerMetadataObject of(List<String> names, MetadataObject.Type type) {
-    Preconditions.checkArgument(
-        names != null, "Cannot create a Ranger metadata object with null names");
-    Preconditions.checkArgument(
-        !names.isEmpty(), "Cannot create a Ranger metadata object with no names");
-    Preconditions.checkArgument(
-        names.size() <= 3,
-        "Cannot create a Ranger metadata object with the name length which is greater than 3");
-    Preconditions.checkArgument(
-        type != null, "Cannot create a Ranger metadata object with no type");
-
-    Preconditions.checkArgument(
-        names.size() != 1 || type == MetadataObject.Type.SCHEMA,
-        "If the length of names is 1, it must be the SCHEMA type");
-
-    Preconditions.checkArgument(
-        names.size() != 2 || type == MetadataObject.Type.TABLE,
-        "If the length of names is 2, it must be the TABLE type");
-
-    Preconditions.checkArgument(
-        names.size() != 3 || type == MetadataObject.Type.COLUMN,
-        "If the length of names is 3, it must be COLUMN");
-
-    for (String name : names) {
-      checkName(name);
-    }
-
-    return new RangerMetadataObjectImpl(
-        getParentFullName(names),
-        getLastName(names),
-        RangerMetadataObject.Type.fromMetadataType(type));
-  }
-
-  /**
    * Get the parent full name of the given full name.
    *
    * @param names The names of the metadata object
@@ -87,11 +47,11 @@ public class RangerMetadataObjects {
     return DOT_JOINER.join(names.subList(0, names.size() - 1));
   }
 
-  private static String getLastName(List<String> names) {
+  static String getLastName(List<String> names) {
     return names.get(names.size() - 1);
   }
 
-  private static void checkName(String name) {
+  static void checkName(String name) {
     Preconditions.checkArgument(name != null, "Cannot create a metadata object with null name");
   }
 

--- a/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/RangerMetadataObjects.java
+++ b/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/RangerMetadataObjects.java
@@ -55,6 +55,13 @@ public class RangerMetadataObjects {
     Preconditions.checkArgument(name != null, "Cannot create a metadata object with null name");
   }
 
+  /** Different underlying datasource have different Ranger securable object rules */
+  interface RangerMetadataObjectRule {
+    /** Validate different underlying datasource Ranger metadata object */
+    void validateRangerMetadataObject(List<String> names, RangerMetadataObject.Type type)
+        throws IllegalArgumentException;
+  }
+
   /** The implementation of the {@link MetadataObject}. */
   public static class RangerMetadataObjectImpl implements RangerMetadataObject {
     private final String name;

--- a/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/RangerMetadataObjects.java
+++ b/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/RangerMetadataObjects.java
@@ -1,0 +1,165 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.authorization.ranger;
+
+import com.google.common.base.Joiner;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Splitter;
+import com.google.common.collect.Lists;
+import java.util.List;
+import org.apache.gravitino.MetadataObject;
+
+/** The helper class for {@link RangerMetadataObject}. */
+public class RangerMetadataObjects {
+  private static final Splitter DOT_SPLITTER = Splitter.on('.');
+
+  private static final Joiner DOT_JOINER = Joiner.on('.');
+
+  private RangerMetadataObjects() {}
+
+  /**
+   * Create the Ranger metadata object with the given names and Gravitino type.
+   *
+   * @param names The names of the Gravitino metadata object
+   * @param type The type of the Gravitino metadata object
+   * @return The created Ranger metadata object
+   */
+  public static RangerMetadataObject of(List<String> names, MetadataObject.Type type) {
+    Preconditions.checkArgument(
+        names != null, "Cannot create a Ranger metadata object with null names");
+    Preconditions.checkArgument(
+        !names.isEmpty(), "Cannot create a Ranger metadata object with no names");
+    Preconditions.checkArgument(
+        names.size() <= 3,
+        "Cannot create a Ranger metadata object with the name length which is greater than 3");
+    Preconditions.checkArgument(
+        type != null, "Cannot create a Ranger metadata object with no type");
+
+    Preconditions.checkArgument(
+        names.size() != 1 || type == MetadataObject.Type.SCHEMA,
+        "If the length of names is 1, it must be the SCHEMA type");
+
+    Preconditions.checkArgument(
+        names.size() != 2 || type == MetadataObject.Type.TABLE,
+        "If the length of names is 2, it must be the TABLE type");
+
+    Preconditions.checkArgument(
+        names.size() != 3 || type == MetadataObject.Type.COLUMN,
+        "If the length of names is 3, it must be COLUMN");
+
+    for (String name : names) {
+      checkName(name);
+    }
+
+    return new RangerMetadataObjectImpl(
+        getParentFullName(names),
+        getLastName(names),
+        RangerMetadataObject.Type.fromMetadataType(type));
+  }
+
+  /**
+   * Get the parent full name of the given full name.
+   *
+   * @param names The names of the metadata object
+   * @return The parent full name if it exists, otherwise null
+   */
+  public static String getParentFullName(List<String> names) {
+    if (names.size() <= 1) {
+      return null;
+    }
+
+    return DOT_JOINER.join(names.subList(0, names.size() - 1));
+  }
+
+  private static String getLastName(List<String> names) {
+    return names.get(names.size() - 1);
+  }
+
+  private static void checkName(String name) {
+    Preconditions.checkArgument(name != null, "Cannot create a metadata object with null name");
+  }
+
+  /** The implementation of the {@link MetadataObject}. */
+  public static class RangerMetadataObjectImpl implements RangerMetadataObject {
+    private final String name;
+
+    private final String parent;
+
+    private final RangerMetadataObject.Type type;
+
+    /**
+     * Create the metadata object with the given name, parent and type.
+     *
+     * @param parent The parent of the metadata object
+     * @param name The name of the metadata object
+     * @param type The type of the metadata object
+     */
+    public RangerMetadataObjectImpl(String parent, String name, RangerMetadataObject.Type type) {
+      this.parent = parent;
+      this.name = name;
+      this.type = type;
+    }
+
+    @Override
+    public String name() {
+      return name;
+    }
+
+    @Override
+    public List<String> names() {
+      return Lists.newArrayList(DOT_SPLITTER.splitToList(fullName()));
+    }
+
+    @Override
+    public String parent() {
+      return parent;
+    }
+
+    @Override
+    public Type type() {
+      return type;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+
+      if (!(o instanceof RangerMetadataObjectImpl)) {
+        return false;
+      }
+
+      RangerMetadataObjectImpl that = (RangerMetadataObjectImpl) o;
+      return java.util.Objects.equals(name, that.name)
+          && java.util.Objects.equals(parent, that.parent)
+          && type == that.type;
+    }
+
+    @Override
+    public int hashCode() {
+      return java.util.Objects.hash(name, parent, type);
+    }
+
+    @Override
+    public String toString() {
+      return "MetadataObject: [fullName=" + fullName() + "], [type=" + type + "]";
+    }
+  }
+}

--- a/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/RangerMetadataObjects.java
+++ b/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/RangerMetadataObjects.java
@@ -48,6 +48,7 @@ public class RangerMetadataObjects {
   }
 
   static String getLastName(List<String> names) {
+    Preconditions.checkArgument(names.size() > 0, "Cannot get the last name of an empty list");
     return names.get(names.size() - 1);
   }
 

--- a/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/RangerSecurableObject.java
+++ b/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/RangerSecurableObject.java
@@ -19,7 +19,6 @@
 package org.apache.gravitino.authorization.ranger;
 
 import java.util.List;
-import org.apache.gravitino.MetadataObject;
 import org.apache.gravitino.annotation.Unstable;
 
 /**
@@ -32,7 +31,7 @@ import org.apache.gravitino.annotation.Unstable;
  * specifically.
  */
 @Unstable
-public interface RangerSecurableObject extends MetadataObject {
+public interface RangerSecurableObject extends RangerMetadataObject {
   /**
    * The privileges of the Ranger securable object.
    *

--- a/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/RangerSecurableObjects.java
+++ b/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/RangerSecurableObjects.java
@@ -22,19 +22,17 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Sets;
 import java.util.List;
 import java.util.Set;
-import org.apache.gravitino.MetadataObject;
 import org.apache.gravitino.authorization.ranger.RangerMetadataObjects.RangerMetadataObjectImpl;
 
 /** The helper class for {@link RangerSecurableObject}. */
 public class RangerSecurableObjects {
-  public static RangerSecurableObject of(
-      List<String> names, MetadataObject.Type type, Set<RangerPrivilege> privileges) {
-    RangerMetadataObject metadataObject = RangerMetadataObjects.of(names, type);
-    return new RangerSecurableObjectImpl(
-        metadataObject.parent(), metadataObject.name(), metadataObject.type(), privileges);
+  /** Different underlying datasource have different Ranger securable object implement */
+  interface RangerSecurableObjectImplementor {
+    RangerSecurableObject generateRangerSecurableObject(
+        List<String> names, RangerMetadataObject.Type type, Set<RangerPrivilege> privileges);
   }
 
-  private static class RangerSecurableObjectImpl extends RangerMetadataObjectImpl
+  public static class RangerSecurableObjectImpl extends RangerMetadataObjectImpl
       implements RangerSecurableObject {
 
     private final List<RangerPrivilege> privileges;

--- a/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/RangerSecurableObjects.java
+++ b/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/RangerSecurableObjects.java
@@ -48,16 +48,6 @@ public class RangerSecurableObjects {
     }
 
     @Override
-    public String fullName() {
-      return super.fullName();
-    }
-
-    @Override
-    public RangerMetadataObject.Type type() {
-      return super.type();
-    }
-
-    @Override
     public List<RangerPrivilege> privileges() {
       return privileges;
     }

--- a/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/RangerSecurableObjects.java
+++ b/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/RangerSecurableObjects.java
@@ -23,22 +23,20 @@ import com.google.common.collect.Sets;
 import java.util.List;
 import java.util.Set;
 import org.apache.gravitino.MetadataObject;
-import org.apache.gravitino.MetadataObjects;
-import org.apache.gravitino.MetadataObjects.MetadataObjectImpl;
+import org.apache.gravitino.authorization.ranger.RangerMetadataObjects.RangerMetadataObjectImpl;
 
 /** The helper class for {@link RangerSecurableObject}. */
 public class RangerSecurableObjects {
   public static RangerSecurableObject of(
       List<String> names, MetadataObject.Type type, Set<RangerPrivilege> privileges) {
-    MetadataObject metadataObject =
-        MetadataObjects.of(
-            MetadataObjects.getParentFullName(names), names.get(names.size() - 1), type);
+    RangerMetadataObject metadataObject = RangerMetadataObjects.of(names, type);
     return new RangerSecurableObjectImpl(
-        metadataObject.parent(), metadataObject.name(), type, privileges);
+        metadataObject.parent(), metadataObject.name(), metadataObject.type(), privileges);
   }
 
-  private static class RangerSecurableObjectImpl extends MetadataObjectImpl
+  private static class RangerSecurableObjectImpl extends RangerMetadataObjectImpl
       implements RangerSecurableObject {
+
     private final List<RangerPrivilege> privileges;
 
     /**
@@ -49,9 +47,22 @@ public class RangerSecurableObjects {
      * @param type The type of the metadata object
      */
     public RangerSecurableObjectImpl(
-        String parent, String name, Type type, Set<RangerPrivilege> privileges) {
+        String parent,
+        String name,
+        RangerMetadataObject.Type type,
+        Set<RangerPrivilege> privileges) {
       super(parent, name, type);
       this.privileges = ImmutableList.copyOf(Sets.newHashSet(privileges));
+    }
+
+    @Override
+    public String fullName() {
+      return super.fullName();
+    }
+
+    @Override
+    public RangerMetadataObject.Type type() {
+      return null;
     }
 
     @Override

--- a/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/RangerSecurableObjects.java
+++ b/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/RangerSecurableObjects.java
@@ -26,12 +26,6 @@ import org.apache.gravitino.authorization.ranger.RangerMetadataObjects.RangerMet
 
 /** The helper class for {@link RangerSecurableObject}. */
 public class RangerSecurableObjects {
-  /** Different underlying datasource have different Ranger securable object implement */
-  interface RangerSecurableObjectImplementor {
-    RangerSecurableObject generateRangerSecurableObject(
-        List<String> names, RangerMetadataObject.Type type, Set<RangerPrivilege> privileges);
-  }
-
   public static class RangerSecurableObjectImpl extends RangerMetadataObjectImpl
       implements RangerSecurableObject {
 

--- a/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/RangerSecurableObjects.java
+++ b/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/RangerSecurableObjects.java
@@ -62,7 +62,7 @@ public class RangerSecurableObjects {
 
     @Override
     public RangerMetadataObject.Type type() {
-      return null;
+      return super.type();
     }
 
     @Override

--- a/authorizations/authorization-ranger/src/test/java/org/apache/gravitino/authorization/ranger/integration/test/RangerAuthorizationPluginIT.java
+++ b/authorizations/authorization-ranger/src/test/java/org/apache/gravitino/authorization/ranger/integration/test/RangerAuthorizationPluginIT.java
@@ -29,6 +29,7 @@ import org.apache.gravitino.authorization.Privileges;
 import org.apache.gravitino.authorization.SecurableObject;
 import org.apache.gravitino.authorization.SecurableObjects;
 import org.apache.gravitino.authorization.ranger.RangerAuthorizationPlugin;
+import org.apache.gravitino.authorization.ranger.RangerMetadataObject;
 import org.apache.gravitino.authorization.ranger.RangerSecurableObject;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
@@ -56,7 +57,8 @@ public class RangerAuthorizationPluginIT {
         rangerAuthPlugin.translatePrivilege(createSchemaInMetalake);
     Assertions.assertEquals(1, createSchemaInMetalake1.size());
     Assertions.assertEquals("*", createSchemaInMetalake1.get(0).fullName());
-    Assertions.assertEquals(MetadataObject.Type.SCHEMA, createSchemaInMetalake1.get(0).type());
+    Assertions.assertEquals(
+        RangerMetadataObject.Type.SCHEMA, createSchemaInMetalake1.get(0).type());
 
     SecurableObject createSchemaInCatalog =
         SecurableObjects.parse(
@@ -67,7 +69,7 @@ public class RangerAuthorizationPluginIT {
         rangerAuthPlugin.translatePrivilege(createSchemaInCatalog);
     Assertions.assertEquals(1, createSchemaInCatalog1.size());
     Assertions.assertEquals("*", createSchemaInCatalog1.get(0).fullName());
-    Assertions.assertEquals(MetadataObject.Type.SCHEMA, createSchemaInCatalog1.get(0).type());
+    Assertions.assertEquals(RangerMetadataObject.Type.SCHEMA, createSchemaInCatalog1.get(0).type());
 
     for (Privilege privilege :
         ImmutableList.of(
@@ -82,9 +84,9 @@ public class RangerAuthorizationPluginIT {
       List<RangerSecurableObject> metalake1 = rangerAuthPlugin.translatePrivilege(metalake);
       Assertions.assertEquals(2, metalake1.size());
       Assertions.assertEquals("*.*", metalake1.get(0).fullName());
-      Assertions.assertEquals(MetadataObject.Type.TABLE, metalake1.get(0).type());
+      Assertions.assertEquals(RangerMetadataObject.Type.TABLE, metalake1.get(0).type());
       Assertions.assertEquals("*.*.*", metalake1.get(1).fullName());
-      Assertions.assertEquals(MetadataObject.Type.COLUMN, metalake1.get(1).type());
+      Assertions.assertEquals(RangerMetadataObject.Type.COLUMN, metalake1.get(1).type());
 
       SecurableObject catalog =
           SecurableObjects.parse(
@@ -94,9 +96,9 @@ public class RangerAuthorizationPluginIT {
       List<RangerSecurableObject> catalog1 = rangerAuthPlugin.translatePrivilege(catalog);
       Assertions.assertEquals(2, catalog1.size());
       Assertions.assertEquals("*.*", catalog1.get(0).fullName());
-      Assertions.assertEquals(MetadataObject.Type.TABLE, catalog1.get(0).type());
+      Assertions.assertEquals(RangerMetadataObject.Type.TABLE, catalog1.get(0).type());
       Assertions.assertEquals("*.*.*", catalog1.get(1).fullName());
-      Assertions.assertEquals(MetadataObject.Type.COLUMN, catalog1.get(1).type());
+      Assertions.assertEquals(RangerMetadataObject.Type.COLUMN, catalog1.get(1).type());
 
       SecurableObject schema =
           SecurableObjects.parse(
@@ -106,9 +108,9 @@ public class RangerAuthorizationPluginIT {
       List<RangerSecurableObject> schema1 = rangerAuthPlugin.translatePrivilege(schema);
       Assertions.assertEquals(2, schema1.size());
       Assertions.assertEquals("schema1.*", schema1.get(0).fullName());
-      Assertions.assertEquals(MetadataObject.Type.TABLE, schema1.get(0).type());
+      Assertions.assertEquals(RangerMetadataObject.Type.TABLE, schema1.get(0).type());
       Assertions.assertEquals("schema1.*.*", schema1.get(1).fullName());
-      Assertions.assertEquals(MetadataObject.Type.COLUMN, schema1.get(1).type());
+      Assertions.assertEquals(RangerMetadataObject.Type.COLUMN, schema1.get(1).type());
 
       if (!privilege.equals(Privileges.CreateTable.allow())) {
         // `CREATE_TABLE` not support securable object for table, So ignore check for table.
@@ -120,9 +122,9 @@ public class RangerAuthorizationPluginIT {
         List<RangerSecurableObject> table1 = rangerAuthPlugin.translatePrivilege(table);
         Assertions.assertEquals(2, table1.size());
         Assertions.assertEquals("schema1.table1", table1.get(0).fullName());
-        Assertions.assertEquals(MetadataObject.Type.TABLE, table1.get(0).type());
+        Assertions.assertEquals(RangerMetadataObject.Type.TABLE, table1.get(0).type());
         Assertions.assertEquals("schema1.table1.*", table1.get(1).fullName());
-        Assertions.assertEquals(MetadataObject.Type.COLUMN, table1.get(1).type());
+        Assertions.assertEquals(RangerMetadataObject.Type.COLUMN, table1.get(1).type());
       }
     }
   }
@@ -135,31 +137,31 @@ public class RangerAuthorizationPluginIT {
       List<RangerSecurableObject> metalakeOwner = rangerAuthPlugin.translateOwner(metalake);
       Assertions.assertEquals(3, metalakeOwner.size());
       Assertions.assertEquals("*", metalakeOwner.get(0).fullName());
-      Assertions.assertEquals(MetadataObject.Type.SCHEMA, metalakeOwner.get(0).type());
+      Assertions.assertEquals(RangerMetadataObject.Type.SCHEMA, metalakeOwner.get(0).type());
       Assertions.assertEquals("*.*", metalakeOwner.get(1).fullName());
-      Assertions.assertEquals(MetadataObject.Type.TABLE, metalakeOwner.get(1).type());
+      Assertions.assertEquals(RangerMetadataObject.Type.TABLE, metalakeOwner.get(1).type());
       Assertions.assertEquals("*.*.*", metalakeOwner.get(2).fullName());
-      Assertions.assertEquals(MetadataObject.Type.COLUMN, metalakeOwner.get(2).type());
+      Assertions.assertEquals(RangerMetadataObject.Type.COLUMN, metalakeOwner.get(2).type());
     }
 
     MetadataObject schema = MetadataObjects.parse("catalog1.schema1", MetadataObject.Type.SCHEMA);
     List<RangerSecurableObject> schemaOwner = rangerAuthPlugin.translateOwner(schema);
     Assertions.assertEquals(3, schemaOwner.size());
     Assertions.assertEquals("schema1", schemaOwner.get(0).fullName());
-    Assertions.assertEquals(MetadataObject.Type.SCHEMA, schemaOwner.get(0).type());
+    Assertions.assertEquals(RangerMetadataObject.Type.SCHEMA, schemaOwner.get(0).type());
     Assertions.assertEquals("schema1.*", schemaOwner.get(1).fullName());
-    Assertions.assertEquals(MetadataObject.Type.TABLE, schemaOwner.get(1).type());
+    Assertions.assertEquals(RangerMetadataObject.Type.TABLE, schemaOwner.get(1).type());
     Assertions.assertEquals("schema1.*.*", schemaOwner.get(2).fullName());
-    Assertions.assertEquals(MetadataObject.Type.COLUMN, schemaOwner.get(2).type());
+    Assertions.assertEquals(RangerMetadataObject.Type.COLUMN, schemaOwner.get(2).type());
 
     MetadataObject table =
         MetadataObjects.parse("catalog1.schema1.table1", MetadataObject.Type.TABLE);
     List<RangerSecurableObject> tableOwner = rangerAuthPlugin.translateOwner(table);
     Assertions.assertEquals(2, tableOwner.size());
     Assertions.assertEquals("schema1.table1", tableOwner.get(0).fullName());
-    Assertions.assertEquals(MetadataObject.Type.TABLE, tableOwner.get(0).type());
+    Assertions.assertEquals(RangerMetadataObject.Type.TABLE, tableOwner.get(0).type());
     Assertions.assertEquals("schema1.table1.*", tableOwner.get(1).fullName());
-    Assertions.assertEquals(MetadataObject.Type.COLUMN, tableOwner.get(1).type());
+    Assertions.assertEquals(RangerMetadataObject.Type.COLUMN, tableOwner.get(1).type());
   }
 
   @Test

--- a/authorizations/authorization-ranger/src/test/java/org/apache/gravitino/authorization/ranger/integration/test/RangerAuthorizationPluginIT.java
+++ b/authorizations/authorization-ranger/src/test/java/org/apache/gravitino/authorization/ranger/integration/test/RangerAuthorizationPluginIT.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.gravitino.authorization.ranger;
+package org.apache.gravitino.authorization.ranger.integration.test;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
@@ -28,12 +28,15 @@ import org.apache.gravitino.authorization.Privilege;
 import org.apache.gravitino.authorization.Privileges;
 import org.apache.gravitino.authorization.SecurableObject;
 import org.apache.gravitino.authorization.SecurableObjects;
-import org.apache.gravitino.authorization.ranger.integration.test.RangerITEnv;
+import org.apache.gravitino.authorization.ranger.RangerAuthorizationPlugin;
+import org.apache.gravitino.authorization.ranger.RangerSecurableObject;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
-public class TestRangerAuthorizationPlugin {
+@Tag("gravitino-docker-test")
+public class RangerAuthorizationPluginIT {
   private static RangerAuthorizationPlugin rangerAuthPlugin;
 
   @BeforeAll

--- a/authorizations/authorization-ranger/src/test/java/org/apache/gravitino/authorization/ranger/integration/test/RangerHiveIT.java
+++ b/authorizations/authorization-ranger/src/test/java/org/apache/gravitino/authorization/ranger/integration/test/RangerHiveIT.java
@@ -18,7 +18,6 @@
  */
 package org.apache.gravitino.authorization.ranger.integration.test;
 
-import static org.apache.gravitino.authorization.SecurableObjects.DOT_SPLITTER;
 import static org.apache.gravitino.authorization.ranger.integration.test.RangerITEnv.currentFunName;
 import static org.apache.gravitino.authorization.ranger.integration.test.RangerITEnv.verifyRoleInRanger;
 
@@ -43,6 +42,7 @@ import org.apache.gravitino.authorization.SecurableObject;
 import org.apache.gravitino.authorization.SecurableObjects;
 import org.apache.gravitino.authorization.ranger.RangerAuthorizationPlugin;
 import org.apache.gravitino.authorization.ranger.RangerHelper;
+import org.apache.gravitino.authorization.ranger.RangerMetadataObject;
 import org.apache.gravitino.authorization.ranger.RangerPrivileges;
 import org.apache.gravitino.authorization.ranger.RangerSecurableObject;
 import org.apache.gravitino.authorization.ranger.RangerSecurableObjects;
@@ -515,7 +515,11 @@ public class RangerHiveIT {
     String userName = "user1";
     rangerAuthHivePlugin.onOwnerSet(
         oldMetadataObject, null, new MockOwner(userName, Owner.Type.USER));
-    verifyOwnerInRanger(oldMetadataObject, Lists.newArrayList(userName));
+    rangerAuthHivePlugin.translateOwner(oldMetadataObject).stream()
+        .forEach(
+            rangerSecurableObject -> {
+              verifyOwnerInRanger(rangerSecurableObject, Lists.newArrayList(userName));
+            });
 
     SecurableObject oldSecurableObject =
         SecurableObjects.parse(
@@ -552,13 +556,21 @@ public class RangerHiveIT {
             .withSecurableObjects(Lists.newArrayList(newSecurableObject))
             .build();
     verifyRoleInRanger(rangerAuthHivePlugin, verifyRole);
-    verifyOwnerInRanger(oldMetadataObject, Lists.newArrayList(userName));
+    rangerAuthHivePlugin.translateOwner(oldMetadataObject).stream()
+        .forEach(
+            rangerSecurableObject -> {
+              verifyOwnerInRanger(rangerSecurableObject, Lists.newArrayList(userName));
+            });
 
     // Delete the role
     Assertions.assertTrue(rangerAuthHivePlugin.onRoleDeleted(verifyRole));
     // Because these metaobjects have an owner, so the policy will not be deleted.
     assertFindManagedPolicy(role, true);
-    verifyOwnerInRanger(oldMetadataObject, Lists.newArrayList(userName));
+    rangerAuthHivePlugin.translateOwner(oldMetadataObject).stream()
+        .forEach(
+            rangerSecurableObject -> {
+              verifyOwnerInRanger(rangerSecurableObject, Lists.newArrayList(userName));
+            });
   }
 
   @Test
@@ -899,7 +911,12 @@ public class RangerHiveIT {
     String ownerName = "owner1";
     rangerAuthHivePlugin.onOwnerSet(
         securableObject1, null, new MockOwner(ownerName, Owner.Type.USER));
-    verifyOwnerInRanger(securableObject1, Lists.newArrayList(ownerName), null, null, null);
+    rangerAuthHivePlugin.translateOwner(securableObject1).stream()
+        .forEach(
+            rangerSecurableObject -> {
+              verifyOwnerInRanger(
+                  rangerSecurableObject, Lists.newArrayList(ownerName), null, null, null);
+            });
 
     RoleEntity role1 =
         RoleEntity.builder()
@@ -1277,23 +1294,13 @@ public class RangerHiveIT {
     assertFindManagedPolicy(role3, true);
   }
 
-  private static String generatePolicyName(MetadataObject metadataObject) {
-    List<String> nsMetadataObject =
-        Lists.newArrayList(SecurableObjects.DOT_SPLITTER.splitToList(metadataObject.fullName()));
-    if (!(metadataObject instanceof RangerSecurableObject)
-        && metadataObject.type() != MetadataObject.Type.METALAKE) {
-      nsMetadataObject.remove(0); // remove `catalog`
-    }
-    return String.join(".", nsMetadataObject);
-  }
-
   /**
    * Verify the Gravitino role in Ranger service
    *
    * <p>metadataObject: the Gravitino securable object to be verified
    */
   private void verifyOwnerInRanger(
-      MetadataObject metadataObject,
+      RangerMetadataObject metadataObject,
       List<String> includeUsers,
       List<String> excludeUsers,
       List<String> includeGroups,
@@ -1301,7 +1308,7 @@ public class RangerHiveIT {
       List<String> includeRoles,
       List<String> excludeRoles) {
     // Find policy by each metadata Object
-    String policyName = generatePolicyName(metadataObject);
+    String policyName = metadataObject.fullName();
     RangerPolicy policy;
     try {
       policy = RangerITEnv.rangerClient.getPolicy(RangerITEnv.RANGER_HIVE_REPO_NAME, policyName);
@@ -1315,13 +1322,7 @@ public class RangerHiveIT {
     Assertions.assertTrue(policy.getPolicyLabels().contains(RangerHelper.MANAGED_BY_GRAVITINO));
 
     // verify namespace
-    List<String> metaObjNamespaces =
-        Lists.newArrayList(DOT_SPLITTER.splitToList(metadataObject.fullName()));
-    if (!(metadataObject instanceof RangerSecurableObject)
-        && metadataObject.type() != MetadataObject.Type.METALAKE) {
-      metaObjNamespaces.remove(0); // skip catalog
-    }
-
+    List<String> metaObjNamespaces = metadataObject.names();
     List<String> rolePolicies = new ArrayList<>();
     for (int i = 0; i < metaObjNamespaces.size(); i++) {
       rolePolicies.add(
@@ -1402,21 +1403,21 @@ public class RangerHiveIT {
             });
   }
 
-  private void verifyOwnerInRanger(MetadataObject metadataObject) {
+  private void verifyOwnerInRanger(RangerMetadataObject metadataObject) {
     verifyOwnerInRanger(metadataObject, null, null, null, null, null, null);
   }
 
-  private void verifyOwnerInRanger(MetadataObject metadataObject, List<String> includeUsers) {
+  private void verifyOwnerInRanger(RangerMetadataObject metadataObject, List<String> includeUsers) {
     verifyOwnerInRanger(metadataObject, includeUsers, null, null, null, null, null);
   }
 
   private void verifyOwnerInRanger(
-      MetadataObject metadataObject, List<String> includeUsers, List<String> excludeUsers) {
+      RangerMetadataObject metadataObject, List<String> includeUsers, List<String> excludeUsers) {
     verifyOwnerInRanger(metadataObject, includeUsers, excludeUsers, null, null, null, null);
   }
 
   private void verifyOwnerInRanger(
-      MetadataObject metadataObject,
+      RangerMetadataObject metadataObject,
       List<String> includeUsers,
       List<String> excludeUsers,
       List<String> includeGroups) {
@@ -1425,7 +1426,7 @@ public class RangerHiveIT {
   }
 
   private void verifyOwnerInRanger(
-      MetadataObject metadataObject,
+      RangerMetadataObject metadataObject,
       List<String> includeUsers,
       List<String> excludeUsers,
       List<String> includeGroups,
@@ -1435,7 +1436,7 @@ public class RangerHiveIT {
   }
 
   private void verifyOwnerInRanger(
-      MetadataObject metadataObject,
+      RangerMetadataObject metadataObject,
       List<String> includeUsers,
       List<String> excludeUsers,
       List<String> includeGroups,

--- a/authorizations/authorization-ranger/src/test/java/org/apache/gravitino/authorization/ranger/integration/test/RangerHiveIT.java
+++ b/authorizations/authorization-ranger/src/test/java/org/apache/gravitino/authorization/ranger/integration/test/RangerHiveIT.java
@@ -45,7 +45,6 @@ import org.apache.gravitino.authorization.ranger.RangerHelper;
 import org.apache.gravitino.authorization.ranger.RangerMetadataObject;
 import org.apache.gravitino.authorization.ranger.RangerPrivileges;
 import org.apache.gravitino.authorization.ranger.RangerSecurableObject;
-import org.apache.gravitino.authorization.ranger.RangerSecurableObjects;
 import org.apache.gravitino.authorization.ranger.reference.RangerDefines;
 import org.apache.gravitino.integration.test.util.GravitinoITUtils;
 import org.apache.gravitino.meta.AuditInfo;
@@ -249,9 +248,9 @@ public class RangerHiveIT {
         GravitinoITUtils.genRandomName(currentFunName()));
     // findManagedPolicy function use precise search, so return null
     RangerSecurableObject rangerSecurableObject =
-        RangerSecurableObjects.of(
+        rangerAuthHivePlugin.generateRangerSecurableObject(
             ImmutableList.of(String.format("%s3", dbName), "tab1"),
-            MetadataObject.Type.TABLE,
+            RangerMetadataObject.Type.TABLE,
             ImmutableSet.of(
                 new RangerPrivileges.RangerHivePrivilegeImpl(
                     RangerPrivileges.RangerHivePrivilege.ALL, Privilege.Condition.ALLOW)));

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -146,7 +146,7 @@ allprojects {
           "$1"
         )
 
-        targetExclude("**/build/**")
+        targetExclude("**/build/**", "**/.pnpm/***")
       }
 
       kotlinGradle {


### PR DESCRIPTION
### What changes were proposed in this pull request?

1. Add `RangerMetadataObject` class.

### Why are the changes needed?

Currently, RangerSecurableObject extends MetadataObject, but Ranger managers meta types different with Gravitino, for example, Ranger doesn't have `METALAKE`, `ROLE`, So we need to Refactor RangerSecurableObject class.

Fix: #5196

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

CI Passed.
