### PR TITLE
[#8167]improve(core): Improve the SPI to load in the specific mapper class

### DIFF
--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/DefaultMapperPackageProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/DefaultMapperPackageProvider.java
@@ -18,13 +18,66 @@
  */
 package org.apache.gravitino.storage.relational.mapper.provider;
 
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import org.apache.gravitino.storage.relational.mapper.CatalogMetaMapper;
+import org.apache.gravitino.storage.relational.mapper.FilesetMetaMapper;
+import org.apache.gravitino.storage.relational.mapper.FilesetVersionMapper;
+import org.apache.gravitino.storage.relational.mapper.GroupMetaMapper;
+import org.apache.gravitino.storage.relational.mapper.GroupRoleRelMapper;
+import org.apache.gravitino.storage.relational.mapper.JobMetaMapper;
+import org.apache.gravitino.storage.relational.mapper.JobTemplateMetaMapper;
+import org.apache.gravitino.storage.relational.mapper.MetalakeMetaMapper;
+import org.apache.gravitino.storage.relational.mapper.ModelMetaMapper;
+import org.apache.gravitino.storage.relational.mapper.ModelVersionAliasRelMapper;
+import org.apache.gravitino.storage.relational.mapper.ModelVersionMetaMapper;
+import org.apache.gravitino.storage.relational.mapper.OwnerMetaMapper;
+import org.apache.gravitino.storage.relational.mapper.PolicyMetaMapper;
+import org.apache.gravitino.storage.relational.mapper.PolicyMetadataObjectRelMapper;
+import org.apache.gravitino.storage.relational.mapper.PolicyVersionMapper;
+import org.apache.gravitino.storage.relational.mapper.RoleMetaMapper;
+import org.apache.gravitino.storage.relational.mapper.SchemaMetaMapper;
+import org.apache.gravitino.storage.relational.mapper.SecurableObjectMapper;
+import org.apache.gravitino.storage.relational.mapper.StatisticMetaMapper;
+import org.apache.gravitino.storage.relational.mapper.TableColumnMapper;
+import org.apache.gravitino.storage.relational.mapper.TableMetaMapper;
+import org.apache.gravitino.storage.relational.mapper.TagMetaMapper;
+import org.apache.gravitino.storage.relational.mapper.TagMetadataObjectRelMapper;
+import org.apache.gravitino.storage.relational.mapper.TopicMetaMapper;
+import org.apache.gravitino.storage.relational.mapper.UserMetaMapper;
+import org.apache.gravitino.storage.relational.mapper.UserRoleRelMapper;
+
 /** The default provider that supplies the primary mapper package for Gravitino. */
 public class DefaultMapperPackageProvider implements MapperPackageProvider {
-  private static final String DEFAULT_MAPPER_PACKAGE =
-      "org.apache.gravitino.storage.relational.mapper";
 
   @Override
-  public String getPackageName() {
-    return DEFAULT_MAPPER_PACKAGE;
+  public List<Class<?>> getMapperClasses() {
+    return ImmutableList.of(
+        CatalogMetaMapper.class,
+        FilesetMetaMapper.class,
+        FilesetVersionMapper.class,
+        GroupMetaMapper.class,
+        GroupRoleRelMapper.class,
+        JobMetaMapper.class,
+        JobTemplateMetaMapper.class,
+        MetalakeMetaMapper.class,
+        ModelMetaMapper.class,
+        ModelVersionAliasRelMapper.class,
+        ModelVersionMetaMapper.class,
+        OwnerMetaMapper.class,
+        PolicyMetadataObjectRelMapper.class,
+        PolicyMetaMapper.class,
+        PolicyVersionMapper.class,
+        RoleMetaMapper.class,
+        SchemaMetaMapper.class,
+        SecurableObjectMapper.class,
+        StatisticMetaMapper.class,
+        TableColumnMapper.class,
+        TableMetaMapper.class,
+        TagMetadataObjectRelMapper.class,
+        TagMetaMapper.class,
+        TopicMetaMapper.class,
+        UserMetaMapper.class,
+        UserRoleRelMapper.class);
   }
 }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/MapperPackageProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/MapperPackageProvider.java
@@ -18,16 +18,18 @@
  */
 package org.apache.gravitino.storage.relational.mapper.provider;
 
+import java.util.List;
+
 /**
- * A Service Provider Interface (SPI) for providing package names that contain MyBatis Mapper
- * interfaces. Implementations of this interface allow for the automatic discovery and registration
- * of mappers from different modules.
+ * A Service Provider Interface (SPI) to provide a list of MyBatis Mapper interfaces.
+ * Implementations of this interface allow for the automatic discovery and registration of mappers
+ * from different modules.
  */
 public interface MapperPackageProvider {
   /**
-   * Returns the package name where MyBatis Mapper interfaces are located.
+   * Get a list of MyBatis Mapper classes to register into MyBatis configuration.
    *
-   * @return A string representing the package name to be scanned.
+   * @return a list of MyBatis Mapper classes
    */
-  String getPackageName();
+  List<Class<?>> getMapperClasses();
 }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/session/SqlSessionFactoryHelper.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/session/SqlSessionFactoryHelper.java
@@ -107,7 +107,7 @@ public class SqlSessionFactoryHelper {
     configuration.setDatabaseId(jdbcType.name().toLowerCase());
     ServiceLoader<MapperPackageProvider> loader = ServiceLoader.load(MapperPackageProvider.class);
     for (MapperPackageProvider provider : loader) {
-      configuration.addMappers(provider.getPackageName());
+      provider.getMapperClasses().forEach(configuration::addMapper);
     }
 
     // Create the SqlSessionFactory object, it is a singleton object


### PR DESCRIPTION
### What changes were proposed in this pull request?

Change the SPI interface to add the specific mapper list instead of general package name.

### Why are the changes needed?

Currently, we're using package name to load in all the mapper class to MyBatis configuration, but our package contains lots of classes other than mapper class, so they will also load in unexpected classes to increase the footprint. So here slightly adjust the SPI to avoid load in the unwanted classes.

Fix: #8167 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing tests.
