### PR TITLE
[#5202] refactor(client-python): fix builder method of ColumnDTO

### DIFF
--- a/clients/client-python/gravitino/dto/rel/column_dto.py
+++ b/clients/client-python/gravitino/dto/rel/column_dto.py
@@ -107,30 +107,9 @@ class ColumnDTO(Column, DataClassJsonMixin):
             f"Column cannot be non-nullable with a null default value: {self._name}.",
         )
 
-    @classmethod
-    def builder(
-        cls,
-        name: str,
-        data_type: Type,
-        comment: str,
-        nullable: bool = True,
-        auto_increment: bool = False,
-        default_value: Optional[Expression] = None,
-    ) -> ColumnDTO:
-        Precondition.check_argument(name is not None, "Column name cannot be null")
-        Precondition.check_argument(
-            data_type is not None, "Column data type cannot be null"
-        )
-        return ColumnDTO(
-            _name=name,
-            _data_type=data_type,
-            _comment=comment,
-            _nullable=nullable,
-            _auto_increment=auto_increment,
-            _default_value=(
-                Column.DEFAULT_VALUE_NOT_SET if default_value is None else default_value
-            ),
-        )
+    @staticmethod
+    def builder() -> ColumnDTO.Builder:
+        return ColumnDTO.Builder()
 
     def __eq__(self, other: ColumnDTO) -> bool:
         if not isinstance(other, ColumnDTO):

--- a/clients/client-python/gravitino/dto/rel/column_dto.py
+++ b/clients/client-python/gravitino/dto/rel/column_dto.py
@@ -159,3 +159,112 @@ class ColumnDTO(Column, DataClassJsonMixin):
                 ),
             )
         )
+
+    class Builder:
+        def __init__(self) -> None:
+            self._name = None
+            self._data_type = None
+            self._comment = None
+            self._nullable: bool = True
+            self._auto_increment: bool = False
+            self._default_value = None
+
+        def with_name(self, name: str) -> ColumnDTO.Builder:
+            """Sets the name of the column.
+
+            Args:
+                name (str): The name of the column.
+
+            Returns:
+                ColumnDTO.Builder: The builder instance.
+            """
+            self._name = name
+            return self
+
+        def with_data_type(self, data_type: Type) -> ColumnDTO.Builder:
+            """Sets the data type of the column.
+
+            Args:
+                data_type (Type): The data type of the column.
+
+            Returns:
+                ColumnDTO.Builder: The builder instance.
+            """
+            self._data_type = data_type
+            return self
+
+        def with_comment(self, comment: str) -> ColumnDTO.Builder:
+            """Sets the comment associated with the column.
+
+            Args:
+                comment (str): The comment associated with the column.
+
+            Returns:
+                ColumnDTO.Builder: The builder instance.
+            """
+            self._comment = comment
+            return self
+
+        def with_nullable(self, nullable: bool) -> ColumnDTO.Builder:
+            """Sets whether the column value can be null.
+
+            Args:
+                nullable (bool): Whether the column value can be null.
+
+            Returns:
+                ColumnDTO.Builder: The builder instance.
+            """
+            self._nullable = nullable
+            return self
+
+        def with_auto_increment(self, auto_increment: bool) -> ColumnDTO.Builder:
+            """Sets whether the column is an auto-increment column.
+
+            Args:
+                auto_increment (bool): Whether the column is an auto-increment column.
+
+            Returns:
+                ColumnDTO.Builder: The builder instance.
+            """
+            self._auto_increment = auto_increment
+            return self
+
+        def with_default_value(self, default_value: Expression) -> ColumnDTO.Builder:
+            """Sets the default value of the column.
+
+            Args:
+                default_value (Expression): The default value of the column.
+
+            Returns:
+                ColumnDTO.Builder: The builder instance.
+            """
+            self._default_value = default_value
+            return self
+
+        def build(self) -> ColumnDTO:
+            """Builds a Column DTO based on the provided builder parameters.
+
+            Returns:
+                ColumnDTO: A new ColumnDTO instance.
+
+            Raises:
+                IllegalArgumentException: If required, fields name and data type are not set.
+            """
+            Precondition.check_argument(
+                self._name is not None, "Column name cannot be null"
+            )
+            Precondition.check_argument(
+                self._data_type is not None, "Column data type cannot be null"
+            )
+            return ColumnDTO(
+                _name=self._name,
+                _data_type=self._data_type,
+                _comment=self._comment,
+                _nullable=self._nullable,
+                _auto_increment=self._auto_increment,
+                _default_value=(
+                    Column.DEFAULT_VALUE_NOT_SET
+                    if self._default_value is None
+                    else self._default_value
+                ),
+            )

