### PR TITLE
[#8306] Avoid rollback when autocommit is true in ScriptRunner.java

### DIFF
--- a/catalogs/hive-metastore-common/src/test/java/org/apache/gravitino/hive/hms/ScriptRunner.java
+++ b/catalogs/hive-metastore-common/src/test/java/org/apache/gravitino/hive/hms/ScriptRunner.java
@@ -189,9 +189,15 @@ public class ScriptRunner {
       e.fillInStackTrace();
       printlnError("Error executing: " + command);
       printlnError(e);
+      if (!autoCommit) {
+        try {
+          conn.rollback();
+        } catch (SQLException rollbackException) {
+          printlnError("Error during rollback " + rollbackException);
+        }
+      }
       throw e;
     } finally {
-      conn.rollback();
       flush();
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
---
- Updated `ScriptRunner.java` so that `conn.rollback()` is **not always called**.  
- Rollback is now only performed when:  
  - `autoCommit` is set to `false`, **and**  
  - an exception occurs during script execution.  
- Moved `conn.rollback()` logic from the `finally` block into the `catch` block.  
- Cleaned up control flow to avoid unnecessary rollback calls after successful commits.  

---

### Why are the changes needed?
---
Previously, `conn.rollback()` was called in the `finally` block regardless of connection mode.  

- When `autoCommit = true`, rollback has no effect and is misleading.  
- When a commit was already performed successfully, rollback was still invoked unnecessarily.  

This change makes rollback behavior **cleaner and safer**, ensuring it is only triggered when actually required.  

---

### Does this PR introduce _any_ user-facing change?
---
-  No user-facing API changes.  
-  Internal improvement in the Hive Metastore test utility `ScriptRunner.java`.  
