### PR TITLE
[#5401] fix (docs): Fix the unsupported format types in the documentation for the Gravitino Trino connector

### DIFF
--- a/docs/trino-connector/catalog-hive.md
+++ b/docs/trino-connector/catalog-hive.md
@@ -26,14 +26,13 @@ properties
 per catalog:
 
 - ORC
-- Parquet
-- Avro
-- RCText (RCFile using ColumnarSerDe)
-- RCBinary (RCFile using LazyBinaryColumnarSerDe)
-- SequenceFile
-- JSON (using org.apache.hive.hcatalog.data.JsonSerDe)
-- CSV (using org.apache.hadoop.hive.serde2.OpenCSVSerde)
-- TextFile
+- PARQUET
+- AVRO
+- RCFILE
+- SEQUENCEFILE
+- JSON
+- CSV
+- TEXTFILE
 
 
 ## Schema operations


### PR DESCRIPTION
### What changes were proposed in this pull request?

ix the unsupported format types in the documentation for the Gravitino Trino connector

### Why are the changes needed?

Fix: #5401 

### Does this PR introduce _any_ user-facing change?

Update docs

### How was this patch tested?

No
