### PR TITLE
[#6991] fix(gvfs): Exclude log4j in gvfs runtime jar

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -26,7 +26,6 @@ dependencies {
   implementation(libs.commons.lang3)
   implementation(libs.commons.collections4)
   implementation(libs.guava)
-  implementation(libs.slf4j.api)
 
   testImplementation(libs.junit.jupiter.api)
   testImplementation(libs.junit.jupiter.params)

--- a/clients/client-java/build.gradle.kts
+++ b/clients/client-java/build.gradle.kts
@@ -30,7 +30,9 @@ dependencies {
   implementation(libs.jackson.datatype.jdk8)
   implementation(libs.jackson.datatype.jsr310)
   implementation(libs.guava)
-  implementation(libs.httpclient5)
+  implementation(libs.httpclient5) {
+    exclude(group = "org.slf4j")
+  }
   implementation(libs.commons.lang3)
 
   compileOnly(libs.lombok)

--- a/clients/filesystem-hadoop3-runtime/build.gradle.kts
+++ b/clients/filesystem-hadoop3-runtime/build.gradle.kts
@@ -26,7 +26,9 @@ plugins {
 }
 
 dependencies {
-  implementation(project(":clients:filesystem-hadoop3"))
+  implementation(project(":clients:filesystem-hadoop3")) {
+    exclude(group = "org.slf4j")
+  }
   implementation(project(":clients:client-java-runtime", configuration = "shadow"))
   implementation(libs.commons.lang3)
 }

--- a/clients/filesystem-hadoop3/build.gradle.kts
+++ b/clients/filesystem-hadoop3/build.gradle.kts
@@ -36,8 +36,9 @@ dependencies {
   }
 
   implementation(libs.caffeine)
-  implementation(libs.guava)
   implementation(libs.commons.lang3)
+  implementation(libs.guava)
+  implementation(libs.slf4j.api)
 
   testImplementation(project(":api"))
   testImplementation(project(":core"))


### PR DESCRIPTION
### What changes were proposed in this pull request?

Exclude the log4j jar in gvfs runtime shading jar to fix the log problem.

### Why are the changes needed?

The log4j jar shipped with GVFS runtime jar will have a conflict with the environment, which will make the log4j not work, so we should exclude the log4j jar in GVFS runtime jar.

Fix: #6991

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing tests.