### PR TITLE
[MINOR] fix(license): Web module adds a new dependency, we should include the new MIT license

### DIFF
--- a/web/web/LICENSE.bin
+++ b/web/web/LICENSE.bin
@@ -332,12 +332,6 @@
    @typescript-eslint/types
    @typescript-eslint/typescript-estree
    @typescript-eslint/visitor-keys
-   @vitest/coverage-v8
-   @vitest/expect
-   @vitest/runner
-   @vitest/snapshot
-   @vitest/spy
-   @vitest/utils
    @xobotyi/scrollbar-width
    acorn
    acorn-jsx

--- a/web/web/licenses/jsdom.txt
+++ b/web/web/licenses/jsdom.txt
@@ -1,0 +1,22 @@
+Copyright (c) 2010 Elijah Insua
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
### What changes were proposed in this pull request?

Web module add a new dependency, we should include the new MIT license

### Why are the changes needed?

Just a minor.
#8232 added jsdom dependency.
Jsdom is mit license. We should include the license.
The test dependencies won't be packaged to the release package. So we don't need to include them.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?
 No need.
