### PR TITLE
[MINOR] fix(release): dev/release/release-build.sh You need a space before the ]. shellcheckSC1020

### DIFF
--- a/dev/release/release-build.sh
+++ b/dev/release/release-build.sh
@@ -170,7 +170,7 @@ if [ -z "$GRAVITINO_VERSION" ]; then
   GRAVITINO_VERSION=$(cat gradle.properties | parse_version)
 fi
 
-if [ -z "$PYGRAVITINO_VERSION"]; then
+if [ -z "$PYGRAVITINO_VERSION" ]; then
   PYGRAVITINO_VERSION=$(cat clients/client-python/setup.py | grep "version=" | awk -F"\"" '{print $2}')
 fi
 


### PR DESCRIPTION


[Minor] dev/release/release-build.sh You need a space before the ].shellcheckSC1020

<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

<https://www.shellcheck.net/wiki/SC1020>

```bash
if [ -z "$PYGRAVITINO_VERSION"];
```

```bash
if [ -z "$PYGRAVITINO_VERSION" ];
```


You need a space before the ] or ]]
Problematic code:
```bash
if [ "$STUFF" = ""]; then
```
Correct code:
```bash
if [ "$STUFF" = "" ]; then
```
Rationale:

Bourne shells are very whitespace sensitive. Adding or removing spaces can drastically alter the meaning of a script. In these cases, ShellCheck has noticed that you're missing a space at the position indicated.



### Why are the changes needed?

Bourne shells are very whitespace sensitive. Adding or removing spaces can drastically alter the meaning of a script. In these cases, ShellCheck has noticed that you're missing a space at the position indicated.

Fix: #(issue)

### Does this PR introduce _any_ user-facing change?
### How was this patch tested?


