### PR TITLE
[#6605] fix(web): fix model version alias to be optional

### DIFF
--- a/web/web/src/app/metalakes/metalake/rightContent/LinkVersionDialog.js
+++ b/web/web/src/app/metalakes/metalake/rightContent/LinkVersionDialog.js
@@ -66,9 +66,8 @@ const schema = yup.object().shape({
       yup.object().shape({
         name: yup
           .string()
-          .required('The alias is required')
           .test('not-number', 'Alias cannot be a number or a numeric string', value => {
-            return value === undefined || isNaN(Number(value))
+            return value && isNaN(Number(value)) || !value
           })
       })
     )
@@ -214,7 +213,7 @@ const LinkVersionDialog = props => {
 
         const schemaData = {
           uri: data.uri,
-          aliases: data.aliases.map(alias => alias.name),
+          aliases: data.aliases.map(alias => alias.name).filter(aliasName => aliasName),
           comment: data.comment,
           properties
         }

--- a/web/web/src/app/metalakes/metalake/rightContent/LinkVersionDialog.js
+++ b/web/web/src/app/metalakes/metalake/rightContent/LinkVersionDialog.js
@@ -64,11 +64,9 @@ const schema = yup.object().shape({
     .array()
     .of(
       yup.object().shape({
-        name: yup
-          .string()
-          .test('not-number', 'Alias cannot be a number or a numeric string', value => {
-            return value && isNaN(Number(value)) || !value
-          })
+        name: yup.string().test('not-number', 'Alias cannot be a number or a numeric string', value => {
+          return (value && isNaN(Number(value))) || !value
+        })
       })
     )
     .test('unique', 'Alias must be unique', (aliases, ctx) => {


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?
click submit button to trigger verification of version form, and no required info for alias form item.
<img width="751" alt="image" src="https://github.com/user-attachments/assets/0ac3a6b0-d626-47fe-add3-783e59d0b9b6" />


### Why are the changes needed?
Model version alias should be optional

Fix: #6605

### Does this PR introduce _any_ user-facing change?
N/A

### How was this patch tested?
manually
