### PR TITLE
[#5803] feat(docker-image): Change username in `hive` Dockerfile from datastrato to gravitino

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -28,6 +28,7 @@ on:
         description: 'Docker version to apply to this image'
         required: true
         type: string
+
       username:
         description: 'Docker username'
         required: true
@@ -36,6 +37,11 @@ on:
         description: 'Publish Docker token'
         required: true
         type: string
+      pat:
+        description: 'GitHub private access token'
+        required: true
+        type: string
+
       publish-latest-tag:
         description: 'Whether to update the latest tag. This operation is only applicable to official releases and should not be used for Release Candidate (RC).'
         required: false

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -28,7 +28,6 @@ on:
         description: 'Docker version to apply to this image'
         required: true
         type: string
-
       username:
         description: 'Docker username'
         required: true
@@ -37,21 +36,11 @@ on:
         description: 'Publish Docker token'
         required: true
         type: string
-      pat:
-        description: 'GitHub private access token'
-        required: true
-        type: string
-
       publish-latest-tag:
         description: 'Whether to update the latest tag. This operation is only applicable to official releases and should not be used for Release Candidate (RC).'
         required: false
         type: boolean
         default: false
-
-# Set permission for building ranger jars.
-permissions:
-  contents: write
-  packages: write
 
 jobs:
   publish-docker-image:

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -48,6 +48,11 @@ on:
         type: boolean
         default: false
 
+# Set permission for building ranger jars.
+permissions:
+  contents: write
+  packages: write
+
 jobs:
   publish-docker-image:
     runs-on: ubuntu-latest

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -172,8 +172,8 @@ allprojects {
       param.environment("PROJECT_VERSION", project.version)
 
       // Gravitino CI Docker image
-      param.environment("GRAVITINO_CI_HIVE_DOCKER_IMAGE", "apache/gravitino-ci:hive-0.1.19")
-      param.environment("GRAVITINO_CI_KERBEROS_HIVE_DOCKER_IMAGE", "apache/gravitino-ci:kerberos-hive-0.1.5")
+      param.environment("GRAVITINO_CI_HIVE_DOCKER_IMAGE", "unknowntpo/gravitino-ci:hive-change-hive-username")
+      param.environment("GRAVITINO_CI_KERBEROS_HIVE_DOCKER_IMAGE", "unknowntpo/gravitino-ci:kerberos-hive-change-hive-username")
       param.environment("GRAVITINO_CI_DORIS_DOCKER_IMAGE", "apache/gravitino-ci:doris-0.1.5")
       param.environment("GRAVITINO_CI_TRINO_DOCKER_IMAGE", "apache/gravitino-ci:trino-0.1.6")
       param.environment("GRAVITINO_CI_RANGER_DOCKER_IMAGE", "apache/gravitino-ci:ranger-0.1.2")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -172,8 +172,8 @@ allprojects {
       param.environment("PROJECT_VERSION", project.version)
 
       // Gravitino CI Docker image
-      param.environment("GRAVITINO_CI_HIVE_DOCKER_IMAGE", "unknowntpo/gravitino-ci:hive-change-hive-username")
-      param.environment("GRAVITINO_CI_KERBEROS_HIVE_DOCKER_IMAGE", "unknowntpo/gravitino-ci:kerberos-hive-change-hive-username")
+      param.environment("GRAVITINO_CI_HIVE_DOCKER_IMAGE", "apache/gravitino-ci:hive-0.1.20")
+      param.environment("GRAVITINO_CI_KERBEROS_HIVE_DOCKER_IMAGE", "apache/gravitino-ci:kerberos-hive-0.1.6")
       param.environment("GRAVITINO_CI_DORIS_DOCKER_IMAGE", "apache/gravitino-ci:doris-0.1.5")
       param.environment("GRAVITINO_CI_TRINO_DOCKER_IMAGE", "apache/gravitino-ci:trino-0.1.6")
       param.environment("GRAVITINO_CI_RANGER_DOCKER_IMAGE", "apache/gravitino-ci:ranger-0.1.2")

--- a/catalogs/catalog-hive/src/test/java/org/apache/gravitino/catalog/hive/integration/test/ProxyCatalogHiveIT.java
+++ b/catalogs/catalog-hive/src/test/java/org/apache/gravitino/catalog/hive/integration/test/ProxyCatalogHiveIT.java
@@ -71,7 +71,7 @@ public class ProxyCatalogHiveIT extends BaseIT {
   public static final String SCHEMA_PREFIX = "ProxyCatalogHiveIT_schema";
   public static final String TABLE_PREFIX = "ProxyCatalogHiveIT_table";
   private static final String PROVIDER = "hive";
-  private static final String EXPECT_USER = "datastrato";
+  private static final String EXPECT_USER = "gravitino";
   private static final String HADOOP_USER_NAME = "HADOOP_USER_NAME";
 
   private static final ContainerSuite containerSuite = ContainerSuite.getInstance();
@@ -94,7 +94,7 @@ public class ProxyCatalogHiveIT extends BaseIT {
     originHadoopUser = System.getenv(HADOOP_USER_NAME);
     setEnv(HADOOP_USER_NAME, null);
 
-    System.setProperty("user.name", "datastrato");
+    System.setProperty("user.name", "gravitino");
 
     Map<String, String> configs = Maps.newHashMap();
     configs.put(Configs.AUTHENTICATORS.getKey(), AuthenticatorType.SIMPLE.name().toLowerCase());
@@ -147,7 +147,7 @@ public class ProxyCatalogHiveIT extends BaseIT {
 
   @Test
   public void testOperateSchema() throws Exception {
-    // create schema normally using user datastrato
+    // create schema normally using user gravitino
     String schemaName = GravitinoITUtils.genRandomName(SCHEMA_PREFIX);
     String anotherSchemaName = GravitinoITUtils.genRandomName(SCHEMA_PREFIX);
 
@@ -202,7 +202,7 @@ public class ProxyCatalogHiveIT extends BaseIT {
 
   @Test
   public void testOperateTable() throws Exception {
-    // create table normally using user datastrato
+    // create table normally using user gravitino
     Column[] columns = createColumns();
     String schemaName = GravitinoITUtils.genRandomName(SCHEMA_PREFIX);
     String tableName = GravitinoITUtils.genRandomName(TABLE_PREFIX);
@@ -308,7 +308,7 @@ public class ProxyCatalogHiveIT extends BaseIT {
                   Transforms.identity(columns[1].name()), Transforms.identity(columns[2].name())
                 });
 
-    // add partition "col2=2023-01-02/col3=gravitino_it_test2" by user datastrato
+    // add partition "col2=2023-01-02/col3=gravitino_it_test2" by user gravitino
     String[] field1 = new String[] {"col2"};
     String[] field2 = new String[] {"col3"};
     Literal<?> primaryPartition = Literals.dateLiteral(LocalDate.parse("2023-01-02"));

--- a/dev/docker/hive/Dockerfile
+++ b/dev/docker/hive/Dockerfile
@@ -182,16 +182,16 @@ ADD packages/mysql-connector-java-${MYSQL_JDBC_DRIVER_VERSION}.tar.gz /opt/
 # add users and groups
 RUN groupadd hdfs && groupadd hadoop && groupadd hive && groupadd mapred
 
-RUN useradd -g hadoop datastrato && echo "datastrato:ds123" | chpasswd && adduser datastrato sudo
-RUN usermod -s /bin/bash datastrato
+RUN useradd -g hadoop gravitino && echo "gravitino:ds123" | chpasswd && adduser gravitino sudo
+RUN usermod -s /bin/bash gravitino
 
-RUN usermod -a -G hdfs datastrato
-RUN usermod -a -G hadoop datastrato
-RUN usermod -a -G hive datastrato
-RUN usermod -a -G mapred datastrato
+RUN usermod -a -G hdfs gravitino
+RUN usermod -a -G hadoop gravitino
+RUN usermod -a -G hive gravitino
+RUN usermod -a -G mapred gravitino
 
-RUN mkdir /home/datastrato
-RUN chown -R datastrato:hadoop /home/datastrato
+RUN mkdir /home/gravitino
+RUN chown -R gravitino:hadoop /home/gravitino
 
 ################################################################################
 # removed install packages and cache

--- a/dev/docker/hive/hive-dependency.sh
+++ b/dev/docker/hive/hive-dependency.sh
@@ -55,10 +55,8 @@ ZOOKEEPER_PACKAGE_NAME="zookeeper-${ZOOKEEPER_VERSION}.tar.gz"
 ZOOKEEPER_DOWNLOAD_URL="https://archive.apache.org/dist/zookeeper/zookeeper-${ZOOKEEPER_VERSION}/${ZOOKEEPER_PACKAGE_NAME}"
 
 RANGER_HIVE_PACKAGE_NAME="ranger-${RANGER_VERSION}-hive-plugin.tar.gz"
-RANGER_HIVE_DOWNLOAD_URL=https://github.com/datastrato/ranger/releases/download/v${RANGER_VERSION}/ranger-${RANGER_VERSION}-hive-plugin.tar.gz
 
 RANGER_HDFS_PACKAGE_NAME="ranger-${RANGER_VERSION}-hdfs-plugin.tar.gz"
-RANGER_HDFS_DOWNLOAD_URL=https://github.com/datastrato/ranger/releases/download/v${RANGER_VERSION}/ranger-${RANGER_VERSION}-hdfs-plugin.tar.gz
 
 # Prepare download packages
 if [[ ! -d "${hive_dir}/packages" ]]; then

--- a/dev/docker/kerberos-hive/Dockerfile
+++ b/dev/docker/kerberos-hive/Dockerfile
@@ -163,16 +163,16 @@ RUN tar -xz -C ${HIVE_HOME}/lib --strip-components 1 -f /tmp/packages/${JDBC_DIV
 # add users and groups
 RUN groupadd hdfs && groupadd hadoop && groupadd hive && groupadd mapred
 
-RUN useradd -g hadoop datastrato && echo "datastrato:ds123" | chpasswd && adduser datastrato sudo
-RUN usermod -s /bin/bash datastrato
+RUN useradd -g hadoop gravitino && echo "gravitino:ds123" | chpasswd && adduser gravitino sudo
+RUN usermod -s /bin/bash gravitino
 
-RUN usermod -a -G hdfs datastrato
-RUN usermod -a -G hadoop datastrato
-RUN usermod -a -G hive datastrato
-RUN usermod -a -G mapred datastrato
+RUN usermod -a -G hdfs gravitino
+RUN usermod -a -G hadoop gravitino
+RUN usermod -a -G hive gravitino
+RUN usermod -a -G mapred gravitino
 
-RUN mkdir /home/datastrato
-RUN chown -R datastrato:hadoop /home/datastrato
+RUN mkdir /home/gravitino
+RUN chown -R gravitino:hadoop /home/gravitino
 
 ################################################################################
 # removed install packages

--- a/dev/docker/ranger/ranger-dependency.sh
+++ b/dev/docker/ranger/ranger-dependency.sh
@@ -24,11 +24,10 @@ ranger_dir="$(cd "${ranger_dir}">/dev/null; pwd)"
 # Environment variables definition
 RANGER_VERSION=2.4.0
 RANGER_PACKAGE_NAME="ranger-${RANGER_VERSION}-admin.tar.gz" # Must export this variable for Dockerfile
-RANGER_DOWNLOAD_URL=https://github.com/datastrato/apache-ranger/releases/download/release-ranger-${RANGER_VERSION}/ranger-${RANGER_VERSION}-admin.tar.gz
 
 MYSQL_CONNECTOR_VERSION=8.0.28
 MYSQL_CONNECTOR_PACKAGE_NAME="mysql-connector-java-${MYSQL_CONNECTOR_VERSION}.jar"
-MYSQL_CONNECTOR_DOWNLOAD_URL=https://search.maven.org/remotecontent?filepath=mysql/mysql-connector-java/${MYSQL_CONNECTOR_VERSION}/mysql-connector-java-${MYSQL_CONNECTOR_VERSION}.jar
+MYSQL_CONNECTOR_DOWNLOAD_URL="https://search.maven.org/remotecontent?filepath=mysql/mysql-connector-java/${MYSQL_CONNECTOR_VERSION}/mysql-connector-java-${MYSQL_CONNECTOR_VERSION}.jar"
 
 # Prepare download packages
 if [[ ! -d "${ranger_dir}/packages" ]]; then

--- a/docs/docker-image-details.md
+++ b/docs/docker-image-details.md
@@ -159,6 +159,10 @@ You can use this kind of image to test the catalog of Apache Hive with kerberos 
 
 Changelog
 
+- apache/gravitino-ci:kerberos-hive-0.1.6
+  - Change username from `datastrato` to `gravitino`.
+    For more information, see [PR](https://github.com/apache/gravitino/pull/7040)
+
 - apache/gravitino-ci:kerberos-hive-0.1.5 (Switch to Apache official DockerHub repository)
   - Use Gravitino release 0.6.0 Dockerfile to build the image.
 
@@ -193,9 +197,13 @@ You can use this kind of image to test the catalog of Apache Hive.
 
 Changelog
 
+- apache/gravitino-ci:hive-0.1.20
+  - Change username from `datastrato` to `gravitino`.
+    For more information, see [PR](https://github.com/apache/gravitino/pull/7040)
+
 - apache/gravitino-ci:hive-0.1.19
   - Build ranger packages from source.
-
+ 
 - apache/gravitino-ci:hive-0.1.18
   - Support UTF-8 encoding for the `hive-site.xml` file and Hive Metastore. 
     For more information, please see [PR](https://github.com/apache/gravitino/pull/6625)


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

This PR changed username in `hive`, `kerberos-hive` Dockerfile from `datastrato` to `gravitino`, and added a commit 5d58e1d69247d07093d4ed1aac5748116560d81a to verify the image is built correctly, this commit will be reverted after new version of image is published.

The steps below need to be done before merging this PR:

- [x] Update `docker-image-details.md`, add information about `gravitino-ci:kerberos-hive-0.1.6` and `gravitino-ci:hive-0.1.20` (new release)
- [x] Verify new image passed all tests in CI.
- [x] Ask @xunliu to publish new docker image (`apache/gravitino-ci:kerberos-hive-0.1.6`, `apache/gravitino-ci:hive-0.1.20`)
- [x] Revert b363f9d5faeffa911430ecaae2b0857c965ce071 (this commit is just for testing newly built image before publishing)
- [x] Change `GRAVITINO_CI_HIVE_DOCKER_IMAGE`, `GRAVITINO_CI_KERBEROS_HIVE_DOCKER_IMAGE` in `./build.gradle.kts` to newly published version

### What changes were proposed in this pull request?

Rename datastrato to gravitino since we've donating this repo to ASF.

Fix: #5803 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

#### Local test

First, execute these steps to build image:

```
# build hive image
./dev/docker/build-docker.sh --platform all --type hive --image <image name and tag> --tag hive-test --latest

# build kerberos image
./dev/docker/build-docker.sh --platform all --type kerberos-hive --image <image name and tag> --tag kerberos-hive-test --latest
```


Run tests in `ProxyCatalogHiveIT`, `HiveUserAuthenticationIT` to verify that image is built successfully.

```
GRAVITINO_CI_HIVE_DOCKER_IMAGE=unknowntpo/gravitino-hive-ci-test:hive-test
GRAVITINO_CI_KERBEROS_HIVE_DOCKER_IMAGE=unknowntpo/gravitino-kerberos-hive-ci-test:kerberos-hive-test

./gradlew :catalogs:catalog-hive:test --tests "org.apache.gravitino.catalog.hive.integration.test.ProxyCatalogHiveIT" -PskipDockerTests=false

./gradlew :catalogs:catalog-hive:test --tests "org.apache.gravitino.catalog.hive.integration.test.HiveUserAuthenticationIT" -PskipDockerTests=false
```

#### CI test
I built the image 
- [unknowntpo/gravitino-ci:kerberos-hive-change-hive-username](https://hub.docker.com/layers/unknowntpo/gravitino-ci/kerberos-hive-change-hive-username/images/sha256-ba7472c69fe0db6f9e3349a775c3f96a619b0f6a6d3f17bb69f59a163b192fa7)
- [unknowntpo/gravitino-ci:hive-change-hive-username](https://hub.docker.com/layers/unknowntpo/gravitino-ci/hive-change-hive-username/images/sha256-e3d1dc9bf2ca42d3e221085475df81937d40809f23f08cd48c61c855e3a7f07d)

and make a commit b363f9d5faeffa911430ecaae2b0857c965ce071 that use these images to run CI tests.
