### PR TITLE
fix SetFilesetProperty output to show fileset name (not schema)

### DIFF
--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/SetFilesetProperty.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/SetFilesetProperty.java
@@ -93,7 +93,7 @@ public class SetFilesetProperty extends Command {
       exitWithError(exp.getMessage());
     }
 
-    printInformation(schema + " property set.");
+    printInformation(fileset + " property set.");
   }
 
   @Override


### PR DESCRIPTION
Fix CLI SetFilesetProperty output to display the fileset name instead of the schema name.  
Ensures the confirmation message correctly reflects the resource being updated.
