### PR TITLE
[#5359] fix(ob-catalog): fix ob catalog default value parse error

### DIFF
--- a/catalogs/catalog-jdbc-mysql/src/test/java/org/apache/gravitino/catalog/mysql/integration/test/CatalogMysqlIT.java
+++ b/catalogs/catalog-jdbc-mysql/src/test/java/org/apache/gravitino/catalog/mysql/integration/test/CatalogMysqlIT.java
@@ -488,6 +488,7 @@ public class CatalogMysqlIT extends BaseIT {
             + "  date_col_5 date DEFAULT '2024-04-01',\n"
             + "  timestamp_col_1 timestamp default '2012-12-31 11:30:45',\n"
             + "  timestamp_col_2 timestamp default 19830905,\n"
+            + "  timestamp_col_3 timestamp(6) default CURRENT_TIMESTAMP(6),\n"
             + "  decimal_6_2_col_1 decimal(6, 2) default 1.2,\n"
             + "  bit_col_1 bit default b'1'\n"
             + ");\n";
@@ -568,6 +569,10 @@ public class CatalogMysqlIT extends BaseIT {
         case "timestamp_col_2":
           Assertions.assertEquals(
               Literals.timestampLiteral("1983-09-05T00:00:00"), column.defaultValue());
+          break;
+        case "timestamp_col_3":
+          Assertions.assertEquals(
+              UnparsedExpression.of("CURRENT_TIMESTAMP(6)"), column.defaultValue());
           break;
         case "decimal_6_2_col_1":
           Assertions.assertEquals(

--- a/catalogs/catalog-jdbc-oceanbase/src/test/java/org/apache/gravitino/catalog/oceanbase/integration/test/CatalogOceanBaseIT.java
+++ b/catalogs/catalog-jdbc-oceanbase/src/test/java/org/apache/gravitino/catalog/oceanbase/integration/test/CatalogOceanBaseIT.java
@@ -473,6 +473,7 @@ public class CatalogOceanBaseIT extends BaseIT {
             + "  date_col_5 date DEFAULT '2024-04-01',\n"
             + "  timestamp_col_1 timestamp default '2012-12-31 11:30:45',\n"
             + "  timestamp_col_2 timestamp default 19830905,\n"
+            + "  timestamp_col_3 timestamp(6) default CURRENT_TIMESTAMP(6),\n"
             + "  decimal_6_2_col_1 decimal(6, 2) default 1.2,\n"
             + "  bit_col_1 bit default b'1'\n"
             + ");\n";
@@ -511,6 +512,7 @@ public class CatalogOceanBaseIT extends BaseIT {
           break;
         case "datetime_col_1":
         case "datetime_col_2":
+        case "timestamp_col_3":
           Assertions.assertEquals(DEFAULT_VALUE_OF_CURRENT_TIMESTAMP, column.defaultValue());
           break;
         case "datetime_col_3":


### PR DESCRIPTION
### What changes were proposed in this pull request?

fix ob catalog default value parse error

### Why are the changes needed?

For OceanBase catalog, the `IS_GENERATEDCOLUMN` value of the column ResultSet is set to `NO`, which is causing `isExpression` to be false and leading to a parse error.

Fix: #5359 

### Does this PR introduce _any_ user-facing change?

no

### How was this patch tested?

tests added
