### PR TITLE
[#5362] fix(client-python): fix wrong Gravitino version

### DIFF
--- a/clients/client-python/gravitino/client/gravitino_version.py
+++ b/clients/client-python/gravitino/client/gravitino_version.py
@@ -61,14 +61,9 @@ class GravitinoVersion(VersionDTO):
             raise GravitinoRuntimeException(
                 f"{GravitinoVersion.__name__} can't compare with {other.__class__.__name__}"
             )
-        version_cmp = [(self.major, other.major), (self.minor, other.minor), (self.patch, other.patch)]
-        for (a, b) in version_cmp:
-            if a > b:
-                return True
-            if a < b:
-                return False
-        # self, other is the same
-        return False
+        v1 = (self.major, self.minor, self.patch)
+        v2 = (other.major, other.minor, other.patch)
+        return v1 > v2
 
     def __eq__(self, other) -> bool:
         if not isinstance(other, GravitinoVersion):

--- a/clients/client-python/gravitino/client/gravitino_version.py
+++ b/clients/client-python/gravitino/client/gravitino_version.py
@@ -65,7 +65,7 @@ class GravitinoVersion(VersionDTO):
         for (a, b) in version_cmp:
             if a > b:
                 return True
-            elif a < b:
+            if a < b:
                 return False
         # self, other is the same
         return False

--- a/clients/client-python/gravitino/client/gravitino_version.py
+++ b/clients/client-python/gravitino/client/gravitino_version.py
@@ -61,12 +61,13 @@ class GravitinoVersion(VersionDTO):
             raise GravitinoRuntimeException(
                 f"{GravitinoVersion.__name__} can't compare with {other.__class__.__name__}"
             )
-        if self.major > other.major:
-            return True
-        if self.minor > other.minor:
-            return True
-        if self.patch > other.patch:
-            return True
+        version_cmp = [(self.major, other.major), (self.minor, other.minor), (self.patch, other.patch)]
+        for (a, b) in version_cmp:
+            if a > b:
+                return True
+            elif a < b:
+                return False
+        # self, other is the same
         return False
 
     def __eq__(self, other) -> bool:

--- a/clients/client-python/tests/unittests/test_gravitino_version.py
+++ b/clients/client-python/tests/unittests/test_gravitino_version.py
@@ -86,6 +86,7 @@ class TestGravitinoVersion(unittest.TestCase):
         version2 = GravitinoVersion(VersionDTO("0.7.0", "2023-01-01", "1234567"))
 
         self.assertFalse(version1 > version2)
+        self.assertGreater(version2, version1)
 
         # test equal with suffix
         version1 = GravitinoVersion(

--- a/clients/client-python/tests/unittests/test_gravitino_version.py
+++ b/clients/client-python/tests/unittests/test_gravitino_version.py
@@ -81,6 +81,12 @@ class TestGravitinoVersion(unittest.TestCase):
 
         self.assertGreater(version1, version2)
 
+        # version1.minor < version2.minor and version1.patch > version.patch
+        version1 = GravitinoVersion(VersionDTO("0.6.1", "2023-01-01", "1234567"))
+        version2 = GravitinoVersion(VersionDTO("0.7.0", "2023-01-01", "1234567"))
+
+        self.assertFalse(version1 > version2)
+
         # test equal with suffix
         version1 = GravitinoVersion(
             VersionDTO("0.6.0-SNAPSHOT", "2023-01-01", "1234567")


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

In current implementation of `GravitinoVersion.__gt__`, we don't handle the case 
when `version1.minor < version2.minor and version1.patch > version.patch`,
i.e. this will cause `0.6.1` greater than `0.7.0`.

### Why are the changes needed?

Bug fix.

Fix: #5362 

### Does this PR introduce _any_ user-facing change?

Yes, bug fixes.

### How was this patch tested?

By `TestGravitinoVersion.test_version_compare`