### PR TITLE
[#6894] feat(client): Java/Python clients supports fileset multiple locations

### DIFF
--- a/clients/client-java/src/main/java/org/apache/gravitino/client/ErrorHandlers.java
+++ b/clients/client-java/src/main/java/org/apache/gravitino/client/ErrorHandlers.java
@@ -46,6 +46,7 @@ import org.apache.gravitino.exceptions.ModelVersionAliasesAlreadyExistException;
 import org.apache.gravitino.exceptions.NoSuchCatalogException;
 import org.apache.gravitino.exceptions.NoSuchFilesetException;
 import org.apache.gravitino.exceptions.NoSuchGroupException;
+import org.apache.gravitino.exceptions.NoSuchLocationNameException;
 import org.apache.gravitino.exceptions.NoSuchMetadataObjectException;
 import org.apache.gravitino.exceptions.NoSuchMetalakeException;
 import org.apache.gravitino.exceptions.NoSuchModelException;
@@ -602,10 +603,18 @@ public class ErrorHandlers {
           throw new IllegalArgumentException(errorMessage);
 
         case ErrorConstants.NOT_FOUND_CODE:
-          if (errorResponse.getType().equals(NoSuchSchemaException.class.getSimpleName())) {
+          if (errorResponse.getType().equals(NoSuchMetalakeException.class.getSimpleName())) {
+            throw new NoSuchMetalakeException(errorMessage);
+          } else if (errorResponse.getType().equals(NoSuchCatalogException.class.getSimpleName())) {
+            throw new NoSuchCatalogException(errorMessage);
+          } else if (errorResponse.getType().equals(NoSuchSchemaException.class.getSimpleName())) {
             throw new NoSuchSchemaException(errorMessage);
           } else if (errorResponse.getType().equals(NoSuchFilesetException.class.getSimpleName())) {
             throw new NoSuchFilesetException(errorMessage);
+          } else if (errorResponse
+              .getType()
+              .equals(NoSuchLocationNameException.class.getSimpleName())) {
+            throw new NoSuchLocationNameException(errorMessage);
           } else {
             throw new NotFoundException(errorMessage);
           }

--- a/clients/client-java/src/main/java/org/apache/gravitino/client/GenericFileset.java
+++ b/clients/client-java/src/main/java/org/apache/gravitino/client/GenericFileset.java
@@ -79,8 +79,8 @@ class GenericFileset implements Fileset, SupportsTags, SupportsRoles, SupportsCr
   }
 
   @Override
-  public String storageLocation() {
-    return filesetDTO.storageLocation();
+  public Map<String, String> storageLocations() {
+    return filesetDTO.storageLocations();
   }
 
   @Override

--- a/clients/client-java/src/test/java/org/apache/gravitino/client/TestFilesetCatalog.java
+++ b/clients/client-java/src/test/java/org/apache/gravitino/client/TestFilesetCatalog.java
@@ -58,6 +58,7 @@ import org.apache.gravitino.dto.responses.FilesetResponse;
 import org.apache.gravitino.exceptions.AlreadyExistsException;
 import org.apache.gravitino.exceptions.FilesetAlreadyExistsException;
 import org.apache.gravitino.exceptions.NoSuchFilesetException;
+import org.apache.gravitino.exceptions.NoSuchLocationNameException;
 import org.apache.gravitino.exceptions.NoSuchSchemaException;
 import org.apache.gravitino.exceptions.NotFoundException;
 import org.apache.gravitino.file.Fileset;
@@ -237,7 +238,7 @@ public class TestFilesetCatalog extends TestBase {
             .properties(ImmutableMap.of("k1", "v1"))
             .build();
     FilesetResponse resp = new FilesetResponse(mockFileset);
-    buildMockResource(Method.POST, filesetPath, req, resp, SC_OK);
+    buildMockResource(Method.POST, filesetPath, toMultipleLocationReq(req), resp, SC_OK);
     Fileset loadedFileset =
         catalog
             .asFilesetCatalog()
@@ -254,7 +255,7 @@ public class TestFilesetCatalog extends TestBase {
     ErrorResponse errResp =
         ErrorResponse.alreadyExists(
             FilesetAlreadyExistsException.class.getSimpleName(), "fileset already exists");
-    buildMockResource(Method.POST, filesetPath, req, errResp, SC_CONFLICT);
+    buildMockResource(Method.POST, filesetPath, toMultipleLocationReq(req), errResp, SC_CONFLICT);
     Assertions.assertThrows(
         AlreadyExistsException.class,
         () ->
@@ -283,6 +284,19 @@ public class TestFilesetCatalog extends TestBase {
                     "mock location",
                     ImmutableMap.of("k1", "v1")),
         "internal error");
+  }
+
+  private FilesetCreateRequest toMultipleLocationReq(FilesetCreateRequest req) {
+    return FilesetCreateRequest.builder()
+        .name(req.getName())
+        .type(req.getType())
+        .comment(req.getComment())
+        .storageLocations(
+            req.getStorageLocation() == null
+                ? ImmutableMap.of()
+                : ImmutableMap.of(LOCATION_NAME_UNKNOWN, req.getStorageLocation()))
+        .properties(req.getProperties())
+        .build();
   }
 
   @Test
@@ -440,6 +454,21 @@ public class TestFilesetCatalog extends TestBase {
     Assertions.assertTrue(StringUtils.isNotBlank(actualFileLocation));
     Assertions.assertEquals(mockFileLocation, actualFileLocation);
 
+    // get location by location name
+    String mockLocationName = "location1";
+    queryParams.put("location_name", mockLocationName);
+    buildMockResource(Method.GET, filesetPath, queryParams, null, resp, SC_OK);
+
+    actualFileLocation =
+        catalog
+            .asFilesetCatalog()
+            .getFileLocation(
+                NameIdentifier.of(fileset.namespace().level(2), fileset.name()),
+                mockSubPath,
+                mockLocationName);
+    Assertions.assertTrue(StringUtils.isNotBlank(actualFileLocation));
+    Assertions.assertEquals(mockFileLocation, actualFileLocation);
+
     // Throw schema not found exception
     ErrorResponse errResp =
         ErrorResponse.notFound(NoSuchSchemaException.class.getSimpleName(), "schema not found");
@@ -475,6 +504,22 @@ public class TestFilesetCatalog extends TestBase {
                 .getFileLocation(
                     NameIdentifier.of(fileset.namespace().level(2), fileset.name()), mockSubPath),
         "internal error");
+
+    // throw NoSuchLocationNameException
+    ErrorResponse errResp3 =
+        ErrorResponse.notFound(
+            NoSuchLocationNameException.class.getSimpleName(), "location name not found");
+    buildMockResource(Method.GET, filesetPath, null, errResp3, SC_NOT_FOUND);
+    Assertions.assertThrows(
+        NoSuchLocationNameException.class,
+        () ->
+            catalog
+                .asFilesetCatalog()
+                .getFileLocation(
+                    NameIdentifier.of(fileset.namespace().level(2), fileset.name()),
+                    mockSubPath,
+                    mockLocationName),
+        "location name not found");
   }
 
   @Test

--- a/clients/client-python/gravitino/client/generic_fileset.py
+++ b/clients/client-python/gravitino/client/generic_fileset.py
@@ -56,12 +56,8 @@ class GenericFileset(Fileset, SupportsCredentials):
     def type(self) -> Fileset.Type:
         return self._fileset.type()
 
-    def storage_location(self) -> str:
-        return self._fileset.storage_location()
-
     def storage_locations(self) -> Dict[str, str]:
-        # todo: implement this method and remove storage_location method
-        pass
+        return self._fileset.storage_locations()
 
     def comment(self) -> Optional[str]:
         return self._fileset.comment()

--- a/clients/client-python/gravitino/dto/fileset_dto.py
+++ b/clients/client-python/gravitino/dto/fileset_dto.py
@@ -32,8 +32,8 @@ class FilesetDTO(Fileset, DataClassJsonMixin):
     _comment: Optional[str] = field(metadata=config(field_name="comment"))
     _type: Fileset.Type = field(metadata=config(field_name="type"))
     _properties: Dict[str, str] = field(metadata=config(field_name="properties"))
-    _storage_location: str = field(
-        default=None, metadata=config(field_name="storageLocation")
+    _storage_locations: Dict[str, str] = field(
+        metadata=config(field_name="storageLocations")
     )
     _audit: AuditDTO = field(default=None, metadata=config(field_name="audit"))
 
@@ -43,12 +43,8 @@ class FilesetDTO(Fileset, DataClassJsonMixin):
     def type(self) -> Fileset.Type:
         return self._type
 
-    def storage_location(self) -> str:
-        return self._storage_location
-
     def storage_locations(self) -> Dict[str, str]:
-        # todo: implement this method and remove storage_location method
-        pass
+        return self._storage_locations
 
     def comment(self) -> Optional[str]:
         return self._comment

--- a/clients/client-python/gravitino/dto/requests/fileset_create_request.py
+++ b/clients/client-python/gravitino/dto/requests/fileset_create_request.py
@@ -31,8 +31,8 @@ class FilesetCreateRequest(RESTRequest):
     _name: str = field(metadata=config(field_name="name"))
     _comment: Optional[str] = field(metadata=config(field_name="comment"))
     _type: Optional[Fileset.Type] = field(metadata=config(field_name="type"))
-    _storage_location: Optional[str] = field(
-        metadata=config(field_name="storageLocation")
+    _storage_locations: Optional[Dict[str, str]] = field(
+        metadata=config(field_name="storageLocations")
     )
     _properties: Optional[Dict[str, str]] = field(
         metadata=config(field_name="properties")
@@ -43,13 +43,13 @@ class FilesetCreateRequest(RESTRequest):
         name: str,
         comment: Optional[str] = None,
         fileset_type: Fileset.Type = None,
-        storage_location: Optional[str] = None,
+        storage_locations: Optional[Dict[str, str]] = None,
         properties: Optional[Dict[str, str]] = None,
     ):
         self._name = name
         self._comment = comment
         self._type = fileset_type
-        self._storage_location = storage_location
+        self._storage_locations = storage_locations
         self._properties = properties
 
     def validate(self):

--- a/clients/client-python/gravitino/dto/responses/fileset_response.py
+++ b/clients/client-python/gravitino/dto/responses/fileset_response.py
@@ -44,9 +44,13 @@ class FilesetResponse(BaseResponse):
             raise IllegalArgumentException("fileset must not be null")
         if not self._fileset.name():
             raise IllegalArgumentException("fileset 'name' must not be null and empty")
-        if not self._fileset.storage_location():
+        if not self._fileset.storage_locations():
             raise IllegalArgumentException(
-                "fileset 'storageLocation' must not be null and empty"
+                "fileset 'storageLocations' must not be null"
+            )
+        if not self._fileset.storage_locations():
+            raise IllegalArgumentException(
+                "fileset 'storageLocations' must not be empty. At least one location is required."
             )
         if self._fileset.type() is None:
             raise IllegalArgumentException("fileset 'type' must not be null and empty")

--- a/clients/client-python/gravitino/exceptions/handlers/fileset_error_handler.py
+++ b/clients/client-python/gravitino/exceptions/handlers/fileset_error_handler.py
@@ -22,6 +22,7 @@ from gravitino.exceptions.base import (
     NoSuchFilesetException,
     NoSuchSchemaException,
     CatalogNotInUseException,
+    NoSuchLocationNameException,
 )
 
 
@@ -38,6 +39,8 @@ class FilesetErrorHandler(RestErrorHandler):
                 raise NoSuchSchemaException(error_message)
             if exception_type == NoSuchFilesetException.__name__:
                 raise NoSuchFilesetException(error_message)
+            if exception_type == NoSuchLocationNameException.__name__:
+                raise NoSuchLocationNameException(error_message)
 
         if code == ErrorConstants.NOT_IN_USE_CODE:
             raise CatalogNotInUseException(error_message)

--- a/clients/client-python/tests/integration/test_fileset_catalog.py
+++ b/clients/client-python/tests/integration/test_fileset_catalog.py
@@ -17,7 +17,7 @@
 
 import logging
 from random import randint
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from gravitino import (
     NameIdentifier,
@@ -48,10 +48,12 @@ class TestFilesetCatalog(IntegrationTestEnv):
     schema_name: str = "schema"
 
     fileset_name: str = "fileset"
+    multiple_locations_fileset_name: str = "multiple_locations_fileset"
     fileset_alter_name: str = fileset_name + "Alter"
     fileset_comment: str = "fileset_comment"
 
     fileset_location: str = "/tmp/TestFilesetCatalog"
+    fileset_location2: str = "/tmp/TestFilesetCatalog2"
     fileset_properties_key1: str = "fileset_properties_key1"
     fileset_properties_value1: str = "fileset_properties_value1"
     fileset_properties_key2: str = "fileset_properties_key2"
@@ -60,6 +62,10 @@ class TestFilesetCatalog(IntegrationTestEnv):
         fileset_properties_key1: fileset_properties_value1,
         fileset_properties_key2: fileset_properties_value2,
     }
+    multiple_locations_fileset_properties: Dict[str, str] = {
+        Fileset.PROPERTY_DEFAULT_LOCATION_NAME: "location1",
+        **fileset_properties,
+    }
     fileset_new_name = fileset_name + "_new"
 
     catalog_ident: NameIdentifier = NameIdentifier.of(metalake_name, catalog_name)
@@ -67,6 +73,9 @@ class TestFilesetCatalog(IntegrationTestEnv):
         metalake_name, catalog_name, schema_name
     )
     fileset_ident: NameIdentifier = NameIdentifier.of(schema_name, fileset_name)
+    multiple_locations_fileset_ident: NameIdentifier = NameIdentifier.of(
+        schema_name, multiple_locations_fileset_name
+    )
     fileset_new_ident: NameIdentifier = NameIdentifier.of(schema_name, fileset_new_name)
 
     gravitino_admin_client: GravitinoAdminClient = GravitinoAdminClient(
@@ -163,16 +172,55 @@ class TestFilesetCatalog(IntegrationTestEnv):
             properties=self.fileset_properties,
         )
 
+    def create_multiple_locations_fileset(self) -> Fileset:
+        catalog = self.gravitino_client.load_catalog(name=self.catalog_name)
+        return catalog.as_fileset_catalog().create_multiple_location_fileset(
+            ident=self.multiple_locations_fileset_ident,
+            fileset_type=Fileset.Type.MANAGED,
+            comment=self.fileset_comment,
+            storage_locations={
+                "location1": self.fileset_location,
+                "location2": self.fileset_location2,
+            },
+            properties=self.multiple_locations_fileset_properties,
+        )
+
     def create_custom_fileset(
-        self, ident: NameIdentifier, storage_location: str
+        self,
+        ident: NameIdentifier,
+        storage_location: Optional[str],
+        storage_locations: Optional[Dict[str, str]] = None,
+        default_location_name: Optional[str] = None,
     ) -> Fileset:
         catalog = self.gravitino_client.load_catalog(name=self.catalog_name)
-        return catalog.as_fileset_catalog().create_fileset(
+        if storage_locations is None:
+            return catalog.as_fileset_catalog().create_fileset(
+                ident=ident,
+                fileset_type=Fileset.Type.MANAGED,
+                comment=self.fileset_comment,
+                storage_location=storage_location,
+                properties=(
+                    self.fileset_properties
+                    if default_location_name is None
+                    else {
+                        Fileset.PROPERTY_DEFAULT_LOCATION_NAME: default_location_name,
+                        **self.fileset_properties,
+                    }
+                ),
+            )
+        return catalog.as_fileset_catalog().create_multiple_location_fileset(
             ident=ident,
             fileset_type=Fileset.Type.MANAGED,
             comment=self.fileset_comment,
-            storage_location=storage_location,
-            properties=self.fileset_properties,
+            storage_locations=storage_locations,
+            properties=(
+                self.fileset_properties
+                if default_location_name is None
+                else {
+                    Fileset.PROPERTY_DEFAULT_LOCATION_NAME: default_location_name,
+                    **self.fileset_properties,
+                }
+            ),
         )
 
     def test_create_fileset(self):
@@ -188,6 +236,28 @@ class TestFilesetCatalog(IntegrationTestEnv):
             },
         )
         self.assertEqual(fileset.storage_location(), f"file:{self.fileset_location}")
+
+    def test_create_fileset_with_multiple_locations(self):
+        fileset = self.create_multiple_locations_fileset()
+        self.assertIsNotNone(fileset)
+        self.assertEqual(fileset.type(), Fileset.Type.MANAGED)
+        self.assertEqual(fileset.comment(), self.fileset_comment)
+        self.assertEqual(
+            fileset.properties(), self.multiple_locations_fileset_properties
+        )
+        self.assertEqual(
+            fileset.storage_location(),
+            f"file:/tmp/test1/{self.schema_name}/{self.multiple_locations_fileset_name}",
+        )
+        self.assertEqual(
+            fileset.storage_locations(),
+            {
+                Fileset.LOCATION_NAME_UNKNOWN: f"file:/tmp/test1/"
+                f"{self.schema_name}/{self.multiple_locations_fileset_name}",
+                "location1": f"file:{self.fileset_location}",
+                "location2": f"file:{self.fileset_location2}",
+            },
+        )
 
     def test_drop_fileset(self):
         self.create_fileset()
@@ -270,6 +340,26 @@ class TestFilesetCatalog(IntegrationTestEnv):
         )
 
         self.assertEqual(actual_file_location, f"file:{fileset_location}/test/test.txt")
+
+        # test get file location from multiple locations fileset
+        fileset_ident: NameIdentifier = NameIdentifier.of(
+            self.schema_name, "test_get_file_location_multiple_locations"
+        )
+        locations = {
+            "default": "/tmp/test_get_file_location",
+            "location1": "/tmp/test_get_file_location1",
+            "location2": "/tmp/test_get_file_location2",
+        }
+        self.create_custom_fileset(fileset_ident, None, locations, "location1")
+        actual_file_location = (
+            self.gravitino_client.load_catalog(name=self.catalog_name)
+            .as_fileset_catalog()
+            .get_file_location(fileset_ident, "/test/test.txt")
+        )
+
+        self.assertEqual(
+            actual_file_location, f"file:{locations['location1']}/test/test.txt"
+        )
 
         # test rename without sub path should throw an exception
         caller_context = CallerContext(

--- a/clients/client-python/tests/unittests/mock_base.py
+++ b/clients/client-python/tests/unittests/mock_base.py
@@ -94,8 +94,11 @@ def mock_load_fileset(name: str, location: str):
         _name=name,
         _type=Fileset.Type.MANAGED,
         _comment="this is test",
-        _properties={"k": "v"},
-        _storage_location=location,
+        _properties={
+            "k": "v",
+            Fileset.PROPERTY_DEFAULT_LOCATION_NAME: Fileset.LOCATION_NAME_UNKNOWN,
+        },
+        _storage_locations={Fileset.LOCATION_NAME_UNKNOWN: location},
         _audit=audit_dto,
     )
     return fileset

--- a/common/src/main/java/org/apache/gravitino/dto/responses/FilesetResponse.java
+++ b/common/src/main/java/org/apache/gravitino/dto/responses/FilesetResponse.java
@@ -63,8 +63,11 @@ public class FilesetResponse extends BaseResponse {
     Preconditions.checkArgument(
         StringUtils.isNotBlank(fileset.name()), "fileset 'name' must not be null and empty");
     Preconditions.checkArgument(
-        StringUtils.isNotBlank(fileset.storageLocation()),
-        "fileset 'storageLocation' must not be null and empty");
-    Preconditions.checkNotNull(fileset.type(), "fileset 'type' must not be null and empty");
+        fileset.type() != null, "fileset 'type' must not be null and empty");
+    Preconditions.checkArgument(
+        fileset.storageLocations() != null, "fileset 'storageLocations' must not be null");
+    Preconditions.checkArgument(
+        !fileset.storageLocations().isEmpty(),
+        "fileset 'storageLocations' must not be empty. At least one location is required.");
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Java/Python clients supports fileset multiple locations

### Why are the changes needed?

Fix: #6894

### Does this PR introduce _any_ user-facing change?

yes, Java/Python clients support fileset multiple locations

### How was this patch tested?

tests added
