### PR TITLE
Update Capability.java

### DIFF
--- a/core/src/main/java/org/apache/gravitino/connector/capability/Capability.java
+++ b/core/src/main/java/org/apache/gravitino/connector/capability/Capability.java
@@ -126,18 +126,23 @@ public interface Capability {
     }
 
     @Override
-    public CapabilityResult specificationOnName(Scope scope, String name) {
-      if (RESERVED_WORDS.contains(name.toLowerCase())) {
-        return CapabilityResult.unsupported(
-            String.format("The %s name '%s' is reserved.", scope, name));
-      }
+public CapabilityResult specificationOnName(Scope scope, String name) {
+  if (RESERVED_WORDS.contains(name.toLowerCase())) {
+    return CapabilityResult.unsupported(
+        String.format("The %s name '%s' is reserved.", scope, name));
+  }
 
-      if (!name.matches(DEFAULT_NAME_PATTERN)) {
-        return CapabilityResult.unsupported(
-            String.format("The %s name '%s' is illegal.", scope, name));
-      }
-      return CapabilityResult.SUPPORTED;
-    }
+  if (!name.matches(DEFAULT_NAME_PATTERN)) {
+    return CapabilityResult.unsupported(
+        String.format(
+            "The %s name '%s' is illegal. It must start with a letter, digit, or underscore, "
+            + "and may contain letters, digits, underscores, slashes, hyphens, or equals signs, "
+            + "with a maximum length of 64 characters.", 
+            scope, name));
+  }
+  return CapabilityResult.SUPPORTED;
+}
+
 
     @Override
     public CapabilityResult managedStorage(Scope scope) {


### PR DESCRIPTION
Adjusted the error message in CapabilityResult.unsupported for DEFAULT_NAME_PATTERN mismatch.
The message now explicitly lists the allowed characters and pattern restrictions based on the regex.
This keeps the logic consistent and clarifies validation criteria for users.