### PR TITLE
[#5648] improvement(iceberg): generate credential according to the data path and metadata path

### DIFF
--- a/core/src/main/java/org/apache/gravitino/credential/CredentialUtils.java
+++ b/core/src/main/java/org/apache/gravitino/credential/CredentialUtils.java
@@ -23,10 +23,10 @@ import com.google.common.collect.ImmutableSet;
 import org.apache.gravitino.utils.PrincipalUtils;
 
 public class CredentialUtils {
-  public static Credential vendCredential(CredentialProvider credentialProvider, String path) {
+  public static Credential vendCredential(CredentialProvider credentialProvider, String[] path) {
     PathBasedCredentialContext pathBasedCredentialContext =
         new PathBasedCredentialContext(
-            PrincipalUtils.getCurrentUserName(), ImmutableSet.of(path), ImmutableSet.of());
+            PrincipalUtils.getCurrentUserName(), ImmutableSet.copyOf(path), ImmutableSet.of());
     return credentialProvider.getCredential(pathBasedCredentialContext);
   }
 }

--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/rest/IcebergTableOperations.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/rest/IcebergTableOperations.java
@@ -54,6 +54,7 @@ import org.apache.gravitino.iceberg.service.dispatcher.IcebergTableOperationDisp
 import org.apache.gravitino.iceberg.service.metrics.IcebergMetricsManager;
 import org.apache.gravitino.listener.api.event.IcebergRequestContext;
 import org.apache.gravitino.metrics.MetricNames;
+import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.ServiceUnavailableException;
@@ -296,7 +297,14 @@ public class IcebergTableOperations {
     }
     Credential credential =
         CredentialUtils.vendCredential(
-            credentialProvider, loadTableResponse.tableMetadata().location());
+            credentialProvider,
+            new String[] {
+              loadTableResponse.tableMetadata().location(),
+              loadTableResponse.tableMetadata().property(TableProperties.WRITE_DATA_LOCATION, ""),
+              loadTableResponse
+                  .tableMetadata()
+                  .property(TableProperties.WRITE_METADATA_LOCATION, "")
+            });
     if (credential == null) {
       throw new ServiceUnavailableException(
           "Couldn't generate credential for %s", credentialProvider.credentialType());

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/integration/test/IcebergRESTS3IT.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/integration/test/IcebergRESTS3IT.java
@@ -19,8 +19,10 @@
 
 package org.apache.gravitino.iceberg.integration.test;
 
+import com.google.common.collect.ImmutableList;
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import org.apache.gravitino.catalog.lakehouse.iceberg.IcebergConstants;
@@ -187,5 +189,11 @@ public class IcebergRESTS3IT extends IcebergRESTJdbcCatalogIT {
         String.format(
             "Expected write.metadata.path to be '%s', but was '%s'",
             writeMetaDataPath, propertiesMap.get(TableProperties.WRITE_METADATA_LOCATION)));
+
+    String value1 = "1";
+    String value2 = "2";
+    sql(String.format("INSERT INTO %s VALUES (%s), (%s);", tableName, value1, value2));
+    List<String> result = convertToStringList(sql(String.format("SELECT * FROM %s", tableName)), 0);
+    Assertions.assertEquals(result, ImmutableList.of((value1), (value2)));
   }
 }

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/integration/test/IcebergRESTS3IT.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/integration/test/IcebergRESTS3IT.java
@@ -154,9 +154,9 @@ public class IcebergRESTS3IT extends IcebergRESTJdbcCatalogIT {
   }
 
   @Test
-  void testWritePathCredential() {
+  void testCredentialWithMultiLocations() {
     String namespaceName = ICEBERG_REST_NS_PREFIX + "credential";
-    String tableName = namespaceName + ".pathCredential";
+    String tableName = namespaceName + ".multi_location";
 
     String writeDataPath = this.s3Warehouse + "/test_data_location";
     String writeMetaDataPath = this.s3Warehouse + "/test_metadata_location";

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/integration/test/IcebergRESTServiceIT.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/integration/test/IcebergRESTServiceIT.java
@@ -45,7 +45,7 @@ import org.junit.jupiter.api.condition.EnabledIf;
 @TestInstance(Lifecycle.PER_CLASS)
 public abstract class IcebergRESTServiceIT extends IcebergRESTServiceBaseIT {
 
-  private static final String ICEBERG_REST_NS_PREFIX = "iceberg_rest_";
+  protected static final String ICEBERG_REST_NS_PREFIX = "iceberg_rest_";
 
   @BeforeAll
   void prepareSQLContext() {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR updates the credential generation process to also consider `write.data.path` and `write.metadata.path`.

### Why are the changes needed?

To provide greater flexibility for users.  
Fixes: #5648

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

- Used Spark to create a table via Gravitino Iceberg REST server to AWS S3 and verified that `write.data.path` and `write.metadata.path` are working as expected.  
- Added unit tests to check if table properties include `write.data.path` and `write.metadata.path`.

![image](https://github.com/user-attachments/assets/fc2ebbfc-e758-4800-99ce-a575bb23605c)
