### PR TITLE
[#6014] refactor: CLI output methods for no data hints

### DIFF
--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/ListCatalogs.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/ListCatalogs.java
@@ -49,11 +49,7 @@ public class ListCatalogs extends Command {
     try {
       GravitinoClient client = buildClient(metalake);
       catalogs = client.listCatalogsInfo();
-      if (catalogs.length == 0) {
-        System.out.println("No catalogs exist.");
-      } else {
-        output(catalogs);
-      }
+      output(catalogs);
     } catch (NoSuchMetalakeException err) {
       exitWithError(ErrorMessages.UNKNOWN_METALAKE);
     } catch (Exception exp) {

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/ListMetalakes.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/ListMetalakes.java
@@ -43,11 +43,7 @@ public class ListMetalakes extends Command {
     try {
       GravitinoAdminClient client = buildAdminClient();
       metalakes = client.listMetalakes();
-      if (metalakes.length == 0) {
-        System.out.println("No metalakes exist.");
-      } else {
-        output(metalakes);
-      }
+      output(metalakes);
     } catch (Exception exp) {
       exitWithError(exp.getMessage());
     }

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/outputs/PlainFormat.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/outputs/PlainFormat.java
@@ -50,10 +50,14 @@ public class PlainFormat {
   static final class MetalakesPlainFormat implements OutputFormat<Metalake[]> {
     @Override
     public void output(Metalake[] metalakes) {
-      List<String> metalakeNames =
-          Arrays.stream(metalakes).map(Metalake::name).collect(Collectors.toList());
-      String all = String.join(System.lineSeparator(), metalakeNames);
-      System.out.println(all);
+      if (metalakes.length == 0) {
+        System.out.println("No metalakes exist.");
+      } else {
+        List<String> metalakeNames =
+            Arrays.stream(metalakes).map(Metalake::name).collect(Collectors.toList());
+        String all = String.join(System.lineSeparator(), metalakeNames);
+        System.out.println(all);
+      }
     }
   }
 
@@ -74,10 +78,14 @@ public class PlainFormat {
   static final class CatalogsPlainFormat implements OutputFormat<Catalog[]> {
     @Override
     public void output(Catalog[] catalogs) {
-      List<String> catalogNames =
-          Arrays.stream(catalogs).map(Catalog::name).collect(Collectors.toList());
-      String all = String.join(System.lineSeparator(), catalogNames);
-      System.out.println(all);
+      if (catalogs.length == 0) {
+        System.out.println("No catalogs exist.");
+      } else {
+        List<String> catalogNames =
+            Arrays.stream(catalogs).map(Catalog::name).collect(Collectors.toList());
+        String all = String.join(System.lineSeparator(), catalogNames);
+        System.out.println(all);
+      }
     }
   }
 }

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/outputs/TableFormat.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/outputs/TableFormat.java
@@ -56,13 +56,17 @@ public class TableFormat {
   static final class MetalakesTableFormat implements OutputFormat<Metalake[]> {
     @Override
     public void output(Metalake[] metalakes) {
-      List<String> headers = Collections.singletonList("metalake");
-      List<List<String>> rows = new ArrayList<>();
-      for (int i = 0; i < metalakes.length; i++) {
-        rows.add(Arrays.asList(metalakes[i].name()));
+      if (metalakes.length == 0) {
+        System.out.println("No metalakes exist.");
+      } else {
+        List<String> headers = Collections.singletonList("metalake");
+        List<List<String>> rows = new ArrayList<>();
+        for (int i = 0; i < metalakes.length; i++) {
+          rows.add(Arrays.asList(metalakes[i].name()));
+        }
+        TableFormatImpl tableFormat = new TableFormatImpl();
+        tableFormat.print(headers, rows);
       }
-      TableFormatImpl tableFormat = new TableFormatImpl();
-      tableFormat.print(headers, rows);
     }
   }
 
@@ -85,13 +89,17 @@ public class TableFormat {
   static final class CatalogsTableFormat implements OutputFormat<Catalog[]> {
     @Override
     public void output(Catalog[] catalogs) {
-      List<String> headers = Collections.singletonList("catalog");
-      List<List<String>> rows = new ArrayList<>();
-      for (int i = 0; i < catalogs.length; i++) {
-        rows.add(Arrays.asList(catalogs[i].name()));
+      if (catalogs.length == 0) {
+        System.out.println("No catalogs exist.");
+      } else {
+        List<String> headers = Collections.singletonList("catalog");
+        List<List<String>> rows = new ArrayList<>();
+        for (int i = 0; i < catalogs.length; i++) {
+          rows.add(Arrays.asList(catalogs[i].name()));
+        }
+        TableFormatImpl tableFormat = new TableFormatImpl();
+        tableFormat.print(headers, rows);
       }
-      TableFormatImpl tableFormat = new TableFormatImpl();
-      tableFormat.print(headers, rows);
     }
   }
 


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

In the `ListMetalakes` and `ListCatalogs` methods, retain the use of  `output(metalakes)`  and `output(catalogs)`. If metalakes or catalogs are empty arrays, they will be handled by the `output` method in `PlainFormat` and `TableFormat`.

### Why are the changes needed?

Issue: https://github.com/apache/gravitino/issues/6014

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

No.
