### PR TITLE
[#8510] improvement(clients): catch NoSuchFilesetException in ListFilesetProperties.java

### DIFF
--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/ListFilesetProperties.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/ListFilesetProperties.java
@@ -25,6 +25,7 @@ import org.apache.gravitino.cli.CommandContext;
 import org.apache.gravitino.cli.ErrorMessages;
 import org.apache.gravitino.client.GravitinoClient;
 import org.apache.gravitino.exceptions.NoSuchCatalogException;
+import org.apache.gravitino.exceptions.NoSuchFilesetException;
 import org.apache.gravitino.exceptions.NoSuchMetalakeException;
 import org.apache.gravitino.exceptions.NoSuchSchemaException;
 import org.apache.gravitino.file.Fileset;
@@ -73,6 +74,8 @@ public class ListFilesetProperties extends ListProperties {
       exitWithError(ErrorMessages.UNKNOWN_CATALOG);
     } catch (NoSuchSchemaException err) {
       exitWithError(ErrorMessages.UNKNOWN_SCHEMA);
+    } catch (NoSuchFilesetException err) {
+      exitWithError(ErrorMessages.UNKNOWN_FILESET);
     } catch (Exception exp) {
       exitWithError(exp.getMessage());
     }


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?
Extend the exception handling in `ListFilesetProperties.java` to explicitly catch `NoSuchFilesetException` and exit with the appropriate error message (`UNKNOWN_FILESET`).

### Why are the changes needed?
Previously, the CLI already handled `NoSuchMetalakeException`, `NoSuchCatalogException`, and `NoSuchSchemaException` with clear error messages.  
However, when a fileset did not exist, the CLI would fall through to the generic `Exception` catch block, resulting in a less user-friendly message.  
Adding explicit handling for `NoSuchFilesetException` ensures consistent error reporting across all “not found” scenarios.

Fix: #8510

### Does this PR introduce _any_ user-facing change?
Yes.  
Users now receive a standardized `UNKNOWN_FILESET` error message when attempting to list properties of a non-existent fileset, aligning the behavior with other missing-entity errors.

### How was this patch tested?
N/A