### PR TITLE
[#5937]feat(build): enhance spotless integration in Gradle build script

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -506,8 +506,8 @@ subprojects {
     val implConfig = configurations.findByName("implementation") ?: return@afterEvaluate
 
     val projectDeps = implConfig.dependencies
-        .filterIsInstance<ProjectDependency>()
-        .filter { it.dependencyProject.plugins.hasPlugin("com.diffplug.spotless") }
+      .filterIsInstance<ProjectDependency>()
+      .filter { it.dependencyProject.plugins.hasPlugin("com.diffplug.spotless") }
 
     tasks.named("spotlessCheck").configure {
       projectDeps.forEach { dep ->
@@ -518,7 +518,6 @@ subprojects {
       }
     }
   }
-
 }
 
 tasks.rat {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -501,6 +501,24 @@ subprojects {
       exclude("test/**")
     }
   }
+
+  afterEvaluate {
+    val implConfig = configurations.findByName("implementation") ?: return@afterEvaluate
+
+    val projectDeps = implConfig.dependencies
+        .filterIsInstance<ProjectDependency>()
+        .filter { it.dependencyProject.plugins.hasPlugin("com.diffplug.spotless") }
+
+    tasks.named("spotlessCheck").configure {
+      projectDeps.forEach { dep ->
+        val spotlessTask = "${dep.dependencyProject.path}:spotlessCheck"
+        if (tasks.findByPath(spotlessTask) != null) {
+          dependsOn(spotlessTask)
+        }
+      }
+    }
+  }
+
 }
 
 tasks.rat {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -501,22 +501,8 @@ subprojects {
       exclude("test/**")
     }
   }
-
-  afterEvaluate {
-    val implConfig = configurations.findByName("implementation") ?: return@afterEvaluate
-
-    val projectDeps = implConfig.dependencies
-      .filterIsInstance<ProjectDependency>()
-      .filter { it.dependencyProject.plugins.hasPlugin("com.diffplug.spotless") }
-
-    tasks.named("spotlessCheck").configure {
-      projectDeps.forEach { dep ->
-        val spotlessTask = "${dep.dependencyProject.path}:spotlessCheck"
-        if (tasks.findByPath(spotlessTask) != null) {
-          dependsOn(spotlessTask)
-        }
-      }
-    }
+  tasks.named("compileJava").configure {
+    dependsOn("spotlessCheck")
   }
 }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Added configuration to ensure that subprojects using the 'com.diffplug.spotless' plugin are included in the 'spotlessCheck' task dependencies.

### Why are the changes needed?
Fix: https://github.com/apache/gravitino/issues/5937

### Does this PR introduce any user-facing change?
no

### How was this patch tested?
Break style by adding spaces to any java file in iceberg-common module, and test it by running ./gradlew compileIcebergRESTServer -x test
check dependence trees by running ./gradlew compileIcebergRESTServer taskTree