### PR TITLE
fix(logging): Correct logger class in IcebergTableRenameOperations

### DIFF
--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/rest/IcebergTableRenameOperations.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/rest/IcebergTableRenameOperations.java
@@ -43,7 +43,7 @@ import org.slf4j.LoggerFactory;
 @Consumes(MediaType.APPLICATION_JSON)
 @Produces(MediaType.APPLICATION_JSON)
 public class IcebergTableRenameOperations {
-  private static final Logger LOG = LoggerFactory.getLogger(IcebergTableOperations.class);
+  private static final Logger LOG = LoggerFactory.getLogger(IcebergTableRenameOperations.class);
 
   @Context private HttpServletRequest httpRequest;
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fixed an incorrect logging class reference in IcebergTableRenameOperations.

### Why are the changes needed?

The logger was incorrectly referencing IcebergTableOperations instead of IcebergTableRenameOperations, which could cause confusion in logs.

Fix: #6518 


### Does this PR introduce *any* user-facing change?

No

### How was this patch tested?

No testing is required.