### PR TITLE
[#7387] fix(iceberg): standalone Iceberg REST server failed to start with oauth enabled

### DIFF
--- a/iceberg/iceberg-rest-server/build.gradle.kts
+++ b/iceberg/iceberg-rest-server/build.gradle.kts
@@ -47,6 +47,7 @@ dependencies {
   implementation(libs.bundles.iceberg)
   implementation(libs.bundles.jetty)
   implementation(libs.bundles.jersey)
+  implementation(libs.bundles.jwt)
   implementation(libs.bundles.log4j)
   implementation(libs.bundles.metrics)
   implementation(libs.bundles.prometheus)


### PR DESCRIPTION
### What changes were proposed in this pull request?

add jwt dependences

### Why are the changes needed?

Fix: #7387 

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
compile standalone IRC server and verify with oauth configuraitons.
