### PR TITLE
[#7513] fix: server shutdown logic should correctly check for forceKill

### DIFF
--- a/bin/gravitino-iceberg-rest-server.sh.template
+++ b/bin/gravitino-iceberg-rest-server.sh.template
@@ -81,7 +81,7 @@ function wait_for_iceberg_rest_server_to_die() {
       break
     fi
 
-    $(kill ${pid} > /dev/null 2> /dev/null)
+    kill ${pid} > /dev/null 2> /dev/null
     if kill -0 ${pid} > /dev/null 2>&1; then
       sleep 3
     else
@@ -91,8 +91,8 @@ function wait_for_iceberg_rest_server_to_die() {
     currentTime=$(date "+%s")
   done
 
-  if [[ forceKill -ne 0 ]]; then
-    $(kill -9 ${pid} > /dev/null 2> /dev/null)
+  if [[ $forceKill -ne 0 ]]; then
+    kill -9 ${pid} > /dev/null 2> /dev/null
   fi
 }
 

--- a/bin/gravitino.sh.template
+++ b/bin/gravitino.sh.template
@@ -81,7 +81,7 @@ function wait_for_gravitino_server_to_die() {
       break
     fi
 
-    $(kill ${pid} > /dev/null 2> /dev/null)
+    kill ${pid} > /dev/null 2> /dev/null
     if kill -0 ${pid} > /dev/null 2>&1; then
       sleep 3
     else
@@ -91,8 +91,8 @@ function wait_for_gravitino_server_to_die() {
     currentTime=$(date "+%s")
   done
 
-  if [[ forceKill -ne 0 ]]; then
-    $(kill -9 ${pid} > /dev/null 2> /dev/null)
+  if [[ $forceKill -ne 0 ]]; then
+    kill -9 ${pid} > /dev/null 2> /dev/null
   fi
 }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

server shutdown logic should correctly check for forceKill

The if statement should check for forcekill variable value. Earlier, it was doing a comparison against the string `forcekill` which would always evaluate to true.

### Why are the changes needed?

Required for correct shutdown of the service

Fix: #7513 

### Does this PR introduce _any_ user-facing change?
N/A

### How was this patch tested?
```
./bin/gravitino.sh start
./bin/gravitino.sh stop
```

(also modified the script to echo some more logs while shutting down. not committed in the patch, done only for local testing)