### PR TITLE
[#3150] fix(doris-catalog): Ignore unknown table properties for Doris catalog.

### DIFF
--- a/catalogs/catalog-jdbc-doris/src/main/java/org/apache/gravitino/catalog/doris/operation/DorisTableOperations.java
+++ b/catalogs/catalog-jdbc-doris/src/main/java/org/apache/gravitino/catalog/doris/operation/DorisTableOperations.java
@@ -194,7 +194,9 @@ public class DorisTableOperations extends JdbcTableOperations {
             .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
     Set<String> unknownProperties = SetUtils.difference(properties.keySet(), result.keySet());
-    LOG.info("Remove unknown properties for Doris table: {}", unknownProperties);
+    if (!unknownProperties.isEmpty()) {
+      LOG.warn("Remove unknown properties '{}' for Doris table.", unknownProperties);
+    }
     return result;
   }
 

--- a/catalogs/catalog-jdbc-doris/src/test/java/org/apache/gravitino/catalog/doris/integration/test/CatalogDorisIT.java
+++ b/catalogs/catalog-jdbc-doris/src/test/java/org/apache/gravitino/catalog/doris/integration/test/CatalogDorisIT.java
@@ -934,4 +934,36 @@ public class CatalogDorisIT extends BaseIT {
       tableCatalog.dropTable(tableIdentifier);
     }
   }
+
+  @Test
+  void testDorisTableWithUnknownProperties() {
+    // create a table
+    NameIdentifier tableIdentifier = NameIdentifier.of(schemaName, tableName);
+    Column[] columns = createColumns();
+
+    Distribution distribution = createDistribution();
+
+    Index[] indexes =
+        new Index[] {
+          Indexes.of(Index.IndexType.PRIMARY_KEY, "k1_index", new String[][] {{DORIS_COL_NAME1}})
+        };
+
+    Map<String, String> properties = ImmutableMap.of("k1", "v1", "k2", "v2", "k3", "v3");
+    TableCatalog tableCatalog = catalog.asTableCatalog();
+    tableCatalog.createTable(
+        tableIdentifier,
+        columns,
+        table_comment,
+        properties,
+        Transforms.EMPTY_TRANSFORM,
+        distribution,
+        null,
+        indexes);
+
+    // load table
+    Table loadTable = tableCatalog.loadTable(tableIdentifier);
+
+    assertFalse(loadTable.properties().containsKey("k1"));
+    assertFalse(loadTable.properties().containsKey("k2"));
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add supported table properties for Doris catalog and ignore all unknown properties.

### Why are the changes needed?

Doris does not support unknown table properties.

Fix: #3150 

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

IT
