### PR TITLE
Fixed issue #6239 removing toString() on String(CLI)

### DIFF
--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/AllMetalakeDetails.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/AllMetalakeDetails.java
@@ -55,6 +55,6 @@ public class AllMetalakeDetails extends Command {
 
     String all = Joiner.on(System.lineSeparator()).join(metalakeDetails);
 
-    System.out.print(all.toString());
+    System.out.print(all);
   }
 }

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/GroupDetails.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/GroupDetails.java
@@ -62,6 +62,6 @@ public class GroupDetails extends Command {
 
     String all = roles.isEmpty() ? "The group has no roles." : String.join(",", roles);
 
-    System.out.println(all.toString());
+    System.out.println(all);
   }
 }

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/ListAllTags.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/ListAllTags.java
@@ -55,6 +55,6 @@ public class ListAllTags extends Command {
 
     String all = tags.length == 0 ? "No tags exist." : String.join(",", tags);
 
-    System.out.println(all.toString());
+    System.out.println(all);
   }
 }

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/ListColumns.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/ListColumns.java
@@ -94,6 +94,6 @@ public class ListColumns extends TableCommand {
               + System.lineSeparator());
     }
 
-    System.out.print(all.toString());
+    System.out.print(all);
   }
 }

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/ListEntityTags.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/ListEntityTags.java
@@ -93,6 +93,6 @@ public class ListEntityTags extends Command {
 
     String all = String.join(",", tags);
 
-    System.out.println(all.toString());
+    System.out.println(all);
   }
 }

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/ListFilesets.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/ListFilesets.java
@@ -73,6 +73,6 @@ public class ListFilesets extends Command {
 
     String all = filesets.length == 0 ? "No filesets exist." : Joiner.on(",").join(filesets);
 
-    System.out.println(all.toString());
+    System.out.println(all);
   }
 }

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/ListGroups.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/ListGroups.java
@@ -55,6 +55,6 @@ public class ListGroups extends Command {
 
     String all = groups.length == 0 ? "No groups exist." : String.join(",", groups);
 
-    System.out.println(all.toString());
+    System.out.println(all);
   }
 }

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/ListProperties.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/ListProperties.java
@@ -51,6 +51,6 @@ public class ListProperties extends Command {
       all.append(property.getKey() + "," + property.getValue() + System.lineSeparator());
     }
 
-    System.out.print(all.toString());
+    System.out.print(all);
   }
 }

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/ListRoles.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/ListRoles.java
@@ -55,6 +55,6 @@ public class ListRoles extends Command {
 
     String all = roles.length == 0 ? "No roles exist." : String.join(",", roles);
 
-    System.out.println(all.toString());
+    System.out.println(all);
   }
 }

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/ListSchema.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/ListSchema.java
@@ -62,6 +62,6 @@ public class ListSchema extends Command {
 
     String all = schemas.length == 0 ? "No schemas exist." : Joiner.on(",").join(schemas);
 
-    System.out.println(all.toString());
+    System.out.println(all);
   }
 }

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/ListTables.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/ListTables.java
@@ -66,6 +66,6 @@ public class ListTables extends TableCommand {
             ? "No tables exist."
             : Joiner.on(System.lineSeparator()).join(tableNames);
 
-    System.out.println(all.toString());
+    System.out.println(all);
   }
 }

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/ListUsers.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/ListUsers.java
@@ -53,8 +53,7 @@ public class ListUsers extends Command {
       exitWithError(exp.getMessage());
     }
 
-    String all = String.join(",", users);
-
-    System.out.println(all.toString());
+    String all = user.length==0 ? "No User exist.": String.join(",",users);
+    System.out.println(all);
   }
 }

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/UntagEntity.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/UntagEntity.java
@@ -19,7 +19,7 @@
 
 package org.apache.gravitino.cli.commands;
 
-import com.google.common.base.Joiner;
+
 import org.apache.gravitino.Catalog;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Schema;
@@ -33,7 +33,7 @@ import org.apache.gravitino.exceptions.NoSuchTableException;
 import org.apache.gravitino.rel.Table;
 
 public class UntagEntity extends Command {
-  public static final Joiner COMMA_JOINER = Joiner.on(", ").skipNulls();
+  
   protected final String metalake;
   protected final FullName name;
   protected final String[] tags;

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/UserDetails.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/UserDetails.java
@@ -62,6 +62,6 @@ public class UserDetails extends Command {
 
     String all = roles.isEmpty() ? "The user has no roles." : String.join(",", roles);
 
-    System.out.println(all.toString());
+    System.out.println(all);
   }
 }


### PR DESCRIPTION

1. " [#6239 ] Fixed: Unnessary toString() on String(CLI)"
   
 
### What changes were proposed in this pull request?
Unnessary toString() on String(CLI).
'all' is already a string . Calling 'toString' won't change anything



### Why are the changes needed?

1st CHANGE: Removing toString() on String(CLI)
REASON: 'all' is already a string . Calling 'toString' won't change anything
2nd CHANGE: String all = roles.isEmpty() ? "The user has no roles." : String.join(",", roles);
REASON: If the roles list is empty, all will be set to the string "The user has no roles.", otherwise, all will be a comma-separated string created by joining the elements of the roles list.

Fix: #(6239)


