### PR TITLE
[#7225]: fix(client-python) minor fix s3a, oss, abs storage handler mapping

### DIFF
--- a/clients/client-python/gravitino/filesystem/gvfs_storage_handler.py
+++ b/clients/client-python/gravitino/filesystem/gvfs_storage_handler.py
@@ -706,9 +706,9 @@ storage_handlers: Dict[StorageType, StorageHandler] = {
     StorageType.LOCAL: LOCA_HANDLER,
     StorageType.HDFS: HDFS_HANDLER,
     StorageType.GCS: GCS_HANDLER,
-    StorageType.S3A: S3StorageHandler,
-    StorageType.OSS: OSSSecretKeyCredential,
-    StorageType.ABS: AzureAccountKeyCredential,
+    StorageType.S3A: S3_HANDLER,
+    StorageType.OSS: OSS_HANDLER,
+    StorageType.ABS: ABS_HANDLER,
 }
 
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

fix [#7225](https://github.com/apache/gravitino/issues/7225#issue-3085354943)

### Why are the changes needed?

As the issue described, for s3, oss, abs storage handler, the handler map put a class instead of handler instance, which is obviously wrong and can issues like handler method call missing `self` parameter.


### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

I tested on my own machine with remote s3 storage, oss and abs is not tested.
