### PR TITLE
[#8640] feat(server): Add server-side REST interface for job template alteration

### DIFF
--- a/api/src/main/java/org/apache/gravitino/job/JobTemplateChange.java
+++ b/api/src/main/java/org/apache/gravitino/job/JobTemplateChange.java
@@ -1,0 +1,701 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.job;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * The interface for job template changes. A job template change is an operation that modifies a job
+ * template. It can be one of the following:
+ *
+ * <ul>
+ *   <li>Rename the job template.
+ *   <li>Update the comment of the job template.
+ *   <li>Update the job template details, such as executable, arguments, environments, custom
+ *       fields, etc.
+ * </ul>
+ */
+public interface JobTemplateChange {
+
+  /**
+   * Creates a new job template change to update the name of the job template.
+   *
+   * @param newName The new name of the job template.
+   * @return The job template change.
+   */
+  static JobTemplateChange rename(String newName) {
+    return new RenameJobTemplate(newName);
+  }
+
+  /**
+   * Creates a new job template change to update the comment of the job template.
+   *
+   * @param newComment The new comment of the job template.
+   * @return The job template change.
+   */
+  static JobTemplateChange updateComment(String newComment) {
+    return new UpdateJobTemplateComment(newComment);
+  }
+
+  /**
+   * Creates a new job template change to update the details of the job template.
+   *
+   * @param templateUpdate The job template update details.
+   * @return The job template change.
+   */
+  static JobTemplateChange updateTemplate(TemplateUpdate templateUpdate) {
+    return new UpdateJobTemplate(templateUpdate);
+  }
+
+  /** A job template change to rename the job template. */
+  final class RenameJobTemplate implements JobTemplateChange {
+    private final String newName;
+
+    private RenameJobTemplate(String newName) {
+      this.newName = newName;
+    }
+
+    /**
+     * Get the new name of the job template.
+     *
+     * @return The new name of the job template.
+     */
+    public String getNewName() {
+      return newName;
+    }
+
+    /**
+     * Checks if this RenameJobTemplate is equal to another object.
+     *
+     * @param o The object to compare with.
+     * @return true if the objects are equal, false otherwise.
+     */
+    @Override
+    public boolean equals(Object o) {
+      if (o == null || getClass() != o.getClass()) return false;
+      RenameJobTemplate that = (RenameJobTemplate) o;
+      return Objects.equals(newName, that.newName);
+    }
+
+    /**
+     * Generates a hash code for this RenameJobTemplate.
+     *
+     * @return The hash code.
+     */
+    @Override
+    public int hashCode() {
+      return Objects.hash(newName);
+    }
+
+    /**
+     * Get the string representation of the job template change.
+     *
+     * @return The string representation of the job template change.
+     */
+    @Override
+    public String toString() {
+      return "RENAME JOB TEMPLATE " + newName;
+    }
+  }
+
+  /** A job template change to update the comment of the job template. */
+  final class UpdateJobTemplateComment implements JobTemplateChange {
+    private final String newComment;
+
+    private UpdateJobTemplateComment(String newComment) {
+      this.newComment = newComment;
+    }
+
+    /**
+     * Get the new comment of the job template.
+     *
+     * @return The new comment of the job template.
+     */
+    public String getNewComment() {
+      return newComment;
+    }
+
+    /**
+     * Checks if this UpdateJobTemplateComment is equal to another object.
+     *
+     * @param o The object to compare with.
+     * @return true if the objects are equal, false otherwise.
+     */
+    @Override
+    public boolean equals(Object o) {
+      if (o == null || getClass() != o.getClass()) return false;
+      UpdateJobTemplateComment that = (UpdateJobTemplateComment) o;
+      return Objects.equals(newComment, that.newComment);
+    }
+
+    /**
+     * Generates a hash code for this UpdateJobTemplateComment.
+     *
+     * @return The hash code.
+     */
+    @Override
+    public int hashCode() {
+      return Objects.hashCode(newComment);
+    }
+
+    /**
+     * Get the string representation of the job template change.
+     *
+     * @return The string representation of the job template change.
+     */
+    @Override
+    public String toString() {
+      return "UPDATE JOB TEMPLATE COMMENT " + newComment;
+    }
+  }
+
+  /** A job template change to update the details of the job template. */
+  final class UpdateJobTemplate implements JobTemplateChange {
+
+    private final TemplateUpdate templateUpdate;
+
+    private UpdateJobTemplate(TemplateUpdate templateUpdate) {
+      this.templateUpdate = templateUpdate;
+    }
+
+    /**
+     * Get the template update.
+     *
+     * @return The template update.
+     */
+    public TemplateUpdate getTemplateUpdate() {
+      return templateUpdate;
+    }
+
+    /**
+     * Checks if this UpdateTemplate is equal to another object.
+     *
+     * @param o The object to compare with.
+     * @return true if the objects are equal, false otherwise.
+     */
+    @Override
+    public boolean equals(Object o) {
+      if (o == null || getClass() != o.getClass()) return false;
+      UpdateJobTemplate that = (UpdateJobTemplate) o;
+      return Objects.equals(templateUpdate, that.templateUpdate);
+    }
+
+    /**
+     * Generates a hash code for this UpdateJobTemplate.
+     *
+     * @return The hash code.
+     */
+    @Override
+    public int hashCode() {
+      return Objects.hashCode(templateUpdate);
+    }
+
+    /**
+     * Get the string representation of the job template change.
+     *
+     * @return The string representation of the job template change.
+     */
+    @Override
+    public String toString() {
+      return "UPDATE JOB TEMPLATE " + templateUpdate.getClass().getSimpleName();
+    }
+  }
+
+  /** Base class for template updates. */
+  abstract class TemplateUpdate {
+
+    private final String newExecutable;
+
+    private final List<String> newArguments;
+
+    private final Map<String, String> newEnvironments;
+
+    private final Map<String, String> newCustomFields;
+
+    /**
+     * Constructor for TemplateUpdate.
+     *
+     * @param builder The builder to construct the TemplateUpdate.
+     */
+    protected TemplateUpdate(BaseBuilder<?, ?> builder) {
+      this.newExecutable = builder.newExecutable;
+      this.newArguments = builder.newArguments;
+      this.newEnvironments = builder.newEnvironments;
+      this.newCustomFields = builder.newCustomFields;
+    }
+
+    /**
+     * Get the new executable of the job template.
+     *
+     * @return The new executable of the job template.
+     */
+    public String getNewExecutable() {
+      return newExecutable;
+    }
+
+    /**
+     * Get the new arguments of the job template.
+     *
+     * @return The new arguments of the job template.
+     */
+    public List<String> getNewArguments() {
+      return newArguments;
+    }
+
+    /**
+     * Get the new environments of the job template.
+     *
+     * @return The new environments of the job template.
+     */
+    public Map<String, String> getNewEnvironments() {
+      return newEnvironments;
+    }
+
+    /**
+     * Get the new custom fields of the job template.
+     *
+     * @return The new custom fields of the job template.
+     */
+    public Map<String, String> getNewCustomFields() {
+      return newCustomFields;
+    }
+
+    /**
+     * Checks if this TemplateUpdate is equal to another object.
+     *
+     * @param o The object to compare with.
+     * @return true if the objects are equal, false otherwise.
+     */
+    @Override
+    public boolean equals(Object o) {
+      if (!(o instanceof TemplateUpdate)) return false;
+
+      TemplateUpdate that = (TemplateUpdate) o;
+      return Objects.equals(newExecutable, that.newExecutable)
+          && Objects.equals(newArguments, that.newArguments)
+          && Objects.equals(newEnvironments, that.newEnvironments)
+          && Objects.equals(newCustomFields, that.newCustomFields);
+    }
+
+    /**
+     * Generates a hash code for this TemplateUpdate.
+     *
+     * @return The hash code.
+     */
+    @Override
+    public int hashCode() {
+      return Objects.hash(newExecutable, newArguments, newEnvironments, newCustomFields);
+    }
+
+    /** Base builder class for constructing TemplateUpdate instances. */
+    protected abstract static class BaseBuilder<
+        B extends BaseBuilder<B, P>, P extends TemplateUpdate> {
+      private String newExecutable;
+      private List<String> newArguments;
+      private Map<String, String> newEnvironments;
+      private Map<String, String> newCustomFields;
+
+      /** Protected constructor to prevent direct instantiation. */
+      protected BaseBuilder() {}
+
+      /**
+       * Returns the builder instance itself for method chaining.
+       *
+       * @return The builder instance.
+       */
+      protected abstract B self();
+
+      /**
+       * Builds the TemplateUpdate instance.
+       *
+       * @return A new TemplateUpdate instance.
+       */
+      public abstract P build();
+
+      /**
+       * Sets the new executable for the job template.
+       *
+       * @param newExecutable The new executable to set.
+       * @return The builder instance for chaining.
+       */
+      public B withNewExecutable(String newExecutable) {
+        this.newExecutable = newExecutable;
+        return self();
+      }
+
+      /**
+       * Sets the new arguments for the job template.
+       *
+       * @param newArguments The new arguments to set.
+       * @return The builder instance for chaining.
+       */
+      public B withNewArguments(List<String> newArguments) {
+        this.newArguments = newArguments;
+        return self();
+      }
+
+      /**
+       * Sets the new environments for the job template.
+       *
+       * @param newEnvironments The new environments to set.
+       * @return The builder instance for chaining.
+       */
+      public B withNewEnvironments(Map<String, String> newEnvironments) {
+        this.newEnvironments = newEnvironments;
+        return self();
+      }
+
+      /**
+       * Sets the new custom fields for the job template.
+       *
+       * @param newCustomFields The new custom fields to set.
+       * @return The builder instance for chaining.
+       */
+      public B withNewCustomFields(Map<String, String> newCustomFields) {
+        this.newCustomFields = newCustomFields;
+        return self();
+      }
+
+      /** Validates the builder fields before building the TemplateUpdate instance. */
+      protected void validate() {
+        Preconditions.checkArgument(
+            StringUtils.isNoneBlank(newExecutable), "Executable cannot be null or blank");
+        this.newArguments =
+            newArguments == null ? Collections.emptyList() : ImmutableList.copyOf(newArguments);
+        this.newEnvironments =
+            newEnvironments == null ? Collections.emptyMap() : ImmutableMap.copyOf(newEnvironments);
+        this.newCustomFields =
+            newCustomFields == null ? Collections.emptyMap() : ImmutableMap.copyOf(newCustomFields);
+      }
+    }
+  }
+
+  /** A job template update for shell templates. */
+  final class ShellTemplateUpdate extends TemplateUpdate {
+
+    private final List<String> newScripts;
+
+    private ShellTemplateUpdate(Builder builder) {
+      super(builder);
+      this.newScripts = builder.newScripts;
+    }
+
+    /**
+     * Get the new scripts of the shell job template.
+     *
+     * @return The new scripts of the shell job template.
+     */
+    public List<String> getNewScripts() {
+      return newScripts;
+    }
+
+    /**
+     * Checks if this ShellTemplateUpdate is equal to another object.
+     *
+     * @param o The object to compare with.
+     * @return true if the objects are equal, false otherwise.
+     */
+    @Override
+    public boolean equals(Object o) {
+      if (o == null || getClass() != o.getClass()) return false;
+      if (!super.equals(o)) return false;
+      ShellTemplateUpdate that = (ShellTemplateUpdate) o;
+      return Objects.equals(newScripts, that.newScripts);
+    }
+
+    /**
+     * Generates a hash code for this ShellTemplateUpdate.
+     *
+     * @return The hash code.
+     */
+    @Override
+    public int hashCode() {
+      return Objects.hash(super.hashCode(), newScripts);
+    }
+
+    /**
+     * Creates a new builder for ShellTemplateUpdate.
+     *
+     * @return A new Builder instance.
+     */
+    public static Builder builder() {
+      return new Builder();
+    }
+
+    /** Builder class for constructing ShellTemplateUpdate instances. */
+    public static class Builder extends BaseBuilder<Builder, ShellTemplateUpdate> {
+
+      private List<String> newScripts;
+
+      private Builder() {}
+
+      /**
+       * Sets the new scripts for the shell job template.
+       *
+       * @param newScripts The new scripts to set.
+       * @return The builder instance for chaining.
+       */
+      public Builder withNewScripts(List<String> newScripts) {
+        this.newScripts = newScripts;
+        return this;
+      }
+
+      /**
+       * Builds the ShellTemplateUpdate instance.
+       *
+       * @return A new ShellTemplateUpdate instance.
+       */
+      @Override
+      public ShellTemplateUpdate build() {
+        validate();
+        return new ShellTemplateUpdate(this);
+      }
+
+      /**
+       * Returns the builder instance itself for method chaining.
+       *
+       * @return The builder instance.
+       */
+      @Override
+      protected Builder self() {
+        return this;
+      }
+
+      /** Validates the builder fields before building the ShellTemplateUpdate instance. */
+      @Override
+      protected void validate() {
+        super.validate();
+        this.newScripts =
+            newScripts == null ? Collections.emptyList() : ImmutableList.copyOf(newScripts);
+      }
+    }
+  }
+
+  /** A job template update for spark templates. */
+  final class SparkTemplateUpdate extends TemplateUpdate {
+
+    private final String newClassName;
+
+    private final List<String> newJars;
+
+    private final List<String> newFiles;
+
+    private final List<String> newArchives;
+
+    private final Map<String, String> newConfigs;
+
+    private SparkTemplateUpdate(Builder builder) {
+      super(builder);
+      this.newClassName = builder.newClassName;
+      this.newJars = builder.newJars;
+      this.newFiles = builder.newFiles;
+      this.newArchives = builder.newArchives;
+      this.newConfigs = builder.newConfigs;
+    }
+
+    /**
+     * Get the new class name of the spark job template.
+     *
+     * @return The new class name of the spark job template.
+     */
+    public String getNewClassName() {
+      return newClassName;
+    }
+
+    /**
+     * Get the new jars of the spark job template.
+     *
+     * @return The new jars of the spark job template.
+     */
+    public List<String> getNewJars() {
+      return newJars;
+    }
+
+    /**
+     * Get the new files of the spark job template.
+     *
+     * @return The new files of the spark job template.
+     */
+    public List<String> getNewFiles() {
+      return newFiles;
+    }
+
+    /**
+     * Get the new archives of the spark job template.
+     *
+     * @return The new archives of the spark job template.
+     */
+    public List<String> getNewArchives() {
+      return newArchives;
+    }
+
+    /**
+     * Get the new configs of the spark job template.
+     *
+     * @return The new configs of the spark job template.
+     */
+    public Map<String, String> getNewConfigs() {
+      return newConfigs;
+    }
+
+    /**
+     * Checks if this SparkTemplateUpdate is equal to another object.
+     *
+     * @param o The object to compare with.
+     * @return true if the objects are equal, false otherwise.
+     */
+    @Override
+    public boolean equals(Object o) {
+      if (o == null || getClass() != o.getClass()) return false;
+      if (!super.equals(o)) return false;
+      SparkTemplateUpdate that = (SparkTemplateUpdate) o;
+      return Objects.equals(newClassName, that.newClassName)
+          && Objects.equals(newJars, that.newJars)
+          && Objects.equals(newFiles, that.newFiles)
+          && Objects.equals(newArchives, that.newArchives)
+          && Objects.equals(newConfigs, that.newConfigs);
+    }
+
+    /**
+     * Generates a hash code for this SparkTemplateUpdate.
+     *
+     * @return The hash code.
+     */
+    @Override
+    public int hashCode() {
+      return Objects.hash(
+          super.hashCode(), newClassName, newJars, newFiles, newArchives, newConfigs);
+    }
+
+    /**
+     * Creates a new builder for SparkTemplateUpdate.
+     *
+     * @return A new Builder instance.
+     */
+    public static Builder builder() {
+      return new Builder();
+    }
+
+    /** Builder class for constructing SparkTemplateUpdate instances. */
+    public static class Builder extends BaseBuilder<Builder, SparkTemplateUpdate> {
+      private String newClassName;
+      private List<String> newJars;
+      private List<String> newFiles;
+      private List<String> newArchives;
+      private Map<String, String> newConfigs;
+
+      private Builder() {}
+
+      /**
+       * Sets the new class name for the spark job template.
+       *
+       * @param newClassName The new class name to set.
+       * @return The builder instance for chaining.
+       */
+      public Builder withNewClassName(String newClassName) {
+        this.newClassName = newClassName;
+        return this;
+      }
+
+      /**
+       * Sets the new jars for the spark job template.
+       *
+       * @param newJars The new jars to set.
+       * @return The builder instance for chaining.
+       */
+      public Builder withNewJars(List<String> newJars) {
+        this.newJars = newJars;
+        return this;
+      }
+
+      /**
+       * Sets the new files for the spark job template.
+       *
+       * @param newFiles The new files to set.
+       * @return The builder instance for chaining.
+       */
+      public Builder withNewFiles(List<String> newFiles) {
+        this.newFiles = newFiles;
+        return this;
+      }
+
+      /**
+       * Sets the new archives for the spark job template.
+       *
+       * @param newArchives The new archives to set.
+       * @return The builder instance for chaining.
+       */
+      public Builder withNewArchives(List<String> newArchives) {
+        this.newArchives = newArchives;
+        return this;
+      }
+
+      /**
+       * Sets the new configs for the spark job template.
+       *
+       * @param newConfigs The new configs to set.
+       * @return The builder instance for chaining.
+       */
+      public Builder withNewConfigs(Map<String, String> newConfigs) {
+        this.newConfigs = newConfigs;
+        return this;
+      }
+
+      /**
+       * Builds the SparkTemplateUpdate instance.
+       *
+       * @return A new SparkTemplateUpdate instance.
+       */
+      @Override
+      public SparkTemplateUpdate build() {
+        validate();
+        return new SparkTemplateUpdate(this);
+      }
+
+      /**
+       * Returns the builder instance itself for method chaining.
+       *
+       * @return The builder instance.
+       */
+      @Override
+      protected Builder self() {
+        return this;
+      }
+
+      /** Validates the builder fields before building the SparkTemplateUpdate instance. */
+      @Override
+      protected void validate() {
+        super.validate();
+        this.newJars = newJars == null ? Collections.emptyList() : ImmutableList.copyOf(newJars);
+        this.newFiles = newFiles == null ? Collections.emptyList() : ImmutableList.copyOf(newFiles);
+        this.newArchives =
+            newArchives == null ? Collections.emptyList() : ImmutableList.copyOf(newArchives);
+        this.newConfigs =
+            newConfigs == null ? Collections.emptyMap() : ImmutableMap.copyOf(newConfigs);
+      }
+    }
+  }
+}

--- a/api/src/main/java/org/apache/gravitino/job/JobTemplateChange.java
+++ b/api/src/main/java/org/apache/gravitino/job/JobTemplateChange.java
@@ -18,14 +18,9 @@
  */
 package org.apache.gravitino.job;
 
-import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import org.apache.commons.lang3.StringUtils;
 
 /**
  * The interface for job template changes. A job template change is an operation that modifies a job
@@ -378,18 +373,6 @@ public interface JobTemplateChange {
         this.newCustomFields = newCustomFields;
         return self();
       }
-
-      /** Validates the builder fields before building the TemplateUpdate instance. */
-      protected void validate() {
-        Preconditions.checkArgument(
-            StringUtils.isNoneBlank(newExecutable), "Executable cannot be null or blank");
-        this.newArguments =
-            newArguments == null ? Collections.emptyList() : ImmutableList.copyOf(newArguments);
-        this.newEnvironments =
-            newEnvironments == null ? Collections.emptyMap() : ImmutableMap.copyOf(newEnvironments);
-        this.newCustomFields =
-            newCustomFields == null ? Collections.emptyMap() : ImmutableMap.copyOf(newCustomFields);
-      }
     }
   }
 
