### PR TITLE
[#6363] improvment(bundle-gcp): Shade some GCP IAM classes in `gcp-bundles` to avoid possible conflict

### DIFF
--- a/bundles/gcp-bundle/build.gradle.kts
+++ b/bundles/gcp-bundle/build.gradle.kts
@@ -37,17 +37,18 @@ tasks.withType(ShadowJar::class.java) {
   archiveClassifier.set("")
 
   // Relocate dependencies to avoid conflicts
-  relocate("org.apache.httpcomponents", "org.apache.gravitino.gcp.shaded.org.apache.httpcomponents")
-  relocate("org.apache.commons", "org.apache.gravitino.gcp.shaded.org.apache.commons")
-  relocate("com.google.common", "org.apache.gravitino.gcp.shaded.com.google.common")
   relocate("com.fasterxml", "org.apache.gravitino.gcp.shaded.com.fasterxml")
-  relocate("org.eclipse.jetty", "org.apache.gravitino.gcp.shaded.org.eclipse.jetty")
-  relocate("com.google.protobuf", "org.apache.gravitino.gcp.shaded.com.google.protobuf")
-  relocate("io.grpc", "org.apache.gravitino.gcp.shaded.io.grpc")
-  relocate("com.google.iam", "org.apache.gravitino.gcp.shaded.com.google.iam")
-  relocate("com.google.longrunning", "org.apache.gravitino.gcp.shaded.com.google.longrunning")
   relocate("com.google.api", "org.apache.gravitino.gcp.shaded.com.google.api")
   relocate("com.google.auth", "org.apache.gravitino.gcp.shaded.com.google.auth")
+  relocate("com.google.common", "org.apache.gravitino.gcp.shaded.com.google.common")
+  relocate("com.google.iam", "org.apache.gravitino.gcp.shaded.com.google.iam")
+  relocate("com.google.longrunning", "org.apache.gravitino.gcp.shaded.com.google.longrunning")
+  relocate("com.google.protobuf", "org.apache.gravitino.gcp.shaded.com.google.protobuf")
+  relocate("io.grpc", "org.apache.gravitino.gcp.shaded.io.grpc")
+
+  relocate("org.apache.commons", "org.apache.gravitino.gcp.shaded.org.apache.commons")
+  relocate("org.apache.httpcomponents", "org.apache.gravitino.gcp.shaded.org.apache.httpcomponents")
+  relocate("org.eclipse.jetty", "org.apache.gravitino.gcp.shaded.org.eclipse.jetty")
   mergeServiceFiles()
 }
 

--- a/bundles/gcp-bundle/build.gradle.kts
+++ b/bundles/gcp-bundle/build.gradle.kts
@@ -42,6 +42,12 @@ tasks.withType(ShadowJar::class.java) {
   relocate("com.google.common", "org.apache.gravitino.gcp.shaded.com.google.common")
   relocate("com.fasterxml", "org.apache.gravitino.gcp.shaded.com.fasterxml")
   relocate("org.eclipse.jetty", "org.apache.gravitino.gcp.shaded.org.eclipse.jetty")
+  relocate("com.google.protobuf", "org.apache.gravitino.gcp.shaded.com.google.protobuf")
+  relocate("io.grpc", "org.apache.gravitino.gcp.shaded.io.grpc")
+  relocate("com.google.iam", "org.apache.gravitino.gcp.shaded.com.google.iam")
+  relocate("com.google.longrunning", "org.apache.gravitino.gcp.shaded.com.google.longrunning")
+  relocate("com.google.api", "org.apache.gravitino.gcp.shaded.com.google.api")
+  relocate("com.google.auth", "org.apache.gravitino.gcp.shaded.com.google.auth")
   mergeServiceFiles()
 }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Shade some GCP, gcp and probobuf classes to avoid conflicts with GCP IAM classes. 

### Why are the changes needed?

To avoid possible class conflicts.

Fix: #6363

### Does this PR introduce _any_ user-facing change?

N/A.

### How was this patch tested?

existing UTs and ITs.