### PR TITLE
[#7720 ] Display numbers in standard format, avoiding scientific notation.

### DIFF
--- a/.github/workflows/chart-test.yaml
+++ b/.github/workflows/chart-test.yaml
@@ -64,7 +64,7 @@ jobs:
         if: steps.list-changed.outputs.changed == 'true'
         run: |
           helm repo add bitnami https://charts.bitnami.com/bitnami
-          ct lint --chart-dirs=dev/charts --chart-yaml-schema=dev/ci/chart_schema.yaml --lint-conf=dev/ci/lintconf.yaml --target-branch ${{ github.event.pull_request.base.ref }} 
+          ct lint --chart-dirs=dev/charts --chart-yaml-schema=dev/ci/chart_schema.yaml --lint-conf=dev/ci/lintconf.yaml --target-branch ${{ github.event.pull_request.base.ref }} --check-version-increment=false
 
       - name: Set up kind cluster
         if: steps.list-changed.outputs.changed == 'true'

--- a/dev/charts/gravitino/resources/config/gravitino.conf
+++ b/dev/charts/gravitino/resources/config/gravitino.conf
@@ -55,7 +55,7 @@ gravitino.catalog.cache.evictionIntervalMs = {{ if .Values.catalog.evictionInter
 # THE CONFIGURATION FOR Gravitino Entity Cache
 gravitino.cache.enabled = {{ .Values.cache.enabled | default true }}
 gravitino.cache.maxEntries = {{ .Values.cache.maxEntries | default 10000 }}
-gravitino.cache.expireTimeInMs = {{ .Values.cache.expireTimeInMs | default 3600000 }}
+gravitino.cache.expireTimeInMs = {{ (.Values.cache.expireTimeInMs | default 3600000) | int }}
 gravitino.cache.enableStats = {{ .Values.cache.enableStats | default false }}
 gravitino.cache.enableWeigher = {{ .Values.cache.enableWeigher | default true }}
 gravitino.cache.implementation = {{ .Values.cache.implementation | default "caffeine" }}

--- a/docs/security/how-to-authenticate.md
+++ b/docs/security/how-to-authenticate.md
@@ -210,7 +210,7 @@ docker run -dti -p 8080:8080 -e KC_BOOTSTRAP_ADMIN_USERNAME=admin -e KC_BOOTSTRA
 5. Add users
 
     Initially, the realm has no users. Use these steps to create a user:
-   * Verify that you are still in the gravitinorealm realm, which is next to Current realm.
+   * Verify that you are still in the gravitinorealm realm, which is next to *Current realm*.
    * Click Users in the left-hand menu.
    * Click *Create new user*.
    * Fill in the form with the following values:  


### PR DESCRIPTION
### What changes were proposed in this pull request?

1. Gravitino start failed if launched by chart. It caused by wrong number format in conf 
```
# THE CONFIGURATION FOR Gravitino Entity Cache
gravitino.cache.enabled = true
gravitino.cache.maxEntries = 10000
gravitino.cache.expireTimeInMs = 3.6e+06
gravitino.cache.enableStats = false
gravitino.cache.enableWeigher = true
gravitino.cache.implementation = caffeine
```
2. Skip ' --check-version-increment' , because it makes no sense if this chart doesn't release to public artifactory automatically. BTW check version increment is not convenient during the Gravitino release period

### Why are the changes needed?

Fix: #7720 

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

CI