### PR TITLE
[#9229] fix(CI): Free disk space to avoid Python tests failure.

### DIFF
--- a/.github/workflows/python-integration-test.yml
+++ b/.github/workflows/python-integration-test.yml
@@ -68,6 +68,10 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
+      - name: Free up disk space
+        run: |
+          dev/ci/util_free_space.sh  
+
       - name: Python Client Integration Test
         id: integrationTest
         run: |


### PR DESCRIPTION

### What changes were proposed in this pull request?

Free some space before running python tests.

### Why are the changes needed?

We need to release some disk space or tests will fail due to out of disk space.

Fix: #9229 

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

CI it self.