### PR TITLE
[#5929] improvement(CLI): fix cli details command produce no output

### DIFF
--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/GroupDetails.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/GroupDetails.java
@@ -60,7 +60,7 @@ public class GroupDetails extends Command {
       exitWithError(exp.getMessage());
     }
 
-    String all = String.join(",", roles);
+    String all = roles.isEmpty() ? "Groups has no roles." : String.join(",", roles);
 
     System.out.println(all.toString());
   }

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/GroupDetails.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/GroupDetails.java
@@ -60,7 +60,7 @@ public class GroupDetails extends Command {
       exitWithError(exp.getMessage());
     }
 
-    String all = roles.isEmpty() ? "Groups has no roles." : String.join(",", roles);
+    String all = roles.isEmpty() ? "The group has no roles." : String.join(",", roles);
 
     System.out.println(all.toString());
   }

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/UserDetails.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/UserDetails.java
@@ -60,7 +60,7 @@ public class UserDetails extends Command {
       exitWithError(exp.getMessage());
     }
 
-    String all = String.join(",", roles);
+    String all = roles.isEmpty() ? "User has no roles." : String.join(",", roles);
 
     System.out.println(all.toString());
   }

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/UserDetails.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/UserDetails.java
@@ -60,7 +60,7 @@ public class UserDetails extends Command {
       exitWithError(exp.getMessage());
     }
 
-    String all = roles.isEmpty() ? "User has no roles." : String.join(",", roles);
+    String all = roles.isEmpty() ? "The user has no roles." : String.join(",", roles);
 
     System.out.println(all.toString());
   }


### PR DESCRIPTION

<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

If a user has no roles then no output is produced from `user\group details` command, it should give some help information.

### Why are the changes needed?

Fix: #5929 

### Does this PR introduce _any_ user-facing change?

NO

### How was this patch tested?

```bash
bin/gcli.sh user details -m demo_metalake --user test_user
# output: User has no roles.

bin/gcli.sh group details -m demo_metalake --group group_no_role
# output: Groups has no roles.
```