### PR TITLE
[#6874] improvement(core): Set `testOnBorrow` to true to avoid possible connection timeout problem

### DIFF
--- a/core/src/main/java/org/apache/gravitino/storage/relational/session/SqlSessionFactoryHelper.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/session/SqlSessionFactoryHelper.java
@@ -98,8 +98,8 @@ public class SqlSessionFactoryHelper {
     dataSource.setRemoveAbandonedOnBorrow(true);
     dataSource.setRemoveAbandonedTimeout(60);
     dataSource.setTimeBetweenEvictionRunsMillis(Duration.ofMillis(10 * 60 * 1000L).toMillis());
-    dataSource.setTestOnBorrow(BaseObjectPoolConfig.DEFAULT_TEST_ON_BORROW);
-    dataSource.setTestWhileIdle(BaseObjectPoolConfig.DEFAULT_TEST_WHILE_IDLE);
+    dataSource.setTestOnBorrow(true);
+    dataSource.setTestWhileIdle(true);
     dataSource.setMinEvictableIdleTimeMillis(1000);
     dataSource.setNumTestsPerEvictionRun(BaseObjectPoolConfig.DEFAULT_NUM_TESTS_PER_EVICTION_RUN);
     dataSource.setTestOnReturn(BaseObjectPoolConfig.DEFAULT_TEST_ON_RETURN);


### PR DESCRIPTION

### What changes were proposed in this pull request?

Set t`estOnBorrow` and `setTestWhileIdle` of JDBC connection pool from `false` to `true`.

### Why are the changes needed?

If the configuration is false, there may be connection problems. 

Fix: #6874 

### Does this PR introduce _any_ user-facing change?

N/A.

### How was this patch tested?

The existing tests.
