### PR TITLE
[#6694] improvement: Avoid binding type `PATH` to `FILESET`

### DIFF
--- a/authorizations/authorization-common/src/main/java/org/apache/gravitino/authorization/common/PathBasedMetadataObject.java
+++ b/authorizations/authorization-common/src/main/java/org/apache/gravitino/authorization/common/PathBasedMetadataObject.java
@@ -36,7 +36,7 @@ public class PathBasedMetadataObject implements AuthorizationMetadataObject {
    */
   public static final class PathType implements AuthorizationMetadataObject.Type {
 
-    private final Set<MetadataObject.Type> allowObjectTypes =
+    private static final Set<MetadataObject.Type> allowObjectTypes =
         ImmutableSet.of(
             MetadataObject.Type.METALAKE,
             MetadataObject.Type.CATALOG,

--- a/authorizations/authorization-common/src/main/java/org/apache/gravitino/authorization/common/PathBasedMetadataObject.java
+++ b/authorizations/authorization-common/src/main/java/org/apache/gravitino/authorization/common/PathBasedMetadataObject.java
@@ -19,8 +19,10 @@
 package org.apache.gravitino.authorization.common;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import org.apache.gravitino.MetadataObject;
 import org.apache.gravitino.authorization.AuthorizationMetadataObject;
 
@@ -34,6 +36,13 @@ public class PathBasedMetadataObject implements AuthorizationMetadataObject {
    */
   public static final class PathType implements AuthorizationMetadataObject.Type {
 
+    private final Set<MetadataObject.Type> allowObjectTypes =
+        ImmutableSet.of(
+            MetadataObject.Type.METALAKE,
+            MetadataObject.Type.CATALOG,
+            MetadataObject.Type.SCHEMA,
+            MetadataObject.Type.TABLE,
+            MetadataObject.Type.FILESET);
     private final MetadataObject.Type metadataType;
 
     public static PathType get(MetadataObject.Type type) {
@@ -41,6 +50,8 @@ public class PathBasedMetadataObject implements AuthorizationMetadataObject {
     }
 
     private PathType(MetadataObject.Type type) {
+      Preconditions.checkArgument(
+          allowObjectTypes.contains(type), "The type isn't allow to create path type");
       this.metadataType = type;
     }
 

--- a/authorizations/authorization-common/src/main/java/org/apache/gravitino/authorization/common/PathBasedMetadataObject.java
+++ b/authorizations/authorization-common/src/main/java/org/apache/gravitino/authorization/common/PathBasedMetadataObject.java
@@ -30,30 +30,41 @@ public class PathBasedMetadataObject implements AuthorizationMetadataObject {
   /**
    * The type of metadata object in the underlying system. Every type will map one kind of the
    * entity of the Gravitino type system. When we store a Hive table, first, we will store the
-   * metadata in the MySQL, and then we will store the data in the HDFS location. For Hive, there is
-   * a default location for the cluster level. We can also specify other locations for schema and
-   * table levels. So a path may not be fileset
+   * metadata in the JDBC database like MySQL, and then we will store the data in the HDFS location.
+   * For Hive, there is a default location for the cluster level.
+   * We can also specify other locations for schema and table levels. So a path may not be fileset
    */
-  public enum Type implements AuthorizationMetadataObject.Type {
-    /** A path is mapped the path of storages like HDFS, S3 etc. */
-    FILESET_PATH(MetadataObject.Type.FILESET),
-    /** A path is mapped the path of table storage like Hive. */
-    TABLE_PATH(MetadataObject.Type.TABLE),
-    /** A path is mapped the path of schema storage like Hive. */
-    SCHEMA_PATH(MetadataObject.Type.SCHEMA),
-    /** A path is mapped the path of cluster storage like Hive. */
-    CATALOG_PATH(MetadataObject.Type.CATALOG),
-    /** A path is mapped the path of all cluster storages like Hive. */
-    METALAKE_PATH(MetadataObject.Type.METALAKE);
+  public static final class PathType implements AuthorizationMetadataObject.Type {
 
     private final MetadataObject.Type metadataType;
 
-    Type(MetadataObject.Type type) {
+    public static PathType get(MetadataObject.Type type) {
+      return new PathType(type);
+    }
+
+    private PathType(MetadataObject.Type type) {
       this.metadataType = type;
     }
 
     public MetadataObject.Type metadataObjectType() {
       return metadataType;
+    }
+
+    @Override
+    public int hashCode() {
+      return metadataType.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (this == obj) {
+        return true;
+      }
+      if (!(obj instanceof PathType)) {
+        return false;
+      }
+
+      return this.metadataType.equals(((PathType) obj).metadataType);
     }
   }
 
@@ -105,7 +116,7 @@ public class PathBasedMetadataObject implements AuthorizationMetadataObject {
         path != null && !path.isEmpty(), "Cannot create a path based metadata object with no path");
 
     HashSet<AuthorizationMetadataObject.Type> typeSet =
-        Sets.newHashSet(PathBasedMetadataObject.Type.values());
+        Sets.newHashSet(PathType.values());
     Preconditions.checkArgument(typeSet.contains(type), "it must be the PATH type");
 
     for (String name : names) {

--- a/authorizations/authorization-common/src/main/java/org/apache/gravitino/authorization/common/PathBasedMetadataObject.java
+++ b/authorizations/authorization-common/src/main/java/org/apache/gravitino/authorization/common/PathBasedMetadataObject.java
@@ -19,8 +19,6 @@
 package org.apache.gravitino.authorization.common;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.Sets;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import org.apache.gravitino.MetadataObject;
@@ -31,8 +29,8 @@ public class PathBasedMetadataObject implements AuthorizationMetadataObject {
    * The type of metadata object in the underlying system. Every type will map one kind of the
    * entity of the Gravitino type system. When we store a Hive table, first, we will store the
    * metadata in the JDBC database like MySQL, and then we will store the data in the HDFS location.
-   * For Hive, there is a default location for the cluster level.
-   * We can also specify other locations for schema and table levels. So a path may not be fileset
+   * For Hive, there is a default location for the cluster level. We can also specify other
+   * locations for schema and table levels. So a path may not be fileset
    */
   public static final class PathType implements AuthorizationMetadataObject.Type {
 
@@ -65,6 +63,11 @@ public class PathBasedMetadataObject implements AuthorizationMetadataObject {
       }
 
       return this.metadataType.equals(((PathType) obj).metadataType);
+    }
+
+    @Override
+    public String toString() {
+      return "PATH";
     }
   }
 
@@ -115,9 +118,7 @@ public class PathBasedMetadataObject implements AuthorizationMetadataObject {
     Preconditions.checkArgument(
         path != null && !path.isEmpty(), "Cannot create a path based metadata object with no path");
 
-    HashSet<AuthorizationMetadataObject.Type> typeSet =
-        Sets.newHashSet(PathType.values());
-    Preconditions.checkArgument(typeSet.contains(type), "it must be the PATH type");
+    Preconditions.checkArgument(type instanceof PathType, "it must be the PATH type");
 
     for (String name : names) {
       Preconditions.checkArgument(
@@ -139,7 +140,7 @@ public class PathBasedMetadataObject implements AuthorizationMetadataObject {
     return Objects.equals(name, that.name)
         && Objects.equals(parent, that.parent)
         && Objects.equals(path, that.path)
-        && type == that.type;
+        && Objects.equals(type, that.type);
   }
 
   @Override

--- a/authorizations/authorization-common/src/test/java/org/apache/gravitino/authorization/common/TestPathBasedMetadataObject.java
+++ b/authorizations/authorization-common/src/test/java/org/apache/gravitino/authorization/common/TestPathBasedMetadataObject.java
@@ -18,6 +18,7 @@
  */
 package org.apache.gravitino.authorization.common;
 
+import org.apache.gravitino.MetadataObject;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -26,12 +27,18 @@ public class TestPathBasedMetadataObject {
   public void PathBasedMetadataObjectEquals() {
     PathBasedMetadataObject pathBasedMetadataObject1 =
         new PathBasedMetadataObject(
-            "parent", "name", "path", PathBasedMetadataObject.PathType.FILESET_PATH);
+            "parent",
+            "name",
+            "path",
+            PathBasedMetadataObject.PathType.get(MetadataObject.Type.FILESET));
     pathBasedMetadataObject1.validateAuthorizationMetadataObject();
 
     PathBasedMetadataObject pathBasedMetadataObject2 =
         new PathBasedMetadataObject(
-            "parent", "name", "path", PathBasedMetadataObject.PathType.FILESET_PATH);
+            "parent",
+            "name",
+            "path",
+            PathBasedMetadataObject.PathType.get(MetadataObject.Type.FILESET));
     pathBasedMetadataObject2.validateAuthorizationMetadataObject();
 
     Assertions.assertEquals(pathBasedMetadataObject1, pathBasedMetadataObject2);
@@ -41,12 +48,18 @@ public class TestPathBasedMetadataObject {
   public void PathBasedMetadataObjectNotEquals() {
     PathBasedMetadataObject pathBasedMetadataObject1 =
         new PathBasedMetadataObject(
-            "parent", "name", "path", PathBasedMetadataObject.PathType.FILESET_PATH);
+            "parent",
+            "name",
+            "path",
+            PathBasedMetadataObject.PathType.get(MetadataObject.Type.FILESET));
     pathBasedMetadataObject1.validateAuthorizationMetadataObject();
 
     PathBasedMetadataObject pathBasedMetadataObject2 =
         new PathBasedMetadataObject(
-            "parent", "name", "path1", PathBasedMetadataObject.PathType.FILESET_PATH);
+            "parent",
+            "name",
+            "path1",
+            PathBasedMetadataObject.PathType.get(MetadataObject.Type.FILESET));
     pathBasedMetadataObject2.validateAuthorizationMetadataObject();
 
     Assertions.assertNotEquals(pathBasedMetadataObject1, pathBasedMetadataObject2);
@@ -56,29 +69,39 @@ public class TestPathBasedMetadataObject {
   void testToString() {
     PathBasedMetadataObject pathBasedMetadataObject1 =
         new PathBasedMetadataObject(
-            "parent", "name", "path", PathBasedMetadataObject.PathType.FILESET_PATH);
+            "parent",
+            "name",
+            "path",
+            PathBasedMetadataObject.PathType.get(MetadataObject.Type.FILESET));
     Assertions.assertEquals(
-        "MetadataObject: [fullName=parent.name],  [path=path], [type=FILESET_PATH]",
+        "MetadataObject: [fullName=parent.name],  [path=path], [type=PATH]",
         pathBasedMetadataObject1.toString());
 
     PathBasedMetadataObject pathBasedMetadataObject2 =
         new PathBasedMetadataObject(
-            "parent", "name", null, PathBasedMetadataObject.PathType.FILESET_PATH);
+            "parent",
+            "name",
+            null,
+            PathBasedMetadataObject.PathType.get(MetadataObject.Type.FILESET));
     Assertions.assertEquals(
-        "MetadataObject: [fullName=parent.name],  [path=null], [type=FILESET_PATH]",
+        "MetadataObject: [fullName=parent.name],  [path=null], [type=PATH]",
         pathBasedMetadataObject2.toString());
 
     PathBasedMetadataObject pathBasedMetadataObject3 =
-        new PathBasedMetadataObject(null, "name", null, PathBasedMetadataObject.PathType.FILESET_PATH);
+        new PathBasedMetadataObject(
+            null, "name", null, PathBasedMetadataObject.PathType.get(MetadataObject.Type.FILESET));
     Assertions.assertEquals(
-        "MetadataObject: [fullName=name],  [path=null], [type=FILESET_PATH]",
+        "MetadataObject: [fullName=name],  [path=null], [type=PATH]",
         pathBasedMetadataObject3.toString());
 
     PathBasedMetadataObject pathBasedMetadataObject4 =
         new PathBasedMetadataObject(
-            null, "name", "path", PathBasedMetadataObject.PathType.FILESET_PATH);
+            null,
+            "name",
+            "path",
+            PathBasedMetadataObject.PathType.get(MetadataObject.Type.FILESET));
     Assertions.assertEquals(
-        "MetadataObject: [fullName=name],  [path=path], [type=FILESET_PATH]",
+        "MetadataObject: [fullName=name],  [path=path], [type=PATH]",
         pathBasedMetadataObject4.toString());
   }
 }

--- a/authorizations/authorization-common/src/test/java/org/apache/gravitino/authorization/common/TestPathBasedMetadataObject.java
+++ b/authorizations/authorization-common/src/test/java/org/apache/gravitino/authorization/common/TestPathBasedMetadataObject.java
@@ -26,12 +26,12 @@ public class TestPathBasedMetadataObject {
   public void PathBasedMetadataObjectEquals() {
     PathBasedMetadataObject pathBasedMetadataObject1 =
         new PathBasedMetadataObject(
-            "parent", "name", "path", PathBasedMetadataObject.Type.FILESET_PATH);
+            "parent", "name", "path", PathBasedMetadataObject.PathType.FILESET_PATH);
     pathBasedMetadataObject1.validateAuthorizationMetadataObject();
 
     PathBasedMetadataObject pathBasedMetadataObject2 =
         new PathBasedMetadataObject(
-            "parent", "name", "path", PathBasedMetadataObject.Type.FILESET_PATH);
+            "parent", "name", "path", PathBasedMetadataObject.PathType.FILESET_PATH);
     pathBasedMetadataObject2.validateAuthorizationMetadataObject();
 
     Assertions.assertEquals(pathBasedMetadataObject1, pathBasedMetadataObject2);
@@ -41,12 +41,12 @@ public class TestPathBasedMetadataObject {
   public void PathBasedMetadataObjectNotEquals() {
     PathBasedMetadataObject pathBasedMetadataObject1 =
         new PathBasedMetadataObject(
-            "parent", "name", "path", PathBasedMetadataObject.Type.FILESET_PATH);
+            "parent", "name", "path", PathBasedMetadataObject.PathType.FILESET_PATH);
     pathBasedMetadataObject1.validateAuthorizationMetadataObject();
 
     PathBasedMetadataObject pathBasedMetadataObject2 =
         new PathBasedMetadataObject(
-            "parent", "name", "path1", PathBasedMetadataObject.Type.FILESET_PATH);
+            "parent", "name", "path1", PathBasedMetadataObject.PathType.FILESET_PATH);
     pathBasedMetadataObject2.validateAuthorizationMetadataObject();
 
     Assertions.assertNotEquals(pathBasedMetadataObject1, pathBasedMetadataObject2);
@@ -56,27 +56,27 @@ public class TestPathBasedMetadataObject {
   void testToString() {
     PathBasedMetadataObject pathBasedMetadataObject1 =
         new PathBasedMetadataObject(
-            "parent", "name", "path", PathBasedMetadataObject.Type.FILESET_PATH);
+            "parent", "name", "path", PathBasedMetadataObject.PathType.FILESET_PATH);
     Assertions.assertEquals(
         "MetadataObject: [fullName=parent.name],  [path=path], [type=FILESET_PATH]",
         pathBasedMetadataObject1.toString());
 
     PathBasedMetadataObject pathBasedMetadataObject2 =
         new PathBasedMetadataObject(
-            "parent", "name", null, PathBasedMetadataObject.Type.FILESET_PATH);
+            "parent", "name", null, PathBasedMetadataObject.PathType.FILESET_PATH);
     Assertions.assertEquals(
         "MetadataObject: [fullName=parent.name],  [path=null], [type=FILESET_PATH]",
         pathBasedMetadataObject2.toString());
 
     PathBasedMetadataObject pathBasedMetadataObject3 =
-        new PathBasedMetadataObject(null, "name", null, PathBasedMetadataObject.Type.FILESET_PATH);
+        new PathBasedMetadataObject(null, "name", null, PathBasedMetadataObject.PathType.FILESET_PATH);
     Assertions.assertEquals(
         "MetadataObject: [fullName=name],  [path=null], [type=FILESET_PATH]",
         pathBasedMetadataObject3.toString());
 
     PathBasedMetadataObject pathBasedMetadataObject4 =
         new PathBasedMetadataObject(
-            null, "name", "path", PathBasedMetadataObject.Type.FILESET_PATH);
+            null, "name", "path", PathBasedMetadataObject.PathType.FILESET_PATH);
     Assertions.assertEquals(
         "MetadataObject: [fullName=name],  [path=path], [type=FILESET_PATH]",
         pathBasedMetadataObject4.toString());

--- a/authorizations/authorization-common/src/test/java/org/apache/gravitino/authorization/common/TestPathBasedMetadataObject.java
+++ b/authorizations/authorization-common/src/test/java/org/apache/gravitino/authorization/common/TestPathBasedMetadataObject.java
@@ -25,11 +25,13 @@ public class TestPathBasedMetadataObject {
   @Test
   public void PathBasedMetadataObjectEquals() {
     PathBasedMetadataObject pathBasedMetadataObject1 =
-        new PathBasedMetadataObject("parent", "name", "path", PathBasedMetadataObject.Type.PATH);
+        new PathBasedMetadataObject(
+            "parent", "name", "path", PathBasedMetadataObject.Type.FILESET_PATH);
     pathBasedMetadataObject1.validateAuthorizationMetadataObject();
 
     PathBasedMetadataObject pathBasedMetadataObject2 =
-        new PathBasedMetadataObject("parent", "name", "path", PathBasedMetadataObject.Type.PATH);
+        new PathBasedMetadataObject(
+            "parent", "name", "path", PathBasedMetadataObject.Type.FILESET_PATH);
     pathBasedMetadataObject2.validateAuthorizationMetadataObject();
 
     Assertions.assertEquals(pathBasedMetadataObject1, pathBasedMetadataObject2);
@@ -38,11 +40,13 @@ public class TestPathBasedMetadataObject {
   @Test
   public void PathBasedMetadataObjectNotEquals() {
     PathBasedMetadataObject pathBasedMetadataObject1 =
-        new PathBasedMetadataObject("parent", "name", "path", PathBasedMetadataObject.Type.PATH);
+        new PathBasedMetadataObject(
+            "parent", "name", "path", PathBasedMetadataObject.Type.FILESET_PATH);
     pathBasedMetadataObject1.validateAuthorizationMetadataObject();
 
     PathBasedMetadataObject pathBasedMetadataObject2 =
-        new PathBasedMetadataObject("parent", "name", "path1", PathBasedMetadataObject.Type.PATH);
+        new PathBasedMetadataObject(
+            "parent", "name", "path1", PathBasedMetadataObject.Type.FILESET_PATH);
     pathBasedMetadataObject2.validateAuthorizationMetadataObject();
 
     Assertions.assertNotEquals(pathBasedMetadataObject1, pathBasedMetadataObject2);
@@ -51,27 +55,30 @@ public class TestPathBasedMetadataObject {
   @Test
   void testToString() {
     PathBasedMetadataObject pathBasedMetadataObject1 =
-        new PathBasedMetadataObject("parent", "name", "path", PathBasedMetadataObject.Type.PATH);
+        new PathBasedMetadataObject(
+            "parent", "name", "path", PathBasedMetadataObject.Type.FILESET_PATH);
     Assertions.assertEquals(
-        "MetadataObject: [fullName=parent.name],  [path=path], [type=PATH]",
+        "MetadataObject: [fullName=parent.name],  [path=path], [type=FILESET_PATH]",
         pathBasedMetadataObject1.toString());
 
     PathBasedMetadataObject pathBasedMetadataObject2 =
-        new PathBasedMetadataObject("parent", "name", null, PathBasedMetadataObject.Type.PATH);
+        new PathBasedMetadataObject(
+            "parent", "name", null, PathBasedMetadataObject.Type.FILESET_PATH);
     Assertions.assertEquals(
-        "MetadataObject: [fullName=parent.name],  [path=null], [type=PATH]",
+        "MetadataObject: [fullName=parent.name],  [path=null], [type=FILESET_PATH]",
         pathBasedMetadataObject2.toString());
 
     PathBasedMetadataObject pathBasedMetadataObject3 =
-        new PathBasedMetadataObject(null, "name", null, PathBasedMetadataObject.Type.PATH);
+        new PathBasedMetadataObject(null, "name", null, PathBasedMetadataObject.Type.FILESET_PATH);
     Assertions.assertEquals(
-        "MetadataObject: [fullName=name],  [path=null], [type=PATH]",
+        "MetadataObject: [fullName=name],  [path=null], [type=FILESET_PATH]",
         pathBasedMetadataObject3.toString());
 
     PathBasedMetadataObject pathBasedMetadataObject4 =
-        new PathBasedMetadataObject(null, "name", "path", PathBasedMetadataObject.Type.PATH);
+        new PathBasedMetadataObject(
+            null, "name", "path", PathBasedMetadataObject.Type.FILESET_PATH);
     Assertions.assertEquals(
-        "MetadataObject: [fullName=name],  [path=path], [type=PATH]",
+        "MetadataObject: [fullName=name],  [path=path], [type=FILESET_PATH]",
         pathBasedMetadataObject4.toString());
   }
 }

--- a/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/RangerAuthorizationHDFSPlugin.java
+++ b/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/RangerAuthorizationHDFSPlugin.java
@@ -18,9 +18,9 @@
  */
 package org.apache.gravitino.authorization.ranger;
 
-import static org.apache.gravitino.authorization.common.PathBasedMetadataObject.Type.FILESET_PATH;
-import static org.apache.gravitino.authorization.common.PathBasedMetadataObject.Type.SCHEMA_PATH;
-import static org.apache.gravitino.authorization.common.PathBasedMetadataObject.Type.TABLE_PATH;
+import static org.apache.gravitino.authorization.common.PathBasedMetadataObject.PathType.FILESET_PATH;
+import static org.apache.gravitino.authorization.common.PathBasedMetadataObject.PathType.SCHEMA_PATH;
+import static org.apache.gravitino.authorization.common.PathBasedMetadataObject.PathType.TABLE_PATH;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
@@ -539,7 +539,7 @@ public class RangerAuthorizationHDFSPlugin extends RangerAuthorizationPlugin {
                                     generateAuthorizationSecurableObject(
                                         pathBasedMetadataObject.names(),
                                         getAuthorizationPath(pathBasedMetadataObject),
-                                        PathBasedMetadataObject.Type.FILESET_PATH,
+                                        PathBasedMetadataObject.PathType.FILESET_PATH,
                                         rangerPrivileges));
                               });
                       break;
@@ -582,7 +582,7 @@ public class RangerAuthorizationHDFSPlugin extends RangerAuthorizationPlugin {
                       generateAuthorizationSecurableObject(
                           pathBasedMetadataObject.names(),
                           getAuthorizationPath(pathBasedMetadataObject),
-                          PathBasedMetadataObject.Type.FILESET_PATH,
+                          PathBasedMetadataObject.PathType.FILESET_PATH,
                           ownerMappingRule()));
                 });
         break;
@@ -667,7 +667,7 @@ public class RangerAuthorizationHDFSPlugin extends RangerAuthorizationPlugin {
                           changeMetadataObject.metadataObject().parent(),
                           changeMetadataObject.metadataObject().name(),
                           locationPath,
-                          PathBasedMetadataObject.Type.FILESET_PATH);
+                          PathBasedMetadataObject.PathType.FILESET_PATH);
                   pathBaseMetadataObject.validateAuthorizationMetadataObject();
                   authzMetadataObjects.add(pathBaseMetadataObject);
                 });
@@ -723,8 +723,7 @@ public class RangerAuthorizationHDFSPlugin extends RangerAuthorizationPlugin {
   }
 
   private static AuthorizationMetadataObject.Type getType(MetadataObject metadataObject) {
-
-    for (PathBasedMetadataObject.Type value : PathBasedMetadataObject.Type.values()) {
+    for (PathBasedMetadataObject.PathType value : PathBasedMetadataObject.PathType.values()) {
       if (value.metadataObjectType() == metadataObject.type()) {
         return value;
       }

--- a/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/RangerAuthorizationHDFSPlugin.java
+++ b/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/RangerAuthorizationHDFSPlugin.java
@@ -18,10 +18,6 @@
  */
 package org.apache.gravitino.authorization.ranger;
 
-import static org.apache.gravitino.authorization.common.PathBasedMetadataObject.PathType.FILESET_PATH;
-import static org.apache.gravitino.authorization.common.PathBasedMetadataObject.PathType.SCHEMA_PATH;
-import static org.apache.gravitino.authorization.common.PathBasedMetadataObject.PathType.TABLE_PATH;
-
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -255,11 +251,17 @@ public class RangerAuthorizationHDFSPlugin extends RangerAuthorizationPlugin {
    */
   @Override
   protected void removeMetadataObject(AuthorizationMetadataObject authzMetadataObject) {
-    if (authzMetadataObject.type().equals(SCHEMA_PATH)) {
+    if (authzMetadataObject
+        .type()
+        .equals(PathBasedMetadataObject.PathType.get(MetadataObject.Type.SCHEMA))) {
       removeSchemaMetadataObject(authzMetadataObject);
-    } else if (authzMetadataObject.type().equals(TABLE_PATH)) {
+    } else if (authzMetadataObject
+        .type()
+        .equals(PathBasedMetadataObject.PathType.get(MetadataObject.Type.TABLE))) {
       removeTableMetadataObject(authzMetadataObject);
-    } else if (authzMetadataObject.type().equals(FILESET_PATH)) {
+    } else if (authzMetadataObject
+        .type()
+        .equals(PathBasedMetadataObject.PathType.get(MetadataObject.Type.FILESET))) {
       removePolicyByMetadataObject(authzMetadataObject);
     } else {
       throw new IllegalArgumentException(
@@ -276,7 +278,9 @@ public class RangerAuthorizationHDFSPlugin extends RangerAuthorizationPlugin {
         authzMetadataObject instanceof PathBasedMetadataObject,
         "The metadata object must be a PathBasedMetadataObject");
     Preconditions.checkArgument(
-        authzMetadataObject.type() == SCHEMA_PATH, "The metadata object type must be a schema");
+        authzMetadataObject.type()
+            == PathBasedMetadataObject.PathType.get(MetadataObject.Type.SCHEMA),
+        "The metadata object type must be a schema");
     Preconditions.checkArgument(
         authzMetadataObject.names().size() == 1, "The metadata object's size must be 1.");
     if (RangerHelper.RESOURCE_ALL.equals(authzMetadataObject.name())) {
@@ -301,7 +305,7 @@ public class RangerAuthorizationHDFSPlugin extends RangerAuthorizationPlugin {
                               AuthorizationMetadataObject.getParentFullName(names),
                               AuthorizationMetadataObject.getLastName(names),
                               locationPath,
-                              SCHEMA_PATH);
+                              PathBasedMetadataObject.PathType.get(MetadataObject.Type.SCHEMA));
                       removeSchemaMetadataObject(schemaMetadataObject);
                     });
               });
@@ -323,7 +327,10 @@ public class RangerAuthorizationHDFSPlugin extends RangerAuthorizationPlugin {
                     locationPath -> {
                       AuthorizationMetadataObject tableMetadataObject =
                           new PathBasedMetadataObject(
-                              authzMetadataObject.name(), table.name(), locationPath, TABLE_PATH);
+                              authzMetadataObject.name(),
+                              table.name(),
+                              locationPath,
+                              PathBasedMetadataObject.PathType.get(MetadataObject.Type.TABLE));
                       removeTableMetadataObject(tableMetadataObject);
                     });
               });
@@ -339,7 +346,10 @@ public class RangerAuthorizationHDFSPlugin extends RangerAuthorizationPlugin {
           locationPath -> {
             AuthorizationMetadataObject schemaMetadataObject =
                 new PathBasedMetadataObject(
-                    authzMetadataObject.name(), schema.name(), locationPath, SCHEMA_PATH);
+                    authzMetadataObject.name(),
+                    schema.name(),
+                    locationPath,
+                    PathBasedMetadataObject.PathType.get(MetadataObject.Type.SCHEMA));
             removePolicyByMetadataObject(schemaMetadataObject);
           });
     }
@@ -356,7 +366,10 @@ public class RangerAuthorizationHDFSPlugin extends RangerAuthorizationPlugin {
     Preconditions.checkArgument(
         authzMetadataObject.names().size() == 3, "The metadata object's name size must be 3");
     Preconditions.checkArgument(
-        authzMetadataObject.type() == TABLE_PATH, "The metadata object type must be a path");
+        authzMetadataObject
+            .type()
+            .equals(PathBasedMetadataObject.PathType.get(MetadataObject.Type.SCHEMA)),
+        "The metadata object type must be a path");
     removePolicyByMetadataObject(authzMetadataObject);
   }
 
@@ -464,13 +477,15 @@ public class RangerAuthorizationHDFSPlugin extends RangerAuthorizationPlugin {
                                         securableObject.parent(),
                                         securableObject.name(),
                                         locationPath,
-                                        getType(securableObject));
+                                        PathBasedMetadataObject.PathType.get(
+                                            securableObject.type()));
                                 pathBaseMetadataObject.validateAuthorizationMetadataObject();
                                 rangerSecurableObjects.add(
                                     generateAuthorizationSecurableObject(
                                         pathBaseMetadataObject.names(),
                                         locationPath,
-                                        getType(securableObject),
+                                        PathBasedMetadataObject.PathType.get(
+                                            securableObject.type()),
                                         rangerPrivileges));
                               });
                       break;
@@ -494,13 +509,15 @@ public class RangerAuthorizationHDFSPlugin extends RangerAuthorizationPlugin {
                                         securableObject.parent(),
                                         securableObject.name(),
                                         locationPath,
-                                        getType(securableObject));
+                                        PathBasedMetadataObject.PathType.get(
+                                            securableObject.type()));
                                 pathBaseMetadataObject.validateAuthorizationMetadataObject();
                                 rangerSecurableObjects.add(
                                     generateAuthorizationSecurableObject(
                                         pathBaseMetadataObject.names(),
                                         locationPath,
-                                        getType(securableObject),
+                                        PathBasedMetadataObject.PathType.get(
+                                            securableObject.type()),
                                         rangerPrivileges));
                               });
                       break;
