### PR TITLE
[#6595] fix (trino-connector): Disable the Trino cascading query integration test

### DIFF
--- a/.github/workflows/python-integration-test.yml
+++ b/.github/workflows/python-integration-test.yml
@@ -48,7 +48,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.source_changes == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 60
     strategy:
       matrix:
         # Integration test for AMD64 architecture

--- a/.github/workflows/trino-integration-test.yml
+++ b/.github/workflows/trino-integration-test.yml
@@ -87,7 +87,8 @@ jobs:
         run: |
           ./gradlew -PskipTests -PtestMode=embedded -PjdkVersion=${{ matrix.java-version }} -PskipDockerTests=false :trino-connector:integration-test:test
           ./gradlew -PskipTests -PtestMode=deploy -PjdkVersion=${{ matrix.java-version }} -PskipDockerTests=false :trino-connector:integration-test:test
-          trino-connector/integration-test/trino-test-tools/run_test.sh
+          # Disable the Trino cascading query integration test, because the connector jars are private now.
+          #trino-connector/integration-test/trino-test-tools/run_test.sh
 
       - name: Upload integrate tests reports
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
### What changes were proposed in this pull request?

Disable the Trino cascading query integration test

### Why are the changes needed?

Fix: #6595

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

No
