### PR TITLE
[#5926] fix(CLI): Fix Missleading error message in Gravitino CLI when missing schema

### DIFF
--- a/clients/cli/src/main/java/org/apache/gravitino/cli/GravitinoCommandLine.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/GravitinoCommandLine.java
@@ -317,24 +317,14 @@ public class GravitinoCommandLine extends TestableCommandLine {
     FullName name = new FullName(line);
     String metalake = name.getMetalakeName();
     String catalog = name.getCatalogName();
+    String schema = name.getSchemaName();
 
     Command.setAuthenticationMode(auth, userName);
+
     List<String> missingEntities = Lists.newArrayList();
-    if (metalake == null) missingEntities.add(CommandEntities.METALAKE);
     if (catalog == null) missingEntities.add(CommandEntities.CATALOG);
 
-    // Handle the CommandActions.LIST action separately as it doesn't use `schema`
-    if (CommandActions.LIST.equals(command)) {
-      if (!missingEntities.isEmpty()) {
-        System.err.println("Missing required argument(s): " + COMMA_JOINER.join(missingEntities));
-        Main.exit(-1);
-      }
-      newListSchema(url, ignore, metalake, catalog).handle();
-      return;
-    }
-
-    String schema = name.getSchemaName();
-    if (schema == null) {
+    if (!CommandActions.LIST.equals(command) && schema == null) {
       missingEntities.add(CommandEntities.SCHEMA);
     }
 
@@ -350,6 +340,10 @@ public class GravitinoCommandLine extends TestableCommandLine {
         } else {
           newSchemaDetails(url, ignore, metalake, catalog, schema).handle();
         }
+        break;
+
+      case CommandActions.LIST:
+        newListSchema(url, ignore, metalake, catalog).handle();
         break;
 
       case CommandActions.CREATE:

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/GravitinoCommandLine.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/GravitinoCommandLine.java
@@ -21,6 +21,7 @@ package org.apache.gravitino.cli;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -318,14 +319,29 @@ public class GravitinoCommandLine extends TestableCommandLine {
     String catalog = name.getCatalogName();
 
     Command.setAuthenticationMode(auth, userName);
+    List<String> missingEntities = Lists.newArrayList();
+    if (metalake == null) missingEntities.add(CommandEntities.METALAKE);
+    if (catalog == null) missingEntities.add(CommandEntities.CATALOG);
 
     // Handle the CommandActions.LIST action separately as it doesn't use `schema`
     if (CommandActions.LIST.equals(command)) {
+      if (!missingEntities.isEmpty()) {
+        System.err.println("Missing required argument(s): " + COMMA_JOINER.join(missingEntities));
+        Main.exit(-1);
+      }
       newListSchema(url, ignore, metalake, catalog).handle();
       return;
     }
 
     String schema = name.getSchemaName();
+    if (schema == null) {
+      missingEntities.add(CommandEntities.SCHEMA);
+    }
+
+    if (!missingEntities.isEmpty()) {
+      System.err.println("Missing required argument(s): " + COMMA_JOINER.join(missingEntities));
+      Main.exit(-1);
+    }
 
     switch (command) {
       case CommandActions.DETAILS:

--- a/clients/cli/src/test/java/org/apache/gravitino/cli/TestSchemaCommands.java
+++ b/clients/cli/src/test/java/org/apache/gravitino/cli/TestSchemaCommands.java
@@ -30,7 +30,6 @@ import static org.mockito.Mockito.when;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
-import java.security.Permission;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Options;
 import org.apache.gravitino.cli.commands.CreateSchema;
@@ -53,14 +52,6 @@ class TestSchemaCommands {
   private final ByteArrayOutputStream errContent = new ByteArrayOutputStream();
   private final PrintStream originalOut = System.out;
   private final PrintStream originalErr = System.err;
-  private final SecurityManager securityManager =
-      new SecurityManager() {
-        public void checkPermission(Permission permission) {
-          if (permission.getName().startsWith("exitVM")) {
-            throw new RuntimeException(permission.getName());
-          }
-        }
-      };
 
   @BeforeEach
   void setUp() {
@@ -71,8 +62,8 @@ class TestSchemaCommands {
   }
 
   @AfterEach
-  void restoreSecurityManager() {
-    System.setSecurityManager(null);
+  void restoreExitFlg() {
+    Main.useExit = true;
   }
 
   @AfterEach
@@ -282,7 +273,7 @@ class TestSchemaCommands {
   @Test
   @SuppressWarnings("DefaultCharset")
   void testListSchemaWithoutCatalog() {
-    System.setSecurityManager(securityManager);
+    Main.useExit = false;
     when(mockCommandLine.hasOption(GravitinoOptions.METALAKE)).thenReturn(true);
     when(mockCommandLine.getOptionValue(GravitinoOptions.METALAKE)).thenReturn("metalake_demo");
     when(mockCommandLine.hasOption(GravitinoOptions.NAME)).thenReturn(false);
@@ -302,7 +293,7 @@ class TestSchemaCommands {
   @Test
   @SuppressWarnings("DefaultCharset")
   void testDetailsSchemaWithoutCatalog() {
-    System.setSecurityManager(securityManager);
+    Main.useExit = false;
     when(mockCommandLine.hasOption(GravitinoOptions.METALAKE)).thenReturn(true);
     when(mockCommandLine.getOptionValue(GravitinoOptions.METALAKE)).thenReturn("metalake_demo");
     when(mockCommandLine.hasOption(GravitinoOptions.NAME)).thenReturn(false);
@@ -326,7 +317,7 @@ class TestSchemaCommands {
   @Test
   @SuppressWarnings("DefaultCharset")
   void testDetailsSchemaWithoutSchema() {
-    System.setSecurityManager(securityManager);
+    Main.useExit = false;
     when(mockCommandLine.hasOption(GravitinoOptions.METALAKE)).thenReturn(true);
     when(mockCommandLine.getOptionValue(GravitinoOptions.METALAKE)).thenReturn("metalake_demo");
     when(mockCommandLine.hasOption(GravitinoOptions.NAME)).thenReturn(true);


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Fix schema arguments validation just like table commands. running  command like  `gcli schema details --metalake metalake_demo --name catalog_postgres -I` give Missleading error message as below.

```bash
Malformed entity name.
Invalid string to encode: null
```
It should display a friendly error message.

### Why are the changes needed?

Fix: #5926 

### Does this PR introduce _any_ user-facing change?

NO

### How was this patch tested?

```bash
bin/gcli.sh schema details --m demo_metalake -i
# output
# Missing --name option.
# Missing --name option.
# Missing required argument(s): catalog, schema

bin/gcli.sh schema details --m demo_metalake --name Hive_catalog -i
# output
# Malformed entity name.
# Missing required argument(s): schema

bin/gcli.sh schema details --m demo_metalake --name Hive_catalog.default -i
# ouput: default,Default Hive database

bin/gcli.sh schema list --m demo_metalake -i
# output:
# Missing --name option.
# Missing required argument(s): catalog

bin/gcli.sh schema list --m demo_metalake -i --name Hive_catalog
# correct output
```
