### PR TITLE
[#8656] Improvement: add UTs and fix a NPE in TableUpdatesRequest.java 

### DIFF
--- a/common/src/main/java/org/apache/gravitino/dto/requests/TableUpdateRequest.java
+++ b/common/src/main/java/org/apache/gravitino/dto/requests/TableUpdateRequest.java
@@ -815,7 +815,7 @@ public interface TableUpdateRequest extends RESTRequest {
      */
     @Override
     public void validate() throws IllegalArgumentException {
-      Preconditions.checkNotNull(index, "Index cannot be null");
+      Preconditions.checkArgument(index != null, "Index cannot be null");
       Preconditions.checkArgument(index.type() != null, "Index type cannot be null");
       Preconditions.checkArgument(
           index.fieldNames() != null && index.fieldNames().length > 0,
@@ -861,7 +861,7 @@ public interface TableUpdateRequest extends RESTRequest {
      */
     @Override
     public void validate() throws IllegalArgumentException {
-      Preconditions.checkNotNull(name, "Index name cannot be null");
+      Preconditions.checkArgument(name != null, "Index name cannot be null");
     }
 
     /** @return An instance of TableChange. */


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add UTs for TableUpdatesRequest.java validate method.
Also There are 2 validate methods throw NPE when arguments is invalid.
### Why are the changes needed?

Add UTs to make sure validate logic.

Fix: #8656

### Does this PR introduce _any_ user-facing change?
NO

### How was this patch tested?

Passed all UTs