### PR TITLE
[#7151] Improvement(license) : Remove ASF license header from gradle-wrapper.properties

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -559,6 +559,7 @@ tasks.rat {
     "dev/docker/**/*.conf",
     "dev/docker/kerberos-hive/kadm5.acl",
     "docs/**/*.md",
+    "gradle/wrapper/gradle-wrapper.properties",
     "lineage/src/test/java/org/apache/gravitino/lineage/source/TestLineageOperations.java",
     "spark-connector/spark-common/src/test/resources/**",
     "web/web/.**",

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,22 +1,3 @@
-#
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
-#
-#  http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
-#
-# Refer from https://github.com/gradle/gradle/blob/master/gradle/wrapper/gradle-wrapper.properties
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 # checksum was taken from https://gradle.org/release-checksums


### PR DESCRIPTION
### What changes were proposed in this pull request?

- Removed the unnecessary ASF license header from `gradle/wrapper/gradle-wrapper.properties`.
- Modified `build.gradle.kts` to add an exclusion for the gradle-wrapper.properties file in the Apache RAT checks.

### Why are the changes needed?

Fixes #7151

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

- Executed `./gradlew rat` for rat check
- Executed `./gradlew spotlessCheck`
- Ran `./gradlew clean build` to ensure build integrity.