### PR TITLE
[#5784] improvement(catalog) Modify the ColumnSize/Scale of JdbcTypeBean to be of type integer. 

### DIFF
--- a/catalogs/catalog-jdbc-common/src/main/java/org/apache/gravitino/catalog/jdbc/converter/JdbcTypeConverter.java
+++ b/catalogs/catalog-jdbc-common/src/main/java/org/apache/gravitino/catalog/jdbc/converter/JdbcTypeConverter.java
@@ -35,10 +35,10 @@ public abstract class JdbcTypeConverter
     private String typeName;
 
     /** Column size. For example: 20 in varchar (20) and 10 in decimal (10,2). */
-    private String columnSize;
+    private Integer columnSize;
 
     /** Scale. For example: 2 in decimal (10,2). */
-    private String scale;
+    private Integer scale;
 
     public JdbcTypeBean(String typeName) {
       this.typeName = typeName;
@@ -52,19 +52,19 @@ public abstract class JdbcTypeConverter
       this.typeName = typeName;
     }
 
-    public String getColumnSize() {
+    public Integer getColumnSize() {
       return columnSize;
     }
 
-    public void setColumnSize(String columnSize) {
+    public void setColumnSize(Integer columnSize) {
       this.columnSize = columnSize;
     }
 
-    public String getScale() {
+    public Integer getScale() {
       return scale;
     }
 
-    public void setScale(String scale) {
+    public void setScale(Integer scale) {
       this.scale = scale;
     }
 

--- a/catalogs/catalog-jdbc-common/src/main/java/org/apache/gravitino/catalog/jdbc/operation/JdbcTableOperations.java
+++ b/catalogs/catalog-jdbc-common/src/main/java/org/apache/gravitino/catalog/jdbc/operation/JdbcTableOperations.java
@@ -587,8 +587,8 @@ public abstract class JdbcTableOperations implements TableOperation {
   protected JdbcColumn.Builder getBasicJdbcColumnInfo(ResultSet column) throws SQLException {
     JdbcTypeConverter.JdbcTypeBean typeBean =
         new JdbcTypeConverter.JdbcTypeBean(column.getString("TYPE_NAME"));
-    typeBean.setColumnSize(column.getString("COLUMN_SIZE"));
-    typeBean.setScale(column.getString("DECIMAL_DIGITS"));
+    typeBean.setColumnSize(column.getInt("COLUMN_SIZE"));
+    typeBean.setScale(column.getInt("DECIMAL_DIGITS"));
     String comment = column.getString("REMARKS");
     boolean nullable = column.getBoolean("NULLABLE");
 

--- a/catalogs/catalog-jdbc-doris/src/main/java/org/apache/gravitino/catalog/doris/converter/DorisColumnDefaultValueConverter.java
+++ b/catalogs/catalog-jdbc-doris/src/main/java/org/apache/gravitino/catalog/doris/converter/DorisColumnDefaultValueConverter.java
@@ -81,10 +81,7 @@ public class DorisColumnDefaultValueConverter extends JdbcColumnDefaultValueConv
         return Literals.doubleLiteral(Double.valueOf(columnDefaultValue));
       case DECIMAL:
         return Literals.decimalLiteral(
-            Decimal.of(
-                columnDefaultValue,
-                Integer.parseInt(columnType.getColumnSize()),
-                Integer.parseInt(columnType.getScale())));
+            Decimal.of(columnDefaultValue, columnType.getColumnSize(), columnType.getScale()));
       case JdbcTypeConverter.DATE:
         return Literals.dateLiteral(LocalDate.parse(columnDefaultValue, DATE_TIME_FORMATTER));
       case JdbcTypeConverter.TIME:
@@ -96,12 +93,9 @@ public class DorisColumnDefaultValueConverter extends JdbcColumnDefaultValueConv
             : Literals.timestampLiteral(
                 LocalDateTime.parse(columnDefaultValue, DATE_TIME_FORMATTER));
       case JdbcTypeConverter.VARCHAR:
-        return Literals.of(
-            columnDefaultValue, Types.VarCharType.of(Integer.parseInt(columnType.getColumnSize())));
+        return Literals.of(columnDefaultValue, Types.VarCharType.of(columnType.getColumnSize()));
       case CHAR:
-        return Literals.of(
-            columnDefaultValue,
-            Types.FixedCharType.of(Integer.parseInt(columnType.getColumnSize())));
+        return Literals.of(columnDefaultValue, Types.FixedCharType.of(columnType.getColumnSize()));
       case JdbcTypeConverter.TEXT:
         return Literals.stringLiteral(columnDefaultValue);
       default:

--- a/catalogs/catalog-jdbc-doris/src/main/java/org/apache/gravitino/catalog/doris/converter/DorisTypeConverter.java
+++ b/catalogs/catalog-jdbc-doris/src/main/java/org/apache/gravitino/catalog/doris/converter/DorisTypeConverter.java
@@ -54,16 +54,15 @@ public class DorisTypeConverter extends JdbcTypeConverter {
       case DOUBLE:
         return Types.DoubleType.get();
       case DECIMAL:
-        return Types.DecimalType.of(
-            Integer.parseInt(typeBean.getColumnSize()), Integer.parseInt(typeBean.getScale()));
+        return Types.DecimalType.of(typeBean.getColumnSize(), typeBean.getScale());
       case DATE:
         return Types.DateType.get();
       case DATETIME:
         return Types.TimestampType.withoutTimeZone();
       case CHAR:
-        return Types.FixedCharType.of(Integer.parseInt(typeBean.getColumnSize()));
+        return Types.FixedCharType.of(typeBean.getColumnSize());
       case VARCHAR:
-        return Types.VarCharType.of(Integer.parseInt(typeBean.getColumnSize()));
+        return Types.VarCharType.of(typeBean.getColumnSize());
       case STRING:
       case TEXT:
         return Types.StringType.get();

--- a/catalogs/catalog-jdbc-doris/src/main/java/org/apache/gravitino/catalog/doris/operation/DorisTablePartitionOperations.java
+++ b/catalogs/catalog-jdbc-doris/src/main/java/org/apache/gravitino/catalog/doris/operation/DorisTablePartitionOperations.java
@@ -285,8 +285,8 @@ public final class DorisTablePartitionOperations extends JdbcTablePartitionOpera
         if (Objects.equals(result.getString("TABLE_NAME"), loadedTable.name())) {
           JdbcTypeConverter.JdbcTypeBean typeBean =
               new JdbcTypeConverter.JdbcTypeBean(result.getString("TYPE_NAME"));
-          typeBean.setColumnSize(result.getString("COLUMN_SIZE"));
-          typeBean.setScale(result.getString("DECIMAL_DIGITS"));
+          typeBean.setColumnSize(result.getInt("COLUMN_SIZE"));
+          typeBean.setScale(result.getInt("DECIMAL_DIGITS"));
           Type gravitinoType = typeConverter.toGravitino(typeBean);
           String columnName = result.getString("COLUMN_NAME");
           columnTypes.put(columnName, gravitinoType);

--- a/catalogs/catalog-jdbc-mysql/src/main/java/org/apache/gravitino/catalog/mysql/converter/MysqlColumnDefaultValueConverter.java
+++ b/catalogs/catalog-jdbc-mysql/src/main/java/org/apache/gravitino/catalog/mysql/converter/MysqlColumnDefaultValueConverter.java
@@ -80,10 +80,7 @@ public class MysqlColumnDefaultValueConverter extends JdbcColumnDefaultValueConv
         return Literals.doubleLiteral(Double.valueOf(columnDefaultValue));
       case MysqlTypeConverter.DECIMAL:
         return Literals.decimalLiteral(
-            Decimal.of(
-                columnDefaultValue,
-                Integer.parseInt(type.getColumnSize()),
-                Integer.parseInt(type.getScale())));
+            Decimal.of(columnDefaultValue, type.getColumnSize(), type.getScale()));
       case JdbcTypeConverter.DATE:
         return Literals.dateLiteral(LocalDate.parse(columnDefaultValue, DATE_FORMATTER));
       case JdbcTypeConverter.TIME:
@@ -95,11 +92,9 @@ public class MysqlColumnDefaultValueConverter extends JdbcColumnDefaultValueConv
             : Literals.timestampLiteral(
                 LocalDateTime.parse(columnDefaultValue, DATE_TIME_FORMATTER));
       case JdbcTypeConverter.VARCHAR:
-        return Literals.of(
-            columnDefaultValue, Types.VarCharType.of(Integer.parseInt(type.getColumnSize())));
+        return Literals.of(columnDefaultValue, Types.VarCharType.of(type.getColumnSize()));
       case MysqlTypeConverter.CHAR:
-        return Literals.of(
-            columnDefaultValue, Types.FixedCharType.of(Integer.parseInt(type.getColumnSize())));
+        return Literals.of(columnDefaultValue, Types.FixedCharType.of(type.getColumnSize()));
       case JdbcTypeConverter.TEXT:
         return Literals.stringLiteral(columnDefaultValue);
       default:

--- a/catalogs/catalog-jdbc-mysql/src/main/java/org/apache/gravitino/catalog/mysql/converter/MysqlTypeConverter.java
+++ b/catalogs/catalog-jdbc-mysql/src/main/java/org/apache/gravitino/catalog/mysql/converter/MysqlTypeConverter.java
@@ -76,12 +76,11 @@ public class MysqlTypeConverter extends JdbcTypeConverter {
       case DATETIME:
         return Types.TimestampType.withoutTimeZone();
       case DECIMAL:
-        return Types.DecimalType.of(
-            Integer.parseInt(typeBean.getColumnSize()), Integer.parseInt(typeBean.getScale()));
+        return Types.DecimalType.of(typeBean.getColumnSize(), typeBean.getScale());
       case VARCHAR:
-        return Types.VarCharType.of(Integer.parseInt(typeBean.getColumnSize()));
+        return Types.VarCharType.of(typeBean.getColumnSize());
       case CHAR:
-        return Types.FixedCharType.of(Integer.parseInt(typeBean.getColumnSize()));
+        return Types.FixedCharType.of(typeBean.getColumnSize());
       case TEXT:
         return Types.StringType.get();
       case BINARY:

--- a/catalogs/catalog-jdbc-mysql/src/test/java/org/apache/gravitino/catalog/mysql/converter/TestMysqlTypeConverter.java
+++ b/catalogs/catalog-jdbc-mysql/src/test/java/org/apache/gravitino/catalog/mysql/converter/TestMysqlTypeConverter.java
@@ -56,9 +56,9 @@ public class TestMysqlTypeConverter {
     checkJdbcTypeToGravitinoType(Types.TimeType.get(), TIME, null, null);
     checkJdbcTypeToGravitinoType(Types.TimestampType.withoutTimeZone(), DATETIME, null, null);
     checkJdbcTypeToGravitinoType(Types.TimestampType.withTimeZone(), TIMESTAMP, null, null);
-    checkJdbcTypeToGravitinoType(Types.DecimalType.of(10, 2), DECIMAL, "10", "2");
-    checkJdbcTypeToGravitinoType(Types.VarCharType.of(20), VARCHAR, "20", null);
-    checkJdbcTypeToGravitinoType(Types.FixedCharType.of(20), CHAR, "20", null);
+    checkJdbcTypeToGravitinoType(Types.DecimalType.of(10, 2), DECIMAL, 10, 2);
+    checkJdbcTypeToGravitinoType(Types.VarCharType.of(20), VARCHAR, 20, null);
+    checkJdbcTypeToGravitinoType(Types.FixedCharType.of(20), CHAR, 20, null);
     checkJdbcTypeToGravitinoType(Types.StringType.get(), TEXT, null, null);
     checkJdbcTypeToGravitinoType(Types.BinaryType.get(), BINARY, null, null);
     checkJdbcTypeToGravitinoType(
@@ -92,13 +92,13 @@ public class TestMysqlTypeConverter {
   }
 
   protected void checkJdbcTypeToGravitinoType(
-      Type gravitinoType, String jdbcTypeName, String columnSize, String scale) {
+      Type gravitinoType, String jdbcTypeName, Integer columnSize, Integer scale) {
     JdbcTypeConverter.JdbcTypeBean typeBean = createTypeBean(jdbcTypeName, columnSize, scale);
     Assertions.assertEquals(gravitinoType, MYSQL_TYPE_CONVERTER.toGravitino(typeBean));
   }
 
   protected static JdbcTypeConverter.JdbcTypeBean createTypeBean(
-      String typeName, String columnSize, String scale) {
+      String typeName, Integer columnSize, Integer scale) {
     return new JdbcTypeConverter.JdbcTypeBean(typeName) {
       {
         setColumnSize(columnSize);

--- a/catalogs/catalog-jdbc-oceanbase/src/main/java/org/apache/gravitino/catalog/oceanbase/converter/OceanBaseColumnDefaultValueConverter.java
+++ b/catalogs/catalog-jdbc-oceanbase/src/main/java/org/apache/gravitino/catalog/oceanbase/converter/OceanBaseColumnDefaultValueConverter.java
@@ -88,10 +88,7 @@ public class OceanBaseColumnDefaultValueConverter extends JdbcColumnDefaultValue
       case OceanBaseTypeConverter.NUMERIC:
       case OceanBaseTypeConverter.DECIMAL:
         return Literals.decimalLiteral(
-            Decimal.of(
-                columnDefaultValue,
-                Integer.parseInt(type.getColumnSize()),
-                Integer.parseInt(type.getScale())));
+            Decimal.of(columnDefaultValue, type.getColumnSize(), type.getScale()));
       case JdbcTypeConverter.DATE:
         return Literals.dateLiteral(LocalDate.parse(columnDefaultValue, DATE_FORMATTER));
       case JdbcTypeConverter.TIME:
@@ -103,11 +100,9 @@ public class OceanBaseColumnDefaultValueConverter extends JdbcColumnDefaultValue
             : Literals.timestampLiteral(
                 LocalDateTime.parse(columnDefaultValue, DATE_TIME_FORMATTER));
       case JdbcTypeConverter.VARCHAR:
-        return Literals.of(
-            columnDefaultValue, Types.VarCharType.of(Integer.parseInt(type.getColumnSize())));
+        return Literals.of(columnDefaultValue, Types.VarCharType.of(type.getColumnSize()));
       case OceanBaseTypeConverter.CHAR:
-        return Literals.of(
-            columnDefaultValue, Types.FixedCharType.of(Integer.parseInt(type.getColumnSize())));
+        return Literals.of(columnDefaultValue, Types.FixedCharType.of(type.getColumnSize()));
       case JdbcTypeConverter.TEXT:
         return Literals.stringLiteral(columnDefaultValue);
       default:

--- a/catalogs/catalog-jdbc-oceanbase/src/main/java/org/apache/gravitino/catalog/oceanbase/converter/OceanBaseTypeConverter.java
+++ b/catalogs/catalog-jdbc-oceanbase/src/main/java/org/apache/gravitino/catalog/oceanbase/converter/OceanBaseTypeConverter.java
@@ -76,12 +76,11 @@ public class OceanBaseTypeConverter extends JdbcTypeConverter {
       case NUMBER:
       case NUMERIC:
       case DECIMAL:
-        return Types.DecimalType.of(
-            Integer.parseInt(typeBean.getColumnSize()), Integer.parseInt(typeBean.getScale()));
+        return Types.DecimalType.of(typeBean.getColumnSize(), typeBean.getScale());
       case VARCHAR:
-        return Types.VarCharType.of(Integer.parseInt(typeBean.getColumnSize()));
+        return Types.VarCharType.of(typeBean.getColumnSize());
       case CHAR:
-        return Types.FixedCharType.of(Integer.parseInt(typeBean.getColumnSize()));
+        return Types.FixedCharType.of(typeBean.getColumnSize());
       case TEXT:
         return Types.StringType.get();
       case BINARY:

--- a/catalogs/catalog-jdbc-oceanbase/src/test/java/org/apache/gravitino/catalog/oceanbase/converter/TestOceanBaseTypeConverter.java
+++ b/catalogs/catalog-jdbc-oceanbase/src/test/java/org/apache/gravitino/catalog/oceanbase/converter/TestOceanBaseTypeConverter.java
@@ -59,9 +59,9 @@ public class TestOceanBaseTypeConverter {
     checkJdbcTypeToGravitinoType(Types.TimeType.get(), TIME, null, null);
     checkJdbcTypeToGravitinoType(Types.TimestampType.withoutTimeZone(), DATETIME, null, null);
     checkJdbcTypeToGravitinoType(Types.TimestampType.withTimeZone(), TIMESTAMP, null, null);
-    checkJdbcTypeToGravitinoType(Types.DecimalType.of(10, 2), DECIMAL, "10", "2");
-    checkJdbcTypeToGravitinoType(Types.VarCharType.of(20), VARCHAR, "20", null);
-    checkJdbcTypeToGravitinoType(Types.FixedCharType.of(20), CHAR, "20", null);
+    checkJdbcTypeToGravitinoType(Types.DecimalType.of(10, 2), DECIMAL, 10, 2);
+    checkJdbcTypeToGravitinoType(Types.VarCharType.of(20), VARCHAR, 20, null);
+    checkJdbcTypeToGravitinoType(Types.FixedCharType.of(20), CHAR, 20, null);
     checkJdbcTypeToGravitinoType(Types.StringType.get(), TEXT, null, null);
     checkJdbcTypeToGravitinoType(Types.BinaryType.get(), BINARY, null, null);
     checkJdbcTypeToGravitinoType(
@@ -95,13 +95,13 @@ public class TestOceanBaseTypeConverter {
   }
 
   protected void checkJdbcTypeToGravitinoType(
-      Type gravitinoType, String jdbcTypeName, String columnSize, String scale) {
+      Type gravitinoType, String jdbcTypeName, Integer columnSize, Integer scale) {
     JdbcTypeConverter.JdbcTypeBean typeBean = createTypeBean(jdbcTypeName, columnSize, scale);
     Assertions.assertEquals(gravitinoType, OCEANBASE_TYPE_CONVERTER.toGravitino(typeBean));
   }
 
   protected static JdbcTypeConverter.JdbcTypeBean createTypeBean(
-      String typeName, String columnSize, String scale) {
+      String typeName, Integer columnSize, Integer scale) {
     return new JdbcTypeConverter.JdbcTypeBean(typeName) {
       {
         setColumnSize(columnSize);

--- a/catalogs/catalog-jdbc-postgresql/src/main/java/org/apache/gravitino/catalog/postgresql/converter/PostgreSqlColumnDefaultValueConverter.java
+++ b/catalogs/catalog-jdbc-postgresql/src/main/java/org/apache/gravitino/catalog/postgresql/converter/PostgreSqlColumnDefaultValueConverter.java
@@ -96,16 +96,13 @@ public class PostgreSqlColumnDefaultValueConverter extends JdbcColumnDefaultValu
         return Literals.doubleLiteral(Double.valueOf(columnDefaultValue));
       case PostgreSqlTypeConverter.NUMERIC:
         return Literals.decimalLiteral(
-            Decimal.of(
-                columnDefaultValue,
-                Integer.parseInt(type.getColumnSize()),
-                Integer.parseInt(type.getScale())));
+            Decimal.of(columnDefaultValue, type.getColumnSize(), type.getScale()));
       case JdbcTypeConverter.DATE:
         return Literals.dateLiteral(LocalDate.parse(columnDefaultValue, DATE_TIME_FORMATTER));
       case PostgreSqlTypeConverter.TIMESTAMP_TZ:
         return Literals.timeLiteral(LocalTime.parse(columnDefaultValue, DATE_TIME_FORMATTER));
       case VARCHAR:
-        return Literals.varcharLiteral(Integer.parseInt(type.getColumnSize()), columnDefaultValue);
+        return Literals.varcharLiteral(type.getColumnSize(), columnDefaultValue);
       case PostgreSqlTypeConverter.BPCHAR:
       case JdbcTypeConverter.TEXT:
         return Literals.stringLiteral(columnDefaultValue);

--- a/catalogs/catalog-jdbc-postgresql/src/main/java/org/apache/gravitino/catalog/postgresql/converter/PostgreSqlTypeConverter.java
+++ b/catalogs/catalog-jdbc-postgresql/src/main/java/org/apache/gravitino/catalog/postgresql/converter/PostgreSqlTypeConverter.java
@@ -69,12 +69,11 @@ public class PostgreSqlTypeConverter extends JdbcTypeConverter {
       case TIMESTAMP_TZ:
         return Types.TimestampType.withTimeZone();
       case NUMERIC:
-        return Types.DecimalType.of(
-            Integer.parseInt(typeBean.getColumnSize()), Integer.parseInt(typeBean.getScale()));
+        return Types.DecimalType.of(typeBean.getColumnSize(), typeBean.getScale());
       case VARCHAR:
-        return Types.VarCharType.of(Integer.parseInt(typeBean.getColumnSize()));
+        return Types.VarCharType.of(typeBean.getColumnSize());
       case BPCHAR:
-        return Types.FixedCharType.of(Integer.parseInt(typeBean.getColumnSize()));
+        return Types.FixedCharType.of(typeBean.getColumnSize());
       case TEXT:
         return Types.StringType.get();
       case BYTEA:

--- a/catalogs/catalog-jdbc-postgresql/src/test/java/org/apache/gravitino/catalog/postgresql/converter/TestPostgreSqlTypeConverter.java
+++ b/catalogs/catalog-jdbc-postgresql/src/test/java/org/apache/gravitino/catalog/postgresql/converter/TestPostgreSqlTypeConverter.java
@@ -61,9 +61,9 @@ public class TestPostgreSqlTypeConverter {
     checkJdbcTypeToGravitinoType(Types.DateType.get(), DATE, null, null);
     checkJdbcTypeToGravitinoType(Types.TimeType.get(), TIME, null, null);
     checkJdbcTypeToGravitinoType(Types.TimestampType.withoutTimeZone(), TIMESTAMP, null, null);
-    checkJdbcTypeToGravitinoType(Types.DecimalType.of(10, 2), NUMERIC, "10", "2");
-    checkJdbcTypeToGravitinoType(Types.VarCharType.of(20), VARCHAR, "20", null);
-    checkJdbcTypeToGravitinoType(Types.FixedCharType.of(20), BPCHAR, "20", null);
+    checkJdbcTypeToGravitinoType(Types.DecimalType.of(10, 2), NUMERIC, 10, 2);
+    checkJdbcTypeToGravitinoType(Types.VarCharType.of(20), VARCHAR, 20, null);
+    checkJdbcTypeToGravitinoType(Types.FixedCharType.of(20), BPCHAR, 20, null);
     checkJdbcTypeToGravitinoType(Types.StringType.get(), TEXT, null, null);
     checkJdbcTypeToGravitinoType(Types.BinaryType.get(), BYTEA, null, null);
     checkJdbcTypeToGravitinoType(
@@ -118,13 +118,13 @@ public class TestPostgreSqlTypeConverter {
   }
 
   protected void checkJdbcTypeToGravitinoType(
-      Type gravitinoType, String jdbcTypeName, String columnSize, String scale) {
+      Type gravitinoType, String jdbcTypeName, Integer columnSize, Integer scale) {
     JdbcTypeConverter.JdbcTypeBean typeBean = createTypeBean(jdbcTypeName, columnSize, scale);
     Assertions.assertEquals(gravitinoType, POSTGRE_SQL_TYPE_CONVERTER.toGravitino(typeBean));
   }
 
   protected static JdbcTypeConverter.JdbcTypeBean createTypeBean(
-      String typeName, String columnSize, String scale) {
+      String typeName, Integer columnSize, Integer scale) {
     return new JdbcTypeConverter.JdbcTypeBean(typeName) {
       {
         setColumnSize(columnSize);


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

 Modify the ColumnSize/Scale of JdbcTypeBean to be of type integer. 

### Why are the changes needed?

Fix: [# (5784)](https://github.com/apache/gravitino/issues/5784)
