### PR TITLE
[#6375] improvment(catalog-hadoop): Remove `protobuf-java` to avoid conflict with authorization module

### DIFF
--- a/catalogs/catalog-hadoop/build.gradle.kts
+++ b/catalogs/catalog-hadoop/build.gradle.kts
@@ -52,7 +52,11 @@ dependencies {
     exclude("org.eclipse.jetty", "*")
     exclude("io.netty")
     exclude("org.fusesource.leveldbjni")
-    // Exclude protobuf-java to avoid conflict with;
+    // Exclude `protobuf-java` 2.5.0 to avoid conflict with a higher version of `protobuf-java`
+    // in the authorization module. The reason is that the class loader of `catalog-hadoop` is the
+    // parent of the class loader of the authorization module, so the class loader of `catalog-hadoop`
+    // will load the class `protobuf-java` 2.5.0 first, which will cause the authorization module to
+    // fail to load the class `protobuf-java` 3.15.8.
     exclude("com.google.protobuf", "protobuf-java")
   }
   implementation(libs.slf4j.api)

--- a/catalogs/catalog-hadoop/build.gradle.kts
+++ b/catalogs/catalog-hadoop/build.gradle.kts
@@ -52,6 +52,8 @@ dependencies {
     exclude("org.eclipse.jetty", "*")
     exclude("io.netty")
     exclude("org.fusesource.leveldbjni")
+    // Exclude protobuf-java to avoid conflict with;
+    exclude("com.google.protobuf", "protobuf-java")
   }
   implementation(libs.slf4j.api)
   implementation(libs.awaitility)
@@ -101,6 +103,9 @@ tasks {
       exclude("javax.servlet-*.jar")
       exclude("kerb-*.jar")
       exclude("kerby-*.jar")
+      // As L55-56 takes no effect actually in the final distribution package, we need to exclude
+      // protobuf-java here
+      exclude("protobuf-java-*.jar")
     }
     into("$rootDir/distribution/package/catalogs/hadoop/libs")
   }

--- a/catalogs/catalog-hadoop/build.gradle.kts
+++ b/catalogs/catalog-hadoop/build.gradle.kts
@@ -103,9 +103,6 @@ tasks {
       exclude("javax.servlet-*.jar")
       exclude("kerb-*.jar")
       exclude("kerby-*.jar")
-      // As L55-56 takes no effect actually in the final distribution package, we need to exclude
-      // protobuf-java here
-      exclude("protobuf-java-*.jar")
     }
     into("$rootDir/distribution/package/catalogs/hadoop/libs")
   }


### PR DESCRIPTION

### What changes were proposed in this pull request?

Remove jar `protobuf-java.jar` from the distribution package to avoid conflicts

### Why are the changes needed?

To make authorization works for GCS fileset.

Fix: #6375 

### Does this PR introduce _any_ user-facing change?

N/A.

### How was this patch tested?

N/A
