### PR TITLE
[#10326] fix: Close replaced dataset cache entries

### DIFF
--- a/core/src/main/java/org/apache/gravitino/stats/storage/LancePartitionStatisticStorage.java
+++ b/core/src/main/java/org/apache/gravitino/stats/storage/LancePartitionStatisticStorage.java
@@ -197,13 +197,13 @@ public class LancePartitionStatisticStorage implements PartitionStatisticStorage
       this.scheduler =
           new ScheduledThreadPoolExecutor(
               1, newDaemonThreadFactory("lance-partition-statistic-storage-cache-cleaner"));
-
       this.datasetCache =
           Optional.of(
               Caffeine.newBuilder()
                   .maximumSize(datasetCacheSize)
                   .scheduler(Scheduler.forScheduledExecutorService(this.scheduler))
-                  .evictionListener(
+                  .executor(Runnable::run)
+                  .removalListener(
                       (RemovalListener<Long, Dataset>)
                           (key, value, cause) -> {
                             if (value != null) {
@@ -304,7 +304,6 @@ public class LancePartitionStatisticStorage implements PartitionStatisticStorage
               .transactionProperties(Collections.emptyMap())
               .build();
       newDataset = appendTxn.commit();
-
       Dataset finalNewDataset = newDataset;
       datasetCache.ifPresent(cache -> cache.put(tableId, finalNewDataset));
     } finally {
@@ -346,7 +345,7 @@ public class LancePartitionStatisticStorage implements PartitionStatisticStorage
         dataset.delete(filterSQL);
       }
     } finally {
-      if (!datasetCache.isPresent() && dataset != null) {
+      if (!datasetCache.isPresent()) {
         dataset.close();
       }
     }
@@ -495,9 +494,7 @@ public class LancePartitionStatisticStorage implements PartitionStatisticStorage
       Long tableId, String partitionFilter) {
 
     Dataset dataset = getDataset(tableId);
-
     String filter = "table_id = " + tableId + partitionFilter;
-
     try (LanceScanner scanner =
         dataset.newScan(
             new ScanOptions.Builder()

--- a/core/src/test/java/org/apache/gravitino/stats/storage/TestLancePartitionStatisticStorage.java
+++ b/core/src/test/java/org/apache/gravitino/stats/storage/TestLancePartitionStatisticStorage.java
@@ -23,6 +23,8 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.github.benmanes.caffeine.cache.Cache;
@@ -600,6 +602,30 @@ public class TestLancePartitionStatisticStorage {
       Assertions.assertTrue(listedStats.isEmpty());
     } finally {
       FileUtils.deleteDirectory(new File(location + "/" + tableEntity.id() + ".lance"));
+      storage.close();
+    }
+  }
+
+  @Test
+  public void testDatasetCacheReplacementClosesOldDataset() throws Exception {
+    String location = Files.createTempDirectory("lance_stats_cache_replace").toString();
+
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put("location", location);
+    properties.put("datasetCacheSize", "10");
+
+    LancePartitionStatisticStorage storage = new LancePartitionStatisticStorage(properties);
+    try {
+      Cache<Long, Dataset> cache = storage.getDatasetCache();
+      Dataset oldDataset = mock(Dataset.class);
+      Dataset newDataset = mock(Dataset.class);
+
+      cache.put(1L, oldDataset);
+      cache.put(1L, newDataset);
+
+      verify(oldDataset, times(1)).close();
+    } finally {
+      FileUtils.deleteDirectory(new File(location));
       storage.close();
     }
   }


### PR DESCRIPTION
### Title
[#10326] fix: Close replaced dataset cache entries

### What changes were proposed in this pull request?

Switched the Caffeine cache listener to a removal listener so that replaced Dataset entries are closed, not just evicted ones. Added a unit test that verifies the old Dataset is closed when the cache entry is replaced.

### Why are the changes needed?

With dataset caching enabled, calling cache.put on an existing key replaces the cached Dataset. Caffeine treats this as a removal (not an eviction), so the eviction listener does not run and the old Dataset remains open, leaking native/file handles during repeated statistics updates.

Fix: #10326(issue)

### Does this PR introduce _any_ user-facing change?

No. There are no changes to user-facing APIs or configuration keys.

### How was this patch tested?

Added a unit test: TestLancePartitionStatisticStorage#testDatasetCacheReplacementClosesOldDataset.
