### PR TITLE
[MINOR] fix(iceberg): remove V1_COMMIT_TRANSACTION endpoint

### DIFF
--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/rest/IcebergConfigOperations.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/rest/IcebergConfigOperations.java
@@ -74,7 +74,6 @@ public class IcebergConfigOperations {
           .add(Endpoint.V1_TABLE_EXISTS)
           .add(Endpoint.V1_REGISTER_TABLE)
           .add(Endpoint.V1_REPORT_METRICS)
-          .add(Endpoint.V1_COMMIT_TRANSACTION)
           .add(Endpoint.V1_TABLE_CREDENTIALS)
           .build();
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

remove `V1_COMMIT_TRANSACTION` endpoint from config interface as Gravitino IRC doesn't support multi table transaction now.

### Why are the changes needed?

Fix: #(issue)

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
existing tests
