### PR TITLE
[#9110] fix(spark): clean cache when execute refresh table sql

### DIFF
--- a/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/catalog/BaseCatalog.java
+++ b/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/catalog/BaseCatalog.java
@@ -462,4 +462,9 @@ public abstract class BaseCatalog implements TableCatalog, SupportsNamespaces {
           e);
     }
   }
+
+  @Override
+  public void invalidateTable(Identifier ident) {
+    sparkCatalog.invalidateTable(ident);
+  }
 }

--- a/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/hive/GravitinoHiveCatalog.java
+++ b/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/hive/GravitinoHiveCatalog.java
@@ -77,9 +77,4 @@ public class GravitinoHiveCatalog extends BaseCatalog {
   protected SparkTypeConverter getSparkTypeConverter() {
     return new SparkHiveTypeConverter();
   }
-
-  @Override
-  public void invalidateTable(Identifier ident) {
-    sparkCatalog.invalidateTable(ident);
-  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Overriding the invalidateTable() method in BaseCatalog

### Why are the changes needed?

After a Spark session started using spark-connecto plugin, and then a table is modified via a Hive client, Spark's refresh table statement fails to clear the table's fileStatusCache,making it impossible to query the latest data from the table.

Fix: #9110 

### Does this PR introduce _any_ user-facing change?

N/A.

### How was this patch tested?

ITs
