### PR TITLE
 [#8341]  improvement(config): ake sure ConfigBuilder params with leading/trailing spaces are parsed correctly

### DIFF
--- a/common/src/main/java/org/apache/gravitino/config/ConfigBuilder.java
+++ b/common/src/main/java/org/apache/gravitino/config/ConfigBuilder.java
@@ -130,10 +130,10 @@ public class ConfigBuilder {
         new ConfigEntry<>(key, version, doc, alternatives, isPublic, isDeprecated);
     Function<String, Integer> func =
         s -> {
-          if (s == null || s.isEmpty()) {
+          if (s == null || s.trim().isEmpty()) {
             return null;
           } else {
-            return Integer.parseInt(s);
+            return Integer.parseInt(s.trim());
           }
         };
     conf.setValueConverter(func);
@@ -155,10 +155,10 @@ public class ConfigBuilder {
         new ConfigEntry<>(key, version, doc, alternatives, isPublic, isDeprecated);
     Function<String, Long> func =
         s -> {
-          if (s == null || s.isEmpty()) {
+          if (s == null || s.trim().isEmpty()) {
             return null;
           } else {
-            return Long.parseLong(s);
+            return Long.parseLong(s.trim());
           }
         };
     conf.setValueConverter(func);
@@ -180,10 +180,10 @@ public class ConfigBuilder {
         new ConfigEntry<>(key, version, doc, alternatives, isPublic, isDeprecated);
     Function<String, Double> func =
         s -> {
-          if (s == null || s.isEmpty()) {
+          if (s == null || s.trim().isEmpty()) {
             return null;
           } else {
-            return Double.parseDouble(s);
+            return Double.parseDouble(s.trim());
           }
         };
     conf.setValueConverter(func);
@@ -205,10 +205,10 @@ public class ConfigBuilder {
         new ConfigEntry<>(key, version, doc, alternatives, isPublic, isDeprecated);
     Function<String, Boolean> func =
         s -> {
-          if (s == null || s.isEmpty()) {
+          if (s == null || s.trim().isEmpty()) {
             return null;
           } else {
-            return Boolean.parseBoolean(s);
+            return Boolean.parseBoolean(s.trim());
           }
         };
     conf.setValueConverter(func);

--- a/core/src/test/java/org/apache/gravitino/TestConfig.java
+++ b/core/src/test/java/org/apache/gravitino/TestConfig.java
@@ -21,6 +21,8 @@ package org.apache.gravitino;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.nio.file.Files;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.Properties;
@@ -149,5 +151,26 @@ public class TestConfig {
     config.set(intConf, Optional.of(2));
     intValue = config.get(intConf);
     Assertions.assertEquals(Optional.of(2), intValue);
+  }
+
+  @Test
+  public void testTrimmedValues() {
+    Map<String, String> props = new HashMap<>();
+
+    props.put("int.key", " 1 ");
+    ConfigEntry<Integer> intEntry = new ConfigBuilder("int.key").intConf();
+    Assertions.assertEquals(1, intEntry.readFrom(props));
+
+    props.put("long.key", " 2 ");
+    ConfigEntry<Long> longEntry = new ConfigBuilder("long.key").longConf();
+    Assertions.assertEquals(2L, longEntry.readFrom(props));
+
+    props.put("double.key", " 3.5 ");
+    ConfigEntry<Double> doubleEntry = new ConfigBuilder("double.key").doubleConf();
+    Assertions.assertEquals(3.5d, doubleEntry.readFrom(props));
+
+    props.put("boolean.key", " true ");
+    ConfigEntry<Boolean> boolEntry = new ConfigBuilder("boolean.key").booleanConf();
+    Assertions.assertTrue(boolEntry.readFrom(props));
   }
 }


### PR DESCRIPTION

### What changes were proposed in this pull request?
Add trim() method on the value string in valudeConvertor in ConfigBuilder.java.
 
### Why are the changes needed?

Params with spaces can be parsed correctly. Otherwise it will throw exceptoin.

Fix: #8341 

### Does this PR introduce _any_ user-facing change?
NO

### How was this patch tested?

Unit test added.