### PR TITLE
[#5756] Bug Fix : Warehouse parameter systematically required 

### DIFF
--- a/catalogs/catalog-lakehouse-iceberg/src/main/java/org/apache/gravitino/catalog/lakehouse/iceberg/IcebergCatalogPropertiesMetadata.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/main/java/org/apache/gravitino/catalog/lakehouse/iceberg/IcebergCatalogPropertiesMetadata.java
@@ -78,6 +78,7 @@ public class IcebergCatalogPropertiesMetadata extends BaseCatalogPropertiesMetad
                 WAREHOUSE,
                 "Iceberg catalog warehouse config",
                 false /* immutable */,
+                null, /* defaultValue */
                 false /* hidden */),
             stringOptionalPropertyEntry(
                 IcebergConstants.IO_IMPL,

--- a/catalogs/catalog-lakehouse-iceberg/src/main/java/org/apache/gravitino/catalog/lakehouse/iceberg/IcebergCatalogPropertiesMetadata.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/main/java/org/apache/gravitino/catalog/lakehouse/iceberg/IcebergCatalogPropertiesMetadata.java
@@ -74,7 +74,7 @@ public class IcebergCatalogPropertiesMetadata extends BaseCatalogPropertiesMetad
                 false /* reserved */),
             stringRequiredPropertyEntry(
                 URI, "Iceberg catalog uri config", false /* immutable */, false /* hidden */),
-            stringRequiredPropertyEntry(
+            stringOptionalPropertyEntry(
                 WAREHOUSE,
                 "Iceberg catalog warehouse config",
                 false /* immutable */,

--- a/catalogs/catalog-lakehouse-iceberg/src/test/java/org/apache/gravitino/catalog/lakehouse/iceberg/TestIcebergCatalog.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/test/java/org/apache/gravitino/catalog/lakehouse/iceberg/TestIcebergCatalog.java
@@ -146,4 +146,51 @@ public class TestIcebergCatalog {
           throwable.getMessage().contains(IcebergCatalogPropertiesMetadata.CATALOG_BACKEND));
     }
   }
+
+  @Test
+  void testCatalogInstanciation() {
+    AuditInfo auditInfo =
+        AuditInfo.builder().withCreator("creator").withCreateTime(Instant.now()).build();
+
+    CatalogEntity entity =
+        CatalogEntity.builder()
+            .withId(1L)
+            .withName("catalog")
+            .withNamespace(Namespace.of("metalake"))
+            .withType(IcebergCatalog.Type.RELATIONAL)
+            .withProvider("iceberg")
+            .withAuditInfo(auditInfo)
+            .build();
+
+    Map<String, String> conf = Maps.newHashMap();
+
+    try (IcebergCatalogOperations ops = new IcebergCatalogOperations()) {
+      ops.initialize(conf, entity.toCatalogInfo(), ICEBERG_PROPERTIES_METADATA);
+      Map<String, String> map1 = Maps.newHashMap();
+      map1.put(IcebergCatalogPropertiesMetadata.CATALOG_BACKEND, "test");
+      PropertiesMetadata metadata = ICEBERG_PROPERTIES_METADATA.catalogPropertiesMetadata();
+      Assertions.assertThrows(
+          IllegalArgumentException.class,
+          () -> {
+            PropertiesMetadataHelpers.validatePropertyForCreate(metadata, map1);
+          });
+
+      Map<String, String> map2 = Maps.newHashMap();
+      map2.put(IcebergCatalogPropertiesMetadata.CATALOG_BACKEND, "rest");
+      map2.put(IcebergCatalogPropertiesMetadata.URI, "127.0.0.1");
+      Assertions.assertDoesNotThrow(
+          () -> {
+            PropertiesMetadataHelpers.validatePropertyForCreate(metadata, map2);
+          });
+
+      Map<String, String> map3 = Maps.newHashMap();
+      Throwable throwable =
+          Assertions.assertThrows(
+              IllegalArgumentException.class,
+              () -> PropertiesMetadataHelpers.validatePropertyForCreate(metadata, map3));
+
+      Assertions.assertTrue(
+          throwable.getMessage().contains(IcebergCatalogPropertiesMetadata.CATALOG_BACKEND));
+    }
+  }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,7 +23,7 @@ org.gradle.caching=true
 org.gradle.jvmargs=-Xmx4g
 
 # version that is going to be updated automatically by releases
