### PR TITLE
[MINOR] improve(mcp):  change the tag of metadata tool to tag and policy

### DIFF
--- a/mcp-server/mcp_server/main.py
+++ b/mcp-server/mcp_server/main.py
@@ -75,8 +75,9 @@ def _parse_args():
         "--include-tool-tags",
         type=_comma_separated_set,
         default=set(),
-        help="The tool tags to include, separated by commas, support tags:[catalog, schema, table]. "
-        "(default: empty, all tools will be included).",
+        help="The tool tags to include, separated by commas, support tags:[catalog, "
+        "schema, table, topic, model, fileset, tag, policy]. default: empty, "
+        "all tools will be included).",
     )
 
     parser.add_argument(

--- a/mcp-server/mcp_server/tools/metadata.py
+++ b/mcp-server/mcp_server/tools/metadata.py
@@ -19,7 +19,7 @@ from fastmcp import Context, FastMCP
 
 
 def load_metadata_tool(mcp: FastMCP):
-    @mcp.tool(tags={"metadata"})
+    @mcp.tool(tags={"tag", "policy"})
     async def metadata_type_to_fullname_formats(ctx: Context) -> dict:
         """
         Get metadata type to full name formats.


### PR DESCRIPTION

### What changes were proposed in this pull request?

change the tag of metadata tool to `tag` and `policy` 


### Why are the changes needed?

metadata tool is used only for `tag` and `policy` 


### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?

testing whether export metadata tools for tag and policy
