### PR TITLE
[#8006]Improvement(DorisUtils): fix bucket count parsing in DorisUtils

### DIFF
--- a/catalogs/catalog-jdbc-doris/src/main/java/org/apache/gravitino/catalog/doris/utils/DorisUtils.java
+++ b/catalogs/catalog-jdbc-doris/src/main/java/org/apache/gravitino/catalog/doris/utils/DorisUtils.java
@@ -49,7 +49,8 @@ public final class DorisUtils {
 
   private static final Pattern DISTRIBUTION_INFO_PATTERN =
       Pattern.compile(
-          "DISTRIBUTED BY\\s+(HASH|RANDOM)\\s*(\\(([^)]+)\\))?\\s*(BUCKETS\\s+(\\d+|AUTO))?");
+          "DISTRIBUTED BY\\s+(HASH|RANDOM)\\s*(\\(([^)]+)\\))?(?:\\s*BUCKETS\\s+(\\d+|AUTO))?",
+          Pattern.CASE_INSENSITIVE);
 
   private static final String LIST_PARTITION = "LIST";
   private static final String RANGE_PARTITION = "RANGE";
@@ -221,8 +222,8 @@ public final class DorisUtils {
 
   private static int extractBucketNum(Matcher matcher) {
     int bucketNum = 1;
-    if (matcher.group(5) != null) {
-      String bucketValue = matcher.group(5);
+    if (matcher.group(4) != null) {
+      String bucketValue = matcher.group(4);
       // Use -1 to indicate auto bucket.
       bucketNum =
           bucketValue.trim().toUpperCase().equals("AUTO")

--- a/catalogs/catalog-jdbc-doris/src/test/java/org/apache/gravitino/catalog/doris/utils/TestDorisUtils.java
+++ b/catalogs/catalog-jdbc-doris/src/test/java/org/apache/gravitino/catalog/doris/utils/TestDorisUtils.java
@@ -191,4 +191,18 @@ public class TestDorisUtils {
         DorisUtils.extractDistributionInfoFromSql(createTableSqlWithRandomAuto);
     assertEquals(distribution3.number(), -1);
   }
+
+  @Test
+  public void testExtractBucketNumFromSql() {
+    String createTableSql =
+        "CREATE TABLE `testTable` (\n`col1` int NOT NULL\n) ENGINE=OLAP\n DISTRIBUTED BY HASH(`col1`) BUCKETS 8";
+    Distribution distribution = DorisUtils.extractDistributionInfoFromSql(createTableSql);
+    assertEquals(8, distribution.number());
+
+    String createTableSqlWithoutBucket =
+        "CREATE TABLE `testTable` (\n`col1` int NOT NULL\n) ENGINE=OLAP\n DISTRIBUTED BY HASH(`col1`)";
+    Distribution distributionDefault =
+        DorisUtils.extractDistributionInfoFromSql(createTableSqlWithoutBucket);
+    assertEquals(1, distributionDefault.number());
+  }
 }


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

updated the Regex Pattern to capture the bucket details.

- Ensure the regex matches both with and without BUCKETS.
- If the regex matches but BUCKETS is missing, default to 1.

### Why are the changes needed?

To fix the bucket count parsing in DorisUtils. The current regex expects BUCKETS to always be present, but in the absence of BUCKETS, the code should default to 1.
The code already defaults to 1 if [matcher.group(5)] is null, but the regex may not always match if BUCKETS is missing, causing the method to throw an exception.

Fix: (#8006)

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
unit testing
