### PR TITLE
[#8919] improve(lance-table): Supports object store configurations for lance table storage

### DIFF
--- a/catalogs/catalog-generic-lakehouse/src/main/java/org/apache/gravitino/catalog/lakehouse/GenericLakehouseCatalogOperations.java
+++ b/catalogs/catalog-generic-lakehouse/src/main/java/org/apache/gravitino/catalog/lakehouse/GenericLakehouseCatalogOperations.java
@@ -19,6 +19,7 @@
 package org.apache.gravitino.catalog.lakehouse;
 
 import static org.apache.gravitino.Entity.EntityType.TABLE;
+import static org.apache.gravitino.catalog.lakehouse.GenericLakehouseTablePropertiesMetadata.LOCATION;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Maps;
@@ -26,6 +27,8 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
+import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.gravitino.Catalog;
 import org.apache.gravitino.Entity;
@@ -79,8 +82,10 @@ public class GenericLakehouseCatalogOperations
   private static final Map<String, LakehouseCatalogOperations> SUPPORTED_FORMATS =
       Maps.newHashMap();
 
+  private Map<String, String> catalogConfig;
   private CatalogInfo catalogInfo;
   private HasPropertyMetadata propertiesMetadata;
+
   /**
    * Initializes the generic lakehouse catalog operations with the provided configuration.
    *
@@ -102,6 +107,9 @@ public class GenericLakehouseCatalogOperations
         StringUtils.isNotBlank(catalogLocation)
             ? Optional.of(catalogLocation).map(this::ensureTrailingSlash).map(Path::new)
             : Optional.empty();
+    this.catalogConfig = conf;
+    this.catalogInfo = info;
+    this.propertiesMetadata = propertiesMetadata;
   }
 
   public GenericLakehouseCatalogOperations() {
@@ -207,11 +215,15 @@ public class GenericLakehouseCatalogOperations
       SortOrder[] sortOrders,
       Index[] indexes)
       throws NoSuchSchemaException, TableAlreadyExistsException {
-    String format = properties.getOrDefault("format", "lance");
-    String tableLocation = calculateTableLocation(ident, properties);
-    Map<String, String> newProperties = Maps.newHashMap(properties);
-    newProperties.put("location", tableLocation);
+    Schema schema = loadSchema(NameIdentifier.of(ident.namespace().levels()));
+    String tableLocation = calculateTableLocation(schema, ident, properties);
+    Map<String, String> tableStorageProps = calculateTableStorageProps(schema, properties);
 
+    Map<String, String> newProperties = Maps.newHashMap(properties);
+    newProperties.put(LOCATION, tableLocation);
+    newProperties.putAll(tableStorageProps);
+
+    String format = properties.getOrDefault("format", "lance");
     LakehouseCatalogOperations lakehouseCatalogOperations =
         SUPPORTED_FORMATS.compute(
             format,
@@ -226,22 +238,13 @@ public class GenericLakehouseCatalogOperations
   }
 
   private String calculateTableLocation(
-      NameIdentifier tableIdent, Map<String, String> tableProperties) {
-    String tableLocation = tableProperties.get("location");
+      Schema schema, NameIdentifier tableIdent, Map<String, String> tableProperties) {
+    String tableLocation = tableProperties.get(LOCATION);
     if (StringUtils.isNotBlank(tableLocation)) {
       return ensureTrailingSlash(tableLocation);
     }
 
-    String schemaLocation;
-    try {
-      Schema schema = loadSchema(NameIdentifier.of(tableIdent.namespace().levels()));
-      schemaLocation = schema.properties().get("location");
-    } catch (NoSuchSchemaException e) {
-      throw new RuntimeException(
-          String.format(
-              "Failed to load schema for table %s to determine default location.", tableIdent),
-          e);
-    }
+    String schemaLocation = schema.properties() == null ? null : schema.properties().get(LOCATION);
 
     // If we do not set location in table properties, and schema location is set, use schema
     // location
@@ -336,5 +339,34 @@ public class GenericLakehouseCatalogOperations
 
     operations.initialize(properties, catalogInfo, propertiesMetadata);
     return operations;
+  }
+
+  /**
+   * Calculate the table storage properties by merging catalog config, schema properties and table
+   * properties. The precedence is: table properties > schema properties > catalog config.
+   *
+   * @param schema The schema of the table.
+   * @param tableProps The table properties.
+   * @return The merged table storage properties.
+   */
+  private Map<String, String> calculateTableStorageProps(
+      Schema schema, Map<String, String> tableProps) {
+    Map<String, String> storageProps = getLanceTableStorageOptions(catalogConfig);
+    storageProps.putAll(getLanceTableStorageOptions(schema.properties()));
+    storageProps.putAll(getLanceTableStorageOptions(tableProps));
+    return storageProps;
+  }
+
+  private Map<String, String> getLanceTableStorageOptions(Map<String, String> properties) {
+    if (MapUtils.isEmpty(properties)) {
+      return Maps.newHashMap();
+    }
+    return properties.entrySet().stream()
+        .filter(
+            e ->
+                e.getKey()
+                    .startsWith(
+                        GenericLakehouseTablePropertiesMetadata.LANCE_TABLE_STORAGE_OPTION_PREFIX))
+        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
   }
 }

