### PR TITLE
[#6544] improvement(catalog): support hyphen in catalog name

### DIFF
--- a/catalogs/catalog-hadoop/src/test/java/org/apache/gravitino/catalog/hadoop/integration/test/HadoopCatalogIT.java
+++ b/catalogs/catalog-hadoop/src/test/java/org/apache/gravitino/catalog/hadoop/integration/test/HadoopCatalogIT.java
@@ -484,6 +484,9 @@ public class HadoopCatalogIT extends BaseIT {
 
   @Test
   void testNameSpec() {
+    Assertions.assertDoesNotThrow(
+        () -> metalake.createCatalog("my-catalog", Catalog.Type.FILESET, provider, null, null));
+
     String illegalName = "ok/test";
 
     // test illegal catalog name

--- a/core/src/main/java/org/apache/gravitino/catalog/CatalogNormalizeDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/CatalogNormalizeDispatcher.java
@@ -48,7 +48,7 @@ public class CatalogNormalizeDispatcher implements CatalogDispatcher {
    *
    * <p>$ - End of the string
    */
-  private static final String CATALOG_NAME_PATTERN = "^\\w[\\w]{0,63}$";
+  private static final String CATALOG_NAME_PATTERN = "^\\w[\\w-]{0,63}$";
 
   private final CatalogDispatcher dispatcher;
 

--- a/core/src/test/java/org/apache/gravitino/catalog/TestCatalogNormalizeDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestCatalogNormalizeDispatcher.java
@@ -126,7 +126,6 @@ public class TestCatalogNormalizeDispatcher {
     Assertions.assertEquals("The catalog name '*' is reserved.", exception.getMessage());
 
     String[] illegalNames = {
-      "catalog-xxx",
       "catalog/xxx",
       "catalog.xxx",
       "catalog xxx",


### PR DESCRIPTION
### What changes were proposed in this pull request?

support hyphen in catalog name

### Why are the changes needed?

Fix: #6544

### Does this PR introduce _any_ user-facing change?

yes, user now can use hyphen in catalog name

### How was this patch tested?

tests added
