### PR TITLE
[#10334] fix(trino-connector): Update base Trino docker image version from 469 to 478

### DIFF
--- a/dev/docker/trino/Dockerfile
+++ b/dev/docker/trino/Dockerfile
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-FROM trinodb/trino:469
+FROM trinodb/trino:478
 LABEL maintainer="dev@gravitino.apache.org"
 
 USER root


### PR DESCRIPTION
### What changes were proposed in this pull request?

Update the base Trino image in the playground Dockerfile from `trinodb/trino:469` to `trinodb/trino:478`.

### Why are the changes needed?

The playground Docker image was using `trinodb/trino:469` as the base image, but the Gravitino Trino connector only supports versions 473-478. This mismatch caused a startup failure:

```
Unsupported Trino-469 version. The Supported version for the Gravitino-Trino-connector from Trino-473 to Trino-478.
```

Fix: #10334

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

The fix aligns the base image version with the supported connector version range (473-478).