### PR TITLE
[MINOR] fix: polish log and error message quality across Java modules

### DIFF
--- a/api/src/main/java/org/apache/gravitino/rel/TableChange.java
+++ b/api/src/main/java/org/apache/gravitino/rel/TableChange.java
@@ -900,7 +900,7 @@ public interface TableChange {
 
     private After(String column) {
       if (null == column) {
-        throw new IllegalArgumentException("column can not be null.");
+        throw new IllegalArgumentException("column cannot be null");
       }
       this.column = column;
     }

--- a/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/RangerAuthorizationPlugin.java
+++ b/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/RangerAuthorizationPlugin.java
@@ -324,7 +324,7 @@ public abstract class RangerAuthorizationPlugin
         LOG.info("Ranger delete role: {} failed!", role, e);
       } else {
         throw new AuthorizationPluginException(
-            "Fail to delete role %s exception: %s", role, e.getMessage());
+            "Failed to delete role %s, exception: %s", role, e.getMessage());
       }
     }
     return Boolean.TRUE;
@@ -622,7 +622,7 @@ public abstract class RangerAuthorizationPlugin
                 rangerClient.grantRole(rangerServiceName, grantRevokeRoleRequest);
               } catch (RangerServiceException e) {
                 throw new AuthorizationPluginException(
-                    "Fail to grant role %s to user %s, exception: %s",
+                    "Failed to grant role %s to user %s, exception: %s",
                     role.name(), user.name(), e.getMessage());
               }
             });
@@ -658,7 +658,7 @@ public abstract class RangerAuthorizationPlugin
                 rangerClient.revokeRole(rangerServiceName, grantRevokeRoleRequest);
               } catch (RangerServiceException e) {
                 throw new AuthorizationPluginException(
-                    "Fail to revoke role %s from user %s, exception: %s",
+                    "Failed to revoke role %s from user %s, exception: %s",
                     role.name(), user.name(), e.getMessage());
               }
             });
@@ -694,7 +694,7 @@ public abstract class RangerAuthorizationPlugin
                 rangerClient.grantRole(rangerServiceName, grantRevokeRoleRequest);
               } catch (RangerServiceException e) {
                 throw new AuthorizationPluginException(
-                    "Fail to grant role: %s to group %s, exception: %s.",
+                    "Failed to grant role %s to group %s, exception: %s",
                     role, group, e.getMessage());
               }
             });
@@ -727,7 +727,7 @@ public abstract class RangerAuthorizationPlugin
                 rangerClient.revokeRole(rangerServiceName, grantRevokeRoleRequest);
               } catch (RangerServiceException e) {
                 throw new AuthorizationPluginException(
-                    "Fail to revoke role %s from group %s, exception: %s",
+                    "Failed to revoke role %s from group %s, exception: %s",
                     role.name(), group.name(), e.getMessage());
               }
             });
@@ -821,11 +821,11 @@ public abstract class RangerAuthorizationPlugin
           }
         } catch (RangerServiceException crse) {
           throw new AuthorizationPluginException(
-              "Fail to create ranger service %s, exception: %s", serviceName, crse.getMessage());
+              "Failed to create Ranger service %s, exception: %s", serviceName, crse.getMessage());
         }
       } else {
         throw new AuthorizationPluginException(
-            "Fail to get ranger service name %s, exception: %s", serviceName, rse.getMessage());
+            "Failed to get Ranger service name %s, exception: %s", serviceName, rse.getMessage());
       }
     }
   }
@@ -1094,7 +1094,7 @@ public abstract class RangerAuthorizationPlugin
         }
       }
     } catch (Exception e) {
-      throw new AuthorizationPluginException("Fail to get the field name of class VXGroup");
+      throw new AuthorizationPluginException("Failed to get the field name of class VXGroup");
     }
     return Optional.empty();
   }

--- a/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/RangerClientExtension.java
+++ b/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/RangerClientExtension.java
@@ -103,7 +103,7 @@ public class RangerClientExtension extends RangerClient {
   @Override
   public RangerPolicy createPolicy(RangerPolicy policy) throws RangerServiceException {
     Preconditions.checkArgument(
-        policy.getResources().size() > 0, "Ranger policy resources can not be empty!");
+        policy.getResources().size() > 0, "Ranger policy resources cannot be empty!");
     return super.createPolicy(policy);
   }
 
@@ -111,7 +111,7 @@ public class RangerClientExtension extends RangerClient {
   public RangerPolicy updatePolicy(long policyId, RangerPolicy policy)
       throws RangerServiceException {
     Preconditions.checkArgument(
-        policy.getResources().size() > 0, "Ranger policy resources can not be empty!");
+        policy.getResources().size() > 0, "Ranger policy resources cannot be empty!");
     return super.updatePolicy(policyId, policy);
   }
 

--- a/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/RangerHelper.java
+++ b/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/RangerHelper.java
@@ -299,7 +299,7 @@ public class RangerHelper {
       // not exist, then create it.
       if (e.getMessage() != null
           && e.getMessage().contains("User doesn't have permissions to get details")) {
-        LOG.warn("The role({}) does not exist in the Ranger!, e: {}", roleName, e);
+        LOG.warn("Role {} does not exist in Ranger", roleName, e);
       } else {
         throw new AuthorizationPluginException(
             "Failed to check role(%s) whether exists in the Ranger! e: %s",

--- a/bundles/gcp/src/main/java/org/apache/gravitino/gcs/credential/GCSTokenGenerator.java
+++ b/bundles/gcp/src/main/java/org/apache/gravitino/gcs/credential/GCSTokenGenerator.java
@@ -248,7 +248,7 @@ public class GCSTokenGenerator implements CredentialGenerator<GCSTokenCredential
     try (InputStream fileInputStream = Files.newInputStream(credentialsFilePath)) {
       return GoogleCredentials.fromStream(fileInputStream);
     } catch (NoSuchFileException e) {
-      throw new IOException("GCS credential file does not exist." + gcsCredentialFilePath, e);
+      throw new IOException("GCS credential file does not exist: " + gcsCredentialFilePath, e);
     }
   }
 

--- a/catalogs/catalog-lakehouse-paimon/src/main/java/org/apache/gravitino/catalog/lakehouse/paimon/PaimonCatalogOperations.java
+++ b/catalogs/catalog-lakehouse-paimon/src/main/java/org/apache/gravitino/catalog/lakehouse/paimon/PaimonCatalogOperations.java
@@ -575,7 +575,7 @@ public class PaimonCatalogOperations
         identifier != null
             && identifier.namespace() != null
             && identifier.namespace().levels().length > 0,
-        "Namespace can not be null or empty.");
+        "Namespace cannot be null or empty");
     String[] levels = identifier.namespace().levels();
     return NameIdentifier.of(levels[levels.length - 1], identifier.name());
   }

