### PR TITLE
[#6525] feat: Support update comment operations for model alteration

### DIFF
--- a/api/src/main/java/org/apache/gravitino/model/ModelCatalog.java
+++ b/api/src/main/java/org/apache/gravitino/model/ModelCatalog.java
@@ -236,4 +236,19 @@ public interface ModelCatalog {
    * @return True if the model version is deleted, false if the model version does not exist.
    */
   boolean deleteModelVersion(NameIdentifier ident, String alias);
+
+  /**
+   * Applies the {@link ModelChange changes} to a model in the catalog.
+   *
+   * <p>Implementations may reject the changes. If any change is rejected, no changes should be
+   * applied to the model.
+   *
+   * @param ident A model identifier
+   * @param changes The changes to apply to the model
+   * @return The altered model metadata
+   * @throws NoSuchModelException If the model does not exist
+   * @throws IllegalArgumentException If the change is rejected by the implementation
+   */
+  Model alterModel(NameIdentifier ident, ModelChange... changes)
+      throws NoSuchModelException, IllegalArgumentException;
 }

--- a/api/src/main/java/org/apache/gravitino/model/ModelChange.java
+++ b/api/src/main/java/org/apache/gravitino/model/ModelChange.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.model;
+
+import java.util.Objects;
+import org.apache.gravitino.annotation.Evolving;
+
+/**
+ * A model change is a change to a model. It can be used to rename a model, update the comment of a
+ * model, set a property and value pair for a model, or remove a property from a model.
+ */
+@Evolving
+public interface ModelChange {
+
+  /**
+   * Creates a new model change to update the model comment.
+   *
+   * @param newComment The new comment for the model.
+   * @return The model change.
+   */
+  static ModelChange updateComment(String newComment) {
+    return new UpdateModelComment(newComment);
+  }
+
+  /** A model change to update the model comment. */
+  final class UpdateModelComment implements ModelChange {
+    private final String newComment;
+
+    private UpdateModelComment(String newComment) {
+      this.newComment = newComment;
+    }
+
+    /**
+     * Retrieves the new comment intended for the model.
+     *
+     * @return The new comment that has been set for the model.
+     */
+    public String getNewComment() {
+      return newComment;
+    }
+
+    /**
+     * Compares this UpdateModelComment instance with another object for equality. Two instances are
+     * considered equal if they designate the same new comment for the model.
+     *
+     * @param o The object to compare with this instance.
+     * @return true if the given object represents the same comment update; false otherwise.
+     */
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+      UpdateModelComment that = (UpdateModelComment) o;
+      return Objects.equals(newComment, that.newComment);
+    }
+
+    /**
+     * Generates a hash code for this UpdateFileComment instance. The hash code is based on the new
+     * comment for the model.
+     *
+     * @return A hash code representing this comment update operation.
+     */
+    @Override
+    public int hashCode() {
+      return Objects.hash(newComment);
+    }
+
+    /**
+     * Provides a string representation of the UpdateModelComment instance. This string format
+     * includes the class name followed by the new comment for the model.
+     *
+     * @return A string summary of this comment update operation.
+     */
+    @Override
+    public String toString() {
+      return "UPDATEMODELCOMMENT " + newComment;
+    }
+  }
+}

--- a/catalogs/catalog-model/src/test/java/org/apache/gravtitino/catalog/model/TestModelCatalogOperations.java
+++ b/catalogs/catalog-model/src/test/java/org/apache/gravtitino/catalog/model/TestModelCatalogOperations.java
@@ -65,6 +65,7 @@ import org.apache.gravitino.meta.BaseMetalake;
 import org.apache.gravitino.meta.CatalogEntity;
 import org.apache.gravitino.meta.SchemaVersion;
 import org.apache.gravitino.model.Model;
+import org.apache.gravitino.model.ModelChange;
 import org.apache.gravitino.model.ModelVersion;
 import org.apache.gravitino.storage.IdGenerator;
 import org.apache.gravitino.storage.RandomIdGenerator;