@@ -470,7 +453,6 @@ public interface JobTemplateChange {
        */
       @Override
       public ShellTemplateUpdate build() {
-        validate();
         return new ShellTemplateUpdate(this);
       }
 
@@ -482,14 +464,6 @@ public interface JobTemplateChange {
       @Override
       protected Builder self() {
         return this;
-      }
-
-      /** Validates the builder fields before building the ShellTemplateUpdate instance. */
-      @Override
-      protected void validate() {
-        super.validate();
-        this.newScripts =
-            newScripts == null ? Collections.emptyList() : ImmutableList.copyOf(newScripts);
       }
     }
   }
@@ -671,7 +645,6 @@ public interface JobTemplateChange {
        */
       @Override
       public SparkTemplateUpdate build() {
-        validate();
         return new SparkTemplateUpdate(this);
       }
 
@@ -683,18 +656,6 @@ public interface JobTemplateChange {
       @Override
       protected Builder self() {
         return this;
-      }
-
-      /** Validates the builder fields before building the SparkTemplateUpdate instance. */
-      @Override
-      protected void validate() {
-        super.validate();
-        this.newJars = newJars == null ? Collections.emptyList() : ImmutableList.copyOf(newJars);
-        this.newFiles = newFiles == null ? Collections.emptyList() : ImmutableList.copyOf(newFiles);
-        this.newArchives =
-            newArchives == null ? Collections.emptyList() : ImmutableList.copyOf(newArchives);
-        this.newConfigs =
-            newConfigs == null ? Collections.emptyMap() : ImmutableMap.copyOf(newConfigs);
       }
     }
   }

