### PR TITLE
[#7635] add extra preconditions to Namespace

### DIFF
--- a/api/src/main/java/org/apache/gravitino/Namespace.java
+++ b/api/src/main/java/org/apache/gravitino/Namespace.java
@@ -76,6 +76,10 @@ public class Namespace {
   public static Namespace fromString(String namespace) {
     Preconditions.checkArgument(namespace != null, "Cannot create a namespace with null input");
     Preconditions.checkArgument(!namespace.endsWith("."), "Cannot create a namespace end with dot");
+    Preconditions.checkArgument(
+        !namespace.startsWith("."), "Cannot create a namespace starting with a dot");
+    Preconditions.checkArgument(
+        !namespace.contains(".."), "Cannot create a namespace with an empty level");
     if (StringUtils.isBlank(namespace)) {
       return empty();
     }


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Added 2 more precondition checks to `Namespace`:
1. leading single dot 
2. contains double dot

### Why are the changes needed?

To enforce a stricter namespace validation.
Fix: #7635 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing tests.
