### PR TITLE
[#8484] Improvement(trino):JDBCCatalogPropertyConverter.java converter where the required property set mistakenly includes the password key twice

### DIFF
--- a/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/catalog/jdbc/JDBCCatalogPropertyConverter.java
+++ b/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/catalog/jdbc/JDBCCatalogPropertyConverter.java
@@ -56,7 +56,7 @@ public class JDBCCatalogPropertyConverter extends CatalogPropertyConverter {
   /** Set of required properties for JDBC connection. */
   public static final Set<String> REQUIRED_PROPERTIES =
       Sets.newHashSet(
-          JDBC_CONNECTION_PASSWORD_KEY, JDBC_CONNECTION_USER_KEY, JDBC_CONNECTION_PASSWORD_KEY);
+          JDBC_CONNECTION_URL_KEY, JDBC_CONNECTION_USER_KEY, JDBC_CONNECTION_PASSWORD_KEY);
 
   @Override
   public TreeBidiMap<String, String> engineToGravitinoMapping() {

--- a/trino-connector/trino-connector/src/test/java/org/apache/gravitino/trino/connector/catalog/jdbc/TestJDBCCatalogPropertyConverter.java
+++ b/trino-connector/trino-connector/src/test/java/org/apache/gravitino/trino/connector/catalog/jdbc/TestJDBCCatalogPropertyConverter.java
@@ -58,4 +58,17 @@ public class TestJDBCCatalogPropertyConverter {
           propertyConverter.gravitinoToEngineProperties(gravitinoPropertiesWithoutPassword);
         });
   }
+
+  @Test
+  public void testMissingConnectionUrl() {
+    PropertyConverter propertyConverter = new JDBCCatalogPropertyConverter();
+    Map<String, String> gravitinoPropertiesWithoutUrl =
+        ImmutableMap.of("jdbc-user", "root", "jdbc-password", "root");
+
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          propertyConverter.gravitinoToEngineProperties(gravitinoPropertiesWithoutUrl);
+        });
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

JDBCCatalogPropertyConverter.java converter where the required property set mistakenly includes the password key twice

### Why are the changes needed?


Fix: #8484

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

org.apache.gravitino.trino.connector.catalog.jdbc.TestJDBCCatalogPropertyConverter#testMissingConnectionUrl