@@ -539,7 +556,8 @@ public class RangerAuthorizationHDFSPlugin extends RangerAuthorizationPlugin {
                                     generateAuthorizationSecurableObject(
                                         pathBasedMetadataObject.names(),
                                         getAuthorizationPath(pathBasedMetadataObject),
-                                        PathBasedMetadataObject.PathType.FILESET_PATH,
+                                        PathBasedMetadataObject.PathType.get(
+                                            MetadataObject.Type.FILESET),
                                         rangerPrivileges));
                               });
                       break;
@@ -582,7 +600,7 @@ public class RangerAuthorizationHDFSPlugin extends RangerAuthorizationPlugin {
                       generateAuthorizationSecurableObject(
                           pathBasedMetadataObject.names(),
                           getAuthorizationPath(pathBasedMetadataObject),
-                          PathBasedMetadataObject.PathType.FILESET_PATH,
+                          PathBasedMetadataObject.PathType.get(MetadataObject.Type.FILESET),
                           ownerMappingRule()));
                 });
         break;
@@ -605,7 +623,8 @@ public class RangerAuthorizationHDFSPlugin extends RangerAuthorizationPlugin {
     List<String> locations = AuthorizationUtils.getMetadataObjectLocation(identifier, entityType);
     locations.forEach(
         locationPath -> {
-          AuthorizationMetadataObject.Type type = getType(metadataObject);
+          AuthorizationMetadataObject.Type type =
+              PathBasedMetadataObject.PathType.get(metadataObject.type());
           PathBasedMetadataObject pathBaseMetadataObject =
               new PathBasedMetadataObject(
                   metadataObject.parent(), metadataObject.name(), locationPath, type);
@@ -667,7 +686,7 @@ public class RangerAuthorizationHDFSPlugin extends RangerAuthorizationPlugin {
                           changeMetadataObject.metadataObject().parent(),
                           changeMetadataObject.metadataObject().name(),
                           locationPath,
-                          PathBasedMetadataObject.PathType.FILESET_PATH);
+                          PathBasedMetadataObject.PathType.get(MetadataObject.Type.FILESET));
                   pathBaseMetadataObject.validateAuthorizationMetadataObject();
                   authzMetadataObjects.add(pathBaseMetadataObject);
                 });
