### PR TITLE
[#5927] improvement(CLI): fix cli get multiple "Malformed entity name."

### DIFF
--- a/clients/cli/src/main/java/org/apache/gravitino/cli/FullName.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/FullName.java
@@ -29,8 +29,8 @@ public class FullName {
   private final CommandLine line;
   private String metalakeEnv;
   private boolean matalakeSet = false;
-  private boolean isMissingNameInfoVisible = true;
-  private boolean isMalformedInfoVisible = true;
+  private boolean hasDisplayedMissingNameInfo = true;
+  private boolean hasDisplayedMalformedInfo = true;
 
   /**
    * Constructor for the {@code FullName} class.
@@ -228,16 +228,16 @@ public class FullName {
   }
 
   private void showMissingNameInfo() {
-    if (isMissingNameInfoVisible) {
+    if (hasDisplayedMissingNameInfo) {
       System.err.println(ErrorMessages.MISSING_NAME);
-      isMissingNameInfoVisible = false;
+      hasDisplayedMissingNameInfo = false;
     }
   }
 
   private void showMalformedInfo() {
-    if (isMalformedInfoVisible) {
+    if (hasDisplayedMalformedInfo) {
       System.err.println(ErrorMessages.MALFORMED_NAME);
-      isMalformedInfoVisible = false;
+      hasDisplayedMalformedInfo = false;
     }
   }
 }

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/FullName.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/FullName.java
@@ -29,6 +29,8 @@ public class FullName {
   private final CommandLine line;
   private String metalakeEnv;
   private boolean matalakeSet = false;
+  private boolean isMissingNameInfoVisible = true;
+  private boolean isMalformedInfoVisible = true;
 
   /**
    * Constructor for the {@code FullName} class.
@@ -159,14 +161,14 @@ public class FullName {
       String[] names = line.getOptionValue(GravitinoOptions.NAME).split("\\.");
 
       if (names.length <= position) {
-        System.err.println(ErrorMessages.MALFORMED_NAME);
+        showMalformedInfo();
         return null;
       }
 
       return names[position];
     }
 
-    System.err.println(ErrorMessages.MISSING_NAME);
+    showMissingNameInfo();
     return null;
   }
 
@@ -223,5 +225,19 @@ public class FullName {
    */
   public boolean hasColumnName() {
     return hasNamePart(4);
+  }
+
+  private void showMissingNameInfo() {
+    if (isMissingNameInfoVisible) {
+      System.err.println(ErrorMessages.MISSING_NAME);
+      isMissingNameInfoVisible = false;
+    }
+  }
+
+  private void showMalformedInfo() {
+    if (isMalformedInfoVisible) {
+      System.err.println(ErrorMessages.MALFORMED_NAME);
+      isMalformedInfoVisible = false;
+    }
   }
 }


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

If an entity name is malformed, the CLI should output 'Malformed entity name.' only once, instead of multiple times.

### Why are the changes needed?

Fix: #5927 

### Does this PR introduce _any_ user-facing change?

NO

### How was this patch tested?

```bash
bin/gcli.sh column list  -m demo_metalake --name Hive_catalog -i
# output: Malformed entity name.
```