### PR TITLE
[MINOR] feat(cli): Add MODEL provider support to CLI

### DIFF
--- a/clients/cli/src/main/java/org/apache/gravitino/cli/Providers.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/Providers.java
@@ -27,6 +27,7 @@ import org.apache.gravitino.Catalog;
  * Gravitino CLI. It also can validate if a given entity is a valid entity.
  */
 public class Providers {
+
   public static final String HIVE = "hive";
   public static final String HADOOP = "hadoop";
   public static final String ICEBERG = "iceberg";
@@ -37,6 +38,7 @@ public class Providers {
   public static final String PAIMON = "paimon";
   public static final String HUDI = "hudi";
   public static final String OCEANBASE = "oceanbase";
+  public static final String MODEL = "model"; // Add MODEL provider constant definition
 
   private static final HashSet<String> VALID_PROVIDERS = new HashSet<>();
 
@@ -51,6 +53,7 @@ public class Providers {
     VALID_PROVIDERS.add(PAIMON);
     VALID_PROVIDERS.add(HUDI);
     VALID_PROVIDERS.add(OCEANBASE);
+    VALID_PROVIDERS.add(MODEL); // Add MODEL to the valid providers set
   }
 
   /**
@@ -85,6 +88,8 @@ public class Providers {
         return "lakehouse-hudi";
       case OCEANBASE:
         return "jdbc-oceanbase";
+      case MODEL:
+        return "model"; // Handle MODEL provider and return internal provider name
       default:
         throw new IllegalArgumentException("Unsupported provider: " + provider);
     }
@@ -105,6 +110,8 @@ public class Providers {
         return Catalog.Type.RELATIONAL;
       case KAFKA:
         return Catalog.Type.MESSAGING;
+      case MODEL: // Set catalog type to MODEL for model provider
+        return Catalog.Type.MODEL;
       default:
         throw new IllegalArgumentException("Unsupported provider: " + provider);
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add support for MODEL provider in CLI catalog creation command by:
- Add MODEL constant definition
- Add MODEL to valid providers set
- Handle MODEL provider in internal() method
- Set catalog type to MODEL for model provider

### Why are the changes needed?

Currently, the CLI throws "Unsupported provider: model" error when trying to create a model catalog. This prevents users from using the CLI to manage model catalogs, even though the server supports model catalogs.

Fix: CLI does not support create model catalog now

### Does this PR introduce *any* user-facing change?

Yes, this PR introduces the following user-facing change:
- Users can now use CLI command `gcli.sh catalog create --metalake <metalake> --name <name> --provider model` to create model catalogs
- The CLI will no longer throw "Unsupported provider: model" error for model provider

### How was this patch tested?

- Built the project successfully with `./gradlew build`
- Ran CLI tests with `./gradlew :clients:cli:test` - all tests passed
- **Manual testing**: CLI command `catalog create --metalake yedian --name model --provider model` now successfully creates model catalog instead of throwing "Unsupported provider: model" error
- Verified the fix by starting local Gravitino server and testing the complete workflow