### PR TITLE
[#7341] fix(chart): output server log to both console and file

### DIFF
--- a/dev/charts/gravitino-iceberg-rest-server/Chart.yaml
+++ b/dev/charts/gravitino-iceberg-rest-server/Chart.yaml
@@ -42,4 +42,4 @@ sources:
   - https://github.com/apache/gravitino/tree/main/dev/charts/gravitino-iceberg-rest-server
 
 appVersion: 1.0.0-SNAPSHOT
-version: 1.0.0
+version: 1.0.1

--- a/dev/charts/gravitino-iceberg-rest-server/resources/init.sh
+++ b/dev/charts/gravitino-iceberg-rest-server/resources/init.sh
@@ -22,4 +22,4 @@ cp /tmp/conf/* ${GRAVITINO_HOME}/conf
 cp /tmp/conf/log4j2.properties ${GRAVITINO_HOME}/conf
 
 echo "Start the Gravitino Iceberg Rest Catalog Server"
-/bin/bash ${GRAVITINO_HOME}/bin/start-iceberg-rest-server.sh start
+/bin/bash ${GRAVITINO_HOME}/bin/gravitino-iceberg-rest-server.sh run

--- a/dev/charts/gravitino-iceberg-rest-server/templates/NOTES.txt
+++ b/dev/charts/gravitino-iceberg-rest-server/templates/NOTES.txt
@@ -25,7 +25,7 @@
 
 2. View service:
    kubectl get svc -n {{ include "gravitino-iceberg-rest-server.namespace" . }} \
-     -l app={{ include "gravitino-iceberg-rest-server.name" . }}
+     -l app.kubernetes.io/name={{ include "gravitino-iceberg-rest-server.name" . }}
 
 3. View config:
    kubectl get cm {{ include "gravitino-iceberg-rest-server.fullname" . }} -n \

--- a/dev/charts/gravitino-iceberg-rest-server/values.yaml
+++ b/dev/charts/gravitino-iceberg-rest-server/values.yaml
@@ -142,12 +142,12 @@ log4j2Properties: {}
 
 ## Additional log4j2 configuration items in log4j2.properties can be added
 ##
-additionalLog4j2Properties: {}
-  # appender.console.type: Console
-  # appender.console.name: console
-  # appender.console.layout.type: PatternLayout
-  # appender.console.layout.pattern: "%d{HH:mm:ss.SSS} %level %msg%n"
-  # rootLogger.appenderRef.console.ref: console
+additionalLog4j2Properties:
+  appender.console.type: Console
+  appender.console.name: consoleLogger
+  appender.console.layout.type: PatternLayout
+  appender.console.layout.pattern: "%d{yyyy-MM-dd HH:mm:ss} %-5p [%t] %c{1}:%L - %m%n"
+  rootLogger.appenderRef.console.ref: consoleLogger
 
 ## Hadoop configuration items in hdfs-site.xml and core-site.xml can be customized
 coreSiteProperties: {}

--- a/dev/charts/gravitino/Chart.yaml
+++ b/dev/charts/gravitino/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: gravitino
 sources:
   - https://github.com/apache/gravitino
-version: 1.0.0
+version: 1.0.2

--- a/dev/charts/gravitino/Chart.yaml
+++ b/dev/charts/gravitino/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: gravitino
 sources:
   - https://github.com/apache/gravitino
-version: 1.0.2
+version: 1.0.1

--- a/dev/charts/gravitino/resources/config/init.sh
+++ b/dev/charts/gravitino/resources/config/init.sh
@@ -34,11 +34,5 @@ echo "Finish downloading"
 cp /tmp/conf/* ${GRAVITINO_HOME}/conf
 cp /tmp/conf/log4j2.properties ${GRAVITINO_HOME}/conf
 
-{{- if .Values.log.containerStdout }}
-# Redirect log files to container stdout and stderr
-ln -sf /dev/stdout ${GRAVITINO_HOME}/logs/gravitino_audit.log
-ln -sf /dev/stdout ${GRAVITINO_HOME}/logs/gravitino-server.log
-ln -sf /dev/stderr ${GRAVITINO_HOME}/logs/gravitino-server.out
-{{- end }}
 echo "Start the Gravitino Server"
-/bin/bash ${GRAVITINO_HOME}/bin/gravitino.sh start
+/bin/bash ${GRAVITINO_HOME}/bin/gravitino.sh run

--- a/dev/charts/gravitino/templates/NOTES.txt
+++ b/dev/charts/gravitino/templates/NOTES.txt
@@ -16,7 +16,7 @@
   specific language governing permissions and limitations
   under the License.
   */}}
-{{ $.Chart.Name }} has been installed. Check its status by running:
+🚀 {{ $.Chart.Name }} has been installed. Check its status by running:
 
   kubectl get pods --namespace {{ include "gravitino.namespace" . }}
 

--- a/dev/charts/gravitino/values.yaml
+++ b/dev/charts/gravitino/values.yaml
@@ -242,11 +242,6 @@ persistence:
   # existingClaim:
   # storageClassName:
 
-## Whether redirect the log files to the container stdout and stderr
-##
-log:
-  containerStdout: false
-
 ## Gravitino log4j2 configuration items in log4j2.properties can be customized
 ##
 log4j2Properties: {}
@@ -286,12 +281,12 @@ log4j2Properties: {}
 
 ## Additional log4j2 configuration items in log4j2.properties can be added
 ##
-additionalLog4j2Properties: {}
-  # appender.console.type: Console
-  # appender.console.name: console
-  # appender.console.layout.type: PatternLayout
-  # appender.console.layout.pattern: "%d{HH:mm:ss.SSS} %level %msg%n"
-  # rootLogger.appenderRef.console.ref: console
+additionalLog4j2Properties:
+  appender.console.type: Console
+  appender.console.name: consoleLogger
+  appender.console.layout.type: PatternLayout
+  appender.console.layout.pattern: "%d{yyyy-MM-dd HH:mm:ss} %-5p [%t] %c{1}:%L - %m%n"
+  rootLogger.appenderRef.console.ref: consoleLogger
 
 ## Expose the gravitino service to be accessed from outside the cluster (LoadBalancer service).
 ## or access it from within the cluster (ClusterIP service). Set the service type and the port to serve it.

--- a/docs/iceberg-rest-catalog-chart.md
+++ b/docs/iceberg-rest-catalog-chart.md
@@ -41,13 +41,13 @@ helm install [RELEASE_NAME] [CHART] [flags]
 
 ### Deploy with Default Configuration
 
-Run the following command to deploy Gravitino Iceberg REST Catalog Server using the default settings, specify container image versions using --set image.tag=x.y.z-incubating (replace x, y, z with the expected version numbers):
+Run the following command to deploy Gravitino Iceberg REST Catalog Server using the default settings, specify container image versions using --set image.tag=x.y.z (replace x, y, z with the expected version numbers):
 
 ```console
 helm upgrade --install gravitino ./gravitino-iceberg-rest-server \
   -n gravitino \
   --create-namespace \
-  --set image.tag=<x.y.z-incubating> \
+  --set image.tag=<x.y.z> \
   --set replicas=2 \
   --set resources.requests.memory="4Gi" \
   --set resources.requests.cpu="2"


### PR DESCRIPTION
### What changes were proposed in this pull request?

Currently deploy gravitino by Chart , the server log either output to console or file. We'd better support both.

 Output to console ,then user can check log by `kubectl logs <pod-name> -n <namespace>` command 

### Why are the changes needed?

Fix: #7341

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

CI
