### PR TITLE
[#5700] feat(CLI):Add extended help for catalogs in Gravitino CLI

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -551,7 +551,8 @@ tasks.rat {
     "clients/client-python/tests/integration/htmlcov/*",
     "clients/client-python/docs/build",
     "clients/client-python/docs/source/generated",
-    "clients/filesystem-fuse/Cargo.lock"
+    "clients/filesystem-fuse/Cargo.lock",
+    "clients/cli/src/main/resources/*.txt"
   )
 
   // Add .gitignore excludes to the Apache Rat exclusion list.

--- a/clients/cli/src/main/resources/catalog_help.txt
+++ b/clients/cli/src/main/resources/catalog_help.txt
@@ -1,0 +1,50 @@
+gcli catalog [details|list|create|delete|update|properties|set|remove]
+
+Please set the metalake in the Gravitino configuration file or the environment variable before running any of these commands.
+
+Example commands
+
+Show a catalog details
+gcli catalog details --name catalog_postgres
+
+Show all catalogs in a metalake
+gcli catalog list
+
+Show a catalog audit information
+gcli catalog details --name catalog_postgres --audit
+
+Creating a catalog
+The type of catalog to be created is specified by the `--provider` option. Different catalogs require different properties, for example, a Hive catalog requires a metastore-uri property.
+
+Create a Hive catalog
+gcli catalog create --name hive --provider hive --properties metastore.uris=thrift://hive-host:9083
+
+Create an Iceberg catalog
+gcli catalog create  -name iceberg --provider iceberg --properties uri=thrift://hive-host:9083,catalog-backend=hive,warehouse=hdfs://hdfs-host:9000/user/iceberg/warehouse
+
+Create a MySQL catalog
+gcli catalog create  -name mysql --provider mysql --properties jdbc-url=jdbc:mysql://mysql-host:3306?useSSL=false,jdbc-user=user,jdbc-password=password,jdbc-driver=com.mysql.cj.jdbc.Driver
+
+Create a Postgres catalog
+gcli catalog create  -name postgres --provider postgres --properties jdbc-url=jdbc:postgresql://postgresql-host/mydb,jdbc-user=user,jdbc-password=password,jdbc-database=db,jdbc-driver=org.postgresql.Driver
+
+Create a Kafka catalog
+gcli catalog create --name kafka --provider kafka --properties bootstrap.servers=127.0.0.1:9092,127.0.0.2:9092
+
+Delete a catalog
+gcli catalog delete --name hive
+
+Rename a catalog
+gcli catalog update --name catalog_mysql --rename mysql
+
+Change a catalog comment
+gcli catalog update --name catalog_mysql --comment "new comment"
+
+Display a catalog's properties
+gcli catalog properties --name catalog_mysql
+
+Set a catalog's property
+gcli catalog set --name catalog_mysql --property test --value value
+
+Remove a catalog's property
+gcli catalog remove --name catalog_mysql --property test


### PR DESCRIPTION
### What changes were proposed in this pull request?

Added extended help for catalog commands.

### Why are the changes needed?

To provide user with extra help.

Fix: #5700

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

N/A
