### PR TITLE
[#7491] improve(client-python): Drop the support of Python 3.8

### DIFF
--- a/.github/workflows/python-integration-test.yml
+++ b/.github/workflows/python-integration-test.yml
@@ -73,7 +73,7 @@ jobs:
         run: |
           ./gradlew compileDistribution -x test -PjdkVersion=${{ matrix.java-version }}
 
-          for pythonVersion in "3.8" "3.9" "3.10" "3.11" "3.12"
+          for pythonVersion in "3.9" "3.10" "3.11" "3.12"
           do
             echo "Use Python version ${pythonVersion} to test the Python client."
             ./gradlew -PjdkVersion=${{ matrix.java-version }} -PpythonVersion=${pythonVersion} -PskipDockerTests=false :clients:client-python:test

--- a/clients/client-python/requirements-dev.txt
+++ b/clients/client-python/requirements-dev.txt
@@ -21,11 +21,7 @@ pylint==3.2.2
 black==24.4.2
 twine==5.1.1
 coverage==7.5.1
-# pandas 2.0.3 is the last version that supports Python 3.8,
-# use it if you need to run tests on Python 3.8;
-# otherwise, use the version that also supports Python 3.12.
-pandas==2.0.3 ; python_version == '3.8'
-pandas==2.2.3 ; python_version > '3.8'
+pandas==2.2.3
 pyarrow==15.0.2
 llama-index==0.11.18
 tenacity==8.3.0

--- a/clients/client-python/setup.py
+++ b/clients/client-python/setup.py
@@ -36,7 +36,7 @@ setup(
     maintainer_email="dev@gravitino.apache.org",
     license="Apache-2.0",
     url="https://github.com/apache/gravitino",
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     keywords="Data, AI, metadata, catalog",
     packages=find_packages(exclude=["tests*", "scripts*"]),
     project_urls={
@@ -49,7 +49,6 @@ setup(
     classifiers=[
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",

--- a/docs/how-to-use-python-client.md
+++ b/docs/how-to-use-python-client.md
@@ -69,7 +69,7 @@ You can ues any IDE to develop Gravitino Python Client. Directly open the client
 
 ### Prerequisites
 
-+ Python 3.8+
++ Python 3.9+
 + Refer to [How to build Gravitino](./how-to-build.md#prerequisites) to have necessary build
   environment ready for building.
 
@@ -84,15 +84,12 @@ You can ues any IDE to develop Gravitino Python Client. Directly open the client
 2. Build the Gravitino Python client module
 
     ```shell
-    # Default Python version is 3.8
+    # Default Python version is 3.9
     ./gradlew :clients:client-python:build
     # If you want to build Python client with specific Python version,
     # add `-PpythonVersion` with version number:
     ./gradlew :clients:client-python:build -PpythonVersion=3.10
     ```
-   Some computer may encounter this error: `fatal error: 'cstdlib' file not found` while setting up Python,
-   this might because default Python version (3.8) is too
-   old, use version 3.9 or newer version instead.
  
 3. Run unit tests
 
@@ -149,7 +146,7 @@ SDK, you need to:
    find $(pwd)/.gradle/python/*/Miniforge3/envs/*/bin/python
    
    # example output
-   /Users/YOUR_USER_NAME/gravitino/.gradle/python/MacOSX/Miniforge3/envs/python-3.8/bin/python
+   /Users/YOUR_USER_NAME/gravitino/.gradle/python/MacOSX/Miniforge3/envs/python-3.9/bin/python
    ```
 
 6. Follow steps in [Create a conda environment](https://www.jetbrains.com/help/idea/configuring-python-sdk.html#gdizlj_44), 

--- a/gradle.properties
+++ b/gradle.properties
@@ -33,7 +33,7 @@ SONATYPE_PASSWORD = password
 defaultScalaVersion = 2.12
 
 # pythonVersion is used to specify the version of Python to build and test Gravitino python client.
-pythonVersion = 3.8
+pythonVersion = 3.9
 
 # skipDockerTests is used to skip the tests that require Docker to be running.
 skipDockerTests = true


### PR DESCRIPTION
### What changes were proposed in this pull request?

Python 3.8 has been EOL in 2024, lots of Python libraries already moved to 3.9+. So as a major release, I'm going to drop the support of Python 3.8 and increase the minimum support version to 3.9+.

### Why are the changes needed?

Fix: #7491 

### Does this PR introduce _any_ user-facing change?

Yes, bumping the supported version to 3.9+ will break the existing 3.8 users.

### How was this patch tested?

Existing UTs.
