### PR TITLE
[#9080][Improvement]Fix the Flink TypeUtils map conversion to use value-type nullability

### DIFF
--- a/flink-connector/flink/src/main/java/org/apache/gravitino/flink/connector/utils/TypeUtils.java
+++ b/flink-connector/flink/src/main/java/org/apache/gravitino/flink/connector/utils/TypeUtils.java
@@ -102,8 +102,9 @@ public class TypeUtils {
         return Types.TimestampType.withTimeZone(zonedPrecision);
       case ARRAY:
         ArrayType arrayType = (ArrayType) logicalType;
-        Type elementType = toGravitinoType(arrayType.getElementType());
-        return Types.ListType.of(elementType, arrayType.isNullable());
+        LogicalType elementLogicalType = arrayType.getElementType();
+        Type elementType = toGravitinoType(elementLogicalType);
+        return Types.ListType.of(elementType, elementLogicalType.isNullable());
       case MAP:
         MapType mapType = (MapType) logicalType;
         LogicalType keyType = mapType.getKeyType();

--- a/flink-connector/flink/src/test/java/org/apache/gravitino/flink/connector/utils/TestTypeUtils.java
+++ b/flink-connector/flink/src/test/java/org/apache/gravitino/flink/connector/utils/TestTypeUtils.java
@@ -86,10 +86,13 @@ public class TestTypeUtils {
             new YearMonthIntervalType(YearMonthIntervalType.YearMonthResolution.YEAR)));
     Assertions.assertEquals(
         Types.ListType.notNull(Types.IntegerType.get()),
-        TypeUtils.toGravitinoType(new ArrayType(false, new IntType())));
+        TypeUtils.toGravitinoType(new ArrayType(false, new IntType(false))));
     Assertions.assertEquals(
         Types.ListType.nullable(Types.IntegerType.get()),
-        TypeUtils.toGravitinoType(new ArrayType(true, new IntType())));
+        TypeUtils.toGravitinoType(new ArrayType(true, new IntType(true))));
+    Assertions.assertEquals(
+        Types.ListType.nullable(Types.IntegerType.get()),
+        TypeUtils.toGravitinoType(new ArrayType(false, new IntType(true))));
     Assertions.assertEquals(
         Types.MapType.of(Types.StringType.get(), Types.IntegerType.get(), true),
         TypeUtils.toGravitinoType(
@@ -102,6 +105,10 @@ public class TestTypeUtils {
         Types.MapType.of(Types.StringType.get(), Types.IntegerType.get(), false),
         TypeUtils.toGravitinoType(
             new MapType(false, new VarCharType(Integer.MAX_VALUE), new IntType(false))));
+    Assertions.assertEquals(
+        Types.MapType.of(Types.StringType.get(), Types.IntegerType.get(), true),
+        TypeUtils.toGravitinoType(
+            new MapType(false, new VarCharType(Integer.MAX_VALUE), new IntType(true))));
     Assertions.assertEquals(
         Types.StructType.of(
             Types.StructType.Field.nullableField("a", Types.IntegerType.get()),
@@ -154,6 +161,10 @@ public class TestTypeUtils {
         DataTypes.MAP(DataTypes.STRING(), DataTypes.INT().nullable()),
         TypeUtils.toFlinkType(
             Types.MapType.of(Types.StringType.get(), Types.IntegerType.get(), true)));
+    Assertions.assertEquals(
+        DataTypes.MAP(DataTypes.STRING(), DataTypes.INT().notNull()),
+        TypeUtils.toFlinkType(
+            Types.MapType.of(Types.StringType.get(), Types.IntegerType.get(), false)));
     Assertions.assertEquals(
         DataTypes.ROW(
             DataTypes.FIELD("a", DataTypes.INT().nullable()),


### PR DESCRIPTION


<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Fix the Flink TypeUtils map conversion to use value-type nullability instead of map-level nullability.

### Why are the changes needed?


Fix: #9080 

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
update some unit tests

