### PR TITLE
improvement(IRC): remove useless injectTableConfig while loading table.

### DIFF
--- a/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/ops/IcebergCatalogWrapper.java
+++ b/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/ops/IcebergCatalogWrapper.java
@@ -24,7 +24,6 @@ import java.sql.DriverManager;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
-import java.util.function.Supplier;
 import lombok.Getter;
 import lombok.Setter;
 import org.apache.commons.lang3.StringUtils;
@@ -162,9 +161,9 @@ public class IcebergCatalogWrapper implements AutoCloseable {
   public LoadTableResponse createTable(Namespace namespace, CreateTableRequest request) {
     request.validate();
     if (request.stageCreate()) {
-      return injectTableConfig(() -> CatalogHandlers.stageTableCreate(catalog, namespace, request));
+      return CatalogHandlers.stageTableCreate(catalog, namespace, request);
     }
-    return injectTableConfig(() -> CatalogHandlers.createTable(catalog, namespace, request));
+    return CatalogHandlers.createTable(catalog, namespace, request);
   }
 
   public void dropTable(TableIdentifier tableIdentifier) {
@@ -176,7 +175,7 @@ public class IcebergCatalogWrapper implements AutoCloseable {
   }
 
   public LoadTableResponse loadTable(TableIdentifier tableIdentifier) {
-    return injectTableConfig(() -> CatalogHandlers.loadTable(catalog, tableIdentifier));
+    return CatalogHandlers.loadTable(catalog, tableIdentifier);
   }
 
   public boolean tableExists(TableIdentifier tableIdentifier) {
@@ -293,12 +292,6 @@ public class IcebergCatalogWrapper implements AutoCloseable {
 
   private void closePostgreSQLCatalogResource() {
     closeDriverLoadedByIsolatedClassLoader(catalogUri);
-  }
-
-  // Some io and security configuration should pass to Iceberg REST client
-  private LoadTableResponse injectTableConfig(Supplier<LoadTableResponse> supplier) {
-    LoadTableResponse loadTableResponse = supplier.get();
-    return LoadTableResponse.builder().withTableMetadata(loadTableResponse.tableMetadata()).build();
   }
 
   @Getter


### PR DESCRIPTION
### What changes were proposed in this pull request?
remove unnecessary injectTableConfig in `IcebergCatalogWrapper`

### Why are the changes needed?
#6021  moves the the credential injection from `IcebergCatalogWrapper` to `CatalogWrapperForREST#injectCredentialConfig` while loading table. Now the `IcebergCatalogWrapper.injectTableConfig` only performs an unnecessary `loadTableResponse` copy, which should be removed.


### Does this PR introduce any user-facing change?
No.

### How was this patch tested?
Existing tests.



cc @FANNG1 Hi, can you please take a look when you have time? Thanks!