### PR TITLE
[#8858](gvfs-python): remove FilesetPathNotFoundError Python

### DIFF
--- a/clients/client-python/gravitino/filesystem/gvfs.py
+++ b/clients/client-python/gravitino/filesystem/gvfs.py
@@ -32,7 +32,6 @@ from gravitino.exceptions.base import (
 )
 from gravitino.filesystem.gvfs_base_operations import (
     BaseGVFSOperations,
-    FilesetPathNotFoundError,
 )
 from gravitino.filesystem.gvfs_config import GVFSConfig
 from gravitino.filesystem.gvfs_default_operations import DefaultGVFSOperations
@@ -94,7 +93,7 @@ class GravitinoVirtualFileSystem(fsspec.AbstractFileSystem):
     @staticmethod
     def _with_exception_translation(operation: FilesetDataOperation):
         """
-        Decorator to translate fileset metadata not found exceptions into FilesetPathNotFoundError.
+        Decorator to translate fileset metadata not found exceptions into FileNotFoundError.
         :param operation: The operation being performed.
         """
 
@@ -106,15 +105,15 @@ class GravitinoVirtualFileSystem(fsspec.AbstractFileSystem):
                 except (NoSuchCatalogException, CatalogNotInUseException) as e:
                     message = f"Cannot get fileset catalog during {operation}"
                     logger.warning("%s, %s", message, str(e))
-                    raise FilesetPathNotFoundError(message) from e
+                    raise FileNotFoundError(message) from e
                 except NoSuchFilesetException as e:
                     message = f"Cannot get fileset during {operation}"
                     logger.warning("%s, %s", message, str(e))
-                    raise FilesetPathNotFoundError(message) from e
+                    raise FileNotFoundError(message) from e
                 except NoSuchLocationNameException as e:
                     message = f"Cannot find location name during {operation}"
                     logger.warning("%s, %s", message, str(e))
-                    raise FilesetPathNotFoundError(message) from e
+                    raise FileNotFoundError(message) from e
 
             return wrapper
 
@@ -168,7 +167,7 @@ class GravitinoVirtualFileSystem(fsspec.AbstractFileSystem):
         )(self._operations.exists)
         try:
             result = decorated_exists(new_path, **kwargs)
-        except FilesetPathNotFoundError:
+        except FileNotFoundError:
             return False
 
         return self._hook.post_exists(
@@ -292,7 +291,7 @@ class GravitinoVirtualFileSystem(fsspec.AbstractFileSystem):
                 compression,
                 **kwargs,
             )
