### PR TITLE
[#10172] fix(server): Guard catch-block request dereferences in REST handlers

### DIFF
--- a/server/src/main/java/org/apache/gravitino/server/web/rest/CatalogOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/CatalogOperations.java
@@ -162,7 +162,7 @@ public class CatalogOperations {
 
     } catch (Exception e) {
       return ExceptionHandlers.handleCatalogException(
-          OperationType.CREATE, request.getName(), metalake, e);
+          OperationType.CREATE, request != null ? request.getName() : "", metalake, e);
     }
   }
 
@@ -198,7 +198,10 @@ public class CatalogOperations {
           });
 
     } catch (Exception e) {
-      LOG.info("Failed to test connection for catalog: {}.{}", metalake, request.getName());
+      LOG.info(
+          "Failed to test connection for catalog: {}.{}",
+          metalake,
+          request != null ? request.getName() : "");
       return ExceptionHandlers.handleTestConnectionException(e);
     }
   }
@@ -244,7 +247,7 @@ public class CatalogOperations {
     } catch (Exception e) {
       LOG.info(
           "Failed to {} catalog: {}.{}",
-          request.isInUse() ? "enable" : "disable",
+          request != null ? (request.isInUse() ? "enable" : "disable") : "set",
           metalake,
           catalogName);
       return ExceptionHandlers.handleCatalogException(op, catalogName, metalake, e);

--- a/server/src/main/java/org/apache/gravitino/server/web/rest/FilesetOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/FilesetOperations.java
@@ -181,7 +181,7 @@ public class FilesetOperations {
 
     } catch (Exception e) {
       return ExceptionHandlers.handleFilesetException(
-          OperationType.CREATE, request.getName(), schema, e);
+          OperationType.CREATE, request != null ? request.getName() : "", schema, e);
     }
   }
 

--- a/server/src/main/java/org/apache/gravitino/server/web/rest/FunctionOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/FunctionOperations.java
@@ -161,7 +161,7 @@ public class FunctionOperations {
           });
     } catch (Exception e) {
       return ExceptionHandlers.handleFunctionException(
-          OperationType.REGISTER, request.getName(), schema, e);
+          OperationType.REGISTER, request != null ? request.getName() : "", schema, e);
     }
   }
 

--- a/server/src/main/java/org/apache/gravitino/server/web/rest/GroupOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/GroupOperations.java
@@ -116,7 +116,7 @@ public class GroupOperations {
           });
     } catch (Exception e) {
       return ExceptionHandlers.handleGroupException(
-          OperationType.ADD, request.getName(), metalake, e);
+          OperationType.ADD, request != null ? request.getName() : "", metalake, e);
     }
   }
 

--- a/server/src/main/java/org/apache/gravitino/server/web/rest/JobOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/JobOperations.java
@@ -173,7 +173,12 @@ public class JobOperations {
 
     } catch (Exception e) {
       return ExceptionHandlers.handleJobTemplateException(
-          OperationType.REGISTER, request.getJobTemplate().name(), metalake, e);
+          OperationType.REGISTER,
+          request != null && request.getJobTemplate() != null
+              ? request.getJobTemplate().name()
+              : "",
+          metalake,
+          e);
     }
   }
 

--- a/server/src/main/java/org/apache/gravitino/server/web/rest/MetalakeOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/MetalakeOperations.java
@@ -201,9 +201,16 @@ public class MetalakeOperations {
           });
 
     } catch (Exception e) {
-      LOG.info("Failed to {} metalake: {}", request.isInUse() ? "enable" : "disable", metalakeName);
+      LOG.info(
+          "Failed to {} metalake: {}",
+          request != null ? (request.isInUse() ? "enable" : "disable") : "set",
+          metalakeName);
       return ExceptionHandlers.handleMetalakeException(
-          request.isInUse() ? OperationType.ENABLE : OperationType.DISABLE, metalakeName, e);
+          request != null
+              ? (request.isInUse() ? OperationType.ENABLE : OperationType.DISABLE)
+              : OperationType.ENABLE,
+          metalakeName,
+          e);
     }
   }
 

--- a/server/src/main/java/org/apache/gravitino/server/web/rest/ModelOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/ModelOperations.java
@@ -196,7 +196,7 @@ public class ModelOperations {
 
     } catch (Exception e) {
       return ExceptionHandlers.handleModelException(
-          OperationType.REGISTER, request.getName(), schema, e);
+          OperationType.REGISTER, request != null ? request.getName() : "", schema, e);
     }
   }
 

