### PR TITLE
[#8113] Improvement to only notify the user when a role deletion succeeds

### DIFF
--- a/core/src/main/java/org/apache/gravitino/hook/AccessControlHookDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/hook/AccessControlHookDispatcher.java
@@ -192,8 +192,8 @@ public class AccessControlHookDispatcher implements AccessControlDispatcher {
       log.debug(e.getMessage());
     }
     boolean resultOfDeleteRole = dispatcher.deleteRole(metalake, role);
-    if (oldRole != null) {
-      notifyRoleUserRelChange(((RoleEntity) oldRole).id());
+    if (resultOfDeleteRole && oldRole != null) {
+      notifyRoleUserRelChange(metalake, role);
     }
     return resultOfDeleteRole;
   }
@@ -214,7 +214,6 @@ public class AccessControlHookDispatcher implements AccessControlDispatcher {
       String metalake, String role, MetadataObject object, Set<Privilege> privileges)
       throws NoSuchMetalakeException, NoSuchRoleException {
     Role grantedRole = dispatcher.grantPrivilegeToRole(metalake, role, object, privileges);
-    notifyRoleUserRelChange(metalake, role);
     return grantedRole;
   }
 
@@ -223,7 +222,6 @@ public class AccessControlHookDispatcher implements AccessControlDispatcher {
       String metalake, String role, MetadataObject object, Set<Privilege> privileges)
       throws NoSuchMetalakeException, NoSuchRoleException {
     Role revokedRole = dispatcher.revokePrivilegesFromRole(metalake, role, object, privileges);
-    notifyRoleUserRelChange(metalake, role);
     return revokedRole;
   }
 

--- a/core/src/main/java/org/apache/gravitino/hook/AccessControlHookDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/hook/AccessControlHookDispatcher.java
@@ -191,13 +191,10 @@ public class AccessControlHookDispatcher implements AccessControlDispatcher {
     } catch (NoSuchRoleException e) {
       log.debug(e.getMessage());
     }
-    
     boolean resultOfDeleteRole = dispatcher.deleteRole(metalake, role);
-
     if (resultOfDeleteRole && oldRole != null) {
       notifyRoleUserRelChange(metalake, role);
     }
-
     return resultOfDeleteRole;
   }
 

--- a/core/src/main/java/org/apache/gravitino/hook/AccessControlHookDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/hook/AccessControlHookDispatcher.java
@@ -143,6 +143,7 @@ public class AccessControlHookDispatcher implements AccessControlDispatcher {
   public User revokeRolesFromUser(String metalake, List<String> roles, String user)
       throws NoSuchUserException, IllegalRoleException, NoSuchMetalakeException {
     User revokedUser = dispatcher.revokeRolesFromUser(metalake, roles, user);
+    notifyRoleUserRelChange(metalake, roles);
     return revokedUser;
   }
 
@@ -216,6 +217,7 @@ public class AccessControlHookDispatcher implements AccessControlDispatcher {
       String metalake, String role, MetadataObject object, Set<Privilege> privileges)
       throws NoSuchMetalakeException, NoSuchRoleException {
     Role grantedRole = dispatcher.grantPrivilegeToRole(metalake, role, object, privileges);
+    notifyRoleUserRelChange(metalake, role);
     return grantedRole;
   }
 
@@ -224,6 +226,7 @@ public class AccessControlHookDispatcher implements AccessControlDispatcher {
       String metalake, String role, MetadataObject object, Set<Privilege> privileges)
       throws NoSuchMetalakeException, NoSuchRoleException {
     Role revokedRole = dispatcher.revokePrivilegesFromRole(metalake, role, object, privileges);
+    notifyRoleUserRelChange(metalake, role);
     return revokedRole;
   }
 

--- a/core/src/main/java/org/apache/gravitino/hook/AccessControlHookDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/hook/AccessControlHookDispatcher.java
@@ -44,7 +44,6 @@ import org.apache.gravitino.exceptions.NoSuchRoleException;
 import org.apache.gravitino.exceptions.NoSuchUserException;
 import org.apache.gravitino.exceptions.RoleAlreadyExistsException;
 import org.apache.gravitino.exceptions.UserAlreadyExistsException;
-import org.apache.gravitino.meta.RoleEntity;
 import org.apache.gravitino.utils.NameIdentifierUtil;
 import org.apache.gravitino.utils.PrincipalUtils;
 

--- a/core/src/main/java/org/apache/gravitino/hook/AccessControlHookDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/hook/AccessControlHookDispatcher.java
@@ -194,8 +194,8 @@ public class AccessControlHookDispatcher implements AccessControlDispatcher {
     
     boolean resultOfDeleteRole = dispatcher.deleteRole(metalake, role);
 
-    if(resultOfDeleteRole && oldRole!= null) {
-      notifyRoleUserRelChange(metalake,role);
+    if (resultOfDeleteRole && oldRole != null) {
+      notifyRoleUserRelChange(metalake, role);
     }
 
     return resultOfDeleteRole;

--- a/core/src/main/java/org/apache/gravitino/hook/AccessControlHookDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/hook/AccessControlHookDispatcher.java
@@ -44,6 +44,7 @@ import org.apache.gravitino.exceptions.NoSuchRoleException;
 import org.apache.gravitino.exceptions.NoSuchUserException;
 import org.apache.gravitino.exceptions.RoleAlreadyExistsException;
 import org.apache.gravitino.exceptions.UserAlreadyExistsException;
+import org.apache.gravitino.meta.RoleEntity;
 import org.apache.gravitino.utils.NameIdentifierUtil;
 import org.apache.gravitino.utils.PrincipalUtils;
 
@@ -192,7 +193,7 @@ public class AccessControlHookDispatcher implements AccessControlDispatcher {
     }
     boolean resultOfDeleteRole = dispatcher.deleteRole(metalake, role);
     if (resultOfDeleteRole && oldRole != null) {
-      notifyRoleUserRelChange(metalake, role);
+      notifyRoleUserRelChange(((RoleEntity) oldRole).id());
     }
     return resultOfDeleteRole;
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Only` notify the user when a role deletion succeeds.

### Why are the changes needed?

To prevent errors and only notify the user when a role deletion succeeds.

Fixes: #8113

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

CI passed