### PR TITLE
[#8367] improvement(core): Remove duplicate setOwner call in TestOwnerMetaService.testDeleteMetadataObject

### DIFF
--- a/core/src/test/java/org/apache/gravitino/storage/relational/service/TestOwnerMetaService.java
+++ b/core/src/test/java/org/apache/gravitino/storage/relational/service/TestOwnerMetaService.java
@@ -510,11 +510,9 @@ class TestOwnerMetaService extends TestJDBCBackend {
         .setOwner(topic.nameIdentifier(), topic.type(), user.nameIdentifier(), user.type());
     OwnerMetaService.getInstance()
         .setOwner(model.nameIdentifier(), model.type(), user.nameIdentifier(), user.type());
-    OwnerMetaService.getInstance()
-        .setOwner(model.nameIdentifier(), model.type(), user.nameIdentifier(), user.type());
 
     UserMetaService.getInstance().deleteUser(user.nameIdentifier());
-    Assertions.assertEquals(25, countAllOwnerRel(user.id()));
+    Assertions.assertEquals(24, countAllOwnerRel(user.id()));
     Assertions.assertEquals(0, countActiveOwnerRel(user.id()));
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Removed the redundant invocation of `OwnerMetaService.setOwner(...)` in `TestOwnerMetaService.testDeleteMetadataObject`.

### Why are the changes needed?

The test invoked `setOwner(...)` twice with the same parameters, causing duplicate rows and an integrity constraint error. 

Fix: #8367  
Related: #7110, #8293

### Does this PR introduce _any_ user-facing change?

No user-facing changes.

### How was this patch tested?

Executed existing unit tests