@@ -720,14 +739,5 @@ public class RangerAuthorizationHDFSPlugin extends RangerAuthorizationPlugin {
                 RangerAuthorizationProperties.FS_DEFAULT_NAME,
                 RangerAuthorizationProperties.FS_DEFAULT_VALUE))
         .build();
-  }
-
-  private static AuthorizationMetadataObject.Type getType(MetadataObject metadataObject) {
-    for (PathBasedMetadataObject.PathType value : PathBasedMetadataObject.PathType.values()) {
-      if (value.metadataObjectType() == metadataObject.type()) {
-        return value;
-      }
-    }
-    throw new IllegalArgumentException("Doesn't support " + metadataObject);
   }
 }

--- a/authorizations/authorization-ranger/src/test/java/org/apache/gravitino/authorization/ranger/integration/test/RangerAuthorizationHDFSPluginIT.java
+++ b/authorizations/authorization-ranger/src/test/java/org/apache/gravitino/authorization/ranger/integration/test/RangerAuthorizationHDFSPluginIT.java
@@ -85,7 +85,7 @@ public class RangerAuthorizationHDFSPluginIT {
                     Assertions.assertEquals(
                         metalake.fullName(), pathBasedMetadataObject.fullName());
                     Assertions.assertEquals(
-                        PathBasedMetadataObject.Type.METALAKE_PATH, pathBasedMetadataObject.type());
+                        PathBasedMetadataObject.PathType.METALAKE_PATH, pathBasedMetadataObject.type());
                     Assertions.assertEquals("/test", pathBasedMetadataObject.path());
                   });
 
