### PR TITLE
[#7249] Remove unnecessary instanceof check for IOException handling

### DIFF
--- a/clients/filesystem-hadoop3/src/main/java/org/apache/gravitino/filesystem/hadoop/GravitinoVirtualFileSystem.java
+++ b/clients/filesystem-hadoop3/src/main/java/org/apache/gravitino/filesystem/hadoop/GravitinoVirtualFileSystem.java
@@ -330,9 +330,6 @@ public class GravitinoVirtualFileSystem extends FileSystem {
       throw new FilesetPathNotFoundException(message, e);
 
     } catch (IOException e) {
-      if (e instanceof FilesetPathNotFoundException) {
-        throw (FilesetPathNotFoundException) e;
-      }
       throw e;
     }
   }


### PR DESCRIPTION
This PR addresses [Issue #7249](https://github.com/apache/gravitino/issues/7249), which pointed out unnecessary use of instanceof in exception handling in GravitinoVirtualFileSystem.java.


```
} catch (IOException e) {
  if (e instanceof FilesetPathNotFoundException) {
    throw (FilesetPathNotFoundException) e;
  }
  throw e;
}
```

This check is redundant since:

FilesetPathNotFoundException is a subtype of IOException

Both branches simply rethrow the exception

```

} catch (IOException e) {
  throw e;
}
```
Or if this block serves no purpose beyond that, it could be safely removed altogether.


