### PR TITLE
[#6870] Fix: Use RELEASE_BRANCH instead of hardcoded main in release script

### DIFF
--- a/dev/release/release-build.sh
+++ b/dev/release/release-build.sh
@@ -22,6 +22,7 @@
 
 SELF=$(cd $(dirname $0) && pwd)
 . "$SELF/release-util.sh"
+RELEASE_BRANCH=${RELEASE_BRANCH:-release}
 
 function exit_with_usage {
   cat << EOF
@@ -113,7 +114,7 @@ if [[ "$1" == "finalize" ]]; then
     echo "v$RELEASE_VERSION already exists. Skip creating it."
   else
     rm -rf gravitino
-    git clone "https://$ASF_USERNAME:$ENCODED_ASF_PASSWORD@$ASF_GRAVITINO_REPO" -b main
+    git clone "https://$ASF_USERNAME:$ENCODED_ASF_PASSWORD@$ASF_GRAVITINO_REPO" -b "$RELEASE_BRANCH"
     cd gravitino
     git tag "v$RELEASE_VERSION" "$RELEASE_TAG"
     git push origin "v$RELEASE_VERSION"


### PR DESCRIPTION
## Description
The release script previously had the `git clone` command hardcoded to the `main` branch. This caused issues when attempting to release from a different branch, such as `release`, resulting in cloning the wrong codebase.

This PR introduces the `RELEASE_BRANCH` variable, allowing the user to specify a branch dynamically. If not provided, it defaults to `release`. This enhances flexibility and prevents accidental use of the wrong branch during the release process.

### Changes Made
- Defined `RELEASE_BRANCH=${RELEASE_BRANCH:-release}` early in the script.
- Updated the `git clone` command to use `$RELEASE_BRANCH` instead of `main`.

This change allows safe and accurate automation for multi-branch release workflows.
Fixes #6870
