### PR TITLE
Add NoSuchCatalogException handling to DeleteTopic command

### DIFF
--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/DeleteTopic.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/DeleteTopic.java
@@ -24,6 +24,7 @@ import org.apache.gravitino.cli.AreYouSure;
 import org.apache.gravitino.cli.CommandContext;
 import org.apache.gravitino.cli.ErrorMessages;
 import org.apache.gravitino.client.GravitinoClient;
+import org.apache.gravitino.exceptions.NoSuchCatalogException;
 import org.apache.gravitino.exceptions.NoSuchMetalakeException;
 import org.apache.gravitino.exceptions.NoSuchSchemaException;
 import org.apache.gravitino.exceptions.NoSuchTopicException;
@@ -76,6 +77,8 @@ public class DeleteTopic extends Command {
       deleted = client.loadCatalog(catalog).asTopicCatalog().dropTopic(name);
     } catch (NoSuchMetalakeException err) {
       exitWithError(ErrorMessages.UNKNOWN_METALAKE);
+    } catch (NoSuchCatalogException err) {
+      exitWithError(ErrorMessages.UNKNOWN_CATALOG);
     } catch (NoSuchSchemaException err) {
       exitWithError(ErrorMessages.UNKNOWN_SCHEMA);
     } catch (NoSuchTopicException err) {


### PR DESCRIPTION
Fixes #8660

### What changes were proposed in this pull request?

Add `NoSuchCatalogException` handling to the `DeleteTopic` command to provide clear error messages when attempting to delete a topic from a non-existent catalog. This aligns the exception handling with other Delete commands in the CLI module (`DeleteFileset`, `DeleteModel`, `DeleteSchema`, etc.).

### Why are the changes needed?

- The `DeleteTopic.handle()` method was missing explicit handling for `NoSuchCatalogException`, which could result in generic error messages instead of the user-friendly `ErrorMessages.UNKNOWN_CATALOG` message
- All other Delete commands (`DeleteFileset`, `DeleteModel`, `DeleteSchema`, etc.) consistently handle `NoSuchCatalogException` with the same pattern
- This change ensures consistent error messaging across all CLI Delete commands, improving user experience when errors occur

### Does this PR introduce _any_ user-facing change?

Yes, but only for error scenarios. When a user attempts to delete a topic from a non-existent catalog, they will now see a clear error message (`"Unknown catalog name."`) instead of a generic exception message. Valid operations remain unchanged.

### How was this patch tested?

- Existing unit tests (`testDeleteTopicCommand`, `testDeleteTopicForceCommand`) continue to pass, ensuring no functional regression
- Local testing completed successfully with Gradle build and Spotless formatting
- **Note on test coverage:** Following the project's established testing pattern, unit tests for Delete commands focus on command routing and invocation verification using mocks. Exception handling logic (including `NoSuchCatalogException`, `NoSuchMetalakeException`, `NoSuchSchemaException`) is consistently not unit-tested across all CLI Delete commands (`DeleteRole`, `DeleteModel`, `DeleteFileset`, etc.). This PR maintains that convention. If additional test coverage for exception handling is desired, I'm happy to add it—please let me know your preference.
