### PR TITLE
[#7945] refactor: Validate Provider type and clarify OAuth provider config supports 'default' and 'oidc'

### DIFF
--- a/server-common/src/main/java/org/apache/gravitino/server/authentication/OAuthConfig.java
+++ b/server-common/src/main/java/org/apache/gravitino/server/authentication/OAuthConfig.java
@@ -77,10 +77,22 @@ public interface OAuthConfig {
   // OAuth provider configs
   ConfigEntry<String> PROVIDER =
       new ConfigBuilder(OAUTH_CONFIG_PREFIX + "provider")
-          .doc("The OAuth provider to use (e.g., azure)")
+          .doc(
+              "The OAuth provider to use. This will be used in the Gravitino Web UI to determine the authentication flow.")
           .version(ConfigConstants.VERSION_1_0_0)
           .stringConf()
-          .create();
+          .checkValue(
+              value -> {
+                if (value == null) return false;
+                for (ProviderType type : ProviderType.values()) {
+                  if (type.name().equalsIgnoreCase(value)) {
+                    return true;
+                  }
+                }
+                return false;
+              },
+              "Invalid OAuth provider type. Supported values: 'default', 'oidc'")
+          .createWithDefault(ProviderType.DEFAULT.name().toLowerCase());
 
   ConfigEntry<String> CLIENT_ID =
       new ConfigBuilder(OAUTH_CONFIG_PREFIX + "clientId")
@@ -91,21 +103,21 @@ public interface OAuthConfig {
 
   ConfigEntry<String> AUTHORITY =
       new ConfigBuilder(OAUTH_CONFIG_PREFIX + "authority")
-          .doc("OAuth authority URL (authorization server)")
+          .doc("OAuth authority URL (authorization server) used for Web UI authentication")
           .version(ConfigConstants.VERSION_1_0_0)
           .stringConf()
           .create();
 
   ConfigEntry<String> SCOPE =
       new ConfigBuilder(OAUTH_CONFIG_PREFIX + "scope")
-          .doc("OAuth scopes (space-separated)")
+          .doc("OAuth scopes (space-separated) used for Web UI authentication")
           .version(ConfigConstants.VERSION_1_0_0)
           .stringConf()
           .create();
 
   ConfigEntry<String> JWKS_URI =
       new ConfigBuilder(OAUTH_CONFIG_PREFIX + "jwksUri")
-          .doc("JWKS URI for token validation")
+          .doc("JWKS URI used for server-side OAuth token validation")
           .version(ConfigConstants.VERSION_1_0_0)
           .stringConf()
           .create();

--- a/server-common/src/main/java/org/apache/gravitino/server/authentication/OAuthConfig.java
+++ b/server-common/src/main/java/org/apache/gravitino/server/authentication/OAuthConfig.java
@@ -91,7 +91,13 @@ public interface OAuthConfig {
                 }
                 return false;
               },
-              "Invalid OAuth provider type. Supported values: 'default', 'oidc'")
+              "Invalid OAuth provider type. Supported values: '"
+                  + String.join(
+                      ", ",
+                      java.util.Arrays.stream(ProviderType.values())
+                          .map(v -> v.name().toLowerCase())
+                          .toArray(String[]::new))
+                  + "'")
           .createWithDefault(ProviderType.DEFAULT.name().toLowerCase());
 
   ConfigEntry<String> CLIENT_ID =

--- a/server-common/src/main/java/org/apache/gravitino/server/authentication/ProviderType.java
+++ b/server-common/src/main/java/org/apache/gravitino/server/authentication/ProviderType.java
@@ -17,12 +17,12 @@
  * under the License.
  */
 
-package org.apache.gravitino.auth;
+package org.apache.gravitino.server.authentication;
 
-/** The type of OAuth provider. */
+/** The type of OAuth provider to use for Gravitino Web UI OAuth sign-in workflow. */
 public enum ProviderType {
   /** Default provider. */
   DEFAULT,
-  /** Azure AD provider. */
-  AZURE
+  /** OIDC provider. */
+  OIDC
 }

--- a/server-common/src/test/java/org/apache/gravitino/server/authentication/TestOAuthConfig.java
+++ b/server-common/src/test/java/org/apache/gravitino/server/authentication/TestOAuthConfig.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.server.authentication;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.gravitino.Config;
+import org.junit.jupiter.api.Test;
+
+public class TestOAuthConfig {
+
+  @Test
+  public void testValidProviderTypes() {
+    Config config = new Config(false) {};
+
+    // Test valid provider types (case insensitive)
+    Map<String, String> properties = new HashMap<>();
+
+    properties.put("gravitino.authenticator.oauth.provider", "default");
+    config.loadFromMap(properties, k -> true);
+    assertEquals("default", config.get(OAuthConfig.PROVIDER));
+
+    properties.clear();
+    properties.put("gravitino.authenticator.oauth.provider", "OIDC");
+    config.loadFromMap(properties, k -> true);
+    assertEquals("OIDC", config.get(OAuthConfig.PROVIDER));
+  }
+
+  @Test
+  public void testInvalidProviderType() {
+    Config config = new Config(false) {};
+
+    Map<String, String> properties = new HashMap<>();
+    properties.put("gravitino.authenticator.oauth.provider", "invalid_provider");
+
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> {
+              config.loadFromMap(properties, k -> true);
+              config.get(OAuthConfig.PROVIDER); // This triggers validation
+            });
+
+    assertTrue(exception.getMessage().contains("Invalid OAuth provider type"));
+    assertTrue(exception.getMessage().contains("default"));
+    assertTrue(exception.getMessage().contains("oidc"));
+  }
+
+  @Test
+  public void testDefaultProviderValue() {
+    Config config = new Config(false) {};
+
+    // No provider specified, should use default
+    Map<String, String> properties = new HashMap<>();
+    config.loadFromMap(properties, k -> true);
+    assertEquals("default", config.get(OAuthConfig.PROVIDER));
+  }
+}


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Move ProviderType from common to server-common, and provide the supported values (default, oidc). Use it to validate the OAuthConfig provider

### Why are the changes needed?

Minor refactor and validate the config

Fix: #7945

### Does this PR introduce _any_ user-facing change?

NA
### How was this patch tested?
Added unit tests

Tested manually as well:
<img width="1847" height="206" alt="Screenshot 2025-08-06 at 2 54 51 PM" src="https://github.com/user-attachments/assets/5f68112f-0756-440a-955d-0bf7acf2d980" />