### PR TITLE
[#7900] fix(catalogs): Fix jdbc catalogs DateTimeType column load with default value

### DIFF
--- a/api/src/main/java/org/apache/gravitino/rel/expressions/literals/Literals.java
+++ b/api/src/main/java/org/apache/gravitino/rel/expressions/literals/Literals.java
@@ -177,6 +177,16 @@ public class Literals {
   }
 
   /**
+   * Creates a date type literal with the given value.
+   *
+   * @param value the date literal value, must be in the format "yyyy-MM-dd"
+   * @return a new {@link Literal} instance
+   */
+  public static LiteralImpl<LocalDate> dateLiteral(String value) {
+    return dateLiteral(LocalDate.parse(value));
+  }
+
+  /**
    * Creates a time type literal with the given value.
    *
    * @param value the time literal value
@@ -184,6 +194,16 @@ public class Literals {
    */
   public static LiteralImpl<LocalTime> timeLiteral(LocalTime value) {
     return of(value, Types.TimeType.get());
+  }
+
+  /**
+   * Creates a time type literal with the given value.
+   *
+   * @param value the time literal value, must be in the format "HH:mm:ss"
+   * @return a new {@link Literal} instance
+   */
+  public static LiteralImpl<LocalTime> timeLiteral(String value) {
+    return timeLiteral(LocalTime.parse(value));
   }
 
   /**

--- a/catalogs/catalog-jdbc-doris/src/main/java/org/apache/gravitino/catalog/doris/converter/DorisColumnDefaultValueConverter.java
+++ b/catalogs/catalog-jdbc-doris/src/main/java/org/apache/gravitino/catalog/doris/converter/DorisColumnDefaultValueConverter.java
@@ -32,7 +32,6 @@ import static org.apache.gravitino.rel.Column.DEFAULT_VALUE_OF_CURRENT_TIMESTAMP
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.LocalTime;
 import org.apache.gravitino.catalog.jdbc.converter.JdbcColumnDefaultValueConverter;
 import org.apache.gravitino.catalog.jdbc.converter.JdbcTypeConverter;
 import org.apache.gravitino.rel.expressions.Expression;
@@ -83,9 +82,7 @@ public class DorisColumnDefaultValueConverter extends JdbcColumnDefaultValueConv
         return Literals.decimalLiteral(
             Decimal.of(columnDefaultValue, columnType.getColumnSize(), columnType.getScale()));
       case JdbcTypeConverter.DATE:
-        return Literals.dateLiteral(LocalDate.parse(columnDefaultValue, DATE_TIME_FORMATTER));
-      case JdbcTypeConverter.TIME:
-        return Literals.timeLiteral(LocalTime.parse(columnDefaultValue, DATE_TIME_FORMATTER));
+        return Literals.dateLiteral(LocalDate.parse(columnDefaultValue, DATE_FORMATTER));
       case JdbcTypeConverter.TIMESTAMP:
       case DATETIME:
         return CURRENT_TIMESTAMP.equals(columnDefaultValue)

--- a/catalogs/catalog-jdbc-mysql/src/main/java/org/apache/gravitino/catalog/mysql/converter/MysqlColumnDefaultValueConverter.java
+++ b/catalogs/catalog-jdbc-mysql/src/main/java/org/apache/gravitino/catalog/mysql/converter/MysqlColumnDefaultValueConverter.java
@@ -24,7 +24,6 @@ import static org.apache.gravitino.rel.Column.DEFAULT_VALUE_OF_CURRENT_TIMESTAMP
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import org.apache.gravitino.catalog.jdbc.converter.JdbcColumnDefaultValueConverter;
 import org.apache.gravitino.catalog.jdbc.converter.JdbcTypeConverter;
@@ -35,9 +34,6 @@ import org.apache.gravitino.rel.types.Decimal;
 import org.apache.gravitino.rel.types.Types;
 
 public class MysqlColumnDefaultValueConverter extends JdbcColumnDefaultValueConverter {
-
-  private static final DateTimeFormatter DATE_TIME_FORMATTER =
-      DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss[.SSSSSS][.SSSSS][.SSSS][.SSS][.SS][.S]");
 
   @Override
   public Expression toGravitino(
@@ -90,7 +86,7 @@ public class MysqlColumnDefaultValueConverter extends JdbcColumnDefaultValueConv
       case JdbcTypeConverter.DATE:
         return Literals.dateLiteral(LocalDate.parse(columnDefaultValue, DATE_FORMATTER));
       case JdbcTypeConverter.TIME:
-        return Literals.timeLiteral(LocalTime.parse(columnDefaultValue, DATE_TIME_FORMATTER));
+        return Literals.timeLiteral(LocalTime.parse(columnDefaultValue, TIME_FORMATTER));
       case JdbcTypeConverter.TIMESTAMP:
       case MysqlTypeConverter.DATETIME:
         if (columnDefaultValue.startsWith(CURRENT_TIMESTAMP)) {

--- a/catalogs/catalog-jdbc-mysql/src/test/java/org/apache/gravitino/catalog/mysql/integration/test/CatalogMysqlIT.java
+++ b/catalogs/catalog-jdbc-mysql/src/test/java/org/apache/gravitino/catalog/mysql/integration/test/CatalogMysqlIT.java
@@ -528,6 +528,8 @@ public class CatalogMysqlIT extends BaseIT {
             + "  varchar200_col_1 varchar(200) default 'curdate()',\n"
             + "  varchar200_col_2 varchar(200) default (curdate()),\n"
             + "  varchar200_col_3 varchar(200) default (CURRENT_TIMESTAMP),\n"
+            + "  time_col_1 time default '00:00:00',\n"
+            + "  time_col_2 time default (now()),\n"
             + "  datetime_col_1 datetime default CURRENT_TIMESTAMP,\n"
             + "  datetime_col_2 datetime default current_timestamp,\n"
             + "  datetime_col_3 datetime default null,\n"
@@ -583,6 +585,12 @@ public class CatalogMysqlIT extends BaseIT {
           Assertions.assertEquals(UnparsedExpression.of("curdate()"), column.defaultValue());
           break;
         case "varchar200_col_3":
+          Assertions.assertEquals(UnparsedExpression.of("now()"), column.defaultValue());
+          break;
+        case "time_col_1":
+          Assertions.assertEquals(Literals.timeLiteral("00:00:00"), column.defaultValue());
+          break;
+        case "time_col_2":
           Assertions.assertEquals(UnparsedExpression.of("now()"), column.defaultValue());
           break;
         case "datetime_col_1":

--- a/catalogs/catalog-jdbc-oceanbase/src/main/java/org/apache/gravitino/catalog/oceanbase/converter/OceanBaseColumnDefaultValueConverter.java
+++ b/catalogs/catalog-jdbc-oceanbase/src/main/java/org/apache/gravitino/catalog/oceanbase/converter/OceanBaseColumnDefaultValueConverter.java
@@ -92,7 +92,7 @@ public class OceanBaseColumnDefaultValueConverter extends JdbcColumnDefaultValue
       case JdbcTypeConverter.DATE:
         return Literals.dateLiteral(LocalDate.parse(columnDefaultValue, DATE_FORMATTER));
       case JdbcTypeConverter.TIME:
-        return Literals.timeLiteral(LocalTime.parse(columnDefaultValue, DATE_TIME_FORMATTER));
+        return Literals.timeLiteral(LocalTime.parse(columnDefaultValue, TIME_FORMATTER));
       case JdbcTypeConverter.TIMESTAMP:
       case OceanBaseTypeConverter.DATETIME:
         return CURRENT_TIMESTAMP.matcher(columnDefaultValue).matches()

--- a/catalogs/catalog-jdbc-oceanbase/src/test/java/org/apache/gravitino/catalog/oceanbase/integration/test/CatalogOceanBaseIT.java
+++ b/catalogs/catalog-jdbc-oceanbase/src/test/java/org/apache/gravitino/catalog/oceanbase/integration/test/CatalogOceanBaseIT.java
@@ -495,6 +495,7 @@ public class CatalogOceanBaseIT extends BaseIT {
             + "  double_col_1 double default 123.45,\n"
             + "  varchar100_col_1 varchar(100) default 'CURRENT_TIMESTAMP',\n"
             + "  varchar200_col_1 varchar(200) default 'curdate()',\n"
+            + "  time_col_1 time default '00:00:00',\n"
             + "  datetime_col_1 datetime default CURRENT_TIMESTAMP,\n"
             + "  datetime_col_2 datetime default current_timestamp,\n"
             + "  datetime_col_3 datetime default null,\n"
@@ -539,6 +540,9 @@ public class CatalogOceanBaseIT extends BaseIT {
           break;
         case "varchar200_col_1":
           Assertions.assertEquals(Literals.varcharLiteral(200, "curdate()"), column.defaultValue());
+          break;
+        case "time_col_1":
+          Assertions.assertEquals(Literals.timeLiteral("00:00:00"), column.defaultValue());
           break;
         case "datetime_col_1":
         case "datetime_col_2":

--- a/catalogs/catalog-jdbc-postgresql/src/main/java/org/apache/gravitino/catalog/postgresql/converter/PostgreSqlColumnDefaultValueConverter.java
+++ b/catalogs/catalog-jdbc-postgresql/src/main/java/org/apache/gravitino/catalog/postgresql/converter/PostgreSqlColumnDefaultValueConverter.java
@@ -23,6 +23,7 @@ import static org.apache.gravitino.rel.Column.DEFAULT_VALUE_NOT_SET;
 import static org.apache.gravitino.rel.Column.DEFAULT_VALUE_OF_CURRENT_TIMESTAMP;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -98,9 +99,13 @@ public class PostgreSqlColumnDefaultValueConverter extends JdbcColumnDefaultValu
         return Literals.decimalLiteral(
             Decimal.of(columnDefaultValue, type.getColumnSize(), type.getScale()));
       case JdbcTypeConverter.DATE:
-        return Literals.dateLiteral(LocalDate.parse(columnDefaultValue, DATE_TIME_FORMATTER));
+        return Literals.dateLiteral(LocalDate.parse(columnDefaultValue, DATE_FORMATTER));
+      case JdbcTypeConverter.TIME:
+        return Literals.timeLiteral(LocalTime.parse(columnDefaultValue, TIME_FORMATTER));
+      case JdbcTypeConverter.TIMESTAMP:
       case PostgreSqlTypeConverter.TIMESTAMP_TZ:
-        return Literals.timeLiteral(LocalTime.parse(columnDefaultValue, DATE_TIME_FORMATTER));
+        return Literals.timestampLiteral(
+            LocalDateTime.parse(columnDefaultValue, DATE_TIME_FORMATTER));
       case VARCHAR:
         return Literals.varcharLiteral(type.getColumnSize(), columnDefaultValue);
       case PostgreSqlTypeConverter.BPCHAR:

--- a/catalogs/catalog-jdbc-postgresql/src/test/java/org/apache/gravitino/catalog/postgresql/integration/test/CatalogPostgreSqlIT.java
+++ b/catalogs/catalog-jdbc-postgresql/src/test/java/org/apache/gravitino/catalog/postgresql/integration/test/CatalogPostgreSqlIT.java
@@ -27,6 +27,9 @@ import com.google.common.collect.Sets;
 import java.io.IOException;
 import java.sql.DriverManager;
 import java.sql.SQLException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
@@ -917,8 +920,32 @@ public class CatalogPostgreSqlIT extends BaseIT {
             true,
             false,
             Literals.integerLiteral(1000));
+    Column col7 =
+        Column.of(
+            "col_7",
+            Types.DateType.get(),
+            "col_7_comment",
+            false,
+            false,
+            Literals.dateLiteral("2024-01-01"));
+    Column col8 =
+        Column.of(
+            "col_8",
+            Types.TimestampType.withoutTimeZone(),
+            "col_8_comment",
+            false,
+            false,
+            Literals.timestampLiteral("2024-01-01T01:01:01"));
+    Column col9 =
+        Column.of(
+            "col_9",
+            Types.TimeType.get(),
+            "col_9_comment",
+            false,
+            false,
+            Literals.timeLiteral("01:01:01"));
 
-    Column[] newColumns = new Column[] {col1, col2, col3, col4, col5, col6};
+    Column[] newColumns = new Column[] {col1, col2, col3, col4, col5, col6, col7, col8, col9};
 
     NameIdentifier tableIdent =
         NameIdentifier.of(schemaName, GravitinoITUtils.genRandomName("pg_it_table"));
@@ -934,6 +961,13 @@ public class CatalogPostgreSqlIT extends BaseIT {
     Assertions.assertEquals(
         Literals.varcharLiteral(255, "current_timestamp"), loadedTable.columns()[4].defaultValue());
     Assertions.assertEquals(Literals.integerLiteral(1000), loadedTable.columns()[5].defaultValue());
+    Assertions.assertEquals(
+        Literals.dateLiteral(LocalDate.of(2024, 1, 1)), loadedTable.columns()[6].defaultValue());
+    Assertions.assertEquals(
+        Literals.timestampLiteral(LocalDateTime.of(2024, 1, 1, 1, 1, 1)),
+        loadedTable.columns()[7].defaultValue());
+    Assertions.assertEquals(
+        Literals.timeLiteral(LocalTime.of(1, 1, 1)), loadedTable.columns()[8].defaultValue());
   }
 
   @Test
@@ -1001,9 +1035,10 @@ public class CatalogPostgreSqlIT extends BaseIT {
             + "    date_col_2 date,\n"
             + "    date_col_3 date default (current_date + interval '1 year'),\n"
             + "    date_col_4 date default current_date,\n"
-            // todo: uncomment when we support timestamp in PG catalog
-            // + "    timestamp_col_1 timestamp default '2012-12-31 11:30:45',\n"
-            + "    decimal_6_2_col_1 decimal(6, 2) default 1.2\n"
+            + "    date_col_5 date default '2012-12-31',\n"
+            + "    decimal_6_2_col_1 decimal(6, 2) default 1.2,\n"
+            + "    timestamp_col_1 timestamp default '2012-12-31 11:30:45',\n"
+            + "    time_col_1 time default '11:30:45'\n"
             + ");";
     System.out.println(sql);
     postgreSqlService.executeQuery(sql);
@@ -1057,13 +1092,15 @@ public class CatalogPostgreSqlIT extends BaseIT {
         case "date_col_4":
           Assertions.assertEquals(UnparsedExpression.of("CURRENT_DATE"), column.defaultValue());
           break;
+        case "date_col_5":
+          Assertions.assertEquals(Literals.dateLiteral("2012-12-31"), column.defaultValue());
+          break;
         case "timestamp_col_1":
           Assertions.assertEquals(
               Literals.timestampLiteral("2012-12-31T11:30:45"), column.defaultValue());
           break;
-        case "timestamp_col_2":
-          Assertions.assertEquals(
-              Literals.timestampLiteral("1983-09-05T00:00:00"), column.defaultValue());
+        case "time_col_1":
+          Assertions.assertEquals(Literals.timeLiteral("11:30:45"), column.defaultValue());
           break;
         case "decimal_6_2_col_1":
           Assertions.assertEquals(

--- a/catalogs/catalog-jdbc-starrocks/src/main/java/org/apache/gravitino/catalog/starrocks/converter/StarRocksColumnDefaultValueConverter.java
+++ b/catalogs/catalog-jdbc-starrocks/src/main/java/org/apache/gravitino/catalog/starrocks/converter/StarRocksColumnDefaultValueConverter.java
@@ -84,7 +84,7 @@ public class StarRocksColumnDefaultValueConverter extends JdbcColumnDefaultValue
         return Literals.decimalLiteral(
             Decimal.of(columnDefaultValue, columnType.getColumnSize(), columnType.getScale()));
       case DATE:
-        return Literals.dateLiteral(LocalDate.parse(columnDefaultValue, DATE_TIME_FORMATTER));
+        return Literals.dateLiteral(LocalDate.parse(columnDefaultValue, DATE_FORMATTER));
       case DATETIME:
         return CURRENT_TIMESTAMP.equals(columnDefaultValue)
             ? DEFAULT_VALUE_OF_CURRENT_TIMESTAMP

--- a/catalogs/catalog-jdbc-starrocks/src/test/java/org/apache/gravitino/catalog/starrocks/integration/test/CatalogStarRocksIT.java
+++ b/catalogs/catalog-jdbc-starrocks/src/test/java/org/apache/gravitino/catalog/starrocks/integration/test/CatalogStarRocksIT.java
@@ -19,6 +19,7 @@
 package org.apache.gravitino.catalog.starrocks.integration.test;
 
 import static org.apache.gravitino.integration.test.util.ITUtils.assertPartition;
+import static org.apache.gravitino.rel.Column.DEFAULT_VALUE_OF_CURRENT_TIMESTAMP;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -27,6 +28,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import java.io.IOException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -924,5 +927,73 @@ public class CatalogStarRocksIT extends BaseIT {
     Assertions.assertArrayEquals(
         distribution.expressions(), loadTable.distribution().expressions());
     tableCatalog.dropTable(tableIdentifier);
+  }
+
+  @Test
+  void testColumnDefaultValue() {
+    // create a table
+    String tableName = GravitinoITUtils.genRandomName("test_table_with_defaule_value");
+    NameIdentifier tableIdentifier = NameIdentifier.of(schemaName, tableName);
+    Column[] columns = createColumns();
+    Column col_default_value_date =
+        Column.of(
+            "col_default_value_date",
+            Types.DateType.get(),
+            "col_default_value_date",
+            false,
+            false,
+            Literals.dateLiteral("2024-01-01"));
+
+    Column col_default_value_timestamp =
+        Column.of(
+            "col_default_value_timestamp",
+            Types.TimestampType.withoutTimeZone(),
+            "col_default_value_timestamp",
+            false,
+            false,
+            Literals.timestampLiteral("2024-01-01T01:01:01"));
+
+    Column col_default_value_timestamp_2 =
+        Column.of(
+            "col_default_value_timestamp_2",
+            Types.TimestampType.withoutTimeZone(),
+            "col_default_value_timestamp_2",
+            false,
+            false,
+            DEFAULT_VALUE_OF_CURRENT_TIMESTAMP);
+    columns =
+        ArrayUtils.addAll(
+            columns,
+            col_default_value_date,
+            col_default_value_timestamp,
+            col_default_value_timestamp_2);
+    Distribution distribution = createDistribution();
+
+    Map<String, String> properties = createTableProperties();
+    TableCatalog tableCatalog = catalog.asTableCatalog();
+    tableCatalog.createTable(
+        tableIdentifier,
+        columns,
+        table_comment,
+        properties,
+        Transforms.EMPTY_TRANSFORM,
+        distribution,
+        null,
+        null);
+
+    // load table
+    Table loadTable = tableCatalog.loadTable(tableIdentifier);
+
+    Column[] colDefaultValues =
+        Arrays.stream(loadTable.columns())
+            .filter(c -> c.name().startsWith("col_default_value_"))
+            .toArray(Column[]::new);
+
+    Assertions.assertEquals(
+        Literals.dateLiteral(LocalDate.of(2024, 1, 1)), colDefaultValues[0].defaultValue());
+    Assertions.assertEquals(
+        Literals.timestampLiteral(LocalDateTime.of(2024, 1, 1, 1, 1, 1)),
+        colDefaultValues[1].defaultValue());
+    Assertions.assertEquals(DEFAULT_VALUE_OF_CURRENT_TIMESTAMP, colDefaultValues[2].defaultValue());
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Update DateTimeType column default value formatter.

- TimeType: "HH:mm:ss[.SSSSSS][.SSSSS][.SSSS][.SSS][.SS][.S]"
- TimestampType: "yyyy-MM-dd HH:mm:ss[.SSSSSS][.SSSSS][.SSSS][.SSS][.SS][.S]"

### Why are the changes needed?
Fix: #7900 

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
local tests
