### PR TITLE
[#7958] fix(authz): Include recursive flag in hashCode(), equals(), toString()

### DIFF
--- a/authorizations/authorization-common/src/main/java/org/apache/gravitino/authorization/common/PathBasedMetadataObject.java
+++ b/authorizations/authorization-common/src/main/java/org/apache/gravitino/authorization/common/PathBasedMetadataObject.java
@@ -174,12 +174,13 @@ public class PathBasedMetadataObject implements AuthorizationMetadataObject {
     return Objects.equals(name, that.name)
         && Objects.equals(parent, that.parent)
         && Objects.equals(path, that.path)
-        && Objects.equals(type, that.type);
+        && Objects.equals(type, that.type)
+        && Objects.equals(recursive, that.recursive);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, parent, path, type);
+    return Objects.hash(name, parent, path, type, recursive);
   }
 
   @Override
@@ -191,6 +192,8 @@ public class PathBasedMetadataObject implements AuthorizationMetadataObject {
         + strPath
         + "], [type="
         + type
+        + "], [recursive="
+        + recursive
         + "]";
   }
 }

--- a/authorizations/authorization-common/src/test/java/org/apache/gravitino/authorization/common/TestPathBasedMetadataObject.java
+++ b/authorizations/authorization-common/src/test/java/org/apache/gravitino/authorization/common/TestPathBasedMetadataObject.java
@@ -54,25 +54,45 @@ public class TestPathBasedMetadataObject {
     PathBasedMetadataObject pathBasedMetadataObject1 =
         new PathBasedMetadataObject("parent", "name", "path", PathBasedMetadataObject.FILESET_PATH);
     Assertions.assertEquals(
-        "MetadataObject: [fullName=parent.name],  [path=path], [type=PATH]",
+        "MetadataObject: [fullName=parent.name],  [path=path], [type=PATH], [recursive=true]",
         pathBasedMetadataObject1.toString());
 
     PathBasedMetadataObject pathBasedMetadataObject2 =
         new PathBasedMetadataObject("parent", "name", null, PathBasedMetadataObject.FILESET_PATH);
     Assertions.assertEquals(
-        "MetadataObject: [fullName=parent.name],  [path=null], [type=PATH]",
+        "MetadataObject: [fullName=parent.name],  [path=null], [type=PATH], [recursive=true]",
         pathBasedMetadataObject2.toString());
 
     PathBasedMetadataObject pathBasedMetadataObject3 =
         new PathBasedMetadataObject(null, "name", null, PathBasedMetadataObject.FILESET_PATH);
     Assertions.assertEquals(
-        "MetadataObject: [fullName=name],  [path=null], [type=PATH]",
+        "MetadataObject: [fullName=name],  [path=null], [type=PATH], [recursive=true]",
         pathBasedMetadataObject3.toString());
 
     PathBasedMetadataObject pathBasedMetadataObject4 =
         new PathBasedMetadataObject(null, "name", "path", PathBasedMetadataObject.FILESET_PATH);
     Assertions.assertEquals(
-        "MetadataObject: [fullName=name],  [path=path], [type=PATH]",
+        "MetadataObject: [fullName=name],  [path=path], [type=PATH], [recursive=true]",
         pathBasedMetadataObject4.toString());
+
+    PathBasedMetadataObject pathBasedMetadataObject5 =
+        new PathBasedMetadataObject(
+            null, "name", "path", PathBasedMetadataObject.FILESET_PATH, false);
+    Assertions.assertEquals(
+        "MetadataObject: [fullName=name],  [path=path], [type=PATH], [recursive=false]",
+        pathBasedMetadataObject5.toString());
+  }
+
+  @Test
+  void testRecursiveFlagAffectsEquality() {
+    PathBasedMetadataObject recursiveObject =
+        new PathBasedMetadataObject(
+            "parent", "name", "path", PathBasedMetadataObject.FILESET_PATH, true);
+    PathBasedMetadataObject nonRecursiveObject =
+        new PathBasedMetadataObject(
+            "parent", "name", "path", PathBasedMetadataObject.FILESET_PATH, false);
+
+    Assertions.assertNotEquals(recursiveObject, nonRecursiveObject);
+    Assertions.assertNotEquals(recursiveObject.hashCode(), nonRecursiveObject.hashCode());
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Updated the PathBasedMetadataObject class to:
- Compare the `recursive` flag in `equals()` and `hashCode()` methods.
- Include the `recursive` flag in the `toString()` output.

### Why are the changes needed?

Previously, the `recursive` flag was not considered in equality checks or hash code generation,
which could lead to incorrect comparisons and inconsistent behavior in hash-based collections.
Additionally, the `toString()` output did not reflect the `recursive` state, making debugging harder.

Fix: #7958

### Does this PR introduce _any_ user-facing change?

No user-facing API changes.  
However, objects with different `recursive` flag values will now be treated as unequal.

### How was this patch tested?

- Added `testRecursiveFlagAffectsEquality()` to the `TestPathBasedMetadataObject` class.
- Added a case to `testToString()`.

