### PR TITLE
[#6035]feat(spark-connector):Support custom catalog backend

### DIFF
--- a/catalogs/catalog-common/src/main/java/org/apache/gravitino/catalog/lakehouse/iceberg/IcebergPropertiesUtils.java
+++ b/catalogs/catalog-common/src/main/java/org/apache/gravitino/catalog/lakehouse/iceberg/IcebergPropertiesUtils.java
@@ -37,6 +37,7 @@ public class IcebergPropertiesUtils {
   static {
     Map<String, String> map = new HashMap();
     map.put(IcebergConstants.CATALOG_BACKEND, IcebergConstants.CATALOG_BACKEND);
+    map.put(IcebergConstants.CATALOG_BACKEND_IMPL, IcebergConstants.CATALOG_BACKEND_IMPL);
     map.put(IcebergConstants.GRAVITINO_JDBC_DRIVER, IcebergConstants.GRAVITINO_JDBC_DRIVER);
     map.put(IcebergConstants.GRAVITINO_JDBC_USER, IcebergConstants.ICEBERG_JDBC_USER);
     map.put(IcebergConstants.GRAVITINO_JDBC_PASSWORD, IcebergConstants.ICEBERG_JDBC_PASSWORD);

--- a/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/iceberg/IcebergPropertiesConstants.java
+++ b/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/iceberg/IcebergPropertiesConstants.java
@@ -29,6 +29,7 @@ public class IcebergPropertiesConstants {
   public static final String GRAVITINO_ICEBERG_CATALOG_BACKEND = IcebergConstants.CATALOG_BACKEND;
 
   static final String ICEBERG_CATALOG_TYPE = CatalogUtil.ICEBERG_CATALOG_TYPE;
+  static final String ICEBERG_CATALOG_IMPL = CatalogProperties.CATALOG_IMPL;
 
   public static final String GRAVITINO_ICEBERG_CATALOG_WAREHOUSE = IcebergConstants.WAREHOUSE;
 
@@ -57,6 +58,8 @@ public class IcebergPropertiesConstants {
   public static final String ICEBERG_CATALOG_BACKEND_REST = CatalogUtil.ICEBERG_CATALOG_TYPE_REST;
 
   static final String GRAVITINO_ICEBERG_CATALOG_BACKEND_REST = "rest";
+
+  public static final String ICEBERG_CATALOG_BACKEND_CUSTOM = "custom";
 
   @VisibleForTesting public static final String ICEBERG_LOCATION = IcebergConstants.LOCATION;
 

--- a/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/iceberg/IcebergPropertiesConverter.java
+++ b/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/iceberg/IcebergPropertiesConverter.java
@@ -49,7 +49,21 @@ public class IcebergPropertiesConverter implements PropertiesConverter {
     Preconditions.checkArgument(
         StringUtils.isNotBlank(catalogBackend),
         String.format("%s should not be empty", IcebergConstants.CATALOG_BACKEND));
-    all.put(IcebergPropertiesConstants.ICEBERG_CATALOG_TYPE, catalogBackend);
+    if (catalogBackend.equalsIgnoreCase(
+        IcebergPropertiesConstants.ICEBERG_CATALOG_BACKEND_CUSTOM)) {
+      String catalogBackendImpl = all.remove(IcebergConstants.CATALOG_BACKEND_IMPL);
+      Preconditions.checkArgument(
+          StringUtils.isNotBlank(catalogBackendImpl),
+          String.format(
+              "%s should not be empty when %s is %s",
+              IcebergConstants.CATALOG_BACKEND_IMPL,
+              IcebergConstants.CATALOG_BACKEND,
+              IcebergPropertiesConstants.ICEBERG_CATALOG_BACKEND_CUSTOM));
+      all.put(IcebergPropertiesConstants.ICEBERG_CATALOG_IMPL, catalogBackendImpl);
+    } else {
+      all.put(IcebergPropertiesConstants.ICEBERG_CATALOG_TYPE, catalogBackend);
+    }
+
     all.put(IcebergPropertiesConstants.ICEBERG_CATALOG_CACHE_ENABLED, "FALSE");
     return all;
   }

--- a/spark-connector/spark-common/src/test/java/org/apache/gravitino/spark/connector/iceberg/TestIcebergPropertiesConverter.java
+++ b/spark-connector/spark-common/src/test/java/org/apache/gravitino/spark/connector/iceberg/TestIcebergPropertiesConverter.java
@@ -21,6 +21,7 @@ package org.apache.gravitino.spark.connector.iceberg;
 
 import com.google.common.collect.ImmutableMap;
 import java.util.Map;
+import org.apache.gravitino.catalog.lakehouse.iceberg.IcebergConstants;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -111,6 +112,31 @@ public class TestIcebergPropertiesConverter {
             "rest-uri",
             IcebergPropertiesConstants.ICEBERG_CATALOG_WAREHOUSE,
             "rest-warehouse"),
+        properties);
+  }
+
+  @Test
+  void testCatalogPropertiesWithCustomBackend() {
+    Map<String, String> properties =
+        icebergPropertiesConverter.toSparkCatalogProperties(
+            ImmutableMap.of(
+                IcebergPropertiesConstants.GRAVITINO_ICEBERG_CATALOG_BACKEND,
+                IcebergPropertiesConstants.ICEBERG_CATALOG_BACKEND_CUSTOM,
+                IcebergConstants.CATALOG_BACKEND_IMPL,
+                "CustomCatalog",
+                IcebergPropertiesConstants.GRAVITINO_ICEBERG_CATALOG_WAREHOUSE,
+                "custom-warehouse",
+                "key1",
+                "value1"));
+
+    Assertions.assertEquals(
+        ImmutableMap.of(
+            IcebergPropertiesConstants.ICEBERG_CATALOG_CACHE_ENABLED,
+            "FALSE",
+            IcebergPropertiesConstants.ICEBERG_CATALOG_IMPL,
+            "CustomCatalog",
+            IcebergPropertiesConstants.ICEBERG_CATALOG_WAREHOUSE,
+            "custom-warehouse"),
         properties);
   }
 }


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?
When the catalog backend is `custom`, add the `catalog-impl` instead `type` in properties

### Why are the changes needed?

Fix: #6035 

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
add a new case in `TestIcebergPropertiesConverter`