-version = 0.7.0-incubating-SNAPSHOT
+version = 0.8.0-incubating-SNAPSHOT
 
 # sonatype credentials
 SONATYPE_USER = admin

--- a/gradle.properties
+++ b/gradle.properties
@@ -37,7 +37,7 @@ jdkVersion = 8
 defaultScalaVersion = 2.12
 
 # pythonVersion is used to specify the version of Python to build and test Gravitino python client.
-pythonVersion = 3.11
+pythonVersion = 3.8
 
 # skipDockerTests is used to skip the tests that require Docker to be running.
 skipDockerTests = true

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,7 @@
 org.gradle.parallel=true
 # Build cache can be disabled with --no-build-cache option
 org.gradle.caching=true
-org.gradle.jvmargs=-Xmx4g
+org.gradle.jvmargs=-Xmx12g
 
 # version that is going to be updated automatically by releases
 version = 0.7.0-incubating-SNAPSHOT
@@ -31,7 +31,7 @@ SONATYPE_PASSWORD = password
 
 # jdkVersion is used to specify the version of JDK to build and test Gravitino, current
 # supported version is 8, 11, and 17.
-jdkVersion = 8
+jdkVersion = 17
 
 # defaultScalaVersion is used to specify the version of Scala to build and test Gravitino
 defaultScalaVersion = 2.12

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,7 +23,7 @@ org.gradle.caching=true
 org.gradle.jvmargs=-Xmx4g
 
 # version that is going to be updated automatically by releases
-version = 0.8.0-incubating-SNAPSHOT
+version = 0.7.0-incubating-SNAPSHOT
 
 # sonatype credentials
 SONATYPE_USER = admin

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,7 @@
 org.gradle.parallel=true
 # Build cache can be disabled with --no-build-cache option
 org.gradle.caching=true
-org.gradle.jvmargs=-Xmx12g
+org.gradle.jvmargs=-Xmx4g
 
 # version that is going to be updated automatically by releases
 version = 0.7.0-incubating-SNAPSHOT
@@ -31,13 +31,13 @@ SONATYPE_PASSWORD = password
 
 # jdkVersion is used to specify the version of JDK to build and test Gravitino, current
 # supported version is 8, 11, and 17.
-jdkVersion = 17
+jdkVersion = 8
 
 # defaultScalaVersion is used to specify the version of Scala to build and test Gravitino
 defaultScalaVersion = 2.12
 
 # pythonVersion is used to specify the version of Python to build and test Gravitino python client.
-pythonVersion = 3.8
+pythonVersion = 3.11
 
 # skipDockerTests is used to skip the tests that require Docker to be running.
 skipDockerTests = true

--- a/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/IcebergConfig.java
+++ b/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/IcebergConfig.java
@@ -23,7 +23,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 import java.util.Map;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.gravitino.Config;

