### PR TITLE
[#8245] improvement: verify partitioning and sort order contents in Iceberg table tests

### DIFF
--- a/catalogs/catalog-lakehouse-iceberg/src/test/java/org/apache/gravitino/catalog/lakehouse/iceberg/integration/test/CatalogIcebergBaseIT.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/test/java/org/apache/gravitino/catalog/lakehouse/iceberg/integration/test/CatalogIcebergBaseIT.java
@@ -495,8 +495,7 @@ public abstract class CatalogIcebergBaseIT extends BaseIT {
     }
 
     // TODO add partitioning and sort order check
-    Assertions.assertEquals(partitioning.length, createdTable.partitioning().length);
-    Assertions.assertEquals(sortOrders.length, createdTable.sortOrder().length);
+    assertPartitioningAndSortOrder(partitioning, sortOrders, createdTable);
 
     Table loadTable = tableCatalog.loadTable(tableIdentifier);
     Assertions.assertEquals(tableName, loadTable.name());
@@ -511,8 +510,7 @@ public abstract class CatalogIcebergBaseIT extends BaseIT {
       assertColumn(columns[i], loadTable.columns()[i]);
     }
 
-    Assertions.assertEquals(partitioning.length, loadTable.partitioning().length);
-    Assertions.assertEquals(sortOrders.length, loadTable.sortOrder().length);
+    assertPartitioningAndSortOrder(partitioning, sortOrders, loadTable);
 
     // catalog load check
     org.apache.iceberg.Table table =
@@ -547,6 +545,21 @@ public abstract class CatalogIcebergBaseIT extends BaseIT {
                     Transforms.EMPTY_TRANSFORM,
                     distribution,
                     sortOrders));
+  }
+
+  private void assertPartitioningAndSortOrder(
+      Transform[] expectedPartitioning,
+      SortOrder[] expectedSortOrders,
+      Table actualTable) {
+    Assertions.assertArrayEquals(expectedPartitioning, actualTable.partitioning());
+    Assertions.assertEquals(expectedSortOrders.length, actualTable.sortOrder().length);
+    for (int i = 0; i < expectedSortOrders.length; i++) {
+      SortOrder expected = expectedSortOrders[i];
+      SortOrder actual = actualTable.sortOrder()[i];
+      Assertions.assertEquals(expected.expression().toString(), actual.expression().toString());
+      Assertions.assertEquals(expected.direction(), actual.direction());
+      Assertions.assertEquals(expected.nullOrdering(), actual.nullOrdering());
+    }
   }
 
   @Test

--- a/catalogs/catalog-lakehouse-iceberg/src/test/java/org/apache/gravitino/catalog/lakehouse/iceberg/integration/test/CatalogIcebergBaseIT.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/test/java/org/apache/gravitino/catalog/lakehouse/iceberg/integration/test/CatalogIcebergBaseIT.java
@@ -548,9 +548,7 @@ public abstract class CatalogIcebergBaseIT extends BaseIT {
   }
 
   private void assertPartitioningAndSortOrder(
-      Transform[] expectedPartitioning,
-      SortOrder[] expectedSortOrders,
-      Table actualTable) {
+      Transform[] expectedPartitioning, SortOrder[] expectedSortOrders, Table actualTable) {
     Assertions.assertArrayEquals(expectedPartitioning, actualTable.partitioning());
     Assertions.assertEquals(expectedSortOrders.length, actualTable.sortOrder().length);
     for (int i = 0; i < expectedSortOrders.length; i++) {


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

- Expanded `CatalogIcebergBaseIT` tests to verify contents of partitioning and sortOrders.

### Why are the changes needed?

- Previous tests only checked length.

Fix: #8245 

### Does this PR introduce _any_ user-facing change?

- No.

### How was this patch tested?

(Please test your changes, and provide instructions on how to test it:
  1. If you add a feature or fix a bug, add a test to cover your changes.
  2. If you fix a flaky test, repeat it for many times to prove it works.)
