### PR TITLE
[#9630] chore(release): update lance REST chart versions in release-tag script

### DIFF
--- a/dev/release/release-tag.sh
+++ b/dev/release/release-tag.sh
@@ -144,23 +144,28 @@ git tag $RELEASE_TAG
 sed -i".tmp14" 's/version = .*$/version = '"$NEXT_VERSION"'/g' gradle.properties
 sed -i".tmp15" 's/    version=.*$/    version="'"$PYGRAVITINO_NEXT_VERSION"'",/g' clients/client-python/setup.py
 sed -i".tmp16" 's/^version = .*$/version = \"'"$NEXT_VERSION"'\"/g' clients/filesystem-fuse/Cargo.toml
+
+# Increase the chart version of Gravitino
 sed -i".tmp17" 's/appVersion: .*$/appVersion: '"$NEXT_VERSION"'/g' dev/charts/gravitino/Chart.yaml
 sed -i".tmp18" '34s/  tag: .*$/  tag: '"$NEXT_VERSION"'/g' dev/charts/gravitino/values.yaml
 CHART_REV=$((CHART_REV + 1))
 NEXT_CHART_VERSION="${CHART_SHORT_VERSION}.${CHART_REV}"
 sed -i".tmp19" 's/^version: .*$/version: '"$NEXT_CHART_VERSION"'/g' dev/charts/gravitino/Chart.yaml
 
+# Increase the chart version of Gravitino Iceberg REST server chart
 IRC_CHART_REV=$((IRC_CHART_REV + 1))
 NEXT_IRC_CHART_VERSION="${IRC_CHART_SHORT_VERSION}.${IRC_CHART_REV}"
 sed -i".tmp20" 's/appVersion: .*$/appVersion: '"$NEXT_VERSION"'/g' dev/charts/gravitino-iceberg-rest-server/Chart.yaml
 sed -i".tmp21" '24s/  tag: .*$/  tag: '"$NEXT_VERSION"'/g' dev/charts/gravitino-iceberg-rest-server/values.yaml
 sed -i".tmp22" 's/^version: .*$/version: '"$NEXT_IRC_CHART_VERSION"'/g' dev/charts/gravitino-iceberg-rest-server/Chart.yaml
 
+# Increase the chart version of Gravitino Lance REST server chart
 LRC_CHART_REV=$((LRC_CHART_REV + 1))
 NEXT_LRC_CHART_VERSION="${LRC_CHART_SHORT_VERSION}.${LRC_CHART_REV}"
 sed -i".tmp23" 's/appVersion: .*$/appVersion: '"$NEXT_VERSION"'/g' dev/charts/gravitino-lance-rest-server/Chart.yaml
 sed -i".tmp24" '30s/  tag: .*$/  tag: '"$NEXT_VERSION"'/g' dev/charts/gravitino-lance-rest-server/values.yaml
 sed -i".tmp25" 's/^version: .*$/version: '"$NEXT_LRC_CHART_VERSION"'/g' dev/charts/gravitino-lance-rest-server/Chart.yaml
+
 sed -i".tmp26" 's/^version = .*$/version = "'"$PYGRAVITINO_NEXT_VERSION"'"/g' mcp-server/pyproject.toml
 
 git commit -a -m "Preparing development version $NEXT_VERSION"


### PR DESCRIPTION
### What changes were proposed in this pull request?


- Extend `dev/release/release-tag.sh` to update the Lance REST Helm chart (`dev/charts/gravitino-lance-rest-server`) during both the release and next-development version steps.
- Align Lance chart `appVersion`, image `tag` in `values.yaml`, and chart `version` bumping with the existing logic used for the core and Iceberg REST charts.

### Why are the changes needed?

- Previously, the release script only bumped the core and Iceberg REST charts, leaving the Lance REST chart out of version/tag synchronization. This change keeps all three charts in lockstep for releases and subsequent snapshot development.

Fix: #9630 

### Does this PR introduce _any_ user-facing change?

- No user-facing API change. Chart metadata (`appVersion`/`tag`/`version`) now updates consistently for Lance REST alongside other charts during the release workflow.

### How was this patch tested?

- Manual simulation in a temporary directory: copied the three charts and executed the same sed-based update flow to confirm `appVersion`, `tag`, and chart `version` are updated in all three charts.
