### PR TITLE
[#5585] fix(hadoop-catalog): Support multiple hadoop versions in runtime and add jars files into resources directory.

### DIFF
--- a/bundles/aws-bundle/build.gradle.kts
+++ b/bundles/aws-bundle/build.gradle.kts
@@ -127,3 +127,16 @@ tasks.jar {
 tasks.compileJava {
   dependsOn(":catalogs:catalog-hadoop:runtimeJars")
 }
+
+// This is to fix the problem:
+/**
+Reason: Task ':bundles:aws-bundle:javadoc' uses this output of task ':bundles:aws-bundle:copyHadoop2_10' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed.
+
+Possible solutions:
+1. Declare task ':bundles:aws-bundle:copyHadoop2_10' as an input of ':bundles:aws-bundle:javadoc'.
+2. Declare an explicit dependency on ':bundles:aws-bundle:copyHadoop2_10' from ':bundles:aws-bundle:javadoc' using Task#dependsOn.
+3. Declare an explicit dependency on ':bundles:aws-bundle:copyHadoop2_10' from ':bundles:aws-bundle:javadoc' using Task#mustRunAfter
+*/
+tasks.javadoc {
+  dependsOn("copyHadoop3_3", "copyHadoop2_7", "copyHadoop2_10")
+}

--- a/bundles/aws-bundle/build.gradle.kts
+++ b/bundles/aws-bundle/build.gradle.kts
@@ -44,7 +44,7 @@ tasks.register<Copy>("copyHadoop2_7") {
   dependsOn(":catalogs:catalog-hadoop:runtimeJars")
 
   val commonsLang3Dependency = libs.commons.lang3.get()
-  val hadoopAWSDependencies = libs.hadoop2.aws.old.get()
+  val hadoopAWSDependencies = libs.hadoop207.aws.get()
 
   val hadoopDependenciesFor2_7 = configurations.detachedConfiguration(
     dependencies.create("${hadoopAWSDependencies.group}:${hadoopAWSDependencies.name}:${hadoopAWSDependencies.version}"),
@@ -68,7 +68,7 @@ tasks.register<Copy>("copyHadoop2_10") {
 
   val commonsLangDependency = libs.commons.lang.get()
   val commonsLang3Dependency = libs.commons.lang3.get()
-  val hadoopAWSDependencies = libs.hadoop3.aws.get()
+  val hadoopAWSDependencies = libs.hadoop210.aws.get()
 
   val hadoopDependenciesFor2_10 = configurations.detachedConfiguration(
     dependencies.create("${hadoopAWSDependencies.group}:${hadoopAWSDependencies.name}:${hadoopAWSDependencies.version}"),

--- a/bundles/aws-bundle/src/main/java/org/apache/gravitino/s3/fs/S3FileSystemProvider.java
+++ b/bundles/aws-bundle/src/main/java/org/apache/gravitino/s3/fs/S3FileSystemProvider.java
@@ -30,9 +30,10 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.s3a.Constants;
-import org.apache.hadoop.fs.s3a.S3AFileSystem;
+import org.apache.hadoop.util.VersionInfo;
 
 public class S3FileSystemProvider implements FileSystemProvider {
+  private static VersionedClassLoader versionedClassLoader;
 
   @VisibleForTesting
   public static final Map<String, String> GRAVITINO_KEY_TO_S3_HADOOP_KEY =
@@ -41,18 +42,49 @@ public class S3FileSystemProvider implements FileSystemProvider {
           S3Properties.GRAVITINO_S3_ACCESS_KEY_ID, Constants.ACCESS_KEY,
           S3Properties.GRAVITINO_S3_SECRET_ACCESS_KEY, Constants.SECRET_KEY);
 
+  // We can't use Constants.AWS_CREDENTIALS_PROVIDER as in 2.7, this key does not exist.
+  private static final String S3_CREDENTIAL_KEY = "fs.s3a.aws.credentials.provider";
+  private static final String S3_SIMPLE_CREDENTIAL =
+      "org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider";
+
   @Override
   public FileSystem getFileSystem(Path path, Map<String, String> config) throws IOException {
-    Configuration configuration = new Configuration();
-    Map<String, String> hadoopConfMap =
-        FileSystemUtils.toHadoopConfigMap(config, GRAVITINO_KEY_TO_S3_HADOOP_KEY);
 
-    if (!hadoopConfMap.containsKey(Constants.AWS_CREDENTIALS_PROVIDER)) {
-      configuration.set(
-          Constants.AWS_CREDENTIALS_PROVIDER, Constants.ASSUMED_ROLE_CREDENTIALS_DEFAULT);
+    try {
+      String hadoopVersion = VersionInfo.getVersion();
+      if (versionedClassLoader == null) {
+        versionedClassLoader = VersionedClassLoader.loadVersion(hadoopVersion);
+      }
+
+      ClassLoader oldClassLoader = Thread.currentThread().getContextClassLoader();
+      try {
+        Thread.currentThread().setContextClassLoader(versionedClassLoader);
+        Configuration configuration = new Configuration();
+        Map<String, String> hadoopConfMap =
+            FileSystemUtils.toHadoopConfigMap(config, GRAVITINO_KEY_TO_S3_HADOOP_KEY);
+
+        if (!hadoopConfMap.containsKey(S3_CREDENTIAL_KEY)) {
+          hadoopConfMap.put(S3_CREDENTIAL_KEY, S3_SIMPLE_CREDENTIAL);
+        }
+
+        hadoopConfMap.forEach(configuration::set);
+
+        // Hadoop-aws 2 does not support IAMInstanceCredentialsProvider
+        if (configuration.get(S3_CREDENTIAL_KEY) != null
+            && versionedClassLoader.getVersion().startsWith("hadoop2")
+            && configuration.get(S3_CREDENTIAL_KEY).contains("IAMInstanceCredentialsProvider")) {
+          configuration.set(S3_CREDENTIAL_KEY, S3_SIMPLE_CREDENTIAL);
+        }
+
+        return FileSystem.newInstance(path.toUri(), configuration);
+      } finally {
+        Thread.currentThread().setContextClassLoader(oldClassLoader);
+      }
+    } catch (ClassNotFoundException e) {
+      throw new IOException("Failed to load the Hadoop versioned class loader", e);
+    } catch (Exception e) {
+      throw new IOException("Failed to create the S3AFileSystem instance", e);
     }
-    hadoopConfMap.forEach(configuration::set);
-    return S3AFileSystem.newInstance(path.toUri(), configuration);
   }
 
   /**

--- a/bundles/aws-bundle/src/main/java/org/apache/gravitino/s3/fs/VersionedClassLoader.java
+++ b/bundles/aws-bundle/src/main/java/org/apache/gravitino/s3/fs/VersionedClassLoader.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.s3.fs;
+
+import com.google.common.collect.Lists;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Files;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+import org.apache.commons.io.IOUtils;
+
+public class VersionedClassLoader extends URLClassLoader {
+
+  private String version;
+
+  public VersionedClassLoader(URL[] urls, ClassLoader parent, String version) {
+    super(urls, parent);
+    this.version = version;
+  }
+
+  public String getVersion() {
+    return version;
+  }
+
+  public void setVersion(String version) {
+    this.version = version;
+  }
+
+  public static VersionedClassLoader loadVersion(String version) throws Exception {
+
+    // Default version 3.3 if the version is not provided
+    String hadoopVersion = "hadoop3_3";
+    String[] versionNumber = version.split("\\.");
+    if (versionNumber.length < 2 || versionNumber.length > 3) {
+      // Users may custom the version, so we need to handle the case that the version is not x.x
+      URL[] urls = loadFile(hadoopVersion);
+      return new VersionedClassLoader(
+          urls, VersionedClassLoader.class.getClassLoader(), hadoopVersion);
+    }
+
+    int mainVersion = Integer.parseInt(versionNumber[0]);
+    int subVersion = Integer.parseInt(versionNumber[1]);
+    int lastVersion = versionNumber.length == 3 ? Integer.parseInt(versionNumber[2]) : -1;
+
+    // Version < 2.10 will use hadoop2_7, version >= 3.3.1 will use hadoop3_3 and others
+    // Use hadoop2_10
+    if (mainVersion == 2 && subVersion < 10) {
+      hadoopVersion = "hadoop2_7";
+    } else if (mainVersion == 3 && ((subVersion == 3 && lastVersion > 0) || subVersion > 3)) {
+      hadoopVersion = "hadoop3_3";
+    } else {
+      hadoopVersion = "hadoop2_10";
+    }
+
+    URL[] urls = loadFile(hadoopVersion);
+    return new VersionedClassLoader(
+        urls, VersionedClassLoader.class.getClassLoader(), hadoopVersion);
+  }
+
+  public static URL[] loadFile(String hadoopVersion) {
+    try {
+      ClassLoader classLoader = VersionedClassLoader.class.getClassLoader();
+
+      String className = VersionedClassLoader.class.getName().replace('.', '/') + ".class";
+      URL classUrl = classLoader.getResource(className);
+
+      if (classUrl == null) {
+        throw new RuntimeException("Class resource not found!");
+      }
+
+      List<URL> list = Lists.newArrayList();
+      if (classUrl.getProtocol().equals("jar")) {
+        String jarFilePath = classUrl.getFile().substring(5, classUrl.getFile().indexOf("!"));
+
+        JarFile jarFile = new JarFile(jarFilePath);
+
+        Enumeration<JarEntry> entries = jarFile.entries();
+        while (entries.hasMoreElements()) {
+          JarEntry entry = entries.nextElement();
+          if (entry.getName().startsWith(hadoopVersion) && entry.getName().endsWith(".jar.zip")) {
+            InputStream inputStream = jarFile.getInputStream(entry);
+            File tempFile = File.createTempFile(entry.getName(), ".jar");
+            IOUtils.copy(inputStream, Files.newOutputStream(tempFile.toPath()));
+            list.add(tempFile.toURI().toURL());
+          }
+        }
+
+        jarFile.close();
+        return list.toArray(new URL[0]);
+      } else {
+        throw new RuntimeException("Unsupported protocol: " + classUrl.getProtocol());
+      }
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/catalogs/catalog-hadoop/build.gradle.kts
+++ b/catalogs/catalog-hadoop/build.gradle.kts
@@ -94,6 +94,7 @@ dependencies {
   testImplementation(libs.junit.jupiter.params)
   testImplementation(libs.testcontainers)
   testImplementation(libs.testcontainers.mysql)
+  testImplementation(libs.hadoop3.aws)
   testImplementation(libs.hadoop3.gcs)
 
   testRuntimeOnly(libs.junit.jupiter.engine)

--- a/catalogs/catalog-hive/build.gradle.kts
+++ b/catalogs/catalog-hive/build.gradle.kts
@@ -128,7 +128,7 @@ dependencies {
   testImplementation(libs.testcontainers)
   testImplementation(libs.testcontainers.mysql)
   testImplementation(libs.testcontainers.localstack)
-  testImplementation(libs.hadoop2.aws)
+  testImplementation(libs.hadoop210.aws)
   testImplementation(libs.hadoop3.abs)
 
   // You need this to run test CatalogHiveABSIT as it required hadoop3 environment introduced by hadoop3.abs

--- a/clients/filesystem-hadoop3-runtime/build.gradle.kts
+++ b/clients/filesystem-hadoop3-runtime/build.gradle.kts
@@ -28,6 +28,7 @@ plugins {
 dependencies {
   implementation(project(":clients:filesystem-hadoop3"))
   implementation(project(":clients:client-java-runtime", configuration = "shadow"))
+  implementation(libs.commons.lang3)
 }
 
 tasks.withType<ShadowJar>(ShadowJar::class.java) {
@@ -38,6 +39,7 @@ tasks.withType<ShadowJar>(ShadowJar::class.java) {
   // Relocate dependencies to avoid conflicts
   relocate("com.google", "org.apache.gravitino.shaded.com.google")
   relocate("com.github.benmanes.caffeine", "org.apache.gravitino.shaded.com.github.benmanes.caffeine")
+  relocate("org.apache.commons.lang3", "org.apache.gravitino.shaded.org.apache.commons.lang3")
 }
 
 tasks.jar {

--- a/clients/filesystem-hadoop3/build.gradle.kts
+++ b/clients/filesystem-hadoop3/build.gradle.kts
@@ -75,6 +75,7 @@ dependencies {
   }
   testImplementation(libs.mysql.driver)
   testImplementation(libs.postgresql.driver)
+  testImplementation(libs.hadoop3.aws)
   testRuntimeOnly(libs.junit.jupiter.engine)
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,11 +32,12 @@ airlift-json = "237"
 airlift-resolver = "1.6"
 hive2 = "2.3.9"
 hadoop2 = "2.10.2"
-hadoop3 = "3.3.0"
+hadoop2-aws-old = "2.7.7"
+hadoop3 = "3.3.1"
 hadoop3-gcs = "1.9.4-hadoop3"
-hadoop3-abs = "3.3.0"
-hadoop3-aliyun = "3.3.0"
-hadoop-minikdc = "3.3.0"
+hadoop3-abs = "3.3.1"
+hadoop3-aliyun = "3.3.1"
+hadoop-minikdc = "3.3.1"
 htrace-core4 = "4.1.0-incubating"
 httpclient5 = "5.2.1"
 mockserver = "5.15.0"
@@ -164,6 +165,7 @@ hadoop2-hdfs-client = { group = "org.apache.hadoop", name = "hadoop-hdfs-client"
 hadoop2-common = { group = "org.apache.hadoop", name = "hadoop-common", version.ref = "hadoop2"}
 hadoop2-mapreduce-client-core = { group = "org.apache.hadoop", name = "hadoop-mapreduce-client-core", version.ref = "hadoop2"}
 hadoop2-aws = { group = "org.apache.hadoop", name = "hadoop-aws", version.ref = "hadoop2"}
+hadoop2-aws-old = { group = "org.apache.hadoop", name = "hadoop-aws", version.ref = "hadoop2-aws-old"}
 hadoop3-aws = { group = "org.apache.hadoop", name = "hadoop-aws", version.ref = "hadoop3"}
 hadoop3-hdfs = { group = "org.apache.hadoop", name = "hadoop-hdfs", version.ref = "hadoop3" }
 hadoop3-common = { group = "org.apache.hadoop", name = "hadoop-common", version.ref = "hadoop3"}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,7 +32,7 @@ airlift-json = "237"
 airlift-resolver = "1.6"
 hive2 = "2.3.9"
 hadoop2 = "2.10.2"
-hadoop2-aws-old = "2.7.7"
+hadoop207-aws = "2.7.7"
 hadoop3 = "3.3.1"
 hadoop3-gcs = "1.9.4-hadoop3"
 hadoop3-abs = "3.3.1"
@@ -164,8 +164,8 @@ hadoop2-hdfs = { group = "org.apache.hadoop", name = "hadoop-hdfs", version.ref 
 hadoop2-hdfs-client = { group = "org.apache.hadoop", name = "hadoop-hdfs-client", version.ref = "hadoop2" }
 hadoop2-common = { group = "org.apache.hadoop", name = "hadoop-common", version.ref = "hadoop2"}
 hadoop2-mapreduce-client-core = { group = "org.apache.hadoop", name = "hadoop-mapreduce-client-core", version.ref = "hadoop2"}
-hadoop2-aws = { group = "org.apache.hadoop", name = "hadoop-aws", version.ref = "hadoop2"}
-hadoop2-aws-old = { group = "org.apache.hadoop", name = "hadoop-aws", version.ref = "hadoop2-aws-old"}
+hadoop210-aws = { group = "org.apache.hadoop", name = "hadoop-aws", version.ref = "hadoop2"}
+hadoop207-aws = { group = "org.apache.hadoop", name = "hadoop-aws", version.ref = "hadoop207-aws"}
 hadoop3-aws = { group = "org.apache.hadoop", name = "hadoop-aws", version.ref = "hadoop3"}
 hadoop3-hdfs = { group = "org.apache.hadoop", name = "hadoop-hdfs", version.ref = "hadoop3" }
 hadoop3-common = { group = "org.apache.hadoop", name = "hadoop-common", version.ref = "hadoop3"}


### PR DESCRIPTION
### What changes were proposed in this pull request?

1. Do not shade hadoop-aws in the jar but replace it in the resource jar.
2. Support multiple hadoop version in the runtime.

### Why are the changes needed?

To support more version.

Fix: #5585 

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

Test locally and existing test. 
