### PR TITLE
Revert "build(deps): bump carloscastrojumo/github-cherry-pick-action from 1.0.9 to 1.0.10 (#6550)"

### DIFF
--- a/.github/workflows/auto-cherry-pick.yml
+++ b/.github/workflows/auto-cherry-pick.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Cherry pick into branch-0.7
-        uses: carloscastrojumo/github-cherry-pick-action@v1.0.10
+        uses: carloscastrojumo/github-cherry-pick-action@v1.0.9
         with:
           branch: branch-0.7
           labels: |
@@ -35,7 +35,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Cherry pick into branch-0.8
-        uses: carloscastrojumo/github-cherry-pick-action@v1.0.10
+        uses: carloscastrojumo/github-cherry-pick-action@v1.0.9
         with:
           branch: branch-0.8
           labels: |


### PR DESCRIPTION
### What changes were proposed in this pull request?

This reverts commit 54a5371f572b7b3eca063cae8606951903c12867.

### Why are the changes needed?

Seems like the new version cannot be used by Apache Gravitino https://github.com/apache/gravitino/actions/runs/13558713734


### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing test.
