### PR TITLE
[#10349] fix(trino-connector): Remove unrecognized JVM option GCLockerRetryAllocationCount for Trino 478+

### DIFF
--- a/dev/docker/trino/conf/jvm.config
+++ b/dev/docker/trino/conf/jvm.config
@@ -28,8 +28,5 @@
 -XX:PerBytecodeRecompilationCutoff=10000
 -Djdk.attach.allowAttachSelf=true
 -Djdk.nio.maxCachedBufferSize=2000000
-# Reduce starvation of threads by GClocker, recommend to set about the number of cpu cores (JDK-8192647)
--XX:+UnlockDiagnosticVMOptions
--XX:GCLockerRetryAllocationCount=32
 -DHADOOP_USER_NAME=hive
 -Dlog4j.configurationFile=/etc/trino/log4j2.properties


### PR DESCRIPTION
### What changes were proposed in this pull request?

Remove the `-XX:GCLockerRetryAllocationCount=32` and related JVM options from
`dev/docker/trino/conf/jvm.config`, as this option was removed in newer JDK versions.

### Why are the changes needed?

Trino 478+ fails to start with the following error:

```
Unrecognized VM option 'GCLockerRetryAllocationCount=32'
Error: Could not create the Java Virtual Machine.
```

Fix: #10349

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manually verified Trino starts successfully after removing the unrecognized JVM option.