### PR TITLE
[#6081] docs: add required tag to type in set owner's request body

### DIFF
--- a/docs/open-api/owners.yaml
+++ b/docs/open-api/owners.yaml
@@ -110,6 +110,7 @@ components:
       type: object
       required:
         - name
+        - type
       properties:
         name:
           type: string


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Added a required tag to `type` under `OwnerSetRequest`.

### Why are the changes needed?

`type` in request body is mandatory.

Fix: #6081 

### Does this PR introduce _any_ user-facing change?

Yes, just OpenAPI docs at https://gravitino.apache.org/docs/0.7.0-incubating/api/rest/set-owner/

### How was this patch tested?

<img width="362" alt="image" src="https://github.com/user-attachments/assets/b55bd402-c7db-4af7-800b-18348d962be0" />
