### PR TITLE
[MINOR] docs: fix icla link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -234,7 +234,7 @@ Before contributing:
 
 Contributions are under the [Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0).
 
-If contributing on behalf of an employer or regularly, you may need to submit an [ICLA](https://www.apache.org/licenses/icla.html). See [ASF Contributor FAQs](https://www.apache.org/dev/new-committers-guide.html#cla).
+If contributing on behalf of an employer or regularly, you may need to submit an [ICLA](https://www.apache.org/licenses/#contributor-license-agreements). See [ASF Contributor FAQs](https://www.apache.org/dev/new-committers-guide.html#cla).
 
 Official repo: [https://github.com/apache/gravitino](https://github.com/apache/gravitino)
 


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Current link to ICLA in CONTRIBUTING.md shows 404 page
Current link with 404: [ICLA](https://www.apache.org/licenses/icla.html)
I found new ICLA link [here](https://infra.apache.org/new-committers-guide.html#submitting-your-individual-contributor-license-agreement-icla) and changed it to [new icla](https://www.apache.org/licenses/#contributor-license-agreements)

### Why are the changes needed?

Fix: docs in CONTRIBUTING

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

It's a documentation change and there are no new tests were added or done.
