### PR TITLE
[#7584] improvement: Add rollback logic to the in-memory test store

### DIFF
--- a/core/src/test/java/org/apache/gravitino/storage/memory/TestMemoryEntityStore.java
+++ b/core/src/test/java/org/apache/gravitino/storage/memory/TestMemoryEntityStore.java
@@ -155,8 +155,8 @@ public class TestMemoryEntityStore {
     public <R, E extends Exception> R executeInTransaction(Executable<R, E> executable)
         throws E, IOException {
       Map<NameIdentifier, Entity> snapshot = createSnapshot();
+      lock.lock();
       try {
-        lock.lock();
         return executable.execute();
       } catch (Exception e) {
         if (snapshot != null) {
@@ -176,8 +176,8 @@ public class TestMemoryEntityStore {
     }
 
     public Map<NameIdentifier, Entity> createSnapshot() {
+      lock.lock();
       try {
-        lock.lock();
         return entityMap.entrySet().stream()
             .collect(
                 Collectors.toMap(

--- a/core/src/test/java/org/apache/gravitino/storage/memory/TestMemoryEntityStore.java
+++ b/core/src/test/java/org/apache/gravitino/storage/memory/TestMemoryEntityStore.java
@@ -154,9 +154,17 @@ public class TestMemoryEntityStore {
     @Override
     public <R, E extends Exception> R executeInTransaction(Executable<R, E> executable)
         throws E, IOException {
+      Map<NameIdentifier, Entity> snapshot = createSnapshot();
       try {
         lock.lock();
         return executable.execute();
+      } catch (Exception e) {
+        if (snapshot != null) {
+          // restore the entityMap in case of failed transactions
+          entityMap.clear();
+          entityMap.putAll(snapshot);
+        }
+        throw e;
       } finally {
         lock.unlock();
       }
@@ -165,6 +173,20 @@ public class TestMemoryEntityStore {
     @Override
     public void close() throws IOException {
       entityMap.clear();
+    }
+
+    public Map<NameIdentifier, Entity> createSnapshot() {
+      try {
+        lock.lock();
+        return entityMap.entrySet().stream()
+            .collect(
+                Collectors.toMap(
+                    Map.Entry::getKey, Map.Entry::getValue, (e1, e2) -> e1, Maps::newHashMap));
+      } catch (Exception e) {
+        throw new RuntimeException("Failed to create snapshot of entity store", e);
+      } finally {
+        lock.unlock();
+      }
     }
   }
 


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Add rollback logic to the in-memory test store. A snapshot will be created during transaction execution and will be restored if an exception occurs

### Why are the changes needed?

Fix: #7584 

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?

Tested with unit tests for rollback logic
