### PR TITLE
[#8207] feat(cli): add validate method to OwnerDetails to check entityType

### DIFF
--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/OwnerDetails.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/OwnerDetails.java
@@ -90,7 +90,7 @@ public class OwnerDetails extends Command {
 
   @Override
   public Command validate() {
-    if( entityType == null ) exitWithError(ErrorMessages.UNKNOWN_ENTITY);
+    if (entityType == null) exitWithError(ErrorMessages.UNKNOWN_ENTITY);
     return this;
   }
 }

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/OwnerDetails.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/OwnerDetails.java
@@ -87,4 +87,10 @@ public class OwnerDetails extends Command {
       printInformation("No owner");
     }
   }
+
+  @Override
+  public Command validate() {
+    if( entityType == null ) exitWithError(ErrorMessages.UNKNOWN_ENTITY);
+    return this;
+  }
 }

--- a/clients/cli/src/test/java/org/apache/gravitino/cli/command/TestOwnerDetails.java
+++ b/clients/cli/src/test/java/org/apache/gravitino/cli/command/TestOwnerDetails.java
@@ -1,0 +1,36 @@
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+
+import com.github.stefanbirkner.systemrules.ExpectedSystemExit;
+import org.apache.gravitino.cli.command.Command;
+import org.apache.gravitino.cli.command.CommandContext;
+import org.apache.gravitino.cli.command.CommandEntities;
+import org.apache.gravitino.cli.command.OwnerDetails;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class TestOwnerDetails {
+
+  @Rule public final ExpectedSystemExit exit = ExpectedSystemExit.none();
+
+  @Test
+  public void testValidate_withValidEntityType() {
+    CommandContext context = new CommandContext();
+    OwnerDetails details = new OwnerDetails(context, "metalake1", "entity1", CommandEntities.TABLE);
+
+    Command result = details.validate();
+
+    assertNotNull(result);
+    assertSame(details, result);
+  }
+
+  @Test
+  public void testValidate_withInvalidEntityType_shouldExit() {
+    CommandContext context = new CommandContext();
+    OwnerDetails details = new OwnerDetails(context, "metalake1", "entity1", "INVALID_TYPE");
+
+    exit.expectSystemExitWithStatus(-1);
+
+    details.validate(); // triggers exit(-1)
+  }
+}

--- a/clients/cli/src/test/java/org/apache/gravitino/cli/command/TestOwnerDetails.java
+++ b/clients/cli/src/test/java/org/apache/gravitino/cli/command/TestOwnerDetails.java
@@ -1,36 +1,72 @@
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertSame;
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.cli.command;
 
-import com.github.stefanbirkner.systemrules.ExpectedSystemExit;
-import org.apache.gravitino.cli.command.Command;
-import org.apache.gravitino.cli.command.CommandContext;
-import org.apache.gravitino.cli.command.CommandEntities;
-import org.apache.gravitino.cli.command.OwnerDetails;
-import org.junit.Rule;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.gravitino.cli.CommandContext;
+import org.apache.gravitino.cli.CommandEntities;
+import org.apache.gravitino.cli.Main;
+import org.apache.gravitino.cli.commands.Command;
+import org.apache.gravitino.cli.commands.OwnerDetails;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 public class TestOwnerDetails {
 
-  @Rule public final ExpectedSystemExit exit = ExpectedSystemExit.none();
+  private CommandContext context;
+
+  @Before
+  public void setUp() {
+    CommandLine mockCommandLine = Mockito.mock(CommandLine.class);
+    context = new CommandContext(mockCommandLine);
+    Main.useExit = false;
+  }
+
+  @After
+  public void tearDown() {
+    Main.useExit = true;
+  }
 
   @Test
-  public void testValidate_withValidEntityType() {
-    CommandContext context = new CommandContext();
-    OwnerDetails details = new OwnerDetails(context, "metalake1", "entity1", CommandEntities.TABLE);
-
-    Command result = details.validate();
-
+  public void testValidate_withValidEntityType_shouldPass() {
+    OwnerDetails command = new OwnerDetails(context, "metalake1", "entity1", CommandEntities.TABLE);
+    Command result = command.validate();
     assertNotNull(result);
-    assertSame(details, result);
+    assertEquals(command, result);
   }
 
   @Test
   public void testValidate_withInvalidEntityType_shouldExit() {
-    CommandContext context = new CommandContext();
-    OwnerDetails details = new OwnerDetails(context, "metalake1", "entity1", "INVALID_TYPE");
+    OwnerDetails command = new OwnerDetails(context, "metalake1", "entity1", "INVALID_TYPE");
 
-    exit.expectSystemExitWithStatus(-1);
-
-    details.validate(); // triggers exit(-1)
+    try {
+      command.validate();
+      fail("Expected RuntimeException due to intercepted exit");
+    } catch (RuntimeException e) {
+      assertTrue(e.getMessage().contains("Exit with code"));
+    }
   }
 }

--- a/flink-connector/flink/src/main/java/org/apache/gravitino/flink/connector/store/GravitinoCatalogStore.java
+++ b/flink-connector/flink/src/main/java/org/apache/gravitino/flink/connector/store/GravitinoCatalogStore.java
@@ -66,11 +66,20 @@ public class GravitinoCatalogStore extends AbstractCatalogStore {
         catalogFactory.gravitinoCatalogProvider(),
         gravitinoProperties);
   }
