### PR TITLE
[#5460] feat(core): Add FlushIntervalSecs to audit log file writer

### DIFF
--- a/bundles/gcp-bundle/build.gradle.kts
+++ b/bundles/gcp-bundle/build.gradle.kts
@@ -49,10 +49,10 @@ tasks.withType(ShadowJar::class.java) {
   archiveClassifier.set("")
 
   // Relocate dependencies to avoid conflicts
-  relocate("org.apache.httpcomponents", "org.apache.gravitino.shaded.org.apache.httpcomponents")
-  relocate("org.apache.commons", "org.apache.gravitino.shaded.org.apache.commons")
-  relocate("com.google", "org.apache.gravitino.shaded.com.google")
-  relocate("com.fasterxml", "org.apache.gravitino.shaded.com.fasterxml")
+  relocate("org.apache.httpcomponents", "org.apache.gravitino.gcp.shaded.org.apache.httpcomponents")
+  relocate("org.apache.commons", "org.apache.gravitino.gcp.shaded.org.apache.commons")
+  relocate("com.google", "org.apache.gravitino.gcp.shaded.com.google")
+  relocate("com.fasterxml", "org.apache.gravitino.gcp.shaded.com.fasterxml")
 }
 
 tasks.jar {

--- a/bundles/gcp-bundle/build.gradle.kts
+++ b/bundles/gcp-bundle/build.gradle.kts
@@ -49,10 +49,10 @@ tasks.withType(ShadowJar::class.java) {
   archiveClassifier.set("")
 
   // Relocate dependencies to avoid conflicts
-  relocate("org.apache.httpcomponents", "org.apache.gravitino.gcp.shaded.org.apache.httpcomponents")
-  relocate("org.apache.commons", "org.apache.gravitino.gcp.shaded.org.apache.commons")
-  relocate("com.google", "org.apache.gravitino.gcp.shaded.com.google")
-  relocate("com.fasterxml", "org.apache.gravitino.gcp.shaded.com.fasterxml")
+  relocate("org.apache.httpcomponents", "org.apache.gravitino.shaded.org.apache.httpcomponents")
+  relocate("org.apache.commons", "org.apache.gravitino.shaded.org.apache.commons")
+  relocate("com.google", "org.apache.gravitino.shaded.com.google")
+  relocate("com.fasterxml", "org.apache.gravitino.shaded.com.fasterxml")
 }
 
 tasks.jar {

--- a/core/src/main/java/org/apache/gravitino/Configs.java
+++ b/core/src/main/java/org/apache/gravitino/Configs.java
@@ -348,7 +348,7 @@ public class Configs {
   public static final String AUDIT_LOG_WRITER_CONFIG_PREFIX = "gravitino.audit.writer.";
 
   public static final ConfigEntry<Boolean> AUDIT_LOG_ENABLED_CONF =
-      new ConfigBuilder("gravitino.audit.enable")
+      new ConfigBuilder("gravitino.audit.enabled")
           .doc("Gravitino audit log enable flag")
           .version(ConfigConstants.VERSION_0_7_0)
           .booleanConf()

--- a/core/src/main/java/org/apache/gravitino/audit/FileAuditWriter.java
+++ b/core/src/main/java/org/apache/gravitino/audit/FileAuditWriter.java
@@ -25,6 +25,7 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
 import java.util.Map;
 import org.apache.gravitino.exceptions.GravitinoRuntimeException;
 import org.slf4j.Logger;
@@ -37,17 +38,18 @@ import org.slf4j.LoggerFactory;
 public class FileAuditWriter implements AuditLogWriter {
   private static final Logger Log = LoggerFactory.getLogger(FileAuditWriter.class);
 
-  public static final String AUDIT_LOG_FILE_NAME = "fileName";
+  private static final String AUDIT_LOG_FILE_NAME = "fileName";
+  private static final String APPEND = "append";
+  private static final String FLUSH_INTERVAL_SECS = "flushIntervalSecs";
+  private static final String LINE_SEPARATOR = System.lineSeparator();
 
-  public static final String APPEND = "append";
-
-  public static final String LINE_SEPARATOR = System.lineSeparator();
-
-  Formatter formatter;
   @VisibleForTesting Writer outWriter;
   @VisibleForTesting String fileName;
 
-  boolean append;
+  private Formatter formatter;
+  private boolean append;
+  private int flushIntervalSecs;
+  private Instant nextFlushTime = Instant.now();
 
   @Override
   public Formatter getFormatter() {
@@ -62,6 +64,7 @@ public class FileAuditWriter implements AuditLogWriter {
             + "/"
             + properties.getOrDefault(AUDIT_LOG_FILE_NAME, "gravitino_audit.log");
     this.append = Boolean.parseBoolean(properties.getOrDefault(APPEND, "true"));
+    this.flushIntervalSecs = Integer.parseInt(properties.getOrDefault(FLUSH_INTERVAL_SECS, "10"));
     try {
       OutputStream outputStream = new FileOutputStream(fileName, append);
       this.outWriter = new OutputStreamWriter(outputStream, StandardCharsets.UTF_8);
@@ -76,6 +79,7 @@ public class FileAuditWriter implements AuditLogWriter {
     String log = auditLog.toString();
     try {
       outWriter.write(log + LINE_SEPARATOR);
+      tryFlush();
     } catch (Exception e) {
       Log.warn("Failed to write audit log: {}", log, e);
     }
@@ -95,5 +99,24 @@ public class FileAuditWriter implements AuditLogWriter {
   @Override
   public String name() {
     return "file";
+  }
+
+  private void tryFlush() {
+    Instant now = Instant.now();
+    if (now.isAfter(nextFlushTime)) {
+      nextFlushTime = now.plusSeconds(flushIntervalSecs);
+      Log.info("Try flush audit writer");
+      doFlush();
+    }
+  }
+
+  private void doFlush() {
+    if (outWriter != null) {
+      try {
+        outWriter.flush();
+      } catch (Exception e) {
+        Log.warn("Flush audit log failed,", e);
+      }
+    }
   }
 }

--- a/core/src/main/java/org/apache/gravitino/audit/FileAuditWriter.java
+++ b/core/src/main/java/org/apache/gravitino/audit/FileAuditWriter.java
@@ -105,7 +105,6 @@ public class FileAuditWriter implements AuditLogWriter {
     Instant now = Instant.now();
     if (now.isAfter(nextFlushTime)) {
       nextFlushTime = now.plusSeconds(flushIntervalSecs);
-      Log.info("Try flush audit writer");
       doFlush();
     }
   }

--- a/docs/gravitino-server-config.md
+++ b/docs/gravitino-server-config.md
@@ -171,10 +171,11 @@ The `AuditLogWriter` defines an interface that enables the writing of metadata a
 
 Writer configuration begins with `gravitino.audit.writer.${name}`, where ${name} is replaced with the actual writer name defined in method `name()`. `FileAuditWriter` is a default implement to log audit information, whose name is `file`.
 
-| Property name                          | Description                                                                   | Default value       | Required | Since Version    |
-|----------------------------------------|-------------------------------------------------------------------------------|---------------------|----------|------------------|
-| `gravitino.audit.writer.file.fileName` | The audit log file name, the path is `${sys:gravitino.log.path}/${fileName}`. | gravitino_audit.log | NO       | 0.7.0-incubating |
-| `gravitino.audit.writer.file.append`   | Whether the log will be written to the end or the beginning of the file.      | true                | NO       | 0.7.0-incubating |
+| Property name                                   | Description                                                                   | Default value       | Required | Since Version    |
+|-------------------------------------------------|-------------------------------------------------------------------------------|---------------------|----------|------------------|
+| `gravitino.audit.writer.file.fileName`          | The audit log file name, the path is `${sys:gravitino.log.path}/${fileName}`. | gravitino_audit.log | NO       | 0.7.0-incubating |
+| `gravitino.audit.writer.file.flushIntervalSecs` | The flush interval time of the audit file in seconds.                         | 10                  | NO       | 0.7.0-incubating |
+| `gravitino.audit.writer.file.append`            | Whether the log will be written to the end or the beginning of the file.      | true                | NO       | 0.7.0-incubating |
 
 ### Security configuration
 


### PR DESCRIPTION

### What changes were proposed in this pull request?
1.  keep `gravitino.audit.enabled` configuration consistent with document
2. add FlushIntervalSecs to flush log writer

### Why are the changes needed?

Fix: #5460 

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

enable audit log and check audit is written after about 10s 