### PR TITLE
[#8196]Improvement(TableDto): validation in TableDTO Builder

### DIFF
--- a/common/src/main/java/org/apache/gravitino/dto/rel/TableDTO.java
+++ b/common/src/main/java/org/apache/gravitino/dto/rel/TableDTO.java
@@ -296,6 +296,8 @@ public class TableDTO implements Table {
     public TableDTO build() {
       Preconditions.checkArgument(name != null && !name.isEmpty(), "name cannot be null or empty");
       Preconditions.checkArgument(audit != null, "audit cannot be null");
+      Preconditions.checkArgument(
+          columns != null && columns.length > 0, "columns cannot be null or empty");
 
       return new TableDTO(
           name,

--- a/common/src/test/java/org/apache/gravitino/dto/rel/TestTableDTO.java
+++ b/common/src/test/java/org/apache/gravitino/dto/rel/TestTableDTO.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.gravitino.dto.rel;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;

--- a/common/src/test/java/org/apache/gravitino/dto/rel/TestTableDTO.java
+++ b/common/src/test/java/org/apache/gravitino/dto/rel/TestTableDTO.java
@@ -1,0 +1,39 @@
+package org.apache.gravitino.dto.rel;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.time.Instant;
+import org.apache.gravitino.dto.AuditDTO;
+import org.apache.gravitino.rel.types.Types;
+import org.junit.jupiter.api.Test;
+
+public class TestTableDTO {
+  @Test
+  public void testBuildWithoutColumns() {
+    AuditDTO audit =
+        AuditDTO.builder().withCreator("creator").withCreateTime(Instant.now()).build();
+    TableDTO.Builder<?> builder = TableDTO.builder().withName("t1").withAudit(audit);
+    assertThrows(IllegalArgumentException.class, builder::build);
+  }
+
+  @Test
+  public void testBuildWithEmptyColumns() {
+    AuditDTO audit =
+        AuditDTO.builder().withCreator("creator").withCreateTime(Instant.now()).build();
+    TableDTO.Builder<?> builder =
+        TableDTO.builder().withName("t1").withAudit(audit).withColumns(new ColumnDTO[0]);
+    assertThrows(IllegalArgumentException.class, builder::build);
+  }
+
+  @Test
+  public void testBuildWithColumns() {
+    AuditDTO audit =
+        AuditDTO.builder().withCreator("creator").withCreateTime(Instant.now()).build();
+    ColumnDTO column =
+        ColumnDTO.builder().withName("c1").withDataType(Types.IntegerType.get()).build();
+    TableDTO.Builder<?> builder =
+        TableDTO.builder().withName("t1").withAudit(audit).withColumns(new ColumnDTO[] {column});
+    assertDoesNotThrow(builder::build);
+  }
+}


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?
Added missing validation to TableDTO.Builder.build() to make sure the table has a non-null, non-empty column list before construction,


### Why are the changes needed?
Improvement to make sure the table has a non-null, non-empty column list before construction,


Fix: #8196 

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
unit testing

