### PR TITLE
[#8218] fix(doris): Fix BUCKETS AUTO parsing for RANDOM distribution

### DIFF
--- a/catalogs/catalog-jdbc-doris/src/main/java/org/apache/gravitino/catalog/doris/utils/DorisUtils.java
+++ b/catalogs/catalog-jdbc-doris/src/main/java/org/apache/gravitino/catalog/doris/utils/DorisUtils.java
@@ -221,7 +221,7 @@ public final class DorisUtils {
 
   private static int extractBucketNum(Matcher matcher) {
     int bucketNum = 1;
-    if (matcher.find(5)) {
+    if (matcher.group(5) != null) {
       String bucketValue = matcher.group(5);
       // Use -1 to indicate auto bucket.
       bucketNum =

--- a/catalogs/catalog-jdbc-doris/src/test/java/org/apache/gravitino/catalog/doris/converter/TestDorisExceptionConverter.java
+++ b/catalogs/catalog-jdbc-doris/src/test/java/org/apache/gravitino/catalog/doris/converter/TestDorisExceptionConverter.java
@@ -46,5 +46,16 @@ public class TestDorisExceptionConverter {
     Assertions.assertEquals(
         DorisExceptionConverter.CODE_NO_SUCH_TABLE,
         DorisExceptionConverter.getErrorCodeFromMessage(msg));
+
+    msg = "errCode = 2, detailMessage = Syntax error in line 3: unexpected token: AUTO";
+    Assertions.assertEquals(
+        DorisExceptionConverter.CODE_BUCKETS_AUTO_NOT_SUPPORTED,
+        DorisExceptionConverter.getErrorCodeFromMessage(msg));
+
+    msg =
+        "You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'AUTO' at line 1";
+    Assertions.assertEquals(
+        DorisExceptionConverter.CODE_BUCKETS_AUTO_NOT_SUPPORTED,
+        DorisExceptionConverter.getErrorCodeFromMessage(msg));
   }
 }

--- a/catalogs/catalog-jdbc-doris/src/test/java/org/apache/gravitino/catalog/doris/utils/TestDorisUtils.java
+++ b/catalogs/catalog-jdbc-doris/src/test/java/org/apache/gravitino/catalog/doris/utils/TestDorisUtils.java
@@ -184,5 +184,11 @@ public class TestDorisUtils {
         "CREATE TABLE `testTable` (\n`col1` date NOT NULL\n) ENGINE=OLAP\n PARTITION BY RANGE(`col1`)\n()\n DISTRIBUTED BY HASH(`col1`) BUCKETS AUTO";
     Distribution distribution2 = DorisUtils.extractDistributionInfoFromSql(createTableSqlWithAuto);
     assertEquals(distribution2.number(), -1);
+
+    String createTableSqlWithRandomAuto =
+        "CREATE TABLE `testTable` (\n`col1` date NOT NULL\n) ENGINE=OLAP\n PARTITION BY RANGE(`col1`)\n()\n DISTRIBUTED BY RANDOM BUCKETS AUTO";
+    Distribution distribution3 =
+        DorisUtils.extractDistributionInfoFromSql(createTableSqlWithRandomAuto);
+    assertEquals(distribution3.number(), -1);
   }
 }


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Fixed the `DorisUtils.extractBucketNum()` method to properly handle `BUCKETS AUTO` parsing for `DISTRIBUTED BY RANDOM` statements. The method was incorrectly calling `matcher.find(5)` which advances the matcher position, causing the bucket value extraction to fail and resulting in a `NumberFormatException` when parsing null values.

**Changes:**
- Changed `if (matcher.find(5))` to `if (matcher.group(5) != null)` in `DorisUtils.extractBucketNum()`
- Added test case for `DISTRIBUTED BY RANDOM BUCKETS AUTO` in `TestDorisUtils.testDistributedInfoPattern()`

### Why are the changes needed?

This fixes a critical bug where Doris table operations fail when encountering `DISTRIBUTED BY RANDOM BUCKETS AUTO` syntax. The root cause was that `matcher.find(5)` advances the matcher position after the initial match, and since there are no subsequent matches, it returns `false` and never reaches the bucket value extraction logic. This leaves `bucketValue` as null, causing `Integer.valueOf(bucketValue)` to throw `NumberFormatException: Cannot parse null string`.

The bug affects users trying to load tables with auto bucket distribution using random strategy, which is a valid Doris SQL syntax.

  Fix: #8218 

### Does this PR introduce _any_ user-facing change?

No user-facing API changes. This is a bug fix that enables proper parsing of existing Doris SQL syntax that was previously failing. Users can now successfully work with tables using `DISTRIBUTED BY RANDOM BUCKETS AUTO` without encountering parsing errors.

### How was this patch tested?


1. **Existing tests**: Verified all existing Doris utility tests continue to pass, ensuring no regression
2. **New test case**: Added `TestDorisUtils.testDistributedInfoPattern()` test case specifically for `DISTRIBUTED BY RANDOM BUCKETS AUTO` to prevent future regressions
3. **Manual verification**: Created and ran a standalone test to reproduce the original bug and verify the fix resolves the `NumberFormatException`
4. **Code formatting**: Applied Spotless formatting to ensure code style compliance

**Test command:**
```
./gradlew :catalogs:catalog-jdbc-doris:test --tests="*TestDorisUtils*"
```

All tests pass successfully with the fix applied.
