### PR TITLE
 [#5963] feat(client): added delete cli command model 

### DIFF
--- a/clients/cli/src/main/java/org/apache/gravitino/cli/GravitinoCommandLine.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/GravitinoCommandLine.java
@@ -1193,11 +1193,9 @@ public class GravitinoCommandLine extends TestableCommandLine {
         break;
 
       case CommandActions.DELETE:
-        {
-          boolean force = line.hasOption(GravitinoOptions.FORCE);
-          newDeleteModel(url, ignore, force, metalake, catalog, schema, model).handle();
-          break;
-        }
+        boolean force = line.hasOption(GravitinoOptions.FORCE);
+        newDeleteModel(url, ignore, force, metalake, catalog, schema, model).handle();
+        break;
 
       case CommandActions.CREATE:
         String createComment = line.getOptionValue(GravitinoOptions.COMMENT);

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/GravitinoCommandLine.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/GravitinoCommandLine.java
@@ -1192,6 +1192,23 @@ public class GravitinoCommandLine extends TestableCommandLine {
         }
         break;
 
+      case CommandActions.CREATE:
+      {
+        String comment = line.getOptionValue(GravitinoOptions.COMMENT);
+        String[] properties = line.getOptionValues(CommandActions.PROPERTIES);
+        Map<String, String> propertyMap = new Properties().parse(properties);
+        newCreateModel(url, ignore, metalake, catalog, schema, model, comment, propertyMap)
+                .handle();
+        break;
+      }
+
+      case CommandActions.DELETE:
+      {
+        boolean force = line.hasOption(GravitinoOptions.FORCE);
+        newDeleteModel(url, ignore, force, metalake, catalog, schema, model).handle();
+        break;
+      }
+
       default:
         System.err.println(ErrorMessages.UNSUPPORTED_ACTION);
         break;

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/GravitinoCommandLine.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/GravitinoCommandLine.java
@@ -1193,21 +1193,21 @@ public class GravitinoCommandLine extends TestableCommandLine {
         break;
 
       case CommandActions.CREATE:
-      {
-        String comment = line.getOptionValue(GravitinoOptions.COMMENT);
-        String[] properties = line.getOptionValues(CommandActions.PROPERTIES);
-        Map<String, String> propertyMap = new Properties().parse(properties);
-        newCreateModel(url, ignore, metalake, catalog, schema, model, comment, propertyMap)
-                .handle();
-        break;
-      }
+        {
+          String comment = line.getOptionValue(GravitinoOptions.COMMENT);
+          String[] properties = line.getOptionValues(CommandActions.PROPERTIES);
+          Map<String, String> propertyMap = new Properties().parse(properties);
+          newCreateModel(url, ignore, metalake, catalog, schema, model, comment, propertyMap)
+              .handle();
+          break;
+        }
 
       case CommandActions.DELETE:
-      {
-        boolean force = line.hasOption(GravitinoOptions.FORCE);
-        newDeleteModel(url, ignore, force, metalake, catalog, schema, model).handle();
-        break;
-      }
+        {
+          boolean force = line.hasOption(GravitinoOptions.FORCE);
+          newDeleteModel(url, ignore, force, metalake, catalog, schema, model).handle();
+          break;
+        }
 
       default:
         System.err.println(ErrorMessages.UNSUPPORTED_ACTION);

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/TestableCommandLine.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/TestableCommandLine.java
@@ -21,121 +21,8 @@
 package org.apache.gravitino.cli;
 
 import java.util.Map;
-import org.apache.gravitino.cli.commands.AddColumn;
-import org.apache.gravitino.cli.commands.AddRoleToGroup;
-import org.apache.gravitino.cli.commands.AddRoleToUser;
-import org.apache.gravitino.cli.commands.CatalogAudit;
-import org.apache.gravitino.cli.commands.CatalogDetails;
-import org.apache.gravitino.cli.commands.CatalogDisable;
-import org.apache.gravitino.cli.commands.CatalogEnable;
-import org.apache.gravitino.cli.commands.ClientVersion;
-import org.apache.gravitino.cli.commands.ColumnAudit;
-import org.apache.gravitino.cli.commands.CreateCatalog;
-import org.apache.gravitino.cli.commands.CreateFileset;
-import org.apache.gravitino.cli.commands.CreateGroup;
-import org.apache.gravitino.cli.commands.CreateMetalake;
-import org.apache.gravitino.cli.commands.CreateRole;
-import org.apache.gravitino.cli.commands.CreateSchema;
-import org.apache.gravitino.cli.commands.CreateTable;
-import org.apache.gravitino.cli.commands.CreateTag;
-import org.apache.gravitino.cli.commands.CreateTopic;
-import org.apache.gravitino.cli.commands.CreateUser;
-import org.apache.gravitino.cli.commands.DeleteCatalog;
-import org.apache.gravitino.cli.commands.DeleteColumn;
-import org.apache.gravitino.cli.commands.DeleteFileset;
-import org.apache.gravitino.cli.commands.DeleteGroup;
-import org.apache.gravitino.cli.commands.DeleteMetalake;
-import org.apache.gravitino.cli.commands.DeleteRole;
-import org.apache.gravitino.cli.commands.DeleteSchema;
-import org.apache.gravitino.cli.commands.DeleteTable;
-import org.apache.gravitino.cli.commands.DeleteTag;
-import org.apache.gravitino.cli.commands.DeleteTopic;
-import org.apache.gravitino.cli.commands.DeleteUser;
-import org.apache.gravitino.cli.commands.FilesetDetails;
-import org.apache.gravitino.cli.commands.GrantPrivilegesToRole;
-import org.apache.gravitino.cli.commands.GroupAudit;
-import org.apache.gravitino.cli.commands.GroupDetails;
-import org.apache.gravitino.cli.commands.ListAllTags;
-import org.apache.gravitino.cli.commands.ListCatalogProperties;
-import org.apache.gravitino.cli.commands.ListCatalogs;
-import org.apache.gravitino.cli.commands.ListColumns;
-import org.apache.gravitino.cli.commands.ListEntityTags;
-import org.apache.gravitino.cli.commands.ListFilesetProperties;
-import org.apache.gravitino.cli.commands.ListFilesets;
-import org.apache.gravitino.cli.commands.ListGroups;
-import org.apache.gravitino.cli.commands.ListIndexes;
-import org.apache.gravitino.cli.commands.ListMetalakeProperties;
-import org.apache.gravitino.cli.commands.ListMetalakes;
-import org.apache.gravitino.cli.commands.ListModel;
-import org.apache.gravitino.cli.commands.ListRoles;
-import org.apache.gravitino.cli.commands.ListSchema;
-import org.apache.gravitino.cli.commands.ListSchemaProperties;
-import org.apache.gravitino.cli.commands.ListTableProperties;
-import org.apache.gravitino.cli.commands.ListTables;
-import org.apache.gravitino.cli.commands.ListTagProperties;
-import org.apache.gravitino.cli.commands.ListTopicProperties;
-import org.apache.gravitino.cli.commands.ListTopics;
-import org.apache.gravitino.cli.commands.ListUsers;
-import org.apache.gravitino.cli.commands.MetalakeAudit;
-import org.apache.gravitino.cli.commands.MetalakeDetails;
-import org.apache.gravitino.cli.commands.MetalakeDisable;
-import org.apache.gravitino.cli.commands.MetalakeEnable;
-import org.apache.gravitino.cli.commands.ModelAudit;
-import org.apache.gravitino.cli.commands.ModelDetails;
-import org.apache.gravitino.cli.commands.OwnerDetails;
-import org.apache.gravitino.cli.commands.RemoveAllTags;
-import org.apache.gravitino.cli.commands.RemoveCatalogProperty;
-import org.apache.gravitino.cli.commands.RemoveFilesetProperty;
-import org.apache.gravitino.cli.commands.RemoveMetalakeProperty;
-import org.apache.gravitino.cli.commands.RemoveRoleFromGroup;
-import org.apache.gravitino.cli.commands.RemoveRoleFromUser;
-import org.apache.gravitino.cli.commands.RemoveSchemaProperty;
-import org.apache.gravitino.cli.commands.RemoveTableProperty;
-import org.apache.gravitino.cli.commands.RemoveTagProperty;
-import org.apache.gravitino.cli.commands.RemoveTopicProperty;
-import org.apache.gravitino.cli.commands.RevokePrivilegesFromRole;
-import org.apache.gravitino.cli.commands.RoleAudit;
-import org.apache.gravitino.cli.commands.RoleDetails;
-import org.apache.gravitino.cli.commands.SchemaAudit;
-import org.apache.gravitino.cli.commands.SchemaDetails;
-import org.apache.gravitino.cli.commands.ServerVersion;
-import org.apache.gravitino.cli.commands.SetCatalogProperty;
-import org.apache.gravitino.cli.commands.SetFilesetProperty;
-import org.apache.gravitino.cli.commands.SetMetalakeProperty;
-import org.apache.gravitino.cli.commands.SetOwner;
-import org.apache.gravitino.cli.commands.SetSchemaProperty;
-import org.apache.gravitino.cli.commands.SetTableProperty;
-import org.apache.gravitino.cli.commands.SetTagProperty;
-import org.apache.gravitino.cli.commands.SetTopicProperty;
-import org.apache.gravitino.cli.commands.TableAudit;
-import org.apache.gravitino.cli.commands.TableDetails;
-import org.apache.gravitino.cli.commands.TableDistribution;
-import org.apache.gravitino.cli.commands.TablePartition;
-import org.apache.gravitino.cli.commands.TableSortOrder;
-import org.apache.gravitino.cli.commands.TagDetails;
-import org.apache.gravitino.cli.commands.TagEntity;
-import org.apache.gravitino.cli.commands.TopicDetails;
-import org.apache.gravitino.cli.commands.UntagEntity;
-import org.apache.gravitino.cli.commands.UpdateCatalogComment;
-import org.apache.gravitino.cli.commands.UpdateCatalogName;
-import org.apache.gravitino.cli.commands.UpdateColumnAutoIncrement;
-import org.apache.gravitino.cli.commands.UpdateColumnComment;
-import org.apache.gravitino.cli.commands.UpdateColumnDatatype;
-import org.apache.gravitino.cli.commands.UpdateColumnDefault;
-import org.apache.gravitino.cli.commands.UpdateColumnName;
-import org.apache.gravitino.cli.commands.UpdateColumnNullability;
-import org.apache.gravitino.cli.commands.UpdateColumnPosition;
-import org.apache.gravitino.cli.commands.UpdateFilesetComment;
-import org.apache.gravitino.cli.commands.UpdateFilesetName;
-import org.apache.gravitino.cli.commands.UpdateMetalakeComment;
-import org.apache.gravitino.cli.commands.UpdateMetalakeName;
-import org.apache.gravitino.cli.commands.UpdateTableComment;
-import org.apache.gravitino.cli.commands.UpdateTableName;
-import org.apache.gravitino.cli.commands.UpdateTagComment;
-import org.apache.gravitino.cli.commands.UpdateTagName;
-import org.apache.gravitino.cli.commands.UpdateTopicComment;
-import org.apache.gravitino.cli.commands.UserAudit;
-import org.apache.gravitino.cli.commands.UserDetails;
+
+import org.apache.gravitino.cli.commands.*;
 
 /*
  * Methods used for testing
@@ -924,5 +811,15 @@ public class TestableCommandLine {
   protected ModelDetails newModelDetails(
       String url, boolean ignore, String metalake, String catalog, String schema, String model) {
     return new ModelDetails(url, ignore, metalake, catalog, schema, model);
+  }
+
+  protected CreateModel newCreateModel(
+      String url, boolean ignore, String metalake, String catalog, String schema, String model, String comment, Map<String, String> properties) {
+    return new CreateModel(url, ignore, metalake, catalog, schema, model, comment, properties);
+  }
+
+  protected DeleteModel newDeleteModel(
+          String url, boolean ignore, boolean force, String metalake, String catalog, String schema, String model) {
+    return new DeleteModel(url, ignore, force, metalake, catalog, schema, model);
   }
 }

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/TestableCommandLine.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/TestableCommandLine.java
@@ -21,8 +21,123 @@
 package org.apache.gravitino.cli;
 
 import java.util.Map;
-
-import org.apache.gravitino.cli.commands.*;
+import org.apache.gravitino.cli.commands.AddColumn;
+import org.apache.gravitino.cli.commands.AddRoleToGroup;
+import org.apache.gravitino.cli.commands.AddRoleToUser;
+import org.apache.gravitino.cli.commands.CatalogAudit;
+import org.apache.gravitino.cli.commands.CatalogDetails;
+import org.apache.gravitino.cli.commands.CatalogDisable;
+import org.apache.gravitino.cli.commands.CatalogEnable;
+import org.apache.gravitino.cli.commands.ClientVersion;
+import org.apache.gravitino.cli.commands.ColumnAudit;
+import org.apache.gravitino.cli.commands.CreateCatalog;
+import org.apache.gravitino.cli.commands.CreateFileset;
+import org.apache.gravitino.cli.commands.CreateGroup;
+import org.apache.gravitino.cli.commands.CreateMetalake;
+import org.apache.gravitino.cli.commands.CreateModel;
+import org.apache.gravitino.cli.commands.CreateRole;
+import org.apache.gravitino.cli.commands.CreateSchema;
+import org.apache.gravitino.cli.commands.CreateTable;
+import org.apache.gravitino.cli.commands.CreateTag;
+import org.apache.gravitino.cli.commands.CreateTopic;
+import org.apache.gravitino.cli.commands.CreateUser;
+import org.apache.gravitino.cli.commands.DeleteCatalog;
+import org.apache.gravitino.cli.commands.DeleteColumn;
+import org.apache.gravitino.cli.commands.DeleteFileset;
+import org.apache.gravitino.cli.commands.DeleteGroup;
+import org.apache.gravitino.cli.commands.DeleteMetalake;
+import org.apache.gravitino.cli.commands.DeleteModel;
+import org.apache.gravitino.cli.commands.DeleteRole;
+import org.apache.gravitino.cli.commands.DeleteSchema;
+import org.apache.gravitino.cli.commands.DeleteTable;
+import org.apache.gravitino.cli.commands.DeleteTag;
+import org.apache.gravitino.cli.commands.DeleteTopic;
+import org.apache.gravitino.cli.commands.DeleteUser;
+import org.apache.gravitino.cli.commands.FilesetDetails;
+import org.apache.gravitino.cli.commands.GrantPrivilegesToRole;
+import org.apache.gravitino.cli.commands.GroupAudit;
+import org.apache.gravitino.cli.commands.GroupDetails;
+import org.apache.gravitino.cli.commands.ListAllTags;
+import org.apache.gravitino.cli.commands.ListCatalogProperties;
+import org.apache.gravitino.cli.commands.ListCatalogs;
+import org.apache.gravitino.cli.commands.ListColumns;
+import org.apache.gravitino.cli.commands.ListEntityTags;
+import org.apache.gravitino.cli.commands.ListFilesetProperties;
+import org.apache.gravitino.cli.commands.ListFilesets;
+import org.apache.gravitino.cli.commands.ListGroups;
+import org.apache.gravitino.cli.commands.ListIndexes;
+import org.apache.gravitino.cli.commands.ListMetalakeProperties;
+import org.apache.gravitino.cli.commands.ListMetalakes;
+import org.apache.gravitino.cli.commands.ListModel;
+import org.apache.gravitino.cli.commands.ListRoles;
+import org.apache.gravitino.cli.commands.ListSchema;
+import org.apache.gravitino.cli.commands.ListSchemaProperties;
+import org.apache.gravitino.cli.commands.ListTableProperties;
+import org.apache.gravitino.cli.commands.ListTables;
+import org.apache.gravitino.cli.commands.ListTagProperties;
+import org.apache.gravitino.cli.commands.ListTopicProperties;
+import org.apache.gravitino.cli.commands.ListTopics;
+import org.apache.gravitino.cli.commands.ListUsers;
+import org.apache.gravitino.cli.commands.MetalakeAudit;
+import org.apache.gravitino.cli.commands.MetalakeDetails;
+import org.apache.gravitino.cli.commands.MetalakeDisable;
+import org.apache.gravitino.cli.commands.MetalakeEnable;
+import org.apache.gravitino.cli.commands.ModelAudit;
+import org.apache.gravitino.cli.commands.ModelDetails;
+import org.apache.gravitino.cli.commands.OwnerDetails;
+import org.apache.gravitino.cli.commands.RemoveAllTags;
+import org.apache.gravitino.cli.commands.RemoveCatalogProperty;
+import org.apache.gravitino.cli.commands.RemoveFilesetProperty;
+import org.apache.gravitino.cli.commands.RemoveMetalakeProperty;
+import org.apache.gravitino.cli.commands.RemoveRoleFromGroup;
+import org.apache.gravitino.cli.commands.RemoveRoleFromUser;
+import org.apache.gravitino.cli.commands.RemoveSchemaProperty;
+import org.apache.gravitino.cli.commands.RemoveTableProperty;
+import org.apache.gravitino.cli.commands.RemoveTagProperty;
+import org.apache.gravitino.cli.commands.RemoveTopicProperty;
+import org.apache.gravitino.cli.commands.RevokePrivilegesFromRole;
+import org.apache.gravitino.cli.commands.RoleAudit;
+import org.apache.gravitino.cli.commands.RoleDetails;
+import org.apache.gravitino.cli.commands.SchemaAudit;
+import org.apache.gravitino.cli.commands.SchemaDetails;
+import org.apache.gravitino.cli.commands.ServerVersion;
+import org.apache.gravitino.cli.commands.SetCatalogProperty;
+import org.apache.gravitino.cli.commands.SetFilesetProperty;
+import org.apache.gravitino.cli.commands.SetMetalakeProperty;
+import org.apache.gravitino.cli.commands.SetOwner;
+import org.apache.gravitino.cli.commands.SetSchemaProperty;
+import org.apache.gravitino.cli.commands.SetTableProperty;
+import org.apache.gravitino.cli.commands.SetTagProperty;
+import org.apache.gravitino.cli.commands.SetTopicProperty;
+import org.apache.gravitino.cli.commands.TableAudit;
+import org.apache.gravitino.cli.commands.TableDetails;
+import org.apache.gravitino.cli.commands.TableDistribution;
+import org.apache.gravitino.cli.commands.TablePartition;
+import org.apache.gravitino.cli.commands.TableSortOrder;
+import org.apache.gravitino.cli.commands.TagDetails;
+import org.apache.gravitino.cli.commands.TagEntity;
+import org.apache.gravitino.cli.commands.TopicDetails;
+import org.apache.gravitino.cli.commands.UntagEntity;
+import org.apache.gravitino.cli.commands.UpdateCatalogComment;
+import org.apache.gravitino.cli.commands.UpdateCatalogName;
+import org.apache.gravitino.cli.commands.UpdateColumnAutoIncrement;
+import org.apache.gravitino.cli.commands.UpdateColumnComment;
+import org.apache.gravitino.cli.commands.UpdateColumnDatatype;
+import org.apache.gravitino.cli.commands.UpdateColumnDefault;
+import org.apache.gravitino.cli.commands.UpdateColumnName;
+import org.apache.gravitino.cli.commands.UpdateColumnNullability;
+import org.apache.gravitino.cli.commands.UpdateColumnPosition;
+import org.apache.gravitino.cli.commands.UpdateFilesetComment;
+import org.apache.gravitino.cli.commands.UpdateFilesetName;
+import org.apache.gravitino.cli.commands.UpdateMetalakeComment;
+import org.apache.gravitino.cli.commands.UpdateMetalakeName;
+import org.apache.gravitino.cli.commands.UpdateTableComment;
+import org.apache.gravitino.cli.commands.UpdateTableName;
+import org.apache.gravitino.cli.commands.UpdateTagComment;
+import org.apache.gravitino.cli.commands.UpdateTagName;
+import org.apache.gravitino.cli.commands.UpdateTopicComment;
+import org.apache.gravitino.cli.commands.UserAudit;
+import org.apache.gravitino.cli.commands.UserDetails;
 
 /*
  * Methods used for testing
@@ -814,12 +929,25 @@ public class TestableCommandLine {
   }
 
   protected CreateModel newCreateModel(
-      String url, boolean ignore, String metalake, String catalog, String schema, String model, String comment, Map<String, String> properties) {
+      String url,
+      boolean ignore,
+      String metalake,
+      String catalog,
+      String schema,
+      String model,
+      String comment,
+      Map<String, String> properties) {
     return new CreateModel(url, ignore, metalake, catalog, schema, model, comment, properties);
   }
 
   protected DeleteModel newDeleteModel(
-          String url, boolean ignore, boolean force, String metalake, String catalog, String schema, String model) {
+      String url,
+      boolean ignore,
+      boolean force,
+      String metalake,
+      String catalog,
+      String schema,
+      String model) {
     return new DeleteModel(url, ignore, force, metalake, catalog, schema, model);
   }
 }

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/CreateModel.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/CreateModel.java
@@ -27,6 +27,8 @@ import org.apache.gravitino.exceptions.NoSuchCatalogException;
 import org.apache.gravitino.exceptions.NoSuchMetalakeException;
 import org.apache.gravitino.exceptions.NoSuchSchemaException;
 
+import java.util.Map;
+
 /** Creates a new model. */
 public class CreateModel extends Command {
 
@@ -35,6 +37,7 @@ public class CreateModel extends Command {
   protected final String schema;
   protected final String model;
   protected final String comment;
+  protected final Map<String, String> properties;
 
   /**
    *
@@ -47,6 +50,7 @@ public class CreateModel extends Command {
    * @param schema The name of the schema.
    * @param model The name of the model.
    * @param comment The comment for the model.
+   * @param properties The model's properties.
    */
   public CreateModel(
       String url,
@@ -55,20 +59,22 @@ public class CreateModel extends Command {
       String catalog,
       String schema,
       String model,
-      String comment) {
+      String comment,
+      Map<String, String> properties) {
     super(url, ignoreVersions);
     this.metalake = metalake;
     this.catalog = catalog;
     this.schema = schema;
     this.model = model;
     this.comment = comment;
+    this.properties = properties;
   }
 
   /** Creates a new model. */
   public void handle() {
     try (GravitinoClient client = buildClient(metalake)) {
       NameIdentifier name = NameIdentifier.of(schema, model);
-      client.loadCatalog(catalog).asModelCatalog().registerModel(name, comment, null);
+      client.loadCatalog(catalog).asModelCatalog().registerModel(name, comment, properties);
     } catch (NoSuchMetalakeException noSuchMetalakeException) {
       exitWithError(ErrorMessages.UNKNOWN_METALAKE);
     } catch (NoSuchCatalogException noSuchCatalogException) {

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/CreateModel.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/CreateModel.java
@@ -19,6 +19,7 @@
 
 package org.apache.gravitino.cli.commands;
 
+import java.util.Map;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.cli.ErrorMessages;
 import org.apache.gravitino.client.GravitinoClient;
@@ -26,8 +27,6 @@ import org.apache.gravitino.exceptions.ModelAlreadyExistsException;
 import org.apache.gravitino.exceptions.NoSuchCatalogException;
 import org.apache.gravitino.exceptions.NoSuchMetalakeException;
 import org.apache.gravitino.exceptions.NoSuchSchemaException;
-
-import java.util.Map;
 
 /** Creates a new model. */
 public class CreateModel extends Command {
@@ -40,7 +39,6 @@ public class CreateModel extends Command {
   protected final Map<String, String> properties;
 
   /**
-   *
    * Creates a new model.
    *
    * @param url The URL of the Gravitino server.

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/CreateModel.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/CreateModel.java
@@ -1,0 +1,65 @@
+package org.apache.gravitino.cli.commands;
+
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.cli.ErrorMessages;
+import org.apache.gravitino.client.GravitinoClient;
+import org.apache.gravitino.exceptions.*;
+import org.apache.gravitino.model.ModelCatalog;
+
+/** Creates a new model. */
+public class CreateModel extends Command {
+
+  protected final String metalake;
+  protected final String catalog;
+  protected final String schema;
+  protected final String model;
+  protected final String comment;
+
+  /**
+   *
+   * Creates a new model.
+   *
+   * @param url The URL of the Gravitino server.
+   * @param ignoreVersions If true don't check the client/server versions match.
+   * @param metalake The name of the metalake.
+   * @param catalog The name of the catalog.
+   * @param schema The name of the schema.
+   * @param model The name of the model.
+   * @param comment The comment for the model.
+   */
+  public CreateModel(
+      String url,
+      boolean ignoreVersions,
+      String metalake,
+      String catalog,
+      String schema,
+      String model,
+      String comment) {
+    super(url, ignoreVersions);
+    this.metalake = metalake;
+    this.catalog = catalog;
+    this.schema = schema;
+    this.model = model;
+    this.comment = comment;
+  }
+
+  /** Creates a new model */
+  public void handle() {
+    try (GravitinoClient client = buildClient(metalake)) {
+      NameIdentifier name = NameIdentifier.of(schema, model);
+      client.loadCatalog(catalog).asModelCatalog().registerModel(name, comment, null);
+    } catch (NoSuchMetalakeException noSuchMetalakeException) {
+      exitWithError(ErrorMessages.UNKNOWN_METALAKE);
+    } catch (NoSuchCatalogException noSuchCatalogException) {
+      exitWithError(ErrorMessages.UNKNOWN_CATALOG);
+    } catch (NoSuchSchemaException noSuchSchemaException) {
+      exitWithError(ErrorMessages.UNKNOWN_SCHEMA);
+    } catch (ModelAlreadyExistsException modelAlreadyExistsException) {
+      exitWithError(ErrorMessages.MODEL_EXISTS);
+    } catch (Exception err) {
+      exitWithError(err.getMessage());
+    }
+
+    System.out.println(model + " created");
+  }
+}

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/DeleteModel.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/DeleteModel.java
@@ -65,7 +65,7 @@ public class DeleteModel extends Command {
     this.model = model;
   }
 
-  /** Deletes and existing model. */
+  /** Deletes an existing model. */
   public void handle() {
     boolean deleted = false;
 

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/DeleteModel.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/DeleteModel.java
@@ -25,8 +25,8 @@ import org.apache.gravitino.cli.ErrorMessages;
 import org.apache.gravitino.client.GravitinoClient;
 import org.apache.gravitino.exceptions.NoSuchCatalogException;
 import org.apache.gravitino.exceptions.NoSuchMetalakeException;
-import org.apache.gravitino.exceptions.NoSuchSchemaException;
 import org.apache.gravitino.exceptions.NoSuchModelException;
+import org.apache.gravitino.exceptions.NoSuchSchemaException;
 
 /** Deletes an existing model. */
 public class DeleteModel extends Command {
@@ -38,7 +38,6 @@ public class DeleteModel extends Command {
   protected final boolean force;
 
   /**
-   *
    * Deletes an existing model.
    *
    * @param url The URL of the Gravitino server.
@@ -50,13 +49,13 @@ public class DeleteModel extends Command {
    * @param model The name of the model.
    */
   public DeleteModel(
-          String url,
-          boolean ignoreVersions,
-          boolean force,
-          String metalake,
-          String catalog,
-          String schema,
-          String model) {
+      String url,
+      boolean ignoreVersions,
+      boolean force,
+      String metalake,
+      String catalog,
+      String schema,
+      String model) {
     super(url, ignoreVersions);
     this.force = force;
     this.metalake = metalake;

--- a/clients/cli/src/main/resources/model_help.txt
+++ b/clients/cli/src/main/resources/model_help.txt
@@ -1,20 +1,20 @@
-gcli model [list|details|create|delete]
+gcli model [list|details|create|update|delete]
 
 Please set the metalake in the Gravitino configuration file or the environment variable before running any of these commands.
 
 Example commands
 
 Register a model
-gcli model create -m demo_metalake --name Hive_catalog.default.model
+gcli model create --name hadoop.schema.model
 
 Register a model with comment
-gcli model create -m demo_metalake --name Hive_catalog.default.model --comment comment
+gcli model create --name hadoop.schema.model --comment comment
 
 Register a model with properties
-gcli model create -m demo_metalake --name Hive_catalog.default.model --properties key1=val1 key2=val2
+gcli model create --name hadoop.schema.model --properties key1=val1 key2=val2
 
-Register a model with properties and comment
-gcli model create -m demo_metalake --name Hive_catalog.default.model --properties key1=val1 klinkey2=val2 --comment comment
+Register a model with properties" and comment
+gcli model create --name hadoop.schema.model --properties key1=val1 key2=val2 --comment comment
 
 List models
 gcli model list --name hadoop.schema
@@ -26,16 +26,16 @@ Show model audit information
 gcli model details --name hadoop.schema.model --audit
 
 Link a model
-gcli model update -m demo_metalake --name Hive_catalog.default.model --uri file:///tmp/file
+gcli model update --name hadoop.schema.model --uri file:///tmp/file
 
 Link a model with alias
-gcli model update -m demo_metalake --name Hive_catalog.default.model --uri file:///tmp/file  --alias aliasA aliasB
+gcli model update --name hadoop.schema.model --uri file:///tmp/file  --alias aliasA aliasB
 
 Link a model with all component
-gcli model update -m demo_metalake --name Hive_catalog.default.model --uri file:///tmp/file  --alias aliasA aliasB --comment comment --properties key1=val1 key2=val2
+gcli model update --name hadoop.schema.model --uri file:///tmp/file  --alias aliasA aliasB --comment comment --properties key1=val1 key2=val2
 
 Link a model without uri
-gcli model update -m demo_metalake --name Hive_catalog.default.model
+gcli model update --name hadoop.schema.model
 
 Delete a model
 gcli model delete --name hadoop.schema.model

--- a/clients/cli/src/main/resources/model_help.txt
+++ b/clients/cli/src/main/resources/model_help.txt
@@ -1,8 +1,20 @@
-gcli model [details]
+gcli model [list|details|create|delete]
 
 Please set the metalake in the Gravitino configuration file or the environment variable before running any of these commands.
 
 Example commands
 
+Create a model
+gcli model create --name hadoop.schema.model --comment new_comment --properties managed=true,location=file:/tmp/root/schema/example
+
+List models
+gcli model list --name hadoop.schema
+
+Show a model's details
+gcli model details --name hadoop.schema.model
+
 Show model audit information
-gcli model details --name catalog_postgres.hr --audit
+gcli model details --name hadoop.schema.model --audit
+
+Delete a model
+gcli model delete --name hadoop.schema.model

--- a/clients/cli/src/test/java/org/apache/gravitino/cli/TestModelCommands.java
+++ b/clients/cli/src/test/java/org/apache/gravitino/cli/TestModelCommands.java
@@ -21,8 +21,7 @@ package org.apache.gravitino.cli;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -37,9 +36,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Options;
-import org.apache.gravitino.cli.commands.ListModel;
-import org.apache.gravitino.cli.commands.ModelAudit;
-import org.apache.gravitino.cli.commands.ModelDetails;
+import org.apache.gravitino.cli.commands.*;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -288,5 +285,60 @@ public class TestModelCommands {
             GravitinoCommandLine.DEFAULT_URL, false, "metalake_demo", "catalog", "schema", "model");
     commandLine.handleCommandLine();
     verify(mockAudit).handle();
+  }
+
+  @Test
+  void testCreateModelCommand() {
+    CreateModel mockCreate = mock(CreateModel.class);
+    when(mockCommandLine.hasOption(GravitinoOptions.METALAKE)).thenReturn(true);
+    when(mockCommandLine.getOptionValue(GravitinoOptions.METALAKE)).thenReturn("metalake_demo");
+    when(mockCommandLine.hasOption(GravitinoOptions.NAME)).thenReturn(true);
+    when(mockCommandLine.getOptionValue(GravitinoOptions.NAME)).thenReturn("catalog.schema.model");
+    when(mockCommandLine.hasOption(GravitinoOptions.COMMENT)).thenReturn(true);
+    when(mockCommandLine.getOptionValue(GravitinoOptions.COMMENT)).thenReturn("comment");
+
+    GravitinoCommandLine commandLine =
+        spy(
+            new GravitinoCommandLine(
+                    mockCommandLine, mockOptions, CommandEntities.MODEL, CommandActions.CREATE));
+    doReturn(mockCreate)
+        .when(commandLine)
+            .newCreateModel(
+                eq(GravitinoCommandLine.DEFAULT_URL),
+                eq(false),
+                eq("metalake_demo"),
+                eq("catalog"),
+                eq("schema"),
+                eq("model"),
+                eq("comment"),
+                any());
+    commandLine.handleCommandLine();
+    verify(mockCreate).handle();
+  }
+
+  @Test
+  void testDeleteModelCommand() {
+    DeleteModel mockDelete = mock(DeleteModel.class);
+    when(mockCommandLine.hasOption(GravitinoOptions.METALAKE)).thenReturn(true);
+    when(mockCommandLine.getOptionValue(GravitinoOptions.METALAKE)).thenReturn("metalake_demo");
+    when(mockCommandLine.hasOption(GravitinoOptions.NAME)).thenReturn(true);
+    when(mockCommandLine.getOptionValue(GravitinoOptions.NAME)).thenReturn("catalog.schema.model");
+
+    GravitinoCommandLine commandLine =
+            spy(
+                    new GravitinoCommandLine(
+                            mockCommandLine, mockOptions, CommandEntities.MODEL, CommandActions.DELETE));
+    doReturn(mockDelete)
+            .when(commandLine)
+            .newDeleteModel(
+                    GravitinoCommandLine.DEFAULT_URL,
+                    false,
+                    false,
+                    "metalake_demo",
+                    "catalog",
+                    "schema",
+                    "model");
+    commandLine.handleCommandLine();
+    verify(mockDelete).handle();
   }
 }

--- a/clients/cli/src/test/java/org/apache/gravitino/cli/TestModelCommands.java
+++ b/clients/cli/src/test/java/org/apache/gravitino/cli/TestModelCommands.java
@@ -21,7 +21,9 @@ package org.apache.gravitino.cli;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -36,7 +38,11 @@ import java.util.Arrays;
 import java.util.Collections;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Options;
-import org.apache.gravitino.cli.commands.*;
+import org.apache.gravitino.cli.commands.CreateModel;
+import org.apache.gravitino.cli.commands.DeleteModel;
+import org.apache.gravitino.cli.commands.ListModel;
+import org.apache.gravitino.cli.commands.ModelAudit;
+import org.apache.gravitino.cli.commands.ModelDetails;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -300,18 +306,18 @@ public class TestModelCommands {
     GravitinoCommandLine commandLine =
         spy(
             new GravitinoCommandLine(
-                    mockCommandLine, mockOptions, CommandEntities.MODEL, CommandActions.CREATE));
+                mockCommandLine, mockOptions, CommandEntities.MODEL, CommandActions.CREATE));
     doReturn(mockCreate)
         .when(commandLine)
-            .newCreateModel(
-                eq(GravitinoCommandLine.DEFAULT_URL),
-                eq(false),
-                eq("metalake_demo"),
-                eq("catalog"),
-                eq("schema"),
-                eq("model"),
-                eq("comment"),
-                any());
+        .newCreateModel(
+            eq(GravitinoCommandLine.DEFAULT_URL),
+            eq(false),
+            eq("metalake_demo"),
+            eq("catalog"),
+            eq("schema"),
+            eq("model"),
+            eq("comment"),
+            any());
     commandLine.handleCommandLine();
     verify(mockCreate).handle();
   }
@@ -325,19 +331,19 @@ public class TestModelCommands {
     when(mockCommandLine.getOptionValue(GravitinoOptions.NAME)).thenReturn("catalog.schema.model");
 
     GravitinoCommandLine commandLine =
-            spy(
-                    new GravitinoCommandLine(
-                            mockCommandLine, mockOptions, CommandEntities.MODEL, CommandActions.DELETE));
+        spy(
+            new GravitinoCommandLine(
+                mockCommandLine, mockOptions, CommandEntities.MODEL, CommandActions.DELETE));
     doReturn(mockDelete)
-            .when(commandLine)
-            .newDeleteModel(
-                    GravitinoCommandLine.DEFAULT_URL,
-                    false,
-                    false,
-                    "metalake_demo",
-                    "catalog",
-                    "schema",
-                    "model");
+        .when(commandLine)
+        .newDeleteModel(
+            GravitinoCommandLine.DEFAULT_URL,
+            false,
+            false,
+            "metalake_demo",
+            "catalog",
+            "schema",
+            "model");
     commandLine.handleCommandLine();
     verify(mockDelete).handle();
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

The delete command is one of the commands suggested by @justinmclean as part of adding Model entity support for the CLI.

### Why are the changes needed?

To add delete functionality for a Model using the CLI

Improvement: https://github.com/apache/gravitino/issues/5963 (NOTE: Create command is redundant with addition of Register command)

### Does this PR introduce any user-facing change?

Yes.

The delete command for a model was added.

### How was this patch tested?

Unit tests were added for Model CLI support and ran successfully for the delete command, along with CI tests in forked repository