### PR TITLE
[#10041] fix(docs): Fix migration guide doc: the curl command `set the owner` is incorrect

### DIFF
--- a/docs/security/access-control.md
+++ b/docs/security/access-control.md
@@ -514,9 +514,9 @@ Set the owner for each existing metalake using the Gravitino API:
 ```shell
 curl -X PUT -H "Accept: application/vnd.gravitino.v1+json" \
 -H "Content-Type: application/json" -d '{
-  "owner": "admin1",
-  "ownerType": "USER"
-}' http://localhost:8090/api/metalakes/{metalake}/owners
+  "name": "admin1",
+  "type": "USER"
+}' http://localhost:8090/api/metalakes/${metalake}/owners/metalake/${metalake}
 ```
 
 </TabItem>


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix migration guide doc: the curl command `set the owner` is incorrect

### Why are the changes needed?

Fix: #10041 

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

N/A
