### PR TITLE
[MINOR] fix: prevent overwriting existing config keys during initialization

### DIFF
--- a/dev/docker/iceberg-rest-server/rewrite_config.py
+++ b/dev/docker/iceberg-rest-server/rewrite_config.py
@@ -83,8 +83,11 @@ def update_config(config, key, value):
 config_file_path = "conf/gravitino-iceberg-rest-server.conf"
 config_map = parse_config_file(config_file_path)
 
+# Set from init_config only if the key doesn't exist
 for k, v in init_config.items():
-    update_config(config_map, k, v)
+    full_key = config_prefix + k
+    if full_key not in config_map:
+        update_config(config_map, k, v)
 
 for k, v in env_map.items():
     if k in os.environ:


### PR DESCRIPTION
### What changes were proposed in this pull request?

The script now only sets config values from init_config if the key does not already exist in config_map, instead of always overwriting existing values.

### Why are the changes needed?

This allows users to override config values in iceberg-rest-server, which was previously not possible because the script always overwrote user-supplied settings.