### PR TITLE
[#10339] fix(python-client): Add missing __init__.py for package discovery

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,11 +1,11 @@
 <!--
 1. Title: [#<issue>] <type>(<scope>): <subject>
    Examples:
-     - "[#123] feat(operator): support xxx"
-     - "[#233] fix: check null before access result in xxx"
-     - "[MINOR] refactor: fix typo in variable name"
-     - "[MINOR] docs: fix typo in README"
-     - "[#255] test: fix flaky test NameOfTheTest"
+     - "[#123] feat(operator): Support xxx"
+     - "[#233] fix: Check null before access result in xxx"
+     - "[MINOR] refactor: Fix typo in variable name"
+     - "[MINOR] docs: Fix typo in README"
+     - "[#255] test: Fix flaky test NameOfTheTest"
    Reference: https://www.conventionalcommits.org/en/v1.0.0/
 2. If the PR is unfinished, please mark this PR as draft.
 -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,8 @@
   4. Constructors.
   5. Methods (Group by visibility, putting `private` methods at the end).
 
-## Issue and PR Guidelines
+## Create Issue and PR Guidelines
+[IMPORTANT] Before creating an issue or PR using the gh command or the GitHub MCP server, please show a preview of the PR/issue first. Submit it only after I confirm. The issue/PR format should follow the reference and keep the content concise and clear.
 - **Issue Templates**: Use the appropriate template from `.github/ISSUE_TEMPLATE/`
 - **PR Description**: Follow the template in `.github/PULL_REQUEST_TEMPLATE`
 

--- a/clients/client-python/gravitino/api/rel/expressions/distributions/__init__.py
+++ b/clients/client-python/gravitino/api/rel/expressions/distributions/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/clients/client-python/gravitino/api/rel/expressions/distributions/strategy.py
+++ b/clients/client-python/gravitino/api/rel/expressions/distributions/strategy.py
@@ -40,13 +40,12 @@ class Strategy(Enum):
         upper_name = name.upper()
         if upper_name == "NONE":
             return Strategy.NONE
-        elif upper_name == "HASH":
+        if upper_name == "HASH":
             return Strategy.HASH
-        elif upper_name == "RANGE":
+        if upper_name == "RANGE":
             return Strategy.RANGE
-        elif upper_name in {"EVEN", "RANDOM"}:
+        if upper_name in {"EVEN", "RANDOM"}:
             return Strategy.EVEN
-        else:
-            raise ValueError(
-                f"Invalid distribution strategy: {name}. Valid values are: {[s.value for s in Strategy]}"
-            )
+        raise ValueError(
+            f"Invalid distribution strategy: {name}. Valid values are: {[s.value for s in Strategy]}"
+        )

--- a/clients/client-python/gravitino/api/rel/partitions/__init__.py
+++ b/clients/client-python/gravitino/api/rel/partitions/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/clients/client-python/gravitino/api/rel/partitions/identity_partition.py
+++ b/clients/client-python/gravitino/api/rel/partitions/identity_partition.py
@@ -34,7 +34,8 @@ class IdentityPartition(Partition):
     its partition name is "dt=2008-08-08/country=us", field names are [["dt"], ["country"]] and
     values are ["2008-08-08", "us"].
 
-    APIs that are still evolving towards becoming stable APIs, and can change from one feature release to another (0.5.0 to 0.6.0).
+    APIs that are still evolving towards becoming stable APIs, and can change from one feature
+    release to another (0.5.0 to 0.6.0).
     """
 
     @abstractmethod

--- a/clients/client-python/gravitino/api/rel/partitions/list_partition.py
+++ b/clients/client-python/gravitino/api/rel/partitions/list_partition.py
@@ -35,7 +35,8 @@ class ListPartition(Partition):
 
     its name is "p202204_California" and lists are [["2022-04-01","Los Angeles"], ["2022-04-01", "San Francisco"]].
 
-    APIs that are still evolving towards becoming stable APIs, and can change from one feature release to another (0.5.0 to 0.6.0).
+    APIs that are still evolving towards becoming stable APIs, and can change from one feature
+    release to another (0.5.0 to 0.6.0).
     """
 
     @abstractmethod

--- a/clients/client-python/gravitino/api/rel/partitions/partition.py
+++ b/clients/client-python/gravitino/api/rel/partitions/partition.py
@@ -24,7 +24,8 @@ class Partition(ABC):
     A partition represents a result of partitioning a table. The partition can be either a
     `IdentityPartition`, `ListPartition`, or `RangePartition`. It depends on the `Table.partitioning()`.
 
-    APIs that are still evolving towards becoming stable APIs, and can change from one feature release to another (0.5.0 to 0.6.0).
+    APIs that are still evolving towards becoming stable APIs, and can change from one feature
+    release to another (0.5.0 to 0.6.0).
     """
 
     @abstractmethod

--- a/clients/client-python/gravitino/api/rel/partitions/range_partition.py
+++ b/clients/client-python/gravitino/api/rel/partitions/range_partition.py
@@ -32,7 +32,8 @@ class RangePartition(Partition):
 
     its upper bound is "2020-03-22" and its lower bound is null.
 
-    APIs that are still evolving towards becoming stable APIs, and can change from one feature release to another (0.5.0 to 0.6.0).
+    APIs that are still evolving towards becoming stable APIs, and can change from one feature
+    release to another (0.5.0 to 0.6.0).
     """
 
     @abstractmethod

--- a/clients/client-python/gravitino/api/rel/types/json_serdes/_helper/__init__.py
+++ b/clients/client-python/gravitino/api/rel/types/json_serdes/_helper/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/clients/client-python/gravitino/api/rel/types/json_serdes/base.py
+++ b/clients/client-python/gravitino/api/rel/types/json_serdes/base.py
@@ -41,7 +41,7 @@ class JsonSerializable(ABC, Generic[_GravitinoTypeT]):
 
     @classmethod
     @abstractmethod
-    def serialize(cls, data_type: _GravitinoTypeT) -> Json:
+    def serialize(cls, value: _GravitinoTypeT) -> Json:
         """To serialize the given `data`.
 
         Args:

--- a/clients/client-python/gravitino/api/rel/types/json_serdes/type_serdes.py
+++ b/clients/client-python/gravitino/api/rel/types/json_serdes/type_serdes.py
@@ -37,7 +37,7 @@ class TypeSerdes(JsonSerializable[Type]):
             Json: The serialized data corresponding to the given Gravitino Type.
         """
 
-        return SerdesUtils.write_value(value)
+        return SerdesUtils.write_data_type(value)
 
     @classmethod
     def deserialize(cls, data: Json) -> Type:

--- a/clients/client-python/gravitino/api/rel/types/json_serdes/type_serdes.py
+++ b/clients/client-python/gravitino/api/rel/types/json_serdes/type_serdes.py
@@ -27,7 +27,7 @@ class TypeSerdes(JsonSerializable[Type]):
     """Custom JSON serializer for Gravitino Type objects."""
 
     @classmethod
-    def serialize(cls, data_type: Type) -> Json:
+    def serialize(cls, value: Type) -> Json:
         """Serialize the given Gravitino Type.
 
         Args:
@@ -37,7 +37,7 @@ class TypeSerdes(JsonSerializable[Type]):
             Json: The serialized data corresponding to the given Gravitino Type.
         """
 
-        return SerdesUtils.write_data_type(data_type)
+        return SerdesUtils.write_value(value)
 
     @classmethod
     def deserialize(cls, data: Json) -> Type:

--- a/clients/client-python/gravitino/dto/rel/expressions/json_serdes/__init__.py
+++ b/clients/client-python/gravitino/dto/rel/expressions/json_serdes/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/clients/client-python/gravitino/dto/rel/expressions/json_serdes/_helper/__init__.py
+++ b/clients/client-python/gravitino/dto/rel/expressions/json_serdes/_helper/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/clients/client-python/gravitino/dto/rel/expressions/json_serdes/_helper/serdes_utils.py
+++ b/clients/client-python/gravitino/dto/rel/expressions/json_serdes/_helper/serdes_utils.py
@@ -73,10 +73,10 @@ class SerdesUtils(SerdesUtilsBase):
         )
         try:
             arg_type = FunctionArg.ArgType(data[cls.EXPRESSION_TYPE].lower())
-        except ValueError:
+        except ValueError as exc:
             raise IllegalArgumentException(
                 f"Unknown function argument type: {data[cls.EXPRESSION_TYPE]}"
-            )
+            ) from exc
 
         if arg_type is FunctionArg.ArgType.LITERAL:
             Precondition.check_argument(
@@ -124,9 +124,12 @@ class SerdesUtils(SerdesUtilsBase):
                 .build()
             )
 