--- a/catalogs/catalog-generic-lakehouse/src/main/java/org/apache/gravitino/catalog/lakehouse/GenericLakehouseCatalogPropertiesMetadata.java
+++ b/catalogs/catalog-generic-lakehouse/src/main/java/org/apache/gravitino/catalog/lakehouse/GenericLakehouseCatalogPropertiesMetadata.java
@@ -19,6 +19,7 @@
 
 package org.apache.gravitino.catalog.lakehouse;
 
+import static org.apache.gravitino.catalog.lakehouse.GenericLakehouseTablePropertiesMetadata.LANCE_TABLE_STORAGE_OPTION_PREFIX;
 import static org.apache.gravitino.connector.PropertyEntry.stringOptionalPropertyEntry;
 
 import com.google.common.collect.ImmutableList;
@@ -42,7 +43,14 @@ public class GenericLakehouseCatalogPropertiesMetadata extends BaseCatalogProper
                 "The root directory of the lakehouse catalog.",
                 false /* immutable */,
                 null, /* defaultValue */
-                false /* hidden */));
+                false /* hidden */),
+            PropertyEntry.stringOptionalPropertyPrefixEntry(
+                LANCE_TABLE_STORAGE_OPTION_PREFIX,
+                "The storage options passed to Lance table.",
+                false /* immutable */,
+                null /* default value*/,
+                false /* hidden */,
+                false /* reserved */));
 
     PROPERTIES_METADATA = Maps.uniqueIndex(propertyEntries, PropertyEntry::getName);
   }

--- a/catalogs/catalog-generic-lakehouse/src/main/java/org/apache/gravitino/catalog/lakehouse/GenericLakehouseSchemaPropertiesMetadata.java
+++ b/catalogs/catalog-generic-lakehouse/src/main/java/org/apache/gravitino/catalog/lakehouse/GenericLakehouseSchemaPropertiesMetadata.java
@@ -18,6 +18,7 @@
  */
 package org.apache.gravitino.catalog.lakehouse;
 
+import static org.apache.gravitino.catalog.lakehouse.GenericLakehouseTablePropertiesMetadata.LANCE_TABLE_STORAGE_OPTION_PREFIX;
 import static org.apache.gravitino.connector.PropertyEntry.stringOptionalPropertyEntry;
 
 import com.google.common.collect.ImmutableList;
@@ -41,7 +42,14 @@ public class GenericLakehouseSchemaPropertiesMetadata extends BasePropertiesMeta
                 "The root directory of the lakehouse schema.",
                 false /* immutable */,
                 null, /* defaultValue */
