### PR TITLE
[#8280]Improvement(GCSTokenProvider): handle empty uri path

### DIFF
--- a/bundles/gcp/src/main/java/org/apache/gravitino/gcs/credential/GCSTokenProvider.java
+++ b/bundles/gcp/src/main/java/org/apache/gravitino/gcs/credential/GCSTokenProvider.java
@@ -146,6 +146,9 @@ public class GCSTokenProvider implements CredentialProvider {
   @VisibleForTesting
   // Remove the first '/', and append `/` if the path does not end with '/'.
   static String normalizeUriPath(String resourcePath) {
+    if (resourcePath.isEmpty() || "/".equals(resourcePath)) {
+      return "";
+    }
     if (resourcePath.startsWith("/")) {
       resourcePath = resourcePath.substring(1);
     }

--- a/bundles/gcp/src/test/java/org/apache/gravitino/gcs/credential/TestGCSTokenProvider.java
+++ b/bundles/gcp/src/test/java/org/apache/gravitino/gcs/credential/TestGCSTokenProvider.java
@@ -53,7 +53,9 @@ public class TestGCSTokenProvider {
             "/a/b/", "a/b/",
             "/a/b", "a/b/",
             "a/b", "a/b/",
-            "a/b/", "a/b/");
+            "a/b/", "a/b/",
+            "/", "",
+            "", "");
 
     checkResults.forEach(
         (k, v) -> {


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?
Handle the empty URI path in normalizeUriPath in GCSTokenProvider 

### Why are the changes needed?
Currently the method normalizeUriPath in GCSTokenProvider.java doesn't handle empty paths correctly.

Fix: #8280 

### Does this PR introduce _any_ user-facing change?
NO


### How was this patch tested?
Unit testing

