### PR TITLE
[#8199] improvement(core): correct lock type in TreeLock log messages

### DIFF
--- a/core/src/main/java/org/apache/gravitino/lock/TreeLock.java
+++ b/core/src/main/java/org/apache/gravitino/lock/TreeLock.java
@@ -111,7 +111,7 @@ public class TreeLock {
           LOG.trace(
               "Node {} has been lock with '{}' lock, hold by {} with ident '{}' at {}",
               this,
-              lockType,
+              type,
               Thread.currentThread(),
               identifier,
               System.currentTimeMillis());
@@ -155,7 +155,7 @@ public class TreeLock {
         LOG.trace(
             "Node {} has been unlock with '{}' lock, hold by {} with ident '{}' for {} ms",
             this,
-            lockType,
+            type,
             Thread.currentThread(),
             identifier,
             System.currentTimeMillis() - holdStartTime);


### PR DESCRIPTION

<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Fixed log messages in `TreeLock.lock()` and `TreeLock.unlock()` to output the actual lock type (`type`) used.

### Why are the changes needed?

Reflect the real lock type applied at each node at log.

Fix: #8199

### Does this PR introduce _any_ user-facing change?

Yes, Log messages will now output the actual lock type in  `TreeLock.lock()` and `TreeLock.unlock()`.  

### How was this patch tested?

Verified log output manually during lock/unlock operations.