@@ -650,6 +651,34 @@ public class TestModelCatalogOperations {
 
     // Test list model versions after deletion
     Assertions.assertThrows(NoSuchModelException.class, () -> ops.listModelVersions(modelIdent));
+  }
+
+  @Test
+  public void testUpdateFilesetComment() {
+    String schemaName = randomSchemaName();
+    createSchema(schemaName);
+
+    String modelName = "model1";
+    String comment = "comment01";
+    NameIdentifier modelIdent =
+        NameIdentifierUtil.ofModel(METALAKE_NAME, CATALOG_NAME, schemaName, modelName);
+    StringIdentifier stringId = StringIdentifier.fromId(idGenerator.nextId());
+    Map<String, String> properties = StringIdentifier.newPropertiesWithId(stringId, null);
+
+    Model registeredModel = ops.registerModel(modelIdent, comment, properties);
+    Assertions.assertEquals(modelName, registeredModel.name());
+    Assertions.assertEquals(comment, registeredModel.comment());
+
+    Model loadedModel = ops.getModel(modelIdent);
+    Assertions.assertEquals(modelName, loadedModel.name());
+    Assertions.assertEquals(comment, loadedModel.comment());
+
+    String alteredComment = "comment01";
+    ModelChange change = ModelChange.updateComment(alteredComment);
+    Model alteredModel = ops.alterModel(modelIdent, change);
+
+    Assertions.assertEquals(modelName, alteredModel.name());
+    Assertions.assertEquals(alteredComment, alteredModel.comment());
   }
 
   private String randomSchemaName() {

--- a/clients/client-java/src/main/java/org/apache/gravitino/client/DTOConverters.java
+++ b/clients/client-java/src/main/java/org/apache/gravitino/client/DTOConverters.java
@@ -38,12 +38,14 @@ import org.apache.gravitino.dto.authorization.SecurableObjectDTO;
 import org.apache.gravitino.dto.requests.CatalogUpdateRequest;
 import org.apache.gravitino.dto.requests.FilesetUpdateRequest;
 import org.apache.gravitino.dto.requests.MetalakeUpdateRequest;
+import org.apache.gravitino.dto.requests.ModelUpdateRequest;
 import org.apache.gravitino.dto.requests.SchemaUpdateRequest;
 import org.apache.gravitino.dto.requests.TableUpdateRequest;
 import org.apache.gravitino.dto.requests.TagUpdateRequest;
 import org.apache.gravitino.dto.requests.TopicUpdateRequest;
 import org.apache.gravitino.file.FilesetChange;
 import org.apache.gravitino.messaging.TopicChange;
+import org.apache.gravitino.model.ModelChange;
 import org.apache.gravitino.rel.Column;
 import org.apache.gravitino.rel.TableChange;
 import org.apache.gravitino.rel.expressions.Expression;
@@ -353,6 +355,17 @@ class DTOConverters {
     } else {
       throw new IllegalArgumentException(
           "Unknown change type: " + change.getClass().getSimpleName());
+    }
+  }
+
+  static ModelUpdateRequest toModelUpdateRequest(ModelChange change) {
+    if (change instanceof ModelChange.UpdateModelComment) {
+      return new ModelUpdateRequest.UpdateModelCommentRequest(
+          ((ModelChange.UpdateModelComment) change).getNewComment());
+
+    } else {
+      throw new IllegalArgumentException(
+          "Unknown model change type: " + change.getClass().getSimpleName());
     }
   }
 }

--- a/clients/client-java/src/main/java/org/apache/gravitino/client/GenericModelCatalog.java
+++ b/clients/client-java/src/main/java/org/apache/gravitino/client/GenericModelCatalog.java
@@ -22,7 +22,9 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.gravitino.Catalog;
 import org.apache.gravitino.NameIdentifier;
@@ -30,6 +32,8 @@ import org.apache.gravitino.Namespace;
 import org.apache.gravitino.dto.AuditDTO;
 import org.apache.gravitino.dto.CatalogDTO;
 import org.apache.gravitino.dto.requests.ModelRegisterRequest;
+import org.apache.gravitino.dto.requests.ModelUpdateRequest;
+import org.apache.gravitino.dto.requests.ModelUpdatesRequest;
 import org.apache.gravitino.dto.requests.ModelVersionLinkRequest;
 import org.apache.gravitino.dto.responses.BaseResponse;
 import org.apache.gravitino.dto.responses.DropResponse;