--- a/api/src/main/java/org/apache/gravitino/job/SupportsJobs.java
+++ b/api/src/main/java/org/apache/gravitino/job/SupportsJobs.java
@@ -73,6 +73,21 @@ public interface SupportsJobs {
   boolean deleteJobTemplate(String jobTemplateName) throws InUseException;
 
   /**
+   * Alters a job template by applying the specified changes. This allows for modifying the
+   * properties of an existing job template, such as its name, description, or parameters.
+   *
+   * @param jobTemplateName the name of the job template to alter
+   * @param changes the changes to apply to the job template
+   * @return the updated job template after applying the changes
+   * @throws NoSuchJobTemplateException if no job template with the specified name exists
+   * @throws IllegalArgumentException if any of the changes cannot be applied to the job template
+   */
+  default JobTemplate alterJobTemplate(String jobTemplateName, JobTemplateChange... changes)
+      throws NoSuchJobTemplateException, IllegalArgumentException {
+    throw new UnsupportedOperationException("Not implemented");
+  }
+
+  /**
    * Lists all the jobs by the specified job template name. This will return a list of job handles
    * associated with the specified job template. Each job handle represents a specific job.
    *

--- a/api/src/test/java/org/apache/gravitino/job/TestJobTemplateChange.java
+++ b/api/src/test/java/org/apache/gravitino/job/TestJobTemplateChange.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gravitino.job;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import java.util.Collections;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TestJobTemplateChange {
+
+  @Test
+  public void testRenameJobTemplate() {
+    JobTemplateChange change = JobTemplateChange.rename("newTemplateName");
+    Assertions.assertInstanceOf(JobTemplateChange.RenameJobTemplate.class, change);
+    Assertions.assertEquals(
+        "newTemplateName", ((JobTemplateChange.RenameJobTemplate) change).getNewName());
+
+    JobTemplateChange change1 = JobTemplateChange.rename("newTemplateName");
+    Assertions.assertEquals(change, change1);
+    Assertions.assertEquals(change.hashCode(), change1.hashCode());
+  }
+
+  @Test
+  public void testUpdateJobTemplateComment() {
+    JobTemplateChange change = JobTemplateChange.updateComment("New comment");
+    Assertions.assertInstanceOf(JobTemplateChange.UpdateJobTemplateComment.class, change);
+    Assertions.assertEquals(
+        "New comment", ((JobTemplateChange.UpdateJobTemplateComment) change).getNewComment());
+
+    JobTemplateChange change1 = JobTemplateChange.updateComment("New comment");
+    Assertions.assertEquals(change, change1);
+    Assertions.assertEquals(change.hashCode(), change1.hashCode());
+  }
+
+  @Test
+  public void testUpdateShellJobTemplate() {
+    JobTemplateChange.ShellTemplateUpdate update =
+        JobTemplateChange.ShellTemplateUpdate.builder()
+            .withNewExecutable("newExecutable.sh")
+            .withNewArguments(Lists.newArrayList("arg1", "arg2"))
+            .withNewEnvironments(ImmutableMap.of("ENV1", "value1", "ENV2", "value2"))
+            .withNewCustomFields(Collections.emptyMap())
+            .withNewScripts(Lists.newArrayList("test1.sh", "test2.sh"))
+            .build();
+
+    JobTemplateChange change = JobTemplateChange.updateTemplate(update);
+
+    Assertions.assertInstanceOf(JobTemplateChange.UpdateJobTemplate.class, change);
+    JobTemplateChange.UpdateJobTemplate updateChange = (JobTemplateChange.UpdateJobTemplate) change;
+    Assertions.assertEquals(
+        update.getNewExecutable(), updateChange.getTemplateUpdate().getNewExecutable());
+    Assertions.assertEquals(
+        update.getNewArguments(), updateChange.getTemplateUpdate().getNewArguments());
+    Assertions.assertEquals(
+        update.getNewEnvironments(), updateChange.getTemplateUpdate().getNewEnvironments());
+    Assertions.assertEquals(
+        update.getNewCustomFields(), updateChange.getTemplateUpdate().getNewCustomFields());
+    Assertions.assertEquals(
+        update.getNewScripts(),
+        ((JobTemplateChange.ShellTemplateUpdate) updateChange.getTemplateUpdate()).getNewScripts());
+  }
+
+  @Test
+  public void testUpdateSparkJobTemplate() {
+    JobTemplateChange.SparkTemplateUpdate update =
+        JobTemplateChange.SparkTemplateUpdate.builder()
+            .withNewClassName("org.apache.spark.examples.NewExample")
+            .withNewExecutable("new-spark-examples.jar")
+            .withNewArguments(Lists.newArrayList("arg1", "arg2"))
+            .withNewEnvironments(ImmutableMap.of("ENV1", "value1", "ENV2", "value2"))
+            .withNewCustomFields(Collections.emptyMap())
+            .withNewJars(Lists.newArrayList("lib1.jar", "lib2.jar"))
+            .withNewFiles(Lists.newArrayList("file1.txt", "file2.txt"))
+            .withNewArchives(Lists.newArrayList("archive1.zip", "archive2.zip"))
+            .withNewConfigs(ImmutableMap.of("spark.master", "local[*]", "spark.app.name", "NewApp"))
+            .build();
+
+    JobTemplateChange change = JobTemplateChange.updateTemplate(update);
+
+    Assertions.assertInstanceOf(JobTemplateChange.UpdateJobTemplate.class, change);
+    JobTemplateChange.UpdateJobTemplate updateChange = (JobTemplateChange.UpdateJobTemplate) change;
+    Assertions.assertEquals(
+        update.getNewClassName(),
+        ((JobTemplateChange.SparkTemplateUpdate) updateChange.getTemplateUpdate())
+            .getNewClassName());
+    Assertions.assertEquals(
+        update.getNewExecutable(), updateChange.getTemplateUpdate().getNewExecutable());
+    Assertions.assertEquals(
+        update.getNewArguments(), updateChange.getTemplateUpdate().getNewArguments());
+    Assertions.assertEquals(
+        update.getNewEnvironments(), updateChange.getTemplateUpdate().getNewEnvironments());
+    Assertions.assertEquals(
+        update.getNewCustomFields(), updateChange.getTemplateUpdate().getNewCustomFields());
+    Assertions.assertEquals(
+        update.getNewJars(),
+        ((JobTemplateChange.SparkTemplateUpdate) updateChange.getTemplateUpdate()).getNewJars());
+    Assertions.assertEquals(
+        update.getNewFiles(),
+        ((JobTemplateChange.SparkTemplateUpdate) updateChange.getTemplateUpdate()).getNewFiles());
+    Assertions.assertEquals(
+        update.getNewArchives(),
+        ((JobTemplateChange.SparkTemplateUpdate) updateChange.getTemplateUpdate())
+            .getNewArchives());
+    Assertions.assertEquals(
+        update.getNewConfigs(),
+        ((JobTemplateChange.SparkTemplateUpdate) updateChange.getTemplateUpdate()).getNewConfigs());
+  }
+}

--- a/clients/client-python/gravitino/api/job/job_template_change.py
+++ b/clients/client-python/gravitino/api/job/job_template_change.py
@@ -1,0 +1,425 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from abc import ABC
+from typing import List, Dict, Optional, Any
+from copy import deepcopy
+
+
+class JobTemplateChange:
+    """
+    The interface for job template changes. A job template change is an operation that modifies a job
+    template. It can be one of the following:
+
+      - Rename the job template.
+      - Update the comment of the job template.
+      - Update the job template details, such as executable, arguments, environments, custom
+        fields, etc.
+    """
+
+    @staticmethod
+    def rename(new_name: str) -> "JobTemplateChange":
+        """
+        Creates a new job template change to update the name of the job template.
+
+        Args:
+            new_name: The new name of the job template.
+
+        Returns:
+            The job template change.
+        """
+        return RenameJobTemplate(new_name)
+
+    @staticmethod
+    def update_comment(new_comment: str) -> "JobTemplateChange":
+        """
+        Creates a new job template change to update the comment of the job template.
+
+        Args:
+            new_comment: The new comment of the job template.
+
+        Returns:
+            The job template change.
+        """
+        return UpdateJobTemplateComment(new_comment)
+
+    @staticmethod
+    def update_template(template_update: "TemplateUpdate") -> "JobTemplateChange":
+        """
+        Creates a new job template change to update the details of the job template.
+
+        Args:
+            template_update: The template update details.
+
+        Returns:
+            The job template change.
+        """
+        return UpdateJobTemplate(template_update)
+
+
+class RenameJobTemplate(JobTemplateChange):
+    """
+    A job template change to rename the job template.
+    """
+
+    def __init__(self, new_name: str):
+        """
+        Initialize a RenameJobTemplate change.
+
+        Args:
+            new_name: The new name of the job template.
+        """
+        self._new_name = new_name
+
+    def get_new_name(self) -> str:
+        """
+        Get the new name of the job template.
+
+        Returns:
+            The new name of the job template.
+        """
+        return self._new_name
+
+    def __eq__(self, other: Any) -> bool:
+        return (
+            isinstance(other, RenameJobTemplate) and self._new_name == other._new_name
+        )
+
+    def __hash__(self) -> int:
+        return hash(self._new_name)
+
+    def __str__(self) -> str:
+        return f"RENAME JOB TEMPLATE {self._new_name}"
+
+
+class UpdateJobTemplateComment(JobTemplateChange):
+    """
+    A job template change to update the comment of the job template.
+    """
+
+    def __init__(self, new_comment: str):
+        """
+        Initialize an UpdateJobTemplateComment change.
+
+        Args:
+            new_comment: The new comment of the job template.
+        """
+        self._new_comment = new_comment
+
+    def get_new_comment(self) -> str:
+        """
+        Get the new comment of the job template.
+
+        Returns:
+            The new comment of the job template.
+        """
+        return self._new_comment
+
+    def __eq__(self, other: Any) -> bool:
+        return (
+            isinstance(other, UpdateJobTemplateComment)
+            and self._new_comment == other._new_comment
+        )
+
+    def __hash__(self) -> int:
+        return hash(self._new_comment)
+
+    def __str__(self) -> str:
+        return f"UPDATE JOB TEMPLATE COMMENT {self._new_comment}"
+
+
+class UpdateJobTemplate(JobTemplateChange):
+    """
+    A job template change to update the details of the job template.
+    """
+
+    def __init__(self, template_update: "TemplateUpdate"):
+        """
+        Initialize an UpdateJobTemplate change.
+
+        Args:
+            template_update: The job template update details.
+        """
+        self._template_update = template_update
+
+    def get_template_update(self) -> "TemplateUpdate":
+        """
+        Get the job template update.
+
+        Returns:
+            The job template update.
+        """
+        return self._template_update
+
+    def __eq__(self, other: Any) -> bool:
+        return (
+            isinstance(other, UpdateJobTemplate)
+            and self._template_update == other._template_update
+        )
+
+    def __hash__(self) -> int:
+        return hash(self._template_update)
+
+    def __str__(self) -> str:
+        return f"UPDATE JOB TEMPLATE {type(self._template_update).__name__}"
+
+
+class TemplateUpdate(ABC):
+    """
+    Base class for template updates.
+    """
+
+    def __init__(
+        self,
+        new_executable: str,
+        new_arguments: Optional[List[str]] = None,
+        new_environments: Optional[Dict[str, str]] = None,
+        new_custom_fields: Optional[Dict[str, str]] = None,
+    ):
+        """
+        Initialize a TemplateUpdate.
+
+        Args:
+            new_executable: The new executable of the job template.
+            new_arguments: The new arguments of the job template.
+            new_environments: The new environments of the job template.
+            new_custom_fields: The new custom fields of the job template.
+        """
+        if not new_executable or not new_executable.strip():
+            raise ValueError("Executable cannot be null or blank")
+        self._new_executable = new_executable
+        self._new_arguments = (
+            deepcopy(new_arguments) if new_arguments is not None else []
+        )
+        self._new_environments = (
+            deepcopy(new_environments) if new_environments is not None else {}
+        )
+        self._new_custom_fields = (
+            deepcopy(new_custom_fields) if new_custom_fields is not None else {}
+        )
+
+    def get_new_executable(self) -> str:
+        """
+        Get the new executable of the job template.
+
+        Returns:
+            The new executable of the job template.
+        """
+        return self._new_executable
+
+    def get_new_arguments(self) -> List[str]:
+        """
+        Get the new arguments of the job template.
+
+        Returns:
+            The new arguments of the job template.
+        """
+        return self._new_arguments
+
+    def get_new_environments(self) -> Dict[str, str]:
+        """
+        Get the new environments of the job template.
+
+        Returns:
+            The new environments of the job template.
+        """
+        return self._new_environments
+
+    def get_new_custom_fields(self) -> Dict[str, str]:
+        """
+        Get the new custom fields of the job template.
+
+        Returns:
+            The new custom fields of the job template.
+        """
+        return self._new_custom_fields
+
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, TemplateUpdate):
+            return False
+        return (
+            self._new_executable == other._new_executable
+            and self._new_arguments == other._new_arguments
+            and self._new_environments == other._new_environments
+            and self._new_custom_fields == other._new_custom_fields
+        )
+
+    def __hash__(self) -> int:
+        return hash(
+            (
+                self._new_executable,
+                tuple(self._new_arguments),
+                frozenset(self._new_environments.items()),
+                frozenset(self._new_custom_fields.items()),
+            )
+        )
+
+
+class ShellTemplateUpdate(TemplateUpdate):
+    """
+    A template update for shell job templates.
+    """
+
+    def __init__(
+        self,
+        new_executable: str,
+        new_arguments: Optional[List[str]] = None,
+        new_environments: Optional[Dict[str, str]] = None,
+        new_custom_fields: Optional[Dict[str, str]] = None,
+        new_scripts: Optional[List[str]] = None,
+    ):
+        """
+        Initialize a ShellTemplateUpdate.
+
+        Args:
+            new_executable: The new executable of the shell job template.
+            new_arguments: The new arguments of the shell job template.
+            new_environments: The new environments of the shell job template.
+            new_custom_fields: The new custom fields of the shell job template.
+            new_scripts: The new scripts of the shell job template.
+        """
+        super().__init__(
+            new_executable, new_arguments, new_environments, new_custom_fields
+        )
+        self._new_scripts = deepcopy(new_scripts) if new_scripts is not None else []
+
+    def get_new_scripts(self) -> List[str]:
+        """
+        Get the new scripts of the shell job template.
+
+        Returns:
+            The new scripts of the shell job template.
+        """
+        return self._new_scripts
+
+    def __eq__(self, other: Any) -> bool:
+        return (
+            isinstance(other, ShellTemplateUpdate)
+            and super().__eq__(other)
+            and self._new_scripts == other._new_scripts
+        )
+
+    def __hash__(self) -> int:
+        return hash((super().__hash__(), tuple(self._new_scripts)))
+
+
+class SparkTemplateUpdate(TemplateUpdate):
+    """
+    A template update for spark job templates.
+    """
+
+    def __init__(
+        self,
+        new_executable: str,
+        new_arguments: Optional[List[str]] = None,
+        new_environments: Optional[Dict[str, str]] = None,
+        new_custom_fields: Optional[Dict[str, str]] = None,
+        new_class_name: Optional[str] = None,
+        new_jars: Optional[List[str]] = None,
+        new_files: Optional[List[str]] = None,
+        new_archives: Optional[List[str]] = None,
+        new_configs: Optional[Dict[str, str]] = None,
+    ):
+        """
+        Initialize a SparkTemplateUpdate.
+
+        Args:
+            new_executable: The new executable of the spark job template.
+            new_arguments: The new arguments of the spark job template.
+            new_environments: The new environments of the spark job template.
+            new_custom_fields: The new custom fields of the spark job template.
+            new_class_name: The new class name of the spark job template.
+            new_jars: The new jars of the spark job template.
+            new_files: The new files of the spark job template.
+            new_archives: The new archives of the spark job template.
+            new_configs: The new configs of the spark job template.
+        """
+        super().__init__(
+            new_executable, new_arguments, new_environments, new_custom_fields
+        )
+        self._new_class_name = new_class_name
+        self._new_jars = deepcopy(new_jars) if new_jars is not None else []
+        self._new_files = deepcopy(new_files) if new_files is not None else []
+        self._new_archives = deepcopy(new_archives) if new_archives is not None else []
+        self._new_configs = deepcopy(new_configs) if new_configs is not None else {}
+
+    def get_new_class_name(self) -> Optional[str]:
+        """
+        Get the new class name of the spark job template.
+
+        Returns:
+            The new class name of the spark job template.
+        """
+        return self._new_class_name
+
+    def get_new_jars(self) -> List[str]:
+        """
+        Get the new jars of the spark job template.
+
+        Returns:
+            The new jars of the spark job template.
+        """
+        return self._new_jars
+
+    def get_new_files(self) -> List[str]:
+        """
+        Get the new files of the spark job template.
+
+        Returns:
+            The new files of the spark job template.
+        """
+        return self._new_files
+
+    def get_new_archives(self) -> List[str]:
+        """
+        Get the new archives of the spark job template.
+
+        Returns:
+            The new archives of the spark job template.
+        """
+        return self._new_archives
+
+    def get_new_configs(self) -> Dict[str, str]:
+        """
+        Get the new configs of the spark job template.
+
+        Returns:
+            The new configs of the spark job template.
+        """
+        return self._new_configs
+
+    def __eq__(self, other: Any) -> bool:
+        return (
+            isinstance(other, SparkTemplateUpdate)
+            and super().__eq__(other)
+            and self._new_class_name == other._new_class_name
+            and self._new_jars == other._new_jars
+            and self._new_files == other._new_files
+            and self._new_archives == other._new_archives
+            and self._new_configs == other._new_configs
+        )
+
+    def __hash__(self) -> int:
+        return hash(
+            (
+                super().__hash__(),
+                self._new_class_name,
+                tuple(self._new_jars),
+                tuple(self._new_files),
+                tuple(self._new_archives),
+                frozenset(self._new_configs.items()),
+            )
+        )

--- a/clients/client-python/gravitino/api/job/job_template_change.py
+++ b/clients/client-python/gravitino/api/job/job_template_change.py
@@ -16,7 +16,6 @@
 # under the License.
 from abc import ABC
 from typing import List, Dict, Optional, Any
-from copy import deepcopy
 
 
 class JobTemplateChange:
@@ -184,7 +183,7 @@ class TemplateUpdate(ABC):
 
     def __init__(
         self,
-        new_executable: str,
+        new_executable: Optional[str] = None,
         new_arguments: Optional[List[str]] = None,
         new_environments: Optional[Dict[str, str]] = None,
         new_custom_fields: Optional[Dict[str, str]] = None,
@@ -198,20 +197,12 @@ class TemplateUpdate(ABC):
             new_environments: The new environments of the job template.
             new_custom_fields: The new custom fields of the job template.
         """
-        if not new_executable or not new_executable.strip():
-            raise ValueError("Executable cannot be null or blank")
         self._new_executable = new_executable
-        self._new_arguments = (
-            deepcopy(new_arguments) if new_arguments is not None else []
-        )
-        self._new_environments = (
-            deepcopy(new_environments) if new_environments is not None else {}
-        )
-        self._new_custom_fields = (
-            deepcopy(new_custom_fields) if new_custom_fields is not None else {}
-        )
+        self._new_arguments = new_arguments
+        self._new_environments = new_environments
+        self._new_custom_fields = new_custom_fields
 
-    def get_new_executable(self) -> str:
+    def get_new_executable(self) -> Optional[str]:
         """
         Get the new executable of the job template.
 
@@ -220,7 +211,7 @@ class TemplateUpdate(ABC):
         """
         return self._new_executable
 
-    def get_new_arguments(self) -> List[str]:
+    def get_new_arguments(self) -> Optional[List[str]]:
         """
         Get the new arguments of the job template.
 
@@ -229,7 +220,7 @@ class TemplateUpdate(ABC):
         """
         return self._new_arguments
 
-    def get_new_environments(self) -> Dict[str, str]:
+    def get_new_environments(self) -> Optional[Dict[str, str]]:
         """
         Get the new environments of the job template.
 
@@ -238,7 +229,7 @@ class TemplateUpdate(ABC):
         """
         return self._new_environments
 
-    def get_new_custom_fields(self) -> Dict[str, str]:
+    def get_new_custom_fields(self) -> Optional[Dict[str, str]]:
         """
         Get the new custom fields of the job template.
 
@@ -275,7 +266,7 @@ class ShellTemplateUpdate(TemplateUpdate):
 
     def __init__(
         self,
-        new_executable: str,
+        new_executable: Optional[str] = None,
         new_arguments: Optional[List[str]] = None,
         new_environments: Optional[Dict[str, str]] = None,
         new_custom_fields: Optional[Dict[str, str]] = None,
@@ -294,9 +285,9 @@ class ShellTemplateUpdate(TemplateUpdate):
         super().__init__(
             new_executable, new_arguments, new_environments, new_custom_fields
         )
-        self._new_scripts = deepcopy(new_scripts) if new_scripts is not None else []
+        self._new_scripts = new_scripts
 
-    def get_new_scripts(self) -> List[str]:
+    def get_new_scripts(self) -> Optional[List[str]]:
         """
         Get the new scripts of the shell job template.
 
@@ -323,7 +314,7 @@ class SparkTemplateUpdate(TemplateUpdate):
 
     def __init__(
         self,
-        new_executable: str,
+        new_executable: Optional[str] = None,
         new_arguments: Optional[List[str]] = None,
         new_environments: Optional[Dict[str, str]] = None,
         new_custom_fields: Optional[Dict[str, str]] = None,
@@ -351,10 +342,10 @@ class SparkTemplateUpdate(TemplateUpdate):
             new_executable, new_arguments, new_environments, new_custom_fields
         )
         self._new_class_name = new_class_name
-        self._new_jars = deepcopy(new_jars) if new_jars is not None else []
-        self._new_files = deepcopy(new_files) if new_files is not None else []
-        self._new_archives = deepcopy(new_archives) if new_archives is not None else []
-        self._new_configs = deepcopy(new_configs) if new_configs is not None else {}
+        self._new_jars = new_jars
+        self._new_files = new_files
+        self._new_archives = new_archives
+        self._new_configs = new_configs
 
     def get_new_class_name(self) -> Optional[str]:
         """
@@ -365,7 +356,7 @@ class SparkTemplateUpdate(TemplateUpdate):
         """
         return self._new_class_name
 
-    def get_new_jars(self) -> List[str]:
+    def get_new_jars(self) -> Optional[List[str]]:
         """
         Get the new jars of the spark job template.
 
@@ -374,7 +365,7 @@ class SparkTemplateUpdate(TemplateUpdate):
         """
         return self._new_jars
 
-    def get_new_files(self) -> List[str]:
+    def get_new_files(self) -> Optional[List[str]]:
         """
         Get the new files of the spark job template.
 
@@ -383,7 +374,7 @@ class SparkTemplateUpdate(TemplateUpdate):
         """
         return self._new_files
 
-    def get_new_archives(self) -> List[str]:
+    def get_new_archives(self) -> Optional[List[str]]:
         """
         Get the new archives of the spark job template.
 
@@ -392,7 +383,7 @@ class SparkTemplateUpdate(TemplateUpdate):
         """
         return self._new_archives
 
-    def get_new_configs(self) -> Dict[str, str]:
+    def get_new_configs(self) -> Optional[Dict[str, str]]:
         """
         Get the new configs of the spark job template.
 

--- a/clients/client-python/gravitino/api/job/supports_jobs.py
+++ b/clients/client-python/gravitino/api/job/supports_jobs.py
@@ -19,6 +19,7 @@ from abc import ABC, abstractmethod
 from typing import List, Dict
 from .job_handle import JobHandle
 from .job_template import JobTemplate
+from .job_template_change import JobTemplateChange
 
 
 class SupportsJobs(ABC):
@@ -89,6 +90,27 @@ class SupportsJobs(ABC):
         """
         pass
 
+    def alter_job_template(
+        self, job_template_name: str, *changes: JobTemplateChange
+    ) -> JobTemplate:
+        """
+        Alters a job template by applying the specified changes. This allows for modifying the
+        properties of an existing job template, such as its name, description, or parameters.
+
+        Args:
+            job_template_name: The name of the job template.
+            changes: The changes to apply to the job template.
+
+        Raises:
+            NoSuchJobTemplateException: If the job template does not exist.
+            IllegalArgumentException: If any of the changes cannot be applied to the job template.
+
+        Returns:
+            The altered job template.
+        """
+        pass
+
+    @abstractmethod
     def list_jobs(self, job_template_name: str = None) -> List[JobHandle]:
         """
         Lists all the jobs in Gravitino. If a job template name is provided, it will filter the jobs

--- a/clients/client-python/tests/unittests/job/__init__.py
+++ b/clients/client-python/tests/unittests/job/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/clients/client-python/tests/unittests/job/test_job_template_change.py
+++ b/clients/client-python/tests/unittests/job/test_job_template_change.py
@@ -1,0 +1,104 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import unittest
+from typing import cast
+
+from gravitino.api.job.job_template_change import (
+    JobTemplateChange,
+    RenameJobTemplate,
+    UpdateJobTemplateComment,
+    UpdateJobTemplate,
+    ShellTemplateUpdate,
+    SparkTemplateUpdate,
+)
+
+
+class TestJobTemplateChange(unittest.TestCase):
+    def test_rename_job_template(self):
+        change = JobTemplateChange.rename("new_name")
+        self.assertIsInstance(change, RenameJobTemplate)
+        self.assertEqual(change.get_new_name(), "new_name")
+        self.assertEqual(str(change), "RENAME JOB TEMPLATE new_name")
+
+    def test_update_comment(self):
+        change = JobTemplateChange.update_comment("new comment")
+        self.assertIsInstance(change, UpdateJobTemplateComment)
+        self.assertEqual(change.get_new_comment(), "new comment")
+        self.assertEqual(str(change), "UPDATE JOB TEMPLATE COMMENT new comment")
+
+    def test_update_shell_template(self):
+        template_update = ShellTemplateUpdate(
+            new_executable="/bin/bash",
+            new_arguments=["-c", "echo hello"],
+            new_environments={"ENV": "test"},
+            new_custom_fields={"field": "value"},
+            new_scripts=["script1", "echo script1 content"],
+        )
+        change = JobTemplateChange.update_template(template_update)
+        self.assertIsInstance(change, UpdateJobTemplate)
+        self.assertEqual(change.get_template_update().get_new_executable(), "/bin/bash")
+        self.assertEqual(
+            change.get_template_update().get_new_arguments(), ["-c", "echo hello"]
+        )
+        self.assertEqual(
+            change.get_template_update().get_new_environments(), {"ENV": "test"}
+        )
+        self.assertEqual(
+            change.get_template_update().get_new_custom_fields(), {"field": "value"}
+        )
+        self.assertEqual(
+            cast(ShellTemplateUpdate, change.get_template_update()).get_new_scripts(),
+            ["script1", "echo script1 content"],
+        )
+
+    def test_update_spark_template(self):
+
+        template_update = SparkTemplateUpdate(
+            new_executable="spark-submit",
+            new_arguments=["--class", "org.example.Main", "app.jar"],
+            new_environments={"SPARK_ENV": "prod"},
+            new_custom_fields={"spark_field": "spark_value"},
+            new_class_name="org.example.Main",
+            new_jars=["lib1.jar", "lib2.jar"],
+            new_files=["file1.txt", "file2.txt"],
+            new_archives=["archive1.zip"],
+            new_configs={"spark.executor.memory": "4g"},
+        )
+        change = JobTemplateChange.update_template(template_update)
+        self.assertIsInstance(change, UpdateJobTemplate)
+        self.assertEqual(
+            change.get_template_update().get_new_executable(), "spark-submit"
+        )
+        self.assertEqual(
+            change.get_template_update().get_new_arguments(),
+            ["--class", "org.example.Main", "app.jar"],
+        )
+        self.assertEqual(
+            change.get_template_update().get_new_environments(), {"SPARK_ENV": "prod"}
+        )
+        self.assertEqual(
+            change.get_template_update().get_new_custom_fields(),
+            {"spark_field": "spark_value"},
+        )
+        spark_update = cast(SparkTemplateUpdate, change.get_template_update())
+        self.assertEqual(spark_update.get_new_class_name(), "org.example.Main")
+        self.assertEqual(spark_update.get_new_jars(), ["lib1.jar", "lib2.jar"])
+        self.assertEqual(spark_update.get_new_files(), ["file1.txt", "file2.txt"])
+        self.assertEqual(spark_update.get_new_archives(), ["archive1.zip"])
+        self.assertEqual(
+            spark_update.get_new_configs(), {"spark.executor.memory": "4g"}
+        )

--- a/common/src/main/java/org/apache/gravitino/dto/job/ShellTemplateUpdateDTO.java
+++ b/common/src/main/java/org/apache/gravitino/dto/job/ShellTemplateUpdateDTO.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.dto.job;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import javax.annotation.Nullable;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+import org.apache.gravitino.job.JobTemplateChange;
+
+/** DTO for updating a Shell Job Template. */
+@Getter
+@EqualsAndHashCode(callSuper = true)
+@SuperBuilder(setterPrefix = "with")
+@ToString(callSuper = true)
+public class ShellTemplateUpdateDTO extends TemplateUpdateDTO {
+
+  @Nullable
+  @JsonProperty("newScripts")
+  private List<String> newScripts;
+
+  /**
+   * The default constructor for Jackson. This constructor is required for deserialization of the
+   * DTO.
+   */
+  private ShellTemplateUpdateDTO() {
+    // Default constructor for Jackson
+    super();
+  }
+
+  @Override
+  public JobTemplateChange.TemplateUpdate toTemplateUpdate() {
+    return JobTemplateChange.ShellTemplateUpdate.builder()
+        .withNewExecutable(getNewExecutable())
+        .withNewArguments(getNewArguments())
+        .withNewEnvironments(getNewEnvironments())
+        .withNewCustomFields(getNewCustomFields())
+        .withNewScripts(newScripts)
+        .build();
+  }
+}

--- a/common/src/main/java/org/apache/gravitino/dto/job/SparkTemplateUpdateDTO.java
+++ b/common/src/main/java/org/apache/gravitino/dto/job/SparkTemplateUpdateDTO.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.dto.job;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+import org.apache.gravitino.job.JobTemplateChange;
+
+/** DTO for updating a Spark Job Template. */
+@Getter
+@EqualsAndHashCode(callSuper = true)
+@SuperBuilder(setterPrefix = "with")
+@ToString(callSuper = true)
+public class SparkTemplateUpdateDTO extends TemplateUpdateDTO {
+
+  @Nullable
+  @JsonProperty("newClassName")
+  private String newClassName;
+
+  @Nullable
+  @JsonProperty("newJars")
+  private List<String> newJars;
+
+  @Nullable
+  @JsonProperty("newFiles")
+  private List<String> newFiles;
+
+  @Nullable
+  @JsonProperty("newArchives")
+  private List<String> newArchives;
+
+  @Nullable
+  @JsonProperty("newConfigs")
+  private Map<String, String> newConfigs;
+
+  /**
+   * The default constructor for Jackson. This constructor is required for deserialization of the
+   * DTO.
+   */
+  private SparkTemplateUpdateDTO() {
+    // Default constructor for Jackson
+    super();
+  }
+
+  @Override
+  public JobTemplateChange.TemplateUpdate toTemplateUpdate() {
+    return JobTemplateChange.SparkTemplateUpdate.builder()
+        .withNewExecutable(getNewExecutable())
+        .withNewArguments(getNewArguments())
+        .withNewEnvironments(getNewEnvironments())
+        .withNewCustomFields(getNewCustomFields())
+        .withNewClassName(newClassName)
+        .withNewJars(newJars)
+        .withNewFiles(newFiles)
+        .withNewArchives(newArchives)
+        .withNewConfigs(newConfigs)
+        .build();
+  }
+}

--- a/common/src/main/java/org/apache/gravitino/dto/job/TemplateUpdateDTO.java
+++ b/common/src/main/java/org/apache/gravitino/dto/job/TemplateUpdateDTO.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.dto.job;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+import org.apache.gravitino.job.JobTemplateChange;
+
+/** DTO for updating a Job Template. */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY)
+@JsonSubTypes({
+  @JsonSubTypes.Type(value = ShellTemplateUpdateDTO.class, name = "shell"),
+  @JsonSubTypes.Type(value = SparkTemplateUpdateDTO.class, name = "spark")
+})
+@Getter
+@EqualsAndHashCode
+@SuperBuilder(setterPrefix = "with")
+@ToString
+public abstract class TemplateUpdateDTO {
+
+  @Nullable
+  @JsonProperty("newExecutable")
+  private String newExecutable;
+
+  @Nullable
+  @JsonProperty("newArguments")
+  private List<String> newArguments;
+
+  @Nullable
+  @JsonProperty("newEnvironments")
+  private Map<String, String> newEnvironments;
+
+  @Nullable
+  @JsonProperty("newCustomFields")
+  private Map<String, String> newCustomFields;
+
+  /**
+   * The default constructor for Jackson. This constructor is required for deserialization of the
+   * DTO.
+   */
+  protected TemplateUpdateDTO() {
+    // Default constructor for Jackson
+  }
+
+  /**
+   * Converts this DTO to a TemplateUpdate object.
+   *
+   * @return the corresponding TemplateUpdate object
+   */
+  public abstract JobTemplateChange.TemplateUpdate toTemplateUpdate();
+}

