### PR TITLE
[#5956] feat(auth): Uses chain authorization to support Hive and HDFS

### DIFF
--- a/.github/workflows/backend-integration-test-action.yml
+++ b/.github/workflows/backend-integration-test-action.yml
@@ -60,7 +60,8 @@ jobs:
           -x :web:web:test -x :web:integration-test:test -x :clients:client-python:test -x :flink-connector:flink:test -x :spark-connector:spark-common:test 
           -x :spark-connector:spark-3.3:test -x :spark-connector:spark-3.4:test -x :spark-connector:spark-3.5:test 
           -x :spark-connector:spark-runtime-3.3:test -x :spark-connector:spark-runtime-3.4:test -x :spark-connector:spark-runtime-3.5:test
-          -x :authorizations:authorization-ranger:test -x :trino-connector:integration-test:test -x :trino-connector:trino-connector:test
+          -x :trino-connector:integration-test:test -x :trino-connector:trino-connector:test
+          -x :authorizations:authorization-chain:test -x :authorizations:authorization-ranger:test 
 
       - name: Upload integrate tests reports
         uses: actions/upload-artifact@v3

--- a/api/src/main/java/org/apache/gravitino/authorization/MetadataObjectChange.java
+++ b/api/src/main/java/org/apache/gravitino/authorization/MetadataObjectChange.java
@@ -19,6 +19,7 @@
 package org.apache.gravitino.authorization;
 
 import com.google.common.base.Preconditions;
+import java.util.List;
 import java.util.Objects;
 import org.apache.gravitino.MetadataObject;
 import org.apache.gravitino.annotation.Evolving;
@@ -44,10 +45,11 @@ public interface MetadataObjectChange {
    * Remove a metadata entity MetadataObjectChange.
    *
    * @param metadataObject The metadata object.
+   * @param locations The locations of the metadata object.
    * @return return a MetadataObjectChange for the remove metadata object.
    */
-  static MetadataObjectChange remove(MetadataObject metadataObject) {
-    return new RemoveMetadataObject(metadataObject);
+  static MetadataObjectChange remove(MetadataObject metadataObject, List<String> locations) {
+    return new RemoveMetadataObject(metadataObject, locations);
   }
 
   /** A RenameMetadataObject is to rename securable object's metadata entity. */
@@ -127,9 +129,11 @@ public interface MetadataObjectChange {
   /** A RemoveMetadataObject is to remove securable object's metadata entity. */
   final class RemoveMetadataObject implements MetadataObjectChange {
     private final MetadataObject metadataObject;
+    private final List<String> locations;
 
-    private RemoveMetadataObject(MetadataObject metadataObject) {
+    private RemoveMetadataObject(MetadataObject metadataObject, List<String> locations) {
       this.metadataObject = metadataObject;
+      this.locations = locations;
     }
 
     /**
@@ -139,6 +143,15 @@ public interface MetadataObjectChange {
      */
     public MetadataObject metadataObject() {
       return metadataObject;
+    }
+
+    /**
+     * Returns the location path of the metadata object.
+     *
+     * @return return a location path.
+     */
+    public List<String> getLocations() {
+      return locations;
     }
 
     /**

--- a/authorizations/authorization-common/src/main/java/org/apache/gravitino/authorization/common/PathBasedMetadataObject.java
+++ b/authorizations/authorization-common/src/main/java/org/apache/gravitino/authorization/common/PathBasedMetadataObject.java
@@ -96,4 +96,37 @@ public class PathBasedMetadataObject implements AuthorizationMetadataObject {
           name != null, "Cannot create a path based metadata object with null name");
     }
   }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+
+    if (!(o instanceof PathBasedMetadataObject)) {
+      return false;
+    }
+
+    PathBasedMetadataObject that = (PathBasedMetadataObject) o;
+    return java.util.Objects.equals(name, that.name)
+        && java.util.Objects.equals(parent, that.parent)
+        && java.util.Objects.equals(path, that.path)
+        && type == that.type;
+  }
+
+  @Override
+  public int hashCode() {
+    return java.util.Objects.hash(name, parent, path, type);
+  }
+
+  @Override
+  public String toString() {
+    return "MetadataObject: [fullName="
+        + fullName()
+        + "],  [path="
+        + path
+        + "], [type="
+        + type
+        + "]";
+  }
 }

--- a/authorizations/authorization-common/src/main/java/org/apache/gravitino/authorization/common/PathBasedMetadataObject.java
+++ b/authorizations/authorization-common/src/main/java/org/apache/gravitino/authorization/common/PathBasedMetadataObject.java
@@ -19,9 +19,7 @@
 package org.apache.gravitino.authorization.common;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableList;
 import java.util.List;
-import javax.annotation.Nullable;
 import org.apache.gravitino.MetadataObject;
 import org.apache.gravitino.authorization.AuthorizationMetadataObject;
 
@@ -44,29 +42,37 @@ public class PathBasedMetadataObject implements AuthorizationMetadataObject {
     }
   }
 
+  private final String name;
+  private final String parent;
   private final String path;
 
   private final AuthorizationMetadataObject.Type type;
 
-  public PathBasedMetadataObject(String path, AuthorizationMetadataObject.Type type) {
+  public PathBasedMetadataObject(
+      String parent, String name, String path, AuthorizationMetadataObject.Type type) {
+    this.parent = parent;
+    this.name = name;
     this.path = path;
     this.type = type;
   }
 
-  @Nullable
-  @Override
-  public String parent() {
-    return null;
-  }
-
   @Override
   public String name() {
-    return this.path;
+    return name;
   }
 
   @Override
   public List<String> names() {
-    return ImmutableList.of(this.path);
+    return DOT_SPLITTER.splitToList(fullName());
+  }
+
+  @Override
+  public String parent() {
+    return parent;
+  }
+
+  public String path() {
+    return path;
   }
 
   @Override
@@ -81,11 +87,7 @@ public class PathBasedMetadataObject implements AuthorizationMetadataObject {
         names != null && !names.isEmpty(),
         "Cannot create a path based metadata object with no names");
     Preconditions.checkArgument(
-        names.size() == 1,
-        "Cannot create a path based metadata object with the name length which is 1");
-    Preconditions.checkArgument(
-        type != null, "Cannot create a path based metadata object with no type");
-
+        path != null && !path.isEmpty(), "Cannot create a path based metadata object with no path");
     Preconditions.checkArgument(
         type == PathBasedMetadataObject.Type.PATH, "it must be the PATH type");
 

--- a/authorizations/authorization-common/src/main/java/org/apache/gravitino/authorization/common/PathBasedMetadataObject.java
+++ b/authorizations/authorization-common/src/main/java/org/apache/gravitino/authorization/common/PathBasedMetadataObject.java
@@ -20,6 +20,7 @@ package org.apache.gravitino.authorization.common;
 
 import com.google.common.base.Preconditions;
 import java.util.List;
+import java.util.Objects;
 import org.apache.gravitino.MetadataObject;
 import org.apache.gravitino.authorization.AuthorizationMetadataObject;
 
@@ -108,25 +109,21 @@ public class PathBasedMetadataObject implements AuthorizationMetadataObject {
     }
 
     PathBasedMetadataObject that = (PathBasedMetadataObject) o;
-    return java.util.Objects.equals(name, that.name)
-        && java.util.Objects.equals(parent, that.parent)
-        && java.util.Objects.equals(path, that.path)
+    return Objects.equals(name, that.name)
+        && Objects.equals(parent, that.parent)
+        && Objects.equals(path, that.path)
         && type == that.type;
   }
 
   @Override
   public int hashCode() {
-    return java.util.Objects.hash(name, parent, path, type);
+    return Objects.hash(name, parent, path, type);
   }
 
   @Override
   public String toString() {
-    return "MetadataObject: [fullName="
-        + fullName()
-        + "],  [path="
-        + path
-        + "], [type="
-        + type
-        + "]";
+    return "MetadataObject: [fullName=" + fullName() + "],  [path=" + path == null
+        ? "null"
+        : path + "], [type=" + type + "]";
   }
 }

--- a/authorizations/authorization-common/src/main/java/org/apache/gravitino/authorization/common/PathBasedSecurableObject.java
+++ b/authorizations/authorization-common/src/main/java/org/apache/gravitino/authorization/common/PathBasedSecurableObject.java
@@ -31,8 +31,12 @@ public class PathBasedSecurableObject extends PathBasedMetadataObject
   private final List<AuthorizationPrivilege> privileges;
 
   public PathBasedSecurableObject(
-      String path, AuthorizationMetadataObject.Type type, Set<AuthorizationPrivilege> privileges) {
-    super(path, type);
+      String parent,
+      String name,
+      String path,
+      AuthorizationMetadataObject.Type type,
+      Set<AuthorizationPrivilege> privileges) {
+    super(parent, name, path, type);
     this.privileges = ImmutableList.copyOf(privileges);
   }
 

--- a/authorizations/authorization-common/src/main/java/org/apache/gravitino/authorization/jdbc/JdbcSecurableObjectMappingProvider.java
+++ b/authorizations/authorization-common/src/main/java/org/apache/gravitino/authorization/jdbc/JdbcSecurableObjectMappingProvider.java
@@ -193,7 +193,7 @@ public class JdbcSecurableObjectMappingProvider implements AuthorizationPrivileg
   }
 
   @Override
-  public AuthorizationMetadataObject translateMetadataObject(MetadataObject metadataObject) {
+  public List<AuthorizationMetadataObject> translateMetadataObject(MetadataObject metadataObject) {
     throw new UnsupportedOperationException("Not supported");
   }
 

--- a/authorizations/authorization-common/src/test/java/org/apache/gravitino/authorization/common/TestPathBasedMetadataObject.java
+++ b/authorizations/authorization-common/src/test/java/org/apache/gravitino/authorization/common/TestPathBasedMetadataObject.java
@@ -1,0 +1,32 @@
+package org.apache.gravitino.authorization.common;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TestPathBasedMetadataObject {
+  @Test
+  public void PathBasedMetadataObjectEquals() {
+    PathBasedMetadataObject pathBasedMetadataObject1 =
+        new PathBasedMetadataObject("parent", "name", "path", PathBasedMetadataObject.Type.PATH);
+    pathBasedMetadataObject1.validateAuthorizationMetadataObject();
+
+    PathBasedMetadataObject pathBasedMetadataObject2 =
+        new PathBasedMetadataObject("parent", "name", "path", PathBasedMetadataObject.Type.PATH);
+    pathBasedMetadataObject2.validateAuthorizationMetadataObject();
+
+    Assertions.assertEquals(pathBasedMetadataObject1, pathBasedMetadataObject2);
+  }
+
+  @Test
+  public void PathBasedMetadataObjectNotEquals() {
+    PathBasedMetadataObject pathBasedMetadataObject1 =
+        new PathBasedMetadataObject("parent", "name", "path", PathBasedMetadataObject.Type.PATH);
+    pathBasedMetadataObject1.validateAuthorizationMetadataObject();
+
+    PathBasedMetadataObject pathBasedMetadataObject2 =
+        new PathBasedMetadataObject("parent", "name", "path1", PathBasedMetadataObject.Type.PATH);
+    pathBasedMetadataObject2.validateAuthorizationMetadataObject();
+
+    Assertions.assertNotEquals(pathBasedMetadataObject1, pathBasedMetadataObject2);
+  }
+}

--- a/authorizations/authorization-common/src/test/java/org/apache/gravitino/authorization/common/TestPathBasedMetadataObject.java
+++ b/authorizations/authorization-common/src/test/java/org/apache/gravitino/authorization/common/TestPathBasedMetadataObject.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.gravitino.authorization.common;
 
 import org.junit.jupiter.api.Assertions;

--- a/authorizations/authorization-ranger/build.gradle.kts
+++ b/authorizations/authorization-ranger/build.gradle.kts
@@ -82,6 +82,7 @@ dependencies {
   testImplementation(project(":integration-test-common", "testArtifacts"))
   testImplementation(libs.junit.jupiter.api)
   testImplementation(libs.mockito.core)
+  testImplementation(libs.mockito.inline)
   testImplementation(libs.testcontainers)
   testImplementation(libs.mysql.driver)
   testImplementation(libs.postgresql.driver)

--- a/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/RangerAuthorizationHDFSPlugin.java
+++ b/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/RangerAuthorizationHDFSPlugin.java
@@ -253,6 +253,7 @@ public class RangerAuthorizationHDFSPlugin extends RangerAuthorizationPlugin {
    * If remove the TABLE, need to remove these the relevant policies, `{schema}.*`, `{schema}.*.*`
    * <br>
    * If remove the COLUMN, Only need to remove `{schema}.*.*` <br>
+   * If remove the PATH, Only need to remove `{path}` <br>
    */
   @Override
   protected void doRemoveMetadataObject(AuthorizationMetadataObject authzMetadataObject) {

--- a/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/RangerAuthorizationHDFSPlugin.java
+++ b/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/RangerAuthorizationHDFSPlugin.java
@@ -257,9 +257,9 @@ public class RangerAuthorizationHDFSPlugin extends RangerAuthorizationPlugin {
   @Override
   protected void removeMetadataObject(AuthorizationMetadataObject authzMetadataObject) {
     if (authzMetadataObject.type().equals(SCHEMA)) {
-      doRemoveSchemaMetadataObject(authzMetadataObject);
+      removeSchemaMetadataObject(authzMetadataObject);
     } else if (authzMetadataObject.type().equals(TABLE)) {
-      doRemoveTableMetadataObject(authzMetadataObject);
+      removeTableMetadataObject(authzMetadataObject);
     } else if (authzMetadataObject.type().equals(COLUMN)
         || authzMetadataObject.type().equals(PATH)) {
       removePolicyByMetadataObject(authzMetadataObject);
@@ -273,7 +273,7 @@ public class RangerAuthorizationHDFSPlugin extends RangerAuthorizationPlugin {
    * Remove the SCHEMA, Need to remove these the relevant policies, `{schema}`, `{schema}.*`,
    * `{schema}.*.*` permissions.
    */
-  private void doRemoveSchemaMetadataObject(AuthorizationMetadataObject authzMetadataObject) {
+  private void removeSchemaMetadataObject(AuthorizationMetadataObject authzMetadataObject) {
     Preconditions.checkArgument(
         authzMetadataObject instanceof PathBasedMetadataObject,
         "The metadata object must be a PathBasedMetadataObject");
@@ -307,7 +307,7 @@ public class RangerAuthorizationHDFSPlugin extends RangerAuthorizationPlugin {
                                   AuthorizationMetadataObject.getLastName(names),
                                   locationPath,
                                   PATH);
-                          doRemoveSchemaMetadataObject(schemaMetadataObject);
+                          removeSchemaMetadataObject(schemaMetadataObject);
                         });
               });
     } else {
@@ -330,24 +330,24 @@ public class RangerAuthorizationHDFSPlugin extends RangerAuthorizationPlugin {
                           AuthorizationMetadataObject tableMetadataObject =
                               new PathBasedMetadataObject(
                                   authzMetadataObject.name(), table.name(), locationPath, PATH);
-                          doRemoveTableMetadataObject(tableMetadataObject);
+                          removeTableMetadataObject(tableMetadataObject);
                         });
-                // Remove schema
-                Schema schema =
-                    GravitinoEnv.getInstance()
-                        .schemaDispatcher()
-                        .loadSchema(NameIdentifier.of(authzMetadataObject.name()));
-                List<String> schemaLocations =
-                    AuthorizationUtils.getMetadataObjectLocation(
-                        identifier, Entity.EntityType.SCHEMA);
-                schemaLocations.stream()
-                    .forEach(
-                        locationPath -> {
-                          AuthorizationMetadataObject schemaMetadataObject =
-                              new PathBasedMetadataObject(
-                                  authzMetadataObject.name(), schema.name(), locationPath, PATH);
-                          removePolicyByMetadataObject(schemaMetadataObject);
-                        });
+              });
+      // Remove schema
+      Schema schema =
+          GravitinoEnv.getInstance()
+              .schemaDispatcher()
+              .loadSchema(NameIdentifier.of(authzMetadataObject.name()));
+      List<String> schemaLocations =
+          AuthorizationUtils.getMetadataObjectLocation(
+              NameIdentifier.parse(authzMetadataObject.fullName()), Entity.EntityType.SCHEMA);
+      schemaLocations.stream()
+          .forEach(
+              locationPath -> {
+                AuthorizationMetadataObject schemaMetadataObject =
+                    new PathBasedMetadataObject(
+                        authzMetadataObject.name(), schema.name(), locationPath, PATH);
+                removePolicyByMetadataObject(schemaMetadataObject);
               });
     }
   }
@@ -356,7 +356,7 @@ public class RangerAuthorizationHDFSPlugin extends RangerAuthorizationPlugin {
    * Remove the TABLE, Need to remove these the relevant policies, `*.{table}`, `*.{table}.{column}`
    * permissions.
    */
-  private void doRemoveTableMetadataObject(AuthorizationMetadataObject authzMetadataObject) {
+  private void removeTableMetadataObject(AuthorizationMetadataObject authzMetadataObject) {
     Preconditions.checkArgument(
         authzMetadataObject instanceof PathBasedMetadataObject,
         "The metadata object must be a PathBasedMetadataObject");

--- a/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/RangerAuthorizationHadoopSQLPlugin.java
+++ b/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/RangerAuthorizationHadoopSQLPlugin.java
@@ -324,7 +324,7 @@ public class RangerAuthorizationHadoopSQLPlugin extends RangerAuthorizationPlugi
       doRemoveSchemaMetadataObject(authzMetadataObject);
     } else if (type.equals(TABLE)) {
       doRemoveTableMetadataObject(authzMetadataObject);
-    } else if (type.equals(COLUMN) || type.equals(PATH)) {
+    } else if (type.equals(COLUMN)) {
       removePolicyByMetadataObject(authzMetadataObject);
     } else {
       throw new IllegalArgumentException(

--- a/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/RangerAuthorizationHadoopSQLPlugin.java
+++ b/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/RangerAuthorizationHadoopSQLPlugin.java
@@ -130,7 +130,7 @@ public class RangerAuthorizationHadoopSQLPlugin extends RangerAuthorizationPlugi
    * If rename the COLUMN, Only need to rename `{schema}.*.*` <br>
    */
   @Override
-  protected void doRenameMetadataObject(
+  protected void renameMetadataObject(
       AuthorizationMetadataObject authzMetadataObject,
       AuthorizationMetadataObject newAuthzMetadataObject) {
     List<Pair<String, String>> mappingOldAndNewMetadata;
@@ -272,7 +272,7 @@ public class RangerAuthorizationHadoopSQLPlugin extends RangerAuthorizationPlugi
    * If remove the COLUMN, Only need to remove `{schema}.*.*` <br>
    */
   @Override
-  protected void doRemoveMetadataObject(AuthorizationMetadataObject authzMetadataObject) {
+  protected void removeMetadataObject(AuthorizationMetadataObject authzMetadataObject) {
     AuthorizationMetadataObject.Type type = authzMetadataObject.type();
     if (type.equals(SCHEMA)) {
       doRemoveSchemaMetadataObject(authzMetadataObject);
@@ -784,14 +784,14 @@ public class RangerAuthorizationHadoopSQLPlugin extends RangerAuthorizationPlugi
                 newAuthzMetadataObject.fullName());
             continue;
           }
-          doRenameMetadataObject(oldAuthMetadataObject, newAuthzMetadataObject);
+          renameMetadataObject(oldAuthMetadataObject, newAuthzMetadataObject);
         }
       } else if (change instanceof MetadataObjectChange.RemoveMetadataObject) {
         MetadataObject metadataObject =
             ((MetadataObjectChange.RemoveMetadataObject) change).metadataObject();
         List<AuthorizationMetadataObject> authzMetadataObjects =
             translateMetadataObject(metadataObject);
-        authzMetadataObjects.stream().forEach(this::doRemoveMetadataObject);
+        authzMetadataObjects.stream().forEach(this::removeMetadataObject);
       } else {
         throw new IllegalArgumentException(
             "Unsupported metadata object change type: "

--- a/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/RangerAuthorizationHadoopSQLPlugin.java
+++ b/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/RangerAuthorizationHadoopSQLPlugin.java
@@ -18,12 +18,18 @@
  */
 package org.apache.gravitino.authorization.ranger;
 
+import static org.apache.gravitino.authorization.common.PathBasedMetadataObject.Type.PATH;
+import static org.apache.gravitino.authorization.ranger.RangerHadoopSQLMetadataObject.Type.COLUMN;
+import static org.apache.gravitino.authorization.ranger.RangerHadoopSQLMetadataObject.Type.SCHEMA;
+import static org.apache.gravitino.authorization.ranger.RangerHadoopSQLMetadataObject.Type.TABLE;
+
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -35,13 +41,16 @@ import org.apache.gravitino.MetadataObject;
 import org.apache.gravitino.authorization.AuthorizationMetadataObject;
 import org.apache.gravitino.authorization.AuthorizationPrivilege;
 import org.apache.gravitino.authorization.AuthorizationSecurableObject;
+import org.apache.gravitino.authorization.MetadataObjectChange;
 import org.apache.gravitino.authorization.Privilege;
 import org.apache.gravitino.authorization.SecurableObject;
 import org.apache.gravitino.authorization.SecurableObjects;
 import org.apache.gravitino.authorization.ranger.RangerPrivileges.RangerHadoopSQLPrivilege;
 import org.apache.gravitino.authorization.ranger.reference.RangerDefines.PolicyResource;
 import org.apache.gravitino.exceptions.AuthorizationPluginException;
+import org.apache.ranger.RangerServiceException;
 import org.apache.ranger.plugin.model.RangerPolicy;
+import org.apache.ranger.plugin.util.SearchFilter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -76,6 +85,328 @@ public class RangerAuthorizationHadoopSQLPlugin extends RangerAuthorizationPlugi
         ImmutableSet.of(RangerHadoopSQLPrivilege.READ, RangerHadoopSQLPrivilege.SELECT));
   }
 
+  /**
+   * Find the managed policy for the ranger securable object.
+   *
+   * @param authzMetadataObject The ranger securable object to find the managed policy.
+   * @return The managed policy for the metadata object.
+   */
+  public RangerPolicy findManagedPolicy(AuthorizationMetadataObject authzMetadataObject)
+      throws AuthorizationPluginException {
+    List<RangerPolicy> policies = wildcardSearchPolies(authzMetadataObject);
+    if (!policies.isEmpty()) {
+      /**
+       * Because Ranger doesn't support the precise search, Ranger will return the policy meets the
+       * wildcard(*,?) conditions, If you use `db.table` condition to search policy, the Ranger will
+       * match `db1.table1`, `db1.table2`, `db*.table*`, So we need to manually precisely filter
+       * this research results.
+       */
+      List<String> nsMetadataObj = authzMetadataObject.names();
+      Map<String, String> preciseFilters = new HashMap<>();
+      for (int i = 0; i < nsMetadataObj.size() && i < policyResourceDefinesRule().size(); i++) {
+        preciseFilters.put(policyResourceDefinesRule().get(i), nsMetadataObj.get(i));
+      }
+      policies =
+          policies.stream()
+              .filter(
+                  policy ->
+                      policy.getResources().entrySet().stream()
+                          .allMatch(
+                              entry ->
+                                  preciseFilters.containsKey(entry.getKey())
+                                      && entry.getValue().getValues().size() == 1
+                                      && entry
+                                          .getValue()
+                                          .getValues()
+                                          .contains(preciseFilters.get(entry.getKey()))))
+              .collect(Collectors.toList());
+    }
+    // Only return the policies that are managed by Gravitino.
+    if (policies.size() > 1) {
+      throw new AuthorizationPluginException("Each metadata object can have at most one policy.");
+    }
+
+    if (policies.isEmpty()) {
+      return null;
+    }
+
+    RangerPolicy policy = policies.get(0);
+    // Delegating Gravitino management policies cannot contain duplicate privilege
+    policy.getPolicyItems().forEach(RangerHelper::checkPolicyItemAccess);
+    policy.getDenyPolicyItems().forEach(RangerHelper::checkPolicyItemAccess);
+    policy.getRowFilterPolicyItems().forEach(RangerHelper::checkPolicyItemAccess);
+    policy.getDataMaskPolicyItems().forEach(RangerHelper::checkPolicyItemAccess);
+
+    return policy;
+  }
+
+  /** Wildcard search the Ranger policies in the different Ranger service. */
+  @Override
+  protected List<RangerPolicy> wildcardSearchPolies(
+      AuthorizationMetadataObject authzMetadataObject) {
+    List<String> resourceDefines = policyResourceDefinesRule();
+    Map<String, String> searchFilters = new HashMap<>();
+    searchFilters.put(SearchFilter.SERVICE_NAME, rangerServiceName);
+    for (int i = 0; i < authzMetadataObject.names().size() && i < resourceDefines.size(); i++) {
+      searchFilters.put(
+          SearchFilter.RESOURCE_PREFIX + resourceDefines.get(i),
+          authzMetadataObject.names().get(i));
+    }
+
+    try {
+      List<RangerPolicy> policies = rangerClient.findPolicies(searchFilters);
+      return policies;
+    } catch (RangerServiceException e) {
+      throw new AuthorizationPluginException(e, "Failed to find the policies in the Ranger");
+    }
+  }
+
+  /**
+   * IF rename the SCHEMA, Need to rename these the relevant policies, `{schema}`, `{schema}.*`,
+   * `{schema}.*.*` <br>
+   * IF rename the TABLE, Need to rename these the relevant policies, `{schema}.*`, `{schema}.*.*`
+   * <br>
+   * IF rename the COLUMN, Only need to rename `{schema}.*.*` <br>
+   */
+  @Override
+  protected void doRenameMetadataObject(
+      AuthorizationMetadataObject authzMetadataObject,
+      AuthorizationMetadataObject newAuthzMetadataObject) {
+    List<Map<String, String>> loop = new ArrayList<>();
+    if (newAuthzMetadataObject.type().equals(SCHEMA)) {
+      loop =
+          ImmutableList.of(
+              ImmutableMap.of(
+                  authzMetadataObject.names().get(0), newAuthzMetadataObject.names().get(0)),
+              ImmutableMap.of(RangerHelper.RESOURCE_ALL, RangerHelper.RESOURCE_ALL),
+              ImmutableMap.of(RangerHelper.RESOURCE_ALL, RangerHelper.RESOURCE_ALL));
+    } else if (newAuthzMetadataObject.type().equals(TABLE)) {
+      loop =
+          ImmutableList.of(
+              ImmutableMap.of(
+                  authzMetadataObject.names().get(0), newAuthzMetadataObject.names().get(0)),
+              ImmutableMap.of(
+                  authzMetadataObject.names().get(1), newAuthzMetadataObject.names().get(1)),
+              ImmutableMap.of(RangerHelper.RESOURCE_ALL, RangerHelper.RESOURCE_ALL));
+    } else if (newAuthzMetadataObject.type().equals(COLUMN)) {
+      loop =
+          ImmutableList.of(
+              ImmutableMap.of(
+                  authzMetadataObject.names().get(0), newAuthzMetadataObject.names().get(0)),
+              ImmutableMap.of(
+                  authzMetadataObject.names().get(1), newAuthzMetadataObject.names().get(1)),
+              ImmutableMap.of(
+                  authzMetadataObject.names().get(2), newAuthzMetadataObject.names().get(2)));
+    } else if (newAuthzMetadataObject.type().equals(PATH)) { // do nothing when fileset is renamed
+    } else {
+      throw new IllegalArgumentException(
+          "Unsupported metadata object type: " + authzMetadataObject.type());
+    }
+
+    List<String> oldMetadataNames = new ArrayList<>();
+    List<String> newMetadataNames = new ArrayList<>();
+    for (int index = 0; index < loop.size(); index++) {
+      oldMetadataNames.add(loop.get(index).keySet().stream().findFirst().get());
+      newMetadataNames.add(loop.get(index).values().stream().findFirst().get());
+
+      AuthorizationMetadataObject.Type type =
+          (index == 0
+              ? RangerHadoopSQLMetadataObject.Type.SCHEMA
+              : (index == 1
+                  ? RangerHadoopSQLMetadataObject.Type.TABLE
+                  : RangerHadoopSQLMetadataObject.Type.COLUMN));
+      AuthorizationMetadataObject authzMetadataObject1 =
+          new RangerHadoopSQLMetadataObject(
+              AuthorizationMetadataObject.getParentFullName(oldMetadataNames),
+              AuthorizationMetadataObject.getLastName(oldMetadataNames),
+              type);
+      AuthorizationMetadataObject newAuthzMetadataObject1 =
+          new RangerHadoopSQLMetadataObject(
+              AuthorizationMetadataObject.getParentFullName(newMetadataNames),
+              AuthorizationMetadataObject.getLastName(newMetadataNames),
+              type);
+      updatePolicyByMetadataObject(
+          type.metadataObjectType(), authzMetadataObject1, newAuthzMetadataObject1);
+    }
+  }
+
+  @Override
+  protected void updatePolicyByMetadataObject(
+      MetadataObject.Type operationType,
+      AuthorizationMetadataObject oldAuthzMetaobject,
+      AuthorizationMetadataObject newAuthzMetaobject) {
+    List<RangerPolicy> oldPolicies = wildcardSearchPolies(oldAuthzMetaobject);
+    List<RangerPolicy> existNewPolicies = wildcardSearchPolies(newAuthzMetaobject);
+    if (oldPolicies.isEmpty()) {
+      LOG.warn("Cannot find the Ranger policy for the metadata object({})!", oldAuthzMetaobject);
+    }
+    if (!existNewPolicies.isEmpty()) {
+      LOG.warn("The Ranger policy for the metadata object({}) already exists!", newAuthzMetaobject);
+    }
+    Map<MetadataObject.Type, Integer> operationTypeIndex =
+        ImmutableMap.of(
+            MetadataObject.Type.SCHEMA, 0,
+            MetadataObject.Type.TABLE, 1,
+            MetadataObject.Type.COLUMN, 2);
+    oldPolicies.stream()
+        .forEach(
+            policy -> {
+              try {
+                String policyName = policy.getName();
+                int index = operationTypeIndex.get(operationType);
+
+                // Update the policy name is following Gravitino's spec
+                if (policy
+                    .getName()
+                    .equals(
+                        AuthorizationSecurableObject.DOT_JOINER.join(oldAuthzMetaobject.names()))) {
+                  List<String> policyNames =
+                      Lists.newArrayList(
+                          AuthorizationSecurableObject.DOT_SPLITTER.splitToList(policyName));
+                  Preconditions.checkArgument(
+                      policyNames.size() >= oldAuthzMetaobject.names().size(),
+                      String.format("The policy name(%s) is invalid!", policyName));
+                  if (policyNames.get(index).equals(RangerHelper.RESOURCE_ALL)) {
+                    // Doesn't need to rename the policy `*`
+                    return;
+                  }
+                  policyNames.set(index, newAuthzMetaobject.names().get(index));
+                  policy.setName(AuthorizationSecurableObject.DOT_JOINER.join(policyNames));
+                }
+                // Update the policy resource name to new name
+                policy
+                    .getResources()
+                    .put(
+                        policyResourceDefinesRule().get(index),
+                        new RangerPolicy.RangerPolicyResource(
+                            newAuthzMetaobject.names().get(index)));
+
+                boolean alreadyExist =
+                    existNewPolicies.stream()
+                        .anyMatch(
+                            existNewPolicy ->
+                                existNewPolicy.getName().equals(policy.getName())
+                                    || existNewPolicy.getResources().equals(policy.getResources()));
+                if (alreadyExist) {
+                  LOG.warn(
+                      "The Ranger policy for the metadata object({}) already exists!",
+                      newAuthzMetaobject);
+                  return;
+                }
+
+                // Update the policy
+                rangerClient.updatePolicy(policy.getId(), policy);
+              } catch (RangerServiceException e) {
+                LOG.error("Failed to rename the policy {}!", policy);
+                throw new RuntimeException(e);
+              }
+            });
+  }
+
+  /**
+   * IF remove the SCHEMA, need to remove these the relevant policies, `{schema}`, `{schema}.*`,
+   * `{schema}.*.*` <br>
+   * IF remove the TABLE, need to remove these the relevant policies, `{schema}.*`, `{schema}.*.*`
+   * <br>
+   * IF remove the COLUMN, Only need to remove `{schema}.*.*` <br>
+   */
+  @Override
+  protected void doRemoveMetadataObject(AuthorizationMetadataObject authzMetadataObject) {
+    AuthorizationMetadataObject.Type type = authzMetadataObject.type();
+    if (type.equals(SCHEMA)) {
+      doRemoveSchemaMetadataObject(authzMetadataObject);
+    } else if (type.equals(TABLE)) {
+      doRemoveTableMetadataObject(authzMetadataObject);
+    } else if (type.equals(COLUMN) || type.equals(PATH)) {
+      removePolicyByMetadataObject(authzMetadataObject);
+    } else {
+      throw new IllegalArgumentException(
+          "Unsupported metadata object type: " + authzMetadataObject.type());
+    }
+  }
+
+  /**
+   * Remove the SCHEMA, Need to remove these the relevant policies, `{schema}`, `{schema}.*`,
+   * `{schema}.*.*` permissions.
+   */
+  private void doRemoveSchemaMetadataObject(AuthorizationMetadataObject authMetadataObject) {
+    Preconditions.checkArgument(
+        authMetadataObject.type() == SCHEMA, "The metadata object type must be SCHEMA");
+    Preconditions.checkArgument(
+        authMetadataObject.names().size() == 1, "The metadata object names must be 1");
+    if (RangerHelper.RESOURCE_ALL.equals(authMetadataObject.name())) {
+      // Delete metalake or catalog policies in this Ranger service
+      try {
+        List<RangerPolicy> policies = rangerClient.getPoliciesInService(rangerServiceName);
+        policies.stream()
+            .filter(RangerHelper::hasGravitinoManagedPolicyItem)
+            .forEach(rangerHelper::removeAllGravitinoManagedPolicyItem);
+      } catch (RangerServiceException e) {
+        throw new RuntimeException(e);
+      }
+    } else {
+      List<List<String>> loop =
+          ImmutableList.of(
+              ImmutableList.of(authMetadataObject.name())
+              /** SCHEMA permission */
+              ,
+              ImmutableList.of(authMetadataObject.name(), RangerHelper.RESOURCE_ALL)
+              /** TABLE permission */
+              ,
+              ImmutableList.of(
+                  authMetadataObject.name(), RangerHelper.RESOURCE_ALL, RangerHelper.RESOURCE_ALL)
+              /** COLUMN permission */
+              );
+
+      for (int index = 0; index < loop.size(); index++) {
+        AuthorizationMetadataObject.Type type =
+            (index == 0
+                ? RangerHadoopSQLMetadataObject.Type.SCHEMA
+                : (index == 1
+                    ? RangerHadoopSQLMetadataObject.Type.TABLE
+                    : RangerHadoopSQLMetadataObject.Type.COLUMN));
+        AuthorizationMetadataObject authzMetadataObject1 =
+            new RangerHadoopSQLMetadataObject(
+                AuthorizationMetadataObject.getParentFullName(loop.get(index)),
+                AuthorizationMetadataObject.getLastName(loop.get(index)),
+                type);
+        removePolicyByMetadataObject(authzMetadataObject1);
+      }
+    }
+  }
+
+  /**
+   * Remove the TABLE, Need to remove these the relevant policies, `*.{table}`, `*.{table}.{column}`
+   * permissions.
+   */
+  private void doRemoveTableMetadataObject(AuthorizationMetadataObject authzMetadataObject) {
+    List<List<String>> loop =
+        ImmutableList.of(
+            authzMetadataObject.names()
+            /** TABLE permission */
+            ,
+            Stream.concat(
+                    authzMetadataObject.names().stream(), Stream.of(RangerHelper.RESOURCE_ALL))
+                .collect(Collectors.toList())
+            /** COLUMN permission */
+            );
+
+    for (int index = 0; index < loop.size(); index++) {
+      AuthorizationMetadataObject.Type type =
+          (index == 0
+              ? RangerHadoopSQLMetadataObject.Type.SCHEMA
+              : (index == 1
+                  ? RangerHadoopSQLMetadataObject.Type.TABLE
+                  : RangerHadoopSQLMetadataObject.Type.COLUMN));
+      AuthorizationMetadataObject authzMetadataObject1 =
+          new RangerHadoopSQLMetadataObject(
+              AuthorizationMetadataObject.getParentFullName(loop.get(index)),
+              AuthorizationMetadataObject.getLastName(loop.get(index)),
+              type);
+      removePolicyByMetadataObject(authzMetadataObject1);
+    }
+  }
+
   @Override
   /** Set the default owner rule. */
   public Set<AuthorizationPrivilege> ownerMappingRule() {
@@ -108,6 +439,7 @@ public class RangerAuthorizationHadoopSQLPlugin extends RangerAuthorizationPlugi
   @Override
   public AuthorizationSecurableObject generateAuthorizationSecurableObject(
       List<String> names,
+      String path,
       AuthorizationMetadataObject.Type type,
       Set<AuthorizationPrivilege> privileges) {
     AuthorizationMetadataObject authMetadataObject =
@@ -163,12 +495,14 @@ public class RangerAuthorizationHadoopSQLPlugin extends RangerAuthorizationPlugi
         rangerSecurableObjects.add(
             generateAuthorizationSecurableObject(
                 ImmutableList.of(RangerHelper.RESOURCE_ALL),
+                null,
                 RangerHadoopSQLMetadataObject.Type.SCHEMA,
                 ownerMappingRule()));
         // Add `*.*` for the TABLE permission
         rangerSecurableObjects.add(
             generateAuthorizationSecurableObject(
                 ImmutableList.of(RangerHelper.RESOURCE_ALL, RangerHelper.RESOURCE_ALL),
+                null,
                 RangerHadoopSQLMetadataObject.Type.TABLE,
                 ownerMappingRule()));
         // Add `*.*.*` for the COLUMN permission
@@ -178,6 +512,7 @@ public class RangerAuthorizationHadoopSQLPlugin extends RangerAuthorizationPlugi
                     RangerHelper.RESOURCE_ALL,
                     RangerHelper.RESOURCE_ALL,
                     RangerHelper.RESOURCE_ALL),
+                null,
                 RangerHadoopSQLMetadataObject.Type.COLUMN,
                 ownerMappingRule()));
         break;
@@ -186,6 +521,7 @@ public class RangerAuthorizationHadoopSQLPlugin extends RangerAuthorizationPlugi
         rangerSecurableObjects.add(
             generateAuthorizationSecurableObject(
                 ImmutableList.of(gravitinoMetadataObject.name() /*Schema name*/),
+                null,
                 RangerHadoopSQLMetadataObject.Type.SCHEMA,
                 ownerMappingRule()));
         // Add `{schema}.*` for the TABLE permission
@@ -193,6 +529,7 @@ public class RangerAuthorizationHadoopSQLPlugin extends RangerAuthorizationPlugi
             generateAuthorizationSecurableObject(
                 ImmutableList.of(
                     gravitinoMetadataObject.name() /*Schema name*/, RangerHelper.RESOURCE_ALL),
+                null,
                 RangerHadoopSQLMetadataObject.Type.TABLE,
                 ownerMappingRule()));
         // Add `{schema}.*.*` for the COLUMN permission
@@ -202,25 +539,32 @@ public class RangerAuthorizationHadoopSQLPlugin extends RangerAuthorizationPlugi
                     gravitinoMetadataObject.name() /*Schema name*/,
                     RangerHelper.RESOURCE_ALL,
                     RangerHelper.RESOURCE_ALL),
+                null,
                 RangerHadoopSQLMetadataObject.Type.COLUMN,
                 ownerMappingRule()));
         break;
       case TABLE:
-        // Add `{schema}.{table}` for the TABLE permission
-        rangerSecurableObjects.add(
-            generateAuthorizationSecurableObject(
-                translateMetadataObject(gravitinoMetadataObject).names(),
-                RangerHadoopSQLMetadataObject.Type.TABLE,
-                ownerMappingRule()));
-        // Add `{schema}.{table}.*` for the COLUMN permission
-        rangerSecurableObjects.add(
-            generateAuthorizationSecurableObject(
-                Stream.concat(
-                        translateMetadataObject(gravitinoMetadataObject).names().stream(),
-                        Stream.of(RangerHelper.RESOURCE_ALL))
-                    .collect(Collectors.toList()),
-                RangerHadoopSQLMetadataObject.Type.COLUMN,
-                ownerMappingRule()));
+        translateMetadataObject(gravitinoMetadataObject).stream()
+            .forEach(
+                rangerMetadataObject -> {
+                  // Add `{schema}.{table}` for the TABLE permission
+                  rangerSecurableObjects.add(
+                      generateAuthorizationSecurableObject(
+                          rangerMetadataObject.names(),
+                          null,
+                          RangerHadoopSQLMetadataObject.Type.TABLE,
+                          ownerMappingRule()));
+                  // Add `{schema}.{table}.*` for the COLUMN permission
+                  rangerSecurableObjects.add(
+                      generateAuthorizationSecurableObject(
+                          Stream.concat(
+                                  rangerMetadataObject.names().stream(),
+                                  Stream.of(RangerHelper.RESOURCE_ALL))
+                              .collect(Collectors.toList()),
+                          null,
+                          RangerHadoopSQLMetadataObject.Type.COLUMN,
+                          ownerMappingRule()));
+                });
         break;
       default:
         throw new AuthorizationPluginException(
@@ -265,6 +609,7 @@ public class RangerAuthorizationHadoopSQLPlugin extends RangerAuthorizationPlugi
                       rangerSecurableObjects.add(
                           generateAuthorizationSecurableObject(
                               ImmutableList.of(RangerHelper.RESOURCE_ALL),
+                              null,
                               RangerHadoopSQLMetadataObject.Type.SCHEMA,
                               rangerPrivileges));
                       break;
@@ -282,6 +627,7 @@ public class RangerAuthorizationHadoopSQLPlugin extends RangerAuthorizationPlugi
                       rangerSecurableObjects.add(
                           generateAuthorizationSecurableObject(
                               ImmutableList.of(RangerHelper.RESOURCE_ALL),
+                              null,
                               RangerHadoopSQLMetadataObject.Type.SCHEMA,
                               rangerPrivileges));
                       break;
@@ -299,6 +645,7 @@ public class RangerAuthorizationHadoopSQLPlugin extends RangerAuthorizationPlugi
                       rangerSecurableObjects.add(
                           generateAuthorizationSecurableObject(
                               ImmutableList.of(RangerHelper.RESOURCE_ALL),
+                              null,
                               RangerHadoopSQLMetadataObject.Type.SCHEMA,
                               rangerPrivileges));
                       break;
@@ -307,6 +654,7 @@ public class RangerAuthorizationHadoopSQLPlugin extends RangerAuthorizationPlugi
                       rangerSecurableObjects.add(
                           generateAuthorizationSecurableObject(
                               ImmutableList.of(securableObject.name() /*Schema name*/),
+                              null,
                               RangerHadoopSQLMetadataObject.Type.SCHEMA,
                               rangerPrivileges));
                       break;
@@ -327,6 +675,7 @@ public class RangerAuthorizationHadoopSQLPlugin extends RangerAuthorizationPlugi
                           generateAuthorizationSecurableObject(
                               ImmutableList.of(
                                   RangerHelper.RESOURCE_ALL, RangerHelper.RESOURCE_ALL),
+                              null,
                               RangerHadoopSQLMetadataObject.Type.TABLE,
                               rangerPrivileges));
                       // Add `*.*.*` for the COLUMN permission
@@ -336,6 +685,7 @@ public class RangerAuthorizationHadoopSQLPlugin extends RangerAuthorizationPlugi
                                   RangerHelper.RESOURCE_ALL,
                                   RangerHelper.RESOURCE_ALL,
                                   RangerHelper.RESOURCE_ALL),
+                              null,
                               RangerHadoopSQLMetadataObject.Type.COLUMN,
                               rangerPrivileges));
                       break;
@@ -346,6 +696,7 @@ public class RangerAuthorizationHadoopSQLPlugin extends RangerAuthorizationPlugi
                               ImmutableList.of(
                                   securableObject.name() /*Schema name*/,
                                   RangerHelper.RESOURCE_ALL),
+                              null,
                               RangerHadoopSQLMetadataObject.Type.TABLE,
                               rangerPrivileges));
                       // Add `{schema}.*.*` for the COLUMN permission