--- a/catalogs/catalog-lakehouse-paimon/src/main/java/org/apache/gravitino/catalog/lakehouse/paimon/ops/PaimonCatalogOps.java
+++ b/catalogs/catalog-lakehouse-paimon/src/main/java/org/apache/gravitino/catalog/lakehouse/paimon/ops/PaimonCatalogOps.java
@@ -54,7 +54,7 @@ public class PaimonCatalogOps implements AutoCloseable {
     paimonBackendCatalogWrapper = loadCatalogBackend(paimonConfig);
     Preconditions.checkArgument(
         paimonBackendCatalogWrapper.getCatalog() != null,
-        "Can not load Paimon backend catalog instance.");
+        "Cannot load Paimon backend catalog instance");
     catalog = paimonBackendCatalogWrapper.getCatalog();
   }
 

--- a/catalogs/catalog-lakehouse-paimon/src/main/java/org/apache/gravitino/catalog/lakehouse/paimon/utils/CatalogUtils.java
+++ b/catalogs/catalog-lakehouse-paimon/src/main/java/org/apache/gravitino/catalog/lakehouse/paimon/utils/CatalogUtils.java
@@ -142,16 +142,16 @@ public class CatalogUtils {
   private static void checkPaimonConfig(PaimonConfig paimonConfig) {
     String metastore = paimonConfig.get(CATALOG_BACKEND);
     Preconditions.checkArgument(
-        StringUtils.isNotBlank(metastore), "Paimon Catalog metastore can not be null or empty.");
+        StringUtils.isNotBlank(metastore), "Paimon Catalog metastore cannot be null or empty");
 
     String warehouse = paimonConfig.get(CATALOG_WAREHOUSE);
     Preconditions.checkArgument(
-        StringUtils.isNotBlank(warehouse), "Paimon Catalog warehouse can not be null or empty.");
+        StringUtils.isNotBlank(warehouse), "Paimon Catalog warehouse cannot be null or empty");
 
     if (!PaimonCatalogBackend.FILESYSTEM.name().equalsIgnoreCase(metastore)) {
       String uri = paimonConfig.get(CATALOG_URI);
       Preconditions.checkArgument(
-          StringUtils.isNotBlank(uri), "Paimon Catalog uri can not be null or empty.");
+          StringUtils.isNotBlank(uri), "Paimon Catalog URI cannot be null or empty");
     }
 
     if (PaimonCatalogBackend.JDBC.name().equalsIgnoreCase(metastore)) {

--- a/catalogs/hadoop-auth/src/main/java/org/apache/gravitino/catalog/hadoop/auth/KerberosAuthUtils.java
+++ b/catalogs/hadoop-auth/src/main/java/org/apache/gravitino/catalog/hadoop/auth/KerberosAuthUtils.java
@@ -137,7 +137,7 @@ public final class KerberosAuthUtils {
     keytabFile.deleteOnExit();
     if (keytabFile.exists() && !keytabFile.delete()) {
       throw new IllegalStateException(
-          String.format("Fail to delete keytab file %s", keytabFile.getAbsolutePath()));
+          String.format("Failed to delete keytab file %s", keytabFile.getAbsolutePath()));
     }
     return fetchKeytabFromUri(keytabUri, keytabFile, timeoutSec, allowHdfsKeytabUri, hadoopConf);
   }
@@ -234,7 +234,7 @@ public final class KerberosAuthUtils {
     try {
       loginUgi.checkTGTAndReloginFromKeytab();
     } catch (Exception e) {
-      log.error("Fail to refresh ugi token: ", e);
+      log.error("Failed to refresh UGI token: ", e);
     }
   }
 

--- a/clients/client-java/src/main/java/org/apache/gravitino/client/KerberosTokenProvider.java
+++ b/clients/client-java/src/main/java/org/apache/gravitino/client/KerberosTokenProvider.java
@@ -82,7 +82,7 @@ public final class KerberosTokenProvider implements AuthDataProvider {
     try {
       return getTokenInternal();
     } catch (Exception e) {
-      throw new IllegalStateException("Fail to get the Kerberos token", e);
+      throw new IllegalStateException("Failed to get the Kerberos token", e);
     }
   }
 
@@ -130,7 +130,7 @@ public final class KerberosTokenProvider implements AuthDataProvider {
         subjectProvider.close();
       }
     } catch (LoginException le) {
-      throw new IOException("Fail to close login context", le);
+      throw new IOException("Failed to close login context", le);
     }
   }
 

--- a/core/src/main/java/org/apache/gravitino/audit/AuditLogManager.java
+++ b/core/src/main/java/org/apache/gravitino/audit/AuditLogManager.java
@@ -49,7 +49,7 @@ public class AuditLogManager {
     }
     String formatterClassName = config.get(Configs.AUDIT_LOG_FORMATTER_CLASS_NAME);
     Formatter formatter = loadFormatter(formatterClassName);
-    LOG.info("Audit log formatter class name:{}", formatterClassName);
+    LOG.info("Audit log formatter class name: {}", formatterClassName);
 
     String writerClassName = config.get(Configs.AUDIT_LOG_WRITER_CLASS_NAME);
     auditLogWriter =
