### PR TITLE
[#8343] fix: correct invalid exception handling in GroupDetails

### DIFF
--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/GroupDetails.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/GroupDetails.java
@@ -24,8 +24,8 @@ import org.apache.gravitino.authorization.Group;
 import org.apache.gravitino.cli.CommandContext;
 import org.apache.gravitino.cli.ErrorMessages;
 import org.apache.gravitino.client.GravitinoClient;
+import org.apache.gravitino.exceptions.NoSuchGroupException;
 import org.apache.gravitino.exceptions.NoSuchMetalakeException;
-import org.apache.gravitino.exceptions.NoSuchUserException;
 
 public class GroupDetails extends Command {
 
@@ -57,7 +57,7 @@ public class GroupDetails extends Command {
       roles = groupObject.roles();
     } catch (NoSuchMetalakeException err) {
       exitWithError(ErrorMessages.UNKNOWN_METALAKE);
-    } catch (NoSuchUserException err) {
+    } catch (NoSuchGroupException err) {
       exitWithError(ErrorMessages.UNKNOWN_GROUP);
     } catch (Exception exp) {
       exitWithError(exp.getMessage());


### PR DESCRIPTION
### What changes were proposed in this pull request?
- In GroupDetails.java, updated the catch clause to handle the correct exception:
  - Changed from NoSuchUserException → NoSuchGroupException.

### Why are the changes needed?
- GroupDetails is currently catching NoSuchUserException by mistake, when it should be handling NoSuchGroupException.

Fix: #8343 

### Does this PR introduce _any_ user-facing change?
- No.
- This change only corrects internal exception handling logic, with no modification to public APIs or user-visible behavior.

### How was this patch tested?
- No new tests added, since this only fixes the caught exception type.

