### PR TITLE
[#7639] improvement(cli): remove duplicate owner in CLI

### DIFF
--- a/clients/cli/src/main/java/org/apache/gravitino/cli/GravitinoOptions.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/GravitinoOptions.java
@@ -119,7 +119,6 @@ public class GravitinoOptions {
     options.addOption(createArgOption(NULL, "column value can be null (true/false)"));
     options.addOption(createArgOption(AUTO, "column value auto-increments (true/false)"));
     options.addOption(createArgOption(DEFAULT, "default column value"));
-    options.addOption(createSimpleOption("o", OWNER, "display entity owner"));
     options.addOption(createArgOption(COLUMNFILE, "CSV file describing columns"));
     options.addOption(createSimpleOption(null, ALL, "on all entities"));
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes the removal of duplicated code that appears twice in the CLI module.

### Why are the changes needed?

Fix: #7639 

### Does this PR introduce _any_ user-facing change?

None

### How was this patch tested?

I verified this patch by reviewing and running the existing test clinets:cli 
