### PR TITLE
[#7520] fix: Deduplicate supportPartitions() call

### DIFF
--- a/core/src/main/java/org/apache/gravitino/catalog/CatalogManager.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/CatalogManager.java
@@ -218,9 +218,9 @@ public class CatalogManager implements CatalogDispatcher, Closeable {
             Preconditions.checkArgument(
                 asTables() != null, "Catalog does not support table operations");
             Table table = asTables().loadTable(tableIdent);
-            SupportsPartitions partitionOps  = table.supportPartitions();
+            SupportsPartitions partitionOps = table.supportPartitions();
             Preconditions.checkArgument(
-                partitionOps != null,  "Table does not support partition operations");
+                partitionOps != null, "Table does not support partition operations");
             return fn.apply(partitionOps);
           });
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR removes the redundant invocation of `table.supportPartitions()` in `CatalogWrapper#doWithPartitionOps`.
Now, the method is called once and its result is cached in a local variable.

### Why are the changes needed?

Calling `table.supportPartitions()` twice results in unnecessary repeated look-ups.
Caching the result improves code readability and performance.

Fix:  #7520

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
No behavior change is expected.
