### PR TITLE
[#10274] fix(core): remove returning false in NoSuchEntityException for unmanaged table

### DIFF
--- a/api/src/main/java/org/apache/gravitino/rel/TableCatalog.java
+++ b/api/src/main/java/org/apache/gravitino/rel/TableCatalog.java
@@ -292,7 +292,7 @@ public interface TableCatalog {
    * is removed.
    *
    * @param ident A table identifier.
-   * @return True if the table is dropped, false if the table does not exist.
+   * @return True if the table is dropped, false if the table does not exist in the underlying catalog.
    */
   boolean dropTable(NameIdentifier ident);
 
@@ -306,7 +306,7 @@ public interface TableCatalog {
    * implementation throws an {@link UnsupportedOperationException}.
    *
    * @param ident A table identifier.
-   * @return True if the table is purged, false if the table does not exist.
+   * @return True if the table is purged, false if the table does not exist in the underlying catalog.
    * @throws UnsupportedOperationException If the catalog does not support to purge a table.
    */
   default boolean purgeTable(NameIdentifier ident) throws UnsupportedOperationException {

--- a/api/src/main/java/org/apache/gravitino/rel/TableCatalog.java
+++ b/api/src/main/java/org/apache/gravitino/rel/TableCatalog.java
@@ -292,7 +292,8 @@ public interface TableCatalog {
    * is removed.
    *
    * @param ident A table identifier.
-   * @return True if the table is dropped, false if the table does not exist in the underlying catalog.
+   * @return True if the table is dropped, false if the table does not exist in the underlying
+   *     catalog.
    */
   boolean dropTable(NameIdentifier ident);
 
@@ -306,7 +307,8 @@ public interface TableCatalog {
    * implementation throws an {@link UnsupportedOperationException}.
    *
    * @param ident A table identifier.
-   * @return True if the table is purged, false if the table does not exist in the underlying catalog.
+   * @return True if the table is purged, false if the table does not exist in the underlying
+   *     catalog.
    * @throws UnsupportedOperationException If the catalog does not support to purge a table.
    */
   default boolean purgeTable(NameIdentifier ident) throws UnsupportedOperationException {

--- a/core/src/main/java/org/apache/gravitino/catalog/TableOperationDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/TableOperationDispatcher.java
@@ -402,7 +402,6 @@ public class TableOperationDispatcher extends OperationDispatcher implements Tab
             store.delete(ident, TABLE);
           } catch (NoSuchEntityException e) {
             LOG.warn("The table to be purged does not exist in the store: {}", ident, e);
-            return false;
           } catch (Exception e) {
             throw new RuntimeException(e);
           }

--- a/core/src/test/java/org/apache/gravitino/catalog/TestTableOperationDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestTableOperationDispatcher.java
@@ -47,6 +47,7 @@ import java.util.stream.Collectors;
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.gravitino.Config;
 import org.apache.gravitino.Entity;
+import org.apache.gravitino.EntityStore;
 import org.apache.gravitino.GravitinoEnv;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
@@ -54,6 +55,8 @@ import org.apache.gravitino.TestCatalog;
 import org.apache.gravitino.TestColumn;
 import org.apache.gravitino.auth.AuthConstants;
 import org.apache.gravitino.connector.TestCatalogOperations;
+import org.apache.gravitino.connector.capability.Capability;
+import org.apache.gravitino.connector.capability.CapabilityResult;
 import org.apache.gravitino.exceptions.NoSuchEntityException;
 import org.apache.gravitino.lock.LockManager;
 import org.apache.gravitino.meta.AuditInfo;
@@ -65,6 +68,7 @@ import org.apache.gravitino.rel.TableChange;
 import org.apache.gravitino.rel.expressions.literals.Literals;
 import org.apache.gravitino.rel.expressions.transforms.Transform;
 import org.apache.gravitino.rel.types.Types;
+import org.apache.gravitino.storage.IdGenerator;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -817,6 +821,32 @@ public class TestTableOperationDispatcher extends TestOperationDispatcher {
     boolean dropped = tableOperationDispatcher.dropTable(tableIdent);
     Assertions.assertTrue(dropped);
     Assertions.assertFalse(entityStore.exists(tableIdent, TABLE));
+  }
+
+  @Test
+  public void testPurgeUnmanagedTableWithMissingStoreEntityShouldUseCatalogResult()
+      throws Exception {
+    CatalogManager mockedCatalogManager = mock(CatalogManager.class);
+    EntityStore mockedStore = mock(EntityStore.class);
+    IdGenerator mockedIdGenerator = mock(IdGenerator.class);
+    CatalogManager.CatalogWrapper mockedCatalogWrapper = mock(CatalogManager.CatalogWrapper.class);
+    Capability mockedCapability = mock(Capability.class);
+    TableOperationDispatcher dispatcherUnderTest =
+        new TableOperationDispatcher(mockedCatalogManager, mockedStore, mockedIdGenerator);
+
+    NameIdentifier tableIdent = NameIdentifier.of(metalake, catalog, "schema72", "table32");
+    NameIdentifier catalogIdent = NameIdentifier.of(metalake, catalog);
+    doReturn(mockedCatalogWrapper).when(mockedCatalogManager).loadCatalogAndWrap(catalogIdent);
+    doReturn(mockedCapability).when(mockedCatalogWrapper).capabilities();
+    doReturn(CapabilityResult.unsupported("unmanaged table"))
+        .when(mockedCapability)
+        .managedStorage(Capability.Scope.TABLE);
+    doReturn(true).when(mockedCatalogWrapper).doWithTableOps(any());
+    doThrow(new NoSuchEntityException("missing store entity"))
+        .when(mockedStore)
+        .delete(tableIdent, TABLE);
+
+    Assertions.assertTrue(dispatcherUnderTest.purgeTable(tableIdent));
   }
 
   private static void testColumns(Column[] expectedColumns, Column[] actualColumns) {


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

In `purgeTable()`, when `store.delete()` throws `NoSuchEntityException` for unmanaged table:
- Before this change, it returns `false`
- After this change, it returns the catalog result (`droppedFromCatalog`)

### Why are the changes needed?

The previous behavior contradicts the method’s own comment that store deletion outcome should not affect the returned result, and only the catalog result should be used.

Fix: #10274

### Does this PR introduce _any_ user-facing change?

`dropped` for DELETE /metalakes/{metalake}/catalogs/{catalog}/schemas/{schema}/tables/{table}?purge=true:
- Before this change, it is always `false`
- After this change, it is the catalog result (`droppedFromCatalog`)

### How was this patch tested?

Verify that `purgeTable()` returns true when "droppedFromCatalog" is true in NoSuchEntityException for unmanaged table