### PR TITLE
[#9270][followup] refactor(authz): Clean up redundant checkCurrentUser check in TagHookDispatcher

### DIFF
--- a/core/src/main/java/org/apache/gravitino/hook/TagHookDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/hook/TagHookDispatcher.java
@@ -21,7 +21,6 @@ import java.util.Map;
 import org.apache.gravitino.Entity;
 import org.apache.gravitino.GravitinoEnv;
 import org.apache.gravitino.MetadataObject;
-import org.apache.gravitino.authorization.AuthorizationUtils;
 import org.apache.gravitino.authorization.Owner;
 import org.apache.gravitino.authorization.OwnerDispatcher;
 import org.apache.gravitino.exceptions.NoSuchTagException;
@@ -57,7 +56,6 @@ public class TagHookDispatcher implements TagDispatcher {
   @Override
   public Tag createTag(
       String metalake, String name, String comment, Map<String, String> properties) {
-    AuthorizationUtils.checkCurrentUser(metalake, PrincipalUtils.getCurrentUserName());
     Tag tag = dispatcher.createTag(metalake, name, comment, properties);
 
     // Set the creator as the owner of the catalog.

--- a/server-common/src/main/java/org/apache/gravitino/server/authorization/jcasbin/JcasbinAuthorizer.java
+++ b/server-common/src/main/java/org/apache/gravitino/server/authorization/jcasbin/JcasbinAuthorizer.java
@@ -217,11 +217,6 @@ public class JcasbinAuthorizer implements GravitinoAuthorizer {
       return false;
     }
 
-    // Service admins are considered users of all metalakes
-    if (isServiceAdmin()) {
-      return true;
-    }
-
     try {
       return GravitinoEnv.getInstance()
               .entityStore()

--- a/server/src/main/java/org/apache/gravitino/server/web/filter/GravitinoInterceptionService.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/filter/GravitinoInterceptionService.java
@@ -40,6 +40,7 @@ import org.apache.gravitino.Entity;
 import org.apache.gravitino.MetadataObject;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.authorization.AuthorizationUtils;
+import org.apache.gravitino.exceptions.ForbiddenException;
 import org.apache.gravitino.server.authorization.annotations.AuthorizationExpression;
 import org.apache.gravitino.server.authorization.annotations.AuthorizationRequest;
 import org.apache.gravitino.server.authorization.expression.AuthorizationExpressionEvaluator;
@@ -144,7 +145,7 @@ public class GravitinoInterceptionService implements InterceptionService {
           String currentUser = PrincipalUtils.getCurrentUserName();
           try {
             AuthorizationUtils.checkCurrentUser(metalakeIdent.name(), currentUser);
-          } catch (org.apache.gravitino.exceptions.ForbiddenException ex) {
+          } catch (ForbiddenException ex) {
             LOG.warn(
                 "User validation failed - User: {}, Metalake: {}, Reason: {}",
                 currentUser,


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

1. Remove redundant isServiceAdmin check from isMetalakeUser()
   - Service admins bypass via SERVICE_ADMIN in authorization expressions
   - Regular users are validated by checkCurrentUser() before authorization
2. Use simple ForbiddenException name instead of fully qualified
   - Add import and use simple name in catch block
3. Remove checkCurrentUser from TagHookDispatcher
   - Check now handled by interceptor, consistent with other dispatchers

Related to PR #9268

### Why are the changes needed?

Refactor

Fix: #9270 

### Does this PR introduce _any_ user-facing change?

no

### How was this patch tested?
Run all tests