### PR TITLE
[#8747] fix(chart): allow setting schema version from the helm chart

### DIFF
--- a/dev/charts/gravitino-iceberg-rest-server/resources/gravitino-iceberg-rest-server.conf
+++ b/dev/charts/gravitino-iceberg-rest-server/resources/gravitino-iceberg-rest-server.conf
@@ -68,6 +68,9 @@ gravitino.iceberg-rest.jdbc-driver = {{.Values.icebergRest.jdbc.driver }}
 {{- if .Values.icebergRest.jdbc.initialize }}
 gravitino.iceberg-rest.jdbc-initialize = {{.Values.icebergRest.jdbc.initialize }}
 {{- end }}
+{{- if .Values.icebergRest.jdbc.schemaVersion }}
+gravitino.iceberg-rest.jdbc.schema-version = {{.Values.icebergRest.jdbc.schemaVersion }}
+{{- end }}
 {{- end }}
 
 {{- if .Values.icebergRest.s3 }}

--- a/dev/charts/gravitino-iceberg-rest-server/values.yaml
+++ b/dev/charts/gravitino-iceberg-rest-server/values.yaml
@@ -78,6 +78,9 @@ icebergRest:
   #   ## JDBC driver class name
   #   ##
   #   driver: "com.mysql.cj.jdbc.Driver"
+  #   ## Schema version for JDBC catalog (required for view support)
+  #   ##
+  #   schemaVersion: "V1"
   ## Implementation class for Iceberg file I/O operations
   ##
   # ioImpl: "org.apache.iceberg.aws.s3.S3FileIO"

--- a/dev/charts/gravitino/resources/config/gravitino.conf
+++ b/dev/charts/gravitino/resources/config/gravitino.conf
@@ -105,6 +105,9 @@ gravitino.iceberg-rest.jdbc-driver = {{.Values.icebergRest.jdbc.driver }}
 {{- if .Values.icebergRest.jdbc.initialize }}
 gravitino.iceberg-rest.jdbc-initialize = {{.Values.icebergRest.jdbc.initialize }}
 {{- end }}
+{{- if .Values.icebergRest.jdbc.schemaVersion }}
+gravitino.iceberg-rest.jdbc.schema-version = {{.Values.icebergRest.jdbc.schemaVersion }}
+{{- end }}
 {{- end }}
 
 {{- if .Values.icebergRest.s3 }}

--- a/dev/charts/gravitino/values.yaml
+++ b/dev/charts/gravitino/values.yaml
@@ -250,6 +250,9 @@ icebergRest:
   #   ## JDBC driver class name
   #   ##
   #   driver: "com.mysql.cj.jdbc.Driver"
+  #   ## Schema version for JDBC catalog (required for view support)
+  #   ##
+  #   schemaVersion: "V1"
   ## Implementation class for Iceberg file I/O operations
   ##
   # ioImpl: "org.apache.iceberg.aws.s3.S3FileIO"


### PR DESCRIPTION
### What changes were proposed in this pull request?

Allow setting schema version from the helm chart

### Why are the changes needed?

Fix: #8747 

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

CI