### PR TITLE
[#8207] feat(cli): add validate method to OwnerDetails to check entityType is not null

### DIFF
--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/OwnerDetails.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/OwnerDetails.java
@@ -87,4 +87,10 @@ public class OwnerDetails extends Command {
       printInformation("No owner");
     }
   }
+
+  @Override
+  public Command validate() {
+    if (entityType == null) exitWithError(ErrorMessages.UNKNOWN_ENTITY);
+    return this;
+  }
 }

--- a/clients/cli/src/test/java/org/apache/gravitino/cli/command/TestOwnerDetails.java
+++ b/clients/cli/src/test/java/org/apache/gravitino/cli/command/TestOwnerDetails.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.cli.command;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.gravitino.cli.CommandContext;
+import org.apache.gravitino.cli.CommandEntities;
+import org.apache.gravitino.cli.Main;
+import org.apache.gravitino.cli.commands.Command;
+import org.apache.gravitino.cli.commands.OwnerDetails;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class TestOwnerDetails {
+
+  private CommandContext context;
+
+  @Before
+  public void setUp() {
+    CommandLine mockCommandLine = Mockito.mock(CommandLine.class);
+    context = new CommandContext(mockCommandLine);
+    Main.useExit = false;
+  }
+
+  @After
+  public void tearDown() {
+    Main.useExit = true;
+  }
+
+  @Test
+  public void testValidate_withValidEntityType_shouldPass() {
+    OwnerDetails command = new OwnerDetails(context, "metalake1", "entity1", CommandEntities.TABLE);
+    Command result = command.validate();
+    assertNotNull(result);
+    assertEquals(command, result);
+  }
+
+  @Test
+  public void testValidate_withInvalidEntityType_shouldExit() {
+    OwnerDetails command = new OwnerDetails(context, "metalake1", "entity1", "INVALID_TYPE");
+
+    try {
+      command.validate();
+      fail("Expected RuntimeException due to intercepted exit");
+    } catch (RuntimeException e) {
+      assertTrue(e.getMessage().contains("Exit with code"));
+    }
+  }
+}


### PR DESCRIPTION
Hi @justinmclean ,
### What changes were proposed in this pull request?

- Implemented `validate()` method in `OwnerDetails` class to check for null or invalid entity types and exit with an error message if invalid.
- Added new JUnit test class `TestOwnerDetails`:
  - `testValidate_withValidEntityType_shouldPass`: ensures that valid entity types pass validation.
  - `testValidate_withInvalidEntityType_shouldExit`: ensures that invalid entity types trigger error exit.

### Why are the changes needed?

- Before this change, `OwnerDetails` did not perform validation for `entityType`.
- Adding validation ensures invalid entity types are caught early with a clear error message, improving the robustness of the CLI.

Fix: #(issue-id)

### Does this PR introduce _any_ user-facing change?

- Yes, users providing an invalid entity type will now see a proper error message instead of unexpected behavior.
- No breaking changes for valid inputs.

### How was this patch tested?

- Added `TestOwnerDetails` JUnit test class.
- Verified behavior for both valid and invalid entity types.
- Used `Mockito` for mocking `CommandLine`.
- Confirmed CLI does not exit silently but throws an error in tests for invalid inputs.
