### PR TITLE
[#8919] improve(lance-table): Supports object store configurations fo…

### DIFF
--- a/catalogs/catalog-generic-lakehouse/src/main/java/org/apache/gravitino/catalog/lakehouse/GenericLakehouseCatalogOperations.java
+++ b/catalogs/catalog-generic-lakehouse/src/main/java/org/apache/gravitino/catalog/lakehouse/GenericLakehouseCatalogOperations.java
@@ -19,6 +19,7 @@
 package org.apache.gravitino.catalog.lakehouse;
 
 import static org.apache.gravitino.Entity.EntityType.TABLE;
+import static org.apache.gravitino.catalog.lakehouse.GenericLakehouseTablePropertiesMetadata.LOCATION;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Maps;
@@ -26,6 +27,8 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
+import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.gravitino.Catalog;
 import org.apache.gravitino.Entity;
@@ -79,8 +82,10 @@ public class GenericLakehouseCatalogOperations
   private static final Map<String, LakehouseCatalogOperations> SUPPORTED_FORMATS =
       Maps.newHashMap();
 
+  private Map<String, String> catalogConfig;
   private CatalogInfo catalogInfo;
   private HasPropertyMetadata propertiesMetadata;
+
   /**
    * Initializes the generic lakehouse catalog operations with the provided configuration.
    *
@@ -102,6 +107,9 @@ public class GenericLakehouseCatalogOperations
         StringUtils.isNotBlank(catalogLocation)
             ? Optional.of(catalogLocation).map(this::ensureTrailingSlash).map(Path::new)
             : Optional.empty();
+    this.catalogConfig = conf;
+    this.catalogInfo = info;
+    this.propertiesMetadata = propertiesMetadata;
   }
 
   public GenericLakehouseCatalogOperations() {
@@ -207,11 +215,15 @@ public class GenericLakehouseCatalogOperations
       SortOrder[] sortOrders,
       Index[] indexes)
       throws NoSuchSchemaException, TableAlreadyExistsException {
-    String format = properties.getOrDefault("format", "lance");
-    String tableLocation = calculateTableLocation(ident, properties);
-    Map<String, String> newProperties = Maps.newHashMap(properties);
-    newProperties.put("location", tableLocation);
+    Schema schema = loadSchema(NameIdentifier.of(ident.namespace().levels()));
+    String tableLocation = calculateTableLocation(schema, ident, properties);
+    Map<String, String> tableStorageProps = calculateTableStorageProps(schema, properties);
 
+    Map<String, String> newProperties = Maps.newHashMap(properties);
+    newProperties.put(LOCATION, tableLocation);
+    newProperties.putAll(tableStorageProps);
+
+    String format = properties.getOrDefault("format", "lance");
     LakehouseCatalogOperations lakehouseCatalogOperations =
         SUPPORTED_FORMATS.compute(
             format,
@@ -226,22 +238,13 @@ public class GenericLakehouseCatalogOperations
   }
 
   private String calculateTableLocation(
-      NameIdentifier tableIdent, Map<String, String> tableProperties) {
-    String tableLocation = tableProperties.get("location");
+      Schema schema, NameIdentifier tableIdent, Map<String, String> tableProperties) {
+    String tableLocation = tableProperties.get(LOCATION);
     if (StringUtils.isNotBlank(tableLocation)) {
       return ensureTrailingSlash(tableLocation);
     }
 
-    String schemaLocation;
-    try {
-      Schema schema = loadSchema(NameIdentifier.of(tableIdent.namespace().levels()));
-      schemaLocation = schema.properties().get("location");
-    } catch (NoSuchSchemaException e) {
-      throw new RuntimeException(
-          String.format(
-              "Failed to load schema for table %s to determine default location.", tableIdent),
-          e);
-    }
+    String schemaLocation = schema.properties() == null ? null : schema.properties().get(LOCATION);
 
     // If we do not set location in table properties, and schema location is set, use schema
     // location
@@ -321,5 +324,34 @@ public class GenericLakehouseCatalogOperations
 
     operations.initialize(properties, catalogInfo, propertiesMetadata);
     return operations;
+  }
+
+  /**
+   * Calculate the table storage properties by merging catalog config, schema properties and table
+   * properties. The precedence is: table properties > schema properties > catalog config.
+   *
+   * @param schema The schema of the table.
+   * @param tableProps The table properties.
+   * @return The merged table storage properties.
+   */
+  private Map<String, String> calculateTableStorageProps(
+      Schema schema, Map<String, String> tableProps) {
+    Map<String, String> storageProps = getLanceTableStorageOptions(catalogConfig);
+    storageProps.putAll(getLanceTableStorageOptions(schema.properties()));
+    storageProps.putAll(getLanceTableStorageOptions(tableProps));
+    return storageProps;
+  }
+
+  private Map<String, String> getLanceTableStorageOptions(Map<String, String> properties) {
+    if (MapUtils.isEmpty(properties)) {
+      return Maps.newHashMap();
+    }
+    return properties.entrySet().stream()
+        .filter(
+            e ->
+                e.getKey()
+                    .startsWith(
+                        GenericLakehouseTablePropertiesMetadata.LANCE_TABLE_STORAGE_OPTION_PREFIX))
+        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
   }
 }

