### PR TITLE
[#5563] Improvement(docs): Improve Docker test instructions to enhance user clarity and guidance

### DIFF
--- a/docs/how-to-test.md
+++ b/docs/how-to-test.md
@@ -105,6 +105,9 @@ public class CatalogHiveIT extends AbstractIT {
 :::note
 * Make sure that the `Docker server` is running before running all the
   integration tests. Otherwise, it only runs the integration tests without the `gravitino-docker-test` tag.
+* To run Docker-related tests, make sure you have installed Docker in your environment and either
+   set skipDockerTests=false in the gradle.properties file (or use `-PskipDockerTests=false` in the command) or
+  (2) export SKIP_DOCKER_TESTS=false in shell. Otherwise, all tests requiring Docker will be skipped.
 * On macOS, be sure to run the `${GRAVITINO_HOME}/dev/docker/tools/mac-docker-connector.sh`
   script before running the integration tests; or make sure that
   [OrbStack](https://orbstack.dev/) is running.


### PR DESCRIPTION

### What changes were proposed in this pull request?

Added instructions to docs/how-to-test.md for configuring Docker-dependent tests by setting skipDockerTests=false in gradle.properties, using -PskipDockerTests=false in the command, or exporting SKIP_DOCKER_TESTS=false in the shell.

### Why are the changes needed?

To prevent confusion for users expecting a complete test run, as tests requiring Docker will be skipped by default without these configurations.

Fix: #5563

### Does this PR introduce _any_ user-facing change?

Yes, it provides clearer documentation on how to enable Docker-related tests to ensure a comprehensive test run.s.)

### How was this patch tested?

N/A
