### PR TITLE
[#10210] improvement(CI):  Automatically run CI for auto-cherry-pick PRs

### DIFF
--- a/.github/workflows/cherry-pick-branch.yml
+++ b/.github/workflows/cherry-pick-branch.yml
@@ -44,7 +44,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # A PAT (or GitHub App token) is required so that the created PR
+          # triggers downstream CI workflows.  GITHUB_TOKEN-created events
+          # are intentionally ignored by GitHub to prevent recursive runs.
+          token: ${{ secrets.CHERRY_PICK_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Set up Git
         run: |
@@ -88,7 +91,7 @@ jobs:
       - name: Create Pull Request
         if: steps.cherry-pick.outputs.branch-name != ''
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.CHERRY_PICK_TOKEN || secrets.GITHUB_TOKEN }}
           COMMIT_MESSAGE: ${{ inputs.commit-message }}
           TARGET_BRANCH: ${{ inputs.target-branch }}
           COMMIT_SHA: ${{ inputs.commit-sha }}


### PR DESCRIPTION
### What changes were proposed in this pull request?

This pull request updates the `.github/workflows/cherry-pick-branch.yml` workflow to improve how authentication tokens are handled when creating pull requests. The main change is to use a Personal Access Token (PAT) or GitHub App token if available, which ensures that downstream CI workflows are correctly triggered by pull requests created through this workflow.

Authentication improvements:

* Updated the `actions/checkout` step to use `secrets.CHERRY_PICK_TOKEN` if available, falling back to `secrets.GITHUB_TOKEN` only if necessary. This change helps ensure that pull request events trigger downstream workflows, which is not possible when using the default `GITHUB_TOKEN`.
* Modified the environment variable `GH_TOKEN` in the "Create Pull Request" step to use `secrets.CHERRY_PICK_TOKEN` if available, otherwise falling back to `secrets.GITHUB_TOKEN`. This maintains consistency and supports triggering CI on created pull requests.

### Why are the changes needed?

For development efficiency.

Fix: #10210

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

Test locally.
