### PR TITLE
[MINOR] test:  Add validation tests for X-Iceberg-Access-Delegation header

### DIFF
--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/TestIcebergTableOperations.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/TestIcebergTableOperations.java
@@ -496,4 +496,54 @@ public class TestIcebergTableOperations extends IcebergNamespaceTestBase {
   private Response doGetTableCredentials(Namespace ns, String tableName) {
     return getTableClientBuilder(ns, Optional.of(tableName + "/credentials")).get();
   }
+
+  @ParameterizedTest
+  @MethodSource("org.apache.gravitino.iceberg.service.rest.IcebergRestTestUtil#testNamespaces")
+  void testRemoteSigningNotSupported(Namespace namespace) {
+    verifyCreateNamespaceSucc(namespace);
+
+    // Attempt to create table with "remote-signing" access delegation
+    // This should fail with UnsupportedOperationException -> 406 Not Acceptable
+    CreateTableRequest createTableRequest =
+        CreateTableRequest.builder()
+            .withName("test_remote_signing")
+            .withSchema(tableSchema)
+            .build();
+
+    Response response =
+        getTableClientBuilder(namespace, Optional.empty())
+            .header(IcebergTableOperations.X_ICEBERG_ACCESS_DELEGATION, "remote-signing")
+            .post(Entity.entity(createTableRequest, MediaType.APPLICATION_JSON_TYPE));
+
+    Assertions.assertEquals(406, response.getStatus());
+    String errorBody = response.readEntity(String.class);
+    Assertions.assertTrue(
+        errorBody.contains("remote signing") || errorBody.contains("remote-signing"),
+        "Error message should mention remote signing: " + errorBody);
+  }
+
+  @ParameterizedTest
+  @MethodSource("org.apache.gravitino.iceberg.service.rest.IcebergRestTestUtil#testNamespaces")
+  void testInvalidAccessDelegation(Namespace namespace) {
+    verifyCreateNamespaceSucc(namespace);
+
+    // Attempt to create table with invalid access delegation value
+    // This should fail with IllegalArgumentException -> 400 Bad Request
+    CreateTableRequest createTableRequest =
+        CreateTableRequest.builder()
+            .withName("test_invalid_delegation")
+            .withSchema(tableSchema)
+            .build();
+
+    Response response =
+        getTableClientBuilder(namespace, Optional.empty())
+            .header(IcebergTableOperations.X_ICEBERG_ACCESS_DELEGATION, "invalid-value")
+            .post(Entity.entity(createTableRequest, MediaType.APPLICATION_JSON_TYPE));
+
+    Assertions.assertEquals(400, response.getStatus());
+    String errorBody = response.readEntity(String.class);
+    Assertions.assertTrue(
+        errorBody.contains("vended-credentials") && errorBody.contains("illegal"),
+        "Error message should mention valid values: " + errorBody);
+  }
 }


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?
Add two new test cases to validate error handling for the X-Iceberg-Access-Delegation header in the Iceberg REST API:

- testRemoteSigningNotSupported: Validates that remote-signing access delegation returns 406 Not Acceptable since it's not currently supported by Gravitino

- testInvalidAccessDelegation: Validates that invalid access delegation values return 400 Bad Request with appropriate error messaging

These tests cover previously untested error paths in the isCredentialVending() validation method

### Why are the changes needed?
Add unit tests

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Unit tests