### PR TITLE
fix: Remove incorrect @VisibleForTesting annotation from ICEBERG_CATALOG_CACHE_ENABLED

### DIFF
--- a/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/iceberg/IcebergPropertiesConstants.java
+++ b/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/iceberg/IcebergPropertiesConstants.java
@@ -76,9 +76,8 @@ public class IcebergPropertiesConstants {
   @VisibleForTesting
   public static final String ICEBERG_FORMAT_VERSION = IcebergConstants.FORMAT_VERSION;
 
-  @VisibleForTesting
   public static final String ICEBERG_CATALOG_CACHE_ENABLED = CatalogProperties.CACHE_ENABLED;
-
+  
   static final String GRAVITINO_ICEBERG_CATALOG_BACKEND_NAME =
       IcebergConstants.CATALOG_BACKEND_NAME;
 


### PR DESCRIPTION
#### **What changes were proposed in this pull request?**

-   Removed the incorrect `@VisibleForTesting` annotation from `ICEBERG_CATALOG_CACHE_ENABLED` in `IcebergPropertiesConstants.java`.
-   This constant is used in production code inside `IcebergPropertiesConverter.java`, so marking it as **only for testing** is incorrect.

#### **Why are the changes needed?**

-   `ICEBERG_CATALOG_CACHE_ENABLED` is being used inside `IcebergPropertiesConverter.java` to set catalog properties.
-   The `@VisibleForTesting` annotation suggests that the constant should only be accessed in test cases, which is misleading and incorrect.
-   This fix ensures that the constant is correctly available for production use.

#### **Fix: #6529 **

#### **Does this PR introduce any user-facing change?**

-   **No user-facing changes.** This is an internal improvement in the codebase.