### PR TITLE
[cherry-pick][#7557] feat(iceberg): get user from HTTP request for Iceberg REST server (#7626)

### DIFF
--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/IcebergExceptionMapper.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/IcebergExceptionMapper.java
@@ -73,6 +73,10 @@ public class IcebergExceptionMapper implements ExceptionMapper<Exception> {
 
   @Override
   public Response toResponse(Exception ex) {
+    return toRESTResponse(ex);
+  }
+
+  public static Response toRESTResponse(Exception ex) {
     int status =
         EXCEPTION_ERROR_CODES.getOrDefault(
             ex.getClass(), Status.INTERNAL_SERVER_ERROR.getStatusCode());

--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/rest/IcebergNamespaceOperations.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/rest/IcebergNamespaceOperations.java
@@ -39,11 +39,13 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import org.apache.gravitino.iceberg.service.IcebergExceptionMapper;
 import org.apache.gravitino.iceberg.service.IcebergObjectMapper;
 import org.apache.gravitino.iceberg.service.IcebergRestUtils;
 import org.apache.gravitino.iceberg.service.dispatcher.IcebergNamespaceOperationDispatcher;
 import org.apache.gravitino.listener.api.event.IcebergRequestContext;
 import org.apache.gravitino.metrics.MetricNames;
+import org.apache.gravitino.server.web.Utils;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.rest.RESTUtil;
 import org.apache.iceberg.rest.requests.CreateNamespaceRequest;
@@ -88,10 +90,19 @@ public class IcebergNamespaceOperations {
         parent.isEmpty() ? Namespace.empty() : RESTUtil.decodeNamespace(parent);
     LOG.info(
         "List Iceberg namespaces, catalog: {}, parentNamespace: {}", catalogName, parentNamespace);
-    IcebergRequestContext context = new IcebergRequestContext(httpServletRequest(), catalogName);
-    ListNamespacesResponse response =
-        namespaceOperationDispatcher.listNamespaces(context, parentNamespace);
-    return IcebergRestUtils.ok(response);
+    try {
+      return Utils.doAs(
+          httpRequest,
+          () -> {
+            IcebergRequestContext context =
+                new IcebergRequestContext(httpServletRequest(), catalogName);
+            ListNamespacesResponse response =
+                namespaceOperationDispatcher.listNamespaces(context, parentNamespace);
+            return IcebergRestUtils.ok(response);
+          });
+    } catch (Exception e) {
+      return IcebergExceptionMapper.toRESTResponse(e);
+    }
   }
 
   @GET
@@ -104,11 +115,19 @@ public class IcebergNamespaceOperations {
     String catalogName = IcebergRestUtils.getCatalogName(prefix);
     Namespace icebergNS = RESTUtil.decodeNamespace(namespace);
     LOG.info("Load Iceberg namespace, catalog: {}, namespace: {}", catalogName, icebergNS);
-
-    IcebergRequestContext context = new IcebergRequestContext(httpServletRequest(), catalogName);
-    GetNamespaceResponse getNamespaceResponse =
-        namespaceOperationDispatcher.loadNamespace(context, icebergNS);
-    return IcebergRestUtils.ok(getNamespaceResponse);
+    try {
+      return Utils.doAs(
+          httpRequest,
+          () -> {
+            IcebergRequestContext context =
+                new IcebergRequestContext(httpServletRequest(), catalogName);
+            GetNamespaceResponse getNamespaceResponse =
+                namespaceOperationDispatcher.loadNamespace(context, icebergNS);
+            return IcebergRestUtils.ok(getNamespaceResponse);
+          });
+    } catch (Exception e) {
+      return IcebergExceptionMapper.toRESTResponse(e);
+    }
   }
 
   @HEAD
@@ -121,13 +140,21 @@ public class IcebergNamespaceOperations {
     String catalogName = IcebergRestUtils.getCatalogName(prefix);
     Namespace icebergNS = RESTUtil.decodeNamespace(namespace);
     LOG.info("Check Iceberg namespace exists, catalog: {}, namespace: {}", catalogName, icebergNS);
-    IcebergRequestContext context = new IcebergRequestContext(httpServletRequest(), catalogName);
-
-    boolean exists = namespaceOperationDispatcher.namespaceExists(context, icebergNS);
-    if (exists) {
-      return IcebergRestUtils.noContent();
-    } else {
-      return IcebergRestUtils.notExists();
+    try {
+      return Utils.doAs(
+          httpRequest,
+          () -> {
+            IcebergRequestContext context =
+                new IcebergRequestContext(httpServletRequest(), catalogName);
+            boolean exists = namespaceOperationDispatcher.namespaceExists(context, icebergNS);
+            if (exists) {
+              return IcebergRestUtils.noContent();
+            } else {
+              return IcebergRestUtils.notExists();
+            }
+          });
+    } catch (Exception e) {
+      return IcebergExceptionMapper.toRESTResponse(e);
     }
   }
 
@@ -142,9 +169,18 @@ public class IcebergNamespaceOperations {
     String catalogName = IcebergRestUtils.getCatalogName(prefix);
     Namespace icebergNS = RESTUtil.decodeNamespace(namespace);
     LOG.info("Drop Iceberg namespace, catalog: {}, namespace: {}", catalogName, icebergNS);
-    IcebergRequestContext context = new IcebergRequestContext(httpServletRequest(), catalogName);
-    namespaceOperationDispatcher.dropNamespace(context, icebergNS);
-    return IcebergRestUtils.noContent();
+    try {
+      return Utils.doAs(
+          httpRequest,
+          () -> {
+            IcebergRequestContext context =
+                new IcebergRequestContext(httpServletRequest(), catalogName);
+            namespaceOperationDispatcher.dropNamespace(context, icebergNS);
+            return IcebergRestUtils.noContent();
+          });
+    } catch (Exception e) {
+      return IcebergExceptionMapper.toRESTResponse(e);
+    }
   }
 
   @POST
@@ -158,10 +194,19 @@ public class IcebergNamespaceOperations {
         "Create Iceberg namespace, catalog: {}, createNamespaceRequest: {}",
         catalogName,
         createNamespaceRequest);
-    IcebergRequestContext context = new IcebergRequestContext(httpServletRequest(), catalogName);
-    CreateNamespaceResponse createNamespaceResponse =
-        namespaceOperationDispatcher.createNamespace(context, createNamespaceRequest);
-    return IcebergRestUtils.ok(createNamespaceResponse);
+    try {
+      return Utils.doAs(
+          httpRequest,
+          () -> {
+            IcebergRequestContext context =
+                new IcebergRequestContext(httpServletRequest(), catalogName);
+            CreateNamespaceResponse createNamespaceResponse =
+                namespaceOperationDispatcher.createNamespace(context, createNamespaceRequest);
+            return IcebergRestUtils.ok(createNamespaceResponse);
+          });
+    } catch (Exception e) {
+      return IcebergExceptionMapper.toRESTResponse(e);
+    }
   }
 
   @POST
@@ -180,11 +225,20 @@ public class IcebergNamespaceOperations {
         catalogName,
         icebergNS,
         SerializeUpdateNamespacePropertiesRequest(updateNamespacePropertiesRequest));
-    IcebergRequestContext context = new IcebergRequestContext(httpServletRequest(), catalogName);
-    UpdateNamespacePropertiesResponse updateNamespacePropertiesResponse =
-        namespaceOperationDispatcher.updateNamespace(
-            context, icebergNS, updateNamespacePropertiesRequest);
-    return IcebergRestUtils.ok(updateNamespacePropertiesResponse);
+    try {
+      return Utils.doAs(
+          httpRequest,
+          () -> {
+            IcebergRequestContext context =
+                new IcebergRequestContext(httpServletRequest(), catalogName);
+            UpdateNamespacePropertiesResponse updateNamespacePropertiesResponse =
+                namespaceOperationDispatcher.updateNamespace(
+                    context, icebergNS, updateNamespacePropertiesRequest);
+            return IcebergRestUtils.ok(updateNamespacePropertiesResponse);
+          });
+    } catch (Exception e) {
+      return IcebergExceptionMapper.toRESTResponse(e);
+    }
   }
 
   @POST
@@ -203,11 +257,20 @@ public class IcebergNamespaceOperations {
         catalogName,
         icebergNS,
         registerTableRequest);
-    IcebergRequestContext context = new IcebergRequestContext(httpServletRequest(), catalogName);
-    LoadTableResponse loadTableResponse =
-        namespaceOperationDispatcher.registerTable(context, icebergNS, registerTableRequest);
-
-    return IcebergRestUtils.ok(loadTableResponse);
+    try {
+      return Utils.doAs(
+          httpRequest,
+          () -> {
+            IcebergRequestContext context =
+                new IcebergRequestContext(httpServletRequest(), catalogName);
+            LoadTableResponse loadTableResponse =
+                namespaceOperationDispatcher.registerTable(
+                    context, icebergNS, registerTableRequest);
+            return IcebergRestUtils.ok(loadTableResponse);
+          });
+    } catch (Exception e) {
+      return IcebergExceptionMapper.toRESTResponse(e);
+    }
   }
 
   // HTTP request is null in Jersey test, override with a mock request when testing.

--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/rest/IcebergTableRenameOperations.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/rest/IcebergTableRenameOperations.java
@@ -31,10 +31,12 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import org.apache.gravitino.iceberg.service.IcebergExceptionMapper;
 import org.apache.gravitino.iceberg.service.IcebergRestUtils;
 import org.apache.gravitino.iceberg.service.dispatcher.IcebergTableOperationDispatcher;
 import org.apache.gravitino.listener.api.event.IcebergRequestContext;
 import org.apache.gravitino.metrics.MetricNames;
+import org.apache.gravitino.server.web.Utils;
 import org.apache.iceberg.rest.requests.RenameTableRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -66,9 +68,18 @@ public class IcebergTableRenameOperations {
         catalogName,
         renameTableRequest.source(),
         renameTableRequest.destination());
-    IcebergRequestContext context = new IcebergRequestContext(httpServletRequest(), catalogName);
-    tableOperationDispatcher.renameTable(context, renameTableRequest);
-    return IcebergRestUtils.noContent();
+    try {
+      return Utils.doAs(
+          httpRequest,
+          () -> {
+            IcebergRequestContext context =
+                new IcebergRequestContext(httpServletRequest(), catalogName);
+            tableOperationDispatcher.renameTable(context, renameTableRequest);
+            return IcebergRestUtils.noContent();
+          });
+    } catch (Exception e) {
+      return IcebergExceptionMapper.toRESTResponse(e);
+    }
   }
 
   // HTTP request is null in Jersey test, override with a mock request when testing.

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/TestIcebergNamespaceOperations.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/TestIcebergNamespaceOperations.java
@@ -20,6 +20,7 @@ package org.apache.gravitino.iceberg.service.rest;
 
 import java.util.Arrays;
 import java.util.Optional;