@@ -99,7 +99,7 @@ public class RangerAuthorizationHDFSPluginIT {
                         (PathBasedMetadataObject) securableObject;
                     Assertions.assertEquals(catalog.fullName(), pathBasedMetadataObject.fullName());
                     Assertions.assertEquals(
-                        PathBasedMetadataObject.Type.CATALOG_PATH, pathBasedMetadataObject.type());
+                        PathBasedMetadataObject.PathType.CATALOG_PATH, pathBasedMetadataObject.type());
                     Assertions.assertEquals("/test", pathBasedMetadataObject.path());
                   });
 
@@ -113,7 +113,7 @@ public class RangerAuthorizationHDFSPluginIT {
                         (PathBasedMetadataObject) securableObject;
                     Assertions.assertEquals(schema.fullName(), pathBasedMetadataObject.fullName());
                     Assertions.assertEquals(
-                        PathBasedMetadataObject.Type.SCHEMA_PATH, pathBasedMetadataObject.type());
+                        PathBasedMetadataObject.PathType.SCHEMA_PATH, pathBasedMetadataObject.type());
                     Assertions.assertEquals("/test", pathBasedMetadataObject.path());
                   });
 
@@ -128,7 +128,7 @@ public class RangerAuthorizationHDFSPluginIT {
                         (PathBasedMetadataObject) securableObject;
                     Assertions.assertEquals(table.fullName(), pathBasedMetadataObject.fullName());
                     Assertions.assertEquals(
-                        PathBasedMetadataObject.Type.TABLE_PATH, securableObject.type());
+                        PathBasedMetadataObject.PathType.TABLE_PATH, securableObject.type());
                     Assertions.assertEquals("/test", pathBasedMetadataObject.path());
                   });
 
