### PR TITLE
[#5452] Improvement(web): add REST catalog backend for Iceberg catalog

### DIFF
--- a/web/web/src/app/metalakes/metalake/rightContent/CreateCatalogDialog.js
+++ b/web/web/src/app/metalakes/metalake/rightContent/CreateCatalogDialog.js
@@ -241,6 +241,12 @@ const CreateCatalogDialog = props => {
       providerSelect === 'lakehouse-paimon'
     ) {
       nextProps = propItems.filter(item => !['jdbc-driver', 'jdbc-user', 'jdbc-password', 'uri'].includes(item.key))
+    } else if (
+      propItems[0]?.key === 'catalog-backend' &&
+      propItems[0]?.value === 'rest' &&
+      providerSelect === 'lakehouse-iceberg'
+    ) {
+      nextProps = propItems.filter(item => !['jdbc-driver', 'jdbc-user', 'jdbc-password', 'warehouse'].includes(item.key))
     }
     const parentField = nextProps.find(i => i.key === 'authentication.type')
     if (!parentField || parentField?.value === 'simple') {
@@ -294,6 +300,12 @@ const CreateCatalogDialog = props => {
             ...others
           }
           uri && (properties['uri'] = uri)
+        } else if (catalogBackend && catalogBackend === 'rest' && providerSelect === 'lakehouse-iceberg') {
+          properties = {
+            'catalog-backend': catalogBackend,
+            uri: uri,
+            ...others
+          }
         } else {
           properties = {
             uri: uri,

--- a/web/web/src/app/metalakes/metalake/rightContent/CreateCatalogDialog.js
+++ b/web/web/src/app/metalakes/metalake/rightContent/CreateCatalogDialog.js
@@ -246,7 +246,9 @@ const CreateCatalogDialog = props => {
       propItems[0]?.value === 'rest' &&
       providerSelect === 'lakehouse-iceberg'
     ) {
-      nextProps = propItems.filter(item => !['jdbc-driver', 'jdbc-user', 'jdbc-password', 'warehouse'].includes(item.key))
+      nextProps = propItems.filter(
+        item => !['jdbc-driver', 'jdbc-user', 'jdbc-password', 'warehouse'].includes(item.key)
+      )
     }
     const parentField = nextProps.find(i => i.key === 'authentication.type')
     if (!parentField || parentField?.value === 'simple') {

--- a/web/web/src/lib/utils/initial.js
+++ b/web/web/src/lib/utils/initial.js
@@ -70,7 +70,7 @@ export const providers = [
         defaultValue: 'hive',
         required: true,
         description: 'Apache Iceberg catalog type choose properties',
-        select: ['hive', 'jdbc']
+        select: ['hive', 'jdbc', 'rest']
       },
       {
         key: 'uri',
@@ -82,6 +82,8 @@ export const providers = [
         key: 'warehouse',
         value: '',
         required: true,
+        parentField: 'catalog-backend',
+        hide: ['rest'],
         description: 'Apache Iceberg catalog warehouse config'
       },
       {
@@ -89,7 +91,7 @@ export const providers = [
         value: '',
         required: true,
         parentField: 'catalog-backend',
-        hide: ['hive'],
+        hide: ['hive', 'rest'],
         description: `"com.mysql.jdbc.Driver" or "com.mysql.cj.jdbc.Driver" for MySQL, "org.postgresql.Driver" for PostgreSQL`
       },
       {
@@ -97,14 +99,14 @@ export const providers = [
         value: '',
         required: true,
         parentField: 'catalog-backend',
-        hide: ['hive']
+        hide: ['hive', 'rest'],
       },
       {
         key: 'jdbc-password',
         value: '',
         required: true,
         parentField: 'catalog-backend',
-        hide: ['hive']
+        hide: ['hive', 'rest']
       },
       {
         key: 'authentication.type',

--- a/web/web/src/lib/utils/initial.js
+++ b/web/web/src/lib/utils/initial.js
@@ -99,7 +99,7 @@ export const providers = [
         value: '',
         required: true,
         parentField: 'catalog-backend',
-        hide: ['hive', 'rest'],
+        hide: ['hive', 'rest']
       },
       {
         key: 'jdbc-password',


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Modified:

     - app/metalakes/metalake/rightContent/CreateCatalogDialog.js
     - lib/utils/initial.js


### Why are the changes needed?

Iceberg catalog supports hive, jdbc catalog backend in WEB, we need to support rest catalog backend too, it only supports uri properties.

      1. Add select item 'rest' in the dropbox menu.
      2. When select rest menu item, only show 'uri' properties edit needs to input.


### Does this PR introduce _any_ user-facing change?

Yes, this PR introduces web UI changes : 

       1.  Add a selectable item called 'rest' to the dropdown menu when creating a new catalog.
       2.  Remove all other properties except 'uri.'


### How was this patch tested?

Visit the Gravitino web UI through the browser and click 'Create Catalog' .
Then, check the menu items and the API call in debug mode. 
You can see the HTTP payload sent as follows:

POST  http://localhost:3000/api/metalakes/test/catalogs

```json
{
  "name": "1",
  "type": "relational",
  "provider": "lakehouse-iceberg",
  "comment": "",
  "properties": {
    "uri": "1",                                     
    "warehouse": "",                        
    "catalog-backend": "rest",
    "authType": "simple"
  }
}
```

response:

```json

{
    "code": 0,
    "catalog": {
        "name": "1",
        "type": "relational",
        "provider": "lakehouse-iceberg",
        "comment": "",
        "properties": {
            "catalog-backend": "rest",
            "warehouse": "",
            "authType": "simple",
            "uri": "1",
            "in-use": "true"
        },
        "audit": {
            "creator": "anonymous",
            "createTime": "2024-11-19T15:16:07.054Z",
            "lastModifier": "anonymous",
            "lastModifiedTime": "2024-11-19T15:16:07.054Z"
        }
    }
}
```
