### PR TITLE
[#8748] Improvement: replace with proper exec run of the server process

### DIFF
--- a/dev/docker/iceberg-rest-server/iceberg-rest-server-dependency.sh
+++ b/dev/docker/iceberg-rest-server/iceberg-rest-server-dependency.sh
@@ -73,10 +73,3 @@ cp bundles/*jar ${iceberg_rest_server_dir}/packages/gravitino-iceberg-rest-serve
 
 cp start-iceberg-rest-server.sh ${iceberg_rest_server_dir}/packages/gravitino-iceberg-rest-server/bin/
 cp rewrite_config.py ${iceberg_rest_server_dir}/packages/gravitino-iceberg-rest-server/bin/
-
-# Keeping the container running at all times
-cat <<EOF >> "${iceberg_rest_server_dir}/packages/gravitino-iceberg-rest-server/bin/gravitino-iceberg-rest-server.sh"
-
-# Keeping a process running in the background
-tail -f /dev/null
-EOF

--- a/dev/docker/iceberg-rest-server/start-iceberg-rest-server.sh
+++ b/dev/docker/iceberg-rest-server/start-iceberg-rest-server.sh
@@ -26,4 +26,4 @@ cd ${iceberg_rest_server_dir}
 
 python bin/rewrite_config.py
 
-./bin/gravitino-iceberg-rest-server.sh start
+exec ./bin/gravitino-iceberg-rest-server.sh run


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Replace the dummy tail -f /dev/null with an exec call that directly runs the server in the foreground.

### Why are the changes needed?

Fix: #8748

### Does this PR introduce _any_ user-facing change?

(Please list the user-facing changes introduced by your change, including
  1. Change in user-facing APIs.
  2. Addition or removal of property keys.)

### How was this patch tested?

(Please test your changes, and provide instructions on how to test it:
  1. If you add a feature or fix a bug, add a test to cover your changes.
  2. If you fix a flaky test, repeat it for many times to prove it works.)