--- a/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/IcebergConfig.java
+++ b/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/IcebergConfig.java
@@ -65,6 +65,7 @@ public class IcebergConfig extends Config implements OverwriteDefaultConfig {
           .doc("Warehouse directory of catalog")
           .version(ConfigConstants.VERSION_0_2_0)
           .stringConf()
+          .setOptional()
           .checkValue(StringUtils::isNotBlank, ConfigConstants.NOT_BLANK_ERROR_MSG)
           .create();
 

--- a/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/IcebergConfig.java
+++ b/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/IcebergConfig.java
@@ -60,7 +60,7 @@ public class IcebergConfig extends Config implements OverwriteDefaultConfig {
           .stringConf()
           .create();
 
-  public static final ConfigEntry<String> CATALOG_WAREHOUSE =
+  public static final ConfigEntry<Optional<String>> CATALOG_WAREHOUSE =
       new ConfigBuilder(IcebergConstants.WAREHOUSE)
           .doc("Warehouse directory of catalog")
           .version(ConfigConstants.VERSION_0_2_0)

--- a/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/IcebergConfig.java
+++ b/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/IcebergConfig.java
@@ -65,9 +65,7 @@ public class IcebergConfig extends Config implements OverwriteDefaultConfig {
           .doc("Warehouse directory of catalog")
           .version(ConfigConstants.VERSION_0_2_0)
           .stringConf()
-          .setOptional()
-          .checkValue(StringUtils::isNotBlank, ConfigConstants.NOT_BLANK_ERROR_MSG)
-          .create();
+          .createWithOptional();
 
   public static final ConfigEntry<String> CATALOG_URI =
       new ConfigBuilder(IcebergConstants.URI)

--- a/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/IcebergConfig.java
+++ b/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/IcebergConfig.java
@@ -23,6 +23,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.Map;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.gravitino.Config;

--- a/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/IcebergConfig.java
+++ b/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/IcebergConfig.java
@@ -61,12 +61,12 @@ public class IcebergConfig extends Config implements OverwriteDefaultConfig {
           .stringConf()
           .create();
 
-  public static final ConfigEntry<Optional<String>> CATALOG_WAREHOUSE =
+  public static final ConfigEntry<String> CATALOG_WAREHOUSE =
       new ConfigBuilder(IcebergConstants.WAREHOUSE)
           .doc("Warehouse directory of catalog")
           .version(ConfigConstants.VERSION_0_2_0)
           .stringConf()
-          .createWithOptional();
+          .create();
 
   public static final ConfigEntry<String> CATALOG_URI =
       new ConfigBuilder(IcebergConstants.URI)

--- a/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/ops/IcebergCatalogWrapper.java
+++ b/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/ops/IcebergCatalogWrapper.java
@@ -29,6 +29,7 @@ import java.util.Set;
 import java.util.function.Supplier;
 import lombok.Getter;
 import lombok.Setter;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.gravitino.catalog.lakehouse.iceberg.IcebergConstants;
 import org.apache.gravitino.iceberg.common.IcebergCatalogBackend;
 import org.apache.gravitino.iceberg.common.IcebergConfig;
@@ -85,7 +86,9 @@ public class IcebergCatalogWrapper implements AutoCloseable {
     if (!IcebergCatalogBackend.MEMORY.equals(catalogBackend)
         && !IcebergCatalogBackend.REST.equals(catalogBackend)) {
       // check whether IcebergConfig.CATALOG_WAREHOUSE exists
-      icebergConfig.get(IcebergConfig.CATALOG_WAREHOUSE);
+      if (StringUtils.isBlank(icebergConfig.get(IcebergConfig.CATALOG_WAREHOUSE))) {
+        throw new IllegalArgumentException("The 'warehouse' parameter must have a value.");
+      }
     }
     if (!IcebergCatalogBackend.MEMORY.equals(catalogBackend)) {
       this.catalogUri = icebergConfig.get(IcebergConfig.CATALOG_URI);

--- a/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/ops/IcebergCatalogWrapper.java
+++ b/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/ops/IcebergCatalogWrapper.java
@@ -86,6 +86,8 @@ public class IcebergCatalogWrapper implements AutoCloseable {
         !IcebergCatalogBackend.REST.equals(catalogBackend)) {
       // check whether IcebergConfig.CATALOG_WAREHOUSE exists
       icebergConfig.get(IcebergConfig.CATALOG_WAREHOUSE);
+    }
+    if (!IcebergCatalogBackend.MEMORY.equals(catalogBackend)){
       this.catalogUri = icebergConfig.get(IcebergConfig.CATALOG_URI);
     }
     this.catalog = IcebergCatalogUtil.loadCatalogBackend(catalogBackend, icebergConfig);

--- a/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/ops/IcebergCatalogWrapper.java
+++ b/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/ops/IcebergCatalogWrapper.java
@@ -82,7 +82,8 @@ public class IcebergCatalogWrapper implements AutoCloseable {
     this.catalogBackend =
         IcebergCatalogBackend.valueOf(
             icebergConfig.get(IcebergConfig.CATALOG_BACKEND).toUpperCase(Locale.ROOT));
-    if (!IcebergCatalogBackend.MEMORY.equals(catalogBackend)) {
+    if (!IcebergCatalogBackend.MEMORY.equals(catalogBackend) &&
+        !IcebergCatalogBackend.REST.equals(catalogBackend)) {
       // check whether IcebergConfig.CATALOG_WAREHOUSE exists
       icebergConfig.get(IcebergConfig.CATALOG_WAREHOUSE);
       this.catalogUri = icebergConfig.get(IcebergConfig.CATALOG_URI);

--- a/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/ops/IcebergCatalogWrapper.java
+++ b/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/ops/IcebergCatalogWrapper.java
@@ -82,12 +82,12 @@ public class IcebergCatalogWrapper implements AutoCloseable {
     this.catalogBackend =
         IcebergCatalogBackend.valueOf(
             icebergConfig.get(IcebergConfig.CATALOG_BACKEND).toUpperCase(Locale.ROOT));
-    if (!IcebergCatalogBackend.MEMORY.equals(catalogBackend) &&
-        !IcebergCatalogBackend.REST.equals(catalogBackend)) {
+    if (!IcebergCatalogBackend.MEMORY.equals(catalogBackend)
+        && !IcebergCatalogBackend.REST.equals(catalogBackend)) {
       // check whether IcebergConfig.CATALOG_WAREHOUSE exists
       icebergConfig.get(IcebergConfig.CATALOG_WAREHOUSE);
     }
-    if (!IcebergCatalogBackend.MEMORY.equals(catalogBackend)){
+    if (!IcebergCatalogBackend.MEMORY.equals(catalogBackend)) {
       this.catalogUri = icebergConfig.get(IcebergConfig.CATALOG_URI);
     }
     this.catalog = IcebergCatalogUtil.loadCatalogBackend(catalogBackend, icebergConfig);


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Removed the systematic validations in Iceberg Config and modified the instantiation of the warehouse attribute and uri attribute in the IcebergCatalogWrapper to conform with the new possibility (REST).

### Why are the changes needed?

The bug was blocking the creation of a rest catalog.

Fix: [#5756](https://github.com/apache/gravitino/issues/5756)

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

./gradlew build && compileDistribution && assembleDistribution + creation of the docker image there : https://hub.docker.com/r/fsalhi2/gravitino

Started gravitino with such configs : 

```
### Gravitino General Settings

gravitino.auxService.names = iceberg-rest
gravitino.iceberg-rest.classpath = iceberg-rest-server/libs, iceberg-rest-server/conf

### HTTP Server

gravitino.iceberg-rest.host = 0.0.0.0
gravitino.iceberg-rest.httpPort = 9001

### Storage

gravitino.iceberg-rest.io-impl = org.apache.iceberg.aws.s3.S3FileIO
gravitino.iceberg-rest.s3-access-key-id = XXXXX
gravitino.iceberg-rest.s3-secret-access-key = XXXXXX
gravitino.iceberg-rest.s3-path-style-access = true
gravitino.iceberg-rest.s3-endpoint = http://minio:9000/
gravitino.iceberg-rest.s3-region = us-east-1

### JDBC

gravitino.iceberg-rest.catalog-backend = jdbc
gravitino.iceberg-rest.uri = jdbc:mysql://mysql:3306/
gravitino.iceberg-rest.warehouse = s3://lake/catalog
gravitino.iceberg-rest.jdbc.user = root
gravitino.iceberg-rest.jdbc.password = XXXXXX
gravitino.iceberg-rest.jdbc-driver = com.mysql.cj.jdbc.Driver
```

Was able to create a catalog through Web UI and start working on the scheme. 