### PR TITLE
[#5100] improvement(docs): Add extra documents to clarify the engine type of MySQL catalog

### DIFF
--- a/docs/jdbc-mysql-catalog.md
+++ b/docs/jdbc-mysql-catalog.md
@@ -187,7 +187,7 @@ Although MySQL itself does not support table properties, Gravitino offers table 
 | `auto-increment-offset` | Used to specify the starting value of the auto-increment field.                                                                                          | (none)        | No        | No         | Yes       | 0.4.0         |
 
 :::note
-Some engine types may not be supported by MySQL by default and required additional configuration. For instance, `FEDERATED` are not supported by 
+Some engine types may not be supported by MySQL by default and require additional configuration. For instance, `FEDERATED` are not supported by 
 default and need to be enabled by setting `federated` to `1` in the MySQL configuration file, the same applies to `ndbinfo`, `MRG_MYISAM`, `PERFORMANCE_SCHEMA`.
 Please refer to the [MySQL documentation](https://dev.mysql.com/doc/refman/8.0/en/federated-storage-engine.html) for more information.
 :::

--- a/docs/jdbc-mysql-catalog.md
+++ b/docs/jdbc-mysql-catalog.md
@@ -186,10 +186,10 @@ Although MySQL itself does not support table properties, Gravitino offers table 
 | `engine`                | The engine used by the table. For example `MyISAM`, `MEMORY`, `CSV`, `ARCHIVE`, `BLACKHOLE`, `FEDERATED`, `ndbinfo`, `MRG_MYISAM`, `PERFORMANCE_SCHEMA`. | `InnoDB`      | No        | No         | Yes       | 0.4.0         |
 | `auto-increment-offset` | Used to specify the starting value of the auto-increment field.                                                                                          | (none)        | No        | No         | Yes       | 0.4.0         |
 
+
 :::note
-Some engine types may not be supported by MySQL by default and require additional configuration. For instance, `FEDERATED` are not supported by 
-default and need to be enabled by setting `federated` to `1` in the MySQL configuration file, the same applies to `ndbinfo`, `MRG_MYISAM`, `PERFORMANCE_SCHEMA`.
-Please refer to the [MySQL documentation](https://dev.mysql.com/doc/refman/8.0/en/federated-storage-engine.html) for more information.
+Some MySQL storage engines, such as FEDERATED, are not enabled by default and require additional configuration to use. For example, to enable the FEDERATED engine, set federated=1 in the MySQL configuration file. Similarly, engines like ndbinfo, MRG_MYISAM, and PERFORMANCE_SCHEMA may also require specific prerequisites or configurations. For detailed instructions, 
+refer to the [MySQL documentation](https://dev.mysql.com/doc/refman/8.0/en/federated-storage-engine.html).
 :::
 
 ### Table indexes

--- a/docs/jdbc-mysql-catalog.md
+++ b/docs/jdbc-mysql-catalog.md
@@ -186,6 +186,12 @@ Although MySQL itself does not support table properties, Gravitino offers table 
 | `engine`                | The engine used by the table. For example `MyISAM`, `MEMORY`, `CSV`, `ARCHIVE`, `BLACKHOLE`, `FEDERATED`, `ndbinfo`, `MRG_MYISAM`, `PERFORMANCE_SCHEMA`. | `InnoDB`      | No        | No         | Yes       | 0.4.0         |
 | `auto-increment-offset` | Used to specify the starting value of the auto-increment field.                                                                                          | (none)        | No        | No         | Yes       | 0.4.0         |
 
+:::note
+Some engine types may not be supported by MySQL by default and required additional configuration. For instance, `FEDERATED` are not supported by 
+default and need to be enabled by setting `federated` to `1` in the MySQL configuration file, the same applies to `ndbinfo`, `MRG_MYISAM`, `PERFORMANCE_SCHEMA`.
+Please refer to the [MySQL documentation](https://dev.mysql.com/doc/refman/8.0/en/federated-storage-engine.html) for more information.
+:::
+
 ### Table indexes
 
 - Supports PRIMARY_KEY and UNIQUE_KEY.


### PR DESCRIPTION

### What changes were proposed in this pull request?

Add more details about the usage of engine type for MySQL catalog. 

### Why are the changes needed?

The value of engine type may be influenced by many factors like MySQL version, configurations and so on, we need to clarify it. 

Fix: #5100 

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

N/A
