### PR TITLE
[#5600] feat(API): Add Java API definition for ML model in Gravitino

### DIFF
--- a/api/src/main/java/org/apache/gravitino/Catalog.java
+++ b/api/src/main/java/org/apache/gravitino/Catalog.java
@@ -24,6 +24,7 @@ import org.apache.gravitino.annotation.Evolving;
 import org.apache.gravitino.authorization.SupportsRoles;
 import org.apache.gravitino.file.FilesetCatalog;
 import org.apache.gravitino.messaging.TopicCatalog;
+import org.apache.gravitino.model.ModelCatalog;
 import org.apache.gravitino.rel.TableCatalog;
 import org.apache.gravitino.tag.SupportsTags;
 
@@ -46,6 +47,9 @@ public interface Catalog extends Auditable {
     /** Catalog Type for Message Queue, like Kafka://topic */
     MESSAGING,
 
+    /** Catalog Type for ML model */
+    MODEL,
+
     /** Catalog Type for test only. */
     UNSUPPORTED;
 
@@ -63,6 +67,8 @@ public interface Catalog extends Auditable {
           return FILESET;
         case "messaging":
           return MESSAGING;
+        case "model":
+          return MODEL;
         default:
           throw new IllegalArgumentException("Unknown catalog type: " + type);
       }
@@ -176,6 +182,14 @@ public interface Catalog extends Auditable {
    */
   default TopicCatalog asTopicCatalog() throws UnsupportedOperationException {
     throw new UnsupportedOperationException("Catalog does not support topic operations");
+  }
+
+  /**
+   * @return the {@link ModelCatalog} if the catalog supports model operations.
+   * @throws UnsupportedOperationException if the catalog does not support model operations.
+   */
+  default ModelCatalog asModelCatalog() throws UnsupportedOperationException {
+    throw new UnsupportedOperationException("Catalog does not support model operations");
   }
 
   /**

--- a/api/src/main/java/org/apache/gravitino/MetadataObject.java
+++ b/api/src/main/java/org/apache/gravitino/MetadataObject.java
@@ -59,7 +59,9 @@ public interface MetadataObject {
     /** A column is a sub-collection of the table that represents a group of same type data. */
     COLUMN,
     /** A role is an object contains specific securable objects with privileges */
-    ROLE
+    ROLE,
+    /** A model is mapped to the model artifact in ML. */
+    MODEL
   }
 
   /**

--- a/api/src/main/java/org/apache/gravitino/MetadataObjects.java
+++ b/api/src/main/java/org/apache/gravitino/MetadataObjects.java
@@ -83,8 +83,9 @@ public class MetadataObjects {
         names.size() != 3
             || type == MetadataObject.Type.FILESET
             || type == MetadataObject.Type.TABLE
-            || type == MetadataObject.Type.TOPIC,
-        "If the length of names is 3, it must be FILESET, TABLE or TOPIC");
+            || type == MetadataObject.Type.TOPIC
+            || type == MetadataObject.Type.MODEL,
+        "If the length of names is 3, it must be FILESET, TABLE, TOPIC or MODEL");
 
     Preconditions.checkArgument(
         names.size() != 4 || type == MetadataObject.Type.COLUMN,

--- a/api/src/main/java/org/apache/gravitino/exceptions/ModelAlreadyExistsException.java
+++ b/api/src/main/java/org/apache/gravitino/exceptions/ModelAlreadyExistsException.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.exceptions;
+
+import com.google.errorprone.annotations.FormatMethod;
+import com.google.errorprone.annotations.FormatString;
+
+/** Exception thrown when a model with specified name already exists. */
+public class ModelAlreadyExistsException extends AlreadyExistsException {
+
+  /**
+   * Constructs a new exception with the specified detail message.
+   *
+   * @param message the detail message.
+   * @param args the arguments to the message.
+   */
+  @FormatMethod
+  public ModelAlreadyExistsException(@FormatString String message, Object... args) {
+    super(message, args);
+  }
+
+  /**
+   * Constructs a new exception with the specified detail message and cause.
+   *
+   * @param cause the cause.
+   * @param message the detail message.
+   * @param args the arguments to the message.
+   */
+  @FormatMethod
+  public ModelAlreadyExistsException(
+      Throwable cause, @FormatString String message, Object... args) {
+    super(cause, message, args);
+  }
+}

--- a/api/src/main/java/org/apache/gravitino/exceptions/ModelVersionAliasesAlreadyExistException.java
+++ b/api/src/main/java/org/apache/gravitino/exceptions/ModelVersionAliasesAlreadyExistException.java
@@ -21,8 +21,8 @@ package org.apache.gravitino.exceptions;
 import com.google.errorprone.annotations.FormatMethod;
 import com.google.errorprone.annotations.FormatString;
 
-/** Exception thrown when the model version aliases already exists. */
-public class ModelVersionAliasesAlreadyExistsException extends AlreadyExistsException {
+/** Exception thrown when the model version aliases already exist. */
+public class ModelVersionAliasesAlreadyExistException extends AlreadyExistsException {
 
   /**
    * Constructs a new exception with the specified detail message.
@@ -31,7 +31,7 @@ public class ModelVersionAliasesAlreadyExistsException extends AlreadyExistsExce
    * @param args the arguments to the message.
    */
   @FormatMethod
-  public ModelVersionAliasesAlreadyExistsException(@FormatString String message, Object... args) {
+  public ModelVersionAliasesAlreadyExistException(@FormatString String message, Object... args) {
     super(message, args);
   }
 
@@ -43,7 +43,7 @@ public class ModelVersionAliasesAlreadyExistsException extends AlreadyExistsExce
    * @param args the arguments to the message.
    */
   @FormatMethod
-  public ModelVersionAliasesAlreadyExistsException(
+  public ModelVersionAliasesAlreadyExistException(
       Throwable cause, @FormatString String message, Object... args) {
     super(cause, message, args);
   }

--- a/api/src/main/java/org/apache/gravitino/exceptions/ModelVersionAliasesAlreadyExistsException.java
+++ b/api/src/main/java/org/apache/gravitino/exceptions/ModelVersionAliasesAlreadyExistsException.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.exceptions;
+
+import com.google.errorprone.annotations.FormatMethod;
+import com.google.errorprone.annotations.FormatString;
+
+/** Exception thrown when the model version aliases already exists. */
+public class ModelVersionAliasesAlreadyExistsException extends AlreadyExistsException {
+
+  /**
+   * Constructs a new exception with the specified detail message.
+   *
+   * @param message the detail message.
+   * @param args the arguments to the message.
+   */
+  @FormatMethod
+  public ModelVersionAliasesAlreadyExistsException(@FormatString String message, Object... args) {
+    super(message, args);
+  }
+
+  /**
+   * Constructs a new exception with the specified detail message and cause.
+   *
+   * @param cause the cause.
+   * @param message the detail message.
+   * @param args the arguments to the message.
+   */
+  @FormatMethod
+  public ModelVersionAliasesAlreadyExistsException(
+      Throwable cause, @FormatString String message, Object... args) {
+    super(cause, message, args);
+  }
+}

--- a/api/src/main/java/org/apache/gravitino/exceptions/NoSuchModelException.java
+++ b/api/src/main/java/org/apache/gravitino/exceptions/NoSuchModelException.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.exceptions;
+
+import com.google.errorprone.annotations.FormatMethod;
+import com.google.errorprone.annotations.FormatString;
+
+/** Exception thrown when a model with specified name is not existed. */
+public class NoSuchModelException extends NotFoundException {
+
+  /**
+   * Constructs a new exception with the specified detail message.
+   *
+   * @param message the detail message.
+   * @param args the arguments to the message.
+   */
+  @FormatMethod
+  public NoSuchModelException(@FormatString String message, Object... args) {
+    super(message, args);
+  }
+
+  /**
+   * Constructs a new exception with the specified detail message and cause.
+   *
+   * @param cause the cause.
+   * @param message the detail message.
+   * @param args the arguments to the message.
+   */
+  @FormatMethod
+  public NoSuchModelException(Throwable cause, String message, Object... args) {
+    super(cause, message, args);
+  }
+}

--- a/api/src/main/java/org/apache/gravitino/exceptions/NoSuchModelVersionException.java
+++ b/api/src/main/java/org/apache/gravitino/exceptions/NoSuchModelVersionException.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.exceptions;
+
+import com.google.errorprone.annotations.FormatMethod;
+import com.google.errorprone.annotations.FormatString;
+
+/** Exception thrown when a model with specified version is not existed. */
+public class NoSuchModelVersionException extends NotFoundException {
+
+  /**
+   * Constructs a new exception with the specified detail message.
+   *
+   * @param message the detail message.
+   * @param args the arguments to the message.
+   */
+  @FormatMethod
+  public NoSuchModelVersionException(@FormatString String message, Object... args) {
+    super(message, args);
+  }
+
+  /**
+   * Constructs a new exception with the specified detail message and cause.
+   *
+   * @param cause the cause.
+   * @param message the detail message.
+   * @param args the arguments to the message.
+   */
+  @FormatMethod
+  public NoSuchModelVersionException(Throwable cause, String message, Object... args) {
+    super(cause, message, args);
+  }
+}

--- a/api/src/main/java/org/apache/gravitino/model/Model.java
+++ b/api/src/main/java/org/apache/gravitino/model/Model.java
@@ -1,0 +1,171 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.model;
+
+import java.util.Collections;
+import java.util.Map;
+import org.apache.gravitino.Auditable;
+import org.apache.gravitino.Namespace;
+import org.apache.gravitino.annotation.Evolving;
+import org.apache.gravitino.authorization.SupportsRoles;
+import org.apache.gravitino.exceptions.ModelVersionAliasesAlreadyExistsException;
+import org.apache.gravitino.exceptions.NoSuchModelException;
+import org.apache.gravitino.exceptions.NoSuchModelVersionException;
+import org.apache.gravitino.tag.SupportsTags;
+
+/**
+ * An interface representing an ML model under a schema {@link Namespace}. A model is a metadata
+ * object that represents the model artifact in ML. Users can register a model object in Gravitino
+ * to manage the mode metadata. The typical use case is to manage the model in ML lifecycle with a
+ * unified way in Gravitino, and access the model artifact with a unified identifier. Also, with the
+ * model registered in Gravitino, users can also govern the model with Gravitino's unified audit,
+ * tag, and role management.
+ *
+ * <p>The difference of Model and tabular data is that the model is schema-free, and the main
+ * property of the model is the model artifact URL. The difference compared to the fileset is that
+ * the model is versioned, and the model object contains the version information.
+ */
+@Evolving
+public interface Model extends Auditable {
+
+  /** @return Name of the model object. */
+  String name();
+
+  /**
+   * The comment of the model object. This is the general description of the model object. User can
+   * still add more detailed information in the model version.
+   *
+   * @return The comment of the model object. Null is returned if no comment is set.
+   */
+  default String comment() {
+    return null;
+  }
+
+  /**
+   * The properties of the model object. The properties are key-value pairs that can be used to
+   * store additional information of the model object. The properties are optional.
+   *
+   * <p>Users can still specify the properties in the model version for different information.
+   *
+   * @return the properties of the model object.
+   */
+  default Map<String, String> properties() {
+    return Collections.emptyMap();
+  }
+
+  /**
+   * The versions of the model object. The model object can have multiple versions. Each version
+   * contains the detailed information of the model artifact, like the URL, the training properties,
+   * etc.
+   *
+   * @return The versions of the model object.
+   */
+  ModelVersion[] versions();
+
+  /**
+   * Get the model version by the version number. If the version does not exist, throw an exception.
+   *
+   * @param version The version number of the model.
+   * @return The model version object.
+   * @throws NoSuchModelVersionException if the version does not exist.
+   */
+  ModelVersion version(int version) throws NoSuchModelVersionException;
+
+  /**
+   * Get the model version by the version alias. If the version does not exist, throw an exception.
+   *
+   * @param alias The version alias of the model.
+   * @return The model version object.
+   * @throws NoSuchModelVersionException if the version does not exist.
+   */
+  ModelVersion versionAlias(String alias) throws NoSuchModelVersionException;
+
+  /**
+   * Check if the model version exists by the version number.
+   *
+   * @param version The version number of the model.
+   * @return True if the version exists, false otherwise.
+   */
+  default boolean versionExists(int version) {
+    try {
+      version(version);
+      return true;
+    } catch (NoSuchModelVersionException e) {
+      return false;
+    }
+  }
+
+  /**
+   * Check if the model version exists by the version alias.
+   *
+   * @param alias The version alias of the model.
+   * @return True if the version exists, false otherwise.
+   */
+  default boolean versionExists(String alias) {
+    try {
+      versionAlias(alias);
+      return true;
+    } catch (NoSuchModelVersionException e) {
+      return false;
+    }
+  }
+
+  /**
+   * Link a new version model to the registered model object. The new version model will be added to
+   * the model object. If the model object does not exist, it will throw an exception.
+   *
+   * @param aliases The aliases of the model version. The aliases should be unique in this model,
+   *     otherwise the {@link ModelVersionAliasesAlreadyExistsException} will be thrown. The aliases
+   *     are optional and can be empty.
+   * @param comment The comment of the model version. The comment is optional and can be null.
+   * @param url The model artifact URL.
+   * @param properties The properties of the model version. The properties are optional and can be
+   *     null or empty.
+   * @return The created model version object.
+   * @throws NoSuchModelException If the model does not exist.
+   * @throws ModelVersionAliasesAlreadyExistsException If the aliases already exist in the model.
+   */
+  ModelVersion link(String[] aliases, String comment, String url, Map<String, String> properties)
+      throws NoSuchModelException, ModelVersionAliasesAlreadyExistsException;
+
+  /**
+   * Remove the model version object of a model by the version number. If the version does not exit,
+   * it will return false.
+   *
+   * @param version The version number of the model.
+   * @return True if the version is removed, false if the version does not exist.
+   */
+  boolean deleteVersion(int version);
+
+  /**
+   * @return The {@link SupportsTags} if the model supports tag operations.
+   * @throws UnsupportedOperationException If the model does not support tag operations.
+   */
+  default SupportsTags supportsTags() {
+    throw new UnsupportedOperationException("Model does not support tag operations.");
+  }
+
+  /**
+   * @return The {@link SupportsRoles} if the model supports role operations.
+   * @throws UnsupportedOperationException If the model does not support role operations.
+   */
+  default SupportsRoles supportsRoles() {
+    throw new UnsupportedOperationException("Model does not support role operations.");
+  }
+}

--- a/api/src/main/java/org/apache/gravitino/model/Model.java
+++ b/api/src/main/java/org/apache/gravitino/model/Model.java
@@ -134,24 +134,33 @@ public interface Model extends Auditable {
    *     otherwise the {@link ModelVersionAliasesAlreadyExistsException} will be thrown. The aliases
    *     are optional and can be empty.
    * @param comment The comment of the model version. The comment is optional and can be null.
-   * @param url The model artifact URL.
+   * @param uri The model artifact URI.
    * @param properties The properties of the model version. The properties are optional and can be
    *     null or empty.
    * @return The created model version object.
    * @throws NoSuchModelException If the model does not exist.
    * @throws ModelVersionAliasesAlreadyExistsException If the aliases already exist in the model.
    */
-  ModelVersion link(String[] aliases, String comment, String url, Map<String, String> properties)
+  ModelVersion link(String[] aliases, String comment, String uri, Map<String, String> properties)
       throws NoSuchModelException, ModelVersionAliasesAlreadyExistsException;
 
   /**
-   * Remove the model version object of a model by the version number. If the version does not exit,
-   * it will return false.
+   * Remove the model version object of a model by the version number. If the version does not
+   * exist, it will return false.
    *
    * @param version The version number of the model.
    * @return True if the version is removed, false if the version does not exist.
    */
   boolean deleteVersion(int version);
+
+  /**
+   * Remove the model version object of a model by the version alias. If the version does not exist,
+   * it will return false.
+   *
+   * @param alias The version alias of the model.
+   * @return True if the version is removed, false if the version does not exist.
+   */
+  boolean deleteVersion(String alias);
 
   /**
    * @return The {@link SupportsTags} if the model supports tag operations.

--- a/api/src/main/java/org/apache/gravitino/model/Model.java
+++ b/api/src/main/java/org/apache/gravitino/model/Model.java
@@ -24,18 +24,15 @@ import org.apache.gravitino.Auditable;
 import org.apache.gravitino.Namespace;
 import org.apache.gravitino.annotation.Evolving;
 import org.apache.gravitino.authorization.SupportsRoles;
-import org.apache.gravitino.exceptions.ModelVersionAliasesAlreadyExistsException;
-import org.apache.gravitino.exceptions.NoSuchModelException;
-import org.apache.gravitino.exceptions.NoSuchModelVersionException;
 import org.apache.gravitino.tag.SupportsTags;
 
 /**
  * An interface representing an ML model under a schema {@link Namespace}. A model is a metadata
  * object that represents the model artifact in ML. Users can register a model object in Gravitino
- * to manage the mode metadata. The typical use case is to manage the model in ML lifecycle with a
+ * to manage the model metadata. The typical use case is to manage the model in ML lifecycle with a
  * unified way in Gravitino, and access the model artifact with a unified identifier. Also, with the
- * model registered in Gravitino, users can also govern the model with Gravitino's unified audit,
- * tag, and role management.
+ * model registered in Gravitino, users can govern the model with Gravitino's unified audit, tag,
+ * and role management.
  *
  * <p>The difference of Model and tabular data is that the model is schema-free, and the main
  * property of the model is the model artifact URL. The difference compared to the fileset is that
@@ -70,97 +67,12 @@ public interface Model extends Auditable {
   }
 
   /**
-   * The versions of the model object. The model object can have multiple versions. Each version
-   * contains the detailed information of the model artifact, like the URL, the training properties,
-   * etc.
+   * The latest version of the model object. The latest version is the version number of the latest
+   * model checkpoint / snapshot that is linked to the registered model.
    *
-   * @return The versions of the model object.
+   * @return The latest version of the model object.
    */
-  ModelVersion[] versions();
-
-  /**
-   * Get the model version by the version number. If the version does not exist, throw an exception.
-   *
-   * @param version The version number of the model.
-   * @return The model version object.
-   * @throws NoSuchModelVersionException if the version does not exist.
-   */
-  ModelVersion version(int version) throws NoSuchModelVersionException;
-
-  /**
-   * Get the model version by the version alias. If the version does not exist, throw an exception.
-   *
-   * @param alias The version alias of the model.
-   * @return The model version object.
-   * @throws NoSuchModelVersionException if the version does not exist.
-   */
-  ModelVersion versionAlias(String alias) throws NoSuchModelVersionException;
-
-  /**
-   * Check if the model version exists by the version number.
-   *
-   * @param version The version number of the model.
-   * @return True if the version exists, false otherwise.
-   */
-  default boolean versionExists(int version) {
-    try {
-      version(version);
-      return true;
-    } catch (NoSuchModelVersionException e) {
-      return false;
-    }
-  }
-
-  /**
-   * Check if the model version exists by the version alias.
-   *
-   * @param alias The version alias of the model.
-   * @return True if the version exists, false otherwise.
-   */
-  default boolean versionExists(String alias) {
-    try {
-      versionAlias(alias);
-      return true;
-    } catch (NoSuchModelVersionException e) {
-      return false;
-    }
-  }
-
-  /**
-   * Link a new version model to the registered model object. The new version model will be added to
-   * the model object. If the model object does not exist, it will throw an exception.
-   *
-   * @param aliases The aliases of the model version. The aliases should be unique in this model,
-   *     otherwise the {@link ModelVersionAliasesAlreadyExistsException} will be thrown. The aliases
-   *     are optional and can be empty.
-   * @param comment The comment of the model version. The comment is optional and can be null.
-   * @param uri The model artifact URI.
-   * @param properties The properties of the model version. The properties are optional and can be
-   *     null or empty.
-   * @return The created model version object.
-   * @throws NoSuchModelException If the model does not exist.
-   * @throws ModelVersionAliasesAlreadyExistsException If the aliases already exist in the model.
-   */
-  ModelVersion link(String[] aliases, String comment, String uri, Map<String, String> properties)
-      throws NoSuchModelException, ModelVersionAliasesAlreadyExistsException;
-
-  /**
-   * Remove the model version object of a model by the version number. If the version does not
-   * exist, it will return false.
-   *
-   * @param version The version number of the model.
-   * @return True if the version is removed, false if the version does not exist.
-   */
-  boolean deleteVersion(int version);
-
-  /**
-   * Remove the model version object of a model by the version alias. If the version does not exist,
-   * it will return false.
-   *
-   * @param alias The version alias of the model.
-   * @return True if the version is removed, false if the version does not exist.
-   */
-  boolean deleteVersion(String alias);
+  int latestVersion();
 
   /**
    * @return The {@link SupportsTags} if the model supports tag operations.

--- a/api/src/main/java/org/apache/gravitino/model/ModelCatalog.java
+++ b/api/src/main/java/org/apache/gravitino/model/ModelCatalog.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.model;
+
+import java.util.Map;
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.Namespace;
+import org.apache.gravitino.annotation.Evolving;
+import org.apache.gravitino.exceptions.ModelAlreadyExistsException;
+import org.apache.gravitino.exceptions.NoSuchModelException;
+import org.apache.gravitino.exceptions.NoSuchSchemaException;
+
+/**
+ * The ModelCatalog interface defines the public API for managing model objects in a schema. If the
+ * catalog implementation supports model objects, it should implement this interface.
+ */
+@Evolving
+public interface ModelCatalog {
+
+  /**
+   * List the models in a schema namespace from the catalog.
+   *
+   * @param namespace A schema namespace.
+   * @return An array of model identifiers in the namespace.
+   * @throws NoSuchSchemaException If the schema does not exist.
+   */
+  NameIdentifier[] listModels(Namespace namespace) throws NoSuchSchemaException;
+
+  /**
+   * Get a model metadata by {@link NameIdentifier} from the catalog.
+   *
+   * @param ident A model identifier.
+   * @return The model metadata.
+   * @throws NoSuchModelException If the model does not exist.
+   */
+  Model getModel(NameIdentifier ident) throws NoSuchModelException;
+
+  /**
+   * Check if a model exists using an {@link NameIdentifier} from the catalog.
+   *
+   * @param ident A model identifier.
+   * @return true If the model exists, false if the model does not exist.
+   */
+  default boolean modelExists(NameIdentifier ident) {
+    try {
+      getModel(ident);
+      return true;
+    } catch (NoSuchModelException e) {
+      return false;
+    }
+  }
+
+  /**
+   * Register a model in the catalog if the model is not existed, otherwise the {@link
+   * ModelAlreadyExistsException} will be throw. The {@link Model} object will be created when the
+   * model is registered, in the meantime, the model version (version 0) will also be created and
+   * linked to the registered model.
+   *
+   * @param ident The name identifier of the model.
+   * @param aliases The aliases of the model version. The alias are optional and can be empty.
+   * @param comment The comment of the model. The comment is optional and can be null.
+   * @param url The model artifact URL.
+   * @param properties The properties of the model. The properties are optional and can be null or
+   *     empty.
+   * @return The registered model object.
+   * @throws ModelAlreadyExistsException If the model already registered.
+   */
+  Model registerModel(
+      NameIdentifier ident,
+      String[] aliases,
+      String comment,
+      String url,
+      Map<String, String> properties)
+      throws ModelAlreadyExistsException;
+
+  /**
+   * Delete the model from the catalog. If the model does not exist, return false. Otherwise, return
+   * true. The deletion of the model will also delete all the model versions linked to this model.
+   *
+   * @param ident The name identifier of the model.
+   * @return True if the model is deleted, false if the model does not exist.
+   */
+  boolean deleteModel(NameIdentifier ident);
+}

--- a/api/src/main/java/org/apache/gravitino/model/ModelCatalog.java
+++ b/api/src/main/java/org/apache/gravitino/model/ModelCatalog.java
@@ -68,7 +68,25 @@ public interface ModelCatalog {
 
   /**
    * Register a model in the catalog if the model is not existed, otherwise the {@link
-   * ModelAlreadyExistsException} will be throw. The {@link Model} object will be created when the
+   * ModelAlreadyExistsException} will be thrown. The {@link Model} object will be created the model
+   * is registered, users can call {@link Model#link(String[], String, String, Map)} to link the
+   * model version to the registered {@link Model}.
+   *
+   * @param ident The name identifier of the model.
+   * @param comment The comment of the model. The comment is optional and can be null.
+   * @param properties The properties of the model. The properties are optional and can be null or
+   *     empty.
+   * @return The registered model object.
+   * @throws ModelAlreadyExistsException If the model already registered.
+   */
+  default Model registerModel(NameIdentifier ident, String comment, Map<String, String> properties)
+      throws ModelAlreadyExistsException {
+    return registerModel(ident, new String[0], comment, null, properties);
+  }
+
+  /**
+   * Register a model in the catalog if the model is not existed, otherwise the {@link
+   * ModelAlreadyExistsException} will be thrown. The {@link Model} object will be created when the
    * model is registered, in the meantime, the model version (version 0) will also be created and
    * linked to the registered model.
    *

--- a/api/src/main/java/org/apache/gravitino/model/ModelVersion.java
+++ b/api/src/main/java/org/apache/gravitino/model/ModelVersion.java
@@ -59,12 +59,12 @@ public interface ModelVersion extends Auditable {
   String[] aliases();
 
   /**
-   * The URL of the model artifact. The URL is the location of the model artifact. The URL can be a
-   * file path or a remote URL.
+   * The URI of the model artifact. The URI is the location of the model artifact. The URI can be a
+   * file path or a remote URI.
    *
-   * @return The URL of the model artifact.
+   * @return The URI of the model artifact.
    */
-  String url();
+  String uri();
 
   /**
    * The properties of the model version. The properties are key-value pairs that can be used to

--- a/api/src/main/java/org/apache/gravitino/model/ModelVersion.java
+++ b/api/src/main/java/org/apache/gravitino/model/ModelVersion.java
@@ -18,6 +18,7 @@
  */
 package org.apache.gravitino.model;
 
+import java.util.Collections;
 import java.util.Map;
 import org.apache.gravitino.Auditable;
 import org.apache.gravitino.annotation.Evolving;
@@ -72,5 +73,7 @@ public interface ModelVersion extends Auditable {
    *
    * @return the properties of the model version.
    */
-  Map<String, String> properties();
+  default Map<String, String> properties() {
+    return Collections.emptyMap();
+  }
 }

--- a/api/src/main/java/org/apache/gravitino/model/ModelVersion.java
+++ b/api/src/main/java/org/apache/gravitino/model/ModelVersion.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.model;
+
+import java.util.Map;
+import org.apache.gravitino.Auditable;
+import org.apache.gravitino.annotation.Evolving;
+
+/**
+ * An interface representing a single model checkpoint under a model {@link Model}. A model version
+ * is a snapshot at a point of time of a model artifact in ML. Users can link a model version to a
+ * registered model.
+ */
+@Evolving
+public interface ModelVersion extends Auditable {
+
+  /**
+   * The version of this model object. The version number is an integer number starts from 0. Each
+   * time the model checkpoint / snapshot is linked to the registered, the version number will be
+   * increased by 1.
+   *
+   * @return The version of the model object.
+   */
+  int version();
+
+  /**
+   * The comment of this model version. This comment can be different from the comment of the model
+   * to provide more detailed information about this version.
+   *
+   * @return The comment of the model version. Null is returned if no comment is set.
+   */
+  default String comment() {
+    return null;
+  }
+
+  /**
+   * The aliases of this model version. The aliases are the alternative names of the model version.
+   * The aliases are optional. The aliases are unique for a model version. If the alias is already
+   * set to one model version, it cannot be set to another model version.
+   *
+   * @return The aliases of the model version.
+   */
+  String[] aliases();
+
+  /**
+   * The URL of the model artifact. The URL is the location of the model artifact. The URL can be a
+   * file path or a remote URL.
+   *
+   * @return The URL of the model artifact.
+   */
+  String url();
+
+  /**
+   * The properties of the model version. The properties are key-value pairs that can be used to
+   * store additional information of the model version. The properties are optional.
+   *
+   * @return the properties of the model version.
+   */
+  Map<String, String> properties();
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds the API definition for ML model and model catalog.

### Why are the changes needed?

This is the first step to support ML model management in Gravitino.

Fix: #5600 

### Does this PR introduce _any_ user-facing change?

Yes.

### How was this patch tested?

Manual verification.
