### PR TITLE
[#10391] Fix license and NOTICE issues for 1.2 release

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -280,7 +280,7 @@
    ./core/src/main/java/org/apache/gravitino/utils/Bytes.java
 
    Apache Submarine
-   ./bin/common.sh
+   ./bin/common.sh.template
 
    Confluent Kafka Streams Examples
    ./catalogs/catalog-kafka/src/test/java/org/apache/gravitino/catalog/kafka/embedded/KafkaClusterEmbedded.java
@@ -294,6 +294,10 @@
    ./integration-test-common/src/test/java/org/apache/gravitino/integration/test/util/CloseableGroup.java
    ./trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/catalog/hive/SortingColumn.java
    ./trino-connector/integration-test/src/test/resources/trino-ci-testset/testsets/hive/00012_format.sql
+   ./trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/util/json/AbstractTypedJacksonModule.java
+   ./trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/util/json/BlockJsonSerde.java
+   ./trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/util/json/TypeDeserializer.java
+   ./trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/util/json/TypeSignatureDeserializer.java
 
    Apache Arrow
    ./dev/ci/util_free_space.sh
@@ -323,6 +327,6 @@
 
     This product bundles a third-party component under the
     BSD License.
-   .dev/docker/kerberos-hive/kadm5.acl
-   .dev/docker/kerberos-hive/kdc.acl
-   .dev/docker/kerberos-hive/krb5.acl
+   ./dev/docker/kerberos-hive/kadm5.acl
+   ./dev/docker/kerberos-hive/kdc.conf
+   ./dev/docker/kerberos-hive/krb5.conf

--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Apache Gravitino
-Copyright 2024-2026 The Apache Software Foundation
+Copyright 2026 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Apache Gravitino
-Copyright 2025 The Apache Software Foundation
+Copyright 2024-2026 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/clients/client-python/NOTICE
+++ b/clients/client-python/NOTICE
@@ -1,5 +1,5 @@
 Apache Gravitino
-Copyright 2024-2026 The Apache Software Foundation
+Copyright 2026 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/clients/client-python/NOTICE
+++ b/clients/client-python/NOTICE
@@ -1,5 +1,5 @@
 Apache Gravitino
-Copyright 2025 The Apache Software Foundation
+Copyright 2024-2026 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/dev/release/release-build.sh
+++ b/dev/release/release-build.sh
@@ -210,8 +210,14 @@ if [[ "$1" == "package" ]]; then
   rm -f gravitino-$GRAVITINO_VERSION-src/NOTICE.rest
   rm -f gravitino-$GRAVITINO_VERSION-src/LICENSE.trino
   rm -f gravitino-$GRAVITINO_VERSION-src/NOTICE.trino
+  rm -f gravitino-$GRAVITINO_VERSION-src/LICENSE.iceberg
+  rm -f gravitino-$GRAVITINO_VERSION-src/NOTICE.iceberg
+  rm -f gravitino-$GRAVITINO_VERSION-src/LICENSE.lance
+  rm -f gravitino-$GRAVITINO_VERSION-src/NOTICE.lance
   rm -f gravitino-$GRAVITINO_VERSION-src/web/web/LICENSE.bin
   rm -f gravitino-$GRAVITINO_VERSION-src/web/web/NOTICE.bin
+  rm -f gravitino-$GRAVITINO_VERSION-src/web-v2/web/LICENSE.bin
+  rm -f gravitino-$GRAVITINO_VERSION-src/web-v2/web/NOTICE.bin
 
   rm -f *.asc
   tar cvzf gravitino-$GRAVITINO_VERSION-src.tar.gz --exclude gravitino-$GRAVITINO_VERSION-src/.git gravitino-$GRAVITINO_VERSION-src

--- a/mcp-server/NOTICE
+++ b/mcp-server/NOTICE
@@ -1,5 +1,5 @@
 Apache Gravitino
-Copyright 2024-2026 The Apache Software Foundation
+Copyright 2026 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/mcp-server/NOTICE
+++ b/mcp-server/NOTICE
@@ -1,5 +1,5 @@
 Apache Gravitino
-Copyright 2025 The Apache Software Foundation
+Copyright 2024-2026 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/web-v2/web/LICENSE.bin
+++ b/web-v2/web/LICENSE.bin
@@ -808,7 +808,6 @@
    ISC license.
 
    @isaacs/cliui
-
    anymatch
    boolbase
    electron-to-chromium

--- a/web-v2/web/LICENSE.bin
+++ b/web-v2/web/LICENSE.bin
@@ -808,6 +808,7 @@
    ISC license.
 
    @isaacs/cliui
+   @isaacs/fs-minipass
    anymatch
    boolbase
    electron-to-chromium

--- a/web-v2/web/LICENSE.bin
+++ b/web-v2/web/LICENSE.bin
@@ -254,16 +254,12 @@
    @babel/template
    @babel/traverse
    @babel/types
-<<<<<<< HEAD
-   @ctrl/tinycolor
-=======
    @bcoe/v8-coverage
    @csstools/css-calc
    @csstools/css-color-parser
    @csstools/css-parser-algorithms
    @csstools/css-tokenizer
    @cyberalien/svg-utils
->>>>>>> 35ca6ba75 ([#10242] web-v2(security): upgrade dependabot affected versions (#10244))
    @discoveryjs/json-ext
    @emotion/babel-plugin
    @emotion/cache
@@ -382,11 +378,7 @@
    callsites
    camelcase-css
    chalk
-<<<<<<< HEAD
-   cheerio
-=======
    check-error
->>>>>>> 35ca6ba75 ([#10242] web-v2(security): upgrade dependabot affected versions (#10244))
    chokidar
    classnames
    client-only
@@ -459,11 +451,8 @@
    fast-loops
    fastest-stable-stringify
    fd-slicer
-<<<<<<< HEAD
-=======
    fdir
    fflate
->>>>>>> 35ca6ba75 ([#10242] web-v2(security): upgrade dependabot affected versions (#10244))
    file-entry-cache
    fill-range
    find-root
@@ -746,11 +735,8 @@
    ufo
    unbox-primitive
    undici-types
-<<<<<<< HEAD
-=======
    universalify
    unrs-resolver
->>>>>>> 35ca6ba75 ([#10242] web-v2(security): upgrade dependabot affected versions (#10244))
    update-browserslist-db
    use-resize-observer
    use-sync-external-store
@@ -822,13 +808,7 @@
    ISC license.
 
    @isaacs/cliui
-<<<<<<< HEAD
-   @trysound/sax
-   @types/tar
-   @ungap/structured-clone
-=======
-   @isaacs/fs-minipass
->>>>>>> 35ca6ba75 ([#10242] web-v2(security): upgrade dependabot affected versions (#10244))
+
    anymatch
    boolbase
    electron-to-chromium
@@ -889,11 +869,8 @@
    chownr
    jackspeak
    path-scurry
-<<<<<<< HEAD
-=======
    sax
    yallist
->>>>>>> 35ca6ba75 ([#10242] web-v2(security): upgrade dependabot affected versions (#10244))
 
    This product bundles various third-party components also under the
    0BSD license.

--- a/web-v2/web/NOTICE
+++ b/web-v2/web/NOTICE
@@ -1,5 +1,5 @@
 Apache Gravitino
-Copyright 2024 The Apache Software Foundation
+Copyright 2024-2026 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/web-v2/web/NOTICE
+++ b/web-v2/web/NOTICE
@@ -1,5 +1,5 @@
 Apache Gravitino
-Copyright 2024-2026 The Apache Software Foundation
+Copyright 2026 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/web/web/NOTICE
+++ b/web/web/NOTICE
@@ -1,5 +1,5 @@
 Apache Gravitino
-Copyright 2024 The Apache Software Foundation
+Copyright 2024-2026 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/web/web/NOTICE
+++ b/web/web/NOTICE
@@ -1,5 +1,5 @@
 Apache Gravitino
-Copyright 2024-2026 The Apache Software Foundation
+Copyright 2026 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix multiple license and NOTICE issues found during the 1.2 release review:

- Update copyright year to 2024-2026 in all NOTICE files (NOTICE, clients/client-python/NOTICE, mcp-server/NOTICE, web/web/NOTICE, web-v2/web/NOTICE)
- Resolve merge conflict markers in `web-v2/web/LICENSE.bin` left by cherry-pick of #10244
- Add 4 Trino-derived files to LICENSE (AbstractTypedJacksonModule.java, BlockJsonSerde.java, TypeDeserializer.java, TypeSignatureDeserializer.java)
- Fix `bin/common.sh` → `bin/common.sh.template` in LICENSE (file does not exist)
- Fix BSD section paths: `.dev/docker/` → `./dev/docker/`, `kdc.acl`/`krb5.acl` → `kdc.conf`/`krb5.conf`
- Fix `release-build.sh`: also remove `LICENSE/NOTICE.iceberg`, `LICENSE/NOTICE.lance`, and `web-v2/web/LICENSE.bin`, `web-v2/web/NOTICE.bin` from source release package

### Why are the changes needed?

Fix: #10391

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

N/A