### PR TITLE
[#7908] improvement(python-client): Support passing custom configuration for python GVFS client.

### DIFF
--- a/clients/client-python/gravitino/filesystem/gvfs.py
+++ b/clients/client-python/gravitino/filesystem/gvfs.py
@@ -70,6 +70,7 @@ class GravitinoVirtualFileSystem(fsspec.AbstractFileSystem):
         :param options: Options for the GravitinoVirtualFileSystem
         :param kwargs: Extra args for super filesystem
         """
+        self._kwargs = dict(kwargs)
         self._hook = self._get_hook_class(options)
         self._hook.initialize(options)
         self._operations = self._get_gvfs_operations_class(
@@ -459,6 +460,7 @@ class GravitinoVirtualFileSystem(fsspec.AbstractFileSystem):
             server_uri=server_uri,
             metalake_name=metalake_name,
             options=options,
+            **self._kwargs,
         )
 
 

--- a/clients/client-python/gravitino/filesystem/gvfs_base_operations.py
+++ b/clients/client-python/gravitino/filesystem/gvfs_base_operations.py
@@ -147,6 +147,7 @@ class BaseGVFSOperations(ABC):
             )
         )
         self._current_location_name = self._init_current_location_name()
+        self._kwargs = kwargs
 
     @property
     def current_location_name(self):
@@ -519,6 +520,7 @@ class BaseGVFSOperations(ABC):
                 fileset_catalog.properties(),
                 self._options,
                 actual_file_location,
+                **self._kwargs,
             )
             self._filesystem_cache[(name_identifier, location_name)] = new_cache_value
             return new_cache_value[1]


### PR DESCRIPTION

### What changes were proposed in this pull request?

Support passing kwargs to Python GVFS client.

### Why are the changes needed?

It's a common requirement.

Fix: #7908 

### Does this PR introduce _any_ user-facing change?

N/A.

### How was this patch tested?

ITs
