### PR TITLE
[#5551] feat(core): add topic pre-event to Gravitino event.

### DIFF
--- a/core/src/main/java/org/apache/gravitino/listener/api/event/AlterTopicPreEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/AlterTopicPreEvent.java
@@ -1,0 +1,26 @@
+package org.apache.gravitino.listener.api.event;
+
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.annotation.DeveloperApi;
+import org.apache.gravitino.messaging.TopicChange;
+
+/** Represents an event triggered before altering a topic. */
+@DeveloperApi
+public class AlterTopicPreEvent extends TopicPreEvent {
+  private final TopicChange[] topicChanges;
+
+  public AlterTopicPreEvent(String user, NameIdentifier identifier, TopicChange[] topicChanges) {
+    super(user, identifier);
+    this.topicChanges = topicChanges;
+  }
+
+  /**
+   * Retrieves the specific changes made to the topic during the alteration process.
+   *
+   * @return An array of {@link TopicChange} objects detailing each modification applied to the
+   *     topic.
+   */
+  public TopicChange[] topicChanges() {
+    return topicChanges;
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/AlterTopicPreEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/AlterTopicPreEvent.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.gravitino.listener.api.event;
 
 import org.apache.gravitino.NameIdentifier;

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/CreateTopicPreEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/CreateTopicPreEvent.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.gravitino.listener.api.event;
 
 import org.apache.gravitino.NameIdentifier;

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/CreateTopicPreEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/CreateTopicPreEvent.java
@@ -1,0 +1,26 @@
+package org.apache.gravitino.listener.api.event;
+
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.annotation.DeveloperApi;
+import org.apache.gravitino.listener.api.info.TopicInfo;
+
+/** Represents an event triggered before creating a topic. */
+@DeveloperApi
+public class CreateTopicPreEvent extends TopicPreEvent {
+  private final TopicInfo createTopicRequest;
+
+  public CreateTopicPreEvent(String user, NameIdentifier identifier, TopicInfo createTopicRequest) {
+    super(user, identifier);
+    this.createTopicRequest = createTopicRequest;
+  }
+
+  /**
+   * Retrieves the creation topic request.
+   *
+   * @return A {@link TopicInfo} instance encapsulating the comprehensive details of create topic
+   *     request.
+   */
+  public TopicInfo createTopicRequest() {
+    return createTopicRequest;
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/DropTopicPreEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/DropTopicPreEvent.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.gravitino.listener.api.event;
 
 import org.apache.gravitino.NameIdentifier;

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/DropTopicPreEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/DropTopicPreEvent.java
@@ -1,0 +1,12 @@
+package org.apache.gravitino.listener.api.event;
+
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.annotation.DeveloperApi;
+
+/** Represents an event triggered before dropping a topic. */
+@DeveloperApi
+public class DropTopicPreEvent extends TopicPreEvent {
+  public DropTopicPreEvent(String user, NameIdentifier identifier) {
+    super(user, identifier);
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/ListTopicPreEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/ListTopicPreEvent.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.gravitino.listener.api.event;
 
 import org.apache.gravitino.NameIdentifier;

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/ListTopicPreEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/ListTopicPreEvent.java
@@ -1,0 +1,25 @@
+package org.apache.gravitino.listener.api.event;
+
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.Namespace;
+import org.apache.gravitino.annotation.DeveloperApi;
+
+/** Represents an event triggered before listing of topics within a namespace. */
+@DeveloperApi
+public class ListTopicPreEvent extends TopicPreEvent {
+  private final Namespace namespace;
+
+  public ListTopicPreEvent(String user, Namespace namespace) {
+    super(user, NameIdentifier.of(namespace.levels()));
+    this.namespace = namespace;
+  }
+
+  /**
+   * Provides the namespace associated with this event.
+   *
+   * @return A {@link Namespace} instance from which topics were listed.
+   */
+  public Namespace namespace() {
+    return namespace;
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/LoadTopicPreEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/LoadTopicPreEvent.java
@@ -1,0 +1,12 @@
+package org.apache.gravitino.listener.api.event;
+
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.annotation.DeveloperApi;
+
+/** Represents an event triggered before loading a topic. */
+@DeveloperApi
+public class LoadTopicPreEvent extends TopicPreEvent {
+  public LoadTopicPreEvent(String user, NameIdentifier identifier) {
+    super(user, identifier);
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/LoadTopicPreEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/LoadTopicPreEvent.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.gravitino.listener.api.event;
 
 import org.apache.gravitino.NameIdentifier;

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/TopicPreEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/TopicPreEvent.java
@@ -1,0 +1,12 @@
+package org.apache.gravitino.listener.api.event;
+
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.annotation.DeveloperApi;
+
+/** Represents a pre-event for topic operations. */
+@DeveloperApi
+public abstract class TopicPreEvent extends PreEvent {
+  protected TopicPreEvent(String user, NameIdentifier identifier) {
+    super(user, identifier);
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/TopicPreEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/TopicPreEvent.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.gravitino.listener.api.event;
 
 import org.apache.gravitino.NameIdentifier;


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Add pre-events for topic events, including `AlterTopicPreEvent`, `CreateTopicPreEvent`, `DropTopicPreEvent`, `ListTopicPreEvent` and `LoadTopicPreEvent`.

### Why are the changes needed?

Fix: #5551 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Related Unit Tests have been added.
