### PR TITLE
[#8009] fix: prevent NPE in validate() when ModelVersionUpdatesRequest updates is null

### DIFF
--- a/common/src/test/java/org/apache/gravitino/dto/requests/TestModelVersionUpdatesRequest.java
+++ b/common/src/test/java/org/apache/gravitino/dto/requests/TestModelVersionUpdatesRequest.java
@@ -16,35 +16,20 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.apache.gravitino.dto.requests;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import java.util.List;
-import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
-import org.apache.gravitino.rest.RESTRequest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
-/** Represents a several request to update a model version. */
-@Getter
-@EqualsAndHashCode
-@AllArgsConstructor
-@NoArgsConstructor(force = true)
-@ToString
-public class ModelVersionUpdatesRequest implements RESTRequest {
-  @JsonProperty("updates")
-  private final List<ModelVersionUpdateRequest> updates;
+public class TestModelVersionUpdatesRequest {
 
-  /** {@inheritDoc} */
-  @Override
-  public void validate() throws IllegalArgumentException {
-    if (updates == null) {
-      throw new IllegalArgumentException("updates cannot be null");
-    }
+  @Test
+  public void testModelVersionUpdatesRequestWithUpdatesNull() {
+    ModelVersionUpdatesRequest modelVersionUpdatesRequest = new ModelVersionUpdatesRequest(null);
 
-    updates.forEach(ModelVersionUpdateRequest::validate);
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        modelVersionUpdatesRequest::validate,
+        "updates cannot be null");
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds a null check for the updates field in ModelVersionUpdateRequest.validate().
If updates is null, the method now throws an IllegalArgumentException with a clear message instead of triggering a NullPointerException.
This ensures that validation fails gracefully when no updates are provided.

### Why are the changes needed?

Previously, when updates was null, calling updates.forEach(...) would result in a NullPointerException, which is less informative and harder to debug.
By explicitly checking for null and throwing IllegalArgumentException, the code provides a clear error message and prevents unexpected runtime failures.

Fix: #8009 

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Added a test to verify that validate() throws IllegalArgumentException when updates is null.
