### PR TITLE
[#10035] fix(mcp-server): Use a concrete version of `fastmcp` to avoid CI error as 3.0.x makes breaking changes(cherry-pick)

### DIFF
--- a/integration-test-common/src/test/java/org/apache/gravitino/integration/test/util/TestITUtils.java
+++ b/integration-test-common/src/test/java/org/apache/gravitino/integration/test/util/TestITUtils.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.integration.test.util;
+
+import java.util.Map;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TestITUtils {
+  @Test
+  public void testIsCiEnvironmentByCI() {
+    Assertions.assertTrue(ITUtils.isCiEnvironment(Map.of("CI", "true")));
+  }
+
+  @Test
+  public void testIsCiEnvironmentByGitHubActions() {
+    Assertions.assertTrue(ITUtils.isCiEnvironment(Map.of("GITHUB_ACTIONS", "true")));
+  }
+
+  @Test
+  public void testIsCiEnvironmentCaseInsensitive() {
+    Assertions.assertTrue(ITUtils.isCiEnvironment(Map.of("CI", "TRUE")));
+  }
+
+  @Test
+  public void testIsCiEnvironmentFalse() {
+    Assertions.assertFalse(ITUtils.isCiEnvironment(Map.of()));
+    Assertions.assertFalse(ITUtils.isCiEnvironment(Map.of("CI", "false")));
+  }
+}

--- a/mcp-server/pyproject.toml
+++ b/mcp-server/pyproject.toml
@@ -22,7 +22,9 @@ description = "Gravitino MCP server"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "fastmcp>=2.10.6",
+    # fastmcp has been release 3.0.x, which makes some incompatible changes, so we temporarily pin
+    # it to 2.14.5 to avoid breaking changes.
+    "fastmcp==2.14.5",
     "parameterized>=0.9.0",
     "pytest>=8.4.1",
     "pylint>=2.20.0",


### PR DESCRIPTION
### What changes were proposed in this pull request?

This pull request makes a small but important update to the `mcp-server/pyproject.toml` dependency configuration. The change temporarily pins the `fastmcp` package to version `2.14.5` due to incompatible changes in the newer `3.0.x` releases.

* Dependency management: Temporarily pinned `fastmcp` to version `2.14.5` to avoid incompatibilities introduced in `3.0.x`, with plans to upgrade in the future.

### Why are the changes needed?

To fix bugs
Fix: #10035 

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

The CI can cover this change.