### PR TITLE
[MINOR] add notification config for discussions

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -67,3 +67,4 @@ notifications:
   commits: commits@gravitino.apache.org
   issues: commits@gravitino.apache.org
   pullrequests: commits@gravitino.apache.org
+  discussions: dev@gravitino.apache.org


### PR DESCRIPTION
### What changes were proposed in this pull request?

add notification config for discussions

### Why are the changes needed?

According to the Apache Infrastructure’s official guidelines  
we should set notification config in .asf.yaml

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

N/A