### PR TITLE
[hotfix] fix camelCase method names from getfieldName to getFieldName

### DIFF
--- a/catalogs/catalog-lakehouse-paimon/src/main/java/org/apache/gravitino/catalog/lakehouse/paimon/utils/TableOpsUtils.java
+++ b/catalogs/catalog-lakehouse-paimon/src/main/java/org/apache/gravitino/catalog/lakehouse/paimon/utils/TableOpsUtils.java
@@ -81,7 +81,7 @@ public class TableOpsUtils {
     if (tableChange instanceof ColumnChange) {
       if (tableChange instanceof AddColumn) {
         AddColumn addColumn = (AddColumn) tableChange;
-        String fieldName = getfieldName(addColumn);
+        String fieldName = getFieldName(addColumn);
         checkColumnCapability(fieldName, addColumn.getDefaultValue(), addColumn.isAutoIncrement());
         return addColumn(
             fieldName,
@@ -89,29 +89,29 @@ public class TableOpsUtils {
             addColumn.getComment(),
             move(fieldName, addColumn.getPosition()));
       } else if (tableChange instanceof DeleteColumn) {
-        return dropColumn(getfieldName((DeleteColumn) tableChange));
+        return dropColumn(getFieldName((DeleteColumn) tableChange));
       } else if (tableChange instanceof RenameColumn) {
         RenameColumn renameColumn = ((RenameColumn) tableChange);
-        return renameColumn(getfieldName(renameColumn), renameColumn.getNewName());
+        return renameColumn(getFieldName(renameColumn), renameColumn.getNewName());
       } else if (tableChange instanceof UpdateColumnComment) {
         UpdateColumnComment updateColumnComment = (UpdateColumnComment) tableChange;
         return updateColumnComment(
-            getfieldName(updateColumnComment), updateColumnComment.getNewComment());
+            getFieldName(updateColumnComment), updateColumnComment.getNewComment());
       } else if (tableChange instanceof UpdateColumnNullability) {
         UpdateColumnNullability updateColumnNullability = (UpdateColumnNullability) tableChange;
         return updateColumnNullability(
-            getfieldName(updateColumnNullability), updateColumnNullability.nullable());
+            getFieldName(updateColumnNullability), updateColumnNullability.nullable());
       } else if (tableChange instanceof UpdateColumnPosition) {
         UpdateColumnPosition updateColumnPosition = (UpdateColumnPosition) tableChange;
         Preconditions.checkArgument(
             !(updateColumnPosition.getPosition() instanceof Default),
             "Default position is not supported for Paimon update column position.");
         return updateColumnPosition(
-            move(getfieldName(updateColumnPosition), updateColumnPosition.getPosition()));
+            move(getFieldName(updateColumnPosition), updateColumnPosition.getPosition()));
       } else if (tableChange instanceof UpdateColumnType) {
         UpdateColumnType updateColumnType = (UpdateColumnType) tableChange;
         return updateColumnType(
-            getfieldName(updateColumnType), toPaimonType(updateColumnType.getNewDataType()));
+            getFieldName(updateColumnType), toPaimonType(updateColumnType.getNewDataType()));
       }
     } else if (tableChange instanceof UpdateComment) {
       return updateComment(((UpdateComment) tableChange).getNewComment());
@@ -147,19 +147,19 @@ public class TableOpsUtils {
         fieldNames.length == 1,
         String.format(
             "Paimon does not support update nested column. Illegal column: %s.",
-            getfieldName(fieldNames)));
+            getFieldName(fieldNames)));
   }
 
