### PR TITLE
[#9482] improvement(common): Enhance version parsing to support release candidates with validation

### DIFF
--- a/common/src/main/java/org/apache/gravitino/Version.java
+++ b/common/src/main/java/org/apache/gravitino/Version.java
@@ -36,7 +36,7 @@ public class Version {
 
   private static final int VERSION_PART_NUMBER = 3;
   private static final Pattern PATTERN =
-      Pattern.compile("^(\\d+)\\.(\\d+)\\.(\\d+)(?:rc(\\d{1,9})|-.*|\\.([a-zA-Z].*))?$");
+      Pattern.compile("^(\\d+)\\.(\\d+)\\.(\\d+)(?:rc(0|[1-9]\\d*)|-.*|\\.([a-zA-Z].*))?$");
 
   private static final Version INSTANCE = new Version();
 

--- a/common/src/test/java/org/apache/gravitino/TestVersion.java
+++ b/common/src/test/java/org/apache/gravitino/TestVersion.java
@@ -39,6 +39,12 @@ public class TestVersion {
         GravitinoRuntimeException.class, () -> Version.parseVersionNumber("1.1.0rc"));
     Assertions.assertThrowsExactly(
         GravitinoRuntimeException.class, () -> Version.parseVersionNumber("1.1.0rc-1"));
+    Assertions.assertThrowsExactly(
+        GravitinoRuntimeException.class, () -> Version.parseVersionNumber("1.1.0rc01"));
+    Assertions.assertThrowsExactly(
+        GravitinoRuntimeException.class, () -> Version.parseVersionNumber("1.1.0rc001"));
+    Assertions.assertThrowsExactly(
+        GravitinoRuntimeException.class, () -> Version.parseVersionNumber("1.1.0rc11xx"));
   }
 
   @Test


### PR DESCRIPTION
### What changes were proposed in this pull request?

This pull request updates the version parsing logic in `Version.java` to support release candidate (RC) versions and adds tests to ensure correct handling of RC numbers. The main changes include expanding the regex pattern to recognize RC versions, enforcing bounds on RC numbers, and introducing unit tests for these scenarios.


### Why are the changes needed?


To make it work when verifing release candidate version in the playground.

Fix: #9482 

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

UTs
