### PR TITLE
[#7589] fix (clients): check null before adding request headers in HTTPClient

### DIFF
--- a/clients/client-java/src/main/java/org/apache/gravitino/client/HTTPClient.java
+++ b/clients/client-java/src/main/java/org/apache/gravitino/client/HTTPClient.java
@@ -673,7 +673,9 @@ public class HTTPClient implements RESTClient {
     // avoid failures.
     request.setHeader(HttpHeaders.CONTENT_TYPE, bodyMimeType);
     request.setHeader(HttpHeaders.ACCEPT, VERSION_HEADER);
-    requestHeaders.forEach(request::setHeader);
+    if (requestHeaders != null) {
+      requestHeaders.forEach(request::setHeader);
+    }
   }
 
   /**

--- a/clients/client-java/src/test/java/org/apache/gravitino/client/TestHTTPClient.java
+++ b/clients/client-java/src/test/java/org/apache/gravitino/client/TestHTTPClient.java
@@ -137,8 +137,8 @@ public class TestHTTPClient {
 
     String path = addRequestTestCaseAndGetPath(Method.GET, body, statusCode, false, true);
 
-    Item response = restClient.get(path, null, Item.class, null, onError);
-    
+    Item response = restClient.get(path, Item.class, (Map<String, String>) null, onError);
+
     Assertions.assertEquals(body, response);
     verify(onError, never()).accept(any());
   }

--- a/clients/client-java/src/test/java/org/apache/gravitino/client/TestHTTPClient.java
+++ b/clients/client-java/src/test/java/org/apache/gravitino/client/TestHTTPClient.java
@@ -127,6 +127,22 @@ public class TestHTTPClient {
     testHttpMethodOnFailure(Method.HEAD, false, false);
   }
 
+  @Test
+  public void testNullHeadersDoNotCauseNPE() throws Exception {
+    Item body = new Item(0L, "test");
+    int statusCode = 200;
+
+    ErrorHandler onError = mock(ErrorHandler.class);
+    doThrow(new RuntimeException("Failure response")).when(onError).accept(any());
+
+    String path = addRequestTestCaseAndGetPath(Method.GET, body, statusCode, false, true);
+
+    Item response = restClient.get(path, null, Item.class, null, onError);
+    
+    Assertions.assertEquals(body, response);
+    verify(onError, never()).accept(any());
+  }
+
   public static void testHttpMethodOnSuccess(
       Method method, boolean hasRequestBody, boolean hasResponseBody)
       throws JsonProcessingException {

--- a/clients/client-java/src/test/java/org/apache/gravitino/client/TestHTTPClient.java
+++ b/clients/client-java/src/test/java/org/apache/gravitino/client/TestHTTPClient.java
@@ -129,7 +129,7 @@ public class TestHTTPClient {
 
   @Test
   public void testNullHeadersDoNotCauseNPE() throws Exception {
-    Item body = new Item(0L, "test");
+    Item body = new Item(0L, "hank");
     int statusCode = 200;
 
     ErrorHandler onError = mock(ErrorHandler.class);


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Added a null check for empty headers before adding request headers in HTTPClient.

Closes: [#7589](https://github.com/apache/gravitino/issues/7589)

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Added a unit test.
