### PR TITLE
[#10136] fix(test): Replace brittle version count assertions with semantic checks in TestFilesetMetaService and TestFunctionMetaService

### DIFF
--- a/core/src/test/java/org/apache/gravitino/storage/relational/service/TestFilesetMetaService.java
+++ b/core/src/test/java/org/apache/gravitino/storage/relational/service/TestFilesetMetaService.java
@@ -199,20 +199,26 @@ public class TestFilesetMetaService extends TestJDBCBackend {
     }
     assertFalse(legacyRecordExistsInDB(fileset.id(), Entity.EntityType.FILESET));
     assertEquals(0, listFilesetVersions(fileset.id()).size());
-    assertEquals(3, listFilesetVersions(anotherFileset.id()).size());
+    Map<Integer, Long> anotherFilesetVersionsAfterHardDelete =
+        listFilesetVersions(anotherFileset.id());
+    assertTrue(anotherFilesetVersionsAfterHardDelete.containsKey(3));
+    assertEquals(0L, anotherFilesetVersionsAfterHardDelete.get(3));
 
     // soft delete for old version fileset
     for (Entity.EntityType entityType : Entity.EntityType.values()) {
       backend.deleteOldVersionData(entityType, 1);
     }
     Map<Integer, Long> versionDeletedMap = listFilesetVersions(anotherFileset.id());
-    assertEquals(3, versionDeletedMap.size());
+    assertTrue(versionDeletedMap.containsKey(3));
+    assertEquals(0L, versionDeletedMap.get(3));
     assertEquals(1, versionDeletedMap.values().stream().filter(value -> value == 0L).count());
-    assertEquals(2, versionDeletedMap.values().stream().filter(value -> value != 0L).count());
 
     // hard delete for old version fileset
     backend.hardDeleteLegacyData(Entity.EntityType.FILESET, Instant.now().toEpochMilli() + 1000);
-    assertEquals(1, listFilesetVersions(anotherFileset.id()).size());
+    Map<Integer, Long> finalFilesetVersions = listFilesetVersions(anotherFileset.id());
+    assertTrue(finalFilesetVersions.containsKey(3));
+    assertEquals(0L, finalFilesetVersions.get(3));
+    assertEquals(1, finalFilesetVersions.values().stream().filter(value -> value == 0L).count());
   }
 
   @TestTemplate

--- a/core/src/test/java/org/apache/gravitino/storage/relational/service/TestFunctionMetaService.java
+++ b/core/src/test/java/org/apache/gravitino/storage/relational/service/TestFunctionMetaService.java
@@ -347,20 +347,26 @@ public class TestFunctionMetaService extends TestJDBCBackend {
     }
     assertFalse(legacyRecordExistsInDB(function.id(), Entity.EntityType.FUNCTION));
     assertEquals(0, listFunctionVersions(function.id()).size());
-    assertEquals(3, listFunctionVersions(anotherFunction.id()).size());
+    Map<Integer, Long> anotherFunctionVersionsAfterHardDelete =
+        listFunctionVersions(anotherFunction.id());
+    assertTrue(anotherFunctionVersionsAfterHardDelete.containsKey(3));
+    assertEquals(0L, anotherFunctionVersionsAfterHardDelete.get(3));
 
     // Soft delete old versions
     for (Entity.EntityType entityType : Entity.EntityType.values()) {
       backend.deleteOldVersionData(entityType, 1);
     }
     Map<Integer, Long> versionDeletedMap = listFunctionVersions(anotherFunction.id());
-    assertEquals(3, versionDeletedMap.size());
+    assertTrue(versionDeletedMap.containsKey(3));
+    assertEquals(0L, versionDeletedMap.get(3));
     assertEquals(1, versionDeletedMap.values().stream().filter(value -> value == 0L).count());
-    assertEquals(2, versionDeletedMap.values().stream().filter(value -> value != 0L).count());
 
     // Hard delete old versions
     backend.hardDeleteLegacyData(Entity.EntityType.FUNCTION, Instant.now().toEpochMilli() + 1000);
-    assertEquals(1, listFunctionVersions(anotherFunction.id()).size());
+    Map<Integer, Long> finalFunctionVersions = listFunctionVersions(anotherFunction.id());
+    assertTrue(finalFunctionVersions.containsKey(3));
+    assertEquals(0L, finalFunctionVersions.get(3));
+    assertEquals(1, finalFunctionVersions.values().stream().filter(value -> value == 0L).count());
   }
 
   @TestTemplate


### PR DESCRIPTION
## What changes were proposed in this pull request?

Replaced fragile `assertEquals(N, listXxxVersions(...).size())` assertions in `TestFilesetMetaService` and `TestFunctionMetaService` with semantic checks that verify the semantically important invariants instead of exact row counts.

This is a follow-up to PR #10082 which applied the same fix to `TestPolicyMetaService`.

## Why are the changes needed?

Same reason as #10082: after `hardDeleteLegacyData` (which iterates over all EntityTypes), these tests assert exact version row counts. In PostgreSQL, `deleteXxxVersionsByLegacyTimeline` deletes **all** version rows with `deleted_at > 0` that are older than the legacy timeline — it does **not** filter by entity ID. This makes exact count assertions fragile under CI conditions.

For a recent CI failure, see: https://github.com/apache/gravitino/actions/runs/22559519486/job/65343121418?pr=10087

The semantically important invariant is that the **latest version (v3) remains active** (`deleted_at == 0`), not that all 3 rows still physically exist. Similarly after `deleteOldVersionData`, what matters is that v3 is active and exactly 1 row remains with `deleted_at == 0`.

## Does this PR introduce any user-facing changes?

No. This is a test-only change.

Fixes #10136