### PR TITLE
[#8382]Improvement(IcebergHiveCachedClientPool): prevent NPE in IcebergHiveCachedClientPool when closing multiple instances

### DIFF
--- a/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/utils/IcebergHiveCachedClientPool.java
+++ b/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/utils/IcebergHiveCachedClientPool.java
@@ -261,6 +261,6 @@ public class IcebergHiveCachedClientPool
   public void close() throws IOException {
     clientPoolCache.asMap().forEach((key, value) -> value.close());
     clientPoolCache.invalidateAll();
-    scheduledExecutorService.shutdownNow();
+    if (scheduledExecutorService != null) scheduledExecutorService.shutdownNow();
   }
 }

--- a/iceberg/iceberg-common/src/test/java/org/apache/gravitino/iceberg/common/utils/TestIcebergHiveCachedClientPool.java
+++ b/iceberg/iceberg-common/src/test/java/org/apache/gravitino/iceberg/common/utils/TestIcebergHiveCachedClientPool.java
@@ -99,4 +99,18 @@ public class TestIcebergHiveCachedClientPool {
                 () -> IcebergHiveCachedClientPool.extractKey("ugi", configuration));
     Assertions.assertNotEquals(key9, key10);
   }
+
+  @Test
+  void testCloseMultipleInstances() throws IOException {
+    Configuration configuration = new Configuration();
+    Map<String, String> properties = Maps.newHashMap();
+    IcebergHiveCachedClientPool pool1 = new IcebergHiveCachedClientPool(configuration, properties);
+    IcebergHiveCachedClientPool pool2 = new IcebergHiveCachedClientPool(configuration, properties);
+
+    Assertions.assertDoesNotThrow(
+        () -> {
+          pool1.close();
+          pool2.close();
+        });
+  }
 }


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?
Add a null check before shutting down scheduledExecutorService in close method.


### Why are the changes needed?
clientPoolCache is a static field, meaning it is shared across all instances of IcebergHiveCachedClientPool.
Only the first instance that calls init() will initialize both clientPoolCache and scheduledExecutorService.
Any subsequent instances will find clientPoolCache already initialized, so they will not initialize scheduledExecutorService (it remains null for those instances).When we create multiple instances of IcebergHiveCachedClientPool, only the first instance will have a non-null scheduledExecutorService.The other instances will have scheduledExecutorService as null.
When we call close() on all instances, each will attempt to call scheduledExecutorService.shutdownNow()
For instances where scheduledExecutorService is null, this results in a NullPointerException.

Fix: (#8382 )

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
unit testing

