### PR TITLE
[#8055] improvement(core): Replace equals() with == for enum comparison in CompatibilityUtils

### DIFF
--- a/core/src/main/java/org/apache/gravitino/audit/v2/CompatibilityUtils.java
+++ b/core/src/main/java/org/apache/gravitino/audit/v2/CompatibilityUtils.java
@@ -101,9 +101,9 @@ public class CompatibilityUtils {
   }
 
   static Status toAuditLogStatus(OperationStatus operationStatus) {
-    if (operationStatus.equals(OperationStatus.SUCCESS)) {
+    if (operationStatus == OperationStatus.SUCCESS) {
       return Status.SUCCESS;
-    } else if (operationStatus.equals(OperationStatus.FAILURE)) {
+    } else if (operationStatus == OperationStatus.FAILURE) {
       return Status.FAILURE;
     } else {
       return Status.UNKNOWN;

--- a/core/src/test/java/org/apache/gravitino/audit/v2/TestCompatibilityUtils.java
+++ b/core/src/test/java/org/apache/gravitino/audit/v2/TestCompatibilityUtils.java
@@ -105,4 +105,10 @@ public class TestCompatibilityUtils {
     Assertions.assertEquals(
         Status.UNKNOWN, CompatibilityUtils.toAuditLogStatus(OperationStatus.UNKNOWN));
   }
+
+  @Test
+  void testOperationStatusNullHandling() {
+    Assertions.assertDoesNotThrow(() -> CompatibilityUtils.toAuditLogStatus(null));
+    Assertions.assertEquals(Status.UNKNOWN, CompatibilityUtils.toAuditLogStatus(null));
+  }
 }


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Replace `equals()` method with `==` operator for enum comparison in the `toAuditLogStatus()` method within `CompatibilityUtils` class. Additionally, add a null safety test case to ensure proper handling of null `OperationStatus` parameters.  

### Why are the changes needed?

1. Using `==` for enum comparison is more efficient than `equals()` since enums are singletons in Java
2. Added test coverage for null parameter handling to ensure robustness

Fix: #8055

### Does this PR introduce _any_ user-facing change?

No, this is purely an internal refactoring change. 

### How was this patch tested?

1. Existing unit tests continue to pass, ensuring no functional regression
2. Added a new test case `testOperationStatusNullHandling()` to verify proper null parameter handling
