### PR TITLE
[#5746] feat(CLI): Support table format output for Audit command

### DIFF
--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/AuditCommand.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/AuditCommand.java
@@ -39,17 +39,10 @@ public abstract class AuditCommand extends Command {
    * @param audit from a class that implements the Auditable interface.
    */
   public void displayAuditInfo(Audit audit) {
-    String auditInfo =
-        "creator,create_time,modified,modified_time"
-            + System.lineSeparator()
-            + audit.creator()
-            + ","
-            + audit.createTime()
-            + ","
-            + audit.lastModifier()
-            + ","
-            + audit.lastModifiedTime();
+    if (audit == null) {
+      return;
+    }
 
-    printResults(auditInfo);
+    printResults(audit);
   }
 }

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/CatalogAudit.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/CatalogAudit.java
@@ -59,8 +59,6 @@ public class CatalogAudit extends AuditCommand {
       exitWithError(exp.getMessage());
     }
 
-    if (result != null) {
-      displayAuditInfo(result.auditInfo());
-    }
+    displayAuditInfo(result.auditInfo());
   }
 }

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/SchemaAudit.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/SchemaAudit.java
@@ -66,8 +66,6 @@ public class SchemaAudit extends AuditCommand {
       exitWithError(exp.getMessage());
     }
 
