### PR TITLE
[#5979] fix(docs): Fix incorrect description in document how-to-use-gvfs.md

### DIFF
--- a/docs/how-to-use-gvfs.md
+++ b/docs/how-to-use-gvfs.md
@@ -518,7 +518,7 @@ fs = gvfs.GravitinoVirtualFileSystem(server_uri="http://localhost:8090", metalak
 
 :::note
 
-Gravitino python client does not support customized filesets defined by users due to the limit of `fsspec` library. 
+Gravitino python client does not support [customized file systems](hadoop-catalog.md#how-to-custom-your-own-hcfs-file-system-fileset) defined by users due to the limit of `fsspec` library. 
 :::
 
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix a vague description about customized file system usage in file how-to-use-gvfs.md.

### Why are the changes needed?

To make documents more accurate. 

Fix: #5979 

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

N/A
