### PR TITLE
[#6868] fix(release): Remove .asc files from PyPI upload

### DIFF
--- a/dev/release/release-build.sh
+++ b/dev/release/release-build.sh
@@ -136,8 +136,7 @@ if [[ "$1" == "finalize" ]]; then
   echo "Uploading Gravitino to PyPi"
   twine upload -u __token__  -p $PYPI_API_TOKEN \
     --repository-url https://upload.pypi.org/legacy/ \
-    "apache_gravitino-$PYGRAVITINO_VERSION.tar.gz" \
-    "apache_gravitino-$PYGRAVITINO_VERSION.tar.gz.asc"
+    "apache_gravitino-$PYGRAVITINO_VERSION.tar.gz"
   echo "Python Gravitino package uploaded"
   rm -fr gravitino
 
@@ -274,8 +273,7 @@ if [[ "$1" == "package" ]]; then
     echo "Uploading Gravitino Python package $RC_RC_PYGRAVITINO_VERSION to PyPi"
     twine upload -u __token__  -p $PYPI_API_TOKEN \
       --repository-url https://upload.pypi.org/legacy/ \
-      "apache_gravitino-$RC_PYGRAVITINO_VERSION.tar.gz" \
-      "apache_gravitino-$RC_PYGRAVITINO_VERSION.tar.gz.asc"
+      "apache_gravitino-$RC_PYGRAVITINO_VERSION.tar.gz"
 
     svn co --depth=empty $RELEASE_STAGING_LOCATION svn-gravitino
     rm -rf "svn-gravitino/${DEST_DIR_NAME}"


### PR DESCRIPTION
### What changes were proposed in this pull request?

Remove .asc (PGP signature) files from PyPI upload commands in the release script.

### Why are the changes needed?

Fix #6868

PyPI deprecated and no longer accepts PGP signature files (.asc). When uploading packages with signature files, PyPI displays a warning that they will be silently ignored. The .asc files are still generated for Apache distribution purposes (dist.apache.org) but should not be uploaded to PyPI.

### Does this PR introduce any user-facing change?

No. This only affects the release process.

### How was this patch tested?

Manual review of the release script changes.