### PR TITLE
[#8084] fix: include `inherited` in TagDTO equality 

### DIFF
--- a/common/src/main/java/org/apache/gravitino/dto/tag/TagDTO.java
+++ b/common/src/main/java/org/apache/gravitino/dto/tag/TagDTO.java
@@ -80,16 +80,21 @@ public class TagDTO implements Tag {
     }
 
     TagDTO tagDTO = (TagDTO) o;
+
+    boolean thisInherited = this.inherited.isPresent() && this.inherited.orElse(false);
+    boolean tagDtoInherited = tagDTO.inherited.isPresent() && tagDTO.inherited.orElse(false);
+
     return Objects.equal(name, tagDTO.name)
         && Objects.equal(comment, tagDTO.comment)
         && Objects.equal(properties, tagDTO.properties)
         && Objects.equal(audit, tagDTO.audit)
-        && Objects.equal(inherited, tagDTO.inherited);
+        && Objects.equal(thisInherited, tagDtoInherited);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(name, comment, properties, audit, inherited);
+    return Objects.hashCode(
+        name, comment, properties, audit, inherited.isPresent() && inherited.orElse(false));
   }
 
   /** @return a new builder for constructing a Tag DTO. */

--- a/common/src/main/java/org/apache/gravitino/dto/tag/TagDTO.java
+++ b/common/src/main/java/org/apache/gravitino/dto/tag/TagDTO.java
@@ -83,12 +83,13 @@ public class TagDTO implements Tag {
     return Objects.equal(name, tagDTO.name)
         && Objects.equal(comment, tagDTO.comment)
         && Objects.equal(properties, tagDTO.properties)
-        && Objects.equal(audit, tagDTO.audit);
+        && Objects.equal(audit, tagDTO.audit)
+        && Objects.equal(inherited, tagDTO.inherited);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(name, comment, properties, audit);
+    return Objects.hashCode(name, comment, properties, audit, inherited);
   }
 
   /** @return a new builder for constructing a Tag DTO. */

--- a/common/src/test/java/org/apache/gravitino/dto/tag/TestTagDTO.java
+++ b/common/src/test/java/org/apache/gravitino/dto/tag/TestTagDTO.java
@@ -100,4 +100,27 @@ public class TestTagDTO {
     TagDTO deserTagDTO4 = JsonUtils.objectMapper().readValue(serJson, TagDTO.class);
     Assertions.assertEquals(Optional.of(true), deserTagDTO4.inherited());
   }
+
+  @Test
+  public void testEqualsConsidersInherited() {
+    AuditDTO audit = AuditDTO.builder().withCreator("user1").withCreateTime(Instant.now()).build();
+
+    TagDTO ownedTag =
+        TagDTO.builder()
+            .withName("tag_test")
+            .withComment("tag comment")
+            .withAudit(audit)
+            .withInherited(Optional.of(false))
+            .build();
+
+    TagDTO inheritedTag =
+        TagDTO.builder()
+            .withName("tag_test")
+            .withComment("tag comment")
+            .withAudit(audit)
+            .withInherited(Optional.of(true))
+            .build();
+
+    Assertions.assertNotEquals(ownedTag, inheritedTag);
+  }
 }


### PR DESCRIPTION

### What changes were proposed in this pull request?

- **TagDTO**: include `inherited` in `equals()` and `hashCode()`.
- **MetadataObjectTagOperations**: when listing tags (`details=true`), **de-duplicate by tag name** and **prefer direct over inherited**; names-only path also returns unique names.
- **Tests**: add a unit test to ensure `inherited` affects equality; existing REST test (`TestMetadataObjectTagOperations`) now passes with the dedup logic.

### Why are the changes needed?

(AS-IS)
- `TagDTO.equals/hashCode` ignored `inherited`, so two tags with the same name but different inheritance were considered equal.
- The list API could return duplicate tag names (one inherited, one direct), and `inherited` on the returned tag might not reflect the stronger (direct) association.

(TO-BE)
- `TagDTO` equality/hash now considers `inherited` so comparisons are accurate.
- Listing tags de-duplicates by name and **keeps the direct association when both direct and inherited exist**. This keeps the expected count stable and the `inherited` flag correct.

Fix: #8084 

### Does this PR introduce _any_ user-facing change?

- API shape unchanged.
- Listing tags (`/metalakes/{metalake}/objects/.../tags`) now:
  - Does not return duplicate names when both direct and inherited exist.
  - For duplicate names, the returned entry is the **direct** one (`inherited=false`).
- This aligns with existing test expectations; functional behavior is clarified and made consistent.


### How was this patch tested?

- Local runs:
  - `./gradlew spotlessApply`
  - `./gradlew :server:test --tests "*TestMetadataObjectTagOperations.testListTagsForObject*"`
  - `./gradlew :common:test --tests "org.apache.gravitino.dto.tag.TestTagDTO"`
  - `./gradlew test -PskipITs`