### PR TITLE
[#7190] fix(catalogs): Validate and filter empty storageLocations in HadoopCatalogOperations

### DIFF
--- a/catalogs/catalog-hadoop/src/main/java/org/apache/gravitino/catalog/hadoop/HadoopCatalogOperations.java
+++ b/catalogs/catalog-hadoop/src/main/java/org/apache/gravitino/catalog/hadoop/HadoopCatalogOperations.java
@@ -245,9 +245,6 @@ public class HadoopCatalogOperations extends ManagedSchemaOperations
       Map<String, String> storageLocations,
       Map<String, String> properties)
       throws NoSuchSchemaException, FilesetAlreadyExistsException {
-    // remove the entries with empty value and check the default-location-names
-    storageLocations = filterAndValidateStorageLocations(storageLocations, properties);
-
     storageLocations.forEach(
         (name, path) -> {
           if (StringUtils.isBlank(name)) {
@@ -299,6 +296,12 @@ public class HadoopCatalogOperations extends ManagedSchemaOperations
 
     // Either catalog property "location", or schema property "location", or storageLocation must be
     // set for managed fileset.
+    for (Map.Entry<String, String> e : storageLocations.entrySet()) {
+      if (StringUtils.isBlank(e.getValue())) {
+        throw new IllegalArgumentException(
+            "Storage location for name '" + e.getKey() + "' must not be null or blank");
+      }
+    }
     Map<String, Path> schemaPaths =
         getAndCheckSchemaPaths(schemaIdent.name(), schemaEntity.properties());
     if (schemaPaths.isEmpty() && storageLocations.isEmpty()) {
@@ -1129,35 +1132,6 @@ public class HadoopCatalogOperations extends ManagedSchemaOperations
   private boolean containsPlaceholder(String location) {
     return StringUtils.isNotBlank(location)
         && LOCATION_PLACEHOLDER_PATTERN.matcher(location).find();
-  }
-
-  private Map<String, String> filterAndValidateStorageLocations(
-      Map<String, String> storageLocations, Map<String, String> properties) {
-    if (storageLocations == null) {
-      return new HashMap<>();
-    }
-    String defaultLocationName =
-        properties != null ? properties.get(PROPERTY_DEFAULT_LOCATION_NAME) : null;
-    Set<String> removedKeys = new HashSet<>();
-    Map<String, String> filtered = new HashMap<>();
-    // if storageLocations is null or empty, remove the entries
-    for (Map.Entry<String, String> e : storageLocations.entrySet()) {
-      String key = e.getKey();
-      String val = e.getValue();
-      if (StringUtils.isNotBlank(val)) {
-        filtered.put(key, val);
-      } else {
-        removedKeys.add(key);
-      }
-    }
-    // check the default-location-name is not in removedKeys
-    if (defaultLocationName != null && removedKeys.contains(defaultLocationName)) {
-      throw new IllegalArgumentException(
-          String.format(
-              "default-location-name '%s' is invalid; please verify that the specified storageLocations are correct.",
-              defaultLocationName));
-    }
-    return filtered;
   }
 
   private Map<String, Path> calculateFilesetPaths(

--- a/catalogs/catalog-hadoop/src/test/java/org/apache/gravitino/catalog/hadoop/TestHadoopCatalogOperations.java
+++ b/catalogs/catalog-hadoop/src/test/java/org/apache/gravitino/catalog/hadoop/TestHadoopCatalogOperations.java
@@ -1519,6 +1519,95 @@ public class TestHadoopCatalogOperations {
               .contains(
                   "Default location name must be set and must be one of the fileset locations"),
           "Exception message: " + exception.getMessage());
+
+      Schema emptySchema =
+          createMultiLocationSchema(
+              "emptySchema", "no-location", ImmutableMap.of(), ImmutableMap.of());
+
+      // only one storage location but value is null
+      exception =
+          Assertions.assertThrows(
+              IllegalArgumentException.class,
+              () ->
+                  createMultiLocationFileset(
+                      "fs1",
+                      emptySchema.name(),
+                      null,
+                      Fileset.Type.MANAGED,
+                      ImmutableMap.of(),
+                      null,
+                      null));
+      Assertions.assertEquals(
+          "Storage location must be set for fileset m1.c1.emptySchema.fs1 when it's catalog and schema location are not set",
+          exception.getMessage());
+
+      // only one storage location but value is ""
+      exception =
+          Assertions.assertThrows(
+              IllegalArgumentException.class,
+              () ->
+                  createMultiLocationFileset(
+                      "fs2",
+                      emptySchema.name(),
+                      null,
+                      Fileset.Type.MANAGED,
+                      ImmutableMap.of(),
+                      ImmutableMap.of("v1", ""),
+                      ImmutableMap.of()));
+      Assertions.assertEquals(
+          "Storage location must be set for fileset m1.c1.emptySchema.fs2 when it's catalog and schema location are not set",
+          exception.getMessage());
+
+      // only one storage location but value is " "
+      exception =
+          Assertions.assertThrows(
+              IllegalArgumentException.class,
+              () ->
+                  createMultiLocationFileset(
+                      "fs3",
+                      emptySchema.name(),
+                      null,
+                      Fileset.Type.MANAGED,
+                      ImmutableMap.of(),
+                      ImmutableMap.of("v1", " "),
+                      ImmutableMap.of()));
+      Assertions.assertEquals(
+          "Storage location must be set for fileset m1.c1.emptySchema.fs3 when it's catalog and schema location are not set",
+          exception.getMessage());
+
+      // single storage location is " " and default-location-name points to it
+      exception =
+          Assertions.assertThrows(
+              IllegalArgumentException.class,
+              () ->
+                  createMultiLocationFileset(
+                      "fs4",
+                      emptySchema.name(),
+                      null,
+                      Fileset.Type.MANAGED,
+                      ImmutableMap.of(),
+                      ImmutableMap.of("loc1", " "),
+                      ImmutableMap.of(PROPERTY_DEFAULT_LOCATION_NAME, "loc1")));
+      Assertions.assertEquals(
+          "default-location-name 'loc1' is invalid; please verify that the specified storageLocations are correct.",
+          exception.getMessage());
+
+      // two storage locations, one valid and one "", default-location-name points to ""
+      exception =
+          Assertions.assertThrows(
+              IllegalArgumentException.class,
+              () ->
+                  createMultiLocationFileset(
+                      "fs5",
+                      emptySchema.name(),
+                      null,
+                      Fileset.Type.MANAGED,
+                      ImmutableMap.of(),
+                      ImmutableMap.of("v1", TEST_ROOT_PATH + "/valid", "v2", ""),
+                      ImmutableMap.of(PROPERTY_DEFAULT_LOCATION_NAME, "v2")));
+      Assertions.assertEquals(
+          "default-location-name 'v2' is invalid; please verify that the specified storageLocations are correct.",
+          exception.getMessage());
     }
   }
 
@@ -2047,7 +2136,29 @@ public class TestHadoopCatalogOperations {
                 "v1",
                 TEST_ROOT_PATH + "/fileset509_1",
                 "v2",
-                TEST_ROOT_PATH + "/fileset509_2")));
+                TEST_ROOT_PATH + "/fileset509_2")),
+        // storageLocations == null, use schemaPaths
+        Arguments.of(
+            "fileset520",
+            Fileset.Type.MANAGED,
+            ImmutableMap.of(),
+            ImmutableMap.of(
+                PROPERTY_MULTIPLE_LOCATIONS_PREFIX + "s",
+                TEST_ROOT_PATH + "/s1/{{schema}}/{{fileset}}"),
+            null,
+            null,
+            ImmutableMap.of("s", TEST_ROOT_PATH + "/s1/s1_fileset520/fileset520")),
+        // storageLocations == null, use catalogPaths
+        Arguments.of(
+            "fileset521",
+            Fileset.Type.MANAGED,
+            ImmutableMap.of(
+                PROPERTY_MULTIPLE_LOCATIONS_PREFIX + "c",
+                TEST_ROOT_PATH + "/catalog1/{{schema}}/{{fileset}}"),
+            ImmutableMap.of(),
+            null,
+            null,
+            ImmutableMap.of("c", TEST_ROOT_PATH + "/catalog1/s1_fileset521/fileset521")));
   }
 
   private static Stream<Arguments> locationWithPlaceholdersArguments() {

--- a/catalogs/catalog-hadoop/src/test/java/org/apache/gravitino/catalog/hadoop/TestHadoopCatalogOperations.java
+++ b/catalogs/catalog-hadoop/src/test/java/org/apache/gravitino/catalog/hadoop/TestHadoopCatalogOperations.java
@@ -1524,24 +1524,7 @@ public class TestHadoopCatalogOperations {
           createMultiLocationSchema(
               "emptySchema", "no-location", ImmutableMap.of(), ImmutableMap.of());
 
-      // only one storage location but value is null
-      exception =
-          Assertions.assertThrows(
-              IllegalArgumentException.class,
-              () ->
-                  createMultiLocationFileset(
-                      "fs1",
-                      emptySchema.name(),
-                      null,
-                      Fileset.Type.MANAGED,
-                      ImmutableMap.of(),
-                      null,
-                      null));
-      Assertions.assertEquals(
-          "Storage location must be set for fileset m1.c1.emptySchema.fs1 when it's catalog and schema location are not set",
-          exception.getMessage());
-
-      // only one storage location but value is ""
+      // storage location value is blank
       exception =
           Assertions.assertThrows(
               IllegalArgumentException.class,
@@ -1555,10 +1538,9 @@ public class TestHadoopCatalogOperations {
                       ImmutableMap.of("v1", ""),
                       ImmutableMap.of()));
       Assertions.assertEquals(
-          "Storage location must be set for fileset m1.c1.emptySchema.fs2 when it's catalog and schema location are not set",
-          exception.getMessage());
+          "Storage location for name 'v1' must not be null or blank", exception.getMessage());
 
-      // only one storage location but value is " "
+      // storage location value is blank
       exception =
           Assertions.assertThrows(
               IllegalArgumentException.class,
@@ -1572,27 +1554,9 @@ public class TestHadoopCatalogOperations {
                       ImmutableMap.of("v1", " "),
                       ImmutableMap.of()));
       Assertions.assertEquals(
-          "Storage location must be set for fileset m1.c1.emptySchema.fs3 when it's catalog and schema location are not set",
-          exception.getMessage());
+          "Storage location for name 'v1' must not be null or blank", exception.getMessage());
 
