### PR TITLE
[#9756] feat(catalogs): Support alternation operations for ClickHouse tables

### DIFF
--- a/catalogs-contrib/catalog-jdbc-clickhouse/src/test/java/org/apache/gravitino/catalog/clickhouse/operations/TestClickHouseTableOperations.java
+++ b/catalogs-contrib/catalog-jdbc-clickhouse/src/test/java/org/apache/gravitino/catalog/clickhouse/operations/TestClickHouseTableOperations.java
@@ -128,7 +128,7 @@ public class TestClickHouseTableOperations extends TestClickHouse {
         () -> TABLE_OPERATIONS.rename(TEST_DB_NAME.toString(), tableName, newName));
     Assertions.assertDoesNotThrow(() -> TABLE_OPERATIONS.load(TEST_DB_NAME.toString(), newName));
 
-    // alter table
+    // alter table add column
     JdbcColumn newColumn =
         JdbcColumn.builder()
             .withName("col_5")
@@ -261,6 +261,7 @@ public class TestClickHouseTableOperations extends TestClickHouse {
     assertionsTableInfo(
         tableName, tableComment, columns, properties, null, Transforms.EMPTY_TRANSFORM, load);
 
+    // Update column type
     TABLE_OPERATIONS.alterTable(
         TEST_DB_NAME.toString(),
         tableName,
@@ -1039,7 +1040,6 @@ public class TestClickHouseTableOperations extends TestClickHouse {
           TableChange.deleteColumn(new String[] {"c3"}, false),
           TableChange.updateColumnNullability(new String[] {"c2"}, false),
           TableChange.deleteIndex("idx1", false),
-          TableChange.updateColumnAutoIncrement(new String[] {"c1"}, true),
           TableChange.renameColumn(new String[] {"c2"}, "c2_new"),
           TableChange.updateComment("new_table_comment")
         };
@@ -1151,7 +1151,7 @@ public class TestClickHouseTableOperations extends TestClickHouse {
     ops.setTable(buildStubTable());
 
     Assertions.assertThrows(
-        IllegalArgumentException.class,
+        UnsupportedOperationException.class,
         () -> ops.buildAlterSql("db", "tbl", new TableChange[] {TableChange.removeProperty("k")}));
   }
 

--- a/catalogs/catalog-jdbc-common/src/main/java/org/apache/gravitino/catalog/jdbc/operation/JdbcTableOperations.java
+++ b/catalogs/catalog-jdbc-common/src/main/java/org/apache/gravitino/catalog/jdbc/operation/JdbcTableOperations.java
@@ -662,8 +662,7 @@ public abstract class JdbcTableOperations implements TableOperation {
   }
 
   protected boolean columnExists(JdbcTable table, String columnName) {
-    return Arrays.stream(table.columns())
-        .anyMatch(col -> col.name().equals(columnName));
+    return Arrays.stream(table.columns()).anyMatch(col -> col.name().equals(columnName));
   }
 
   protected Connection getConnection(String catalog) throws SQLException {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Support alternation operations for ClickHouse tables.

### Why are the changes needed?

It's a feature. 

Fix: #9756 

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

UTs