-
+  /**
+   * Removes the specified catalog.
+   *
+   * @param catalogName name of the catalog to remove
+   * @param ignoreIfNotExists if true, ignore when the catalog does not exist
+   * @throws CatalogException if the catalog cannot be removed
+   */
   @Override
   public void removeCatalog(String catalogName, boolean ignoreIfNotExists) throws CatalogException {
     try {
-      gravitinoCatalogManager.dropCatalog(catalogName);
+      boolean isDropped = gravitinoCatalogManager.dropCatalog(catalogName);
+      if (!ignoreIfNotExists && !isDropped) {
+        throw new CatalogException(String.format("Failed to remove the catalog: %s", catalogName));
+      }
     } catch (Exception e) {
       throw new CatalogException(String.format("Failed to remove the catalog: %s", catalogName), e);
     }

--- a/flink-connector/flink/src/test/java/org/apache/gravitino/flink/connector/store/TestGravitinoCatalogStore.java
+++ b/flink-connector/flink/src/test/java/org/apache/gravitino/flink/connector/store/TestGravitinoCatalogStore.java
@@ -1,0 +1,79 @@
+package org.apache.gravitino.flink.connector.store;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.apache.flink.table.catalog.exceptions.CatalogException;
+import org.apache.gravitino.flink.connector.catalog.GravitinoCatalogManager;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestGravitinoCatalogStore {
+  private GravitinoCatalogManager gravitinoCatalogMockManager;
+  private GravitinoCatalogStore gravitinoCatalogStore;
+
+  @Before
+  public void setupCatalogStore() {
+    gravitinoCatalogMockManager = mock(GravitinoCatalogManager.class);
+    gravitinoCatalogStore = new GravitinoCatalogStore(gravitinoCatalogMockManager);
+  }
+
+  @Test
+  public void testRemoveCatalog_whenCatalogExists_shouldSucceed() {
+    String catalogName = "testCatalog";
+    when(gravitinoCatalogMockManager.dropCatalog(catalogName)).thenReturn(true);
+    try {
+      gravitinoCatalogStore.removeCatalog(catalogName, false);
+    } catch (Exception e) {
+      fail("Expected no exception, but got: " + e.getMessage());
+    }
+    verify(gravitinoCatalogMockManager).dropCatalog(catalogName);
+  }
+
+  @Test
+  public void testRemoveCatalog_whenCatalogNotExists_ignoreFlagTrue_shouldNotThrow() {
+    String catalogName = "missingCatalog";
+    when(gravitinoCatalogMockManager.dropCatalog(catalogName)).thenReturn(false);
+    try {
+      gravitinoCatalogStore.removeCatalog(catalogName, true);
+    } catch (Exception e) {
+      fail("Expected no exception, but got: " + e.getMessage());
+    }
+    verify(gravitinoCatalogMockManager).dropCatalog(catalogName);
+  }
+
+  @Test
+  public void testRemoveCatalog_whenCatalogNotExists_ignoreFlagFalse_shouldThrow() {
+    String catalogName = "missingCatalog";
+    when(gravitinoCatalogMockManager.dropCatalog(catalogName)).thenReturn(false);
+    try {
+      gravitinoCatalogStore.removeCatalog(catalogName, false);
+      fail("Expected CatalogException to be thrown");
+    } catch (CatalogException e) {
+      assertTrue(
+          "Expected failure message to contain 'Failed to remove the catalog:'",
+          e.getMessage().contains("Failed to remove the catalog:"));
+    }
+    verify(gravitinoCatalogMockManager).dropCatalog(catalogName);
+  }
+
+  @Test
+  public void testRemoveCatalog_UnexpectedException_shouldThrow() {
+    String catalogName = "errorCatalog";
+    when(gravitinoCatalogMockManager.dropCatalog(catalogName))
+        .thenThrow(new RuntimeException("UnexpectedErrorOccurred"));
+    try {
+      gravitinoCatalogStore.removeCatalog(catalogName, false);
+      fail("Expected CatalogException to be thrown");
+    } catch (CatalogException e) {
+      assertTrue(
+          "Expected failure message to contain 'Failed to remove the catalog:'",
+          e.getMessage().contains("Failed to remove the catalog:"));
+      assertTrue("Expected cause to be RuntimeException", e.getCause() instanceof RuntimeException);
+    }
+    verify(gravitinoCatalogMockManager).dropCatalog(catalogName);
+  }
+}

--- a/flink-connector/flink/src/test/java/org/apache/gravitino/flink/connector/store/TestGravitinoCatalogStore.java
+++ b/flink-connector/flink/src/test/java/org/apache/gravitino/flink/connector/store/TestGravitinoCatalogStore.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.gravitino.flink.connector.store;
 
 import static org.junit.Assert.assertTrue;


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR adds a ```validate()``` method to the OwnerDetails class in the Gravitino CLI module. The method ensures that entityType is not null before proceeding with command execution. If entityType is null, the CLI exits with a descriptive error message using ```ErrorMessages.UNKNOWN_ENTITY```.
This change improves input validation and prevents unexpected behavior during command handling.

## Why are the changes needed?
Without validation, commands may proceed with a null entityType, leading to runtime errors or unclear failures. This update:
- Adds a safeguard against null entityType
- Aligns with validation patterns used in other CLI components
- Enhances user experience with clearer error messaging
Fix: #8207

## Does this PR introduce any user-facing change?
Yes:
- Users will now receive a clear error message if they attempt to run a command without specifying a valid entity type.
- The CLI will exit gracefully with ErrorMessages.UNKNOWN_ENTITY when validation fails.

## How was this patch tested?
- Added a unit test to verify that validate() exits with an error when entityType is null.
- Confirmed that valid OwnerDetails instances pass validation successfully.
