### PR TITLE
[MINOR] fix(doc): Fix the binary data type mapping error of the gravitino and paimon tables in the paimon catalog document.

### DIFF
--- a/docs/lakehouse-paimon-catalog.md
+++ b/docs/lakehouse-paimon-catalog.md
@@ -154,28 +154,28 @@ Paimon Table primary key constraint should not be same with partition fields, th
 
 ### Table column types
 
-| Gravitino Type              | Apache Paimon Type             |
-|-----------------------------|--------------------------------|
-| `Struct`                    | `Row`                          |
-| `Map`                       | `Map`                          |
-| `List`                      | `Array`                        |
-| `Boolean`                   | `Boolean`                      |
-| `Byte`                      | `TinyInt`                      |
-| `Short`                     | `SmallInt`                     |
-| `Integer`                   | `Int`                          |
-| `Long`                      | `BigInt`                       |
-| `Float`                     | `Float`                        |
-| `Double`                    | `Double`                       |
-| `Decimal`                   | `Decimal`                      |
-| `String`                    | `VarChar(Integer.MAX_VALUE)`   |
-| `VarChar`                   | `VarChar`                      |
-| `FixedChar`                 | `Char`                         |
-| `Date`                      | `Date`                         |
-| `Time`                      | `Time`                         |
-| `TimestampType withZone`    | `LocalZonedTimestamp`          |
-| `TimestampType withoutZone` | `Timestamp`                    |
-| `Binary`                    | `Binary`                       |
-| `Fixed`                     | `VarBinary`                    |
+| Gravitino Type              | Apache Paimon Type           |
+|-----------------------------|------------------------------|
+| `Struct`                    | `Row`                        |
+| `Map`                       | `Map`                        |
+| `List`                      | `Array`                      |
+| `Boolean`                   | `Boolean`                    |
+| `Byte`                      | `TinyInt`                    |
+| `Short`                     | `SmallInt`                   |
+| `Integer`                   | `Int`                        |
+| `Long`                      | `BigInt`                     |
+| `Float`                     | `Float`                      |
+| `Double`                    | `Double`                     |
+| `Decimal`                   | `Decimal`                    |
+| `String`                    | `VarChar(Integer.MAX_VALUE)` |
+| `VarChar`                   | `VarChar`                    |
+| `FixedChar`                 | `Char`                       |
+| `Date`                      | `Date`                       |
+| `Time`                      | `Time`                       |
+| `TimestampType withZone`    | `LocalZonedTimestamp`        |
+| `TimestampType withoutZone` | `Timestamp`                  |
+| `Fixed`                     | `Binary`                     |
+| `Binary`                    | `VarBinary`                  |
 
 :::info
 Gravitino doesn't support Paimon `MultisetType` type.


### PR DESCRIPTION


<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

 Fix the binary data type mapping error of the gravitino and paimon tables in the paimon catalog document.

