### PR TITLE
Fix possible NPE in TagMetaService#getTagIdByTagName when tag does no…

### DIFF
--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/TagMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/TagMetaService.java
@@ -410,10 +410,18 @@ public class TagMetaService {
   }
 
   public Long getTagIdByTagName(Long metalakeId, String tagName) {
-    return SessionUtils.getWithoutCommit(
+    TagPO tagPO =
+        SessionUtils.getWithoutCommit(
             TagMetaMapper.class,
-            mapper -> mapper.selectTagMetaByMetalakeIdAndName(metalakeId, tagName))
-        .getTagId();
+            mapper -> mapper.selectTagMetaByMetalakeIdAndName(metalakeId, tagName));
+
+    if (tagPO == null) {
+      throw new NoSuchEntityException(
+          NoSuchEntityException.NO_SUCH_ENTITY_MESSAGE,
+          Entity.EntityType.TAG.name().toLowerCase(),
+          tagName);
+    }
+    return tagPO.getTagId();
   }
 
   private List<TagPO> getTagPOsByMetalakeAndNames(String metalakeName, List<String> tagNames) {

--- a/core/src/test/java/org/apache/gravitino/storage/relational/service/TestTagMetaService.java
+++ b/core/src/test/java/org/apache/gravitino/storage/relational/service/TestTagMetaService.java
@@ -1112,6 +1112,18 @@ public class TestTagMetaService extends TestJDBCBackend {
     Assertions.assertEquals(21, countAllTagRel(tagEntity1.id()));
   }
 
+  @TestTemplate
+  public void testGetTagIdByTagNameWhenTagNotFound() throws IOException {
+    createAndInsertMakeLake(METALAKE_NAME);
+
+    TagMetaService tagMetaService = TagMetaService.getInstance();
+    long metalakeId = MetalakeMetaService.getInstance().getMetalakeIdByName(METALAKE_NAME);
+
+    Assertions.assertThrows(
+        NoSuchEntityException.class,
+        () -> tagMetaService.getTagIdByTagName(metalakeId, "missing_tag"));
+  }
+
   private boolean containsGenericEntity(
       List<GenericEntity> genericEntities, String name, Entity.EntityType entityType) {
     return genericEntities.stream().anyMatch(e -> e.name().equals(name) && e.type() == entityType);


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR fixes a potential `NullPointerException` in `TagMetaService#getTagIdByTagName`.

Previously, the method directly dereferenced the result returned by
`selectTagMetaByMetalakeIdAndName(...)` and called `.getTagId()` without checking if the returned `TagPO` was `null`. If the tag did not exist (or was concurrently deleted), this could result in a `NullPointerException`.

This change adds a null check and throws a `NoSuchEntityException` when the tag is not found. This behavior aligns with other meta services (e.g., role/user/group) that throw domain-level exceptions when entities are missing.

## How was this patch tested?

* Added a new unit test `testGetTagIdByTagNameWhenTagNotFound` in `TestTagMetaService`.
* The test verifies that `NoSuchEntityException` is thrown when attempting to retrieve a tag ID for a non-existent tag.
* Ran the full `:core:test` suite locally and all tests passed successfully.

## Does this PR introduce any user-facing change?

No user-facing changes. This improves internal error handling and prevents unexpected `NullPointerException`s.

Fixed #10221 