### PR TITLE
[#9390] improvment(lance-rest): Unified Lance REST configurations format with Iceberg REST

### DIFF
--- a/conf/gravitino-lance-rest-server.conf.template
+++ b/conf/gravitino-lance-rest-server.conf.template
@@ -44,6 +44,6 @@ gravitino.lance-rest.responseHeaderSize = 131072
 # The backend Lance namespace for Lance REST service, it's recommended to use Gravitino
 gravitino.lance-rest.namespace-backend = gravitino
 # The uri of the Lance REST service gravitino namespace backend
-gravitino.lance-rest.gravitino.uri = http://localhost:8090
+gravitino.lance-rest.gravitino-uri = http://localhost:8090
 # The metalake name used for Lance REST service gravitino namespace backend, please create the metalake before using it, and configure the metalake name here.
-# gravitino.lance-rest.gravitino.metalake-name = metalake
+# gravitino.lance-rest.gravitino-metalake = metalake

--- a/conf/gravitino.conf.template
+++ b/conf/gravitino.conf.template
@@ -105,6 +105,6 @@ gravitino.lance-rest.httpPort = 9101
 # The backend Lance namespace for Lance REST service, it's recommended to use Gravitino
 gravitino.lance-rest.namespace-backend = gravitino
 # The uri of the Lance REST service gravitino namespace backend
-gravitino.lance-rest.gravitino.uri = http://localhost:8090
+gravitino.lance-rest.gravitino-uri = http://localhost:8090
 # The metalake name used for Lance REST service gravitino namespace backend, please create the metalake first before using it, and configure the metalake name here.
-# gravitino.lance-rest.gravitino.metalake-name = metalake
+# gravitino.lance-rest.gravitino.metalake = metalake

--- a/dev/docker/lance-rest-server/rewrite_config.py
+++ b/dev/docker/lance-rest-server/rewrite_config.py
@@ -20,16 +20,16 @@ import os
 
 env_map = {
     "LANCE_REST_NAMESPACE_BACKEND": "namespace-backend",
-    "LANCE_REST_GRAVITINO_URI": "gravitino.uri",
-    "LANCE_REST_GRAVITINO_METALAKE_NAME": "gravitino.metalake-name",
+    "LANCE_REST_GRAVITINO_URI": "gravitino-uri",
+    "LANCE_REST_GRAVITINO_METALAKE_NAME": "gravitino-metalake",
     "LANCE_REST_HOST": "host",
     "LANCE_REST_PORT": "httpPort"
 }
 
 init_config = {
     "namespace-backend": "gravitino",
-    "gravitino.uri": "http://localhost:8090",
-    "gravitino.metalake-name": "metalake",
+    "gravitino-uri": "http://localhost:8090",
+    "gravitino-metalake": "metalake",
     "host": "0.0.0.0",
     "httpPort": "9101"
 }

--- a/docs/docker-image-details.md
+++ b/docs/docker-image-details.md
@@ -142,7 +142,7 @@ Memory settings
 Use `GRAVITINO_MEM` to size the JVM (default `-Xms1024m -Xmx1024m -XX:MaxMetaspaceSize=512m`). Example: `-e GRAVITINO_MEM="-Xms2g -Xmx2g -XX:MaxMetaspaceSize=512m"`. Launch scripts append `GRAVITINO_MEM` to `JAVA_OPTS`, so set it whenever you need different heap/metaspace sizes.
 
 Currently, Gravitino Lance REST server supports setting the following environment variables
-- LANCE_REST_GRAVITINO_METALAKE_NAME: It will overwrite the configuration "gravitino.lance-rest.gravitino.metalake-name" in configuration file `conf/gravitino-lance-rest-server.conf`. **You should set it to your Gravitino metalake name.**
+- LANCE_REST_GRAVITINO_METALAKE_NAME: It will overwrite the configuration "gravitino.lance-rest.gravitino-metalake" in configuration file `conf/gravitino-lance-rest-server.conf`. **You should set it to your Gravitino metalake name.**
 - LANCE_REST_NAMESPACE_BACKEND: It will overwrite the configuration "gravitino.lance-rest.namespace-backend" in configuration file `conf/gravitino-lance-rest-server.conf`. The default value is "gravitino" and you should not change it as of now.
 - LANCE_REST_GRAVITINO_URI: It will overwrite the configuration "gravitino.lance-rest.gravitino-uri" in configuration file `conf/gravitino-lance-rest-server.conf`. The default value is "http://localhost:8090" and you can change it to your Gravitino server address.
 - LANCE_REST_HOST: It will overwrite the configuration "gravitino.lance-rest.host" in configuration file `conf/gravitino-lance-rest-server.conf`. The default value is `0.0.0.0`.

--- a/lance/lance-common/src/main/java/org/apache/gravitino/lance/common/config/LanceConfig.java
+++ b/lance/lance-common/src/main/java/org/apache/gravitino/lance/common/config/LanceConfig.java
@@ -31,7 +31,7 @@ public class LanceConfig extends Config implements OverwriteDefaultConfig {
 
   public static final String LANCE_CONFIG_PREFIX = "gravitino.lance-rest.";
   public static final String CONFIG_NAMESPACE_BACKEND = "namespace-backend";
-  public static final String CONFIG_METALAKE = "metalake-name";
+  public static final String CONFIG_METALAKE = "metalake";
   public static final String CONFIG_URI = "uri";
 
   public static final int DEFAULT_LANCE_REST_SERVICE_HTTP_PORT = 9101;
@@ -47,14 +47,14 @@ public class LanceConfig extends Config implements OverwriteDefaultConfig {
           .createWithDefault(GRAVITINO_NAMESPACE_BACKEND);
 
   public static final ConfigEntry<String> METALAKE_NAME =
-      new ConfigBuilder(GRAVITINO_NAMESPACE_BACKEND + "." + CONFIG_METALAKE)
+      new ConfigBuilder(GRAVITINO_NAMESPACE_BACKEND + "-" + CONFIG_METALAKE)
           .doc("The Metalake name for Lance Gravitino namespace backend")
           .version(ConfigConstants.VERSION_1_1_0)
           .stringConf()
           .create();
 
   public static final ConfigEntry<String> NAMESPACE_BACKEND_URI =
-      new ConfigBuilder(GRAVITINO_NAMESPACE_BACKEND + "." + CONFIG_URI)
+      new ConfigBuilder(GRAVITINO_NAMESPACE_BACKEND + "-" + CONFIG_URI)
           .doc("The URI of the namespace backend, e.g., Gravitino server URI")
           .version(ConfigConstants.VERSION_1_1_0)
           .stringConf()


### PR DESCRIPTION
### What changes were proposed in this pull request?

Change configuration:
- `gravitino.lance-rest.gravitino.uri` to `gravitino.lance-rest.gravitino-uri`
- `gravitino.lance-rest.gravitino.metalake` to `gravitino.lance-rest.gravitino-metalake`

### Why are the changes needed?

To make the format consistent with that in Iceberg REST.

Fix: #9390 

### Does this PR introduce _any_ user-facing change?

Yes，but Lance REST has not been released yet, so it's free to do so.

### How was this patch tested?

UTs and ITs
