### PR TITLE
[#5825] improvement(CLI): Update the error message for creating a metalake when the required parameter is missing.

### DIFF
--- a/clients/cli/src/main/java/org/apache/gravitino/cli/GravitinoCommandLine.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/GravitinoCommandLine.java
@@ -32,7 +32,6 @@ import java.util.Objects;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Options;
-import org.apache.gravitino.MetadataObject;
 import org.apache.gravitino.cli.commands.Command;
 
 /* Gravitino Command line */
@@ -177,7 +176,7 @@ public class GravitinoCommandLine extends TestableCommandLine {
       newListMetalakes(url, ignore, outputFormat).handle();
     } else if (CommandActions.CREATE.equals(command)) {
       if (Objects.isNull(metalake)) {
-        System.err.println("! " + MetadataObject.Type.METALAKE.name() + " is not defined");
+        System.err.println("! " + CommandEntities.METALAKE + " is not defined");
         return;
       }
       String comment = line.getOptionValue(GravitinoOptions.COMMENT);

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/GravitinoCommandLine.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/GravitinoCommandLine.java
@@ -28,9 +28,11 @@ import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Map;
+import java.util.Objects;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Options;
+import org.apache.gravitino.MetadataObject;
 import org.apache.gravitino.cli.commands.Command;
 
 /* Gravitino Command line */
@@ -174,6 +176,10 @@ public class GravitinoCommandLine extends TestableCommandLine {
     } else if (CommandActions.LIST.equals(command)) {
       newListMetalakes(url, ignore, outputFormat).handle();
     } else if (CommandActions.CREATE.equals(command)) {
+      if (Objects.isNull(metalake)) {
+        System.err.println("! " + MetadataObject.Type.METALAKE.name() + " is not defined");
+        return;
+      }
       String comment = line.getOptionValue(GravitinoOptions.COMMENT);
       newCreateMetalake(url, ignore, metalake, comment).handle();
     } else if (CommandActions.DELETE.equals(command)) {


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Currently, when a metalake is created without specifying the metalake argument, the message "Cannot parse a null or empty identifier" is displayed. This message is unclear and lacks helpful guidance for the user. Update the message to: "! metalake is not defined" to make it more user-friendly and informative.

### Why are the changes needed?

Fix: #5825 

### Does this PR introduce _any_ user-facing change?

NO

### How was this patch tested?

<img width="282" alt="image" src="https://github.com/user-attachments/assets/cb59089f-e60f-4c12-a781-0a79e449c472" />