### PR TITLE
[#8300] fix(cli): add missing space in RemoveModelVersionProperty output

### DIFF
--- a/clients/cli/src/main/java/org/apache/gravitino/cli/commands/RemoveModelVersionProperty.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/commands/RemoveModelVersionProperty.java
@@ -99,10 +99,10 @@ public class RemoveModelVersionProperty extends Command {
     }
 
     if (alias != null) {
-      printInformation(model + " alias " + alias + "property " + property + " property removed.");
+      printInformation(model + " alias " + alias + " property " + property + " property removed.");
     } else {
       printInformation(
-          model + " version " + version + "property " + property + " property removed.");
+          model + " version " + version + " property " + property + " property removed.");
     }
   }
 

--- a/clients/cli/src/main/java/org/apache/gravitino/cli/outputs/Column.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/outputs/Column.java
@@ -29,7 +29,7 @@ import org.apache.gravitino.cli.CommandContext;
  */
 public class Column {
   /** The character used to indicate that a cell has been truncated. */
-  public static final char ELLIPSIS = '…';
+  public static final char ELLIPSIS = '\u2026';
 
   private final String header;
   private final HorizontalAlign headerAlign;


### PR DESCRIPTION

### What changes were proposed in this pull request?

This pull request fixes a formatting issue in the CLI output where a space
was missing before the model version property name in
RemoveModelVersionProperty.java.

### Why are the changes needed?

The CLI output was incorrectly formatted due to a missing space before the
property name, which reduced readability and resulted in inconsistent
output formatting. This change improves the clarity of the CLI output.

Fixes #8300

### Does this PR introduce any user-facing change?

Yes. The CLI output formatting is corrected by adding a missing space before
the model version property name. No APIs or configuration properties are
changed.

### How was this patch tested?

The change was manually verified by running the CLI command and confirming
that the output now includes the correct spacing. No automated tests were
added as this is a minor formatting fix.