--- a/catalogs/catalog-generic-lakehouse/src/main/java/org/apache/gravitino/catalog/lakehouse/GenericLakehouseCatalogPropertiesMetadata.java
+++ b/catalogs/catalog-generic-lakehouse/src/main/java/org/apache/gravitino/catalog/lakehouse/GenericLakehouseCatalogPropertiesMetadata.java
@@ -19,6 +19,7 @@
 
 package org.apache.gravitino.catalog.lakehouse;
 
+import static org.apache.gravitino.catalog.lakehouse.GenericLakehouseTablePropertiesMetadata.LANCE_TABLE_STORAGE_OPTION_PREFIX;
 import static org.apache.gravitino.connector.PropertyEntry.stringOptionalPropertyEntry;
 
 import com.google.common.collect.ImmutableList;
@@ -42,7 +43,14 @@ public class GenericLakehouseCatalogPropertiesMetadata extends BaseCatalogProper
                 "The root directory of the lakehouse catalog.",
                 false /* immutable */,
                 null, /* defaultValue */
-                false /* hidden */));
+                false /* hidden */),
+            PropertyEntry.stringOptionalPropertyPrefixEntry(
+                LANCE_TABLE_STORAGE_OPTION_PREFIX,
+                "The storage options passed to Lance table.",
+                false /* immutable */,
+                null /* default value*/,
+                false /* hidden */,
+                false /* reserved */));
 
     PROPERTIES_METADATA = Maps.uniqueIndex(propertyEntries, PropertyEntry::getName);
   }

--- a/catalogs/catalog-generic-lakehouse/src/main/java/org/apache/gravitino/catalog/lakehouse/GenericLakehouseSchemaPropertiesMetadata.java
+++ b/catalogs/catalog-generic-lakehouse/src/main/java/org/apache/gravitino/catalog/lakehouse/GenericLakehouseSchemaPropertiesMetadata.java
@@ -18,6 +18,7 @@
  */
 package org.apache.gravitino.catalog.lakehouse;
 
+import static org.apache.gravitino.catalog.lakehouse.GenericLakehouseTablePropertiesMetadata.LANCE_TABLE_STORAGE_OPTION_PREFIX;
 import static org.apache.gravitino.connector.PropertyEntry.stringOptionalPropertyEntry;
 
 import com.google.common.collect.ImmutableList;
@@ -41,7 +42,14 @@ public class GenericLakehouseSchemaPropertiesMetadata extends BasePropertiesMeta
                 "The root directory of the lakehouse schema.",
                 false /* immutable */,
                 null, /* defaultValue */
-                false /* hidden */));
+                false /* hidden */),
+            PropertyEntry.stringOptionalPropertyPrefixEntry(
+                LANCE_TABLE_STORAGE_OPTION_PREFIX,
+                "The storage options passed to Lance table.",
+                false /* immutable */,
+                null /* default value*/,
+                false /* hidden */,
+                false /* reserved */));
 
     PROPERTIES_METADATA = Maps.uniqueIndex(propertyEntries, PropertyEntry::getName);
   }

--- a/catalogs/catalog-generic-lakehouse/src/main/java/org/apache/gravitino/catalog/lakehouse/GenericLakehouseTablePropertiesMetadata.java
+++ b/catalogs/catalog-generic-lakehouse/src/main/java/org/apache/gravitino/catalog/lakehouse/GenericLakehouseTablePropertiesMetadata.java
@@ -18,21 +18,43 @@
  */
 package org.apache.gravitino.catalog.lakehouse;
 
