### PR TITLE
[#9606] improvment(lance): enhance table registration to support existing datasets and schema extraction

### DIFF
--- a/catalogs/catalog-lakehouse-generic/src/main/java/org/apache/gravitino/catalog/lakehouse/lance/LanceTableOperations.java
+++ b/catalogs/catalog-lakehouse-generic/src/main/java/org/apache/gravitino/catalog/lakehouse/lance/LanceTableOperations.java
@@ -48,6 +48,7 @@ import org.apache.gravitino.exceptions.NoSuchTableException;
 import org.apache.gravitino.exceptions.TableAlreadyExistsException;
 import org.apache.gravitino.lance.common.ops.gravitino.LanceDataTypeConverter;
 import org.apache.gravitino.lance.common.utils.ArrowUtils;
+import org.apache.gravitino.lance.common.utils.LanceConstants;
 import org.apache.gravitino.lance.common.utils.LancePropertiesUtils;
 import org.apache.gravitino.rel.Column;
 import org.apache.gravitino.rel.Table;
@@ -284,6 +285,18 @@ public class LanceTableOperations extends ManagedTableOperations {
             e);
       }
 
+      return super.createTable(
+          ident, columns, comment, properties, partitions, distribution, sortOrders, indexes);
+    }
+
+    // Check whether it's a create empty table operation.
+    boolean createEmpty =
+        Optional.ofNullable(properties.get(LanceConstants.LANCE_TABLE_CREATE_EMPTY))
+            .map(Boolean::parseBoolean)
+            .orElse(false);
+    if (createEmpty) {
+      // For create empty table, we just create the table metadata in Gravitino without creating
+      // the underlying Lance dataset.
       return super.createTable(
           ident, columns, comment, properties, partitions, distribution, sortOrders, indexes);
     }

