### PR TITLE
[#8861] Improve(test): further bump testPolicyAndTagCacheWeigher timeout to 20s

### DIFF
--- a/core/src/test/java/org/apache/gravitino/cache/TestCacheConfig.java
+++ b/core/src/test/java/org/apache/gravitino/cache/TestCacheConfig.java
@@ -157,7 +157,7 @@ public class TestCacheConfig {
     // There should no tag entities in the cache, because the weight of each tag entity is 100 that
     // is higher than the maximum weight of the fileset entity which is 200.
     Awaitility.await()
-        .atMost(Duration.ofSeconds(10))
+        .atMost(Duration.ofSeconds(20))
         .pollInterval(Duration.ofMillis(10))
         .until(
             () ->


### PR DESCRIPTION
### What changes were proposed in this pull request?

Bump timeout from 10 seconds to 20 seconds

### Why are the changes needed?

```
> Task :core:test

TestCacheConfig > testPolicyAndTagCacheWeigher() FAILED
    org.awaitility.core.ConditionTimeoutException: Condition with Lambda expression in org.apache.gravitino.cache.TestCacheConfig was not fulfilled within 10 seconds.
        at app//org.awaitility.core.ConditionAwaiter.await(ConditionAwaiter.java:167)
        at app//org.awaitility.core.CallableCondition.await(CallableCondition.java:78)
        at app//org.awaitility.core.CallableCondition.await(CallableCondition.java:26)
        at app//org.awaitility.core.ConditionFactory.until(ConditionFactory.java:1006)
        at app//org.awaitility.core.ConditionFactory.until(ConditionFactory.java:975)
        at app//org.apache.gravitino.cache.TestCacheConfig.testPolicyAndTagCacheWeigher(TestCacheConfig.java:162)
```

see failure: https://github.com/apache/gravitino/actions/runs/18693766507/job/53305862655?pr=8868

Fix: [#8861](https://github.com/apache/gravitino/issues/8861)

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Updated unit tests