### PR TITLE
[#8664] improvement(core): add missing space between the table name and column list in insertModelMetaOnDuplicateKeyUpdate query

### DIFF
--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/ModelMetaPostgreSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/ModelMetaPostgreSQLProvider.java
@@ -29,7 +29,7 @@ public class ModelMetaPostgreSQLProvider extends ModelMetaBaseSQLProvider {
   public String insertModelMetaOnDuplicateKeyUpdate(@Param("modelMeta") ModelPO modelPO) {
     return "INSERT INTO "
         + ModelMetaMapper.TABLE_NAME
-        + "(model_id, model_name, metalake_id, catalog_id, schema_id,"
+        + " (model_id, model_name, metalake_id, catalog_id, schema_id,"
         + " model_comment, model_properties, model_latest_version, audit_info, deleted_at)"
         + " VALUES (#{modelMeta.modelId}, #{modelMeta.modelName}, #{modelMeta.metalakeId},"
         + " #{modelMeta.catalogId}, #{modelMeta.schemaId}, #{modelMeta.modelComment},"


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fixed a missing space in the `insertModelMetaOnDuplicateKeyUpdate` query where the column list directly followed `TABLE_NAME` without whitespace.

### Why are the changes needed?

Fix: #8664

### Does this PR introduce _any_ user-facing change?

No user-facing changes.

### How was this patch tested?

Executed existing unit tests
