### PR TITLE
[#7593] Renamed wildcardSearchPolies to wildcardSearchPolicies

### DIFF
--- a/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/RangerAuthorizationHDFSPlugin.java
+++ b/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/RangerAuthorizationHDFSPlugin.java
@@ -158,7 +158,7 @@ public class RangerAuthorizationHDFSPlugin extends RangerAuthorizationPlugin {
 
   @Override
   /** Wildcard search the Ranger policies in the different Ranger service. */
-  protected List<RangerPolicy> wildcardSearchPolies(
+  protected List<RangerPolicy> wildcardSearchPolicies(
       AuthorizationMetadataObject authzMetadataObject) {
     Preconditions.checkArgument(authzMetadataObject instanceof PathBasedMetadataObject);
     PathBasedMetadataObject pathBasedMetadataObject = (PathBasedMetadataObject) authzMetadataObject;
@@ -205,8 +205,8 @@ public class RangerAuthorizationHDFSPlugin extends RangerAuthorizationPlugin {
       MetadataObject.Type operationType,
       AuthorizationMetadataObject oldAuthzMetaObject,
       AuthorizationMetadataObject newAuthzMetaObject) {
-    List<RangerPolicy> oldPolicies = wildcardSearchPolies(oldAuthzMetaObject);
-    List<RangerPolicy> existNewPolicies = wildcardSearchPolies(newAuthzMetaObject);
+    List<RangerPolicy> oldPolicies = wildcardSearchPolicies(oldAuthzMetaObject);
+    List<RangerPolicy> existNewPolicies = wildcardSearchPolicies(newAuthzMetaObject);
     if (oldPolicies.isEmpty()) {
       LOG.warn("Cannot find the Ranger policy for the metadata object({})!", oldAuthzMetaObject);
       return;

--- a/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/RangerAuthorizationHadoopSQLPlugin.java
+++ b/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/RangerAuthorizationHadoopSQLPlugin.java
@@ -108,7 +108,7 @@ public class RangerAuthorizationHadoopSQLPlugin extends RangerAuthorizationPlugi
 
   /** Wildcard search the Ranger policies in the different Ranger service. */
   @Override
-  protected List<RangerPolicy> wildcardSearchPolies(
+  protected List<RangerPolicy> wildcardSearchPolicies(
       AuthorizationMetadataObject authzMetadataObject) {
     List<String> resourceDefines = policyResourceDefinesRule();
     Map<String, String> searchFilters = new HashMap<>();
@@ -199,8 +199,8 @@ public class RangerAuthorizationHadoopSQLPlugin extends RangerAuthorizationPlugi
       MetadataObject.Type operationType,
       AuthorizationMetadataObject oldAuthzMetaObject,
       AuthorizationMetadataObject newAuthzMetaObject) {
-    List<RangerPolicy> oldPolicies = wildcardSearchPolies(oldAuthzMetaObject);
-    List<RangerPolicy> existNewPolicies = wildcardSearchPolies(newAuthzMetaObject);
+    List<RangerPolicy> oldPolicies = wildcardSearchPolicies(oldAuthzMetaObject);
+    List<RangerPolicy> existNewPolicies = wildcardSearchPolicies(newAuthzMetaObject);
     if (oldPolicies.isEmpty()) {
       LOG.warn("Cannot find the Ranger policy for the metadata object({})!", oldAuthzMetaObject);
       return;

--- a/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/RangerAuthorizationPlugin.java
+++ b/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/RangerAuthorizationPlugin.java
@@ -163,7 +163,7 @@ public abstract class RangerAuthorizationPlugin
    * @param authzMetadataObject The authorization metadata object used to perform wildcard search.
    * @return A list of Ranger policies matching the wildcard conditions.
    */
-  protected abstract List<RangerPolicy> wildcardSearchPolies(
+  protected abstract List<RangerPolicy> wildcardSearchPolicies(
       AuthorizationMetadataObject authzMetadataObject);
 
   /**
@@ -196,7 +196,7 @@ public abstract class RangerAuthorizationPlugin
   protected RangerPolicy preciseFindPolicy(
       AuthorizationMetadataObject authzMetadataObject, Map<String, String> preciseFilters)
       throws AuthorizationPluginException {
-    List<RangerPolicy> policies = wildcardSearchPolies(authzMetadataObject);
+    List<RangerPolicy> policies = wildcardSearchPolicies(authzMetadataObject);
     if (!policies.isEmpty()) {
       policies =
           policies.stream()


### PR DESCRIPTION
### What changes were proposed in this pull request?

This pull request changes the wildcardSearchPolies method's name to wildcardSearchPolicies, serving as a minor spelling fix

### Why are the changes needed?

Fix: #7593 
