### PR TITLE
[#10128] fix(storage): validate GRAVITINO_HOME before building relative storage path

### DIFF
--- a/core/src/main/java/org/apache/gravitino/storage/relational/database/H2Database.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/database/H2Database.java
@@ -106,7 +106,13 @@ public class H2Database implements JDBCDatabase {
     Path path = Paths.get(dbPath);
     // Relative Path
     if (!path.isAbsolute()) {
-      path = Paths.get(System.getenv("GRAVITINO_HOME"), dbPath);
+      String gravitinoHome = System.getenv("GRAVITINO_HOME");
+      if (StringUtils.isBlank(gravitinoHome)) {
+        throw new IllegalArgumentException(
+            "GRAVITINO_HOME environment variable must be set when using relative storage path: "
+                + dbPath);
+      }
+      path = Paths.get(gravitinoHome, dbPath);
       return path.toString();
     }
 

--- a/core/src/test/java/org/apache/gravitino/storage/relational/database/TestH2Database.java
+++ b/core/src/test/java/org/apache/gravitino/storage/relational/database/TestH2Database.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.storage.relational.database;
+
+import java.lang.reflect.Method;
+import org.apache.gravitino.Config;
+import org.apache.gravitino.Configs;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TestH2Database {
+
+  @Test
+  public void testGetStoragePathWithRelativePathWhenGravitinoHomeMissing() throws Exception {
+    String javaBin = System.getProperty("java.home") + "/bin/java";
+    String classPath = System.getProperty("java.class.path");
+    String className =
+        "org.apache.gravitino.storage.relational.database.H2DatabaseStoragePathProbe";
+
+    ProcessBuilder pb = new ProcessBuilder(javaBin, "-cp", classPath, className);
+    pb.environment().remove("GRAVITINO_HOME");
+    Process process = pb.start();
+    int exitCode = process.waitFor();
+
+    Assertions.assertEquals(
+        1,
+        exitCode,
+        "Expected relative storage path resolution to fail when GRAVITINO_HOME is unset");
+  }
+}
+
+class H2DatabaseStoragePathProbe {
+  public static void main(String[] args) {
+    try {
+      Config config = new Config(false) {};
+      config.set(Configs.ENTITY_RELATIONAL_JDBC_BACKEND_PATH, "relative-db-path");
+
+      Method getStoragePath = H2Database.class.getDeclaredMethod("getStoragePath", Config.class);
+      getStoragePath.setAccessible(true);
+      getStoragePath.invoke(null, config);
+      System.exit(0);
+    } catch (Exception e) {
+      if (e.getCause() instanceof IllegalArgumentException
+          && e.getCause().getMessage().contains("GRAVITINO_HOME")) {
+        System.exit(1);
+      }
+      System.exit(2);
+    }
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add validation for GRAVITINO_HOME environment variable before building relative storage paths in H2Database.

## Why are the changes needed?

Currently, if GRAVITINO_HOME is not set and a relative storage path is configured, the code throws a NullPointerException at runtime during H2 initialization. This makes debugging difficult and causes startup failures.

Fix #10128

## Does this PR introduce any user-facing change?

Yes - users will now get a clear IllegalArgumentException with a descriptive message when GRAVITINO_HOME is missing, instead of a confusing NullPointerException.

## How was this patch tested?

- Added unit test TestH2Database.testGetStoragePathWithRelativePathWhenGravitinoHomeMissing()
- Test verifies that IllegalArgumentException is thrown when GRAVITINO_HOME is unset with relative path
- Existing tests should continue to pass