### PR TITLE
[#7214] Fix Javadoc issues in task :flink-connector:flink:javadoc

### DIFF
--- a/flink-connector/flink/src/main/java/org/apache/gravitino/flink/connector/iceberg/GravitinoIcebergCatalogFactory.java
+++ b/flink-connector/flink/src/main/java/org/apache/gravitino/flink/connector/iceberg/GravitinoIcebergCatalogFactory.java
@@ -61,7 +61,8 @@ public class GravitinoIcebergCatalogFactory implements BaseCatalogFactory {
   /**
    * Define gravitino catalog provider.
    *
-   * @return
+   * @return The name of the Gravitino catalog provider, which is "lakehouse-iceberg" for this
+   *     implementation.
    */
   @Override
   public String gravitinoCatalogProvider() {
@@ -71,7 +72,7 @@ public class GravitinoIcebergCatalogFactory implements BaseCatalogFactory {
   /**
    * Define gravitino catalog type.
    *
-   * @return
+   * @return The type of the Gravitino catalog, which is RELATIONAL for this implementation.
    */
   @Override
   public org.apache.gravitino.Catalog.Type gravitinoCatalogType() {
@@ -81,7 +82,7 @@ public class GravitinoIcebergCatalogFactory implements BaseCatalogFactory {
   /**
    * Define properties converter.
    *
-   * @return
+   * @return The properties converter instance for Iceberg catalog.
    */
   @Override
   public PropertiesConverter propertiesConverter() {

--- a/flink-connector/flink/src/main/java/org/apache/gravitino/flink/connector/utils/FactoryUtils.java
+++ b/flink-connector/flink/src/main/java/org/apache/gravitino/flink/connector/utils/FactoryUtils.java
@@ -97,6 +97,10 @@ public class FactoryUtils {
    * Creates a utility that helps to validate options for a {@link CatalogFactory}.
    *
    * <p>Note: This utility checks for left-over options in the final step.
+   *
+   * @param factory The catalog factory to create the helper for
+   * @param context The context containing the options to validate
+   * @return A new CatalogFactoryHelper instance
    */
   public static FactoryUtil.CatalogFactoryHelper createCatalogFactoryHelper(
       CatalogFactory factory, CatalogFactory.Context context) {


### PR DESCRIPTION
### Title 

[#7214] fix(docs): resolve Javadoc issues in `:flink-connector:flink:javadoc`

### What changes were proposed in this pull request?

This PR fixes multiple Javadoc generation issues within the `:flink-connector:flink` module. Specifically:

* Fixed incomplete Javadoc comments.

### Why are the changes needed?

These changes are necessary to ensure:

1. Javadoc can be successfully generated without warnings or errors.
2. Code quality and documentation consistency are maintained.
3. CI builds involving Javadoc generation (especially with `spotlessApply` or similar tasks) pass without failure.

### Does this PR introduce *any* user-facing change?

No user-facing changes are introduced. All changes are limited to internal documentation (Javadoc).

### How was this patch tested?

* Ran `./gradlew :flink-connector:flink:javadoc` to confirm successful Javadoc generation.
* Verified that `spotlessCheck` and `spotlessApply` pass without formatting or documentation issues.
* Manually reviewed the modified Javadoc for correctness and clarity.
