### PR TITLE
[#8677] fix(test): Fix IT `FilesetGCSCatalogIT` fails due to place-holder

### DIFF
--- a/catalogs/catalog-fileset/src/test/java/org/apache/gravitino/catalog/fileset/integration/test/FilesetCatalogIT.java
+++ b/catalogs/catalog-fileset/src/test/java/org/apache/gravitino/catalog/fileset/integration/test/FilesetCatalogIT.java
@@ -1300,7 +1300,8 @@ public class FilesetCatalogIT extends BaseIT {
       Path location = new Path(storageLocation);
       try {
         fileSystem.deleteOnExit(location);
-      } catch (IOException e) {
+        // Catch any exception to avoid test failure.
+      } catch (Exception e) {
         LOG.warn("Failed to delete location: {}", location, e);
       }
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix test error in `FilesetGCSCatalogIT`. The reason is that GCS path does not support the place-holder `{{}}`

### Why are the changes needed?

It's a bug.

Fix: #8677 

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

Test locally. 

<img width="1604" height="532" alt="image" src="https://github.com/user-attachments/assets/6ec67fe0-1f4c-4c39-80e2-46dd76c57d25" />
