### PR TITLE
[#8872]Improve(test): check some tag cache will be evicted instead of all

### DIFF
--- a/core/src/test/java/org/apache/gravitino/cache/TestCacheConfig.java
+++ b/core/src/test/java/org/apache/gravitino/cache/TestCacheConfig.java
@@ -152,22 +152,34 @@ public class TestCacheConfig {
           List.of(fileset));
     }
 
+    // Access all filesets to make them more likely to be retained
+    for (int i = 5; i < 15; i++) {
+      String filesetName = "fileset" + i;
+      cache.getIfPresent(
+          EntityCacheRelationKey.of(
+              NameIdentifier.of(new String[] {"metalake1", "catalog1", "schema1", filesetName}),
+              Entity.EntityType.FILESET));
+    }
+
     Thread.sleep(1000);
 
-    // There should no tag entities in the cache, because the weight of each tag entity is 100 that
-    // is higher than the maximum weight of the fileset entity which is 200.
-    Awaitility.await()
-        .atMost(Duration.ofSeconds(10))
-        .pollInterval(Duration.ofMillis(10))
-        .until(
-            () ->
-                IntStream.of(0, 1, 2, 3)
-                    .mapToObj(i -> NameIdentifierUtil.ofTag("metalake", "tag" + i))
-                    .allMatch(
-                        tagNameIdent ->
-                            cache.getIfPresent(
-                                    EntityCacheRelationKey.of(tagNameIdent, Entity.EntityType.TAG))
-                                == null));
+    // Some tag entities should be evicted from the cache, because the weight of each tag entity
+    // is 100 and we have 10 filesets with weight 200 each, exceeding the max weight of 2000.
+    // Due to Caffeine's non-deterministic W-TinyLFU eviction algorithm, we verify that some tags
+    // were evicted rather than checking for specific tags.
+    long remainingTags =
+        IntStream.range(0, 10)
+            .mapToObj(i -> NameIdentifierUtil.ofTag("metalake", "tag" + i))
+            .filter(
+                tagNameIdent ->
+                    cache.getIfPresent(
+                            EntityCacheRelationKey.of(tagNameIdent, Entity.EntityType.TAG))
+                        != null)
+            .count();
+
+    Assertions.assertTrue(
+        remainingTags < 10,
+        "Expected some tags to be evicted, but found " + remainingTags + " tags still in cache");
   }
 
   @Test


### PR DESCRIPTION
### What changes were proposed in this pull request?

It turns out bumping to 10 seconds even 20 seconds still doesn't work - https://github.com/apache/gravitino/pull/8870. It's because Caffeine's W-TinyLFU eviction algorithm is **NON-DETERMINISTIC**. It doesn't guarantee which specific entries will be evicted, even after an hour. It makes probabilistic decisions based on:
- Access frequency (how often accessed)
- Recency (when last accessed)
- Random sampling for efficiency
- Weight of entries

Although weight plays a significant role, it's not the sole indicator on which cache to evict. 

With the change in this PR:
1. We check some tags are evicted, instead of checking all tag caches are evicted. 

### Why are the changes needed?

Fix the flaky test of testPolicyAndTagCacheWeigher

Fix: [#8861](https://github.com/apache/gravitino/issues/8861)

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Unit test updated
