### PR TITLE
[#9125] Replace UNKNOWN_USER with UNKNOWN_ENTITY in NoSuchMetadataObjectException

### DIFF
--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/RevokePrivilegesFromRole.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/RevokePrivilegesFromRole.java
@@ -89,7 +89,7 @@ public class RevokePrivilegesFromRole extends MetadataCommand {
     } catch (NoSuchRoleException err) {
       exitWithError(ErrorMessages.UNKNOWN_ROLE);
     } catch (NoSuchMetadataObjectException err) {
-      exitWithError(ErrorMessages.UNKNOWN_USER);
+      exitWithError(ErrorMessages.UNKNOWN_ENTITY);
     } catch (Exception exp) {
       exitWithError(exp.getMessage());
     }


### PR DESCRIPTION
Fixed : #9125

This PR refactors - NoSuchMetadataObjectException refers strictly to missing metadata entities and not to users.
This patch replaces `UNKNOWN_USER` with `UNKNOWN_ENTITY` to more accurately represent the failure condition and align with naming semantics