### PR TITLE
[#5932] improve(CLI): Fix the CLI  delete the anonymous user

### DIFF
--- a/clients/cli/src/main/java/org/apache/gravitino/cli/ErrorMessages.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/ErrorMessages.java
@@ -24,7 +24,7 @@ public class ErrorMessages {
   public static final String CATALOG_EXISTS = "Catalog already exists.";
   public static final String COLUMN_EXISTS = "Column already exists.";
   public static final String DELETE_ANONYMOUS_USER =
-      "Can't delete anonymous user. This will cause unexpected " + "behavior.";
+      "Can't delete anonymous user. This will cause unexpected behavior.";
   public static final String FILESET_EXISTS = "Fileset already exists.";
   public static final String GROUP_EXISTS = "Group already exists.";
   public static final String METALAKE_EXISTS = "Metalake already exists.";

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/ErrorMessages.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/ErrorMessages.java
@@ -23,6 +23,8 @@ package org.apache.gravitino.cli;
 public class ErrorMessages {
   public static final String CATALOG_EXISTS = "Catalog already exists.";
   public static final String COLUMN_EXISTS = "Column already exists.";
+  public static final String DELETE_ANONYMOUS_USER =
+      "Can't delete anonymous user. This will cause unexpected " + "behavior.";
   public static final String FILESET_EXISTS = "Fileset already exists.";
   public static final String GROUP_EXISTS = "Group already exists.";
   public static final String METALAKE_EXISTS = "Metalake already exists.";

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/DeleteUser.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/DeleteUser.java
@@ -19,6 +19,7 @@
 
 package org.apache.gravitino.cli.commands;
 
+import org.apache.gravitino.auth.AuthConstants;
 import org.apache.gravitino.cli.AreYouSure;
 import org.apache.gravitino.cli.ErrorMessages;
 import org.apache.gravitino.client.GravitinoClient;
@@ -53,7 +54,7 @@ public class DeleteUser extends Command {
   public void handle() {
     boolean deleted = false;
 
-    if ("anonymous".equalsIgnoreCase(user)) {
+    if (AuthConstants.ANONYMOUS_USER.equalsIgnoreCase(user)) {
       exitWithError(ErrorMessages.DELETE_ANONYMOUS_USER);
     }
 

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/DeleteUser.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/DeleteUser.java
@@ -53,6 +53,10 @@ public class DeleteUser extends Command {
   public void handle() {
     boolean deleted = false;
 
+    if ("anonymous".equalsIgnoreCase(user)) {
+      exitWithError(ErrorMessages.DELETE_ANONYMOUS_USER);
+    }
+
     if (!AreYouSure.really(force)) {
       return;
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix the CLI  delete the anonymous user
### Why are the changes needed?

Fix: #5932 

### Does this PR introduce _any_ user-facing change?

(Please list the user-facing changes introduced by your change, including
  1. Change in user-facing APIs.
  2. Addition or removal of property keys.)

### How was this patch tested?

local test

```bash
gcli user delete -m demo_metalake --user anonymous
# Can't delete anonymous user. This will cause unexpected behavior.
```

<img width="536" alt="image" src="https://github.com/user-attachments/assets/479ec7eb-2ad3-42bd-b70a-a6f2ce05f794" />