@@ -355,6 +706,7 @@ public class RangerAuthorizationHadoopSQLPlugin extends RangerAuthorizationPlugi
                                   securableObject.name() /*Schema name*/,
                                   RangerHelper.RESOURCE_ALL,
                                   RangerHelper.RESOURCE_ALL),
+                              null,
                               RangerHadoopSQLMetadataObject.Type.COLUMN,
                               rangerPrivileges));
                       break;
@@ -364,21 +716,27 @@ public class RangerAuthorizationHadoopSQLPlugin extends RangerAuthorizationPlugi
                             "The privilege %s is not supported for the securable object: %s",
                             gravitinoPrivilege.name(), securableObject.type());
                       } else {
-                        // Add `{schema}.{table}` for the TABLE permission
-                        rangerSecurableObjects.add(
-                            generateAuthorizationSecurableObject(
-                                translateMetadataObject(securableObject).names(),
-                                RangerHadoopSQLMetadataObject.Type.TABLE,
-                                rangerPrivileges));
-                        // Add `{schema}.{table}.*` for the COLUMN permission
-                        rangerSecurableObjects.add(
-                            generateAuthorizationSecurableObject(
-                                Stream.concat(
-                                        translateMetadataObject(securableObject).names().stream(),
-                                        Stream.of(RangerHelper.RESOURCE_ALL))
-                                    .collect(Collectors.toList()),
-                                RangerHadoopSQLMetadataObject.Type.COLUMN,
-                                rangerPrivileges));
+                        translateMetadataObject(securableObject).stream()
+                            .forEach(
+                                rangerMetadataObject -> {
+                                  // Add `{schema}.{table}` for the TABLE permission
+                                  rangerSecurableObjects.add(
+                                      generateAuthorizationSecurableObject(
+                                          rangerMetadataObject.names(),
+                                          null,
+                                          RangerHadoopSQLMetadataObject.Type.TABLE,
+                                          rangerPrivileges));
+                                  // Add `{schema}.{table}.*` for the COLUMN permission
+                                  rangerSecurableObjects.add(
+                                      generateAuthorizationSecurableObject(
+                                          Stream.concat(
+                                                  rangerMetadataObject.names().stream(),
+                                                  Stream.of(RangerHelper.RESOURCE_ALL))
+                                              .collect(Collectors.toList()),
+                                          null,
+                                          RangerHadoopSQLMetadataObject.Type.COLUMN,
+                                          rangerPrivileges));
+                                });
                       }
                       break;
                     default:
