### PR TITLE
[#7198] fix(web): Removes redundant text on the “Create new schema” page under the Iceberg catalog section

### DIFF
--- a/web/web/src/app/metalakes/metalake/rightContent/CreateSchemaDialog.js
+++ b/web/web/src/app/metalakes/metalake/rightContent/CreateSchemaDialog.js
@@ -306,7 +306,6 @@ const CreateSchemaDialog = props => {
                     )}
                   />
                 </FormControl>
-                {activatedCatalogDetail?.properties['catalog-backend']}
               </Grid>
             )}
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Remove redundant code `{activatedCatalogDetail?.properties['catalog-backend']}`

### Why are the changes needed?

Fixes #7198

### Does this PR introduce any user-facing change?

Removes redundant text on the “Create new schema” page under the Iceberg catalog section.

### How was this patch tested?

- Ran `pnpm prettier . --check`
- Ran `./gradlew clean build`
- User interface testing

<img width="1433" alt="image" src="https://github.com/user-attachments/assets/a519a0d1-6cf7-484e-8caa-8f05deca1f2b" />

