### PR TITLE
[#7906] improvement(trino-connector): Increase the priority of configuration which is defined by Gravitino

### DIFF
--- a/docs/trino-connector/supported-catalog.md
+++ b/docs/trino-connector/supported-catalog.md
@@ -137,6 +137,7 @@ call gravitino.system.create_catalog(
 ```
 
 A prefix with `trino.bypass.` in the configuration key is used to indicate Gravitino Trino connector to pass the Trino connector configuration to the Gravitino catalog in the Trino runtime.
+Note that it is when a configuration property is explicitly defined in Gravitino that the `trino.bypass.`properties which for the same property will be skipped.
 
 More Trino connector configurations can refer to:
 - [Hive catalog](https://trino.io/docs/current/connector/hive.html#hive-general-configuration-properties)

--- a/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/catalog/hive/HiveConnectorAdapter.java
+++ b/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/catalog/hive/HiveConnectorAdapter.java
@@ -49,11 +49,13 @@ public class HiveConnectorAdapter implements CatalogConnectorAdapter {
   public Map<String, String> buildInternalConnectorConfig(GravitinoCatalog catalog)
       throws Exception {
     Map<String, String> config = new HashMap<>();
-    config.put("hive.metastore.uri", catalog.getRequiredProperty("metastore.uris"));
-    config.put("hive.security", "allow-all");
+    String metastoreUri = catalog.getRequiredProperty("metastore.uris");
     Map<String, String> trinoProperty =
         catalogConverter.gravitinoToEngineProperties(catalog.getProperties());
+    // The order of put operations determines the priority of parameters.
     config.putAll(trinoProperty);
+    config.put("hive.metastore.uri", metastoreUri);
+    config.put("hive.security", "allow-all");
     return config;
   }
 

--- a/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/catalog/iceberg/IcebergCatalogPropertyConverter.java
+++ b/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/catalog/iceberg/IcebergCatalogPropertyConverter.java
@@ -55,8 +55,11 @@ public class IcebergCatalogPropertyConverter extends CatalogPropertyConverter {
       default:
         throw new UnsupportedOperationException("Unsupported backend type: " + backend);
     }
-    stringStringMap.putAll(super.gravitinoToEngineProperties(properties));
-    return stringStringMap;
+    Map<String, String> config = new HashMap<>();
+    // The order of put operations determines the priority of parameters.
+    config.putAll(super.gravitinoToEngineProperties(properties));
+    config.putAll(stringStringMap);
+    return config;
   }
 
   private Map<String, String> buildHiveBackendProperties(Map<String, String> properties) {

--- a/trino-connector/trino-connector/src/test/java/org/apache/gravitino/trino/connector/catalog/hive/TestHiveCatalogPropertyConverter.java
+++ b/trino-connector/trino-connector/src/test/java/org/apache/gravitino/trino/connector/catalog/hive/TestHiveCatalogPropertyConverter.java
@@ -51,12 +51,15 @@ public class TestHiveCatalogPropertyConverter {
   @SuppressWarnings("unchecked")
   public void testBuildConnectorProperties() throws Exception {
     String name = "test_catalog";
+    // trino.bypass properties will be skipped when the catalog properties is defined by Gravitino
     Map<String, String> properties =
         ImmutableMap.<String, String>builder()
+            .put("trino.bypass.hive.security", "skip_value")
             .put("metastore.uris", "thrift://localhost:9083")
             .put("unknown-key", "1")
             .put("trino.bypass.hive.unknown-key", "1")
             .put("trino.bypass.hive.config.resources", "/tmp/hive-site.xml, /tmp/core-site.xml")
+            .put("trino.bypass.hive.metastore.uri", "skip_value")
             .build();
     Catalog mockCatalog =
         TestGravitinoCatalog.mockCatalog(

--- a/trino-connector/trino-connector/src/test/java/org/apache/gravitino/trino/connector/catalog/iceberg/TestIcebergCatalogPropertyConverter.java
+++ b/trino-connector/trino-connector/src/test/java/org/apache/gravitino/trino/connector/catalog/iceberg/TestIcebergCatalogPropertyConverter.java
@@ -129,8 +129,10 @@ public class TestIcebergCatalogPropertyConverter {
   @SuppressWarnings("unchecked")
   public void testBuildConnectorPropertiesWithMySqlBackEnd() throws Exception {
     String name = "test_catalog";
+    // trino.bypass properties will be skipped when the catalog properties is defined by Gravitino
     Map<String, String> properties =
         ImmutableMap.<String, String>builder()
+            .put("trino.bypass.iceberg.jdbc-catalog.connection-url", "skip_value")
             .put("uri", "jdbc:mysql://%s:3306/metastore_db?createDatabaseIfNotExist=true")
             .put("catalog-backend", "jdbc")
             .put("warehouse", "://tmp/warehouse")
@@ -140,6 +142,7 @@ public class TestIcebergCatalogPropertyConverter {
             .put("unknown-key", "1")
             .put("trino.bypass.iceberg.unknown-key", "1")
             .put("trino.bypass.iceberg.table-statistics-enabled", "true")
+            .put("trino.bypass.iceberg.jdbc-catalog.connection-user", "skip_value")
             .build();
     Catalog mockCatalog =
         TestGravitinoCatalog.mockCatalog(

--- a/trino-connector/trino-connector/src/test/java/org/apache/gravitino/trino/connector/catalog/jdbc/mysql/TestMySQLCatalogPropertyConverter.java
+++ b/trino-connector/trino-connector/src/test/java/org/apache/gravitino/trino/connector/catalog/jdbc/mysql/TestMySQLCatalogPropertyConverter.java
@@ -32,14 +32,17 @@ public class TestMySQLCatalogPropertyConverter {
   @SuppressWarnings("unchecked")
   public void testBuildMySqlConnectorProperties() throws Exception {
     String name = "test_catalog";
+    // trino.bypass properties will be skipped when the catalog properties is defined by Gravitino
     Map<String, String> properties =
         ImmutableMap.<String, String>builder()
+            .put("trino.bypass.connection-user", "skip_value")
             .put("jdbc-url", "jdbc:mysql://localhost:5432/test")
             .put("jdbc-user", "test")
             .put("jdbc-password", "test")
             .put("trino.bypass.join-pushdown.strategy", "EAGER")
             .put("unknown-key", "1")
             .put("trino.bypass.mysql.unknown-key", "1")
+            .put("trino.bypass.connection-url", "skip_value")
             .build();
     Catalog mockCatalog =
         TestGravitinoCatalog.mockCatalog(


### PR DESCRIPTION
### What changes were proposed in this pull request?
`trino.bypass` properties will be skipped when the catalog properties is defined by Gravitino

### Why are the changes needed?
Fix: #7906 

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
local tests