### PR TITLE
[#8032] fix(core): add soft delete condition to sort delete logic

### DIFF
--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/JobMetaBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/JobMetaBaseSQLProvider.java
@@ -172,7 +172,7 @@ public class JobMetaBaseSQLProvider {
         + JobMetaMapper.TABLE_NAME
         + " SET deleted_at = (UNIX_TIMESTAMP() * 1000.0)"
         + " + EXTRACT(MICROSECOND FROM CURRENT_TIMESTAMP(3)) / 1000.0"
-        + " WHERE job_finished_at < #{legacyTimeline} AND job_finished_at > 0";
+        + " WHERE job_finished_at < #{legacyTimeline} AND job_finished_at > 0 AND deleted_at = 0";
   }
 
   public String deleteJobMetasByLegacyTimeline(

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/JobMetaPostgreSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/JobMetaPostgreSQLProvider.java
@@ -100,7 +100,7 @@ public class JobMetaPostgreSQLProvider extends JobMetaBaseSQLProvider {
         + JobMetaMapper.TABLE_NAME
         + " SET deleted_at = floor(extract(epoch from((current_timestamp -"
         + " timestamp '1970-01-01 00:00:00')*1000))) "
-        + " WHERE job_finished_at < #{legacyTimeline} AND job_finished_at > 0";
+        + " WHERE job_finished_at < #{legacyTimeline} AND job_finished_at > 0 AND deleted_at = 0";
   }
 
   @Override


### PR DESCRIPTION

<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

This PR adds the `AND deleted_at = 0` condition to the sort delete logic in the codebase. This ensures that only non-deleted records are considered during sort operations, preventing deleted records from being included in the sorting process.


### Why are the changes needed?

Fix: #8032

The current sort delete logic was missing a crucial condition to filter out already soft-deleted records. Without the `AND deleted_at = 0` condition, the sort operation could potentially include records that have been marked as deleted (deleted_at > 0), leading to inconsistent behavior and potential data integrity issues.

This fix ensures that:
1. Soft-deleted records are properly excluded from sort operations
2. Data consistency is maintained across the application
3. The soft delete pattern is correctly implemented throughout the codebase

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

- Since the changes involve SQL query string modifications only, no additional unit tests were written.