-  public static String[] getfieldName(String fieldName) {
+  public static String[] getFieldName(String fieldName) {
     return new String[] {fieldName};
   }
 
-  public static String getfieldName(String[] fieldName) {
+  public static String getFieldName(String[] fieldName) {
     return DOT.join(fieldName);
   }
 
-  private static String getfieldName(ColumnChange columnChange) {
-    return getfieldName(columnChange.fieldName());
+  private static String getFieldName(ColumnChange columnChange) {
+    return getFieldName(columnChange.fieldName());
   }
 
   private static Move move(String fieldName, ColumnPosition columnPosition)

--- a/catalogs/catalog-lakehouse-paimon/src/test/java/org/apache/gravitino/catalog/lakehouse/paimon/ops/TestPaimonCatalogOps.java
+++ b/catalogs/catalog-lakehouse-paimon/src/test/java/org/apache/gravitino/catalog/lakehouse/paimon/ops/TestPaimonCatalogOps.java
@@ -18,7 +18,7 @@
  */
 package org.apache.gravitino.catalog.lakehouse.paimon.ops;
 
-import static org.apache.gravitino.catalog.lakehouse.paimon.utils.TableOpsUtils.getfieldName;
+import static org.apache.gravitino.catalog.lakehouse.paimon.utils.TableOpsUtils.getFieldName;
 import static org.apache.gravitino.catalog.lakehouse.paimon.utils.TypeUtils.toPaimonType;
 import static org.apache.gravitino.rel.TableChange.ColumnPosition.after;
 import static org.apache.gravitino.rel.TableChange.ColumnPosition.defaultPos;
@@ -190,9 +190,9 @@ public class TestPaimonCatalogOps {
           assertEquals("col_1", dataField.name());
           assertEquals(UpdateColumnComment.class.getSimpleName(), dataField.description());
         },
-        updateColumnComment(getfieldName("col_1"), UpdateColumnComment.class.getSimpleName()));
+        updateColumnComment(getFieldName("col_1"), UpdateColumnComment.class.getSimpleName()));
     assertColumnNotExist(
-        updateColumnComment(getfieldName("col_10"), UpdateComment.class.getSimpleName()));
+        updateColumnComment(getFieldName("col_10"), UpdateComment.class.getSimpleName()));
   }
 
   @Test
@@ -203,8 +203,8 @@ public class TestPaimonCatalogOps {
           assertEquals("col_2", dataField.name());
           assertFalse(dataField.type().isNullable());
         },
-        updateColumnNullability(getfieldName("col_2"), false));
-    assertColumnNotExist(updateColumnNullability(getfieldName("col_5"), true));
+        updateColumnNullability(getFieldName("col_2"), false));
+    assertColumnNotExist(updateColumnNullability(getFieldName("col_5"), true));
   }
 
   @Test
@@ -229,18 +229,18 @@ public class TestPaimonCatalogOps {
           assertEquals("col_1", dataField.name());
           assertEquals(DataTypes.BIGINT(), dataField.type());
         },
-        updateColumnType(getfieldName("col_1"), Types.LongType.get()));
-    assertColumnNotExist(updateColumnType(getfieldName("col_5"), Types.ShortType.get()));
+        updateColumnType(getFieldName("col_1"), Types.LongType.get()));
+    assertColumnNotExist(updateColumnType(getFieldName("col_5"), Types.ShortType.get()));
     assertThrowsExactly(
         IllegalStateException.class,
         () ->
             assertAlterTable(
-                table -> {}, updateColumnType(getfieldName("col_1"), Types.DateType.get())));
+                table -> {}, updateColumnType(getFieldName("col_1"), Types.DateType.get())));
     assertThrowsExactly(
         IllegalStateException.class,
         () ->
             assertAlterTable(
-                table -> {}, updateColumnType(getfieldName("col_4"), Types.LongType.get())));
+                table -> {}, updateColumnType(getFieldName("col_4"), Types.LongType.get())));
   }
 
   @Test
@@ -252,11 +252,11 @@ public class TestPaimonCatalogOps {
           assertEquals("col_5", fieldNames.get(1));
           assertEquals(4, fieldNames.size());
         },
-        renameColumn(getfieldName("col_2"), "col_5"));
-    assertColumnNotExist(renameColumn(getfieldName("col_6"), "col_7"));
+        renameColumn(getFieldName("col_2"), "col_5"));
+    assertColumnNotExist(renameColumn(getFieldName("col_6"), "col_7"));
     assertThrowsExactly(
         ColumnAlreadyExistException.class,
-        () -> assertAlterTable(table -> {}, renameColumn(getfieldName("col_1"), "col_4")));
+        () -> assertAlterTable(table -> {}, renameColumn(getFieldName("col_1"), "col_4")));
   }
 
   @Test
