### PR TITLE
 [#10166] Resolve NPE problem in grant/revoke permission's error handling when request body is null

### DIFF
--- a/server/src/main/java/org/apache/gravitino/server/web/rest/PermissionOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/PermissionOperations.java
@@ -101,8 +101,9 @@ public class PermissionOperations {
                             metalake, request.getRoleNames(), user))));
           });
     } catch (Exception e) {
+      String roleNames = request == null ? "" : StringUtils.join(request.getRoleNames(), ",");
       return ExceptionHandlers.handleUserPermissionOperationException(
-          OperationType.GRANT, StringUtils.join(request.getRoleNames(), ","), user, e);
+          OperationType.GRANT, roleNames, user, e);
     }
   }
 
@@ -130,8 +131,9 @@ public class PermissionOperations {
                             metalake, request.getRoleNames(), group))));
           });
     } catch (Exception e) {
+      String roleNames = request == null ? "" : StringUtils.join(request.getRoleNames(), ",");
       return ExceptionHandlers.handleGroupPermissionOperationException(
-          OperationType.GRANT, StringUtils.join(request.getRoleNames(), ","), group, e);
+          OperationType.GRANT, roleNames, group, e);
     }
   }
 
@@ -159,8 +161,9 @@ public class PermissionOperations {
                             metalake, request.getRoleNames(), user))));
           });
     } catch (Exception e) {
+      String roleNames = request == null ? "" : StringUtils.join(request.getRoleNames(), ",");
       return ExceptionHandlers.handleUserPermissionOperationException(
-          OperationType.REVOKE, StringUtils.join(request.getRoleNames(), ","), user, e);
+          OperationType.REVOKE, roleNames, user, e);
     }
   }
 
@@ -188,8 +191,9 @@ public class PermissionOperations {
                             metalake, request.getRoleNames(), group))));
           });
     } catch (Exception e) {
+      String roleNames = request == null ? "" : StringUtils.join(request.getRoleNames(), ",");
       return ExceptionHandlers.handleGroupPermissionOperationException(
-          OperationType.REVOKE, StringUtils.join(request.getRoleNames()), group, e);
+          OperationType.REVOKE, roleNames, group, e);
     }
   }
 

--- a/server/src/test/java/org/apache/gravitino/server/web/rest/TestPermissionOperations.java
+++ b/server/src/test/java/org/apache/gravitino/server/web/rest/TestPermissionOperations.java
@@ -812,4 +812,66 @@ public class TestPermissionOperations extends BaseOperationsTest {
     Assertions.assertEquals(ErrorConstants.INTERNAL_ERROR_CODE, errorResponse2.getCode());
     Assertions.assertEquals(RuntimeException.class.getSimpleName(), errorResponse2.getType());
   }
+
+  @Test
+  public void testGrantRolesToUserWithNullRequest() throws Exception {
+    Mockito.reset(entityStore);
+    BaseMetalake metalake = mock(BaseMetalake.class);
+    PropertiesMetadata propertiesMetadata = mock(PropertiesMetadata.class);
+    when(propertiesMetadata.getOrDefault(any(), any())).thenReturn(true);
+    when(metalake.propertiesMetadata()).thenReturn(propertiesMetadata);
+    when(entityStore.get(any(), any(), any())).thenReturn(metalake);
+
+    PermissionOperations operations = new PermissionOperations();
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    when(request.getAttribute(any())).thenReturn(null);
+    FieldUtils.writeField(operations, "httpRequest", request, true);
+
+    Response response = operations.grantRolesToUser("metalake1", "user1", null);
+    Assertions.assertEquals(
+        Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatus());
+  }
+
+  @Test
+  public void testGrantRolesToGroupWithNullRequest() throws Exception {
+    Mockito.reset(entityStore);
+    BaseMetalake metalake = mock(BaseMetalake.class);
+    PropertiesMetadata propertiesMetadata = mock(PropertiesMetadata.class);
+    when(propertiesMetadata.getOrDefault(any(), any())).thenReturn(true);
+    when(metalake.propertiesMetadata()).thenReturn(propertiesMetadata);
+    when(entityStore.get(any(), any(), any())).thenReturn(metalake);
+
+    PermissionOperations operations = new PermissionOperations();
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    when(request.getAttribute(any())).thenReturn(null);
+    FieldUtils.writeField(operations, "httpRequest", request, true);
+
+    Response response = operations.grantRolesToGroup("metalake1", "group1", null);
+    Assertions.assertEquals(
+        Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatus());
+  }
+
+  @Test
+  public void testRevokeRolesFromUserWithNullRequest() throws Exception {
+    PermissionOperations operations = new PermissionOperations();
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    when(request.getAttribute(any())).thenReturn(null);
+    FieldUtils.writeField(operations, "httpRequest", request, true);
+
+    Response response = operations.revokeRolesFromUser("metalake1", "user1", null);
+    Assertions.assertEquals(
+        Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatus());
+  }
+
+  @Test
+  public void testRevokeRolesFromGroupWithNullRequest() throws Exception {
+    PermissionOperations operations = new PermissionOperations();
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    when(request.getAttribute(any())).thenReturn(null);
+    FieldUtils.writeField(operations, "httpRequest", request, true);
+
+    Response response = operations.revokeRolesFromGroup("metalake1", "group1", null);
+    Assertions.assertEquals(
+        Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatus());
+  }
 }


### PR DESCRIPTION

<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?
Build role-name string with a null guard in grant/revoke permission operation error handling logics

### Why are the changes needed?
To avoid NPE

Fix: #10166

### Does this PR introduce _any_ user-facing change?
No
### How was this patch tested?
UTs