### PR TITLE
[#8655] fix(api): Add null check for comparator in PartitionRange

### DIFF
--- a/api/src/main/java/org/apache/gravitino/stats/PartitionRange.java
+++ b/api/src/main/java/org/apache/gravitino/stats/PartitionRange.java
@@ -64,6 +64,7 @@ public class PartitionRange {
     Preconditions.checkArgument(upperBoundType != null, "Upper bound type cannot be null");
     Preconditions.checkArgument(
         !upperPartitionName.isEmpty(), "Upper partition name cannot be empty");
+    Preconditions.checkArgument(comparator != null, "Comparator cannot be null");
     PartitionRange partitionRange = new PartitionRange();
     partitionRange.upperPartitionName = Optional.of(upperPartitionName);
     partitionRange.upperBoundType = Optional.of(upperBoundType);

--- a/api/src/test/java/org/apache/gravitino/stats/TestPartitionRange.java
+++ b/api/src/test/java/org/apache/gravitino/stats/TestPartitionRange.java
@@ -88,4 +88,11 @@ public class TestPartitionRange {
     Assertions.assertEquals(PartitionRange.BoundType.CLOSED, range6.lowerBoundType().get());
     Assertions.assertEquals(PartitionRange.BoundType.OPEN, range6.upperBoundType().get());
   }
+
+  @Test
+  public void testUpToWithNullComparator() {
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> PartitionRange.upTo("upper", PartitionRange.BoundType.CLOSED, null));
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds a `Preconditions.checkArgument` to the `upTo(String, BoundType, SortOrder)` method in `PartitionRange.java` to ensure the `comparator` argument is not null.

### Why are the changes needed?

The `upTo` method was missing a null check for its `comparator` argument. This was inconsistent with the other factory methods (`downTo`, `between`) in the same class. Without this check, passing a `null` comparator could lead to a `NullPointerException` later in the execution path, making it harder to debug. This change ensures the method fails early with a clear error message.

Fix: #8655

### Does this PR introduce _any_ user-facing change?

Yes. Calling `PartitionRange.upTo(...)` with a `null` comparator will now immediately throw an `IllegalArgumentException`, which is the intended and consistent behavior for the class.

### How was this patch tested?

- Added a new unit test, `testUpToWithNullComparator`, to `TestPartitionRange.java` as suggested in the issue description.
- The test verifies that calling `PartitionRange.upTo` with a null comparator correctly throws an `IllegalArgumentException`.
- All other existing tests in the `:api` module were run and continue to pass.