### PR TITLE
[#5829] improvement(CLI): Slightly misleading error message when group is not specified

### DIFF
--- a/clients/cli/src/main/java/org/apache/gravitino/cli/ErrorMessages.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/ErrorMessages.java
@@ -30,6 +30,7 @@ public class ErrorMessages {
   public static final String UNKNOWN_TABLE = "Unknown table name.";
   public static final String MALFORMED_NAME = "Malformed entity name.";
   public static final String MISSING_NAME = "Missing --name option.";
+  public static final String MISSING_GROUP = "Missing --group option.";
   public static final String METALAKE_EXISTS = "Metalake already exists.";
   public static final String CATALOG_EXISTS = "Catalog already exists.";
   public static final String SCHEMA_EXISTS = "Schema already exists.";

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/GravitinoCommandLine.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/GravitinoCommandLine.java
@@ -537,6 +537,7 @@ public class GravitinoCommandLine extends TestableCommandLine {
 
     if (group == null && !CommandActions.LIST.equals(command)) {
       System.err.println(ErrorMessages.MISSING_GROUP);
+      return;
     }
 
     switch (command) {

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/GravitinoCommandLine.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/GravitinoCommandLine.java
@@ -535,6 +535,10 @@ public class GravitinoCommandLine extends TestableCommandLine {
 
     Command.setAuthenticationMode(auth, userName);
 
+    if (group == null && !CommandActions.LIST.equals(command)) {
+      System.err.println(ErrorMessages.MISSING_GROUP);
+    }
+
     switch (command) {
       case CommandActions.DETAILS:
         if (line.hasOption(GravitinoOptions.AUDIT)) {


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Slightly missing leading error message when group is not specified, it should give some hints to user.

### Why are the changes needed?

Fix: #5829 

### Does this PR introduce _any_ user-facing change?

NO

### How was this patch tested?

```bash
bin/gcli.sh group create --metalake demo_metalake
# Missing --group option.

bin/gcli.sh group details --metalake demo_metalake
# Missing --group option.

bin/gcli.sh group delete --metalake demo_metalake
# Missing --group option.
```
