### PR TITLE
[#5913] fix(docs): Fix the wrong shell command

### DIFF
--- a/docs/security/access-control.md
+++ b/docs/security/access-control.md
@@ -561,10 +561,10 @@ The request path for REST API is `/api/metalakes/{metalake}/objects/{metadataObj
 
 ```shell
 curl -X GET -H "Accept: application/vnd.gravitino.v1+json" \
-http://localhost:8090/api/metalakes/test/objects/catalog/catalog1/tags
+http://localhost:8090/api/metalakes/test/objects/catalog/catalog1/roles
 
 curl -X GET -H "Accept: application/vnd.gravitino.v1+json" \
-http://localhost:8090/api/metalakes/test/objects/schema/catalog1.schema1/tags
+http://localhost:8090/api/metalakes/test/objects/schema/catalog1.schema1/roles
 ```
 
 </TabItem>


### PR DESCRIPTION

### What changes were proposed in this pull request?

Fix the wrong shell command. We should use `roles` instead of `tags`

### Why are the changes needed?

Fix: #5913

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Just documents.
