### PR TITLE
[#9462] fix(lakehouse-generic): Ensure external table property is set during table registration

### DIFF
--- a/catalogs/catalog-lakehouse-generic/src/main/java/org/apache/gravitino/catalog/lakehouse/lance/LanceTableOperations.java
+++ b/catalogs/catalog-lakehouse-generic/src/main/java/org/apache/gravitino/catalog/lakehouse/lance/LanceTableOperations.java
@@ -22,6 +22,7 @@ import static org.apache.gravitino.lance.common.utils.LanceConstants.LANCE_CREAT
 import static org.apache.gravitino.lance.common.utils.LanceConstants.LANCE_TABLE_REGISTER;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.Maps;
 import com.lancedb.lance.Dataset;
 import com.lancedb.lance.WriteParams;
 import com.lancedb.lance.index.DistanceType;
@@ -259,8 +260,15 @@ public class LanceTableOperations extends ManagedTableOperations {
       throws NoSuchSchemaException, TableAlreadyExistsException {
 
     if (register) {
+      // If this is a register operation, it should be a external table.
+      Map<String, String> stringStringMap = Maps.newHashMap(properties);
+      if (!properties.containsKey(Table.PROPERTY_EXTERNAL)
+          || !Boolean.parseBoolean(properties.get(Table.PROPERTY_EXTERNAL))) {
+        stringStringMap.put(Table.PROPERTY_EXTERNAL, "true");
+      }
+
       return super.createTable(
-          ident, columns, comment, properties, partitions, distribution, sortOrders, indexes);
+          ident, columns, comment, stringStringMap, partitions, distribution, sortOrders, indexes);
     }
 
     Map<String, String> storageProps = LancePropertiesUtils.getLanceStorageOptions(properties);

--- a/catalogs/catalog-lakehouse-generic/src/test/java/org/apache/gravitino/catalog/lakehouse/lance/integration/test/CatalogGenericCatalogLanceIT.java
+++ b/catalogs/catalog-lakehouse-generic/src/test/java/org/apache/gravitino/catalog/lakehouse/lance/integration/test/CatalogGenericCatalogLanceIT.java
@@ -292,6 +292,34 @@ public class CatalogGenericCatalogLanceIT extends BaseIT {
   }
 
   @Test
+  void testRegisterAndDropTable() {
+    String tableName = GravitinoITUtils.genRandomName(TABLE_PREFIX);
+    NameIdentifier nameIdentifier = NameIdentifier.of(schemaName, tableName);
+    Map<String, String> properties = createProperties();
+
+    String tableLocation = tempDirectory + "/" + tableName;
+    properties.put("format", "lance");
+    properties.put("location", tableLocation);
+    properties.put("lance.register", "true");
+
+    catalog
+        .asTableCatalog()
+        .createTable(
+            nameIdentifier,
+            new Column[] {},
+            TABLE_COMMENT,
+            properties,
+            Transforms.EMPTY_TRANSFORM,
+            null,
+            null);
+
+    Table loadedTable = catalog.asTableCatalog().loadTable(nameIdentifier);
+    Assertions.assertEquals(tableName, loadedTable.name());
+
+    Assertions.assertDoesNotThrow(() -> catalog.asTableCatalog().dropTable(nameIdentifier));
+  }
+
+  @Test
   void testLanceTableFormat() {
     String tableName = GravitinoITUtils.genRandomName(TABLE_PREFIX);
     Column[] columns = createColumns();

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/TableMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/TableMetaService.java
@@ -289,7 +289,7 @@ public class TableMetaService {
                 mapper ->
                     mapper.softDeletePolicyMetadataObjectRelsByTableId(
                         namespacedEntityId.entityId()));
-            SessionUtils.doWithCommit(
+            SessionUtils.doWithoutCommit(
                 TableVersionMapper.class,
                 mapper ->
                     mapper.softDeleteTableVersionByTableIdAndVersion(


### PR DESCRIPTION

### What changes were proposed in this pull request?

If `lance.register` is true, we need to make sure that `external` is true.

### Why are the changes needed?

It's a design

Fix: #9462 

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

ITs