@@ -268,9 +268,9 @@ public class TestPaimonCatalogOps {
           assertEquals("col_3", fieldNames.get(1));
           assertEquals(3, fieldNames.size());
         },
-        deleteColumn(getfieldName("col_2"), true));
-    assertColumnNotExist(deleteColumn(getfieldName("col_5"), true));
-    assertColumnNotExist(deleteColumn(getfieldName("col_5"), false));
+        deleteColumn(getFieldName("col_2"), true));
+    assertColumnNotExist(deleteColumn(getFieldName("col_5"), true));
+    assertColumnNotExist(deleteColumn(getFieldName("col_5"), false));
   }
 
   @Test
@@ -326,8 +326,8 @@ public class TestPaimonCatalogOps {
           assertTrue(options.containsKey("test_property_key"));
           assertEquals("test_property_value", options.get("test_property_key"));
         },
-        renameColumn(getfieldName("col_1"), "col_5"),
-        deleteColumn(getfieldName("col_2"), true),
+        renameColumn(getFieldName("col_1"), "col_5"),
+        deleteColumn(getFieldName("col_2"), true),
         setProperty("test_property_key", "test_property_value"));
   }
 
@@ -342,7 +342,7 @@ public class TestPaimonCatalogOps {
           assertEquals("col_3", fieldNames.get(fields[2]));
           assertEquals("col_4", fieldNames.get(fields[3]));
         },
-        updateColumnPosition(getfieldName(columnName), columnPosition));
+        updateColumnPosition(getFieldName(columnName), columnPosition));
   }
 
   private void assertAddColumn(int column, Type type, ColumnPosition columnPosition, Integer field)
