### PR TITLE
[#5489] fix(build): Improve the gradle to skip some modules to avoid publishing empty jars

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -401,9 +401,17 @@ subprojects {
   publishing {
     publications {
       create<MavenPublication>("MavenJava") {
-        from(components["java"])
-        artifact(sourcesJar)
-        artifact(javadocJar)
+        if (project.name == "web" ||
+          project.name == "docs" ||
+          project.name == "integration-test" ||
+          project.name == "integration-test-common"
+        ) {
+          setArtifacts(emptyList<Any>())
+        } else {
+          from(components["java"])
+          artifact(sourcesJar)
+          artifact(javadocJar)
+        }
 
         pom {
           name.set("Gravitino")

--- a/dev/release/release-build.sh
+++ b/dev/release/release-build.sh
@@ -360,7 +360,7 @@ if [[ "$1" == "publish-release" ]]; then
   if ! is_dry_run; then
     nexus_upload=$NEXUS_ROOT/deployByRepositoryId/$staged_repo_id
     echo "Uploading files to $nexus_upload"
-    for file in $(find . -type f -not -path "./docs/*" -not -path "./web/*")
+    for file in $(find . -type f -not -path "./docs/*" -not -path "./web/*" -not -path "./integration-test-common/*" -not -path "./integration-test/*")
     do
       # strip leading ./
       file_short=$(echo $file | sed -e "s/\.\///")


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR improves the gradle and release script to skip some modules.

### Why are the changes needed?

This is to avoid some unnecessary empty jars to be published to maven repo.

Fix: #5489 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Tested locally.
