### PR TITLE
[#7640] add missing validate call to build method in SparkJobTemplate

### DIFF
--- a/api/src/main/java/org/apache/gravitino/job/SparkJobTemplate.java
+++ b/api/src/main/java/org/apache/gravitino/job/SparkJobTemplate.java
@@ -240,6 +240,7 @@ public class SparkJobTemplate extends JobTemplate {
      */
     @Override
     public SparkJobTemplate build() {
+      validate();
       return new SparkJobTemplate(this);
     }
 


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Add a call of the existing `validation` method before object construction in `build`.

### Why are the changes needed?

`validate` method exists with proper validation logic but is never called during object construction.
Fix: #7640

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing tests.