### PR TITLE
[#8486] Improvement(core): Correct the LocalJobExecutor test teardown to run after each test

### DIFF
--- a/core/src/test/java/org/apache/gravitino/job/local/TestLocalJobExecutor.java
+++ b/core/src/test/java/org/apache/gravitino/job/local/TestLocalJobExecutor.java
@@ -35,6 +35,7 @@ import org.apache.gravitino.meta.AuditInfo;
 import org.apache.gravitino.meta.JobTemplateEntity;
 import org.apache.gravitino.utils.NamespaceUtil;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -96,7 +97,7 @@ public class TestLocalJobExecutor {
     workingDir = Files.createTempDirectory("gravitino-test-local-job-executor").toFile();
   }
 
-  @BeforeEach
+  @AfterEach
   public void tearDown() throws IOException {
     if (workingDir != null && workingDir.exists()) {
       FileUtils.deleteDirectory(workingDir);


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Correct the LocalJobExecutor test teardown to run after each test 

### Why are the changes needed?


Fix: #([8486](https://github.com/apache/gravitino/issues/8486))

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

N/A
