### PR TITLE
[#9792] improvement(lance): Add dataset version handling in table operations

### DIFF
--- a/lance/lance-common/src/main/java/org/apache/gravitino/lance/common/ops/gravitino/GravitinoLanceTableOperations.java
+++ b/lance/lance-common/src/main/java/org/apache/gravitino/lance/common/ops/gravitino/GravitinoLanceTableOperations.java
@@ -24,6 +24,7 @@ import static org.apache.gravitino.lance.common.utils.LanceConstants.LANCE_CREAT
 import static org.apache.gravitino.lance.common.utils.LanceConstants.LANCE_LOCATION;
 import static org.apache.gravitino.lance.common.utils.LanceConstants.LANCE_TABLE_CREATE_EMPTY;
 import static org.apache.gravitino.lance.common.utils.LanceConstants.LANCE_TABLE_FORMAT;
+import static org.apache.gravitino.lance.common.utils.LanceConstants.LANCE_TABLE_VERSION;
 import static org.apache.gravitino.rel.Column.DEFAULT_VALUE_NOT_SET;
 
 import com.google.common.base.Preconditions;
@@ -92,7 +93,10 @@ public class GravitinoLanceTableOperations implements LanceTableOperations {
     response.setProperties(table.properties());
     response.setLocation(table.properties().get(LANCE_LOCATION));
     response.setSchema(toJsonArrowSchema(table.columns()));
-    response.setVersion(null);
+    response.setVersion(
+        Optional.ofNullable(table.properties().get(LANCE_TABLE_VERSION))
+            .map(Long::valueOf)
+            .orElse(null));
     response.setStorageOptions(LancePropertiesUtils.getLanceStorageOptions(table.properties()));
     return response;
   }
@@ -147,7 +151,10 @@ public class GravitinoLanceTableOperations implements LanceTableOperations {
     // Extract storage options from table properties. All storage options stores in table
     // properties.
     response.setStorageOptions(LancePropertiesUtils.getLanceStorageOptions(t.properties()));
-    response.setVersion(null);
+    response.setVersion(
+        Optional.ofNullable(t.properties().get(LANCE_TABLE_VERSION))
+            .map(Long::valueOf)
+            .orElse(null));
     response.setLocation(t.properties().get(LANCE_LOCATION));
     response.setProperties(t.properties());
     return response;

--- a/lance/lance-common/src/main/java/org/apache/gravitino/lance/common/utils/LanceConstants.java
+++ b/lance/lance-common/src/main/java/org/apache/gravitino/lance/common/utils/LanceConstants.java
@@ -37,6 +37,7 @@ public class LanceConstants {
 
   public static final String LANCE_TABLE_REGISTER = "lance.register";
 
+  public static final String LANCE_TABLE_VERSION = "lance.version";
   // Mark whether it is to create an empty Lance table(no data files)
   public static final String LANCE_TABLE_CREATE_EMPTY = "lance.create-empty";
 

--- a/lance/lance-rest-server/src/test/java/org/apache/gravitino/lance/integration/test/LanceRESTServiceIT.java
+++ b/lance/lance-rest-server/src/test/java/org/apache/gravitino/lance/integration/test/LanceRESTServiceIT.java
@@ -500,12 +500,14 @@ public class LanceRESTServiceIT extends BaseIT {
     Assertions.assertEquals("v1", response.getProperties().get("key1"));
     Assertions.assertEquals("value_a", response.getStorageOptions().get("a"));
     Assertions.assertEquals("value_b", response.getStorageOptions().get("b"));
+    Assertions.assertNotNull(response.getVersion());
 
     DescribeTableRequest describeTableRequest = new DescribeTableRequest();
     describeTableRequest.setId(ids);
     DescribeTableResponse loadTable = ns.describeTable(describeTableRequest);
     Assertions.assertNotNull(loadTable);
     Assertions.assertEquals(location, loadTable.getLocation());
+    Assertions.assertNotNull(loadTable.getVersion());
 
     List<JsonArrowField> jsonArrowFields = loadTable.getSchema().getFields();
     for (int i = 0; i < jsonArrowFields.size(); i++) {


### PR DESCRIPTION

### What changes were proposed in this pull request?

This pull request introduces support for tracking and returning the version of a Lance table throughout its creation and description APIs. The changes ensure that the table version is stored as a property, propagated through responses, and verified in integration tests.

### Why are the changes needed?

Make APIs in the Lance REST server according to the docs.

Fix: #9792

### Does this PR introduce _any_ user-facing change?

N/A.

### How was this patch tested?

ITs
