### PR TITLE
[#6529] fix(core): remove unnecessary @VisibleForTesting annotation from ICEBERG_CATALOG_CACHE_ENABLED

### DIFF
--- a/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/iceberg/IcebergPropertiesConstants.java
+++ b/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/iceberg/IcebergPropertiesConstants.java
@@ -76,7 +76,6 @@ public class IcebergPropertiesConstants {
   @VisibleForTesting
   public static final String ICEBERG_FORMAT_VERSION = IcebergConstants.FORMAT_VERSION;
 
-  @VisibleForTesting
   public static final String ICEBERG_CATALOG_CACHE_ENABLED = CatalogProperties.CACHE_ENABLED;
 
   static final String GRAVITINO_ICEBERG_CATALOG_BACKEND_NAME =


### PR DESCRIPTION
Title:

```
[#6529 ] fix: Remove incorrect @VisibleForTesting annotation & apply Spotless formatting

```

* * * * *

### What changes were proposed in this pull request?

-   Removed incorrect `@VisibleForTesting` annotation from `ICEBERG_CATALOG_CACHE_ENABLED`.
-   Applied Spotless formatting to multiple files (`README.md`, `docs/`, `gradle-wrapper.properties`, `gradlew`).

* * * * *

### Why are the changes needed?

-   The `@VisibleForTesting` annotation was incorrectly added to `ICEBERG_CATALOG_CACHE_ENABLED`, which is a public constant and does not require this annotation.
-   Spotless ensures code consistency and formatting, avoiding CI failures.

* * * * *

### Does this PR introduce *any* user-facing change?

No, this PR does not introduce any user-facing changes. It only includes formatting fixes and annotation removal.

* * * * *

### How was this patch tested?

-   Ran `./gradlew :spark-connector:spark-common:spotlessApply` to format the code.
-   Verified changes using `git diff` to ensure only formatting and annotation removal.
-   Ensured that the CI check passes after applying the fixes.

Fix: #6529 , Closes #6571 , #6532 