### PR TITLE
[#5928] fix(CLI): Fix columns details command produces no output

### DIFF
--- a/clients/cli/src/main/java/org/apache/gravitino/cli/GravitinoCommandLine.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/GravitinoCommandLine.java
@@ -756,7 +756,8 @@ public class GravitinoCommandLine extends TestableCommandLine {
         if (line.hasOption(GravitinoOptions.AUDIT)) {
           newColumnAudit(url, ignore, metalake, catalog, schema, table, column).handle();
         } else {
-          System.out.println(ErrorMessages.UNSUPPORTED_ACTION);
+          System.err.println(ErrorMessages.UNSUPPORTED_ACTION);
+          Main.exit(-1);
         }
         break;
 

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/GravitinoCommandLine.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/GravitinoCommandLine.java
@@ -755,6 +755,8 @@ public class GravitinoCommandLine extends TestableCommandLine {
       case CommandActions.DETAILS:
         if (line.hasOption(GravitinoOptions.AUDIT)) {
           newColumnAudit(url, ignore, metalake, catalog, schema, table, column).handle();
+        } else {
+          System.out.println(ErrorMessages.UNSUPPORTED_ACTION);
         }
         break;
 

--- a/clients/cli/src/test/java/org/apache/gravitino/cli/TestColumnCommands.java
+++ b/clients/cli/src/test/java/org/apache/gravitino/cli/TestColumnCommands.java
@@ -19,12 +19,17 @@
 
 package org.apache.gravitino.cli;
 
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Options;
 import org.apache.gravitino.cli.commands.AddColumn;
@@ -38,17 +43,30 @@ import org.apache.gravitino.cli.commands.UpdateColumnDefault;
 import org.apache.gravitino.cli.commands.UpdateColumnName;
 import org.apache.gravitino.cli.commands.UpdateColumnNullability;
 import org.apache.gravitino.cli.commands.UpdateColumnPosition;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class TestColumnCommands {
   private CommandLine mockCommandLine;
   private Options mockOptions;
+  private final ByteArrayOutputStream outContent = new ByteArrayOutputStream();
+  private final ByteArrayOutputStream errContent = new ByteArrayOutputStream();
+  private final PrintStream originalOut = System.out;
+  private final PrintStream originalErr = System.err;
 
   @BeforeEach
   void setUp() {
     mockCommandLine = mock(CommandLine.class);
     mockOptions = mock(Options.class);
+    System.setOut(new PrintStream(outContent));
+    System.setErr(new PrintStream(errContent));
+  }
+
+  @AfterEach
+  public void restoreStreams() {
+    System.setOut(originalOut);
+    System.setErr(originalErr);
   }
 
   @Test
@@ -96,6 +114,32 @@ class TestColumnCommands {
             "name");
     commandLine.handleCommandLine();
     verify(mockAudit).handle();
+  }
+
+  @Test
+  void testColumnDetailsCommand() {
+    when(mockCommandLine.hasOption(GravitinoOptions.METALAKE)).thenReturn(true);
+    when(mockCommandLine.getOptionValue(GravitinoOptions.METALAKE)).thenReturn("metalake_demo");
+    when(mockCommandLine.hasOption(GravitinoOptions.NAME)).thenReturn(true);
+    when(mockCommandLine.getOptionValue(GravitinoOptions.NAME))
+        .thenReturn("catalog.schema.users.name");
+    GravitinoCommandLine commandLine =
+        spy(
+            new GravitinoCommandLine(
+                mockCommandLine, mockOptions, CommandEntities.COLUMN, CommandActions.DETAILS));
+
+    commandLine.handleCommandLine();
+    verify(commandLine, never())
+        .newColumnAudit(
+            GravitinoCommandLine.DEFAULT_URL,
+            false,
+            "metalake_demo",
+            "catalog",
+            "schema",
+            "users",
+            "name");
+    String output = new String(outContent.toByteArray(), StandardCharsets.UTF_8).trim();
+    assertEquals(output, ErrorMessages.UNSUPPORTED_ACTION);
   }
 
   @Test

--- a/clients/cli/src/test/java/org/apache/gravitino/cli/TestColumnCommands.java
+++ b/clients/cli/src/test/java/org/apache/gravitino/cli/TestColumnCommands.java
@@ -20,6 +20,7 @@
 package org.apache.gravitino.cli;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -118,6 +119,7 @@ class TestColumnCommands {
 
   @Test
   void testColumnDetailsCommand() {
+    Main.useExit = false;
     when(mockCommandLine.hasOption(GravitinoOptions.METALAKE)).thenReturn(true);
     when(mockCommandLine.getOptionValue(GravitinoOptions.METALAKE)).thenReturn("metalake_demo");
     when(mockCommandLine.hasOption(GravitinoOptions.NAME)).thenReturn(true);
@@ -128,7 +130,7 @@ class TestColumnCommands {
             new GravitinoCommandLine(
                 mockCommandLine, mockOptions, CommandEntities.COLUMN, CommandActions.DETAILS));
 
-    commandLine.handleCommandLine();
+    assertThrows(RuntimeException.class, commandLine::handleCommandLine);
     verify(commandLine, never())
         .newColumnAudit(
             GravitinoCommandLine.DEFAULT_URL,
@@ -138,7 +140,8 @@ class TestColumnCommands {
             "schema",
             "users",
             "name");
-    String output = new String(outContent.toByteArray(), StandardCharsets.UTF_8).trim();
+
+    String output = new String(errContent.toByteArray(), StandardCharsets.UTF_8).trim();
     assertEquals(output, ErrorMessages.UNSUPPORTED_ACTION);
   }
 


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Fix columns details command produces no output, when command without --audit option, cli should tell user that command is not support.

### Why are the changes needed?

Fix: #5928 

### Does this PR introduce _any_ user-facing change?

NO

### How was this patch tested?

local test.
