### PR TITLE
fix(iceberg-rest): StaticIcebergConfigProvider respects gravitino-metalake config for auth

### DIFF
--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/provider/StaticIcebergConfigProvider.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/provider/StaticIcebergConfigProvider.java
@@ -43,8 +43,11 @@ public class StaticIcebergConfigProvider implements IcebergConfigProvider {
 
   @VisibleForTesting Map<String, IcebergConfig> catalogConfigs;
 
+  private Map<String, String> properties;
+
   @Override
   public void initialize(Map<String, String> properties) {
+    this.properties = properties;
     this.catalogConfigs =
         properties.keySet().stream()
             .map(this::getCatalogName)
@@ -69,6 +72,12 @@ public class StaticIcebergConfigProvider implements IcebergConfigProvider {
 
   @Override
   public void close() {}
+
+  @Override
+  public String getMetalakeName() {
+    return properties.getOrDefault(
+        IcebergConstants.GRAVITINO_METALAKE, IcebergConstants.ICEBERG_REST_DEFAULT_METALAKE);
+  }
 
   private Optional<String> getCatalogName(String catalogConfigKey) {
     if (!catalogConfigKey.startsWith("catalog.")) {

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/provider/TestStaticIcebergConfigProvider.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/provider/TestStaticIcebergConfigProvider.java
@@ -112,4 +112,24 @@ public class TestStaticIcebergConfigProvider {
     Optional<IcebergConfig> config = provider.getIcebergCatalogConfig(catalogName);
     Assertions.assertEquals(Optional.empty(), config);
   }
+
+  @Test
+  public void testGetMetalakeNameWithCustomValue() {
+    Map<String, String> config = Maps.newHashMap();
+    config.put(IcebergConstants.GRAVITINO_METALAKE, "testlake");
+
+    StaticIcebergConfigProvider provider = new StaticIcebergConfigProvider();
+    provider.initialize(config);
+
+    Assertions.assertEquals("testlake", provider.getMetalakeName());
+  }
+
+  @Test
+  public void testGetMetalakeNameDefaultsToGravitino() {
+    StaticIcebergConfigProvider provider = new StaticIcebergConfigProvider();
+    provider.initialize(Maps.newHashMap());
+
+    Assertions.assertEquals(
+        IcebergConstants.ICEBERG_REST_DEFAULT_METALAKE, provider.getMetalakeName());
+  }
 }


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Fix: override getMetalakeName() to read the gravitino-metalake config property (IcebergConstants.GRAVITINO_METALAKE), falling back to the default only if unset. This mirrors the existing behavior in DynamicIcebergConfigProvider.

### Why are the changes needed?

When authorization is enabled, IcebergRESTServerContext calls getMetalakeName() at startup to determine which Gravitino metalake to check privileges against. StaticIcebergConfigProvider did not override this method, so it always returned the hardcoded default "gravitino" regardless of configuration. This caused every Iceberg REST request to fail with 403 when auth was enabled and the actual metalake name was anything other than "gravitino".

Fix: #(issue)

### Does this PR introduce _any_ user-facing change?

no

### How was this patch tested?

Added unit test