### PR TITLE
[#6245] fix(authz): Authorization should use classloader to create the plugin

### DIFF
--- a/core/src/main/java/org/apache/gravitino/connector/BaseCatalog.java
+++ b/core/src/main/java/org/apache/gravitino/connector/BaseCatalog.java
@@ -208,8 +208,15 @@ public abstract class BaseCatalog<T extends BaseCatalog>
           try {
             BaseAuthorization<?> authorization =
                 BaseAuthorization.createAuthorization(classLoader, authorizationProvider);
+
+            // Load the authorization plugin with the class loader of the catalog.
+            // Because the JDBC authorization plugin may load JDBC driver using the class loader.
             authorizationPlugin =
-                authorization.newPlugin(entity.namespace().level(0), provider(), this.conf);
+                classLoader.withClassLoader(
+                    cl ->
+                        authorization.newPlugin(
+                            entity.namespace().level(0), provider(), this.conf));
+
           } catch (Exception e) {
             LOG.error("Failed to load authorization with class loader", e);
             throw new RuntimeException(e);


### PR DESCRIPTION
### What changes were proposed in this pull request?

Authorization should use classloader to create the plugin

### Why are the changes needed?

Fix: #6245

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

I tested it manually.