### PR TITLE
[#7753] improve error messages when auth fails

### DIFF
--- a/server/src/main/java/org/apache/gravitino/server/web/filter/GravitinoInterceptionService.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/filter/GravitinoInterceptionService.java
@@ -167,8 +167,6 @@ public class GravitinoInterceptionService implements InterceptionService {
                 "User '%s' is not authorized to perform operation '%s' on metadata '%s'",
                 currentUser, methodName, accessMetadataName.name());
       }
-
-      // Create response without stack trace for security
       return Utils.forbidden(contextualMessage, null);
     }
 

--- a/server/src/main/java/org/apache/gravitino/server/web/filter/GravitinoInterceptionService.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/filter/GravitinoInterceptionService.java
@@ -159,8 +159,8 @@ public class GravitinoInterceptionService implements InterceptionService {
       if (StringUtils.isNotBlank(errorMessage)) {
         contextualMessage =
             String.format(
-                "User '%s' is not authorized to perform operation '%s': %s",
-                currentUser, methodName, errorMessage);
+                "User '%s' is not authorized to perform operation '%s' on metadata '%s': %s",
+                currentUser, methodName, accessMetadataName.name(), errorMessage);
       } else {
         contextualMessage =
             String.format(


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Include useful info e.g. user, operation, metadata object in the error messages when auth fails.

### Why are the changes needed?

Fix: #7753 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

`org.apache.gravitino.server.web.filter.TestGravitinoInterceptionService`
