### PR TITLE
[#7219] docs: add missing deprecated javadoc tag

### DIFF
--- a/catalogs/catalog-common/src/main/java/org/apache/gravitino/credential/CredentialConstants.java
+++ b/catalogs/catalog-common/src/main/java/org/apache/gravitino/credential/CredentialConstants.java
@@ -20,7 +20,9 @@
 package org.apache.gravitino.credential;
 
 public class CredentialConstants {
+  /** @deprecated Please use {@link #CREDENTIAL_PROVIDERS} instead. */
   @Deprecated public static final String CREDENTIAL_PROVIDER_TYPE = "credential-provider-type";
+
   public static final String CREDENTIAL_PROVIDERS = "credential-providers";
   public static final String CREDENTIAL_CACHE_EXPIRE_RATIO = "credential-cache-expire-ratio";
   public static final String CREDENTIAL_CACHE_MAX_SIZE = "credential-cache-max-size";

--- a/clients/client-java/src/main/java/org/apache/gravitino/client/GravitinoClient.java
+++ b/clients/client-java/src/main/java/org/apache/gravitino/client/GravitinoClient.java
@@ -463,6 +463,7 @@ public class GravitinoClient extends GravitinoClientBase
    * @throws NoSuchMetalakeException If the Metalake with the given name does not exist.
    * @throws IllegalPrivilegeException If any privilege can't be bind to the metadata object.
    * @throws RuntimeException If revoking privileges from a role encounters storage issues.
+   * @deprecated use {@link #revokePrivilegesFromRole(String, MetadataObject, Set)} instead.
    */
   @Deprecated
   public Role revokePrivilegesFromRole(

--- a/clients/client-java/src/main/java/org/apache/gravitino/client/GravitinoClient.java
+++ b/clients/client-java/src/main/java/org/apache/gravitino/client/GravitinoClient.java
@@ -421,6 +421,7 @@ public class GravitinoClient extends GravitinoClientBase
    * @throws NoSuchMetalakeException If the Metalake with the given name does not exist.
    * @throws IllegalPrivilegeException If any privilege can't be bind to the metadata object.
    * @throws RuntimeException If granting roles to a role encounters storage issues.
+   * @deprecated use {@link #grantPrivilegesToRole(String, MetadataObject, Set)} instead.
    */
   @Deprecated
   public Role grantPrivilegesToRole(String role, MetadataObject object, List<Privilege> privileges)

--- a/clients/client-java/src/main/java/org/apache/gravitino/client/GravitinoMetalake.java
+++ b/clients/client-java/src/main/java/org/apache/gravitino/client/GravitinoMetalake.java
@@ -1078,6 +1078,7 @@ public class GravitinoMetalake extends MetalakeDTO
    * @throws NoSuchMetalakeException If the Metalake with the given name does not exist.
    * @throws IllegalPrivilegeException If any privilege can't be bind to the metadata object.
    * @throws RuntimeException If revoking privileges from a role encounters storage issues.
+   * @deprecated use {@link #revokePrivilegesFromRole(String, MetadataObject, Set)} instead.
    */
   @Deprecated
   public Role revokePrivilegesFromRole(

--- a/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/IcebergConfig.java
+++ b/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/IcebergConfig.java
@@ -246,6 +246,11 @@ public class IcebergConfig extends Config implements OverwriteDefaultConfig {
           .toSequence()
           .createWithDefault(Collections.emptyList());
 
+  /**
+   * Configuration entry for the single credential-provider type for Iceberg.
+   *
+   * @deprecated use {@link CredentialConstants#CREDENTIAL_PROVIDERS} instead
+   */
   @Deprecated
   public static final ConfigEntry<String> CREDENTIAL_PROVIDER_TYPE =
       new ConfigBuilder(CredentialConstants.CREDENTIAL_PROVIDER_TYPE)

--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/listener/api/event/IcebergRequestContext.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/listener/api/event/IcebergRequestContext.java
@@ -27,7 +27,9 @@ import org.apache.gravitino.utils.PrincipalUtils;
 /** The general request context information for Iceberg REST operations. */
 public class IcebergRequestContext {
 
-  // To keep compatibility with old IcebergRequestContext, will remove in new release.
+  /**
+   * @deprecated Kept only for backward-compatibility and will be removed in the next major release.
+   */
   @Deprecated private final HttpServletRequest httpServletRequest;
   private final String catalogName;
   private final String userName;

--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/listener/api/event/IcebergRequestContext.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/listener/api/event/IcebergRequestContext.java
@@ -31,6 +31,7 @@ public class IcebergRequestContext {
    * @deprecated Kept only for backward-compatibility and will be removed in the next major release.
    */
   @Deprecated private final HttpServletRequest httpServletRequest;
+
   private final String catalogName;
   private final String userName;
   private final String remoteHostName;

--- a/server/src/main/java/org/apache/gravitino/server/web/rest/TagOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/TagOperations.java
@@ -248,6 +248,10 @@ public class TagOperations {
     }
   }
 
+  /**
+   * @deprecated This API has moved to {@code
+   *     /api/metalakes/{metalake}/objects/{type}/{fullName}/tags}.
+   */
   @Deprecated
   @GET
   @Path("{type}/{fullName}")
@@ -265,6 +269,10 @@ public class TagOperations {
     return metadataObjectTagOperations.listTagsForMetadataObject(metalake, type, fullName, verbose);
   }
 
+  /**
+   * @deprecated This API has moved to {@code
+   *     /api/metalakes/{metalake}/objects/{type}/{fullName}/tags/{tag}}.
+   */
   @Deprecated
   @GET
   @Path("{type}/{fullName}/{tag}")
@@ -282,6 +290,10 @@ public class TagOperations {
     return metadataObjectTagOperations.getTagForObject(metalake, type, fullName, tagName);
   }
 
+  /**
+   * @deprecated This API has moved to {@code
+   *     /api/metalakes/{metalake}/objects/{type}/{fullName}/tags}.
+   */
   @Deprecated
   @POST
   @Path("{type}/{fullName}")

--- a/trino-connector/integration-test/src/test/java/org/apache/gravitino/trino/connector/integration/test/TrinoConnectorIT.java
+++ b/trino-connector/integration-test/src/test/java/org/apache/gravitino/trino/connector/integration/test/TrinoConnectorIT.java
@@ -65,6 +65,7 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/** @deprecated */
 @Disabled
 @Deprecated
 @Tag("gravitino-docker-test")

--- a/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/GravitinoConfig.java
+++ b/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/GravitinoConfig.java
@@ -62,6 +62,7 @@ public class GravitinoConfig {
   private static final ConfigEntry GRAVITINO_METALAKE =
       new ConfigEntry("gravitino.metalake", "The metalake name for used", "", true);
 
+  /** @deprecated Please use {@code gravitino.use-single-metalake} instead. */
   @Deprecated
   @SuppressWarnings("UnusedVariable")
   private static final ConfigEntry GRAVITINO_SIMPLIFY_CATALOG_NAMES =


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Add missing `@deprecated` javadoc tags.

### Why are the changes needed?

Fix: #7219

### Does this PR introduce _any_ user-facing change?

(Please list the user-facing changes introduced by your change, including
  1. Change in user-facing APIs.
  2. Addition or removal of property keys.)

### How was this patch tested?

(Please test your changes, and provide instructions on how to test it:
  1. If you add a feature or fix a bug, add a test to cover your changes.
  2. If you fix a flaky test, repeat it for many times to prove it works.)
