### PR TITLE
[#5395] improvment(hive-catalog,iceberg): Set configuration `hive.metastore.sasl.enabled` automatically when kerberos is enabled.

### DIFF
--- a/catalogs/catalog-lakehouse-iceberg/src/test/java/org/apache/gravitino/catalog/lakehouse/iceberg/integration/test/CatalogIcebergKerberosHiveIT.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/test/java/org/apache/gravitino/catalog/lakehouse/iceberg/integration/test/CatalogIcebergKerberosHiveIT.java
@@ -232,8 +232,6 @@ public class CatalogIcebergKerberosHiveIT extends BaseIT {
         CATALOG_BYPASS_PREFIX + "hive.metastore.kerberos.principal",
         "hive/_HOST@HADOOPKRB"
             .replace("_HOST", containerSuite.getKerberosHiveContainer().getHostName()));
-    properties.put(CATALOG_BYPASS_PREFIX + "hive.metastore.sasl.enabled", "true");
-
     properties.put(IcebergConfig.CATALOG_BACKEND.getKey(), TYPE);
     properties.put(IcebergConfig.CATALOG_URI.getKey(), URIS);
     properties.put(IcebergConfig.CATALOG_WAREHOUSE.getKey(), WAREHOUSE);

--- a/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/utils/IcebergCatalogUtil.java
+++ b/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/utils/IcebergCatalogUtil.java
@@ -20,6 +20,7 @@ package org.apache.gravitino.iceberg.common.utils;
 
 import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.HADOOP_SECURITY_AUTHENTICATION;
 import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.HADOOP_SECURITY_AUTHORIZATION;
+import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.METASTORE_USE_THRIFT_SASL;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
@@ -78,6 +79,7 @@ public class IcebergCatalogUtil {
       resultProperties.put(CatalogProperties.CLIENT_POOL_CACHE_KEYS, "USER_NAME");
       hdfsConfiguration.set(HADOOP_SECURITY_AUTHORIZATION, "true");
       hdfsConfiguration.set(HADOOP_SECURITY_AUTHENTICATION, "kerberos");
+      hdfsConfiguration.set(METASTORE_USE_THRIFT_SASL.varname, "true");
       hiveCatalog.setConf(hdfsConfiguration);
       hiveCatalog.initialize(icebergCatalogName, properties);
 

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/integration/test/IcebergRestKerberosHiveCatalogIT.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/integration/test/IcebergRestKerberosHiveCatalogIT.java
@@ -115,7 +115,6 @@ public class IcebergRestKerberosHiveCatalogIT extends IcebergRESTHiveCatalogIT {
     configMap.put(
         "gravitino.iceberg-rest.authentication.kerberos.keytab-uri",
         tempDir + HIVE_METASTORE_CLIENT_KEYTAB);
-    configMap.put("gravitino.iceberg-rest.hive.metastore.sasl.enabled", "true");
     configMap.put(
         "gravitino.iceberg-rest.hive.metastore.kerberos.principal",
         "hive/_HOST@HADOOPKRB"


### PR DESCRIPTION
### What changes were proposed in this pull request?

Automatically set hive.metastore.sasl.enabled to true If Kerberos is enabled.

### Why are the changes needed?

Users will not need to set this value explicitly.

Fix: #5395

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

Existing ITs.
