### PR TITLE
[#7220] refactor: use \\w (word) rather than [a-zA-Z0-9_] in regex

### DIFF
--- a/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/catalog/iceberg/ExpressionUtil.java
+++ b/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/catalog/iceberg/ExpressionUtil.java
@@ -38,7 +38,7 @@ import org.apache.gravitino.rel.expressions.transforms.Transforms;
 
 /** This class is used to convert expression of bucket, sort_by, partition object to string */
 public class ExpressionUtil {
-  private static final String IDENTIFIER = "[a-zA-Z_][a-zA-Z0-9_]*";
+  private static final String IDENTIFIER = "[a-zA-Z_]\\w*";
   private static final String FUNCTION_ARG_INT = "(\\d+)";
   private static final String FUNCTION_ARG_IDENTIFIER = "(" + IDENTIFIER + ")";
   private static final Pattern YEAR_FUNCTION_PATTERN =


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Use \\w (word) rather than [a-zA-Z0-9_] in regex in `ExpressionUtil`.

### Why are the changes needed?

Fix: #7220

### Does this PR introduce _any_ user-facing change?

(Please list the user-facing changes introduced by your change, including
  1. Change in user-facing APIs.
  2. Addition or removal of property keys.)

### How was this patch tested?

(Please test your changes, and provide instructions on how to test it:
  1. If you add a feature or fix a bug, add a test to cover your changes.
  2. If you fix a flaky test, repeat it for many times to prove it works.)
