### PR TITLE
[#5349] improvement(docker): Update Gravitino dockerfile to put cloud bundles into the docker image.

### DIFF
--- a/dev/docker/gravitino/gravitino-dependency.sh
+++ b/dev/docker/gravitino/gravitino-dependency.sh
@@ -22,14 +22,23 @@ gravitino_dir="$(dirname "${BASH_SOURCE-$0}")"
 gravitino_dir="$(cd "${gravitino_dir}">/dev/null; pwd)"
 gravitino_home="$(cd "${gravitino_dir}/../../..">/dev/null; pwd)"
 
+# Build the Gravitino project
+${gravitino_home}/gradlew clean build -x test
+
+rm -rf ${gravitino_home}/distribution
 # Prepare compile Gravitino packages
-${gravitino_home}/gradlew clean compileDistribution -x test
+${gravitino_home}/gradlew compileDistribution -x test
 
 # Removed old packages, Avoid multiple re-executions using the wrong file
 rm -rf "${gravitino_dir}/packages"
 mkdir -p "${gravitino_dir}/packages"
 
 cp -r "${gravitino_home}/distribution/package" "${gravitino_dir}/packages/gravitino"
+
+# Copy the S3, Aliyun, AWS, and GCP bundles to the Hadoop catalog libs
+cp ${gravitino_home}/bundles/aliyun-bundle/build/libs/*.jar "${gravitino_dir}/packages/gravitino/catalogs/hadoop/libs"
+cp ${gravitino_home}/bundles/aws-bundle/build/libs/*.jar "${gravitino_dir}/packages/gravitino/catalogs/hadoop/libs"
+cp ${gravitino_home}/bundles/gcp-bundle/build/libs/*.jar "${gravitino_dir}/packages/gravitino/catalogs/hadoop/libs"
 
 # Keeping the container running at all times
 cat <<EOF >> "${gravitino_dir}/packages/gravitino/bin/gravitino.sh"

--- a/dev/docker/gravitino/gravitino-dependency.sh
+++ b/dev/docker/gravitino/gravitino-dependency.sh
@@ -35,7 +35,7 @@ mkdir -p "${gravitino_dir}/packages"
 
 cp -r "${gravitino_home}/distribution/package" "${gravitino_dir}/packages/gravitino"
 
-# Copy the S3, Aliyun, AWS, and GCP bundles to the Hadoop catalog libs
+# Copy the Aliyun, AWS, and GCP bundles to the Hadoop catalog libs
 cp ${gravitino_home}/bundles/aliyun-bundle/build/libs/*.jar "${gravitino_dir}/packages/gravitino/catalogs/hadoop/libs"
 cp ${gravitino_home}/bundles/aws-bundle/build/libs/*.jar "${gravitino_dir}/packages/gravitino/catalogs/hadoop/libs"
 cp ${gravitino_home}/bundles/gcp-bundle/build/libs/*.jar "${gravitino_dir}/packages/gravitino/catalogs/hadoop/libs"

--- a/docs/docker-image-details.md
+++ b/docs/docker-image-details.md
@@ -14,10 +14,14 @@ You can deploy the service with the Gravitino Docker image.
 Container startup commands
 
 ```shell
-docker run --rm -d -p 8090:8090 -p 9001:9001 apache/gravitino:0.6.1-incubating
+docker run --rm -d -p 8090:8090 -p 9001:9001 apache/gravitino:0.7.0-incubating
 ```
 
 Changelog
+
+- apache/gravitino:0.7.0-incubating
+  - Based on Gravitino 0.7.0-incubating, you can know more information from 0.7.0-incubating release notes.
+  - Place bundle jars (gravitino-aws-bundle.jar, gravitino-gcp-bundle.jar, gravitino-aliyun-bundle.jar) in the `${GRAVITINO_HOME}/catalogs/hadoop/libs` folder to support the cloud storage catalog without manually adding the jars to the classpath.
 
 - apache/gravitino:0.6.1-incubating
   - Based on Gravitino 0.6.1-incubating, you can know more information from 0.6.1-incubating release notes.

--- a/docs/docker-image-details.md
+++ b/docs/docker-image-details.md
@@ -20,7 +20,7 @@ docker run --rm -d -p 8090:8090 -p 9001:9001 apache/gravitino:0.7.0-incubating
 Changelog
 
 - apache/gravitino:0.7.0-incubating
-  - Based on Gravitino 0.7.0-incubating, you can know more information from 0.7.0-incubating release notes.
+  - Based on Gravitino 0.7.0-incubating, you can know more information from 0.7.0-incubating [release notes](https://github.com/apache/gravitino/releases/tag/v0.7.0-incubating).
   - Place bundle jars (gravitino-aws-bundle.jar, gravitino-gcp-bundle.jar, gravitino-aliyun-bundle.jar) in the `${GRAVITINO_HOME}/catalogs/hadoop/libs` folder to support the cloud storage catalog without manually adding the jars to the classpath.
 
 - apache/gravitino:0.6.1-incubating


### PR DESCRIPTION
### What changes were proposed in this pull request?

Copy cloud storage bundles jars to folder `$GRAVITINO_HOME/catalogs/hadoop/libs` when building Gravitino docker image to free from manually doing it. 

### Why are the changes needed?

We aim to make Gravitino user-friendly for managing cloud storage. 

Fix: #5349 

### Does this PR introduce _any_ user-facing change?

N/A.

### How was this patch tested?

Manually verify locally. 
