### PR TITLE
[#10171] fix(server): Add null request body checks to REST create/register endpoints

### DIFF
--- a/server/src/main/java/org/apache/gravitino/server/web/rest/FilesetOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/FilesetOperations.java
@@ -144,6 +144,12 @@ public class FilesetOperations {
       @PathParam("catalog") @AuthorizationMetadata(type = Entity.EntityType.CATALOG) String catalog,
       @PathParam("schema") @AuthorizationMetadata(type = Entity.EntityType.SCHEMA) String schema,
       FilesetCreateRequest request) {
+    if (request == null) {
+      LOG.warn("Received create fileset request with null request body");
+      return ExceptionHandlers.handleFilesetException(
+          OperationType.CREATE, "", schema, new IllegalArgumentException("Request body cannot be null"));
+    }
+
     LOG.info(
         "Received create fileset request: {}.{}.{}.{}",
         metalake,

--- a/server/src/main/java/org/apache/gravitino/server/web/rest/FunctionOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/FunctionOperations.java
@@ -127,6 +127,12 @@ public class FunctionOperations {
       @PathParam("catalog") String catalog,
       @PathParam("schema") String schema,
       FunctionRegisterRequest request) {
+    if (request == null) {
+      LOG.warn("Received register function request with null request body");
+      return ExceptionHandlers.handleFunctionException(
+          OperationType.REGISTER, "", schema, new IllegalArgumentException("Request body cannot be null"));
+    }
+
     LOG.info(
         "Received register function request: {}.{}.{}.{}",
         metalake,

--- a/server/src/main/java/org/apache/gravitino/server/web/rest/JobOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/JobOperations.java
@@ -150,6 +150,12 @@ public class JobOperations {
       @PathParam("metalake") @AuthorizationMetadata(type = Entity.EntityType.METALAKE)
           String metalake,
       JobTemplateRegisterRequest request) {
+    if (request == null) {
+      LOG.warn("Received register job template request with null request body");
+      return ExceptionHandlers.handleJobTemplateException(
+          OperationType.REGISTER, "", metalake, new IllegalArgumentException("Request body cannot be null"));
+    }
+
     LOG.info(
         "Received request to register job template {} in metalake: {}",
         request.getJobTemplate().name(),
@@ -356,6 +362,12 @@ public class JobOperations {
           String metalake,
       @AuthorizationRequest(type = AuthorizationRequest.RequestType.RUN_JOB)
           JobRunRequest request) {
+    if (request == null) {
+      LOG.warn("Received run job request with null request body");
+      return ExceptionHandlers.handleJobException(
+          OperationType.RUN, "", metalake, new IllegalArgumentException("Request body cannot be null"));
+    }
+
     LOG.info(
         "Received request to run job {} in metalake: {}", request.getJobTemplateName(), metalake);
 

--- a/server/src/main/java/org/apache/gravitino/server/web/rest/ModelOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/ModelOperations.java
@@ -172,6 +172,12 @@ public class ModelOperations {
       @PathParam("catalog") @AuthorizationMetadata(type = Entity.EntityType.CATALOG) String catalog,
       @PathParam("schema") @AuthorizationMetadata(type = Entity.EntityType.SCHEMA) String schema,
       ModelRegisterRequest request) {
+    if (request == null) {
+      LOG.warn("Received register model request with null request body");
+      return ExceptionHandlers.handleModelException(
+          OperationType.REGISTER, "", schema, new IllegalArgumentException("Request body cannot be null"));
+    }
+
     LOG.info(
         "Received register model request: {}.{}.{}.{}",
         metalake,

--- a/server/src/main/java/org/apache/gravitino/server/web/rest/SchemaOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/SchemaOperations.java
@@ -122,6 +122,12 @@ public class SchemaOperations {
           String metalake,
       @PathParam("catalog") @AuthorizationMetadata(type = Entity.EntityType.CATALOG) String catalog,
       SchemaCreateRequest request) {
+    if (request == null) {
+      LOG.warn("Received create schema request with null request body");
+      return ExceptionHandlers.handleSchemaException(
+          OperationType.CREATE, "", catalog, new IllegalArgumentException("Request body cannot be null"));
+    }
+
     LOG.info("Received create schema request: {}.{}.{}", metalake, catalog, request.getName());
     try {
       return Utils.doAs(

--- a/server/src/main/java/org/apache/gravitino/server/web/rest/TableOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/TableOperations.java
@@ -131,6 +131,12 @@ public class TableOperations {
       @PathParam("catalog") @AuthorizationMetadata(type = Entity.EntityType.CATALOG) String catalog,
       @PathParam("schema") @AuthorizationMetadata(type = Entity.EntityType.SCHEMA) String schema,
       TableCreateRequest request) {
+    if (request == null) {
+      LOG.warn("Received create table request with null request body");
+      return ExceptionHandlers.handleTableException(
+          OperationType.CREATE, "", schema, new IllegalArgumentException("Request body cannot be null"));
+    }
+
     LOG.info(
         "Received create table request: {}.{}.{}.{}", metalake, catalog, schema, request.getName());
     try {

--- a/server/src/test/java/org/apache/gravitino/server/web/rest/TestFilesetOperations.java
+++ b/server/src/test/java/org/apache/gravitino/server/web/rest/TestFilesetOperations.java
@@ -696,6 +696,23 @@ public class TestFilesetOperations extends BaseOperationsTest {
     Assertions.assertEquals(updatedFileset.properties(), filesetDTO.properties());
   }
 
+  @Test
+  public void testCreateFilesetWithNullRequestBody() {
+    Response resp =
+        target(filesetPath(metalake, catalog, schema))
+            .request(MediaType.APPLICATION_JSON_TYPE)
+            .accept("application/vnd.gravitino.v1+json")
+            .post(Entity.entity(null, MediaType.APPLICATION_JSON_TYPE));
+
+    Assertions.assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), resp.getStatus());
+
+    ErrorResponse errorResponse = resp.readEntity(ErrorResponse.class);
+    Assertions.assertEquals(ErrorConstants.ILLEGAL_ARGUMENTS_CODE, errorResponse.getCode());
+    Assertions.assertEquals(
+        IllegalArgumentException.class.getSimpleName(), errorResponse.getType());
+    Assertions.assertTrue(errorResponse.getMessage().contains("Request body cannot be null"));
+  }
+
   private static String filesetPath(String metalake, String catalog, String schema) {
     return new StringBuilder()
         .append("/metalakes/")

--- a/server/src/test/java/org/apache/gravitino/server/web/rest/TestFunctionOperations.java
+++ b/server/src/test/java/org/apache/gravitino/server/web/rest/TestFunctionOperations.java
@@ -649,6 +649,23 @@ public class TestFunctionOperations extends BaseOperationsTest {
     Assertions.assertEquals(RuntimeException.class.getSimpleName(), errorResp1.getType());
   }
 
+  @Test
+  public void testRegisterFunctionWithNullRequestBody() {
+    Response resp =
+        target(functionPath())
+            .request(MediaType.APPLICATION_JSON_TYPE)
+            .accept("application/vnd.gravitino.v1+json")
+            .post(Entity.entity(null, MediaType.APPLICATION_JSON_TYPE));
+
+    Assertions.assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), resp.getStatus());
+
+    ErrorResponse errorResponse = resp.readEntity(ErrorResponse.class);
+    Assertions.assertEquals(ErrorConstants.ILLEGAL_ARGUMENTS_CODE, errorResponse.getCode());
+    Assertions.assertEquals(
+        IllegalArgumentException.class.getSimpleName(), errorResponse.getType());
+    Assertions.assertTrue(errorResponse.getMessage().contains("Request body cannot be null"));
+  }
+
   private String functionPath() {
     return "/metalakes/" + metalake + "/catalogs/" + catalog + "/schemas/" + schema + "/functions";
   }

--- a/server/src/test/java/org/apache/gravitino/server/web/rest/TestJobOperations.java
+++ b/server/src/test/java/org/apache/gravitino/server/web/rest/TestJobOperations.java
@@ -830,6 +830,40 @@ public class TestJobOperations extends JerseyTest {
     Assertions.assertEquals(NoSuchJobException.class.getSimpleName(), errorResp.getType());
   }
 
+  @Test
+  public void testRegisterJobTemplateWithNullRequestBody() {
+    Response resp =
+        target(jobTemplatePath())
+            .request(MediaType.APPLICATION_JSON_TYPE)
+            .accept("application/vnd.gravitino.v1+json")
+            .post(Entity.entity(null, MediaType.APPLICATION_JSON_TYPE));
+
+    Assertions.assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), resp.getStatus());
+
+    ErrorResponse errorResponse = resp.readEntity(ErrorResponse.class);
+    Assertions.assertEquals(ErrorConstants.ILLEGAL_ARGUMENTS_CODE, errorResponse.getCode());
+    Assertions.assertEquals(
+        IllegalArgumentException.class.getSimpleName(), errorResponse.getType());
+    Assertions.assertTrue(errorResponse.getMessage().contains("Request body cannot be null"));
+  }
+
+  @Test
+  public void testRunJobWithNullRequestBody() {
+    Response resp =
+        target(jobRunPath())
+            .request(MediaType.APPLICATION_JSON_TYPE)
+            .accept("application/vnd.gravitino.v1+json")
+            .post(Entity.entity(null, MediaType.APPLICATION_JSON_TYPE));
+
+    Assertions.assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), resp.getStatus());
+
+    ErrorResponse errorResponse = resp.readEntity(ErrorResponse.class);
+    Assertions.assertEquals(ErrorConstants.ILLEGAL_ARGUMENTS_CODE, errorResponse.getCode());
+    Assertions.assertEquals(
+        IllegalArgumentException.class.getSimpleName(), errorResponse.getType());
+    Assertions.assertTrue(errorResponse.getMessage().contains("Request body cannot be null"));
+  }
+
   private String jobTemplatePath() {
     return "/metalakes/" + metalake + "/jobs/templates";
   }

--- a/server/src/test/java/org/apache/gravitino/server/web/rest/TestModelOperations.java
+++ b/server/src/test/java/org/apache/gravitino/server/web/rest/TestModelOperations.java
@@ -1530,6 +1530,23 @@ public class TestModelOperations extends BaseOperationsTest {
     Assertions.assertEquals(RuntimeException.class.getSimpleName(), errorResp3.getType());
   }
 
+  @Test
+  public void testRegisterModelWithNullRequestBody() {
+    Response resp =
+        target(modelPath())
+            .request(MediaType.APPLICATION_JSON_TYPE)
+            .accept("application/vnd.gravitino.v1+json")
+            .post(Entity.entity(null, MediaType.APPLICATION_JSON_TYPE));
+
+    Assertions.assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), resp.getStatus());
+
+    ErrorResponse errorResponse = resp.readEntity(ErrorResponse.class);
+    Assertions.assertEquals(ErrorConstants.ILLEGAL_ARGUMENTS_CODE, errorResponse.getCode());
+    Assertions.assertEquals(
+        IllegalArgumentException.class.getSimpleName(), errorResponse.getType());
+    Assertions.assertTrue(errorResponse.getMessage().contains("Request body cannot be null"));
+  }
+
   private String modelPath() {
     return "/metalakes/" + metalake + "/catalogs/" + catalog + "/schemas/" + schema + "/models";
   }

--- a/server/src/test/java/org/apache/gravitino/server/web/rest/TestSchemaOperations.java
+++ b/server/src/test/java/org/apache/gravitino/server/web/rest/TestSchemaOperations.java
@@ -476,6 +476,23 @@ public class TestSchemaOperations extends BaseOperationsTest {
     Assertions.assertEquals(RuntimeException.class.getSimpleName(), errorResp4.getType());
   }
 
+  @Test
+  public void testCreateSchemaWithNullRequestBody() {
+    Response resp =
+        target("/metalakes/" + metalake + "/catalogs/" + catalog + "/schemas")
+            .request(MediaType.APPLICATION_JSON_TYPE)
+            .accept("application/vnd.gravitino.v1+json")
+            .post(javax.ws.rs.client.Entity.entity(null, MediaType.APPLICATION_JSON_TYPE));
+
+    Assertions.assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), resp.getStatus());
+
+    ErrorResponse errorResponse = resp.readEntity(ErrorResponse.class);
+    Assertions.assertEquals(ErrorConstants.ILLEGAL_ARGUMENTS_CODE, errorResponse.getCode());
+    Assertions.assertEquals(
+        IllegalArgumentException.class.getSimpleName(), errorResponse.getType());
+    Assertions.assertTrue(errorResponse.getMessage().contains("Request body cannot be null"));
+  }
+
   private static Schema mockSchema(String name, String comment, Map<String, String> properties) {
     Schema mockSchema = mock(Schema.class);
     when(mockSchema.name()).thenReturn(name);

--- a/server/src/test/java/org/apache/gravitino/server/web/rest/TestTableOperations.java
+++ b/server/src/test/java/org/apache/gravitino/server/web/rest/TestTableOperations.java
@@ -912,6 +912,23 @@ public class TestTableOperations extends BaseOperationsTest {
     Assertions.assertArrayEquals(tableDTO.index(), updatedTable.index());
   }
 
+  @Test
+  public void testCreateTableWithNullRequestBody() {
+    Response resp =
+        target(tablePath(metalake, catalog, schema))
+            .request(MediaType.APPLICATION_JSON_TYPE)
+            .accept("application/vnd.gravitino.v1+json")
+            .post(Entity.entity(null, MediaType.APPLICATION_JSON_TYPE));
+
+    Assertions.assertEquals(Status.BAD_REQUEST.getStatusCode(), resp.getStatus());
+
+    ErrorResponse errorResponse = resp.readEntity(ErrorResponse.class);
+    Assertions.assertEquals(ErrorConstants.ILLEGAL_ARGUMENTS_CODE, errorResponse.getCode());
+    Assertions.assertEquals(
+        IllegalArgumentException.class.getSimpleName(), errorResponse.getType());
+    Assertions.assertTrue(errorResponse.getMessage().contains("Request body cannot be null"));
+  }
+
   private static String tablePath(String metalake, String catalog, String schema) {
     return new StringBuilder()
         .append("/metalakes/")


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add null checks for request body parameters before accessing request fields in REST endpoints. Previously, if request deserialization yielded `null` (e.g., empty body, literal JSON `null`, or binding edge cases), accessing `request.getName()` or similar methods before the `try` block would trigger an uncaught `NullPointerException`, bypassing the expected `ExceptionHandlers` error handling path.

### Why are the changes needed?

Several REST endpoints dereference `request` fields (e.g., `request.getName()`, `request.getJobTemplateName()`) before entering their `try` block. This causes uncaught NPEs that bypass the structured error response path, returning unhelpful 500 errors instead of proper 400 Bad Request responses.

Fix #10171

### Does this PR introduce _any_ user-facing change?

No API changes. Null request bodies now return a structured `400 Bad Request` error response instead of an unhandled `500 Internal Server Error`.

### How was this patch tested?

Added unit tests for null request body behavior in all matching REST test classes:
- `TestTableOperations.testCreateTableWithNullRequestBody`
- `TestFilesetOperations.testCreateFilesetWithNullRequestBody`
- `TestFunctionOperations.testRegisterFunctionWithNullRequestBody`
- `TestModelOperations.testRegisterModelWithNullRequestBody`
- `TestSchemaOperations.testCreateSchemaWithNullRequestBody`
- `TestJobOperations.testRegisterJobTemplateWithNullRequestBody`
- `TestJobOperations.testRunJobWithNullRequestBody`

### Affected endpoints

| File | Method |
|------|--------|
| `TableOperations.java` | `createTable` |
| `FilesetOperations.java` | `createFileset` |
| `FunctionOperations.java` | `registerFunction` |
| `ModelOperations.java` | `registerModel` |
| `SchemaOperations.java` | `createSchema` |
| `JobOperations.java` | `registerJobTemplate` |
| `JobOperations.java` | `runJob` |