### PR TITLE
[Minor] fix(docs): Fix mistakes in docs about the example of S3 fileset.

### DIFF
--- a/docs/how-to-use-gvfs.md
+++ b/docs/how-to-use-gvfs.md
@@ -83,10 +83,10 @@ At the same time, you need to place the corresponding bundle jar [`gravitino-aws
 
 #### GCS fileset
 
-| Configuration item             | Description                                                                                                                                                                              | Default value | Required                  | Since version      |
-|--------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|---------------------------|--------------------|
-| `fs.gvfs.filesystem.providers` | The file system providers to add. Set it to `gs` if it's a GCS fileset, or a comma separated string that contains `gs` like `gs,s3` to support multiple kinds of fileset including `gs`. | (none)        | Yes if it's a GCS fileset.|   0.7.0-incubating |
-| `gcs-service-account-file`     | The path of GCS service account JSON file.                                                                                                                                               | (none)        | Yes if it's a GCS fileset.| 0.7.0-incubating   |
+| Configuration item             | Description                                                                                                                                                                              | Default value | Required                  | Since version    |
+|--------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|---------------------------|------------------|
+| `fs.gvfs.filesystem.providers` | The file system providers to add. Set it to `gs` if it's a GCS fileset, or a comma separated string that contains `gs` like `gs,s3` to support multiple kinds of fileset including `gs`. | (none)        | Yes if it's a GCS fileset.| 0.7.0-incubating |
+| `gcs-service-account-file`     | The path of GCS service account JSON file.                                                                                                                                               | (none)        | Yes if it's a GCS fileset.| 0.7.0-incubating |
 
 In the meantime, you need to place the corresponding bundle jar [`gravitino-gcp-bundle-${version}.jar`](https://repo1.maven.org/maven2/org/apache/gravitino/gcp-bundle/) in the Hadoop environment(typically located in `${HADOOP_HOME}/share/hadoop/common/lib/`).
 

--- a/docs/manage-fileset-metadata-using-gravitino.md
+++ b/docs/manage-fileset-metadata-using-gravitino.md
@@ -61,7 +61,7 @@ curl -X POST -H "Accept: application/vnd.gravitino.v1+json" \
   "comment": "comment",
   "provider": "hadoop",
   "properties": {
-    "location": "oss:/bucket/root",
+    "location": "s3a://bucket/root",
     "s3-access-key-id": "access_key",
     "s3-secret-access-key": "secret_key",
     "s3-endpoint": "http://oss-cn-hangzhou.aliyuncs.com",
@@ -93,7 +93,7 @@ Catalog catalog = gravitinoClient.createCatalog("catalog",
 
 // create a S3 catalog
 s3Properties = ImmutableMap.<String, String>builder()
-    .put("location", "oss:/bucket/root")
+    .put("location", "s3a://bucket/root")
     .put("s3-access-key-id", "access_key")
     .put("s3-secret-access-key", "secret_key")
     .put("s3-endpoint", "http://oss-cn-hangzhou.aliyuncs.com")
@@ -121,7 +121,7 @@ catalog = gravitino_client.create_catalog(name="catalog",
 
 # create a S3 catalog
 s3_properties = {
-    "location": "oss:/bucket/root",
+    "location": "s3a://bucket/root",
     "s3-access-key-id": "access_key"
     "s3-secret-access-key": "secret_key",
     "s3-endpoint": "http://oss-cn-hangzhou.aliyuncs.com"

--- a/docs/manage-fileset-metadata-using-gravitino.md
+++ b/docs/manage-fileset-metadata-using-gravitino.md
@@ -64,7 +64,7 @@ curl -X POST -H "Accept: application/vnd.gravitino.v1+json" \
     "location": "s3a://bucket/root",
     "s3-access-key-id": "access_key",
     "s3-secret-access-key": "secret_key",
-    "s3-endpoint": "http://oss-cn-hangzhou.aliyuncs.com",
+    "s3-endpoint": "http://s3.ap-northeast-1.amazonaws.com",
     "filesystem-providers": "s3"
   }
 }' http://localhost:8090/api/metalakes/metalake/catalogs
@@ -96,7 +96,7 @@ s3Properties = ImmutableMap.<String, String>builder()
     .put("location", "s3a://bucket/root")
     .put("s3-access-key-id", "access_key")
     .put("s3-secret-access-key", "secret_key")
-    .put("s3-endpoint", "http://oss-cn-hangzhou.aliyuncs.com")
+    .put("s3-endpoint", "http://s3.ap-northeast-1.amazonaws.com")
     .put("filesystem-providers", "s3")
     .build();
 
@@ -124,7 +124,7 @@ s3_properties = {
     "location": "s3a://bucket/root",
     "s3-access-key-id": "access_key"
     "s3-secret-access-key": "secret_key",
-    "s3-endpoint": "http://oss-cn-hangzhou.aliyuncs.com"
+    "s3-endpoint": "http://s3.ap-northeast-1.amazonaws.com"
 }
 
 s3_catalog = gravitino_client.create_catalog(name="catalog",


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix s3 fileset example that uses "oss:/" prefix mistakenly. 

### Why are the changes needed?

It's a mistake. 

### Does this PR introduce _any_ user-facing change?

N/A.

### How was this patch tested?

N/A