--- a/catalogs/catalog-lakehouse-generic/src/main/java/org/apache/gravitino/catalog/lakehouse/lance/LanceTableOperations.java
+++ b/catalogs/catalog-lakehouse-generic/src/main/java/org/apache/gravitino/catalog/lakehouse/lance/LanceTableOperations.java
@@ -264,7 +264,7 @@ public class LanceTableOperations extends ManagedTableOperations {
     Map<String, String> storageProps = LancePropertiesUtils.getLanceStorageOptions(properties);
     if (register) {
       // Try to check if the Lance dataset exists at the location and then extract the schema.
-      // Note: We will ignore the columns parameter in this case.
+      // Note: We will ignore the column parameter in this case.
       LOG.warn(
           "Registering existing Lance table at location {}. The provided schema will be ignored. columns: {}",
           location,

--- a/catalogs/catalog-lakehouse-generic/src/main/java/org/apache/gravitino/catalog/lakehouse/lance/LanceTableOperations.java
+++ b/catalogs/catalog-lakehouse-generic/src/main/java/org/apache/gravitino/catalog/lakehouse/lance/LanceTableOperations.java
@@ -23,6 +23,7 @@ import static org.apache.gravitino.lance.common.utils.LanceConstants.LANCE_TABLE
 
 import com.google.common.base.Preconditions;
 import com.lancedb.lance.Dataset;
+import com.lancedb.lance.ReadOptions;
 import com.lancedb.lance.WriteParams;
 import com.lancedb.lance.index.DistanceType;
 import com.lancedb.lance.index.IndexParams;
@@ -35,6 +36,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.Schema;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.gravitino.EntityStore;
 import org.apache.gravitino.NameIdentifier;
@@ -45,6 +47,7 @@ import org.apache.gravitino.exceptions.NoSuchSchemaException;
 import org.apache.gravitino.exceptions.NoSuchTableException;
 import org.apache.gravitino.exceptions.TableAlreadyExistsException;
 import org.apache.gravitino.lance.common.ops.gravitino.LanceDataTypeConverter;
+import org.apache.gravitino.lance.common.utils.ArrowUtils;
 import org.apache.gravitino.lance.common.utils.LancePropertiesUtils;
 import org.apache.gravitino.rel.Column;
 import org.apache.gravitino.rel.Table;
@@ -258,12 +261,33 @@ public class LanceTableOperations extends ManagedTableOperations {
       String location)
       throws NoSuchSchemaException, TableAlreadyExistsException {
 
+    Map<String, String> storageProps = LancePropertiesUtils.getLanceStorageOptions(properties);
     if (register) {
+      // Try to check if the Lance dataset exists at the location and then extract the schema.
+      // Note: We will ignore the columns parameter in this case.
+      LOG.warn(
+          "Registering existing Lance table at location {}. The provided schema will be ignored. columns: {}",
+          location,
+          Arrays.toString(columns));
+
+      try (Dataset readDataset =
+          Dataset.open(
+              location, new ReadOptions.Builder().setStorageOptions(storageProps).build())) {
+        Schema schema = readDataset.getSchema();
+        List<Column> existingColumns = ArrowUtils.extractColumns(schema);
+        columns = existingColumns.toArray(new Column[0]);
+      } catch (Exception e) {
+        throw new IllegalArgumentException(
+            String.format(
+                "Failed to register Lance table. No existing Lance dataset found at location %s",
+                location),
+            e);
+      }
+
       return super.createTable(
           ident, columns, comment, properties, partitions, distribution, sortOrders, indexes);
     }
 
-    Map<String, String> storageProps = LancePropertiesUtils.getLanceStorageOptions(properties);
     try (Dataset ignored =
         Dataset.create(
             new RootAllocator(),

--- a/catalogs/catalog-lakehouse-generic/src/test/java/org/apache/gravitino/catalog/lakehouse/lance/integration/test/CatalogGenericCatalogLanceIT.java
+++ b/catalogs/catalog-lakehouse-generic/src/test/java/org/apache/gravitino/catalog/lakehouse/lance/integration/test/CatalogGenericCatalogLanceIT.java
@@ -932,7 +932,7 @@ public class CatalogGenericCatalogLanceIT extends BaseIT {
                 newTableIdentifier,
                 new Column[0],
                 TABLE_COMMENT,
-                properties,
+                newCreateProperties,
                 Transforms.EMPTY_TRANSFORM,
                 Distributions.NONE,
                 new SortOrder[0]);

--- a/lance/lance-rest-server/build.gradle.kts
+++ b/lance/lance-rest-server/build.gradle.kts
@@ -86,7 +86,6 @@ dependencies {
     exclude(group = "com.lancedb", module = "lance-namespace-core") // This is unnecessary in the core module
   }
 
-
   testImplementation(libs.junit.jupiter.api)
   testImplementation(libs.mockito.inline)
   testImplementation(libs.mysql.driver)

--- a/lance/lance-rest-server/build.gradle.kts
+++ b/lance/lance-rest-server/build.gradle.kts
@@ -74,6 +74,19 @@ dependencies {
     exclude(group = "org.junit.jupiter")
   }
 
+  testImplementation(libs.lance) {
+    exclude(group = "com.fasterxml.jackson.core", module = "*") // provided by gravitino
+    exclude(group = "com.fasterxml.jackson.datatype", module = "*") // provided by gravitino
+    exclude(group = "commons-codec", module = "commons-codec") // provided by jcasbin
+    exclude(group = "com.google.guava", module = "guava") // provided by gravitino
+    exclude(group = "org.apache.commons", module = "commons-lang3") // provided by gravitino
+    exclude(group = "org.junit.jupiter", module = "*") // provided by test scope
+    exclude(group = "com.fasterxml.jackson.jaxrs", module = "jackson-jaxrs-json-provider") // using gravitino's version
+    exclude(group = "org.apache.httpcomponents.client5", module = "*") // provided by gravitino
+    exclude(group = "com.lancedb", module = "lance-namespace-core") // This is unnecessary in the core module
+  }
+
+
   testImplementation(libs.junit.jupiter.api)
   testImplementation(libs.mockito.inline)
   testImplementation(libs.mysql.driver)

--- a/lance/lance-rest-server/src/test/java/org/apache/gravitino/lance/integration/test/LanceRESTServiceIT.java
+++ b/lance/lance-rest-server/src/test/java/org/apache/gravitino/lance/integration/test/LanceRESTServiceIT.java
@@ -708,7 +708,7 @@ public class LanceRESTServiceIT extends BaseIT {
     try (Dataset dataset =
         Dataset.create(allocator, location, schema, new WriteParams.Builder().build())) {
     } catch (Exception e) {
-      throw new RuntimeException(e);
+      throw new RuntimeException("Failed to create Lance dataset at location: " + location, e);
     }
   }
 


### PR DESCRIPTION

### What changes were proposed in this pull request?

This pull request refactors and improves the handling of Lance table registration in the Gravitino catalog, especially around registering existing tables and schema extraction. The changes centralize Arrow schema/column conversion utilities, improve error handling for registering tables at non-existent locations, and update tests to reflect the new behavior and utilities.


### Why are the changes needed?

We need to 
1. Check the existence of the Lance table when registering it.
2. We need to extract the schema from the Lance table when registering

Fix: #9606 
Fix: #9516

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

UTs and ITs