### PR TITLE
[#6845] fix(core): handle NonEmptyEntityException while dropSchema

### DIFF
--- a/catalogs/catalog-jdbc-mysql/src/test/java/org/apache/gravitino/catalog/mysql/integration/test/CatalogMysqlIT.java
+++ b/catalogs/catalog-jdbc-mysql/src/test/java/org/apache/gravitino/catalog/mysql/integration/test/CatalogMysqlIT.java
@@ -923,6 +923,23 @@ public class CatalogMysqlIT extends BaseIT {
         () -> {
           schemas.loadSchema(schemaName);
         });
+
+    // test drop inconsistent database
+    catalog
+        .asSchemas()
+        .createSchema(schemaName, null, ImmutableMap.<String, String>builder().build());
+    catalog
+        .asTableCatalog()
+        .createTable(
+            NameIdentifier.of(schemaName, tableName),
+            createColumns(),
+            "Created by Gravitino client",
+            ImmutableMap.<String, String>builder().build());
+    // drop the table externally
+    mysqlService.executeQuery("DROP TABLE " + schemaName + "." + tableName);
+
+    // drop the schema without cascade
+    Assertions.assertTrue(catalog.asSchemas().dropSchema(schemaName, false));
   }
 
   @Test

--- a/core/src/main/java/org/apache/gravitino/catalog/SchemaOperationDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/SchemaOperationDispatcher.java
@@ -338,7 +338,7 @@ public class SchemaOperationDispatcher extends OperationDispatcher implements Sc
           } catch (NoSuchEntityException e) {
             LOG.warn("The schema to be dropped does not exist in the store: {}", ident, e);
           } catch (NonEmptyEntityException e) {
-            LOG.warn("The schema to be dropped does not empty in the store: {}", ident, e);
+            LOG.warn("The schema is not empty in the store: {}", ident, e);
             // then cascade delete the schema, otherwise, the schema will never be deleted.
             try {
               store.delete(ident, SCHEMA, true);

--- a/core/src/main/java/org/apache/gravitino/catalog/SchemaOperationDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/SchemaOperationDispatcher.java
@@ -339,6 +339,13 @@ public class SchemaOperationDispatcher extends OperationDispatcher implements Sc
             LOG.warn("The schema to be dropped does not exist in the store: {}", ident, e);
           } catch (NonEmptyEntityException e) {
             LOG.warn("The schema to be dropped does not empty in the store: {}", ident, e);
+            // then cascade delete the schema, otherwise, the schema will never be deleted.
+            try {
+              store.delete(ident, SCHEMA, true);
+            } catch (Exception e1) {
+              LOG.warn("Failed to delete the schema from the store: {}", ident, e1);
+            }
+
           } catch (Exception e) {
             throw new RuntimeException(e);
           }

--- a/core/src/main/java/org/apache/gravitino/catalog/SchemaOperationDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/SchemaOperationDispatcher.java
@@ -36,7 +36,6 @@ import org.apache.gravitino.connector.capability.Capability;
 import org.apache.gravitino.exceptions.NoSuchCatalogException;
 import org.apache.gravitino.exceptions.NoSuchEntityException;
 import org.apache.gravitino.exceptions.NoSuchSchemaException;
-import org.apache.gravitino.exceptions.NonEmptyEntityException;
 import org.apache.gravitino.exceptions.NonEmptySchemaException;
 import org.apache.gravitino.exceptions.SchemaAlreadyExistsException;
 import org.apache.gravitino.lock.LockType;
@@ -334,18 +333,9 @@ public class SchemaOperationDispatcher extends OperationDispatcher implements Sc
           // return value of the store operation into account. We only take the return value of the
           // catalog into account.
           try {
-            store.delete(ident, SCHEMA, cascade);
+            store.delete(ident, SCHEMA, true);
           } catch (NoSuchEntityException e) {
             LOG.warn("The schema to be dropped does not exist in the store: {}", ident, e);
-          } catch (NonEmptyEntityException e) {
-            LOG.warn("The schema to be dropped is not empty in the store: {}", ident, e);
-            // then cascade delete the schema, otherwise, the schema will never be deleted.
-            try {
-              store.delete(ident, SCHEMA, true);
-            } catch (Exception e1) {
-              LOG.warn("Failed to delete the schema from the store: {}", ident, e1);
-            }
-
           } catch (Exception e) {
             throw new RuntimeException(e);
           }

--- a/core/src/main/java/org/apache/gravitino/catalog/SchemaOperationDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/SchemaOperationDispatcher.java
@@ -36,6 +36,7 @@ import org.apache.gravitino.connector.capability.Capability;
 import org.apache.gravitino.exceptions.NoSuchCatalogException;
 import org.apache.gravitino.exceptions.NoSuchEntityException;
 import org.apache.gravitino.exceptions.NoSuchSchemaException;
+import org.apache.gravitino.exceptions.NonEmptyEntityException;
 import org.apache.gravitino.exceptions.NonEmptySchemaException;
 import org.apache.gravitino.exceptions.SchemaAlreadyExistsException;
 import org.apache.gravitino.lock.LockType;
@@ -336,6 +337,8 @@ public class SchemaOperationDispatcher extends OperationDispatcher implements Sc
             store.delete(ident, SCHEMA, cascade);
           } catch (NoSuchEntityException e) {
             LOG.warn("The schema to be dropped does not exist in the store: {}", ident, e);
+          } catch (NonEmptyEntityException e) {
+            LOG.warn("The schema to be dropped does not empty in the store: {}", ident, e);
           } catch (Exception e) {
             throw new RuntimeException(e);
           }

