### PR TITLE
[#10164] fix(server): prevent NPE in createSchema when request is null

### DIFF
--- a/server/src/main/java/org/apache/gravitino/server/web/rest/SchemaOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/SchemaOperations.java
@@ -122,11 +122,15 @@ public class SchemaOperations {
           String metalake,
       @PathParam("catalog") @AuthorizationMetadata(type = Entity.EntityType.CATALOG) String catalog,
       SchemaCreateRequest request) {
-    LOG.info("Received create schema request: {}.{}.{}", metalake, catalog, request.getName());
     try {
       return Utils.doAs(
           httpRequest,
           () -> {
+            if (request == null) {
+              throw new IllegalArgumentException("Request body shouldn't be null");
+            }
+            LOG.info(
+                "Received create schema request: {}.{}.{}", metalake, catalog, request.getName());
             request.validate();
             NameIdentifier ident =
                 NameIdentifierUtil.ofSchema(metalake, catalog, request.getName());
@@ -138,8 +142,8 @@ public class SchemaOperations {
           });
 
     } catch (Exception e) {
-      return ExceptionHandlers.handleSchemaException(
-          OperationType.CREATE, request.getName(), catalog, e);
+      String schemaName = request != null ? request.getName() : "unknownName";
+      return ExceptionHandlers.handleSchemaException(OperationType.CREATE, schemaName, catalog, e);
     }
   }
 

--- a/server/src/test/java/org/apache/gravitino/server/web/rest/TestSchemaOperations.java
+++ b/server/src/test/java/org/apache/gravitino/server/web/rest/TestSchemaOperations.java
@@ -489,4 +489,10 @@ public class TestSchemaOperations extends BaseOperationsTest {
 
     return mockSchema;
   }
+
+  @Test
+  public void testCreateSchemaWithNullRequestShouldNotThrow() {
+    SchemaOperations operations = new SchemaOperations(dispatcher);
+    Assertions.assertDoesNotThrow(() -> operations.createSchema(metalake, catalog, null));
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
- Moved the logging of request.getName() inside the try block to avoid accessing a null object
- Added a guard clause to fail fast with an IllegalArgumentException if the request body is null
- Ensured the exception handler in the catch block is null-safe
- Added a unit test testCreateSchemaWithNullRequestShouldNotThrow to verify the fix

### Why are the changes needed?

Sending a null request body to createSchema causes a raw NullPointerException before the try-catch block, resulting in an inconsistent 500 error instead of a proper validation error.

Fix: #10164

### Does this PR introduce _any_ user-facing change?

No user-facing changes were introduced.

### How was this patch tested?

1. Added a new JUnit test case in TestSchemaOperations.java: testCreateSchemaWithNullRequestShouldNotThrow
2. Ran ./gradlew :server:test --tests "org.apache.gravitino.server.web.rest.TestSchemaOperations" and verified all tests passed