### PR TITLE
[#5341] fix (trino-connector): Adjust the default precision of the time and timestamp types for different catalogs

### DIFF
--- a/trino-connector/integration-test/src/test/java/org/apache/gravitino/trino/connector/integration/test/TrinoQueryITBase.java
+++ b/trino-connector/integration-test/src/test/java/org/apache/gravitino/trino/connector/integration/test/TrinoQueryITBase.java
@@ -211,9 +211,7 @@ public class TrinoQueryITBase {
                     .forEach(
                         table -> {
                           boolean dropped =
-                              tableCatalog.dropTable(
-                                  NameIdentifier.of(
-                                      metalakeName, catalogName, schema, table.name()));
+                              tableCatalog.dropTable(NameIdentifier.of(schema, table.name()));
                           LOG.info(
                               "Drop table \"{}.{}\".{}.{}",
                               metalakeName,
@@ -227,7 +225,7 @@ public class TrinoQueryITBase {
 
                 schemas.dropSchema(schema, false);
               } catch (Exception e) {
-                LOG.error("Failed to drop schema {}", schema);
+                LOG.error("Failed to drop schema {}", schema, e);
               }
               LOG.info("Drop schema \"{}.{}\".{}", metalakeName, catalogName, schema);
             });

--- a/trino-connector/integration-test/src/test/resources/trino-ci-testset/testsets/hive/00006_datatype.sql
+++ b/trino-connector/integration-test/src/test/resources/trino-ci-testset/testsets/hive/00006_datatype.sql
@@ -2,7 +2,7 @@ CREATE SCHEMA gt_hive.gt_db1;
 
 USE gt_hive.gt_db1;
 
--- Unsupported Type: TIME
+-- Unsupported Type: TIME, TIMESTAMP WITH TIME ZONE
 CREATE TABLE tb01 (
     f1 VARCHAR(200),
     f2 CHAR(20),

--- a/trino-connector/integration-test/src/test/resources/trino-ci-testset/testsets/jdbc-mysql/00006_datatype.sql
+++ b/trino-connector/integration-test/src/test/resources/trino-ci-testset/testsets/jdbc-mysql/00006_datatype.sql
@@ -17,52 +17,59 @@ CREATE TABLE tb01 (
     f12 BIGINT,
     f13 DATE,
     f14 TIME,
-    f15 TIMESTAMP
+    f15 TIMESTAMP,
+    f16 TIMESTAMP WITH TIME ZONE
 );
 
 SHOW CREATE TABLE tb01;
 
-INSERT INTO tb01 (f1, f2, f3, f4, f5, f6, f8, f9, f10, f11, f12, f13, f14, f15)
-VALUES ('Sample text 1', 'Text1', x'65', 123.456, 7.89, 12.34, 1, 100, 1000, 1000, 100000, DATE '2024-01-01', TIME '08:00:00', TIMESTAMP '2024-01-01 08:00:00');
+INSERT INTO tb01 (f1, f2, f3, f4, f5, f6, f8, f9, f10, f11, f12, f13, f14, f15, f16)
+VALUES ('Sample text 1', 'Text1', x'65', 123.456, 7.89, 12.34, 1, 100, 1000, 1000, 100000, DATE '2024-01-01',
+        TIME '08:00:00', TIMESTAMP '2024-01-01 08:00:00', TIMESTAMP '2024-01-01 08:00:00 UTC');
 
-INSERT INTO tb01 (f1, f2, f3, f4, f5, f6, f8, f9, f10, f11, f12, f13, f14, f15)
-VALUES (NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO tb01 (f1, f2, f3, f4, f5, f6, f8, f9, f10, f11, f12, f13, f14, f15, f16)
+VALUES (NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULl);
 
 select * from tb01 order by f1;
 
 CREATE TABLE tb02 (
-    f1 VARCHAR(200) not null ,
-    f2 CHAR(20) not null ,
-    f3 VARBINARY not null ,
-    f4 DECIMAL(10, 3) not null ,
-    f5 REAL not null ,
-    f6 DOUBLE not null ,
-    f8 TINYINT not null ,
-    f9 SMALLINT not null ,
-    f10 INT not null ,
-    f11 INTEGER not null ,
-    f12 BIGINT not null ,
-    f13 DATE not null ,
-    f14 TIME not null ,
-    f15 TIMESTAMP not null
+    f1 VARCHAR(200) NOT NULL ,
+    f2 CHAR(20) NOT NULL ,
+    f3 VARBINARY NOT NULL ,
+    f4 DECIMAL(10, 3) NOT NULL ,
+    f5 REAL NOT NULL ,
+    f6 DOUBLE NOT NULL ,
+    f8 TINYINT NOT NULL ,
+    f9 SMALLINT NOT NULL ,
+    f10 INT NOT NULL ,
+    f11 INTEGER NOT NULL ,
+    f12 BIGINT NOT NULL ,
+    f13 DATE NOT NULL ,
+    f14 TIME NOT NULL ,
+    f15 TIMESTAMP NOT NULL,
+    f16 TIMESTAMP WITH TIME ZONE NOT NULL
 );
 
 show create table tb02;
 
-INSERT INTO tb02 (f1, f2, f3, f4, f5, f6, f8, f9, f10, f11, f12, f13, f14, f15)
-VALUES ('Sample text 1', 'Text1', x'65', 123.456, 7.89, 12.34, 1, 100, 1000, 1000, 100000, DATE '2024-01-01', TIME '08:00:00', TIMESTAMP '2024-01-01 08:00:00');
+INSERT INTO tb02 (f1, f2, f3, f4, f5, f6, f8, f9, f10, f11, f12, f13, f14, f15, f16)
+VALUES ('Sample text 1', 'Text1', x'65', 123.456, 7.89, 12.34, 1, 100, 1000, 1000, 100000, DATE '2024-01-01',
+        TIME '08:00:00', TIMESTAMP '2024-01-01 08:00:00', TIMESTAMP '2024-01-01 08:00:00 UTC');
 
-INSERT INTO tb02 (f1, f2, f3, f4, f5, f6, f8, f9, f10, f11, f12, f13, f14, f15)
-VALUES (NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO tb02 (f1, f2, f3, f4, f5, f6, f8, f9, f10, f11, f12, f13, f14, f15, f16)
+VALUES (NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
-INSERT INTO tb02 (f1, f2, f3, f4, f5, f6, f8, f9, f10, f11, f12, f13, f14, f15)
-VALUES ('Sample text 1', NULL, x'65', 123.456, 7.89, 12.34, 1, 100, 1000, 1000, 100000, DATE '2024-01-01', TIME '08:00:00', TIMESTAMP '2024-01-01 08:00:00');
+INSERT INTO tb02 (f1, f2, f3, f4, f5, f6, f8, f9, f10, f11, f12, f13, f14, f15, f16)
+VALUES ('Sample text 1', NULL, x'65', 123.456, 7.89, 12.34, 1, 100, 1000, 1000, 100000, DATE '2024-01-01',
+        TIME '08:00:00', TIMESTAMP '2024-01-01 08:00:00', TIMESTAMP '2024-01-01 08:00:00 UTC');
 
-INSERT INTO tb02 (f1, f2, f3, f4, f5, f6, f8, f9, f10, f11, f12, f13, f14, f15)
-VALUES ('Sample text 1', 'same3', x'65', 123.456, 7.89, 12.34, 1, 100, 1000, 1000, NULl, DATE '2024-01-01', TIME '08:00:00', TIMESTAMP '2024-01-01 08:00:00');
+INSERT INTO tb02 (f1, f2, f3, f4, f5, f6, f8, f9, f10, f11, f12, f13, f14, f15, f16)
+VALUES ('Sample text 1', 'same3', x'65', 123.456, 7.89, 12.34, 1, 100, 1000, 1000, NULl, DATE '2024-01-01',
+        TIME '08:00:00', TIMESTAMP '2024-01-01 08:00:00', TIMESTAMP '2024-01-01 08:00:00 UTC');
 
-INSERT INTO tb02 (f1, f2, f3, f4, f5, f6, f8, f9, f10, f11, f12, f13, f14, f15)
-VALUES ('Sample text 1', 'same9', x'65', 123.456, 7.89, 12.34, 1, 100, 1000, 1000, 1992382342, DATE '2024-01-01', NULL, TIMESTAMP '2024-01-01 08:00:00');
+INSERT INTO tb02 (f1, f2, f3, f4, f5, f6, f8, f9, f10, f11, f12, f13, f14, f15, f16)
+VALUES ('Sample text 1', 'same9', x'65', 123.456, 7.89, 12.34, 1, 100, 1000, 1000, 1992382342, DATE '2024-01-01',
+        NULL, TIMESTAMP '2024-01-01 08:00:00', TIMESTAMP '2024-01-01 08:00:00 UTC');
 
 drop table tb01;
 

--- a/trino-connector/integration-test/src/test/resources/trino-ci-testset/testsets/jdbc-mysql/00006_datatype.txt
+++ b/trino-connector/integration-test/src/test/resources/trino-ci-testset/testsets/jdbc-mysql/00006_datatype.txt
@@ -17,8 +17,9 @@ CREATE TABLE
    f11 integer,
    f12 bigint,
    f13 date,
-   f14 time(3),
-   f15 timestamp(3)
+   f14 time(0),
+   f15 timestamp(0),
+   f16 timestamp(0) with time zone
 )
 COMMENT ''
 WITH (
@@ -29,8 +30,8 @@ INSERT: 1 row
 
 INSERT: 1 row
 
-"Sample text 1","Text1               ","65","123.456","7.89","12.34","1","100","1000","1000","100000","2024-01-01","08:00:00.000","2024-01-01 08:00:00.000"
-"","","","","","","","","","","","","",""
+"Sample text 1","Text1               ","65","123.456","7.89","12.34","1","100","1000","1000","100000","2024-01-01","08:00:00","2024-01-01 08:00:00","2024-01-01 08:00:00 UTC"
+"","","","","","","","","","","","","","",""
 
 CREATE TABLE
 
@@ -47,8 +48,9 @@ CREATE TABLE
    f11 integer NOT NULL,
    f12 bigint NOT NULL,
    f13 date NOT NULL,
-   f14 time(3) NOT NULL,
-   f15 timestamp(3) NOT NULL
+   f14 time(0) NOT NULL,
+   f15 timestamp(0) NOT NULL,
+   f16 timestamp(0) with time zone NOT NULL
 )
 COMMENT ''
 WITH (

--- a/trino-connector/integration-test/src/test/resources/trino-ci-testset/testsets/jdbc-postgresql/00006_datatype.sql
+++ b/trino-connector/integration-test/src/test/resources/trino-ci-testset/testsets/jdbc-postgresql/00006_datatype.sql
@@ -17,17 +17,19 @@ CREATE TABLE tb01 (
     f12 BIGINT,
     f13 DATE,
     f14 TIME,
-    f15 TIMESTAMP
+    f15 TIMESTAMP,
+    f16 TIMESTAMP WITH TIME ZONE
 );
 
 
 SHOW CREATE TABLE tb01;
 
-INSERT INTO tb01 (f1, f2, f3, f4, f5, f6, f7, f9, f10, f11, f12, f13, f14, f15)
-VALUES ('Sample text 1', 'Text1', x'65', 123.456, 7.89, 12.34, false, 100, 1000, 1000, 100000, DATE '2024-01-01', TIME '08:00:00', TIMESTAMP '2024-01-01 08:00:00');
+INSERT INTO tb01 (f1, f2, f3, f4, f5, f6, f7, f9, f10, f11, f12, f13, f14, f15, f16)
+VALUES ('Sample text 1', 'Text1', x'65', 123.456, 7.89, 12.34, false, 100, 1000, 1000, 100000, DATE '2024-01-01',
+        TIME '08:00:00', TIMESTAMP '2024-01-01 08:00:00', TIMESTAMP '2024-01-01 08:00:00 UTC');
 
-INSERT INTO tb01 (f1, f2, f3, f4, f5, f6, f7, f9, f10, f11, f12, f13, f14, f15)
-VALUES (NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO tb01 (f1, f2, f3, f4, f5, f6, f7, f9, f10, f11, f12, f13, f14, f15, f16)
+VALUES (NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 select * from tb01 order by f1;
 
@@ -45,25 +47,30 @@ CREATE TABLE tb02 (
     f12 BIGINT not null ,
     f13 DATE not null ,
     f14 TIME not null ,
-    f15 TIMESTAMP not null
+    f15 TIMESTAMP not null,
+    f16 TIMESTAMP WITH TIME ZONE not null
 );
 
 show create table tb02;
 
-INSERT INTO tb02 (f1, f2, f3, f4, f5, f6, f7, f9, f10, f11, f12, f13, f14, f15)
-VALUES ('Sample text 1', 'Text1', x'65', 123.456, 7.89, 12.34, false, 100, 1000, 1000, 100000, DATE '2024-01-01', TIME '08:00:00', TIMESTAMP '2024-01-01 08:00:00');
+INSERT INTO tb02 (f1, f2, f3, f4, f5, f6, f7, f9, f10, f11, f12, f13, f14, f15, f16)
+VALUES ('Sample text 1', 'Text1', x'65', 123.456, 7.89, 12.34, false, 100, 1000, 1000, 100000, DATE '2024-01-01',
+        TIME '08:00:00', TIMESTAMP '2024-01-01 08:00:00', TIMESTAMP '2024-01-01 08:00:00 UTC');
 
-INSERT INTO tb02 (f1, f2, f3, f4, f5, f6, f7, f9, f10, f11, f12, f13, f14, f15)
-VALUES (NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO tb02 (f1, f2, f3, f4, f5, f6, f7, f9, f10, f11, f12, f13, f14, f15, f16)
+VALUES (NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
-INSERT INTO tb02 (f1, f2, f3, f4, f5, f6, f7, f9, f10, f11, f12, f13, f14, f15)
-VALUES ('Sample text 1', NULL, x'65', 123.456, 7.89, 12.34, false, 100, 1000, 1000, 100000, DATE '2024-01-01', TIME '08:00:00', TIMESTAMP '2024-01-01 08:00:00');
+INSERT INTO tb02 (f1, f2, f3, f4, f5, f6, f7, f9, f10, f11, f12, f13, f14, f15, f16)
+VALUES ('Sample text 1', NULL, x'65', 123.456, 7.89, 12.34, false, 100, 1000, 1000, 100000,
+        DATE '2024-01-01', TIME '08:00:00', TIMESTAMP '2024-01-01 08:00:00', TIMESTAMP '2024-01-01 08:00:00 UTC');
 
-INSERT INTO tb02 (f1, f2, f3, f4, f5, f6, f7, f9, f10, f11, f12, f13, f14, f15)
-VALUES ('Sample text 1', 'same3', x'65', 123.456, 7.89, 12.34, false, 100, 1000, 1000, NULl, DATE '2024-01-01', TIME '08:00:00', TIMESTAMP '2024-01-01 08:00:00');
+INSERT INTO tb02 (f1, f2, f3, f4, f5, f6, f7, f9, f10, f11, f12, f13, f14, f15, f16)
+VALUES ('Sample text 1', 'same3', x'65', 123.456, 7.89, 12.34, false, 100, 1000, 1000, NULl, DATE '2024-01-01',
+        TIME '08:00:00', TIMESTAMP '2024-01-01 08:00:00', TIMESTAMP '2024-01-01 08:00:00 UTC');
 
-INSERT INTO tb02 (f1, f2, f3, f4, f5, f6, f7, f9, f10, f11, f12, f13, f14, f15)
-VALUES ('Sample text 1', 'same9', x'65', 123.456, 7.89, 12.34, false, 100, 1000, 1000, 1992382342, DATE '2024-01-01', NULL, TIMESTAMP '2024-01-01 08:00:00');
+INSERT INTO tb02 (f1, f2, f3, f4, f5, f6, f7, f9, f10, f11, f12, f13, f14, f15, f16)
+VALUES ('Sample text 1', 'same9', x'65', 123.456, 7.89, 12.34, false, 100, 1000, 1000, 1992382342, DATE '2024-01-01',
+        NULL, TIMESTAMP '2024-01-01 08:00:00', TIMESTAMP '2024-01-01 08:00:00 UTC');
 
 drop table tb01;
 

--- a/trino-connector/integration-test/src/test/resources/trino-ci-testset/testsets/jdbc-postgresql/00006_datatype.txt
+++ b/trino-connector/integration-test/src/test/resources/trino-ci-testset/testsets/jdbc-postgresql/00006_datatype.txt
@@ -17,8 +17,9 @@ CREATE TABLE
    f11 integer,
    f12 bigint,
    f13 date,
-   f14 time(3),
-   f15 timestamp(3)
+   f14 time(6),
+   f15 timestamp(6),
+   f16 timestamp(6) with time zone
 )
 COMMENT ''"
 
@@ -26,8 +27,8 @@ INSERT: 1 row
 
 INSERT: 1 row
 
-"Sample text 1","Text1               ","65","123.456","7.89","12.34","false","100","1000","1000","100000","2024-01-01","08:00:00.000","2024-01-01 08:00:00.000"
-"","","","","","","","","","","","","",""
+"Sample text 1","Text1               ","65","123.456","7.89","12.34","false","100","1000","1000","100000","2024-01-01","08:00:00.000000","2024-01-01 08:00:00.000000","2024-01-01 08:00:00.000000 UTC"
+"","","","","","","","","","","","","","",""
 
 CREATE TABLE
 
@@ -44,8 +45,9 @@ CREATE TABLE
    f11 integer NOT NULL,
    f12 bigint NOT NULL,
    f13 date NOT NULL,
-   f14 time(3) NOT NULL,
-   f15 timestamp(3) NOT NULL
+   f14 time(6) NOT NULL,
+   f15 timestamp(6) NOT NULL,
+   f16 timestamp(6) with time zone NOT NULL
 )
 COMMENT ''"
 

--- a/trino-connector/integration-test/src/test/resources/trino-ci-testset/testsets/lakehouse-iceberg/00006_datatype.sql
+++ b/trino-connector/integration-test/src/test/resources/trino-ci-testset/testsets/lakehouse-iceberg/00006_datatype.sql
@@ -15,50 +15,57 @@ CREATE TABLE tb01 (
     f12 BIGINT,
     f13 DATE,
     f14 TIME,
-    f15 TIMESTAMP
+    f15 TIMESTAMP,
+    f16 TIMESTAMP WITH TIME ZONE
 );
 
 SHOW CREATE TABLE tb01;
 
-INSERT INTO tb01 (f1, f3, f4, f5, f6, f7, f10, f11, f12, f13, f14, f15)
-VALUES ('Sample text 1', x'65', 123.456, 7.89, 12.34, true, 1000, 1000, 100000, DATE '2024-01-01', TIME '08:00:00', TIMESTAMP '2024-01-01 08:00:00');
+INSERT INTO tb01 (f1, f3, f4, f5, f6, f7, f10, f11, f12, f13, f14, f15, f16)
+VALUES ('Sample text 1', x'65', 123.456, 7.89, 12.34, true, 1000, 1000, 100000, DATE '2024-01-01', TIME '08:00:00',
+        TIMESTAMP '2024-01-01 08:00:00', TIMESTAMP '2024-01-01 08:00:00 UTC');
 
-INSERT INTO tb01 (f1, f3, f4, f5, f6, f7, f10, f11, f12, f13, f14, f15)
-VALUES (NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO tb01 (f1, f3, f4, f5, f6, f7, f10, f11, f12, f13, f14, f15, f16)
+VALUES (NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 select * from tb01 order by f1;
 
 CREATE TABLE tb02 (
-    f1 VARCHAR not null ,
-    f3 VARBINARY not null ,
-    f4 DECIMAL(10, 3) not null ,
-    f5 REAL not null ,
-    f6 DOUBLE not null ,
-    f7 BOOLEAN not null ,
-    f10 INT not null ,
-    f11 INTEGER not null ,
-    f12 BIGINT not null ,
-    f13 DATE not null ,
-    f14 TIME not null ,
-    f15 TIMESTAMP not null
+    f1 VARCHAR NOT NULL ,
+    f3 VARBINARY NOT NULL ,
+    f4 DECIMAL(10, 3) NOT NULL ,
+    f5 REAL NOT NULL ,
+    f6 DOUBLE NOT NULL ,
+    f7 BOOLEAN NOT NULL ,
+    f10 INT NOT NULL ,
+    f11 INTEGER NOT NULL ,
+    f12 BIGINT NOT NULL ,
+    f13 DATE NOT NULL ,
+    f14 TIME NOT NULL ,
+    f15 TIMESTAMP NOT NULL,
+    f16 TIMESTAMP WITH TIME ZONE NOT NULL
 );
 
 show create table tb02;
 
-INSERT INTO tb02 (f1, f3, f4, f5, f6, f7, f10, f11, f12, f13, f14, f15)
-VALUES ('Sample text 1', x'65', 123.456, 7.89, 12.34, true, 1000, 1000, 100000, DATE '2024-01-01', TIME '08:00:00', TIMESTAMP '2024-01-01 08:00:00');
+INSERT INTO tb02 (f1, f3, f4, f5, f6, f7, f10, f11, f12, f13, f14, f15, f16)
+VALUES ('Sample text 1', x'65', 123.456, 7.89, 12.34, true, 1000, 1000, 100000, DATE '2024-01-01', TIME '08:00:00',
+        TIMESTAMP '2024-01-01 08:00:00', TIMESTAMP '2024-01-01 08:00:00 UTC');
 
-INSERT INTO tb02 (f1, f3, f4, f5, f6, f7, f10, f11, f12, f13, f14, f15)
-VALUES (NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO tb02 (f1, f3, f4, f5, f6, f7, f10, f11, f12, f13, f14, f15, f16)
+VALUES (NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
-INSERT INTO tb02 (f1, f3, f4, f5, f6, f10, f11, f12, f13, f14, f15)
-VALUES ('Sample text 1', x'65', 123.456, 7.89, 12.34, 1000, 1000, 100000, DATE '2024-01-01', TIME '08:00:00', TIMESTAMP '2024-01-01 08:00:00');
+INSERT INTO tb02 (f1, f3, f4, f5, f6, f10, f11, f12, f13, f14, f15, f16)
+VALUES ('Sample text 1', x'65', 123.456, 7.89, 12.34, 1000, 1000, 100000, DATE '2024-01-01', TIME '08:00:00',
+        TIMESTAMP '2024-01-01 08:00:00', TIMESTAMP '2024-01-01 08:00:00 UTC');
 
-INSERT INTO tb02 (f1, f3, f4, f5, f6, f7, f10, f11, f12, f13, f14, f15)
-VALUES ('Sample text 1', x'65', 123.456, 7.89, 12.34, true, 1000, 1000, NULL, DATE '2024-01-01', TIME '08:00:00', TIMESTAMP '2024-01-01 08:00:00');
+INSERT INTO tb02 (f1, f3, f4, f5, f6, f7, f10, f11, f12, f13, f14, f15, f16)
+VALUES ('Sample text 1', x'65', 123.456, 7.89, 12.34, true, 1000, 1000, NULL, DATE '2024-01-01', TIME '08:00:00',
+        TIMESTAMP '2024-01-01 08:00:00', TIMESTAMP '2024-01-01 08:00:00 UTC');
 
-INSERT INTO tb02 (f1, f3, f4, f5, f6, f7, f10, f11, f12, f13, f14, f15)
-VALUES ('Sample text 1', x'65', 123.456, 7.89, 12.34, true, 1000, 1000, 1992382342, DATE '2024-01-01', NULL, TIMESTAMP '2024-01-01 08:00:00');
+INSERT INTO tb02 (f1, f3, f4, f5, f6, f7, f10, f11, f12, f13, f14, f15, f16)
+VALUES ('Sample text 1', x'65', 123.456, 7.89, 12.34, true, 1000, 1000, 1992382342, DATE '2024-01-01', NULL,
+        TIMESTAMP '2024-01-01 08:00:00', TIMESTAMP '2024-01-01 08:00:00 UTC');
 
 drop table tb01;
 

--- a/trino-connector/integration-test/src/test/resources/trino-ci-testset/testsets/lakehouse-iceberg/00006_datatype.txt
+++ b/trino-connector/integration-test/src/test/resources/trino-ci-testset/testsets/lakehouse-iceberg/00006_datatype.txt
@@ -16,7 +16,8 @@ CREATE TABLE
    f12 bigint,
    f13 date,
    f14 time(6),
-   f15 timestamp(6)
+   f15 timestamp(6),
+   f16 timestamp(6) with time zone
 )
 COMMENT ''
 WITH (
@@ -28,8 +29,8 @@ INSERT: 1 row
 
 INSERT: 1 row
 
-"Sample text 1","65","123.456","7.89","12.34","true","1000","1000","100000","2024-01-01","08:00:00.000000","2024-01-01 08:00:00.000000"
-"","","","","","","","","","","",""
+"Sample text 1","65","123.456","7.89","12.34","true","1000","1000","100000","2024-01-01","08:00:00.000000","2024-01-01 08:00:00.000000","2024-01-01 08:00:00.000000 UTC"
+"","","","","","","","","","","","",""
 
 CREATE TABLE
 
@@ -45,7 +46,8 @@ CREATE TABLE
    f12 bigint NOT NULL,
    f13 date NOT NULL,
    f14 time(6) NOT NULL,
-   f15 timestamp(6) NOT NULL
+   f15 timestamp(6) NOT NULL,
+   f16 timestamp(6) with time zone NOT NULL
 )
 COMMENT ''
 WITH (

--- a/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/catalog/hive/HiveDataTypeTransformer.java
+++ b/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/catalog/hive/HiveDataTypeTransformer.java
@@ -34,17 +34,8 @@ public class HiveDataTypeTransformer extends GeneralDataTypeTransformer {
 
   @Override
   public io.trino.spi.type.Type getTrinoType(Type type) {
-    boolean unsupportedType = false;
-    if (Type.Name.TIMESTAMP == type.name()) {
-      Types.TimestampType timestampType = (Types.TimestampType) type;
-      if (timestampType.hasTimeZone()) {
-        unsupportedType = true;
-      } else if (Type.Name.TIME == type.name()) {
-        unsupportedType = true;
-      }
-    }
-
-    if (unsupportedType) {
+    if ((Type.Name.TIMESTAMP == type.name() && ((Types.TimestampType) type).hasTimeZone())
+        || Type.Name.TIME == type.name()) {
       throw new TrinoException(
           GravitinoErrorCode.GRAVITINO_UNSUPPORTED_GRAVITINO_DATATYPE,
           "Unsupported gravitino datatype: " + type);

--- a/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/catalog/hive/HiveDataTypeTransformer.java
+++ b/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/catalog/hive/HiveDataTypeTransformer.java
@@ -33,6 +33,26 @@ public class HiveDataTypeTransformer extends GeneralDataTypeTransformer {
   private static final int HIVE_CHAR_MAX_LENGTH = 255;
 
   @Override
+  public io.trino.spi.type.Type getTrinoType(Type type) {
+    boolean unsupportedType = false;
+    if (Type.Name.TIMESTAMP == type.name()) {
+      Types.TimestampType timestampType = (Types.TimestampType) type;
+      if (timestampType.hasTimeZone()) {
+        unsupportedType = true;
+      } else if (Type.Name.TIME == type.name()) {
+        unsupportedType = true;
+      }
+    }
+
+    if (unsupportedType) {
+      throw new TrinoException(
+          GravitinoErrorCode.GRAVITINO_UNSUPPORTED_GRAVITINO_DATATYPE,
+          "Unsupported gravitino datatype: " + type);
+    }
+    return super.getTrinoType(type);
+  }
+
+  @Override
   public Type getGravitinoType(io.trino.spi.type.Type type) {
     Class<? extends io.trino.spi.type.Type> typeClass = type.getClass();
     if (typeClass == VarcharType.class) {

--- a/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/catalog/jdbc/mysql/MySQLDataTypeTransformer.java
+++ b/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/catalog/jdbc/mysql/MySQLDataTypeTransformer.java
@@ -21,6 +21,9 @@ package org.apache.gravitino.trino.connector.catalog.jdbc.mysql;
 
 import io.trino.spi.TrinoException;
 import io.trino.spi.type.CharType;
+import io.trino.spi.type.TimeType;
+import io.trino.spi.type.TimestampType;
+import io.trino.spi.type.TimestampWithTimeZoneType;
 import org.apache.gravitino.rel.types.Type;
 import org.apache.gravitino.rel.types.Type.Name;
 import org.apache.gravitino.rel.types.Types;
@@ -40,6 +43,15 @@ public class MySQLDataTypeTransformer extends GeneralDataTypeTransformer {
   public io.trino.spi.type.Type getTrinoType(Type type) {
     if (type.name() == Name.STRING) {
       return io.trino.spi.type.VarcharType.createUnboundedVarcharType();
+    } else if (Name.TIMESTAMP == type.name()) {
+      Types.TimestampType timestampType = (Types.TimestampType) type;
+      if (timestampType.hasTimeZone()) {
+        return TimestampWithTimeZoneType.TIMESTAMP_TZ_SECONDS;
+      } else {
+        return TimestampType.TIMESTAMP_SECONDS;
+      }
+    } else if (Name.TIME == type.name()) {
+      return TimeType.TIME_SECONDS;
     }
 
     return super.getTrinoType(type);

--- a/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/catalog/jdbc/postgresql/PostgreSQLDataTypeTransformer.java
+++ b/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/catalog/jdbc/postgresql/PostgreSQLDataTypeTransformer.java
@@ -21,6 +21,9 @@ package org.apache.gravitino.trino.connector.catalog.jdbc.postgresql;
 
 import io.trino.spi.TrinoException;
 import io.trino.spi.type.CharType;
+import io.trino.spi.type.TimeType;
+import io.trino.spi.type.TimestampType;
+import io.trino.spi.type.TimestampWithTimeZoneType;
 import org.apache.gravitino.rel.types.Type;
 import org.apache.gravitino.rel.types.Type.Name;
 import org.apache.gravitino.rel.types.Types;
@@ -40,6 +43,15 @@ public class PostgreSQLDataTypeTransformer extends GeneralDataTypeTransformer {
   public io.trino.spi.type.Type getTrinoType(Type type) {
     if (type.name() == Name.STRING) {
       return io.trino.spi.type.VarcharType.createUnboundedVarcharType();
+    } else if (Name.TIMESTAMP == type.name()) {
+      Types.TimestampType timestampType = (Types.TimestampType) type;
+      if (timestampType.hasTimeZone()) {
+        return TimestampWithTimeZoneType.TIMESTAMP_TZ_MICROS;
+      } else {
+        return TimestampType.TIMESTAMP_MICROS;
+      }
+    } else if (Name.TIME == type.name()) {
+      return TimeType.TIME_MICROS;
     }
 
     return super.getTrinoType(type);


### PR DESCRIPTION

### What changes were proposed in this pull request?

Adjust the default precision of the time and timestamp types for different catalogs. keep the same precision as the original connector

### Why are the changes needed?

Fix: #5341

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Update IT