### PR TITLE
[#8304] fix: Possible NPE in LineageService

### DIFF
--- a/lineage/src/main/java/org/apache/gravitino/lineage/LineageService.java
+++ b/lineage/src/main/java/org/apache/gravitino/lineage/LineageService.java
@@ -65,10 +65,12 @@ public class LineageService implements LineageDispatcher, SupportsRESTPackages {
 
   @Override
   public boolean dispatchLineageEvent(OpenLineage.RunEvent runEvent) {
+    if (runEvent == null) {
+      return false;
+    }
     if (sinkManager.isHighWatermark()) {
       return false;
     }
-
     RunEvent newEvent = processor.process(runEvent);
     sinkManager.sink(newEvent);
     return true;

--- a/lineage/src/test/java/org/apache/gravitino/lineage/TestLineageService.java
+++ b/lineage/src/test/java/org/apache/gravitino/lineage/TestLineageService.java
@@ -1,0 +1,32 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.apache.gravitino.lineage;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class TestLineageService {
+  @Test
+  void testDispatchLineageEventWithoutInitialization() {
+    try (LineageService service = new LineageService()) {
+      Assertions.assertFalse(service.dispatchLineageEvent(null));
+    }
+  }
+}


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?
Add a null check for the argument in dispatchLineageEvent and return false if it is null.

### Why are the changes needed?
 The method dispatchLineageEvent can throw a NullPointerException if called without proper initialization or with a null argument.

Fix: (#8304 )

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
unit testing

