### PR TITLE
Use Path + Files.newInputStream with try-with-resources in GCSTokenProvider

### DIFF
--- a/bundles/gcp/src/main/java/org/apache/gravitino/gcs/credential/GCSTokenProvider.java
+++ b/bundles/gcp/src/main/java/org/apache/gravitino/gcs/credential/GCSTokenProvider.java
@@ -26,10 +26,13 @@ import com.google.auth.oauth2.DownscopedCredentials;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
-import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -261,12 +264,12 @@ public class GCSTokenProvider implements CredentialProvider {
     String gcsCredentialFilePath = gcsCredentialConfig.gcsCredentialFilePath();
     if (StringUtils.isBlank(gcsCredentialFilePath)) {
       return GoogleCredentials.getApplicationDefault();
-    } else {
-      File credentialsFile = new File(gcsCredentialFilePath);
-      if (!credentialsFile.exists()) {
-        throw new IOException("GCS credential file does not exist." + gcsCredentialFilePath);
-      }
-      return GoogleCredentials.fromStream(new FileInputStream(credentialsFile));
+    }
+    Path credentialsFilePath = Paths.get(gcsCredentialFilePath);
+    try (InputStream fileInputStream = Files.newInputStream(credentialsFilePath)) {
+      return GoogleCredentials.fromStream(fileInputStream);
+    } catch (NoSuchFileException e) {
+      throw new IOException("GCS credential file does not exist." + gcsCredentialFilePath, e);
     }
   }
 }


### PR DESCRIPTION

## Title: [#7682] Use Path + Files.newInputStream in GCSTokenProvider

### What changes were proposed in this pull request?

- Replaced legacy I/O with NIO

  - java.io.File / FileInputStream → java.nio.file.Path / Files.newInputStream

- Introduced try‑with‑resources to guarantee stream closure.

- Removed redundant exists() check

   -  Eliminates TOCTOU risk, NoSuchFileException is now handled explicitly.

- Add root cause in exception message.

### Why are the changes needed?

- Resource‑leak prevention – prior code could leave file descriptors open on exceptions.

- Modern API adoption – java.nio.file provides better link/permission handling and futureproofs the codebase.

- Race‑condition mitigation – removing the pre‑check avoids TOCTOU between exists() and file opening.

Fix: #7682

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

