### PR TITLE
[#6517] fix: unneeded call to toString()

### DIFF
--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/UntagEntity.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/UntagEntity.java
@@ -134,7 +134,7 @@ public class UntagEntity extends Command {
       printInformation(
           entity + " removed tags " + String.join(",", tags) + " now tagged with " + all);
     } else {
-      printInformation(entity + " removed tag " + tags[0].toString() + " now tagged with " + all);
+      printInformation(entity + " removed tag " + tags[0] + " now tagged with " + all);
     }
   }
 


### PR DESCRIPTION


### What changes were proposed in this pull request?

As tags is an array of strings, `tags[0].toString()` doesn't require `toString()`.

### Why are the changes needed?

to string method not needed.

Fix: #6517 

### Does this PR introduce _any_ user-facing change?

no

### How was this patch tested?

no needed
