### PR TITLE
[#5198] feat(client-python): add policy

### DIFF
--- a/clients/client-python/gravitino/api/policy/__init__.py
+++ b/clients/client-python/gravitino/api/policy/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/clients/client-python/gravitino/api/policy/policy.py
+++ b/clients/client-python/gravitino/api/policy/policy.py
@@ -1,0 +1,193 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from abc import ABC, abstractmethod
+from enum import Enum
+
+from gravitino.api.auditable import Auditable
+from gravitino.api.metadata_object import MetadataObject
+from gravitino.api.policy.policy_content import PolicyContent
+from gravitino.api.policy.policy_contents import PolicyContents
+from gravitino.exceptions.base import (
+    IllegalArgumentException,
+    UnsupportedOperationException,
+)
+from gravitino.utils.precondition import Precondition
+
+
+class Policy(Auditable):
+    """The interface of the policy.
+
+    The policy is a set of rules that can be associated with a metadata object.
+    The policy can be used for data governance and so on.
+    """
+
+    BUILT_IN_TYPE_PREFIX: str = "system_"
+    """The prefix for built-in policy types. All built-in policy types should start with this prefix."""
+
+    @abstractmethod
+    def name(self) -> str:
+        """Get the name of the policy.
+
+        Returns:
+            The name of the policy.
+        """
+
+    @abstractmethod
+    def policy_type(self) -> str:
+        """Get the type of the policy.
+
+        Returns:
+            str: The type of the policy.
+        """
+
+    @abstractmethod
+    def comment(self) -> str:
+        """Get the comment of the policy.
+
+        Returns:
+            str: The comment of the policy.
+        """
+
+    @abstractmethod
+    def enabled(self) -> bool:
+        """Whether the policy is enabled or not.
+
+        Returns:
+            bool: `True` if the policy is enabled, False otherwise.
+        """
+
+    @abstractmethod
+    def content(self) -> PolicyContent:
+        """Get the content of the policy.
+
+        Returns:
+            PolicyContent: The content of the policy.
+        """
+
+    @abstractmethod
+    def inherited(self) -> bool:
+        """Check if the policy is inherited from a parent object or not.
+
+        **NOTE**: The return value is optional, Only when the policy is associated with a metadata
+        object, and called from the metadata object, the return value will be present. Otherwise, it
+        will be empty.
+
+        Returns:
+            bool:
+                `True` if the policy is inherited, false if it is owned by the object itself.
+                the policy is not associated with any object.
+        """
+
+    def associated_objects(self) -> "Policy.AssociatedObjects":
+        """Get the associated objects of the policy.
+
+        Returns:
+            Policy.AssociatedObjects: The associated objects of the policy.
+        """
+        raise UnsupportedOperationException(
+            "The associatedObjects method is not supported."
+        )
+
+    class AssociatedObjects(ABC):
+        """The interface of the associated objects of the policy.
+
+        The associated objects are the objects that the policy is associated with.
+        """
+
+        def count(self) -> int:
+            """Gets the number of objects that are associated with this policy
+
+            Returns:
+                int: The number of objects that are associated with this policy
+            """
+            objects = self.objects()
+            return 0 if objects is None else len(objects)
+
+        @abstractmethod
+        def objects(self) -> list[MetadataObject]:
+            """Gets the list of objects that are associated with this policy.
+
+            Returns:
+                list[MetadataObject]: The list of objects that are associated with this policy.
+            """
+
+    class BuiltInType(Enum):
+        """The built-in policy types.
+
+        Predefined policy types that are provided by the system.
+        """
+
+        # TODO: add built-in policies, such as:
+        # DATA_COMPACTION(BUILT_IN_TYPE_PREFIX + "data_compaction",
+        # PolicyContent.DataCompactionContent.class)
+
+        CUSTOM = ("custom", PolicyContents.CustomContent)
+        """Custom policy type. "custom" is a fixed string that indicates the policy is
+        a non-built-in
+        """
+
+        def __init__(self, policy_type: str, content_class: type[PolicyContent]):
+            self._policy_type = policy_type
+            self._content_class = content_class
+
+        def policy_type(self) -> str:
+            """Get the policy type string.
+
+            Returns:
+                str: the policy type string.
+            """
+            return self._policy_type
+
+        def content_class(self) -> type[PolicyContent]:
+            """Get the content class of the policy.
+
+            Returns:
+                type[PolicyContent]: the content class of the policy.
+            """
+            return self._content_class
+
+        @staticmethod
+        def from_policy_type(policy_type: str) -> "Policy.BuiltInType":
+            """Get the built-in policy type from the policy type string.
+
+            Args:
+                policy_type (str): the policy type string
+
+            Raises:
+                IllegalArgumentException:
+                    if `policy_type` is not either a valid built-in policy type or a
+                    custom policy type.
+
+            Returns:
+                Policy.BuiltInType:
+                    the built-in policy type if it matches, otherwise returns `CUSTOM` type
+            """
+            Precondition.check_string_not_empty(
+                policy_type, "policy_type cannot be blank"
+            )
+            for type_ in Policy.BuiltInType:
+                if type_.policy_type() == policy_type:
+                    return type_
+            if policy_type.startswith(Policy.BUILT_IN_TYPE_PREFIX):
+                raise IllegalArgumentException(
+                    f"Unknown built-in policy type: {policy_type}"
+                )
+            raise IllegalArgumentException(
+                f"Unknown policy type: {policy_type}, it should start with "
+                f"'{Policy.BUILT_IN_TYPE_PREFIX}' or be 'custom'"
+            )

--- a/clients/client-python/gravitino/api/policy/policy_content.py
+++ b/clients/client-python/gravitino/api/policy/policy_content.py
@@ -1,0 +1,44 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from abc import ABC, abstractmethod
+
+from gravitino.api.metadata_object import MetadataObject
+from gravitino.utils.precondition import Precondition
+
+
+class PolicyContent(ABC):
+    """The interface of the content of the policy."""
+
+    @abstractmethod
+    def supported_object_types(self) -> set[MetadataObject.Type]:
+        """Returns the set of metadata object types that the policy can be applied to."""
+
+    @abstractmethod
+    def properties(self) -> dict[str, str]:
+        """Returns the additional properties of the policy."""
+
+    def validate(self) -> None:
+        """Validates the policy content.
+
+        Raises:
+            IllegalArgumentException: if the content is invalid.
+        """
+        Precondition.check_argument(
+            len(self.supported_object_types()) > 0,
+            "supported_object_types cannot be empty",
+        )

--- a/clients/client-python/gravitino/api/policy/policy_contents.py
+++ b/clients/client-python/gravitino/api/policy/policy_contents.py
@@ -1,0 +1,112 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from typing import Any, Optional
+
+from gravitino.api.metadata_object import MetadataObject
+from gravitino.api.policy.policy_content import PolicyContent
+
+
+class PolicyContents:
+    """Utility class for creating instances of `PolicyContent`"""
+
+    @staticmethod
+    def custom(
+        rules: dict[str, Any],
+        supported_object_types: set[MetadataObject.Type],
+        properties: dict[str, str],
+    ) -> PolicyContent:
+        """Creates a custom policy content with the given rules and properties.
+
+        Args:
+            rules: The custom rules of the policy.
+            supported_object_types: The set of metadata object types that the policy can be applied to.
+            properties: The additional properties of the policy.
+
+        Returns:
+            A new instance of `PolicyContent` with the specified rules and properties.
+        """
+        return PolicyContents.CustomContent(rules, supported_object_types, properties)
+
+    class CustomContent(PolicyContent):
+        """A custom content implementation of `PolicyContent` that holds custom rules and properties."""
+
+        def __init__(
+            self,
+            custom_rules: Optional[dict[str, Any]] = None,
+            supported_object_types: Optional[set[MetadataObject.Type]] = None,
+            properties: Optional[dict[str, str]] = None,
+        ):
+            """Constructor for `CustomContent`.
+
+            Args:
+                custom_rules: the custom rules of the policy
+                supported_object_types: the set of metadata object types that the policy can be applied to
+                properties: the additional properties of the policy
+            """
+            self._custom_rules = custom_rules
+            self._supported_object_types = frozenset(supported_object_types or set())
+            self._properties = properties
+
+        def custom_rules(self) -> Optional[dict[str, Any]]:
+            """Returns the custom rules of the policy.
+
+            Returns:
+                Optional[dict[str, Any]]: a map of custom rules.
+            """
+            return self._custom_rules
+
+        def supported_object_types(self) -> set[MetadataObject.Type]:
+            return set(self._supported_object_types)
+
+        def properties(self) -> Optional[dict[str, str]]:
+            return self._properties
+
+        def __eq__(self, other) -> bool:
+            if not isinstance(other, PolicyContents.CustomContent):
+                return False
+            return (
+                self._custom_rules == other.custom_rules()
+                and self._properties == other.properties()
+                and self._supported_object_types == other.supported_object_types()
+            )
+
+        def __hash__(self) -> int:
+            return hash(
+                (
+                    (
+                        tuple(sorted(self._custom_rules.items()))
+                        if self._custom_rules
+                        else None
+                    ),
+                    (
+                        tuple(sorted(self._properties.items()))
+                        if self._properties
+                        else None
+                    ),
+                    self._supported_object_types,
+                )
+            )
+
+        def __str__(self) -> str:
+            return (
+                f"CustomContent("
+                f"custom_rules={self._custom_rules}, "
+                f"properties={self._properties}, "
+                f"supported_object_types={set(self._supported_object_types)}"
+                f")"
+            )

--- a/clients/client-python/tests/unittests/policy/__init__.py
+++ b/clients/client-python/tests/unittests/policy/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/clients/client-python/tests/unittests/policy/test_policy.py
+++ b/clients/client-python/tests/unittests/policy/test_policy.py
@@ -1,0 +1,93 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import unittest
+from unittest.mock import Mock
+
+from gravitino.api.metadata_object import MetadataObject
+from gravitino.api.policy.policy import Policy
+from gravitino.api.policy.policy_contents import PolicyContents
+from gravitino.exceptions.base import IllegalArgumentException
+
+
+class TestPolicyBuiltInType(unittest.TestCase):
+    """Test cases for Policy.BuiltInType enum."""
+
+    def test_custom_type_properties(self):
+        """Test CUSTOM type properties."""
+        custom_type = Policy.BuiltInType.CUSTOM
+        self.assertEqual("custom", custom_type.policy_type())
+        self.assertEqual(PolicyContents.CustomContent, custom_type.content_class())
+
+    def test_from_policy_type_custom(self):
+        """Test from_policy_type with custom type."""
+        result = Policy.BuiltInType.from_policy_type("custom")
+        self.assertEqual(Policy.BuiltInType.CUSTOM, result)
+
+    def test_from_policy_type_unknown_builtin(self):
+        """Test from_policy_type with unknown built-in type."""
+        with self.assertRaisesRegex(
+            IllegalArgumentException, "Unknown built-in policy type"
+        ):
+            Policy.BuiltInType.from_policy_type("system_unknown")
+        with self.assertRaisesRegex(IllegalArgumentException, "Unknown policy type"):
+            Policy.BuiltInType.from_policy_type("invalid_type")
+
+    def test_from_policy_type_empty_string(self):
+        """Test from_policy_type with empty string."""
+        with self.assertRaisesRegex(
+            IllegalArgumentException, "policy_type cannot be blank"
+        ):
+            Policy.BuiltInType.from_policy_type("")
+        with self.assertRaisesRegex(
+            IllegalArgumentException, "policy_type cannot be blank"
+        ):
+            Policy.BuiltInType.from_policy_type(None)
+
+
+class TestAssociatedObjects(Policy.AssociatedObjects):
+    def __init__(self, objects_list):
+        self._objects = objects_list
+
+    def objects(self):
+        return self._objects
+
+
+class TestPolicyAssociatedObjects(unittest.TestCase):
+    """Test cases for Policy.AssociatedObjects class."""
+
+    def test_count_with_objects(self):
+        """Test count method with objects."""
+        mock_objects = [Mock(spec=MetadataObject), Mock(spec=MetadataObject)]
+        associated = TestAssociatedObjects(mock_objects)
+        self.assertEqual(2, associated.count())
+
+    def test_count_with_empty_list_and_none(self):
+        """Test count method with empty list."""
+        associated = TestAssociatedObjects([])
+        self.assertEqual(0, associated.count())
+
+        associated = TestAssociatedObjects(None)
+        self.assertEqual(0, associated.count())
+
+
+class TestPolicyConstants(unittest.TestCase):
+    """Test cases for Policy constants."""
+
+    def test_built_in_type_prefix(self):
+        """Test BUILT_IN_TYPE_PREFIX constant."""
+        self.assertEqual("system_", Policy.BUILT_IN_TYPE_PREFIX)

--- a/clients/client-python/tests/unittests/policy/test_policy_content.py
+++ b/clients/client-python/tests/unittests/policy/test_policy_content.py
@@ -1,0 +1,60 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+
+import unittest
+
+from gravitino.api.metadata_object import MetadataObject
+from gravitino.api.policy.policy_content import PolicyContent
+from gravitino.exceptions.base import IllegalArgumentException
+
+
+class MockPolicyContent(PolicyContent):
+    """Concrete implementation for testing."""
+
+    def __init__(self, object_types=None, props=None):
+        self._object_types = object_types or set()
+        self._props = props or {}
+
+    def supported_object_types(self) -> set[MetadataObject.Type]:
+        return self._object_types
+
+    def properties(self) -> dict[str, str]:
+        return self._props
+
+
+class TestPolicyContent(unittest.TestCase):
+    def test_supported_object_types(self):
+        object_types = {MetadataObject.Type.CATALOG, MetadataObject.Type.FILESET}
+        policy = MockPolicyContent(object_types=object_types)
+        self.assertSetEqual(policy.supported_object_types(), object_types)
+
+    def test_properties(self):
+        props = {"key1": "value1", "key2": "value2"}
+        policy = MockPolicyContent(props=props)
+        self.assertDictEqual(policy.properties(), props)
+
+    def test_validate_with_empty_object_types_raises_error(self):
+        policy = MockPolicyContent(object_types=set())
+        with self.assertRaisesRegex(
+            IllegalArgumentException, "supported_object_types cannot be empty"
+        ):
+            policy.validate()
+
+    def test_validate_with_non_empty_object_types_passes(self):
+        policy = MockPolicyContent(object_types={MetadataObject.Type.CATALOG})
+        policy.validate()

--- a/clients/client-python/tests/unittests/policy/test_policy_contents.py
+++ b/clients/client-python/tests/unittests/policy/test_policy_contents.py
@@ -1,0 +1,105 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import unittest
+
+from gravitino.api.metadata_object import MetadataObject
+from gravitino.api.policy.policy_contents import PolicyContents
+
+
+class TestPolicyContents(unittest.TestCase):
+    def test_custom_creates_custom_content(self):
+        rules = {"rule1": "value1"}
+        object_types = {MetadataObject.Type.CATALOG}
+        properties = {"prop1": "val1"}
+
+        content = PolicyContents.custom(rules, object_types, properties)
+
+        self.assertIsInstance(content, PolicyContents.CustomContent)
+        self.assertEqual(content.custom_rules(), rules)
+        self.assertEqual(content.supported_object_types(), object_types)
+        self.assertEqual(content.properties(), properties)
+
+    def test_custom_content_init_with_none_values(self):
+        content = PolicyContents.CustomContent()
+
+        self.assertIsNone(content.custom_rules())
+        self.assertSetEqual(content.supported_object_types(), set())
+        self.assertIsNone(content.properties())
+
+    def test_custom_content_init_with_values(self):
+        rules = {"rule1": "value1"}
+        object_types = {MetadataObject.Type.CATALOG, MetadataObject.Type.FILESET}
+        properties = {"prop1": "val1"}
+
+        content = PolicyContents.CustomContent(rules, object_types, properties)
+
+        self.assertEqual(content.custom_rules(), rules)
+        self.assertSetEqual(content.supported_object_types(), object_types)
+        self.assertEqual(content.properties(), properties)
+
+    def test_equality_same_objects(self):
+        rules = {"rule1": "value1"}
+        object_types = {MetadataObject.Type.CATALOG}
+        properties = {"prop1": "val1"}
+
+        content1 = PolicyContents.custom(rules, object_types, properties)
+        content2 = PolicyContents.custom(rules, object_types, properties)
+
+        self.assertEqual(content1, content2)
+
+    def test_equality_different_rules(self):
+        object_types = {MetadataObject.Type.CATALOG}
+        properties = {"prop1": "val1"}
+
+        content1 = PolicyContents.CustomContent(
+            {"rule1": "value1"}, object_types, properties
+        )
+        content2 = PolicyContents.CustomContent(
+            {"rule2": "value2"}, object_types, properties
+        )
+
+        self.assertNotEqual(content1, content2)
+
+    def test_equality_different_types(self):
+        content = PolicyContents.CustomContent()
+
+        self.assertNotEqual(content, "not a CustomContent")
+        self.assertNotEqual(content, None)
+
+    def test_hash_consistency(self):
+        rules = {"rule1": "value1"}
+        object_types = {MetadataObject.Type.CATALOG}
+        properties = {"prop1": "val1"}
+
+        content1 = PolicyContents.CustomContent(rules, object_types, properties)
+        content2 = PolicyContents.CustomContent(rules, object_types, properties)
+
+        self.assertEqual(hash(content1), hash(content2))
+
+    def test_str_representation(self):
+        rules = {"rule1": "value1"}
+        object_types = {MetadataObject.Type.CATALOG}
+        properties = {"prop1": "val1"}
+
+        content = PolicyContents.CustomContent(rules, object_types, properties)
+        str_repr = str(content)
+
+        self.assertIn("CustomContent", str_repr)
+        self.assertIn("custom_rules", str_repr)
+        self.assertIn("properties", str_repr)
+        self.assertIn("supported_object_types", str_repr)


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

This PR is aimed at implementing the following classes corresponding to the Java client.

- Policy.java
- PolicyContent.java
- PolicyContents.java

### Why are the changes needed?

We need to support python client for table operations.

#5198 

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Unit tests
