### PR TITLE
[Improvement] Correct entity type in ModelMetaService.java error mess…

### DIFF
--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/ModelMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/ModelMetaService.java
@@ -260,7 +260,7 @@ public class ModelMetaService {
                       POConverters.updateModelPO(oldModelPO, newEntity), oldModelPO));
     } catch (RuntimeException re) {
       ExceptionUtils.checkSQLException(
-          re, Entity.EntityType.CATALOG, newEntity.nameIdentifier().toString());
+          re, Entity.EntityType.MODEL, newEntity.nameIdentifier().toString());
       throw re;
     }
 


### PR DESCRIPTION
…age (fixes #8349)

<!--
1. Title:[#8349] fix(core): use correct entity type MODEL instead of CATALOG in ModelMetaService

2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Replaced `Entity.EntityType.CATALOG` with `Entity.EntityType.MODEL` in  
`core/src/main/java/org/apache/gravitino/storage/relational/service/ModelMetaService.java`.

### Why are the changes needed?

This fixes the wrong entity type passed into `ExceptionUtils.checkSQLException`.  
The correct entity type for `ModelMetaService` is `MODEL`, not `CATALOG`.

Fix: #(issue)

### Does this PR introduce _any_ user-facing change?


No user-facing changes. Internal bugfix only.

### How was this patch tested?     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/

I have not verified the build or run tests locally due to environment limitations.  
Please confirm if running the full test suite is required for this change.
