### PR TITLE
[#7011] improve (core): Add object type of AssociateTagsForMetadataObjectEvent

### DIFF
--- a/core/src/main/java/org/apache/gravitino/listener/api/event/AssociateTagsForMetadataObjectEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/AssociateTagsForMetadataObjectEvent.java
@@ -28,6 +28,7 @@ import org.apache.gravitino.utils.MetadataObjectUtil;
  */
 @DeveloperApi
 public final class AssociateTagsForMetadataObjectEvent extends TagEvent {
+  private final MetadataObject.Type objectType;
   private final String[] tagsToAdd;
   private final String[] tagsToRemove;
   private final String[] associatedTags;
@@ -50,9 +51,19 @@ public final class AssociateTagsForMetadataObjectEvent extends TagEvent {
       String[] tagsToRemove,
       String[] associatedTags) {
     super(user, MetadataObjectUtil.toEntityIdent(metalake, metadataObject));
+    this.objectType = metadataObject.type();
     this.tagsToAdd = tagsToAdd != null ? tagsToAdd.clone() : new String[0];
     this.tagsToRemove = tagsToRemove != null ? tagsToRemove.clone() : new String[0];
     this.associatedTags = associatedTags != null ? associatedTags.clone() : new String[0];
+  }
+
+  /**
+   * Provides the type of metadata object associated with this event.
+   *
+   * @return The type of metadata object.
+   */
+  public MetadataObject.Type objectType() {
+    return objectType;
   }
 
   /**

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/AssociateTagsForMetadataObjectFailureEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/AssociateTagsForMetadataObjectFailureEvent.java
@@ -28,6 +28,7 @@ import org.apache.gravitino.utils.MetadataObjectUtil;
  */
 @DeveloperApi
 public class AssociateTagsForMetadataObjectFailureEvent extends TagFailureEvent {
+  private final MetadataObject.Type objectType;
   private final String[] tagsToAdd;
   private final String[] tagsToRemove;
 
@@ -50,8 +51,18 @@ public class AssociateTagsForMetadataObjectFailureEvent extends TagFailureEvent 
       String[] tagsToRemove,
       Exception exception) {
     super(user, MetadataObjectUtil.toEntityIdent(metalake, metadataObject), exception);
+    this.objectType = metadataObject.type();
     this.tagsToAdd = tagsToAdd;
     this.tagsToRemove = tagsToRemove;
+  }
+
+  /**
+   * Provides the type of metadata object associated with this event.
+   *
+   * @return The type of metadata object.
+   */
+  public MetadataObject.Type objectType() {
+    return objectType;
   }
 
   /**

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/AssociateTagsForMetadataObjectPreEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/AssociateTagsForMetadataObjectPreEvent.java
@@ -25,6 +25,7 @@ import org.apache.gravitino.utils.MetadataObjectUtil;
 /** Represents an event triggered before associating tags with a specific metadata object. */
 @DeveloperApi
 public class AssociateTagsForMetadataObjectPreEvent extends TagPreEvent {
+  private final MetadataObject.Type objectType;
   private final String[] tagsToAdd;
   private final String[] tagsToRemove;
 
@@ -44,8 +45,18 @@ public class AssociateTagsForMetadataObjectPreEvent extends TagPreEvent {
       String[] tagsToAdd,
       String[] tagsToRemove) {
     super(user, MetadataObjectUtil.toEntityIdent(metalake, metadataObject));
+    this.objectType = metadataObject.type();
     this.tagsToAdd = tagsToAdd;
     this.tagsToRemove = tagsToRemove;
+  }
+
+  /**
+   * Provides the type of metadata object associated with this event.
+   *
+   * @return The type of metadata object.
+   */
+  public MetadataObject.Type objectType() {
+    return objectType;
   }
 
   /**

--- a/core/src/test/java/org/apache/gravitino/listener/api/event/TestTagEvent.java
+++ b/core/src/test/java/org/apache/gravitino/listener/api/event/TestTagEvent.java
@@ -255,7 +255,7 @@ public class TestTagEvent {
   }
 
   @Test
-  void testAssociateTagsForMetadataObject() {
+  void testAssociateTagsForMetadataObjectPreEvent() {
     MetadataObject metadataObject =
         NameIdentifierUtil.toMetadataObject(
             NameIdentifierUtil.ofCatalog("metalake", "catalog_for_test"),
@@ -271,6 +271,9 @@ public class TestTagEvent {
 
     Assertions.assertEquals(identifier.toString(), preEvent.identifier().toString());
     Assertions.assertEquals(AssociateTagsForMetadataObjectPreEvent.class, preEvent.getClass());
+    Assertions.assertEquals(
+        MetadataObject.Type.CATALOG,
+        ((AssociateTagsForMetadataObjectPreEvent) preEvent).objectType());
     Assertions.assertArrayEquals(
         tagsToAdd, ((AssociateTagsForMetadataObjectPreEvent) preEvent).tagsToAdd());
     Assertions.assertArrayEquals(
@@ -283,6 +286,9 @@ public class TestTagEvent {
     Event postevent = dummyEventListener.popPostEvent();
     Assertions.assertEquals(identifier.toString(), postevent.identifier().toString());
     Assertions.assertEquals(AssociateTagsForMetadataObjectEvent.class, postevent.getClass());
+    Assertions.assertEquals(
+        MetadataObject.Type.CATALOG,
+        ((AssociateTagsForMetadataObjectEvent) postevent).objectType());
     Assertions.assertArrayEquals(
         tagsToAdd, ((AssociateTagsForMetadataObjectEvent) postevent).tagsToAdd());
     Assertions.assertArrayEquals(
@@ -482,6 +488,9 @@ public class TestTagEvent {
     Assertions.assertEquals(
         GravitinoRuntimeException.class,
         ((AssociateTagsForMetadataObjectFailureEvent) event).exception().getClass());
+    Assertions.assertEquals(
+        MetadataObject.Type.CATALOG,
+        ((AssociateTagsForMetadataObjectFailureEvent) event).objectType());
     Assertions.assertEquals(
         tagsToAssociate, ((AssociateTagsForMetadataObjectFailureEvent) event).tagsToAdd());
     Assertions.assertEquals(


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add objectType of AssociateTagsForMetadataObjectEvent

### Why are the changes needed?

Fix: #7011 

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Manually test