### PR TITLE
[#8082] fix: call request.validate() in PartitionOperations.java

### DIFF
--- a/server/src/main/java/org/apache/gravitino/server/web/rest/PartitionOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/PartitionOperations.java
@@ -173,6 +173,8 @@ public class PartitionOperations {
     Preconditions.checkArgument(
         request.getPartitions().length == 1, "Only one partition is supported");
 
+    request.validate();
+
     try {
       return Utils.doAs(
           httpRequest,


### PR DESCRIPTION
### What changes were proposed in this pull request?

In `PartitionOperations.java`, the `addPartitions` method was missing a call to `request.validate()`.  
This PR adds `request.validate()` to ensure that invalid requests are rejected properly.

### Why are the changes needed?

Without this validation, requests with missing or null partitions could bypass checks, potentially causing unexpected errors.  
Adding this call ensures that invalid requests return `BAD_REQUEST` as expected.

Fix: #8082(https://github.com/apache/gravitino/issues/8082)

### Does this PR introduce _any_ user-facing change?

No. Existing APIs behave the same for valid requests. Invalid requests now correctly return `BAD_REQUEST`.

### How was this patch tested?

- Added a unit test `testAddPartitionWithNullPartitions()` that verifies a `BAD_REQUEST` response for invalid input.  
- Verified locally and via CI that the test passes and validation works as expected.