### PR TITLE
[#8203] fix: prevent NPE in CreateTagFailureEvent when TagInfo is null

### DIFF
--- a/core/src/main/java/org/apache/gravitino/listener/api/event/CreateTagFailureEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/CreateTagFailureEvent.java
@@ -40,7 +40,10 @@ public class CreateTagFailureEvent extends TagFailureEvent {
    *     insights into the reasons behind the operation's failure.
    */
   public CreateTagFailureEvent(String user, String metalake, TagInfo tagInfo, Exception exception) {
-    super(user, NameIdentifierUtil.ofTag(metalake, tagInfo.name()), exception);
+    super(
+        user,
+        (tagInfo == null ? null : NameIdentifierUtil.ofTag(metalake, tagInfo.name())),
+        exception);
     this.tagInfo = tagInfo;
   }
 

--- a/core/src/test/java/org/apache/gravitino/listener/api/event/TestTagEvent.java
+++ b/core/src/test/java/org/apache/gravitino/listener/api/event/TestTagEvent.java
@@ -19,14 +19,7 @@
 
 package org.apache.gravitino.listener.api.event;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
 import com.google.common.collect.ImmutableMap;
-import java.util.Arrays;
-import java.util.Map;
-import java.util.Objects;
 import org.apache.gravitino.Entity;
 import org.apache.gravitino.MetadataObject;
 import org.apache.gravitino.NameIdentifier;
@@ -45,6 +38,14 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Objects;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class TestTagEvent {
@@ -339,6 +340,17 @@ public class TestTagEvent {
     Assertions.assertEquals(tag.comment(), ((CreateTagFailureEvent) event).tagInfo().comment());
     Assertions.assertEquals(
         tag.properties(), ((CreateTagFailureEvent) event).tagInfo().properties());
+    Assertions.assertEquals(OperationType.CREATE_TAG, event.operationType());
+    Assertions.assertEquals(OperationStatus.FAILURE, event.operationStatus());
+  }
+
+  @Test
+  public void testNullTagInfoDoesNotThrow() {
+    Exception ex = new Exception("boom");
+    CreateTagFailureEvent event = new CreateTagFailureEvent("user", "metalake", null, ex);
+    Assertions.assertNull(event.tagInfo());
+    Assertions.assertNull(event.identifier());
+    Assertions.assertEquals(ex, event.exception());
     Assertions.assertEquals(OperationType.CREATE_TAG, event.operationType());
     Assertions.assertEquals(OperationStatus.FAILURE, event.operationStatus());
   }

--- a/core/src/test/java/org/apache/gravitino/listener/api/event/TestTagEvent.java
+++ b/core/src/test/java/org/apache/gravitino/listener/api/event/TestTagEvent.java
@@ -19,7 +19,14 @@
 
 package org.apache.gravitino.listener.api.event;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import com.google.common.collect.ImmutableMap;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Objects;
 import org.apache.gravitino.Entity;
 import org.apache.gravitino.MetadataObject;
 import org.apache.gravitino.NameIdentifier;
@@ -38,14 +45,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-
-import java.util.Arrays;
-import java.util.Map;
-import java.util.Objects;
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class TestTagEvent {


### PR DESCRIPTION
### What changes were proposed in this pull request?

- Add null guard in `CreateTagFailureEvent` constructor.  
- Do not construct a `NameIdentifier` when `TagInfo` is null.  
- Ensure `tagInfo()` and `identifier()` return `null` consistently if no `TagInfo` is provided.  
- Added a unit test `testNullTagInfoDoesNotThrow` to verify expected behavior.

### Why are the changes needed?

- Previously, passing a null `TagInfo` caused a `NullPointerException` in the constructor when creating the `NameIdentifier`.  
- This patch prevents the unexpected NPE and ensures that failure events can still be created safely without tag information.  

Fix: #8203

### Does this PR introduce _any_ user-facing change?

- No API changes.  
- Behavioral change: `CreateTagFailureEvent` no longer throws NPE if `TagInfo` is null.  
- In such cases, both `tagInfo()` and `identifier()` return `null`.

### How was this patch tested?

- Added a new test in `CreateTagFailureEventTest` verifying null `TagInfo` does not throw.  
- Verified that events with valid `TagInfo` still construct a proper `NameIdentifier`.  
- Ensured all existing tests continue to pass.