### PR TITLE
[#7634] Improvement: Add null filter to ConfigEntry seqToStr method

### DIFF
--- a/core/src/main/java/org/apache/gravitino/config/ConfigEntry.java
+++ b/core/src/main/java/org/apache/gravitino/config/ConfigEntry.java
@@ -18,11 +18,7 @@
  */
 package org.apache.gravitino.config;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.NoSuchElementException;
-import java.util.Optional;
+import java.util.*;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -172,9 +168,9 @@ public class ConfigEntry<T> {
    * @return The converted string.
    */
   public String seqToStr(List<T> seq, Function<T, String> converter) {
-    List<String> valList = seq.stream().map(converter).collect(Collectors.toList());
-    String str = String.join(",", valList);
-    return str;
+    List<String> valList =
+        seq.stream().filter(Objects::nonNull).map(converter).collect(Collectors.toList());
+    return String.join(",", valList);
   }
 
   /**

--- a/core/src/test/java/org/apache/gravitino/config/TestConfigEntryList.java
+++ b/core/src/test/java/org/apache/gravitino/config/TestConfigEntryList.java
@@ -163,13 +163,13 @@ public class TestConfigEntryList {
   @Test
   public void testSeqToStrWithNullElement() {
     ConfigEntry<List<Integer>> testConf =
-            new ConfigBuilder("gravitino.seq.null")
-                    .intConf()
-                    .toSequence()
-                    .createWithDefault(Lists.newArrayList());
+        new ConfigBuilder("gravitino.seq.null")
+            .intConf()
+            .toSequence()
+            .createWithDefault(Lists.newArrayList());
 
     Assertions.assertDoesNotThrow(
-            () -> testConf.writeTo(configMapEmpty, Lists.newArrayList(1, null, 2)));
+        () -> testConf.writeTo(configMapEmpty, Lists.newArrayList(1, null, 2)));
     Assertions.assertEquals("1,2", configMapEmpty.get("gravitino.seq.null"));
   }
 }

--- a/core/src/test/java/org/apache/gravitino/config/TestConfigEntryList.java
+++ b/core/src/test/java/org/apache/gravitino/config/TestConfigEntryList.java
@@ -159,4 +159,17 @@ public class TestConfigEntryList {
     Assertions.assertThrows(
         IllegalArgumentException.class, () -> testConfWithoutDefault.readFrom(configMap));
   }
+
+  @Test
+  public void testSeqToStrWithNullElement() {
+    ConfigEntry<List<Integer>> testConf =
+            new ConfigBuilder("gravitino.seq.null")
+                    .intConf()
+                    .toSequence()
+                    .createWithDefault(Lists.newArrayList());
+
+    Assertions.assertDoesNotThrow(
+            () -> testConf.writeTo(configMapEmpty, Lists.newArrayList(1, null, 2)));
+    Assertions.assertEquals("1,2", configMapEmpty.get("gravitino.seq.null"));
+  }
 }


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Add null filter to ConfigEntry seqToStr method

### Why are the changes needed?

Fix: #7634

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Added a unit test
