### PR TITLE
[#8752] feat(gvfs-python): set operation context in Python gvfs hook

### DIFF
--- a/clients/client-python/gravitino/filesystem/gvfs.py
+++ b/clients/client-python/gravitino/filesystem/gvfs.py
@@ -75,6 +75,7 @@ class GravitinoVirtualFileSystem(fsspec.AbstractFileSystem):
         self._operations = self._get_gvfs_operations_class(
             server_uri, metalake_name, options
         )
+        self._hook.set_operations_context(self._operations)
 
         super().__init__(**kwargs)
 

--- a/clients/client-python/gravitino/filesystem/gvfs_hook.py
+++ b/clients/client-python/gravitino/filesystem/gvfs_hook.py
@@ -30,6 +30,17 @@ class GravitinoVirtualFileSystemHook(ABC):
     idempotent issues if required.
     """
 
+    def set_operations_context(self, operations):
+        """
+        Set the operations context for this hook. This method will be called during GVFS initialization
+        to provide the hook with access to the BaseGVFSOperations instance.
+
+        Args:
+            operations: The BaseGVFSOperations instance.
+        """
+        # Default implementation does nothing - hooks can override if they need operations access
+        pass
+
     @abstractmethod
     def initialize(self, config: Optional[Dict[str, str]]):
         """

--- a/clients/client-python/tests/unittests/test_gvfs_with_hook.py
+++ b/clients/client-python/tests/unittests/test_gvfs_with_hook.py
@@ -34,6 +34,8 @@ class MockGVFSHook(GravitinoVirtualFileSystemHook):
     # pylint: disable=too-many-instance-attributes
 
     def __init__(self):
+        self.set_operations_context_called = False
+        self.operations = None
         self.ls_called = False
         self.info_called = False
         self.exists_called = False
@@ -64,6 +66,10 @@ class MockGVFSHook(GravitinoVirtualFileSystemHook):
         self.post_get_file_called = False
         self.post_created_called = False
         self.post_modified_called = False
+
+    def set_operations_context(self, operations):
+        self.set_operations_context_called = True
+        self.operations = operations
 
     def initialize(self, config: Optional[Dict[str, str]]):
         pass
@@ -259,6 +265,11 @@ class TestGVFSHook(unittest.TestCase):
                     GVFSConfig.GVFS_FILESYSTEM_HOOK: "tests.unittests.test_gvfs_with_hook.MockGVFSHook"
                 },
             )
+
+            # Test that set_operations_context was called during initialization
+            self.assertTrue(fs.hook.set_operations_context_called)
+            self.assertIsNotNone(fs.hook.operations)
+            self.assertEqual(fs.operations, fs.hook.operations)
 
             # Test pre_exists and post_exists hook
             fs.exists(fileset_virtual_path)


### PR DESCRIPTION
### What changes were proposed in this pull request?

add setOperationsContext in hook interface with default implementation. This is the python GVFS change. 

### Why are the changes needed?

The hook's fallback logic needs to use functions like getFileSystem, which currently only exist in the operation object. To solve this, we'll pass the operation context to the hook. This approach allows the hook to reuse the getFileSystem logic and its cache, simplifying the fallback implementation.

The JAVA side change is in this PR https://github.com/apache/gravitino/pull/8867. This Python change is to make the Python GVFS logics consistent with JAVA GVFS.

Fix: https://github.com/apache/gravitino/issues/8752

### Does this PR introduce _any_ user-facing change?

No. The default behavior remains unchanged.

### How was this patch tested?

unit tested
