### PR TITLE
[#7754] improvement(storage) : Add a configuration to disable entity store GC for RelationalEntityStore

### DIFF
--- a/core/src/main/java/org/apache/gravitino/Configs.java
+++ b/core/src/main/java/org/apache/gravitino/Configs.java
@@ -176,11 +176,11 @@ public class Configs {
           .createWithDefault(DEFAULT_RELATIONAL_JDBC_BACKEND_PATH);
 
   public static final ConfigEntry<Boolean> ENTITY_STORE_GC_ENABLED =
-          new ConfigBuilder(ENTITY_RELATIONAL_JDBC_BACKEND_GC_ENABLED)
-                  .doc("Whether to enable the GC for Entity store.")
-                  .version(ConfigConstants.VERSION_1_0_0)
-                  .booleanConf()
-                  .createWithDefault(true);
+      new ConfigBuilder(ENTITY_RELATIONAL_JDBC_BACKEND_GC_ENABLED)
+          .doc("Whether to enable the GC for Entity store.")
+          .version(ConfigConstants.VERSION_1_0_0)
+          .booleanConf()
+          .createWithDefault(true);
 
   public static final ConfigEntry<Long> CATALOG_CACHE_EVICTION_INTERVAL_MS =
       new ConfigBuilder("gravitino.catalog.cache.evictionIntervalMs")

--- a/core/src/main/java/org/apache/gravitino/Configs.java
+++ b/core/src/main/java/org/apache/gravitino/Configs.java
@@ -57,6 +57,8 @@ public class Configs {
   public static final String ENTITY_RELATIONAL_JDBC_BACKEND_STORAGE_PATH_KEY =
       "gravitino.entity.store.relational.storagePath";
 
+  public static final String ENTITY_RELATIONAL_JDBC_BACKEND_GC_ENABLED = "true";
+
   public static final Long DEFAULT_DELETE_AFTER_TIME = 604800000L; // 7 days
 
   // Config for data keep time after soft deletion, in milliseconds.
@@ -172,6 +174,13 @@ public class Configs {
           .version(ConfigConstants.VERSION_0_6_0)
           .stringConf()
           .createWithDefault(DEFAULT_RELATIONAL_JDBC_BACKEND_PATH);
+
+  public static final ConfigEntry<Boolean> ENTITY_STORE_GC_ENABLED =
+          new ConfigBuilder(ENTITY_RELATIONAL_JDBC_BACKEND_GC_ENABLED)
+                  .doc("Whether to enable the GC for Entity store.")
+                  .version(ConfigConstants.VERSION_1_0_0)
+                  .booleanConf()
+                  .createWithDefault(true);
 
   public static final ConfigEntry<Long> CATALOG_CACHE_EVICTION_INTERVAL_MS =
       new ConfigBuilder("gravitino.catalog.cache.evictionIntervalMs")

--- a/core/src/main/java/org/apache/gravitino/storage/relational/RelationalEntityStore.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/RelationalEntityStore.java
@@ -63,8 +63,10 @@ public class RelationalEntityStore
   @Override
   public void initialize(Config config) throws RuntimeException {
     this.backend = createRelationalEntityBackend(config);
-    this.garbageCollector = new RelationalGarbageCollector(backend, config);
-    this.garbageCollector.start();
+    if (config.get(Configs.ENTITY_STORE_GC_ENABLED)) {
+      this.garbageCollector = new RelationalGarbageCollector(backend, config);
+      this.garbageCollector.start();
+    }
     this.cache =
         config.get(Configs.CACHE_ENABLED)
             ? CacheFactory.getEntityCache(config)
@@ -159,7 +161,9 @@ public class RelationalEntityStore
   @Override
   public void close() throws IOException {
     cache.clear();
-    garbageCollector.close();
+    if(garbageCollector != null) {
+      garbageCollector.close();
+    }
     backend.close();
   }
 

--- a/core/src/main/java/org/apache/gravitino/storage/relational/RelationalEntityStore.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/RelationalEntityStore.java
@@ -161,7 +161,7 @@ public class RelationalEntityStore
   @Override
   public void close() throws IOException {
     cache.clear();
-    if(garbageCollector != null) {
+    if (garbageCollector != null) {
       garbageCollector.close();
     }
     backend.close();


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?
Added a configuration to disable GC for relational entity stores

### Why are the changes needed?

To provide an option to disable entity store GC in some server to make only one server start the GC in case multiple servers use the same RDMS.

Fix: #7754 

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?
N/A
