### PR TITLE
[#7636] add null check to BaseEntityCache validation

### DIFF
--- a/core/src/main/java/org/apache/gravitino/cache/BaseEntityCache.java
+++ b/core/src/main/java/org/apache/gravitino/cache/BaseEntityCache.java
@@ -64,6 +64,7 @@ public abstract class BaseEntityCache implements EntityCache {
    * @param entity The {@link Entity} instance to check.
    */
   protected static void validateEntityHasIdentifier(Entity entity) {
+    Preconditions.checkArgument(entity != null, "Entity cannot be null");
     Preconditions.checkArgument(
         entity instanceof HasIdentifier, "Unsupported EntityType: " + entity.type());
   }


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Add a null check before entity type check.

### Why are the changes needed?

Previously, `validateEntityHasIdentifier` only validates the entity type but doesn't check if the entity is null before accessing its properties, which may cause misleading error messages.
Fix: #7636

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing tests.
