### PR TITLE
[#6239] fix: No need for toString() on string (CLI)

### DIFF
--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/AllMetalakeDetails.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/AllMetalakeDetails.java
@@ -55,6 +55,6 @@ public class AllMetalakeDetails extends Command {
 
     String all = Joiner.on(System.lineSeparator()).join(metalakeDetails);
 
-    System.out.print(all.toString());
+    System.out.print(all);
   }
 }

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/GroupDetails.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/GroupDetails.java
@@ -62,6 +62,6 @@ public class GroupDetails extends Command {
 
     String all = roles.isEmpty() ? "The group has no roles." : String.join(",", roles);
 
-    System.out.println(all.toString());
+    System.out.println(all);
   }
 }

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/ListAllTags.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/ListAllTags.java
@@ -55,6 +55,6 @@ public class ListAllTags extends Command {
 
     String all = tags.length == 0 ? "No tags exist." : String.join(",", tags);
 
-    System.out.println(all.toString());
+    System.out.println(all);
   }
 }

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/ListColumns.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/ListColumns.java
@@ -94,6 +94,6 @@ public class ListColumns extends TableCommand {
               + System.lineSeparator());
     }
 
-    System.out.print(all.toString());
+    System.out.print(all);
   }
 }

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/ListEntityTags.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/ListEntityTags.java
@@ -93,6 +93,6 @@ public class ListEntityTags extends Command {
 
     String all = String.join(",", tags);
 
-    System.out.println(all.toString());
+    System.out.println(all);
   }
 }

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/ListFilesets.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/ListFilesets.java
@@ -73,6 +73,6 @@ public class ListFilesets extends Command {
 
     String all = filesets.length == 0 ? "No filesets exist." : Joiner.on(",").join(filesets);
 
-    System.out.println(all.toString());
+    System.out.println(all);
   }
 }

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/ListGroups.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/ListGroups.java
@@ -55,6 +55,6 @@ public class ListGroups extends Command {
 
     String all = groups.length == 0 ? "No groups exist." : String.join(",", groups);
 
-    System.out.println(all.toString());
+    System.out.println(all);
   }
 }

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/ListProperties.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/ListProperties.java
@@ -51,6 +51,6 @@ public class ListProperties extends Command {
       all.append(property.getKey() + "," + property.getValue() + System.lineSeparator());
     }
 
-    System.out.print(all.toString());
+    System.out.print(all);
   }
 }

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/ListRoles.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/ListRoles.java
@@ -55,6 +55,6 @@ public class ListRoles extends Command {
 
     String all = roles.length == 0 ? "No roles exist." : String.join(",", roles);
 
-    System.out.println(all.toString());
+    System.out.println(all);
   }
 }

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/ListSchema.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/ListSchema.java
@@ -62,6 +62,6 @@ public class ListSchema extends Command {
 
     String all = schemas.length == 0 ? "No schemas exist." : Joiner.on(",").join(schemas);
 
-    System.out.println(all.toString());
+    System.out.println(all);
   }
 }

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/ListTables.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/ListTables.java
@@ -66,6 +66,6 @@ public class ListTables extends TableCommand {
             ? "No tables exist."
             : Joiner.on(System.lineSeparator()).join(tableNames);
 
-    System.out.println(all.toString());
+    System.out.println(all);
   }
 }

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/ListUsers.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/ListUsers.java
@@ -53,8 +53,8 @@ public class ListUsers extends Command {
       exitWithError(exp.getMessage());
     }
 
-    String all = String.join(",", users);
+    String all = users.length == 0 ? "No users exist." : String.join(",", users);
 
-    System.out.println(all.toString());
+    System.out.println(all);
   }
 }

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/UntagEntity.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/UntagEntity.java
@@ -19,7 +19,6 @@
 
 package org.apache.gravitino.cli.commands;
 
-import com.google.common.base.Joiner;
 import org.apache.gravitino.Catalog;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Schema;
@@ -33,7 +32,6 @@ import org.apache.gravitino.exceptions.NoSuchTableException;
 import org.apache.gravitino.rel.Table;
 
 public class UntagEntity extends Command {
-  public static final Joiner COMMA_JOINER = Joiner.on(", ").skipNulls();
   protected final String metalake;
   protected final FullName name;
   protected final String[] tags;

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/UserDetails.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/UserDetails.java
@@ -62,6 +62,6 @@ public class UserDetails extends Command {
 
     String all = roles.isEmpty() ? "The user has no roles." : String.join(",", roles);
 
-    System.out.println(all.toString());
+    System.out.println(all);
   }
 }


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Remove unnecessary toSrting() from CLI

### Why are the changes needed?

Fix: [#(6239)](https://github.com/apache/gravitino/issues/6239)

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

N/A