### PR TITLE
[MINOR] fix(iceberg): Correct metric name typo in view exists endpoint

### DIFF
--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/rest/IcebergViewOperations.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/rest/IcebergViewOperations.java
@@ -221,7 +221,7 @@ public class IcebergViewOperations {
   @Path("{view}")
   @Produces(MediaType.APPLICATION_JSON)
   @Timed(name = "view-exists." + MetricNames.HTTP_PROCESS_DURATION, absolute = true)
-  @ResponseMetered(name = "view-exits", absolute = true)
+  @ResponseMetered(name = "view-exists", absolute = true)
   public Response viewExists(
       @PathParam("prefix") String prefix,
       @Encoded() @PathParam("namespace") String namespace,


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?
Change 'view-exits' to 'view-exists' in the @ResponseMetered annotation for the viewExists() REST endpoint.

### Why are the changes needed?
Fix typo

### Does this PR introduce _any_ user-facing change?
Yes, fixes the metric name

### How was this patch tested?

To see the current metric:
```
 curl -s http://localhost:9001/metrics | grep -o '"[^"]*view-exit[^"]*"'
```

After this fix, the metric name should be fixed