--- a/server/src/main/java/org/apache/gravitino/server/web/rest/PermissionOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/PermissionOperations.java
@@ -102,7 +102,10 @@ public class PermissionOperations {
           });
     } catch (Exception e) {
       return ExceptionHandlers.handleUserPermissionOperationException(
-          OperationType.GRANT, StringUtils.join(request.getRoleNames(), ","), user, e);
+          OperationType.GRANT,
+          request != null ? StringUtils.join(request.getRoleNames(), ",") : "",
+          user,
+          e);
     }
   }
 
@@ -131,7 +134,10 @@ public class PermissionOperations {
           });
     } catch (Exception e) {
       return ExceptionHandlers.handleGroupPermissionOperationException(
-          OperationType.GRANT, StringUtils.join(request.getRoleNames(), ","), group, e);
+          OperationType.GRANT,
+          request != null ? StringUtils.join(request.getRoleNames(), ",") : "",
+          group,
+          e);
     }
   }
 
@@ -160,7 +166,10 @@ public class PermissionOperations {
           });
     } catch (Exception e) {
       return ExceptionHandlers.handleUserPermissionOperationException(
-          OperationType.REVOKE, StringUtils.join(request.getRoleNames(), ","), user, e);
+          OperationType.REVOKE,
+          request != null ? StringUtils.join(request.getRoleNames(), ",") : "",
+          user,
+          e);
     }
   }
 
@@ -189,7 +198,10 @@ public class PermissionOperations {
           });
     } catch (Exception e) {
       return ExceptionHandlers.handleGroupPermissionOperationException(
-          OperationType.REVOKE, StringUtils.join(request.getRoleNames()), group, e);
+          OperationType.REVOKE,
+          request != null ? StringUtils.join(request.getRoleNames()) : "",
+          group,
+          e);
     }
   }
 

--- a/server/src/main/java/org/apache/gravitino/server/web/rest/PolicyOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/PolicyOperations.java
@@ -163,7 +163,7 @@ public class PolicyOperations {
           });
     } catch (Exception e) {
       return ExceptionHandlers.handlePolicyException(
-          OperationType.CREATE, request.getName(), metalake, e);
+          OperationType.CREATE, request != null ? request.getName() : "", metalake, e);
     }
   }
 

--- a/server/src/main/java/org/apache/gravitino/server/web/rest/RoleOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/RoleOperations.java
@@ -198,7 +198,7 @@ public class RoleOperations {
 
     } catch (Exception e) {
       return ExceptionHandlers.handleRoleException(
-          OperationType.CREATE, request.getName(), metalake, e);
+          OperationType.CREATE, request != null ? request.getName() : "", metalake, e);
     }
   }
 

--- a/server/src/main/java/org/apache/gravitino/server/web/rest/SchemaOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/SchemaOperations.java
@@ -139,7 +139,7 @@ public class SchemaOperations {
 
     } catch (Exception e) {
       return ExceptionHandlers.handleSchemaException(
-          OperationType.CREATE, request.getName(), catalog, e);
+          OperationType.CREATE, request != null ? request.getName() : "", catalog, e);
     }
   }
 

--- a/server/src/main/java/org/apache/gravitino/server/web/rest/StatisticOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/StatisticOperations.java
@@ -188,7 +188,10 @@ public class StatisticOperations {
           });
     } catch (Exception e) {
       return ExceptionHandlers.handleStatisticException(
-          OperationType.UPDATE, StringUtils.join(request.getUpdates().keySet(), ","), fullName, e);
+          OperationType.UPDATE,
+          request != null ? StringUtils.join(request.getUpdates().keySet(), ",") : "",
+          fullName,
+          e);
     }
   }
 
@@ -236,7 +239,10 @@ public class StatisticOperations {
           });
     } catch (Exception e) {
       return ExceptionHandlers.handleStatisticException(
-          OperationType.DROP, StringUtils.join(request.getNames(), ","), fullName, e);
+          OperationType.DROP,
+          request != null ? StringUtils.join(request.getNames(), ",") : "",
+          fullName,
+          e);
     }
   }
 
@@ -399,11 +405,13 @@ public class StatisticOperations {
           metalake,
           e);
       String partitions =
-          StringUtils.joinWith(
-              ",",
-              request.getUpdates().stream()
-                  .map(PartitionStatisticsUpdateDTO::partitionName)
-                  .collect(Collectors.toList()));
+          request != null
+              ? StringUtils.joinWith(
+                  ",",
+                  request.getUpdates().stream()
+                      .map(PartitionStatisticsUpdateDTO::partitionName)
+                      .collect(Collectors.toList()))
+              : "";
       return ExceptionHandlers.handlePartitionStatsException(
           OperationType.UPDATE, partitions, fullName, e);
     }
