### PR TITLE
[ISSUE5363] Make fileset python client pluggable

### DIFF
--- a/clients/client-python/gravitino/filesystem/gvfs_config.py
+++ b/clients/client-python/gravitino/filesystem/gvfs_config.py
@@ -73,3 +73,5 @@ class GVFSConfig:
 
     # The configuration key for whether to enable credential vending. The default is false.
     GVFS_FILESYSTEM_ENABLE_CREDENTIAL_VENDING = "enable_credential_vending"
+
+    GVFS_FILESYSTEM_STORAGE_HANDLER_PROVIDERS = "storage_handler_providers"

--- a/clients/client-python/gravitino/filesystem/storage_handler_provider.py
+++ b/clients/client-python/gravitino/filesystem/storage_handler_provider.py
@@ -1,0 +1,15 @@
+class StorageHandlerProvider(ABC):
+    @abstractmethod
+    def get_storage_handler(self) -> StorageHandler:
+        """返回存储处理器实例"""
+        pass
+
+    @abstractmethod
+    def scheme(self) -> str:
+        """返回支持的URI scheme，如's3a', 'custom'等"""
+        pass
+
+    @abstractmethod
+    def name(self) -> str:
+        """返回provider名称"""
+        pass


### PR DESCRIPTION
### What changes were proposed in this pull request?

Related to [ISSUE#5363](https://github.com/apache/gravitino/issues/5363)

### Why are the changes needed?

Usage example

- Implement a custom StorageHandlerProvider
- Specify the provider class name in the configuration
- No need to modify the Gravitino core code
# User code example 
```
options = { 
"server_uri": "http://localhost:8090", 
"metalake_name": "test_metalake", 
"storage_handler_providers": "com.example.CustomFileSystemProvider" 
} 

fs = gvfs.GravitinoVirtualFileSystem( 
server_uri="http://localhost:8090", 
metalake_name="test_metalake", 
options=options 
)
```

### How was this patch tested?

(Please test your changes, and provide instructions on how to test it:
  1. If you add a feature or fix a bug, add a test to cover your changes.
  2. If you fix a flaky test, repeat it for many times to prove it works.)
