### PR TITLE
[MINOR] Remove unnecessary blank space in the PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -20,7 +20,7 @@
   1. If you propose a new API, clarify the use case for a new API.
   2. If you fix a bug, describe the bug.)
 
-Fix: # (issue)
+Fix: #(issue)
 
 ### Does this PR introduce _any_ user-facing change?
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Remove unnecessary blank space in the PR template

### Why are the changes needed?

This is not a major issue, but the unnecessary blank space is somewhat annoying and requires adjustment every time I create a PR.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Not needed
