### PR TITLE
[#7208] improvement(javadoc): fix java doc @link reference issue

### DIFF
--- a/lineage/src/main/java/org/apache/gravitino/lineage/LineageDispatcher.java
+++ b/lineage/src/main/java/org/apache/gravitino/lineage/LineageDispatcher.java
@@ -30,7 +30,7 @@ import java.io.Closeable;
  *
  * <ol>
  *   <li>{@link #initialize(LineageConfig)} with required configurations
- *   <li>Repeated calls to {@link #dispatchLineageEvent(RunEvent)}
+ *   <li>Repeated calls to {@link #dispatchLineageEvent(io.openlineage.server.OpenLineage.RunEvent)}
  *   <li>{@link #close()} for resource cleanup
  * </ol>
  */


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix the Javadoc @link reference in

`lineage/src/main/java/org/apache/gravitino/lineage/LineageDispatcher.java`.

### Why are the changes needed?

Fixes #7208

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

- Ran `./gradlew :lineage:javadoc` to confirm the Javadoc warning was resolved.
- Ran `./gradlew clean build` to ensure the build passes without errors.