### PR TITLE
[#5498] improvement(storage): Modify the length limit of privileges column

### DIFF
--- a/authorizations/authorization-ranger/src/test/java/org/apache/gravitino/authorization/ranger/integration/test/RangerBaseE2EIT.java
+++ b/authorizations/authorization-ranger/src/test/java/org/apache/gravitino/authorization/ranger/integration/test/RangerBaseE2EIT.java
@@ -529,7 +529,8 @@ public abstract class RangerBaseE2EIT extends BaseIT {
                 Privileges.ModifyTable.allow(),
                 Privileges.ManageUsers.allow(),
                 Privileges.ManageGroups.allow(),
-                Privileges.CreateRole.allow()));
+                Privileges.CreateRole.allow(),
+                Privileges.ManageGrants.allow()));
     metalake.createRole(roleName, Collections.emptyMap(), Lists.newArrayList(securableObject));
 
     // Granted this role to the spark execution user `HADOOP_USER_NAME`

--- a/core/src/main/java/org/apache/gravitino/config/ConfigConstants.java
+++ b/core/src/main/java/org/apache/gravitino/config/ConfigConstants.java
@@ -67,4 +67,7 @@ public final class ConfigConstants {
 
   /** The version number for the 0.7.0 release. */
   public static final String VERSION_0_7_0 = "0.7.0";
+
+  /** The version number for the 0.8.0 release. */
+  public static final String VERSION_0_8_0 = "0.8.0";
 }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/database/H2Database.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/database/H2Database.java
@@ -58,7 +58,7 @@ public class H2Database implements JDBCDatabase {
         Statement statement = connection.createStatement()) {
       String sqlContent =
           FileUtils.readFileToString(
-              new File(gravitinoHome + "/scripts/h2/schema-0.7.0-h2.sql"), StandardCharsets.UTF_8);
+              new File(gravitinoHome + "/scripts/h2/schema-0.8.0-h2.sql"), StandardCharsets.UTF_8);
 
       statement.execute(sqlContent);
     } catch (Exception e) {

--- a/core/src/test/java/org/apache/gravitino/storage/relational/TestJDBCBackend.java
+++ b/core/src/test/java/org/apache/gravitino/storage/relational/TestJDBCBackend.java
@@ -150,7 +150,7 @@ public class TestJDBCBackend {
 
   private static void prepareJdbcTable() {
     // Read the ddl sql to create table
-    String scriptPath = "h2/schema-0.7.0-h2.sql";
+    String scriptPath = "h2/schema-0.8.0-h2.sql";
     try (SqlSession sqlSession =
             SqlSessionFactoryHelper.getInstance().getSqlSessionFactory().openSession(true);
         Connection connection = sqlSession.getConnection();

--- a/core/src/test/java/org/apache/gravitino/storage/relational/service/TestFilesetMetaService.java
+++ b/core/src/test/java/org/apache/gravitino/storage/relational/service/TestFilesetMetaService.java
@@ -93,7 +93,7 @@ public class TestFilesetMetaService {
               new File(
                   gravitinoHome
                       + String.format(
-                          "/scripts/mysql/schema-%s-mysql.sql", ConfigConstants.VERSION_0_5_0)),
+                          "/scripts/mysql/schema-%s-mysql.sql", ConfigConstants.VERSION_0_8_0)),
               "UTF-8");
       String[] initMySQLBackendSqls =
           Arrays.stream(mysqlContent.split(";"))

--- a/integration-test-common/src/test/java/org/apache/gravitino/integration/test/util/BaseIT.java
+++ b/integration-test-common/src/test/java/org/apache/gravitino/integration/test/util/BaseIT.java
@@ -194,7 +194,7 @@ public class BaseIT {
                   gravitinoHome
                       + String.format(
                           "/scripts/postgresql/schema-%s-postgresql.sql",
-                          ConfigConstants.VERSION_0_7_0)),
+                          ConfigConstants.VERSION_0_8_0)),
               "UTF-8");
 
       String[] initPGBackendSqls =
@@ -239,7 +239,7 @@ public class BaseIT {
               new File(
                   gravitinoHome
                       + String.format(
-                          "/scripts/mysql/schema-%s-mysql.sql", ConfigConstants.VERSION_0_7_0)),
+                          "/scripts/mysql/schema-%s-mysql.sql", ConfigConstants.VERSION_0_8_0)),
               "UTF-8");
 
       String[] initMySQLBackendSqls =

