### PR TITLE
[#6496] feat(CLI): Support plain format output for Schema and Table command

### DIFF
--- a/clients/cli/src/main/java/org/apache/gravitino/cli/outputs/OutputFormat.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/outputs/OutputFormat.java
@@ -26,7 +26,7 @@ import com.google.common.base.Joiner;
  */
 public interface OutputFormat<T> {
   /** Joiner for creating comma-separated output strings, ignoring null values */
-  Joiner COMMA_JOINER = Joiner.on(", ").skipNulls();
+  Joiner COMMA_JOINER = Joiner.on(",").skipNulls();
   /** Joiner for creating line-separated output strings, ignoring null values */
   Joiner NEWLINE_JOINER = Joiner.on(System.lineSeparator()).skipNulls();
 

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/outputs/PlainFormat.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/outputs/PlainFormat.java
@@ -194,7 +194,11 @@ public abstract class PlainFormat<T> extends BaseOutputFormat<T> {
               .map(
                   column ->
                       COMMA_JOINER.join(
-                          column.name(), column.dataType().simpleString(), column.comment()))
+                          column.name(),
+                          column.dataType().simpleString(),
+                          column.autoIncrement(),
+                          column.nullable(),
+                          column.comment() == null ? "N/A" : column.comment()))
               .collect(Collectors.toList());
       output.append(NEWLINE_JOINER.join(columnOutput));
       output.append(System.lineSeparator());

--- a/clients/cli/src/test/java/org/apache/gravitino/cli/output/TestPlainFormat.java
+++ b/clients/cli/src/test/java/org/apache/gravitino/cli/output/TestPlainFormat.java
@@ -131,10 +131,36 @@ public class TestPlainFormat {
     Table mockTable = getMockTable();
     PlainFormat.output(mockTable, mockContext);
     String output = new String(outContent.toByteArray(), StandardCharsets.UTF_8).trim();
+    Assertions.assertEquals("demo_table, This is a demo table", output);
+  }
+
+  @Test
+  void testAuditWithTableFormat() {
+    CommandContext mockContext = getMockContext();
+    Audit mockAudit = mock(Audit.class);
+    when(mockAudit.creator()).thenReturn("demo_user");
+    when(mockAudit.createTime()).thenReturn(Instant.ofEpochMilli(1611111111111L));
+    when(mockAudit.lastModifier()).thenReturn("demo_user");
+    when(mockAudit.lastModifiedTime()).thenReturn(Instant.ofEpochMilli(1611111111111L));
+
+    PlainFormat.output(mockAudit, mockContext);
+    String output = new String(outContent.toByteArray(), StandardCharsets.UTF_8).trim();
     Assertions.assertEquals(
-        "id, integer, true, false, This is a int column\n"
-            + "name, string, false, true, This is a string column",
-        output);
+        "demo_user, 2021-01-20T02:51:51.111Z, demo_user, 2021-01-20T02:51:51.111Z", output);
+  }
+
+  @Test
+  void testAuditWithTableFormatWithNullValues() {
+    CommandContext mockContext = getMockContext();
+    Audit mockAudit = mock(Audit.class);
+    when(mockAudit.creator()).thenReturn("demo_user");
+    when(mockAudit.createTime()).thenReturn(null);
+    when(mockAudit.lastModifier()).thenReturn(null);
+    when(mockAudit.lastModifiedTime()).thenReturn(null);
+
+    PlainFormat.output(mockAudit, mockContext);
+    String output = new String(outContent.toByteArray(), StandardCharsets.UTF_8).trim();
+    Assertions.assertEquals("demo_user, N/A, N/A, N/A", output);
   }
 
   @Test
@@ -235,15 +261,5 @@ public class TestPlainFormat {
     when(mockColumn.autoIncrement()).thenReturn(autoIncrement);
 
     return mockColumn;
-  }
-
-  private Audit getMockAudit() {
-    Audit mockAudit = mock(Audit.class);
-    when(mockAudit.creator()).thenReturn("demo_user");
-    when(mockAudit.createTime()).thenReturn(Instant.ofEpochMilli(1611111111111L));
-    when(mockAudit.lastModifier()).thenReturn("demo_user");
-    when(mockAudit.lastModifiedTime()).thenReturn(Instant.ofEpochMilli(1611111111111L));
-
-    return mockAudit;
   }
 }

--- a/clients/cli/src/test/java/org/apache/gravitino/cli/output/TestPlainFormat.java
+++ b/clients/cli/src/test/java/org/apache/gravitino/cli/output/TestPlainFormat.java
@@ -33,6 +33,9 @@ import org.apache.gravitino.Metalake;
 import org.apache.gravitino.Schema;
 import org.apache.gravitino.cli.CommandContext;
 import org.apache.gravitino.cli.outputs.PlainFormat;
