### PR TITLE
[#8168] Fix NPE in EntityCombinedFileset by initializing hiddenProperties field

### DIFF
--- a/core/src/main/java/org/apache/gravitino/catalog/EntityCombinedFileset.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/EntityCombinedFileset.java
@@ -18,6 +18,7 @@
  */
 package org.apache.gravitino.catalog;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -33,7 +34,7 @@ public final class EntityCombinedFileset implements Fileset {
   private final FilesetEntity filesetEntity;
 
   // Sets of properties that should be hidden from the user.
-  private Set<String> hiddenProperties;
+  private Set<String> hiddenProperties = Collections.emptySet();
 
   private EntityCombinedFileset(Fileset fileset, FilesetEntity filesetEntity) {
     this.fileset = fileset;
@@ -57,7 +58,7 @@ public final class EntityCombinedFileset implements Fileset {
   }
 
   public EntityCombinedFileset withHiddenProperties(Set<String> hiddenProperties) {
-    this.hiddenProperties = hiddenProperties;
+    this.hiddenProperties = hiddenProperties != null ? hiddenProperties : Collections.emptySet();
     return this;
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
In `EntityCombinedFileset.java`, the `properties()` method directly called `hiddenProperties.contains()` without null checking, which could throw a `NullPointerException` if `hiddenProperties` was not initialized. This PR updates the code to initialize `hiddenProperties` with an empty set and adds null-safe handling in the `withHiddenProperties()` method.

### Why are the changes needed?
Without this fix, calling `properties()` on an `EntityCombinedFileset` instance before setting hidden properties could cause NPEs, breaking fileset property retrieval. Adding proper initialization ensures that the object is always in a valid state and handles missing hidden properties gracefully.

Fixes #8168

### Does this PR introduce any user-facing change?
No. Valid requests behave the same. Cases where `hiddenProperties` was not explicitly set are now safely handled without throwing exceptions.

### How was this patch tested?
* Added unit tests to verify that calling `properties()` without setting hidden properties does not cause exceptions
* Added tests to ensure null input to `withHiddenProperties()` is handled safely
* Added tests to verify that hidden property filtering works correctly when properties are set
* Verified that existing functionality remains unchanged