### PR TITLE
Fix concurrency issue in AuthorizationRequestContext.loadRole

### DIFF
--- a/core/src/main/java/org/apache/gravitino/authorization/AuthorizationRequestContext.java
+++ b/core/src/main/java/org/apache/gravitino/authorization/AuthorizationRequestContext.java
@@ -21,11 +21,11 @@ import java.security.Principal;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Function;
-import java.util.concurrent.FutureTask;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
 import org.apache.gravitino.MetadataObject;
 
 public class AuthorizationRequestContext {
@@ -86,10 +86,12 @@ public class AuthorizationRequestContext {
     if (hasLoadRole.get()) {
       return;
     }
-    FutureTask<Void> task = new FutureTask<>(() -> {
-      runnable.run();
-      return null;
-    });
+    FutureTask<Void> task =
+        new FutureTask<>(
+            () -> {
+              runnable.run();
+              return null;
+            });
     if (loadRoleTask.compareAndSet(null, task)) {
       task.run();
       hasLoadRole.set(true);

--- a/core/src/test/java/org/apache/gravitino/authorization/TestAuthorizationRequestContext.java
+++ b/core/src/test/java/org/apache/gravitino/authorization/TestAuthorizationRequestContext.java
@@ -1,0 +1,49 @@
+package org.apache.gravitino.authorization;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+public class TestAuthorizationRequestContext {
+
+  @Test
+  public void testLoadRoleRunsOnlyOnce() throws InterruptedException {
+    AuthorizationRequestContext context = new AuthorizationRequestContext();
+    AtomicInteger counter = new AtomicInteger(0);
+
+    Runnable init = counter::incrementAndGet;
+
+    int threadCount = 10;
+    ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+
+    CountDownLatch ready = new CountDownLatch(threadCount);
+    CountDownLatch start = new CountDownLatch(1);
+
+    for (int i = 0; i < threadCount; i++) {
+      executor.submit(
+          () -> {
+            try {
+              ready.countDown();
+              start.await();
+              context.loadRole(init);
+            } catch (InterruptedException e) {
+              Thread.currentThread().interrupt();
+            }
+          });
+    }
+
+    ready.await();
+    start.countDown();
+
+    executor.shutdown();
+    executor.awaitTermination(5, TimeUnit.SECONDS);
+
+    assertEquals(
+        1, counter.get(), "Initializer should run exactly once, even with concurrent calls");
+  }
+}


### PR DESCRIPTION
This PR resolves a race condition in AuthorizationRequestContext.loadRole, where multiple threads could execute the role initializer concurrently.
The fix introduces a FutureTask guarded by an AtomicReference, ensuring the initializer runs exactly once, even under concurrent access.

A focused unit test (TestAuthorizationRequestContext) is added to verify that loadRole executes the initializer only once when called from multiple threads.