### PR TITLE
[#10034] fix(core): Fix loading table problem due to incorrect SQL sentence in fetch column infos (#10062)(cherry-pick)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,7 +110,7 @@ jobs:
     strategy:
       matrix:
         java-version: [ 17 ]
-    timeout-minutes: 60
+    timeout-minutes: 90
     needs: changes
     if: needs.changes.outputs.source_changes == 'true'
     # Steps represent a sequence of tasks that will be executed as part of the job

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/TableColumnBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/TableColumnBaseSQLProvider.java
@@ -123,7 +123,10 @@ public class TableColumnBaseSQLProvider {
         + " FROM "
         + TableColumnMapper.COLUMN_TABLE_NAME
         + " WHERE table_id = #{tableId} AND column_name = #{columnName} AND deleted_at = 0"
-        + " ORDER BY table_version DESC LIMIT 1";
+        // Update a column will generate two records with the same version, one with op_type = 2
+        // (update) and another with op_type = 3 (delete). We should not return NULL if both records
+        // exist with the same version, otherwise the caller will think the column does not exist.
+        + " ORDER BY table_version DESC, column_op_type ASC, id DESC LIMIT 1";
   }
 
   public String selectColumnPOById(@Param("columnId") Long columnId) {

--- a/core/src/test/java/org/apache/gravitino/storage/relational/service/TestTableColumnMetaService.java
+++ b/core/src/test/java/org/apache/gravitino/storage/relational/service/TestTableColumnMetaService.java
@@ -529,6 +529,70 @@ public class TestTableColumnMetaService extends TestJDBCBackend {
         () -> TableColumnMetaService.getInstance().getColumnPOById(updatedColumn.id()));
   }
 
+  @TestTemplate
+  public void testGetColumnIdByNamePrefersNonDeletedRecordInSameVersion() throws IOException {
+    String catalogName = "catalog1";
+    String schemaName = "schema1";
+    createParentEntities(METALAKE_NAME, catalogName, schemaName, AUDIT_INFO);
+
+    ColumnEntity oldColumn =
+        ColumnEntity.builder()
+            .withId(RandomIdGenerator.INSTANCE.nextId())
+            .withName("column1")
+            .withPosition(0)
+            .withComment("comment1")
+            .withDataType(Types.IntegerType.get())
+            .withNullable(true)
+            .withAutoIncrement(false)
+            .withDefaultValue(Literals.integerLiteral(1))
+            .withAuditInfo(AUDIT_INFO)
+            .build();
+
+    TableEntity createdTable =
+        TableEntity.builder()
+            .withId(RandomIdGenerator.INSTANCE.nextId())
+            .withName("table_same_name")
+            .withNamespace(Namespace.of(METALAKE_NAME, catalogName, schemaName))
+            .withColumns(Lists.newArrayList(oldColumn))
+            .withAuditInfo(AUDIT_INFO)
+            .build();
+    TableMetaService.getInstance().insertTable(createdTable, false);
+
+    TableEntity retrievedTable =
+        TableMetaService.getInstance().getTableByIdentifier(createdTable.nameIdentifier());
+
+    // Replace the column with a new column id but the same name in one table update.
+    ColumnEntity newColumn =
+        ColumnEntity.builder()
+            .withId(RandomIdGenerator.INSTANCE.nextId())
+            .withName("column1")
+            .withPosition(0)
+            .withComment("comment1_new")
+            .withDataType(Types.LongType.get())
+            .withNullable(true)
+            .withAutoIncrement(false)
+            .withDefaultValue(Literals.longLiteral(2L))
+            .withAuditInfo(AUDIT_INFO)
+            .build();
+
+    TableEntity updatedTable =
+        TableEntity.builder()
+            .withId(retrievedTable.id())
+            .withName(retrievedTable.name())
+            .withNamespace(retrievedTable.namespace())
+            .withColumns(Lists.newArrayList(newColumn))
+            .withAuditInfo(retrievedTable.auditInfo())
+            .build();
+
+    TableMetaService.getInstance()
+        .updateTable(retrievedTable.nameIdentifier(), old -> updatedTable);
+
+    Long selectedColumnId =
+        TableColumnMetaService.getInstance()
+            .getColumnIdByTableIdAndName(retrievedTable.id(), newColumn.name());
+    Assertions.assertEquals(newColumn.id(), selectedColumnId);
+  }
+
   private void compareTwoColumns(
       List<ColumnEntity> expectedColumns, List<ColumnEntity> actualColumns) {
     Assertions.assertEquals(expectedColumns.size(), actualColumns.size());


### PR DESCRIPTION

### What changes were proposed in this pull request?

This pull request introduces improvements to logging for column updates, refines the SQL query for selecting columns to prefer non-deleted records, and adds a new test to verify this behavior. The most important changes are grouped below by theme.


### Why are the changes needed?

It's a bug.

Fix: #10034


### Does this PR introduce _any_ user-facing change?

N/A.

### How was this patch tested?

Newly added UT and test locally.