### PR TITLE
[#5454] feat(web): different data table column types are supported depending on the provider

### DIFF
--- a/web/web/src/lib/utils/initial.js
+++ b/web/web/src/lib/utils/initial.js
@@ -348,6 +348,30 @@ export const providers = [
 ]
 
 const parameterizedColumnTypes = {
+  char: {
+    params: ['length'],
+    validateParams: params => {
+      if (params.length !== 1) {
+        return {
+          valid: false,
+          message: 'Please set length'
+        }
+      }
+
+      const length = params[0]
+
+      if (length <= 0) {
+        return {
+          valid: false,
+          message: 'The length must be greater than 0'
+        }
+      }
+
+      return {
+        valid: true
+      }
+    }
+  },
   decimal: {
     params: ['precision', 'scale'],
     validateParams: params => {
@@ -378,7 +402,7 @@ const parameterizedColumnTypes = {
       }
     }
   },
-  char: {
+  fixed: {
     params: ['length'],
     validateParams: params => {
       if (params.length !== 1) {
@@ -425,30 +449,6 @@ const parameterizedColumnTypes = {
         valid: true
       }
     }
-  },
-  fixed: {
-    params: ['length'],
-    validateParams: params => {
-      if (params.length !== 1) {
-        return {
-          valid: false,
-          message: 'Please set length'
-        }
-      }
-
-      const length = params[0]
-
-      if (length <= 0) {
-        return {
-          valid: false,
-          message: 'The length must be greater than 0'
-        }
-      }
-
-      return {
-        valid: true
-      }
-    }
   }
 }
 
@@ -460,114 +460,113 @@ export const getParameterizedColumnType = type => {
 
 const relationalColumnTypeMap = {
   'lakehouse-iceberg': [
+    'binary',
     'boolean',
+    'date',
+    'decimal',
+    'double',
+    'fixed',
+    'float',
     'integer',
     'long',
-    'float',
-    'double',
     'string',
-    'date',
     'time',
     'timestamp',
     'timestamp_tz',
-    'decimal',
-    'fixed',
-    'binary',
     'uuid'
   ],
 
   hive: [
+    'binary',
     'boolean',
     'byte',
-    'short',
-    'integer',
-    'long',
-    'float',
-    'double',
-    'decimal',
-    'string',
     'char',
-    'varchar',
-    'timestamp',
     'date',
-    'interval_year',
+    'decimal',
+    'double',
+    'float',
+    'integer',
     'interval_day',
-    'binary'
+    'interval_year',
+    'long',
+    'short',
+    'string',
+    'timestamp',
+    'varchar'
   ],
 
   'jdbc-mysql': [
+    'binary',
     'byte',
     'byte unsigned',
-    'short',
-    'short unsigned',
+    'char',
+    'date',
+    'decimal',
+    'double',
+    'float',
     'integer',
     'integer unsigned',
     'long',
     'long unsigned',
-    'float',
-    'double',
+    'short',
+    'short unsigned',
     'string',
-    'date',
     'time',
     'timestamp',
-    'decimal',
-    'varchar',
-    'char',
-    'binary'
+    'varchar'
   ],
-
   'jdbc-postgresql': [
+    'binary',
     'boolean',
-    'short',
+    'char',
+    'date',
+    'decimal',
+    'double',
+    'float',
     'integer',
     'long',
-    'float',
-    'double',
+    'short',
     'string',
-    'date',
     'time',
     'timestamp',
     'timestamp_tz',
-    'decimal',
-    'varchar',
-    'char',
-    'binary'
+    'varchar'
   ],
 
   'jdbc-doris': [
     'boolean',
     'byte',
-    'short',
+    'char',
+    'date',
+    'decimal',
+    'double',
+    'float',
     'integer',
     'long',
-    'float',
-    'double',
-    'decimal',
-    'date',
+    'short',
+    'string',
     'timestamp',
-    'varchar',
-    'char',
-    'string'
+    'varchar'
   ],
 
   'lakehouse-paimon': [
+    'binary',
     'boolean',
     'byte',
-    'short',
-    'integer',
-    'long',
-    'float',
-    'double',
-    'decimal',
-    'string',
-    'varchar',
     'char',
     'date',
+    'decimal',
+    'double',
+    'fixed',
+    'float',
+    'integer',
+    'long',
+    'short',
+    'string',
     'time',
     'timestamp',
     'timestamp_tz',
-    'binary',
-    'fixed'
+    'varchar'
   ]
 }
 

--- a/web/web/src/lib/utils/initial.js
+++ b/web/web/src/lib/utils/initial.js
@@ -497,9 +497,13 @@ const relationalColumnTypeMap = {
 
   'jdbc-mysql': [
     'byte',
+    'byte unsigned',
     'short',
+    'short unsigned',
     'integer',
+    'integer unsigned',
     'long',
+    'long unsigned',
     'float',
     'double',
     'string',

--- a/web/web/src/lib/utils/initial.js
+++ b/web/web/src/lib/utils/initial.js
@@ -347,16 +347,8 @@ export const providers = [
   }
 ]
 
-export const tableColumnTypes = [
-  { key: 'boolean' },
-  { key: 'byte' },
-  { key: 'short' },
-  { key: 'integer' },
-  { key: 'long' },
-  { key: 'float' },
-  { key: 'double' },
-  {
-    key: 'decimal',
+const parameterizedColumnTypes = {
+  decimal: {
     params: ['precision', 'scale'],
     validateParams: params => {
       if (params.length !== 2) {
@@ -386,13 +378,7 @@ export const tableColumnTypes = [
       }
     }
   },
-  { key: 'date' },
-  { key: 'time' },
-  { key: 'timestamp' },
-  { key: 'timestamp_tz' },
-  { key: 'string' },
-  {
-    key: 'char',
+  char: {
     params: ['length'],
     validateParams: params => {
       if (params.length !== 1) {
@@ -416,8 +402,7 @@ export const tableColumnTypes = [
       }
     }
   },
-  {
-    key: 'varchar',
+  varchar: {
     params: ['length'],
     validateParams: params => {
       if (params.length !== 1) {
@@ -441,10 +426,7 @@ export const tableColumnTypes = [
       }
     }
   },
-  { key: 'interval_day' },
-  { key: 'interval_year' },
-  {
-    key: 'fixed',
+  fixed: {
     params: ['length'],
     validateParams: params => {
       if (params.length !== 1) {
@@ -467,7 +449,128 @@ export const tableColumnTypes = [
         valid: true
       }
     }
-  },
-  { key: 'uuid' },
-  { key: 'binary' }
-]
+  }
+}
+
+export const getParameterizedColumnType = type => {
+  if (Object.keys(parameterizedColumnTypes).includes(type)) {
+    return parameterizedColumnTypes[type]
+  }
+}
+
+const relationalColumnTypeMap = {
+  'lakehouse-iceberg': [
+    'boolean',
+    'integer',
+    'long',
+    'float',
+    'double',
+    'string',
+    'date',
+    'time',
+    'timestamp',
+    'timestamp_tz',
+    'decimal',
+    'fixed',
+    'binary',
+    'uuid'
+  ],
+
+  hive: [
+    'boolean',
+    'byte',
+    'short',
+    'integer',
+    'long',
+    'float',
+    'double',
+    'decimal',
+    'string',
+    'char',
+    'varchar',
+    'timestamp',
+    'date',
+    'interval_year',
+    'interval_day',
+    'binary'
+  ],
+
+  'jdbc-mysql': [
+    'byte',
+    'short',
+    'integer',
+    'long',
+    'float',
+    'double',
+    'string',
+    'date',
+    'time',
+    'timestamp',
+    'decimal',
+    'varchar',
+    'char',
+    'binary'
+  ],
+
+  'jdbc-postgresql': [
+    'boolean',
+    'short',
+    'integer',
+    'long',
+    'float',
+    'double',
+    'string',
+    'date',
+    'time',
+    'timestamp',
+    'timestamp_tz',
+    'decimal',
+    'varchar',
+    'char',
+    'binary'
+  ],
+
+  'jdbc-doris': [
+    'boolean',
+    'byte',
+    'short',
+    'integer',
+    'long',
+    'float',
+    'double',
+    'decimal',
+    'date',
+    'timestamp',
+    'varchar',
+    'char',
+    'string'
+  ],
+
+  'lakehouse-paimon': [
+    'boolean',
+    'byte',
+    'short',
+    'integer',
+    'long',
+    'float',
+    'double',
+    'decimal',
+    'string',
+    'varchar',
+    'char',
+    'date',
+    'time',
+    'timestamp',
+    'timestamp_tz',
+    'binary',
+    'fixed'
+  ]
+}
+
+export const getRelationalColumnTypeMap = catalog => {
+  if (Object.keys(relationalColumnTypeMap).includes(catalog)) {
+    return relationalColumnTypeMap[catalog]
+  }
+
+  return []
+}


### PR DESCRIPTION
### What changes are proposed in this pull request?

When creating or updating a table, the column types will vary depending on the provider.

### Why are these changes needed?

Fixes: #5454

### Does this PR introduce _any_ user-facing changes?

No.

### How was this patch tested?

Tested by creating and updating tables with different providers to verify that the column types differ as expected and match the [documentation](https://gravitino.apache.org/docs/0.6.1-incubating/lakehouse-iceberg-catalog/#table-column-types).

Additionally, verified the success of the create/update operations.
