### PR TITLE
[#8509] improvement(catalog-postgresql): map SQLState class "08" to ConnectionFailedException

### DIFF
--- a/catalogs/catalog-jdbc-postgresql/src/main/java/org/apache/gravitino/catalog/postgresql/converter/PostgreSqlExceptionConverter.java
+++ b/catalogs/catalog-jdbc-postgresql/src/main/java/org/apache/gravitino/catalog/postgresql/converter/PostgreSqlExceptionConverter.java
@@ -35,7 +35,13 @@ public class PostgreSqlExceptionConverter extends JdbcExceptionConverter {
   private static final String INVALID_SCHEMA_NAME = "3D000";
   private static final String INVALID_SCHEMA = "3F000";
   private static final String UNDEFINED_TABLE = "42P01";
-  private static final String CONNECTION_EXCEPTION = "08"; // class code
+
+  /**
+   * SQLSTATE '08' is the class code of connection exceptions See <a
+   * href="https://www.postgresql.org/docs/current/errcodes-appendix.html#ERRCODES-TABLE">PostgreSQL
+   * errcodes appendix</a>.
+   */
+  private static final String CONNECTION_EXCEPTION = "08";
 
   @SuppressWarnings("FormatStringAnnotation")
   @Override

--- a/catalogs/catalog-jdbc-postgresql/src/main/java/org/apache/gravitino/catalog/postgresql/converter/PostgreSqlExceptionConverter.java
+++ b/catalogs/catalog-jdbc-postgresql/src/main/java/org/apache/gravitino/catalog/postgresql/converter/PostgreSqlExceptionConverter.java
@@ -44,12 +44,13 @@ public class PostgreSqlExceptionConverter extends JdbcExceptionConverter {
           return new NoSuchSchemaException(se.getMessage(), se);
         case "42P01":
           return new NoSuchTableException(se.getMessage(), se);
-        default: {
-          if (se.getSQLState().startsWith("08")) {
-            return new ConnectionFailedException(se.getMessage(), se);
+        default:
+          {
+            if (se.getSQLState().startsWith("08")) {
+              return new ConnectionFailedException(se.getMessage(), se);
+            }
+            return new GravitinoRuntimeException(se.getMessage(), se);
           }
-          return new GravitinoRuntimeException(se.getMessage(), se);
-        }
       }
     } else {
       if (se.getMessage() != null && se.getMessage().contains("password authentication failed")) {

--- a/catalogs/catalog-jdbc-postgresql/src/main/java/org/apache/gravitino/catalog/postgresql/converter/PostgreSqlExceptionConverter.java
+++ b/catalogs/catalog-jdbc-postgresql/src/main/java/org/apache/gravitino/catalog/postgresql/converter/PostgreSqlExceptionConverter.java
@@ -44,8 +44,12 @@ public class PostgreSqlExceptionConverter extends JdbcExceptionConverter {
           return new NoSuchSchemaException(se.getMessage(), se);
         case "42P01":
           return new NoSuchTableException(se.getMessage(), se);
-        default:
+        default: {
+          if (se.getSQLState().startsWith("08")) {
+            return new ConnectionFailedException(se.getMessage(), se);
+          }
           return new GravitinoRuntimeException(se.getMessage(), se);
+        }
       }
     } else {
       if (se.getMessage() != null && se.getMessage().contains("password authentication failed")) {

--- a/catalogs/catalog-jdbc-postgresql/src/main/java/org/apache/gravitino/catalog/postgresql/converter/PostgreSqlExceptionConverter.java
+++ b/catalogs/catalog-jdbc-postgresql/src/main/java/org/apache/gravitino/catalog/postgresql/converter/PostgreSqlExceptionConverter.java
@@ -29,24 +29,32 @@ import org.apache.gravitino.exceptions.TableAlreadyExistsException;
 
 public class PostgreSqlExceptionConverter extends JdbcExceptionConverter {
 
+  private static final String DUPLICATE_DATABASE = "42P04";
+  private static final String DUPLICATE_SCHEMA = "42P06";
+  private static final String DUPLICATE_TABLE = "42P07";
+  private static final String INVALID_SCHEMA_NAME = "3D000";
+  private static final String INVALID_SCHEMA = "3F000";
+  private static final String UNDEFINED_TABLE = "42P01";
+  private static final String CONNECTION_EXCEPTION = "08"; // class code
+
   @SuppressWarnings("FormatStringAnnotation")
   @Override
   public GravitinoRuntimeException toGravitinoException(SQLException se) {
     if (null != se.getSQLState()) {
       switch (se.getSQLState()) {
-        case "42P04":
-        case "42P06":
+        case DUPLICATE_DATABASE:
+        case DUPLICATE_SCHEMA:
           return new SchemaAlreadyExistsException(se.getMessage(), se);
-        case "42P07":
+        case DUPLICATE_TABLE:
           return new TableAlreadyExistsException(se.getMessage(), se);
-        case "3D000":
-        case "3F000":
+        case INVALID_SCHEMA_NAME:
+        case INVALID_SCHEMA:
           return new NoSuchSchemaException(se.getMessage(), se);
-        case "42P01":
+        case UNDEFINED_TABLE:
           return new NoSuchTableException(se.getMessage(), se);
         default:
           {
-            if (se.getSQLState().startsWith("08")) {
+            if (se.getSQLState().startsWith(CONNECTION_EXCEPTION)) {
               return new ConnectionFailedException(se.getMessage(), se);
             }
             return new GravitinoRuntimeException(se.getMessage(), se);


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?
Update `PostgreSqlExceptionConverter` so that SQLState codes in class "08" (connection errors) are mapped to a more specific `ConnectionFailedException` instead of the generic `GravitinoRuntimeException`.

### Why are the changes needed?
Previously, PostgreSQL connection-related errors (SQLState class "08") were reported as generic runtime exceptions, making it harder for clients and higher layers to distinguish connection failures from other SQL errors.  
This change improves error handling by returning a more meaningful exception, allowing callers to react appropriately (e.g., retrying connections).

Fix: #8509 

### Does this PR introduce _any_ user-facing change?
Yes.  
Users interacting with Gravitino via the PostgreSQL catalog will now receive a `ConnectionFailedException` for SQLState class "08" errors instead of a generic `GravitinoRuntimeException`.

### How was this patch tested?
N/A
