### PR TITLE
[#9314] improvement(CI): Update cherry-pick workflow to target new branch versions

### DIFF
--- a/.github/workflows/auto-cherry-pick.yml
+++ b/.github/workflows/auto-cherry-pick.yml
@@ -59,7 +59,7 @@ jobs:
           labels: |
             cherry-pick
           reviewers: |
-            jerryshao  
+            jerryshao
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION

### What changes were proposed in this pull request?

Updated the GitHub Actions workflow to rename branches from `0.x` to `1.x`. This aligns with the new branching convention and ensures cherry-pick automation works for the renamed branches.

### Why are the changes needed?

- Branch-0.8 and Branch-0.9 will not be updated anymore.
- Branch-1.1 will be released within two weeks.
- 
Fix: #9314 

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

Existing CI.
