### PR TITLE
[#7515] feat(core): Improve fromComment in StringIdentifier

### DIFF
--- a/core/src/main/java/org/apache/gravitino/StringIdentifier.java
+++ b/core/src/main/java/org/apache/gravitino/StringIdentifier.java
@@ -176,12 +176,17 @@ public class StringIdentifier {
       return null;
     }
 
-    int index = comment.lastIndexOf('(');
-    if (index == -1) {
+    int left = comment.lastIndexOf('(');
+    int right = comment.lastIndexOf(')');
+    if (left == -1 || right == -1) {
+      return null;
+    }
+    String innerComment = comment.substring(left + 1, right).trim();
+    if (!innerComment.startsWith(STRING_COMMENT)) {
       return null;
     }
 
-    String idString = comment.substring(index + STRING_COMMENT.length() + 1, comment.length() - 1);
+    String idString = innerComment.substring(STRING_COMMENT.length()).trim();
     return fromString(idString);
   }
 

--- a/core/src/test/java/org/apache/gravitino/TestStringIdentifier.java
+++ b/core/src/test/java/org/apache/gravitino/TestStringIdentifier.java
@@ -163,6 +163,10 @@ public class TestStringIdentifier {
     String comment1 = "This is a comment";
     StringIdentifier stringIdFromComment2 = StringIdentifier.fromComment(comment1);
     Assertions.assertNull(stringIdFromComment2);
+
+    // Test comment contains parentheses but not the Gravitino prefix
+    String comment2 = "A comment (other info)";
+    Assertions.assertNull(StringIdentifier.fromComment(comment2));
   }
 
   @Test


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Improve fromComment in StringIdentifier

### Why are the changes needed?

Fix: #7515 

### Does this PR introduce _any_ user-facing change?

no

### How was this patch tested?

Unit tests