--- a/common/src/main/java/org/apache/gravitino/dto/requests/JobTemplateUpdateRequest.java
+++ b/common/src/main/java/org/apache/gravitino/dto/requests/JobTemplateUpdateRequest.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.dto.requests;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.google.common.base.Preconditions;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.gravitino.dto.job.TemplateUpdateDTO;
+import org.apache.gravitino.job.JobTemplateChange;
+import org.apache.gravitino.rest.RESTRequest;
+
+/**
+ * Represents a request to update a job template. This can include renaming the template, updating
+ * its comment, or changing its content.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY)
+@JsonSubTypes({
+  @JsonSubTypes.Type(
+      value = JobTemplateUpdateRequest.RenameJobTemplateRequest.class,
+      name = "rename"),
+  @JsonSubTypes.Type(
+      value = JobTemplateUpdateRequest.UpdateJobTemplateCommentRequest.class,
+      name = "updateComment"),
+  @JsonSubTypes.Type(
+      value = JobTemplateUpdateRequest.UpdateJobTemplateContentRequest.class,
+      name = "updateTemplate")
+})
+public interface JobTemplateUpdateRequest extends RESTRequest {
+
+  /**
+   * Get the job template change that is requested.
+   *
+   * @return the job template change
+   */
+  JobTemplateChange jobTemplateChange();
+
+  /** The request to rename a job template. */
+  @EqualsAndHashCode
+  @ToString
+  class RenameJobTemplateRequest implements JobTemplateUpdateRequest {
+
+    @Getter
+    @JsonProperty("newName")
+    private final String newName;
+
+    /**
+     * Constructor for RenameJobTemplateRequest.
+     *
+     * @param newName the new name for the job template
+     */
+    public RenameJobTemplateRequest(String newName) {
+      this.newName = newName;
+    }
+
+    /** Default constructor for Jackson. */
+    public RenameJobTemplateRequest() {
+      this(null);
+    }
+
+    @Override
+    public void validate() throws IllegalArgumentException {
+      Preconditions.checkArgument(
+          StringUtils.isNotBlank(newName), "\"newName\" is required and cannot be empty");
+    }
+
+    @Override
+    public JobTemplateChange jobTemplateChange() {
+      return JobTemplateChange.rename(newName);
+    }
+  }
+
+  /** The request to update the comment of a job template. */
+  @EqualsAndHashCode
+  @ToString
+  class UpdateJobTemplateCommentRequest implements JobTemplateUpdateRequest {
+
+    @Getter
+    @JsonProperty("newComment")
+    private final String newComment;
+
+    /**
+     * Constructor for UpdateJobTemplateCommentRequest.
+     *
+     * @param newComment the new comment for the job template
+     */
+    public UpdateJobTemplateCommentRequest(String newComment) {
+      this.newComment = newComment;
+    }
+
+    /** Default constructor for Jackson. */
+    public UpdateJobTemplateCommentRequest() {
+      this(null);
+    }
+
+    @Override
+    public void validate() throws IllegalArgumentException {
+      // No specific validation needed for comment, it can be null or empty
+    }
+
+    @Override
+    public JobTemplateChange jobTemplateChange() {
+      return JobTemplateChange.updateComment(newComment);
+    }
+  }
+
+  /** The request to update the content of a job template. */
+  @EqualsAndHashCode
+  @ToString
+  class UpdateJobTemplateContentRequest implements JobTemplateUpdateRequest {
+
+    @Getter
+    @JsonProperty("newTemplate")
+    private final TemplateUpdateDTO newTemplate;
+
+    /**
+     * Constructor for UpdateJobTemplateContentRequest.
+     *
+     * @param newTemplate the new template content for the job template
+     */
+    public UpdateJobTemplateContentRequest(TemplateUpdateDTO newTemplate) {
+      this.newTemplate = newTemplate;
+    }
+
+    /** Default constructor for Jackson. */
+    public UpdateJobTemplateContentRequest() {
+      this(null);
+    }
+
+    @Override
+    public void validate() throws IllegalArgumentException {
+      Preconditions.checkArgument(
+          newTemplate != null, "\"newTemplate\" is required and cannot be null");
+    }
+
+    @Override
+    public JobTemplateChange jobTemplateChange() {
+      return JobTemplateChange.updateTemplate(newTemplate.toTemplateUpdate());
+    }
+  }
+}