@@ -357,7 +357,7 @@ public class TestPaimonCatalogOps {
           assertTrue(dataField.type().isNullable());
         },
         addColumn(
-            getfieldName(columnName),
+            getFieldName(columnName),
             type,
             SchemaChange.AddColumn.class.getSimpleName(),
             columnPosition,

--- a/catalogs/catalog-lakehouse-paimon/src/test/java/org/apache/gravitino/catalog/lakehouse/paimon/utils/TestTableOpsUtils.java
+++ b/catalogs/catalog-lakehouse-paimon/src/test/java/org/apache/gravitino/catalog/lakehouse/paimon/utils/TestTableOpsUtils.java
@@ -19,7 +19,7 @@
 package org.apache.gravitino.catalog.lakehouse.paimon.utils;
 
 import static org.apache.gravitino.catalog.lakehouse.paimon.utils.TableOpsUtils.buildSchemaChange;
-import static org.apache.gravitino.catalog.lakehouse.paimon.utils.TableOpsUtils.getfieldName;
+import static org.apache.gravitino.catalog.lakehouse.paimon.utils.TableOpsUtils.getFieldName;
 import static org.apache.gravitino.rel.TableChange.ColumnPosition.after;
 import static org.apache.gravitino.rel.TableChange.ColumnPosition.defaultPos;
 import static org.apache.gravitino.rel.TableChange.addColumn;
@@ -78,7 +78,7 @@ public class TestTableOpsUtils {
   void testAddColumnFirst() {
     assertTableChange(
         addColumn(
-            TableOpsUtils.getFieldName("col_1"),
+            getFieldName("col_1"),
             IntegerType.get(),
             AddColumn.class.getSimpleName(),
             TableChange.ColumnPosition.first(),
@@ -102,7 +102,7 @@ public class TestTableOpsUtils {
   void testAddColumnAfter() {
     assertTableChange(
         addColumn(
-            TableOpsUtils.getFieldName("col_2"),
+            getFieldName("col_2"),
             FloatType.get(),
             AddColumn.class.getSimpleName(),
             after("col_1"),
@@ -126,7 +126,7 @@ public class TestTableOpsUtils {
   void testAddColumnDefaultPosition() {
     assertTableChange(
         addColumn(
-            TableOpsUtils.getFieldName("col_3"),
+            getFieldName("col_3"),
             ListType.of(StringType.get(), false),
             AddColumn.class.getSimpleName(),
             defaultPos(),
@@ -147,7 +147,7 @@ public class TestTableOpsUtils {
   void testAddColumnWitNullPosition() {
     assertTableChange(
         addColumn(
-            TableOpsUtils.getFieldName("col_4"),
+            getFieldName("col_4"),
             MapType.of(StringType.get(), IntegerType.get(), true),
             AddColumn.class.getSimpleName(),
             null,
@@ -167,12 +167,11 @@ public class TestTableOpsUtils {
   @Test
   void testupdateColumnComment() {
     assertTableChange(
-        updateColumnComment(
-            TableOpsUtils.getFieldName("col_1"), UpdateColumnComment.class.getSimpleName()),
+        updateColumnComment(getFieldName("col_1"), UpdateColumnComment.class.getSimpleName()),
         UpdateColumnComment.class,
         schemaChange -> {
           UpdateColumnComment updateColumnComment = (UpdateColumnComment) schemaChange;
-          assertEquals("col_1", getfieldName(updateColumnComment.fieldNames()));
+          assertEquals("col_1", getFieldName(updateColumnComment.fieldNames()));
           assertEquals(
               UpdateColumnComment.class.getSimpleName(), updateColumnComment.newDescription());
         });
@@ -181,11 +180,11 @@ public class TestTableOpsUtils {
   @Test
   void testUpdateColumnNullability() {
     assertTableChange(
-        updateColumnNullability(X.getFieldName("col_2"), false),
+        updateColumnNullability(getFieldName("col_2"), false),
         UpdateColumnNullability.class,
         schemaChange -> {
           UpdateColumnNullability updateColumnNullability = (UpdateColumnNullability) schemaChange;
-          assertEquals("col_2", getfieldName(updateColumnNullability.fieldNames()));
+          assertEquals("col_2", getFieldName(updateColumnNullability.fieldNames()));
           assertFalse(updateColumnNullability.newNullability());
         });
   }
@@ -193,7 +192,7 @@ public class TestTableOpsUtils {
   @Test
   void testUpdateColumnType() {
     assertTableChange(
-        updateColumnType(getfieldName("col_4"), DoubleType.get()),
+        updateColumnType(getFieldName("col_4"), DoubleType.get()),
         UpdateColumnType.class,
         schemaChange -> {
           UpdateColumnType updateColumnType = (UpdateColumnType) schemaChange;
@@ -205,7 +204,7 @@ public class TestTableOpsUtils {
   @Test
   void testRenameColumn() {
     assertTableChange(
-        renameColumn(getfieldName("col_1"), "col_5"),
+        renameColumn(getFieldName("col_1"), "col_5"),
         RenameColumn.class,
         schemaChange -> {
           RenameColumn renameColumn = (RenameColumn) schemaChange;
@@ -217,7 +216,7 @@ public class TestTableOpsUtils {
   @Test
   void testDeleteColumn() {
     assertTableChange(
-        deleteColumn(getfieldName("col_2"), true),
+        deleteColumn(getFieldName("col_2"), true),
         DropColumn.class,
         schemaChange -> {
           DropColumn dropColumn = (DropColumn) schemaChange;
@@ -262,7 +261,7 @@ public class TestTableOpsUtils {
   @Test
   void testUpdateColumnPosition() {
     assertTableChange(
-        updateColumnPosition(getfieldName("col_3"), after("col_1")),
+        updateColumnPosition(getFieldName("col_3"), after("col_1")),
         UpdateColumnPosition.class,
         schemaChange -> {
           UpdateColumnPosition updateColumnPosition = (UpdateColumnPosition) schemaChange;
@@ -279,16 +278,16 @@ public class TestTableOpsUtils {
             addIndex(IndexType.UNIQUE_KEY, "uk", new String[][] {{"col_5"}}),
             deleteIndex("uk", true),
             rename("tb_1"),
-            updateColumnAutoIncrement(getfieldName("col_5"), true),
+            updateColumnAutoIncrement(getFieldName("col_5"), true),
             updateColumnDefaultValue(
-                getfieldName("col_5"), Literals.of("default", Types.VarCharType.of(255))))
+                getFieldName("col_5"), Literals.of("default", Types.VarCharType.of(255))))
         .forEach(this::assertUnsupportedTableChange);
 
     // Test IllegalArgumentException with AddColumn default value and auto increment.
     Arrays.asList(
             Pair.of(
                 addColumn(
-                    getfieldName("col_1"),
+                    getFieldName("col_1"),
                     IntegerType.get(),
                     AddColumn.class.getSimpleName(),
                     TableChange.ColumnPosition.first(),
@@ -298,7 +297,7 @@ public class TestTableOpsUtils {
                 "Paimon set column default value through table properties instead of column info. Illegal column: col_1."),
             Pair.of(
                 addColumn(
-                    getfieldName("col_1"),
+                    getFieldName("col_1"),
                     IntegerType.get(),
                     AddColumn.class.getSimpleName(),
                     TableChange.ColumnPosition.first(),

--- a/catalogs/catalog-lakehouse-paimon/src/test/java/org/apache/gravitino/catalog/lakehouse/paimon/utils/TestTableOpsUtils.java
+++ b/catalogs/catalog-lakehouse-paimon/src/test/java/org/apache/gravitino/catalog/lakehouse/paimon/utils/TestTableOpsUtils.java
@@ -78,7 +78,7 @@ public class TestTableOpsUtils {
   void testAddColumnFirst() {
     assertTableChange(
         addColumn(
-            getfieldName("col_1"),
+            TableOpsUtils.getFieldName("col_1"),
             IntegerType.get(),
             AddColumn.class.getSimpleName(),
             TableChange.ColumnPosition.first(),
@@ -102,7 +102,7 @@ public class TestTableOpsUtils {
   void testAddColumnAfter() {
     assertTableChange(
         addColumn(
-            getfieldName("col_2"),
+            TableOpsUtils.getFieldName("col_2"),
             FloatType.get(),
             AddColumn.class.getSimpleName(),
             after("col_1"),
@@ -126,7 +126,7 @@ public class TestTableOpsUtils {
   void testAddColumnDefaultPosition() {
     assertTableChange(
         addColumn(
-            getfieldName("col_3"),
+            TableOpsUtils.getFieldName("col_3"),
             ListType.of(StringType.get(), false),
             AddColumn.class.getSimpleName(),
             defaultPos(),
@@ -147,7 +147,7 @@ public class TestTableOpsUtils {
   void testAddColumnWitNullPosition() {
     assertTableChange(
         addColumn(
-            getfieldName("col_4"),
+            TableOpsUtils.getFieldName("col_4"),
             MapType.of(StringType.get(), IntegerType.get(), true),
             AddColumn.class.getSimpleName(),
             null,
@@ -167,7 +167,8 @@ public class TestTableOpsUtils {
   @Test
   void testupdateColumnComment() {
     assertTableChange(
-        updateColumnComment(getfieldName("col_1"), UpdateColumnComment.class.getSimpleName()),
+        updateColumnComment(
+            TableOpsUtils.getFieldName("col_1"), UpdateColumnComment.class.getSimpleName()),
         UpdateColumnComment.class,
         schemaChange -> {
           UpdateColumnComment updateColumnComment = (UpdateColumnComment) schemaChange;
@@ -180,7 +181,7 @@ public class TestTableOpsUtils {
   @Test
   void testUpdateColumnNullability() {
     assertTableChange(
-        updateColumnNullability(getfieldName("col_2"), false),
+        updateColumnNullability(X.getFieldName("col_2"), false),
         UpdateColumnNullability.class,
         schemaChange -> {
           UpdateColumnNullability updateColumnNullability = (UpdateColumnNullability) schemaChange;


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

fix camelCase method names from `getfieldName` to `getFieldName`


### Why are the changes needed?

`getfieldName` is not standardized in naming


### Does this PR introduce _any_ user-facing change?

none

### How was this patch tested?

TestTableOpsUtils
