### PR TITLE
[#7378] fix(storage): prevent connection leaks in relational service methods

### DIFF
--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/TableColumnMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/TableColumnMetaService.java
@@ -107,7 +107,7 @@ public class TableColumnMetaService {
 
   public int deleteColumnsByLegacyTimeline(Long legacyTimeline, int limit) {
     // deleteColumns will be done in the outside transaction, so we don't do commit here.
-    return SessionUtils.doWithoutCommitAndFetchResult(
+    return SessionUtils.getWithoutCommit(
         TableColumnMapper.class,
         mapper -> mapper.deleteColumnPOsByLegacyTimeline(legacyTimeline, limit));
   }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/TagMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/TagMetaService.java
@@ -169,7 +169,7 @@ public class TagMetaService {
               metalakeId, metadataObject.fullName(), metadataObject.type());
 
       tagPOs =
-          SessionUtils.doWithoutCommitAndFetchResult(
+          SessionUtils.getWithoutCommit(
               TagMetadataObjectRelMapper.class,
               mapper ->
                   mapper.listTagPOsByMetadataObjectIdAndType(
@@ -336,7 +336,7 @@ public class TagMetaService {
 
       // Fetch all the tags associated with the metadata object after the operation.
       List<TagPO> tagPOs =
-          SessionUtils.doWithoutCommitAndFetchResult(
+          SessionUtils.getWithoutCommit(
               TagMetadataObjectRelMapper.class,
               mapper ->
                   mapper.listTagPOsByMetadataObjectIdAndType(


### PR DESCRIPTION
### What changes were proposed in this pull request?
- Replaced unsafe `doWithoutCommit[AndFetchResult]` methods with `getWithoutCommit` in relational services
- Implemented proper connection/session resource cleanup using try-finally blocks
- Modified affected methods in:
  - `TableColumnMetaService.deleteColumnsByLegacyTimeline()`
  - `TagMetaService#getTagForMetadataObject|associateTagsWithMetadataObject`

### Why are the changes needed?
Fix: #7378

Prevents database connection leaks that could lead to:
- Connection pool exhaustion
- Potential system instability under heavy load
- Resource management inconsistencies

### Does this PR introduce any user-facing change?
No
- Maintains identical transactional behavior
- Preserves all existing functionality
- Only changes internal resource management

### How was this patch tested?
- Connection pool stability verification under repeated operations (1000+ iterations)
- Transaction rollback behavior validation
- Query/update result correctness checks
- Integration with existing transaction management flows