### PR TITLE
[#6278] improve(CLI): Revoke all privileges from a role via the Gravitino CLI.

### DIFF
--- a/clients/cli/src/main/java/org/apache/gravitino/cli/RoleCommandHandler.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/RoleCommandHandler.java
@@ -137,11 +137,19 @@ public class RoleCommandHandler extends CommandHandler {
   }
 
   private void handleRevokeCommand() {
-    gravitinoCommandLine
-        .newRevokePrivilegesFromRole(
-            url, ignore, metalake, getOneRole(), new FullName(line), privileges)
-        .validate()
-        .handle();
+    boolean removeAll = line.hasOption(GravitinoOptions.ALL);
+    if (removeAll) {
+      gravitinoCommandLine
+          .newRevokeAllPrivileges(url, ignore, metalake, getOneRole(), new FullName(line))
+          .validate()
+          .handle();
+    } else {
+      gravitinoCommandLine
+          .newRevokePrivilegesFromRole(
+              url, ignore, metalake, getOneRole(), new FullName(line), privileges)
+          .validate()
+          .handle();
+    }
   }
 
   private String getOneRole() {

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/TestableCommandLine.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/TestableCommandLine.java
@@ -97,6 +97,7 @@ import org.apache.gravitino.cli.commands.RemoveSchemaProperty;
 import org.apache.gravitino.cli.commands.RemoveTableProperty;
 import org.apache.gravitino.cli.commands.RemoveTagProperty;
 import org.apache.gravitino.cli.commands.RemoveTopicProperty;
+import org.apache.gravitino.cli.commands.RevokeAllPrivileges;
 import org.apache.gravitino.cli.commands.RevokePrivilegesFromRole;
 import org.apache.gravitino.cli.commands.RoleAudit;
 import org.apache.gravitino.cli.commands.RoleDetails;
@@ -899,6 +900,11 @@ public class TestableCommandLine {
       FullName entity,
       String[] privileges) {
     return new RevokePrivilegesFromRole(url, ignore, metalake, role, entity, privileges);
+  }
+
+  protected RevokeAllPrivileges newRevokeAllPrivileges(
+      String url, boolean ignore, String metalake, String role, FullName entity) {
+    return new RevokeAllPrivileges(url, ignore, metalake, role, entity);
   }
 
   protected MetalakeEnable newMetalakeEnable(

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/RevokeAllPrivileges.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/RevokeAllPrivileges.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.cli.commands;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.gravitino.MetadataObject;
+import org.apache.gravitino.authorization.Privilege;
+import org.apache.gravitino.authorization.Role;
+import org.apache.gravitino.authorization.SecurableObject;
+import org.apache.gravitino.cli.ErrorMessages;
+import org.apache.gravitino.cli.FullName;
+import org.apache.gravitino.client.GravitinoClient;
+import org.apache.gravitino.exceptions.NoSuchMetalakeException;
+import org.apache.gravitino.exceptions.NoSuchRoleException;
+
+/** Revokes all privileges from a role to an entity or all entities. */
+public class RevokeAllPrivileges extends MetadataCommand {
+
+  protected final String metalake;
+  protected final String role;
+  protected final FullName entity;
+
+  /**
+   * Revokes all privileges from a role to an entity or all entities.
+   *
+   * @param url The URL of the Gravitino server.
+   * @param ignoreVersions If true don't check the client/server versions match.
+   * @param metalake The name of the metalake.
+   * @param role The name of the role.
+   * @param entity The name of the entity.
+   */
+  public RevokeAllPrivileges(
+      String url, boolean ignoreVersions, String metalake, String role, FullName entity) {
+    super(url, ignoreVersions);
+    this.metalake = metalake;
+    this.role = role;
+    this.entity = entity;
+  }
+
+  /** Revokes all privileges from a role to an entity or all entities. */
+  @Override
+  public void handle() {
+    List<SecurableObject> matchedObjects;
+    Map<String, Set<Privilege>> revokedPrivileges = Maps.newHashMap();
+
+    try {
+      GravitinoClient client = buildClient(metalake);
+      matchedObjects = getMatchedObjects(client);
+
+      for (SecurableObject securableObject : matchedObjects) {
+        String objectFullName = securableObject.fullName();
+        Set<Privilege> privileges = new HashSet<>(securableObject.privileges());
+        MetadataObject metadataObject = constructMetadataObject(entity, client);
+        client.revokePrivilegesFromRole(role, metadataObject, privileges);
+
+        revokedPrivileges.put(objectFullName, privileges);
+      }
+    } catch (NoSuchMetalakeException e) {
+      exitWithError(ErrorMessages.UNKNOWN_METALAKE);
+    } catch (NoSuchRoleException e) {
+      exitWithError(ErrorMessages.UNKNOWN_ROLE);
+    } catch (Exception e) {
+      exitWithError(e.getMessage());
+    }
+
+    if (revokedPrivileges.isEmpty()) outputRevokedPrivileges("No privileges revoked.");
+    outputRevokedPrivileges(revokedPrivileges);
+  }
+
+  private List<SecurableObject> getMatchedObjects(GravitinoClient client) {
+    Role gRole = client.getRole(role);
+    return gRole.securableObjects().stream()
+        .filter(s -> s.fullName().equals(entity.getName()))
+        .collect(Collectors.toList());
+  }
+
+  private void outputRevokedPrivileges(Map<String, Set<Privilege>> revokedPrivileges) {
+    List<String> revokedInfoList = Lists.newArrayList();
+
+    for (Map.Entry<String, Set<Privilege>> entry : revokedPrivileges.entrySet()) {
+      List<String> revokedPrivilegesList =
+          entry.getValue().stream().map(Privilege::simpleString).collect(Collectors.toList());
+      revokedInfoList.add(entry.getKey() + ": " + COMMA_JOINER.join(revokedPrivilegesList));
+    }
+
+    System.out.println("Revoked privileges:");
+    for (String info : revokedInfoList) {
+      System.out.println(info);
+    }
+  }
+
+  private void outputRevokedPrivileges(String message) {
+    System.out.println(message);
+  }
+
+  /**
+   * verify the arguments.
+   *
+   * @return Returns itself via argument validation, otherwise exits.
+   */
+  @Override
+  public Command validate() {
+    if (!entity.hasName()) exitWithError(ErrorMessages.MISSING_NAME);
+    return super.validate();
+  }
+}

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/RevokePrivilegesFromRole.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/RevokePrivilegesFromRole.java
@@ -87,17 +87,13 @@ public class RevokePrivilegesFromRole extends MetadataCommand {
       MetadataObject metadataObject = constructMetadataObject(entity, client);
       client.revokePrivilegesFromRole(role, metadataObject, privilegesSet);
     } catch (NoSuchMetalakeException err) {
-      System.err.println(ErrorMessages.UNKNOWN_METALAKE);
-      return;
+      exitWithError(ErrorMessages.UNKNOWN_METALAKE);
     } catch (NoSuchRoleException err) {
-      System.err.println(ErrorMessages.UNKNOWN_ROLE);
-      return;
+      exitWithError(ErrorMessages.UNKNOWN_ROLE);
     } catch (NoSuchMetadataObjectException err) {
-      System.err.println(ErrorMessages.UNKNOWN_USER);
-      return;
+      exitWithError(ErrorMessages.UNKNOWN_USER);
     } catch (Exception exp) {
-      System.err.println(exp.getMessage());
-      return;
+      exitWithError(exp.getMessage());
     }
 
     String all = String.join(",", privileges);

--- a/clients/cli/src/main/resources/role_help.txt
+++ b/clients/cli/src/main/resources/role_help.txt
@@ -42,3 +42,6 @@ gcli role grant --name catalog_postgres --role admin --privilege create_table mo
 
 Revoke a privilege
 gcli role revoke --metalake metalake_demo --name catalog_postgres --role admin --privilege create_table modify_table
+
+Revoke all privileges
+gcli role revoke --metalake metalake_demo --name catalog_postgres --role admin --all

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -798,6 +798,12 @@ gcli role grant --name catalog_postgres --role admin --privilege create_table mo
 gcli role revoke --metalake metalake_demo --name catalog_postgres --role admin --privilege create_table modify_table
 ```
 
+### Revoke all privileges
+
+```bash
+gcli role revoke --metalake metalake_demo --name catalog_postgres --role admin --all
+```
+
 ### Topic commands
 
 #### Display a topic's details


### PR DESCRIPTION
### What changes were proposed in this pull request?

Revoke all privileges from a role via the Gravitino CLI. syntax: `gcli role revoke --name <name> --role <role> --all`

The step as follows:

1. Retrieve the `SecurableObject` instance using `role` and `fullname`;
2. Obtain the privileges associated with the `SecurableObject`;
3. Revoke all identified privileges;

### Why are the changes needed?

Fix: #6278 

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

local tests + ut

```bash
gcli role grant -m demo_metalake --name Hive.default --role roleA --privilege create_table modify_table -i
# roleA granted create_table,modify_table on Hive.default

gcli role revoke -m demo_metalake --name Hive.default --all --role roleA -i
# Hive.default: ALLOW create table, ALLOW modify table
```