### PR TITLE
removed extra bin/bash line

### DIFF
--- a/trino-connector/integration-test/trino-test-tools/download_jar.sh
+++ b/trino-connector/integration-test/trino-test-tools/download_jar.sh
@@ -18,7 +18,6 @@
 # under the License.
 
 set -e
-#!/bin/bash
 
 # Function to download a JAR file if it does not already exist
 download_jar() {


### PR DESCRIPTION
# What changes were proposed in this pull request?

This pull request removes extra #!/bin/bash line from the trino-connector/integration-test/trino-test-tools/download_jar.sh file.

Closes #7587 

