### PR TITLE
[#7888] fix incorrect path in docs for list partitions

### DIFF
--- a/docs/open-api/openapi.yaml
+++ b/docs/open-api/openapi.yaml
@@ -98,7 +98,7 @@ paths:
   /metalakes/{metalake}/catalogs/{catalog}/schemas/{schema}/tables/{table}:
     $ref: "./tables.yaml#/paths/~1metalakes~1%7Bmetalake%7D~1catalogs~1%7Bcatalog%7D~1schemas~1%7Bschema%7D~1tables~1%7Btable%7D"
 
-  /metalaskes/{metalake}/catalogs/{catalog}/schemas/{schema}/tables/{table}/partitions:
+  /metalakes/{metalake}/catalogs/{catalog}/schemas/{schema}/tables/{table}/partitions:
     $ref: "./partitions.yaml#/paths/~1metalakes~1%7Bmetalake%7D~1catalogs~1%7Bcatalog%7D~1schemas~1%7Bschema%7D~1tables~1%7Btable%7D~1partitions"
 
   /metalakes/{metalake}/catalogs/{catalog}/schemas/{schema}/tables/{table}/partitions/{partition}:


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Fix the incorrect path in OpenAPI docs for list partitions.

### Why are the changes needed?

The existing path has a typo.
Fix: #7888 

### Does this PR introduce _any_ user-facing change?

Yes, user-facing OpenAPI doc.

### How was this patch tested?

Rendering `openapi.yaml`.