@@ -44,6 +48,7 @@ import org.apache.gravitino.exceptions.NoSuchModelVersionException;
 import org.apache.gravitino.exceptions.NoSuchSchemaException;
 import org.apache.gravitino.model.Model;
 import org.apache.gravitino.model.ModelCatalog;
+import org.apache.gravitino.model.ModelChange;
 import org.apache.gravitino.model.ModelVersion;
 import org.apache.gravitino.rest.RESTUtils;
 
@@ -247,6 +252,33 @@ class GenericModelCatalog extends BaseSchemaCatalog implements ModelCatalog {
     resp.validate();
 
     return resp.dropped();
+  }
+
+  @Override
+  public Model alterModel(NameIdentifier ident, ModelChange... changes)
+      throws NoSuchModelException, IllegalArgumentException {
+    checkModelNameIdentifier(ident);
+
+    // Convert ModelChange objects to DTO requests
+    List<ModelUpdateRequest> updateRequests =
+        Arrays.stream(changes)
+            .map(DTOConverters::toModelUpdateRequest)
+            .collect(Collectors.toList());
+
+    ModelUpdatesRequest req = new ModelUpdatesRequest(updateRequests);
+    req.validate();
+
+    Namespace modelFullNs = modelFullNamespace(ident.namespace());
+    ModelResponse resp =
+        restClient.put(
+            formatModelRequestPath(modelFullNs) + "/" + RESTUtils.encodeString(ident.name()),
+            req,
+            ModelResponse.class,
+            Collections.emptyMap(),
+            ErrorHandlers.modelErrorHandler());
+
+    resp.validate();
+    return new GenericModel(resp.getModel(), restClient, modelFullNs);
   }
 
   /** @return A new builder instance for {@link GenericModelCatalog}. */

--- a/clients/client-python/gravitino/api/model/model_change.py
+++ b/clients/client-python/gravitino/api/model/model_change.py
@@ -1,0 +1,60 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from abc import ABC
+from dataclasses import dataclass, field
+from dataclasses_json import config
+
+class ModelChange(ABC):
+    """A model change is a change to a model. It can be used to update model metadata."""
+
+    @staticmethod
+    def update_comment(new_comment: str):
+        """Creates a new model change to update the model comment.
+
+        Args:
+            new_comment: The new comment for the model.
+
+        Returns:
+            The model change.
+        """
+        return ModelChange.UpdateModelComment(new_comment)
+
+    @dataclass
+    class UpdateModelComment:
+        """A model change to update the model comment."""
+
+        _new_comment: str = field(metadata=config(field_name="newComment"))
+
+        def new_comment(self) -> str:
+            """Retrieves the new comment for the model.
+
+            Returns:
+                The new comment that has been set.
+            """
+            return self._new_comment
+
+        def __eq__(self, other) -> bool:
+            if not isinstance(other, ModelChange.UpdateModelComment):
+                return False
+            return self._new_comment == other.new_comment()
+
+        def __hash__(self):
+            return hash(self._new_comment)
+
+        def __str__(self):
+            return f"UPDATEMODELCOMMENT {self._new_comment}"

--- a/clients/client-python/gravitino/dto/requests/model_update_request.py
+++ b/clients/client-python/gravitino/dto/requests/model_update_request.py
@@ -1,0 +1,57 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from abc import abstractmethod
+from dataclasses import dataclass, field
+from dataclasses_json import config
+
+from gravitino.api.model.model_change import ModelChange
+from gravitino.rest.rest_message import RESTRequest
+
+
+@dataclass
+class ModelUpdateRequestBase(RESTRequest):
+    """Base class for all model update requests."""
+    _type: str = field(metadata=config(field_name="@type"))
+
+    def __init__(self, action_type: str):
+        self._type = action_type
+
+    @abstractmethod
+    def model_change(self) -> ModelChange:
+        """Convert to model change operation"""
+        pass
+
+
+class ModelUpdateRequest:
+    """Namespace for all model update request types."""
+
+    @dataclass
+    class UpdateModelCommentRequest(ModelUpdateRequestBase):
+        """Request to update model comment"""
+        _new_comment: str = field(metadata=config(field_name="newComment"))
+
+        def __init__(self, new_comment: str):
+            super().__init__("updateComment")
+            self._new_comment = new_comment
+
+        def validate(self):
+            if not self._new_comment:
+                raise ValueError('"new_comment" field is required')
+
+        def model_change(self) -> ModelChange:
+            return ModelChange.update_comment(self._new_comment)

