### PR TITLE
[#5685] Refact the way CLI commands are called to catch more errors / be more future proof

### DIFF
--- a/clients/cli/src/main/java/org/apache/gravitino/cli/GravitinoCommandLine.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/GravitinoCommandLine.java
@@ -204,7 +204,10 @@ public class GravitinoCommandLine extends TestableCommandLine {
     Set<String> flags = new HashSet<>();
     flags.add(command);
     for (Option option : line.getOptions()) {
-      flags.add(option.getLongOpt());
+      String flag = option.getLongOpt();
+      if (!flag.equals(GravitinoOptions.METALAKE)) {
+        flags.add(option.getLongOpt());
+      }
     }
 
     Runnable commandHandler = commandMap.get(flags);


### PR DESCRIPTION
### What changes were proposed in this pull request?

Change handle metlake command to use a command map that determines which command to run based on the command and flags passed in.

### Why are the changes needed?

For ease in adding commands in the future and avoiding complicated if/else logic.

Fix: #5685

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Tested locally.