### PR TITLE
[8158] improvement: display an error if both alias and version are null in UpdateModelVersionAliases

### DIFF
--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/UpdateModelVersionAliases.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/UpdateModelVersionAliases.java
@@ -114,7 +114,9 @@ public class UpdateModelVersionAliases extends Command {
     if (alias != null && version != null) {
       exitWithError("Cannot specify both alias and version");
     }
-
+    if (alias == null && version == null) {
+      exitWithError("Either alias or version must be specified");
+    }
     return this;
   }
 }

--- a/clients/cli/src/test/java/org/apache/gravitino/cli/TestModelCommands.java
+++ b/clients/cli/src/test/java/org/apache/gravitino/cli/TestModelCommands.java
@@ -1146,4 +1146,25 @@ public class TestModelCommands {
 
     Assertions.assertThrows(RuntimeException.class, commandLine::handleCommandLine);
   }
+
+  @Test
+  void testUpdateModelVersionAliasesByNullAliasAndVersion() {
+    Main.useExit = false;
+    when(mockCommandLine.hasOption(GravitinoOptions.METALAKE)).thenReturn(true);
+    when(mockCommandLine.getOptionValue(GravitinoOptions.METALAKE)).thenReturn("metalake_demo");
+    when(mockCommandLine.hasOption(GravitinoOptions.ALIAS)).thenReturn(false);
+    when(mockCommandLine.getOptionValues(GravitinoOptions.ALIAS)).thenReturn(null);
+    when(mockCommandLine.hasOption(GravitinoOptions.VERSION)).thenReturn(false);
+    when(mockCommandLine.getOptionValue(GravitinoOptions.VERSION)).thenReturn(null);
+    when(mockCommandLine.hasOption(GravitinoOptions.NEW_ALIAS)).thenReturn(true);
+    when(mockCommandLine.getOptionValues(GravitinoOptions.NEW_ALIAS))
+        .thenReturn(new String[] {"aliasA", "aliasB"});
+
+    GravitinoCommandLine commandLine =
+        spy(
+            new GravitinoCommandLine(
+                mockCommandLine, mockOptions, CommandEntities.MODEL, CommandActions.UPDATE));
+
+    Assertions.assertThrows(RuntimeException.class, commandLine::handleCommandLine);
+  }
 }


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?
display an error if both alias and version are null in UpdateModelVersionAliases
(Please outline the changes and how this PR fixes the issue.)

### Why are the changes needed?

(Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, describe the bug.)

Fix: #8158 
### Does this PR introduce _any_ user-facing change?

(Please list the user-facing changes introduced by your change, including
  1. Change in user-facing APIs.
  2. Addition or removal of property keys.)

### How was this patch tested?
Unit testing
(Please test your changes, and provide instructions on how to test it:
  1. If you add a feature or fix a bug, add a test to cover your changes.
  2. If you fix a flaky test, repeat it for many times to prove it works.)