--- a/common/src/main/java/org/apache/gravitino/dto/requests/JobTemplateUpdatesRequest.java
+++ b/common/src/main/java/org/apache/gravitino/dto/requests/JobTemplateUpdatesRequest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.dto.requests;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+import org.apache.gravitino.rest.RESTRequest;
+
+/** Represents a request to update a job template with series of updates. */
+@Getter
+@EqualsAndHashCode
+@ToString
+public class JobTemplateUpdatesRequest implements RESTRequest {
+
+  @JsonProperty("updates")
+  private final List<JobTemplateUpdateRequest> updates;
+
+  /**
+   * Creates a new JobTemplateUpdatesRequest.
+   *
+   * @param updates The updates to apply to the job template.
+   */
+  public JobTemplateUpdatesRequest(List<JobTemplateUpdateRequest> updates) {
+    this.updates = updates;
+  }
+
+  /** This is the constructor that is used by Jackson deserializer */
+  public JobTemplateUpdatesRequest() {
+    this(null);
+  }
+
+  /**
+   * Validates the request.
+   *
+   * @throws IllegalArgumentException If the request is invalid, this exception is thrown.
+   */
+  @Override
+  public void validate() throws IllegalArgumentException {
+    updates.forEach(RESTRequest::validate);
+  }
+}

