### PR TITLE
[#9448] improvement(catalogs):  Validate table location and add unit tests for location checks

### DIFF
--- a/catalogs/catalog-lakehouse-generic/src/test/java/org/apache/gravitino/catalog/lakehouse/lance/TestLanceTableOperations.java
+++ b/catalogs/catalog-lakehouse-generic/src/test/java/org/apache/gravitino/catalog/lakehouse/lance/TestLanceTableOperations.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.spy;
 
 import com.google.common.collect.Maps;
 import java.util.Map;
+import java.util.stream.Stream;
 import org.apache.gravitino.EntityStore;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.catalog.ManagedSchemaOperations;
@@ -38,6 +39,9 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class TestLanceTableOperations {
 
@@ -88,5 +92,23 @@ public class TestLanceTableOperations {
                 null,
                 new SortOrder[0],
                 new Index[0]));
+  }
+
+  @ParameterizedTest
+  @MethodSource("pathProvider")
+  void testRegisterWithInvalidLocation(String location, boolean isValid) {
+    Assertions.assertEquals(isValid, lanceTableOps.isValidLanceLocation(location));
+  }
+
+  static Stream<Arguments> pathProvider() {
+    return Stream.of(
+        Arguments.of("/data/lance/table1", true),
+        Arguments.of("hdfs://namenode:8020/data/lance/table2", true),
+        Arguments.of("s3a://bucket/data/lance/table3", true),
+        Arguments.of("file:///data/lance/table4", true),
+        Arguments.of("ftp://server/data/lance/table5", true),
+        Arguments.of("invalid/path", false),
+        Arguments.of("", false),
+        Arguments.of(null, false));
   }
 }

--- a/lance/lance-rest-server/src/test/java/org/apache/gravitino/lance/integration/test/LanceRESTServiceIT.java
+++ b/lance/lance-rest-server/src/test/java/org/apache/gravitino/lance/integration/test/LanceRESTServiceIT.java
@@ -672,6 +672,17 @@ public class LanceRESTServiceIT extends BaseIT {
     Assertions.assertNotNull(response);
     Assertions.assertEquals(nonExistingLocation, response.getLocation());
     Assertions.assertFalse(new File(nonExistingLocation).exists());
+
+    // Now try to register an invalid path
+    String invalidPath = "invalid/path";
+    ids = List.of(CATALOG_NAME, SCHEMA_NAME, "table_register_invalid_path");
+    registerTableRequest.setMode(ModeEnum.CREATE);
+    registerTableRequest.setId(ids);
+    registerTableRequest.setLocation(invalidPath);
+    LanceNamespaceException exception =
+        Assertions.assertThrows(
+            LanceNamespaceException.class, () -> ns.registerTable(registerTableRequest));
+    Assertions.assertTrue(exception.getMessage().contains("Table location is invalid"));
   }
 
   @Test


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pull request improves validation for table locations in the Lance catalog implementation. The main change is the introduction of a stricter check to ensure table locations are valid URIs or absolute file paths, preventing invalid or ambiguous locations from being used. Comprehensive unit and integration tests are also added to verify this behavior.

**Validation improvements:**

* Added a new `isValidLanceLocation` method in `LanceTableOperations` to validate that table locations are either valid URIs with a scheme or absolute file paths. This method is now used in table creation to enforce correct location formats. [[1]](diffhunk://#diff-0f917d044cc444092f273c9619772077d88a905b4543f9587a57b6c74d1bb0acR31-R40) [[2]](diffhunk://#diff-0f917d044cc444092f273c9619772077d88a905b4543f9587a57b6c74d1bb0acL110-R116) [[3]](diffhunk://#diff-0f917d044cc444092f273c9619772077d88a905b4543f9587a57b6c74d1bb0acR349-R378)

**Testing enhancements:**

* Added parameterized unit tests in `TestLanceTableOperations` to cover various valid and invalid location formats, ensuring the new validation logic works as intended. [[1]](diffhunk://#diff-00a450bde65f0cdc55b48e1f5e698558f9841516ee3ed98857115676702ca5d1R27) [[2]](diffhunk://#diff-00a450bde65f0cdc55b48e1f5e698558f9841516ee3ed98857115676702ca5d1R42-R44) [[3]](diffhunk://#diff-00a450bde65f0cdc55b48e1f5e698558f9841516ee3ed98857115676702ca5d1R96-R113)
* Updated integration test `LanceRESTServiceIT` to assert that registering a table with an invalid location fails with the expected error message.

### Why are the changes needed?

Better user experience.

Fix: #9448

### Does this PR introduce _any_ user-facing change?

N/A.

### How was this patch tested?

UTs and ITs