### PR TITLE
Improvement : fix(server) : Fix missing-partition handling in PartitionOperations.java to avoid server errors

### DIFF
--- a/server/src/main/java/org/apache/gravitino/server/web/rest/PartitionOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/PartitionOperations.java
@@ -180,19 +180,18 @@ public class PartitionOperations {
       @PathParam("schema") @AuthorizationMetadata(type = Entity.EntityType.SCHEMA) String schema,
       @PathParam("table") @AuthorizationMetadata(type = Entity.EntityType.TABLE) String table,
       AddPartitionsRequest request) {
-    LOG.info(
-        "Received add {} partition(s) request for table {}.{}.{}.{} ",
-        request.getPartitions().length,
-        metalake,
-        catalog,
-        schema,
-        table);
-    Preconditions.checkArgument(
-        request.getPartitions().length == 1, "Only one partition is supported");
-
-    request.validate();
-
     try {
+      request.validate();
+
+      LOG.info(
+          "Received add {} partition(s) request for table {}.{}.{}.{} ",
+          request.getPartitions().length,
+          metalake,
+          catalog,
+          schema,
+          table);
+      Preconditions.checkArgument(
+          request.getPartitions().length == 1, "Only one partition is supported");
       return Utils.doAs(
           httpRequest,
           () -> {

--- a/server/src/test/java/org/apache/gravitino/server/web/rest/TestPartitionOperations.java
+++ b/server/src/test/java/org/apache/gravitino/server/web/rest/TestPartitionOperations.java
@@ -326,4 +326,24 @@ public class TestPartitionOperations extends JerseyTest {
     Assertions.assertEquals(0, noExistDropResponse.getCode());
     Assertions.assertFalse(noExistDropResponse.dropped());
   }
+
+  @Test
+  public void testAddPartitionWithNullPartitions() {
+    AddPartitionsRequest invalidReq = new AddPartitionsRequest();
+
+    try (Response resp =
+        target(partitionPath(metalake, catalog, schema, table))
+            .request(MediaType.APPLICATION_JSON_TYPE)
+            .accept("application/vnd.gravitino.v1+json")
+            .post(Entity.entity(invalidReq, MediaType.APPLICATION_JSON_TYPE))) {
+
+      Assertions.assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), resp.getStatus());
+
+      ErrorResponse errorResponse = resp.readEntity(ErrorResponse.class);
+      Assertions.assertEquals(ErrorConstants.ILLEGAL_ARGUMENTS_CODE, errorResponse.getCode());
+      Assertions.assertEquals(
+          IllegalArgumentException.class.getSimpleName(), errorResponse.getType());
+      Assertions.assertTrue(errorResponse.getMessage().contains("partitions must not be null"));
+    }
+  }
 }


### PR DESCRIPTION
<!--
1. Title: [#9307] fix(core): fix missing-partition handling in PartitionOperations
-->
  
### What changes were proposed in this pull request?

This change updates the handling of partitions in `PartitionOperations` so that missing-partition cases are properly handled, avoiding server errors when partitions are missing or invalid.

### Why are the changes needed?

Without this change, in certain scenarios where a partition is missing or not found, operations in `PartitionOperations` could trigger server-side errors — e.g. a NullPointerException or inappropriate behavior when partition metadata is absent. This fix ensures robustness by detecting missing partitions and handling them gracefully, preventing potential crashes.  

Fixes: #9307  

### Does this PR introduce _any_ user-facing change?

No — this change is internal to partition-handling logic. The public API remains the same; there are no changes to user-visible APIs or configuration keys.  

### How was this patch tested?

By applying the patch and running the existing test suite to ensure no regressions. For partition operations involving missing partitions, the behavior has been corrected (i.e. operations now fail gracefully instead of erroring). If necessary, additional unit tests should be added to cover missing-partition cases to ensure this fix works reliably under various scenarios.  
