### PR TITLE
[#7209] Fix Javadoc issues in task :catalogs:catalog-lakehouse-paimon…

### DIFF
--- a/catalogs/catalog-lakehouse-paimon/src/main/java/org/apache/gravitino/catalog/lakehouse/paimon/GravitinoPaimonColumn.java
+++ b/catalogs/catalog-lakehouse-paimon/src/main/java/org/apache/gravitino/catalog/lakehouse/paimon/GravitinoPaimonColumn.java
@@ -38,6 +38,8 @@ public class GravitinoPaimonColumn extends BaseColumn {
    * Converts {@link GravitinoPaimonColumn} instance to inner column.
    *
    * @param id The id of inner column.
+   * @param gravitinoColumn The Gravitino column to convert (contains name, type, nullability, and
+   *     comment).
    * @return The converted inner column.
    */
   public static DataField toPaimonColumn(int id, Column gravitinoColumn) {

--- a/catalogs/catalog-lakehouse-paimon/src/main/java/org/apache/gravitino/catalog/lakehouse/paimon/authentication/kerberos/KerberosClient.java
+++ b/catalogs/catalog-lakehouse-paimon/src/main/java/org/apache/gravitino/catalog/lakehouse/paimon/authentication/kerberos/KerberosClient.java
@@ -51,7 +51,7 @@ public class KerberosClient implements Closeable {
    * performing kerberos authentication based on the keytab file.
    *
    * @param keytabFilePath local keytab file path
-   * @throws IOException
+   * @throws IOException if Kerberos authentication fails
    */
   public void login(String keytabFilePath) throws IOException {
     KerberosConfig kerberosConfig = new KerberosConfig(conf);

--- a/catalogs/catalog-lakehouse-paimon/src/main/java/org/apache/gravitino/catalog/lakehouse/paimon/utils/CatalogUtils.java
+++ b/catalogs/catalog-lakehouse-paimon/src/main/java/org/apache/gravitino/catalog/lakehouse/paimon/utils/CatalogUtils.java
@@ -83,6 +83,7 @@ public class CatalogUtils {
    * Loads {@link Catalog} instance with given {@link PaimonConfig} with kerberos auth.
    *
    * @param paimonConfig The Paimon configuration.
+   * @param configuration The Hadoop configuration for Kerberos
    * @return The {@link Catalog} instance of catalog backend.
    */
   public static Catalog loadCatalogBackendWithKerberosAuth(


### PR DESCRIPTION
[#7209] fix(docs): resolve Javadoc issues in :catalogs:catalog-lakehouse-paimon:javadoc

**What changes were proposed in this pull request?**
This PR fixes multiple Javadoc generation issues within the :catalogs:catalog-lakehouse-paimon module. Specifically:

Added missing @param descriptions in GravitinoPaimonColumn.java and CatalogUtils.java

Added description for @throws in KerberosClient.java

Ensured all documentation complies with Spotless formatting requirements

**Why are the changes needed?**
These changes are necessary to ensure:

Clean Javadoc generation without warnings

Consistent documentation standards across the codebase

Successful CI builds involving documentation checks

Better developer experience with complete API documentation

**Does this PR introduce any user-facing change?**
No, these changes only affect internal documentation (Javadoc comments).

**How was this patch tested?**

Ran ./gradlew :catalogs:catalog-lakehouse-paimon:javadoc to verify successful generation

Executed spotlessCheck and spotlessApply to confirm formatting compliance
