### PR TITLE
[#6468] feature(core): add metrics for mysql backend connect pool

### DIFF
--- a/core/src/main/java/org/apache/gravitino/metrics/MetricNames.java
+++ b/core/src/main/java/org/apache/gravitino/metrics/MetricNames.java
@@ -22,6 +22,12 @@ package org.apache.gravitino.metrics;
 public class MetricNames {
   public static final String HTTP_PROCESS_DURATION = "http-request-duration-seconds";
   public static final String SERVER_IDLE_THREAD_NUM = "http-server.idle-thread.num";
+  public static final String ENTITY_STORE_RELATION_DATASOURCE_ACTIVE_CONNECTIONS =
+      "entity-store.relation-datasource.active-connections";
+  public static final String ENTITY_STORE_RELATION_DATASOURCE_IDLE_CONNECTIONS =
+      "entity-store.relation-datasource.idle-connections";
+  public static final String ENTITY_STORE_RELATION_DATASOURCE_MAX_CONNECTIONS =
+      "entity-store.relation-datasource.max-connections";
 
   private MetricNames() {}
 }

--- a/core/src/main/java/org/apache/gravitino/metrics/source/MetricsSource.java
+++ b/core/src/main/java/org/apache/gravitino/metrics/source/MetricsSource.java
@@ -41,7 +41,6 @@ public abstract class MetricsSource {
   public static final String ICEBERG_REST_SERVER_METRIC_NAME = "iceberg-rest-server";
   public static final String GRAVITINO_SERVER_METRIC_NAME = "gravitino-server";
   public static final String JVM_METRIC_NAME = "jvm";
-  public static final String RELATION_DATASOURCE_METRIC_NAME = "relation-datasource";
   private final MetricRegistry metricRegistry;
   private final String metricsSourceName;
   private final int timeSlidingWindowSeconds;

--- a/core/src/main/java/org/apache/gravitino/metrics/source/MetricsSource.java
+++ b/core/src/main/java/org/apache/gravitino/metrics/source/MetricsSource.java
@@ -41,6 +41,7 @@ public abstract class MetricsSource {
   public static final String ICEBERG_REST_SERVER_METRIC_NAME = "iceberg-rest-server";
   public static final String GRAVITINO_SERVER_METRIC_NAME = "gravitino-server";
   public static final String JVM_METRIC_NAME = "jvm";
+  public static final String RELATION_DATASOURCE_METRIC_NAME = "relation-datasource";
   private final MetricRegistry metricRegistry;
   private final String metricsSourceName;
   private final int timeSlidingWindowSeconds;

--- a/core/src/main/java/org/apache/gravitino/metrics/source/RelationDatasourceMetricsSource.java
+++ b/core/src/main/java/org/apache/gravitino/metrics/source/RelationDatasourceMetricsSource.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.metrics.source;
+
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.MetricRegistry;
+import org.apache.commons.dbcp2.BasicDataSource;
+
+public class RelationDatasourceMetricsSource extends MetricsSource {
+
+  public RelationDatasourceMetricsSource(BasicDataSource dataSource) {
+    super(MetricsSource.RELATION_DATASOURCE_METRIC_NAME);
+    MetricRegistry metricRegistry = getMetricRegistry();
+    metricRegistry.register("activeConnectionCount", (Gauge<Integer>) dataSource::getNumActive);
+    metricRegistry.register("idleConnectionCount", (Gauge<Integer>) dataSource::getNumIdle);
+    metricRegistry.register("maxConnectionCount", (Gauge<Integer>) dataSource::getMaxTotal);
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/metrics/source/RelationDatasourceMetricsSource.java
+++ b/core/src/main/java/org/apache/gravitino/metrics/source/RelationDatasourceMetricsSource.java
@@ -20,16 +20,21 @@
 package org.apache.gravitino.metrics.source;
 
 import com.codahale.metrics.Gauge;
-import com.codahale.metrics.MetricRegistry;
 import org.apache.commons.dbcp2.BasicDataSource;
+import org.apache.gravitino.metrics.MetricNames;
 
 public class RelationDatasourceMetricsSource extends MetricsSource {
 
   public RelationDatasourceMetricsSource(BasicDataSource dataSource) {
-    super(MetricsSource.RELATION_DATASOURCE_METRIC_NAME);
-    MetricRegistry metricRegistry = getMetricRegistry();
-    metricRegistry.register("activeConnectionCount", (Gauge<Integer>) dataSource::getNumActive);
-    metricRegistry.register("idleConnectionCount", (Gauge<Integer>) dataSource::getNumIdle);
-    metricRegistry.register("maxConnectionCount", (Gauge<Integer>) dataSource::getMaxTotal);
+    super(MetricsSource.GRAVITINO_SERVER_METRIC_NAME);
+    registerGauge(
+        MetricNames.ENTITY_STORE_RELATION_DATASOURCE_ACTIVE_CONNECTIONS,
+        (Gauge<Integer>) dataSource::getNumActive);
+    registerGauge(
+        MetricNames.ENTITY_STORE_RELATION_DATASOURCE_IDLE_CONNECTIONS,
+        (Gauge<Integer>) dataSource::getNumIdle);
+    registerGauge(
+        MetricNames.ENTITY_STORE_RELATION_DATASOURCE_MAX_CONNECTIONS,
+        (Gauge<Integer>) dataSource::getMaxTotal);
   }
 }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/session/SqlSessionFactoryHelper.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/session/SqlSessionFactoryHelper.java
@@ -26,6 +26,9 @@ import org.apache.commons.dbcp2.BasicDataSource;
 import org.apache.commons.pool2.impl.BaseObjectPoolConfig;
 import org.apache.gravitino.Config;
 import org.apache.gravitino.Configs;
+import org.apache.gravitino.GravitinoEnv;
+import org.apache.gravitino.metrics.MetricsSystem;
+import org.apache.gravitino.metrics.source.RelationDatasourceMetricsSource;
 import org.apache.gravitino.storage.relational.JDBCBackend.JDBCBackendType;
 import org.apache.gravitino.storage.relational.mapper.CatalogMetaMapper;
 import org.apache.gravitino.storage.relational.mapper.FilesetMetaMapper;
@@ -102,6 +105,8 @@ public class SqlSessionFactoryHelper {
     dataSource.setSoftMinEvictableIdleTimeMillis(
         BaseObjectPoolConfig.DEFAULT_SOFT_MIN_EVICTABLE_IDLE_TIME.toMillis());
     dataSource.setLifo(BaseObjectPoolConfig.DEFAULT_LIFO);
+    MetricsSystem metricsSystem = GravitinoEnv.getInstance().metricsSystem();
+    metricsSystem.register(new RelationDatasourceMetricsSource(dataSource));
 
     // Create the transaction factory and env
     TransactionFactory transactionFactory = new JdbcTransactionFactory();

--- a/core/src/main/java/org/apache/gravitino/storage/relational/session/SqlSessionFactoryHelper.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/session/SqlSessionFactoryHelper.java
@@ -106,8 +106,11 @@ public class SqlSessionFactoryHelper {
         BaseObjectPoolConfig.DEFAULT_SOFT_MIN_EVICTABLE_IDLE_TIME.toMillis());
     dataSource.setLifo(BaseObjectPoolConfig.DEFAULT_LIFO);
     MetricsSystem metricsSystem = GravitinoEnv.getInstance().metricsSystem();
-    metricsSystem.register(new RelationDatasourceMetricsSource(dataSource));
-
+    // Add null check to avoid NPE when metrics system is not initialized in test environments
+    if (metricsSystem != null) {
+      // Register connection pool metrics when metrics system is available
+      metricsSystem.register(new RelationDatasourceMetricsSource(dataSource));
+    }
     // Create the transaction factory and env
     TransactionFactory transactionFactory = new JdbcTransactionFactory();
     Environment environment = new Environment("development", transactionFactory, dataSource);

--- a/core/src/test/java/org/apache/gravitino/metrics/TestExtractMetricNameAndLabel.java
+++ b/core/src/test/java/org/apache/gravitino/metrics/TestExtractMetricNameAndLabel.java
@@ -79,5 +79,35 @@ public class TestExtractMetricNameAndLabel {
             + "_"
             + Collector.sanitizeMetricName(MetricNames.HTTP_PROCESS_DURATION),
         ImmutableMap.of("operation", "update-table"));
+
+    checkResult(
+        MetricsSource.GRAVITINO_SERVER_METRIC_NAME
+            + "."
+            + MetricNames.ENTITY_STORE_RELATION_DATASOURCE_ACTIVE_CONNECTIONS,
+        Collector.sanitizeMetricName(MetricsSource.GRAVITINO_SERVER_METRIC_NAME)
+            + "_"
+            + Collector.sanitizeMetricName(
+                MetricNames.ENTITY_STORE_RELATION_DATASOURCE_ACTIVE_CONNECTIONS),
+        ImmutableMap.of());
+
+    checkResult(
+        MetricsSource.GRAVITINO_SERVER_METRIC_NAME
+            + "."
+            + MetricNames.ENTITY_STORE_RELATION_DATASOURCE_IDLE_CONNECTIONS,
+        Collector.sanitizeMetricName(MetricsSource.GRAVITINO_SERVER_METRIC_NAME)
+            + "_"
+            + Collector.sanitizeMetricName(
+                MetricNames.ENTITY_STORE_RELATION_DATASOURCE_IDLE_CONNECTIONS),
+        ImmutableMap.of());
+
+    checkResult(
+        MetricsSource.GRAVITINO_SERVER_METRIC_NAME
+            + "."
+            + MetricNames.ENTITY_STORE_RELATION_DATASOURCE_MAX_CONNECTIONS,
+        Collector.sanitizeMetricName(MetricsSource.GRAVITINO_SERVER_METRIC_NAME)
+            + "_"
+            + Collector.sanitizeMetricName(
+                MetricNames.ENTITY_STORE_RELATION_DATASOURCE_MAX_CONNECTIONS),
+        ImmutableMap.of());
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Support metrics for JDBC backend connect pool :
1. activeConnectionCount
2. idleConnectionCount
3. maxConnectionCount

### Why are the changes needed?

Support metrics for JDBC connection pool

Fix: #6468

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

No need to test
