### PR TITLE
[#6493] feat(CLI): Support table format output for Schema and Table command

### DIFF
--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/Command.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/Command.java
@@ -235,7 +235,7 @@ public abstract class Command {
    * @param entity The entity to output.
    * @param <T> The type of entity.
    */
-  protected <T> void output(T entity) {
+  private <T> void output(T entity) {
     if (outputFormat == null) {
       PlainFormat.output(entity, context);
       return;

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/ListSchema.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/ListSchema.java
@@ -19,8 +19,6 @@
 
 package org.apache.gravitino.cli.commands;
 
-import org.apache.gravitino.Catalog;
-import org.apache.gravitino.Schema;
 import org.apache.gravitino.cli.CommandContext;
 import org.apache.gravitino.cli.ErrorMessages;
 import org.apache.gravitino.client.GravitinoClient;
@@ -50,12 +48,9 @@ public class ListSchema extends Command {
   @Override
   public void handle() {
     String[] schemas = new String[0];
-    Catalog tableCatalog = null;
-
     try {
       GravitinoClient client = buildClient(metalake);
-      tableCatalog = client.loadCatalog(catalog);
-      schemas = tableCatalog.asSchemas().listSchemas();
+      schemas = client.loadCatalog(catalog).asSchemas().listSchemas();
     } catch (NoSuchMetalakeException err) {
       exitWithError(ErrorMessages.UNKNOWN_METALAKE);
     } catch (NoSuchCatalogException err) {
@@ -65,15 +60,10 @@ public class ListSchema extends Command {
     }
 
     if (schemas.length == 0) {
-      printInformation("No schemas found in catalog " + catalog);
+      printInformation("No schemas exist.");
       return;
     }
-    // PERF load table may cause performance issue
-    Schema[] schemaObjects = new Schema[schemas.length];
-    for (int i = 0; i < schemas.length; i++) {
-      schemaObjects[i] = tableCatalog.asSchemas().loadSchema(schemas[i]);
-    }
 
-    printResults(schemaObjects);
+    printResults(schemas);
   }
 }

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/ListSchema.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/ListSchema.java
@@ -19,7 +19,6 @@
 
 package org.apache.gravitino.cli.commands;
 
-import com.google.common.base.Joiner;
 import org.apache.gravitino.cli.CommandContext;
 import org.apache.gravitino.cli.ErrorMessages;
 import org.apache.gravitino.client.GravitinoClient;
@@ -60,8 +59,11 @@ public class ListSchema extends Command {
       exitWithError(exp.getMessage());
     }
 
-    String all = schemas.length == 0 ? "No schemas exist." : Joiner.on(",").join(schemas);
+    if (schemas.length == 0) {
+      printInformation("No schemas found in catalog " + catalog);
+      return;
+    }
 
-    printInformation(all);
+    printResults(schemas);
   }
 }

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/ListSchema.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/ListSchema.java
@@ -19,6 +19,8 @@
 
 package org.apache.gravitino.cli.commands;
 
+import org.apache.gravitino.Catalog;
+import org.apache.gravitino.Schema;
 import org.apache.gravitino.cli.CommandContext;
 import org.apache.gravitino.cli.ErrorMessages;
 import org.apache.gravitino.client.GravitinoClient;
@@ -48,9 +50,13 @@ public class ListSchema extends Command {
   @Override
   public void handle() {
     String[] schemas = new String[0];
+    GravitinoClient client;
+    Catalog gCatalog = null;
+
     try {
-      GravitinoClient client = buildClient(metalake);
-      schemas = client.loadCatalog(catalog).asSchemas().listSchemas();
+      client = buildClient(metalake);
+      gCatalog = client.loadCatalog(catalog);
+      schemas = gCatalog.asSchemas().listSchemas();
     } catch (NoSuchMetalakeException err) {
       exitWithError(ErrorMessages.UNKNOWN_METALAKE);
     } catch (NoSuchCatalogException err) {
@@ -59,11 +65,16 @@ public class ListSchema extends Command {
       exitWithError(exp.getMessage());
     }
 
+    Schema[] schemaObjects = new Schema[schemas.length];
+    for (int i = 0; i < schemas.length; i++) {
+      schemaObjects[i] = gCatalog.asSchemas().loadSchema(schemas[i]);
+    }
+
     if (schemas.length == 0) {
       printInformation("No schemas exist.");
       return;
     }
 
-    printResults(schemas);
+    printResults(schemaObjects);
   }
 }

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/ListSchema.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/ListSchema.java
@@ -19,6 +19,8 @@
 
 package org.apache.gravitino.cli.commands;
 
+import org.apache.gravitino.Catalog;
+import org.apache.gravitino.Schema;
 import org.apache.gravitino.cli.CommandContext;
 import org.apache.gravitino.cli.ErrorMessages;
 import org.apache.gravitino.client.GravitinoClient;
@@ -48,9 +50,12 @@ public class ListSchema extends Command {
   @Override
   public void handle() {
     String[] schemas = new String[0];
+    Catalog tableCatalog = null;
+
     try {
       GravitinoClient client = buildClient(metalake);
-      schemas = client.loadCatalog(catalog).asSchemas().listSchemas();
+      tableCatalog = client.loadCatalog(catalog);
+      schemas = tableCatalog.asSchemas().listSchemas();
     } catch (NoSuchMetalakeException err) {
       exitWithError(ErrorMessages.UNKNOWN_METALAKE);
     } catch (NoSuchCatalogException err) {
@@ -64,6 +69,11 @@ public class ListSchema extends Command {
       return;
     }
 
-    printResults(schemas);
+    Schema[] schemaObjects = new Schema[schemas.length];
+    for (int i = 0; i < schemas.length; i++) {
+      schemaObjects[i] = tableCatalog.asSchemas().loadSchema(schemas[i]);
+    }
+
+    printResults(schemaObjects);
   }
 }

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/ListSchema.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/ListSchema.java
@@ -68,7 +68,7 @@ public class ListSchema extends Command {
       printInformation("No schemas found in catalog " + catalog);
       return;
     }
-
+    // PERF load table may cause performance issue
     Schema[] schemaObjects = new Schema[schemas.length];
     for (int i = 0; i < schemas.length; i++) {
       schemaObjects[i] = tableCatalog.asSchemas().loadSchema(schemas[i]);

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/ListTables.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/ListTables.java
@@ -19,11 +19,11 @@
 
 package org.apache.gravitino.cli.commands;
 
-import java.util.ArrayList;
-import java.util.List;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
 import org.apache.gravitino.cli.CommandContext;
+import org.apache.gravitino.rel.Table;
+import org.apache.gravitino.rel.TableCatalog;
 
 /** List the names of all tables in a schema. */
 public class ListTables extends TableCommand {
@@ -48,22 +48,25 @@ public class ListTables extends TableCommand {
   public void handle() {
     NameIdentifier[] tables = null;
     Namespace name = Namespace.of(schema);
+    TableCatalog gCatalog = null;
+
     try {
-      tables = tableCatalog().listTables(name);
+      gCatalog = tableCatalog();
+      tables = gCatalog.listTables(name);
     } catch (Exception exp) {
       exitWithError(exp.getMessage());
     }
 
-    List<String> tableNames = new ArrayList<>();
-    for (int i = 0; i < tables.length; i++) {
-      tableNames.add(tables[i].name());
-    }
-
-    if (tableNames.isEmpty()) {
+    if (tables.length == 0) {
       printInformation("No tables exist.");
       return;
     }
 
-    printResults(tableNames.toArray(new String[0]));
+    Table[] gTables = new Table[tables.length];
+    for (int i = 0; i < tables.length; i++) {
+      gTables[i] = gCatalog.loadTable(tables[i]);
+    }
+
+    printResults(gTables);
   }
 }

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/ListTables.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/ListTables.java
@@ -24,8 +24,6 @@ import java.util.List;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
 import org.apache.gravitino.cli.CommandContext;
-import org.apache.gravitino.rel.Table;
-import org.apache.gravitino.rel.TableCatalog;
 
 /** List the names of all tables in a schema. */
 public class ListTables extends TableCommand {
@@ -50,25 +48,15 @@ public class ListTables extends TableCommand {
   public void handle() {
     NameIdentifier[] tables = null;
     Namespace name = Namespace.of(schema);
-    TableCatalog tableCatalog = null;
-
     try {
-      tableCatalog = tableCatalog();
-      tables = tableCatalog.listTables(name);
+      tables = tableCatalog().listTables(name);
     } catch (Exception exp) {
       exitWithError(exp.getMessage());
     }
 
     List<String> tableNames = new ArrayList<>();
-    for (NameIdentifier table : tables) {
-      tableNames.add(table.name());
-    }
-    // PERF load table may cause performance issue
-    Table[] tableObjects = new Table[tableNames.size()];
-    int i = 0;
-    for (NameIdentifier tableIdent : tables) {
-      tableObjects[i] = tableCatalog.loadTable(tableIdent);
-      i++;
+    for (int i = 0; i < tables.length; i++) {
+      tableNames.add(tables[i].name());
     }
 
     if (tableNames.isEmpty()) {
@@ -76,6 +64,6 @@ public class ListTables extends TableCommand {
       return;
     }
 
-    printResults(tableObjects);
+    printResults(tableNames);
   }
 }

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/ListTables.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/ListTables.java
@@ -64,6 +64,6 @@ public class ListTables extends TableCommand {
       return;
     }
 
-    printResults(tableNames);
+    printResults(tableNames.toArray(new String[0]));
   }
 }

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/ListTables.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/ListTables.java
@@ -19,11 +19,12 @@
 
 package org.apache.gravitino.cli.commands;
 
+import org.apache.gravitino.Audit;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
 import org.apache.gravitino.cli.CommandContext;
+import org.apache.gravitino.rel.Column;
 import org.apache.gravitino.rel.Table;
-import org.apache.gravitino.rel.TableCatalog;
 
 /** List the names of all tables in a schema. */
 public class ListTables extends TableCommand {
@@ -48,11 +49,9 @@ public class ListTables extends TableCommand {
   public void handle() {
     NameIdentifier[] tables = null;
     Namespace name = Namespace.of(schema);
-    TableCatalog gCatalog = null;
 
     try {
-      gCatalog = tableCatalog();
-      tables = gCatalog.listTables(name);
+      tables = tableCatalog().listTables(name);
     } catch (Exception exp) {
       exitWithError(exp.getMessage());
     }
@@ -64,7 +63,25 @@ public class ListTables extends TableCommand {
 
     Table[] gTables = new Table[tables.length];
     for (int i = 0; i < tables.length; i++) {
-      gTables[i] = gCatalog.loadTable(tables[i]);
+      String tableName = tables[i].name();
+      gTables[i] =
+          new Table() {
+
+            @Override
+            public String name() {
+              return tableName;
+            }
+
+            @Override
+            public Column[] columns() {
+              return new Column[0];
+            }
+
+            @Override
+            public Audit auditInfo() {
+              return null;
+            }
+          };
     }
 
     printResults(gTables);

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/SchemaDetails.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/SchemaDetails.java
@@ -68,7 +68,7 @@ public class SchemaDetails extends Command {
     }
 
     if (result != null) {
-      printInformation(result.name() + "," + result.comment());
+      printResults(result);
     }
   }
 }

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/TableDetails.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/TableDetails.java
@@ -57,6 +57,8 @@ public class TableDetails extends TableCommand {
       exitWithError(exp.getMessage());
     }
 
-    printInformation(gTable.name() + "," + gTable.comment());
+    if (gTable != null) {
+      printResults(gTable);
+    }
   }
 }

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/outputs/TableFormat.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/outputs/TableFormat.java
@@ -79,10 +79,12 @@ public abstract class TableFormat<T> extends BaseOutputFormat<T> {
       new CatalogListTableFormat(context).output((Catalog[]) entity);
     } else if (entity instanceof Schema) {
       new SchemaTableFormat(context).output((Schema) entity);
+    } else if (entity instanceof Schema[]) {
+      new SchemaListTableFormat(context).output((Schema[]) entity);
     } else if (entity instanceof Table) {
       new TableDetailsTableFormat(context).output((Table) entity);
-    } else if (entity instanceof String[]) {
-      new ListTableFormat(context).output((String[]) entity);
+    } else if (entity instanceof Table[]) {
+      new TableListTableFormat(context).output((Table[]) entity);
     } else {
       throw new IllegalArgumentException("Unsupported object type");
     }
@@ -495,7 +497,7 @@ public abstract class TableFormat<T> extends BaseOutputFormat<T> {
     @Override
     public String getOutput(Metalake[] metalakes) {
 
-      Column columnName = new Column(context, "Name");
+      Column columnName = new Column(context, "metalake");
       Arrays.stream(metalakes).forEach(metalake -> columnName.addCell(metalake.name()));
 
       return getTableFormat(columnName);
@@ -542,7 +544,7 @@ public abstract class TableFormat<T> extends BaseOutputFormat<T> {
     /** {@inheritDoc} */
     @Override
     public String getOutput(Catalog[] catalogs) {
-      Column columnName = new Column(context, "Name");
+      Column columnName = new Column(context, "catalog");
       Arrays.stream(catalogs).forEach(metalake -> columnName.addCell(metalake.name()));
 
       return getTableFormat(columnName);
@@ -568,6 +570,25 @@ public abstract class TableFormat<T> extends BaseOutputFormat<T> {
       columnComment.addCell(schema.comment());
 
       return getTableFormat(columnName, columnComment);
+    }
+  }
+
+  /**
+   * Formats an array of Schemas into a single-column table display. Lists all schema names in a
+   * vertical format.
+   */
+  static final class SchemaListTableFormat extends TableFormat<Schema[]> {
+    public SchemaListTableFormat(CommandContext context) {
+      super(context);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String getOutput(Schema[] schemas) {
+      Column column = new Column(context, "schema");
+      Arrays.stream(schemas).forEach(schema -> column.addCell(schema.name()));
+
+      return getTableFormat(column);
     }
   }
 
@@ -604,21 +625,20 @@ public abstract class TableFormat<T> extends BaseOutputFormat<T> {
     }
   }
 
-  static final class ListTableFormat extends TableFormat<String[]> {
-    /**
-     * Creates a new {@link TableFormat} with the specified properties.
-     *
-     * @param context the command context.
-     */
-    public ListTableFormat(CommandContext context) {
+  /**
+   * Formats an array of {@link Table} into a single-column table display. Lists all table names in
+   * a vertical format.
+   */
+  static final class TableListTableFormat extends TableFormat<Table[]> {
+    public TableListTableFormat(CommandContext context) {
       super(context);
     }
 
     /** {@inheritDoc} */
     @Override
-    public String getOutput(String[] entities) {
-      Column column = new Column(context, "name");
-      Arrays.stream(entities).forEach(column::addCell);
+    public String getOutput(Table[] tables) {
+      Column column = new Column(context, "table");
+      Arrays.stream(tables).forEach(table -> column.addCell(table.name()));
 
       return getTableFormat(column);
     }

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/outputs/TableFormat.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/outputs/TableFormat.java
@@ -79,12 +79,10 @@ public abstract class TableFormat<T> extends BaseOutputFormat<T> {
       new CatalogListTableFormat(context).output((Catalog[]) entity);
     } else if (entity instanceof Schema) {
       new SchemaTableFormat(context).output((Schema) entity);
-    } else if (entity instanceof Schema[]) {
-      new SchemaListTableFormat(context).output((Schema[]) entity);
     } else if (entity instanceof Table) {
       new TableDetailsTableFormat(context).output((Table) entity);
-    } else if (entity instanceof Table[]) {
-      new TableListTableFormat(context).output((Table[]) entity);
+    } else if (entity instanceof String[]) {
+      new ListTableFormat(context).output((String[]) entity);
     } else {
       throw new IllegalArgumentException("Unsupported object type");
     }
@@ -497,7 +495,7 @@ public abstract class TableFormat<T> extends BaseOutputFormat<T> {
     @Override
     public String getOutput(Metalake[] metalakes) {
 
-      Column columnName = new Column(context, "metalake");
+      Column columnName = new Column(context, "Name");
       Arrays.stream(metalakes).forEach(metalake -> columnName.addCell(metalake.name()));
 
       return getTableFormat(columnName);
@@ -544,7 +542,7 @@ public abstract class TableFormat<T> extends BaseOutputFormat<T> {
     /** {@inheritDoc} */
     @Override
     public String getOutput(Catalog[] catalogs) {
-      Column columnName = new Column(context, "catalog");
+      Column columnName = new Column(context, "Name");
       Arrays.stream(catalogs).forEach(metalake -> columnName.addCell(metalake.name()));
 
       return getTableFormat(columnName);
@@ -570,25 +568,6 @@ public abstract class TableFormat<T> extends BaseOutputFormat<T> {
       columnComment.addCell(schema.comment());
 
       return getTableFormat(columnName, columnComment);
-    }
-  }
-
-  /**
-   * Formats an array of Schemas into a single-column table display. Lists all schema names in a
-   * vertical format.
-   */
-  static final class SchemaListTableFormat extends TableFormat<Schema[]> {
-    public SchemaListTableFormat(CommandContext context) {
-      super(context);
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public String getOutput(Schema[] schemas) {
-      Column column = new Column(context, "schema");
-      Arrays.stream(schemas).forEach(schema -> column.addCell(schema.name()));
-
-      return getTableFormat(column);
     }
   }
 
@@ -625,20 +604,21 @@ public abstract class TableFormat<T> extends BaseOutputFormat<T> {
     }
   }
 
-  /**
-   * Formats an array of {@link Table} into a single-column table display. Lists all table names in
-   * a vertical format.
-   */
-  static final class TableListTableFormat extends TableFormat<Table[]> {
-    public TableListTableFormat(CommandContext context) {
+  static final class ListTableFormat extends TableFormat<String[]> {
+    /**
+     * Creates a new {@link TableFormat} with the specified properties.
+     *
+     * @param context the command context.
+     */
+    public ListTableFormat(CommandContext context) {
       super(context);
     }
 
     /** {@inheritDoc} */
     @Override
-    public String getOutput(Table[] tables) {
+    public String getOutput(String[] entities) {
       Column column = new Column(context, "name");
-      Arrays.stream(tables).forEach(table -> column.addCell(table.name()));
+      Arrays.stream(entities).forEach(column::addCell);
 
       return getTableFormat(column);
     }

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/outputs/TableFormat.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/outputs/TableFormat.java
@@ -47,7 +47,9 @@ import java.util.List;
 import java.util.Objects;
 import org.apache.gravitino.Catalog;
 import org.apache.gravitino.Metalake;
+import org.apache.gravitino.Schema;
 import org.apache.gravitino.cli.CommandContext;
+import org.apache.gravitino.rel.Table;
 
 /**
  * Abstract base class for formatting entity information into ASCII-art tables. Provides
@@ -75,6 +77,14 @@ public abstract class TableFormat<T> extends BaseOutputFormat<T> {
       new CatalogTableFormat(context).output((Catalog) entity);
     } else if (entity instanceof Catalog[]) {
       new CatalogListTableFormat(context).output((Catalog[]) entity);
+    } else if (entity instanceof Schema) {
+      new SchemaTableFormat(context).output((Schema) entity);
+    } else if (entity instanceof Schema[]) {
+      new SchemaListTableFormat(context).output((Schema[]) entity);
+    } else if (entity instanceof Table) {
+      new TableDetailsTableFormat(context).output((Table) entity);
+    } else if (entity instanceof Table[]) {
+      new TableListTableFormat(context).output((Table[]) entity);
     } else {
       throw new IllegalArgumentException("Unsupported object type");
     }
@@ -538,6 +548,98 @@ public abstract class TableFormat<T> extends BaseOutputFormat<T> {
       Arrays.stream(catalogs).forEach(metalake -> columnName.addCell(metalake.name()));
 
       return getTableFormat(columnName);
+    }
+  }
+
+  /**
+   * Formats a single {@link Schema} instance into a two-column table display. Displays catalog
+   * details including name and comment information.
+   */
+  static final class SchemaTableFormat extends TableFormat<Schema> {
+    public SchemaTableFormat(CommandContext context) {
+      super(context);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String getOutput(Schema schema) {
+      Column columnName = new Column(context, "schema");
+      Column columnComment = new Column(context, "comment");
+
+      columnName.addCell(schema.name());
+      columnComment.addCell(schema.comment());
+
+      return getTableFormat(columnName, columnComment);
+    }
+  }
+
+  /**
+   * Formats an array of Schemas into a single-column table display. Lists all schema names in a
+   * vertical format.
+   */
+  static final class SchemaListTableFormat extends TableFormat<Schema[]> {
+    public SchemaListTableFormat(CommandContext context) {
+      super(context);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String getOutput(Schema[] schemas) {
+      Column column = new Column(context, "schema");
+      Arrays.stream(schemas).forEach(schema -> column.addCell(schema.name()));
+
+      return getTableFormat(column);
+    }
+  }
+
+  /**
+   * Formats a single {@link Table} instance into a two-column table display. Displays table details
+   * including name and comment information.
+   */
+  static final class TableDetailsTableFormat extends TableFormat<Table> {
+    public TableDetailsTableFormat(CommandContext context) {
+      super(context);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String getOutput(Table table) {
+      Column columnName = new Column(context, "name");
+      Column columnType = new Column(context, "type");
+      Column columnAutoIncrement = new Column(context, "AutoIncrement");
+      Column columnNullable = new Column(context, "nullable");
+      Column columnComment = new Column(context, "comment");
+
+      org.apache.gravitino.rel.Column[] columns = table.columns();
+      for (org.apache.gravitino.rel.Column column : columns) {
+        columnName.addCell(column.name());
+        columnType.addCell(column.dataType().simpleString());
+        columnAutoIncrement.addCell(column.autoIncrement());
+        columnNullable.addCell(column.nullable());
+        columnComment.addCell(column.comment().isEmpty() ? "N/A" : column.comment());
+      }
+
+      return getTableFormat(
+          columnName, columnType, columnAutoIncrement, columnNullable, columnComment);
+    }
+  }
+
+  /**
+   * Formats an array of {@link Table} into a single-column table display. Lists all table names in
+   * a vertical format.
+   */
+  static final class TableListTableFormat extends TableFormat<Table[]> {
+    public TableListTableFormat(CommandContext context) {
+      super(context);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String getOutput(Table[] tables) {
+      Column column = new Column(context, "name");
+      Arrays.stream(tables).forEach(table -> column.addCell(table.name()));
+
+      return getTableFormat(column);
     }
   }
 }

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/outputs/TableFormat.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/outputs/TableFormat.java
@@ -616,7 +616,8 @@ public abstract class TableFormat<T> extends BaseOutputFormat<T> {
         columnType.addCell(column.dataType().simpleString());
         columnAutoIncrement.addCell(column.autoIncrement());
         columnNullable.addCell(column.nullable());
-        columnComment.addCell(column.comment().isEmpty() ? "N/A" : column.comment());
+        columnComment.addCell(
+            column.comment() == null || column.comment().isEmpty() ? "N/A" : column.comment());
       }
 
       return getTableFormat(

--- a/clients/cli/src/test/java/org/apache/gravitino/cli/integration/test/TableFormatOutputIT.java
+++ b/clients/cli/src/test/java/org/apache/gravitino/cli/integration/test/TableFormatOutputIT.java
@@ -106,7 +106,7 @@ public class TableFormatOutputIT extends BaseIT {
     String output = new String(outputStream.toByteArray(), StandardCharsets.UTF_8).trim();
     assertEquals(
         "+-------------+\n"
-            + "|  Metalake   |\n"
+            + "|    Name     |\n"
             + "+-------------+\n"
             + "| my_metalake |\n"
             + "+-------------+",
@@ -170,7 +170,7 @@ public class TableFormatOutputIT extends BaseIT {
     String output = new String(outputStream.toByteArray(), StandardCharsets.UTF_8).trim();
     assertEquals(
         "+-----------+\n"
-            + "|  Catalog  |\n"
+            + "|   Name    |\n"
             + "+-----------+\n"
             + "| postgres  |\n"
             + "| postgres2 |\n"

--- a/clients/cli/src/test/java/org/apache/gravitino/cli/integration/test/TableFormatOutputIT.java
+++ b/clients/cli/src/test/java/org/apache/gravitino/cli/integration/test/TableFormatOutputIT.java
@@ -106,7 +106,7 @@ public class TableFormatOutputIT extends BaseIT {
     String output = new String(outputStream.toByteArray(), StandardCharsets.UTF_8).trim();
     assertEquals(
         "+-------------+\n"
-            + "|    Name     |\n"
+            + "|  Metalake   |\n"
             + "+-------------+\n"
             + "| my_metalake |\n"
             + "+-------------+",
@@ -170,7 +170,7 @@ public class TableFormatOutputIT extends BaseIT {
     String output = new String(outputStream.toByteArray(), StandardCharsets.UTF_8).trim();
     assertEquals(
         "+-----------+\n"
-            + "|   Name    |\n"
+            + "|  Catalog  |\n"
             + "+-----------+\n"
             + "| postgres  |\n"
             + "| postgres2 |\n"

--- a/clients/cli/src/test/java/org/apache/gravitino/cli/output/TestTableFormat.java
+++ b/clients/cli/src/test/java/org/apache/gravitino/cli/output/TestTableFormat.java
@@ -255,7 +255,7 @@ public class TestTableFormat {
     String output = new String(outContent.toByteArray(), StandardCharsets.UTF_8).trim();
     Assertions.assertEquals(
         "+-----------+\n"
-            + "|   Name    |\n"
+            + "| Metalake  |\n"
             + "+-----------+\n"
             + "| metalake1 |\n"
             + "| metalake2 |\n"
@@ -282,11 +282,19 @@ public class TestTableFormat {
   @Test
   void testListCatalogWithTableFormat() {
     CommandContext mockContext = getMockContext();
-    TableFormat.output(new String[] {"catalog1", "catalog2"}, mockContext);
+    Catalog mockCatalog1 =
+        getMockCatalog(
+            "catalog1", Catalog.Type.RELATIONAL, "demo_provider", "This is a demo catalog");
+    Catalog mockCatalog2 =
+        getMockCatalog(
+            "catalog2", Catalog.Type.RELATIONAL, "demo_provider", "This is another demo catalog");
+
+    TableFormat.output(new Catalog[] {mockCatalog1, mockCatalog2}, mockContext);
+
     String output = new String(outContent.toByteArray(), StandardCharsets.UTF_8).trim();
     Assertions.assertEquals(
         "+----------+\n"
-            + "|   Name   |\n"
+            + "| Catalog  |\n"
             + "+----------+\n"
             + "| catalog1 |\n"
             + "| catalog2 |\n"
@@ -313,15 +321,19 @@ public class TestTableFormat {
   @Test
   void testListSchemaWithTableFormat() {
     CommandContext mockContext = getMockContext();
-    TableFormat.output(new String[] {"schema1", "schema2"}, mockContext);
+    Schema mockSchema1 = getMockSchema("demo_schema1", "This is a demo schema");
+    Schema mockSchema2 = getMockSchema("demo_schema2", "This is another demo schema");
+
+    TableFormat.output(new Schema[] {mockSchema1, mockSchema2}, mockContext);
+
     String output = new String(outContent.toByteArray(), StandardCharsets.UTF_8).trim();
     Assertions.assertEquals(
-        "+---------+\n"
-            + "|  Name   |\n"
-            + "+---------+\n"
-            + "| schema1 |\n"
-            + "| schema2 |\n"
-            + "+---------+",
+        "+--------------+\n"
+            + "|    Schema    |\n"
+            + "+--------------+\n"
+            + "| demo_schema1 |\n"
+            + "| demo_schema2 |\n"
+            + "+--------------+",
         output);
   }
 
@@ -346,11 +358,14 @@ public class TestTableFormat {
   void testListTableWithTableFormat() {
     CommandContext mockContext = getMockContext();
 
-    TableFormat.output(new String[] {"table1", "table2"}, mockContext);
+    Table mockTable1 = getMockTable("table1", "This is a demo table");
+    Table mockTable2 = getMockTable("table2", "This is another demo table");
+    TableFormat.output(new Table[] {mockTable1, mockTable2}, mockContext);
+
     String output = new String(outContent.toByteArray(), StandardCharsets.UTF_8).trim();
     Assertions.assertEquals(
         "+--------+\n"
-            + "|  Name  |\n"
+            + "| Table  |\n"
             + "+--------+\n"
             + "| table1 |\n"
             + "| table2 |\n"

--- a/clients/cli/src/test/java/org/apache/gravitino/cli/output/TestTableFormat.java
+++ b/clients/cli/src/test/java/org/apache/gravitino/cli/output/TestTableFormat.java
@@ -255,7 +255,7 @@ public class TestTableFormat {
     String output = new String(outContent.toByteArray(), StandardCharsets.UTF_8).trim();
     Assertions.assertEquals(
         "+-----------+\n"
-            + "| Metalake  |\n"
+            + "|   Name    |\n"
             + "+-----------+\n"
             + "| metalake1 |\n"
             + "| metalake2 |\n"
@@ -282,16 +282,11 @@ public class TestTableFormat {
   @Test
   void testListCatalogWithTableFormat() {
     CommandContext mockContext = getMockContext();
-    Catalog mockCatalog1 =
-        getMockCatalog("catalog1", Catalog.Type.FILESET, "provider1", "This is a catalog");
-    Catalog mockCatalog2 =
-        getMockCatalog("catalog2", Catalog.Type.RELATIONAL, "provider2", "This is another catalog");
-
-    TableFormat.output(new Catalog[] {mockCatalog1, mockCatalog2}, mockContext);
+    TableFormat.output(new String[] {"catalog1", "catalog2"}, mockContext);
     String output = new String(outContent.toByteArray(), StandardCharsets.UTF_8).trim();
     Assertions.assertEquals(
         "+----------+\n"
-            + "| Catalog  |\n"
+            + "|   Name   |\n"
             + "+----------+\n"
             + "| catalog1 |\n"
             + "| catalog2 |\n"
@@ -318,14 +313,11 @@ public class TestTableFormat {
   @Test
   void testListSchemaWithTableFormat() {
     CommandContext mockContext = getMockContext();
-    Schema mockSchema1 = getMockSchema("schema1", "This is a schema");
-    Schema mockSchema2 = getMockSchema("schema2", "This is another schema");
-
-    TableFormat.output(new Schema[] {mockSchema1, mockSchema2}, mockContext);
+    TableFormat.output(new String[] {"schema1", "schema2"}, mockContext);
     String output = new String(outContent.toByteArray(), StandardCharsets.UTF_8).trim();
     Assertions.assertEquals(
         "+---------+\n"
-            + "| Schema  |\n"
+            + "|  Name   |\n"
             + "+---------+\n"
             + "| schema1 |\n"
             + "| schema2 |\n"
@@ -353,10 +345,8 @@ public class TestTableFormat {
   @Test
   void testListTableWithTableFormat() {
     CommandContext mockContext = getMockContext();
-    Table mockTable1 = getMockTable("table1", "This is a table");
-    Table mockTable2 = getMockTable("table2", "This is another table");
 
-    TableFormat.output(new Table[] {mockTable1, mockTable2}, mockContext);
+    TableFormat.output(new String[] {"table1", "table2"}, mockContext);
     String output = new String(outContent.toByteArray(), StandardCharsets.UTF_8).trim();
     Assertions.assertEquals(
         "+--------+\n"

--- a/clients/cli/src/test/java/org/apache/gravitino/cli/output/TestTableFormat.java
+++ b/clients/cli/src/test/java/org/apache/gravitino/cli/output/TestTableFormat.java
@@ -28,9 +28,13 @@ import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import org.apache.gravitino.Catalog;
 import org.apache.gravitino.Metalake;
+import org.apache.gravitino.Schema;
 import org.apache.gravitino.cli.CommandContext;
 import org.apache.gravitino.cli.outputs.Column;
 import org.apache.gravitino.cli.outputs.TableFormat;
+import org.apache.gravitino.rel.Table;
+import org.apache.gravitino.rel.types.Type;
+import org.apache.gravitino.rel.types.Types;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -296,6 +300,75 @@ public class TestTableFormat {
   }
 
   @Test
+  void testSchemaDetailsWithTableFormat() {
+    CommandContext mockContext = getMockContext();
+    Schema mockSchema = getMockSchema();
+
+    TableFormat.output(mockSchema, mockContext);
+    String output = new String(outContent.toByteArray(), StandardCharsets.UTF_8).trim();
+    Assertions.assertEquals(
+        "+-------------+-----------------------+\n"
+            + "|   Schema    |        Comment        |\n"
+            + "+-------------+-----------------------+\n"
+            + "| demo_schema | This is a demo schema |\n"
+            + "+-------------+-----------------------+",
+        output);
+  }
+
+  @Test
+  void testListSchemaWithTableFormat() {
+    CommandContext mockContext = getMockContext();
+    Schema mockSchema1 = getMockSchema("schema1", "This is a schema");
+    Schema mockSchema2 = getMockSchema("schema2", "This is another schema");
+
+    TableFormat.output(new Schema[] {mockSchema1, mockSchema2}, mockContext);
+    String output = new String(outContent.toByteArray(), StandardCharsets.UTF_8).trim();
+    Assertions.assertEquals(
+        "+---------+\n"
+            + "| Schema  |\n"
+            + "+---------+\n"
+            + "| schema1 |\n"
+            + "| schema2 |\n"
+            + "+---------+",
+        output);
+  }
+
+  @Test
+  void testTableDetailsWithTableFormat() {
+    CommandContext mockContext = getMockContext();
+    Table mockTable = getMockTable();
+
+    TableFormat.output(mockTable, mockContext);
+    String output = new String(outContent.toByteArray(), StandardCharsets.UTF_8).trim();
+    Assertions.assertEquals(
+        "+------+---------+---------------+----------+-------------------------+\n"
+            + "| Name |  Type   | AutoIncrement | Nullable |         Comment         |\n"
+            + "+------+---------+---------------+----------+-------------------------+\n"
+            + "| id   | integer | true          | false    | This is a int column    |\n"
+            + "| name | string  | false         | true     | This is a string column |\n"
+            + "+------+---------+---------------+----------+-------------------------+",
+        output);
+  }
+
+  @Test
+  void testListTableWithTableFormat() {
+    CommandContext mockContext = getMockContext();
+    Table mockTable1 = getMockTable("table1", "This is a table");
+    Table mockTable2 = getMockTable("table2", "This is another table");
+
+    TableFormat.output(new Table[] {mockTable1, mockTable2}, mockContext);
+    String output = new String(outContent.toByteArray(), StandardCharsets.UTF_8).trim();
+    Assertions.assertEquals(
+        "+--------+\n"
+            + "|  Name  |\n"
+            + "+--------+\n"
+            + "| table1 |\n"
+            + "| table2 |\n"
+            + "+--------+",
+        output);
+  }
+
+  @Test
   void testOutputWithUnsupportType() {
     CommandContext mockContext = getMockContext();
     Object mockObject = new Object();
@@ -305,12 +378,6 @@ public class TestTableFormat {
         () -> {
           TableFormat.output(mockObject, mockContext);
         });
-  }
-
-  private void addRepeatedCells(Column column, int count) {
-    for (int i = 0; i < count; i++) {
-      column.addCell(column.getHeader() + "-" + (i + 1));
-    }
   }
 
   private CommandContext getMockContext() {
@@ -344,5 +411,49 @@ public class TestTableFormat {
     when(mockCatalog.comment()).thenReturn(comment);
 
     return mockCatalog;
+  }
+
+  private Schema getMockSchema() {
+    return getMockSchema("demo_schema", "This is a demo schema");
+  }
+
+  private Schema getMockSchema(String name, String comment) {
+    Schema mockSchema = mock(Schema.class);
+    when(mockSchema.name()).thenReturn(name);
+    when(mockSchema.comment()).thenReturn(comment);
+
+    return mockSchema;
+  }
+
+  private Table getMockTable() {
+    return getMockTable("demo_table", "This is a demo table");
+  }
+
+  private Table getMockTable(String name, String comment) {
+    Table mockTable = mock(Table.class);
+    org.apache.gravitino.rel.Column mockColumnInt =
+        getMockColumn("id", Types.IntegerType.get(), "This is a int column", false, true);
+    org.apache.gravitino.rel.Column mockColumnString =
+        getMockColumn("name", Types.StringType.get(), "This is a string column", true, false);
+
+    when(mockTable.name()).thenReturn(name);
+    when(mockTable.comment()).thenReturn(comment);
+    when(mockTable.columns())
+        .thenReturn(new org.apache.gravitino.rel.Column[] {mockColumnInt, mockColumnString});
+
+    return mockTable;
+  }
+
+  private org.apache.gravitino.rel.Column getMockColumn(
+      String name, Type dataType, String comment, boolean nullable, boolean autoIncrement) {
+
+    org.apache.gravitino.rel.Column mockColumn = mock(org.apache.gravitino.rel.Column.class);
+    when(mockColumn.name()).thenReturn(name);
+    when(mockColumn.dataType()).thenReturn(dataType);
+    when(mockColumn.comment()).thenReturn(comment);
+    when(mockColumn.nullable()).thenReturn(nullable);
+    when(mockColumn.autoIncrement()).thenReturn(autoIncrement);
+
+    return mockColumn;
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Support table format output for Schema and Table command.

### Why are the changes needed?

Fix: #6493 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

local test.

```bash
gcli schema list -m demo_metalake --name Hive_catalog --output table -i
+---------------------------+
|          Schema           |
+---------------------------+
| convert_example           |
| default                   |
| hive_best_performance     |
| test_hive_convert_example |
| test_multiple_data_source |
+---------------------------+

gcli schema details -m demo_metalake --name Hive_catalog.default --output table -i
+---------+-----------------------+
| Schema  |        Comment        |
+---------+-----------------------+
| default | Default Hive database |
+---------+-----------------------+

gcli table list -m demo_metalake --name Hive_catalog.default -i --output table
+---------------------------------------+
|                 Table                 |
+---------------------------------------+
| test_create_txt_tbl_without_delimited |
| test_jinjia_tbl1                      |
| test_jinjia_tbl2                      |
| test                                  |
| test1                                 |
| example_table                         |
| example_table2                        |
+---------------------------------------+

gcli table details -m demo_metalake --name Hive_catalog.default.test1  -i --output table

+----------+---------+---------------+----------+---------+
|   Name   |  Type   | AutoIncrement | Nullable | Comment |
+----------+---------+---------------+----------+---------+
| id       | integer | false         | true     | N/A     |
| name     | string  | false         | true     | N/A     |
| standard | long    | false         | true     | N/A     |
| dt       | string  | false         | true     | N/A     |
+----------+---------+---------------+----------+---------+
```
