### PR TITLE
[#8283] improvement(cli): Exit with error when both --comment and --rename are missing in fileset update

### DIFF
--- a/clients/cli/src/main/java/org/apache/gravitino/cli/ErrorMessages.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/ErrorMessages.java
@@ -51,6 +51,7 @@ public class ErrorMessages {
 
   public static final String MALFORMED_NAME = "Malformed entity name.";
   public static final String MISSING_COLUMN_FILE = "Missing --columnfile option.";
+  public static final String MISSING_COMMENT_AND_RENAME = "Missing --comment and --rename options.";
   public static final String MISSING_DATATYPE = "Missing --datatype option.";
   public static final String MISSING_ENTITIES = "Missing required entity names: ";
 

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/FilesetCommandHandler.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/FilesetCommandHandler.java
@@ -189,6 +189,11 @@ public class FilesetCommandHandler extends CommandHandler {
 
   /** Handles the "UPDATE" command. */
   private void handleUpdateCommand() {
+    if (!line.hasOption(GravitinoOptions.COMMENT) && !line.hasOption(GravitinoOptions.RENAME)) {
+      System.err.println(ErrorMessages.MISSING_COMMENT_AND_RENAME);
+      Main.exit(-1);
+    }
+
     if (line.hasOption(GravitinoOptions.COMMENT)) {
       String comment = line.getOptionValue(GravitinoOptions.COMMENT);
       gravitinoCommandLine

--- a/clients/cli/src/test/java/org/apache/gravitino/cli/TestFilesetCommands.java
+++ b/clients/cli/src/test/java/org/apache/gravitino/cli/TestFilesetCommands.java
@@ -714,4 +714,24 @@ class TestFilesetCommands {
     // Should not throw exception when managed property is present
     Assertions.assertDoesNotThrow(spyCreateFileset::validate);
   }
+
+  @Test
+  void testUpdateFilesetCommandWithoutOptions() {
+    Main.useExit = false;
+
+    when(mockCommandLine.hasOption(GravitinoOptions.METALAKE)).thenReturn(true);
+    when(mockCommandLine.getOptionValue(GravitinoOptions.METALAKE)).thenReturn("metalake_demo");
+    when(mockCommandLine.hasOption(GravitinoOptions.NAME)).thenReturn(true);
+    when(mockCommandLine.getOptionValue(GravitinoOptions.NAME))
+        .thenReturn("catalog.schema.fileset");
+
+    GravitinoCommandLine commandLine =
+        new GravitinoCommandLine(
+            mockCommandLine, mockOptions, CommandEntities.FILESET, CommandActions.UPDATE);
+
+    assertThrows(RuntimeException.class, commandLine::handleCommandLine);
+    String errOutput = new String(errContent.toByteArray(), StandardCharsets.UTF_8).trim();
+
+    assertEquals(ErrorMessages.MISSING_COMMENT_AND_RENAME, errOutput);
+  }
 }


### PR DESCRIPTION

<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

- Added validation in `FilesetCommandHandler.handleUpdateCommand()` to exit with an error when both `--comment` and `--rename` options are missing for the `fileset update` command.
- Introduced new error message constant `MISSING_COMMENT_AND_RENAME`.
- Added a unit test `testUpdateFilesetCommandWithoutOptions`.

### Why are the changes needed?

Currently, the `fileset update` command can be executed without providing `--comment` or `--rename` options, which results in a no-op operation.

Fix: #8283

### Does this PR introduce _any_ user-facing change?

Yes.  
- Running `fileset update` without `--comment` or `--rename` will now exit with an error message:  
```
Missing --comment and --rename options.
```

### How was this patch tested?

1. Executed a unit test `testUpdateFilesetCommandWithoutOptions()`
2. Executed existing unit tests
