### PR TITLE
[MINOR] Fix: Typo in Iceberg table-exists metric name

### DIFF
--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/rest/IcebergTableOperations.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/rest/IcebergTableOperations.java
@@ -258,7 +258,7 @@ public class IcebergTableOperations {
   @Path("{table}")
   @Produces(MediaType.APPLICATION_JSON)
   @Timed(name = "table-exists." + MetricNames.HTTP_PROCESS_DURATION, absolute = true)
-  @ResponseMetered(name = "table-exits", absolute = true)
+  @ResponseMetered(name = "table-exists", absolute = true)
   public Response tableExists(
       @PathParam("prefix") String prefix,
       @Encoded() @PathParam("namespace") String namespace,


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?
The @ResponseMetered annotation had 'table-exits' instead of 'table-exists', causing incorrect metric reporting for the tableExists endpoint.

This fixes the metric name to properly align with the operation.

### Why are the changes needed?
Fix typo in metric name

### Does this PR introduce _any_ user-facing change?
Fix typo in metric name

### How was this patch tested?
To see the current metric:
```
 curl -s http://localhost:9001/metrics | grep -o '"[^"]*table-exit[^"]*"'
```
After this fix, the metric name should be fixed