### PR TITLE
[#5683] Improvement: Remove gravitino-web-*.jar from Gravitino release files

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -804,7 +804,7 @@ tasks {
         it.name != "bundled-catalog" &&
         it.name != "hive-metastore-common" && it.name != "gcp-bundle" &&
         it.name != "aliyun-bundle" && it.name != "aws-bundle" && it.name != "azure-bundle" &&
-        it.name != "docs"
+        it.name != "docs" && it.name != "web"
       ) {
         dependsOn("${it.name}:build")
         from("${it.name}/build/libs")


### PR DESCRIPTION


### Why are the changes needed?

close #5683 

### Does this PR introduce _any_ user-facing change?

None

### How was this patch tested?

Using following command
`./gradlew compileDistribution -x test -x :docs:lintOpenAPI`