### PR TITLE
[#7958] fix(namespace): reject blank or whitespace-only input in fromString()

### DIFF
--- a/api/src/main/java/org/apache/gravitino/Namespace.java
+++ b/api/src/main/java/org/apache/gravitino/Namespace.java
@@ -75,14 +75,13 @@ public class Namespace {
    */
   public static Namespace fromString(String namespace) {
     Preconditions.checkArgument(namespace != null, "Cannot create a namespace with null input");
+    // Reject blank or whitespace-only namespaces (e.g., " ", "\t", "\n")
+    Preconditions.checkArgument(!StringUtils.isBlank(namespace), "Cannot create a namespace with blank input");
     Preconditions.checkArgument(!namespace.endsWith("."), "Cannot create a namespace end with dot");
     Preconditions.checkArgument(
         !namespace.startsWith("."), "Cannot create a namespace starting with a dot");
     Preconditions.checkArgument(
         !namespace.contains(".."), "Cannot create a namespace with an empty level");
-    if (StringUtils.isBlank(namespace)) {
-      return empty();
-    }
     return Namespace.of(namespace.split("\\."));
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR updates the `Namespace.fromString()` method to reject inputs that are blank or consist only of whitespace (e.g., `" "`, `"\t"`, `"\n"`).  
A new precondition was added using `StringUtils.isBlank(...)`, and placed early in the validation chain to ensure the method fails fast on invalid input.

### Why are the changes needed?

Previously, passing a blank or whitespace-only string would bypass structural validations and return a namespace unexpectedly (e.g., via `.split()` producing an empty array).  
This could lead to invalid namespace objects or hidden bugs in downstream components.

### Fix: #7958 


### Does this PR introduce _any_ user-facing change?

Yes.  
Calling `Namespace.fromString(" ")` or similar will now throw an `IllegalArgumentException` instead of silently creating an empty namespace.

### How was this patch tested?

- a test case in `testFromStringInvalidArgs` exists to verify the behavior:
  ```java
  Assertions.assertThrows(IllegalArgumentException.class, () -> Namespace.fromString(" "));
