### PR TITLE
[#8881] improvement(fileset): use fileset write lock instead of schema lock for fileset creation

### DIFF
--- a/core/src/main/java/org/apache/gravitino/catalog/FilesetOperationDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/FilesetOperationDispatcher.java
@@ -157,7 +157,9 @@ public class FilesetOperationDispatcher extends OperationDispatcher implements F
 
     Fileset createdFileset =
         TreeLockUtils.doWithTreeLock(
-            NameIdentifier.of(ident.namespace().levels()),
+            // Lock at fileset level (not schema level) to allow concurrent fileset creation.
+            // Trade-off: listFilesets() may temporarily miss in-progress creations until complete.
+            ident,
             LockType.WRITE,
             () ->
                 doWithCatalog(


### PR DESCRIPTION
### What changes were proposed in this pull request?

Scope locking down from schema-level to a fileset-level write lock during fileset creation. This allows multiple filesets to be created concurrently within the same schema and should improve create-fileset throughput.

### Why are the changes needed?

The schema-wide lock serialized all creations within a schema, becoming a bottleneck. Using a per-fileset write lock reduces contention and increases parallelism. Note: this is a performance–consistency trade-off; during active writes, listing operations may briefly return incomplete results until creations commit.

Fix: #8881 

### Does this PR introduce _any_ user-facing change?

no

### How was this patch tested?

manual testing
