### PR TITLE
[#7054] fix(build): Fail to build Iceberg REST catalog Docker image

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -668,7 +668,7 @@ tasks {
           into("${rootProject.name}-iceberg-rest-server/conf")
         }
         from(projectDir.dir("bin")) {
-          include("common.sh", "${rootProject.name}-iceberg-rest-server.sh")
+          include("common.sh.template", "${rootProject.name}-iceberg-rest-server.sh.template")
           into("${rootProject.name}-iceberg-rest-server/bin")
         }
         into(outputDir)


### PR DESCRIPTION
### What changes were proposed in this pull request?


Fail to build Iceberg REST catalog Docker image

### Why the changes are needed?

Fix: #7054 

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
build Iceberg REST server image successfully