### PR TITLE
[#8697] improvement(core): Adjust weight value for entities with type `metalake` and `catalog` in Caffeine cache weighter.

### DIFF
--- a/core/src/main/java/org/apache/gravitino/cache/EntityCacheWeigher.java
+++ b/core/src/main/java/org/apache/gravitino/cache/EntityCacheWeigher.java
@@ -43,10 +43,10 @@ import org.slf4j.LoggerFactory;
  * </ul>
  */
 public class EntityCacheWeigher implements Weigher<EntityCacheKey, List<Entity>> {
-  public static final int METALAKE_WEIGHT = 100;
-  public static final int CATALOG_WEIGHT = 75;
-  public static final int SCHEMA_WEIGHT = 50;
-  public static final int OTHER_WEIGHT = 15;
+  public static final int METALAKE_WEIGHT = 0;
+  public static final int CATALOG_WEIGHT = 0;
+  public static final int SCHEMA_WEIGHT = 10;
+  public static final int OTHER_WEIGHT = 100;
   private static final Logger LOG = LoggerFactory.getLogger(EntityCacheWeigher.class.getName());
   private static final EntityCacheWeigher INSTANCE = new EntityCacheWeigher();
   private static final Map<Entity.EntityType, Integer> ENTITY_WEIGHTS =
@@ -54,7 +54,7 @@ public class EntityCacheWeigher implements Weigher<EntityCacheKey, List<Entity>>
           Entity.EntityType.METALAKE, METALAKE_WEIGHT,
           Entity.EntityType.CATALOG, CATALOG_WEIGHT,
           Entity.EntityType.SCHEMA, SCHEMA_WEIGHT);
-  private static long MAX_WEIGHT =
+  private static final long MAX_WEIGHT =
       2 * (METALAKE_WEIGHT * 10 + CATALOG_WEIGHT * (10 * 200) + SCHEMA_WEIGHT * (10 * 200 * 1000));
 
   @VisibleForTesting

--- a/core/src/main/java/org/apache/gravitino/cache/EntityCacheWeigher.java
+++ b/core/src/main/java/org/apache/gravitino/cache/EntityCacheWeigher.java
@@ -36,10 +36,12 @@ import org.slf4j.LoggerFactory;
  * weight is calculated as follows:
  *
  * <ul>
- *   <li>Metalake: 100
- *   <li>Catalog: 75
- *   <li>Schema: 50
- *   <li>Other: 15
+ *   <li>Metalake: 0, which means that it will never be evicted from the cache unless timeout occurs
+ *       or manually cleared.
+ *   <li>Catalog: 0, which means that it will never be evicted from the cache unless timeout occurs
+ *       or manually cleared.
+ *   <li>Schema: 10
+ *   <li>Other: 100
  * </ul>
  */
 public class EntityCacheWeigher implements Weigher<EntityCacheKey, List<Entity>> {

--- a/core/src/test/java/org/apache/gravitino/cache/TestCacheConfig.java
+++ b/core/src/test/java/org/apache/gravitino/cache/TestCacheConfig.java
@@ -21,6 +21,7 @@ package org.apache.gravitino.cache;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
+import java.time.Duration;
 import java.util.List;
 import org.apache.gravitino.Catalog;
 import org.apache.gravitino.Config;
@@ -33,6 +34,7 @@ import org.apache.gravitino.meta.BaseMetalake;
 import org.apache.gravitino.meta.CatalogEntity;
 import org.apache.gravitino.meta.SchemaEntity;
 import org.apache.gravitino.meta.SchemaVersion;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -120,7 +122,10 @@ public class TestCacheConfig {
     }
 
     // Only some of the 100 schemas are still in the cache, to be exact, 500 / 10 = 50 schemas.
-    Assertions.assertEquals(10 + 3 + 500 / 10, cache.asMap().size());
+    Awaitility.await()
+        .atMost(Duration.ofSeconds(5))
+        .pollInterval(Duration.ofMillis(10))
+        .until(() -> cache.asMap().size() == 10 + 3 + 500 / 10);
   }
 
   @Test

--- a/core/src/test/java/org/apache/gravitino/cache/TestCacheConfig.java
+++ b/core/src/test/java/org/apache/gravitino/cache/TestCacheConfig.java
@@ -103,13 +103,15 @@ public class TestCacheConfig {
           List.of(schemaEntity));
     }
 
-    Thread.sleep(100);
+    // Three 3 metalakes still in cache.
+    for (int i = 0; i < 3; i++) {
+      Assertions.assertNotNull(
+          cache.getIfPresent(
+              EntityCacheRelationKey.of(
+                  NameIdentifier.of("metalake" + 1), Entity.EntityType.METALAKE)));
+    }
 
-    // be evicted
-    Assertions.assertNotNull(
-        cache.getIfPresent(
-            EntityCacheRelationKey.of(NameIdentifier.of("metalake1"), Entity.EntityType.METALAKE)));
-
+    // 10 catalogs still in cache.
     for (int i = 0; i < 10; i++) {
       Assertions.assertNotNull(
           cache.getIfPresent(
@@ -117,6 +119,7 @@ public class TestCacheConfig {
                   NameIdentifier.of("metalake1.catalog" + i), Entity.EntityType.CATALOG)));
     }
 
+    // Only some of the 100 schemas are still in the cache, to be exact, 500 / 10 = 50 schemas.
     Assertions.assertEquals(10 + 3 + 500 / 10, cache.asMap().size());
   }
 

--- a/core/src/test/java/org/apache/gravitino/cache/TestCacheConfig.java
+++ b/core/src/test/java/org/apache/gravitino/cache/TestCacheConfig.java
@@ -117,7 +117,7 @@ public class TestCacheConfig {
                   NameIdentifier.of("metalake1.catalog" + i), Entity.EntityType.CATALOG)));
     }
 
-    Assertions.assertTrue(cache.asMap().size() == 10 + 3 + 500 / 10);
+    Assertions.assertEquals(10 + 3 + 500 / 10, cache.asMap().size());
   }
 
   @Test

--- a/core/src/test/java/org/apache/gravitino/cache/TestCacheConfig.java
+++ b/core/src/test/java/org/apache/gravitino/cache/TestCacheConfig.java
@@ -45,7 +45,7 @@ public class TestCacheConfig {
     Assertions.assertTrue(config.get(Configs.CACHE_WEIGHER_ENABLED));
     Assertions.assertEquals(10_000, config.get(Configs.CACHE_MAX_ENTRIES));
     Assertions.assertEquals(3_600_000L, config.get(Configs.CACHE_EXPIRATION_TIME));
-    Assertions.assertEquals(200_302_000L, EntityCacheWeigher.getMaxWeight());
+    Assertions.assertEquals(40_000_000L, EntityCacheWeigher.getMaxWeight());
     Assertions.assertEquals("caffeine", config.get(Configs.CACHE_IMPLEMENTATION));
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Adjust the weight value for the entity `metalake` and `catalog` to prevent it from being evicted easily.  Entities with a higher weight value are more likely to be evicted, so we need to make it smaller for entities with types `metalake` and `catalog`.

### Why are the changes needed?

Metalakes and catalogs are frequently accessed entities that can always keep them in memory.

Fix: #8697

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

UTs
