### PR TITLE
[#9528] feat(storage): support function management (PO) (part-1)

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/core/src/main/java/org/apache/gravitino/storage/relational/po/FunctionMaxVersionPO.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/po/FunctionMaxVersionPO.java
@@ -18,31 +18,23 @@
  */
 package org.apache.gravitino.storage.relational.po;
 
-import com.google.common.base.Objects;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import lombok.experimental.Accessors;
 
+@Getter
+@Accessors(fluent = true)
+@EqualsAndHashCode
+@ToString
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(setterPrefix = "with")
 public class FunctionMaxVersionPO {
   private Long functionId;
   private Long version;
-
-  public Long getFunctionId() {
-    return functionId;
-  }
-
-  public Long getVersion() {
-    return version;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) return true;
-    if (!(o instanceof FunctionMaxVersionPO)) return false;
-    FunctionMaxVersionPO that = (FunctionMaxVersionPO) o;
-    return Objects.equal(getFunctionId(), that.getFunctionId())
-        && Objects.equal(getVersion(), that.getVersion());
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hashCode(getFunctionId(), getVersion());
-  }
 }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/po/FunctionPO.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/po/FunctionPO.java
@@ -21,10 +21,14 @@ package org.apache.gravitino.storage.relational.po;
 import com.google.common.base.Preconditions;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.ToString;
+import lombok.experimental.Accessors;
 import org.apache.commons.lang3.StringUtils;
 
 @EqualsAndHashCode
 @Getter