@@ -143,7 +143,7 @@ public class RangerAuthorizationHDFSPluginIT {
                         (PathBasedMetadataObject) securableObject;
                     Assertions.assertEquals(fileset.fullName(), pathBasedMetadataObject.fullName());
                     Assertions.assertEquals(
-                        PathBasedMetadataObject.Type.FILESET_PATH, securableObject.type());
+                        PathBasedMetadataObject.PathType.FILESET_PATH, securableObject.type());
                     Assertions.assertEquals("/test", pathBasedMetadataObject.path());
                   });
         });
@@ -206,7 +206,7 @@ public class RangerAuthorizationHDFSPluginIT {
                 PathBasedSecurableObject pathBasedSecurableObject =
                     (PathBasedSecurableObject) securableObject;
                 Assertions.assertEquals(
-                    PathBasedMetadataObject.Type.FILESET_PATH, pathBasedSecurableObject.type());
+                    PathBasedMetadataObject.PathType.FILESET_PATH, pathBasedSecurableObject.type());
                 Assertions.assertEquals("/test", pathBasedSecurableObject.path());
                 Assertions.assertEquals(2, pathBasedSecurableObject.privileges().size());
               });
@@ -246,7 +246,7 @@ public class RangerAuthorizationHDFSPluginIT {
                 Assertions.assertEquals(1, filesetOwner.size());
                 Assertions.assertEquals("/test", pathBasedSecurableObject.path());
                 Assertions.assertEquals(
-                    PathBasedMetadataObject.Type.FILESET_PATH, pathBasedSecurableObject.type());
+                    PathBasedMetadataObject.PathType.FILESET_PATH, pathBasedSecurableObject.type());
                 Assertions.assertEquals(3, pathBasedSecurableObject.privileges().size());
               });
         });

