### PR TITLE
[#8435] feat(iceberg): passing s3.path-style-access to the client side in Iceberg REST server

### DIFF
--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/CatalogWrapperForREST.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/CatalogWrapperForREST.java
@@ -59,7 +59,8 @@ public class CatalogWrapperForREST extends IcebergCatalogWrapper {
           IcebergConstants.IO_IMPL,
           IcebergConstants.AWS_S3_REGION,
           IcebergConstants.ICEBERG_S3_ENDPOINT,
-          IcebergConstants.ICEBERG_OSS_ENDPOINT);
+          IcebergConstants.ICEBERG_OSS_ENDPOINT,
+          IcebergConstants.ICEBERG_S3_PATH_STYLE_ACCESS);
 
   @SuppressWarnings("deprecation")
   private static Map<String, String> deprecatedProperties =

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/IcebergRestTestUtil.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/IcebergRestTestUtil.java
@@ -122,6 +122,10 @@ public class IcebergRestTestUtil {
       catalogConf.put(
           String.format("%s.%s", catalogConfigPrefix, IcebergConstants.ICEBERG_OSS_ENDPOINT),
           "https://oss-endpoint.example.com");
+      catalogConf.put(
+          String.format(
+              "%s.%s", catalogConfigPrefix, IcebergConstants.ICEBERG_S3_PATH_STYLE_ACCESS),
+          "true");
       IcebergConfigProvider configProvider = IcebergConfigProviderFactory.create(catalogConf);
       configProvider.initialize(catalogConf);
       // used to override register table interface

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/TestIcebergConfig.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/TestIcebergConfig.java
@@ -88,7 +88,9 @@ public class TestIcebergConfig extends IcebergTestBase {
             IcebergConstants.AWS_S3_REGION,
             "us-west-2",
             IcebergConstants.ICEBERG_OSS_ENDPOINT,
-            "https://oss-endpoint.example.com");
+            "https://oss-endpoint.example.com",
+            IcebergConstants.ICEBERG_S3_PATH_STYLE_ACCESS,
+            "true");
     Assertions.assertEquals(expectedConfig, response.defaults());
     Assertions.assertEquals(0, response.overrides().size());
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

passing s3.path-style-access to the client side in Iceberg REST server 

### Why are the changes needed?

Fix: #8435 

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
adding UT
