### PR TITLE
[MINOR] docs: Remove outdated tips from `web-ui.md`

### DIFF
--- a/docs/webui.md
+++ b/docs/webui.md
@@ -351,10 +351,6 @@ Creating a catalog requires these fields:
   </TabItem>
 </Tabs>
 
-:::tip
-Due to the current limitation of the web interface, which only allows for viewing, the functionality to create or modify schema, tables, or filesets is not available. Please refer to the [documentation](./manage-fileset-metadata-using-gravitino.md) to use the REST API for these operations.
-:::
-
 ###### 2. Type `fileset`
 
 <Tabs>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr removes outdated tips from `web-ui.md` because, as indicated in the subsequent text, operations such as creating or modifying schemas, tables, or filesets can now be performed through the web UI.

### Why are the changes needed?
Remove outdated tips from `web-ui.md`


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
manual review

