### PR TITLE
[#8215] connector(trino/flink): Support for reading/writing time precision

### DIFF
--- a/trino-connector/integration-test/src/test/resources/trino-ci-testset/testsets/jdbc-postgresql/00006_datatype.txt
+++ b/trino-connector/integration-test/src/test/resources/trino-ci-testset/testsets/jdbc-postgresql/00006_datatype.txt
@@ -17,9 +17,9 @@ CREATE TABLE
    f11 integer,
    f12 bigint,
    f13 date,
-   f14 time(6),
-   f15 timestamp(6),
-   f16 timestamp(6) with time zone
+   f14 time(3),
+   f15 timestamp(3),
+   f16 timestamp(3) with time zone
 )
 COMMENT ''"
 
@@ -27,7 +27,7 @@ INSERT: 1 row
 
 INSERT: 1 row
 
-"Sample text 1","Text1               ","65","123.456","7.89","12.34","false","100","1000","1000","100000","2024-01-01","08:00:00.000000","2024-01-01 08:00:00.000000","2024-01-01 08:00:00.000000 UTC"
+"Sample text 1","Text1               ","65","123.456","7.89","12.34","false","100","1000","1000","100000","2024-01-01","08:00:00.000","2024-01-01 08:00:00.000","2024-01-01 08:00:00.000 UTC"
 "","","","","","","","","","","","","","",""
 
 CREATE TABLE
@@ -45,9 +45,9 @@ CREATE TABLE
    f11 integer NOT NULL,
    f12 bigint NOT NULL,
    f13 date NOT NULL,
-   f14 time(6) NOT NULL,
-   f15 timestamp(6) NOT NULL,
-   f16 timestamp(6) with time zone NOT NULL
+   f14 time(3) NOT NULL,
+   f15 timestamp(3) NOT NULL,
+   f16 timestamp(3) with time zone NOT NULL
 )
 COMMENT ''"
 

--- a/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/catalog/hive/HiveDataTypeTransformer.java
+++ b/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/catalog/hive/HiveDataTypeTransformer.java
@@ -76,8 +76,18 @@ public class HiveDataTypeTransformer extends GeneralDataTypeTransformer {
 
       return Types.FixedCharType.of(charType.getLength());
     } else if (io.trino.spi.type.TimestampType.class.isAssignableFrom(typeClass)) {
-      // When creating a table in Hive, the timestamp data type only supports not specifying
-      // precision, with the default precision being 3 (milliseconds precision)
+      // When creating a table in Hive, the timestamp data type only supports timestamp and
+      // timestamp(3)
+      // with the precision being 3 (milliseconds precision)
+      io.trino.spi.type.TimestampType timestampType = (io.trino.spi.type.TimestampType) type;
+      int precision = timestampType.getPrecision();
+      if (precision != TRINO_MILLIS_PRECISION) {
+        throw new TrinoException(
+            GravitinoErrorCode.GRAVITINO_ILLEGAL_ARGUMENT,
+            "Incorrect timestamp precision for timestamp("
+                + precision
+                + "), the configured precision is MILLISECONDS;");
+      }
       return Types.TimestampType.withoutTimeZone();
     }
 

--- a/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/catalog/hive/HiveDataTypeTransformer.java
+++ b/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/catalog/hive/HiveDataTypeTransformer.java
@@ -20,6 +20,7 @@
 package org.apache.gravitino.trino.connector.catalog.hive;
 
 import io.trino.spi.TrinoException;
+import io.trino.spi.type.TimestampType;
 import io.trino.spi.type.VarcharType;
 import org.apache.gravitino.rel.types.Type;
 import org.apache.gravitino.rel.types.Types;
@@ -39,6 +40,8 @@ public class HiveDataTypeTransformer extends GeneralDataTypeTransformer {
       throw new TrinoException(
           GravitinoErrorCode.GRAVITINO_UNSUPPORTED_GRAVITINO_DATATYPE,
           "Unsupported gravitino datatype: " + type);
+    } else if (Type.Name.TIMESTAMP == type.name()) {
+      return TimestampType.TIMESTAMP_MILLIS;
     }
     return super.getTrinoType(type);
   }
@@ -72,6 +75,10 @@ public class HiveDataTypeTransformer extends GeneralDataTypeTransformer {
       }
 
       return Types.FixedCharType.of(charType.getLength());
