### PR TITLE
[#6007] fix: fix hadoop catalog entity name limitation

### DIFF
--- a/catalogs/catalog-hadoop/src/main/java/org/apache/gravitino/catalog/hadoop/HadoopCatalogCapability.java
+++ b/catalogs/catalog-hadoop/src/main/java/org/apache/gravitino/catalog/hadoop/HadoopCatalogCapability.java
@@ -31,4 +31,19 @@ public class HadoopCatalogCapability implements Capability {
     return CapabilityResult.unsupported(
         String.format("Hadoop catalog does not support managed storage for %s.", scope));
   }
+
+  @Override
+  public CapabilityResult specificationOnName(Scope scope, String name) {
+    CapabilityResult capabilityResult = Capability.super.specificationOnName(scope, name);
+    if (!capabilityResult.supported()) {
+      return capabilityResult;
+    }
+
+    if (name.contains("/")) {
+      return CapabilityResult.unsupported(
+          String.format("Hadoop catalog does not support '/' in the name for %s.", scope));
+    }
+
+    return CapabilityResult.SUPPORTED;
+  }
 }

--- a/catalogs/catalog-hadoop/src/test/java/org/apache/gravitino/catalog/hadoop/integration/test/HadoopCatalogIT.java
+++ b/catalogs/catalog-hadoop/src/test/java/org/apache/gravitino/catalog/hadoop/integration/test/HadoopCatalogIT.java
@@ -18,6 +18,8 @@
  */
 package org.apache.gravitino.catalog.hadoop.integration.test;
 
+import static org.apache.gravitino.file.Fileset.Type.MANAGED;
+
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import java.io.IOException;
@@ -176,17 +178,13 @@ public class HadoopCatalogIT extends BaseIT {
         fileSystem.exists(new Path(storageLocation)), "storage location should not exists");
     Fileset fileset =
         createFileset(
-            filesetName,
-            "comment",
-            Fileset.Type.MANAGED,
-            storageLocation,
-            ImmutableMap.of("k1", "v1"));
+            filesetName, "comment", MANAGED, storageLocation, ImmutableMap.of("k1", "v1"));
 
     // verify fileset is created
     assertFilesetExists(filesetName);
     Assertions.assertNotNull(fileset, "fileset should be created");
     Assertions.assertEquals("comment", fileset.comment());
-    Assertions.assertEquals(Fileset.Type.MANAGED, fileset.type());
+    Assertions.assertEquals(MANAGED, fileset.type());
     Assertions.assertEquals(storageLocation, fileset.storageLocation());
     Assertions.assertEquals(1, fileset.properties().size());
     Assertions.assertEquals("v1", fileset.properties().get("k1"));
@@ -196,20 +194,16 @@ public class HadoopCatalogIT extends BaseIT {
         FilesetAlreadyExistsException.class,
         () ->
             createFileset(
-                filesetName,
-                "comment",
-                Fileset.Type.MANAGED,
-                storageLocation,
-                ImmutableMap.of("k1", "v1")),
+                filesetName, "comment", MANAGED, storageLocation, ImmutableMap.of("k1", "v1")),
         "Should throw FilesetAlreadyExistsException when fileset already exists");
 
     // create fileset with null storage location
     String filesetName2 = "test_create_fileset_no_storage_location";
-    Fileset fileset2 = createFileset(filesetName2, null, Fileset.Type.MANAGED, null, null);
+    Fileset fileset2 = createFileset(filesetName2, null, MANAGED, null, null);
     assertFilesetExists(filesetName2);
     Assertions.assertNotNull(fileset2, "fileset should be created");
     Assertions.assertNull(fileset2.comment(), "comment should be null");
