### PR TITLE
[#9714] web-v2(UI): removeTopicFromStore after dropping topic

### DIFF
--- a/web-v2/web/src/lib/store/metalakes/index.js
+++ b/web-v2/web/src/lib/store/metalakes/index.js
@@ -1830,16 +1830,13 @@ export const appMetalakesSlice = createSlice({
     },
     removeTopicFromStore(state, action) {
       const { metalake, catalog, catalogType, schema, topic } = action.payload
-      const schemaKey = `{{${metalake}}}{{${catalog}}}{{${catalogType}}}{{${schema}}}`
-      const topicKey = `{{${metalake}}}{{${catalog}}}{{${catalogType}}}{{${schema}}}{{${topic}}}`
+      const effectiveCatalogType = catalogType || 'messaging'
+      const schemaKey = `{{${metalake}}}{{${catalog}}}{{${effectiveCatalogType}}}{{${schema}}}`
+      const topicKey = `{{${metalake}}}{{${catalog}}}{{${effectiveCatalogType}}}{{${schema}}}{{${topic}}}`
 
       state.topics = state.topics.filter(item => item.name !== topic)
       state.tableData = state.tableData.filter(item => !(item?.node === 'topic' && item?.name === topic))
       state.selectedNodes = state.selectedNodes.filter(key => key !== topicKey)
-
-      if (state.activatedDetails?.name === topic) {
-        state.activatedDetails = null
-      }
 
       const schemaNode = findInTree(state.metalakeTree, 'key', schemaKey)
       if (schemaNode?.children?.length) {


### PR DESCRIPTION
### What changes were proposed in this pull request?
`removeTopicFromStore` replace `fetchTopics` after dropping topic 


### Why are the changes needed?
topic broker sync issue

Fix: #9714

### Does this PR introduce _any_ user-facing change?
N/A

### How was this patch tested?
manually
