### PR TITLE
[#5202] feat(client-python): add dto classes for default values

### DIFF
--- a/clients/client-python/gravitino/dto/rel/expressions/field_reference_dto.py
+++ b/clients/client-python/gravitino/dto/rel/expressions/field_reference_dto.py
@@ -1,0 +1,44 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+from typing import List
+
+from gravitino.api.expressions.named_reference import NamedReference
+from gravitino.dto.rel.expressions.function_arg import FunctionArg
+
+
+class FieldReferenceDTO(NamedReference, FunctionArg):
+    """Data transfer object representing a field reference."""
+
+    def __init__(self, field_name: List[str]):
+        self._field_name = field_name
+
+    def field_name(self) -> List[str]:
+        return self._field_name
+
+    def arg_type(self) -> FunctionArg.ArgType:
+        return self.ArgType.FIELD
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, FieldReferenceDTO):
+            return False
+        return self._field_name == other.field_name()
+
+    def __hash__(self) -> int:
+        return hash((self.arg_type(), tuple(self._field_name)))

--- a/clients/client-python/gravitino/dto/rel/expressions/func_expression_dto.py
+++ b/clients/client-python/gravitino/dto/rel/expressions/func_expression_dto.py
@@ -1,0 +1,59 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+from typing import List
+
+from gravitino.api.expressions.expression import Expression
+from gravitino.api.expressions.function_expression import FunctionExpression
+from gravitino.dto.rel.expressions.function_arg import FunctionArg
+
+
+class FuncExpressionDTO(FunctionExpression, FunctionArg):
+    def __init__(self, function_name: str, function_args: List[FunctionArg]):
+        self._function_name = function_name
+        self._function_args = function_args
+
+    def args(self) -> List[FunctionArg]:
+        """The function arguments.
+
+        Returns:
+            List[FunctionArg]: The function arguments.
+        """
+        return self._function_args
+
+    def function_name(self) -> str:
+        return self._function_name
+
+    def arguments(self) -> List[Expression]:
+        return self._function_args
+
+    def arg_type(self) -> FunctionArg.ArgType:
+        return self.ArgType.FUNCTION
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, FuncExpressionDTO):
+            return False
+        return (
+            self._function_name == other.function_name()
+            and self._function_args == other.args()
+            and self.arg_type() is other.arg_type()
+        )
+
+    def __hash__(self) -> int:
+        return hash((self.arg_type(), self._function_name, tuple(self._function_args)))

--- a/clients/client-python/gravitino/dto/rel/expressions/unparsed_expression_dto.py
+++ b/clients/client-python/gravitino/dto/rel/expressions/unparsed_expression_dto.py
@@ -1,0 +1,50 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from gravitino.api.expressions.unparsed_expression import UnparsedExpression
+from gravitino.dto.rel.expressions.function_arg import FunctionArg
+
+
+class UnparsedExpressionDTO(UnparsedExpression, FunctionArg):
+    """Data transfer object representing an unparsed expression."""
+
+    def __init__(self, unparsed_expression: str):
+        self._unparsed_expression = unparsed_expression
+
+    def unparsed_expression(self) -> str:
+        """Returns the unparsed expression as a string.
+
+        Returns:
+            str: The value of the unparsed expression.
+        """
+        return self._unparsed_expression
+
+    def arg_type(self) -> FunctionArg.ArgType:
+        return self.ArgType.UNPARSED
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, UnparsedExpressionDTO):
+            return False
+        return self._unparsed_expression == other.unparsed_expression()
+
+    def __hash__(self) -> int:
+        return hash((self.arg_type(), self._unparsed_expression))
+
+    def __str__(self) -> str:
+        return (
+            f"UnparsedExpressionDTO{{unparsedExpression='{self._unparsed_expression}'}}"
+        )

--- a/clients/client-python/tests/unittests/dto/rel/test_field_reference_dto.py
+++ b/clients/client-python/tests/unittests/dto/rel/test_field_reference_dto.py
@@ -1,0 +1,49 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import unittest
+
+from gravitino.api.types.types import Types
+from gravitino.dto.rel.expressions.field_reference_dto import FieldReferenceDTO
+from gravitino.dto.rel.expressions.function_arg import FunctionArg
+from gravitino.dto.rel.expressions.literal_dto import LiteralDTO
+
+
+class TestFieldReferenceDTO(unittest.TestCase):
+    def setUp(self):
+        self._field_references = [
+            FieldReferenceDTO(field_name=[f"field_name_{idx}"]) for idx in range(3)
+        ]
+
+    def test_field_reference_dto(self):
+        dto = FieldReferenceDTO(field_name=self._field_references[0].field_name())
+        self.assertListEqual(dto.field_name(), self._field_references[0].field_name())
+        self.assertIs(dto.arg_type(), FunctionArg.ArgType.FIELD)
+
+    def test_equality(self):
+        dto = FieldReferenceDTO(field_name=self._field_references[0].field_name())
+
+        self.assertTrue(dto == self._field_references[0])
+        self.assertFalse(dto == self._field_references[1])
+        self.assertFalse(
+            dto == LiteralDTO(value="value", data_type=Types.StringType.get())
+        )
+
+    def test_hash(self):
+        dto_dict = {dto: idx for idx, dto in enumerate(self._field_references)}
+        self.assertEqual(0, dto_dict.get(self._field_references[0]))
+        self.assertNotEqual(0, dto_dict.get(self._field_references[1]))

