### PR TITLE
[#5278]improvement(cli):Display partition information for Tables in t…

### DIFF
--- a/clients/cli/src/main/java/org/apache/gravitino/cli/GravitinoCommandLine.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/GravitinoCommandLine.java
@@ -78,6 +78,7 @@ import org.apache.gravitino.cli.commands.SetTagProperty;
 import org.apache.gravitino.cli.commands.TableAudit;
 import org.apache.gravitino.cli.commands.TableDetails;
 import org.apache.gravitino.cli.commands.TableDistribution;
+import org.apache.gravitino.cli.commands.TablePartition;
 import org.apache.gravitino.cli.commands.TagDetails;
 import org.apache.gravitino.cli.commands.TagEntity;
 import org.apache.gravitino.cli.commands.UntagEntity;
@@ -355,6 +356,8 @@ public class GravitinoCommandLine {
         new ListIndexes(url, ignore, metalake, catalog, schema, table).handle();
       } else if (line.hasOption(GravitinoOptions.DISTRIBUTION)) {
         new TableDistribution(url, ignore, metalake, catalog, schema, table).handle();
+      } else if (line.hasOption(GravitinoOptions.Partition)) {
+        new TablePartition(url, ignore, metalake, catalog, schema, table).handle();
       } else {
         new TableDetails(url, ignore, metalake, catalog, schema, table).handle();
       }

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/GravitinoOptions.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/GravitinoOptions.java
@@ -45,6 +45,7 @@ public class GravitinoOptions {
   public static final String INDEX = "index";
   public static final String FORCE = "force";
   public static final String DISTRIBUTION = "distribution";
+  public static final String Partition = "partition";
 
   /**
    * Builds and returns the CLI options for Gravitino.
@@ -65,6 +66,7 @@ public class GravitinoOptions {
     options.addOption(createSimpleOption("a", AUDIT, "display audit information"));
     options.addOption(createSimpleOption("x", INDEX, "Display index infromation"));
     options.addOption(createSimpleOption("d", DISTRIBUTION, "Display distribution information"));
+    options.addOption(createSimpleOption("p", Partition, "Display partition information"));
 
     // Create/update options
     options.addOption(createArgOption(null, RENAME, "new entity name"));

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/TablePartition.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/TablePartition.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.cli.commands;
+
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.rel.expressions.transforms.Transform;
+import org.apache.gravitino.rel.partitions.Partition;
+
+/** Displays the details of a table's partition. */
+public class TablePartition extends TableCommand {
+
+  protected final String schema;
+  protected final String table;
+
+  /**
+   * Displays the details of a table's distirbution.
+   *
+   * @param url The URL of the Gravitino server.
+   * @param ignoreVersions If true don't check the client/server versions match.
+   * @param metalake The name of the metalake.
+   * @param catalog The name of the catalog.
+   * @param schema The name of the schenma.
+   * @param table The name of the table.
+   */
+  public TablePartition(
+      String url,
+      boolean ignoreVersions,
+      String metalake,
+      String catalog,
+      String schema,
+      String table) {
+    super(url, ignoreVersions, metalake, catalog);
+    this.schema = schema;
+    this.table = table;
+  }
+
+  /** Displays the name and properties of partition. */
+  @Override
+  public void handle() {
+    Transform transforms[];
+    try {
+      NameIdentifier name = NameIdentifier.of(schema, table);
+      transforms = tableCatalog().loadTable(name).partitioning();
+    } catch (Exception exp) {
+      System.err.println(exp.getMessage());
+      return;
+    }
+    for (Transform transform : transforms) {
+      Partition[] partitions = transform.assignments();
+      if (partitions.length == 0) {
+        System.out.println("None");
+      } else {
+        for (Partition partition : partitions) {
+          System.out.println(partition.name() + "," + partition.properties());
+        }
+      }
+    }
+  }
+}

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/TablePartition.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/TablePartition.java
@@ -30,7 +30,7 @@ public class TablePartition extends TableCommand {
   protected final String table;
 
   /**
-   * Displays the details of a table's distirbution.
+   * Displays the details of a table's partition.
    *
    * @param url The URL of the Gravitino server.
    * @param ignoreVersions If true don't check the client/server versions match.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -373,7 +373,16 @@ gcli table details --name catalog_postgres.hr.departments
 ```bash
 gcli table details --name catalog_postgres.hr.departments --audit
 ```
+
 #### Show tables distribution information
+```bash
+gcli table details --name catalog_postgres.hr.departments --distribution
+```
+
+#### Show tables partition information
+```bash
+gcli table details --name catalog_postgres.hr.departments --partition
+```
 
 ### Show table indexes
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add --partition option to display partition information on Tables.


### Why are the changes needed?

This change allows users to retrieve additional partition information on Tables
Closes: #5278 

### Does this PR introduce _any_ user-facing change?

Yes, it adds the --partition option to CLIeys.)

### How was this patch tested?

Compiled and tested locally.