### PR TITLE
[#5832] Minor: metalake error message

### DIFF
--- a/common/src/main/java/org/apache/gravitino/dto/requests/MetalakeCreateRequest.java
+++ b/common/src/main/java/org/apache/gravitino/dto/requests/MetalakeCreateRequest.java
@@ -74,6 +74,6 @@ public class MetalakeCreateRequest implements RESTRequest {
   @Override
   public void validate() throws IllegalArgumentException {
     Preconditions.checkArgument(
-        StringUtils.isNotBlank(name), "\"name\" field is required and cannot be empty");
+        StringUtils.isNotBlank(name), "\"name\" field is required. Please provide a valid name for the Metalake. It cannot be empty or only whitespace.");
   }
 }


### PR DESCRIPTION
### Why are these changes necessary?
The original error message was unclear, which could confuse users when they encountered an issue with the 'name' field. Improving the error message helps to provide clearer guidance to users.


### Related Issues
This PR addresses issue #5832 , which reported an unclear error message when the 'name' field is empty.
https://github.com/apache/gravitino/issues/5832