--- a/clients/client-python/gravitino/dto/requests/model_updates_request.py
+++ b/clients/client-python/gravitino/dto/requests/model_updates_request.py
@@ -1,0 +1,46 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from dataclasses import dataclass, field
+from typing import List
+
+from dataclasses_json import config
+
+from gravitino.dto.requests.model_update_request import ModelUpdateRequest
+from gravitino.rest.rest_message import RESTRequest
+
+
+@dataclass
+class ModelUpdatesRequest(RESTRequest):
+    """Represents a collection of model metadata update operations to be applied atomically."""
+
+    _updates: List[ModelUpdateRequest] = field(
+        metadata=config(field_name="updates"),
+        default_factory=list
+    )
+
+    def validate(self):
+        """Validates the update requests.
+
+        Raises:
+            ValueError: If the updates list is empty or contains invalid requests.
+        """
+        if not self._updates:
+            raise ValueError("At least one model update must be specified")
+
+        for update in self._updates:
+            update.validate()

--- a/common/src/main/java/org/apache/gravitino/dto/requests/ModelUpdateRequest.java
+++ b/common/src/main/java/org/apache/gravitino/dto/requests/ModelUpdateRequest.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.dto.requests;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import org.apache.gravitino.model.ModelChange;
+import org.apache.gravitino.rest.RESTRequest;
+
+/** Request to update a model. */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY)
+@JsonSubTypes({
+  @JsonSubTypes.Type(
+      value = ModelUpdateRequest.UpdateModelCommentRequest.class,
+      name = "updateComment")
+})
+public interface ModelUpdateRequest extends RESTRequest {
+
+  /**
+   * Returns the model change.
+   *
+   * @return the model change.
+   */
+  ModelChange modelChange();
+
+  /** The model update request for updating the comment of a model. */
+  @EqualsAndHashCode
+  @NoArgsConstructor(force = true)
+  @AllArgsConstructor
+  @ToString
+  class UpdateModelCommentRequest implements ModelUpdateRequest {
+
+    @Getter
+    @JsonProperty("newComment")
+    private final String newComment;
+
+    /** @return The model change. */
+    @Override
+    public ModelChange modelChange() {
+      return ModelChange.updateComment(newComment);
+    }
+
+    /** Validates the fields of the request. Always pass. */
+    @Override
+    public void validate() throws IllegalArgumentException {}
+  }
+}

