### PR TITLE
[#9830] web(UI): doris table edit

### DIFF
--- a/web/web/src/app/metalakes/metalake/rightContent/CreateTableDialog.js
+++ b/web/web/src/app/metalakes/metalake/rightContent/CreateTableDialog.js
@@ -207,7 +207,7 @@ const CreateTableDialog = props => {
       updatedProps.forEach(item => (item.hasDuplicateKey = false))
     }
 
-    const isReserved = propInfo.reserved.includes(updatedProps[index].key)
+    const isReserved = propInfo.reserved?.includes(updatedProps[index].key) || false
     updatedProps[index].isReserved = isReserved
 
     setInnerProps(updatedProps)
@@ -549,7 +549,7 @@ const CreateTableDialog = props => {
         return {
           key,
           value,
-          disabled: propInfo.reserved.includes(key) || propInfo.immutable.includes(key)
+          disabled: propInfo.reserved?.includes(key) || propInfo.immutable?.includes(key)
         }
       })
 

--- a/web/web/src/lib/utils/initial.js
+++ b/web/web/src/lib/utils/initial.js
@@ -678,11 +678,13 @@ const relationalTablePropInfoMap = {
   },
   'jdbc-starrocks': {
     reserved: [],
+    immutable: [],
     allowDelete: true,
     allowAdd: true
   },
   'jdbc-doris': {
     reserved: [],
+    immutable: [],
     allowDelete: true,
     allowAdd: true
   },


### PR DESCRIPTION
fix: Add missing immutable property to Doris and StarRocks table configs (#9830)

- Add immutable: [] to jdbc-doris configuration
- Add immutable: [] to jdbc-starrocks configuration  
- Add defensive optional chaining in CreateTableDialog.js

This fixes a TypeError when editing Doris/StarRocks tables in the UI.
The code was calling .includes() on undefined immutable property,
causing the dialog to crash with 'Application error: a client-side
exception has occurred'.

Fixes #9830