### PR TITLE
[#9648] fix(test): Replace direct column assertion with Awaitility as schema changes in `StarRocks` and `Doris` are asynchronous

### DIFF
--- a/catalogs/catalog-jdbc-doris/src/test/java/org/apache/gravitino/catalog/doris/integration/test/CatalogDorisIT.java
+++ b/catalogs/catalog-jdbc-doris/src/test/java/org/apache/gravitino/catalog/doris/integration/test/CatalogDorisIT.java
@@ -564,10 +564,14 @@ public class CatalogDorisIT extends BaseIT {
         .pollInterval(WAIT_INTERVAL_IN_SECONDS, TimeUnit.SECONDS)
         .untilAsserted(
             () -> assertEquals(5, tableCatalog.loadTable(tableIdentifier).columns().length));
-
-    ITUtils.assertColumn(
-        Column.of("col_5", Types.VarCharType.of(255), "col_5_comment"),
-        tableCatalog.loadTable(tableIdentifier).columns()[4]);
+    Awaitility.await()
+        .atMost(MAX_WAIT_IN_SECONDS, TimeUnit.SECONDS)
+        .pollInterval(WAIT_INTERVAL_IN_SECONDS, TimeUnit.SECONDS)
+        .untilAsserted(
+            () ->
+                ITUtils.assertColumn(
+                    Column.of("col_5", Types.VarCharType.of(255), "col_5_comment"),
+                    tableCatalog.loadTable(tableIdentifier).columns()[4]));
 
     // change column position
     // TODO: change column position is unstable, add it later

--- a/catalogs/catalog-jdbc-starrocks/src/test/java/org/apache/gravitino/catalog/starrocks/integration/test/CatalogStarRocksIT.java
+++ b/catalogs/catalog-jdbc-starrocks/src/test/java/org/apache/gravitino/catalog/starrocks/integration/test/CatalogStarRocksIT.java
@@ -530,10 +530,14 @@ public class CatalogStarRocksIT extends BaseIT {
         .pollInterval(WAIT_INTERVAL_IN_SECONDS, TimeUnit.SECONDS)
         .untilAsserted(
             () -> assertEquals(5, tableCatalog.loadTable(tableIdentifier).columns().length));
-
-    ITUtils.assertColumn(
-        Column.of("col_5", Types.VarCharType.of(255), "col_5_comment"),
-        tableCatalog.loadTable(tableIdentifier).columns()[4]);
+    Awaitility.await()
+        .atMost(MAX_WAIT_IN_SECONDS, TimeUnit.SECONDS)
+        .pollInterval(WAIT_INTERVAL_IN_SECONDS, TimeUnit.SECONDS)
+        .untilAsserted(
+            () ->
+                ITUtils.assertColumn(
+                    Column.of("col_5", Types.VarCharType.of(255), "col_5_comment"),
+                    tableCatalog.loadTable(tableIdentifier).columns()[4]));
 
     // change column position
     // TODO: change column position is unstable, add it later


### PR DESCRIPTION
### What changes were proposed in this pull request?

This pull request updates integration tests for both Doris and StarRocks JDBC catalogs to improve the reliability and clarity of assertions when verifying altered table schemas. The main change is restructuring the Awaitility assertions to ensure column properties are checked in a more robust and consistent way.

### Why are the changes needed?

For better stability. 

Fix: #9648

### Does this PR introduce _any_ user-facing change?

N/A.

### How was this patch tested?

Test Locally and CI. 
