### PR TITLE
[#7280] refactor: localize schema stubbing in TestHadoopCatalogOperations

### DIFF
--- a/catalogs/catalog-hadoop/src/test/java/org/apache/gravitino/catalog/hadoop/TestHadoopCatalogOperations.java
+++ b/catalogs/catalog-hadoop/src/test/java/org/apache/gravitino/catalog/hadoop/TestHadoopCatalogOperations.java
@@ -151,6 +151,7 @@ public class TestHadoopCatalogOperations {
   private static EntityStore store;
 
   private static IdGenerator idGenerator;
+  private static SchemaMetaService spySchemaMetaService;
 
   private static CatalogInfo randomCatalogInfo() {
     return new CatalogInfo(
@@ -187,6 +188,13 @@ public class TestHadoopCatalogOperations {
         props,
         null,
         Namespace.of(metalakeName));
+  }
+
+  private void stubSchema(long schemaId) {
+    doReturn(new SchemaIds(1L, 1L, schemaId))
+        .when(spySchemaMetaService)
+        .getSchemaIdByMetalakeNameAndCatalogNameAndSchemaName(
+            Mockito.anyString(), Mockito.anyString(), Mockito.eq("schema" + schemaId));
   }
 
   @BeforeAll
@@ -231,23 +239,11 @@ public class TestHadoopCatalogOperations {
         .getCatalogIdByMetalakeIdAndName(Mockito.anyLong(), Mockito.anyString());
 
     SchemaMetaService serviceMetaService = SchemaMetaService.getInstance();
-    SchemaMetaService spySchemaMetaService = Mockito.spy(serviceMetaService);
+    spySchemaMetaService = Mockito.spy(serviceMetaService);
 
     doReturn(new CatalogIds(1L, 1L))
         .when(spyCatalogMetaService)
         .getCatalogIdByMetalakeAndCatalogName(Mockito.anyString(), Mockito.anyString());
-
-    doReturn(new SchemaIds(1L, 1L, 1L))
-        .when(spySchemaMetaService)
-        .getSchemaIdByMetalakeNameAndCatalogNameAndSchemaName(
-            Mockito.anyString(), Mockito.anyString(), Mockito.eq("schema11"));
-
-    for (int i = 10; i < 33; i++) {
-      doReturn(new SchemaIds(1L, 1L, (long) i))
-          .when(spySchemaMetaService)
-          .getSchemaIdByMetalakeNameAndCatalogNameAndSchemaName(
-              Mockito.anyString(), Mockito.anyString(), Mockito.eq("schema" + i));
-    }
 
     Stream<Arguments> argumentsStream = testRenameArguments();
     argumentsStream.forEach(
@@ -1188,6 +1184,7 @@ public class TestHadoopCatalogOperations {
 
   @Test
   public void testRemoveFilesetComment() throws IOException {
+    stubSchema(27L);
     String schemaName = "schema27";
     String comment = "comment27";
     String schemaPath = TEST_ROOT_PATH + "/" + schemaName;

--- a/catalogs/catalog-hadoop/src/test/java/org/apache/gravitino/catalog/hadoop/TestHadoopCatalogOperations.java
+++ b/catalogs/catalog-hadoop/src/test/java/org/apache/gravitino/catalog/hadoop/TestHadoopCatalogOperations.java
@@ -606,6 +606,7 @@ public class TestHadoopCatalogOperations {
 
   @Test
   public void testDropSchema() throws IOException {
+    stubSchema(20L);
     String name = "schema20";
     String comment = "comment20";
     String catalogPath = TEST_ROOT_PATH + "/" + "catalog20";
@@ -670,6 +671,7 @@ public class TestHadoopCatalogOperations {
 
   @Test
   public void testDropSchemaWithFSOpsDisabled() throws IOException {
+    stubSchema(21L);
     String name = "schema21";
     String comment = "comment21";
     String catalogPath = TEST_ROOT_PATH + "/" + "catalog20";
@@ -875,6 +877,7 @@ public class TestHadoopCatalogOperations {
 
   @Test
   public void testListFilesets() throws IOException {
+    stubSchema(23L);
     String schemaName = "schema23";
     String comment = "comment23";
     String schemaPath = TEST_ROOT_PATH + "/" + schemaName;
@@ -898,6 +901,7 @@ public class TestHadoopCatalogOperations {
 
   @Test
   public void testListFilesetFiles() throws IOException {
+    stubSchema(30L);
     String schemaName = "schema30";
     String comment = "comment30";
     String filesetName = "fileset30";
@@ -947,6 +951,7 @@ public class TestHadoopCatalogOperations {
 
   @Test
   public void testListFilesetFilesWithFSOpsDisabled() throws Exception {
+    stubSchema(31L);
     String schemaName = "schema31";
     String comment = "comment31";
     String filesetName = "fileset31";
@@ -975,6 +980,7 @@ public class TestHadoopCatalogOperations {
 
   @Test
   public void testListFilesetFilesWithNonExistentPath() throws IOException {
+    stubSchema(32L);
     String schemaName = "schema32";
     String comment = "comment32";
     String filesetName = "fileset32";
@@ -1054,6 +1060,7 @@ public class TestHadoopCatalogOperations {
 
   @Test
   public void testAlterFilesetProperties() throws IOException {
+    stubSchema(25L);
     String schemaName = "schema25";
     String comment = "comment25";
     String schemaPath = TEST_ROOT_PATH + "/" + schemaName;
@@ -1161,6 +1168,7 @@ public class TestHadoopCatalogOperations {
 
   @Test
   public void testUpdateFilesetComment() throws IOException {
+    stubSchema(26L);
     String schemaName = "schema26";
     String comment = "comment26";
     String schemaPath = TEST_ROOT_PATH + "/" + schemaName;
@@ -1254,6 +1262,7 @@ public class TestHadoopCatalogOperations {
 
   @Test
   public void testGetFileLocation() throws IOException {
+    stubSchema(29L);
     String schemaName = "schema29";
     String comment = "schema29";
     String schemaPath = TEST_ROOT_PATH + "/" + schemaName;


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Move the schema-stubbing action to its corresponding test.

### Why are the changes needed?

In `setUp()` of `TestHadoopCatalogOperations`, we stub schema files in a fixed‐length loop. As we add new tests that require additional schemas to be stubbed (e.g. schema30, schema31, ...) , this manual update of the loop's upper bound is inefficient and throws misleading test failures.

Fix: #7280 

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

by `TestHadoopCatalogOperations` itself
