### PR TITLE
Revert #8255 update group changes

### DIFF
--- a/core/src/test/java/org/apache/gravitino/storage/relational/service/TestGroupMetaService.java
+++ b/core/src/test/java/org/apache/gravitino/storage/relational/service/TestGroupMetaService.java
@@ -1012,44 +1012,4 @@ class TestGroupMetaService extends TestJDBCBackend {
     }
     return count;
   }
-
-  @Test
-  void updateGroupWithoutRoleChange() throws IOException {
-    AuditInfo auditInfo =
-        AuditInfo.builder().withCreator("creator").withCreateTime(Instant.now()).build();
-    BaseMetalake metalake =
-        createBaseMakeLake(RandomIdGenerator.INSTANCE.nextId(), metalakeName, auditInfo);
-    backend.insert(metalake, false);
-
-    GroupMetaService groupMetaService = GroupMetaService.getInstance();
-
-    GroupEntity group1 =
-        createGroupEntity(
-            RandomIdGenerator.INSTANCE.nextId(),
-            AuthorizationUtils.ofGroupNamespace(metalakeName),
-            "group1",
-            auditInfo);
-    groupMetaService.insertGroup(group1, false);
-
-    Function<GroupEntity, GroupEntity> renameUpdater =
-        group ->
-            GroupEntity.builder()
-                .withNamespace(group.namespace())
-                .withId(group.id())
-                .withName("group_renamed")
-                .withRoleNames(group.roleNames())
-                .withRoleIds(group.roleIds())
-                .withAuditInfo(group.auditInfo())
-                .build();
-    groupMetaService.updateGroup(group1.nameIdentifier(), renameUpdater);
-
-    Assertions.assertThrows(
-        NoSuchEntityException.class,
-        () -> groupMetaService.getGroupByIdentifier(group1.nameIdentifier()));
-
-    GroupEntity updated =
-        groupMetaService.getGroupByIdentifier(
-            AuthorizationUtils.ofGroup(metalakeName, "group_renamed"));
-    Assertions.assertEquals("group_renamed", updated.name());
-  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

"Fix early return in GroupMetaService.updateGroup ignoring non-role changes (#8255)"

This reverts commit bfddf5cbcac26915b85267cb5628495c12ca40c2.

### Why are the changes needed?

As this broke a test.

Fix: #N/A

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

Tested locally.