-    Assertions.assertEquals(Fileset.Type.MANAGED, fileset2.type(), "type should be MANAGED");
+    Assertions.assertEquals(MANAGED, fileset2.type(), "type should be MANAGED");
     Assertions.assertEquals(
         storageLocation(filesetName2),
         fileset2.storageLocation(),
@@ -219,13 +213,7 @@ public class HadoopCatalogIT extends BaseIT {
     // create fileset with null fileset name
     Assertions.assertThrows(
         IllegalNameIdentifierException.class,
-        () ->
-            createFileset(
-                null,
-                "comment",
-                Fileset.Type.MANAGED,
-                storageLocation,
-                ImmutableMap.of("k1", "v1")),
+        () -> createFileset(null, "comment", MANAGED, storageLocation, ImmutableMap.of("k1", "v1")),
         "Should throw IllegalArgumentException when fileset name is null");
 
     // create fileset with null fileset type
@@ -234,8 +222,7 @@ public class HadoopCatalogIT extends BaseIT {
     Fileset fileset3 =
         createFileset(filesetName3, "comment", null, storageLocation3, ImmutableMap.of("k1", "v1"));
     assertFilesetExists(filesetName3);
-    Assertions.assertEquals(
-        Fileset.Type.MANAGED, fileset3.type(), "fileset type should be MANAGED by default");
+    Assertions.assertEquals(MANAGED, fileset3.type(), "fileset type should be MANAGED by default");
   }
 
   @Test
@@ -249,7 +236,7 @@ public class HadoopCatalogIT extends BaseIT {
         createFileset(
             filesetName,
             "这是中文comment",
-            Fileset.Type.MANAGED,
+            MANAGED,
             storageLocation,
             ImmutableMap.of("k1", "v1", "test", "中文测试test", "中文key", "test1"));
 
@@ -257,7 +244,7 @@ public class HadoopCatalogIT extends BaseIT {
     assertFilesetExists(filesetName);
     Assertions.assertNotNull(fileset, "fileset should be created");
     Assertions.assertEquals("这是中文comment", fileset.comment());
-    Assertions.assertEquals(Fileset.Type.MANAGED, fileset.type());
+    Assertions.assertEquals(MANAGED, fileset.type());
     Assertions.assertEquals(storageLocation, fileset.storageLocation());
     Assertions.assertEquals(3, fileset.properties().size());
     Assertions.assertEquals("v1", fileset.properties().get("k1"));
@@ -301,12 +288,34 @@ public class HadoopCatalogIT extends BaseIT {
 
   @Test
   void testNameSpec() {
-    String illegalName = "/%~?*";
+    String illegalName = "ok/test";
 
+    // test illegal catalog name
+    Exception exception =
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () -> metalake.createCatalog(illegalName, Catalog.Type.FILESET, provider, null, null));
+    Assertions.assertTrue(exception.getMessage().contains("The catalog name 'ok/test' is illegal"));
+
+    // test illegal schema name
+    exception =
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () -> catalog.asSchemas().createSchema(illegalName, "comment", null));
+    Assertions.assertTrue(
+        exception.getMessage().contains("does not support '/' in the name for SCHEMA"));
+
+    // test illegal fileset name
     NameIdentifier nameIdentifier = NameIdentifier.of(schemaName, illegalName);
-
-    Assertions.assertThrows(
-        NoSuchFilesetException.class, () -> catalog.asFilesetCatalog().loadFileset(nameIdentifier));
+    exception =
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                catalog
+                    .asFilesetCatalog()
+                    .createFileset(nameIdentifier, null, MANAGED, null, null));
+    Assertions.assertTrue(
+        exception.getMessage().contains("does not support '/' in the name for FILESET"));
   }
 
   @Test
@@ -317,11 +326,7 @@ public class HadoopCatalogIT extends BaseIT {
 
     Fileset fileset =
         createFileset(
-            filesetName,
-            "comment",
-            Fileset.Type.MANAGED,
-            storageLocation,
-            ImmutableMap.of("k1", "v1"));
+            filesetName, "comment", MANAGED, storageLocation, ImmutableMap.of("k1", "v1"));
     assertFilesetExists(filesetName);
 
     // test load fileset
@@ -353,8 +358,7 @@ public class HadoopCatalogIT extends BaseIT {
     Assertions.assertFalse(
         fileSystem.exists(new Path(storageLocation)), "storage location should not exists");
 
-    createFileset(
-        filesetName, "comment", Fileset.Type.MANAGED, storageLocation, ImmutableMap.of("k1", "v1"));
+    createFileset(filesetName, "comment", MANAGED, storageLocation, ImmutableMap.of("k1", "v1"));
     assertFilesetExists(filesetName);
 
     // drop fileset
@@ -414,11 +418,7 @@ public class HadoopCatalogIT extends BaseIT {
 
     Fileset fileset1 =
         createFileset(
-            filesetName1,
-            "comment",
-            Fileset.Type.MANAGED,
-            storageLocation,
-            ImmutableMap.of("k1", "v1"));
+            filesetName1, "comment", MANAGED, storageLocation, ImmutableMap.of("k1", "v1"));
     assertFilesetExists(filesetName1);
 
     // create fileset2
@@ -427,11 +427,7 @@ public class HadoopCatalogIT extends BaseIT {
 
     Fileset fileset2 =
         createFileset(
-            filesetName2,
-            "comment",
-            Fileset.Type.MANAGED,
-            storageLocation2,
-            ImmutableMap.of("k1", "v1"));
+            filesetName2, "comment", MANAGED, storageLocation2, ImmutableMap.of("k1", "v1"));
     assertFilesetExists(filesetName2);
 
     // list filesets
@@ -449,8 +445,7 @@ public class HadoopCatalogIT extends BaseIT {
     String filesetName = "test_rename_fileset";
     String storageLocation = storageLocation(filesetName);
 
-    createFileset(
-        filesetName, "comment", Fileset.Type.MANAGED, storageLocation, ImmutableMap.of("k1", "v1"));
+    createFileset(filesetName, "comment", MANAGED, storageLocation, ImmutableMap.of("k1", "v1"));
     assertFilesetExists(filesetName);
 
     // rename fileset
@@ -465,7 +460,7 @@ public class HadoopCatalogIT extends BaseIT {
     Assertions.assertNotNull(newFileset, "fileset should be created");
     Assertions.assertEquals(newFilesetName, newFileset.name(), "fileset name should be updated");
     Assertions.assertEquals("comment", newFileset.comment(), "comment should not be change");
-    Assertions.assertEquals(Fileset.Type.MANAGED, newFileset.type(), "type should not be change");
+    Assertions.assertEquals(MANAGED, newFileset.type(), "type should not be change");
     Assertions.assertEquals(
         storageLocation, newFileset.storageLocation(), "storage location should not be change");
     Assertions.assertEquals(1, newFileset.properties().size(), "properties should not be change");
@@ -479,8 +474,7 @@ public class HadoopCatalogIT extends BaseIT {
     String filesetName = "test_update_fileset_comment";
     String storageLocation = storageLocation(filesetName);
 
-    createFileset(
-        filesetName, "comment", Fileset.Type.MANAGED, storageLocation, ImmutableMap.of("k1", "v1"));
+    createFileset(filesetName, "comment", MANAGED, storageLocation, ImmutableMap.of("k1", "v1"));
     assertFilesetExists(filesetName);
 
     // update fileset comment
@@ -496,7 +490,7 @@ public class HadoopCatalogIT extends BaseIT {
     // verify fileset is updated
     Assertions.assertNotNull(newFileset, "fileset should be created");
     Assertions.assertEquals(newComment, newFileset.comment(), "comment should be updated");
-    Assertions.assertEquals(Fileset.Type.MANAGED, newFileset.type(), "type should not be change");
+    Assertions.assertEquals(MANAGED, newFileset.type(), "type should not be change");
     Assertions.assertEquals(
         storageLocation, newFileset.storageLocation(), "storage location should not be change");
     Assertions.assertEquals(1, newFileset.properties().size(), "properties should not be change");
@@ -510,8 +504,7 @@ public class HadoopCatalogIT extends BaseIT {
     String filesetName = "test_update_fileset_properties";
     String storageLocation = storageLocation(filesetName);
 
-    createFileset(
-        filesetName, "comment", Fileset.Type.MANAGED, storageLocation, ImmutableMap.of("k1", "v1"));
+    createFileset(filesetName, "comment", MANAGED, storageLocation, ImmutableMap.of("k1", "v1"));
     assertFilesetExists(filesetName);
 
     // update fileset properties
@@ -525,7 +518,7 @@ public class HadoopCatalogIT extends BaseIT {
     // verify fileset is updated
     Assertions.assertNotNull(newFileset, "fileset should be created");
     Assertions.assertEquals("comment", newFileset.comment(), "comment should not be change");
-    Assertions.assertEquals(Fileset.Type.MANAGED, newFileset.type(), "type should not be change");
+    Assertions.assertEquals(MANAGED, newFileset.type(), "type should not be change");
     Assertions.assertEquals(
         storageLocation, newFileset.storageLocation(), "storage location should not be change");
     Assertions.assertEquals(1, newFileset.properties().size(), "properties should not be change");
@@ -539,8 +532,7 @@ public class HadoopCatalogIT extends BaseIT {
     String filesetName = "test_remove_fileset_properties";
     String storageLocation = storageLocation(filesetName);
 
-    createFileset(
-        filesetName, "comment", Fileset.Type.MANAGED, storageLocation, ImmutableMap.of("k1", "v1"));
+    createFileset(filesetName, "comment", MANAGED, storageLocation, ImmutableMap.of("k1", "v1"));
     assertFilesetExists(filesetName);
 
     // update fileset properties
@@ -554,7 +546,7 @@ public class HadoopCatalogIT extends BaseIT {
     // verify fileset is updated
     Assertions.assertNotNull(newFileset, "fileset should be created");
     Assertions.assertEquals("comment", newFileset.comment(), "comment should not be change");
-    Assertions.assertEquals(Fileset.Type.MANAGED, newFileset.type(), "type should not be change");
+    Assertions.assertEquals(MANAGED, newFileset.type(), "type should not be change");
     Assertions.assertEquals(
         storageLocation, newFileset.storageLocation(), "storage location should not be change");
     Assertions.assertEquals(0, newFileset.properties().size(), "properties should be removed");
@@ -566,8 +558,7 @@ public class HadoopCatalogIT extends BaseIT {
     String filesetName = "test_remove_fileset_comment";
     String storageLocation = storageLocation(filesetName);
 
-    createFileset(
-        filesetName, "comment", Fileset.Type.MANAGED, storageLocation, ImmutableMap.of("k1", "v1"));
+    createFileset(filesetName, "comment", MANAGED, storageLocation, ImmutableMap.of("k1", "v1"));
     assertFilesetExists(filesetName);
 
     // remove fileset comment
@@ -581,7 +572,7 @@ public class HadoopCatalogIT extends BaseIT {
     // verify fileset is updated
     Assertions.assertNotNull(newFileset, "fileset should be created");
     Assertions.assertNull(newFileset.comment(), "comment should be removed");
-    Assertions.assertEquals(Fileset.Type.MANAGED, newFileset.type(), "type should not be changed");
+    Assertions.assertEquals(MANAGED, newFileset.type(), "type should not be changed");
     Assertions.assertEquals(
         storageLocation, newFileset.storageLocation(), "storage location should not be changed");
     Assertions.assertEquals(1, newFileset.properties().size(), "properties should not be changed");
@@ -626,7 +617,7 @@ public class HadoopCatalogIT extends BaseIT {
             .createFileset(
                 filesetIdent,
                 "fileset comment",
-                Fileset.Type.MANAGED,
+                MANAGED,
                 generateLocation(filesetName),
                 Maps.newHashMap());
     Assertions.assertTrue(catalog.asFilesetCatalog().filesetExists(filesetIdent));
@@ -673,7 +664,7 @@ public class HadoopCatalogIT extends BaseIT {
               .createFileset(
                   filesetIdent,
                   "fileset comment",
-                  Fileset.Type.MANAGED,
+                  MANAGED,
                   generateLocation(filesetName),
                   Maps.newHashMap());
 
@@ -717,7 +708,7 @@ public class HadoopCatalogIT extends BaseIT {
             .createFileset(
                 NameIdentifier.of(localSchema.name(), "local_fileset"),
                 "fileset comment",
-                Fileset.Type.MANAGED,
+                MANAGED,
                 null,
                 ImmutableMap.of("k1", "v1"));
     Assertions.assertEquals(
@@ -738,7 +729,7 @@ public class HadoopCatalogIT extends BaseIT {
             .createFileset(
                 NameIdentifier.of(localSchema2.name(), "local_fileset2"),
                 "fileset comment",
-                Fileset.Type.MANAGED,
+                MANAGED,
                 null,
                 ImmutableMap.of("k1", "v1"));
     Assertions.assertEquals(hdfsLocation + "/local_fileset2", localFileset2.storageLocation());

--- a/catalogs/catalog-hadoop/src/test/java/org/apache/gravitino/catalog/hadoop/integration/test/HadoopCatalogIT.java
+++ b/catalogs/catalog-hadoop/src/test/java/org/apache/gravitino/catalog/hadoop/integration/test/HadoopCatalogIT.java
@@ -297,6 +297,13 @@ public class HadoopCatalogIT extends BaseIT {
             () -> metalake.createCatalog(illegalName, Catalog.Type.FILESET, provider, null, null));
     Assertions.assertTrue(exception.getMessage().contains("The catalog name 'ok/test' is illegal"));
 
+    // test rename catalog to illegal name
+    exception =
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () -> metalake.alterCatalog(catalog.name(), CatalogChange.rename(illegalName)));
+    Assertions.assertTrue(exception.getMessage().contains("The catalog name 'ok/test' is illegal"));
+
     // test illegal schema name
     exception =
         Assertions.assertThrows(
@@ -314,6 +321,17 @@ public class HadoopCatalogIT extends BaseIT {
                 catalog
                     .asFilesetCatalog()
                     .createFileset(nameIdentifier, null, MANAGED, null, null));
+    Assertions.assertTrue(
+        exception.getMessage().contains("does not support '/' in the name for FILESET"));
+
+    // test rename fileset to illegal name
+    exception =
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                catalog
+                    .asFilesetCatalog()
+                    .alterFileset(nameIdentifier, FilesetChange.rename(illegalName)));
     Assertions.assertTrue(
         exception.getMessage().contains("does not support '/' in the name for FILESET"));
   }

--- a/catalogs/catalog-jdbc-mysql/src/test/java/org/apache/gravitino/catalog/mysql/integration/test/CatalogMysqlIT.java
+++ b/catalogs/catalog-jdbc-mysql/src/test/java/org/apache/gravitino/catalog/mysql/integration/test/CatalogMysqlIT.java
@@ -1571,7 +1571,14 @@ public class CatalogMysqlIT extends BaseIT {
     Assertions.assertEquals(testSchemaName, schema.name());
 
     String[] schemaIdents = catalog.asSchemas().listSchemas();
-    Assertions.assertTrue(Arrays.stream(schemaIdents).anyMatch(s -> s.equals(testSchemaName)));
+    Assertions.assertTrue(Arrays.asList(schemaIdents).contains(testSchemaName));
+
+    Exception exception =
+        Assertions.assertThrows(
+            SchemaAlreadyExistsException.class,
+            () -> catalog.asSchemas().createSchema(testSchemaName, null, Collections.emptyMap()));
+    Assertions.assertTrue(
+        exception.getMessage().contains("Can't create database '//'; database exists"));
 
     Assertions.assertTrue(catalog.asSchemas().dropSchema(testSchemaName, false));
     Assertions.assertFalse(catalog.asSchemas().schemaExists(testSchemaName));

--- a/clients/client-java/src/main/java/org/apache/gravitino/client/BaseSchemaCatalog.java
+++ b/clients/client-java/src/main/java/org/apache/gravitino/client/BaseSchemaCatalog.java
@@ -278,9 +278,9 @@ abstract class BaseSchemaCatalog extends CatalogDTO
   static String formatSchemaRequestPath(Namespace ns) {
     return new StringBuilder()
         .append("api/metalakes/")
-        .append(ns.level(0))
+        .append(RESTUtils.encodeString(ns.level(0)))
         .append("/catalogs/")
-        .append(ns.level(1))
+        .append(RESTUtils.encodeString(ns.level(1)))
         .append("/schemas")
         .toString();
   }

--- a/clients/client-java/src/main/java/org/apache/gravitino/client/BaseSchemaCatalog.java
+++ b/clients/client-java/src/main/java/org/apache/gravitino/client/BaseSchemaCatalog.java
@@ -144,8 +144,7 @@ abstract class BaseSchemaCatalog extends CatalogDTO
   public Schema createSchema(String schemaName, String comment, Map<String, String> properties)
       throws NoSuchCatalogException, SchemaAlreadyExistsException {
 
-    SchemaCreateRequest req =
-        new SchemaCreateRequest(RESTUtils.encodeString(schemaName), comment, properties);
+    SchemaCreateRequest req = new SchemaCreateRequest(schemaName, comment, properties);
     req.validate();
 
     SchemaResponse resp =

--- a/clients/client-java/src/main/java/org/apache/gravitino/client/FilesetCatalog.java
+++ b/clients/client-java/src/main/java/org/apache/gravitino/client/FilesetCatalog.java
@@ -154,7 +154,7 @@ class FilesetCatalog extends BaseSchemaCatalog
     Namespace fullNamespace = getFilesetFullNamespace(ident.namespace());
     FilesetCreateRequest req =
         FilesetCreateRequest.builder()
-            .name(RESTUtils.encodeString(ident.name()))
+            .name(ident.name())
             .comment(comment)
             .type(type)
             .storageLocation(storageLocation)

--- a/clients/client-java/src/main/java/org/apache/gravitino/client/FilesetCatalog.java
+++ b/clients/client-java/src/main/java/org/apache/gravitino/client/FilesetCatalog.java
@@ -197,7 +197,7 @@ class FilesetCatalog extends BaseSchemaCatalog
 
     FilesetResponse resp =
         restClient.put(
-            formatFilesetRequestPath(fullNamespace) + "/" + ident.name(),
+            formatFilesetRequestPath(fullNamespace) + "/" + RESTUtils.encodeString(ident.name()),
             req,
             FilesetResponse.class,
             Collections.emptyMap(),
@@ -223,7 +223,7 @@ class FilesetCatalog extends BaseSchemaCatalog
     Namespace fullNamespace = getFilesetFullNamespace(ident.namespace());
     DropResponse resp =
         restClient.delete(
-            formatFilesetRequestPath(fullNamespace) + "/" + ident.name(),
+            formatFilesetRequestPath(fullNamespace) + "/" + RESTUtils.encodeString(ident.name()),
             DropResponse.class,
             Collections.emptyMap(),
             ErrorHandlers.filesetErrorHandler());

--- a/clients/client-java/src/main/java/org/apache/gravitino/client/GravitinoMetalake.java
+++ b/clients/client-java/src/main/java/org/apache/gravitino/client/GravitinoMetalake.java
@@ -255,7 +255,10 @@ public class GravitinoMetalake extends MetalakeDTO
 
     CatalogResponse resp =
         restClient.put(
-            String.format(API_METALAKES_CATALOGS_PATH, this.name(), catalogName),
+            String.format(
+                API_METALAKES_CATALOGS_PATH,
+                RESTUtils.encodeString(this.name()),
+                RESTUtils.encodeString(catalogName)),
             updatesRequest,
             CatalogResponse.class,
             Collections.emptyMap(),
@@ -289,7 +292,10 @@ public class GravitinoMetalake extends MetalakeDTO
 
     DropResponse resp =
         restClient.delete(
-            String.format(API_METALAKES_CATALOGS_PATH, this.name(), catalogName),
+            String.format(
+                API_METALAKES_CATALOGS_PATH,
+                RESTUtils.encodeString(this.name()),
+                RESTUtils.encodeString(catalogName)),
             params,
             DropResponse.class,
             Collections.emptyMap(),
@@ -304,7 +310,10 @@ public class GravitinoMetalake extends MetalakeDTO
 
     ErrorResponse resp =
         restClient.patch(
-            String.format(API_METALAKES_CATALOGS_PATH, this.name(), catalogName),
+            String.format(
+                API_METALAKES_CATALOGS_PATH,
+                RESTUtils.encodeString(this.name()),
+                RESTUtils.encodeString(catalogName)),
             req,
             ErrorResponse.class,
             Collections.emptyMap(),
@@ -323,7 +332,10 @@ public class GravitinoMetalake extends MetalakeDTO
 
     ErrorResponse resp =
         restClient.patch(
-            String.format(API_METALAKES_CATALOGS_PATH, this.name(), catalogName),
+            String.format(
+                API_METALAKES_CATALOGS_PATH,
+                RESTUtils.encodeString(this.name()),
+                RESTUtils.encodeString(catalogName)),
             req,
             ErrorResponse.class,
             Collections.emptyMap(),
@@ -364,7 +376,8 @@ public class GravitinoMetalake extends MetalakeDTO
     // only)
     ErrorResponse resp =
         restClient.post(
-            String.format("api/metalakes/%s/catalogs/testConnection", this.name()),
+            String.format(
+                "api/metalakes/%s/catalogs/testConnection", RESTUtils.encodeString(this.name())),
             req,
             ErrorResponse.class,
             Collections.emptyMap(),
@@ -393,7 +406,7 @@ public class GravitinoMetalake extends MetalakeDTO
   public String[] listTags() throws NoSuchMetalakeException {
     NameListResponse resp =
         restClient.get(
-            String.format(API_METALAKES_TAGS_PATH, this.name()),
+            String.format(API_METALAKES_TAGS_PATH, RESTUtils.encodeString(this.name())),
             NameListResponse.class,
             Collections.emptyMap(),
             ErrorHandlers.tagErrorHandler());
@@ -412,7 +425,7 @@ public class GravitinoMetalake extends MetalakeDTO
     Map<String, String> params = ImmutableMap.of("details", "true");
     TagListResponse resp =
         restClient.get(
-            String.format(API_METALAKES_TAGS_PATH, this.name()),
+            String.format(API_METALAKES_TAGS_PATH, RESTUtils.encodeString(this.name())),
             params,
             TagListResponse.class,
             Collections.emptyMap(),
@@ -437,7 +450,9 @@ public class GravitinoMetalake extends MetalakeDTO
 
     TagResponse resp =
         restClient.get(
-            String.format(API_METALAKES_TAGS_PATH, this.name()) + "/" + name,
+            String.format(API_METALAKES_TAGS_PATH, RESTUtils.encodeString(this.name()))
+                + "/"
+                + RESTUtils.encodeString(name),
             TagResponse.class,
             Collections.emptyMap(),
             ErrorHandlers.tagErrorHandler());
@@ -464,7 +479,7 @@ public class GravitinoMetalake extends MetalakeDTO
 
     TagResponse resp =
         restClient.post(
-            String.format(API_METALAKES_TAGS_PATH, this.name()),
+            String.format(API_METALAKES_TAGS_PATH, RESTUtils.encodeString(this.name())),
             req,
             TagResponse.class,
             Collections.emptyMap(),
@@ -494,7 +509,9 @@ public class GravitinoMetalake extends MetalakeDTO
 
     TagResponse resp =
         restClient.put(
-            String.format(API_METALAKES_TAGS_PATH, this.name()) + "/" + name,
+            String.format(API_METALAKES_TAGS_PATH, RESTUtils.encodeString(this.name()))
+                + "/"
+                + RESTUtils.encodeString(name),
             req,
             TagResponse.class,
             Collections.emptyMap(),
@@ -516,7 +533,9 @@ public class GravitinoMetalake extends MetalakeDTO
 
     DropResponse resp =
         restClient.delete(
-            String.format(API_METALAKES_TAGS_PATH, this.name()) + "/" + name,
+            String.format(API_METALAKES_TAGS_PATH, RESTUtils.encodeString(this.name()))
+                + "/"
+                + RESTUtils.encodeString(name),
             DropResponse.class,
             Collections.emptyMap(),
             ErrorHandlers.tagErrorHandler());
@@ -539,7 +558,8 @@ public class GravitinoMetalake extends MetalakeDTO
 
     UserResponse resp =
         restClient.post(
-            String.format(API_METALAKES_USERS_PATH, this.name(), BLANK_PLACEHOLDER),
+            String.format(
+                API_METALAKES_USERS_PATH, RESTUtils.encodeString(this.name()), BLANK_PLACEHOLDER),
             req,
             UserResponse.class,
             Collections.emptyMap(),
@@ -561,7 +581,10 @@ public class GravitinoMetalake extends MetalakeDTO
   public boolean removeUser(String user) throws NoSuchMetalakeException {
     RemoveResponse resp =
         restClient.delete(
-            String.format(API_METALAKES_USERS_PATH, this.name(), RESTUtils.encodeString(user)),
+            String.format(
+                API_METALAKES_USERS_PATH,
+                RESTUtils.encodeString(this.name()),
+                RESTUtils.encodeString(user)),
             RemoveResponse.class,
             Collections.emptyMap(),
             ErrorHandlers.userErrorHandler());
@@ -582,7 +605,10 @@ public class GravitinoMetalake extends MetalakeDTO
   public User getUser(String user) throws NoSuchUserException, NoSuchMetalakeException {
     UserResponse resp =
         restClient.get(
-            String.format(API_METALAKES_USERS_PATH, this.name(), RESTUtils.encodeString(user)),
+            String.format(
+                API_METALAKES_USERS_PATH,
+                RESTUtils.encodeString(this.name()),
+                RESTUtils.encodeString(user)),
             UserResponse.class,
             Collections.emptyMap(),
             ErrorHandlers.userErrorHandler());
@@ -603,7 +629,8 @@ public class GravitinoMetalake extends MetalakeDTO
 
     UserListResponse resp =
         restClient.get(
-            String.format(API_METALAKES_USERS_PATH, name(), BLANK_PLACEHOLDER),
+            String.format(
+                API_METALAKES_USERS_PATH, RESTUtils.encodeString(this.name()), BLANK_PLACEHOLDER),
             params,
             UserListResponse.class,
             Collections.emptyMap(),
@@ -622,7 +649,8 @@ public class GravitinoMetalake extends MetalakeDTO
   public String[] listUserNames() throws NoSuchMetalakeException {
     NameListResponse resp =
         restClient.get(
-            String.format(API_METALAKES_USERS_PATH, name(), BLANK_PLACEHOLDER),
+            String.format(
+                API_METALAKES_USERS_PATH, RESTUtils.encodeString(this.name()), BLANK_PLACEHOLDER),
             NameListResponse.class,
             Collections.emptyMap(),
             ErrorHandlers.userErrorHandler());
@@ -646,7 +674,8 @@ public class GravitinoMetalake extends MetalakeDTO
 
     GroupResponse resp =
         restClient.post(
-            String.format(API_METALAKES_GROUPS_PATH, this.name(), BLANK_PLACEHOLDER),
+            String.format(
+                API_METALAKES_GROUPS_PATH, RESTUtils.encodeString(this.name()), BLANK_PLACEHOLDER),
             req,
             GroupResponse.class,
             Collections.emptyMap(),
@@ -668,7 +697,10 @@ public class GravitinoMetalake extends MetalakeDTO
   public boolean removeGroup(String group) throws NoSuchMetalakeException {
     RemoveResponse resp =
         restClient.delete(
-            String.format(API_METALAKES_GROUPS_PATH, this.name(), RESTUtils.encodeString(group)),
+            String.format(
+                API_METALAKES_GROUPS_PATH,
+                RESTUtils.encodeString(this.name()),
+                RESTUtils.encodeString(group)),
             RemoveResponse.class,
             Collections.emptyMap(),
             ErrorHandlers.groupErrorHandler());
@@ -689,7 +721,10 @@ public class GravitinoMetalake extends MetalakeDTO
   public Group getGroup(String group) throws NoSuchGroupException, NoSuchMetalakeException {
     GroupResponse resp =
         restClient.get(
-            String.format(API_METALAKES_GROUPS_PATH, this.name(), RESTUtils.encodeString(group)),
+            String.format(
+                API_METALAKES_GROUPS_PATH,
+                RESTUtils.encodeString(this.name()),
+                RESTUtils.encodeString(group)),
             GroupResponse.class,
             Collections.emptyMap(),
             ErrorHandlers.groupErrorHandler());
@@ -710,7 +745,8 @@ public class GravitinoMetalake extends MetalakeDTO
 
     GroupListResponse resp =
         restClient.get(
-            String.format(API_METALAKES_GROUPS_PATH, name(), BLANK_PLACEHOLDER),
+            String.format(
+                API_METALAKES_GROUPS_PATH, RESTUtils.encodeString(this.name()), BLANK_PLACEHOLDER),
             params,
             GroupListResponse.class,
             Collections.emptyMap(),
@@ -728,7 +764,8 @@ public class GravitinoMetalake extends MetalakeDTO
   public String[] listGroupNames() throws NoSuchMetalakeException {
     NameListResponse resp =
         restClient.get(
-            String.format(API_METALAKES_GROUPS_PATH, name(), BLANK_PLACEHOLDER),
+            String.format(
+                API_METALAKES_GROUPS_PATH, RESTUtils.encodeString(this.name()), BLANK_PLACEHOLDER),
             NameListResponse.class,
             Collections.emptyMap(),
             ErrorHandlers.groupErrorHandler());
@@ -748,7 +785,10 @@ public class GravitinoMetalake extends MetalakeDTO
   public Role getRole(String role) throws NoSuchRoleException, NoSuchMetalakeException {
     RoleResponse resp =
         restClient.get(
-            String.format(API_METALAKES_ROLES_PATH, this.name(), RESTUtils.encodeString(role)),
+            String.format(
+                API_METALAKES_ROLES_PATH,
+                RESTUtils.encodeString(this.name()),
+                RESTUtils.encodeString(role)),
             RoleResponse.class,
             Collections.emptyMap(),
             ErrorHandlers.roleErrorHandler());
@@ -769,7 +809,10 @@ public class GravitinoMetalake extends MetalakeDTO
   public boolean deleteRole(String role) throws NoSuchMetalakeException {
     DeleteResponse resp =
         restClient.delete(
-            String.format(API_METALAKES_ROLES_PATH, this.name(), RESTUtils.encodeString(role)),
+            String.format(
+                API_METALAKES_ROLES_PATH,
+                RESTUtils.encodeString(this.name()),
+                RESTUtils.encodeString(role)),
             DeleteResponse.class,
             Collections.emptyMap(),
             ErrorHandlers.roleErrorHandler());
@@ -804,7 +847,8 @@ public class GravitinoMetalake extends MetalakeDTO
 
     RoleResponse resp =
         restClient.post(
-            String.format(API_METALAKES_ROLES_PATH, this.name(), BLANK_PLACEHOLDER),
+            String.format(
+                API_METALAKES_ROLES_PATH, RESTUtils.encodeString(this.name()), BLANK_PLACEHOLDER),
             req,
             RoleResponse.class,
             Collections.emptyMap(),
@@ -823,7 +867,8 @@ public class GravitinoMetalake extends MetalakeDTO
   public String[] listRoleNames() {
     NameListResponse resp =
         restClient.get(
-            String.format(API_METALAKES_ROLES_PATH, this.name(), BLANK_PLACEHOLDER),
+            String.format(
+                API_METALAKES_ROLES_PATH, RESTUtils.encodeString(this.name()), BLANK_PLACEHOLDER),
             NameListResponse.class,
             Collections.emptyMap(),
             ErrorHandlers.roleErrorHandler());
@@ -852,7 +897,7 @@ public class GravitinoMetalake extends MetalakeDTO
         restClient.put(
             String.format(
                 API_PERMISSION_PATH,
-                this.name(),
+                RESTUtils.encodeString(this.name()),
                 String.format("users/%s/grant", RESTUtils.encodeString(user))),
             request,
             UserResponse.class,
@@ -883,7 +928,7 @@ public class GravitinoMetalake extends MetalakeDTO
         restClient.put(
             String.format(
                 API_PERMISSION_PATH,
-                this.name(),
+                RESTUtils.encodeString(this.name()),
                 String.format("groups/%s/grant", RESTUtils.encodeString(group))),
             request,
             GroupResponse.class,
@@ -914,7 +959,7 @@ public class GravitinoMetalake extends MetalakeDTO
         restClient.put(
             String.format(
                 API_PERMISSION_PATH,
-                this.name(),
+                RESTUtils.encodeString(this.name()),
                 String.format("users/%s/revoke", RESTUtils.encodeString(user))),
             request,
             UserResponse.class,
@@ -945,7 +990,7 @@ public class GravitinoMetalake extends MetalakeDTO
         restClient.put(
             String.format(
                 API_PERMISSION_PATH,
-                this.name(),
+                RESTUtils.encodeString(this.name()),
                 String.format("groups/%s/revoke", RESTUtils.encodeString(group))),
             request,
             GroupResponse.class,
@@ -981,12 +1026,12 @@ public class GravitinoMetalake extends MetalakeDTO
         restClient.put(
             String.format(
                 API_PERMISSION_PATH,
-                this.name(),
+                RESTUtils.encodeString(this.name()),
                 String.format(
                     "roles/%s/%s/%s/grant",
                     RESTUtils.encodeString(role),
                     object.type().name().toLowerCase(Locale.ROOT),
-                    object.fullName())),
+                    RESTUtils.encodeString(object.fullName()))),
             request,
             RoleResponse.class,
             Collections.emptyMap(),
@@ -1023,12 +1068,12 @@ public class GravitinoMetalake extends MetalakeDTO
         restClient.put(
             String.format(
                 API_PERMISSION_PATH,
-                this.name(),
+                RESTUtils.encodeString(this.name()),
                 String.format(
                     "roles/%s/%s/%s/revoke",
                     RESTUtils.encodeString(role),
                     object.type().name().toLowerCase(Locale.ROOT),
-                    object.fullName())),
+                    RESTUtils.encodeString(object.fullName()))),
             request,
             RoleResponse.class,
             Collections.emptyMap(),
@@ -1052,7 +1097,7 @@ public class GravitinoMetalake extends MetalakeDTO
         restClient.get(
             String.format(
                 API_METALAKES_OWNERS_PATH,
-                this.name(),
+                RESTUtils.encodeString(this.name()),
                 String.format(
                     "%s/%s",
                     object.type().name().toLowerCase(Locale.ROOT),
@@ -1080,7 +1125,7 @@ public class GravitinoMetalake extends MetalakeDTO
         restClient.put(
             String.format(
                 API_METALAKES_OWNERS_PATH,
-                this.name(),
+                RESTUtils.encodeString(this.name()),
                 String.format(
                     "%s/%s",
                     object.type().name().toLowerCase(Locale.ROOT),

--- a/clients/client-java/src/main/java/org/apache/gravitino/client/MessagingCatalog.java
+++ b/clients/client-java/src/main/java/org/apache/gravitino/client/MessagingCatalog.java
@@ -44,6 +44,7 @@ import org.apache.gravitino.messaging.DataLayout;
 import org.apache.gravitino.messaging.Topic;
 import org.apache.gravitino.messaging.TopicCatalog;
 import org.apache.gravitino.messaging.TopicChange;
+import org.apache.gravitino.rest.RESTUtils;
 
 /**
  * Messaging catalog is a catalog implementation that supports messaging-like metadata operations,
@@ -115,7 +116,7 @@ class MessagingCatalog extends BaseSchemaCatalog implements TopicCatalog {
     Namespace fullNamespace = getTopicFullNamespace(ident.namespace());
     TopicResponse resp =
         restClient.get(
-            formatTopicRequestPath(fullNamespace) + "/" + ident.name(),
+            formatTopicRequestPath(fullNamespace) + "/" + RESTUtils.encodeString(ident.name()),
             TopicResponse.class,
             Collections.emptyMap(),
             ErrorHandlers.topicErrorHandler());
@@ -187,7 +188,7 @@ class MessagingCatalog extends BaseSchemaCatalog implements TopicCatalog {
 
     TopicResponse resp =
         restClient.put(
-            formatTopicRequestPath(fullNamespace) + "/" + ident.name(),
+            formatTopicRequestPath(fullNamespace) + "/" + RESTUtils.encodeString(ident.name()),
             updatesRequest,
             TopicResponse.class,
             Collections.emptyMap(),
@@ -210,7 +211,7 @@ class MessagingCatalog extends BaseSchemaCatalog implements TopicCatalog {
     Namespace fullNamespace = getTopicFullNamespace(ident.namespace());
     DropResponse resp =
         restClient.delete(
-            formatTopicRequestPath(fullNamespace) + "/" + ident.name(),
+            formatTopicRequestPath(fullNamespace) + "/" + RESTUtils.encodeString(ident.name()),
             DropResponse.class,
             Collections.emptyMap(),
             ErrorHandlers.topicErrorHandler());
@@ -222,7 +223,10 @@ class MessagingCatalog extends BaseSchemaCatalog implements TopicCatalog {
   @VisibleForTesting
   static String formatTopicRequestPath(Namespace ns) {
     Namespace schemaNs = Namespace.of(ns.level(0), ns.level(1));
-    return formatSchemaRequestPath(schemaNs) + "/" + ns.level(2) + "/topics";
+    return formatSchemaRequestPath(schemaNs)
+        + "/"
+        + RESTUtils.encodeString(ns.level(2))
+        + "/topics";
   }
 
   /**

--- a/clients/client-java/src/main/java/org/apache/gravitino/client/RelationalCatalog.java
+++ b/clients/client-java/src/main/java/org/apache/gravitino/client/RelationalCatalog.java
@@ -155,7 +155,7 @@ class RelationalCatalog extends BaseSchemaCatalog implements TableCatalog {
 
     TableCreateRequest req =
         new TableCreateRequest(
-            RESTUtils.encodeString(ident.name()),
+            ident.name(),
             comment,
             toDTOs(columns),
             properties,

--- a/clients/client-java/src/main/java/org/apache/gravitino/client/RelationalTable.java
+++ b/clients/client-java/src/main/java/org/apache/gravitino/client/RelationalTable.java
@@ -186,13 +186,13 @@ class RelationalTable implements Table, SupportsPartitions, SupportsTags, Suppor
   @VisibleForTesting
   String getPartitionRequestPath() {
     return "api/metalakes/"
-        + namespace.level(0)
+        + RESTUtils.encodeString(namespace.level(0))
         + "/catalogs/"
-        + namespace.level(1)
+        + RESTUtils.encodeString(namespace.level(1))
         + "/schemas/"
-        + namespace.level(2)
+        + RESTUtils.encodeString(namespace.level(2))
         + "/tables/"
-        + name()
+        + RESTUtils.encodeString(name())
         + "/partitions";
   }
 

--- a/clients/client-python/gravitino/client/base_schema_catalog.py
+++ b/clients/client-python/gravitino/client/base_schema_catalog.py
@@ -227,7 +227,13 @@ class BaseSchemaCatalog(CatalogDTO, SupportsSchemas):
 
     @staticmethod
     def format_schema_request_path(ns: Namespace):
-        return "api/metalakes/" + ns.level(0) + "/catalogs/" + ns.level(1) + "/schemas"
+        return (
+            "api/metalakes/"
+            + encode_string(ns.level(0))
+            + "/catalogs/"
+            + encode_string(ns.level(1))
+            + "/schemas"
+        )
 
     @staticmethod
     def to_schema_update_request(change: SchemaChange):

--- a/clients/client-python/gravitino/client/fileset_catalog.py
+++ b/clients/client-python/gravitino/client/fileset_catalog.py
@@ -205,7 +205,7 @@ class FilesetCatalog(BaseSchemaCatalog, SupportsCredentials):
         req.validate()
 
         resp = self.rest_client.put(
-            f"{self.format_fileset_request_path(full_namespace)}/{ident.name()}",
+            f"{self.format_fileset_request_path(full_namespace)}/{encode_string(ident.name())}",
             req,
             error_handler=FILESET_ERROR_HANDLER,
         )
@@ -231,7 +231,7 @@ class FilesetCatalog(BaseSchemaCatalog, SupportsCredentials):
         full_namespace = self._get_fileset_full_namespace(ident.namespace())
 
         resp = self.rest_client.delete(
-            f"{self.format_fileset_request_path(full_namespace)}/{ident.name()}",
+            f"{self.format_fileset_request_path(full_namespace)}/{encode_string(ident.name())}",
             error_handler=FILESET_ERROR_HANDLER,
         )
         drop_resp = DropResponse.from_json(resp.body, infer_missing=True)

--- a/clients/client-python/gravitino/client/gravitino_admin_client.py
+++ b/clients/client-python/gravitino/client/gravitino_admin_client.py
@@ -29,6 +29,7 @@ from gravitino.dto.responses.metalake_list_response import MetalakeListResponse
 from gravitino.dto.responses.metalake_response import MetalakeResponse
 from gravitino.api.metalake_change import MetalakeChange
 from gravitino.exceptions.handlers.metalake_error_handler import METALAKE_ERROR_HANDLER
+from gravitino.rest.rest_utils import encode_string
 
 logger = logging.getLogger(__name__)
 
@@ -103,7 +104,7 @@ class GravitinoAdminClient(GravitinoClientBase):
         updates_request.validate()
 
         resp = self._rest_client.put(
-            self.API_METALAKES_IDENTIFIER_PATH + name,
+            self.API_METALAKES_IDENTIFIER_PATH + encode_string(name),
             updates_request,
             error_handler=METALAKE_ERROR_HANDLER,
         )
@@ -126,7 +127,7 @@ class GravitinoAdminClient(GravitinoClientBase):
 
         params = {"force": str(force)}
         resp = self._rest_client.delete(
-            self.API_METALAKES_IDENTIFIER_PATH + name,
+            self.API_METALAKES_IDENTIFIER_PATH + encode_string(name),
             params=params,
             error_handler=METALAKE_ERROR_HANDLER,
         )
@@ -147,7 +148,7 @@ class GravitinoAdminClient(GravitinoClientBase):
         metalake_enable_request = MetalakeSetRequest(in_use=True)
         metalake_enable_request.validate()
 
-        url = self.API_METALAKES_IDENTIFIER_PATH + name
+        url = self.API_METALAKES_IDENTIFIER_PATH + encode_string(name)
         self._rest_client.patch(
             url, json=metalake_enable_request, error_handler=METALAKE_ERROR_HANDLER
         )
@@ -165,7 +166,7 @@ class GravitinoAdminClient(GravitinoClientBase):
         metalake_disable_request = MetalakeSetRequest(in_use=False)
         metalake_disable_request.validate()
 
-        url = self.API_METALAKES_IDENTIFIER_PATH + name
+        url = self.API_METALAKES_IDENTIFIER_PATH + encode_string(name)
         self._rest_client.patch(
             url, json=metalake_disable_request, error_handler=METALAKE_ERROR_HANDLER
         )

--- a/clients/client-python/gravitino/client/gravitino_client_base.py
+++ b/clients/client-python/gravitino/client/gravitino_client_base.py
@@ -27,6 +27,7 @@ from gravitino.dto.responses.metalake_response import MetalakeResponse
 from gravitino.dto.responses.version_response import VersionResponse
 from gravitino.exceptions.handlers.metalake_error_handler import METALAKE_ERROR_HANDLER
 from gravitino.exceptions.handlers.rest_error_handler import REST_ERROR_HANDLER
+from gravitino.rest.rest_utils import encode_string
 from gravitino.utils import HTTPClient
 from gravitino.exceptions.base import GravitinoRuntimeException
 from gravitino.constants.version import VERSION_INI, Version
@@ -75,7 +76,7 @@ class GravitinoClientBase:
 
         self.check_metalake_name(name)
         response = self._rest_client.get(
-            GravitinoClientBase.API_METALAKES_IDENTIFIER_PATH + name,
+            GravitinoClientBase.API_METALAKES_IDENTIFIER_PATH + encode_string(name),
             error_handler=METALAKE_ERROR_HANDLER,
         )
         metalake_response = MetalakeResponse.from_json(

--- a/clients/client-python/gravitino/client/gravitino_metalake.py
+++ b/clients/client-python/gravitino/client/gravitino_metalake.py
@@ -30,6 +30,7 @@ from gravitino.dto.responses.catalog_response import CatalogResponse
 from gravitino.dto.responses.drop_response import DropResponse
 from gravitino.dto.responses.entity_list_response import EntityListResponse
 from gravitino.exceptions.handlers.catalog_error_handler import CATALOG_ERROR_HANDLER
+from gravitino.rest.rest_utils import encode_string
 from gravitino.utils import HTTPClient
 
 
@@ -104,7 +105,9 @@ class GravitinoMetalake(MetalakeDTO):
         Returns:
             The Catalog with specified name.
         """
-        url = self.API_METALAKES_CATALOGS_PATH.format(self.name(), name)
+        url = self.API_METALAKES_CATALOGS_PATH.format(
+            encode_string(self.name()), encode_string(name)
+        )
         response = self.rest_client.get(url, error_handler=CATALOG_ERROR_HANDLER)
         catalog_resp = CatalogResponse.from_json(response.body, infer_missing=True)
 
@@ -146,7 +149,7 @@ class GravitinoMetalake(MetalakeDTO):
         )
         catalog_create_request.validate()
 
-        url = f"api/metalakes/{self.name()}/catalogs"
+        url = f"api/metalakes/{encode_string(self.name())}/catalogs"
         response = self.rest_client.post(
             url, json=catalog_create_request, error_handler=CATALOG_ERROR_HANDLER
         )
@@ -175,7 +178,9 @@ class GravitinoMetalake(MetalakeDTO):
         updates_request = CatalogUpdatesRequest(reqs)
         updates_request.validate()
 
-        url = self.API_METALAKES_CATALOGS_PATH.format(self.name(), name)
+        url = self.API_METALAKES_CATALOGS_PATH.format(
+            encode_string(self.name()), encode_string(name)
+        )
         response = self.rest_client.put(
             url, json=updates_request, error_handler=CATALOG_ERROR_HANDLER
         )
@@ -197,7 +202,9 @@ class GravitinoMetalake(MetalakeDTO):
             true if the catalog is dropped successfully, false if the catalog does not exist.
         """
         params = {"force": str(force)}
-        url = self.API_METALAKES_CATALOGS_PATH.format(self.name(), name)
+        url = self.API_METALAKES_CATALOGS_PATH.format(
+            encode_string(self.name()), encode_string(name)
+        )
         response = self.rest_client.delete(
             url, params=params, error_handler=CATALOG_ERROR_HANDLER
         )
@@ -220,7 +227,9 @@ class GravitinoMetalake(MetalakeDTO):
         catalog_enable_request = CatalogSetRequest(in_use=True)
         catalog_enable_request.validate()
 
-        url = self.API_METALAKES_CATALOGS_PATH.format(self.name(), name)
+        url = self.API_METALAKES_CATALOGS_PATH.format(
+            encode_string(self.name()), encode_string(name)
+        )
         self.rest_client.patch(
             url, json=catalog_enable_request, error_handler=CATALOG_ERROR_HANDLER
         )
@@ -238,7 +247,9 @@ class GravitinoMetalake(MetalakeDTO):
         catalog_disable_request = CatalogSetRequest(in_use=False)
         catalog_disable_request.validate()
 
-        url = self.API_METALAKES_CATALOGS_PATH.format(self.name(), name)
+        url = self.API_METALAKES_CATALOGS_PATH.format(
+            encode_string(self.name()), encode_string(name)
+        )
         self.rest_client.patch(
             url, json=catalog_disable_request, error_handler=CATALOG_ERROR_HANDLER
         )

--- a/clients/client-python/gravitino/rest/rest_utils.py
+++ b/clients/client-python/gravitino/rest/rest_utils.py
@@ -24,4 +24,4 @@ def encode_string(to_encode: str):
     if to_encode is None:
         raise IllegalArgumentException("Invalid string to encode: None")
 
-    return urllib.parse.quote(to_encode)
+    return urllib.parse.quote(to_encode, encoding="utf-8")


### PR DESCRIPTION
### What changes were proposed in this pull request?

 - limit '/' in schema name and fileset name for hadoop catalog
 - fix name encode issue when create schema, table, fileset and topic

### Why are the changes needed?

Fix: #6007 

### Does this PR introduce _any_ user-facing change?

yes, add new limitation for fileset name

### How was this patch tested?

ITs added
