### PR TITLE
[#7511] fix typo's in code

### DIFF
--- a/clients/cli/src/main/java/org/apache/gravitino/cli/FullName.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/FullName.java
@@ -22,7 +22,7 @@ package org.apache.gravitino.cli;
 import org.apache.commons.cli.CommandLine;
 
 /**
- * Extracts different arts of a full name (dot seperated) from the command line input. This includes
+ * Extracts different parts of a full name (dot separated) from the command line input. This includes
  * metalake, catalog, schema, and table names.
  */
 public class FullName {

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/FullName.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/FullName.java
@@ -22,8 +22,8 @@ package org.apache.gravitino.cli;
 import org.apache.commons.cli.CommandLine;
 
 /**
- * Extracts different parts of a full name (dot separated) from the command line input. This includes
- * metalake, catalog, schema, and table names.
+ * Extracts different parts of a full name (dot separated) from the command line input. This
+ * includes metalake, catalog, schema, and table names.
  */
 public class FullName {
   private final CommandLine line;

--- a/clients/client-java/src/test/java/org/apache/gravitino/client/integration/test/TagIT.java
+++ b/clients/client-java/src/test/java/org/apache/gravitino/client/integration/test/TagIT.java
@@ -671,9 +671,9 @@ public class TagIT extends BaseIT {
     Assertions.assertTrue(tagNames.contains(tag2.name()));
     Assertions.assertFalse(tagNames.contains(tag3.name()));
 
-    Tag retrivedTag = relationalCatalog.supportsTags().getTag(tag2.name());
-    Assertions.assertEquals(tag2.name(), retrivedTag.name());
-    Assertions.assertEquals(tag2.comment(), retrivedTag.comment());
+    Tag retrievedTag = relationalCatalog.supportsTags().getTag(tag2.name());
+    Assertions.assertEquals(tag2.name(), retrievedTag.name());
+    Assertions.assertEquals(tag2.comment(), retrievedTag.comment());
 
     boolean deleted = metalake.deleteTag("null");
     Assertions.assertFalse(deleted);

--- a/clients/client-python/tests/integration/containers/base_container.py
+++ b/clients/client-python/tests/integration/containers/base_container.py
@@ -36,7 +36,7 @@ class BaseContainer:
     _container_name: str
 
     def __init__(
-        self, container_name: str, image_name: str, enviroment: Dict = None, **kwarg
+        self, container_name: str, image_name: str, environment: Dict = None, **kwarg
     ):
         self._container_name = container_name
         self._docker_client = docker.from_env()
@@ -58,7 +58,7 @@ class BaseContainer:
                 image=image_name,
                 name=self._container_name,
                 detach=True,
-                environment=enviroment,
+                environment=environment,
                 network=self._network_name,
                 **kwarg,
             )

--- a/clients/client-python/tests/unittests/auth/test_oauth2_token_provider.py
+++ b/clients/client-python/tests/unittests/auth/test_oauth2_token_provider.py
@@ -45,7 +45,7 @@ class TestOAuth2TokenProvider(unittest.TestCase):
         "gravitino.utils.http_client.HTTPClient._make_request",
         return_value=mock_base.mock_authentication_invalid_client_error(),
     )
-    def test_authertication_invalid_client_error(self, *mock_methods):
+    def test_authentication_invalid_client_error(self, *mock_methods):
         with self.assertRaises(UnauthorizedException):
             _ = DefaultOAuth2TokenProvider(
                 uri=f"http://127.0.0.1:{OAUTH_PORT}",
@@ -58,7 +58,7 @@ class TestOAuth2TokenProvider(unittest.TestCase):
         "gravitino.utils.http_client.HTTPClient._make_request",
         return_value=mock_base.mock_authentication_invalid_grant_error(),
     )
-    def test_authertication_invalid_grant_error(self, *mock_methods):
+    def test_authentication_invalid_grant_error(self, *mock_methods):
         with self.assertRaises(BadRequestException):
             _ = DefaultOAuth2TokenProvider(
                 uri=f"http://127.0.0.1:{OAUTH_PORT}",

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -463,7 +463,7 @@ Setting and removing schema properties is not currently supported by the Java AP
 
 ### Table commands
 
-When creating a table the columns are specified in CSV file specifying the name of the column, the datatype, a comment, true or false if the column is nullable, true or false if the column is auto incremented, a default value and a default type. Not all of the columns need to be specifed just the name and datatype columns. If not specified comment default to null, nullability to true and auto increment to false. If only the default value is specified it defaults to the same data type as the column.
+When creating a table the columns are specified in CSV file specifying the name of the column, the datatype, a comment, true or false if the column is nullable, true or false if the column is auto incremented, a default value and a default type. Not all of the columns need to be specified just the name and datatype columns. If not specified comment default to null, nullability to true and auto increment to false. If only the default value is specified it defaults to the same data type as the column.
 
 Example CSV file
 


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

There are several minor issues in the spelling of variable names etc

"enviroment" in base_container.py
"seperated" in VList.java and FullName.java
“arts” instead of “parts” in FullName.java
“authertication” misspelled in test_oauth2_token_provider.py
“specifed” in docs/cli.md
“retrivedTag” in TagIT.java


### Why are the changes needed?

(Please clarify why the changes are needed. For instance,
 
spelling issues of the variable names

Fix: #7511

### Does this PR introduce _any_ user-facing change?

(Please list the user-facing changes introduced by your change, including
no

### How was this patch tested?

(Please test your changes, and provide instructions on how to test it:

just spell check.
