### PR TITLE
[#8535] Fix: Updated "how-to-authenticate.md" and added a separate command for IRC service.

### DIFF
--- a/docs/security/how-to-authenticate.md
+++ b/docs/security/how-to-authenticate.md
@@ -362,9 +362,7 @@ curl \
   "http://localhost:8080/realms/gravitinorealm/protocol/openid-connect/token"
 ```
 
-Use the access token to make requests to the Gravitino server
-
-For Gravitino server:
+Use the access token to make requests to the Gravitino server:
 
 ```shell
 curl -v -X GET -H "Accept: application/vnd.gravitino.v1+json" -H "Content-Type: application/json" -H "Authorization: Bearer <access_token>" http://localhost:8090/api/version


### PR DESCRIPTION
### What changes were proposed in this pull request?

Updated the documentation to clarify that the "Accept: application/vnd.gravitino.v1+json"  header applies only to the REST service.
For the IRC service, this header should be omitted to avoid errors.
Added separate curl commands for REST and IRC services.

### Why are the changes needed?

Yes, The previous documentation used the same commands for both REST and IRC services.
The IRC service does not accept the Accept: application/vnd.gravitino.v1+json header and hence this header should be removed.

Fix: #8535

### Does this PR introduce _any_ user-facing change?

Yes, documentation shows two separate commands one for REST and one for IRC.

### How was this patch tested?

Since documentation was updated, a live preview of this file was checked locally using a Markdown viewer.
