### PR TITLE
[#8122] fix(core): Fix unable to handle Java error in doAs

### DIFF
--- a/core/src/main/java/org/apache/gravitino/utils/PrincipalUtils.java
+++ b/core/src/main/java/org/apache/gravitino/utils/PrincipalUtils.java
@@ -26,9 +26,14 @@ import java.security.PrivilegedExceptionAction;
 import javax.security.auth.Subject;
 import org.apache.gravitino.UserPrincipal;
 import org.apache.gravitino.auth.AuthConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @SuppressWarnings("removal")
 public class PrincipalUtils {
+
+  private static final Logger LOG = LoggerFactory.getLogger(PrincipalUtils.class);
+
   private PrincipalUtils() {}
 
   public static <T> T doAs(Principal principal, PrivilegedExceptionAction<T> action)
@@ -41,6 +46,9 @@ public class PrincipalUtils {
       Throwable cause = pae.getCause();
       Throwables.propagateIfPossible(cause, Exception.class);
       throw new RuntimeException("doAs method occurs an unexpected exception", pae);
+    } catch (Throwable t) {
+      LOG.warn("doAs method occurs an unexpected error", t);
+      throw new RuntimeException("doAs method occurs an unexpected exception", t);
     }
   }
 

--- a/core/src/main/java/org/apache/gravitino/utils/PrincipalUtils.java
+++ b/core/src/main/java/org/apache/gravitino/utils/PrincipalUtils.java
@@ -46,7 +46,7 @@ public class PrincipalUtils {
       Throwable cause = pae.getCause();
       Throwables.propagateIfPossible(cause, Exception.class);
       throw new RuntimeException("doAs method occurs an unexpected exception", pae);
-    } catch (Throwable t) {
+    } catch (Error t) {
       LOG.warn("doAs method occurs an unexpected error", t);
       throw new RuntimeException("doAs method occurs an unexpected exception", t);
     }

--- a/server/src/test/java/org/apache/gravitino/server/web/rest/TestFilesetOperations.java
+++ b/server/src/test/java/org/apache/gravitino/server/web/rest/TestFilesetOperations.java
@@ -373,6 +373,21 @@ public class TestFilesetOperations extends BaseOperationsTest {
     ErrorResponse errorResp3 = resp3.readEntity(ErrorResponse.class);
     Assertions.assertEquals(ErrorConstants.INTERNAL_ERROR_CODE, errorResp3.getCode());
     Assertions.assertEquals(RuntimeException.class.getSimpleName(), errorResp3.getType());
+
+    // Test throw Error
+    doThrow(new Error("mock error"))
+        .when(dispatcher)
+        .createMultipleLocationFileset(any(), any(), any(), any(), any());
+    Response resp4 =
+        target(filesetPath(metalake, catalog, schema))
+            .request(MediaType.APPLICATION_JSON_TYPE)
+            .accept("application/vnd.gravitino.v1+json")
+            .post(Entity.entity(req, MediaType.APPLICATION_JSON_TYPE));
+    Assertions.assertEquals(
+        Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), resp4.getStatus());
+    ErrorResponse errorResp4 = resp4.readEntity(ErrorResponse.class);
+    Assertions.assertEquals(ErrorConstants.INTERNAL_ERROR_CODE, errorResp4.getCode());
+    Assertions.assertEquals(RuntimeException.class.getSimpleName(), errorResp4.getType());
   }
 
   @Test


### PR DESCRIPTION

### What changes were proposed in this pull request?

Handle JAVA error message as well as excetion messages.

### Why are the changes needed?

Java error message also needed to be handled.

Fix: #8122

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

Existing UTs and test locally 


<img width="3334" height="256" alt="image" src="https://github.com/user-attachments/assets/32605bda-19a0-4d0e-909b-457963ccaa05" />
<img width="3334" height="924" alt="image" src="https://github.com/user-attachments/assets/8a4c2582-37e9-4c6e-943e-c45d22829146" />

