### PR TITLE
[#6429] Fixed Wrong log format codes

### DIFF
--- a/core/src/main/java/org/apache/gravitino/authorization/AuthorizationUtils.java
+++ b/core/src/main/java/org/apache/gravitino/authorization/AuthorizationUtils.java
@@ -417,7 +417,7 @@ public class AuthorizationUtils {
       if (defaultSchemaLocation != null && !defaultSchemaLocation.isEmpty()) {
         return defaultSchemaLocation;
       } else {
-        LOG.warn("Schema %s location is not found", defaultSchemaIdent);
+        LOG.warn("Schema {} location is not found", defaultSchemaIdent);
       }
     }
 
@@ -480,7 +480,7 @@ public class AuthorizationUtils {
                 if (StringUtils.isNotBlank(schemaLocation)) {
                   locations.add(schemaLocation);
                 } else {
-                  LOG.warn("Schema %s location is not found", ident);
+                  LOG.warn("Schema {} location is not found", ident);
                 }
               }
             }
@@ -501,7 +501,7 @@ public class AuthorizationUtils {
                 if (StringUtils.isNotBlank(tableLocation)) {
                   locations.add(tableLocation);
                 } else {
-                  LOG.warn("Table %s location is not found", ident);
+                  LOG.warn("Table {} location is not found", ident);
                 }
               }
             }
@@ -522,7 +522,7 @@ public class AuthorizationUtils {
               "Failed to get location paths for metadata object %s type %s", ident, type);
       }
     } catch (Exception e) {
-      LOG.warn("Failed to get location paths for metadata object %s type %s", ident, type, e);
+      LOG.warn("Failed to get location paths for metadata object {} type {}", ident, type, e);
     }
 
     return locations;


### PR DESCRIPTION
### What changes were proposed in this pull request?

The PR updates incorrect log format codes from `%s` to `{}` in the following lines:

- Line 420
- Line 483
- Line 504
- Line 525

The original code in these lines used the `%s` placeholder, which is invalid for the logging framework used. It has been corrected to use `{}` to match the proper syntax for log messages.

### Why are the changes needed?

This change is necessary to fix the incorrect log format codes in the codebase. The `%s` placeholder is not valid and can lead to incorrect log formatting or errors when the logs are generated. The correct placeholder syntax for this logging framework is `{}`.

Fix: #6429

### Does this PR introduce _any_ user-facing change?

No user-facing changes are introduced. This is an internal fix for the logging format.

### How was this patch tested?

The changes were verified manually by reviewing the code and ensuring that all instances of `%s` were replaced with `{}` in the affected lines. No new functionality was added, so no additional tests were required.