### PR TITLE
[MINOR] fix(build): Bump the dependency version to fix several security issues

### DIFF
--- a/clients/client-python/requirements-dev.txt
+++ b/clients/client-python/requirements-dev.txt
@@ -15,15 +15,15 @@
 # specific language governing permissions and limitations
 # under the License.
 
-requests==2.32.3
+requests==2.32.5
 dataclasses-json==0.6.7
 pylint==3.2.2
 black==24.4.2
 twine==5.1.1
 coverage==7.5.1
-pandas==2.3.3
+pandas==2.2.3
 pyarrow==15.0.2
-llama-index==0.12.41
+llama-index==0.13.0
 tenacity==8.3.0
 cachetools==6.2.1
 readerwriterlock==1.0.9

--- a/clients/client-python/requirements.txt
+++ b/clients/client-python/requirements.txt
@@ -17,7 +17,7 @@
 
 
 # the tools to publish the python client to Pypi
-requests==2.32.3
+requests==2.32.5
 dataclasses-json==0.6.7
 readerwriterlock==1.0.9
 fsspec==2024.3.1


### PR DESCRIPTION
### What changes were proposed in this pull request?

Increase several Python dependency versions to fix the security issues mentioned in https://github.com/apache/gravitino/security.

Note that the current LlamaIndex version is incompatible with Pandas version, so downgrading the Pandas version to be compatible with LlamaIndex.

### Why are the changes needed?

To fix the security issues.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing CIs.
