### PR TITLE
[#233] Improvement(catalog): StarRocks table alter operation trigger IllegalPropertyOperation on unknown properties

### DIFF
--- a/api/src/main/java/org/apache/gravitino/exceptions/IllegalPropertyException.java
+++ b/api/src/main/java/org/apache/gravitino/exceptions/IllegalPropertyException.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.exceptions;
+
+import com.google.errorprone.annotations.FormatMethod;
+import com.google.errorprone.annotations.FormatString;
+
+/** An exception thrown when a property is invalid. */
+public class IllegalPropertyException extends GravitinoRuntimeException {
+
+  /**
+   * Constructs a new exception with the specified detail message.
+   *
+   * @param message the detail message.
+   * @param args the arguments to the message.
+   */
+  @FormatMethod
+  public IllegalPropertyException(@FormatString String message, Object... args) {
+    super(message, args);
+  }
+
+  /**
+   * Constructs a new exception with the specified detail message and cause.
+   *
+   * @param cause the cause.
+   * @param message the detail message.
+   * @param args the arguments to the message.
+   */
+  @FormatMethod
+  public IllegalPropertyException(Throwable cause, @FormatString String message, Object... args) {
+    super(cause, message, args);
+  }
+}

--- a/api/src/test/java/org/apache/gravitino/stats/TestPartitionRange.java
+++ b/api/src/test/java/org/apache/gravitino/stats/TestPartitionRange.java
@@ -43,7 +43,7 @@ public class TestPartitionRange {
     Assertions.assertFalse(range2.upperPartitionName().isPresent());
     Assertions.assertTrue(range2.lowerPartitionName().isPresent());
     Assertions.assertEquals("lower", range2.lowerPartitionName().get());
-    Assertions.assertEquals(defaultSortOrder, defaultSortOrder);
+    Assertions.assertEquals(defaultSortOrder, range2.comparator());
     Assertions.assertEquals(PartitionRange.BoundType.CLOSED, range2.lowerBoundType().get());
 
     PartitionRange range3 =


### PR DESCRIPTION

### What changes were proposed in this pull request?

Add a new `IllegalPropertyException` which extends `GravitinoRuntimeException` to handle the unknown property issue in Starrocks.

### Why are the changes needed?
Unknown properties in Starrocks can not be well handled. It throw an generic `GravitinoRuntimeException` when set up an unknown property to table. So raise this PR to add a new Custom Exception class to handle the case.

Fix: #(8418)

### Does this PR introduce _any_ user-facing change?

NO
### How was this patch tested?

run `./gradlew build` and passed all the UTs and ITs.
run `./gradlew :catalogs:catalog-jdbc-starrocks:test --tests "org.apache.gravitino.catalog.starrocks.operation.TestStarRocksTableOperations" -PskipDockerTests=false` and passed docker test in `StarRocksTableOperations`