-        except FilesetPathNotFoundError as e:
+        except FileNotFoundError as e:
             if mode in ("w", "wb", "x", "xb", "a", "ab"):
                 raise OSError(
                     f"Fileset is not found for path: {new_path} for operation OPEN. This "
@@ -319,12 +318,14 @@ class GravitinoVirtualFileSystem(fsspec.AbstractFileSystem):
         :param kwargs: Extra args
         """
         new_path = self._hook.pre_mkdir(path, create_parents, **kwargs)
-        decorated_mkdir = self._with_exception_translation(FilesetDataOperation.MKDIRS)(
-            self._operations.mkdir
-        )
         try:
-            decorated_mkdir(new_path, create_parents, **kwargs)
-        except FilesetPathNotFoundError as e:
+            self._operations.mkdir(new_path, create_parents, **kwargs)
+        except (
+            NoSuchCatalogException,
+            CatalogNotInUseException,
+            NoSuchFilesetException,
+            NoSuchLocationNameException,
+        ) as e:
             raise OSError(
                 f"Fileset is not found for path: {new_path} for operation MKDIRS. This "
                 f"may be caused by fileset related metadata not found or not in use "
@@ -338,12 +339,14 @@ class GravitinoVirtualFileSystem(fsspec.AbstractFileSystem):
         :param exist_ok: Continue if a directory already exists
         """
         new_path = self._hook.pre_makedirs(path, exist_ok)
-        decorated_makedirs = self._with_exception_translation(
-            FilesetDataOperation.MKDIRS
-        )(self._operations.makedirs)
         try:
-            decorated_makedirs(new_path, exist_ok)
-        except FilesetPathNotFoundError as e:
+            self._operations.makedirs(new_path, exist_ok)
+        except (
+            NoSuchCatalogException,
+            CatalogNotInUseException,
+            NoSuchFilesetException,
+            NoSuchLocationNameException,
+        ) as e:
             raise OSError(
                 f"Fileset is not found for path: {new_path} for operation MKDIRS. This "
                 f"may be caused by fileset related metadata not found or not in use "

--- a/clients/client-python/gravitino/filesystem/gvfs_base_operations.py
+++ b/clients/client-python/gravitino/filesystem/gvfs_base_operations.py
@@ -56,10 +56,6 @@ PROTOCOL_NAME = "gvfs"
 TIME_WITHOUT_EXPIRATION = sys.maxsize
 
 
-class FilesetPathNotFoundError(FileNotFoundError):
-    """Exception raised when the catalog, schema or fileset is not found in the GVFS path."""
-
-
 class BaseGVFSOperations(ABC):
     """
     Abstract base class for Gravitino Virtual File System operations.

--- a/clients/client-python/tests/unittests/test_gvfs_without_fileset.py
+++ b/clients/client-python/tests/unittests/test_gvfs_without_fileset.py
@@ -19,7 +19,6 @@ from unittest.mock import patch
 
 from gravitino.exceptions.base import NoSuchFilesetException
 from gravitino.filesystem.gvfs import GravitinoVirtualFileSystem
-from gravitino.filesystem.gvfs_base_operations import FilesetPathNotFoundError
 
 
 class TestGVFSWithoutFileset(unittest.TestCase):
@@ -57,10 +56,10 @@ class TestGVFSWithoutFileset(unittest.TestCase):
         )
 
         self.assertRaises(
-            FilesetPathNotFoundError, fs.ls, "fileset/test_catalog/schema/fileset"
+            FileNotFoundError, fs.ls, "fileset/test_catalog/schema/fileset"
         )
         self.assertRaises(
-            FilesetPathNotFoundError, fs.info, "fileset/test_catalog/schema/fileset"
+            FileNotFoundError, fs.info, "fileset/test_catalog/schema/fileset"
         )
 
         self.assertFalse(fs.exists("fileset/test_catalog/schema/fileset"))
@@ -72,15 +71,15 @@ class TestGVFSWithoutFileset(unittest.TestCase):
             )
 
         self.assertRaises(
-            FilesetPathNotFoundError, fs.rm, "fileset/test_catalog/schema/fileset/a"
+            FileNotFoundError, fs.rm, "fileset/test_catalog/schema/fileset/a"
         )
         self.assertRaises(
-            FilesetPathNotFoundError,
+            FileNotFoundError,
             fs.rm_file,
             "fileset/test_catalog/schema/fileset/a",
         )
         self.assertRaises(
-            FilesetPathNotFoundError, fs.rmdir, "fileset/test_catalog/schema/fileset/a"
+            FileNotFoundError, fs.rmdir, "fileset/test_catalog/schema/fileset/a"
         )
 
         self.assertRaises(OSError, fs.open, "fileset/test_catalog/schema/fileset", "w")
@@ -91,13 +90,13 @@ class TestGVFSWithoutFileset(unittest.TestCase):
         self.assertRaises(OSError, fs.open, "fileset/test_catalog/schema/fileset", "xb")
 
         self.assertRaises(
-            FilesetPathNotFoundError,
+            FileNotFoundError,
             fs.open,
             "fileset/test_catalog/schema/fileset/a",
             "r",
         )
         self.assertRaises(
-            FilesetPathNotFoundError,
+            FileNotFoundError,
             fs.open,
             "fileset/test_catalog/schema/fileset/a",
             "rb",
@@ -109,18 +108,18 @@ class TestGVFSWithoutFileset(unittest.TestCase):
         )
 
         self.assertRaises(
-            FilesetPathNotFoundError,
+            FileNotFoundError,
             fs.created,
             "fileset/test_catalog/schema/fileset/a",
         )
         self.assertRaises(
-            FilesetPathNotFoundError,
+            FileNotFoundError,
             fs.modified,
             "fileset/test_catalog/schema/fileset/a",
         )
 
         self.assertRaises(
-            FilesetPathNotFoundError,
+            FileNotFoundError,
             fs.cat_file,
             "fileset/test_catalog/schema/fileset/a",
         )


### PR DESCRIPTION
### What changes were proposed in this pull request?

Remove FilesetPathNotFoundError and throws FileNotFoundError instead. 

### Why are the changes needed?

Have Python GVFS consistent with JAVA GVFS behavior. This is a follow up action item of https://github.com/apache/gravitino/pull/8859

Fix: #8858 

### Does this PR introduce _any_ user-facing change?

FilesetPathNotFoundError will be removed. Users will see FileNotFoundError instead. 

### How was this patch tested?

1. unit tests.
2. tested in our environment

