### PR TITLE
[#10286] web-v2(UI): update associated table size

### DIFF
--- a/web-v2/web/src/components/AssociatedTable.js
+++ b/web-v2/web/src/components/AssociatedTable.js
@@ -122,6 +122,7 @@ export default function AssociatedTable({ ...props }) {
   return (
     <Spin spinning={store.rolesForObjectLoading}>
       <Table
+        size='small'
         dataSource={tableData}
         columns={resizableColumns}
         components={components}


### PR DESCRIPTION
### What changes were proposed in this pull request?
update associated table size
<img width="3538" height="1862" alt="image" src="https://github.com/user-attachments/assets/f7995d83-4f44-4895-a371-0a115b24b756" />


### Why are the changes needed?
N/A

Fix: #10286

### Does this PR introduce _any_ user-facing change?
N/A

### How was this patch tested?
manually
Verified the associated table renders correctly with reduced row height in the `Catalog Details` page