### PR TITLE
[#6834] fix(release-build): wrong path of license + notice bin files

### DIFF
--- a/dev/release/release-build.sh
+++ b/dev/release/release-build.sh
@@ -207,8 +207,8 @@ if [[ "$1" == "package" ]]; then
   rm -f gravitino-$GRAVITINO_VERSION-src/NOTICE.rest
   rm -f gravitino-$GRAVITINO_VERSION-src/LICENSE.trino
   rm -f gravitino-$GRAVITINO_VERSION-src/NOTICE.trino
-  rm -f gravitino-$GRAVITINO_VERSION-src/web/LICENSE.bin
-  rm -f gravitino-$GRAVITINO_VERSION-src/web/NOTICE.bin
+  rm -f gravitino-$GRAVITINO_VERSION-src/web/web/LICENSE.bin
+  rm -f gravitino-$GRAVITINO_VERSION-src/web/web/NOTICE.bin
 
   rm -f *.asc
   tar cvzf gravitino-$GRAVITINO_VERSION-src.tar.gz --exclude gravitino-$GRAVITINO_VERSION-src/.git gravitino-$GRAVITINO_VERSION-src


### PR DESCRIPTION
### What changes were proposed in this pull request?

Set correct path to [LICENSE.bin](https://github.com/apache/gravitino/blob/main/web/web/LICENSE.bin) and [NOTICE.bin](https://github.com/apache/gravitino/blob/main/web/web/NOTICE.bin) files in release-build.sh

### Why are the changes needed?

The two bin files weren't removed after the build.

Fix: #6834 

### Does this PR introduce _any_ user-facing change?

_None_

### How was this patch tested?

Not necessary, you can see where the files are just by browsing them.