### PR TITLE
[#6166] web(ui): load tree load data after refreshing the version details page

### DIFF
--- a/web/web/src/app/metalakes/metalake/MetalakeView.js
+++ b/web/web/src/app/metalakes/metalake/MetalakeView.js
@@ -112,26 +112,39 @@ const MetalakeView = () => {
           dispatch(getSchemaDetails({ metalake, catalog, schema }))
         }
 
-        if (paramsSize === 5 && catalog && schema) {
+        if (paramsSize === 5 && catalog && type && schema && (table || fileset || topic || model)) {
           if (!store.catalogs.length) {
             await dispatch(fetchCatalogs({ metalake }))
             await dispatch(fetchSchemas({ metalake, catalog, type }))
           }
-          if (table) {
-            dispatch(getTableDetails({ init: true, metalake, catalog, schema, table }))
-          }
-          if (fileset) {
-            dispatch(getFilesetDetails({ init: true, metalake, catalog, schema, fileset }))
-          }
-          if (topic) {
-            dispatch(getTopicDetails({ init: true, metalake, catalog, schema, topic }))
-          }
-          if (model) {
-            dispatch(fetchModelVersions({ init: true, metalake, catalog, schema, model }))
-            dispatch(getModelDetails({ init: true, metalake, catalog, schema, model }))
+          switch (type) {
+            case 'relational':
+              await dispatch(fetchTables({ init: true, page: 'schemas', metalake, catalog, schema }))
+              await dispatch(getTableDetails({ init: true, metalake, catalog, schema, table }))
+              break
+            case 'fileset':
+              await dispatch(fetchFilesets({ init: true, page: 'schemas', metalake, catalog, schema }))
+              await dispatch(getFilesetDetails({ init: true, metalake, catalog, schema, fileset }))
+              break
+            case 'messaging':
+              await dispatch(fetchTopics({ init: true, page: 'schemas', metalake, catalog, schema }))
+              await dispatch(getTopicDetails({ init: true, metalake, catalog, schema, topic }))
+              break
+            case 'model':
+              await dispatch(fetchModels({ init: true, page: 'schemas', metalake, catalog, schema }))
+              await dispatch(fetchModelVersions({ init: true, metalake, catalog, schema, model }))
+              await dispatch(getModelDetails({ init: true, metalake, catalog, schema, model }))
+              break
+            default:
+              break
           }
         }
         if (paramsSize === 6 && version) {
+          if (!store.catalogs.length) {
+            await dispatch(fetchCatalogs({ metalake }))
+            await dispatch(fetchSchemas({ metalake, catalog, type }))
+            await dispatch(fetchModels({ init: true, page: 'schemas', metalake, catalog, schema }))
+          }
           dispatch(getVersionDetails({ init: true, metalake, catalog, schema, model, version }))
         }
       }


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?
Reload tree data after refreshing the version details page
<img width="1352" alt="image" src="https://github.com/user-attachments/assets/80bc7370-0052-4be8-9b6d-efbe6d97e945" />

### Why are the changes needed?
N/A

Fix: #6166

### Does this PR introduce _any_ user-facing change?
N/A

### How was this patch tested?
manually