+@ToString
+@Accessors(fluent = true)
 public class FunctionPO {
 
   private Long functionId;
@@ -53,123 +57,50 @@ public class FunctionPO {
 
   private FunctionVersionPO functionVersionPO;
 
-  private FunctionPO() {}
+  public FunctionPO() {}
 
-  public static Builder builder() {
-    return new Builder();
-  }
+  @lombok.Builder(setterPrefix = "with")
+  private FunctionPO(
+      Long functionId,
+      String functionName,
+      Long metalakeId,
+      Long catalogId,
+      Long schemaId,
+      String functionType,
+      Integer deterministic,
+      String returnType,
+      Integer functionLatestVersion,
+      Integer functionCurrentVersion,
+      String auditInfo,
+      Long deletedAt,
+      FunctionVersionPO functionVersionPO) {
+    Preconditions.checkArgument(functionId != null, "Function id is required");
+    Preconditions.checkArgument(
+        StringUtils.isNotBlank(functionName), "Function name cannot be empty");
+    Preconditions.checkArgument(metalakeId != null, "Metalake id is required");
+    Preconditions.checkArgument(catalogId != null, "Catalog id is required");
+    Preconditions.checkArgument(schemaId != null, "Schema id is required");
+    Preconditions.checkArgument(
+        StringUtils.isNotBlank(functionType), "Function type cannot be empty");
+    Preconditions.checkArgument(
+        functionLatestVersion != null, "Function latest version is required");
+    Preconditions.checkArgument(
+        functionCurrentVersion != null, "Function current version is required");
+    Preconditions.checkArgument(StringUtils.isNotBlank(auditInfo), "Audit info cannot be empty");
+    Preconditions.checkArgument(deletedAt != null, "Deleted at is required");
 
-  public static class Builder {
-
-    private final FunctionPO functionPO;
-
-    private Builder() {
-      functionPO = new FunctionPO();
-    }
-
-    public Builder withFunctionId(Long functionId) {
-      functionPO.functionId = functionId;
-      return this;
-    }
-
-    public Builder withFunctionName(String functionName) {
-      functionPO.functionName = functionName;
-      return this;
-    }
-
-    public Builder withMetalakeId(Long metalakeId) {
-      functionPO.metalakeId = metalakeId;
-      return this;
-    }
-
-    public Builder withCatalogId(Long catalogId) {
-      functionPO.catalogId = catalogId;
-      return this;
-    }
-
-    public Builder withSchemaId(Long schemaId) {
-      functionPO.schemaId = schemaId;
-      return this;
-    }
-
-    public Builder withFunctionType(String functionType) {
-      functionPO.functionType = functionType;
-      return this;
-    }
-
-    public Builder withDeterministic(Integer deterministic) {
-      functionPO.deterministic = deterministic;
-      return this;
-    }
-
-    public Builder withReturnType(String returnType) {
-      functionPO.returnType = returnType;
-      return this;
-    }
-
-    public Builder withFunctionLatestVersion(Integer functionLatestVersion) {
-      functionPO.functionLatestVersion = functionLatestVersion;
-      return this;
-    }
-
-    public Builder withFunctionCurrentVersion(Integer functionCurrentVersion) {
-      functionPO.functionCurrentVersion = functionCurrentVersion;
-      return this;
-    }
-
-    public Builder withAuditInfo(String auditInfo) {
-      functionPO.auditInfo = auditInfo;
-      return this;
-    }
-
-    public Builder withDeletedAt(Long deletedAt) {
-      functionPO.deletedAt = deletedAt;
-      return this;
-    }
-
-    public Builder withFunctionVersionPO(FunctionVersionPO functionVersionPO) {
-      functionPO.functionVersionPO = functionVersionPO;
-      return this;
-    }
-
-    public Long getMetalakeId() {
-      Preconditions.checkState(functionPO.metalakeId != null, "Metalake id is null");
-      return functionPO.metalakeId;
-    }
-
-    public Long getCatalogId() {
-      Preconditions.checkState(functionPO.catalogId != null, "Catalog id is null");
-      return functionPO.catalogId;
-    }
-
-    public Long getSchemaId() {
-      Preconditions.checkState(functionPO.schemaId != null, "Schema id is null");
-      return functionPO.schemaId;
-    }
-
-    public Integer getFunctionCurrentVersion() {
-      Preconditions.checkState(
-          functionPO.functionCurrentVersion != null, "Function current version is null");
-      return functionPO.functionCurrentVersion;
-    }
-
-    public FunctionPO build() {
-      Preconditions.checkArgument(functionPO.functionId != null, "Function id is required");
-      Preconditions.checkArgument(
-          StringUtils.isNotBlank(functionPO.functionName), "Function name cannot be empty");
-      Preconditions.checkArgument(functionPO.metalakeId != null, "Metalake id is required");
-      Preconditions.checkArgument(functionPO.catalogId != null, "Catalog id is required");
-      Preconditions.checkArgument(functionPO.schemaId != null, "Schema id is required");
-      Preconditions.checkArgument(
-          StringUtils.isNotBlank(functionPO.functionType), "Function type cannot be empty");
-      Preconditions.checkArgument(
-          functionPO.functionLatestVersion != null, "Function latest version is required");
-      Preconditions.checkArgument(
-          functionPO.functionCurrentVersion != null, "Function current version is required");
-      Preconditions.checkArgument(
-          StringUtils.isNotBlank(functionPO.auditInfo), "Audit info cannot be empty");
-      Preconditions.checkArgument(functionPO.deletedAt != null, "Deleted at is required");
-      return functionPO;
-    }
+    this.functionId = functionId;
+    this.functionName = functionName;
+    this.metalakeId = metalakeId;
+    this.catalogId = catalogId;
+    this.schemaId = schemaId;
+    this.functionType = functionType;
+    this.deterministic = deterministic;
+    this.returnType = returnType;
+    this.functionLatestVersion = functionLatestVersion;
+    this.functionCurrentVersion = functionCurrentVersion;
+    this.auditInfo = auditInfo;
+    this.deletedAt = deletedAt;
+    this.functionVersionPO = functionVersionPO;
   }
 }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/po/FunctionVersionPO.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/po/FunctionVersionPO.java
@@ -21,10 +21,14 @@ package org.apache.gravitino.storage.relational.po;
 import com.google.common.base.Preconditions;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.ToString;
+import lombok.experimental.Accessors;
 import org.apache.commons.lang3.StringUtils;
 
 @EqualsAndHashCode
 @Getter
+@ToString
+@Accessors(fluent = true)
 public class FunctionVersionPO {
 
   private Long id;
@@ -47,76 +51,35 @@ public class FunctionVersionPO {
 
   private Long deletedAt;
 
-  private FunctionVersionPO() {}
+  public FunctionVersionPO() {}
 
-  public static Builder builder() {
-    return new Builder();
-  }
+  @lombok.Builder(setterPrefix = "with")
+  private FunctionVersionPO(
+      Long id,
+      Long functionId,
+      Long metalakeId,
+      Long catalogId,
+      Long schemaId,
+      Integer functionVersion,
+      String functionComment,
+      String definitions,
+      String auditInfo,
+      Long deletedAt) {
+    Preconditions.checkArgument(functionId != null, "Function id is required");
+    Preconditions.checkArgument(functionVersion != null, "Function version is required");
+    Preconditions.checkArgument(StringUtils.isNotBlank(definitions), "Definitions cannot be empty");
+    Preconditions.checkArgument(StringUtils.isNotBlank(auditInfo), "Audit info cannot be empty");
+    Preconditions.checkArgument(deletedAt != null, "Deleted at is required");
 
-  public static class Builder {
-
-    private final FunctionVersionPO functionVersionPO;
-
-    private Builder() {
-      functionVersionPO = new FunctionVersionPO();
-    }
-
-    public Builder withFunctionId(Long functionId) {
-      functionVersionPO.functionId = functionId;
-      return this;
-    }
-
-    public Builder withMetalakeId(Long metalakeId) {
-      functionVersionPO.metalakeId = metalakeId;
-      return this;
-    }
-
-    public Builder withCatalogId(Long catalogId) {
-      functionVersionPO.catalogId = catalogId;
-      return this;
-    }
-
-    public Builder withSchemaId(Long schemaId) {
-      functionVersionPO.schemaId = schemaId;
-      return this;
-    }
-
-    public Builder withFunctionVersion(Integer functionVersion) {
-      functionVersionPO.functionVersion = functionVersion;
-      return this;
-    }
-
-    public Builder withFunctionComment(String functionComment) {
-      functionVersionPO.functionComment = functionComment;
-      return this;
-    }
-
-    public Builder withDefinitions(String definitions) {
-      functionVersionPO.definitions = definitions;
-      return this;
-    }
-
-    public Builder withAuditInfo(String auditInfo) {
-      functionVersionPO.auditInfo = auditInfo;
-      return this;
-    }
-
-    public Builder withDeletedAt(Long deletedAt) {
-      functionVersionPO.deletedAt = deletedAt;
-      return this;
-    }
-
-    public FunctionVersionPO build() {
-      Preconditions.checkArgument(functionVersionPO.functionId != null, "Function id is required");
-      Preconditions.checkArgument(
-          functionVersionPO.functionVersion != null, "Function version is required");
-      Preconditions.checkArgument(
-          StringUtils.isNotBlank(functionVersionPO.definitions), "Definitions cannot be empty");
-      Preconditions.checkArgument(
-          StringUtils.isNotBlank(functionVersionPO.auditInfo), "Audit info cannot be empty");
-      Preconditions.checkArgument(functionVersionPO.deletedAt != null, "Deleted at is required");
-
-      return functionVersionPO;
-    }
+    this.id = id;
+    this.functionId = functionId;
+    this.metalakeId = metalakeId;
+    this.catalogId = catalogId;
+    this.schemaId = schemaId;
+    this.functionVersion = functionVersion;
+    this.functionComment = functionComment;
+    this.definitions = definitions;
+    this.auditInfo = auditInfo;
+    this.deletedAt = deletedAt;
   }
 }

--- a/core/src/test/java/org/apache/gravitino/storage/relational/po/TestFunctionPO.java
+++ b/core/src/test/java/org/apache/gravitino/storage/relational/po/TestFunctionPO.java
@@ -1,0 +1,172 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.storage.relational.po;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TestFunctionPO {
+
+  @Test
+  public void testFunctionPOBuilder() {
+    FunctionPO functionPO =
+        FunctionPO.builder()
+            .withFunctionId(1L)
+            .withFunctionName("test-function")
+            .withMetalakeId(1L)
+            .withCatalogId(1L)
+            .withSchemaId(1L)
+            .withFunctionType("SCALAR")
+            .withDeterministic(1)
+            .withReturnType("STRING")
+            .withFunctionLatestVersion(1)
+            .withFunctionCurrentVersion(1)
+            .withAuditInfo("audit-info")
+            .withDeletedAt(0L)
+            .build();
+
+    Assertions.assertEquals(1L, functionPO.functionId());
+    Assertions.assertEquals("test-function", functionPO.functionName());
+    Assertions.assertEquals(1L, functionPO.metalakeId());
+    Assertions.assertEquals(1L, functionPO.catalogId());
+    Assertions.assertEquals(1L, functionPO.schemaId());
+    Assertions.assertEquals("SCALAR", functionPO.functionType());
+    Assertions.assertEquals(1, functionPO.deterministic());
+    Assertions.assertEquals("STRING", functionPO.returnType());
+    Assertions.assertEquals(1, functionPO.functionLatestVersion());
+    Assertions.assertEquals(1, functionPO.functionCurrentVersion());
+    Assertions.assertEquals("audit-info", functionPO.auditInfo());
+    Assertions.assertEquals(0L, functionPO.deletedAt());
+  }
+
+  @Test
+  public void testFunctionVersionPOBuilder() {
+    FunctionVersionPO functionVersionPO =
+        FunctionVersionPO.builder()
+            .withId(1L)
+            .withFunctionId(1L)
+            .withMetalakeId(1L)
+            .withCatalogId(1L)
+            .withSchemaId(1L)
+            .withFunctionVersion(1)
+            .withFunctionComment("test-comment")
+            .withDefinitions("definitions")
+            .withAuditInfo("audit-info")
+            .withDeletedAt(0L)
+            .build();
+
+    Assertions.assertEquals(1L, functionVersionPO.id());
+    Assertions.assertEquals(1L, functionVersionPO.functionId());
+    Assertions.assertEquals(1L, functionVersionPO.metalakeId());
+    Assertions.assertEquals(1L, functionVersionPO.catalogId());
+    Assertions.assertEquals(1L, functionVersionPO.schemaId());
+    Assertions.assertEquals(1, functionVersionPO.functionVersion());
+    Assertions.assertEquals("test-comment", functionVersionPO.functionComment());
+    Assertions.assertEquals("definitions", functionVersionPO.definitions());
+    Assertions.assertEquals("audit-info", functionVersionPO.auditInfo());
+    Assertions.assertEquals(0L, functionVersionPO.deletedAt());
+  }
+
+  @Test
+  public void testFunctionMaxVersionPOBuilder() {
+    FunctionMaxVersionPO functionMaxVersionPO =
+        FunctionMaxVersionPO.builder().withFunctionId(1L).withVersion(1L).build();
+
+    Assertions.assertEquals(1L, functionMaxVersionPO.functionId());
+    Assertions.assertEquals(1L, functionMaxVersionPO.version());
+  }
+
+  @Test
+  public void testEqualsAndHashCode() {
+    FunctionPO functionPO1 =
+        FunctionPO.builder()
+            .withFunctionId(1L)
+            .withFunctionName("test-function")
+            .withMetalakeId(1L)
+            .withCatalogId(1L)
+            .withSchemaId(1L)
+            .withFunctionType("SCALAR")
+            .withDeterministic(1)
+            .withReturnType("STRING")
+            .withFunctionLatestVersion(1)
+            .withFunctionCurrentVersion(1)
+            .withAuditInfo("audit-info")
+            .withDeletedAt(0L)
+            .build();
+
+    FunctionPO functionPO2 =
+        FunctionPO.builder()
+            .withFunctionId(1L)
+            .withFunctionName("test-function")
+            .withMetalakeId(1L)
+            .withCatalogId(1L)
+            .withSchemaId(1L)
+            .withFunctionType("SCALAR")
+            .withDeterministic(1)
+            .withReturnType("STRING")
+            .withFunctionLatestVersion(1)
+            .withFunctionCurrentVersion(1)
+            .withAuditInfo("audit-info")
+            .withDeletedAt(0L)
+            .build();
+
+    Assertions.assertEquals(functionPO1, functionPO2);
+    Assertions.assertEquals(functionPO1.hashCode(), functionPO2.hashCode());
+
+    FunctionVersionPO functionVersionPO1 =
+        FunctionVersionPO.builder()
+            .withId(1L)
+            .withFunctionId(1L)
+            .withMetalakeId(1L)
+            .withCatalogId(1L)
+            .withSchemaId(1L)
+            .withFunctionVersion(1)
+            .withFunctionComment("test-comment")
+            .withDefinitions("definitions")
+            .withAuditInfo("audit-info")
+            .withDeletedAt(0L)
+            .build();
+
+    FunctionVersionPO functionVersionPO2 =
+        FunctionVersionPO.builder()
+            .withId(1L)
+            .withFunctionId(1L)
+            .withMetalakeId(1L)
+            .withCatalogId(1L)
+            .withSchemaId(1L)
+            .withFunctionVersion(1)
+            .withFunctionComment("test-comment")
+            .withDefinitions("definitions")
+            .withAuditInfo("audit-info")
+            .withDeletedAt(0L)
+            .build();
+
+    Assertions.assertEquals(functionVersionPO1, functionVersionPO2);
+    Assertions.assertEquals(functionVersionPO1.hashCode(), functionVersionPO2.hashCode());
+
+    FunctionMaxVersionPO functionMaxVersionPO1 =
+        FunctionMaxVersionPO.builder().withFunctionId(1L).withVersion(1L).build();
+
+    FunctionMaxVersionPO functionMaxVersionPO2 =
+        FunctionMaxVersionPO.builder().withFunctionId(1L).withVersion(1L).build();
+
+    Assertions.assertEquals(functionMaxVersionPO1, functionMaxVersionPO2);
+    Assertions.assertEquals(functionMaxVersionPO1.hashCode(), functionMaxVersionPO2.hashCode());
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

Introduce PO (Persistent Object) classes for Function management in relational storage.
- Added FunctionPO: Represents the base function metadata.
- Added FunctionVersionPO: Represents specific versions of a function.
- Added FunctionMaxVersionPO: Used for tracking function versions.

### Why are the changes needed?

These POs serve as the fundamental data structures for mapping database records to Java objects in the relational storage implementation of UDFs (User Defined Functions).

Fix: #9528

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Compiling and verified in subsequent commits.