### PR TITLE
[#7222] fix(lineage): Remove unnecessary toString call in Utils.getJobName

### DIFF
--- a/lineage/src/main/java/org/apache/gravitino/lineage/Utils.java
+++ b/lineage/src/main/java/org/apache/gravitino/lineage/Utils.java
@@ -33,6 +33,6 @@ public class Utils {
 
   public static String getJobName(RunEvent event) {
     Job job = event.getJob();
-    return job == null ? "Unknown" : job.getName().toString();
+    return job == null ? "Unknown" : job.getName();
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

FIX #7222 

### Why are the changes needed?

In lineage/src/main/java/org/apache/gravitino/lineage/Utils.java the method getJobName uses toString() when it is not needed.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

All build tests passed.
