### PR TITLE
[#8052] Improvement(core): Fix directory in LocalProcessBuilder

### DIFF
--- a/core/src/main/java/org/apache/gravitino/job/local/LocalProcessBuilder.java
+++ b/core/src/main/java/org/apache/gravitino/job/local/LocalProcessBuilder.java
@@ -33,7 +33,7 @@ public abstract class LocalProcessBuilder {
     this.jobTemplate = jobTemplate;
     // Executable should be in the working directory, so we can figure out the working directory
     // from the executable path.
-    this.workingDirectory = new File(jobTemplate.executable()).getParentFile();
+    this.workingDirectory = new File(jobTemplate.executable()).getAbsoluteFile().getParentFile();
   }
 
   public abstract Process start();


### PR DESCRIPTION
### What changes were proposed in this pull request?

Use `getAbsoluteFile().getParentFile()` instead of `getParentFile()` in `LocalProcessBuilder.java` to ensure a non-null parent directory even when the executable path lacks a parent component.

### Why are the changes needed?

Fixes #8052

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

`./gradlew build`