### PR TITLE
[#8344] improvement(catalog): set default bucket number to be 1 when group is missing in dorisUtils

### DIFF
--- a/catalogs/catalog-jdbc-doris/src/main/java/org/apache/gravitino/catalog/doris/utils/DorisUtils.java
+++ b/catalogs/catalog-jdbc-doris/src/main/java/org/apache/gravitino/catalog/doris/utils/DorisUtils.java
@@ -223,6 +223,10 @@ public final class DorisUtils {
     int bucketNum = 1;
     if (matcher.find(5)) {
       String bucketValue = matcher.group(5);
+      // If a bucket group is missing, fall back to default (1)
+      if (bucketValue == null || bucketValue.trim().isEmpty()) {
+        return bucketNum;
+      }
       // Use -1 to indicate auto bucket.
       bucketNum =
           bucketValue.trim().toUpperCase().equals("AUTO")

--- a/catalogs/catalog-jdbc-doris/src/test/java/org/apache/gravitino/catalog/doris/utils/TestDorisUtils.java
+++ b/catalogs/catalog-jdbc-doris/src/test/java/org/apache/gravitino/catalog/doris/utils/TestDorisUtils.java
@@ -185,4 +185,18 @@ public class TestDorisUtils {
     Distribution distribution2 = DorisUtils.extractDistributionInfoFromSql(createTableSqlWithAuto);
     assertEquals(distribution2.number(), -1);
   }
+
+  @Test
+  public void testDistributionWithoutBucketClauseDefaultsToOne() {
+    String createTableSql =
+        "CREATE TABLE `testTable` (\n`col1` date NOT NULL\n) ENGINE=OLAP\n PARTITION BY RANGE(`col1`)\n()\n DISTRIBUTED BY HASH(`col1`)";
+    Distribution distribution = DorisUtils.extractDistributionInfoFromSql(createTableSql);
+    assertEquals(distribution.number(), 1);
+
+    String createTableSqlWithEmptyBuckets =
+        "CREATE TABLE `testTable` (\n`col1` date NOT NULL\n) ENGINE=OLAP\n PARTITION BY RANGE(`col1`)\n()\n DISTRIBUTED BY HASH(`col1`) BUCKETS";
+    Distribution distribution2 =
+        DorisUtils.extractDistributionInfoFromSql(createTableSqlWithEmptyBuckets);
+    assertEquals(distribution2.number(), 1);
+  }
 }

--- a/catalogs/catalog-jdbc-doris/src/test/java/org/apache/gravitino/catalog/doris/utils/TestDorisUtils.java
+++ b/catalogs/catalog-jdbc-doris/src/test/java/org/apache/gravitino/catalog/doris/utils/TestDorisUtils.java
@@ -184,19 +184,11 @@ public class TestDorisUtils {
         "CREATE TABLE `testTable` (\n`col1` date NOT NULL\n) ENGINE=OLAP\n PARTITION BY RANGE(`col1`)\n()\n DISTRIBUTED BY HASH(`col1`) BUCKETS AUTO";
     Distribution distribution2 = DorisUtils.extractDistributionInfoFromSql(createTableSqlWithAuto);
     assertEquals(distribution2.number(), -1);
-  }
 
-  @Test
-  public void testDistributionWithoutBucketClauseDefaultsToOne() {
-    String createTableSql =
+    String createTableSqlWithoutBuckets =
         "CREATE TABLE `testTable` (\n`col1` date NOT NULL\n) ENGINE=OLAP\n PARTITION BY RANGE(`col1`)\n()\n DISTRIBUTED BY HASH(`col1`)";
-    Distribution distribution = DorisUtils.extractDistributionInfoFromSql(createTableSql);
-    assertEquals(distribution.number(), 1);
-
-    String createTableSqlWithEmptyBuckets =
-        "CREATE TABLE `testTable` (\n`col1` date NOT NULL\n) ENGINE=OLAP\n PARTITION BY RANGE(`col1`)\n()\n DISTRIBUTED BY HASH(`col1`) BUCKETS";
-    Distribution distribution2 =
-        DorisUtils.extractDistributionInfoFromSql(createTableSqlWithEmptyBuckets);
-    assertEquals(distribution2.number(), 1);
+    Distribution distribution3 =
+        DorisUtils.extractDistributionInfoFromSql(createTableSqlWithoutBuckets);
+    assertEquals(distribution3.number(), 1);
   }
 }


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

- Updated `DorisUtils` to set default bucket number = 1 if the bucket group is missing or empty.
- Added a new unit test case in `TestDorisUtils` to verify correct behavior when bucket clause is absent.

### Why are the changes needed?

Fix: #8344

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Using unit tests locally:
`./gradlew test -PskipITs`