@@ -57,7 +57,7 @@ public class AuditLogManager {
             writerClassName,
             config.getConfigsWithPrefix(Configs.AUDIT_LOG_WRITER_CONFIG_PREFIX),
             formatter);
-    LOG.info("Audit log writer class name:{}", writerClassName);
+    LOG.info("Audit log writer class name: {}", writerClassName);
 
     eventBusManager.addEventListener(
         "audit-log",
@@ -83,7 +83,7 @@ public class AuditLogManager {
             try {
               auditLogWriter.write(event);
             } catch (Exception e) {
-              LOG.warn("Failed to write audit log {}.", event, e);
+              LOG.warn("Failed to write audit log {}", event, e);
             }
           }
 
@@ -111,7 +111,8 @@ public class AuditLogManager {
     try {
       return (Formatter) Class.forName(className).getDeclaredConstructor().newInstance();
     } catch (Exception e) {
-      throw new GravitinoRuntimeException(e, "Failed to load formatter class name %s", className);
+      throw new GravitinoRuntimeException(
+          e, "Failed to load audit log formatter class %s", className);
     }
   }
 

--- a/core/src/main/java/org/apache/gravitino/authorization/GravitinoAuthorizer.java
+++ b/core/src/main/java/org/apache/gravitino/authorization/GravitinoAuthorizer.java
@@ -189,7 +189,7 @@ public interface GravitinoAuthorizer extends Closeable {
                   RoleEntity.class);
       handleRolePrivilegeChange(entity.id());
     } catch (Exception e) {
-      throw new RuntimeException("Can not get Role Entity", e);
+      throw new RuntimeException("Cannot get role entity", e);
     }
   }
 

--- a/core/src/main/java/org/apache/gravitino/authorization/OwnerManager.java
+++ b/core/src/main/java/org/apache/gravitino/authorization/OwnerManager.java
@@ -130,7 +130,7 @@ public class OwnerManager implements OwnerDispatcher {
           nse, "Metadata object %s or owner %s is not found", metadataObject.fullName(), ownerName);
     } catch (IOException ioe) {
       LOG.info(
-          "Fail to set the owner {} of metadata object {}",
+          "Failed to set the owner {} of metadata object {}",
           ownerName,
           metadataObject.fullName(),
           ioe);
@@ -225,7 +225,8 @@ public class OwnerManager implements OwnerDispatcher {
           nse.getMessage());
       throw new NotFoundException(nse, "Metadata object or owner %s is not found", ownerName);
     } catch (IOException ioe) {
-      LOG.warn("Fail to batch set owner {} on {} objects", ownerName, metadataObjects.size(), ioe);
+      LOG.warn(
+          "Failed to batch set owner {} on {} objects", ownerName, metadataObjects.size(), ioe);
       throw new RuntimeException(ioe);
     }
   }
@@ -339,7 +340,7 @@ public class OwnerManager implements OwnerDispatcher {
       throw new NoSuchMetadataObjectException(
           "The metadata object of %s isn't found", metadataObject.fullName());
     } catch (IOException ioe) {
-      LOG.info("Fail to get the owner of entity {}", metadataObject.fullName(), ioe);
+      LOG.info("Failed to get the owner of entity {}", metadataObject.fullName(), ioe);
       throw new RuntimeException(ioe);
     }
   }

--- a/core/src/main/java/org/apache/gravitino/auxiliary/AuxiliaryServiceManager.java
+++ b/core/src/main/java/org/apache/gravitino/auxiliary/AuxiliaryServiceManager.java
@@ -148,7 +148,7 @@ public class AuxiliaryServiceManager {
       LOG.error("Failed to register auxService: {}", auxServiceName, e);
       throw new RuntimeException(e);
     }
-    LOG.info("AuxService:{} registered successfully", auxServiceName);
+    LOG.info("AuxService {} registered successfully", auxServiceName);
   }
 
   private void registerAuxServices(Map<String, String> config) {
@@ -206,7 +206,7 @@ public class AuxiliaryServiceManager {
     try {
       auxiliaryService.serviceStop();
     } catch (Exception e) {
-      LOG.warn("AuxService:{} stop failed", auxServiceName, e);
+      LOG.warn("Failed to stop AuxService {}", auxServiceName, e);
       if (firstException == null) {
         firstException = e;
       }

--- a/core/src/main/java/org/apache/gravitino/catalog/SchemaOperationDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/SchemaOperationDispatcher.java
@@ -415,7 +415,7 @@ public class SchemaOperationDispatcher extends OperationDispatcher implements Sc
       throw e;
     } catch (Exception e) {
       LOG.error(FormattedErrorMessages.STORE_OP_FAILURE, "put", identifier, e);
-      throw new RuntimeException("Fail to import schema entity to the store.", e);
+      throw new RuntimeException("Failed to import schema entity to the store", e);
     }
   }
 

--- a/core/src/main/java/org/apache/gravitino/catalog/TableOperationDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/TableOperationDispatcher.java
@@ -523,7 +523,7 @@ public class TableOperationDispatcher extends OperationDispatcher implements Tab
       throw e;
     } catch (Exception e) {
       LOG.error(FormattedErrorMessages.STORE_OP_FAILURE, "put", identifier, e);
-      throw new RuntimeException("Fail to import the table entity to the store.", e);
+      throw new RuntimeException("Failed to import the table entity to the store", e);
     }
 
     return EntityCombinedTable.of(table.tableFromCatalog(), tableEntity)

--- a/core/src/main/java/org/apache/gravitino/catalog/TopicOperationDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/TopicOperationDispatcher.java
@@ -307,7 +307,7 @@ public class TopicOperationDispatcher extends OperationDispatcher implements Top
       store.put(topicEntity, true);
     } catch (Exception e) {
       LOG.error(FormattedErrorMessages.STORE_OP_FAILURE, "put", identifier, e);
-      throw new RuntimeException("Fail to import topic entity to store.", e);
+      throw new RuntimeException("Failed to import topic entity to the store", e);
     }
   }
 

