### PR TITLE
[#7205] fix: javadoc for :catalogs:catalog-common

### DIFF
--- a/catalogs/catalog-common/src/main/java/org/apache/gravitino/catalog/property/PropertyConverter.java
+++ b/catalogs/catalog-common/src/main/java/org/apache/gravitino/catalog/property/PropertyConverter.java
@@ -50,8 +50,8 @@ public abstract class PropertyConverter {
   /**
    * Convert Gravitino properties to engine properties.
    *
-   * @param gravitinoProperties map of Gravitino properties.
-   * @return map of engine properties.
+   * @param gravitinoProperties map of Gravitino properties
+   * @return map of engine properties
    */
   public Map<String, String> gravitinoToEngineProperties(Map<String, String> gravitinoProperties) {
     Map<String, String> engineProperties = new HashMap<>();
@@ -73,8 +73,8 @@ public abstract class PropertyConverter {
    * <p>If different engine has different behavior about error handling, you can override this
    * method.
    *
-   * @param engineProperties map of engine properties.
-   * @return map of Gravitino properties.
+   * @param engineProperties map of engine properties
+   * @return map of Gravitino properties
    */
   public Map<String, Object> engineToGravitinoProperties(Map<String, Object> engineProperties) {
     Map<String, Object> gravitinoProperties = new HashMap<>();

--- a/catalogs/catalog-common/src/main/java/org/apache/gravitino/catalog/property/PropertyConverter.java
+++ b/catalogs/catalog-common/src/main/java/org/apache/gravitino/catalog/property/PropertyConverter.java
@@ -47,7 +47,12 @@ public abstract class PropertyConverter {
     return res;
   }
 
-  /** Convert Gravitino properties to engine properties. */
+  /**
+   * Convert Gravitino properties to engine properties.
+   *
+   * @param gravitinoProperties map of Gravitino properties.
+   * @return map of engine properties.
+   */
   public Map<String, String> gravitinoToEngineProperties(Map<String, String> gravitinoProperties) {
     Map<String, String> engineProperties = new HashMap<>();
     Map<String, String> gravitinoToEngineMapping = reverseMap(engineToGravitinoMapping());
@@ -67,6 +72,9 @@ public abstract class PropertyConverter {
    *
    * <p>If different engine has different behavior about error handling, you can override this
    * method.
+   *
+   * @param engineProperties map of engine properties.
+   * @return map of Gravitino properties.
    */
   public Map<String, Object> engineToGravitinoProperties(Map<String, Object> engineProperties) {
     Map<String, Object> gravitinoProperties = new HashMap<>();


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

fix javadoc for :catalogs:catalog-common

### Why are the changes needed?

Fix: #7205

### Does this PR introduce _any_ user-facing change?

(Please list the user-facing changes introduced by your change, including
  1. Change in user-facing APIs.
  2. Addition or removal of property keys.)

### How was this patch tested?

(Please test your changes, and provide instructions on how to test it:
  1. If you add a feature or fix a bug, add a test to cover your changes.
  2. If you fix a flaky test, repeat it for many times to prove it works.)
