### PR TITLE
Fix #10123: Add null check for MetalakeCreateRequest

### DIFF
--- a/server/src/main/java/org/apache/gravitino/server/web/rest/MetalakeOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/MetalakeOperations.java
@@ -117,6 +117,9 @@ public class MetalakeOperations {
           "Only service admins can create metalakes, current user can't create the metalake,"
               + "  you should configure it in the server configuration first")
   public Response createMetalake(MetalakeCreateRequest request) {
+    if (request == null) {
+      return Utils.illegalArguments("Metalake create request cannot be null");
+    }
     LOG.info("Received create metalake request for {}", request.getName());
     try {
       return Utils.doAs(

--- a/server/src/test/java/org/apache/gravitino/server/web/rest/TestMetalakeOperations.java
+++ b/server/src/test/java/org/apache/gravitino/server/web/rest/TestMetalakeOperations.java
@@ -234,6 +234,22 @@ public class TestMetalakeOperations extends BaseOperationsTest {
   }
 
   @Test
+  public void testCreateMetalakeWithNullRequest() {
+    Response resp =
+        target("/metalakes")
+            .request(MediaType.APPLICATION_JSON_TYPE)
+            .accept("application/vnd.gravitino.v1+json")
+            .post(Entity.entity("null", MediaType.APPLICATION_JSON_TYPE));
+
+    Assertions.assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), resp.getStatus());
+
+    ErrorResponse errorResponse = resp.readEntity(ErrorResponse.class);
+    Assertions.assertEquals(ErrorConstants.ILLEGAL_ARGUMENTS_CODE, errorResponse.getCode());
+    Assertions.assertEquals(
+        IllegalArgumentException.class.getSimpleName(), errorResponse.getType());
+  }
+
+  @Test
   public void testLoadMetalake() {
     String metalakeName = "test";
     Long id = 1L;


### PR DESCRIPTION
## Summary
- Fixed NPE in `MetalakeOperations.createMetalake()` when request body is null
- Added null check that returns BAD_REQUEST with appropriate error message
- Added test case `testCreateMetalakeWithNullRequest()` to verify the fix

## Fixes
Fixes #10123

## Test Plan
- Added `testCreateMetalakeWithNullRequest()` test in `TestMetalakeOperations.java`
- Tests null request body handling with BAD_REQUEST response verification