### PR TITLE
[#5527] Add audit command to roles, users and groups in the Gravitino CLI

### DIFF
--- a/clients/cli/src/main/java/org/apache/gravitino/cli/GravitinoCommandLine.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/GravitinoCommandLine.java
@@ -373,7 +373,11 @@ public class GravitinoCommandLine extends TestableCommandLine {
     Command.setAuthenticationMode(auth, userName);
 
     if (CommandActions.DETAILS.equals(command)) {
-      newUserDetails(url, ignore, metalake, user).handle();
+      if (line.hasOption(GravitinoOptions.AUDIT)) {
+        newUserAudit(url, ignore, metalake, user).handle();
+      } else {
+        newUserDetails(url, ignore, metalake, user).handle();
+      }
     } else if (CommandActions.LIST.equals(command)) {
       newListUsers(url, ignore, metalake).handle();
     } else if (CommandActions.CREATE.equals(command)) {
@@ -408,7 +412,11 @@ public class GravitinoCommandLine extends TestableCommandLine {
     Command.setAuthenticationMode(auth, userName);
 
     if (CommandActions.DETAILS.equals(command)) {
-      newGroupDetails(url, ignore, metalake, group).handle();
+      if (line.hasOption(GravitinoOptions.AUDIT)) {
+        newGroupAudit(url, ignore, metalake, group).handle();
+      } else {
+        newGroupDetails(url, ignore, metalake, group).handle();
+      }
     } else if (CommandActions.LIST.equals(command)) {
       newListGroups(url, ignore, metalake).handle();
     } else if (CommandActions.CREATE.equals(command)) {
@@ -511,7 +519,11 @@ public class GravitinoCommandLine extends TestableCommandLine {
     Command.setAuthenticationMode(auth, userName);
 
     if (CommandActions.DETAILS.equals(command)) {
-      newRoleDetails(url, ignore, metalake, role).handle();
+      if (line.hasOption(GravitinoOptions.AUDIT)) {
+        newRoleAudit(url, ignore, metalake, role).handle();
+      } else {
+        newRoleDetails(url, ignore, metalake, role).handle();
+      }
     } else if (CommandActions.LIST.equals(command)) {
       newListRoles(url, ignore, metalake).handle();
     } else if (CommandActions.CREATE.equals(command)) {

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/TestableCommandLine.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/TestableCommandLine.java
@@ -49,6 +49,7 @@ import org.apache.gravitino.cli.commands.DeleteTag;
 import org.apache.gravitino.cli.commands.DeleteTopic;
 import org.apache.gravitino.cli.commands.DeleteUser;
 import org.apache.gravitino.cli.commands.FilesetDetails;
+import org.apache.gravitino.cli.commands.GroupAudit;
 import org.apache.gravitino.cli.commands.GroupDetails;
 import org.apache.gravitino.cli.commands.ListAllTags;
 import org.apache.gravitino.cli.commands.ListCatalogProperties;
@@ -83,6 +84,7 @@ import org.apache.gravitino.cli.commands.RemoveSchemaProperty;
 import org.apache.gravitino.cli.commands.RemoveTableProperty;
 import org.apache.gravitino.cli.commands.RemoveTagProperty;
 import org.apache.gravitino.cli.commands.RemoveTopicProperty;
+import org.apache.gravitino.cli.commands.RoleAudit;
 import org.apache.gravitino.cli.commands.RoleDetails;
 import org.apache.gravitino.cli.commands.SchemaAudit;
 import org.apache.gravitino.cli.commands.SchemaDetails;
@@ -122,6 +124,7 @@ import org.apache.gravitino.cli.commands.UpdateTableName;
 import org.apache.gravitino.cli.commands.UpdateTagComment;
 import org.apache.gravitino.cli.commands.UpdateTagName;
 import org.apache.gravitino.cli.commands.UpdateTopicComment;
+import org.apache.gravitino.cli.commands.UserAudit;
 import org.apache.gravitino.cli.commands.UserDetails;
 
 /*
@@ -391,6 +394,10 @@ public class TestableCommandLine {
     return new ListUsers(url, ignore, metalake);
   }
 
+  protected UserAudit newUserAudit(String url, boolean ignore, String metalake, String user) {
+    return new UserAudit(url, ignore, metalake, user);
+  }
+
   protected CreateUser newCreateUser(String url, boolean ignore, String metalake, String user) {
     return new CreateUser(url, ignore, metalake, user);
   }
@@ -418,6 +425,10 @@ public class TestableCommandLine {
     return new ListGroups(url, ignore, metalake);
   }
 
+  protected GroupAudit newGroupAudit(String url, boolean ignore, String metalake, String group) {
+    return new GroupAudit(url, ignore, metalake, group);
+  }
+
   protected CreateGroup newCreateGroup(String url, boolean ignore, String metalake, String user) {
     return new CreateGroup(url, ignore, metalake, user);
   }
@@ -443,6 +454,10 @@ public class TestableCommandLine {
 
   protected ListRoles newListRoles(String url, boolean ignore, String metalake) {
     return new ListRoles(url, ignore, metalake);
+  }
+
+  protected RoleAudit newRoleAudit(String url, boolean ignore, String metalake, String role) {
+    return new RoleAudit(url, ignore, metalake, role);
   }
 
   protected CreateRole newCreateRole(String url, boolean ignore, String metalake, String role) {

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/GroupAudit.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/GroupAudit.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.cli.commands;
+
+import org.apache.gravitino.authorization.Group;
+import org.apache.gravitino.cli.ErrorMessages;
+import org.apache.gravitino.client.GravitinoClient;
+import org.apache.gravitino.exceptions.NoSuchGroupException;
+import org.apache.gravitino.exceptions.NoSuchMetalakeException;
+
+public class GroupAudit extends AuditCommand {
+
+  protected final String metalake;
+  protected final String group;
+
+  /**
+   * Displays the audit information of a group.
+   *
+   * @param url The URL of the Gravitino server.
+   * @param ignoreVersions If true don't check the client/server versions match.
+   * @param metalake The name of the metalake.
+   * @param group The name of the group.
+   */
+  public GroupAudit(String url, boolean ignoreVersions, String metalake, String group) {
+    super(url, ignoreVersions);
+    this.metalake = metalake;
+    this.group = group;
+  }
+
+  /** Displays the audit information of a specified group. */
+  @Override
+  public void handle() {
+    Group result;
+
+    try (GravitinoClient client = buildClient(metalake)) {
+      result = client.getGroup(this.group);
+    } catch (NoSuchMetalakeException err) {
+      System.err.println(ErrorMessages.UNKNOWN_METALAKE);
+      return;
+    } catch (NoSuchGroupException err) {
+      System.err.println(ErrorMessages.UNKNOWN_GROUP);
+      return;
+    } catch (Exception exp) {
+      System.err.println(exp.getMessage());
+      return;
+    }
+
+    if (result != null) {
+      displayAuditInfo(result.auditInfo());
+    }
+  }
+}

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/RoleAudit.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/RoleAudit.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.cli.commands;
+
+import org.apache.gravitino.authorization.Role;
+import org.apache.gravitino.cli.ErrorMessages;
+import org.apache.gravitino.client.GravitinoClient;
+import org.apache.gravitino.exceptions.NoSuchMetalakeException;
+import org.apache.gravitino.exceptions.NoSuchRoleException;
+
+public class RoleAudit extends AuditCommand {
+
+  protected final String metalake;
+  protected final String role;
+
+  /**
+   * Displays the audit information of a role.
+   *
+   * @param url The URL of the Gravitino server.
+   * @param ignoreVersions If true don't check the client/server versions match.
+   * @param metalake The name of the metalake.
+   * @param role The name of the role.
+   */
+  public RoleAudit(String url, boolean ignoreVersions, String metalake, String role) {
+    super(url, ignoreVersions);
+    this.metalake = metalake;
+    this.role = role;
+  }
+
+  /** Displays the audit information of a specified role. */
+  @Override
+  public void handle() {
+    Role result;
+
+    try (GravitinoClient client = buildClient(metalake)) {
+      result = client.getRole(this.role);
+    } catch (NoSuchMetalakeException err) {
+      System.err.println(ErrorMessages.UNKNOWN_METALAKE);
+      return;
+    } catch (NoSuchRoleException err) {
+      System.err.println(ErrorMessages.UNKNOWN_ROLE);
+      return;
+    } catch (Exception exp) {
+      System.err.println(exp.getMessage());
+      return;
+    }
+
+    if (result != null) {
+      displayAuditInfo(result.auditInfo());
+    }
+  }
+}

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/UserAudit.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/UserAudit.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.cli.commands;
+
+import org.apache.gravitino.authorization.User;
+import org.apache.gravitino.cli.ErrorMessages;
+import org.apache.gravitino.client.GravitinoClient;
+import org.apache.gravitino.exceptions.NoSuchMetalakeException;
+import org.apache.gravitino.exceptions.NoSuchUserException;
+
+public class UserAudit extends AuditCommand {
+
+  protected final String metalake;
+  protected final String user;
+
+  /**
+   * Displays the audit information of a user.
+   *
+   * @param url The URL of the Gravitino server.
+   * @param ignoreVersions If true don't check the client/server versions match.
+   * @param metalake The name of the metalake.
+   * @param user The name of the user.
+   */
+  public UserAudit(String url, boolean ignoreVersions, String metalake, String user) {
+    super(url, ignoreVersions);
+    this.metalake = metalake;
+    this.user = user;
+  }
+
+  /** Displays the audit information of a specified user. */
+  @Override
+  public void handle() {
+    User result;
+
+    try (GravitinoClient client = buildClient(metalake)) {
+      result = client.getUser(this.user);
+    } catch (NoSuchMetalakeException err) {
+      System.err.println(ErrorMessages.UNKNOWN_METALAKE);
+      return;
+    } catch (NoSuchUserException err) {
+      System.err.println(ErrorMessages.UNKNOWN_USER);
+      return;
+    } catch (Exception exp) {
+      System.err.println(exp.getMessage());
+      return;
+    }
+
+    if (result != null) {
+      displayAuditInfo(result.auditInfo());
+    }
+  }
+}

--- a/clients/cli/src/test/java/org/apache/gravitino/cli/TestGroupCommands.java
+++ b/clients/cli/src/test/java/org/apache/gravitino/cli/TestGroupCommands.java
@@ -30,6 +30,7 @@ import org.apache.commons.cli.Options;
 import org.apache.gravitino.cli.commands.AddRoleToGroup;
 import org.apache.gravitino.cli.commands.CreateGroup;
 import org.apache.gravitino.cli.commands.DeleteGroup;
+import org.apache.gravitino.cli.commands.GroupAudit;
 import org.apache.gravitino.cli.commands.GroupDetails;
 import org.apache.gravitino.cli.commands.ListGroups;
 import org.apache.gravitino.cli.commands.RemoveRoleFromGroup;
@@ -78,6 +79,25 @@ class TestGroupCommands {
         .newGroupDetails(GravitinoCommandLine.DEFAULT_URL, false, "metalake_demo", "groupA");
     commandLine.handleCommandLine();
     verify(mockDetails).handle();
+  }
+
+  @Test
+  void testGroupAuditCommand() {
+    GroupAudit mockAudit = mock(GroupAudit.class);
+    when(mockCommandLine.hasOption(GravitinoOptions.METALAKE)).thenReturn(true);
+    when(mockCommandLine.getOptionValue(GravitinoOptions.METALAKE)).thenReturn("metalake_demo");
+    when(mockCommandLine.hasOption(GravitinoOptions.GROUP)).thenReturn(true);
+    when(mockCommandLine.getOptionValue(GravitinoOptions.GROUP)).thenReturn("group");
+    when(mockCommandLine.hasOption(GravitinoOptions.AUDIT)).thenReturn(true);
+    GravitinoCommandLine commandLine =
+        spy(
+            new GravitinoCommandLine(
+                mockCommandLine, mockOptions, CommandEntities.GROUP, CommandActions.DETAILS));
+    doReturn(mockAudit)
+        .when(commandLine)
+        .newGroupAudit(GravitinoCommandLine.DEFAULT_URL, false, "metalake_demo", "group");
+    commandLine.handleCommandLine();
+    verify(mockAudit).handle();
   }
 
   @Test

--- a/clients/cli/src/test/java/org/apache/gravitino/cli/TestRoleCommands.java
+++ b/clients/cli/src/test/java/org/apache/gravitino/cli/TestRoleCommands.java
@@ -30,6 +30,7 @@ import org.apache.commons.cli.Options;
 import org.apache.gravitino.cli.commands.CreateRole;
 import org.apache.gravitino.cli.commands.DeleteRole;
 import org.apache.gravitino.cli.commands.ListRoles;
+import org.apache.gravitino.cli.commands.RoleAudit;
 import org.apache.gravitino.cli.commands.RoleDetails;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -76,6 +77,25 @@ class TestRoleCommands {
         .newRoleDetails(GravitinoCommandLine.DEFAULT_URL, false, "metalake_demo", "admin");
     commandLine.handleCommandLine();
     verify(mockDetails).handle();
+  }
+
+  @Test
+  void testRoleAuditCommand() {
+    RoleAudit mockAudit = mock(RoleAudit.class);
+    when(mockCommandLine.hasOption(GravitinoOptions.METALAKE)).thenReturn(true);
+    when(mockCommandLine.getOptionValue(GravitinoOptions.METALAKE)).thenReturn("metalake_demo");
+    when(mockCommandLine.hasOption(GravitinoOptions.ROLE)).thenReturn(true);
+    when(mockCommandLine.getOptionValue(GravitinoOptions.ROLE)).thenReturn("group");
+    when(mockCommandLine.hasOption(GravitinoOptions.AUDIT)).thenReturn(true);
+    GravitinoCommandLine commandLine =
+        spy(
+            new GravitinoCommandLine(
+                mockCommandLine, mockOptions, CommandEntities.ROLE, CommandActions.DETAILS));
+    doReturn(mockAudit)
+        .when(commandLine)
+        .newRoleAudit(GravitinoCommandLine.DEFAULT_URL, false, "metalake_demo", "group");
+    commandLine.handleCommandLine();
+    verify(mockAudit).handle();
   }
 
   @Test

--- a/clients/cli/src/test/java/org/apache/gravitino/cli/TestUserCommands.java
+++ b/clients/cli/src/test/java/org/apache/gravitino/cli/TestUserCommands.java
@@ -31,6 +31,7 @@ import org.apache.gravitino.cli.commands.CreateUser;
 import org.apache.gravitino.cli.commands.DeleteUser;
 import org.apache.gravitino.cli.commands.ListUsers;
 import org.apache.gravitino.cli.commands.RemoveRoleFromUser;
+import org.apache.gravitino.cli.commands.UserAudit;
 import org.apache.gravitino.cli.commands.UserDetails;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -77,6 +78,25 @@ class TestUserCommands {
         .newUserDetails(GravitinoCommandLine.DEFAULT_URL, false, "metalake_demo", "user");
     commandLine.handleCommandLine();
     verify(mockDetails).handle();
+  }
+
+  @Test
+  void testUserAuditCommand() {
+    UserAudit mockAudit = mock(UserAudit.class);
+    when(mockCommandLine.hasOption(GravitinoOptions.METALAKE)).thenReturn(true);
+    when(mockCommandLine.getOptionValue(GravitinoOptions.METALAKE)).thenReturn("metalake_demo");
+    when(mockCommandLine.hasOption(GravitinoOptions.USER)).thenReturn(true);
+    when(mockCommandLine.getOptionValue(GravitinoOptions.USER)).thenReturn("group");
+    when(mockCommandLine.hasOption(GravitinoOptions.AUDIT)).thenReturn(true);
+    GravitinoCommandLine commandLine =
+        spy(
+            new GravitinoCommandLine(
+                mockCommandLine, mockOptions, CommandEntities.USER, CommandActions.DETAILS));
+    doReturn(mockAudit)
+        .when(commandLine)
+        .newUserAudit(GravitinoCommandLine.DEFAULT_URL, false, "metalake_demo", "group");
+    commandLine.handleCommandLine();
+    verify(mockAudit).handle();
   }
 
   @Test

--- a/clients/cli/src/test/java/org/apache/gravitino/cli/TestUserCommands.java
+++ b/clients/cli/src/test/java/org/apache/gravitino/cli/TestUserCommands.java
@@ -86,7 +86,7 @@ class TestUserCommands {
     when(mockCommandLine.hasOption(GravitinoOptions.METALAKE)).thenReturn(true);
     when(mockCommandLine.getOptionValue(GravitinoOptions.METALAKE)).thenReturn("metalake_demo");
     when(mockCommandLine.hasOption(GravitinoOptions.USER)).thenReturn(true);
-    when(mockCommandLine.getOptionValue(GravitinoOptions.USER)).thenReturn("group");
+    when(mockCommandLine.getOptionValue(GravitinoOptions.USER)).thenReturn("admin");
     when(mockCommandLine.hasOption(GravitinoOptions.AUDIT)).thenReturn(true);
     GravitinoCommandLine commandLine =
         spy(
@@ -94,7 +94,7 @@ class TestUserCommands {
                 mockCommandLine, mockOptions, CommandEntities.USER, CommandActions.DETAILS));
     doReturn(mockAudit)
         .when(commandLine)
-        .newUserAudit(GravitinoCommandLine.DEFAULT_URL, false, "metalake_demo", "group");
+        .newUserAudit(GravitinoCommandLine.DEFAULT_URL, false, "metalake_demo", "admin");
     commandLine.handleCommandLine();
     verify(mockAudit).handle();
   }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -228,7 +228,7 @@ gcli metalake list
 gcli metalake details
 ```
 
-#### Show a metalake audit information
+#### Show a metalake's audit information
 
 ```bash
 gcli metalake details --audit
@@ -290,7 +290,7 @@ gcli catalog list
 gcli catalog details --name catalog_postgres
 ```
 
-#### Show a catalog audit information
+#### Show a catalog's audit information
 
 ```bash
 gcli catalog details --name catalog_postgres --audit
@@ -404,7 +404,7 @@ gcli schema list --name catalog_postgres
 gcli schema details --name catalog_postgres.hr
 ```
 
-#### Show schema audit information
+#### Show schema's audit information
 
 ```bash
 gcli schema details --name catalog_postgres.hr --audit
@@ -526,6 +526,12 @@ gcli user details --user new_user
 gcli user list
 ```
 
+#### Show a roles's audit information
+
+```bash
+gcli user details --user new_user --audit
+```
+
 #### Delete a user
 
 ```bash
@@ -550,6 +556,12 @@ gcli group details --group new_group
 
 ```bash
 gcli group list
+```
+
+#### Show a groups's audit information
+
+```bash
+gcli group details --group new_group --audit
 ```
 
 #### Delete a group
@@ -670,6 +682,12 @@ gcli role details --role admin
 
 ```bash
 gcli role list
+```
+
+#### Show a roles's audit information
+
+```bash
+gcli role details --role admin --audit
 ```
 
 #### Create a role


### PR DESCRIPTION
### What changes were proposed in this pull request?

Added audit command to roles, users and groups in the Gravitino CLI.

### Why are the changes needed?

So all entities support the audit command.

Fix: #5527

### Does this PR introduce _any_ user-facing change?

No, but add more commands.

### How was this patch tested?

Tested locally.
