### PR TITLE
[#8409]Fix delimiters in Properties.java

### DIFF
--- a/clients/cli/src/main/java/org/apache/gravitino/cli/Properties.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/Properties.java
@@ -21,6 +21,7 @@ package org.apache.gravitino.cli;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 /**
  * A utility class to parse a delimited list of name-value pairs into a List of key-value entries.
@@ -45,8 +46,8 @@ public class Properties {
    * @param keyValueSeparator The separator used to distinguish keys from values in each pair.
    */
   public Properties(String delimiter, String keyValueSeparator) {
-    this.delimiter = delimiter;
-    this.keyValueSeparator = keyValueSeparator;
+    this.delimiter = Pattern.quote(delimiter);
+    this.keyValueSeparator = Pattern.quote(keyValueSeparator);
   }
 
   /**

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/Properties.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/Properties.java
@@ -19,6 +19,7 @@
 
 package org.apache.gravitino.cli;
 
+import com.google.common.base.Preconditions;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Pattern;
@@ -30,13 +31,13 @@ import java.util.regex.Pattern;
  * delimiter and key-value separator can be customized.
  */
 public class Properties {
-  private String delimiter;
-  private String keyValueSeparator;
+  private Pattern delimiterPattern;
+  private Pattern keyValueSeparatorPattern;
 
   /** Default constructor, sets the delimiter to "," and the key-value separator to "=". */
   public Properties() {
-    this.delimiter = ",";
-    this.keyValueSeparator = "=";
+    this.delimiterPattern = Pattern.compile(",");
+    this.keyValueSeparatorPattern = Pattern.compile("=");
   }
 
   /**
@@ -46,8 +47,13 @@ public class Properties {
    * @param keyValueSeparator The separator used to distinguish keys from values in each pair.
    */
   public Properties(String delimiter, String keyValueSeparator) {
-    this.delimiter = Pattern.quote(delimiter);
-    this.keyValueSeparator = Pattern.quote(keyValueSeparator);
+    Preconditions.checkArgument(
+        delimiter != null && !delimiter.isEmpty(), "delimiter cannot be null or empty");
+    Preconditions.checkArgument(
+        keyValueSeparator != null && !keyValueSeparator.isEmpty(),
+        "keyValueSeparator cannot be null or empty");
+    this.delimiterPattern = Pattern.compile(Pattern.quote(delimiter));
+    this.keyValueSeparatorPattern = Pattern.compile(Pattern.quote(keyValueSeparator));
   }
 
   /**
@@ -64,11 +70,17 @@ public class Properties {
 
     if (inputs != null) {
       for (String input : inputs) {
+        if (input == null || input.isEmpty()) {
+          continue;
+        }
         // Split the input by the delimiter into key-value pairs
-        String[] pairs = input.split(delimiter);
+        String[] pairs = delimiterPattern.split(input);
         for (String pair : pairs) {
+          if (pair.isEmpty()) {
+            continue;
+          }
           // Split each key-value pair by the separator
-          String[] keyValue = pair.split(keyValueSeparator, 2);
+          String[] keyValue = keyValueSeparatorPattern.split(pair, 2);
           if (keyValue.length == 2) {
             map.put(keyValue[0].trim(), keyValue[1].trim());
           }

--- a/clients/cli/src/test/java/org/apache/gravitino/cli/PropertiesTest.java
+++ b/clients/cli/src/test/java/org/apache/gravitino/cli/PropertiesTest.java
@@ -181,4 +181,28 @@ public class PropertiesTest {
     assertEquals("value2", result.get("key1"), "Last value should overwrite previous ones");
     assertEquals("value3", result.get("key2"));
   }
+
+  @Test
+  public void testDelimiterWithRegexSpecialChar() {
+    Properties properties = new Properties("|", "=");
+    String[] input = {"key1=value1|key2=value2"};
+
+    Map<String, String> result = properties.parse(input);
+
+    assertEquals(2, result.size());
+    assertEquals("value1", result.get("key1"));
+    assertEquals("value2", result.get("key2"));
+  }
+
+  @Test
+  public void testSeparatorWithRegexSpecialChar() {
+    Properties properties = new Properties(",", "|");
+    String[] input = {"key1|value1,key2|value2"};
+
+    Map<String, String> result = properties.parse(input);
+
+    assertEquals(2, result.size());
+    assertEquals("value1", result.get("key1"));
+    assertEquals("value2", result.get("key2"));
+  }
 }

--- a/clients/cli/src/test/java/org/apache/gravitino/cli/PropertiesTest.java
+++ b/clients/cli/src/test/java/org/apache/gravitino/cli/PropertiesTest.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Map;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class PropertiesTest {
@@ -204,5 +205,24 @@ public class PropertiesTest {
     assertEquals(2, result.size());
     assertEquals("value1", result.get("key1"));
     assertEquals("value2", result.get("key2"));
+  }
+
+  @Test
+  public void testSeparatorWithNullOrEmptyInput() {
+    Throwable ex1 =
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new Properties(null, "="));
+    Assertions.assertTrue(ex1.getMessage().contains("delimiter cannot be null or empty"));
+
+    Throwable ex2 =
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new Properties("", "="));
+    Assertions.assertTrue(ex2.getMessage().contains("delimiter cannot be null or empty"));
+
+    Throwable ex3 =
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new Properties(",", null));
+    Assertions.assertTrue(ex3.getMessage().contains("keyValueSeparator cannot be null or empty"));
+
+    Throwable ex4 =
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new Properties(",", ""));
+    Assertions.assertTrue(ex4.getMessage().contains("keyValueSeparator cannot be null or empty"));
   }
 }


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?
Fix delimiters in Properties.java, make sure it split string correct with custom delimiter

### Why are the changes needed?

Fix: #8409 

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?

add unit tests
