### PR TITLE
[#7336] fix(client-fuse): fix gvfs fuse location parsing

### DIFF
--- a/clients/filesystem-fuse/src/gvfs_creator.rs
+++ b/clients/filesystem-fuse/src/gvfs_creator.rs
@@ -126,9 +126,9 @@ pub fn extract_fileset(path: &str) -> GvfsResult<(String, String, String)> {
         return Err(InvalidConfig.to_error(format!("Invalid fileset path: {}", path)));
     }
 
-    let catalog = split[1].to_string();
-    let schema = split[2].to_string();
-    let fileset = split[3].to_string();
+    let catalog = split[0].to_string();
+    let schema = split[1].to_string();
+    let fileset = split[2].to_string();
     Ok((catalog, schema, fileset))
 }
 

--- a/clients/filesystem-fuse/src/gvfs_creator.rs
+++ b/clients/filesystem-fuse/src/gvfs_creator.rs
@@ -111,6 +111,10 @@ pub(crate) async fn create_fs_with_fileset(
 }
 
 pub fn extract_fileset(path: &str) -> GvfsResult<(String, String, String)> {
+    let mut path = path;
+    if path.ends_with('/') {
+        path = &path[0..path.len() - 1];
+    }
     let path = parse_location(path)?;
 
     if path.scheme() != GRAVITINO_FILESET_SCHEMA {
@@ -122,7 +126,7 @@ pub fn extract_fileset(path: &str) -> GvfsResult<(String, String, String)> {
         return Err(InvalidConfig.to_error(format!("Invalid fileset path: {}", path)));
     }
     let split = split.unwrap().collect::<Vec<&str>>();
-    if split.len() != 4 {
+    if split.len() != 3 {
         return Err(InvalidConfig.to_error(format!("Invalid fileset path: {}", path)));
     }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

fix [#7336]

### Why are the changes needed?

As the issue described, the current fuse client is not working with gvfs url without metalake.


### Does this PR introduce _any_ user-facing change?

No. 

### How was this patch tested?

I built and tested on my local server.