### PR TITLE
[#5957] feat(CLI): Table format output for SchemaDetails command

### DIFF
--- a/clients/cli/src/main/java/org/apache/gravitino/cli/SchemaCommandHandler.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/SchemaCommandHandler.java
@@ -35,6 +35,7 @@ public class SchemaCommandHandler extends CommandHandler {
   private final String metalake;
   private final String catalog;
   private String schema;
+  private final String outputFormat;
 
   /**
    * Constructs a {@link SchemaCommandHandler} instance.
@@ -55,6 +56,7 @@ public class SchemaCommandHandler extends CommandHandler {
     this.name = new FullName(line);
     this.metalake = name.getMetalakeName();
     this.catalog = name.getCatalogName();
+    this.outputFormat = line.getOptionValue(GravitinoOptions.OUTPUT);
   }
 
   @Override
@@ -132,7 +134,7 @@ public class SchemaCommandHandler extends CommandHandler {
           .handle();
     } else {
       gravitinoCommandLine
-          .newSchemaDetails(url, ignore, metalake, catalog, schema)
+          .newSchemaDetails(url, ignore, outputFormat, metalake, catalog, schema)
           .validate()
           .handle();
     }

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/TestableCommandLine.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/TestableCommandLine.java
@@ -267,8 +267,8 @@ public class TestableCommandLine {
   }
 
   protected SchemaDetails newSchemaDetails(
-      String url, boolean ignore, String metalake, String catalog, String schema) {
-    return new SchemaDetails(url, ignore, metalake, catalog, schema);
+      String url, boolean ignore, String outputFormat, String metalake, String catalog, String schema) {
+    return new SchemaDetails(url, ignore, outputFormat, metalake, catalog, schema);
   }
 
   protected ListSchema newListSchema(String url, boolean ignore, String metalake, String catalog) {

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/TestableCommandLine.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/TestableCommandLine.java
@@ -267,7 +267,12 @@ public class TestableCommandLine {
   }
 
   protected SchemaDetails newSchemaDetails(
-      String url, boolean ignore, String outputFormat, String metalake, String catalog, String schema) {
+      String url,
+      boolean ignore,
+      String outputFormat,
+      String metalake,
+      String catalog,
+      String schema) {
     return new SchemaDetails(url, ignore, outputFormat, metalake, catalog, schema);
   }
 

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/SchemaDetails.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/SchemaDetails.java
@@ -38,13 +38,14 @@ public class SchemaDetails extends Command {
    *
    * @param url The URL of the Gravitino server.
    * @param ignoreVersions If true don't check the client/server versions match.
+   * @param outputFormat The output format.
    * @param metalake The name of the metalake.
    * @param catalog The name of the catalog.
    * @param schema The name of the schenma.
    */
   public SchemaDetails(
-      String url, boolean ignoreVersions, String metalake, String catalog, String schema) {
-    super(url, ignoreVersions);
+      String url, boolean ignoreVersions, String outputFormat, String metalake, String catalog, String schema) {
+    super(url, ignoreVersions, outputFormat);
     this.metalake = metalake;
     this.catalog = catalog;
     this.schema = schema;
@@ -58,6 +59,7 @@ public class SchemaDetails extends Command {
     try {
       GravitinoClient client = buildClient(metalake);
       result = client.loadCatalog(catalog).asSchemas().loadSchema(schema);
+      output(result);
     } catch (NoSuchMetalakeException err) {
       exitWithError(ErrorMessages.UNKNOWN_METALAKE);
     } catch (NoSuchCatalogException err) {
@@ -66,10 +68,6 @@ public class SchemaDetails extends Command {
       exitWithError(ErrorMessages.UNKNOWN_SCHEMA);
     } catch (Exception exp) {
       exitWithError(exp.getMessage());
-    }
-
-    if (result != null) {
-      System.out.println(result.name() + "," + result.comment());
     }
   }
 }

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/SchemaDetails.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/SchemaDetails.java
@@ -44,7 +44,12 @@ public class SchemaDetails extends Command {
    * @param schema The name of the schenma.
    */
   public SchemaDetails(
-      String url, boolean ignoreVersions, String outputFormat, String metalake, String catalog, String schema) {
+      String url,
+      boolean ignoreVersions,
+      String outputFormat,
+      String metalake,
+      String catalog,
+      String schema) {
     super(url, ignoreVersions, outputFormat);
     this.metalake = metalake;
     this.catalog = catalog;

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/outputs/PlainFormat.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/outputs/PlainFormat.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.gravitino.Catalog;
 import org.apache.gravitino.Metalake;
+import org.apache.gravitino.Schema;
 
 /** Plain format to print a pretty string to standard out. */
 public class PlainFormat {
@@ -35,6 +36,8 @@ public class PlainFormat {
       new CatalogPlainFormat().output((Catalog) object);
     } else if (object instanceof Catalog[]) {
       new CatalogsPlainFormat().output((Catalog[]) object);
+    } else if (object instanceof Schema) {
+      new SchemaPlainFormat().output((Schema) object);
     } else {
       throw new IllegalArgumentException("Unsupported object type");
     }
@@ -86,6 +89,13 @@ public class PlainFormat {
         String all = String.join(System.lineSeparator(), catalogNames);
         System.out.println(all);
       }
+    }
+  }
+
+  static final class SchemaPlainFormat implements OutputFormat<Schema> {
+    @Override
+    public void output(Schema schema) {
+      System.out.println(schema.name() + "," + schema.comment());
     }
   }
 }

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/outputs/PlainFormat.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/outputs/PlainFormat.java
@@ -95,7 +95,11 @@ public class PlainFormat {
   static final class SchemaPlainFormat implements OutputFormat<Schema> {
     @Override
     public void output(Schema schema) {
-      System.out.println(schema.name() + "," + schema.comment());
+      if (schema == null) {
+        System.out.println("No schemas exist.");
+      } else {
+        System.out.println(schema.name() + "," + schema.comment());
+      }
     }
   }
 }

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/outputs/TableFormat.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/outputs/TableFormat.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.regex.Pattern;
 import org.apache.gravitino.Catalog;
 import org.apache.gravitino.Metalake;
+import org.apache.gravitino.Schema;
 
 /** Table format to print a pretty table to standard out. */
 public class TableFormat {
@@ -37,6 +38,8 @@ public class TableFormat {
       new CatalogTableFormat().output((Catalog) object);
     } else if (object instanceof Catalog[]) {
       new CatalogsTableFormat().output((Catalog[]) object);
+    } else if (object instanceof Schema) {
+      new SchemaTableFormat().output((Schema) object);
     } else {
       throw new IllegalArgumentException("Unsupported object type");
     }
@@ -100,6 +103,20 @@ public class TableFormat {
         TableFormatImpl tableFormat = new TableFormatImpl();
         tableFormat.print(headers, rows);
       }
+    }
+  }
+
+  static final class SchemaTableFormat implements OutputFormat<Schema> {
+    @Override
+    public void output(Schema schema) {
+      List<String> headers = Arrays.asList("schema", "comment");
+      List<List<String>> rows = new ArrayList<>();
+      rows.add(
+              Arrays.asList(
+                      schema.name(),
+                      schema.comment()));
+      TableFormatImpl tableFormat = new TableFormatImpl();
+      tableFormat.print(headers, rows);
     }
   }
 

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/outputs/TableFormat.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/outputs/TableFormat.java
@@ -111,10 +111,7 @@ public class TableFormat {
     public void output(Schema schema) {
       List<String> headers = Arrays.asList("schema", "comment");
       List<List<String>> rows = new ArrayList<>();
-      rows.add(
-              Arrays.asList(
-                      schema.name(),
-                      schema.comment()));
+      rows.add(Arrays.asList(schema.name(), schema.comment() + ""));
       TableFormatImpl tableFormat = new TableFormatImpl();
       tableFormat.print(headers, rows);
     }

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/outputs/TableFormat.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/outputs/TableFormat.java
@@ -109,11 +109,15 @@ public class TableFormat {
   static final class SchemaTableFormat implements OutputFormat<Schema> {
     @Override
     public void output(Schema schema) {
-      List<String> headers = Arrays.asList("schema", "comment");
-      List<List<String>> rows = new ArrayList<>();
-      rows.add(Arrays.asList(schema.name(), schema.comment() + ""));
-      TableFormatImpl tableFormat = new TableFormatImpl();
-      tableFormat.print(headers, rows);
+      if (schema == null) {
+        System.out.println("No schemas exist.");
+      } else {
+        List<String> headers = Arrays.asList("schema", "comment");
+        List<List<String>> rows = new ArrayList<>();
+        rows.add(Arrays.asList(schema.name(), schema.comment() + ""));
+        TableFormatImpl tableFormat = new TableFormatImpl();
+        tableFormat.print(headers, rows);
+      }
     }
   }
 

--- a/clients/cli/src/test/java/org/apache/gravitino/cli/TestSchemaCommands.java
+++ b/clients/cli/src/test/java/org/apache/gravitino/cli/TestSchemaCommands.java
@@ -108,7 +108,7 @@ class TestSchemaCommands {
     doReturn(mockDetails)
         .when(commandLine)
         .newSchemaDetails(
-            GravitinoCommandLine.DEFAULT_URL, false, "metalake_demo", "catalog", "schema");
+            GravitinoCommandLine.DEFAULT_URL, false, null, "metalake_demo", "catalog", "schema");
     doReturn(mockDetails).when(mockDetails).validate();
     commandLine.handleCommandLine();
     verify(mockDetails).handle();


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Support table format output for SchemaDetails command.

### Why are the changes needed?

Issue: https://github.com/apache/gravitino/issues/5957

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

```
gcli schema details --name <schema_name> -m <metalake_name>
gcli schema details --name <schema_name> -m <metalake_name> --output plain
gcli schema details --name <schema_name> -m <metalake_name> --output table
```
