### PR TITLE
[#5934] fix(auth): Avoid other catalogs' privileges are pushed down

### DIFF
--- a/core/src/main/java/org/apache/gravitino/authorization/AuthorizationUtils.java
+++ b/core/src/main/java/org/apache/gravitino/authorization/AuthorizationUtils.java
@@ -147,8 +147,8 @@ public class AuthorizationUtils {
   public static void callAuthorizationPluginForSecurableObjects(
       String metalake,
       List<SecurableObject> securableObjects,
-      Set<String> catalogsAlreadySet,
       BiConsumer<AuthorizationPlugin, String> consumer) {
+    Set<String> catalogsAlreadySet = Sets.newHashSet();
     CatalogManager catalogManager = GravitinoEnv.getInstance().catalogManager();
     for (SecurableObject securableObject : securableObjects) {
       if (needApplyAuthorizationPluginAllCatalogs(securableObject)) {

--- a/core/src/main/java/org/apache/gravitino/authorization/AuthorizationUtils.java
+++ b/core/src/main/java/org/apache/gravitino/authorization/AuthorizationUtils.java
@@ -18,10 +18,12 @@
  */
 package org.apache.gravitino.authorization;
 
+import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import org.apache.gravitino.Catalog;
 import org.apache.gravitino.Entity;
@@ -39,6 +41,7 @@ import org.apache.gravitino.exceptions.IllegalPrivilegeException;
 import org.apache.gravitino.exceptions.NoSuchCatalogException;
 import org.apache.gravitino.exceptions.NoSuchMetadataObjectException;
 import org.apache.gravitino.exceptions.NoSuchUserException;
+import org.apache.gravitino.meta.RoleEntity;
 import org.apache.gravitino.utils.MetadataObjectUtil;
 import org.apache.gravitino.utils.NameIdentifierUtil;
 
@@ -145,7 +148,7 @@ public class AuthorizationUtils {
       String metalake,
       List<SecurableObject> securableObjects,
       Set<String> catalogsAlreadySet,
-      Consumer<AuthorizationPlugin> consumer) {
+      BiConsumer<AuthorizationPlugin, String> consumer) {
     CatalogManager catalogManager = GravitinoEnv.getInstance().catalogManager();
     for (SecurableObject securableObject : securableObjects) {
       if (needApplyAuthorizationPluginAllCatalogs(securableObject)) {
@@ -245,40 +248,6 @@ public class AuthorizationUtils {
     }
   }
 
-  private static void checkCatalogType(
-      NameIdentifier catalogIdent, Catalog.Type type, Privilege privilege) {
-    Catalog catalog = GravitinoEnv.getInstance().catalogDispatcher().loadCatalog(catalogIdent);
-    if (catalog.type() != type) {
-      throw new IllegalPrivilegeException(
-          "Catalog %s type %s doesn't support privilege %s",
-          catalogIdent, catalog.type(), privilege);
-    }
-  }
-
-  private static boolean needApplyAuthorizationPluginAllCatalogs(MetadataObject.Type type) {
-    return type == MetadataObject.Type.METALAKE;
-  }
-
-  private static boolean needApplyAuthorization(MetadataObject.Type type) {
-    return type != MetadataObject.Type.ROLE && type != MetadataObject.Type.METALAKE;
-  }
-
-  private static void callAuthorizationPluginImpl(
-      Consumer<AuthorizationPlugin> consumer, Catalog catalog) {
-
-    if (catalog instanceof BaseCatalog) {
-      BaseCatalog baseCatalog = (BaseCatalog) catalog;
-      if (baseCatalog.getAuthorizationPlugin() != null) {
-        consumer.accept(baseCatalog.getAuthorizationPlugin());
-      }
-    } else {
-      throw new IllegalArgumentException(
-          String.format(
-              "Catalog %s is not a BaseCatalog, we don't support authorization plugin for it",
-              catalog.type()));
-    }
-  }
-
   public static void authorizationPluginRemovePrivileges(
       NameIdentifier ident, Entity.EntityType type) {
     // If we enable authorization, we should remove the privileges about the entity in the
@@ -311,6 +280,83 @@ public class AuthorizationUtils {
           authorizationPlugin -> {
             authorizationPlugin.onMetadataUpdated(renameObject);
           });
+    }
+  }
+
+  public static Role filterSecurableObjects(
+      RoleEntity role, String metalakeName, String catalogName) {
+    List<SecurableObject> securableObjects = role.securableObjects();
+    List<SecurableObject> filteredSecurableObjects = Lists.newArrayList();
+    for (SecurableObject securableObject : securableObjects) {
+      NameIdentifier identifier = MetadataObjectUtil.toEntityIdent(metalakeName, securableObject);
+      if (securableObject.type() == MetadataObject.Type.METALAKE) {
+        filteredSecurableObjects.add(securableObject);
+      } else {
+        NameIdentifier catalogIdent = NameIdentifierUtil.getCatalogIdentifier(identifier);
+
+        if (catalogIdent.name().equals(catalogName)) {
+          filteredSecurableObjects.add(securableObject);
+        }
+      }
+    }
+
+    return RoleEntity.builder()
+        .withId(role.id())
+        .withName(role.name())
+        .withAuditInfo(role.auditInfo())
+        .withNamespace(role.namespace())
+        .withSecurableObjects(filteredSecurableObjects)
+        .withProperties(role.properties())
+        .build();
+  }
+
+  private static boolean needApplyAuthorizationPluginAllCatalogs(MetadataObject.Type type) {
+    return type == MetadataObject.Type.METALAKE;
+  }
+
+  private static boolean needApplyAuthorization(MetadataObject.Type type) {
+    return type != MetadataObject.Type.ROLE && type != MetadataObject.Type.METALAKE;
+  }
+
+  private static void callAuthorizationPluginImpl(
+      BiConsumer<AuthorizationPlugin, String> consumer, Catalog catalog) {
+
+    if (catalog instanceof BaseCatalog) {
+      BaseCatalog baseCatalog = (BaseCatalog) catalog;
+      if (baseCatalog.getAuthorizationPlugin() != null) {
+        consumer.accept(baseCatalog.getAuthorizationPlugin(), catalog.name());
+      }
+    } else {
+      throw new IllegalArgumentException(
+          String.format(
+              "Catalog %s is not a BaseCatalog, we don't support authorization plugin for it",
+              catalog.type()));
+    }
+  }
+
+  private static void callAuthorizationPluginImpl(
+      Consumer<AuthorizationPlugin> consumer, Catalog catalog) {
+
+    if (catalog instanceof BaseCatalog) {
+      BaseCatalog baseCatalog = (BaseCatalog) catalog;
+      if (baseCatalog.getAuthorizationPlugin() != null) {
+        consumer.accept(baseCatalog.getAuthorizationPlugin());
+      }
+    } else {
+      throw new IllegalArgumentException(
+          String.format(
+              "Catalog %s is not a BaseCatalog, we don't support authorization plugin for it",
+              catalog.type()));
+    }
+  }
+
+  private static void checkCatalogType(
+      NameIdentifier catalogIdent, Catalog.Type type, Privilege privilege) {
+    Catalog catalog = GravitinoEnv.getInstance().catalogDispatcher().loadCatalog(catalogIdent);
+    if (catalog.type() != type) {
+      throw new IllegalPrivilegeException(
+          "Catalog %s type %s doesn't support privilege %s",
+          catalogIdent, catalog.type(), privilege);
     }
   }
 }

--- a/core/src/main/java/org/apache/gravitino/authorization/PermissionManager.java
+++ b/core/src/main/java/org/apache/gravitino/authorization/PermissionManager.java
@@ -116,7 +116,6 @@ class PermissionManager {
                     .build();
               });
 
-      Set<String> catalogs = Sets.newHashSet();
       List<SecurableObject> securableObjects = Lists.newArrayList();
 
       for (Role grantedRole : roleEntitiesToGrant) {
@@ -126,7 +125,6 @@ class PermissionManager {
       AuthorizationUtils.callAuthorizationPluginForSecurableObjects(
           metalake,
           securableObjects,
-          catalogs,
           (authorizationPlugin, catalogName) ->
               authorizationPlugin.onGrantedRolesToUser(
                   roleEntitiesToGrant.stream()
@@ -204,7 +202,6 @@ class PermissionManager {
                     .build();
               });
 
-      Set<String> catalogs = Sets.newHashSet();
       List<SecurableObject> securableObjects = Lists.newArrayList();
 
       for (Role grantedRole : roleEntitiesToGrant) {
@@ -214,7 +211,6 @@ class PermissionManager {
       AuthorizationUtils.callAuthorizationPluginForSecurableObjects(
           metalake,
           securableObjects,
-          catalogs,
           (authorizationPlugin, catalogName) ->
               authorizationPlugin.onGrantedRolesToGroup(
                   roleEntitiesToGrant.stream()
@@ -291,7 +287,6 @@ class PermissionManager {
                     .build();
               });
 
-      Set<String> catalogs = Sets.newHashSet();
       List<SecurableObject> securableObjects = Lists.newArrayList();
       for (Role grantedRole : roleEntitiesToRevoke) {
         securableObjects.addAll(grantedRole.securableObjects());
@@ -300,7 +295,6 @@ class PermissionManager {
       AuthorizationUtils.callAuthorizationPluginForSecurableObjects(
           metalake,
           securableObjects,
-          catalogs,
           (authorizationPlugin, catalogName) ->
               authorizationPlugin.onRevokedRolesFromGroup(
                   roleEntitiesToRevoke.stream()
@@ -379,7 +373,6 @@ class PermissionManager {
                     .build();
               });
 
-      Set<String> catalogs = Sets.newHashSet();
       List<SecurableObject> securableObjects = Lists.newArrayList();
       for (Role grantedRole : roleEntitiesToRevoke) {
         securableObjects.addAll(grantedRole.securableObjects());
@@ -388,7 +381,6 @@ class PermissionManager {
       AuthorizationUtils.callAuthorizationPluginForSecurableObjects(
           metalake,
           securableObjects,
-          catalogs,
           (authorizationPlugin, catalogName) ->
               authorizationPlugin.onRevokedRolesFromUser(
                   roleEntitiesToRevoke.stream()

--- a/core/src/main/java/org/apache/gravitino/authorization/PermissionManager.java
+++ b/core/src/main/java/org/apache/gravitino/authorization/PermissionManager.java
@@ -21,6 +21,7 @@ package org.apache.gravitino.authorization;
 import static org.apache.gravitino.authorization.AuthorizationUtils.GROUP_DOES_NOT_EXIST_MSG;
 import static org.apache.gravitino.authorization.AuthorizationUtils.ROLE_DOES_NOT_EXIST_MSG;
 import static org.apache.gravitino.authorization.AuthorizationUtils.USER_DOES_NOT_EXIST_MSG;
+import static org.apache.gravitino.authorization.AuthorizationUtils.filterSecurableObjects;
 
 import com.google.common.collect.Lists;
 import java.io.IOException;
@@ -116,15 +117,22 @@ class PermissionManager {
               });
 
       Set<String> catalogs = Sets.newHashSet();
+      List<SecurableObject> securableObjects = Lists.newArrayList();
+
       for (Role grantedRole : roleEntitiesToGrant) {
-        AuthorizationUtils.callAuthorizationPluginForSecurableObjects(
-            metalake,
-            grantedRole.securableObjects(),
-            catalogs,
-            authorizationPlugin ->
-                authorizationPlugin.onGrantedRolesToUser(
-                    Lists.newArrayList(roleEntitiesToGrant), updatedUser));
+        securableObjects.addAll(grantedRole.securableObjects());
       }
+
+      AuthorizationUtils.callAuthorizationPluginForSecurableObjects(
+          metalake,
+          securableObjects,
+          catalogs,
+          (authorizationPlugin, catalogName) ->
+              authorizationPlugin.onGrantedRolesToUser(
+                  roleEntitiesToGrant.stream()
+                      .map(roleEntity -> filterSecurableObjects(roleEntity, metalake, catalogName))
+                      .collect(Collectors.toList()),
+                  updatedUser));
 
       return updatedUser;
     } catch (NoSuchEntityException nse) {
@@ -197,15 +205,22 @@ class PermissionManager {
               });
 
       Set<String> catalogs = Sets.newHashSet();
+      List<SecurableObject> securableObjects = Lists.newArrayList();
+
       for (Role grantedRole : roleEntitiesToGrant) {
-        AuthorizationUtils.callAuthorizationPluginForSecurableObjects(
-            metalake,
-            grantedRole.securableObjects(),
-            catalogs,
-            authorizationPlugin ->
-                authorizationPlugin.onGrantedRolesToGroup(
-                    Lists.newArrayList(roleEntitiesToGrant), updatedGroup));
+        securableObjects.addAll(grantedRole.securableObjects());
       }
+
+      AuthorizationUtils.callAuthorizationPluginForSecurableObjects(
+          metalake,
+          securableObjects,
+          catalogs,
+          (authorizationPlugin, catalogName) ->
+              authorizationPlugin.onGrantedRolesToGroup(
+                  roleEntitiesToGrant.stream()
+                      .map(roleEntity -> filterSecurableObjects(roleEntity, metalake, catalogName))
+                      .collect(Collectors.toList()),
+                  updatedGroup));
 
       return updatedGroup;
     } catch (NoSuchEntityException nse) {
@@ -277,15 +292,21 @@ class PermissionManager {
               });
 
       Set<String> catalogs = Sets.newHashSet();
+      List<SecurableObject> securableObjects = Lists.newArrayList();
       for (Role grantedRole : roleEntitiesToRevoke) {
-        AuthorizationUtils.callAuthorizationPluginForSecurableObjects(
-            metalake,
-            grantedRole.securableObjects(),
-            catalogs,
-            authorizationPlugin ->
-                authorizationPlugin.onRevokedRolesFromGroup(
-                    Lists.newArrayList(roleEntitiesToRevoke), updatedGroup));
+        securableObjects.addAll(grantedRole.securableObjects());
       }
+
+      AuthorizationUtils.callAuthorizationPluginForSecurableObjects(
+          metalake,
+          securableObjects,
+          catalogs,
+          (authorizationPlugin, catalogName) ->
+              authorizationPlugin.onRevokedRolesFromGroup(
+                  roleEntitiesToRevoke.stream()
+                      .map(roleEntity -> filterSecurableObjects(roleEntity, metalake, catalogName))
+                      .collect(Collectors.toList()),
+                  updatedGroup));
 
       return updatedGroup;
 
@@ -359,15 +380,21 @@ class PermissionManager {
               });
 
       Set<String> catalogs = Sets.newHashSet();
+      List<SecurableObject> securableObjects = Lists.newArrayList();
       for (Role grantedRole : roleEntitiesToRevoke) {
-        AuthorizationUtils.callAuthorizationPluginForSecurableObjects(
-            metalake,
-            grantedRole.securableObjects(),
-            catalogs,
-            authorizationPlugin ->
-                authorizationPlugin.onRevokedRolesFromUser(
-                    Lists.newArrayList(roleEntitiesToRevoke), updatedUser));
+        securableObjects.addAll(grantedRole.securableObjects());
       }
+
+      AuthorizationUtils.callAuthorizationPluginForSecurableObjects(
+          metalake,
+          securableObjects,
+          catalogs,
+          (authorizationPlugin, catalogName) ->
+              authorizationPlugin.onRevokedRolesFromUser(
+                  roleEntitiesToRevoke.stream()
+                      .map(roleEntity -> filterSecurableObjects(roleEntity, metalake, catalogName))
+                      .collect(Collectors.toList()),
+                  updatedUser));
 
       return updatedUser;
     } catch (NoSuchEntityException nse) {

--- a/core/src/main/java/org/apache/gravitino/authorization/RoleManager.java
+++ b/core/src/main/java/org/apache/gravitino/authorization/RoleManager.java
@@ -88,7 +88,9 @@ class RoleManager {
           metalake,
           roleEntity.securableObjects(),
           Sets.newHashSet(),
-          authorizationPlugin -> authorizationPlugin.onRoleCreated(roleEntity));
+          (authorizationPlugin, catalogName) ->
+              authorizationPlugin.onRoleCreated(
+                  AuthorizationUtils.filterSecurableObjects(roleEntity, metalake, catalogName)));
 
       return roleEntity;
     } catch (EntityAlreadyExistsException e) {
@@ -123,7 +125,9 @@ class RoleManager {
             metalake,
             roleEntity.securableObjects(),
             Sets.newHashSet(),
-            authorizationPlugin -> authorizationPlugin.onRoleDeleted(roleEntity));
+            (authorizationPlugin, catalogName) ->
+                authorizationPlugin.onRoleDeleted(
+                    AuthorizationUtils.filterSecurableObjects(roleEntity, metalake, catalogName)));
       } catch (NoSuchEntityException nse) {
         // ignore, because the role may have been deleted.
       }

--- a/core/src/main/java/org/apache/gravitino/authorization/RoleManager.java
+++ b/core/src/main/java/org/apache/gravitino/authorization/RoleManager.java
@@ -21,7 +21,6 @@ package org.apache.gravitino.authorization;
 
 import static org.apache.gravitino.metalake.MetalakeManager.checkMetalake;
 
-import com.google.common.collect.Sets;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.List;
@@ -87,7 +86,6 @@ class RoleManager {
       AuthorizationUtils.callAuthorizationPluginForSecurableObjects(
           metalake,
           roleEntity.securableObjects(),
-          Sets.newHashSet(),
           (authorizationPlugin, catalogName) ->
               authorizationPlugin.onRoleCreated(
                   AuthorizationUtils.filterSecurableObjects(roleEntity, metalake, catalogName)));
@@ -124,7 +122,6 @@ class RoleManager {
         AuthorizationUtils.callAuthorizationPluginForSecurableObjects(
             metalake,
             roleEntity.securableObjects(),
-            Sets.newHashSet(),
             (authorizationPlugin, catalogName) ->
                 authorizationPlugin.onRoleDeleted(
                     AuthorizationUtils.filterSecurableObjects(roleEntity, metalake, catalogName)));


### PR DESCRIPTION
### What changes were proposed in this pull request?
Avoid other catalogs' privileges are pushed down.
For example, if a role has two catalogs. One catalog has select table, the other catalog has create table.
The plugin will make the role can create and select table at the same time.

### Why are the changes needed?

Fix: #5934

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Add a UT