### PR TITLE
[#7597] fix: fix EntityType short name duplicate issue

### DIFF
--- a/core/src/main/java/org/apache/gravitino/Entity.java
+++ b/core/src/main/java/org/apache/gravitino/Entity.java
@@ -61,40 +61,21 @@ public interface Entity extends Serializable {
   /** Enumeration defining the types of entities in the Gravitino framework. */
   @Getter
   enum EntityType {
-    METALAKE("ml", 0),
-    CATALOG("ca", 1),
-    SCHEMA("sc", 2),
-    TABLE("ta", 3),
-    COLUMN("co", 4),
-    FILESET("fi", 5),
-    TOPIC("to", 6),
-    USER("us", 7),
-    GROUP("gr", 8),
-    ROLE("ro", 9),
-    TAG("ta", 10),
-    MODEL("mo", 11),
-    MODEL_VERSION("mv", 12),
-    POLICY("po", 13),
-
-    AUDIT("au", 65534);
-
-    // Short name can be used to identify the entity type in the logs, persistent storage, etc.
-    private final String shortName;
-    private final int index;
-
-    EntityType(String shortName, int index) {
-      this.shortName = shortName;
-      this.index = index;
-    }
-
-    public static EntityType fromShortName(String shortName) {
-      for (EntityType entityType : EntityType.values()) {
-        if (entityType.shortName.equals(shortName)) {
-          return entityType;
-        }
-      }
-      throw new IllegalArgumentException("Unknown entity type: " + shortName);
-    }
+    METALAKE,
+    CATALOG,
+    SCHEMA,
+    TABLE,
+    COLUMN,
+    FILESET,
+    TOPIC,
+    USER,
+    GROUP,
+    ROLE,
+    TAG,
+    MODEL,
+    MODEL_VERSION,
+    POLICY,
+    AUDIT;
 
     /**
      * Returns the parent entity types of the given entity type. The parent entity types are the

--- a/core/src/main/java/org/apache/gravitino/cache/EntityCacheKey.java
+++ b/core/src/main/java/org/apache/gravitino/cache/EntityCacheKey.java
@@ -138,7 +138,7 @@ public class EntityCacheKey {
    */
   @Override
   public String toString() {
-    String stringExpr = identifier.toString() + ":" + type.getShortName();
+    String stringExpr = identifier.toString() + ":" + type.toString();
     if (relationType != null) {
       stringExpr += ":" + relationType.name();
     }

--- a/core/src/test/java/org/apache/gravitino/cache/TestEntityCacheKey.java
+++ b/core/src/test/java/org/apache/gravitino/cache/TestEntityCacheKey.java
@@ -35,7 +35,7 @@ public class TestEntityCacheKey {
     EntityCacheKey key =
         EntityCacheKey.of(
             ident, Entity.EntityType.ROLE, SupportsRelationOperations.Type.ROLE_GROUP_REL);
-    Assertions.assertEquals("metalake.system.role.role1:ro:ROLE_GROUP_REL", key.toString());
+    Assertions.assertEquals("metalake.system.role.role1:ROLE:ROLE_GROUP_REL", key.toString());
     Assertions.assertEquals(
         NameIdentifier.of("metalake", "system", "role", "role1"), key.identifier());
     Assertions.assertEquals(Entity.EntityType.ROLE, key.entityType());
@@ -43,7 +43,7 @@ public class TestEntityCacheKey {
 
     // test Store Entity
     EntityCacheKey key2 = EntityCacheKey.of(ident, Entity.EntityType.ROLE, null);
-    Assertions.assertEquals("metalake.system.role.role1:ro", key2.toString());
+    Assertions.assertEquals("metalake.system.role.role1:ROLE", key2.toString());
     Assertions.assertEquals(
         NameIdentifier.of("metalake", "system", "role", "role1"), key2.identifier());
     Assertions.assertEquals(Entity.EntityType.ROLE, key2.entityType());
@@ -137,7 +137,7 @@ public class TestEntityCacheKey {
 
     EntityCacheKey key = EntityCacheKey.of(ident, type);
 
-    Assertions.assertEquals("metalake.system.user.user1:us", key.toString());
+    Assertions.assertEquals("metalake.system.user.user1:USER", key.toString());
   }
 
   @Test
@@ -148,6 +148,6 @@ public class TestEntityCacheKey {
 
     EntityCacheKey key = EntityCacheKey.of(ident, type, relationType);
 
-    Assertions.assertEquals("metalake.system.user.user1:us:ROLE_USER_REL", key.toString());
+    Assertions.assertEquals("metalake.system.user.user1:USER:ROLE_USER_REL", key.toString());
   }
 }


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

The `EntityType ` class has short name variable, but it's duplicated.  Table and Tag both used `ta`. 
And the short name is not used anymore.
This pr is try to clean up related code.


### Why are the changes needed?


Fix: #7597
### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Use existing tests.

