### PR TITLE
[#7179] improvement(core): Remove old cached System

### DIFF
--- a/core/src/main/java/org/apache/gravitino/metalake/MetalakeManager.java
+++ b/core/src/main/java/org/apache/gravitino/metalake/MetalakeManager.java
@@ -79,6 +79,11 @@ public class MetalakeManager implements MetalakeDispatcher, Closeable {
   public MetalakeManager(EntityStore store, IdGenerator idGenerator) {
     this.store = store;
     this.idGenerator = idGenerator;
+
+    BaseMetalake[] baseMetalakes = listMetalakes();
+    for (BaseMetalake baseMetalake : baseMetalakes) {
+      loadMetalake(baseMetalake.nameIdentifier());
+    }
   }
 
   /**

--- a/core/src/main/java/org/apache/gravitino/metalake/MetalakeManager.java
+++ b/core/src/main/java/org/apache/gravitino/metalake/MetalakeManager.java
@@ -259,6 +259,7 @@ public class MetalakeManager implements MetalakeDispatcher, Closeable {
               throw new MetalakeNotInUseException(
                   "Metalake %s is not in use, please enable it first", ident);
             }
+
             return store.update(
                 ident,
                 BaseMetalake.class,

--- a/core/src/main/java/org/apache/gravitino/metalake/MetalakeManager.java
+++ b/core/src/main/java/org/apache/gravitino/metalake/MetalakeManager.java
@@ -20,12 +20,7 @@ package org.apache.gravitino.metalake;
 
 import static org.apache.gravitino.Metalake.PROPERTY_IN_USE;
 
-import com.github.benmanes.caffeine.cache.Cache;
-import com.github.benmanes.caffeine.cache.Caffeine;
-import com.github.benmanes.caffeine.cache.Scheduler;
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Maps;
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import java.io.Closeable;
 import java.io.IOException;
 import java.time.Instant;
@@ -33,8 +28,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ScheduledThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
 import org.apache.gravitino.Entity.EntityType;
 import org.apache.gravitino.EntityAlreadyExistsException;
 import org.apache.gravitino.EntityStore;
@@ -72,26 +65,9 @@ public class MetalakeManager implements MetalakeDispatcher, Closeable {
 
   private final IdGenerator idGenerator;
 
-  // Currently, there will be only one MetalakeManager instance in the system. In this case
-  // we can clear or close the cache when the instance is destroyed.
-  @VisibleForTesting
-  static final Cache<NameIdentifier, BaseMetalake> METALAKE_CACHE =
-      Caffeine.newBuilder()
-          .expireAfterAccess(24, TimeUnit.HOURS)
-          .removalListener((k, v, c) -> LOG.info("Closing metalake {}.", k))
-          .scheduler(
-              Scheduler.forScheduledExecutorService(
-                  new ScheduledThreadPoolExecutor(
-                      1,
-                      new ThreadFactoryBuilder()
-                          .setDaemon(true)
-                          .setNameFormat("metalake-cleaner-%d")
-                          .build())))
-          .build();
-
   @Override
   public void close() {
-    METALAKE_CACHE.invalidateAll();
+    // do nothing
   }
 
   /**
@@ -103,13 +79,6 @@ public class MetalakeManager implements MetalakeDispatcher, Closeable {
   public MetalakeManager(EntityStore store, IdGenerator idGenerator) {
     this.store = store;
     this.idGenerator = idGenerator;
-
-    // pre-load all metalakes and put them into cache, this is useful when user load schema/table
-    // directly without list/get metalake first.
-    BaseMetalake[] metalakes = listMetalakes();
-    for (BaseMetalake metalake : metalakes) {
-      METALAKE_CACHE.put(metalake.nameIdentifier(), metalake);
-    }
   }
 
   /**
@@ -140,10 +109,7 @@ public class MetalakeManager implements MetalakeDispatcher, Closeable {
   public static boolean metalakeInUse(EntityStore store, NameIdentifier ident)
       throws NoSuchMetalakeException {
     try {
-      BaseMetalake metalake = METALAKE_CACHE.getIfPresent(ident);
-      if (metalake == null) {
-        metalake = store.get(ident, EntityType.METALAKE, BaseMetalake.class);
-      }
+      BaseMetalake metalake = store.get(ident, EntityType.METALAKE, BaseMetalake.class);
       return (boolean)
           metalake.propertiesMetadata().getOrDefault(metalake.properties(), PROPERTY_IN_USE);
     } catch (NoSuchEntityException e) {
@@ -191,22 +157,18 @@ public class MetalakeManager implements MetalakeDispatcher, Closeable {
     return TreeLockUtils.doWithTreeLock(
         ident,
         LockType.READ,
-        () ->
-            METALAKE_CACHE.get(
-                ident,
-                k -> {
-                  try {
-                    BaseMetalake baseMetalake =
-                        store.get(ident, EntityType.METALAKE, BaseMetalake.class);
-                    return newMetalakeWithResolvedProperties(baseMetalake);
-                  } catch (NoSuchEntityException e) {
-                    LOG.warn("Metalake {} does not exist", ident, e);
-                    throw new NoSuchMetalakeException(METALAKE_DOES_NOT_EXIST_MSG, ident);
-                  } catch (IOException ioe) {
-                    LOG.error("Loading Metalake {} failed due to storage issues", ident, ioe);
-                    throw new RuntimeException(ioe);
-                  }
-                }));
+        () -> {
+          try {
+            BaseMetalake baseMetalake = store.get(ident, EntityType.METALAKE, BaseMetalake.class);
+            return newMetalakeWithResolvedProperties(baseMetalake);
+          } catch (NoSuchEntityException e) {
+            LOG.warn("Metalake {} does not exist", ident, e);
+            throw new NoSuchMetalakeException(METALAKE_DOES_NOT_EXIST_MSG, ident);
+          } catch (IOException ioe) {
+            LOG.error("Loading Metalake {} failed due to storage issues", ident, ioe);
+            throw new RuntimeException(ioe);
+          }
+        });
   }
 
   private BaseMetalake newMetalakeWithResolvedProperties(BaseMetalake metalakeEntity) {
@@ -266,7 +228,6 @@ public class MetalakeManager implements MetalakeDispatcher, Closeable {
         () -> {
           try {
             store.put(metalake, false /* overwritten */);
-            METALAKE_CACHE.put(ident, newMetalakeWithResolvedProperties(metalake));
             return metalake;
           } catch (EntityAlreadyExistsException | AlreadyExistsException e) {
             LOG.warn("Metalake {} already exists", ident, e);
@@ -298,25 +259,20 @@ public class MetalakeManager implements MetalakeDispatcher, Closeable {
               throw new MetalakeNotInUseException(
                   "Metalake %s is not in use, please enable it first", ident);
             }
-            METALAKE_CACHE.invalidate(ident);
-            BaseMetalake baseMetalake =
-                store.update(
-                    ident,
-                    BaseMetalake.class,
-                    EntityType.METALAKE,
-                    metalake -> {
-                      BaseMetalake.Builder builder = newMetalakeBuilder(metalake);
-                      Map<String, String> newProps =
-                          metalake.properties() == null
-                              ? Maps.newHashMap()
-                              : Maps.newHashMap(metalake.properties());
-                      builder = updateEntity(builder, newProps, changes);
+            return store.update(
+                ident,
+                BaseMetalake.class,
+                EntityType.METALAKE,
+                metalake -> {
+                  BaseMetalake.Builder builder = newMetalakeBuilder(metalake);
+                  Map<String, String> newProps =
+                      metalake.properties() == null
+                          ? Maps.newHashMap()
+                          : Maps.newHashMap(metalake.properties());
+                  builder = updateEntity(builder, newProps, changes);
 
-                      return builder.build();
-                    });
-            METALAKE_CACHE.put(
-                baseMetalake.nameIdentifier(), newMetalakeWithResolvedProperties(baseMetalake));
-            return baseMetalake;
+                  return builder.build();
+                });
           } catch (NoSuchEntityException ne) {
             LOG.warn("Metalake {} does not exist", ident, ne);
             throw new NoSuchMetalakeException(METALAKE_DOES_NOT_EXIST_MSG, ident);
@@ -353,8 +309,6 @@ public class MetalakeManager implements MetalakeDispatcher, Closeable {
                   "Metalake %s is in use, please disable it first or use force option", ident);
             }
 
