### PR TITLE
[#6880] improve(core): Refactor EventBus#dispatchEvent

### DIFF
--- a/core/src/main/java/org/apache/gravitino/listener/api/EventDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/EventDispatcher.java
@@ -17,22 +17,27 @@
  * under the License.
  */
 
-package org.apache.gravitino.listener.api.event;
+package org.apache.gravitino.listener.api;
 
-import org.apache.gravitino.NameIdentifier;
-import org.apache.gravitino.annotation.DeveloperApi;
-import org.apache.gravitino.listener.api.EventDispatcher;
+import org.apache.gravitino.exceptions.ForbiddenException;
+import org.apache.gravitino.listener.api.event.Event;
+import org.apache.gravitino.listener.api.event.PreEvent;
 
-/** Represents a post event. */
-@DeveloperApi
-public abstract class Event extends BaseEvent {
-  protected Event(String user, NameIdentifier identifier) {
-    super(user, identifier);
-  }
+/** Defines the contract for dispatching events to registered listeners. */
+public interface EventDispatcher {
 
-  /** {@inheritDoc} */
-  @Override
-  public void accept(EventDispatcher visitor) {
-    visitor.dispatchPostEvent(this);
-  }
+  /**
+   * Dispatches a {@link PreEvent} to the appropriate listener.
+   *
+   * @param event the pre-event to be dispatched.
+   * @throws ForbiddenException if the dispatch is not permitted by the plugin.
+   */
+  void dispatchPreEvent(PreEvent event) throws ForbiddenException;
+
+  /**
+   * Dispatches a {@link Event} (post-event) to the appropriate listener.
+   *
+   * @param event the post-event to be dispatched.
+   */
+  void dispatchPostEvent(Event event);
 }

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/BaseEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/BaseEvent.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import javax.annotation.Nullable;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.annotation.DeveloperApi;
+import org.apache.gravitino.listener.api.EventDispatcher;
 
 /**
  * The abstract base class for all events. It encapsulates common information such as the user who
@@ -49,6 +50,13 @@ public abstract class BaseEvent {
     this.identifier = identifier;
     this.eventTime = System.currentTimeMillis();
   }
+
+  /**
+   * Accept a visitor to process the event itself.
+   *
+   * @param visitor the implementation of the visitor interface.
+   */
+  public abstract void accept(EventDispatcher visitor);
 
   /**
    * Retrieves the user associated with this event.

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/PreEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/PreEvent.java
@@ -21,6 +21,7 @@ package org.apache.gravitino.listener.api.event;
 
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.annotation.DeveloperApi;
+import org.apache.gravitino.listener.api.EventDispatcher;
 
 /** Represents a pre event. */
 @DeveloperApi
@@ -29,6 +30,13 @@ public abstract class PreEvent extends BaseEvent {
     super(user, identifier);
   }
 
+  /** {@inheritDoc} */
+  @Override
+  public void accept(EventDispatcher visitor) {
+    visitor.dispatchPreEvent(this);
+  }
+
+  /** {@inheritDoc} */
   @Override
   public OperationStatus operationStatus() {
     return OperationStatus.UNPROCESSED;


### PR DESCRIPTION
### What changes were proposed in this pull request?

Refactor EventBus#dispatchEvent. 
By adding the `accept(EventVisitor visitor)` method to BaseEvent and its subclasses, the handling logic is delegated to the event itself. This allows the EventBus to simply call `event.accept(InternalVisitor())`, with the event determining how it should be processed.

1. **Type-safe** – Eliminates the need for `instanceof` checks
2. **Clear decoupling** – Events are only responsible for invoking `accept` method, without knowing the listener implementation
3. **Strong encapsulation** – Prevents external misuse by restricting direct access to visitor methods
4. **Easily extensible** – Adding new event types only requires creating new classes and visitXxx() methods, without modifying the dispatch logic

### Why are the changes needed?

Fix: #6880

### Does this PR introduce _any_ user-facing change?

no

### How was this patch tested?

local test.