-        if arg_type is FunctionArg.ArgType.UNPARSED:
-            Precondition.check_argument(
-                isinstance(data.get(cls.UNPARSED_EXPRESSION), str),
-                f"Cannot parse unparsed expression from missing string field unparsedExpression: {data}",
-            )
-            return UnparsedExpressionDTO(data[cls.UNPARSED_EXPRESSION])
+        Precondition.check_argument(
+            arg_type is FunctionArg.ArgType.UNPARSED,
+            f"Unknown function argument type: {arg_type}",
+        )
+        Precondition.check_argument(
+            isinstance(data.get(cls.UNPARSED_EXPRESSION), str),
+            f"Cannot parse unparsed expression from missing string field unparsedExpression: {data}",
+        )
+        return UnparsedExpressionDTO(data[cls.UNPARSED_EXPRESSION])

--- a/clients/client-python/gravitino/dto/rel/indexes/json_serdes/index_serdes.py
+++ b/clients/client-python/gravitino/dto/rel/indexes/json_serdes/index_serdes.py
@@ -26,11 +26,11 @@ from gravitino.utils.serdes import SerdesUtilsBase
 
 class IndexSerdes(SerdesUtilsBase, JsonSerializable[Index]):
     @classmethod
-    def serialize(cls, data_type: Index) -> dict[str, Any]:
-        result: dict[str, Any] = {cls.INDEX_TYPE: data_type.type().name.upper()}
-        if data_type.name() is not None:
-            result[cls.INDEX_NAME] = data_type.name()
-        result[cls.INDEX_FIELD_NAMES] = data_type.field_names()
+    def serialize(cls, value: Index) -> dict[str, Any]:
+        result: dict[str, Any] = {cls.INDEX_TYPE: value.type().name.upper()}
+        if value.name() is not None:
+            result[cls.INDEX_NAME] = value.name()
+        result[cls.INDEX_FIELD_NAMES] = value.field_names()
 
         return result
 

