### PR TITLE
[#5937] Add spotlessCheck to iceberg-common module on compileIcebergRESTServer

### DIFF
--- a/api/src/test/java/org/apache/gravitino/TestMetadataObjects.java
+++ b/api/src/test/java/org/apache/gravitino/TestMetadataObjects.java
@@ -84,4 +84,17 @@ public class TestMetadataObjects {
             MetadataObjects.of(
                 Lists.newArrayList("catalog", "schema", "table"), MetadataObject.Type.COLUMN));
   }
+
+  @Test
+  public void testRoleObject() {
+    // Test legal name
+    MetadataObject roleObject =
+        MetadataObjects.of(Lists.newArrayList("role"), MetadataObject.Type.ROLE);
+    Assertions.assertEquals("role", roleObject.fullName());
+
+    // Test illegal name
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> MetadataObjects.of(Lists.newArrayList("role", "test"), MetadataObject.Type.ROLE));
+  }
 }

--- a/api/src/test/java/org/apache/gravitino/TestMetadataObjects.java
+++ b/api/src/test/java/org/apache/gravitino/TestMetadataObjects.java
@@ -88,13 +88,12 @@ public class TestMetadataObjects {
   @Test
   public void testRoleObject() {
     // Test legal name
-    MetadataObject roleObject =
-        MetadataObjects.of(Lists.newArrayList("role"), MetadataObject.Type.ROLE);
+    MetadataObject roleObject = MetadataObjects.of(null, "role", MetadataObject.Type.ROLE);
     Assertions.assertEquals("role", roleObject.fullName());
 
     // Test illegal name
     Assertions.assertThrows(
         IllegalArgumentException.class,
-        () -> MetadataObjects.of(Lists.newArrayList("role", "test"), MetadataObject.Type.ROLE));
+        () -> MetadataObjects.of(null, "role.test", MetadataObject.Type.ROLE));
   }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -625,7 +625,10 @@ tasks {
   }
 
   val compileIcebergRESTServer by registering {
-    dependsOn("iceberg:iceberg-rest-server:copyLibAndConfigsToStandalonePackage")
+    dependsOn(
+      "iceberg:iceberg-common:spotlessCheck",
+      "iceberg:iceberg-rest-server:copyLibAndConfigsToStandalonePackage"
+    )
     group = "gravitino distribution"
     outputs.dir(projectDir.dir("distribution/${rootProject.name}-iceberg-rest-server"))
     doLast {

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/MetadataObjectService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/MetadataObjectService.java
@@ -50,10 +50,10 @@ public class MetadataObjectService {
       return MetalakeMetaService.getInstance().getMetalakeIdByName(fullName);
     }
 
-    List<String> names = DOT_SPLITTER.splitToList(fullName);
     if (type == MetadataObject.Type.ROLE) {
       return RoleMetaService.getInstance().getRoleIdByMetalakeIdAndName(metalakeId, fullName);
     }
+    List<String> names = DOT_SPLITTER.splitToList(fullName);
 
     long catalogId =
         CatalogMetaService.getInstance().getCatalogIdByMetalakeIdAndName(metalakeId, names.get(0));

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/MetadataObjectService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/MetadataObjectService.java
@@ -52,7 +52,7 @@ public class MetadataObjectService {
 
     List<String> names = DOT_SPLITTER.splitToList(fullName);
     if (type == MetadataObject.Type.ROLE) {
-      return RoleMetaService.getInstance().getRoleIdByMetalakeIdAndName(metalakeId, names.get(0));
+      return RoleMetaService.getInstance().getRoleIdByMetalakeIdAndName(metalakeId, fullName);
     }
 
     long catalogId =


### PR DESCRIPTION
What changes were proposed in this pull request?
Add spotlessCheck to iceberg-common module on compileIcebergRESTServer

Why are the changes needed?
Fix: https://github.com/apache/gravitino/issues/5937

Does this PR introduce any user-facing change?
no

How was this patch tested?
Break style by adding spaces to any java file in  iceberg-common module, and test it by running ./gradlew compileIcebergRESTServer -x test