### PR TITLE
[#10002] improvement(function): Improve error messages for UDF updateImpl/removeImpl/addImpl operations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,4 @@ derby.log
 web/node_modules
 web/dist
 web/.next
+.worktrees/


### PR DESCRIPTION
### What changes were proposed in this pull request?

Improves error messages for `updateImpl`, `removeImpl`, and `addImpl` operations in `ManagedFunctionOperations` to provide actionable context when operations fail.

Previously, when a user specified parameters with a mismatched `dataType` or name, the error message could be misleading. For example, the user would see "runtime 'SPARK' not found in the definition" when SPARK actually existed — the real problem was that the parameter signature didn't match any definition.

**Changes:**

- Added a `formatParams()` helper to format parameter arrays as human-readable strings (e.g., `(x: integer, y: string)`).
- **"no definition found"** errors now list all available parameter signatures, so users can compare and spot mismatches in `dataType` or parameter names.
- **"runtime not found"** errors now list the runtimes actually present in the matched definition.
- Applied consistently to `updateImplInDefinition`, `removeImplFromDefinition`, and `addImplToDefinition`.

**Before:**
```
Cannot update implementation: runtime 'SPARK' not found in the definition
```

**After (runtime not found):**
```
Cannot update implementation: runtime 'TRINO' not found in the definition (a: integer). Available runtimes in that definition: [SPARK]
```

**After (parameters mismatch):**
```
Cannot update implementation: no definition found with the specified parameters (x: integer). Available parameter signatures: [(a: integer)]
```

### Why are the changes needed?

The previous error messages were misleading. A user receiving "runtime 'SPARK' not found" could not tell whether SPARK was truly absent or whether their parameter signature was wrong. This change makes the error messages actionable and helps users quickly identify the root cause.

Fixes #10002

### Does this PR introduce _any_ user-facing change?

Yes — error message text for failed `updateImpl`, `removeImpl`, and `addImpl` REST API calls is now more descriptive and actionable.

### How was this patch tested?

- Updated `testAlterFunctionUpdateImplNonExistingRuntime` and `testAlterFunctionRemoveImplNonExistingRuntime` to assert that the error message includes both the missing and available runtimes.
- Added `testAlterFunctionUpdateImplWrongParameters` and `testAlterFunctionRemoveImplWrongParameters` to verify that the "no definition found" error includes both the specified signature and available signatures.