### PR TITLE
Fix metadata confusion in GravitinoInterceptionService

### DIFF
--- a/server/src/main/java/org/apache/gravitino/server/web/filter/GravitinoInterceptionService.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/filter/GravitinoInterceptionService.java
@@ -234,8 +234,10 @@ public class GravitinoInterceptionService implements InterceptionService {
                     NameIdentifierUtil.ofFileset(metalake, catalog, schema, fileset));
                 break;
               case MODEL:
+                String model = entities.get(Entity.EntityType.MODEL);
                 nameIdentifierMap.put(
-                    Entity.EntityType.MODEL, NameIdentifierUtil.ofMetalake(metalake));
+                    Entity.EntityType.MODEL,
+                    NameIdentifierUtil.ofModel(metalake, catalog, schema, model));
                 break;
               case METALAKE:
                 nameIdentifierMap.put(

--- a/server/src/main/java/org/apache/gravitino/server/web/filter/GravitinoInterceptionService.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/filter/GravitinoInterceptionService.java
@@ -234,10 +234,8 @@ public class GravitinoInterceptionService implements InterceptionService {
                     NameIdentifierUtil.ofFileset(metalake, catalog, schema, fileset));
                 break;
               case MODEL:
-                String model = entities.get(Entity.EntityType.MODEL);
                 nameIdentifierMap.put(
-                    Entity.EntityType.MODEL,
-                    NameIdentifierUtil.ofModel(metadata, catalog, schema, model));
+                    Entity.EntityType.MODEL, NameIdentifierUtil.ofMetalake(metalake));
                 break;
               case METALAKE:
                 nameIdentifierMap.put(


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

GravitinoInterceptionService.java there was an error - wrong NameIdentifier was used.

### Why are the changes needed?

This PR fixes bug when wrong NameIdentifier was used in GravitinoInterceptionService.java

Fix: #8013

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

1. By running relevant JUnit test.
