### PR TITLE
[#7438] subtask(UI): Web UI supports model version with multiple URIs

### DIFF
--- a/web/web/src/app/metalakes/metalake/rightContent/LinkVersionDialog.js
+++ b/web/web/src/app/metalakes/metalake/rightContent/LinkVersionDialog.js
@@ -61,16 +61,17 @@ const defaultValues = {
 
 const schema = yup.object().shape({
   uris: yup
-      .array()
-      .of(
-        yup.object().shape({
-          uri: yup.string().when('name', {
-            is: name => !!name || name === 'default',
-            then: schema => schema.required(),
-            otherwise: schema => schema
-          })
+    .array()
+    .of(
+      yup.object().shape({
+        uri: yup.string().when('name', {
+          is: name => !!name || name === 'default',
+          then: schema => schema.required(),
+          otherwise: schema => schema
         })
-      ).test('unique', 'Uri name must be unique', (uris, ctx) => {
+      })
+    )
+    .test('unique', 'Uri name must be unique', (uris, ctx) => {
       const values = uris?.filter(l => !!l.name).map(l => l.name)
       const duplicates = values.filter((value, index, self) => self.indexOf(value) !== index)
 
@@ -201,7 +202,11 @@ const LinkVersionDialog = props => {
     name: 'aliases'
   })
 
-  const { fields: uris, append: appendUri, remove: removeUri } = useFieldArray({
+  const {
+    fields: uris,
+    append: appendUri,
+    remove: removeUri
+  } = useFieldArray({
     control,
     name: 'uris'
   })
@@ -298,7 +303,9 @@ const LinkVersionDialog = props => {
       setCacheData(data)
       setValue('comment', data.comment)
 
-      const uris = data.uris ? Object.entries(data.uris).map(([name, uri]) => ({ name, uri })) : [{ name: 'default', uri: data.uri || '' }]
+      const uris = data.uris
+        ? Object.entries(data.uris).map(([name, uri]) => ({ name, uri }))
+        : [{ name: 'default', uri: data.uri || '' }]
       setValue('uris', uris)
       const aliases = data.aliases.map(alias => ({ name: alias }))
       setValue(`aliases`, aliases)
@@ -366,9 +373,7 @@ const LinkVersionDialog = props => {
                                 label={`Name ${index + 1}`}
                                 data-refer={`uris-name-${index}`}
                                 error={!!errors.uris?.[index]?.name || !!errors.uris?.message}
-                                helperText={
-                                  errors.uris?.[index]?.name?.message || errors.uris?.message
-                                }
+                                helperText={errors.uris?.[index]?.name?.message || errors.uris?.message}
                                 fullWidth
                               />
                             )}
@@ -385,13 +390,8 @@ const LinkVersionDialog = props => {
                                 onChange={onChange}
                                 label={`URI ${index + 1}`}
                                 data-refer={`uris-uri-${index}`}
-                                error={
-                                  !!errors.uris?.[index]?.uri || !!errors.uris?.message
-                                }
-                                helperText={
-                                  errors.uris?.[index]?.uri?.message ||
-                                  errors.uris?.message
-                                }
+                                error={!!errors.uris?.[index]?.uri || !!errors.uris?.message}
+                                helperText={errors.uris?.[index]?.uri?.message || errors.uris?.message}
                                 fullWidth
                               />
                             )}
@@ -427,9 +427,7 @@ const LinkVersionDialog = props => {
                   </Grid>
                 )
               })}
-              {errors.uris && (
-                <FormHelperText sx={{ color: 'error.main' }}>{errors.uris.message}</FormHelperText>
-              )}
+              {errors.uris && <FormHelperText sx={{ color: 'error.main' }}>{errors.uris.message}</FormHelperText>}
             </Grid>
 
             <Grid item xs={12}>

--- a/web/web/src/app/metalakes/metalake/rightContent/tabsContent/detailsView/DetailsView.js
+++ b/web/web/src/app/metalakes/metalake/rightContent/tabsContent/detailsView/DetailsView.js
@@ -210,10 +210,7 @@ const DetailsView = () => {
                           className={'twc-py-[0.7rem] twc-truncate twc-max-w-[134px]'}
                           data-refer={`uris-name-${name}`}
                         >
-                          <Tooltip
-                            title={<span data-refer={`tip-uris-name-${name}`}>{name}</span>}
-                            placement='bottom'
-                          >
+                          <Tooltip title={<span data-refer={`tip-uris-name-${name}`}>{name}</span>} placement='bottom'>
                             {name}
                           </Tooltip>
                         </TableCell>
@@ -223,11 +220,7 @@ const DetailsView = () => {
                           data-prev-refer={`uris-name-${name}`}
                         >
                           <Tooltip
-                            title={
-                              <span data-prev-refer={`uris-name-${name}`}>
-                                {activatedItem?.uris[name]}
-                              </span>
-                            }
+                            title={<span data-prev-refer={`uris-name-${name}`}>{activatedItem?.uris[name]}</span>}
                             placement='bottom'
                           >
                             {activatedItem?.uris[name]}

--- a/web/web/src/app/metalakes/metalake/rightContent/tabsContent/detailsView/DetailsView.js
+++ b/web/web/src/app/metalakes/metalake/rightContent/tabsContent/detailsView/DetailsView.js
@@ -184,6 +184,64 @@ const DetailsView = () => {
           </Grid>
         )}
 
+        {activatedItem?.uris && (
+          <Grid item xs={12} sx={{ mb: [0, 5] }}>
+            <Typography variant='body2' sx={{ mb: 2 }}>
+              URI(s)
+            </Typography>
+
+            <TableContainer>
+              <Table>
+                <TableHead
+                  sx={{
+                    backgroundColor: theme => theme.palette.action.hover
+                  }}
+                >
+                  <TableRow>
+                    <TableCell sx={{ py: 2 }}>Name</TableCell>
+                    <TableCell sx={{ py: 2 }}>URI</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody data-refer='details-uris-table'>
+                  {Object.keys(activatedItem?.uris).map((name, index) => {
+                    return (
+                      <TableRow key={index} data-refer={`details-uris-index-${index}`}>
+                        <TableCell
+                          className={'twc-py-[0.7rem] twc-truncate twc-max-w-[134px]'}
+                          data-refer={`uris-name-${name}`}
+                        >
+                          <Tooltip
+                            title={<span data-refer={`tip-uris-name-${name}`}>{name}</span>}
+                            placement='bottom'
+                          >
+                            {name}
+                          </Tooltip>
+                        </TableCell>
+                        <TableCell
+                          className={'twc-py-[0.7rem] twc-truncate twc-max-w-[134px]'}
+                          data-refer={`uris-location-${activatedItem?.uris[name]}`}
+                          data-prev-refer={`uris-name-${name}`}
+                        >
+                          <Tooltip
+                            title={
+                              <span data-prev-refer={`uris-name-${name}`}>
+                                {activatedItem?.uris[name]}
+                              </span>
+                            }
+                            placement='bottom'
+                          >
+                            {activatedItem?.uris[name]}
+                          </Tooltip>
+                        </TableCell>
+                      </TableRow>
+                    )
+                  })}
+                </TableBody>
+              </Table>
+            </TableContainer>
+          </Grid>
+        )}
+
         {activatedItem?.aliases && (
           <Grid item xs={12} md={6} sx={{ mb: [0, 5] }}>
             <Typography variant='body2' sx={{ mb: 2 }}>

--- a/web/web/src/components/DetailsDrawer.js
+++ b/web/web/src/components/DetailsDrawer.js
@@ -134,6 +134,64 @@ const DetailsDrawer = props => {
           </Grid>
         )}
 
+        {drawerData.uris && (
+          <Grid item xs={12} sx={{ mb: [0, 5] }}>
+            <Typography variant='body2' sx={{ mb: 2 }}>
+              URI(s)
+            </Typography>
+
+            <TableContainer>
+              <Table>
+                <TableHead
+                  sx={{
+                    backgroundColor: theme => theme.palette.action.hover
+                  }}
+                >
+                  <TableRow>
+                    <TableCell sx={{ py: 2 }}>Name</TableCell>
+                    <TableCell sx={{ py: 2 }}>URI</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody data-refer='details-props-table'>
+                  {Object.keys(drawerData.uris).map((name, index) => {
+                    return (
+                      <TableRow key={index} data-refer={`details-props-index-${index}`}>
+                        <TableCell
+                          className={'twc-py-[0.7rem] twc-truncate twc-max-w-[134px]'}
+                          data-refer={`uris-name-${name}`}
+                        >
+                          <Tooltip
+                            title={<span data-refer={`tip-uris-name-${name}`}>{name}</span>}
+                            placement='bottom'
+                          >
+                            {name}
+                          </Tooltip>
+                        </TableCell>
+                        <TableCell
+                          className={'twc-py-[0.7rem] twc-truncate twc-max-w-[134px]'}
+                          data-refer={`uris-uri-${drawerData.uris[name]}`}
+                          data-prev-refer={`uris-name-${name}`}
+                        >
+                          <Tooltip
+                            title={
+                              <span data-prev-refer={`uris-uri-${name}`}>
+                                {drawerData.uris[name]}
+                              </span>
+                            }
+                            placement='bottom'
+                          >
+                            {drawerData.uris[name]}
+                          </Tooltip>
+                        </TableCell>
+                      </TableRow>
+                    )
+                  })}
+                </TableBody>
+              </Table>
+            </TableContainer>
+          </Grid>
+        )}
+
         {drawerData.aliases && (
           <Grid item xs={12} md={6} sx={{ mb: [0, 5] }}>
             <Typography variant='body2' sx={{ mb: 2 }}>

--- a/web/web/src/components/DetailsDrawer.js
+++ b/web/web/src/components/DetailsDrawer.js
@@ -160,10 +160,7 @@ const DetailsDrawer = props => {
                           className={'twc-py-[0.7rem] twc-truncate twc-max-w-[134px]'}
                           data-refer={`uris-name-${name}`}
                         >
-                          <Tooltip
-                            title={<span data-refer={`tip-uris-name-${name}`}>{name}</span>}
-                            placement='bottom'
-                          >
+                          <Tooltip title={<span data-refer={`tip-uris-name-${name}`}>{name}</span>} placement='bottom'>
                             {name}
                           </Tooltip>
                         </TableCell>
@@ -173,11 +170,7 @@ const DetailsDrawer = props => {
                           data-prev-refer={`uris-name-${name}`}
                         >
                           <Tooltip
-                            title={
-                              <span data-prev-refer={`uris-uri-${name}`}>
-                                {drawerData.uris[name]}
-                              </span>
-                            }
+                            title={<span data-prev-refer={`uris-uri-${name}`}>{drawerData.uris[name]}</span>}
                             placement='bottom'
                           >
                             {drawerData.uris[name]}

--- a/web/web/src/lib/utils/index.js
+++ b/web/web/src/lib/utils/index.js
@@ -63,6 +63,40 @@ export const genUpdates = (originalData, newData) => {
     updates.push({ '@type': 'updateUri', newUri: newData.uri })
   }
 
+  const originalUris = originalData.uris || {}
+  const newUris = newData.uris || {}
+
+  for (const key in originalUris) {
+    if (!(key in newUris)) {
+      updates.push({ '@type': 'removeUri', uriName: key })
+    }
+  }
+
+  for (const key in newUris) {
+    if (originalUris[key] !== newUris[key]) {
+      if (originalUris[key] === undefined) {
+        updates.push({ '@type': 'addUri', uriName: key, uri: newUris[key] })
+      } else {
+        updates.push({ '@type': 'updateUri', uriName: key, newUri: newUris[key] })
+      }
+    }
+  }
+
+  const originalAliases = originalData.aliases || []
+  const newAliases = newData.aliases || []
+  
+  const aliasesToAdd = newAliases.filter(alias => !originalAliases.includes(alias))
+  const aliasesToRemove = originalAliases.filter(alias => !newAliases.includes(alias))
+  
+  if (aliasesToAdd.length > 0 || aliasesToRemove.length > 0) {
+    updates.push({ 
+      '@type': 'updateAliases', 
+      aliasesToAdd: aliasesToAdd, 
+      aliasesToRemove: aliasesToRemove 
+    })
+  }
+
+
   if (originalData.comment !== newData.comment) {
     updates.push({ '@type': 'updateComment', newComment: newData.comment })
   }

--- a/web/web/src/lib/utils/index.js
+++ b/web/web/src/lib/utils/index.js
@@ -84,18 +84,17 @@ export const genUpdates = (originalData, newData) => {
 
   const originalAliases = originalData.aliases || []
   const newAliases = newData.aliases || []
-  
+
   const aliasesToAdd = newAliases.filter(alias => !originalAliases.includes(alias))
   const aliasesToRemove = originalAliases.filter(alias => !newAliases.includes(alias))
-  
+
   if (aliasesToAdd.length > 0 || aliasesToRemove.length > 0) {
-    updates.push({ 
-      '@type': 'updateAliases', 
-      aliasesToAdd: aliasesToAdd, 
-      aliasesToRemove: aliasesToRemove 
+    updates.push({
+      '@type': 'updateAliases',
+      aliasesToAdd: aliasesToAdd,
+      aliasesToRemove: aliasesToRemove
     })
   }
-
 
   if (originalData.comment !== newData.comment) {
     updates.push({ '@type': 'updateComment', newComment: newData.comment })


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. Web UI supports model version with multiple URIs
2. support edit aliases
<img width="700" height="844" alt="image" src="https://github.com/user-attachments/assets/f9296878-d6bc-415b-88af-9ad8f790213d" />
<img width="1051" height="885" alt="image" src="https://github.com/user-attachments/assets/9d3fc85e-9209-4db2-badd-6b23f2964d95" />
<img width="1148" height="781" alt="image" src="https://github.com/user-attachments/assets/000c9020-3268-4562-b868-7ad32f296076" />
<img width="779" height="709" alt="image" src="https://github.com/user-attachments/assets/90d43765-b986-48db-9aca-89976862e714" />



### Why are the changes needed?
N/A

Fix: #7438

### Does this PR introduce _any_ user-facing change?
N/A

### How was this patch tested?
munually
