### PR TITLE
[#4707] fix (client): Fix the Gravitino client-side version verification to ignore patch version numbers

### DIFF
--- a/clients/client-java/src/main/java/org/apache/gravitino/client/GravitinoClientBase.java
+++ b/clients/client-java/src/main/java/org/apache/gravitino/client/GravitinoClientBase.java
@@ -102,7 +102,7 @@ public abstract class GravitinoClientBase implements Closeable {
     GravitinoVersion clientVersion = clientVersion();
     if (!clientVersion.compatibleWithServerVersion(serverVersion)) {
       throw new GravitinoRuntimeException(
-          "Gravitino does not support the case that the client-side major version is higher than the server-side version."
+          "Gravitino does not support the case that the client-side version is higher than the server version."
               + "The client version is %s, and the server version %s",
           clientVersion.version(), serverVersion.version());
     }

--- a/clients/client-java/src/main/java/org/apache/gravitino/client/GravitinoVersion.java
+++ b/clients/client-java/src/main/java/org/apache/gravitino/client/GravitinoVersion.java
@@ -57,12 +57,11 @@ public class GravitinoVersion extends VersionDTO {
    * Check if the current version is compatible with the server version.
    *
    * @param serverVersion the server version to check compatibility with
-   * @return true if the client current major version is less than or equal to the server's major
-   *     version
+   * @return true if the client current major version is less than or equal to the server's version
    */
   public boolean compatibleWithServerVersion(GravitinoVersion serverVersion) {
     int[] left = getVersionNumber();
     int[] right = serverVersion.getVersionNumber();
-    return left[0] <= right[0];
+    return left[0] < right[0] || (left[0] == right[0] && left[1] <= right[1]);
   }
 }

--- a/clients/client-java/src/test/java/org/apache/gravitino/client/TestGravitinoVersion.java
+++ b/clients/client-java/src/test/java/org/apache/gravitino/client/TestGravitinoVersion.java
@@ -135,8 +135,8 @@ public class TestGravitinoVersion {
 
   @Test
   void testVersionCompatibility() {
-    GravitinoVersion version1 = new GravitinoVersion("2.5.3", "2023-01-01", "1234567");
-    GravitinoVersion version2 = new GravitinoVersion("2.5.4", "2023-01-01", "1234567");
+    GravitinoVersion version1 = new GravitinoVersion("2.6.3", "2023-01-01", "1234567");
+    GravitinoVersion version2 = new GravitinoVersion("2.6.4", "2023-01-01", "1234567");
     assertTrue(version1.compatibleWithServerVersion(version2));
 
     version1 = new GravitinoVersion("2.6.3", "2023-01-01", "1234567");
@@ -144,12 +144,16 @@ public class TestGravitinoVersion {
     assertTrue(version1.compatibleWithServerVersion(version2));
 
     version1 = new GravitinoVersion("2.6.3", "2023-01-01", "1234567");
-    version2 = new GravitinoVersion("2.5.4", "2023-01-01", "1234567");
+    version2 = new GravitinoVersion("2.6.2", "2023-01-01", "1234567");
     assertTrue(version1.compatibleWithServerVersion(version2));
 
     version1 = new GravitinoVersion("2.6.3", "2023-01-01", "1234567");
     version2 = new GravitinoVersion("3.5.4", "2023-01-01", "1234567");
     assertTrue(version1.compatibleWithServerVersion(version2));
+
+    version1 = new GravitinoVersion("2.6.3", "2023-01-01", "1234567");
+    version2 = new GravitinoVersion("2.5.3", "2023-01-01", "1234567");
+    assertFalse(version1.compatibleWithServerVersion(version2));
 
     version1 = new GravitinoVersion("3.6.3", "2023-01-01", "1234567");
     version2 = new GravitinoVersion("2.5.4", "2023-01-01", "1234567");

--- a/clients/client-python/gravitino/client/gravitino_client_base.py
+++ b/clients/client-python/gravitino/client/gravitino_client_base.py
@@ -105,7 +105,7 @@ class GravitinoClientBase:
         if not client_version.compatible_with_server_version(server_version):
             raise GravitinoRuntimeException(
                 "Gravitino does not support the case that "
-                "the client-side major version is higher than the server-side version."
+                "the client-side version is higher than the server-side version."
                 f"The client version is {client_version.version()}, and the server version {server_version.version()}"
             )
 

--- a/clients/client-python/gravitino/client/gravitino_version.py
+++ b/clients/client-python/gravitino/client/gravitino_version.py
@@ -84,4 +84,4 @@ class GravitinoVersion(VersionDTO):
         Compatibility is defined such that the client major version is less than or equal
         to the server major version.
         """
-        return self.major <= server_version.major
+        return (self.major, self.minor) <= (server_version.major, server_version.minor)

--- a/clients/client-python/tests/unittests/test_gravitino_version.py
+++ b/clients/client-python/tests/unittests/test_gravitino_version.py
@@ -197,13 +197,21 @@ class TestGravitinoVersion(unittest.TestCase):
         version2 = GravitinoVersion(VersionDTO("1.6.0", "2023-01-01", "1234567"))
         self.assertTrue(version1.compatible_with_server_version(version2))
 
+        version1 = GravitinoVersion(VersionDTO("1.6.1", "2023-01-01", "1234567"))
+        version2 = GravitinoVersion(VersionDTO("1.6.2", "2023-01-01", "1234567"))
+        self.assertTrue(version1.compatible_with_server_version(version2))
+
+        version1 = GravitinoVersion(VersionDTO("1.6.2", "2023-01-01", "1234567"))
+        version2 = GravitinoVersion(VersionDTO("1.6.1", "2023-01-01", "1234567"))
+        self.assertTrue(version1.compatible_with_server_version(version2))
+
         version1 = GravitinoVersion(VersionDTO("1.6.0", "2023-01-01", "1234567"))
         version2 = GravitinoVersion(VersionDTO("2.6.1", "2023-01-01", "1234567"))
         self.assertTrue(version1.compatible_with_server_version(version2))
 
         version1 = GravitinoVersion(VersionDTO("1.6.0", "2023-01-01", "1234567"))
         version2 = GravitinoVersion(VersionDTO("1.4.0", "2023-01-01", "1234567"))
-        self.assertTrue(version1.compatible_with_server_version(version2))
+        self.assertFalse(version1.compatible_with_server_version(version2))
 
         version1 = GravitinoVersion(VersionDTO("1.6.0", "2023-01-01", "1234567"))
         version2 = GravitinoVersion(VersionDTO("0.6.0", "2023-01-01", "1234567"))


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix the Gravitino client-side version verification to ignore patch version numbers

### Why are the changes needed?

Fix: https://github.com/apache/gravitino/issues/4707

### Does this PR introduce _any_ user-facing change?

NO

### How was this patch tested?

UTs
