### PR TITLE
[#7707] Improvement(client-cli): Fix the parsing of whitespace correctly in list and map types in the CLI.

### DIFF
--- a/clients/cli/src/main/java/org/apache/gravitino/cli/ParseType.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/ParseType.java
@@ -73,21 +73,21 @@ public class ParseType {
   }
 
   private static Type toListType(String datatype) {
-    Pattern pattern = Pattern.compile("^list\\((.+)\\)$");
+    Pattern pattern = Pattern.compile("^list\\s*\\(\\s*(.+?)\\s*\\)$");
     Matcher matcher = pattern.matcher(datatype);
     if (matcher.matches()) {
-      Type elementType = toBasicType(matcher.group(1));
+      Type elementType = toBasicType(matcher.group(1).trim());
       return Types.ListType.of(elementType, false);
     }
     throw new IllegalArgumentException("Malformed list type: " + datatype);
   }
 
   private static Type toMapType(String datatype) {
-    Pattern pattern = Pattern.compile("^map\\((.+),(.+)\\)$");
+    Pattern pattern = Pattern.compile("^map\\s*\\(\\s*(.+?)\\s*,\\s*(.+?)\\s*\\)$");
     Matcher matcher = pattern.matcher(datatype);
     if (matcher.matches()) {
-      Type keyType = toBasicType(matcher.group(1));
-      Type valueType = toBasicType(matcher.group(2));
+      Type keyType = toBasicType(matcher.group(1).trim());
+      Type valueType = toBasicType(matcher.group(2).trim());
       return Types.MapType.of(keyType, valueType, false);
     }
     throw new IllegalArgumentException("Malformed map type: " + datatype);

--- a/clients/cli/src/test/java/org/apache/gravitino/cli/TestParseType.java
+++ b/clients/cli/src/test/java/org/apache/gravitino/cli/TestParseType.java
@@ -100,4 +100,22 @@ public class TestParseType {
     assertThrows(IllegalArgumentException.class, () -> ParseType.toType("varchar(-10)"));
     assertThrows(IllegalArgumentException.class, () -> ParseType.toType("decimal(10,abc)"));
   }
+
+  @Test
+  public void testParseTypeListWithSpaces() {
+    Type type = ParseType.toType("list( integer )");
+    assertThat(type, instanceOf(Types.ListType.class));
+    Type elementType = ((Types.ListType) type).elementType();
+    assertThat(elementType, instanceOf(Types.IntegerType.class));
+  }
+
+  @Test
+  public void testParseTypeMapWithSpaces() {
+    Type type = ParseType.toType("map( string , integer )");
+    assertThat(type, instanceOf(Types.MapType.class));
+    Type keyType = ((Types.MapType) type).keyType();
+    Type valueType = ((Types.MapType) type).valueType();
+    assertThat(keyType, instanceOf(Types.StringType.class));
+    assertThat(valueType, instanceOf(Types.IntegerType.class));
+  }
 }


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?
Fix the parsing of whitespace correctly in list and map types in the CLI.

### Why are the changes needed?
Fix: #7707

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Added a unit test
