### PR TITLE
[#8932] fix(iceberg):The Iceberg REST server config interface shouldn't return view endpoints for JDBC catalog with v0 schema version

### DIFF
--- a/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/ops/IcebergCatalogWrapper.java
+++ b/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/ops/IcebergCatalogWrapper.java
@@ -43,6 +43,7 @@ import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.SupportsNamespaces;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.catalog.ViewCatalog;
+import org.apache.iceberg.jdbc.JdbcCatalogWithMetadataLocationSupport;
 import org.apache.iceberg.rest.CatalogHandlers;
 import org.apache.iceberg.rest.requests.CreateNamespaceRequest;
 import org.apache.iceberg.rest.requests.CreateTableRequest;
@@ -262,7 +263,18 @@ public class IcebergCatalogWrapper implements AutoCloseable {
   }
 
   public boolean supportsViewOperations() {
-    return catalog instanceof ViewCatalog;
+    if (!(catalog instanceof ViewCatalog)) {
+      return false;
+    }
+
+    // JDBC catalog only supports view operations from v1 schema version
+    if (catalog instanceof JdbcCatalogWithMetadataLocationSupport) {
+      JdbcCatalogWithMetadataLocationSupport jdbcCatalog =
+          (JdbcCatalogWithMetadataLocationSupport) catalog;
+      return jdbcCatalog.supportsViewsWithSchemaVersion();
+    }
+
+    return true;
   }
 
   @Override

--- a/iceberg/iceberg-common/src/main/java/org/apache/iceberg/jdbc/JdbcCatalogWithMetadataLocationSupport.java
+++ b/iceberg/iceberg-common/src/main/java/org/apache/iceberg/jdbc/JdbcCatalogWithMetadataLocationSupport.java
@@ -57,6 +57,17 @@ public class JdbcCatalogWithMetadataLocationSupport extends JdbcCatalog
     return table.get(METADATA_LOCATION_PROP);
   }
 
+  /**
+   * Check if the JDBC catalog schema version supports view operations. View operations are
+   * supported from V1 schema version onwards.
+   *
+   * @return true if the schema version supports view operations, false otherwise
+   */
+  public boolean supportsViewsWithSchemaVersion() {
+    // V0 doesn't support views, only V1 and later versions do
+    return jdbcSchemaVersion != null && jdbcSchemaVersion != SchemaVersion.V0;
+  }
+
   private void loadFields() {
     try {
       this.jdbcCatalogName = (String) FieldUtils.readField(this, "catalogName", true);

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/TestIcebergConfig.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/TestIcebergConfig.java
@@ -119,4 +119,26 @@ public class TestIcebergConfig extends IcebergTestBase {
     Response response = getIcebergClientBuilder(path, Optional.empty()).get();
     Assertions.assertEquals(500, response.getStatus());
   }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"", IcebergRestTestUtil.PREFIX})
+  public void testConfigEndpointsContainViewOperations(String prefix) {
+    setUrlPathWithPrefix(prefix);
+    String warehouseName = IcebergRestTestUtil.PREFIX;
+    Map<String, String> queryParams = ImmutableMap.of("warehouse", warehouseName);
+    Response resp =
+        getIcebergClientBuilder(IcebergRestTestUtil.CONFIG_PATH, Optional.of(queryParams)).get();
+    Assertions.assertEquals(Response.Status.OK.getStatusCode(), resp.getStatus());
+
+    ConfigResponse response = resp.readEntity(ConfigResponse.class);
+
+    // Verify that view endpoints are present
+    boolean hasViewListEndpoint =
+        response.endpoints().stream()
+            .anyMatch(endpoint -> endpoint.path().contains("namespaces/{namespace}/views"));
+
+    Assertions.assertTrue(
+        hasViewListEndpoint,
+        "Config response should contain view list endpoint for catalog that supports views");
+  }
 }


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

(Please outline the changes and how this PR fixes the issue.)

### Why are the changes needed?

Fix: #([8932](https://github.com/apache/gravitino/issues/8932))

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

org.apache.iceberg.jdbc.TestJdbcCatalogWithMetadataLocationSupport#testSupportsViewsWithSchemaVersion
org.apache.gravitino.iceberg.service.rest.TestIcebergConfig#testConfigEndpointsContainViewOperations
