### PR TITLE
[#7632] reuse dataOperation in Utils

### DIFF
--- a/server-common/src/main/java/org/apache/gravitino/server/web/Utils.java
+++ b/server-common/src/main/java/org/apache/gravitino/server/web/Utils.java
@@ -213,8 +213,7 @@ public class Utils {
 
     String dataOperation =
         httpRequest.getHeader(FilesetAuditConstants.HTTP_HEADER_FILESET_DATA_OPERATION);
-    if (StringUtils.isNotBlank(
-        httpRequest.getHeader(FilesetAuditConstants.HTTP_HEADER_FILESET_DATA_OPERATION))) {
+    if (StringUtils.isNotBlank(dataOperation)) {
       filteredHeaders.put(
           FilesetAuditConstants.HTTP_HEADER_FILESET_DATA_OPERATION,
           FilesetDataOperation.checkValid(dataOperation)


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Replace the second usage of `httpRequest.getHeader(FilesetAuditConstants.HTTP_HEADER_FILESET_DATA_OPERATION)` with `dataOperation` which was previously defined.

### Why are the changes needed?

Cleaner and less code.
Fix: #7632 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing tests.
