### PR TITLE
[#9990][followup] Adjust docker container parameter to make OceanBase tests pass(cherry-pick)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ concurrency:
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   changes:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36

--- a/catalogs/catalog-jdbc-oceanbase/src/test/java/org/apache/gravitino/catalog/oceanbase/operation/TestOceanBaseDatabaseOperations.java
+++ b/catalogs/catalog-jdbc-oceanbase/src/test/java/org/apache/gravitino/catalog/oceanbase/operation/TestOceanBaseDatabaseOperations.java
@@ -23,12 +23,10 @@ import java.util.List;
 import java.util.Map;
 import org.apache.gravitino.utils.RandomNameUtils;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 @Tag("gravitino-docker-test")
-@Disabled
 public class TestOceanBaseDatabaseOperations extends TestOceanBase {
 
   @Test

--- a/catalogs/catalog-jdbc-oceanbase/src/test/java/org/apache/gravitino/catalog/oceanbase/operation/TestOceanBaseTableOperations.java
+++ b/catalogs/catalog-jdbc-oceanbase/src/test/java/org/apache/gravitino/catalog/oceanbase/operation/TestOceanBaseTableOperations.java
@@ -43,12 +43,10 @@ import org.apache.gravitino.rel.types.Types;
 import org.apache.gravitino.utils.RandomNameUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 @Tag("gravitino-docker-test")
-@Disabled
 public class TestOceanBaseTableOperations extends TestOceanBase {
   private static final Type VARCHAR = Types.VarCharType.of(255);
   private static final Type INT = Types.IntegerType.get();

--- a/integration-test-common/src/test/java/org/apache/gravitino/integration/test/container/ContainerSuite.java
+++ b/integration-test-common/src/test/java/org/apache/gravitino/integration/test/container/ContainerSuite.java
@@ -454,9 +454,9 @@ public class ContainerSuite implements Closeable {
                           "OB_DATAFILE_SIZE",
                           "1G",
                           "OB_LOG_DISK_SIZE",
-                          "2G",
+                          "8G",
                           "OB_MEMORY_LIMIT",
-                          "4G"))
+                          "6G"))
                   .withNetwork(network)
                   .withFilesToMount(
                       ImmutableMap.<String, String>builder().put("/tmp/obdata", "/root/ob").build())


### PR DESCRIPTION
### What changes were proposed in this pull request?

This pull request makes adjustments to the OceanBase testing setup by enabling previously disabled integration tests and increasing resource allocations for the OceanBase container. These changes aim to improve test coverage and ensure the container has sufficient resources for running tests reliably.

### Why are the changes needed?

To make it work

Fix: #9990 

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

Existing tests.