### PR TITLE
[#7466] add testListMetadataObjectsForTagFailureEvent to TestTagEvent

### DIFF
--- a/core/src/test/java/org/apache/gravitino/listener/api/event/TestTagEvent.java
+++ b/core/src/test/java/org/apache/gravitino/listener/api/event/TestTagEvent.java
@@ -469,6 +469,20 @@ public class TestTagEvent {
   }
 
   @Test
+  void testListMetadataObjectsForTagFailureEvent() {
+    Assertions.assertThrowsExactly(
+        GravitinoRuntimeException.class,
+        () -> failureDispatcher.listMetadataObjectsForTag("metalake", tag.name()));
+    Event event = dummyEventListener.popPostEvent();
+    Assertions.assertEquals(ListMetadataObjectsForTagFailureEvent.class, event.getClass());
+    Assertions.assertEquals(
+        GravitinoRuntimeException.class,
+        ((ListMetadataObjectsForTagFailureEvent) event).exception().getClass());
+    Assertions.assertEquals(OperationType.LIST_METADATA_OBJECTS_FOR_TAG, event.operationType());
+    Assertions.assertEquals(OperationStatus.FAILURE, event.operationStatus());
+  }
+
+  @Test
   void testAssociateTagsForMetadataObjectFailureEvent() {
     MetadataObject metadataObject =
         NameIdentifierUtil.toMetadataObject(


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Add `testListMetadataObjectsForTagFailureEvent` to `TestTagEvent`.

### Why are the changes needed?

Missing failure event test for `listMetadataObjectsForTag`.
Fix: #7466

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Unit test added.
