### PR TITLE
[#8937] fix(core): Fix flaky test in testPolicyAndTagCacheWeigher (cherry-pick)

### DIFF
--- a/core/src/test/java/org/apache/gravitino/cache/TestCacheConfig.java
+++ b/core/src/test/java/org/apache/gravitino/cache/TestCacheConfig.java
@@ -147,7 +147,7 @@ public class TestCacheConfig {
               .build();
       cache.put(
           EntityCacheRelationKey.of(
-              NameIdentifier.of(new String[] {"metalake1", "catalog1", "schema1", filesetName}),
+              NameIdentifier.of("metalake1", "catalog1", "schema1", filesetName),
               Entity.EntityType.FILESET),
           List.of(fileset));
     }
@@ -201,11 +201,15 @@ public class TestCacheConfig {
             "Expected significant eviction due to weight limit (max=5000). Found filesets=%d, tags=%d (total=%d/20)",
             remainingFilesets, remainingTags, remainingFilesets + remainingTags));
 
-    Assertions.assertTrue(
-        remainingFilesets > remainingTags,
-        String.format(
-            "Expected filesets (weight=200, freq=5) to be prioritized over tags (weight=500, freq=1). Found filesets=%d, tags=%d",
-            remainingFilesets, remainingTags));
+    // Comment the following case due to the occasional test failure in CI environment. The weight
+    // mechanism in Caffeine is probabilistic, so in some rare cases tags may not be fully evicted.
+    // So we will comment out this strict assertion for now.
+    //    Assertions.assertTrue(
+    //        remainingFilesets > remainingTags,
+    //        String.format(
+    //            "Expected filesets (weight=200, freq=5) to be prioritized over tags (weight=500,
+    // freq=1). Found filesets=%d, tags=%d",
+    //            remainingFilesets, remainingTags));
   }
 
   @Test


### PR DESCRIPTION
### What changes were proposed in this pull request?

Comment out the flaky test cases.

### Why are the changes needed?

As the weight mechanism in the Caffeine cache is probabilistic, the CI pipeline will fail occasionally(failure rate is about 10% or so).

Fix: #8937

### Does this PR introduce _any_ user-facing change?

N/A.

### How was this patch tested?

The existing tests.