### PR TITLE
[#6384] fix: Gravitino default JVM config mismatches with comments from gravitino-env.sh

### DIFF
--- a/bin/common.sh.template
+++ b/bin/common.sh.template
@@ -106,7 +106,7 @@ function addDirToClasspath(){
 }
 
 if [[ -z "${GRAVITINO_MEM}" ]]; then
-  export GRAVITINO_MEM="-Xmx1024m"
+  export GRAVITINO_MEM="-Xms1024m -Xmx1024m -XX:MaxMetaspaceSize=512m"
 fi
 
 if [[ -n "${JAVA_HOME}" ]]; then


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Update Gravitino JVM memory default.

### Why are the changes needed?

Fix: https://github.com/apache/gravitino/issues/6384

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

No test
