### PR TITLE
sanitize gravitino-catalog metrics

### DIFF
--- a/core/src/main/java/org/apache/gravitino/metrics/GravitinoSampleBuilder.java
+++ b/core/src/main/java/org/apache/gravitino/metrics/GravitinoSampleBuilder.java
@@ -82,10 +82,10 @@ public class GravitinoSampleBuilder extends CustomMappingSampleBuilder {
       String provider = matcher.group(1);
       String metalake = matcher.group(2);
       String catalog = matcher.group(3);
-      // Replace '.' with '_' in the remaining part to conform to Prometheus naming conventions
-      String metricNameRest = matcher.group(4).replace('.', '_');
-
-      String prometheusName = GRAVITINO_CATALOG_METRIC_PREFIX + "_" + metricNameRest;
+      // Use Prometheus client's sanitization to conform to naming conventions
+      String metricNameRest = Collector.sanitizeMetricName(matcher.group(4));
+      String sanitizedPrefix = Collector.sanitizeMetricName(GRAVITINO_CATALOG_METRIC_PREFIX);
+      String prometheusName = sanitizedPrefix + "_" + metricNameRest;
 
       List<String> labelNames = new ArrayList<>();
       labelNames.add("provider");


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

(Please outline the changes and how this PR fixes the issue.)

### Why are the changes needed?

Example gravitino-catalog metric from /prometheus/metrics endpoint: 
```
# TYPE gravitino-catalog_fileset-cache_loads-success summary
gravitino-catalog_fileset-cache_loads-success{provider="fileset",metalake="uber",catalog="ma",quantile="0.5",} 0.015295218000000001
```
which contains hyphen (-).

It does not conform prometheus standard - https://github.com/apache/gravitino/blob/caee8d20f5129dc22b7b3e7290091f619f590cbc/core/src/main/java/org/apache/gravitino/metrics/MetricsSystem.java#L189-L195

It causes errors when we parse the metrics from the endpoint.

(Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, describe the bug.)

Fix: #(issue) https://github.com/apache/gravitino/issues/8750

### Does this PR introduce _any_ user-facing change?

No

(Please list the user-facing changes introduced by your change, including
  1. Change in user-facing APIs.
  2. Addition or removal of property keys.)

### How was this patch tested?

Unit test added

(Please test your changes, and provide instructions on how to test it:
  1. If you add a feature or fix a bug, add a test to cover your changes.
  2. If you fix a flaky test, repeat it for many times to prove it works.)
