### PR TITLE
[#7218] improvement(spark-connector): Add null check for partition column names

### DIFF
--- a/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/utils/HiveGravitinoOperationOperator.java
+++ b/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/utils/HiveGravitinoOperationOperator.java
@@ -19,6 +19,7 @@
 
 package org.apache.gravitino.spark.connector.utils;
 
+import com.google.common.base.Preconditions;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -145,9 +146,7 @@ public class HiveGravitinoOperationOperator {
   private @NotNull String getHivePartitionName(
       String[] names, InternalRow ident, StructType partitionSchema) {
     StringBuilder partitionName = new StringBuilder();
-    if (names == null) {
-      throw new IllegalArgumentException("Partition column names must not be null");
-    }
+    Preconditions.checkArgument(names != null, "Partition column names must not be null");
     for (int i = 0; i < names.length; i++) {
       StructField structField = partitionSchema.apply(i);
       DataType dataType = structField.dataType();


### PR DESCRIPTION
### What changes were proposed in this pull request?

Added a null check for the names parameter in `getHivePartitionName` to avoid potential NPE.

### Why are the changes needed?

Fixes #7218

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

- Ran `./gradlew clean build`