### PR TITLE
[#7880] feat(policy): java client supports policy operations (part-2)

### DIFF
--- a/api/src/main/java/org/apache/gravitino/Catalog.java
+++ b/api/src/main/java/org/apache/gravitino/Catalog.java
@@ -26,6 +26,7 @@ import org.apache.gravitino.credential.SupportsCredentials;
 import org.apache.gravitino.file.FilesetCatalog;
 import org.apache.gravitino.messaging.TopicCatalog;
 import org.apache.gravitino.model.ModelCatalog;
+import org.apache.gravitino.policy.SupportsPolicies;
 import org.apache.gravitino.rel.TableCatalog;
 import org.apache.gravitino.tag.SupportsTags;
 
@@ -222,6 +223,14 @@ public interface Catalog extends Auditable {
    */
   default SupportsTags supportsTags() throws UnsupportedOperationException {
     throw new UnsupportedOperationException("Catalog does not support tag operations");
+  }
+
+  /**
+   * @return the {@link SupportsPolicies} if the catalog supports policy operations.
+   * @throws UnsupportedOperationException if the catalog does not support policy operations.
+   */
+  default SupportsPolicies supportsPolicies() throws UnsupportedOperationException {
+    throw new UnsupportedOperationException("Catalog does not support policy operations");
   }
 
   /**

--- a/api/src/main/java/org/apache/gravitino/Schema.java
+++ b/api/src/main/java/org/apache/gravitino/Schema.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import javax.annotation.Nullable;
 import org.apache.gravitino.annotation.Evolving;
 import org.apache.gravitino.authorization.SupportsRoles;
+import org.apache.gravitino.policy.SupportsPolicies;
 import org.apache.gravitino.tag.SupportsTags;
 
 /**
@@ -56,6 +57,14 @@ public interface Schema extends Auditable {
    */
   default SupportsTags supportsTags() {
     throw new UnsupportedOperationException("Schema does not support tag operations.");
+  }
+
+  /**
+   * @return the {@link SupportsPolicies} if the schema supports policy operations.
+   * @throws UnsupportedOperationException if the schema does not support policy operations.
+   */
+  default SupportsPolicies supportsPolicies() {
+    throw new UnsupportedOperationException("Schema does not support policy operations.");
   }
 
   /**

--- a/api/src/main/java/org/apache/gravitino/file/Fileset.java
+++ b/api/src/main/java/org/apache/gravitino/file/Fileset.java
@@ -26,6 +26,7 @@ import org.apache.gravitino.Namespace;
 import org.apache.gravitino.annotation.Evolving;
 import org.apache.gravitino.authorization.SupportsRoles;
 import org.apache.gravitino.credential.SupportsCredentials;
+import org.apache.gravitino.policy.SupportsPolicies;
 import org.apache.gravitino.tag.SupportsTags;
 
 /**
@@ -240,6 +241,14 @@ public interface Fileset extends Auditable {
    */
   default SupportsTags supportsTags() {
     throw new UnsupportedOperationException("Fileset does not support tag operations.");
+  }
+
+  /**
+   * @return The {@link SupportsPolicies} if the fileset supports policy operations.
+   * @throws UnsupportedOperationException If the fileset does not support policy operations.
+   */
+  default SupportsPolicies supportsPolicies() {
+    throw new UnsupportedOperationException("Fileset does not support policy operations.");
   }
 
   /**

--- a/api/src/main/java/org/apache/gravitino/messaging/Topic.java
+++ b/api/src/main/java/org/apache/gravitino/messaging/Topic.java
@@ -25,6 +25,7 @@ import org.apache.gravitino.Auditable;
 import org.apache.gravitino.Namespace;
 import org.apache.gravitino.annotation.Evolving;
 import org.apache.gravitino.authorization.SupportsRoles;
+import org.apache.gravitino.policy.SupportsPolicies;
 import org.apache.gravitino.tag.SupportsTags;
 
 /**
@@ -58,6 +59,14 @@ public interface Topic extends Auditable {
    */
   default SupportsTags supportsTags() {
     throw new UnsupportedOperationException("Topic does not support tag operations.");
+  }
+
+  /**
+   * @return the {@link SupportsPolicies} if the topic supports policy operations.
+   * @throws UnsupportedOperationException if the topic does not support policy operations.
+   */
+  default SupportsPolicies supportsPolicies() {
+    throw new UnsupportedOperationException("Topic does not support policy operations.");
   }
 
   /**

--- a/api/src/main/java/org/apache/gravitino/model/Model.java
+++ b/api/src/main/java/org/apache/gravitino/model/Model.java
@@ -24,6 +24,7 @@ import org.apache.gravitino.Auditable;
 import org.apache.gravitino.Namespace;
 import org.apache.gravitino.annotation.Evolving;
 import org.apache.gravitino.authorization.SupportsRoles;
+import org.apache.gravitino.policy.SupportsPolicies;
 import org.apache.gravitino.tag.SupportsTags;
 
 /**
@@ -80,6 +81,14 @@ public interface Model extends Auditable {
    */
   default SupportsTags supportsTags() {
     throw new UnsupportedOperationException("Model does not support tag operations.");
+  }
+
+  /**
+   * @return The {@link SupportsPolicies} if the model supports policy operations.
+   * @throws UnsupportedOperationException If the model does not support policy operations.
+   */
+  default SupportsPolicies supportsPolicies() {
+    throw new UnsupportedOperationException("Model does not support policy operations.");
   }
 
   /**

--- a/api/src/main/java/org/apache/gravitino/rel/Table.java
+++ b/api/src/main/java/org/apache/gravitino/rel/Table.java
@@ -25,6 +25,7 @@ import org.apache.gravitino.Auditable;
 import org.apache.gravitino.Namespace;
 import org.apache.gravitino.annotation.Evolving;
 import org.apache.gravitino.authorization.SupportsRoles;
+import org.apache.gravitino.policy.SupportsPolicies;
 import org.apache.gravitino.rel.expressions.distributions.Distribution;
 import org.apache.gravitino.rel.expressions.distributions.Distributions;
 import org.apache.gravitino.rel.expressions.sorts.SortOrder;
@@ -103,6 +104,14 @@ public interface Table extends Auditable {
    */
   default SupportsTags supportsTags() {
     throw new UnsupportedOperationException("Table does not support tag operations.");
+  }
+
+  /**
+   * @return The {@link SupportsPolicies} if the table supports policy operations.
+   * @throws UnsupportedOperationException If the table does not support policy operations.
+   */
+  default SupportsPolicies supportsPolicies() {
+    throw new UnsupportedOperationException("Table does not support policy operations.");
   }
 
   /**

--- a/clients/client-java/build.gradle.kts
+++ b/clients/client-java/build.gradle.kts
@@ -72,6 +72,7 @@ tasks.test {
     exclude("**/integration/test/**")
   } else {
     dependsOn(":catalogs:catalog-fileset:jar", ":catalogs:catalog-fileset:runtimeJars")
+    dependsOn(":catalogs:catalog-model:jar", ":catalogs:catalog-model:runtimeJars")
     dependsOn(":catalogs:catalog-hive:jar", ":catalogs:catalog-hive:runtimeJars")
     dependsOn(":catalogs:catalog-kafka:jar", ":catalogs:catalog-kafka:runtimeJars")
   }

--- a/clients/client-java/src/main/java/org/apache/gravitino/client/GenericFileset.java
+++ b/clients/client-java/src/main/java/org/apache/gravitino/client/GenericFileset.java
@@ -30,19 +30,25 @@ import org.apache.gravitino.authorization.SupportsRoles;
 import org.apache.gravitino.credential.Credential;
 import org.apache.gravitino.credential.SupportsCredentials;
 import org.apache.gravitino.dto.file.FilesetDTO;
+import org.apache.gravitino.exceptions.NoSuchPolicyException;
 import org.apache.gravitino.exceptions.NoSuchTagException;
+import org.apache.gravitino.exceptions.PolicyAlreadyAssociatedException;
 import org.apache.gravitino.file.Fileset;
+import org.apache.gravitino.policy.Policy;
+import org.apache.gravitino.policy.SupportsPolicies;
 import org.apache.gravitino.tag.SupportsTags;
 import org.apache.gravitino.tag.Tag;
 
 /** Represents a generic fileset. */
-class GenericFileset implements Fileset, SupportsTags, SupportsRoles, SupportsCredentials {
+class GenericFileset
+    implements Fileset, SupportsTags, SupportsRoles, SupportsCredentials, SupportsPolicies {
 
   private final FilesetDTO filesetDTO;
 
   private final MetadataObjectTagOperations objectTagOperations;
   private final MetadataObjectRoleOperations objectRoleOperations;
   private final MetadataObjectCredentialOperations objectCredentialOperations;
+  private final MetadataObjectPolicyOperations objectPolicyOperations;
 
   GenericFileset(FilesetDTO filesetDTO, RESTClient restClient, Namespace filesetNs) {
     this.filesetDTO = filesetDTO;
@@ -55,6 +61,8 @@ class GenericFileset implements Fileset, SupportsTags, SupportsRoles, SupportsCr
         new MetadataObjectRoleOperations(filesetNs.level(0), filesetObject, restClient);
     this.objectCredentialOperations =
         new MetadataObjectCredentialOperations(filesetNs.level(0), filesetObject, restClient);
+    this.objectPolicyOperations =
+        new MetadataObjectPolicyOperations(filesetNs.level(0), filesetObject, restClient);
   }
 
   @Override
@@ -94,6 +102,11 @@ class GenericFileset implements Fileset, SupportsTags, SupportsRoles, SupportsCr
   }
 
   @Override
+  public SupportsPolicies supportsPolicies() {
+    return this;
+  }
+
+  @Override
   public SupportsRoles supportsRoles() {
     return this;
   }
@@ -121,6 +134,27 @@ class GenericFileset implements Fileset, SupportsTags, SupportsRoles, SupportsCr
   @Override
   public String[] associateTags(String[] tagsToAdd, String[] tagsToRemove) {
     return objectTagOperations.associateTags(tagsToAdd, tagsToRemove);
+  }
+
+  @Override
+  public String[] listPolicies() {
+    return objectPolicyOperations.listPolicies();
+  }
+
+  @Override
+  public Policy[] listPolicyInfos() {
+    return objectPolicyOperations.listPolicyInfos();
+  }
+
+  @Override
+  public Policy getPolicy(String name) throws NoSuchPolicyException {
+    return objectPolicyOperations.getPolicy(name);
+  }
+
+  @Override
+  public String[] associatePolicies(String[] policiesToAdd, String[] policiesToRemove)
+      throws PolicyAlreadyAssociatedException {
+    return objectPolicyOperations.associatePolicies(policiesToAdd, policiesToRemove);
   }
 
   @Override

--- a/clients/client-java/src/main/java/org/apache/gravitino/client/GenericModel.java
+++ b/clients/client-java/src/main/java/org/apache/gravitino/client/GenericModel.java
@@ -27,18 +27,23 @@ import org.apache.gravitino.MetadataObjects;
 import org.apache.gravitino.Namespace;
 import org.apache.gravitino.authorization.SupportsRoles;
 import org.apache.gravitino.dto.model.ModelDTO;
+import org.apache.gravitino.exceptions.NoSuchPolicyException;
 import org.apache.gravitino.exceptions.NoSuchTagException;
+import org.apache.gravitino.exceptions.PolicyAlreadyAssociatedException;
 import org.apache.gravitino.exceptions.TagAlreadyAssociatedException;
 import org.apache.gravitino.model.Model;
+import org.apache.gravitino.policy.Policy;
+import org.apache.gravitino.policy.SupportsPolicies;
 import org.apache.gravitino.tag.SupportsTags;
 import org.apache.gravitino.tag.Tag;
 
 /** Represents a generic model. */
-class GenericModel implements Model, SupportsTags {
+class GenericModel implements Model, SupportsTags, SupportsPolicies {
 
   private final ModelDTO modelDTO;
 
   private final MetadataObjectTagOperations objectTagOperations;
+  private final MetadataObjectPolicyOperations objectPolicyOperations;
 
   GenericModel(ModelDTO modelDTO, RESTClient restClient, Namespace modelNs) {
     this.modelDTO = modelDTO;
@@ -47,6 +52,8 @@ class GenericModel implements Model, SupportsTags {
     MetadataObject modelObject = MetadataObjects.of(modelFullName, MetadataObject.Type.MODEL);
     this.objectTagOperations =
         new MetadataObjectTagOperations(modelNs.level(0), modelObject, restClient);
+    this.objectPolicyOperations =
+        new MetadataObjectPolicyOperations(modelNs.level(0), modelObject, restClient);
   }
 
   @Override
@@ -76,6 +83,11 @@ class GenericModel implements Model, SupportsTags {
 
   @Override
   public SupportsTags supportsTags() {
+    return this;
+  }
+
+  @Override
+  public SupportsPolicies supportsPolicies() {
     return this;
   }
 
@@ -121,5 +133,26 @@ class GenericModel implements Model, SupportsTags {
   public String[] associateTags(String[] tagsToAdd, String[] tagsToRemove)
       throws TagAlreadyAssociatedException {
     return objectTagOperations.associateTags(tagsToAdd, tagsToRemove);
+  }
+
+  @Override
+  public String[] listPolicies() {
+    return objectPolicyOperations.listPolicies();
+  }
+
+  @Override
+  public Policy[] listPolicyInfos() {
+    return objectPolicyOperations.listPolicyInfos();
+  }
+
+  @Override
+  public Policy getPolicy(String name) throws NoSuchPolicyException {
+    return objectPolicyOperations.getPolicy(name);
+  }
+
+  @Override
+  public String[] associatePolicies(String[] policiesToAdd, String[] policiesToRemove)
+      throws PolicyAlreadyAssociatedException {
+    return objectPolicyOperations.associatePolicies(policiesToAdd, policiesToRemove);
   }
 }

--- a/clients/client-java/src/main/java/org/apache/gravitino/client/GenericPolicy.java
+++ b/clients/client-java/src/main/java/org/apache/gravitino/client/GenericPolicy.java
@@ -18,6 +18,8 @@
  */
 package org.apache.gravitino.client;
 
+import static org.apache.gravitino.dto.util.DTOConverters.fromDTO;
+
 import java.util.Collections;
 import java.util.Optional;
 import org.apache.gravitino.Audit;
@@ -33,12 +35,15 @@ class GenericPolicy implements Policy, Policy.AssociatedObjects {
 
   private final PolicyDTO policyDTO;
 
+  private final PolicyContent content;
+
   private final RESTClient restClient;
 
   private final String metalake;
 
   GenericPolicy(PolicyDTO policyDTO, RESTClient restClient, String metalake) {
     this.policyDTO = policyDTO;
+    this.content = fromDTO(policyDTO.content());
     this.restClient = restClient;
     this.metalake = metalake;
   }
@@ -65,7 +70,7 @@ class GenericPolicy implements Policy, Policy.AssociatedObjects {
 
   @Override
   public PolicyContent content() {
-    return policyDTO.content();
+    return content;
   }
 
   @Override
@@ -114,5 +119,18 @@ class GenericPolicy implements Policy, Policy.AssociatedObjects {
   @Override
   public int hashCode() {
     return policyDTO.hashCode();
+  }
+
+  @Override
+  public String toString() {
+    return "GenericPolicy{"
+        + "policyDTO="
+        + policyDTO
+        + ", content="
+        + content
+        + ", metalake='"
+        + metalake
+        + '\''
+        + '}';
   }
 }

--- a/clients/client-java/src/main/java/org/apache/gravitino/client/GenericSchema.java
+++ b/clients/client-java/src/main/java/org/apache/gravitino/client/GenericSchema.java
@@ -25,17 +25,22 @@ import org.apache.gravitino.MetadataObjects;
 import org.apache.gravitino.Schema;
 import org.apache.gravitino.authorization.SupportsRoles;
 import org.apache.gravitino.dto.SchemaDTO;
+import org.apache.gravitino.exceptions.NoSuchPolicyException;
 import org.apache.gravitino.exceptions.NoSuchTagException;
+import org.apache.gravitino.exceptions.PolicyAlreadyAssociatedException;
+import org.apache.gravitino.policy.Policy;
+import org.apache.gravitino.policy.SupportsPolicies;
 import org.apache.gravitino.tag.SupportsTags;
 import org.apache.gravitino.tag.Tag;
 
 /** Represents a generic schema. */
-class GenericSchema implements Schema, SupportsTags, SupportsRoles {
+class GenericSchema implements Schema, SupportsTags, SupportsRoles, SupportsPolicies {
 
   private final SchemaDTO schemaDTO;
 
   private final MetadataObjectTagOperations objectTagOperations;
   private final MetadataObjectRoleOperations objectRoleOperations;
+  private final MetadataObjectPolicyOperations objectPolicyOperations;
 
   GenericSchema(SchemaDTO schemaDTO, RESTClient restClient, String metalake, String catalog) {
     this.schemaDTO = schemaDTO;
@@ -44,10 +49,17 @@ class GenericSchema implements Schema, SupportsTags, SupportsRoles {
     this.objectTagOperations = new MetadataObjectTagOperations(metalake, schemaObject, restClient);
     this.objectRoleOperations =
         new MetadataObjectRoleOperations(metalake, schemaObject, restClient);
+    this.objectPolicyOperations =
+        new MetadataObjectPolicyOperations(metalake, schemaObject, restClient);
   }
 
   @Override
   public SupportsTags supportsTags() {
+    return this;
+  }
+
+  @Override
+  public SupportsPolicies supportsPolicies() {
     return this;
   }
 
@@ -94,6 +106,27 @@ class GenericSchema implements Schema, SupportsTags, SupportsRoles {
   @Override
   public String[] associateTags(String[] tagsToAdd, String[] tagsToRemove) {
     return objectTagOperations.associateTags(tagsToAdd, tagsToRemove);
+  }
+
+  @Override
+  public String[] listPolicies() {
+    return objectPolicyOperations.listPolicies();
+  }
+
+  @Override
+  public Policy[] listPolicyInfos() {
+    return objectPolicyOperations.listPolicyInfos();
+  }
+
+  @Override
+  public Policy getPolicy(String name) throws NoSuchPolicyException {
+    return objectPolicyOperations.getPolicy(name);
+  }
+
+  @Override
+  public String[] associatePolicies(String[] policiesToAdd, String[] policiesToRemove)
+      throws PolicyAlreadyAssociatedException {
+    return objectPolicyOperations.associatePolicies(policiesToAdd, policiesToRemove);
   }
 
   @Override

--- a/clients/client-java/src/main/java/org/apache/gravitino/client/GenericTopic.java
+++ b/clients/client-java/src/main/java/org/apache/gravitino/client/GenericTopic.java
@@ -27,18 +27,23 @@ import org.apache.gravitino.MetadataObjects;
 import org.apache.gravitino.Namespace;
 import org.apache.gravitino.authorization.SupportsRoles;
 import org.apache.gravitino.dto.messaging.TopicDTO;
+import org.apache.gravitino.exceptions.NoSuchPolicyException;
 import org.apache.gravitino.exceptions.NoSuchTagException;
+import org.apache.gravitino.exceptions.PolicyAlreadyAssociatedException;
 import org.apache.gravitino.messaging.Topic;
+import org.apache.gravitino.policy.Policy;
+import org.apache.gravitino.policy.SupportsPolicies;
 import org.apache.gravitino.tag.SupportsTags;
 import org.apache.gravitino.tag.Tag;
 
 /** Represents a generic topic. */
-class GenericTopic implements Topic, SupportsTags, SupportsRoles {
+class GenericTopic implements Topic, SupportsTags, SupportsRoles, SupportsPolicies {
 
   private final TopicDTO topicDTO;
 
   private final MetadataObjectTagOperations objectTagOperations;
   private final MetadataObjectRoleOperations objectRoleOperations;
+  private final MetadataObjectPolicyOperations objectPolicyOperations;
 
   GenericTopic(TopicDTO topicDTO, RESTClient restClient, Namespace topicNs) {
     this.topicDTO = topicDTO;
@@ -49,6 +54,8 @@ class GenericTopic implements Topic, SupportsTags, SupportsRoles {
         new MetadataObjectTagOperations(topicNs.level(0), topicObject, restClient);
     this.objectRoleOperations =
         new MetadataObjectRoleOperations(topicNs.level(0), topicObject, restClient);
+    this.objectPolicyOperations =
+        new MetadataObjectPolicyOperations(topicNs.level(0), topicObject, restClient);
   }
 
   @Override
@@ -77,6 +84,11 @@ class GenericTopic implements Topic, SupportsTags, SupportsRoles {
   }
 
   @Override
+  public SupportsPolicies supportsPolicies() {
+    return this;
+  }
+
+  @Override
   public SupportsRoles supportsRoles() {
     return this;
   }
@@ -99,6 +111,27 @@ class GenericTopic implements Topic, SupportsTags, SupportsRoles {
   @Override
   public String[] associateTags(String[] tagsToAdd, String[] tagsToRemove) {
     return objectTagOperations.associateTags(tagsToAdd, tagsToRemove);
+  }
+
+  @Override
+  public String[] listPolicies() {
+    return objectPolicyOperations.listPolicies();
+  }
+
+  @Override
+  public Policy[] listPolicyInfos() {
+    return objectPolicyOperations.listPolicyInfos();
+  }
+
+  @Override
+  public Policy getPolicy(String name) throws NoSuchPolicyException {
+    return objectPolicyOperations.getPolicy(name);
+  }
+
+  @Override
+  public String[] associatePolicies(String[] policiesToAdd, String[] policiesToRemove)
+      throws PolicyAlreadyAssociatedException {
+    return objectPolicyOperations.associatePolicies(policiesToAdd, policiesToRemove);
   }
 
   @Override

--- a/clients/client-java/src/main/java/org/apache/gravitino/client/MetadataObjectPolicyOperations.java
+++ b/clients/client-java/src/main/java/org/apache/gravitino/client/MetadataObjectPolicyOperations.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.client;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Locale;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.gravitino.MetadataObject;
+import org.apache.gravitino.dto.requests.PoliciesAssociateRequest;
+import org.apache.gravitino.dto.responses.NameListResponse;
+import org.apache.gravitino.dto.responses.PolicyListResponse;
+import org.apache.gravitino.dto.responses.PolicyResponse;
+import org.apache.gravitino.exceptions.NoSuchPolicyException;
+import org.apache.gravitino.policy.Policy;
+import org.apache.gravitino.policy.SupportsPolicies;
+import org.apache.gravitino.rest.RESTUtils;
+
+/**
+ * The implementation of {@link SupportsPolicies}. This interface will be composited into catalog,
+ * schema, table, fileset and topic to provide policy operations for these metadata objects
+ */
+class MetadataObjectPolicyOperations implements SupportsPolicies {
+
+  private final String metalakeName;
+
+  private final RESTClient restClient;
+
+  private final String policyRequestPath;
+
+  MetadataObjectPolicyOperations(
+      String metalakeName, MetadataObject metadataObject, RESTClient restClient) {
+    this.metalakeName = metalakeName;
+    this.restClient = restClient;
+    this.policyRequestPath =
+        String.format(
+            "api/metalakes/%s/objects/%s/%s/policies",
+            RESTUtils.encodeString(metalakeName),
+            metadataObject.type().name().toLowerCase(Locale.ROOT),
+            RESTUtils.encodeString(metadataObject.fullName()));
+  }
+
+  @Override
+  public String[] listPolicies() {
+    NameListResponse resp =
+        restClient.get(
+            policyRequestPath,
+            NameListResponse.class,
+            Collections.emptyMap(),
+            ErrorHandlers.policyErrorHandler());
+
+    resp.validate();
+    return resp.getNames();
+  }
+
+  @Override
+  public Policy[] listPolicyInfos() {
+    PolicyListResponse resp =
+        restClient.get(
+            policyRequestPath,
+            ImmutableMap.of("details", "true"),
+            PolicyListResponse.class,
+            Collections.emptyMap(),
+            ErrorHandlers.policyErrorHandler());
+
+    resp.validate();
+    return Arrays.stream(resp.getPolicies())
+        .map(policyDTO -> new GenericPolicy(policyDTO, restClient, metalakeName))
+        .toArray(Policy[]::new);
+  }
+
+  @Override
+  public Policy getPolicy(String name) throws NoSuchPolicyException {
+    Preconditions.checkArgument(
+        StringUtils.isNotBlank(name), "Policy name must not be null or empty");
+
+    PolicyResponse resp =
+        restClient.get(
+            policyRequestPath + "/" + RESTUtils.encodeString(name),
+            PolicyResponse.class,
+            Collections.emptyMap(),
+            ErrorHandlers.policyErrorHandler());
+
+    resp.validate();
+    return new GenericPolicy(resp.getPolicy(), restClient, metalakeName);
+  }
+
+  @Override
+  public String[] associatePolicies(String[] policiesToAdd, String[] policiesToRemove) {
+    PoliciesAssociateRequest request =
+        new PoliciesAssociateRequest(policiesToAdd, policiesToRemove);
+    request.validate();
+
+    NameListResponse resp =
+        restClient.post(
+            policyRequestPath,
+            request,
+            NameListResponse.class,
+            Collections.emptyMap(),
+            ErrorHandlers.policyErrorHandler());
+
+    resp.validate();
+    return resp.getNames();
+  }
+}

--- a/clients/client-java/src/test/java/org/apache/gravitino/client/TestGravitinoMetalake.java
+++ b/clients/client-java/src/test/java/org/apache/gravitino/client/TestGravitinoMetalake.java
@@ -18,6 +18,8 @@
  */
 package org.apache.gravitino.client;
 
+import static org.apache.gravitino.dto.util.DTOConverters.fromDTO;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -791,10 +793,10 @@ public class TestGravitinoMetalake extends TestBase {
     Assertions.assertEquals(2, policyInfos.length);
     Assertions.assertEquals(policy1.name(), policyInfos[0].name());
     Assertions.assertEquals(policy1.comment(), policyInfos[0].comment());
-    Assertions.assertEquals(policy1.content(), policyInfos[0].content());
+    Assertions.assertEquals(fromDTO(policy1.content()), policyInfos[0].content());
     Assertions.assertEquals(policy2.name(), policyInfos[1].name());
     Assertions.assertEquals(policy2.comment(), policyInfos[1].comment());
-    Assertions.assertEquals(policy2.content(), policyInfos[1].content());
+    Assertions.assertEquals(fromDTO(policy2.content()), policyInfos[1].content());
 
     // Test empty policy list
     PolicyListResponse resp1 = new PolicyListResponse(new PolicyDTO[] {});
@@ -843,8 +845,8 @@ public class TestGravitinoMetalake extends TestBase {
 
     Policy policy = gravitinoClient.getPolicy(policyName);
     Assertions.assertEquals(policyName, policy.name());
-    Assertions.assertEquals(policy1.comment(), policy.comment());
-    Assertions.assertEquals(policy1.content(), policy.content());
+    Assertions.assertEquals((policy1.comment()), policy.comment());
+    Assertions.assertEquals(fromDTO(policy1.content()), policy.content());
 
     // Test throw NoSuchMetalakeException
     ErrorResponse errorResponse =

--- a/clients/client-java/src/test/java/org/apache/gravitino/client/TestSupportPolicies.java
+++ b/clients/client-java/src/test/java/org/apache/gravitino/client/TestSupportPolicies.java
@@ -1,0 +1,529 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.client;
+
+import static org.apache.gravitino.file.Fileset.LOCATION_NAME_UNKNOWN;
+import static org.apache.hc.core5.http.HttpStatus.SC_INTERNAL_SERVER_ERROR;
+import static org.apache.hc.core5.http.HttpStatus.SC_NOT_FOUND;
+import static org.apache.hc.core5.http.HttpStatus.SC_OK;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.google.common.collect.ImmutableMap;
+import java.util.Collections;
+import java.util.Locale;
+import java.util.Set;
+import org.apache.gravitino.Catalog;
+import org.apache.gravitino.MetadataObject;
+import org.apache.gravitino.MetadataObjects;
+import org.apache.gravitino.Namespace;
+import org.apache.gravitino.Schema;
+import org.apache.gravitino.dto.AuditDTO;
+import org.apache.gravitino.dto.SchemaDTO;
+import org.apache.gravitino.dto.file.FilesetDTO;
+import org.apache.gravitino.dto.messaging.TopicDTO;
+import org.apache.gravitino.dto.policy.PolicyContentDTO;
+import org.apache.gravitino.dto.policy.PolicyDTO;
+import org.apache.gravitino.dto.rel.ColumnDTO;
+import org.apache.gravitino.dto.rel.TableDTO;
+import org.apache.gravitino.dto.requests.PoliciesAssociateRequest;
+import org.apache.gravitino.dto.responses.ErrorResponse;
+import org.apache.gravitino.dto.responses.NameListResponse;
+import org.apache.gravitino.dto.responses.PolicyListResponse;
+import org.apache.gravitino.dto.responses.PolicyResponse;
+import org.apache.gravitino.exceptions.NoSuchPolicyException;
+import org.apache.gravitino.exceptions.NotFoundException;
+import org.apache.gravitino.file.Fileset;
+import org.apache.gravitino.messaging.Topic;
+import org.apache.gravitino.policy.Policy;
+import org.apache.gravitino.policy.SupportsPolicies;
+import org.apache.gravitino.rel.Table;
+import org.apache.gravitino.rel.types.Types;
+import org.apache.hc.core5.http.Method;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class TestSupportPolicies extends TestBase {
+
+  private static final String METALAKE_NAME = "metalake";
+
+  private static Catalog relationalCatalog;
+
+  private static Catalog filesetCatalog;
+
+  private static Catalog messagingCatalog;
+
+  private static Schema genericSchema;
+
+  private static Table relationalTable;
+
+  private static Fileset genericFileset;
+
+  private static Topic genericTopic;
+
+  private final Set<MetadataObject.Type> supportedObjectTypes =
+      Collections.singleton(MetadataObject.Type.FILESET);
+  private final PolicyContentDTO.CustomContentDTO contentDTO =
+      PolicyContentDTO.CustomContentDTO.builder()
+          .withSupportedObjectTypes(supportedObjectTypes)
+          .build();
+
+  @BeforeAll
+  public static void setUp() throws Exception {
+    TestBase.setUp();
+    TestGravitinoMetalake.createMetalake(client, METALAKE_NAME);
+
+    relationalCatalog =
+        new RelationalCatalog(
+            Namespace.of(METALAKE_NAME),
+            "catalog1",
+            Catalog.Type.RELATIONAL,
+            "test",
+            "comment",
+            Collections.emptyMap(),
+            AuditDTO.builder().build(),
+            client.restClient());
+
+    filesetCatalog =
+        new FilesetCatalog(
+            Namespace.of(METALAKE_NAME),
+            "catalog2",
+            Catalog.Type.FILESET,
+            "test",
+            "comment",
+            Collections.emptyMap(),
+            AuditDTO.builder().build(),
+            client.restClient());
+
+    messagingCatalog =
+        new MessagingCatalog(
+            Namespace.of(METALAKE_NAME),
+            "catalog3",
+            Catalog.Type.MESSAGING,
+            "test",
+            "comment",
+            Collections.emptyMap(),
+            AuditDTO.builder().build(),
+            client.restClient());
+
+    genericSchema =
+        new GenericSchema(
+            SchemaDTO.builder()
+                .withName("schema1")
+                .withComment("comment1")
+                .withProperties(Collections.emptyMap())
+                .withAudit(AuditDTO.builder().withCreator("test").build())
+                .build(),
+            client.restClient(),
+            METALAKE_NAME,
+            "catalog1");
+
+    relationalTable =
+        RelationalTable.from(
+            Namespace.of(METALAKE_NAME, "catalog1", "schema1"),
+            TableDTO.builder()
+                .withName("table1")
+                .withComment("comment1")
+                .withColumns(
+                    new ColumnDTO[] {
+                      ColumnDTO.builder()
+                          .withName("col1")
+                          .withDataType(Types.IntegerType.get())
+                          .build()
+                    })
+                .withProperties(Collections.emptyMap())
+                .withAudit(AuditDTO.builder().withCreator("test").build())
+                .build(),
+            client.restClient());
+
+    genericFileset =
+        new GenericFileset(
+            FilesetDTO.builder()
+                .name("fileset1")
+                .comment("comment1")
+                .type(Fileset.Type.EXTERNAL)
+                .storageLocations(ImmutableMap.of(LOCATION_NAME_UNKNOWN, "s3://bucket/path"))
+                .properties(Collections.emptyMap())
+                .audit(AuditDTO.builder().withCreator("test").build())
+                .build(),
+            client.restClient(),
+            Namespace.of(METALAKE_NAME, "catalog1", "schema1"));
+
+    genericTopic =
+        new GenericTopic(
+            TopicDTO.builder()
+                .withName("topic1")
+                .withComment("comment1")
+                .withProperties(Collections.emptyMap())
+                .withAudit(AuditDTO.builder().withCreator("test").build())
+                .build(),
+            client.restClient(),
+            Namespace.of(METALAKE_NAME, "catalog1", "schema1"));
+  }
+
+  @Test
+  public void testListPoliciesForCatalog() throws JsonProcessingException {
+    testListPolicies(
+        relationalCatalog.supportsPolicies(),
+        MetadataObjects.of(null, relationalCatalog.name(), MetadataObject.Type.CATALOG));
+
+    testListPolicies(
+        filesetCatalog.supportsPolicies(),
+        MetadataObjects.of(null, filesetCatalog.name(), MetadataObject.Type.CATALOG));
+
+    testListPolicies(
+        messagingCatalog.supportsPolicies(),
+        MetadataObjects.of(null, messagingCatalog.name(), MetadataObject.Type.CATALOG));
+  }
+
+  @Test
+  public void testListPoliciesForSchema() throws JsonProcessingException {
+    testListPolicies(
+        genericSchema.supportsPolicies(),
+        MetadataObjects.of("catalog1", genericSchema.name(), MetadataObject.Type.SCHEMA));
+  }
+
+  @Test
+  public void testListPoliciesForTable() throws JsonProcessingException {
+    testListPolicies(
+        relationalTable.supportsPolicies(),
+        MetadataObjects.of("catalog1.schema1", relationalTable.name(), MetadataObject.Type.TABLE));
+  }
+
+  @Test
+  public void testListPoliciesForFileset() throws JsonProcessingException {
+    testListPolicies(
+        genericFileset.supportsPolicies(),
+        MetadataObjects.of("catalog1.schema1", genericFileset.name(), MetadataObject.Type.FILESET));
+  }
+
+  @Test
+  public void testListPoliciesForTopic() throws JsonProcessingException {
+    testListPolicies(
+        genericTopic.supportsPolicies(),
+        MetadataObjects.of("catalog1.schema1", genericTopic.name(), MetadataObject.Type.TOPIC));
+  }
+
+  @Test
+  public void testListPoliciesInfoForCatalog() throws JsonProcessingException {
+    testListPoliciesInfo(
+        relationalCatalog.supportsPolicies(),
+        MetadataObjects.of(null, relationalCatalog.name(), MetadataObject.Type.CATALOG));
+
+    testListPoliciesInfo(
+        filesetCatalog.supportsPolicies(),
+        MetadataObjects.of(null, filesetCatalog.name(), MetadataObject.Type.CATALOG));
+
+    testListPoliciesInfo(
+        messagingCatalog.supportsPolicies(),
+        MetadataObjects.of(null, messagingCatalog.name(), MetadataObject.Type.CATALOG));
+  }
+
+  @Test
+  public void testListPoliciesInfoForSchema() throws JsonProcessingException {
+    testListPoliciesInfo(
+        genericSchema.supportsPolicies(),
+        MetadataObjects.of("catalog1", genericSchema.name(), MetadataObject.Type.SCHEMA));
+  }
+
+  @Test
+  public void testListPoliciesInfoForTable() throws JsonProcessingException {
+    testListPoliciesInfo(
+        relationalTable.supportsPolicies(),
+        MetadataObjects.of("catalog1.schema1", relationalTable.name(), MetadataObject.Type.TABLE));
+  }
+
+  @Test
+  public void testListPoliciesInfoForFileset() throws JsonProcessingException {
+    testListPoliciesInfo(
+        genericFileset.supportsPolicies(),
+        MetadataObjects.of("catalog1.schema1", genericFileset.name(), MetadataObject.Type.FILESET));
+  }
+
+  @Test
+  public void testListPoliciesInfoForTopic() throws JsonProcessingException {
+    testListPoliciesInfo(
+        genericTopic.supportsPolicies(),
+        MetadataObjects.of("catalog1.schema1", genericTopic.name(), MetadataObject.Type.TOPIC));
+  }
+
+  @Test
+  public void testGetPolicyForCatalog() throws JsonProcessingException {
+    testGetPolicy(
+        relationalCatalog.supportsPolicies(),
+        MetadataObjects.of(null, relationalCatalog.name(), MetadataObject.Type.CATALOG));
+
+    testGetPolicy(
+        filesetCatalog.supportsPolicies(),
+        MetadataObjects.of(null, filesetCatalog.name(), MetadataObject.Type.CATALOG));
+
+    testGetPolicy(
+        messagingCatalog.supportsPolicies(),
+        MetadataObjects.of(null, messagingCatalog.name(), MetadataObject.Type.CATALOG));
+  }
+
+  @Test
+  public void testGetPolicyForSchema() throws JsonProcessingException {
+    testGetPolicy(
+        genericSchema.supportsPolicies(),
+        MetadataObjects.of("catalog1", genericSchema.name(), MetadataObject.Type.SCHEMA));
+  }
+
+  @Test
+  public void testGetPolicyForTable() throws JsonProcessingException {
+    testGetPolicy(
+        relationalTable.supportsPolicies(),
+        MetadataObjects.of("catalog1.schema1", relationalTable.name(), MetadataObject.Type.TABLE));
+  }
+
+  @Test
+  public void testGetPolicyForFileset() throws JsonProcessingException {
+    testGetPolicy(
+        genericFileset.supportsPolicies(),
+        MetadataObjects.of("catalog1.schema1", genericFileset.name(), MetadataObject.Type.FILESET));
+  }
+
+  @Test
+  public void testGetPolicyForTopic() throws JsonProcessingException {
+    testGetPolicy(
+        genericTopic.supportsPolicies(),
+        MetadataObjects.of("catalog1.schema1", genericTopic.name(), MetadataObject.Type.TOPIC));
+  }
+
+  @Test
+  public void testAssociatePoliciesForCatalog() throws JsonProcessingException {
+    testAssociatePolicies(
+        relationalCatalog.supportsPolicies(),
+        MetadataObjects.of(null, relationalCatalog.name(), MetadataObject.Type.CATALOG));
+
+    testAssociatePolicies(
+        filesetCatalog.supportsPolicies(),
+        MetadataObjects.of(null, filesetCatalog.name(), MetadataObject.Type.CATALOG));
+
+    testAssociatePolicies(
+        messagingCatalog.supportsPolicies(),
+        MetadataObjects.of(null, messagingCatalog.name(), MetadataObject.Type.CATALOG));
+  }
+
+  @Test
+  public void testAssociatePoliciesForSchema() throws JsonProcessingException {
+    testAssociatePolicies(
+        genericSchema.supportsPolicies(),
+        MetadataObjects.of("catalog1", genericSchema.name(), MetadataObject.Type.SCHEMA));
+  }
+
+  @Test
+  public void testAssociatePoliciesForTable() throws JsonProcessingException {
+    testAssociatePolicies(
+        relationalTable.supportsPolicies(),
+        MetadataObjects.of("catalog1.schema1", relationalTable.name(), MetadataObject.Type.TABLE));
+  }
+
+  @Test
+  public void testAssociatePoliciesForFileset() throws JsonProcessingException {
+    testAssociatePolicies(
+        genericFileset.supportsPolicies(),
+        MetadataObjects.of("catalog1.schema1", genericFileset.name(), MetadataObject.Type.FILESET));
+  }
+
+  @Test
+  public void testAssociatePoliciesForTopic() throws JsonProcessingException {
+    testAssociatePolicies(
+        genericTopic.supportsPolicies(),
+        MetadataObjects.of("catalog1.schema1", genericTopic.name(), MetadataObject.Type.TOPIC));
+  }
+
+  private void testListPolicies(SupportsPolicies supportsPolicies, MetadataObject metadataObject)
+      throws JsonProcessingException {
+    String path =
+        "/api/metalakes/"
+            + METALAKE_NAME
+            + "/objects/"
+            + metadataObject.type().name().toLowerCase(Locale.ROOT)
+            + "/"
+            + metadataObject.fullName()
+            + "/policies";
+
+    String[] policies = new String[] {"policy1", "policy2"};
+    NameListResponse resp = new NameListResponse(policies);
+    buildMockResource(Method.GET, path, null, resp, SC_OK);
+
+    String[] actualPolicies = supportsPolicies.listPolicies();
+    Assertions.assertArrayEquals(policies, actualPolicies);
+
+    // Return empty list
+    NameListResponse resp1 = new NameListResponse(new String[0]);
+    buildMockResource(Method.GET, path, null, resp1, SC_OK);
+
+    String[] actualPolicies1 = supportsPolicies.listPolicies();
+    Assertions.assertArrayEquals(new String[0], actualPolicies1);
+
+    // Test throw NotFoundException
+    ErrorResponse errorResp =
+        ErrorResponse.notFound(NotFoundException.class.getSimpleName(), "mock error");
+    buildMockResource(Method.GET, path, null, errorResp, SC_NOT_FOUND);
+
+    Throwable ex = Assertions.assertThrows(NotFoundException.class, supportsPolicies::listPolicies);
+    Assertions.assertTrue(ex.getMessage().contains("mock error"));
+
+    // Test throw internal error
+    ErrorResponse errorResp1 = ErrorResponse.internalError("mock error");
+    buildMockResource(Method.GET, path, null, errorResp1, SC_INTERNAL_SERVER_ERROR);
+
+    Throwable ex1 = Assertions.assertThrows(RuntimeException.class, supportsPolicies::listPolicies);
+    Assertions.assertTrue(ex1.getMessage().contains("mock error"));
+  }
+
+  private void testListPoliciesInfo(
+      SupportsPolicies supportsPolicies, MetadataObject metadataObject)
+      throws JsonProcessingException {
+    String path =
+        "/api/metalakes/"
+            + METALAKE_NAME
+            + "/objects/"
+            + metadataObject.type().name().toLowerCase(Locale.ROOT)
+            + "/"
+            + metadataObject.fullName()
+            + "/policies";
+
+    PolicyDTO policy1 =
+        PolicyDTO.builder()
+            .withName("policy1")
+            .withPolicyType("custom")
+            .withContent(contentDTO)
+            .withAudit(AuditDTO.builder().withCreator("test").build())
+            .build();
+    PolicyDTO policy2 =
+        PolicyDTO.builder()
+            .withName("policy2")
+            .withPolicyType("custom")
+            .withContent(contentDTO)
+            .withAudit(AuditDTO.builder().withCreator("test").build())
+            .build();
+    PolicyDTO[] policies = new PolicyDTO[] {policy1, policy2};
+    PolicyListResponse resp = new PolicyListResponse(policies);
+    buildMockResource(Method.GET, path, null, resp, SC_OK);
+
+    Policy[] actualPolicies = supportsPolicies.listPolicyInfos();
+    Assertions.assertEquals(2, actualPolicies.length);
+    Assertions.assertEquals("policy1", actualPolicies[0].name());
+    Assertions.assertEquals("policy2", actualPolicies[1].name());
+
+    // Return empty list
+    PolicyListResponse resp1 = new PolicyListResponse(new PolicyDTO[0]);
+    buildMockResource(Method.GET, path, null, resp1, SC_OK);
+
+    Policy[] actualPolicies1 = supportsPolicies.listPolicyInfos();
+    Assertions.assertArrayEquals(new Policy[0], actualPolicies1);
+
+    // Test throw NotFoundException
+    ErrorResponse errorResp =
+        ErrorResponse.notFound(NotFoundException.class.getSimpleName(), "mock error");
+    buildMockResource(Method.GET, path, null, errorResp, SC_NOT_FOUND);
+
+    Throwable ex = Assertions.assertThrows(NotFoundException.class, supportsPolicies::listPolicies);
+    Assertions.assertTrue(ex.getMessage().contains("mock error"));
+
+    // Test throw internal error
+    ErrorResponse errorResp1 = ErrorResponse.internalError("mock error");
+    buildMockResource(Method.GET, path, null, errorResp1, SC_INTERNAL_SERVER_ERROR);
+
+    Throwable ex1 = Assertions.assertThrows(RuntimeException.class, supportsPolicies::listPolicies);
+    Assertions.assertTrue(ex1.getMessage().contains("mock error"));
+  }
+
+  private void testGetPolicy(SupportsPolicies supportsPolicies, MetadataObject metadataObject)
+      throws JsonProcessingException {
+    String path =
+        "/api/metalakes/"
+            + METALAKE_NAME
+            + "/objects/"
+            + metadataObject.type().name().toLowerCase(Locale.ROOT)
+            + "/"
+            + metadataObject.fullName()
+            + "/policies/policy1";
+
+    PolicyDTO policy1 =
+        PolicyDTO.builder()
+            .withName("policy1")
+            .withPolicyType("test")
+            .withContent(contentDTO)
+            .withAudit(AuditDTO.builder().withCreator("test").build())
+            .build();
+
+    PolicyResponse resp = new PolicyResponse(policy1);
+    buildMockResource(Method.GET, path, null, resp, SC_OK);
+
+    Policy actualPolicy = supportsPolicies.getPolicy("policy1");
+    Assertions.assertEquals("policy1", actualPolicy.name());
+
+    // Test throw NoSuchPolicyException
+    ErrorResponse errorResp =
+        ErrorResponse.notFound(NoSuchPolicyException.class.getSimpleName(), "mock error");
+    buildMockResource(Method.GET, path, null, errorResp, SC_NOT_FOUND);
+
+    Throwable ex =
+        Assertions.assertThrows(
+            NoSuchPolicyException.class, () -> supportsPolicies.getPolicy("policy1"));
+    Assertions.assertTrue(ex.getMessage().contains("mock error"));
+
+    // Test throw internal error
+    ErrorResponse errorResp1 = ErrorResponse.internalError("mock error");
+    buildMockResource(Method.GET, path, null, errorResp1, SC_INTERNAL_SERVER_ERROR);
+
+    Throwable ex1 =
+        Assertions.assertThrows(
+            RuntimeException.class, () -> supportsPolicies.getPolicy("policy1"));
+    Assertions.assertTrue(ex1.getMessage().contains("mock error"));
+  }
+
+  private void testAssociatePolicies(
+      SupportsPolicies supportsPolicies, MetadataObject metadataObject)
+      throws JsonProcessingException {
+    String path =
+        "/api/metalakes/"
+            + METALAKE_NAME
+            + "/objects/"
+            + metadataObject.type().name().toLowerCase(Locale.ROOT)
+            + "/"
+            + metadataObject.fullName()
+            + "/policies";
+
+    String[] policiesToAdd = new String[] {"policy1", "policy2"};
+    String[] policiesToRemove = new String[] {"policy3", "policy4"};
+    PoliciesAssociateRequest request =
+        new PoliciesAssociateRequest(policiesToAdd, policiesToRemove);
+
+    NameListResponse resp = new NameListResponse(policiesToAdd);
+    buildMockResource(Method.POST, path, request, resp, SC_OK);
+
+    String[] actualPolicies = supportsPolicies.associatePolicies(policiesToAdd, policiesToRemove);
+    Assertions.assertArrayEquals(policiesToAdd, actualPolicies);
+
+    // Test throw internal error
+    ErrorResponse errorResp1 = ErrorResponse.internalError("mock error");
+    buildMockResource(Method.POST, path, request, errorResp1, SC_INTERNAL_SERVER_ERROR);
+
+    Throwable ex1 =
+        Assertions.assertThrows(
+            RuntimeException.class,
+            () -> supportsPolicies.associatePolicies(policiesToAdd, policiesToRemove));
+    Assertions.assertTrue(ex1.getMessage().contains("mock error"));
+  }
+}

--- a/clients/client-java/src/test/java/org/apache/gravitino/client/integration/test/PolicyIT.java
+++ b/clients/client-java/src/test/java/org/apache/gravitino/client/integration/test/PolicyIT.java
@@ -1,0 +1,772 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.client.integration.test;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.gravitino.Catalog;
+import org.apache.gravitino.MetadataObject;
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.Schema;
+import org.apache.gravitino.client.GravitinoMetalake;
+import org.apache.gravitino.dto.tag.MetadataObjectDTO;
+import org.apache.gravitino.exceptions.NoSuchPolicyException;
+import org.apache.gravitino.exceptions.PolicyAlreadyAssociatedException;
+import org.apache.gravitino.exceptions.PolicyAlreadyExistsException;
+import org.apache.gravitino.integration.test.container.ContainerSuite;
+import org.apache.gravitino.integration.test.container.HiveContainer;
+import org.apache.gravitino.integration.test.util.BaseIT;
+import org.apache.gravitino.integration.test.util.GravitinoITUtils;
+import org.apache.gravitino.model.Model;
+import org.apache.gravitino.policy.Policy;
+import org.apache.gravitino.policy.PolicyChange;
+import org.apache.gravitino.policy.PolicyContent;
+import org.apache.gravitino.policy.PolicyContents;
+import org.apache.gravitino.rel.Column;
+import org.apache.gravitino.rel.Table;
+import org.apache.gravitino.rel.types.Types;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("gravitino-docker-test")
+public class PolicyIT extends BaseIT {
+
+  private static final ContainerSuite containerSuite = ContainerSuite.getInstance();
+
+  private static final String metalakeName = GravitinoITUtils.genRandomName("policy_it_metalake");
+
+  private static GravitinoMetalake metalake;
+  private static Catalog relationalCatalog;
+  private static Schema schema;
+  private static Table table;
+
+  private static Catalog modelCatalog;
+  private static Schema modelSchema;
+  private static Model model;
+
+  @BeforeAll
+  public void setUp() {
+    containerSuite.startHiveContainer();
+    String hmsUri =
+        String.format(
+            "thrift://%s:%d",
+            containerSuite.getHiveContainer().getContainerIpAddress(),
+            HiveContainer.HIVE_METASTORE_PORT);
+
+    // Create metalake
+    Assertions.assertFalse(client.metalakeExists(metalakeName));
+    metalake = client.createMetalake(metalakeName, "metalake", Collections.emptyMap());
+
+    // Create catalog
+    String catalogName = GravitinoITUtils.genRandomName("policy_it_catalog");
+    Assertions.assertFalse(metalake.catalogExists(catalogName));
+    relationalCatalog =
+        metalake.createCatalog(
+            catalogName,
+            Catalog.Type.RELATIONAL,
+            "hive",
+            "comment",
+            ImmutableMap.of("metastore.uris", hmsUri));
+
+    // Create schema
+    String schemaName = GravitinoITUtils.genRandomName("policy_it_schema");
+    Assertions.assertFalse(relationalCatalog.asSchemas().schemaExists(schemaName));
+    schema =
+        relationalCatalog.asSchemas().createSchema(schemaName, "comment", Collections.emptyMap());
+
+    // Create table
+    String tableName = GravitinoITUtils.genRandomName("policy_it_table");
+    Assertions.assertFalse(
+        relationalCatalog.asTableCatalog().tableExists(NameIdentifier.of(schemaName, tableName)));
+    table =
+        relationalCatalog
+            .asTableCatalog()
+            .createTable(
+                NameIdentifier.of(schemaName, tableName),
+                new Column[] {
+                  Column.of("col1", Types.IntegerType.get()),
+                  Column.of("col2", Types.StringType.get())
+                },
+                "comment",
+                Collections.emptyMap());
+
+    // Create model catalog
+    String modelCatalogName = GravitinoITUtils.genRandomName("policy_it_model_catalog");
+    Assertions.assertFalse(metalake.catalogExists(modelCatalogName));
+    modelCatalog =
+        metalake.createCatalog(
+            modelCatalogName, Catalog.Type.MODEL, "comment", Collections.emptyMap());
+
+    // Create model schema
+    String modelSchemaName = GravitinoITUtils.genRandomName("policy_it_model_schema");
+    Assertions.assertFalse(modelCatalog.asSchemas().schemaExists(modelSchemaName));
+    modelSchema =
+        modelCatalog.asSchemas().createSchema(modelSchemaName, "comment", Collections.emptyMap());
+
+    // Create model
+    String modelName = GravitinoITUtils.genRandomName("policy_it_model");
+    Assertions.assertFalse(
+        modelCatalog.asModelCatalog().modelExists(NameIdentifier.of(modelSchemaName, modelName)));
+    model =
+        modelCatalog
+            .asModelCatalog()
+            .registerModel(
+                NameIdentifier.of(modelSchemaName, modelName), "comment", Collections.emptyMap());
+  }
+
+  @AfterAll
+  public void tearDown() {
+    relationalCatalog.asTableCatalog().dropTable(NameIdentifier.of(schema.name(), table.name()));
+    relationalCatalog.asSchemas().dropSchema(schema.name(), true);
+    metalake.dropCatalog(relationalCatalog.name(), true);
+
+    modelCatalog.asModelCatalog().deleteModel(NameIdentifier.of(modelSchema.name(), model.name()));
+    modelCatalog.asSchemas().dropSchema(modelSchema.name(), true);
+    metalake.dropCatalog(modelCatalog.name(), true);
+
+    client.dropMetalake(metalakeName, true);
+
+    if (client != null) {
+      client.close();
+      client = null;
+    }
+
+    try {
+      closer.close();
+    } catch (Exception e) {
+      // Swallow exceptions
+    }
+  }
+
+  @AfterEach
+  public void cleanUp() {
+    String[] tablePolicies = table.supportsPolicies().listPolicies();
+    table.supportsPolicies().associatePolicies(null, tablePolicies);
+
+    String[] schemaPolicies = schema.supportsPolicies().listPolicies();
+    schema.supportsPolicies().associatePolicies(null, schemaPolicies);
+
+    String[] catalogPolicies = relationalCatalog.supportsPolicies().listPolicies();
+    relationalCatalog.supportsPolicies().associatePolicies(null, catalogPolicies);
+
+    String[] policies = metalake.listPolicies();
+    for (String policy : policies) {
+      metalake.deletePolicy(policy);
+    }
+  }
+
+  @Test
+  public void testCreateGetAndListPolicy() {
+    String policyName = GravitinoITUtils.genRandomName("policy_it_policy");
+    Assertions.assertThrows(NoSuchPolicyException.class, () -> metalake.getPolicy(policyName));
+
+    // Test create
+    PolicyContent content =
+        PolicyContents.custom(
+            ImmutableMap.of("rule1", "value1"), ImmutableSet.of(MetadataObject.Type.TABLE), null);
+    Policy policy = metalake.createPolicy(policyName, "custom", "comment", true, content);
+    Assertions.assertEquals(policyName, policy.name());
+    Assertions.assertEquals("comment", policy.comment());
+    Assertions.assertEquals("custom", policy.policyType());
+    Assertions.assertTrue(policy.enabled());
+    Assertions.assertFalse(policy.inherited().isPresent());
+    Assertions.assertEquals(content, policy.content());
+
+    // Test already existed policy
+    Assertions.assertThrows(
+        PolicyAlreadyExistsException.class,
+        () -> metalake.createPolicy(policyName, "custom", "comment", true, content));
+
+    // Test get
+    Policy fetchedPolicy = metalake.getPolicy(policyName);
+    Assertions.assertEquals(policy, fetchedPolicy);
+    Assertions.assertEquals(policyName, fetchedPolicy.name());
+    Assertions.assertEquals("comment", fetchedPolicy.comment());
+    Assertions.assertEquals("custom", fetchedPolicy.policyType());
+    Assertions.assertTrue(fetchedPolicy.enabled());
+    Assertions.assertFalse(fetchedPolicy.inherited().isPresent());
+    Assertions.assertEquals(content, fetchedPolicy.content());
+
+    // test List names
+    String policyName1 = GravitinoITUtils.genRandomName("policy_it_policy1");
+    Policy policy1 = metalake.createPolicy(policyName1, "custom", null, false, content);
+    Assertions.assertEquals(policyName1, policy1.name());
+
+    String[] policyNames = metalake.listPolicies();
+    Assertions.assertEquals(2, policyNames.length);
+    Set<String> policyNamesSet = Sets.newHashSet(policyName, policyName1);
+    Set<String> resultPolicyNamesSet = Sets.newHashSet(policyNames);
+    Assertions.assertEquals(policyNamesSet, resultPolicyNamesSet);
+
+    // test List policies
+    Set<Policy> policies = Sets.newHashSet(metalake.listPolicyInfos());
+    Set<Policy> expectedPolicies = Sets.newHashSet(policy, policy1);
+    Assertions.assertEquals(expectedPolicies, policies);
+
+    // Test null comment
+    String policyName2 = GravitinoITUtils.genRandomName("policy_it_policy2");
+    Policy policy2 = metalake.createPolicy(policyName2, "custom", null, true, content);
+
+    Assertions.assertEquals(policyName2, policy2.name());
+    Assertions.assertNull(policy2.comment());
+
+    Policy LoadedPolicy2 = metalake.getPolicy(policyName2);
+    Assertions.assertEquals(policy2, LoadedPolicy2);
+
+    // Test null content
+    String policyName3 = GravitinoITUtils.genRandomName("policy_it_policy3");
+    Exception e =
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () -> metalake.createPolicy(policyName3, "custom", null, true, null));
+    Assertions.assertEquals("\"content\" is required and cannot be null", e.getMessage());
+
+    // Test null supported types in content
+    e =
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                metalake.createPolicy(
+                    policyName3, "custom", null, true, PolicyContents.custom(null, null, null)));
+    Assertions.assertEquals("supportedObjectTypes cannot be empty", e.getMessage());
+
+    // Test enable false
+    String policyName4 = GravitinoITUtils.genRandomName("policy_it_policy4");
+    Policy policy4 = metalake.createPolicy(policyName4, "custom", null, false, content);
+    Assertions.assertEquals(policyName4, policy4.name());
+    Assertions.assertFalse(policy4.enabled());
+    Assertions.assertFalse(policy4.inherited().isPresent());
+
+    Policy loadedPolicy4 = metalake.getPolicy(policyName4);
+    Assertions.assertEquals(policy4, loadedPolicy4);
+    Assertions.assertFalse(loadedPolicy4.enabled());
+
+    // Test illegal policy type
+    String policyName6 = GravitinoITUtils.genRandomName("policy_it_policy6");
+    e =
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () -> metalake.createPolicy(policyName6, "illegal_type", null, true, content));
+    Assertions.assertTrue(e.getMessage().contains("Unknown policy type"));
+  }
+
+  @Test
+  public void testCreateAndAlterPolicy() {
+    PolicyContent content =
+        PolicyContents.custom(
+            ImmutableMap.of("rule1", "value1"), ImmutableSet.of(MetadataObject.Type.TABLE), null);
+    String policyName = GravitinoITUtils.genRandomName("policy_it_policy");
+    metalake.createPolicy(policyName, "custom", "comment", true, content);
+
+    Policy[] policies = metalake.listPolicyInfos();
+    Assertions.assertEquals(1, policies.length);
+    Assertions.assertEquals(policyName, policies[0].name());
+    Assertions.assertEquals("comment", policies[0].comment());
+    Assertions.assertEquals("custom", policies[0].policyType());
+
+    // Test rename and update comment
+    String newPolicyName = GravitinoITUtils.genRandomName("policy_it_policy_new");
+    PolicyChange rename = PolicyChange.rename(newPolicyName);
+    PolicyChange updateComment = PolicyChange.updateComment("new comment");
+
+    Policy alteredPolicy = metalake.alterPolicy(policyName, rename, updateComment);
+    Assertions.assertEquals(newPolicyName, alteredPolicy.name());
+    Assertions.assertEquals("new comment", alteredPolicy.comment());
+    Assertions.assertFalse(alteredPolicy.inherited().isPresent());
+
+    // Test update content
+    PolicyContent newContent =
+        PolicyContents.custom(
+            ImmutableMap.of("rule2", "value2"),
+            ImmutableSet.of(MetadataObject.Type.TABLE),
+            ImmutableMap.of("key1", "value1"));
+    PolicyChange updateContent = PolicyChange.updateContent("custom", newContent);
+
+    Policy alteredPolicy2 = metalake.alterPolicy(newPolicyName, updateContent);
+    Assertions.assertEquals(newPolicyName, alteredPolicy2.name());
+    Assertions.assertEquals("new comment", alteredPolicy2.comment());
+    Assertions.assertFalse(alteredPolicy2.inherited().isPresent());
+    Assertions.assertEquals(newContent, alteredPolicy2.content());
+
+    // Test list after alter
+    policies = metalake.listPolicyInfos();
+    Assertions.assertEquals(1, policies.length);
+    Assertions.assertEquals(newPolicyName, policies[0].name());
+    Assertions.assertEquals("new comment", policies[0].comment());
+    Assertions.assertEquals(newContent, policies[0].content());
+    Assertions.assertFalse(policies[0].inherited().isPresent());
+
+    // Test update content with wrong type
+    PolicyChange updateContentWrongType = PolicyChange.updateContent("wrong_type", newContent);
+
+    Exception e =
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () -> metalake.alterPolicy(newPolicyName, updateContentWrongType));
+    Assertions.assertTrue(e.getMessage().contains("Unknown policy type"));
+
+    // Test throw NoSuchPolicyException
+    Assertions.assertThrows(
+        NoSuchPolicyException.class, () -> metalake.alterPolicy("non-existed-policy", rename));
+
+    // Test alter policy on no comment
+    String policyName1 = GravitinoITUtils.genRandomName("policy_it_policy1");
+    metalake.createPolicy(policyName1, "custom", null, true, content);
+
+    String newPolicyName1 = GravitinoITUtils.genRandomName("policy_it_policy_new1");
+    PolicyChange rename1 = PolicyChange.rename(newPolicyName1);
+    PolicyChange updateComment1 = PolicyChange.updateComment("new comment1");
+    PolicyChange updateContent1 = PolicyChange.updateContent("custom", newContent);
+
+    Policy alteredPolicy5 =
+        metalake.alterPolicy(policyName1, rename1, updateComment1, updateContent1);
+    Assertions.assertEquals(newPolicyName1, alteredPolicy5.name());
+    Assertions.assertEquals("new comment1", alteredPolicy5.comment());
+    Assertions.assertEquals(newContent, alteredPolicy5.content());
+    Assertions.assertFalse(alteredPolicy5.inherited().isPresent());
+
+    // Test alter supported types in content
+    PolicyContent newContent2 =
+        PolicyContents.custom(
+            ImmutableMap.of("rule3", "value3"),
+            ImmutableSet.of(MetadataObject.Type.TABLE, MetadataObject.Type.MODEL),
+            null);
+    PolicyChange updateContent2 = PolicyChange.updateContent("custom", newContent2);
+    Policy alteredPolicy6 = metalake.alterPolicy(newPolicyName1, updateContent2);
+
+    Assertions.assertEquals(newPolicyName1, alteredPolicy6.name());
+    Assertions.assertEquals(newContent2, alteredPolicy6.content());
+
+    alteredPolicy6 = metalake.getPolicy(newPolicyName1);
+    Assertions.assertEquals(newPolicyName1, alteredPolicy6.name());
+    Assertions.assertEquals(newContent2, alteredPolicy6.content());
+
+    // Test disable and enable
+    Assertions.assertDoesNotThrow(() -> metalake.disablePolicy(newPolicyName));
+    Policy policy = metalake.getPolicy(newPolicyName);
+    Assertions.assertFalse(policy.enabled());
+
+    Assertions.assertDoesNotThrow(() -> metalake.enablePolicy(newPolicyName));
+    policy = metalake.getPolicy(policy.name());
+    Assertions.assertTrue(policy.enabled());
+  }
+
+  @Test
+  public void testCreateAndDeletePolicy() {
+    PolicyContent content =
+        PolicyContents.custom(
+            ImmutableMap.of("rule1", "value1"), ImmutableSet.of(MetadataObject.Type.TABLE), null);
+    String policyName = GravitinoITUtils.genRandomName("policy_it_policy");
+    metalake.createPolicy(policyName, "custom", null, true, content);
+
+    // Test delete
+    Assertions.assertTrue(metalake.deletePolicy(policyName));
+    Assertions.assertFalse(metalake.deletePolicy(policyName));
+  }
+
+  @Test
+  public void testAssociatePoliciesToCatalog() {
+    Policy policy1 =
+        createCustomPolicy(GravitinoITUtils.genRandomName("policy_it_catalog_policy1"));
+    Policy policy2 =
+        createCustomPolicy(GravitinoITUtils.genRandomName("policy_it_catalog_policy2"));
+
+    // Test associate policies to catalog
+    String[] policies =
+        relationalCatalog
+            .supportsPolicies()
+            .associatePolicies(new String[] {policy1.name(), policy2.name()}, null);
+
+    Assertions.assertEquals(2, policies.length);
+    Set<String> policyNames = Sets.newHashSet(policies);
+    Assertions.assertTrue(policyNames.contains(policy1.name()));
+    Assertions.assertTrue(policyNames.contains(policy2.name()));
+
+    // Test disassociate policies from catalog
+    String[] policies1 =
+        relationalCatalog
+            .supportsPolicies()
+            .associatePolicies(null, new String[] {policy1.name(), policy2.name()});
+    Assertions.assertEquals(0, policies1.length);
+
+    // Test associate non-existed policies to catalog
+    String[] policies2 =
+        relationalCatalog
+            .supportsPolicies()
+            .associatePolicies(new String[] {"non-existed-policy"}, null);
+    Assertions.assertEquals(0, policies2.length);
+
+    // Test disassociate non-existed policies from catalog
+    String[] policies3 =
+        relationalCatalog
+            .supportsPolicies()
+            .associatePolicies(null, new String[] {"non-existed-policy"});
+    Assertions.assertEquals(0, policies3.length);
+
+    // Test associate same policies to catalog
+    String[] policies4 =
+        relationalCatalog
+            .supportsPolicies()
+            .associatePolicies(new String[] {policy1.name(), policy1.name()}, null);
+    Assertions.assertEquals(1, policies4.length);
+    Assertions.assertEquals(policy1.name(), policies4[0]);
+
+    // Test associate same policy again to catalog
+    Assertions.assertThrows(
+        PolicyAlreadyAssociatedException.class,
+        () ->
+            relationalCatalog
+                .supportsPolicies()
+                .associatePolicies(new String[] {policy1.name()}, null));
+
+    // Test associate and disassociate same policies to catalog
+    String[] policies5 =
+        relationalCatalog
+            .supportsPolicies()
+            .associatePolicies(new String[] {policy2.name()}, new String[] {policy2.name()});
+    Assertions.assertEquals(1, policies5.length);
+    Assertions.assertEquals(policy1.name(), policies5[0]);
+
+    // Test List associated policies for catalog
+    String[] policies6 = relationalCatalog.supportsPolicies().listPolicies();
+    Assertions.assertEquals(1, policies6.length);
+    Assertions.assertEquals(policy1.name(), policies6[0]);
+
+    // Test List associated policies with details for catalog
+    Policy[] policies7 = relationalCatalog.supportsPolicies().listPolicyInfos();
+    Assertions.assertEquals(1, policies7.length);
+    Assertions.assertEquals(policy1, policies7[0]);
+    Assertions.assertFalse(policies7[0].inherited().get());
+    Assertions.assertTrue(policies7[0].enabled());
+
+    // Test disable the policy then list again
+    // todo: uncomment after the bug is fixed
+    // https://github.com/apache/gravitino/issues/7787#issue-3255540700
+    //    Assertions.assertDoesNotThrow(() -> metalake.disablePolicy(policy1.name()));
+    //    Policy[] policies8 = relationalCatalog.supportsPolicies().listPolicyInfos();
+    //    Assertions.assertEquals(1, policies8.length);
+    //    Assertions.assertEquals(policy1.name(), policies8[0].name());
+    //    Assertions.assertFalse(policies8[0].enabled());
+
+    // Test get associated policy for catalog
+    Policy policy = relationalCatalog.supportsPolicies().getPolicy(policy1.name());
+    Assertions.assertEquals(policy1, policy);
+    Assertions.assertFalse(policy.inherited().get());
+
+    // Test get non-existed policy for catalog
+    Assertions.assertThrows(
+        NoSuchPolicyException.class,
+        () -> relationalCatalog.supportsPolicies().getPolicy("non-existed-policy"));
+
+    // Test get objects associated with policy
+    Assertions.assertEquals(1, policy.associatedObjects().count());
+    MetadataObject catalogObject = policy.associatedObjects().objects()[0];
+    Assertions.assertEquals(relationalCatalog.name(), catalogObject.name());
+    Assertions.assertEquals(MetadataObject.Type.CATALOG, catalogObject.type());
+  }
+
+  @Test
+  public void testAssociatePoliciesToSchema() {
+    Policy policy1 = createCustomPolicy(GravitinoITUtils.genRandomName("policy_it_schema_policy1"));
+    Policy policy2 = createCustomPolicy(GravitinoITUtils.genRandomName("policy_it_schema_policy2"));
+
+    // Associate policies to catalog
+    relationalCatalog.supportsPolicies().associatePolicies(new String[] {policy1.name()}, null);
+
+    // Test list associated policies for schema
+    String[] policies1 = schema.supportsPolicies().listPolicies();
+    Assertions.assertEquals(Sets.newHashSet(policy1.name()), Sets.newHashSet(policies1));
+
+    // Test associate policies to schema
+    String[] policies =
+        schema
+            .supportsPolicies()
+            .associatePolicies(new String[] {policy1.name(), policy2.name()}, null);
+
+    Assertions.assertEquals(2, policies.length);
+    HashSet<String> expected = Sets.newHashSet(policy1.name(), policy2.name());
+    Assertions.assertEquals(expected, Sets.newHashSet(policies));
+
+    // Test list associated policies with details for schema
+    Policy[] policies2 = schema.supportsPolicies().listPolicyInfos();
+    Assertions.assertEquals(2, policies2.length);
+
+    Set<Policy> nonInheritedPolicies =
+        Arrays.stream(policies2)
+            .filter(policy -> !policy.inherited().get())
+            .collect(Collectors.toSet());
+    Set<Policy> inheritedPolicies =
+        Arrays.stream(policies2)
+            .filter(policy -> policy.inherited().get())
+            .collect(Collectors.toSet());
+
+    Assertions.assertEquals(2, nonInheritedPolicies.size());
+    Assertions.assertEquals(0, inheritedPolicies.size());
+    Assertions.assertTrue(nonInheritedPolicies.contains(policy1));
+    Assertions.assertTrue(nonInheritedPolicies.contains(policy2));
+    Assertions.assertFalse(inheritedPolicies.contains(policy2));
+
+    // Test get associated policy for schema
+    Policy policy = schema.supportsPolicies().getPolicy(policy1.name());
+    Assertions.assertEquals(policy1, policy);
+    Assertions.assertFalse(policy.inherited().get());
+
+    // Test get objects associated with policy
+    Assertions.assertEquals(2, policy.associatedObjects().count());
+    Set<MetadataObject> resultObjects = Sets.newHashSet(policy.associatedObjects().objects());
+    Set<MetadataObject> expectedObjects =
+        Sets.newHashSet(
+            MetadataObjectDTO.builder()
+                .withName(relationalCatalog.name())
+                .withType(MetadataObject.Type.CATALOG)
+                .build(),
+            MetadataObjectDTO.builder()
+                .withParent(relationalCatalog.name())
+                .withName(schema.name())
+                .withType(MetadataObject.Type.SCHEMA)
+                .build());
+    Assertions.assertEquals(expectedObjects, resultObjects);
+  }
+
+  @Test
+  public void testAssociatePoliciesToTable() {
+    PolicyContent content =
+        PolicyContents.custom(
+            ImmutableMap.of("rule1", "value1"), ImmutableSet.of(MetadataObject.Type.TABLE), null);
+    Policy policy1 =
+        metalake.createPolicy(
+            GravitinoITUtils.genRandomName("policy_it_table_policy1"),
+            "custom",
+            null,
+            true,
+            content);
+    Policy policy2 =
+        metalake.createPolicy(
+            GravitinoITUtils.genRandomName("policy_it_table_policy2"),
+            "custom",
+            null,
+            true,
+            content);
+    Policy policy3 =
+        metalake.createPolicy(
+            GravitinoITUtils.genRandomName("policy_it_table_policy3"),
+            "custom",
+            null,
+            true,
+            content);
+
+    // Associate policies to catalog
+    relationalCatalog.supportsPolicies().associatePolicies(new String[] {policy1.name()}, null);
+
+    // Associate policies to schema
+    schema.supportsPolicies().associatePolicies(new String[] {policy2.name()}, null);
+
+    // Test associate policies to table
+    String[] policies =
+        table.supportsPolicies().associatePolicies(new String[] {policy3.name()}, null);
+
+    Assertions.assertEquals(1, policies.length);
+    Assertions.assertEquals(policy3.name(), policies[0]);
+
+    // Test list associated policies for table
+    String[] policies1 = table.supportsPolicies().listPolicies();
+    Assertions.assertEquals(3, policies1.length);
+    Set<String> policyNames = Sets.newHashSet(policies1);
+    Assertions.assertTrue(policyNames.contains(policy1.name()));
+    Assertions.assertTrue(policyNames.contains(policy2.name()));
+    Assertions.assertTrue(policyNames.contains(policy3.name()));
+
+    // Test list associated policies with details for table
+    Policy[] policies2 = table.supportsPolicies().listPolicyInfos();
+    Assertions.assertEquals(3, policies2.length);
+
+    Set<Policy> nonInheritedPolicies =
+        Arrays.stream(policies2)
+            .filter(policy -> !policy.inherited().get())
+            .collect(Collectors.toSet());
+    Set<Policy> inheritedPolicies =
+        Arrays.stream(policies2)
+            .filter(policy -> policy.inherited().get())
+            .collect(Collectors.toSet());
+
+    Assertions.assertEquals(1, nonInheritedPolicies.size());
+    Assertions.assertEquals(2, inheritedPolicies.size());
+    Assertions.assertTrue(nonInheritedPolicies.contains(policy3));
+    Assertions.assertTrue(inheritedPolicies.contains(policy1));
+    Assertions.assertTrue(inheritedPolicies.contains(policy2));
+
+    // Test get associated policy for table
+    Policy resultPolicy1 = table.supportsPolicies().getPolicy(policy1.name());
+    Assertions.assertEquals(policy1, resultPolicy1);
+    Assertions.assertTrue(resultPolicy1.inherited().get());
+
+    Policy resultPolicy2 = table.supportsPolicies().getPolicy(policy2.name());
+    Assertions.assertEquals(policy2, resultPolicy2);
+    Assertions.assertTrue(resultPolicy2.inherited().get());
+
+    Policy resultPolicy3 = table.supportsPolicies().getPolicy(policy3.name());
+    Assertions.assertEquals(policy3, resultPolicy3);
+    Assertions.assertFalse(resultPolicy3.inherited().get());
+
+    // Test get objects associated with policy
+    Assertions.assertEquals(1, policy1.associatedObjects().count());
+    Assertions.assertEquals(
+        relationalCatalog.name(), policy1.associatedObjects().objects()[0].name());
+    Assertions.assertEquals(
+        MetadataObject.Type.CATALOG, policy1.associatedObjects().objects()[0].type());
+
+    Assertions.assertEquals(1, policy2.associatedObjects().count());
+    Assertions.assertEquals(schema.name(), policy2.associatedObjects().objects()[0].name());
+    Assertions.assertEquals(
+        MetadataObject.Type.SCHEMA, policy2.associatedObjects().objects()[0].type());
+
+    Assertions.assertEquals(1, policy3.associatedObjects().count());
+    Assertions.assertEquals(table.name(), policy3.associatedObjects().objects()[0].name());
+    Assertions.assertEquals(
+        MetadataObject.Type.TABLE, policy3.associatedObjects().objects()[0].type());
+  }
+
+  @Test
+  public void testAssociateAndDeletePolicies() {
+    Policy policy1 = createCustomPolicy(GravitinoITUtils.genRandomName("policy_it_policy1"));
+    Policy policy2 = createCustomPolicy(GravitinoITUtils.genRandomName("policy_it_policy2"));
+    Policy policy3 = createCustomPolicy(GravitinoITUtils.genRandomName("policy_it_policy3"));
+
+    String[] associatedPolicies =
+        relationalCatalog
+            .supportsPolicies()
+            .associatePolicies(
+                new String[] {policy1.name(), policy2.name()}, new String[] {policy3.name()});
+
+    Assertions.assertEquals(2, associatedPolicies.length);
+    Set<String> policyNames = Sets.newHashSet(associatedPolicies);
+    Assertions.assertTrue(policyNames.contains(policy1.name()));
+    Assertions.assertTrue(policyNames.contains(policy2.name()));
+    Assertions.assertFalse(policyNames.contains(policy3.name()));
+
+    Policy retrievedPolicy = relationalCatalog.supportsPolicies().getPolicy(policy2.name());
+    Assertions.assertEquals(policy2.name(), retrievedPolicy.name());
+    Assertions.assertEquals(policy2.comment(), retrievedPolicy.comment());
+
+    boolean deleted = metalake.deletePolicy("null");
+    Assertions.assertFalse(deleted);
+
+    deleted = metalake.deletePolicy(policy1.name());
+    Assertions.assertTrue(deleted);
+    deleted = metalake.deletePolicy(policy1.name());
+    Assertions.assertFalse(deleted);
+
+    String[] associatedPolicies1 = relationalCatalog.supportsPolicies().listPolicies();
+    Assertions.assertArrayEquals(new String[] {policy2.name()}, associatedPolicies1);
+  }
+
+  @Test
+  public void testAssociatePoliciesToModel() {
+    Policy policy1 = createCustomPolicy(GravitinoITUtils.genRandomName("policy_it_model_policy1"));
+    Policy policy2 = createCustomPolicy(GravitinoITUtils.genRandomName("policy_it_model_policy2"));
+    Policy policy3 = createCustomPolicy(GravitinoITUtils.genRandomName("policy_it_model_policy3"));
+
+    // Associate policies to catalog
+    modelCatalog.supportsPolicies().associatePolicies(new String[] {policy1.name()}, null);
+
+    // Associate policies to schema
+    modelSchema.supportsPolicies().associatePolicies(new String[] {policy2.name()}, null);
+
+    // Associate policies to model
+    model.supportsPolicies().associatePolicies(new String[] {policy3.name()}, null);
+
+    // Test list associated policies for model
+    String[] policies1 = model.supportsPolicies().listPolicies();
+    Assertions.assertEquals(3, policies1.length);
+    Set<String> policyNames = Sets.newHashSet(policies1);
+    Assertions.assertTrue(policyNames.contains(policy1.name()));
+    Assertions.assertTrue(policyNames.contains(policy2.name()));
+    Assertions.assertTrue(policyNames.contains(policy3.name()));
+
+    // Test list associated policies with details for model
+    Policy[] policies2 = model.supportsPolicies().listPolicyInfos();
+    Assertions.assertEquals(3, policies2.length);
+
+    Set<Policy> nonInheritedPolicies =
+        Arrays.stream(policies2)
+            .filter(policy -> !policy.inherited().get())
+            .collect(Collectors.toSet());
+    Set<Policy> inheritedPolicies =
+        Arrays.stream(policies2)
+            .filter(policy -> policy.inherited().get())
+            .collect(Collectors.toSet());
+
+    Assertions.assertEquals(1, nonInheritedPolicies.size());
+    Assertions.assertEquals(2, inheritedPolicies.size());
+    Assertions.assertTrue(nonInheritedPolicies.contains(policy3));
+    Assertions.assertTrue(inheritedPolicies.contains(policy1));
+    Assertions.assertTrue(inheritedPolicies.contains(policy2));
+
+    // Test get associated policy for model
+    Policy resultPolicy1 = model.supportsPolicies().getPolicy(policy1.name());
+    Assertions.assertEquals(policy1, resultPolicy1);
+    Assertions.assertTrue(resultPolicy1.inherited().get());
+
+    Policy resultPolicy2 = model.supportsPolicies().getPolicy(policy2.name());
+    Assertions.assertEquals(policy2, resultPolicy2);
+    Assertions.assertTrue(resultPolicy2.inherited().get());
+
+    Policy resultPolicy3 = model.supportsPolicies().getPolicy(policy3.name());
+    Assertions.assertEquals(policy3, resultPolicy3);
+    Assertions.assertFalse(resultPolicy3.inherited().get());
+
+    // Test get objects associated with policy
+    Assertions.assertEquals(1, policy1.associatedObjects().count());
+    Assertions.assertEquals(modelCatalog.name(), policy1.associatedObjects().objects()[0].name());
+    Assertions.assertEquals(
+        MetadataObject.Type.CATALOG, policy1.associatedObjects().objects()[0].type());
+
+    Assertions.assertEquals(1, policy2.associatedObjects().count());
+    Assertions.assertEquals(modelSchema.name(), policy2.associatedObjects().objects()[0].name());
+    Assertions.assertEquals(
+        MetadataObject.Type.SCHEMA, policy2.associatedObjects().objects()[0].type());
+
+    Assertions.assertEquals(1, policy3.associatedObjects().count());
+    Assertions.assertEquals(model.name(), policy3.associatedObjects().objects()[0].name());
+    Assertions.assertEquals(
+        MetadataObject.Type.MODEL, policy3.associatedObjects().objects()[0].type());
+  }
+
+  private Policy createCustomPolicy(String name) {
+    return metalake.createPolicy(
+        name,
+        "custom",
+        "test comment",
+        true,
+        PolicyContents.custom(
+            ImmutableMap.of("rule1", "value1"),
+            ImmutableSet.of(MetadataObject.Type.CATALOG),
+            null));
+  }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,7 +40,7 @@ defaultScalaVersion = 2.12
 pythonVersion = 3.8
 
 # skipDockerTests is used to skip the tests that require Docker to be running.
-skipDockerTests = true
+skipDockerTests = false
 
 # enableFuse is used to enable the fuse module in the build.
 enableFuse = false

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,7 +40,7 @@ defaultScalaVersion = 2.12
 pythonVersion = 3.8
 
 # skipDockerTests is used to skip the tests that require Docker to be running.
-skipDockerTests = false
+skipDockerTests = true
 
 # enableFuse is used to enable the fuse module in the build.
 enableFuse = false


### PR DESCRIPTION
### What changes were proposed in this pull request?

Java client supports policy relational operations and add ITs

### Why are the changes needed?

Fix: #7880 

### Does this PR introduce _any_ user-facing change?

yes, new feature of Java client

### How was this patch tested?

tests added