--- a/clients/client-python/gravitino/dto/rel/json_serdes/distribution_serdes.py
+++ b/clients/client-python/gravitino/dto/rel/json_serdes/distribution_serdes.py
@@ -30,12 +30,12 @@ class DistributionSerDes(SerdesUtilsBase, JsonSerializable[DistributionDTO]):
     """Custom JSON deserializer for DistributionDTO objects."""
 
     @classmethod
-    def serialize(cls, data_type: DistributionDTO) -> dict[str, Any]:
+    def serialize(cls, value: DistributionDTO) -> dict[str, Any]:
         return {
-            cls.STRATEGY: data_type.strategy().name.lower(),
-            cls.NUMBER: data_type.number(),
+            cls.STRATEGY: value.strategy().name.lower(),
+            cls.NUMBER: value.number(),
             cls.FUNCTION_ARGS: [
-                SerdesUtils.write_function_arg(arg) for arg in data_type.args()
+                SerdesUtils.write_function_arg(arg) for arg in value.args()
             ],
         }
 

--- a/clients/client-python/gravitino/dto/rel/json_serdes/sort_order_serdes.py
+++ b/clients/client-python/gravitino/dto/rel/json_serdes/sort_order_serdes.py
@@ -30,7 +30,7 @@ class SortOrderSerdes(SerdesUtilsBase, JsonSerializable[SortOrderDTO]):
     """Custom JSON serializer/deserializer for SortOrderDTO objects."""
 
     @classmethod
-    def serialize(cls, data_type: SortOrderDTO) -> dict[str, Any]:
+    def serialize(cls, value: SortOrderDTO) -> dict[str, Any]:
         """
         Serialize the given data into a dictionary.
 
@@ -42,9 +42,9 @@ class SortOrderSerdes(SerdesUtilsBase, JsonSerializable[SortOrderDTO]):
         """
 
         return {
-            cls.SORT_TERM: SerdesUtils.write_function_arg(data_type.sort_term()),
-            cls.DIRECTION: str(data_type.direction()),
-            cls.NULL_ORDERING: str(data_type.null_ordering()),
+            cls.SORT_TERM: SerdesUtils.write_function_arg(value.sort_term()),
+            cls.DIRECTION: str(value.direction()),
+            cls.NULL_ORDERING: str(value.null_ordering()),
         }
 
     @classmethod

--- a/clients/client-python/gravitino/dto/rel/partitioning/json_serdes/partitioning_serdes.py
+++ b/clients/client-python/gravitino/dto/rel/partitioning/json_serdes/partitioning_serdes.py
@@ -68,7 +68,7 @@ class PartitioningSerdes(SerdesUtilsBase, JsonSerializable[Partitioning]):
     )
 
     @classmethod
