### PR TITLE
[#6745] fix(client,authn): Fix the No key to store error when Running the Spark connector with a Kerberos ticket cache

### DIFF
--- a/common/src/main/java/org/apache/gravitino/auth/KerberosUtils.java
+++ b/common/src/main/java/org/apache/gravitino/auth/KerberosUtils.java
@@ -122,18 +122,18 @@ public class KerberosUtils {
         options.put("useKeyTab", "true");
         options.put("keyTab", keyTabFile);
         options.put("storeKey", "true");
+      } else {
+        options.put("useTicketCache", "true");
+	String ticketCache = System.getenv("KRB5CCNAME");
+	if (ticketCache != null) {
+          options.put("ticketCache", ticketCache);
+	}
+	options.put("renewTGT", "true");
       }
-
       options.put("principal", principal);
       options.put("doNotPrompt", "true");
-      options.put("useTicketCache", "true");
-      options.put("renewTGT", "true");
       options.put("refreshKrb5Config", "true");
       options.put("isInitiator", "true");
-      String ticketCache = System.getenv("KRB5CCNAME");
-      if (ticketCache != null) {
-        options.put("ticketCache", ticketCache);
-      }
       options.put("debug", "true");
 
       return new AppConfigurationEntry[] {

--- a/common/src/main/java/org/apache/gravitino/auth/KerberosUtils.java
+++ b/common/src/main/java/org/apache/gravitino/auth/KerberosUtils.java
@@ -124,11 +124,11 @@ public class KerberosUtils {
         options.put("storeKey", "true");
       } else {
         options.put("useTicketCache", "true");
-	String ticketCache = System.getenv("KRB5CCNAME");
-	if (ticketCache != null) {
+        String ticketCache = System.getenv("KRB5CCNAME");
+        if (ticketCache != null) {
           options.put("ticketCache", ticketCache);
-	}
-	options.put("renewTGT", "true");
+        }
+        options.put("renewTGT", "true");
       }
       options.put("principal", principal);
       options.put("doNotPrompt", "true");


### PR DESCRIPTION

### What changes were proposed in this pull request?

Fix the No key to store error when Running the Spark connector with a Kerberos ticket cache

### Why are the changes needed?

Fix: #6745


### Does this PR introduce _any_ user-facing change?

No 

### How was this patch tested?
local test.
