### PR TITLE
[#9124] Handle negative partNo safely and fix test file typo

### DIFF
--- a/clients/cli/src/main/java/org/apache/gravitino/cli/FullName.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/FullName.java
@@ -215,7 +215,7 @@ public class FullName {
       int length = names.length;
       int position = partNo;
 
-      return position >= 0 && position <= length;
+      return position > 0 && position <= length;
     }
 
     return false;

--- a/clients/cli/src/test/java/org/apache/gravitino/cli/TestFullName.java
+++ b/clients/cli/src/test/java/org/apache/gravitino/cli/TestFullName.java
@@ -278,6 +278,8 @@ public class TestFullName {
     CommandLine commandLine = new DefaultParser().parse(options, args);
     FullName fullName = new FullName(commandLine);
 
+    assertFalse(fullName.hasNamePart(0));
+
     assertTrue(fullName.hasNamePart(1));
     assertTrue(fullName.hasNamePart(2));
     assertTrue(fullName.hasNamePart(3));


### PR DESCRIPTION
Fixed #9124

- Negative partNo values can now be safely handled.
- Added unit test cases to verify this behavior.
- Renamed the test file from TestFulllName to TestFullName to fix a minor typo.