### PR TITLE
[#8205] improvement(client-python): Make GVFS configuration prior to that of catalogs from Gravitino server.

### DIFF
--- a/clients/client-python/gravitino/filesystem/gvfs_storage_handler.py
+++ b/clients/client-python/gravitino/filesystem/gvfs_storage_handler.py
@@ -285,13 +285,25 @@ class S3StorageHandler(StorageHandler):
         """Get the file system with expiration.
         :return: The file system and the expiration time
         """
-        # S3 endpoint from gravitino server, Note: the endpoint may not a real S3 endpoint
-        # it can be a simulated S3 endpoint, such as minio, so though the endpoint is not a required field
-        # for S3FileSystem, we still need to assign the endpoint to the S3FileSystem
-        s3_endpoint = catalog_props.get("s3-endpoint", None) if catalog_props else None
-        # If the s3 endpoint is not found in the fileset catalog, get it from the client options
-        if s3_endpoint is None and options:
-            s3_endpoint = options.get(GVFSConfig.GVFS_FILESYSTEM_S3_ENDPOINT)
+        # S3 endpoint from client options has a higher priority, override the endpoint from catalog properties.
+        # Note: the endpoint may not be a real S3 endpoint, it can be a simulated S3 endpoint, such as minio,
+        # so though the endpoint is not a required field for S3FileSystem, we still need to assign the endpoint
+        # to the S3FileSystem
+        s3_endpoint = None
+        if options:
+            s3_endpoint = (
+                options.get(GVFSConfig.GVFS_FILESYSTEM_S3_ENDPOINT, s3_endpoint)
+                if options
+                else None
+            )
+            if s3_endpoint is None:
+                s3_endpoint = (
+                    catalog_props.get("s3-endpoint", None) if catalog_props else None
+                )
+        else:
+            s3_endpoint = (
+                catalog_props.get("s3-endpoint", None) if catalog_props else None
+            )
 
         if credentials:
             credential = self._get_most_suitable_credential(credentials)
@@ -470,13 +482,22 @@ class OSSStorageHandler(StorageHandler):
         actual_path: Optional[str] = None,
         **kwargs,
     ) -> Tuple[int, AbstractFileSystem]:
-        # OSS endpoint from gravitino server
-        oss_endpoint = (
-            catalog_props.get("oss-endpoint", None) if catalog_props else None
-        )
-        # If the oss endpoint is not found in the fileset catalog, get it from the client options
-        if oss_endpoint is None and options:
-            oss_endpoint = options.get(GVFSConfig.GVFS_FILESYSTEM_OSS_ENDPOINT)
+        oss_endpoint = None
+        # OSS endpoint from client options has a higher priority, override the endpoint from catalog properties.
+        if options:
+            oss_endpoint = (
+                options.get(GVFSConfig.GVFS_FILESYSTEM_OSS_ENDPOINT, oss_endpoint)
+                if options
+                else None
+            )
+            if oss_endpoint is None:
+                oss_endpoint = (
+                    catalog_props.get("oss-endpoint", None) if catalog_props else None
+                )
+        else:
+            oss_endpoint = (
+                catalog_props.get("oss-endpoint", None) if catalog_props else None
+            )
 
         if credentials:
             credential = self._get_most_suitable_credential(credentials)

--- a/clients/client-python/tests/unittests/test_storage_handler.py
+++ b/clients/client-python/tests/unittests/test_storage_handler.py
@@ -1,0 +1,91 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import unittest
+from unittest.mock import patch
+
+from fsspec.implementations.memory import MemoryFileSystem
+
+from gravitino.filesystem.gvfs_storage_handler import S3StorageHandler
+
+
+class TestStorageHandler(unittest.TestCase):
+    def setUp(self):
+        # Set up any necessary state before each test
+        pass
+
+    def tearDown(self):
+        # Clean up after each test
+        pass
+
+    def test_s3_storage_handler(self):
+        s3_storage_handler = S3StorageHandler()
+
+        # Mock the get_filesystem method to return a mock filesystem
+        mock_filesystem = MemoryFileSystem()
+        captured_args = {}
+
+        def capture_args_and_return_mock(*args, **kwargs):
+            captured_args.update(
+                {
+                    "key": kwargs.get("key"),
+                    "secret": kwargs.get("secret"),
+                    "endpoint_url": kwargs.get("endpoint_url"),
+                }
+            )
+            return mock_filesystem
+
+        with patch.object(
+            s3_storage_handler,
+            "get_filesystem",
+            side_effect=capture_args_and_return_mock,
+        ):
+            result = s3_storage_handler.get_filesystem_with_expiration(
+                [],
+                {
+                    "s3-endpoint": "endpoint_from_catalog",
+                },
+                {
+                    "s3_endpoint": "endpoint_from_client",
+                    "s3_access_key_id": "access_key_from_client",
+                    "s3_secret_access_key": "secret_key_from_client",
+                },
+                None,
+            )
+
+            self.assertEqual(result[1], mock_filesystem)
+            self.assertEqual(captured_args["key"], "access_key_from_client")
+            self.assertEqual(captured_args["secret"], "secret_key_from_client")
+            self.assertEqual(captured_args["endpoint_url"], "endpoint_from_client")
+
+            captured_args = {}
+            result = s3_storage_handler.get_filesystem_with_expiration(
+                [],
+                {
+                    "s3-endpoint": "endpoint_from_catalog",
+                },
+                {
+                    "s3_access_key_id": "access_key_from_client",
+                    "s3_secret_access_key": "secret_key_from_client",
+                },
+                None,
+            )
+
+            self.assertEqual(result[1], mock_filesystem)
+            self.assertEqual(captured_args["key"], "access_key_from_client")
+            self.assertEqual(captured_args["secret"], "secret_key_from_client")
+            self.assertEqual(captured_args["endpoint_url"], "endpoint_from_catalog")


### PR DESCRIPTION
### What changes were proposed in this pull request?

Configurations from GVFS clients will override those from Gravitino server.


### Why are the changes needed?

Let the user customize their own settings.

Fix: #8205 

### Does this PR introduce _any_ user-facing change?

N/A.

### How was this patch tested?

UT and existing tests. 