### PR TITLE
[#9996] web(UI): Add global tips to use web v2

### DIFF
--- a/web/web/src/app/rootLayout/Layout.js
+++ b/web/web/src/app/rootLayout/Layout.js
@@ -79,7 +79,7 @@ const Layout = ({ children, scrollToTop }) => {
                 <Box sx={{ flex: 1 }}>
                   <Typography variant='body2' component='div'>
                     <Box component='span' sx={{ fontWeight: 600 }}>
-                      Try the new Web V2 Web UI.
+                      Try the new V2 Web UI.
                     </Box>
                     <Box component='div' sx={{ fontFamily: 'monospace', mt: 1 }}>
                       # In &lt;path-to-gravitino&gt;/conf/gravitino-env.sh


### PR DESCRIPTION
### What changes were proposed in this pull request?
<img width="2808" height="1874" alt="image" src="https://github.com/user-attachments/assets/fe323b7d-c12c-492f-80ca-f5c4fffcafeb" />


### Why are the changes needed?
Add global tips to use web v2

Fix: #9996

### Does this PR introduce _any_ user-facing change?
N/A

### How was this patch tested?
manually
