### PR TITLE
[#8346] fix(server): fix misleading log message in catalog drop operation

### DIFF
--- a/server/src/main/java/org/apache/gravitino/server/web/rest/CatalogOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/CatalogOperations.java
@@ -333,9 +333,10 @@ public class CatalogOperations {
             boolean dropped = catalogDispatcher.dropCatalog(ident, force);
             if (!dropped) {
               LOG.warn("Failed to drop catalog {} under metalake {}", catalogName, metalakeName);
+            } else {
+              LOG.info("Catalog dropped: {}.{}", metalakeName, catalogName);
             }
             Response response = Utils.ok(new DropResponse(dropped));
-            LOG.info("Catalog dropped: {}.{}", metalakeName, catalogName);
             return response;
           });
     } catch (Exception e) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Move success log message inside conditional block to avoid misleading logs in `CatalogOperations.java` .

### Why are the changes needed?

Fixes #8346

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

- Ran `./gradlew clean build`