### PR TITLE
[#7688] fix(server): Fix duplicated tags when list tags for a metadata object.

### DIFF
--- a/clients/client-java/src/test/java/org/apache/gravitino/client/integration/test/TagIT.java
+++ b/clients/client-java/src/test/java/org/apache/gravitino/client/integration/test/TagIT.java
@@ -434,7 +434,7 @@ public class TagIT extends BaseIT {
 
     // Test list associated tags with details for schema
     Tag[] tags2 = schema.supportsTags().listTagsInfo();
-    Assertions.assertEquals(3, tags2.length);
+    Assertions.assertEquals(2, tags2.length);
 
     Set<Tag> nonInheritedTags =
         Arrays.stream(tags2).filter(tag -> !tag.inherited().get()).collect(Collectors.toSet());
@@ -442,10 +442,9 @@ public class TagIT extends BaseIT {
         Arrays.stream(tags2).filter(tag -> tag.inherited().get()).collect(Collectors.toSet());
 
     Assertions.assertEquals(2, nonInheritedTags.size());
-    Assertions.assertEquals(1, inheritedTags.size());
+    Assertions.assertEquals(0, inheritedTags.size());
     Assertions.assertTrue(nonInheritedTags.contains(tag1));
     Assertions.assertTrue(nonInheritedTags.contains(tag2));
-    Assertions.assertTrue(inheritedTags.contains(tag1));
     Assertions.assertFalse(inheritedTags.contains(tag2));
 
     // Test get associated tag for schema

--- a/server/src/main/java/org/apache/gravitino/server/web/rest/MetadataObjectTagOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/MetadataObjectTagOperations.java
@@ -20,12 +20,11 @@ package org.apache.gravitino.server.web.rest;
 
 import com.codahale.metrics.annotation.ResponseMetered;
 import com.codahale.metrics.annotation.Timed;
-import com.google.common.collect.Lists;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
+import java.util.Set;
 import javax.inject.Inject;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.DefaultValue;
@@ -51,6 +50,7 @@ import org.apache.gravitino.metrics.MetricNames;
 import org.apache.gravitino.server.web.Utils;
 import org.apache.gravitino.tag.Tag;
 import org.apache.gravitino.tag.TagDispatcher;
+import org.glassfish.jersey.internal.guava.Sets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -163,7 +163,7 @@ public class MetadataObjectTagOperations {
                 MetadataObjects.parse(
                     fullName, MetadataObject.Type.valueOf(type.toUpperCase(Locale.ROOT)));
 
-            List<TagDTO> tags = Lists.newArrayList();
+            Set<TagDTO> tags = Sets.newHashSet();
             Tag[] nonInheritedTags = tagDispatcher.listTagsInfoForMetadataObject(metalake, object);
             if (ArrayUtils.isNotEmpty(nonInheritedTags)) {
               Collections.addAll(

--- a/server/src/main/java/org/apache/gravitino/server/web/rest/MetadataObjectTagOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/MetadataObjectTagOperations.java
@@ -197,9 +197,8 @@ public class MetadataObjectTagOperations {
               return Utils.ok(new TagListResponse(tags.toArray(new TagDTO[0])));
 
             } else {
-              // Due to same name tag will be associated to both parent and child objects, so we
-              // need to deduplicate the tag names.
-              String[] tagNames = tags.stream().map(TagDTO::name).distinct().toArray(String[]::new);
+              // We have used Set to avoid duplicate tag names
+              String[] tagNames = tags.stream().map(TagDTO::name).toArray(String[]::new);
 
               LOG.info(
                   "List {} tags for object type: {}, full name: {} under metalake: {}",


### PR DESCRIPTION


### What changes were proposed in this pull request?

Use set to remove duplicated tags when list all tags for a metadata object.

### Why are the changes needed?

We need to eliminate duplicates.

Fix: #7688 

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

UT
