### PR TITLE
[#6097] improve(CLI): Add --quiet option to the Gravitino CLI

### DIFF
--- a/clients/cli/src/main/java/org/apache/gravitino/cli/CommandContext.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/CommandContext.java
@@ -29,6 +29,7 @@ public class CommandContext {
   private final boolean ignoreVersions;
   private final String outputFormat;
   private final String url;
+  private final boolean quiet;
   private final CommandLine line;
 
   private String ignoreEnv;
@@ -50,6 +51,7 @@ public class CommandContext {
         line.hasOption(GravitinoOptions.OUTPUT)
             ? line.getOptionValue(GravitinoOptions.OUTPUT)
             : Command.OUTPUT_FORMAT_PLAIN;
+    this.quiet = line.hasOption(GravitinoOptions.QUIET);
 
     this.url = getUrl();
     this.ignoreVersions = getIgnore();
@@ -89,6 +91,15 @@ public class CommandContext {
    */
   public String outputFormat() {
     return outputFormat;
+  }
+
+  /**
+   * Returns whether the command information should be suppressed.
+   *
+   * @return True if the command information should be suppressed.
+   */
+  public boolean quiet() {
+    return quiet;
   }
 
   /**

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/GravitinoOptions.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/GravitinoOptions.java
@@ -48,6 +48,7 @@ public class GravitinoOptions {
   public static final String PRIVILEGE = "privilege";
   public static final String PROPERTIES = "properties";
   public static final String PROPERTY = "property";
+  public static final String QUIET = "quiet";
   public static final String PROVIDER = "provider";
   public static final String RENAME = "rename";
   public static final String ROLE = "role";
@@ -91,6 +92,7 @@ public class GravitinoOptions {
     options.addOption(createSimpleOption(null, SORTORDER, "display sortorder information"));
     options.addOption(createSimpleOption(null, ENABLE, "enable entities"));
     options.addOption(createSimpleOption(null, DISABLE, "disable entities"));
+    options.addOption(createSimpleOption(null, QUIET, "quiet mode"));
 
     // Create/update options
     options.addOption(createArgOption(RENAME, "new entity name"));

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/Command.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/Command.java
@@ -85,7 +85,10 @@ public abstract class Command {
    * @param message The message to display.
    */
   public void printInformation(String message) {
-    // so that future outoput could be suppressed
+    if (context.quiet()) {
+      return;
+    }
+
     System.out.print(message);
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add --quiet option to the Gravitino CLI

### Why are the changes needed?

Fix: #6097 

### Does this PR introduce _any_ user-facing change?

user can use --quiet option suppress the output.

### How was this patch tested?

local test

```bash
gcli tag create -m cli_demo --tag tagA tagB -i
# Tags tagA,tagB created

gcli tag create -m cli_demo --tag tagC tagD -i --quiet
# no output
```
