### PR TITLE
Used passed in lineSeparator in writeHorizontalLine

### DIFF
--- a/clients/cli/src/main/java/org/apache/gravitino/cli/outputs/TableFormat.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/outputs/TableFormat.java
@@ -431,7 +431,7 @@ public abstract class TableFormat<T> extends BaseOutputFormat<T> {
     if (right != null) {
       osw.write(right);
     }
-    
+
     osw.write(lineSeparator != null ? lineSeparator : System.lineSeparator());
   }
 


### PR DESCRIPTION
In clients/cli/src/main/java/org/apache/gravitino/cli/outputs/TableFormat.java 

This update ensures that the lineSeparator argument passed to writeHorizontalLine is actually used instead of being ignored.
Previously, the method always used System.lineSeparator(). Now it directly writes the provided `lineSeparator`.

Closes #7978