### PR TITLE
[#8109] improvement(core): correct PostgreSQL ON CONFLICT syntax using EXCLUDED instead of VALUES

### DIFF
--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/UserRoleRelPostgreSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/UserRoleRelPostgreSQLProvider.java
@@ -92,12 +92,12 @@ public class UserRoleRelPostgreSQLProvider extends UserRoleRelBaseSQLProvider {
         + " #{item.deletedAt})"
         + "</foreach>"
         + " ON CONFLICT (user_id, role_id, deleted_at) DO UPDATE SET"
-        + " user_id = VALUES(user_id),"
-        + " role_id = VALUES(role_id),"
-        + " audit_info = VALUES(audit_info),"
-        + " current_version = VALUES(current_version),"
-        + " last_version = VALUES(last_version),"
-        + " deleted_at = VALUES(deleted_at)"
+        + " user_id = EXCLUDED.user_id,"
+        + " role_id = EXCLUDED.role_id,"
+        + " audit_info = EXCLUDED.audit_info,"
+        + " current_version = EXCLUDED.current_version,"
+        + " last_version = EXCLUDED.last_version,"
+        + " deleted_at = EXCLUDED.deleted_at"
         + "</script>";
   }
 


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

This PR fixes the incorrect SQL syntax in `UserRoleRelPostgreSQLProvider.java` by replacing `VALUES()` function calls with `EXCLUDED` references in the `ON CONFLICT ... DO UPDATE` clause. The change ensures proper PostgreSQL compatibility for upsert operations.\

### Why are the changes needed?

The current implementation uses MySQL-specific `VALUES()` function syntax in PostgreSQL provider, which is incorrect according to PostgreSQL documentation. PostgreSQL's `INSERT ... ON CONFLICT ... DO UPDATE` requires using `EXCLUDED` table alias to reference the values that would have been inserted, not the `VALUES()` function.

Fix: #8109

### Does this PR introduce _any_ user-facing change?

No user-facing changes. This is a bug fix that ensures the existing functionality works correctly on PostgreSQL databases.  

### How was this patch tested?

Tested with existing tests.
