### PR TITLE
[#10277] fix(core): validate privilege array lengths in POConverters.fromSecurableObjectPO

### DIFF
--- a/core/src/main/java/org/apache/gravitino/storage/relational/utils/POConverters.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/utils/POConverters.java
@@ -1307,9 +1307,6 @@ public class POConverters {
 
       List<Privilege> privileges = Lists.newArrayList();
       Preconditions.checkArgument(
-          privilegeNames != null && privilegeConditions != null,
-          "Privilege names and conditions cannot be null");
-      Preconditions.checkArgument(
           privilegeNames.size() == privilegeConditions.size(),
           "Privilege names and conditions must have the same size, but got %s names and %s conditions",
           privilegeNames.size(),

--- a/core/src/test/java/org/apache/gravitino/storage/relational/utils/TestPOConverters.java
+++ b/core/src/test/java/org/apache/gravitino/storage/relational/utils/TestPOConverters.java
@@ -1740,13 +1740,13 @@ public class TestPOConverters {
   }
 
   @Test
-  public void testFromSecurableObjectPOWithMismatchedPrivileges() {
+  public void testFromSecurableObjectPOWithNullPrivileges() {
     SecurableObjectPO securableObjectPO =
         SecurableObjectPO.builder()
             .withRoleId(1L)
             .withMetadataObjectId(1L)
             .withType(MetadataObject.Type.CATALOG.name())
-            .withPrivilegeNames("[\"USE_CATALOG\", \"CREATE_SCHEMA\"]")
+            .withPrivilegeNames("null")
             .withPrivilegeConditions("[\"ALLOW\"]")
             .withCurrentVersion(1L)
             .withLastVersion(1L)
@@ -1754,7 +1754,7 @@ public class TestPOConverters {
             .build();
 
     Assertions.assertThrows(
-        IllegalArgumentException.class,
+        RuntimeException.class,
         () ->
             POConverters.fromSecurableObjectPO(
                 "test_catalog", securableObjectPO, MetadataObject.Type.CATALOG));


### PR DESCRIPTION
Added input validation in POConverters.fromSecurableObjectPO to check that privilegeNames and privilegeConditions are non-null and have equal sizes before iterating, failing fast with a clear IllegalArgumentException instead of a cryptic IndexOutOfBoundsException.

Fixes #10277

Testing: Added testFromSecurableObjectPOWithMismatchedPrivileges in TestPOConverters which verifies the exception is thrown when privilege arrays are mismatched.
