### PR TITLE
[#8010] improvement: fix resource path enumeration to accumulate parent segments

### DIFF
--- a/bundles/gcp/src/main/java/org/apache/gravitino/gcs/credential/GCSTokenGenerator.java
+++ b/bundles/gcp/src/main/java/org/apache/gravitino/gcs/credential/GCSTokenGenerator.java
@@ -111,21 +111,22 @@ public class GCSTokenGenerator implements CredentialGenerator<GCSTokenCredential
 
   // "a/b/c" will get ["a", "a/", "a/b", "a/b/", "a/b/c"]
   static List<String> getAllResources(String resourcePath) {
+    if (resourcePath == null || resourcePath.isEmpty() || resourcePath.equals("/")) {
+      return Arrays.asList("");
+    }
     if (resourcePath.endsWith("/")) {
       resourcePath = resourcePath.substring(0, resourcePath.length() - 1);
-    }
-    if (resourcePath.isEmpty()) {
-      return Arrays.asList("");
     }
     Preconditions.checkArgument(
         !resourcePath.startsWith("/"), resourcePath + " should not start with /");
     List<String> parts = Arrays.asList(resourcePath.split("/"));
     List<String> results = new ArrayList<>();
-    String parent = "";
+    StringBuilder parent = new StringBuilder();
     for (int i = 0; i < parts.size() - 1; i++) {
-      results.add(parts.get(i));
-      parent += parts.get(i) + "/";
-      results.add(parent);
+      String part = parts.get(i);
+      results.add(parent + part);
+      parent.append(part).append("/");
+      results.add(parent.toString());
     }
     results.add(parent + parts.get(parts.size() - 1));
     return results;

--- a/bundles/gcp/src/test/java/org/apache/gravitino/gcs/credential/TestGCSTokenProvider.java
+++ b/bundles/gcp/src/test/java/org/apache/gravitino/gcs/credential/TestGCSTokenProvider.java
@@ -31,13 +31,16 @@ public class TestGCSTokenProvider {
   @Test
   void testGetAllResources() {
     Map<String, List<String>> checkResults =
-        ImmutableMap.of(
-            "a/b", Arrays.asList("a", "a/", "a/b"),
-            "a/b/", Arrays.asList("a", "a/", "a/b"),
-            "a", Arrays.asList("a"),
-            "a/", Arrays.asList("a"),
-            "", Arrays.asList(""),
-            "/", Arrays.asList(""));
+        ImmutableMap.<String, List<String>>builder()
+            .put("a/b", Arrays.asList("a", "a/", "a/b"))
+            .put("a/b/", Arrays.asList("a", "a/", "a/b"))
+            .put("a/b/c", Arrays.asList("a", "a/", "a/b", "a/b/", "a/b/c"))
+            .put("a/b/c/", Arrays.asList("a", "a/", "a/b", "a/b/", "a/b/c"))
+            .put("a", Arrays.asList("a"))
+            .put("a/", Arrays.asList("a"))
+            .put("", Arrays.asList(""))
+            .put("/", Arrays.asList(""))
+            .build();
 
     checkResults.forEach(
         (key, value) -> {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR fixes the incorrect resource path enumeration logic in the GCS token provider by ensuring that multi-level paths accumulate parent segments correctly and include both non-directory and directory variants where appropriate.
Additionally, the logic that previously concatenated strings to the `parent` variable using + operations has been replaced with a StringBuilder for improved efficiency, and cases where `resourcePath` is null are now handled safely.

### Why are the changes needed?

The previous implementation did not include the non-directory path segments for intermediate levels.
Additionally, repeatedly concatenating strings using the + operator introduced unnecessary overhead, and the absence of null handling for resourcePath could result in unexpected exceptions.

Fix: https://github.com/apache/gravitino/issues/8010

### Does this PR introduce _any_ user-facing change?

No new user-facing API is introduced.

### How was this patch tested?

Use the test code below

```java
  @Test
  void testGetAllResources() {
    Map<String, List<String>> checkResults =
        ImmutableMap.<String, List<String>>builder()
            .put("a/b", Arrays.asList("a", "a/", "a/b"))
            .put("a/b/", Arrays.asList("a", "a/", "a/b"))
            .put("a/b/c", Arrays.asList("a", "a/", "a/b", "a/b/", "a/b/c"))
            .put("a/b/c/", Arrays.asList("a", "a/", "a/b", "a/b/", "a/b/c"))
            .put("a", Arrays.asList("a"))
            .put("a/", Arrays.asList("a"))
            .put("", Arrays.asList(""))
            .put("/", Arrays.asList(""))
            .build();

    checkResults.forEach(
        (key, value) -> {
          List<String> parentResources = GCSTokenProvider.getAllResources(key);
          Assertions.assertArrayEquals(value.toArray(), parentResources.toArray());
        });
  }
```