### PR TITLE
fix:partial-failure

### DIFF
--- a/core/src/main/java/org/apache/gravitino/job/JobManager.java
+++ b/core/src/main/java/org/apache/gravitino/job/JobManager.java
@@ -464,6 +464,12 @@ public class JobManager implements JobOperationDispatcher {
     try {
       entityStore.put(jobEntity, false /* overwrite */);
     } catch (IOException e) {
+      try {
+        jobExecutor.cancelJob(jobExecutionId);
+        LOG.warn("Rolled back job execution {} after store failure", jobExecutionId);
+      } catch (Exception cancelEx) {
+        LOG.error("Failed to cancel orphaned job execution {} during rollback", jobExecutionId, cancelEx);
+      }
       throw new RuntimeException("Failed to register the job entity " + jobEntity, e);
     }
 

--- a/core/src/test/java/org/apache/gravitino/job/TestJobManager.java
+++ b/core/src/test/java/org/apache/gravitino/job/TestJobManager.java
@@ -902,6 +902,28 @@ public class TestJobManager {
   }
 
   @Test
+  public void testRunJobShouldCancelSubmittedJobWhenStorePutFails() throws IOException {
+    mockedMetalake
+            .when(() -> MetalakeManager.checkMetalake(metalakeIdent, entityStore))
+            .thenAnswer(a -> null);
+
+    JobTemplateEntity shellJobTemplate =
+            newShellJobTemplateEntity("shell_job", "A shell job template");
+    when(jobManager.getJobTemplate(metalake, shellJobTemplate.name())).thenReturn(shellJobTemplate);
+
+    String jobExecutionId = "job_execution_id_for_test";
+    when(jobExecutor.submitJob(any())).thenReturn(jobExecutionId);
+    doThrow(new IOException("Entity store error"))
+            .when(entityStore)
+            .put(any(JobEntity.class), anyBoolean());
+
+    Assertions.assertThrows(
+            RuntimeException.class, () -> jobManager.runJob(metalake, "shell_job", Collections.emptyMap()));
+
+    verify(jobExecutor, times(1)).cancelJob(jobExecutionId);
+  }
+
+  @Test
   public void testFetchFileFromUriWithMissingLocalFileShouldFail() throws IOException {
     File stagingDir = new File(testStagingDir);
     Assertions.assertTrue(stagingDir.mkdirs() || stagingDir.exists());


### PR DESCRIPTION
1. Title: [#10271] fix(job): cancel submitted job execution when entity store persistence fails in runJob
 
### What changes were proposed in this pull request?

Added rollback compensation logic in `JobManager.runJob()`. 
If `entityStore.put()` fails after `jobExecutor.submitJob()` succeeds, 
the submitted job execution is now cancelled via `jobExecutor.cancelJob(jobExecutionId)` 
before rethrowing the original exception. Rollback success and failure are both logged.

### Why are the changes needed?

Previously, if entityStore.put() threw an IOException, the method would 
rethrow but leave the already-submitted job running with no persisted record. 

Fix: #10271

### Does this PR introduce _any_ user-facing change?

No user-facing changes. This is an internal failure-handling improvement.

### How was this patch tested?

Added unit test `testRunJobShouldCancelSubmittedJobWhenStorePutFails` 
in `JobManagerTest.java` that:
- Mocks entityStore.put() to throw IOException
- Verifies that jobExecutor.cancelJob() is called exactly once with 
  the correct jobExecutionId
- Verifies that RuntimeException is still thrown to the caller
