### PR TITLE
[#3765] improvement(client-python): Fixed missing-timeout Pylint rule for client-python

### DIFF
--- a/clients/client-python/pylintrc
+++ b/clients/client-python/pylintrc
@@ -37,7 +37,6 @@ disable=missing-class-docstring,
         no-member,
         fixme,          
         unnecessary-pass,               
-        missing-timeout,                #TODO-fix
         duplicate-code,                 #TODO-fix
         too-many-arguments,             #TODO-fix
 

--- a/clients/client-python/tests/integration/auth/test_oauth2_client.py
+++ b/clients/client-python/tests/integration/auth/test_oauth2_client.py
@@ -34,6 +34,7 @@ from tests.integration.integration_test_env import (
     check_gravitino_server_status,
 )
 from tests.integration.containers.oauth2_container import OAuth2Container
+from tests.integration.config import Config
 
 logger = logging.getLogger(__name__)
 
@@ -93,7 +94,7 @@ class TestOAuth2(IntegrationTestEnv, TestCommonAuth):
         jwk_uri = f"{cls.oauth2_server_uri}/oauth2/jwks"
 
         # Get JWK from OAuth2 Server
-        res = requests.get(jwk_uri).json()
+        res = requests.get(jwk_uri, timeout=Config.REQUEST["TIMEOUT"]).json()
         key = res["keys"][0]
 
         # Convert JWK to PEM

--- a/clients/client-python/tests/integration/config.py
+++ b/clients/client-python/tests/integration/config.py
@@ -1,2 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+
 class Config:
     REQUEST = {"TIMEOUT": 30}

--- a/clients/client-python/tests/integration/config.py
+++ b/clients/client-python/tests/integration/config.py
@@ -1,0 +1,2 @@
+class Config:
+    REQUEST = {"TIMEOUT": 30}

--- a/clients/client-python/tests/integration/integration_test_env.py
+++ b/clients/client-python/tests/integration/integration_test_env.py
@@ -26,13 +26,18 @@ import shutil
 import requests
 
 from gravitino.exceptions.base import GravitinoRuntimeException
+from tests.integration.config import Config
 
 logger = logging.getLogger(__name__)
 
 
 def get_gravitino_server_version(**kwargs):
     try:
-        response = requests.get("http://localhost:8090/api/version", **kwargs)
+        response = requests.get(
+            "http://localhost:8090/api/version",
+            timeout=Config.REQUEST["TIMEOUT"],
+            **kwargs,
+        )
         response.raise_for_status()  # raise an exception for bad status codes
         response.close()
         return True


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR fixes missing-timeout Pylint rule for client-python 

- modified:
  * clients/client-python/tests/integration/integration_test_env.py    (added a reasonable timeout for requests.get)
  * clients/client-python/tests/integration/auth/test_oauth2_client.py   (added a reasonable timeout for requests.get)
  * clients/client-python/pylintrc   (removed missing-timeout from disable section in pylintrc)

- new file:
  * clients/client-python/tests/integration/config.py (added a file to store constant values)

### Why are the changes needed?

Define a reasonable timeout for requests.get to prevent program from hanging indefinitely

Fix: #3765

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?
```bash
./gradlew clients:client-python:pylint
```