### PR TITLE
[#5424] fix(paimon): remove duplicate schema names for Paimon catalog JDBC backend

### DIFF
--- a/catalogs/catalog-lakehouse-paimon/src/main/java/org/apache/gravitino/catalog/lakehouse/paimon/PaimonCatalogOperations.java
+++ b/catalogs/catalog-lakehouse-paimon/src/main/java/org/apache/gravitino/catalog/lakehouse/paimon/PaimonCatalogOperations.java
@@ -126,7 +126,10 @@ public class PaimonCatalogOperations implements CatalogOperations, SupportsSchem
    */
   @Override
   public NameIdentifier[] listSchemas(Namespace namespace) throws NoSuchCatalogException {
+    // Paimon JDBC catalog backend may produce duplicate schema names, remove the duplicate schema
+    // in Gravitino side util the bug is fixed in Paimon
     return paimonCatalogOps.listDatabases().stream()
+        .distinct()
         .map(paimonNamespace -> NameIdentifier.of(namespace, paimonNamespace))
         .toArray(NameIdentifier[]::new);
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

remove duplicate schema names after list schemas from Paimon

### Why are the changes needed?

Fix: #5424 

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
test in local env, create schema s1, create table t1, will get only one schema not two schemas