+import org.apache.gravitino.rel.Table;
+import org.apache.gravitino.rel.types.Type;
+import org.apache.gravitino.rel.types.Types;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -103,6 +106,57 @@ public class TestPlainFormat {
   }
 
   @Test
+  void testSchemaDetailsWithPlainFormat() {
+    CommandContext mockContext = getMockContext();
+    Schema mockSchema = getMockSchema();
+    PlainFormat.output(mockSchema, mockContext);
+    String output = new String(outContent.toByteArray(), StandardCharsets.UTF_8).trim();
+    Assertions.assertEquals("demo_schema, This is a demo schema", output);
+  }
+
+  @Test
+  void testListSchemaWithPlainFormat() {
+    CommandContext mockContext = getMockContext();
+    Schema mockSchema1 = getMockSchema("schema1", "This is a schema");
+    Schema mockSchema2 = getMockSchema("schema2", "This is another schema");
+
+    PlainFormat.output(new Schema[] {mockSchema1, mockSchema2}, mockContext);
+    String output = new String(outContent.toByteArray(), StandardCharsets.UTF_8).trim();
+    Assertions.assertEquals("schema1\n" + "schema2", output);
+  }
+
+  @Test
+  void testTableDetailsWithPlainFormat() {
+    CommandContext mockContext = getMockContext();
+    Table mockTable = getMockTable();
+    PlainFormat.output(mockTable, mockContext);
+    String output = new String(outContent.toByteArray(), StandardCharsets.UTF_8).trim();
+    Assertions.assertEquals(
+        "id, integer, This is a int column\n" + "name, string, This is a string column", output);
+  }
+
+  @Test
+  void testListTableWithPlainFormat() {
+    CommandContext mockContext = getMockContext();
+    Table mockTable1 = getMockTable("table1", "This is a table");
+    Table mockTable2 = getMockTable("table2", "This is another table");
+
+    PlainFormat.output(new Table[] {mockTable1, mockTable2}, mockContext);
+    String output = new String(outContent.toByteArray(), StandardCharsets.UTF_8).trim();
+    Assertions.assertEquals("table1\n" + "table2", output);
+  }
+
+  @Test
+  void testTableDetailsWithAuditWithPlainFormat() {
+    CommandContext mockContext = getMockContext();
+    Table mockTable = getMockTable();
+    PlainFormat.output(mockTable, mockContext);
+    String output = new String(outContent.toByteArray(), StandardCharsets.UTF_8).trim();
+    Assertions.assertEquals(
+        "id, integer, This is a int column\n" + "name, string, This is a string column", output);
+  }
+
+  @Test
   void testOutputWithUnsupportType() {
     CommandContext mockContext = getMockContext();
     Object mockObject = new Object();
@@ -157,6 +211,38 @@ public class TestPlainFormat {
     when(mockSchema.comment()).thenReturn(comment);
 
     return mockSchema;
+  }
+
+  private Table getMockTable() {
+    return getMockTable("demo_table", "This is a demo table");
+  }
+
+  private Table getMockTable(String name, String comment) {
+    Table mockTable = mock(Table.class);
+    org.apache.gravitino.rel.Column mockColumnInt =
+        getMockColumn("id", Types.IntegerType.get(), "This is a int column", false, true);
+    org.apache.gravitino.rel.Column mockColumnString =
+        getMockColumn("name", Types.StringType.get(), "This is a string column", true, false);
+
+    when(mockTable.name()).thenReturn(name);
+    when(mockTable.comment()).thenReturn(comment);
+    when(mockTable.columns())
+        .thenReturn(new org.apache.gravitino.rel.Column[] {mockColumnInt, mockColumnString});
+
+    return mockTable;
+  }
+
+  private org.apache.gravitino.rel.Column getMockColumn(
+      String name, Type dataType, String comment, boolean nullable, boolean autoIncrement) {
+
+    org.apache.gravitino.rel.Column mockColumn = mock(org.apache.gravitino.rel.Column.class);
+    when(mockColumn.name()).thenReturn(name);
+    when(mockColumn.dataType()).thenReturn(dataType);
+    when(mockColumn.comment()).thenReturn(comment);
+    when(mockColumn.nullable()).thenReturn(nullable);
+    when(mockColumn.autoIncrement()).thenReturn(autoIncrement);
+
+    return mockColumn;
   }
 
   private Audit getMockAudit() {

--- a/clients/cli/src/test/java/org/apache/gravitino/cli/output/TestPlainFormat.java
+++ b/clients/cli/src/test/java/org/apache/gravitino/cli/output/TestPlainFormat.java
@@ -132,7 +132,9 @@ public class TestPlainFormat {
     PlainFormat.output(mockTable, mockContext);
     String output = new String(outContent.toByteArray(), StandardCharsets.UTF_8).trim();
     Assertions.assertEquals(
-        "id, integer, This is a int column\n" + "name, string, This is a string column", output);
+        "id, integer, true, false, This is a int column\n"
+            + "name, string, false, true, This is a string column",
+        output);
   }
 
   @Test
@@ -144,16 +146,6 @@ public class TestPlainFormat {
     PlainFormat.output(new Table[] {mockTable1, mockTable2}, mockContext);
     String output = new String(outContent.toByteArray(), StandardCharsets.UTF_8).trim();
     Assertions.assertEquals("table1\n" + "table2", output);
-  }
-
-  @Test
-  void testTableDetailsWithAuditWithPlainFormat() {
-    CommandContext mockContext = getMockContext();
-    Table mockTable = getMockTable();
-    PlainFormat.output(mockTable, mockContext);
-    String output = new String(outContent.toByteArray(), StandardCharsets.UTF_8).trim();
-    Assertions.assertEquals(
-        "id, integer, This is a int column\n" + "name, string, This is a string column", output);
   }
 
   @Test

--- a/clients/cli/src/test/java/org/apache/gravitino/cli/output/TestPlainFormat.java
+++ b/clients/cli/src/test/java/org/apache/gravitino/cli/output/TestPlainFormat.java
@@ -67,7 +67,7 @@ public class TestPlainFormat {
 
     PlainFormat.output(mockMetalake, mockContext);
     String output = new String(outContent.toByteArray(), StandardCharsets.UTF_8).trim();
-    Assertions.assertEquals("demo_metalake, This is a demo metalake", output);
+    Assertions.assertEquals("demo_metalake,This is a demo metalake", output);
   }
 
   @Test
@@ -88,8 +88,7 @@ public class TestPlainFormat {
 
     PlainFormat.output(mockCatalog, mockContext);
     String output = new String(outContent.toByteArray(), StandardCharsets.UTF_8).trim();
-    Assertions.assertEquals(
-        "demo_catalog, RELATIONAL, demo_provider, This is a demo catalog", output);
+    Assertions.assertEquals("demo_catalog,RELATIONAL,demo_provider,This is a demo catalog", output);
   }
 
   @Test
@@ -111,7 +110,7 @@ public class TestPlainFormat {
     Schema mockSchema = getMockSchema();
     PlainFormat.output(mockSchema, mockContext);
     String output = new String(outContent.toByteArray(), StandardCharsets.UTF_8).trim();
-    Assertions.assertEquals("demo_schema, This is a demo schema", output);
+    Assertions.assertEquals("demo_schema,This is a demo schema", output);
   }
 
   @Test
@@ -131,7 +130,7 @@ public class TestPlainFormat {
     Table mockTable = getMockTable();
     PlainFormat.output(mockTable, mockContext);
     String output = new String(outContent.toByteArray(), StandardCharsets.UTF_8).trim();
-    Assertions.assertEquals("demo_table, This is a demo table", output);
+    Assertions.assertEquals("demo_table,This is a demo table", output);
   }
 
   @Test
@@ -146,7 +145,7 @@ public class TestPlainFormat {
     PlainFormat.output(mockAudit, mockContext);
     String output = new String(outContent.toByteArray(), StandardCharsets.UTF_8).trim();
     Assertions.assertEquals(
-        "demo_user, 2021-01-20T02:51:51.111Z, demo_user, 2021-01-20T02:51:51.111Z", output);
+        "demo_user,2021-01-20T02:51:51.111Z,demo_user,2021-01-20T02:51:51.111Z", output);
   }
 
   @Test
@@ -160,7 +159,7 @@ public class TestPlainFormat {
 
     PlainFormat.output(mockAudit, mockContext);
     String output = new String(outContent.toByteArray(), StandardCharsets.UTF_8).trim();
-    Assertions.assertEquals("demo_user, N/A, N/A, N/A", output);
+    Assertions.assertEquals("demo_user,N/A,N/A,N/A", output);
   }
 
   @Test


### PR DESCRIPTION
### What changes were proposed in this pull request?

Support plain format output for Schema and Table command

### Why are the changes needed?

Fix: #6496

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

local test
```bash
gcli schema list -m demo_metalake --name Hive_catalog  -i
default,Default Hive database

gcli table list -m demo_metalake --name Hive_catalog.default -i 
employee_partitions
source_table
test_dt_partition
test_key_en
sales
order_tb1
tmp
float_test
test_tbl

gcli table details -m demo_metalake --name Hive_catalog.default.test1  -i 
test1,N/A

gcli schema details -m demo_metalake --name Hive_catalog.default -i 
default,Default Hive database
```