### PR TITLE
[#5598] fix(dependency): fix multiple SLF4J providers issue

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -771,6 +771,7 @@ tasks {
     subprojects.forEach() {
       if (!it.name.startsWith("catalog") &&
         !it.name.startsWith("authorization") &&
+        !it.name.startsWith("cli") &&
         !it.name.startsWith("client") && !it.name.startsWith("filesystem") && !it.name.startsWith("spark") && !it.name.startsWith("iceberg") && it.name != "trino-connector" &&
         it.name != "integration-test" && it.name != "bundled-catalog" && !it.name.startsWith("flink") &&
         it.name != "integration-test" && it.name != "hive-metastore-common" && !it.name.startsWith("flink") &&


### PR DESCRIPTION
### What changes were proposed in this pull request?

 - remove cli dependencies from server lib

### Why are the changes needed?
cli module introduces the slf4j-simple, which is unnecessary

Fix: #5598 

### Does this PR introduce _any_ user-facing change?

no

### How was this patch tested?

1. package: `compileDistribution -x test`
2. list the server libs and does not see the jar of slf4j-simple
