### PR TITLE
[#7255] improve (trino-connector): Treat the version check for catalog names with dots as a warning.

### DIFF
--- a/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/catalog/CatalogRegister.java
+++ b/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/catalog/CatalogRegister.java
@@ -80,11 +80,11 @@ public class CatalogRegister {
     if (!config.simplifyCatalogNames()) {
       int version = Integer.parseInt(context.getSpiVersion());
       if (version < MIN_SUPPORT_CATALOG_NAME_WITH_METALAKE_TRINO_SPI_VERSION) {
-        String errmsg =
-            String.format(
-                "Trino-%s does not support catalog name with dots, The minimal required version is Trino-%d",
-                trinoVersion, MIN_SUPPORT_CATALOG_NAME_WITH_METALAKE_TRINO_SPI_VERSION);
-        throw new TrinoException(GravitinoErrorCode.GRAVITINO_UNSUPPORTED_TRINO_VERSION, errmsg);
+        LOG.warn(
+            "Trino-{} does not support catalog name with dots, The minimal required version is Trino-{}."
+                + "Some errors may occur when using the USE <CATALOG>.<SCHEMA> statement in Trino",
+            trinoVersion,
+            MIN_SUPPORT_CATALOG_NAME_WITH_METALAKE_TRINO_SPI_VERSION);
       }
     }
   }


### PR DESCRIPTION

### What changes were proposed in this pull request?

Treat the version check for catalog names with dots as a warning.

### Why are the changes needed?

Fix: #7255

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Manually test
