### PR TITLE
[MINOR] docs: polish Iceberg REST server document

### DIFF
--- a/docs/iceberg-rest-service.md
+++ b/docs/iceberg-rest-service.md
@@ -245,7 +245,7 @@ The Gravitino Iceberg REST server supports multiple catalogs, and you could mana
 
 ##### Static catalog configuration provider
 
-The static catalog configuration provider retrieves the catalog configuration from the configuration file of the Gravitino Iceberg REST server. You could configure the default catalog with `gravitino.iceberg-rest.catalog.<param name>=<value>`. For specific catalogs, use the format `gravitino.iceberg-rest.catalog.<catalog name>.<param name>=<value>`.
+The static catalog configuration provider retrieves the catalog configuration from the configuration file of the Gravitino Iceberg REST server. You could configure the default catalog with `gravitino.iceberg-rest.<param name>=<value>`. For specific catalogs, use the format `gravitino.iceberg-rest.catalog.<catalog name>.<param name>=<value>`.
 
 For instance, you could configure three different catalogs, the default catalog and the specific `hive_backend` and `jdbc_backend` catalogs separately.
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

correct default catalog from `gravitino.iceberg-rest.catalog.<param name>=<value>`  to `gravitino.iceberg-rest.<param name>=<value>`

### Why are the changes needed?

The example for Iceberg multi catalog is not correct 


### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?

testing with multi catalog for IcebergREST server
