### PR TITLE
[#9139] fix(lock): Prevent NPE when timestamp is missing in TreeLock.unlock

### DIFF
--- a/core/src/main/java/org/apache/gravitino/lock/TreeLock.java
+++ b/core/src/main/java/org/apache/gravitino/lock/TreeLock.java
@@ -153,15 +153,18 @@ public class TreeLock {
       LockType type = pair.getRight();
       current.unlock(type);
 
-      long holdStartTime = current.removeHoldingThreadTimestamp(Thread.currentThread(), identifier);
+      Long holdStartTime = current.removeHoldingThreadTimestamp(Thread.currentThread(), identifier);
       if (LOG.isTraceEnabled()) {
+        long duration =
+            (holdStartTime == null) ? -1L : (System.currentTimeMillis() - holdStartTime);
+
         LOG.trace(
             "Node {} has been unlock with '{}' lock, hold by {} with ident '{}' for {} ms",
             this,
             type,
             Thread.currentThread(),
             identifier,
-            System.currentTimeMillis() - holdStartTime);
+            duration);
       }
     }
 

--- a/core/src/main/java/org/apache/gravitino/lock/TreeLockNode.java
+++ b/core/src/main/java/org/apache/gravitino/lock/TreeLockNode.java
@@ -117,7 +117,7 @@ public class TreeLockNode {
     holdingThreadTimestamp.put(ThreadIdentifier.of(currentThread, identifier), timestamp);
   }
 
-  long removeHoldingThreadTimestamp(Thread currentThread, NameIdentifier identifier) {
+  Long removeHoldingThreadTimestamp(Thread currentThread, NameIdentifier identifier) {
     return holdingThreadTimestamp.remove(ThreadIdentifier.of(currentThread, identifier));
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
- Updated TreeLockNode.removeHoldingThreadTimestamp to return a nullable Long instead of long.
- Modified TreeLock.unlock() to handle null timestamps safely before logging.
- Ensures unlocking works correctly even when the timestamp map is cleared.

### Why are the changes needed?

- holdingThreadTimestamp is a Map<ThreadIdentifier, Long>, and Map.remove() returns null when no timestamp exists.
- The previous implementation returned long, causing a null → primitive unboxing and leading to a NullPointerException.
- Unlocking a node should not depend on the presence of a timestamp value, so the logic must tolerate null entries.

Fix: #9139 

### Does this PR introduce _any_ user-facing change?

- no.
- This change only improves internal lock handling and exception safety.

### How was this patch tested?
- Verified using the unit test included in the issue (testUnlockWithMissingHoldingTimestamp).
- Confirmed all existing tests continue to pass.
