### PR TITLE
[#10129] Fix potential NPE in EventBus.dispatchEvent when baseEvent is null

### DIFF
--- a/core/src/main/java/org/apache/gravitino/listener/EventBus.java
+++ b/core/src/main/java/org/apache/gravitino/listener/EventBus.java
@@ -74,6 +74,7 @@ public class EventBus {
    *     SupportsChangingPreEvent}, otherwise {@link Optional#empty() empty}
    */
   public Optional<BaseEvent> dispatchEvent(BaseEvent baseEvent) {
+    Preconditions.checkNotNull(baseEvent, "baseEvent cannot be null");
     if (baseEvent instanceof PreEvent) {
       return dispatchAndTransformPreEvent((PreEvent) baseEvent);
     } else if (baseEvent instanceof Event) {

--- a/core/src/test/java/org/apache/gravitino/listener/TestEventBus.java
+++ b/core/src/test/java/org/apache/gravitino/listener/TestEventBus.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.listener;
+
+import java.util.Collections;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TestEventBus {
+
+  @Test
+  void testDispatchNullEventThrowsNullPointerException() {
+    EventBus eventBus = new EventBus(Collections.emptyList());
+    Assertions.assertThrows(NullPointerException.class, () -> eventBus.dispatchEvent(null));
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add an explicit null check using `Preconditions.checkNotNull` at the start of `EventBus.dispatchEvent()` to prevent `NullPointerException` when `baseEvent` is null.

### Why are the changes needed?

When `baseEvent` is null, the `else` branch in `dispatchEvent` builds an error message using `baseEvent.getClass().getSimpleName()`, which throws a `NullPointerException` instead of a clear error message.

Fix: [#10129](https://github.com/apache/gravitino/issues/10129)

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Added `TestEventBus` with a unit test verifying that dispatching a null event throws `NullPointerException` with a clear message instead of an uncontrolled NPE.

Signed-off-by: Nikita Nagar <permanayan84@gmail.com>