### PR TITLE
[#7202] [Improvement] Fix broken anchors in markdown files

### DIFF
--- a/docs/gravitino-server-config.md
+++ b/docs/gravitino-server-config.md
@@ -204,7 +204,7 @@ Refer to [security](security/security.md) for HTTPS and authentication configura
 |-------------------------------------------|------------------------------------------------------|---------------|----------|---------------|
 | `gravitino.metrics.timeSlidingWindowSecs` | The seconds of Gravitino metrics time sliding window | 60            | No       | 0.5.1         |
 
-## Apache Gravitino catalog properties configuration
+## Gravitino catalog properties configuration
 
 There are three types of catalog properties:
 

--- a/docs/manage-model-metadata-using-gravitino.md
+++ b/docs/manage-model-metadata-using-gravitino.md
@@ -492,7 +492,7 @@ model_list = catalog.as_model_catalog().list_models(namespace=Namespace.of("mode
 </TabItem>
 </Tabs>
 
-## ModelVersion operations
+## Model Version operations
 
 :::tip
  - Users should create a metalake, a catalog, a schema, and a model before link a model version

--- a/docs/manage-relational-metadata-using-gravitino.md
+++ b/docs/manage-relational-metadata-using-gravitino.md
@@ -874,7 +874,7 @@ In order to create a table, you need to provide the following information:
 - Table column auto-increment (optional)
 - Table property (optional)
 
-#### Apache Gravitino table column type
+#### Gravitino table column type
 
 The following types that Gravitino supports:
 

--- a/docs/security/authorization-pushdown.md
+++ b/docs/security/authorization-pushdown.md
@@ -13,7 +13,7 @@ Gravitino offers a set of authorization frameworks that integrate with various u
 Gravitino manages different data sources through Catalogs, and when a user performs an authorization operation on data within a Catalog, Gravitino invokes the Authorization Plugin module for that Catalog.
 This module translates Gravitino's authorization model into the permission rules of the underlying data source. The permissions are then enforced by the underlying permission system via the respective client, such as JDBC or the Apache Ranger client.
 
-### Ranger Hadoop SQL Plugin
+### Authorization Hive with Ranger Properties
 
 In order to use the Ranger Hadoop SQL Plugin, you need to configure the following properties:
 


### PR DESCRIPTION
[#7202] [Improvement] Fix broken anchors in markdown files

### What changes were proposed in this pull request?
- Updated heading anchors in documentation files to match existing links:
  - Modified headings in ~
     - `gravitino-server-config.md`
     - `manage-model-metadata-using-gravitino.md`
     - `manage-relational-metadata-using-gravitino.md`
     - `security/authorization-pushdown.md`

### Why are the changes needed?
- Several markdown files contained references to anchors that didn't match the actual section headings
- This was causing navigation issues in the generated documentation
- Fixes: #7202

### Does this PR introduce any user-facing change?
- No 

### How was this patch tested?
- Verified all internal links work correctly in local documentation