### PR TITLE
[#10391] Fix license and NOTICE issues

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -280,7 +280,7 @@
    ./core/src/main/java/org/apache/gravitino/utils/Bytes.java
 
    Apache Submarine
-   ./bin/common.sh
+   ./bin/common.sh.template
 
    Confluent Kafka Streams Examples
    ./catalogs/catalog-kafka/src/test/java/org/apache/gravitino/catalog/kafka/embedded/KafkaClusterEmbedded.java
@@ -294,6 +294,10 @@
    ./integration-test-common/src/test/java/org/apache/gravitino/integration/test/util/CloseableGroup.java
    ./trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/catalog/hive/SortingColumn.java
    ./trino-connector/integration-test/src/test/resources/trino-ci-testset/testsets/hive/00012_format.sql
+   ./trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/util/json/AbstractTypedJacksonModule.java
+   ./trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/util/json/BlockJsonSerde.java
+   ./trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/util/json/TypeDeserializer.java
+   ./trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/util/json/TypeSignatureDeserializer.java
 
    Apache Arrow
    ./dev/ci/util_free_space.sh
@@ -323,6 +327,6 @@
 
     This product bundles a third-party component under the
     BSD License.
-   .dev/docker/kerberos-hive/kadm5.acl
-   .dev/docker/kerberos-hive/kdc.acl
-   .dev/docker/kerberos-hive/krb5.acl
+   ./dev/docker/kerberos-hive/kadm5.acl
+   ./dev/docker/kerberos-hive/kdc.conf
+   ./dev/docker/kerberos-hive/krb5.conf

--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Apache Gravitino
-Copyright 2025 The Apache Software Foundation
+Copyright 2026 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/clients/client-python/NOTICE
+++ b/clients/client-python/NOTICE
@@ -1,5 +1,5 @@
 Apache Gravitino
-Copyright 2025 The Apache Software Foundation
+Copyright 2026 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/dev/release/release-build.sh
+++ b/dev/release/release-build.sh
@@ -206,12 +206,16 @@ if [[ "$1" == "package" ]]; then
 
   rm -f gravitino-$GRAVITINO_VERSION-src/LICENSE.bin
   rm -f gravitino-$GRAVITINO_VERSION-src/NOTICE.bin
-  rm -f gravitino-$GRAVITINO_VERSION-src/LICENSE.rest
-  rm -f gravitino-$GRAVITINO_VERSION-src/NOTICE.rest
   rm -f gravitino-$GRAVITINO_VERSION-src/LICENSE.trino
   rm -f gravitino-$GRAVITINO_VERSION-src/NOTICE.trino
+  rm -f gravitino-$GRAVITINO_VERSION-src/LICENSE.iceberg
+  rm -f gravitino-$GRAVITINO_VERSION-src/NOTICE.iceberg
+  rm -f gravitino-$GRAVITINO_VERSION-src/LICENSE.lance
+  rm -f gravitino-$GRAVITINO_VERSION-src/NOTICE.lance
   rm -f gravitino-$GRAVITINO_VERSION-src/web/web/LICENSE.bin
   rm -f gravitino-$GRAVITINO_VERSION-src/web/web/NOTICE.bin
+  rm -f gravitino-$GRAVITINO_VERSION-src/web-v2/web/LICENSE.bin
+  rm -f gravitino-$GRAVITINO_VERSION-src/web-v2/web/NOTICE.bin
 
   rm -f *.asc
   tar cvzf gravitino-$GRAVITINO_VERSION-src.tar.gz --exclude gravitino-$GRAVITINO_VERSION-src/.git gravitino-$GRAVITINO_VERSION-src

--- a/mcp-server/NOTICE
+++ b/mcp-server/NOTICE
@@ -1,5 +1,5 @@
 Apache Gravitino
-Copyright 2025 The Apache Software Foundation
+Copyright 2026 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/web-v2/web/NOTICE
+++ b/web-v2/web/NOTICE
@@ -1,5 +1,5 @@
 Apache Gravitino
-Copyright 2024 The Apache Software Foundation
+Copyright 2026 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/web/web/NOTICE
+++ b/web/web/NOTICE
@@ -1,5 +1,5 @@
 Apache Gravitino
-Copyright 2024 The Apache Software Foundation
+Copyright 2026 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix multiple license and NOTICE issues found during the release review:

- Update copyright year to 2026 in all NOTICE files (NOTICE, clients/client-python/NOTICE, mcp-server/NOTICE, web/web/NOTICE, web-v2/web/NOTICE)
- Add 4 Trino-derived files to LICENSE (AbstractTypedJacksonModule.java, BlockJsonSerde.java, TypeDeserializer.java, TypeSignatureDeserializer.java)
- Fix `bin/common.sh` -> `bin/common.sh.template` in LICENSE (file does not exist)
- Fix BSD section paths: `.dev/docker/` -> `./dev/docker/`, `kdc.acl`/`krb5.acl` -> `kdc.conf`/`krb5.conf`
- Fix `release-build.sh`: remove non-existent LICENSE/NOTICE.rest entries, and also remove LICENSE/NOTICE.iceberg, LICENSE/NOTICE.lance, web-v2/web/LICENSE.bin, web-v2/web/NOTICE.bin from source release package

### Why are the changes needed?

Fix: #10391

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

N/A