### PR TITLE
[#8969] fix(client-python): fix fileset test with GCS in python module

### DIFF
--- a/clients/client-python/gravitino/filesystem/gvfs_storage_handler.py
+++ b/clients/client-python/gravitino/filesystem/gvfs_storage_handler.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 import importlib
+import logging
 import sys
 import time
 from abc import ABC, abstractmethod
@@ -41,6 +42,8 @@ from gravitino.filesystem.gvfs_config import GVFSConfig
 
 TIME_WITHOUT_EXPIRATION = sys.maxsize
 SLASH = "/"
+
+logger = logging.getLogger(__name__)
 
 
 class StorageType(Enum):
@@ -103,6 +106,10 @@ class StorageHandler(ABC):
             entry["name"], fileset_location, gvfs_path_prefix
         )
         last_modified = self._get_last_modified(entry)
+        if last_modified is None:
+            logger.info(
+                "The last modified time is %s for %s", last_modified, fileset_location
+            )
         return {
             "name": path,
             "size": entry["size"],
@@ -189,7 +196,7 @@ class StorageHandler(ABC):
         return actual_path
 
     def _get_last_modified(self, entry: Dict):
-        return entry["mtime"]
+        return entry["mtime"] if "mtime" in entry else None
 
 
 class LocalStorageHandler(StorageHandler):

--- a/clients/client-python/tests/integration/test_gvfs_with_gcs.py
+++ b/clients/client-python/tests/integration/test_gvfs_with_gcs.py
@@ -283,8 +283,7 @@ class TestGvfsWithGCS(TestGvfsWithHDFS):
         mkdir_dir = mkdir_dir.replace(self.bucket_name, new_bucket)
         mkdir_actual_dir = mkdir_actual_dir.replace(self.bucket_name, new_bucket)
 
-        with self.assertRaises(OSError):
-            fs.mkdir(mkdir_dir, create_parents=True)
+        fs.mkdir(mkdir_dir, create_parents=True)
         self.assertFalse(self.fs.exists(mkdir_actual_dir))
 
     def test_makedirs(self):

--- a/clients/client-python/tests/integration/test_gvfs_with_hdfs.py
+++ b/clients/client-python/tests/integration/test_gvfs_with_hdfs.py
@@ -216,7 +216,9 @@ class TestGvfsWithHDFS(IntegrationTestEnv):
     @classmethod
     def _clean_test_data(cls):
         cls.gravitino_client = GravitinoClient(
-            uri="http://localhost:8090", metalake_name=cls.metalake_name
+            uri="http://localhost:8090",
+            metalake_name=cls.metalake_name,
+            client_config={"gravitino_client_request_timeout": 180},
         )
         catalog = cls.gravitino_client.load_catalog(name=cls.catalog_name)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

1. Increase the timeout time when connecting to the Gravitino server.
2. In some cases, the modification time of the GCS file/directory is empty.

### Why are the changes needed?

It's a bug.

Fix: #8969

### Does this PR introduce _any_ user-facing change?

N/A.

### How was this patch tested?

It's self test.
