### PR TITLE
[#5279] improvement(cli): Display sort order information for Tables in the Gravitino CLI

### DIFF
--- a/clients/cli/src/main/java/org/apache/gravitino/cli/GravitinoCommandLine.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/GravitinoCommandLine.java
@@ -309,6 +309,8 @@ public class GravitinoCommandLine extends TestableCommandLine {
         newTableDistribution(url, ignore, metalake, catalog, schema, table).handle();
       } else if (line.hasOption(GravitinoOptions.PARTITION)) {
         newTablePartition(url, ignore, metalake, catalog, schema, table).handle();
+      } else if (line.hasOption(GravitinoOptions.SORTORDER)) {
+        newTableSortOrder(url, ignore, metalake, catalog, schema, table).handle();
       } else {
         newTableDetails(url, ignore, metalake, catalog, schema, table).handle();
       }

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/GravitinoOptions.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/GravitinoOptions.java
@@ -54,6 +54,7 @@ public class GravitinoOptions {
   public static final String DISTRIBUTION = "distribution";
   public static final String PARTITION = "partition";
   public static final String OUTPUT = "output";
+  public static final String SORTORDER = "sortorder";
 
   /**
    * Builds and returns the CLI options for Gravitino.
@@ -76,6 +77,7 @@ public class GravitinoOptions {
     options.addOption(createSimpleOption("d", DISTRIBUTION, "display distribution information"));
     options.addOption(createSimpleOption(PARTITION, "display partition information"));
     options.addOption(createSimpleOption("o", OWNER, "display entity owner"));
+    options.addOption(createSimpleOption(null, SORTORDER, "display sortorder information"));
 
     // Create/update options
     options.addOption(createArgOption(RENAME, "new entity name"));

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/TestableCommandLine.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/TestableCommandLine.java
@@ -97,6 +97,7 @@ import org.apache.gravitino.cli.commands.TableAudit;
 import org.apache.gravitino.cli.commands.TableDetails;
 import org.apache.gravitino.cli.commands.TableDistribution;
 import org.apache.gravitino.cli.commands.TablePartition;
+import org.apache.gravitino.cli.commands.TableSortOrder;
 import org.apache.gravitino.cli.commands.TagDetails;
 import org.apache.gravitino.cli.commands.TagEntity;
 import org.apache.gravitino.cli.commands.TopicDetails;
@@ -323,6 +324,11 @@ public class TestableCommandLine {
   protected TableDistribution newTableDistribution(
       String url, boolean ignore, String metalake, String catalog, String schema, String table) {
     return new TableDistribution(url, ignore, metalake, catalog, schema, table);
+  }
+
+  protected TableSortOrder newTableSortOrder(
+      String url, boolean ignore, String metalake, String catalog, String schema, String table) {
+    return new TableSortOrder(url, ignore, metalake, catalog, schema, table);
   }
 
   protected UpdateTableComment newUpdateTableComment(

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/TableSortOrder.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/TableSortOrder.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.cli.commands;
+
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.rel.expressions.sorts.SortOrder;
+
+/** Displays the details of a table's sort order. */
+public class TableSortOrder extends TableCommand {
+
+  protected final String schema;
+  protected final String table;
+
+  /**
+   * Displays the details of a table's sort order.
+   *
+   * @param url The URL of the Gravitino server.
+   * @param ignoreVersions If true don't check the client/server versions match.
+   * @param metalake The name of the metalake.
+   * @param catalog The name of the catalog.
+   * @param schema The name of the schenma.
+   * @param table The name of the table.
+   */
+  public TableSortOrder(
+      String url,
+      boolean ignoreVersions,
+      String metalake,
+      String catalog,
+      String schema,
+      String table) {
+    super(url, ignoreVersions, metalake, catalog);
+    this.schema = schema;
+    this.table = table;
+  }
+
+  /** Displays the expression, direction and nullOrdering number of sort order. */
+  @Override
+  public void handle() {
+    SortOrder[] sortOrders;
+
+    try {
+      NameIdentifier name = NameIdentifier.of(schema, table);
+      sortOrders = tableCatalog().loadTable(name).sortOrder();
+    } catch (Exception exp) {
+      System.err.println(exp.getMessage());
+      return;
+    }
+    for (SortOrder sortOrder : sortOrders) {
+      System.out.printf(
+          "%s,%s,%s%n", sortOrder.expression(), sortOrder.direction(), sortOrder.nullOrdering());
+    }
+  }
+}

--- a/clients/cli/src/test/java/org/apache/gravitino/cli/TestTableCommands.java
+++ b/clients/cli/src/test/java/org/apache/gravitino/cli/TestTableCommands.java
@@ -37,6 +37,7 @@ import org.apache.gravitino.cli.commands.TableAudit;
 import org.apache.gravitino.cli.commands.TableDetails;
 import org.apache.gravitino.cli.commands.TableDistribution;
 import org.apache.gravitino.cli.commands.TablePartition;
+import org.apache.gravitino.cli.commands.TableSortOrder;
 import org.apache.gravitino.cli.commands.UpdateTableComment;
 import org.apache.gravitino.cli.commands.UpdateTableName;
 import org.junit.jupiter.api.BeforeEach;
@@ -150,6 +151,29 @@ class TestTableCommands {
             GravitinoCommandLine.DEFAULT_URL, false, "metalake_demo", "catalog", "schema", "users");
     commandLine.handleCommandLine();
     verify(mockDistribution).handle();
+  }
+
+  @Test
+  void testTableSortOrderCommand() {
+    TableSortOrder mockSortOrder = mock(TableSortOrder.class);
+
+    when(mockCommandLine.hasOption(GravitinoOptions.METALAKE)).thenReturn(true);
+    when(mockCommandLine.getOptionValue(GravitinoOptions.METALAKE)).thenReturn("metalake_demo");
+    when(mockCommandLine.hasOption(GravitinoOptions.NAME)).thenReturn(true);
+    when(mockCommandLine.getOptionValue(GravitinoOptions.NAME)).thenReturn("catalog.schema.users");
+    when(mockCommandLine.hasOption(GravitinoOptions.SORTORDER)).thenReturn(true);
+
+    GravitinoCommandLine commandLine =
+        spy(
+            new GravitinoCommandLine(
+                mockCommandLine, mockOptions, CommandEntities.TABLE, CommandActions.DETAILS));
+    doReturn(mockSortOrder)
+        .when(commandLine)
+        .newTableSortOrder(
+            GravitinoCommandLine.DEFAULT_URL, false, "metalake_demo", "catalog", "schema", "users");
+
+    commandLine.handleCommandLine();
+    verify(mockSortOrder).handle();
   }
 
   @Test

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -395,6 +395,11 @@ gcli table details --name catalog_postgres.hr.departments --distribution
 gcli table details --name catalog_postgres.hr.departments --partition
 ```
 
+#### Show tables sort order information
+```bash
+gcli table details --name catalog_postgres.hr.departments --sortorder
+```
+
 ### Show table indexes
 
 ```bash


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add --sortorder option to display sort order information on Tables.

### Why are the changes needed?

Closes: #5279

### Does this PR introduce _any_ user-facing change?

Yes, it adds the --sortorder option to CLI

### How was this patch tested?

Compiled and tested locally.
