### PR TITLE
#8663. Add a precondition to check updates is not null in FilesetUpdatesRequest.java and a unit test

### DIFF
--- a/common/src/main/java/org/apache/gravitino/dto/requests/FilesetUpdatesRequest.java
+++ b/common/src/main/java/org/apache/gravitino/dto/requests/FilesetUpdatesRequest.java
@@ -41,6 +41,9 @@ public class FilesetUpdatesRequest implements RESTRequest {
 
   @Override
   public void validate() throws IllegalArgumentException {
+    if (updates == null) {
+      throw new IllegalArgumentException("Updates list cannot be null");
+    }
     updates.forEach(RESTMessage::validate);
   }
 }

--- a/common/src/test/java/org/apache/gravitino/dto/requests/TestFilesetUpdatesRequest.java
+++ b/common/src/test/java/org/apache/gravitino/dto/requests/TestFilesetUpdatesRequest.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.dto.requests;
+
+import java.util.Collections;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TestFilesetUpdatesRequest {
+
+  @Test
+  public void testValidateWithNullUpdates() {
+    // Test that creating a request with null updates throws an exception during validation
+    FilesetUpdatesRequest request = new FilesetUpdatesRequest(null);
+
+    final IllegalArgumentException exception =
+        Assertions.assertThrows(IllegalArgumentException.class, request::validate);
+
+    Assertions.assertEquals("Updates list cannot be null", exception.getMessage());
+  }
+
+  @Test
+  public void testValidateWithEmptyUpdates() {
+    // Test that a non-null but empty list of updates is valid
+    FilesetUpdatesRequest request = new FilesetUpdatesRequest(Collections.emptyList());
+
+    Assertions.assertDoesNotThrow(request::validate);
+  }
+}


### PR DESCRIPTION

<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?
I have added code to check that updates is not null in `common/src/main/java/org/apache/gravitino/dto/requests/FilesetUpdatesRequest.java` to avoid a `NullPointerException`. Additionally a unit test (in `common/src/test/java/org/apache/gravitino/dto/requests/TestFilesetUpdatesRequest.java`) to test the updates has been added. 


### Why are the changes needed?

Fix: The changes have been made per issue https://github.com/apache/gravitino/issues/8663

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

I have tested the updates through the added unit test by running `./gradlew :common:test --tests "org.apache.gravitino.dto.requests.TestFilesetUpdatesRequest"` in my computer. The test completes and I get a `BUILD SUCCESSFUL` message.

(Please test your changes, and provide instructions on how to test it:
  1. If you add a feature or fix a bug, add a test to cover your changes.
  2. If you fix a flaky test, repeat it for many times to prove it works.)