--- a/common/src/test/java/org/apache/gravitino/dto/job/TestTemplateUpdateDTO.java
+++ b/common/src/test/java/org/apache/gravitino/dto/job/TestTemplateUpdateDTO.java
@@ -1,0 +1,320 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.dto.job;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.apache.gravitino.json.JsonUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TestTemplateUpdateDTO {
+
+  @Test
+  public void testShellTemplateUpdateDTO() throws JsonProcessingException {
+    ShellTemplateUpdateDTO shellTemplateUpdateDTO =
+        ShellTemplateUpdateDTO.builder()
+            .withNewExecutable("/bin/bash")
+            .withNewArguments(ImmutableList.of("-c", "echo Hello World"))
+            .withNewEnvironments(ImmutableMap.of("ENV_VAR", "value"))
+            .withNewCustomFields(ImmutableMap.of("customKey", "customValue"))
+            .withNewScripts(ImmutableList.of("/path/to/script1.sh", "/path/to/script2.sh"))
+            .build();
+
+    String serJson = JsonUtils.objectMapper().writeValueAsString(shellTemplateUpdateDTO);
+    ShellTemplateUpdateDTO deserDTO =
+        JsonUtils.objectMapper().readValue(serJson, ShellTemplateUpdateDTO.class);
+    Assertions.assertEquals(shellTemplateUpdateDTO, deserDTO);
+
+    shellTemplateUpdateDTO =
+        ShellTemplateUpdateDTO.builder()
+            .withNewEnvironments(ImmutableMap.of("ENV_VAR", "value"))
+            .withNewCustomFields(ImmutableMap.of("customKey", "customValue"))
+            .withNewScripts(ImmutableList.of("/path/to/script1.sh", "/path/to/script2.sh"))
+            .build();
+
+    serJson = JsonUtils.objectMapper().writeValueAsString(shellTemplateUpdateDTO);
+    deserDTO = JsonUtils.objectMapper().readValue(serJson, ShellTemplateUpdateDTO.class);
+    Assertions.assertNull(deserDTO.getNewExecutable());
+    Assertions.assertNull(deserDTO.getNewArguments());
+    Assertions.assertEquals(shellTemplateUpdateDTO, deserDTO);
+
+    shellTemplateUpdateDTO =
+        ShellTemplateUpdateDTO.builder()
+            .withNewScripts(ImmutableList.of("/path/to/script1.sh", "/path/to/script2.sh"))
+            .build();
+
+    serJson = JsonUtils.objectMapper().writeValueAsString(shellTemplateUpdateDTO);
+    deserDTO = JsonUtils.objectMapper().readValue(serJson, ShellTemplateUpdateDTO.class);
+    Assertions.assertNull(deserDTO.getNewEnvironments());
+    Assertions.assertNull(deserDTO.getNewCustomFields());
+    Assertions.assertEquals(shellTemplateUpdateDTO, deserDTO);
+
+    shellTemplateUpdateDTO = ShellTemplateUpdateDTO.builder().build();
+    serJson = JsonUtils.objectMapper().writeValueAsString(shellTemplateUpdateDTO);
+    deserDTO = JsonUtils.objectMapper().readValue(serJson, ShellTemplateUpdateDTO.class);
+    Assertions.assertNull(deserDTO.getNewScripts());
+    Assertions.assertEquals(shellTemplateUpdateDTO, deserDTO);
+  }
+
+  @Test
+  public void testSparkTemplateUpdateDTO() throws JsonProcessingException {
+    SparkTemplateUpdateDTO sparkTemplateUpdateDTO =
+        SparkTemplateUpdateDTO.builder()
+            .withNewExecutable("spark-submit")
+            .withNewArguments(ImmutableList.of("--class", "org.example.Main"))
+            .withNewEnvironments(ImmutableMap.of("SPARK_ENV", "prod"))
+            .withNewCustomFields(ImmutableMap.of("customKey", "customValue"))
+            .withNewClassName("org.example.Main")
+            .withNewJars(ImmutableList.of("/path/to/jar1.jar", "/path/to/jar2.jar"))
+            .withNewFiles(ImmutableList.of("/path/to/file1.txt", "/path/to/file2.txt"))
+            .withNewArchives(ImmutableList.of("/path/to/archive1.zip", "/path/to/archive2.zip"))
+            .withNewConfigs(ImmutableMap.of("spark.executor.memory", "4g"))
+            .build();
+
+    String serJson = JsonUtils.objectMapper().writeValueAsString(sparkTemplateUpdateDTO);
+    SparkTemplateUpdateDTO deserDTO =
+        JsonUtils.objectMapper().readValue(serJson, SparkTemplateUpdateDTO.class);
+    Assertions.assertEquals(sparkTemplateUpdateDTO, deserDTO);
+
+    sparkTemplateUpdateDTO =
+        SparkTemplateUpdateDTO.builder()
+            .withNewEnvironments(ImmutableMap.of("SPARK_ENV", "prod"))
+            .withNewCustomFields(ImmutableMap.of("customKey", "customValue"))
+            .withNewClassName("org.example.Main")
+            .withNewJars(ImmutableList.of("/path/to/jar1.jar", "/path/to/jar2.jar"))
+            .withNewFiles(ImmutableList.of("/path/to/file1.txt", "/path/to/file2.txt"))
+            .withNewArchives(ImmutableList.of("/path/to/archive1.zip", "/path/to/archive2.zip"))
+            .withNewConfigs(ImmutableMap.of("spark.executor.memory", "4g"))
+            .build();
+
+    serJson = JsonUtils.objectMapper().writeValueAsString(sparkTemplateUpdateDTO);
+    deserDTO = JsonUtils.objectMapper().readValue(serJson, SparkTemplateUpdateDTO.class);
+    Assertions.assertNull(deserDTO.getNewExecutable());
+    Assertions.assertNull(deserDTO.getNewArguments());
+    Assertions.assertEquals(sparkTemplateUpdateDTO, deserDTO);
+
+    sparkTemplateUpdateDTO =
+        SparkTemplateUpdateDTO.builder()
+            .withNewClassName("org.example.Main")
+            .withNewJars(ImmutableList.of("/path/to/jar1.jar", "/path/to/jar2.jar"))
+            .withNewFiles(ImmutableList.of("/path/to/file1.txt", "/path/to/file2.txt"))
+            .withNewArchives(ImmutableList.of("/path/to/archive1.zip", "/path/to/archive2.zip"))
+            .withNewConfigs(ImmutableMap.of("spark.executor.memory", "4g"))
+            .build();
+
+    serJson = JsonUtils.objectMapper().writeValueAsString(sparkTemplateUpdateDTO);
+    deserDTO = JsonUtils.objectMapper().readValue(serJson, SparkTemplateUpdateDTO.class);
+    Assertions.assertNull(deserDTO.getNewEnvironments());
+    Assertions.assertNull(deserDTO.getNewCustomFields());
+    Assertions.assertEquals(sparkTemplateUpdateDTO, deserDTO);
+
+    sparkTemplateUpdateDTO =
+        SparkTemplateUpdateDTO.builder()
+            .withNewConfigs(ImmutableMap.of("spark.executor.memory", "4g"))
+            .build();
+
+    serJson = JsonUtils.objectMapper().writeValueAsString(sparkTemplateUpdateDTO);
+    deserDTO = JsonUtils.objectMapper().readValue(serJson, SparkTemplateUpdateDTO.class);
+    Assertions.assertNull(deserDTO.getNewClassName());
+    Assertions.assertNull(deserDTO.getNewJars());
+    Assertions.assertNull(deserDTO.getNewFiles());
+    Assertions.assertNull(deserDTO.getNewArchives());
+    Assertions.assertEquals(sparkTemplateUpdateDTO, deserDTO);
+
+    sparkTemplateUpdateDTO = SparkTemplateUpdateDTO.builder().build();
+    serJson = JsonUtils.objectMapper().writeValueAsString(sparkTemplateUpdateDTO);
+    deserDTO = JsonUtils.objectMapper().readValue(serJson, SparkTemplateUpdateDTO.class);
+    Assertions.assertNull(deserDTO.getNewConfigs());
+    Assertions.assertEquals(sparkTemplateUpdateDTO, deserDTO);
+  }
+
+  @Test
+  public void testDeserializeShellTemplateUpdate() throws JsonProcessingException {
+    String json =
+        "{"
+            + "\"@type\":\"shell\","
+            + "\"newExecutable\":\"/bin/bash\","
+            + "\"newArguments\":[\"-c\",\"echo Hello World\"],"
+            + "\"newEnvironments\":{\"ENV_VAR\":\"value\"},"
+            + "\"newCustomFields\":{\"customKey\":\"customValue\"},"
+            + "\"newScripts\":[\"/path/to/script1.sh\",\"/path/to/script2.sh\"]"
+            + "}";
+
+    TemplateUpdateDTO dto = JsonUtils.objectMapper().readValue(json, TemplateUpdateDTO.class);
+    Assertions.assertInstanceOf(ShellTemplateUpdateDTO.class, dto);
+    ShellTemplateUpdateDTO shellDto = (ShellTemplateUpdateDTO) dto;
+    Assertions.assertEquals("/bin/bash", shellDto.getNewExecutable());
+    Assertions.assertEquals(ImmutableList.of("-c", "echo Hello World"), shellDto.getNewArguments());
+    Assertions.assertEquals(ImmutableMap.of("ENV_VAR", "value"), shellDto.getNewEnvironments());
+    Assertions.assertEquals(
+        ImmutableMap.of("customKey", "customValue"), shellDto.getNewCustomFields());
+    Assertions.assertEquals(
+        ImmutableList.of("/path/to/script1.sh", "/path/to/script2.sh"), shellDto.getNewScripts());
+
+    json =
+        "{"
+            + "\"@type\":\"shell\","
+            + "\"newEnvironments\":{\"ENV_VAR\":\"value\"},"
+            + "\"newCustomFields\":{\"customKey\":\"customValue\"},"
+            + "\"newScripts\":[\"/path/to/script1.sh\",\"/path/to/script2.sh\"]"
+            + "}";
+
+    dto = JsonUtils.objectMapper().readValue(json, TemplateUpdateDTO.class);
+    Assertions.assertInstanceOf(ShellTemplateUpdateDTO.class, dto);
+    shellDto = (ShellTemplateUpdateDTO) dto;
+    Assertions.assertNull(shellDto.getNewExecutable());
+    Assertions.assertNull(shellDto.getNewArguments());
+
+    json =
+        "{"
+            + "\"@type\":\"shell\","
+            + "\"newScripts\":[\"/path/to/script1.sh\",\"/path/to/script2.sh\"]"
+            + "}";
+
+    dto = JsonUtils.objectMapper().readValue(json, TemplateUpdateDTO.class);
+    Assertions.assertInstanceOf(ShellTemplateUpdateDTO.class, dto);
+    shellDto = (ShellTemplateUpdateDTO) dto;
+    Assertions.assertNull(shellDto.getNewEnvironments());
+    Assertions.assertNull(shellDto.getNewCustomFields());
+    Assertions.assertEquals(
+        ImmutableList.of("/path/to/script1.sh", "/path/to/script2.sh"), shellDto.getNewScripts());
+
+    json = "{" + "\"@type\":\"shell\"" + "}";
+
+    dto = JsonUtils.objectMapper().readValue(json, TemplateUpdateDTO.class);
+    Assertions.assertInstanceOf(ShellTemplateUpdateDTO.class, dto);
+    shellDto = (ShellTemplateUpdateDTO) dto;
+    Assertions.assertNull(shellDto.getNewScripts());
+  }
+
+  @Test
+  public void testDeserializeSparkTemplateUpdate() throws JsonProcessingException {
+    String json =
+        "{"
+            + "\"@type\":\"spark\","
+            + "\"newExecutable\":\"spark-submit\","
+            + "\"newArguments\":[\"--class\",\"org.example.Main\"],"
+            + "\"newEnvironments\":{\"SPARK_ENV\":\"prod\"},"
+            + "\"newCustomFields\":{\"customKey\":\"customValue\"},"
+            + "\"newClassName\":\"org.example.Main\","
+            + "\"newJars\":[\"/path/to/jar1.jar\",\"/path/to/jar2.jar\"],"
+            + "\"newFiles\":[\"/path/to/file1.txt\",\"/path/to/file2.txt\"],"
+            + "\"newArchives\":[\"/path/to/archive1.zip\",\"/path/to/archive2.zip\"],"
+            + "\"newConfigs\":{\"spark.executor.memory\":\"4g\"}"
+            + "}";
+
+    TemplateUpdateDTO dto = JsonUtils.objectMapper().readValue(json, TemplateUpdateDTO.class);
+    Assertions.assertInstanceOf(SparkTemplateUpdateDTO.class, dto);
+    SparkTemplateUpdateDTO sparkDto = (SparkTemplateUpdateDTO) dto;
+    Assertions.assertEquals("spark-submit", sparkDto.getNewExecutable());
+    Assertions.assertEquals(
+        ImmutableList.of("--class", "org.example.Main"), sparkDto.getNewArguments());
+    Assertions.assertEquals(ImmutableMap.of("SPARK_ENV", "prod"), sparkDto.getNewEnvironments());
+    Assertions.assertEquals(
+        ImmutableMap.of("customKey", "customValue"), sparkDto.getNewCustomFields());
+    Assertions.assertEquals("org.example.Main", sparkDto.getNewClassName());
+    Assertions.assertEquals(
+        ImmutableList.of("/path/to/jar1.jar", "/path/to/jar2.jar"), sparkDto.getNewJars());
+    Assertions.assertEquals(
+        ImmutableList.of("/path/to/file1.txt", "/path/to/file2.txt"), sparkDto.getNewFiles());
+    Assertions.assertEquals(
+        ImmutableList.of("/path/to/archive1.zip", "/path/to/archive2.zip"),
+        sparkDto.getNewArchives());
+    Assertions.assertEquals(
+        ImmutableMap.of("spark.executor.memory", "4g"), sparkDto.getNewConfigs());
+
+    json =
+        "{"
+            + "\"@type\":\"spark\","
+            + "\"newEnvironments\":{\"SPARK_ENV\":\"prod\"},"
+            + "\"newCustomFields\":{\"customKey\":\"customValue\"},"
+            + "\"newClassName\":\"org.example.Main\","
+            + "\"newJars\":[\"/path/to/jar1.jar\",\"/path/to/jar2.jar\"],"
+            + "\"newFiles\":[\"/path/to/file1.txt\",\"/path/to/file2.txt\"],"
+            + "\"newArchives\":[\"/path/to/archive1.zip\",\"/path/to/archive2.zip\"],"
+            + "\"newConfigs\":{\"spark.executor.memory\":\"4g\"}"
+            + "}";
+
+    dto = JsonUtils.objectMapper().readValue(json, TemplateUpdateDTO.class);
+    Assertions.assertInstanceOf(SparkTemplateUpdateDTO.class, dto);
+    sparkDto = (SparkTemplateUpdateDTO) dto;
+    Assertions.assertNull(sparkDto.getNewExecutable());
+    Assertions.assertNull(sparkDto.getNewArguments());
+    Assertions.assertEquals(ImmutableMap.of("SPARK_ENV", "prod"), sparkDto.getNewEnvironments());
+    Assertions.assertEquals(
+        ImmutableMap.of("customKey", "customValue"), sparkDto.getNewCustomFields());
+    Assertions.assertEquals("org.example.Main", sparkDto.getNewClassName());
+    Assertions.assertEquals(
+        ImmutableList.of("/path/to/jar1.jar", "/path/to/jar2.jar"), sparkDto.getNewJars());
+    Assertions.assertEquals(
+        ImmutableList.of("/path/to/file1.txt", "/path/to/file2.txt"), sparkDto.getNewFiles());
+    Assertions.assertEquals(
+        ImmutableList.of("/path/to/archive1.zip", "/path/to/archive2.zip"),
+        sparkDto.getNewArchives());
+    Assertions.assertEquals(
+        ImmutableMap.of("spark.executor.memory", "4g"), sparkDto.getNewConfigs());
+
+    json =
+        "{"
+            + "\"@type\":\"spark\","
+            + "\"newClassName\":\"org.example.Main\","
+            + "\"newJars\":[\"/path/to/jar1.jar\",\"/path/to/jar2.jar\"],"
+            + "\"newFiles\":[\"/path/to/file1.txt\",\"/path/to/file2.txt\"],"
+            + "\"newArchives\":[\"/path/to/archive1.zip\",\"/path/to/archive2.zip\"],"
+            + "\"newConfigs\":{\"spark.executor.memory\":\"4g\"}"
+            + "}";
+
+    dto = JsonUtils.objectMapper().readValue(json, TemplateUpdateDTO.class);
+    Assertions.assertInstanceOf(SparkTemplateUpdateDTO.class, dto);
+    sparkDto = (SparkTemplateUpdateDTO) dto;
+    Assertions.assertNull(sparkDto.getNewExecutable());
+    Assertions.assertNull(sparkDto.getNewArguments());
+    Assertions.assertNull(sparkDto.getNewEnvironments());
+    Assertions.assertNull(sparkDto.getNewCustomFields());
+
+    json = "{" + "\"@type\":\"spark\"," + "\"newConfigs\":{\"spark.executor.memory\":\"4g\"}" + "}";
+
+    dto = JsonUtils.objectMapper().readValue(json, TemplateUpdateDTO.class);
+    Assertions.assertInstanceOf(SparkTemplateUpdateDTO.class, dto);
+    sparkDto = (SparkTemplateUpdateDTO) dto;
+    Assertions.assertNull(sparkDto.getNewClassName());
+    Assertions.assertNull(sparkDto.getNewJars());
+    Assertions.assertNull(sparkDto.getNewFiles());
+    Assertions.assertNull(sparkDto.getNewArchives());
+    Assertions.assertEquals(
+        ImmutableMap.of("spark.executor.memory", "4g"), sparkDto.getNewConfigs());
+
+    json = "{" + "\"@type\":\"spark\"" + "}";
+
+    dto = JsonUtils.objectMapper().readValue(json, TemplateUpdateDTO.class);
+    Assertions.assertInstanceOf(SparkTemplateUpdateDTO.class, dto);
+    sparkDto = (SparkTemplateUpdateDTO) dto;
+    Assertions.assertNull(sparkDto.getNewConfigs());
+    Assertions.assertNull(sparkDto.getNewClassName());
+    Assertions.assertNull(sparkDto.getNewJars());
+    Assertions.assertNull(sparkDto.getNewFiles());
+    Assertions.assertNull(sparkDto.getNewArchives());
+    Assertions.assertNull(sparkDto.getNewExecutable());
+    Assertions.assertNull(sparkDto.getNewArguments());
+    Assertions.assertNull(sparkDto.getNewEnvironments());
+    Assertions.assertNull(sparkDto.getNewCustomFields());
+  }
+}

