### PR TITLE
[#9816] fix(catalogs): Fix alter JDBC catalogs column default value problem(cherry-pick)

### DIFF
--- a/catalogs/catalog-jdbc-common/src/main/java/org/apache/gravitino/catalog/jdbc/operation/JdbcTableOperations.java
+++ b/catalogs/catalog-jdbc-common/src/main/java/org/apache/gravitino/catalog/jdbc/operation/JdbcTableOperations.java
@@ -18,6 +18,8 @@
  */
 package org.apache.gravitino.catalog.jdbc.operation;
 
+import static org.apache.gravitino.rel.Column.DEFAULT_VALUE_NOT_SET;
+
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import java.sql.Connection;
@@ -93,6 +95,14 @@ public abstract class JdbcTableOperations implements TableOperation {
     this.exceptionMapper = exceptionMapper;
     this.typeConverter = jdbcTypeConverter;
     this.columnDefaultValueConverter = jdbcColumnDefaultValueConverter;
+  }
+
+  protected void appendDefaultValue(JdbcColumn column, StringBuilder sqlBuilder) {
+    if (DEFAULT_VALUE_NOT_SET.equals(column.defaultValue())) {
+      return;
+    }
+    String defaultValue = columnDefaultValueConverter.fromGravitino(column.defaultValue());
+    sqlBuilder.append("DEFAULT ").append(defaultValue).append(SPACE);
   }
 
   @Override

--- a/catalogs/catalog-jdbc-doris/build.gradle.kts
+++ b/catalogs/catalog-jdbc-doris/build.gradle.kts
@@ -51,6 +51,7 @@ dependencies {
 
   testImplementation(libs.junit.jupiter.api)
   testImplementation(libs.junit.jupiter.params)
+  testImplementation(libs.mockito.core)
   testImplementation(libs.mysql.driver)
   testImplementation(libs.postgresql.driver)
   testImplementation(libs.testcontainers)

--- a/catalogs/catalog-jdbc-doris/src/main/java/org/apache/gravitino/catalog/doris/operation/DorisTableOperations.java
+++ b/catalogs/catalog-jdbc-doris/src/main/java/org/apache/gravitino/catalog/doris/operation/DorisTableOperations.java
@@ -24,6 +24,7 @@ import static org.apache.gravitino.catalog.doris.DorisTablePropertiesMetadata.RE
 import static org.apache.gravitino.catalog.doris.utils.DorisUtils.generatePartitionSqlFragment;
 import static org.apache.gravitino.rel.Column.DEFAULT_VALUE_NOT_SET;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import java.sql.Connection;
@@ -148,7 +149,8 @@ public class DorisTableOperations extends JdbcTableOperations {
     return result;
   }
 
-  private Map<String, String> appendNecessaryProperties(Map<String, String> properties) {
+  @VisibleForTesting
+  Map<String, String> appendNecessaryProperties(Map<String, String> properties) {
     Map<String, String> resultMap;
     if (properties == null) {
       resultMap = new HashMap<>();
@@ -749,12 +751,7 @@ public class DorisTableOperations extends JdbcTableOperations {
     }
 
     // Add DEFAULT value if specified
-    if (!DEFAULT_VALUE_NOT_SET.equals(column.defaultValue())) {
-      sqlBuilder
-          .append("DEFAULT ")
-          .append(columnDefaultValueConverter.fromGravitino(column.defaultValue()))
-          .append(SPACE);
-    }
+    appendDefaultValue(column, sqlBuilder);
 
     // Add column auto_increment if specified
     if (column.autoIncrement()) {

--- a/catalogs/catalog-jdbc-doris/src/test/java/org/apache/gravitino/catalog/doris/operation/TestDorisTableOperationsSqlGeneration.java
+++ b/catalogs/catalog-jdbc-doris/src/test/java/org/apache/gravitino/catalog/doris/operation/TestDorisTableOperationsSqlGeneration.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog.doris.operation;
+
+import java.util.Collections;
+import org.apache.gravitino.catalog.doris.converter.DorisTypeConverter;
+import org.apache.gravitino.catalog.jdbc.JdbcColumn;
+import org.apache.gravitino.catalog.jdbc.converter.JdbcColumnDefaultValueConverter;
+import org.apache.gravitino.catalog.jdbc.converter.JdbcExceptionConverter;
+import org.apache.gravitino.rel.expressions.NamedReference;
+import org.apache.gravitino.rel.expressions.distributions.Distribution;
+import org.apache.gravitino.rel.expressions.distributions.Distributions;
+import org.apache.gravitino.rel.expressions.literals.Literals;
+import org.apache.gravitino.rel.expressions.transforms.Transforms;
+import org.apache.gravitino.rel.indexes.Indexes;
+import org.apache.gravitino.rel.types.Types;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+public class TestDorisTableOperationsSqlGeneration {
+
+  private static class TestableDorisTableOperations extends DorisTableOperations {
+    public TestableDorisTableOperations() {
+      super.exceptionMapper = new JdbcExceptionConverter();
+      super.typeConverter = new DorisTypeConverter();
+      super.columnDefaultValueConverter = new JdbcColumnDefaultValueConverter();
+    }
+
+    public String createTableSql(
+        String tableName, JdbcColumn[] columns, Distribution distribution) {
+      return generateCreateTableSql(
+          tableName,
+          columns,
+          "comment",
+          Collections.emptyMap(),
+          Transforms.EMPTY_TRANSFORM,
+          distribution,
+          Indexes.EMPTY_INDEXES);
+    }
+  }
+
+  @Test
+  public void testCreateTableWithEmptyStringDefaultValue() {
+    TestableDorisTableOperations ops = new TestableDorisTableOperations();
+    String tableName = "test_table";
+    JdbcColumn col1 =
+        JdbcColumn.builder()
+            .withName("col1")
+            .withType(Types.IntegerType.get())
+            .withNullable(false)
+            .withDefaultValue(Literals.of("", Types.VarCharType.of(255)))
+            .build();
+    // Doris requires distribution
+    Distribution distribution = Distributions.hash(1, NamedReference.field("col1"));
+
+    TestableDorisTableOperations mockOps = Mockito.spy(ops);
+    Mockito.doAnswer(a -> a.getArgument(0))
+        .when(mockOps)
+        .appendNecessaryProperties(Mockito.anyMap());
+
+    String sql = mockOps.createTableSql(tableName, new JdbcColumn[] {col1}, distribution);
+    JdbcColumnDefaultValueConverter converter = new JdbcColumnDefaultValueConverter();
+    Assertions.assertTrue(
+        sql.contains("DEFAULT " + converter.fromGravitino(col1.defaultValue())),
+        "Should contain DEFAULT '' but was: " + sql);
+  }
+
+  @Test
+  public void testCreateTableWithNonEmptyStringDefaultValue() {
+    TestableDorisTableOperations ops = new TestableDorisTableOperations();
+    String tableName = "test_table";
+    JdbcColumn col1 =
+        JdbcColumn.builder()
+            .withName("col1")
+            .withType(Types.IntegerType.get())
+            .withNullable(false)
+            .withDefaultValue(Literals.of("abc", Types.VarCharType.of(255)))
+            .build();
+    // Doris requires distribution
+    Distribution distribution = Distributions.hash(1, NamedReference.field("col1"));
+
+    TestableDorisTableOperations mockOps = Mockito.spy(ops);
+    Mockito.doAnswer(a -> a.getArgument(0))
+        .when(mockOps)
+        .appendNecessaryProperties(Mockito.anyMap());
+
+    String sql = mockOps.createTableSql(tableName, new JdbcColumn[] {col1}, distribution);
+    JdbcColumnDefaultValueConverter converter = new JdbcColumnDefaultValueConverter();
+    Assertions.assertTrue(
+        sql.contains("DEFAULT " + converter.fromGravitino(col1.defaultValue())),
+        "Should contain DEFAULT value but was: " + sql);
+  }
+}

--- a/catalogs/catalog-jdbc-mysql/src/main/java/org/apache/gravitino/catalog/mysql/operation/MysqlTableOperations.java
+++ b/catalogs/catalog-jdbc-mysql/src/main/java/org/apache/gravitino/catalog/mysql/operation/MysqlTableOperations.java
@@ -618,12 +618,7 @@ public class MysqlTableOperations extends JdbcTableOperations {
     }
 
     // Add DEFAULT value if specified
-    if (!DEFAULT_VALUE_NOT_SET.equals(column.defaultValue())) {
-      sqlBuilder
-          .append("DEFAULT ")
-          .append(columnDefaultValueConverter.fromGravitino(column.defaultValue()))
-          .append(SPACE);
-    }
+    appendDefaultValue(column, sqlBuilder);
 
     // Add column auto_increment if specified
     if (column.autoIncrement()) {

--- a/catalogs/catalog-jdbc-mysql/src/test/java/org/apache/gravitino/catalog/mysql/operation/TestMysqlTableOperationsSqlGeneration.java
+++ b/catalogs/catalog-jdbc-mysql/src/test/java/org/apache/gravitino/catalog/mysql/operation/TestMysqlTableOperationsSqlGeneration.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog.mysql.operation;
+
+import java.util.Collections;
+import org.apache.gravitino.catalog.jdbc.JdbcColumn;
+import org.apache.gravitino.catalog.jdbc.converter.JdbcColumnDefaultValueConverter;
+import org.apache.gravitino.catalog.jdbc.converter.JdbcExceptionConverter;
+import org.apache.gravitino.catalog.mysql.converter.MysqlTypeConverter;
+import org.apache.gravitino.rel.expressions.distributions.Distributions;
+import org.apache.gravitino.rel.expressions.literals.Literals;
+import org.apache.gravitino.rel.expressions.transforms.Transforms;
+import org.apache.gravitino.rel.indexes.Indexes;
+import org.apache.gravitino.rel.types.Types;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TestMysqlTableOperationsSqlGeneration {
+
+  private static class TestableMysqlTableOperations extends MysqlTableOperations {
+    public TestableMysqlTableOperations() {
+      super.exceptionMapper = new JdbcExceptionConverter();
+      super.typeConverter = new MysqlTypeConverter();
+      super.columnDefaultValueConverter = new JdbcColumnDefaultValueConverter();
+    }
+
+    public String createTableSql(String tableName, JdbcColumn[] columns) {
+      return generateCreateTableSql(
+          tableName,
+          columns,
+          "comment",
+          Collections.emptyMap(),
+          Transforms.EMPTY_TRANSFORM,
+          Distributions.NONE,
+          Indexes.EMPTY_INDEXES);
+    }
+  }
+
+  @Test
+  public void testCreateTableWithEmptyStringDefaultValue() {
+    TestableMysqlTableOperations ops = new TestableMysqlTableOperations();
+    String tableName = "test_table";
+    JdbcColumn col1 =
+        JdbcColumn.builder()
+            .withName("col1")
+            .withType(Types.VarCharType.of(255))
+            .withNullable(false)
+            .withDefaultValue(Literals.of("", Types.VarCharType.of(255)))
+            .build();
+
+    String sql = ops.createTableSql(tableName, new JdbcColumn[] {col1});
+    JdbcColumnDefaultValueConverter converter = new JdbcColumnDefaultValueConverter();
+    Assertions.assertTrue(
+        sql.contains("DEFAULT " + converter.fromGravitino(col1.defaultValue())),
+        "Should contain DEFAULT '' but was: " + sql);
+  }
+
+  @Test
+  public void testCreateTableWithNonEmptyStringDefaultValue() {
+    TestableMysqlTableOperations ops = new TestableMysqlTableOperations();
+    String tableName = "test_table";
+    JdbcColumn col1 =
+        JdbcColumn.builder()
+            .withName("col1")
+            .withType(Types.VarCharType.of(255))
+            .withNullable(false)
+            .withDefaultValue(Literals.of("abc", Types.VarCharType.of(255)))
+            .build();
+
+    String sql = ops.createTableSql(tableName, new JdbcColumn[] {col1});
+    JdbcColumnDefaultValueConverter converter = new JdbcColumnDefaultValueConverter();
+    Assertions.assertTrue(
+        sql.contains("DEFAULT " + converter.fromGravitino(col1.defaultValue())),
+        "Should contain DEFAULT value but was: " + sql);
+  }
+}

--- a/catalogs/catalog-jdbc-oceanbase/src/main/java/org/apache/gravitino/catalog/oceanbase/operation/OceanBaseTableOperations.java
+++ b/catalogs/catalog-jdbc-oceanbase/src/main/java/org/apache/gravitino/catalog/oceanbase/operation/OceanBaseTableOperations.java
@@ -633,12 +633,7 @@ public class OceanBaseTableOperations extends JdbcTableOperations {
     }
 
     // Add DEFAULT value if specified
-    if (!DEFAULT_VALUE_NOT_SET.equals(column.defaultValue())) {
-      sqlBuilder
-          .append("DEFAULT ")
-          .append(columnDefaultValueConverter.fromGravitino(column.defaultValue()))
-          .append(SPACE);
-    }
+    appendDefaultValue(column, sqlBuilder);
 
     // Add column auto_increment if specified
     if (column.autoIncrement()) {

--- a/catalogs/catalog-jdbc-oceanbase/src/test/java/org/apache/gravitino/catalog/oceanbase/operation/TestOceanBaseTableOperationsSqlGeneration.java
+++ b/catalogs/catalog-jdbc-oceanbase/src/test/java/org/apache/gravitino/catalog/oceanbase/operation/TestOceanBaseTableOperationsSqlGeneration.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog.oceanbase.operation;
+
+import java.util.Collections;
+import org.apache.gravitino.catalog.jdbc.JdbcColumn;
+import org.apache.gravitino.catalog.jdbc.converter.JdbcColumnDefaultValueConverter;
+import org.apache.gravitino.catalog.jdbc.converter.JdbcExceptionConverter;
+import org.apache.gravitino.catalog.oceanbase.converter.OceanBaseTypeConverter;
+import org.apache.gravitino.rel.expressions.distributions.Distributions;
+import org.apache.gravitino.rel.expressions.literals.Literals;
+import org.apache.gravitino.rel.expressions.transforms.Transforms;
+import org.apache.gravitino.rel.indexes.Indexes;
+import org.apache.gravitino.rel.types.Types;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TestOceanBaseTableOperationsSqlGeneration {
+
+  private static class TestableOceanBaseTableOperations extends OceanBaseTableOperations {
+    public TestableOceanBaseTableOperations() {
+      super.exceptionMapper = new JdbcExceptionConverter();
+      super.typeConverter = new OceanBaseTypeConverter();
+      super.columnDefaultValueConverter = new JdbcColumnDefaultValueConverter();
+    }
+
+    public String createTableSql(String tableName, JdbcColumn[] columns) {
+      return generateCreateTableSql(
+          tableName,
+          columns,
+          "comment",
+          Collections.emptyMap(),
+          Transforms.EMPTY_TRANSFORM,
+          Distributions.NONE,
+          Indexes.EMPTY_INDEXES);
+    }
+  }
+
+  @Test
+  public void testCreateTableWithEmptyStringDefaultValue() {
+    TestableOceanBaseTableOperations ops = new TestableOceanBaseTableOperations();
+    String tableName = "test_table";
+    JdbcColumn col1 =
+        JdbcColumn.builder()
+            .withName("col1")
+            .withType(Types.VarCharType.of(255))
+            .withNullable(false)
+            .withDefaultValue(Literals.of("", Types.VarCharType.of(255)))
+            .build();
+
+    String sql = ops.createTableSql(tableName, new JdbcColumn[] {col1});
+    JdbcColumnDefaultValueConverter converter = new JdbcColumnDefaultValueConverter();
+    Assertions.assertTrue(
+        sql.contains("DEFAULT " + converter.fromGravitino(col1.defaultValue())),
+        "Should contain DEFAULT '' but was: " + sql);
+  }
+
+  @Test
+  public void testCreateTableWithNonEmptyStringDefaultValue() {
+    TestableOceanBaseTableOperations ops = new TestableOceanBaseTableOperations();
+    String tableName = "test_table";
+    JdbcColumn col1 =
+        JdbcColumn.builder()
+            .withName("col1")
+            .withType(Types.VarCharType.of(255))
+            .withNullable(false)
+            .withDefaultValue(Literals.of("abc", Types.VarCharType.of(255)))
+            .build();
+
+    String sql = ops.createTableSql(tableName, new JdbcColumn[] {col1});
+    JdbcColumnDefaultValueConverter converter = new JdbcColumnDefaultValueConverter();
+    Assertions.assertTrue(
+        sql.contains("DEFAULT " + converter.fromGravitino(col1.defaultValue())),
+        "Should contain DEFAULT value but was: " + sql);
+  }
+}

--- a/catalogs/catalog-jdbc-postgresql/src/main/java/org/apache/gravitino/catalog/postgresql/operation/PostgreSqlTableOperations.java
+++ b/catalogs/catalog-jdbc-postgresql/src/main/java/org/apache/gravitino/catalog/postgresql/operation/PostgreSqlTableOperations.java
@@ -18,8 +18,6 @@
  */
 package org.apache.gravitino.catalog.postgresql.operation;
 
-import static org.apache.gravitino.rel.Column.DEFAULT_VALUE_NOT_SET;
-
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
@@ -293,12 +291,7 @@ public class PostgreSqlTableOperations extends JdbcTableOperations
       sqlBuilder.append("NOT NULL ");
     }
     // Add DEFAULT value if specified
-    if (!DEFAULT_VALUE_NOT_SET.equals(column.defaultValue())) {
-      sqlBuilder
-          .append("DEFAULT ")
-          .append(columnDefaultValueConverter.fromGravitino(column.defaultValue()))
-          .append(SPACE);
-    }
+    appendDefaultValue(column, sqlBuilder);
   }
 
   @Override

--- a/catalogs/catalog-jdbc-postgresql/src/test/java/org/apache/gravitino/catalog/postgresql/operation/TestPostgreSqlTableOperationsSqlGeneration.java
+++ b/catalogs/catalog-jdbc-postgresql/src/test/java/org/apache/gravitino/catalog/postgresql/operation/TestPostgreSqlTableOperationsSqlGeneration.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog.postgresql.operation;
+
+import java.util.Collections;
+import org.apache.gravitino.catalog.jdbc.JdbcColumn;
+import org.apache.gravitino.catalog.jdbc.converter.JdbcColumnDefaultValueConverter;
+import org.apache.gravitino.catalog.jdbc.converter.JdbcExceptionConverter;
+import org.apache.gravitino.catalog.postgresql.converter.PostgreSqlTypeConverter;
+import org.apache.gravitino.rel.expressions.distributions.Distributions;
+import org.apache.gravitino.rel.expressions.literals.Literals;
+import org.apache.gravitino.rel.expressions.transforms.Transforms;
+import org.apache.gravitino.rel.indexes.Indexes;
+import org.apache.gravitino.rel.types.Types;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TestPostgreSqlTableOperationsSqlGeneration {
+
+  private static class TestablePostgreSqlTableOperations extends PostgreSqlTableOperations {
+    public TestablePostgreSqlTableOperations() {
+      super.exceptionMapper = new JdbcExceptionConverter();
+      super.typeConverter = new PostgreSqlTypeConverter();
+      super.columnDefaultValueConverter = new JdbcColumnDefaultValueConverter();
+    }
+
+    public String createTableSql(String tableName, JdbcColumn[] columns) {
+      return generateCreateTableSql(
+          tableName,
+          columns,
+          "comment",
+          Collections.emptyMap(),
+          Transforms.EMPTY_TRANSFORM,
+          Distributions.NONE,
+          Indexes.EMPTY_INDEXES);
+    }
+  }
+
+  @Test
+  public void testCreateTableWithEmptyStringDefaultValue() {
+    TestablePostgreSqlTableOperations ops = new TestablePostgreSqlTableOperations();
+    String tableName = "test_table";
+    JdbcColumn col1 =
+        JdbcColumn.builder()
+            .withName("col1")
+            .withType(Types.VarCharType.of(255))
+            .withNullable(false)
+            .withDefaultValue(Literals.of("", Types.VarCharType.of(255)))
+            .build();
+
+    String sql = ops.createTableSql(tableName, new JdbcColumn[] {col1});
+    JdbcColumnDefaultValueConverter converter = new JdbcColumnDefaultValueConverter();
+    Assertions.assertTrue(
+        sql.contains("DEFAULT " + converter.fromGravitino(col1.defaultValue())),
+        "Should contain DEFAULT '' but was: " + sql);
+  }
+
+  @Test
+  public void testCreateTableWithNonEmptyStringDefaultValue() {
+    TestablePostgreSqlTableOperations ops = new TestablePostgreSqlTableOperations();
+    String tableName = "test_table";
+    JdbcColumn col1 =
+        JdbcColumn.builder()
+            .withName("col1")
+            .withType(Types.VarCharType.of(255))
+            .withNullable(false)
+            .withDefaultValue(Literals.of("abc", Types.VarCharType.of(255)))
+            .build();
+
+    String sql = ops.createTableSql(tableName, new JdbcColumn[] {col1});
+    JdbcColumnDefaultValueConverter converter = new JdbcColumnDefaultValueConverter();
+    Assertions.assertTrue(
+        sql.contains("DEFAULT " + converter.fromGravitino(col1.defaultValue())),
+        "Should contain DEFAULT value but was: " + sql);
+  }
+}

--- a/catalogs/catalog-jdbc-starrocks/src/main/java/org/apache/gravitino/catalog/starrocks/operations/StarRocksTableOperations.java
+++ b/catalogs/catalog-jdbc-starrocks/src/main/java/org/apache/gravitino/catalog/starrocks/operations/StarRocksTableOperations.java
@@ -324,12 +324,7 @@ public class StarRocksTableOperations extends JdbcTableOperations {
     }
 
     // Add DEFAULT value if specified
-    if (!DEFAULT_VALUE_NOT_SET.equals(column.defaultValue())) {
-      sqlBuilder
-          .append("DEFAULT ")
-          .append(columnDefaultValueConverter.fromGravitino(column.defaultValue()))
-          .append(SPACE);
-    }
+    appendDefaultValue(column, sqlBuilder);
 
     // Add column auto_increment if specified
     if (column.autoIncrement()) {

--- a/catalogs/catalog-jdbc-starrocks/src/test/java/org/apache/gravitino/catalog/starrocks/operation/TestStarRocksTableOperationsSqlGeneration.java
+++ b/catalogs/catalog-jdbc-starrocks/src/test/java/org/apache/gravitino/catalog/starrocks/operation/TestStarRocksTableOperationsSqlGeneration.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog.starrocks.operation;
+
+import java.util.Collections;
+import org.apache.gravitino.catalog.jdbc.JdbcColumn;
+import org.apache.gravitino.catalog.jdbc.converter.JdbcColumnDefaultValueConverter;
+import org.apache.gravitino.catalog.jdbc.converter.JdbcExceptionConverter;
+import org.apache.gravitino.catalog.starrocks.converter.StarRocksTypeConverter;
+import org.apache.gravitino.catalog.starrocks.operations.StarRocksTableOperations;
+import org.apache.gravitino.rel.expressions.NamedReference;
+import org.apache.gravitino.rel.expressions.distributions.Distribution;
+import org.apache.gravitino.rel.expressions.distributions.Distributions;
+import org.apache.gravitino.rel.expressions.literals.Literals;
+import org.apache.gravitino.rel.expressions.transforms.Transforms;
+import org.apache.gravitino.rel.indexes.Indexes;
+import org.apache.gravitino.rel.types.Types;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TestStarRocksTableOperationsSqlGeneration {
+
+  private static class TestableStarRocksTableOperations extends StarRocksTableOperations {
+
+    public TestableStarRocksTableOperations() {
+      super.exceptionMapper = new JdbcExceptionConverter();
+      super.typeConverter = new StarRocksTypeConverter();
+      super.columnDefaultValueConverter = new JdbcColumnDefaultValueConverter();
+    }
+
+    public String createTableSql(
+        String tableName, JdbcColumn[] columns, Distribution distribution) {
+      return generateCreateTableSql(
+          tableName,
+          columns,
+          "comment",
+          Collections.emptyMap(),
+          Transforms.EMPTY_TRANSFORM,
+          distribution,
+          Indexes.EMPTY_INDEXES);
+    }
+  }
+
+  @Test
+  public void testCreateTableWithEmptyStringDefaultValue() {
+    TestableStarRocksTableOperations ops = new TestableStarRocksTableOperations();
+    String tableName = "test_table";
+    JdbcColumn col1 =
+        JdbcColumn.builder()
+            .withName("col1")
+            .withType(Types.VarCharType.of(255))
+            .withNullable(false)
+            .withDefaultValue(Literals.of("", Types.VarCharType.of(255)))
+            .build();
+
+    // StarRocks requires distribution
+    Distribution distribution = Distributions.hash(1, NamedReference.field("col1"));
+
+    String sql = ops.createTableSql(tableName, new JdbcColumn[] {col1}, distribution);
+    JdbcColumnDefaultValueConverter converter = new JdbcColumnDefaultValueConverter();
+    Assertions.assertTrue(
+        sql.contains("DEFAULT " + converter.fromGravitino(col1.defaultValue())),
+        "Should contain DEFAULT '' but was: " + sql);
+  }
+
+  @Test
+  public void testCreateTableWithNonEmptyStringDefaultValue() {
+    TestableStarRocksTableOperations ops = new TestableStarRocksTableOperations();
+    String tableName = "test_table";
+    JdbcColumn col1 =
+        JdbcColumn.builder()
+            .withName("col1")
+            .withType(Types.VarCharType.of(255))
+            .withNullable(false)
+            .withDefaultValue(Literals.of("abc", Types.VarCharType.of(255)))
+            .build();
+
+    // StarRocks requires distribution
+    Distribution distribution = Distributions.hash(1, NamedReference.field("col1"));
+
+    String sql = ops.createTableSql(tableName, new JdbcColumn[] {col1}, distribution);
+    JdbcColumnDefaultValueConverter converter = new JdbcColumnDefaultValueConverter();
+    Assertions.assertTrue(
+        sql.contains("DEFAULT " + converter.fromGravitino(col1.defaultValue())),
+        "Should contain DEFAULT value but was: " + sql);
+  }
+
+  @Test
+  public void testCreateTableWithWhitespaceDefaultValue() {
+    TestableStarRocksTableOperations ops = new TestableStarRocksTableOperations();
+    String tableName = "test_table";
+    JdbcColumn col1 =
+        JdbcColumn.builder()
+            .withName("col1")
+            .withType(Types.VarCharType.of(255))
+            .withNullable(false)
+            .withDefaultValue(Literals.of("   ", Types.VarCharType.of(255)))
+            .build();
+
+    Distribution distribution = Distributions.hash(1, NamedReference.field("col1"));
+    String sql = ops.createTableSql(tableName, new JdbcColumn[] {col1}, distribution);
+    JdbcColumnDefaultValueConverter converter = new JdbcColumnDefaultValueConverter();
+    Assertions.assertTrue(
+        sql.contains("DEFAULT " + converter.fromGravitino(col1.defaultValue())),
+        "Should contain DEFAULT '   ' but was: " + sql);
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

This pull request enhances the handling of default values for string-type columns in JDBC catalog implementations for MySQL, PostgreSQL, Doris, OceanBase, and StarRocks. It ensures that string default values are always properly quoted in generated SQL, addressing cases where default values may be empty or unquoted. Comprehensive unit tests have been added for each implementation to verify this behavior.

### Why are the changes needed?

It's a bug.

Fix: #9816

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

UTs.
