### PR TITLE
fix(LocalFileSystemProvider): Use GRAVITINO_BYPASS for prefix trimming

### DIFF
--- a/catalogs/hadoop-common/src/main/java/org/apache/gravitino/catalog/hadoop/fs/LocalFileSystemProvider.java
+++ b/catalogs/hadoop-common/src/main/java/org/apache/gravitino/catalog/hadoop/fs/LocalFileSystemProvider.java
@@ -18,7 +18,7 @@
  */
 package org.apache.gravitino.catalog.hadoop.fs;
 
-import static org.apache.gravitino.catalog.hadoop.fs.Constants.BUILTIN_HDFS_FS_PROVIDER;
+import static org.apache.gravitino.catalog.hadoop.fs.FileSystemProvider.GRAVITINO_BYPASS;
 import static org.apache.gravitino.catalog.hadoop.fs.Constants.BUILTIN_LOCAL_FS_PROVIDER;
 
 import java.io.IOException;
@@ -32,7 +32,7 @@ public class LocalFileSystemProvider implements FileSystemProvider {
   @Override
   public FileSystem getFileSystem(Path path, Map<String, String> config) throws IOException {
     Configuration configuration =
-        FileSystemUtils.createConfiguration(BUILTIN_HDFS_FS_PROVIDER, config);
+        FileSystemUtils.createConfiguration(GRAVITINO_BYPASS, config);
     return FileSystem.newInstance(path.toUri(), configuration);
   }
 


### PR DESCRIPTION
The LocalFileSystemProvider was incorrectly using BUILTIN_HDFS_FS_PROVIDER (value: 'builtin-hdfs') in createConfiguration(), which prevented properties with 'gravitino.bypass' prefix from being properly trimmed.

This fix replaces BUILTIN_HDFS_FS_PROVIDER with GRAVITINO_BYPASS to correctly handle the prefix trimming.

Closes #9249

<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

(Please outline the changes and how this PR fixes the issue.)

### Why are the changes needed?

(Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, describe the bug.)

Fix: #(issue)

### Does this PR introduce _any_ user-facing change?

(Please list the user-facing changes introduced by your change, including
  1. Change in user-facing APIs.
  2. Addition or removal of property keys.)

### How was this patch tested?

(Please test your changes, and provide instructions on how to test it:
  1. If you add a feature or fix a bug, add a test to cover your changes.
  2. If you fix a flaky test, repeat it for many times to prove it works.)
