### PR TITLE
[#9746][followup] fix(core): Set namespace when fetching view entity

### DIFF
--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/ViewMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/ViewMetaService.java
@@ -119,6 +119,7 @@ public class ViewMetaService {
                 GenericEntity.builder()
                     .withId(viewPO.getViewId())
                     .withName(viewPO.getViewName())
+                    .withNamespace(namespace)
                     .withEntityType(Entity.EntityType.VIEW)
                     .build())
         .collect(Collectors.toList());
@@ -141,6 +142,7 @@ public class ViewMetaService {
     return GenericEntity.builder()
         .withId(viewPO.getViewId())
         .withName(viewPO.getViewName())
+        .withNamespace(identifier.namespace())
         .withEntityType(Entity.EntityType.VIEW)
         .build();
   }

--- a/core/src/test/java/org/apache/gravitino/storage/relational/service/TestViewMetaService.java
+++ b/core/src/test/java/org/apache/gravitino/storage/relational/service/TestViewMetaService.java
@@ -71,6 +71,7 @@ public class TestViewMetaService extends TestJDBCBackend {
     assertNotNull(retrievedView);
     assertEquals(view.id(), retrievedView.id());
     assertEquals(view.name(), retrievedView.name());
+    assertEquals(viewNamespace, retrievedView.namespace());
     assertEquals(Entity.EntityType.VIEW, retrievedView.type());
   }
 
@@ -103,6 +104,7 @@ public class TestViewMetaService extends TestJDBCBackend {
     GenericEntity retrievedView = backend.get(viewIdent, Entity.EntityType.VIEW);
     assertNotNull(retrievedView);
     assertEquals(view.id(), retrievedView.id());
+    assertEquals(viewNamespace, retrievedView.namespace());
   }
 
   @TestTemplate
@@ -125,6 +127,8 @@ public class TestViewMetaService extends TestJDBCBackend {
     assertTrue(views.stream().anyMatch(v -> v.name().equals("view1")));
     assertTrue(views.stream().anyMatch(v -> v.name().equals("view2")));
     assertTrue(views.stream().anyMatch(v -> v.name().equals("view3")));
+    // Verify all views have namespace set
+    assertTrue(views.stream().allMatch(v -> viewNamespace.equals(v.namespace())));
   }
 
   @TestTemplate
@@ -160,6 +164,7 @@ public class TestViewMetaService extends TestJDBCBackend {
     GenericEntity retrievedView = backend.get(newViewIdent, Entity.EntityType.VIEW);
     assertNotNull(retrievedView);
     assertEquals("view_updated", retrievedView.name());
+    assertEquals(viewNamespace, retrievedView.namespace());
   }
 
   @TestTemplate
@@ -245,6 +250,7 @@ public class TestViewMetaService extends TestJDBCBackend {
         backend.get(NameIdentifier.of(viewNamespace, "lifecycle_view"), Entity.EntityType.VIEW);
     assertEquals(view.id(), viewEntity.id());
     assertEquals(view.name(), viewEntity.name());
+    assertEquals(viewNamespace, viewEntity.namespace());
 
     // meta data soft delete
     backend.delete(


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Fix ViewMetaService to properly set the namespace field when building GenericEntity objects in listViewsByNamespace() and getViewByIdentifier() methods.

### Why are the changes needed?

Previously, ViewMetaService was not setting the namespace when creating GenericEntity objects for views, which could cause issues when code depends on the namespace being properly set. One place we had issue was in the reverse lookup : https://github.com/apache/gravitino/blob/a8414f6de3cbc3e507113ee1eba1594e3303756b/core/src/main/java/org/apache/gravitino/cache/ReverseIndexRules.java#L129
where it was giving indexOutOfBoundsException due to no namespace

Fix: #9746 

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Unit tests