### PR TITLE
[#7787][HOTFIX] fix(core): Disable the entity cache by default

### DIFF
--- a/core/src/main/java/org/apache/gravitino/Configs.java
+++ b/core/src/main/java/org/apache/gravitino/Configs.java
@@ -357,7 +357,7 @@ public class Configs {
           .doc("Whether to enable the cached Entity store.")
           .version(ConfigConstants.VERSION_1_0_0)
           .booleanConf()
-          .createWithDefault(true);
+          .createWithDefault(false);
 
   // Maximum number of entries in the cache
   public static final ConfigEntry<Integer> CACHE_MAX_ENTRIES =

--- a/core/src/main/java/org/apache/gravitino/storage/relational/session/SqlSessionFactoryHelper.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/session/SqlSessionFactoryHelper.java
@@ -33,6 +33,7 @@ import org.apache.gravitino.metrics.source.RelationDatasourceMetricsSource;
 import org.apache.gravitino.storage.relational.JDBCBackend.JDBCBackendType;
 import org.apache.gravitino.storage.relational.mapper.provider.MapperPackageProvider;
 import org.apache.gravitino.utils.JdbcUrlUtils;
+import org.apache.ibatis.cache.impl.PerpetualCache;
 import org.apache.ibatis.mapping.Environment;
 import org.apache.ibatis.session.Configuration;
 import org.apache.ibatis.session.SqlSessionFactory;
@@ -105,9 +106,11 @@ public class SqlSessionFactoryHelper {
     // Initialize the configuration
     Configuration configuration = new Configuration(environment);
     configuration.setDatabaseId(jdbcType.name().toLowerCase());
+    configuration.setCacheEnabled(true);
     ServiceLoader<MapperPackageProvider> loader = ServiceLoader.load(MapperPackageProvider.class);
     for (MapperPackageProvider provider : loader) {
       configuration.addMappers(provider.getPackageName());
+      configuration.addCache(new PerpetualCache(provider.getPackageName()));
     }
 
     // Create the SqlSessionFactory object, it is a singleton object

--- a/core/src/test/java/org/apache/gravitino/cache/TestCacheConfig.java
+++ b/core/src/test/java/org/apache/gravitino/cache/TestCacheConfig.java
@@ -29,7 +29,7 @@ public class TestCacheConfig {
   void testDefaultCacheConfig() {
     Config config = new Config(false) {};
     Assertions.assertFalse(config.get(Configs.CACHE_STATS_ENABLED));
-    Assertions.assertTrue(config.get(Configs.CACHE_ENABLED));
+    Assertions.assertFalse(config.get(Configs.CACHE_ENABLED));
     Assertions.assertTrue(config.get(Configs.CACHE_WEIGHER_ENABLED));
     Assertions.assertEquals(10_000, config.get(Configs.CACHE_MAX_ENTRIES));
     Assertions.assertEquals(3_600_000L, config.get(Configs.CACHE_EXPIRATION_TIME));


### PR DESCRIPTION
### What changes were proposed in this pull request?

Current entity cache still has lots of corner cases need to be fixed, so disable by default.

### Why are the changes needed?

#7787 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing UTs.
