### PR TITLE
[#8014] fix: correct operation type in MetalakeOperations exception handler

### DIFF
--- a/server/src/main/java/org/apache/gravitino/server/web/rest/MetalakeOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/MetalakeOperations.java
@@ -205,7 +205,8 @@ public class MetalakeOperations {
 
     } catch (Exception e) {
       LOG.info("Failed to {} metalake: {}", request.isInUse() ? "enable" : "disable", metalakeName);
-      return ExceptionHandlers.handleMetalakeException(OperationType.LOAD, metalakeName, e);
+      return ExceptionHandlers.handleMetalakeException(
+          request.isInUse() ? OperationType.ENABLE : OperationType.DISABLE, metalakeName, e);
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR fixes the incorrect operation type used in the exception handler of the `setMetalake` method in `MetalakeOperations.java`. The method was incorrectly using `OperationType.LOAD` for both enable and disable operations in the exception handler, which made error reporting inaccurate.

**Changes made:**
- Updated the exception handler in `setMetalake` method to use `OperationType.ENABLE` when enabling a metalake
- Updated the exception handler in `setMetalake` method to use `OperationType.DISABLE` when disabling a metalake
- The operation type now correctly reflects the actual operation being performed (enable vs disable)

### Why are the changes needed?

The changes are needed to improve error reporting accuracy and debugging capabilities:

1. **Accurate Error Reporting**: Previously, when either enable or disable operations failed, the exception would incorrectly report the operation as `LOAD`, making it difficult to understand which actual operation failed.

2. **Better Traceability**: With the correct operation types, developers and operators can easily identify whether an enable or disable operation caused an issue, improving troubleshooting efficiency.

3. **Consistency**: The exception handler should reflect the actual operation being performed, maintaining consistency between the operation logic and error reporting.

Fix: #8014

### Does this PR introduce _any_ user-facing change?

**No**, this PR does not introduce any user-facing changes:
- No changes to user-facing APIs
- No addition or removal of property keys
- No changes to the method signature or behavior
- Only internal error reporting is improved

### How was this patch tested?

This patch was tested by:

1. **Code Review**: Verified that the logic correctly maps `request.isInUse()` to the appropriate operation types:
   - `true` → `OperationType.ENABLE`
   - `false` → `OperationType.DISABLE`

2. **Existing Test Coverage**: The change leverages existing test coverage for the `setMetalake` method functionality

3. **Manual Verification**: Confirmed that:
   - The method logic remains unchanged (only exception handling is updated)
   - The conditional logic properly determines the correct operation type
   - No compilation errors or warnings are introduced

**Note**: While the current test suite for `TestMetalakeOperations` doesn't specifically test the exception scenarios for `setMetalake`, the fix is minimal and focused only on using the correct operation type in the existing exception handler. The core functionality and existing tests remain unaffected.