### PR TITLE
[#10345] fix(optimizer): remove unnecessary optimizer config copy

### DIFF
--- a/maintenance/optimizer/build.gradle.kts
+++ b/maintenance/optimizer/build.gradle.kts
@@ -115,23 +115,8 @@ tasks {
     into("$rootDir/distribution/package/optimizer/libs")
   }
 
-  register("copyConfigs", Copy::class) {
-    from("src/main/resources")
-    into("$rootDir/distribution/package/optimizer/conf")
-
-    rename { original ->
-      if (original.endsWith(".template")) {
-        original.replace(".template", "")
-      } else {
-        original
-      }
-    }
-
-    fileMode = 0b111101101
-  }
-
   register("copyLibAndConfigs", Copy::class) {
-    dependsOn("copyLibs", "copyConfigs")
+    dependsOn("copyLibs")
   }
 }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR removes the unnecessary optimizer config copy step from distribution packaging.

- Delete `copyConfigs` task in `maintenance/optimizer/build.gradle.kts`.
- Keep `copyLibAndConfigs` task name for compatibility, but make it depend only on `copyLibs`.

With this change, `distribution/package/optimizer/conf` is no longer populated by files from `src/main/resources`, so SPI service files are not placed under `optimizer/conf`.

### Why are the changes needed?

The optimizer packaging currently copies `src/main/resources` into `optimizer/conf`, which introduces non-config files such as:

- `META-INF/services/org.apache.gravitino.maintenance.optimizer.api.common.Provider`
- `org.apache.gravitino.maintenance.optimizer.api.monitor.MetricsEvaluator*`
- `org.apache.gravitino.maintenance.optimizer.api.updater.StatisticsCalculator`

These files are SPI metadata and should stay on classpath in jars, not in config directory.

Fix: #10345

### Does this PR introduce _any_ user-facing change?

No.

- No user-facing API changes.
- No config key changes.
- Packaging output is cleaner: optimizer config directory no longer contains SPI metadata files.

### How was this patch tested?

- `GRADLE_USER_HOME=.gradle-local ./gradlew :maintenance:optimizer:copyLibAndConfigs -x test`
- `GRADLE_USER_HOME=.gradle-local ./gradlew compileDistribution -x test -x :web:web:build -x :web-v2:web:build`
- Run optimizer CLI from distribution package:
  - `GRAVITINO_HOME=$PWD GRAVITINO_CONF_DIR=$PWD/conf GRAVITINO_LOG_DIR=$PWD/logs ./bin/gravitino-optimizer.sh --help`
  - `GRAVITINO_HOME=$PWD GRAVITINO_CONF_DIR=$PWD/conf GRAVITINO_LOG_DIR=$PWD/logs ./bin/gravitino-optimizer.sh --type update-statistics --help`

Validation result: `distribution/package/optimizer` contains `libs` only, and no unwanted SPI files under `optimizer/conf`.
