### PR TITLE
[MINOR] improve(CI): Increase the CI timeout for Python and Ranger test

### DIFF
--- a/.github/workflows/access-control-integration-test.yml
+++ b/.github/workflows/access-control-integration-test.yml
@@ -51,7 +51,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.source_changes == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 90
     strategy:
       matrix:
         # Integration test for AMD64 architecture

--- a/.github/workflows/python-integration-test.yml
+++ b/.github/workflows/python-integration-test.yml
@@ -48,7 +48,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.source_changes == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 90
     strategy:
       matrix:
         # Integration test for AMD64 architecture


### PR DESCRIPTION
### What changes were proposed in this pull request?

Increase the timeout to 90 minutes for Python and Ranger CI Test.

### Why are the changes needed?

To make the CI more stable without rerun.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

N/A
