### PR TITLE
[#9121] fix(auth): Correct KeyFactory handling for ECDSA algorithms

### DIFF
--- a/server-common/src/main/java/org/apache/gravitino/server/authentication/StaticSignKeyValidator.java
+++ b/server-common/src/main/java/org/apache/gravitino/server/authentication/StaticSignKeyValidator.java
@@ -112,17 +112,27 @@ public class StaticSignKeyValidator implements OAuthTokenValidator {
       SignatureAlgorithmFamilyType algFamilyType =
           SignatureAlgorithmFamilyType.valueOf(SignatureAlgorithm.valueOf(algType).getFamilyName());
 
-      if (SignatureAlgorithmFamilyType.HMAC == algFamilyType) {
-        return Keys.hmacShaKeyFor(key);
-      } else if (SignatureAlgorithmFamilyType.RSA == algFamilyType
-          || SignatureAlgorithmFamilyType.ECDSA == algFamilyType) {
-        X509EncodedKeySpec spec = new X509EncodedKeySpec(key);
-        KeyFactory kf = KeyFactory.getInstance(algFamilyType.name());
-        return kf.generatePublic(spec);
-      }
+      return generateKeyByFamilyType(algFamilyType, key, algType);
     } catch (Exception e) {
       throw new IllegalArgumentException("Failed to decode key", e);
     }
-    throw new IllegalArgumentException("Unsupported signature algorithm type: " + algType);
+  }
+
+  private static Key generateKeyByFamilyType(
+      SignatureAlgorithmFamilyType algFamilyType, byte[] key, String algType) throws Exception {
+
+    switch (algFamilyType) {
+      case RSA:
+        return KeyFactory.getInstance("RSA").generatePublic(new X509EncodedKeySpec(key));
+
+      case ECDSA:
+        return KeyFactory.getInstance("EC").generatePublic(new X509EncodedKeySpec(key));
+
+      case HMAC:
+        return Keys.hmacShaKeyFor(key);
+
+      default:
+        throw new IllegalArgumentException("Unsupported signature algorithm type: " + algType);
+    }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

- Fixed incorrect KeyFactory lookup for ECDSA algorithms.
- Updated the key generation logic to use "EC" instead of "ECDSA" when handling ES256/ES384/ES512 keys.
- Refactored the branching into a dedicated generateKeyByFamilyType method.


### Why are the changes needed?

- Java does not provide a KeyFactory named "ECDSA", which caused token validation to fail with ECDSA signatures.
- Using "EC" resolves the issue and allows proper validation of ES256 tokens.

Fix: #9121 

### Does this PR introduce _any_ user-facing change?
- no.
- This change only corrects internal exception handling logic, with no modification to public APIs or user-visible behavior.

### How was this patch tested?
- Verified using an ES256 token generation flow as described in the issue.
- Confirmed all existing tests continue to pass.
