### PR TITLE
[#8390] fix(api): remove premature String.format in AuthorizationPluginException

### DIFF
--- a/api/src/main/java/org/apache/gravitino/exceptions/AuthorizationPluginException.java
+++ b/api/src/main/java/org/apache/gravitino/exceptions/AuthorizationPluginException.java
@@ -32,7 +32,7 @@ public class AuthorizationPluginException extends GravitinoRuntimeException {
    */
   @FormatMethod
   public AuthorizationPluginException(@FormatString String message, Object... args) {
-    super(String.format(message, args));
+    super(message, args);
   }
 
   /**


### PR DESCRIPTION

### What changes were proposed in this pull request?

- Removed the direct call to `String.format` in `AuthorizationPluginException` constructors.  
- Delegated `(message, args)` directly to `GravitinoRuntimeException`.  
- This ensures messages containing `%` (like `"100% done"`) are not misinterpreted as format specifiers when no args are passed.

### Why are the changes needed?

Currently, `AuthorizationPluginException` always formats the message string.  
This causes errors when the message includes `%` but no formatting arguments are provided (e.g., `"100% done"`).  

By removing premature formatting and letting the parent class handle it, we avoid these errors and maintain expected behavior.

Fixes: #8390

### Does this PR introduce _any_ user-facing change?

Yes.  
- Exception messages are now preserved as-is if no formatting arguments are provided.  
- Example: `"100% done"` will no longer cause a `MissingFormatArgumentException`.