### PR TITLE
[#6011] fix(authz): `MODIFY_TABLE` should contain the select table privilege

### DIFF
--- a/authorizations/authorization-chain/src/test/java/org/apache/gravitino/authorization/chain/integration/test/TestChainedAuthorizationIT.java
+++ b/authorizations/authorization-chain/src/test/java/org/apache/gravitino/authorization/chain/integration/test/TestChainedAuthorizationIT.java
@@ -320,22 +320,22 @@ public class TestChainedAuthorizationIT extends RangerBaseE2EIT {
   }
 
   @Test
-  void testReadWriteTableWithMetalakeLevelRole() throws InterruptedException {
+  void testSelectModifyTableWithMetalakeLevelRole() throws InterruptedException {
     // TODO
   }
 
   @Test
-  void testReadWriteTableWithTableLevelRole() throws InterruptedException {
+  void testSelectModifyTableWithTableLevelRole() throws InterruptedException {
     // TODO
   }
 
   @Test
-  void testReadOnlyTable() throws InterruptedException {
+  void testSelectOnlyTable() throws InterruptedException {
     // TODO
   }
 
   @Test
-  void testWriteOnlyTable() throws InterruptedException {
+  void testModifyOnlyTable() throws InterruptedException {
     // TODO
   }
 

--- a/authorizations/authorization-chain/src/test/java/org/apache/gravitino/authorization/chain/integration/test/TestChainedAuthorizationIT.java
+++ b/authorizations/authorization-chain/src/test/java/org/apache/gravitino/authorization/chain/integration/test/TestChainedAuthorizationIT.java
@@ -385,32 +385,32 @@ public class TestChainedAuthorizationIT extends RangerBaseE2EIT {
   }
 
   @Override
-  protected void checkUpdateSQLWithReadWritePrivileges() {
+  protected void checkUpdateSQLWithSelectModifyPrivileges() {
     // TODO
   }
 
   @Override
-  protected void checkUpdateSQLWithReadPrivileges() {
+  protected void checkUpdateSQLWithSelectPrivileges() {
     // TODO
   }
 
   @Override
-  protected void checkUpdateSQLWithWritePrivileges() {
+  protected void checkUpdateSQLWithModifyPrivileges() {
     // TODO
   }
 
   @Override
-  protected void checkDeleteSQLWithReadWritePrivileges() {
+  protected void checkDeleteSQLWithSelectModifyPrivileges() {
     // TODO
   }
 
   @Override
-  protected void checkDeleteSQLWithReadPrivileges() {
+  protected void checkDeleteSQLWithSelectPrivileges() {
     // TODO
   }
 
   @Override
-  protected void checkDeleteSQLWithWritePrivileges() {
+  protected void checkDeleteSQLWithModifyPrivileges() {
     // TODO
   }
 

--- a/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/RangerAuthorizationHadoopSQLPlugin.java
+++ b/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/RangerAuthorizationHadoopSQLPlugin.java
@@ -78,6 +78,8 @@ public class RangerAuthorizationHadoopSQLPlugin extends RangerAuthorizationPlugi
         ImmutableSet.of(RangerHadoopSQLPrivilege.CREATE),
         Privilege.Name.MODIFY_TABLE,
         ImmutableSet.of(
+            RangerHadoopSQLPrivilege.READ,
+            RangerHadoopSQLPrivilege.SELECT,
             RangerHadoopSQLPrivilege.UPDATE,
             RangerHadoopSQLPrivilege.ALTER,
             RangerHadoopSQLPrivilege.WRITE),

--- a/authorizations/authorization-ranger/src/test/java/org/apache/gravitino/authorization/ranger/integration/test/RangerBaseE2EIT.java
+++ b/authorizations/authorization-ranger/src/test/java/org/apache/gravitino/authorization/ranger/integration/test/RangerBaseE2EIT.java
@@ -191,17 +191,17 @@ public abstract class RangerBaseE2EIT extends BaseIT {
 
   protected abstract void checkTableAllPrivilegesExceptForCreating();
 
-  protected abstract void checkUpdateSQLWithReadWritePrivileges();
+  protected abstract void checkUpdateSQLWithSelectModifyPrivileges();
 
-  protected abstract void checkUpdateSQLWithReadPrivileges();
+  protected abstract void checkUpdateSQLWithSelectPrivileges();
 
-  protected abstract void checkUpdateSQLWithWritePrivileges();
+  protected abstract void checkUpdateSQLWithModifyPrivileges();
 
-  protected abstract void checkDeleteSQLWithReadWritePrivileges();
+  protected abstract void checkDeleteSQLWithSelectModifyPrivileges();
 
-  protected abstract void checkDeleteSQLWithReadPrivileges();
+  protected abstract void checkDeleteSQLWithSelectPrivileges();
 
-  protected abstract void checkDeleteSQLWithWritePrivileges();
+  protected abstract void checkDeleteSQLWithModifyPrivileges();
 
   protected abstract void useCatalog();
 
@@ -346,10 +346,10 @@ public abstract class RangerBaseE2EIT extends BaseIT {
     sparkSession.sql(SQL_SELECT_TABLE).collectAsList();
 
     // case 3: Update data in the table
-    checkUpdateSQLWithReadWritePrivileges();
+    checkUpdateSQLWithSelectModifyPrivileges();
 
     // case 4:  Delete data from the table.
-    checkDeleteSQLWithReadWritePrivileges();
+    checkDeleteSQLWithSelectModifyPrivileges();
 
     // case 5: Succeed to alter the table
     testAlterTable();
@@ -410,10 +410,10 @@ public abstract class RangerBaseE2EIT extends BaseIT {
     sparkSession.sql(SQL_SELECT_TABLE).collectAsList();
 
     // case 3: Update data in the table.
-    checkUpdateSQLWithReadWritePrivileges();
+    checkUpdateSQLWithSelectModifyPrivileges();
 
     // case 4: Delete data from the table.
-    checkDeleteSQLWithReadWritePrivileges();
+    checkDeleteSQLWithSelectModifyPrivileges();
 
     // case 5: Succeed to alter the table
     testAlterTable();
@@ -464,10 +464,10 @@ public abstract class RangerBaseE2EIT extends BaseIT {
     sparkSession.sql(SQL_SELECT_TABLE).collectAsList();
 
     // case 3: Update data in the table
-    checkUpdateSQLWithReadPrivileges();
+    checkUpdateSQLWithSelectPrivileges();
 
     // case 4: Delete data from the table
-    checkDeleteSQLWithReadPrivileges();
+    checkDeleteSQLWithSelectPrivileges();
 
     // case 5: Fail to alter the table
     Assertions.assertThrows(AccessControlException.class, () -> sparkSession.sql(SQL_ALTER_TABLE));
@@ -518,10 +518,10 @@ public abstract class RangerBaseE2EIT extends BaseIT {
     sparkSession.sql(SQL_SELECT_TABLE).collectAsList();
 
     // case 3: Update data in the table
-    checkUpdateSQLWithWritePrivileges();
+    checkUpdateSQLWithModifyPrivileges();
 
     // case 4: Delete data from the table
-    checkDeleteSQLWithWritePrivileges();
+    checkDeleteSQLWithModifyPrivileges();
 
     // case 5: Succeed to alter the table
     testAlterTable();

--- a/authorizations/authorization-ranger/src/test/java/org/apache/gravitino/authorization/ranger/integration/test/RangerBaseE2EIT.java
+++ b/authorizations/authorization-ranger/src/test/java/org/apache/gravitino/authorization/ranger/integration/test/RangerBaseE2EIT.java
@@ -313,7 +313,7 @@ public abstract class RangerBaseE2EIT extends BaseIT {
   }
 
   @Test
-  void testReadWriteTableWithMetalakeLevelRole() throws InterruptedException {
+  void testSelectModifyTableWithMetalakeLevelRole() throws InterruptedException {
     // Choose a catalog
     useCatalog();
 
@@ -368,7 +368,7 @@ public abstract class RangerBaseE2EIT extends BaseIT {
   }
 
   @Test
-  void testReadWriteTableWithTableLevelRole() throws InterruptedException {
+  void testSelectModifyTableWithTableLevelRole() throws InterruptedException {
     // Choose a catalog
     useCatalog();
 
@@ -432,7 +432,7 @@ public abstract class RangerBaseE2EIT extends BaseIT {
   }
 
   @Test
-  void testReadOnlyTable() throws InterruptedException {
+  void testSelectOnlyTable() throws InterruptedException {
     // Choose a catalog
     useCatalog();
 
@@ -486,7 +486,7 @@ public abstract class RangerBaseE2EIT extends BaseIT {
   }
 
   @Test
-  void testWriteOnlyTable() throws InterruptedException {
+  void testModifyOnlyTable() throws InterruptedException {
     // Choose a catalog
     useCatalog();
 
@@ -514,9 +514,8 @@ public abstract class RangerBaseE2EIT extends BaseIT {
     // case 1: Succeed to insert data into the table
     sparkSession.sql(SQL_INSERT_TABLE);
 
-    // case 2: Fail to select data from the table
-    Assertions.assertThrows(
-        AccessControlException.class, () -> sparkSession.sql(SQL_SELECT_TABLE).collectAsList());
+    // case 2: Fail select data from the table
+    sparkSession.sql(SQL_SELECT_TABLE).collectAsList();
 
     // case 3: Update data in the table
     checkUpdateSQLWithWritePrivileges();

--- a/authorizations/authorization-ranger/src/test/java/org/apache/gravitino/authorization/ranger/integration/test/RangerBaseE2EIT.java
+++ b/authorizations/authorization-ranger/src/test/java/org/apache/gravitino/authorization/ranger/integration/test/RangerBaseE2EIT.java
@@ -514,7 +514,7 @@ public abstract class RangerBaseE2EIT extends BaseIT {
     // case 1: Succeed to insert data into the table
     sparkSession.sql(SQL_INSERT_TABLE);
 
-    // case 2: Fail select data from the table
+    // case 2: Succeed to select data from the table
     sparkSession.sql(SQL_SELECT_TABLE).collectAsList();
 
     // case 3: Update data in the table

--- a/authorizations/authorization-ranger/src/test/java/org/apache/gravitino/authorization/ranger/integration/test/RangerHiveE2EIT.java
+++ b/authorizations/authorization-ranger/src/test/java/org/apache/gravitino/authorization/ranger/integration/test/RangerHiveE2EIT.java
@@ -133,35 +133,35 @@ public class RangerHiveE2EIT extends RangerBaseE2EIT {
   }
 
   @Override
-  protected void checkUpdateSQLWithReadWritePrivileges() {
+  protected void checkUpdateSQLWithSelectModifyPrivileges() {
     Assertions.assertThrows(
         SparkUnsupportedOperationException.class, () -> sparkSession.sql(SQL_UPDATE_TABLE));
   }
 
   @Override
-  protected void checkUpdateSQLWithReadPrivileges() {
+  protected void checkUpdateSQLWithSelectPrivileges() {
     Assertions.assertThrows(
         SparkUnsupportedOperationException.class, () -> sparkSession.sql(SQL_UPDATE_TABLE));
   }
 
   @Override
-  protected void checkUpdateSQLWithWritePrivileges() {
+  protected void checkUpdateSQLWithModifyPrivileges() {
     Assertions.assertThrows(
         SparkUnsupportedOperationException.class, () -> sparkSession.sql(SQL_UPDATE_TABLE));
   }
 
   @Override
-  protected void checkDeleteSQLWithReadWritePrivileges() {
+  protected void checkDeleteSQLWithSelectModifyPrivileges() {
     Assertions.assertThrows(AnalysisException.class, () -> sparkSession.sql(SQL_DELETE_TABLE));
   }
 
   @Override
-  protected void checkDeleteSQLWithReadPrivileges() {
+  protected void checkDeleteSQLWithSelectPrivileges() {
     Assertions.assertThrows(AnalysisException.class, () -> sparkSession.sql(SQL_DELETE_TABLE));
   }
 
   @Override
-  protected void checkDeleteSQLWithWritePrivileges() {
+  protected void checkDeleteSQLWithModifyPrivileges() {
     Assertions.assertThrows(AnalysisException.class, () -> sparkSession.sql(SQL_DELETE_TABLE));
   }
 

--- a/authorizations/authorization-ranger/src/test/java/org/apache/gravitino/authorization/ranger/integration/test/RangerIcebergE2EIT.java
+++ b/authorizations/authorization-ranger/src/test/java/org/apache/gravitino/authorization/ranger/integration/test/RangerIcebergE2EIT.java
@@ -111,33 +111,33 @@ public class RangerIcebergE2EIT extends RangerBaseE2EIT {
     return System.getenv(HADOOP_USER_NAME);
   }
 
-  public void checkUpdateSQLWithReadWritePrivileges() {
+  public void checkUpdateSQLWithSelectModifyPrivileges() {
     sparkSession.sql(SQL_UPDATE_TABLE);
   }
 
   @Override
-  public void checkUpdateSQLWithReadPrivileges() {
+  public void checkUpdateSQLWithSelectPrivileges() {
     Assertions.assertThrows(AccessControlException.class, () -> sparkSession.sql(SQL_UPDATE_TABLE));
   }
 
   @Override
-  public void checkUpdateSQLWithWritePrivileges() {
-    Assertions.assertThrows(AccessControlException.class, () -> sparkSession.sql(SQL_UPDATE_TABLE));
+  public void checkUpdateSQLWithModifyPrivileges() {
+    sparkSession.sql(SQL_UPDATE_TABLE);
   }
 
   @Override
-  public void checkDeleteSQLWithReadWritePrivileges() {
+  public void checkDeleteSQLWithSelectModifyPrivileges() {
     sparkSession.sql(SQL_DELETE_TABLE);
   }
 
   @Override
-  public void checkDeleteSQLWithReadPrivileges() {
+  public void checkDeleteSQLWithSelectPrivileges() {
     Assertions.assertThrows(AccessControlException.class, () -> sparkSession.sql(SQL_DELETE_TABLE));
   }
 
   @Override
-  public void checkDeleteSQLWithWritePrivileges() {
-    Assertions.assertThrows(AccessControlException.class, () -> sparkSession.sql(SQL_DELETE_TABLE));
+  public void checkDeleteSQLWithModifyPrivileges() {
+    sparkSession.sql(SQL_DELETE_TABLE);
   }
 
   public void checkWithoutPrivileges() {

--- a/authorizations/authorization-ranger/src/test/java/org/apache/gravitino/authorization/ranger/integration/test/RangerPaimonE2EIT.java
+++ b/authorizations/authorization-ranger/src/test/java/org/apache/gravitino/authorization/ranger/integration/test/RangerPaimonE2EIT.java
@@ -130,32 +130,32 @@ public class RangerPaimonE2EIT extends RangerBaseE2EIT {
   }
 
   @Override
-  protected void checkUpdateSQLWithReadWritePrivileges() {
+  protected void checkUpdateSQLWithSelectModifyPrivileges() {
     // Kyuubi Paimon Ranger plugin doesn't support to update yet.
   }
 
   @Override
-  protected void checkUpdateSQLWithReadPrivileges() {
+  protected void checkUpdateSQLWithSelectPrivileges() {
     // Kyuubi Paimon Ranger plugin doesn't support to update yet.
   }
 
   @Override
-  protected void checkUpdateSQLWithWritePrivileges() {
+  protected void checkUpdateSQLWithModifyPrivileges() {
     // Kyuubi Paimon Ranger plugin doesn't support to update yet.
   }
 
   @Override
-  protected void checkDeleteSQLWithReadWritePrivileges() {
+  protected void checkDeleteSQLWithSelectModifyPrivileges() {
     // Kyuubi Paimon Ranger plugin doesn't support to delete yet.
   }
 
   @Override
-  protected void checkDeleteSQLWithReadPrivileges() {
+  protected void checkDeleteSQLWithSelectPrivileges() {
     // Kyuubi Paimon Ranger plugin doesn't support to delete yet.
   }
 
   @Override
-  protected void checkDeleteSQLWithWritePrivileges() {
+  protected void checkDeleteSQLWithModifyPrivileges() {
     // Kyuubi Paimon Ranger plugin doesn't support to delete yet.
   }
 

--- a/docs/security/access-control.md
+++ b/docs/security/access-control.md
@@ -202,11 +202,11 @@ and `USE_SCHEMA` privileges on its parent schema.
 
 ### Table privileges
 
-| Name         | Supports Securable Object         | Operation                                        |
-|--------------|-----------------------------------|--------------------------------------------------|
-| CREATE_TABLE | Metalake, Catalog, Schema         | Create a table                                   |
-| MODIFY_TABLE | Metalake, Catalog, Schema, Table  | Write data to a table or modify the table schema |
-| SELECT_TABLE | Metalake, Catalog, Schema, Table  | Select data from a table                         |
+| Name         | Supports Securable Object         | Operation                                                                 |
+|--------------|-----------------------------------|---------------------------------------------------------------------------|
+| CREATE_TABLE | Metalake, Catalog, Schema         | Create a table                                                            |
+| MODIFY_TABLE | Metalake, Catalog, Schema, Table  | Select data from a data, write data to a table or modify the table schema |
+| SELECT_TABLE | Metalake, Catalog, Schema, Table  | Select data from a table                                                  |
 
 ### Topic privileges
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

`MODIFY_TABLE` should contain the select table privilege

### Why are the changes needed?

More proper semantics

Fix: #6011

### Does this PR introduce _any_ user-facing change?

Correct the document.

### How was this patch tested?

Modify the UT.