### PR TITLE
[#8202] fix(cli): Fix NPE in TableFormat.java when a user has no roles

### DIFF
--- a/clients/cli/src/main/java/org/apache/gravitino/cli/outputs/TableFormat.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/outputs/TableFormat.java
@@ -42,6 +42,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -845,7 +846,9 @@ public abstract class TableFormat<T> extends BaseOutputFormat<T> {
       Column columnRoles = new Column(context, "roles");
 
       columnName.addCell(user.name());
-      columnRoles.addCell(Command.COMMA_JOINER.join(user.roles()));
+
+      List<String> roleList = user.roles() == null ? new ArrayList<>() : user.roles();
+      columnRoles.addCell(Command.COMMA_JOINER.join(roleList));
 
       return getTableFormat(columnName, columnRoles);
     }

--- a/clients/cli/src/test/java/org/apache/gravitino/cli/output/TestTableFormat.java
+++ b/clients/cli/src/test/java/org/apache/gravitino/cli/output/TestTableFormat.java
@@ -950,4 +950,22 @@ public class TestTableFormat {
 
     Assertions.assertEquals(expected.trim(), outputString.trim());
   }
+
+  @Test
+  void testUserDetailsWithNullRoles() {
+    CommandContext mockContext = TestCliUtil.getMockContext();
+    User mockUser = mock(User.class);
+    when(mockUser.name()).thenReturn("user1");
+    when(mockUser.roles()).thenReturn(null);
+
+    TableFormat.output(mockUser, mockContext);
+    String output = new String(outContent.toByteArray(), StandardCharsets.UTF_8).trim();
+    Assertions.assertEquals(
+        "+-------+-------+\n"
+            + "| Name  | Roles |\n"
+            + "+-------+-------+\n"
+            + "| user1 |       |\n"
+            + "+-------+-------+",
+        output);
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Return a new ArrayList when user doesn't have any roles to prevent NPE.

### Why are the changes needed?

Prevent NPE when user doesn't have any roles.

Fix: #8202

### Does this PR introduce _any_ user-facing change?

No
### How was this patch tested?

Passed UT.