### PR TITLE
[#5569] improvement(CLI): Add ability to grant or revoke multiple roles or groups at once in the Gravitino CLI

### DIFF
--- a/clients/cli/src/main/java/org/apache/gravitino/cli/GravitinoCommandLine.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/GravitinoCommandLine.java
@@ -385,14 +385,13 @@ public class GravitinoCommandLine extends TestableCommandLine {
       boolean force = line.hasOption(GravitinoOptions.FORCE);
       newDeleteUser(url, ignore, force, metalake, user).handle();
     } else if (CommandActions.REVOKE.equals(command)) {
-      // Retrieve values of the role option from the command line, e.g., ["role1", "role2"]
+      // Role options supports multiple values
       String[] roles = line.getOptionValues(GravitinoOptions.ROLE);
       for (String role : roles) {
         newRemoveRoleFromUser(url, ignore, metalake, user, role).handle();
       }
       System.out.printf("Remove roles %s from user %s%n", COMMA_JOINER.join(roles), user);
     } else if (CommandActions.GRANT.equals(command)) {
-      // Retrieve values of the role option from the command line, e.g., ["role1", "role2"]
       String[] roles = line.getOptionValues(GravitinoOptions.ROLE);
       for (String role : roles) {
         newAddRoleToUser(url, ignore, metalake, user, role).handle();
@@ -424,14 +423,13 @@ public class GravitinoCommandLine extends TestableCommandLine {
       boolean force = line.hasOption(GravitinoOptions.FORCE);
       newDeleteGroup(url, ignore, force, metalake, group).handle();
     } else if (CommandActions.REVOKE.equals(command)) {
-      // Retrieve values of the role option from the command line, e.g., ["role1", "role2"]
+      // Role options supports multiple values
       String[] roles = line.getOptionValues(GravitinoOptions.ROLE);
       for (String role : roles) {
         newRemoveRoleFromGroup(url, ignore, metalake, group, role).handle();
       }
       System.out.printf("Remove roles %s from group %s%n", COMMA_JOINER.join(roles), group);
     } else if (CommandActions.GRANT.equals(command)) {
-      // Retrieve values of the role option from the command line, e.g., ["role1", "role2"]
       String[] roles = line.getOptionValues(GravitinoOptions.ROLE);
       for (String role : roles) {
         newAddRoleToGroup(url, ignore, metalake, group, role).handle();

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/GravitinoCommandLine.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/GravitinoCommandLine.java
@@ -385,27 +385,19 @@ public class GravitinoCommandLine extends TestableCommandLine {
       boolean force = line.hasOption(GravitinoOptions.FORCE);
       newDeleteUser(url, ignore, force, metalake, user).handle();
     } else if (CommandActions.REVOKE.equals(command)) {
+      // Retrieve values of the role option from the command line, e.g., ["role1", "role2"]
       String[] roles = line.getOptionValues(GravitinoOptions.ROLE);
-      if (roles == null || roles.length == 0) {
-        return;
+      for (String role : roles) {
+        newRemoveRoleFromUser(url, ignore, metalake, user, role).handle();
       }
       System.out.printf("Remove roles %s from user %s%n", COMMA_JOINER.join(roles), user);
-      for (String role : roles) {
-        if (role != null) {
-          newRemoveRoleFromUser(url, ignore, metalake, user, role).handle();
-        }
-      }
     } else if (CommandActions.GRANT.equals(command)) {
+      // Retrieve values of the role option from the command line, e.g., ["role1", "role2"]
       String[] roles = line.getOptionValues(GravitinoOptions.ROLE);
-      if (roles == null || roles.length == 0) {
-        return;
+      for (String role : roles) {
+        newAddRoleToUser(url, ignore, metalake, user, role).handle();
       }
       System.out.printf("Grant roles %s to user %s%n", String.join(", ", roles), user);
-      for (String role : roles) {
-        if (role != null) {
-          newAddRoleToUser(url, ignore, metalake, user, role).handle();
-        }
-      }
     } else {
       System.err.println(ErrorMessages.UNSUPPORTED_ACTION);
     }
@@ -432,27 +424,19 @@ public class GravitinoCommandLine extends TestableCommandLine {
       boolean force = line.hasOption(GravitinoOptions.FORCE);
       newDeleteGroup(url, ignore, force, metalake, group).handle();
     } else if (CommandActions.REVOKE.equals(command)) {
+      // Retrieve values of the role option from the command line, e.g., ["role1", "role2"]
       String[] roles = line.getOptionValues(GravitinoOptions.ROLE);
-      if (roles == null || roles.length == 0) {
-        return;
+      for (String role : roles) {
+        newRemoveRoleFromGroup(url, ignore, metalake, group, role).handle();
       }
       System.out.printf("Remove roles %s from group %s%n", COMMA_JOINER.join(roles), group);
-      for (String role : roles) {
-        if (role != null) {
-          newRemoveRoleFromGroup(url, ignore, metalake, group, role).handle();
-        }
-      }
     } else if (CommandActions.GRANT.equals(command)) {
+      // Retrieve values of the role option from the command line, e.g., ["role1", "role2"]
       String[] roles = line.getOptionValues(GravitinoOptions.ROLE);
-      if (roles == null || roles.length == 0) {
-        return;
+      for (String role : roles) {
+        newAddRoleToGroup(url, ignore, metalake, group, role).handle();
       }
       System.out.printf("Grant roles %s to group %s%n", COMMA_JOINER.join(roles), group);
-      for (String role : roles) {
-        if (role != null) {
-          newAddRoleToGroup(url, ignore, metalake, group, role).handle();
-        }
-      }
     } else {
       System.err.println(ErrorMessages.UNSUPPORTED_ACTION);
     }

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/GravitinoCommandLine.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/GravitinoCommandLine.java
@@ -19,6 +19,7 @@
 
 package org.apache.gravitino.cli;
 
+import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -49,6 +50,8 @@ public class GravitinoCommandLine extends TestableCommandLine {
 
   public static final String CMD = "gcli"; // recommended name
   public static final String DEFAULT_URL = "http://localhost:8090";
+  // This joiner is used to join multiple outputs to be displayed, e.g. roles or groups
+  private static final Joiner COMMA_JOINER = Joiner.on(", ").skipNulls();
 
   /**
    * Gravitino Command line.
@@ -382,14 +385,26 @@ public class GravitinoCommandLine extends TestableCommandLine {
       boolean force = line.hasOption(GravitinoOptions.FORCE);
       newDeleteUser(url, ignore, force, metalake, user).handle();
     } else if (CommandActions.REVOKE.equals(command)) {
-      String role = line.getOptionValue(GravitinoOptions.ROLE);
-      if (role != null) {
-        newRemoveRoleFromUser(url, ignore, metalake, user, role).handle();
+      String[] roles = line.getOptionValues(GravitinoOptions.ROLE);
+      if (roles == null || roles.length == 0) {
+        return;
+      }
+      System.out.printf("Remove roles %s from user %s%n", COMMA_JOINER.join(roles), user);
+      for (String role : roles) {
+        if (role != null) {
+          newRemoveRoleFromUser(url, ignore, metalake, user, role).handle();
+        }
       }
     } else if (CommandActions.GRANT.equals(command)) {
-      String role = line.getOptionValue(GravitinoOptions.ROLE);
-      if (role != null) {
-        newAddRoleToUser(url, ignore, metalake, user, role).handle();
+      String[] roles = line.getOptionValues(GravitinoOptions.ROLE);
+      if (roles == null || roles.length == 0) {
+        return;
+      }
+      System.out.printf("Grant roles %s to user %s%n", String.join(", ", roles), user);
+      for (String role : roles) {
+        if (role != null) {
+          newAddRoleToUser(url, ignore, metalake, user, role).handle();
+        }
       }
     } else {
       System.err.println(ErrorMessages.UNSUPPORTED_ACTION);
@@ -417,14 +432,26 @@ public class GravitinoCommandLine extends TestableCommandLine {
       boolean force = line.hasOption(GravitinoOptions.FORCE);
       newDeleteGroup(url, ignore, force, metalake, group).handle();
     } else if (CommandActions.REVOKE.equals(command)) {
-      String role = line.getOptionValue(GravitinoOptions.ROLE);
-      if (role != null) {
-        newRemoveRoleFromGroup(url, ignore, metalake, group, role).handle();
+      String[] roles = line.getOptionValues(GravitinoOptions.ROLE);
+      if (roles == null || roles.length == 0) {
+        return;
+      }
+      System.out.printf("Remove roles %s from group %s%n", COMMA_JOINER.join(roles), group);
+      for (String role : roles) {
+        if (role != null) {
+          newRemoveRoleFromGroup(url, ignore, metalake, group, role).handle();
+        }
       }
     } else if (CommandActions.GRANT.equals(command)) {
-      String role = line.getOptionValue(GravitinoOptions.ROLE);
-      if (role != null) {
-        newAddRoleToGroup(url, ignore, metalake, group, role).handle();
+      String[] roles = line.getOptionValues(GravitinoOptions.ROLE);
+      if (roles == null || roles.length == 0) {
+        return;
+      }
+      System.out.printf("Grant roles %s to group %s%n", COMMA_JOINER.join(roles), group);
+      for (String role : roles) {
+        if (role != null) {
+          newAddRoleToGroup(url, ignore, metalake, group, role).handle();
+        }
       }
     } else {
       System.err.println(ErrorMessages.UNSUPPORTED_ACTION);

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/GravitinoCommandLine.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/GravitinoCommandLine.java
@@ -385,7 +385,6 @@ public class GravitinoCommandLine extends TestableCommandLine {
       boolean force = line.hasOption(GravitinoOptions.FORCE);
       newDeleteUser(url, ignore, force, metalake, user).handle();
     } else if (CommandActions.REVOKE.equals(command)) {
-      // Role options supports multiple values
       String[] roles = line.getOptionValues(GravitinoOptions.ROLE);
       for (String role : roles) {
         newRemoveRoleFromUser(url, ignore, metalake, user, role).handle();
@@ -423,7 +422,6 @@ public class GravitinoCommandLine extends TestableCommandLine {
       boolean force = line.hasOption(GravitinoOptions.FORCE);
       newDeleteGroup(url, ignore, force, metalake, group).handle();
     } else if (CommandActions.REVOKE.equals(command)) {
-      // Role options supports multiple values
       String[] roles = line.getOptionValues(GravitinoOptions.ROLE);
       for (String role : roles) {
         newRemoveRoleFromGroup(url, ignore, metalake, group, role).handle();

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/GravitinoOptions.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/GravitinoOptions.java
@@ -102,7 +102,7 @@ public class GravitinoOptions {
     options.addOption(createSimpleOption("o", OWNER, "display entity owner"));
     options.addOption(createArgOption(COLUMNFILE, "CSV file describing columns"));
 
-    // Properties and tags can have multiple values
+    // Options that support multiple values
     options.addOption(createArgsOption("p", PROPERTIES, "property name/value pairs"));
     options.addOption(createArgsOption("t", TAG, "tag name"));
     options.addOption(createArgsOption("r", ROLE, "role name"));

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/GravitinoOptions.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/GravitinoOptions.java
@@ -100,12 +100,12 @@ public class GravitinoOptions {
     options.addOption(createArgOption(AUTO, "column value auto-increments (true/false)"));
     options.addOption(createArgOption(DEFAULT, "default column value"));
     options.addOption(createSimpleOption("o", OWNER, "display entity owner"));
-    options.addOption(createArgsOption("r", ROLE, "role name"));
     options.addOption(createArgOption(COLUMNFILE, "CSV file describing columns"));
 
     // Properties and tags can have multiple values
     options.addOption(createArgsOption("p", PROPERTIES, "property name/value pairs"));
     options.addOption(createArgsOption("t", TAG, "tag name"));
+    options.addOption(createArgsOption("r", ROLE, "role name"));
 
     // Force delete entities and rename metalake operations
     options.addOption(createSimpleOption("f", FORCE, "force operation"));

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/GravitinoOptions.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/GravitinoOptions.java
@@ -100,7 +100,7 @@ public class GravitinoOptions {
     options.addOption(createArgOption(AUTO, "column value auto-increments (true/false)"));
     options.addOption(createArgOption(DEFAULT, "default column value"));
     options.addOption(createSimpleOption("o", OWNER, "display entity owner"));
-    options.addOption(createArgOption("r", ROLE, "role name"));
+    options.addOption(createArgsOption("r", ROLE, "role name"));
     options.addOption(createArgOption(COLUMNFILE, "CSV file describing columns"));
 
     // Properties and tags can have multiple values

--- a/clients/cli/src/test/java/org/apache/gravitino/cli/TestGroupCommands.java
+++ b/clients/cli/src/test/java/org/apache/gravitino/cli/TestGroupCommands.java
@@ -135,7 +135,6 @@ class TestGroupCommands {
     verify(mockDelete).handle();
   }
 
-  @Test
   void testRemoveRoleFromGroupCommand() {
     RemoveRoleFromGroup mockRemove = mock(RemoveRoleFromGroup.class);
     when(mockCommandLine.hasOption(GravitinoOptions.METALAKE)).thenReturn(true);
@@ -156,7 +155,6 @@ class TestGroupCommands {
     verify(mockRemove).handle();
   }
 
-  @Test
   void testAddRoleToGroupCommand() {
     AddRoleToGroup mockAdd = mock(AddRoleToGroup.class);
     when(mockCommandLine.hasOption(GravitinoOptions.METALAKE)).thenReturn(true);
@@ -175,5 +173,69 @@ class TestGroupCommands {
             GravitinoCommandLine.DEFAULT_URL, false, "metalake_demo", "groupA", "admin");
     commandLine.handleCommandLine();
     verify(mockAdd).handle();
+  }
+
+  @Test
+  void testRemoveRolesFromGroupCommand() {
+    RemoveRoleFromGroup mockRemoveFirstRole = mock(RemoveRoleFromGroup.class);
+    RemoveRoleFromGroup mockRemoveSecondRole = mock(RemoveRoleFromGroup.class);
+    when(mockCommandLine.hasOption(GravitinoOptions.METALAKE)).thenReturn(true);
+    when(mockCommandLine.getOptionValue(GravitinoOptions.METALAKE)).thenReturn("metalake_demo");
+    when(mockCommandLine.hasOption(GravitinoOptions.GROUP)).thenReturn(true);
+    when(mockCommandLine.getOptionValue(GravitinoOptions.GROUP)).thenReturn("groupA");
+    when(mockCommandLine.hasOption(GravitinoOptions.ROLE)).thenReturn(true);
+    when(mockCommandLine.getOptionValues(GravitinoOptions.ROLE))
+        .thenReturn(new String[] {"admin", "role1"});
+    GravitinoCommandLine commandLine =
+        spy(
+            new GravitinoCommandLine(
+                mockCommandLine, mockOptions, CommandEntities.GROUP, CommandActions.REVOKE));
+    // Verify first role
+    doReturn(mockRemoveFirstRole)
+        .when(commandLine)
+        .newRemoveRoleFromGroup(
+            GravitinoCommandLine.DEFAULT_URL, false, "metalake_demo", "groupA", "admin");
+    commandLine.handleCommandLine();
+    verify(mockRemoveFirstRole).handle();
+
+    // Verify second role
+    doReturn(mockRemoveSecondRole)
+        .when(commandLine)
+        .newRemoveRoleFromGroup(
+            GravitinoCommandLine.DEFAULT_URL, false, "metalake_demo", "groupA", "role1");
+    commandLine.handleCommandLine();
+    verify(mockRemoveSecondRole).handle();
+  }
+
+  @Test
+  void testAddRolesToGroupCommand() {
+    AddRoleToGroup mockAddFirstRole = mock(AddRoleToGroup.class);
+    AddRoleToGroup mockAddSecondRole = mock(AddRoleToGroup.class);
+    when(mockCommandLine.hasOption(GravitinoOptions.METALAKE)).thenReturn(true);
+    when(mockCommandLine.getOptionValue(GravitinoOptions.METALAKE)).thenReturn("metalake_demo");
+    when(mockCommandLine.hasOption(GravitinoOptions.GROUP)).thenReturn(true);
+    when(mockCommandLine.getOptionValue(GravitinoOptions.GROUP)).thenReturn("groupA");
+    when(mockCommandLine.hasOption(GravitinoOptions.ROLE)).thenReturn(true);
+    when(mockCommandLine.getOptionValues(GravitinoOptions.ROLE))
+        .thenReturn(new String[] {"admin", "role1"});
+    GravitinoCommandLine commandLine =
+        spy(
+            new GravitinoCommandLine(
+                mockCommandLine, mockOptions, CommandEntities.GROUP, CommandActions.GRANT));
+    // Verify first role
+    doReturn(mockAddFirstRole)
+        .when(commandLine)
+        .newAddRoleToGroup(
+            GravitinoCommandLine.DEFAULT_URL, false, "metalake_demo", "groupA", "admin");
+    commandLine.handleCommandLine();
+    verify(mockAddFirstRole).handle();
+
+    // Verify second role
+    doReturn(mockAddSecondRole)
+        .when(commandLine)
+        .newAddRoleToGroup(
+            GravitinoCommandLine.DEFAULT_URL, false, "metalake_demo", "groupA", "role1");
+    commandLine.handleCommandLine();
+    verify(mockAddSecondRole).handle();
   }
 }

--- a/clients/cli/src/test/java/org/apache/gravitino/cli/TestUserCommands.java
+++ b/clients/cli/src/test/java/org/apache/gravitino/cli/TestUserCommands.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.when;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Options;
+import org.apache.gravitino.cli.commands.AddRoleToUser;
 import org.apache.gravitino.cli.commands.CreateUser;
 import org.apache.gravitino.cli.commands.DeleteUser;
 import org.apache.gravitino.cli.commands.ListUsers;
@@ -172,5 +173,71 @@ class TestUserCommands {
             GravitinoCommandLine.DEFAULT_URL, false, "metalake_demo", "user", "admin");
     commandLine.handleCommandLine();
     verify(mockAdd).handle();
+  }
+
+  @Test
+  void testRemoveRolesFromUserCommand() {
+    RemoveRoleFromUser mockRemoveFirstRole = mock(RemoveRoleFromUser.class);
+    RemoveRoleFromUser mockRemoveSecondRole = mock(RemoveRoleFromUser.class);
+
+    when(mockCommandLine.hasOption(GravitinoOptions.METALAKE)).thenReturn(true);
+    when(mockCommandLine.getOptionValue(GravitinoOptions.METALAKE)).thenReturn("metalake_demo");
+    when(mockCommandLine.hasOption(GravitinoOptions.USER)).thenReturn(true);
+    when(mockCommandLine.getOptionValue(GravitinoOptions.USER)).thenReturn("user");
+    when(mockCommandLine.hasOption(GravitinoOptions.ROLE)).thenReturn(true);
+    when(mockCommandLine.getOptionValues(GravitinoOptions.ROLE))
+        .thenReturn(new String[] {"admin", "role1"});
+    GravitinoCommandLine commandLine =
+        spy(
+            new GravitinoCommandLine(
+                mockCommandLine, mockOptions, CommandEntities.USER, CommandActions.REVOKE));
+    // Verify first role
+    doReturn(mockRemoveFirstRole)
+        .when(commandLine)
+        .newRemoveRoleFromUser(
+            GravitinoCommandLine.DEFAULT_URL, false, "metalake_demo", "user", "admin");
+    commandLine.handleCommandLine();
+    verify(mockRemoveFirstRole).handle();
+
+    // Verify second role
+    doReturn(mockRemoveSecondRole)
+        .when(commandLine)
+        .newRemoveRoleFromUser(
+            GravitinoCommandLine.DEFAULT_URL, false, "metalake_demo", "user", "role1");
+    commandLine.handleCommandLine();
+    verify(mockRemoveSecondRole).handle();
+  }
+
+  @Test
+  void testAddRolesToUserCommand() {
+    AddRoleToUser mockAddFirstRole = mock(AddRoleToUser.class);
+    AddRoleToUser mockAddSecondRole = mock(AddRoleToUser.class);
+
+    when(mockCommandLine.hasOption(GravitinoOptions.METALAKE)).thenReturn(true);
+    when(mockCommandLine.getOptionValue(GravitinoOptions.METALAKE)).thenReturn("metalake_demo");
+    when(mockCommandLine.hasOption(GravitinoOptions.USER)).thenReturn(true);
+    when(mockCommandLine.getOptionValue(GravitinoOptions.USER)).thenReturn("user");
+    when(mockCommandLine.hasOption(GravitinoOptions.ROLE)).thenReturn(true);
+    when(mockCommandLine.getOptionValues(GravitinoOptions.ROLE))
+        .thenReturn(new String[] {"admin", "role1"});
+    GravitinoCommandLine commandLine =
+        spy(
+            new GravitinoCommandLine(
+                mockCommandLine, mockOptions, CommandEntities.USER, CommandActions.GRANT));
+    // Verify first role
+    doReturn(mockAddFirstRole)
+        .when(commandLine)
+        .newAddRoleToUser(
+            GravitinoCommandLine.DEFAULT_URL, false, "metalake_demo", "user", "admin");
+    commandLine.handleCommandLine();
+    verify(mockAddFirstRole).handle();
+
+    // Verify second role
+    doReturn(mockAddSecondRole)
+        .when(commandLine)
+        .newAddRoleToUser(
+            GravitinoCommandLine.DEFAULT_URL, false, "metalake_demo", "user", "role1");
+    commandLine.handleCommandLine();
+    verify(mockAddSecondRole).handle();
   }
 }


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Add ability to grant or revoke multiple roles or groups at once in the Gravitino CLI,

### Why are the changes needed?

Fix:[#5569](https://github.com/apache/gravitino/issues/5569)

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

#### I. bash test

**Grant\revoke role to user**
1. Grant single role to a user
![image](https://github.com/user-attachments/assets/a8990b1e-dc74-4cf3-bcd8-6e09f32f43d6)
2. Grant multiple role to a user
![image](https://github.com/user-attachments/assets/dc828341-7124-487d-b7ca-db402fb2c196)
3. Revoke multiple role to from user
![image](https://github.com/user-attachments/assets/87603fc4-9b7d-4bbf-8af9-b9d2dc67d86b)

**Grant\revoke role to group**
1.  Grant single role to a group
![image](https://github.com/user-attachments/assets/549aeec3-c55b-4d76-a6f5-f8baf06788e3)
2. Grant multiple role to a group
![image](https://github.com/user-attachments/assets/fbe05fcf-2232-4e36-8dbd-2d7b87e4fb9e)
3. Revoke multiple role to from group
![image](https://github.com/user-attachments/assets/8ddd3d1a-a550-40f7-b292-004a42225fa2)

#### II. unit test

Please check the [commit](https://github.com/apache/gravitino/commit/788396aab379638707ca5733e89069fab0e0002f)
