### PR TITLE
[#7807] improvement(mysql-catalog): Add index column not null limitation

### DIFF
--- a/catalogs/catalog-jdbc-mysql/src/main/java/org/apache/gravitino/catalog/mysql/operation/MysqlTableOperations.java
+++ b/catalogs/catalog-jdbc-mysql/src/main/java/org/apache/gravitino/catalog/mysql/operation/MysqlTableOperations.java
@@ -652,7 +652,7 @@ public class MysqlTableOperations extends JdbcTableOperations {
         Arrays.stream(columns).collect(Collectors.toMap(JdbcColumn::name, c -> c));
     for (Index index : indexes) {
       if (index.type() == Index.IndexType.UNIQUE_KEY) {
-        // the column in the unique index must be not null
+        // the auto increment column in the unique index must be not null
         for (String[] colNames : index.fieldNames()) {
           JdbcColumn column = columnMap.get(colNames[0]);
           Preconditions.checkArgument(
@@ -661,10 +661,25 @@ public class MysqlTableOperations extends JdbcTableOperations {
               colNames[0],
               index.name());
           Preconditions.checkArgument(
-              !column.nullable(),
-              "Column %s in the unique index %s must be a not null column",
+              !(column.autoIncrement() && column.nullable()),
+              "Auto increment column %s in the unique index %s must be a not null column",
               colNames[0],
               index.name());
+        }
+      }
+
+      if (index.type() == Index.IndexType.PRIMARY_KEY) {
+        // the column in the primary key must be not null
+        for (String[] colNames : index.fieldNames()) {
+          JdbcColumn column = columnMap.get(colNames[0]);
+          Preconditions.checkArgument(
+              column != null,
+              "Column %s in the primary key does not exist in the table",
+              colNames[0]);
+          Preconditions.checkArgument(
+              !column.nullable(),
+              "Column %s in the primary key must be a not null column",
+              colNames[0]);
         }
       }
     }

--- a/catalogs/catalog-jdbc-mysql/src/test/java/org/apache/gravitino/catalog/mysql/operation/TestMysqlTableOperations.java
+++ b/catalogs/catalog-jdbc-mysql/src/test/java/org/apache/gravitino/catalog/mysql/operation/TestMysqlTableOperations.java
@@ -64,7 +64,7 @@ public class TestMysqlTableOperations extends TestMysql {
             .withName("col_1")
             .withType(VARCHAR)
             .withComment("test_comment")
-            .withNullable(false)
+            .withNullable(true)
             .build());
     columns.add(
         JdbcColumn.builder()
@@ -573,7 +573,7 @@ public class TestMysqlTableOperations extends TestMysql {
         JdbcColumn.builder()
             .withName("col_4")
             .withType(Types.DateType.get())
-            .withNullable(false)
+            .withNullable(true)
             .withComment("date")
             .withDefaultValue(Column.DEFAULT_VALUE_NOT_SET)
             .build());


### PR DESCRIPTION
### What changes were proposed in this pull request?
- The `primary key` must be `not null`
-  The auto increment `unique key` must be `not null`

### Why are the changes needed?
Fix: #7807

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
local tests