--- a/common/src/main/java/org/apache/gravitino/dto/requests/ModelUpdatesRequest.java
+++ b/common/src/main/java/org/apache/gravitino/dto/requests/ModelUpdatesRequest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.dto.requests;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+import org.apache.gravitino.rest.RESTRequest;
+
+/** Represents a request to update a model. */
+@Getter
+@EqualsAndHashCode
+@ToString
+public class ModelUpdatesRequest implements RESTRequest {
+
+  @JsonProperty("updates")
+  private final List<ModelUpdateRequest> updates;
+
+  /**
+   * Creates a new ModelUpdatesRequest.
+   *
+   * @param updates The updates to apply to the model.
+   */
+  public ModelUpdatesRequest(List<ModelUpdateRequest> updates) {
+    this.updates = updates;
+  }
+
+  /** This is the constructor that is used by Jackson deserializer */
+  public ModelUpdatesRequest() {
+    this(null);
+  }
+
+  /**
+   * Validates the request.
+   *
+   * @throws IllegalArgumentException If the request is invalid, this exception is thrown.
+   */
+  @Override
+  public void validate() throws IllegalArgumentException {
+    updates.forEach(RESTRequest::validate);
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/catalog/ModelNormalizeDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/ModelNormalizeDispatcher.java
@@ -33,6 +33,7 @@ import org.apache.gravitino.exceptions.NoSuchModelException;
 import org.apache.gravitino.exceptions.NoSuchModelVersionException;
 import org.apache.gravitino.exceptions.NoSuchSchemaException;
 import org.apache.gravitino.model.Model;
+import org.apache.gravitino.model.ModelChange;
 import org.apache.gravitino.model.ModelVersion;
 
 public class ModelNormalizeDispatcher implements ModelDispatcher {
@@ -126,6 +127,12 @@ public class ModelNormalizeDispatcher implements ModelDispatcher {
   @Override
   public boolean deleteModelVersion(NameIdentifier ident, String alias) {
     return dispatcher.deleteModelVersion(normalizeCaseSensitive(ident), alias);
+  }
+
+  @Override
+  public Model alterModel(NameIdentifier ident, ModelChange... changes)
+      throws NoSuchModelException, IllegalArgumentException {
+    return dispatcher.alterModel(normalizeCaseSensitive(ident), changes);
   }
 
   private Namespace normalizeCaseSensitive(Namespace namespace) {

--- a/core/src/main/java/org/apache/gravitino/storage/relational/JDBCBackend.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/JDBCBackend.java
@@ -203,6 +203,8 @@ public class JDBCBackend implements RelationalBackend {
         return (E) RoleMetaService.getInstance().updateRole(ident, updater);
       case TAG:
         return (E) TagMetaService.getInstance().updateTag(ident, updater);
+      case MODEL:
+        return (E) ModelMetaService.getInstance().updateModel(ident, updater);
       default:
         throw new UnsupportedEntityTypeException(
             "Unsupported entity type: %s for update operation", entityType);

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/ModelMetaMapper.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/ModelMetaMapper.java
@@ -84,4 +84,8 @@ public interface ModelMetaMapper {
 
   @UpdateProvider(type = ModelMetaSQLProviderFactory.class, method = "updateModelLatestVersion")
   Integer updateModelLatestVersion(@Param("modelId") Long modelId);
+
+  @UpdateProvider(type = ModelMetaSQLProviderFactory.class, method = "updateModelMeta")
+  Integer updateModelMeta(
+      @Param("newModelMeta") ModelPO newModelPO, @Param("oldModelMeta") ModelPO oldModelPO);
 }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/ModelMetaSQLProviderFactory.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/ModelMetaSQLProviderFactory.java
@@ -101,4 +101,9 @@ public class ModelMetaSQLProviderFactory {
   public static String updateModelLatestVersion(@Param("modelId") Long modelId) {
     return getProvider().updateModelLatestVersion(modelId);
   }
+
+  public static String updateModelMeta(
+      @Param("newModelMeta") ModelPO newModelPO, @Param("oldModelMeta") ModelPO oldModelPO) {
+    return getProvider().updateModelMeta(newModelPO, oldModelPO);
+  }
 }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/ModelMetaBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/ModelMetaBaseSQLProvider.java
@@ -141,4 +141,29 @@ public class ModelMetaBaseSQLProvider {
         + " SET model_latest_version = model_latest_version + 1"
         + " WHERE model_id = #{modelId} AND deleted_at = 0";
   }
+
+  public String updateModelMeta(
+      @Param("newModelMeta") ModelPO newModelPO, @Param("oldModelMeta") ModelPO oldModelPO) {
+    return "UPDATE "
+        + ModelMetaMapper.TABLE_NAME
+        + " SET model_name = #{newModelMeta.modelName},"
+        + " metalake_id = #{newModelMeta.metalakeId},"
+        + " catalog_id = #{newModelMeta.catalogId},"
+        + " schema_id = #{newModelMeta.schemaId},"
+        + " model_comment = #{newModelMeta.modelComment},"
+        + " model_properties = #{newModelMeta.modelProperties},"
+        + " model_latest_version = #{newModelMeta.modelLatestVersion},"
+        + " audit_info = #{newModelMeta.auditInfo},"
+        + " deleted_at = #{newModelMeta.deletedAt}"
+        + " WHERE model_id = #{oldModelMeta.modelId}"
+        + " AND model_name = #{oldModelMeta.modelName}"
+        + " AND metalake_id = #{oldModelMeta.metalakeId}"
+        + " AND catalog_id = #{oldModelMeta.catalogId}"
+        + " AND schema_id = #{oldModelMeta.schemaId}"
+        + " AND model_comment = #{oldModelMeta.modelComment}"
+        + " AND model_properties = #{oldModelMeta.modelProperties}"
+        + " AND model_latest_version = #{oldModelMeta.modelLatestVersion}"
+        + " AND audit_info = #{oldModelMeta.auditInfo}"
+        + " AND deleted_at = 0";
+  }
 }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/utils/POConverters.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/utils/POConverters.java
@@ -1392,4 +1392,23 @@ public class POConverters {
                     .build())
         .collect(Collectors.toList());
   }
+
+  public static ModelPO updateModelPO(ModelPO oldModelPO, ModelEntity newModel) {
+    try {
+      return ModelPO.builder()
+          .withModelId(newModel.id())
+          .withModelName(newModel.name())
+          .withMetalakeId(oldModelPO.getMetalakeId())
+          .withCatalogId(oldModelPO.getCatalogId())
+          .withSchemaId(oldModelPO.getSchemaId())
+          .withModelComment(newModel.comment())
+          .withModelLatestVersion(newModel.latestVersion())
+          .withModelProperties(JsonUtils.anyFieldMapper().writeValueAsString(newModel.properties()))
+          .withAuditInfo(JsonUtils.anyFieldMapper().writeValueAsString(newModel.auditInfo()))
+          .withDeletedAt(DEFAULT_DELETED_AT)
+          .build();
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException("Failed to serialize json object:", e);
+    }
+  }
 }

--- a/docs/manage-model-metadata-using-gravitino.md
+++ b/docs/manage-model-metadata-using-gravitino.md
@@ -302,6 +302,108 @@ model: Model = catalog.as_model_catalog().get_model(ident=NameIdentifier.of("mod
 </TabItem>
 </Tabs>
 
+### Alter a model
+
+You can modify a model's metadata (e.g., rename, update comment, or modify properties) by sending a `PUT` request to the `/api/metalakes/{metalake_name}/catalogs/{catalog_name}/schemas/{schema_name}/models/{model_name}` endpoint or using the Gravitino Java/Python client. The following is an example of modifying a model:
+
+<Tabs groupId="language" queryString>
+<TabItem value="shell" label="Shell">
+
+```shell
+curl -X PUT -H "Accept: application/vnd.gravitino.v1+json" \
+-H "Content-Type: application/json" -d '{
+  "updates": [
+    {
+      "@type": "updateComment",
+      "newComment": "Updated model comment"
+    },
+    {
+      "@type": "rename",
+      "newName": "example_model_renamed"
+    },
+    {
+      "@type": "setProperty",
+      "property": "k2",
+      "value": "v2"
+    },
+    {
+      "@type": "removeProperty",
+      "property": "k1"
+    }
+  ]
+}' http://localhost:8090/api/metalakes/example/catalogs/model_catalog/schemas/model_schema/models/example_model
+```
+
+</TabItem>
+<TabItem value="java" label="Java">
+
+```java
+// Load the catalog and model
+GravitinoClient gravitinoClient = GravitinoClient
+    .builder("http://localhost:8090")
+    .withMetalake("example")
+    .build();
+
+Catalog catalog = gravitinoClient.loadCatalog("model_catalog");
+ModelCatalog modelCatalog = catalog.asModelCatalog();
+
+// Define modifications
+ModelChange[] changes = {
+    ModelChange.updateComment("Updated model comment"),
+    ModelChange.rename("example_model_renamed"),
+    ModelChange.setProperty("k2", "v2"),
+    ModelChange.removeProperty("k1")
+};
+
+// Apply changes
+Model updatedModel = modelCatalog.alterModel(
+    NameIdentifier.of("model_schema", "example_model"),
+    changes
+);
+```
+
+</TabItem>
+<TabItem value="python" label="Python">
+
+```python
+gravitino_client: GravitinoClient = GravitinoClient(uri="http://localhost:8090", metalake_name="example")
+
+catalog: Catalog = gravitino_client.load_catalog(name="model_catalog")
+model_catalog = catalog.as_model_catalog()
+
+# Define modifications
+changes = (
+    ModelChange.update_comment("Updated model comment"),
+    ModelChange.rename("example_model_renamed"),
+    ModelChange.set_property("k2", "v2"),
+    ModelChange.remove_property("k1")
+)
+
+# Apply changes
+updated_model = model_catalog.alter_model(
+    ident=NameIdentifier.of("model_schema", "example_model"),
+    *changes
+)
+```
+
+</TabItem>
+</Tabs>
+
+#### Supported modifications
+The following operations are supported for altering a model:
+
+| Operation               | JSON Example                                                                 | Java Method                               | Python Method                         |
+|-------------------------|------------------------------------------------------------------------------|-------------------------------------------|---------------------------------------|
+| **Rename model**        | `{"@type":"rename","newName":"new_name"}`                                    | `ModelChange.rename("new_name")`         | `ModelChange.rename("new_name")`      |
+| **Update comment**      | `{"@type":"updateComment","newComment":"new_comment"}`                       | `ModelChange.updateComment("new_comment")` | `ModelChange.update_comment("new_comment")` |
+| **Set property**        | `{"@type":"setProperty","property":"key","value":"value"}`                   | `ModelChange.setProperty("key", "value")` | `ModelChange.set_property("key", "value")` |
+| **Remove property**     | `{"@type":"removeProperty","property":"key"}`                                | `ModelChange.removeProperty("key")`       | `ModelChange.remove_property("key")`  |
+
+:::note
+- Multiple modifications can be applied in a single request.
+- If the target model does not exist, a `404 Not Found` error will be returned.
+  :::
+
 ### Delete a model
 
 You can delete a model by sending a `DELETE` request to the `/api/metalakes/{metalake_name}

--- a/docs/open-api/models.yaml
+++ b/docs/open-api/models.yaml
@@ -122,6 +122,34 @@ paths:
         "5xx":
           $ref: "./openapi.yaml#/components/responses/ServerErrorResponse"
 
+    put:
+      tags:
+        - model
+      summary: Alter model
+      operationId: alterModel
+      description: Updates the specified model in a schema
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ModelUpdatesRequest"
+      responses:
+        "200":
+          $ref: "#/components/responses/ModelResponse"
+        "400":
+          $ref: "./openapi.yaml#/components/responses/BadRequestErrorResponse"
+        "404":
+          description: Not Found - The target model does not exist
+          content:
+            application/vnd.gravitino.v1+json:
+              schema:
+                $ref: "./openapi.yaml#/components/schemas/ErrorModel"
+              examples:
+                NoSuchModelException:
+                  $ref: "#/components/examples/NoSuchModelException"
+        "5xx":
+          $ref: "./openapi.yaml#/components/responses/ServerErrorResponse"
+
   /metalakes/{metalake}/catalogs/{catalog}/schemas/{schema}/models/{model}/versions:
     parameters:
       - $ref: "./openapi.yaml#/components/parameters/metalake"
@@ -391,6 +419,40 @@ components:
           default: {}
           additionalProperties:
             type: string
+
+    ModelUpdatesRequest:
+      type: object
+      required:
+        - updates
+      properties:
+        updates:
+          type: array
+          items:
+            $ref: "#/components/schemas/ModelUpdateRequest"
+
+    ModelUpdateRequest:
+      oneOf:
+        - $ref: "#/components/schemas/UpdateModelCommentRequest"
+        # 可扩展其他类型如RenameModelRequest等
+      discriminator:
+        propertyName: "@type"
+        mapping:
+          updateComment: "#/components/schemas/UpdateModelCommentRequest"
+
+    UpdateModelCommentRequest:
+      type: object
+      required:
+        - "@type"
+        - newComment
+      properties:
+        "@type":
+          type: string
+          enum: [updateComment]
+        newComment:
+          type: string
+      example:
+        "@type": "updateComment"
+        newComment: "new comment"
 
   responses:
     ModelResponse:

--- a/server/src/test/java/org/apache/gravitino/server/web/rest/TestModelOperations.java
+++ b/server/src/test/java/org/apache/gravitino/server/web/rest/TestModelOperations.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.when;
 import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
 import java.time.Instant;
+import java.util.Collections;
 import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.client.Entity;
@@ -36,6 +37,8 @@ import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
 import org.apache.gravitino.catalog.ModelDispatcher;
 import org.apache.gravitino.dto.requests.ModelRegisterRequest;
+import org.apache.gravitino.dto.requests.ModelUpdateRequest;
+import org.apache.gravitino.dto.requests.ModelUpdatesRequest;
 import org.apache.gravitino.dto.requests.ModelVersionLinkRequest;
 import org.apache.gravitino.dto.responses.BaseResponse;
 import org.apache.gravitino.dto.responses.DropResponse;
@@ -50,6 +53,7 @@ import org.apache.gravitino.exceptions.NoSuchModelException;
 import org.apache.gravitino.exceptions.NoSuchSchemaException;
 import org.apache.gravitino.meta.AuditInfo;
 import org.apache.gravitino.model.Model;
+import org.apache.gravitino.model.ModelChange;
 import org.apache.gravitino.model.ModelVersion;
 import org.apache.gravitino.rest.RESTUtils;
 import org.apache.gravitino.utils.NameIdentifierUtil;
@@ -790,6 +794,67 @@ public class TestModelOperations extends JerseyTest {
     ErrorResponse errorResp2 = resp5.readEntity(ErrorResponse.class);
     Assertions.assertEquals(ErrorConstants.INTERNAL_ERROR_CODE, errorResp2.getCode());
     Assertions.assertEquals(RuntimeException.class.getSimpleName(), errorResp2.getType());
+  }
+
+  @Test
+  public void testAlterModel() {
+    NameIdentifier modelId = NameIdentifierUtil.ofModel(metalake, catalog, schema, "model1");
+    Model updatedModel = mockModel("model1", "newComment", 0);
+
+    // Mock alterModel to return updated model
+    when(modelDispatcher.alterModel(
+            modelId, new ModelChange[] {ModelChange.updateComment("newComment")}))
+        .thenReturn(updatedModel);
+
+    // Build update request
+    ModelUpdatesRequest req =
+        new ModelUpdatesRequest(
+            Collections.singletonList(
+                new ModelUpdateRequest.UpdateModelCommentRequest("newComment")));
+
+    Response resp =
+        target(modelPath())
+            .path("model1")
+            .request(MediaType.APPLICATION_JSON_TYPE)
+            .accept("application/vnd.gravitino.v1+json")
+            .put(Entity.entity(req, MediaType.APPLICATION_JSON_TYPE));
+
+    Assertions.assertEquals(Response.Status.OK.getStatusCode(), resp.getStatus());
+    ModelResponse modelResp = resp.readEntity(ModelResponse.class);
+    Assertions.assertEquals("newComment", modelResp.getModel().comment());
+
+    // Test NoSuchModelException
+    doThrow(new NoSuchModelException("mock error"))
+        .when(modelDispatcher)
+        .alterModel(modelId, new ModelChange[] {ModelChange.updateComment("newComment")});
+
+    Response resp1 =
+        target(modelPath())
+            .path("model1")
+            .request(MediaType.APPLICATION_JSON_TYPE)
+            .accept("application/vnd.gravitino.v1+json")
+            .put(Entity.entity(req, MediaType.APPLICATION_JSON_TYPE));
+
+    Assertions.assertEquals(Response.Status.NOT_FOUND.getStatusCode(), resp1.getStatus());
+    ErrorResponse errorResp = resp1.readEntity(ErrorResponse.class);
+    Assertions.assertEquals(ErrorConstants.NOT_FOUND_CODE, errorResp.getCode());
+
+    // Test RuntimeException
+    doThrow(new RuntimeException("mock error"))
+        .when(modelDispatcher)
+        .alterModel(modelId, new ModelChange[] {ModelChange.updateComment("newComment")});
+
+    Response resp2 =
+        target(modelPath())
+            .path("model1")
+            .request(MediaType.APPLICATION_JSON_TYPE)
+            .accept("application/vnd.gravitino.v1+json")
+            .put(Entity.entity(req, MediaType.APPLICATION_JSON_TYPE));
+
+    Assertions.assertEquals(
+        Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), resp2.getStatus());
+    ErrorResponse errorResp1 = resp2.readEntity(ErrorResponse.class);
+    Assertions.assertEquals(ErrorConstants.INTERNAL_ERROR_CODE, errorResp1.getCode());
   }
 
   private String modelPath() {


### PR DESCRIPTION
### What changes were proposed in this pull request?

1. Add ModelChange API interface for comment modification
2. Implement comment update logic in model catalog and relational database
3. Add REST endpoint to support comment modification
4. Add Java client for model comment update
5. Add Python client for model comment update
6. Add UT and IT to validate comment alteration functionality

### Why are the changes needed?
Support update comment operations for model alteration

Fix: #([issue](https://github.com/apache/gravitino/issues/6525))

### Does this PR introduce _any_ user-facing change?

Yes, support alter model for update comment

### How was this patch tested?

Test added
