### PR TITLE
[#9122] [Improvement]: Prevent potential null pointer error in MetadataObjectStatisticsOperations.java

### DIFF
--- a/clients/client-java/src/main/java/org/apache/gravitino/client/MetadataObjectStatisticsOperations.java
+++ b/clients/client-java/src/main/java/org/apache/gravitino/client/MetadataObjectStatisticsOperations.java
@@ -93,6 +93,9 @@ class MetadataObjectStatisticsOperations implements SupportsStatistics {
 
   @Override
   public boolean dropStatistics(List<String> statistics) throws UnmodifiableStatisticException {
+    Preconditions.checkArgument(
+        statistics != null && !statistics.isEmpty(), "Statistics list must not be null or empty");
+
     StatisticsDropRequest request = new StatisticsDropRequest(statistics.toArray(new String[0]));
     request.validate();
 

--- a/clients/client-java/src/test/java/org/apache/gravitino/client/TestSupportsStatistics.java
+++ b/clients/client-java/src/test/java/org/apache/gravitino/client/TestSupportsStatistics.java
@@ -251,6 +251,15 @@ public class TestSupportsStatistics extends TestBase {
     Assertions.assertThrows(
         UnmodifiableStatisticException.class,
         () -> supportsStatistics.dropStatistics(statisticsToDrop));
+
+    // Test null statistics list exception
+    Assertions.assertThrows(
+        IllegalArgumentException.class, () -> supportsStatistics.dropStatistics(null));
+
+    // Test empty statistics list exception
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> supportsStatistics.dropStatistics(Collections.emptyList()));
   }
 
   private String getTableStatisticsPath() {


### PR DESCRIPTION

<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

- Add argument validation in MetadataObjectStatisticsOperations#dropStatistics to throw IllegalArgumentException when the list is null or empty.
- Extend unit tests to assert null/empty list behavior.

### Why are the changes needed?

- Prevents potential NullPointerException and provides clearer error feedback to callers.

Fix: #9122

### Does this PR introduce _any_ user-facing change?

- dropStatistics(null | empty) now throws IllegalArgumentException (null input previously could cause NPE).

### How was this patch tested?

- Unit tests added for null and empty list inputs.