--- a/clients/client-python/tests/unittests/dto/rel/test_func_expression_dto.py
+++ b/clients/client-python/tests/unittests/dto/rel/test_func_expression_dto.py
@@ -1,0 +1,59 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import unittest
+
+from gravitino.api.types.types import Types
+from gravitino.dto.rel.expressions.field_reference_dto import FieldReferenceDTO
+from gravitino.dto.rel.expressions.func_expression_dto import FuncExpressionDTO
+from gravitino.dto.rel.expressions.literal_dto import LiteralDTO
+
+
+class TestFuncExpressionDTO(unittest.TestCase):
+    def setUp(self) -> None:
+        self._func_args = [
+            LiteralDTO(value="year", data_type=Types.StringType.get()),
+            FieldReferenceDTO(field_name=["birthday"]),
+        ]
+        self._func_expressions = [
+            FuncExpressionDTO(function_name="function_without_args", function_args=[]),
+            FuncExpressionDTO(
+                function_name="function_with_args", function_args=self._func_args
+            ),
+        ]
+
+    def test_func_expression_dto(self):
+        dto = self._func_expressions[1]
+
+        self.assertEqual(dto.function_name(), "function_with_args")
+        self.assertListEqual(dto.args(), self._func_args)
+        self.assertListEqual(dto.arguments(), self._func_args)
+        self.assertIs(dto.arg_type(), FuncExpressionDTO.ArgType.FUNCTION)
+
+    def test_equality(self):
+        dto = self._func_expressions[1]
+        dto1 = FuncExpressionDTO(
+            function_name="function_with_args", function_args=self._func_args
+        )
+        self.assertTrue(dto == dto1)
+        self.assertFalse(dto == self._func_expressions[0])
+        self.assertFalse(dto == self._func_args[0])
+
+    def test_hash(self):
+        dto_dict = {dto: idx for idx, dto in enumerate(self._func_expressions)}
+        self.assertEqual(0, dto_dict.get(self._func_expressions[0]))
+        self.assertNotEqual(0, dto_dict.get(self._func_expressions[1]))

--- a/clients/client-python/tests/unittests/dto/rel/test_unparsed_expression_dto.py
+++ b/clients/client-python/tests/unittests/dto/rel/test_unparsed_expression_dto.py
@@ -1,0 +1,59 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import unittest
+
+from gravitino.api.types.types import Types
+from gravitino.dto.rel.expressions.literal_dto import LiteralDTO
+from gravitino.dto.rel.expressions.unparsed_expression_dto import UnparsedExpressionDTO
+
+
+class TestUnparsedExpressionDTO(unittest.TestCase):
+    def setUp(self) -> None:
+        self._dtos = [
+            UnparsedExpressionDTO(unparsed_expression=f"unparsed_expression_{idx}")
+            for idx in range(3)
+        ]
+
+    def test_unparsed_expression_dto(self):
+        dto = self._dtos[0]
+
+        self.assertIs(dto.arg_type(), UnparsedExpressionDTO.ArgType.UNPARSED)
+        self.assertEqual(dto.unparsed_expression(), "unparsed_expression_0")
+        self.assertEqual(
+            str(dto),
+            "UnparsedExpressionDTO{unparsedExpression='unparsed_expression_0'}",
+        )
+
+    def test_equality(self):
+        dto = self._dtos[0]
+        similar_dto = UnparsedExpressionDTO(unparsed_expression="unparsed_expression_0")
+        another_dto = UnparsedExpressionDTO(
+            unparsed_expression="another_unparsed_expression"
+        )
+
+        self.assertTrue(dto == similar_dto)
+        self.assertFalse(dto == another_dto)
+        self.assertFalse(
+            dto == LiteralDTO(value="value", data_type=Types.StringType.get())
+        )
+
+    def test_hash(self):
+        dto_dict = {dto: idx for idx, dto in enumerate(self._dtos)}
+
+        self.assertEqual(0, dto_dict.get(self._dtos[0]))
+        self.assertNotEqual(0, dto_dict.get(self._dtos[1]))


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

This is the third part (totally 4 planned) of implementation to the following classes from Java to support Column and its default value, including:

- FieldReferenceDTO
- FuncExpressionDTO
- UnparsedExpressionDTO

### Why are the changes needed?

We need to support Column and its default value in python client.

#5202

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Unit tests
