### PR TITLE
[#10174] Improvement(POConverters): possible NPE for null lastVersion in fileset version update

### DIFF
--- a/core/src/main/java/org/apache/gravitino/storage/relational/utils/POConverters.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/utils/POConverters.java
@@ -702,6 +702,9 @@ public class POConverters {
       FilesetPO oldFilesetPO, FilesetEntity newFileset, boolean needUpdateVersion) {
     try {
       Long lastVersion = oldFilesetPO.getLastVersion();
+      if (lastVersion == null) {
+        lastVersion = INIT_VERSION;
+      }
       Long currentVersion;
       List<FilesetVersionPO> newFilesetVersionPOs;
       // Will set the version to the last version + 1

--- a/core/src/test/java/org/apache/gravitino/storage/relational/utils/TestPOConverters.java
+++ b/core/src/test/java/org/apache/gravitino/storage/relational/utils/TestPOConverters.java
@@ -795,6 +795,28 @@ public class TestPOConverters {
   }
 
   @Test
+  public void testUpdateFilesetPOVersionWithNullLastVersion() throws Exception {
+    FilesetEntity filesetEntity =
+        createFileset(
+            1L,
+            "test",
+            NamespaceUtil.ofFileset("test_metalake", "test_catalog", "test_schema"),
+            "this is test",
+            "hdfs://localhost/test",
+            ImmutableMap.of("key", "value"));
+    FilesetPO.Builder builder =
+        FilesetPO.builder().withMetalakeId(1L).withCatalogId(1L).withSchemaId(1L);
+    FilesetPO initPO = POConverters.initializeFilesetPOWithVersion(filesetEntity, builder);
+
+    java.lang.reflect.Field lastVersionField = FilesetPO.class.getDeclaredField("lastVersion");
+    lastVersionField.setAccessible(true);
+    lastVersionField.set(initPO, null);
+
+    Assertions.assertDoesNotThrow(
+        () -> POConverters.updateFilesetPOWithVersion(initPO, filesetEntity, true));
+  }
+
+  @Test
   public void testFromPolicyPO() throws JsonProcessingException {
     ImmutableSet<MetadataObject.Type> supportedObjectTypes =
         ImmutableSet.of(MetadataObject.Type.TABLE, MetadataObject.Type.SCHEMA);


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): Support xxx"
     - "[#233] fix: Check null before access result in xxx"
     - "[MINOR] refactor: Fix typo in variable name"
     - "[MINOR] docs: Fix typo in README"
     - "[#255] test: Fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?
In updateFilesetPOWithVersion, validate oldFilesetPO.getLastVersion() and normalize null to a safe baseline version ( INIT_VERSION) before incrementing to avoid NPE.


### Why are the changes needed?

POConverters.updateFilesetPOWithVersion reads Long lastVersion = oldFilesetPO.getLastVersion(); and then executes lastVersion++ when needUpdateVersion is true. If lastVersion is null, Java auto-unboxing triggers a NullPointerException.

Fix: (#10174 )

### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
unit test
