### PR TITLE
fix(iceberg): Fix OAuth user identity propagation in Iceberg create table REST operation

### DIFF
--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/listener/api/event/IcebergRequestContext.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/listener/api/event/IcebergRequestContext.java
@@ -21,6 +21,8 @@ package org.apache.gravitino.listener.api.event;
 
 import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
+import org.apache.gravitino.UserPrincipal;
+import org.apache.gravitino.auth.AuthConstants;
 import org.apache.gravitino.iceberg.service.IcebergRestUtils;
 import org.apache.gravitino.utils.PrincipalUtils;
 
@@ -61,7 +63,17 @@ public class IcebergRequestContext {
     this.remoteHostName = httpRequest.getRemoteHost();
     this.httpHeaders = IcebergRestUtils.getHttpHeaders(httpRequest);
     this.catalogName = catalogName;
-    this.userName = PrincipalUtils.getCurrentUserName();
+
+    // Get the authenticated principal from the HTTP request attribute
+    // This is set by the AuthenticationFilter and matches the behavior in Utils.doAs()
+    UserPrincipal principal =
+        (UserPrincipal)
+            httpRequest.getAttribute(AuthConstants.AUTHENTICATED_PRINCIPAL_ATTRIBUTE_NAME);
+    if (principal == null) {
+      this.userName = PrincipalUtils.getCurrentUserName();
+    } else {
+      this.userName = principal.getName();
+    }
     this.requestCredentialVending = requestCredentialVending;
   }
 


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

(Please outline the changes and how this PR fixes the issue.)
Fix IcebergTableOperationExecutor to execute catalog operations within authenticated user's security context using PrincipalUtils.doAs()
- This ensures that when clients (like Spark SQL) connect with OAuth tokens, table creation operations properly record the authenticated user as the creator instead of showing 'N/A'

### Why are the changes needed?

Fixes issue where OAuth-authenticated table creation showed incorrect creator in audit metadata.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Tested by creating tables through Gravitino Web UI, curl command and spark-sql client, all with OAuth enabled.
Created by field now shows up on the UI on the table details