### PR TITLE
[#7211] improvement(catalogs): Fix Javadoc warnings in catalog-jdbc-common

### DIFF
--- a/catalogs/catalog-jdbc-common/src/main/java/org/apache/gravitino/catalog/jdbc/operation/DatabaseOperation.java
+++ b/catalogs/catalog-jdbc-common/src/main/java/org/apache/gravitino/catalog/jdbc/operation/DatabaseOperation.java
@@ -44,6 +44,7 @@ public interface DatabaseOperation {
    *
    * @param databaseName The name of the database.
    * @param comment The comment of the database.
+   * @param properties Additional properties for the database creation.
    */
   void create(String databaseName, String comment, Map<String, String> properties)
       throws SchemaAlreadyExistsException;

--- a/catalogs/catalog-jdbc-common/src/main/java/org/apache/gravitino/catalog/jdbc/operation/JdbcDatabaseOperations.java
+++ b/catalogs/catalog-jdbc-common/src/main/java/org/apache/gravitino/catalog/jdbc/operation/JdbcDatabaseOperations.java
@@ -219,9 +219,17 @@ public abstract class JdbcDatabaseOperations implements DatabaseOperation {
     return createSysDatabaseNameSet().contains(dbName.toLowerCase(Locale.ROOT));
   }
 
-  /** Check whether support setting schema comment. */
+  /**
+   * Check whether support setting schema comment.
+   *
+   * @return true if schema comments are supported; false otherwise.
+   */
   protected abstract boolean supportSchemaComment();
 
-  /** Create a set of system database names. */
+  /**
+   * Create a set of system database names.
+   *
+   * @return a set of system database names in lowercase.
+   */
   protected abstract Set<String> createSysDatabaseNameSet();
 }

--- a/catalogs/catalog-jdbc-common/src/main/java/org/apache/gravitino/catalog/jdbc/operation/JdbcTableOperations.java
+++ b/catalogs/catalog-jdbc-common/src/main/java/org/apache/gravitino/catalog/jdbc/operation/JdbcTableOperations.java
@@ -156,7 +156,10 @@ public abstract class JdbcTableOperations implements TableOperation {
    * not found, it will throw a NoSuchTableException.
    *
    * @param tablesResult The result set of the table
+   * @param databaseName The name of the database.
+   * @param tableName The name of the table.
    * @return The builder of the table to be returned
+   * @throws SQLException if a database access error occurs.
    */
   protected JdbcTable.Builder getTableBuilder(
       ResultSet tablesResult, String databaseName, String tableName) throws SQLException {
@@ -246,7 +249,7 @@ public abstract class JdbcTableOperations implements TableOperation {
    * @param connection jdbc connection
    * @param tableName table name
    * @return Returns all table properties values.
-   * @throws SQLException
+   * @throws SQLException if a database access error occurs
    */
   protected Map<String, String> getTableProperties(Connection connection, String tableName)
       throws SQLException {
@@ -365,9 +368,10 @@ public abstract class JdbcTableOperations implements TableOperation {
    * from the JDBC driver, like the table comment in MySQL of the 5.7 version.
    *
    * @param connection jdbc connection
+   * @param databaseName The name of the database
    * @param tableName table name
    * @param jdbcTableBuilder The builder of the table to be returned
-   * @throws SQLException
+   * @throws SQLException if a database access error occurs
    */
   protected void correctJdbcTableFields(
       Connection connection,
@@ -468,6 +472,10 @@ public abstract class JdbcTableOperations implements TableOperation {
   /**
    * The default implementation of this method is based on MySQL syntax, and if the catalog does not
    * support MySQL syntax, this method needs to be rewritten.
+   *
+   * @param oldTableName The original table name
+   * @param newTableName The new table name
+   * @return The SQL statement to rename a table
    */
   protected String generateRenameTableSql(String oldTableName, String newTableName) {
     return String.format("RENAME TABLE `%s` TO `%s`", oldTableName, newTableName);
@@ -476,6 +484,9 @@ public abstract class JdbcTableOperations implements TableOperation {
   /**
    * The default implementation of this method is based on MySQL syntax, and if the catalog does not
    * support MySQL syntax, this method needs to be rewritten.
+   *
+   * @param tableName The name of the table to be dropped
+   * @return The SQL statement to drop a table
    */
   protected String generateDropTableSql(String tableName) {
     return String.format("DROP TABLE `%s`", tableName);
@@ -489,6 +500,11 @@ public abstract class JdbcTableOperations implements TableOperation {
   /**
    * The default implementation of this method is based on MySQL syntax, and if the catalog does not
    * support MySQL syntax, this method needs to be rewritten.
+   *
+   * @param databaseName The name of the database
+   * @param tableName The name of the table
+   * @param lazyLoadCreateTable The pre-loaded table object, if available
+   * @return The resulting JdbcTable object
    */
   protected JdbcTable getOrCreateTable(
       String databaseName, String tableName, JdbcTable lazyLoadCreateTable) {
@@ -549,6 +565,9 @@ public abstract class JdbcTableOperations implements TableOperation {
   /**
    * The default implementation of this method is based on MySQL syntax, and if the catalog does not
    * support MySQL syntax, this method needs to be rewritten.
+   *
+   * @param fieldNames The 2D array of index field names
+   * @return A comma-separated string of index field names
    */
   protected static String getIndexFieldStr(String[][] fieldNames) {
     return Arrays.stream(fieldNames)

--- a/catalogs/catalog-jdbc-common/src/main/java/org/apache/gravitino/catalog/jdbc/operation/TableOperation.java
+++ b/catalogs/catalog-jdbc-common/src/main/java/org/apache/gravitino/catalog/jdbc/operation/TableOperation.java
@@ -44,6 +44,7 @@ public interface TableOperation {
    * @param exceptionMapper The exception mapper to use for the operations.
    * @param jdbcTypeConverter The type converter to use for the operations.
    * @param conf The configuration to use for the operations.
+   * @param jdbcColumnDefaultValueConverter The converter used to handle default column values.
    */
   void initialize(
       DataSource dataSource,
@@ -59,6 +60,7 @@ public interface TableOperation {
    * @param comment The comment of the table.
    * @param properties The properties of the table.
    * @param partitioning The partitioning of the table.
+   * @param distribution The distribution information of the table.
    * @param indexes The indexes of the table.
    */
   void create(
@@ -89,7 +91,7 @@ public interface TableOperation {
    * @param databaseName The name of the database.
    * @param tableName The name of the table.
    * @return information object of the JDBC table.
-   * @throws NoSuchTableException
+   * @throws NoSuchTableException if the specified table does not exist
    */
   JdbcTable load(String databaseName, String tableName) throws NoSuchTableException;
 
@@ -112,6 +114,7 @@ public interface TableOperation {
   /**
    * @param databaseName The name of the database.
    * @param tableName The name of the table.
+   * @return true if the table is successfully purged; false otherwise.
    */
   boolean purge(String databaseName, String tableName);
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix the Javadoc @param, @return, and @throws tags in

`catalogs/catalog-jdbc-common/src/main/java/org/apache/gravitino/catalog/jdbc/operation` package, specifically in the following files:

- `DatabaseOperation.java`
- `JdbcDatabaseOperations.java`
- `JdbcTableOperations.java`
- `TableOperation.java`

### Why are the changes needed?

Fixes #7211

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

- Ran `./gradlew :catalogs:catalog-jdbc-common:javadoc to confirm all Javadoc` warnings were resolved.
- Ran `./gradlew clean build`