### PR TITLE
[#5444] fix(gcp): relocate GCP bundle jar to avoid conflict with Gravitino

### DIFF
--- a/bundles/gcp-bundle/build.gradle.kts
+++ b/bundles/gcp-bundle/build.gradle.kts
@@ -49,10 +49,10 @@ tasks.withType(ShadowJar::class.java) {
   archiveClassifier.set("")
 
   // Relocate dependencies to avoid conflicts
-  relocate("org.apache.httpcomponents", "org.apache.gravitino.shaded.org.apache.httpcomponents")
-  relocate("org.apache.commons", "org.apache.gravitino.shaded.org.apache.commons")
-  relocate("com.google", "org.apache.gravitino.shaded.com.google")
-  relocate("com.fasterxml", "org.apache.gravitino.shaded.com.fasterxml")
+  relocate("org.apache.httpcomponents", "org.apache.gravitino.gcp.shaded.org.apache.httpcomponents")
+  relocate("org.apache.commons", "org.apache.gravitino.gcp.shaded.org.apache.commons")
+  relocate("com.google", "org.apache.gravitino.gcp.shaded.com.google")
+  relocate("com.fasterxml", "org.apache.gravitino.gcp.shaded.com.fasterxml")
 }
 
 tasks.jar {

--- a/bundles/gcp-bundle/src/main/resources/META-INF/services/org.apache.hadoop.fs.FileSystem
+++ b/bundles/gcp-bundle/src/main/resources/META-INF/services/org.apache.hadoop.fs.FileSystem
@@ -17,4 +17,4 @@
 # under the License.
 #
 
-org.apache.gravitino.shaded.com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystem
+org.apache.gravitino.gcp.shaded.com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystem

--- a/docs/manage-fileset-metadata-using-gravitino.md
+++ b/docs/manage-fileset-metadata-using-gravitino.md
@@ -61,7 +61,7 @@ curl -X POST -H "Accept: application/vnd.gravitino.v1+json" \
   "comment": "comment",
   "provider": "hadoop",
   "properties": {
-    "location": "s3a:/bucket/root",
+    "location": "oss:/bucket/root",
     "s3-access-key-id": "access_key",
     "s3-secret-access-key": "secret_key",
     "s3-endpoint": "http://oss-cn-hangzhou.aliyuncs.com",
@@ -93,7 +93,7 @@ Catalog catalog = gravitinoClient.createCatalog("catalog",
 
 // create a S3 catalog
 s3Properties = ImmutableMap.<String, String>builder()
-    .put("location", "s3a:/bucket/root")
+    .put("location", "oss:/bucket/root")
     .put("s3-access-key-id", "access_key")
     .put("s3-secret-access-key", "secret_key")
     .put("s3-endpoint", "http://oss-cn-hangzhou.aliyuncs.com")
@@ -121,7 +121,7 @@ catalog = gravitino_client.create_catalog(name="catalog",
 
 # create a S3 catalog
 s3_properties = {
-    "location": "s3a:/bucket/root",
+    "location": "oss:/bucket/root",
     "s3-access-key-id": "access_key"
     "s3-secret-access-key": "secret_key",
     "s3-endpoint": "http://oss-cn-hangzhou.aliyuncs.com"

--- a/docs/manage-fileset-metadata-using-gravitino.md
+++ b/docs/manage-fileset-metadata-using-gravitino.md
@@ -61,7 +61,7 @@ curl -X POST -H "Accept: application/vnd.gravitino.v1+json" \
   "comment": "comment",
   "provider": "hadoop",
   "properties": {
-    "location": "oss:/bucket/root",
+    "location": "s3a:/bucket/root",
     "s3-access-key-id": "access_key",
     "s3-secret-access-key": "secret_key",
     "s3-endpoint": "http://oss-cn-hangzhou.aliyuncs.com",
@@ -93,7 +93,7 @@ Catalog catalog = gravitinoClient.createCatalog("catalog",
 
 // create a S3 catalog
 s3Properties = ImmutableMap.<String, String>builder()
-    .put("location", "oss:/bucket/root")
+    .put("location", "s3a:/bucket/root")
     .put("s3-access-key-id", "access_key")
     .put("s3-secret-access-key", "secret_key")
     .put("s3-endpoint", "http://oss-cn-hangzhou.aliyuncs.com")
@@ -121,7 +121,7 @@ catalog = gravitino_client.create_catalog(name="catalog",
 
 # create a S3 catalog
 s3_properties = {
-    "location": "oss:/bucket/root",
+    "location": "s3a:/bucket/root",
     "s3-access-key-id": "access_key"
     "s3-secret-access-key": "secret_key",
     "s3-endpoint": "http://oss-cn-hangzhou.aliyuncs.com"


### PR DESCRIPTION
### What changes were proposed in this pull request?

shade `gcp` package to `org.apache.gravitino.gcp.shaded` to avoid conflict with the shaded package in Gravitino.

### Why are the changes needed?

The faster XML package in GCP bundle jar is conflict with the package in Gravitino java client runtime.
 
Fix: #5444 


### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?

run a app to use GCP bundle to do fileset operations.