### PR TITLE
Update the mapping between principal and username

### DIFF
--- a/server-common/src/main/java/org/apache/gravitino/server/authentication/KerberosAuthenticator.java
+++ b/server-common/src/main/java/org/apache/gravitino/server/authentication/KerberosAuthenticator.java
@@ -177,7 +177,7 @@ public class KerberosAuthenticator implements Authenticator {
         throw new UnauthorizedException("Principal has wrong format", AuthConstants.NEGOTIATE);
       }
 
-      String user = principalComponents.get(0);
+      String user = Splitter.on('/').splitToList(principalComponents.get(0)).get(0);
       // TODO: We will have KerberosUserPrincipal in the future.
       //  We can put more information of Kerberos to the KerberosUserPrincipal
       // For example, we can put the token into the KerberosUserPrincipal,


### PR DESCRIPTION

[#9108 ]fix(server-common) Update the mapping between principal and username

### What changes were proposed in this pull request?

Tenant principals are typically in the format "userName/groupName@realm". When accessing a Kerberos-authenticated Gravitino server using the spark-connector, the tenant's username is mapped to "userName/groupName". However, there is no "userName/groupName" user in Hadoop. Hadoop's auth_to_local rule generally maps to "userName".

### Why are the changes needed?

permission verification

Fix: #9108

### Does this PR introduce _any_ user-facing change?

N/A.

### How was this patch tested?

ITs
