### PR TITLE
Fix malformed multi-role names in group revoke error handling

### DIFF
--- a/server/src/main/java/org/apache/gravitino/server/web/rest/PermissionOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/PermissionOperations.java
@@ -189,7 +189,7 @@ public class PermissionOperations {
           });
     } catch (Exception e) {
       return ExceptionHandlers.handleGroupPermissionOperationException(
-          OperationType.REVOKE, StringUtils.join(request.getRoleNames()), group, e);
+          OperationType.REVOKE, StringUtils.join(request.getRoleNames(), ","), group, e);
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR fixes malformed role names in the error handling of the
`revokeRolesFromGroup` operation.

Previously, the code used:

`StringUtils.join(request.getRoleNames())`

which concatenated role names without any delimiter. For example:

role1role2

This PR updates the code to include a comma delimiter:

`StringUtils.join(request.getRoleNames(), ",")`

which produces a readable output such as:

role1,role2

### Why are the changes needed?

This improves the readability of error messages when multiple roles
are involved and keeps the behavior consistent with the existing
`revokeRolesFromUser` implementation.

### Does this PR introduce any user-facing change?

No functional change. This only improves error message formatting.

### Related Issue

Fixes #10222 