### PR TITLE
[Minor] Add column audit command to CLI

### DIFF
--- a/clients/cli/src/main/java/org/apache/gravitino/cli/GravitinoCommandLine.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/GravitinoCommandLine.java
@@ -538,7 +538,9 @@ public class GravitinoCommandLine extends TestableCommandLine {
 
     Command.setAuthenticationMode(auth, userName);
 
-    if (CommandActions.LIST.equals(command)) {
+    if (line.hasOption(GravitinoOptions.AUDIT)) {
+      newColumnAudit(url, ignore, metalake, catalog, schema, table, column).handle();
+    } else if (CommandActions.LIST.equals(command)) {
       newListColumns(url, ignore, metalake, catalog, schema, table).handle();
     } else if (CommandActions.CREATE.equals(command)) {
       String datatype = line.getOptionValue(GravitinoOptions.DATATYPE);

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/TestableCommandLine.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/TestableCommandLine.java
@@ -27,6 +27,7 @@ import org.apache.gravitino.cli.commands.AddRoleToUser;
 import org.apache.gravitino.cli.commands.CatalogAudit;
 import org.apache.gravitino.cli.commands.CatalogDetails;
 import org.apache.gravitino.cli.commands.ClientVersion;
+import org.apache.gravitino.cli.commands.ColumnAudit;
 import org.apache.gravitino.cli.commands.CreateCatalog;
 import org.apache.gravitino.cli.commands.CreateFileset;
 import org.apache.gravitino.cli.commands.CreateGroup;
@@ -515,6 +516,17 @@ public class TestableCommandLine {
   protected UntagEntity newUntagEntity(
       String url, boolean ignore, String metalake, FullName name, String[] tags) {
     return new UntagEntity(url, ignore, metalake, name, tags);
+  }
+
+  protected ColumnAudit newColumnAudit(
+      String url,
+      boolean ignore,
+      String metalake,
+      String catalog,
+      String schema,
+      String table,
+      String column) {
+    return new ColumnAudit(url, ignore, metalake, catalog, schema, table, column);
   }
 
   protected ListColumns newListColumns(

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/ColumnAudit.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/ColumnAudit.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.cli.commands;
+
+import org.apache.gravitino.Catalog;
+import org.apache.gravitino.cli.ErrorMessages;
+import org.apache.gravitino.client.GravitinoClient;
+import org.apache.gravitino.exceptions.NoSuchCatalogException;
+import org.apache.gravitino.exceptions.NoSuchColumnException;
+import org.apache.gravitino.exceptions.NoSuchMetalakeException;
+import org.apache.gravitino.exceptions.NoSuchTableException;
+
+public class ColumnAudit extends AuditCommand {
+
+  protected final String metalake;
+  protected final String catalog;
+  protected final String schema;
+  protected final String table;
+  protected final String column;
+
+  /**
+   * Displays the audit information of a column.
+   *
+   * @param url The URL of the Gravitino server.
+   * @param ignoreVersions If true don't check the client/server versions match.
+   * @param metalake The name of the metalake.
+   * @param catalog The name of the catalog.
+   * @param schema The name of the schema.
+   * @param table The name of the table.
+   * @param column The name of the column.
+   */
+  public ColumnAudit(
+      String url,
+      boolean ignoreVersions,
+      String metalake,
+      String catalog,
+      String schema,
+      String table,
+      String column) {
+    super(url, ignoreVersions);
+    this.metalake = metalake;
+    this.catalog = catalog;
+    this.schema = schema;
+    this.table = table;
+    this.column = column;
+  }
+
+  /** Displays the audit information of a specified column. */
+  @Override
+  public void handle() {
+    Catalog result;
+
+    try (GravitinoClient client = buildClient(metalake)) {
+      result = client.loadCatalog(this.catalog);
+    } catch (NoSuchMetalakeException err) {
+      System.err.println(ErrorMessages.UNKNOWN_METALAKE);
+      return;
+    } catch (NoSuchCatalogException err) {
+      System.err.println(ErrorMessages.UNKNOWN_CATALOG);
+      return;
+    } catch (NoSuchTableException err) {
+      System.err.println(ErrorMessages.UNKNOWN_TABLE);
+      return;
+    } catch (NoSuchColumnException err) {
+      System.err.println(ErrorMessages.UNKNOWN_COLUMN);
+      return;
+    } catch (Exception exp) {
+      System.err.println(exp.getMessage());
+      return;
+    }
+
+    if (result != null) {
+      displayAuditInfo(result.auditInfo());
+    }
+  }
+}

--- a/clients/cli/src/test/java/org/apache/gravitino/cli/TestColumnCommands.java
+++ b/clients/cli/src/test/java/org/apache/gravitino/cli/TestColumnCommands.java
@@ -28,6 +28,7 @@ import static org.mockito.Mockito.when;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Options;
 import org.apache.gravitino.cli.commands.AddColumn;
+import org.apache.gravitino.cli.commands.ColumnAudit;
 import org.apache.gravitino.cli.commands.DeleteColumn;
 import org.apache.gravitino.cli.commands.ListColumns;
 import org.apache.gravitino.cli.commands.UpdateColumnAutoIncrement;
@@ -68,6 +69,33 @@ class TestColumnCommands {
             GravitinoCommandLine.DEFAULT_URL, false, "metalake_demo", "catalog", "schema", "users");
     commandLine.handleCommandLine();
     verify(mockList).handle();
+  }
+
+  @Test
+  void testColumnAuditCommand() {
+    ColumnAudit mockAudit = mock(ColumnAudit.class);
+    when(mockCommandLine.hasOption(GravitinoOptions.METALAKE)).thenReturn(true);
+    when(mockCommandLine.getOptionValue(GravitinoOptions.METALAKE)).thenReturn("metalake_demo");
+    when(mockCommandLine.hasOption(GravitinoOptions.NAME)).thenReturn(true);
+    when(mockCommandLine.getOptionValue(GravitinoOptions.NAME))
+        .thenReturn("catalog.schema.users.name");
+    when(mockCommandLine.hasOption(GravitinoOptions.AUDIT)).thenReturn(true);
+    GravitinoCommandLine commandLine =
+        spy(
+            new GravitinoCommandLine(
+                mockCommandLine, mockOptions, CommandEntities.COLUMN, CommandActions.DETAILS));
+    doReturn(mockAudit)
+        .when(commandLine)
+        .newColumnAudit(
+            GravitinoCommandLine.DEFAULT_URL,
+            false,
+            "metalake_demo",
+            "catalog",
+            "schema",
+            "users",
+            "name");
+    commandLine.handleCommandLine();
+    verify(mockAudit).handle();
   }
 
   @Test

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -822,6 +822,12 @@ null, boolean, byte, ubyte, short, ushort, integer, uinteger, long, ulong, float
 
 In addition decimal(precision,scale) and varchar(length).
 
+#### Show a column's audit information
+
+```bash
+gcli column details --name catalog_postgres.hr.departments.name --audit
+```
+
 #### Add a column
 
 ```bash


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add column audit command.

### Why are the changes needed?

Column audi info was added after the CLI work was done.

Fix: # N/A

### Does this PR introduce _any_ user-facing change?

Adds one command

### How was this patch tested?

Tested locally.