--- a/authorizations/authorization-ranger/src/test/java/org/apache/gravitino/authorization/ranger/integration/test/RangerAuthorizationHDFSPluginIT.java
+++ b/authorizations/authorization-ranger/src/test/java/org/apache/gravitino/authorization/ranger/integration/test/RangerAuthorizationHDFSPluginIT.java
@@ -85,7 +85,7 @@ public class RangerAuthorizationHDFSPluginIT {
                     Assertions.assertEquals(
                         metalake.fullName(), pathBasedMetadataObject.fullName());
                     Assertions.assertEquals(
-                        PathBasedMetadataObject.Type.PATH, pathBasedMetadataObject.type());
+                        PathBasedMetadataObject.Type.METALAKE_PATH, pathBasedMetadataObject.type());
                     Assertions.assertEquals("/test", pathBasedMetadataObject.path());
                   });
 
@@ -99,7 +99,7 @@ public class RangerAuthorizationHDFSPluginIT {
                         (PathBasedMetadataObject) securableObject;
                     Assertions.assertEquals(catalog.fullName(), pathBasedMetadataObject.fullName());
                     Assertions.assertEquals(
-                        PathBasedMetadataObject.Type.PATH, pathBasedMetadataObject.type());
+                        PathBasedMetadataObject.Type.CATALOG_PATH, pathBasedMetadataObject.type());
                     Assertions.assertEquals("/test", pathBasedMetadataObject.path());
                   });
 
