### PR TITLE
[#6756] fix (trino-connector): Fix the exception when the Trino connector loads an unsupported catalog type.

### DIFF
--- a/clients/client-java/src/main/java/org/apache/gravitino/client/ObjectMapperProvider.java
+++ b/clients/client-java/src/main/java/org/apache/gravitino/client/ObjectMapperProvider.java
@@ -40,6 +40,7 @@ public class ObjectMapperProvider {
             .configure(EnumFeature.WRITE_ENUMS_TO_LOWERCASE, true)
             .enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS)
             .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+            .configure(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL, true)
             .build()
             .registerModule(new JavaTimeModule())
             .registerModule(new Jdk8Module());

--- a/common/src/main/java/org/apache/gravitino/dto/CatalogDTO.java
+++ b/common/src/main/java/org/apache/gravitino/dto/CatalogDTO.java
@@ -18,6 +18,8 @@
  */
 package org.apache.gravitino.dto;
 
+import static org.apache.gravitino.Catalog.Type.UNSUPPORTED;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 import java.util.Map;
@@ -98,6 +100,9 @@ public class CatalogDTO implements Catalog {
    */
   @Override
   public Type type() {
+    if (type == null) {
+      return UNSUPPORTED;
+    }
     return type;
   }
 

--- a/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/catalog/CatalogConnectorManager.java
+++ b/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/catalog/CatalogConnectorManager.java
@@ -240,6 +240,12 @@ public class CatalogConnectorManager {
                     loadCatalog(gravitinoCatalog);
                   }
                 }
+              } catch (UnsupportedOperationException e) {
+                LOG.warn(
+                    "Unsupported catalog type for catalog {} in metalake {}: {}",
+                    catalogName,
+                    metalake.name(),
+                    e.getMessage());
               } catch (Exception e) {
                 LOG.error(
                     "Failed to load metalake {}'s catalog {}.", metalake.name(), catalogName, e);

--- a/trino-connector/trino-connector/src/test/java/org/apache/gravitino/trino/connector/metadata/TestGravitinoCatalog.java
+++ b/trino-connector/trino-connector/src/test/java/org/apache/gravitino/trino/connector/metadata/TestGravitinoCatalog.java
@@ -20,6 +20,7 @@ package org.apache.gravitino.trino.connector.metadata;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -30,6 +31,7 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.gravitino.Audit;
 import org.apache.gravitino.Catalog;
+import org.apache.gravitino.client.ObjectMapperProvider;
 import org.junit.jupiter.api.Test;
 
 public class TestGravitinoCatalog {
@@ -45,6 +47,13 @@ public class TestGravitinoCatalog {
     assertEquals(catalogName, catalog.getName());
     assertEquals(provider, catalog.getProvider());
     assertEquals(catalog.getRegion(), "");
+  }
+
+  @Test
+  public void testUnSupportedCatalog() throws Exception {
+    String json = "\"xxxx\"";
+    Catalog.Type t = ObjectMapperProvider.objectMapper().readValue(json, Catalog.Type.class);
+    assertNull(t);
   }
 
   @Test


### PR DESCRIPTION

### What changes were proposed in this pull request?

Fix the exception when the Trino connector loads an unsupported catalog type.

### Why are the changes needed?

Fix: #6756 

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Manually test
