### PR TITLE
[#6747] improvement(web): can be dropped while set not in-use false

### DIFF
--- a/web/web/src/app/metalakes/metalake/rightContent/tabsContent/tableView/TableView.js
+++ b/web/web/src/app/metalakes/metalake/rightContent/tabsContent/tableView/TableView.js
@@ -336,7 +336,7 @@ const TableView = () => {
               title='Delete'
               size='small'
               sx={{ color: theme => theme.palette.error.light }}
-              onClick={() => handleDelete({ name: row.name, type: row.node, catalogType: row.type })}
+              onClick={() => handleDelete({ name: row.name, type: row.node, catalogType: row.type, inUse: row.inUse === 'true' })}
               data-refer={`delete-entity-${row.name}`}
             >
               <DeleteIcon />
@@ -640,9 +640,9 @@ const TableView = () => {
     }
   }
 
-  const handleDelete = ({ name, type, catalogType }) => {
+  const handleDelete = ({ name, type, catalogType, inUse }) => {
     setOpenConfirmDelete(true)
-    setConfirmCacheData({ name, type, catalogType })
+    setConfirmCacheData({ name, type, catalogType, inUse })
   }
 
   const handleCloseConfirm = () => {

--- a/web/web/src/app/metalakes/metalake/rightContent/tabsContent/tableView/TableView.js
+++ b/web/web/src/app/metalakes/metalake/rightContent/tabsContent/tableView/TableView.js
@@ -336,7 +336,9 @@ const TableView = () => {
               title='Delete'
               size='small'
               sx={{ color: theme => theme.palette.error.light }}
-              onClick={() => handleDelete({ name: row.name, type: row.node, catalogType: row.type, inUse: row.inUse === 'true' })}
+              onClick={() =>
+                handleDelete({ name: row.name, type: row.node, catalogType: row.type, inUse: row.inUse === 'true' })
+              }
               data-refer={`delete-entity-${row.name}`}
             >
               <DeleteIcon />

--- a/web/web/src/components/ConfirmDeleteDialog.js
+++ b/web/web/src/components/ConfirmDeleteDialog.js
@@ -38,26 +38,30 @@ const ConfirmDeleteDialog = props => {
             Confirm Drop?
           </Typography>
           {confirmCacheData?.type === 'catalog' && confirmCacheData?.inUse ? (
-            <Typography>
-              Make sure the {confirmCacheData.type} is not in-use.
-            </Typography>
+            <Typography>Make sure the {confirmCacheData.type} is not in-use.</Typography>
           ) : (
             <Typography>
-              {confirmCacheData?.type === 'metalake' && <span>Make sure the {confirmCacheData.type} is not in-use, and all sub-entities in it are dropped. </span>}
+              {confirmCacheData?.type === 'metalake' && (
+                <span>
+                  Make sure the {confirmCacheData.type} is not in-use, and all sub-entities in it are dropped.{' '}
+                </span>
+              )}
               This action can not be reversed!
             </Typography>
           )}
         </Box>
       </DialogContent>
       <DialogActions className={'twc-justify-center twc-px-5 twc-pb-8'}>
-        {!(confirmCacheData?.type === 'catalog' && confirmCacheData?.inUse) && <Button
-          variant='contained'
-          data-refer='confirm-delete'
-          className={'twc-mr-2'}
-          onClick={() => handleConfirmDeleteSubmit()}
-        >
-          Drop
-        </Button>}
+        {!(confirmCacheData?.type === 'catalog' && confirmCacheData?.inUse) && (
+          <Button
+            variant='contained'
+            data-refer='confirm-delete'
+            className={'twc-mr-2'}
+            onClick={() => handleConfirmDeleteSubmit()}
+          >
+            Drop
+          </Button>
+        )}
         <Button variant='outlined' color='secondary' onClick={() => handleClose()}>
           Cancel
         </Button>

--- a/web/web/src/components/ConfirmDeleteDialog.js
+++ b/web/web/src/components/ConfirmDeleteDialog.js
@@ -37,25 +37,27 @@ const ConfirmDeleteDialog = props => {
           <Typography variant='h4' className={'twc-mb-5 '} sx={{ color: 'text.secondary' }}>
             Confirm Drop?
           </Typography>
-          {['metalake', 'catalog'].includes(confirmCacheData?.type) ? (
+          {confirmCacheData?.type === 'catalog' && confirmCacheData?.inUse ? (
             <Typography>
-              Make sure the {confirmCacheData.type} is not in-use, and all sub-entities in it are dropped. This action
-              can not be reversed!
+              Make sure the {confirmCacheData.type} is not in-use.
             </Typography>
           ) : (
-            <Typography>This action can not be reversed!</Typography>
+            <Typography>
+              {confirmCacheData?.type === 'metalake' && <span>Make sure the {confirmCacheData.type} is not in-use, and all sub-entities in it are dropped. </span>}
+              This action can not be reversed!
+            </Typography>
           )}
         </Box>
       </DialogContent>
       <DialogActions className={'twc-justify-center twc-px-5 twc-pb-8'}>
-        <Button
+        {!(confirmCacheData?.type === 'catalog' && confirmCacheData?.inUse) && <Button
           variant='contained'
           data-refer='confirm-delete'
           className={'twc-mr-2'}
           onClick={() => handleConfirmDeleteSubmit()}
         >
           Drop
-        </Button>
+        </Button>}
         <Button variant='outlined' color='secondary' onClick={() => handleClose()}>
           Cancel
         </Button>

--- a/web/web/src/lib/api/catalogs/index.js
+++ b/web/web/src/lib/api/catalogs/index.js
@@ -28,7 +28,7 @@ const Apis = {
   UPDATE: ({ metalake, catalog }) =>
     `/api/metalakes/${encodeURIComponent(metalake)}/catalogs/${encodeURIComponent(catalog)}`,
   DELETE: ({ metalake, catalog }) =>
-    `/api/metalakes/${encodeURIComponent(metalake)}/catalogs/${encodeURIComponent(catalog)}`,
+    `/api/metalakes/${encodeURIComponent(metalake)}/catalogs/${encodeURIComponent(catalog)}?force=true`,
   UPDATEINUSE: ({ metalake, catalog }) =>
     `/api/metalakes/${encodeURIComponent(metalake)}/catalogs/${encodeURIComponent(catalog)}`
 }


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?
can be droped while set not in-use false
<img width="910" alt="image" src="https://github.com/user-attachments/assets/77c792db-9546-48d0-8048-1938b9ec3f48" />
<img width="807" alt="image" src="https://github.com/user-attachments/assets/0d75ca12-62b1-462f-b9c8-24ddf3b183fa" />


### Why are the changes needed?
The user experience is bad: can not be dropped even if set in-use false

Fix: #6747

### Does this PR introduce _any_ user-facing change?
N/A

### How was this patch tested?
manually