### PR TITLE
[MINOR] improve(CLI): Remove redundant code in CLI

### DIFF
--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/AuditCommand.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/AuditCommand.java
@@ -23,13 +23,6 @@ import org.apache.gravitino.Audit;
 import org.apache.gravitino.cli.CommandContext;
 
 public abstract class AuditCommand extends Command {
-  /**
-   * @param url The URL of the Gravitino server.
-   * @param ignoreVersions If true don't check the client/server versions match.
-   */
-  public AuditCommand(String url, boolean ignoreVersions) {
-    super(url, ignoreVersions);
-  }
 
   /** @param context The command context. */
   public AuditCommand(CommandContext context) {

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/Command.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/Command.java
@@ -55,7 +55,7 @@ public abstract class Command {
   private final boolean ignoreVersions;
   private final String outputFormat;
 
-  protected CommandContext context = null; // TODO make final
+  protected final CommandContext context;
 
   /**
    * Command constructor.
@@ -67,31 +67,6 @@ public abstract class Command {
     this.url = context.url();
     this.ignoreVersions = context.ignoreVersions();
     this.outputFormat = context.outputFormat();
-  }
-
-  /**
-   * Command constructor.
-   *
-   * @param url The URL of the Gravitino server.
-   * @param ignoreVersions If true don't check the client/server versions match.
-   */
-  public Command(String url, boolean ignoreVersions) {
-    this.url = url;
-    this.ignoreVersions = ignoreVersions;
-    this.outputFormat = OUTPUT_FORMAT_PLAIN;
-  }
-
-  /**
-   * Command constructor.
-   *
-   * @param url The URL of the Gravitino server.
-   * @param ignoreVersions If true don't check the client/server versions match.
-   * @param outputFormat output format used in some commands
-   */
-  public Command(String url, boolean ignoreVersions, String outputFormat) {
-    this.url = url;
-    this.ignoreVersions = ignoreVersions;
-    this.outputFormat = outputFormat;
   }
 
   /**

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/ListProperties.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/ListProperties.java
@@ -34,16 +34,6 @@ public class ListProperties extends Command {
     super(context);
   }
 
-  /**
-   * List the properties of an entity.
-   *
-   * @param url The URL of the Gravitino server.
-   * @param ignoreVersions If true don't check the client/server versions match.
-   */
-  public ListProperties(String url, boolean ignoreVersions) {
-    super(url, ignoreVersions);
-  }
-
   @Override
   public void handle() {
     /* Do nothing */

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/MetadataCommand.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/MetadataCommand.java
@@ -31,16 +31,6 @@ public class MetadataCommand extends Command {
   /**
    * MetadataCommand constructor.
    *
-   * @param url The URL of the Gravitino server.
-   * @param ignoreVersions If true don't check the client/server versions match.
-   */
-  public MetadataCommand(String url, boolean ignoreVersions) {
-    super(url, ignoreVersions);
-  }
-
-  /**
-   * MetadataCommand constructor.
-   *
    * @param context The command context.
    */
   public MetadataCommand(CommandContext context) {

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/TableCommand.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/TableCommand.java
@@ -40,20 +40,6 @@ public class TableCommand extends AuditCommand {
     this.catalog = catalog;
   }
 
-  /**
-   * Common code for all table commands.
-   *
-   * @param url The URL of the Gravitino server.
-   * @param ignoreVersions If true don't check the client/server versions match.
-   * @param metalake The name of the metalake.
-   * @param catalog The name of the catalog.
-   */
-  public TableCommand(String url, boolean ignoreVersions, String metalake, String catalog) {
-    super(url, ignoreVersions);
-    this.metalake = metalake;
-    this.catalog = catalog;
-  }
-
   /* Overridden in parent - do nothing  */
   @Override
   public void handle() {}


### PR DESCRIPTION
### What changes were proposed in this pull request?

Remove redundant code in CLI, and make context argument final in Command class. 

### Why are the changes needed?

The constructor should take only one argument, CommandContext.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

local test.
