### PR TITLE
[#5691] fix(doris-catalog): Fix errors in type mapping about timestamp in Doris catalog.

### DIFF
--- a/catalogs/catalog-jdbc-doris/src/main/java/org/apache/gravitino/catalog/doris/converter/DorisTypeConverter.java
+++ b/catalogs/catalog-jdbc-doris/src/main/java/org/apache/gravitino/catalog/doris/converter/DorisTypeConverter.java
@@ -59,7 +59,7 @@ public class DorisTypeConverter extends JdbcTypeConverter {
       case DATE:
         return Types.DateType.get();
       case DATETIME:
-        return Types.TimestampType.withTimeZone();
+        return Types.TimestampType.withoutTimeZone();
       case CHAR:
         return Types.FixedCharType.of(Integer.parseInt(typeBean.getColumnSize()));
       case VARCHAR:

--- a/catalogs/catalog-jdbc-doris/src/test/java/org/apache/gravitino/catalog/doris/operation/TestDorisTableOperations.java
+++ b/catalogs/catalog-jdbc-doris/src/test/java/org/apache/gravitino/catalog/doris/operation/TestDorisTableOperations.java
@@ -433,6 +433,11 @@ public class TestDorisTableOperations extends TestDoris {
         JdbcColumn.builder().withName("col_11").withType(Types.FixedCharType.of(10)).build());
     columns.add(JdbcColumn.builder().withName("col_12").withType(Types.VarCharType.of(10)).build());
     columns.add(JdbcColumn.builder().withName("col_13").withType(Types.StringType.get()).build());
+    columns.add(
+        JdbcColumn.builder()
+            .withName("col_14")
+            .withType(Types.TimestampType.withoutTimeZone())
+            .build());
 
     Distribution distribution =
         Distributions.hash(DEFAULT_BUCKET_SIZE, NamedReference.field("col_1"));


### PR DESCRIPTION
### What changes were proposed in this pull request?

When loading table with datetime column from Doris table, we should convert it to Gravitno timestamp without timezone NOT timestamp_tz(timestamp with timezone)

### Why are the changes needed?

According to docs 
1. https://gravitino.apache.org/docs/0.7.0-incubating/jdbc-doris-catalog#table-column-types
2. https://doris.apache.org/docs/1.2/sql-manual/sql-reference/Data-Definition-Statements/Create/CREATE-TABLE

it's a bug when converting Gravitino timestamp type to Doris datetime type. 

Fix: #5691

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

UT & IT