-import com.google.common.collect.ImmutableMap;
+import static org.apache.gravitino.connector.PropertyEntry.stringOptionalPropertyEntry;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Maps;
+import java.util.List;
 import java.util.Map;
 import org.apache.gravitino.connector.BasePropertiesMetadata;
 import org.apache.gravitino.connector.PropertyEntry;
 
 public class GenericLakehouseTablePropertiesMetadata extends BasePropertiesMetadata {
+  public static final String LOCATION = "location";
+  public static final String LANCE_TABLE_STORAGE_OPTION_PREFIX = "lance.storage.";
 
-  private static final Map<String, PropertyEntry<?>> propertiesMetadata;
+  private static final Map<String, PropertyEntry<?>> PROPERTIES_METADATA;
 
   static {
-    propertiesMetadata = ImmutableMap.of();
+    List<PropertyEntry<?>> propertyEntries =
+        ImmutableList.of(
+            stringOptionalPropertyEntry(
+                LOCATION,
+                "The root directory of the lakehouse table.",
+                true /* immutable */,
+                null, /* defaultValue */
+                false /* hidden */),
+            PropertyEntry.stringOptionalPropertyPrefixEntry(
+                LANCE_TABLE_STORAGE_OPTION_PREFIX,
+                "The storage options passed to Lance table.",
+                false /* immutable */,
+                null /* default value*/,
+                false /* hidden */,
+                false /* reserved */));
+
+    PROPERTIES_METADATA = Maps.uniqueIndex(propertyEntries, PropertyEntry::getName);
   }
 
   @Override
   protected Map<String, PropertyEntry<?>> specificPropertyEntries() {
-    return propertiesMetadata;
+    return PROPERTIES_METADATA;
   }
 }

--- a/catalogs/catalog-generic-lakehouse/src/main/java/org/apache/gravitino/catalog/lakehouse/lance/LanceCatalogOperations.java
+++ b/catalogs/catalog-generic-lakehouse/src/main/java/org/apache/gravitino/catalog/lakehouse/lance/LanceCatalogOperations.java
@@ -19,6 +19,9 @@
 
 package org.apache.gravitino.catalog.lakehouse.lance;
 
+import static org.apache.gravitino.catalog.lakehouse.GenericLakehouseTablePropertiesMetadata.LANCE_TABLE_STORAGE_OPTION_PREFIX;
+import static org.apache.gravitino.catalog.lakehouse.GenericLakehouseTablePropertiesMetadata.LOCATION;
+
 import com.google.common.collect.ImmutableMap;
 import com.lancedb.lance.Dataset;
 import com.lancedb.lance.WriteParams;
@@ -99,13 +102,20 @@ public class LanceCatalogOperations implements LakehouseCatalogOperations {
       Index[] indexes)
       throws NoSuchSchemaException, TableAlreadyExistsException {
     // Ignore partitions, distributions, sortOrders, and indexes for Lance tables;
-    String location = properties.get("location");
+    String location = properties.get(LOCATION);
+    Map<String, String> storageProps =
+        properties.entrySet().stream()
+            .filter(e -> e.getKey().startsWith(LANCE_TABLE_STORAGE_OPTION_PREFIX))
+            .collect(
+                Collectors.toMap(
+                    e -> e.getKey().substring(LANCE_TABLE_STORAGE_OPTION_PREFIX.length()),
+                    Map.Entry::getValue));
     try (Dataset dataset =
         Dataset.create(
             new RootAllocator(),
             location,
             convertColumnsToSchema(columns),
-            new WriteParams.Builder().build())) {
+            new WriteParams.Builder().withStorageOptions(storageProps).build())) {
       GenericLakehouseTable.Builder builder = GenericLakehouseTable.builder();
       return builder
           .withName(ident.name())


### PR DESCRIPTION
…r Lance table (#8920)

- The properties with the prefix `lance.storage.` will be used for lance table storage

Fix: #8919

no

by hand

<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

(Please outline the changes and how this PR fixes the issue.)

### Why are the changes needed?

(Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, describe the bug.)

Fix: #(issue)

### Does this PR introduce _any_ user-facing change?

(Please list the user-facing changes introduced by your change, including
  1. Change in user-facing APIs.
  2. Addition or removal of property keys.)

### How was this patch tested?

(Please test your changes, and provide instructions on how to test it:
  1. If you add a feature or fix a bug, add a test to cover your changes.
  2. If you fix a flaky test, repeat it for many times to prove it works.)
