### PR TITLE
[#9143] Use orElseGet() instead of orElse() for lazy evaluation in Config.java

### DIFF
--- a/common/src/main/java/org/apache/gravitino/Config.java
+++ b/common/src/main/java/org/apache/gravitino/Config.java
@@ -85,10 +85,11 @@ public abstract class Config {
   public Config loadFromFile(String name) throws Exception {
     String confDir =
         Optional.ofNullable(System.getenv("GRAVITINO_CONF_DIR"))
-            .orElse(
-                Optional.ofNullable(System.getenv("GRAVITINO_HOME"))
-                    .map(s -> s + File.separator + "conf")
-                    .orElse(null));
+            .orElseGet(
+                () ->
+                    Optional.ofNullable(System.getenv("GRAVITINO_HOME"))
+                        .map(s -> s + File.separator + "conf")
+                        .orElse(null));
 
     if (confDir == null) {
       throw new IllegalArgumentException("GRAVITINO_CONF_DIR or GRAVITINO_HOME not set");


### PR DESCRIPTION
### What changes were proposed in this pull request?

Use `orElseGet()` instead of `orElse()` when determining the configuration directory in `Config.loadFromFile()`.

### Why are the changes needed?

- `orElse()` eagerly evaluates its argument, meaning the fallback expression is computed even when the Optional contains a value.
- This causes the lookup and mapping for `GRAVITINO_HOME` to run unnecessarily whenever `GRAVITINO_CONF_DIR` is set.
- Using `orElseGet()` with a Supplier lambda ensures the fallback expression is only evaluated when needed.

Fixes #9143

### How was this patch tested?

- Compiled successfully with `./gradlew :common:compileJava`
- All tests pass with `./gradlew :common:test` and `./gradlew :server:test`