### PR TITLE
[#9075] fix CLI jar selection when multiple CLI jars exist (issue #9075)

### DIFF
--- a/bin/gcli.sh.template
+++ b/bin/gcli.sh.template
@@ -29,7 +29,7 @@ AUXLIB_DIR="${GRAVITINO_HOME}/auxlib"
 
 # Search strategy for finding the Gravitino CLI JAR:
 if [ -z "$CLI_JAR" ]; then
-    CLI_JAR=$(find "${AUXLIB_DIR}" -name "gravitino-cli-*.jar" 2>/dev/null)
+    CLI_JAR=$(ls -1 "${AUXLIB_DIR}"/gravitino-cli-*.jar 2>/dev/null | sort -V | tail -n 1)
 fi
 
 if [ -z "$CLI_JAR" ]; then


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

This PR fixes an issue where gcli.sh fails to run when multiple CLI jars exist inside the auxlib directory.
The original implementation used find, which returns multiple paths if more than one matching jar exists.
This results in a multi-line string being passed to java -jar, causing an error

This PR updates the logic to:
- list all matching CLI jars
- sort them using version-aware sorting (sort -V)
-  select only one valid jar is passed to the JVM.

This ensures only one valid jar is passed

### Why are the changes needed?

When multiple CLI jars exist (e.g., gravitino-cli-1.1.0-SNAPSHOT.jar and gravitino-cli-1.0.0-SNAPSHOT.jar),
the previous logic assigned a multi-line value to CLI_JAR.
Passing this to java -jar results in failure even though the jar exists

Fix: #9075

### Does this PR introduce _any_ user-facing change?

Users running ./bin/gcli.sh in a distribution will now reliably run the latest available CLI jar even if multiple versions exist in auxlib
This prevents confusing errors

### How was this patch tested?

Automated tests do not exist for this script, but the logic minimal and easy to validate manually.