@@ -404,12 +762,7 @@ public class RangerAuthorizationHadoopSQLPlugin extends RangerAuthorizationPlugi
    * convert the Gravitino metadata object to the Ranger metadata object.
    */
   @Override
-  public AuthorizationMetadataObject translateMetadataObject(MetadataObject metadataObject) {
-    Preconditions.checkArgument(
-        allowMetadataObjectTypesRule().contains(metadataObject.type()),
-        String.format(
-            "The metadata object type %s is not supported in the RangerAuthorizationHivePlugin",
-            metadataObject.type()));
+  public List<AuthorizationMetadataObject> translateMetadataObject(MetadataObject metadataObject) {
     Preconditions.checkArgument(
         !(metadataObject instanceof RangerPrivileges),
         "The metadata object must be not a RangerPrivileges object.");
@@ -435,6 +788,62 @@ public class RangerAuthorizationHadoopSQLPlugin extends RangerAuthorizationPlugi
             AuthorizationMetadataObject.getLastName(nsMetadataObject),
             type);
     rangerHadoopSQLMetadataObject.validateAuthorizationMetadataObject();
-    return rangerHadoopSQLMetadataObject;
+    return ImmutableList.of(rangerHadoopSQLMetadataObject);
+  }
+
+  @Override
+  public Boolean onMetadataUpdated(MetadataObjectChange... changes) throws RuntimeException {
+    for (MetadataObjectChange change : changes) {
+      if (change instanceof MetadataObjectChange.RenameMetadataObject) {
+        MetadataObject metadataObject =
+            ((MetadataObjectChange.RenameMetadataObject) change).metadataObject();
+        MetadataObject newMetadataObject =
+            ((MetadataObjectChange.RenameMetadataObject) change).newMetadataObject();
+        Preconditions.checkArgument(
+            metadataObject.type() == newMetadataObject.type(),
+            "The old and new metadata object type must be equal!");
+        if (metadataObject.type() == MetadataObject.Type.METALAKE) {
+          // Rename the metalake name
+          this.metalake = newMetadataObject.name();
+          // Did not need to update the Ranger policy
+          continue;
+        } else if (metadataObject.type() == MetadataObject.Type.CATALOG) {
+          // Did not need to update the Ranger policy
+          continue;
+        }
+        List<AuthorizationMetadataObject> oldAuthzMetadataObjects =
+            translateMetadataObject(metadataObject);
+        List<AuthorizationMetadataObject> newAuthzMetadataObjects =
+            translateMetadataObject(newMetadataObject);
+        Preconditions.checkArgument(
+            oldAuthzMetadataObjects.size() == newAuthzMetadataObjects.size(),
+            "The old and new metadata objects size must be equal!");
+        for (int i = 0; i < oldAuthzMetadataObjects.size(); i++) {
+          AuthorizationMetadataObject oldAuthMetadataObject = oldAuthzMetadataObjects.get(i);
+          AuthorizationMetadataObject newAuthzMetadataObject = newAuthzMetadataObjects.get(i);
+          if (oldAuthMetadataObject.equals(newAuthzMetadataObject)) {
+            LOG.info(
+                "The metadata object({}) and new metadata object({}) are equal, so ignore rename!",
+                oldAuthMetadataObject.fullName(),
+                newAuthzMetadataObject.fullName());
+            continue;
+          }
+          doRenameMetadataObject(oldAuthMetadataObject, newAuthzMetadataObject);
+        }
+      } else if (change instanceof MetadataObjectChange.RemoveMetadataObject) {
+        MetadataObject metadataObject =
+            ((MetadataObjectChange.RemoveMetadataObject) change).metadataObject();
+        //        if (metadataObject.type() != MetadataObject.Type.FILESET) {
+        List<AuthorizationMetadataObject> authzMetadataObjects =
+            translateMetadataObject(metadataObject);
+        authzMetadataObjects.stream().forEach(this::doRemoveMetadataObject);
+        //        }
+      } else {
+        throw new IllegalArgumentException(
+            "Unsupported metadata object change type: "
+                + (change == null ? "null" : change.getClass().getSimpleName()));
+      }
+    }
+    return Boolean.TRUE;
   }
 }

--- a/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/RangerAuthorizationPlugin.java
+++ b/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/RangerAuthorizationPlugin.java
@@ -18,9 +18,6 @@
  */
 package org.apache.gravitino.authorization.ranger;
 
