### PR TITLE
Fix softDeleteSQL to correctly calculate deleted_at in milliseconds

### DIFF
--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/StatisticPostgresSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/StatisticPostgresSQLProvider.java
@@ -28,7 +28,7 @@ public class StatisticPostgresSQLProvider extends StatisticBaseSQLProvider {
   @Override
   protected String softDeleteSQL() {
     return " SET deleted_at = floor(extract(epoch from((current_timestamp -"
-        + " timestamp '1970-01-01 00:00:00')*1000))) ";
+        + " timestamp '1970-01-01 00:00:00'))*1000) ";
   }
 
   @Override


### PR DESCRIPTION
Moved the * 1000 multiplication outside the extract(epoch ...) call.

The SQL now reads:

```SET deleted_at = floor(extract(epoch from current_timestamp) * 1000)```

This change ensures the deleted timestamp is properly recorded in milliseconds, providing accuracy required by downstream consumers.