### PR TITLE
[#8887] fix(iceberg): Return 503 when metrics endpoint rejects requests

### DIFF
--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/metrics/IcebergMetricsManager.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/metrics/IcebergMetricsManager.java
@@ -108,14 +108,23 @@ public class IcebergMetricsManager {
                 TimeUnit.HOURS));
   }
 
-  public void recordMetric(MetricsReport metricsReport) {
+  /**
+   * Records a metrics report by adding it to the processing queue.
+   *
+   * @param metricsReport the metrics report to record
+   * @return true if the metric was successfully queued, false if it was rejected (manager closed or
+   *     queue full)
+   */
+  public boolean recordMetric(MetricsReport metricsReport) {
     if (isClosed) {
       logMetrics("Drop Iceberg metrics because Iceberg Metrics Manager is closed.", metricsReport);
-      return;
+      return false;
     }
     if (!queue.offer(metricsReport)) {
       logMetrics("Drop Iceberg metrics because metrics queue is full.", metricsReport);
+      return false;
     }
+    return true;
   }
 
   public void close() {

--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/rest/IcebergTableOperations.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/rest/IcebergTableOperations.java
@@ -310,8 +310,14 @@ public class IcebergTableOperations {
       return Utils.doAs(
           httpRequest,
           () -> {
-            icebergMetricsManager.recordMetric(request.report());
-            return IcebergRestUtils.noContent();
+            boolean accepted = icebergMetricsManager.recordMetric(request.report());
+            if (accepted) {
+              return IcebergRestUtils.noContent();
+            } else {
+              return IcebergRestUtils.errorResponse(
+                  new RuntimeException("Metrics service unavailable: queue full or service closed"),
+                  Response.Status.SERVICE_UNAVAILABLE.getStatusCode());
+            }
           });
     } catch (Exception e) {
       return IcebergExceptionMapper.toRESTResponse(e);


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

This PR implements proper HTTP status code handling for the Iceberg metrics endpoint as specified in the Iceberg REST API specification.

**Changes:**
1. Modified `IcebergMetricsManager.recordMetric()` to return `boolean` instead of `void`
   - Returns `true` when metric is successfully queued
   - Returns `false` when manager is closed or queue is full
2. Updated `IcebergTableOperations.reportTableMetrics()` to check the return value
   - Returns HTTP 204 (No Content) when metric is accepted
   - Returns HTTP 503 (Service Unavailable) when metric is rejected
3. Added unit tests in `TestIcebergMetricsManager`


### Why are the changes needed?

The Iceberg REST API specification defines specific status codes for the metrics endpoint:
- **204 No Content**: Metric successfully accepted
- **503 Service Unavailable**: Server cannot accept metric (e.g., queue full, service shutting down)

Previously, the endpoint always returned 204 even when metrics were silently dropped due to queue overflow or manager shutdown. This PR ensures clients receive proper feedback about metric acceptance.


Fix: #8887

### Does this PR introduce _any_ user-facing change?
Yes, behavioral change:
- **Before**: Metrics endpoint always returned HTTP 204, even when metrics were dropped
- **After**: Returns HTTP 503 when metrics cannot be accepted (queue full or manager closed)

This is backward compatible as clients should already handle 5xx responses gracefully.

### How was this patch tested?
- Unit tests
- Validation in Dev environment:
   - Tested with concurrent requests to `/iceberg/v1/namespaces/test_db/tables/test_table/metrics` to verify it works and not breaking.
