### PR TITLE
[#5329] improvement(core): Clarify exception when importing entity multiple times

### DIFF
--- a/catalogs/catalog-jdbc-postgresql/src/test/java/org/apache/gravitino/catalog/postgresql/integration/test/CatalogPostgreSqlIT.java
+++ b/catalogs/catalog-jdbc-postgresql/src/test/java/org/apache/gravitino/catalog/postgresql/integration/test/CatalogPostgreSqlIT.java
@@ -118,8 +118,8 @@ public class CatalogPostgreSqlIT extends BaseIT {
 
     postgreSqlService = new PostgreSqlService(POSTGRESQL_CONTAINER, TEST_DB_NAME);
     createMetalake();
-    createCatalog();
-    createSchema();
+    catalog = createCatalog(catalogName);
+    createSchema(schemaName);
   }
 
   @AfterAll
@@ -139,7 +139,7 @@ public class CatalogPostgreSqlIT extends BaseIT {
   @AfterEach
   public void resetSchema() {
     clearTableAndSchema();
-    createSchema();
+    createSchema(schemaName);
   }
 
   private void clearTableAndSchema() {
@@ -162,7 +162,7 @@ public class CatalogPostgreSqlIT extends BaseIT {
     metalake = loadMetalake;
   }
 
-  private void createCatalog() throws SQLException {
+  private Catalog createCatalog(String catalogName) throws SQLException {
     Map<String, String> catalogProperties = Maps.newHashMap();
 
     String jdbcUrl = POSTGRESQL_CONTAINER.getJdbcUrl(TEST_DB_NAME);
@@ -179,10 +179,10 @@ public class CatalogPostgreSqlIT extends BaseIT {
     Catalog loadCatalog = metalake.loadCatalog(catalogName);
     Assertions.assertEquals(createdCatalog, loadCatalog);
 
-    catalog = loadCatalog;
+    return loadCatalog;
   }
 
-  private void createSchema() {
+  private void createSchema(String schemaName) {
 
     Schema createdSchema =
         catalog.asSchemas().createSchema(schemaName, schema_comment, Collections.EMPTY_MAP);
@@ -654,7 +654,7 @@ public class CatalogPostgreSqlIT extends BaseIT {
   }
 
   @Test
-  void testCreateAndLoadSchema() {
+  void testCreateAndLoadSchema() throws SQLException {
     String testSchemaName = "test";
 
     Schema schema = catalog.asSchemas().createSchema(testSchemaName, "comment", null);
@@ -665,15 +665,26 @@ public class CatalogPostgreSqlIT extends BaseIT {
     Assertions.assertEquals("comment", schema.comment());
 
     // test null comment
-    testSchemaName = "test2";
+    String testSchemaName2 = "test2";
 
-    schema = catalog.asSchemas().createSchema(testSchemaName, null, null);
+    schema = catalog.asSchemas().createSchema(testSchemaName2, null, null);
     Assertions.assertEquals("anonymous", schema.auditInfo().creator());
     // todo: Gravitino put id to comment, makes comment is empty string not null.
     Assertions.assertTrue(StringUtils.isEmpty(schema.comment()));
-    schema = catalog.asSchemas().loadSchema(testSchemaName);
+    schema = catalog.asSchemas().loadSchema(testSchemaName2);
     Assertions.assertEquals("anonymous", schema.auditInfo().creator());
     Assertions.assertTrue(StringUtils.isEmpty(schema.comment()));
+
+    // test register PG service to multiple catalogs
+    String newCatalogName = GravitinoITUtils.genRandomName("new_catalog");
+    Catalog newCatalog = createCatalog(newCatalogName);
+    newCatalog.asSchemas().loadSchema(testSchemaName2);
+    Assertions.assertTrue(catalog.asSchemas().dropSchema(testSchemaName2, false));
+    createSchema(testSchemaName2);
+    Assertions.assertThrows(
+        UnsupportedOperationException.class,
+        () -> newCatalog.asSchemas().loadSchema(testSchemaName2));
+    Assertions.assertTrue(metalake.dropCatalog(newCatalogName, true));
   }
 
   @Test

--- a/catalogs/catalog-jdbc-postgresql/src/test/java/org/apache/gravitino/catalog/postgresql/integration/test/CatalogPostgreSqlIT.java
+++ b/catalogs/catalog-jdbc-postgresql/src/test/java/org/apache/gravitino/catalog/postgresql/integration/test/CatalogPostgreSqlIT.java
@@ -681,9 +681,15 @@ public class CatalogPostgreSqlIT extends BaseIT {
     newCatalog.asSchemas().loadSchema(testSchemaName2);
     Assertions.assertTrue(catalog.asSchemas().dropSchema(testSchemaName2, false));
     createSchema(testSchemaName2);
+    SupportsSchemas schemaOps = newCatalog.asSchemas();
     Assertions.assertThrows(
-        UnsupportedOperationException.class,
-        () -> newCatalog.asSchemas().loadSchema(testSchemaName2));
+        UnsupportedOperationException.class, () -> schemaOps.loadSchema(testSchemaName2));
+    // recovered by re-build the catalog
+    Assertions.assertTrue(metalake.dropCatalog(newCatalogName, true));
+    newCatalog = createCatalog(newCatalogName);
+    Schema loadedSchema = newCatalog.asSchemas().loadSchema(testSchemaName2);
+    Assertions.assertEquals(testSchemaName2, loadedSchema.name());
+
     Assertions.assertTrue(metalake.dropCatalog(newCatalogName, true));
   }
 

--- a/core/src/main/java/org/apache/gravitino/catalog/SchemaOperationDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/SchemaOperationDispatcher.java
@@ -24,6 +24,7 @@ import static org.apache.gravitino.utils.NameIdentifierUtil.getCatalogIdentifier
 
 import java.time.Instant;
 import java.util.Map;
+import org.apache.gravitino.EntityAlreadyExistsException;
 import org.apache.gravitino.EntityStore;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
@@ -350,6 +351,10 @@ public class SchemaOperationDispatcher extends OperationDispatcher implements Sc
             .build();
     try {
       store.put(schemaEntity, true);
+    } catch (EntityAlreadyExistsException e) {
+      LOG.error("Failed to import schema {} with id {} to the store.", identifier, uid, e);
+      throw new UnsupportedOperationException(
+          "The schema is already managed by another catalog and cannot be loaded by the current catalog.");
     } catch (Exception e) {
       LOG.error(FormattedErrorMessages.STORE_OP_FAILURE, "put", identifier, e);
       throw new RuntimeException("Fail to import schema entity to the store.", e);

--- a/core/src/main/java/org/apache/gravitino/catalog/SchemaOperationDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/SchemaOperationDispatcher.java
@@ -354,7 +354,8 @@ public class SchemaOperationDispatcher extends OperationDispatcher implements Sc
     } catch (EntityAlreadyExistsException e) {
       LOG.error("Failed to import schema {} with id {} to the store.", identifier, uid, e);
       throw new UnsupportedOperationException(
-          "The schema is already managed by another catalog and cannot be loaded by the current catalog.");
+          "Schema managed by multiple catalogs. This may cause unexpected issues such as privilege conflicts. "
+              + "To resolve: Remove all catalogs managing this schema, then recreate one catalog to ensure single-catalog management.");
     } catch (Exception e) {
       LOG.error(FormattedErrorMessages.STORE_OP_FAILURE, "put", identifier, e);
       throw new RuntimeException("Fail to import schema entity to the store.", e);

--- a/core/src/main/java/org/apache/gravitino/catalog/TableOperationDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/TableOperationDispatcher.java
@@ -398,7 +398,8 @@ public class TableOperationDispatcher extends OperationDispatcher implements Tab
     } catch (EntityAlreadyExistsException e) {
       LOG.error("Failed to import table {} with id {} to the store.", identifier, uid, e);
       throw new UnsupportedOperationException(
-          "The table is already managed by another catalog and cannot be loaded by the current catalog.");
+          "Table managed by multiple catalogs. This may cause unexpected issues such as privilege conflicts. "
+              + "To resolve: Remove all catalogs managing this table, then recreate one catalog to ensure single-catalog management.");
     } catch (Exception e) {
       LOG.error(FormattedErrorMessages.STORE_OP_FAILURE, "put", identifier, e);
       throw new RuntimeException("Fail to import the table entity to the store.", e);

--- a/core/src/main/java/org/apache/gravitino/catalog/TableOperationDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/TableOperationDispatcher.java
@@ -35,6 +35,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.gravitino.EntityAlreadyExistsException;
 import org.apache.gravitino.EntityStore;
 import org.apache.gravitino.GravitinoEnv;
 import org.apache.gravitino.NameIdentifier;
@@ -394,6 +395,10 @@ public class TableOperationDispatcher extends OperationDispatcher implements Tab
             .build();
     try {
       store.put(tableEntity, true);
+    } catch (EntityAlreadyExistsException e) {
+      LOG.error("Failed to import table {} with id {} to the store.", identifier, uid, e);
+      throw new UnsupportedOperationException(
+          "The table is already managed by another catalog and cannot be loaded by the current catalog.");
     } catch (Exception e) {
       LOG.error(FormattedErrorMessages.STORE_OP_FAILURE, "put", identifier, e);
       throw new RuntimeException("Fail to import the table entity to the store.", e);

--- a/docs/manage-relational-metadata-using-gravitino.md
+++ b/docs/manage-relational-metadata-using-gravitino.md
@@ -36,6 +36,11 @@ Assuming:
 
 ### Create a catalog
 
+:::caution
+It is not recommended to use one data source to create multiple catalogs, 
+as multiple catalogs operating on the same source may result in unpredictable behavior.
+:::
+
 :::tip
 The code below is an example of creating a Hive catalog. For other relational catalogs, the code is
 similar, but the catalog type, provider, and properties may be different. For more details, please refer to the related doc.


### PR DESCRIPTION
### What changes were proposed in this pull request?

 - remind users not to register multiple catalogs using the same data source in the user doc
 - clarify exception when importing entity multiple times.

### Why are the changes needed?

Fix: #5329 

import one source multiple times will update the existing record and result in unexpected behaviors

### Does this PR introduce _any_ user-facing change?

yes, clarify the exception

### How was this patch tested?

tests added
