### PR TITLE
[#5603] Add metalake extended help command to Gravitino CLI

### DIFF
--- a/clients/cli/src/main/java/org/apache/gravitino/cli/CommandActions.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/CommandActions.java
@@ -26,6 +26,7 @@ import java.util.HashSet;
  * Gravitino CLI. It also can validate if a given command is a valid commands.
  */
 public class CommandActions {
+  public static final String HELP = "help";
   public static final String DETAILS = "details";
   public static final String LIST = "list";
   public static final String UPDATE = "update";
@@ -40,6 +41,7 @@ public class CommandActions {
   private static final HashSet<String> VALID_COMMANDS = new HashSet<>();
 
   static {
+    VALID_COMMANDS.add(HELP);
     VALID_COMMANDS.add(DETAILS);
     VALID_COMMANDS.add(LIST);
     VALID_COMMANDS.add(UPDATE);

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/GravitinoCommandLine.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/GravitinoCommandLine.java
@@ -19,6 +19,11 @@
 
 package org.apache.gravitino.cli;
 
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.HelpFormatter;
@@ -175,7 +180,9 @@ public class GravitinoCommandLine {
 
   /** Executes the appropriate command based on the command type. */
   private void executeCommand() {
-    if (entity.equals(CommandEntities.COLUMN)) {
+    if (command.equals(CommandActions.HELP)) {
+      handleHelpCommand();
+    } else if (entity.equals(CommandEntities.COLUMN)) {
       handleColumnCommand();
     } else if (entity.equals(CommandEntities.TABLE)) {
       handleTableCommand();
@@ -511,6 +518,23 @@ public class GravitinoCommandLine {
 
     if (CommandActions.LIST.equals(command)) {
       new ListColumns(url, ignore, metalake, catalog, schema, table).handle();
+    }
+  }
+
+  private void handleHelpCommand() {
+    String helpFile = entity.toLowerCase() + "_help.txt";
+
+    try (InputStream inputStream = this.getClass().getClassLoader().getResourceAsStream(helpFile);
+        BufferedReader reader =
+            new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8))) {
+      StringBuilder helpMessage = new StringBuilder();
+      String helpLine;
+      while ((helpLine = reader.readLine()) != null) {
+        helpMessage.append(helpLine).append(System.lineSeparator());
+      }
+      System.err.print(helpMessage.toString());
+    } catch (IOException e) {
+      System.err.println("Failed to load help message: " + e.getMessage());
     }
   }
 

--- a/clients/cli/src/main/resources/metalake_help.txt
+++ b/clients/cli/src/main/resources/metalake_help.txt
@@ -1,0 +1,40 @@
+gcli metalake [details|list|create|delete|update|properties|set|remove]
+
+The Metalake for the CLI can be set using one of the following methods:
+1. Passed in on the command line via the --metalake parameter.
+2. Set via the GRAVITINO_METALAKE environment variable.
+3. Stored in the Gravitino CLI configuration file.
+
+Example Commands
+
+Show all metalakes
+gcli metalake list
+
+Show details of a metalake
+gcli metalake details
+
+Show metalake's audit information
+gcli metalake details --audit
+
+Create a metalake
+gcli metalake create --metalake my_metalake --comment "This is my metalake"
+
+Delete a metalake
+Note:This is a potentially dangerous command to run
+gcli metalake delete
+
+Rename a metalake
+Note:This is a potentially dangerous command to run
+gcli metalake update  --rename demo
+
+Update a metalake's comment
+gcli metalake update  --comment "new comment"
+
+Display the properties of a metalake
+gcli metalake properties
+
+Set a metalake's property
+gcli metalake set  --property test --value value
+
+Remove a metalake's property
+gcli metalake remove  --property test

--- a/clients/cli/src/test/java/org/apache/gravitino/cli/TestCommandActions.java
+++ b/clients/cli/src/test/java/org/apache/gravitino/cli/TestCommandActions.java
@@ -44,6 +44,8 @@ public class TestCommandActions {
     assertTrue(
         CommandActions.isValidCommand(CommandActions.PROPERTIES),
         "PROPERTIES should be a valid command");
+    assertTrue(
+        CommandActions.isValidCommand(CommandActions.HELP), "HELP should be a valid command");
   }
 
   @Test


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add metalake extended help command to Gravitino CLI

### Why are the changes needed?

To give the use extended help via the command line.

Fix: #5603

### Does this PR introduce _any_ user-facing change?

No, other than providing extra help information.

### How was this patch tested?

Locally.