--- a/core/src/main/java/org/apache/gravitino/catalog/SchemaOperationDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/SchemaOperationDispatcher.java
@@ -338,7 +338,7 @@ public class SchemaOperationDispatcher extends OperationDispatcher implements Sc
           } catch (NoSuchEntityException e) {
             LOG.warn("The schema to be dropped does not exist in the store: {}", ident, e);
           } catch (NonEmptyEntityException e) {
-            LOG.warn("The schema is not empty in the store: {}", ident, e);
+            LOG.warn("The schema to be dropped is not empty in the store: {}", ident, e);
             // then cascade delete the schema, otherwise, the schema will never be deleted.
             try {
               store.delete(ident, SCHEMA, true);

--- a/core/src/test/java/org/apache/gravitino/catalog/TestSchemaOperationDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestSchemaOperationDispatcher.java
@@ -47,6 +47,7 @@ import org.apache.gravitino.Schema;
 import org.apache.gravitino.SchemaChange;
 import org.apache.gravitino.auth.AuthConstants;
 import org.apache.gravitino.exceptions.NoSuchEntityException;
+import org.apache.gravitino.exceptions.NonEmptyEntityException;
 import org.apache.gravitino.lock.LockManager;
 import org.apache.gravitino.meta.AuditInfo;
 import org.apache.gravitino.meta.SchemaEntity;
@@ -294,5 +295,11 @@ public class TestSchemaOperationDispatcher extends TestOperationDispatcher {
     doThrow(new IOException()).when(entityStore).delete(any(), any(), anyBoolean());
     Assertions.assertThrows(
         RuntimeException.class, () -> dispatcher.dropSchema(schemaIdent, false));
+
+    // Test if the schema is not empty in entity store but does exist in catalog
+    doThrow(new NonEmptyEntityException("mock error"))
+        .when(entityStore)
+        .delete(any(), any(), anyBoolean());
+    Assertions.assertFalse(dispatcher.dropSchema(schemaIdent, false));
   }
 }

--- a/core/src/test/java/org/apache/gravitino/catalog/TestSchemaOperationDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestSchemaOperationDispatcher.java
@@ -47,7 +47,6 @@ import org.apache.gravitino.Schema;
 import org.apache.gravitino.SchemaChange;
 import org.apache.gravitino.auth.AuthConstants;
 import org.apache.gravitino.exceptions.NoSuchEntityException;
-import org.apache.gravitino.exceptions.NonEmptyEntityException;
 import org.apache.gravitino.lock.LockManager;
 import org.apache.gravitino.meta.AuditInfo;
 import org.apache.gravitino.meta.SchemaEntity;
@@ -295,11 +294,5 @@ public class TestSchemaOperationDispatcher extends TestOperationDispatcher {
     doThrow(new IOException()).when(entityStore).delete(any(), any(), anyBoolean());
     Assertions.assertThrows(
         RuntimeException.class, () -> dispatcher.dropSchema(schemaIdent, false));
-
-    // Test if the schema is not empty in entity store but does exist in catalog
-    doThrow(new NonEmptyEntityException("mock error"))
-        .when(entityStore)
-        .delete(any(), any(), anyBoolean());
-    Assertions.assertFalse(dispatcher.dropSchema(schemaIdent, false));
   }
 }


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Catch the NonEmptyEntityException exception while dropSchema.

### Why are the changes needed?

Fix: #6845 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

1. Create a schema and a table in MySQL or PG catalog in Gravitino UI
2. Drop the table by mysql client or psql cli
3. Drop the schema in Gravitino UI
4. No exception occurs