-                false /* hidden */));
+                false /* hidden */),
+            PropertyEntry.stringOptionalPropertyPrefixEntry(
+                LANCE_TABLE_STORAGE_OPTION_PREFIX,
+                "The storage options passed to Lance table.",
+                false /* immutable */,
+                null /* default value*/,
+                false /* hidden */,
+                false /* reserved */));
 
     PROPERTIES_METADATA = Maps.uniqueIndex(propertyEntries, PropertyEntry::getName);
   }

--- a/catalogs/catalog-generic-lakehouse/src/main/java/org/apache/gravitino/catalog/lakehouse/GenericLakehouseTablePropertiesMetadata.java
+++ b/catalogs/catalog-generic-lakehouse/src/main/java/org/apache/gravitino/catalog/lakehouse/GenericLakehouseTablePropertiesMetadata.java
@@ -18,21 +18,43 @@
  */
 package org.apache.gravitino.catalog.lakehouse;
 
-import com.google.common.collect.ImmutableMap;
+import static org.apache.gravitino.connector.PropertyEntry.stringOptionalPropertyEntry;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Maps;
+import java.util.List;
 import java.util.Map;
 import org.apache.gravitino.connector.BasePropertiesMetadata;
 import org.apache.gravitino.connector.PropertyEntry;
 
 public class GenericLakehouseTablePropertiesMetadata extends BasePropertiesMetadata {
+  public static final String LOCATION = "location";
+  public static final String LANCE_TABLE_STORAGE_OPTION_PREFIX = "lance.storage.";
 
-  private static final Map<String, PropertyEntry<?>> propertiesMetadata;
+  private static final Map<String, PropertyEntry<?>> PROPERTIES_METADATA;
 
   static {
-    propertiesMetadata = ImmutableMap.of();
+    List<PropertyEntry<?>> propertyEntries =
+        ImmutableList.of(
+            stringOptionalPropertyEntry(
+                LOCATION,
+                "The root directory of the lakehouse table.",
+                true /* immutable */,
+                null, /* defaultValue */
+                false /* hidden */),
+            PropertyEntry.stringOptionalPropertyPrefixEntry(
+                LANCE_TABLE_STORAGE_OPTION_PREFIX,
+                "The storage options passed to Lance table.",
+                false /* immutable */,
+                null /* default value*/,
+                false /* hidden */,
+                false /* reserved */));
+
+    PROPERTIES_METADATA = Maps.uniqueIndex(propertyEntries, PropertyEntry::getName);
   }
 
   @Override
   protected Map<String, PropertyEntry<?>> specificPropertyEntries() {
-    return propertiesMetadata;
+    return PROPERTIES_METADATA;
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds support for object store configurations for Lance tables in the generic lakehouse catalog:
1. Property prefix support: Introduced `lance.storage.*` as a configurable property prefix at catalog, schema, and table levels for Lance table storage options
2. Property merging logic: Implemented hierarchical property resolution where table properties override schema properties, which override catalog config
3. Metadata updates: Added `lance.storage.*` prefix to `GenericLakehouseCatalogPropertiesMetadata`, `GenericLakehouseSchemaPropertiesMetadata`, and `GenericLakehouseTablePropertiesMetadata`
4. Storage configuration passing: Modified `LanceCatalogOperations.createTable()` to extract `lance.storage.*` properties and pass them to Lance's `WriteParams.Builder().withStorageOptions()`
Refactoring: Restructured table location and storage property calculation logic in GenericLakehouseCatalogOperations

### Why are the changes needed?

Lance tables need to support various object storage backends (S3, GCS, ADLS, OSS) with specific configurations like credentials, endpoints, and regions. Without this feature, users cannot configure Lance tables to work with cloud object stores, limiting Lance to local file systems only. This change enables production deployments of Lance tables on cloud storage.

Fix: #8919 

### Does this PR introduce _any_ user-facing change?

Yes, users can now configure Lance table storage options using properties with the `lance.storage.` prefix at catalog, schema, or table level.

Properties follow precedence: table > schema > catalog.

### How was this patch tested?

By hand (manual testing).
