### PR TITLE
[#7594] fix(restutils): correct loop condition in port range logic

### DIFF
--- a/common/src/main/java/org/apache/gravitino/rest/RESTUtils.java
+++ b/common/src/main/java/org/apache/gravitino/rest/RESTUtils.java
@@ -160,7 +160,7 @@ public class RESTUtils {
 
     Random random = new Random();
     final int maxRetry = 200;
-    for (int i = portRangeStart; i <= portRangeEnd || i < portRangeStart + maxRetry; ++i) {
+    for (int i = portRangeStart; i <= portRangeEnd && i < portRangeStart + maxRetry; ++i) {
       int randomNumber = random.nextInt(portRangeEnd - portRangeStart + 1) + portRangeStart;
       try (ServerSocket socket = new ServerSocket(randomNumber)) {
         return socket.getLocalPort();


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

This Pull Request fixes a logical error in the for loop condition in the RESTUtils.java file. The for loop previously used logical OR (`||`) operator and that has been changed to logical AND (`&&`) operator. 

### Why are the changes needed?
By using `||` operator, the loop condition could result in loop exceeding the intended port range **or** retry limit. Changing to `&&` operator ensures the loop condition does not exceed the port range **and** maximum retry count, preventing unintended behavior.  

Fix: #(7594)

### Does this PR introduce _any_ user-facing change?
No user-facing changes.

### How was this patch tested?
The loop logic was manually verified and no unit tests were added.
