### PR TITLE
[9817] fix(docs): Optimize documentation example errors

### DIFF
--- a/docs/manage-relational-metadata-using-gravitino.md
+++ b/docs/manage-relational-metadata-using-gravitino.md
@@ -844,7 +844,7 @@ Map<String, String> tablePropertiesMap = ImmutableMap.<String, String>builder()
 tableCatalog.createTable(
   NameIdentifier.of("schema", "example_table"),
   new Column[] {
-    Column.of("id", Types.IntegerType.get(), "id column comment", false, true, Literals.integerLiteral(-1)),
+    Column.of("id", Types.IntegerType.get(), "id column comment", false, true, Column.DEFAULT_VALUE_NOT_SET),
     Column.of("name", Types.VarCharType.of(500), "name column comment", true, false, Literals.NULL),
     Column.of("StartingDate", Types.TimestampType.withoutTimeZone(), "StartingDate column comment", false, false, Column.DEFAULT_VALUE_OF_CURRENT_TIMESTAMP),
     Column.of("info", Types.StructType.of(


### PR DESCRIPTION
### What changes were proposed in this pull request?

Modified the file `manage-relational-metadata-using-gravitino.md`

### Why does it need to change?

There is an incorrect example in the document. The two attributes of primary key auto-increment and default value are semantically conflicting.

Fix: #9817

### Does this PR introduce _any_ user-facing changes?

None

### How is this patch tested?

Only the documentation has been changed, no unit tests need to be added