--- a/scripts/h2/schema-0.8.0-h2.sql
+++ b/scripts/h2/schema-0.8.0-h2.sql
@@ -1,0 +1,291 @@
+--
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file--
+--  distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"). You may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--  http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+--
+
+CREATE TABLE IF NOT EXISTS `metalake_meta` (
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `metalake_name` VARCHAR(128) NOT NULL COMMENT 'metalake name',
+    `metalake_comment` VARCHAR(256) DEFAULT '' COMMENT 'metalake comment',
+    `properties` MEDIUMTEXT DEFAULT NULL COMMENT 'metalake properties',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'metalake audit info',
+    `schema_version` MEDIUMTEXT NOT NULL COMMENT 'metalake schema version info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'metalake current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'metalake last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'metalake deleted at',
+    PRIMARY KEY (metalake_id),
+    CONSTRAINT uk_mn_del UNIQUE (metalake_name, deleted_at)
+) ENGINE = InnoDB;
+
+
+CREATE TABLE IF NOT EXISTS `catalog_meta` (
+    `catalog_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'catalog id',
+    `catalog_name` VARCHAR(128) NOT NULL COMMENT 'catalog name',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `type` VARCHAR(64) NOT NULL COMMENT 'catalog type',
+    `provider` VARCHAR(64) NOT NULL COMMENT 'catalog provider',
+    `catalog_comment` VARCHAR(256) DEFAULT '' COMMENT 'catalog comment',
+    `properties` MEDIUMTEXT DEFAULT NULL COMMENT 'catalog properties',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'catalog audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'catalog current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'catalog last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'catalog deleted at',
+    PRIMARY KEY (catalog_id),
+    CONSTRAINT uk_mid_cn_del UNIQUE (metalake_id, catalog_name, deleted_at)
+) ENGINE=InnoDB;
+
+
+CREATE TABLE IF NOT EXISTS `schema_meta` (
+    `schema_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'schema id',
+    `schema_name` VARCHAR(128) NOT NULL COMMENT 'schema name',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `catalog_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'catalog id',
+    `schema_comment` VARCHAR(256) DEFAULT '' COMMENT 'schema comment',
+    `properties` MEDIUMTEXT DEFAULT NULL COMMENT 'schema properties',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'schema audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'schema current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'schema last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'schema deleted at',
+    PRIMARY KEY (schema_id),
+    CONSTRAINT uk_cid_sn_del UNIQUE (catalog_id, schema_name, deleted_at),
+    -- Aliases are used here, and indexes with the same name in H2 can only be created once.
+    KEY idx_smid (metalake_id)
+) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS `table_meta` (
+    `table_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'table id',
+    `table_name` VARCHAR(128) NOT NULL COMMENT 'table name',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `catalog_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'catalog id',
+    `schema_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'schema id',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'table audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'table current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'table last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'table deleted at',
+    PRIMARY KEY (table_id),
+    CONSTRAINT uk_sid_tn_del UNIQUE (schema_id, table_name, deleted_at),
+    -- Aliases are used here, and indexes with the same name in H2 can only be created once.
+    KEY idx_tmid (metalake_id),
+    KEY idx_tcid (catalog_id)
+) ENGINE=InnoDB;
+
+
+CREATE TABLE IF NOT EXISTS `table_column_version_info` (
+    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'auto increment id',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `catalog_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'catalog id',
+    `schema_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'schema id',
+    `table_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'table id',
+    `table_version` INT UNSIGNED NOT NULL COMMENT 'table version',
+    `column_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'column id',
+    `column_name` VARCHAR(128) NOT NULL COMMENT 'column name',
+    `column_position` INT UNSIGNED NOT NULL COMMENT 'column position, starting from 0',
+    `column_type` TEXT NOT NULL COMMENT 'column type',
+    `column_comment` VARCHAR(256) DEFAULT '' COMMENT 'column comment',
+    `column_nullable` TINYINT(1) NOT NULL DEFAULT 1 COMMENT 'column nullable, 0 is not nullable, 1 is nullable',
+    `column_auto_increment` TINYINT(1) NOT NULL DEFAULT 0 COMMENT 'column auto increment, 0 is not auto increment, 1 is auto increment',
+    `column_default_value` TEXT DEFAULT NULL COMMENT 'column default value',
+    `column_op_type` TINYINT(1) NOT NULL COMMENT 'column operation type, 1 is create, 2 is update, 3 is delete',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'column deleted at',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'column audit info',
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `uk_tid_ver_cid_del` (`table_id`, `table_version`, `column_id`, `deleted_at`),
+    KEY `idx_tcmid` (`metalake_id`),
+    KEY `idx_tccid` (`catalog_id`),
+    KEY `idx_tcsid` (`schema_id`)
+) ENGINE=InnoDB;
+
+
+CREATE TABLE IF NOT EXISTS `fileset_meta` (
+    `fileset_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'fileset id',
+    `fileset_name` VARCHAR(128) NOT NULL COMMENT 'fileset name',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `catalog_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'catalog id',
+    `schema_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'schema id',
+    `type` VARCHAR(64) NOT NULL COMMENT 'fileset type',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'fileset audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'fileset current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'fileset last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'fileset deleted at',
+    PRIMARY KEY (fileset_id),
+    CONSTRAINT uk_sid_fn_del UNIQUE (schema_id, fileset_name, deleted_at),
+    -- Aliases are used here, and indexes with the same name in H2 can only be created once.
+    KEY idx_fmid (metalake_id),
+    KEY idx_fcid (catalog_id)
+) ENGINE=InnoDB;
+
+
+CREATE TABLE IF NOT EXISTS `fileset_version_info` (
+    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'auto increment id',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `catalog_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'catalog id',
+    `schema_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'schema id',
+    `fileset_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'fileset id',
+    `version` INT UNSIGNED NOT NULL COMMENT 'fileset info version',
+    `fileset_comment` VARCHAR(256) DEFAULT '' COMMENT 'fileset comment',
+    `properties` MEDIUMTEXT DEFAULT NULL COMMENT 'fileset properties',
+    `storage_location` MEDIUMTEXT DEFAULT NULL COMMENT 'fileset storage location',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'fileset deleted at',
+    PRIMARY KEY (id),
+    CONSTRAINT uk_fid_ver_del UNIQUE (fileset_id, version, deleted_at),
+    -- Aliases are used here, and indexes with the same name in H2 can only be created once.
+    KEY idx_fvmid (metalake_id),
+    KEY idx_fvcid (catalog_id)
+) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS `topic_meta` (
+    `topic_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'topic id',
+    `topic_name` VARCHAR(128) NOT NULL COMMENT 'topic name',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `catalog_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'catalog id',
+    `schema_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'schema id',
+    `comment` VARCHAR(256) DEFAULT '' COMMENT 'topic comment',
+    `properties` MEDIUMTEXT DEFAULT NULL COMMENT 'topic properties',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'topic audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'topic current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'topic last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'topic deleted at',
+    PRIMARY KEY (topic_id),
+    CONSTRAINT uk_cid_tn_del UNIQUE (schema_id, topic_name, deleted_at),
+    -- Aliases are used here, and indexes with the same name in H2 can only be created once.
+    KEY idx_tvmid (metalake_id),
+    KEY idx_tvcid (catalog_id)
+) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS `user_meta` (
+    `user_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'user id',
+    `user_name` VARCHAR(128) NOT NULL COMMENT 'username',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'user audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'user current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'user last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'user deleted at',
+    PRIMARY KEY (`user_id`),
+    CONSTRAINT `uk_mid_us_del` UNIQUE (`metalake_id`, `user_name`, `deleted_at`)
+) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS `role_meta` (
+    `role_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'role id',
+    `role_name` VARCHAR(128) NOT NULL COMMENT 'role name',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `properties` MEDIUMTEXT DEFAULT NULL COMMENT 'schema properties',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'role audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'role current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'role last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'role deleted at',
+    PRIMARY KEY (`role_id`),
+    CONSTRAINT `uk_mid_rn_del` UNIQUE (`metalake_id`, `role_name`, `deleted_at`)
+) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS `role_meta_securable_object` (
+    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'auto increment id',
+    `role_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'role id',
+    `metadata_object_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'securable object entity id',
+    `type`  VARCHAR(128) NOT NULL COMMENT 'securable object type',
+    `privilege_names` TEXT(81920) NOT NULL COMMENT 'securable object privilege names',
+    `privilege_conditions` TEXT(81920) NOT NULL COMMENT 'securable object privilege conditions',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'securable objectcurrent version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'securable object last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'securable object deleted at',
+    PRIMARY KEY (`id`),
+    KEY `idx_obj_rid` (`role_id`),
+    KEY `idx_obj_eid` (`metadata_object_id`)
+    ) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS `user_role_rel` (
+    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'auto increment id',
+    `user_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'user id',
+    `role_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'role id',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'relation audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'relation current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'relation last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'relation deleted at',
+    PRIMARY KEY (`id`),
+    CONSTRAINT `uk_ui_ri_del` UNIQUE (`user_id`, `role_id`, `deleted_at`),
+    KEY `idx_rid` (`role_id`)
+) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS `group_meta` (
+    `group_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'group id',
+    `group_name` VARCHAR(128) NOT NULL COMMENT 'group name',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'group audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'group current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'group last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'group deleted at',
+    PRIMARY KEY (`group_id`),
+    CONSTRAINT `uk_mid_gr_del` UNIQUE (`metalake_id`, `group_name`, `deleted_at`)
+    ) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS `group_role_rel` (
+    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'auto increment id',
+    `group_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'group id',
+    `role_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'role id',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'relation audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'relation current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'relation last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'relation deleted at',
+    PRIMARY KEY (`id`),
+    CONSTRAINT `uk_gi_ri_del` UNIQUE (`group_id`, `role_id`, `deleted_at`),
+    KEY `idx_gid` (`group_id`)
+    ) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS `tag_meta` (
+    `tag_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'tag id',
+    `tag_name` VARCHAR(128) NOT NULL COMMENT 'tag name',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `tag_comment` VARCHAR(256) DEFAULT '' COMMENT 'tag comment',
+    `properties` MEDIUMTEXT DEFAULT NULL COMMENT 'tag properties',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'tag audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'tag current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'tag last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'tag deleted at',
+    PRIMARY KEY (`tag_id`),
+    UNIQUE KEY `uk_mn_tn_del` (`metalake_id`, `tag_name`, `deleted_at`)
+    ) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS `tag_relation_meta` (
+    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'auto increment id',
+    `tag_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'tag id',
+    `metadata_object_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metadata object id',
+    `metadata_object_type` VARCHAR(64) NOT NULL COMMENT 'metadata object type',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'tag relation audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'tag relation current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'tag relation last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'tag relation deleted at',
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `uk_ti_mi_del` (`tag_id`, `metadata_object_id`, `deleted_at`),
+    KEY `idx_tid` (`tag_id`),
+    KEY `idx_mid` (`metadata_object_id`)
+    ) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS `owner_meta` (
+    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'auto increment id',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `owner_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'owner id',
+    `owner_type` VARCHAR(64) NOT NULL COMMENT 'owner type',
+    `metadata_object_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metadata object id',
+    `metadata_object_type` VARCHAR(64) NOT NULL COMMENT 'metadata object type',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'owner relation audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'owner relation current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'owner relation last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'owner relation deleted at',
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `uk_ow_me_del` (`owner_id`, `metadata_object_id`, `metadata_object_type`, `deleted_at`),
+    KEY `idx_oid` (`owner_id`),
+    KEY `idx_meid` (`metadata_object_id`)
+    ) ENGINE=InnoDB;

--- a/scripts/h2/upgrade-0.7.0-to-0.8.0-h2.sql
+++ b/scripts/h2/upgrade-0.7.0-to-0.8.0-h2.sql
@@ -1,0 +1,20 @@
+--
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file--
+--  distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"). You may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--  http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+--
+ALTER TABLE `role_meta_securable_object` ALTER COLUMN `privilege_names` TEXT(81920);
+ALTER TABLE `role_meta_securable_object` ALTER COLUMN `privilege_conditions` TEXT(81920);

--- a/scripts/mysql/schema-0.8.0-mysql.sql
+++ b/scripts/mysql/schema-0.8.0-mysql.sql
@@ -1,0 +1,282 @@
+--
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file--
+--  distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"). You may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--  http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+--
+
+CREATE TABLE IF NOT EXISTS `metalake_meta` (
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `metalake_name` VARCHAR(128) NOT NULL COMMENT 'metalake name',
+    `metalake_comment` VARCHAR(256) DEFAULT '' COMMENT 'metalake comment',
+    `properties` MEDIUMTEXT DEFAULT NULL COMMENT 'metalake properties',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'metalake audit info',
+    `schema_version` MEDIUMTEXT NOT NULL COMMENT 'metalake schema version info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'metalake current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'metalake last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'metalake deleted at',
+    PRIMARY KEY (`metalake_id`),
+    UNIQUE KEY `uk_mn_del` (`metalake_name`, `deleted_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'metalake metadata';
+
+CREATE TABLE IF NOT EXISTS `catalog_meta` (
+    `catalog_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'catalog id',
+    `catalog_name` VARCHAR(128) NOT NULL COMMENT 'catalog name',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `type` VARCHAR(64) NOT NULL COMMENT 'catalog type',
+    `provider` VARCHAR(64) NOT NULL COMMENT 'catalog provider',
+    `catalog_comment` VARCHAR(256) DEFAULT '' COMMENT 'catalog comment',
+    `properties` MEDIUMTEXT DEFAULT NULL COMMENT 'catalog properties',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'catalog audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'catalog current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'catalog last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'catalog deleted at',
+    PRIMARY KEY (`catalog_id`),
+    UNIQUE KEY `uk_mid_cn_del` (`metalake_id`, `catalog_name`, `deleted_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'catalog metadata';
+
+CREATE TABLE IF NOT EXISTS `schema_meta` (
+    `schema_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'schema id',
+    `schema_name` VARCHAR(128) NOT NULL COMMENT 'schema name',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `catalog_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'catalog id',
+    `schema_comment` VARCHAR(256) DEFAULT '' COMMENT 'schema comment',
+    `properties` MEDIUMTEXT DEFAULT NULL COMMENT 'schema properties',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'schema audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'schema current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'schema last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'schema deleted at',
+    PRIMARY KEY (`schema_id`),
+    UNIQUE KEY `uk_cid_sn_del` (`catalog_id`, `schema_name`, `deleted_at`),
+    KEY `idx_mid` (`metalake_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'schema metadata';
+
+CREATE TABLE IF NOT EXISTS `table_meta` (
+    `table_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'table id',
+    `table_name` VARCHAR(128) NOT NULL COMMENT 'table name',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `catalog_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'catalog id',
+    `schema_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'schema id',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'table audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'table current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'table last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'table deleted at',
+    PRIMARY KEY (`table_id`),
+    UNIQUE KEY `uk_sid_tn_del` (`schema_id`, `table_name`, `deleted_at`),
+    KEY `idx_mid` (`metalake_id`),
+    KEY `idx_cid` (`catalog_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'table metadata';
+
+CREATE TABLE IF NOT EXISTS `table_column_version_info` (
+    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'auto increment id',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `catalog_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'catalog id',
+    `schema_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'schema id',
+    `table_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'table id',
+    `table_version` INT UNSIGNED NOT NULL COMMENT 'table version',
+    `column_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'column id',
+    `column_name` VARCHAR(128) NOT NULL COMMENT 'column name',
+    `column_position` INT UNSIGNED NOT NULL COMMENT 'column position, starting from 0',
+    `column_type` TEXT NOT NULL COMMENT 'column type',
+    `column_comment` VARCHAR(256) DEFAULT '' COMMENT 'column comment',
+    `column_nullable` TINYINT(1) NOT NULL DEFAULT 1 COMMENT 'column nullable, 0 is not nullable, 1 is nullable',
+    `column_auto_increment` TINYINT(1) NOT NULL DEFAULT 0 COMMENT 'column auto increment, 0 is not auto increment, 1 is auto increment',
+    `column_default_value` TEXT DEFAULT NULL COMMENT 'column default value',
+    `column_op_type` TINYINT(1) NOT NULL COMMENT 'column operation type, 1 is create, 2 is update, 3 is delete',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'column deleted at',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'column audit info',
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `uk_tid_ver_cid_del` (`table_id`, `table_version`, `column_id`, `deleted_at`),
+    KEY `idx_mid` (`metalake_id`),
+    KEY `idx_cid` (`catalog_id`),
+    KEY `idx_sid` (`schema_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'table column version info';
+
+CREATE TABLE IF NOT EXISTS `fileset_meta` (
+    `fileset_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'fileset id',
+    `fileset_name` VARCHAR(128) NOT NULL COMMENT 'fileset name',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `catalog_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'catalog id',
+    `schema_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'schema id',
+    `type` VARCHAR(64) NOT NULL COMMENT 'fileset type',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'fileset audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'fileset current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'fileset last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'fileset deleted at',
+    PRIMARY KEY (`fileset_id`),
+    UNIQUE KEY `uk_sid_fn_del` (`schema_id`, `fileset_name`, `deleted_at`),
+    KEY `idx_mid` (`metalake_id`),
+    KEY `idx_cid` (`catalog_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'fileset metadata';
+
+CREATE TABLE IF NOT EXISTS `fileset_version_info` (
+    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'auto increment id',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `catalog_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'catalog id',
+    `schema_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'schema id',
+    `fileset_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'fileset id',
+    `version` INT UNSIGNED NOT NULL COMMENT 'fileset info version',
+    `fileset_comment` VARCHAR(256) DEFAULT '' COMMENT 'fileset comment',
+    `properties` MEDIUMTEXT DEFAULT NULL COMMENT 'fileset properties',
+    `storage_location` MEDIUMTEXT NOT NULL COMMENT 'fileset storage location',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'fileset deleted at',
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `uk_fid_ver_del` (`fileset_id`, `version`, `deleted_at`),
+    KEY `idx_mid` (`metalake_id`),
+    KEY `idx_cid` (`catalog_id`),
+    KEY `idx_sid` (`schema_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'fileset version info';
+
+CREATE TABLE IF NOT EXISTS `topic_meta` (
+    `topic_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'topic id',
+    `topic_name` VARCHAR(128) NOT NULL COMMENT 'topic name',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `catalog_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'catalog id',
+    `schema_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'schema id',
+    `comment` VARCHAR(256) DEFAULT '' COMMENT 'topic comment',
+    `properties` MEDIUMTEXT DEFAULT NULL COMMENT 'topic properties',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'topic audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'topic current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'topic last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'topic deleted at',
+    PRIMARY KEY (`topic_id`),
+    UNIQUE KEY `uk_sid_tn_del` (`schema_id`, `topic_name`, `deleted_at`),
+    KEY `idx_mid` (`metalake_id`),
+    KEY `idx_cid` (`catalog_id`)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'topic metadata';
+
+CREATE TABLE IF NOT EXISTS `user_meta` (
+    `user_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'user id',
+    `user_name` VARCHAR(128) NOT NULL COMMENT 'username',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'user audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'user current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'user last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'user deleted at',
+    PRIMARY KEY (`user_id`),
+    UNIQUE KEY `uk_mid_us_del` (`metalake_id`, `user_name`, `deleted_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'user metadata';
+
+CREATE TABLE IF NOT EXISTS `role_meta` (
+    `role_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'role id',
+    `role_name` VARCHAR(128) NOT NULL COMMENT 'role name',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `properties` MEDIUMTEXT DEFAULT NULL COMMENT 'schema properties',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'role audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'role current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'role last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'role deleted at',
+    PRIMARY KEY (`role_id`),
+    UNIQUE KEY `uk_mid_rn_del` (`metalake_id`, `role_name`, `deleted_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'role metadata';
+
+CREATE TABLE IF NOT EXISTS `role_meta_securable_object` (
+    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'auto increment id',
+    `role_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'role id',
+    `metadata_object_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'The entity id of securable object',
+    `type`  VARCHAR(128) NOT NULL COMMENT 'securable object type',
+    `privilege_names` TEXT(81920) NOT NULL COMMENT 'securable object privilege names',
+    `privilege_conditions` TEXT(81920) NOT NULL COMMENT 'securable object privilege conditions',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'securable objectcurrent version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'securable object last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'securable object deleted at',
+    PRIMARY KEY (`id`),
+    KEY `idx_obj_rid` (`role_id`),
+    KEY `idx_obj_eid` (`metadata_object_id`)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'securable object meta';
+
+CREATE TABLE IF NOT EXISTS `user_role_rel` (
+    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'auto increment id',
+    `user_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'user id',
+    `role_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'role id',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'relation audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'relation current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'relation last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'relation deleted at',
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `uk_ui_ri_del` (`user_id`, `role_id`, `deleted_at`),
+    KEY `idx_rid` (`role_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'user role relation';
+
+CREATE TABLE IF NOT EXISTS `group_meta` (
+    `group_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'group id',
+    `group_name` VARCHAR(128) NOT NULL COMMENT 'group name',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'group audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'group current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'group last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'group deleted at',
+    PRIMARY KEY (`group_id`),
+    UNIQUE KEY `uk_mid_gr_del` (`metalake_id`, `group_name`, `deleted_at`)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'group metadata';
+
+CREATE TABLE IF NOT EXISTS `group_role_rel` (
+    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'auto increment id',
+    `group_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'group id',
+    `role_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'role id',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'relation audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'relation current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'relation last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'relation deleted at',
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `uk_gi_ri_del` (`group_id`, `role_id`, `deleted_at`),
+    KEY `idx_rid` (`group_id`)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'group role relation';
+
+CREATE TABLE IF NOT EXISTS `tag_meta` (
+    `tag_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'tag id',
+    `tag_name` VARCHAR(128) NOT NULL COMMENT 'tag name',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `tag_comment` VARCHAR(256) DEFAULT '' COMMENT 'tag comment',
+    `properties` MEDIUMTEXT DEFAULT NULL COMMENT 'tag properties',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'tag audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'tag current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'tag last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'tag deleted at',
+    PRIMARY KEY (`tag_id`),
+    UNIQUE KEY `uk_mi_tn_del` (`metalake_id`, `tag_name`, `deleted_at`)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'tag metadata';
+
+CREATE TABLE IF NOT EXISTS `tag_relation_meta` (
+    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'auto increment id',
+    `tag_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'tag id',
+    `metadata_object_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metadata object id',
+    `metadata_object_type` VARCHAR(64) NOT NULL COMMENT 'metadata object type',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'tag relation audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'tag relation current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'tag relation last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'tag relation deleted at',
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `uk_ti_mi_mo_del` (`tag_id`, `metadata_object_id`, `metadata_object_type`, `deleted_at`),
+    KEY `idx_tid` (`tag_id`),
+    KEY `idx_mid` (`metadata_object_id`)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'tag metadata object relation';
+
+CREATE TABLE IF NOT EXISTS `owner_meta` (
+    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'auto increment id',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `owner_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'owner id',
+    `owner_type` VARCHAR(64) NOT NULL COMMENT 'owner type',
+    `metadata_object_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metadata object id',
+    `metadata_object_type` VARCHAR(64) NOT NULL COMMENT 'metadata object type',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'owner relation audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'owner relation current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'owner relation last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'owner relation deleted at',
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `uk_ow_me_del` (`owner_id`, `metadata_object_id`, `metadata_object_type`,`deleted_at`),
+    KEY `idx_oid` (`owner_id`),
+    KEY `idx_meid` (`metadata_object_id`)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'owner relation';

--- a/scripts/mysql/upgrade-0.7.0-to-0.8.0-mysql.sql
+++ b/scripts/mysql/upgrade-0.7.0-to-0.8.0-mysql.sql
@@ -1,0 +1,20 @@
+--
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file--
+--  distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"). You may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--  http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+--
+ALTER TABLE `role_meta_securable_object` MODIFY COLUMN `privilege_names` TEXT(81920);
+ALTER TABLE `role_meta_securable_object` MODIFY COLUMN `privilege_conditions` TEXT(81920);

--- a/scripts/postgresql/schema-0.8.0-postgresql.sql
+++ b/scripts/postgresql/schema-0.8.0-postgresql.sql
@@ -1,0 +1,502 @@
+--
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file--
+--  distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"). You may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--  http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+--
+
+-- Note: Database and schema creation is not included in this script. Please create the database and
+-- schema before running this script. for example in psql:
+-- CREATE DATABASE example_db;
+-- \c example_db
+-- CREATE SCHEMA example_schema;
+-- set search_path to example_schema;
+
+
+CREATE TABLE IF NOT EXISTS metalake_meta (
+    metalake_id BIGINT NOT NULL,
+    metalake_name VARCHAR(128) NOT NULL,
+    metalake_comment VARCHAR(256) DEFAULT '',
+    properties TEXT DEFAULT NULL,
+    audit_info TEXT NOT NULL,
+    schema_version TEXT NOT NULL,
+    current_version INT NOT NULL DEFAULT 1,
+    last_version INT NOT NULL DEFAULT 1,
+    deleted_at BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (metalake_id),
+    UNIQUE (metalake_name, deleted_at)
+    );
+COMMENT ON TABLE metalake_meta IS 'metalake metadata';
+
+COMMENT ON COLUMN metalake_meta.metalake_id IS 'metalake id';
+COMMENT ON COLUMN metalake_meta.metalake_name IS 'metalake name';
+COMMENT ON COLUMN metalake_meta.metalake_comment IS 'metalake comment';
+COMMENT ON COLUMN metalake_meta.properties IS 'metalake properties';
+COMMENT ON COLUMN metalake_meta.audit_info IS 'metalake audit info';
+COMMENT ON COLUMN metalake_meta.schema_version IS 'metalake schema version info';
+COMMENT ON COLUMN metalake_meta.current_version IS 'metalake current version';
+COMMENT ON COLUMN metalake_meta.last_version IS 'metalake last version';
+COMMENT ON COLUMN metalake_meta.deleted_at IS 'metalake deleted at';
+
+
+CREATE TABLE IF NOT EXISTS catalog_meta (
+    catalog_id BIGINT NOT NULL,
+    catalog_name VARCHAR(128) NOT NULL,
+    metalake_id BIGINT NOT NULL,
+    type VARCHAR(64) NOT NULL,
+    provider VARCHAR(64) NOT NULL,
+    catalog_comment VARCHAR(256) DEFAULT '',
+    properties TEXT DEFAULT NULL,
+    audit_info TEXT NOT NULL,
+    current_version INT NOT NULL DEFAULT 1,
+    last_version INT NOT NULL DEFAULT 1,
+    deleted_at BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (catalog_id),
+    UNIQUE (metalake_id, catalog_name, deleted_at)
+    );
+
+COMMENT ON TABLE catalog_meta IS 'catalog metadata';
+
+COMMENT ON COLUMN catalog_meta.catalog_id IS 'catalog id';
+COMMENT ON COLUMN catalog_meta.catalog_name IS 'catalog name';
+COMMENT ON COLUMN catalog_meta.metalake_id IS 'metalake id';
+COMMENT ON COLUMN catalog_meta.type IS 'catalog type';
+COMMENT ON COLUMN catalog_meta.provider IS 'catalog provider';
+COMMENT ON COLUMN catalog_meta.catalog_comment IS 'catalog comment';
+COMMENT ON COLUMN catalog_meta.properties IS 'catalog properties';
+COMMENT ON COLUMN catalog_meta.audit_info IS 'catalog audit info';
+COMMENT ON COLUMN catalog_meta.current_version IS 'catalog current version';
+COMMENT ON COLUMN catalog_meta.last_version IS 'catalog last version';
+COMMENT ON COLUMN catalog_meta.deleted_at IS 'catalog deleted at';
+
+
+CREATE TABLE IF NOT EXISTS schema_meta (
+    schema_id BIGINT NOT NULL,
+    schema_name VARCHAR(128) NOT NULL,
+    metalake_id BIGINT NOT NULL,
+    catalog_id BIGINT NOT NULL,
+    schema_comment VARCHAR(256) DEFAULT '',
+    properties TEXT DEFAULT NULL,
+    audit_info TEXT NOT NULL,
+    current_version INT NOT NULL DEFAULT 1,
+    last_version INT NOT NULL DEFAULT 1,
+    deleted_at BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (schema_id),
+    UNIQUE (catalog_id, schema_name, deleted_at)
+    );
+
+CREATE INDEX IF NOT EXISTS idx_metalake_id ON schema_meta (metalake_id);
+COMMENT ON TABLE schema_meta IS 'schema metadata';
+
+COMMENT ON COLUMN schema_meta.schema_id IS 'schema id';
+COMMENT ON COLUMN schema_meta.schema_name IS 'schema name';
+COMMENT ON COLUMN schema_meta.metalake_id IS 'metalake id';
+COMMENT ON COLUMN schema_meta.catalog_id IS 'catalog id';
+COMMENT ON COLUMN schema_meta.schema_comment IS 'schema comment';
+COMMENT ON COLUMN schema_meta.properties IS 'schema properties';
+COMMENT ON COLUMN schema_meta.audit_info IS 'schema audit info';
+COMMENT ON COLUMN schema_meta.current_version IS 'schema current version';
+COMMENT ON COLUMN schema_meta.last_version IS 'schema last version';
+COMMENT ON COLUMN schema_meta.deleted_at IS 'schema deleted at';
+
+
+CREATE TABLE IF NOT EXISTS table_meta (
+    table_id BIGINT NOT NULL,
+    table_name VARCHAR(128) NOT NULL,
+    metalake_id BIGINT NOT NULL,
+    catalog_id BIGINT NOT NULL,
+    schema_id BIGINT NOT NULL,
+    audit_info TEXT NOT NULL,
+    current_version INT NOT NULL DEFAULT 1,
+    last_version INT NOT NULL DEFAULT 1,
+    deleted_at BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (table_id),
+    UNIQUE (schema_id, table_name, deleted_at)
+    );
+
+CREATE INDEX IF NOT EXISTS idx_metalake_id ON table_meta (metalake_id);
+CREATE INDEX IF NOT EXISTS idx_catalog_id ON table_meta (catalog_id);
+COMMENT ON TABLE table_meta IS 'table metadata';
+
+COMMENT ON COLUMN table_meta.table_id IS 'table id';
+COMMENT ON COLUMN table_meta.table_name IS 'table name';
+COMMENT ON COLUMN table_meta.metalake_id IS 'metalake id';
+COMMENT ON COLUMN table_meta.catalog_id IS 'catalog id';
+COMMENT ON COLUMN table_meta.schema_id IS 'schema id';
+COMMENT ON COLUMN table_meta.audit_info IS 'table audit info';
+COMMENT ON COLUMN table_meta.current_version IS 'table current version';
+COMMENT ON COLUMN table_meta.last_version IS 'table last version';
+COMMENT ON COLUMN table_meta.deleted_at IS 'table deleted at';
+
+CREATE TABLE IF NOT EXISTS table_column_version_info (
+    id BIGINT NOT NULL GENERATED BY DEFAULT AS IDENTITY,
+    metalake_id BIGINT NOT NULL,
+    catalog_id BIGINT NOT NULL,
+    schema_id BIGINT NOT NULL,
+    table_id BIGINT NOT NULL,
+    table_version INT NOT NULL,
+    column_id BIGINT NOT NULL,
+    column_name VARCHAR(128) NOT NULL,
+    column_position INT NOT NULL,
+    column_type TEXT NOT NULL,
+    column_comment VARCHAR(256) DEFAULT '',
+    column_nullable SMALLINT NOT NULL DEFAULT 1,
+    column_auto_increment SMALLINT NOT NULL DEFAULT 0,
+    column_default_value TEXT DEFAULT NULL,
+    column_op_type SMALLINT NOT NULL,
+    deleted_at BIGINT NOT NULL DEFAULT 0,
+    audit_info TEXT NOT NULL,
+    PRIMARY KEY (id),
+    UNIQUE (table_id, table_version, column_id, deleted_at)
+);
+CREATE INDEX idx_mid ON table_column_version_info (metalake_id);
+CREATE INDEX idx_cid ON table_column_version_info (catalog_id);
+CREATE INDEX idx_sid ON table_column_version_info (schema_id);
+COMMENT ON TABLE table_column_version_info IS 'table column version information';
+
+COMMENT ON COLUMN table_column_version_info.id IS 'auto increment id';
+COMMENT ON COLUMN table_column_version_info.metalake_id IS 'metalake id';
+COMMENT ON COLUMN table_column_version_info.catalog_id IS 'catalog id';
+COMMENT ON COLUMN table_column_version_info.schema_id IS 'schema id';
+COMMENT ON COLUMN table_column_version_info.table_id IS 'table id';
+COMMENT ON COLUMN table_column_version_info.table_version IS 'table version';
+COMMENT ON COLUMN table_column_version_info.column_id IS 'column id';
+COMMENT ON COLUMN table_column_version_info.column_name IS 'column name';
+COMMENT ON COLUMN table_column_version_info.column_position IS 'column position, starting from 0';
+COMMENT ON COLUMN table_column_version_info.column_type IS 'column type';
+COMMENT ON COLUMN table_column_version_info.column_comment IS 'column comment';
+COMMENT ON COLUMN table_column_version_info.column_nullable IS 'column nullable, 0 is not nullable, 1 is nullable';
+COMMENT ON COLUMN table_column_version_info.column_auto_increment IS 'column auto increment, 0 is not auto increment, 1 is auto increment';
+COMMENT ON COLUMN table_column_version_info.column_default_value IS 'column default value';
+COMMENT ON COLUMN table_column_version_info.column_op_type IS 'column operation type, 1 is create, 2 is update, 3 is delete';
+COMMENT ON COLUMN table_column_version_info.deleted_at IS 'column deleted at';
+COMMENT ON COLUMN table_column_version_info.audit_info IS 'column audit info';
+
+
+CREATE TABLE IF NOT EXISTS fileset_meta (
+    fileset_id BIGINT NOT NULL,
+    fileset_name VARCHAR(128) NOT NULL,
+    metalake_id BIGINT NOT NULL,
+    catalog_id BIGINT NOT NULL,
+    schema_id BIGINT NOT NULL,
+    type VARCHAR(64) NOT NULL,
+    audit_info TEXT NOT NULL,
+    current_version INT NOT NULL DEFAULT 1,
+    last_version INT NOT NULL DEFAULT 1,
+    deleted_at BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (fileset_id),
+    UNIQUE (schema_id, fileset_name, deleted_at)
+    );
+
+CREATE INDEX IF NOT EXISTS idx_metalake_id ON fileset_meta (metalake_id);
+CREATE INDEX IF NOT EXISTS idx_catalog_id ON fileset_meta (catalog_id);
+COMMENT ON TABLE fileset_meta IS 'fileset metadata';
+
+COMMENT ON COLUMN fileset_meta.fileset_id IS 'fileset id';
+COMMENT ON COLUMN fileset_meta.fileset_name IS 'fileset name';
+COMMENT ON COLUMN fileset_meta.metalake_id IS 'metalake id';
+COMMENT ON COLUMN fileset_meta.catalog_id IS 'catalog id';
+COMMENT ON COLUMN fileset_meta.schema_id IS 'schema id';
+COMMENT ON COLUMN fileset_meta.type IS 'fileset type';
+COMMENT ON COLUMN fileset_meta.audit_info IS 'fileset audit info';
+COMMENT ON COLUMN fileset_meta.current_version IS 'fileset current version';
+COMMENT ON COLUMN fileset_meta.last_version IS 'fileset last version';
+COMMENT ON COLUMN fileset_meta.deleted_at IS 'fileset deleted at';
+
+
+CREATE TABLE IF NOT EXISTS fileset_version_info (
+    id BIGINT NOT NULL GENERATED BY DEFAULT AS IDENTITY,
+    metalake_id BIGINT NOT NULL,
+    catalog_id BIGINT NOT NULL,
+    schema_id BIGINT NOT NULL,
+    fileset_id BIGINT NOT NULL,
+    version INT NOT NULL,
+    fileset_comment VARCHAR(256) DEFAULT '',
+    properties TEXT DEFAULT NULL,
+    storage_location TEXT NOT NULL,
+    deleted_at BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (id),
+    UNIQUE (fileset_id, version, deleted_at)
+    );
+
+CREATE INDEX IF NOT EXISTS idx_metalake_id ON fileset_version_info (metalake_id);
+CREATE INDEX IF NOT EXISTS idx_catalog_id ON fileset_version_info (catalog_id);
+CREATE INDEX IF NOT EXISTS idx_schema_id ON fileset_version_info (schema_id);
+COMMENT ON TABLE fileset_version_info IS 'fileset version information';
+
+COMMENT ON COLUMN fileset_version_info.id IS 'auto increment id';
+COMMENT ON COLUMN fileset_version_info.metalake_id IS 'metalake id';
+COMMENT ON COLUMN fileset_version_info.catalog_id IS 'catalog id';
+COMMENT ON COLUMN fileset_version_info.schema_id IS 'schema id';
+COMMENT ON COLUMN fileset_version_info.fileset_id IS 'fileset id';
+COMMENT ON COLUMN fileset_version_info.version IS 'fileset info version';
+COMMENT ON COLUMN fileset_version_info.fileset_comment IS 'fileset comment';
+COMMENT ON COLUMN fileset_version_info.properties IS 'fileset properties';
+COMMENT ON COLUMN fileset_version_info.storage_location IS 'fileset storage location';
+COMMENT ON COLUMN fileset_version_info.deleted_at IS 'fileset deleted at';
+
+
+CREATE TABLE IF NOT EXISTS topic_meta (
+    topic_id BIGINT NOT NULL,
+    topic_name VARCHAR(128) NOT NULL,
+    metalake_id BIGINT NOT NULL,
+    catalog_id BIGINT NOT NULL,
+    schema_id BIGINT NOT NULL,
+    comment VARCHAR(256) DEFAULT '',
+    properties TEXT DEFAULT NULL,
+    audit_info TEXT NOT NULL,
+    current_version INT NOT NULL DEFAULT 1,
+    last_version INT NOT NULL DEFAULT 1,
+    deleted_at BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (topic_id),
+    UNIQUE (schema_id, topic_name, deleted_at)
+    );
+
+CREATE INDEX IF NOT EXISTS idx_metalake_id ON topic_meta (metalake_id);
+CREATE INDEX IF NOT EXISTS idx_catalog_id ON topic_meta (catalog_id);
+COMMENT ON TABLE topic_meta IS 'topic metadata';
+
+COMMENT ON COLUMN topic_meta.topic_id IS 'topic id';
+COMMENT ON COLUMN topic_meta.topic_name IS 'topic name';
+COMMENT ON COLUMN topic_meta.metalake_id IS 'metalake id';
+COMMENT ON COLUMN topic_meta.catalog_id IS 'catalog id';
+COMMENT ON COLUMN topic_meta.schema_id IS 'schema id';
+COMMENT ON COLUMN topic_meta.comment IS 'topic comment';
+COMMENT ON COLUMN topic_meta.properties IS 'topic properties';
+COMMENT ON COLUMN topic_meta.audit_info IS 'topic audit info';
+COMMENT ON COLUMN topic_meta.current_version IS 'topic current version';
+COMMENT ON COLUMN topic_meta.last_version IS 'topic last version';
+COMMENT ON COLUMN topic_meta.deleted_at IS 'topic deleted at';
+
+
+CREATE TABLE IF NOT EXISTS user_meta (
+    user_id BIGINT NOT NULL,
+    user_name VARCHAR(128) NOT NULL,
+    metalake_id BIGINT NOT NULL,
+    audit_info TEXT NOT NULL,
+    current_version INT NOT NULL DEFAULT 1,
+    last_version INT NOT NULL DEFAULT 1,
+    deleted_at BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (user_id),
+    UNIQUE (metalake_id, user_name, deleted_at)
+    );
+COMMENT ON TABLE user_meta IS 'user metadata';
+
+COMMENT ON COLUMN user_meta.user_id IS 'user id';
+COMMENT ON COLUMN user_meta.user_name IS 'username';
+COMMENT ON COLUMN user_meta.metalake_id IS 'metalake id';
+COMMENT ON COLUMN user_meta.audit_info IS 'user audit info';
+COMMENT ON COLUMN user_meta.current_version IS 'user current version';
+COMMENT ON COLUMN user_meta.last_version IS 'user last version';
+COMMENT ON COLUMN user_meta.deleted_at IS 'user deleted at';
+
+CREATE TABLE IF NOT EXISTS role_meta (
+    role_id BIGINT NOT NULL,
+    role_name VARCHAR(128) NOT NULL,
+    metalake_id BIGINT NOT NULL,
+    properties TEXT DEFAULT NULL,
+    audit_info TEXT NOT NULL,
+    current_version INT NOT NULL DEFAULT 1,
+    last_version INT NOT NULL DEFAULT 1,
+    deleted_at BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (role_id),
+    UNIQUE (metalake_id, role_name, deleted_at)
+    );
+
+COMMENT ON TABLE role_meta IS 'role metadata';
+
+COMMENT ON COLUMN role_meta.role_id IS 'role id';
+COMMENT ON COLUMN role_meta.role_name IS 'role name';
+COMMENT ON COLUMN role_meta.metalake_id IS 'metalake id';
+COMMENT ON COLUMN role_meta.properties IS 'role properties';
+COMMENT ON COLUMN role_meta.audit_info IS 'role audit info';
+COMMENT ON COLUMN role_meta.current_version IS 'role current version';
+COMMENT ON COLUMN role_meta.last_version IS 'role last version';
+COMMENT ON COLUMN role_meta.deleted_at IS 'role deleted at';
+
+
+CREATE TABLE IF NOT EXISTS role_meta_securable_object (
+    id BIGINT NOT NULL GENERATED BY DEFAULT AS IDENTITY,
+    role_id BIGINT NOT NULL,
+    metadata_object_id BIGINT NOT NULL,
+    type  VARCHAR(128) NOT NULL,
+    privilege_names VARCHAR(81920) NOT NULL,
+    privilege_conditions VARCHAR(81920) NOT NULL,
+    current_version INT NOT NULL DEFAULT 1,
+    last_version INT NOT NULL DEFAULT 1,
+    deleted_at BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (id)
+    );
+
+CREATE INDEX IF NOT EXISTS idx_role_id ON role_meta_securable_object (role_id);
+COMMENT ON TABLE role_meta_securable_object IS 'role to securable object relation metadata';
+
+COMMENT ON COLUMN role_meta_securable_object.id IS 'auto increment id';
+COMMENT ON COLUMN role_meta_securable_object.role_id IS 'role id';
+COMMENT ON COLUMN role_meta_securable_object.metadata_object_id IS 'The entity id of securable object';
+COMMENT ON COLUMN role_meta_securable_object.type IS 'securable object type';
+COMMENT ON COLUMN role_meta_securable_object.privilege_names IS 'securable object privilege names';
+COMMENT ON COLUMN role_meta_securable_object.privilege_conditions IS 'securable object privilege conditions';
+COMMENT ON COLUMN role_meta_securable_object.current_version IS 'securable object current version';
+COMMENT ON COLUMN role_meta_securable_object.last_version IS 'securable object last version';
+COMMENT ON COLUMN role_meta_securable_object.deleted_at IS 'securable object deleted at';
+
+
+CREATE TABLE IF NOT EXISTS user_role_rel (
+    id BIGINT NOT NULL GENERATED BY DEFAULT AS IDENTITY,
+    user_id BIGINT NOT NULL,
+    role_id BIGINT NOT NULL,
+    audit_info TEXT NOT NULL,
+    current_version INT NOT NULL DEFAULT 1,
+    last_version INT NOT NULL DEFAULT 1,
+    deleted_at BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (id),
+    UNIQUE (user_id, role_id, deleted_at)
+    );
+
+CREATE INDEX IF NOT EXISTS idx_user_id ON user_role_rel (user_id);
+COMMENT ON TABLE user_role_rel IS 'user role relation metadata';
+
+COMMENT ON COLUMN user_role_rel.id IS 'auto increment id';
+COMMENT ON COLUMN user_role_rel.user_id IS 'user id';
+COMMENT ON COLUMN user_role_rel.role_id IS 'role id';
+COMMENT ON COLUMN user_role_rel.audit_info IS 'relation audit info';
+COMMENT ON COLUMN user_role_rel.current_version IS 'relation current version';
+COMMENT ON COLUMN user_role_rel.last_version IS 'relation last version';
+COMMENT ON COLUMN user_role_rel.deleted_at IS 'relation deleted at';
+
+
+CREATE TABLE IF NOT EXISTS group_meta (
+    group_id BIGINT NOT NULL,
+    group_name VARCHAR(128) NOT NULL,
+    metalake_id BIGINT NOT NULL,
+    audit_info TEXT NOT NULL,
+    current_version INT NOT NULL DEFAULT 1,
+    last_version INT NOT NULL DEFAULT 1,
+    deleted_at BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (group_id),
+    UNIQUE (metalake_id, group_name, deleted_at)
+    );
+COMMENT ON TABLE group_meta IS 'group metadata';
+
+COMMENT ON COLUMN group_meta.group_id IS 'group id';
+COMMENT ON COLUMN group_meta.group_name IS 'group name';
+COMMENT ON COLUMN group_meta.metalake_id IS 'metalake id';
+COMMENT ON COLUMN group_meta.audit_info IS 'group audit info';
+COMMENT ON COLUMN group_meta.current_version IS 'group current version';
+COMMENT ON COLUMN group_meta.last_version IS 'group last version';
+COMMENT ON COLUMN group_meta.deleted_at IS 'group deleted at';
+
+
+CREATE TABLE IF NOT EXISTS group_role_rel (
+    id BIGSERIAL NOT NULL,
+    group_id BIGINT NOT NULL,
+    role_id BIGINT NOT NULL,
+    audit_info TEXT NOT NULL,
+    current_version INT NOT NULL DEFAULT 1,
+    last_version INT NOT NULL DEFAULT 1,
+    deleted_at BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (id),
+    UNIQUE (group_id, role_id, deleted_at)
+    );
+
+CREATE INDEX IF NOT EXISTS idx_group_id ON group_role_rel (group_id);
+COMMENT ON TABLE group_role_rel IS 'relation between group and role';
+COMMENT ON COLUMN group_role_rel.id IS 'auto increment id';
+COMMENT ON COLUMN group_role_rel.group_id IS 'group id';
+COMMENT ON COLUMN group_role_rel.role_id IS 'role id';
+COMMENT ON COLUMN group_role_rel.audit_info IS 'relation audit info';
+COMMENT ON COLUMN group_role_rel.current_version IS 'relation current version';
+COMMENT ON COLUMN group_role_rel.last_version IS 'relation last version';
+COMMENT ON COLUMN group_role_rel.deleted_at IS 'relation deleted at';
+
+CREATE TABLE IF NOT EXISTS tag_meta (
+    tag_id BIGINT NOT NULL,
+    tag_name VARCHAR(128) NOT NULL,
+    metalake_id BIGINT NOT NULL,
+    tag_comment VARCHAR(256) DEFAULT '',
+    properties TEXT DEFAULT NULL,
+    audit_info TEXT NOT NULL,
+    current_version INT NOT NULL DEFAULT 1,
+    last_version INT NOT NULL DEFAULT 1,
+    deleted_at BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (tag_id),
+    UNIQUE (metalake_id, tag_name, deleted_at)
+    );
+
+COMMENT ON TABLE tag_meta IS 'tag metadata';
+
+COMMENT ON COLUMN tag_meta.tag_id IS 'tag id';
+COMMENT ON COLUMN tag_meta.tag_name IS 'tag name';
+COMMENT ON COLUMN tag_meta.metalake_id IS 'metalake id';
+COMMENT ON COLUMN tag_meta.tag_comment IS 'tag comment';
+COMMENT ON COLUMN tag_meta.properties IS 'tag properties';
+COMMENT ON COLUMN tag_meta.audit_info IS 'tag audit info';
+
+
+CREATE TABLE IF NOT EXISTS tag_relation_meta (
+    id BIGINT GENERATED BY DEFAULT AS IDENTITY,
+    tag_id BIGINT NOT NULL,
+    metadata_object_id BIGINT NOT NULL,
+    metadata_object_type VARCHAR(64) NOT NULL,
+    audit_info TEXT NOT NULL,
+    current_version INT NOT NULL DEFAULT 1,
+    last_version INT NOT NULL DEFAULT 1,
+    deleted_at BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (id),
+    UNIQUE (tag_id, metadata_object_id, metadata_object_type, deleted_at)
+    );
+
+CREATE INDEX IF NOT EXISTS idx_tag_id ON tag_relation_meta (tag_id);
+CREATE INDEX IF NOT EXISTS idx_metadata_object_id ON tag_relation_meta (metadata_object_id);
+COMMENT ON TABLE tag_relation_meta IS 'tag metadata object relation';
+COMMENT ON COLUMN tag_relation_meta.id IS 'auto increment id';
+COMMENT ON COLUMN tag_relation_meta.tag_id IS 'tag id';
+COMMENT ON COLUMN tag_relation_meta.metadata_object_id IS 'metadata object id';
+COMMENT ON COLUMN tag_relation_meta.metadata_object_type IS 'metadata object type';
+COMMENT ON COLUMN tag_relation_meta.audit_info IS 'tag relation audit info';
+COMMENT ON COLUMN tag_relation_meta.current_version IS 'tag relation current version';
+COMMENT ON COLUMN tag_relation_meta.last_version IS 'tag relation last version';
+COMMENT ON COLUMN tag_relation_meta.deleted_at IS 'tag relation deleted at';
+
+CREATE TABLE IF NOT EXISTS owner_meta (
+    id BIGINT GENERATED BY DEFAULT AS IDENTITY,
+    metalake_id BIGINT NOT NULL,
+    owner_id BIGINT NOT NULL,
+    owner_type VARCHAR(64) NOT NULL,
+    metadata_object_id BIGINT NOT NULL,
+    metadata_object_type VARCHAR(64) NOT NULL,
+    audit_info TEXT NOT NULL,
+    current_version INT NOT NULL DEFAULT 1,
+    last_version INT NOT NULL DEFAULT 1,
+    deleted_at BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (id),
+    UNIQUE (owner_id, metadata_object_id, metadata_object_type, deleted_at)
+    );
+
+CREATE INDEX IF NOT EXISTS idx_owner_id ON owner_meta (owner_id);
+CREATE INDEX IF NOT EXISTS idx_metadata_object_id ON owner_meta (metadata_object_id);
+COMMENT ON TABLE owner_meta IS 'owner relation';
+COMMENT ON COLUMN owner_meta.id IS 'auto increment id';
+COMMENT ON COLUMN owner_meta.metalake_id IS 'metalake id';
+COMMENT ON COLUMN owner_meta.owner_id IS 'owner id';
+COMMENT ON COLUMN owner_meta.owner_type IS 'owner type';
+COMMENT ON COLUMN owner_meta.metadata_object_id IS 'metadata object id';
+COMMENT ON COLUMN owner_meta.metadata_object_type IS 'metadata object type';
+COMMENT ON COLUMN owner_meta.audit_info IS 'owner relation audit info';
+COMMENT ON COLUMN owner_meta.current_version IS 'owner relation current version';
+COMMENT ON COLUMN owner_meta.last_version IS 'owner relation last version';
+COMMENT ON COLUMN owner_meta.deleted_at IS 'owner relation deleted at';
+

--- a/scripts/postgresql/upgrade-0.7.0-to-0.8.0-postgresql.sql
+++ b/scripts/postgresql/upgrade-0.7.0-to-0.8.0-postgresql.sql
@@ -1,0 +1,20 @@
+--
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file--
+--  distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"). You may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--  http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+--
+ALTER TABLE role_meta_securable_object ALTER COLUMN privilege_names TYPE VARCHAR(81920);
+ALTER TABLE role_meta_securable_object ALTER COLUMN privilege_conditions TYPE VARCHAR(81920);


### PR DESCRIPTION
### What changes were proposed in this pull request?

Modify the length limit of privileges column
According to the privilege interface, our privilege max value is 64 * 64. Every privilege name is about 14 character. So I use 64* 64 * 20 as new length limit.

### Why are the changes needed?

Fix: #5498 

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?

Manual test.
