### PR TITLE
[#6409] fix(client-python): Change to use `GenericFileset`  for the return value of fileset catalog

### DIFF
--- a/clients/client-python/gravitino/client/fileset_catalog.py
+++ b/clients/client-python/gravitino/client/fileset_catalog.py
@@ -178,7 +178,7 @@ class FilesetCatalog(BaseSchemaCatalog, SupportsCredentials):
         fileset_resp = FilesetResponse.from_json(resp.body, infer_missing=True)
         fileset_resp.validate()
 
-        return fileset_resp.fileset()
+        return GenericFileset(fileset_resp.fileset(), self.rest_client, full_namespace)
 
     def alter_fileset(self, ident: NameIdentifier, *changes) -> Fileset:
         """Update a fileset metadata in the catalog.
@@ -187,7 +187,7 @@ class FilesetCatalog(BaseSchemaCatalog, SupportsCredentials):
             ident: A fileset identifier, which should be "schema.fileset" format.
             changes: The changes to apply to the fileset.
 
-        Args:
+        Raises:
             IllegalArgumentException If the changes are invalid.
             NoSuchFilesetException If the fileset does not exist.
 
@@ -212,7 +212,7 @@ class FilesetCatalog(BaseSchemaCatalog, SupportsCredentials):
         fileset_resp = FilesetResponse.from_json(resp.body, infer_missing=True)
         fileset_resp.validate()
 
-        return fileset_resp.fileset()
+        return GenericFileset(fileset_resp.fileset(), self.rest_client, full_namespace)
 
     def drop_fileset(self, ident: NameIdentifier) -> bool:
         """Drop a fileset from the catalog.


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR changes the return value to `GenericFileset` for fileset operation.

### Why are the changes needed?

Previously, it returns the plain fileset dto, so that it cannot support some operations like get credentials.

Fix: #6409 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing tests.