-import static org.apache.gravitino.authorization.ranger.RangerHadoopSQLMetadataObject.Type.SCHEMA;
-import static org.apache.gravitino.authorization.ranger.RangerHadoopSQLMetadataObject.Type.TABLE;
-
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
@@ -315,7 +312,7 @@ public abstract class RangerAuthorizationPlugin
         authzSecurableObjects.stream()
             .forEach(
                 authzSecurableObject -> {
-                  if (!doRemoveSecurableObject(role.name(), authzSecurableObject)) {
+                  if (!removeSecurableObject(role.name(), authzSecurableObject)) {
                     throw new AuthorizationPluginException(
                         "Failed to add the securable object to the Ranger policy!");
                   }
@@ -343,7 +340,7 @@ public abstract class RangerAuthorizationPlugin
         rangerOldSecurableObjects.stream()
             .forEach(
                 AuthorizationSecurableObject -> {
-                  doRemoveSecurableObject(role.name(), AuthorizationSecurableObject);
+                  removeSecurableObject(role.name(), AuthorizationSecurableObject);
                 });
         rangerNewSecurableObjects.stream()
             .forEach(
@@ -397,14 +394,14 @@ public abstract class RangerAuthorizationPlugin
                 newAuthzMetadataObject.fullName());
             continue;
           }
-          doRenameMetadataObject(oldAuthMetadataObject, newAuthzMetadataObject);
+          renameMetadataObject(oldAuthMetadataObject, newAuthzMetadataObject);
         }
       } else if (change instanceof MetadataObjectChange.RemoveMetadataObject) {
         MetadataObject metadataObject =
             ((MetadataObjectChange.RemoveMetadataObject) change).metadataObject();
         List<AuthorizationMetadataObject> authzMetadataObjects =
             translateMetadataObject(metadataObject);
-        authzMetadataObjects.stream().forEach(this::doRemoveMetadataObject);
+        authzMetadataObjects.stream().forEach(this::removeMetadataObject);
       } else {
         throw new IllegalArgumentException(
             "Unsupported metadata object change type: "
@@ -829,7 +826,7 @@ public abstract class RangerAuthorizationPlugin
    * <br>
    * 3. If policy does not contain any policy item, then delete this policy. <br>
    */
-  private boolean doRemoveSecurableObject(
+  private boolean removeSecurableObject(
       String roleName, AuthorizationSecurableObject authzSecurableObject) {
     RangerPolicy policy = findManagedPolicy(authzSecurableObject);
     if (policy == null) {
@@ -920,11 +917,11 @@ public abstract class RangerAuthorizationPlugin
    * <br>
    * IF rename the COLUMN, Only need to rename `{schema}.*.*` <br>
    */
-  protected abstract void doRenameMetadataObject(
+  protected abstract void renameMetadataObject(
       AuthorizationMetadataObject authzMetadataObject,
       AuthorizationMetadataObject newAuthzMetadataObject);
 
-  protected abstract void doRemoveMetadataObject(AuthorizationMetadataObject authzMetadataObject);
+  protected abstract void removeMetadataObject(AuthorizationMetadataObject authzMetadataObject);
 
   /**
    * Remove the policy by the metadata object names. <br>

--- a/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/RangerAuthorizationPlugin.java
+++ b/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/RangerAuthorizationPlugin.java
@@ -18,23 +18,21 @@
  */
 package org.apache.gravitino.authorization.ranger;
 
+import static org.apache.gravitino.authorization.ranger.RangerHadoopSQLMetadataObject.Type.SCHEMA;
+import static org.apache.gravitino.authorization.ranger.RangerHadoopSQLMetadataObject.Type.TABLE;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Lists;
 import java.io.IOException;
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import org.apache.gravitino.MetadataObject;
 import org.apache.gravitino.authorization.AuthorizationMetadataObject;
 import org.apache.gravitino.authorization.AuthorizationPrivilege;
@@ -83,7 +81,7 @@ public abstract class RangerAuthorizationPlugin
   protected String metalake;
   protected final String rangerServiceName;
   protected final RangerClientExtension rangerClient;
-  private final RangerHelper rangerHelper;
+  protected final RangerHelper rangerHelper;
   @VisibleForTesting public final String rangerAdminName;
 
   protected RangerAuthorizationPlugin(String metalake, Map<String, String> config) {
@@ -127,6 +125,24 @@ public abstract class RangerAuthorizationPlugin
    */
   protected abstract RangerPolicy createPolicyAddResources(
       AuthorizationMetadataObject metadataObject);
+
+  /** Wildcard search the Ranger policies in the different Ranger service. */
+  protected abstract List<RangerPolicy> wildcardSearchPolies(
+      AuthorizationMetadataObject authzMetadataObject);
+
+  /**
+   * Find the managed policy for the ranger securable object.
+   *
+   * @param authzMetadataObject The ranger securable object to find the managed policy.
+   * @return The managed policy for the metadata object.
+   */
+  public abstract RangerPolicy findManagedPolicy(AuthorizationMetadataObject authzMetadataObject)
+      throws AuthorizationPluginException;
+
+  protected abstract void updatePolicyByMetadataObject(
+      MetadataObject.Type operationType,
+      AuthorizationMetadataObject oldAuthzMetaobject,
+      AuthorizationMetadataObject newAuthzMetaobject);
 
   protected RangerPolicy addOwnerToNewPolicy(
       AuthorizationMetadataObject metadataObject, Owner newOwner) {
@@ -232,12 +248,12 @@ public abstract class RangerAuthorizationPlugin
           return Boolean.FALSE;
         }
 
-        List<AuthorizationSecurableObject> AuthorizationSecurableObjects =
+        List<AuthorizationSecurableObject> authzSecurableObjects =
             translatePrivilege(securableObject);
-        AuthorizationSecurableObjects.stream()
+        authzSecurableObjects.stream()
             .forEach(
-                AuthorizationSecurableObject -> {
-                  if (!doAddSecurableObject(role.name(), AuthorizationSecurableObject)) {
+                authzSecurableObject -> {
+                  if (!doAddSecurableObject(role.name(), authzSecurableObject)) {
                     throw new AuthorizationPluginException(
                         "Failed to add the securable object to the Ranger policy!");
                   }
@@ -249,12 +265,12 @@ public abstract class RangerAuthorizationPlugin
           return Boolean.FALSE;
         }
 
-        List<AuthorizationSecurableObject> AuthorizationSecurableObjects =
+        List<AuthorizationSecurableObject> authzSecurableObjects =
             translatePrivilege(securableObject);
-        AuthorizationSecurableObjects.stream()
+        authzSecurableObjects.stream()
             .forEach(
-                AuthorizationSecurableObject -> {
-                  if (!doRemoveSecurableObject(role.name(), AuthorizationSecurableObject)) {
+                authzSecurableObject -> {
+                  if (!doRemoveSecurableObject(role.name(), authzSecurableObject)) {
                     throw new AuthorizationPluginException(
                         "Failed to add the securable object to the Ranger policy!");
                   }
@@ -307,30 +323,43 @@ public abstract class RangerAuthorizationPlugin
             ((MetadataObjectChange.RenameMetadataObject) change).metadataObject();
         MetadataObject newMetadataObject =
             ((MetadataObjectChange.RenameMetadataObject) change).newMetadataObject();
-        if (metadataObject.type() == MetadataObject.Type.METALAKE
-            && newMetadataObject.type() == MetadataObject.Type.METALAKE) {
-          // Modify the metalake name
+        Preconditions.checkArgument(
+            metadataObject.type() == newMetadataObject.type(),
+            "The old and new metadata object type must be equal!");
+        if (metadataObject.type() == MetadataObject.Type.METALAKE) {
+          // Rename the metalake name
           this.metalake = newMetadataObject.name();
-        }
-        AuthorizationMetadataObject oldAuthMetadataObject = translateMetadataObject(metadataObject);
-        AuthorizationMetadataObject newAuthMetadataObject =
-            translateMetadataObject(newMetadataObject);
-        if (oldAuthMetadataObject.equals(newAuthMetadataObject)) {
-          LOG.info(
-              "The metadata object({}) and new metadata object({}) are equal, so ignore rename!",
-              oldAuthMetadataObject.fullName(),
-              newAuthMetadataObject.fullName());
+          // Did not need to update the Ranger policy
+          continue;
+        } else if (metadataObject.type() == MetadataObject.Type.CATALOG) {
+          // Did not need to update the Ranger policy
           continue;
         }
-        doRenameMetadataObject(oldAuthMetadataObject, newAuthMetadataObject);
+        List<AuthorizationMetadataObject> oldAuthzMetadataObjects =
+            translateMetadataObject(metadataObject);
+        List<AuthorizationMetadataObject> newAuthzMetadataObjects =
+            translateMetadataObject(newMetadataObject);
+        Preconditions.checkArgument(
+            oldAuthzMetadataObjects.size() == newAuthzMetadataObjects.size(),
+            "The old and new metadata objects size must be equal!");
+        for (int i = 0; i < oldAuthzMetadataObjects.size(); i++) {
+          AuthorizationMetadataObject oldAuthMetadataObject = oldAuthzMetadataObjects.get(i);
+          AuthorizationMetadataObject newAuthzMetadataObject = newAuthzMetadataObjects.get(i);
+          if (oldAuthMetadataObject.equals(newAuthzMetadataObject)) {
+            LOG.info(
+                "The metadata object({}) and new metadata object({}) are equal, so ignore rename!",
+                oldAuthMetadataObject.fullName(),
+                newAuthzMetadataObject.fullName());
+            continue;
+          }
+          doRenameMetadataObject(oldAuthMetadataObject, newAuthzMetadataObject);
+        }
       } else if (change instanceof MetadataObjectChange.RemoveMetadataObject) {
         MetadataObject metadataObject =
             ((MetadataObjectChange.RemoveMetadataObject) change).metadataObject();
-        if (metadataObject.type() != MetadataObject.Type.FILESET) {
-          AuthorizationMetadataObject AuthorizationMetadataObject =
-              translateMetadataObject(metadataObject);
-          doRemoveMetadataObject(AuthorizationMetadataObject);
-        }
+        List<AuthorizationMetadataObject> authzMetadataObjects =
+            translateMetadataObject(metadataObject);
+        authzMetadataObjects.stream().forEach(this::doRemoveMetadataObject);
       } else {
         throw new IllegalArgumentException(
             "Unsupported metadata object change type: "
@@ -431,7 +460,7 @@ public abstract class RangerAuthorizationPlugin
         rangerSecurableObjects.stream()
             .forEach(
                 rangerSecurableObject -> {
-                  RangerPolicy policy = rangerHelper.findManagedPolicy(rangerSecurableObject);
+                  RangerPolicy policy = findManagedPolicy(rangerSecurableObject);
                   try {
                     if (policy == null) {
                       policy = addOwnerRoleToNewPolicy(rangerSecurableObject, ownerRoleName);
@@ -453,8 +482,7 @@ public abstract class RangerAuthorizationPlugin
         rangerSecurableObjects.stream()
             .forEach(
                 AuthorizationSecurableObject -> {
-                  RangerPolicy policy =
-                      rangerHelper.findManagedPolicy(AuthorizationSecurableObject);
+                  RangerPolicy policy = findManagedPolicy(AuthorizationSecurableObject);
                   try {
                     if (policy == null) {
                       policy = addOwnerToNewPolicy(AuthorizationSecurableObject, newOwner);
@@ -684,14 +712,14 @@ public abstract class RangerAuthorizationPlugin
    */
   private boolean doAddSecurableObject(
       String roleName, AuthorizationSecurableObject securableObject) {
-    RangerPolicy policy = rangerHelper.findManagedPolicy(securableObject);
+    RangerPolicy policy = findManagedPolicy(securableObject);
     if (policy != null) {
       // Check the policy item's accesses and roles equal the Ranger securable object's privilege
-      List<AuthorizationPrivilege> allowPrivilies =
+      List<AuthorizationPrivilege> allowPrivileges =
           securableObject.privileges().stream()
               .filter(privilege -> privilege.condition() == Privilege.Condition.ALLOW)
               .collect(Collectors.toList());
-      List<AuthorizationPrivilege> denyPrivilies =
+      List<AuthorizationPrivilege> denyPrivileges =
           securableObject.privileges().stream()
               .filter(privilege -> privilege.condition() == Privilege.Condition.DENY)
               .collect(Collectors.toList());
@@ -720,8 +748,8 @@ public abstract class RangerAuthorizationPlugin
               .map(RangerPrivileges::valueOf)
               .collect(Collectors.toSet());
 
-      if (policyPrivileges.containsAll(allowPrivilies)
-          && policyDenyPrivileges.containsAll(denyPrivilies)) {
+      if (policyPrivileges.containsAll(allowPrivileges)
+          && policyDenyPrivileges.containsAll(denyPrivileges)) {
         LOG.info(
             "The privilege({}) already added to Ranger policy({})!",
             policy.getName(),
@@ -757,17 +785,17 @@ public abstract class RangerAuthorizationPlugin
    * 3. If policy does not contain any policy item, then delete this policy. <br>
    */
   private boolean doRemoveSecurableObject(
-      String roleName, AuthorizationSecurableObject AuthorizationSecurableObject) {
-    RangerPolicy policy = rangerHelper.findManagedPolicy(AuthorizationSecurableObject);
+      String roleName, AuthorizationSecurableObject authzSecurableObject) {
+    RangerPolicy policy = findManagedPolicy(authzSecurableObject);
     if (policy == null) {
       LOG.warn(
           "Cannot find the Ranger policy for the Ranger securable object({})!",
-          AuthorizationSecurableObject.fullName());
+          authzSecurableObject.fullName());
       // Don't throw exception or return false, because need support immutable operation.
       return true;
     }
 
-    AuthorizationSecurableObject.privileges().stream()
+    authzSecurableObject.privileges().stream()
         .forEach(
             rangerPrivilege -> {
               if (rangerPrivilege.condition() == Privilege.Condition.ALLOW) {
@@ -776,7 +804,7 @@ public abstract class RangerAuthorizationPlugin
                     .forEach(
                         policyItem -> {
                           removePolicyItemIfEqualRoleName(
-                              policyItem, AuthorizationSecurableObject, roleName);
+                              policyItem, authzSecurableObject, roleName);
                         });
               } else {
                 policy
@@ -784,7 +812,7 @@ public abstract class RangerAuthorizationPlugin
                     .forEach(
                         policyItem -> {
                           removePolicyItemIfEqualRoleName(
-                              policyItem, AuthorizationSecurableObject, roleName);
+                              policyItem, authzSecurableObject, roleName);
                         });
               }
             });
@@ -806,7 +834,11 @@ public abstract class RangerAuthorizationPlugin
                     && policyItem.getGroups().isEmpty());
 
     try {
-      rangerClient.updatePolicy(policy.getId(), policy);
+      if (policy.getPolicyItems().isEmpty() && policy.getDenyPolicyItems().isEmpty()) {
+        rangerClient.deletePolicy(policy.getId());
+      } else {
+        rangerClient.updatePolicy(policy.getId(), policy);
+      }
     } catch (RangerServiceException e) {
       LOG.error("Failed to remove the policy item from the Ranger policy {}!", policy);
       throw new AuthorizationPluginException(
@@ -837,299 +869,28 @@ public abstract class RangerAuthorizationPlugin
   }
 
   /**
-   * IF remove the SCHEMA, need to remove these the relevant policies, `{schema}`, `{schema}.*`,
-   * `{schema}.*.*` <br>
-   * IF remove the TABLE, need to remove these the relevant policies, `{schema}.*`, `{schema}.*.*`
-   * <br>
-   * IF remove the COLUMN, Only need to remove `{schema}.*.*` <br>
-   */
-  private void doRemoveMetadataObject(AuthorizationMetadataObject authMetadataObject) {
-    switch (authMetadataObject.metadataObjectType()) {
-      case SCHEMA:
-        doRemoveSchemaMetadataObject(authMetadataObject);
-        break;
-      case TABLE:
-        doRemoveTableMetadataObject(authMetadataObject);
-        break;
-      case COLUMN:
-        removePolicyByMetadataObject(authMetadataObject.names());
-        break;
-      case FILESET:
-        // can not get fileset path in this case, do nothing
-        break;
-      default:
-        throw new IllegalArgumentException(
-            "Unsupported metadata object type: " + authMetadataObject.type());
-    }
-  }
-
-  /**
-   * Remove the SCHEMA, Need to remove these the relevant policies, `{schema}`, `{schema}.*`,
-   * `{schema}.*.*` permissions.
-   */
-  private void doRemoveSchemaMetadataObject(AuthorizationMetadataObject authMetadataObject) {
-    Preconditions.checkArgument(
-        authMetadataObject.type() == RangerHadoopSQLMetadataObject.Type.SCHEMA,
-        "The metadata object type must be SCHEMA");
-    Preconditions.checkArgument(
-        authMetadataObject.names().size() == 1, "The metadata object names must be 1");
-    if (RangerHelper.RESOURCE_ALL.equals(authMetadataObject.name())) {
-      // Delete metalake or catalog policies in this Ranger service
-      try {
-        List<RangerPolicy> policies = rangerClient.getPoliciesInService(rangerServiceName);
-        policies.stream()
-            .filter(rangerHelper::hasGravitinoManagedPolicyItem)
-            .forEach(rangerHelper::removeAllGravitinoManagedPolicyItem);
-      } catch (RangerServiceException e) {
-        throw new RuntimeException(e);
-      }
-    } else {
-      List<List<String>> loop =
-          ImmutableList.of(
-              ImmutableList.of(authMetadataObject.name())
-              /** SCHEMA permission */
-              ,
-              ImmutableList.of(authMetadataObject.name(), RangerHelper.RESOURCE_ALL)
-              /** TABLE permission */
-              ,
-              ImmutableList.of(
-                  authMetadataObject.name(), RangerHelper.RESOURCE_ALL, RangerHelper.RESOURCE_ALL)
-              /** COLUMN permission */
-              );
-      for (List<String> resNames : loop) {
-        removePolicyByMetadataObject(resNames);
-      }
-    }
-  }
-
-  /**
-   * Remove the TABLE, Need to remove these the relevant policies, `*.{table}`, `*.{table}.{column}`
-   * permissions.
-   */
-  private void doRemoveTableMetadataObject(
-      AuthorizationMetadataObject AuthorizationMetadataObject) {
-    List<List<String>> loop =
-        ImmutableList.of(
-            AuthorizationMetadataObject.names()
-            /** TABLE permission */
-            ,
-            Stream.concat(
-                    AuthorizationMetadataObject.names().stream(),
-                    Stream.of(RangerHelper.RESOURCE_ALL))
-                .collect(Collectors.toList())
-            /** COLUMN permission */
-            );
-    for (List<String> resNames : loop) {
-      removePolicyByMetadataObject(resNames);
-    }
-  }
-
-  /**
    * IF rename the SCHEMA, Need to rename these the relevant policies, `{schema}`, `{schema}.*`,
    * `{schema}.*.*` <br>
    * IF rename the TABLE, Need to rename these the relevant policies, `{schema}.*`, `{schema}.*.*`
    * <br>
    * IF rename the COLUMN, Only need to rename `{schema}.*.*` <br>
    */
-  private void doRenameMetadataObject(
-      AuthorizationMetadataObject AuthorizationMetadataObject,
-      AuthorizationMetadataObject newAuthMetadataObject) {
-    switch (newAuthMetadataObject.metadataObjectType()) {
-      case SCHEMA:
-        doRenameSchemaMetadataObject(AuthorizationMetadataObject, newAuthMetadataObject);
-        break;
-      case TABLE:
-        doRenameTableMetadataObject(AuthorizationMetadataObject, newAuthMetadataObject);
-        break;
-      case COLUMN:
-        doRenameColumnMetadataObject(AuthorizationMetadataObject, newAuthMetadataObject);
-        break;
-      case FILESET:
-        // do nothing when fileset is renamed
-        break;
-      default:
-        throw new IllegalArgumentException(
-            "Unsupported metadata object type: " + AuthorizationMetadataObject.type());
-    }
-  }
+  protected abstract void doRenameMetadataObject(
+      AuthorizationMetadataObject authzMetadataObject,
+      AuthorizationMetadataObject newAuthzMetadataObject);
 
-  /**
-   * Rename the SCHEMA, Need to rename these the relevant policies, `{schema}`, `{schema}.*`,
-   * `{schema}.*.*` <br>
-   */
-  private void doRenameSchemaMetadataObject(
-      AuthorizationMetadataObject AuthorizationMetadataObject,
-      AuthorizationMetadataObject newAuthorizationMetadataObject) {
-    List<String> oldMetadataNames = new ArrayList<>();
-    List<String> newMetadataNames = new ArrayList<>();
-    List<Map<String, String>> loop =
-        ImmutableList.of(
-            ImmutableMap.of(
-                AuthorizationMetadataObject.names().get(0),
-                newAuthorizationMetadataObject.names().get(0)),
-            ImmutableMap.of(RangerHelper.RESOURCE_ALL, RangerHelper.RESOURCE_ALL),
-            ImmutableMap.of(RangerHelper.RESOURCE_ALL, RangerHelper.RESOURCE_ALL));
-    for (Map<String, String> mapName : loop) {
-      oldMetadataNames.add(mapName.keySet().stream().findFirst().get());
-      newMetadataNames.add(mapName.values().stream().findFirst().get());
-      updatePolicyByMetadataObject(MetadataObject.Type.SCHEMA, oldMetadataNames, newMetadataNames);
-    }
-  }
-
-  /**
-   * Rename the TABLE, Need to rename these the relevant policies, `*.{table}`, `*.{table}.{column}`
-   * <br>
-   */
-  private void doRenameTableMetadataObject(
-      AuthorizationMetadataObject AuthorizationMetadataObject,
-      AuthorizationMetadataObject newAuthorizationMetadataObject) {
-    List<String> oldMetadataNames = new ArrayList<>();
-    List<String> newMetadataNames = new ArrayList<>();
-    List<Map<String, MetadataObject.Type>> loop =
-        ImmutableList.of(
-            ImmutableMap.of(AuthorizationMetadataObject.names().get(0), MetadataObject.Type.SCHEMA),
-            ImmutableMap.of(AuthorizationMetadataObject.names().get(1), MetadataObject.Type.TABLE),
-            ImmutableMap.of(RangerHelper.RESOURCE_ALL, MetadataObject.Type.COLUMN));
-    for (Map<String, MetadataObject.Type> nameAndType : loop) {
-      oldMetadataNames.add(nameAndType.keySet().stream().findFirst().get());
-      if (nameAndType.containsValue(MetadataObject.Type.SCHEMA)) {
-        newMetadataNames.add(newAuthorizationMetadataObject.names().get(0));
-        // Skip update the schema name operation
-        continue;
-      } else if (nameAndType.containsValue(MetadataObject.Type.TABLE)) {
-        newMetadataNames.add(newAuthorizationMetadataObject.names().get(1));
-      } else if (nameAndType.containsValue(MetadataObject.Type.COLUMN)) {
-        newMetadataNames.add(RangerHelper.RESOURCE_ALL);
-      }
-      updatePolicyByMetadataObject(MetadataObject.Type.TABLE, oldMetadataNames, newMetadataNames);
-    }
-  }
-
-  /** rename the COLUMN, Only need to rename `*.*.{column}` <br> */
-  private void doRenameColumnMetadataObject(
-      AuthorizationMetadataObject AuthorizationMetadataObject,
-      AuthorizationMetadataObject newAuthorizationMetadataObject) {
-    List<String> oldMetadataNames = new ArrayList<>();
-    List<String> newMetadataNames = new ArrayList<>();
-    List<Map<String, MetadataObject.Type>> loop =
-        ImmutableList.of(
-            ImmutableMap.of(AuthorizationMetadataObject.names().get(0), MetadataObject.Type.SCHEMA),
-            ImmutableMap.of(AuthorizationMetadataObject.names().get(1), MetadataObject.Type.TABLE),
-            ImmutableMap.of(
-                AuthorizationMetadataObject.names().get(2), MetadataObject.Type.COLUMN));
-    for (Map<String, MetadataObject.Type> nameAndType : loop) {
-      oldMetadataNames.add(nameAndType.keySet().stream().findFirst().get());
-      if (nameAndType.containsValue(MetadataObject.Type.SCHEMA)) {
-        newMetadataNames.add(newAuthorizationMetadataObject.names().get(0));
-        // Skip update the schema name operation
-        continue;
-      } else if (nameAndType.containsValue(MetadataObject.Type.TABLE)) {
-        newMetadataNames.add(newAuthorizationMetadataObject.names().get(1));
-        // Skip update the table name operation
-        continue;
-      } else if (nameAndType.containsValue(MetadataObject.Type.COLUMN)) {
-        newMetadataNames.add(newAuthorizationMetadataObject.names().get(2));
-      }
-      updatePolicyByMetadataObject(MetadataObject.Type.COLUMN, oldMetadataNames, newMetadataNames);
-    }
-  }
+  protected abstract void doRemoveMetadataObject(AuthorizationMetadataObject authzMetadataObject);
 
   /**
    * Remove the policy by the metadata object names. <br>
    *
-   * @param metadataNames The metadata object names.
+   * @param authzMetadataObject The authorization metadata object.
    */
-  private void removePolicyByMetadataObject(List<String> metadataNames) {
-    List<RangerPolicy> policies = rangerHelper.wildcardSearchPolies(metadataNames);
-    Map<String, String> preciseFilters = new HashMap<>();
-    for (int i = 0; i < metadataNames.size(); i++) {
-      preciseFilters.put(rangerHelper.policyResourceDefines.get(i), metadataNames.get(i));
+  protected void removePolicyByMetadataObject(AuthorizationMetadataObject authzMetadataObject) {
+    RangerPolicy policy = findManagedPolicy(authzMetadataObject);
+    if (policy != null) {
+      rangerHelper.removeAllGravitinoManagedPolicyItem(policy);
     }
-    policies =
-        policies.stream()
-            .filter(
-                policy ->
-                    policy.getResources().entrySet().stream()
-                        .allMatch(
-                            entry ->
-                                preciseFilters.containsKey(entry.getKey())
-                                    && entry.getValue().getValues().size() == 1
-                                    && entry
-                                        .getValue()
-                                        .getValues()
-                                        .contains(preciseFilters.get(entry.getKey()))))
-            .collect(Collectors.toList());
-    policies.forEach(rangerHelper::removeAllGravitinoManagedPolicyItem);
-  }
-
-  private void updatePolicyByMetadataObject(
-      MetadataObject.Type operationType,
-      List<String> oldMetadataNames,
-      List<String> newMetadataNames) {
-    List<RangerPolicy> oldPolicies = rangerHelper.wildcardSearchPolies(oldMetadataNames);
-    List<RangerPolicy> existNewPolicies = rangerHelper.wildcardSearchPolies(newMetadataNames);
-    if (oldPolicies.isEmpty()) {
-      LOG.warn("Cannot find the Ranger policy for the metadata object({})!", oldMetadataNames);
-    }
-    if (!existNewPolicies.isEmpty()) {
-      LOG.warn("The Ranger policy for the metadata object({}) already exists!", newMetadataNames);
-    }
-    Map<MetadataObject.Type, Integer> operationTypeIndex =
-        ImmutableMap.of(
-            MetadataObject.Type.SCHEMA, 0,
-            MetadataObject.Type.TABLE, 1,
-            MetadataObject.Type.COLUMN, 2);
-    oldPolicies.stream()
-        .forEach(
-            policy -> {
-              try {
-                String policyName = policy.getName();
-                int index = operationTypeIndex.get(operationType);
-
-                // Update the policy name is following Gravitino's spec
-                if (policy
-                    .getName()
-                    .equals(AuthorizationSecurableObject.DOT_JOINER.join(oldMetadataNames))) {
-                  List<String> policyNames =
-                      Lists.newArrayList(
-                          AuthorizationSecurableObject.DOT_SPLITTER.splitToList(policyName));
-                  Preconditions.checkArgument(
-                      policyNames.size() >= oldMetadataNames.size(),
-                      String.format("The policy name(%s) is invalid!", policyName));
-                  if (policyNames.get(index).equals(RangerHelper.RESOURCE_ALL)) {
-                    // Doesn't need to rename the policy `*`
-                    return;
-                  }
-                  policyNames.set(index, newMetadataNames.get(index));
-                  policy.setName(AuthorizationSecurableObject.DOT_JOINER.join(policyNames));
-                }
-                // Update the policy resource name to new name
-                policy
-                    .getResources()
-                    .put(
-                        rangerHelper.policyResourceDefines.get(index),
-                        new RangerPolicy.RangerPolicyResource(newMetadataNames.get(index)));
-
-                boolean alreadyExist =
-                    existNewPolicies.stream()
-                        .anyMatch(
-                            existNewPolicy ->
-                                existNewPolicy.getName().equals(policy.getName())
-                                    || existNewPolicy.getResources().equals(policy.getResources()));
-                if (alreadyExist) {
-                  LOG.warn(
-                      "The Ranger policy for the metadata object({}) already exists!",
-                      newMetadataNames);
-                  return;
-                }
-
-                // Update the policy
-                rangerClient.updatePolicy(policy.getId(), policy);
-              } catch (RangerServiceException e) {
-                LOG.error("Failed to rename the policy {}!", policy);
-                throw new RuntimeException(e);
-              }
-            });
   }
 
   @Override
@@ -1138,6 +899,7 @@ public abstract class RangerAuthorizationPlugin
   /** Generate authorization securable object */
   public abstract AuthorizationSecurableObject generateAuthorizationSecurableObject(
       List<String> names,
+      String path,
       AuthorizationMetadataObject.Type type,
       Set<AuthorizationPrivilege> privileges);
 

--- a/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/RangerHadoopSQLMetadataObject.java
+++ b/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/RangerHadoopSQLMetadataObject.java
@@ -48,7 +48,7 @@ public class RangerHadoopSQLMetadataObject implements AuthorizationMetadataObjec
 
     public static Type fromMetadataType(MetadataObject.Type metadataType) {
       for (Type type : Type.values()) {
-        if (type.metadataObjectType() == metadataType) {
+        if (type.metadataType == metadataType) {
           return type;
         }
       }

--- a/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/RangerHelper.java
+++ b/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/RangerHelper.java
@@ -20,13 +20,10 @@ package org.apache.gravitino.authorization.ranger;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Sets;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.commons.lang.StringUtils;
-import org.apache.gravitino.authorization.AuthorizationMetadataObject;
 import org.apache.gravitino.authorization.AuthorizationPrivilege;
 import org.apache.gravitino.authorization.AuthorizationSecurableObject;
 import org.apache.gravitino.authorization.Owner;
@@ -37,7 +34,6 @@ import org.apache.ranger.RangerServiceException;
 import org.apache.ranger.plugin.model.RangerPolicy;
 import org.apache.ranger.plugin.model.RangerRole;
 import org.apache.ranger.plugin.util.GrantRevokeRoleRequest;
-import org.apache.ranger.plugin.util.SearchFilter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -89,7 +85,7 @@ public class RangerHelper {
    * @param policyItem The policy item to check
    * @throws AuthorizationPluginException If the policy item contains more than one access type
    */
-  void checkPolicyItemAccess(RangerPolicy.RangerPolicyItem policyItem)
+  public static void checkPolicyItemAccess(RangerPolicy.RangerPolicyItem policyItem)
       throws AuthorizationPluginException {
     if (!isGravitinoManagedPolicyItemAccess(policyItem)) {
       return;
@@ -169,94 +165,17 @@ public class RangerHelper {
             });
   }
 
-  /**
-   * Find the managed policies for the ranger securable object.
-   *
-   * @param metadataNames The metadata object names to find the managed policy.
-   * @return The managed policy for the metadata object.
-   */
-  public List<RangerPolicy> wildcardSearchPolies(List<String> metadataNames)
-      throws AuthorizationPluginException {
-    Map<String, String> searchFilters = new HashMap<>();
-    searchFilters.put(SearchFilter.SERVICE_NAME, rangerServiceName);
-    for (int i = 0; i < metadataNames.size(); i++) {
-      searchFilters.put(
-          SearchFilter.RESOURCE_PREFIX + policyResourceDefines.get(i), metadataNames.get(i));
-    }
-
-    try {
-      List<RangerPolicy> policies = rangerClient.findPolicies(searchFilters);
-      return policies;
-    } catch (RangerServiceException e) {
-      throw new AuthorizationPluginException(e, "Failed to find the policies in the Ranger");
-    }
-  }
-
-  /**
-   * Find the managed policy for the ranger securable object.
-   *
-   * @param AuthorizationMetadataObject The ranger securable object to find the managed policy.
-   * @return The managed policy for the metadata object.
-   */
-  public RangerPolicy findManagedPolicy(AuthorizationMetadataObject AuthorizationMetadataObject)
-      throws AuthorizationPluginException {
-    List<RangerPolicy> policies = wildcardSearchPolies(AuthorizationMetadataObject.names());
-    if (!policies.isEmpty()) {
-      /**
-       * Because Ranger doesn't support the precise search, Ranger will return the policy meets the
-       * wildcard(*,?) conditions, If you use `db.table` condition to search policy, the Ranger will
-       * match `db1.table1`, `db1.table2`, `db*.table*`, So we need to manually precisely filter
-       * this research results.
-       */
-      List<String> nsMetadataObj = AuthorizationMetadataObject.names();
-      Map<String, String> preciseFilters = new HashMap<>();
-      for (int i = 0; i < nsMetadataObj.size(); i++) {
-        preciseFilters.put(policyResourceDefines.get(i), nsMetadataObj.get(i));
-      }
-      policies =
-          policies.stream()
-              .filter(
-                  policy ->
-                      policy.getResources().entrySet().stream()
-                          .allMatch(
-                              entry ->
-                                  preciseFilters.containsKey(entry.getKey())
-                                      && entry.getValue().getValues().size() == 1
-                                      && entry
-                                          .getValue()
-                                          .getValues()
-                                          .contains(preciseFilters.get(entry.getKey()))))
-              .collect(Collectors.toList());
-    }
-    // Only return the policies that are managed by Gravitino.
-    if (policies.size() > 1) {
-      throw new AuthorizationPluginException("Each metadata object can have at most one policy.");
-    }
-
-    if (policies.isEmpty()) {
-      return null;
-    }
-
-    RangerPolicy policy = policies.get(0);
-    // Delegating Gravitino management policies cannot contain duplicate privilege
-    policy.getPolicyItems().forEach(this::checkPolicyItemAccess);
-    policy.getDenyPolicyItems().forEach(this::checkPolicyItemAccess);
-    policy.getRowFilterPolicyItems().forEach(this::checkPolicyItemAccess);
-    policy.getDataMaskPolicyItems().forEach(this::checkPolicyItemAccess);
-
-    return policy;
-  }
-
-  public boolean isGravitinoManagedPolicyItemAccess(RangerPolicy.RangerPolicyItem policyItem) {
+  public static boolean isGravitinoManagedPolicyItemAccess(
+      RangerPolicy.RangerPolicyItem policyItem) {
     return policyItem.getRoles().stream().anyMatch(role -> role.startsWith(GRAVITINO_ROLE_PREFIX));
   }
 
-  public boolean hasGravitinoManagedPolicyItem(RangerPolicy policy) {
+  public static boolean hasGravitinoManagedPolicyItem(RangerPolicy policy) {
     List<RangerPolicy.RangerPolicyItem> policyItems = policy.getPolicyItems();
     policyItems.addAll(policy.getDenyPolicyItems());
     policyItems.addAll(policy.getRowFilterPolicyItems());
     policyItems.addAll(policy.getDataMaskPolicyItems());
-    return policyItems.stream().anyMatch(this::isGravitinoManagedPolicyItemAccess);
+    return policyItems.stream().anyMatch(RangerHelper::isGravitinoManagedPolicyItemAccess);
   }
 
   public void removeAllGravitinoManagedPolicyItem(RangerPolicy policy) {
@@ -277,7 +196,14 @@ public class RangerHelper {
           policy.getDataMaskPolicyItems().stream()
               .filter(item -> !isGravitinoManagedPolicyItemAccess(item))
               .collect(Collectors.toList()));
-      rangerClient.updatePolicy(policy.getId(), policy);
+      if (policy.getPolicyItems().isEmpty()
+          && policy.getDenyPolicyItems().isEmpty()
+          && policy.getRowFilterPolicyItems().isEmpty()
+          && policy.getDataMaskPolicyItems().isEmpty()) {
+        rangerClient.deletePolicy(policy.getId());
+      } else {
+        rangerClient.updatePolicy(policy.getId(), policy);
+      }
     } catch (RangerServiceException e) {
       LOG.error("Failed to update the policy {}!", policy);
       throw new RuntimeException(e);
@@ -383,7 +309,7 @@ public class RangerHelper {
                                     });
                           });
                 })
-            .filter(this::isGravitinoManagedPolicyItemAccess)
+            .filter(RangerHelper::isGravitinoManagedPolicyItemAccess)
             .collect(Collectors.toList());
     // Add or remove the owner in the policy item
     matchPolicyItems.forEach(

--- a/authorizations/authorization-ranger/src/test/java/org/apache/gravitino/authorization/ranger/integration/test/RangerAuthorizationHDFSPluginIT.java
+++ b/authorizations/authorization-ranger/src/test/java/org/apache/gravitino/authorization/ranger/integration/test/RangerAuthorizationHDFSPluginIT.java
@@ -18,22 +18,28 @@
  */
 package org.apache.gravitino.authorization.ranger.integration.test;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import java.util.List;
+import org.apache.gravitino.Entity;
 import org.apache.gravitino.MetadataObject;
 import org.apache.gravitino.MetadataObjects;
-import org.apache.gravitino.authorization.AuthorizationMetadataObject;
+import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.authorization.AuthorizationSecurableObject;
+import org.apache.gravitino.authorization.AuthorizationUtils;
 import org.apache.gravitino.authorization.Privileges;
 import org.apache.gravitino.authorization.SecurableObject;
 import org.apache.gravitino.authorization.SecurableObjects;
 import org.apache.gravitino.authorization.common.PathBasedMetadataObject;
+import org.apache.gravitino.authorization.common.PathBasedSecurableObject;
 import org.apache.gravitino.authorization.ranger.RangerAuthorizationPlugin;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 @Tag("gravitino-docker-test")
 public class RangerAuthorizationHDFSPluginIT {
@@ -51,121 +57,198 @@ public class RangerAuthorizationHDFSPluginIT {
     RangerITEnv.cleanup();
   }
 
+  public static void withMockedAuthorizationUtils(Runnable testCode) {
+    try (MockedStatic<AuthorizationUtils> authzUtilsMockedStatic =
+        Mockito.mockStatic(AuthorizationUtils.class)) {
+      authzUtilsMockedStatic
+          .when(
+              () ->
+                  AuthorizationUtils.getMetadataObjectLocation(
+                      Mockito.any(NameIdentifier.class), Mockito.any(Entity.EntityType.class)))
+          .thenReturn(ImmutableList.of("/test"));
+      testCode.run();
+    }
+  }
+
   @Test
   public void testTranslateMetadataObject() {
-    MetadataObject metalake =
-        MetadataObjects.parse(String.format("metalake1"), MetadataObject.Type.METALAKE);
-    Assertions.assertEquals(
-        PathBasedMetadataObject.Type.PATH,
-        rangerAuthPlugin.translateMetadataObject(metalake).type());
+    withMockedAuthorizationUtils(
+        () -> {
+          MetadataObject metalake =
+              MetadataObjects.parse(String.format("metalake1"), MetadataObject.Type.METALAKE);
+          rangerAuthPlugin
+              .translateMetadataObject(metalake)
+              .forEach(
+                  securableObject -> {
+                    PathBasedMetadataObject pathBasedMetadataObject =
+                        (PathBasedMetadataObject) securableObject;
+                    Assertions.assertEquals(
+                        metalake.fullName(), pathBasedMetadataObject.fullName());
+                    Assertions.assertEquals(
+                        PathBasedMetadataObject.Type.PATH, pathBasedMetadataObject.type());
+                    Assertions.assertEquals("/test", pathBasedMetadataObject.path());
+                  });
 
-    MetadataObject catalog =
-        MetadataObjects.parse(String.format("catalog1"), MetadataObject.Type.CATALOG);
-    Assertions.assertEquals(
-        PathBasedMetadataObject.Type.PATH,
-        rangerAuthPlugin.translateMetadataObject(catalog).type());
+          MetadataObject catalog =
+              MetadataObjects.parse(String.format("catalog1"), MetadataObject.Type.CATALOG);
+          rangerAuthPlugin
+              .translateMetadataObject(catalog)
+              .forEach(
+                  securableObject -> {
+                    PathBasedMetadataObject pathBasedMetadataObject =
+                        (PathBasedMetadataObject) securableObject;
+                    Assertions.assertEquals(catalog.fullName(), pathBasedMetadataObject.fullName());
+                    Assertions.assertEquals(
+                        PathBasedMetadataObject.Type.PATH, pathBasedMetadataObject.type());
+                    Assertions.assertEquals("/test", pathBasedMetadataObject.path());
+                  });
 
-    MetadataObject schema =
-        MetadataObjects.parse(String.format("catalog1.schema1"), MetadataObject.Type.SCHEMA);
-    Assertions.assertEquals(
-        PathBasedMetadataObject.Type.PATH, rangerAuthPlugin.translateMetadataObject(schema).type());
+          MetadataObject schema =
+              MetadataObjects.parse(String.format("catalog1.schema1"), MetadataObject.Type.SCHEMA);
+          rangerAuthPlugin
+              .translateMetadataObject(schema)
+              .forEach(
+                  securableObject -> {
+                    PathBasedMetadataObject pathBasedMetadataObject =
+                        (PathBasedMetadataObject) securableObject;
+                    Assertions.assertEquals(schema.fullName(), pathBasedMetadataObject.fullName());
+                    Assertions.assertEquals(
+                        PathBasedMetadataObject.Type.PATH, pathBasedMetadataObject.type());
+                    Assertions.assertEquals("/test", pathBasedMetadataObject.path());
+                  });
 
-    MetadataObject table =
-        MetadataObjects.parse(String.format("catalog1.schema1.tab1"), MetadataObject.Type.TABLE);
-    Assertions.assertThrows(
-        IllegalArgumentException.class, () -> rangerAuthPlugin.translateMetadataObject(table));
+          MetadataObject table =
+              MetadataObjects.parse(
+                  String.format("catalog1.schema1.tab1"), MetadataObject.Type.TABLE);
+          rangerAuthPlugin
+              .translateMetadataObject(table)
+              .forEach(
+                  securableObject -> {
+                    PathBasedMetadataObject pathBasedMetadataObject =
+                        (PathBasedMetadataObject) securableObject;
+                    Assertions.assertEquals(table.fullName(), pathBasedMetadataObject.fullName());
+                    Assertions.assertEquals(
+                        PathBasedMetadataObject.Type.PATH, securableObject.type());
+                    Assertions.assertEquals("/test", pathBasedMetadataObject.path());
+                  });
 
-    MetadataObject fileset =
-        MetadataObjects.parse(
-            String.format("catalog1.schema1.fileset1"), MetadataObject.Type.FILESET);
-    AuthorizationMetadataObject rangerFileset = rangerAuthPlugin.translateMetadataObject(fileset);
-    Assertions.assertEquals(1, rangerFileset.names().size());
-    Assertions.assertEquals("/test", rangerFileset.fullName());
-    Assertions.assertEquals(PathBasedMetadataObject.Type.PATH, rangerFileset.type());
+          MetadataObject fileset =
+              MetadataObjects.parse(
+                  String.format("catalog1.schema1.fileset1"), MetadataObject.Type.FILESET);
+          rangerAuthPlugin
+              .translateMetadataObject(fileset)
+              .forEach(
+                  securableObject -> {
+                    PathBasedMetadataObject pathBasedMetadataObject =
+                        (PathBasedMetadataObject) securableObject;
+                    Assertions.assertEquals(fileset.fullName(), pathBasedMetadataObject.fullName());
+                    Assertions.assertEquals(
+                        PathBasedMetadataObject.Type.PATH, securableObject.type());
+                    Assertions.assertEquals("/test", pathBasedMetadataObject.path());
+                  });
+        });
   }
 
   @Test
   public void testTranslatePrivilege() {
-    SecurableObject filesetInMetalake =
-        SecurableObjects.parse(
-            String.format("metalake1"),
-            MetadataObject.Type.METALAKE,
-            Lists.newArrayList(
-                Privileges.CreateFileset.allow(),
-                Privileges.ReadFileset.allow(),
-                Privileges.WriteFileset.allow()));
-    List<AuthorizationSecurableObject> filesetInMetalake1 =
-        rangerAuthPlugin.translatePrivilege(filesetInMetalake);
-    Assertions.assertEquals(0, filesetInMetalake1.size());
+    withMockedAuthorizationUtils(
+        () -> {
+          SecurableObject filesetInMetalake =
+              SecurableObjects.parse(
+                  String.format("metalake1"),
+                  MetadataObject.Type.METALAKE,
+                  Lists.newArrayList(
+                      Privileges.CreateFileset.allow(),
+                      Privileges.ReadFileset.allow(),
+                      Privileges.WriteFileset.allow()));
+          List<AuthorizationSecurableObject> filesetInMetalake1 =
+              rangerAuthPlugin.translatePrivilege(filesetInMetalake);
+          Assertions.assertEquals(0, filesetInMetalake1.size());
 
-    SecurableObject filesetInCatalog =
-        SecurableObjects.parse(
-            String.format("catalog1"),
-            MetadataObject.Type.CATALOG,
-            Lists.newArrayList(
-                Privileges.CreateFileset.allow(),
-                Privileges.ReadFileset.allow(),
-                Privileges.WriteFileset.allow()));
-    List<AuthorizationSecurableObject> filesetInCatalog1 =
-        rangerAuthPlugin.translatePrivilege(filesetInCatalog);
-    Assertions.assertEquals(0, filesetInCatalog1.size());
+          SecurableObject filesetInCatalog =
+              SecurableObjects.parse(
+                  String.format("catalog1"),
+                  MetadataObject.Type.CATALOG,
+                  Lists.newArrayList(
+                      Privileges.CreateFileset.allow(),
+                      Privileges.ReadFileset.allow(),
+                      Privileges.WriteFileset.allow()));
+          List<AuthorizationSecurableObject> filesetInCatalog1 =
+              rangerAuthPlugin.translatePrivilege(filesetInCatalog);
+          Assertions.assertEquals(0, filesetInCatalog1.size());
 
-    SecurableObject filesetInSchema =
-        SecurableObjects.parse(
-            String.format("catalog1.schema1"),
-            MetadataObject.Type.SCHEMA,
-            Lists.newArrayList(
-                Privileges.CreateFileset.allow(),
-                Privileges.ReadFileset.allow(),
-                Privileges.WriteFileset.allow()));
-    List<AuthorizationSecurableObject> filesetInSchema1 =
-        rangerAuthPlugin.translatePrivilege(filesetInSchema);
-    Assertions.assertEquals(0, filesetInSchema1.size());
+          SecurableObject filesetInSchema =
+              SecurableObjects.parse(
+                  String.format("catalog1.schema1"),
+                  MetadataObject.Type.SCHEMA,
+                  Lists.newArrayList(
+                      Privileges.CreateFileset.allow(),
+                      Privileges.ReadFileset.allow(),
+                      Privileges.WriteFileset.allow()));
+          List<AuthorizationSecurableObject> filesetInSchema1 =
+              rangerAuthPlugin.translatePrivilege(filesetInSchema);
+          Assertions.assertEquals(0, filesetInSchema1.size());
 
-    SecurableObject filesetInFileset =
-        SecurableObjects.parse(
-            String.format("catalog1.schema1.fileset1"),
-            MetadataObject.Type.FILESET,
-            Lists.newArrayList(
-                Privileges.CreateFileset.allow(),
-                Privileges.ReadFileset.allow(),
-                Privileges.WriteFileset.allow()));
-    List<AuthorizationSecurableObject> filesetInFileset1 =
-        rangerAuthPlugin.translatePrivilege(filesetInFileset);
-    Assertions.assertEquals(2, filesetInFileset1.size());
+          SecurableObject filesetInFileset =
+              SecurableObjects.parse(
+                  String.format("catalog1.schema1.fileset1"),
+                  MetadataObject.Type.FILESET,
+                  Lists.newArrayList(
+                      Privileges.CreateFileset.allow(),
+                      Privileges.ReadFileset.allow(),
+                      Privileges.WriteFileset.allow()));
+          List<AuthorizationSecurableObject> filesetInFileset1 =
+              rangerAuthPlugin.translatePrivilege(filesetInFileset);
+          Assertions.assertEquals(2, filesetInFileset1.size());
 
-    filesetInFileset1.forEach(
-        securableObject -> {
-          Assertions.assertEquals(PathBasedMetadataObject.Type.PATH, securableObject.type());
-          Assertions.assertEquals("/test", securableObject.fullName());
-          Assertions.assertEquals(2, securableObject.privileges().size());
+          filesetInFileset1.forEach(
+              securableObject -> {
+                PathBasedSecurableObject pathBasedSecurableObject =
+                    (PathBasedSecurableObject) securableObject;
+                Assertions.assertEquals(
+                    PathBasedMetadataObject.Type.PATH, pathBasedSecurableObject.type());
+                Assertions.assertEquals("/test", pathBasedSecurableObject.path());
+                Assertions.assertEquals(2, pathBasedSecurableObject.privileges().size());
+              });
         });
   }
 
   @Test
   public void testTranslateOwner() {
-    MetadataObject metalake =
-        MetadataObjects.parse(String.format("metalake1"), MetadataObject.Type.METALAKE);
-    List<AuthorizationSecurableObject> metalakeOwner = rangerAuthPlugin.translateOwner(metalake);
-    Assertions.assertEquals(0, metalakeOwner.size());
+    withMockedAuthorizationUtils(
+        () -> {
+          MetadataObject metalake =
+              MetadataObjects.parse(String.format("metalake1"), MetadataObject.Type.METALAKE);
+          List<AuthorizationSecurableObject> metalakeOwner =
+              rangerAuthPlugin.translateOwner(metalake);
+          Assertions.assertEquals(0, metalakeOwner.size());
 
-    MetadataObject catalog =
-        MetadataObjects.parse(String.format("catalog1"), MetadataObject.Type.CATALOG);
-    List<AuthorizationSecurableObject> catalogOwner = rangerAuthPlugin.translateOwner(catalog);
-    Assertions.assertEquals(0, catalogOwner.size());
+          MetadataObject catalog =
+              MetadataObjects.parse(String.format("catalog1"), MetadataObject.Type.CATALOG);
+          List<AuthorizationSecurableObject> catalogOwner =
+              rangerAuthPlugin.translateOwner(catalog);
+          Assertions.assertEquals(0, catalogOwner.size());
 
-    MetadataObject schema =
-        MetadataObjects.parse(String.format("catalog1.schema1"), MetadataObject.Type.SCHEMA);
-    List<AuthorizationSecurableObject> schemaOwner = rangerAuthPlugin.translateOwner(schema);
-    Assertions.assertEquals(0, schemaOwner.size());
+          MetadataObject schema =
+              MetadataObjects.parse(String.format("catalog1.schema1"), MetadataObject.Type.SCHEMA);
+          List<AuthorizationSecurableObject> schemaOwner = rangerAuthPlugin.translateOwner(schema);
+          Assertions.assertEquals(0, schemaOwner.size());
 
-    MetadataObject fileset =
-        MetadataObjects.parse(
-            String.format("catalog1.schema1.fileset1"), MetadataObject.Type.FILESET);
-    List<AuthorizationSecurableObject> filesetOwner = rangerAuthPlugin.translateOwner(fileset);
-    Assertions.assertEquals(1, filesetOwner.size());
-    Assertions.assertEquals("/test", filesetOwner.get(0).fullName());
-    Assertions.assertEquals(PathBasedMetadataObject.Type.PATH, filesetOwner.get(0).type());
-    Assertions.assertEquals(3, filesetOwner.get(0).privileges().size());
+          MetadataObject fileset =
+              MetadataObjects.parse(
+                  String.format("catalog1.schema1.fileset1"), MetadataObject.Type.FILESET);
+          List<AuthorizationSecurableObject> filesetOwner =
+              rangerAuthPlugin.translateOwner(fileset);
+          filesetOwner.forEach(
+              authorizationSecurableObject -> {
+                PathBasedSecurableObject pathBasedSecurableObject =
+                    (PathBasedSecurableObject) authorizationSecurableObject;
+                Assertions.assertEquals(1, filesetOwner.size());
+                Assertions.assertEquals("/test", pathBasedSecurableObject.path());
+                Assertions.assertEquals(
+                    PathBasedMetadataObject.Type.PATH, pathBasedSecurableObject.type());
+                Assertions.assertEquals(3, pathBasedSecurableObject.privileges().size());
+              });
+        });
   }
 }

--- a/authorizations/authorization-ranger/src/test/java/org/apache/gravitino/authorization/ranger/integration/test/RangerAuthorizationPluginIT.java
+++ b/authorizations/authorization-ranger/src/test/java/org/apache/gravitino/authorization/ranger/integration/test/RangerAuthorizationPluginIT.java
@@ -58,32 +58,51 @@ public class RangerAuthorizationPluginIT {
   public void testTranslateMetadataObject() {
     MetadataObject metalake =
         MetadataObjects.parse(String.format("metalake1"), MetadataObject.Type.METALAKE);
-    AuthorizationMetadataObject rangerMetalake = rangerAuthPlugin.translateMetadataObject(metalake);
-    Assertions.assertEquals(1, rangerMetalake.names().size());
-    Assertions.assertEquals(RangerHelper.RESOURCE_ALL, rangerMetalake.names().get(0));
-    Assertions.assertEquals(RangerHadoopSQLMetadataObject.Type.SCHEMA, rangerMetalake.type());
+    List<AuthorizationMetadataObject> rangerMetalake =
+        rangerAuthPlugin.translateMetadataObject(metalake);
+    rangerMetalake.stream()
+        .forEach(
+            authz -> {
+              Assertions.assertEquals(1, authz.names().size());
+              Assertions.assertEquals(RangerHelper.RESOURCE_ALL, authz.names().get(0));
+              Assertions.assertEquals(RangerHadoopSQLMetadataObject.Type.SCHEMA, authz.type());
+            });
 
     MetadataObject catalog =
         MetadataObjects.parse(String.format("catalog1"), MetadataObject.Type.CATALOG);
-    AuthorizationMetadataObject rangerCatalog = rangerAuthPlugin.translateMetadataObject(catalog);
-    Assertions.assertEquals(1, rangerCatalog.names().size());
-    Assertions.assertEquals(RangerHelper.RESOURCE_ALL, rangerCatalog.names().get(0));
-    Assertions.assertEquals(RangerHadoopSQLMetadataObject.Type.SCHEMA, rangerCatalog.type());
+    List<AuthorizationMetadataObject> rangerCatalog =
+        rangerAuthPlugin.translateMetadataObject(catalog);
+    rangerCatalog.stream()
+        .forEach(
+            authz -> {
+              Assertions.assertEquals(1, authz.names().size());
+              Assertions.assertEquals(RangerHelper.RESOURCE_ALL, authz.names().get(0));
+              Assertions.assertEquals(RangerHadoopSQLMetadataObject.Type.SCHEMA, authz.type());
+            });
 
     MetadataObject schema =
         MetadataObjects.parse(String.format("catalog1.schema1"), MetadataObject.Type.SCHEMA);
-    AuthorizationMetadataObject rangerSchema = rangerAuthPlugin.translateMetadataObject(schema);
-    Assertions.assertEquals(1, rangerSchema.names().size());
-    Assertions.assertEquals("schema1", rangerSchema.names().get(0));
-    Assertions.assertEquals(RangerHadoopSQLMetadataObject.Type.SCHEMA, rangerSchema.type());
+    List<AuthorizationMetadataObject> rangerSchema =
+        rangerAuthPlugin.translateMetadataObject(schema);
+    rangerSchema.stream()
+        .forEach(
+            authz -> {
+              Assertions.assertEquals(1, authz.names().size());
+              Assertions.assertEquals("schema1", authz.names().get(0));
+              Assertions.assertEquals(RangerHadoopSQLMetadataObject.Type.SCHEMA, authz.type());
+            });
 
     MetadataObject table =
         MetadataObjects.parse(String.format("catalog1.schema1.tab1"), MetadataObject.Type.TABLE);
-    AuthorizationMetadataObject rangerTable = rangerAuthPlugin.translateMetadataObject(table);
-    Assertions.assertEquals(2, rangerTable.names().size());
-    Assertions.assertEquals("schema1", rangerTable.names().get(0));
-    Assertions.assertEquals("tab1", rangerTable.names().get(1));
-    Assertions.assertEquals(RangerHadoopSQLMetadataObject.Type.TABLE, rangerTable.type());
+    List<AuthorizationMetadataObject> rangerTable = rangerAuthPlugin.translateMetadataObject(table);
+    rangerTable.stream()
+        .forEach(
+            authz -> {
+              Assertions.assertEquals(2, authz.names().size());
+              Assertions.assertEquals("schema1", authz.names().get(0));
+              Assertions.assertEquals("tab1", authz.names().get(1));
+              Assertions.assertEquals(RangerHadoopSQLMetadataObject.Type.TABLE, authz.type());
+            });
   }
 
   @Test

--- a/authorizations/authorization-ranger/src/test/java/org/apache/gravitino/authorization/ranger/integration/test/RangerBaseE2EIT.java
+++ b/authorizations/authorization-ranger/src/test/java/org/apache/gravitino/authorization/ranger/integration/test/RangerBaseE2EIT.java
@@ -170,8 +170,6 @@ public abstract class RangerBaseE2EIT extends BaseIT {
     metalake = loadMetalake;
   }
 
-  public abstract void createCatalog();
-
   protected static void waitForUpdatingPolicies() {
     // After Ranger authorization, Must wait a period of time for the Ranger Spark plugin to update
     // the policy Sleep time must be greater than the policy update interval
@@ -183,6 +181,10 @@ public abstract class RangerBaseE2EIT extends BaseIT {
       LOG.error("Failed to sleep", e);
     }
   }
+
+  protected abstract void createCatalog();
+
+  protected abstract String testUserName();
 
   protected abstract void checkTableAllPrivilegesExceptForCreating();
 
@@ -198,7 +200,7 @@ public abstract class RangerBaseE2EIT extends BaseIT {
 
   protected abstract void checkDeleteSQLWithWritePrivileges();
 
-  protected abstract void useCatalog() throws InterruptedException;
+  protected abstract void useCatalog();
 
   protected abstract void checkWithoutPrivileges();
 
@@ -206,7 +208,7 @@ public abstract class RangerBaseE2EIT extends BaseIT {
 
   // ISSUE-5947: can't rename a catalog or a metalake
   @Test
-  void testRenameMetalakeOrCatalog() {
+  protected void testRenameMetalakeOrCatalog() {
     Assertions.assertDoesNotThrow(
         () -> client.alterMetalake(metalakeName, MetalakeChange.rename("new_name")));
     Assertions.assertDoesNotThrow(
@@ -224,17 +226,28 @@ public abstract class RangerBaseE2EIT extends BaseIT {
     useCatalog();
 
     // First, fail to create the schema
-    Assertions.assertThrows(
-        AccessControlException.class, () -> sparkSession.sql(SQL_CREATE_SCHEMA));
+    Assertions.assertThrows(Exception.class, () -> sparkSession.sql(SQL_CREATE_SCHEMA));
+    Exception accessControlException =
+        Assertions.assertThrows(Exception.class, () -> sparkSession.sql(SQL_CREATE_SCHEMA));
+    Assertions.assertTrue(
+        accessControlException
+                .getMessage()
+                .contains(
+                    String.format(
+                        "Permission denied: user [%s] does not have [create] privilege",
+                        testUserName()))
+            || accessControlException
+                .getMessage()
+                .contains(
+                    String.format("Permission denied: user=%s, access=WRITE", testUserName())));
 
     // Second, grant the `CREATE_SCHEMA` role
-    String userName1 = System.getenv(HADOOP_USER_NAME);
     String roleName = currentFunName();
     SecurableObject securableObject =
         SecurableObjects.ofMetalake(
             metalakeName, Lists.newArrayList(Privileges.CreateSchema.allow()));
     metalake.createRole(roleName, Collections.emptyMap(), Lists.newArrayList(securableObject));
-    metalake.grantRolesToUser(Lists.newArrayList(roleName), userName1);
+    metalake.grantRolesToUser(Lists.newArrayList(roleName), testUserName());
     waitForUpdatingPolicies();
 
     // Third, succeed to create the schema
@@ -259,7 +272,7 @@ public abstract class RangerBaseE2EIT extends BaseIT {
         SecurableObjects.ofMetalake(
             metalakeName,
             Lists.newArrayList(Privileges.UseSchema.allow(), Privileges.CreateSchema.allow()));
-    String userName1 = System.getenv(HADOOP_USER_NAME);
+    String userName1 = testUserName();
     metalake.createRole(
         createSchemaRole, Collections.emptyMap(), Lists.newArrayList(securableObject));
     metalake.grantRolesToUser(Lists.newArrayList(createSchemaRole), userName1);
@@ -312,7 +325,7 @@ public abstract class RangerBaseE2EIT extends BaseIT {
                 Privileges.CreateTable.allow(),
                 Privileges.SelectTable.allow(),
                 Privileges.ModifyTable.allow()));
-    String userName1 = System.getenv(HADOOP_USER_NAME);
+    String userName1 = testUserName();
     metalake.createRole(readWriteRole, Collections.emptyMap(), Lists.newArrayList(securableObject));
     metalake.grantRolesToUser(Lists.newArrayList(readWriteRole), userName1);
     waitForUpdatingPolicies();
@@ -365,7 +378,7 @@ public abstract class RangerBaseE2EIT extends BaseIT {
                 Privileges.UseSchema.allow(),
                 Privileges.CreateSchema.allow(),
                 Privileges.CreateTable.allow()));
-    String userName1 = System.getenv(HADOOP_USER_NAME);
+    String userName1 = testUserName();
     metalake.createRole(roleName, Collections.emptyMap(), Lists.newArrayList(securableObject));
     metalake.grantRolesToUser(Lists.newArrayList(roleName), userName1);
     waitForUpdatingPolicies();
@@ -430,7 +443,7 @@ public abstract class RangerBaseE2EIT extends BaseIT {
                 Privileges.CreateSchema.allow(),
                 Privileges.CreateTable.allow(),
                 Privileges.SelectTable.allow()));
-    String userName1 = System.getenv(HADOOP_USER_NAME);
+    String userName1 = testUserName();
     metalake.createRole(readOnlyRole, Collections.emptyMap(), Lists.newArrayList(securableObject));
     metalake.grantRolesToUser(Lists.newArrayList(readOnlyRole), userName1);
     waitForUpdatingPolicies();
@@ -484,7 +497,7 @@ public abstract class RangerBaseE2EIT extends BaseIT {
                 Privileges.CreateSchema.allow(),
                 Privileges.CreateTable.allow(),
                 Privileges.ModifyTable.allow()));
-    String userName1 = System.getenv(HADOOP_USER_NAME);
+    String userName1 = testUserName();
     metalake.createRole(writeOnlyRole, Collections.emptyMap(), Lists.newArrayList(securableObject));
     metalake.grantRolesToUser(Lists.newArrayList(writeOnlyRole), userName1);
     waitForUpdatingPolicies();
@@ -555,7 +568,7 @@ public abstract class RangerBaseE2EIT extends BaseIT {
     metalake.createRole(roleName, Collections.emptyMap(), Lists.newArrayList(securableObject));
 
     // Granted this role to the spark execution user `HADOOP_USER_NAME`
-    String userName1 = System.getenv(HADOOP_USER_NAME);
+    String userName1 = testUserName();
     metalake.grantRolesToUser(Lists.newArrayList(roleName), userName1);
 
     waitForUpdatingPolicies();
@@ -591,7 +604,7 @@ public abstract class RangerBaseE2EIT extends BaseIT {
     metalake.createRole(roleName, Collections.emptyMap(), Lists.newArrayList(securableObject));
 
     // Granted this role to the spark execution user `HADOOP_USER_NAME`
-    String userName1 = System.getenv(HADOOP_USER_NAME);
+    String userName1 = testUserName();
     metalake.grantRolesToUser(Lists.newArrayList(roleName), userName1);
     waitForUpdatingPolicies();
 
@@ -637,7 +650,7 @@ public abstract class RangerBaseE2EIT extends BaseIT {
     metalake.createRole(roleName, Collections.emptyMap(), Lists.newArrayList(securableObject));
 
     // Granted this role to the spark execution user `HADOOP_USER_NAME`
-    String userName1 = System.getenv(HADOOP_USER_NAME);
+    String userName1 = testUserName();
     metalake.grantRolesToUser(Lists.newArrayList(roleName), userName1);
     waitForUpdatingPolicies();
 
@@ -696,7 +709,7 @@ public abstract class RangerBaseE2EIT extends BaseIT {
                 Privileges.ModifyTable.allow()));
     metalake.createRole(roleName, Collections.emptyMap(), Lists.newArrayList(securableObject));
     // Granted this role to the spark execution user `HADOOP_USER_NAME`
-    String userName1 = System.getenv(HADOOP_USER_NAME);
+    String userName1 = testUserName();
     metalake.grantRolesToUser(Lists.newArrayList(roleName), userName1);
 
     waitForUpdatingPolicies();
@@ -734,7 +747,7 @@ public abstract class RangerBaseE2EIT extends BaseIT {
                 Privileges.ModifyTable.allow()));
     metalake.createRole(roleName, Collections.emptyMap(), Lists.newArrayList(securableObject));
     // Granted this role to the spark execution user `HADOOP_USER_NAME`
-    String userName1 = System.getenv(HADOOP_USER_NAME);
+    String userName1 = testUserName();
     metalake.grantRolesToUser(Lists.newArrayList(roleName), userName1);
 
     waitForUpdatingPolicies();
@@ -780,7 +793,7 @@ public abstract class RangerBaseE2EIT extends BaseIT {
                 Privileges.CreateSchema.allow(),
                 Privileges.CreateTable.allow(),
                 Privileges.ModifyTable.allow()));
-    String userName1 = System.getenv(HADOOP_USER_NAME);
+    String userName1 = testUserName();
     metalake.createRole(helperRole, Collections.emptyMap(), Lists.newArrayList(securableObject));
     metalake.grantRolesToUser(Lists.newArrayList(helperRole), userName1);
     waitForUpdatingPolicies();
@@ -880,7 +893,7 @@ public abstract class RangerBaseE2EIT extends BaseIT {
   }
 
   @Test
-  void testAllowUseSchemaPrivilege() throws InterruptedException {
+  protected void testAllowUseSchemaPrivilege() throws InterruptedException {
     // Choose a catalog
     useCatalog();
 
@@ -894,7 +907,7 @@ public abstract class RangerBaseE2EIT extends BaseIT {
     metalake.createRole(roleName, Collections.emptyMap(), Lists.newArrayList(securableObject));
 
     // Granted this role to the spark execution user `HADOOP_USER_NAME`
-    String userName1 = System.getenv(HADOOP_USER_NAME);
+    String userName1 = testUserName();
     metalake.grantRolesToUser(Lists.newArrayList(roleName), userName1);
     waitForUpdatingPolicies();
 
@@ -967,7 +980,7 @@ public abstract class RangerBaseE2EIT extends BaseIT {
         roleName, Collections.emptyMap(), Lists.newArrayList(allowObject, denyObject));
 
     // Granted this role to the spark execution user `HADOOP_USER_NAME`
-    String userName1 = System.getenv(HADOOP_USER_NAME);
+    String userName1 = testUserName();
     metalake.grantRolesToUser(Lists.newArrayList(roleName), userName1);
     waitForUpdatingPolicies();
 
@@ -993,7 +1006,7 @@ public abstract class RangerBaseE2EIT extends BaseIT {
         roleName, Collections.emptyMap(), Lists.newArrayList(allowObject, denyObject));
 
     // Granted this role to the spark execution user `HADOOP_USER_NAME`
-    userName1 = System.getenv(HADOOP_USER_NAME);
+    userName1 = testUserName();
     metalake.grantRolesToUser(Lists.newArrayList(roleName), userName1);
 
     waitForUpdatingPolicies();
@@ -1027,7 +1040,7 @@ public abstract class RangerBaseE2EIT extends BaseIT {
         AccessControlException.class, () -> sparkSession.sql(SQL_CREATE_SCHEMA));
 
     // Granted this role to the spark execution user `HADOOP_USER_NAME`
-    String userName1 = System.getenv(HADOOP_USER_NAME);
+    String userName1 = testUserName();
     metalake.grantRolesToUser(Lists.newArrayList(roleName), userName1);
 
     waitForUpdatingPolicies();

--- a/authorizations/authorization-ranger/src/test/java/org/apache/gravitino/authorization/ranger/integration/test/RangerFilesetIT.java
+++ b/authorizations/authorization-ranger/src/test/java/org/apache/gravitino/authorization/ranger/integration/test/RangerFilesetIT.java
@@ -373,8 +373,7 @@ public class RangerFilesetIT extends BaseIT {
 
     catalog.asFilesetCatalog().dropFileset(NameIdentifier.of(schemaName, fileset.name()));
     policies = rangerClient.getPoliciesInService(RangerITEnv.RANGER_HDFS_REPO_NAME);
-    Assertions.assertEquals(1, policies.size());
-    Assertions.assertEquals(3, policies.get(0).getPolicyItems().size());
+    Assertions.assertEquals(0, policies.size());
   }
 
   @Test

--- a/authorizations/authorization-ranger/src/test/java/org/apache/gravitino/authorization/ranger/integration/test/RangerHiveE2EIT.java
+++ b/authorizations/authorization-ranger/src/test/java/org/apache/gravitino/authorization/ranger/integration/test/RangerHiveE2EIT.java
@@ -110,8 +110,13 @@ public class RangerHiveE2EIT extends RangerBaseE2EIT {
   }
 
   @Override
-  protected void useCatalog() throws InterruptedException {
+  protected void useCatalog() {
     // Do nothing, default catalog is ok for Hive.
+  }
+
+  @Override
+  protected String testUserName() {
+    return System.getenv(HADOOP_USER_NAME);
   }
 
   @Override

--- a/authorizations/authorization-ranger/src/test/java/org/apache/gravitino/authorization/ranger/integration/test/RangerHiveIT.java
+++ b/authorizations/authorization-ranger/src/test/java/org/apache/gravitino/authorization/ranger/integration/test/RangerHiveIT.java
@@ -343,18 +343,19 @@ public class RangerHiveIT {
     AuthorizationSecurableObject rangerSecurableObject =
         rangerAuthHivePlugin.generateAuthorizationSecurableObject(
             ImmutableList.of(String.format("%s3", dbName), "tab1"),
+            "",
             RangerHadoopSQLMetadataObject.Type.TABLE,
             ImmutableSet.of(
                 new RangerPrivileges.RangerHivePrivilegeImpl(
                     RangerPrivileges.RangerHadoopSQLPrivilege.ALL, Privilege.Condition.ALLOW)));
-    Assertions.assertNull(rangerHelper.findManagedPolicy(rangerSecurableObject));
+    Assertions.assertNull(rangerAuthHivePlugin.findManagedPolicy(rangerSecurableObject));
 
     // Add a policy for `db3.tab1`
     createHivePolicy(
         Lists.newArrayList(String.format("%s3", dbName), "tab1"),
         GravitinoITUtils.genRandomName(currentFunName()));
     // findManagedPolicy function use precise search, so return not null
-    Assertions.assertNotNull(rangerHelper.findManagedPolicy(rangerSecurableObject));
+    Assertions.assertNotNull(rangerAuthHivePlugin.findManagedPolicy(rangerSecurableObject));
   }
 
   @Test
@@ -461,7 +462,7 @@ public class RangerHiveIT {
   }
 
   static boolean deleteHivePolicy(RangerHadoopSQLSecurableObject rangerSecurableObject) {
-    RangerPolicy policy = rangerHelper.findManagedPolicy(rangerSecurableObject);
+    RangerPolicy policy = rangerAuthHivePlugin.findManagedPolicy(rangerSecurableObject);
     if (policy != null) {
       try {
         RangerITEnv.rangerClient.deletePolicy(policy.getId());
@@ -890,18 +891,21 @@ public class RangerHiveIT {
             .build();
     Assertions.assertTrue(rangerAuthHivePlugin.onRoleCreated(role));
     assertFindManagedPolicyItems(role, true);
+    Assertions.assertEquals(
+        6, rangerClient.getPoliciesInService(RangerITEnv.RANGER_HIVE_REPO_NAME).size());
 
     Assertions.assertTrue(
-        rangerAuthHivePlugin.onMetadataUpdated(MetadataObjectChange.remove(metadataObject)));
+        rangerAuthHivePlugin.onMetadataUpdated(
+            MetadataObjectChange.remove(metadataObject, ImmutableList.of())));
     assertFindManagedPolicyItems(role, false);
 
     Assertions.assertEquals(
-        6, rangerClient.getPoliciesInService(RangerITEnv.RANGER_HIVE_REPO_NAME).size());
+        4, rangerClient.getPoliciesInService(RangerITEnv.RANGER_HIVE_REPO_NAME).size());
     rangerClient
         .getPoliciesInService(RangerITEnv.RANGER_HIVE_REPO_NAME)
         .forEach(
             policy -> {
-              Assertions.assertFalse(rangerHelper.hasGravitinoManagedPolicyItem(policy));
+              Assertions.assertFalse(RangerHelper.hasGravitinoManagedPolicyItem(policy));
             });
   }
 
@@ -937,7 +941,8 @@ public class RangerHiveIT {
         4, rangerClient.getPoliciesInService(RangerITEnv.RANGER_HIVE_REPO_NAME).size());
 
     Assertions.assertTrue(
-        rangerAuthHivePlugin.onMetadataUpdated(MetadataObjectChange.remove(schemaObject)));
+        rangerAuthHivePlugin.onMetadataUpdated(
+            MetadataObjectChange.remove(schemaObject, ImmutableList.of())));
     RoleEntity roleVerify =
         RoleEntity.builder()
             .withId(1L)
@@ -947,7 +952,13 @@ public class RangerHiveIT {
             .build();
     assertFindManagedPolicyItems(roleVerify, false);
     Assertions.assertEquals(
-        4, rangerClient.getPoliciesInService(RangerITEnv.RANGER_HIVE_REPO_NAME).size());
+        2, rangerClient.getPoliciesInService(RangerITEnv.RANGER_HIVE_REPO_NAME).size());
+
+    Assertions.assertTrue(
+        rangerAuthHivePlugin.onMetadataUpdated(
+            MetadataObjectChange.remove(tableObject, ImmutableList.of())));
+    Assertions.assertEquals(
+        0, rangerClient.getPoliciesInService(RangerITEnv.RANGER_HIVE_REPO_NAME).size());
   }
 
   @Test
@@ -980,7 +991,8 @@ public class RangerHiveIT {
     assertFindManagedPolicyItems(role, true);
 
     Assertions.assertTrue(
-        rangerAuthHivePlugin.onMetadataUpdated(MetadataObjectChange.remove(tableObject)));
+        rangerAuthHivePlugin.onMetadataUpdated(
+            MetadataObjectChange.remove(tableObject, ImmutableList.of())));
     RoleEntity verifyScheamRole =
         RoleEntity.builder()
             .withId(1L)
@@ -998,7 +1010,7 @@ public class RangerHiveIT {
     assertFindManagedPolicyItems(verifyScheamRole, true);
     assertFindManagedPolicyItems(verifyTableRole, false);
     Assertions.assertEquals(
-        4, rangerClient.getPoliciesInService(RangerITEnv.RANGER_HIVE_REPO_NAME).size());
+        2, rangerClient.getPoliciesInService(RangerITEnv.RANGER_HIVE_REPO_NAME).size());
   }
 
   @Test
@@ -1247,7 +1259,7 @@ public class RangerHiveIT {
                     .map(
                         rangerSecurableObject -> {
                           LOG.info("rangerSecurableObject: " + rangerSecurableObject);
-                          return rangerHelper.findManagedPolicy(rangerSecurableObject);
+                          return rangerAuthHivePlugin.findManagedPolicy(rangerSecurableObject);
                         }))
         .filter(Objects::nonNull)
         .collect(Collectors.toList());

--- a/authorizations/authorization-ranger/src/test/java/org/apache/gravitino/authorization/ranger/integration/test/RangerITEnv.java
+++ b/authorizations/authorization-ranger/src/test/java/org/apache/gravitino/authorization/ranger/integration/test/RangerITEnv.java
@@ -19,7 +19,6 @@
 package org.apache.gravitino.authorization.ranger.integration.test;
 
 import static org.apache.gravitino.integration.test.container.RangerContainer.RANGER_SERVER_PORT;
-import static org.mockito.Mockito.doReturn;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -64,7 +63,7 @@ public class RangerITEnv {
   private static final String RANGER_HIVE_TYPE = "hive";
   public static final String RANGER_HDFS_REPO_NAME = "hdfsDev";
   private static final String RANGER_HDFS_TYPE = "hdfs";
-  protected static RangerClient rangerClient;
+  public static RangerClient rangerClient;
   public static final String HADOOP_USER_NAME = "gravitino";
   private static volatile boolean initRangerService = false;
   private static final ContainerSuite containerSuite = ContainerSuite.getInstance();
@@ -139,7 +138,6 @@ public class RangerITEnv {
                     "HDFS",
                     RangerAuthorizationProperties.RANGER_SERVICE_NAME,
                     RangerITEnv.RANGER_HDFS_REPO_NAME)));
-    doReturn("/test").when(spyRangerAuthorizationHDFSPlugin).getLocationPath(Mockito.any());
     rangerAuthHDFSPlugin = spyRangerAuthorizationHDFSPlugin;
 
     rangerHelper =

--- a/authorizations/authorization-ranger/src/test/java/org/apache/gravitino/authorization/ranger/integration/test/RangerIcebergE2EIT.java
+++ b/authorizations/authorization-ranger/src/test/java/org/apache/gravitino/authorization/ranger/integration/test/RangerIcebergE2EIT.java
@@ -107,37 +107,40 @@ public class RangerIcebergE2EIT extends RangerBaseE2EIT {
   }
 
   @Override
-  protected void checkUpdateSQLWithReadWritePrivileges() {
+  protected String testUserName() {
+    return System.getenv(HADOOP_USER_NAME);
+  }
+
+  public void checkUpdateSQLWithReadWritePrivileges() {
     sparkSession.sql(SQL_UPDATE_TABLE);
   }
 
   @Override
-  protected void checkUpdateSQLWithReadPrivileges() {
+  public void checkUpdateSQLWithReadPrivileges() {
     Assertions.assertThrows(AccessControlException.class, () -> sparkSession.sql(SQL_UPDATE_TABLE));
   }
 
   @Override
-  protected void checkUpdateSQLWithWritePrivileges() {
+  public void checkUpdateSQLWithWritePrivileges() {
     Assertions.assertThrows(AccessControlException.class, () -> sparkSession.sql(SQL_UPDATE_TABLE));
   }
 
   @Override
-  protected void checkDeleteSQLWithReadWritePrivileges() {
+  public void checkDeleteSQLWithReadWritePrivileges() {
     sparkSession.sql(SQL_DELETE_TABLE);
   }
 
   @Override
-  protected void checkDeleteSQLWithReadPrivileges() {
+  public void checkDeleteSQLWithReadPrivileges() {
     Assertions.assertThrows(AccessControlException.class, () -> sparkSession.sql(SQL_DELETE_TABLE));
   }
 
   @Override
-  protected void checkDeleteSQLWithWritePrivileges() {
+  public void checkDeleteSQLWithWritePrivileges() {
     Assertions.assertThrows(AccessControlException.class, () -> sparkSession.sql(SQL_DELETE_TABLE));
   }
 
-  @Override
-  protected void checkWithoutPrivileges() {
+  public void checkWithoutPrivileges() {
     Assertions.assertThrows(AccessControlException.class, () -> sparkSession.sql(SQL_INSERT_TABLE));
     Assertions.assertThrows(
         AccessControlException.class, () -> sparkSession.sql(SQL_SELECT_TABLE).collectAsList());
@@ -151,8 +154,7 @@ public class RangerIcebergE2EIT extends RangerBaseE2EIT {
     Assertions.assertThrows(AccessControlException.class, () -> sparkSession.sql(SQL_UPDATE_TABLE));
   }
 
-  @Override
-  protected void testAlterTable() {
+  public void testAlterTable() {
     sparkSession.sql(SQL_ALTER_TABLE);
     sparkSession.sql(SQL_ALTER_TABLE_BACK);
   }
@@ -183,8 +185,7 @@ public class RangerIcebergE2EIT extends RangerBaseE2EIT {
     LOG.info("Catalog created: {}", catalog);
   }
 
-  @Override
-  protected void useCatalog() throws InterruptedException {
+  public void useCatalog() {
     String userName1 = System.getenv(HADOOP_USER_NAME);
     String roleName = currentFunName();
     SecurableObject securableObject =
@@ -198,7 +199,7 @@ public class RangerIcebergE2EIT extends RangerBaseE2EIT {
     waitForUpdatingPolicies();
   }
 
-  protected void checkTableAllPrivilegesExceptForCreating() {
+  public void checkTableAllPrivilegesExceptForCreating() {
     // - a. Succeed to insert data into the table
     sparkSession.sql(SQL_INSERT_TABLE);
 

--- a/authorizations/authorization-ranger/src/test/java/org/apache/gravitino/authorization/ranger/integration/test/RangerPaimonE2EIT.java
+++ b/authorizations/authorization-ranger/src/test/java/org/apache/gravitino/authorization/ranger/integration/test/RangerPaimonE2EIT.java
@@ -110,7 +110,12 @@ public class RangerPaimonE2EIT extends RangerBaseE2EIT {
   }
 
   @Override
-  protected void useCatalog() throws InterruptedException {
+  protected String testUserName() {
+    return System.getenv(HADOOP_USER_NAME);
+  }
+
+  @Override
+  protected void useCatalog() {
     String userName1 = System.getenv(HADOOP_USER_NAME);
     String roleName = currentFunName();
     SecurableObject securableObject =

--- a/catalogs/catalog-hive/src/test/java/org/apache/gravitino/catalog/hive/integration/test/CatalogHiveIT.java
+++ b/catalogs/catalog-hive/src/test/java/org/apache/gravitino/catalog/hive/integration/test/CatalogHiveIT.java
@@ -229,7 +229,14 @@ public class CatalogHiveIT extends BaseIT {
                 catalog.asSchemas().dropSchema(schema, true);
               }));
       Arrays.stream(metalake.listCatalogs())
-          .forEach((catalogName -> metalake.dropCatalog(catalogName, true)));
+          .forEach(
+              catalogName -> {
+                try {
+                  metalake.dropCatalog(catalogName, true);
+                } catch (Exception e) {
+                  // Ignore exception
+                }
+              });
       client.dropMetalake(metalakeName, true);
     }
     if (hiveClientPool != null) {

--- a/catalogs/catalog-hive/src/test/java/org/apache/gravitino/catalog/hive/integration/test/CatalogHiveIT.java
+++ b/catalogs/catalog-hive/src/test/java/org/apache/gravitino/catalog/hive/integration/test/CatalogHiveIT.java
@@ -231,11 +231,7 @@ public class CatalogHiveIT extends BaseIT {
       Arrays.stream(metalake.listCatalogs())
           .forEach(
               catalogName -> {
-                try {
-                  metalake.dropCatalog(catalogName, true);
-                } catch (Exception e) {
-                  // Ignore exception
-                }
+                metalake.dropCatalog(catalogName, true);
               });
       client.dropMetalake(metalakeName, true);
     }

--- a/catalogs/catalog-jdbc-postgresql/src/test/java/org/apache/gravitino/catalog/postgresql/integration/test/CatalogPostgreSqlIT.java
+++ b/catalogs/catalog-jdbc-postgresql/src/test/java/org/apache/gravitino/catalog/postgresql/integration/test/CatalogPostgreSqlIT.java
@@ -653,7 +653,7 @@ public class CatalogPostgreSqlIT extends BaseIT {
         });
   }
 
-  @Test
+  //  @Test TODO(mchades): https://github.com/apache/gravitino/issues/6134
   void testCreateAndLoadSchema() throws SQLException {
     String testSchemaName = "test";
 
@@ -682,7 +682,8 @@ public class CatalogPostgreSqlIT extends BaseIT {
     Assertions.assertTrue(catalog.asSchemas().dropSchema(testSchemaName2, false));
     createSchema(testSchemaName2);
     SupportsSchemas schemaOps = newCatalog.asSchemas();
-    Assertions.assertDoesNotThrow(() -> schemaOps.loadSchema(testSchemaName2));
+    Assertions.assertThrows(
+        UnsupportedOperationException.class, () -> schemaOps.loadSchema(testSchemaName2));
     // recovered by re-build the catalog
     Assertions.assertTrue(metalake.dropCatalog(newCatalogName, true));
     newCatalog = createCatalog(newCatalogName);

--- a/catalogs/catalog-jdbc-postgresql/src/test/java/org/apache/gravitino/catalog/postgresql/integration/test/CatalogPostgreSqlIT.java
+++ b/catalogs/catalog-jdbc-postgresql/src/test/java/org/apache/gravitino/catalog/postgresql/integration/test/CatalogPostgreSqlIT.java
@@ -682,8 +682,7 @@ public class CatalogPostgreSqlIT extends BaseIT {
     Assertions.assertTrue(catalog.asSchemas().dropSchema(testSchemaName2, false));
     createSchema(testSchemaName2);
     SupportsSchemas schemaOps = newCatalog.asSchemas();
-    Assertions.assertThrows(
-        UnsupportedOperationException.class, () -> schemaOps.loadSchema(testSchemaName2));
+    Assertions.assertDoesNotThrow(() -> schemaOps.loadSchema(testSchemaName2));
     // recovered by re-build the catalog
     Assertions.assertTrue(metalake.dropCatalog(newCatalogName, true));
     newCatalog = createCatalog(newCatalogName);

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -56,6 +56,7 @@ dependencies {
   testImplementation(libs.junit.jupiter.api)
   testImplementation(libs.junit.jupiter.params)
   testImplementation(libs.mockito.core)
+  testImplementation(libs.mockito.inline)
   testImplementation(libs.mysql.driver)
   testImplementation(libs.postgresql.driver)
   testImplementation(libs.testcontainers)

--- a/core/src/main/java/org/apache/gravitino/authorization/AuthorizationPrivilegesMappingProvider.java
+++ b/core/src/main/java/org/apache/gravitino/authorization/AuthorizationPrivilegesMappingProvider.java
@@ -77,7 +77,7 @@ public interface AuthorizationPrivilegesMappingProvider {
    * Translate the Gravitino metadata object to the underlying data source metadata object.
    *
    * @param metadataObject The Gravitino metadata object.
-   * @return The underlying data source metadata object.
+   * @return The underlying data source metadata object list.
    */
-  AuthorizationMetadataObject translateMetadataObject(MetadataObject metadataObject);
+  List<AuthorizationMetadataObject> translateMetadataObject(MetadataObject metadataObject);
 }

--- a/core/src/main/java/org/apache/gravitino/authorization/AuthorizationUtils.java
+++ b/core/src/main/java/org/apache/gravitino/authorization/AuthorizationUtils.java
@@ -428,7 +428,7 @@ public class AuthorizationUtils {
             if (catalogObj.provider().equals("hive")) {
               // The Hive default schema location is Hive warehouse directory
               String defaultSchemaLocation =
-                  getHiveDefaultLocation(ident.namespace().level(0), ident.namespace().level(1));
+                  getHiveDefaultLocation(ident.namespace().level(0), ident.name());
               if (defaultSchemaLocation != null && !defaultSchemaLocation.isEmpty()) {
                 locations.add(defaultSchemaLocation);
               }

--- a/core/src/main/java/org/apache/gravitino/authorization/AuthorizationUtils.java
+++ b/core/src/main/java/org/apache/gravitino/authorization/AuthorizationUtils.java
@@ -414,10 +414,11 @@ public class AuthorizationUtils {
                         if (schema.properties().containsKey(HiveConstants.LOCATION)) {
                           String defaultSchemaLocation =
                               schema.properties().get(HiveConstants.LOCATION);
-                          Preconditions.checkArgument(
-                              defaultSchemaLocation != null,
-                              String.format("Catalog %s location is not found", ident));
-                          locations.add(defaultSchemaLocation);
+                          if (defaultSchemaLocation != null && !defaultSchemaLocation.isEmpty()) {
+                            locations.add(defaultSchemaLocation);
+                          } else {
+                            LOG.warn("Catalog %s location is not found", ident);
+                          }
                         }
                       }
                     });
@@ -435,10 +436,11 @@ public class AuthorizationUtils {
                               metalake, catalogObj.name(), "default" /*Hive default schema*/));
               if (schema.properties().containsKey(HiveConstants.LOCATION)) {
                 String defaultSchemaLocation = schema.properties().get(HiveConstants.LOCATION);
-                Preconditions.checkArgument(
-                    defaultSchemaLocation != null,
-                    String.format("Catalog %s location is not found", ident));
-                locations.add(defaultSchemaLocation);
+                if (defaultSchemaLocation != null && !defaultSchemaLocation.isEmpty()) {
+                  locations.add(defaultSchemaLocation);
+                } else {
+                  LOG.warn("Catalog %s location is not found", ident);
+                }
               }
             }
           }
@@ -448,9 +450,11 @@ public class AuthorizationUtils {
             Schema schema = GravitinoEnv.getInstance().schemaDispatcher().loadSchema(ident);
             if (schema.properties().containsKey(HiveConstants.LOCATION)) {
               String schemaLocation = schema.properties().get(HiveConstants.LOCATION);
-              Preconditions.checkArgument(
-                  schemaLocation != null, String.format("Schema %s location is not found", ident));
-              locations.add(schemaLocation);
+              if (schemaLocation != null && schemaLocation.isEmpty()) {
+                locations.add(schemaLocation);
+              } else {
+                LOG.warn("Schema %s location is not found", ident);
+              }
             }
           }
           break;
@@ -458,10 +462,12 @@ public class AuthorizationUtils {
           {
             Table table = GravitinoEnv.getInstance().tableDispatcher().loadTable(ident);
             if (table.properties().containsKey(HiveConstants.LOCATION)) {
-              String schemaLocation = table.properties().get(HiveConstants.LOCATION);
-              Preconditions.checkArgument(
-                  schemaLocation != null, String.format("Table %s location is not found", ident));
-              locations.add(schemaLocation);
+              String tableLocation = table.properties().get(HiveConstants.LOCATION);
+              if (tableLocation != null && tableLocation.isEmpty()) {
+                locations.add(tableLocation);
+              } else {
+                LOG.warn("Table %s location is not found", ident);
+              }
             }
           }
           break;
@@ -476,8 +482,6 @@ public class AuthorizationUtils {
               filesetLocation != null,
               String.format("Fileset %s location is not found", identifier));
           locations.add(filesetLocation);
-          break;
-        case TOPIC:
           break;
         default:
           throw new AuthorizationPluginException(

--- a/core/src/main/java/org/apache/gravitino/authorization/AuthorizationUtils.java
+++ b/core/src/main/java/org/apache/gravitino/authorization/AuthorizationUtils.java
@@ -28,7 +28,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.apache.gravitino.Catalog;
 import org.apache.gravitino.Entity;
@@ -74,7 +73,6 @@ public class AuthorizationUtils {
   private static final Set<Privilege.Name> TOPIC_PRIVILEGES =
       Sets.immutableEnumSet(
           Privilege.Name.CREATE_TOPIC, Privilege.Name.PRODUCE_TOPIC, Privilege.Name.CONSUME_TOPIC);
-  private static final Pattern HDFS_PATTERN = Pattern.compile("^hdfs://[^/]*");
 
   private AuthorizationUtils() {}
 
@@ -398,7 +396,6 @@ public class AuthorizationUtils {
           {
             NameIdentifier[] identifiers =
                 GravitinoEnv.getInstance().catalogDispatcher().listCatalogs(Namespace.of(metalake));
-            List<String> finalLocationPath = locations;
             Arrays.stream(identifiers)
                 .collect(Collectors.toList())
                 .forEach(
@@ -420,9 +417,7 @@ public class AuthorizationUtils {
                           Preconditions.checkArgument(
                               defaultSchemaLocation != null,
                               String.format("Catalog %s location is not found", ident));
-                          String location =
-                              HDFS_PATTERN.matcher(defaultSchemaLocation).replaceAll("");
-                          finalLocationPath.add(location);
+                          locations.add(defaultSchemaLocation);
                         }
                       }
                     });
@@ -443,8 +438,7 @@ public class AuthorizationUtils {
                 Preconditions.checkArgument(
                     defaultSchemaLocation != null,
                     String.format("Catalog %s location is not found", ident));
-                String location = HDFS_PATTERN.matcher(defaultSchemaLocation).replaceAll("");
-                locations.add(location);
+                locations.add(defaultSchemaLocation);
               }
             }
           }
@@ -456,8 +450,7 @@ public class AuthorizationUtils {
               String schemaLocation = schema.properties().get(HiveConstants.LOCATION);
               Preconditions.checkArgument(
                   schemaLocation != null, String.format("Schema %s location is not found", ident));
-              String location = HDFS_PATTERN.matcher(schemaLocation).replaceAll("");
-              locations.add(location);
+              locations.add(schemaLocation);
             }
           }
           break;
@@ -468,8 +461,7 @@ public class AuthorizationUtils {
               String schemaLocation = table.properties().get(HiveConstants.LOCATION);
               Preconditions.checkArgument(
                   schemaLocation != null, String.format("Table %s location is not found", ident));
-              String location = HDFS_PATTERN.matcher(schemaLocation).replaceAll("");
-              locations.add(location);
+              locations.add(schemaLocation);
             }
           }
           break;
@@ -483,7 +475,7 @@ public class AuthorizationUtils {
           Preconditions.checkArgument(
               filesetLocation != null,
               String.format("Fileset %s location is not found", identifier));
-          locations.add(HDFS_PATTERN.matcher(filesetLocation).replaceAll(""));
+          locations.add(filesetLocation);
           break;
         case TOPIC:
           break;

--- a/core/src/main/java/org/apache/gravitino/catalog/CatalogManager.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/CatalogManager.java
@@ -745,6 +745,8 @@ public class CatalogManager implements CatalogDispatcher, Closeable {
         // PostgreSQL catalog includes the "public" schema, see
         // https://github.com/apache/gravitino/issues/2314
         return !schemaEntities.get(0).name().equals("public");
+      } else if ("hive".equals(catalogEntity.getProvider())) {
+        return !schemaEntities.get(0).name().equals("default");
       }
     }
 

--- a/core/src/main/java/org/apache/gravitino/hook/CatalogHookDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/hook/CatalogHookDispatcher.java
@@ -18,6 +18,7 @@
  */
 package org.apache.gravitino.hook;
 
+import java.util.List;
 import java.util.Map;
 import org.apache.gravitino.Catalog;
 import org.apache.gravitino.CatalogChange;
@@ -126,7 +127,10 @@ public class CatalogHookDispatcher implements CatalogDispatcher {
   @Override
   public boolean dropCatalog(NameIdentifier ident, boolean force)
       throws NonEmptyEntityException, CatalogInUseException {
-    AuthorizationUtils.authorizationPluginRemovePrivileges(ident, Entity.EntityType.CATALOG);
+    List<String> locations =
+        AuthorizationUtils.getMetadataObjectLocation(ident, Entity.EntityType.CATALOG);
+    AuthorizationUtils.authorizationPluginRemovePrivileges(
+        ident, Entity.EntityType.CATALOG, locations);
     return dispatcher.dropCatalog(ident, force);
   }
 

--- a/core/src/main/java/org/apache/gravitino/hook/FilesetHookDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/hook/FilesetHookDispatcher.java
@@ -18,6 +18,7 @@
  */
 package org.apache.gravitino.hook;
 
+import java.util.List;
 import java.util.Map;
 import org.apache.gravitino.Entity;
 import org.apache.gravitino.GravitinoEnv;
@@ -103,8 +104,11 @@ public class FilesetHookDispatcher implements FilesetDispatcher {
 
   @Override
   public boolean dropFileset(NameIdentifier ident) {
+    List<String> locations =
+        AuthorizationUtils.getMetadataObjectLocation(ident, Entity.EntityType.FILESET);
     boolean dropped = dispatcher.dropFileset(ident);
-    AuthorizationUtils.authorizationPluginRemovePrivileges(ident, Entity.EntityType.FILESET);
+    AuthorizationUtils.authorizationPluginRemovePrivileges(
+        ident, Entity.EntityType.FILESET, locations);
     return dropped;
   }
 

--- a/core/src/main/java/org/apache/gravitino/hook/SchemaHookDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/hook/SchemaHookDispatcher.java
@@ -18,6 +18,7 @@
  */
 package org.apache.gravitino.hook;
 
+import java.util.List;
 import java.util.Map;
 import org.apache.gravitino.Entity;
 import org.apache.gravitino.GravitinoEnv;
@@ -89,8 +90,11 @@ public class SchemaHookDispatcher implements SchemaDispatcher {
 
   @Override
   public boolean dropSchema(NameIdentifier ident, boolean cascade) throws NonEmptySchemaException {
+    List<String> locations =
+        AuthorizationUtils.getMetadataObjectLocation(ident, Entity.EntityType.SCHEMA);
     boolean dropped = dispatcher.dropSchema(ident, cascade);
-    AuthorizationUtils.authorizationPluginRemovePrivileges(ident, Entity.EntityType.SCHEMA);
+    AuthorizationUtils.authorizationPluginRemovePrivileges(
+        ident, Entity.EntityType.SCHEMA, locations);
     return dropped;
   }
 

--- a/core/src/main/java/org/apache/gravitino/hook/TableHookDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/hook/TableHookDispatcher.java
@@ -18,6 +18,7 @@
  */
 package org.apache.gravitino.hook;
 
+import java.util.List;
 import java.util.Map;
 import org.apache.gravitino.Entity;
 import org.apache.gravitino.GravitinoEnv;
@@ -115,15 +116,21 @@ public class TableHookDispatcher implements TableDispatcher {
 
   @Override
   public boolean dropTable(NameIdentifier ident) {
+    List<String> locations =
+        AuthorizationUtils.getMetadataObjectLocation(ident, Entity.EntityType.TABLE);
     boolean dropped = dispatcher.dropTable(ident);
-    AuthorizationUtils.authorizationPluginRemovePrivileges(ident, Entity.EntityType.TABLE);
+    AuthorizationUtils.authorizationPluginRemovePrivileges(
+        ident, Entity.EntityType.TABLE, locations);
     return dropped;
   }
 
   @Override
   public boolean purgeTable(NameIdentifier ident) throws UnsupportedOperationException {
+    List<String> locations =
+        AuthorizationUtils.getMetadataObjectLocation(ident, Entity.EntityType.TABLE);
     boolean purged = dispatcher.purgeTable(ident);
-    AuthorizationUtils.authorizationPluginRemovePrivileges(ident, Entity.EntityType.TABLE);
+    AuthorizationUtils.authorizationPluginRemovePrivileges(
+        ident, Entity.EntityType.TABLE, locations);
     return purged;
   }
 

--- a/core/src/main/java/org/apache/gravitino/hook/TopicHookDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/hook/TopicHookDispatcher.java
@@ -18,6 +18,7 @@
  */
 package org.apache.gravitino.hook;
 
+import java.util.List;
 import java.util.Map;
 import org.apache.gravitino.Entity;
 import org.apache.gravitino.GravitinoEnv;
@@ -88,8 +89,11 @@ public class TopicHookDispatcher implements TopicDispatcher {
 
   @Override
   public boolean dropTopic(NameIdentifier ident) {
+    List<String> locations =
+        AuthorizationUtils.getMetadataObjectLocation(ident, Entity.EntityType.TOPIC);
     boolean dropped = dispatcher.dropTopic(ident);
-    AuthorizationUtils.authorizationPluginRemovePrivileges(ident, Entity.EntityType.TOPIC);
+    AuthorizationUtils.authorizationPluginRemovePrivileges(
+        ident, Entity.EntityType.TOPIC, locations);
     return dropped;
   }
 

--- a/core/src/test/java/org/apache/gravitino/hook/TestTableHookDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/hook/TestTableHookDispatcher.java
@@ -18,12 +18,28 @@
  */
 package org.apache.gravitino.hook;
 
+import static org.apache.gravitino.Configs.CATALOG_CACHE_EVICTION_INTERVAL_MS;
+import static org.apache.gravitino.Configs.DEFAULT_ENTITY_RELATIONAL_STORE;
+import static org.apache.gravitino.Configs.ENTITY_RELATIONAL_JDBC_BACKEND_DRIVER;
+import static org.apache.gravitino.Configs.ENTITY_RELATIONAL_JDBC_BACKEND_URL;
+import static org.apache.gravitino.Configs.ENTITY_RELATIONAL_STORE;
+import static org.apache.gravitino.Configs.ENTITY_STORE;
+import static org.apache.gravitino.Configs.RELATIONAL_ENTITY_STORE;
+import static org.apache.gravitino.Configs.SERVICE_ADMINS;
+import static org.apache.gravitino.Configs.STORE_DELETE_AFTER_TIME;
+import static org.apache.gravitino.Configs.STORE_TRANSACTION_MAX_SKEW_TIME;
+import static org.apache.gravitino.Configs.TREE_LOCK_CLEAN_INTERVAL;
+import static org.apache.gravitino.Configs.TREE_LOCK_MAX_NODE_IN_MEMORY;
+import static org.apache.gravitino.Configs.TREE_LOCK_MIN_NODE_IN_MEMORY;
+import static org.apache.gravitino.Configs.VERSION_RETENTION_COUNT;
 import static org.mockito.ArgumentMatchers.any;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
 import java.io.IOException;
 import java.util.Map;
 import org.apache.commons.lang3.reflect.FieldUtils;
+import org.apache.gravitino.Config;
 import org.apache.gravitino.GravitinoEnv;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
@@ -34,6 +50,7 @@ import org.apache.gravitino.catalog.TestOperationDispatcher;
 import org.apache.gravitino.catalog.TestTableOperationDispatcher;
 import org.apache.gravitino.connector.BaseCatalog;
 import org.apache.gravitino.connector.authorization.AuthorizationPlugin;
+import org.apache.gravitino.lock.LockManager;
 import org.apache.gravitino.rel.Column;
 import org.apache.gravitino.rel.TableChange;
 import org.apache.gravitino.rel.expressions.NamedReference;
@@ -120,13 +137,35 @@ public class TestTableHookDispatcher extends TestOperationDispatcher {
     tableHookDispatcher.createTable(
         tableIdent, columns, "comment", props, transforms, distribution, sortOrders, indexes);
 
-    Mockito.reset(authorizationPlugin);
-    tableHookDispatcher.dropTable(tableIdent);
-    Mockito.verify(authorizationPlugin).onMetadataUpdated(any());
-
-    Mockito.reset(authorizationPlugin);
-    schemaHookDispatcher.dropSchema(NameIdentifier.of(tableNs.levels()), true);
-    Mockito.verify(authorizationPlugin).onMetadataUpdated(any());
+    withMockedAuthorizationUtils(
+        () -> {
+          tableHookDispatcher.dropTable(tableIdent);
+          Config config = Mockito.mock(Config.class);
+          Mockito.when(config.get(SERVICE_ADMINS))
+              .thenReturn(Lists.newArrayList("admin1", "admin2"));
+          Mockito.when(config.get(ENTITY_STORE)).thenReturn(RELATIONAL_ENTITY_STORE);
+          Mockito.when(config.get(ENTITY_RELATIONAL_STORE))
+              .thenReturn(DEFAULT_ENTITY_RELATIONAL_STORE);
+          Mockito.when(config.get(ENTITY_RELATIONAL_JDBC_BACKEND_URL))
+              .thenReturn(
+                  String.format("jdbc:h2:file:%s;DB_CLOSE_DELAY=-1;MODE=MYSQL", "/tmp/testdb"));
+          Mockito.when(config.get(ENTITY_RELATIONAL_JDBC_BACKEND_DRIVER))
+              .thenReturn("org.h2.Driver");
+          Mockito.when(config.get(STORE_TRANSACTION_MAX_SKEW_TIME)).thenReturn(1000L);
+          Mockito.when(config.get(STORE_DELETE_AFTER_TIME)).thenReturn(20 * 60 * 1000L);
+          Mockito.when(config.get(VERSION_RETENTION_COUNT)).thenReturn(1L);
+          Mockito.when(config.get(CATALOG_CACHE_EVICTION_INTERVAL_MS)).thenReturn(1000L);
+          Mockito.doReturn(100000L).when(config).get(TREE_LOCK_MAX_NODE_IN_MEMORY);
+          Mockito.doReturn(1000L).when(config).get(TREE_LOCK_MIN_NODE_IN_MEMORY);
+          Mockito.doReturn(36000L).when(config).get(TREE_LOCK_CLEAN_INTERVAL);
+          try {
+            FieldUtils.writeField(
+                GravitinoEnv.getInstance(), "lockManager", new LockManager(config), true);
+          } catch (IllegalAccessException e) {
+            throw new RuntimeException(e);
+          }
+          schemaHookDispatcher.dropSchema(NameIdentifier.of(tableNs.levels()), true);
+        });
   }
 
   @Test

--- a/core/src/test/java/org/apache/gravitino/hook/TestTopicHookDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/hook/TestTopicHookDispatcher.java
@@ -72,8 +72,9 @@ public class TestTopicHookDispatcher extends TestOperationDispatcher {
     NameIdentifier topicIdent = NameIdentifier.of(topicNs, "topicNAME");
     topicHookDispatcher.createTopic(topicIdent, "comment", null, props);
 
-    Mockito.reset(authorizationPlugin);
-    topicHookDispatcher.dropTopic(topicIdent);
-    Mockito.verify(authorizationPlugin).onMetadataUpdated(any());
+    withMockedAuthorizationUtils(
+        () -> {
+          topicHookDispatcher.dropTopic(topicIdent);
+        });
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

1. Fixed some incorrect variable names.
2. Make `findManagedPolicy()` and `wildcardSearchPolies()` an abstract functions.
3. Supports `CreateSchema` privilege in the Chained  Ranger Hive and Ranger HDFS

### Why are the changes needed?

Fix: #5956

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

Added ITs.
