### PR TITLE
[#4209] chore replace hardcoded  value with std definition

### DIFF
--- a/server-common/src/main/java/org/apache/gravitino/server/authentication/KerberosServerUtils.java
+++ b/server-common/src/main/java/org/apache/gravitino/server/authentication/KerberosServerUtils.java
@@ -22,6 +22,7 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
 import java.nio.charset.IllegalCharsetNameException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -353,11 +354,7 @@ public class KerberosServerUtils {
     }
 
     String getAsString() {
-      try {
-        return new String(bb.array(), bb.arrayOffset() + bb.position(), bb.remaining(), "UTF-8");
-      } catch (UnsupportedEncodingException e) {
-        throw new IllegalCharsetNameException("UTF-8"); // won't happen.
-      }
+        return new String(bb.array(), bb.arrayOffset() + bb.position(), bb.remaining(), StandardCharsets.UTF_8);
     }
 
     @Override

--- a/server-common/src/main/java/org/apache/gravitino/server/authentication/KerberosServerUtils.java
+++ b/server-common/src/main/java/org/apache/gravitino/server/authentication/KerberosServerUtils.java
@@ -16,12 +16,10 @@ package org.apache.gravitino.server.authentication;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.lang.reflect.InvocationTargetException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
-import java.nio.charset.IllegalCharsetNameException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -354,7 +352,8 @@ public class KerberosServerUtils {
     }
 
     String getAsString() {
-        return new String(bb.array(), bb.arrayOffset() + bb.position(), bb.remaining(), StandardCharsets.UTF_8);
+      return new String(
+          bb.array(), bb.arrayOffset() + bb.position(), bb.remaining(), StandardCharsets.UTF_8);
     }
 
     @Override


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?
Use standard definition lib value to replace the hardcoded value: UTF-8.
### Why are the changes needed?

Fix: #4209

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
no
