### PR TITLE
[5302]Improvement (trino-connector): Set the log level to debug for the logging of load catalog

### DIFF
--- a/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/catalog/CatalogConnectorManager.java
+++ b/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/catalog/CatalogConnectorManager.java
@@ -127,7 +127,7 @@ public class CatalogConnectorManager {
         try {
           GravitinoMetalake metalake =
               metalakes.computeIfAbsent(usedMetalake, this::retrieveMetalake);
-          LOG.info("Load metalake: {}", usedMetalake);
+          LOG.debug("Load metalake: {}", usedMetalake);
           loadCatalogs(metalake);
         } catch (Exception e) {
           LOG.error("Load Metalake {} failed.", usedMetalake, e);
@@ -158,7 +158,7 @@ public class CatalogConnectorManager {
       return;
     }
 
-    LOG.info(
+    LOG.debug(
         "Load metalake {}'s catalogs. catalogs: {}.",
         metalake.name(),
         Arrays.toString(catalogNames));


### PR DESCRIPTION

### What changes were proposed in this pull request?

Reduce redundant logging in the Trino connector.

### Why are the changes needed?

Fix: #5302 

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

No
