### PR TITLE
[MINOR] fix(gvfs): expose the nested exception for better understanding

### DIFF
--- a/clients/filesystem-hadoop3/src/main/java/org/apache/gravitino/filesystem/hadoop/GravitinoVirtualFileSystem.java
+++ b/clients/filesystem-hadoop3/src/main/java/org/apache/gravitino/filesystem/hadoop/GravitinoVirtualFileSystem.java
@@ -322,8 +322,10 @@ public class GravitinoVirtualFileSystem extends FileSystem {
                 return provider.getFileSystem(filePath, totalProperty);
               } catch (IOException ioe) {
                 throw new GravitinoRuntimeException(
+                    ioe,
                     "Exception occurs when create new FileSystem for actual uri: %s, msg: %s",
-                    uri, ioe);
+                    uri,
+                    ioe.getMessage());
               }
             });
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Improve the gvfs to expose the nested exception for better understanding.

### Why are the changes needed?

The exception message may not be enough to understand the problem why the fs initialization is failed. So we should expose the whole stack for better understanding.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing tests.
