### PR TITLE
[#7437] feat(client): Java/Python clients and CLI support model version with multiple URIs

### DIFF
--- a/api/src/main/java/org/apache/gravitino/model/ModelCatalog.java
+++ b/api/src/main/java/org/apache/gravitino/model/ModelCatalog.java
@@ -267,10 +267,8 @@ public interface ModelCatalog {
    * @throws NoSuchModelVersionException If the model version does not exist.
    * @return The URI of the model version.
    */
-  default String getModelVersionUri(NameIdentifier ident, int version, String uriName)
-      throws NoSuchModelVersionException, NoSuchModelVersionURINameException {
-    throw new UnsupportedOperationException("Not supported yet");
-  }
+  String getModelVersionUri(NameIdentifier ident, int version, String uriName)
+      throws NoSuchModelVersionException, NoSuchModelVersionURINameException;
 
   /**
    * Get the URI of the model artifact with a specified version alias and URI name.
@@ -281,10 +279,8 @@ public interface ModelCatalog {
    * @throws NoSuchModelVersionException If the model version does not exist.
    * @return The URI of the model version.
    */
-  default String getModelVersionUri(NameIdentifier ident, String alias, String uriName)
-      throws NoSuchModelVersionException, NoSuchModelVersionURINameException {
-    throw new UnsupportedOperationException("Not supported yet");
-  }
+  String getModelVersionUri(NameIdentifier ident, String alias, String uriName)
+      throws NoSuchModelVersionException, NoSuchModelVersionURINameException;
 
   /**
    * Delete the model version by the {@link NameIdentifier} and version number. If the model version

--- a/api/src/main/java/org/apache/gravitino/model/ModelCatalog.java
+++ b/api/src/main/java/org/apache/gravitino/model/ModelCatalog.java
@@ -250,15 +250,13 @@ public interface ModelCatalog {
    * @throws NoSuchModelException If the model does not exist.
    * @throws ModelVersionAliasesAlreadyExistException If the aliases already exist in the model.
    */
-  default void linkModelVersion(
+  void linkModelVersion(
       NameIdentifier ident,
       Map<String, String> uris,
       String[] aliases,
       String comment,
       Map<String, String> properties)
-      throws NoSuchModelException, ModelVersionAliasesAlreadyExistException {
-    throw new UnsupportedOperationException("Not supported yet");
-  }
+      throws NoSuchModelException, ModelVersionAliasesAlreadyExistException;
 
   /**
    * Get the URI of the model artifact with a specified version number and URI name.

--- a/api/src/main/java/org/apache/gravitino/model/ModelVersion.java
+++ b/api/src/main/java/org/apache/gravitino/model/ModelVersion.java
@@ -84,9 +84,7 @@ public interface ModelVersion extends Auditable {
    * @return The URIs of the model version, the key is the name of the URI and the value is the URI
    *     of the model artifact.
    */
-  default Map<String, String> uris() {
-    throw new UnsupportedOperationException("Not implemented yet");
-  }
+  Map<String, String> uris();
 
   /**
    * The properties of the model version. The properties are key-value pairs that can be used to

--- a/catalogs/catalog-model/src/test/java/org/apache/gravtitino/catalog/model/integration/test/ModelCatalogOperationsIT.java
+++ b/catalogs/catalog-model/src/test/java/org/apache/gravtitino/catalog/model/integration/test/ModelCatalogOperationsIT.java
@@ -370,6 +370,51 @@ public class ModelCatalogOperationsIT extends BaseIT {
   }
 
   @Test
+  public void testLinkModelVersionWithMultipleUris() {
+    String modelName = RandomNameUtils.genRandomName("model1");
+    NameIdentifier modelIdent = NameIdentifier.of(schemaName, modelName);
+    gravitinoCatalog.asModelCatalog().registerModel(modelIdent, null, null);
+    Map<String, String> uris = ImmutableMap.of("n1", "u1", "n2", "u2");
+    gravitinoCatalog
+        .asModelCatalog()
+        .linkModelVersion(modelIdent, uris, new String[] {"alias1"}, "comment1", null);
+
+    Assertions.assertTrue(gravitinoCatalog.asModelCatalog().modelVersionExists(modelIdent, 0));
+    Assertions.assertTrue(
+        gravitinoCatalog.asModelCatalog().modelVersionExists(modelIdent, "alias1"));
+
+    // Test get model version
+    ModelVersion modelVersion = gravitinoCatalog.asModelCatalog().getModelVersion(modelIdent, 0);
+    Assertions.assertEquals(0, modelVersion.version());
+    Assertions.assertEquals(uris, modelVersion.uris());
+    Assertions.assertArrayEquals(new String[] {"alias1"}, modelVersion.aliases());
+    Assertions.assertEquals("comment1", modelVersion.comment());
+    Assertions.assertEquals(Collections.emptyMap(), modelVersion.properties());
+
+    // Test list model versions
+    int[] modelVersions = gravitinoCatalog.asModelCatalog().listModelVersions(modelIdent);
+    Set<Integer> resultSet = Arrays.stream(modelVersions).boxed().collect(Collectors.toSet());
+    Assertions.assertEquals(1, resultSet.size());
+    Assertions.assertTrue(resultSet.contains(0));
+
+    // Test list model version infos
+    ModelVersion[] modelVersionInfos =
+        gravitinoCatalog.asModelCatalog().listModelVersionInfos(modelIdent);
+    Assertions.assertEquals(1, modelVersionInfos.length);
+    Assertions.assertEquals(0, modelVersionInfos[0].version());
+    Assertions.assertEquals(uris, modelVersionInfos[0].uris());
+    Assertions.assertArrayEquals(new String[] {"alias1"}, modelVersionInfos[0].aliases());
+    Assertions.assertEquals("comment1", modelVersionInfos[0].comment());
+    Assertions.assertEquals(Collections.emptyMap(), modelVersionInfos[0].properties());
+
+    // Test delete and list model versions info
+    Assertions.assertTrue(gravitinoCatalog.asModelCatalog().deleteModelVersion(modelIdent, 0));
+    int[] modelVersionsAfterDelete =
+        gravitinoCatalog.asModelCatalog().listModelVersions(modelIdent);
+    Assertions.assertEquals(0, modelVersionsAfterDelete.length);
+  }
+
+  @Test
   void testLinkAndUpdateModelVersionComment() {
     String modelName = RandomNameUtils.genRandomName("model1");
     Map<String, String> properties = ImmutableMap.of("key1", "val1", "key2", "val2");

--- a/catalogs/catalog-model/src/test/java/org/apache/gravtitino/catalog/model/integration/test/ModelCatalogOperationsIT.java
+++ b/catalogs/catalog-model/src/test/java/org/apache/gravtitino/catalog/model/integration/test/ModelCatalogOperationsIT.java
@@ -760,6 +760,84 @@ public class ModelCatalogOperationsIT extends BaseIT {
   }
 
   @Test
+  void testLinkAndUpdateModelVersionUriWithMultipleUris() {
+    String modelName = RandomNameUtils.genRandomName("model1");
+    String[] aliases = {"alias1"};
+    Map<String, String> properties = ImmutableMap.of("key1", "val1", "key2", "val2");
+    NameIdentifier modelIdent = NameIdentifier.of(schemaName, modelName);
+
+    Map<String, String> uris = ImmutableMap.of("n1", "u1");
+    String versionComment = "comment";
+
+    // create and link model version
+    gravitinoCatalog.asModelCatalog().registerModel(modelIdent, null, null);
+    gravitinoCatalog
+        .asModelCatalog()
+        .linkModelVersion(modelIdent, uris, aliases, versionComment, properties);
+    ModelVersion modelVersion = gravitinoCatalog.asModelCatalog().getModelVersion(modelIdent, 0);
+    Assertions.assertEquals(0, modelVersion.version());
+    Assertions.assertEquals(uris, modelVersion.uris());
+    Assertions.assertArrayEquals(aliases, modelVersion.aliases());
+    Assertions.assertEquals(versionComment, modelVersion.comment());
+    Assertions.assertEquals(properties, modelVersion.properties());
+
+    // Test update uri
+    Map<String, String> updatedUris = ImmutableMap.of("n1", "u1-1");
+    ModelVersionChange updateUriChange = ModelVersionChange.updateUri("n1", "u1-1");
+    ModelVersion updatedModelVersion =
+        gravitinoCatalog.asModelCatalog().alterModelVersion(modelIdent, 0, updateUriChange);
+    Assertions.assertEquals(modelVersion.version(), updatedModelVersion.version());
+    Assertions.assertEquals(updatedUris, updatedModelVersion.uris());
+    Assertions.assertArrayEquals(modelVersion.aliases(), updatedModelVersion.aliases());
+    Assertions.assertEquals(modelVersion.comment(), updatedModelVersion.comment());
+    Assertions.assertEquals(modelVersion.properties(), updatedModelVersion.properties());
+
+    ModelVersion reloadedModelVersion =
+        gravitinoCatalog.asModelCatalog().getModelVersion(modelIdent, 0);
+    Assertions.assertEquals(modelVersion.version(), reloadedModelVersion.version());
+    Assertions.assertEquals(updatedUris, reloadedModelVersion.uris());
+    Assertions.assertArrayEquals(modelVersion.aliases(), reloadedModelVersion.aliases());
+    Assertions.assertEquals(modelVersion.comment(), reloadedModelVersion.comment());
+    Assertions.assertEquals(modelVersion.properties(), reloadedModelVersion.properties());
+
+    // Test add uri
+    updatedUris = ImmutableMap.of("n1", "u1-1", "n2", "u2");
+    ModelVersionChange addUriChange = ModelVersionChange.addUri("n2", "u2");
+    updatedModelVersion =
+        gravitinoCatalog.asModelCatalog().alterModelVersion(modelIdent, 0, addUriChange);
+    Assertions.assertEquals(modelVersion.version(), updatedModelVersion.version());
+    Assertions.assertEquals(updatedUris, updatedModelVersion.uris());
+    Assertions.assertArrayEquals(modelVersion.aliases(), updatedModelVersion.aliases());
+    Assertions.assertEquals(modelVersion.comment(), updatedModelVersion.comment());
+    Assertions.assertEquals(modelVersion.properties(), updatedModelVersion.properties());
+
+    reloadedModelVersion = gravitinoCatalog.asModelCatalog().getModelVersion(modelIdent, 0);
+    Assertions.assertEquals(modelVersion.version(), reloadedModelVersion.version());
+    Assertions.assertEquals(updatedUris, reloadedModelVersion.uris());
+    Assertions.assertArrayEquals(modelVersion.aliases(), reloadedModelVersion.aliases());
+    Assertions.assertEquals(modelVersion.comment(), reloadedModelVersion.comment());
+    Assertions.assertEquals(modelVersion.properties(), reloadedModelVersion.properties());
+
+    // Test remove uri
+    updatedUris = ImmutableMap.of("n2", "u2");
+    ModelVersionChange removeUriChange = ModelVersionChange.removeUri("n1");
+    updatedModelVersion =
+        gravitinoCatalog.asModelCatalog().alterModelVersion(modelIdent, 0, removeUriChange);
+    Assertions.assertEquals(modelVersion.version(), updatedModelVersion.version());
+    Assertions.assertEquals(updatedUris, updatedModelVersion.uris());
+    Assertions.assertArrayEquals(modelVersion.aliases(), updatedModelVersion.aliases());
+    Assertions.assertEquals(modelVersion.comment(), updatedModelVersion.comment());
+    Assertions.assertEquals(modelVersion.properties(), updatedModelVersion.properties());
+
+    reloadedModelVersion = gravitinoCatalog.asModelCatalog().getModelVersion(modelIdent, 0);
+    Assertions.assertEquals(modelVersion.version(), reloadedModelVersion.version());
+    Assertions.assertEquals(updatedUris, reloadedModelVersion.uris());
+    Assertions.assertArrayEquals(modelVersion.aliases(), reloadedModelVersion.aliases());
+    Assertions.assertEquals(modelVersion.comment(), reloadedModelVersion.comment());
+    Assertions.assertEquals(modelVersion.properties(), reloadedModelVersion.properties());
+  }
+
+  @Test
   void testLinkAndUpdateModelVersionUriByAlias() {
     String modelName = RandomNameUtils.genRandomName("model1");
     String[] aliases = {"alias1"};

--- a/clients/client-java/src/main/java/org/apache/gravitino/client/ErrorHandlers.java
+++ b/clients/client-java/src/main/java/org/apache/gravitino/client/ErrorHandlers.java
@@ -54,6 +54,7 @@ import org.apache.gravitino.exceptions.NoSuchMetadataObjectException;
 import org.apache.gravitino.exceptions.NoSuchMetalakeException;
 import org.apache.gravitino.exceptions.NoSuchModelException;
 import org.apache.gravitino.exceptions.NoSuchModelVersionException;
+import org.apache.gravitino.exceptions.NoSuchModelVersionURINameException;
 import org.apache.gravitino.exceptions.NoSuchPartitionException;
 import org.apache.gravitino.exceptions.NoSuchPolicyException;
 import org.apache.gravitino.exceptions.NoSuchRoleException;
@@ -1097,6 +1098,10 @@ public class ErrorHandlers {
               .getType()
               .equals(NoSuchModelVersionException.class.getSimpleName())) {
             throw new NoSuchModelVersionException(errorMsg);
+          } else if (errorResponse
+              .getType()
+              .equals(NoSuchModelVersionURINameException.class.getSimpleName())) {
+            throw new NoSuchModelVersionURINameException(errorMsg);
           } else {
             throw new NotFoundException(errorMsg);
           }

--- a/clients/client-java/src/main/java/org/apache/gravitino/client/GenericModelCatalog.java
+++ b/clients/client-java/src/main/java/org/apache/gravitino/client/GenericModelCatalog.java
@@ -220,14 +220,14 @@ class GenericModelCatalog extends BaseSchemaCatalog implements ModelCatalog {
   @Override
   public void linkModelVersion(
       NameIdentifier ident,
-      String uri,
+      Map<String, String> uris,
       String[] aliases,
       String comment,
       Map<String, String> properties)
       throws NoSuchModelException, ModelVersionAliasesAlreadyExistException {
     checkModelNameIdentifier(ident);
 
-    ModelVersionLinkRequest req = new ModelVersionLinkRequest(uri, aliases, comment, properties);
+    ModelVersionLinkRequest req = new ModelVersionLinkRequest(uris, aliases, comment, properties);
     NameIdentifier modelFullIdent = modelFullNameIdentifier(ident);
     BaseResponse resp =
         restClient.post(

--- a/clients/client-java/src/main/java/org/apache/gravitino/client/GenericModelVersion.java
+++ b/clients/client-java/src/main/java/org/apache/gravitino/client/GenericModelVersion.java
@@ -37,8 +37,8 @@ class GenericModelVersion implements ModelVersion {
   }
 
   @Override
-  public String uri() {
-    return modelVersionDTO.uri();
+  public Map<String, String> uris() {
+    return modelVersionDTO.uris();
   }
 
   @Override

--- a/clients/client-python/gravitino/api/model_version_change.py
+++ b/clients/client-python/gravitino/api/model_version_change.py
@@ -56,14 +56,36 @@ class ModelVersionChange(ABC):
         return ModelVersionChange.RemoveProperty(key)
 
     @staticmethod
-    def update_uri(uri: str):
+    def update_uri(uri: str, uri_name: str = None):
         """Creates a new model version change to update the uri of the model version.
         Args:
             uri: The new uri of the model version.
+            uri_name: The uri name of the model version to be updated.
         Returns:
             The model version change.
         """
-        return ModelVersionChange.UpdateUri(uri)
+        return ModelVersionChange.UpdateUri(uri, uri_name)
+
+    @staticmethod
+    def add_uri(uri_name: str, uri: str):
+        """Creates a new model version change to add the uri of the model version.
+        Args:
+            uri_name: The uri name of the model version to be added.
+            uri: The new uri of the model version to be added.
+        Returns:
+            The model version change.
+        """
+        return ModelVersionChange.AddUri(uri_name, uri)
+
+    @staticmethod
+    def remove_uri(uri_name: str):
+        """Creates a new model version change to remove the uri of the model version.
+        Args:
+            uri_name: The uri name of the model version to be removed.
+        Returns:
+            The model version change.
+        """
+        return ModelVersionChange.RemoveUri(uri_name)
 
     @staticmethod
     def update_aliases(aliases_to_add, aliases_to_remove):
@@ -213,8 +235,9 @@ class ModelVersionChange(ABC):
     class UpdateUri:
         """A model version change to update the URI of the model version."""
 
-        def __init__(self, new_uri: str):
+        def __init__(self, new_uri: str, uri_name: str = None):
             self._new_uri = new_uri
+            self._uri_name = uri_name
 
         def new_uri(self) -> str:
             """Retrieves the new URI of the model version.
@@ -223,9 +246,16 @@ class ModelVersionChange(ABC):
             """
             return self._new_uri
 
+        def uri_name(self) -> str:
+            """Retrieves the URI name of the model version to be updated.
+            Returns:
+                The URI name of the model version to be updated.
+            """
+            return self._uri_name
+
         def __eq__(self, other):
             """Compares this UpdateUri instance with another object for equality. Two instances are
-            considered equal if they designate the same new URI for the model version.
+            considered equal if they designate the same new URI and URI name for the model version.
             Args:
                 other: The object to compare with this instance.
             Returns:
@@ -234,23 +264,118 @@ class ModelVersionChange(ABC):
             """
             if not isinstance(other, ModelVersionChange.UpdateUri):
                 return False
-            return self.new_uri() == other.new_uri()
+            return (
+                self.new_uri() == other.new_uri()
+                and self.uri_name() == other.uri_name()
+            )
 
         def __hash__(self):
             """Generates a hash code for this UpdateUri instance. The hash code is primarily based on
-            the new URI for the model version.
+            the new URI and its name for the model version.
             Returns:
                 A hash code value for this URI update operation.
             """
-            return hash(self.new_uri())
+            return hash((self.new_uri(), self.uri_name()))
 
         def __str__(self):
             """Provides a string representation of the UpdateUri instance. This string includes the
-            class name followed by the new URI of the model version.
+            class name followed by the new URI and its name of the model version.
             Returns:
                 A string summary of this URI update operation.
             """
-            return f"UpdateUri {self._new_uri}"
+            return f"UpdateUri uriName: ({self._uri_name}) newUri: ({self._new_uri})"
+
+    class AddUri:
+        """A ModelVersionChange to add a uri of the model version."""
+
+        def __init__(self, uri_name: str, uri: str):
+            self._uri_name = uri_name
+            self._uri = uri
+
+        def uri_name(self) -> str:
+            """Retrieves the URI name of the model version to be added.
+            Returns:
+                The URI name of the model version to be added.
+            """
+            return self._uri_name
+
+        def uri(self) -> str:
+            """Retrieves the URI of the model version to be added.
+            Returns:
+                The new URI of the model version to be added.
+            """
+            return self._uri
+
+        def __eq__(self, other):
+            """Compares this AddUri instance with another object for equality. Two instances are
+            considered equal if they designate the same URI and URI name for the model version.
+            Args:
+                other: The object to compare with this instance.
+            Returns:
+                true if the given object represents an identical model version URI add operation;
+                false otherwise.
+            """
+            if not isinstance(other, ModelVersionChange.AddUri):
+                return False
+            return self.uri_name() == other.uri_name() and self.uri() == other.uri()
+
+        def __hash__(self):
+            """Generates a hash code for this AddUri instance. The hash code is primarily based on
+            the URI and its name for the model version.
+            Returns:
+                A hash code value for this URI add operation.
+            """
+            return hash((self.uri_name(), self.uri()))
+
+        def __str__(self):
+            """Provides a string representation of the AddUri instance. This string includes the
+            class name followed by the URI and its name of the model version.
+            Returns:
+                A string summary of this URI add operation.
+            """
+            return f"AddUri uriName: ({self._uri_name}) uri: ({self.uri})"
+
+    class RemoveUri:
+        """A ModelVersionChange to remove a uri of the model version."""
+
+        def __init__(self, uri_name: str):
+            self._uri_name = uri_name
+
+        def uri_name(self) -> str:
+            """Retrieves the URI name of the model version to be removed.
+            Returns:
+                The URI name of the model version to be removed.
+            """
+            return self._uri_name
+
+        def __eq__(self, other):
+            """Compares this RemoveUri instance with another object for equality. Two instances are
+            considered equal if they designate the same URI name for the model version.
+            Args:
+                other: The object to compare with this instance.
+            Returns:
+                true if the given object represents an identical model version URI remove operation;
+                false otherwise.
+            """
+            if not isinstance(other, ModelVersionChange.RemoveUri):
+                return False
+            return self.uri_name() == other.uri_name()
+
+        def __hash__(self):
+            """Generates a hash code for this RemoveUri instance. The hash code is primarily based on
+            the URI name for the model version.
+            Returns:
+                A hash code value for this URI remove operation.
+            """
+            return hash(self.uri_name())
+
+        def __str__(self):
+            """Provides a string representation of the RemoveUri instance. This string includes the
+            class name followed by the URI name of the model version.
+            Returns:
+                A string summary of this URI remove operation.
+            """
+            return f"RemoveUri uriName: ({self._uri_name})"
 
     class UpdateAliases:
         """A model version change to update the aliases of the model version."""

--- a/clients/client-python/gravitino/client/generic_model_catalog.py
+++ b/clients/client-python/gravitino/client/generic_model_catalog.py
@@ -45,6 +45,7 @@ from gravitino.dto.responses.model_version_list_response import (
     ModelVersionListResponse,
 )
 from gravitino.dto.responses.model_version_response import ModelVersionResponse
+from gravitino.dto.responses.model_version_uri_response import ModelVersionUriResponse
 from gravitino.exceptions.handlers.model_error_handler import MODEL_ERROR_HANDLER
 from gravitino.name_identifier import NameIdentifier
 from gravitino.namespace import Namespace
@@ -450,20 +451,11 @@ class GenericModelCatalog(BaseSchemaCatalog):
             NoSuchModelException: If the model does not exist.
             ModelVersionAliasesAlreadyExistException: If the aliases of the model version already exist.
         """
-        self._check_model_ident(model_ident)
+        uris = {ModelVersion.URI_NAME_UNKNOWN: uri} if uri else {}
 
-        model_full_ident = self._model_full_identifier(model_ident)
-
-        request = ModelVersionLinkRequest(uri, comment, aliases, properties)
-        request.validate()
-
-        resp = self.rest_client.post(
-            f"{self._format_model_version_request_path(model_full_ident)}/versions",
-            request,
-            error_handler=MODEL_ERROR_HANDLER,
+        return self.link_model_version_with_multiple_uris(
+            model_ident, uris, aliases, comment, properties
         )
-        base_resp = BaseResponse.from_json(resp.body, infer_missing=True)
-        base_resp.validate()
 
     def link_model_version_with_multiple_uris(
         self,
@@ -491,7 +483,20 @@ class GenericModelCatalog(BaseSchemaCatalog):
             NoSuchModelException: If the model does not exist.
             ModelVersionAliasesAlreadyExistException: If the aliases of the model version already exist.
         """
-        raise NotImplementedError("Not supported yet")
+        self._check_model_ident(model_ident)
+
+        model_full_ident = self._model_full_identifier(model_ident)
+
+        request = ModelVersionLinkRequest(uris, comment, aliases, properties)
+        request.validate()
+
+        resp = self.rest_client.post(
+            f"{self._format_model_version_request_path(model_full_ident)}/versions",
+            request,
+            error_handler=MODEL_ERROR_HANDLER,
+        )
+        base_resp = BaseResponse.from_json(resp.body, infer_missing=True)
+        base_resp.validate()
 
     def get_model_version_uri(
         self, model_ident: NameIdentifier, version: int, uri_name: str = None
@@ -510,7 +515,25 @@ class GenericModelCatalog(BaseSchemaCatalog):
         Returns:
             The URI of the model version.
         """
-        raise NotImplementedError("Not supported yet")
+        self._check_model_ident(model_ident)
+
+        model_full_ident = self._model_full_identifier(model_ident)
+        params = {}
+        if uri_name is not None:
+            params["uriName"] = encode_string(uri_name)
+
+        resp = self.rest_client.get(
+            f"{self._format_model_version_request_path(model_full_ident)}/versions/{version}/uri",
+            params=params,
+            error_handler=MODEL_ERROR_HANDLER,
+        )
+
+        model_version_uri_resp = ModelVersionUriResponse.from_json(
+            resp.body, infer_missing=True
+        )
+        model_version_uri_resp.validate()
+
+        return model_version_uri_resp.uri()
 
     def get_model_version_uri_by_alias(
         self, model_ident: NameIdentifier, alias: str, uri_name: str = None
@@ -529,7 +552,25 @@ class GenericModelCatalog(BaseSchemaCatalog):
         Returns:
             The URI of the model version.
         """
-        raise NotImplementedError("Not supported yet")
+        self._check_model_ident(model_ident)
+
+        model_full_ident = self._model_full_identifier(model_ident)
+        params = {}
+        if uri_name is not None:
+            params["uriName"] = encode_string(uri_name)
+
+        resp = self.rest_client.get(
+            f"{self._format_model_version_request_path(model_full_ident)}/aliases/{encode_string(alias)}/uri",
+            params=params,
+            error_handler=MODEL_ERROR_HANDLER,
+        )
+
+        model_version_uri_resp = ModelVersionUriResponse.from_json(
+            resp.body, infer_missing=True
+        )
+        model_version_uri_resp.validate()
+
+        return model_version_uri_resp.uri()
 
     def delete_model_version(self, model_ident: NameIdentifier, version: int) -> bool:
         """Delete the model version from the catalog. If the model version does not exist, return false.
@@ -608,9 +649,10 @@ class GenericModelCatalog(BaseSchemaCatalog):
         Returns:
             The registered model object.
         """
-        model = self.register_model(ident, comment, properties)
-        self.link_model_version(ident, uri, aliases, comment, properties)
-        return model
+        uris = {ModelVersion.URI_NAME_UNKNOWN: uri} if uri else {}
+        return self.register_model_version_with_multiple_uris(
+            ident, uris, aliases, comment, properties
+        )
 
     def register_model_version_with_multiple_uris(
         self,
@@ -683,7 +725,17 @@ class GenericModelCatalog(BaseSchemaCatalog):
 
         if isinstance(change, ModelVersionChange.UpdateUri):
             return ModelVersionUpdateRequest.UpdateModelVersionUriRequest(
-                change.new_uri()
+                change.new_uri(), change.uri_name()
+            )
+
+        if isinstance(change, ModelVersionChange.AddUri):
+            return ModelVersionUpdateRequest.AddModelVersionUriRequest(
+                change.uri_name(), change.uri()
+            )
+
+        if isinstance(change, ModelVersionChange.RemoveUri):
+            return ModelVersionUpdateRequest.RemoveModelVersionUriRequest(
+                change.uri_name()
             )
 
         if isinstance(change, ModelVersionChange.UpdateAliases):

--- a/clients/client-python/gravitino/client/generic_model_version.py
+++ b/clients/client-python/gravitino/client/generic_model_version.py
@@ -37,9 +37,6 @@ class GenericModelVersion(ModelVersion):
     def aliases(self) -> List[str]:
         return self._model_version_dto.aliases()
 
-    def uri(self) -> str:
-        return self._model_version_dto.uri()
-
     def uris(self) -> Dict[str, str]:
         return self._model_version_dto.uris()
 

--- a/clients/client-python/gravitino/dto/model_version_dto.py
+++ b/clients/client-python/gravitino/dto/model_version_dto.py
@@ -31,7 +31,7 @@ class ModelVersionDTO(ModelVersion, DataClassJsonMixin):
     _version: int = field(metadata=config(field_name="version"))
     _comment: Optional[str] = field(metadata=config(field_name="comment"))
     _aliases: Optional[List[str]] = field(metadata=config(field_name="aliases"))
-    _uri: str = field(metadata=config(field_name="uri"))
+    _uris: Dict[str, str] = field(metadata=config(field_name="uris"))
     _properties: Optional[Dict[str, str]] = field(
         metadata=config(field_name="properties")
     )
@@ -46,11 +46,8 @@ class ModelVersionDTO(ModelVersion, DataClassJsonMixin):
     def aliases(self) -> Optional[List[str]]:
         return self._aliases
 
-    def uri(self) -> str:
-        return self._uri
-
     def uris(self) -> Dict[str, str]:
-        raise NotImplementedError("Not supported yet")
+        return self._uris
 
     def properties(self) -> Optional[Dict[str, str]]:
         return self._properties

--- a/clients/client-python/gravitino/dto/requests/model_version_link_request.py
+++ b/clients/client-python/gravitino/dto/requests/model_version_link_request.py
@@ -27,7 +27,7 @@ from gravitino.rest.rest_message import RESTRequest
 class ModelVersionLinkRequest(RESTRequest):
     """Represents a request to link a model version to a model."""
 
-    _uri: str = field(metadata=config(field_name="uri"))
+    _uris: Dict[str, str] = field(metadata=config(field_name="uris"))
     _comment: Optional[str] = field(metadata=config(field_name="comment"))
     _aliases: Optional[List[str]] = field(metadata=config(field_name="aliases"))
     _properties: Optional[Dict[str, str]] = field(
@@ -36,12 +36,12 @@ class ModelVersionLinkRequest(RESTRequest):
 
     def __init__(
         self,
-        uri: str,
+        uris: Dict[str, str],
         comment: Optional[str] = None,
         aliases: Optional[List[str]] = None,
         properties: Optional[Dict[str, str]] = None,
     ):
-        self._uri = uri
+        self._uris = uris
         self._comment = comment
         self._aliases = aliases
         self._properties = properties
@@ -52,10 +52,16 @@ class ModelVersionLinkRequest(RESTRequest):
         Raises:
             IllegalArgumentException if the request is invalid
         """
-        if not self._is_not_blank(self._uri):
+        if not self._uris:
             raise IllegalArgumentException(
-                '"uri" field is required and cannot be empty'
+                '"uris" field is required and cannot be empty'
             )
+
+        for key, value in self._uris.items():
+            if not self._is_not_blank(key):
+                raise IllegalArgumentException("uri name must not be null or empty")
+            if not self._is_not_blank(value):
+                raise IllegalArgumentException("uri must not be null or empty")
 
         for alias in self._aliases or []:
             if not self._is_not_blank(alias):

--- a/clients/client-python/gravitino/dto/requests/model_version_update_request.py
+++ b/clients/client-python/gravitino/dto/requests/model_version_update_request.py
@@ -113,11 +113,12 @@ class ModelVersionUpdateRequest:
         """Request to update model version uri"""
 
         _new_uri: Optional[str] = field(metadata=config(field_name="newUri"))
-        """Represents a request to update the uri on a Metalake."""
+        _uri_name: Optional[str] = field(metadata=config(field_name="uriName"))
 
-        def __init__(self, new_uri: str):
+        def __init__(self, new_uri: str, uri_name: str):
             super().__init__("updateUri")
             self._new_uri = new_uri
+            self._uri_name = uri_name
 
         def new_uri(self):
             """Retrieves the new uri of the model version.
@@ -126,8 +127,15 @@ class ModelVersionUpdateRequest:
             """
             return self._new_uri
 
+        def uri_name(self):
+            """Retrieves the uri name of the model version.
+            Returns:
+                The uri name of the model version.
+            """
+            return self._uri_name
+
         def validate(self):
-            """Validates the fields of the request. Always pass."""
+            """Validates the fields of the request."""
             if not self._new_uri:
                 raise ValueError('"newUri" field is required')
 
@@ -137,7 +145,78 @@ class ModelVersionUpdateRequest:
             Returns:
                 ModelVersionChange: The ModelVersionChange object representing the update uri operation.
             """
-            return ModelVersionChange.update_uri(self._new_uri)
+            return ModelVersionChange.update_uri(self._new_uri, self._uri_name)
+
+    @dataclass
+    class AddModelVersionUriRequest(ModelVersionUpdateRequestBase):
+        """Request to add model version uri"""
+
+        _uri_name: Optional[str] = field(metadata=config(field_name="uriName"))
+        _uri: Optional[str] = field(metadata=config(field_name="uri"))
+
+        def __init__(self, uri_name: str, uri: str):
+            super().__init__("addUri")
+            self._uri_name = uri_name
+            self._uri = uri
+
+        def uri_name(self):
+            """Retrieves the uri name of the model version.
+            Returns:
+                The uri name of the model version.
+            """
+            return self._uri_name
+
+        def uri(self):
+            """Retrieves the uri of the model version.
+            Returns:
+                The uri of the model version.
+            """
+            return self._uri
+
+        def validate(self):
+            """Validates the fields of the request."""
+            if not self._uri_name:
+                raise ValueError('"uriName" field is required')
+            if not self._uri:
+                raise ValueError('"uri" field is required')
+
+        def model_version_change(self):
+            """
+            Returns a ModelVersionChange object representing the add uri operation.
+            Returns:
+                ModelVersionChange: The ModelVersionChange object representing the add uri operation.
+            """
+            return ModelVersionChange.add_uri(self._uri_name, self._uri)
+
+    @dataclass
+    class RemoveModelVersionUriRequest(ModelVersionUpdateRequestBase):
+        """Request to remove model version uri"""
+
+        _uri_name: Optional[str] = field(metadata=config(field_name="uriName"))
+
+        def __init__(self, uri_name: str):
+            super().__init__("removeUri")
+            self._uri_name = uri_name
+
+        def uri_name(self):
+            """Retrieves the uri name of the model version.
+            Returns:
+                The uri name of the model version.
+            """
+            return self._uri_name
+
+        def validate(self):
+            """Validates the fields of the request."""
+            if not self._uri_name:
+                raise ValueError('"uriName" field is required')
+
+        def model_version_change(self):
+            """
+            Returns a ModelVersionChange object representing the remove uri operation.
+            Returns:
+                ModelVersionChange: The ModelVersionChange object representing the remove uri operation.
+            """
+            return ModelVersionChange.remove_uri(self._uri_name)
 
     @dataclass
     class ModelVersionAliasesRequest(ModelVersionUpdateRequestBase):

--- a/clients/client-python/gravitino/dto/responses/model_version_list_response.py
+++ b/clients/client-python/gravitino/dto/responses/model_version_list_response.py
@@ -73,7 +73,7 @@ class ModelVersionInfoListResponse(BaseResponse):
                 raise IllegalArgumentException(
                     "Model version 'version' must not be null"
                 )
-            if version.uri() is None:
+            if version.uris() is None:
                 raise IllegalArgumentException("Model version 'uri' must not be null")
             if version.audit_info() is None:
                 raise IllegalArgumentException(

--- a/clients/client-python/gravitino/dto/responses/model_version_uri_response.py
+++ b/clients/client-python/gravitino/dto/responses/model_version_uri_response.py
@@ -14,38 +14,29 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from dataclasses import field, dataclass
+
+from dataclasses import dataclass, field
 
 from dataclasses_json import config
-
-from gravitino.dto.model_version_dto import ModelVersionDTO
 from gravitino.dto.responses.base_response import BaseResponse
 from gravitino.exceptions.base import IllegalArgumentException
 
 
 @dataclass
-class ModelVersionResponse(BaseResponse):
-    """Represents a response for a model version."""
+class ModelVersionUriResponse(BaseResponse):
+    """Response for the model version uri."""
 
-    _model_version: ModelVersionDTO = field(metadata=config(field_name="modelVersion"))
+    _uri: str = field(metadata=config(field_name="uri"))
 
-    def model_version(self) -> ModelVersionDTO:
-        """Returns the model version."""
-        return self._model_version
+    def uri(self) -> str:
+        return self._uri
 
     def validate(self):
         """Validates the response data.
 
         Raises:
-            IllegalArgumentException if the model version is not set.
+            IllegalArgumentException if model version uri is not set.
         """
         super().validate()
-
-        if self._model_version is None:
-            raise IllegalArgumentException("Model version must not be null")
-        if self._model_version.version() is None:
-            raise IllegalArgumentException("Model version 'version' must not be null")
-        if self._model_version.uris() is None:
-            raise IllegalArgumentException("Model version 'uri' must not be null")
-        if self._model_version.audit_info() is None:
-            raise IllegalArgumentException("Model version 'auditInfo' must not be null")
+        if self._uri is None or len(self.uri()) == 0:
+            raise IllegalArgumentException("Model version uri must not be null")

--- a/clients/client-python/pylintrc
+++ b/clients/client-python/pylintrc
@@ -93,3 +93,7 @@ variable-naming-style=snake_case
 
 # Naming Style for Module
 module-naming-style=snake_case
+
+[DESIGN]
+# Maximum number of return statements allowed in a function
+max-returns=10

--- a/clients/client-python/tests/unittests/test_model_catalog_api.py
+++ b/clients/client-python/tests/unittests/test_model_catalog_api.py
@@ -35,6 +35,7 @@ from gravitino.dto.responses.model_version_list_response import (
     ModelVersionListResponse,
 )
 from gravitino.dto.responses.model_version_response import ModelVersionResponse
+from gravitino.dto.responses.model_version_uri_response import ModelVersionUriResponse
 from gravitino.namespace import Namespace
 from gravitino.utils import Response
 from tests.unittests import mock_base
@@ -274,7 +275,7 @@ class TestModelCatalogApi(unittest.TestCase):
         model_versions_dto = [
             ModelVersionDTO(
                 _version=0,
-                _uri="http://localhost:8090",
+                _uris={"unknown": "http://localhost:8090"},
                 _aliases=["alias1", "alias2"],
                 _comment="this is test",
                 _properties={"k": "v"},
@@ -325,7 +326,7 @@ class TestModelCatalogApi(unittest.TestCase):
 
         model_version_dto = ModelVersionDTO(
             _version=1,
-            _uri="http://localhost:8090",
+            _uris={"unknown": "http://localhost:8090"},
             _aliases=["alias1", "alias2"],
             _comment="new comment",
             _properties={"k": "v"},
@@ -363,7 +364,7 @@ class TestModelCatalogApi(unittest.TestCase):
         ## test with response
         model_version_dto = ModelVersionDTO(
             _version=1,
-            _uri="http://localhost:8090",
+            _uris={"unknown": "http://localhost:8090"},
             _aliases=["alias1", "alias2"],
             _comment="this is test",
             _properties={"k": "v"},
@@ -390,7 +391,7 @@ class TestModelCatalogApi(unittest.TestCase):
         ## test with empty response
         model_version_dto = ModelVersionDTO(
             _version=1,
-            _uri="http://localhost:8090",
+            _uris={"unknown": "http://localhost:8090"},
             _aliases=None,
             _comment=None,
             _properties=None,
@@ -425,7 +426,7 @@ class TestModelCatalogApi(unittest.TestCase):
         ## test with response
         model_version_dto = ModelVersionDTO(
             _version=1,
-            _uri="http://localhost:8090",
+            _uris={"unknown": "http://localhost:8090"},
             _aliases=["alias1", "alias2"],
             _comment="this is test",
             _properties={"k": "v"},
@@ -448,6 +449,74 @@ class TestModelCatalogApi(unittest.TestCase):
                     {"k": "v"},
                 )
             )
+
+    def test_link_model_version_with_multiple_uris(self, *mock_method):
+        gravitino_client = GravitinoClient(
+            uri="http://localhost:8090", metalake_name=self._metalake_name
+        )
+        catalog = gravitino_client.load_catalog(self._catalog_name)
+
+        model_ident = NameIdentifier.of("schema", "model1")
+
+        ## test with response
+        model_version_dto = ModelVersionDTO(
+            _version=1,
+            _uris={"default-uri-name": "http://localhost:8090"},
+            _aliases=["alias1", "alias2"],
+            _comment="this is test",
+            _properties={"k": "v"},
+            _audit=AuditDTO(_creator="test", _create_time="2022-01-01T00:00:00Z"),
+        )
+        model_resp = ModelVersionResponse(_model_version=model_version_dto, _code=0)
+        json_str = model_resp.to_json()
+        mock_resp = self._mock_http_response(json_str)
+
+        with patch(
+            "gravitino.utils.http_client.HTTPClient.post",
+            return_value=mock_resp,
+        ):
+            self.assertIsNone(
+                catalog.as_model_catalog().link_model_version_with_multiple_uris(
+                    model_ident,
+                    {"default-uri-name": "http://localhost:8090"},
+                    ["alias1", "alias2"],
+                    "this is test",
+                    {"k": "v"},
+                )
+            )
+
+    def test_get_model_version_uri(self, *mock_method):
+        gravitino_client = GravitinoClient(
+            uri="http://localhost:8090", metalake_name=self._metalake_name
+        )
+        catalog = gravitino_client.load_catalog(self._catalog_name)
+
+        model_ident = NameIdentifier.of("schema", "model1")
+        version = 1
+        alias = "alias1"
+
+        ## test with response
+        model_version_uri_resp = ModelVersionUriResponse(
+            _code=0, _uri="s3://path/to/model"
+        )
+        json_str = model_version_uri_resp.to_json()
+        mock_resp = self._mock_http_response(json_str)
+
+        with patch(
+            "gravitino.utils.http_client.HTTPClient.get",
+            return_value=mock_resp,
+        ):
+            model_version_uri = catalog.as_model_catalog().get_model_version_uri(
+                model_ident, version, "uri_name"
+            )
+            self.assertEqual("s3://path/to/model", model_version_uri)
+
+            model_version_uri = (
+                catalog.as_model_catalog().get_model_version_uri_by_alias(
+                    model_ident, alias, "uri_name"
+                )
+            )
+            self.assertEqual("s3://path/to/model", model_version_uri)
 
     def test_delete_model_version(self, *mock_method):
         gravitino_client = GravitinoClient(

--- a/clients/client-python/tests/unittests/test_responses.py
+++ b/clients/client-python/tests/unittests/test_responses.py
@@ -22,6 +22,7 @@ from gravitino.dto.responses.file_location_response import FileLocationResponse
 from gravitino.dto.responses.model_response import ModelResponse
 from gravitino.dto.responses.model_version_list_response import ModelVersionListResponse
 from gravitino.dto.responses.model_version_response import ModelVersionResponse
+from gravitino.dto.responses.model_version_uri_response import ModelVersionUriResponse
 from gravitino.exceptions.base import IllegalArgumentException
 
 
@@ -161,7 +162,7 @@ class TestResponses(unittest.TestCase):
             "modelVersion": {
                 "version": 0,
                 "aliases": ["alias1", "alias2"],
-                "uri": "http://localhost:8080",
+                "uris": {"unknown": "http://localhost:8080"},
                 "comment": "test comment",
                 "properties": {"key1": "value1"},
                 "audit": {
@@ -188,7 +189,7 @@ class TestResponses(unittest.TestCase):
             "code": 0,
             "modelVersion": {
                 "version": 0,
-                "uri": "http://localhost:8080",
+                "uris": {"unknown": "http://localhost:8080"},
                 "audit": {
                     "creator": "anonymous",
                     "createTime": "2024-04-05T10:10:35.218Z",
@@ -208,7 +209,7 @@ class TestResponses(unittest.TestCase):
         json_data = {
             "code": 0,
             "modelVersion": {
-                "uri": "http://localhost:8080",
+                "uris": {"unknown": "http://localhost:8080"},
                 "audit": {
                     "creator": "anonymous",
                     "createTime": "2024-04-05T10:10:35.218Z",
@@ -241,7 +242,7 @@ class TestResponses(unittest.TestCase):
             "code": 0,
             "modelVersion": {
                 "version": 0,
-                "uri": "http://localhost:8080",
+                "uris": {"unknown": "http://localhost:8080"},
             },
         }
         json_str = json.dumps(json_data)
@@ -249,3 +250,28 @@ class TestResponses(unittest.TestCase):
             json_str, infer_missing=True
         )
         self.assertRaises(IllegalArgumentException, resp.validate)
+
+    def test_model_version_uri_response(self):
+        json_data = {"code": 0, "uri": "s3://path/to/model"}
+        json_str = json.dumps(json_data)
+        resp: ModelVersionUriResponse = ModelVersionUriResponse.from_json(
+            json_str, infer_missing=True
+        )
+        resp.validate()
+        self.assertEqual("s3://path/to/model", resp.uri())
+
+        json_data_missing = {"code": 0, "uri": ""}
+        json_str_missing = json.dumps(json_data_missing)
+        resp_missing: ModelVersionUriResponse = ModelVersionUriResponse.from_json(
+            json_str_missing, infer_missing=True
+        )
+        self.assertRaises(IllegalArgumentException, resp_missing.validate)
+
+        json_data_missing_1 = {
+            "code": 0,
+        }
+        json_str_missing_1 = json.dumps(json_data_missing_1)
+        resp_missing_1: ModelVersionUriResponse = ModelVersionUriResponse.from_json(
+            json_str_missing_1, infer_missing=True
+        )
+        self.assertRaises(IllegalArgumentException, resp_missing_1.validate)


### PR DESCRIPTION
### What changes were proposed in this pull request?

Java/Python clients and CLI support model version with multiple URIs.

### Why are the changes needed?

Fix: #(7437)

### Does this PR introduce _any_ user-facing change?

Yes.

### How was this patch tested?

UT & IT.
