### PR TITLE
[#7977] fix: resolve race condition in snapshot creation by adjusting lock usage

### DIFF
--- a/core/src/test/java/org/apache/gravitino/storage/memory/TestMemoryEntityStore.java
+++ b/core/src/test/java/org/apache/gravitino/storage/memory/TestMemoryEntityStore.java
@@ -154,8 +154,8 @@ public class TestMemoryEntityStore {
     @Override
     public <R, E extends Exception> R executeInTransaction(Executable<R, E> executable)
         throws E, IOException {
-      Map<NameIdentifier, Entity> snapshot = createSnapshot();
       lock.lock();
+      Map<NameIdentifier, Entity> snapshot = createSnapshot();
       try {
         return executable.execute();
       } catch (Exception e) {
@@ -176,17 +176,10 @@ public class TestMemoryEntityStore {
     }
 
     public Map<NameIdentifier, Entity> createSnapshot() {
-      lock.lock();
-      try {
-        return entityMap.entrySet().stream()
-            .collect(
-                Collectors.toMap(
-                    Map.Entry::getKey, Map.Entry::getValue, (e1, e2) -> e1, Maps::newHashMap));
-      } catch (Exception e) {
-        throw new RuntimeException("Failed to create snapshot of entity store", e);
-      } finally {
-        lock.unlock();
-      }
+      return entityMap.entrySet().stream()
+          .collect(
+              Collectors.toMap(
+                  Map.Entry::getKey, Map.Entry::getValue, (e1, e2) -> e1, Maps::newHashMap));
     }
   }
 


### PR DESCRIPTION

<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?
Previously, the snapshot for rollback was created outside the lock, which could lead to inconsistent state and race conditions in concurrent scenarios.
This change ensures the snapshot is always created while holding the lock, preventing data corruption and ensuring reliable transaction rollback.

### Why are the changes needed?

Fix: #7977

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
With UTs added earlier
