### PR TITLE
[#8200] improvement(core): throw exception when unlocking without an active lock in TreeLock

### DIFF
--- a/core/src/main/java/org/apache/gravitino/lock/TreeLock.java
+++ b/core/src/main/java/org/apache/gravitino/lock/TreeLock.java
@@ -143,6 +143,9 @@ public class TreeLock {
     if (lockType == null) {
       throw new IllegalStateException("We must lock the tree lock before unlock it.");
     }
+    if (heldLocks.isEmpty()) {
+      throw new IllegalStateException("We must hold a lock before unlocking it.");
+    }
 
     while (!heldLocks.isEmpty()) {
       Pair<TreeLockNode, LockType> pair = heldLocks.pop();

--- a/core/src/test/java/org/apache/gravitino/lock/TestTreeLock.java
+++ b/core/src/test/java/org/apache/gravitino/lock/TestTreeLock.java
@@ -102,4 +102,11 @@ class TestTreeLock {
     Mockito.verify(mockNode2, Mockito.never()).unlock(Mockito.any());
     Mockito.verify(mockNode3, Mockito.never()).unlock(Mockito.any());
   }
+
+  @Test
+  void testDoubleUnlockThrows() {
+    lock.lock(LockType.READ);
+    lock.unlock();
+    assertThrows(IllegalStateException.class, () -> lock.unlock());
+  }
 }


### PR DESCRIPTION

<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Added a check in `TreeLock.unlock()` to throw `IllegalStateException` when `unlock()` is called without any active lock.  

### Why are the changes needed?

Previously, calling `unlock()` without holding a lock (e.g., double unlock) was silently ignored, which could hide logic errors in lock handling.  

Fix: #8200

### Does this PR introduce _any_ user-facing change?

Yes.  
  1. Users calling `unlock()` without an active lock will now receive an `IllegalStateException`.

### How was this patch tested?

  1. Added a unit test `testDoubleUnlockThrows()` verifying that a second `unlock()` call throws `IllegalStateException`
  2. Executed existing unit tests
