### PR TITLE
[#7403] fix(core): Fix bugs in SQL session commit in the core module

### DIFF
--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/TableColumnMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/TableColumnMetaService.java
@@ -100,7 +100,7 @@ public class TableColumnMetaService {
   boolean deleteColumnsByTableId(Long tableId) {
     // deleteColumns will be done in deleteTable transaction, so we don't do commit here.
     Integer result =
-        SessionUtils.doWithCommitAndFetchResult(
+        SessionUtils.doWithoutCommitAndFetchResult(
             TableColumnMapper.class, mapper -> mapper.softDeleteColumnsByTableId(tableId));
     return result > 0;
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Replace `doWithCommitAndFetchResult` with `doWithoutCommitAndFetchResult` in the method `deleteColumnsByTableId`.

### Why are the changes needed?

The method is used in `doMultipleWithCommit` and should not use `doWithCommitAndFetchResult`.

Fix: #7403 

### Does this PR introduce _any_ user-facing change?

N/A.

### How was this patch tested?

Existing UTs and ITs.
