### PR TITLE
[#9528] feat(core): Add storage layer support for UDF persistence

### DIFF
--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/FunctionMetaMapper.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/FunctionMetaMapper.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.storage.relational.mapper;
+
+import java.util.List;
+import org.apache.gravitino.storage.relational.po.FunctionPO;
+import org.apache.gravitino.storage.relational.po.FunctionVersionPO;
+import org.apache.ibatis.annotations.DeleteProvider;
+import org.apache.ibatis.annotations.InsertProvider;
+import org.apache.ibatis.annotations.One;
+import org.apache.ibatis.annotations.Param;
+import org.apache.ibatis.annotations.Result;
+import org.apache.ibatis.annotations.ResultMap;
+import org.apache.ibatis.annotations.Results;
+import org.apache.ibatis.annotations.Select;
+import org.apache.ibatis.annotations.SelectProvider;
+import org.apache.ibatis.annotations.UpdateProvider;
+
+public interface FunctionMetaMapper {
+  String TABLE_NAME = "function_meta";
+  String VERSION_TABLE_NAME = "function_version_info";
+
+  @Results(
+      id = "mapToFunctionVersionPO",
+      value = {
+        @Result(property = "id", column = "id", id = true),
+        @Result(property = "metalakeId", column = "version_metalake_id"),
+        @Result(property = "catalogId", column = "version_catalog_id"),
+        @Result(property = "schemaId", column = "version_schema_id"),
+        @Result(property = "functionId", column = "version_function_id"),
+        @Result(property = "functionVersion", column = "version"),
+        @Result(property = "functionComment", column = "function_comment"),
+        @Result(property = "definitions", column = "definitions"),
+        @Result(property = "auditInfo", column = "version_audit_info"),
+        @Result(property = "deletedAt", column = "version_deleted_at")
+      })
+  @Select("SELECT 1") // Dummy SQL to avoid MyBatis error, never be executed
+  FunctionVersionPO mapToFunctionVersionPO();
+
+  @InsertProvider(type = FunctionMetaSQLProviderFactory.class, method = "insertFunctionMeta")
+  void insertFunctionMeta(@Param("functionMeta") FunctionPO functionPO);
+
+  @InsertProvider(
+      type = FunctionMetaSQLProviderFactory.class,
+      method = "insertFunctionMetaOnDuplicateKeyUpdate")
+  void insertFunctionMetaOnDuplicateKeyUpdate(@Param("functionMeta") FunctionPO functionPO);
+
+  @Results({
+    @Result(property = "functionId", column = "function_id", id = true),
+    @Result(property = "functionName", column = "function_name"),
+    @Result(property = "metalakeId", column = "metalake_id"),
+    @Result(property = "catalogId", column = "catalog_id"),
+    @Result(property = "schemaId", column = "schema_id"),
+    @Result(property = "functionType", column = "function_type"),
+    @Result(property = "deterministic", column = "deterministic"),
+    @Result(property = "returnType", column = "return_type"),
+    @Result(property = "functionCurrentVersion", column = "function_current_version"),
+    @Result(property = "functionLatestVersion", column = "function_latest_version"),
+    @Result(property = "auditInfo", column = "audit_info"),
+    @Result(property = "deletedAt", column = "deleted_at"),
+    @Result(
+        property = "functionVersionPO",
+        javaType = FunctionVersionPO.class,
+        column =
+            "{id,version_metalake_id,version_catalog_id,version_schema_id,version_function_id,"
+                + "version,function_comment,definitions,version_audit_info,version_deleted_at}",
+        one = @One(resultMap = "mapToFunctionVersionPO"))
+  })
+  @SelectProvider(type = FunctionMetaSQLProviderFactory.class, method = "listFunctionPOsBySchemaId")
+  List<FunctionPO> listFunctionPOsBySchemaId(@Param("schemaId") Long schemaId);
+
+  @Results(
+      id = "functionPOResultMap",
+      value = {
+        @Result(property = "functionId", column = "function_id", id = true),
+        @Result(property = "functionName", column = "function_name"),
+        @Result(property = "metalakeId", column = "metalake_id"),
+        @Result(property = "catalogId", column = "catalog_id"),
+        @Result(property = "schemaId", column = "schema_id"),
+        @Result(property = "functionType", column = "function_type"),
+        @Result(property = "deterministic", column = "deterministic"),
+        @Result(property = "returnType", column = "return_type"),
+        @Result(property = "functionCurrentVersion", column = "function_current_version"),
+        @Result(property = "functionLatestVersion", column = "function_latest_version"),
+        @Result(property = "auditInfo", column = "audit_info"),
+        @Result(property = "deletedAt", column = "deleted_at"),
+        @Result(
+            property = "functionVersionPO",
+            javaType = FunctionVersionPO.class,
+            column =
+                "{id,version_metalake_id,version_catalog_id,version_schema_id,version_function_id,"
+                    + "version,function_comment,definitions,version_audit_info,version_deleted_at}",
+            one = @One(resultMap = "mapToFunctionVersionPO"))
+      })
+  @SelectProvider(
+      type = FunctionMetaSQLProviderFactory.class,
+      method = "listFunctionPOsByFullQualifiedName")
+  List<FunctionPO> listFunctionPOsByFullQualifiedName(
+      @Param("metalakeName") String metalakeName,
+      @Param("catalogName") String catalogName,
+      @Param("schemaName") String schemaName);
+
+  @ResultMap("functionPOResultMap")
+  @SelectProvider(
+      type = FunctionMetaSQLProviderFactory.class,
+      method = "selectFunctionMetaByFullQualifiedName")
+  FunctionPO selectFunctionMetaByFullQualifiedName(
+      @Param("metalakeName") String metalakeName,
+      @Param("catalogName") String catalogName,
+      @Param("schemaName") String schemaName,
+      @Param("functionName") String functionName);
+
+  @ResultMap("functionPOResultMap")
+  @SelectProvider(
+      type = FunctionMetaSQLProviderFactory.class,
+      method = "selectFunctionMetaBySchemaIdAndName")
+  FunctionPO selectFunctionMetaBySchemaIdAndName(
+      @Param("schemaId") Long schemaId, @Param("functionName") String functionName);
+
+  @UpdateProvider(
+      type = FunctionMetaSQLProviderFactory.class,
+      method = "softDeleteFunctionMetaByFunctionId")
+  Integer softDeleteFunctionMetaByFunctionId(@Param("functionId") Long functionId);
+
+  @UpdateProvider(
+      type = FunctionMetaSQLProviderFactory.class,
+      method = "softDeleteFunctionMetasByCatalogId")
+  Integer softDeleteFunctionMetasByCatalogId(@Param("catalogId") Long catalogId);
+
+  @UpdateProvider(
+      type = FunctionMetaSQLProviderFactory.class,
+      method = "softDeleteFunctionMetasByMetalakeId")
+  Integer softDeleteFunctionMetasByMetalakeId(@Param("metalakeId") Long metalakeId);
+
+  @UpdateProvider(
+      type = FunctionMetaSQLProviderFactory.class,
+      method = "softDeleteFunctionMetasBySchemaId")
+  Integer softDeleteFunctionMetasBySchemaId(@Param("schemaId") Long schemaId);
+
+  @DeleteProvider(
+      type = FunctionMetaSQLProviderFactory.class,
+      method = "deleteFunctionMetasByLegacyTimeline")
+  Integer deleteFunctionMetasByLegacyTimeline(
+      @Param("legacyTimeline") Long legacyTimeline, @Param("limit") int limit);
+
+  @UpdateProvider(type = FunctionMetaSQLProviderFactory.class, method = "updateFunctionMeta")
+  Integer updateFunctionMeta(
+      @Param("newFunctionMeta") FunctionPO newFunctionPO,
+      @Param("oldFunctionMeta") FunctionPO oldFunctionPO);
+}

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/FunctionMetaSQLProviderFactory.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/FunctionMetaSQLProviderFactory.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.storage.relational.mapper;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import org.apache.gravitino.storage.relational.JDBCBackend.JDBCBackendType;
+import org.apache.gravitino.storage.relational.mapper.provider.base.FunctionMetaBaseSQLProvider;
+import org.apache.gravitino.storage.relational.mapper.provider.postgresql.FunctionMetaPostgreSQLProvider;
+import org.apache.gravitino.storage.relational.po.FunctionPO;
+import org.apache.gravitino.storage.relational.session.SqlSessionFactoryHelper;
+import org.apache.ibatis.annotations.Param;
+
+public class FunctionMetaSQLProviderFactory {
+
+  static class FunctionMetaMySQLProvider extends FunctionMetaBaseSQLProvider {}
+
+  static class FunctionMetaH2Provider extends FunctionMetaBaseSQLProvider {}
+
+  private static final Map<JDBCBackendType, FunctionMetaBaseSQLProvider>
+      FUNCTION_META_SQL_PROVIDER_MAP =
+          ImmutableMap.of(
+              JDBCBackendType.MYSQL, new FunctionMetaMySQLProvider(),
+              JDBCBackendType.H2, new FunctionMetaH2Provider(),
+              JDBCBackendType.POSTGRESQL, new FunctionMetaPostgreSQLProvider());
+
+  public static FunctionMetaBaseSQLProvider getProvider() {
+    String databaseId =
+        SqlSessionFactoryHelper.getInstance()
+            .getSqlSessionFactory()
+            .getConfiguration()
+            .getDatabaseId();
+
+    JDBCBackendType jdbcBackendType = JDBCBackendType.fromString(databaseId);
+    return FUNCTION_META_SQL_PROVIDER_MAP.get(jdbcBackendType);
+  }
+
+  public static String insertFunctionMeta(@Param("functionMeta") FunctionPO functionPO) {
+    return getProvider().insertFunctionMeta(functionPO);
+  }
+
+  public static String insertFunctionMetaOnDuplicateKeyUpdate(
+      @Param("functionMeta") FunctionPO functionPO) {
+    return getProvider().insertFunctionMetaOnDuplicateKeyUpdate(functionPO);
+  }
+
+  public static String listFunctionPOsBySchemaId(@Param("schemaId") Long schemaId) {
+    return getProvider().listFunctionPOsBySchemaId(schemaId);
+  }
+
+  public static String listFunctionPOsByFullQualifiedName(
+      @Param("metalakeName") String metalakeName,
+      @Param("catalogName") String catalogName,
+      @Param("schemaName") String schemaName) {
+    return getProvider().listFunctionPOsByFullQualifiedName(metalakeName, catalogName, schemaName);
+  }
+
+  public static String selectFunctionMetaByFullQualifiedName(
+      @Param("metalakeName") String metalakeName,
+      @Param("catalogName") String catalogName,
+      @Param("schemaName") String schemaName,
+      @Param("functionName") String functionName) {
+    return getProvider()
+        .selectFunctionMetaByFullQualifiedName(metalakeName, catalogName, schemaName, functionName);
+  }
+
+  public static String selectFunctionMetaBySchemaIdAndName(
+      @Param("schemaId") Long schemaId, @Param("functionName") String functionName) {
+    return getProvider().selectFunctionMetaBySchemaIdAndName(schemaId, functionName);
+  }
+
+  public static String softDeleteFunctionMetaByFunctionId(@Param("functionId") Long functionId) {
+    return getProvider().softDeleteFunctionMetaByFunctionId(functionId);
+  }
+
+  public static String softDeleteFunctionMetasByCatalogId(@Param("catalogId") Long catalogId) {
+    return getProvider().softDeleteFunctionMetasByCatalogId(catalogId);
+  }
+
+  public static String softDeleteFunctionMetasByMetalakeId(@Param("metalakeId") Long metalakeId) {
+    return getProvider().softDeleteFunctionMetasByMetalakeId(metalakeId);
+  }
+
+  public static String softDeleteFunctionMetasBySchemaId(@Param("schemaId") Long schemaId) {
+    return getProvider().softDeleteFunctionMetasBySchemaId(schemaId);
+  }
+
+  public static String deleteFunctionMetasByLegacyTimeline(
+      @Param("legacyTimeline") Long legacyTimeline, @Param("limit") int limit) {
+    return getProvider().deleteFunctionMetasByLegacyTimeline(legacyTimeline, limit);
+  }
+
+  public static String updateFunctionMeta(
+      @Param("newFunctionMeta") FunctionPO newFunctionPO,
+      @Param("oldFunctionMeta") FunctionPO oldFunctionPO) {
+    return getProvider().updateFunctionMeta(newFunctionPO, oldFunctionPO);
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/FunctionVersionMetaMapper.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/FunctionVersionMetaMapper.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.storage.relational.mapper;
+
+import java.util.List;
+import org.apache.gravitino.storage.relational.po.FunctionMaxVersionPO;
+import org.apache.gravitino.storage.relational.po.FunctionVersionPO;
+import org.apache.ibatis.annotations.DeleteProvider;
+import org.apache.ibatis.annotations.InsertProvider;
+import org.apache.ibatis.annotations.Param;
+import org.apache.ibatis.annotations.SelectProvider;
+import org.apache.ibatis.annotations.UpdateProvider;
+
+public interface FunctionVersionMetaMapper {
+
+  String TABLE_NAME = "function_version_info";
+
+  @InsertProvider(
+      type = FunctionVersionMetaSQLProviderFactory.class,
+      method = "insertFunctionVersionMeta")
+  void insertFunctionVersionMeta(@Param("functionVersionMeta") FunctionVersionPO functionVersionPO);
+
+  @InsertProvider(
+      type = FunctionVersionMetaSQLProviderFactory.class,
+      method = "insertFunctionVersionMetaOnDuplicateKeyUpdate")
+  void insertFunctionVersionMetaOnDuplicateKeyUpdate(
+      @Param("functionVersionMeta") FunctionVersionPO functionVersionPO);
+
+  @UpdateProvider(
+      type = FunctionVersionMetaSQLProviderFactory.class,
+      method = "softDeleteFunctionVersionMetasBySchemaId")
+  Integer softDeleteFunctionVersionMetasBySchemaId(@Param("schemaId") Long schemaId);
+
+  @UpdateProvider(
+      type = FunctionVersionMetaSQLProviderFactory.class,
+      method = "softDeleteFunctionVersionMetasByCatalogId")
+  Integer softDeleteFunctionVersionMetasByCatalogId(@Param("catalogId") Long catalogId);
+
+  @UpdateProvider(
+      type = FunctionVersionMetaSQLProviderFactory.class,
+      method = "softDeleteFunctionVersionMetasByMetalakeId")
+  Integer softDeleteFunctionVersionMetasByMetalakeId(@Param("metalakeId") Long metalakeId);
+
+  @DeleteProvider(
+      type = FunctionVersionMetaSQLProviderFactory.class,
+      method = "deleteFunctionVersionMetasByLegacyTimeline")
+  Integer deleteFunctionVersionMetasByLegacyTimeline(
+      @Param("legacyTimeline") Long legacyTimeline, @Param("limit") int limit);
+
+  @SelectProvider(
+      type = FunctionVersionMetaSQLProviderFactory.class,
+      method = "selectFunctionVersionsByRetentionCount")
+  List<FunctionMaxVersionPO> selectFunctionVersionsByRetentionCount(
+      @Param("versionRetentionCount") Long versionRetentionCount);
+
+  @UpdateProvider(
+      type = FunctionVersionMetaSQLProviderFactory.class,
+      method = "softDeleteFunctionVersionsByRetentionLine")
+  Integer softDeleteFunctionVersionsByRetentionLine(
+      @Param("functionId") Long functionId,
+      @Param("versionRetentionLine") long versionRetentionLine,
+      @Param("limit") int limit);
+
+  @UpdateProvider(
+      type = FunctionVersionMetaSQLProviderFactory.class,
+      method = "softDeleteFunctionVersionsByFunctionId")
+  Integer softDeleteFunctionVersionsByFunctionId(@Param("functionId") Long functionId);
+}

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/FunctionVersionMetaSQLProviderFactory.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/FunctionVersionMetaSQLProviderFactory.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.storage.relational.mapper;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import org.apache.gravitino.storage.relational.JDBCBackend.JDBCBackendType;
+import org.apache.gravitino.storage.relational.mapper.provider.base.FunctionVersionMetaBaseSQLProvider;
+import org.apache.gravitino.storage.relational.mapper.provider.postgresql.FunctionVersionMetaPostgreSQLProvider;
+import org.apache.gravitino.storage.relational.po.FunctionVersionPO;
+import org.apache.gravitino.storage.relational.session.SqlSessionFactoryHelper;
+import org.apache.ibatis.annotations.Param;
+
+public class FunctionVersionMetaSQLProviderFactory {
+
+  static class FunctionVersionMetaMySQLProvider extends FunctionVersionMetaBaseSQLProvider {}
+
+  static class FunctionVersionMetaH2Provider extends FunctionVersionMetaBaseSQLProvider {}
+
+  private static final Map<JDBCBackendType, FunctionVersionMetaBaseSQLProvider>
+      FUNCTION_VERSION_META_SQL_PROVIDER_MAP =
+          ImmutableMap.of(
+              JDBCBackendType.MYSQL, new FunctionVersionMetaMySQLProvider(),
+              JDBCBackendType.H2, new FunctionVersionMetaH2Provider(),
+              JDBCBackendType.POSTGRESQL, new FunctionVersionMetaPostgreSQLProvider());
+
+  public static FunctionVersionMetaBaseSQLProvider getProvider() {
+    String databaseId =
+        SqlSessionFactoryHelper.getInstance()
+            .getSqlSessionFactory()
+            .getConfiguration()
+            .getDatabaseId();
+
+    JDBCBackendType jdbcBackendType = JDBCBackendType.fromString(databaseId);
+    return FUNCTION_VERSION_META_SQL_PROVIDER_MAP.get(jdbcBackendType);
+  }
+
+  public static String insertFunctionVersionMeta(
+      @Param("functionVersionMeta") FunctionVersionPO functionVersionPO) {
+    return getProvider().insertFunctionVersionMeta(functionVersionPO);
+  }
+
+  public static String insertFunctionVersionMetaOnDuplicateKeyUpdate(
+      @Param("functionVersionMeta") FunctionVersionPO functionVersionPO) {
+    return getProvider().insertFunctionVersionMetaOnDuplicateKeyUpdate(functionVersionPO);
+  }
+
+  public static String softDeleteFunctionVersionMetasBySchemaId(@Param("schemaId") Long schemaId) {
+    return getProvider().softDeleteFunctionVersionMetasBySchemaId(schemaId);
+  }
+
+  public static String softDeleteFunctionVersionMetasByCatalogId(
+      @Param("catalogId") Long catalogId) {
+    return getProvider().softDeleteFunctionVersionMetasByCatalogId(catalogId);
+  }
+
+  public static String softDeleteFunctionVersionMetasByMetalakeId(
+      @Param("metalakeId") Long metalakeId) {
+    return getProvider().softDeleteFunctionVersionMetasByMetalakeId(metalakeId);
+  }
+
+  public static String deleteFunctionVersionMetasByLegacyTimeline(
+      @Param("legacyTimeline") Long legacyTimeline, @Param("limit") int limit) {
+    return getProvider().deleteFunctionVersionMetasByLegacyTimeline(legacyTimeline, limit);
+  }
+
+  public static String selectFunctionVersionsByRetentionCount(
+      @Param("versionRetentionCount") Long versionRetentionCount) {
+    return getProvider().selectFunctionVersionsByRetentionCount(versionRetentionCount);
+  }
+
+  public static String softDeleteFunctionVersionsByRetentionLine(
+      @Param("functionId") Long functionId,
+      @Param("versionRetentionLine") long versionRetentionLine,
+      @Param("limit") int limit) {
+    return getProvider()
+        .softDeleteFunctionVersionsByRetentionLine(functionId, versionRetentionLine, limit);
+  }
+
+  public static String softDeleteFunctionVersionsByFunctionId(
+      @Param("functionId") Long functionId) {
+    return getProvider().softDeleteFunctionVersionsByFunctionId(functionId);
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/DefaultMapperPackageProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/DefaultMapperPackageProvider.java
@@ -23,6 +23,8 @@ import java.util.List;
 import org.apache.gravitino.storage.relational.mapper.CatalogMetaMapper;
 import org.apache.gravitino.storage.relational.mapper.FilesetMetaMapper;
 import org.apache.gravitino.storage.relational.mapper.FilesetVersionMapper;
+import org.apache.gravitino.storage.relational.mapper.FunctionMetaMapper;
+import org.apache.gravitino.storage.relational.mapper.FunctionVersionMetaMapper;
 import org.apache.gravitino.storage.relational.mapper.GroupMetaMapper;
 import org.apache.gravitino.storage.relational.mapper.GroupRoleRelMapper;
 import org.apache.gravitino.storage.relational.mapper.JobMetaMapper;
@@ -57,6 +59,8 @@ public class DefaultMapperPackageProvider implements MapperPackageProvider {
         CatalogMetaMapper.class,
         FilesetMetaMapper.class,
         FilesetVersionMapper.class,
+        FunctionMetaMapper.class,
+        FunctionVersionMetaMapper.class,
         GroupMetaMapper.class,
         GroupRoleRelMapper.class,
         JobMetaMapper.class,

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/FunctionMetaBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/FunctionMetaBaseSQLProvider.java
@@ -1,0 +1,285 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.storage.relational.mapper.provider.base;
+
+import static org.apache.gravitino.storage.relational.mapper.FunctionMetaMapper.TABLE_NAME;
+import static org.apache.gravitino.storage.relational.mapper.FunctionMetaMapper.VERSION_TABLE_NAME;
+
+import org.apache.gravitino.storage.relational.mapper.CatalogMetaMapper;
+import org.apache.gravitino.storage.relational.mapper.MetalakeMetaMapper;
+import org.apache.gravitino.storage.relational.mapper.SchemaMetaMapper;
+import org.apache.gravitino.storage.relational.po.FunctionPO;
+import org.apache.ibatis.annotations.Param;
+
+public class FunctionMetaBaseSQLProvider {
+
+  public String listFunctionPOsByFullQualifiedName(
+      @Param("metalakeName") String metalakeName,
+      @Param("catalogName") String catalogName,
+      @Param("schemaName") String schemaName) {
+    return """
+        SELECT
+            mm.metalake_id,
+            cm.catalog_id,
+            sm.schema_id,
+            fm.function_id,
+            fm.function_name,
+            fm.function_type,
+            fm.deterministic,
+            fm.return_type,
+            fm.function_current_version,
+            fm.function_latest_version,
+            fm.audit_info,
+            fm.deleted_at,
+            vi.id,
+            vi.metalake_id as version_metalake_id,
+            vi.catalog_id as version_catalog_id,
+            vi.schema_id as version_schema_id,
+            vi.function_id as version_function_id,
+            vi.version,
+            vi.function_comment,
+            vi.definitions,
+            vi.audit_info as version_audit_info,
+            vi.deleted_at as version_deleted_at
+        FROM
+            %s mm
+        INNER JOIN
+            %s cm ON mm.metalake_id = cm.metalake_id
+            AND cm.catalog_name = #{catalogName}
+            AND cm.deleted_at = 0
+        LEFT JOIN
+            %s sm ON cm.catalog_id = sm.catalog_id
+            AND sm.schema_name = #{schemaName}
+            AND sm.deleted_at = 0
+        LEFT JOIN
+            %s fm ON sm.schema_id = fm.schema_id
+            AND fm.deleted_at = 0
+        LEFT JOIN
+            %s vi ON fm.function_id = vi.function_id
+            AND fm.function_current_version = vi.version
+            AND vi.deleted_at = 0
+        WHERE
+            mm.metalake_name = #{metalakeName}
+            AND mm.deleted_at = 0
+        """
+        .formatted(
+            MetalakeMetaMapper.TABLE_NAME,
+            CatalogMetaMapper.TABLE_NAME,
+            SchemaMetaMapper.TABLE_NAME,
+            TABLE_NAME,
+            VERSION_TABLE_NAME);
+  }
+
+  public String insertFunctionMeta(@Param("functionMeta") FunctionPO functionPO) {
+    return "INSERT INTO "
+        + TABLE_NAME
+        + " (function_id, function_name, metalake_id, catalog_id, schema_id,"
+        + " function_type, `deterministic`, return_type, function_current_version, function_latest_version, audit_info, deleted_at)"
+        + " VALUES (#{functionMeta.functionId}, #{functionMeta.functionName}, #{functionMeta.metalakeId},"
+        + " #{functionMeta.catalogId}, #{functionMeta.schemaId}, #{functionMeta.functionType},"
+        + " #{functionMeta.deterministic}, #{functionMeta.returnType},"
+        + " #{functionMeta.functionCurrentVersion}, #{functionMeta.functionLatestVersion}, #{functionMeta.auditInfo},"
+        + " #{functionMeta.deletedAt})";
+  }
+
+  public String insertFunctionMetaOnDuplicateKeyUpdate(
+      @Param("functionMeta") FunctionPO functionPO) {
+    return "INSERT INTO "
+        + TABLE_NAME
+        + " (function_id, function_name, metalake_id, catalog_id, schema_id,"
+        + " function_type, `deterministic`, return_type, function_current_version, function_latest_version, audit_info, deleted_at)"
+        + " VALUES (#{functionMeta.functionId}, #{functionMeta.functionName}, #{functionMeta.metalakeId},"
+        + " #{functionMeta.catalogId}, #{functionMeta.schemaId}, #{functionMeta.functionType},"
+        + " #{functionMeta.deterministic}, #{functionMeta.returnType},"
+        + " #{functionMeta.functionCurrentVersion}, #{functionMeta.functionLatestVersion}, #{functionMeta.auditInfo},"
+        + " #{functionMeta.deletedAt})"
+        + " ON DUPLICATE KEY UPDATE"
+        + " function_name = #{functionMeta.functionName},"
+        + " metalake_id = #{functionMeta.metalakeId},"
+        + " catalog_id = #{functionMeta.catalogId},"
+        + " schema_id = #{functionMeta.schemaId},"
+        + " function_type = #{functionMeta.functionType},"
+        + " `deterministic` = #{functionMeta.deterministic},"
+        + " return_type = #{functionMeta.returnType},"
+        + " function_current_version = #{functionMeta.functionCurrentVersion},"
+        + " function_latest_version = #{functionMeta.functionLatestVersion},"
+        + " audit_info = #{functionMeta.auditInfo},"
+        + " deleted_at = #{functionMeta.deletedAt}";
+  }
+
+  public String selectFunctionMetaByFullQualifiedName(
+      @Param("metalakeName") String metalakeName,
+      @Param("catalogName") String catalogName,
+      @Param("schemaName") String schemaName,
+      @Param("functionName") String functionName) {
+    return """
+        SELECT
+            mm.metalake_id,
+            cm.catalog_id,
+            sm.schema_id,
+            fm.function_id,
+            fm.function_name,
+            fm.function_type,
+            fm.deterministic,
+            fm.return_type,
+            fm.function_current_version,
+            fm.function_latest_version,
+            fm.audit_info,
+            fm.deleted_at,
+            vi.id,
+            vi.metalake_id as version_metalake_id,
+            vi.catalog_id as version_catalog_id,
+            vi.schema_id as version_schema_id,
+            vi.function_id as version_function_id,
+            vi.version,
+            vi.function_comment,
+            vi.definitions,
+            vi.audit_info as version_audit_info,
+            vi.deleted_at as version_deleted_at
+        FROM
+            %s mm
+        INNER JOIN
+            %s cm ON mm.metalake_id = cm.metalake_id
+            AND cm.catalog_name = #{catalogName}
+            AND cm.deleted_at = 0
+        LEFT JOIN
+            %s sm ON cm.catalog_id = sm.catalog_id
+            AND sm.schema_name = #{schemaName}
+            AND sm.deleted_at = 0
+        LEFT JOIN
+            %s fm ON sm.schema_id = fm.schema_id
+            AND fm.function_name = #{functionName}
+            AND fm.deleted_at = 0
+        INNER JOIN
+            %s vi ON fm.function_id = vi.function_id
+            AND fm.function_current_version = vi.version
+            AND vi.deleted_at = 0
+        WHERE
+            mm.metalake_name = #{metalakeName}
+            AND mm.deleted_at = 0
+        """
+        .formatted(
+            MetalakeMetaMapper.TABLE_NAME,
+            CatalogMetaMapper.TABLE_NAME,
+            SchemaMetaMapper.TABLE_NAME,
+            TABLE_NAME,
+            VERSION_TABLE_NAME);
+  }
+
+  public String listFunctionPOsBySchemaId(@Param("schemaId") Long schemaId) {
+    return "SELECT fm.function_id, fm.function_name, fm.metalake_id, fm.catalog_id, fm.schema_id,"
+        + " fm.function_type, fm.`deterministic`, fm.return_type, fm.function_current_version, fm.function_latest_version,"
+        + " fm.audit_info, fm.deleted_at,"
+        + " vi.id, vi.metalake_id as version_metalake_id, vi.catalog_id as version_catalog_id,"
+        + " vi.schema_id as version_schema_id, vi.function_id as version_function_id,"
+        + " vi.version, vi.function_comment, vi.definitions,"
+        + " vi.audit_info as version_audit_info, vi.deleted_at as version_deleted_at"
+        + " FROM "
+        + TABLE_NAME
+        + " fm INNER JOIN "
+        + VERSION_TABLE_NAME
+        + " vi ON fm.function_id = vi.function_id AND fm.function_current_version = vi.version"
+        + " WHERE fm.schema_id = #{schemaId} AND fm.deleted_at = 0 AND vi.deleted_at = 0";
+  }
+
+  public String selectFunctionMetaBySchemaIdAndName(
+      @Param("schemaId") Long schemaId, @Param("functionName") String functionName) {
+    return "SELECT fm.function_id, fm.function_name, fm.metalake_id, fm.catalog_id, fm.schema_id,"
+        + " fm.function_type, fm.`deterministic`, fm.return_type, fm.function_current_version, fm.function_latest_version,"
+        + " fm.audit_info, fm.deleted_at,"
+        + " vi.id, vi.metalake_id as version_metalake_id, vi.catalog_id as version_catalog_id,"
+        + " vi.schema_id as version_schema_id, vi.function_id as version_function_id,"
+        + " vi.version, vi.function_comment, vi.definitions,"
+        + " vi.audit_info as version_audit_info, vi.deleted_at as version_deleted_at"
+        + " FROM "
+        + TABLE_NAME
+        + " fm INNER JOIN "
+        + VERSION_TABLE_NAME
+        + " vi ON fm.function_id = vi.function_id AND fm.function_current_version = vi.version"
+        + " WHERE fm.schema_id = #{schemaId} AND fm.function_name = #{functionName}"
+        + " AND fm.deleted_at = 0 AND vi.deleted_at = 0";
+  }
+
+  public String softDeleteFunctionMetaByFunctionId(@Param("functionId") Long functionId) {
+    return "UPDATE "
+        + TABLE_NAME
+        + " SET deleted_at = (UNIX_TIMESTAMP() * 1000.0)"
+        + " + EXTRACT(MICROSECOND FROM CURRENT_TIMESTAMP(3)) / 1000"
+        + " WHERE function_id = #{functionId} AND deleted_at = 0";
+  }
+
+  public String softDeleteFunctionMetasByCatalogId(@Param("catalogId") Long catalogId) {
+    return "UPDATE "
+        + TABLE_NAME
+        + " SET deleted_at = (UNIX_TIMESTAMP() * 1000.0)"
+        + " + EXTRACT(MICROSECOND FROM CURRENT_TIMESTAMP(3)) / 1000"
+        + " WHERE catalog_id = #{catalogId} AND deleted_at = 0";
+  }
+
+  public String softDeleteFunctionMetasByMetalakeId(@Param("metalakeId") Long metalakeId) {
+    return "UPDATE "
+        + TABLE_NAME
+        + " SET deleted_at = (UNIX_TIMESTAMP() * 1000.0)"
+        + " + EXTRACT(MICROSECOND FROM CURRENT_TIMESTAMP(3)) / 1000"
+        + " WHERE metalake_id = #{metalakeId} AND deleted_at = 0";
+  }
+
+  public String softDeleteFunctionMetasBySchemaId(@Param("schemaId") Long schemaId) {
+    return "UPDATE "
+        + TABLE_NAME
+        + " SET deleted_at = (UNIX_TIMESTAMP() * 1000.0)"
+        + " + EXTRACT(MICROSECOND FROM CURRENT_TIMESTAMP(3)) / 1000"
+        + " WHERE schema_id = #{schemaId} AND deleted_at = 0";
+  }
+
+  public String deleteFunctionMetasByLegacyTimeline(
+      @Param("legacyTimeline") Long legacyTimeline, @Param("limit") int limit) {
+    return "DELETE FROM "
+        + TABLE_NAME
+        + " WHERE deleted_at > 0 AND deleted_at < #{legacyTimeline} LIMIT #{limit}";
+  }
+
+  public String updateFunctionMeta(
+      @Param("newFunctionMeta") FunctionPO newFunctionPO,
+      @Param("oldFunctionMeta") FunctionPO oldFunctionPO) {
+    return "UPDATE "
+        + TABLE_NAME
+        + " SET function_name = #{newFunctionMeta.functionName},"
+        + " metalake_id = #{newFunctionMeta.metalakeId},"
+        + " catalog_id = #{newFunctionMeta.catalogId},"
+        + " schema_id = #{newFunctionMeta.schemaId},"
+        + " function_type = #{newFunctionMeta.functionType},"
+        + " `deterministic` = #{newFunctionMeta.deterministic},"
+        + " return_type = #{newFunctionMeta.returnType},"
+        + " function_current_version = #{newFunctionMeta.functionCurrentVersion},"
+        + " function_latest_version = #{newFunctionMeta.functionLatestVersion},"
+        + " audit_info = #{newFunctionMeta.auditInfo},"
+        + " deleted_at = #{newFunctionMeta.deletedAt}"
+        + " WHERE function_id = #{oldFunctionMeta.functionId}"
+        + " AND function_name = #{oldFunctionMeta.functionName}"
+        + " AND metalake_id = #{oldFunctionMeta.metalakeId}"
+        + " AND catalog_id = #{oldFunctionMeta.catalogId}"
+        + " AND schema_id = #{oldFunctionMeta.schemaId}"
+        + " AND function_type = #{oldFunctionMeta.functionType}"
+        + " AND function_current_version = #{oldFunctionMeta.functionCurrentVersion}"
+        + " AND function_latest_version = #{oldFunctionMeta.functionLatestVersion}"
+        + " AND audit_info = #{oldFunctionMeta.auditInfo}"
+        + " AND deleted_at = 0";
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/FunctionVersionMetaBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/FunctionVersionMetaBaseSQLProvider.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.storage.relational.mapper.provider.base;
+
+import org.apache.gravitino.storage.relational.mapper.FunctionVersionMetaMapper;
+import org.apache.gravitino.storage.relational.po.FunctionVersionPO;
+import org.apache.ibatis.annotations.Param;
+
+public class FunctionVersionMetaBaseSQLProvider {
+
+  public String insertFunctionVersionMeta(
+      @Param("functionVersionMeta") FunctionVersionPO functionVersionPO) {
+    return "INSERT INTO "
+        + FunctionVersionMetaMapper.TABLE_NAME
+        + " (metalake_id, catalog_id, schema_id, function_id, version,"
+        + " function_comment, definitions, audit_info, deleted_at)"
+        + " VALUES (#{functionVersionMeta.metalakeId}, #{functionVersionMeta.catalogId},"
+        + " #{functionVersionMeta.schemaId}, #{functionVersionMeta.functionId},"
+        + " #{functionVersionMeta.functionVersion}, #{functionVersionMeta.functionComment},"
+        + " #{functionVersionMeta.definitions}, #{functionVersionMeta.auditInfo},"
+        + " #{functionVersionMeta.deletedAt})";
+  }
+
+  public String insertFunctionVersionMetaOnDuplicateKeyUpdate(
+      @Param("functionVersionMeta") FunctionVersionPO functionVersionPO) {
+    return "INSERT INTO "
+        + FunctionVersionMetaMapper.TABLE_NAME
+        + " (metalake_id, catalog_id, schema_id, function_id, version,"
+        + " function_comment, definitions, audit_info, deleted_at)"
+        + " VALUES (#{functionVersionMeta.metalakeId}, #{functionVersionMeta.catalogId},"
+        + " #{functionVersionMeta.schemaId}, #{functionVersionMeta.functionId},"
+        + " #{functionVersionMeta.functionVersion}, #{functionVersionMeta.functionComment},"
+        + " #{functionVersionMeta.definitions}, #{functionVersionMeta.auditInfo},"
+        + " #{functionVersionMeta.deletedAt})"
+        + " ON DUPLICATE KEY UPDATE"
+        + " function_comment = #{functionVersionMeta.functionComment},"
+        + " definitions = #{functionVersionMeta.definitions},"
+        + " audit_info = #{functionVersionMeta.auditInfo},"
+        + " deleted_at = #{functionVersionMeta.deletedAt}";
+  }
+
+  public String softDeleteFunctionVersionMetasBySchemaId(@Param("schemaId") Long schemaId) {
+    return "UPDATE "
+        + FunctionVersionMetaMapper.TABLE_NAME
+        + " SET deleted_at = (UNIX_TIMESTAMP() * 1000.0)"
+        + " + EXTRACT(MICROSECOND FROM CURRENT_TIMESTAMP(3)) / 1000"
+        + " WHERE schema_id = #{schemaId} AND deleted_at = 0";
+  }
+
+  public String softDeleteFunctionVersionMetasByCatalogId(@Param("catalogId") Long catalogId) {
+    return "UPDATE "
+        + FunctionVersionMetaMapper.TABLE_NAME
+        + " SET deleted_at = (UNIX_TIMESTAMP() * 1000.0)"
+        + " + EXTRACT(MICROSECOND FROM CURRENT_TIMESTAMP(3)) / 1000"
+        + " WHERE catalog_id = #{catalogId} AND deleted_at = 0";
+  }
+
+  public String softDeleteFunctionVersionMetasByMetalakeId(@Param("metalakeId") Long metalakeId) {
+    return "UPDATE "
+        + FunctionVersionMetaMapper.TABLE_NAME
+        + " SET deleted_at = (UNIX_TIMESTAMP() * 1000.0)"
+        + " + EXTRACT(MICROSECOND FROM CURRENT_TIMESTAMP(3)) / 1000"
+        + " WHERE metalake_id = #{metalakeId} AND deleted_at = 0";
+  }
+
+  public String deleteFunctionVersionMetasByLegacyTimeline(
+      @Param("legacyTimeline") Long legacyTimeline, @Param("limit") int limit) {
+    return "DELETE FROM "
+        + FunctionVersionMetaMapper.TABLE_NAME
+        + " WHERE deleted_at > 0 AND deleted_at < #{legacyTimeline} LIMIT #{limit}";
+  }
+
+  public String selectFunctionVersionsByRetentionCount(
+      @Param("versionRetentionCount") Long versionRetentionCount) {
+    return "SELECT function_id as functionId,"
+        + " MAX(version) as version"
+        + " FROM "
+        + FunctionVersionMetaMapper.TABLE_NAME
+        + " WHERE version > #{versionRetentionCount} AND deleted_at = 0"
+        + " GROUP BY function_id";
+  }
+
+  public String softDeleteFunctionVersionsByRetentionLine(
+      @Param("functionId") Long functionId,
+      @Param("versionRetentionLine") long versionRetentionLine,
+      @Param("limit") int limit) {
+    return "UPDATE "
+        + FunctionVersionMetaMapper.TABLE_NAME
+        + " SET deleted_at = (UNIX_TIMESTAMP() * 1000.0)"
+        + " + EXTRACT(MICROSECOND FROM CURRENT_TIMESTAMP(3)) / 1000"
+        + " WHERE function_id = #{functionId} AND version <= #{versionRetentionLine}"
+        + " AND deleted_at = 0 LIMIT #{limit}";
+  }
+
+  public String softDeleteFunctionVersionsByFunctionId(@Param("functionId") Long functionId) {
+    return "UPDATE "
+        + FunctionVersionMetaMapper.TABLE_NAME
+        + " SET deleted_at = (UNIX_TIMESTAMP() * 1000.0)"
+        + " + EXTRACT(MICROSECOND FROM CURRENT_TIMESTAMP(3)) / 1000"
+        + " WHERE function_id = #{functionId} AND deleted_at = 0";
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/FunctionMetaPostgreSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/FunctionMetaPostgreSQLProvider.java
@@ -1,0 +1,173 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.storage.relational.mapper.provider.postgresql;
+
+import org.apache.gravitino.storage.relational.mapper.FunctionMetaMapper;
+import org.apache.gravitino.storage.relational.mapper.provider.base.FunctionMetaBaseSQLProvider;
+import org.apache.gravitino.storage.relational.po.FunctionPO;
+import org.apache.ibatis.annotations.Param;
+
+public class FunctionMetaPostgreSQLProvider extends FunctionMetaBaseSQLProvider {
+
+  @Override
+  public String insertFunctionMeta(@Param("functionMeta") FunctionPO functionPO) {
+    return "INSERT INTO "
+        + FunctionMetaMapper.TABLE_NAME
+        + " (function_id, function_name, metalake_id, catalog_id, schema_id,"
+        + " function_type, \"deterministic\", return_type, function_current_version, function_latest_version, audit_info, deleted_at)"
+        + " VALUES (#{functionMeta.functionId}, #{functionMeta.functionName}, #{functionMeta.metalakeId},"
+        + " #{functionMeta.catalogId}, #{functionMeta.schemaId}, #{functionMeta.functionType},"
+        + " #{functionMeta.deterministic}, #{functionMeta.returnType},"
+        + " #{functionMeta.functionCurrentVersion}, #{functionMeta.functionLatestVersion}, #{functionMeta.auditInfo},"
+        + " #{functionMeta.deletedAt})";
+  }
+
+  @Override
+  public String insertFunctionMetaOnDuplicateKeyUpdate(
+      @Param("functionMeta") FunctionPO functionPO) {
+    return "INSERT INTO "
+        + FunctionMetaMapper.TABLE_NAME
+        + " (function_id, function_name, metalake_id, catalog_id, schema_id,"
+        + " function_type, \"deterministic\", return_type, function_current_version, function_latest_version, audit_info, deleted_at)"
+        + " VALUES (#{functionMeta.functionId}, #{functionMeta.functionName}, #{functionMeta.metalakeId},"
+        + " #{functionMeta.catalogId}, #{functionMeta.schemaId}, #{functionMeta.functionType},"
+        + " #{functionMeta.deterministic}, #{functionMeta.returnType},"
+        + " #{functionMeta.functionCurrentVersion}, #{functionMeta.functionLatestVersion}, #{functionMeta.auditInfo},"
+        + " #{functionMeta.deletedAt})"
+        + " ON CONFLICT (function_id) DO UPDATE SET"
+        + " function_name = #{functionMeta.functionName},"
+        + " metalake_id = #{functionMeta.metalakeId},"
+        + " catalog_id = #{functionMeta.catalogId},"
+        + " schema_id = #{functionMeta.schemaId},"
+        + " function_type = #{functionMeta.functionType},"
+        + " \"deterministic\" = #{functionMeta.deterministic},"
+        + " return_type = #{functionMeta.returnType},"
+        + " function_current_version = #{functionMeta.functionCurrentVersion},"
+        + " function_latest_version = #{functionMeta.functionLatestVersion},"
+        + " audit_info = #{functionMeta.auditInfo},"
+        + " deleted_at = #{functionMeta.deletedAt}";
+  }
+
+  @Override
+  public String listFunctionPOsBySchemaId(@Param("schemaId") Long schemaId) {
+    return "SELECT fm.function_id, fm.function_name, fm.metalake_id, fm.catalog_id, fm.schema_id,"
+        + " fm.function_type, fm.\"deterministic\", fm.return_type, fm.function_current_version, fm.function_latest_version,"
+        + " fm.audit_info, fm.deleted_at,"
+        + " vi.id, vi.metalake_id as version_metalake_id, vi.catalog_id as version_catalog_id,"
+        + " vi.schema_id as version_schema_id, vi.function_id as version_function_id,"
+        + " vi.version, vi.function_comment, vi.definitions,"
+        + " vi.audit_info as version_audit_info, vi.deleted_at as version_deleted_at"
+        + " FROM "
+        + FunctionMetaMapper.TABLE_NAME
+        + " fm INNER JOIN "
+        + FunctionMetaMapper.VERSION_TABLE_NAME
+        + " vi ON fm.function_id = vi.function_id AND fm.function_current_version = vi.version"
+        + " WHERE fm.schema_id = #{schemaId} AND fm.deleted_at = 0 AND vi.deleted_at = 0";
+  }
+
+  @Override
+  public String selectFunctionMetaBySchemaIdAndName(
+      @Param("schemaId") Long schemaId, @Param("functionName") String functionName) {
+    return "SELECT fm.function_id, fm.function_name, fm.metalake_id, fm.catalog_id, fm.schema_id,"
+        + " fm.function_type, fm.\"deterministic\", fm.return_type, fm.function_current_version, fm.function_latest_version,"
+        + " fm.audit_info, fm.deleted_at,"
+        + " vi.id, vi.metalake_id as version_metalake_id, vi.catalog_id as version_catalog_id,"
+        + " vi.schema_id as version_schema_id, vi.function_id as version_function_id,"
+        + " vi.version, vi.function_comment, vi.definitions,"
+        + " vi.audit_info as version_audit_info, vi.deleted_at as version_deleted_at"
+        + " FROM "
+        + FunctionMetaMapper.TABLE_NAME
+        + " fm INNER JOIN "
+        + FunctionMetaMapper.VERSION_TABLE_NAME
+        + " vi ON fm.function_id = vi.function_id AND fm.function_current_version = vi.version"
+        + " WHERE fm.schema_id = #{schemaId} AND fm.function_name = #{functionName}"
+        + " AND fm.deleted_at = 0 AND vi.deleted_at = 0";
+  }
+
+  @Override
+  public String softDeleteFunctionMetaByFunctionId(@Param("functionId") Long functionId) {
+    return "UPDATE "
+        + FunctionMetaMapper.TABLE_NAME
+        + " SET deleted_at = CAST(EXTRACT(EPOCH FROM CURRENT_TIMESTAMP) * 1000 AS BIGINT)"
+        + " WHERE function_id = #{functionId} AND deleted_at = 0";
+  }
+
+  @Override
+  public String softDeleteFunctionMetasByCatalogId(@Param("catalogId") Long catalogId) {
+    return "UPDATE "
+        + FunctionMetaMapper.TABLE_NAME
+        + " SET deleted_at = CAST(EXTRACT(EPOCH FROM CURRENT_TIMESTAMP) * 1000 AS BIGINT)"
+        + " WHERE catalog_id = #{catalogId} AND deleted_at = 0";
+  }
+
+  @Override
+  public String softDeleteFunctionMetasByMetalakeId(@Param("metalakeId") Long metalakeId) {
+    return "UPDATE "
+        + FunctionMetaMapper.TABLE_NAME
+        + " SET deleted_at = CAST(EXTRACT(EPOCH FROM CURRENT_TIMESTAMP) * 1000 AS BIGINT)"
+        + " WHERE metalake_id = #{metalakeId} AND deleted_at = 0";
+  }
+
+  @Override
+  public String softDeleteFunctionMetasBySchemaId(@Param("schemaId") Long schemaId) {
+    return "UPDATE "
+        + FunctionMetaMapper.TABLE_NAME
+        + " SET deleted_at = CAST(EXTRACT(EPOCH FROM CURRENT_TIMESTAMP) * 1000 AS BIGINT)"
+        + " WHERE schema_id = #{schemaId} AND deleted_at = 0";
+  }
+
+  @Override
+  public String deleteFunctionMetasByLegacyTimeline(
+      @Param("legacyTimeline") Long legacyTimeline, @Param("limit") int limit) {
+    return "DELETE FROM "
+        + FunctionMetaMapper.TABLE_NAME
+        + " WHERE function_id IN (SELECT function_id FROM "
+        + FunctionMetaMapper.TABLE_NAME
+        + " WHERE deleted_at > 0 AND deleted_at < #{legacyTimeline} LIMIT #{limit})";
+  }
+
+  @Override
+  public String updateFunctionMeta(
+      @Param("newFunctionMeta") FunctionPO newFunctionPO,
+      @Param("oldFunctionMeta") FunctionPO oldFunctionPO) {
+    return "UPDATE "
+        + FunctionMetaMapper.TABLE_NAME
+        + " SET function_name = #{newFunctionMeta.functionName},"
+        + " metalake_id = #{newFunctionMeta.metalakeId},"
+        + " catalog_id = #{newFunctionMeta.catalogId},"
+        + " schema_id = #{newFunctionMeta.schemaId},"
+        + " function_type = #{newFunctionMeta.functionType},"
+        + " \"deterministic\" = #{newFunctionMeta.deterministic},"
+        + " return_type = #{newFunctionMeta.returnType},"
+        + " function_current_version = #{newFunctionMeta.functionCurrentVersion},"
+        + " function_latest_version = #{newFunctionMeta.functionLatestVersion},"
+        + " audit_info = #{newFunctionMeta.auditInfo},"
+        + " deleted_at = #{newFunctionMeta.deletedAt}"
+        + " WHERE function_id = #{oldFunctionMeta.functionId}"
+        + " AND function_name = #{oldFunctionMeta.functionName}"
+        + " AND metalake_id = #{oldFunctionMeta.metalakeId}"
+        + " AND catalog_id = #{oldFunctionMeta.catalogId}"
+        + " AND schema_id = #{oldFunctionMeta.schemaId}"
+        + " AND function_type = #{oldFunctionMeta.functionType}"
+        + " AND function_current_version = #{oldFunctionMeta.functionCurrentVersion}"
+        + " AND function_latest_version = #{oldFunctionMeta.functionLatestVersion}"
+        + " AND audit_info = #{oldFunctionMeta.auditInfo}"
+        + " AND deleted_at = 0";
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/FunctionVersionMetaPostgreSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/FunctionVersionMetaPostgreSQLProvider.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.storage.relational.mapper.provider.postgresql;
+
+import org.apache.gravitino.storage.relational.mapper.FunctionVersionMetaMapper;
+import org.apache.gravitino.storage.relational.mapper.provider.base.FunctionVersionMetaBaseSQLProvider;
+import org.apache.gravitino.storage.relational.po.FunctionVersionPO;
+import org.apache.ibatis.annotations.Param;
+
+public class FunctionVersionMetaPostgreSQLProvider extends FunctionVersionMetaBaseSQLProvider {
+
+  @Override
+  public String insertFunctionVersionMetaOnDuplicateKeyUpdate(
+      @Param("functionVersionMeta") FunctionVersionPO functionVersionPO) {
+    return "INSERT INTO "
+        + FunctionVersionMetaMapper.TABLE_NAME
+        + " (metalake_id, catalog_id, schema_id, function_id, version,"
+        + " function_comment, definitions, audit_info, deleted_at)"
+        + " VALUES (#{functionVersionMeta.metalakeId}, #{functionVersionMeta.catalogId},"
+        + " #{functionVersionMeta.schemaId}, #{functionVersionMeta.functionId},"
+        + " #{functionVersionMeta.functionVersion}, #{functionVersionMeta.functionComment},"
+        + " #{functionVersionMeta.definitions}, #{functionVersionMeta.auditInfo},"
+        + " #{functionVersionMeta.deletedAt})"
+        + " ON CONFLICT (function_id, version, deleted_at) DO UPDATE SET"
+        + " function_comment = #{functionVersionMeta.functionComment},"
+        + " definitions = #{functionVersionMeta.definitions},"
+        + " audit_info = #{functionVersionMeta.auditInfo},"
+        + " deleted_at = #{functionVersionMeta.deletedAt}";
+  }
+
+  @Override
+  public String softDeleteFunctionVersionMetasBySchemaId(@Param("schemaId") Long schemaId) {
+    return "UPDATE "
+        + FunctionVersionMetaMapper.TABLE_NAME
+        + " SET deleted_at = CAST(EXTRACT(EPOCH FROM CURRENT_TIMESTAMP) * 1000 AS BIGINT)"
+        + " WHERE schema_id = #{schemaId} AND deleted_at = 0";
+  }
+
+  @Override
+  public String softDeleteFunctionVersionMetasByCatalogId(@Param("catalogId") Long catalogId) {
+    return "UPDATE "
+        + FunctionVersionMetaMapper.TABLE_NAME
+        + " SET deleted_at = CAST(EXTRACT(EPOCH FROM CURRENT_TIMESTAMP) * 1000 AS BIGINT)"
+        + " WHERE catalog_id = #{catalogId} AND deleted_at = 0";
+  }
+
+  @Override
+  public String softDeleteFunctionVersionMetasByMetalakeId(@Param("metalakeId") Long metalakeId) {
+    return "UPDATE "
+        + FunctionVersionMetaMapper.TABLE_NAME
+        + " SET deleted_at = CAST(EXTRACT(EPOCH FROM CURRENT_TIMESTAMP) * 1000 AS BIGINT)"
+        + " WHERE metalake_id = #{metalakeId} AND deleted_at = 0";
+  }
+
+  @Override
+  public String deleteFunctionVersionMetasByLegacyTimeline(
+      @Param("legacyTimeline") Long legacyTimeline, @Param("limit") int limit) {
+    return "DELETE FROM "
+        + FunctionVersionMetaMapper.TABLE_NAME
+        + " WHERE id IN (SELECT id FROM "
+        + FunctionVersionMetaMapper.TABLE_NAME
+        + " WHERE deleted_at > 0 AND deleted_at < #{legacyTimeline} LIMIT #{limit})";
+  }
+
+  @Override
+  public String softDeleteFunctionVersionsByRetentionLine(
+      @Param("functionId") Long functionId,
+      @Param("versionRetentionLine") long versionRetentionLine,
+      @Param("limit") int limit) {
+    return "UPDATE "
+        + FunctionVersionMetaMapper.TABLE_NAME
+        + " SET deleted_at = CAST(EXTRACT(EPOCH FROM CURRENT_TIMESTAMP) * 1000 AS BIGINT)"
+        + " WHERE id IN (SELECT id FROM "
+        + FunctionVersionMetaMapper.TABLE_NAME
+        + " WHERE function_id = #{functionId} AND version <= #{versionRetentionLine}"
+        + " AND deleted_at = 0 LIMIT #{limit})";
+  }
+
+  @Override
+  public String softDeleteFunctionVersionsByFunctionId(@Param("functionId") Long functionId) {
+    return "UPDATE "
+        + FunctionVersionMetaMapper.TABLE_NAME
+        + " SET deleted_at = CAST(EXTRACT(EPOCH FROM CURRENT_TIMESTAMP) * 1000 AS BIGINT)"
+        + " WHERE function_id = #{functionId} AND deleted_at = 0";
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/storage/relational/po/FunctionMaxVersionPO.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/po/FunctionMaxVersionPO.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.storage.relational.po;
+
+import com.google.common.base.Objects;
+
+public class FunctionMaxVersionPO {
+  private Long functionId;
+  private Long version;
+
+  public Long getFunctionId() {
+    return functionId;
+  }
+
+  public Long getVersion() {
+    return version;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof FunctionMaxVersionPO)) return false;
+    FunctionMaxVersionPO that = (FunctionMaxVersionPO) o;
+    return Objects.equal(getFunctionId(), that.getFunctionId())
+        && Objects.equal(getVersion(), that.getVersion());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(getFunctionId(), getVersion());
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/storage/relational/po/FunctionPO.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/po/FunctionPO.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.storage.relational.po;
+
+import com.google.common.base.Preconditions;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import org.apache.commons.lang3.StringUtils;
+
+@EqualsAndHashCode
+@Getter
+public class FunctionPO {
+
+  private Long functionId;
+
+  private String functionName;
+
+  private Long metalakeId;
+
+  private Long catalogId;
+
+  private Long schemaId;
+
+  private String functionType;
+
+  private Integer deterministic;
+
+  private String returnType;
+
+  private Integer functionLatestVersion;
+
+  private Integer functionCurrentVersion;
+
+  private String auditInfo;
+
+  private Long deletedAt;
+
+  private FunctionVersionPO functionVersionPO;
+
+  private FunctionPO() {}
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+
+    private final FunctionPO functionPO;
+
+    private Builder() {
+      functionPO = new FunctionPO();
+    }
+
+    public Builder withFunctionId(Long functionId) {
+      functionPO.functionId = functionId;
+      return this;
+    }
+
+    public Builder withFunctionName(String functionName) {
+      functionPO.functionName = functionName;
+      return this;
+    }
+
+    public Builder withMetalakeId(Long metalakeId) {
+      functionPO.metalakeId = metalakeId;
+      return this;
+    }
+
+    public Builder withCatalogId(Long catalogId) {
+      functionPO.catalogId = catalogId;
+      return this;
+    }
+
+    public Builder withSchemaId(Long schemaId) {
+      functionPO.schemaId = schemaId;
+      return this;
+    }
+
+    public Builder withFunctionType(String functionType) {
+      functionPO.functionType = functionType;
+      return this;
+    }
+
+    public Builder withDeterministic(Integer deterministic) {
+      functionPO.deterministic = deterministic;
+      return this;
+    }
+
+    public Builder withReturnType(String returnType) {
+      functionPO.returnType = returnType;
+      return this;
+    }
+
+    public Builder withFunctionLatestVersion(Integer functionLatestVersion) {
+      functionPO.functionLatestVersion = functionLatestVersion;
+      return this;
+    }
+
+    public Builder withFunctionCurrentVersion(Integer functionCurrentVersion) {
+      functionPO.functionCurrentVersion = functionCurrentVersion;
+      return this;
+    }
+
+    public Builder withAuditInfo(String auditInfo) {
+      functionPO.auditInfo = auditInfo;
+      return this;
+    }
+
+    public Builder withDeletedAt(Long deletedAt) {
+      functionPO.deletedAt = deletedAt;
+      return this;
+    }
+
+    public Builder withFunctionVersionPO(FunctionVersionPO functionVersionPO) {
+      functionPO.functionVersionPO = functionVersionPO;
+      return this;
+    }
+
+    public Long getMetalakeId() {
+      Preconditions.checkState(functionPO.metalakeId != null, "Metalake id is null");
+      return functionPO.metalakeId;
+    }
+
+    public Long getCatalogId() {
+      Preconditions.checkState(functionPO.catalogId != null, "Catalog id is null");
+      return functionPO.catalogId;
+    }
+
+    public Long getSchemaId() {
+      Preconditions.checkState(functionPO.schemaId != null, "Schema id is null");
+      return functionPO.schemaId;
+    }
+
+    public Integer getFunctionCurrentVersion() {
+      Preconditions.checkState(
+          functionPO.functionCurrentVersion != null, "Function current version is null");
+      return functionPO.functionCurrentVersion;
+    }
+
+    public FunctionPO build() {
+      Preconditions.checkArgument(functionPO.functionId != null, "Function id is required");
+      Preconditions.checkArgument(
+          StringUtils.isNotBlank(functionPO.functionName), "Function name cannot be empty");
+      Preconditions.checkArgument(functionPO.metalakeId != null, "Metalake id is required");
+      Preconditions.checkArgument(functionPO.catalogId != null, "Catalog id is required");
+      Preconditions.checkArgument(functionPO.schemaId != null, "Schema id is required");
+      Preconditions.checkArgument(
+          StringUtils.isNotBlank(functionPO.functionType), "Function type cannot be empty");
+      Preconditions.checkArgument(
+          functionPO.functionLatestVersion != null, "Function latest version is required");
+      Preconditions.checkArgument(
+          functionPO.functionCurrentVersion != null, "Function current version is required");
+      Preconditions.checkArgument(
+          StringUtils.isNotBlank(functionPO.auditInfo), "Audit info cannot be empty");
+      Preconditions.checkArgument(functionPO.deletedAt != null, "Deleted at is required");
+      return functionPO;
+    }
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/storage/relational/po/FunctionVersionPO.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/po/FunctionVersionPO.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.storage.relational.po;
+
+import com.google.common.base.Preconditions;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import org.apache.commons.lang3.StringUtils;
+
+@EqualsAndHashCode
+@Getter
+public class FunctionVersionPO {
+
+  private Long id;
+
+  private Long functionId;
+
+  private Long metalakeId;
+
+  private Long catalogId;
+
+  private Long schemaId;
+
+  private Integer functionVersion;
+
+  private String functionComment;
+
+  private String definitions;
+
+  private String auditInfo;
+
+  private Long deletedAt;
+
+  private FunctionVersionPO() {}
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+
+    private final FunctionVersionPO functionVersionPO;
+
+    private Builder() {
+      functionVersionPO = new FunctionVersionPO();
+    }
+
+    public Builder withFunctionId(Long functionId) {
+      functionVersionPO.functionId = functionId;
+      return this;
+    }
+
+    public Builder withMetalakeId(Long metalakeId) {
+      functionVersionPO.metalakeId = metalakeId;
+      return this;
+    }
+
+    public Builder withCatalogId(Long catalogId) {
+      functionVersionPO.catalogId = catalogId;
+      return this;
+    }
+
+    public Builder withSchemaId(Long schemaId) {
+      functionVersionPO.schemaId = schemaId;
+      return this;
+    }
+
+    public Builder withFunctionVersion(Integer functionVersion) {
+      functionVersionPO.functionVersion = functionVersion;
+      return this;
+    }
+
+    public Builder withFunctionComment(String functionComment) {
+      functionVersionPO.functionComment = functionComment;
+      return this;
+    }
+
+    public Builder withDefinitions(String definitions) {
+      functionVersionPO.definitions = definitions;
+      return this;
+    }
+
+    public Builder withAuditInfo(String auditInfo) {
+      functionVersionPO.auditInfo = auditInfo;
+      return this;
+    }
+
+    public Builder withDeletedAt(Long deletedAt) {
+      functionVersionPO.deletedAt = deletedAt;
+      return this;
+    }
+
+    public FunctionVersionPO build() {
+      Preconditions.checkArgument(functionVersionPO.functionId != null, "Function id is required");
+      Preconditions.checkArgument(
+          functionVersionPO.functionVersion != null, "Function version is required");
+      Preconditions.checkArgument(
+          StringUtils.isNotBlank(functionVersionPO.definitions), "Definitions cannot be empty");
+      Preconditions.checkArgument(
+          StringUtils.isNotBlank(functionVersionPO.auditInfo), "Audit info cannot be empty");
+      Preconditions.checkArgument(functionVersionPO.deletedAt != null, "Deleted at is required");
+
+      return functionVersionPO;
+    }
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/CatalogMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/CatalogMetaService.java
@@ -39,6 +39,8 @@ import org.apache.gravitino.storage.relational.helper.CatalogIds;
 import org.apache.gravitino.storage.relational.mapper.CatalogMetaMapper;
 import org.apache.gravitino.storage.relational.mapper.FilesetMetaMapper;
 import org.apache.gravitino.storage.relational.mapper.FilesetVersionMapper;
+import org.apache.gravitino.storage.relational.mapper.FunctionMetaMapper;
+import org.apache.gravitino.storage.relational.mapper.FunctionVersionMetaMapper;
 import org.apache.gravitino.storage.relational.mapper.ModelMetaMapper;
 import org.apache.gravitino.storage.relational.mapper.ModelVersionAliasRelMapper;
 import org.apache.gravitino.storage.relational.mapper.ModelVersionMetaMapper;
@@ -277,6 +279,14 @@ public class CatalogMetaService {
               SessionUtils.doWithoutCommit(
                   TopicMetaMapper.class,
                   mapper -> mapper.softDeleteTopicMetasByCatalogId(catalogId)),
+          () ->
+              SessionUtils.doWithoutCommit(
+                  FunctionMetaMapper.class,
+                  mapper -> mapper.softDeleteFunctionMetasByCatalogId(catalogId)),
+          () ->
+              SessionUtils.doWithoutCommit(
+                  FunctionVersionMetaMapper.class,
+                  mapper -> mapper.softDeleteFunctionVersionMetasByCatalogId(catalogId)),
           () ->
               SessionUtils.doWithoutCommit(
                   OwnerMetaMapper.class, mapper -> mapper.softDeleteOwnerRelByCatalogId(catalogId)),

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/FunctionMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/FunctionMetaService.java
@@ -1,0 +1,440 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.storage.relational.service;
+
+import static org.apache.gravitino.metrics.source.MetricsSource.GRAVITINO_RELATIONAL_STORE_METRIC_NAME;
+import static org.apache.gravitino.storage.relational.utils.POConverters.DEFAULT_DELETED_AT;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.google.common.base.Preconditions;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.apache.gravitino.Entity;
+import org.apache.gravitino.GravitinoEnv;
+import org.apache.gravitino.HasIdentifier;
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.Namespace;
+import org.apache.gravitino.dto.function.FunctionDefinitionDTO;
+import org.apache.gravitino.exceptions.NoSuchEntityException;
+import org.apache.gravitino.function.FunctionDefinition;
+import org.apache.gravitino.function.FunctionType;
+import org.apache.gravitino.json.JsonUtils;
+import org.apache.gravitino.meta.AuditInfo;
+import org.apache.gravitino.meta.FunctionEntity;
+import org.apache.gravitino.meta.NamespacedEntityId;
+import org.apache.gravitino.metrics.Monitored;
+import org.apache.gravitino.rel.types.Type;
+import org.apache.gravitino.storage.relational.mapper.FunctionMetaMapper;
+import org.apache.gravitino.storage.relational.mapper.FunctionVersionMetaMapper;
+import org.apache.gravitino.storage.relational.po.FunctionMaxVersionPO;
+import org.apache.gravitino.storage.relational.po.FunctionPO;
+import org.apache.gravitino.storage.relational.po.FunctionVersionPO;
+import org.apache.gravitino.storage.relational.utils.ExceptionUtils;
+import org.apache.gravitino.storage.relational.utils.SessionUtils;
+import org.apache.gravitino.utils.NameIdentifierUtil;
+import org.apache.gravitino.utils.NamespaceUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class FunctionMetaService {
+  public static FunctionMetaService getInstance() {
+    return INSTANCE;
+  }
+
+  private static final Logger LOG = LoggerFactory.getLogger(FunctionMetaService.class);
+  private static final FunctionMetaService INSTANCE = new FunctionMetaService();
+  private static final Integer INITIAL_VERSION = 1;
+
+  private FunctionMetaService() {}
+
+  @Monitored(
+      metricsSource = GRAVITINO_RELATIONAL_STORE_METRIC_NAME,
+      baseMetricName = "listFunctionsByNamespace")
+  public List<FunctionEntity> listFunctionsByNamespace(Namespace ns) {
+    NamespaceUtil.checkFunction(ns);
+
+    List<FunctionPO> functionPOs = listFunctionPOs(ns);
+    return functionPOs.stream().map(f -> fromFunctionPO(f, ns)).collect(Collectors.toList());
+  }
+
+  @Monitored(
+      metricsSource = GRAVITINO_RELATIONAL_STORE_METRIC_NAME,
+      baseMetricName = "getFunctionByIdentifier")
+  public FunctionEntity getFunctionByIdentifier(NameIdentifier ident) {
+    FunctionPO functionPO = getFunctionPOByIdentifier(ident);
+    return fromFunctionPO(functionPO, ident.namespace());
+  }
+
+  @Monitored(
+      metricsSource = GRAVITINO_RELATIONAL_STORE_METRIC_NAME,
+      baseMetricName = "insertFunction")
+  public void insertFunction(FunctionEntity functionEntity, boolean overwrite) throws IOException {
+    NameIdentifierUtil.checkFunction(functionEntity.nameIdentifier());
+
+    FunctionPO.Builder builder = FunctionPO.builder();
+    try {
+      fillFunctionPOBuilderParentEntityId(builder, functionEntity.namespace());
+      FunctionPO po = initializeFunctionPO(functionEntity, builder);
+
+      SessionUtils.doMultipleWithCommit(
+          () ->
+              SessionUtils.doWithoutCommit(
+                  FunctionMetaMapper.class,
+                  mapper -> {
+                    if (overwrite) {
+                      mapper.insertFunctionMetaOnDuplicateKeyUpdate(po);
+                    } else {
+                      mapper.insertFunctionMeta(po);
+                    }
+                  }),
+          () ->
+              SessionUtils.doWithoutCommit(
+                  FunctionVersionMetaMapper.class,
+                  mapper -> {
+                    if (overwrite) {
+                      mapper.insertFunctionVersionMetaOnDuplicateKeyUpdate(
+                          po.getFunctionVersionPO());
+                    } else {
+                      mapper.insertFunctionVersionMeta(po.getFunctionVersionPO());
+                    }
+                  }));
+    } catch (RuntimeException re) {
+      ExceptionUtils.checkSQLException(
+          re, Entity.EntityType.FUNCTION, functionEntity.nameIdentifier().toString());
+      throw re;
+    }
+  }
+
+  @Monitored(
+      metricsSource = GRAVITINO_RELATIONAL_STORE_METRIC_NAME,
+      baseMetricName = "deleteFunction")
+  public boolean deleteFunction(NameIdentifier ident) {
+    FunctionPO functionPO = getFunctionPOByIdentifier(ident);
+    Long functionId = functionPO.getFunctionId();
+
+    AtomicInteger functionDeletedCount = new AtomicInteger();
+    SessionUtils.doMultipleWithCommit(
+        // delete function meta
+        () ->
+            functionDeletedCount.set(
+                SessionUtils.getWithoutCommit(
+                    FunctionMetaMapper.class,
+                    mapper -> mapper.softDeleteFunctionMetaByFunctionId(functionId))),
+
+        // delete function versions first
+        () -> {
+          if (functionDeletedCount.get() > 0) {
+            SessionUtils.doWithoutCommit(
+                FunctionVersionMetaMapper.class,
+                mapper -> mapper.softDeleteFunctionVersionsByFunctionId(functionId));
+          }
+        });
+
+    return functionDeletedCount.get() > 0;
+  }
+
+  @Monitored(
+      metricsSource = GRAVITINO_RELATIONAL_STORE_METRIC_NAME,
+      baseMetricName = "deleteFunctionMetasByLegacyTimeline")
+  public int deleteFunctionMetasByLegacyTimeline(Long legacyTimeline, int limit) {
+    int functionDeletedCount =
+        SessionUtils.doWithCommitAndFetchResult(
+            FunctionVersionMetaMapper.class,
+            mapper -> mapper.deleteFunctionVersionMetasByLegacyTimeline(legacyTimeline, limit));
+
+    int functionVersionDeletedCount =
+        SessionUtils.doWithCommitAndFetchResult(
+            FunctionMetaMapper.class,
+            mapper -> mapper.deleteFunctionMetasByLegacyTimeline(legacyTimeline, limit));
+
+    return functionDeletedCount + functionVersionDeletedCount;
+  }
+
+  @Monitored(
+      metricsSource = GRAVITINO_RELATIONAL_STORE_METRIC_NAME,
+      baseMetricName = "deleteFunctionVersionsByRetentionCount")
+  public int deleteFunctionVersionsByRetentionCount(Long versionRetentionCount, int limit) {
+    List<FunctionMaxVersionPO> functionCurVersions =
+        SessionUtils.getWithoutCommit(
+            FunctionVersionMetaMapper.class,
+            mapper -> mapper.selectFunctionVersionsByRetentionCount(versionRetentionCount));
+
+    int totalDeletedCount = 0;
+    for (FunctionMaxVersionPO functionCurVersion : functionCurVersions) {
+      long versionRetentionLine = functionCurVersion.getVersion() - versionRetentionCount;
+      int deletedCount =
+          SessionUtils.doWithCommitAndFetchResult(
+              FunctionVersionMetaMapper.class,
+              mapper ->
+                  mapper.softDeleteFunctionVersionsByRetentionLine(
+                      functionCurVersion.getFunctionId(), versionRetentionLine, limit));
+      totalDeletedCount += deletedCount;
+
+      LOG.info(
+          "Soft delete functionVersions count: {} which versions are older than or equal to"
+              + " versionRetentionLine: {}, the current functionId and version is: <{}, {}>.",
+          deletedCount,
+          versionRetentionLine,
+          functionCurVersion.getFunctionId(),
+          functionCurVersion.getVersion());
+    }
+    return totalDeletedCount;
+  }
+
+  @Monitored(
+      metricsSource = GRAVITINO_RELATIONAL_STORE_METRIC_NAME,
+      baseMetricName = "getFunctionPOByIdentifier")
+  FunctionPO getFunctionPOByIdentifier(NameIdentifier ident) {
+    NameIdentifierUtil.checkFunction(ident);
+
+    return functionPOFetcher().apply(ident);
+  }
+
+  @Monitored(
+      metricsSource = GRAVITINO_RELATIONAL_STORE_METRIC_NAME,
+      baseMetricName = "updateFunction")
+  public <E extends Entity & HasIdentifier> FunctionEntity updateFunction(
+      NameIdentifier identifier, Function<E, E> updater) throws IOException {
+    FunctionPO oldFunctionPO = getFunctionPOByIdentifier(identifier);
+    FunctionEntity oldFunctionEntity = fromFunctionPO(oldFunctionPO, identifier.namespace());
+    FunctionEntity newEntity = (FunctionEntity) updater.apply((E) oldFunctionEntity);
+    Preconditions.checkArgument(
+        Objects.equals(oldFunctionEntity.id(), newEntity.id()),
+        "The updated function entity id: %s should be same with the entity id before: %s",
+        newEntity.id(),
+        oldFunctionEntity.id());
+
+    try {
+      FunctionPO newFunctionPO = updateFunctionPO(oldFunctionPO, newEntity);
+      // Insert a new version and update function meta
+      SessionUtils.doMultipleWithCommit(
+          () ->
+              SessionUtils.doWithoutCommit(
+                  FunctionVersionMetaMapper.class,
+                  mapper -> mapper.insertFunctionVersionMeta(newFunctionPO.getFunctionVersionPO())),
+          () ->
+              SessionUtils.doWithoutCommit(
+                  FunctionMetaMapper.class,
+                  mapper -> mapper.updateFunctionMeta(newFunctionPO, oldFunctionPO)));
+
+      return newEntity;
+    } catch (RuntimeException re) {
+      ExceptionUtils.checkSQLException(
+          re, Entity.EntityType.FUNCTION, newEntity.nameIdentifier().toString());
+      throw re;
+    }
+  }
+
+  private Function<NameIdentifier, FunctionPO> functionPOFetcher() {
+    return GravitinoEnv.getInstance().cacheEnabled()
+        ? this::getFunctionPOBySchemaId
+        : this::getFunctionPOByFullQualifiedName;
+  }
+
+  private FunctionPO getFunctionPOBySchemaId(NameIdentifier ident) {
+    Long schemaId =
+        EntityIdService.getEntityId(
+            NameIdentifier.of(ident.namespace().levels()), Entity.EntityType.SCHEMA);
+
+    FunctionPO functionPO =
+        SessionUtils.getWithoutCommit(
+            FunctionMetaMapper.class,
+            mapper -> mapper.selectFunctionMetaBySchemaIdAndName(schemaId, ident.name()));
+
+    if (functionPO == null) {
+      throw new NoSuchEntityException(
+          NoSuchEntityException.NO_SUCH_ENTITY_MESSAGE,
+          Entity.EntityType.FUNCTION.name().toLowerCase(Locale.ROOT),
+          ident.toString());
+    }
+    return functionPO;
+  }
+
+  private FunctionPO getFunctionPOByFullQualifiedName(NameIdentifier ident) {
+    String[] namespaceLevels = ident.namespace().levels();
+    FunctionPO functionPO =
+        SessionUtils.getWithoutCommit(
+            FunctionMetaMapper.class,
+            mapper ->
+                mapper.selectFunctionMetaByFullQualifiedName(
+                    namespaceLevels[0], namespaceLevels[1], namespaceLevels[2], ident.name()));
+
+    if (functionPO == null || functionPO.getFunctionId() == null) {
+      throw new NoSuchEntityException(
+          NoSuchEntityException.NO_SUCH_ENTITY_MESSAGE,
+          Entity.EntityType.FUNCTION.name().toLowerCase(Locale.ROOT),
+          ident.name());
+    }
+
+    if (functionPO.getSchemaId() == null) {
+      throw new NoSuchEntityException(
+          NoSuchEntityException.NO_SUCH_ENTITY_MESSAGE,
+          Entity.EntityType.SCHEMA.name().toLowerCase(),
+          namespaceLevels[2]);
+    }
+    return functionPO;
+  }
+
+  private List<FunctionPO> listFunctionPOs(Namespace namespace) {
+    return functionListFetcher().apply(namespace);
+  }
+
+  private List<FunctionPO> listFunctionPOsBySchemaId(Namespace namespace) {
+    Long schemaId =
+        EntityIdService.getEntityId(
+            NameIdentifier.of(namespace.levels()), Entity.EntityType.SCHEMA);
+    return SessionUtils.getWithoutCommit(
+        FunctionMetaMapper.class, mapper -> mapper.listFunctionPOsBySchemaId(schemaId));
+  }
+
+  private Function<Namespace, List<FunctionPO>> functionListFetcher() {
+    return GravitinoEnv.getInstance().cacheEnabled()
+        ? this::listFunctionPOsBySchemaId
+        : this::listFunctionPOsByFullQualifiedName;
+  }
+
+  private List<FunctionPO> listFunctionPOsByFullQualifiedName(Namespace namespace) {
+    String[] namespaceLevels = namespace.levels();
+    List<FunctionPO> functionPOs =
+        SessionUtils.getWithoutCommit(
+            FunctionMetaMapper.class,
+            mapper ->
+                mapper.listFunctionPOsByFullQualifiedName(
+                    namespaceLevels[0], namespaceLevels[1], namespaceLevels[2]));
+    if (functionPOs.isEmpty() || functionPOs.get(0).getSchemaId() == null) {
+      throw new NoSuchEntityException(
+          NoSuchEntityException.NO_SUCH_ENTITY_MESSAGE,
+          Entity.EntityType.SCHEMA.name().toLowerCase(),
+          namespaceLevels[2]);
+    }
+    return functionPOs.stream()
+        .filter(po -> po.getFunctionId() != null)
+        .collect(Collectors.toList());
+  }
+
+  private void fillFunctionPOBuilderParentEntityId(FunctionPO.Builder builder, Namespace ns) {
+    NamespaceUtil.checkFunction(ns);
+    NamespacedEntityId namespacedEntityId =
+        EntityIdService.getEntityIds(NameIdentifier.of(ns.levels()), Entity.EntityType.SCHEMA);
+    builder.withMetalakeId(namespacedEntityId.namespaceIds()[0]);
+    builder.withCatalogId(namespacedEntityId.namespaceIds()[1]);
+    builder.withSchemaId(namespacedEntityId.entityId());
+  }
+
+  // ============================ PO Converters ============================
+
+  private FunctionEntity fromFunctionPO(FunctionPO functionPO, Namespace namespace) {
+    try {
+      FunctionVersionPO versionPO = functionPO.getFunctionVersionPO();
+      List<FunctionDefinitionDTO> definitionDTOs =
+          JsonUtils.anyFieldMapper()
+              .readValue(
+                  versionPO.getDefinitions(),
+                  JsonUtils.anyFieldMapper()
+                      .getTypeFactory()
+                      .constructCollectionType(List.class, FunctionDefinitionDTO.class));
+      FunctionDefinition[] definitions =
+          definitionDTOs.stream()
+              .map(FunctionDefinitionDTO::toFunctionDefinition)
+              .toArray(FunctionDefinition[]::new);
+      return FunctionEntity.builder()
+          .withId(functionPO.getFunctionId())
+          .withName(functionPO.getFunctionName())
+          .withNamespace(namespace)
+          .withComment(versionPO.getFunctionComment())
+          .withFunctionType(FunctionType.valueOf(functionPO.getFunctionType()))
+          .withDeterministic(
+              functionPO.getDeterministic() != null && functionPO.getDeterministic() == 1)
+          .withReturnType(
+              JsonUtils.anyFieldMapper().readValue(functionPO.getReturnType(), Type.class))
+          .withDefinitions(definitions)
+          .withAuditInfo(
+              JsonUtils.anyFieldMapper().readValue(functionPO.getAuditInfo(), AuditInfo.class))
+          .build();
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException("Failed to deserialize json object:", e);
+    }
+  }
+
+  private FunctionPO initializeFunctionPO(
+      FunctionEntity functionEntity, FunctionPO.Builder builder) {
+    builder.withFunctionLatestVersion(INITIAL_VERSION).withFunctionCurrentVersion(INITIAL_VERSION);
+    return buildFunctionPO(functionEntity, builder);
+  }
+
+  private FunctionVersionPO initializeFunctionVersionPO(
+      FunctionEntity functionEntity, FunctionPO.Builder builder) {
+    try {
+      List<FunctionDefinitionDTO> definitionDTOs =
+          Arrays.stream(functionEntity.definitions())
+              .map(FunctionDefinitionDTO::fromFunctionDefinition)
+              .collect(Collectors.toList());
+      return FunctionVersionPO.builder()
+          .withFunctionId(functionEntity.id())
+          .withMetalakeId(builder.getMetalakeId())
+          .withCatalogId(builder.getCatalogId())
+          .withSchemaId(builder.getSchemaId())
+          .withFunctionVersion(builder.getFunctionCurrentVersion())
+          .withFunctionComment(functionEntity.comment())
+          .withDefinitions(JsonUtils.anyFieldMapper().writeValueAsString(definitionDTOs))
+          .withAuditInfo(JsonUtils.anyFieldMapper().writeValueAsString(functionEntity.auditInfo()))
+          .withDeletedAt(DEFAULT_DELETED_AT)
+          .build();
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException("Failed to serialize json object:", e);
+    }
+  }
+
+  private FunctionPO updateFunctionPO(FunctionPO oldFunctionPO, FunctionEntity newFunction) {
+    FunctionPO.Builder builder =
+        FunctionPO.builder()
+            .withMetalakeId(oldFunctionPO.getMetalakeId())
+            .withCatalogId(oldFunctionPO.getCatalogId())
+            .withSchemaId(oldFunctionPO.getSchemaId())
+            .withFunctionLatestVersion(oldFunctionPO.getFunctionLatestVersion() + 1)
+            .withFunctionCurrentVersion(oldFunctionPO.getFunctionLatestVersion() + 1);
+    return buildFunctionPO(newFunction, builder);
+  }
+
+  private FunctionPO buildFunctionPO(FunctionEntity functionEntity, FunctionPO.Builder builder) {
+    try {
+      FunctionVersionPO versionPO = initializeFunctionVersionPO(functionEntity, builder);
+      return builder
+          .withFunctionId(functionEntity.id())
+          .withFunctionName(functionEntity.name())
+          .withFunctionType(functionEntity.functionType().name())
+          .withDeterministic(functionEntity.deterministic() ? 1 : 0)
+          .withReturnType(
+              JsonUtils.anyFieldMapper().writeValueAsString(functionEntity.returnType()))
+          .withFunctionVersionPO(versionPO)
+          .withAuditInfo(JsonUtils.anyFieldMapper().writeValueAsString(functionEntity.auditInfo()))
+          .withDeletedAt(DEFAULT_DELETED_AT)
+          .build();
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException("Failed to serialize json object:", e);
+    }
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/MetalakeMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/MetalakeMetaService.java
@@ -37,6 +37,8 @@ import org.apache.gravitino.metrics.Monitored;
 import org.apache.gravitino.storage.relational.mapper.CatalogMetaMapper;
 import org.apache.gravitino.storage.relational.mapper.FilesetMetaMapper;
 import org.apache.gravitino.storage.relational.mapper.FilesetVersionMapper;
+import org.apache.gravitino.storage.relational.mapper.FunctionMetaMapper;
+import org.apache.gravitino.storage.relational.mapper.FunctionVersionMetaMapper;
 import org.apache.gravitino.storage.relational.mapper.GroupMetaMapper;
 import org.apache.gravitino.storage.relational.mapper.GroupRoleRelMapper;
 import org.apache.gravitino.storage.relational.mapper.JobMetaMapper;
@@ -229,6 +231,14 @@ public class MetalakeMetaService {
                 SessionUtils.doWithoutCommit(
                     TopicMetaMapper.class,
                     mapper -> mapper.softDeleteTopicMetasByMetalakeId(metalakeId)),
+            () ->
+                SessionUtils.doWithoutCommit(
+                    FunctionMetaMapper.class,
+                    mapper -> mapper.softDeleteFunctionMetasByMetalakeId(metalakeId)),
+            () ->
+                SessionUtils.doWithoutCommit(
+                    FunctionVersionMetaMapper.class,
+                    mapper -> mapper.softDeleteFunctionVersionMetasByMetalakeId(metalakeId)),
             () ->
                 SessionUtils.doWithoutCommit(
                     UserRoleRelMapper.class,

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/SchemaMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/SchemaMetaService.java
@@ -45,6 +45,8 @@ import org.apache.gravitino.metrics.Monitored;
 import org.apache.gravitino.storage.relational.helper.SchemaIds;
 import org.apache.gravitino.storage.relational.mapper.FilesetMetaMapper;
 import org.apache.gravitino.storage.relational.mapper.FilesetVersionMapper;
+import org.apache.gravitino.storage.relational.mapper.FunctionMetaMapper;
+import org.apache.gravitino.storage.relational.mapper.FunctionVersionMetaMapper;
 import org.apache.gravitino.storage.relational.mapper.ModelMetaMapper;
 import org.apache.gravitino.storage.relational.mapper.ModelVersionAliasRelMapper;
 import org.apache.gravitino.storage.relational.mapper.ModelVersionMetaMapper;
@@ -246,6 +248,14 @@ public class SchemaMetaService {
           () ->
               SessionUtils.doWithoutCommit(
                   TopicMetaMapper.class, mapper -> mapper.softDeleteTopicMetasBySchemaId(schemaId)),
+          () ->
+              SessionUtils.doWithoutCommit(
+                  FunctionMetaMapper.class,
+                  mapper -> mapper.softDeleteFunctionMetasBySchemaId(schemaId)),
+          () ->
+              SessionUtils.doWithoutCommit(
+                  FunctionVersionMetaMapper.class,
+                  mapper -> mapper.softDeleteFunctionVersionMetasBySchemaId(schemaId)),
           () ->
               SessionUtils.doWithoutCommit(
                   OwnerMetaMapper.class, mapper -> mapper.softDeleteOwnerRelBySchemaId(schemaId)),

--- a/core/src/main/java/org/apache/gravitino/utils/NameIdentifierUtil.java
+++ b/core/src/main/java/org/apache/gravitino/utils/NameIdentifierUtil.java
@@ -546,6 +546,17 @@ public class NameIdentifierUtil {
   }
 
   /**
+   * Check the given {@link NameIdentifier} is a function identifier. Throw an {@link
+   * IllegalNameIdentifierException} if it's not.
+   *
+   * @param ident The function {@link NameIdentifier} to check.
+   */
+  public static void checkFunction(NameIdentifier ident) {
+    NameIdentifier.check(ident != null, "Function identifier must not be null");
+    NamespaceUtil.checkFunction(ident.namespace());
+  }
+
+  /**
    * Check the given {@link NameIdentifier} is a job identifier. Throw an {@link
    * IllegalNameIdentifierException} if it's not.
    *

--- a/core/src/main/java/org/apache/gravitino/utils/NamespaceUtil.java
+++ b/core/src/main/java/org/apache/gravitino/utils/NamespaceUtil.java
@@ -363,6 +363,19 @@ public class NamespaceUtil {
   }
 
   /**
+   * Check if the given function namespace is legal, throw an {@link IllegalNamespaceException} if
+   * it's illegal.
+   *
+   * @param namespace The function namespace
+   */
+  public static void checkFunction(Namespace namespace) {
+    check(
+        namespace != null && namespace.length() == 3,
+        "Function namespace must be non-null and have 3 levels, the input namespace is %s",
+        namespace);
+  }
+
+  /**
    * Check if the given job template namespace is legal, throw an {@link IllegalNamespaceException}
    *
    * @param namespace The job template namespace

--- a/core/src/test/java/org/apache/gravitino/storage/relational/TestJDBCBackend.java
+++ b/core/src/test/java/org/apache/gravitino/storage/relational/TestJDBCBackend.java
@@ -225,6 +225,10 @@ public abstract class TestJDBCBackend {
         tableName = "policy_meta";
         idColumnName = "policy_id";
         break;
+      case FUNCTION:
+        tableName = "function_meta";
+        idColumnName = "function_id";
+        break;
       default:
         throw new IllegalArgumentException("Unsupported entity type: " + entityType);
     }

--- a/core/src/test/java/org/apache/gravitino/storage/relational/service/TestFunctionMetaService.java
+++ b/core/src/test/java/org/apache/gravitino/storage/relational/service/TestFunctionMetaService.java
@@ -1,0 +1,498 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.storage.relational.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.gravitino.Entity;
+import org.apache.gravitino.EntityAlreadyExistsException;
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.Namespace;
+import org.apache.gravitino.exceptions.NoSuchEntityException;
+import org.apache.gravitino.function.FunctionDefinition;
+import org.apache.gravitino.function.FunctionDefinitions;
+import org.apache.gravitino.function.FunctionImpl;
+import org.apache.gravitino.function.FunctionImpls;
+import org.apache.gravitino.function.FunctionParam;
+import org.apache.gravitino.function.FunctionParams;
+import org.apache.gravitino.function.FunctionType;
+import org.apache.gravitino.integration.test.util.GravitinoITUtils;
+import org.apache.gravitino.meta.AuditInfo;
+import org.apache.gravitino.meta.FunctionEntity;
+import org.apache.gravitino.rel.types.Types;
+import org.apache.gravitino.storage.RandomIdGenerator;
+import org.apache.gravitino.storage.relational.TestJDBCBackend;
+import org.apache.gravitino.storage.relational.session.SqlSessionFactoryHelper;
+import org.apache.gravitino.utils.NameIdentifierUtil;
+import org.apache.gravitino.utils.NamespaceUtil;
+import org.apache.ibatis.session.SqlSession;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+
+public class TestFunctionMetaService extends TestJDBCBackend {
+  private final String metalakeName = GravitinoITUtils.genRandomName("tst_metalake");
+  private final String catalogName = GravitinoITUtils.genRandomName("tst_fn_catalog");
+  private final String schemaName = GravitinoITUtils.genRandomName("tst_fn_schema");
+
+  @BeforeEach
+  public void prepare() throws IOException {
+    createAndInsertMakeLake(metalakeName);
+    createAndInsertCatalog(metalakeName, catalogName);
+    createAndInsertSchema(metalakeName, catalogName, schemaName);
+  }
+
+  @TestTemplate
+  public void testInsertAlreadyExistsException() throws IOException {
+    FunctionEntity function =
+        createFunctionEntity(
+            RandomIdGenerator.INSTANCE.nextId(),
+            NamespaceUtil.ofFunction(metalakeName, catalogName, schemaName),
+            "test_function",
+            AUDIT_INFO);
+    FunctionEntity functionCopy =
+        createFunctionEntity(
+            RandomIdGenerator.INSTANCE.nextId(),
+            NamespaceUtil.ofFunction(metalakeName, catalogName, schemaName),
+            "test_function",
+            AUDIT_INFO);
+
+    FunctionMetaService.getInstance().insertFunction(function, false);
+    assertThrows(
+        EntityAlreadyExistsException.class,
+        () -> FunctionMetaService.getInstance().insertFunction(functionCopy, false));
+  }
+
+  @TestTemplate
+  public void testInsertAndGetFunction() throws IOException {
+    String functionName = GravitinoITUtils.genRandomName("test_function");
+    Namespace ns = NamespaceUtil.ofFunction(metalakeName, catalogName, schemaName);
+    FunctionEntity function =
+        createFunctionEntity(RandomIdGenerator.INSTANCE.nextId(), ns, functionName, AUDIT_INFO);
+
+    FunctionMetaService.getInstance().insertFunction(function, false);
+
+    // Get function using standard identifier (always returns latest version)
+    NameIdentifier functionIdent =
+        NameIdentifier.of(metalakeName, catalogName, schemaName, functionName);
+    FunctionEntity loadedFunction =
+        FunctionMetaService.getInstance().getFunctionByIdentifier(functionIdent);
+
+    assertNotNull(loadedFunction);
+    assertEquals(function.id(), loadedFunction.id());
+    assertEquals(function.name(), loadedFunction.name());
+    assertEquals(function.comment(), loadedFunction.comment());
+    assertEquals(function.functionType(), loadedFunction.functionType());
+    assertEquals(function.deterministic(), loadedFunction.deterministic());
+  }
+
+  @TestTemplate
+  public void testMultipleVersionsInStorage() throws IOException {
+    // This test verifies that multiple versions are created in storage layer
+    // even though the API always returns the latest version
+    String functionName = GravitinoITUtils.genRandomName("test_function");
+    Namespace ns = NamespaceUtil.ofFunction(metalakeName, catalogName, schemaName);
+    FunctionEntity function =
+        createFunctionEntity(RandomIdGenerator.INSTANCE.nextId(), ns, functionName, AUDIT_INFO);
+
+    FunctionMetaService.getInstance().insertFunction(function, false);
+
+    // Update function to create version 2 in storage layer
+    NameIdentifier functionIdent =
+        NameIdentifier.of(metalakeName, catalogName, schemaName, functionName);
+    FunctionEntity updatedFunction =
+        FunctionEntity.builder()
+            .withId(function.id())
+            .withName(function.name())
+            .withNamespace(ns)
+            .withComment("updated comment")
+            .withFunctionType(function.functionType())
+            .withDeterministic(function.deterministic())
+            .withReturnType(function.returnType())
+            .withDefinitions(function.definitions())
+            .withAuditInfo(AUDIT_INFO)
+            .build();
+
+    FunctionMetaService.getInstance().updateFunction(functionIdent, e -> updatedFunction);
+
+    // Get function always returns latest version
+    FunctionEntity loadedLatest =
+        FunctionMetaService.getInstance().getFunctionByIdentifier(functionIdent);
+    assertEquals("updated comment", loadedLatest.comment());
+
+    // Verify both versions exist in storage
+    Map<Integer, Long> versions = listFunctionVersions(function.id());
+    assertEquals(2, versions.size());
+    assertTrue(versions.containsKey(1));
+    assertTrue(versions.containsKey(2));
+  }
+
+  @TestTemplate
+  public void testListFunctions() throws IOException {
+    Namespace ns = NamespaceUtil.ofFunction(metalakeName, catalogName, schemaName);
+
+    String functionName1 = GravitinoITUtils.genRandomName("test_function1");
+    FunctionEntity function1 =
+        createFunctionEntity(RandomIdGenerator.INSTANCE.nextId(), ns, functionName1, AUDIT_INFO);
+
+    String functionName2 = GravitinoITUtils.genRandomName("test_function2");
+    FunctionEntity function2 =
+        createFunctionEntity(RandomIdGenerator.INSTANCE.nextId(), ns, functionName2, AUDIT_INFO);
+
+    FunctionMetaService.getInstance().insertFunction(function1, false);
+    FunctionMetaService.getInstance().insertFunction(function2, false);
+
+    List<FunctionEntity> functions = FunctionMetaService.getInstance().listFunctionsByNamespace(ns);
+
+    assertEquals(2, functions.size());
+    assertTrue(functions.stream().anyMatch(f -> f.name().equals(functionName1)));
+    assertTrue(functions.stream().anyMatch(f -> f.name().equals(functionName2)));
+  }
+
+  @TestTemplate
+  public void testUpdateFunction() throws IOException {
+    String functionName = GravitinoITUtils.genRandomName("test_function");
+    Namespace ns = NamespaceUtil.ofFunction(metalakeName, catalogName, schemaName);
+    FunctionEntity function =
+        createFunctionEntity(RandomIdGenerator.INSTANCE.nextId(), ns, functionName, AUDIT_INFO);
+
+    FunctionMetaService.getInstance().insertFunction(function, false);
+
+    // Update function (new version in storage layer)
+    NameIdentifier functionIdent =
+        NameIdentifier.of(metalakeName, catalogName, schemaName, functionName);
+    FunctionEntity updatedFunction =
+        FunctionEntity.builder()
+            .withId(function.id())
+            .withName(function.name())
+            .withNamespace(ns)
+            .withComment("updated comment")
+            .withFunctionType(function.functionType())
+            .withDeterministic(true)
+            .withReturnType(function.returnType())
+            .withDefinitions(function.definitions())
+            .withAuditInfo(AUDIT_INFO)
+            .build();
+
+    FunctionEntity result =
+        FunctionMetaService.getInstance().updateFunction(functionIdent, e -> updatedFunction);
+
+    assertEquals("updated comment", result.comment());
+    assertTrue(result.deterministic());
+
+    // Verify both versions exist in DB
+    Map<Integer, Long> versions = listFunctionVersions(function.id());
+    assertEquals(2, versions.size());
+    assertTrue(versions.containsKey(1));
+    assertTrue(versions.containsKey(2));
+  }
+
+  @TestTemplate
+  public void testDeleteFunction() throws IOException {
+    String functionName = GravitinoITUtils.genRandomName("test_function");
+    Namespace ns = NamespaceUtil.ofFunction(metalakeName, catalogName, schemaName);
+    FunctionEntity function =
+        createFunctionEntity(RandomIdGenerator.INSTANCE.nextId(), ns, functionName, AUDIT_INFO);
+
+    FunctionMetaService.getInstance().insertFunction(function, false);
+
+    NameIdentifier functionIdent =
+        NameIdentifier.of(metalakeName, catalogName, schemaName, functionName);
+    assertTrue(FunctionMetaService.getInstance().deleteFunction(functionIdent));
+
+    // Verify function is soft deleted
+    assertThrows(
+        NoSuchEntityException.class,
+        () -> FunctionMetaService.getInstance().getFunctionByIdentifier(functionIdent));
+  }
+
+  @TestTemplate
+  public void testDeleteNonExistentFunction() {
+    NameIdentifier functionIdent =
+        NameIdentifier.of(metalakeName, catalogName, schemaName, "non_existent_function");
+    assertThrows(
+        NoSuchEntityException.class,
+        () -> FunctionMetaService.getInstance().deleteFunction(functionIdent));
+  }
+
+  @TestTemplate
+  public void testMetaLifeCycleFromCreationToDeletion() throws IOException {
+    String functionName = GravitinoITUtils.genRandomName("test_function");
+    Namespace ns = NamespaceUtil.ofFunction(metalakeName, catalogName, schemaName);
+    FunctionEntity function =
+        createFunctionEntity(RandomIdGenerator.INSTANCE.nextId(), ns, functionName, AUDIT_INFO);
+
+    FunctionMetaService.getInstance().insertFunction(function, false);
+
+    // Update function to create version 2 in storage layer
+    NameIdentifier functionIdent =
+        NameIdentifier.of(metalakeName, catalogName, schemaName, functionName);
+    FunctionEntity functionV2 =
+        FunctionEntity.builder()
+            .withId(function.id())
+            .withName(function.name())
+            .withNamespace(ns)
+            .withComment("version 2 comment")
+            .withFunctionType(function.functionType())
+            .withDeterministic(function.deterministic())
+            .withReturnType(function.returnType())
+            .withDefinitions(function.definitions())
+            .withAuditInfo(AUDIT_INFO)
+            .build();
+
+    FunctionMetaService.getInstance().updateFunction(functionIdent, e -> functionV2);
+
+    // Create another function in a different schema
+    String anotherMetalakeName = GravitinoITUtils.genRandomName("another-metalake");
+    String anotherCatalogName = GravitinoITUtils.genRandomName("another-catalog");
+    String anotherSchemaName = GravitinoITUtils.genRandomName("another-schema");
+    createAndInsertMakeLake(anotherMetalakeName);
+    createAndInsertCatalog(anotherMetalakeName, anotherCatalogName);
+    createAndInsertSchema(anotherMetalakeName, anotherCatalogName, anotherSchemaName);
+
+    FunctionEntity anotherFunction =
+        createFunctionEntity(
+            RandomIdGenerator.INSTANCE.nextId(),
+            NamespaceUtil.ofFunction(anotherMetalakeName, anotherCatalogName, anotherSchemaName),
+            "another_function",
+            AUDIT_INFO);
+    FunctionMetaService.getInstance().insertFunction(anotherFunction, false);
+
+    // Update another function to version 2 and 3
+    NameIdentifier anotherFunctionIdent =
+        NameIdentifier.of(
+            anotherMetalakeName, anotherCatalogName, anotherSchemaName, "another_function");
+    Namespace anotherNs =
+        NamespaceUtil.ofFunction(anotherMetalakeName, anotherCatalogName, anotherSchemaName);
+    FunctionEntity anotherFunctionV2 =
+        FunctionEntity.builder()
+            .withId(anotherFunction.id())
+            .withName(anotherFunction.name())
+            .withNamespace(anotherNs)
+            .withComment("another function v2")
+            .withFunctionType(anotherFunction.functionType())
+            .withDeterministic(anotherFunction.deterministic())
+            .withReturnType(anotherFunction.returnType())
+            .withDefinitions(anotherFunction.definitions())
+            .withAuditInfo(AUDIT_INFO)
+            .build();
+    FunctionMetaService.getInstance().updateFunction(anotherFunctionIdent, e -> anotherFunctionV2);
+
+    FunctionEntity anotherFunctionV3 =
+        FunctionEntity.builder()
+            .withId(anotherFunction.id())
+            .withName(anotherFunction.name())
+            .withNamespace(anotherNs)
+            .withComment("another function v3")
+            .withFunctionType(anotherFunction.functionType())
+            .withDeterministic(anotherFunction.deterministic())
+            .withReturnType(anotherFunction.returnType())
+            .withDefinitions(anotherFunction.definitions())
+            .withAuditInfo(AUDIT_INFO)
+            .build();
+    FunctionMetaService.getInstance().updateFunction(anotherFunctionIdent, e -> anotherFunctionV3);
+
+    // Verify list functions
+    List<FunctionEntity> functions = FunctionMetaService.getInstance().listFunctionsByNamespace(ns);
+    assertEquals(1, functions.size());
+    assertEquals(functionV2.name(), functions.get(0).name());
+
+    // Soft delete metalake (cascading delete)
+    backend.delete(NameIdentifierUtil.ofMetalake(metalakeName), Entity.EntityType.METALAKE, true);
+
+    // Verify function is deleted in the deleted metalake
+    assertThrows(
+        NoSuchEntityException.class,
+        () -> FunctionMetaService.getInstance().getFunctionByIdentifier(functionIdent));
+
+    // Verify another function still exists
+    NameIdentifier anotherFunctionIdentForVerify =
+        NameIdentifier.of(
+            anotherMetalakeName, anotherCatalogName, anotherSchemaName, "another_function");
+    FunctionEntity loadedAnotherFunction =
+        FunctionMetaService.getInstance().getFunctionByIdentifier(anotherFunctionIdentForVerify);
+    assertNotNull(loadedAnotherFunction);
+
+    // Check legacy record after soft delete
+    assertTrue(legacyRecordExistsInDB(function.id(), Entity.EntityType.FUNCTION));
+    assertEquals(2, listFunctionVersions(function.id()).size());
+    assertEquals(3, listFunctionVersions(anotherFunction.id()).size());
+
+    // Hard delete legacy data
+    for (Entity.EntityType entityType : Entity.EntityType.values()) {
+      backend.hardDeleteLegacyData(entityType, Instant.now().toEpochMilli() + 1000);
+    }
+    assertFalse(legacyRecordExistsInDB(function.id(), Entity.EntityType.FUNCTION));
+    assertEquals(0, listFunctionVersions(function.id()).size());
+    assertEquals(3, listFunctionVersions(anotherFunction.id()).size());
+
+    // Soft delete old versions
+    for (Entity.EntityType entityType : Entity.EntityType.values()) {
+      backend.deleteOldVersionData(entityType, 1);
+    }
+    Map<Integer, Long> versionDeletedMap = listFunctionVersions(anotherFunction.id());
+    assertEquals(3, versionDeletedMap.size());
+    assertEquals(1, versionDeletedMap.values().stream().filter(value -> value == 0L).count());
+    assertEquals(2, versionDeletedMap.values().stream().filter(value -> value != 0L).count());
+
+    // Hard delete old versions
+    backend.hardDeleteLegacyData(Entity.EntityType.FUNCTION, Instant.now().toEpochMilli() + 1000);
+    assertEquals(1, listFunctionVersions(anotherFunction.id()).size());
+  }
+
+  @TestTemplate
+  public void testDeleteFunctionVersionsByRetentionCount() throws IOException {
+    String functionName = GravitinoITUtils.genRandomName("test_function");
+    Namespace ns = NamespaceUtil.ofFunction(metalakeName, catalogName, schemaName);
+    FunctionEntity function =
+        createFunctionEntity(RandomIdGenerator.INSTANCE.nextId(), ns, functionName, AUDIT_INFO);
+
+    FunctionMetaService.getInstance().insertFunction(function, false);
+
+    // Create multiple versions
+    NameIdentifier functionIdent =
+        NameIdentifier.of(metalakeName, catalogName, schemaName, functionName);
+
+    for (int v = 2; v <= 5; v++) {
+      final int version = v;
+      FunctionEntity updatedFunction =
+          FunctionEntity.builder()
+              .withId(function.id())
+              .withName(function.name())
+              .withNamespace(ns)
+              .withComment("version " + version)
+              .withFunctionType(function.functionType())
+              .withDeterministic(function.deterministic())
+              .withReturnType(function.returnType())
+              .withDefinitions(function.definitions())
+              .withAuditInfo(AUDIT_INFO)
+              .build();
+      FunctionMetaService.getInstance().updateFunction(functionIdent, e -> updatedFunction);
+    }
+
+    // Verify all 5 versions exist
+    assertEquals(5, listFunctionVersions(function.id()).size());
+
+    // Soft delete versions by retention count (keep only 2)
+    FunctionMetaService.getInstance().deleteFunctionVersionsByRetentionCount(2L, 100);
+
+    // Verify 3 versions are soft deleted
+    Map<Integer, Long> versionDeletedMap = listFunctionVersions(function.id());
+    assertEquals(5, versionDeletedMap.size());
+    assertEquals(2, versionDeletedMap.values().stream().filter(value -> value == 0L).count());
+    assertEquals(3, versionDeletedMap.values().stream().filter(value -> value != 0L).count());
+  }
+
+  @TestTemplate
+  public void testGetNonExistentFunction() {
+    NameIdentifier functionIdent =
+        NameIdentifier.of(metalakeName, catalogName, schemaName, "non_existent_function");
+    assertThrows(
+        NoSuchEntityException.class,
+        () -> FunctionMetaService.getInstance().getFunctionByIdentifier(functionIdent));
+  }
+
+  @TestTemplate
+  public void testInsertFunctionWithOverwrite() throws IOException {
+    String functionName = GravitinoITUtils.genRandomName("test_function");
+    Namespace ns = NamespaceUtil.ofFunction(metalakeName, catalogName, schemaName);
+    FunctionEntity function =
+        createFunctionEntity(RandomIdGenerator.INSTANCE.nextId(), ns, functionName, AUDIT_INFO);
+
+    FunctionMetaService.getInstance().insertFunction(function, false);
+
+    NameIdentifier functionIdent =
+        NameIdentifier.of(metalakeName, catalogName, schemaName, functionName);
+
+    // Insert with overwrite=true should succeed
+    FunctionEntity newFunction =
+        FunctionEntity.builder()
+            .withId(function.id())
+            .withName(function.name())
+            .withNamespace(ns)
+            .withComment("overwritten comment")
+            .withFunctionType(function.functionType())
+            .withDeterministic(true)
+            .withReturnType(function.returnType())
+            .withDefinitions(function.definitions())
+            .withAuditInfo(AUDIT_INFO)
+            .build();
+
+    FunctionMetaService.getInstance().insertFunction(newFunction, true);
+
+    // Verify the function was updated
+    FunctionEntity loadedFunction =
+        FunctionMetaService.getInstance().getFunctionByIdentifier(functionIdent);
+    assertEquals("overwritten comment", loadedFunction.comment());
+    assertTrue(loadedFunction.deterministic());
+  }
+
+  private FunctionEntity createFunctionEntity(
+      Long id, Namespace namespace, String name, AuditInfo auditInfo) {
+    FunctionParam param1 = FunctionParams.of("param1", Types.IntegerType.get());
+    FunctionParam param2 = FunctionParams.of("param2", Types.StringType.get());
+    FunctionImpl impl = FunctionImpls.ofSql(FunctionImpl.RuntimeType.SPARK, "SELECT param1 + 1");
+    FunctionDefinition definition =
+        FunctionDefinitions.of(new FunctionParam[] {param1, param2}, new FunctionImpl[] {impl});
+
+    return FunctionEntity.builder()
+        .withId(id)
+        .withName(name)
+        .withNamespace(namespace)
+        .withComment("test function comment")
+        .withFunctionType(FunctionType.SCALAR)
+        .withDeterministic(false)
+        .withReturnType(Types.IntegerType.get())
+        .withDefinitions(new FunctionDefinition[] {definition})
+        .withAuditInfo(auditInfo)
+        .build();
+  }
+
+  private Map<Integer, Long> listFunctionVersions(Long functionId) {
+    Map<Integer, Long> versionDeletedTime = new HashMap<>();
+    try (SqlSession sqlSession =
+            SqlSessionFactoryHelper.getInstance().getSqlSessionFactory().openSession(true);
+        Connection connection = sqlSession.getConnection();
+        Statement statement = connection.createStatement();
+        ResultSet rs =
+            statement.executeQuery(
+                String.format(
+                    "SELECT version, deleted_at FROM function_version_info WHERE function_id = %d",
+                    functionId))) {
+      while (rs.next()) {
+        versionDeletedTime.put(rs.getInt("version"), rs.getLong("deleted_at"));
+      }
+    } catch (SQLException e) {
+      throw new RuntimeException("SQL execution failed", e);
+    }
+    return versionDeletedTime;
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR implements the storage layer for UDF (User-Defined Function) persistence in the relational database backend. It adds the necessary components to persist function metadata to MySQL, PostgreSQL, and H2 databases.

### Why are the changes needed?

This is part of the UDF management feature (issue #9528). The storage layer is required to persist function metadata, including function definitions, implementations, and version information.

Fix: #9528

### Does this PR introduce _any_ user-facing change?

No. This PR adds internal storage layer support only.

### How was this patch tested?

- Added unit tests for `FunctionMetaService` (`TestFunctionMetaService`)
- Updated `TestJDBCBackend` to include FUNCTION entity type