+    } else if (io.trino.spi.type.TimestampType.class.isAssignableFrom(typeClass)) {
+      // When creating a table in Hive, the timestamp data type only supports not specifying
+      // precision, with the default precision being 3 (milliseconds precision)
+      return Types.TimestampType.withoutTimeZone();
     }
 
     return super.getGravitinoType(type);

--- a/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/catalog/iceberg/IcebergDataTypeTransformer.java
+++ b/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/catalog/iceberg/IcebergDataTypeTransformer.java
@@ -49,6 +49,15 @@ public class IcebergDataTypeTransformer extends GeneralDataTypeTransformer {
             "Iceberg does not support the datatype VARCHAR with length");
       }
       return Types.StringType.get();
+    } else if (io.trino.spi.type.TimeType.class.isAssignableFrom(typeClass)) {
+      // Iceberg only supports time type with microsecond (6) precision
+      return Types.TimeType.of(TRINO_MICROS_PRECISION);
+    } else if (io.trino.spi.type.TimestampType.class.isAssignableFrom(typeClass)) {
+      // Iceberg only supports timestamp type (without time zone) with microsecond (6) precision
+      return Types.TimestampType.withoutTimeZone(TRINO_MICROS_PRECISION);
+    } else if (io.trino.spi.type.TimestampWithTimeZoneType.class.isAssignableFrom(typeClass)) {
+      // Iceberg only supports timestamp with time zone type with microsecond (6) precision
+      return Types.TimestampType.withTimeZone(TRINO_MICROS_PRECISION);
     }
 
     return super.getGravitinoType(type);

--- a/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/catalog/jdbc/mysql/MySQLDataTypeTransformer.java
+++ b/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/catalog/jdbc/mysql/MySQLDataTypeTransformer.java
@@ -103,6 +103,15 @@ public class MySQLDataTypeTransformer extends GeneralDataTypeTransformer {
       return Types.VarCharType.of(length);
     } else if (typeClass == JSON_TYPE.getClass()) {
       return Types.ExternalType.of(MySQLExternalDataType.JSON.getMysqlTypeName());
+    } else if (io.trino.spi.type.TimeType.class.isAssignableFrom(typeClass)) {
+      // MySQL only supports time type with second (0) precision
+      return Types.TimeType.of(TRINO_SECONDS_PRECISION);
+    } else if (io.trino.spi.type.TimestampType.class.isAssignableFrom(typeClass)) {
+      // MySQL only supports timestamp type (without time zone) with second (0) precision
+      return Types.TimestampType.withoutTimeZone(TRINO_SECONDS_PRECISION);
+    } else if (io.trino.spi.type.TimestampWithTimeZoneType.class.isAssignableFrom(typeClass)) {
+      // MySQL only supports timestamp with time zone type with second (0) precision
+      return Types.TimestampType.withTimeZone(TRINO_SECONDS_PRECISION);
     }
 
     return super.getGravitinoType(type);

