### PR TITLE
[#9142] fix(trino-connector): Fix `getNextPage()` to Return `null` After Completion

### DIFF
--- a/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/system/GravitinoSystemConnector.java
+++ b/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/system/GravitinoSystemConnector.java
@@ -205,6 +205,9 @@ public class GravitinoSystemConnector implements Connector {
 
     @Override
     public Page getNextPage() {
+      if (isFinished) {
+        return null;
+      }
       isFinished = true;
       return page;
     }

--- a/trino-connector/trino-connector/src/test/java/org/apache/gravitino/trino/connector/system/TestGravitinoSystemConnector.java
+++ b/trino-connector/trino-connector/src/test/java/org/apache/gravitino/trino/connector/system/TestGravitinoSystemConnector.java
@@ -18,206 +18,41 @@
  */
 package org.apache.gravitino.trino.connector.system;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import io.trino.spi.HostAddress;
 import io.trino.spi.Page;
-import io.trino.spi.connector.ColumnHandle;
-import io.trino.spi.connector.Connector;
-import io.trino.spi.connector.ConnectorMetadata;
-import io.trino.spi.connector.ConnectorPageSource;
-import io.trino.spi.connector.ConnectorPageSourceProvider;
-import io.trino.spi.connector.ConnectorSession;
-import io.trino.spi.connector.ConnectorSplit;
-import io.trino.spi.connector.ConnectorSplitManager;
-import io.trino.spi.connector.ConnectorSplitSource;
-import io.trino.spi.connector.ConnectorTableHandle;
-import io.trino.spi.connector.ConnectorTransactionHandle;
-import io.trino.spi.connector.Constraint;
-import io.trino.spi.connector.DynamicFilter;
-import io.trino.spi.connector.FixedSplitSource;
-import io.trino.spi.connector.SchemaTableName;
-import io.trino.spi.procedure.Procedure;
-import io.trino.spi.transaction.IsolationLevel;
-import java.io.IOException;
-import java.util.Collections;
-import java.util.List;
-import java.util.Set;
-import org.apache.gravitino.trino.connector.system.storedprocedure.GravitinoStoredProcedureFactory;
-import org.apache.gravitino.trino.connector.system.table.GravitinoSystemTableFactory;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
-/**
- * GravitinoSystemConnector is primarily used to drive the GravitinoCatalogManager to load catalog
- * connectors managed in the Apache Gravitino server. After users configure the Gravitino connector
- * through Trino catalog configuration, a GravitinoSystemConnector is initially created. And it
- * provides some system tables and stored procedures of Gravitino connector.
- */
-public class GravitinoSystemConnector implements Connector {
+public class TestGravitinoSystemConnector {
+  @Test
+  public void testSystemTablePageSourceReturnsPageOnlyOnce() throws Exception {
+    Page page = new Page(0);
+    try (GravitinoSystemConnector.SystemTablePageSource pageSource =
+        new GravitinoSystemConnector.SystemTablePageSource(page)) {
 
-  private final GravitinoStoredProcedureFactory gravitinoStoredProcedureFactory;
-
-  /**
-   * Constructs a new GravitinoSystemConnector.
-   *
-   * @param gravitinoStoredProcedureFactory the factory for creating stored procedures
-   */
-  public GravitinoSystemConnector(GravitinoStoredProcedureFactory gravitinoStoredProcedureFactory) {
-    this.gravitinoStoredProcedureFactory = gravitinoStoredProcedureFactory;
-  }
-
-  @Override
-  public ConnectorTransactionHandle beginTransaction(
-      IsolationLevel isolationLevel, boolean readOnly, boolean autoCommit) {
-    return TransactionHandle.INSTANCE;
-  }
-
-  @Override
-  public Set<Procedure> getProcedures() {
-    return gravitinoStoredProcedureFactory.getStoredProcedures();
-  }
-
-  @Override
-  public ConnectorMetadata getMetadata(
-      ConnectorSession session, ConnectorTransactionHandle transactionHandle) {
-    return new GravitinoSystemConnectorMetadata();
-  }
-
-  @Override
-  public ConnectorSplitManager getSplitManager() {
-    return new SplitManager();
-  }
-
-  @Override
-  public ConnectorPageSourceProvider getPageSourceProvider() {
-    return new DatasourceProvider();
-  }
-
-  /** The transaction handle for Gravitino system connector. */
-  public enum TransactionHandle implements ConnectorTransactionHandle {
-    /** The singleton instance of the transaction handle. */
-    INSTANCE
-  }
-
-  /** The datasource provider. */
-  public static class DatasourceProvider implements ConnectorPageSourceProvider {
-
-    @Override
-    public ConnectorPageSource createPageSource(
-        ConnectorTransactionHandle transaction,
-        ConnectorSession session,
-        ConnectorSplit split,
-        ConnectorTableHandle table,
-        List<ColumnHandle> columns,
-        DynamicFilter dynamicFilter) {
-
-      SchemaTableName tableName =
-          ((GravitinoSystemConnectorMetadata.SystemTableHandle) table).getName();
-      return new SystemTablePageSource(GravitinoSystemTableFactory.loadPageData(tableName));
+      Assertions.assertFalse(pageSource.isFinished());
+      Assertions.assertSame(page, pageSource.getNextPage());
+      Assertions.assertTrue(pageSource.isFinished());
+      Assertions.assertNull(pageSource.getNextPage());
     }
   }
 
-  /** The split manager. */
-  public static class SplitManager implements ConnectorSplitManager {
+  @Test
+  public void testSystemTablePageSourceMultipleGetNextPageCalls() throws Exception {
+    Page page = new Page(0);
+    try (GravitinoSystemConnector.SystemTablePageSource pageSource =
+        new GravitinoSystemConnector.SystemTablePageSource(page)) {
 
-    @Override
-    public ConnectorSplitSource getSplits(
-        ConnectorTransactionHandle transaction,
-        ConnectorSession session,
-        ConnectorTableHandle connectorTableHandle,
-        DynamicFilter dynamicFilter,
-        Constraint constraint) {
+      // First call should return the page
+      Page firstPage = pageSource.getNextPage();
+      Assertions.assertNotNull(firstPage);
+      Assertions.assertSame(page, firstPage);
+      Assertions.assertTrue(pageSource.isFinished());
 
-      SchemaTableName tableName =
-          ((GravitinoSystemConnectorMetadata.SystemTableHandle) connectorTableHandle).getName();
-      return new FixedSplitSource(new Split(tableName));
+      // Subsequent calls should return null
+      Assertions.assertNull(pageSource.getNextPage());
+      Assertions.assertNull(pageSource.getNextPage());
+      Assertions.assertNull(pageSource.getNextPage());
+      Assertions.assertTrue(pageSource.isFinished());
     }
-  }
-
-  /** The split. */
-  public static class Split implements ConnectorSplit {
-    private final SchemaTableName tableName;
-
-    /**
-     * Constructs a new Split with the specified table name.
-     *
-     * @param tableName the table name
-     */
-    @JsonCreator
-    public Split(@JsonProperty("tableName") SchemaTableName tableName) {
-      this.tableName = tableName;
-    }
-
-    /**
-     * Retrieves the table name.
-     *
-     * @return the table name
-     */
-    @JsonProperty
-    public SchemaTableName getTableName() {
-      return tableName;
-    }
-
-    @Override
-    public boolean isRemotelyAccessible() {
-      return true;
-    }
-
-    @Override
-    public List<HostAddress> getAddresses() {
-      return Collections.emptyList();
-    }
-
-    @Override
-    public Object getInfo() {
-      return this;
-    }
-  }
-
-  /** The system table page source. */
-  public static class SystemTablePageSource implements ConnectorPageSource {
-
-    private boolean isFinished = false;
-    private final Page page;
-
-    /**
-     * Constructs a new SystemTablePageSource.
-     *
-     * @param page the page containing system table data
-     */
-    public SystemTablePageSource(Page page) {
-      this.page = page;
-    }
-
-    @Override
-    public long getCompletedBytes() {
-      return 0;
-    }
-
-    @Override
-    public long getReadTimeNanos() {
-      return 0;
-    }
-
-    @Override
-    public boolean isFinished() {
-      return isFinished;
-    }
-
-    @Override
-    public Page getNextPage() {
-      if(isFinished){
-        return null;
-      }
-      isFinished = true;
-      return page;
-    }
-
-    @Override
-    public long getMemoryUsage() {
-      return 0;
-    }
-
-    @Override
-    public void close() throws IOException {}
   }
 }


### PR DESCRIPTION

### What changes were proposed in this pull request?

This PR fixes the behavior of `SystemTablePageSource#getNextPage()` so that it returns the page only on the first call and returns null on all subsequent calls. A new isFinished flag is introduced to track whether the page has already been consumed.

### Why are the changes needed?

Previously, `getNextPage()` could return the same page multiple times, which violated the expected contract and caused unit tests to fail. The method should provide the page exactly once and then signal completion by returning null.

Fixed #9142

### Does this PR introduce any user-facing change?

No. This change affects only internal behavior of the page source implementation and does not modify any user-facing APIs, configuration, or output.

### How was this patch tested?

Unit tests were used to verify that `getNextPage()` returns the page only once and that all subsequent calls consistently return null.