### PR TITLE
[#8086] improvement(spark): prevent NPE in SparkPartitionUtils 

### DIFF
--- a/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/utils/SparkPartitionUtils.java
+++ b/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/utils/SparkPartitionUtils.java
@@ -46,6 +46,10 @@ public class SparkPartitionUtils {
   private SparkPartitionUtils() {}
 
   public static Literal<?> toGravitinoLiteral(InternalRow ident, int ordinal, DataType sparkType) {
+    if (ident.isNullAt(ordinal)) {
+      return Literals.NULL;
+    }
+
     if (sparkType instanceof ByteType) {
       return Literals.byteLiteral(ident.getByte(ordinal));
     } else if (sparkType instanceof ShortType) {

--- a/spark-connector/spark-common/src/test/java/org/apache/gravitino/spark/connector/utils/TestSparkPartitionUtils.java
+++ b/spark-connector/spark-common/src/test/java/org/apache/gravitino/spark/connector/utils/TestSparkPartitionUtils.java
@@ -178,7 +178,8 @@ public class TestSparkPartitionUtils {
 
   @Test
   void testToGravitinoLiteralWithMixedNullAndNonNull() {
-    GenericInternalRow mixedRow = new GenericInternalRow(new Object[] {null, "test", 42});
+    GenericInternalRow mixedRow =
+        new GenericInternalRow(new Object[] {null, UTF8String.fromString("test"), 42});
 
     Assertions.assertEquals(
         Literals.NULL, SparkPartitionUtils.toGravitinoLiteral(mixedRow, 0, DataTypes.StringType));

--- a/spark-connector/spark-common/src/test/java/org/apache/gravitino/spark/connector/utils/TestSparkPartitionUtils.java
+++ b/spark-connector/spark-common/src/test/java/org/apache/gravitino/spark/connector/utils/TestSparkPartitionUtils.java
@@ -150,4 +150,45 @@ public class TestSparkPartitionUtils {
             SparkPartitionUtils.getSparkPartitionValue(
                 "1970-01-01 00:00:00", DataTypes.TimestampType));
   }
+
+  @Test
+  void testToGravitinoLiteralWithNull() {
+    GenericInternalRow rowWithNull = new GenericInternalRow(new Object[] {null});
+    Assertions.assertEquals(
+        Literals.NULL,
+        SparkPartitionUtils.toGravitinoLiteral(rowWithNull, 0, DataTypes.IntegerType));
+  }
+
+  @Test
+  void testToGravitinoLiteralWithNullForDifferentTypes() {
+    GenericInternalRow rowWithNull = new GenericInternalRow(new Object[] {null});
+
+    Assertions.assertEquals(
+        Literals.NULL,
+        SparkPartitionUtils.toGravitinoLiteral(rowWithNull, 0, DataTypes.StringType));
+
+    Assertions.assertEquals(
+        Literals.NULL,
+        SparkPartitionUtils.toGravitinoLiteral(rowWithNull, 0, DataTypes.BooleanType));
+
+    Assertions.assertEquals(
+        Literals.NULL,
+        SparkPartitionUtils.toGravitinoLiteral(rowWithNull, 0, DataTypes.DoubleType));
+  }
+
+  @Test
+  void testToGravitinoLiteralWithMixedNullAndNonNull() {
+    GenericInternalRow mixedRow = new GenericInternalRow(new Object[] {null, "test", 42});
+
+    Assertions.assertEquals(
+        Literals.NULL, SparkPartitionUtils.toGravitinoLiteral(mixedRow, 0, DataTypes.StringType));
+
+    Assertions.assertEquals(
+        Literals.stringLiteral("test"),
+        SparkPartitionUtils.toGravitinoLiteral(mixedRow, 1, DataTypes.StringType));
+
+    Assertions.assertEquals(
+        Literals.integerLiteral(42),
+        SparkPartitionUtils.toGravitinoLiteral(mixedRow, 2, DataTypes.IntegerType));
+  }
 }

--- a/spark-connector/spark-common/src/test/java/org/apache/gravitino/spark/connector/utils/TestSparkPartitionUtils.java
+++ b/spark-connector/spark-common/src/test/java/org/apache/gravitino/spark/connector/utils/TestSparkPartitionUtils.java
@@ -152,31 +152,6 @@ public class TestSparkPartitionUtils {
   }
 
   @Test
-  void testToGravitinoLiteralWithNull() {
-    GenericInternalRow rowWithNull = new GenericInternalRow(new Object[] {null});
-    Assertions.assertEquals(
-        Literals.NULL,
-        SparkPartitionUtils.toGravitinoLiteral(rowWithNull, 0, DataTypes.IntegerType));
-  }
-
-  @Test
-  void testToGravitinoLiteralWithNullForDifferentTypes() {
-    GenericInternalRow rowWithNull = new GenericInternalRow(new Object[] {null});
-
-    Assertions.assertEquals(
-        Literals.NULL,
-        SparkPartitionUtils.toGravitinoLiteral(rowWithNull, 0, DataTypes.StringType));
-
-    Assertions.assertEquals(
-        Literals.NULL,
-        SparkPartitionUtils.toGravitinoLiteral(rowWithNull, 0, DataTypes.BooleanType));
-
-    Assertions.assertEquals(
-        Literals.NULL,
-        SparkPartitionUtils.toGravitinoLiteral(rowWithNull, 0, DataTypes.DoubleType));
-  }
-
-  @Test
   void testToGravitinoLiteralWithMixedNullAndNonNull() {
     GenericInternalRow mixedRow =
         new GenericInternalRow(new Object[] {null, UTF8String.fromString("test"), 42});


### PR DESCRIPTION
### What changes were proposed in this pull request?
Checks for null values in toGravitinoLiteral before proceeding to prevent NPE

### Why are the changes needed?
Improvement to prevent NPE in SparkPartitionUtils.

Fix: #8086

### Does this PR introduce _any_ user-facing change?

no


### How was this patch tested?
Unit testing

