### PR TITLE
[#9082] fix(core): validate job run id parsing to avoid SIOOBE

### DIFF
--- a/core/src/test/java/org/apache/gravitino/storage/relational/service/TestJobMetaService.java
+++ b/core/src/test/java/org/apache/gravitino/storage/relational/service/TestJobMetaService.java
@@ -35,7 +35,7 @@ import org.apache.gravitino.storage.relational.TestJDBCBackend;
 import org.apache.gravitino.utils.NameIdentifierUtil;
 import org.apache.gravitino.utils.NamespaceUtil;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestTemplate;
 
 public class TestJobMetaService extends TestJDBCBackend {
 
@@ -44,7 +44,7 @@ public class TestJobMetaService extends TestJDBCBackend {
   private static final AuditInfo AUDIT_INFO =
       AuditInfo.builder().withCreator("test").withCreateTime(Instant.now()).build();
 
-  @Test
+  @TestTemplate
   public void testInsertAndListJobs() throws IOException {
     BaseMetalake metalake =
         createBaseMakeLake(RandomIdGenerator.INSTANCE.nextId(), METALAKE_NAME, AUDIT_INFO);
@@ -87,7 +87,7 @@ public class TestJobMetaService extends TestJDBCBackend {
     Assertions.assertTrue(emptyJobs.isEmpty());
   }
 
-  @Test
+  @TestTemplate
   public void testInsertAndGetJob() throws IOException {
     BaseMetalake metalake =
         createBaseMakeLake(RandomIdGenerator.INSTANCE.nextId(), METALAKE_NAME, AUDIT_INFO);
@@ -148,7 +148,7 @@ public class TestJobMetaService extends TestJDBCBackend {
     Assertions.assertTrue(retrievedFinishedJob.finishedAt() > 0);
   }
 
-  @Test
+  @TestTemplate
   public void testDeleteJobsByLegacyTimeline() throws IOException {
     BaseMetalake metalake =
         createBaseMakeLake(RandomIdGenerator.INSTANCE.nextId(), METALAKE_NAME, AUDIT_INFO);
@@ -195,7 +195,7 @@ public class TestJobMetaService extends TestJDBCBackend {
     Assertions.assertTrue(jobs.isEmpty(), "Jobs should be deleted by legacy timeline");
   }
 
-  @Test
+  @TestTemplate
   public void testDeleteJobByIdentifier() throws IOException {
     BaseMetalake metalake =
         createBaseMakeLake(RandomIdGenerator.INSTANCE.nextId(), METALAKE_NAME, AUDIT_INFO);
@@ -224,5 +224,36 @@ public class TestJobMetaService extends TestJDBCBackend {
     Assertions.assertFalse(
         JobMetaService.getInstance()
             .deleteJob(NameIdentifierUtil.ofJob(METALAKE_NAME, job.name())));
+  }
+
+  @Test
+  public void testGetJobWithMalformedIdentifierThrowsNoSuchEntityException() {
+    Assertions.assertThrows(
+        NoSuchEntityException.class,
+        () ->
+            JobMetaService.getInstance()
+                .getJobByIdentifier(NameIdentifierUtil.ofJob(METALAKE_NAME, "invalid")));
+
+    Assertions.assertThrows(
+        NoSuchEntityException.class,
+        () ->
+            JobMetaService.getInstance()
+                .getJobByIdentifier(
+                    NameIdentifierUtil.ofJob(METALAKE_NAME, JobHandle.JOB_ID_PREFIX)));
+  }
+
+  @Test
+  public void testDeleteJobWithMalformedIdentifierThrowsNoSuchEntityException() {
+    Assertions.assertThrows(
+        NoSuchEntityException.class,
+        () ->
+            JobMetaService.getInstance()
+                .deleteJob(NameIdentifierUtil.ofJob(METALAKE_NAME, "invalid")));
+
+    Assertions.assertThrows(
+        NoSuchEntityException.class,
+        () ->
+            JobMetaService.getInstance()
+                .deleteJob(NameIdentifierUtil.ofJob(METALAKE_NAME, JobHandle.JOB_ID_PREFIX)));
   }
 }


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

- Route job ID parsing in `JobMetaService`#`getJobByIdentifier`/`deleteJob` through `parseJobRunId` so malformed IDs throw `NoSuchEntityException` instead of runtime errors.
- Fix the missing-job error message to include the actual identifier (`ident.toString()`).
- Keep DB-backed tests as `@TestTemplate` so `BackendTestExtension` can inject the relational backend per invocation (required for H2/MySQL/PostgreSQL runs).

### Why are the changes needed?

- Prevents StringIndexOutOfBoundsException/NumberFormatException from malformed job IDs and ensures callers get a consistent NoSuchEntityException.
- The backend-injection extension only runs with `@TestTemplate`; using plain `@Test` would bypass it and leave the backend uninitialized.

Fix: #9082

### Does this PR introduce _any_ user-facing change?
 - No API or behavior changes. Malformed job IDs now consistently return `NoSuchEntityException` instead of unexpected runtime errors, improving error consistency.

### How was this patch tested?
 - Added unit tests:
      - `TestJobMetaService`#`testGetJobWithMalformedIdentifierThrowsNoSuchEntityException`
      - `TestJobMetaService`#`testDeleteJobWithMalformedIdentifierThrowsNoSuchEntityException`
  - Formatting: ./gradlew :core:spotlessJavaCheck
  - Unit: ./gradlew :core:test --tests "org.apache.gravitino.storage.relational.service.TestJobMetaService"