### PR TITLE
Fix incorrect name/comment assignment in TestModelMetaService tests

### DIFF
--- a/core/src/test/java/org/apache/gravitino/storage/relational/service/TestModelMetaService.java
+++ b/core/src/test/java/org/apache/gravitino/storage/relational/service/TestModelMetaService.java
@@ -266,11 +266,11 @@ public class TestModelMetaService extends TestJDBCBackend {
     ModelEntity updatedModel =
         ModelEntity.builder()
             .withId(modelEntity.id())
-            .withName(newComment)
+            .withName(modelEntity.name())
             .withNamespace(modelEntity.namespace())
             .withLatestVersion(modelEntity.latestVersion())
             .withAuditInfo(modelEntity.auditInfo())
-            .withComment(modelEntity.comment())
+            .withComment(newComment)
             .withProperties(modelEntity.properties())
             .build();
 
@@ -309,7 +309,7 @@ public class TestModelMetaService extends TestJDBCBackend {
     ModelEntity updatedModel =
         ModelEntity.builder()
             .withId(modelEntity.id())
-            .withName(modelEntity.comment())
+            .withName(modelEntity.name())
             .withNamespace(modelEntity.namespace())
             .withLatestVersion(modelEntity.latestVersion())
             .withAuditInfo(modelEntity.auditInfo())


### PR DESCRIPTION
**What changes were proposed in this pull request?**
In `TestModelMetaService.java`, the tests testInsertAndUpdateModelComment and testInsertAndUpdateModelProperties were incorrectly setting the name and comment fields. This PR fixes the assignments so that name and comment are updated correctly according to the test's intent.

**Why are the changes needed?**
Previously, the tests would either overwrite the name with a comment value or keep the comment unchanged, causing the tests to not properly verify updates. Fixing the assignments ensures that comment updates and property updates are correctly tested.

Fixes: #8282

**Does this PR introduce any user-facing change?**
No. This only fixes test behavior.

**How was this patch tested?**
- Corrected field assignments in the affected tests.
- Verified that `testInsertAndUpdateModelComment` correctly updates the comment without changing the name.
- Verified that `testInsertAndUpdateModelProperties` correctly maintains the name and updates properties.
- Ran all existing tests to confirm no regressions.

