### PR TITLE
[#7521] fix(common): Fix precondition message mismatch

### DIFF
--- a/common/src/main/java/org/apache/gravitino/dto/rel/DistributionDTO.java
+++ b/common/src/main/java/org/apache/gravitino/dto/rel/DistributionDTO.java
@@ -164,7 +164,7 @@ public class DistributionDTO implements Distribution {
 
       Preconditions.checkState(args != null, "expressions cannot be null");
       // Check if the number of buckets is greater than -1, -1 is auto.
-      Preconditions.checkState(number >= -1, "bucketNum must be greater than -1");
+      Preconditions.checkState(number >= -1, "bucketNum must be greater than or equal -1");
       return new DistributionDTO(strategy, number, args);
     }
   }


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Update the error message in Preconditions.checkState to match the validation logic.
This change ensures that the error message accurately reflects the status being checked by the code.

### Why are the changes needed?

Previously, the validation logic allowed values greater than or equal to -1, but the error message stated that only values greater than -1 were acceptable. This could mislead users or developers.

Fix: #7521 

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Local verification.
