### PR TITLE
[#10315]fix(client-python): Fix GCS credential handling for gcsfs 2026.2.0 compatibility

### DIFF
--- a/clients/client-python/gravitino/filesystem/gvfs_storage_handler.py
+++ b/clients/client-python/gravitino/filesystem/gvfs_storage_handler.py
@@ -42,8 +42,8 @@ from gravitino.exceptions.base import GravitinoRuntimeException
 from gravitino.filesystem.gvfs_config import GVFSConfig
 
 try:
-    from google.auth import _helpers
     from google.auth.credentials import Credentials
+    from google.auth.exceptions import RefreshError
 
     GOOGLE_AUTH_AVAILABLE = True
 except ImportError:
@@ -433,7 +433,7 @@ class GCSStorageHandler(StorageHandler):
 
                         def refresh(self, request):
                             # Static token cannot be refreshed
-                            raise RuntimeError(
+                            raise RefreshError(
                                 "Cannot refresh static access token. "
                                 "Please request a new credential from Gravitino."
                             )
@@ -442,7 +442,7 @@ class GCSStorageHandler(StorageHandler):
                         def expired(self):
                             if not self.expiry:
                                 return False
-                            return _helpers.utcnow() >= self.expiry
+                            return datetime.now(timezone.utc) >= self.expiry
 
                         @property
                         def valid(self):


### PR DESCRIPTION

### What changes were proposed in this pull request?

Wrap GCS OAuth2 access tokens in a google.auth.credentials.Credentials object before
passing to gcsfs.GCSFileSystem. The new gcsfs version (2026.2.0) requires Credentials
objects instead of raw token strings.

Changes:

Created StaticCredentials class implementing google.auth.credentials.Credentials interface
Properly converts token string and expiry time to Credentials object
Uses google.auth._helpers.utcnow() for consistent time comparison
### Why are the changes needed?

The gcsfs library was upgraded from 2024.3.1 to 2026.2.0 in commit https://github.com/datastrato/gravitino-internal/commit/79e37271216ebed689b1b4ea592adb12d6173170. The new
version changed the token parameter handling and no longer accepts raw OAuth2 token strings.
It now requires google.auth.credentials.Credentials objects.

Without this fix, all GCS credential-based tests fail with "Provided token is either not
valid, or expired" error, breaking the credential vending feature for GCS storage.

Fix: #10315 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

The CI can pass.
