### PR TITLE
[#9136] fix(doris): trim bucket number to prevent NumberFormatException

### DIFF
--- a/catalogs/catalog-jdbc-doris/src/main/java/org/apache/gravitino/catalog/doris/utils/DorisUtils.java
+++ b/catalogs/catalog-jdbc-doris/src/main/java/org/apache/gravitino/catalog/doris/utils/DorisUtils.java
@@ -223,10 +223,10 @@ public final class DorisUtils {
   private static int extractBucketNum(Matcher matcher) {
     int bucketNum = 1;
     if (matcher.group(4) != null) {
-      String bucketValue = matcher.group(4);
+      String bucketValue = matcher.group(4).trim();
       // Use -1 to indicate auto bucket.
       bucketNum =
-          bucketValue.trim().toUpperCase().equals("AUTO")
+          bucketValue.toUpperCase().equals("AUTO")
               ? Distributions.AUTO
               : Integer.valueOf(bucketValue);
     }

--- a/catalogs/catalog-jdbc-doris/src/test/java/org/apache/gravitino/catalog/doris/utils/TestDorisUtils.java
+++ b/catalogs/catalog-jdbc-doris/src/test/java/org/apache/gravitino/catalog/doris/utils/TestDorisUtils.java
@@ -205,4 +205,25 @@ public class TestDorisUtils {
         DorisUtils.extractDistributionInfoFromSql(createTableSqlWithoutBucket);
     assertEquals(1, distributionDefault.number());
   }
+
+  @Test
+  public void testExtractBucketNumWithWhitespace() {
+    String createTableSqlWithWhitespace =
+        "CREATE TABLE `testTable` (\n`col1` int NOT NULL\n) ENGINE=OLAP\n DISTRIBUTED BY HASH(`col1`) BUCKETS  16 ";
+    Distribution distribution =
+        DorisUtils.extractDistributionInfoFromSql(createTableSqlWithWhitespace);
+    assertEquals(16, distribution.number());
+
+    String createTableSqlWithAutoWhitespace =
+        "CREATE TABLE `testTable` (\n`col1` int NOT NULL\n) ENGINE=OLAP\n DISTRIBUTED BY HASH(`col1`) BUCKETS  AUTO ";
+    Distribution distributionAuto =
+        DorisUtils.extractDistributionInfoFromSql(createTableSqlWithAutoWhitespace);
+    assertEquals(-1, distributionAuto.number());
+
+    String createTableSqlWithAutoLeadingWhitespace =
+        "CREATE TABLE `testTable` (\n`col1` int NOT NULL\n) ENGINE=OLAP\n DISTRIBUTED BY HASH(`col1`) BUCKETS  AUTO";
+    Distribution distributionAutoLeading =
+        DorisUtils.extractDistributionInfoFromSql(createTableSqlWithAutoLeadingWhitespace);
+    assertEquals(-1, distributionAutoLeading.number());
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

- Modified DorisUtils.extractBucketNum to trim the bucket number string before parsing.


### Why are the changes needed?
- To prevent a NumberFormatException when parsing numeric bucket numbers that include whitespace. (e.g., " 16 ")

Fix: #9136 

### Does this PR introduce _any_ user-facing change?

- No.

### How was this patch tested?

- Verified using the unit test included in the issue (testExtractBucketNumWithWhitespace()).
- Confirmed all existing tests continue to pass.