### PR TITLE
[#9193] improvement(lance-rest): Automatically build necessary modules when running Lance REST integration tests.

### DIFF
--- a/lance/lance-rest-server/build.gradle.kts
+++ b/lance/lance-rest-server/build.gradle.kts
@@ -110,4 +110,11 @@ tasks {
   named("generateMetadataFileForMavenJavaPublication") {
     dependsOn(copyDepends)
   }
+
+  test {
+    val testMode = project.properties["testMode"] as? String ?: "embedded"
+    if (testMode == "embedded") {
+      dependsOn(":catalogs:catalog-generic-lakehouse:build")
+    }
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Running module `generic-lakehouse-catalog` first if running  Lance REST integration tests in embedded mode.

### Why are the changes needed?

It's for developer convenience.

Fix: #9193 

### Does this PR introduce _any_ user-facing change?

N/A.

### How was this patch tested?

Test locally. 