-      // single storage location is " " and default-location-name points to it
-      exception =
-          Assertions.assertThrows(
-              IllegalArgumentException.class,
-              () ->
-                  createMultiLocationFileset(
-                      "fs4",
-                      emptySchema.name(),
-                      null,
-                      Fileset.Type.MANAGED,
-                      ImmutableMap.of(),
-                      ImmutableMap.of("loc1", " "),
-                      ImmutableMap.of(PROPERTY_DEFAULT_LOCATION_NAME, "loc1")));
-      Assertions.assertEquals(
-          "default-location-name 'loc1' is invalid; please verify that the specified storageLocations are correct.",
-          exception.getMessage());
-
-      // two storage locations, one valid and one "", default-location-name points to ""
+      // two storage locations, one valid and one is blank
       exception =
           Assertions.assertThrows(
               IllegalArgumentException.class,
@@ -1604,10 +1568,9 @@ public class TestHadoopCatalogOperations {
                       Fileset.Type.MANAGED,
                       ImmutableMap.of(),
                       ImmutableMap.of("v1", TEST_ROOT_PATH + "/valid", "v2", ""),
-                      ImmutableMap.of(PROPERTY_DEFAULT_LOCATION_NAME, "v2")));
+                      ImmutableMap.of()));
       Assertions.assertEquals(
-          "default-location-name 'v2' is invalid; please verify that the specified storageLocations are correct.",
-          exception.getMessage());
+          "Storage location for name 'v2' must not be null or blank", exception.getMessage());
     }
   }
 
