### PR TITLE
[#6382] feat(iceberg):  Make Gravitino Iceberg REST server keep compatibility with Trino

### DIFF
--- a/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/ops/IcebergCatalogWrapper.java
+++ b/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/ops/IcebergCatalogWrapper.java
@@ -216,10 +216,11 @@ public class IcebergCatalogWrapper implements AutoCloseable {
   }
 
   public LoadViewResponse loadView(TableIdentifier viewIdentifier) {
-    // Trino will try to list Iceberg view when listing tables, return empty list to avoid the
-    // unexpected exception.
+    // Trino Analyzer try to get view from Iceberg catalog, return NoSuchViewException to keep
+    // the compatibility with Trino.
     if (!(catalog instanceof ViewCatalog)) {
-      throw new NoSuchViewException("catalog doesn't support view");
+      throw new NoSuchViewException(
+          String.format("Catalog %s doesn't support view", catalog.name()));
     }
     return CatalogHandlers.loadView(getViewCatalog(), viewIdentifier);
   }
@@ -234,12 +235,15 @@ public class IcebergCatalogWrapper implements AutoCloseable {
   }
 
   public boolean viewExists(TableIdentifier viewIdentifier) {
+    if (!(catalog instanceof ViewCatalog)) {
+      return false;
+    }
     return getViewCatalog().viewExists(viewIdentifier);
   }
 
   public ListTablesResponse listView(Namespace namespace) {
-    // Trino will try to list Iceberg view when listing tables, return empty list to avoid the
-    // unexpected exception.
+    // Trino try to list Iceberg view when listing tables in some version, return empty list to
+    // avoid the unexpected exception.
     if (!(catalog instanceof ViewCatalog)) {
       return ListTablesResponse.builder().build();
     }

--- a/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/ops/IcebergCatalogWrapper.java
+++ b/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/ops/IcebergCatalogWrapper.java
@@ -40,6 +40,7 @@ import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.SupportsNamespaces;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.catalog.ViewCatalog;
+import org.apache.iceberg.exceptions.NoSuchViewException;
 import org.apache.iceberg.rest.CatalogHandlers;
 import org.apache.iceberg.rest.requests.CreateNamespaceRequest;
 import org.apache.iceberg.rest.requests.CreateTableRequest;
@@ -215,6 +216,11 @@ public class IcebergCatalogWrapper implements AutoCloseable {
   }
 
   public LoadViewResponse loadView(TableIdentifier viewIdentifier) {
+    // Trino will try to list Iceberg view when listing tables, return empty list to avoid the
+    // unexpected exception.
+    if (!(catalog instanceof ViewCatalog)) {
+      throw new NoSuchViewException("catalog doesn't support view");
+    }
     return CatalogHandlers.loadView(getViewCatalog(), viewIdentifier);
   }
 
@@ -232,6 +238,11 @@ public class IcebergCatalogWrapper implements AutoCloseable {
   }
 
   public ListTablesResponse listView(Namespace namespace) {
+    // Trino will try to list Iceberg view when listing tables, return empty list to avoid the
+    // unexpected exception.
+    if (!(catalog instanceof ViewCatalog)) {
+      return ListTablesResponse.builder().build();
+    }
     return CatalogHandlers.listViews(getViewCatalog(), namespace);
   }
 

--- a/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/ops/IcebergCatalogWrapper.java
+++ b/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/ops/IcebergCatalogWrapper.java
@@ -219,8 +219,7 @@ public class IcebergCatalogWrapper implements AutoCloseable {
     // Trino Analyzer try to get view from Iceberg catalog, return NoSuchViewException to keep
     // the compatibility with Trino.
     if (!(catalog instanceof ViewCatalog)) {
-      throw new NoSuchViewException(
-          String.format("Catalog %s doesn't support view", catalog.name()));
+      throw new NoSuchViewException("Catalog %s doesn't support view", catalog.name());
     }
     return CatalogHandlers.loadView(getViewCatalog(), viewIdentifier);
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

To keep compatible with Trino, for the catalog backend which doesn't support view operation:

1. Return empty list when listing views 
2. Throw `NoSuchViewException` not `UnsupportedOperationException` for load view.

### Why are the changes needed?

Fix: #6382 

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?

test basic SQL with Trino and Gravitino Iceberg REST server
```
connector.name=iceberg
iceberg.catalog.type=rest
iceberg.rest-catalog.uri=http://192.168.31.176:9001/iceberg/
fs.hadoop.enabled=true
```