### PR TITLE
[#7585] feat: add DB name validation to secure DB creation

### DIFF
--- a/integration-test-common/src/test/java/org/apache/gravitino/integration/test/container/MySQLContainer.java
+++ b/integration-test-common/src/test/java/org/apache/gravitino/integration/test/container/MySQLContainer.java
@@ -132,13 +132,31 @@ public class MySQLContainer extends BaseContainer {
             DriverManager.getConnection(mySQLJdbcUrl, USER_NAME, getPassword());
         Statement statement = connection.createStatement()) {
 
-      String query = String.format("CREATE DATABASE IF NOT EXISTS %s;", testDatabaseName);
+      // validate database name to ensure it only contains safe characters
+      String databaseName = testDatabaseName.toString();
+      if (!isValidDatabaseName(databaseName)) {
+        throw new IllegalArgumentException("Invalid database name: " + databaseName);
+      }
+
+      String query = String.format("CREATE DATABASE IF NOT EXISTS `%s`;", databaseName);
       // FIXME: String, which is used in SQL, can be unsafe
       statement.execute(query);
       LOG.info(String.format("MySQL container database %s has been created", testDatabaseName));
     } catch (Exception e) {
       throw new RuntimeException("Failed to create database", e);
     }
+  }
+
+  private boolean isValidDatabaseName(String databaseName) {
+    if (databaseName == null || databaseName.isEmpty()) {
+      return false;
+    }
+
+    if (databaseName.length() > 64) {
+      return false;
+    }
+
+    return databaseName.matches("^[a-zA-Z0-9_$]+$");
   }
 
   public String getUsername() {


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?
Added DB name validation to the createDatabase method to secure DB creation.

Fix: #7585 

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Tested with unit tests to validate if invalid names are rejected and the names in the TestDatabaseName enum are accepted
