### PR TITLE
[7538] feat(OAuth) : Adding configs for Azure OAuth login

### DIFF
--- a/common/src/main/java/org/apache/gravitino/auth/ProviderType.java
+++ b/common/src/main/java/org/apache/gravitino/auth/ProviderType.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.auth;
+
+/** The type of OAuth provider. */
+public enum ProviderType {
+  /** Default provider. */
+  DEFAULT,
+  /** Azure AD provider. */
+  AZURE
+}

--- a/dev/charts/gravitino/resources/config/gravitino.conf
+++ b/dev/charts/gravitino/resources/config/gravitino.conf
@@ -69,6 +69,17 @@ gravitino.authenticator.oauth.defaultSignKey = {{ .Values.authenticator.oauth.de
 gravitino.authenticator.oauth.serverUri = {{ .Values.authenticator.oauth.serverUri }}
 gravitino.authenticator.oauth.tokenPath = {{ .Values.authenticator.oauth.tokenPath }}
 
+gravitino.authenticator.oauth.provider = {{ .Values.authenticator.oauth.provider }}
+# Generic OAuth provider configs
+{{- if .Values.authenticator.oauth.provider }}
+gravitino.authenticator.oauth.client-id = {{ .Values.authenticator.oauth.clientId }}
+gravitino.authenticator.oauth.authority = {{ .Values.authenticator.oauth.authority }}
+gravitino.authenticator.oauth.scope = {{ .Values.authenticator.oauth.scope }}
+{{- if .Values.authenticator.oauth.jwksUri }}
+gravitino.authenticator.oauth.jwks-uri = {{ .Values.authenticator.oauth.jwksUri }}
+{{- end }}
+{{- end }}
+
 # THE CONFIGURATION FOR AUXILIARY SERVICE
 gravitino.auxService.names = {{ .Values.auxService.names | default "iceberg-rest" }}
 gravitino.iceberg-rest.classpath = {{ .Values.icebergRest.classpath | default "iceberg-rest-server/libs, iceberg-rest-server/conf"  }}

--- a/server-common/src/main/java/org/apache/gravitino/server/authentication/OAuthConfig.java
+++ b/server-common/src/main/java/org/apache/gravitino/server/authentication/OAuthConfig.java
@@ -73,4 +73,40 @@ public interface OAuthConfig {
           .stringConf()
           .checkValue(StringUtils::isNotBlank, ConfigConstants.NOT_BLANK_ERROR_MSG)
           .create();
+
+  // OAuth provider configs
+  ConfigEntry<String> PROVIDER =
+      new ConfigBuilder(OAUTH_CONFIG_PREFIX + "provider")
+          .doc("The OAuth provider to use (e.g., azure)")
+          .version(ConfigConstants.VERSION_1_0_0)
+          .stringConf()
+          .create();
+
+  ConfigEntry<String> CLIENT_ID =
+      new ConfigBuilder(OAUTH_CONFIG_PREFIX + "client-id")
+          .doc("OAuth client ID used for Web UI authentication")
+          .version(ConfigConstants.VERSION_1_0_0)
+          .stringConf()
+          .create();
+
+  ConfigEntry<String> AUTHORITY =
+      new ConfigBuilder(OAUTH_CONFIG_PREFIX + "authority")
+          .doc("OAuth authority URL (authorization server)")
+          .version(ConfigConstants.VERSION_1_0_0)
+          .stringConf()
+          .create();
+
+  ConfigEntry<String> SCOPE =
+      new ConfigBuilder(OAUTH_CONFIG_PREFIX + "scope")
+          .doc("OAuth scopes (space-separated)")
+          .version(ConfigConstants.VERSION_1_0_0)
+          .stringConf()
+          .create();
+
+  ConfigEntry<String> JWKS_URI =
+      new ConfigBuilder(OAUTH_CONFIG_PREFIX + "jwks-uri")
+          .doc("JWKS URI for token validation")
+          .version(ConfigConstants.VERSION_1_0_0)
+          .stringConf()
+          .create();
 }

--- a/server/src/main/java/org/apache/gravitino/server/web/ConfigServlet.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/ConfigServlet.java
@@ -40,7 +40,13 @@ public class ConfigServlet extends HttpServlet {
   private static final Logger LOG = LoggerFactory.getLogger(ConfigServlet.class);
 
   private static final ImmutableSet<ConfigEntry<?>> oauthConfigEntries =
-      ImmutableSet.of(OAuthConfig.DEFAULT_SERVER_URI, OAuthConfig.DEFAULT_TOKEN_PATH);
+      ImmutableSet.of(
+          OAuthConfig.DEFAULT_SERVER_URI,
+          OAuthConfig.DEFAULT_TOKEN_PATH,
+          OAuthConfig.PROVIDER,
+          OAuthConfig.CLIENT_ID,
+          OAuthConfig.AUTHORITY,
+          OAuthConfig.SCOPE);
 
   private static final ImmutableSet<ConfigEntry<?>> basicConfigEntries =
       ImmutableSet.of(Configs.AUTHENTICATORS, Configs.ENABLE_AUTHORIZATION);


### PR DESCRIPTION
### What changes were proposed in this pull request?

Adding configs required for Azure based oAuth login
These will not cause any problems with the current oAuth as these are just additional configs exposed in /configs endpoint

### Why are the changes needed?

These changes will be used in future PRs for Azure MSAL based oAuth support in the front end code, through /configs endpoint

Fix: #7538 

### Does this PR introduce _any_ user-facing change?

This does not introduce user facing changes. Only changing the /configs API response for now

### How was this patch tested?

(Please test your changes, and provide instructions on how to test it:
Tested in local deployment.
Enabled Azure oauth by
```
gravitino.authenticators = oauth
gravitino.authenticator.oauth.provider = azure
```
and set
gravitino.authenticator.oauth.azure.client-id , gravitino.authenticator.oauth.azure.authority, gravitino.authenticator.oauth.azure.redirect-uri, gravitino.authenticator.oauth.azure.jwks-uri, gravitino.authenticator.oauth.azure.scope

along with existing oauth required parameters (we can modify this in future to make it such that if provider is set, the current oauth params need not be "required")
Configs endpoint returns:
<img width="1135" height="282" alt="Screenshot 2025-07-22 at 12 05 23 PM" src="https://github.com/user-attachments/assets/f0801088-5330-4e64-b2e3-ff9ad7bc02a3" />


