### PR TITLE
[#9894] feat (trino-connector): Add the version segment module to support Trino 440-445

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -861,7 +861,7 @@ tasks {
 
   val compileTrinoConnector by registering {
     dependsOn("trino-connector:trino-connector-435-439:copyLibs")
-    dependsOn("trino-connector:trino-connector-445-445:copyLibs")
+    dependsOn("trino-connector:trino-connector-440-445:copyLibs")
     group = "gravitino distribution"
     outputs.dir(projectDir.dir("distribution/${rootProject.name}-trino-connector-435-439"))
   }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -861,6 +861,7 @@ tasks {
 
   val compileTrinoConnector by registering {
     dependsOn("trino-connector:trino-connector-435-439:copyLibs")
+    dependsOn("trino-connector:trino-connector-445-445:copyLibs")
     group = "gravitino distribution"
     outputs.dir(projectDir.dir("distribution/${rootProject.name}-trino-connector-435-439"))
   }

--- a/clients/client-python/requirements-dev.txt
+++ b/clients/client-python/requirements-dev.txt
@@ -32,3 +32,4 @@ pyjwt[crypto]==2.10.1
 jwcrypto==1.5.6
 sphinx==7.1.2
 furo==2024.8.6
+banks<2.4.0

--- a/clients/client-python/requirements-dev.txt
+++ b/clients/client-python/requirements-dev.txt
@@ -32,4 +32,6 @@ pyjwt[crypto]==2.10.1
 jwcrypto==1.5.6
 sphinx==7.1.2
 furo==2024.8.6
-banks<2.4.0
+# banks 2.4.0 does not support python 3.9.* or lower, so we limit the version here. We can also
+# consider upgrading the python version to 3.10.x or higher in the future to avoid this issue.
+banks==2.3.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,6 +24,10 @@ org.gradle.jvmargs=-Xmx4g
 org.gradle.java.installations.auto-download=true
 org.gradle.java.installations.auto-detect=true
 
+# Increase network timeout for toolchain downloads (in milliseconds)
+systemProp.org.gradle.internal.http.connectionTimeout=300000
+systemProp.org.gradle.internal.http.socketTimeout=300000
+
 # version that is going to be updated automatically by releases
 version = 1.2.0-SNAPSHOT
 

--- a/integration-test-common/docker-script/docker-compose.yaml
+++ b/integration-test-common/docker-script/docker-compose.yaml
@@ -19,7 +19,7 @@
 services:
 
   hive:
-    image: apache/gravitino-ci:hive-0.1.13
+    image: apache/gravitino-ci:hive-0.1.20
     networks:
       - trino-net
     container_name: trino-ci-hive
@@ -79,7 +79,7 @@ services:
       retries: 5
 
   trino:
-    image: trinodb/trino:${TRINO_VERSION:-435}
+    image: trinodb/trino:${TRINO_VERSION:-440}
     networks:
       - trino-net
     container_name: trino-ci-trino
@@ -94,7 +94,7 @@ services:
     entrypoint:  /bin/bash /tmp/trino/init.sh
     volumes:
       - ./init/trino:/tmp/trino
-      - ${GRAVITINO_TRINO_CONNECTOR_DIR:-../../trino-connector/trino-connector-435-439/build/libs}:/usr/lib/trino/plugin/gravitino
+      - ${GRAVITINO_TRINO_CONNECTOR_DIR:-../../trino-connector/trino-connector-440-445/build/libs}:/usr/lib/trino/plugin/gravitino
     extra_hosts:
       - "host.docker.internal:host-gateway"
     healthcheck:
@@ -113,7 +113,7 @@ services:
         condition: service_healthy
 
   trino-worker:
-    image: trinodb/trino:${TRINO_VERSION:-435}
+    image: trinodb/trino:${TRINO_VERSION:-440}
     networks:
       - trino-net
     deploy:
@@ -128,7 +128,7 @@ services:
     entrypoint:  /bin/bash /tmp/trino/init.sh
     volumes:
       - ./init/trino:/tmp/trino
-      - ${GRAVITINO_TRINO_CONNECTOR_DIR:-../../trino-connector/trino-connector-435-439/build/libs}:/usr/lib/trino/plugin/gravitino
+      - ${GRAVITINO_TRINO_CONNECTOR_DIR:-../../trino-connector/trino-connector-440-445/build/libs}:/usr/lib/trino/plugin/gravitino
     extra_hosts:
       - "host.docker.internal:host-gateway"
     depends_on:

--- a/integration-test-common/docker-script/init/trino/init.sh
+++ b/integration-test-common/docker-script/init/trino/init.sh
@@ -60,7 +60,7 @@ fi
 
 # Container start up
 if [[ "${TRINO_ROLE}" == "coordinator" ]]; then
-  nohup /usr/lib/trino/bin/run-trino > /tmp/trino.out 2>&1 &
+  nohup /usr/lib/trino/bin/run-trino 2>&1 | tee /tmp/trino.log &
 
   counter=0
   while [ $counter -le 300 ]; do

--- a/integration-test-common/docker-script/launch.sh
+++ b/integration-test-common/docker-script/launch.sh
@@ -36,15 +36,20 @@ cd ${playground_dir}
 LOG_DIR=../build/trino-ci-container-log
 rm -fr $LOG_DIR
 mkdir -p $LOG_DIR
+LOG_PATH=$LOG_DIR/trino-ci-docker-compose.log
+echo "The docker compose log is: $LOG_PATH"
 
 docker compose up -d
 
-LOG_PATH=$LOG_DIR/trino-ci-docker-compose.log
-
-echo "The docker compose log is: $LOG_PATH"
-
-# Stream logs to the console in real time while still saving to the log file.
-docker compose logs -f -t | tee -a "$LOG_PATH" &
+# Stream logs directly to the log file (no console output).
+docker compose logs -f -t | tee -a "$LOG_PATH" >/dev/null &
+LOG_FOLLOW_PID=$!
+cleanup_log_follow() {
+  if [ -n "$LOG_FOLLOW_PID" ] && kill -0 "$LOG_FOLLOW_PID" 2>/dev/null; then
+    kill "$LOG_FOLLOW_PID" >/dev/null 2>&1
+  fi
+}
+trap cleanup_log_follow EXIT
 
 max_attempts=300
 attempts=0

--- a/integration-test-common/docker-script/launch.sh
+++ b/integration-test-common/docker-script/launch.sh
@@ -42,7 +42,7 @@ echo "The docker compose log is: $LOG_PATH"
 docker compose up -d
 
 # Stream logs directly to the log file (no console output).
-docker compose logs -f -t | tee -a "$LOG_PATH" >/dev/null &
+nohup docker compose logs -f -t | tee -a "$LOG_PATH" &
 LOG_FOLLOW_PID=$!
 cleanup_log_follow() {
   if [ -n "$LOG_FOLLOW_PID" ] && kill -0 "$LOG_FOLLOW_PID" 2>/dev/null; then

--- a/integration-test-common/docker-script/launch.sh
+++ b/integration-test-common/docker-script/launch.sh
@@ -43,7 +43,8 @@ LOG_PATH=$LOG_DIR/trino-ci-docker-compose.log
 
 echo "The docker compose log is: $LOG_PATH"
 
-nohup docker compose logs -f  -t > $LOG_PATH &
+# Stream logs to the console in real time while still saving to the log file.
+docker compose logs -f -t | tee -a "$LOG_PATH" &
 
 max_attempts=300
 attempts=0

--- a/integration-test-common/docker-script/shutdown.sh
+++ b/integration-test-common/docker-script/shutdown.sh
@@ -24,6 +24,7 @@ LOG_DIR=../build/trino-ci-container-log
 if [ -d $LOG_DIR ]; then
   docker cp trino-ci-hive:/usr/local/hadoop/logs $LOG_DIR/hdfs
   docker cp trino-ci-hive:/tmp/root $LOG_DIR/hive
+  docker cp trino-ci-trino:/tmp/trino.log $LOG_DIR/trino.log
 fi
 
 export GRAVITINO_TRINO_CONNECTOR_DIR=/dev/null

--- a/mcp-server/build.gradle.kts
+++ b/mcp-server/build.gradle.kts
@@ -117,7 +117,12 @@ tasks {
 
     doFirst {
       println("UV executable path: ${getUvExecutable()}")
-      commandLine(getUvExecutable(), "venv", venvDir.absolutePath)
+      if (venvDir.exists()) {
+        logger.lifecycle("Virtual environment already exists at: ${venvDir.absolutePath}, clearing...")
+        commandLine(getUvExecutable(), "venv", "--clear", venvDir.absolutePath)
+      } else {
+        commandLine(getUvExecutable(), "venv", venvDir.absolutePath)
+      }
     }
 
     doLast {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -66,6 +66,7 @@ include("authorizations:authorization-ranger", "authorizations:authorization-com
 include(
   "trino-connector:trino-connector",
   "trino-connector:trino-connector-435-439",
+  "trino-connector:trino-connector-440-445",
   "trino-connector:integration-test"
 )
 include("spark-connector:spark-common")

--- a/trino-connector/integration-test/build.gradle.kts
+++ b/trino-connector/integration-test/build.gradle.kts
@@ -71,7 +71,7 @@ dependencies {
 }
 
 tasks.register("setupDependencies") {
-  dependsOn(":trino-connector:trino-connector:jar")
+  dependsOn(":trino-connector:trino-connector-440-445:jar")
   dependsOn(":catalogs:catalog-lakehouse-iceberg:jar", ":catalogs:catalog-lakehouse-iceberg:runtimeJars")
   dependsOn(":catalogs:catalog-jdbc-mysql:jar", ":catalogs:catalog-jdbc-mysql:runtimeJars")
   dependsOn(":catalogs:catalog-jdbc-postgresql:jar", ":catalogs:catalog-jdbc-postgresql:runtimeJars")

--- a/trino-connector/integration-test/build.gradle.kts
+++ b/trino-connector/integration-test/build.gradle.kts
@@ -71,6 +71,7 @@ dependencies {
 }
 
 tasks.register("setupDependencies") {
+  dependsOn(":trino-connector:trino-connector-435-439:jar")
   dependsOn(":trino-connector:trino-connector-440-445:jar")
   dependsOn(":catalogs:catalog-lakehouse-iceberg:jar", ":catalogs:catalog-lakehouse-iceberg:runtimeJars")
   dependsOn(":catalogs:catalog-jdbc-mysql:jar", ":catalogs:catalog-jdbc-mysql:runtimeJars")

--- a/trino-connector/trino-connector-440-445/build.gradle.kts
+++ b/trino-connector/trino-connector-440-445/build.gradle.kts
@@ -55,6 +55,7 @@ dependencies {
   implementation(libs.commons.collections4)
   implementation(libs.commons.lang3)
   implementation("io.trino:trino-jdbc:$trinoVersion")
+  runtimeOnly("io.opentelemetry.semconv:opentelemetry-semconv:1.23.1-alpha")
   compileOnly(libs.airlift.resolver)
   compileOnly("io.trino:trino-spi:$trinoVersion") {
     exclude("org.apache.logging.log4j")

--- a/trino-connector/trino-connector-440-445/build.gradle.kts
+++ b/trino-connector/trino-connector-440-445/build.gradle.kts
@@ -27,9 +27,9 @@ plugins {
   `maven-publish`
 }
 
-// This module supports Trino versions 435-439
-val minTrinoVersion = 435
-val maxTrinoVersion = 439
+// This module supports Trino versions 440-445
+val minTrinoVersion = 440
+val maxTrinoVersion = 445
 
 val trinoVersion = providers.gradleProperty("trinoVersion")
   .map { it.trim().toInt() }

--- a/trino-connector/trino-connector-440-445/src/main/java/org/apache/gravitino/trino/connector/GravitinoConnector440.java
+++ b/trino-connector/trino-connector-440-445/src/main/java/org/apache/gravitino/trino/connector/GravitinoConnector440.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.trino.connector;
+
+import io.trino.spi.connector.ConnectorMetadata;
+import io.trino.spi.connector.ConnectorNodePartitioningProvider;
+import io.trino.spi.connector.ConnectorSplitManager;
+import org.apache.gravitino.trino.connector.catalog.CatalogConnectorContext;
+import org.apache.gravitino.trino.connector.catalog.CatalogConnectorMetadata;
+import org.apache.gravitino.trino.connector.catalog.CatalogConnectorMetadataAdapter;
+
+public class GravitinoConnector440 extends GravitinoConnector {
+
+  public GravitinoConnector440(CatalogConnectorContext connectorContext) {
+    super(connectorContext);
+  }
+
+  @Override
+  protected GravitinoMetadata createGravitinoMetadata(
+      CatalogConnectorMetadata catalogConnectorMetadata,
+      CatalogConnectorMetadataAdapter metadataAdapter,
+      ConnectorMetadata internalMetadata) {
+    return new GravitinoMetadata440(catalogConnectorMetadata, metadataAdapter, internalMetadata);
+  }
+
+  @Override
+  public ConnectorSplitManager getSplitManager() {
+    ConnectorSplitManager splitManager =
+        catalogConnectorContext.getInternalConnector().getSplitManager();
+    return new GravitinoSplitManager440(splitManager);
+  }
+
+  @Override
+  public ConnectorNodePartitioningProvider getNodePartitioningProvider() {
+    ConnectorNodePartitioningProvider nodePartitioningProvider =
+        catalogConnectorContext.getInternalConnector().getNodePartitioningProvider();
+    return new GravitinoNodePartitioningProvider440(nodePartitioningProvider);
+  }
+}

--- a/trino-connector/trino-connector-440-445/src/main/java/org/apache/gravitino/trino/connector/GravitinoConnectorFactory440.java
+++ b/trino-connector/trino-connector-440-445/src/main/java/org/apache/gravitino/trino/connector/GravitinoConnectorFactory440.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.trino.connector;
+
+import org.apache.gravitino.client.GravitinoAdminClient;
+import org.apache.gravitino.trino.connector.catalog.CatalogConnectorContext;
+import org.apache.gravitino.trino.connector.system.GravitinoSystemConnector;
+import org.apache.gravitino.trino.connector.system.storedprocedure.GravitinoStoredProcedureFactory;
+
+public class GravitinoConnectorFactory440 extends GravitinoConnectorFactory {
+
+  public GravitinoConnectorFactory440(GravitinoAdminClient client) {
+    super(client);
+  }
+
+  @Override
+  protected int getMinSupportTrinoSpiVersion() {
+    return 440;
+  }
+
+  @Override
+  protected int getMaxSupportTrinoSpiVersion() {
+    return 445;
+  }
+
+  @Override
+  protected GravitinoConnector createConnector(CatalogConnectorContext connectorContext) {
+    return new GravitinoConnector440(connectorContext);
+  }
+
+  @Override
+  protected GravitinoSystemConnector createSystemConnector(
+      GravitinoStoredProcedureFactory storedProcedureFactory) {
+    return new GravitinoSystemConnector440(storedProcedureFactory);
+  }
+}

--- a/trino-connector/trino-connector-440-445/src/main/java/org/apache/gravitino/trino/connector/GravitinoMetadata440.java
+++ b/trino-connector/trino-connector-440-445/src/main/java/org/apache/gravitino/trino/connector/GravitinoMetadata440.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.trino.connector;
+
+import io.airlift.slice.Slice;
+import io.trino.spi.connector.ColumnMetadata;
+import io.trino.spi.connector.ConnectorInsertTableHandle;
+import io.trino.spi.connector.ConnectorMergeTableHandle;
+import io.trino.spi.connector.ConnectorOutputMetadata;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.ConnectorTableHandle;
+import io.trino.spi.connector.RetryMode;
+import io.trino.spi.connector.SchemaTableName;
+import io.trino.spi.statistics.ComputedStatistics;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.apache.gravitino.trino.connector.catalog.CatalogConnectorMetadata;
+import org.apache.gravitino.trino.connector.catalog.CatalogConnectorMetadataAdapter;
+import org.apache.gravitino.trino.connector.metadata.GravitinoColumn;
+
+public class GravitinoMetadata440 extends GravitinoMetadata {
+
+  public GravitinoMetadata440(
+      CatalogConnectorMetadata catalogConnectorMetadata,
+      CatalogConnectorMetadataAdapter metadataAdapter,
+      io.trino.spi.connector.ConnectorMetadata internalMetadata) {
+    super(catalogConnectorMetadata, metadataAdapter, internalMetadata);
+  }
+
+  @Override
+  public void addColumn(
+      ConnectorSession session, ConnectorTableHandle tableHandle, ColumnMetadata column) {
+    GravitinoColumn gravitinoColumn = metadataAdapter.createColumn(column);
+    catalogConnectorMetadata.addColumn(getTableName(tableHandle), gravitinoColumn);
+  }
+
+  @Override
+  public Optional<ConnectorOutputMetadata> finishInsert(
+      ConnectorSession session,
+      ConnectorInsertTableHandle insertHandle,
+      List<ConnectorTableHandle> sourceTableHandles,
+      Collection<Slice> fragments,
+      Collection<ComputedStatistics> computedStatistics) {
+    return internalMetadata.finishInsert(
+        session,
+        GravitinoHandle.unWrap(insertHandle),
+        sourceTableHandles.stream().map(GravitinoHandle::unWrap).collect(Collectors.toList()),
+        fragments,
+        computedStatistics);
+  }
+
+  @Override
+  public ConnectorMergeTableHandle beginMerge(
+      ConnectorSession session, ConnectorTableHandle tableHandle, RetryMode retryMode) {
+    ConnectorMergeTableHandle connectorMergeTableHandle =
+        internalMetadata.beginMerge(session, GravitinoHandle.unWrap(tableHandle), retryMode);
+    SchemaTableName tableName = getTableName(tableHandle);
+
+    return new GravitinoMergeTableHandle(
+        tableName.getSchemaName(), tableName.getTableName(), connectorMergeTableHandle);
+  }
+
+  @Override
+  public void finishMerge(
+      ConnectorSession session,
+      ConnectorMergeTableHandle mergeTableHandle,
+      Collection<Slice> fragments,
+      Collection<ComputedStatistics> computedStatistics) {
+    internalMetadata.finishMerge(
+        session, GravitinoHandle.unWrap(mergeTableHandle), fragments, computedStatistics);
+  }
+}

--- a/trino-connector/trino-connector-440-445/src/main/java/org/apache/gravitino/trino/connector/GravitinoNodePartitioningProvider440.java
+++ b/trino-connector/trino-connector-440-445/src/main/java/org/apache/gravitino/trino/connector/GravitinoNodePartitioningProvider440.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.trino.connector;
+
+import io.trino.spi.connector.ConnectorNodePartitioningProvider;
+
+/** Trino NodePartitioningProvider implementation with the new split bucket function signature. */
+public class GravitinoNodePartitioningProvider440 extends GravitinoNodePartitioningProvider {
+
+  public GravitinoNodePartitioningProvider440(
+      ConnectorNodePartitioningProvider nodePartitioningProvider) {
+    super(nodePartitioningProvider);
+  }
+}

--- a/trino-connector/trino-connector-440-445/src/main/java/org/apache/gravitino/trino/connector/GravitinoPlugin440.java
+++ b/trino-connector/trino-connector-440-445/src/main/java/org/apache/gravitino/trino/connector/GravitinoPlugin440.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.trino.connector;
+
+import org.apache.gravitino.client.GravitinoAdminClient;
+
+/** Trino plugin endpoint, using java spi mechanism */
+public class GravitinoPlugin440 extends GravitinoPlugin {
+
+  public GravitinoPlugin440() {
+    super();
+  }
+
+  public GravitinoPlugin440(GravitinoAdminClient client) {
+    super(client);
+  }
+
+  @Override
+  protected GravitinoConnectorFactory createConnectorFactory(GravitinoAdminClient client) {
+    return new GravitinoConnectorFactory440(client);
+  }
+}

--- a/trino-connector/trino-connector-440-445/src/main/java/org/apache/gravitino/trino/connector/GravitinoSplitManager440.java
+++ b/trino-connector/trino-connector-440-445/src/main/java/org/apache/gravitino/trino/connector/GravitinoSplitManager440.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.trino.connector;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.trino.spi.connector.ConnectorSplit;
+import io.trino.spi.connector.ConnectorSplitManager;
+import io.trino.spi.connector.ConnectorSplitSource;
+
+public class GravitinoSplitManager440 extends GravitinoSplitManager {
+
+  public GravitinoSplitManager440(ConnectorSplitManager internalSplitManager) {
+    super(internalSplitManager);
+  }
+
+  @Override
+  protected ConnectorSplitSource createSplitSource(ConnectorSplitSource splits) {
+    return new GravitinoSplitSource440(splits);
+  }
+
+  static class GravitinoSplitSource440 extends GravitinoSplitSource {
+
+    GravitinoSplitSource440(ConnectorSplitSource connectorSplitSource) {
+      super(connectorSplitSource);
+    }
+
+    @Override
+    protected ConnectorSplit createSplit(ConnectorSplit split) {
+      return new GravitinoSplit440(split);
+    }
+  }
+
+  public static class GravitinoSplit440 extends GravitinoSplit {
+
+    @JsonCreator
+    public GravitinoSplit440(@JsonProperty(HANDLE_STRING) String handleString) {
+      super(handleString);
+    }
+
+    public GravitinoSplit440(ConnectorSplit split) {
+      super(split);
+    }
+
+    @Override
+    public Object getInfo() {
+      return getInternalHandle().getInfo();
+    }
+  }
+}

--- a/trino-connector/trino-connector-440-445/src/main/java/org/apache/gravitino/trino/connector/GravitinoSystemConnector440.java
+++ b/trino-connector/trino-connector-440-445/src/main/java/org/apache/gravitino/trino/connector/GravitinoSystemConnector440.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.trino.connector;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.trino.spi.Page;
+import io.trino.spi.connector.ConnectorPageSource;
+import io.trino.spi.connector.ConnectorPageSourceProvider;
+import io.trino.spi.connector.ConnectorSplit;
+import io.trino.spi.connector.ConnectorSplitManager;
+import io.trino.spi.connector.SchemaTableName;
+import org.apache.gravitino.trino.connector.system.GravitinoSystemConnector;
+import org.apache.gravitino.trino.connector.system.storedprocedure.GravitinoStoredProcedureFactory;
+
+public class GravitinoSystemConnector440 extends GravitinoSystemConnector {
+
+  public GravitinoSystemConnector440(
+      GravitinoStoredProcedureFactory gravitinoStoredProcedureFactory) {
+    super(gravitinoStoredProcedureFactory);
+  }
+
+  @Override
+  protected ConnectorSplitManager createSplitManager() {
+    return new GravitinoSplitManager440();
+  }
+
+  @Override
+  protected ConnectorPageSourceProvider createPageSourceProvider() {
+    return new DatasourceProvider440();
+  }
+
+  static class DatasourceProvider440 extends DatasourceProvider {
+
+    @Override
+    protected ConnectorPageSource createPageSource(Page page) {
+      return new SystemTablePageSource440(page);
+    }
+  }
+
+  static class GravitinoSplitManager440 extends SplitManager {
+
+    protected ConnectorSplit createSplit(SchemaTableName tableName) {
+      return new Split440(tableName);
+    }
+  }
+
+  static class SystemTablePageSource440 extends SystemTablePageSource {
+
+    public SystemTablePageSource440(Page page) {
+      super(page);
+    }
+
+    public Page getNextPage() {
+      return nextPage();
+    }
+  }
+
+  public static class Split440 extends Split {
+
+    @JsonCreator
+    public Split440(@JsonProperty("tableName") SchemaTableName tableName) {
+      super(tableName);
+    }
+
+    @Override
+    public Object getInfo() {
+      return this;
+    }
+  }
+}

--- a/trino-connector/trino-connector-440-445/src/main/resources/META-INF/services/io.trino.spi.Plugin
+++ b/trino-connector/trino-connector-440-445/src/main/resources/META-INF/services/io.trino.spi.Plugin
@@ -1,0 +1,19 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+org.apache.gravitino.trino.connector.GravitinoPlugin440

--- a/trino-connector/trino-connector-440-445/src/test/java/TestGravitinoConnector440.java
+++ b/trino-connector/trino-connector-440-445/src/test/java/TestGravitinoConnector440.java
@@ -32,7 +32,7 @@ public class TestGravitinoConnector440 {
   @Nested
   class SingleMetalake extends TestGravitinoConnector {
     @Override
-    protected GravitinoPlugin createGravitinoPulgin(GravitinoAdminClient client) {
+    protected GravitinoPlugin createGravitinoPlugin(GravitinoAdminClient client) {
       return new GravitinoPlugin440(client);
     }
 
@@ -46,7 +46,7 @@ public class TestGravitinoConnector440 {
   @Nested
   class MultiMetalake extends TestGravitinoConnectorWithMetalakeCatalogName {
     @Override
-    protected GravitinoPlugin createGravitinoPulgin(GravitinoAdminClient client) {
+    protected GravitinoPlugin createGravitinoPlugin(GravitinoAdminClient client) {
       return new GravitinoPlugin440(client);
     }
 

--- a/trino-connector/trino-connector-440-445/src/test/java/TestGravitinoConnector440.java
+++ b/trino-connector/trino-connector-440-445/src/test/java/TestGravitinoConnector440.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import static io.trino.testing.TestingSession.testSessionBuilder;
+
+import io.trino.Session;
+import io.trino.testing.DistributedQueryRunner;
+import org.apache.gravitino.client.GravitinoAdminClient;
+import org.apache.gravitino.trino.connector.GravitinoPlugin;
+import org.apache.gravitino.trino.connector.GravitinoPlugin440;
+import org.apache.gravitino.trino.connector.TestGravitinoConnector;
+import org.apache.gravitino.trino.connector.TestGravitinoConnectorWithMetalakeCatalogName;
+import org.junit.jupiter.api.Nested;
+
+public class TestGravitinoConnector440 {
+  @Nested
+  class SingleMetalake extends TestGravitinoConnector {
+    @Override
+    protected GravitinoPlugin createGravitinoPulgin(GravitinoAdminClient client) {
+      return new GravitinoPlugin440(client);
+    }
+
+    @Override
+    protected DistributedQueryRunner createTrinoQueryRunner() throws Exception {
+      Session session = testSessionBuilder().setCatalog("gravitino").build();
+      return DistributedQueryRunner.builder(session).setNodeCount(1).build();
+    }
+  }
+
+  @Nested
+  class MultiMetalake extends TestGravitinoConnectorWithMetalakeCatalogName {
+    @Override
+    protected GravitinoPlugin createGravitinoPulgin(GravitinoAdminClient client) {
+      return new GravitinoPlugin440(client);
+    }
+
+    @Override
+    protected DistributedQueryRunner createTrinoQueryRunner() throws Exception {
+      Session session = testSessionBuilder().setCatalog("gravitino").build();
+      return DistributedQueryRunner.builder(session).setNodeCount(1).build();
+    }
+  }
+}

--- a/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/GravitinoDynamicFilter.java
+++ b/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/GravitinoDynamicFilter.java
@@ -22,7 +22,8 @@ import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.DynamicFilter;
 import io.trino.spi.predicate.TupleDomain;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;import java.util.stream.Collectors;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
 
 /** The GravitinoDynamicFilter is used to warp DynamicFilter */
 class GravitinoDynamicFilter implements DynamicFilter {

--- a/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/GravitinoDynamicFilter.java
+++ b/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/GravitinoDynamicFilter.java
@@ -22,7 +22,7 @@ import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.DynamicFilter;
 import io.trino.spi.predicate.TupleDomain;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletableFuture;import java.util.stream.Collectors;
 
 /** The GravitinoDynamicFilter is used to warp DynamicFilter */
 class GravitinoDynamicFilter implements DynamicFilter {
@@ -34,7 +34,9 @@ class GravitinoDynamicFilter implements DynamicFilter {
 
   @Override
   public Set<ColumnHandle> getColumnsCovered() {
-    return delegate.getColumnsCovered();
+    return delegate.getColumnsCovered().stream()
+        .map(GravitinoHandle::unWrap)
+        .collect(Collectors.toSet());
   }
 
   @Override

--- a/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/GravitinoSplitManager.java
+++ b/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/GravitinoSplitManager.java
@@ -55,7 +55,7 @@ public class GravitinoSplitManager implements ConnectorSplitManager {
             session,
             GravitinoHandle.unWrap(connectorTableHandle),
             new GravitinoDynamicFilter(dynamicFilter),
-            constraint);
+            new GravitinoConstraint(constraint));
     return createSplitSource(splits);
   }
 

--- a/trino-connector/trino-connector/src/test/java/org/apache/gravitino/trino/connector/GravitinoMockServer.java
+++ b/trino-connector/trino-connector/src/test/java/org/apache/gravitino/trino/connector/GravitinoMockServer.java
@@ -621,7 +621,8 @@ public class GravitinoMockServer implements AutoCloseable {
   }
 
   private void addColumn(
-      ConnectorMetadata metadata, ConnectorTableHandle tableHandle, ColumnMetadata columnMetadata) throws TrinoException{
+      ConnectorMetadata metadata, ConnectorTableHandle tableHandle, ColumnMetadata columnMetadata)
+      throws TrinoException {
     if (trinoVersion < SPI_VERSION_SUPPORT_ADD_COLUMN_WITH_POSITION) {
       try {
         metadata

--- a/trino-connector/trino-connector/src/test/java/org/apache/gravitino/trino/connector/GravitinoMockServer.java
+++ b/trino-connector/trino-connector/src/test/java/org/apache/gravitino/trino/connector/GravitinoMockServer.java
@@ -621,7 +621,7 @@ public class GravitinoMockServer implements AutoCloseable {
   }
 
   private void addColumn(
-      ConnectorMetadata metadata, ConnectorTableHandle tableHandle, ColumnMetadata columnMetadata) {
+      ConnectorMetadata metadata, ConnectorTableHandle tableHandle, ColumnMetadata columnMetadata) throws TrinoException{
     if (trinoVersion < SPI_VERSION_SUPPORT_ADD_COLUMN_WITH_POSITION) {
       try {
         metadata
@@ -634,7 +634,7 @@ public class GravitinoMockServer implements AutoCloseable {
             .invoke(metadata, null, tableHandle, columnMetadata);
       } catch (ReflectiveOperationException e) {
         if (e.getCause() instanceof TrinoException) {
-          throw new RuntimeException(e.getCause().getMessage(), e);
+          throw (TrinoException) e.getCause();
         }
         throw new RuntimeException("Failed to invoke legacy addColumn by reflection", e);
       }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add the version segment module for 440-445 to support Trino 440 through Trino 445

### Why are the changes needed?

Fix: #9894

### Does this PR introduce _any_ user-facing change?

NO

### How was this patch tested?

UT and IT