### PR TITLE
[#7456] feat(client-java): Support custom http client config for gravitino client

### DIFF
--- a/clients/client-java/src/main/java/org/apache/gravitino/client/GravitinoAdminClient.java
+++ b/clients/client-java/src/main/java/org/apache/gravitino/client/GravitinoAdminClient.java
@@ -57,13 +57,15 @@ public class GravitinoAdminClient extends GravitinoClientBase implements Support
    * @param checkVersion Whether to check the version of the Gravitino server. Gravitino does not
    *     support the case that the client-side version is higher than the server-side version.
    * @param headers The base header for Gravitino API.
+   * @param properties A map of properties (key-value pairs) used to configure the Gravitino client.
    */
   private GravitinoAdminClient(
       String uri,
       AuthDataProvider authDataProvider,
       boolean checkVersion,
-      Map<String, String> headers) {
-    super(uri, authDataProvider, checkVersion, headers);
+      Map<String, String> headers,
+      Map<String, String> properties) {
+    super(uri, authDataProvider, checkVersion, headers, properties);
   }
 
   /**
@@ -256,7 +258,7 @@ public class GravitinoAdminClient extends GravitinoClientBase implements Support
     public GravitinoAdminClient build() {
       Preconditions.checkArgument(
           uri != null && !uri.isEmpty(), "The argument 'uri' must be a valid URI");
-      return new GravitinoAdminClient(uri, authDataProvider, checkVersion, headers);
+      return new GravitinoAdminClient(uri, authDataProvider, checkVersion, headers, properties);
     }
   }
 }

--- a/clients/client-java/src/main/java/org/apache/gravitino/client/GravitinoClient.java
+++ b/clients/client-java/src/main/java/org/apache/gravitino/client/GravitinoClient.java
@@ -78,6 +78,7 @@ public class GravitinoClient extends GravitinoClientBase
    * @param checkVersion Whether to check the version of the Gravitino server. Gravitino does not
    *     support the case that the client-side version is higher than the server-side version.
    * @param headers The base header for Gravitino API.
+   * @param properties A map of properties (key-value pairs) used to configure the Gravitino client.
    * @throws NoSuchMetalakeException if the metalake with specified name does not exist.
    */
   private GravitinoClient(
@@ -85,8 +86,9 @@ public class GravitinoClient extends GravitinoClientBase
       String metalakeName,
       AuthDataProvider authDataProvider,
       boolean checkVersion,
-      Map<String, String> headers) {
-    super(uri, authDataProvider, checkVersion, headers);
+      Map<String, String> headers,
+      Map<String, String> properties) {
+    super(uri, authDataProvider, checkVersion, headers, properties);
     this.metalake = loadMetalake(metalakeName);
   }
 
@@ -599,7 +601,8 @@ public class GravitinoClient extends GravitinoClientBase
           metalakeName != null && !metalakeName.isEmpty(),
           "The argument 'metalakeName' must be a valid name");
 
-      return new GravitinoClient(uri, metalakeName, authDataProvider, checkVersion, headers);
+      return new GravitinoClient(
+          uri, metalakeName, authDataProvider, checkVersion, headers, properties);
     }
   }
 }

