### PR TITLE
[#7556] table authorization support for Iceberg REST server

### DIFF
--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/IcebergRESTAuthInterceptionService.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/IcebergRESTAuthInterceptionService.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.iceberg;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import org.aopalliance.intercept.ConstructorInterceptor;
+import org.aopalliance.intercept.MethodInterceptor;
+import org.aopalliance.intercept.MethodInvocation;
+import org.apache.gravitino.Entity;
+import org.apache.gravitino.MetadataObject;
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.exceptions.ForbiddenException;
+import org.apache.gravitino.iceberg.service.rest.IcebergTableOperations;
+import org.apache.gravitino.server.authorization.annotations.AuthorizationExpression;
+import org.apache.gravitino.server.authorization.expression.AuthorizationExpressionEvaluator;
+import org.apache.gravitino.server.web.Utils;
+import org.glassfish.hk2.api.Descriptor;
+import org.glassfish.hk2.api.Filter;
+import org.glassfish.hk2.api.InterceptionService;
+
+/**
+ * IcebergRESTAuthInterceptionService defines a method interceptor for REST interfaces to create
+ * dynamic proxies. It implements metadata authorization when invoking REST API methods. It needs to
+ * be registered in the hk2 bean container when the gravitino server starts.
+ */
+public class IcebergRESTAuthInterceptionService implements InterceptionService {
+
+  @Override
+  public Filter getDescriptorFilter() {
+    return new ClassListFilter(ImmutableSet.of(IcebergTableOperations.class.getName()));
+  }
+
+  @Override
+  public List<MethodInterceptor> getMethodInterceptors(Method method) {
+    return ImmutableList.of(new MetadataAuthorizationMethodInterceptor());
+  }
+
+  /**
+   * Through dynamic proxy, obtain the annotations on the method and parameter list to perform
+   * metadata authorization.
+   */
+  private static class MetadataAuthorizationMethodInterceptor implements MethodInterceptor {
+
+    /**
+     * Determine whether authorization is required and the rules via the authorization annotation ,
+     * and obtain the metadata ID that requires authorization via the authorization annotation.
+     *
+     * @param methodInvocation methodInvocation with the Method object
+     * @return the return result of the original method.
+     * @throws Throwable throw an exception when authorization fails.
+     */
+    @Override
+    public Object invoke(MethodInvocation methodInvocation) throws Throwable {
+      try {
+        Method method = methodInvocation.getMethod();
+        Parameter[] parameters = method.getParameters();
+        AuthorizationExpression expressionAnnotation =
+            method.getAnnotation(AuthorizationExpression.class);
+        if (expressionAnnotation != null) {
+          String expression = expressionAnnotation.expression();
+          Object[] args = methodInvocation.getArguments();
+          Map<Entity.EntityType, NameIdentifier> metadataContext =
+              extractNameIdentifierFromParameters(parameters, args);
+          AuthorizationExpressionEvaluator authorizationExpressionEvaluator =
+              new AuthorizationExpressionEvaluator(expression);
+          boolean authorizeResult = authorizationExpressionEvaluator.evaluate(metadataContext);
+          if (!authorizeResult) {
+            MetadataObject.Type type = expressionAnnotation.accessMetadataType();
+            NameIdentifier accessMetadataName =
+                metadataContext.get(Entity.EntityType.valueOf(type.name()));
+            return Utils.forbidden(
+                String.format("Can not access metadata {%s}.", accessMetadataName.name()),
+                new ForbiddenException("Can not access metadata {%s}.", accessMetadataName));
+          }
+        }
+        return methodInvocation.proceed();
+      } catch (Exception ex) {
+        return Utils.forbidden("Can not access metadata. Cause by: " + ex.getMessage(), ex);
+      }
+    }
+
+    private Map<Entity.EntityType, NameIdentifier> extractNameIdentifierFromParameters(
+        Parameter[] parameters, Object[] args) {
+      // TODO: diff from GravitinoInterceptionService
+      // get metalake from configuration, catalog from prefix PathParam, namespace from namespace
+      // PathParam
+    }
+  }
+
+  @Override
+  public List<ConstructorInterceptor> getConstructorInterceptors(Constructor<?> constructor) {
+    return Collections.emptyList();
+  }
+
+  private static class ClassListFilter implements Filter {
+    private final Set<String> targetClasses;
+
+    public ClassListFilter(Set<String> targetClasses) {
+      this.targetClasses = new HashSet<>(targetClasses);
+    }
+
+    @Override
+    public boolean matches(Descriptor descriptor) {
+      String implementation = descriptor.getImplementation();
+      return targetClasses.contains(implementation);
+    }
+  }
+}

--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/RESTService.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/RESTService.java
@@ -21,6 +21,7 @@ package org.apache.gravitino.iceberg;
 import com.google.common.collect.Lists;
 import java.util.List;
 import java.util.Map;
+import javax.inject.Singleton;
 import javax.servlet.Servlet;
 import org.apache.gravitino.GravitinoEnv;
 import org.apache.gravitino.auxiliary.GravitinoAuxiliaryService;
@@ -46,6 +47,7 @@ import org.apache.gravitino.metrics.source.MetricsSource;
 import org.apache.gravitino.server.web.HttpServerMetricsSource;
 import org.apache.gravitino.server.web.JettyServer;
 import org.apache.gravitino.server.web.JettyServerConfig;
+import org.glassfish.hk2.api.InterceptionService;
 import org.glassfish.hk2.utilities.binding.AbstractBinder;
 import org.glassfish.jersey.jackson.JacksonFeature;
 import org.glassfish.jersey.server.ResourceConfig;
@@ -110,6 +112,9 @@ public class RESTService implements GravitinoAuxiliaryService {
         new AbstractBinder() {
           @Override
           protected void configure() {
+            bind(IcebergRESTAuthInterceptionService.class)
+                .to(InterceptionService.class)
+                .in(Singleton.class);
             bind(icebergCatalogWrapperManager).to(IcebergCatalogWrapperManager.class).ranked(1);
             bind(icebergMetricsManager).to(IcebergMetricsManager.class).ranked(1);
             bind(icebergTableEventDispatcher).to(IcebergTableOperationDispatcher.class).ranked(1);

--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/rest/IcebergTableOperations.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/rest/IcebergTableOperations.java
@@ -41,12 +41,14 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.gravitino.MetadataObject;
 import org.apache.gravitino.iceberg.service.IcebergObjectMapper;
 import org.apache.gravitino.iceberg.service.IcebergRestUtils;
 import org.apache.gravitino.iceberg.service.dispatcher.IcebergTableOperationDispatcher;
 import org.apache.gravitino.iceberg.service.metrics.IcebergMetricsManager;
 import org.apache.gravitino.listener.api.event.IcebergRequestContext;
 import org.apache.gravitino.metrics.MetricNames;
+import org.apache.gravitino.server.authorization.annotations.AuthorizationExpression;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.rest.RESTUtil;
@@ -102,6 +104,12 @@ public class IcebergTableOperations {
   @Produces(MediaType.APPLICATION_JSON)
   @Timed(name = "create-table." + MetricNames.HTTP_PROCESS_DURATION, absolute = true)
   @ResponseMetered(name = "create-table", absolute = true)
+  @AuthorizationExpression(
+      expression =
+          "METALAKE::CREATE_TABLE || CATALOG::CREATE_TABLE || "
+              + "SCHEMA::CREATE_TABLE || METALAKE::OWNER || "
+              + "CATALOG::OWNER || SCHEMA::OWNER",
+      accessMetadataType = MetadataObject.Type.TABLE)
   public Response createTable(
       @PathParam("prefix") String prefix,
       @Encoded() @PathParam("namespace") String namespace,
@@ -130,6 +138,12 @@ public class IcebergTableOperations {
   @Produces(MediaType.APPLICATION_JSON)
   @Timed(name = "update-table." + MetricNames.HTTP_PROCESS_DURATION, absolute = true)
   @ResponseMetered(name = "update-table", absolute = true)
+  @AuthorizationExpression(
+      expression =
+          "METALAKE::MODIFY_TABLE || CATALOG::MODIFY_TABLE || "
+              + "SCHEMA::MODIFY_TABLE || TABLE::MODIFY_TABLE || "
+              + "METALAKE::OWNER || CATALOG::OWNER || SCHEMA::OWNER || TABLE::OWNER",
+      accessMetadataType = MetadataObject.Type.TABLE)
   public Response updateTable(
       @PathParam("prefix") String prefix,
       @Encoded() @PathParam("namespace") String namespace,
@@ -157,6 +171,9 @@ public class IcebergTableOperations {
   @Produces(MediaType.APPLICATION_JSON)
   @Timed(name = "drop-table." + MetricNames.HTTP_PROCESS_DURATION, absolute = true)
   @ResponseMetered(name = "drop-table", absolute = true)
+  @AuthorizationExpression(
+      expression = "METALAKE::OWNER || CATALOG::OWNER || SCHEMA::OWNER || TABLE::OWNER",
+      accessMetadataType = MetadataObject.Type.TABLE)
   public Response dropTable(
       @PathParam("prefix") String prefix,
       @Encoded() @PathParam("namespace") String namespace,
@@ -181,6 +198,14 @@ public class IcebergTableOperations {
   @Produces(MediaType.APPLICATION_JSON)
   @Timed(name = "load-table." + MetricNames.HTTP_PROCESS_DURATION, absolute = true)
   @ResponseMetered(name = "load-table", absolute = true)
+  @AuthorizationExpression(
+      expression =
+          "METALAKE::SELECT_TABLE || CATALOG::SELECT_TABLE || "
+              + "SCHEMA::SELECT_TABLE || TABLE::SELECT_TABLE || "
+              + "METALAKE::MODIFY_TABLE || CATALOG::MODIFY_TABLE || "
+              + "SCHEMA::MODIFY_TABLE || TABLE::MODIFY_TABLE || "
+              + "METALAKE::OWNER || CATALOG::OWNER || SCHEMA::OWNER || TABLE::OWNER",
+      accessMetadataType = MetadataObject.Type.TABLE)
   public Response loadTable(
       @PathParam("prefix") String prefix,
       @Encoded() @PathParam("namespace") String namespace,
@@ -212,6 +237,13 @@ public class IcebergTableOperations {
   @Produces(MediaType.APPLICATION_JSON)
   @Timed(name = "table-exists." + MetricNames.HTTP_PROCESS_DURATION, absolute = true)
   @ResponseMetered(name = "table-exits", absolute = true)
+  @AuthorizationExpression(
+      expression =
+          "METALAKE::SELECT_TABLE || CATALOG::SELECT_TABLE || "
+              + "SCHEMA::SELECT_TABLE || TABLE::SELECT_TABLE || "
+              + "METALAKE::OWNER || CATALOG::OWNER || SCHEMA::OWNER || "
+              + "TABLE::OWNER",
+      accessMetadataType = MetadataObject.Type.TABLE)
   public Response tableExists(
       @PathParam("prefix") String prefix,
       @Encoded() @PathParam("namespace") String namespace,
@@ -238,6 +270,12 @@ public class IcebergTableOperations {
   @Produces(MediaType.APPLICATION_JSON)
   @Timed(name = "report-table-metrics." + MetricNames.HTTP_PROCESS_DURATION, absolute = true)
   @ResponseMetered(name = "report-table-metrics", absolute = true)
+  @AuthorizationExpression(
+      expression =
+          "METALAKE::MODIFY_TABLE || CATALOG::MODIFY_TABLE || "
+              + "SCHEMA::MODIFY_TABLE || TABLE::MODIFY_TABLE || "
+              + "METALAKE::OWNER || CATALOG::OWNER || SCHEMA::OWNER || TABLE::OWNER",
+      accessMetadataType = MetadataObject.Type.TABLE)
   public Response reportTableMetrics(
       @PathParam("prefix") String prefix,
       @Encoded() @PathParam("namespace") String namespace,


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Add auth support to table operations for Iceberg REST server.

### Why are the changes needed?

Gravitino previously relied on pushing permission checks to underlying data sources (e.g., Apache Ranger, IAM), but differences in each system made unified authentication difficult. See #6762.
Fix: #7556

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

`org.apache.gravitino.iceberg.service.rest.TestIcebergTableOperations`
