### PR TITLE
[#8034] Improvement: Fully support nullable simpleStrings in Types.java

### DIFF
--- a/api/src/main/java/org/apache/gravitino/rel/types/Types.java
+++ b/api/src/main/java/org/apache/gravitino/rel/types/Types.java
@@ -1096,7 +1096,9 @@ public class Types {
 
     @Override
     public String simpleString() {
-      return "map<" + keyType.simpleString() + "," + valueType.simpleString() + ">";
+      return valueNullable
+          ? "map<" + keyType.simpleString() + "," + valueType.simpleString() + ">"
+          : "map<" + keyType.simpleString() + "," + valueType.simpleString() + ", NOT NULL>";
     }
 
     @Override

--- a/api/src/test/java/org/apache/gravitino/rel/TestTypes.java
+++ b/api/src/test/java/org/apache/gravitino/rel/TestTypes.java
@@ -202,6 +202,13 @@ public class TestTypes {
     Assertions.assertEquals("list<integer>", listType.simpleString());
     Assertions.assertEquals(listType, Types.ListType.nullable(Types.IntegerType.get()));
 
+    Types.ListType listTypeNotNull = Types.ListType.notNull(Types.StringType.get());
+    Assertions.assertEquals(Type.Name.LIST, listTypeNotNull.name());
+    Assertions.assertFalse(listTypeNotNull.elementNullable());
+    Assertions.assertEquals(Types.StringType.get(), listTypeNotNull.elementType());
+    Assertions.assertEquals("list<string, NOT NULL>", listTypeNotNull.simpleString());
+    Assertions.assertEquals(listTypeNotNull, Types.ListType.notNull(Types.StringType.get()));
+
     Types.MapType mapType =
         Types.MapType.valueNullable(Types.IntegerType.get(), Types.StringType.get());
     Assertions.assertEquals(Type.Name.MAP, mapType.name());
@@ -210,6 +217,16 @@ public class TestTypes {
     Assertions.assertEquals("map<integer,string>", mapType.simpleString());
     Assertions.assertEquals(
         mapType, Types.MapType.valueNullable(Types.IntegerType.get(), Types.StringType.get()));
+
+    Types.MapType mapTypeNotNull =
+        Types.MapType.valueNotNull(Types.IntegerType.get(), Types.StringType.get());
+    Assertions.assertEquals(Type.Name.MAP, mapTypeNotNull.name());
+    Assertions.assertEquals(Types.IntegerType.get(), mapTypeNotNull.keyType());
+    Assertions.assertEquals(Types.StringType.get(), mapTypeNotNull.valueType());
+    Assertions.assertEquals("map<integer,string, NOT NULL>", mapTypeNotNull.simpleString());
+    Assertions.assertEquals(
+        mapTypeNotNull,
+        Types.MapType.valueNotNull(Types.IntegerType.get(), Types.StringType.get()));
 
     Types.UnionType unionType =
         Types.UnionType.of(


### PR DESCRIPTION
<!--
1. Title: [#8034] Improvement: Fully support nullable simpleStrings in Types.java
-->

### What changes were proposed in this pull request?

This PR adds full support for nullable simpleStrings in `api/src/main/java/org/apache/gravitino/rel/types/Types.java`. More specifically, for the `simpleString()` method for the complex type `MapType`.
Additionally, a couple of unit tests are added to cover the cases where `MapType` and `ListType` can have non-nullable fields in them.

### Why are the changes needed?

It is important to indicate (in the human readable `simpleString()` output) whether an instantiated complex type like the `MapType` can or cannot have null values for its elements. In code, this is indicated by a `valueNullable` boolean field.
For example, a `MapType` which maps each `IntegerType` to a `StringType` might not want to allow an `IntegerType->Null` mapping. In that case, a call to the `simpleString()` method should return the following string `map<integer,string, NOT NULL>` to indicate this behavior.


Fix: #8034

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Locally, with the provided unit test in the original issue post. Additionally, since `ListType` also allows for a similar non-null behavior as indicated by the code, I've decided to add a test to cover it as well.
Since the other two complex types either do not exhibit the behavior (in case of `UnionType`) or already have the behavior covered in a test (in case of `StructType`), no additional tests were added for the other complex types.