@@ -2136,29 +2099,7 @@ public class TestHadoopCatalogOperations {
                 "v1",
                 TEST_ROOT_PATH + "/fileset509_1",
                 "v2",
-                TEST_ROOT_PATH + "/fileset509_2")),
-        // storageLocations == null, use schemaPaths
-        Arguments.of(
-            "fileset520",
-            Fileset.Type.MANAGED,
-            ImmutableMap.of(),
-            ImmutableMap.of(
-                PROPERTY_MULTIPLE_LOCATIONS_PREFIX + "s",
-                TEST_ROOT_PATH + "/s1/{{schema}}/{{fileset}}"),
-            null,
-            null,
-            ImmutableMap.of("s", TEST_ROOT_PATH + "/s1/s1_fileset520/fileset520")),
-        // storageLocations == null, use catalogPaths
-        Arguments.of(
-            "fileset521",
-            Fileset.Type.MANAGED,
-            ImmutableMap.of(
-                PROPERTY_MULTIPLE_LOCATIONS_PREFIX + "c",
-                TEST_ROOT_PATH + "/catalog1/{{schema}}/{{fileset}}"),
-            ImmutableMap.of(),
-            null,
-            null,
-            ImmutableMap.of("c", TEST_ROOT_PATH + "/catalog1/s1_fileset521/fileset521")));
+                TEST_ROOT_PATH + "/fileset509_2")));
   }
 
   private static Stream<Arguments> locationWithPlaceholdersArguments() {

--- a/catalogs/catalog-hadoop/src/test/java/org/apache/gravitino/catalog/hadoop/TestHadoopCatalogOperations.java
+++ b/catalogs/catalog-hadoop/src/test/java/org/apache/gravitino/catalog/hadoop/TestHadoopCatalogOperations.java
@@ -1512,6 +1512,33 @@ public class TestHadoopCatalogOperations {
       Assertions.assertEquals(
           "Location value must not be blank for location name: v1", exception.getMessage());
 
+      // empty location in schema location
+      exception =
+          Assertions.assertThrows(
+              IllegalArgumentException.class,
+              () ->
+                  createMultiLocationSchema(
+                      "s1", "comment", ImmutableMap.of(), ImmutableMap.of("location", "")));
+      Assertions.assertEquals(
+          "The value of the schema property location must not be blank", exception.getMessage());
+
+      // empty fileset storage location
+      exception =
+          Assertions.assertThrows(
+              IllegalArgumentException.class,
+              () ->
+                  createMultiLocationFileset(
+                      "fileset_test",
+                      "s1",
+                      null,
+                      Fileset.Type.MANAGED,
+                      ImmutableMap.of(),
+                      ImmutableMap.of("location1", ""),
+                      null));
+      Assertions.assertEquals(
+          "Storage location must not be blank for location name: location1",
+          exception.getMessage());
+
       // storage location is parent of schema location
       Schema multipLocationSchema =
           createMultiLocationSchema(

--- a/catalogs/catalog-hadoop/src/test/java/org/apache/gravitino/catalog/hadoop/TestHadoopCatalogOperations.java
+++ b/catalogs/catalog-hadoop/src/test/java/org/apache/gravitino/catalog/hadoop/TestHadoopCatalogOperations.java
@@ -50,6 +50,7 @@ import java.io.IOException;
 import java.net.ConnectException;
 import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
@@ -1493,6 +1494,24 @@ public class TestHadoopCatalogOperations {
                       null));
       Assertions.assertEquals("Location name must not be blank", exception.getMessage());
 
+      // empty location in catalog location
+      Map<String, String> illegalLocations2 =
+          new HashMap<String, String>() {
+            {
+              put(PROPERTY_MULTIPLE_LOCATIONS_PREFIX + "v1", null);
+            }
+          };
+      exception =
+          Assertions.assertThrows(
+              IllegalArgumentException.class,
+              () ->
+                  ops.initialize(
+                      illegalLocations2,
+                      randomCatalogInfo("m1", "c1"),
+                      HADOOP_PROPERTIES_METADATA));
+      Assertions.assertEquals(
+          "Location value must not be blank for location name: v1", exception.getMessage());
+
       // storage location is parent of schema location
       Schema multipLocationSchema =
           createMultiLocationSchema(
@@ -1519,58 +1538,6 @@ public class TestHadoopCatalogOperations {
               .contains(
                   "Default location name must be set and must be one of the fileset locations"),
           "Exception message: " + exception.getMessage());
-
-      Schema emptySchema =
-          createMultiLocationSchema(
-              "emptySchema", "no-location", ImmutableMap.of(), ImmutableMap.of());
-
-      // storage location value is blank
-      exception =
-          Assertions.assertThrows(
-              IllegalArgumentException.class,
-              () ->
-                  createMultiLocationFileset(
-                      "fs2",
-                      emptySchema.name(),
-                      null,
-                      Fileset.Type.MANAGED,
-                      ImmutableMap.of(),
-                      ImmutableMap.of("v1", ""),
-                      ImmutableMap.of()));
-      Assertions.assertEquals(
-          "Storage location for name 'v1' must not be null or blank", exception.getMessage());
-
-      // storage location value is blank
-      exception =
-          Assertions.assertThrows(
-              IllegalArgumentException.class,
-              () ->
-                  createMultiLocationFileset(
-                      "fs3",
-                      emptySchema.name(),
-                      null,
-                      Fileset.Type.MANAGED,
-                      ImmutableMap.of(),
-                      ImmutableMap.of("v1", " "),
-                      ImmutableMap.of()));
-      Assertions.assertEquals(
-          "Storage location for name 'v1' must not be null or blank", exception.getMessage());
-
-      // two storage locations, one valid and one is blank
-      exception =
-          Assertions.assertThrows(
-              IllegalArgumentException.class,
-              () ->
-                  createMultiLocationFileset(
-                      "fs5",
-                      emptySchema.name(),
-                      null,
-                      Fileset.Type.MANAGED,
-                      ImmutableMap.of(),
-                      ImmutableMap.of("v1", TEST_ROOT_PATH + "/valid", "v2", ""),
-                      ImmutableMap.of()));
-      Assertions.assertEquals(
-          "Storage location for name 'v2' must not be null or blank", exception.getMessage());
     }
   }
 

--- a/catalogs/catalog-hadoop/src/test/java/org/apache/gravitino/catalog/hadoop/TestHadoopCatalogOperations.java
+++ b/catalogs/catalog-hadoop/src/test/java/org/apache/gravitino/catalog/hadoop/TestHadoopCatalogOperations.java
@@ -383,15 +383,15 @@ public class TestHadoopCatalogOperations {
     String name = "schema28";
     String comment = "comment28";
     String catalogPath = "";
-    Schema schema = createSchema(name, comment, catalogPath, null);
-    Assertions.assertEquals(name, schema.name());
-    Assertions.assertEquals(comment, schema.comment());
 
     Throwable exception =
         Assertions.assertThrows(
-            SchemaAlreadyExistsException.class,
-            () -> createSchema(name, comment, catalogPath, null));
-    Assertions.assertEquals("Schema m1.c1.schema28 already exists", exception.getMessage());
+            IllegalArgumentException.class, () -> createSchema(name, comment, catalogPath, null));
+    Assertions.assertEquals(
+        "The value of the catalog property "
+            + HadoopCatalogPropertiesMetadata.LOCATION
+            + " must not be blank",
+        exception.getMessage());
   }
 
   @Test

