### PR TITLE
[#10177] improvement(core): ensure SessionUtils rolls back on Throwable

### DIFF
--- a/core/src/main/java/org/apache/gravitino/storage/relational/utils/SessionUtils.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/utils/SessionUtils.java
@@ -40,9 +40,9 @@ public class SessionUtils {
       T mapper = SqlSessions.getMapper(mapperClazz);
       consumer.accept(mapper);
       SqlSessions.commitAndCloseSqlSession();
-    } catch (Exception e) {
+    } catch (Throwable t) {
       SqlSessions.rollbackAndCloseSqlSession();
-      throw e;
+      throw t;
     }
   }
 
@@ -56,9 +56,9 @@ public class SessionUtils {
       R result = func.apply(mapper);
       SqlSessions.commitAndCloseSqlSession();
       return result;
-    } catch (Exception e) {
+    } catch (Throwable t) {
       SqlSessions.rollbackAndCloseSqlSession();
-      throw e;
+      throw t;
     }
   }
 
@@ -101,9 +101,9 @@ public class SessionUtils {
     try {
       Arrays.stream(operations).forEach(Runnable::run);
       SqlSessions.commitAndCloseSqlSession();
-    } catch (Exception e) {
+    } catch (Throwable t) {
       SqlSessions.rollbackAndCloseSqlSession();
-      throw e;
+      throw t;
     }
   }
 

--- a/core/src/test/java/org/apache/gravitino/storage/relational/utils/TestSessionUtils.java
+++ b/core/src/test/java/org/apache/gravitino/storage/relational/utils/TestSessionUtils.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.storage.relational.utils;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+
+import org.apache.gravitino.storage.relational.session.SqlSessions;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+public class TestSessionUtils {
+
+  @Test
+  public void testDoWithCommitShouldRollbackOnAssertionError() {
+    Object mapper = new Object();
+
+    try (MockedStatic<SqlSessions> mockedSqlSessions = mockStatic(SqlSessions.class)) {
+      mockedSqlSessions.when(() -> SqlSessions.getMapper(Object.class)).thenReturn(mapper);
+
+      assertThrows(
+          AssertionError.class,
+          () ->
+              SessionUtils.doWithCommit(
+                  Object.class,
+                  ignored -> {
+                    throw new AssertionError("boom");
+                  }));
+
+      mockedSqlSessions.verify(SqlSessions::rollbackAndCloseSqlSession);
+      mockedSqlSessions.verify(() -> SqlSessions.commitAndCloseSqlSession(), never());
+    }
+  }
+
+  @Test
+  public void testDoWithCommitAndFetchResultShouldRollbackOnAssertionError() {
+    Object mapper = new Object();
+
+    try (MockedStatic<SqlSessions> mockedSqlSessions = mockStatic(SqlSessions.class)) {
+      mockedSqlSessions.when(() -> SqlSessions.getMapper(Object.class)).thenReturn(mapper);
+
+      assertThrows(
+          AssertionError.class,
+          () ->
+              SessionUtils.doWithCommitAndFetchResult(
+                  Object.class,
+                  ignored -> {
+                    throw new AssertionError("boom");
+                  }));
+
+      mockedSqlSessions.verify(SqlSessions::rollbackAndCloseSqlSession);
+      mockedSqlSessions.verify(() -> SqlSessions.commitAndCloseSqlSession(), never());
+    }
+  }
+
+  @Test
+  public void testDoMultipleWithCommitShouldRollbackOnAssertionError() {
+    try (MockedStatic<SqlSessions> mockedSqlSessions = mockStatic(SqlSessions.class)) {
+      assertThrows(
+          AssertionError.class,
+          () ->
+              SessionUtils.doMultipleWithCommit(
+                  () -> {
+                    throw new AssertionError("boom");
+                  }));
+
+      mockedSqlSessions.verify(SqlSessions::getSqlSession);
+      mockedSqlSessions.verify(SqlSessions::rollbackAndCloseSqlSession);
+      mockedSqlSessions.verify(() -> SqlSessions.commitAndCloseSqlSession(), never());
+    }
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR updates `SessionUtils` to ensure transaction cleanup also runs when callbacks throw non-`Exception` throwables.

The changes include:
- broaden the failure handling in `doWithCommit` from `Exception` to `Throwable`
- apply the same pattern to `doWithCommitAndFetchResult`
- apply the same pattern to `doMultipleWithCommit`
- add unit tests to verify rollback happens when callbacks throw `AssertionError`

With this change, `SqlSessions.rollbackAndCloseSqlSession()` is invoked consistently for callback failures before the throwable is rethrown.

### Why are the changes needed?

`SessionUtils` previously caught only `Exception` in commit-managed helper methods.

If a mapper callback threw a non-`Exception` throwable such as `AssertionError`, the rollback path was skipped, which could leave the SQL session or transaction state unclosed.

This PR fixes that bug by making rollback/close run for all throwables in the callback path.

Fix: #10177

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Added unit tests in `TestSessionUtils` to verify:
- `doWithCommit` rolls back and does not commit on `AssertionError`
- `doWithCommitAndFetchResult` rolls back and does not commit on `AssertionError`
- `doMultipleWithCommit` rolls back and does not commit on `AssertionError`

Verified with:

```bash
env JAVA_HOME=/opt/homebrew/Cellar/openjdk@17/17.0.16/libexec/openjdk.jdk/Contents/Home \
  ./gradlew :core:test --tests org.apache.gravitino.storage.relational.utils.TestSessionUtils -PskipITs
