### PR TITLE
[#5199] feat(client-python): add partitioning DTO serdes

### DIFF
--- a/clients/client-python/gravitino/api/types/json_serdes/base.py
+++ b/clients/client-python/gravitino/api/types/json_serdes/base.py
@@ -22,9 +22,12 @@ from dataclasses_json.core import Json
 
 from gravitino.api.expressions.expression import Expression
 from gravitino.api.types.types import Type
+from gravitino.dto.rel.partitioning.partitioning import Partitioning
 from gravitino.dto.rel.partitions.partition_dto import PartitionDTO
 
-GravitinoTypeT = TypeVar("GravitinoTypeT", bound=Union[Expression, Type, PartitionDTO])
+GravitinoTypeT = TypeVar(
+    "GravitinoTypeT", bound=Union[Expression, Type, Partitioning, PartitionDTO]
+)
 
 
 class JsonSerializable(ABC, Generic[GravitinoTypeT]):

--- a/clients/client-python/gravitino/api/types/json_serdes/base.py
+++ b/clients/client-python/gravitino/api/types/json_serdes/base.py
@@ -20,26 +20,32 @@ from typing import Generic, TypeVar, Union
 
 from dataclasses_json.core import Json
 
+from gravitino.api.expressions.distributions.distribution import Distribution
 from gravitino.api.expressions.expression import Expression
+from gravitino.api.expressions.indexes.index import Index
+from gravitino.api.expressions.sorts.sort_order import SortOrder
 from gravitino.api.types.types import Type
 from gravitino.dto.rel.partitioning.partitioning import Partitioning
 from gravitino.dto.rel.partitions.partition_dto import PartitionDTO
 
-GravitinoTypeT = TypeVar(
-    "GravitinoTypeT", bound=Union[Expression, Type, Partitioning, PartitionDTO]
+_GravitinoTypeT = TypeVar(
+    "_GravitinoTypeT",
+    bound=Union[
+        Expression, Type, Partitioning, PartitionDTO, Distribution, Index, SortOrder
+    ],
 )
 
 
-class JsonSerializable(ABC, Generic[GravitinoTypeT]):
+class JsonSerializable(ABC, Generic[_GravitinoTypeT]):
     """Customized generic Serializer for DataClassJson."""
 
     @classmethod
     @abstractmethod
-    def serialize(cls, data_type: GravitinoTypeT) -> Json:
+    def serialize(cls, data_type: _GravitinoTypeT) -> Json:
         """To serialize the given `data`.
 
         Args:
-            data (GravitinoTypeT): The data to be serialized.
+            data (_GravitinoTypeT): The data to be serialized.
 
         Returns:
             Json: The serialized data.
@@ -48,13 +54,13 @@ class JsonSerializable(ABC, Generic[GravitinoTypeT]):
 
     @classmethod
     @abstractmethod
-    def deserialize(cls, data: Json) -> GravitinoTypeT:
+    def deserialize(cls, data: Json) -> _GravitinoTypeT:
         """To deserialize the given `data`.
 
         Args:
             data (Json): The data to be deserialized.
 
         Returns:
-            GravitinoTypeT: The deserialized data.
+            _GravitinoTypeT: The deserialized data.
         """
         pass

--- a/clients/client-python/gravitino/dto/rel/partitioning/json_serdes/__init__.py
+++ b/clients/client-python/gravitino/dto/rel/partitioning/json_serdes/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/clients/client-python/gravitino/dto/rel/partitioning/json_serdes/partitioning_serdes.py
+++ b/clients/client-python/gravitino/dto/rel/partitioning/json_serdes/partitioning_serdes.py
@@ -33,6 +33,9 @@ from gravitino.dto.rel.partitioning.partitioning import (
     Partitioning,
     SingleFieldPartitioning,
 )
+from gravitino.dto.rel.partitioning.truncate_partitioning_dto import (
+    TruncatePartitioningDTO,
+)
 from gravitino.dto.rel.partitioning.year_partitioning_dto import YearPartitioningDTO
 from gravitino.utils.precondition import Precondition
 from gravitino.utils.serdes import SerdesUtilsBase
@@ -78,6 +81,13 @@ class PartitioningSerdes(SerdesUtilsBase, JsonSerializable[Partitioning]):
                 cls.NUM_BUCKETS: partitioning.num_buckets(),
                 cls.FIELD_NAMES: partitioning.field_names(),
             }
+        if strategy is Partitioning.Strategy.TRUNCATE:
+            partitioning = cast(TruncatePartitioningDTO, data_type)
+            return {
+                **result,
+                cls.WIDTH: partitioning.width(),
+                cls.FIELD_NAME: partitioning.field_name(),
+            }
 
         raise IOError(f"Unknown partitioning strategy: {strategy}")
 
@@ -103,5 +113,10 @@ class PartitioningSerdes(SerdesUtilsBase, JsonSerializable[Partitioning]):
             return BucketPartitioningDTO(
                 int(data[cls.NUM_BUCKETS]),
                 *data.get(cls.FIELD_NAMES, []),
+            )
+        if strategy is Partitioning.Strategy.TRUNCATE:
+            return TruncatePartitioningDTO(
+                int(data[cls.WIDTH]),
+                data.get(cls.FIELD_NAME, []),
             )
         raise IOError(f"Unknown partitioning strategy: {data[cls.STRATEGY]}")

--- a/clients/client-python/gravitino/dto/rel/partitioning/json_serdes/partitioning_serdes.py
+++ b/clients/client-python/gravitino/dto/rel/partitioning/json_serdes/partitioning_serdes.py
@@ -1,0 +1,93 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from contextlib import suppress
+from types import MappingProxyType
+from typing import Any, Dict, Final, cast
+
+from gravitino.api.types.json_serdes.base import JsonSerializable
+from gravitino.dto.rel.partitioning.day_partitioning_dto import DayPartitioningDTO
+from gravitino.dto.rel.partitioning.hour_partitioning_dto import HourPartitioningDTO
+from gravitino.dto.rel.partitioning.identity_partitioning_dto import (
+    IdentityPartitioningDTO,
+)
+from gravitino.dto.rel.partitioning.month_partitioning_dto import MonthPartitioningDTO
+from gravitino.dto.rel.partitioning.partitioning import (
+    Partitioning,
+    SingleFieldPartitioning,
+)
+from gravitino.dto.rel.partitioning.year_partitioning_dto import YearPartitioningDTO
+from gravitino.utils.precondition import Precondition
+from gravitino.utils.serdes import SerdesUtilsBase
+
+
+class PartitioningSerdes(SerdesUtilsBase, JsonSerializable[Partitioning]):
+    """Custom JSON serializer/deserializer for PartitionDTO objects."""
+
+    _SINGLE_FIELD_PARTITIONING: Final[MappingProxyType] = MappingProxyType(
+        {
+            Partitioning.Strategy.IDENTITY: IdentityPartitioningDTO,
+            Partitioning.Strategy.YEAR: YearPartitioningDTO,
+            Partitioning.Strategy.MONTH: MonthPartitioningDTO,
+            Partitioning.Strategy.DAY: DayPartitioningDTO,
+            Partitioning.Strategy.HOUR: HourPartitioningDTO,
+        }
+    )
+
+    @classmethod
+    def serialize(cls, data_type: Partitioning) -> Dict[str, Any]:
+        """Serialize the given PartitionDTO object.
+
+        Args:
+            data_type (Partitioning): The PartitionDTO objects.
+
+        Returns:
+            Dict[str, Any]: The serialized result.
+
+        Raises:
+            IOError: If partitioning strategy is unknown.
+        """
+
+        strategy = data_type.strategy()
+        result = {cls.STRATEGY: strategy.name.lower()}
+
+        if strategy in cls._SINGLE_FIELD_PARTITIONING:
+            partitioning = cast(SingleFieldPartitioning, data_type)
+            return {**result, cls.FIELD_NAME: partitioning.field_name()}
+
+        raise IOError(f"Unknown partitioning strategy: {strategy}")
+
+    @classmethod
+    def deserialize(cls, data: Dict[str, Any]) -> Partitioning:
+        Precondition.check_argument(
+            isinstance(data, dict) and len(data) > 0,
+            f"Cannot parse partitioning from invalid JSON: {data}",
+        )
+        Precondition.check_argument(
+            cls.STRATEGY in data,
+            f"Cannot parse partitioning from missing strategy: {data}",
+        )
+        strategy = None
+        with suppress(ValueError):
+            strategy = Partitioning.Strategy(data[cls.STRATEGY].lower())
+
+        if strategy in cls._SINGLE_FIELD_PARTITIONING:
+            return cls._SINGLE_FIELD_PARTITIONING[strategy](
+                *data.get(cls.FIELD_NAME, [])
+            )
+
+        raise IOError(f"Unknown partitioning strategy: {data[cls.STRATEGY]}")

--- a/clients/client-python/gravitino/dto/rel/partitioning/json_serdes/partitioning_serdes.py
+++ b/clients/client-python/gravitino/dto/rel/partitioning/json_serdes/partitioning_serdes.py
@@ -136,6 +136,18 @@ class PartitioningSerdes(SerdesUtilsBase, JsonSerializable[Partitioning]):
 
     @classmethod
     def deserialize(cls, data: Dict[str, Any]) -> Partitioning:
+        """Deserialize the given JSON data to the corresponding Partitioning object.
+
+        Args:
+            data (Dict[str, Any]): The JSON data object to be deserialized.
+
+        Returns:
+            Partitioning: The deserialized result.
+
+        Raises:
+            IllegalArgumentException: If there's illegal arguments in the given JSON data.
+        """
+
         Precondition.check_argument(
             isinstance(data, dict) and len(data) > 0,
             f"Cannot parse partitioning from invalid JSON: {data}",

--- a/clients/client-python/gravitino/dto/rel/partitioning/json_serdes/partitioning_serdes.py
+++ b/clients/client-python/gravitino/dto/rel/partitioning/json_serdes/partitioning_serdes.py
@@ -75,30 +75,30 @@ class PartitioningSerdes(SerdesUtilsBase, JsonSerializable[Partitioning]):
         result = {cls.STRATEGY: strategy.name.lower()}
 
         if strategy in cls._SINGLE_FIELD_PARTITIONING:
-            partitioning = cast(SingleFieldPartitioning, data_type)
-            return {**result, cls.FIELD_NAME: partitioning.field_name()}
+            dto = cast(SingleFieldPartitioning, data_type)
+            return {**result, cls.FIELD_NAME: dto.field_name()}
         if strategy is Partitioning.Strategy.BUCKET:
-            partitioning = cast(BucketPartitioningDTO, data_type)
+            dto = cast(BucketPartitioningDTO, data_type)
             return {
                 **result,
-                cls.NUM_BUCKETS: partitioning.num_buckets(),
-                cls.FIELD_NAMES: partitioning.field_names(),
+                cls.NUM_BUCKETS: dto.num_buckets(),
+                cls.FIELD_NAMES: dto.field_names(),
             }
         if strategy is Partitioning.Strategy.TRUNCATE:
-            partitioning = cast(TruncatePartitioningDTO, data_type)
+            dto = cast(TruncatePartitioningDTO, data_type)
             return {
                 **result,
-                cls.WIDTH: partitioning.width(),
-                cls.FIELD_NAME: partitioning.field_name(),
+                cls.WIDTH: dto.width(),
+                cls.FIELD_NAME: dto.field_name(),
             }
         if strategy is Partitioning.Strategy.LIST:
-            partitioning = cast(ListPartitioningDTO, data_type)
+            dto = cast(ListPartitioningDTO, data_type)
             return {
                 **result,
-                cls.FIELD_NAMES: partitioning.field_names(),
+                cls.FIELD_NAMES: dto.field_names(),
                 cls.ASSIGNMENTS_NAME: [
                     SerdesUtils.write_partition(list_partition_dto)
-                    for list_partition_dto in partitioning.assignments()
+                    for list_partition_dto in dto.assignments()
                 ],
             }
 

--- a/clients/client-python/gravitino/dto/rel/partitioning/json_serdes/partitioning_serdes.py
+++ b/clients/client-python/gravitino/dto/rel/partitioning/json_serdes/partitioning_serdes.py
@@ -28,6 +28,7 @@ from gravitino.dto.rel.partitioning.hour_partitioning_dto import HourPartitionin
 from gravitino.dto.rel.partitioning.identity_partitioning_dto import (
     IdentityPartitioningDTO,
 )
+from gravitino.dto.rel.partitioning.list_partitioning_dto import ListPartitioningDTO
 from gravitino.dto.rel.partitioning.month_partitioning_dto import MonthPartitioningDTO
 from gravitino.dto.rel.partitioning.partitioning import (
     Partitioning,
@@ -37,6 +38,8 @@ from gravitino.dto.rel.partitioning.truncate_partitioning_dto import (
     TruncatePartitioningDTO,
 )
 from gravitino.dto.rel.partitioning.year_partitioning_dto import YearPartitioningDTO
+from gravitino.dto.rel.partitions.json_serdes._helper.serdes_utils import SerdesUtils
+from gravitino.dto.rel.partitions.list_partition_dto import ListPartitionDTO
 from gravitino.utils.precondition import Precondition
 from gravitino.utils.serdes import SerdesUtilsBase
 
@@ -88,6 +91,16 @@ class PartitioningSerdes(SerdesUtilsBase, JsonSerializable[Partitioning]):
                 cls.WIDTH: partitioning.width(),
                 cls.FIELD_NAME: partitioning.field_name(),
             }
+        if strategy is Partitioning.Strategy.LIST:
+            partitioning = cast(ListPartitioningDTO, data_type)
+            return {
+                **result,
+                cls.FIELD_NAMES: partitioning.field_names(),
+                cls.ASSIGNMENTS_NAME: [
+                    SerdesUtils.write_partition(list_partition_dto)
+                    for list_partition_dto in partitioning.assignments()
+                ],
+            }
 
         raise IOError(f"Unknown partitioning strategy: {strategy}")
 
@@ -119,4 +132,21 @@ class PartitioningSerdes(SerdesUtilsBase, JsonSerializable[Partitioning]):
                 int(data[cls.WIDTH]),
                 data.get(cls.FIELD_NAME, []),
             )
+        if strategy is Partitioning.Strategy.LIST:
+            field_names = data[cls.FIELD_NAMES]
+            assignments_data = data.get(cls.ASSIGNMENTS_NAME, [])
+            Precondition.check_argument(
+                isinstance(assignments_data, list),
+                f"Cannot parse list partitioning from non-array assignments: {assignments_data}",
+            )
+            assignments = []
+            for assignment in assignments_data:
+                partition_dto = SerdesUtils.read_partition(assignment)
+                Precondition.check_argument(
+                    isinstance(partition_dto, ListPartitionDTO),
+                    f"Cannot parse list partitioning from non-list assignment: {assignment}",
+                )
+                assignments.append(partition_dto)
+            return ListPartitioningDTO(field_names, assignments)
+
         raise IOError(f"Unknown partitioning strategy: {data[cls.STRATEGY]}")

--- a/clients/client-python/gravitino/dto/rel/partitioning/partitioning.py
+++ b/clients/client-python/gravitino/dto/rel/partitioning/partitioning.py
@@ -22,7 +22,6 @@ from typing import Final, List
 from gravitino.api.expressions.expression import Expression
 from gravitino.api.expressions.named_reference import NamedReference
 from gravitino.api.expressions.transforms.transform import Transform
-from gravitino.dto.rel.column_dto import ColumnDTO
 from gravitino.dto.rel.partition_utils import PartitionUtils
 from gravitino.exceptions.base import IllegalArgumentException
 from gravitino.utils.precondition import Precondition
@@ -76,7 +75,7 @@ class Partitioning(Transform):
         pass  # pragma: no cover
 
     @abstractmethod
-    def validate(self, columns: List[ColumnDTO]) -> None:
+    def validate(self, columns: List["ColumnDTO"]) -> None:
         """Validates the partitioning columns.
 
         Args:
@@ -128,7 +127,7 @@ class SingleFieldPartitioning(Partitioning):
         """
         return self._field_name
 
-    def validate(self, columns: List[ColumnDTO]) -> None:
+    def validate(self, columns: List["ColumnDTO"]) -> None:
         """Validates the partitioning columns.
 
         Args:

--- a/clients/client-python/gravitino/utils/serdes.py
+++ b/clients/client-python/gravitino/utils/serdes.py
@@ -69,6 +69,7 @@ class SerdesUtilsBase:
     INDEX_TYPE: Final[str] = "indexType"
     INDEX_NAME: Final[str] = "name"
     INDEX_FIELD_NAMES: Final[str] = "fieldNames"
+    NUMBER: Final[str] = "number"
 
     NON_PRIMITIVE_TYPES: Final[Set[Name]] = {
         Name.STRUCT,

--- a/clients/client-python/gravitino/utils/serdes.py
+++ b/clients/client-python/gravitino/utils/serdes.py
@@ -59,6 +59,10 @@ class SerdesUtilsBase:
     LIST_PARTITION_LISTS: Final[str] = "lists"
     RANGE_PARTITION_UPPER: Final[str] = "upper"
     RANGE_PARTITION_LOWER: Final[str] = "lower"
+    STRATEGY: Final[str] = "strategy"
+    NUM_BUCKETS: Final[str] = "numBuckets"
+    WIDTH: Final[str] = "width"
+    ASSIGNMENTS_NAME: Final[str] = "assignments"
 
     NON_PRIMITIVE_TYPES: Final[Set[Name]] = {
         Name.STRUCT,

--- a/clients/client-python/gravitino/utils/serdes.py
+++ b/clients/client-python/gravitino/utils/serdes.py
@@ -66,6 +66,9 @@ class SerdesUtilsBase:
     SORT_TERM: Final[str] = "sortTerm"
     DIRECTION: Final[str] = "direction"
     NULL_ORDERING: Final[str] = "nullOrdering"
+    INDEX_TYPE: Final[str] = "indexType"
+    INDEX_NAME: Final[str] = "name"
+    INDEX_FIELD_NAMES: Final[str] = "fieldNames"
 
     NON_PRIMITIVE_TYPES: Final[Set[Name]] = {
         Name.STRUCT,

--- a/clients/client-python/gravitino/utils/serdes.py
+++ b/clients/client-python/gravitino/utils/serdes.py
@@ -63,6 +63,9 @@ class SerdesUtilsBase:
     NUM_BUCKETS: Final[str] = "numBuckets"
     WIDTH: Final[str] = "width"
     ASSIGNMENTS_NAME: Final[str] = "assignments"
+    SORT_TERM: Final[str] = "sortTerm"
+    DIRECTION: Final[str] = "direction"
+    NULL_ORDERING: Final[str] = "nullOrdering"
 
     NON_PRIMITIVE_TYPES: Final[Set[Name]] = {
         Name.STRUCT,

--- a/clients/client-python/tests/unittests/dto/rel/test_partitioning_serdes.py
+++ b/clients/client-python/tests/unittests/dto/rel/test_partitioning_serdes.py
@@ -172,3 +172,25 @@ class TestPartitioningSerdes(unittest.TestCase):
             self.assertListEqual(
                 partitioning_dto.field_name(), deserialized.field_name()
             )
+
+    def test_serdes_bucket_partitioning_dto(self):
+        field_names = [["score"]]
+        json_string = f"""
+        {{
+            "{PartitioningSerdes.STRATEGY}": "{Partitioning.Strategy.BUCKET.value}",
+            "{PartitioningSerdes.NUM_BUCKETS}": 10,
+            "{PartitioningSerdes.FIELD_NAMES}": {json.dumps(field_names)}
+        }}
+        """
+
+        expected_serialized = json.loads(json_string)
+        deserialized = PartitioningSerdes.deserialize(expected_serialized)
+
+        self.assertEqual(Partitioning.Strategy.BUCKET.name.lower(), deserialized.name())
+        self.assertEqual(
+            Partitioning.Strategy.BUCKET.value, deserialized.strategy().value
+        )
+        self.assertListEqual(field_names, deserialized.field_names())
+
+        serialized = PartitioningSerdes.serialize(deserialized)
+        self.assertDictEqual(expected_serialized, serialized)

--- a/clients/client-python/tests/unittests/dto/rel/test_partitioning_serdes.py
+++ b/clients/client-python/tests/unittests/dto/rel/test_partitioning_serdes.py
@@ -1,0 +1,174 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import json
+import unittest
+from enum import Enum
+from unittest.mock import patch
+
+from gravitino.api.types.types import Types
+from gravitino.dto.rel.expressions.literal_dto import LiteralDTO
+from gravitino.dto.rel.partitioning.bucket_partitioning_dto import BucketPartitioningDTO
+from gravitino.dto.rel.partitioning.day_partitioning_dto import DayPartitioningDTO
+from gravitino.dto.rel.partitioning.function_partitioning_dto import (
+    FunctionPartitioningDTO,
+)
+from gravitino.dto.rel.partitioning.hour_partitioning_dto import HourPartitioningDTO
+from gravitino.dto.rel.partitioning.identity_partitioning_dto import (
+    IdentityPartitioningDTO,
+)
+from gravitino.dto.rel.partitioning.json_serdes.partitioning_serdes import (
+    PartitioningSerdes,
+)
+from gravitino.dto.rel.partitioning.list_partitioning_dto import ListPartitioningDTO
+from gravitino.dto.rel.partitioning.month_partitioning_dto import MonthPartitioningDTO
+from gravitino.dto.rel.partitioning.partitioning import Partitioning
+from gravitino.dto.rel.partitioning.range_partitioning_dto import RangePartitioningDTO
+from gravitino.dto.rel.partitioning.truncate_partitioning_dto import (
+    TruncatePartitioningDTO,
+)
+from gravitino.dto.rel.partitioning.year_partitioning_dto import YearPartitioningDTO
+from gravitino.exceptions.base import IllegalArgumentException
+
+
+class MockPartitionStrategy(str, Enum):
+    INVALID_STRATEGY = "invalid_partitioning_strategy"
+
+
+class TestPartitioningSerdes(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.field_name = [f"dummy_field_{i}" for i in range(1)]
+        cls.literals = {
+            PartitioningSerdes.RANGE_PARTITION_LOWER: LiteralDTO.builder()
+            .with_data_type(Types.IntegerType.get())
+            .with_value("0")
+            .build(),
+            PartitioningSerdes.RANGE_PARTITION_UPPER: LiteralDTO.builder()
+            .with_data_type(Types.IntegerType.get())
+            .with_value("100")
+            .build(),
+        }
+        cls.single_field_partitioning_dtos = {
+            Partitioning.Strategy.IDENTITY: IdentityPartitioningDTO(*cls.field_name),
+            Partitioning.Strategy.YEAR: YearPartitioningDTO(*cls.field_name),
+            Partitioning.Strategy.MONTH: MonthPartitioningDTO(*cls.field_name),
+            Partitioning.Strategy.DAY: DayPartitioningDTO(*cls.field_name),
+            Partitioning.Strategy.HOUR: HourPartitioningDTO(*cls.field_name),
+        }
+        cls.non_single_field_partitioning_dtos = {
+            Partitioning.Strategy.BUCKET: BucketPartitioningDTO(10, cls.field_name),
+            Partitioning.Strategy.FUNCTION: FunctionPartitioningDTO(
+                "func_name",
+                *cls.literals.values(),
+            ),
+            Partitioning.Strategy.LIST: ListPartitioningDTO([cls.field_name]),
+            Partitioning.Strategy.RANGE: RangePartitioningDTO(cls.field_name),
+            Partitioning.Strategy.TRUNCATE: TruncatePartitioningDTO(10, cls.field_name),
+        }
+
+    def test_serialize_invalid_strategy(self):
+        mock_dto = IdentityPartitioningDTO(*self.field_name)
+        with patch.object(
+            mock_dto, "strategy", return_value=MockPartitionStrategy.INVALID_STRATEGY
+        ):
+            self.assertRaisesRegex(
+                IOError,
+                "Unknown partitioning strategy",
+                PartitioningSerdes.serialize,
+                mock_dto,
+            )
+
+    def test_deserialize_invalid_json(self):
+        invalid_partitioning_data = (None, "invalid_data", {})
+
+        for invalid_data in invalid_partitioning_data:
+            with self.assertRaisesRegex(
+                IllegalArgumentException, "Cannot parse partitioning from invalid JSON"
+            ):
+                PartitioningSerdes.deserialize(invalid_data)
+
+    def test_deserialize_invalid_strategy(self):
+        """Tests missing strategy and unknown partitioning strategy."""
+
+        invalid_data_base = {
+            PartitioningSerdes.FIELD_NAME: self.field_name,
+        }
+        invalid_strategy_data = {
+            PartitioningSerdes.STRATEGY: "invalid_strategy",
+            **invalid_data_base,
+        }
+
+        with self.assertRaisesRegex(
+            IllegalArgumentException,
+            "Cannot parse partitioning from missing strategy",
+        ):
+            PartitioningSerdes.deserialize(invalid_data_base)
+
+        with self.assertRaisesRegex(
+            IOError,
+            "Unknown partitioning strategy",
+        ):
+            PartitioningSerdes.deserialize(invalid_strategy_data)
+
+    def test_serialize_single_field_partitioning_dto(self):
+        for partitioning_dto in self.single_field_partitioning_dtos.values():
+            serialized = PartitioningSerdes.serialize(partitioning_dto)
+            self.assertEqual(
+                partitioning_dto.name(), serialized[PartitioningSerdes.STRATEGY]
+            )
+            self.assertEqual(
+                partitioning_dto.strategy().value,
+                serialized[PartitioningSerdes.STRATEGY],
+            )
+            self.assertListEqual(
+                partitioning_dto.field_name(),
+                serialized[PartitioningSerdes.FIELD_NAME],
+            )
+
+    def test_deserialize_single_field_partitioning_dto(self):
+        for partitioning_dto in self.single_field_partitioning_dtos.values():
+            serialized = PartitioningSerdes.serialize(partitioning_dto)
+            deserialized = PartitioningSerdes.deserialize(serialized)
+
+            self.assertEqual(partitioning_dto.name(), deserialized.name())
+            self.assertEqual(
+                partitioning_dto.strategy().value, deserialized.strategy().value
+            )
+            self.assertListEqual(
+                partitioning_dto.field_name(), deserialized.field_name()
+            )
+
+    def test_deserialize_single_field_partitioning_dto_from_json_string(self):
+        for strategy, partitioning_dto in self.single_field_partitioning_dtos.items():
+            json_string = f"""
+            {{
+                "{PartitioningSerdes.STRATEGY}": "{strategy.value}",
+                "{PartitioningSerdes.FIELD_NAME}": {json.dumps(partitioning_dto.field_name())}
+            }}
+            """
+
+            expected_serialized = json.loads(json_string)
+            deserialized = PartitioningSerdes.deserialize(expected_serialized)
+
+            self.assertEqual(partitioning_dto.name(), deserialized.name())
+            self.assertEqual(
+                partitioning_dto.strategy().value, deserialized.strategy().value
+            )
+            self.assertListEqual(
+                partitioning_dto.field_name(), deserialized.field_name()
+            )

--- a/clients/client-python/tests/unittests/dto/rel/test_partitioning_serdes.py
+++ b/clients/client-python/tests/unittests/dto/rel/test_partitioning_serdes.py
@@ -69,7 +69,7 @@ class TestPartitioningSerdes(unittest.TestCase):
             )
 
     def test_deserialize_invalid_json(self):
-        invalid_partitioning_data = (None, "invalid_data", {})
+        invalid_partitioning_data = (None, "invalid_data")
 
         for invalid_data in invalid_partitioning_data:
             with self.assertRaisesRegex(
@@ -77,28 +77,39 @@ class TestPartitioningSerdes(unittest.TestCase):
             ):
                 PartitioningSerdes.deserialize(invalid_data)
 
+        invalid_json_string = "{}"
+        with self.assertRaisesRegex(
+            IllegalArgumentException, "Cannot parse partitioning from invalid JSON"
+        ):
+            PartitioningSerdes.deserialize(json.loads(invalid_json_string))
+
     def test_deserialize_invalid_strategy(self):
         """Tests missing strategy and unknown partitioning strategy."""
 
-        invalid_data_base = {
-            PartitioningSerdes.FIELD_NAME: self.field_name,
+        missing_strategy_json_string = """
+        {
+            "fieldName": ["dummy_field_0"]
         }
-        invalid_strategy_data = {
-            PartitioningSerdes.STRATEGY: "invalid_strategy",
-            **invalid_data_base,
+        """
+
+        invalid_strategy_json_string = """
+        {
+            "strategy": "invalid_strategy",
+            "fieldName": ["dummy_field_0"]
         }
+        """
 
         with self.assertRaisesRegex(
             IllegalArgumentException,
             "Cannot parse partitioning from missing strategy",
         ):
-            PartitioningSerdes.deserialize(invalid_data_base)
+            PartitioningSerdes.deserialize(json.loads(missing_strategy_json_string))
 
         with self.assertRaisesRegex(
             IOError,
             "Unknown partitioning strategy",
         ):
-            PartitioningSerdes.deserialize(invalid_strategy_data)
+            PartitioningSerdes.deserialize(json.loads(invalid_strategy_json_string))
 
     def test_serialize_single_field_partitioning_dto(self):
         for partitioning_dto in self.single_field_partitioning_dtos.values():

--- a/clients/client-python/tests/unittests/dto/rel/test_partitioning_serdes.py
+++ b/clients/client-python/tests/unittests/dto/rel/test_partitioning_serdes.py
@@ -194,3 +194,27 @@ class TestPartitioningSerdes(unittest.TestCase):
 
         serialized = PartitioningSerdes.serialize(deserialized)
         self.assertDictEqual(expected_serialized, serialized)
+
+    def test_serdes_truncate_partitioning_dto(self):
+        field_name = ["score"]
+        json_string = f"""
+        {{
+            "{PartitioningSerdes.STRATEGY}": "{Partitioning.Strategy.TRUNCATE.value}",
+            "{PartitioningSerdes.WIDTH}": 20,
+            "{PartitioningSerdes.FIELD_NAME}": {json.dumps(field_name)}
+        }}
+        """
+
+        expected_serialized = json.loads(json_string)
+        deserialized = PartitioningSerdes.deserialize(expected_serialized)
+
+        self.assertEqual(
+            Partitioning.Strategy.TRUNCATE.name.lower(), deserialized.name()
+        )
+        self.assertEqual(
+            Partitioning.Strategy.TRUNCATE.value, deserialized.strategy().value
+        )
+        self.assertListEqual(field_name, deserialized.field_name())
+
+        serialized = PartitioningSerdes.serialize(deserialized)
+        self.assertDictEqual(expected_serialized, serialized)


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

This PR is aimed at implementing the following classes corresponding to the Java client.

JsonUtils.java

- PartitioningSerializer
- PartitioningDeserializer

### Why are the changes needed?

We need to support table partitioning, bucketing and sort ordering and indexes

#5199

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Unit tests