--- a/core/src/main/java/org/apache/gravitino/catalog/ViewOperationDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/ViewOperationDispatcher.java
@@ -540,7 +540,7 @@ public class ViewOperationDispatcher extends OperationDispatcher implements View
               + "To resolve: Remove all catalogs managing this view, then recreate one catalog to ensure single-catalog management.");
     } catch (Exception e) {
       LOG.error(FormattedErrorMessages.STORE_OP_FAILURE, "put", ident, e);
-      throw new RuntimeException("Fail to import the view entity to the store.", e);
+      throw new RuntimeException("Failed to import the view entity to the store", e);
     }
 
     return EntityCombinedView.of(catalogView, viewEntity)

--- a/core/src/main/java/org/apache/gravitino/hook/CatalogHookDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/hook/CatalogHookDispatcher.java
@@ -100,12 +100,12 @@ public class CatalogHookDispatcher implements CatalogDispatcher {
       }
     } catch (Exception postHookException) {
       LOG.warn(
-          "Fail to execute the post hook operations, rollback the catalog " + ident,
+          "Failed to execute post hook operations, rolling back catalog " + ident,
           postHookException);
       try {
         dispatcher.dropCatalog(ident, true);
       } catch (Exception rollbackException) {
-        LOG.warn("Fail to rollback the catalog during the post hook", rollbackException);
+        LOG.warn("Failed to roll back the catalog during the post hook", rollbackException);
         postHookException.addSuppressed(rollbackException);
       }
       throw postHookException;

--- a/core/src/main/java/org/apache/gravitino/listener/AsyncQueueListener.java
+++ b/core/src/main/java/org/apache/gravitino/listener/AsyncQueueListener.java
@@ -131,7 +131,7 @@ public class AsyncQueueListener implements EventListenerPlugin {
         LOG.warn("{} event dispatcher thread is interrupted.", asyncQueueListenerName);
         break;
       } catch (Exception e) {
-        LOG.warn("{} throw a exception while processing event", asyncQueueListenerName, e);
+        LOG.warn("{} threw an exception while processing event", asyncQueueListenerName, e);
       }
     }
 

--- a/core/src/main/java/org/apache/gravitino/metrics/MetricsSystem.java
+++ b/core/src/main/java/org/apache/gravitino/metrics/MetricsSystem.java
@@ -146,7 +146,7 @@ public class MetricsSystem implements Closeable {
           try {
             reporter.close();
           } catch (IOException exception) {
-            LOG.warn("Close metrics reporter failed,", exception);
+            LOG.warn("Failed to close metrics reporter", exception);
           }
         });
   }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/RelationalGarbageCollector.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/RelationalGarbageCollector.java
@@ -71,7 +71,7 @@ public final class RelationalGarbageCollector implements Closeable {
   @VisibleForTesting
   public void collectAndClean() {
     long threadId = Thread.currentThread().getId();
-    LOG.debug("Thread {} start to collect garbage...", threadId);
+    LOG.debug("Thread {} starting garbage collection", threadId);
 
     try {
       LOG.debug("Start to collect and delete legacy data by thread {}", threadId);
@@ -103,13 +103,14 @@ public final class RelationalGarbageCollector implements Closeable {
             deletedCount = backend.deleteOldVersionData(entityType, versionRetentionCount);
           }
         } catch (RuntimeException e) {
-          LOG.error("Failed to softly delete type of " + entityType + "'s old version data: ", e);
+          LOG.error(
+              "Failed to soft-delete old version data for entity type " + entityType + ": ", e);
         }
       }
     } catch (Exception e) {
-      LOG.error("Thread {} failed to collect and clean garbage.", threadId, e);
+      LOG.error("Thread {} failed to collect and clean garbage", threadId, e);
     } finally {
-      LOG.debug("Thread {} finish to collect garbage.", threadId);
+      LOG.debug("Thread {} finished collecting garbage", threadId);
     }
   }
 

--- a/core/src/main/java/org/apache/gravitino/utils/PrincipalUtils.java
+++ b/core/src/main/java/org/apache/gravitino/utils/PrincipalUtils.java
@@ -54,10 +54,10 @@ public class PrincipalUtils {
     } catch (PrivilegedActionException pae) {
       Throwable cause = pae.getCause();
       Throwables.propagateIfPossible(cause, Exception.class);
-      throw new RuntimeException("doAs method occurs an unexpected exception", pae);
+      throw new RuntimeException("doAs method encountered an unexpected exception", pae);
     } catch (Error t) {
-      LOG.warn("doAs method occurs an unexpected error", t);
-      throw new RuntimeException("doAs method occurs an unexpected exception", t);
+      LOG.warn("doAs method encountered an unexpected error", t);
+      throw new RuntimeException("doAs method encountered an unexpected exception", t);
     }
   }
 

--- a/server-common/src/main/java/org/apache/gravitino/server/authentication/KerberosAuthenticator.java
+++ b/server-common/src/main/java/org/apache/gravitino/server/authentication/KerberosAuthenticator.java
@@ -144,8 +144,8 @@ public class KerberosAuthenticator implements Authenticator {
             }
           });
     } catch (Exception e) {
-      LOG.warn("Fail to validate the token, exception: ", e);
-      throw new UnauthorizedException("Fail to validate the token", AuthConstants.NEGOTIATE);
+      LOG.warn("Failed to validate the token, exception: ", e);
+      throw new UnauthorizedException("Failed to validate the token", AuthConstants.NEGOTIATE);
     }
   }
 

