### PR TITLE
[Minor] fix(scripts): Fix a minor problem in `release-util.sh`

### DIFF
--- a/dev/release/release-util.sh
+++ b/dev/release/release-util.sh
@@ -171,7 +171,7 @@ function get_release_info {
   fi
 
   export GIT_EMAIL="$ASF_USERNAME@apache.org"
-  export GPG_KEY=$(read_config "GPG key" "$GIT_EMAIL")
+  export GPG_KEY=$(read_config "GPG key" "$GPG_KEY")
 
   cat <<EOF
 ================


### PR DESCRIPTION

### What changes were proposed in this pull request?

This pull request makes a minor update to the `get_release_info` function in `dev/release/release-util.sh`, specifically changing how the `GPG_KEY` configuration is read. The change improves the logic for retrieving the GPG key.

* Updated the `get_release_info` function to use the existing `GPG_KEY` environment variable instead of deriving it from the `GIT_EMAIL` when reading the GPG key configuration.

### Why are the changes needed?

It's a bug.

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

Test locally.
