### PR TITLE
[MINOR] fix(lance-rest-server): remove encoded annotation

### DIFF
--- a/lance/lance-rest-server/src/main/java/org/apache/gravitino/lance/service/rest/LanceNamespaceOperations.java
+++ b/lance/lance-rest-server/src/main/java/org/apache/gravitino/lance/service/rest/LanceNamespaceOperations.java
@@ -33,7 +33,6 @@ import java.util.regex.Pattern;
 import javax.inject.Inject;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DefaultValue;
-import javax.ws.rs.Encoded;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -63,7 +62,7 @@ public class LanceNamespaceOperations {
   @Timed(name = "list-namespaces." + MetricNames.HTTP_PROCESS_DURATION, absolute = true)
   @ResponseMetered(name = "list-namespaces", absolute = true)
   public Response listNamespaces(
-      @Encoded @PathParam("id") String namespaceId,
+      @PathParam("id") String namespaceId,
       @DefaultValue(NAMESPACE_DELIMITER_DEFAULT) @QueryParam("delimiter") String delimiter,
       @QueryParam("page_token") String pageToken,
       @QueryParam("limit") Integer limit) {
@@ -83,7 +82,7 @@ public class LanceNamespaceOperations {
   @Timed(name = "describe-namespaces." + MetricNames.HTTP_PROCESS_DURATION, absolute = true)
   @ResponseMetered(name = "describe-namespaces", absolute = true)
   public Response describeNamespace(
-      @Encoded @PathParam("id") String namespaceId,
+      @PathParam("id") String namespaceId,
       @DefaultValue(NAMESPACE_DELIMITER_DEFAULT) @QueryParam("delimiter") String delimiter) {
     try {
       DescribeNamespaceResponse response =
@@ -99,7 +98,7 @@ public class LanceNamespaceOperations {
   @Timed(name = "create-namespaces." + MetricNames.HTTP_PROCESS_DURATION, absolute = true)
   @ResponseMetered(name = "create-namespaces", absolute = true)
   public Response createNamespace(
-      @Encoded @PathParam("id") String namespaceId,
+      @PathParam("id") String namespaceId,
       @DefaultValue(NAMESPACE_DELIMITER_DEFAULT) @QueryParam("delimiter") String delimiter,
       CreateNamespaceRequest request) {
     try {
@@ -124,7 +123,7 @@ public class LanceNamespaceOperations {
   @Timed(name = "drop-namespaces." + MetricNames.HTTP_PROCESS_DURATION, absolute = true)
   @ResponseMetered(name = "drop-namespaces", absolute = true)
   public Response dropNamespace(
-      @Encoded @PathParam("id") String namespaceId,
+      @PathParam("id") String namespaceId,
       @DefaultValue(NAMESPACE_DELIMITER_DEFAULT) @QueryParam("delimiter") String delimiter,
       DropNamespaceRequest request) {
     try {
@@ -151,7 +150,7 @@ public class LanceNamespaceOperations {
   @Timed(name = "namespace-exists." + MetricNames.HTTP_PROCESS_DURATION, absolute = true)
   @ResponseMetered(name = "namespace-exists", absolute = true)
   public Response namespaceExists(
-      @Encoded @PathParam("id") String namespaceId,
+      @PathParam("id") String namespaceId,
       @DefaultValue(NAMESPACE_DELIMITER_DEFAULT) @QueryParam("delimiter") String delimiter) {
     try {
       lanceNamespace.asNamespaceOps().namespaceExists(namespaceId, Pattern.quote(delimiter));


### PR DESCRIPTION
### What changes were proposed in this pull request?

remove encoded annotation

### Why are the changes needed?

most http client will encode the specify chart automatically, so we don't need to disable automatic decoding of parameter

### Does this PR introduce _any_ user-facing change?

no

### How was this patch tested?

tested locally
