### PR TITLE
[#7465] build(core): Fix Gravitino core jcstress jar should not be in libs folder

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -819,11 +819,7 @@ tasks {
         it.name != "trino-connector" &&
         it.parent?.name != "bundles"
       ) {
-        from(
-          project.files(it.configurations.runtimeClasspath).filter { file ->
-            !file.name.contains("jcstress", ignoreCase = true)
-          }
-        )
+        from(it.configurations.runtimeClasspath)
         into("distribution/package/libs")
       }
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -819,7 +819,11 @@ tasks {
         it.name != "trino-connector" &&
         it.parent?.name != "bundles"
       ) {
-        from(it.configurations.runtimeClasspath)
+        from(
+          project.files(it.configurations.runtimeClasspath).filter { file ->
+            !file.name.contains("jcstress", ignoreCase = true)
+          }
+        )
         into("distribution/package/libs")
       }
     }
@@ -851,9 +855,11 @@ tasks {
         it.parent?.name != "bundles"
       ) {
         dependsOn("${it.name}:build")
-        from("${it.name}/build/libs")
+        from("${it.name}/build/libs") {
+          include("*.jar")
+          exclude("*-jcstress.jar")
+        }
         into("distribution/package/libs")
-        include("*.jar")
         setDuplicatesStrategy(DuplicatesStrategy.INCLUDE)
       }
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This change ensures that jcstress test artifacts (e.g., `*-jcstress.jar`) are no longer included in the libs folder after running `./gradlew compileDistribution`. 

![image](https://github.com/user-attachments/assets/a6303021-d693-4a0e-ad02-04d647bc358a)

### Why are the changes needed?

Fix: #7465 

### Does this PR introduce _any_ user-facing change?

no

### How was this patch tested?

local test.
