### PR TITLE
[#8731] fix(policy): PolicyUpdateRequest.validate checks for null policyType

### DIFF
--- a/common/src/main/java/org/apache/gravitino/dto/requests/PolicyUpdateRequest.java
+++ b/common/src/main/java/org/apache/gravitino/dto/requests/PolicyUpdateRequest.java
@@ -167,6 +167,7 @@ public interface PolicyUpdateRequest extends RESTRequest {
 
     @Override
     public void validate() throws IllegalArgumentException {
+      Preconditions.checkArgument(policyType != null, "\"policyType\" must not be null");
       Preconditions.checkArgument(newContent != null, "\"newContent\" must not be null");
       newContent.validate();
     }


### PR DESCRIPTION
**Description:**

This Pull Request implements the improvement requested in issue #8731.

**The change:**
A validation check has been added to the **`validate()`** method of the inner class **`UpdatePolicyContentRequest`** (found in `PolicyUpdateRequest.java`) to ensure that the **`policyType` field is not null**.

The check uses `Preconditions.checkArgument(policyType != null, "\"policyType\" must not be null")` to align with the existing validation patterns in the class.

**Closes Issue:** Fixes #8731