### PR TITLE
[#8981] Improvement(iceberg-catalog): CatalogWrapperForREST.close() calls super.close() 

### DIFF
--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/CatalogWrapperForREST.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/CatalogWrapperForREST.java
@@ -136,9 +136,17 @@ public class CatalogWrapperForREST extends IcebergCatalogWrapper {
   }
 
   @Override
-  public void close() {
-    if (catalogCredentialManager != null) {
-      catalogCredentialManager.close();
+  public void close() throws Exception {
+    try {
+      if (catalogCredentialManager != null) {
+        catalogCredentialManager.close();
+      }
+    } finally {
+      // Call super.close() to release parent class resources including:
+      // 1. Close underlying catalog (JdbcCatalog, WrappedHiveCatalog, etc.)
+      // 2. Close metadata cache
+      // 3. Cleanup JDBC drivers and threads (MySQL AbandonedConnectionCleanupThread, etc.)
+      super.close();
     }
   }
 


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

CatalogWrapperForREST.close() calls super.close() to release parent class resources.

### Why are the changes needed?


Fix: #([8981](https://github.com/apache/gravitino/issues/8981))

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

N/A
