### PR TITLE
[#7098] Throw exception when converting timestamp with timezone to Hive type

### DIFF
--- a/catalogs/hive-metastore-common/src/main/java/org/apache/gravitino/hive/converter/HiveDataTypeConverter.java
+++ b/catalogs/hive-metastore-common/src/main/java/org/apache/gravitino/hive/converter/HiveDataTypeConverter.java
@@ -89,9 +89,11 @@ public class HiveDataTypeConverter implements DataTypeConverter<TypeInfo, String
       case TIMESTAMP:
         if (type instanceof Types.TimestampType) {
           Types.TimestampType tsType = (Types.TimestampType) type;
+          // Timestamps are interpreted to be timezoneless in Hive:
+          // https://hive.apache.org/docs/latest/languagemanual-types_27838462/#timestamps
           if (tsType.hasTimeZone()) {
             throw new UnsupportedOperationException(
-                "Unsupported conversion: Hive does not support TIMESTAMP WITH TIMEZONE type.");
+                "Unsupported conversion: Please use the TIMESTAMP WITHOUT TIMEZONE type. TIMESTAMP WITH TIMEZONE type is not supported by Hive.");
           }
           return getPrimitiveTypeInfo(TIMESTAMP_TYPE_NAME);
         }

--- a/catalogs/hive-metastore-common/src/main/java/org/apache/gravitino/hive/converter/HiveDataTypeConverter.java
+++ b/catalogs/hive-metastore-common/src/main/java/org/apache/gravitino/hive/converter/HiveDataTypeConverter.java
@@ -87,7 +87,15 @@ public class HiveDataTypeConverter implements DataTypeConverter<TypeInfo, String
       case DATE:
         return getPrimitiveTypeInfo(DATE_TYPE_NAME);
       case TIMESTAMP:
-        return getPrimitiveTypeInfo(TIMESTAMP_TYPE_NAME);
+        if (type instanceof Types.TimestampType) {
+          Types.TimestampType tsType = (Types.TimestampType) type;
+          if (tsType.hasTimeZone()) {
+            throw new UnsupportedOperationException(
+                "Unsupported conversion: Hive does not support TIMESTAMP WITH TIMEZONE type.");
+          }
+          return getPrimitiveTypeInfo(TIMESTAMP_TYPE_NAME);
+        }
+        throw new UnsupportedOperationException("Unknown timestamp type: " + type);
       case DECIMAL:
         Types.DecimalType decimalType = (Types.DecimalType) type;
         return getDecimalTypeInfo(decimalType.precision(), decimalType.scale());

--- a/catalogs/hive-metastore-common/src/test/java/org/apache/gravitino/hive/converter/TestTypeConverter.java
+++ b/catalogs/hive-metastore-common/src/test/java/org/apache/gravitino/hive/converter/TestTypeConverter.java
@@ -91,6 +91,18 @@ public class TestTypeConverter {
         () -> CONVERTER.fromGravitino(Types.ExternalType.of(USER_DEFINED_TYPE)));
   }
 
+  @Test
+  public void testTimestampWithTimeZoneThrowsException() {
+    Types.TimestampType timestampWithTimeZone = Types.TimestampType.withTimeZone();
+    UnsupportedOperationException exception =
+        Assertions.assertThrows(
+            UnsupportedOperationException.class,
+            () -> HiveDataTypeConverter.CONVERTER.fromGravitino(timestampWithTimeZone));
+    Assertions.assertEquals(
+        "Unsupported conversion: Hive does not support TIMESTAMP WITH TIMEZONE type.",
+        exception.getMessage());
+  }
+
   private void testConverter(String typeName) {
     TypeInfo hiveType = getTypeInfoFromTypeString(typeName);
     TypeInfo convertedType = CONVERTER.fromGravitino(CONVERTER.toGravitino(hiveType.getTypeName()));

--- a/catalogs/hive-metastore-common/src/test/java/org/apache/gravitino/hive/converter/TestTypeConverter.java
+++ b/catalogs/hive-metastore-common/src/test/java/org/apache/gravitino/hive/converter/TestTypeConverter.java
@@ -99,7 +99,7 @@ public class TestTypeConverter {
             UnsupportedOperationException.class,
             () -> HiveDataTypeConverter.CONVERTER.fromGravitino(timestampWithTimeZone));
     Assertions.assertEquals(
-        "Unsupported conversion: Hive does not support TIMESTAMP WITH TIMEZONE type.",
+        "Unsupported conversion: Please use the TIMESTAMP WITHOUT TIMEZONE type. TIMESTAMP WITH TIMEZONE type is not supported by Hive.",
         exception.getMessage());
   }
 


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

- add case handling to `HiveDataTypeConverter`: if trying to convert gravitino timestamp with timezone to Hive, throws `UnsupportedOperationException`
- add one more test case (timestamp with timezone) to `TestTypeConverter`

### Why are the changes needed?

Fix: #7098 

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

<img width="1204" alt="image" src="https://github.com/user-attachments/assets/05461308-f89e-4c50-b916-9125cde43bcb" />

