### PR TITLE
[#10009] Fix: Add equals and hashCode methods to Policy.java (#10012)

### DIFF
--- a/bundles/aliyun/build.gradle.kts
+++ b/bundles/aliyun/build.gradle.kts
@@ -43,6 +43,7 @@ dependencies {
   compileOnly(libs.aliyun.credentials.sdk)
   compileOnly(libs.hadoop3.client.api)
   compileOnly(libs.hadoop3.oss)
+  compileOnly(libs.lombok)
 
   testImplementation(libs.junit.jupiter.api)
   testImplementation(libs.junit.jupiter.params)

--- a/bundles/aliyun/src/main/java/org/apache/gravitino/oss/credential/policy/Condition.java
+++ b/bundles/aliyun/src/main/java/org/apache/gravitino/oss/credential/policy/Condition.java
@@ -21,7 +21,9 @@ package org.apache.gravitino.oss.credential.policy;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.EqualsAndHashCode;
 
+@EqualsAndHashCode
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class Condition {
 

--- a/bundles/aliyun/src/main/java/org/apache/gravitino/oss/credential/policy/Policy.java
+++ b/bundles/aliyun/src/main/java/org/apache/gravitino/oss/credential/policy/Policy.java
@@ -23,7 +23,9 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.ArrayList;
 import java.util.List;
+import lombok.EqualsAndHashCode;
 
+@EqualsAndHashCode
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class Policy {
 

--- a/bundles/aliyun/src/main/java/org/apache/gravitino/oss/credential/policy/Statement.java
+++ b/bundles/aliyun/src/main/java/org/apache/gravitino/oss/credential/policy/Statement.java
@@ -23,7 +23,9 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.ArrayList;
 import java.util.List;
+import lombok.EqualsAndHashCode;
 
+@EqualsAndHashCode
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class Statement {
 

--- a/bundles/aliyun/src/main/java/org/apache/gravitino/oss/credential/policy/StringLike.java
+++ b/bundles/aliyun/src/main/java/org/apache/gravitino/oss/credential/policy/StringLike.java
@@ -23,7 +23,9 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.ArrayList;
 import java.util.List;
+import lombok.EqualsAndHashCode;
 
+@EqualsAndHashCode
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class StringLike {
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This change uses the lombok annotation to add equals() and hashCode() methods to Policy.java

### Why are the changes needed?

Without equals() and hashCode() methods, Policy class shouldn't be used in a `Set` because objects with duplicate fields are allowed to co-exist in the `Set`.

Fix: #10009

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing IT test.