--- a/clients/client-java/src/main/java/org/apache/gravitino/client/GravitinoClientBase.java
+++ b/clients/client-java/src/main/java/org/apache/gravitino/client/GravitinoClientBase.java
@@ -61,17 +61,19 @@ public abstract class GravitinoClientBase implements Closeable {
    * @param authDataProvider The provider of the data which is used for authentication.
    * @param checkVersion Whether to check the version of the Gravitino server.
    * @param headers The base header of the Gravitino API.
+   * @param properties A map of properties (key-value pairs) used to configure the Gravitino client.
    */
   protected GravitinoClientBase(
       String uri,
       AuthDataProvider authDataProvider,
       boolean checkVersion,
-      Map<String, String> headers) {
+      Map<String, String> headers,
+      Map<String, String> properties) {
     ObjectMapper mapper = ObjectMapperProvider.objectMapper();
 
     if (checkVersion) {
       this.restClient =
-          HTTPClient.builder(Collections.emptyMap())
+          HTTPClient.builder(properties)
               .uri(uri)
               .withAuthDataProvider(authDataProvider)
               .withObjectMapper(mapper)
@@ -81,7 +83,7 @@ public abstract class GravitinoClientBase implements Closeable {
 
     } else {
       this.restClient =
-          HTTPClient.builder(Collections.emptyMap())
+          HTTPClient.builder(properties)
               .uri(uri)
               .withAuthDataProvider(authDataProvider)
               .withObjectMapper(mapper)
@@ -208,6 +210,8 @@ public abstract class GravitinoClientBase implements Closeable {
     protected boolean checkVersion = true;
     /** The request base header for the Gravitino API. */
     protected Map<String, String> headers = ImmutableMap.of();
+    /** A map of properties (key-value pairs) used to configure the Gravitino client. */
+    protected Map<String, String> properties = ImmutableMap.of();
 
     /**
      * The constructor for the Builder class.
@@ -302,6 +306,20 @@ public abstract class GravitinoClientBase implements Closeable {
     public Builder<T> withHeaders(Map<String, String> headers) {
       if (headers != null) {
         this.headers = ImmutableMap.copyOf(headers);
+      }
+      return this;
+    }
+
+    /**
+     * Set base client config for Gravitino Client.
+     *
+     * @param properties A map of properties (key-value pairs) used to configure the Gravitino
+     *     client.
+     * @return This Builder instance for method chaining.
+     */
+    public Builder<T> withClientConfig(Map<String, String> properties) {
+      if (properties != null) {
+        this.properties = ImmutableMap.copyOf(properties);
       }
       return this;
     }

--- a/clients/client-java/src/main/java/org/apache/gravitino/client/GravitinoClientConfiguration.java
+++ b/clients/client-java/src/main/java/org/apache/gravitino/client/GravitinoClientConfiguration.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.client;
+
+import com.google.common.collect.ImmutableSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import org.apache.gravitino.utils.MapUtils;
+
+/** Configuration class for Gravitino Java client */
+public class GravitinoClientConfiguration {
+  /** The value of messages used to indicate that the configuration should be a positive number. */
+  public static final String POSITIVE_NUMBER_ERROR_MSG = "The value must be a positive number";
+  /** The configuration key prefix for the Gravitino client config. */
+  public static final String GRAVITINO_CLIENT_CONFIG_PREFIX = "gravitino.client.";
+
+  /** A default value for http connection timeout in milliseconds. */
+  public static final long CLIENT_CONNECTION_TIMEOUT_MS_DEFAULT = 180_000L;
+
+  /** A default value for http socket timeout in milliseconds. */
+  public static final int CLIENT_SOCKET_TIMEOUT_MS_DEFAULT = 180_000;
+
+  /** An optional http connection timeout in milliseconds. */
+  public static final String CLIENT_CONNECTION_TIMEOUT_MS = "gravitino.client.connectionTimeoutMs";
+
+  /** An optional http socket timeout in milliseconds. */
+  public static final String CLIENT_SOCKET_TIMEOUT_MS = "gravitino.client.socketTimeoutMs";
+
+  private static final Set<String> SUPPORT_CLIENT_CONFIG_KEYS =
+      ImmutableSet.of(CLIENT_CONNECTION_TIMEOUT_MS, CLIENT_SOCKET_TIMEOUT_MS);
+
+  private Map<String, String> properties;
+
+  private GravitinoClientConfiguration(Map<String, String> properties) {
+    this.properties = properties;
+  }
+
+  /**
+   * Build GravitinoClientConfiguration from properties.
+   *
+   * @param properties The properties object containing configuration key-value pairs.
+   * @return GravitinoClientConfiguration instance
+   */
+  public static GravitinoClientConfiguration buildFromProperties(Map<String, String> properties) {
+    for (String key : properties.keySet()) {
+      if (!SUPPORT_CLIENT_CONFIG_KEYS.contains(key)) {
+        throw new IllegalArgumentException(String.format("Invalid property for client: %s", key));
+      }
+    }
+    return new GravitinoClientConfiguration(properties);
+  }
+
+  /**
+   * Extract connection timeout from the properties map
+   *
+   * @return connection timeout
+   */
+  public long getClientConnectionTimeoutMs() {
+    long connectionTimeoutMillis =
+        MapUtils.propertyAsLong(
+            properties, CLIENT_CONNECTION_TIMEOUT_MS, CLIENT_CONNECTION_TIMEOUT_MS_DEFAULT);
+    checkValue(
+        value -> value >= 0,
+        CLIENT_CONNECTION_TIMEOUT_MS,
+        connectionTimeoutMillis,
+        POSITIVE_NUMBER_ERROR_MSG);
+    return connectionTimeoutMillis;
+  }
+
+  /**
+   * Extract socket timeout from the properties map
+   *
+   * @return socket timeout
+   */
+  public int getClientSocketTimeoutMs() {
+    int socketTimeoutMillis =
+        MapUtils.propertyAsInt(
+            properties, CLIENT_SOCKET_TIMEOUT_MS, CLIENT_SOCKET_TIMEOUT_MS_DEFAULT);
+    checkValue(
+        value -> value >= 0,
+        CLIENT_SOCKET_TIMEOUT_MS,
+        socketTimeoutMillis,
+        POSITIVE_NUMBER_ERROR_MSG);
+    return socketTimeoutMillis;
+  }
+
+  private static <T> void checkValue(
+      Function<T, Boolean> checkValueFunc, String key, T value, String errorMsg) {
+    if (!checkValueFunc.apply(value)) {
+      throw new IllegalArgumentException(
+          String.format("%s in %s is invalid. %s", value, key, errorMsg));
+    }
+  }
+}

--- a/clients/client-java/src/test/java/org/apache/gravitino/client/TestGravitinoClientBuilder.java
+++ b/clients/client-java/src/test/java/org/apache/gravitino/client/TestGravitinoClientBuilder.java
@@ -58,6 +58,26 @@ public class TestGravitinoClientBuilder {
           new SimpleTokenProvider().getTokenData(), client.getAuthDataProvider().getTokenData());
     }
   }
+
+  @Test
+  public void testGravitinoClientProperties() {
+    Map<String, String> properties =
+        ImmutableMap.of(
+            "gravitino.client.connectionTimeoutMs", "10", "gravitino.client.socketTimeoutMs", "10");
+    try (MockGravitinoClient client =
+        MockGravitinoClient.builder("http://127.0.0.1").withClientConfig(properties).build()) {
+      Assertions.assertEquals(properties, client.getProperties());
+    }
+
+    try (MockGravitinoClient client = MockGravitinoClient.builder("http://127.0.0.1").build()) {
+      Assertions.assertEquals(ImmutableMap.of(), client.getProperties());
+    }
+
+    try (MockGravitinoClient client =
+        MockGravitinoClient.builder("http://127.0.0.1").withClientConfig(null).build()) {
+      Assertions.assertEquals(ImmutableMap.of(), client.getProperties());
+    }
+  }
 }
 
 class MockGravitinoClient extends GravitinoClientBase {
@@ -66,18 +86,25 @@ class MockGravitinoClient extends GravitinoClientBase {
 
   private AuthDataProvider authDataProvider;
 
+  private Map<String, String> properties;
+
   /**
    * Constructs a new GravitinoClient with the given URI, authenticator and AuthDataProvider.
    *
    * @param uri The base URI for the Gravitino API.
    * @param authDataProvider The provider of the data which is used for authentication.
    * @param headers The base header of the Gravitino API.
+   * @param properties A map of properties (key-value pairs) used to configure the HTTP client.
    */
   private MockGravitinoClient(
-      String uri, AuthDataProvider authDataProvider, Map<String, String> headers) {
-    super(uri, authDataProvider, false, headers);
+      String uri,
+      AuthDataProvider authDataProvider,
+      Map<String, String> headers,
+      Map<String, String> properties) {
+    super(uri, authDataProvider, false, headers, properties);
     this.headers = headers;
     this.authDataProvider = authDataProvider;
+    this.properties = properties;
   }
 
   Map<String, String> getHeaders() {
@@ -86,6 +113,10 @@ class MockGravitinoClient extends GravitinoClientBase {
 
   AuthDataProvider getAuthDataProvider() {
     return authDataProvider;
+  }
+
+  Map<String, String> getProperties() {
+    return properties;
   }
 
   /**
@@ -111,7 +142,7 @@ class MockGravitinoClient extends GravitinoClientBase {
 
     @Override
     public MockGravitinoClient build() {
-      return new MockGravitinoClient(uri, authDataProvider, headers);
+      return new MockGravitinoClient(uri, authDataProvider, headers, properties);
     }
   }
 }

--- a/clients/client-java/src/test/java/org/apache/gravitino/client/TestGravitinoClientConfiguration.java
+++ b/clients/client-java/src/test/java/org/apache/gravitino/client/TestGravitinoClientConfiguration.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.client;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TestGravitinoClientConfiguration {
+  @Test
+  void testValidConfig() {
+    Map<String, String> properties =
+        ImmutableMap.of(
+            "gravitino.client.connectionTimeoutMs", String.valueOf(20),
+            "gravitino.client.socketTimeoutMs", String.valueOf(10));
+    GravitinoClientConfiguration clientConfiguration =
+        GravitinoClientConfiguration.buildFromProperties(properties);
+    Assertions.assertEquals(clientConfiguration.getClientConnectionTimeoutMs(), 20L);
+    Assertions.assertEquals(clientConfiguration.getClientSocketTimeoutMs(), 10);
+  }
+
+  @Test
+  void testInValidConfig() {
+
+    Map<String, String> properties =
+        ImmutableMap.of(
+            "gravitino.client.xxxx", String.valueOf(10),
+            "gravitino.client.socketTimeoutMs", String.valueOf(20));
+    Throwable throwable =
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () -> GravitinoClientConfiguration.buildFromProperties(properties));
+    Assertions.assertEquals(
+        "Invalid property for client: gravitino.client.xxxx", throwable.getMessage());
+  }
+}

--- a/clients/client-java/src/test/java/org/apache/gravitino/client/TestHTTPClient.java
+++ b/clients/client-java/src/test/java/org/apache/gravitino/client/TestHTTPClient.java
@@ -32,14 +32,18 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
+import java.net.SocketTimeoutException;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import org.apache.gravitino.dto.responses.ErrorResponse;
 import org.apache.gravitino.exceptions.NotFoundException;
+import org.apache.gravitino.exceptions.RESTException;
 import org.apache.gravitino.rest.RESTRequest;
 import org.apache.gravitino.rest.RESTResponse;
+import org.apache.hc.client5.http.config.ConnectionConfig;
 import org.apache.hc.core5.http.Method;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
@@ -141,6 +145,115 @@ public class TestHTTPClient {
 
     Assertions.assertEquals(body, response);
     verify(onError, never()).accept(any());
+  }
+
+  @Test
+  public void testSocketAndConnectionTimeoutSet() {
+    // test default value
+    ConnectionConfig connectionConfigWithDefault =
+        HTTPClient.configureConnectionConfig(
+            GravitinoClientConfiguration.buildFromProperties(ImmutableMap.of()));
+    Assertions.assertNotNull(connectionConfigWithDefault);
+    Assertions.assertEquals(
+        connectionConfigWithDefault.getConnectTimeout().getDuration(),
+        GravitinoClientConfiguration.CLIENT_CONNECTION_TIMEOUT_MS_DEFAULT);
+    Assertions.assertEquals(
+        connectionConfigWithDefault.getSocketTimeout().getDuration(),
+        GravitinoClientConfiguration.CLIENT_SOCKET_TIMEOUT_MS_DEFAULT);
+
+    // test custom value
+    long connectionTimeoutMs = 10L;
+    int socketTimeoutMs = 10;
+    Map<String, String> properties =
+        ImmutableMap.of(
+            "gravitino.client.connectionTimeoutMs", String.valueOf(connectionTimeoutMs),
+            "gravitino.client.socketTimeoutMs", String.valueOf(socketTimeoutMs));
+
+    ConnectionConfig connectionConfig =
+        HTTPClient.configureConnectionConfig(
+            GravitinoClientConfiguration.buildFromProperties(properties));
+    Assertions.assertNotNull(connectionConfig);
+    Assertions.assertEquals(
+        connectionConfig.getConnectTimeout().getDuration(), connectionTimeoutMs);
+    Assertions.assertEquals(connectionConfig.getSocketTimeout().getDuration(), socketTimeoutMs);
+
+    // test invalid value
+    Map<String, String> propertiesWithInvalidConnectionTimeoutMs =
+        ImmutableMap.of("gravitino.client.connectionTimeoutMs", "-1");
+    try {
+      HTTPClient.configureConnectionConfig(
+          GravitinoClientConfiguration.buildFromProperties(
+              propertiesWithInvalidConnectionTimeoutMs));
+    } catch (IllegalArgumentException e) {
+      Assertions.assertEquals(
+          "-1 in gravitino.client.connectionTimeoutMs is invalid. The value must be a positive number",
+          e.getMessage());
+    }
+
+    Map<String, String> propertiesWithInvalidSocketTimeoutMs =
+        ImmutableMap.of("gravitino.client.socketTimeoutMs", "aaaa");
+    try {
+      HTTPClient.configureConnectionConfig(
+          GravitinoClientConfiguration.buildFromProperties(propertiesWithInvalidSocketTimeoutMs));
+    } catch (IllegalArgumentException e) {
+      Assertions.assertEquals(
+          "aaaa in gravitino.client.socketTimeoutMs is invalid. The value must be an integer number",
+          e.getMessage());
+    }
+  }
+
+  @Test
+  public void testConnectionTimeout() throws IOException {
+    String path = "test_connection_timeout";
+    long connectionTimeoutMs = 2000;
+    Map<String, String> properties =
+        ImmutableMap.of(
+            "gravitino.client.connectionTimeoutMs", String.valueOf(connectionTimeoutMs));
+    // use error server port to simulate hitting the configured connection timeout of 2 seconds
+    try (HTTPClient client =
+        HTTPClient.builder(properties)
+            .uri(String.format("http://127.0.0.1:%d", mockServer.getPort() + 1))
+            .build()) {
+      HttpRequest mockRequest =
+          request().withPath("/" + path).withMethod(Method.HEAD.name().toUpperCase(Locale.ROOT));
+      HttpResponse mockResponse = response().withStatusCode(200);
+      mockServer.when(mockRequest).respond(mockResponse);
+
+      long start = System.currentTimeMillis();
+      Assertions.assertThrows(
+          RESTException.class, () -> client.head(path, ImmutableMap.of(), response -> {}));
+      long end = System.currentTimeMillis();
+      Assertions.assertTrue((end - start) < 5000);
+    }
+  }
+
+  @Test
+  public void testSocketTimeout() throws IOException {
+    String path = "test_socket_timeout";
+    long socketTimeoutMs = 2000;
+    Map<String, String> properties =
+        ImmutableMap.of("gravitino.client.socketTimeoutMs", String.valueOf(socketTimeoutMs));
+    try (HTTPClient client =
+        HTTPClient.builder(properties)
+            .uri(String.format("http://127.0.0.1:%d", mockServer.getPort()))
+            .build()) {
+      HttpRequest mockRequest =
+          request().withPath("/" + path).withMethod(Method.HEAD.name().toUpperCase(Locale.ROOT));
+      // Setting a response delay of 5 seconds to simulate hitting the configured socket timeout of
+      // 2 seconds
+      HttpResponse mockResponse =
+          response()
+              .withStatusCode(200)
+              .withBody("Delayed response")
+              .withDelay(TimeUnit.MILLISECONDS, 5000);
+      mockServer.when(mockRequest).respond(mockResponse);
+
+      Throwable throwable =
+          Assertions.assertThrows(
+              RESTException.class, () -> client.head(path, ImmutableMap.of(), response -> {}));
+      Assertions.assertInstanceOf(SocketTimeoutException.class, throwable.getCause());
+      Assertions.assertEquals("Read timed out", throwable.getCause().getMessage());
+    }
   }
 
   public static void testHttpMethodOnSuccess(

--- a/common/src/main/java/org/apache/gravitino/utils/MapUtils.java
+++ b/common/src/main/java/org/apache/gravitino/utils/MapUtils.java
@@ -76,4 +76,52 @@ public class MapUtils {
   public static Map<String, String> unmodifiableMap(Map<String, String> m) {
     return Collections.unmodifiableMap(m);
   }
+
+  /**
+   * Extract an integer value from the properties map with provided key. If provided key not exist
+   * in the properties map, it will return default value.
+   *
+   * @param properties input map
+   * @param property provided key
+   * @param defaultValue default value
+   * @return integer value from the properties map with provided key.
+   */
+  public static int propertyAsInt(
+      Map<String, String> properties, String property, int defaultValue) {
+    String value = properties.get(property);
+    if (value != null) {
+      try {
+        return Integer.parseInt(value);
+      } catch (NumberFormatException e) {
+        throw new IllegalArgumentException(
+            String.format(
+                "%s in %s is invalid. %s", value, property, "The value must be an integer number"));
+      }
+    }
+    return defaultValue;
+  }
+
+  /**
+   * Extract a long value from the properties map with provided key. If provided key not exist in
+   * the properties map, it will return default value.
+   *
+   * @param properties input map
+   * @param property provided key
+   * @param defaultValue default value
+   * @return long value from the properties map with provided key.
+   */
+  public static long propertyAsLong(
+      Map<String, String> properties, String property, long defaultValue) {
+    String value = properties.get(property);
+    if (value != null) {
+      try {
+        return Long.parseLong(value);
+      } catch (NumberFormatException e) {
+        throw new IllegalArgumentException(
+            String.format(
+                "%s in %s is invalid. %s", value, property, "The value must be a long number"));
+      }
+    }
+    return defaultValue;
+  }
 }

--- a/docs/how-to-use-java-client.md
+++ b/docs/how-to-use-java-client.md
@@ -1,0 +1,45 @@
+---
+title: "How to use Apache Gravitino Java client"
+slug: /how-to-use-gravitino-java-client
+date: 2025-07-09
+keyword: Gravitino Java client
+license: This software is licensed under the Apache License version 2.
+---
+
+## Introduction
+
+You can use Gravitino Java client library with Spark, Spring and other Java environment.
+
+First of all, you must have a Gravitino server set up and run, you can refer document of 
+[how to install Gravitino](./how-to-install.md) to build Gravitino server from source code and 
+install it in your local.
+
+## Gravitino Java client configurations
+
+You can customize the Gravitino Java client by using `withClientConfig`. 
+```java
+ Map<String, String> properties =
+        ImmutableMap.of(
+            "gravitino.client.connectionTimeoutMs", "10", 
+            "gravitino.client.socketTimeoutMs", "10"
+        );
+
+GravitinoClient gravitinoClient = GravitinoClient.builder("http://localhost:8090")
+.withMetalake("metalake")
+.withClientConfig(properties) // add custom client config (optional)
+.builder();
+
+GravitinoAdminClient gravitinoAdminClient = GravitinoAdminClient.builder("http://localhost:8090")
+.withClientConfig(properties) // add custom client config (optional)
+.builder();
+// ...
+```
+
+### Gravitino Java client configuration
+
+| Configuration item                     | Description                                          | Default value       | Required | Since version |
+|----------------------------------------|------------------------------------------------------|---------------------|----------|---------------|
+| `gravitino.client.connectionTimeoutMs` | An optional http connection timeout in milliseconds. | `180000`(3 minutes) | No       | 1.0.0         |
+| `gravitino.client.socketTimeoutMs`     | An optional http socket timeout in milliseconds.     | `180000`(3 minutes) | No       | 1.0.0         |
+
+**Note:** Invalid configuration properties will result in exceptions. 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Support pass custom http client config when using the Java Gravitino Client. 

### Why are the changes needed?

- We can config connectionTimeout or socketTimeout and so on.

Fix: #7456

### Does this PR introduce _any_ user-facing change?

- support http client config

|config      | default | Description |
| ----------- |----------- |----------- |
|gravitino.client.connectionTimeoutMs | null  | An optional http connection timeout in milliseconds|
|gravitino.client.socketTimeoutMs | null | An optional http socket timeout in milliseconds |

- add `withClientConfig` in `org.apache.gravitino.client.GravitinoClientBase.Builder`
```
 Map<String, String> properties =
        ImmutableMap.of(
            "gravitino.client.connectionTimeoutMs", "10", 
            "gravitino.client.socketTimeoutMs", "10"
        );
            
GravitinoClient.builder("uri")
.withMetalake("metalake")
.withClientConfig(properties) // add custom client config (optional)
.builder(); 

GravitinoAdminClient.builder("uri")
.withClientConfig(properties) // add custom client config (optional)
.builder();            
```

### How was this patch tested?
original Uts
