### PR TITLE
[#5389] feat(logging): add org.apache.logging.log4j:log4j-layout-template-json to support server log in json format

### DIFF
--- a/LICENSE.bin
+++ b/LICENSE.bin
@@ -312,6 +312,7 @@
    Apache Log4j API
    Apache Log4j Core
    Apache Log4j SLF4J 2.0 Binding
+   Apache Log4j Layout For Templated JSON Encoding
    Apache ORC
    Apache Parquet Hadoop Bundle
    Apache Thrift

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -135,6 +135,7 @@ log4j-slf4j2-impl = { group = "org.apache.logging.log4j", name = "log4j-slf4j2-i
 log4j-api = { group = "org.apache.logging.log4j", name = "log4j-api", version.ref = "log4j" }
 log4j-core = { group = "org.apache.logging.log4j", name = "log4j-core", version.ref = "log4j" }
 log4j-12-api = { group = "org.apache.logging.log4j", name = "log4j-1.2-api", version.ref = "log4j" }
+log4j-layout-template-json = { group = "org.apache.logging.log4j", name = "log4j-layout-template-json", version.ref = "log4j" }
 jetty-server = { group = "org.eclipse.jetty", name = "jetty-server", version.ref = "jetty" }
 jetty-servlet = { group = "org.eclipse.jetty", name = "jetty-servlet", version.ref = "jetty" }
 jetty-servlets = { group = "org.eclipse.jetty", name = "jetty-servlets", version.ref = "jetty" }
@@ -258,7 +259,7 @@ google-auth-http = { group = "com.google.auth", name = "google-auth-library-oaut
 google-auth-credentials = { group = "com.google.auth", name = "google-auth-library-credentials", version.ref = "google-auth" }
 
 [bundles]
-log4j = ["slf4j-api", "log4j-slf4j2-impl", "log4j-api", "log4j-core", "log4j-12-api"]
+log4j = ["slf4j-api", "log4j-slf4j2-impl", "log4j-api", "log4j-core", "log4j-12-api", "log4j-layout-template-json"]
 jetty = ["jetty-server", "jetty-servlet", "jetty-webapp", "jetty-servlets"]
 jersey = ["jersey-server", "jersey-container-servlet-core", "jersey-container-jetty-http", "jersey-media-json-jackson", "jersey-hk2"]
 iceberg = ["iceberg-core", "iceberg-api"]


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add org.apache.logging.log4j:log4j-layout-template-json to support server log in json format.

### Why are the changes needed?

There are use cases required server logs to be viewed from logsearch tools such as Kibana. These use cases recommends log format to be json.

Based on
https://logging.apache.org/log4j/2.x/manual/json-template-layout.html, `log4j-layout-template-json` is needed to enable json layout for log4j.

Fix: https://github.com/apache/gravitino/issues/5389

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Tested locally with modified lo4j property file.
```
appender.rolling.layout.type = JsonTemplateLayout
appender.rolling.layout.eventTemplate = {"instant":{"$resolver":"timestamp","pattern":{"format":"yyyy-MM-dd'T'HH:mm:ss.SSS'Z'","timeZone":"UTC"}},"level":{"$resolver":"level","field":"name"},"thread":{"$resolver":"thread","field":"name"},"message":{"$resolver":"message","stringified":true},"exception":{"$resolver":"exception","field":"stackTrace","stackTrace":{"stringified":true}}}
```

For better usability, json can be passed in via a individual file using [eventTemplateUri](https://logging.apache.org/log4j/2.x/manual/json-template-layout.html#plugin-attr-eventTemplateUri) instead.