### PR TITLE
[#7778] feat(client-python): Support statistics python client config for gravitino client

### DIFF
--- a/clients/client-python/gravitino/api/statistics/__init__.py
+++ b/clients/client-python/gravitino/api/statistics/__init__.py
@@ -1,0 +1,25 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Statistics API for Apache Gravitino Python client."""
+
+from gravitino.api.statistics.statistic import Statistic
+from gravitino.api.statistics.statistic_value import StatisticValue
+from gravitino.api.statistics.statistic_values import StatisticValues
+from gravitino.api.statistics.supports_statistics import SupportsStatistics
+
+__all__ = ["Statistic", "StatisticValue", "StatisticValues", "SupportsStatistics"]

--- a/clients/client-python/gravitino/api/statistics/statistic.py
+++ b/clients/client-python/gravitino/api/statistics/statistic.py
@@ -1,0 +1,72 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Definition of the Statistic interface for Apache Gravitino."""
+
+from abc import ABC, abstractmethod
+from typing import Optional
+
+from gravitino.api.statistics.statistic_value import StatisticValue
+
+
+class Statistic(ABC):
+    """
+    Represents a statistic for a metadata object. A statistic is a key-value pair where the key is
+    the statistic name and the value is the statistic value.
+    """
+
+    CUSTOM_PREFIX = "custom."
+
+    @abstractmethod
+    def name(self) -> str:
+        """
+        Get the name of the statistic.
+
+        Returns:
+            The name of the statistic.
+        """
+        pass
+
+    @abstractmethod
+    def value(self) -> Optional[StatisticValue]:
+        """
+        Get the value of the statistic.
+
+        Returns:
+            The value of the statistic, or None if not set.
+        """
+        pass
+
+    @abstractmethod
+    def reserved(self) -> bool:
+        """
+        Check if the statistic is reserved (system-defined).
+
+        Returns:
+            True if the statistic is reserved, False otherwise.
+        """
+        pass
+
+    @abstractmethod
+    def modifiable(self) -> bool:
+        """
+        Check if the statistic is modifiable.
+
+        Returns:
+            True if the statistic is modifiable, False otherwise.
+        """
+        pass

--- a/clients/client-python/gravitino/api/statistics/statistic_value.py
+++ b/clients/client-python/gravitino/api/statistics/statistic_value.py
@@ -1,0 +1,61 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Defines the base interface for statistic values in Gravitino."""
+
+from abc import ABC, abstractmethod
+from typing import TypeVar, Generic
+
+
+T = TypeVar("T")
+
+
+class StatisticValue(ABC, Generic[T]):
+    """
+    Represents a statistic value. A statistic value is a value that can be used to describe a
+    statistic. It can be a boolean, long, double, string, list, or object.
+    """
+
+    class Type:
+        """The type of the statistic value."""
+
+        BOOLEAN = "boolean"
+        LONG = "long"
+        DOUBLE = "double"
+        STRING = "string"
+        LIST = "list"
+        OBJECT = "object"
+
+    @abstractmethod
+    def value(self) -> T:
+        """
+        Get the value of the statistic.
+
+        Returns:
+            The value of the statistic.
+        """
+        pass
+
+    @abstractmethod
+    def data_type(self) -> str:
+        """
+        Get the data type of the statistic value.
+
+        Returns:
+            The data type of the statistic value.
+        """
+        pass

--- a/clients/client-python/gravitino/api/statistics/statistic_values.py
+++ b/clients/client-python/gravitino/api/statistics/statistic_values.py
@@ -1,0 +1,133 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Factory and concrete implementations for creating statistic values."""
+
+from typing import List, Dict, TypeVar
+
+from gravitino.api.statistics.statistic_value import StatisticValue
+
+
+T = TypeVar("T")
+
+
+class StatisticValues:
+    """Factory class for creating statistic values."""
+
+    class BooleanValue(StatisticValue[bool]):
+        """Boolean statistic value."""
+
+        def __init__(self, value: bool):
+            self._value = value
+
+        def value(self) -> bool:
+            return self._value
+
+        def data_type(self) -> str:
+            return StatisticValue.Type.BOOLEAN
+
+    class LongValue(StatisticValue[int]):
+        """Long integer statistic value."""
+
+        def __init__(self, value: int):
+            self._value = value
+
+        def value(self) -> int:
+            return self._value
+
+        def data_type(self) -> str:
+            return StatisticValue.Type.LONG
+
+    class DoubleValue(StatisticValue[float]):
+        """Double (float) statistic value."""
+
+        def __init__(self, value: float):
+            self._value = value
+
+        def value(self) -> float:
+            return self._value
+
+        def data_type(self) -> str:
+            return StatisticValue.Type.DOUBLE
+
+    class StringValue(StatisticValue[str]):
+        """String statistic value."""
+
+        def __init__(self, value: str):
+            self._value = value
+
+        def value(self) -> str:
+            return self._value
+
+        def data_type(self) -> str:
+            return StatisticValue.Type.STRING
+
+    class ListValue(StatisticValue[List[StatisticValue]]):
+        """List statistic value."""
+
+        def __init__(self, values: List[StatisticValue]):
+            self._values = values
+
+        def value(self) -> List[StatisticValue]:
+            return self._values
+
+        def data_type(self) -> str:
+            return StatisticValue.Type.LIST
+
+    class ObjectValue(StatisticValue[Dict[str, StatisticValue]]):
+        """Object (map) statistic value."""
+
+        def __init__(self, values: Dict[str, StatisticValue]):
+            self._values = values
+
+        def value(self) -> Dict[str, StatisticValue]:
+            return self._values
+
+        def data_type(self) -> str:
+            return StatisticValue.Type.OBJECT
+
+    @staticmethod
+    def of_boolean(value: bool) -> StatisticValue[bool]:
+        """Create a boolean statistic value."""
+        return StatisticValues.BooleanValue(value)
+
+    @staticmethod
+    def of_long(value: int) -> StatisticValue[int]:
+        """Create a long statistic value."""
+        return StatisticValues.LongValue(value)
+
+    @staticmethod
+    def of_double(value: float) -> StatisticValue[float]:
+        """Create a double statistic value."""
+        return StatisticValues.DoubleValue(value)
+
+    @staticmethod
+    def of_string(value: str) -> StatisticValue[str]:
+        """Create a string statistic value."""
+        return StatisticValues.StringValue(value)
+
+    @staticmethod
+    def of_list(values: List[StatisticValue]) -> StatisticValue[List[StatisticValue]]:
+        """Create a list statistic value."""
+        return StatisticValues.ListValue(values)
+
+    @staticmethod
+    def of_object(
+        values: Dict[str, StatisticValue]
+    ) -> StatisticValue[Dict[str, StatisticValue]]:
+        """Create an object statistic value."""
+        return StatisticValues.ObjectValue(values)

--- a/clients/client-python/gravitino/api/statistics/supports_statistics.py
+++ b/clients/client-python/gravitino/api/statistics/supports_statistics.py
@@ -1,0 +1,80 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Interface for metadata objects that support statistics operations."""
+
+from abc import ABC, abstractmethod
+from typing import List, Dict
+
+from gravitino.api.statistics.statistic import Statistic
+from gravitino.api.statistics.statistic_value import StatisticValue
+
+
+class SupportsStatistics(ABC):
+    """
+    SupportsStatistics provides methods to list and update statistics. A table, a partition or a
+    fileset can implement this interface to manage its statistics.
+    """
+
+    @abstractmethod
+    def list_statistics(self) -> List[Statistic]:
+        """
+        Lists all statistics.
+
+        Returns:
+            A list of statistics.
+        """
+        pass
+
+    @abstractmethod
+    def update_statistics(
+        self, statistics: Dict[str, StatisticValue]
+    ) -> List[Statistic]:
+        """
+        Updates statistics with the provided values. If the statistic exists, it will be updated with
+        the new value. If the statistic does not exist, it will be created. If the statistic is
+        unmodifiable, it will throw an UnmodifiableStatisticException. If the statistic name is
+        illegal, it will throw an IllegalStatisticNameException.
+
+        Args:
+            statistics: A map of statistic names to their values.
+
+        Returns:
+            A list of updated statistics.
+
+        Raises:
+            UnmodifiableStatisticException: If any of the statistics to be updated are unmodifiable.
+            IllegalStatisticNameException: If any of the statistic names are illegal.
+        """
+        pass
+
+    @abstractmethod
+    def drop_statistics(self, statistics: List[str]) -> bool:
+        """
+        Drop statistics by their names. If the statistic is unmodifiable, it will throw an
+        UnmodifiableStatisticException.
+
+        Args:
+            statistics: A list of statistic names to be dropped.
+
+        Returns:
+            True if the statistics were successfully dropped, False if no statistics were dropped.
+
+        Raises:
+            UnmodifiableStatisticException: If any of the statistics to be dropped are unmodifiable.
+        """
+        pass

--- a/clients/client-python/gravitino/client/metadata_object_statistics_operations.py
+++ b/clients/client-python/gravitino/client/metadata_object_statistics_operations.py
@@ -1,0 +1,165 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Client implementation for metadata object statistics operations."""
+
+from typing import List, Dict
+
+from gravitino.api.metadata_object import MetadataObject
+from gravitino.api.statistics.statistic import Statistic
+from gravitino.api.statistics.statistic_value import StatisticValue
+from gravitino.api.statistics.supports_statistics import SupportsStatistics
+from gravitino.audit.caller_context import CallerContextHolder
+from gravitino.dto.requests.statistics_update_request import StatisticsUpdateRequest
+from gravitino.dto.responses.drop_response import DropResponse
+from gravitino.dto.responses.statistic_list_response import StatisticListResponse
+from gravitino.dto.stats.statistic_value_dto import (
+    StatisticValueDTO,
+    BooleanValueDTO,
+    LongValueDTO,
+    DoubleValueDTO,
+    StringValueDTO,
+    ListValueDTO,
+    ObjectValueDTO,
+)
+from gravitino.exceptions.base import IllegalArgumentException
+from gravitino.exceptions.handlers.statistics_error_handler import (
+    STATISTICS_ERROR_HANDLER,
+)
+from gravitino.utils import HTTPClient
+from gravitino.rest.rest_utils import encode_string
+
+
+class MetadataObjectStatisticsOperations(SupportsStatistics):
+    """
+    The implementation of SupportsStatistics. This interface will be composited into table to
+    provide statistics operations for table metadata objects.
+    """
+
+    _rest_client: HTTPClient
+    _statistics_request_path: str
+
+    def __init__(
+        self,
+        metalake_name: str,
+        catalog_name: str,
+        metadata_object: MetadataObject,
+        rest_client: HTTPClient,
+    ):
+        self._rest_client = rest_client
+
+        # Build the REST API path based on the metadata object type
+        full_name = metadata_object.full_name()
+
+        # Currently only TABLE type is supported
+        if metadata_object.type() != MetadataObject.Type.TABLE:
+            raise IllegalArgumentException(
+                f"Statistics are only supported for TABLE object type, but got: {metadata_object.type()}"
+            )
+
+        # For table:
+        # api/metalakes/{metalake}/catalogs/{catalog}/schemas/{schema}/tables/{table}/statistics
+        parts = full_name.split(".")
+        if len(parts) != 3:
+            raise IllegalArgumentException(f"Invalid table full name: {full_name}")
+
+        # fullName format is catalog.schema.table, we need schema and table
+        self._statistics_request_path = (
+            f"api/metalakes/{encode_string(metalake_name)}/catalogs/{encode_string(catalog_name)}/"
+            f"schemas/{encode_string(parts[1])}/tables/{encode_string(parts[2])}/statistics"
+        )
+
+    def list_statistics(self) -> List[Statistic]:
+        """Lists all statistics."""
+        with CallerContextHolder.with_context(self._rest_client.get_context_map()):
+            resp = self._rest_client.get(
+                self._statistics_request_path,
+                error_handler=STATISTICS_ERROR_HANDLER,
+            )
+
+            statistic_list_resp = StatisticListResponse.from_json(
+                resp.body, infer_missing=True
+            )
+            statistic_list_resp.validate()
+            return statistic_list_resp.statistics()
+
+    def update_statistics(
+        self, statistics: Dict[str, StatisticValue]
+    ) -> List[Statistic]:
+        """Updates statistics with the provided values."""
+        if not statistics:
+            raise IllegalArgumentException("Statistics must not be None or empty")
+
+        # Convert StatisticValue to StatisticValueDTO
+        statistic_dtos = {}
+        for name, value in statistics.items():
+            statistic_dtos[name] = self._to_statistic_value_dto(value)
+
+        request = StatisticsUpdateRequest(statistics=statistic_dtos)
+        request.validate()
+
+        with CallerContextHolder.with_context(self._rest_client.get_context_map()):
+            resp = self._rest_client.post(
+                self._statistics_request_path,
+                json=request.to_json(),
+                error_handler=STATISTICS_ERROR_HANDLER,
+            )
+
+            statistic_list_resp = StatisticListResponse.from_json(
+                resp.body, infer_missing=True
+            )
+            statistic_list_resp.validate()
+            return statistic_list_resp.statistics()
+
+    def drop_statistics(self, statistics: List[str]) -> bool:
+        """Drop statistics by their names."""
+        if not statistics:
+            raise IllegalArgumentException("Statistics list must not be None or empty")
+
+        # Convert the list of statistics to a query parameter
+        query_params = {"statistics": ",".join(statistics)}
+
+        with CallerContextHolder.with_context(self._rest_client.get_context_map()):
+            resp = self._rest_client.delete(
+                self._statistics_request_path,
+                params=query_params,
+                error_handler=STATISTICS_ERROR_HANDLER,
+            )
+
+            drop_resp = DropResponse.from_json(resp.body, infer_missing=True)
+            drop_resp.validate()
+            return drop_resp.dropped()
+
+    def _to_statistic_value_dto(self, value: StatisticValue) -> StatisticValueDTO:
+        """Convert StatisticValue to StatisticValueDTO."""
+        data_type = value.data_type()
+
+        if data_type == StatisticValue.Type.BOOLEAN:
+            return BooleanValueDTO(value.value())
+        if data_type == StatisticValue.Type.LONG:
+            return LongValueDTO(value.value())
+        if data_type == StatisticValue.Type.DOUBLE:
+            return DoubleValueDTO(value.value())
+        if data_type == StatisticValue.Type.STRING:
+            return StringValueDTO(value.value())
+        if data_type == StatisticValue.Type.LIST:
+            items = [self._to_statistic_value_dto(item) for item in value.value()]
+            return ListValueDTO(items)
+        if data_type == StatisticValue.Type.OBJECT:
+            obj = {k: self._to_statistic_value_dto(v) for k, v in value.value().items()}
+            return ObjectValueDTO(obj)
+        raise ValueError(f"Unknown statistic value type: {data_type}")

--- a/clients/client-python/gravitino/dto/requests/statistics_update_request.py
+++ b/clients/client-python/gravitino/dto/requests/statistics_update_request.py
@@ -1,0 +1,56 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""REST request for updating statistics."""
+
+from typing import Dict
+
+from gravitino.dto.stats.statistic_value_dto import StatisticValueDTO
+from gravitino.rest.rest_message import RESTRequest
+
+
+class StatisticsUpdateRequest(RESTRequest):
+    """Request to update statistics."""
+
+    _statistics: Dict[str, StatisticValueDTO]
+
+    def __init__(self, statistics: Dict[str, StatisticValueDTO] = None):
+        self._statistics = statistics or {}
+
+    def validate(self):
+        assert (
+            self._statistics is not None and len(self._statistics) > 0
+        ), "Statistics must not be None or empty"
+
+    def to_json(self) -> dict:  # pylint: disable=arguments-differ
+        """Convert to JSON representation."""
+        return {
+            "statistics": {k: v.to_json() for k, v in self._statistics.items()},
+        }
+
+    @classmethod
+    def from_json(
+        cls, json_dict: dict
+    ) -> (
+        "StatisticsUpdateRequest"
+    ):  # pylint: disable=arguments-differ,arguments-renamed
+        """Create from JSON representation."""
+        statistics_dict = json_dict.get("statistics", {})
+        statistics = {
+            k: StatisticValueDTO.from_json(v) for k, v in statistics_dict.items()
+        }
+        return cls(statistics=statistics)

--- a/clients/client-python/gravitino/dto/responses/statistic_list_response.py
+++ b/clients/client-python/gravitino/dto/responses/statistic_list_response.py
@@ -1,0 +1,71 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""REST response containing a list of statistics."""
+
+import json
+from typing import List
+
+from gravitino.dto.responses.base_response import BaseResponse
+from gravitino.dto.stats.statistic_dto import StatisticDTO
+
+
+class StatisticListResponse(BaseResponse):
+    """Response containing a list of statistics."""
+
+    _statistics: List[StatisticDTO]
+
+    def __init__(self, statistics: List[StatisticDTO] = None):
+        super().__init__(0)
+        self._statistics = statistics or []
+
+    def statistics(self) -> List[StatisticDTO]:
+        """Get the list of statistics."""
+        return self._statistics
+
+    def validate(self):
+        """Validate the response."""
+        super().validate()
+        assert self._statistics is not None, "Statistics must not be None"
+
+    @classmethod
+    def from_json(
+        cls, s, *, infer_missing=False, **kwargs
+    ):  # pylint: disable=arguments-differ,unused-argument
+        """Create from JSON representation."""
+        # Handle both string and dict input
+        if isinstance(s, str):
+            json_dict = json.loads(s)
+        else:
+            json_dict = s
+
+        statistics = []
+        if "statistics" in json_dict:
+            statistics = [
+                StatisticDTO.from_json(stat) for stat in json_dict.get("statistics", [])
+            ]
+
+        resp = cls(statistics=statistics)
+        resp._code = json_dict.get("code", 0)
+        return resp
+
+    def to_json(self) -> dict:  # pylint: disable=arguments-differ
+        """Convert to JSON representation."""
+        return {
+            "code": self._code,
+            "statistics": [stat.to_json() for stat in self._statistics],
+        }

--- a/clients/client-python/gravitino/dto/stats/__init__.py
+++ b/clients/client-python/gravitino/dto/stats/__init__.py
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Data Transfer Objects for statistics operations."""

--- a/clients/client-python/gravitino/dto/stats/statistic_dto.py
+++ b/clients/client-python/gravitino/dto/stats/statistic_dto.py
@@ -1,0 +1,87 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Data Transfer Object for representing a statistic."""
+
+from typing import Optional
+
+from gravitino.api.statistics.statistic import Statistic
+from gravitino.api.statistics.statistic_value import StatisticValue
+from gravitino.dto.stats.statistic_value_dto import StatisticValueDTO
+from gravitino.rest.rest_message import RESTRequest
+
+
+class StatisticDTO(Statistic, RESTRequest):  # pylint: disable=abstract-method
+    """DTO representing a statistic."""
+
+    _name: str
+    _value: Optional[StatisticValueDTO]
+    _reserved: bool
+    _modifiable: bool
+
+    def __init__(
+        self,
+        name: str = None,
+        value: Optional[StatisticValueDTO] = None,
+        reserved: bool = False,
+        modifiable: bool = True,
+    ):
+        self._name = name
+        self._value = value
+        self._reserved = reserved
+        self._modifiable = modifiable
+
+    def name(self) -> str:
+        return self._name
+
+    def value(self) -> Optional[StatisticValue]:
+        return self._value
+
+    def reserved(self) -> bool:
+        return self._reserved
+
+    def modifiable(self) -> bool:
+        return self._modifiable
+
+    def validate(self):
+        assert self._name is not None, "Statistic name must not be None"
+
+    @classmethod
+    # pylint: disable-next=arguments-differ,arguments-renamed
+    def from_json(cls, json_dict: dict) -> "StatisticDTO":
+        """Create a StatisticDTO from JSON representation."""
+        value = None
+        if "value" in json_dict and json_dict["value"] is not None:
+            value = StatisticValueDTO.from_json(json_dict["value"])
+
+        return cls(
+            name=json_dict.get("name"),
+            value=value,
+            reserved=json_dict.get("reserved", False),
+            modifiable=json_dict.get("modifiable", True),
+        )
+
+    def to_json(self) -> dict:  # pylint: disable=arguments-differ
+        """Convert to JSON representation."""
+        result = {
+            "name": self._name,
+            "reserved": self._reserved,
+            "modifiable": self._modifiable,
+        }
+        if self._value is not None:
+            result["value"] = self._value.to_json()
+        return result

--- a/clients/client-python/gravitino/dto/stats/statistic_value_dto.py
+++ b/clients/client-python/gravitino/dto/stats/statistic_value_dto.py
@@ -1,0 +1,159 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Data Transfer Objects for statistic values with JSON serialization support."""
+
+from abc import ABC, abstractmethod
+from typing import List, Dict, TypeVar
+
+from gravitino.api.statistics.statistic_value import StatisticValue
+
+
+T = TypeVar("T")
+
+
+class StatisticValueDTO(StatisticValue[T], ABC):
+    """Abstract base class for statistic value DTOs."""
+
+    @abstractmethod
+    def to_json(self) -> dict:
+        """Convert to JSON representation."""
+        pass
+
+    @classmethod
+    def from_json(cls, json_dict: dict) -> "StatisticValueDTO":
+        """Create a StatisticValueDTO from JSON representation."""
+        data_type = json_dict.get("type")
+        value = json_dict.get("value")
+
+        if data_type == StatisticValue.Type.BOOLEAN:
+            return BooleanValueDTO(value)
+        if data_type == StatisticValue.Type.LONG:
+            return LongValueDTO(value)
+        if data_type == StatisticValue.Type.DOUBLE:
+            return DoubleValueDTO(value)
+        if data_type == StatisticValue.Type.STRING:
+            return StringValueDTO(value)
+        if data_type == StatisticValue.Type.LIST:
+            items = [StatisticValueDTO.from_json(item) for item in value]
+            return ListValueDTO(items)
+        if data_type == StatisticValue.Type.OBJECT:
+            obj = {k: StatisticValueDTO.from_json(v) for k, v in value.items()}
+            return ObjectValueDTO(obj)
+        raise ValueError(f"Unknown statistic value type: {data_type}")
+
+
+class BooleanValueDTO(StatisticValueDTO[bool]):
+    """Boolean statistic value DTO."""
+
+    def __init__(self, value: bool):
+        self._value = value
+
+    def value(self) -> bool:
+        return self._value
+
+    def data_type(self) -> str:
+        return StatisticValue.Type.BOOLEAN
+
+    def to_json(self) -> dict:
+        return {"type": self.data_type(), "value": self._value}
+
+
+class LongValueDTO(StatisticValueDTO[int]):
+    """Long statistic value DTO."""
+
+    def __init__(self, value: int):
+        self._value = value
+
+    def value(self) -> int:
+        return self._value
+
+    def data_type(self) -> str:
+        return StatisticValue.Type.LONG
+
+    def to_json(self) -> dict:
+        return {"type": self.data_type(), "value": self._value}
+
+
+class DoubleValueDTO(StatisticValueDTO[float]):
+    """Double statistic value DTO."""
+
+    def __init__(self, value: float):
+        self._value = value
+
+    def value(self) -> float:
+        return self._value
+
+    def data_type(self) -> str:
+        return StatisticValue.Type.DOUBLE
+
+    def to_json(self) -> dict:
+        return {"type": self.data_type(), "value": self._value}
+
+
+class StringValueDTO(StatisticValueDTO[str]):
+    """String statistic value DTO."""
+
+    def __init__(self, value: str):
+        self._value = value
+
+    def value(self) -> str:
+        return self._value
+
+    def data_type(self) -> str:
+        return StatisticValue.Type.STRING
+
+    def to_json(self) -> dict:
+        return {"type": self.data_type(), "value": self._value}
+
+
+class ListValueDTO(StatisticValueDTO[List[StatisticValueDTO]]):
+    """List statistic value DTO."""
+
+    def __init__(self, values: List[StatisticValueDTO]):
+        self._values = values
+
+    def value(self) -> List[StatisticValueDTO]:
+        return self._values
+
+    def data_type(self) -> str:
+        return StatisticValue.Type.LIST
+
+    def to_json(self) -> dict:
+        return {
+            "type": self.data_type(),
+            "value": [item.to_json() for item in self._values],
+        }
+
+
+class ObjectValueDTO(StatisticValueDTO[Dict[str, StatisticValueDTO]]):
+    """Object statistic value DTO."""
+
+    def __init__(self, values: Dict[str, StatisticValueDTO]):
+        self._values = values
+
+    def value(self) -> Dict[str, StatisticValueDTO]:
+        return self._values
+
+    def data_type(self) -> str:
+        return StatisticValue.Type.OBJECT
+
+    def to_json(self) -> dict:
+        return {
+            "type": self.data_type(),
+            "value": {k: v.to_json() for k, v in self._values.items()},
+        }

--- a/clients/client-python/gravitino/exceptions/handlers/statistics_error_handler.py
+++ b/clients/client-python/gravitino/exceptions/handlers/statistics_error_handler.py
@@ -1,0 +1,53 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Error handler for statistics-related REST API errors."""
+
+from gravitino.constants.error import ErrorConstants
+from gravitino.dto.responses.error_response import ErrorResponse
+from gravitino.exceptions.base import NotFoundException
+from gravitino.exceptions.handlers.rest_error_handler import RestErrorHandler
+from gravitino.exceptions.statistics_exceptions import (
+    IllegalStatisticNameException,
+    UnmodifiableStatisticException,
+)
+
+
+class StatisticsErrorHandler(RestErrorHandler):
+    """Error handler for statistics operations."""
+
+    def handle(self, error_response: ErrorResponse):
+        """Handle error response for statistics operations."""
+        error_code = error_response.code()
+
+        if error_code == ErrorConstants.ILLEGAL_ARGUMENTS_CODE:
+            if "statistic name" in error_response.message().lower():
+                raise IllegalStatisticNameException(
+                    self._format_error_message(error_response)
+                )
+            if "unmodifiable" in error_response.message().lower():
+                raise UnmodifiableStatisticException(
+                    self._format_error_message(error_response)
+                )
+
+        if error_code == ErrorConstants.NOT_FOUND_CODE:
+            raise NotFoundException(self._format_error_message(error_response))
+
+        super().handle(error_response)
+
+
+STATISTICS_ERROR_HANDLER = StatisticsErrorHandler()

--- a/clients/client-python/gravitino/exceptions/statistics_exceptions.py
+++ b/clients/client-python/gravitino/exceptions/statistics_exceptions.py
@@ -1,0 +1,28 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Custom exceptions for statistics operations."""
+
+from gravitino.exceptions.base import GravitinoRuntimeException
+
+
+class IllegalStatisticNameException(GravitinoRuntimeException):
+    """An exception thrown when a statistic name is illegal."""
+
+
+class UnmodifiableStatisticException(GravitinoRuntimeException):
+    """An exception thrown when trying to modify an unmodifiable statistic."""

--- a/clients/client-python/tests/integration/test_table_statistics.py
+++ b/clients/client-python/tests/integration/test_table_statistics.py
@@ -1,0 +1,199 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+Integration test for table statistics functionality.
+This test demonstrates how statistics work with tables in Gravitino.
+"""
+
+import logging
+from typing import List, Dict
+
+from gravitino.api.metadata_object import MetadataObject
+from gravitino.api.statistics.statistic import Statistic
+from gravitino.api.statistics.statistic_value import StatisticValue
+from gravitino.api.statistics.statistic_values import StatisticValues
+from gravitino.api.statistics.supports_statistics import SupportsStatistics
+from gravitino.client.gravitino_client import GravitinoClient
+from gravitino.client.metadata_object_impl import MetadataObjectImpl
+from gravitino.client.metadata_object_statistics_operations import (
+    MetadataObjectStatisticsOperations,
+)
+from tests.integration.integration_test_env import IntegrationTestEnv
+
+logger = logging.getLogger(__name__)
+
+
+class TableWithStatistics(SupportsStatistics):
+    """
+    Example implementation of a table that supports statistics.
+    This would typically be part of the RelationalTable implementation.
+    """
+
+    def __init__(
+        self,
+        metalake_name: str,
+        catalog_name: str,
+        schema_name: str,
+        table_name: str,
+        rest_client,
+    ):
+        self.metalake_name = metalake_name
+        self.catalog_name = catalog_name
+        self.schema_name = schema_name
+        self.table_name = table_name
+
+        # Create metadata object for the table
+        table_object = MetadataObjectImpl(
+            [catalog_name, schema_name, table_name], MetadataObject.Type.TABLE
+        )
+
+        # Initialize statistics operations
+        self._statistics_operations = MetadataObjectStatisticsOperations(
+            metalake_name, catalog_name, table_object, rest_client
+        )
+
+    def list_statistics(self) -> List[Statistic]:
+        """List all statistics for this table."""
+        return self._statistics_operations.list_statistics()
+
+    def update_statistics(
+        self, statistics: Dict[str, StatisticValue]
+    ) -> List[Statistic]:
+        """Update statistics for this table."""
+        return self._statistics_operations.update_statistics(statistics)
+
+    def drop_statistics(self, statistics: List[str]) -> bool:
+        """Drop specified statistics from this table."""
+        return self._statistics_operations.drop_statistics(statistics)
+
+
+class TestTableStatistics(IntegrationTestEnv):
+    """Integration test for table statistics functionality."""
+
+    metalake_name: str = "test_metalake_statistics"
+    catalog_name: str = "test_catalog_statistics"
+    schema_name: str = "test_schema_statistics"
+    table_name: str = "test_table_statistics"
+
+    def setUp(self):
+        super().setUp()
+        self.gravitino_client = GravitinoClient(
+            uri="http://localhost:8090",
+            metalake_name=self.metalake_name,
+            check_version=False,
+        )
+
+    def test_table_statistics_operations(self):
+        """Test complete statistics workflow for a table."""
+        # Note: This test assumes that the table already exists in Gravitino.
+        # In a real scenario, you would create the metalake, catalog, schema, and table first.
+
+        # Create a table with statistics support
+        # Note: In a real implementation, this would be obtained from the catalog
+        # Here we directly access the protected member for testing purposes
+        # pylint: disable=protected-access
+        table = TableWithStatistics(
+            self.metalake_name,
+            self.catalog_name,
+            self.schema_name,
+            self.table_name,
+            self.gravitino_client._rest_client,
+        )
+
+        try:
+            # 1. List initial statistics (might be empty)
+            initial_stats = table.list_statistics()
+            logger.info("Initial statistics count: %d", len(initial_stats))
+
+            # 2. Update/create statistics
+            statistics_to_update = {
+                # System statistics
+                "row_count": StatisticValues.of_long(1000000),
+                "size_in_bytes": StatisticValues.of_long(1024 * 1024 * 100),  # 100MB
+                # Custom statistics
+                "custom.avg_order_value": StatisticValues.of_double(156.78),
+                "custom.unique_customers": StatisticValues.of_long(50000),
+                "custom.data_quality_score": StatisticValues.of_double(0.95),
+                # Complex statistics
+                "custom.column_stats": StatisticValues.of_object(
+                    {
+                        "order_id": StatisticValues.of_object(
+                            {
+                                "min": StatisticValues.of_long(1),
+                                "max": StatisticValues.of_long(1000000),
+                                "null_count": StatisticValues.of_long(0),
+                            }
+                        ),
+                        "customer_id": StatisticValues.of_object(
+                            {
+                                "distinct_count": StatisticValues.of_long(50000),
+                                "null_count": StatisticValues.of_long(100),
+                            }
+                        ),
+                    }
+                ),
+                # List statistics
+                "custom.top_products": StatisticValues.of_list(
+                    [
+                        StatisticValues.of_string("Product A"),
+                        StatisticValues.of_string("Product B"),
+                        StatisticValues.of_string("Product C"),
+                    ]
+                ),
+            }
+
+            updated_stats = table.update_statistics(statistics_to_update)
+            logger.info("Updated statistics count: %d", len(updated_stats))
+
+            # Print updated statistics
+            for stat in updated_stats:
+                logger.info(
+                    "Statistic: %s, Value: %s, Reserved: %s, Modifiable: %s",
+                    stat.name(),
+                    stat.value().value() if stat.value() else "None",
+                    stat.reserved(),
+                    stat.modifiable(),
+                )
+
+            # 3. List statistics again to verify
+            all_stats = table.list_statistics()
+            logger.info("Total statistics after update: %d", len(all_stats))
+
+            # 4. Drop some custom statistics
+            stats_to_drop = ["custom.data_quality_score", "custom.top_products"]
+            dropped = table.drop_statistics(stats_to_drop)
+            logger.info("Statistics dropped: %s", dropped)
+
+            # 5. List final statistics
+            final_stats = table.list_statistics()
+            logger.info("Final statistics count: %d", len(final_stats))
+
+            # Verify the dropped statistics are gone
+            remaining_names = [stat.name() for stat in final_stats]
+            assert "custom.data_quality_score" not in remaining_names
+            assert "custom.top_products" not in remaining_names
+
+        except Exception as e:
+            logger.error("Error during statistics test: %s", e)
+            raise
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()

--- a/clients/client-python/tests/unittests/test_statistics_api.py
+++ b/clients/client-python/tests/unittests/test_statistics_api.py
@@ -1,0 +1,255 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import unittest
+from unittest.mock import Mock
+
+from gravitino.api.metadata_object import MetadataObject
+from gravitino.api.statistics.statistic_values import StatisticValues
+from gravitino.client.metadata_object_impl import MetadataObjectImpl
+from gravitino.client.metadata_object_statistics_operations import (
+    MetadataObjectStatisticsOperations,
+)
+from gravitino.exceptions.base import IllegalArgumentException
+
+
+class TestStatisticsAPI(unittest.TestCase):
+    """Test cases for the statistics API."""
+
+    def setUp(self):
+        self.metalake_name = "test_metalake"
+        self.catalog_name = "test_catalog"
+        self.schema_name = "test_schema"
+        self.table_name = "test_table"
+
+        # Create a table metadata object
+        self.table_object = MetadataObjectImpl(
+            [self.catalog_name, self.schema_name, self.table_name],
+            MetadataObject.Type.TABLE,
+        )
+
+        # Mock HTTP client
+        self.mock_client = Mock()
+        self.mock_client.get_context_map = Mock(return_value={})
+
+        # Create statistics operations instance
+        self.stats_ops = MetadataObjectStatisticsOperations(
+            self.metalake_name, self.catalog_name, self.table_object, self.mock_client
+        )
+
+    def test_list_statistics(self):
+        """Test listing statistics."""
+        # Mock response
+        mock_response = Mock()
+        mock_response.json.return_value = {
+            "code": 0,
+            "statistics": [
+                {
+                    "name": "row_count",
+                    "value": {"type": "long", "value": 1000},
+                    "reserved": True,
+                    "modifiable": False,
+                },
+                {
+                    "name": "custom.avg_column_value",
+                    "value": {"type": "double", "value": 123.45},
+                    "reserved": False,
+                    "modifiable": True,
+                },
+            ],
+        }
+        mock_response.in_stream = False
+
+        self.mock_client.get.return_value = mock_response
+
+        # Call list_statistics
+        statistics = self.stats_ops.list_statistics()
+
+        # Verify results
+        assert len(statistics) == 2
+        assert statistics[0].name() == "row_count"
+        assert statistics[0].value().value() == 1000
+        assert statistics[0].reserved() is True
+        assert statistics[0].modifiable() is False
+
+        assert statistics[1].name() == "custom.avg_column_value"
+        assert statistics[1].value().value() == 123.45
+        assert statistics[1].reserved() is False
+        assert statistics[1].modifiable() is True
+
+    def test_update_statistics(self):
+        """Test updating statistics."""
+        # Prepare update data
+        statistics_to_update = {
+            "row_count": StatisticValues.of_long(2000),
+            "custom.max_value": StatisticValues.of_double(999.99),
+            "custom.metadata": StatisticValues.of_object(
+                {
+                    "last_updated": StatisticValues.of_string("2024-01-01"),
+                    "updated_by": StatisticValues.of_string("user1"),
+                }
+            ),
+        }
+
+        # Mock response
+        mock_response = Mock()
+        mock_response.json.return_value = {
+            "code": 0,
+            "statistics": [
+                {
+                    "name": "row_count",
+                    "value": {"type": "long", "value": 2000},
+                    "reserved": True,
+                    "modifiable": False,
+                },
+                {
+                    "name": "custom.max_value",
+                    "value": {"type": "double", "value": 999.99},
+                    "reserved": False,
+                    "modifiable": True,
+                },
+                {
+                    "name": "custom.metadata",
+                    "value": {
+                        "type": "object",
+                        "value": {
+                            "last_updated": {"type": "string", "value": "2024-01-01"},
+                            "updated_by": {"type": "string", "value": "user1"},
+                        },
+                    },
+                    "reserved": False,
+                    "modifiable": True,
+                },
+            ],
+        }
+        mock_response.in_stream = False
+
+        self.mock_client.post.return_value = mock_response
+
+        # Call update_statistics
+        updated_statistics = self.stats_ops.update_statistics(statistics_to_update)
+
+        # Verify results
+        assert len(updated_statistics) == 3
+        assert updated_statistics[0].name() == "row_count"
+        assert updated_statistics[0].value().value() == 2000
+
+        # Verify the request was called with correct data
+        self.mock_client.post.assert_called_once()
+        call_args = self.mock_client.post.call_args
+        assert "statistics" in call_args.kwargs["json"]
+
+    def test_drop_statistics(self):
+        """Test dropping statistics."""
+        statistics_to_drop = ["custom.avg_column_value", "custom.max_value"]
+
+        # Mock response
+        mock_response = Mock()
+        mock_response.json.return_value = {"code": 0, "dropped": True}
+        mock_response.in_stream = False
+
+        self.mock_client.delete.return_value = mock_response
+
+        # Call drop_statistics
+        dropped = self.stats_ops.drop_statistics(statistics_to_drop)
+
+        # Verify results
+        assert dropped is True
+
+        # Verify the request was called with correct parameters
+        self.mock_client.delete.assert_called_once()
+        call_args = self.mock_client.delete.call_args
+        assert (
+            call_args.kwargs["params"]["statistics"]
+            == "custom.avg_column_value,custom.max_value"
+        )
+
+    def test_invalid_metadata_object_type(self):
+        """Test that non-table metadata objects are rejected."""
+        catalog_object = MetadataObjectImpl(
+            [self.catalog_name], MetadataObject.Type.CATALOG
+        )
+
+        with self.assertRaises(IllegalArgumentException) as cm:
+            MetadataObjectStatisticsOperations(
+                self.metalake_name, self.catalog_name, catalog_object, self.mock_client
+            )
+
+        assert "Statistics are only supported for TABLE object type" in str(
+            cm.exception
+        )
+
+    def test_empty_statistics_update(self):
+        """Test that empty statistics update is rejected."""
+        with self.assertRaises(IllegalArgumentException) as cm:
+            self.stats_ops.update_statistics({})
+
+        assert "Statistics must not be None or empty" in str(cm.exception)
+
+    def test_empty_statistics_drop(self):
+        """Test that empty statistics drop is rejected."""
+        with self.assertRaises(IllegalArgumentException) as cm:
+            self.stats_ops.drop_statistics([])
+
+        assert "Statistics list must not be None or empty" in str(cm.exception)
+
+    def test_statistic_value_types(self):
+        """Test all supported statistic value types."""
+        # Test boolean value
+        bool_value = StatisticValues.of_boolean(True)
+        assert bool_value.value() is True
+        assert bool_value.data_type() == "boolean"
+
+        # Test long value
+        long_value = StatisticValues.of_long(12345)
+        assert long_value.value() == 12345
+        assert long_value.data_type() == "long"
+
+        # Test double value
+        double_value = StatisticValues.of_double(123.45)
+        assert double_value.value() == 123.45
+        assert double_value.data_type() == "double"
+
+        # Test string value
+        string_value = StatisticValues.of_string("test string")
+        assert string_value.value() == "test string"
+        assert string_value.data_type() == "string"
+
+        # Test list value
+        list_value = StatisticValues.of_list(
+            [
+                StatisticValues.of_long(1),
+                StatisticValues.of_long(2),
+                StatisticValues.of_long(3),
+            ]
+        )
+        assert len(list_value.value()) == 3
+        assert list_value.data_type() == "list"
+
+        # Test object value
+        object_value = StatisticValues.of_object(
+            {
+                "key1": StatisticValues.of_string("value1"),
+                "key2": StatisticValues.of_long(123),
+            }
+        )
+        assert len(object_value.value()) == 2
+        assert object_value.data_type() == "object"
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
What changes were proposed in this pull request?

  This PR implements the Python client for the Statistics API in Apache Gravitino. The implementation includes:
  - Statistics API interfaces (Statistic, StatisticValue, StatisticValues, SupportsStatistics)
  - DTOs for statistics data transfer (StatisticDTO, StatisticValueDTO)
  - Request/Response classes (StatisticsUpdateRequest, StatisticListResponse)
  - Client operations class (MetadataObjectStatisticsOperations)
  - Exception handling (IllegalStatisticNameException, UnmodifiableStatisticException)

  Why are the changes needed?

  - List statistics for metadata objects (tables)
  - Update statistics with custom values
  - Drop statistics by name

  Fix: [#(issue)](https://github.com/apache/gravitino/issues/7778)

  Does this PR introduce any user-facing change?

  Yes, this PR adds new user-facing APIs for Python users:
  1. New API classes: SupportsStatistics interface for objects that support statistics operations
  2. New methods: list_statistics(), update_statistics(), drop_statistics()
  3. New factory class: StatisticValues for creating statistic values of different types

  How was this patch tested?

  - Added unit tests in tests/unittests/test_statistics_api.py covering all components