### PR TITLE
[#9028] improve(core): Refactor the table and table entity to avoid introducing unnecessary interfaces

### DIFF
--- a/api/src/main/java/org/apache/gravitino/rel/Table.java
+++ b/api/src/main/java/org/apache/gravitino/rel/Table.java
@@ -45,6 +45,46 @@ import org.apache.gravitino.tag.SupportsTags;
 public interface Table extends Auditable {
 
   /**
+   * The property name for the table format. This property indicates the format of the table, such
+   * as "iceberg", "hudi", "lance", etc. generic lakehouse catalog will use this property to
+   * determine the table format and perform specific operations based on the format. For other
+   * relational catalogs, this property can be ignored.
+   *
+   * <p>This property is a must-have property for generic lakehouse catalog to create tables, and
+   * cannot be modified after table creation.
+   *
+   * <p>Current supported formats include:
+   *
+   * <ul>
+   *   <li>lance
+   * </ul>
+   */
+  String PROPERTY_TABLE_FORMAT = "format";
+
+  /**
+   * The property name to indicate whether the table is external. This property is a boolean value
+   * represented as a string ("true" or "false"). if true (the table is external), the drop
+   * operation will not delete the underlying data.
+   *
+   * <p>This property is optional and defaults to "false" if not specified. Also, it depends on the
+   * catalog implementation to decide whether to leverage and allow to alter this property.
+   */
+  String PROPERTY_EXTERNAL = "external";
+
+  /**
+   * The property name for the table location. This property indicates the physical location of the
+   * table's data, such as a file path or a URI.
+   *
+   * <p>The location property is optional, it can be specified when creating the table. If not, the
+   * catalog implementation may use a location based on the catalog and schema location properties.
+   *
+   * <p>It depends on the catalog implementation to decide whether to leverage and allow to alter
+   * this property after table creation. And the behavior of altering this property (moving the
+   * table data) is also catalog specific.
+   */
+  String PROPERTY_LOCATION = "location";
+
+  /**
    * @return Name of the table.
    */
   String name();
@@ -97,37 +137,6 @@ public interface Table extends Auditable {
    */
   default Map<String, String> properties() {
     return Collections.emptyMap();
-  }
-
-  /**
-   * Table format of the table. For example, in a file-based table, it could be "parquet", "Lance",
-   * "Iceberg", etc.
-   *
-   * @return the table format name, for more information: LakehouseTableFormat
-   */
-  default String format() {
-    throw new UnsupportedOperationException("Table format is not supported.");
-  }
-
-  /**
-   * Gets the location of the table if the table has a location. For example, in a file-based table,
-   * it could be the root path where the table data is stored.
-   *
-   * @return the location of the table as a string.
-   */
-  default String location() {
-    throw new UnsupportedOperationException("Table location is not supported.");
-  }
-
-  /**
-   * Indicates whether the table is external. An external table is a table that is not managed by
-   * the catalog and the drop operation will not delete the underlying data. If it's a managed
-   * table, dropping the table will delete the underlying data.
-   *
-   * @return true if the table is external, false otherwise
-   */
-  default boolean external() {
-    return false;
   }
 
   /**

--- a/catalogs/catalog-generic-lakehouse/src/main/java/org/apache/gravitino/catalog/lakehouse/GenericLakehouseCatalogOperations.java
+++ b/catalogs/catalog-generic-lakehouse/src/main/java/org/apache/gravitino/catalog/lakehouse/GenericLakehouseCatalogOperations.java
@@ -211,16 +211,16 @@ public class GenericLakehouseCatalogOperations
     try {
       TableEntity tableEntity = store.get(ident, Entity.EntityType.TABLE, TableEntity.class);
       return GenericLakehouseTable.builder()
-          .withFormat(tableEntity.getFormat())
-          .withProperties(tableEntity.getProperties())
+          .withFormat(tableEntity.format())
+          .withProperties(tableEntity.properties())
           .withAuditInfo(tableEntity.auditInfo())
-          .withSortOrders(tableEntity.getSortOrder())
-          .withPartitioning(tableEntity.getPartitions())
-          .withDistribution(tableEntity.getDistribution())
+          .withSortOrders(tableEntity.sortOrders())
+          .withPartitioning(tableEntity.partitioning())
+          .withDistribution(tableEntity.distribution())
           .withColumns(EntityConverter.toColumns(tableEntity.columns()))
-          .withIndexes(tableEntity.getIndexes())
+          .withIndexes(tableEntity.indexes())
           .withName(tableEntity.name())
-          .withComment(tableEntity.getComment())
+          .withComment(tableEntity.comment())
           .build();
     } catch (NoSuchEntityException e) {
       throw new NoSuchTableException(e, "Table %s does not exist", ident);
@@ -276,8 +276,8 @@ public class GenericLakehouseCatalogOperations
               .withFormat(format.lowerName())
               .withProperties(newProperties)
               .withComment(comment)
-              .withPartitions(partitions)
-              .withSortOrder(sortOrders)
+              .withPartitioning(partitions)
+              .withSortOrders(sortOrders)
               .withDistribution(distribution)
               .withIndexes(indexes)
               .withId(idGenerator.nextId())
@@ -370,7 +370,7 @@ public class GenericLakehouseCatalogOperations
       throws NoSuchTableException, IllegalArgumentException {
     try {
       TableEntity tableEntity = store.get(ident, Entity.EntityType.TABLE, TableEntity.class);
-      Map<String, String> tableProperties = tableEntity.getProperties();
+      Map<String, String> tableProperties = tableEntity.properties();
       LakehouseCatalogOperations lakehouseCatalogOperations =
           getLakehouseCatalogOperations(tableProperties);
       return lakehouseCatalogOperations.alterTable(ident, changes);
@@ -384,7 +384,7 @@ public class GenericLakehouseCatalogOperations
     try {
       TableEntity tableEntity = store.get(ident, Entity.EntityType.TABLE, TableEntity.class);
       LakehouseCatalogOperations lakehouseCatalogOperations =
-          getLakehouseCatalogOperations(tableEntity.getProperties());
+          getLakehouseCatalogOperations(tableEntity.properties());
       return lakehouseCatalogOperations.purgeTable(ident);
     } catch (NoSuchTableException e) {
       LOG.warn("Table {} does not exist, skip purging it.", ident);

--- a/catalogs/catalog-generic-lakehouse/src/main/java/org/apache/gravitino/catalog/lakehouse/lance/LanceCatalogOperations.java
+++ b/catalogs/catalog-generic-lakehouse/src/main/java/org/apache/gravitino/catalog/lakehouse/lance/LanceCatalogOperations.java
@@ -190,7 +190,7 @@ public class LanceCatalogOperations implements LakehouseCatalogOperations {
                       .withId(tableEntity.id())
                       .withName(tableEntity.name())
                       .withNamespace(tableEntity.namespace())
-                      .withFormat(entity.getFormat())
+                      .withFormat(entity.format())
                       .withAuditInfo(
                           AuditInfo.builder()
                               .withCreator(tableEntity.auditInfo().creator())
@@ -200,13 +200,12 @@ public class LanceCatalogOperations implements LakehouseCatalogOperations {
                               .build())
                       .withColumns(tableEntity.columns())
                       .withIndexes(
-                          ArrayUtils.addAll(
-                              entity.getIndexes(), addedIndexes.toArray(new Index[0])))
-                      .withDistribution(tableEntity.getDistribution())
-                      .withPartitions(tableEntity.getPartitions())
-                      .withSortOrder(tableEntity.getSortOrder())
-                      .withProperties(tableEntity.getProperties())
-                      .withComment(tableEntity.getComment())
+                          ArrayUtils.addAll(entity.indexes(), addedIndexes.toArray(new Index[0])))
+                      .withDistribution(tableEntity.distribution())
+                      .withPartitioning(tableEntity.partitioning())
+                      .withSortOrders(tableEntity.sortOrders())
+                      .withProperties(tableEntity.properties())
+                      .withComment(tableEntity.comment())
                       .build());
 
       // Add indexes to Lance dataset
@@ -214,16 +213,16 @@ public class LanceCatalogOperations implements LakehouseCatalogOperations {
 
       // return the updated table
       return GenericLakehouseTable.builder()
-          .withFormat(updatedEntity.getFormat())
-          .withProperties(updatedEntity.getProperties())
+          .withFormat(updatedEntity.format())
+          .withProperties(updatedEntity.properties())
           .withAuditInfo(updatedEntity.auditInfo())
-          .withSortOrders(updatedEntity.getSortOrder())
-          .withPartitioning(updatedEntity.getPartitions())
-          .withDistribution(updatedEntity.getDistribution())
+          .withSortOrders(updatedEntity.sortOrders())
+          .withPartitioning(updatedEntity.partitioning())
+          .withDistribution(updatedEntity.distribution())
           .withColumns(EntityConverter.toColumns(updatedEntity.columns()))
-          .withIndexes(updatedEntity.getIndexes())
+          .withIndexes(updatedEntity.indexes())
           .withName(updatedEntity.name())
-          .withComment(updatedEntity.getComment())
+          .withComment(updatedEntity.comment())
           .build();
     } catch (NoSuchEntityException e) {
       throw new NoSuchTableException("No such table: %s", ident);
@@ -234,9 +233,7 @@ public class LanceCatalogOperations implements LakehouseCatalogOperations {
 
   private void addLanceIndex(TableEntity updatedEntity, List<Index> addedIndexes) {
     String location =
-        updatedEntity
-            .getProperties()
-            .get(GenericLakehouseTablePropertiesMetadata.LAKEHOUSE_LOCATION);
+        updatedEntity.properties().get(GenericLakehouseTablePropertiesMetadata.LAKEHOUSE_LOCATION);
     try (Dataset dataset = Dataset.open(location, new RootAllocator())) {
       // For Lance, we only support adding indexes, so in fact, we can't handle drop index here.
       for (Index index : addedIndexes) {
@@ -276,7 +273,7 @@ public class LanceCatalogOperations implements LakehouseCatalogOperations {
   public boolean purgeTable(NameIdentifier ident) {
     try {
       TableEntity tableEntity = store.get(ident, Entity.EntityType.TABLE, TableEntity.class);
-      Map<String, String> lancePropertiesMap = tableEntity.getProperties();
+      Map<String, String> lancePropertiesMap = tableEntity.properties();
       String location =
           lancePropertiesMap.get(GenericLakehouseTablePropertiesMetadata.LAKEHOUSE_LOCATION);
 

--- a/catalogs/catalog-generic-lakehouse/src/test/java/org/apache/gravitino/catalog/lakehouse/integration/test/CatalogGenericLakehouseLanceIT.java
+++ b/catalogs/catalog-generic-lakehouse/src/test/java/org/apache/gravitino/catalog/lakehouse/integration/test/CatalogGenericLakehouseLanceIT.java
@@ -53,7 +53,6 @@ import org.apache.gravitino.Catalog;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Schema;
 import org.apache.gravitino.client.GravitinoMetalake;
-import org.apache.gravitino.integration.test.container.ContainerSuite;
 import org.apache.gravitino.integration.test.util.BaseIT;
 import org.apache.gravitino.integration.test.util.GravitinoITUtils;
 import org.apache.gravitino.rel.Column;
@@ -97,7 +96,6 @@ public class CatalogGenericLakehouseLanceIT extends BaseIT {
   public static final String LANCE_COL_NAME2 = "lance_col_name2";
   public static final String LANCE_COL_NAME3 = "lance_col_name3";
   protected final String provider = "generic-lakehouse";
-  protected final ContainerSuite containerSuite = ContainerSuite.getInstance();
   protected GravitinoMetalake metalake;
   protected Catalog catalog;
   protected String tempDirectory;

--- a/core/src/main/java/org/apache/gravitino/catalog/EntityCombinedTable.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/EntityCombinedTable.java
@@ -129,16 +129,6 @@ public final class EntityCombinedTable implements Table {
     return table.index();
   }
 
-  @Override
-  public String format() {
-    return table.format();
-  }
-
-  @Override
-  public String location() {
-    return table.location();
-  }
-
   public boolean imported() {
     return imported;
   }

--- a/core/src/main/java/org/apache/gravitino/connector/GenericLakehouseTable.java
+++ b/core/src/main/java/org/apache/gravitino/connector/GenericLakehouseTable.java
@@ -19,26 +19,13 @@
 
 package org.apache.gravitino.connector;
 
+import com.google.common.collect.ImmutableMap;
+import org.apache.gravitino.rel.Table;
+
 public class GenericLakehouseTable extends BaseTable {
-  private String format;
 
   public static Builder builder() {
     return new Builder();
-  }
-
-  @Override
-  public String format() {
-    return format;
-  }
-
-  @Override
-  public String location() {
-    return properties.get("location");
-  }
-
-  @Override
-  public boolean external() {
-    return properties.get("external") != null && Boolean.parseBoolean(properties.get("external"));
   }
 
   @Override
@@ -58,10 +45,13 @@ public class GenericLakehouseTable extends BaseTable {
     @Override
     protected GenericLakehouseTable internalBuild() {
       GenericLakehouseTable genericLakehouseTable = new GenericLakehouseTable();
-      genericLakehouseTable.format = this.format;
       genericLakehouseTable.columns = this.columns;
       genericLakehouseTable.comment = this.comment;
-      genericLakehouseTable.properties = this.properties;
+      genericLakehouseTable.properties =
+          ImmutableMap.<String, String>builder()
+              .putAll(this.properties)
+              .put(Table.PROPERTY_TABLE_FORMAT, this.format)
+              .buildKeepingLast();
       genericLakehouseTable.auditInfo = this.auditInfo;
       genericLakehouseTable.distribution = this.distribution;
       genericLakehouseTable.indexes = this.indexes;

--- a/core/src/main/java/org/apache/gravitino/storage/relational/utils/POConverters.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/utils/POConverters.java
@@ -401,33 +401,32 @@ public class POConverters {
           .withCurrentVersion(INIT_VERSION)
           .withLastVersion(INIT_VERSION)
           .withDeletedAt(DEFAULT_DELETED_AT)
-          .withFormat(tableEntity.getFormat())
-          .withComment(tableEntity.getComment())
+          .withFormat(tableEntity.format())
+          .withComment(tableEntity.comment())
           .withProperties(
-              tableEntity.getProperties() == null
+              tableEntity.properties() == null
                   ? null
-                  : JsonUtils.anyFieldMapper().writeValueAsString(tableEntity.getProperties()))
+                  : JsonUtils.anyFieldMapper().writeValueAsString(tableEntity.properties()))
           .withIndexes(
-              tableEntity.getIndexes() == null
+              tableEntity.indexes() == null
                   ? null
                   : JsonUtils.anyFieldMapper()
-                      .writeValueAsString(DTOConverters.toDTOs(tableEntity.getIndexes())))
+                      .writeValueAsString(DTOConverters.toDTOs(tableEntity.indexes())))
           .withDistribution(
-              tableEntity.getDistribution() == null
+              tableEntity.distribution() == null
                   ? null
                   : JsonUtils.anyFieldMapper()
-                      .writeValueAsString(DTOConverters.toDTO(tableEntity.getDistribution())))
+                      .writeValueAsString(DTOConverters.toDTO(tableEntity.distribution())))
           .withSortOrders(
-              tableEntity.getSortOrder() == null
+              tableEntity.sortOrders() == null
                   ? null
                   : JsonUtils.anyFieldMapper()
-                      .writeValueAsString(DTOConverters.toDTOs(tableEntity.getSortOrder())))
+                      .writeValueAsString(DTOConverters.toDTOs(tableEntity.sortOrders())))
           .withPartitions(
-              tableEntity.getPartitions() == null
+              tableEntity.partitioning() == null
                   ? null
                   : JsonUtils.anyFieldMapper()
-                      .writeValueAsString(DTOConverters.toDTOs(tableEntity.getPartitions())));
-      // TODO support partitions later
+                      .writeValueAsString(DTOConverters.toDTOs(tableEntity.partitioning())));
       return builder.build();
     } catch (JsonProcessingException e) {
       throw new RuntimeException("Failed to serialize json object:", e);
@@ -461,33 +460,33 @@ public class POConverters {
               .withCurrentVersion(currentVersion)
               .withLastVersion(lastVersion)
               .withDeletedAt(DEFAULT_DELETED_AT)
-              .withComment(newTable.getComment())
+              .withComment(newTable.comment())
               .withProperties(
-                  newTable.getProperties() == null
+                  newTable.properties() == null
                       ? null
-                      : JsonUtils.anyFieldMapper().writeValueAsString(newTable.getProperties()))
+                      : JsonUtils.anyFieldMapper().writeValueAsString(newTable.properties()))
               .withIndexes(
-                  newTable.getIndexes() == null
+                  newTable.indexes() == null
                       ? null
                       : JsonUtils.anyFieldMapper()
-                          .writeValueAsString(DTOConverters.toDTOs(newTable.getIndexes())))
+                          .writeValueAsString(DTOConverters.toDTOs(newTable.indexes())))
               .withDistribution(
-                  newTable.getDistribution() == null
+                  newTable.distribution() == null
                       ? null
                       : JsonUtils.anyFieldMapper()
-                          .writeValueAsString(DTOConverters.toDTO(newTable.getDistribution())))
+                          .writeValueAsString(DTOConverters.toDTO(newTable.distribution())))
               .withSortOrders(
-                  newTable.getSortOrder() == null
+                  newTable.sortOrders() == null
                       ? null
                       : JsonUtils.anyFieldMapper()
-                          .writeValueAsString(DTOConverters.toDTOs(newTable.getSortOrder())))
+                          .writeValueAsString(DTOConverters.toDTOs(newTable.sortOrders())))
               .withPartitions(
-                  newTable.getPartitions() == null
+                  newTable.partitioning() == null
                       ? null
                       : JsonUtils.anyFieldMapper()
-                          .writeValueAsString(DTOConverters.toDTOs(newTable.getPartitions())))
+                          .writeValueAsString(DTOConverters.toDTOs(newTable.partitioning())))
               // TODO support partitions later
-              .withFormat(newTable.getFormat());
+              .withFormat(newTable.format());
 
       return builder.build();
     } catch (JsonProcessingException e) {
@@ -522,7 +521,7 @@ public class POConverters {
                   : DTOConverters.fromDTO(
                       JsonUtils.anyFieldMapper()
                           .readValue(tablePO.getDistribution(), DistributionDTO.class)))
-          .withSortOrder(
+          .withSortOrders(
               StringUtils.isBlank(tablePO.getSortOrders())
                   ? null
                   : DTOConverters.fromDTOs(
@@ -534,7 +533,7 @@ public class POConverters {
                   : DTOConverters.fromDTOs(
                       JsonUtils.anyFieldMapper().readValue(tablePO.getIndexes(), IndexDTO[].class)))
           // TODO add field partition, distribution and sort order;
-          .withPartitions(
+          .withPartitioning(
               StringUtils.isBlank(tablePO.getPartitions())
                   ? null
                   : JsonUtils.anyFieldMapper()

--- a/core/src/test/java/org/apache/gravitino/meta/TestEntity.java
+++ b/core/src/test/java/org/apache/gravitino/meta/TestEntity.java
@@ -175,7 +175,7 @@ public class TestEntity {
             .withName(tableName)
             .withAuditInfo(auditInfo)
             .withFormat(format)
-            .withSortOrder(sortOrders)
+            .withSortOrders(sortOrders)
             .withProperties(tableProperties)
             .withComment(comment)
             .withIndexes(indexes)
@@ -189,7 +189,7 @@ public class TestEntity {
     Assertions.assertEquals(format, fields.get(TableEntity.FORMAT));
     Assertions.assertEquals(tableProperties, fields.get(TableEntity.PROPERTIES));
     Assertions.assertEquals(comment, fields.get(TableEntity.COMMENT));
-    Assertions.assertEquals(sortOrders, fields.get(TableEntity.SORT_ORDER));
+    Assertions.assertEquals(sortOrders, fields.get(TableEntity.SORT_ORDERS));
     Assertions.assertEquals(indexes, fields.get(TableEntity.INDEXES));
     Assertions.assertEquals(distribution, fields.get(TableEntity.DISTRIBUTION));
   }

--- a/core/src/test/java/org/apache/gravitino/storage/TestEntityStorage.java
+++ b/core/src/test/java/org/apache/gravitino/storage/TestEntityStorage.java
@@ -3107,9 +3107,9 @@ public class TestEntityStorage {
           store.get(table.nameIdentifier(), Entity.EntityType.TABLE, TableEntity.class);
 
       // check table properties
-      Assertions.assertEquals("/tmp/test", fetchedTable.getProperties().get("location"));
-      Assertions.assertEquals("lance", fetchedTable.getProperties().get("format"));
-      Assertions.assertEquals("This is a lance table", fetchedTable.getComment());
+      Assertions.assertEquals("/tmp/test", fetchedTable.properties().get("location"));
+      Assertions.assertEquals("lance", fetchedTable.properties().get("format"));
+      Assertions.assertEquals("This is a lance table", fetchedTable.comment());
       Assertions.assertEquals(1, fetchedTable.columns().size());
       Assertions.assertEquals("column1", fetchedTable.columns().get(0).name());
 
@@ -3150,9 +3150,9 @@ public class TestEntityStorage {
 
       // check updated table properties
       Assertions.assertEquals(
-          "/tmp/updated_test", fetchedUpdatedTable.getProperties().get("location"));
-      Assertions.assertEquals("lance", fetchedUpdatedTable.getProperties().get("format"));
-      Assertions.assertEquals("This is an updated lance table", fetchedUpdatedTable.getComment());
+          "/tmp/updated_test", fetchedUpdatedTable.properties().get("location"));
+      Assertions.assertEquals("lance", fetchedUpdatedTable.properties().get("format"));
+      Assertions.assertEquals("This is an updated lance table", fetchedUpdatedTable.comment());
       Assertions.assertEquals(2, fetchedUpdatedTable.columns().size());
       for (ColumnEntity column : fetchedUpdatedTable.columns()) {
         if (column.name().equals("column1")) {
@@ -3161,10 +3161,7 @@ public class TestEntityStorage {
       }
 
       Assertions.assertTrue(
-          fetchedUpdatedTable.columns().stream()
-              .filter(c -> c.name().equals("column2"))
-              .findFirst()
-              .isPresent());
+          fetchedUpdatedTable.columns().stream().anyMatch(c -> c.name().equals("column2")));
 
       // Test drop the table
       Assertions.assertTrue(store.delete(table.nameIdentifier(), Entity.EntityType.TABLE));

--- a/core/src/test/java/org/apache/gravitino/storage/relational/TestJDBCBackend.java
+++ b/core/src/test/java/org/apache/gravitino/storage/relational/TestJDBCBackend.java
@@ -1253,7 +1253,7 @@ public class TestJDBCBackend {
     backend.insert(table, false);
 
     TableEntity fetchedTable = backend.get(table.nameIdentifier(), Entity.EntityType.TABLE);
-    Assertions.assertEquals("LANCE", fetchedTable.getProperties().get("format"));
+    Assertions.assertEquals("LANCE", fetchedTable.properties().get("format"));
 
     TableEntity updatedTable =
         TableEntity.builder()

--- a/core/src/test/java/org/apache/gravitino/storage/relational/utils/TestPOConverters.java
+++ b/core/src/test/java/org/apache/gravitino/storage/relational/utils/TestPOConverters.java
@@ -629,8 +629,8 @@ public class TestPOConverters {
             Lists.newArrayList(),
             NamespaceUtil.ofTable("test_metalake", "test_catalog", "test_schema"));
 
-    Assertions.assertEquals(tableEntity.getDistribution(), entity.getDistribution());
-    Assertions.assertArrayEquals(tableEntity.getPartitions(), entity.getPartitions());
+    Assertions.assertEquals(tableEntity.distribution(), entity.distribution());
+    Assertions.assertArrayEquals(tableEntity.partitioning(), entity.partitioning());
   }
 
   @Test
@@ -1398,7 +1398,7 @@ public class TestPOConverters {
         .withNamespace(namespace)
         .withColumns(columns)
         .withDistribution(Distributions.of(Strategy.EVEN, 10, NamedReference.field("key")))
-        .withSortOrder(
+        .withSortOrders(
             new SortOrder[] {SortOrders.of(NamedReference.field("col1"), SortDirection.ASCENDING)})
         .withAuditInfo(auditInfo)
         .build();

--- a/lance/lance-common/src/main/java/org/apache/gravitino/lance/common/config/LanceConfig.java
+++ b/lance/lance-common/src/main/java/org/apache/gravitino/lance/common/config/LanceConfig.java
@@ -42,21 +42,21 @@ public class LanceConfig extends Config implements OverwriteDefaultConfig {
   public static final ConfigEntry<String> NAMESPACE_BACKEND =
       new ConfigBuilder(CONFIG_NAMESPACE_BACKEND)
           .doc("The backend implementation for namespace operations")
-          .version(ConfigConstants.VERSION_0_1_0)
+          .version(ConfigConstants.VERSION_1_1_0)
           .stringConf()
           .createWithDefault(GRAVITINO_NAMESPACE_BACKEND);
 
   public static final ConfigEntry<String> METALAKE_NAME =
       new ConfigBuilder(GRAVITINO_NAMESPACE_BACKEND + "." + CONFIG_METALAKE)
           .doc("The Metalake name for Lance Gravitino namespace backend")
-          .version(ConfigConstants.VERSION_0_1_0)
+          .version(ConfigConstants.VERSION_1_1_0)
           .stringConf()
           .create();
 
   public static final ConfigEntry<String> NAMESPACE_BACKEND_URI =
       new ConfigBuilder(GRAVITINO_NAMESPACE_BACKEND + "." + CONFIG_URI)
           .doc("The URI of the namespace backend, e.g., Gravitino server URI")
-          .version(ConfigConstants.VERSION_0_1_0)
+          .version(ConfigConstants.VERSION_1_1_0)
           .stringConf()
           .createWithDefault(GRAVITINO_URI);
 

--- a/mcp-server/tests/unit/tools/__init__.py
+++ b/mcp-server/tests/unit/tools/__init__.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import logging
 
 from tests.unit.tools.mock_operation import (
     MockCatalogOperation,
@@ -21,3 +22,5 @@ from tests.unit.tools.mock_operation import (
     MockSchemaOperation,
     MockTableOperation,
 )
+
+logging.disable(logging.INFO)


### PR DESCRIPTION
### What changes were proposed in this pull request?

Refactored the Table interface and TableEntity class to simplify the generic lakehouse catalog implementation by removing unnecessary interfaces and consolidating table-related logic. The changes include:
- Restructured the Table.java interface methods
- Updated TableEntity.java to improve its internal structure and reduce complexity
- Modified GenericLakehouseCatalogOperations and LanceCatalogOperations to work with the refactored table structure
- Updated POConverters to align with the new table entity structure

### Why are the changes needed?

The previous implementation had unnecessary interface abstractions that made the generic lakehouse catalog more complex than needed. This refactoring:
- Makes the generic lakehouse catalog more stable and maintainable
- Reduces code complexity by removing redundant interfaces
- Improves code organization and readability
- Simplifies future development and debugging

Fix: #9028 

### Does this PR introduce _any_ user-facing change?

No. This is an internal refactoring that doesn't change any public APIs or user-facing behavior.

### How was this patch tested?

- All existing unit tests (UT) pass
- All existing integration tests (IT) pass
- Specifically verified CatalogGenericLakehouseLanceIT and other affected test suites
