### PR TITLE
[#5824] fix(CLI): Fix CLi throws an inappropriate exception when table name is unknown in Gravitino CLI command

### DIFF
--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/ListColumns.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/ListColumns.java
@@ -20,6 +20,8 @@
 package org.apache.gravitino.cli.commands;
 
 import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.cli.ErrorMessages;
+import org.apache.gravitino.exceptions.NoSuchTableException;
 import org.apache.gravitino.rel.Column;
 
 /** Displays the details of a table's columns. */
@@ -58,6 +60,9 @@ public class ListColumns extends TableCommand {
     try {
       NameIdentifier name = NameIdentifier.of(schema, table);
       columns = tableCatalog().loadTable(name).columns();
+    } catch (NoSuchTableException noSuchTableException) {
+      System.err.println(ErrorMessages.UNKNOWN_TABLE + table);
+      return;
     } catch (Exception exp) {
       System.err.println(exp.getMessage());
       return;

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/ListColumns.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/ListColumns.java
@@ -19,6 +19,7 @@
 
 package org.apache.gravitino.cli.commands;
 
+import com.google.common.base.Joiner;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.cli.ErrorMessages;
 import org.apache.gravitino.exceptions.NoSuchTableException;
@@ -61,7 +62,8 @@ public class ListColumns extends TableCommand {
       NameIdentifier name = NameIdentifier.of(schema, table);
       columns = tableCatalog().loadTable(name).columns();
     } catch (NoSuchTableException noSuchTableException) {
-      System.err.println(ErrorMessages.UNKNOWN_TABLE + table);
+      System.err.println(
+          ErrorMessages.UNKNOWN_TABLE + Joiner.on(".").join(metalake, catalog, schema, table));
       return;
     } catch (Exception exp) {
       System.err.println(exp.getMessage());


### PR DESCRIPTION
When using the column list command, the CLI should provide a hint rather than throwing an exception if the table does not exist.

<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

When using the column list command, the CLI should provide a hint rather than throwing an exception if the table does not exist.

### Why are the changes needed?

Fix: #5824 

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?
![image](https://github.com/user-attachments/assets/bb76c8e5-92fa-45df-bd53-9dba45bb3dd9)

