### PR TITLE
[#5861] improvement(CLI): Refactor the validation logic in the handle methods

### DIFF
--- a/clients/cli/src/main/java/org/apache/gravitino/cli/ErrorMessages.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/ErrorMessages.java
@@ -32,7 +32,7 @@ public class ErrorMessages {
   public static final String MISSING_NAME = "Missing --name option.";
   public static final String MISSING_GROUP = "Missing --group option.";
   public static final String MISSING_USER = "Missing --user option.";
-  public static final String MISSING_TAG = "Missing --tar option.";
+  public static final String MISSING_TAG = "Missing --tag option.";
   public static final String METALAKE_EXISTS = "Metalake already exists.";
   public static final String CATALOG_EXISTS = "Catalog already exists.";
   public static final String SCHEMA_EXISTS = "Schema already exists.";

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/ErrorMessages.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/ErrorMessages.java
@@ -32,6 +32,7 @@ public class ErrorMessages {
   public static final String MISSING_NAME = "Missing --name option.";
   public static final String MISSING_GROUP = "Missing --group option.";
   public static final String MISSING_USER = "Missing --user option.";
+  public static final String MISSING_TAG = "Missing --tar option.";
   public static final String METALAKE_EXISTS = "Metalake already exists.";
   public static final String CATALOG_EXISTS = "Catalog already exists.";
   public static final String SCHEMA_EXISTS = "Schema already exists.";

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/GravitinoCommandLine.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/GravitinoCommandLine.java
@@ -31,8 +31,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Options;
@@ -255,6 +253,7 @@ public class GravitinoCommandLine extends TestableCommandLine {
     String outputFormat = line.getOptionValue(GravitinoOptions.OUTPUT);
 
     Command.setAuthenticationMode(auth, userName);
+    List<String> missingEntities = Lists.newArrayList();
 
     // Handle the CommandActions.LIST action separately as it doesn't use `catalog`
     if (CommandActions.LIST.equals(command)) {
@@ -263,6 +262,8 @@ public class GravitinoCommandLine extends TestableCommandLine {
     }
 
     String catalog = name.getCatalogName();
+    if (catalog == null) missingEntities.add(CommandEntities.CATALOG);
+    checkEntities(missingEntities);
 
     switch (command) {
       case CommandActions.DETAILS:
@@ -343,29 +344,21 @@ public class GravitinoCommandLine extends TestableCommandLine {
     String catalog = name.getCatalogName();
 
     Command.setAuthenticationMode(auth, userName);
+
     List<String> missingEntities = Lists.newArrayList();
     if (metalake == null) missingEntities.add(CommandEntities.METALAKE);
     if (catalog == null) missingEntities.add(CommandEntities.CATALOG);
 
     // Handle the CommandActions.LIST action separately as it doesn't use `schema`
     if (CommandActions.LIST.equals(command)) {
-      if (!missingEntities.isEmpty()) {
-        System.err.println("Missing required argument(s): " + COMMA_JOINER.join(missingEntities));
-        Main.exit(-1);
-      }
+      checkEntities(missingEntities);
       newListSchema(url, ignore, metalake, catalog).handle();
       return;
     }
 
     String schema = name.getSchemaName();
-    if (schema == null) {
-      missingEntities.add(CommandEntities.SCHEMA);
-    }
-
-    if (!missingEntities.isEmpty()) {
-      System.err.println("Missing required argument(s): " + COMMA_JOINER.join(missingEntities));
-      Main.exit(-1);
-    }
+    if (schema == null) missingEntities.add(CommandEntities.SCHEMA);
+    checkEntities(missingEntities);
 
     switch (command) {
       case CommandActions.DETAILS:
@@ -421,33 +414,20 @@ public class GravitinoCommandLine extends TestableCommandLine {
     String schema = name.getSchemaName();
 
     Command.setAuthenticationMode(auth, userName);
-    List<String> missingEntities =
-        Stream.of(
-                catalog == null ? CommandEntities.CATALOG : null,
-                schema == null ? CommandEntities.SCHEMA : null)
-            .filter(Objects::nonNull)
-            .collect(Collectors.toList());
+    List<String> missingEntities = Lists.newArrayList();
+    if (catalog == null) missingEntities.add(CommandEntities.CATALOG);
+    if (schema == null) missingEntities.add(CommandEntities.SCHEMA);
 
     // Handle CommandActions.LIST action separately as it doesn't require the `table`
     if (CommandActions.LIST.equals(command)) {
-      if (!missingEntities.isEmpty()) {
-        System.err.println(
-            "Missing required argument(s): " + Joiner.on(", ").join(missingEntities));
-        Main.exit(-1);
-      }
+      checkEntities(missingEntities);
       newListTables(url, ignore, metalake, catalog, schema).handle();
       return;
     }
 
     String table = name.getTableName();
-    if (table == null) {
-      missingEntities.add(CommandEntities.TABLE);
-    }
-
-    if (!missingEntities.isEmpty()) {
-      System.err.println("Missing required argument(s): " + Joiner.on(", ").join(missingEntities));
-      Main.exit(-1);
-    }
+    if (table == null) missingEntities.add(CommandEntities.TABLE);
+    checkEntities(missingEntities);
 
     switch (command) {
       case CommandActions.DETAILS:
@@ -527,7 +507,7 @@ public class GravitinoCommandLine extends TestableCommandLine {
 
     if (user == null && !CommandActions.LIST.equals(command)) {
       System.err.println(ErrorMessages.MISSING_USER);
-      return;
+      Main.exit(-1);
     }
 
     switch (command) {
@@ -588,7 +568,7 @@ public class GravitinoCommandLine extends TestableCommandLine {
 
     if (group == null && !CommandActions.LIST.equals(command)) {
       System.err.println(ErrorMessages.MISSING_GROUP);
-      return;
+      Main.exit(-1);
     }
 
     switch (command) {
@@ -647,6 +627,13 @@ public class GravitinoCommandLine extends TestableCommandLine {
     Command.setAuthenticationMode(auth, userName);
 
     String[] tags = line.getOptionValues(GravitinoOptions.TAG);
+    if (tags == null
+        && !((CommandActions.REMOVE.equals(command) && line.hasOption(GravitinoOptions.FORCE))
+            || CommandActions.LIST.equals(command))) {
+      System.err.println(ErrorMessages.MISSING_TAG);
+      Main.exit(-1);
+    }
+
     if (tags != null) {
       tags = Arrays.stream(tags).distinct().toArray(String[]::new);
     }
@@ -790,12 +777,20 @@ public class GravitinoCommandLine extends TestableCommandLine {
 
     Command.setAuthenticationMode(auth, userName);
 
+    List<String> missingEntities = Lists.newArrayList();
+    if (catalog == null) missingEntities.add(CommandEntities.CATALOG);
+    if (schema == null) missingEntities.add(CommandEntities.SCHEMA);
+    if (table == null) missingEntities.add(CommandEntities.TABLE);
+
     if (CommandActions.LIST.equals(command)) {
+      checkEntities(missingEntities);
       newListColumns(url, ignore, metalake, catalog, schema, table).handle();
       return;
     }
 
     String column = name.getColumnName();
+    if (column == null) missingEntities.add(CommandEntities.COLUMN);
+    checkEntities(missingEntities);
 
     switch (command) {
       case CommandActions.DETAILS:
@@ -965,12 +960,19 @@ public class GravitinoCommandLine extends TestableCommandLine {
 
     Command.setAuthenticationMode(auth, userName);
 
+    List<String> missingEntities = Lists.newArrayList();
+    if (catalog == null) missingEntities.add(CommandEntities.CATALOG);
+    if (schema == null) missingEntities.add(CommandEntities.SCHEMA);
+
     if (CommandActions.LIST.equals(command)) {
+      checkEntities(missingEntities);
       newListTopics(url, ignore, metalake, catalog, schema).handle();
       return;
     }
 
     String topic = name.getTopicName();
+    if (topic == null) missingEntities.add(CommandEntities.TOPIC);
+    checkEntities(missingEntities);
 
     switch (command) {
       case CommandActions.DETAILS:
@@ -1040,12 +1042,20 @@ public class GravitinoCommandLine extends TestableCommandLine {
 
     Command.setAuthenticationMode(auth, userName);
 
+    List<String> missingEntities = Lists.newArrayList();
+    if (catalog == null) missingEntities.add(CommandEntities.CATALOG);
+    if (schema == null) missingEntities.add(CommandEntities.SCHEMA);
+
+    // Handle CommandActions.LIST action separately as it doesn't require the `fileset`
     if (CommandActions.LIST.equals(command)) {
+      checkEntities(missingEntities);
       newListFilesets(url, ignore, metalake, catalog, schema).handle();
       return;
     }
 
     String fileset = name.getFilesetName();
+    if (fileset == null) missingEntities.add(CommandEntities.FILESET);
+    checkEntities(missingEntities);
 
     switch (command) {
       case CommandActions.DETAILS:
@@ -1182,5 +1192,12 @@ public class GravitinoCommandLine extends TestableCommandLine {
     }
 
     return null;
+  }
+
+  private void checkEntities(List<String> entities) {
+    if (!entities.isEmpty()) {
+      System.err.println("Missing required argument(s): " + COMMA_JOINER.join(entities));
+      Main.exit(-1);
+    }
   }
 }

--- a/clients/cli/src/test/java/org/apache/gravitino/cli/TestGroupCommands.java
+++ b/clients/cli/src/test/java/org/apache/gravitino/cli/TestGroupCommands.java
@@ -19,12 +19,18 @@
 
 package org.apache.gravitino.cli;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Options;
 import org.apache.gravitino.cli.commands.AddRoleToGroup;
@@ -34,17 +40,35 @@ import org.apache.gravitino.cli.commands.GroupAudit;
 import org.apache.gravitino.cli.commands.GroupDetails;
 import org.apache.gravitino.cli.commands.ListGroups;
 import org.apache.gravitino.cli.commands.RemoveRoleFromGroup;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class TestGroupCommands {
   private CommandLine mockCommandLine;
   private Options mockOptions;
+  private final ByteArrayOutputStream outContent = new ByteArrayOutputStream();
+  private final ByteArrayOutputStream errContent = new ByteArrayOutputStream();
+  private final PrintStream originalOut = System.out;
+  private final PrintStream originalErr = System.err;
 
   @BeforeEach
   void setUp() {
     mockCommandLine = mock(CommandLine.class);
     mockOptions = mock(Options.class);
+    System.setOut(new PrintStream(outContent));
+    System.setErr(new PrintStream(errContent));
+  }
+
+  @AfterEach
+  void restoreExitFlg() {
+    Main.useExit = true;
+  }
+
+  @AfterEach
+  public void restoreStreams() {
+    System.setOut(originalOut);
+    System.setErr(originalErr);
   }
 
   @Test
@@ -259,5 +283,24 @@ class TestGroupCommands {
 
     verify(mockAddSecondRole).handle();
     verify(mockAddFirstRole).handle();
+  }
+
+  @Test
+  @SuppressWarnings("DefaultCharset")
+  void testDeleteGroupCommandWithoutGroupOption() {
+    Main.useExit = false;
+    when(mockCommandLine.hasOption(GravitinoOptions.METALAKE)).thenReturn(true);
+    when(mockCommandLine.getOptionValue(GravitinoOptions.METALAKE)).thenReturn("metalake_demo");
+    when(mockCommandLine.hasOption(GravitinoOptions.GROUP)).thenReturn(false);
+    GravitinoCommandLine commandLine =
+        spy(
+            new GravitinoCommandLine(
+                mockCommandLine, mockOptions, CommandEntities.GROUP, CommandActions.DELETE));
+
+    assertThrows(RuntimeException.class, commandLine::handleCommandLine);
+    verify(commandLine, never())
+        .newDeleteGroup(GravitinoCommandLine.DEFAULT_URL, false, false, "metalake_demo", null);
+    String output = new String(errContent.toByteArray(), StandardCharsets.UTF_8).trim();
+    assertEquals(output, ErrorMessages.MISSING_GROUP);
   }
 }

--- a/clients/cli/src/test/java/org/apache/gravitino/cli/TestMain.java
+++ b/clients/cli/src/test/java/org/apache/gravitino/cli/TestMain.java
@@ -192,7 +192,6 @@ public class TestMain {
     assertTrue(errContent.toString().contains(ErrorMessages.TAG_EMPTY)); // Expect error
   }
 
-  @Test
   @SuppressWarnings("DefaultCharset")
   public void DeleteTagWithNoTag() {
     String[] args = {"tag", "delete", "--metalake", "metalake_test_no_tag", "-f"};

--- a/clients/cli/src/test/java/org/apache/gravitino/cli/TestTableCommands.java
+++ b/clients/cli/src/test/java/org/apache/gravitino/cli/TestTableCommands.java
@@ -19,8 +19,8 @@
 
 package org.apache.gravitino.cli;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -30,6 +30,7 @@ import static org.mockito.Mockito.when;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Options;
 import org.apache.gravitino.cli.commands.CreateTable;
@@ -451,14 +452,15 @@ class TestTableCommands {
     assertThrows(RuntimeException.class, commandLine::handleCommandLine);
     verify(commandLine, never())
         .newListTables(GravitinoCommandLine.DEFAULT_URL, false, "metalake_demo", null, null);
-    assertTrue(
-        errContent
-            .toString()
-            .contains(
-                "Missing required argument(s): "
-                    + CommandEntities.CATALOG
-                    + ", "
-                    + CommandEntities.SCHEMA));
+    String output = new String(errContent.toByteArray(), StandardCharsets.UTF_8).trim();
+    assertEquals(
+        output,
+        ErrorMessages.MISSING_NAME
+            + "\n"
+            + "Missing required argument(s): "
+            + CommandEntities.CATALOG
+            + ", "
+            + CommandEntities.SCHEMA);
   }
 
   @Test
@@ -478,8 +480,13 @@ class TestTableCommands {
     assertThrows(RuntimeException.class, commandLine::handleCommandLine);
     verify(commandLine, never())
         .newListTables(GravitinoCommandLine.DEFAULT_URL, false, "metalake_demo", "catalog", null);
-    assertTrue(
-        errContent.toString().contains("Missing required argument(s): " + CommandEntities.SCHEMA));
+    String output = new String(errContent.toByteArray(), StandardCharsets.UTF_8).trim();
+    assertEquals(
+        output,
+        ErrorMessages.MALFORMED_NAME
+            + "\n"
+            + "Missing required argument(s): "
+            + CommandEntities.SCHEMA);
   }
 
   @Test
@@ -498,16 +505,17 @@ class TestTableCommands {
     verify(commandLine, never())
         .newTableDetails(
             GravitinoCommandLine.DEFAULT_URL, false, "metalake_demo", null, null, null);
-    assertTrue(
-        errContent
-            .toString()
-            .contains(
-                "Missing required argument(s): "
-                    + CommandEntities.CATALOG
-                    + ", "
-                    + CommandEntities.SCHEMA
-                    + ", "
-                    + CommandEntities.TABLE));
+    String output = new String(errContent.toByteArray(), StandardCharsets.UTF_8).trim();
+    assertEquals(
+        output,
+        ErrorMessages.MISSING_NAME
+            + "\n"
+            + "Missing required argument(s): "
+            + CommandEntities.CATALOG
+            + ", "
+            + CommandEntities.SCHEMA
+            + ", "
+            + CommandEntities.TABLE);
   }
 
   @Test
@@ -526,14 +534,15 @@ class TestTableCommands {
     verify(commandLine, never())
         .newTableDetails(
             GravitinoCommandLine.DEFAULT_URL, false, "metalake_demo", "catalog", null, null);
-    assertTrue(
-        errContent
-            .toString()
-            .contains(
-                "Missing required argument(s): "
-                    + CommandEntities.SCHEMA
-                    + ", "
-                    + CommandEntities.TABLE));
+    String output = new String(errContent.toByteArray(), StandardCharsets.UTF_8).trim();
+    assertEquals(
+        output,
+        ErrorMessages.MALFORMED_NAME
+            + "\n"
+            + "Missing required argument(s): "
+            + CommandEntities.SCHEMA
+            + ", "
+            + CommandEntities.TABLE);
   }
 
   @Test
@@ -554,7 +563,12 @@ class TestTableCommands {
     verify(commandLine, never())
         .newTableDetails(
             GravitinoCommandLine.DEFAULT_URL, false, "metalake_demo", "catalog", "schema", null);
-    assertTrue(
-        errContent.toString().contains("Missing required argument(s): " + CommandEntities.TABLE));
+    String output = new String(errContent.toByteArray(), StandardCharsets.UTF_8).trim();
+    assertEquals(
+        output,
+        ErrorMessages.MALFORMED_NAME
+            + "\n"
+            + "Missing required argument(s): "
+            + CommandEntities.TABLE);
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

refactor the validation logic of all entities and add test case, just like validation of table command #5906 . A hint is provided when the user's output is missing the required arguments. for example:

```bash
gcli column list -m demo_metalake, --name Hive_catalog
# Malformed entity name.
# Missing required argument(s): schema, table

gcli column details -m demo_metalake, --name Hive_catalog --audit
# Malformed entity name.
# Missing required argument(s): schema, table, column

gcli user delete -m demo_metalake
Missing --user option.
```
Currently, the Role command needs to be refactored and opened as a separate issue

### Why are the changes needed?

Fix: #5861 

### Does this PR introduce _any_ user-facing change?

NO

### How was this patch tested?

local test