--- a/clients/client-python/tests/unittests/dto/rel/test_column_dto.py
+++ b/clients/client-python/tests/unittests/dto/rel/test_column_dto.py
@@ -84,40 +84,50 @@ class TestColumnDTO(unittest.TestCase):
         self.assertNotEqual("column_1", column_dto_dict.get(column_dto_2))
 
     def test_column_dto_builder(self):
-        ColumnDTO.builder(
-            name="",
-            data_type=Types.StringType.get(),
-            comment="comment",
-            default_value=LiteralDTO(
-                value="default_value", data_type=Types.StringType.get()
-            ),
+        instance = (
+            ColumnDTO.builder()
+            .with_name(name="")
+            .with_data_type(data_type=Types.StringType.get())
+            .with_comment(comment="comment")
+            .with_default_value(
+                default_value=LiteralDTO(
+                    value="default_value", data_type=Types.StringType.get()
+                )
+            )
+            .build()
         )
+        self.assertIsInstance(instance, ColumnDTO)
+        self.assertEqual(instance.name(), "")
+        self.assertEqual(instance.data_type(), Types.StringType.get())
+        self.assertEqual(instance.comment(), "comment")
+        self.assertFalse(instance.auto_increment())
+        self.assertTrue(instance.nullable())
+        self.assertIsInstance(instance.default_value(), LiteralDTO)
+        self.assertEqual(instance.default_value().value(), "default_value")
 
         with self.assertRaisesRegex(
             IllegalArgumentException,
             "Column name cannot be null",
         ):
-            ColumnDTO.builder(
-                name=None,
-                data_type=Types.StringType.get(),
-                comment="comment",
+            ColumnDTO.builder().with_data_type(
+                data_type=Types.StringType.get()
+            ).with_comment(comment="comment").with_default_value(
                 default_value=LiteralDTO(
                     value="default_value", data_type=Types.StringType.get()
-                ),
-            )
+                )
+            ).build()
 
         with self.assertRaisesRegex(
             IllegalArgumentException,
             "Column data type cannot be null",
         ):
-            ColumnDTO.builder(
-                name="column",
-                data_type=None,
-                comment="comment",
+            ColumnDTO.builder().with_name(name="column").with_comment(
+                comment="comment"
+            ).with_default_value(
                 default_value=LiteralDTO(
                     value="default_value", data_type=Types.StringType.get()
-                ),
-            )
+                )
+            ).build()
 
     def test_column_dto_violate_non_nullable(self):
         column_dto = ColumnDTO.builder(

--- a/clients/client-python/tests/unittests/dto/rel/test_column_dto.py
+++ b/clients/client-python/tests/unittests/dto/rel/test_column_dto.py
@@ -62,11 +62,11 @@ class TestColumnDTO(unittest.TestCase):
             Types.UnparsedType.of(unparsed_type="unparsed_type"),
         ]
         cls._string_columns = [
-            ColumnDTO.builder(
-                name=f"column_{idx}",
-                data_type=Types.StringType.get(),
-                comment=f"column_{idx} comment",
-            )
+            ColumnDTO.builder()
+            .with_name(name=f"column_{idx}")
+            .with_data_type(data_type=Types.StringType.get())
+            .with_comment(comment=f"column_{idx} comment")
+            .build()
             for idx in range(3)
         ]
 
@@ -130,12 +130,16 @@ class TestColumnDTO(unittest.TestCase):
             ).build()
 
     def test_column_dto_violate_non_nullable(self):
