### PR TITLE
[MINOR] fix(test): Disable `_catalog_cache.clear`  when cache is diabled.

### DIFF
--- a/clients/client-python/tests/integration/test_gvfs_with_s3.py
+++ b/clients/client-python/tests/integration/test_gvfs_with_s3.py
@@ -279,6 +279,7 @@ class TestGvfsWithS3(TestGvfsWithHDFS):
         )
 
         if fs.operations._enable_fileset_metadata_cache:
+            fs.operations._fileset_cache.clear()
             fs.operations._catalog_cache.clear()
 
         s3_fs = fs.operations._get_actual_filesystem(mkdir_dir, None)

--- a/clients/client-python/tests/integration/test_gvfs_with_s3.py
+++ b/clients/client-python/tests/integration/test_gvfs_with_s3.py
@@ -278,7 +278,9 @@ class TestGvfsWithS3(TestGvfsWithHDFS):
             **self.conf,
         )
 
-        fs.operations._catalog_cache.clear()
+        # As #8254 introduces a switch to initialize cache for catalog, by default
+        # it's disabled, so here we don't need to clear the cache any more.
+        # fs.operations._catalog_cache.clear()
         s3_fs = fs.operations._get_actual_filesystem(mkdir_dir, None)
         config_kwargs = s3_fs.config_kwargs
         self.assertEqual("virtual", config_kwargs.get("s3").get("addressing_style"))

--- a/clients/client-python/tests/integration/test_gvfs_with_s3.py
+++ b/clients/client-python/tests/integration/test_gvfs_with_s3.py
@@ -278,9 +278,9 @@ class TestGvfsWithS3(TestGvfsWithHDFS):
             **self.conf,
         )
 
-        # As #8254 introduces a switch to initialize cache for catalog, by default
-        # it's disabled, so here we don't need to clear the cache any more.
-        # fs.operations._catalog_cache.clear()
+        if fs.operations._enable_fileset_metadata_cache:
+            fs.operations._catalog_cache.clear()
+
         s3_fs = fs.operations._get_actual_filesystem(mkdir_dir, None)
         config_kwargs = s3_fs.config_kwargs
         self.assertEqual("virtual", config_kwargs.get("s3").get("addressing_style"))


### PR DESCRIPTION

### What changes were proposed in this pull request?

Comment the line `fs.operations._catalog_cache.clear()` 

### Why are the changes needed?

_catalog_cache will not initialized when `ENABLE_FILESET_METADATA_CACHE_DEFAULT` is changed to false.

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

Existing tests.
