### PR TITLE
[#10311] fix(optimizer): resolve built-in rewrite adapter by template name

### DIFF
--- a/maintenance/optimizer/src/main/java/org/apache/gravitino/maintenance/optimizer/recommender/job/GravitinoJobSubmitter.java
+++ b/maintenance/optimizer/src/main/java/org/apache/gravitino/maintenance/optimizer/recommender/job/GravitinoJobSubmitter.java
@@ -30,7 +30,7 @@ import org.apache.gravitino.maintenance.optimizer.api.recommender.JobSubmitter;
 import org.apache.gravitino.maintenance.optimizer.common.OptimizerEnv;
 import org.apache.gravitino.maintenance.optimizer.common.conf.OptimizerConfig;
 import org.apache.gravitino.maintenance.optimizer.common.util.GravitinoClientUtils;
-import org.apache.gravitino.maintenance.optimizer.recommender.handler.compaction.CompactionStrategyHandler;
+import org.apache.gravitino.policy.IcebergDataCompactionContent;
 
 /** Submits optimizer jobs to Gravitino using job template adapters. */
 public class GravitinoJobSubmitter implements JobSubmitter {
@@ -47,7 +47,9 @@ public class GravitinoJobSubmitter implements JobSubmitter {
    * @return provider name
    */
   private final Map<String, Class<? extends GravitinoJobAdapter>> jobAdapters =
-      ImmutableMap.of(CompactionStrategyHandler.NAME, GravitinoCompactionJobAdapter.class);
+      ImmutableMap.of(
+          IcebergDataCompactionContent.JOB_TEMPLATE_NAME_VALUE,
+          GravitinoCompactionJobAdapter.class);
 
   @Override
   public String name() {

--- a/maintenance/optimizer/src/test/java/org/apache/gravitino/maintenance/optimizer/recommender/job/TestGravitinoJobSubmitter.java
+++ b/maintenance/optimizer/src/test/java/org/apache/gravitino/maintenance/optimizer/recommender/job/TestGravitinoJobSubmitter.java
@@ -24,15 +24,16 @@ import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.maintenance.optimizer.api.recommender.JobExecutionContext;
 import org.apache.gravitino.maintenance.optimizer.common.OptimizerEnv;
 import org.apache.gravitino.maintenance.optimizer.common.conf.OptimizerConfig;
-import org.apache.gravitino.maintenance.optimizer.recommender.handler.compaction.CompactionStrategyHandler;
+import org.apache.gravitino.policy.IcebergDataCompactionContent;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class TestGravitinoJobSubmitter {
   @Test
-  void loadJobAdapterReturnsCompactionAdapter() {
+  void loadJobAdapterReturnsCompactionAdapterForBuiltInTemplateName() {
     GravitinoJobSubmitter submitter = new GravitinoJobSubmitter();
-    GravitinoJobAdapter adapter = submitter.loadJobAdapter(CompactionStrategyHandler.NAME);
+    GravitinoJobAdapter adapter =
+        submitter.loadJobAdapter(IcebergDataCompactionContent.JOB_TEMPLATE_NAME_VALUE);
     Assertions.assertTrue(adapter instanceof GravitinoCompactionJobAdapter);
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR fixes built-in adapter resolution for optimizer strategy job submission:

- Map built-in template name `builtin-iceberg-rewrite-data-files` to `GravitinoCompactionJobAdapter` in `GravitinoJobSubmitter`.
- Remove the legacy strategy-type alias mapping from the built-in adapter registry.
- Update unit tests to align with the template-name-based contract.

### Why are the changes needed?

`submit-strategy-jobs` submits jobs using the job template name from strategy/policy content.
Before this change, built-in adapter lookup relied on a strategy-type alias path, which can cause submission failures like:

`No job adapter found for template: builtin-iceberg-rewrite-data-files`

This patch makes the lookup consistent with actual runtime input (`jobTemplateName`).

Fix: #10311 

### Does this PR introduce _any_ user-facing change?

Yes, a user-visible bug fix in optimizer behavior:

- `gravitino-optimizer.sh --type submit-strategy-jobs` can now resolve the built-in rewrite template adapter through the default template-name mapping.
- No user-facing API changes.
- No property key additions/removals.

### How was this patch tested?

- Added/updated unit tests in `TestGravitinoJobSubmitter`.
- Ran:

```bash
./gradlew :maintenance:optimizer:test --tests org.apache.gravitino.maintenance.optimizer.recommender.job.TestGravitinoJobSubmitter -PskipITs
```

- Result: BUILD SUCCESSFUL.