-        column_dto = ColumnDTO.builder(
-            name="column_name",
-            data_type=Types.StringType.get(),
-            comment="comment",
-            nullable=False,
-            default_value=LiteralDTO(value="None", data_type=Types.NullType.get()),
+        column_dto = (
+            ColumnDTO.builder()
+            .with_name(name="column_name")
+            .with_data_type(data_type=Types.StringType.get())
+            .with_comment(comment="comment")
+            .with_nullable(nullable=False)
+            .with_default_value(
+                default_value=LiteralDTO(value="None", data_type=Types.NullType.get())
+            )
+            .build()
         )
         with self.assertRaisesRegex(
             IllegalArgumentException,
@@ -144,11 +148,14 @@ class TestColumnDTO(unittest.TestCase):
             column_dto.validate()
 
     def test_column_dto_default_value_not_set(self):
-        column_dto = ColumnDTO.builder(
-            name="column_name",
-            data_type=Types.StringType.get(),
-            comment="comment",
+        column_dto = (
+            ColumnDTO.builder()
+            .with_name(name="column_name")
+            .with_data_type(data_type=Types.StringType.get())
+            .with_comment(comment="comment")
+            .build()
         )
+
         self.assertEqual(column_dto.name(), "column_name")
         self.assertEqual(column_dto.nullable(), True)
         self.assertEqual(column_dto.auto_increment(), False)
@@ -168,10 +175,12 @@ class TestColumnDTO(unittest.TestCase):
             "autoIncrement": False,
         }
         for supported_type in self._supported_types:
-            column_dto = ColumnDTO.builder(
-                name=str(supported_type.name()),
-                data_type=supported_type,
-                comment=supported_type.simple_string(),
+            column_dto = (
+                ColumnDTO.builder()
+                .with_name(name=str(supported_type.name()))
+                .with_data_type(data_type=supported_type)
+                .with_comment(comment=supported_type.simple_string())
+                .build()
             )
             expected_dict["name"] = str(supported_type.name())
             expected_dict["type"] = TypeSerdes.serialize(supported_type)
@@ -188,12 +197,14 @@ class TestColumnDTO(unittest.TestCase):
         """
 
         for supported_type in self._supported_types:
-            column_dto = ColumnDTO.builder(
-                name=str(supported_type.name()),
-                data_type=supported_type,
-                comment=supported_type.simple_string(),
-                nullable=True,
-                auto_increment=False,
+            column_dto = (
+                ColumnDTO.builder()
+                .with_name(name=str(supported_type.name()))
+                .with_data_type(data_type=supported_type)
+                .with_comment(comment=supported_type.simple_string())
+                .with_nullable(nullable=True)
+                .with_auto_increment(auto_increment=False)
+                .build()
             )
             serialized_json = column_dto.to_json()
             deserialized_column_dto = ColumnDTO.from_json(serialized_json)

--- a/clients/client-python/tests/unittests/dto/rel/test_function_arg.py
+++ b/clients/client-python/tests/unittests/dto/rel/test_function_arg.py
@@ -32,12 +32,12 @@ class TestFunctionArg(unittest.TestCase):
         ]
         self._column_names = [f"column{i}" for i in range(len(self._data_types))]
         self._columns = [
-            ColumnDTO.builder(
-                name=column_name,
-                data_type=data_type,
-                comment=f"{column_name} comment",
-                nullable=False,
-            )
+            ColumnDTO.builder()
+            .with_name(name=column_name)
+            .with_data_type(data_type=data_type)
+            .with_comment(comment=f"{column_name} comment")
+            .with_nullable(nullable=False)
+            .build()
             for column_name, data_type in zip(self._column_names, self._data_types)
         ]
 

--- a/clients/client-python/tests/unittests/dto/rel/test_partition_utils.py
+++ b/clients/client-python/tests/unittests/dto/rel/test_partition_utils.py
@@ -32,12 +32,12 @@ class TestPartitionUtils(unittest.TestCase):
         ]
         self._column_names = [f"column{i}" for i in range(len(self._data_types))]
         self._columns = [
-            ColumnDTO.builder(
-                name=column_name,
-                data_type=data_type,
-                comment=f"{column_name} comment",
-                nullable=False,
-            )
+            ColumnDTO.builder()
+            .with_name(name=column_name)
+            .with_data_type(data_type=data_type)
+            .with_comment(comment=f"{column_name} comment")
+            .with_nullable(nullable=False)
+            .build()
             for column_name, data_type in zip(self._column_names, self._data_types)
         ]
 


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

This is a refactor of builder method for `ColumnDTO` that is proposed in the [comments](https://github.com/apache/gravitino/pull/7357#discussion_r2139040656) of the previous PR. 

### Why are the changes needed?

We need to support Column and its default value in python client.

#5202

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Unit tests