@@ -113,7 +113,7 @@ public class RangerAuthorizationHDFSPluginIT {
                         (PathBasedMetadataObject) securableObject;
                     Assertions.assertEquals(schema.fullName(), pathBasedMetadataObject.fullName());
                     Assertions.assertEquals(
-                        PathBasedMetadataObject.Type.PATH, pathBasedMetadataObject.type());
+                        PathBasedMetadataObject.Type.SCHEMA_PATH, pathBasedMetadataObject.type());
                     Assertions.assertEquals("/test", pathBasedMetadataObject.path());
                   });
 
@@ -128,7 +128,7 @@ public class RangerAuthorizationHDFSPluginIT {
                         (PathBasedMetadataObject) securableObject;
                     Assertions.assertEquals(table.fullName(), pathBasedMetadataObject.fullName());
                     Assertions.assertEquals(
-                        PathBasedMetadataObject.Type.PATH, securableObject.type());
+                        PathBasedMetadataObject.Type.TABLE_PATH, securableObject.type());
                     Assertions.assertEquals("/test", pathBasedMetadataObject.path());
                   });
 
@@ -143,7 +143,7 @@ public class RangerAuthorizationHDFSPluginIT {
                         (PathBasedMetadataObject) securableObject;
                     Assertions.assertEquals(fileset.fullName(), pathBasedMetadataObject.fullName());
                     Assertions.assertEquals(
-                        PathBasedMetadataObject.Type.PATH, securableObject.type());
+                        PathBasedMetadataObject.Type.FILESET_PATH, securableObject.type());
                     Assertions.assertEquals("/test", pathBasedMetadataObject.path());
                   });
         });
