### PR TITLE
[#9747][followup]feat(IRC): pass jdbc-schema-version config property to iceberg

### DIFF
--- a/catalogs/catalog-common/src/main/java/org/apache/gravitino/catalog/lakehouse/iceberg/IcebergConstants.java
+++ b/catalogs/catalog-common/src/main/java/org/apache/gravitino/catalog/lakehouse/iceberg/IcebergConstants.java
@@ -31,6 +31,9 @@ public class IcebergConstants {
   public static final String ICEBERG_JDBC_PASSWORD = "jdbc.password";
   public static final String ICEBERG_JDBC_INITIALIZE = "jdbc-initialize";
 
+  public static final String GRAVITINO_JDBC_SCHEMA_VERSION = "jdbc-schema-version";
+  public static final String ICEBERG_JDBC_SCHEMA_VERSION = "jdbc.schema-version";
+
   public static final String GRAVITINO_JDBC_DRIVER = "jdbc-driver";
   public static final String WAREHOUSE = "warehouse";
   public static final String URI = "uri";

--- a/catalogs/catalog-common/src/main/java/org/apache/gravitino/catalog/lakehouse/iceberg/IcebergPropertiesUtils.java
+++ b/catalogs/catalog-common/src/main/java/org/apache/gravitino/catalog/lakehouse/iceberg/IcebergPropertiesUtils.java
@@ -42,6 +42,9 @@ public class IcebergPropertiesUtils {
     map.put(IcebergConstants.GRAVITINO_JDBC_DRIVER, IcebergConstants.GRAVITINO_JDBC_DRIVER);
     map.put(IcebergConstants.GRAVITINO_JDBC_USER, IcebergConstants.ICEBERG_JDBC_USER);
     map.put(IcebergConstants.GRAVITINO_JDBC_PASSWORD, IcebergConstants.ICEBERG_JDBC_PASSWORD);
+    map.put(
+        IcebergConstants.GRAVITINO_JDBC_SCHEMA_VERSION,
+        IcebergConstants.ICEBERG_JDBC_SCHEMA_VERSION);
     map.put(IcebergConstants.URI, IcebergConstants.URI);
     map.put(IcebergConstants.WAREHOUSE, IcebergConstants.WAREHOUSE);
     map.put(IcebergConstants.CATALOG_BACKEND_NAME, IcebergConstants.CATALOG_BACKEND_NAME);

--- a/catalogs/catalog-common/src/test/java/org/apache/gravitino/lakehouse/iceberg/TestIcebergPropertiesUtils.java
+++ b/catalogs/catalog-common/src/test/java/org/apache/gravitino/lakehouse/iceberg/TestIcebergPropertiesUtils.java
@@ -29,6 +29,18 @@ import org.junit.jupiter.api.Test;
 public class TestIcebergPropertiesUtils {
 
   @Test
+  void testJdbcSchemaVersionPropertyIsMapped() {
+    Map<String, String> gravitinoProps =
+        ImmutableMap.of(IcebergConstants.GRAVITINO_JDBC_SCHEMA_VERSION, "V1");
+    Map<String, String> icebergProps =
+        IcebergPropertiesUtils.toIcebergCatalogProperties(gravitinoProps);
+    Assertions.assertEquals(
+        "V1",
+        icebergProps.get(IcebergConstants.ICEBERG_JDBC_SCHEMA_VERSION),
+        "jdbc-schema-version must be translated to jdbc.schema-version for Iceberg");
+  }
+
+  @Test
   void testGetCatalogBackendName() {
     Map<String, String> catalogProperties =
         ImmutableMap.of(


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

IcebergPropertiesUtils.toIcebergCatalogProperties() maps Gravitino config
keys to their Iceberg counterparts. The jdbc-schema-version property
(Gravitino key: 'jdbc-schema-version', Iceberg key: 'jdbc.schema-version')
was missing from the mapping

### Why are the changes needed?

Gravitino catalog config was silently ignored and never reached the underlying
JdbcCatalog. Without jdbc.schema-version=V1 the JDBC catalog does not support
view operations, causing UnsupportedOperationException on viewExists().


Fix: #(issue)

### Does this PR introduce _any_ user-facing change?

no

### How was this patch tested?

unit tests