### PR TITLE
[#8507] Add null check for namespace in ListTopicFailureEvent

### DIFF
--- a/core/src/main/java/org/apache/gravitino/listener/api/event/ListTopicFailureEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/ListTopicFailureEvent.java
@@ -45,8 +45,8 @@ public final class ListTopicFailureEvent extends TopicFailureEvent {
   }
 
   private static NameIdentifier toNameIdentifier(Namespace namespace) {
-     Preconditions.checkArgument(namespace != null, "namespace must not be null");
-     return NameIdentifier.of(namespace.levels());
+    Preconditions.checkArgument(namespace != null, "namespace must not be null");
+    return NameIdentifier.of(namespace.levels());
   }
 
   /**

--- a/core/src/test/java/org/apache/gravitino/listener/api/event/ListTopicFailureEventTest.java
+++ b/core/src/test/java/org/apache/gravitino/listener/api/event/ListTopicFailureEventTest.java
@@ -28,7 +28,7 @@ public class ListTopicFailureEventTest {
   public void testNamespaceMustNotBeNull() {
     Assertions.assertThrows(
         IllegalArgumentException.class,
-         () -> {
+        () -> {
           new ListTopicFailureEvent("user", null, new Exception());
         });
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Added a precondition check to ensure the namespace parameter is not null in `ListTopicFailureEvent` constructor using `Preconditions.checkNotNull()`.

### Why are the changes needed?

To prevent NullPointerException and fail fast with a clear error message when null namespace is passed to the constructor.

Fix: #8507

### Does this PR introduce any user-facing change?

No

### How was this patch tested?

Added unit test `testNamespaceMustNotBeNull()` to verify the null check throws NullPointerException when the namespace is null.