### PR TITLE
fix/ added a missing comma in insertPolicyMetaOnDuplicateKeyUpdate in PolicyMetaPostgreSQLProvider.java

### DIFF
--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/PolicyMetaPostgreSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/PolicyMetaPostgreSQLProvider.java
@@ -75,7 +75,7 @@ public class PolicyMetaPostgreSQLProvider extends PolicyMetaBaseSQLProvider {
         + " metalake_id = #{policyPO.metalakeId},"
         + " audit_info = #{policyPO.auditInfo},"
         + " current_version = #{policyPO.currentVersion},"
-        + " last_version = #{policyPO.lastVersion}"
+        + " last_version = #{policyPO.lastVersion},"
         + " deleted_at = #{policyPO.deletedAt}";
   }
 }


### PR DESCRIPTION
Title:

[#8383] fix(core): added missing comma in SQL of PolicyMetaPostgreSQLProvider.java

### What changes were proposed in this pull request?

Added a missing comma in the SQL statement of insertPolicyMetaOnDuplicateKeyUpdate in PolicyMetaPostgreSQLProvider.java.

### Why are the changes needed?

Without this comma, the SQL would fail or behave incorrectly when updating policy metadata in PostgreSQL. This fixes a small bug that can cause runtime errors.

Fix: #8383

### Does this PR introduce _any_ user-facing change?

There are no changes to APIs or configuration visible to end users. Hence, it doesn't introduce _any_ user-facing change

### How was this patch tested?

Applied Spotless formatting 
Ran ./gradlew build -x test.
