### PR TITLE
[#7415] fix(core): Use doWithCommitAndFetchResult in deleteColumnsByLegacyTimeline

### DIFF
--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/TableColumnMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/TableColumnMetaService.java
@@ -106,8 +106,7 @@ public class TableColumnMetaService {
   }
 
   public int deleteColumnsByLegacyTimeline(Long legacyTimeline, int limit) {
-    // deleteColumns will be done in the outside transaction, so we don't do commit here.
-    return SessionUtils.doWithoutCommitAndFetchResult(
+    return SessionUtils.doWithCommitAndFetchResult(
         TableColumnMapper.class,
         mapper -> mapper.deleteColumnPOsByLegacyTimeline(legacyTimeline, limit));
   }


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?
This PR modifies the  deleteColumnsByLegacyTimeline method in the  TableColumnMetaService class, changing the transaction handling from doWithoutCommitAndFetchResult to doWithCommitAndFetchResult.


### Why are the changes needed?
This change is necessary because the  deleteColumnsByLegacyTimeline method is a standalone operation that needs to commit its transaction immediately after execution. Using doWithCommitAndFetchResult ensures:
1. The deletion operation executes and commits within its own transaction, not depending on external transactions
2. Consistency with garbage collection operations for other entity types (like MetalakeMeta, CatalogMeta, etc.) which also use doWithCommitAndFetchResult
3. Prevention of database locking issues caused by long-running transactions
4. Immediate visibility of deletion results to other transactions


Fix: #(issue)

### Does this PR introduce _any_ user-facing change?
No, this is an improvement to the internal implementation and does not affect user interfaces or functionality.

### How was this patch tested?
The modified method was verified through the junit test TestTableColumnMetaService.testDeleteColumnsByLegacyTimeline, which ensures: 
1. The system correctly identifies and deletes columns with a specific legacy timeline
2. The batch deletion functionality (with limit parameter) works properly
3. The deletion operation is idempotent, meaning repeated calls do not cause errors
