### PR TITLE
[#6335] fix(python-client): Fix pypi document link error 

### DIFF
--- a/clients/client-python/build.gradle.kts
+++ b/clients/client-python/build.gradle.kts
@@ -31,8 +31,6 @@ pythonPlugin {
   pythonVersion.set(project.rootProject.extra["pythonVersion"].toString())
 }
 
-val gravitinoVersion: String = project.properties["version"] as String
-
 fun deleteCacheDir(targetDir: String) {
   project.fileTree(project.projectDir).matching {
     include("**/$targetDir/**")
@@ -124,10 +122,10 @@ fun generatePypiProjectHomePage() {
     // relative path of the images in the how-to-use-python-client.md file is incorrect. We need
     // to fix the relative path of the images/markdown to the absolute path.
     val content = outputFile.readText()
-    val docsUrl = "https://gravitino.apache.org/docs/$gravitinoVersion"
+    val docsUrl = "https://gravitino.apache.org/docs/latest"
 
     // Use regular expression to match the `[](./a/b/c.md?language=python)` or `[](./a/b/c.md#arg1)` link in the content
-    // Convert `[](./a/b/c.md?language=python)` to `[](https://gravitino.apache.org/docs/$gravitinoVersion/a/b/c/language=python)`
+    // Convert `[](./a/b/c.md?language=python)` to `[](https://gravitino.apache.org/docs/latest/a/b/c/language=python)`
     val patternDocs = Regex("""(?<!!)\[([^\]]+)]\(\.\/([^)]+)\.md([?#][^)]+)?\)""")
     val contentUpdateDocs = patternDocs.replace(content) { matchResult ->
       val text = matchResult.groupValues[1]

--- a/clients/client-python/build.gradle.kts
+++ b/clients/client-python/build.gradle.kts
@@ -31,6 +31,8 @@ pythonPlugin {
   pythonVersion.set(project.rootProject.extra["pythonVersion"].toString())
 }
 
+val gravitinoVersion: String = project.properties["version"] as String
+
 fun deleteCacheDir(targetDir: String) {
   project.fileTree(project.projectDir).matching {
     include("**/$targetDir/**")
@@ -122,7 +124,7 @@ fun generatePypiProjectHomePage() {
     // relative path of the images in the how-to-use-python-client.md file is incorrect. We need
     // to fix the relative path of the images/markdown to the absolute path.
     val content = outputFile.readText()
-    val docsUrl = "https://datastrato.ai/docs/latest"
+    val docsUrl = "https://gravitino.apache.org/docs/$gravitinoVersion"
 
     // Use regular expression to match the `[](./a/b/c.md?language=python)` or `[](./a/b/c.md#arg1)` link in the content
     // Convert `[](./a/b/c.md?language=python)` to `[](https://datastrato.ai/docs/latest/a/b/c/language=python)`

--- a/clients/client-python/build.gradle.kts
+++ b/clients/client-python/build.gradle.kts
@@ -127,7 +127,7 @@ fun generatePypiProjectHomePage() {
     val docsUrl = "https://gravitino.apache.org/docs/$gravitinoVersion"
 
     // Use regular expression to match the `[](./a/b/c.md?language=python)` or `[](./a/b/c.md#arg1)` link in the content
-    // Convert `[](./a/b/c.md?language=python)` to `[](https://datastrato.ai/docs/latest/a/b/c/language=python)`
+    // Convert `[](./a/b/c.md?language=python)` to `[](https://gravitino.apache.org/docs/$gravitinoVersion/a/b/c/language=python)`
     val patternDocs = Regex("""(?<!!)\[([^\]]+)]\(\.\/([^)]+)\.md([?#][^)]+)?\)""")
     val contentUpdateDocs = patternDocs.replace(content) { matchResult ->
       val text = matchResult.groupValues[1]


### PR DESCRIPTION
### What changes were proposed in this pull request?

Correct the Gravitino document link from `https://datastrato.ai/docs/latest` to `https://gravitino.apache.org/docs/$gravitinoVersion`, suppose the publish version is `0.8.0-incubating`, the link will start with `https://gravitino.apache.org/docs/0.8.0-incubating`

### Why are the changes needed?

Fix: #6335 

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?

run `./gradlew :clients:client-python:distribution -x test` and check `README`
