### PR TITLE
[#5496] docs: launch playground

### DIFF
--- a/docs/how-to-use-the-playground.md
+++ b/docs/how-to-use-the-playground.md
@@ -13,7 +13,7 @@ Depending on your network and computer, startup time may take 3-5 minutes. Once 
 
 ## Prerequisites
 
-Install Git, Docker, Docker Compose.
+Install Git (optional), Docker, Docker Compose.
 
 ## System Resource Requirements
 
@@ -35,6 +35,16 @@ The playground runs several services. The TCP ports used may clash with existing
 ## Playground usage
 
 ### Launch playground
+
+You can launch the playground in two ways:
+
+1. Use a single curl command
+
+```shell
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/apache/gravitino-playground/HEAD/install.sh)"
+```
+
+2. Use Git
 
 ```shell
 git clone git@github.com:apache/gravitino-playground.git


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Add instructions for launching the playground with Git and a single curl command.

### Why are the changes needed?

Provide instructions for users to launch the playground.

Fix: #5496

### Does this PR introduce _any_ user-facing change?

  1. Change in how-to-use-the-playground.md

### How was this patch tested?

Use Markdown Live Preview.
https://markdownlivepreview.com/
