### PR TITLE
[#5336] feat(auth-ranger): Remove MANAGED_BY_GRAVITINO limit

### DIFF
--- a/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/RangerAuthorizationPlugin.java
+++ b/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/RangerAuthorizationPlugin.java
@@ -587,6 +587,9 @@ public abstract class RangerAuthorizationPlugin
       if (policy.getId() == null) {
         rangerClient.createPolicy(policy);
       } else {
+        if (!policy.getPolicyLabels().contains(RangerHelper.MANAGED_BY_GRAVITINO)) {
+          policy.getPolicyLabels().add(RangerHelper.MANAGED_BY_GRAVITINO);
+        }
         rangerClient.updatePolicy(policy.getId(), policy);
       }
     } catch (RangerServiceException e) {

--- a/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/RangerHelper.java
+++ b/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/RangerHelper.java
@@ -196,11 +196,9 @@ public class RangerHelper {
   public RangerPolicy findManagedPolicy(RangerMetadataObject rangerMetadataObject)
       throws AuthorizationPluginException {
     List<String> nsMetadataObj = rangerMetadataObject.names();
-
     Map<String, String> searchFilters = new HashMap<>();
     Map<String, String> preciseFilters = new HashMap<>();
     searchFilters.put(SearchFilter.SERVICE_NAME, rangerServiceName);
-    searchFilters.put(SearchFilter.POLICY_LABELS_PARTIAL, MANAGED_BY_GRAVITINO);
     for (int i = 0; i < nsMetadataObj.size(); i++) {
       searchFilters.put(
           SearchFilter.RESOURCE_PREFIX + policyResourceDefines.get(i), nsMetadataObj.get(i));
@@ -209,7 +207,6 @@ public class RangerHelper {
 
     try {
       List<RangerPolicy> policies = rangerClient.findPolicies(searchFilters);
-
       if (!policies.isEmpty()) {
         /**
          * Because Ranger doesn't support the precise search, Ranger will return the policy meets
@@ -400,7 +397,6 @@ public class RangerHelper {
     policy.setPolicyLabels(Lists.newArrayList(RangerHelper.MANAGED_BY_GRAVITINO));
 
     List<String> nsMetadataObject = metadataObject.names();
-
     for (int i = 0; i < nsMetadataObject.size(); i++) {
       RangerPolicy.RangerPolicyResource policyResource =
           new RangerPolicy.RangerPolicyResource(nsMetadataObject.get(i));

--- a/authorizations/authorization-ranger/src/test/java/org/apache/gravitino/authorization/ranger/integration/test/RangerITEnv.java
+++ b/authorizations/authorization-ranger/src/test/java/org/apache/gravitino/authorization/ranger/integration/test/RangerITEnv.java
@@ -19,7 +19,6 @@
 package org.apache.gravitino.authorization.ranger.integration.test;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Lists;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -508,7 +507,6 @@ public class RangerITEnv {
     Map<String, String> resourceFilter = new HashMap<>(); // use to match the precise policy
     Map<String, String> policyFilter = new HashMap<>();
     policyFilter.put(SearchFilter.SERVICE_NAME, serviceName);
-    policyFilter.put(SearchFilter.POLICY_LABELS_PARTIAL, RangerHelper.MANAGED_BY_GRAVITINO);
     final int[] index = {0};
     policyResourceMap.forEach(
         (k, v) -> {
@@ -562,7 +560,6 @@ public class RangerITEnv {
         policy.setServiceType(type);
         policy.setService(serviceName);
         policy.setName(policyName);
-        policy.setPolicyLabels(Lists.newArrayList(RangerHelper.MANAGED_BY_GRAVITINO));
         policy.setResources(policyResourceMap);
         policy.setPolicyItems(policyItems);
         rangerClient.createPolicy(policy);
@@ -594,6 +591,8 @@ public class RangerITEnv {
 
   /** Don't call this function in the Lambda function body, It will return a random function name */
   public static String currentFunName() {
-    return Thread.currentThread().getStackTrace()[2].getMethodName();
+    String name = Thread.currentThread().getStackTrace()[2].getMethodName();
+    Assertions.assertFalse(name.startsWith("lambda$"), "Don't call this function in the Lambda");
+    return name;
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Currently, Gravitino only operation have `MANAGED_BY_GRAVITINO` label's Ranger Policy.
If a user has a Ranger service and this Ranger already has some Ranger Policy.
When Gravitino will push down a Ranger Policy, if this Policy manage resource already exist in the Ranger service and this Policy doesn't have `MANAGED_BY_GRAVITINO` label, then Gravitino will throw exception.

### Why are the changes needed?

Fix: #5336

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

Added ITs
