### PR TITLE
[#6729] improvement(docker-image): Copy Hadoop Azure bundles to Gravitino docker image

### DIFF
--- a/dev/docker/gravitino/gravitino-dependency.sh
+++ b/dev/docker/gravitino/gravitino-dependency.sh
@@ -35,10 +35,11 @@ mkdir -p "${gravitino_dir}/packages"
 
 cp -r "${gravitino_home}/distribution/package" "${gravitino_dir}/packages/gravitino"
 
-# Copy the Aliyun, AWS, and GCP bundles to the Hadoop catalog libs
+# Copy the Aliyun, AWS, GCP and Azure bundles to the Hadoop catalog libs
 cp ${gravitino_home}/bundles/aliyun-bundle/build/libs/*.jar "${gravitino_dir}/packages/gravitino/catalogs/hadoop/libs"
 cp ${gravitino_home}/bundles/aws-bundle/build/libs/*.jar "${gravitino_dir}/packages/gravitino/catalogs/hadoop/libs"
 cp ${gravitino_home}/bundles/gcp-bundle/build/libs/*.jar "${gravitino_dir}/packages/gravitino/catalogs/hadoop/libs"
+cp ${gravitino_home}/bundles/azure-bundle/build/libs/*.jar "${gravitino_dir}/packages/gravitino/catalogs/hadoop/libs"
 
 # Keeping the container running at all times
 cat <<EOF >> "${gravitino_dir}/packages/gravitino/bin/gravitino.sh"


### PR DESCRIPTION
### What changes were proposed in this pull request?

Copy Hadoop Azure bundle jars to the Gravitino Hadoop catalog classpath. 

This a cherry-pick PR to branch-0.8 for #6729 

### Why are the changes needed?

Hadoop with Azure has been supported since Gravtitino 0.8.0-incubating, we need to add it Hadoop classpath as S3 did.  

Fix: #6729 

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

Test Locally. 