--- a/server-common/src/main/java/org/apache/gravitino/server/authorization/GravitinoAuthorizerProvider.java
+++ b/server-common/src/main/java/org/apache/gravitino/server/authorization/GravitinoAuthorizerProvider.java
@@ -56,7 +56,7 @@ public class GravitinoAuthorizerProvider implements Closeable {
                   (GravitinoAuthorizer)
                       Class.forName(authorizationImpl).getDeclaredConstructor().newInstance();
             } catch (Exception e) {
-              throw new IllegalArgumentException("Can not initialize GravitinoAuthorizer", e);
+              throw new IllegalArgumentException("Cannot initialize GravitinoAuthorizer", e);
             }
           } else {
             gravitinoAuthorizer = new PassThroughAuthorizer();

--- a/server-common/src/main/java/org/apache/gravitino/server/authorization/MetadataAuthzHelper.java
+++ b/server-common/src/main/java/org/apache/gravitino/server/authorization/MetadataAuthzHelper.java
@@ -407,7 +407,7 @@ public class MetadataAuthzHelper {
                             : null;
                       });
                 } catch (Exception e) {
-                  LOG.error("GravitinoAuthorize error:{}", e.getMessage(), e);
+                  LOG.error("GravitinoAuthorizer error: {}", e.getMessage(), e);
                   return null;
                 }
               },

--- a/server-common/src/main/java/org/apache/gravitino/server/authorization/jcasbin/JcasbinAuthorizer.java
+++ b/server-common/src/main/java/org/apache/gravitino/server/authorization/jcasbin/JcasbinAuthorizer.java
@@ -220,7 +220,7 @@ public class JcasbinAuthorizer implements GravitinoAuthorizer {
   private Model getModel(String modelFilePath) {
     Model model = new Model();
     try (InputStream modelStream = JcasbinAuthorizer.class.getResourceAsStream(modelFilePath)) {
-      Preconditions.checkArgument(modelStream != null, "Jcasbin model file can not found.");
+      Preconditions.checkArgument(modelStream != null, "Jcasbin model file not found");
       String modelData = IOUtils.toString(modelStream, StandardCharsets.UTF_8);
       model.loadModelFromText(modelData);
     } catch (IOException e) {
@@ -459,7 +459,7 @@ public class JcasbinAuthorizer implements GravitinoAuthorizer {
         return false;
 
       } catch (Exception e) {
-        LOG.warn("can not get user id or role id.", e);
+        LOG.warn("Cannot get user ID or role ID", e);
         return false;
       }
     }
@@ -709,7 +709,7 @@ public class JcasbinAuthorizer implements GravitinoAuthorizer {
         userInfo = userInfoOpt.get();
         userId = userInfo.getUserId();
       } catch (Exception e) {
-        LOG.debug("Can not get entity id", e);
+        LOG.debug("Cannot get entity ID", e);
         return false;
       }
 

--- a/server-common/src/main/java/org/apache/gravitino/server/web/JettyServer.java
+++ b/server-common/src/main/java/org/apache/gravitino/server/web/JettyServer.java
@@ -190,20 +190,20 @@ public class JettyServer {
       server.start();
     } catch (BindException e) {
       LOG.error(
-          "Failed to start {} web server on host {} port {}, which is already in use.",
+          "Failed to start {} web server on host {} port {}, which is already in use",
           serverName,
           serverConfig.getHost(),
           serverConfig.getHttpPort(),
           e);
-      throw new RuntimeException("Failed to start " + serverName + " web server.", e);
+      throw new RuntimeException("Failed to start " + serverName + " web server", e);
 
     } catch (Exception e) {
-      LOG.error("Failed to start {} web server.", serverName, e);
-      throw new RuntimeException("Failed to start " + serverName + " web server.", e);
+      LOG.error("Failed to start {} web server", serverName, e);
+      throw new RuntimeException("Failed to start " + serverName + " web server", e);
     }
 
     if (!serverConfig.isEnableHttps()) {
-      LOG.warn("Users would better use HTTPS to avoid token data leak.");
+      LOG.warn("Users should use HTTPS to avoid exposing tokens");
     }
 
     LOG.info(
@@ -214,7 +214,7 @@ public class JettyServer {
     try {
       server.join();
     } catch (InterruptedException e) {
-      LOG.info("Interrupted while {} web server is joining.", serverName);
+      LOG.info("Interrupted while {} web server is joining", serverName);
       Thread.currentThread().interrupt();
     }
   }
@@ -241,7 +241,7 @@ public class JettyServer {
             getPort());
       } catch (Exception e) {
         // Swallow the exception.
-        LOG.warn("Failed to stop {} web server.", serverName, e);
+        LOG.warn("Failed to stop {} web server", serverName, e);
       }
 
       server = null;

--- a/server-common/src/test/java/org/apache/gravitino/server/authentication/TestKerberosAuthenticator.java
+++ b/server-common/src/test/java/org/apache/gravitino/server/authentication/TestKerberosAuthenticator.java
@@ -135,7 +135,7 @@ public class TestKerberosAuthenticator extends KerberosSecurityTestcase {
             });
     Assertions.assertEquals("Blank token found", e.getMessage());
 
-    // case 4: Fail to validate the token
+    // case 4: Failed to validate the token
     String header = AuthConstants.AUTHORIZATION_NEGOTIATE_HEADER + "xxxx";
     byte[] bytes3 = header.getBytes(StandardCharsets.UTF_8);
     e =
@@ -144,7 +144,7 @@ public class TestKerberosAuthenticator extends KerberosSecurityTestcase {
             () -> {
               kerberosAuthenticator.authenticateToken(bytes3);
             });
-    Assertions.assertEquals("Fail to validate the token", e.getMessage());
+    Assertions.assertEquals("Failed to validate the token", e.getMessage());
   }
 
   @Test

