### PR TITLE
[#6612] fix(hive-image): Support Chinese in database, table and column commens for Hive catalog

### DIFF
--- a/dev/docker/hive/start.sh
+++ b/dev/docker/hive/start.sh
@@ -69,7 +69,7 @@ if [[ -n "$SERVICE_ACCOUNT_FILE" ]]; then
   sed -i "s|SERVICE_ACCOUNT_FILE|${SERVICE_ACCOUNT_FILE}|g" ${HIVE_CONF_DIR}/hive-site.xml
 fi
 
-sed -i "s/useSSL=false/useSSL=false&amp;characterEncoding=utf8&amp;useUnicode=true/g" ${HIVE_CONF_DIR}/hive-site.xml
+sed -i "s/useSSL=false/useSSL=false\&amp;characterEncoding=utf8\&amp;useUnicode=true/g" ${HIVE_CONF_DIR}/hive-site.xml
 
 # Link mysql-connector-java after deciding where HIVE_HOME symbolic link points to.
 ln -s /opt/mysql-connector-java-${MYSQL_JDBC_DRIVER_VERSION}/mysql-connector-java-${MYSQL_JDBC_DRIVER_VERSION}.jar ${HIVE_HOME}/lib
@@ -178,6 +178,16 @@ set -i 's/varchar(767)/text/g' ${HIVE_HOME}/scripts/metastore/upgrade/mysql/hive
 # start hive
 echo "Starting Hive..."
 ${HIVE_HOME}/bin/schematool -initSchema -dbType mysql
+echo """
+  alter table DBS modify column \`DESC\` varchar(4000) character set utf8mb4 collate utf8mb4_bin;
+  alter table COLUMNS_V2 modify column COMMENT varchar(256) character set utf8mb4 collate utf8mb4_bin;
+  alter table TABLE_PARAMS modify column PARAM_VALUE varchar(4000) character set utf8mb4 collate utf8mb4_bin;
+  alter table PARTITION_PARAMS modify column PARAM_VALUE varchar(4000) character set utf8mb4 collate utf8mb4_bin;
+  alter table PARTITION_KEYS modify column PKEY_COMMENT varchar(4000) character set utf8mb4 collate utf8mb4_bin;
+  alter table INDEX_PARAMS modify column PARAM_VALUE varchar(4000) character set utf8mb4 collate utf8mb4_bin;
+  alter table PARTITIONS  modify column PART_NAME varchar(757) character set utf8mb4 collate utf8mb4_bin;
+""" | mysql --user=root --password=${MYSQL_PWD} -Dmetastore_db
+
 ${HIVE_HOME}/bin/hive --service hiveserver2 > /dev/null 2>&1 &
 ${HIVE_HOME}/bin/hive --service metastore > /dev/null 2>&1 &
 

--- a/dev/docker/hive/start.sh
+++ b/dev/docker/hive/start.sh
@@ -69,6 +69,8 @@ if [[ -n "$SERVICE_ACCOUNT_FILE" ]]; then
   sed -i "s|SERVICE_ACCOUNT_FILE|${SERVICE_ACCOUNT_FILE}|g" ${HIVE_CONF_DIR}/hive-site.xml
 fi
 
+sed -i "s/useSSL=false/useSSL=false&amp;characterEncoding=utf8&amp;useUnicode=true/g" ${HIVE_CONF_DIR}/hive-site.xml
+
 # Link mysql-connector-java after deciding where HIVE_HOME symbolic link points to.
 ln -s /opt/mysql-connector-java-${MYSQL_JDBC_DRIVER_VERSION}/mysql-connector-java-${MYSQL_JDBC_DRIVER_VERSION}.jar ${HIVE_HOME}/lib
 
@@ -164,6 +166,14 @@ echo """
   FLUSH PRIVILEGES;
   CREATE DATABASE hive;
 """ | mysql --user=root --password=${MYSQL_PWD}
+
+
+# change charset
+
+set -i 's/CHARACTER SET latin1 COLLATE latin1_bin/CHARACTER SET utf8mb4 COLLATE utf8mb4_bin/g' ${HIVE_HOME}/scripts/metastore/upgrade/mysql/hive-schema-2.3.0.mysql.sql
+set -i 's/CHARSET=latin1/CHARSET=utf8/g' ${HIVE_HOME}/scripts/metastore/upgrade/mysql/hive-schema-2.3.0.mysql.sql
+set -i 's/varchar(4000)/text/g' ${HIVE_HOME}/scripts/metastore/upgrade/mysql/hive-schema-2.3.0.mysql.sql
+set -i 's/varchar(767)/text/g' ${HIVE_HOME}/scripts/metastore/upgrade/mysql/hive-schema-2.3.0.mysql.sql
 
 # start hive
 echo "Starting Hive..."

--- a/dev/docker/hive/start.sh
+++ b/dev/docker/hive/start.sh
@@ -167,14 +167,6 @@ echo """
   CREATE DATABASE hive;
 """ | mysql --user=root --password=${MYSQL_PWD}
 
-
-# change charset
-
-set -i 's/CHARACTER SET latin1 COLLATE latin1_bin/CHARACTER SET utf8mb4 COLLATE utf8mb4_bin/g' ${HIVE_HOME}/scripts/metastore/upgrade/mysql/hive-schema-2.3.0.mysql.sql
-set -i 's/CHARSET=latin1/CHARSET=utf8/g' ${HIVE_HOME}/scripts/metastore/upgrade/mysql/hive-schema-2.3.0.mysql.sql
-set -i 's/varchar(4000)/text/g' ${HIVE_HOME}/scripts/metastore/upgrade/mysql/hive-schema-2.3.0.mysql.sql
-set -i 's/varchar(767)/text/g' ${HIVE_HOME}/scripts/metastore/upgrade/mysql/hive-schema-2.3.0.mysql.sql
-
 # start hive
 echo "Starting Hive..."
 ${HIVE_HOME}/bin/schematool -initSchema -dbType mysql


### PR DESCRIPTION
### What changes were proposed in this pull request?

Modify the table structure of the MySQL table for the Hive metastore 

### Why are the changes needed?

The default chaset `latin1` does not support Chinese. 

Fix: #6612 

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

<img width="1409" alt="image" src="https://github.com/user-attachments/assets/531d08b8-6f19-4a27-888f-8ed101a36b08" />

<img width="1214" alt="image" src="https://github.com/user-attachments/assets/d16c5257-b763-4efc-9246-c590a0874548" />


<img width="1393" alt="image" src="https://github.com/user-attachments/assets/0c5c9abb-8394-408f-81d8-9cf8bd43f240" />

