### PR TITLE
[#9400]improvement(release): Add copying and signing for Gravitino Lance REST server binary distribution

### DIFF
--- a/dev/release/release-build.sh
+++ b/dev/release/release-build.sh
@@ -277,7 +277,7 @@ if [[ "$1" == "package" ]]; then
       error 'The environment variable PYPI_API_TOKEN is not set. Exiting.'
     fi
 
-    echo "Uploading Gravitino Python package $RC_RC_PYGRAVITINO_VERSION to PyPi"
+    echo "Uploading Gravitino Python package $RC_PYGRAVITINO_VERSION to PyPi"
     twine upload -u __token__  -p $PYPI_API_TOKEN \
       --repository-url https://upload.pypi.org/legacy/ \
       "apache_gravitino-$RC_PYGRAVITINO_VERSION.tar.gz"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This pull request adds support for packaging and signing the Gravitino Lance REST server binary distribution in the release build script. This ensures that the Lance REST server binary is properly copied, signed, and its checksum is generated alongside other distributions.

Distribution packaging and signing:

* Updated `dev/release/release-build.sh` to copy the `gravitino-lance-rest-server-$GRAVITINO_VERSION-bin.tar.gz` file, sign it with GPG, and generate its SHA-512 checksum, similar to the existing process for other distributions.

### Why are the changes needed?

We are going to release the Lance REST service in 1.1.0 release

Fix: #9400

### Does this PR introduce _any_ user-facing change?

N/A.

### How was this patch tested?

Test locally. 
