### PR TITLE
[#5276] improment(cli): display audit information on Metalakes in the Gravitino CLI

### DIFF
--- a/clients/cli/src/main/java/org/apache/gravitino/cli/GravitinoCommandLine.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/GravitinoCommandLine.java
@@ -29,6 +29,7 @@ import org.apache.gravitino.cli.commands.ListColumns;
 import org.apache.gravitino.cli.commands.ListMetalakes;
 import org.apache.gravitino.cli.commands.ListSchema;
 import org.apache.gravitino.cli.commands.ListTables;
+import org.apache.gravitino.cli.commands.MetalakeAuditInfo;
 import org.apache.gravitino.cli.commands.MetalakeDetails;
 import org.apache.gravitino.cli.commands.SchemaDetails;
 import org.apache.gravitino.cli.commands.ServerVersion;
@@ -124,6 +125,9 @@ public class GravitinoCommandLine {
 
     if (CommandActions.DETAILS.equals(command)) {
       new MetalakeDetails(url, ignore, metalake).handle();
+      if (line.hasOption(GravitinoOptions.AUDIT)) {
+        new MetalakeAuditInfo(url, ignore, metalake).handle();
+      }
     } else if (CommandActions.LIST.equals(command)) {
       new ListMetalakes(url, ignore).handle();
     }

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/GravitinoCommandLine.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/GravitinoCommandLine.java
@@ -124,9 +124,10 @@ public class GravitinoCommandLine {
     String metalake = name.getMetalakeName();
 
     if (CommandActions.DETAILS.equals(command)) {
-      new MetalakeDetails(url, ignore, metalake).handle();
       if (line.hasOption(GravitinoOptions.AUDIT)) {
         new MetalakeAuditInfo(url, ignore, metalake).handle();
+      } else {
+        new MetalakeDetails(url, ignore, metalake).handle();
       }
     } else if (CommandActions.LIST.equals(command)) {
       new ListMetalakes(url, ignore).handle();

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/GravitinoOptions.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/GravitinoOptions.java
@@ -31,6 +31,7 @@ public class GravitinoOptions {
   public static final String NAME = "name";
   public static final String METALAKE = "metalake";
   public static final String IGNORE = "ignore";
+  public static final String AUDIT = "audit";
 
   /**
    * Builds and returns the CLI options for Gravitino.
@@ -48,6 +49,7 @@ public class GravitinoOptions {
     options.addOption(createArgOption("f", NAME, "full entity name (dot separated)"));
     options.addOption(createArgOption("m", METALAKE, "Metalake name"));
     options.addOption(createSimpleOption("i", IGNORE, "Ignore client/sever version check"));
+    options.addOption(createSimpleOption("a", AUDIT, "Display audit information"));
 
     return options;
   }

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/MetalakeAuditInfo.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/MetalakeAuditInfo.java
@@ -54,7 +54,8 @@ public class MetalakeAuditInfo extends Command {
     }
 
     String auditInfo =
-        "creator,createTime,lastModifier,lastModifiedTime\n"
+        "creator,createTime,lastModifier,lastModifiedTime"
+            + System.lineSeparator()
             + audit.creator()
             + ","
             + audit.createTime()

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/MetalakeAuditInfo.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/MetalakeAuditInfo.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.cli.commands;
+
+import org.apache.gravitino.Audit;
+import org.apache.gravitino.cli.ErrorMessages;
+import org.apache.gravitino.client.GravitinoClient;
+import org.apache.gravitino.exceptions.NoSuchMetalakeException;
+
+/** Displays the audit information of a metalake. */
+public class MetalakeAuditInfo extends Command {
+  protected final String metalake;
+
+  /**
+   * Displays metalake audit information.
+   *
+   * @param url The URL of the Gravitino server.
+   * @param ignoreVersions If true don't check the client/server versions match.
+   * @param metalake The name of the metalake.
+   */
+  public MetalakeAuditInfo(String url, boolean ignoreVersions, String metalake) {
+    super(url, ignoreVersions);
+    this.metalake = metalake;
+  }
+
+  /** Displays the audit information of a metalake. */
+  public void handle() {
+    Audit audit;
+    try (GravitinoClient client = buildClient(metalake)) {
+      audit = client.loadMetalake(metalake).auditInfo();
+    } catch (NoSuchMetalakeException err) {
+      System.err.println(ErrorMessages.UNKNOWN_METALAKE);
+      return;
+    } catch (Exception exp) {
+      System.err.println(exp.getMessage());
+      return;
+    }
+
+    String auditInfo =
+        String.format(
+            "creator: %s\ncreateTime: %s\nlastModifier: %s\nlastModifiedTime: %s",
+            audit.creator(), audit.createTime(), audit.lastModifier(), audit.lastModifiedTime());
+    System.out.println(auditInfo);
+  }
+}

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/MetalakeAuditInfo.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/MetalakeAuditInfo.java
@@ -54,9 +54,15 @@ public class MetalakeAuditInfo extends Command {
     }
 
     String auditInfo =
-        String.format(
-            "creator: %s\ncreateTime: %s\nlastModifier: %s\nlastModifiedTime: %s",
-            audit.creator(), audit.createTime(), audit.lastModifier(), audit.lastModifiedTime());
+        "creator,createTime,lastModifier,lastModifiedTime\n"
+            + audit.creator()
+            + ","
+            + audit.createTime()
+            + ","
+            + audit.lastModifier()
+            + ","
+            + audit.lastModifiedTime();
+
     System.out.println(auditInfo);
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add the `--audit` option to display audit information on Metalakes.

### Why are the changes needed?

This change allows users to retrieve additional audit information on Metalakes, providing more insights.

Fix: #5276 

### Does this PR introduce _any_ user-facing change?

Yes, it adds the `--audit` option to `CommandEntities.METALAKE`.

### How was this patch tested?

1. Follow the instructions in the [cli README](https://github.com/apache/gravitino/tree/main/clients/cli) to build the CLI sub-project.
2. Start the Gravitino server.

To test, use a command like the following:
```
gcli metalake details --metalake <your meatalake name> --audit
```
Check that the output matches the expected audit information.
![messageImage_1730814949436](https://github.com/user-attachments/assets/4abf4e01-cef9-470e-b1e1-bf02378aa44e)

![image](https://github.com/user-attachments/assets/64ef2c05-10c6-4ca8-a8d8-e2fd19e9b242)

