### PR TITLE
[#5410] Improvement(iceberg-reset): Make IT `IcebergRestKerberosHiveCatalogIT` works in deploy mode.

### DIFF
--- a/iceberg/iceberg-rest-server/build.gradle.kts
+++ b/iceberg/iceberg-rest-server/build.gradle.kts
@@ -91,6 +91,7 @@ dependencies {
   testImplementation(libs.sqlite.jdbc)
   testImplementation(libs.slf4j.api)
   testImplementation(libs.testcontainers)
+  testImplementation(libs.hadoop2.common)
 
   testRuntimeOnly(libs.junit.jupiter.engine)
 }

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/integration/test/IcebergRESTServiceBaseIT.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/integration/test/IcebergRESTServiceBaseIT.java
@@ -53,7 +53,7 @@ import org.slf4j.LoggerFactory;
 public abstract class IcebergRESTServiceBaseIT {
 
   public static final Logger LOG = LoggerFactory.getLogger(IcebergRESTServiceBaseIT.class);
-  private SparkSession sparkSession;
+  protected SparkSession sparkSession;
   protected IcebergCatalogBackend catalogType = IcebergCatalogBackend.MEMORY;
   private IcebergRESTServerManager icebergRESTServerManager;
 
@@ -121,14 +121,14 @@ public abstract class IcebergRESTServiceBaseIT {
     LOG.info("Iceberg REST service config registered, {}", StringUtils.join(icebergConfigs));
   }
 
-  private int getServerPort() {
+  protected int getServerPort() {
     JettyServerConfig jettyServerConfig =
         JettyServerConfig.fromConfig(
             icebergRESTServerManager.getServerConfig(), IcebergConfig.ICEBERG_CONFIG_PREFIX);
     return jettyServerConfig.getHttpPort();
   }
 
-  private void initSparkEnv() {
+  protected void initSparkEnv() {
     int port = getServerPort();
     LOG.info("Iceberg REST server port:{}", port);
     String icebergRESTUri = String.format("http://127.0.0.1:%d/iceberg/", port);

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/integration/test/IcebergRESTServiceIT.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/integration/test/IcebergRESTServiceIT.java
@@ -70,7 +70,7 @@ public abstract class IcebergRESTServiceIT extends IcebergRESTServiceBaseIT {
     sql("DROP database " + namespace);
   }
 
-  private void purgeAllIcebergTestNamespaces() {
+  protected void purgeAllIcebergTestNamespaces() {
     List<Object[]> databases =
         sql(String.format("SHOW DATABASES like '%s*'", ICEBERG_REST_NS_PREFIX));
     Set<String> databasesString = convertToStringSet(databases, 0);


### PR DESCRIPTION
### What changes were proposed in this pull request?

Make IcebergRestKerberosHiveCatalogIT can run in deploy mode.

### Why are the changes needed?

We need to make it work in both embedded and deploy mode.

Fix: #5410


### Does this PR introduce _any_ user-facing change?

N/A.

### How was this patch tested?

Existing IT.
