### PR TITLE
[#8511] improvement(core): add missing space in CredentialCacheKey.toString()

### DIFF
--- a/core/src/main/java/org/apache/gravitino/credential/CredentialCacheKey.java
+++ b/core/src/main/java/org/apache/gravitino/credential/CredentialCacheKey.java
@@ -57,7 +57,7 @@ public class CredentialCacheKey {
     stringBuilder
         .append("credentialType: ")
         .append(credentialType)
-        .append("credentialContext: ")
+        .append(" credentialContext: ")
         .append(credentialContext);
     return stringBuilder.toString();
   }

--- a/core/src/test/java/org/apache/gravitino/credential/TestCredentialCacheKey.java
+++ b/core/src/test/java/org/apache/gravitino/credential/TestCredentialCacheKey.java
@@ -53,4 +53,13 @@ public class TestCredentialCacheKey {
     CredentialCacheKey key4 = new CredentialCacheKey("s3-token1", context);
     Assertions.assertFalse(cache.contains(key4));
   }
+
+  @Test
+  void testToStringContainsSpaceBetweenFields() {
+    PathBasedCredentialContext context =
+        new PathBasedCredentialContext("user", ImmutableSet.of(), ImmutableSet.of());
+    CredentialCacheKey key = new CredentialCacheKey("s3-token", context);
+
+    Assertions.assertTrue(key.toString().contains("credentialType: s3-token credentialContext:"));
+  }
 }


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?
Added a missing space between the `credentialType` and `credentialContext` fields in the `toString()` output of `CredentialCacheKey`, improving its readability.

### Why are the changes needed?
The missing space made the string representation less readable and could confuse debugging or log parsing. This fix ensures clear separation between fields and improves developer experience while interpreting the output.

Fix: #8511 

### Does this PR introduce _any_ user-facing change?
Yes—minor formatting improvement seen in log outputs, error messages, or any usage of `toString()` on `CredentialCacheKey`. No behavioral changes.

### How was this patch tested?
- Added unit test to verify the spaced output in `toString()` includes `"credentialType: <type> credentialContext:"`.