### PR TITLE
[#8387]Prevent duplicate whitespace in StringIdentifier

### DIFF
--- a/core/src/main/java/org/apache/gravitino/StringIdentifier.java
+++ b/core/src/main/java/org/apache/gravitino/StringIdentifier.java
@@ -168,7 +168,8 @@ public class StringIdentifier {
       return String.format(STRING_COMMENT_FORMAT, "", STRING_COMMENT, stringId.toString());
     }
 
-    return String.format(STRING_COMMENT_FORMAT, comment + " ", STRING_COMMENT, stringId.toString());
+    return String.format(
+        STRING_COMMENT_FORMAT, comment.trim() + " ", STRING_COMMENT, stringId.toString());
   }
 
   public static StringIdentifier fromComment(String comment) {

--- a/core/src/test/java/org/apache/gravitino/TestStringIdentifier.java
+++ b/core/src/test/java/org/apache/gravitino/TestStringIdentifier.java
@@ -206,4 +206,21 @@ public class TestStringIdentifier {
     Assertions.assertEquals(
         commentWithSpace.trim(), StringIdentifier.removeIdFromComment(commentWithId));
   }
+
+  @Test
+  public void testAddToCommentAvoidsDuplicateSpace() {
+    String commentWithSpace1 = "This is a comment ";
+    StringIdentifier identifier1 = StringIdentifier.fromId(1L);
+    String commentWithId1 = StringIdentifier.addToComment(identifier1, commentWithSpace1);
+    Assertions.assertEquals(
+        commentWithSpace1.trim() + " (From Gravitino, DO NOT EDIT: " + identifier1 + ")",
+        commentWithId1);
+
+    String commentWithSpace2 = "  This is a comment ";
+    StringIdentifier identifier2 = StringIdentifier.fromId(2L);
+    String commentWithId2 = StringIdentifier.addToComment(identifier2, commentWithSpace2);
+    Assertions.assertEquals(
+        commentWithSpace2.trim() + " (From Gravitino, DO NOT EDIT: " + identifier2 + ")",
+        commentWithId2);
+  }
 }


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?
Prevent duplicate whitespace in org.apache.gravitino.StringIdentifier#addToComment


### Why are the changes needed?
Fix: #8387 

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
add some unit tests
