### PR TITLE
[#6243] fix(docs): Fix wrong seperator of yaml example in flink-connector.md

### DIFF
--- a/docs/flink-connector/flink-connector.md
+++ b/docs/flink-connector/flink-connector.md
@@ -34,16 +34,16 @@ This capability allows users to perform federation queries, accessing data from 
 
 Set the flink configuration in flink-conf.yaml.
 ```yaml
-table.catalog-store.kind=gravitino
-table.catalog-store.gravitino.gravitino.metalake=test
-table.catalog-store.gravitino.gravitino.uri=http://localhost:8080
+table.catalog-store.kind: gravitino
+table.catalog-store.gravitino.gravitino.metalake: test
+table.catalog-store.gravitino.gravitino.uri: http://localhost:8090
 ```
 Or you can set the flink configuration in the `TableEnvironment`.
 ```java
 final Configuration configuration = new Configuration();
 configuration.setString("table.catalog-store.kind", "gravitino");
 configuration.setString("table.catalog-store.gravitino.gravitino.metalake", "test");
-configuration.setString("table.catalog-store.gravitino.gravitino.uri", "http://localhost:8080");
+configuration.setString("table.catalog-store.gravitino.gravitino.uri", "http://localhost:8090");
 EnvironmentSettings.Builder builder = EnvironmentSettings.newInstance().withConfiguration(configuration);
 TableEnvironment tableEnv = TableEnvironment.create(builder.inBatchMode().build());
 ```


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Replace `=` with `:` to correct the yaml example.

### Why are the changes needed?
The yaml example uses wrong seperator.

Fix: #6243

### Does this PR introduce _any_ user-facing change?
None

### How was this patch tested?
None.
