### PR TITLE
[#7823] feat(server): upgrade Gravitino server mini JDK version to 17

### DIFF
--- a/.github/workflows/backend-integration-test.yml
+++ b/.github/workflows/backend-integration-test.yml
@@ -54,7 +54,7 @@ jobs:
     strategy:
       matrix:
         architecture: [linux/amd64]
-        java-version: [ 8, 11, 17 ]
+        java-version: [ 17 ]
         backend: [ h2, mysql, postgresql ]
         test-mode: [ embedded, deploy ]
         exclude:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,7 @@ jobs:
 
       - uses: actions/setup-java@v4
         with:
-          java-version: 8
+          java-version: 17
           distribution: 'temurin'
           cache: 'gradle'
 
@@ -76,7 +76,7 @@ jobs:
 
       - uses: actions/setup-java@v4
         with:
-          java-version: 8
+          java-version: 17
           distribution: 'temurin'
           cache: 'gradle'
 
@@ -103,7 +103,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java-version: [ 8, 11, 17 ]
+        java-version: [ 17 ]
     timeout-minutes: 60
     needs: changes
     if: needs.changes.outputs.source_changes == 'true'

--- a/.github/workflows/cron-integration-test.yml
+++ b/.github/workflows/cron-integration-test.yml
@@ -55,7 +55,7 @@ jobs:
     strategy:
       matrix:
         architecture: [linux/amd64]
-        java-version: [ 8, 11, 17 ]
+        java-version: [ 17 ]
         test-mode: [ embedded, deploy ]
     env:
       DOCKER_RUN_NAME: hive-amd64

--- a/.github/workflows/flink-integration-test.yml
+++ b/.github/workflows/flink-integration-test.yml
@@ -53,7 +53,7 @@ jobs:
     strategy:
       matrix:
         architecture: [linux/amd64]
-        java-version: [ 8, 11, 17 ]
+        java-version: [ 17 ]
     uses: ./.github/workflows/flink-integration-test-action.yml
     with:
       architecture: ${{ matrix.architecture }}

--- a/.github/workflows/spark-integration-test.yml
+++ b/.github/workflows/spark-integration-test.yml
@@ -53,7 +53,7 @@ jobs:
       matrix:
         # Integration test for AMD64 architecture
         architecture: [linux/amd64]
-        java-version: [ 8, 11, 17 ]
+        java-version: [ 17 ]
         scala-version: [ 2.12 ]
         test-mode: [ embedded, deploy ]
     uses: ./.github/workflows/spark-integration-test-action.yml

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -286,8 +286,6 @@ subprojects {
         languageVersion.set(JavaLanguageVersion.of(17))
       } else {
         languageVersion.set(JavaLanguageVersion.of(extra["jdkVersion"].toString().toInt()))
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
       }
     }
   }

--- a/catalogs/catalog-fileset/src/test/java/org/apache/gravitino/catalog/fileset/integration/test/HadoopUserAuthenticationIT.java
+++ b/catalogs/catalog-fileset/src/test/java/org/apache/gravitino/catalog/fileset/integration/test/HadoopUserAuthenticationIT.java
@@ -57,7 +57,6 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.utility.MountableFile;
-import sun.security.krb5.KrbException;
 
 @Tag("gravitino-docker-test")
 public class HadoopUserAuthenticationIT extends BaseIT {
@@ -135,7 +134,7 @@ public class HadoopUserAuthenticationIT extends BaseIT {
     System.clearProperty("sun.security.krb5.debug");
   }
 
-  private static void prepareKerberosConfig() throws IOException, KrbException {
+  private static void prepareKerberosConfig() throws IOException {
     // Keytab of the Gravitino SDK client
     kerberosHiveContainer
         .getContainer()

--- a/gradle.properties
+++ b/gradle.properties
@@ -30,8 +30,8 @@ SONATYPE_USER = admin
 SONATYPE_PASSWORD = password
 
 # jdkVersion is used to specify the version of JDK to build and test Gravitino, current
-# supported version is 8, 11, and 17.
-jdkVersion = 8
+# supported version is 17.
+jdkVersion = 17
 
 # defaultScalaVersion is used to specify the version of Scala to build and test Gravitino
 defaultScalaVersion = 2.12


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. Upgrade Gravitino server server minimal JDK version to 17
2. Remove other version of JDK in CI pipe lines.
### Why are the changes needed?

We could upgrade the Iceberg version only if we upgrade the IRC and Gravitino server

Fix: #7823 

### Does this PR introduce _any_ user-facing change?

Yes, the server couldn't run under JDK8, JDK11

### How was this patch tested?

UTs and ITs