### PR TITLE
[#5772] fix: missing param <T>

### DIFF
--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/Command.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/Command.java
@@ -151,6 +151,7 @@ public abstract class Command {
    * Outputs the entity to the console.
    *
    * @param entity The entity to output.
+   * @param <T> The type of entity.
    */
   protected <T> void output(T entity) {
     if (outputFormat == null) {


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Missing param `<T>` is added to the `output` method of `Command.java`.

### Why are the changes needed?

Fix: https://github.com/apache/gravitino/issues/5772

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?
To verify, please run the following command:
```
./gradlew clean build -x test
```
After running this command, the warning `no @param for <T>` will no longer appear.