@@ -461,11 +469,13 @@ public class StatisticOperations {
           metalake,
           e);
       String partitions =
-          StringUtils.joinWith(
-              ",",
-              request.getDrops().stream()
-                  .map(PartitionStatisticsDropDTO::partitionName)
-                  .collect(Collectors.toList()));
+          request != null
+              ? StringUtils.joinWith(
+                  ",",
+                  request.getDrops().stream()
+                      .map(PartitionStatisticsDropDTO::partitionName)
+                      .collect(Collectors.toList()))
+              : "";
       return ExceptionHandlers.handlePartitionStatsException(
           OperationType.DROP, partitions, fullName, e);
     }

--- a/server/src/main/java/org/apache/gravitino/server/web/rest/TableOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/TableOperations.java
@@ -164,7 +164,7 @@ public class TableOperations {
 
     } catch (Exception e) {
       return ExceptionHandlers.handleTableException(
-          OperationType.CREATE, request.getName(), schema, e);
+          OperationType.CREATE, request != null ? request.getName() : "", schema, e);
     }
   }
 

--- a/server/src/main/java/org/apache/gravitino/server/web/rest/TagOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/TagOperations.java
@@ -164,7 +164,7 @@ public class TagOperations {
           });
     } catch (Exception e) {
       return ExceptionHandlers.handleTagException(
-          OperationType.CREATE, request.getName(), metalake, e);
+          OperationType.CREATE, request != null ? request.getName() : "", metalake, e);
     }
   }
 

--- a/server/src/main/java/org/apache/gravitino/server/web/rest/TopicOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/TopicOperations.java
@@ -160,7 +160,7 @@ public class TopicOperations {
           });
     } catch (Exception e) {
       return ExceptionHandlers.handleTopicException(
-          OperationType.CREATE, request.getName(), schema, e);
+          OperationType.CREATE, request != null ? request.getName() : "", schema, e);
     }
   }
 

--- a/server/src/main/java/org/apache/gravitino/server/web/rest/UserOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/UserOperations.java
@@ -166,7 +166,7 @@ public class UserOperations {
           });
     } catch (Exception e) {
       return ExceptionHandlers.handleUserException(
-          OperationType.ADD, request.getName(), metalake, e);
+          OperationType.ADD, request != null ? request.getName() : "", metalake, e);
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add null-safe access for `request` objects in `catch` blocks across 16 REST handler files. Each unsafe `request.get*()` call in a catch block is replaced with a ternary null check, e.g.:

```java
// Before (unsafe):
request.getName()

// After (safe):
request != null ? request.getName() : ""
```

### Why are the changes needed?

When `request` is `null` (e.g., due to deserialization failure) and an exception occurs inside the `try` block, the `catch` block attempts to dereference `request` to build an error message. This throws a secondary `NullPointerException` that **masks the original exception**, making debugging significantly harder.

The existing fix in `MetalakeOperations.createMetalake` (line 142) already demonstrates the correct pattern:
```java
String metalakeName = request != null ? request.getName() : "";
```

This PR applies the same pattern consistently across all remaining REST handlers.

### Does this PR introduce _any_ user-facing change?

No API changes. Error responses now correctly reflect the original exception instead of being masked by a secondary NPE in the catch block.

### How was this patch tested?

Manual review of all 16 affected files. The changes are purely defensive — they only affect the error path behavior when `request` is null, preserving all existing normal-path behavior.

Affected handlers (23 catch-block sites across 16 files):

| File | Method(s) |
|------|-----------|
| `CatalogOperations` | `createCatalog`, `testConnection`, `setCatalog` |
| `SchemaOperations` | `createSchema` |
| `TableOperations` | `createTable` |
| `FilesetOperations` | `createFileset` |
| `FunctionOperations` | `registerFunction` |
| `ModelOperations` | `registerModel` |
| `TopicOperations` | `createTopic` |
| `TagOperations` | `createTag` |
| `PolicyOperations` | `createPolicy` |
| `RoleOperations` | `createRole` |
| `GroupOperations` | `addGroup` |
| `UserOperations` | `addUser` |
| `PermissionOperations` | `grantRolesToUser`, `grantRolesToGroup`, `revokeRolesFromUser`, `revokeRolesFromGroup` |
| `JobOperations` | `registerJobTemplate` |
| `StatisticOperations` | `updateStatistics`, `dropStatistics`, `updatePartitionStatistics`, `dropPartitionStatistics` |
| `MetalakeOperations` | `setMetalake` |

Closes #10172