### PR TITLE
[#7984] Improvement (CLI): add validation method for entity type in SetOwner command

### DIFF
--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/SetOwner.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/SetOwner.java
@@ -98,4 +98,13 @@ public class SetOwner extends Command {
 
     printInformation("Set owner to " + owner);
   }
+
+  @Override
+  public Command validate() {
+    if (entityType == null) {
+      System.err.println(ErrorMessages.UNKNOWN_ENTITY);
+      throw new RuntimeException();
+    }
+    return super.validate();
+  }
 }

--- a/clients/cli/src/test/java/org/apache/gravitino/cli/TestOwnerCommands.java
+++ b/clients/cli/src/test/java/org/apache/gravitino/cli/TestOwnerCommands.java
@@ -193,4 +193,14 @@ class TestOwnerCommands {
     String errOutput = new String(errContent.toByteArray(), StandardCharsets.UTF_8).trim();
     assertEquals(ErrorMessages.INVALID_SET_COMMAND, errOutput);
   }
+
+  @Test
+  void testSetOwnerInvalidEntityType() {
+    Main.useExit = false;
+    CommandContext context = new CommandContext(mockCommandLine);
+    SetOwner setOwner = new SetOwner(context, "metalake_demo", "obj", "invalid", "user", false);
+    assertThrows(RuntimeException.class, setOwner::validate);
+    String errOutput = new String(errContent.toByteArray(), StandardCharsets.UTF_8).trim();
+    assertEquals(ErrorMessages.UNKNOWN_ENTITY, errOutput);
+  }
 }


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?
Add a validation method for entity type in SetOwner command

### Why are the changes needed?
Fix: #7984 

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Added a UT
