### PR TITLE
[#10167] Fail topic creation when metadata store persistence fails

### DIFF
--- a/core/src/main/java/org/apache/gravitino/catalog/TopicOperationDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/TopicOperationDispatcher.java
@@ -395,10 +395,8 @@ public class TopicOperationDispatcher extends OperationDispatcher implements Top
       store.put(topicEntity, true /* overwrite */);
     } catch (Exception e) {
       LOG.error(OperationDispatcher.FormattedErrorMessages.STORE_OP_FAILURE, "put", ident, e);
-      return EntityCombinedTopic.of(topic)
-          .withHiddenProperties(
-              getHiddenPropertyNames(
-                  catalogIdent, HasPropertyMetadata::topicPropertiesMetadata, topic.properties()));
+      throw new RuntimeException(
+          "Failed to persist topic entity for " + ident + " in the store", e);
     }
 
     return EntityCombinedTopic.of(topic, topicEntity)

--- a/core/src/test/java/org/apache/gravitino/catalog/TestTopicOperationDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestTopicOperationDispatcher.java
@@ -274,6 +274,21 @@ public class TestTopicOperationDispatcher extends TestOperationDispatcher {
     Assertions.assertTrue(entityStore.exists(topicIdent, Entity.EntityType.TOPIC));
   }
 
+  @Test
+  public void testCreateTopicShouldFailWhenStorePutFails() throws IOException {
+    Namespace topicNs = Namespace.of(metalake, catalog, "schema171");
+    Map<String, String> props = ImmutableMap.of("k1", "v1", "k2", "v2");
+    schemaOperationDispatcher.createSchema(NameIdentifier.of(topicNs.levels()), "comment", props);
+
+    reset(entityStore);
+    doThrow(new IOException("store put failed")).when(entityStore).put(any(), eq(true));
+
+    NameIdentifier topicIdent = NameIdentifier.of(topicNs, "topic71");
+    Assertions.assertThrows(
+        RuntimeException.class,
+        () -> topicOperationDispatcher.createTopic(topicIdent, "comment", null, props));
+  }
+
   public static SchemaOperationDispatcher getSchemaOperationDispatcher() {
     return schemaOperationDispatcher;
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

`TopicOperationDispatcher#internalCreateTopic` previously caught `store.put` failures and returned a successful `Topic` result with only a log warning. This left the catalog and metadata store inconsistent — the topic exists in the catalog but Gravitino's metadata was not persisted, causing later operations to behave incorrectly.

The fix rethrows the `store.put` exception as a `RuntimeException` instead of swallowing it.

### Why are the changes needed?

When `store.put` fails, the method currently returns a successful result, silently dropping the persistence error. This creates an inconsistent state where:
- The topic exists in the underlying catalog
- Gravitino's metadata store has no record of it
- Subsequent operations (load, alter, drop) will fail with confusing errors

### Does this PR introduce _any_ user-facing change?

No. The external API is unchanged. Topic creation that previously appeared to succeed (but was actually partially broken) will now correctly report failure.

### How was this patch tested?

Added unit test `testCreateTopicShouldFailWhenStorePutFails` (as suggested in #10167) that:
1. Creates a schema
2. Mocks `entityStore.put()` to throw `IOException`
3. Asserts that `createTopic` throws `RuntimeException`

Closes #10167