### PR TITLE
[#8741] improvement(catalog-common): Unload common logging in htrace.

### DIFF
--- a/catalogs/catalog-common/src/main/java/org/apache/gravitino/utils/ClassLoaderResourceCleanerUtils.java
+++ b/catalogs/catalog-common/src/main/java/org/apache/gravitino/utils/ClassLoaderResourceCleanerUtils.java
@@ -221,6 +221,19 @@ public class ClassLoaderResourceCleanerUtils {
    */
   private static void releaseLogFactoryInCommonLogging(ClassLoader currentClassLoader)
       throws Exception {
+
+    // If we use fileset with the local file system, HTrace will be used, so we need to
+    // release the HTrace LogFactory as well.
+    try {
+      Class<?> htraceLogFactoryClass =
+          Class.forName(
+              "org.apache.htrace.shaded.commons.logging.LogFactory", true, currentClassLoader);
+      MethodUtils.invokeStaticMethod(htraceLogFactoryClass, "release", currentClassLoader);
+    } catch (Exception e) {
+      // Ignore if htrace is not used
+      LOG.debug("HTrace is not used, skipping release of HTrace LogFactory...");
+    }
+
     // Release the LogFactory for the FilesetCatalogOperations class loader
     Class<?> logFactoryClass =
         Class.forName("org.apache.commons.logging.LogFactory", true, currentClassLoader);


### PR DESCRIPTION

### What changes were proposed in this pull request?

Unloaded common logging in htrace when catalogs are about to close.

### Why are the changes needed?

We need to unload it or the class loader that loads it will not be cleaned

Fix: #8741 

### Does this PR introduce _any_ user-facing change?

N/A.

### How was this patch tested?

Test locally.
