### PR TITLE
[HOTFIX] fix compile paimon error by broken maven version for net.minidev:json-smart

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -976,3 +976,10 @@ fun checkOrbStackStatus() {
 }
 
 printDockerCheckInfo()
+
+// Temporarily locking in to avoid https://github.com/netplex/json-smart-v2/issues/240
+configurations.all {
+  resolutionStrategy {
+    force("net.minidev:json-smart:2.3")
+  }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -269,6 +269,13 @@ subprojects {
     mavenLocal()
   }
 
+  // Temporarily locking in to avoid https://github.com/netplex/json-smart-v2/issues/240
+  configurations.all {
+    resolutionStrategy {
+      force("net.minidev:json-smart:2.3")
+    }
+  }
+
   java {
     toolchain {
       // Some JDK vendors like Homebrew installed OpenJDK 17 have problems in building trino-connector:
@@ -976,10 +983,3 @@ fun checkOrbStackStatus() {
 }
 
 printDockerCheckInfo()
-
-// Temporarily locking in to avoid https://github.com/netplex/json-smart-v2/issues/240
-configurations.all {
-  resolutionStrategy {
-    force("net.minidev:json-smart:2.3")
-  }
-}

--- a/catalogs/catalog-lakehouse-paimon/build.gradle.kts
+++ b/catalogs/catalog-lakehouse-paimon/build.gradle.kts
@@ -29,6 +29,13 @@ val sparkVersion: String = libs.versions.spark34.get()
 val sparkMajorVersion: String = sparkVersion.substringBeforeLast(".")
 val paimonVersion: String = libs.versions.paimon.get()
 
+// Temporarily locking in to avoid https://github.com/netplex/json-smart-v2/issues/240
+configurations.all {
+  resolutionStrategy {
+    force("net.minidev:json-smart:2.3")
+  }
+}
+
 dependencies {
   implementation(project(":api")) {
     exclude("*")

--- a/catalogs/catalog-lakehouse-paimon/build.gradle.kts
+++ b/catalogs/catalog-lakehouse-paimon/build.gradle.kts
@@ -32,7 +32,7 @@ val paimonVersion: String = libs.versions.paimon.get()
 // Temporarily locking in to avoid https://github.com/netplex/json-smart-v2/issues/240
 configurations.all {
   resolutionStrategy {
-    force("net.minidev:json-smart:2.3")
+    force("net.minidev:json-smart:2.5.2")
   }
 }
 

--- a/catalogs/catalog-lakehouse-paimon/build.gradle.kts
+++ b/catalogs/catalog-lakehouse-paimon/build.gradle.kts
@@ -29,13 +29,6 @@ val sparkVersion: String = libs.versions.spark34.get()
 val sparkMajorVersion: String = sparkVersion.substringBeforeLast(".")
 val paimonVersion: String = libs.versions.paimon.get()
 
-// Temporarily locking in to avoid https://github.com/netplex/json-smart-v2/issues/240
-configurations.all {
-  resolutionStrategy {
-    force("net.minidev:json-smart:2.5.2")
-  }
-}
-
 dependencies {
   implementation(project(":api")) {
     exclude("*")


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Temporarily locking in to avoid https://github.com/netplex/json-smart-v2/issues/240

### Why are the changes needed?

Couldn't compile Gravitino code
```
Execution failed for task ':catalogs:catalog-lakehouse paimon:compileJava'.

> Could not resolve all files for configuration ':catalogs:catalog-lakehouse-paimon: compileclasspath'

> Could not find any version that matches net.minidev:json-smart:[1.3.1,2.3].

Versions that do not match: 2.5.2

Searched in the following locations:
- https: //repo.maven.apache.org/maven2/net/minidev/json-smart/maven-metadata.xml

file:/home/runner/.m2/repository/net/minidev/json-smart/

Required by:
project :catalogs:catalog-lakethouse-paimon > org.apache.hadop:hadop-comon:2.10.2 > org.apache.hadoop:hadop-auth2.10.2 > com.nimbusds:nimbus-jose-jwt:7.g
```


### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
compile success in local