-    def serialize(cls, data_type: Partitioning) -> Dict[str, Any]:
+    def serialize(cls, value: Partitioning) -> Dict[str, Any]:
         """Serialize the given PartitionDTO object.
 
         Args:
@@ -81,28 +81,28 @@ class PartitioningSerdes(SerdesUtilsBase, JsonSerializable[Partitioning]):
             IOError: If partitioning strategy is unknown.
         """
 
-        strategy = data_type.strategy()
+        strategy = value.strategy()
         result = {cls.STRATEGY: strategy.name.lower()}
 
         if strategy in cls._SINGLE_FIELD_PARTITIONING:
-            dto = cast(SingleFieldPartitioning, data_type)
+            dto = cast(SingleFieldPartitioning, value)
             return {**result, cls.FIELD_NAME: dto.field_name()}
         if strategy is Partitioning.Strategy.BUCKET:
-            dto = cast(BucketPartitioningDTO, data_type)
+            dto = cast(BucketPartitioningDTO, value)
             return {
                 **result,
                 cls.NUM_BUCKETS: dto.num_buckets(),
                 cls.FIELD_NAMES: dto.field_names(),
             }
         if strategy is Partitioning.Strategy.TRUNCATE:
-            dto = cast(TruncatePartitioningDTO, data_type)
+            dto = cast(TruncatePartitioningDTO, value)
             return {
                 **result,
                 cls.WIDTH: dto.width(),
                 cls.FIELD_NAME: dto.field_name(),
             }
         if strategy is Partitioning.Strategy.LIST:
-            dto = cast(ListPartitioningDTO, data_type)
+            dto = cast(ListPartitioningDTO, value)
             return {
                 **result,
                 cls.FIELD_NAMES: dto.field_names(),
@@ -112,7 +112,7 @@ class PartitioningSerdes(SerdesUtilsBase, JsonSerializable[Partitioning]):
                 ],
             }
         if strategy is Partitioning.Strategy.RANGE:
-            dto = cast(RangePartitioningDTO, data_type)
+            dto = cast(RangePartitioningDTO, value)
             return {
                 **result,
                 cls.FIELD_NAME: dto.field_name(),
@@ -122,7 +122,7 @@ class PartitioningSerdes(SerdesUtilsBase, JsonSerializable[Partitioning]):
                 ],
             }
         if strategy is Partitioning.Strategy.FUNCTION:
-            dto = cast(FunctionPartitioningDTO, data_type)
+            dto = cast(FunctionPartitioningDTO, value)
             return {
                 **result,
                 cls.FUNCTION_NAME: dto.function_name(),

--- a/clients/client-python/gravitino/dto/rel/partitions/json_serdes/partition_dto_serdes.py
+++ b/clients/client-python/gravitino/dto/rel/partitions/json_serdes/partition_dto_serdes.py
@@ -24,8 +24,8 @@ from gravitino.dto.rel.partitions.partition_dto import PartitionDTO
 
 class PartitionDTOSerdes(JsonSerializable[PartitionDTO]):
     @classmethod
-    def serialize(cls, data_type: PartitionDTO) -> Dict[str, Any]:
-        return SerdesUtils.write_partition(data_type)
+    def serialize(cls, value: PartitionDTO) -> Dict[str, Any]:
+        return SerdesUtils.write_partition(value)
 
     @classmethod
     def deserialize(cls, data: Dict[str, Any]) -> PartitionDTO:

--- a/clients/client-python/pylintrc
+++ b/clients/client-python/pylintrc
@@ -94,3 +94,8 @@ variable-naming-style=snake_case
 
 # Naming Style for Module
 module-naming-style=snake_case
+
+[DESIGN]
+
+# Maximum number of return / yield for a function / method body.
+max-returns=10


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add missing `__init__.py` files in 5 directories under `clients/client-python/gravitino/`.

### Why are the changes needed?

`setup.py` uses `find_packages()` which requires `__init__.py` to recognize directories as Python packages. Without these files, importing `GravitinoClient` after `pip install` fails with `ModuleNotFoundError`.

Fix: #10339

### Does this PR introduce _any_ user-facing change?

Yes. Fixes `ModuleNotFoundError` when importing `gravitino` after `pip install apache-gravitino`.

### How was this patch tested?

`python3 -c "from gravitino import GravitinoClient"` passes after the fix.