### PR TITLE
[#7784] improvement(CI): Increase timeout time for build pipeline.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,7 +104,7 @@ jobs:
     strategy:
       matrix:
         java-version: [ 8, 11, 17 ]
-    timeout-minutes: 30
+    timeout-minutes: 60
     needs: changes
     if: needs.changes.outputs.source_changes == 'true'
     # Steps represent a sequence of tasks that will be executed as part of the job


### PR DESCRIPTION
### What changes were proposed in this pull request?

Increase the timeout time for build task from 30m to 60m.

### Why are the changes needed?

30m is not enough as the project introduces more modules.

Fix: #7784

### Does this PR introduce _any_ user-facing change?

N/A.

### How was this patch tested?

Exsiting CI.