### PR TITLE
[#7247] refactor(authorization): Formatted error logger in authorization ranger client extension and include stacktrace

### DIFF
--- a/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/RangerClientExtension.java
+++ b/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/RangerClientExtension.java
@@ -119,7 +119,7 @@ public class RangerClientExtension extends RangerClient {
     try {
       callAPIMethodClassResponseType.invoke(this, CREATE_EXTERNAL_USER, null, user, VXUser.class);
     } catch (UniformInterfaceException e) {
-      LOG.error("Failed to create user: " + e.getResponse().getEntity(String.class));
+      LOG.error("Failed to create user: {}", e.getResponse().getEntity(String.class));
       return Boolean.FALSE;
     } catch (InvocationTargetException | IllegalAccessException e) {
       Throwable cause = e.getCause();
@@ -169,7 +169,7 @@ public class RangerClientExtension extends RangerClient {
     try {
       callAPIMethodClassResponseType.invoke(this, CREATE_GROUP, null, group, VXGroup.class);
     } catch (UniformInterfaceException e) {
-      LOG.error("Failed to create user: " + e.getResponse().getEntity(String.class));
+      LOG.error("Failed to create group: {}", e.getResponse().getEntity(String.class));
       return Boolean.FALSE;
     } catch (InvocationTargetException | IllegalAccessException e) {
       throw new RuntimeException(e);

--- a/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/RangerClientExtension.java
+++ b/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/RangerClientExtension.java
@@ -119,7 +119,7 @@ public class RangerClientExtension extends RangerClient {
     try {
       callAPIMethodClassResponseType.invoke(this, CREATE_EXTERNAL_USER, null, user, VXUser.class);
     } catch (UniformInterfaceException e) {
-      LOG.error("Failed to create user: {}", e.getResponse().getEntity(String.class));
+      LOG.error("Failed to create user: {}", e.getResponse().getEntity(String.class), e);
       return Boolean.FALSE;
     } catch (InvocationTargetException | IllegalAccessException e) {
       Throwable cause = e.getCause();
@@ -169,7 +169,7 @@ public class RangerClientExtension extends RangerClient {
     try {
       callAPIMethodClassResponseType.invoke(this, CREATE_GROUP, null, group, VXGroup.class);
     } catch (UniformInterfaceException e) {
-      LOG.error("Failed to create group: {}", e.getResponse().getEntity(String.class));
+      LOG.error("Failed to create group: {}", e.getResponse().getEntity(String.class), e);
       return Boolean.FALSE;
     } catch (InvocationTargetException | IllegalAccessException e) {
       throw new RuntimeException(e);


### PR DESCRIPTION

### What changes were proposed in this pull request?
1: Use the syntax to log message in log.error
2: Log stacktrace with message

### Why are the changes needed?

Fix: #(7247)

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?

Logger not tested, assuming basic log.error syntax