### PR TITLE
[#8313] Improvement (iceberg-rest): Standardize credentials in loadTable/loadView responses for Iceberg REST server

### DIFF
--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/IcebergAccessDelegationUtil.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/IcebergAccessDelegationUtil.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.iceberg.service;
+
+import org.apache.commons.lang3.StringUtils;
+
+/** Utility class for handling Iceberg access delegation validation. */
+public class IcebergAccessDelegationUtil {
+
+  /** The HTTP header name for Iceberg access delegation. */
+  public static final String X_ICEBERG_ACCESS_DELEGATION = "X-Iceberg-Access-Delegation";
+
+  private IcebergAccessDelegationUtil() {}
+
+  /**
+   * Determines if the access delegation header indicates credential vending is requested.
+   *
+   * @param accessDelegation The access delegation header value
+   * @return true if credential vending is requested, false otherwise
+   * @throws UnsupportedOperationException if remote signing is requested (not supported)
+   * @throws IllegalArgumentException if the access delegation value is invalid
+   */
+  public static boolean isCredentialVending(String accessDelegation) {
+    if (StringUtils.isBlank(accessDelegation)) {
+      return false;
+    }
+    if ("vended-credentials".equalsIgnoreCase(accessDelegation)) {
+      return true;
+    }
+    if ("remote-signing".equalsIgnoreCase(accessDelegation)) {
+      throw new UnsupportedOperationException(
+          "Gravitino IcebergRESTServer doesn't support remote signing");
+    } else {
+      throw new IllegalArgumentException(
+          X_ICEBERG_ACCESS_DELEGATION
+              + ": "
+              + accessDelegation
+              + " is illegal, Iceberg REST spec supports: [vended-credentials,remote-signing], "
+              + "Gravitino Iceberg REST server supports: vended-credentials");
+    }
+  }
+}

--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/dispatcher/IcebergViewOperationExecutor.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/dispatcher/IcebergViewOperationExecutor.java
@@ -64,7 +64,7 @@ public class IcebergViewOperationExecutor implements IcebergViewOperationDispatc
   public LoadViewResponse loadView(IcebergRequestContext context, TableIdentifier viewIdentifier) {
     return icebergCatalogWrapperManager
         .getCatalogWrapper(context.catalogName())
-        .loadView(viewIdentifier);
+        .loadView(viewIdentifier, context.requestCredentialVending());
   }
 
   @Override

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/TestIcebergAccessDelegationUtil.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/TestIcebergAccessDelegationUtil.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.iceberg.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class TestIcebergAccessDelegationUtil {
+
+  @Test
+  void testIsCredentialVendingWithNull() {
+    assertFalse(IcebergAccessDelegationUtil.isCredentialVending(null));
+  }
+
+  @Test
+  void testIsCredentialVendingWithVendedCredentials() {
+    assertTrue(IcebergAccessDelegationUtil.isCredentialVending("vended-credentials"));
+    assertTrue(IcebergAccessDelegationUtil.isCredentialVending("VENDED-CREDENTIALS"));
+    assertTrue(IcebergAccessDelegationUtil.isCredentialVending("Vended-Credentials"));
+  }
+
+  @Test
+  void testIsCredentialVendingWithRemoteSigning() {
+    UnsupportedOperationException exception =
+        assertThrows(
+            UnsupportedOperationException.class,
+            () -> IcebergAccessDelegationUtil.isCredentialVending("remote-signing"));
+    assertEquals(
+        "Gravitino IcebergRESTServer doesn't support remote signing", exception.getMessage());
+  }
+
+  @Test
+  void testIsCredentialVendingWithInvalidValue() {
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> IcebergAccessDelegationUtil.isCredentialVending("invalid-value"));
+    assertTrue(
+        exception.getMessage().contains("X-Iceberg-Access-Delegation: invalid-value is illegal"));
+    assertTrue(
+        exception
+            .getMessage()
+            .contains("Iceberg REST spec supports: [vended-credentials,remote-signing]"));
+    assertTrue(
+        exception
+            .getMessage()
+            .contains("Gravitino Iceberg REST server supports: vended-credentials"));
+  }
+}

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/TestIcebergTableOperations.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/TestIcebergTableOperations.java
@@ -32,6 +32,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import org.apache.gravitino.credential.Credential;
+import org.apache.gravitino.iceberg.service.IcebergAccessDelegationUtil;
 import org.apache.gravitino.iceberg.service.extension.DummyCredentialProvider;
 import org.apache.gravitino.listener.api.event.Event;
 import org.apache.gravitino.listener.api.event.IcebergCreateTableEvent;
@@ -331,7 +332,7 @@ public class TestIcebergTableOperations extends IcebergNamespaceTestBase {
     CreateTableRequest createTableRequest =
         CreateTableRequest.builder().withName(name).withSchema(tableSchema).build();
     return getTableClientBuilder(ns, Optional.empty())
-        .header(IcebergTableOperations.X_ICEBERG_ACCESS_DELEGATION, "vended-credentials")
+        .header(IcebergAccessDelegationUtil.X_ICEBERG_ACCESS_DELEGATION, "vended-credentials")
         .post(Entity.entity(createTableRequest, MediaType.APPLICATION_JSON_TYPE));
   }
 
@@ -366,7 +367,7 @@ public class TestIcebergTableOperations extends IcebergNamespaceTestBase {
 
   private Response doLoadTableWithCredentialVending(Namespace ns, String name) {
     return getTableClientBuilder(ns, Optional.of(name))
-        .header(IcebergTableOperations.X_ICEBERG_ACCESS_DELEGATION, "vended-credentials")
+        .header(IcebergAccessDelegationUtil.X_ICEBERG_ACCESS_DELEGATION, "vended-credentials")
         .get();
   }
 


### PR DESCRIPTION

### What changes were proposed in this pull request?

Standardize credentials in loadTable/loadView responses for Iceberg REST server

### Why are the changes needed?

Fix: #([8313](https://github.com/apache/gravitino/issues/8313))

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

N/A
