### PR TITLE
[#8039] Assigned tags to tagsToAdd for messaging and fileset

### DIFF
--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/TagEntity.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/TagEntity.java
@@ -88,14 +88,14 @@ public class TagEntity extends Command {
             entity = fileset;
             Fileset gFileset =
                 catalogObject.asFilesetCatalog().loadFileset(FullNameUtil.toFileset(name));
-            gFileset.supportsTags().associateTags(tags, null);
+            tagsToAdd = gFileset.supportsTags().associateTags(tags, null);
             break;
 
           case MESSAGING:
             String topic = name.getTopicName();
             entity = topic;
             Topic gTopic = catalogObject.asTopicCatalog().loadTopic(FullNameUtil.toTopic(name));
-            gTopic.supportsTags().associateTags(tags, null);
+            tagsToAdd = gTopic.supportsTags().associateTags(tags, null);
             break;
 
           default:


### PR DESCRIPTION
Title:
Fix tags not being saved for FILESET and MESSAGING entities

Description:
- Updated FILESET and MESSAGING cases to assign the result of associateTags() to tagsToAdd, matching the behavior of RELATIONAL and MODEL cases.

- Ensures that tags are correctly captured and processed for these entity types.

Closes #8039 