### PR TITLE
[#6516] fix: add @Override annotation

### DIFF
--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/SchemaMetaPostgreSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/SchemaMetaPostgreSQLProvider.java
@@ -83,6 +83,7 @@ public class SchemaMetaPostgreSQLProvider extends SchemaMetaBaseSQLProvider {
         + " WHERE catalog_id = #{catalogId} AND deleted_at = 0";
   }
 
+  @Override
   public String deleteSchemaMetasByLegacyTimeline(
       @Param("legacyTimeline") Long legacyTimeline, @Param("limit") int limit) {
     return "DELETE FROM "


### PR DESCRIPTION
### What changes were proposed in this pull request?

The method `deleteSchemaMetasByLegacyTimeline` ([SchemaMetaPostgreSQLProvider.java](https://github.com/apache/gravitino/blob/4996d0c50e64fc9a702117a4ded1451867d7b89b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/SchemaMetaPostgreSQLProvider.java#L86)) was missing the `@Override` annotation.

### Why are the changes needed?

Method `deleteSchemaMetasByLegacyTimeline` is missing the override annotation.

Fix: #6516 

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

No testing is required.
