### PR TITLE
[#8380] fix: Fix test in TestPartitionRange

### DIFF
--- a/api/src/test/java/org/apache/gravitino/stats/TestPartitionRange.java
+++ b/api/src/test/java/org/apache/gravitino/stats/TestPartitionRange.java
@@ -43,7 +43,7 @@ public class TestPartitionRange {
     Assertions.assertFalse(range2.upperPartitionName().isPresent());
     Assertions.assertTrue(range2.lowerPartitionName().isPresent());
     Assertions.assertEquals("lower", range2.lowerPartitionName().get());
-    Assertions.assertEquals(defaultSortOrder, defaultSortOrder);
+    Assertions.assertEquals(defaultSortOrder, range2.comparator());
     Assertions.assertEquals(PartitionRange.BoundType.CLOSED, range2.lowerBoundType().get());
 
     PartitionRange range3 =


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix the assertion to make default order compare to `range2.comparator()`

### Why are the changes needed?

The assertion always true. Make it workable.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?

Unit Test