### PR TITLE
[#7841] feat(policy): implement the policy management on server-side (part-2)

### DIFF
--- a/common/src/main/java/org/apache/gravitino/dto/requests/PoliciesAssociateRequest.java
+++ b/common/src/main/java/org/apache/gravitino/dto/requests/PoliciesAssociateRequest.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.dto.requests;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Preconditions;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.gravitino.rest.RESTRequest;
+
+/** Represents a request to associate policies. */
+@Getter
+@EqualsAndHashCode
+@ToString
+public class PoliciesAssociateRequest implements RESTRequest {
+
+  @JsonProperty("policiesToAdd")
+  private final String[] policiesToAdd;
+
+  @JsonProperty("policiesToRemove")
+  private final String[] policiesToRemove;
+
+  /**
+   * Creates a new PoliciesAssociateRequest.
+   *
+   * @param policiesToAdd The policies to add.
+   * @param policiesToRemove The policies to remove.
+   */
+  public PoliciesAssociateRequest(String[] policiesToAdd, String[] policiesToRemove) {
+    this.policiesToAdd = policiesToAdd;
+    this.policiesToRemove = policiesToRemove;
+  }
+
+  /** This is the constructor that is used by Jackson deserializer */
+  private PoliciesAssociateRequest() {
+    this(null, null);
+  }
+
+  /**
+   * Validates the request.
+   *
+   * @throws IllegalArgumentException If the request is invalid, this exception is thrown.
+   */
+  @Override
+  public void validate() throws IllegalArgumentException {
+    Preconditions.checkArgument(
+        policiesToAdd != null || policiesToRemove != null,
+        "policiesToAdd and policiesToRemove cannot both be null");
+
+    if (policiesToAdd != null) {
+      for (String policy : policiesToAdd) {
+        Preconditions.checkArgument(
+            StringUtils.isNotBlank(policy),
+            "policiesToAdd must not contain null or empty policy names");
+      }
+    }
+
+    if (policiesToRemove != null) {
+      for (String policy : policiesToRemove) {
+        Preconditions.checkArgument(
+            StringUtils.isNotBlank(policy),
+            "policiesToRemove must not contain null or empty policy names");
+      }
+    }
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/PolicyMetaPostgreSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/PolicyMetaPostgreSQLProvider.java
@@ -18,7 +18,7 @@
  */
 package org.apache.gravitino.storage.relational.mapper.provider.postgresql;
 
-import static org.apache.gravitino.storage.relational.mapper.FilesetMetaMapper.META_TABLE_NAME;
+import static org.apache.gravitino.storage.relational.mapper.PolicyMetaMapper.POLICY_META_TABLE_NAME;
 
 import org.apache.gravitino.storage.relational.mapper.provider.base.PolicyMetaBaseSQLProvider;
 import org.apache.gravitino.storage.relational.po.PolicyPO;
@@ -28,7 +28,7 @@ public class PolicyMetaPostgreSQLProvider extends PolicyMetaBaseSQLProvider {
   @Override
   public String softDeletePolicyByMetalakeAndPolicyName(String metalakeName, String policyName) {
     return "UPDATE "
-        + META_TABLE_NAME
+        + POLICY_META_TABLE_NAME
         + " SET deleted_at = floor(extract(epoch from((current_timestamp -"
         + " timestamp '1970-01-01 00:00:00')*1000)))"
         + " WHERE metalake_id = (SELECT metalake_id FROM "
@@ -39,7 +39,7 @@ public class PolicyMetaPostgreSQLProvider extends PolicyMetaBaseSQLProvider {
   @Override
   public String softDeletePolicyMetasByMetalakeId(Long metalakeId) {
     return "UPDATE "
-        + META_TABLE_NAME
+        + POLICY_META_TABLE_NAME
         + " SET deleted_at = floor(extract(epoch from((current_timestamp -"
         + " timestamp '1970-01-01 00:00:00')*1000)))"
         + " WHERE metalake_id = #{metalakeId} AND deleted_at = 0";
@@ -48,16 +48,16 @@ public class PolicyMetaPostgreSQLProvider extends PolicyMetaBaseSQLProvider {
   @Override
   public String deletePolicyMetasByLegacyTimeline(Long legacyTimeline, int limit) {
     return "DELETE FROM "
-        + META_TABLE_NAME
+        + POLICY_META_TABLE_NAME
         + " WHERE policy_id IN (SELECT policy_id FROM "
-        + META_TABLE_NAME
+        + POLICY_META_TABLE_NAME
         + " WHERE deleted_at = 0 AND legacy_timeline < #{legacyTimeline} LIMIT #{limit})";
   }
 
   @Override
   public String insertPolicyMetaOnDuplicateKeyUpdate(PolicyPO policyPO) {
     return "INSERT INTO "
-        + META_TABLE_NAME
+        + POLICY_META_TABLE_NAME
         + " (policy_id, policy_name, policy_type, metalake_id,"
         + " audit_info, current_version, last_version, deleted_at)"
         + " VALUES ("

--- a/core/src/test/java/org/apache/gravitino/storage/relational/service/TestPolicyMetaService.java
+++ b/core/src/test/java/org/apache/gravitino/storage/relational/service/TestPolicyMetaService.java
@@ -142,7 +142,8 @@ public class TestPolicyMetaService extends TestJDBCBackend {
             .build();
 
     Assertions.assertThrows(
-        Exception.class, () -> policyMetaService.insertPolicy(PolicyEntity2, false));
+        EntityAlreadyExistsException.class,
+        () -> policyMetaService.insertPolicy(PolicyEntity2, false));
 
     policyMetaService.insertPolicy(PolicyEntity2, true);
 

--- a/scripts/h2/upgrade-0.9.0-to-1.0.0-h2.sql
+++ b/scripts/h2/upgrade-0.9.0-to-1.0.0-h2.sql
@@ -41,7 +41,7 @@ CREATE TABLE IF NOT EXISTS `policy_version_info` (
     `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'policy deleted at',
     PRIMARY KEY (`id`),
     UNIQUE KEY `uk_pod_ver_del` (`policy_id`, `version`, `deleted_at`),
-    KEY `idx_mid` (`metalake_id`),
+    KEY `idx_mid` (`metalake_id`)
 ) ENGINE=InnoDB;
 
 CREATE TABLE IF NOT EXISTS `policy_relation_meta` (

--- a/scripts/postgresql/schema-1.0.0-postgresql.sql
+++ b/scripts/postgresql/schema-1.0.0-postgresql.sql
@@ -619,7 +619,7 @@ CREATE TABLE IF NOT EXISTS policy_version_info (
     policy_id BIGINT NOT NULL,
     version INT NOT NULL,
     policy_comment TEXT DEFAULT NULL,
-    enabled SMALLINT DEFAULT 1,
+    enabled BOOLEAN DEFAULT TRUE,
     content TEXT DEFAULT NULL,
     deleted_at BIGINT NOT NULL DEFAULT 0,
     PRIMARY KEY (id),

--- a/scripts/postgresql/upgrade-0.9.0-to-1.0.0-postgresql.sql
+++ b/scripts/postgresql/upgrade-0.9.0-to-1.0.0-postgresql.sql
@@ -47,7 +47,7 @@ CREATE TABLE IF NOT EXISTS policy_version_info (
     policy_id BIGINT NOT NULL,
     version INT NOT NULL,
     policy_comment TEXT DEFAULT NULL,
-    enabled SMALLINT DEFAULT 1,
+    enabled BOOLEAN DEFAULT TRUE,
     content TEXT DEFAULT NULL,
     deleted_at BIGINT NOT NULL DEFAULT 0,
     PRIMARY KEY (id),

--- a/server/src/main/java/org/apache/gravitino/server/web/rest/MetadataObjectPolicyOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/MetadataObjectPolicyOperations.java
@@ -1,0 +1,274 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.server.web.rest;
+
+import com.codahale.metrics.annotation.ResponseMetered;
+import com.codahale.metrics.annotation.Timed;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.Set;
+import javax.inject.Inject;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response;
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.gravitino.MetadataObject;
+import org.apache.gravitino.MetadataObjects;
+import org.apache.gravitino.dto.policy.PolicyDTO;
+import org.apache.gravitino.dto.requests.PoliciesAssociateRequest;
+import org.apache.gravitino.dto.responses.NameListResponse;
+import org.apache.gravitino.dto.responses.PolicyListResponse;
+import org.apache.gravitino.dto.responses.PolicyResponse;
+import org.apache.gravitino.exceptions.NoSuchPolicyException;
+import org.apache.gravitino.meta.PolicyEntity;
+import org.apache.gravitino.metrics.MetricNames;
+import org.apache.gravitino.policy.PolicyDispatcher;
+import org.apache.gravitino.server.web.Utils;
+import org.glassfish.jersey.internal.guava.Sets;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Path("/metalakes/{metalake}/objects/{type}/{fullName}/policies")
+public class MetadataObjectPolicyOperations {
+  private static final Logger LOG = LoggerFactory.getLogger(MetadataObjectPolicyOperations.class);
+
+  private final PolicyDispatcher policyDispatcher;
+
+  @Context private HttpServletRequest httpRequest;
+
+  @Inject
+  public MetadataObjectPolicyOperations(PolicyDispatcher policyDispatcher) {
+    this.policyDispatcher = policyDispatcher;
+  }
+
+  @GET
+  @Path("{policy}")
+  @Produces("application/vnd.gravitino.v1+json")
+  @Timed(name = "get-object-policy." + MetricNames.HTTP_PROCESS_DURATION, absolute = true)
+  @ResponseMetered(name = "get-object-policy", absolute = true)
+  public Response getPolicyForObject(
+      @PathParam("metalake") String metalake,
+      @PathParam("type") String type,
+      @PathParam("fullName") String fullName,
+      @PathParam("policy") String policyName) {
+    LOG.info(
+        "Received get policy {} request for object type: {}, full name: {} under metalake: {}",
+        policyName,
+        type,
+        fullName,
+        metalake);
+
+    try {
+      return Utils.doAs(
+          httpRequest,
+          () -> {
+            MetadataObject object =
+                MetadataObjects.parse(
+                    fullName, MetadataObject.Type.valueOf(type.toUpperCase(Locale.ROOT)));
+            Optional<PolicyEntity> policyEntity = getPolicyForObject(metalake, object, policyName);
+            Optional<PolicyDTO> policyDTO =
+                policyEntity.map(t -> PolicyOperations.toDTO(t, Optional.of(false)));
+
+            MetadataObject parentObject = MetadataObjects.parent(object);
+            while (!policyEntity.isPresent() && parentObject != null) {
+              policyEntity = getPolicyForObject(metalake, parentObject, policyName);
+              policyDTO = policyEntity.map(t -> PolicyOperations.toDTO(t, Optional.of(true)));
+              parentObject = MetadataObjects.parent(parentObject);
+            }
+
+            if (!policyDTO.isPresent()) {
+              LOG.warn(
+                  "Policy {} not found for object type: {}, full name: {} under metalake: {}",
+                  policyName,
+                  type,
+                  fullName,
+                  metalake);
+              return Utils.notFound(
+                  NoSuchPolicyException.class.getSimpleName(),
+                  "Policy not found: "
+                      + policyName
+                      + " for object type: "
+                      + type
+                      + ", full name: "
+                      + fullName
+                      + " under metalake: "
+                      + metalake);
+            } else {
+              LOG.info(
+                  "Get policy: {} for object type: {}, full name: {} under metalake: {}",
+                  policyName,
+                  type,
+                  fullName,
+                  metalake);
+              return Utils.ok(new PolicyResponse(policyDTO.get()));
+            }
+          });
+
+    } catch (Exception e) {
+      return ExceptionHandlers.handlePolicyException(OperationType.GET, policyName, fullName, e);
+    }
+  }
+
+  @GET
+  @Produces("application/vnd.gravitino.v1+json")
+  @Timed(name = "list-object-policies." + MetricNames.HTTP_PROCESS_DURATION, absolute = true)
+  @ResponseMetered(name = "list-object-policies", absolute = true)
+  public Response listPoliciesForMetadataObject(
+      @PathParam("metalake") String metalake,
+      @PathParam("type") String type,
+      @PathParam("fullName") String fullName,
+      @QueryParam("details") @DefaultValue("false") boolean verbose) {
+    LOG.info(
+        "Received list policy {} request for object type: {}, full name: {} under metalake: {}",
+        verbose ? "infos" : "names",
+        type,
+        fullName,
+        metalake);
+
+    try {
+      return Utils.doAs(
+          httpRequest,
+          () -> {
+            MetadataObject object =
+                MetadataObjects.parse(
+                    fullName, MetadataObject.Type.valueOf(type.toUpperCase(Locale.ROOT)));
+
+            Set<PolicyDTO> policies = Sets.newHashSet();
+            PolicyEntity[] nonInheritedPolicies =
+                policyDispatcher.listPolicyInfosForMetadataObject(metalake, object);
+            if (ArrayUtils.isNotEmpty(nonInheritedPolicies)) {
+              Collections.addAll(
+                  policies,
+                  Arrays.stream(nonInheritedPolicies)
+                      .map(t -> PolicyOperations.toDTO(t, Optional.of(false)))
+                      .toArray(PolicyDTO[]::new));
+            }
+
+            MetadataObject parentObject = MetadataObjects.parent(object);
+            while (parentObject != null) {
+              PolicyEntity[] inheritedPolicies =
+                  policyDispatcher.listPolicyInfosForMetadataObject(metalake, parentObject);
+              if (ArrayUtils.isNotEmpty(inheritedPolicies)) {
+                Collections.addAll(
+                    policies,
+                    Arrays.stream(inheritedPolicies)
+                        .map(t -> PolicyOperations.toDTO(t, Optional.of(true)))
+                        .toArray(PolicyDTO[]::new));
+              }
+              parentObject = MetadataObjects.parent(parentObject);
+            }
+
+            if (verbose) {
+              LOG.info(
+                  "List {} policies info for object type: {}, full name: {} under metalake: {}",
+                  policies.size(),
+                  type,
+                  fullName,
+                  metalake);
+              return Utils.ok(new PolicyListResponse(policies.toArray(new PolicyDTO[0])));
+
+            } else {
+              String[] policyNames = policies.stream().map(PolicyDTO::name).toArray(String[]::new);
+
+              LOG.info(
+                  "List {} policies for object type: {}, full name: {} under metalake: {}",
+                  policyNames.length,
+                  type,
+                  fullName,
+                  metalake);
+              return Utils.ok(new NameListResponse(policyNames));
+            }
+          });
+
+    } catch (Exception e) {
+      return ExceptionHandlers.handlePolicyException(OperationType.LIST, "", fullName, e);
+    }
+  }
+
+  @POST
+  @Produces("application/vnd.gravitino.v1+json")
+  @Timed(name = "associate-object-policies." + MetricNames.HTTP_PROCESS_DURATION, absolute = true)
+  @ResponseMetered(name = "associate-object-policies", absolute = true)
+  public Response associatePoliciesForObject(
+      @PathParam("metalake") String metalake,
+      @PathParam("type") String type,
+      @PathParam("fullName") String fullName,
+      PoliciesAssociateRequest request) {
+    LOG.info(
+        "Received associate policies request for object type: {}, full name: {} under metalake: {}",
+        type,
+        fullName,
+        metalake);
+
+    try {
+      return Utils.doAs(
+          httpRequest,
+          () -> {
+            request.validate();
+            MetadataObject object =
+                MetadataObjects.parse(
+                    fullName, MetadataObject.Type.valueOf(type.toUpperCase(Locale.ROOT)));
+            String[] policyNames =
+                policyDispatcher.associatePoliciesForMetadataObject(
+                    metalake, object, request.getPoliciesToAdd(), request.getPoliciesToRemove());
+            policyNames = policyNames == null ? new String[0] : policyNames;
+
+            LOG.info(
+                "Associated policies: {} for object type: {}, full name: {} under metalake: {}",
+                Arrays.toString(policyNames),
+                type,
+                fullName,
+                metalake);
+            return Utils.ok(new NameListResponse(policyNames));
+          });
+
+    } catch (Exception e) {
+      return ExceptionHandlers.handlePolicyException(OperationType.ASSOCIATE, "", fullName, e);
+    }
+  }
+
+  /**
+   * Get the policy for the given metadata object and policy name. If the policy is not found,
+   * return an empty Optional.
+   *
+   * @param metalake the name of the metalake
+   * @param object the metadata object for which the policy is associated
+   * @param policyName the name of the policy to retrieve
+   * @return an Optional containing the policy if found, otherwise an empty Optional
+   */
+  private Optional<PolicyEntity> getPolicyForObject(
+      String metalake, MetadataObject object, String policyName) {
+    try {
+      return Optional.ofNullable(
+          policyDispatcher.getPolicyForMetadataObject(metalake, object, policyName));
+    } catch (NoSuchPolicyException e) {
+      LOG.info("Policy {} not found for object: {}", policyName, object);
+      return Optional.empty();
+    }
+  }
+}

--- a/server/src/test/java/org/apache/gravitino/server/web/rest/TestMetadataObjectPolicyOperations.java
+++ b/server/src/test/java/org/apache/gravitino/server/web/rest/TestMetadataObjectPolicyOperations.java
@@ -1,0 +1,574 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.server.web.rest;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import org.apache.gravitino.MetadataObject;
+import org.apache.gravitino.MetadataObjects;
+import org.apache.gravitino.dto.requests.PoliciesAssociateRequest;
+import org.apache.gravitino.dto.responses.ErrorConstants;
+import org.apache.gravitino.dto.responses.ErrorResponse;
+import org.apache.gravitino.dto.responses.NameListResponse;
+import org.apache.gravitino.dto.responses.PolicyListResponse;
+import org.apache.gravitino.dto.responses.PolicyResponse;
+import org.apache.gravitino.exceptions.NoSuchPolicyException;
+import org.apache.gravitino.exceptions.PolicyAlreadyAssociatedException;
+import org.apache.gravitino.meta.AuditInfo;
+import org.apache.gravitino.meta.PolicyEntity;
+import org.apache.gravitino.policy.Policy;
+import org.apache.gravitino.policy.PolicyContent;
+import org.apache.gravitino.policy.PolicyContents;
+import org.apache.gravitino.policy.PolicyDispatcher;
+import org.apache.gravitino.policy.PolicyManager;
+import org.apache.gravitino.rest.RESTUtils;
+import org.glassfish.jersey.internal.inject.AbstractBinder;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.glassfish.jersey.test.JerseyTest;
+import org.glassfish.jersey.test.TestProperties;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TestMetadataObjectPolicyOperations extends JerseyTest {
+
+  private static class MockServletRequestFactory extends ServletRequestFactoryBase {
+
+    @Override
+    public HttpServletRequest get() {
+      HttpServletRequest request = mock(HttpServletRequest.class);
+      when(request.getRemoteUser()).thenReturn(null);
+      return request;
+    }
+  }
+
+  private final PolicyManager policyManager = mock(PolicyManager.class);
+
+  private final String metalake = "test_metalake";
+
+  private final AuditInfo testAuditInfo1 =
+      AuditInfo.builder().withCreator("user1").withCreateTime(Instant.now()).build();
+  private final PolicyContent policyContent =
+      PolicyContents.custom(null, ImmutableSet.of(MetadataObject.Type.TABLE), null);
+
+  @Override
+  protected Application configure() {
+    try {
+      forceSet(
+          TestProperties.CONTAINER_PORT, String.valueOf(RESTUtils.findAvailablePort(2000, 3000)));
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+
+    ResourceConfig resourceConfig = new ResourceConfig();
+    resourceConfig.register(MetadataObjectPolicyOperations.class);
+    resourceConfig.register(
+        new AbstractBinder() {
+          @Override
+          protected void configure() {
+            bind(policyManager).to(PolicyDispatcher.class).ranked(2);
+            bindFactory(MockServletRequestFactory.class).to(HttpServletRequest.class);
+          }
+        });
+
+    return resourceConfig;
+  }
+
+  @Test
+  public void testListPoliciesForObject() {
+    MetadataObject catalog = MetadataObjects.parse("object1", MetadataObject.Type.CATALOG);
+    MetadataObject schema = MetadataObjects.parse("object1.object2", MetadataObject.Type.SCHEMA);
+    MetadataObject table =
+        MetadataObjects.parse("object1.object2.object3", MetadataObject.Type.TABLE);
+
+    PolicyEntity[] catalogPolicyInfos = new PolicyEntity[] {createPolicy("policy1")};
+    when(policyManager.listPolicyInfosForMetadataObject(metalake, catalog))
+        .thenReturn(catalogPolicyInfos);
+
+    PolicyEntity[] schemaPolicyInfos = new PolicyEntity[] {createPolicy("policy3")};
+    when(policyManager.listPolicyInfosForMetadataObject(metalake, schema))
+        .thenReturn(schemaPolicyInfos);
+
+    PolicyEntity[] tablePolicyInfos = {createPolicy("policy5")};
+    when(policyManager.listPolicyInfosForMetadataObject(metalake, table))
+        .thenReturn(tablePolicyInfos);
+
+    // Test catalog policies
+    Response response =
+        target(basePath(metalake))
+            .path(catalog.type().toString())
+            .path(catalog.fullName())
+            .path("/policies")
+            .queryParam("details", true)
+            .request(MediaType.APPLICATION_JSON_TYPE)
+            .accept("application/vnd.gravitino.v1+json")
+            .get();
+
+    Assertions.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+
+    PolicyListResponse policyListResponse = response.readEntity(PolicyListResponse.class);
+    Assertions.assertEquals(0, policyListResponse.getCode());
+    Assertions.assertEquals(catalogPolicyInfos.length, policyListResponse.getPolicies().length);
+
+    Map<String, Policy> resultPolicies =
+        Arrays.stream(policyListResponse.getPolicies())
+            .collect(Collectors.toMap(Policy::name, Function.identity()));
+
+    Assertions.assertTrue(resultPolicies.containsKey("policy1"));
+    Assertions.assertFalse(resultPolicies.get("policy1").inherited().get());
+
+    Response response1 =
+        target(basePath(metalake))
+            .path(catalog.type().toString())
+            .path(catalog.fullName())
+            .path("policies")
+            .request(MediaType.APPLICATION_JSON_TYPE)
+            .accept("application/vnd.gravitino.v1+json")
+            .get();
+
+    Assertions.assertEquals(Response.Status.OK.getStatusCode(), response1.getStatus());
+
+    NameListResponse nameListResponse = response1.readEntity(NameListResponse.class);
+    Assertions.assertEquals(0, nameListResponse.getCode());
+    Assertions.assertEquals(catalogPolicyInfos.length, nameListResponse.getNames().length);
+    Assertions.assertArrayEquals(
+        Arrays.stream(catalogPolicyInfos).map(PolicyEntity::name).toArray(String[]::new),
+        nameListResponse.getNames());
+
+    // Test schema policies
+    Response response2 =
+        target(basePath(metalake))
+            .path(schema.type().toString())
+            .path(schema.fullName())
+            .path("policies")
+            .queryParam("details", true)
+            .request(MediaType.APPLICATION_JSON_TYPE)
+            .accept("application/vnd.gravitino.v1+json")
+            .get();
+
+    Assertions.assertEquals(Response.Status.OK.getStatusCode(), response2.getStatus());
+
+    PolicyListResponse policyListResponse1 = response2.readEntity(PolicyListResponse.class);
+    Assertions.assertEquals(0, policyListResponse1.getCode());
+    Assertions.assertEquals(
+        schemaPolicyInfos.length + catalogPolicyInfos.length,
+        policyListResponse1.getPolicies().length);
+
+    Map<String, Policy> resultPolicies1 =
+        Arrays.stream(policyListResponse1.getPolicies())
+            .collect(Collectors.toMap(Policy::name, Function.identity()));
+
+    Assertions.assertTrue(resultPolicies1.containsKey("policy1"));
+    Assertions.assertTrue(resultPolicies1.containsKey("policy3"));
+
+    Assertions.assertTrue(resultPolicies1.get("policy1").inherited().get());
+    Assertions.assertFalse(resultPolicies1.get("policy3").inherited().get());
+
+    Response response3 =
+        target(basePath(metalake))
+            .path(schema.type().toString())
+            .path(schema.fullName())
+            .path("policies")
+            .request(MediaType.APPLICATION_JSON_TYPE)
+            .accept("application/vnd.gravitino.v1+json")
+            .get();
+
+    Assertions.assertEquals(Response.Status.OK.getStatusCode(), response3.getStatus());
+
+    NameListResponse nameListResponse1 = response3.readEntity(NameListResponse.class);
+    Assertions.assertEquals(0, nameListResponse1.getCode());
+    Assertions.assertEquals(
+        schemaPolicyInfos.length + catalogPolicyInfos.length, nameListResponse1.getNames().length);
+    Set<String> resultNames = Sets.newHashSet(nameListResponse1.getNames());
+    Assertions.assertTrue(resultNames.contains("policy1"));
+    Assertions.assertTrue(resultNames.contains("policy3"));
+
+    // Test table policies
+    Response response4 =
+        target(basePath(metalake))
+            .path(table.type().toString())
+            .path(table.fullName())
+            .path("policies")
+            .queryParam("details", true)
+            .request(MediaType.APPLICATION_JSON_TYPE)
+            .accept("application/vnd.gravitino.v1+json")
+            .get();
+
+    Assertions.assertEquals(Response.Status.OK.getStatusCode(), response4.getStatus());
+
+    PolicyListResponse policyListResponse2 = response4.readEntity(PolicyListResponse.class);
+    Assertions.assertEquals(0, policyListResponse2.getCode());
+    Assertions.assertEquals(
+        schemaPolicyInfos.length + catalogPolicyInfos.length + tablePolicyInfos.length,
+        policyListResponse2.getPolicies().length);
+
+    Map<String, Policy> resultPolicies2 =
+        Arrays.stream(policyListResponse2.getPolicies())
+            .collect(Collectors.toMap(Policy::name, Function.identity()));
+
+    Assertions.assertTrue(resultPolicies2.containsKey("policy1"));
+    Assertions.assertTrue(resultPolicies2.containsKey("policy3"));
+    Assertions.assertTrue(resultPolicies2.containsKey("policy5"));
+
+    Assertions.assertTrue(resultPolicies2.get("policy1").inherited().get());
+    Assertions.assertTrue(resultPolicies2.get("policy3").inherited().get());
+    Assertions.assertFalse(resultPolicies2.get("policy5").inherited().get());
+
+    Response response5 =
+        target(basePath(metalake))
+            .path(table.type().toString())
+            .path(table.fullName())
+            .path("policies")
+            .request(MediaType.APPLICATION_JSON_TYPE)
+            .accept("application/vnd.gravitino.v1+json")
+            .get();
+
+    Assertions.assertEquals(Response.Status.OK.getStatusCode(), response5.getStatus());
+
+    NameListResponse nameListResponse2 = response5.readEntity(NameListResponse.class);
+    Assertions.assertEquals(0, nameListResponse2.getCode());
+    Assertions.assertEquals(
+        schemaPolicyInfos.length + catalogPolicyInfos.length + tablePolicyInfos.length,
+        nameListResponse2.getNames().length);
+
+    Set<String> resultNames1 = Sets.newHashSet(nameListResponse2.getNames());
+    Assertions.assertTrue(resultNames1.contains("policy1"));
+    Assertions.assertTrue(resultNames1.contains("policy3"));
+    Assertions.assertTrue(resultNames1.contains("policy5"));
+
+    tablePolicyInfos =
+        new PolicyEntity[] {
+          createPolicy("policy5"),
+          // Policy policy3 already associated with schema
+          createPolicy("policy3"),
+          // Policy policy1 already associated with catalog
+          createPolicy("policy1"),
+          createPolicy("policy0")
+        };
+    when(policyManager.listPolicyInfosForMetadataObject(metalake, table))
+        .thenReturn(tablePolicyInfos);
+
+    Response response8 =
+        target(basePath(metalake))
+            .path(table.type().toString())
+            .path(table.fullName())
+            .path("policies")
+            .queryParam("details", true)
+            .request(MediaType.APPLICATION_JSON_TYPE)
+            .accept("application/vnd.gravitino.v1+json")
+            .get();
+
+    Assertions.assertEquals(Response.Status.OK.getStatusCode(), response8.getStatus());
+
+    PolicyListResponse policyListResponse8 = response8.readEntity(PolicyListResponse.class);
+    Assertions.assertEquals(0, policyListResponse8.getCode());
+    Assertions.assertEquals(4, policyListResponse8.getPolicies().length);
+
+    Map<String, Policy> resultPolicies8 =
+        Arrays.stream(policyListResponse8.getPolicies())
+            .collect(Collectors.toMap(Policy::name, Function.identity()));
+
+    Assertions.assertTrue(resultPolicies8.containsKey("policy0"));
+    Assertions.assertTrue(resultPolicies8.containsKey("policy1"));
+    Assertions.assertTrue(resultPolicies8.containsKey("policy3"));
+    Assertions.assertTrue(resultPolicies8.containsKey("policy5"));
+
+    Assertions.assertFalse(resultPolicies8.get("policy1").inherited().get());
+    Assertions.assertFalse(resultPolicies8.get("policy3").inherited().get());
+    Assertions.assertFalse(resultPolicies8.get("policy5").inherited().get());
+    Assertions.assertFalse(resultPolicies8.get("policy0").inherited().get());
+  }
+
+  @Test
+  public void testGetPolicyForObject() {
+    PolicyEntity policy1 = createPolicy("policy1");
+    MetadataObject catalog = MetadataObjects.parse("object1", MetadataObject.Type.CATALOG);
+    when(policyManager.getPolicyForMetadataObject(metalake, catalog, "policy1"))
+        .thenReturn(policy1);
+
+    PolicyEntity policy2 = createPolicy("policy2");
+    MetadataObject schema = MetadataObjects.parse("object1.object2", MetadataObject.Type.SCHEMA);
+    when(policyManager.getPolicyForMetadataObject(metalake, schema, "policy2")).thenReturn(policy2);
+
+    PolicyEntity policy3 = createPolicy("policy3");
+    MetadataObject table =
+        MetadataObjects.parse("object1.object2.object3", MetadataObject.Type.TABLE);
+    when(policyManager.getPolicyForMetadataObject(metalake, table, "policy3")).thenReturn(policy3);
+
+    // Test catalog policy
+    Response response =
+        target(basePath(metalake))
+            .path(catalog.type().toString())
+            .path(catalog.fullName())
+            .path("policies")
+            .path("policy1")
+            .request(MediaType.APPLICATION_JSON_TYPE)
+            .accept("application/vnd.gravitino.v1+json")
+            .get();
+
+    Assertions.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+
+    PolicyResponse policyResponse = response.readEntity(PolicyResponse.class);
+    Assertions.assertEquals(0, policyResponse.getCode());
+
+    Policy respPolicy = policyResponse.getPolicy();
+    Assertions.assertEquals(policy1.name(), respPolicy.name());
+    Assertions.assertEquals(policy1.comment(), respPolicy.comment());
+    Assertions.assertFalse(respPolicy.inherited().get());
+
+    // Test schema policy
+    Response response1 =
+        target(basePath(metalake))
+            .path(schema.type().toString())
+            .path(schema.fullName())
+            .path("policies")
+            .path("policy2")
+            .request(MediaType.APPLICATION_JSON_TYPE)
+            .accept("application/vnd.gravitino.v1+json")
+            .get();
+
+    Assertions.assertEquals(Response.Status.OK.getStatusCode(), response1.getStatus());
+
+    PolicyResponse policyResponse1 = response1.readEntity(PolicyResponse.class);
+    Assertions.assertEquals(0, policyResponse1.getCode());
+
+    Policy respPolicy1 = policyResponse1.getPolicy();
+    Assertions.assertEquals(policy2.name(), respPolicy1.name());
+    Assertions.assertEquals(policy2.comment(), respPolicy1.comment());
+    Assertions.assertFalse(respPolicy1.inherited().get());
+
+    // Test table policy
+    Response response2 =
+        target(basePath(metalake))
+            .path(table.type().toString())
+            .path(table.fullName())
+            .path("policies")
+            .path("policy3")
+            .request(MediaType.APPLICATION_JSON_TYPE)
+            .accept("application/vnd.gravitino.v1+json")
+            .get();
+
+    Assertions.assertEquals(Response.Status.OK.getStatusCode(), response2.getStatus());
+
+    PolicyResponse policyResponse2 = response2.readEntity(PolicyResponse.class);
+    Assertions.assertEquals(0, policyResponse2.getCode());
+
+    Policy respPolicy2 = policyResponse2.getPolicy();
+    Assertions.assertEquals(policy3.name(), respPolicy2.name());
+    Assertions.assertEquals(policy3.comment(), respPolicy2.comment());
+    Assertions.assertFalse(respPolicy2.inherited().get());
+
+    // Test get schema inherited policy
+    Response response4 =
+        target(basePath(metalake))
+            .path(schema.type().toString())
+            .path(schema.fullName())
+            .path("policies")
+            .path("policy1")
+            .request(MediaType.APPLICATION_JSON_TYPE)
+            .accept("application/vnd.gravitino.v1+json")
+            .get();
+
+    Assertions.assertEquals(Response.Status.OK.getStatusCode(), response4.getStatus());
+
+    PolicyResponse policyResponse4 = response4.readEntity(PolicyResponse.class);
+    Assertions.assertEquals(0, policyResponse4.getCode());
+
+    Policy respPolicy4 = policyResponse4.getPolicy();
+    Assertions.assertEquals(policy1.name(), respPolicy4.name());
+    Assertions.assertEquals(policy1.comment(), respPolicy4.comment());
+    Assertions.assertTrue(respPolicy4.inherited().get());
+
+    // Test get table inherited policy
+    Response response5 =
+        target(basePath(metalake))
+            .path(table.type().toString())
+            .path(table.fullName())
+            .path("policies")
+            .path("policy2")
+            .request(MediaType.APPLICATION_JSON_TYPE)
+            .accept("application/vnd.gravitino.v1+json")
+            .get();
+
+    Assertions.assertEquals(Response.Status.OK.getStatusCode(), response5.getStatus());
+
+    PolicyResponse policyResponse5 = response5.readEntity(PolicyResponse.class);
+    Assertions.assertEquals(0, policyResponse5.getCode());
+
+    Policy respPolicy5 = policyResponse5.getPolicy();
+    Assertions.assertEquals(policy2.name(), respPolicy5.name());
+    Assertions.assertEquals(policy2.comment(), respPolicy5.comment());
+    Assertions.assertTrue(respPolicy5.inherited().get());
+
+    // Test catalog policy throw NoSuchPolicyException
+    Response response7 =
+        target(basePath(metalake))
+            .path(catalog.type().toString())
+            .path(catalog.fullName())
+            .path("policies")
+            .path("policy2")
+            .request(MediaType.APPLICATION_JSON_TYPE)
+            .accept("application/vnd.gravitino.v1+json")
+            .get();
+
+    Assertions.assertEquals(Response.Status.NOT_FOUND.getStatusCode(), response7.getStatus());
+
+    ErrorResponse errorResponse = response7.readEntity(ErrorResponse.class);
+    Assertions.assertEquals(ErrorConstants.NOT_FOUND_CODE, errorResponse.getCode());
+    Assertions.assertEquals(NoSuchPolicyException.class.getSimpleName(), errorResponse.getType());
+
+    // Test schema policy throw NoSuchPolicyException
+    Response response8 =
+        target(basePath(metalake))
+            .path(schema.type().toString())
+            .path(schema.fullName())
+            .path("policies")
+            .path("policy3")
+            .request(MediaType.APPLICATION_JSON_TYPE)
+            .accept("application/vnd.gravitino.v1+json")
+            .get();
+
+    Assertions.assertEquals(Response.Status.NOT_FOUND.getStatusCode(), response8.getStatus());
+
+    ErrorResponse errorResponse1 = response8.readEntity(ErrorResponse.class);
+    Assertions.assertEquals(ErrorConstants.NOT_FOUND_CODE, errorResponse1.getCode());
+    Assertions.assertEquals(NoSuchPolicyException.class.getSimpleName(), errorResponse1.getType());
+  }
+
+  @Test
+  public void testAssociatePoliciesForObject() {
+    String[] policiesToAdd = new String[] {"policy1", "policy2"};
+    String[] policiesToRemove = new String[] {"policy3", "policy4"};
+
+    MetadataObject catalog = MetadataObjects.parse("object1", MetadataObject.Type.CATALOG);
+    when(policyManager.associatePoliciesForMetadataObject(
+            metalake, catalog, policiesToAdd, policiesToRemove))
+        .thenReturn(policiesToAdd);
+
+    PoliciesAssociateRequest request =
+        new PoliciesAssociateRequest(policiesToAdd, policiesToRemove);
+    Response response =
+        target(basePath(metalake))
+            .path(catalog.type().toString())
+            .path(catalog.fullName())
+            .path("policies")
+            .request(MediaType.APPLICATION_JSON_TYPE)
+            .accept("application/vnd.gravitino.v1+json")
+            .post(Entity.entity(request, MediaType.APPLICATION_JSON_TYPE));
+
+    Assertions.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+    Assertions.assertEquals(MediaType.APPLICATION_JSON_TYPE, response.getMediaType());
+
+    NameListResponse nameListResponse = response.readEntity(NameListResponse.class);
+    Assertions.assertEquals(0, nameListResponse.getCode());
+
+    Assertions.assertArrayEquals(policiesToAdd, nameListResponse.getNames());
+
+    // Test throw null policies
+    when(policyManager.associatePoliciesForMetadataObject(
+            metalake, catalog, policiesToAdd, policiesToRemove))
+        .thenReturn(null);
+    Response response1 =
+        target(basePath(metalake))
+            .path(catalog.type().toString())
+            .path(catalog.fullName())
+            .path("policies")
+            .request(MediaType.APPLICATION_JSON_TYPE)
+            .accept("application/vnd.gravitino.v1+json")
+            .post(Entity.entity(request, MediaType.APPLICATION_JSON_TYPE));
+
+    Assertions.assertEquals(Response.Status.OK.getStatusCode(), response1.getStatus());
+
+    NameListResponse nameListResponse1 = response1.readEntity(NameListResponse.class);
+    Assertions.assertEquals(0, nameListResponse1.getCode());
+
+    Assertions.assertEquals(0, nameListResponse1.getNames().length);
+
+    // Test throw PolicyAlreadyAssociatedException
+    doThrow(new PolicyAlreadyAssociatedException("mock error"))
+        .when(policyManager)
+        .associatePoliciesForMetadataObject(metalake, catalog, policiesToAdd, policiesToRemove);
+    Response response2 =
+        target(basePath(metalake))
+            .path(catalog.type().toString())
+            .path(catalog.fullName())
+            .path("policies")
+            .request(MediaType.APPLICATION_JSON_TYPE)
+            .accept("application/vnd.gravitino.v1+json")
+            .post(Entity.entity(request, MediaType.APPLICATION_JSON_TYPE));
+
+    Assertions.assertEquals(Response.Status.CONFLICT.getStatusCode(), response2.getStatus());
+
+    ErrorResponse errorResponse = response2.readEntity(ErrorResponse.class);
+    Assertions.assertEquals(ErrorConstants.ALREADY_EXISTS_CODE, errorResponse.getCode());
+    Assertions.assertEquals(
+        PolicyAlreadyAssociatedException.class.getSimpleName(), errorResponse.getType());
+
+    // Test throw RuntimeException
+    doThrow(new RuntimeException("mock error"))
+        .when(policyManager)
+        .associatePoliciesForMetadataObject(any(), any(), any(), any());
+
+    Response response3 =
+        target(basePath(metalake))
+            .path(catalog.type().toString())
+            .path(catalog.fullName())
+            .path("policies")
+            .request(MediaType.APPLICATION_JSON_TYPE)
+            .accept("application/vnd.gravitino.v1+json")
+            .post(Entity.entity(request, MediaType.APPLICATION_JSON_TYPE));
+
+    Assertions.assertEquals(
+        Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), response3.getStatus());
+
+    ErrorResponse errorResponse1 = response3.readEntity(ErrorResponse.class);
+    Assertions.assertEquals(ErrorConstants.INTERNAL_ERROR_CODE, errorResponse1.getCode());
+    Assertions.assertEquals(RuntimeException.class.getSimpleName(), errorResponse1.getType());
+  }
+
+  private String basePath(String metalake) {
+    return "/metalakes/" + metalake + "/objects";
+  }
+
+  private PolicyEntity createPolicy(String policyName) {
+    return PolicyEntity.builder()
+        .withName(policyName)
+        .withId(1L)
+        .withPolicyType(Policy.BuiltInType.CUSTOM)
+        .withContent(policyContent)
+        .withAuditInfo(testAuditInfo1)
+        .build();
+  }
+}

--- a/server/src/test/java/org/apache/gravitino/server/web/rest/TestPolicyOperations.java
+++ b/server/src/test/java/org/apache/gravitino/server/web/rest/TestPolicyOperations.java
@@ -38,6 +38,7 @@ import javax.ws.rs.core.Application;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import org.apache.gravitino.MetadataObject;
+import org.apache.gravitino.MetadataObjects;
 import org.apache.gravitino.dto.requests.PolicyCreateRequest;
 import org.apache.gravitino.dto.requests.PolicySetRequest;
 import org.apache.gravitino.dto.requests.PolicyUpdateRequest;
@@ -46,6 +47,7 @@ import org.apache.gravitino.dto.responses.BaseResponse;
 import org.apache.gravitino.dto.responses.DropResponse;
 import org.apache.gravitino.dto.responses.ErrorConstants;
 import org.apache.gravitino.dto.responses.ErrorResponse;
+import org.apache.gravitino.dto.responses.MetadataObjectListResponse;
 import org.apache.gravitino.dto.responses.NameListResponse;
 import org.apache.gravitino.dto.responses.PolicyListResponse;
 import org.apache.gravitino.dto.responses.PolicyResponse;
@@ -104,8 +106,7 @@ public class TestPolicyOperations extends JerseyTest {
           @Override
           protected void configure() {
             bind(policyManager).to(PolicyDispatcher.class).ranked(2);
-            bindFactory(TestPolicyOperations.MockServletRequestFactory.class)
-                .to(HttpServletRequest.class);
+            bindFactory(MockServletRequestFactory.class).to(HttpServletRequest.class);
           }
         });
 
@@ -561,6 +562,80 @@ public class TestPolicyOperations extends JerseyTest {
     ErrorResponse errorResp1 = resp2.readEntity(ErrorResponse.class);
     Assertions.assertEquals(ErrorConstants.INTERNAL_ERROR_CODE, errorResp1.getCode());
     Assertions.assertEquals(RuntimeException.class.getSimpleName(), errorResp1.getType());
+  }
+
+  @Test
+  public void testListMetadataObjectForPolicy() {
+    MetadataObject[] objects =
+        new MetadataObject[] {
+          MetadataObjects.parse("object1", MetadataObject.Type.CATALOG),
+          MetadataObjects.parse("object1.object2", MetadataObject.Type.SCHEMA),
+          MetadataObjects.parse("object1.object2.object3", MetadataObject.Type.TABLE),
+        };
+
+    when(policyManager.listMetadataObjectsForPolicy(metalake, "policy1")).thenReturn(objects);
+
+    Response response =
+        target(policyPath(metalake))
+            .path("policy1")
+            .path("objects")
+            .request(MediaType.APPLICATION_JSON_TYPE)
+            .accept("application/vnd.gravitino.v1+json")
+            .get();
+
+    Assertions.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+    Assertions.assertEquals(MediaType.APPLICATION_JSON_TYPE, response.getMediaType());
+
+    MetadataObjectListResponse objectListResponse =
+        response.readEntity(MetadataObjectListResponse.class);
+    Assertions.assertEquals(0, objectListResponse.getCode());
+
+    MetadataObject[] respObjects = objectListResponse.getMetadataObjects();
+    Assertions.assertEquals(objects.length, respObjects.length);
+
+    for (int i = 0; i < objects.length; i++) {
+      Assertions.assertEquals(objects[i].type(), respObjects[i].type());
+      Assertions.assertEquals(objects[i].fullName(), respObjects[i].fullName());
+    }
+
+    // Test throw NoSuchPolicyException
+    doThrow(new NoSuchPolicyException("mock error"))
+        .when(policyManager)
+        .listMetadataObjectsForPolicy(metalake, "policy1");
+
+    Response response1 =
+        target(policyPath(metalake))
+            .path("policy1")
+            .path("objects")
+            .request(MediaType.APPLICATION_JSON_TYPE)
+            .accept("application/vnd.gravitino.v1+json")
+            .get();
+
+    Assertions.assertEquals(Response.Status.NOT_FOUND.getStatusCode(), response1.getStatus());
+
+    ErrorResponse errorResponse = response1.readEntity(ErrorResponse.class);
+    Assertions.assertEquals(ErrorConstants.NOT_FOUND_CODE, errorResponse.getCode());
+    Assertions.assertEquals(NoSuchPolicyException.class.getSimpleName(), errorResponse.getType());
+
+    // Test throw RuntimeException
+    doThrow(new RuntimeException("mock error"))
+        .when(policyManager)
+        .listMetadataObjectsForPolicy(any(), any());
+
+    Response response2 =
+        target(policyPath(metalake))
+            .path("policy1")
+            .path("objects")
+            .request(MediaType.APPLICATION_JSON_TYPE)
+            .accept("application/vnd.gravitino.v1+json")
+            .get();
+
+    Assertions.assertEquals(
+        Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), response2.getStatus());
+
+    ErrorResponse errorResponse1 = response2.readEntity(ErrorResponse.class);
+    Assertions.assertEquals(ErrorConstants.INTERNAL_ERROR_CODE, errorResponse1.getCode());
+    Assertions.assertEquals(RuntimeException.class.getSimpleName(), errorResponse1.getType());
   }
 
   private String policyPath(String metalake) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

policy relational operations implementation on server-side

### Why are the changes needed?

Fix: #7841 

### Does this PR introduce _any_ user-facing change?

yes, new APIs are implemented

### How was this patch tested?

tests added
