### PR TITLE
[MINOR]test(IRC): Fix testUpdateNamespace to correctly test schema owner case

### DIFF
--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/integration/test/IcebergNamespaceAuthorizationIT.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/integration/test/IcebergNamespaceAuthorizationIT.java
@@ -28,7 +28,6 @@ import java.util.Optional;
 import java.util.UUID;
 import org.apache.gravitino.MetadataObject;
 import org.apache.gravitino.MetadataObjects;
-import org.apache.gravitino.SchemaChange;
 import org.apache.gravitino.authorization.Owner;
 import org.apache.gravitino.authorization.Privileges;
 import org.apache.gravitino.authorization.SecurableObject;
@@ -216,13 +215,8 @@ public class IcebergNamespaceAuthorizationIT extends IcebergAuthorizationIT {
         NORMAL_USER,
         Owner.Type.USER);
 
-    grantUseSchemaRole(namespace);
-
     Assertions.assertDoesNotThrow(
-        () ->
-            catalogClientWithAllPrivilege
-                .asSchemas()
-                .alterSchema(namespace, SchemaChange.setProperty("modified-by", "owner")));
+        () -> sql("ALTER DATABASE %s SET DBPROPERTIES ('key'='value')", namespace));
   }
 
   @Test


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?
Current test was incorrect. It was using catalogClientWithAllPrivilege to run the alterSchema, which runs as admin user, and not as the NORMAL_USER to test schema ownership. catalogClientWithAllPrivilege runs as admin user which will anyways pass, irrespective of setting owner to NORMAL_USER

### Why are the changes needed?

Fixes incorrect test

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Fix integration test