### PR TITLE
[#8863] improvement(policy): Add a convenience method to get all rules in the policy content

### DIFF
--- a/api/src/main/java/org/apache/gravitino/policy/PolicyContent.java
+++ b/api/src/main/java/org/apache/gravitino/policy/PolicyContent.java
@@ -38,6 +38,16 @@ public interface PolicyContent {
   Map<String, String> properties();
 
   /**
+   * A convenience method to get all rules in the policy content.
+   *
+   * @return A map of rule names to their corresponding rule objects.
+   */
+  default Map<String, Object> rules() {
+    // backward compatibility
+    throw new UnsupportedOperationException("Does support get all rules.");
+  }
+
+  /**
    * Validates the policy content.
    *
    * @throws IllegalArgumentException if the content is invalid.

--- a/api/src/main/java/org/apache/gravitino/policy/PolicyContents.java
+++ b/api/src/main/java/org/apache/gravitino/policy/PolicyContents.java
@@ -88,6 +88,11 @@ public class PolicyContents {
     }
 
     @Override
+    public Map<String, Object> rules() {
+      return customRules;
+    }
+
+    @Override
     public Set<MetadataObject.Type> supportedObjectTypes() {
       return supportedObjectTypes;
     }

--- a/clients/client-java/src/test/java/org/apache/gravitino/client/integration/test/PolicyIT.java
+++ b/clients/client-java/src/test/java/org/apache/gravitino/client/integration/test/PolicyIT.java
@@ -197,6 +197,7 @@ public class PolicyIT extends BaseIT {
     Assertions.assertTrue(policy.enabled());
     Assertions.assertFalse(policy.inherited().isPresent());
     Assertions.assertEquals(content, policy.content());
+    Assertions.assertEquals(content.rules(), policy.content().rules());
 
     // Test already existed policy
     Assertions.assertThrows(
@@ -212,6 +213,7 @@ public class PolicyIT extends BaseIT {
     Assertions.assertTrue(fetchedPolicy.enabled());
     Assertions.assertFalse(fetchedPolicy.inherited().isPresent());
     Assertions.assertEquals(content, fetchedPolicy.content());
+    Assertions.assertEquals(content.rules(), fetchedPolicy.content().rules());
 
     // test List names
     String policyName1 = GravitinoITUtils.genRandomName("policy_it_policy1");


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add a convenience method to get all rules in the policy content

### Why are the changes needed?

Fix: #8863

### Does this PR introduce _any_ user-facing change?

yes, the new method is for the client

### How was this patch tested?

tests added
