### PR TITLE
[#6890] feat(core): backend storage supports fileset multiple locations

### DIFF
--- a/authorizations/authorization-ranger/src/test/java/org/apache/gravitino/authorization/ranger/integration/test/RangerHiveHdfsE2EIT.java
+++ b/authorizations/authorization-ranger/src/test/java/org/apache/gravitino/authorization/ranger/integration/test/RangerHiveHdfsE2EIT.java
@@ -55,10 +55,12 @@ import org.apache.hadoop.security.UserGroupInformation;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@Tag("gravitino-docker-test")
 public class RangerHiveHdfsE2EIT extends BaseIT {
 
   private static final Logger LOG = LoggerFactory.getLogger(RangerHiveHdfsE2EIT.class);

--- a/catalogs/catalog-hadoop/src/main/java/org/apache/gravitino/catalog/hadoop/HadoopCatalogOperations.java
+++ b/catalogs/catalog-hadoop/src/main/java/org/apache/gravitino/catalog/hadoop/HadoopCatalogOperations.java
@@ -19,6 +19,7 @@
 package org.apache.gravitino.catalog.hadoop;
 
 import static org.apache.gravitino.connector.BaseCatalog.CATALOG_BYPASS_PREFIX;
+import static org.apache.gravitino.file.Fileset.LOCATION_NAME_UNKNOWN;
 import static org.apache.gravitino.file.Fileset.PROPERTY_CATALOG_PLACEHOLDER;
 import static org.apache.gravitino.file.Fileset.PROPERTY_FILESET_PLACEHOLDER;
 import static org.apache.gravitino.file.Fileset.PROPERTY_LOCATION_PLACEHOLDER_PREFIX;
@@ -301,7 +302,7 @@ public class HadoopCatalogOperations extends ManagedSchemaOperations
             // Store the storageLocation to the store. If the "storageLocation" is null for managed
             // fileset, Gravitino will get and store the location based on the catalog/schema's
             // location and store it to the store.
-            .withStorageLocation(filesetPath.toString())
+            .withStorageLocations(ImmutableMap.of(LOCATION_NAME_UNKNOWN, filesetPath.toString()))
             .withProperties(properties)
             .withAuditInfo(
                 AuditInfo.builder()
@@ -699,7 +700,8 @@ public class HadoopCatalogOperations extends ManagedSchemaOperations
         .withId(filesetEntity.id())
         .withComment(newComment)
         .withFilesetType(filesetEntity.filesetType())
-        .withStorageLocation(filesetEntity.storageLocation())
+        .withStorageLocations(
+            ImmutableMap.of(LOCATION_NAME_UNKNOWN, filesetEntity.storageLocation()))
         .withProperties(props)
         .withAuditInfo(
             AuditInfo.builder()

--- a/core/src/main/java/org/apache/gravitino/config/ConfigConstants.java
+++ b/core/src/main/java/org/apache/gravitino/config/ConfigConstants.java
@@ -75,5 +75,5 @@ public final class ConfigConstants {
   public static final String VERSION_0_9_0 = "0.9.0";
 
   /** The current version of backend storage initialization script. */
-  public static final String CURRENT_SCRIPT_VERSION = VERSION_0_8_0;
+  public static final String CURRENT_SCRIPT_VERSION = VERSION_0_9_0;
 }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/FilesetMetaMapper.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/FilesetMetaMapper.java
@@ -21,11 +21,14 @@ package org.apache.gravitino.storage.relational.mapper;
 
 import java.util.List;
 import org.apache.gravitino.storage.relational.po.FilesetPO;
+import org.apache.gravitino.storage.relational.po.FilesetVersionPO;
 import org.apache.ibatis.annotations.DeleteProvider;
 import org.apache.ibatis.annotations.InsertProvider;
+import org.apache.ibatis.annotations.Many;
 import org.apache.ibatis.annotations.Param;
 import org.apache.ibatis.annotations.Result;
 import org.apache.ibatis.annotations.Results;
+import org.apache.ibatis.annotations.Select;
 import org.apache.ibatis.annotations.SelectProvider;
 import org.apache.ibatis.annotations.UpdateProvider;
 
@@ -42,8 +45,26 @@ public interface FilesetMetaMapper {
 
   String VERSION_TABLE_NAME = "fileset_version_info";
 
+  @Results(
+      id = "mapToFilesetVersionPO",
+      value = {
+        @Result(property = "id", column = "id", id = true),
+        @Result(property = "metalakeId", column = "version_metalake_id"),
+        @Result(property = "catalogId", column = "version_catalog_id"),
+        @Result(property = "schemaId", column = "version_schema_id"),
+        @Result(property = "filesetId", column = "version_fileset_id"),
+        @Result(property = "version", column = "version"),
+        @Result(property = "filesetComment", column = "fileset_comment"),
+        @Result(property = "properties", column = "properties"),
+        @Result(property = "locationName", column = "storage_location_name"),
+        @Result(property = "storageLocation", column = "storage_location"),
+        @Result(property = "deletedAt", column = "version_deleted_at")
+      })
+  @Select("SELECT 1") // Dummy SQL to avoid MyBatis error, never be executed
+  FilesetVersionPO mapToFilesetVersionPO();
+
   @Results({
-    @Result(property = "filesetId", column = "fileset_id"),
+    @Result(property = "filesetId", column = "fileset_id", id = true),
     @Result(property = "filesetName", column = "fileset_name"),
     @Result(property = "metalakeId", column = "metalake_id"),
     @Result(property = "catalogId", column = "catalog_id"),
@@ -53,22 +74,19 @@ public interface FilesetMetaMapper {
     @Result(property = "currentVersion", column = "current_version"),
     @Result(property = "lastVersion", column = "last_version"),
     @Result(property = "deletedAt", column = "deleted_at"),
-    @Result(property = "filesetVersionPO.id", column = "id"),
-    @Result(property = "filesetVersionPO.metalakeId", column = "version_metalake_id"),
-    @Result(property = "filesetVersionPO.catalogId", column = "version_catalog_id"),
-    @Result(property = "filesetVersionPO.schemaId", column = "version_schema_id"),
-    @Result(property = "filesetVersionPO.filesetId", column = "version_fileset_id"),
-    @Result(property = "filesetVersionPO.version", column = "version"),
-    @Result(property = "filesetVersionPO.filesetComment", column = "fileset_comment"),
-    @Result(property = "filesetVersionPO.properties", column = "properties"),
-    @Result(property = "filesetVersionPO.storageLocation", column = "storage_location"),
-    @Result(property = "filesetVersionPO.deletedAt", column = "version_deleted_at")
+    @Result(
+        property = "filesetVersionPOs",
+        javaType = List.class,
+        column =
+            "{id,version_metalake_id,version_catalog_id,version_schema_id,version_fileset_id,version,"
+                + "fileset_comment,properties,storage_location_name,storage_location,version_deleted_at}",
+        many = @Many(resultMap = "mapToFilesetVersionPO"))
   })
   @SelectProvider(type = FilesetMetaSQLProviderFactory.class, method = "listFilesetPOsBySchemaId")
   List<FilesetPO> listFilesetPOsBySchemaId(@Param("schemaId") Long schemaId);
 
   @Results({
-    @Result(property = "filesetId", column = "fileset_id"),
+    @Result(property = "filesetId", column = "fileset_id", id = true),
     @Result(property = "filesetName", column = "fileset_name"),
     @Result(property = "metalakeId", column = "metalake_id"),
     @Result(property = "catalogId", column = "catalog_id"),
@@ -78,16 +96,13 @@ public interface FilesetMetaMapper {
     @Result(property = "currentVersion", column = "current_version"),
     @Result(property = "lastVersion", column = "last_version"),
     @Result(property = "deletedAt", column = "deleted_at"),
-    @Result(property = "filesetVersionPO.id", column = "id"),
-    @Result(property = "filesetVersionPO.metalakeId", column = "version_metalake_id"),
-    @Result(property = "filesetVersionPO.catalogId", column = "version_catalog_id"),
-    @Result(property = "filesetVersionPO.schemaId", column = "version_schema_id"),
-    @Result(property = "filesetVersionPO.filesetId", column = "version_fileset_id"),
-    @Result(property = "filesetVersionPO.version", column = "version"),
-    @Result(property = "filesetVersionPO.filesetComment", column = "fileset_comment"),
-    @Result(property = "filesetVersionPO.properties", column = "properties"),
-    @Result(property = "filesetVersionPO.storageLocation", column = "storage_location"),
-    @Result(property = "filesetVersionPO.deletedAt", column = "version_deleted_at")
+    @Result(
+        property = "filesetVersionPOs",
+        javaType = List.class,
+        column =
+            "{id,version_metalake_id,version_catalog_id,version_schema_id,version_fileset_id,version,"
+                + "fileset_comment,properties,storage_location_name,storage_location,version_deleted_at}",
+        many = @Many(resultMap = "mapToFilesetVersionPO"))
   })
   @SelectProvider(type = FilesetMetaSQLProviderFactory.class, method = "listFilesetPOsByFilesetIds")
   List<FilesetPO> listFilesetPOsByFilesetIds(@Param("filesetIds") List<Long> filesetIds);
@@ -99,7 +114,7 @@ public interface FilesetMetaMapper {
       @Param("schemaId") Long schemaId, @Param("filesetName") String name);
 
   @Results({
-    @Result(property = "filesetId", column = "fileset_id"),
+    @Result(property = "filesetId", column = "fileset_id", id = true),
     @Result(property = "filesetName", column = "fileset_name"),
     @Result(property = "metalakeId", column = "metalake_id"),
     @Result(property = "catalogId", column = "catalog_id"),
@@ -109,16 +124,13 @@ public interface FilesetMetaMapper {
     @Result(property = "currentVersion", column = "current_version"),
     @Result(property = "lastVersion", column = "last_version"),
     @Result(property = "deletedAt", column = "deleted_at"),
-    @Result(property = "filesetVersionPO.id", column = "id"),
-    @Result(property = "filesetVersionPO.metalakeId", column = "version_metalake_id"),
-    @Result(property = "filesetVersionPO.catalogId", column = "version_catalog_id"),
-    @Result(property = "filesetVersionPO.schemaId", column = "version_schema_id"),
-    @Result(property = "filesetVersionPO.filesetId", column = "version_fileset_id"),
-    @Result(property = "filesetVersionPO.version", column = "version"),
-    @Result(property = "filesetVersionPO.filesetComment", column = "fileset_comment"),
-    @Result(property = "filesetVersionPO.properties", column = "properties"),
-    @Result(property = "filesetVersionPO.storageLocation", column = "storage_location"),
-    @Result(property = "filesetVersionPO.deletedAt", column = "version_deleted_at")
+    @Result(
+        property = "filesetVersionPOs",
+        javaType = List.class,
+        column =
+            "{id,version_metalake_id,version_catalog_id,version_schema_id,version_fileset_id,version,"
+                + "fileset_comment,properties,storage_location_name,storage_location,version_deleted_at}",
+        many = @Many(resultMap = "mapToFilesetVersionPO"))
   })
   @SelectProvider(
       type = FilesetMetaSQLProviderFactory.class,
@@ -127,7 +139,7 @@ public interface FilesetMetaMapper {
       @Param("schemaId") Long schemaId, @Param("filesetName") String name);
 
   @Results({
-    @Result(property = "filesetId", column = "fileset_id"),
+    @Result(property = "filesetId", column = "fileset_id", id = true),
     @Result(property = "filesetName", column = "fileset_name"),
     @Result(property = "metalakeId", column = "metalake_id"),
     @Result(property = "catalogId", column = "catalog_id"),
@@ -137,16 +149,13 @@ public interface FilesetMetaMapper {
     @Result(property = "currentVersion", column = "current_version"),
     @Result(property = "lastVersion", column = "last_version"),
     @Result(property = "deletedAt", column = "deleted_at"),
-    @Result(property = "filesetVersionPO.id", column = "id"),
-    @Result(property = "filesetVersionPO.metalakeId", column = "version_metalake_id"),
-    @Result(property = "filesetVersionPO.catalogId", column = "version_catalog_id"),
-    @Result(property = "filesetVersionPO.schemaId", column = "version_schema_id"),
-    @Result(property = "filesetVersionPO.filesetId", column = "version_fileset_id"),
-    @Result(property = "filesetVersionPO.version", column = "version"),
-    @Result(property = "filesetVersionPO.filesetComment", column = "fileset_comment"),
-    @Result(property = "filesetVersionPO.properties", column = "properties"),
-    @Result(property = "filesetVersionPO.storageLocation", column = "storage_location"),
-    @Result(property = "filesetVersionPO.deletedAt", column = "version_deleted_at")
+    @Result(
+        property = "filesetVersionPOs",
+        javaType = List.class,
+        column =
+            "{id,version_metalake_id,version_catalog_id,version_schema_id,version_fileset_id,version,"
+                + "fileset_comment,properties,storage_location_name,storage_location,version_deleted_at}",
+        many = @Many(resultMap = "mapToFilesetVersionPO"))
   })
   @SelectProvider(type = FilesetMetaSQLProviderFactory.class, method = "selectFilesetMetaById")
   FilesetPO selectFilesetMetaById(@Param("filesetId") Long filesetId);

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/FilesetVersionMapper.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/FilesetVersionMapper.java
@@ -39,14 +39,14 @@ import org.apache.ibatis.annotations.UpdateProvider;
 public interface FilesetVersionMapper {
   String VERSION_TABLE_NAME = "fileset_version_info";
 
-  @InsertProvider(type = FilesetVersionSQLProviderFactory.class, method = "insertFilesetVersion")
-  void insertFilesetVersion(@Param("filesetVersion") FilesetVersionPO filesetVersionPO);
+  @InsertProvider(type = FilesetVersionSQLProviderFactory.class, method = "insertFilesetVersions")
+  void insertFilesetVersions(@Param("filesetVersions") List<FilesetVersionPO> filesetVersionPOs);
 
   @InsertProvider(
       type = FilesetVersionSQLProviderFactory.class,
-      method = "insertFilesetVersionOnDuplicateKeyUpdate")
-  void insertFilesetVersionOnDuplicateKeyUpdate(
-      @Param("filesetVersion") FilesetVersionPO filesetVersionPO);
+      method = "insertFilesetVersionsOnDuplicateKeyUpdate")
+  void insertFilesetVersionsOnDuplicateKeyUpdate(
+      @Param("filesetVersions") List<FilesetVersionPO> filesetVersionPOs);
 
   @UpdateProvider(
       type = FilesetVersionSQLProviderFactory.class,

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/FilesetVersionSQLProviderFactory.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/FilesetVersionSQLProviderFactory.java
@@ -19,6 +19,7 @@ package org.apache.gravitino.storage.relational.mapper;
  */
 
 import com.google.common.collect.ImmutableMap;
+import java.util.List;
 import java.util.Map;
 import org.apache.gravitino.storage.relational.JDBCBackend.JDBCBackendType;
 import org.apache.gravitino.storage.relational.mapper.provider.base.FilesetVersionBaseSQLProvider;
@@ -50,14 +51,14 @@ public class FilesetVersionSQLProviderFactory {
 
   static class FilesetVersionH2Provider extends FilesetVersionBaseSQLProvider {}
 
-  public static String insertFilesetVersion(
-      @Param("filesetVersion") FilesetVersionPO filesetVersionPO) {
-    return getProvider().insertFilesetVersion(filesetVersionPO);
+  public static String insertFilesetVersions(
+      @Param("filesetVersions") List<FilesetVersionPO> filesetVersionPOs) {
+    return getProvider().insertFilesetVersions(filesetVersionPOs);
   }
 
-  public static String insertFilesetVersionOnDuplicateKeyUpdate(
-      @Param("filesetVersion") FilesetVersionPO filesetVersionPO) {
-    return getProvider().insertFilesetVersionOnDuplicateKeyUpdate(filesetVersionPO);
+  public static String insertFilesetVersionsOnDuplicateKeyUpdate(
+      @Param("filesetVersions") List<FilesetVersionPO> filesetVersionPOs) {
+    return getProvider().insertFilesetVersionsOnDuplicateKeyUpdate(filesetVersionPOs);
   }
 
   public static String softDeleteFilesetVersionsByMetalakeId(@Param("metalakeId") Long metalakeId) {

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/FilesetMetaBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/FilesetMetaBaseSQLProvider.java
@@ -33,7 +33,7 @@ public class FilesetMetaBaseSQLProvider {
         + " fm.type, fm.audit_info, fm.current_version, fm.last_version, fm.deleted_at,"
         + " vi.id, vi.metalake_id as version_metalake_id, vi.catalog_id as version_catalog_id,"
         + " vi.schema_id as version_schema_id, vi.fileset_id as version_fileset_id,"
-        + " vi.version, vi.fileset_comment, vi.properties, vi.storage_location,"
+        + " vi.version, vi.fileset_comment, vi.properties, vi.storage_location_name, vi.storage_location,"
         + " vi.deleted_at as version_deleted_at"
         + " FROM "
         + META_TABLE_NAME
@@ -79,7 +79,7 @@ public class FilesetMetaBaseSQLProvider {
         + " fm.type, fm.audit_info, fm.current_version, fm.last_version, fm.deleted_at,"
         + " vi.id, vi.metalake_id as version_metalake_id, vi.catalog_id as version_catalog_id,"
         + " vi.schema_id as version_schema_id, vi.fileset_id as version_fileset_id,"
-        + " vi.version, vi.fileset_comment, vi.properties, vi.storage_location,"
+        + " vi.version, vi.fileset_comment, vi.properties, vi.storage_location_name, vi.storage_location,"
         + " vi.deleted_at as version_deleted_at"
         + " FROM "
         + META_TABLE_NAME
@@ -95,7 +95,7 @@ public class FilesetMetaBaseSQLProvider {
         + " fm.type, fm.audit_info, fm.current_version, fm.last_version, fm.deleted_at,"
         + " vi.id, vi.metalake_id as version_metalake_id, vi.catalog_id as version_catalog_id,"
         + " vi.schema_id as version_schema_id, vi.fileset_id as version_fileset_id,"
-        + " vi.version, vi.fileset_comment, vi.properties, vi.storage_location,"
+        + " vi.version, vi.fileset_comment, vi.properties, vi.storage_location_name, vi.storage_location,"
         + " vi.deleted_at as version_deleted_at"
         + " FROM "
         + META_TABLE_NAME

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/FilesetVersionBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/FilesetVersionBaseSQLProvider.java
@@ -20,57 +20,55 @@ package org.apache.gravitino.storage.relational.mapper.provider.base;
 
 import static org.apache.gravitino.storage.relational.mapper.FilesetVersionMapper.VERSION_TABLE_NAME;
 
+import java.util.List;
 import org.apache.gravitino.storage.relational.po.FilesetVersionPO;
 import org.apache.ibatis.annotations.Param;
 
 public class FilesetVersionBaseSQLProvider {
-  public String insertFilesetVersion(@Param("filesetVersion") FilesetVersionPO filesetVersionPO) {
-    return "INSERT INTO "
+
+  public String insertFilesetVersions(
+      @Param("filesetVersions") List<FilesetVersionPO> filesetVersionPOs) {
+    return "<script>"
+        + "INSERT INTO "
         + VERSION_TABLE_NAME
-        + "(metalake_id, catalog_id, schema_id, fileset_id,"
-        + " version, fileset_comment, properties, storage_location,"
+        + " (metalake_id, catalog_id, schema_id, fileset_id,"
+        + " version, fileset_comment, properties, storage_location_name, storage_location,"
         + " deleted_at)"
-        + " VALUES("
-        + " #{filesetVersion.metalakeId},"
-        + " #{filesetVersion.catalogId},"
-        + " #{filesetVersion.schemaId},"
-        + " #{filesetVersion.filesetId},"
-        + " #{filesetVersion.version},"
-        + " #{filesetVersion.filesetComment},"
-        + " #{filesetVersion.properties},"
-        + " #{filesetVersion.storageLocation},"
-        + " #{filesetVersion.deletedAt}"
-        + " )";
+        + " VALUES "
+        + "<foreach collection='filesetVersions' item='version' separator=','>"
+        + " (#{version.metalakeId}, #{version.catalogId}, #{version.schemaId}, #{version.filesetId},"
+        + " #{version.version}, #{version.filesetComment}, #{version.properties},"
+        + " #{version.locationName}, #{version.storageLocation}, #{version.deletedAt})"
+        + "</foreach>"
+        + "</script>";
   }
 
-  public String insertFilesetVersionOnDuplicateKeyUpdate(
-      @Param("filesetVersion") FilesetVersionPO filesetVersionPO) {
-    return "INSERT INTO "
+  public String insertFilesetVersionsOnDuplicateKeyUpdate(
+      @Param("filesetVersions") List<FilesetVersionPO> filesetVersionPOs) {
+    return "<script>"
+        + "INSERT INTO "
         + VERSION_TABLE_NAME
-        + "(metalake_id, catalog_id, schema_id, fileset_id,"
-        + " version, fileset_comment, properties, storage_location,"
+        + " (metalake_id, catalog_id, schema_id, fileset_id,"
+        + " version, fileset_comment, properties, storage_location_name, storage_location,"
         + " deleted_at)"
-        + " VALUES("
-        + " #{filesetVersion.metalakeId},"
-        + " #{filesetVersion.catalogId},"
-        + " #{filesetVersion.schemaId},"
-        + " #{filesetVersion.filesetId},"
-        + " #{filesetVersion.version},"
-        + " #{filesetVersion.filesetComment},"
-        + " #{filesetVersion.properties},"
-        + " #{filesetVersion.storageLocation},"
-        + " #{filesetVersion.deletedAt}"
-        + " )"
+        + " VALUES "
+        + "<foreach collection='filesetVersions' item='version' separator=','>"
+        + " (#{version.metalakeId}, #{version.catalogId}, #{version.schemaId}, #{version.filesetId},"
+        + " #{version.version}, #{version.filesetComment}, #{version.properties},"
+        + " #{version.locationName}, #{version.storageLocation}, #{version.deletedAt})"
+        + "</foreach>"
         + " ON DUPLICATE KEY UPDATE"
-        + " metalake_id = #{filesetVersion.metalakeId},"
-        + " catalog_id = #{filesetVersion.catalogId},"
-        + " schema_id = #{filesetVersion.schemaId},"
-        + " fileset_id = #{filesetVersion.filesetId},"
-        + " version = #{filesetVersion.version},"
-        + " fileset_comment = #{filesetVersion.filesetComment},"
-        + " properties = #{filesetVersion.properties},"
-        + " storage_location = #{filesetVersion.storageLocation},"
-        + " deleted_at = #{filesetVersion.deletedAt}";
+        + " metalake_id = VALUES(metalake_id),"
+        + " catalog_id = VALUES(catalog_id),"
+        + " schema_id = VALUES(schema_id),"
+        + " fileset_id = VALUES(fileset_id),"
+        + " version = VALUES(version),"
+        + " fileset_comment = VALUES(fileset_comment),"
+        + " properties = VALUES(properties),"
+        + " storage_location_name = VALUES(storage_location_name),"
+        + " storage_location = VALUES(storage_location),"
+        + " deleted_at = VALUES(deleted_at)"
+        + "</script>";
   }
 
   public String softDeleteFilesetVersionsByMetalakeId(@Param("metalakeId") Long metalakeId) {

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/FilesetVersionPostgreSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/FilesetVersionPostgreSQLProvider.java
@@ -20,6 +20,7 @@ package org.apache.gravitino.storage.relational.mapper.provider.postgresql;
 
 import static org.apache.gravitino.storage.relational.mapper.FilesetVersionMapper.VERSION_TABLE_NAME;
 
+import java.util.List;
 import org.apache.gravitino.storage.relational.mapper.provider.base.FilesetVersionBaseSQLProvider;
 import org.apache.gravitino.storage.relational.po.FilesetVersionPO;
 import org.apache.ibatis.annotations.Param;
@@ -82,32 +83,31 @@ public class FilesetVersionPostgreSQLProvider extends FilesetVersionBaseSQLProvi
   }
 
   @Override
-  public String insertFilesetVersionOnDuplicateKeyUpdate(FilesetVersionPO filesetVersionPO) {
-    return "INSERT INTO "
+  public String insertFilesetVersionsOnDuplicateKeyUpdate(
+      List<FilesetVersionPO> filesetVersionPOs) {
+    return "<script>"
+        + "INSERT INTO "
         + VERSION_TABLE_NAME
-        + "(metalake_id, catalog_id, schema_id, fileset_id,"
-        + " version, fileset_comment, properties, storage_location,"
+        + " (metalake_id, catalog_id, schema_id, fileset_id,"
+        + " version, fileset_comment, properties, storage_location_name, storage_location,"
         + " deleted_at)"
-        + " VALUES("
-        + " #{filesetVersion.metalakeId},"
-        + " #{filesetVersion.catalogId},"
-        + " #{filesetVersion.schemaId},"
-        + " #{filesetVersion.filesetId},"
-        + " #{filesetVersion.version},"
-        + " #{filesetVersion.filesetComment},"
-        + " #{filesetVersion.properties},"
-        + " #{filesetVersion.storageLocation},"
-        + " #{filesetVersion.deletedAt}"
-        + " )"
-        + " ON CONFLICT(fileset_id, version, deleted_at) DO UPDATE SET"
-        + " metalake_id = #{filesetVersion.metalakeId},"
-        + " catalog_id = #{filesetVersion.catalogId},"
-        + " schema_id = #{filesetVersion.schemaId},"
-        + " fileset_id = #{filesetVersion.filesetId},"
-        + " version = #{filesetVersion.version},"
-        + " fileset_comment = #{filesetVersion.filesetComment},"
-        + " properties = #{filesetVersion.properties},"
-        + " storage_location = #{filesetVersion.storageLocation},"
-        + " deleted_at = #{filesetVersion.deletedAt}";
+        + " VALUES "
+        + "<foreach collection='filesetVersions' item='version' separator=','>"
+        + " (#{version.metalakeId}, #{version.catalogId}, #{version.schemaId}, #{version.filesetId},"
+        + " #{version.version}, #{version.filesetComment}, #{version.properties},"
+        + " #{version.locationName}, #{version.storageLocation}, #{version.deletedAt})"
+        + "</foreach>"
+        + " ON CONFLICT(fileset_id, version, storage_location_name, deleted_at) DO UPDATE SET"
+        + " metalake_id = EXCLUDED.metalake_id,"
+        + " catalog_id = EXCLUDED.catalog_id,"
+        + " schema_id = EXCLUDED.schema_id,"
+        + " fileset_id = EXCLUDED.fileset_id,"
+        + " version = EXCLUDED.version,"
+        + " fileset_comment = EXCLUDED.fileset_comment,"
+        + " properties = EXCLUDED.properties,"
+        + " storage_location_name = EXCLUDED.storage_location_name,"
+        + " storage_location = EXCLUDED.storage_location,"
+        + " deleted_at = EXCLUDED.deleted_at"
+        + "</script>";
   }
 }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/po/FilesetPO.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/po/FilesetPO.java
@@ -20,6 +20,7 @@ package org.apache.gravitino.storage.relational.po;
 
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
+import java.util.List;
 
 public class FilesetPO {
   private Long filesetId;
@@ -32,7 +33,7 @@ public class FilesetPO {
   private Long currentVersion;
   private Long lastVersion;
   private Long deletedAt;
-  private FilesetVersionPO filesetVersionPO;
+  private List<FilesetVersionPO> filesetVersionPOs;
 
   public Long getFilesetId() {
     return filesetId;
@@ -74,8 +75,8 @@ public class FilesetPO {
     return deletedAt;
   }
 
-  public FilesetVersionPO getFilesetVersionPO() {
-    return filesetVersionPO;
+  public List<FilesetVersionPO> getFilesetVersionPOs() {
+    return filesetVersionPOs;
   }
 
   @Override
@@ -97,7 +98,7 @@ public class FilesetPO {
         && Objects.equal(getCurrentVersion(), filesetPO.getCurrentVersion())
         && Objects.equal(getLastVersion(), filesetPO.getLastVersion())
         && Objects.equal(getDeletedAt(), filesetPO.getDeletedAt())
-        && Objects.equal(getFilesetVersionPO(), filesetPO.getFilesetVersionPO());
+        && Objects.equal(getFilesetVersionPOs(), filesetPO.getFilesetVersionPOs());
   }
 
   @Override
@@ -113,7 +114,7 @@ public class FilesetPO {
         getCurrentVersion(),
         getLastVersion(),
         getDeletedAt(),
-        getFilesetVersionPO());
+        getFilesetVersionPOs());
   }
 
   public static class Builder {
@@ -173,8 +174,8 @@ public class FilesetPO {
       return this;
     }
 
-    public FilesetPO.Builder withFilesetVersionPO(FilesetVersionPO filesetVersionPO) {
-      filesetPO.filesetVersionPO = filesetVersionPO;
+    public FilesetPO.Builder withFilesetVersionPOs(List<FilesetVersionPO> filesetVersionPOs) {
+      filesetPO.filesetVersionPOs = filesetVersionPOs;
       return this;
     }
 
@@ -204,7 +205,8 @@ public class FilesetPO {
       Preconditions.checkArgument(filesetPO.lastVersion != null, "Last version is required");
       Preconditions.checkArgument(filesetPO.deletedAt != null, "Deleted at is required");
       Preconditions.checkArgument(
-          filesetPO.filesetVersionPO != null, "Fileset version is required");
+          filesetPO.filesetVersionPOs != null && !filesetPO.filesetVersionPOs.isEmpty(),
+          "Fileset version is required");
     }
 
     public FilesetPO build() {

--- a/core/src/main/java/org/apache/gravitino/storage/relational/po/FilesetVersionPO.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/po/FilesetVersionPO.java
@@ -31,6 +31,7 @@ public class FilesetVersionPO {
   private Long version;
   private String filesetComment;
   private String properties;
+  private String locationName;
   private String storageLocation;
   private Long deletedAt;
 
@@ -66,6 +67,10 @@ public class FilesetVersionPO {
     return properties;
   }
 
+  public String getLocationName() {
+    return locationName;
+  }
+
   public String getStorageLocation() {
     return storageLocation;
   }
@@ -91,6 +96,7 @@ public class FilesetVersionPO {
         && Objects.equal(getVersion(), that.getVersion())
         && Objects.equal(getFilesetComment(), that.getFilesetComment())
         && Objects.equal(getProperties(), that.getProperties())
+        && Objects.equal(getLocationName(), that.getLocationName())
         && Objects.equal(getStorageLocation(), that.getStorageLocation())
         && Objects.equal(getDeletedAt(), that.getDeletedAt());
   }
@@ -106,6 +112,7 @@ public class FilesetVersionPO {
         getVersion(),
         getFilesetComment(),
         getProperties(),
+        getLocationName(),
         getStorageLocation(),
         getDeletedAt());
   }
@@ -162,6 +169,11 @@ public class FilesetVersionPO {
       return this;
     }
 
+    public Builder withLocationName(String locationName) {
+      filesetVersionPO.locationName = locationName;
+      return this;
+    }
+
     public Builder withDeletedAt(Long deletedAt) {
       filesetVersionPO.deletedAt = deletedAt;
       return this;
@@ -173,6 +185,8 @@ public class FilesetVersionPO {
       Preconditions.checkArgument(filesetVersionPO.schemaId != null, "Schema id is required");
       Preconditions.checkArgument(filesetVersionPO.filesetId != null, "Fileset id is required");
       Preconditions.checkArgument(filesetVersionPO.version != null, "Fileset version is required");
+      Preconditions.checkArgument(
+          StringUtils.isNotBlank(filesetVersionPO.locationName), "Location name is required");
       Preconditions.checkArgument(
           StringUtils.isNotBlank(filesetVersionPO.storageLocation), "Storage location is required");
       Preconditions.checkArgument(filesetVersionPO.deletedAt != null, "Deleted at is required");

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/FilesetMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/FilesetMetaService.java
@@ -149,9 +149,9 @@ public class FilesetMetaService {
                   FilesetVersionMapper.class,
                   mapper -> {
                     if (overwrite) {
-                      mapper.insertFilesetVersionOnDuplicateKeyUpdate(po.getFilesetVersionPO());
+                      mapper.insertFilesetVersionsOnDuplicateKeyUpdate(po.getFilesetVersionPOs());
                     } else {
-                      mapper.insertFilesetVersion(po.getFilesetVersionPO());
+                      mapper.insertFilesetVersions(po.getFilesetVersionPOs());
                     }
                   }));
     } catch (RuntimeException re) {
@@ -183,7 +183,8 @@ public class FilesetMetaService {
     Integer updateResult;
     try {
       boolean checkNeedUpdateVersion =
-          POConverters.checkFilesetVersionNeedUpdate(oldFilesetPO.getFilesetVersionPO(), newEntity);
+          POConverters.checkFilesetVersionNeedUpdate(
+              oldFilesetPO.getFilesetVersionPOs(), newEntity);
       FilesetPO newFilesetPO =
           POConverters.updateFilesetPOWithVersion(oldFilesetPO, newEntity, checkNeedUpdateVersion);
       if (checkNeedUpdateVersion) {
@@ -196,7 +197,7 @@ public class FilesetMetaService {
             () ->
                 SessionUtils.doWithoutCommit(
                     FilesetVersionMapper.class,
-                    mapper -> mapper.insertFilesetVersion(newFilesetPO.getFilesetVersionPO())),
+                    mapper -> mapper.insertFilesetVersions(newFilesetPO.getFilesetVersionPOs())),
             () ->
                 SessionUtils.doWithoutCommit(
                     FilesetMetaMapper.class,

--- a/core/src/main/java/org/apache/gravitino/storage/relational/utils/POConverters.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/utils/POConverters.java
@@ -544,19 +544,24 @@ public class POConverters {
   public static FilesetPO initializeFilesetPOWithVersion(
       FilesetEntity filesetEntity, FilesetPO.Builder builder) {
     try {
-      FilesetVersionPO filesetVersionPO =
-          FilesetVersionPO.builder()
-              .withMetalakeId(builder.getFilesetMetalakeId())
-              .withCatalogId(builder.getFilesetCatalogId())
-              .withSchemaId(builder.getFilesetSchemaId())
-              .withFilesetId(filesetEntity.id())
-              .withVersion(INIT_VERSION)
-              .withFilesetComment(filesetEntity.comment())
-              .withStorageLocation(filesetEntity.storageLocation())
-              .withProperties(
-                  JsonUtils.anyFieldMapper().writeValueAsString(filesetEntity.properties()))
-              .withDeletedAt(DEFAULT_DELETED_AT)
-              .build();
+      String props = JsonUtils.anyFieldMapper().writeValueAsString(filesetEntity.properties());
+      List<FilesetVersionPO> filesetVersionPOs =
+          filesetEntity.storageLocations().entrySet().stream()
+              .map(
+                  entry ->
+                      FilesetVersionPO.builder()
+                          .withMetalakeId(builder.getFilesetMetalakeId())
+                          .withCatalogId(builder.getFilesetCatalogId())
+                          .withSchemaId(builder.getFilesetSchemaId())
+                          .withFilesetId(filesetEntity.id())
+                          .withVersion(INIT_VERSION)
+                          .withFilesetComment(filesetEntity.comment())
+                          .withLocationName(entry.getKey())
+                          .withStorageLocation(entry.getValue())
+                          .withProperties(props)
+                          .withDeletedAt(DEFAULT_DELETED_AT)
+                          .build())
+              .collect(Collectors.toList());
       return builder
           .withFilesetId(filesetEntity.id())
           .withFilesetName(filesetEntity.name())
@@ -565,7 +570,7 @@ public class POConverters {
           .withCurrentVersion(INIT_VERSION)
           .withLastVersion(INIT_VERSION)
           .withDeletedAt(DEFAULT_DELETED_AT)
-          .withFilesetVersionPO(filesetVersionPO)
+          .withFilesetVersionPOs(filesetVersionPOs)
           .build();
     } catch (JsonProcessingException e) {
       throw new RuntimeException("Failed to serialize json object:", e);
@@ -584,27 +589,32 @@ public class POConverters {
     try {
       Long lastVersion = oldFilesetPO.getLastVersion();
       Long currentVersion;
-      FilesetVersionPO newFilesetVersionPO;
+      List<FilesetVersionPO> newFilesetVersionPOs;
       // Will set the version to the last version + 1
       if (needUpdateVersion) {
         lastVersion++;
         currentVersion = lastVersion;
-        newFilesetVersionPO =
-            FilesetVersionPO.builder()
-                .withMetalakeId(oldFilesetPO.getMetalakeId())
-                .withCatalogId(oldFilesetPO.getCatalogId())
-                .withSchemaId(oldFilesetPO.getSchemaId())
-                .withFilesetId(newFileset.id())
-                .withVersion(currentVersion)
-                .withFilesetComment(newFileset.comment())
-                .withStorageLocation(newFileset.storageLocation())
-                .withProperties(
-                    JsonUtils.anyFieldMapper().writeValueAsString(newFileset.properties()))
-                .withDeletedAt(DEFAULT_DELETED_AT)
-                .build();
+        String props = JsonUtils.anyFieldMapper().writeValueAsString(newFileset.properties());
+        newFilesetVersionPOs =
+            newFileset.storageLocations().entrySet().stream()
+                .map(
+                    entry ->
+                        FilesetVersionPO.builder()
+                            .withMetalakeId(oldFilesetPO.getMetalakeId())
+                            .withCatalogId(oldFilesetPO.getCatalogId())
+                            .withSchemaId(oldFilesetPO.getSchemaId())
+                            .withFilesetId(newFileset.id())
+                            .withVersion(currentVersion)
+                            .withFilesetComment(newFileset.comment())
+                            .withLocationName(entry.getKey())
+                            .withStorageLocation(entry.getValue())
+                            .withProperties(props)
+                            .withDeletedAt(DEFAULT_DELETED_AT)
+                            .build())
+                .collect(Collectors.toList());
       } else {
         currentVersion = oldFilesetPO.getCurrentVersion();
-        newFilesetVersionPO = oldFilesetPO.getFilesetVersionPO();
+        newFilesetVersionPOs = oldFilesetPO.getFilesetVersionPOs();
       }
       return FilesetPO.builder()
           .withFilesetId(newFileset.id())
@@ -617,7 +627,7 @@ public class POConverters {
           .withCurrentVersion(currentVersion)
           .withLastVersion(lastVersion)
           .withDeletedAt(DEFAULT_DELETED_AT)
-          .withFilesetVersionPO(newFilesetVersionPO)
+          .withFilesetVersionPOs(newFilesetVersionPOs)
           .build();
     } catch (JsonProcessingException e) {
       throw new RuntimeException("Failed to serialize json object:", e);
@@ -625,16 +635,21 @@ public class POConverters {
   }
 
   public static boolean checkFilesetVersionNeedUpdate(
-      FilesetVersionPO oldFilesetVersionPO, FilesetEntity newFileset) {
-    if (!StringUtils.equals(oldFilesetVersionPO.getFilesetComment(), newFileset.comment())
-        || !StringUtils.equals(
-            oldFilesetVersionPO.getStorageLocation(), newFileset.storageLocation())) {
+      List<FilesetVersionPO> oldFilesetVersionPOs, FilesetEntity newFileset) {
+    Map<String, String> storageLocations =
+        oldFilesetVersionPOs.stream()
+            .collect(
+                Collectors.toMap(
+                    FilesetVersionPO::getLocationName, FilesetVersionPO::getStorageLocation));
+    if (!StringUtils.equals(oldFilesetVersionPOs.get(0).getFilesetComment(), newFileset.comment())
+        || !Objects.equals(storageLocations, newFileset.storageLocations())) {
       return true;
     }
 
     try {
       Map<String, String> oldProperties =
-          JsonUtils.anyFieldMapper().readValue(oldFilesetVersionPO.getProperties(), Map.class);
+          JsonUtils.anyFieldMapper()
+              .readValue(oldFilesetVersionPOs.get(0).getProperties(), Map.class);
       if (oldProperties == null) {
         return newFileset.properties() != null;
       }
@@ -652,17 +667,22 @@ public class POConverters {
    * @return FilesetEntity object from FilesetPO object
    */
   public static FilesetEntity fromFilesetPO(FilesetPO filesetPO, Namespace namespace) {
+    Map<String, String> storageLocations =
+        filesetPO.getFilesetVersionPOs().stream()
+            .collect(
+                Collectors.toMap(
+                    FilesetVersionPO::getLocationName, FilesetVersionPO::getStorageLocation));
     try {
       return FilesetEntity.builder()
           .withId(filesetPO.getFilesetId())
           .withName(filesetPO.getFilesetName())
           .withNamespace(namespace)
-          .withComment(filesetPO.getFilesetVersionPO().getFilesetComment())
+          .withComment(filesetPO.getFilesetVersionPOs().get(0).getFilesetComment())
           .withFilesetType(Fileset.Type.valueOf(filesetPO.getType()))
-          .withStorageLocation(filesetPO.getFilesetVersionPO().getStorageLocation())
+          .withStorageLocations(storageLocations)
           .withProperties(
               JsonUtils.anyFieldMapper()
-                  .readValue(filesetPO.getFilesetVersionPO().getProperties(), Map.class))
+                  .readValue(filesetPO.getFilesetVersionPOs().get(0).getProperties(), Map.class))
           .withAuditInfo(
               JsonUtils.anyFieldMapper().readValue(filesetPO.getAuditInfo(), AuditInfo.class))
           .build();

--- a/core/src/test/java/org/apache/gravitino/meta/TestEntity.java
+++ b/core/src/test/java/org/apache/gravitino/meta/TestEntity.java
@@ -18,6 +18,8 @@
  */
 package org.apache.gravitino.meta;
 
+import static org.apache.gravitino.file.Fileset.LOCATION_NAME_UNKNOWN;
+
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import java.time.Instant;
@@ -165,7 +167,7 @@ public class TestEntity {
             .withName(fileName)
             .withAuditInfo(auditInfo)
             .withFilesetType(Fileset.Type.MANAGED)
-            .withStorageLocation("testLocation")
+            .withStorageLocations(ImmutableMap.of(LOCATION_NAME_UNKNOWN, "testLocation"))
             .withProperties(map)
             .build();
 
@@ -176,7 +178,10 @@ public class TestEntity {
     Assertions.assertEquals(Fileset.Type.MANAGED, fields.get(FilesetEntity.TYPE));
     Assertions.assertEquals(map, fields.get(FilesetEntity.PROPERTIES));
     Assertions.assertNull(fields.get(FilesetEntity.COMMENT));
-    Assertions.assertEquals("testLocation", fields.get(FilesetEntity.STORAGE_LOCATION));
+    Assertions.assertEquals(
+        "testLocation",
+        ((Map<String, String>) fields.get(FilesetEntity.STORAGE_LOCATIONS))
+            .get(LOCATION_NAME_UNKNOWN));
 
     FilesetEntity testFile1 =
         FilesetEntity.builder()
@@ -185,7 +190,7 @@ public class TestEntity {
             .withAuditInfo(auditInfo)
             .withFilesetType(Fileset.Type.MANAGED)
             .withComment("testComment")
-            .withStorageLocation("testLocation")
+            .withStorageLocations(ImmutableMap.of(LOCATION_NAME_UNKNOWN, "testLocation"))
             .build();
     Assertions.assertEquals("testComment", testFile1.comment());
     Assertions.assertNull(testFile1.properties());
@@ -193,17 +198,17 @@ public class TestEntity {
     Throwable exception =
         Assertions.assertThrows(
             IllegalArgumentException.class,
-            () -> {
-              FilesetEntity.builder()
-                  .withId(fileId)
-                  .withName(fileName)
-                  .withAuditInfo(auditInfo)
-                  .withFilesetType(Fileset.Type.EXTERNAL)
-                  .withProperties(map)
-                  .withComment("testComment")
-                  .build();
-            });
-    Assertions.assertEquals("Field storage_location is required", exception.getMessage());
+            () ->
+                FilesetEntity.builder()
+                    .withId(fileId)
+                    .withName(fileName)
+                    .withAuditInfo(auditInfo)
+                    .withFilesetType(Fileset.Type.EXTERNAL)
+                    .withProperties(map)
+                    .withComment("testComment")
+                    .build());
+    Assertions.assertEquals(
+        "The storage locations of the fileset entity must not be empty.", exception.getMessage());
   }
 
   @Test

--- a/core/src/test/java/org/apache/gravitino/storage/TestEntityStorage.java
+++ b/core/src/test/java/org/apache/gravitino/storage/TestEntityStorage.java
@@ -32,6 +32,7 @@ import static org.apache.gravitino.Configs.ENTITY_STORE;
 import static org.apache.gravitino.Configs.RELATIONAL_ENTITY_STORE;
 import static org.apache.gravitino.Configs.STORE_DELETE_AFTER_TIME;
 import static org.apache.gravitino.Configs.VERSION_RETENTION_COUNT;
+import static org.apache.gravitino.file.Fileset.LOCATION_NAME_UNKNOWN;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
@@ -1468,7 +1469,7 @@ public class TestEntityStorage {
         .withName(name)
         .withNamespace(namespace)
         .withFilesetType(Fileset.Type.MANAGED)
-        .withStorageLocation("/tmp")
+        .withStorageLocations(ImmutableMap.of(LOCATION_NAME_UNKNOWN, "/tmp"))
         .withComment("")
         .withProperties(null)
         .withAuditInfo(auditInfo)

--- a/core/src/test/java/org/apache/gravitino/storage/memory/TestMemoryEntityStore.java
+++ b/core/src/test/java/org/apache/gravitino/storage/memory/TestMemoryEntityStore.java
@@ -18,6 +18,9 @@
  */
 package org.apache.gravitino.storage.memory;
 
+import static org.apache.gravitino.file.Fileset.LOCATION_NAME_UNKNOWN;
+
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import java.io.IOException;
@@ -209,7 +212,7 @@ public class TestMemoryEntityStore {
             .withId(1L)
             .withName("fileset")
             .withFilesetType(Fileset.Type.MANAGED)
-            .withStorageLocation("file:/tmp")
+            .withStorageLocations(ImmutableMap.of(LOCATION_NAME_UNKNOWN, "file:/tmp"))
             .withNamespace(Namespace.of("metalake", "catalog", "db"))
             .withAuditInfo(auditInfo)
             .build();

--- a/core/src/test/java/org/apache/gravitino/storage/relational/TestJDBCBackend.java
+++ b/core/src/test/java/org/apache/gravitino/storage/relational/TestJDBCBackend.java
@@ -29,6 +29,7 @@ import static org.apache.gravitino.Configs.ENTITY_RELATIONAL_STORE;
 import static org.apache.gravitino.Configs.ENTITY_STORE;
 import static org.apache.gravitino.Configs.RELATIONAL_ENTITY_STORE;
 import static org.apache.gravitino.SupportsRelationOperations.Type.OWNER_REL;
+import static org.apache.gravitino.file.Fileset.LOCATION_NAME_UNKNOWN;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -94,21 +95,23 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.mockito.Mockito;
 
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class TestJDBCBackend {
-  private static final String JDBC_STORE_PATH =
+  private final String JDBC_STORE_PATH =
       "/tmp/gravitino_jdbc_entityStore_" + UUID.randomUUID().toString().replace("-", "");
-  private static final String DB_DIR = JDBC_STORE_PATH + "/testdb";
-  private static final String H2_FILE = DB_DIR + ".mv.db";
-  private static final Config config = Mockito.mock(Config.class);
-  public static final ImmutableMap<String, String> RELATIONAL_BACKENDS =
+  private final String DB_DIR = JDBC_STORE_PATH + "/testdb";
+  private final String H2_FILE = DB_DIR + ".mv.db";
+  private final Config config = Mockito.mock(Config.class);
+  public final ImmutableMap<String, String> RELATIONAL_BACKENDS =
       ImmutableMap.of(
           Configs.DEFAULT_ENTITY_RELATIONAL_STORE, JDBCBackend.class.getCanonicalName());
-  public static RelationalBackend backend;
+  protected RelationalBackend backend;
 
   @BeforeAll
-  public static void setup() {
+  public void setup() {
     File dir = new File(DB_DIR);
     dir.deleteOnExit();
     if (dir.exists() || !dir.isDirectory()) {
@@ -139,7 +142,7 @@ public class TestJDBCBackend {
   }
 
   @AfterAll
-  public static void tearDown() throws IOException {
+  public void tearDown() throws IOException {
     dropAllTables();
     File dir = new File(DB_DIR);
     if (dir.exists()) {
@@ -1355,7 +1358,7 @@ public class TestJDBCBackend {
         .withName(name)
         .withNamespace(namespace)
         .withFilesetType(Fileset.Type.MANAGED)
-        .withStorageLocation("/tmp")
+        .withStorageLocations(ImmutableMap.of(LOCATION_NAME_UNKNOWN, "/tmp"))
         .withComment("")
         .withProperties(new HashMap<>())
         .withAuditInfo(auditInfo)

--- a/core/src/test/java/org/apache/gravitino/storage/relational/service/TestFilesetMetaService.java
+++ b/core/src/test/java/org/apache/gravitino/storage/relational/service/TestFilesetMetaService.java
@@ -18,9 +18,10 @@
  */
 package org.apache.gravitino.storage.relational.service;
 
+import static org.apache.gravitino.file.Fileset.LOCATION_NAME_UNKNOWN;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.google.common.collect.Lists;
 import java.io.File;
 import java.io.IOException;
 import java.sql.Connection;
@@ -30,8 +31,10 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.time.Instant;
 import java.util.Arrays;
-import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -41,6 +44,7 @@ import org.apache.gravitino.Configs;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
 import org.apache.gravitino.config.ConfigConstants;
+import org.apache.gravitino.exceptions.NoSuchEntityException;
 import org.apache.gravitino.file.Fileset;
 import org.apache.gravitino.integration.test.container.ContainerSuite;
 import org.apache.gravitino.integration.test.container.MySQLContainer;
@@ -57,23 +61,33 @@ import org.apache.gravitino.storage.RandomIdGenerator;
 import org.apache.gravitino.storage.relational.session.SqlSessionFactoryHelper;
 import org.apache.gravitino.utils.NamespaceUtil;
 import org.apache.ibatis.session.SqlSession;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.testcontainers.shaded.com.google.common.collect.ImmutableMap;
+import org.testcontainers.shaded.org.apache.commons.lang3.tuple.Pair;
 
 @Tag("gravitino-docker-test")
+@EnabledIfEnvironmentVariable(named = "jdbcBackend", matches = "MySQL")
 public class TestFilesetMetaService {
   private static final Logger LOG = LoggerFactory.getLogger(TestFilesetMetaService.class);
   private static final ContainerSuite containerSuite = ContainerSuite.getInstance();
+  private static final IdGenerator idGenerator = new RandomIdGenerator();
+
+  private static final AuditInfo auditInfo =
+      AuditInfo.builder().withCreator("creator").withCreateTime(Instant.now()).build();
+  private static final String metalakeName = GravitinoITUtils.genRandomName("tst_metalake");
+  private static final String catalogName = GravitinoITUtils.genRandomName("tst_fs_catalog");
+  private static final String schemaName = GravitinoITUtils.genRandomName("tst_fs_schema");
 
   @BeforeAll
-  public static void setup() {
-    Assumptions.assumeTrue("MySQL".equals(System.getenv("jdbcBackend")));
+  public static void setup() throws IOException {
     TestDatabaseName META_DATA = TestDatabaseName.MYSQL_JDBC_BACKEND;
     containerSuite.startMySQLContainer(META_DATA);
     MySQLContainer MYSQL_CONTAINER = containerSuite.getMySQLContainer();
@@ -118,31 +132,13 @@ public class TestFilesetMetaService {
     Mockito.when(config.get(Configs.ENTITY_RELATIONAL_JDBC_BACKEND_PASSWORD)).thenReturn("root");
 
     SqlSessionFactoryHelper.getInstance().init(config);
+
+    prepareMetalake();
+    prepareCatalog();
+    prepareSchema();
   }
 
-  @AfterAll
-  public static void tearDown() {}
-
-  @Test
-  public void testDeleteFilesetVersionsByRetentionCount() throws IOException {
-    Assumptions.assumeTrue("MySQL".equals(System.getenv("jdbcBackend")));
-    IdGenerator idGenerator = new RandomIdGenerator();
-    AuditInfo auditInfo =
-        AuditInfo.builder().withCreator("creator").withCreateTime(Instant.now()).build();
-    String metalakeName = GravitinoITUtils.genRandomName("tst_metalake");
-    BaseMetalake metalake = createBaseMakeLake(idGenerator.nextId(), metalakeName, auditInfo);
-    MetalakeMetaService.getInstance().insertMetalake(metalake, true);
-    assertNotNull(
-        MetalakeMetaService.getInstance().getMetalakeByIdentifier(NameIdentifier.of(metalakeName)));
-    String catalogName = GravitinoITUtils.genRandomName("tst_fs_catalog");
-    CatalogEntity catalogEntity =
-        createCatalog(
-            idGenerator.nextId(), NamespaceUtil.ofCatalog(metalakeName), catalogName, auditInfo);
-    CatalogMetaService.getInstance().insertCatalog(catalogEntity, true);
-    assertNotNull(
-        CatalogMetaService.getInstance()
-            .getCatalogByIdentifier(NameIdentifier.of(metalakeName, catalogName)));
-    String schemaName = GravitinoITUtils.genRandomName("tst_fs_schema");
+  private static void prepareSchema() throws IOException {
     SchemaEntity schemaEntity =
         createSchemaEntity(
             idGenerator.nextId(),
@@ -153,6 +149,120 @@ public class TestFilesetMetaService {
     assertNotNull(
         SchemaMetaService.getInstance()
             .getSchemaByIdentifier(NameIdentifier.of(metalakeName, catalogName, schemaName)));
+  }
+
+  private static void prepareMetalake() throws IOException {
+    BaseMetalake metalake = createBaseMakeLake(idGenerator.nextId(), metalakeName, auditInfo);
+    MetalakeMetaService.getInstance().insertMetalake(metalake, true);
+    assertNotNull(
+        MetalakeMetaService.getInstance().getMetalakeByIdentifier(NameIdentifier.of(metalakeName)));
+  }
+
+  private static void prepareCatalog() throws IOException {
+    CatalogEntity catalogEntity =
+        createCatalog(
+            idGenerator.nextId(), NamespaceUtil.ofCatalog(metalakeName), catalogName, auditInfo);
+    CatalogMetaService.getInstance().insertCatalog(catalogEntity, true);
+    assertNotNull(
+        CatalogMetaService.getInstance()
+            .getCatalogByIdentifier(NameIdentifier.of(metalakeName, catalogName)));
+  }
+
+  @AfterEach
+  public void cleanFilesets() throws IOException {
+    SchemaMetaService.getInstance()
+        .deleteSchema(NameIdentifier.of(metalakeName, catalogName, schemaName), true);
+    prepareSchema();
+  }
+
+  @Test
+  public void testFilesetMultipleLocations() {
+    // test create
+    String filesetName = GravitinoITUtils.genRandomName("multiple_location_fileset");
+    NameIdentifier filesetIdent =
+        NameIdentifier.of(metalakeName, catalogName, schemaName, filesetName);
+    String locationName = "location1";
+    Map<String, String> locations =
+        ImmutableMap.of(LOCATION_NAME_UNKNOWN, "/tmp", locationName, "/tmp2");
+    Namespace filesetNs = NamespaceUtil.ofFileset(metalakeName, catalogName, schemaName);
+    FilesetEntity filesetEntity =
+        FilesetEntity.builder()
+            .withId(idGenerator.nextId())
+            .withName(filesetName)
+            .withNamespace(filesetNs)
+            .withFilesetType(Fileset.Type.MANAGED)
+            .withStorageLocations(locations)
+            .withComment("")
+            .withProperties(null)
+            .withAuditInfo(auditInfo)
+            .build();
+    Assertions.assertDoesNotThrow(
+        () -> FilesetMetaService.getInstance().insertFileset(filesetEntity, true));
+
+    // test load
+    FilesetEntity loadedFilesetEntity =
+        FilesetMetaService.getInstance().getFilesetByIdentifier(filesetIdent);
+    Assertions.assertEquals(filesetEntity, loadedFilesetEntity);
+
+    // test update
+    Map<String, String> newProps = ImmutableMap.of("k1", "v1", "k2", "v2");
+    FilesetEntity updatedFilesetEntity =
+        FilesetEntity.builder()
+            .withId(loadedFilesetEntity.id())
+            .withName(loadedFilesetEntity.name())
+            .withNamespace(loadedFilesetEntity.namespace())
+            .withFilesetType(loadedFilesetEntity.filesetType())
+            .withStorageLocations(loadedFilesetEntity.storageLocations())
+            .withComment(loadedFilesetEntity.comment())
+            .withProperties(newProps)
+            .withAuditInfo(
+                AuditInfo.builder().withCreator("creator2").withCreateTime(Instant.now()).build())
+            .build();
+    Assertions.assertDoesNotThrow(
+        () ->
+            FilesetMetaService.getInstance()
+                .updateFileset(filesetIdent, e -> updatedFilesetEntity));
+    FilesetEntity updatedLoadedFilesetEntity =
+        FilesetMetaService.getInstance().getFilesetByIdentifier(filesetIdent);
+    Assertions.assertEquals(updatedFilesetEntity, updatedLoadedFilesetEntity);
+
+    // test list
+    String filesetName2 = GravitinoITUtils.genRandomName("multiple_location_fileset2");
+    NameIdentifier filesetIdent2 =
+        NameIdentifier.of(metalakeName, catalogName, schemaName, filesetName2);
+    FilesetEntity filesetEntity2 =
+        FilesetEntity.builder()
+            .withId(idGenerator.nextId())
+            .withName(filesetName2)
+            .withNamespace(filesetNs)
+            .withFilesetType(Fileset.Type.MANAGED)
+            .withStorageLocations(locations)
+            .withComment("")
+            .withProperties(null)
+            .withAuditInfo(auditInfo)
+            .build();
+    Assertions.assertDoesNotThrow(
+        () -> FilesetMetaService.getInstance().insertFileset(filesetEntity2, true));
+    int count = FilesetMetaService.getInstance().listFilesetsByNamespace(filesetNs).size();
+    Assertions.assertEquals(2, count);
+
+    // test delete
+    Assertions.assertDoesNotThrow(
+        () -> FilesetMetaService.getInstance().deleteFileset(filesetIdent2));
+    Assertions.assertThrows(
+        NoSuchEntityException.class,
+        () -> FilesetMetaService.getInstance().getFilesetByIdentifier(filesetIdent2));
+    List<Pair<Integer, String>> versionInfos = listFilesetInvalidVersions(filesetEntity2.id());
+    Assertions.assertEquals(2, versionInfos.size());
+    Assertions.assertEquals(1, versionInfos.get(0).getLeft());
+    Set<String> locationNames =
+        versionInfos.stream().map(Pair::getRight).collect(Collectors.toSet());
+    Assertions.assertTrue(locationNames.contains(LOCATION_NAME_UNKNOWN));
+    Assertions.assertTrue(locationNames.contains(locationName));
+  }
+
+  @Test
+  public void testDeleteFilesetVersionsByRetentionCount() throws IOException {
     String filesetName = GravitinoITUtils.genRandomName("tst_fs_fileset");
     FilesetEntity filesetEntity =
         createFilesetEntity(
@@ -180,13 +290,15 @@ public class TestFilesetMetaService {
                   "/tmp1");
             });
     FilesetMetaService.getInstance().deleteFilesetVersionsByRetentionCount(1L, 100);
-    Map<Integer, Long> versionInfo = listFilesetValidVersions(filesetEntity.id());
+    List<Pair<Integer, String>> versionInfos = listFilesetInvalidVersions(filesetEntity.id());
     // version 1 should be softly deleted
-    assertTrue(versionInfo.get(1) > 0);
+    Assertions.assertEquals(1, versionInfos.size());
+    Assertions.assertEquals(1, versionInfos.get(0).getLeft());
+    Assertions.assertEquals(LOCATION_NAME_UNKNOWN, versionInfos.get(0).getRight());
   }
 
-  private Map<Integer, Long> listFilesetValidVersions(Long filesetId) {
-    Map<Integer, Long> versionDeletedTime = new HashMap<>();
+  private List<Pair<Integer, String>> listFilesetInvalidVersions(Long filesetId) {
+    List<Pair<Integer, String>> deletedVersions = Lists.newArrayList();
     try (SqlSession sqlSession =
             SqlSessionFactoryHelper.getInstance().getSqlSessionFactory().openSession(true);
         Connection connection = sqlSession.getConnection();
@@ -194,15 +306,15 @@ public class TestFilesetMetaService {
         ResultSet rs =
             statement.executeQuery(
                 String.format(
-                    "SELECT version, deleted_at FROM fileset_version_info WHERE fileset_id = %d",
+                    "SELECT version, storage_location_name FROM fileset_version_info WHERE fileset_id = %d and deleted_at > 0",
                     filesetId))) {
       while (rs.next()) {
-        versionDeletedTime.put(rs.getInt("version"), rs.getLong("deleted_at"));
+        deletedVersions.add(Pair.of(rs.getInt("version"), rs.getString("storage_location_name")));
       }
     } catch (SQLException e) {
       throw new RuntimeException("SQL execution failed", e);
     }
-    return versionDeletedTime;
+    return deletedVersions;
   }
 
   public static BaseMetalake createBaseMakeLake(Long id, String name, AuditInfo auditInfo) {
@@ -249,7 +361,7 @@ public class TestFilesetMetaService {
         .withName(name)
         .withNamespace(namespace)
         .withFilesetType(Fileset.Type.MANAGED)
-        .withStorageLocation(location)
+        .withStorageLocations(ImmutableMap.of(LOCATION_NAME_UNKNOWN, location))
         .withComment("")
         .withProperties(null)
         .withAuditInfo(auditInfo)

--- a/scripts/h2/schema-0.9.0-h2.sql
+++ b/scripts/h2/schema-0.9.0-h2.sql
@@ -1,0 +1,339 @@
+--
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file--
+--  distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"). You may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--  http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+--
+
+CREATE TABLE IF NOT EXISTS `metalake_meta` (
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `metalake_name` VARCHAR(128) NOT NULL COMMENT 'metalake name',
+    `metalake_comment` VARCHAR(256) DEFAULT '' COMMENT 'metalake comment',
+    `properties` MEDIUMTEXT DEFAULT NULL COMMENT 'metalake properties',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'metalake audit info',
+    `schema_version` MEDIUMTEXT NOT NULL COMMENT 'metalake schema version info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'metalake current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'metalake last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'metalake deleted at',
+    PRIMARY KEY (metalake_id),
+    CONSTRAINT uk_mn_del UNIQUE (metalake_name, deleted_at)
+) ENGINE = InnoDB;
+
+
+CREATE TABLE IF NOT EXISTS `catalog_meta` (
+    `catalog_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'catalog id',
+    `catalog_name` VARCHAR(128) NOT NULL COMMENT 'catalog name',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `type` VARCHAR(64) NOT NULL COMMENT 'catalog type',
+    `provider` VARCHAR(64) NOT NULL COMMENT 'catalog provider',
+    `catalog_comment` VARCHAR(256) DEFAULT '' COMMENT 'catalog comment',
+    `properties` MEDIUMTEXT DEFAULT NULL COMMENT 'catalog properties',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'catalog audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'catalog current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'catalog last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'catalog deleted at',
+    PRIMARY KEY (catalog_id),
+    CONSTRAINT uk_mid_cn_del UNIQUE (metalake_id, catalog_name, deleted_at)
+) ENGINE=InnoDB;
+
+
+CREATE TABLE IF NOT EXISTS `schema_meta` (
+    `schema_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'schema id',
+    `schema_name` VARCHAR(128) NOT NULL COMMENT 'schema name',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `catalog_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'catalog id',
+    `schema_comment` VARCHAR(256) DEFAULT '' COMMENT 'schema comment',
+    `properties` MEDIUMTEXT DEFAULT NULL COMMENT 'schema properties',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'schema audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'schema current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'schema last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'schema deleted at',
+    PRIMARY KEY (schema_id),
+    CONSTRAINT uk_cid_sn_del UNIQUE (catalog_id, schema_name, deleted_at),
+    -- Aliases are used here, and indexes with the same name in H2 can only be created once.
+    KEY idx_smid (metalake_id)
+) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS `table_meta` (
+    `table_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'table id',
+    `table_name` VARCHAR(128) NOT NULL COMMENT 'table name',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `catalog_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'catalog id',
+    `schema_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'schema id',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'table audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'table current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'table last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'table deleted at',
+    PRIMARY KEY (table_id),
+    CONSTRAINT uk_sid_tn_del UNIQUE (schema_id, table_name, deleted_at),
+    -- Aliases are used here, and indexes with the same name in H2 can only be created once.
+    KEY idx_tmid (metalake_id),
+    KEY idx_tcid (catalog_id)
+) ENGINE=InnoDB;
+
+
+CREATE TABLE IF NOT EXISTS `table_column_version_info` (
+    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'auto increment id',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `catalog_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'catalog id',
+    `schema_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'schema id',
+    `table_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'table id',
+    `table_version` INT UNSIGNED NOT NULL COMMENT 'table version',
+    `column_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'column id',
+    `column_name` VARCHAR(128) NOT NULL COMMENT 'column name',
+    `column_position` INT UNSIGNED NOT NULL COMMENT 'column position, starting from 0',
+    `column_type` TEXT NOT NULL COMMENT 'column type',
+    `column_comment` VARCHAR(256) DEFAULT '' COMMENT 'column comment',
+    `column_nullable` TINYINT(1) NOT NULL DEFAULT 1 COMMENT 'column nullable, 0 is not nullable, 1 is nullable',
+    `column_auto_increment` TINYINT(1) NOT NULL DEFAULT 0 COMMENT 'column auto increment, 0 is not auto increment, 1 is auto increment',
+    `column_default_value` TEXT DEFAULT NULL COMMENT 'column default value',
+    `column_op_type` TINYINT(1) NOT NULL COMMENT 'column operation type, 1 is create, 2 is update, 3 is delete',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'column deleted at',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'column audit info',
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `uk_tid_ver_cid_del` (`table_id`, `table_version`, `column_id`, `deleted_at`),
+    KEY `idx_tcmid` (`metalake_id`),
+    KEY `idx_tccid` (`catalog_id`),
+    KEY `idx_tcsid` (`schema_id`)
+) ENGINE=InnoDB;
+
+
+CREATE TABLE IF NOT EXISTS `fileset_meta` (
+    `fileset_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'fileset id',
+    `fileset_name` VARCHAR(128) NOT NULL COMMENT 'fileset name',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `catalog_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'catalog id',
+    `schema_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'schema id',
+    `type` VARCHAR(64) NOT NULL COMMENT 'fileset type',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'fileset audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'fileset current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'fileset last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'fileset deleted at',
+    PRIMARY KEY (fileset_id),
+    CONSTRAINT uk_sid_fn_del UNIQUE (schema_id, fileset_name, deleted_at),
+    -- Aliases are used here, and indexes with the same name in H2 can only be created once.
+    KEY idx_fmid (metalake_id),
+    KEY idx_fcid (catalog_id)
+) ENGINE=InnoDB;
+
+
+CREATE TABLE IF NOT EXISTS `fileset_version_info` (
+    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'auto increment id',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `catalog_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'catalog id',
+    `schema_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'schema id',
+    `fileset_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'fileset id',
+    `version` INT UNSIGNED NOT NULL COMMENT 'fileset info version',
+    `fileset_comment` VARCHAR(256) DEFAULT '' COMMENT 'fileset comment',
+    `properties` MEDIUMTEXT DEFAULT NULL COMMENT 'fileset properties',
+    `storage_location_name` VARCHAR(128) NOT NULL DEFAULT 'default' COMMENT 'fileset storage location name',
+    `storage_location` MEDIUMTEXT DEFAULT NULL COMMENT 'fileset storage location',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'fileset deleted at',
+    PRIMARY KEY (id),
+    CONSTRAINT uk_fid_ver_del UNIQUE (fileset_id, version, storage_location_name, deleted_at),
+    -- Aliases are used here, and indexes with the same name in H2 can only be created once.
+    KEY idx_fvmid (metalake_id),
+    KEY idx_fvcid (catalog_id)
+) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS `topic_meta` (
+    `topic_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'topic id',
+    `topic_name` VARCHAR(128) NOT NULL COMMENT 'topic name',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `catalog_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'catalog id',
+    `schema_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'schema id',
+    `comment` VARCHAR(256) DEFAULT '' COMMENT 'topic comment',
+    `properties` MEDIUMTEXT DEFAULT NULL COMMENT 'topic properties',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'topic audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'topic current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'topic last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'topic deleted at',
+    PRIMARY KEY (topic_id),
+    CONSTRAINT uk_cid_tn_del UNIQUE (schema_id, topic_name, deleted_at),
+    -- Aliases are used here, and indexes with the same name in H2 can only be created once.
+    KEY idx_tvmid (metalake_id),
+    KEY idx_tvcid (catalog_id)
+) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS `user_meta` (
+    `user_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'user id',
+    `user_name` VARCHAR(128) NOT NULL COMMENT 'username',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'user audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'user current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'user last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'user deleted at',
+    PRIMARY KEY (`user_id`),
+    CONSTRAINT `uk_mid_us_del` UNIQUE (`metalake_id`, `user_name`, `deleted_at`)
+) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS `role_meta` (
+    `role_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'role id',
+    `role_name` VARCHAR(128) NOT NULL COMMENT 'role name',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `properties` MEDIUMTEXT DEFAULT NULL COMMENT 'schema properties',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'role audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'role current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'role last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'role deleted at',
+    PRIMARY KEY (`role_id`),
+    CONSTRAINT `uk_mid_rn_del` UNIQUE (`metalake_id`, `role_name`, `deleted_at`)
+) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS `role_meta_securable_object` (
+    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'auto increment id',
+    `role_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'role id',
+    `metadata_object_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'securable object entity id',
+    `type`  VARCHAR(128) NOT NULL COMMENT 'securable object type',
+    `privilege_names` TEXT(81920) NOT NULL COMMENT 'securable object privilege names',
+    `privilege_conditions` TEXT(81920) NOT NULL COMMENT 'securable object privilege conditions',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'securable objectcurrent version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'securable object last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'securable object deleted at',
+    PRIMARY KEY (`id`),
+    KEY `idx_obj_rid` (`role_id`),
+    KEY `idx_obj_eid` (`metadata_object_id`)
+    ) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS `user_role_rel` (
+    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'auto increment id',
+    `user_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'user id',
+    `role_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'role id',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'relation audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'relation current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'relation last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'relation deleted at',
+    PRIMARY KEY (`id`),
+    CONSTRAINT `uk_ui_ri_del` UNIQUE (`user_id`, `role_id`, `deleted_at`),
+    KEY `idx_rid` (`role_id`)
+) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS `group_meta` (
+    `group_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'group id',
+    `group_name` VARCHAR(128) NOT NULL COMMENT 'group name',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'group audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'group current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'group last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'group deleted at',
+    PRIMARY KEY (`group_id`),
+    CONSTRAINT `uk_mid_gr_del` UNIQUE (`metalake_id`, `group_name`, `deleted_at`)
+    ) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS `group_role_rel` (
+    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'auto increment id',
+    `group_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'group id',
+    `role_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'role id',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'relation audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'relation current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'relation last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'relation deleted at',
+    PRIMARY KEY (`id`),
+    CONSTRAINT `uk_gi_ri_del` UNIQUE (`group_id`, `role_id`, `deleted_at`),
+    KEY `idx_gid` (`group_id`)
+    ) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS `tag_meta` (
+    `tag_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'tag id',
+    `tag_name` VARCHAR(128) NOT NULL COMMENT 'tag name',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `tag_comment` VARCHAR(256) DEFAULT '' COMMENT 'tag comment',
+    `properties` MEDIUMTEXT DEFAULT NULL COMMENT 'tag properties',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'tag audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'tag current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'tag last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'tag deleted at',
+    PRIMARY KEY (`tag_id`),
+    UNIQUE KEY `uk_mn_tn_del` (`metalake_id`, `tag_name`, `deleted_at`)
+    ) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS `tag_relation_meta` (
+    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'auto increment id',
+    `tag_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'tag id',
+    `metadata_object_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metadata object id',
+    `metadata_object_type` VARCHAR(64) NOT NULL COMMENT 'metadata object type',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'tag relation audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'tag relation current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'tag relation last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'tag relation deleted at',
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `uk_ti_mi_del` (`tag_id`, `metadata_object_id`, `deleted_at`),
+    KEY `idx_tid` (`tag_id`),
+    KEY `idx_mid` (`metadata_object_id`)
+    ) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS `owner_meta` (
+    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'auto increment id',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `owner_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'owner id',
+    `owner_type` VARCHAR(64) NOT NULL COMMENT 'owner type',
+    `metadata_object_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metadata object id',
+    `metadata_object_type` VARCHAR(64) NOT NULL COMMENT 'metadata object type',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'owner relation audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'owner relation current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'owner relation last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'owner relation deleted at',
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `uk_ow_me_del` (`owner_id`, `metadata_object_id`, `metadata_object_type`, `deleted_at`),
+    KEY `idx_oid` (`owner_id`),
+    KEY `idx_meid` (`metadata_object_id`)
+    ) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS `model_meta` (
+    `model_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'model id',
+    `model_name` VARCHAR(128) NOT NULL COMMENT 'model name',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `catalog_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'catalog id',
+    `schema_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'schema id',
+    `model_comment` TEXT DEFAULT NULL COMMENT 'model comment',
+    `model_properties` MEDIUMTEXT DEFAULT NULL COMMENT 'model properties',
+    `model_latest_version` INT UNSIGNED DEFAULT 0 COMMENT 'model latest version',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'model audit info',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'model deleted at',
+    PRIMARY KEY (`model_id`),
+    UNIQUE KEY `uk_sid_mn_del` (`schema_id`, `model_name`, `deleted_at`),
+    KEY `idx_mmid` (`metalake_id`),
+    KEY `idx_mcid` (`catalog_id`)
+) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS `model_version_info` (
+    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'auto increment id',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `catalog_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'catalog id',
+    `schema_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'schema id',
+    `model_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'model id',
+    `version` INT UNSIGNED NOT NULL COMMENT 'model version',
+    `model_version_comment` TEXT DEFAULT NULL COMMENT 'model version comment',
+    `model_version_properties` MEDIUMTEXT DEFAULT NULL COMMENT 'model version properties',
+    `model_version_uri` TEXT NOT NULL COMMENT 'model storage uri',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'model version audit info',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'model version deleted at',
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `uk_mid_ver_del` (`model_id`, `version`, `deleted_at`),
+    KEY `idx_vmid` (`metalake_id`),
+    KEY `idx_vcid` (`catalog_id`),
+    KEY `idx_vsid` (`schema_id`)
+) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS `model_version_alias_rel` (
+    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'auto increment id',
+    `model_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'model id',
+    `model_version` INT UNSIGNED NOT NULL COMMENT 'model version',
+    `model_version_alias` VARCHAR(128) NOT NULL COMMENT 'model version alias',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'model version alias deleted at',
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `uk_mi_mva_del` (`model_id`, `model_version_alias`, `deleted_at`),
+    KEY `idx_mva` (`model_version_alias`)
+) ENGINE=InnoDB;

--- a/scripts/h2/upgrade-0.8.0-to-0.9.0-h2.sql
+++ b/scripts/h2/upgrade-0.8.0-to-0.9.0-h2.sql
@@ -1,0 +1,25 @@
+--
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file--
+--  distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"). You may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--  http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+--
+
+-- using default 'unknown' to fill in the new column for compatibility
+ALTER TABLE `fileset_version_info` ADD COLUMN `storage_location_name` VARCHAR(256) NOT NULL DEFAULT 'unknown' COMMENT 'fileset storage location name';
+ALTER TABLE `fileset_version_info` DROP INDEX `uk_fid_ver_del`;
+ALTER TABLE `fileset_version_info` ADD CONSTRAINT `uk_fid_ver_sto_del` UNIQUE (`fileset_id`, `version`, `storage_location_name`, `deleted_at`);
+-- remove the default value for storage_location_name
+ALTER TABLE `fileset_version_info` ALTER COLUMN `storage_location_name` DROP DEFAULT;

--- a/scripts/mysql/schema-0.9.0-mysql.sql
+++ b/scripts/mysql/schema-0.9.0-mysql.sql
@@ -1,0 +1,330 @@
+--
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file--
+--  distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"). You may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--  http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+--
+
+CREATE TABLE IF NOT EXISTS `metalake_meta` (
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `metalake_name` VARCHAR(128) NOT NULL COMMENT 'metalake name',
+    `metalake_comment` VARCHAR(256) DEFAULT '' COMMENT 'metalake comment',
+    `properties` MEDIUMTEXT DEFAULT NULL COMMENT 'metalake properties',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'metalake audit info',
+    `schema_version` MEDIUMTEXT NOT NULL COMMENT 'metalake schema version info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'metalake current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'metalake last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'metalake deleted at',
+    PRIMARY KEY (`metalake_id`),
+    UNIQUE KEY `uk_mn_del` (`metalake_name`, `deleted_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'metalake metadata';
+
+CREATE TABLE IF NOT EXISTS `catalog_meta` (
+    `catalog_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'catalog id',
+    `catalog_name` VARCHAR(128) NOT NULL COMMENT 'catalog name',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `type` VARCHAR(64) NOT NULL COMMENT 'catalog type',
+    `provider` VARCHAR(64) NOT NULL COMMENT 'catalog provider',
+    `catalog_comment` VARCHAR(256) DEFAULT '' COMMENT 'catalog comment',
+    `properties` MEDIUMTEXT DEFAULT NULL COMMENT 'catalog properties',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'catalog audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'catalog current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'catalog last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'catalog deleted at',
+    PRIMARY KEY (`catalog_id`),
+    UNIQUE KEY `uk_mid_cn_del` (`metalake_id`, `catalog_name`, `deleted_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'catalog metadata';
+
+CREATE TABLE IF NOT EXISTS `schema_meta` (
+    `schema_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'schema id',
+    `schema_name` VARCHAR(128) NOT NULL COMMENT 'schema name',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `catalog_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'catalog id',
+    `schema_comment` VARCHAR(256) DEFAULT '' COMMENT 'schema comment',
+    `properties` MEDIUMTEXT DEFAULT NULL COMMENT 'schema properties',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'schema audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'schema current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'schema last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'schema deleted at',
+    PRIMARY KEY (`schema_id`),
+    UNIQUE KEY `uk_cid_sn_del` (`catalog_id`, `schema_name`, `deleted_at`),
+    KEY `idx_mid` (`metalake_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'schema metadata';
+
+CREATE TABLE IF NOT EXISTS `table_meta` (
+    `table_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'table id',
+    `table_name` VARCHAR(128) NOT NULL COMMENT 'table name',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `catalog_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'catalog id',
+    `schema_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'schema id',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'table audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'table current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'table last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'table deleted at',
+    PRIMARY KEY (`table_id`),
+    UNIQUE KEY `uk_sid_tn_del` (`schema_id`, `table_name`, `deleted_at`),
+    KEY `idx_mid` (`metalake_id`),
+    KEY `idx_cid` (`catalog_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'table metadata';
+
+CREATE TABLE IF NOT EXISTS `table_column_version_info` (
+    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'auto increment id',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `catalog_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'catalog id',
+    `schema_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'schema id',
+    `table_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'table id',
+    `table_version` INT UNSIGNED NOT NULL COMMENT 'table version',
+    `column_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'column id',
+    `column_name` VARCHAR(128) NOT NULL COMMENT 'column name',
+    `column_position` INT UNSIGNED NOT NULL COMMENT 'column position, starting from 0',
+    `column_type` TEXT NOT NULL COMMENT 'column type',
+    `column_comment` VARCHAR(256) DEFAULT '' COMMENT 'column comment',
+    `column_nullable` TINYINT(1) NOT NULL DEFAULT 1 COMMENT 'column nullable, 0 is not nullable, 1 is nullable',
+    `column_auto_increment` TINYINT(1) NOT NULL DEFAULT 0 COMMENT 'column auto increment, 0 is not auto increment, 1 is auto increment',
+    `column_default_value` TEXT DEFAULT NULL COMMENT 'column default value',
+    `column_op_type` TINYINT(1) NOT NULL COMMENT 'column operation type, 1 is create, 2 is update, 3 is delete',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'column deleted at',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'column audit info',
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `uk_tid_ver_cid_del` (`table_id`, `table_version`, `column_id`, `deleted_at`),
+    KEY `idx_mid` (`metalake_id`),
+    KEY `idx_cid` (`catalog_id`),
+    KEY `idx_sid` (`schema_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'table column version info';
+
+CREATE TABLE IF NOT EXISTS `fileset_meta` (
+    `fileset_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'fileset id',
+    `fileset_name` VARCHAR(128) NOT NULL COMMENT 'fileset name',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `catalog_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'catalog id',
+    `schema_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'schema id',
+    `type` VARCHAR(64) NOT NULL COMMENT 'fileset type',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'fileset audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'fileset current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'fileset last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'fileset deleted at',
+    PRIMARY KEY (`fileset_id`),
+    UNIQUE KEY `uk_sid_fn_del` (`schema_id`, `fileset_name`, `deleted_at`),
+    KEY `idx_mid` (`metalake_id`),
+    KEY `idx_cid` (`catalog_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'fileset metadata';
+
+CREATE TABLE IF NOT EXISTS `fileset_version_info` (
+    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'auto increment id',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `catalog_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'catalog id',
+    `schema_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'schema id',
+    `fileset_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'fileset id',
+    `version` INT UNSIGNED NOT NULL COMMENT 'fileset info version',
+    `fileset_comment` VARCHAR(256) DEFAULT '' COMMENT 'fileset comment',
+    `properties` MEDIUMTEXT DEFAULT NULL COMMENT 'fileset properties',
+    `storage_location_name` VARCHAR(256) NOT NULL DEFAULT 'default' COMMENT 'fileset storage location name',
+    `storage_location` MEDIUMTEXT NOT NULL COMMENT 'fileset storage location',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'fileset deleted at',
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `uk_fid_ver_sto_del` (`fileset_id`, `version`, `storage_location_name`, `deleted_at`),
+    KEY `idx_mid` (`metalake_id`),
+    KEY `idx_cid` (`catalog_id`),
+    KEY `idx_sid` (`schema_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'fileset version info';
+
+CREATE TABLE IF NOT EXISTS `topic_meta` (
+    `topic_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'topic id',
+    `topic_name` VARCHAR(128) NOT NULL COMMENT 'topic name',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `catalog_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'catalog id',
+    `schema_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'schema id',
+    `comment` VARCHAR(256) DEFAULT '' COMMENT 'topic comment',
+    `properties` MEDIUMTEXT DEFAULT NULL COMMENT 'topic properties',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'topic audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'topic current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'topic last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'topic deleted at',
+    PRIMARY KEY (`topic_id`),
+    UNIQUE KEY `uk_sid_tn_del` (`schema_id`, `topic_name`, `deleted_at`),
+    KEY `idx_mid` (`metalake_id`),
+    KEY `idx_cid` (`catalog_id`)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'topic metadata';
+
+CREATE TABLE IF NOT EXISTS `user_meta` (
+    `user_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'user id',
+    `user_name` VARCHAR(128) NOT NULL COMMENT 'username',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'user audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'user current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'user last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'user deleted at',
+    PRIMARY KEY (`user_id`),
+    UNIQUE KEY `uk_mid_us_del` (`metalake_id`, `user_name`, `deleted_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'user metadata';
+
+CREATE TABLE IF NOT EXISTS `role_meta` (
+    `role_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'role id',
+    `role_name` VARCHAR(128) NOT NULL COMMENT 'role name',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `properties` MEDIUMTEXT DEFAULT NULL COMMENT 'schema properties',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'role audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'role current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'role last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'role deleted at',
+    PRIMARY KEY (`role_id`),
+    UNIQUE KEY `uk_mid_rn_del` (`metalake_id`, `role_name`, `deleted_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'role metadata';
+
+CREATE TABLE IF NOT EXISTS `role_meta_securable_object` (
+    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'auto increment id',
+    `role_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'role id',
+    `metadata_object_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'The entity id of securable object',
+    `type`  VARCHAR(128) NOT NULL COMMENT 'securable object type',
+    `privilege_names` TEXT(81920) NOT NULL COMMENT 'securable object privilege names',
+    `privilege_conditions` TEXT(81920) NOT NULL COMMENT 'securable object privilege conditions',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'securable objectcurrent version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'securable object last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'securable object deleted at',
+    PRIMARY KEY (`id`),
+    KEY `idx_obj_rid` (`role_id`),
+    KEY `idx_obj_eid` (`metadata_object_id`)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'securable object meta';
+
+CREATE TABLE IF NOT EXISTS `user_role_rel` (
+    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'auto increment id',
+    `user_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'user id',
+    `role_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'role id',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'relation audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'relation current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'relation last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'relation deleted at',
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `uk_ui_ri_del` (`user_id`, `role_id`, `deleted_at`),
+    KEY `idx_rid` (`role_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'user role relation';
+
+CREATE TABLE IF NOT EXISTS `group_meta` (
+    `group_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'group id',
+    `group_name` VARCHAR(128) NOT NULL COMMENT 'group name',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'group audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'group current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'group last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'group deleted at',
+    PRIMARY KEY (`group_id`),
+    UNIQUE KEY `uk_mid_gr_del` (`metalake_id`, `group_name`, `deleted_at`)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'group metadata';
+
+CREATE TABLE IF NOT EXISTS `group_role_rel` (
+    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'auto increment id',
+    `group_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'group id',
+    `role_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'role id',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'relation audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'relation current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'relation last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'relation deleted at',
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `uk_gi_ri_del` (`group_id`, `role_id`, `deleted_at`),
+    KEY `idx_rid` (`group_id`)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'group role relation';
+
+CREATE TABLE IF NOT EXISTS `tag_meta` (
+    `tag_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'tag id',
+    `tag_name` VARCHAR(128) NOT NULL COMMENT 'tag name',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `tag_comment` VARCHAR(256) DEFAULT '' COMMENT 'tag comment',
+    `properties` MEDIUMTEXT DEFAULT NULL COMMENT 'tag properties',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'tag audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'tag current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'tag last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'tag deleted at',
+    PRIMARY KEY (`tag_id`),
+    UNIQUE KEY `uk_mi_tn_del` (`metalake_id`, `tag_name`, `deleted_at`)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'tag metadata';
+
+CREATE TABLE IF NOT EXISTS `tag_relation_meta` (
+    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'auto increment id',
+    `tag_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'tag id',
+    `metadata_object_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metadata object id',
+    `metadata_object_type` VARCHAR(64) NOT NULL COMMENT 'metadata object type',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'tag relation audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'tag relation current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'tag relation last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'tag relation deleted at',
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `uk_ti_mi_mo_del` (`tag_id`, `metadata_object_id`, `metadata_object_type`, `deleted_at`),
+    KEY `idx_tid` (`tag_id`),
+    KEY `idx_mid` (`metadata_object_id`)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'tag metadata object relation';
+
+CREATE TABLE IF NOT EXISTS `owner_meta` (
+    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'auto increment id',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `owner_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'owner id',
+    `owner_type` VARCHAR(64) NOT NULL COMMENT 'owner type',
+    `metadata_object_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metadata object id',
+    `metadata_object_type` VARCHAR(64) NOT NULL COMMENT 'metadata object type',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'owner relation audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'owner relation current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'owner relation last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'owner relation deleted at',
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `uk_ow_me_del` (`owner_id`, `metadata_object_id`, `metadata_object_type`,`deleted_at`),
+    KEY `idx_oid` (`owner_id`),
+    KEY `idx_meid` (`metadata_object_id`)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'owner relation';
+
+CREATE TABLE IF NOT EXISTS `model_meta` (
+    `model_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'model id',
+    `model_name` VARCHAR(128) NOT NULL COMMENT 'model name',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `catalog_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'catalog id',
+    `schema_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'schema id',
+    `model_comment` TEXT DEFAULT NULL COMMENT 'model comment',
+    `model_properties` MEDIUMTEXT DEFAULT NULL COMMENT 'model properties',
+    `model_latest_version` INT UNSIGNED DEFAULT 0 COMMENT 'model latest version',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'model audit info',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'model deleted at',
+    PRIMARY KEY (`model_id`),
+    UNIQUE KEY `uk_sid_mn_del` (`schema_id`, `model_name`, `deleted_at`),
+    KEY `idx_mid` (`metalake_id`),
+    KEY `idx_cid` (`catalog_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'model metadata';
+
+CREATE TABLE IF NOT EXISTS `model_version_info` (
+    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'auto increment id',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `catalog_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'catalog id',
+    `schema_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'schema id',
+    `model_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'model id',
+    `version` INT UNSIGNED NOT NULL COMMENT 'model version',
+    `model_version_comment` TEXT DEFAULT NULL COMMENT 'model version comment',
+    `model_version_properties` MEDIUMTEXT DEFAULT NULL COMMENT 'model version properties',
+    `model_version_uri` TEXT NOT NULL COMMENT 'model storage uri',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'model version audit info',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'model version deleted at',
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `uk_mid_ver_del` (`model_id`, `version`, `deleted_at`),
+    KEY `idx_mid` (`metalake_id`),
+    KEY `idx_cid` (`catalog_id`),
+    KEY `idx_sid` (`schema_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'model version info';
+
+CREATE TABLE IF NOT EXISTS `model_version_alias_rel` (
+    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'auto increment id',
+    `model_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'model id',
+    `model_version` INT UNSIGNED NOT NULL COMMENT 'model version',
+    `model_version_alias` VARCHAR(128) NOT NULL COMMENT 'model version alias',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'model version alias deleted at',
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `uk_mi_mva_del` (`model_id`, `model_version_alias`, `deleted_at`),
+    KEY `idx_mva` (`model_version_alias`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'model_version_alias_rel';

--- a/scripts/mysql/upgrade-0.8.0-to-0.9.0-mysql.sql
+++ b/scripts/mysql/upgrade-0.8.0-to-0.9.0-mysql.sql
@@ -1,0 +1,25 @@
+--
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file--
+--  distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"). You may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--  http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+--
+
+-- using default 'unknown' to fill in the new column for compatibility
+ALTER TABLE `fileset_version_info` ADD COLUMN `storage_location_name` VARCHAR(256) NOT NULL DEFAULT 'unknown' COMMENT 'fileset storage location name' AFTER `properties`;
+ALTER TABLE `fileset_version_info` DROP INDEX `uk_fid_ver_del`;
+ALTER TABLE `fileset_version_info` ADD CONSTRAINT `uk_fid_ver_sto_del` UNIQUE KEY (`fileset_id`, `version`, `storage_location_name`, `deleted_at`);
+-- remove the default value for storage_location_name
+ALTER TABLE `fileset_version_info` ALTER COLUMN `storage_location_name` DROP DEFAULT;

--- a/scripts/postgresql/schema-0.9.0-postgresql.sql
+++ b/scripts/postgresql/schema-0.9.0-postgresql.sql
@@ -1,0 +1,587 @@
+--
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file--
+--  distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"). You may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--  http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+--
+
+-- Note: Database and schema creation is not included in this script. Please create the database and
+-- schema before running this script. for example in psql:
+-- CREATE DATABASE example_db;
+-- \c example_db
+-- CREATE SCHEMA example_schema;
+-- set search_path to example_schema;
+
+CREATE TABLE IF NOT EXISTS metalake_meta (
+    metalake_id BIGINT NOT NULL,
+    metalake_name VARCHAR(128) NOT NULL,
+    metalake_comment VARCHAR(256) DEFAULT '',
+    properties TEXT DEFAULT NULL,
+    audit_info TEXT NOT NULL,
+    schema_version TEXT NOT NULL,
+    current_version INT NOT NULL DEFAULT 1,
+    last_version INT NOT NULL DEFAULT 1,
+    deleted_at BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (metalake_id),
+    UNIQUE (metalake_name, deleted_at)
+    );
+COMMENT ON TABLE metalake_meta IS 'metalake metadata';
+
+COMMENT ON COLUMN metalake_meta.metalake_id IS 'metalake id';
+COMMENT ON COLUMN metalake_meta.metalake_name IS 'metalake name';
+COMMENT ON COLUMN metalake_meta.metalake_comment IS 'metalake comment';
+COMMENT ON COLUMN metalake_meta.properties IS 'metalake properties';
+COMMENT ON COLUMN metalake_meta.audit_info IS 'metalake audit info';
+COMMENT ON COLUMN metalake_meta.schema_version IS 'metalake schema version info';
+COMMENT ON COLUMN metalake_meta.current_version IS 'metalake current version';
+COMMENT ON COLUMN metalake_meta.last_version IS 'metalake last version';
+COMMENT ON COLUMN metalake_meta.deleted_at IS 'metalake deleted at';
+
+
+CREATE TABLE IF NOT EXISTS catalog_meta (
+    catalog_id BIGINT NOT NULL,
+    catalog_name VARCHAR(128) NOT NULL,
+    metalake_id BIGINT NOT NULL,
+    type VARCHAR(64) NOT NULL,
+    provider VARCHAR(64) NOT NULL,
+    catalog_comment VARCHAR(256) DEFAULT '',
+    properties TEXT DEFAULT NULL,
+    audit_info TEXT NOT NULL,
+    current_version INT NOT NULL DEFAULT 1,
+    last_version INT NOT NULL DEFAULT 1,
+    deleted_at BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (catalog_id),
+    UNIQUE (metalake_id, catalog_name, deleted_at)
+    );
+
+COMMENT ON TABLE catalog_meta IS 'catalog metadata';
+
+COMMENT ON COLUMN catalog_meta.catalog_id IS 'catalog id';
+COMMENT ON COLUMN catalog_meta.catalog_name IS 'catalog name';
+COMMENT ON COLUMN catalog_meta.metalake_id IS 'metalake id';
+COMMENT ON COLUMN catalog_meta.type IS 'catalog type';
+COMMENT ON COLUMN catalog_meta.provider IS 'catalog provider';
+COMMENT ON COLUMN catalog_meta.catalog_comment IS 'catalog comment';
+COMMENT ON COLUMN catalog_meta.properties IS 'catalog properties';
+COMMENT ON COLUMN catalog_meta.audit_info IS 'catalog audit info';
+COMMENT ON COLUMN catalog_meta.current_version IS 'catalog current version';
+COMMENT ON COLUMN catalog_meta.last_version IS 'catalog last version';
+COMMENT ON COLUMN catalog_meta.deleted_at IS 'catalog deleted at';
+
+
+CREATE TABLE IF NOT EXISTS schema_meta (
+    schema_id BIGINT NOT NULL,
+    schema_name VARCHAR(128) NOT NULL,
+    metalake_id BIGINT NOT NULL,
+    catalog_id BIGINT NOT NULL,
+    schema_comment VARCHAR(256) DEFAULT '',
+    properties TEXT DEFAULT NULL,
+    audit_info TEXT NOT NULL,
+    current_version INT NOT NULL DEFAULT 1,
+    last_version INT NOT NULL DEFAULT 1,
+    deleted_at BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (schema_id),
+    UNIQUE (catalog_id, schema_name, deleted_at)
+    );
+
+CREATE INDEX IF NOT EXISTS idx_metalake_id ON schema_meta (metalake_id);
+COMMENT ON TABLE schema_meta IS 'schema metadata';
+
+COMMENT ON COLUMN schema_meta.schema_id IS 'schema id';
+COMMENT ON COLUMN schema_meta.schema_name IS 'schema name';
+COMMENT ON COLUMN schema_meta.metalake_id IS 'metalake id';
+COMMENT ON COLUMN schema_meta.catalog_id IS 'catalog id';
+COMMENT ON COLUMN schema_meta.schema_comment IS 'schema comment';
+COMMENT ON COLUMN schema_meta.properties IS 'schema properties';
+COMMENT ON COLUMN schema_meta.audit_info IS 'schema audit info';
+COMMENT ON COLUMN schema_meta.current_version IS 'schema current version';
+COMMENT ON COLUMN schema_meta.last_version IS 'schema last version';
+COMMENT ON COLUMN schema_meta.deleted_at IS 'schema deleted at';
+
+
+CREATE TABLE IF NOT EXISTS table_meta (
+    table_id BIGINT NOT NULL,
+    table_name VARCHAR(128) NOT NULL,
+    metalake_id BIGINT NOT NULL,
+    catalog_id BIGINT NOT NULL,
+    schema_id BIGINT NOT NULL,
+    audit_info TEXT NOT NULL,
+    current_version INT NOT NULL DEFAULT 1,
+    last_version INT NOT NULL DEFAULT 1,
+    deleted_at BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (table_id),
+    UNIQUE (schema_id, table_name, deleted_at)
+    );
+
+CREATE INDEX IF NOT EXISTS idx_metalake_id ON table_meta (metalake_id);
+CREATE INDEX IF NOT EXISTS idx_catalog_id ON table_meta (catalog_id);
+COMMENT ON TABLE table_meta IS 'table metadata';
+
+COMMENT ON COLUMN table_meta.table_id IS 'table id';
+COMMENT ON COLUMN table_meta.table_name IS 'table name';
+COMMENT ON COLUMN table_meta.metalake_id IS 'metalake id';
+COMMENT ON COLUMN table_meta.catalog_id IS 'catalog id';
+COMMENT ON COLUMN table_meta.schema_id IS 'schema id';
+COMMENT ON COLUMN table_meta.audit_info IS 'table audit info';
+COMMENT ON COLUMN table_meta.current_version IS 'table current version';
+COMMENT ON COLUMN table_meta.last_version IS 'table last version';
+COMMENT ON COLUMN table_meta.deleted_at IS 'table deleted at';
+
+CREATE TABLE IF NOT EXISTS table_column_version_info (
+    id BIGINT NOT NULL GENERATED BY DEFAULT AS IDENTITY,
+    metalake_id BIGINT NOT NULL,
+    catalog_id BIGINT NOT NULL,
+    schema_id BIGINT NOT NULL,
+    table_id BIGINT NOT NULL,
+    table_version INT NOT NULL,
+    column_id BIGINT NOT NULL,
+    column_name VARCHAR(128) NOT NULL,
+    column_position INT NOT NULL,
+    column_type TEXT NOT NULL,
+    column_comment VARCHAR(256) DEFAULT '',
+    column_nullable SMALLINT NOT NULL DEFAULT 1,
+    column_auto_increment SMALLINT NOT NULL DEFAULT 0,
+    column_default_value TEXT DEFAULT NULL,
+    column_op_type SMALLINT NOT NULL,
+    deleted_at BIGINT NOT NULL DEFAULT 0,
+    audit_info TEXT NOT NULL,
+    PRIMARY KEY (id),
+    UNIQUE (table_id, table_version, column_id, deleted_at)
+);
+CREATE INDEX idx_mid ON table_column_version_info (metalake_id);
+CREATE INDEX idx_cid ON table_column_version_info (catalog_id);
+CREATE INDEX idx_sid ON table_column_version_info (schema_id);
+COMMENT ON TABLE table_column_version_info IS 'table column version information';
+
+COMMENT ON COLUMN table_column_version_info.id IS 'auto increment id';
+COMMENT ON COLUMN table_column_version_info.metalake_id IS 'metalake id';
+COMMENT ON COLUMN table_column_version_info.catalog_id IS 'catalog id';
+COMMENT ON COLUMN table_column_version_info.schema_id IS 'schema id';
+COMMENT ON COLUMN table_column_version_info.table_id IS 'table id';
+COMMENT ON COLUMN table_column_version_info.table_version IS 'table version';
+COMMENT ON COLUMN table_column_version_info.column_id IS 'column id';
+COMMENT ON COLUMN table_column_version_info.column_name IS 'column name';
+COMMENT ON COLUMN table_column_version_info.column_position IS 'column position, starting from 0';
+COMMENT ON COLUMN table_column_version_info.column_type IS 'column type';
+COMMENT ON COLUMN table_column_version_info.column_comment IS 'column comment';
+COMMENT ON COLUMN table_column_version_info.column_nullable IS 'column nullable, 0 is not nullable, 1 is nullable';
+COMMENT ON COLUMN table_column_version_info.column_auto_increment IS 'column auto increment, 0 is not auto increment, 1 is auto increment';
+COMMENT ON COLUMN table_column_version_info.column_default_value IS 'column default value';
+COMMENT ON COLUMN table_column_version_info.column_op_type IS 'column operation type, 1 is create, 2 is update, 3 is delete';
+COMMENT ON COLUMN table_column_version_info.deleted_at IS 'column deleted at';
+COMMENT ON COLUMN table_column_version_info.audit_info IS 'column audit info';
+
+
+CREATE TABLE IF NOT EXISTS fileset_meta (
+    fileset_id BIGINT NOT NULL,
+    fileset_name VARCHAR(128) NOT NULL,
+    metalake_id BIGINT NOT NULL,
+    catalog_id BIGINT NOT NULL,
+    schema_id BIGINT NOT NULL,
+    type VARCHAR(64) NOT NULL,
+    audit_info TEXT NOT NULL,
+    current_version INT NOT NULL DEFAULT 1,
+    last_version INT NOT NULL DEFAULT 1,
+    deleted_at BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (fileset_id),
+    UNIQUE (schema_id, fileset_name, deleted_at)
+    );
+
+CREATE INDEX IF NOT EXISTS idx_metalake_id ON fileset_meta (metalake_id);
+CREATE INDEX IF NOT EXISTS idx_catalog_id ON fileset_meta (catalog_id);
+COMMENT ON TABLE fileset_meta IS 'fileset metadata';
+
+COMMENT ON COLUMN fileset_meta.fileset_id IS 'fileset id';
+COMMENT ON COLUMN fileset_meta.fileset_name IS 'fileset name';
+COMMENT ON COLUMN fileset_meta.metalake_id IS 'metalake id';
+COMMENT ON COLUMN fileset_meta.catalog_id IS 'catalog id';
+COMMENT ON COLUMN fileset_meta.schema_id IS 'schema id';
+COMMENT ON COLUMN fileset_meta.type IS 'fileset type';
+COMMENT ON COLUMN fileset_meta.audit_info IS 'fileset audit info';
+COMMENT ON COLUMN fileset_meta.current_version IS 'fileset current version';
+COMMENT ON COLUMN fileset_meta.last_version IS 'fileset last version';
+COMMENT ON COLUMN fileset_meta.deleted_at IS 'fileset deleted at';
+
+
+CREATE TABLE IF NOT EXISTS fileset_version_info (
+    id BIGINT NOT NULL GENERATED BY DEFAULT AS IDENTITY,
+    metalake_id BIGINT NOT NULL,
+    catalog_id BIGINT NOT NULL,
+    schema_id BIGINT NOT NULL,
+    fileset_id BIGINT NOT NULL,
+    version INT NOT NULL,
+    fileset_comment VARCHAR(256) DEFAULT '',
+    properties TEXT DEFAULT NULL,
+    storage_location_name VARCHAR(256) NOT NULL DEFAULT 'default',
+    storage_location TEXT NOT NULL,
+    deleted_at BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (id),
+    UNIQUE (fileset_id, version, storage_location_name, deleted_at)
+    );
+
+CREATE INDEX IF NOT EXISTS idx_metalake_id ON fileset_version_info (metalake_id);
+CREATE INDEX IF NOT EXISTS idx_catalog_id ON fileset_version_info (catalog_id);
+CREATE INDEX IF NOT EXISTS idx_schema_id ON fileset_version_info (schema_id);
+COMMENT ON TABLE fileset_version_info IS 'fileset version information';
+
+COMMENT ON COLUMN fileset_version_info.id IS 'auto increment id';
+COMMENT ON COLUMN fileset_version_info.metalake_id IS 'metalake id';
+COMMENT ON COLUMN fileset_version_info.catalog_id IS 'catalog id';
+COMMENT ON COLUMN fileset_version_info.schema_id IS 'schema id';
+COMMENT ON COLUMN fileset_version_info.fileset_id IS 'fileset id';
+COMMENT ON COLUMN fileset_version_info.version IS 'fileset info version';
+COMMENT ON COLUMN fileset_version_info.fileset_comment IS 'fileset comment';
+COMMENT ON COLUMN fileset_version_info.properties IS 'fileset properties';
+COMMENT ON COLUMN fileset_version_info.storage_location_name IS 'fileset storage location name';
+COMMENT ON COLUMN fileset_version_info.storage_location IS 'fileset storage location';
+COMMENT ON COLUMN fileset_version_info.deleted_at IS 'fileset deleted at';
+
+
+CREATE TABLE IF NOT EXISTS topic_meta (
+    topic_id BIGINT NOT NULL,
+    topic_name VARCHAR(128) NOT NULL,
+    metalake_id BIGINT NOT NULL,
+    catalog_id BIGINT NOT NULL,
+    schema_id BIGINT NOT NULL,
+    comment VARCHAR(256) DEFAULT '',
+    properties TEXT DEFAULT NULL,
+    audit_info TEXT NOT NULL,
+    current_version INT NOT NULL DEFAULT 1,
+    last_version INT NOT NULL DEFAULT 1,
+    deleted_at BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (topic_id),
+    UNIQUE (schema_id, topic_name, deleted_at)
+    );
+
+CREATE INDEX IF NOT EXISTS idx_metalake_id ON topic_meta (metalake_id);
+CREATE INDEX IF NOT EXISTS idx_catalog_id ON topic_meta (catalog_id);
+COMMENT ON TABLE topic_meta IS 'topic metadata';
+
+COMMENT ON COLUMN topic_meta.topic_id IS 'topic id';
+COMMENT ON COLUMN topic_meta.topic_name IS 'topic name';
+COMMENT ON COLUMN topic_meta.metalake_id IS 'metalake id';
+COMMENT ON COLUMN topic_meta.catalog_id IS 'catalog id';
+COMMENT ON COLUMN topic_meta.schema_id IS 'schema id';
+COMMENT ON COLUMN topic_meta.comment IS 'topic comment';
+COMMENT ON COLUMN topic_meta.properties IS 'topic properties';
+COMMENT ON COLUMN topic_meta.audit_info IS 'topic audit info';
+COMMENT ON COLUMN topic_meta.current_version IS 'topic current version';
+COMMENT ON COLUMN topic_meta.last_version IS 'topic last version';
+COMMENT ON COLUMN topic_meta.deleted_at IS 'topic deleted at';
+
+
+CREATE TABLE IF NOT EXISTS user_meta (
+    user_id BIGINT NOT NULL,
+    user_name VARCHAR(128) NOT NULL,
+    metalake_id BIGINT NOT NULL,
+    audit_info TEXT NOT NULL,
+    current_version INT NOT NULL DEFAULT 1,
+    last_version INT NOT NULL DEFAULT 1,
+    deleted_at BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (user_id),
+    UNIQUE (metalake_id, user_name, deleted_at)
+    );
+COMMENT ON TABLE user_meta IS 'user metadata';
+
+COMMENT ON COLUMN user_meta.user_id IS 'user id';
+COMMENT ON COLUMN user_meta.user_name IS 'username';
+COMMENT ON COLUMN user_meta.metalake_id IS 'metalake id';
+COMMENT ON COLUMN user_meta.audit_info IS 'user audit info';
+COMMENT ON COLUMN user_meta.current_version IS 'user current version';
+COMMENT ON COLUMN user_meta.last_version IS 'user last version';
+COMMENT ON COLUMN user_meta.deleted_at IS 'user deleted at';
+
+CREATE TABLE IF NOT EXISTS role_meta (
+    role_id BIGINT NOT NULL,
+    role_name VARCHAR(128) NOT NULL,
+    metalake_id BIGINT NOT NULL,
+    properties TEXT DEFAULT NULL,
+    audit_info TEXT NOT NULL,
+    current_version INT NOT NULL DEFAULT 1,
+    last_version INT NOT NULL DEFAULT 1,
+    deleted_at BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (role_id),
+    UNIQUE (metalake_id, role_name, deleted_at)
+    );
+
+COMMENT ON TABLE role_meta IS 'role metadata';
+
+COMMENT ON COLUMN role_meta.role_id IS 'role id';
+COMMENT ON COLUMN role_meta.role_name IS 'role name';
+COMMENT ON COLUMN role_meta.metalake_id IS 'metalake id';
+COMMENT ON COLUMN role_meta.properties IS 'role properties';
+COMMENT ON COLUMN role_meta.audit_info IS 'role audit info';
+COMMENT ON COLUMN role_meta.current_version IS 'role current version';
+COMMENT ON COLUMN role_meta.last_version IS 'role last version';
+COMMENT ON COLUMN role_meta.deleted_at IS 'role deleted at';
+
+
+CREATE TABLE IF NOT EXISTS role_meta_securable_object (
+    id BIGINT NOT NULL GENERATED BY DEFAULT AS IDENTITY,
+    role_id BIGINT NOT NULL,
+    metadata_object_id BIGINT NOT NULL,
+    type  VARCHAR(128) NOT NULL,
+    privilege_names VARCHAR(81920) NOT NULL,
+    privilege_conditions VARCHAR(81920) NOT NULL,
+    current_version INT NOT NULL DEFAULT 1,
+    last_version INT NOT NULL DEFAULT 1,
+    deleted_at BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (id)
+    );
+
+CREATE INDEX IF NOT EXISTS idx_role_id ON role_meta_securable_object (role_id);
+COMMENT ON TABLE role_meta_securable_object IS 'role to securable object relation metadata';
+
+COMMENT ON COLUMN role_meta_securable_object.id IS 'auto increment id';
+COMMENT ON COLUMN role_meta_securable_object.role_id IS 'role id';
+COMMENT ON COLUMN role_meta_securable_object.metadata_object_id IS 'The entity id of securable object';
+COMMENT ON COLUMN role_meta_securable_object.type IS 'securable object type';
+COMMENT ON COLUMN role_meta_securable_object.privilege_names IS 'securable object privilege names';
+COMMENT ON COLUMN role_meta_securable_object.privilege_conditions IS 'securable object privilege conditions';
+COMMENT ON COLUMN role_meta_securable_object.current_version IS 'securable object current version';
+COMMENT ON COLUMN role_meta_securable_object.last_version IS 'securable object last version';
+COMMENT ON COLUMN role_meta_securable_object.deleted_at IS 'securable object deleted at';
+
+
+CREATE TABLE IF NOT EXISTS user_role_rel (
+    id BIGINT NOT NULL GENERATED BY DEFAULT AS IDENTITY,
+    user_id BIGINT NOT NULL,
+    role_id BIGINT NOT NULL,
+    audit_info TEXT NOT NULL,
+    current_version INT NOT NULL DEFAULT 1,
+    last_version INT NOT NULL DEFAULT 1,
+    deleted_at BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (id),
+    UNIQUE (user_id, role_id, deleted_at)
+    );
+
+CREATE INDEX IF NOT EXISTS idx_user_id ON user_role_rel (user_id);
+COMMENT ON TABLE user_role_rel IS 'user role relation metadata';
+
+COMMENT ON COLUMN user_role_rel.id IS 'auto increment id';
+COMMENT ON COLUMN user_role_rel.user_id IS 'user id';
+COMMENT ON COLUMN user_role_rel.role_id IS 'role id';
+COMMENT ON COLUMN user_role_rel.audit_info IS 'relation audit info';
+COMMENT ON COLUMN user_role_rel.current_version IS 'relation current version';
+COMMENT ON COLUMN user_role_rel.last_version IS 'relation last version';
+COMMENT ON COLUMN user_role_rel.deleted_at IS 'relation deleted at';
+
+
+CREATE TABLE IF NOT EXISTS group_meta (
+    group_id BIGINT NOT NULL,
+    group_name VARCHAR(128) NOT NULL,
+    metalake_id BIGINT NOT NULL,
+    audit_info TEXT NOT NULL,
+    current_version INT NOT NULL DEFAULT 1,
+    last_version INT NOT NULL DEFAULT 1,
+    deleted_at BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (group_id),
+    UNIQUE (metalake_id, group_name, deleted_at)
+    );
+COMMENT ON TABLE group_meta IS 'group metadata';
+
+COMMENT ON COLUMN group_meta.group_id IS 'group id';
+COMMENT ON COLUMN group_meta.group_name IS 'group name';
+COMMENT ON COLUMN group_meta.metalake_id IS 'metalake id';
+COMMENT ON COLUMN group_meta.audit_info IS 'group audit info';
+COMMENT ON COLUMN group_meta.current_version IS 'group current version';
+COMMENT ON COLUMN group_meta.last_version IS 'group last version';
+COMMENT ON COLUMN group_meta.deleted_at IS 'group deleted at';
+
+
+CREATE TABLE IF NOT EXISTS group_role_rel (
+    id BIGSERIAL NOT NULL,
+    group_id BIGINT NOT NULL,
+    role_id BIGINT NOT NULL,
+    audit_info TEXT NOT NULL,
+    current_version INT NOT NULL DEFAULT 1,
+    last_version INT NOT NULL DEFAULT 1,
+    deleted_at BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (id),
+    UNIQUE (group_id, role_id, deleted_at)
+    );
+
+CREATE INDEX IF NOT EXISTS idx_group_id ON group_role_rel (group_id);
+COMMENT ON TABLE group_role_rel IS 'relation between group and role';
+COMMENT ON COLUMN group_role_rel.id IS 'auto increment id';
+COMMENT ON COLUMN group_role_rel.group_id IS 'group id';
+COMMENT ON COLUMN group_role_rel.role_id IS 'role id';
+COMMENT ON COLUMN group_role_rel.audit_info IS 'relation audit info';
+COMMENT ON COLUMN group_role_rel.current_version IS 'relation current version';
+COMMENT ON COLUMN group_role_rel.last_version IS 'relation last version';
+COMMENT ON COLUMN group_role_rel.deleted_at IS 'relation deleted at';
+
+CREATE TABLE IF NOT EXISTS tag_meta (
+    tag_id BIGINT NOT NULL,
+    tag_name VARCHAR(128) NOT NULL,
+    metalake_id BIGINT NOT NULL,
+    tag_comment VARCHAR(256) DEFAULT '',
+    properties TEXT DEFAULT NULL,
+    audit_info TEXT NOT NULL,
+    current_version INT NOT NULL DEFAULT 1,
+    last_version INT NOT NULL DEFAULT 1,
+    deleted_at BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (tag_id),
+    UNIQUE (metalake_id, tag_name, deleted_at)
+    );
+
+COMMENT ON TABLE tag_meta IS 'tag metadata';
+
+COMMENT ON COLUMN tag_meta.tag_id IS 'tag id';
+COMMENT ON COLUMN tag_meta.tag_name IS 'tag name';
+COMMENT ON COLUMN tag_meta.metalake_id IS 'metalake id';
+COMMENT ON COLUMN tag_meta.tag_comment IS 'tag comment';
+COMMENT ON COLUMN tag_meta.properties IS 'tag properties';
+COMMENT ON COLUMN tag_meta.audit_info IS 'tag audit info';
+
+
+CREATE TABLE IF NOT EXISTS tag_relation_meta (
+    id BIGINT GENERATED BY DEFAULT AS IDENTITY,
+    tag_id BIGINT NOT NULL,
+    metadata_object_id BIGINT NOT NULL,
+    metadata_object_type VARCHAR(64) NOT NULL,
+    audit_info TEXT NOT NULL,
+    current_version INT NOT NULL DEFAULT 1,
+    last_version INT NOT NULL DEFAULT 1,
+    deleted_at BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (id),
+    UNIQUE (tag_id, metadata_object_id, metadata_object_type, deleted_at)
+    );
+
+CREATE INDEX IF NOT EXISTS idx_tag_id ON tag_relation_meta (tag_id);
+CREATE INDEX IF NOT EXISTS idx_metadata_object_id ON tag_relation_meta (metadata_object_id);
+COMMENT ON TABLE tag_relation_meta IS 'tag metadata object relation';
+COMMENT ON COLUMN tag_relation_meta.id IS 'auto increment id';
+COMMENT ON COLUMN tag_relation_meta.tag_id IS 'tag id';
+COMMENT ON COLUMN tag_relation_meta.metadata_object_id IS 'metadata object id';
+COMMENT ON COLUMN tag_relation_meta.metadata_object_type IS 'metadata object type';
+COMMENT ON COLUMN tag_relation_meta.audit_info IS 'tag relation audit info';
+COMMENT ON COLUMN tag_relation_meta.current_version IS 'tag relation current version';
+COMMENT ON COLUMN tag_relation_meta.last_version IS 'tag relation last version';
+COMMENT ON COLUMN tag_relation_meta.deleted_at IS 'tag relation deleted at';
+
+CREATE TABLE IF NOT EXISTS owner_meta (
+    id BIGINT GENERATED BY DEFAULT AS IDENTITY,
+    metalake_id BIGINT NOT NULL,
+    owner_id BIGINT NOT NULL,
+    owner_type VARCHAR(64) NOT NULL,
+    metadata_object_id BIGINT NOT NULL,
+    metadata_object_type VARCHAR(64) NOT NULL,
+    audit_info TEXT NOT NULL,
+    current_version INT NOT NULL DEFAULT 1,
+    last_version INT NOT NULL DEFAULT 1,
+    deleted_at BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (id),
+    UNIQUE (owner_id, metadata_object_id, metadata_object_type, deleted_at)
+    );
+
+CREATE INDEX IF NOT EXISTS idx_owner_id ON owner_meta (owner_id);
+CREATE INDEX IF NOT EXISTS idx_metadata_object_id ON owner_meta (metadata_object_id);
+COMMENT ON TABLE owner_meta IS 'owner relation';
+COMMENT ON COLUMN owner_meta.id IS 'auto increment id';
+COMMENT ON COLUMN owner_meta.metalake_id IS 'metalake id';
+COMMENT ON COLUMN owner_meta.owner_id IS 'owner id';
+COMMENT ON COLUMN owner_meta.owner_type IS 'owner type';
+COMMENT ON COLUMN owner_meta.metadata_object_id IS 'metadata object id';
+COMMENT ON COLUMN owner_meta.metadata_object_type IS 'metadata object type';
+COMMENT ON COLUMN owner_meta.audit_info IS 'owner relation audit info';
+COMMENT ON COLUMN owner_meta.current_version IS 'owner relation current version';
+COMMENT ON COLUMN owner_meta.last_version IS 'owner relation last version';
+COMMENT ON COLUMN owner_meta.deleted_at IS 'owner relation deleted at';
+
+
+CREATE TABLE IF NOT EXISTS model_meta (
+    model_id BIGINT NOT NULL,
+    model_name VARCHAR(128) NOT NULL,
+    metalake_id BIGINT NOT NULL,
+    catalog_id BIGINT NOT NULL,
+    schema_id BIGINT NOT NULL,
+    model_comment VARCHAR(65535) DEFAULT NULL,
+    model_properties TEXT DEFAULT NULL,
+    model_latest_version INT NOT NULL DEFAULT 0,
+    audit_info TEXT NOT NULL,
+    deleted_at BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (model_id),
+    UNIQUE (schema_id, model_name, deleted_at)
+    );
+
+CREATE INDEX IF NOT EXISTS idx_metalake_id ON model_meta (metalake_id);
+CREATE INDEX IF NOT EXISTS idx_catalog_id ON model_meta (catalog_id);
+COMMENT ON TABLE model_meta IS 'model metadata';
+
+COMMENT ON COLUMN model_meta.model_id IS 'model id';
+COMMENT ON COLUMN model_meta.model_name IS 'model name';
+COMMENT ON COLUMN model_meta.metalake_id IS 'metalake id';
+COMMENT ON COLUMN model_meta.catalog_id IS 'catalog id';
+COMMENT ON COLUMN model_meta.schema_id IS 'schema id';
+COMMENT ON COLUMN model_meta.model_comment IS 'model comment';
+COMMENT ON COLUMN model_meta.model_properties IS 'model properties';
+COMMENT ON COLUMN model_meta.model_latest_version IS 'model max version';
+COMMENT ON COLUMN model_meta.audit_info IS 'model audit info';
+COMMENT ON COLUMN model_meta.deleted_at IS 'model deleted at';
+
+
+CREATE TABLE IF NOT EXISTS model_version_info (
+    id BIGINT NOT NULL GENERATED BY DEFAULT AS IDENTITY,
+    metalake_id BIGINT NOT NULL,
+    catalog_id BIGINT NOT NULL,
+    schema_id BIGINT NOT NULL,
+    model_id BIGINT NOT NULL,
+    version INT NOT NULL,
+    model_version_comment VARCHAR(65535) DEFAULT NULL,
+    model_version_properties TEXT DEFAULT NULL,
+    model_version_uri TEXT NOT NULL,
+    audit_info TEXT NOT NULL,
+    deleted_at BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (id),
+    UNIQUE (model_id, version, deleted_at)
+    );
+
+CREATE INDEX IF NOT EXISTS idx_metalake_id ON model_version_info (metalake_id);
+CREATE INDEX IF NOT EXISTS idx_catalog_id ON model_version_info (catalog_id);
+CREATE INDEX IF NOT EXISTS idx_schema_id ON model_version_info (schema_id);
+COMMENT ON TABLE model_version_info IS 'model version information';
+
+COMMENT ON COLUMN model_version_info.id IS 'auto increment id';
+COMMENT ON COLUMN model_version_info.metalake_id IS 'metalake id';
+COMMENT ON COLUMN model_version_info.catalog_id IS 'catalog id';
+COMMENT ON COLUMN model_version_info.schema_id IS 'schema id';
+COMMENT ON COLUMN model_version_info.model_id IS 'model id';
+COMMENT ON COLUMN model_version_info.version IS 'model version';
+COMMENT ON COLUMN model_version_info.model_version_comment IS 'model version comment';
+COMMENT ON COLUMN model_version_info.model_version_properties IS 'model version properties';
+COMMENT ON COLUMN model_version_info.model_version_uri IS 'model storage uri';
+COMMENT ON COLUMN model_version_info.audit_info IS 'model version audit info';
+COMMENT ON COLUMN model_version_info.deleted_at IS 'model version deleted at';
+
+
+CREATE TABLE IF NOT EXISTS model_version_alias_rel (
+    id BIGINT NOT NULL GENERATED BY DEFAULT AS IDENTITY,
+    model_id BIGINT NOT NULL,
+    model_version INT NOT NULL,
+    model_version_alias VARCHAR(128) NOT NULL,
+    deleted_at BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (id),
+    UNIQUE (model_id, model_version_alias, deleted_at)
+    );
+
+CREATE INDEX IF NOT EXISTS idx_model_version_alias on model_version_alias_rel (model_version_alias);
+COMMENT ON TABLE model_version_alias_rel IS 'model version alias relation';
+
+COMMENT ON COLUMN model_version_alias_rel.id IS 'auto increment id';
+COMMENT ON COLUMN model_version_alias_rel.model_id IS 'model id';
+COMMENT ON COLUMN model_version_alias_rel.model_version IS 'model version';
+COMMENT ON COLUMN model_version_alias_rel.model_version_alias IS 'model version alias';
+COMMENT ON COLUMN model_version_alias_rel.deleted_at IS 'model version alias deleted at';

--- a/scripts/postgresql/upgrade-0.8.0-to-0.9.0-postgresql.sql
+++ b/scripts/postgresql/upgrade-0.8.0-to-0.9.0-postgresql.sql
@@ -1,0 +1,26 @@
+--
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file--
+--  distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"). You may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--  http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+--
+
+-- using default 'unknown' to fill in the new column for compatibility
+ALTER TABLE fileset_version_info ADD COLUMN storage_location_name VARCHAR(256) NOT NULL DEFAULT 'unknown';
+COMMENT ON COLUMN fileset_version_info.storage_location_name IS 'fileset storage location name';
+ALTER TABLE fileset_version_info DROP CONSTRAINT uk_fid_ver_del;
+ALTER TABLE fileset_version_info ADD CONSTRAINT uk_fid_ver_sto_del UNIQUE (fileset_id, version, storage_location_name, deleted_at);
+-- remove the default value for storage_location_name
+ALTER TABLE fileset_version_info ALTER COLUMN storage_location_name DROP DEFAULT;


### PR DESCRIPTION
### What changes were proposed in this pull request?

- add `location_name` column to `fileset_version_info` table
- replace field `FilesetVersionPO filesetVersionPO` in `FilesetPO` with `List<FilesetVersionPO> filesetVersionPOs`
- replace field `storageLocation` of `FilesetEntity` with `storageLocations`
- Compatible with single location

### Why are the changes needed?

Fix: #6890 

### Does this PR introduce _any_ user-facing change?

no

### How was this patch tested?

CI pass
