### PR TITLE
[#8752] feat(gvfs-java): set operation context in gvfs hook

### DIFF
--- a/clients/filesystem-hadoop3/src/main/java/org/apache/gravitino/filesystem/hadoop/GravitinoVirtualFileSystem.java
+++ b/clients/filesystem-hadoop3/src/main/java/org/apache/gravitino/filesystem/hadoop/GravitinoVirtualFileSystem.java
@@ -99,6 +99,8 @@ public class GravitinoVirtualFileSystem extends FileSystem {
           e, "Cannot create operations instance: %s", operationsClassName);
     }
 
+    hook.setOperationsContext(operations);
+
     this.workingDirectory = new Path(name);
     this.uri = URI.create(name.getScheme() + "://" + name.getAuthority());
 

--- a/clients/filesystem-hadoop3/src/main/java/org/apache/gravitino/filesystem/hadoop/GravitinoVirtualFileSystemHook.java
+++ b/clients/filesystem-hadoop3/src/main/java/org/apache/gravitino/filesystem/hadoop/GravitinoVirtualFileSystemHook.java
@@ -38,6 +38,16 @@ import org.apache.hadoop.fs.permission.FsPermission;
 public interface GravitinoVirtualFileSystemHook extends Closeable {
 
   /**
+   * Set the operations context for this hook. This method will be called during GVFS initialization
+   * to provide the hook with access to the BaseGVFSOperations instance.
+   *
+   * @param operations the BaseGVFSOperations instance
+   */
+  default void setOperationsContext(BaseGVFSOperations operations) {
+    // Default implementation does nothing - hooks can override if they need operations access
+  }
+
+  /**
    * Initialize the hook with the configuration. This method will be called in the GVFS initialize
    * method, and the configuration will be passed from the GVFS configuration. The implementor can
    * initialize the hook with the configuration. The exception will be thrown to the caller and fail

--- a/clients/filesystem-hadoop3/src/test/java/org/apache/gravitino/filesystem/hadoop/MockGVFSHook.java
+++ b/clients/filesystem-hadoop3/src/test/java/org/apache/gravitino/filesystem/hadoop/MockGVFSHook.java
@@ -29,6 +29,8 @@ import org.apache.hadoop.fs.permission.FsPermission;
 
 public class MockGVFSHook implements GravitinoVirtualFileSystemHook {
 
+  boolean setOperationsContextCalled = false;
+  BaseGVFSOperations operations = null;
   boolean preSetWorkingDirectoryCalled = false;
   boolean preOpenCalled = false;
   boolean preCreateCalled = false;
@@ -51,6 +53,12 @@ public class MockGVFSHook implements GravitinoVirtualFileSystemHook {
   boolean postMkdirsCalled = false;
   boolean postGetDefaultReplicationCalled = false;
   boolean postGetDefaultBlockSizeCalled = false;
+
+  @Override
+  public void setOperationsContext(BaseGVFSOperations operations) {
+    this.setOperationsContextCalled = true;
+    this.operations = operations;
+  }
 
   @Override
   public void initialize(Map<String, String> config) {}


### PR DESCRIPTION
### What changes were proposed in this pull request?

add setOperationsContext in hook interface with default implementation.

### Why are the changes needed?

The hook's fallback logic needs to use functions like getFileSystem, which currently only exist in the operation object. To solve this, we'll pass the operation context to the hook. This approach allows the hook to reuse the getFileSystem logic and its cache, simplifying the fallback implementation.

Fix: #8752 

### Does this PR introduce _any_ user-facing change?

No. The default behavior remains unchanged.

### How was this patch tested?

unit tested
