### PR TITLE
[#8507] Improvement(core): In ListTopicFailureEvent.java add precondition to check if namespace is not null

### DIFF
--- a/core/src/main/java/org/apache/gravitino/listener/api/event/ListTopicFailureEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/ListTopicFailureEvent.java
@@ -19,6 +19,8 @@
 
 package org.apache.gravitino.listener.api.event;
 
+import static java.util.Objects.requireNonNull;
+
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
 import org.apache.gravitino.annotation.DeveloperApi;
@@ -39,7 +41,8 @@ public final class ListTopicFailureEvent extends TopicFailureEvent {
    * @param exception The exception encountered during the attempt to list topics.
    */
   public ListTopicFailureEvent(String user, Namespace namespace, Exception exception) {
-    super(user, NameIdentifier.of(namespace.levels()), exception);
+    super(user, NameIdentifier.of(requireNonNull(namespace, "namespace must not be null").levels()),
+          exception);
     this.namespace = namespace;
   }
 

--- a/core/src/test/java/org/apache/gravitino/listener/api/event/TestTopicEvent.java
+++ b/core/src/test/java/org/apache/gravitino/listener/api/event/TestTopicEvent.java
@@ -244,6 +244,17 @@ public class TestTopicEvent {
     Assertions.assertEquals(OperationStatus.FAILURE, event.operationStatus());
   }
 
+  @Test
+  void testListTopicFailureEventWithNullNamespace() {
+    NullPointerException exception =
+      Assertions.assertThrowsExactly(
+          NullPointerException.class,
+          () -> new ListTopicFailureEvent("user", null, new Exception("boom")));
+
+    Assertions.assertEquals("namespace must not be null", exception.getMessage());
+  }
+
+
   private void checkTopicInfo(TopicInfo topicInfo, Topic topic) {
     Assertions.assertEquals(topic.name(), topicInfo.name());
     Assertions.assertEquals(topic.properties(), topicInfo.properties());


### PR DESCRIPTION
[Improvement(core)] In ListTopicFailureEvent.java add precondition to check if namespace is not null
### What changes were proposed in this pull request?

Added a null check in the ListTopicFailureEvent constructor using Objects.requireNonNull to ensure that the namespace is not null.  
Added a unit test `testListTopicFailureEventWithNullNamespace()` in TestTopicEvent to verify that a NullPointerException is thrown when namespace is null.

### Why are the changes needed?

To prevent potential NullPointerExceptions when creating a ListTopicFailureEvent with a null namespace and improve code robustness.

Fix: #8507

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

N/A
