### PR TITLE
[#6082] fix: Fix error code of creating role operation

### DIFF
--- a/core/src/main/java/org/apache/gravitino/utils/MetadataObjectUtil.java
+++ b/core/src/main/java/org/apache/gravitino/utils/MetadataObjectUtil.java
@@ -32,6 +32,7 @@ import org.apache.gravitino.GravitinoEnv;
 import org.apache.gravitino.MetadataObject;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.authorization.AuthorizationUtils;
+import org.apache.gravitino.exceptions.IllegalMetadataObjectException;
 import org.apache.gravitino.exceptions.NoSuchMetadataObjectException;
 import org.apache.gravitino.exceptions.NoSuchRoleException;
 
@@ -125,6 +126,9 @@ public class MetadataObjectUtil {
 
     switch (object.type()) {
       case METALAKE:
+        if (!metalake.equals(object.name())) {
+          throw new IllegalMetadataObjectException("The metalake object name must be %s", metalake);
+        }
         NameIdentifierUtil.checkMetalake(identifier);
         check(env.metalakeDispatcher().metalakeExists(identifier), exceptionToThrowSupplier);
         break;

--- a/server/src/main/java/org/apache/gravitino/server/web/rest/RoleOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/RoleOperations.java
@@ -142,10 +142,10 @@ public class RoleOperations {
 
               Set<Privilege> privileges = Sets.newHashSet(object.privileges());
               AuthorizationUtils.checkDuplicatedNamePrivilege(privileges);
-              for (Privilege privilege : object.privileges()) {
-                AuthorizationUtils.checkPrivilege((PrivilegeDTO) privilege, object, metalake);
-              }
               try {
+                for (Privilege privilege : object.privileges()) {
+                  AuthorizationUtils.checkPrivilege((PrivilegeDTO) privilege, object, metalake);
+                }
                 MetadataObjectUtil.checkMetadataObject(metalake, object);
               } catch (NoSuchMetadataObjectException nsm) {
                 throw new IllegalMetadataObjectException(nsm);


### PR DESCRIPTION
### What changes were proposed in this pull request?

We should return 400, if the role contains an error metalake metadata object.
We should return 400, if the catalog doesn't exist.

### Why are the changes needed?

Fix: #6082

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Added UT.
