### PR TITLE
[#6049] fix(bundles): Fix scheme gs not found problem

### DIFF
--- a/.github/workflows/backend-integration-test.yml
+++ b/.github/workflows/backend-integration-test.yml
@@ -39,6 +39,7 @@ jobs:
               - meta/**
               - scripts/**
               - server/**
+              - bundles/**
               - server-common/**
               - build.gradle.kts
               - gradle.properties

--- a/bundles/aws-bundle/build.gradle.kts
+++ b/bundles/aws-bundle/build.gradle.kts
@@ -39,7 +39,6 @@ tasks.withType(ShadowJar::class.java) {
   relocate("org.apache.commons.lang3", "org.apache.gravitino.aws.shaded.org.apache.commons.lang3")
   relocate("com.google.common", "org.apache.gravitino.aws.shaded.com.google.common")
   relocate("com.fasterxml.jackson", "org.apache.gravitino.aws.shaded.com.fasterxml.jackson")
-
   mergeServiceFiles()
 }
 

--- a/bundles/aws-bundle/build.gradle.kts
+++ b/bundles/aws-bundle/build.gradle.kts
@@ -39,6 +39,8 @@ tasks.withType(ShadowJar::class.java) {
   relocate("org.apache.commons.lang3", "org.apache.gravitino.aws.shaded.org.apache.commons.lang3")
   relocate("com.google.common", "org.apache.gravitino.aws.shaded.com.google.common")
   relocate("com.fasterxml.jackson", "org.apache.gravitino.aws.shaded.com.fasterxml.jackson")
+
+  mergeServiceFiles()
 }
 
 tasks.jar {

--- a/bundles/azure-bundle/build.gradle.kts
+++ b/bundles/azure-bundle/build.gradle.kts
@@ -42,7 +42,6 @@ tasks.withType(ShadowJar::class.java) {
   relocate("com.fasterxml", "org.apache.gravitino.azure.shaded.com.fasterxml")
   relocate("com.google.common", "org.apache.gravitino.azure.shaded.com.google.common")
   relocate("org.eclipse.jetty", "org.apache.gravitino.azure.shaded.org.eclipse.jetty")
-
   mergeServiceFiles()
 }
 

--- a/bundles/azure-bundle/build.gradle.kts
+++ b/bundles/azure-bundle/build.gradle.kts
@@ -42,6 +42,8 @@ tasks.withType(ShadowJar::class.java) {
   relocate("com.fasterxml", "org.apache.gravitino.azure.shaded.com.fasterxml")
   relocate("com.google.common", "org.apache.gravitino.azure.shaded.com.google.common")
   relocate("org.eclipse.jetty", "org.apache.gravitino.azure.shaded.org.eclipse.jetty")
+
+  mergeServiceFiles()
 }
 
 tasks.jar {

--- a/bundles/gcp-bundle/build.gradle.kts
+++ b/bundles/gcp-bundle/build.gradle.kts
@@ -42,6 +42,7 @@ tasks.withType(ShadowJar::class.java) {
   relocate("com.google.common", "org.apache.gravitino.gcp.shaded.com.google.common")
   relocate("com.fasterxml", "org.apache.gravitino.gcp.shaded.com.fasterxml")
   relocate("org.eclipse.jetty", "org.apache.gravitino.gcp.shaded.org.eclipse.jetty")
+  mergeServiceFiles()
 }
 
 tasks.jar {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add `mergeServiceFiles()` when build the bundle jars


### Why are the changes needed?

After add HDFS client to gravitino bundle jar, we should add make sure both Gravitino and HDFS `Filesystem` are merged into resource file

Fix: #6049

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

Existing test. 