### PR TITLE
[#9317] improvement(server): a missing partition will cause sever error…

### DIFF
--- a/server/src/main/java/org/apache/gravitino/server/web/rest/PartitionOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/PartitionOperations.java
@@ -180,19 +180,22 @@ public class PartitionOperations {
       @PathParam("schema") @AuthorizationMetadata(type = Entity.EntityType.SCHEMA) String schema,
       @PathParam("table") @AuthorizationMetadata(type = Entity.EntityType.TABLE) String table,
       AddPartitionsRequest request) {
-    LOG.info(
-        "Received add {} partition(s) request for table {}.{}.{}.{} ",
-        request.getPartitions().length,
-        metalake,
-        catalog,
-        schema,
-        table);
-    Preconditions.checkArgument(
-        request.getPartitions().length == 1, "Only one partition is supported");
-
-    request.validate();
-
     try {
+      if (request == null || request.getPartitions() == null) {
+        throw new IllegalArgumentException("partitions must not be null");
+      }
+      LOG.info(
+          "Received add {} partition(s) request for table {}.{}.{}.{} ",
+          request.getPartitions().length,
+          metalake,
+          catalog,
+          schema,
+          table);
+      Preconditions.checkArgument(
+          request.getPartitions().length == 1, "Only one partition is supported");
+
+      request.validate();
+
       return Utils.doAs(
           httpRequest,
           () -> {

--- a/server/src/test/java/org/apache/gravitino/server/web/rest/TestPartitionOperations.java
+++ b/server/src/test/java/org/apache/gravitino/server/web/rest/TestPartitionOperations.java
@@ -326,4 +326,23 @@ public class TestPartitionOperations extends JerseyTest {
     Assertions.assertEquals(0, noExistDropResponse.getCode());
     Assertions.assertFalse(noExistDropResponse.dropped());
   }
+
+  @Test
+  public void testAddPartitionWithNullPartitions() {
+    AddPartitionsRequest invalidReq = new AddPartitionsRequest();
+
+    Response resp =
+        target(partitionPath(metalake, catalog, schema, table))
+            .request(MediaType.APPLICATION_JSON_TYPE)
+            .accept("application/vnd.gravitino.v1+json")
+            .post(Entity.entity(invalidReq, MediaType.APPLICATION_JSON_TYPE));
+
+    Assertions.assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), resp.getStatus());
+
+    ErrorResponse errorResponse = resp.readEntity(ErrorResponse.class);
+    Assertions.assertEquals(ErrorConstants.ILLEGAL_ARGUMENTS_CODE, errorResponse.getCode());
+    Assertions.assertEquals(
+        IllegalArgumentException.class.getSimpleName(), errorResponse.getType());
+    Assertions.assertTrue(errorResponse.getMessage().contains("partitions must not be null"));
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Introduced a null check in the addPartitions resource method within PartitionOperations.java, It throws IllegalArgumentException, expanded the try scope to cover the check as well.
A new unit test, testAddPartitionWithNullPartitions(), for fix validation.


### Why are the changes needed?

Currently, if the request or its partition are null, the result is an NPE, it bypassed the intended error mapping logic and was treated as an unexpected server error, resulting in an 500 Internal Server Error response.

Fix: #9317 

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?

Added testAddPartitionWithNullPartitions() to test suit and executed these:
 ./gradlew :common:compileJava
./gradlew :common:test 
./gradlew :server:test
All builds/tests were successful. 

