### PR TITLE
[#6184]improve(core): Remove the protobuf dependency

### DIFF
--- a/NOTICE.bin
+++ b/NOTICE.bin
@@ -184,14 +184,6 @@ zlib in pure Java, which can be obtained at:
   * HOMEPAGE:
     * http://www.jcraft.com/jzlib/
 
-This product optionally depends on 'Protocol Buffers', Google's data
-interchange format, which can be obtained at:
-
-  * LICENSE:
-    * license/LICENSE.protobuf.txt (New BSD License)
-  * HOMEPAGE:
-    * http://code.google.com/p/protobuf/
-
 This product optionally depends on 'SLF4J', a simple logging facade for Java,
 which can be obtained at:
 

--- a/NOTICE.rest
+++ b/NOTICE.rest
@@ -253,7 +253,7 @@ Dropwizard Hadoop Metrics
 Copyright 2016 Josh Elser
 
 AWS EventStream for Java
-Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved. 
+Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 Apache Gravitino (incubating)
 Copyright 2024 The Apache Software Foundation
@@ -488,7 +488,7 @@ The Apache Software Foundation (https://www.apache.org/).
 This product includes software developed by
 Joda.org (https://www.joda.org/).
 
-Kerby-kerb Admin                 
+Kerby-kerb Admin
 Copyright 2014-2022 The Apache Software Foundation
 
 Kerby-kerb core
@@ -524,7 +524,7 @@ Copyright 2014-2022 The Apache Software Foundation
 Kerby PKIX Project
 Copyright 2014-2022 The Apache Software Foundation
 
-Kerby Util 
+Kerby Util
 Copyright 2014-2022 The Apache Software Foundation
 
 Kerby XDR Project
@@ -604,14 +604,6 @@ zlib in pure Java, which can be obtained at:
     * license/LICENSE.jzlib.txt (BSD Style License)
   * HOMEPAGE:
     * http://www.jcraft.com/jzlib/
-
-This product optionally depends on 'Protocol Buffers', Google's data
-interchange format, which can be obtained at:
-
-  * LICENSE:
-    * license/LICENSE.protobuf.txt (New BSD License)
-  * HOMEPAGE:
-    * http://code.google.com/p/protobuf/
 
 This product optionally depends on 'SLF4J', a simple logging facade for Java,
 which can be obtained at:

--- a/clients/client-java/build.gradle.kts
+++ b/clients/client-java/build.gradle.kts
@@ -25,10 +25,6 @@ plugins {
 dependencies {
   implementation(project(":api"))
   implementation(project(":common"))
-  implementation(libs.protobuf.java.util) {
-    exclude("com.google.guava", "guava")
-      .because("Brings in Guava for Android, which we don't want (and breaks multimaps).")
-  }
   implementation(libs.jackson.databind)
   implementation(libs.jackson.annotations)
   implementation(libs.jackson.datatype.jdk8)

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -36,7 +36,6 @@ dependencies {
   implementation(libs.jackson.datatype.jdk8)
   implementation(libs.jackson.datatype.jsr310)
   implementation(libs.jackson.databind)
-  implementation(libs.protobuf.java)
 
   annotationProcessor(libs.lombok)
   compileOnly(libs.lombok)

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -36,10 +36,6 @@ dependencies {
   implementation(libs.guava)
   implementation(libs.h2db)
   implementation(libs.mybatis)
-  implementation(libs.protobuf.java.util) {
-    exclude("com.google.guava", "guava")
-      .because("Brings in Guava for Android, which we don't want (and breaks multimaps).")
-  }
 
   annotationProcessor(libs.lombok)
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -93,7 +93,6 @@ cglib = "2.2"
 ranger = "2.4.0"
 javax-jaxb-api = "2.3.1"
 javax-ws-rs-api = "2.1.1"
-protobuf-plugin = "0.9.2"
 spotless-plugin = '6.11.0'
 gradle-extensions-plugin = '1.74'
 publish-plugin = '1.2.0'
@@ -129,8 +128,6 @@ azure-identity = { group = "com.azure", name = "azure-identity", version.ref = "
 azure-storage-file-datalake = { group = "com.azure", name = "azure-storage-file-datalake", version.ref = "azure-storage-file-datalake"}
 reactor-netty-http = {group = "io.projectreactor.netty", name = "reactor-netty-http", version.ref = "reactor-netty-http"}
 reactor-netty-core = {group = "io.projectreactor.netty", name = "reactor-netty-core", version.ref = "reactor-netty-core"}
-protobuf-java = { group = "com.google.protobuf", name = "protobuf-java", version.ref = "protoc" }
-protobuf-java-util = { group = "com.google.protobuf", name = "protobuf-java-util", version.ref = "protoc" }
 jackson-databind = { group = "com.fasterxml.jackson.core", name = "jackson-databind", version.ref = "jackson" }
 jackson-annotations = { group = "com.fasterxml.jackson.core", name = "jackson-annotations", version.ref = "jackson" }
 jackson-datatype-jdk8 = { group = "com.fasterxml.jackson.datatype", name = "jackson-datatype-jdk8", version.ref = "jackson" }
@@ -293,7 +290,6 @@ prometheus = ["prometheus-servlet", "prometheus-dropwizard", "prometheus-client"
 kerby = ["kerby-core", "kerby-simplekdc"]
 
 [plugins]
-protobuf = { id = "com.google.protobuf", version.ref = "protobuf-plugin" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless-plugin" }
 gradle-extensions = { id = "com.github.vlsi.gradle-extensions", version.ref = "gradle-extensions-plugin" }
 publish = { id = "io.github.gradle-nexus.publish-plugin", version.ref = "publish-plugin" }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Remove the unused protobuf dependency.

### Why are the changes needed?

Since we already removed the KV storage support, so protobuf dependency is not required any more.

Fix: #6184 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing tests.
