### PR TITLE
[#8322] improvement: fix sort direction parsing bug and add test case

### DIFF
--- a/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/catalog/iceberg/ExpressionUtil.java
+++ b/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/catalog/iceberg/ExpressionUtil.java
@@ -297,7 +297,7 @@ public class ExpressionUtil {
                 (m) -> {
                   NamedReference.FieldReference sortField = NamedReference.field(m.group(1));
                   SortDirection sortDirection =
-                      m.group(1).equalsIgnoreCase(SORT_DIRECTION_ASC)
+                      m.group(2).equalsIgnoreCase(SORT_DIRECTION_ASC)
                           ? SortDirection.ASCENDING
                           : SortDirection.DESCENDING;
                   NullOrdering nullOrdering =

--- a/trino-connector/trino-connector/src/test/java/org/apache/gravitino/trino/connector/catalog/iceberg/TestExpressionUtil.java
+++ b/trino-connector/trino-connector/src/test/java/org/apache/gravitino/trino/connector/catalog/iceberg/TestExpressionUtil.java
@@ -270,6 +270,11 @@ public class TestExpressionUtil {
         SortOrders.of(
             NamedReference.field("F4"), SortDirection.DESCENDING, NullOrdering.NULLS_FIRST),
         sortOrders[3]);
+
+    sortOrderFiled = List.of("f1 ASC");
+    sortOrders = ExpressionUtil.sortOrderFiledToExpression(sortOrderFiled);
+    Assertions.assertEquals(1, sortOrders.length);
+    Assertions.assertEquals(SortOrders.ascending(NamedReference.field("f1")), sortOrders[0]);
   }
 
   @Test


### PR DESCRIPTION
### What changes were proposed in this pull request?

- Fixed incorrect group index in `ExpressionUtil.parseSortOrder()` method and added test case to verify the fix.

### Why are the changes needed?

- The bug caused "ASC" and "DESC" keywords to be incorrectly interpreted.

Fix: #8322 

### Does this PR introduce _any_ user-facing change?

- No.

### How was this patch tested?

- Added test case for "f1 ASC" parsing to `testSortOrderFiledToExpression()` method.
