### PR TITLE
[#6511] fix (gvfs-fuse): Fix rust build failed on `rust check`

### DIFF
--- a/clients/filesystem-fuse/Makefile
+++ b/clients/filesystem-fuse/Makefile
@@ -43,7 +43,7 @@ check-cargo-sort: install-cargo-sort
 	cargo sort -c
 
 install-cargo-machete:
-	cargo install cargo-machete
+	cargo install cargo-machete@0.7.0
 
 cargo-machete: install-cargo-machete
 	cargo machete


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix rust build failed on `rust check, make the version of `cargo-machete` is 0.7.0.

### Why are the changes needed?

Fix: #6511

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Manually