-            METALAKE_CACHE.invalidate(ident);
-
             List<CatalogEntity> catalogEntities =
                 store.list(Namespace.of(ident.name()), CatalogEntity.class, EntityType.CATALOG);
             if (!catalogEntities.isEmpty() && !force) {
@@ -381,25 +335,22 @@ public class MetalakeManager implements MetalakeDispatcher, Closeable {
           try {
             boolean inUse = metalakeInUse(store, ident);
             if (!inUse) {
-              METALAKE_CACHE.invalidate(ident);
-              BaseMetalake baseMetalake =
-                  store.update(
-                      ident,
-                      BaseMetalake.class,
-                      EntityType.METALAKE,
-                      metalake -> {
-                        BaseMetalake.Builder builder = newMetalakeBuilder(metalake);
+              store.update(
+                  ident,
+                  BaseMetalake.class,
+                  EntityType.METALAKE,
+                  metalake -> {
+                    BaseMetalake.Builder builder = newMetalakeBuilder(metalake);
 
-                        Map<String, String> newProps =
-                            metalake.properties() == null
-                                ? Maps.newHashMap()
-                                : Maps.newHashMap(metalake.properties());
-                        newProps.put(PROPERTY_IN_USE, "true");
-                        builder.withProperties(newProps);
+                    Map<String, String> newProps =
+                        metalake.properties() == null
+                            ? Maps.newHashMap()
+                            : Maps.newHashMap(metalake.properties());
+                    newProps.put(PROPERTY_IN_USE, "true");
+                    builder.withProperties(newProps);
 
-                        return builder.build();
-                      });
-              METALAKE_CACHE.put(ident, newMetalakeWithResolvedProperties(baseMetalake));
+                    return builder.build();
+                  });
             }
 
             return null;
@@ -418,25 +369,22 @@ public class MetalakeManager implements MetalakeDispatcher, Closeable {
           try {
             boolean inUse = metalakeInUse(store, ident);
             if (inUse) {
-              METALAKE_CACHE.invalidate(ident);
-              BaseMetalake baseMetalake =
-                  store.update(
-                      ident,
-                      BaseMetalake.class,
-                      EntityType.METALAKE,
-                      metalake -> {
-                        BaseMetalake.Builder builder = newMetalakeBuilder(metalake);
+              store.update(
+                  ident,
+                  BaseMetalake.class,
+                  EntityType.METALAKE,
+                  metalake -> {
+                    BaseMetalake.Builder builder = newMetalakeBuilder(metalake);
 
-                        Map<String, String> newProps =
-                            metalake.properties() == null
-                                ? Maps.newHashMap()
-                                : Maps.newHashMap(metalake.properties());
-                        newProps.put(PROPERTY_IN_USE, "false");
-                        builder.withProperties(newProps);
+                    Map<String, String> newProps =
+                        metalake.properties() == null
+                            ? Maps.newHashMap()
+                            : Maps.newHashMap(metalake.properties());
+                    newProps.put(PROPERTY_IN_USE, "false");
+                    builder.withProperties(newProps);
 
-                        return builder.build();
-                      });
-              METALAKE_CACHE.put(ident, newMetalakeWithResolvedProperties(baseMetalake));
+                    return builder.build();
+                  });
             }
             return null;
           } catch (IOException e) {

--- a/core/src/main/java/org/apache/gravitino/metalake/MetalakeManager.java
+++ b/core/src/main/java/org/apache/gravitino/metalake/MetalakeManager.java
@@ -80,6 +80,8 @@ public class MetalakeManager implements MetalakeDispatcher, Closeable {
     this.store = store;
     this.idGenerator = idGenerator;
 
+    // preload all metalakes and put them into cache, this is useful when user load schema/table
+    // directly without list/get metalake first.
     BaseMetalake[] baseMetalakes = listMetalakes();
     for (BaseMetalake baseMetalake : baseMetalakes) {
       loadMetalake(baseMetalake.nameIdentifier());

--- a/core/src/test/java/org/apache/gravitino/metalake/TestMetalakeManager.java
+++ b/core/src/test/java/org/apache/gravitino/metalake/TestMetalakeManager.java
@@ -23,7 +23,6 @@ import static org.apache.gravitino.Configs.TREE_LOCK_MAX_NODE_IN_MEMORY;
 import static org.apache.gravitino.Configs.TREE_LOCK_MIN_NODE_IN_MEMORY;
 import static org.mockito.Mockito.doReturn;
 
-import com.github.benmanes.caffeine.cache.Cache;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
 import java.io.IOException;
@@ -208,65 +207,6 @@ public class TestMetalakeManager {
     NameIdentifier ident1 = NameIdentifier.of("test42");
     boolean dropped1 = metalakeManager.dropMetalake(ident1);
     Assertions.assertFalse(dropped1, "metalake should be non-existent");
-  }
-
-  @Test
-  public void testMetalakeCache() {
-    NameIdentifier ident = NameIdentifier.of("test51");
-    Map<String, String> props = ImmutableMap.of("key1", "value1");
-    BaseMetalake metalake = metalakeManager.createMetalake(ident, "comment", props);
-    Assertions.assertEquals("test51", metalake.name());
-    Assertions.assertEquals("comment", metalake.comment());
-
-    Cache<NameIdentifier, BaseMetalake> cache = MetalakeManager.METALAKE_CACHE;
-
-    BaseMetalake baseMetalake = cache.getIfPresent(ident);
-    Assertions.assertNotNull(baseMetalake);
-    Assertions.assertEquals("test51", baseMetalake.name());
-    Assertions.assertEquals("comment", baseMetalake.comment());
-
-    metalakeManager.disableMetalake(ident);
-    baseMetalake = cache.getIfPresent(ident);
-    Assertions.assertNotNull(baseMetalake);
-    metalakeManager.dropMetalake(ident);
-    baseMetalake = cache.getIfPresent(ident);
-    Assertions.assertNull(baseMetalake);
-
-    metalakeManager.createMetalake(ident, "comment", props);
-    baseMetalake = cache.getIfPresent(ident);
-    Assertions.assertNotNull(baseMetalake);
-
-    metalakeManager.disableMetalake(ident);
-    metalakeManager.dropMetalake(ident);
-    baseMetalake = cache.getIfPresent(ident);
-    Assertions.assertNull(baseMetalake);
-
-    metalakeManager.createMetalake(ident, "comment", props);
-    baseMetalake = cache.getIfPresent(ident);
-    Assertions.assertNotNull(baseMetalake);
-    metalakeManager.disableMetalake(ident);
-    metalakeManager.dropMetalake(ident);
-    baseMetalake = cache.getIfPresent(ident);
-    Assertions.assertNull(baseMetalake);
-
-    metalakeManager.createMetalake(ident, "comment", props);
-    baseMetalake = cache.getIfPresent(ident);
-    Assertions.assertNotNull(baseMetalake);
-    metalakeManager.disableMetalake(ident);
-    baseMetalake = cache.getIfPresent(ident);
-    Assertions.assertNotNull(baseMetalake);
-    Assertions.assertEquals("false", baseMetalake.properties().get("in-use"));
-    metalakeManager.enableMetalake(ident);
-    baseMetalake = cache.getIfPresent(ident);
-    Assertions.assertNotNull(baseMetalake);
-    Assertions.assertEquals("true", baseMetalake.properties().get("in-use"));
-
-    metalakeManager.loadMetalake(ident);
-    baseMetalake = cache.getIfPresent(ident);
-    Assertions.assertNotNull(baseMetalake);
-    metalakeManager.disableMetalake(ident);
-    baseMetalake = cache.getIfPresent(ident);
-    Assertions.assertNotNull(baseMetalake);
   }
 
   private void testProperties(Map<String, String> expectedProps, Map<String, String> testProps) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Remove old cached System.

To unify the caching architecture, we should remove legacy cache modules that directly proxy the underlying EntityStore, especially those that simply cache raw entity results. For example:

- `MetalakeManager`: its cache is a direct wrapper around EntityStore.
- `FilesetCatalogOperations`: its caching logic is also a shallow reuse of the underlying store.

In contrast, cache modules whose content is not directly sourced from the EntityStore, and which provide additional encapsulation or are relied on by external systems, should be preserved. For example:

- `CatalogManager`: it caches CatalogWrapper objects instead of raw Entity instances, and is externally depended upon.

In summary, the cache cleanup strategy should be based on two principles:
- Whether the cache directly proxies the EntityStore.
- Whether it is externally depended upon or involves semantic wrapping.

This helps clearly distinguish between caches that should be removed and those that should be retained.

### Why are the changes needed?

Fix: #7179 

### Does this PR introduce _any_ user-facing change?

no.

### How was this patch tested?

local test.
