### PR TITLE
[Cherry-Pick][branch-1.0] [#8661] fix(server): Correct exception handling in setPolicy

### DIFF
--- a/server/src/main/java/org/apache/gravitino/server/web/rest/PolicyOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/PolicyOperations.java
@@ -208,11 +208,13 @@ public class PolicyOperations {
       PolicySetRequest request) {
     LOG.info("Received set policy request for policy: {} under metalake: {}", name, metalake);
 
+    OperationType op = request.isEnable() ? OperationType.ENABLE : OperationType.DISABLE;
+
     try {
       return Utils.doAs(
           httpRequest,
           () -> {
-            if (request.isEnable()) {
+            if (op == OperationType.ENABLE) {
               policyDispatcher.enablePolicy(metalake, name);
             } else {
               policyDispatcher.disablePolicy(metalake, name);
@@ -227,7 +229,7 @@ public class PolicyOperations {
             return response;
           });
     } catch (Exception e) {
-      return ExceptionHandlers.handlePolicyException(OperationType.ENABLE, name, metalake, e);
+      return ExceptionHandlers.handlePolicyException(op, name, metalake, e);
     }
   }
 

--- a/server/src/test/java/org/apache/gravitino/server/web/rest/TestPolicyOperations.java
+++ b/server/src/test/java/org/apache/gravitino/server/web/rest/TestPolicyOperations.java
@@ -514,6 +514,29 @@ public class TestPolicyOperations extends JerseyTest {
     Assertions.assertEquals(0, baseResponse1.getCode());
   }
 
+  // Test to check exception on failure in set policy is dynamic based on enable/disable
+  @Test
+  public void testSetPolicyDisableFailure() {
+    PolicySetRequest req = new PolicySetRequest(false);
+    doThrow(new RuntimeException("mock disable exception"))
+        .when(policyManager)
+        .disablePolicy(any(), any());
+    Response resp =
+        target(policyPath(metalake))
+            .path("policy1")
+            .property(HttpUrlConnectorProvider.SET_METHOD_WORKAROUND, true)
+            .request(MediaType.APPLICATION_JSON_TYPE)
+            .accept("application/vnd.gravitino.v1+json")
+            .method("PATCH", Entity.entity(req, MediaType.APPLICATION_JSON_TYPE));
+
+    Assertions.assertEquals(
+        Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), resp.getStatus());
+
+    ErrorResponse errorResp = resp.readEntity(ErrorResponse.class);
+    Assertions.assertEquals(ErrorConstants.INTERNAL_ERROR_CODE, errorResp.getCode());
+    Assertions.assertEquals(RuntimeException.class.getSimpleName(), errorResp.getType());
+  }
+
   @Test
   public void testDeletePolicy() {
     when(policyManager.deletePolicy(metalake, "policy1")).thenReturn(true);


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR cherry-picks the fix from the merged pull request #8681 onto the `branch-1.0` maintenance branch.

### Why are the changes needed?

To apply the important bug fix for `setPolicy` exception handling to the stable `1.0` release branch, ensuring users of that version also benefit from the correction.

Fix: #8661

### Does this PR introduce _any_ user-facing change?

Yes. The error response returned to an API user when a `disable` policy operation fails is now correctly identified. This aligns the behavior of `branch-1.0` with the `main` branch for this scenario.

### How was this patch tested?

- The original change was fully tested with a new unit test in pull request #8681.
- Verified that the commit cherry-picks cleanly onto `branch-1.0`.
- All existing tests in the `:server` module were run against this branch and continue to pass.