### PR TITLE
[#9137] fix(stats): initialize comparator with DEFAULT_COMPARATOR in default constructor

### DIFF
--- a/api/src/main/java/org/apache/gravitino/stats/PartitionRange.java
+++ b/api/src/main/java/org/apache/gravitino/stats/PartitionRange.java
@@ -36,7 +36,9 @@ public class PartitionRange {
 
   private SortOrder comparator;
 
-  private PartitionRange() {}
+  private PartitionRange() {
+    this.comparator = DEFAULT_COMPARATOR;
+  }
 
   /** A PartitionRange that includes all partitions. */
   public static final PartitionRange ALL_PARTITIONS = new PartitionRange();

--- a/api/src/test/java/org/apache/gravitino/stats/TestPartitionRange.java
+++ b/api/src/test/java/org/apache/gravitino/stats/TestPartitionRange.java
@@ -95,4 +95,16 @@ public class TestPartitionRange {
         IllegalArgumentException.class,
         () -> PartitionRange.upTo("upper", PartitionRange.BoundType.CLOSED, null));
   }
+
+  @Test
+  public void testAllPartitionsComparator() {
+    SortOrder defaultSortOrder =
+        SortOrders.of(NamedReference.MetadataField.PARTITION_NAME_FIELD, SortDirection.ASCENDING);
+
+    PartitionRange allPartitions = PartitionRange.ALL_PARTITIONS;
+
+    Assertions.assertFalse(allPartitions.lowerPartitionName().isPresent());
+    Assertions.assertFalse(allPartitions.upperPartitionName().isPresent());
+    Assertions.assertEquals(defaultSortOrder, allPartitions.comparator());
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

- Initialize the comparator with DEFAULT_COMPARATOR in the default constructor.

### Why are the changes needed?

- The default constructor used by ALL_PARTITIONS does not initialize the comparator, which results in it being null.

Fix: #9137

### Does this PR introduce _any_ user-facing change?

- No.

### How was this patch tested?

- Verified using the unit test included in the issue (testAllPartitionsComparator()).
- Confirmed all existing tests continue to pass.
