### PR TITLE
[#6030] fix(CLI): Fix Setting the same tags multiple times in the Gravitino CLi gives unexpected output

### DIFF
--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/TagEntity.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/TagEntity.java
@@ -19,7 +19,6 @@
 
 package org.apache.gravitino.cli.commands;
 
-import com.google.common.base.Joiner;
 import org.apache.gravitino.Catalog;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Schema;

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/TagEntity.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/TagEntity.java
@@ -34,7 +34,6 @@ import org.apache.gravitino.exceptions.TagAlreadyAssociatedException;
 import org.apache.gravitino.rel.Table;
 
 public class TagEntity extends Command {
-  public static final Joiner COMMA_JOINER = Joiner.on(", ").skipNulls();
   protected final String metalake;
   protected final FullName name;
   protected final String[] tags;

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/TagEntity.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/TagEntity.java
@@ -97,9 +97,8 @@ public class TagEntity extends Command {
       exitWithError(ErrorMessages.UNKNOWN_SCHEMA);
     } catch (NoSuchTableException err) {
       exitWithError(ErrorMessages.UNKNOWN_TABLE);
-    } catch (TagAlreadyAssociatedException tagAlreadyAssociatedException) {
-      exitWithError(
-          "[" + COMMA_JOINER.join(tags) + "]" + " are already associated with " + name.getName());
+    } catch (TagAlreadyAssociatedException err) {
+      exitWithError("Tags are already associated with " + name.getName());
     } catch (Exception exp) {
       exitWithError(exp.getMessage());
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix the error information when Setting the same tags multiple times in the Gravitino CLi. now a hint information is given when the tag is set repeatedly

### Why are the changes needed?

Fix: #6030 

### Does this PR introduce _any_ user-facing change?

NO

### How was this patch tested?

```bash
gcli tag set --metalake demo_metalake --name Hive_catalog --tag tagB tagC
# Hive_catalog now tagged with tagB,tagC

gcli tag set --metalake demo_metalake --name Hive_catalog --tag tagB tagC
# [tagB, tagC] are(is) already associated with Hive_catalog
```