### PR TITLE
[#8302] fix(cli): Fix potential NPE in ListTables

### DIFF
--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/ListTables.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/ListTables.java
@@ -25,6 +25,7 @@ import org.apache.gravitino.Namespace;
 import org.apache.gravitino.cli.CommandContext;
 import org.apache.gravitino.rel.Column;
 import org.apache.gravitino.rel.Table;
+import org.apache.gravitino.rel.TableCatalog;
 
 /** List the names of all tables in a schema. */
 public class ListTables extends TableCommand {
@@ -50,13 +51,20 @@ public class ListTables extends TableCommand {
     NameIdentifier[] tables = null;
     Namespace name = Namespace.of(schema);
 
+    TableCatalog catalog = tableCatalog();
+    if (catalog == null) {
+      // The error message is already printed in the tableCatalog() method.
+      // We just need to exit here.
+      return;
+    }
+
     try {
-      tables = tableCatalog().listTables(name);
+      tables = catalog.listTables(name);
     } catch (Exception exp) {
       exitWithError(exp.getMessage());
     }
 
-    if (tables.length == 0) {
+    if (tables == null || tables.length == 0) {
       printInformation("No tables exist.");
       return;
     }


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

This pull request addresses issue #8302 by adding null checks in ListTables.java to prevent potential NullPointerExceptions.
The key changes include:
- Checking if the tableCatalog object is null before it is used.
- Checking if the tables array is null after calling listTables() and before its properties are accessed.

### Why are the changes needed?

Previously, the list tables command would crash with a NullPointerException if it was executed with a non-existent catalog or if the listTables operation returned null for any reason. This change ensures the command handles these scenarios gracefully by exiting cleanly instead of crashing, which improves the overall stability and reliability of the CLI tool.

Fixes: #8302

### Does this PR introduce _any_ user-facing change?

No. This PR does not introduce any user-facing changes. It is a bug fix that improves the stability and error handling of the CLI.

### How was this patch tested?

This patch was tested by running a full build of the project, including all unit and integration tests, using the ./gradlew clean build command. The build completed successfully, and all existing tests passed, confirming that the changes did not introduce any regressions.

The fix itself was manually reasoned about to ensure it correctly handles the null-checking logic, preventing the NullPointerException. No new tests were added as this change is a simple safeguard and does not alter the existing logic of the command.