--- a/web/web/src/app/metalakes/metalake/rightContent/CreateFilesetDialog.js
+++ b/web/web/src/app/metalakes/metalake/rightContent/CreateFilesetDialog.js
@@ -234,12 +234,10 @@ const CreateFilesetDialog = props => {
           name: data.name,
           type: data.type,
           storageLocations: data.storageLocations.reduce((acc, item) => {
-            const trimmedName = item.name?.trim()
-            const trimmedLocation = item.location?.trim()
-            if (trimmedName && trimmedLocation) {
-              acc[trimmedName] = trimmedLocation
+            if (item.name && item.location) {
+              acc[item.name] = item.location
               if (item.defaultLocation && !properties['default-location-name']) {
-                properties['default-location-name'] = trimmedName
+                properties['default-location-name'] = item.name
               }
             }
 

--- a/web/web/src/app/metalakes/metalake/rightContent/CreateFilesetDialog.js
+++ b/web/web/src/app/metalakes/metalake/rightContent/CreateFilesetDialog.js
@@ -234,10 +234,12 @@ const CreateFilesetDialog = props => {
           name: data.name,
           type: data.type,
           storageLocations: data.storageLocations.reduce((acc, item) => {
-            if (item.name && item.location) {
-              acc[item.name] = item.location
+            const trimmedName = item.name?.trim()
+            const trimmedLocation = item.location?.trim()
+            if (trimmedName && trimmedLocation) {
+              acc[trimmedName] = trimmedLocation
               if (item.defaultLocation && !properties['default-location-name']) {
-                properties['default-location-name'] = item.name
+                properties['default-location-name'] = trimmedName
               }
             }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add validation: throw error if StorageLocation is null or blank  `Storage location for name '" + e.getKey() + "' must not be null or blank`

### Why are the changes needed?

Fixes #7190

### Does this PR introduce any user-facing change?

No. APIs and behavior are unchanged, only error messages for invalid input are clearer.

### How was this patch tested?

- Added new unit tests.
- Verified with `./gradlew clean build`.