### PR TITLE
[#8110] Improvement: Equality check in equals method in FileSetCatalogOperations.java

### DIFF
--- a/catalogs/catalog-fileset/src/main/java/org/apache/gravitino/catalog/fileset/FilesetCatalogOperations.java
+++ b/catalogs/catalog-fileset/src/main/java/org/apache/gravitino/catalog/fileset/FilesetCatalogOperations.java
@@ -187,7 +187,7 @@ public class FilesetCatalogOperations extends ManagedSchemaOperations
       }
       FileSystemCacheKey that = (FileSystemCacheKey) o;
       return conf.equals(that.conf)
-          && (scheme == null ? that.schema == null : scheme.equals(that.scheme))
+          && (scheme == null ? that.scheme == null : scheme.equals(that.scheme))
           && (authority == null ? that.authority == null : authority.equals(that.authority))
           && currentUser.equals(that.currentUser);
     }


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?
  - Fixed a bug in the `equals` method where `scheme` was incorrectly compared to `that.authority`.  
  - Updated the logic to correctly compare `scheme` with `that.scheme`

### Why are the changes needed?
   This fix ensures object equality is consistent and accurate.  

Fix: #8110

### Does this PR introduce _any_ user-facing change?
  - No user-facing changes.  
  - This fix only corrects the internal equality logic.

### How was this patch tested?

 Verified that objects with different `scheme` values are not considered equal.  
