### PR TITLE
[#10126] fix(server): return proper HTTP statuses for testConnection

### DIFF
--- a/server/src/main/java/org/apache/gravitino/server/web/rest/ExceptionHandlers.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/ExceptionHandlers.java
@@ -19,9 +19,7 @@
 package org.apache.gravitino.server.web.rest;
 
 import com.google.common.annotations.VisibleForTesting;
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import org.apache.gravitino.dto.responses.ErrorResponse;
 import org.apache.gravitino.exceptions.AlreadyExistsException;
 import org.apache.gravitino.exceptions.CatalogAlreadyExistsException;
 import org.apache.gravitino.exceptions.ConnectionFailedException;
@@ -159,30 +157,24 @@ public class ExceptionHandlers {
   }
 
   public static Response handleTestConnectionException(Exception e) {
-    ErrorResponse response;
     if (e instanceof IllegalArgumentException) {
-      response = ErrorResponse.illegalArguments(e.getMessage(), e);
+      return Utils.illegalArguments(e.getMessage(), e);
 
     } else if (e instanceof ConnectionFailedException) {
-      response = ErrorResponse.connectionFailed(e.getMessage(), e);
+      return Utils.connectionFailed(e.getMessage(), e);
 
     } else if (e instanceof NotFoundException) {
-      response = ErrorResponse.notFound(e.getClass().getSimpleName(), e.getMessage(), e);
+      return Utils.notFound(e.getMessage(), e);
 
     } else if (e instanceof AlreadyExistsException) {
-      response = ErrorResponse.alreadyExists(e.getClass().getSimpleName(), e.getMessage(), e);
+      return Utils.alreadyExists(e.getMessage(), e);
 
     } else if (e instanceof NotInUseException) {
-      response = ErrorResponse.notInUse(e.getClass().getSimpleName(), e.getMessage(), e);
+      return Utils.notInUse(e.getMessage(), e);
 
     } else {
       return Utils.internalError(e.getMessage(), e);
     }
-
-    return Response.status(Response.Status.OK)
-        .entity(response)
-        .type(MediaType.APPLICATION_JSON)
-        .build();
   }
 
   public static Response handleOwnerException(

--- a/server/src/test/java/org/apache/gravitino/server/web/rest/TestCatalogOperations.java
+++ b/server/src/test/java/org/apache/gravitino/server/web/rest/TestCatalogOperations.java
@@ -323,6 +323,27 @@ public class TestCatalogOperations extends BaseOperationsTest {
     BaseResponse testResponse = resp.readEntity(BaseResponse.class);
     Assertions.assertEquals(0, testResponse.getCode());
 
+    // Test throw IllegalArgumentException
+    doThrow(new IllegalArgumentException("invalid properties"))
+        .when(manager)
+        .testConnection(any(), any(), any(), any(), any());
+    Response respInvalidProperties =
+        target("/metalakes/metalake1/catalogs/testConnection")
+            .request(MediaType.APPLICATION_JSON_TYPE)
+            .accept("application/vnd.gravitino.v1+json")
+            .post(Entity.entity(req, MediaType.APPLICATION_JSON_TYPE));
+
+    Assertions.assertEquals(
+        Response.Status.BAD_REQUEST.getStatusCode(), respInvalidProperties.getStatus());
+    Assertions.assertEquals(MediaType.APPLICATION_JSON_TYPE, respInvalidProperties.getMediaType());
+
+    ErrorResponse invalidPropertiesErrorResponse =
+        respInvalidProperties.readEntity(ErrorResponse.class);
+    Assertions.assertEquals(
+        ErrorConstants.ILLEGAL_ARGUMENTS_CODE, invalidPropertiesErrorResponse.getCode());
+    Assertions.assertEquals(
+        IllegalArgumentException.class.getSimpleName(), invalidPropertiesErrorResponse.getType());
+
     // test throw RuntimeException
     doThrow(new RuntimeException("connection failed"))
         .when(manager)

--- a/server/src/test/java/org/apache/gravitino/server/web/rest/TestExceptionHandlers.java
+++ b/server/src/test/java/org/apache/gravitino/server/web/rest/TestExceptionHandlers.java
@@ -18,6 +18,11 @@
  */
 package org.apache.gravitino.server.web.rest;
 
+import javax.ws.rs.core.Response;
+import org.apache.gravitino.exceptions.AlreadyExistsException;
+import org.apache.gravitino.exceptions.ConnectionFailedException;
+import org.apache.gravitino.exceptions.NotFoundException;
+import org.apache.gravitino.exceptions.NotInUseException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -49,5 +54,40 @@ public class TestExceptionHandlers {
 
     String msg6 = ExceptionHandlers.BaseExceptionHandler.getErrorMsg(e6);
     Assertions.assertEquals("", msg6);
+  }
+
+  @Test
+  public void testHandleTestConnectionExceptionShouldReturnErrorStatus() {
+    Response illegalArgumentsResponse =
+        ExceptionHandlers.handleTestConnectionException(
+            new IllegalArgumentException("invalid properties"));
+    Assertions.assertEquals(
+        Response.Status.BAD_REQUEST.getStatusCode(), illegalArgumentsResponse.getStatus());
+
+    Response notFoundResponse =
+        ExceptionHandlers.handleTestConnectionException(new NotFoundException("catalog not found"));
+    Assertions.assertEquals(
+        Response.Status.NOT_FOUND.getStatusCode(), notFoundResponse.getStatus());
+
+    Response alreadyExistsResponse =
+        ExceptionHandlers.handleTestConnectionException(
+            new AlreadyExistsException("catalog already exists"));
+    Assertions.assertEquals(
+        Response.Status.CONFLICT.getStatusCode(), alreadyExistsResponse.getStatus());
+
+    Response notInUseResponse =
+        ExceptionHandlers.handleTestConnectionException(new NotInUseException("catalog disabled"));
+    Assertions.assertEquals(Response.Status.CONFLICT.getStatusCode(), notInUseResponse.getStatus());
+
+    Response connectionFailedResponse =
+        ExceptionHandlers.handleTestConnectionException(
+            new ConnectionFailedException("connection failed"));
+    Assertions.assertEquals(
+        Response.Status.BAD_GATEWAY.getStatusCode(), connectionFailedResponse.getStatus());
+
+    Response fallbackResponse =
+        ExceptionHandlers.handleTestConnectionException(new RuntimeException("unexpected"));
+    Assertions.assertEquals(
+        Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), fallbackResponse.getStatus());
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR fixes incorrect HTTP semantics in POST /metalakes/{metalake}/catalogs/testConnection error handling.

- Updated ExceptionHandlers.handleTestConnectionException(Exception e) to return status-aware Utils responses instead of always returning 200 OK.
- Replaced manual ErrorResponse + Response.Status.OK building with:
  - IllegalArgumentException -> Utils.illegalArguments(...) (400)
  - NotFoundException -> Utils.notFound(...) (404)
  - AlreadyExistsException -> Utils.alreadyExists(...) (409)
  - NotInUseException -> Utils.notInUse(...) (409)
  - ConnectionFailedException -> Utils.connectionFailed(...) (502)
  - fallback -> Utils.internalError(...) (500)
- Added TestExceptionHandlers.testHandleTestConnectionExceptionShouldReturnErrorStatus to verify status mapping.
- Extended TestCatalogOperations.testConnection to verify API-level behavior for IllegalArgumentException (400) and error body code/type.

## Why are the changes needed?
testConnection could return HTTP 200 OK even when validation/connection errors occurred.
This caused clients to treat failed checks as successful at the HTTP layer.
The change aligns status codes with actual outcomes while preserving existing error response body format.

Fix: #10126

## Does this PR introduce any user-facing change?
Yes.

- For POST /metalakes/{metalake}/catalogs/testConnection, error cases no longer return 200 OK.
- Users/clients will now receive proper non-200 statuses (400/404/409/502/500) depending on exception type.
- Error payload format is unchanged.

## How was this patch tested?
- Added/updated unit tests:
  - server/src/test/java/org/apache/gravitino/server/web/rest/TestExceptionHandlers.java
  - server/src/test/java/org/apache/gravitino/server/web/rest/TestCatalogOperations.java
- Ran:
  - ./gradlew :server:test --tests org.apache.gravitino.server.web.rest.TestExceptionHandlers --tests  org.apache.gravitino.server.web.rest.TestCatalogOperations -PskipITs
- Result: BUILD SUCCESSFUL (JDK 17).