### PR TITLE
[#6537] improvement(core): Change the level of some log in `LockManager` and `GrabageCollector` from INFO to DEBUG 

### DIFF
--- a/core/src/main/java/org/apache/gravitino/lock/LockManager.java
+++ b/core/src/main/java/org/apache/gravitino/lock/LockManager.java
@@ -112,9 +112,9 @@ public class LockManager {
 
     deadLockChecker.scheduleAtFixedRate(
         () -> {
-          LOG.info("Start to check the dead lock...");
+          LOG.debug("Start to check the dead lock...");
           checkDeadLock(treeLockRootNode);
-          LOG.info("Finish to check the dead lock...");
+          LOG.debug("Finish to check the dead lock...");
         },
         0,
         60,
@@ -161,12 +161,12 @@ public class LockManager {
     lockCleaner.scheduleAtFixedRate(
         () -> {
           long nodeCount = totalNodeCount.get();
-          LOG.info("Total tree lock node count: {}", nodeCount);
+          LOG.debug("Total tree lock node count: {}", nodeCount);
           // If the total node count is greater than the maxTreeNodeInMemory * 0.5, we will do the
           // clear up in case of the memory explosion.
           if (nodeCount > maxTreeNodeInMemory * 0.5) {
             StopWatch watch = StopWatch.createStarted();
-            LOG.trace("Start to clean up the stale tree lock nodes...");
+            LOG.info("Start to clean up the stale tree lock nodes...");
             treeLockRootNode
                 .getAllChildren()
                 .forEach(child -> evictStaleNodes(child, treeLockRootNode));

--- a/core/src/main/java/org/apache/gravitino/storage/relational/RelationalGarbageCollector.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/RelationalGarbageCollector.java
@@ -71,14 +71,14 @@ public final class RelationalGarbageCollector implements Closeable {
   @VisibleForTesting
   public void collectAndClean() {
     long threadId = Thread.currentThread().getId();
-    LOG.info("Thread {} start to collect garbage...", threadId);
+    LOG.debug("Thread {} start to collect garbage...", threadId);
 
     try {
-      LOG.info("Start to collect and delete legacy data by thread {}", threadId);
+      LOG.debug("Start to collect and delete legacy data by thread {}", threadId);
       long legacyTimeline = System.currentTimeMillis() - storeDeleteAfterTimeMillis;
       for (Entity.EntityType entityType : Entity.EntityType.values()) {
         long deletedCount = Long.MAX_VALUE;
-        LOG.info(
+        LOG.debug(
             "Try to physically delete {} legacy data that has been marked deleted before {}",
             entityType,
             legacyTimeline);
@@ -94,7 +94,7 @@ public final class RelationalGarbageCollector implements Closeable {
       LOG.info("Start to collect and delete old version data by thread {}", threadId);
       for (Entity.EntityType entityType : Entity.EntityType.values()) {
         long deletedCount = Long.MAX_VALUE;
-        LOG.info(
+        LOG.debug(
             "Try to softly delete {} old version data that has been over retention count {}",
             entityType,
             versionRetentionCount);
@@ -109,7 +109,7 @@ public final class RelationalGarbageCollector implements Closeable {
     } catch (Exception e) {
       LOG.error("Thread {} failed to collect and clean garbage.", threadId, e);
     } finally {
-      LOG.info("Thread {} finish to collect garbage.", threadId);
+      LOG.debug("Thread {} finish to collect garbage.", threadId);
     }
   }
 


### PR DESCRIPTION


### What changes were proposed in this pull request?

Change the level of log from INFO to DEBUG.

### Why are the changes needed?

As the log will be show periodically, in order to reduce the size of the Gravitino server log, we need to change it from INFO to DEBUG.

Fix: #6537 

### Does this PR introduce _any_ user-facing change?

N/A.

### How was this patch tested?

Existing UTs and ITs.
