### PR TITLE
[#7572] patch(gvfs): fix gvfs conf name for fileset metadata cache

### DIFF
--- a/clients/filesystem-hadoop3/src/main/java/org/apache/gravitino/filesystem/hadoop/BaseGVFSOperations.java
+++ b/clients/filesystem-hadoop3/src/main/java/org/apache/gravitino/filesystem/hadoop/BaseGVFSOperations.java
@@ -20,8 +20,8 @@ package org.apache.gravitino.filesystem.hadoop;
 
 import static org.apache.gravitino.file.Fileset.PROPERTY_DEFAULT_LOCATION_NAME;
 import static org.apache.gravitino.filesystem.hadoop.GravitinoVirtualFileSystemConfiguration.FS_GRAVITINO_CURRENT_LOCATION_NAME;
-import static org.apache.gravitino.filesystem.hadoop.GravitinoVirtualFileSystemConfiguration.FS_GRAVITINO_FILESET_CATALOG_CACHE_ENABLE;
-import static org.apache.gravitino.filesystem.hadoop.GravitinoVirtualFileSystemConfiguration.FS_GRAVITINO_FILESET_CATALOG_CACHE_ENABLE_DEFAULT;
+import static org.apache.gravitino.filesystem.hadoop.GravitinoVirtualFileSystemConfiguration.FS_GRAVITINO_FILESET_METADATA_CACHE_ENABLE;
+import static org.apache.gravitino.filesystem.hadoop.GravitinoVirtualFileSystemConfiguration.FS_GRAVITINO_FILESET_METADATA_CACHE_ENABLE_DEFAULT;
 import static org.apache.gravitino.filesystem.hadoop.GravitinoVirtualFileSystemUtils.extractIdentifier;
 import static org.apache.gravitino.filesystem.hadoop.GravitinoVirtualFileSystemUtils.getConfigMap;
 import static org.apache.gravitino.filesystem.hadoop.GravitinoVirtualFileSystemUtils.getSubPathFromGvfsPath;
@@ -148,8 +148,8 @@ public abstract class BaseGVFSOperations implements Closeable {
     this.gravitinoClient = GravitinoVirtualFileSystemUtils.createClient(configuration);
     boolean enableFilesetCatalogCache =
         configuration.getBoolean(
-            FS_GRAVITINO_FILESET_CATALOG_CACHE_ENABLE,
-            FS_GRAVITINO_FILESET_CATALOG_CACHE_ENABLE_DEFAULT);
+            FS_GRAVITINO_FILESET_METADATA_CACHE_ENABLE,
+            FS_GRAVITINO_FILESET_METADATA_CACHE_ENABLE_DEFAULT);
     this.filesetMetadataCache =
         enableFilesetCatalogCache
             ? Optional.of(new FilesetMetadataCache(gravitinoClient))

--- a/clients/filesystem-hadoop3/src/main/java/org/apache/gravitino/filesystem/hadoop/GravitinoVirtualFileSystemConfiguration.java
+++ b/clients/filesystem-hadoop3/src/main/java/org/apache/gravitino/filesystem/hadoop/GravitinoVirtualFileSystemConfiguration.java
@@ -165,15 +165,15 @@ public class GravitinoVirtualFileSystemConfiguration {
       ImmutableList.of(FS_GRAVITINO_CLIENT_METALAKE_KEY, FS_GRAVITINO_CLIENT_AUTH_TYPE_KEY);
 
   /**
-   * The configuration key for whether to enable fileset catalog cache. The default is false. Note
-   * that this cache causes a side effect: if you modify the fileset or fileset catalog metadata,
-   * the client can not see the latest changes.
+   * The configuration key for whether to enable fileset and catalog cache. The default is false.
+   * Note that this cache causes a side effect: if you modify the fileset or fileset catalog
+   * metadata, the client can not see the latest changes.
    */
-  public static final String FS_GRAVITINO_FILESET_CATALOG_CACHE_ENABLE =
-      "fs.gravitino.filesetCatalog.cache.enable";
+  public static final String FS_GRAVITINO_FILESET_METADATA_CACHE_ENABLE =
+      "fs.gravitino.filesetMetadataCache.cache.enable";
 
-  /** The default value for whether to enable fileset catalog cache. */
-  public static final boolean FS_GRAVITINO_FILESET_CATALOG_CACHE_ENABLE_DEFAULT = false;
+  /** The default value for whether to enable fileset and catalog cache. */
+  public static final boolean FS_GRAVITINO_FILESET_METADATA_CACHE_ENABLE_DEFAULT = false;
 
   private GravitinoVirtualFileSystemConfiguration() {}
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

fix gvfs conf name for fileset metadata cache

### Why are the changes needed?

Fix: #7572

### Does this PR introduce _any_ user-facing change?

no

### How was this patch tested?

CI pass