--- a/common/src/test/java/org/apache/gravitino/dto/requests/TestJobTemplateUpdatesRequest.java
+++ b/common/src/test/java/org/apache/gravitino/dto/requests/TestJobTemplateUpdatesRequest.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.dto.requests;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.google.common.collect.ImmutableList;
+import org.apache.gravitino.dto.job.ShellTemplateUpdateDTO;
+import org.apache.gravitino.json.JsonUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TestJobTemplateUpdatesRequest {
+
+  @Test
+  public void testSerDeRequest() throws JsonProcessingException {
+    JobTemplateUpdateRequest renameReq =
+        new JobTemplateUpdateRequest.RenameJobTemplateRequest("new_template_name");
+    JobTemplateUpdateRequest updateCommentReq =
+        new JobTemplateUpdateRequest.UpdateJobTemplateCommentRequest("Updated comment");
+    JobTemplateUpdateRequest updateContentReq =
+        new JobTemplateUpdateRequest.UpdateJobTemplateContentRequest(
+            ShellTemplateUpdateDTO.builder().withNewExecutable("/bin/bash").build());
+
+    JobTemplateUpdatesRequest request =
+        new JobTemplateUpdatesRequest(
+            ImmutableList.of(renameReq, updateCommentReq, updateContentReq));
+
+    String json = JsonUtils.objectMapper().writeValueAsString(request);
+    JobTemplateUpdatesRequest deserializedRequest =
+        JsonUtils.objectMapper().readValue(json, JobTemplateUpdatesRequest.class);
+
+    Assertions.assertEquals(request, deserializedRequest);
+    Assertions.assertTrue(deserializedRequest.getUpdates().contains(renameReq));
+    Assertions.assertTrue(deserializedRequest.getUpdates().contains(updateCommentReq));
+    Assertions.assertTrue(deserializedRequest.getUpdates().contains(updateContentReq));
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/job/JobManager.java
+++ b/core/src/main/java/org/apache/gravitino/job/JobManager.java
@@ -301,6 +301,40 @@ public class JobManager implements JobOperationDispatcher {
   }
 
   @Override
+  public JobTemplateEntity alterJobTemplate(
+      String metalake, String jobTemplateName, JobTemplateChange... changes)
+      throws NoSuchJobTemplateException, IllegalArgumentException {
+    checkMetalake(NameIdentifierUtil.ofMetalake(metalake), entityStore);
+
+    NameIdentifier jobTemplateIdent = NameIdentifierUtil.ofJobTemplate(metalake, jobTemplateName);
+    return TreeLockUtils.doWithTreeLock(
+        jobTemplateIdent,
+        LockType.WRITE,
+        () -> {
+          try {
+            return entityStore.update(
+                jobTemplateIdent,
+                JobTemplateEntity.class,
+                Entity.EntityType.JOB_TEMPLATE,
+                jobTemplateEntity ->
+                    updateJobTemplateEntity(jobTemplateIdent, jobTemplateEntity, changes));
+          } catch (NoSuchEntityException e) {
+            throw new NoSuchJobTemplateException(
+                "Job template with name %s under metalake %s does not exist",
+                jobTemplateName, metalake);
+          } catch (IOException ioe) {
+            throw new RuntimeException(ioe);
+          } catch (EntityAlreadyExistsException e) {
+            throw new RuntimeException(
+                "Job template with the same name "
+                    + jobTemplateName
+                    + " already exists, this is unexpected because job template doesn't support rename",
+                e);
+          }
+        });
+  }
+
+  @Override
   public List<JobEntity> listJobs(String metalake, Optional<String> jobTemplateName)
       throws NoSuchJobTemplateException {
     checkMetalake(NameIdentifierUtil.ofMetalake(metalake), entityStore);
@@ -761,5 +795,126 @@ public class JobManager implements JobOperationDispatcher {
     } catch (IOException e) {
       throw new RuntimeException("Failed to list in-use metalakes", e);
     }
+  }
+
+  @VisibleForTesting
+  JobTemplateEntity updateJobTemplateEntity(
+      NameIdentifier jobTemplateIdent,
+      JobTemplateEntity jobTemplateEntity,
+      JobTemplateChange... changes) {
+    String newName = jobTemplateEntity.name();
+    String newComment = jobTemplateEntity.comment();
+    JobTemplateEntity.Builder newTemplateBuilder = JobTemplateEntity.builder();
+    JobTemplateEntity.TemplateContent.TemplateContentBuilder newTemplateContentBuilder =
+        JobTemplateEntity.TemplateContent.builder()
+            .withJobType(jobTemplateEntity.templateContent().jobType())
+            .withExecutable(jobTemplateEntity.templateContent().executable())
+            .withArguments(jobTemplateEntity.templateContent().arguments())
+            .withEnvironments(jobTemplateEntity.templateContent().environments())
+            .withCustomFields(jobTemplateEntity.templateContent().customFields())
+            .withScripts(jobTemplateEntity.templateContent().scripts())
+            .withClassName(jobTemplateEntity.templateContent().className())
+            .withJars(jobTemplateEntity.templateContent().jars())
+            .withFiles(jobTemplateEntity.templateContent().files())
+            .withArchives(jobTemplateEntity.templateContent().archives())
+            .withConfigs(jobTemplateEntity.templateContent().configs());
+
+    for (JobTemplateChange change : changes) {
+      if (change instanceof JobTemplateChange.RenameJobTemplate) {
+        newName = ((JobTemplateChange.RenameJobTemplate) change).getNewName();
+
+      } else if (change instanceof JobTemplateChange.UpdateJobTemplateComment) {
+        newComment = ((JobTemplateChange.UpdateJobTemplateComment) change).getNewComment();
+
+      } else if (change instanceof JobTemplateChange.UpdateJobTemplate) {
+        JobTemplateEntity.TemplateContent oldTemplateContent = jobTemplateEntity.templateContent();
+        JobTemplateChange.TemplateUpdate templateUpdate =
+            ((JobTemplateChange.UpdateJobTemplate) change).getTemplateUpdate();
+        newTemplateContentBuilder
+            .withJobType(oldTemplateContent.jobType())
+            .withExecutable(
+                updatedValue(
+                    oldTemplateContent.executable(),
+                    Optional.ofNullable(templateUpdate.getNewExecutable())))
+            .withArguments(
+                updatedValue(
+                    oldTemplateContent.arguments(),
+                    Optional.ofNullable(templateUpdate.getNewArguments())))
+            .withEnvironments(
+                updatedValue(
+                    oldTemplateContent.environments(),
+                    Optional.ofNullable(templateUpdate.getNewEnvironments())))
+            .withCustomFields(
+                updatedValue(
+                    oldTemplateContent.customFields(),
+                    Optional.ofNullable(templateUpdate.getNewCustomFields())));
+
+        if (templateUpdate instanceof JobTemplateChange.ShellTemplateUpdate) {
+          Preconditions.checkArgument(
+              jobTemplateEntity.templateContent().jobType() == JobTemplate.JobType.SHELL,
+              "Job template %s is not a shell job template, cannot update to shell template",
+              jobTemplateIdent.name());
+
+          JobTemplateChange.ShellTemplateUpdate shellUpdate =
+              (JobTemplateChange.ShellTemplateUpdate) templateUpdate;
+          newTemplateContentBuilder.withScripts(
+              updatedValue(
+                  oldTemplateContent.scripts(), Optional.ofNullable(shellUpdate.getNewScripts())));
+
+        } else if (templateUpdate instanceof JobTemplateChange.SparkTemplateUpdate) {
+          Preconditions.checkArgument(
+              jobTemplateEntity.templateContent().jobType() == JobTemplate.JobType.SPARK,
+              "Job template %s is not a spark job template, cannot update to spark template",
+              jobTemplateIdent.name());
+
+          JobTemplateChange.SparkTemplateUpdate sparkUpdate =
+              (JobTemplateChange.SparkTemplateUpdate) templateUpdate;
+          newTemplateContentBuilder
+              .withClassName(
+                  updatedValue(
+                      oldTemplateContent.className(),
+                      Optional.ofNullable(sparkUpdate.getNewClassName())))
+              .withJars(
+                  updatedValue(
+                      oldTemplateContent.jars(), Optional.ofNullable(sparkUpdate.getNewJars())))
+              .withFiles(
+                  updatedValue(
+                      oldTemplateContent.files(), Optional.ofNullable(sparkUpdate.getNewFiles())))
+              .withArchives(
+                  updatedValue(
+                      oldTemplateContent.archives(),
+                      Optional.ofNullable(sparkUpdate.getNewArchives())))
+              .withConfigs(
+                  updatedValue(
+                      oldTemplateContent.configs(),
+                      Optional.ofNullable(sparkUpdate.getNewConfigs())));
+
+        } else {
+          throw new IllegalArgumentException("Unsupported template update: " + templateUpdate);
+        }
+
+      } else {
+        throw new IllegalArgumentException("Unsupported job template change: " + change);
+      }
+    }
+
+    return newTemplateBuilder
+        .withId(jobTemplateEntity.id())
+        .withName(newName)
+        .withComment(newComment)
+        .withNamespace(jobTemplateIdent.namespace())
+        .withTemplateContent(newTemplateContentBuilder.build())
+        .withAuditInfo(
+            AuditInfo.builder()
+                .withCreator(jobTemplateEntity.auditInfo().creator())
+                .withCreateTime(jobTemplateEntity.auditInfo().createTime())
+                .withLastModifier(PrincipalUtils.getCurrentPrincipal().getName())
+                .withLastModifiedTime(Instant.now())
+                .build())
+        .build();
+  }
+
+  private <T> T updatedValue(T currentValue, Optional<T> newValue) {
+    return newValue.orElse(currentValue);
   }
 }

--- a/core/src/main/java/org/apache/gravitino/job/JobOperationDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/job/JobOperationDispatcher.java
@@ -74,6 +74,20 @@ public interface JobOperationDispatcher extends Closeable {
   boolean deleteJobTemplate(String metalake, String jobTemplateName) throws InUseException;
 
   /**
+   * Alters a job template by applying the specified changes in the specified metalake.
+   *
+   * @param metalake the name of the metalake
+   * @param jobTemplateName the name of the job template to alter
+   * @param changes the changes to apply to the job template
+   * @return the updated job template entity after applying the changes
+   * @throws NoSuchJobTemplateException if no job template with the specified name exists
+   * @throws IllegalArgumentException if any of the changes cannot be applied to the job template.
+   */
+  JobTemplateEntity alterJobTemplate(
+      String metalake, String jobTemplateName, JobTemplateChange... changes)
+      throws NoSuchJobTemplateException, IllegalArgumentException;
+
+  /**
    * List all the jobs. If the jobTemplateName is provided, it will list the jobs associated with
    * that job template, if not, it will list all the jobs in the specified metalake.
    *

--- a/core/src/main/java/org/apache/gravitino/job/local/LocalJobExecutor.java
+++ b/core/src/main/java/org/apache/gravitino/job/local/LocalJobExecutor.java
@@ -316,7 +316,7 @@ public class LocalJobExecutor implements JobExecutor {
         jobExecutorService.submit(() -> runJob(jobPair));
 
       } catch (InterruptedException e) {
-        LOG.warn("Polling job interrupted", e);
+        LOG.warn("Polling job interrupted");
         finished = true;
       }
     }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/JDBCBackend.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/JDBCBackend.java
@@ -239,6 +239,8 @@ public class JDBCBackend implements RelationalBackend {
         return (E) ModelVersionMetaService.getInstance().updateModelVersion(ident, updater);
       case POLICY:
         return (E) PolicyMetaService.getInstance().updatePolicy(ident, updater);
+      case JOB_TEMPLATE:
+        return (E) JobTemplateMetaService.getInstance().updateJobTemplate(ident, updater);
       default:
         throw new UnsupportedEntityTypeException(
             "Unsupported entity type: %s for update operation", entityType);

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/JobTemplateMetaMapper.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/JobTemplateMetaMapper.java
@@ -65,4 +65,9 @@ public interface JobTemplateMetaMapper {
       method = "deleteJobTemplateMetasByLegacyTimeline")
   Integer deleteJobTemplateMetasByLegacyTimeline(
       @Param("legacyTimeline") Long legacyTimeline, @Param("limit") int limit);
+
+  @UpdateProvider(type = JobTemplateMetaSQLProviderFactory.class, method = "updateJobTemplateMeta")
+  Integer updateJobTemplateMeta(
+      @Param("newJobTemplateMeta") JobTemplatePO newJobTemplatePO,
+      @Param("oldJobTemplateMeta") JobTemplatePO oldJobTemplatePO);
 }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/JobTemplateMetaSQLProviderFactory.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/JobTemplateMetaSQLProviderFactory.java
@@ -87,4 +87,10 @@ public class JobTemplateMetaSQLProviderFactory {
       @Param("legacyTimeline") Long legacyTimeline, @Param("limit") int limit) {
     return getProvider().deleteJobTemplateMetasByLegacyTimeline(legacyTimeline, limit);
   }
+
+  public static String updateJobTemplateMeta(
+      @Param("newJobTemplateMeta") JobTemplatePO newJobTemplatePO,
+      @Param("oldJobTemplateMeta") JobTemplatePO oldJobTemplatePO) {
+    return getProvider().updateJobTemplateMeta(newJobTemplatePO, oldJobTemplatePO);
+  }
 }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/JobTemplateMetaBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/JobTemplateMetaBaseSQLProvider.java
@@ -120,4 +120,25 @@ public class JobTemplateMetaBaseSQLProvider {
         + JobTemplateMetaMapper.TABLE_NAME
         + " WHERE deleted_at < #{legacyTimeline} AND deleted_at > 0 LIMIT #{limit}";
   }
+
+  public String updateJobTemplateMeta(
+      @Param("newJobTemplateMeta") JobTemplatePO newJobTemplatePO,
+      @Param("oldJobTemplateMeta") JobTemplatePO oldJobTemplatePO) {
+    return "UPDATE "
+        + JobTemplateMetaMapper.TABLE_NAME
+        + " SET job_template_name = #{newJobTemplateMeta.jobTemplateName},"
+        + " metalake_id = #{newJobTemplateMeta.metalakeId},"
+        + " job_template_comment = #{newJobTemplateMeta.jobTemplateComment},"
+        + " job_template_content = #{newJobTemplateMeta.jobTemplateContent},"
+        + " audit_info = #{newJobTemplateMeta.auditInfo},"
+        + " current_version = #{newJobTemplateMeta.currentVersion},"
+        + " last_version = #{newJobTemplateMeta.lastVersion},"
+        + " deleted_at = #{newJobTemplateMeta.deletedAt}"
+        + " WHERE job_template_id = #{oldJobTemplateMeta.jobTemplateId}"
+        + " AND job_template_name = #{oldJobTemplateMeta.jobTemplateName}"
+        + " AND metalake_id = #{oldJobTemplateMeta.metalakeId}"
+        + " AND current_version = #{oldJobTemplateMeta.currentVersion}"
+        + " AND last_version = #{oldJobTemplateMeta.lastVersion}"
+        + " AND deleted_at = 0";
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds the server-side REST interface for job template alteration.

### Why are the changes needed?

This is a part of work to support job template alteration.

Fix: #8640 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

UTs added.