--- a/server/src/main/java/org/apache/gravitino/server/web/rest/OwnerOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/OwnerOperations.java
@@ -75,7 +75,7 @@ public class OwnerOperations {
   @ResponseMetered(name = "get-object-owner", absolute = true)
   @AuthorizationExpression(
       expression = CAN_ACCESS_METADATA,
-      errorMessage = "Current user can not get this objects's owner")
+      errorMessage = "Current user cannot get this object's owner")
   public Response getOwnerForObject(
       @PathParam("metalake") @AuthorizationMetadata(type = Entity.EntityType.METALAKE)
           String metalake,
@@ -110,7 +110,7 @@ public class OwnerOperations {
   @ResponseMetered(name = "set-object-owner", absolute = true)
   @AuthorizationExpression(
       expression = CAN_SET_OWNER,
-      errorMessage = "Current user can not set this objects's owner")
+      errorMessage = "Current user cannot set this object's owner")
   public Response setOwnerForObject(
       @PathParam("metalake") @AuthorizationMetadata(type = Entity.EntityType.METALAKE)
           String metalake,

--- a/server/src/main/java/org/apache/gravitino/server/web/rest/PermissionOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/PermissionOperations.java
@@ -200,7 +200,7 @@ public class PermissionOperations {
   @ResponseMetered(name = "grant-privilege-to-role", absolute = true)
   @AuthorizationExpression(
       expression = CAN_OPERATE_METADATA_PRIVILEGE,
-      errorMessage = "Current user can not grant privilege to role.")
+      errorMessage = "Current user cannot grant privilege to role")
   public Response grantPrivilegeToRole(
       @PathParam("metalake") @AuthorizationMetadata(type = Entity.EntityType.METALAKE)
           String metalake,
@@ -248,7 +248,7 @@ public class PermissionOperations {
   @ResponseMetered(name = "revoke-privilege-from-role", absolute = true)
   @AuthorizationExpression(
       expression = CAN_OPERATE_METADATA_PRIVILEGE,
-      errorMessage = "Current user can not revoke privilege from role.")
+      errorMessage = "Current user cannot revoke privilege from role")
   public Response revokePrivilegeFromRole(
       @PathParam("metalake") @AuthorizationMetadata(type = Entity.EntityType.METALAKE)
           String metalake,

--- a/server/src/main/java/org/apache/gravitino/server/web/rest/SchemaOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/SchemaOperations.java
@@ -253,7 +253,7 @@ public class SchemaOperations {
             if (dropped) {
               LOG.info("Schema dropped: {}.{}.{}", metalake, catalog, schema);
             } else {
-              LOG.warn("Fail to drop schema {} under namespace {}", schema, ident.namespace());
+              LOG.warn("Failed to drop schema {} under namespace {}", schema, ident.namespace());
             }
 
             Response response = Utils.ok(new DropResponse(dropped));

--- a/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/GravitinoConfig.java
+++ b/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/GravitinoConfig.java
@@ -76,10 +76,14 @@ public class GravitinoConfig {
   // Gravitino config entity
   private static final ConfigEntry GRAVITINO_URI =
       new ConfigEntry(
-          "gravitino.uri", "The uri of the gravitino web server", "http://localhost:8090", false);
+          "gravitino.uri", "The URI of the Gravitino server", "http://localhost:8090", false);
 
   private static final ConfigEntry GRAVITINO_METALAKE =
-      new ConfigEntry("gravitino.metalake", "The metalake name for used", "", true);
+      new ConfigEntry(
+          "gravitino.metalake",
+          "The name of the metalake (top-level namespace) to connect to",
+          "",
+          true);
 
   private static final ConfigEntry GRAVITINO_USER =
       new ConfigEntry(
@@ -96,7 +100,7 @@ public class GravitinoConfig {
   private static final ConfigEntry GRAVITINO_SIMPLIFY_CATALOG_NAMES =
       new ConfigEntry(
           "gravitino.simplify-catalog-names",
-          "Omit metalake prefix for catalog names, is deprecated, use gravitino.use-single-metalake instead",
+          "Deprecated: omits the metalake prefix from catalog names. Use gravitino.use-single-metalake instead.",
           "true",
           false);
 
@@ -111,22 +115,24 @@ public class GravitinoConfig {
   private static final ConfigEntry GRAVITINO_CLOUD_REGION_CODE =
       new ConfigEntry(
           "gravitino.cloud.region-code",
-          "The property to specify the region code of the cloud that the catalog is running on.",
+          "Cloud region code for filtering catalogs by region. Leave empty for on-premises deployments.",
           "",
           false);
 
   private static final ConfigEntry GRAVITINO_CATALOG_CONNECTOR_FACTORY_CLASS_NAME =
       new ConfigEntry(
           "gravitino.catalog.connector.factory.class.name",
-          "The class name for the custom CatalogConnectorFactory. The class must implement the CatalogConnectorFactory interface",
+          "Fully qualified class name of a custom CatalogConnectorFactory implementation. If omitted, the default factory is used.",
           "",
           false);
 
   private static final ConfigEntry TRINO_JDBC_USER =
-      new ConfigEntry("trino.jdbc.user", "The jdbc user name of Trino", "admin", false);
+      new ConfigEntry(
+          "trino.jdbc.user", "The JDBC username for connecting to Trino", "admin", false);
 
   private static final ConfigEntry TRINO_JDBC_PASSWORD =
-      new ConfigEntry("trino.jdbc.password", "The jdbc user password of Trino", "", false);
+      new ConfigEntry(
+          "trino.jdbc.password", "The JDBC password for connecting to Trino", "", false);
 
   private static final ConfigEntry GRAVITINO_METADATA_REFRESH_INTERVAL_SECOND =
       new ConfigEntry(
@@ -138,17 +144,21 @@ public class GravitinoConfig {
   private static final ConfigEntry GRAVITINO_TRINO_SKIP_VERSION_VALIDATION =
       new ConfigEntry(
           "gravitino.trino.skip-version-validation",
-          "The property to specify whether skip Trino version validation or not. Note there may be compatiablity problem if true.",
+          "When true, skips Trino version validation and logs a warning instead of throwing an error. Gravitino supports Trino versions 435-439; other versions are untested.",
           "false",
           false);
 
   private static final ConfigEntry GRAVITINO_CLIENT_CONFIG_PREFIX =
-      new ConfigEntry("gravitino.client.", "The config prefix for Grivitino client", "", false);
+      new ConfigEntry(
+          "gravitino.client.",
+          "Prefix for Gravitino client properties. Any property beginning with this prefix is passed through to the Gravitino client (e.g., gravitino.client.auth.type=oauth2).",
+          "",
+          false);
 
   private static final ConfigEntry GRAVITINO_TRINO_SKIP_CATALOG_PATTERNS =
       new ConfigEntry(
           "gravitino.trino.skip-catalog-patterns",
-          "The property to specify a comma-separated list of catalog name regex patterns that should be excluded from loading.",
+          "Comma-separated list of regex patterns matching Gravitino catalog names to exclude from loading into Trino.",
           "",
           false);
 
@@ -225,7 +235,7 @@ public class GravitinoConfig {
   }
 
   /**
-   * Retrieves the config for Grivitino client.
+   * Retrieves the config for Gravitino client.
    *
    * @return the config properties map
    */

--- a/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/GravitinoConnectorFactory.java
+++ b/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/GravitinoConnectorFactory.java
@@ -174,7 +174,7 @@ public class GravitinoConnectorFactory implements ConnectorFactory {
       if (trinoVersion < getMinSupportTrinoSpiVersion()
           || trinoVersion > getMaxSupportTrinoSpiVersion()) {
         LOG.warn(
-            "The version {} has not undergone thorough testing with Gravitino, there may be compatibility problem.",
+            "Trino version {} has not been tested with Gravitino and may have compatibility issues",
             trinoVersion);
       }
       return;
@@ -185,8 +185,8 @@ public class GravitinoConnectorFactory implements ConnectorFactory {
         || trinoVersion > getMaxSupportTrinoSpiVersion()) {
       String errmsg =
           String.format(
-              "Unsupported Trino-%s version. The Supported version for the Gravitino-Trino-connector from Trino-%d to Trino-%d."
-                  + "Maybe you can set gravitino.trino.skip-version-validation to skip version validation.",
+              "Unsupported Trino version %s. Supported versions are %d to %d. "
+                  + "To bypass this check, set gravitino.trino.skip-version-validation=true",
               trinoVersion, getMinSupportTrinoSpiVersion(), getMaxSupportTrinoSpiVersion());
       throw new TrinoException(GravitinoErrorCode.GRAVITINO_UNSUPPORTED_TRINO_VERSION, errmsg);
     }
@@ -224,8 +224,7 @@ public class GravitinoConnectorFactory implements ConnectorFactory {
       Object obj = clazz.getDeclaredConstructor(GravitinoConfig.class).newInstance(config);
       return (CatalogConnectorFactory) obj;
     } catch (Exception e) {
-      throw new TrinoException(
-          GRAVITINO_RUNTIME_ERROR, "Can not create CatalogConnectorFactory ", e);
+      throw new TrinoException(GRAVITINO_RUNTIME_ERROR, "Cannot create CatalogConnectorFactory", e);
     }
   }
 

--- a/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/GravitinoConnectorPluginManager.java
+++ b/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/GravitinoConnectorPluginManager.java
@@ -68,7 +68,7 @@ public class GravitinoConnectorPluginManager {
       pluginLoaderClass = appClassloader.loadClass(PLUGIN_CLASSLOADER_CLASS_NAME);
     } catch (ClassNotFoundException e) {
       throw new TrinoException(
-          GravitinoErrorCode.GRAVITINO_RUNTIME_ERROR, "Can not load Plugin class loader", e);
+          GravitinoErrorCode.GRAVITINO_RUNTIME_ERROR, "Cannot load plugin class loader", e);
     }
 
     if (GravitinoConfig.trinoConfig.contains(TRINO_PLUGIN_BUNDLES)) {
@@ -95,7 +95,7 @@ public class GravitinoConnectorPluginManager {
         if (!APP_CLASS_LOADER_NAME.equals(classLoader.getName())) {
           throw new TrinoException(
               GravitinoErrorCode.GRAVITINO_RUNTIME_ERROR,
-              "Can not initialize GravitinoConnectorPluginManager when classLoader is not appClassLoader");
+              "Cannot initialize GravitinoConnectorPluginManager when classLoader is not appClassLoader");
         }
         instance = new GravitinoConnectorPluginManager(classLoader);
       }
@@ -149,7 +149,7 @@ public class GravitinoConnectorPluginManager {
     File directory = new File(dirName);
     File[] pluginFiles = directory.listFiles();
     if (pluginFiles == null || pluginFiles.length == 0) {
-      LOG.warn("Can not load plugin {} from empty directory {}", pluginName, dirName);
+      LOG.warn("Cannot load plugin {} from empty directory {}", pluginName, dirName);
       return;
     }
     List<URL> files =
@@ -191,13 +191,13 @@ public class GravitinoConnectorPluginManager {
           ServiceLoader.load(Plugin.class, (ClassLoader) pluginClassLoader);
       List<Plugin> pluginList = ImmutableList.copyOf(serviceLoader);
       if (pluginList.isEmpty()) {
-        LOG.warn("The {} plugin directory does not found connector SIP interface", pluginName);
+        LOG.warn("The {} plugin directory does not contain a connector SPI interface", pluginName);
         return;
       }
       Plugin plugin = pluginList.get(0);
       if (plugin.getConnectorFactories() == null
           || !plugin.getConnectorFactories().iterator().hasNext()) {
-        LOG.warn("The {} plugin does not contains any ConnectorFactories ", pluginName);
+        LOG.warn("The {} plugin does not contain any ConnectorFactories", pluginName);
         return;
       }
       connectorPlugins.put(pluginName, pluginList.get(0));
@@ -286,7 +286,7 @@ public class GravitinoConnectorPluginManager {
       if (plugin == null) {
         throw new TrinoException(
             GravitinoErrorCode.GRAVITINO_RUNTIME_ERROR,
-            "Can not found plugin for connector " + connectorName);
+            "Cannot find plugin for connector " + connectorName);
       }
       try (ThreadContextClassLoader ignored =
           new ThreadContextClassLoader(plugin.getClass().getClassLoader())) {
@@ -318,7 +318,7 @@ public class GravitinoConnectorPluginManager {
     if (plugin == null) {
       throw new TrinoException(
           GravitinoErrorCode.GRAVITINO_RUNTIME_ERROR,
-          "Can not found class loader for " + classLoaderName);
+          "Cannot find class loader for " + classLoaderName);
     }
     return plugin.getClass().getClassLoader();
   }

--- a/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/GravitinoHandle.java
+++ b/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/GravitinoHandle.java
@@ -130,7 +130,7 @@ interface GravitinoHandle<T> {
             JsonCodec.getMapper(clazz.getClassLoader()).readerFor(clazz).readValue(valueString);
         return new HandleWrapper<>(newHandle);
       } catch (Exception e) {
-        throw new TrinoException(GRAVITINO_ILLEGAL_ARGUMENT, "Can not deserialize from json", e);
+        throw new TrinoException(GRAVITINO_ILLEGAL_ARGUMENT, "Cannot deserialize from JSON", e);
       }
     }
 
@@ -148,7 +148,7 @@ interface GravitinoHandle<T> {
                   .writerFor(clazz)
                   .writeValueAsString(this.handle);
         } catch (Exception e) {
-          throw new TrinoException(GRAVITINO_ILLEGAL_ARGUMENT, "Can not serialize to json", e);
+          throw new TrinoException(GRAVITINO_ILLEGAL_ARGUMENT, "Cannot serialize to JSON", e);
         }
       }
       return valueString;

--- a/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/catalog/CatalogRegister.java
+++ b/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/catalog/CatalogRegister.java
@@ -186,14 +186,14 @@ public class CatalogRegister {
           throw e;
         } catch (Exception e) {
           failedException = e;
-          LOG.warn("Execute command failed: {}, ", showCatalogCommand, e);
+          LOG.warn("Failed to execute command: {}", showCatalogCommand, e);
           Thread.sleep(EXECUTE_QUERY_BACKOFF_TIME_SECOND * 1000);
         }
       }
       throw failedException;
     } catch (Exception e) {
       throw new TrinoException(
-          GravitinoErrorCode.GRAVITINO_RUNTIME_ERROR, "Failed to check catalog exist", e);
+          GravitinoErrorCode.GRAVITINO_RUNTIME_ERROR, "Failed to check if catalog exists", e);
     }
   }
 
@@ -202,8 +202,7 @@ public class CatalogRegister {
       int retries = EXECUTE_QUERY_MAX_RETRIES;
       Exception failedException =
           new TrinoException(
-              GravitinoErrorCode.GRAVITINO_RUNTIME_ERROR,
-              "Initial placeholder exception - this should be replaced with a real exception if retries fail.");
+              GravitinoErrorCode.GRAVITINO_RUNTIME_ERROR, "All retry attempts failed");
       while (retries-- > 0) {
         try (Statement statement = connection.createStatement()) {
           // check the catalog is already created
@@ -213,7 +212,7 @@ public class CatalogRegister {
           throw e;
         } catch (Exception e) {
           failedException = e;
-          LOG.warn("Execute command failed: {}, ", sql, e);
+          LOG.warn("Failed to execute command: {}", sql, e);
           Thread.sleep(EXECUTE_QUERY_BACKOFF_TIME_SECOND * 1000);
         }
       }


### PR DESCRIPTION
Improves the English quality of user-facing log messages, exception messages, and configuration descriptions across `api`, `authorizations`, `bundles`, `catalogs` (paimon, hadoop-common, hive-metastore-common), `clients`, `core`, `iceberg`, `server`, `server-common`, and `trino-connector` modules.

All changes are native English speaker corrections with no behavioral impact, except for two genuine message-content fixes called out below.

### Message-content fixes (not pure polish)

1. **`GCSTokenGenerator`** (`bundles/gcp/.../GCSTokenGenerator.java`): the `IOException` message concatenated a path directly after a period: `"GCS credential file does not exist." + gcsCredentialFilePath`. At runtime that produces `...does not exist./path/to/key.json`. Changed the period to a colon-space so the message reads correctly.

2. **`RangerHelper`** (`authorizations/.../RangerHelper.java`): a `LOG.warn` had a malformed format string: `"The role({}) does not exist in the Ranger!, e: {}"`. The spurious `!,` and the `e: {}` pattern produced confusing output. Replaced with `"Role {} does not exist in Ranger"` and let SLF4J auto-format the trailing exception.

### Polish patterns applied consistently

- `"Can not"` / `"can not"` → `"Cannot"` / `"cannot"`
- `"Fail to"` → `"Failed to"`
- `"id"` → `"ID"`, `"uri"` → `"URI"` when used as identifiers
- `"SIP"` → `"SPI"` (typo in `GravitinoConnectorPluginManager`)
- `"Grivitino"` → `"Gravitino"` (typo in `GravitinoConfig`)
- Removed trailing periods from log and exception messages being touched
- Fixed missing spaces after colons in log messages
- Fixed non-idiomatic phrasing ("would better use", "throw a exception", "occurs an unexpected")
- Improved `GravitinoConfig` property descriptions for clarity
- Capitalized project names within touched messages (Ranger)

### Notes

- Rebased onto current `main`; resolved conflicts in four files where upstream had refactored around messages originally touched (`CatalogHookDispatcher`, `JcasbinAuthorizer`, `SchemaOperations`, `GravitinoConfig`).
- `./gradlew spotlessApply` run and folded in; `spotlessCheck` passes clean.
- Scope is broader than the originally-stated "core, server, trino-connector". Now covers the catalog modules that the original PR description had called out as a follow-on.
- A separate follow-on PR for broader readability and meaning improvements in user-facing messages will come once this lands.