### PR TITLE
[#7664] remove duplicate MODEL in CommandEntities.java

### DIFF
--- a/clients/cli/src/main/java/org/apache/gravitino/cli/CommandEntities.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/CommandEntities.java
@@ -54,7 +54,6 @@ public class CommandEntities {
     VALID_ENTITIES.add(TOPIC);
     VALID_ENTITIES.add(FILESET);
     VALID_ENTITIES.add(ROLE);
-    VALID_ENTITIES.add(MODEL);
   }
 
   /**


### PR DESCRIPTION

## [#7664] <fix> remove duplicate MODEL in CommandEntities.java

### What changes were proposed in this pull request?

remove duplicate MODEL in CommandEntities.java

### Why are the changes needed?

The VALID_ENTITIES set previously contained two entries for 'MODEL'. 

Fix: #7664

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?
Since the removal only affects the internal entity registration logic and does not impact any user-facing behavior or API, no additional tests were required.
