### PR TITLE
[MINOR] Temporary disable tag protection to delete some wrong tags

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -52,8 +52,6 @@ github:
         required_approving_review_count: 1
   dependabot_alerts: true
   dependabot_updates: false
-  protected_tags:
-    - "v*.*.*"
   collaborators:
     - noidname01
     - orenccl


### PR DESCRIPTION
### What changes were proposed in this pull request?

Update the `.asf.yaml` file to disable tag protection.

### Why are the changes needed?

There's a wrong tag needs to be deleted, so we have to disable this temporarily to delete that tag.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing tests.
