### PR TITLE
[#5280] improvement(cli): Display distribution / bucketing information for Tables in the Gravitino CLI 

### DIFF
--- a/clients/cli/src/main/java/org/apache/gravitino/cli/GravitinoCommandLine.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/GravitinoCommandLine.java
@@ -72,10 +72,10 @@ import org.apache.gravitino.cli.commands.SetSchemaProperty;
 import org.apache.gravitino.cli.commands.SetTagProperty;
 import org.apache.gravitino.cli.commands.TableAudit;
 import org.apache.gravitino.cli.commands.TableDetails;
+import org.apache.gravitino.cli.commands.TableDistribution;
 import org.apache.gravitino.cli.commands.TagDetails;
 import org.apache.gravitino.cli.commands.TagEntity;
 import org.apache.gravitino.cli.commands.UntagEntity;
-import org.apache.gravitino.cli.commands.TableDistribution;
 import org.apache.gravitino.cli.commands.UpdateCatalogComment;
 import org.apache.gravitino.cli.commands.UpdateCatalogName;
 import org.apache.gravitino.cli.commands.UpdateMetalakeComment;
@@ -346,7 +346,7 @@ public class GravitinoCommandLine {
     if (CommandActions.DETAILS.equals(command)) {
       if (line.hasOption(GravitinoOptions.AUDIT)) {
         new TableAudit(url, ignore, metalake, catalog, schema, table).handle();
-      } else if (line.hasOption(GravitinoOptions.DISTRIBUTION)){
+      } else if (line.hasOption(GravitinoOptions.DISTRIBUTION)) {
         new TableDistribution(url, ignore, metalake, catalog, schema, table).handle();
       } else {
         new TableDetails(url, ignore, metalake, catalog, schema, table).handle();
@@ -377,7 +377,7 @@ public class GravitinoCommandLine {
       new DeleteUser(url, ignore, force, metalake, user).handle();
     }
   }
-  //tung
+
   /** Handles the command execution for Group based on command type and the command line options. */
   protected void handleGroupCommand() {
     String url = getUrl();

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/GravitinoCommandLine.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/GravitinoCommandLine.java
@@ -346,6 +346,8 @@ public class GravitinoCommandLine {
     if (CommandActions.DETAILS.equals(command)) {
       if (line.hasOption(GravitinoOptions.AUDIT)) {
         new TableAudit(url, ignore, metalake, catalog, schema, table).handle();
+      } else if (line.hasOption(GravitinoOptions.DISTRIBUTION)){
+        new TableDistribution(url, ignore, metalake, catalog, schema, table).handle();
       } else {
         new TableDetails(url, ignore, metalake, catalog, schema, table).handle();
       }

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/GravitinoCommandLine.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/GravitinoCommandLine.java
@@ -75,6 +75,7 @@ import org.apache.gravitino.cli.commands.TableDetails;
 import org.apache.gravitino.cli.commands.TagDetails;
 import org.apache.gravitino.cli.commands.TagEntity;
 import org.apache.gravitino.cli.commands.UntagEntity;
+import org.apache.gravitino.cli.commands.TableDistribution;
 import org.apache.gravitino.cli.commands.UpdateCatalogComment;
 import org.apache.gravitino.cli.commands.UpdateCatalogName;
 import org.apache.gravitino.cli.commands.UpdateMetalakeComment;

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/GravitinoCommandLine.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/GravitinoCommandLine.java
@@ -377,7 +377,7 @@ public class GravitinoCommandLine {
       new DeleteUser(url, ignore, force, metalake, user).handle();
     }
   }
-
+  //tung
   /** Handles the command execution for Group based on command type and the command line options. */
   protected void handleGroupCommand() {
     String url = getUrl();

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/GravitinoOptions.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/GravitinoOptions.java
@@ -43,6 +43,7 @@ public class GravitinoOptions {
   public static final String ROLE = "role";
   public static final String AUDIT = "audit";
   public static final String FORCE = "force";
+  public static final String DISTRIBUTION = "distribution";
 
   /**
    * Builds and returns the CLI options for Gravitino.
@@ -61,6 +62,7 @@ public class GravitinoOptions {
     options.addOption(createArgOption("m", METALAKE, "metalake name"));
     options.addOption(createSimpleOption("i", IGNORE, "ignore client/sever version check"));
     options.addOption(createSimpleOption("a", AUDIT, "display audit information"));
+      options.addOption(createSimpleOption("d", DISTRIBUTION, "Display distribution information"));
 
     // Create/update options
     options.addOption(createArgOption(null, RENAME, "new entity name"));

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/GravitinoOptions.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/GravitinoOptions.java
@@ -62,7 +62,7 @@ public class GravitinoOptions {
     options.addOption(createArgOption("m", METALAKE, "metalake name"));
     options.addOption(createSimpleOption("i", IGNORE, "ignore client/sever version check"));
     options.addOption(createSimpleOption("a", AUDIT, "display audit information"));
-      options.addOption(createSimpleOption("d", DISTRIBUTION, "Display distribution information"));
+    options.addOption(createSimpleOption("d", DISTRIBUTION, "Display distribution information"));
 
     // Create/update options
     options.addOption(createArgOption(null, RENAME, "new entity name"));

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/TableDistribution.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/TableDistribution.java
@@ -22,14 +22,14 @@ package org.apache.gravitino.cli.commands;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.rel.expressions.distributions.Distribution;
 
-/** Displays the details of a table's columns. */
+/** Displays the details of a table's distirbution. */
 public class TableDistribution extends TableCommand {
 
   protected final String schema;
   protected final String table;
 
   /**
-   * Displays the details of a table's columns.
+   * Displays the details of a table's distirbution.
    *
    * @param url The URL of the Gravitino server.
    * @param ignoreVersions If true don't check the client/server versions match.

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/TableDistribution.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/TableDistribution.java
@@ -63,6 +63,6 @@ public class TableDistribution extends TableCommand {
       return;
     }
 
-    System.out.println(distribution.strategy() + ", " + distribution.number());
+    System.out.println(distribution.strategy() + "," + distribution.number());
   }
 }

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/TableDistribution.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/TableDistribution.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.cli.commands;
+
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.rel.expressions.distributions.Distribution;
+
+/** Displays the details of a table's columns. */
+public class TableDistribution extends TableCommand {
+
+  protected final String schema;
+  protected final String table;
+
+  /**
+   * Displays the details of a table's columns.
+   *
+   * @param url The URL of the Gravitino server.
+   * @param ignoreVersions If true don't check the client/server versions match.
+   * @param metalake The name of the metalake.
+   * @param catalog The name of the catalog.
+   * @param schema The name of the schenma.
+   * @param table The name of the table.
+   */
+  public TableDistribution(
+      String url,
+      boolean ignoreVersions,
+      String metalake,
+      String catalog,
+      String schema,
+      String table) {
+    super(url, ignoreVersions, metalake, catalog);
+    this.schema = schema;
+    this.table = table;
+  }
+
+  /** Displays the strategy and bucket number of distirbution. */
+  @Override
+  public void handle() {
+    Distribution distribution;
+
+    try {
+      NameIdentifier name = NameIdentifier.of(schema, table);
+      distribution = tableCatalog().loadTable(name).distribution();
+    } catch (Exception exp) {
+      System.err.println(exp.getMessage());
+      return;
+    }
+
+    System.out.println(distribution.strategy() + ", " + distribution.number());
+  }
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -372,7 +372,11 @@ gcli column list --name catalog_postgres.hr.departments
 ```bash
 gcli table details --name catalog_postgres.hr.departments --audit
 ```
+#### Show tables distribution information
 
+```bash
+gcli table details --metalake metalake_demo --name catalog_postgres.hr.departments --distribution
+```
 #### Delete a table
 
 ```bash


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add --distribution option to display distribution information on Tables.

### Why are the changes needed?

This change allows users to retrieve additional distribution information on Tables
Closes: #5280 

### Does this PR introduce _any_ user-facing change?

Yes, it adds the --distribution option to CLI

### How was this patch tested?

Compiled and tested locally.