-    if (result != null) {
-      displayAuditInfo(result.auditInfo());
-    }
+    displayAuditInfo(result.auditInfo());
   }
 }

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/outputs/TableFormat.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/outputs/TableFormat.java
@@ -665,9 +665,10 @@ public abstract class TableFormat<T> extends BaseOutputFormat<T> {
       Column columnModifyTime = new Column(context, "modify time");
 
       columnCreator.addCell(audit.creator());
-      columnCreateTime.addCell(audit.createTime());
-      columnModified.addCell(audit.lastModifier());
-      columnModifyTime.addCell(audit.lastModifiedTime());
+      columnCreateTime.addCell(audit.createTime() == null ? "N/A" : audit.createTime().toString());
+      columnModified.addCell(audit.lastModifier() == null ? "N/A" : audit.lastModifier());
+      columnModifyTime.addCell(
+          audit.lastModifiedTime() == null ? "N/A" : audit.lastModifiedTime().toString());
 
       return getTableFormat(columnCreator, columnCreateTime, columnModified, columnModifyTime);
     }

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/outputs/TableFormat.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/outputs/TableFormat.java
@@ -660,9 +660,9 @@ public abstract class TableFormat<T> extends BaseOutputFormat<T> {
     @Override
     public String getOutput(Audit audit) {
       Column columnCreator = new Column(context, "creator");
-      Column columnCreateTime = new Column(context, "create time");
-      Column columnModified = new Column(context, "modified");
-      Column columnModifyTime = new Column(context, "modify time");
+      Column columnCreateTime = new Column(context, "creation at");
+      Column columnModified = new Column(context, "modifier");
+      Column columnModifyTime = new Column(context, "modified at");
 
       columnCreator.addCell(audit.creator());
       columnCreateTime.addCell(audit.createTime() == null ? "N/A" : audit.createTime().toString());

--- a/clients/cli/src/test/java/org/apache/gravitino/cli/output/TestTableFormat.java
+++ b/clients/cli/src/test/java/org/apache/gravitino/cli/output/TestTableFormat.java
@@ -26,6 +26,8 @@ import static org.mockito.Mockito.when;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import org.apache.gravitino.Audit;
 import org.apache.gravitino.Catalog;
 import org.apache.gravitino.Metalake;
 import org.apache.gravitino.Schema;
@@ -374,6 +376,21 @@ public class TestTableFormat {
   }
 
   @Test
+  void testAuditWithTableFormat() {
+    CommandContext mockContext = getMockContext();
+    Audit mockAudit = getMockAudit();
+    TableFormat.output(mockAudit, mockContext);
+    String output = new String(outContent.toByteArray(), StandardCharsets.UTF_8).trim();
+    Assertions.assertEquals(
+        "+-----------+--------------------------+-----------+--------------------------+\n"
+            + "|  Creator  |       Create time        | Modified  |       Modify time        |\n"
+            + "+-----------+--------------------------+-----------+--------------------------+\n"
+            + "| demo_user | 2021-01-20T02:51:51.111Z | demo_user | 2021-01-20T02:51:51.111Z |\n"
+            + "+-----------+--------------------------+-----------+--------------------------+",
+        output);
+  }
+
+  @Test
   void testOutputWithUnsupportType() {
     CommandContext mockContext = getMockContext();
     Object mockObject = new Object();
@@ -460,5 +477,15 @@ public class TestTableFormat {
     when(mockColumn.autoIncrement()).thenReturn(autoIncrement);
 
     return mockColumn;
+  }
+
+  private Audit getMockAudit() {
+    Audit mockAudit = mock(Audit.class);
+    when(mockAudit.creator()).thenReturn("demo_user");
+    when(mockAudit.createTime()).thenReturn(Instant.ofEpochMilli(1611111111111L));
+    when(mockAudit.lastModifier()).thenReturn("demo_user");
+    when(mockAudit.lastModifiedTime()).thenReturn(Instant.ofEpochMilli(1611111111111L));
+
+    return mockAudit;
   }
 }

--- a/clients/cli/src/test/java/org/apache/gravitino/cli/output/TestTableFormat.java
+++ b/clients/cli/src/test/java/org/apache/gravitino/cli/output/TestTableFormat.java
@@ -378,8 +378,14 @@ public class TestTableFormat {
   @Test
   void testAuditWithTableFormat() {
     CommandContext mockContext = getMockContext();
-    Audit mockAudit = getMockAudit();
+    Audit mockAudit = mock(Audit.class);
+    when(mockAudit.creator()).thenReturn("demo_user");
+    when(mockAudit.createTime()).thenReturn(Instant.ofEpochMilli(1611111111111L));
+    when(mockAudit.lastModifier()).thenReturn("demo_user");
+    when(mockAudit.lastModifiedTime()).thenReturn(Instant.ofEpochMilli(1611111111111L));
+
     TableFormat.output(mockAudit, mockContext);
+
     String output = new String(outContent.toByteArray(), StandardCharsets.UTF_8).trim();
     Assertions.assertEquals(
         "+-----------+--------------------------+-----------+--------------------------+\n"
@@ -387,6 +393,27 @@ public class TestTableFormat {
             + "+-----------+--------------------------+-----------+--------------------------+\n"
             + "| demo_user | 2021-01-20T02:51:51.111Z | demo_user | 2021-01-20T02:51:51.111Z |\n"
             + "+-----------+--------------------------+-----------+--------------------------+",
+        output);
+  }
+
+  @Test
+  void testAuditWithTableFormatWithNullValues() {
+    CommandContext mockContext = getMockContext();
+    Audit mockAudit = mock(Audit.class);
+    when(mockAudit.creator()).thenReturn("demo_user");
+    when(mockAudit.createTime()).thenReturn(null);
+    when(mockAudit.lastModifier()).thenReturn(null);
+    when(mockAudit.lastModifiedTime()).thenReturn(null);
+
+    TableFormat.output(mockAudit, mockContext);
+
+    String output = new String(outContent.toByteArray(), StandardCharsets.UTF_8).trim();
+    Assertions.assertEquals(
+        "+-----------+-------------+----------+-------------+\n"
+            + "|  Creator  | Create time | Modified | Modify time |\n"
+            + "+-----------+-------------+----------+-------------+\n"
+            + "| demo_user | N/A         | N/A      | N/A         |\n"
+            + "+-----------+-------------+----------+-------------+",
         output);
   }
 
@@ -477,15 +504,5 @@ public class TestTableFormat {
     when(mockColumn.autoIncrement()).thenReturn(autoIncrement);
 
     return mockColumn;
-  }
-
-  private Audit getMockAudit() {
-    Audit mockAudit = mock(Audit.class);
-    when(mockAudit.creator()).thenReturn("demo_user");
-    when(mockAudit.createTime()).thenReturn(Instant.ofEpochMilli(1611111111111L));
-    when(mockAudit.lastModifier()).thenReturn("demo_user");
-    when(mockAudit.lastModifiedTime()).thenReturn(Instant.ofEpochMilli(1611111111111L));
-
-    return mockAudit;
   }
 }

--- a/clients/cli/src/test/java/org/apache/gravitino/cli/output/TestTableFormat.java
+++ b/clients/cli/src/test/java/org/apache/gravitino/cli/output/TestTableFormat.java
@@ -389,7 +389,7 @@ public class TestTableFormat {
     String output = new String(outContent.toByteArray(), StandardCharsets.UTF_8).trim();
     Assertions.assertEquals(
         "+-----------+--------------------------+-----------+--------------------------+\n"
-            + "|  Creator  |       Create time        | Modified  |       Modify time        |\n"
+            + "|  Creator  |       Creation at        | Modifier  |       Modified at        |\n"
             + "+-----------+--------------------------+-----------+--------------------------+\n"
             + "| demo_user | 2021-01-20T02:51:51.111Z | demo_user | 2021-01-20T02:51:51.111Z |\n"
             + "+-----------+--------------------------+-----------+--------------------------+",
@@ -410,7 +410,7 @@ public class TestTableFormat {
     String output = new String(outContent.toByteArray(), StandardCharsets.UTF_8).trim();
     Assertions.assertEquals(
         "+-----------+-------------+----------+-------------+\n"
-            + "|  Creator  | Create time | Modified | Modify time |\n"
+            + "|  Creator  | Creation at | Modifier | Modified at |\n"
             + "+-----------+-------------+----------+-------------+\n"
             + "| demo_user | N/A         | N/A      | N/A         |\n"
             + "+-----------+-------------+----------+-------------+",


### PR DESCRIPTION
### What changes were proposed in this pull request?

Support table format output for Audit command.

### Why are the changes needed?

Fix: #5746 

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

local test.
```bash
gcli metalake  details   --output table  -m demo_metalake --audit  -i
+-----------+--------------------------+-----------+--------------------------+
|  Creator  |       Creation at        | Modifier  |       Modified at        |
+-----------+--------------------------+-----------+--------------------------+
| anonymous | 2024-12-04T07:41:18.512Z | anonymous | 2025-01-14T07:56:25.496Z |
+-----------+--------------------------+-----------+--------------------------+

gcli catalog  details --name Hive_catalog  -i --output table  -m demo_metalake --audit
+-----------+--------------------------+-----------+-----------------------------+
|  Creator  |       Creation at        | Modifier  |         Modified at         |
+-----------+--------------------------+-----------+-----------------------------+
| anonymous | 2024-12-05T01:20:40.512Z | anonymous | 2025-02-21T08:36:50.613886Z |
+-----------+--------------------------+-----------+-----------------------------+

gcli schema  details --name Hive_catalog.default --output table  -m demo_metalake --audit -i
+---------+-------------+----------+-------------+
| Creator | Creation at | Modifier | Modified at |
+---------+-------------+----------+-------------+
| public  | N/A         | N/A      | N/A         |
+---------+-------------+----------+-------------+

gcli table  details --name Hive_catalog.default.test_dates --output table  -m demo_metalake --audit -i
+-----------+----------------------+----------+-------------+
|  Creator  |     Creation at      | Modifier | Modified at |
+-----------+----------------------+----------+-------------+
| panchenxi | 2024-07-24T07:20:52Z | N/A      | N/A         |
+-----------+----------------------+----------+-------------+
```
