### PR TITLE
[#8161] fix(catalog): respect ignoreIfNotExists flag in removeCatalog

### DIFF
--- a/flink-connector/flink/src/main/java/org/apache/gravitino/flink/connector/store/GravitinoCatalogStore.java
+++ b/flink-connector/flink/src/main/java/org/apache/gravitino/flink/connector/store/GravitinoCatalogStore.java
@@ -27,6 +27,7 @@ import java.util.Optional;
 import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.function.Predicate;
+
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.table.catalog.AbstractCatalogStore;
 import org.apache.flink.table.catalog.CatalogDescriptor;
@@ -42,130 +43,142 @@ import org.apache.gravitino.flink.connector.catalog.GravitinoCatalogManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** GravitinoCatalogStore is used to store catalog information to Apache Gravitino server. */
+/**
+ * GravitinoCatalogStore is used to store catalog information to Apache Gravitino server.
+ */
 public class GravitinoCatalogStore extends AbstractCatalogStore {
-  private static final Logger LOG = LoggerFactory.getLogger(GravitinoCatalogStore.class);
-  private final GravitinoCatalogManager gravitinoCatalogManager;
+    private static final Logger LOG = LoggerFactory.getLogger(GravitinoCatalogStore.class);
+    private final GravitinoCatalogManager gravitinoCatalogManager;
 
-  public GravitinoCatalogStore(GravitinoCatalogManager catalogManager) {
-    this.gravitinoCatalogManager = catalogManager;
-  }
-
-  @Override
-  public void storeCatalog(String catalogName, CatalogDescriptor descriptor)
-      throws CatalogException {
-    Configuration configuration = descriptor.getConfiguration();
-    Map<String, String> gravitino = configuration.toMap();
-    BaseCatalogFactory catalogFactory = getCatalogFactory(gravitino);
-    Map<String, String> gravitinoProperties =
-        catalogFactory.propertiesConverter().toGravitinoCatalogProperties(configuration);
-    gravitinoCatalogManager.createCatalog(
-        catalogName,
-        catalogFactory.gravitinoCatalogType(),
-        null,
-        catalogFactory.gravitinoCatalogProvider(),
-        gravitinoProperties);
-  }
-
-  @Override
-  public void removeCatalog(String catalogName, boolean ignoreIfNotExists) throws CatalogException {
-    try {
-      gravitinoCatalogManager.dropCatalog(catalogName);
-    } catch (Exception e) {
-      throw new CatalogException(String.format("Failed to remove the catalog: %s", catalogName), e);
+    public GravitinoCatalogStore(GravitinoCatalogManager catalogManager) {
+        this.gravitinoCatalogManager = catalogManager;
     }
-  }
 
-  /**
-   * Get a catalog by name.
-   *
-   * @param catalogName name of the catalog to retrieve
-   * @return the requested catalog or empty if the catalog does not exist
-   * @throws CatalogException throw a CatalogException when the Catalog cannot be created.
-   */
-  @Override
-  public Optional<CatalogDescriptor> getCatalog(String catalogName) throws CatalogException {
-    try {
-      Catalog catalog = gravitinoCatalogManager.getGravitinoCatalogInfo(catalogName);
-      BaseCatalogFactory catalogFactory = getCatalogFactory(catalog.provider());
-      PropertiesConverter propertiesConverter = catalogFactory.propertiesConverter();
-      Map<String, String> flinkCatalogProperties =
-          propertiesConverter.toFlinkCatalogProperties(catalog.properties());
-      CatalogDescriptor descriptor =
-          CatalogDescriptor.of(catalogName, Configuration.fromMap(flinkCatalogProperties));
-      return Optional.of(descriptor);
-    } catch (NoSuchCatalogException noSuchCatalogException) {
-      return Optional.empty();
-    } catch (Exception e) {
-      throw new CatalogException(String.format("Failed to get the catalog: %s", catalogName), e);
+    @Override
+    public void storeCatalog(String catalogName, CatalogDescriptor descriptor)
+            throws CatalogException {
+        Configuration configuration = descriptor.getConfiguration();
+        Map<String, String> gravitino = configuration.toMap();
+        BaseCatalogFactory catalogFactory = getCatalogFactory(gravitino);
+        Map<String, String> gravitinoProperties =
+                catalogFactory.propertiesConverter().toGravitinoCatalogProperties(configuration);
+        gravitinoCatalogManager.createCatalog(
+                catalogName,
+                catalogFactory.gravitinoCatalogType(),
+                null,
+                catalogFactory.gravitinoCatalogProvider(),
+                gravitinoProperties);
     }
-  }
 
-  @Override
-  public Set<String> listCatalogs() throws CatalogException {
-    try {
-      return gravitinoCatalogManager.listCatalogs();
-    } catch (Exception e) {
-      throw new CatalogException("Failed to list catalog.", e);
-    }
-  }
-
-  @Override
-  public boolean contains(String catalogName) throws CatalogException {
-    return gravitinoCatalogManager.contains(catalogName);
-  }
-
-  private BaseCatalogFactory getCatalogFactory(Map<String, String> configuration) {
-    String catalogType =
-        Preconditions.checkNotNull(
-            configuration.get(CommonCatalogOptions.CATALOG_TYPE.key()),
-            "%s should not be null.",
-            CommonCatalogOptions.CATALOG_TYPE);
-
-    return discoverFactories(
-        catalogFactory -> (catalogFactory.factoryIdentifier().equalsIgnoreCase(catalogType)),
-        String.format(
-            "Flink catalog type [%s] matched multiple flink catalog factories, it should only match one.",
-            catalogType));
-  }
-
-  private BaseCatalogFactory getCatalogFactory(String provider) {
-    return discoverFactories(
-        catalogFactory ->
-            ((BaseCatalogFactory) catalogFactory)
-                .gravitinoCatalogProvider()
-                .equalsIgnoreCase(provider),
-        String.format(
-            "Gravitino catalog provider [%s] matched multiple flink catalog factories, it should only match one.",
-            provider));
-  }
-
-  private BaseCatalogFactory discoverFactories(Predicate<Factory> predicate, String errorMessage) {
-    Iterator<Factory> serviceLoaderIterator = ServiceLoader.load(Factory.class).iterator();
-    final List<Factory> factories = new ArrayList<>();
-    while (true) {
-      try {
-        if (!serviceLoaderIterator.hasNext()) {
-          break;
+    /**
+     * Removes the specified catalog.
+     *
+     * @param catalogName       the catalog name
+     * @param ignoreIfNotExists if {@code true}, do nothing when the catalog does not exist
+     * @throws CatalogException if an error occurs during removal
+     */
+    @Override
+    public void removeCatalog(String catalogName, boolean ignoreIfNotExists) throws CatalogException {
+        try {
+            boolean isDropped = gravitinoCatalogManager.dropCatalog(catalogName);
+            if (!ignoreIfNotExists && !isDropped) {
+                throw new CatalogException(String.format("Failed to remove the catalog: %s", catalogName));
+            }
+        } catch (Exception e) {
+            throw new CatalogException(String.format("Failed to remove the catalog: %s", catalogName), e);
         }
-        Factory catalogFactory = serviceLoaderIterator.next();
-        if (catalogFactory instanceof BaseCatalogFactory && predicate.test(catalogFactory)) {
-          factories.add(catalogFactory);
-        }
-      } catch (NoClassDefFoundError e) {
-        LOG.debug("NoClassDefFoundError when loading a {}.", Factory.class.getCanonicalName(), e);
-      } catch (Exception e) {
-        throw new RuntimeException("Unexpected error when trying to load service provider.", e);
-      }
     }
 
-    if (factories.isEmpty()) {
-      throw new RuntimeException("Failed to correctly match the Flink catalog factory.");
+    /**
+     * Get a catalog by name.
+     *
+     * @param catalogName name of the catalog to retrieve
+     * @return the requested catalog or empty if the catalog does not exist
+     * @throws CatalogException throw a CatalogException when the Catalog cannot be created.
+     */
+    @Override
+    public Optional<CatalogDescriptor> getCatalog(String catalogName) throws CatalogException {
+        try {
+            Catalog catalog = gravitinoCatalogManager.getGravitinoCatalogInfo(catalogName);
+            BaseCatalogFactory catalogFactory = getCatalogFactory(catalog.provider());
+            PropertiesConverter propertiesConverter = catalogFactory.propertiesConverter();
+            Map<String, String> flinkCatalogProperties =
+                    propertiesConverter.toFlinkCatalogProperties(catalog.properties());
+            CatalogDescriptor descriptor =
+                    CatalogDescriptor.of(catalogName, Configuration.fromMap(flinkCatalogProperties));
+            return Optional.of(descriptor);
+        } catch (NoSuchCatalogException noSuchCatalogException) {
+            return Optional.empty();
+        } catch (Exception e) {
+            throw new CatalogException(String.format("Failed to get the catalog: %s", catalogName), e);
+        }
     }
-    // It should only match one.
-    if (factories.size() > 1) {
-      throw new RuntimeException(errorMessage);
+
+    @Override
+    public Set<String> listCatalogs() throws CatalogException {
+        try {
+            return gravitinoCatalogManager.listCatalogs();
+        } catch (Exception e) {
+            throw new CatalogException("Failed to list catalog.", e);
+        }
     }
-    return (BaseCatalogFactory) factories.get(0);
-  }
+
+    @Override
+    public boolean contains(String catalogName) throws CatalogException {
+        return gravitinoCatalogManager.contains(catalogName);
+    }
+
+    private BaseCatalogFactory getCatalogFactory(Map<String, String> configuration) {
+        String catalogType =
+                Preconditions.checkNotNull(
+                        configuration.get(CommonCatalogOptions.CATALOG_TYPE.key()),
+                        "%s should not be null.",
+                        CommonCatalogOptions.CATALOG_TYPE);
+
+        return discoverFactories(
+                catalogFactory -> (catalogFactory.factoryIdentifier().equalsIgnoreCase(catalogType)),
+                String.format(
+                        "Flink catalog type [%s] matched multiple flink catalog factories, it should only match one.",
+                        catalogType));
+    }
+
+    private BaseCatalogFactory getCatalogFactory(String provider) {
+        return discoverFactories(
+                catalogFactory ->
+                        ((BaseCatalogFactory) catalogFactory)
+                                .gravitinoCatalogProvider()
+                                .equalsIgnoreCase(provider),
+                String.format(
+                        "Gravitino catalog provider [%s] matched multiple flink catalog factories, it should only match one.",
+                        provider));
+    }
+
+    private BaseCatalogFactory discoverFactories(Predicate<Factory> predicate, String errorMessage) {
+        Iterator<Factory> serviceLoaderIterator = ServiceLoader.load(Factory.class).iterator();
+        final List<Factory> factories = new ArrayList<>();
+        while (true) {
+            try {
+                if (!serviceLoaderIterator.hasNext()) {
+                    break;
+                }
+                Factory catalogFactory = serviceLoaderIterator.next();
+                if (catalogFactory instanceof BaseCatalogFactory && predicate.test(catalogFactory)) {
+                    factories.add(catalogFactory);
+                }
+            } catch (NoClassDefFoundError e) {
+                LOG.debug("NoClassDefFoundError when loading a {}.", Factory.class.getCanonicalName(), e);
+            } catch (Exception e) {
+                throw new RuntimeException("Unexpected error when trying to load service provider.", e);
+            }
+        }
+
+        if (factories.isEmpty()) {
+            throw new RuntimeException("Failed to correctly match the Flink catalog factory.");
+        }
+        // It should only match one.
+        if (factories.size() > 1) {
+            throw new RuntimeException(errorMessage);
+        }
+        return (BaseCatalogFactory) factories.get(0);
+    }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

- Updated `removeCatalog` implementation to respect the `ignoreIfNotExists` flag.
- If the catalog does not exist and `ignoreIfNotExists` is true, the method now exits silently.
- If the catalog does not exist and `ignoreIfNotExists` is false, a `CatalogException` is thrown.
- Wrapped underlying errors in `CatalogException` for consistency.

### Why are the changes needed?

- The previous implementation ignored the `ignoreIfNotExists` flag.
- This led to unexpected exceptions even when users explicitly indicated they wanted missing catalogs to be ignored.
- Fixing this ensures more predictable behavior and aligns with the contract of the API.

Fix: #8161

### Does this PR introduce _any_ user-facing change?

Yes.  
- Users who set `ignoreIfNotExists = true` will no longer see unnecessary exceptions if the catalog is missing.  
- Behavior is now consistent with expected API semantics.