### PR TITLE
[#8754] build(iceberg-common): upgrade Hadoop dependencies to 3.3.1

### DIFF
--- a/iceberg/iceberg-common/build.gradle.kts
+++ b/iceberg/iceberg-common/build.gradle.kts
@@ -47,7 +47,7 @@ dependencies {
   implementation(libs.iceberg.azure)
   implementation(libs.iceberg.hive.metastore)
   implementation(libs.iceberg.gcp)
-  implementation(libs.hadoop2.common) {
+  implementation(libs.hadoop3.common) {
     exclude("com.github.spotbugs")
     exclude("com.sun.jersey")
     exclude("javax.servlet")
@@ -56,17 +56,15 @@ dependencies {
     exclude("org.mortbay.jetty")
   }
   // use hdfs-default.xml
-  implementation(libs.hadoop2.hdfs) {
+  implementation(libs.hadoop3.hdfs) {
     exclude("*")
   }
-  implementation(libs.hadoop2.hdfs.client) {
+  implementation(libs.hadoop3.client.api)
+  implementation(libs.hadoop3.client.runtime) {
     exclude("com.sun.jersey")
     exclude("javax.servlet")
     exclude("org.fusesource.leveldbjni")
     exclude("org.mortbay.jetty")
-  }
-  implementation(libs.hadoop2.mapreduce.client.core) {
-    exclude("*")
   }
   implementation(libs.hive2.metastore) {
     exclude("co.cask.tephra")


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?
Spark client on connecting to Icebeg Rest catalog in Gravitino gives the error:
```
	at org.apache.spark.deploy.SparkSubmit.main(SparkSubmit.scala)
Exception in thread "main" org.apache.iceberg.exceptions.ServiceFailureException: Server error: null: {
"servlet":"org.glassfish.jersey.servlet.ServletContainer-602f8f94",
"message":"org.glassfish.jersey.server.ContainerException: java.lang.NoSuchMethodError: &apos;void org.apache.hadoop.security.HadoopKerberosName.setRuleMechanism(java.lang.String)&apos;",
"url":"/iceberg/v1/config",
"status":"500"
}
```
Looking at the jars on Gravitino server, seems like there's a mix of hadoop 2.x and 3.x which is causing the class conflicts
```
kubectl exec deployment/gravitino -n hms3 -- find /r
oot -name "*hadoop*" -type f | head -10
/root/gravitino/iceberg-rest-server/libs/hadoop-auth-2.10.2.jar
/root/gravitino/iceberg-rest-server/libs/hadoop-hdfs-client-2.10.2.jar
/root/gravitino/iceberg-rest-server/libs/hadoop-hdfs-2.10.2.jar
/root/gravitino/iceberg-rest-server/libs/hadoop-common-2.10.2.jar
/root/gravitino/iceberg-rest-server/libs/gcs-connector-hadoop2-2.2.18-shaded.jar
/root/gravitino/iceberg-rest-server/libs/hadoop-mapreduce-client-core-2.10.2.jar
/root/gravitino/iceberg-rest-server/libs/hadoop-annotations-2.10.2.jar
/root/gravitino/authorizations/ranger/libs/hadoop-client-api-3.3.1.jar
/root/gravitino/authorizations/ranger/libs/hadoop-client-runtime-3.3.1.jar
/root/gravitino/catalogs/lakehouse-paimon/libs/hadoop-auth-2.10.2.jar
```

### Why are the changes needed?

Fix: #(issue)

### Does this PR introduce _any_ user-facing change?
No
### How was this patch tested?
Testing on spark-client, after the fix , is able to connect to the Gravitino server without the error stack.