### PR TITLE
[#6813] feat(server): Support update URI for model version

### DIFF
--- a/api/src/main/java/org/apache/gravitino/model/ModelVersionChange.java
+++ b/api/src/main/java/org/apache/gravitino/model/ModelVersionChange.java
@@ -61,6 +61,16 @@ public interface ModelVersionChange {
     return new ModelVersionChange.RemoveProperty(property);
   }
 
+  /**
+   * Create a ModelVersionChange for updating the uri of a model version.
+   *
+   * @param newUri The new uri to be set for the model version.
+   * @return A new ModelVersionChange instance for updating the uri of a model version.
+   */
+  static ModelVersionChange updateUri(String newUri) {
+    return new ModelVersionChange.UpdateUri(newUri);
+  }
+
   /** A ModelVersionChange to update the model version comment. */
   final class UpdateComment implements ModelVersionChange {
 
@@ -254,6 +264,67 @@ public interface ModelVersionChange {
     @Override
     public String toString() {
       return "REMOVEPROPERTY " + property;
+    }
+  }
+
+  /** A ModelVersionChange to update the uri of a model version. */
+  final class UpdateUri implements ModelVersionChange {
+    private final String newUri;
+
+    /**
+     * Creates a new {@link UpdateUri} instance with the specified new uri.
+     *
+     * @param newUri The new uri to be set for the model version.
+     */
+    public UpdateUri(String newUri) {
+      this.newUri = newUri;
+    }
+
+    /**
+     * Returns the new uri to be set for the model version.
+     *
+     * @return The new uri to be set for the model version.
+     */
+    public String newUri() {
+      return newUri;
+    }
+
+    /**
+     * Compares this UpdateUri instance with another object for equality. The comparison is based on
+     * the new uri of the model version.
+     *
+     * @param obj The object to compare with this instance.
+     * @return {@code true} if the given object represents the same model update operation; {@code
+     *     false} otherwise.
+     */
+    @Override
+    public boolean equals(Object obj) {
+      if (obj == this) return true;
+      if (!(obj instanceof UpdateUri)) return false;
+      UpdateUri other = (UpdateUri) obj;
+      return Objects.equals(newUri, other.newUri);
+    }
+
+    /**
+     * Generates a hash code for this UpdateUri instance. The hash code is based on the new uri of
+     * the model.
+     *
+     * @return A hash code value for this model renaming operation.
+     */
+    @Override
+    public int hashCode() {
+      return Objects.hash(newUri);
+    }
+
+    /**
+     * Provides a string representation of the UpdateUri instance. This string format includes the
+     * class name followed by the new uri to be set.
+     *
+     * @return A string summary of the UpdateUri instance.
+     */
+    @Override
+    public String toString() {
+      return "UpdateUri " + newUri;
     }
   }
 }

--- a/api/src/test/java/org/apache/gravitino/model/TestModelVersionChange.java
+++ b/api/src/test/java/org/apache/gravitino/model/TestModelVersionChange.java
@@ -155,4 +155,57 @@ public class TestModelVersionChange {
     Assertions.assertNotEquals(modelVersionChange1.hashCode(), modelVersionChange3.hashCode());
     Assertions.assertNotEquals(modelVersionChange2.hashCode(), modelVersionChange3.hashCode());
   }
+
+  @Test
+  void testUpdateUriChangeUseStaticMethod() {}
+
+  @Test
+  void testUpdateUriChangeUseConstructor() {}
+
+  @Test
+  void testUpdateUriChangeEquals() {}
+
+  @Test
+  void testCreateAddReferenceChangeUseStaticMethod() {
+    String newUri = "S3://bucket/key";
+    ModelVersionChange modelVersionChange = ModelVersionChange.updateUri(newUri);
+
+    Assertions.assertEquals(ModelVersionChange.UpdateUri.class, modelVersionChange.getClass());
+
+    ModelVersionChange.UpdateUri updateUriChange =
+        (ModelVersionChange.UpdateUri) modelVersionChange;
+    Assertions.assertEquals(newUri, updateUriChange.newUri());
+    Assertions.assertEquals("UpdateUri " + newUri, updateUriChange.toString());
+  }
+
+  @Test
+  void testCreateAddReferenceChangeUseConstructor() {
+    String newUri = "S3://bucket/key";
+    ModelVersionChange modelVersionChange = new ModelVersionChange.UpdateUri(newUri);
+
+    Assertions.assertEquals(ModelVersionChange.UpdateUri.class, modelVersionChange.getClass());
+
+    ModelVersionChange.UpdateUri updateUriChange =
+        (ModelVersionChange.UpdateUri) modelVersionChange;
+    Assertions.assertEquals(newUri, updateUriChange.newUri());
+    Assertions.assertEquals("UpdateUri " + newUri, updateUriChange.toString());
+  }
+
+  @Test
+  void testAddReferenceChangeEquals() {
+    String uri1 = "S3://bucket/key1";
+    String uri2 = "S3://bucket/key2";
+
+    ModelVersionChange modelVersionChange1 = ModelVersionChange.updateUri(uri1);
+    ModelVersionChange modelVersionChange2 = ModelVersionChange.updateUri(uri1);
+    ModelVersionChange modelVersionChange3 = ModelVersionChange.updateUri(uri2);
+
+    Assertions.assertEquals(modelVersionChange1, modelVersionChange2);
+    Assertions.assertNotEquals(modelVersionChange1, modelVersionChange3);
+    Assertions.assertNotEquals(modelVersionChange2, modelVersionChange3);
+
+    Assertions.assertEquals(modelVersionChange1.hashCode(), modelVersionChange2.hashCode());
+    Assertions.assertNotEquals(modelVersionChange1.hashCode(), modelVersionChange3.hashCode());
+    Assertions.assertNotEquals(modelVersionChange2.hashCode(), modelVersionChange3.hashCode());
+  }
 }

