### PR TITLE
[#8159] improvement(cli): Use toType() instead of toBasicType() for support more complex types

### DIFF
--- a/clients/cli/src/main/java/org/apache/gravitino/cli/ParseType.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/ParseType.java
@@ -76,7 +76,7 @@ public class ParseType {
     Pattern pattern = Pattern.compile("^list\\s*\\(\\s*(.+?)\\s*\\)$");
     Matcher matcher = pattern.matcher(datatype);
     if (matcher.matches()) {
-      Type elementType = toBasicType(matcher.group(1).trim());
+      Type elementType = toType(matcher.group(1).trim());
       return Types.ListType.of(elementType, false);
     }
     throw new IllegalArgumentException("Malformed list type: " + datatype);
@@ -86,8 +86,8 @@ public class ParseType {
     Pattern pattern = Pattern.compile("^map\\s*\\(\\s*(.+?)\\s*,\\s*(.+?)\\s*\\)$");
     Matcher matcher = pattern.matcher(datatype);
     if (matcher.matches()) {
-      Type keyType = toBasicType(matcher.group(1).trim());
-      Type valueType = toBasicType(matcher.group(2).trim());
+      Type keyType = toType(matcher.group(1).trim());
+      Type valueType = toType(matcher.group(2).trim());
       return Types.MapType.of(keyType, valueType, false);
     }
     throw new IllegalArgumentException("Malformed map type: " + datatype);

--- a/clients/cli/src/test/java/org/apache/gravitino/cli/TestParseType.java
+++ b/clients/cli/src/test/java/org/apache/gravitino/cli/TestParseType.java
@@ -118,4 +118,26 @@ public class TestParseType {
     assertThat(keyType, instanceOf(Types.StringType.class));
     assertThat(valueType, instanceOf(Types.IntegerType.class));
   }
+
+  @Test
+  public void testParseTypeNestedList() {
+    Type type = ParseType.toType("list(list(integer))");
+    assertThat(type, instanceOf(Types.ListType.class));
+    Type innerList = ((Types.ListType) type).elementType();
+    assertThat(innerList, instanceOf(Types.ListType.class));
+    Type elementType = ((Types.ListType) innerList).elementType();
+    assertThat(elementType, instanceOf(Types.IntegerType.class));
+  }
+
+  @Test
+  public void testParseTypeMapWithNestedValue() {
+    Type type = ParseType.toType("map(string,list(integer))");
+    assertThat(type, instanceOf(Types.MapType.class));
+    Type keyType = ((Types.MapType) type).keyType();
+    Type valueType = ((Types.MapType) type).valueType();
+    assertThat(keyType, instanceOf(Types.StringType.class));
+    assertThat(valueType, instanceOf(Types.ListType.class));
+    Type elementType = ((Types.ListType) valueType).elementType();
+    assertThat(elementType, instanceOf(Types.IntegerType.class));
+  }
 }


### PR DESCRIPTION

<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

This PR updates the `ParseType` class to support parsing of nested complex types (e.g. `list(list(integer))`, `map(string,list(integer))`).  

### Why are the changes needed?

Currently, the CLI only supports simple types or single-level lists/maps.  
It fails for more complex definitions like `list(list(integer))` or `map(string,list(integer))`.  

Fix: #8159

### Does this PR introduce _any_ user-facing change?

Users can now define more complex schemas in the CLI, such as:
- `list(list(integer))`
- `map(string,list(integer))`

### How was this patch tested?

- Added new unit tests:
  - `testParseTypeNestedList`
  - `testParseTypeMapWithNestedValue`
- Executed existing unit tests