### PR TITLE
[#9270] : feat(iceberg): Refactor checkCurrentUser call to the interceptor

### DIFF
--- a/clients/client-java/src/test/java/org/apache/gravitino/client/integration/test/authorization/CheckCurrentUserIT.java
+++ b/clients/client-java/src/test/java/org/apache/gravitino/client/integration/test/authorization/CheckCurrentUserIT.java
@@ -95,7 +95,9 @@ public class CheckCurrentUserIT extends BaseIT {
     GravitinoAdminClient anotherClient = GravitinoAdminClient.builder(uri).withSimpleAuth().build();
 
     metalake = client.createMetalake(metalakeName, "metalake comment", Collections.emptyMap());
+    metalake.addUser("test");
     anotherMetalake = anotherClient.loadMetalake(metalakeName);
+    metalake.removeUser("test");
   }
 
   @AfterAll
@@ -167,7 +169,9 @@ public class CheckCurrentUserIT extends BaseIT {
             catalogName, Catalog.Type.FILESET, "hadoop", "comment", Collections.emptyMap());
 
     // Test to create a schema with a not-existed user
+    metalake.addUser("test");
     Catalog anotherCatalog = anotherMetalake.loadCatalog(catalogName);
+    metalake.removeUser("test");
     Assertions.assertThrows(
         ForbiddenException.class,
         () -> anotherCatalog.asSchemas().createSchema("schema", "comment", Collections.emptyMap()));
@@ -202,12 +206,15 @@ public class CheckCurrentUserIT extends BaseIT {
     SecurableObject metalakeSecObject =
         SecurableObjects.ofMetalake(
             metalakeName, Lists.newArrayList(Privileges.CreateCatalog.allow()));
+
+    // Test creating role with non-existent user fails
     Assertions.assertThrows(
         ForbiddenException.class,
         () ->
             anotherMetalake.createRole(
                 "role", Collections.emptyMap(), Lists.newArrayList(metalakeSecObject)));
 
+    // Test creating role with admin user succeeds
     Assertions.assertDoesNotThrow(
         () ->
             metalake.createRole(
@@ -232,7 +239,9 @@ public class CheckCurrentUserIT extends BaseIT {
             catalogName, Catalog.Type.RELATIONAL, "hive", "catalog comment", properties);
 
     // Test to create schema with not-existed user
+    metalake.addUser("test");
     Catalog anotherCatalog = anotherMetalake.loadCatalog(catalogName);
+    metalake.removeUser("test");
     Assertions.assertThrows(
         ForbiddenException.class,
         () -> anotherCatalog.asSchemas().createSchema("schema", "comment", Collections.emptyMap()));

--- a/core/src/main/java/org/apache/gravitino/hook/AccessControlHookDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/hook/AccessControlHookDispatcher.java
@@ -159,9 +159,6 @@ public class AccessControlHookDispatcher implements AccessControlDispatcher {
       Map<String, String> properties,
       List<SecurableObject> securableObjects)
       throws RoleAlreadyExistsException, NoSuchMetalakeException {
-    // Check whether the current user exists or not
-    AuthorizationUtils.checkCurrentUser(metalake, PrincipalUtils.getCurrentUserName());
-
     Role createdRole = dispatcher.createRole(metalake, role, properties, securableObjects);
 
     // Set the creator as the owner of role.

--- a/core/src/main/java/org/apache/gravitino/hook/CatalogHookDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/hook/CatalogHookDispatcher.java
@@ -79,10 +79,6 @@ public class CatalogHookDispatcher implements CatalogDispatcher {
       String comment,
       Map<String, String> properties)
       throws NoSuchMetalakeException, CatalogAlreadyExistsException {
-    // Check whether the current user exists or not
-    AuthorizationUtils.checkCurrentUser(
-        ident.namespace().level(0), PrincipalUtils.getCurrentUserName());
-
     Catalog catalog = dispatcher.createCatalog(ident, type, provider, comment, properties);
 
     try {

--- a/core/src/main/java/org/apache/gravitino/hook/FilesetHookDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/hook/FilesetHookDispatcher.java
@@ -75,10 +75,6 @@ public class FilesetHookDispatcher implements FilesetDispatcher {
       Map<String, String> storageLocations,
       Map<String, String> properties)
       throws NoSuchSchemaException, FilesetAlreadyExistsException {
-    // Check whether the current user exists or not
-    AuthorizationUtils.checkCurrentUser(
-        ident.namespace().level(0), PrincipalUtils.getCurrentUserName());
-
     Fileset fileset =
         dispatcher.createMultipleLocationFileset(
             ident, comment, type, storageLocations, properties);

--- a/core/src/main/java/org/apache/gravitino/hook/ModelHookDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/hook/ModelHookDispatcher.java
@@ -24,7 +24,6 @@ import org.apache.gravitino.Entity;
 import org.apache.gravitino.GravitinoEnv;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
-import org.apache.gravitino.authorization.AuthorizationUtils;
 import org.apache.gravitino.authorization.Owner;
 import org.apache.gravitino.authorization.OwnerDispatcher;
 import org.apache.gravitino.catalog.ModelDispatcher;
@@ -67,10 +66,6 @@ public class ModelHookDispatcher implements ModelDispatcher {
   @Override
   public Model registerModel(NameIdentifier ident, String comment, Map<String, String> properties)
       throws NoSuchSchemaException, ModelAlreadyExistsException {
-    // Check whether the current user exists or not
-    AuthorizationUtils.checkCurrentUser(
-        ident.namespace().level(0), PrincipalUtils.getCurrentUserName());
-
     Model model = dispatcher.registerModel(ident, comment, properties);
 
     // Set the creator as owner of the model.
@@ -159,10 +154,6 @@ public class ModelHookDispatcher implements ModelDispatcher {
       Map<String, String> properties)
       throws NoSuchSchemaException, ModelAlreadyExistsException,
           ModelVersionAliasesAlreadyExistException {
-    // Check whether the current user exists or not
-    AuthorizationUtils.checkCurrentUser(
-        ident.namespace().level(0), PrincipalUtils.getCurrentUserName());
-
     Model model = dispatcher.registerModel(ident, uris, aliases, comment, properties);
 
     // Set the creator as owner of the model.

--- a/core/src/main/java/org/apache/gravitino/hook/SchemaHookDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/hook/SchemaHookDispatcher.java
@@ -57,10 +57,6 @@ public class SchemaHookDispatcher implements SchemaDispatcher {
   @Override
   public Schema createSchema(NameIdentifier ident, String comment, Map<String, String> properties)
       throws NoSuchCatalogException, SchemaAlreadyExistsException {
-    // Check whether the current user exists or not
-    AuthorizationUtils.checkCurrentUser(
-        ident.namespace().level(0), PrincipalUtils.getCurrentUserName());
-
     Schema schema = dispatcher.createSchema(ident, comment, properties);
 
     // Set the creator as the owner of the schema.

--- a/core/src/main/java/org/apache/gravitino/hook/TableHookDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/hook/TableHookDispatcher.java
@@ -74,11 +74,6 @@ public class TableHookDispatcher implements TableDispatcher {
       SortOrder[] sortOrders,
       Index[] indexes)
       throws NoSuchSchemaException, TableAlreadyExistsException {
-    // Check whether the current user exists or not
-    // TODO(bharos): Move this to PassThroughAuthorizer
-    AuthorizationUtils.checkCurrentUser(
-        ident.namespace().level(0), PrincipalUtils.getCurrentUserName());
-
     Table table =
         dispatcher.createTable(
             ident, columns, comment, properties, partitions, distribution, sortOrders, indexes);

--- a/core/src/main/java/org/apache/gravitino/hook/TopicHookDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/hook/TopicHookDispatcher.java
@@ -63,10 +63,6 @@ public class TopicHookDispatcher implements TopicDispatcher {
   public Topic createTopic(
       NameIdentifier ident, String comment, DataLayout dataLayout, Map<String, String> properties)
       throws NoSuchSchemaException, TopicAlreadyExistsException {
-    // Check whether the current user exists or not
-    AuthorizationUtils.checkCurrentUser(
-        ident.namespace().level(0), PrincipalUtils.getCurrentUserName());
-
     Topic topic = dispatcher.createTopic(ident, comment, dataLayout, properties);
 
     // Set the creator as the owner of the topic.

--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/dispatcher/IcebergNamespaceHookDispatcher.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/dispatcher/IcebergNamespaceHookDispatcher.java
@@ -22,7 +22,6 @@ import java.io.IOException;
 import org.apache.gravitino.Entity;
 import org.apache.gravitino.EntityStore;
 import org.apache.gravitino.GravitinoEnv;
-import org.apache.gravitino.authorization.AuthorizationUtils;
 import org.apache.gravitino.catalog.SchemaDispatcher;
 import org.apache.gravitino.catalog.TableDispatcher;
 import org.apache.gravitino.exceptions.NoSuchEntityException;
@@ -58,8 +57,6 @@ public class IcebergNamespaceHookDispatcher implements IcebergNamespaceOperation
   @Override
   public CreateNamespaceResponse createNamespace(
       IcebergRequestContext context, CreateNamespaceRequest createRequest) {
-    AuthorizationUtils.checkCurrentUser(metalake, context.userName());
-
     CreateNamespaceResponse response = dispatcher.createNamespace(context, createRequest);
 
     importSchema(context.catalogName(), createRequest.namespace());

--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/dispatcher/IcebergTableHookDispatcher.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/dispatcher/IcebergTableHookDispatcher.java
@@ -24,7 +24,6 @@ import org.apache.gravitino.Entity;
 import org.apache.gravitino.EntityStore;
 import org.apache.gravitino.GravitinoEnv;
 import org.apache.gravitino.NameIdentifier;
-import org.apache.gravitino.authorization.AuthorizationUtils;
 import org.apache.gravitino.catalog.TableDispatcher;
 import org.apache.gravitino.exceptions.NoSuchEntityException;
 import org.apache.gravitino.iceberg.common.utils.IcebergIdentifierUtils;
@@ -55,8 +54,6 @@ public class IcebergTableHookDispatcher implements IcebergTableOperationDispatch
   @Override
   public LoadTableResponse createTable(
       IcebergRequestContext context, Namespace namespace, CreateTableRequest createTableRequest) {
-    AuthorizationUtils.checkCurrentUser(metalake, context.userName());
-
     LoadTableResponse response = dispatcher.createTable(context, namespace, createTableRequest);
     importTable(context.catalogName(), namespace, createTableRequest.name());
     IcebergOwnershipUtils.setTableOwner(
@@ -116,8 +113,6 @@ public class IcebergTableHookDispatcher implements IcebergTableOperationDispatch
 
   @Override
   public void renameTable(IcebergRequestContext context, RenameTableRequest renameTableRequest) {
-    AuthorizationUtils.checkCurrentUser(metalake, context.userName());
-
     dispatcher.renameTable(context, renameTableRequest);
     NameIdentifier tableSource =
         IcebergIdentifierUtils.toGravitinoTableIdentifier(

--- a/server-common/src/main/java/org/apache/gravitino/server/authorization/jcasbin/JcasbinAuthorizer.java
+++ b/server-common/src/main/java/org/apache/gravitino/server/authorization/jcasbin/JcasbinAuthorizer.java
@@ -216,6 +216,12 @@ public class JcasbinAuthorizer implements GravitinoAuthorizer {
     if (StringUtils.isBlank(currentUserName)) {
       return false;
     }
+
+    // Service admins are considered users of all metalakes
+    if (isServiceAdmin()) {
+      return true;
+    }
+
     try {
       return GravitinoEnv.getInstance()
               .entityStore()

--- a/server/src/main/java/org/apache/gravitino/server/web/filter/GravitinoInterceptionService.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/filter/GravitinoInterceptionService.java
@@ -39,6 +39,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.gravitino.Entity;
 import org.apache.gravitino.MetadataObject;
 import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.authorization.AuthorizationUtils;
 import org.apache.gravitino.server.authorization.annotations.AuthorizationExpression;
 import org.apache.gravitino.server.authorization.annotations.AuthorizationRequest;
 import org.apache.gravitino.server.authorization.expression.AuthorizationExpressionEvaluator;
@@ -125,11 +126,43 @@ public class GravitinoInterceptionService implements InterceptionService {
      */
     @Override
     public Object invoke(MethodInvocation methodInvocation) throws Throwable {
+      Method method = methodInvocation.getMethod();
+      Parameter[] parameters = method.getParameters();
+      AuthorizationExpression expressionAnnotation =
+          method.getAnnotation(AuthorizationExpression.class);
+
+      // Check current user exists in metalake before authorization
+      if (expressionAnnotation != null) {
+        Object[] args = methodInvocation.getArguments();
+        Map<Entity.EntityType, NameIdentifier> metadataContext =
+            extractNameIdentifierFromParameters(parameters, args);
+
+        // Check if current user exists in the metalake.
+        NameIdentifier metalakeIdent = metadataContext.get(Entity.EntityType.METALAKE);
+
+        if (metalakeIdent != null) {
+          String currentUser = PrincipalUtils.getCurrentUserName();
+          try {
+            AuthorizationUtils.checkCurrentUser(metalakeIdent.name(), currentUser);
+          } catch (org.apache.gravitino.exceptions.ForbiddenException ex) {
+            LOG.warn(
+                "User validation failed - User: {}, Metalake: {}, Reason: {}",
+                currentUser,
+                metalakeIdent.name(),
+                ex.getMessage());
+            return Utils.forbidden(ex.getMessage(), ex);
+          } catch (Exception ex) {
+            LOG.error(
+                "Unexpected error during user validation - User: {}, Metalake: {}",
+                currentUser,
+                metalakeIdent.name(),
+                ex);
+            return Utils.internalError("Failed to validate user", ex);
+          }
+        }
+      }
+
       try {
-        Method method = methodInvocation.getMethod();
-        Parameter[] parameters = method.getParameters();
-        AuthorizationExpression expressionAnnotation =
-            method.getAnnotation(AuthorizationExpression.class);
         AuthorizationExecutor executor;
         if (expressionAnnotation != null) {
           String expression = expressionAnnotation.expression();
@@ -137,6 +170,7 @@ public class GravitinoInterceptionService implements InterceptionService {
           String entityType = extractMetadataObjectTypeFromParameters(parameters, args);
           Map<Entity.EntityType, NameIdentifier> metadataContext =
               extractNameIdentifierFromParameters(parameters, args);
+
           Map<String, Object> pathParams = Utils.extractPathParamsFromParameters(parameters, args);
           AuthorizationExpressionEvaluator authorizationExpressionEvaluator =
               new AuthorizationExpressionEvaluator(expression);


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Moving the check to the interception service ensures the user is validated **once per request** before authorization begins, improving performance while maintaining the same security guarantees.


### Why are the changes needed?

Better refactor and minimize duplicate calls 

Fix : #9270 

### Does this PR introduce _any_ user-facing change?

No. The validation still occurs at the same point in the request flow with identical behavior - non-existent users still receive `ForbiddenException`.


### How was this patch tested?

Running all the tests
