### PR TITLE
[minor] fix(dev): fix ValueError when parsing config file with multiple '=' in one line

### DIFF
--- a/dev/docker/iceberg-rest-server/rewrite_config.py
+++ b/dev/docker/iceberg-rest-server/rewrite_config.py
@@ -48,7 +48,7 @@ def parse_config_file(file_path):
         for line in file:  
             stripped_line = line.strip()  
             if stripped_line and not stripped_line.startswith('#'):  
-                key, value = stripped_line.split('=')  
+                key, value = stripped_line.split('=', 1)
                 key = key.strip()  
                 value = value.strip()  
                 config_map[key] = value  


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix potential parsing error in the `rewrite_config.parse_config_file` function.

### Why are the changes needed?

If a configuration line contains multiple '=' characters, the `rewrite_config.parse_config_file` function will throw a `ValueError: too many values to unpack`. 

This change ensures the function correctly handles lines with multiple '=' characters.

### Does this PR introduce any user-facing changes?

No.

### How was this patch tested?

Rebuilt the project and tested with configurations containing multiple '=' characters in a single line.
