### PR TITLE
[MINOR] docs: fix typo in catalog.management exception message

### DIFF
--- a/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/GravitinoConfig.java
+++ b/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/GravitinoConfig.java
@@ -237,7 +237,7 @@ public class GravitinoConfig {
                 properties.getProperty(TRINO_CATALOG_MANAGEMENT))) {
           throw new TrinoException(
               GravitinoErrorCode.GRAVITINO_MISSING_CONFIG,
-              "Gravitino connector works only at catalog.management = static mode");
+              "Gravitino connector works only at catalog.management = dynamic mode");
         }
       } catch (IOException e) {
         throw new TrinoException(


### PR DESCRIPTION
### What changes were proposed in this pull request?
The exception message should be `catalog.management = dynamic` when the trino configuration is incorrect.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Not required