### PR TITLE
#10169 Fix race condition in AsyncQueueListener drop event logging

### DIFF
--- a/core/src/main/java/org/apache/gravitino/listener/AsyncQueueListener.java
+++ b/core/src/main/java/org/apache/gravitino/listener/AsyncQueueListener.java
@@ -54,8 +54,7 @@ public class AsyncQueueListener implements EventListenerPlugin {
   private final AtomicBoolean stopped = new AtomicBoolean(false);
   private final AtomicLong dropEventCounters = new AtomicLong(0);
   private final AtomicLong lastDropEventCounters = new AtomicLong(0);
-  private final AtomicReference<Instant> lastRecordDropEventTime =
-      new AtomicReference<>(Instant.EPOCH);
+  private final AtomicReference<Instant> lastRecordDropEventTime = new AtomicReference<>(Instant.EPOCH);
   private final String asyncQueueListenerName;
   private final int highWatermarkThreshold;
 

--- a/core/src/main/java/org/apache/gravitino/listener/AsyncQueueListener.java
+++ b/core/src/main/java/org/apache/gravitino/listener/AsyncQueueListener.java
@@ -28,6 +28,7 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 import org.apache.gravitino.listener.api.EventListenerPlugin;
 import org.apache.gravitino.listener.api.event.BaseEvent;
 import org.apache.gravitino.listener.api.event.Event;
@@ -53,7 +54,8 @@ public class AsyncQueueListener implements EventListenerPlugin {
   private final AtomicBoolean stopped = new AtomicBoolean(false);
   private final AtomicLong dropEventCounters = new AtomicLong(0);
   private final AtomicLong lastDropEventCounters = new AtomicLong(0);
-  private Instant lastRecordDropEventTime = Instant.EPOCH;
+  private final AtomicReference<Instant> lastRecordDropEventTime =
+      new AtomicReference<>(Instant.EPOCH);
   private final String asyncQueueListenerName;
   private final int highWatermarkThreshold;
 
@@ -151,14 +153,15 @@ public class AsyncQueueListener implements EventListenerPlugin {
     // 2. Thread B increment dropEventCounters and update lastDropEventCounters
     // 3. Thread A get lastDropEventCounters
     long dropEvents = currentDropEvents - lastDropEvents;
-    if (dropEvents > 0 && Instant.now().isAfter(lastRecordDropEventTime.plusSeconds(60))) {
+    Instant lastDropTime = lastRecordDropEventTime.get();
+    if (dropEvents > 0 && Instant.now().isAfter(lastDropTime.plusSeconds(60))) {
       if (lastDropEventCounters.compareAndSet(lastDropEvents, currentDropEvents)) {
         LOG.warn(
             "{} drop {} events since {}",
             asyncQueueListenerName,
             dropEvents,
-            lastRecordDropEventTime);
-        lastRecordDropEventTime = Instant.now();
+            lastDropTime);
+        lastRecordDropEventTime.set(Instant.now());
       }
     }
   }

--- a/core/src/main/java/org/apache/gravitino/listener/AsyncQueueListener.java
+++ b/core/src/main/java/org/apache/gravitino/listener/AsyncQueueListener.java
@@ -54,7 +54,8 @@ public class AsyncQueueListener implements EventListenerPlugin {
   private final AtomicBoolean stopped = new AtomicBoolean(false);
   private final AtomicLong dropEventCounters = new AtomicLong(0);
   private final AtomicLong lastDropEventCounters = new AtomicLong(0);
-  private final AtomicReference<Instant> lastRecordDropEventTime = new AtomicReference<>(Instant.EPOCH);
+  private final AtomicReference<Instant> lastRecordDropEventTime =
+      new AtomicReference<>(Instant.EPOCH);
   private final String asyncQueueListenerName;
   private final int highWatermarkThreshold;
 
@@ -155,11 +156,7 @@ public class AsyncQueueListener implements EventListenerPlugin {
     Instant lastDropTime = lastRecordDropEventTime.get();
     if (dropEvents > 0 && Instant.now().isAfter(lastDropTime.plusSeconds(60))) {
       if (lastDropEventCounters.compareAndSet(lastDropEvents, currentDropEvents)) {
-        LOG.warn(
-            "{} drop {} events since {}",
-            asyncQueueListenerName,
-            dropEvents,
-            lastDropTime);
+        LOG.warn("{} drop {} events since {}", asyncQueueListenerName, dropEvents, lastDropTime);
         lastRecordDropEventTime.set(Instant.now());
       }
     }

--- a/core/src/main/java/org/apache/gravitino/listener/AsyncQueueListener.java
+++ b/core/src/main/java/org/apache/gravitino/listener/AsyncQueueListener.java
@@ -153,11 +153,12 @@ public class AsyncQueueListener implements EventListenerPlugin {
     // 2. Thread B increment dropEventCounters and update lastDropEventCounters
     // 3. Thread A get lastDropEventCounters
     long dropEvents = currentDropEvents - lastDropEvents;
+    Instant now = Instant.now();
     Instant lastDropTime = lastRecordDropEventTime.get();
-    if (dropEvents > 0 && Instant.now().isAfter(lastDropTime.plusSeconds(60))) {
+    if (dropEvents > 0 && now.isAfter(lastDropTime.plusSeconds(60))) {
       if (lastDropEventCounters.compareAndSet(lastDropEvents, currentDropEvents)) {
         LOG.warn("{} drop {} events since {}", asyncQueueListenerName, dropEvents, lastDropTime);
-        lastRecordDropEventTime.set(Instant.now());
+        lastRecordDropEventTime.set(now);
       }
     }
   }

--- a/core/src/test/java/org/apache/gravitino/listener/TestAsyncQueueListenerConcurrency.java
+++ b/core/src/test/java/org/apache/gravitino/listener/TestAsyncQueueListenerConcurrency.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.listener;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.listener.api.EventListenerPlugin;
+import org.apache.gravitino.listener.api.event.Event;
+import org.apache.gravitino.listener.api.event.OperationStatus;
+import org.apache.gravitino.listener.api.event.PreEvent;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TestAsyncQueueListenerConcurrency {
+
+  static class DummyEvent extends Event {
+
+    protected DummyEvent(String user, NameIdentifier identifier) {
+      super(user, identifier);
+    }
+
+    @Override
+    public OperationStatus operationStatus() {
+      return OperationStatus.SUCCESS;
+    }
+  }
+
+  static class NoOpListener implements EventListenerPlugin {
+    @Override
+    public void init(Map<String, String> properties) {}
+
+    @Override
+    public void start() {}
+
+    @Override
+    public void stop() {}
+
+    @Override
+    public void onPostEvent(Event event) {}
+
+    @Override
+    public void onPreEvent(PreEvent event) {}
+  }
+
+  @Test
+  void testConcurrentDropEventsDoNotThrow() throws InterruptedException {
+    // Create a queue with capacity 1 so events are dropped quickly.
+    List<EventListenerPlugin> listeners = Collections.singletonList(new NoOpListener());
+    AsyncQueueListener asyncQueueListener =
+        new AsyncQueueListener(listeners, "concurrency-test", 1, 5);
+    asyncQueueListener.start();
+
+    int threadCount = 10;
+    int eventsPerThread = 100;
+    ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+    CountDownLatch latch = new CountDownLatch(threadCount);
+    List<Throwable> errors = Collections.synchronizedList(new ArrayList<>());
+
+    for (int t = 0; t < threadCount; t++) {
+      executor.submit(
+          () -> {
+            try {
+              for (int i = 0; i < eventsPerThread; i++) {
+                asyncQueueListener.onPostEvent(
+                    new DummyEvent("user", NameIdentifier.of("ns", "name")));
+              }
+            } catch (Exception e) {
+              errors.add(e);
+            } finally {
+              latch.countDown();
+            }
+          });
+    }
+
+    latch.await(30, TimeUnit.SECONDS);
+    executor.shutdown();
+    asyncQueueListener.stop();
+
+    Assertions.assertTrue(
+        errors.isEmpty(), "Concurrent event enqueue should not throw: " + errors);
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

Replace the plain `Instant` field `lastRecordDropEventTime` with `AtomicReference<Instant>` in `AsyncQueueListener` to fix a race condition in the drop event logging throttle.

### Why are the changes needed?

Fix: #10169

The `lastRecordDropEventTime` field is read and written by multiple concurrent event producer threads (via `enqueueEvent` → `logDropEventsIfNecessary`), but it was a non-volatile, unsynchronized `Instant` field. This causes two issues:

1. **Visibility**: Without `volatile` or atomic semantics, writes by one thread may never be seen by other threads due to CPU caching / Java Memory Model.
2. **Consistency**: A thread could read a stale `lastRecordDropEventTime` for the time-gate check, then log an incorrect "since" timestamp.

### How was this patch tested?

- Added `TestAsyncQueueListenerConcurrency` with a test that spawns 10 threads each enqueuing 100 events into a capacity-1 queue, exercising the concurrent drop path and verifying no exceptions are thrown.
- Existing tests in `TestEventListenerManager` continue to pass.

### Changes summary

| File | Change |
|------|--------|
| `AsyncQueueListener.java` | `Instant lastRecordDropEventTime` → `AtomicReference<Instant> lastRecordDropEventTime`; snapshot to local var before time-gate check |
| `TestAsyncQueueListenerConcurrency.java` | New test for concurrent event drop safety |