+import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.core.Application;
 import org.apache.gravitino.listener.api.event.Event;
 import org.apache.gravitino.listener.api.event.IcebergCreateNamespaceEvent;
@@ -40,11 +41,13 @@ import org.apache.gravitino.listener.api.event.IcebergUpdateNamespaceEvent;
 import org.apache.gravitino.listener.api.event.IcebergUpdateNamespaceFailureEvent;
 import org.apache.gravitino.listener.api.event.IcebergUpdateNamespacePreEvent;
 import org.apache.iceberg.catalog.Namespace;
+import org.glassfish.jersey.internal.inject.AbstractBinder;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mockito;
 
 public class TestIcebergNamespaceOperations extends IcebergNamespaceTestBase {
 
@@ -56,6 +59,18 @@ public class TestIcebergNamespaceOperations extends IcebergNamespaceTestBase {
     ResourceConfig resourceConfig =
         IcebergRestTestUtil.getIcebergResourceConfig(
             MockIcebergNamespaceOperations.class, true, Arrays.asList(dummyEventListener));
+
+    // register a mock HttpServletRequest with user info
+    resourceConfig.register(
+        new AbstractBinder() {
+          @Override
+          protected void configure() {
+            HttpServletRequest mockRequest = Mockito.mock(HttpServletRequest.class);
+            Mockito.when(mockRequest.getUserPrincipal()).thenReturn(() -> "test-user");
+            bind(mockRequest).to(HttpServletRequest.class);
+          }
+        });
+
     return resourceConfig;
   }
 

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/TestIcebergTableOperations.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/TestIcebergTableOperations.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.Application;
 import javax.ws.rs.core.MediaType;
@@ -71,10 +72,12 @@ import org.apache.iceberg.rest.responses.ListTablesResponse;
 import org.apache.iceberg.rest.responses.LoadTableResponse;
 import org.apache.iceberg.types.Types.NestedField;
 import org.apache.iceberg.types.Types.StringType;
+import org.glassfish.jersey.internal.inject.AbstractBinder;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mockito;
 
 public class TestIcebergTableOperations extends IcebergNamespaceTestBase {
 
@@ -95,6 +98,17 @@ public class TestIcebergTableOperations extends IcebergNamespaceTestBase {
     // create namespace before each table test
     resourceConfig.register(MockIcebergNamespaceOperations.class);
     resourceConfig.register(MockIcebergTableRenameOperations.class);
+
+    // register a mock HttpServletRequest with user info
+    resourceConfig.register(
+        new AbstractBinder() {
+          @Override
+          protected void configure() {
+            HttpServletRequest mockRequest = Mockito.mock(HttpServletRequest.class);
+            Mockito.when(mockRequest.getUserPrincipal()).thenReturn(() -> "test-user");
+            bind(mockRequest).to(HttpServletRequest.class);
+          }
+        });
 
     return resourceConfig;
   }

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/TestIcebergViewOperations.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/TestIcebergViewOperations.java
@@ -24,6 +24,7 @@ import java.util.Arrays;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.Application;
 import javax.ws.rs.core.MediaType;
@@ -63,10 +64,12 @@ import org.apache.iceberg.types.Types;
 import org.apache.iceberg.view.ImmutableSQLViewRepresentation;
 import org.apache.iceberg.view.ImmutableViewVersion;
 import org.apache.iceberg.view.ViewMetadata;
+import org.glassfish.jersey.internal.inject.AbstractBinder;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mockito;
 
 public class TestIcebergViewOperations extends IcebergNamespaceTestBase {
   private static final Schema viewSchema =
@@ -88,6 +91,17 @@ public class TestIcebergViewOperations extends IcebergNamespaceTestBase {
     // create namespace before each view test
     resourceConfig.register(MockIcebergNamespaceOperations.class);
     resourceConfig.register(MockIcebergViewRenameOperations.class);
+
+    // register a mock HttpServletRequest with user info
+    resourceConfig.register(
+        new AbstractBinder() {
+          @Override
+          protected void configure() {
+            HttpServletRequest mockRequest = Mockito.mock(HttpServletRequest.class);
+            Mockito.when(mockRequest.getUserPrincipal()).thenReturn(() -> "test-user");
+            bind(mockRequest).to(HttpServletRequest.class);
+          }
+        });
 
     return resourceConfig;
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR is cherry pick from #7626, the author is @yunchipang

1. Wrapped business logic with `Utils.doAs(httpRequest, ...)` in methods of `IcebergXXXOperations` to extract and establish user context.
2. Mocked `HttpServletRequest` with test user principal for tests in `TestIcebergXXXOperations`.

- [x] `IcebergTableOperations`
- [x] `IcebergTableRenameOperations`
- [x] `IcebergNamespaceOperations`
- [x] `IcebergViewOperations`
- [x] `IcebergViewRenameOperations`

### Why are the changes needed?

To have all operations of Iceberg REST server to be executed under authenticated user context.
Fix: #7557

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

`org.apache.gravitino.iceberg.service.rest.TestIcebergTableOperations` `org.apache.gravitino.iceberg.service.rest.TestIcebergNamespaceOperations` `org.apache.gravitino.iceberg.service.rest.TestIcebergViewOperations`
