### PR TITLE
[#8381]Improvement(OceanbaseTableOperations):   empty SQL statements should not stop all SQL statements in alterTable

### DIFF
--- a/catalogs/catalog-jdbc-oceanbase/src/main/java/org/apache/gravitino/catalog/oceanbase/operation/OceanBaseTableOperations.java
+++ b/catalogs/catalog-jdbc-oceanbase/src/main/java/org/apache/gravitino/catalog/oceanbase/operation/OceanBaseTableOperations.java
@@ -217,7 +217,7 @@ public class OceanBaseTableOperations extends JdbcTableOperations {
         String sql = generateAlterTableSql(databaseName, tableName, change);
         if (StringUtils.isEmpty(sql)) {
           LOG.info("No changes to alter table {} from database {}", tableName, databaseName);
-          return;
+          continue;
         }
         JdbcConnectorUtils.executeUpdate(connection, sql);
       }

--- a/catalogs/catalog-jdbc-oceanbase/src/test/java/org/apache/gravitino/catalog/oceanbase/operation/TestOceanBaseTableOperations.java
+++ b/catalogs/catalog-jdbc-oceanbase/src/test/java/org/apache/gravitino/catalog/oceanbase/operation/TestOceanBaseTableOperations.java
@@ -1157,16 +1157,18 @@ public class TestOceanBaseTableOperations extends TestOceanBase {
         Indexes.EMPTY_INDEXES);
 
     // Alter table with one valid change and one empty SQL change
-    TableChange validChange = TableChange.updateColumnComment(new String[] {"col_1"}, "Updated comment");
-    TableChange emptyChange = new TableChange() {
-        @Override
-        public String toString() {
+    TableChange validChange =
+        TableChange.updateColumnComment(new String[] {"col_1"}, "Updated comment");
+    TableChange emptyChange =
+        new TableChange() {
+          @Override
+          public String toString() {
             return "EmptyChange";
-        }
-    };
+          }
+        };
 
-    Assertions.assertDoesNotThrow(() ->
-        TABLE_OPERATIONS.alterTable(TEST_DB_NAME, tableName, emptyChange, validChange));
+    Assertions.assertDoesNotThrow(
+        () -> TABLE_OPERATIONS.alterTable(TEST_DB_NAME, tableName, emptyChange, validChange));
 
     // Verify the valid change was applied
     JdbcTable table = TABLE_OPERATIONS.load(TEST_DB_NAME, tableName);

--- a/catalogs/catalog-jdbc-oceanbase/src/test/java/org/apache/gravitino/catalog/oceanbase/operation/TestOceanBaseTableOperations.java
+++ b/catalogs/catalog-jdbc-oceanbase/src/test/java/org/apache/gravitino/catalog/oceanbase/operation/TestOceanBaseTableOperations.java
@@ -1159,17 +1159,9 @@ public class TestOceanBaseTableOperations extends TestOceanBase {
     // Alter table with one valid change and one empty SQL change
     TableChange validChange =
         TableChange.updateColumnComment(new String[] {"col_1"}, "Updated comment");
-    TableChange emptyChange =
-        new TableChange() {
-          @Override
-          public String toString() {
-            return "EmptyChange";
-          }
-        };
-
+    TableChange emptyChange = TableChange.deleteColumn(new String[] {"non_existent_col"}, true);
     Assertions.assertDoesNotThrow(
         () -> TABLE_OPERATIONS.alterTable(TEST_DB_NAME, tableName, emptyChange, validChange));
-
     // Verify the valid change was applied
     JdbcTable table = TABLE_OPERATIONS.load(TEST_DB_NAME, tableName);
     Assertions.assertEquals("Updated comment", table.columns()[0].comment());


### PR DESCRIPTION
### What changes were proposed in this pull request?
Use of continue instead of return in alterTable method so that empty SQL statements no longer stop processing subsequent changes.

### Why are the changes needed?
 empty SQL statements no longer stop processing subsequent changes in alterTable method 


Fix: #8381

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Unit testing

