### PR TITLE
[#8007] fix: include fieldnames in hashCode

### DIFF
--- a/common/src/main/java/org/apache/gravitino/dto/rel/indexes/IndexDTO.java
+++ b/common/src/main/java/org/apache/gravitino/dto/rel/indexes/IndexDTO.java
@@ -99,7 +99,9 @@ public class IndexDTO implements Index {
   @Override
   public int hashCode() {
     int result = Objects.hash(indexType, name);
-    result = 31 * result + Arrays.hashCode(fieldNames);
+    for (String[] fieldName : fieldNames) {
+      result = 31 * result + Arrays.hashCode(fieldName);
+    }
     return result;
   }
 

--- a/common/src/test/java/org/apache/gravitino/dto/rel/indexes/TestIndexDTO.java
+++ b/common/src/test/java/org/apache/gravitino/dto/rel/indexes/TestIndexDTO.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.gravitino.dto.rel.indexes;
 
 import org.junit.jupiter.api.Assertions;

--- a/common/src/test/java/org/apache/gravitino/dto/rel/indexes/TestIndexDTO.java
+++ b/common/src/test/java/org/apache/gravitino/dto/rel/indexes/TestIndexDTO.java
@@ -1,0 +1,30 @@
+package org.apache.gravitino.dto.rel.indexes;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TestIndexDTO {
+
+  @Test
+  public void testHashCodeConsistentWithEquals() {
+    String[][] fields1 = new String[][] {{"a"}, {"b"}};
+    String[][] fields2 = new String[][] {{"a"}, {"b"}};
+
+    IndexDTO index1 =
+        IndexDTO.builder()
+            .withIndexType(IndexDTO.IndexType.PRIMARY_KEY)
+            .withName("idx")
+            .withFieldNames(fields1)
+            .build();
+
+    IndexDTO index2 =
+        IndexDTO.builder()
+            .withIndexType(IndexDTO.IndexType.PRIMARY_KEY)
+            .withName("idx")
+            .withFieldNames(fields2)
+            .build();
+
+    Assertions.assertEquals(index1, index2);
+    Assertions.assertEquals(index1.hashCode(), index2.hashCode());
+  }
+}


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Modified IndexDTO's hashCode() method to include fieldNames in the hash calculation.
The fieldNames is a two-dimensional String[][] array, and each sub-array’s hash is incorporated to ensure more accurate hash codes.

### Why are the changes needed?

This fix ensures that fieldNames contributes to the hash code, maintaining the contract between equals() and hashCode().

Fix: #8007

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Added a new test class org.apache.gravitino.dto.rel.indexes.TestIndexDTO to verify the updated hashCode() behavior.
