### PR TITLE
[#5754] improve(build): Fix rewrite_config.py with the correct shebang line

### DIFF
--- a/dev/docker/iceberg-rest-server/rewrite_config.py
+++ b/dev/docker/iceberg-rest-server/rewrite_config.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env 
+#!/usr/bin/env bash
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information


### PR DESCRIPTION

<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

modified:
- __dev/docker/iceberg-rest-server/rewrite_config.py__

Correct the shebang line to specify the correct shell `bash`
```bash
#!/usr/bin/env bash
```
<br>

### Why are the changes needed?

The `env` command should be assigned an interpreter like `bash` or `python`. 
<br>

### Does this PR introduce _any_ user-facing change?

No.
<br>

### How was this patch tested?
Although we usually execute this script with the Python interpreter (for example: `python rewrite_config.py`) rather than executing it without an interpreter, with the fix applied, executing this script without an interpreter will no longer result in a hang.

