### PR TITLE
[#6080] fix(docs): Fix the wrong possible values.

### DIFF
--- a/docs/open-api/roles.yaml
+++ b/docs/open-api/roles.yaml
@@ -148,7 +148,7 @@ paths:
   /metalakes/{metalake}/objects/{metadataObjectType}/{metadataObjectFullName}/roles:
     parameters:
       - $ref: "./openapi.yaml#/components/parameters/metalake"
-      - $ref: "./openapi.yaml#/components/parameters/metadataObjectType"
+      - $ref: "#/components/parameters/metadataObjectTypeOfRole"
       - $ref: "./openapi.yaml#/components/parameters/metadataObjectFullName"
 
     get:
@@ -387,3 +387,19 @@ components:
         "code": 0,
         "names": [ "user1", "user2" ]
       }
+  parameters:
+    metadataObjectTypeOfRole:
+      name: metadataObjectType
+      in: path
+      description: The type of the metadata object
+      required: true
+      schema:
+        type: string
+        enum:
+          - "METALAKE"
+          - "CATALOG"
+          - "SCHEMA"
+          - "TABLE"
+          - "FILESET"
+          - "TOPIC"
+          - "MODEL"

--- a/docs/open-api/roles.yaml
+++ b/docs/open-api/roles.yaml
@@ -402,4 +402,3 @@ components:
           - "TABLE"
           - "FILESET"
           - "TOPIC"
-          - "MODEL"


### PR DESCRIPTION
What changes were proposed in this pull request?
List role names for metadata object, "COLUMN" and "ROLE" value for "metadataObjectType" are meaningless currently. Remove it.

Why are the changes needed?
Fix: #6080

Does this PR introduce any user-facing change?
No.

How was this patch tested?
Just documents.

