### PR TITLE
[#8061]improvement(tableOpsUtils): NPE in tableOpsUtils while validating column with null default values

### DIFF
--- a/catalogs/catalog-lakehouse-paimon/src/main/java/org/apache/gravitino/catalog/lakehouse/paimon/utils/TableOpsUtils.java
+++ b/catalogs/catalog-lakehouse-paimon/src/main/java/org/apache/gravitino/catalog/lakehouse/paimon/utils/TableOpsUtils.java
@@ -129,7 +129,7 @@ public class TableOpsUtils {
 
   private static void checkColumnDefaultValue(String fieldName, Expression defaultValue) {
     Preconditions.checkArgument(
-        defaultValue.equals(Column.DEFAULT_VALUE_NOT_SET),
+        defaultValue == null || defaultValue.equals(Column.DEFAULT_VALUE_NOT_SET),
         String.format(
             "Paimon set column default value through table properties instead of column info. Illegal column: %s.",
             fieldName));

--- a/catalogs/catalog-lakehouse-paimon/src/test/java/org/apache/gravitino/catalog/lakehouse/paimon/utils/TestTableOpsUtils.java
+++ b/catalogs/catalog-lakehouse-paimon/src/test/java/org/apache/gravitino/catalog/lakehouse/paimon/utils/TestTableOpsUtils.java
@@ -48,6 +48,7 @@ import java.util.Arrays;
 import java.util.function.Consumer;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.gravitino.rel.TableChange;
+import org.apache.gravitino.rel.expressions.Expression;
 import org.apache.gravitino.rel.expressions.literals.Literals;
 import org.apache.gravitino.rel.indexes.Index.IndexType;
 import org.apache.gravitino.rel.types.Types;
@@ -305,6 +306,17 @@ public class TestTableOpsUtils {
                     true),
                 "Paimon does not support auto increment column. Illegal column: col_1."))
         .forEach(this::assertIllegalTableChange);
+  }
+
+  @Test
+  void testAddColumnWithNullDefaultValue() {
+    assertTableChange(
+        addColumn(getFieldName("col_5"), IntegerType.get(), (Expression) null),
+        AddColumn.class,
+        schemaChange -> {
+          AddColumn addColumn = (AddColumn) schemaChange;
+          assertEquals("col_5", addColumn.fieldNames()[0]);
+        });
   }
 
   private void assertTableChange(


### PR DESCRIPTION
…fault values

<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Add a check for null as a possible default value in checkColumnDefaultvalues



### Why are the changes needed?
There is a potential NullPointerException when validating columns with null default values in checkColumnDefaultValues in tableOpsUtils.

Fix: (#8016 )

### Does this PR introduce _any_ user-facing change?
NO


### How was this patch tested?
unit testing

