### PR TITLE
[#7641] improvement(api): Missing @Override annotation to the hashCode method of SparkJobTemplate

### DIFF
--- a/api/src/main/java/org/apache/gravitino/job/SparkJobTemplate.java
+++ b/api/src/main/java/org/apache/gravitino/job/SparkJobTemplate.java
@@ -121,6 +121,7 @@ public class SparkJobTemplate extends JobTemplate {
         && Objects.equals(configs, that.configs);
   }
 
+  @Override
   public int hashCode() {
     return Objects.hash(super.hashCode(), className, jars, files, archives, configs);
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Added Missing @Override annotation

### Why are the changes needed?

Fix: #7641 

### Does this PR introduce _any_ user-facing change?

None

### How was this patch tested?

Execute existing api module test 
