### PR TITLE
[#9077] fix(dto): Ensure updates list is not null

### DIFF
--- a/common/src/main/java/org/apache/gravitino/dto/requests/CatalogUpdatesRequest.java
+++ b/common/src/main/java/org/apache/gravitino/dto/requests/CatalogUpdatesRequest.java
@@ -19,6 +19,7 @@
 package org.apache.gravitino.dto.requests;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Preconditions;
 import java.util.List;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -55,6 +56,7 @@ public class CatalogUpdatesRequest implements RESTRequest {
    */
   @Override
   public void validate() throws IllegalArgumentException {
+    Preconditions.checkArgument(updates != null, "updates must not be null");
     updates.forEach(RESTRequest::validate);
   }
 }

--- a/common/src/main/java/org/apache/gravitino/dto/requests/JobTemplateUpdatesRequest.java
+++ b/common/src/main/java/org/apache/gravitino/dto/requests/JobTemplateUpdatesRequest.java
@@ -19,6 +19,7 @@
 package org.apache.gravitino.dto.requests;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Preconditions;
 import java.util.List;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -55,6 +56,7 @@ public class JobTemplateUpdatesRequest implements RESTRequest {
    */
   @Override
   public void validate() throws IllegalArgumentException {
+    Preconditions.checkArgument(updates != null, "updates must not be null");
     updates.forEach(RESTRequest::validate);
   }
 }

--- a/common/src/main/java/org/apache/gravitino/dto/requests/MetalakeUpdatesRequest.java
+++ b/common/src/main/java/org/apache/gravitino/dto/requests/MetalakeUpdatesRequest.java
@@ -19,6 +19,7 @@
 package org.apache.gravitino.dto.requests;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Preconditions;
 import java.util.List;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -55,6 +56,7 @@ public class MetalakeUpdatesRequest implements RESTRequest {
    */
   @Override
   public void validate() throws IllegalArgumentException {
+    Preconditions.checkArgument(updates != null, "updates must not be null");
     updates.forEach(RESTRequest::validate);
   }
 }

--- a/common/src/main/java/org/apache/gravitino/dto/requests/ModelUpdatesRequest.java
+++ b/common/src/main/java/org/apache/gravitino/dto/requests/ModelUpdatesRequest.java
@@ -20,6 +20,7 @@
 package org.apache.gravitino.dto.requests;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Preconditions;
 import java.util.List;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -55,6 +56,7 @@ public class ModelUpdatesRequest implements RESTRequest {
    */
   @Override
   public void validate() throws IllegalArgumentException {
+    Preconditions.checkArgument(updates != null, "updates must not be null");
     updates.forEach(RESTRequest::validate);
   }
 }

--- a/common/src/main/java/org/apache/gravitino/dto/requests/SchemaUpdatesRequest.java
+++ b/common/src/main/java/org/apache/gravitino/dto/requests/SchemaUpdatesRequest.java
@@ -19,6 +19,7 @@
 package org.apache.gravitino.dto.requests;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Preconditions;
 import java.util.List;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -55,6 +56,7 @@ public class SchemaUpdatesRequest implements RESTRequest {
    */
   @Override
   public void validate() throws IllegalArgumentException {
+    Preconditions.checkArgument(updates != null, "updates must not be null");
     updates.forEach(RESTRequest::validate);
   }
 }

--- a/common/src/main/java/org/apache/gravitino/dto/requests/TableUpdatesRequest.java
+++ b/common/src/main/java/org/apache/gravitino/dto/requests/TableUpdatesRequest.java
@@ -19,6 +19,7 @@
 package org.apache.gravitino.dto.requests;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Preconditions;
 import java.util.List;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -55,6 +56,7 @@ public class TableUpdatesRequest implements RESTRequest {
    */
   @Override
   public void validate() throws IllegalArgumentException {
+    Preconditions.checkArgument(updates != null, "updates must not be null");
     updates.forEach(RESTRequest::validate);
   }
 }

--- a/common/src/main/java/org/apache/gravitino/dto/requests/TopicUpdatesRequest.java
+++ b/common/src/main/java/org/apache/gravitino/dto/requests/TopicUpdatesRequest.java
@@ -19,6 +19,7 @@
 package org.apache.gravitino.dto.requests;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Preconditions;
 import java.util.List;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -55,6 +56,7 @@ public class TopicUpdatesRequest implements RESTRequest {
    */
   @Override
   public void validate() throws IllegalArgumentException {
+    Preconditions.checkArgument(updates != null, "Updates list cannot be null");
     updates.forEach(RESTRequest::validate);
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

- Prevent potential `NPE` in the validate method of classes implementing `RESTRequest`.
- Although not requested, TopicCreateRequest was also included in the PR since it follows the same structure and should not allow `NPE` either.

### Why are the changes needed?

- Added null check for updates list in request validation.

Fix: #9077

### Does this PR introduce _any_ user-facing change?

- no.
- This change only corrects internal exception handling logic, with no modification to public APIs or user-visible behavior.


### How was this patch tested?

- No new tests added, since this only fixes the caught exception type.
- Ensured all existing tests continue to pass.
