### PR TITLE
[Minor] Fix web license and notice files in the binary release

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -387,6 +387,11 @@ subprojects {
         if (name == "sourcesJar") {
           include("LICENSE")
           include("NOTICE")
+        } else if (project.name == "web") {
+          include("web/web/LICENSE.bin")
+          rename("LICENSE.bin", "LICENSE")
+          include("web/web/NOTICE.bin")
+          rename("NOTICE.bin", "NOTICE")
         } else {
           include("LICENSE.bin")
           rename("LICENSE.bin", "LICENSE")
@@ -633,6 +638,9 @@ tasks {
         from(projectDir.file("NOTICE.bin")) { into("package") }
         from(projectDir.file("README.md")) { into("package") }
         from(projectDir.file("DISCLAIMER.txt")) { into("package") }
+        from(projectDir.dir("web/web/licenses")) { into("package/web/licenses") }
+        from(projectDir.dir("web/web/LICENSE.bin")) { into("package/web") }
+        from(projectDir.dir("web/web/NOTICE.bin")) { into("package/web") }
         into(outputDir)
         rename { fileName ->
           fileName.replace(".bin", "")


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix web license and notice files in the binary release to include all web licenses and use the right files for the META-INF directory in the war file.

### Why are the changes needed?

To comply with ASF policy - although binary releases are not official.

Fix: #N/A

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Locally by creating and inspecting a distribution.
