### PR TITLE
[#9305] Improvement(lineage): in LineageSinkManager:capacityPerSink has the possibility to be set to zero.

### DIFF
--- a/lineage/src/main/java/org/apache/gravitino/lineage/sink/LineageSinkManager.java
+++ b/lineage/src/main/java/org/apache/gravitino/lineage/sink/LineageSinkManager.java
@@ -81,6 +81,7 @@ public class LineageSinkManager implements Closeable {
         StringUtils.isNotBlank(queueCapacity), "Lineage sink queue capacity is not set");
 
     int totalCapacity = Integer.parseInt(queueCapacity);
+    Preconditions.checkArgument(totalCapacity > 0, "Lineage sink queue capacity must be positive");
     int capacityPerSink = Math.max(1, totalCapacity / sinks.size());
 
     eventListenerConfigs.put(

--- a/lineage/src/test/java/org/apache/gravitino/lineage/sink/TestLineageSinkManager.java
+++ b/lineage/src/test/java/org/apache/gravitino/lineage/sink/TestLineageSinkManager.java
@@ -114,6 +114,17 @@ public class TestLineageSinkManager {
         });
   }
 
+  @Test
+  public void testInvalidQueueCapacityThrowsException() {
+    List<String> sinks = Arrays.asList("sinkA", "sinkB");
+    Map<String, String> lineageConfigs = new HashMap<>();
+    lineageConfigs.put(LineageConfig.LINEAGE_SINK_QUEUE_CAPACITY, "0");
+
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> LineageSinkManager.transformToEventListenerConfigs(sinks, lineageConfigs));
+  }
+
   private void checkLineageSink(LineageSinkForTest sink) {
     Map<String, String> configs = sink.getConfigs();
     Assertions.assertTrue(configs.containsKey("name"));


### PR DESCRIPTION

### What changes were proposed in this pull request?

This PR adds a default value of 1 for integer divisons that result in 0 at the level generateEventListenerConfigs methods.

the fix uses parseInt to parse into an int primitive instead of Integer object since were storing into int, and Math.max(1, totalCapacity / sinks.size()) to guarantee a minimum queue capacitypersink of 1.

### Why are the changes needed?

Previously, integer division operations in generateEventListenerConfigs could result in a value of 0 capacityPerSink, when the total capacity is less than the number of sinks. this violates EventListenerConfig explicit rule that enforces a capacity being larger than 0. which leads to an initialization failure when the configuration is loaded.

Fix: #9305

### Does this PR introduce _any_ user-facing change?

No, this is purely internal

### How was this patch tested?

Added unit test and ran the following:
./gradlew :common:compileJava
./gradlew :common:test
./gradlew :lineage:test

