### PR TITLE
[#9278] improvement(server): Fix missing appender reference for REST logger in log4j2 configuration

### DIFF
--- a/conf/log4j2.properties.template
+++ b/conf/log4j2.properties.template
@@ -74,6 +74,7 @@ logger.lineage.additivity = false
 
 logger.rest.name = org.apache.gravitino.server.web.rest
 logger.rest.level = warn
+logger.rest.appenderRef.rolling.ref = fileLogger
 logger.rest.additivity = false
 
 # Configure root logger


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR fixes a logging configuration issue where REST operation exceptions were not being written to the server log file.

**Changes:**
- Added `logger.rest.appenderRef.rolling.ref = fileLogger` to `conf/log4j2.properties.template`

**Root Cause:**
The REST logger (`org.apache.gravitino.server.web.rest`) was defined with a log level and additivity setting, but was missing the appender reference. This meant that when REST operations failed (e.g., invalid storage location in fileset creation), the exception stack traces were not written to `gravitino-server.log`, making server-side debugging difficult.

**Impact:**
- REST operation failures now properly log exception stack traces to gravitino-server.log
- Aligns template configuration with `distribution/package/conf/log4j2.properties` (which already had this fix)
- Improves server-side debuggability for operators

### Why are the changes needed?

Fix #9278 

As reported in the issue, when REST API operations fail (such as creating a fileset with invalid storage location `s://bucket`), there are no error logs in the server side (gravitino-server.log). The client receives error responses, but operators cannot debug the issue without server-side logs.

This is a critical observability issue that affects production deployments.

### Does this PR introduce _any_ user-facing change?

No user-facing changes. This is an internal logging configuration fix that improves observability.

### How was this patch tested?

- Manual testing confirmed that REST operation exceptions now appear in server logs
- Verified all other log4j2 configuration files don't have similar issues
- Confirmed the fix aligns with the already-correct `distribution/package/conf/log4j2.properties`