### PR TITLE
[#8984] Improvement(paimon): Remove the redundant schemaExists() check in PaimonCatalogOperations.listTables()

### DIFF
--- a/catalogs/catalog-lakehouse-paimon/src/main/java/org/apache/gravitino/catalog/lakehouse/paimon/PaimonCatalogOperations.java
+++ b/catalogs/catalog-lakehouse-paimon/src/main/java/org/apache/gravitino/catalog/lakehouse/paimon/PaimonCatalogOperations.java
@@ -269,15 +269,14 @@ public class PaimonCatalogOperations implements CatalogOperations, SupportsSchem
   public NameIdentifier[] listTables(Namespace namespace) throws NoSuchSchemaException {
     String[] levels = namespace.levels();
     NameIdentifier schemaIdentifier = NameIdentifier.of(levels[levels.length - 1]);
-    if (!schemaExists(schemaIdentifier)) {
-      throw new NoSuchSchemaException(NO_SUCH_SCHEMA_EXCEPTION, namespace.toString());
-    }
+
     List<String> tables;
     try {
       tables = paimonCatalogOps.listTables(schemaIdentifier.name());
     } catch (Catalog.DatabaseNotExistException e) {
-      throw new NoSuchSchemaException(NO_SUCH_SCHEMA_EXCEPTION, namespace.toString());
+      throw new NoSuchSchemaException(e, NO_SUCH_SCHEMA_EXCEPTION, namespace.toString());
     }
+
     return tables.stream()
         .map(
             tableIdentifier ->


### PR DESCRIPTION
### What changes were proposed in this pull request?

Remove the redundant schemaExists() check in PaimonCatalogOperations.listTables()

### Why are the changes needed?

Fix: #([8984](https://github.com/apache/gravitino/issues/8984))

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

N/A
