### PR TITLE
[#6766] fix (gvfs-fuse): Fix the test failed when setting the project version without SNAPSHOT

### DIFF
--- a/clients/filesystem-fuse/tests/bin/gravitino_server.sh
+++ b/clients/filesystem-fuse/tests/bin/gravitino_server.sh
@@ -60,11 +60,11 @@ create_resource() {
 start_gravitino_server() {
   echo "Starting Gravitino Server"
   # copy the aws-bundle to the server
-  if ls $GRAVITINO_SERVER_DIR/catalogs/hadoop/libs/gravitino-aws-bundle-*-incubating-SNAPSHOT.jar 1>/dev/null 2>&1; then
+  if ls $GRAVITINO_SERVER_DIR/catalogs/hadoop/libs/gravitino-aws-bundle-*.jar 1>/dev/null 2>&1; then
      echo "File exists, skipping copy."
   else
     echo "Copying the aws-bundle to the server"
-    cp $GRAVITINO_HOME/bundles/aws-bundle/build/libs/gravitino-aws-bundle-*-incubating-SNAPSHOT.jar \
+    cp $GRAVITINO_HOME/bundles/aws-bundle/build/libs/gravitino-aws-bundle-*.jar \
       $GRAVITINO_SERVER_DIR/catalogs/hadoop/libs
   fi
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix the gvfs-fuse test to copy the aws-bundle JAR without a name that contains SNAPSHOT

### Why are the changes needed?

Fix: #6766

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Manually test
