### PR TITLE
#5440 fix(web): include missing JDBC properties in catalog creation payload for Apache Iceberg

### DIFF
--- a/web/web/src/app/metalakes/metalake/rightContent/CreateCatalogDialog.js
+++ b/web/web/src/app/metalakes/metalake/rightContent/CreateCatalogDialog.js
@@ -287,6 +287,9 @@ const CreateCatalogDialog = props => {
             uri: uri,
             ...others
           }
+          jdbcDriver && (properties['jdbc-driver'] = jdbcDriver);
+          jdbcUser && (properties['jdbc-user'] = jdbcUser);
+          jdbcPwd && (properties['jdbc-password'] = jdbcPwd);
         } else if (catalogBackend && catalogBackend === 'filesystem' && providerSelect === 'lakehouse-paimon') {
           properties = {
             'catalog-backend': catalogBackend,

--- a/web/web/src/app/metalakes/metalake/rightContent/CreateCatalogDialog.js
+++ b/web/web/src/app/metalakes/metalake/rightContent/CreateCatalogDialog.js
@@ -230,8 +230,7 @@ const CreateCatalogDialog = props => {
     let nextProps = propItems
 
     if (
-      propItems[0]?.key === 'catalog-backend' &&
-      propItems[0]?.value === 'hive' &&
+      propItems.some(item => item.key === 'catalog-backend' && ['hive', 'iceberg'].includes(item.value)) &&
       ['lakehouse-iceberg', 'lakehouse-paimon'].includes(providerSelect)
     ) {
       nextProps = propItems.filter(item => !['jdbc-driver', 'jdbc-user', 'jdbc-password'].includes(item.key))
@@ -280,7 +279,7 @@ const CreateCatalogDialog = props => {
 
         if (
           catalogBackend &&
-          catalogBackend === 'hive' &&
+          ['hive', 'iceberg'].includes(catalogBackend) &&
           ['lakehouse-iceberg', 'lakehouse-paimon'].includes(providerSelect)
         ) {
           properties = {


### PR DESCRIPTION
Why are the changes needed?
These changes are needed to address a bug in the Gravitino UI that prevents users from successfully creating a catalog with `type: relational` and `provider: Apache Iceberg`. The missing properties cause a 400 error on the backend, blocking catalog creation.

Fix: #5440 

Does this PR introduce any user-facing change?
Yes, this PR allows users to create catalogs with `type: relational` and `provider: Apache Iceberg` without encountering a 400 error due to missing JDBC properties. It resolves the issue of incomplete payloads and improves catalog creation reliability.

How was this patch tested?
1. Manual Testing:
  - Opened the "Create Catalog" dialog in the Gravitino UI.
  - Set `type` to `relational`, `provider` to `Apache Iceberg`, and configured `catalog-backend` as `jdbc` with appropriate `jdbc-driver`, `jdbc-user`, and `jdbc-password` values.
  - Clicked "Create" and verified successful catalog creation without errors.

2. Steps to Test:
Follow the reproduction steps outlined in the issue report to confirm that the changes address the problem.

3. Edge Cases:
Tested with `catalog-backend` set to `jdbc` and verified correct behavior.