@@ -206,7 +206,7 @@ public class RangerAuthorizationHDFSPluginIT {
                 PathBasedSecurableObject pathBasedSecurableObject =
                     (PathBasedSecurableObject) securableObject;
                 Assertions.assertEquals(
-                    PathBasedMetadataObject.Type.PATH, pathBasedSecurableObject.type());
+                    PathBasedMetadataObject.Type.FILESET_PATH, pathBasedSecurableObject.type());
                 Assertions.assertEquals("/test", pathBasedSecurableObject.path());
                 Assertions.assertEquals(2, pathBasedSecurableObject.privileges().size());
               });
@@ -246,7 +246,7 @@ public class RangerAuthorizationHDFSPluginIT {
                 Assertions.assertEquals(1, filesetOwner.size());
                 Assertions.assertEquals("/test", pathBasedSecurableObject.path());
                 Assertions.assertEquals(
-                    PathBasedMetadataObject.Type.PATH, pathBasedSecurableObject.type());
+                    PathBasedMetadataObject.Type.FILESET_PATH, pathBasedSecurableObject.type());
                 Assertions.assertEquals(3, pathBasedSecurableObject.privileges().size());
               });
         });

--- a/authorizations/authorization-ranger/src/test/java/org/apache/gravitino/authorization/ranger/integration/test/RangerAuthorizationHDFSPluginIT.java
+++ b/authorizations/authorization-ranger/src/test/java/org/apache/gravitino/authorization/ranger/integration/test/RangerAuthorizationHDFSPluginIT.java
@@ -85,7 +85,8 @@ public class RangerAuthorizationHDFSPluginIT {
                     Assertions.assertEquals(
                         metalake.fullName(), pathBasedMetadataObject.fullName());
                     Assertions.assertEquals(
-                        PathBasedMetadataObject.PathType.METALAKE_PATH, pathBasedMetadataObject.type());
+                        PathBasedMetadataObject.PathType.get(MetadataObject.Type.METALAKE),
+                        pathBasedMetadataObject.type());
                     Assertions.assertEquals("/test", pathBasedMetadataObject.path());
                   });
 
@@ -99,7 +100,8 @@ public class RangerAuthorizationHDFSPluginIT {
                         (PathBasedMetadataObject) securableObject;
                     Assertions.assertEquals(catalog.fullName(), pathBasedMetadataObject.fullName());
                     Assertions.assertEquals(
-                        PathBasedMetadataObject.PathType.CATALOG_PATH, pathBasedMetadataObject.type());
+                        PathBasedMetadataObject.PathType.get(MetadataObject.Type.CATALOG),
+                        pathBasedMetadataObject.type());
                     Assertions.assertEquals("/test", pathBasedMetadataObject.path());
                   });
 
@@ -113,7 +115,8 @@ public class RangerAuthorizationHDFSPluginIT {
                         (PathBasedMetadataObject) securableObject;
                     Assertions.assertEquals(schema.fullName(), pathBasedMetadataObject.fullName());
                     Assertions.assertEquals(
-                        PathBasedMetadataObject.PathType.SCHEMA_PATH, pathBasedMetadataObject.type());
+                        PathBasedMetadataObject.PathType.get(MetadataObject.Type.SCHEMA),
+                        pathBasedMetadataObject.type());
                     Assertions.assertEquals("/test", pathBasedMetadataObject.path());
                   });
 
@@ -128,7 +131,8 @@ public class RangerAuthorizationHDFSPluginIT {
                         (PathBasedMetadataObject) securableObject;
                     Assertions.assertEquals(table.fullName(), pathBasedMetadataObject.fullName());
                     Assertions.assertEquals(
-                        PathBasedMetadataObject.PathType.TABLE_PATH, securableObject.type());
+                        PathBasedMetadataObject.PathType.get(MetadataObject.Type.TABLE),
+                        securableObject.type());
                     Assertions.assertEquals("/test", pathBasedMetadataObject.path());
                   });
 
@@ -143,7 +147,8 @@ public class RangerAuthorizationHDFSPluginIT {
                         (PathBasedMetadataObject) securableObject;
                     Assertions.assertEquals(fileset.fullName(), pathBasedMetadataObject.fullName());
                     Assertions.assertEquals(
-                        PathBasedMetadataObject.PathType.FILESET_PATH, securableObject.type());
+                        PathBasedMetadataObject.PathType.get(MetadataObject.Type.FILESET),
+                        securableObject.type());
                     Assertions.assertEquals("/test", pathBasedMetadataObject.path());
                   });
         });
@@ -206,7 +211,8 @@ public class RangerAuthorizationHDFSPluginIT {
                 PathBasedSecurableObject pathBasedSecurableObject =
                     (PathBasedSecurableObject) securableObject;
                 Assertions.assertEquals(
-                    PathBasedMetadataObject.PathType.FILESET_PATH, pathBasedSecurableObject.type());
+                    PathBasedMetadataObject.PathType.get(MetadataObject.Type.FILESET),
+                    pathBasedSecurableObject.type());
                 Assertions.assertEquals("/test", pathBasedSecurableObject.path());
                 Assertions.assertEquals(2, pathBasedSecurableObject.privileges().size());
               });
@@ -246,7 +252,8 @@ public class RangerAuthorizationHDFSPluginIT {
                 Assertions.assertEquals(1, filesetOwner.size());
                 Assertions.assertEquals("/test", pathBasedSecurableObject.path());
                 Assertions.assertEquals(
-                    PathBasedMetadataObject.PathType.FILESET_PATH, pathBasedSecurableObject.type());
+                    PathBasedMetadataObject.PathType.get(MetadataObject.Type.FILESET),
+                    pathBasedSecurableObject.type());
                 Assertions.assertEquals(3, pathBasedSecurableObject.privileges().size());
               });
         });


### PR DESCRIPTION
### What changes were proposed in this pull request?

Avoid binding type `PATH` to `FILESET`. When we store a Hive table, first, we will store the metadata in the MySQL, and then we will store the data in the HDFS location. For Hive, there is a default location for the cluster level. We can also specify other locations for schema and table levels. So a path won't only be fileset. 

### Why are the changes needed?

Fix: #6698

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

CI passed.