### PR TITLE
[#7890] fix(CI): Fix auto cherry-pick CI action can't work

### DIFF
--- a/.github/workflows/auto-cherry-pick.yml
+++ b/.github/workflows/auto-cherry-pick.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Cherry pick into branch-0.8
-        uses: carloscastrojumo/github-cherry-pick-action@v1.0.9
+        uses: carloscastrojumo/github-cherry-pick-action@503773289f4a459069c832dc628826685b75b4b3
         with:
           branch: branch-0.8
           labels: |
@@ -36,7 +36,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Cherry pick into branch-0.9
-        uses: carloscastrojumo/github-cherry-pick-action@v1.0.9
+        uses: carloscastrojumo/github-cherry-pick-action@503773289f4a459069c832dc628826685b75b4b3
         with:
           branch: branch-0.9
           labels: |


### PR DESCRIPTION


### What changes were proposed in this pull request?

Change the verison of github-cherry-pick-action from v1.0.9 to 503773289f4a459069c832dc628826685b75b4b3

### Why are the changes needed?

Changes in https://github.com/apache/infrastructure-actions/commit/f65b1b9f5c4a50a7559fed2773a00f6361e1fe56 make v1.0.9 can't work.
Fix: #7890 

### Does this PR introduce _any_ user-facing change?

N/A.

### How was this patch tested?

CI
