### PR TITLE
[#10397] fix(iceberg): Fix wrong namespaces when listing tables or views

### DIFF
--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/rest/IcebergTableOperations.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/rest/IcebergTableOperations.java
@@ -552,7 +552,7 @@ public class IcebergTableOperations {
     List<TableIdentifier> filteredIdentifiers = new ArrayList<>();
     for (NameIdentifier ident : idents) {
       filteredIdentifiers.add(
-          TableIdentifier.of(Namespace.of(ident.namespace().level(0)), ident.name()));
+          TableIdentifier.of(Namespace.of(ident.namespace().level(2)), ident.name()));
     }
     return ListTablesResponse.builder()
         .addAll(filteredIdentifiers)

--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/rest/IcebergViewOperations.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/rest/IcebergViewOperations.java
@@ -353,7 +353,7 @@ public class IcebergViewOperations {
     List<TableIdentifier> filteredIdentifiers = new ArrayList<>();
     for (NameIdentifier ident : idents) {
       filteredIdentifiers.add(
-          TableIdentifier.of(Namespace.of(ident.namespace().level(0)), ident.name()));
+          TableIdentifier.of(Namespace.of(ident.namespace().level(2)), ident.name()));
     }
     return ListTablesResponse.builder()
         .addAll(filteredIdentifiers)

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/integration/test/IcebergAuthorizationIT.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/integration/test/IcebergAuthorizationIT.java
@@ -271,7 +271,13 @@ public class IcebergAuthorizationIT extends BaseIT {
   }
 
   protected Set<String> listTableNames(String database) {
-    return convertToStringSet(sql("SHOW TABLES in %s", database), 1);
+    List<Object[]> objects = sql("SHOW TABLES in %s", database);
+    for (Object[] row : objects) {
+      if (row.length > 1) {
+        Assertions.assertEquals(database, String.valueOf(row[0]));
+      }
+    }
+    return convertToStringSet(objects, 1);
   }
 
   protected List<Object[]> sql2(String query) {

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/integration/test/IcebergViewAuthorizationIT.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/integration/test/IcebergViewAuthorizationIT.java
@@ -488,6 +488,12 @@ public class IcebergViewAuthorizationIT extends IcebergAuthorizationIT {
 
   private Set<String> listViewNames(String database) {
     List<Object[]> rows = sql("SHOW VIEWS in %s", database);
+    rows.forEach(
+        row -> {
+          if (row.length > 1) {
+            Assertions.assertEquals(database, row[0]);
+          }
+        });
     return rows.stream()
         .map(row -> row.length > 1 ? (String) row[1] : (String) row[0])
         .collect(Collectors.toSet());


### PR DESCRIPTION
### What changes were proposed in this pull request?

 Fix wrong namespaces when listing tables or views

### Why are the changes needed?

Fix: #10397

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Added test cases.
