### PR TITLE
[#6893] feat(server): support fileset multiple locations in REST API

### DIFF
--- a/clients/client-java/src/test/java/org/apache/gravitino/client/TestFilesetCatalog.java
+++ b/clients/client-java/src/test/java/org/apache/gravitino/client/TestFilesetCatalog.java
@@ -18,6 +18,7 @@
  */
 package org.apache.gravitino.client;
 
+import static org.apache.gravitino.file.Fileset.LOCATION_NAME_UNKNOWN;
 import static org.apache.hc.core5.http.HttpStatus.SC_CONFLICT;
 import static org.apache.hc.core5.http.HttpStatus.SC_NOT_FOUND;
 import static org.apache.hc.core5.http.HttpStatus.SC_OK;
@@ -544,11 +545,13 @@ public class TestFilesetCatalog extends TestBase {
       String comment,
       String location,
       Map<String, String> properties) {
+    Map<String, String> locations =
+        location == null ? ImmutableMap.of() : ImmutableMap.of(LOCATION_NAME_UNKNOWN, location);
     return FilesetDTO.builder()
         .name(name)
         .type(type)
         .comment(comment)
-        .storageLocation(location)
+        .storageLocations(locations)
         .properties(properties)
         .audit(AuditDTO.builder().withCreator("creator").withCreateTime(Instant.now()).build())
         .build();

--- a/clients/client-java/src/test/java/org/apache/gravitino/client/TestSupportCredentials.java
+++ b/clients/client-java/src/test/java/org/apache/gravitino/client/TestSupportCredentials.java
@@ -18,10 +18,12 @@
  */
 package org.apache.gravitino.client;
 
+import static org.apache.gravitino.file.Fileset.LOCATION_NAME_UNKNOWN;
 import static org.apache.hc.core5.http.HttpStatus.SC_INTERNAL_SERVER_ERROR;
 import static org.apache.hc.core5.http.HttpStatus.SC_OK;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.google.common.collect.ImmutableMap;
 import java.util.Collections;
 import java.util.Locale;
 import org.apache.gravitino.Catalog;
@@ -74,7 +76,7 @@ public class TestSupportCredentials extends TestBase {
                 .name("fileset1")
                 .comment("comment1")
                 .type(Fileset.Type.EXTERNAL)
-                .storageLocation("s3://bucket/path")
+                .storageLocations(ImmutableMap.of(LOCATION_NAME_UNKNOWN, "s3://bucket/path"))
                 .properties(Collections.emptyMap())
                 .audit(AuditDTO.builder().withCreator("test").build())
                 .build(),

--- a/clients/client-java/src/test/java/org/apache/gravitino/client/TestSupportRoles.java
+++ b/clients/client-java/src/test/java/org/apache/gravitino/client/TestSupportRoles.java
@@ -18,11 +18,13 @@
  */
 package org.apache.gravitino.client;
 
+import static org.apache.gravitino.file.Fileset.LOCATION_NAME_UNKNOWN;
 import static org.apache.hc.core5.http.HttpStatus.SC_INTERNAL_SERVER_ERROR;
 import static org.apache.hc.core5.http.HttpStatus.SC_NOT_FOUND;
 import static org.apache.hc.core5.http.HttpStatus.SC_OK;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.google.common.collect.ImmutableMap;
 import java.util.Collections;
 import java.util.Locale;
 import org.apache.gravitino.Catalog;
@@ -142,7 +144,7 @@ public class TestSupportRoles extends TestBase {
                 .name("fileset1")
                 .comment("comment1")
                 .type(Fileset.Type.EXTERNAL)
-                .storageLocation("s3://bucket/path")
+                .storageLocations(ImmutableMap.of(LOCATION_NAME_UNKNOWN, "s3://bucket/path"))
                 .properties(Collections.emptyMap())
                 .audit(AuditDTO.builder().withCreator("test").build())
                 .build(),

--- a/clients/client-java/src/test/java/org/apache/gravitino/client/TestSupportTags.java
+++ b/clients/client-java/src/test/java/org/apache/gravitino/client/TestSupportTags.java
@@ -18,11 +18,13 @@
  */
 package org.apache.gravitino.client;
 
+import static org.apache.gravitino.file.Fileset.LOCATION_NAME_UNKNOWN;
 import static org.apache.hc.core5.http.HttpStatus.SC_INTERNAL_SERVER_ERROR;
 import static org.apache.hc.core5.http.HttpStatus.SC_NOT_FOUND;
 import static org.apache.hc.core5.http.HttpStatus.SC_OK;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.google.common.collect.ImmutableMap;
 import java.util.Collections;
 import java.util.Locale;
 import org.apache.gravitino.Catalog;
@@ -152,7 +154,7 @@ public class TestSupportTags extends TestBase {
                 .name("fileset1")
                 .comment("comment1")
                 .type(Fileset.Type.EXTERNAL)
-                .storageLocation("s3://bucket/path")
+                .storageLocations(ImmutableMap.of(LOCATION_NAME_UNKNOWN, "s3://bucket/path"))
                 .properties(Collections.emptyMap())
                 .audit(AuditDTO.builder().withCreator("test").build())
                 .build(),

--- a/clients/filesystem-hadoop3/src/test/java/org/apache/gravitino/filesystem/hadoop/GravitinoMockServerBase.java
+++ b/clients/filesystem-hadoop3/src/test/java/org/apache/gravitino/filesystem/hadoop/GravitinoMockServerBase.java
@@ -18,6 +18,7 @@
  */
 package org.apache.gravitino.filesystem.hadoop;
 
+import static org.apache.gravitino.file.Fileset.LOCATION_NAME_UNKNOWN;
 import static org.apache.hc.core5.http.HttpStatus.SC_OK;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -184,11 +185,15 @@ public abstract class GravitinoMockServerBase {
         String.format(
             "/api/metalakes/%s/catalogs/%s/schemas/%s/filesets/%s",
             metalakeName, catalogName, schemaName, filesetName);
+    Map<String, String> locations =
+        location == null
+            ? Collections.emptyMap()
+            : ImmutableMap.of(LOCATION_NAME_UNKNOWN, location);
     FilesetDTO mockFileset =
         FilesetDTO.builder()
             .name(fileset.name())
             .type(type)
-            .storageLocation(location)
+            .storageLocations(locations)
             .comment("comment")
             .properties(ImmutableMap.of("k1", "v1"))
             .audit(AuditDTO.builder().withCreator("creator").withCreateTime(Instant.now()).build())

--- a/clients/filesystem-hadoop3/src/test/java/org/apache/gravitino/filesystem/hadoop/TestGvfsBase.java
+++ b/clients/filesystem-hadoop3/src/test/java/org/apache/gravitino/filesystem/hadoop/TestGvfsBase.java
@@ -18,6 +18,7 @@
  */
 package org.apache.gravitino.filesystem.hadoop;
 
+import static org.apache.gravitino.file.Fileset.LOCATION_NAME_UNKNOWN;
 import static org.apache.hc.core5.http.HttpStatus.SC_OK;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -341,7 +342,7 @@ public class TestGvfsBase extends GravitinoMockServerBase {
                 .comment("comment")
                 .type(Fileset.Type.MANAGED)
                 .audit(AuditDTO.builder().build())
-                .storageLocation(filesetLocation.toString())
+                .storageLocations(ImmutableMap.of(LOCATION_NAME_UNKNOWN, filesetLocation))
                 .build());
     CredentialResponse credentialResponse = new CredentialResponse(new CredentialDTO[] {});
 

--- a/common/src/main/java/org/apache/gravitino/dto/file/FilesetDTO.java
+++ b/common/src/main/java/org/apache/gravitino/dto/file/FilesetDTO.java
@@ -20,20 +20,16 @@ package org.apache.gravitino.dto.file;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
+import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.Nullable;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.gravitino.dto.AuditDTO;
 import org.apache.gravitino.file.Fileset;
 
 /** Represents a Fileset DTO (Data Transfer Object). */
-@NoArgsConstructor(access = AccessLevel.PRIVATE, force = true)
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @EqualsAndHashCode
 public class FilesetDTO implements Fileset {
 
@@ -49,11 +45,33 @@ public class FilesetDTO implements Fileset {
   @JsonProperty("storageLocation")
   private String storageLocation;
 
+  @JsonProperty("storageLocations")
+  private Map<String, String> storageLocations;
+
   @JsonProperty("properties")
   private Map<String, String> properties;
 
   @JsonProperty("audit")
   private AuditDTO audit;
+
+  private FilesetDTO() {}
+
+  private FilesetDTO(
+      String name,
+      String comment,
+      Type type,
+      String storageLocation,
+      Map<String, String> storageLocations,
+      Map<String, String> properties,
+      AuditDTO audit) {
+    this.name = name;
+    this.comment = comment;
+    this.type = type;
+    this.storageLocation = storageLocation;
+    this.storageLocations = storageLocations;
+    this.properties = properties;
+    this.audit = audit;
+  }
 
   @Override
   public String name() {
@@ -72,8 +90,8 @@ public class FilesetDTO implements Fileset {
   }
 
   @Override
-  public String storageLocation() {
-    return storageLocation;
+  public Map<String, String> storageLocations() {
+    return storageLocations;
   }
 
   @Override
@@ -86,18 +104,116 @@ public class FilesetDTO implements Fileset {
     return audit;
   }
 
-  @Builder(builderMethodName = "builder")
-  private static FilesetDTO internalBuilder(
-      String name,
-      String comment,
-      Type type,
-      String storageLocation,
-      Map<String, String> properties,
-      AuditDTO audit) {
-    Preconditions.checkArgument(StringUtils.isNotBlank(name), "name cannot be null or empty");
-    Preconditions.checkNotNull(type, "type cannot be null");
-    Preconditions.checkNotNull(audit, "audit cannot be null");
+  /**
+   * Create a new FilesetDTO builder.
+   *
+   * @return A new FilesetDTO builder.
+   */
+  public static FilesetDTOBuilder builder() {
+    return new FilesetDTOBuilder();
+  }
 
-    return new FilesetDTO(name, comment, type, storageLocation, properties, audit);
+  /** Builder for FilesetDTO. */
+  public static class FilesetDTOBuilder {
+    private String name;
+    private String comment;
+    private Type type;
+    private Map<String, String> storageLocations = new HashMap<>();
+    private Map<String, String> properties;
+    private AuditDTO audit;
+
+    private FilesetDTOBuilder() {}
+
+    /**
+     * Set the name of the fileset.
+     *
+     * @param name The name of the fileset.
+     * @return The builder instance.
+     */
+    public FilesetDTOBuilder name(String name) {
+      this.name = name;
+      return this;
+    }
+
+    /**
+     * Set the comment of the fileset.
+     *
+     * @param comment The comment of the fileset.
+     * @return The builder instance.
+     */
+    public FilesetDTOBuilder comment(String comment) {
+      this.comment = comment;
+      return this;
+    }
+
+    /**
+     * Set the type of the fileset.
+     *
+     * @param type The type of the fileset.
+     * @return The builder instance.
+     */
+    public FilesetDTOBuilder type(Type type) {
+      this.type = type;
+      return this;
+    }
+
+    /**
+     * Set the storage locations of the fileset.
+     *
+     * @param storageLocations The storage locations of the fileset.
+     * @return The builder instance.
+     */
+    public FilesetDTOBuilder storageLocations(Map<String, String> storageLocations) {
+      this.storageLocations = ImmutableMap.copyOf(storageLocations);
+      return this;
+    }
+
+    /**
+     * Set the properties of the fileset.
+     *
+     * @param properties The properties of the fileset.
+     * @return The builder instance.
+     */
+    public FilesetDTOBuilder properties(Map<String, String> properties) {
+      this.properties = properties;
+      return this;
+    }
+
+    /**
+     * Set the audit information of the fileset.
+     *
+     * @param audit The audit information of the fileset.
+     * @return The builder instance.
+     */
+    public FilesetDTOBuilder audit(AuditDTO audit) {
+      this.audit = audit;
+      return this;
+    }
+
+    /**
+     * Build the FilesetDTO.
+     *
+     * @return The built FilesetDTO.
+     */
+    public FilesetDTO build() {
+      Preconditions.checkArgument(StringUtils.isNotBlank(name), "name cannot be null or empty");
+      Preconditions.checkArgument(
+          !storageLocations.isEmpty(),
+          "storage locations cannot be empty. At least one location is required.");
+      storageLocations.forEach(
+          (n, l) -> {
+            Preconditions.checkArgument(StringUtils.isNotBlank(n), "location name cannot be empty");
+            Preconditions.checkArgument(
+                StringUtils.isNotBlank(l), "storage location cannot be empty");
+          });
+      return new FilesetDTO(
+          name,
+          comment,
+          type,
+          storageLocations.get(LOCATION_NAME_UNKNOWN),
+          storageLocations,
+          properties,
+          audit);
+    }
   }
 }

--- a/common/src/main/java/org/apache/gravitino/dto/requests/FilesetCreateRequest.java
+++ b/common/src/main/java/org/apache/gravitino/dto/requests/FilesetCreateRequest.java
@@ -57,6 +57,10 @@ public class FilesetCreateRequest implements RESTRequest {
   private String storageLocation;
 
   @Nullable
+  @JsonProperty("storageLocations")
+  private Map<String, String> storageLocations;
+
+  @Nullable
   @JsonProperty("properties")
   private Map<String, String> properties;
 

--- a/common/src/main/java/org/apache/gravitino/dto/util/DTOConverters.java
+++ b/common/src/main/java/org/apache/gravitino/dto/util/DTOConverters.java
@@ -612,7 +612,7 @@ public class DTOConverters {
         .name(fileset.name())
         .comment(fileset.comment())
         .type(fileset.type())
-        .storageLocation(fileset.storageLocation())
+        .storageLocations(fileset.storageLocations())
         .properties(fileset.properties())
         .audit(toDTO(fileset.auditInfo()))
         .build();

--- a/common/src/test/java/org/apache/gravitino/dto/file/TestFilesetDTO.java
+++ b/common/src/test/java/org/apache/gravitino/dto/file/TestFilesetDTO.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.dto.file;
+
+import static org.apache.gravitino.file.Fileset.LOCATION_NAME_UNKNOWN;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.google.common.collect.ImmutableMap;
+import java.time.Instant;
+import java.util.Map;
+import org.apache.gravitino.dto.AuditDTO;
+import org.apache.gravitino.json.JsonUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TestFilesetDTO {
+
+  @Test
+  public void testFilesetSerDe() throws JsonProcessingException {
+    AuditDTO audit = AuditDTO.builder().withCreator("user1").withCreateTime(Instant.now()).build();
+    Map<String, String> props = ImmutableMap.of("key", "value");
+
+    // test with default location
+    FilesetDTO filesetDTO =
+        FilesetDTO.builder()
+            .name("fileset_test")
+            .comment("model comment")
+            .storageLocations(ImmutableMap.of(LOCATION_NAME_UNKNOWN, "/a/b/c", "v1", "/d/e/f"))
+            .properties(props)
+            .audit(audit)
+            .build();
+    Assertions.assertEquals("fileset_test", filesetDTO.name());
+    Assertions.assertEquals("model comment", filesetDTO.comment());
+    Assertions.assertEquals(
+        ImmutableMap.of(LOCATION_NAME_UNKNOWN, "/a/b/c", "v1", "/d/e/f"),
+        filesetDTO.storageLocations());
+    Assertions.assertEquals("/a/b/c", filesetDTO.storageLocation());
+    Assertions.assertEquals(props, filesetDTO.properties());
+    Assertions.assertEquals(audit, filesetDTO.auditInfo());
+
+    String serJson = JsonUtils.objectMapper().writeValueAsString(filesetDTO);
+    FilesetDTO deserFilesetDTO = JsonUtils.objectMapper().readValue(serJson, FilesetDTO.class);
+    Assertions.assertEquals(filesetDTO, deserFilesetDTO);
+
+    // test without default location exception
+    Exception exception =
+        Assertions.assertThrows(
+            IllegalArgumentException.class, () -> FilesetDTO.builder().name("test").build());
+    Assertions.assertEquals(
+        "storage locations cannot be empty. At least one location is required.",
+        exception.getMessage());
+
+    // test empty location name exception
+    exception =
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () -> FilesetDTO.builder().storageLocations(ImmutableMap.of("", "/a/b/c")).build());
+    Assertions.assertEquals("name cannot be null or empty", exception.getMessage());
+
+    // test empty default location
+    exception =
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                FilesetDTO.builder()
+                    .name("test")
+                    .storageLocations(ImmutableMap.of(LOCATION_NAME_UNKNOWN, ""))
+                    .build());
+    Assertions.assertEquals("storage location cannot be empty", exception.getMessage());
+
+    // test empty location
+    exception =
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                FilesetDTO.builder()
+                    .name("test")
+                    .storageLocations(ImmutableMap.of(LOCATION_NAME_UNKNOWN, "/a/b/c", "v1", ""))
+                    .build());
+    Assertions.assertEquals("storage location cannot be empty", exception.getMessage());
+  }
+}

--- a/docs/open-api/filesets.yaml
+++ b/docs/open-api/filesets.yaml
@@ -177,6 +177,13 @@ paths:
           schema:
             type: string
           description: The sub path to the file or directory
+        - name: location_name
+          in: query
+          required: false
+          schema:
+            type: string
+            default: "default"
+          description: The location name in the fileset
       responses:
         "200":
           $ref: "#/components/responses/FileLocationResponse"
@@ -249,6 +256,14 @@ components:
           description: The location of the fileset. If the storage location of managed fileset is empty, it will \
             use the location of namespace. The storage location of external fileset must be set.
           nullable: true
+        storageLocations:
+          type: object
+          description: The storage locations of the fileset. If the storage location of managed fileset is empty, \
+            it will use the location of namespace. The storage locations of external fileset must be set.
+          nullable: true
+          default: { }
+          additionalProperties:
+            type: string
         properties:
           type: object
           description: The properties of the fileset. Can be empty.


### PR DESCRIPTION
### What changes were proposed in this pull request?

support fileset multiple locations in REST API

### Why are the changes needed?

support fileset multiple locations in REST API

Fix: #6893 

### Does this PR introduce _any_ user-facing change?

yes

### How was this patch tested?

tests added
