### PR TITLE
[#8195] fix(flink-jdbc): validate required 'jdbc-url' in toFlinkCatalogProperties to prevent NPE

### DIFF
--- a/flink-connector/flink/src/main/java/org/apache/gravitino/flink/connector/jdbc/JdbcPropertiesConverter.java
+++ b/flink-connector/flink/src/main/java/org/apache/gravitino/flink/connector/jdbc/JdbcPropertiesConverter.java
@@ -49,7 +49,10 @@ public abstract class JdbcPropertiesConverter implements PropertiesConverter {
         PropertiesConverter.super.toFlinkCatalogProperties(gravitinoProperties);
     String gravitinoJdbcUrl = gravitinoProperties.get(JdbcPropertiesConstants.GRAVITINO_JDBC_URL);
     Preconditions.checkArgument(
-        gravitinoJdbcUrl != null, "Cannot create a catalog properties with null jdbc-url");
+        gravitinoJdbcUrl != null,
+        "Cannot create catalog properties: missing '"
+            + JdbcPropertiesConstants.GRAVITINO_JDBC_URL
+            + "'.");
 
     // The URL in FlinkJdbcCatalog does not support database and other parameters.
     flinkCatalogProperties.put(

--- a/flink-connector/flink/src/main/java/org/apache/gravitino/flink/connector/jdbc/JdbcPropertiesConverter.java
+++ b/flink-connector/flink/src/main/java/org/apache/gravitino/flink/connector/jdbc/JdbcPropertiesConverter.java
@@ -48,6 +48,9 @@ public abstract class JdbcPropertiesConverter implements PropertiesConverter {
     Map<String, String> flinkCatalogProperties =
         PropertiesConverter.super.toFlinkCatalogProperties(gravitinoProperties);
     String gravitinoJdbcUrl = gravitinoProperties.get(JdbcPropertiesConstants.GRAVITINO_JDBC_URL);
+    Preconditions.checkArgument(
+        gravitinoJdbcUrl != null, "Cannot create a catalog properties with null jdbc-url");
+
     // The URL in FlinkJdbcCatalog does not support database and other parameters.
     flinkCatalogProperties.put(
         JdbcPropertiesConstants.FLINK_JDBC_URL, getBaseUrlFromJdbcUrl(gravitinoJdbcUrl));

--- a/flink-connector/flink/src/test/java/org/apache/gravitino/flink/connector/jdbc/AbstractJdbcPropertiesConverterTestSuite.java
+++ b/flink-connector/flink/src/test/java/org/apache/gravitino/flink/connector/jdbc/AbstractJdbcPropertiesConverterTestSuite.java
@@ -153,4 +153,19 @@ public abstract class AbstractJdbcPropertiesConverterTestSuite {
     Assertions.assertEquals(
         testDriver, properties.get(JdbcPropertiesConstants.GRAVITINO_JDBC_DRIVER));
   }
+
+  @Test
+  public void testToJdbcCatalogPropertiesWithoutUrl() {
+    Map<String, String> catalogPropertiesWithoutUrl = new HashMap<>(catalogProperties);
+    catalogPropertiesWithoutUrl.remove(JdbcPropertiesConstants.GRAVITINO_JDBC_URL);
+
+    IllegalArgumentException ex =
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                getConverter(catalogPropertiesWithoutUrl)
+                    .toFlinkCatalogProperties(catalogPropertiesWithoutUrl));
+
+    Assertions.assertTrue(ex.getMessage().contains(JdbcPropertiesConstants.GRAVITINO_JDBC_URL));
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

- Validate required property GRAVITINO_JDBC_URL in JdbcPropertiesConverter#toFlinkCatalogProperties to prevent NPE.
- Throw IllegalArgumentException with a clear message when jdbc-url is missing or blank, instead of letting an NPE occur.
- `Tests` : add the test `testToJdbcCatalogPropertiesWithoutUrl()` in AbstractJdbcPropertiesConverterTestSuite

### Why are the changes needed?

- When jdbc-url is missing, the current implementation can throw a NullPointerException during URL processing. Failing fast with a meaningful validation error improves debuggability and avoids leaking internal details.

Fix: #8195

### Does this PR introduce *any* user-facing change?
- APIs / property keys: No changes.
- Behavior: If jdbc-url is missing, the code now throws IllegalArgumentException with a descriptive message (previously resulted in an NPE).

### How was this patch tested?

Local runs:
```
./gradlew spotlessApply
./gradlew test -PskipITs
```