### PR TITLE
[#5213] fix(test): Increase the timeout to avoid flaky test

### DIFF
--- a/catalogs/catalog-hive/src/test/java/org/apache/gravitino/catalog/hive/TestFetchFileUtils.java
+++ b/catalogs/catalog-hive/src/test/java/org/apache/gravitino/catalog/hive/TestFetchFileUtils.java
@@ -68,7 +68,7 @@ public class TestFetchFileUtils {
     while (!success) {
       try {
         LOG.info("Attempting to download file from URL: {} (Attempt {})", fileUrl, attempts + 1);
-        FetchFileUtils.fetchFileFromUri(fileUrl, destFile, 30, conf);
+        FetchFileUtils.fetchFileFromUri(fileUrl, destFile, 45, conf);
         success = true;
         LOG.info("File downloaded successfully on attempt {}", attempts + 1);
       } catch (IOException e) {
@@ -76,7 +76,7 @@ public class TestFetchFileUtils {
         LOG.error("Download attempt {} failed due to: {}", attempts, e.getMessage(), e);
         if (attempts < MAX_RETRIES) {
           long retryDelay = INITIAL_RETRY_DELAY_MS * (1L << (attempts - 1));
-          LOG.warn("Retrying in {}ms", retryDelay);
+          LOG.warn("Retrying in {} ms", retryDelay);
           Thread.sleep(retryDelay);
         } else {
           throw new AssertionError("Failed to download file after " + MAX_RETRIES + " attempts", e);

--- a/catalogs/catalog-hive/src/test/java/org/apache/gravitino/catalog/hive/TestFetchFileUtils.java
+++ b/catalogs/catalog-hive/src/test/java/org/apache/gravitino/catalog/hive/TestFetchFileUtils.java
@@ -65,10 +65,10 @@ public class TestFetchFileUtils {
     boolean success = false;
     int attempts = 0;
 
-    while (!success && attempts < MAX_RETRIES) {
+    while (!success) {
       try {
         LOG.info("Attempting to download file from URL: {} (Attempt {})", fileUrl, attempts + 1);
-        FetchFileUtils.fetchFileFromUri(fileUrl, destFile, 10, conf);
+        FetchFileUtils.fetchFileFromUri(fileUrl, destFile, 30, conf);
         success = true;
         LOG.info("File downloaded successfully on attempt {}", attempts + 1);
       } catch (IOException e) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Increase the timeout to avoid flaky issue.

### Why are the changes needed?

Previously we increased the retry times, but not timeout, we should increase the timeout to make the test more robust.

Fix: #5213 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing UTs.