### PR TITLE
[MINOR] docs: Fix Spark datatype mapping for TimestampNTZType

### DIFF
--- a/docs/spark-connector/spark-connector.md
+++ b/docs/spark-connector/spark-connector.md
@@ -84,23 +84,23 @@ The command `SHOW CATALOGS` will only display the Spark default catalog, named s
 
 Gravitino spark connector support the following datatype mapping between Spark and Gravitino.
 
-| Spark Data Type     | Gravitino Data Type           | Since Version |
-|---------------------|-------------------------------|---------------|
-| `BooleanType`       | `boolean`                     | 0.5.0         |
-| `ByteType`          | `byte`                        | 0.5.0         |
-| `ShortType`         | `short`                       | 0.5.0         |
-| `IntegerType`       | `integer`                     | 0.5.0         |
-| `LongType`          | `long`                        | 0.5.0         |
-| `FloatType`         | `float`                       | 0.5.0         |
-| `DoubleType`        | `double`                      | 0.5.0         |
-| `DecimalType`       | `decimal`                     | 0.5.0         |
-| `StringType`        | `string`                      | 0.5.0         |
-| `CharType`          | `char`                        | 0.5.0         |
-| `VarcharType`       | `varchar`                     | 0.5.0         |
-| `TimestampType`     | `timestamp with time zone`    | 0.5.0         |
+| Spark Data Type                   | Gravitino Data Type           | Since Version |
+|-----------------------------------|-------------------------------|---------------|
+| `BooleanType`                     | `boolean`                     | 0.5.0         |
+| `ByteType`                        | `byte`                        | 0.5.0         |
+| `ShortType`                       | `short`                       | 0.5.0         |
+| `IntegerType`                     | `integer`                     | 0.5.0         |
+| `LongType`                        | `long`                        | 0.5.0         |
+| `FloatType`                       | `float`                       | 0.5.0         |
+| `DoubleType`                      | `double`                      | 0.5.0         |
+| `DecimalType`                     | `decimal`                     | 0.5.0         |
+| `StringType`                      | `string`                      | 0.5.0         |
+| `CharType`                        | `char`                        | 0.5.0         |
+| `VarcharType`                     | `varchar`                     | 0.5.0         |
+| `TimestampType`                   | `timestamp with time zone`    | 0.5.0         |
 | `TimestampNTZType` *(Spark 3.4+)* | `timestamp without time zone` | 0.5.0         |
-| `DateType`          | `date`                        | 0.5.0         |
-| `BinaryType`        | `binary`                      | 0.5.0         |
-| `ArrayType`         | `array`                       | 0.5.0         |
-| `MapType`           | `map`                         | 0.5.0         |
-| `StructType`        | `struct`                      | 0.5.0         |
+| `DateType`                        | `date`                        | 0.5.0         |
+| `BinaryType`                      | `binary`                      | 0.5.0         |
+| `ArrayType`                       | `array`                       | 0.5.0         |
+| `MapType`                         | `map`                         | 0.5.0         |
+| `StructType`                      | `struct`                      | 0.5.0         |


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

This PR fixes a small document issue in the Spark connector datatype mapping.
Since `TimestampNTZType` is not available in Spark 3.3 - it was introduced in 3.4. The current docs may mislead users running Spark 3.3
This PR applies a minimal inline annotation:
```
TimestampNTZType (Spark 3.4+)
```

### Why are the changes needed?
Fix a small document issue

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?
