### PR TITLE
fix(test): close H2 backend before deleting files to prevent file lock issues

### DIFF
--- a/core/src/test/java/org/apache/gravitino/storage/relational/TestJDBCBackend.java
+++ b/core/src/test/java/org/apache/gravitino/storage/relational/TestJDBCBackend.java
@@ -144,6 +144,7 @@ public class TestJDBCBackend {
   @AfterAll
   public void tearDown() throws IOException {
     dropAllTables();
+    backend.close();
     File dir = new File(DB_DIR);
     if (dir.exists()) {
       Files.delete(Paths.get(DB_DIR));
@@ -151,7 +152,6 @@ public class TestJDBCBackend {
 
     Files.delete(Paths.get(H2_FILE));
     Files.delete(Paths.get(JDBC_STORE_PATH));
-    backend.close();
   }
 
   @BeforeEach


### PR DESCRIPTION
This PR fixes an issue in the test teardown process where database files are deleted before properly closing the H2 backend. Deleting files while the database connections are still open causes file locking errors, especially on Windows systems.

By ensuring that backend.close() is called before deleting the H2 database files, this change prevents the "file in use" exceptions and improves test stability across all platforms.