### PR TITLE
[MINOR] Remove unused throw exception in SecureHadoopCatalogOperations#testConnection

### DIFF
--- a/catalogs/catalog-hadoop/src/main/java/org/apache/gravitino/catalog/hadoop/SecureHadoopCatalogOperations.java
+++ b/catalogs/catalog-hadoop/src/main/java/org/apache/gravitino/catalog/hadoop/SecureHadoopCatalogOperations.java
@@ -54,7 +54,6 @@ import org.apache.gravitino.utils.PrincipalUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@SuppressWarnings("removal")
 public class SecureHadoopCatalogOperations
     implements CatalogOperations, SupportsSchemas, FilesetCatalog {
 

--- a/catalogs/catalog-hadoop/src/main/java/org/apache/gravitino/catalog/hadoop/SecureHadoopCatalogOperations.java
+++ b/catalogs/catalog-hadoop/src/main/java/org/apache/gravitino/catalog/hadoop/SecureHadoopCatalogOperations.java
@@ -54,6 +54,7 @@ import org.apache.gravitino.utils.PrincipalUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@SuppressWarnings("removal")
 public class SecureHadoopCatalogOperations
     implements CatalogOperations, SupportsSchemas, FilesetCatalog {
 
@@ -242,8 +243,7 @@ public class SecureHadoopCatalogOperations
       Catalog.Type type,
       String provider,
       String comment,
-      Map<String, String> properties)
-      throws Exception {
+      Map<String, String> properties) {
     hadoopCatalogOperations.testConnection(catalogIdent, type, provider, comment, properties);
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

the `testConnection` throw Exception is redundant in this method, so we should remove it.

### Why are the changes needed?
update the code quality

### Does this PR introduce _any_ user-facing change?
n/a

### How was this patch tested?
n/a