### PR TITLE
[#6603] chore(*): fix CLI.sh can't find the Jar

### DIFF
--- a/bin/gcli.sh.template
+++ b/bin/gcli.sh.template
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Referred from Apache Submarine's common.sh implementation
+# bin/common.sh
+
+set -e
+
+if [ -L "${BASH_SOURCE-$0}" ]; then
+    FWDIR=$(dirname "$(readlink "${BASH_SOURCE-$0}")")
+else
+    FWDIR=$(dirname "${BASH_SOURCE-$0}")
+fi
+
+FWDIR=$(
+    cd "$FWDIR" || exit 2
+    pwd
+)
+
+ROOT_DIR=$(dirname "$FWDIR")
+ROOT_DIR=$(
+    cd "$ROOT_DIR" || exit 2
+    pwd
+)
+
+. "${FWDIR}/common.sh"
+
+CLI_JAR=$(find "$ROOT_DIR/libs" -name "gravitino-cli-*-incubating-SNAPSHOT.jar" 2>/dev/null)
+VERSION=$(basename "$CLI_JAR" | grep -o '[0-9]\+\.[0-9]\+\.[0-9]\+')
+if [ -z "$CLI_JAR" ]; then
+    echo "Could not find CLI jar in $ROOT_DIR/libs "
+    exit 1
+fi
+
+
+echo "Find CLI jar version: $VERSION"
+java -jar "$CLI_JAR" "$@"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -819,6 +819,12 @@ tasks {
         setDuplicatesStrategy(DuplicatesStrategy.INCLUDE)
       }
     }
+
+    dependsOn("clients:cli:build")
+    from("clients/cli/build/libs")
+    into("distribution/package/libs")
+    include("*.jar")
+    setDuplicatesStrategy(DuplicatesStrategy.INCLUDE)
   }
 
   register("copyCatalogLibAndConfigs", Copy::class) {

--- a/clients/cli/README.md
+++ b/clients/cli/README.md
@@ -52,7 +52,7 @@ Before you can build and run this project, it is suggested you have the followin
 3. Create an alias:
 
     ```bash
-    alias gcli='java -jar clients/cli/build/libs/gravitino-cli-*-incubating-SNAPSHOT.jar'
+    alias gcli='sh $GRAVITINO_HOME/bin/gcli.sh'
     ```
 3. Test the command:
     ```bash

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -17,10 +17,10 @@ Currently, the CLI allows users to view metadata information for metalakes, cata
 You can configure an alias for the CLI for ease of use, with the following command:
 
 ```bash
-alias gcli='java -jar ../../cli/build/libs/gravitino-cli-*-incubating-SNAPSHOT.jar'
+alias gcli='sh $GRAVITINO_HOME/bin/gcli.sh'
 ```
 
-Or you use the `gcli.sh` script found in the `clients/cli/bin/` directory to run the CLI.
+Or you use the `gcli.sh` script found in the `/path/to/gravitino/bin/` directory to run the CLI.
 
 ## Usage
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

fix CLI.sh can't find the Jar
1. Changing the packaging flow, Copy the CLI-related jars to `package/libs` and add gcli.sh to `bin`.
2. change some docs file.

### Why are the changes needed?

Fix: #6603 

### Does this PR introduce _any_ user-facing change?

yes, If user set the `GRAVITINO_HOME` environment variable, then can create a convenient alias by running alias `gcli='sh $GRAVITINO_HOME/bin/gcli.sh'`. After that, user will be able to use the `gcli` tool directly from anywhere in their terminal.

### How was this patch tested?

local test.
![image](https://github.com/user-attachments/assets/20e449db-c9a7-409f-b627-dc14054884a8)

![image](https://github.com/user-attachments/assets/f24159f3-0708-4093-b5bc-7bcfec95aadd)