### PR TITLE
Fix early return in GroupMetaService.updateGroup ignoring non-role changes

### DIFF
--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/GroupMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/GroupMetaService.java
@@ -218,9 +218,9 @@ public class GroupMetaService {
                   mapper ->
                       mapper.updateGroupMeta(
                           POConverters.updateGroupPOWithVersion(oldGroupPO, newEntity),
-                          oldGroupPO)), // 항상 그룹 메타데이터 업데이트
+                          oldGroupPO)),
           () -> {
-            if (!insertRoleIds.isEmpty()) { // 추가할 역할이 있을 때만 실행
+            if (!insertRoleIds.isEmpty()) {
               SessionUtils.doWithoutCommit(
                   GroupRoleRelMapper.class,
                   mapper ->
@@ -230,7 +230,7 @@ public class GroupMetaService {
             }
           },
           () -> {
-            if (!deleteRoleIds.isEmpty()) { // 삭제할 역할이 있을 때만 실행
+            if (!deleteRoleIds.isEmpty()) {
               SessionUtils.doWithoutCommit(
                   GroupRoleRelMapper.class,
                   mapper ->

--- a/core/src/test/java/org/apache/gravitino/storage/relational/service/TestGroupMetaService.java
+++ b/core/src/test/java/org/apache/gravitino/storage/relational/service/TestGroupMetaService.java
@@ -675,7 +675,7 @@ class TestGroupMetaService extends TestJDBCBackend {
     Assertions.assertEquals(
         Sets.newHashSet(role1.id(), role4.id()), Sets.newHashSet(noUpdaterGroup.roleIds()));
     Assertions.assertEquals("creator", noUpdaterGroup.auditInfo().creator());
-    Assertions.assertEquals("grantRevokeUser", noUpdaterGroup.auditInfo().lastModifier());
+    Assertions.assertEquals("noUpdateUser", noUpdaterGroup.auditInfo().lastModifier());
 
     // Delete a role, the group entity won't contain this role.
     RoleMetaService.getInstance().deleteRole(role1.nameIdentifier());

--- a/core/src/test/java/org/apache/gravitino/storage/relational/service/TestGroupMetaService.java
+++ b/core/src/test/java/org/apache/gravitino/storage/relational/service/TestGroupMetaService.java
@@ -1012,4 +1012,46 @@ class TestGroupMetaService extends TestJDBCBackend {
     }
     return count;
   }
+
+  @Test
+  void updateGroupWithoutRoleChange() throws IOException {
+    AuditInfo auditInfo =
+        AuditInfo.builder().withCreator("creator").withCreateTime(Instant.now()).build();
+    BaseMetalake metalake =
+        createBaseMakeLake(RandomIdGenerator.INSTANCE.nextId(), metalakeName, auditInfo);
+    backend.insert(metalake, false);
+
+    GroupMetaService groupMetaService = GroupMetaService.getInstance();
+
+    GroupEntity group1 =
+        createGroupEntity(
+            RandomIdGenerator.INSTANCE.nextId(),
+            AuthorizationUtils.ofGroupNamespace(metalakeName),
+            "group1",
+            auditInfo);
+    groupMetaService.insertGroup(group1, false);
+
+    Function<GroupEntity, GroupEntity> renameUpdater =
+        group ->
+            GroupEntity.builder()
+                .withNamespace(group.namespace())
+                .withId(group.id())
+                .withName("group_renamed") // 이름만 변경
+                .withRoleNames(group.roleNames())
+                .withRoleIds(group.roleIds())
+                .withAuditInfo(group.auditInfo())
+                .build();
+    groupMetaService.updateGroup(group1.nameIdentifier(), renameUpdater);
+
+    // 기존 이름으로는 찾을 수 없어야 함
+    Assertions.assertThrows(
+        NoSuchEntityException.class,
+        () -> groupMetaService.getGroupByIdentifier(group1.nameIdentifier()));
+
+    // 새 이름으로는 찾을 수 있어야 함
+    GroupEntity updated =
+        groupMetaService.getGroupByIdentifier(
+            AuthorizationUtils.ofGroup(metalakeName, "group_renamed"));
+    Assertions.assertEquals("group_renamed", updated.name());
+  }
 }

--- a/core/src/test/java/org/apache/gravitino/storage/relational/service/TestGroupMetaService.java
+++ b/core/src/test/java/org/apache/gravitino/storage/relational/service/TestGroupMetaService.java
@@ -1036,19 +1036,17 @@ class TestGroupMetaService extends TestJDBCBackend {
             GroupEntity.builder()
                 .withNamespace(group.namespace())
                 .withId(group.id())
-                .withName("group_renamed") // 이름만 변경
+                .withName("group_renamed")
                 .withRoleNames(group.roleNames())
                 .withRoleIds(group.roleIds())
                 .withAuditInfo(group.auditInfo())
                 .build();
     groupMetaService.updateGroup(group1.nameIdentifier(), renameUpdater);
 
-    // 기존 이름으로는 찾을 수 없어야 함
     Assertions.assertThrows(
         NoSuchEntityException.class,
         () -> groupMetaService.getGroupByIdentifier(group1.nameIdentifier()));
 
-    // 새 이름으로는 찾을 수 있어야 함
     GroupEntity updated =
         groupMetaService.getGroupByIdentifier(
             AuthorizationUtils.ofGroup(metalakeName, "group_renamed"));


### PR DESCRIPTION
**What changes were proposed in this pull request?**
In `GroupMetaService.java`, the `updateGroup` method had an early return when there were no role changes (`insertRoleIds.isEmpty() && deleteRoleIds.isEmpty()`), which caused other group changes like name updates or audit info modifications to be ignored. This PR removes the early return logic and ensures that group metadata is always updated, while role-specific operations are only performed when necessary.

**Why are the changes needed?**
Without this fix, updating a group's name or other non-role properties would be silently ignored if there were no role changes, leading to inconsistent behavior. Users expecting group renames or audit info updates would find their changes were not persisted to the database.

Fixes #8201

**Does this PR introduce any user-facing change?**
No. Valid requests now behave correctly where they previously failed silently. Group updates that don't involve role changes will now work as expected.

**How was this patch tested?**
* Added unit test `updateGroupWithoutRoleChange()` to verify that group name changes work without role modifications
* Verified that the test fails with the old code and passes with the fix
* Confirmed that existing role-based update functionality remains unchanged
* All existing tests continue to pass, ensuring no regression in role management features