--- a/api/src/test/java/org/apache/gravitino/model/TestModelVersionChange.java
+++ b/api/src/test/java/org/apache/gravitino/model/TestModelVersionChange.java
@@ -157,16 +157,7 @@ public class TestModelVersionChange {
   }
 
   @Test
-  void testUpdateUriChangeUseStaticMethod() {}
-
-  @Test
-  void testUpdateUriChangeUseConstructor() {}
-
-  @Test
-  void testUpdateUriChangeEquals() {}
-
-  @Test
-  void testCreateAddReferenceChangeUseStaticMethod() {
+  void testUpdateUriChangeUseStaticMethod() {
     String newUri = "S3://bucket/key";
     ModelVersionChange modelVersionChange = ModelVersionChange.updateUri(newUri);
 
@@ -179,7 +170,7 @@ public class TestModelVersionChange {
   }
 
   @Test
-  void testCreateAddReferenceChangeUseConstructor() {
+  void testUpdateUriChangeUseConstructor() {
     String newUri = "S3://bucket/key";
     ModelVersionChange modelVersionChange = new ModelVersionChange.UpdateUri(newUri);
 
@@ -192,7 +183,7 @@ public class TestModelVersionChange {
   }
 
   @Test
-  void testAddReferenceChangeEquals() {
+  void testUpdateUriChangeEquals() {
     String uri1 = "S3://bucket/key1";
     String uri2 = "S3://bucket/key2";
 

--- a/catalogs/catalog-model/src/main/java/org/apache/gravitino/catalog/model/ModelCatalogOperations.java
+++ b/catalogs/catalog-model/src/main/java/org/apache/gravitino/catalog/model/ModelCatalogOperations.java
@@ -425,6 +425,10 @@ public class ModelCatalogOperations extends ManagedSchemaOperations
             (ModelVersionChange.RemoveProperty) change;
         doRemoveProperty(entityProperties, removePropertyChange);
 
+      } else if (change instanceof ModelVersionChange.UpdateUri) {
+        ModelVersionChange.UpdateUri updateUriChange = (ModelVersionChange.UpdateUri) change;
+        entityUri = updateUriChange.newUri();
+
       } else {
         throw new IllegalArgumentException(
             "Unsupported model version change: " + change.getClass().getSimpleName());

--- a/core/src/test/java/org/apache/gravitino/catalog/TestModelOperationDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestModelOperationDispatcher.java
@@ -554,6 +554,79 @@ public class TestModelOperationDispatcher extends TestOperationDispatcher {
     Assertions.assertEquals(newProps, alteredModelVersion.properties());
   }
 
+  @Test
+  void testUpdateModelVersionUri() {
+    String schemaName = randomSchemaName();
+    String schemaComment = "schema which tests update";
+
+    String modelName = randomModelName();
+    String modelComment = "model which tests update";
+    Map<String, String> props = ImmutableMap.of("k1", "v1", "k2", "v2");
+    String newUri = "s3://new-bucket/new-path/new-model.json";
+
+    String versionUri = "s3://test-bucket/test-path/model.json";
+    String[] versionAliases = {"alias1", "alias2"};
+    String versionComment = "version which tests update";
+
+    NameIdentifier schemaIdent = NameIdentifier.of(metalake, catalog, schemaName);
+    schemaOperationDispatcher.createSchema(schemaIdent, schemaComment, props);
+
+    NameIdentifier modelIdent =
+        NameIdentifierUtil.ofModel(metalake, catalog, schemaName, modelName);
+    modelOperationDispatcher.registerModel(modelIdent, modelComment, props);
+
+    modelOperationDispatcher.linkModelVersion(
+        modelIdent, versionUri, versionAliases, versionComment, props);
+
+    ModelVersionChange change = ModelVersionChange.updateUri(newUri);
+    ModelVersion modelVersion = modelOperationDispatcher.getModelVersion(modelIdent, 0);
+    ModelVersion alteredModelVersion =
+        modelOperationDispatcher.alterModelVersion(modelIdent, 0, change);
+
+    Assertions.assertEquals(newUri, alteredModelVersion.uri());
+    Assertions.assertEquals(modelVersion.version(), alteredModelVersion.version());
+    Assertions.assertEquals(modelVersion.aliases(), alteredModelVersion.aliases());
+    Assertions.assertEquals(modelVersion.comment(), alteredModelVersion.comment());
+    Assertions.assertEquals(modelVersion.properties(), alteredModelVersion.properties());
+  }
+
+  @Test
+  void testUpdateModelVersionUriByAlias() {
+    String schemaName = randomSchemaName();
+    String schemaComment = "schema which tests update";
+
+    String modelName = randomModelName();
+    String modelComment = "model which tests update";
+    Map<String, String> props = ImmutableMap.of("k1", "v1", "k2", "v2");
+    String newUri = "s3://new-bucket/new-path/new-model.json";
+
+    String versionUri = "s3://test-bucket/test-path/model.json";
+    String[] versionAliases = {"alias1", "alias2"};
+    String versionComment = "version which tests update";
+
+    NameIdentifier schemaIdent = NameIdentifier.of(metalake, catalog, schemaName);
+    schemaOperationDispatcher.createSchema(schemaIdent, schemaComment, props);
+
+    NameIdentifier modelIdent =
+        NameIdentifierUtil.ofModel(metalake, catalog, schemaName, modelName);
+    modelOperationDispatcher.registerModel(modelIdent, modelComment, props);
+
+    modelOperationDispatcher.linkModelVersion(
+        modelIdent, versionUri, versionAliases, versionComment, props);
+
+    ModelVersionChange change = ModelVersionChange.updateUri(newUri);
+    ModelVersion modelVersion =
+        modelOperationDispatcher.getModelVersion(modelIdent, versionAliases[0]);
+    ModelVersion alteredModelVersion =
+        modelOperationDispatcher.alterModelVersion(modelIdent, versionAliases[0], change);
+
+    Assertions.assertEquals(newUri, alteredModelVersion.uri());
+    Assertions.assertEquals(modelVersion.version(), alteredModelVersion.version());
+    Assertions.assertEquals(modelVersion.aliases(), alteredModelVersion.aliases());
+    Assertions.assertEquals(modelVersion.comment(), alteredModelVersion.comment());
+    Assertions.assertEquals(modelVersion.properties(), alteredModelVersion.properties());
+  }
+
   private String randomSchemaName() {
     return "schema_" + UUID.randomUUID().toString().replace("-", "");
   }

--- a/core/src/test/java/org/apache/gravitino/connector/TestCatalogOperations.java
+++ b/core/src/test/java/org/apache/gravitino/connector/TestCatalogOperations.java
@@ -1055,6 +1055,10 @@ public class TestCatalogOperations
         ModelVersionChange.SetProperty setProperty = (ModelVersionChange.SetProperty) change;
         newProps.put(setProperty.property(), setProperty.value());
 
+      } else if (change instanceof ModelVersionChange.UpdateUri) {
+        ModelVersionChange.UpdateUri updateUriChange = (ModelVersionChange.UpdateUri) change;
+        newUri = updateUriChange.newUri();
+
       } else {
         throw new IllegalArgumentException("Unsupported model change: " + change);
       }

--- a/core/src/test/java/org/apache/gravitino/storage/relational/service/TestModelVersionMetaService.java
+++ b/core/src/test/java/org/apache/gravitino/storage/relational/service/TestModelVersionMetaService.java
@@ -632,6 +632,89 @@ public class TestModelVersionMetaService extends TestJDBCBackend {
                     updatePropertiesUpdater));
   }
 
+  @Test
+  void testUpdateModelVersionUri() throws IOException {
+    createParentEntities(METALAKE_NAME, CATALOG_NAME, SCHEMA_NAME, auditInfo);
+
+    Map<String, String> properties = ImmutableMap.of("k1", "v1", "k2", "v2");
+    String modelName = randomModelName();
+    String modelComment = "model1 comment";
+    String modelVersionUri = "S3://test/path/to/model/version";
+    List<String> modelVersionAliases = ImmutableList.of("alias1", "alias2");
+    String modelVersionComment = "test comment";
+    String updatedUri = "S3://test/path/to/new/model/version";
+    int version = 0;
+
+    ModelEntity modelEntity =
+        createModelEntity(
+            RandomIdGenerator.INSTANCE.nextId(),
+            MODEL_NS,
+            modelName,
+            modelComment,
+            0,
+            properties,
+            auditInfo);
+
+    ModelVersionEntity modelVersionEntity =
+        createModelVersionEntity(
+            modelEntity.nameIdentifier(),
+            version,
+            modelVersionUri,
+            modelVersionAliases,
+            modelVersionComment,
+            properties,
+            auditInfo);
+
+    ModelVersionEntity updatedModelVersionEntity =
+        createModelVersionEntity(
+            modelVersionEntity.modelIdentifier(),
+            modelVersionEntity.version(),
+            updatedUri,
+            modelVersionEntity.aliases(),
+            modelVersionEntity.comment(),
+            modelVersionEntity.properties(),
+            modelVersionEntity.auditInfo());
+
+    Assertions.assertDoesNotThrow(
+        () -> ModelMetaService.getInstance().insertModel(modelEntity, false));
+
+    Assertions.assertDoesNotThrow(
+        () -> ModelVersionMetaService.getInstance().insertModelVersion(modelVersionEntity));
+
+    Function<ModelVersionEntity, ModelVersionEntity> updatePropertiesUpdater =
+        oldModelVersionEntity -> updatedModelVersionEntity;
+
+    ModelVersionEntity alteredModelVersionEntity =
+        ModelVersionMetaService.getInstance()
+            .updateModelVersion(modelVersionEntity.nameIdentifier(), updatePropertiesUpdater);
+
+    Assertions.assertEquals(updatedModelVersionEntity, alteredModelVersionEntity);
+
+    // Test update a non-exist model
+    Assertions.assertThrows(
+        NoSuchEntityException.class,
+        () ->
+            ModelVersionMetaService.getInstance()
+                .updateModelVersion(
+                    NameIdentifierUtil.ofModelVersion(
+                        METALAKE_NAME,
+                        CATALOG_NAME,
+                        SCHEMA_NAME,
+                        "non_exist_model",
+                        "non_exist_version"),
+                    updatePropertiesUpdater));
+
+    // Test update a non-exist model version
+    Assertions.assertThrows(
+        NoSuchEntityException.class,
+        () ->
+            ModelVersionMetaService.getInstance()
+                .updateModelVersion(
+                    NameIdentifierUtil.ofModelVersion(
+                        METALAKE_NAME, CATALOG_NAME, SCHEMA_NAME, modelName, "non_exist_version"),
+                    updatePropertiesUpdater));
+  }
+
   private NameIdentifier getModelVersionIdent(NameIdentifier modelIdent, int version) {
     List<String> parts = Lists.newArrayList(modelIdent.namespace().levels());
     parts.add(modelIdent.name());


### PR DESCRIPTION
### What changes were proposed in this pull request?

Support update URI for model version

- [X] PR1: Add ModelVersionChange API interface, Implement the update uri logic in model catalog and JDBC backend logic, update related event.
- [ ] PR2: Add REST endpoint to support model version change, add Java client and Python client for model version comment update.

### Why are the changes needed?

Fix: #6813 

### Does this PR introduce _any_ user-facing change?

User can update the uri of a model version.

### How was this patch tested?

local ut test
