### PR TITLE
[#5533] fix (trino-connector): Fix the exception of ArrayIndexOutOfBoundsException when execute COMMENT COLUMN command

### DIFF
--- a/trino-connector/integration-test/src/test/java/org/apache/gravitino/trino/connector/integration/test/TrinoQueryIT.java
+++ b/trino-connector/integration-test/src/test/java/org/apache/gravitino/trino/connector/integration/test/TrinoQueryIT.java
@@ -55,15 +55,15 @@ import org.slf4j.LoggerFactory;
 public class TrinoQueryIT extends TrinoQueryITBase {
   private static final Logger LOG = LoggerFactory.getLogger(TrinoQueryIT.class);
 
-  static String testsetsDir = "";
-  AtomicInteger passCount = new AtomicInteger(0);
-  AtomicInteger totalCount = new AtomicInteger(0);
-  static boolean exitOnFailed = true;
+  protected static String testsetsDir;
+  protected AtomicInteger passCount = new AtomicInteger(0);
+  protected AtomicInteger totalCount = new AtomicInteger(0);
+  protected static boolean exitOnFailed = true;
 
   // key: tester name, value: tester result
-  private static Map<String, TestStatus> allTestStatus = new TreeMap<>();
+  private static final Map<String, TestStatus> allTestStatus = new TreeMap<>();
 
-  private static int testParallelism = 2;
+  private static final int testParallelism = 2;
 
   static Map<String, String> queryParams = new HashMap<>();
 
@@ -275,8 +275,8 @@ public class TrinoQueryIT extends TrinoQueryITBase {
    * actual result matches the query failed result. 3. The expected result is a regular expression,
    * and the actual result matches the regular expression.
    *
-   * @param expectResult
-   * @param result
+   * @param expectResult the expected result
+   * @param result the actual result
    * @return false if the expected result is empty or the actual result does not match the expected.
    *     For {@literal <BLANK_LINE>} case, return true if the actual result is empty. For {@literal
    *     <QUERY_FAILED>} case, replace the placeholder with "^Query \\w+ failed.*: " and do match.
@@ -338,7 +338,7 @@ public class TrinoQueryIT extends TrinoQueryITBase {
   @Test
   public void testSql() throws Exception {
     ExecutorService executor = Executors.newFixedThreadPool(testParallelism);
-    CompletionService completionService = new ExecutorCompletionService<>(executor);
+    CompletionService<Integer> completionService = new ExecutorCompletionService<>(executor);
 
     String[] testSetNames =
         Arrays.stream(TrinoQueryITBase.listDirectory(testsetsDir))
@@ -357,7 +357,7 @@ public class TrinoQueryIT extends TrinoQueryITBase {
 
   public void testSql(String testSetDirName, String catalog, String testerPrefix) throws Exception {
     ExecutorService executor = Executors.newFixedThreadPool(testParallelism);
-    CompletionService completionService = new ExecutorCompletionService<>(executor);
+    CompletionService<Integer> completionService = new ExecutorCompletionService<>(executor);
 
     totalCount.addAndGet(getTesterCount(testSetDirName, catalog, testerPrefix));
     List<Future<Integer>> futures =
@@ -369,7 +369,7 @@ public class TrinoQueryIT extends TrinoQueryITBase {
 
   private void waitForCompleted(
       ExecutorService executor,
-      CompletionService completionService,
+      CompletionService<Integer> completionService,
       List<Future<Integer>> allFutures) {
     for (int i = 0; i < allFutures.size(); i++) {
       try {
@@ -405,7 +405,7 @@ public class TrinoQueryIT extends TrinoQueryITBase {
   }
 
   public List<Future<Integer>> runOneTestset(
-      CompletionService completionService,
+      CompletionService<Integer> completionService,
       String testSetDirName,
       String catalog,
       String testerFilter)

--- a/trino-connector/integration-test/src/test/java/org/apache/gravitino/trino/connector/integration/test/TrinoQueryRunner.java
+++ b/trino-connector/integration-test/src/test/java/org/apache/gravitino/trino/connector/integration/test/TrinoQueryRunner.java
@@ -42,9 +42,9 @@ import org.slf4j.LoggerFactory;
 class TrinoQueryRunner {
   private static final Logger LOG = LoggerFactory.getLogger(TrinoQueryRunner.class);
 
-  private QueryRunner queryRunner;
-  private Terminal terminal;
-  private URI uri;
+  private final QueryRunner queryRunner;
+  private final Terminal terminal;
+  private final URI uri;
 
   TrinoQueryRunner(String trinoUri) throws Exception {
     this.uri = new URI(trinoUri);
@@ -92,10 +92,11 @@ class TrinoQueryRunner {
   String runQueryOnce(String query) {
     Query queryResult = queryRunner.startQuery(query);
     StringOutputStream outputStream = new StringOutputStream();
+    StringOutputStream errorStream = new StringOutputStream();
     queryResult.renderOutput(
         this.terminal,
         new PrintStream(outputStream),
-        new PrintStream(outputStream),
+        new PrintStream(errorStream),
         CSV,
         Optional.of(""),
         false);
@@ -109,17 +110,17 @@ class TrinoQueryRunner {
       session = builder.build();
       queryRunner.setSession(session);
     }
-    return outputStream.toString();
+
+    // avoid the ide capturing the error message as failure
+    return outputStream + errorStream.toString().replace("\nCaused by:", "\n-Caused by:");
   }
 
-  boolean stop() {
+  void stop() {
     try {
       queryRunner.close();
       terminal.close();
-      return true;
     } catch (Exception e) {
       LOG.error("Failed to stop query runner", e);
-      return false;
     }
   }
 }

--- a/trino-connector/integration-test/src/test/java/org/apache/gravitino/trino/connector/integration/test/TrinoQueryRunner.java
+++ b/trino-connector/integration-test/src/test/java/org/apache/gravitino/trino/connector/integration/test/TrinoQueryRunner.java
@@ -111,7 +111,7 @@ class TrinoQueryRunner {
       queryRunner.setSession(session);
     }
 
-    // avoid the ide capturing the error message as failure
+    // Avoid the IDE capturing the error message as failure
     String err_message = errorStream.toString().replace("\nCaused by:", "\n-Caused by:");
     String out_message = outputStream.toString();
     return err_message + out_message;

--- a/trino-connector/integration-test/src/test/java/org/apache/gravitino/trino/connector/integration/test/TrinoQueryRunner.java
+++ b/trino-connector/integration-test/src/test/java/org/apache/gravitino/trino/connector/integration/test/TrinoQueryRunner.java
@@ -112,7 +112,9 @@ class TrinoQueryRunner {
     }
 
     // avoid the ide capturing the error message as failure
-    return outputStream + errorStream.toString().replace("\nCaused by:", "\n-Caused by:");
+    String err_message = errorStream.toString().replace("Error: ", "");
+    String out_message = outputStream.toString();
+    return err_message + out_message;
   }
 
   void stop() {

--- a/trino-connector/integration-test/src/test/java/org/apache/gravitino/trino/connector/integration/test/TrinoQueryRunner.java
+++ b/trino-connector/integration-test/src/test/java/org/apache/gravitino/trino/connector/integration/test/TrinoQueryRunner.java
@@ -112,7 +112,7 @@ class TrinoQueryRunner {
     }
 
     // avoid the ide capturing the error message as failure
-    String err_message = errorStream.toString().replace("Error: ", "");
+    String err_message = errorStream.toString().replace("\nCaused by:", "\n-Caused by:");
     String out_message = outputStream.toString();
     return err_message + out_message;
   }

--- a/trino-connector/integration-test/src/test/resources/trino-ci-testset/testsets/jdbc-mysql/00002_alter_table.sql
+++ b/trino-connector/integration-test/src/test/resources/trino-ci-testset/testsets/jdbc-mysql/00002_alter_table.sql
@@ -37,6 +37,8 @@ show create table gt_mysql.gt_db1.tb01;
 alter table gt_mysql.gt_db1.tb01 add column address varchar(200) not null comment 'address of users';
 show create table gt_mysql.gt_db1.tb01;
 
+COMMENT ON COLUMN gt_mysql.gt_db1.tb01.city IS NULL;
+
 drop table gt_mysql.gt_db1.tb01;
 
 drop schema gt_mysql.gt_db1;

--- a/trino-connector/integration-test/src/test/resources/trino-ci-testset/testsets/jdbc-mysql/00002_alter_table.txt
+++ b/trino-connector/integration-test/src/test/resources/trino-ci-testset/testsets/jdbc-mysql/00002_alter_table.txt
@@ -104,6 +104,8 @@ WITH (
    engine = 'InnoDB'
 )"
 
+<QUERY_FAILED> "newComment" field is required and cannot be empty
+
 DROP TABLE
 
 DROP SCHEMA

--- a/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/GravitinoErrorCode.java
+++ b/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/GravitinoErrorCode.java
@@ -23,6 +23,7 @@ import static io.trino.spi.ErrorType.EXTERNAL;
 import io.trino.spi.ErrorCode;
 import io.trino.spi.ErrorCodeSupplier;
 import io.trino.spi.ErrorType;
+import java.util.List;
 
 public enum GravitinoErrorCode implements ErrorCodeSupplier {
   GRAVITINO_UNSUPPORTED_TRINO_VERSION(0, EXTERNAL),
@@ -63,5 +64,10 @@ public enum GravitinoErrorCode implements ErrorCodeSupplier {
   @Override
   public ErrorCode toErrorCode() {
     return errorCode;
+  }
+
+  public static String toSimpleErrorMessage(Exception e) {
+    List<String> lines = e.getMessage().lines().toList();
+    return lines.size() > 1 ? lines.get(0) + lines.get(1) : lines.get(0);
   }
 }

--- a/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/catalog/CatalogConnectorMetadata.java
+++ b/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/catalog/CatalogConnectorMetadata.java
@@ -190,8 +190,7 @@ public class CatalogConnectorMetadata {
       // TODO yuhui need improve get the error message. From IllegalArgumentException.
       // At present, the IllegalArgumentException cannot get the error information clearly from the
       // Gravitino server.
-      String message =
-          e.getMessage().lines().toList().get(0) + e.getMessage().lines().toList().get(1);
+      String message = GravitinoErrorCode.toSimpleErrorMessage(e);
       throw new TrinoException(GravitinoErrorCode.GRAVITINO_ILLEGAL_ARGUMENT, message, e);
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix the exception of ArrayIndexOutOfBoundsException when handle error message of IllegalArgumentException

### Why are the changes needed?

Fix: #5533 

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

IT
