### PR TITLE
[#5585] fix(catalog-hadoop): Test and make fileset with cloud storage can work with Spark 3.2.0~3.5.3

### DIFF
--- a/bundles/aliyun-bundle/build.gradle.kts
+++ b/bundles/aliyun-bundle/build.gradle.kts
@@ -25,8 +25,14 @@ plugins {
 }
 
 dependencies {
-  compileOnly(project(":catalogs:catalog-hadoop"))
-  compileOnly(libs.hadoop3.common)
+  compileOnly(project(":catalogs:catalog-hadoop")) {
+    exclude(group = "*")
+  }
+
+  compileOnly(libs.hadoop3.client.api)
+  compileOnly(libs.hadoop3.client.runtime)
+
+  implementation(libs.guava)
   implementation(libs.hadoop3.oss)
 
   // oss needs StringUtils from commons-lang3 or the following error will occur in 3.3.0
@@ -49,6 +55,7 @@ tasks.withType(ShadowJar::class.java) {
   // Relocate dependencies to avoid conflicts
   relocate("org.jdom", "org.apache.gravitino.shaded.org.jdom")
   relocate("org.apache.commons.lang3", "org.apache.gravitino.shaded.org.apache.commons.lang3")
+  relocate("com.google", "org.apache.gravitino.shaded.com.google")
 }
 
 tasks.jar {

--- a/bundles/aws-bundle/build.gradle.kts
+++ b/bundles/aws-bundle/build.gradle.kts
@@ -25,12 +25,23 @@ plugins {
 }
 
 dependencies {
-  compileOnly(project(":api"))
-  compileOnly(project(":core"))
-  compileOnly(project(":catalogs:catalog-common"))
-  compileOnly(project(":catalogs:catalog-hadoop"))
-  compileOnly(libs.hadoop3.common)
+  compileOnly(project(":api")) {
+    exclude("*")
+  }
 
+  compileOnly(project(":core")) {
+    exclude("*")
+  }
+
+  compileOnly(project(":catalogs:catalog-hadoop")) {
+    exclude("*")
+  }
+
+  compileOnly(libs.hadoop3.client.api)
+  compileOnly(libs.hadoop3.client.runtime)
+
+  implementation(libs.commons.lang3)
+  implementation(libs.guava)
   implementation(libs.aws.iam)
   implementation(libs.aws.policy)
   implementation(libs.aws.sts)
@@ -44,6 +55,9 @@ tasks.withType(ShadowJar::class.java) {
   isZip64 = true
   configurations = listOf(project.configurations.runtimeClasspath.get())
   archiveClassifier.set("")
+
+  relocate("com.google.common", "org.apache.gravitino.shaded.com.google.common")
+  relocate("org.apache.commons.lang3", "org.apache.gravitino.shaded.org.apache.commons.lang3")
 }
 
 tasks.jar {

--- a/bundles/azure-bundle/build.gradle.kts
+++ b/bundles/azure-bundle/build.gradle.kts
@@ -25,11 +25,12 @@ plugins {
 }
 
 dependencies {
-  compileOnly(project(":api"))
-  compileOnly(project(":core"))
-  compileOnly(project(":catalogs:catalog-hadoop"))
+  compileOnly(project(":catalogs:catalog-hadoop")) {
+    exclude(group = "*")
+  }
 
-  compileOnly(libs.hadoop3.common)
+  compileOnly(libs.hadoop3.client.api)
+  compileOnly(libs.hadoop3.client.runtime)
 
   implementation(libs.commons.lang3)
   // runtime used
@@ -47,8 +48,10 @@ tasks.withType(ShadowJar::class.java) {
 
   // Relocate dependencies to avoid conflicts
   relocate("org.apache.httpcomponents", "org.apache.gravitino.azure.shaded.org.apache.httpcomponents")
-  relocate("org.apache.commons", "org.apache.gravitino.azure.shaded.org.apache.commons")
-  relocate("com.fasterxml", "org.apache.gravitino.azure.shaded.com.fasterxml")
+  // Why do we do this changes? If we shade the prefixes 'org.apache.commons', some jar like `commons-io`
+  // will be shaded mistakenly and will lead to some errors.
+  relocate("org.apache.commons.lang3", "org.apache.gravitino.azure.shaded.org.apache.commons.lang3")
+  relocate("org.apache.commons.logging", "org.apache.gravitino.azure.shaded.org.apache.commons.logging")
   relocate("com.google.guava", "org.apache.gravitino.azure.shaded.com.google.guava")
 }
 

--- a/bundles/azure-bundle/src/main/java/org/apache/gravitino/abs/fs/AzureFileSystemProvider.java
+++ b/bundles/azure-bundle/src/main/java/org/apache/gravitino/abs/fs/AzureFileSystemProvider.java
@@ -23,7 +23,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
 import java.util.Map;
-import javax.annotation.Nonnull;
 import org.apache.gravitino.catalog.hadoop.fs.FileSystemProvider;
 import org.apache.gravitino.catalog.hadoop.fs.FileSystemUtils;
 import org.apache.gravitino.storage.ABSProperties;
@@ -42,8 +41,7 @@ public class AzureFileSystemProvider implements FileSystemProvider {
   private static final String ABFS_IMPL_KEY = "fs.abfss.impl";
 
   @Override
-  public FileSystem getFileSystem(@Nonnull Path path, @Nonnull Map<String, String> config)
-      throws IOException {
+  public FileSystem getFileSystem(Path path, Map<String, String> config) throws IOException {
     Configuration configuration = new Configuration();
 
     Map<String, String> hadoopConfMap =

--- a/bundles/gcp-bundle/build.gradle.kts
+++ b/bundles/gcp-bundle/build.gradle.kts
@@ -25,12 +25,18 @@ plugins {
 }
 
 dependencies {
-  compileOnly(project(":api"))
-  compileOnly(project(":core"))
-  compileOnly(project(":catalogs:catalog-common"))
-  compileOnly(project(":catalogs:catalog-hadoop"))
+  compileOnly(project(":api")) {
+    exclude("*")
+  }
+  compileOnly(project(":core")) {
+    exclude("*")
+  }
 
-  compileOnly(libs.hadoop3.common)
+  compileOnly(project(":catalogs:catalog-hadoop")) {
+    exclude(group = "*")
+  }
+  compileOnly(libs.hadoop3.client.api)
+  compileOnly(libs.hadoop3.client.runtime)
 
   implementation(libs.commons.lang3)
   // runtime used

--- a/bundles/gcp-bundle/src/main/java/org/apache/gravitino/gcs/fs/GCSFileSystemProvider.java
+++ b/bundles/gcp-bundle/src/main/java/org/apache/gravitino/gcs/fs/GCSFileSystemProvider.java
@@ -29,11 +29,8 @@ import org.apache.gravitino.storage.GCSProperties;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class GCSFileSystemProvider implements FileSystemProvider {
-  private static final Logger LOGGER = LoggerFactory.getLogger(GCSFileSystemProvider.class);
   private static final String GCS_SERVICE_ACCOUNT_JSON_FILE =
       "fs.gs.auth.service.account.json.keyfile";
 
@@ -46,7 +43,6 @@ public class GCSFileSystemProvider implements FileSystemProvider {
     Configuration configuration = new Configuration();
     FileSystemUtils.toHadoopConfigMap(config, GRAVITINO_KEY_TO_GCS_HADOOP_KEY)
         .forEach(configuration::set);
-    LOGGER.info("Creating GCS file system with config: {}", config);
     return GoogleHadoopFileSystem.newInstance(path.toUri(), configuration);
   }
 

--- a/catalogs/catalog-hadoop/build.gradle.kts
+++ b/catalogs/catalog-hadoop/build.gradle.kts
@@ -69,6 +69,10 @@ dependencies {
 
   testImplementation(libs.minikdc)
   testImplementation(libs.hadoop3.minicluster)
+  testImplementation(libs.guava)
+  testImplementation(libs.commons.lang3)
+  testImplementation(libs.commons.io)
+  testImplementation(libs.commons.collections3)
 
   testImplementation(libs.bundles.log4j)
   testImplementation(libs.mockito.core)

--- a/catalogs/catalog-hadoop/build.gradle.kts
+++ b/catalogs/catalog-hadoop/build.gradle.kts
@@ -41,18 +41,11 @@ dependencies {
   }
 
   compileOnly(libs.guava)
+  compileOnly(libs.commons.lang3)
+  compileOnly(libs.commons.io)
 
-  implementation(libs.hadoop3.common) {
-    exclude("com.sun.jersey")
-    exclude("javax.servlet", "servlet-api")
-    exclude("org.eclipse.jetty", "*")
-    exclude("org.apache.hadoop", "hadoop-auth")
-    exclude("org.apache.curator", "curator-client")
-    exclude("org.apache.curator", "curator-framework")
-    exclude("org.apache.curator", "curator-recipes")
-    exclude("org.apache.avro", "avro")
-    exclude("com.sun.jersey", "jersey-servlet")
-  }
+  implementation(libs.hadoop3.client.api)
+  implementation(libs.hadoop3.client.runtime)
 
   implementation(libs.hadoop3.hdfs) {
     exclude("com.sun.jersey")
@@ -63,14 +56,6 @@ dependencies {
     exclude("io.netty")
     exclude("org.fusesource.leveldbjni")
   }
-  implementation(libs.hadoop3.client) {
-    exclude("org.apache.hadoop", "hadoop-mapreduce-client-core")
-    exclude("org.apache.hadoop", "hadoop-mapreduce-client-jobclient")
-    exclude("org.apache.hadoop", "hadoop-yarn-api")
-    exclude("org.apache.hadoop", "hadoop-yarn-client")
-    exclude("com.squareup.okhttp", "okhttp")
-  }
-
   implementation(libs.slf4j.api)
 
   testImplementation(project(":clients:client-java"))
@@ -119,6 +104,11 @@ tasks {
       exclude("kerb-*.jar")
       exclude("kerby-*.jar")
     }
+
+    // remove common-text:1.4.jar as it conflicts with common-text:1.10.jar introduced by
+    // hadoop-common 3.3.6;
+    exclude("commons-text-1.4.jar")
+
     into("$rootDir/distribution/package/catalogs/hadoop/libs")
   }
 

--- a/catalogs/catalog-hadoop/build.gradle.kts
+++ b/catalogs/catalog-hadoop/build.gradle.kts
@@ -106,7 +106,7 @@ tasks {
     }
 
     // remove common-text:1.4.jar as it conflicts with common-text:1.10.jar introduced by
-    // hadoop-common 3.3.6;
+    // hadoop-common 3.3.1;
     exclude("commons-text-1.4.jar")
 
     into("$rootDir/distribution/package/catalogs/hadoop/libs")

--- a/catalogs/catalog-hadoop/src/test/java/org/apache/gravitino/catalog/hadoop/integration/test/HadoopGCSCatalogIT.java
+++ b/catalogs/catalog-hadoop/src/test/java/org/apache/gravitino/catalog/hadoop/integration/test/HadoopGCSCatalogIT.java
@@ -40,7 +40,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIf;
 
-@EnabledIf(value = "isGCPConfigured", disabledReason = "GCP is not configured.")
+@EnabledIf(value = "isGCSConfigured", disabledReason = "GCS is not configured.")
 public class HadoopGCSCatalogIT extends HadoopCatalogIT {
 
   public static final String BUCKET_NAME = System.getenv("GCS_BUCKET_NAME");
@@ -170,7 +170,7 @@ public class HadoopGCSCatalogIT extends HadoopCatalogIT {
     metalake.dropCatalog(localCatalogName, true);
   }
 
-  private static boolean isGCPConfigured() {
+  private static boolean isGCSConfigured() {
     return StringUtils.isNotBlank(System.getenv("GCS_SERVICE_ACCOUNT_JSON_PATH"))
         && StringUtils.isNotBlank(System.getenv("GCS_BUCKET_NAME"));
   }

--- a/clients/filesystem-hadoop3-runtime/build.gradle.kts
+++ b/clients/filesystem-hadoop3-runtime/build.gradle.kts
@@ -36,6 +36,7 @@ tasks.withType<ShadowJar>(ShadowJar::class.java) {
   archiveClassifier.set("")
 
   // Relocate dependencies to avoid conflicts
+  relocate("org.apache.commons.lang3", "org.apache.gravitino.shaded.org.apache.commons.lang3")
   relocate("com.google", "org.apache.gravitino.shaded.com.google")
   relocate("com.github.benmanes.caffeine", "org.apache.gravitino.shaded.com.github.benmanes.caffeine")
 }

--- a/clients/filesystem-hadoop3/build.gradle.kts
+++ b/clients/filesystem-hadoop3/build.gradle.kts
@@ -25,7 +25,9 @@ plugins {
 
 dependencies {
   compileOnly(project(":clients:client-java-runtime", configuration = "shadow"))
-  compileOnly(libs.hadoop3.common)
+  compileOnly(libs.hadoop3.client.api)
+  compileOnly(libs.hadoop3.client.runtime)
+
   implementation(project(":catalogs:catalog-hadoop")) {
     exclude(group = "*")
   }
@@ -33,6 +35,8 @@ dependencies {
     exclude(group = "*")
   }
 
+  implementation(libs.guava)
+  implementation(libs.commons.lang3)
   implementation(libs.caffeine)
 
   testImplementation(project(":api"))
@@ -52,11 +56,8 @@ dependencies {
   testImplementation(libs.bundles.jwt)
   testImplementation(libs.testcontainers)
   testImplementation(libs.guava)
-  testImplementation(libs.hadoop3.client)
-  testImplementation(libs.hadoop3.common) {
-    exclude("com.sun.jersey")
-    exclude("javax.servlet", "servlet-api")
-  }
+  testImplementation(libs.hadoop3.client.api)
+  testImplementation(libs.hadoop3.client.runtime)
   testImplementation(libs.hadoop3.hdfs) {
     exclude("com.sun.jersey")
     exclude("javax.servlet", "servlet-api")

--- a/clients/filesystem-hadoop3/src/test/java/org/apache/gravitino/filesystem/hadoop/integration/test/GravitinoVirtualFileSystemGCSIT.java
+++ b/clients/filesystem-hadoop3/src/test/java/org/apache/gravitino/filesystem/hadoop/integration/test/GravitinoVirtualFileSystemGCSIT.java
@@ -41,7 +41,7 @@ import org.junit.jupiter.api.condition.EnabledIf;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@EnabledIf(value = "isGCPConfigured", disabledReason = "GCP is not configured")
+@EnabledIf(value = "isGCSConfigured", disabledReason = "GCS is not configured")
 public class GravitinoVirtualFileSystemGCSIT extends GravitinoVirtualFileSystemIT {
   private static final Logger LOG = LoggerFactory.getLogger(GravitinoVirtualFileSystemGCSIT.class);
 
@@ -99,8 +99,8 @@ public class GravitinoVirtualFileSystemGCSIT extends GravitinoVirtualFileSystemI
   public void tearDown() throws IOException {
     Catalog catalog = metalake.loadCatalog(catalogName);
     catalog.asSchemas().dropSchema(schemaName, true);
-    metalake.dropCatalog(catalogName);
-    client.dropMetalake(metalakeName);
+    metalake.dropCatalog(catalogName, true);
+    client.dropMetalake(metalakeName, true);
 
     if (client != null) {
       client.close();
@@ -142,7 +142,7 @@ public class GravitinoVirtualFileSystemGCSIT extends GravitinoVirtualFileSystemI
       "GCS does not support append, java.io.IOException: The append operation is not supported")
   public void testAppend() throws IOException {}
 
-  private static boolean isGCPConfigured() {
+  private static boolean isGCSConfigured() {
     return StringUtils.isNotBlank(System.getenv("GCS_SERVICE_ACCOUNT_JSON_PATH"))
         && StringUtils.isNotBlank(System.getenv("GCS_BUCKET_NAME"));
   }

--- a/clients/filesystem-hadoop3/src/test/java/org/apache/gravitino/filesystem/hadoop/integration/test/GravitinoVirtualFileSystemS3IT.java
+++ b/clients/filesystem-hadoop3/src/test/java/org/apache/gravitino/filesystem/hadoop/integration/test/GravitinoVirtualFileSystemS3IT.java
@@ -26,11 +26,8 @@ import com.google.common.collect.Maps;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
-import java.util.UUID;
-import java.util.concurrent.TimeUnit;
 import org.apache.gravitino.Catalog;
 import org.apache.gravitino.catalog.hadoop.fs.FileSystemUtils;
-import org.apache.gravitino.integration.test.container.GravitinoLocalStackContainer;
 import org.apache.gravitino.integration.test.util.GravitinoITUtils;
 import org.apache.gravitino.s3.fs.S3FileSystemProvider;
 import org.apache.gravitino.storage.S3Properties;
@@ -39,79 +36,27 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.condition.EnabledIf;
+import org.junit.platform.commons.util.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.testcontainers.containers.Container;
-import org.testcontainers.shaded.org.awaitility.Awaitility;
 
+@EnabledIf(value = "s3IsConfigured", disabledReason = "S3 is not configured.")
 public class GravitinoVirtualFileSystemS3IT extends GravitinoVirtualFileSystemIT {
   private static final Logger LOG = LoggerFactory.getLogger(GravitinoVirtualFileSystemS3IT.class);
-
-  private String bucketName = "s3-bucket-" + UUID.randomUUID().toString().replace("-", "");
-  private String accessKey;
-  private String secretKey;
-  private String s3Endpoint;
-
-  private GravitinoLocalStackContainer gravitinoLocalStackContainer;
+  private static final String S3_BUCKET_NAME = System.getenv("S3_BUCKET_NAME");
+  private static final String S3_ACCESS_KEY = System.getenv("S3_ACCESS_KEY_ID");
+  private static final String S3_SECRET_KEY = System.getenv("S3_SECRET_ACCESS_KEY");
+  private static final String S3_END_POINT = System.getenv("S3_ENDPOINT");
 
   @BeforeAll
   public void startIntegrationTest() {
     // Do nothing
   }
 
-  private void startS3Mocker() {
-    containerSuite.startLocalStackContainer();
-    gravitinoLocalStackContainer = containerSuite.getLocalStackContainer();
-
-    Awaitility.await()
-        .atMost(60, TimeUnit.SECONDS)
-        .pollInterval(1, TimeUnit.SECONDS)
-        .until(
-            () -> {
-              try {
-                Container.ExecResult result =
-                    gravitinoLocalStackContainer.executeInContainer(
-                        "awslocal", "iam", "create-user", "--user-name", "anonymous");
-                return result.getExitCode() == 0;
-              } catch (Exception e) {
-                LOG.info("LocalStack is not ready yet for: ", e);
-                return false;
-              }
-            });
-
-    gravitinoLocalStackContainer.executeInContainer("awslocal", "s3", "mb", "s3://" + bucketName);
-
-    Container.ExecResult result =
-        gravitinoLocalStackContainer.executeInContainer(
-            "awslocal", "iam", "create-access-key", "--user-name", "anonymous");
-
-    gravitinoLocalStackContainer.executeInContainer(
-        "awslocal",
-        "s3api",
-        "put-bucket-acl",
-        "--bucket",
-        "my-test-bucket",
-        "--acl",
-        "public-read-write");
-
-    // Get access key and secret key from result
-    String[] lines = result.getStdout().split("\n");
-    accessKey = lines[3].split(":")[1].trim().substring(1, 21);
-    secretKey = lines[5].split(":")[1].trim().substring(1, 41);
-
-    LOG.info("Access key: " + accessKey);
-    LOG.info("Secret key: " + secretKey);
-
-    s3Endpoint =
-        String.format("http://%s:%d", gravitinoLocalStackContainer.getContainerIpAddress(), 4566);
-  }
-
   @BeforeAll
   public void startUp() throws Exception {
     copyBundleJarsToHadoop("aws-bundle");
-
-    // Start s3 simulator
-    startS3Mocker();
 
     // Need to download jars to gravitino server
     super.startIntegrationTest();
@@ -131,9 +76,9 @@ public class GravitinoVirtualFileSystemS3IT extends GravitinoVirtualFileSystemIT
     Assertions.assertTrue(client.metalakeExists(metalakeName));
 
     Map<String, String> properties = Maps.newHashMap();
-    properties.put("gravitino.bypass.fs.s3a.access.key", accessKey);
-    properties.put("gravitino.bypass.fs.s3a.secret.key", secretKey);
-    properties.put("gravitino.bypass.fs.s3a.endpoint", s3Endpoint);
+    properties.put("gravitino.bypass.fs.s3a.access.key", S3_ACCESS_KEY);
+    properties.put("gravitino.bypass.fs.s3a.secret.key", S3_SECRET_KEY);
+    properties.put("gravitino.bypass.fs.s3a.endpoint", S3_END_POINT);
     properties.put(
         "gravitino.bypass.fs.s3a.aws.credentials.provider",
         "org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider");
@@ -154,9 +99,9 @@ public class GravitinoVirtualFileSystemS3IT extends GravitinoVirtualFileSystemIT
     conf.set("fs.gravitino.client.metalake", metalakeName);
 
     // Pass this configuration to the real file system
-    conf.set(S3Properties.GRAVITINO_S3_SECRET_ACCESS_KEY, accessKey);
-    conf.set(S3Properties.GRAVITINO_S3_ACCESS_KEY_ID, secretKey);
-    conf.set(S3Properties.GRAVITINO_S3_ENDPOINT, s3Endpoint);
+    conf.set(S3Properties.GRAVITINO_S3_SECRET_ACCESS_KEY, S3_SECRET_KEY);
+    conf.set(S3Properties.GRAVITINO_S3_ACCESS_KEY_ID, S3_ACCESS_KEY);
+    conf.set(S3Properties.GRAVITINO_S3_ENDPOINT, S3_END_POINT);
     conf.set(FS_FILESYSTEM_PROVIDERS, "s3");
   }
 
@@ -199,10 +144,17 @@ public class GravitinoVirtualFileSystemS3IT extends GravitinoVirtualFileSystemIT
   }
 
   protected String genStorageLocation(String fileset) {
-    return String.format("s3a://%s/%s", bucketName, fileset);
+    return String.format("s3a://%s/%s", S3_BUCKET_NAME, fileset);
   }
 
   @Disabled(
-      "GCS does not support append, java.io.IOException: The append operation is not supported")
+      "S3 does not support append, java.io.IOException: The append operation is not supported")
   public void testAppend() throws IOException {}
+
+  private static boolean s3IsConfigured() {
+    return StringUtils.isNotBlank(System.getenv("S3_ACCESS_KEY_ID"))
+        && StringUtils.isNotBlank(System.getenv("S3_SECRET_ACCESS_KEY"))
+        && StringUtils.isNotBlank(System.getenv("S3_ENDPOINT"))
+        && StringUtils.isNotBlank(System.getenv("S3_BUCKET_NAME"));
+  }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,11 +32,11 @@ airlift-json = "237"
 airlift-resolver = "1.6"
 hive2 = "2.3.9"
 hadoop2 = "2.10.2"
-hadoop3 = "3.3.0"
+hadoop3 = "3.3.1"
 hadoop3-gcs = "1.9.4-hadoop3"
-hadoop3-abs = "3.3.0"
-hadoop3-aliyun = "3.3.0"
-hadoop-minikdc = "3.3.0"
+hadoop3-abs = "3.3.1"
+hadoop3-aliyun = "3.3.1"
+hadoop-minikdc = "3.3.1"
 htrace-core4 = "4.1.0-incubating"
 httpclient5 = "5.2.1"
 mockserver = "5.15.0"
@@ -168,6 +168,10 @@ hadoop3-aws = { group = "org.apache.hadoop", name = "hadoop-aws", version.ref = 
 hadoop3-hdfs = { group = "org.apache.hadoop", name = "hadoop-hdfs", version.ref = "hadoop3" }
 hadoop3-common = { group = "org.apache.hadoop", name = "hadoop-common", version.ref = "hadoop3"}
 hadoop3-client = { group = "org.apache.hadoop", name = "hadoop-client", version.ref = "hadoop3"}
+
+hadoop3-client-api = { group = "org.apache.hadoop", name = "hadoop-client-api", version.ref = "hadoop3"}
+hadoop3-client-runtime = { group = "org.apache.hadoop", name = "hadoop-client-runtime", version.ref = "hadoop3"}
+
 hadoop3-minicluster = { group = "org.apache.hadoop", name = "hadoop-minicluster", version.ref = "hadoop-minikdc"}
 hadoop3-gcs = { group = "com.google.cloud.bigdataoss", name = "gcs-connector", version.ref = "hadoop3-gcs"}
 hadoop3-oss = { group = "org.apache.hadoop", name = "hadoop-aliyun", version.ref = "hadoop3-aliyun"}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -172,7 +172,7 @@ hadoop3-client = { group = "org.apache.hadoop", name = "hadoop-client", version.
 hadoop3-client-api = { group = "org.apache.hadoop", name = "hadoop-client-api", version.ref = "hadoop3"}
 hadoop3-client-runtime = { group = "org.apache.hadoop", name = "hadoop-client-runtime", version.ref = "hadoop3"}
 
-hadoop3-minicluster = { group = "org.apache.hadoop", name = "hadoop-minicluster", version.ref = "hadoop-minikdc"}
+hadoop3-minicluster = { group = "org.apache.hadoop", name = "hadoop-client-minicluster", version.ref = "hadoop-minikdc"}
 hadoop3-gcs = { group = "com.google.cloud.bigdataoss", name = "gcs-connector", version.ref = "hadoop3-gcs"}
 hadoop3-oss = { group = "org.apache.hadoop", name = "hadoop-aliyun", version.ref = "hadoop3-aliyun"}
 hadoop3-abs = { group = "org.apache.hadoop", name = "hadoop-azure", version.ref = "hadoop3-abs"}


### PR DESCRIPTION


### What changes were proposed in this pull request?

1. Update the Hadoop version from 3.3.0 to 3.3.1 to avoid bugs existing in the Hadoop 3.3.0, why use 3.3.1 and 3.3.6, because version hadoop-aws 3.3.6 is a very updated version and needs the corresponding Hadoop version, which will make it difficult to use in production.
2. Replace dependencies `hadoop-common` and `hadoop-client` with `hadoop-client-api` and `hadoop-client-runtime` to avoid third-party dependencies compatibility issues. 


### Why are the changes needed?

To make fileset that can be used in production.

Fix: #5585 

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

Locally and existing UTs and ITs.
