### PR TITLE
[#10165] improvement: Escape partition/statistic values in Lance delete filters to prevent malformed SQL

### DIFF
--- a/core/src/main/java/org/apache/gravitino/stats/storage/LancePartitionStatisticStorage.java
+++ b/core/src/main/java/org/apache/gravitino/stats/storage/LancePartitionStatisticStorage.java
@@ -326,9 +326,11 @@ public class LancePartitionStatisticStorage implements PartitionStatisticStorage
             "table_id = "
                 + tableId
                 + " AND partition_name = '"
-                + partition
+                + escapeSqlLiteral(partition)
                 + "' AND statistic_name IN ("
-                + statistics.stream().map(str -> "'" + str + "'").collect(Collectors.joining(", "))
+                + statistics.stream()
+                    .map(str -> "'" + escapeSqlLiteral(str) + "'")
+                    .collect(Collectors.joining(", "))
                 + ")");
       }
 
@@ -449,7 +451,7 @@ public class LancePartitionStatisticStorage implements PartitionStatisticStorage
                                 "AND partition_name "
                                     + (type == PartitionRange.BoundType.CLOSED ? ">= " : "> ")
                                     + "'"
-                                    + name
+                                    + escapeSqlLiteral(name)
                                     + "'"))
             .orElse("");
     String toPartitionNameFilter =
@@ -464,11 +466,15 @@ public class LancePartitionStatisticStorage implements PartitionStatisticStorage
                                 "AND partition_name "
                                     + (type == PartitionRange.BoundType.CLOSED ? "<= " : "< ")
                                     + "'"
-                                    + name
+                                    + escapeSqlLiteral(name)
                                     + "'"))
             .orElse("");
 
     return fromPartitionNameFilter + toPartitionNameFilter;
+  }
+
+  private static String escapeSqlLiteral(String value) {
+    return value.replace("'", "''");
   }
 
   private List<PersistedPartitionStatistics> listStatisticsImpl(

--- a/core/src/test/java/org/apache/gravitino/stats/storage/TestLancePartitionStatisticStorage.java
+++ b/core/src/test/java/org/apache/gravitino/stats/storage/TestLancePartitionStatisticStorage.java
@@ -36,6 +36,7 @@ import org.apache.gravitino.MetadataObject;
 import org.apache.gravitino.MetadataObjects;
 import org.apache.gravitino.meta.TableEntity;
 import org.apache.gravitino.stats.PartitionRange;
+import org.apache.gravitino.stats.PartitionStatisticsDrop;
 import org.apache.gravitino.stats.PartitionStatisticsModification;
 import org.apache.gravitino.stats.PartitionStatisticsUpdate;
 import org.apache.gravitino.stats.StatisticValue;
@@ -492,5 +493,53 @@ public class TestLancePartitionStatisticStorage {
       }
     }
     return newData;
+  }
+
+  @Test
+  public void testDropStatisticsWithQuoteInPartitionName() throws Exception {
+    PartitionStatisticStorageFactory factory = new LancePartitionStatisticStorageFactory();
+    String metalakeName = "metalake";
+    MetadataObject metadataObject =
+        MetadataObjects.of(
+            Lists.newArrayList("catalog", "schema", "table"), MetadataObject.Type.TABLE);
+
+    EntityStore entityStore = mock(EntityStore.class);
+    TableEntity tableEntity = mock(TableEntity.class);
+    when(entityStore.get(any(), any(), any())).thenReturn(tableEntity);
+    when(tableEntity.id()).thenReturn(1L);
+    FieldUtils.writeField(GravitinoEnv.getInstance(), "entityStore", entityStore, true);
+
+    String location = Files.createTempDirectory("lance_stats_test_quote").toString();
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put("location", location);
+
+    LancePartitionStatisticStorage storage =
+        (LancePartitionStatisticStorage) factory.create(properties);
+    try {
+      String quotedPartition = "partition'01";
+      Map<String, StatisticValue<?>> stats = Maps.newHashMap();
+      stats.put("statistic0", StatisticValues.stringValue("value0"));
+
+      storage.updateStatistics(
+          metalakeName,
+          Lists.newArrayList(
+              MetadataObjectStatisticsUpdate.of(
+                  metadataObject,
+                  Lists.newArrayList(
+                      PartitionStatisticsModification.update(quotedPartition, stats)))));
+
+      PartitionStatisticsDrop drop =
+          PartitionStatisticsModification.drop(quotedPartition, Lists.newArrayList("statistic0"));
+
+      Assertions.assertDoesNotThrow(
+          () ->
+              storage.dropStatistics(
+                  metalakeName,
+                  Lists.newArrayList(
+                      MetadataObjectStatisticsDrop.of(metadataObject, Lists.newArrayList(drop)))));
+    } finally {
+      FileUtils.deleteDirectory(new File(location + "/" + tableEntity.id() + ".lance"));
+      storage.close();
+    }
   }
 }


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->


### What changes were proposed in this pull request?
- Added a static escapeSqlLiteral method in LancePartitionStatisticStorage class that escapes single quotes in SQL literals by replacing ' with ''
- Used this method to escape partition names and statistic names in dropStatisticsImpl method
- Also applied the same fix to getPartitionFilter method to handle partition names with single quotes

### Why are the changes needed?

(Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, describe the bug.)

Fix: #10165

### Does this PR introduce _any_ user-facing change?

(Please list the user-facing changes introduced by your change, including
  1. Change in user-facing APIs.
  2. Addition or removal of property keys.)

### How was this patch tested?

(Please test your changes, and provide instructions on how to test it:
  1. If you add a feature or fix a bug, add a test to cover your changes.
  2. If you fix a flaky test, repeat it for many times to prove it works.)

- Added a new test case testDropStatisticsWithQuoteInPartitionName that specifically tests partition names with single quotes