### PR TITLE
[MINOR] optimizer: relax statistics input validation for non-local calculators

### DIFF
--- a/maintenance/optimizer/src/main/java/org/apache/gravitino/maintenance/optimizer/OptimizerCmd.java
+++ b/maintenance/optimizer/src/main/java/org/apache/gravitino/maintenance/optimizer/OptimizerCmd.java
@@ -326,12 +326,6 @@ public class OptimizerCmd {
             "Command '%s' with --calculator-name %s requires one of --statistics-payload "
                 + "or --file-path.",
             LOCAL_STATS_CALCULATOR_NAME)
-        .addForbidWhenOption(
-            CliOption.CALCULATOR_NAME.longOpt(),
-            value -> !LOCAL_STATS_CALCULATOR_NAME.equals(value),
-            List.of(CliOption.STATISTICS_PAYLOAD.longOpt(), CliOption.FILE_PATH.longOpt()),
-            "--statistics-payload and --file-path are only supported when --calculator-name is %s.",
-            LOCAL_STATS_CALCULATOR_NAME)
         .build();
   }
 
@@ -502,12 +496,12 @@ public class OptimizerCmd {
         "statistics-payload",
         CliOptionArgType.SINGLE,
         null,
-        "Inline statistics payload for local-stats-calculator"),
+        "Inline statistics payload for the selected calculator"),
     FILE_PATH(
         "file-path",
         CliOptionArgType.SINGLE,
         null,
-        "Path to statistics input file for local-stats-calculator"),
+        "Path to statistics input file for the selected calculator"),
     ACTION_TIME("action-time", CliOptionArgType.SINGLE, null, "Action time in epoch seconds"),
     RANGE_SECONDS(
         "range-seconds", CliOptionArgType.SINGLE, null, "Range seconds for monitor evaluation"),

--- a/maintenance/optimizer/src/test/java/org/apache/gravitino/maintenance/optimizer/TestOptimizerCmd.java
+++ b/maintenance/optimizer/src/test/java/org/apache/gravitino/maintenance/optimizer/TestOptimizerCmd.java
@@ -59,19 +59,20 @@ class TestOptimizerCmd {
   }
 
   @Test
-  void testRejectStatisticsInputWhenCalculatorIsNotLocal() {
+  void testAllowStatisticsInputWhenCalculatorIsNotLocal() throws Exception {
+    Path confPath = createOptimizerConfForUpdater();
     String[] output =
         runCommand(
             "--type",
             "update-statistics",
             "--calculator-name",
-            "mock-calculator",
+            StatisticsCalculatorForTest.NAME,
             "--statistics-payload",
-            "{\"identifier\":\"c.db.t\"}");
-    Assertions.assertTrue(
-        output[1].contains(
-            "--statistics-payload and --file-path are only supported when --calculator-name "
-                + "is local-stats-calculator."));
+            "{\"identifier\":\"test.db.table\",\"stats-type\":\"table\",\"row_count\":100}",
+            "--conf-path",
+            confPath.toString());
+    Assertions.assertTrue(output[1].isEmpty(), "stderr=" + output[1] + ", stdout=" + output[0]);
+    Assertions.assertTrue(output[0].contains("SUMMARY: statistics"));
   }
 
   @Test


### PR DESCRIPTION
## What changes
- Remove the CLI rule that forbids `--statistics-payload` / `--file-path` when `--calculator-name` is not `local-stats-calculator`.
- Keep existing local-calculator requirement: when calculator is `local-stats-calculator`, one of `--statistics-payload` or `--file-path` is still required.
- Update CLI option descriptions to be calculator-agnostic.
- Update optimizer CLI tests to cover the new behavior for non-local calculators.

## Why
The previous rule blocked extension scenarios (for example custom calculators that accept file/payload inputs) at CLI validation time.

## Validation
- `./gradlew :maintenance:optimizer:test --tests "org.apache.gravitino.maintenance.optimizer.TestOptimizerCmd"`
