### PR TITLE
[#6786] fix(authz): modify querying roles by user in ROLE_USER_REL relation for JcasbinAuthorizer

### DIFF
--- a/core/src/main/java/org/apache/gravitino/storage/relational/JDBCBackend.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/JDBCBackend.java
@@ -443,6 +443,8 @@ public class JDBCBackend implements RelationalBackend {
       case ROLE_USER_REL:
         if (identType == Entity.EntityType.ROLE) {
           return (List<E>) UserMetaService.getInstance().listUsersByRoleIdent(nameIdentifier);
+        } else if (identType == Entity.EntityType.USER) {
+          return (List<E>) RoleMetaService.getInstance().listRolesByUserIdent(nameIdentifier);
         } else {
           throw new IllegalArgumentException(
               String.format("ROLE_USER_REL doesn't support type %s", identType.name()));

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/RoleMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/RoleMetaService.java
@@ -40,6 +40,7 @@ import org.apache.gravitino.authorization.AuthorizationUtils;
 import org.apache.gravitino.authorization.SecurableObject;
 import org.apache.gravitino.exceptions.NoSuchEntityException;
 import org.apache.gravitino.meta.RoleEntity;
+import org.apache.gravitino.meta.UserEntity;
 import org.apache.gravitino.storage.relational.mapper.GroupRoleRelMapper;
 import org.apache.gravitino.storage.relational.mapper.OwnerMetaMapper;
 import org.apache.gravitino.storage.relational.mapper.RoleMetaMapper;
@@ -86,11 +87,9 @@ public class RoleMetaService {
   }
 
   public List<RoleEntity> listRolesByUserIdent(NameIdentifier userIdent) {
+    UserEntity user = UserMetaService.getInstance().getUserByIdentifier(userIdent);
     String metalake = NameIdentifierUtil.getMetalake(userIdent);
-    Long metalakeId = MetalakeMetaService.getInstance().getMetalakeIdByName(metalake);
-    Long userId =
-        UserMetaService.getInstance().getUserIdByMetalakeIdAndName(metalakeId, userIdent.name());
-    List<RolePO> rolePOs = listRolesByUserId(userId);
+    List<RolePO> rolePOs = listRolesByUserId(user.id());
     return rolePOs.stream()
         .map(
             po ->

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/RoleMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/RoleMetaService.java
@@ -85,6 +85,20 @@ public class RoleMetaService {
         RoleMetaMapper.class, mapper -> mapper.listRolesByUserId(userId));
   }
 
+  public List<RoleEntity> listRolesByUserIdent(NameIdentifier userIdent) {
+    String metalake = NameIdentifierUtil.getMetalake(userIdent);
+    Long metalakeId = MetalakeMetaService.getInstance().getMetalakeIdByName(metalake);
+    Long userId =
+        UserMetaService.getInstance().getUserIdByMetalakeIdAndName(metalakeId, userIdent.name());
+    List<RolePO> rolePOs = listRolesByUserId(userId);
+    return rolePOs.stream()
+        .map(
+            po ->
+                POConverters.fromRolePO(
+                    po, Collections.emptyList(), AuthorizationUtils.ofRoleNamespace(metalake)))
+        .collect(Collectors.toList());
+  }
+
   public List<RoleEntity> listRolesByMetadataObject(
       NameIdentifier metadataObjectIdent, Entity.EntityType metadataObjectType, boolean allFields) {
     String metalake = NameIdentifierUtil.getMetalake(metadataObjectIdent);

--- a/server-common/src/main/java/org/apache/gravitino/server/authorization/jcasbin/JcasbinAuthorizer.java
+++ b/server-common/src/main/java/org/apache/gravitino/server/authorization/jcasbin/JcasbinAuthorizer.java
@@ -154,7 +154,7 @@ public class JcasbinAuthorizer implements GravitinoAuthorizer {
               .listEntitiesByRelation(
                   SupportsRelationOperations.Type.ROLE_USER_REL,
                   NameIdentifierUtil.ofUser(metalake, username),
-                  Entity.EntityType.ROLE);
+                  Entity.EntityType.USER);
 
       for (RoleEntity role : entities) {
         Long roleId = role.id();

--- a/server-common/src/test/java/org/apache/gravitino/server/authorization/jcasbin/TestJcasbinAuthorizer.java
+++ b/server-common/src/test/java/org/apache/gravitino/server/authorization/jcasbin/TestJcasbinAuthorizer.java
@@ -166,7 +166,7 @@ public class TestJcasbinAuthorizer {
     when(supportsRelationOperations.listEntitiesByRelation(
             eq(SupportsRelationOperations.Type.ROLE_USER_REL),
             eq(userNameIdentifier),
-            eq(Entity.EntityType.ROLE)))
+            eq(Entity.EntityType.USER)))
         .thenReturn(ImmutableList.of(allowRole));
     assertTrue(doAuthorize(currentPrincipal));
     // Test role cache.
@@ -177,7 +177,7 @@ public class TestJcasbinAuthorizer {
     when(supportsRelationOperations.listEntitiesByRelation(
             eq(SupportsRelationOperations.Type.ROLE_USER_REL),
             eq(userNameIdentifier),
-            eq(Entity.EntityType.ROLE)))
+            eq(Entity.EntityType.USER)))
         .thenReturn(ImmutableList.of(tempNewRole));
     assertTrue(doAuthorize(currentPrincipal));
     // After clearing the cache, authorize will fail
@@ -187,7 +187,7 @@ public class TestJcasbinAuthorizer {
     when(supportsRelationOperations.listEntitiesByRelation(
             eq(SupportsRelationOperations.Type.ROLE_USER_REL),
             eq(userNameIdentifier),
-            eq(Entity.EntityType.ROLE)))
+            eq(Entity.EntityType.USER)))
         .thenReturn(ImmutableList.of(allowRole));
     assertTrue(doAuthorize(currentPrincipal));
     // Test deny
@@ -195,7 +195,7 @@ public class TestJcasbinAuthorizer {
     when(supportsRelationOperations.listEntitiesByRelation(
             eq(SupportsRelationOperations.Type.ROLE_USER_REL),
             eq(userNameIdentifier),
-            eq(Entity.EntityType.ROLE)))
+            eq(Entity.EntityType.USER)))
         .thenReturn(ImmutableList.of(allowRole, denyRole));
     assertFalse(doAuthorize(currentPrincipal));
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Currently, the `ROLE_USER_REL` relation in `JDBCBackend` only supports querying users by role, but not querying roles by user. This causes issues in `JcasbinAuthorizer` when trying to load user privileges.

This PR adds support for querying roles by user in the `ROLE_USER_REL` relation by modifying the `listEntitiesByRelation` method in `JDBCBackend`.

### Why are the changes needed?

Fixes #6786

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

Ran `./gradlew clean build`