### PR TITLE
[#4842] fix(hadoop-catalog): Improve the schema drop logic for fileset catalog

### DIFF
--- a/catalogs/catalog-hadoop/src/main/java/org/apache/gravitino/catalog/hadoop/HadoopCatalogOperations.java
+++ b/catalogs/catalog-hadoop/src/main/java/org/apache/gravitino/catalog/hadoop/HadoopCatalogOperations.java
@@ -613,6 +613,9 @@ public class HadoopCatalogOperations implements CatalogOperations, SupportsSchem
               f -> {
                 ClassLoader oldCl = Thread.currentThread().getContextClassLoader();
                 try {
+                  // parallelStream uses forkjoin thread pool, which has a different classloader
+                  // than the catalog thread. We need to set the context classloader to the
+                  // catalog's classloader to avoid classloading issues.
                   Thread.currentThread().setContextClassLoader(cl);
                   Path filesetPath = new Path(f.storageLocation());
                   FileSystem fs = getFileSystem(filesetPath, conf);

--- a/catalogs/catalog-hadoop/src/main/java/org/apache/gravitino/catalog/hadoop/HadoopCatalogOperations.java
+++ b/catalogs/catalog-hadoop/src/main/java/org/apache/gravitino/catalog/hadoop/HadoopCatalogOperations.java
@@ -598,8 +598,6 @@ public class HadoopCatalogOperations implements CatalogOperations, SupportsSchem
       // The reason why we delete the managed fileset's storage location one by one is because we
       // may mis-delete the storage location of the external fileset if it happens to be under
       // the schema path.
-      // Besides, we don't delete the schema path to avoid mis-delete some unmanaged files/folders
-      // under this path.
       filesets.stream()
           .filter(f -> f.filesetType() == Fileset.Type.MANAGED)
           .forEach(
@@ -625,10 +623,10 @@ public class HadoopCatalogOperations implements CatalogOperations, SupportsSchem
       Map<String, String> properties =
           Optional.ofNullable(schemaEntity.properties()).orElse(Collections.emptyMap());
 
+      // Delete the schema path if it exists and is empty.
       Path schemaPath = getSchemaPath(ident.name(), properties);
       if (schemaPath != null) {
         FileSystem fs = getFileSystem(schemaPath, conf);
-        // If the schema path is empty, we should delete the schema path.
         if (fs.exists(schemaPath)) {
           FileStatus[] statuses = fs.listStatus(schemaPath);
           if (statuses.length == 0) {

--- a/catalogs/catalog-hadoop/src/main/java/org/apache/gravitino/catalog/hadoop/HadoopCatalogOperations.java
+++ b/catalogs/catalog-hadoop/src/main/java/org/apache/gravitino/catalog/hadoop/HadoopCatalogOperations.java
@@ -641,11 +641,13 @@ public class HadoopCatalogOperations implements CatalogOperations, SupportsSchem
 
       // Delete the schema path if it exists and is empty.
       Path schemaPath = getSchemaPath(ident.name(), properties);
+      // Nothing to delete if the schema path is not set.
       if (schemaPath == null) {
         return false;
       }
 
       FileSystem fs = getFileSystem(schemaPath, conf);
+      // Nothing to delete if the schema path does not exist.
       if (!fs.exists(schemaPath)) {
         return false;
       }

--- a/catalogs/catalog-hadoop/src/test/java/org/apache/gravitino/catalog/hadoop/integration/test/HadoopUserAuthenticationIT.java
+++ b/catalogs/catalog-hadoop/src/test/java/org/apache/gravitino/catalog/hadoop/integration/test/HadoopUserAuthenticationIT.java
@@ -550,8 +550,7 @@ public class HadoopUserAuthenticationIT extends BaseIT {
     Assertions.assertDoesNotThrow(
         () -> catalog.asFilesetCatalog().dropFileset(NameIdentifier.of(SCHEMA_NAME, fileset2)));
 
-    Assertions.assertThrows(
-        Exception.class, () -> catalog.asSchemas().dropSchema(SCHEMA_NAME, true));
+    Assertions.assertDoesNotThrow(() -> catalog.asSchemas().dropSchema(SCHEMA_NAME, true));
     kerberosHiveContainer.executeInContainer(
         "hadoop", "fs", "-chown", "-R", "cli_schema", "/user/hadoop/" + catalogName);
     Assertions.assertDoesNotThrow(() -> catalog.asSchemas().dropSchema(SCHEMA_NAME, true));

--- a/docs/manage-fileset-metadata-using-gravitino.md
+++ b/docs/manage-fileset-metadata-using-gravitino.md
@@ -275,8 +275,10 @@ Please refer to [Drop a schema](./manage-relational-metadata-using-gravitino.md#
 in relational catalog for more details. For a fileset catalog, the schema drop operation is the
 same.
 
-Note that the drop operation will also remove all of the filesets as well as the managed files
-under this schema path if `cascade` is set to `true`.
+Note that the drop operation will delete all the fileset metadata under this schema if `cascade`
+set to `true`. Besides, for `MANAGED` fileset, this drop operation will also **remove** all the
+files/directories of this fileset; for `EXTERNAL` fileset, this drop operation will only delete
+the metadata of this fileset.
 
 ### List all schemas under a catalog
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR changes the schema drop mechanism to delete the fileset path one by one, instead of delete the schema path. This improvement will:

1. Delete the fileset path that is not under the schema's location.
2. Avoid deleting the external fileset path that happens to under schema location.

### Why are the changes needed?

To make the drop mechanism correct.

Fix: #4842 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Add UT to cover the changes.
