### PR TITLE
[#9859] fix(docker): Remove invalid copy to jdbc-oceanbase libs

### DIFF
--- a/dev/docker/gravitino/gravitino-dependency.sh
+++ b/dev/docker/gravitino/gravitino-dependency.sh
@@ -69,10 +69,10 @@ wget "https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.27/$mysql_dr
 cp "${gravitino_staging_dir}/${mysql_driver}" "${gravitino_package_dir}/catalogs/jdbc-mysql/libs/"
 cp "${gravitino_staging_dir}/${mysql_driver}" "${gravitino_package_dir}/catalogs/jdbc-doris/libs/"
 cp "${gravitino_staging_dir}/${mysql_driver}" "${gravitino_package_dir}/catalogs/jdbc-starrocks/libs/"
-cp "${gravitino_staging_dir}/${mysql_driver}" "${gravitino_package_dir}/catalogs/jdbc-oceanbase/libs/"
 cp "${gravitino_staging_dir}/${mysql_driver}" "${gravitino_package_dir}/catalogs/lakehouse-iceberg/libs/"
 cp "${gravitino_staging_dir}/${mysql_driver}" "${gravitino_iceberg_rest_dir}"
 cp "${gravitino_staging_dir}/${mysql_driver}" "${gravitino_package_dir}/libs/"
+
 
 pg_driver="postgresql-42.7.0.jar"
 wget "https://jdbc.postgresql.org/download/${pg_driver}" -O "${gravitino_staging_dir}/${pg_driver}"


### PR DESCRIPTION
## Problem
Fixes #9859
Docker build script fails when copying MySQL driver to `catalogs/jdbc-oceanbase/libs/`:
cp: cannot create regular file '.../catalogs/jdbc-oceanbase/libs/': No such file or directory Error: Process completed with exit code 1.

## Root Cause
The `jdbc-oceanbase` catalog is in `catalogs-contrib/` and is excluded from the default distribution:
1. `build.gradle.kts` line 1127 creates `distribution/package/catalogs/jdbc-oceanbase/`
2. Lines 776-782 delete all contrib catalogs from `distribution/package/`
3. `gravitino-dependency.sh` tries to copy MySQL driver to deleted directory → fails
## Solution
Remove the invalid copy command from `gravitino-dependency.sh` line 72.
Contrib catalogs (oceanbase, clickhouse) are intentionally excluded from release packages and Docker images, so the copy operation should not exist.
## Testing
- Verified line removal fixes build script execution path
- Confirmed other catalog copies (mysql, doris, starrocks, iceberg) remain intact
- No other changes included
Closes #9859