### PR TITLE
[Minor] improvement(docs): Remove support for data type `map` and `interval_year` for Lance table in docs.

### DIFF
--- a/docs/lakehouse-generic-lance-table.md
+++ b/docs/lakehouse-generic-lance-table.md
@@ -48,7 +48,7 @@ Lance uses Apache Arrow for table schemas. The following table shows type mappin
 | Gravitino Type                   | Arrow Type                              |
 |----------------------------------|-----------------------------------------|
 | `Struct`                         | `Struct`                                |
-| `Map`                            | `Map`                                   |
+| `Map`                            | Not supported by Lance                  |
 | `List`                           | `Array`                                 |
 | `Boolean`                        | `Boolean`                               |
 | `Byte`                           | `Int8`                                  |
@@ -72,7 +72,7 @@ Lance uses Apache Arrow for table schemas. The following table shows type mappin
 | `Time`/`Time(9)`                 | `Time Nanosecond`                       |
 | `Null`                           | `Null`                                  |
 | `Fixed(n)`                       | `Fixed-Size Binary(n)`                  |
-| `Interval_year`                  | `Interval(YearMonth)`                   |
+| `Interval_year`                  | Not supported by Lance                  |
 | `Interval_day`                   | `Duration(Microsecond)`                 |
 | `External(arrow_field_json_str)` | Any Arrow Field                         |
 


### PR DESCRIPTION


### What changes were proposed in this pull request?

This pull request updates the documentation for Lance's support of Apache Arrow types, clarifying which types are not supported. The most important changes are clarifications in the type mapping table to indicate unsupported types.

Documentation updates:

* Updated the type mapping table in `docs/lakehouse-generic-lance-table.md` to clarify that the `Map` type is not supported by Lance, instead of mapping it to Arrow's `Map` type.
* Updated the type mapping table to indicate that `Interval_year` is not supported by Lance, instead of mapping it to Arrow's `Interval(YearMonth)` type.

### Why are the changes needed?

Data type `map` and `interval(yearmonth)` are not supported by Lance in release 0.39.0


### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

Test locally. 