### PR TITLE
[#6027] improvement(CLI): fix Gravitino CLI get wrong catalogName

### DIFF
--- a/clients/cli/src/main/java/org/apache/gravitino/cli/ErrorMessages.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/ErrorMessages.java
@@ -30,6 +30,7 @@ public class ErrorMessages {
   public static final String UNKNOWN_TABLE = "Unknown table name.";
   public static final String MALFORMED_NAME = "Malformed entity name.";
   public static final String MISSING_NAME = "Missing --name option.";
+  public static final String MISSING_METALAKE = "Missing --metalake option.";
   public static final String MISSING_GROUP = "Missing --group option.";
   public static final String MISSING_USER = "Missing --user option.";
   public static final String MISSING_ROLE = "Missing --role option.";

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/FullName.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/FullName.java
@@ -73,10 +73,7 @@ public class FullName {
       }
     }
 
-    // Extract the metalake name from the full name option
-    if (line.hasOption(GravitinoOptions.NAME)) {
-      return line.getOptionValue(GravitinoOptions.NAME).split("\\.")[0];
-    }
+    System.err.println(ErrorMessages.MISSING_METALAKE);
 
     return null;
   }

--- a/clients/cli/src/test/java/org/apache/gravitino/cli/TestFulllName.java
+++ b/clients/cli/src/test/java/org/apache/gravitino/cli/TestFulllName.java
@@ -212,4 +212,28 @@ public class TestFulllName {
     String output = new String(errContent.toByteArray(), StandardCharsets.UTF_8).trim();
     assertEquals(output, ErrorMessages.MALFORMED_NAME);
   }
+
+  @Test
+  @SuppressWarnings("DefaultCharset")
+  public void testGetMetalake() throws ParseException {
+    String[] args = {
+      "table", "list", "-i", "-m", "demo_metalake", "--name", "Hive_catalog.default"
+    };
+    CommandLine commandLine = new DefaultParser().parse(options, args);
+    FullName fullName = new FullName(commandLine);
+    String metalakeName = fullName.getMetalakeName();
+    assertEquals(metalakeName, "demo_metalake");
+  }
+
+  @Test
+  @SuppressWarnings("DefaultCharset")
+  public void testGetMetalakeWithoutMetalakeOption() throws ParseException {
+    String[] args = {"table", "list", "-i", "--name", "Hive_catalog.default"};
+    CommandLine commandLine = new DefaultParser().parse(options, args);
+    FullName fullName = new FullName(commandLine);
+    String metalakeName = fullName.getMetalakeName();
+    assertNull(metalakeName);
+    String errOutput = new String(errContent.toByteArray(), StandardCharsets.UTF_8).trim();
+    assertEquals(errOutput, ErrorMessages.MISSING_METALAKE);
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix Gravitino CLI get wrong catalogName when set metalake name by --name option. A hint is given if the -metalake option is not set.

### Why are the changes needed?

Fix: #6027 

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

local test
```bash
gcli table list --name Hive_catalog.default
Missing --metalake option.
```