--- a/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/util/GeneralDataTypeTransformer.java
+++ b/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/util/GeneralDataTypeTransformer.java
@@ -59,6 +59,7 @@ public class GeneralDataTypeTransformer {
   // @see
   // https://trino.io/docs/current/language/types.html#date-and-time
   protected static final int TRINO_SECONDS_PRECISION = 0;
+  protected static final int TRINO_MILLIS_PRECISION = 3;
   protected static final int TRINO_MICROS_PRECISION = 6;
   protected static final int TRINO_PICOS_PRECISION = 12;
 

--- a/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/util/GeneralDataTypeTransformer.java
+++ b/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/util/GeneralDataTypeTransformer.java
@@ -55,6 +55,13 @@ import org.apache.gravitino.trino.connector.GravitinoErrorCode;
 /** This class is used to transform datatype between Apache Gravitino and Trino */
 public class GeneralDataTypeTransformer {
 
+  // Trino supports time/timestamp precision from 0 to 12 (picoseconds precision).
+  // @see
+  // https://trino.io/docs/current/language/types.html#date-and-time
+  protected static final int TRINO_SECONDS_PRECISION = 0;
+  protected static final int TRINO_MICROS_PRECISION = 6;
+  protected static final int TRINO_PICOS_PRECISION = 12;
+
   /**
    * Transforms a Gravitino datatype to a Trino datatype.
    *
@@ -108,13 +115,38 @@ public class GeneralDataTypeTransformer {
       case DATE:
         return DATE;
       case TIME:
+        Types.TimeType timeType = (Types.TimeType) type;
+        if (timeType.hasPrecisionSet()) {
+          int precision = timeType.precision();
+          if (precision >= TRINO_SECONDS_PRECISION && precision <= TRINO_PICOS_PRECISION) {
+            return TimeType.createTimeType(precision);
+          } else {
+            throw new TrinoException(
+                GravitinoErrorCode.GRAVITINO_UNSUPPORTED_GRAVITINO_DATATYPE,
+                "Unsupported time precision for Trino: " + precision);
+          }
+        }
+        // default millis (precision 3) to match Trino default precision
         return TimeType.TIME_MILLIS;
       case TIMESTAMP:
-        if (((Types.TimestampType) type).hasTimeZone()) {
-          return TimestampWithTimeZoneType.TIMESTAMP_TZ_MILLIS;
-        } else {
-          return TimestampType.TIMESTAMP_MILLIS;
+        Types.TimestampType timestampType = (Types.TimestampType) type;
+        boolean hasTimeZone = timestampType.hasTimeZone();
+        if (timestampType.hasPrecisionSet()) {
+          int precision = timestampType.precision();
+          if (precision >= TRINO_SECONDS_PRECISION && precision <= TRINO_PICOS_PRECISION) {
+            return hasTimeZone
+                ? TimestampWithTimeZoneType.createTimestampWithTimeZoneType(precision)
+                : TimestampType.createTimestampType(precision);
+          } else {
+            throw new TrinoException(
+                GravitinoErrorCode.GRAVITINO_UNSUPPORTED_GRAVITINO_DATATYPE,
+                "Unsupported timestamp precision for Trino: " + precision);
+          }
         }
+        // default millis (precision 3) to match Trino default precision
+        return hasTimeZone
+            ? TimestampWithTimeZoneType.TIMESTAMP_TZ_MILLIS
+            : TimestampType.TIMESTAMP_MILLIS;
       case LIST:
         return new ArrayType(getTrinoType(((Types.ListType) type).elementType()));
       case MAP:
@@ -191,11 +223,11 @@ public class GeneralDataTypeTransformer {
     } else if (typeClass == io.trino.spi.type.DateType.class) {
       return Types.DateType.get();
     } else if (io.trino.spi.type.TimeType.class.isAssignableFrom(typeClass)) {
-      return Types.TimeType.get();
+      return Types.TimeType.of(((TimeType) type).getPrecision());
     } else if (io.trino.spi.type.TimestampType.class.isAssignableFrom(typeClass)) {
-      return Types.TimestampType.withoutTimeZone();
+      return Types.TimestampType.withoutTimeZone(((TimestampType) type).getPrecision());
     } else if (io.trino.spi.type.TimestampWithTimeZoneType.class.isAssignableFrom(typeClass)) {
-      return Types.TimestampType.withTimeZone();
+      return Types.TimestampType.withTimeZone(((TimestampWithTimeZoneType) type).getPrecision());
     } else if (typeClass == io.trino.spi.type.ArrayType.class) {
       // Ignore nullability for the type, we could only get nullability from column metadata
       return Types.ListType.of(

--- a/trino-connector/trino-connector/src/test/java/org/apache/gravitino/trino/connector/util/TestDataTypeTransformer.java
+++ b/trino-connector/trino-connector/src/test/java/org/apache/gravitino/trino/connector/util/TestDataTypeTransformer.java
@@ -88,13 +88,13 @@ public class TestDataTypeTransformer {
     Assertions.assertEquals(
         dataTypeTransformer.getGravitinoType(DateType.DATE), Types.DateType.get());
     Assertions.assertEquals(
-        dataTypeTransformer.getGravitinoType(TimeType.TIME_MILLIS), Types.TimeType.get());
+        dataTypeTransformer.getGravitinoType(TimeType.TIME_MILLIS), Types.TimeType.of(3));
     Assertions.assertEquals(
         dataTypeTransformer.getGravitinoType(TimestampType.TIMESTAMP_MILLIS),
-        Types.TimestampType.withoutTimeZone());
+        Types.TimestampType.withoutTimeZone(3));
     Assertions.assertEquals(
         dataTypeTransformer.getGravitinoType(TimestampWithTimeZoneType.TIMESTAMP_TZ_MILLIS),
-        Types.TimestampType.withTimeZone());
+        Types.TimestampType.withTimeZone(3));
 
     Assertions.assertEquals(
         dataTypeTransformer.getGravitinoType(new ArrayType(IntegerType.INTEGER)),


### PR DESCRIPTION
### Why are the changes needed?

Fix: #8215 

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

UT already added.
