### PR TITLE
[#6722] fix(jdbc-doris): use `show backends` to get the count of Doris BE nodes

### DIFF
--- a/catalogs/catalog-jdbc-doris/src/main/java/org/apache/gravitino/catalog/doris/operation/DorisTableOperations.java
+++ b/catalogs/catalog-jdbc-doris/src/main/java/org/apache/gravitino/catalog/doris/operation/DorisTableOperations.java
@@ -159,23 +159,27 @@ public class DorisTableOperations extends JdbcTableOperations {
     // If the backend server is less than DEFAULT_REPLICATION_FACTOR_IN_SERVER_SIDE (3), we need to
     // set the property 'replication_num' to 1 explicitly.
     if (!resultMap.containsKey(REPLICATION_FACTOR)) {
-      // Try to check the number of backend servers.
-      String query = "select count(*) from information_schema.backends where Alive = 'true'";
+      // Try to check the number of backend servers using show backends command
+      String query = "show backends";
 
       try (Connection connection = dataSource.getConnection();
           Statement statement = connection.createStatement();
           ResultSet resultSet = statement.executeQuery(query)) {
+        int backendCount = 0;
         while (resultSet.next()) {
-          int backendCount = resultSet.getInt(1);
-          if (backendCount < DEFAULT_REPLICATION_FACTOR_IN_SERVER_SIDE) {
-            resultMap.put(
-                REPLICATION_FACTOR,
-                DORIS_TABLE_PROPERTIES_META
-                    .propertyEntries()
-                    .get(REPLICATION_FACTOR)
-                    .getDefaultValue()
-                    .toString());
+          String alive = resultSet.getString("Alive");
+          if ("true".equalsIgnoreCase(alive)) {
+            backendCount++;
           }
+        }
+        if (backendCount < DEFAULT_REPLICATION_FACTOR_IN_SERVER_SIDE) {
+          resultMap.put(
+              REPLICATION_FACTOR,
+              DORIS_TABLE_PROPERTIES_META
+                  .propertyEntries()
+                  .get(REPLICATION_FACTOR)
+                  .getDefaultValue()
+                  .toString());
         }
       } catch (Exception e) {
         throw new RuntimeException("Failed to get the number of backend servers", e);

--- a/catalogs/catalog-jdbc-doris/src/main/java/org/apache/gravitino/catalog/doris/operation/DorisTableOperations.java
+++ b/catalogs/catalog-jdbc-doris/src/main/java/org/apache/gravitino/catalog/doris/operation/DorisTableOperations.java
@@ -159,7 +159,8 @@ public class DorisTableOperations extends JdbcTableOperations {
     // If the backend server is less than DEFAULT_REPLICATION_FACTOR_IN_SERVER_SIDE (3), we need to
     // set the property 'replication_num' to 1 explicitly.
     if (!resultMap.containsKey(REPLICATION_FACTOR)) {
-      // Try to check the number of backend servers using show backends command
+      // Try to check the number of backend servers using `show backends`, this SQL is supported by
+      // all versions of Doris
       String query = "show backends";
 
       try (Connection connection = dataSource.getConnection();


### PR DESCRIPTION
### What changes were proposed in this pull request?

use `show backends` to get the count of Doris Backend (BE) nodes

### Why are the changes needed?

Fix: #6722

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

IT
