### PR TITLE
[#9554] fix(test): Adjust `TestJobManager` to fix flaky test in CI pipeline

### DIFF
--- a/core/src/main/java/org/apache/gravitino/job/JobManager.java
+++ b/core/src/main/java/org/apache/gravitino/job/JobManager.java
@@ -99,9 +99,9 @@ public class JobManager implements JobOperationDispatcher {
 
   private final long jobStagingDirKeepTimeInMs;
 
-  private final ScheduledExecutorService cleanUpExecutor;
+  @VisibleForTesting final ScheduledExecutorService cleanUpExecutor;
 
-  private final ScheduledExecutorService statusPullExecutor;
+  @VisibleForTesting final ScheduledExecutorService statusPullExecutor;
 
   public JobManager(Config config, EntityStore entityStore, IdGenerator idGenerator) {
     this(config, entityStore, idGenerator, JobExecutorFactory.create(config));


### PR DESCRIPTION
### What changes were proposed in this pull request?

This pull request refactors the `TestJobManager` test class to improve test isolation and reliability by converting static fields and lifecycle methods to instance-level, ensuring a fresh test environment for each test case. Additionally, it addresses potential interference from background threads and updates utility methods for consistency.

Test lifecycle and isolation improvements:

* Converted all static fields (e.g., `jobManager`, `entityStore`, `config`, etc.) to instance fields, and changed `@BeforeAll`/`@AfterAll` methods to `@BeforeEach`/`@AfterEach` to ensure each test runs with a clean setup and teardown.
* Updated the test staging directory to use a unique `UUID` for each test run, preventing collisions between tests.

Background thread management:

* Explicitly shuts down background scheduler executors (`cleanUpExecutor` and `statusPullExecutor`) in the `setUp` method to prevent interference with test execution and resource leaks.

Utility method updates:

* Changed helper methods (`newShellJobTemplateEntity`, `newSparkJobTemplateEntity`, and `newJobEntity`) from static to instance methods for consistency with the new instance-based test structure. [[1]](diffhunk://#diff-de6e5a136a3bf0d4be93b1b267b421b38e404c4f70bfa798858251c5f24b9687L813-R818) [[2]](diffhunk://#diff-de6e5a136a3bf0d4be93b1b267b421b38e404c4f70bfa798858251c5f24b9687L832-R837) [[3]](diffhunk://#diff-de6e5a136a3bf0d4be93b1b267b421b38e404c4f70bfa798858251c5f24b9687L852-R857)

Cleanup and mocking:

* Removed the redundant `@AfterEach reset()` method and ensured proper cleanup of resources and mocks in the new `tearDown` method.
### Why are the changes needed?



Fix: #9554

### Does this PR introduce _any_ user-facing change?

N/A.

### How was this patch tested?

Test locally. 
