### PR TITLE
[#8959] fix(lance-rest): Fix configuration name error in Lance configurations.

### DIFF
--- a/lance/lance-common/src/main/java/org/apache/gravitino/lance/common/config/LanceConfig.java
+++ b/lance/lance-common/src/main/java/org/apache/gravitino/lance/common/config/LanceConfig.java
@@ -47,14 +47,14 @@ public class LanceConfig extends Config implements OverwriteDefaultConfig {
           .createWithDefault(GRAVITINO_NAMESPACE_BACKEND);
 
   public static final ConfigEntry<String> METALAKE_NAME =
-      new ConfigBuilder(LANCE_CONFIG_PREFIX + GRAVITINO_NAMESPACE_BACKEND + "." + CONFIG_METALAKE)
+      new ConfigBuilder(GRAVITINO_NAMESPACE_BACKEND + "." + CONFIG_METALAKE)
           .doc("The Metalake name for Lance Gravitino namespace backend")
           .version(ConfigConstants.VERSION_0_1_0)
           .stringConf()
           .create();
 
   public static final ConfigEntry<String> NAMESPACE_BACKEND_URI =
-      new ConfigBuilder(LANCE_CONFIG_PREFIX + GRAVITINO_NAMESPACE_BACKEND + "." + CONFIG_URI)
+      new ConfigBuilder(GRAVITINO_NAMESPACE_BACKEND + "." + CONFIG_URI)
           .doc("The URI of the namespace backend, e.g., Gravitino server URI")
           .version(ConfigConstants.VERSION_0_1_0)
           .stringConf()


### PR DESCRIPTION


### What changes were proposed in this pull request?

Remove excessive LANCE_CONFIG_PREFIX;

### Why are the changes needed?

Prefix LANCE_CONFIG_PREFIX has been removed when Lance server starts.

Fix: #8959

### Does this PR introduce _any_ user-facing change?

N/A.

### How was this patch tested?

Test locally.