### PR TITLE
[MINOR] docs(table-maintenance-service): fix optimizer quick-start rewrite log verification

### DIFF
--- a/docs/table-maintenance-service/optimizer-quick-start.md
+++ b/docs/table-maintenance-service/optimizer-quick-start.md
@@ -230,10 +230,9 @@ curl -sS "http://localhost:8090/api/metalakes/test/objects/table/rest_catalog.db
 
 # Staging path is controlled by `gravitino.job.stagingDir` (default: `/tmp/gravitino/jobs/staging`).
 # Verify rewrite actually rewrote files (N should be > 0 for non-empty table).
-# Key summary lines are typically in output.log; some environments may also print to error.log.
 log_dir="/tmp/gravitino/jobs/staging/test/builtin-iceberg-rewrite-data-files/${strategy_job_id}"
 grep -E "Rewritten data files|Added data files|completed successfully" \
-  "${log_dir}/output.log" "${log_dir}/error.log" 2>/dev/null
+  "${log_dir}/output.log"
 ```
 
 By default, Gravitino pulls job status every `300000` ms (`gravitino.job.statusPullIntervalInMs`).


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR updates the TMS quick-start verification command in
`docs/table-maintenance-service/optimizer-quick-start.md`:

- In step 7, use `log_dir` and grep rewrite summary lines from `output.log`.
- Keep the verification command aligned with actual built-in rewrite job output.

### Why are the changes needed?

During end-to-end validation on Gravitino 1.2.0, rewrite summary lines such as:

- `Rewritten data files: <N>`
- `Added data files: <N>`
- `Rewrite data files job completed successfully`

were written to `output.log`. The previous doc command checked `error.log`,
which can cause false-negative verification.

Fix: #N/A

### Does this PR introduce _any_ user-facing change?

No API or property changes.
Only documentation behavior/command guidance is corrected.

### How was this patch tested?

Validated by running optimizer quick-start workflow end to end with:

- Gravitino: `/Users/fanng/release/1.2.0/gravitino-1.2.0-bin`
- Spark: `/Users/fanng/deploy/demo/spark-3.5.3-bin-hadoop3`

Observed successful rewrite job and confirmed summary lines exist in:
`/tmp/gravitino/jobs/staging/test/builtin-iceberg-rewrite-data-files/<job_id>/output.log`.
