### PR TITLE
[cherry-pick][#8830] fix (gvfs-fuse) : Disable the CI to build fuse-filesystem module 

### DIFF
--- a/.github/workflows/gvfs-fuse-build-test.yml
+++ b/.github/workflows/gvfs-fuse-build-test.yml
@@ -2,10 +2,11 @@ name: Build gvfs-fuse and testing
 
 # Controls when the workflow will run
 on:
-  push:
-    branches: [ "main", "branch-*" ]
-  pull_request:
-    branches: [ "main", "branch-*" ]
+  # Temporarily disable
+  # push:
+  #  branches: [ "main", "branch-*" ]
+  # pull_request:
+  #  branches: [ "main", "branch-*" ]
   workflow_dispatch:
 
 concurrency:

--- a/clients/filesystem-fuse/Makefile
+++ b/clients/filesystem-fuse/Makefile
@@ -54,7 +54,9 @@ install-taplo-cli:
 check-toml: install-taplo-cli
 	taplo check
 
-check: check-fmt check-clippy check-cargo-sort
+#  todo: Disable some checks due to build failures caused by Rust dependency library upgrades.
+#  check: check-fmt check-clippy check-cargo-sort check-toml cargo-machete
+check: check-fmt check-cargo-sort
 
 doc-test:
 	cargo test --no-fail-fast --doc --all-features --workspace


### PR DESCRIPTION
### What changes were proposed in this pull request?

Disable the CI to build fuse-filesystem module.

### Why are the changes needed?

#8827

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

CI

(cherry picked from commit 7c359976986d2f446681dcdcdae92828d4db6a9d)