### PR TITLE
[#4398] feat(core): support credential cache for Gravitino server

### DIFF
--- a/catalogs/catalog-common/src/main/java/org/apache/gravitino/credential/CredentialConstants.java
+++ b/catalogs/catalog-common/src/main/java/org/apache/gravitino/credential/CredentialConstants.java
@@ -22,6 +22,8 @@ package org.apache.gravitino.credential;
 public class CredentialConstants {
   public static final String CREDENTIAL_PROVIDER_TYPE = "credential-provider-type";
   public static final String CREDENTIAL_PROVIDERS = "credential-providers";
+  public static final String CREDENTIAL_CACHE_EXPIRE_IN_SECS = "credential-cache-expire-in-secs";
+  public static final String CREDENTIAL_CACHE_MAX_SIZE = "credential-cache-max-size";
   public static final String S3_TOKEN_CREDENTIAL_PROVIDER = "s3-token";
   public static final String S3_TOKEN_EXPIRE_IN_SECS = "s3-token-expire-in-secs";
 

--- a/catalogs/catalog-common/src/main/java/org/apache/gravitino/credential/CredentialConstants.java
+++ b/catalogs/catalog-common/src/main/java/org/apache/gravitino/credential/CredentialConstants.java
@@ -22,7 +22,7 @@ package org.apache.gravitino.credential;
 public class CredentialConstants {
   public static final String CREDENTIAL_PROVIDER_TYPE = "credential-provider-type";
   public static final String CREDENTIAL_PROVIDERS = "credential-providers";
-  public static final String CREDENTIAL_CACHE_EXPIRE_IN_SECS = "credential-cache-expire-in-secs";
+  public static final String CREDENTIAL_CACHE_EXPIRE_RATIO = "credential-cache-expire-ratio";
   public static final String CREDENTIAL_CACHE_MAX_SIZE = "credential-cache-max-size";
   public static final String S3_TOKEN_CREDENTIAL_PROVIDER = "s3-token";
   public static final String S3_TOKEN_EXPIRE_IN_SECS = "s3-token-expire-in-secs";

--- a/core/src/main/java/org/apache/gravitino/config/ConfigBuilder.java
+++ b/core/src/main/java/org/apache/gravitino/config/ConfigBuilder.java
@@ -171,6 +171,31 @@ public class ConfigBuilder {
   }
 
   /**
+   * Creates a configuration entry for Double data type.
+   *
+   * @return The created ConfigEntry instance for Double data type.
+   */
+  public ConfigEntry<Double> doubleConf() {
+    ConfigEntry<Double> conf =
+        new ConfigEntry<>(key, version, doc, alternatives, isPublic, isDeprecated);
+    Function<String, Double> func =
+        s -> {
+          if (s == null || s.isEmpty()) {
+            return null;
+          } else {
+            return Double.parseDouble(s);
+          }
+        };
+    conf.setValueConverter(func);
+
+    Function<Double, String> stringFunc =
+        t -> Optional.ofNullable(t).map(String::valueOf).orElse(null);
+    conf.setStringConverter(stringFunc);
+
+    return conf;
+  }
+
+  /**
    * Creates a configuration entry for Boolean data type.
    *
    * @return The created ConfigEntry instance for Boolean data type.

--- a/core/src/main/java/org/apache/gravitino/connector/PropertyEntry.java
+++ b/core/src/main/java/org/apache/gravitino/connector/PropertyEntry.java
@@ -29,6 +29,7 @@ import org.apache.commons.lang3.StringUtils;
 
 @Getter
 public final class PropertyEntry<T> {
+
   private final String name;
   private final String description;
   private final boolean required;
@@ -90,6 +91,7 @@ public final class PropertyEntry<T> {
   }
 
   public static class Builder<T> {
+
     private String name;
     private String description;
     private boolean required;
@@ -208,6 +210,28 @@ public final class PropertyEntry<T> {
         .withJavaType(Long.class)
         .withDefaultValue(defaultValue)
         .withDecoder(Long::parseLong)
+        .withEncoder(String::valueOf)
+        .withHidden(hidden)
+        .withReserved(reserved)
+        .build();
+  }
+
+  public static PropertyEntry<Double> doublePropertyEntry(
+      String name,
+      String description,
+      boolean required,
+      boolean immutable,
+      double defaultValue,
+      boolean hidden,
+      boolean reserved) {
+    return new Builder<Double>()
+        .withName(name)
+        .withDescription(description)
+        .withRequired(required)
+        .withImmutable(immutable)
+        .withJavaType(Double.class)
+        .withDefaultValue(defaultValue)
+        .withDecoder(Double::parseDouble)
         .withEncoder(String::valueOf)
         .withHidden(hidden)
         .withReserved(reserved)

--- a/core/src/main/java/org/apache/gravitino/credential/CatalogCredentialManager.java
+++ b/core/src/main/java/org/apache/gravitino/credential/CatalogCredentialManager.java
@@ -72,7 +72,7 @@ public class CatalogCredentialManager implements Closeable {
   private Credential doGetCredential(CredentialCacheKey credentialCacheKey) {
     String credentialType = credentialCacheKey.getCredentialType();
     CredentialContext context = credentialCacheKey.getCredentialContext();
-    LOG.debug("try get credential, credential type: {}, context: {}", credentialType, context);
+    LOG.debug("Try get credential, credential type: {}, context: {}.", credentialType, context);
     Preconditions.checkState(
         credentialProviders.containsKey(credentialType),
         String.format("Credential %s not found", credentialType));

--- a/core/src/main/java/org/apache/gravitino/credential/CatalogCredentialManager.java
+++ b/core/src/main/java/org/apache/gravitino/credential/CatalogCredentialManager.java
@@ -34,20 +34,21 @@ public class CatalogCredentialManager implements Closeable {
 
   private static final Logger LOG = LoggerFactory.getLogger(CatalogCredentialManager.class);
 
+  private final CredentialCache<CredentialCacheKey> credentialCache;
+
   private final String catalogName;
   private final Map<String, CredentialProvider> credentialProviders;
 
   public CatalogCredentialManager(String catalogName, Map<String, String> catalogProperties) {
     this.catalogName = catalogName;
     this.credentialProviders = CredentialUtils.loadCredentialProviders(catalogProperties);
+    this.credentialCache = new CredentialCache();
+    credentialCache.initialize(catalogProperties);
   }
 
   public Credential getCredential(String credentialType, CredentialContext context) {
-    // todo: add credential cache
-    Preconditions.checkState(
-        credentialProviders.containsKey(credentialType),
-        String.format("Credential %s not found", credentialType));
-    return credentialProviders.get(credentialType).getCredential(context);
+    CredentialCacheKey credentialCacheKey = new CredentialCacheKey(credentialType, context);
+    return credentialCache.getCredential(credentialCacheKey, cacheKey -> doGetCredential(cacheKey));
   }
 
   @Override
@@ -66,5 +67,15 @@ public class CatalogCredentialManager implements Closeable {
                     e);
               }
             });
+  }
+
+  private Credential doGetCredential(CredentialCacheKey credentialCacheKey) {
+    String credentialType = credentialCacheKey.getCredentialType();
+    CredentialContext context = credentialCacheKey.getCredentialContext();
+    LOG.debug("try get credential, credential type: {}, context: {}", credentialType, context);
+    Preconditions.checkState(
+        credentialProviders.containsKey(credentialType),
+        String.format("Credential %s not found", credentialType));
+    return credentialProviders.get(credentialType).getCredential(context);
   }
 }

--- a/core/src/main/java/org/apache/gravitino/credential/CredentialCache.java
+++ b/core/src/main/java/org/apache/gravitino/credential/CredentialCache.java
@@ -82,7 +82,8 @@ public class CredentialCache<T> implements Closeable {
             .expireAfter(new CredentialExpireTimeCalculator(cacheExpireRatio))
             .maximumSize(cacheSize)
             .removalListener(
-                (cacheKey, credential, c) -> LOG.debug("credential expire {}.", cacheKey))
+                (cacheKey, credential, c) ->
+                    LOG.debug("Credential expire, cache key: {}.", cacheKey))
             .build();
   }
 

--- a/core/src/main/java/org/apache/gravitino/credential/CredentialCache.java
+++ b/core/src/main/java/org/apache/gravitino/credential/CredentialCache.java
@@ -1,0 +1,100 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.apache.gravitino.credential;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.Expiry;
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import org.apache.gravitino.credential.config.CredentialConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class CredentialCache<T> implements Closeable {
+
+  private static final Logger LOG = LoggerFactory.getLogger(CredentialCache.class);
+
+  // Calculates the credential expire time in the cache.
+  static class CredentialExpireTimeCalculator<T> implements Expiry<T, Credential> {
+
+    private long credentialCacheExpireTimeInMs;
+
+    public CredentialExpireTimeCalculator(long credentialCacheExpireTimeInSecs) {
+      this.credentialCacheExpireTimeInMs = credentialCacheExpireTimeInSecs * 1000;
+    }
+
+    // Set expire time after add a credential in the cache.
+    @Override
+    public long expireAfterCreate(T key, Credential credential, long currentTime) {
+      long credentialExpireTime = credential.expireTimeInMs();
+      long timeToExpire = credentialExpireTime - System.currentTimeMillis();
+      if (timeToExpire <= 0) {
+        return 0;
+      }
+
+      long idealExpireTime = Math.min(timeToExpire / 2, credentialCacheExpireTimeInMs);
+      return TimeUnit.MILLISECONDS.toNanos(idealExpireTime);
+    }
+
+    // Not change expire time after update credential, this should not happen.
+    @Override
+    public long expireAfterUpdate(T key, Credential value, long currentTime, long currentDuration) {
+      return currentDuration;
+    }
+
+    // Not change expire time after read credential.
+    @Override
+    public long expireAfterRead(T key, Credential value, long currentTime, long currentDuration) {
+      return currentDuration;
+    }
+  }
+
+  private Cache<T, Credential> credentialCache;
+
+  public void initialize(Map<String, String> catalogProperties) {
+    CredentialConfig credentialConfig = new CredentialConfig(catalogProperties);
+    long cache_size = credentialConfig.get(CredentialConfig.CREDENTIAL_CACHE_MAZ_SIZE);
+    long cache_expire_time = credentialConfig.get(CredentialConfig.CREDENTIAL_CACHE_EXPIRE_IN_SECS);
+
+    this.credentialCache =
+        Caffeine.newBuilder()
+            .expireAfter(new CredentialExpireTimeCalculator(cache_expire_time))
+            .maximumSize(cache_size)
+            .removalListener(
+                (cacheKey, credential, c) -> LOG.debug("credential expire {}.", cacheKey))
+            .build();
+  }
+
+  public Credential getCredential(T cacheKey, Function<T, Credential> credentialSupplier) {
+    return credentialCache.get(cacheKey, key -> credentialSupplier.apply(cacheKey));
+  }
+
+  @Override
+  public void close() throws IOException {
+    if (credentialCache != null) {
+      credentialCache.invalidateAll();
+      credentialCache = null;
+    }
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/credential/CredentialCacheKey.java
+++ b/core/src/main/java/org/apache/gravitino/credential/CredentialCacheKey.java
@@ -19,27 +19,23 @@
 
 package org.apache.gravitino.credential;
 
-import com.google.common.base.Objects;
-import com.google.common.base.Preconditions;
-import javax.validation.constraints.NotNull;
+import java.util.Objects;
+import lombok.Getter;
 
-/** CatalogCredentialContext is generated when user requesting catalog credentials. */
-public class CatalogCredentialContext implements CredentialContext {
-  @NotNull private final String userName;
+@Getter
+public class CredentialCacheKey {
 
-  public CatalogCredentialContext(String userName) {
-    Preconditions.checkNotNull(userName, "User name should not be null");
-    this.userName = userName;
-  }
+  private final String credentialType;
+  private final CredentialContext credentialContext;
 
-  @Override
-  public String getUserName() {
-    return userName;
+  public CredentialCacheKey(String credentialType, CredentialContext credentialContext) {
+    this.credentialType = credentialType;
+    this.credentialContext = credentialContext;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(userName);
+    return Objects.hash(credentialType, credentialContext);
   }
 
   @Override
@@ -47,16 +43,22 @@ public class CatalogCredentialContext implements CredentialContext {
     if (this == o) {
       return true;
     }
-    if (o == null || !(o instanceof CatalogCredentialContext)) {
+    if (o == null || !(o instanceof CredentialCacheKey)) {
       return false;
     }
-    return Objects.equal(userName, ((CatalogCredentialContext) o).userName);
+    CredentialCacheKey that = (CredentialCacheKey) o;
+    return Objects.equals(credentialType, that.credentialType)
+        && Objects.equals(credentialContext, that.credentialContext);
   }
 
   @Override
   public String toString() {
     StringBuilder stringBuilder = new StringBuilder();
-    stringBuilder.append("User name: ").append(userName);
+    stringBuilder
+        .append("credentialType: ")
+        .append(credentialType)
+        .append("credentialContext: ")
+        .append(credentialContext);
     return stringBuilder.toString();
   }
 }

--- a/core/src/main/java/org/apache/gravitino/credential/PathBasedCredentialContext.java
+++ b/core/src/main/java/org/apache/gravitino/credential/PathBasedCredentialContext.java
@@ -20,6 +20,7 @@
 package org.apache.gravitino.credential;
 
 import com.google.common.base.Preconditions;
+import java.util.Objects;
 import java.util.Set;
 import javax.validation.constraints.NotNull;
 
@@ -54,5 +55,37 @@ public class PathBasedCredentialContext implements CredentialContext {
 
   public Set<String> getReadPaths() {
     return readPaths;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(userName, writePaths, readPaths);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || !(o instanceof PathBasedCredentialContext)) {
+      return false;
+    }
+    PathBasedCredentialContext that = (PathBasedCredentialContext) o;
+    return Objects.equals(userName, that.userName)
+        && Objects.equals(writePaths, that.writePaths)
+        && Objects.equals(readPaths, that.readPaths);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder stringBuilder = new StringBuilder();
+    stringBuilder
+        .append("User name: ")
+        .append(userName)
+        .append(", write path: ")
+        .append(writePaths)
+        .append(", read path: ")
+        .append(readPaths);
+    return stringBuilder.toString();
   }
 }

--- a/core/src/main/java/org/apache/gravitino/credential/config/CredentialConfig.java
+++ b/core/src/main/java/org/apache/gravitino/credential/config/CredentialConfig.java
@@ -70,12 +70,14 @@ public class CredentialConfig extends Config {
   public static final ConfigEntry<Double> CREDENTIAL_CACHE_EXPIRE_RATIO =
       new ConfigBuilder(CredentialConstants.CREDENTIAL_CACHE_EXPIRE_RATIO)
           .doc(
-              "Ratio of the credential's expiration time when Gravitino remove credential from the cache.")
+              "Ratio of the credential's expiration time when Gravitino remove credential from the "
+                  + "cache.")
           .version(ConfigConstants.VERSION_0_8_0)
           .doubleConf()
           .checkValue(
               ratio -> ratio >= 0 && ratio < 1,
-              "Ratio of the credential's expiration time should great than or equal to 0 and less than 1.")
+              "Ratio of the credential's expiration time should greater than or equal to 0 "
+                  + "and less than 1.")
           .createWithDefault(DEFAULT_CREDENTIAL_CACHE_EXPIRE_RATIO);
 
   public static final ConfigEntry<Long> CREDENTIAL_CACHE_MAX_SIZE =

--- a/core/src/main/java/org/apache/gravitino/credential/config/CredentialConfig.java
+++ b/core/src/main/java/org/apache/gravitino/credential/config/CredentialConfig.java
@@ -31,7 +31,7 @@ import org.apache.gravitino.credential.CredentialConstants;
 public class CredentialConfig extends Config {
 
   private static final long DEFAULT_CREDENTIAL_CACHE_MAX_SIZE = 10_000L;
-  private static final long DEFAULT_CREDENTIAL_CACHE_EXPIRE_IN_SECS = 300;
+  private static final double DEFAULT_CREDENTIAL_CACHE_EXPIRE_RATIO = 0.15d;
 
   public static final Map<String, PropertyEntry<?>> CREDENTIAL_PROPERTY_ENTRIES =
       new ImmutableMap.Builder<String, PropertyEntry<?>>()
@@ -46,13 +46,13 @@ public class CredentialConfig extends Config {
                   false /* hidden */,
                   false /* reserved */))
           .put(
-              CredentialConstants.CREDENTIAL_CACHE_EXPIRE_IN_SECS,
-              PropertyEntry.longPropertyEntry(
-                  CredentialConstants.CREDENTIAL_CACHE_EXPIRE_IN_SECS,
-                  "Max cache time for the credential.",
+              CredentialConstants.CREDENTIAL_CACHE_EXPIRE_RATIO,
+              PropertyEntry.doublePropertyEntry(
+                  CredentialConstants.CREDENTIAL_CACHE_EXPIRE_RATIO,
+                  "Ratio of the credential's expiration time when Gravitino remove credential from the cache.",
                   false /* required */,
                   false /* immutable */,
-                  DEFAULT_CREDENTIAL_CACHE_EXPIRE_IN_SECS /* default value */,
+                  DEFAULT_CREDENTIAL_CACHE_EXPIRE_RATIO /* default value */,
                   false /* hidden */,
                   false /* reserved */))
           .put(
@@ -67,14 +67,18 @@ public class CredentialConfig extends Config {
                   false /* reserved */))
           .build();
 
-  public static final ConfigEntry<Long> CREDENTIAL_CACHE_EXPIRE_IN_SECS =
-      new ConfigBuilder(CredentialConstants.CREDENTIAL_CACHE_EXPIRE_IN_SECS)
-          .doc("Max expire time for the credential cache.")
+  public static final ConfigEntry<Double> CREDENTIAL_CACHE_EXPIRE_RATIO =
+      new ConfigBuilder(CredentialConstants.CREDENTIAL_CACHE_EXPIRE_RATIO)
+          .doc(
+              "Ratio of the credential's expiration time when Gravitino remove credential from the cache.")
           .version(ConfigConstants.VERSION_0_8_0)
-          .longConf()
-          .createWithDefault(DEFAULT_CREDENTIAL_CACHE_EXPIRE_IN_SECS);
+          .doubleConf()
+          .checkValue(
+              ratio -> ratio >= 0 && ratio < 1,
+              "Ratio of the credential's expiration time should great than or equal to 0 and less than 1.")
+          .createWithDefault(DEFAULT_CREDENTIAL_CACHE_EXPIRE_RATIO);
 
-  public static final ConfigEntry<Long> CREDENTIAL_CACHE_MAZ_SIZE =
+  public static final ConfigEntry<Long> CREDENTIAL_CACHE_MAX_SIZE =
       new ConfigBuilder(CredentialConstants.CREDENTIAL_CACHE_MAX_SIZE)
           .doc("Max cache size for the credential.")
           .version(ConfigConstants.VERSION_0_8_0)

--- a/core/src/main/java/org/apache/gravitino/credential/config/CredentialConfig.java
+++ b/core/src/main/java/org/apache/gravitino/credential/config/CredentialConfig.java
@@ -21,16 +21,23 @@ package org.apache.gravitino.credential.config;
 
 import com.google.common.collect.ImmutableMap;
 import java.util.Map;
+import org.apache.gravitino.Config;
+import org.apache.gravitino.config.ConfigBuilder;
+import org.apache.gravitino.config.ConfigConstants;
+import org.apache.gravitino.config.ConfigEntry;
 import org.apache.gravitino.connector.PropertyEntry;
 import org.apache.gravitino.credential.CredentialConstants;
 
-public class CredentialConfig {
+public class CredentialConfig extends Config {
+
+  private static final long DEFAULT_CREDENTIAL_CACHE_MAX_SIZE = 10_000L;
+  private static final long DEFAULT_CREDENTIAL_CACHE_EXPIRE_IN_SECS = 300;
 
   public static final Map<String, PropertyEntry<?>> CREDENTIAL_PROPERTY_ENTRIES =
       new ImmutableMap.Builder<String, PropertyEntry<?>>()
           .put(
               CredentialConstants.CREDENTIAL_PROVIDERS,
-              PropertyEntry.booleanPropertyEntry(
+              PropertyEntry.stringPropertyEntry(
                   CredentialConstants.CREDENTIAL_PROVIDERS,
                   "Credential providers for the Gravitino catalog, schema, fileset, table, etc.",
                   false /* required */,
@@ -38,5 +45,44 @@ public class CredentialConfig {
                   null /* default value */,
                   false /* hidden */,
                   false /* reserved */))
+          .put(
+              CredentialConstants.CREDENTIAL_CACHE_EXPIRE_IN_SECS,
+              PropertyEntry.longPropertyEntry(
+                  CredentialConstants.CREDENTIAL_CACHE_EXPIRE_IN_SECS,
+                  "Max cache time for the credential.",
+                  false /* required */,
+                  false /* immutable */,
+                  DEFAULT_CREDENTIAL_CACHE_EXPIRE_IN_SECS /* default value */,
+                  false /* hidden */,
+                  false /* reserved */))
+          .put(
+              CredentialConstants.CREDENTIAL_CACHE_MAX_SIZE,
+              PropertyEntry.longPropertyEntry(
+                  CredentialConstants.CREDENTIAL_CACHE_MAX_SIZE,
+                  "Max size for the credential cache.",
+                  false /* required */,
+                  false /* immutable */,
+                  DEFAULT_CREDENTIAL_CACHE_MAX_SIZE /* default value */,
+                  false /* hidden */,
+                  false /* reserved */))
           .build();
+
+  public static final ConfigEntry<Long> CREDENTIAL_CACHE_EXPIRE_IN_SECS =
+      new ConfigBuilder(CredentialConstants.CREDENTIAL_CACHE_EXPIRE_IN_SECS)
+          .doc("Max expire time for the credential cache.")
+          .version(ConfigConstants.VERSION_0_8_0)
+          .longConf()
+          .createWithDefault(DEFAULT_CREDENTIAL_CACHE_EXPIRE_IN_SECS);
+
+  public static final ConfigEntry<Long> CREDENTIAL_CACHE_MAZ_SIZE =
+      new ConfigBuilder(CredentialConstants.CREDENTIAL_CACHE_MAX_SIZE)
+          .doc("Max cache size for the credential.")
+          .version(ConfigConstants.VERSION_0_8_0)
+          .longConf()
+          .createWithDefault(DEFAULT_CREDENTIAL_CACHE_MAX_SIZE);
+
+  public CredentialConfig(Map<String, String> properties) {
+    super(false);
+    loadFromMap(properties, k -> true);
+  }
 }

--- a/core/src/test/java/org/apache/gravitino/credential/TestCredentialCacheKey.java
+++ b/core/src/test/java/org/apache/gravitino/credential/TestCredentialCacheKey.java
@@ -1,0 +1,56 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.apache.gravitino.credential;
+
+import java.util.Set;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.shaded.com.google.common.collect.ImmutableSet;
+
+public class TestCredentialCacheKey {
+
+  @Test
+  void testCredentialCacheKey() {
+
+    PathBasedCredentialContext context1 =
+        new PathBasedCredentialContext("user1", ImmutableSet.of("path1"), ImmutableSet.of("path2"));
+    PathBasedCredentialContext context2 =
+        new PathBasedCredentialContext("user2", ImmutableSet.of("path1"), ImmutableSet.of("path2"));
+    PathBasedCredentialContext context3 =
+        new PathBasedCredentialContext("user3", ImmutableSet.of("path3"), ImmutableSet.of("path4"));
+
+    CredentialCacheKey key1 = new CredentialCacheKey("s3-token", context1);
+
+    Set<CredentialCacheKey> cache = ImmutableSet.of(key1);
+    Assertions.assertTrue(cache.contains(key1));
+
+    // different user
+    CredentialCacheKey key2 = new CredentialCacheKey("s3-token", context2);
+    Assertions.assertFalse(cache.contains(key2));
+
+    // different path
+    CredentialCacheKey key3 = new CredentialCacheKey("s3-token", context3);
+    Assertions.assertFalse(cache.contains(key3));
+
+    // different credential type
+    CredentialCacheKey key4 = new CredentialCacheKey("s3-token1", context1);
+    Assertions.assertFalse(cache.contains(key4));
+  }
+}

--- a/core/src/test/java/org/apache/gravitino/credential/TestCredentialCacheKey.java
+++ b/core/src/test/java/org/apache/gravitino/credential/TestCredentialCacheKey.java
@@ -29,28 +29,28 @@ public class TestCredentialCacheKey {
   @Test
   void testCredentialCacheKey() {
 
-    PathBasedCredentialContext context1 =
+    PathBasedCredentialContext context =
         new PathBasedCredentialContext("user1", ImmutableSet.of("path1"), ImmutableSet.of("path2"));
-    PathBasedCredentialContext context2 =
+    PathBasedCredentialContext contextWithDiffUser =
         new PathBasedCredentialContext("user2", ImmutableSet.of("path1"), ImmutableSet.of("path2"));
-    PathBasedCredentialContext context3 =
-        new PathBasedCredentialContext("user3", ImmutableSet.of("path3"), ImmutableSet.of("path4"));
+    PathBasedCredentialContext contextWithDiffPath =
+        new PathBasedCredentialContext("user1", ImmutableSet.of("path3"), ImmutableSet.of("path4"));
 
-    CredentialCacheKey key1 = new CredentialCacheKey("s3-token", context1);
+    CredentialCacheKey key1 = new CredentialCacheKey("s3-token", context);
 
     Set<CredentialCacheKey> cache = ImmutableSet.of(key1);
     Assertions.assertTrue(cache.contains(key1));
 
     // different user
-    CredentialCacheKey key2 = new CredentialCacheKey("s3-token", context2);
+    CredentialCacheKey key2 = new CredentialCacheKey("s3-token", contextWithDiffUser);
     Assertions.assertFalse(cache.contains(key2));
 
     // different path
-    CredentialCacheKey key3 = new CredentialCacheKey("s3-token", context3);
+    CredentialCacheKey key3 = new CredentialCacheKey("s3-token", contextWithDiffPath);
     Assertions.assertFalse(cache.contains(key3));
 
     // different credential type
-    CredentialCacheKey key4 = new CredentialCacheKey("s3-token1", context1);
+    CredentialCacheKey key4 = new CredentialCacheKey("s3-token1", context);
     Assertions.assertFalse(cache.contains(key4));
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

add credential cache for Gravitino server,  not support for Iceberg rest server yet.

### Why are the changes needed?

Fix: #4398 

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?

testing in local env,  get credential from Gravitino server and see whether it's fetched from remote or local cache
