### PR TITLE
[#7893] feat(authz): Enable the test catalog connection operation to support authorization.

### DIFF
--- a/clients/client-java/src/test/java/org/apache/gravitino/client/integration/test/authorization/CatalogAuthorizationIT.java
+++ b/clients/client-java/src/test/java/org/apache/gravitino/client/integration/test/authorization/CatalogAuthorizationIT.java
@@ -59,9 +59,17 @@ public class CatalogAuthorizationIT extends BaseRestApiAuthorizationIT {
 
   @Test
   @Order(1)
-  public void testCreateCatalog() {
+  public void testCreateCatalog() throws Exception {
     Map<String, String> properties = Maps.newHashMap();
     properties.put("metastore.uris", hmsUri);
+    assertThrows(
+        "Can not access metadata {" + catalog1 + "}.",
+        ForbiddenException.class,
+        () -> {
+          normalUserClient
+              .loadMetalake(METALAKE)
+              .testConnection(catalog1, Catalog.Type.RELATIONAL, "hive", "comment", properties);
+        });
     assertThrows(
         "Can not access metadata {" + catalog1 + "}.",
         ForbiddenException.class,
@@ -72,7 +80,13 @@ public class CatalogAuthorizationIT extends BaseRestApiAuthorizationIT {
         });
     client
         .loadMetalake(METALAKE)
+        .testConnection(catalog1, Catalog.Type.RELATIONAL, "hive", "comment", properties);
+    client
+        .loadMetalake(METALAKE)
         .createCatalog(catalog1, Catalog.Type.RELATIONAL, "hive", "comment", properties);
+    client
+        .loadMetalake(METALAKE)
+        .testConnection(catalog2, Catalog.Type.RELATIONAL, "hive", "comment", properties);
     client
         .loadMetalake(METALAKE)
         .createCatalog(catalog2, Catalog.Type.RELATIONAL, "hive", "comment", properties);

--- a/server/src/main/java/org/apache/gravitino/server/web/rest/CatalogOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/CatalogOperations.java
@@ -168,6 +168,9 @@ public class CatalogOperations {
   @Path("testConnection")
   @Produces("application/vnd.gravitino.v1+json")
   @Timed(name = "test-connection." + MetricNames.HTTP_PROCESS_DURATION, absolute = true)
+  @AuthorizationExpression(
+      expression = "METALAKE::CREATE_CATALOG || METALAKE::OWNER",
+      accessMetadataType = MetadataObject.Type.METALAKE)
   @ResponseMetered(name = "test-connection", absolute = true)
   public Response testConnection(
       @PathParam("metalake") @AuthorizationMetadata(type = Entity.EntityType.METALAKE)


### PR DESCRIPTION
### What changes were proposed in this pull request?

Enable the test catalog connection operation to support authorization.

### Why are the changes needed?

Fix: #7893 

### Does this PR introduce _any_ user-facing change?

None

### How was this patch tested?

org.apache.gravitino.client.integration.test.authorization.CatalogAuthorizationIT#testCreateCatalog
