### PR TITLE
[#10414] improvement(core): Unify cache invalidation in CatalogManager/Jcasbin/EntityStore

### DIFF
--- a/core/src/main/java/org/apache/gravitino/Configs.java
+++ b/core/src/main/java/org/apache/gravitino/Configs.java
@@ -461,6 +461,14 @@ public class Configs {
           .checkValue(value -> value > 0, "Lock segments must be positive.")
           .createWithDefault(16);
 
+  // Whether to enable cache invalidation event dispatch
+  public static final ConfigEntry<Boolean> CACHE_INVALIDATION_ENABLED =
+      new ConfigBuilder("gravitino.cache.invalidation.enabled")
+          .doc("Whether to enable the cache invalidation service and event dispatch.")
+          .version(ConfigConstants.VERSION_1_2_0)
+          .booleanConf()
+          .createWithDefault(true);
+
   public static final ConfigEntry<String> JOB_STAGING_DIR =
       new ConfigBuilder("gravitino.job.stagingDir")
           .doc("Directory for managing staging files when running jobs.")

--- a/core/src/main/java/org/apache/gravitino/cache/invalidation/CacheDomain.java
+++ b/core/src/main/java/org/apache/gravitino/cache/invalidation/CacheDomain.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.cache.invalidation;
+
+/** Logical domains for cache invalidation events. */
+public enum CacheDomain {
+  ENTITY,
+  CATALOG,
+  AUTH_ROLE,
+  AUTH_OWNER
+}

--- a/core/src/main/java/org/apache/gravitino/cache/invalidation/CacheInvalidationEvent.java
+++ b/core/src/main/java/org/apache/gravitino/cache/invalidation/CacheInvalidationEvent.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.cache.invalidation;
+
+import com.google.common.base.Preconditions;
+import java.util.Objects;
+import javax.annotation.Nullable;
+
+/** Immutable cache invalidation event. */
+public final class CacheInvalidationEvent {
+  private final CacheDomain domain;
+  private final CacheInvalidationOperation operation;
+  private final String sourceNode;
+  private final long timestampMillis;
+  @Nullable private final Object key;
+
+  private CacheInvalidationEvent(
+      CacheDomain domain,
+      CacheInvalidationOperation operation,
+      @Nullable Object key,
+      String sourceNode,
+      long timestampMillis) {
+    this.domain = Preconditions.checkNotNull(domain, "domain cannot be null");
+    this.operation = Preconditions.checkNotNull(operation, "operation cannot be null");
+    this.sourceNode = Preconditions.checkNotNull(sourceNode, "sourceNode cannot be null");
+    this.timestampMillis = timestampMillis;
+    this.key = key;
+  }
+
+  public static CacheInvalidationEvent of(
+      CacheDomain domain,
+      CacheInvalidationOperation operation,
+      @Nullable Object key,
+      String sourceNode) {
+    return new CacheInvalidationEvent(
+        domain, operation, key, sourceNode, System.currentTimeMillis());
+  }
+
+  public CacheDomain domain() {
+    return domain;
+  }
+
+  public CacheInvalidationOperation operation() {
+    return operation;
+  }
+
+  @Nullable
+  public Object key() {
+    return key;
+  }
+
+  public String sourceNode() {
+    return sourceNode;
+  }
+
+  public long timestampMillis() {
+    return timestampMillis;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (!(o instanceof CacheInvalidationEvent)) {
+      return false;
+    }
+    CacheInvalidationEvent that = (CacheInvalidationEvent) o;
+    return timestampMillis == that.timestampMillis
+        && domain == that.domain
+        && operation == that.operation
+        && Objects.equals(sourceNode, that.sourceNode)
+        && Objects.equals(key, that.key);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(domain, operation, sourceNode, timestampMillis, key);
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/cache/invalidation/CacheInvalidationHandler.java
+++ b/core/src/main/java/org/apache/gravitino/cache/invalidation/CacheInvalidationHandler.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.cache.invalidation;
+
+/** Handler that applies invalidation events to module-local caches. */
+@FunctionalInterface
+public interface CacheInvalidationHandler {
+  void handle(CacheInvalidationEvent event);
+}

--- a/core/src/main/java/org/apache/gravitino/cache/invalidation/CacheInvalidationOperation.java
+++ b/core/src/main/java/org/apache/gravitino/cache/invalidation/CacheInvalidationOperation.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.cache.invalidation;
+
+/** Operations represented by cache invalidation events. */
+public enum CacheInvalidationOperation {
+  INVALIDATE_KEY,
+  INVALIDATE_ALL,
+  UPSERT_KEY
+}

--- a/core/src/main/java/org/apache/gravitino/cache/invalidation/CacheInvalidationService.java
+++ b/core/src/main/java/org/apache/gravitino/cache/invalidation/CacheInvalidationService.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.cache.invalidation;
+
+/** Service for publishing and handling cache invalidation events. */
+public interface CacheInvalidationService {
+  void publish(CacheInvalidationEvent event);
+
+  void registerHandler(CacheDomain domain, String handlerId, CacheInvalidationHandler handler);
+
+  void unregisterHandler(CacheDomain domain, String handlerId);
+
+  boolean isEnabled();
+
+  String localNodeId();
+}

--- a/core/src/main/java/org/apache/gravitino/cache/invalidation/CacheInvalidationServiceFactory.java
+++ b/core/src/main/java/org/apache/gravitino/cache/invalidation/CacheInvalidationServiceFactory.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.cache.invalidation;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.apache.gravitino.Config;
+import org.apache.gravitino.Configs;
+
+/** Singleton factory for cache invalidation service. */
+public final class CacheInvalidationServiceFactory {
+  private static volatile CacheInvalidationService invalidationService;
+
+  private CacheInvalidationServiceFactory() {}
+
+  public static CacheInvalidationService getOrCreate(Config config) {
+    if (invalidationService == null) {
+      synchronized (CacheInvalidationServiceFactory.class) {
+        if (invalidationService == null) {
+          invalidationService =
+              new LocalCacheInvalidationService(config.get(Configs.CACHE_INVALIDATION_ENABLED));
+        }
+      }
+    }
+    return invalidationService;
+  }
+
+  @VisibleForTesting
+  public static void resetForTest() {
+    synchronized (CacheInvalidationServiceFactory.class) {
+      invalidationService = null;
+    }
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/cache/invalidation/CatalogCacheInvalidationKey.java
+++ b/core/src/main/java/org/apache/gravitino/cache/invalidation/CatalogCacheInvalidationKey.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.cache.invalidation;
+
+import com.google.common.base.Preconditions;
+import java.util.Objects;
+import org.apache.gravitino.NameIdentifier;
+
+/** Invalidation key for catalog cache entries. */
+public final class CatalogCacheInvalidationKey {
+  private final NameIdentifier nameIdentifier;
+
+  private CatalogCacheInvalidationKey(NameIdentifier nameIdentifier) {
+    this.nameIdentifier =
+        Preconditions.checkNotNull(nameIdentifier, "nameIdentifier cannot be null");
+  }
+
+  public static CatalogCacheInvalidationKey of(NameIdentifier nameIdentifier) {
+    return new CatalogCacheInvalidationKey(nameIdentifier);
+  }
+
+  public NameIdentifier nameIdentifier() {
+    return nameIdentifier;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (!(o instanceof CatalogCacheInvalidationKey)) {
+      return false;
+    }
+    CatalogCacheInvalidationKey that = (CatalogCacheInvalidationKey) o;
+    return Objects.equals(nameIdentifier, that.nameIdentifier);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(nameIdentifier);
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/cache/invalidation/EntityCacheInvalidationKey.java
+++ b/core/src/main/java/org/apache/gravitino/cache/invalidation/EntityCacheInvalidationKey.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.cache.invalidation;
+
+import com.google.common.base.Preconditions;
+import java.util.Objects;
+import javax.annotation.Nullable;
+import org.apache.gravitino.Entity;
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.SupportsRelationOperations;
+
+/** Invalidation key for entity and relation caches. */
+public final class EntityCacheInvalidationKey {
+  private final NameIdentifier identifier;
+  private final Entity.EntityType entityType;
+  @Nullable private final SupportsRelationOperations.Type relationType;
+
+  private EntityCacheInvalidationKey(
+      NameIdentifier identifier,
+      Entity.EntityType entityType,
+      @Nullable SupportsRelationOperations.Type relationType) {
+    this.identifier = Preconditions.checkNotNull(identifier, "identifier cannot be null");
+    this.entityType = Preconditions.checkNotNull(entityType, "entityType cannot be null");
+    this.relationType = relationType;
+  }
+
+  public static EntityCacheInvalidationKey of(
+      NameIdentifier identifier,
+      Entity.EntityType entityType,
+      @Nullable SupportsRelationOperations.Type relationType) {
+    return new EntityCacheInvalidationKey(identifier, entityType, relationType);
+  }
+
+  public NameIdentifier identifier() {
+    return identifier;
+  }
+
+  public Entity.EntityType entityType() {
+    return entityType;
+  }
+
+  @Nullable
+  public SupportsRelationOperations.Type relationType() {
+    return relationType;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (!(o instanceof EntityCacheInvalidationKey)) {
+      return false;
+    }
+    EntityCacheInvalidationKey that = (EntityCacheInvalidationKey) o;
+    return Objects.equals(identifier, that.identifier)
+        && entityType == that.entityType
+        && relationType == that.relationType;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(identifier, entityType, relationType);
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/cache/invalidation/LocalCacheInvalidationService.java
+++ b/core/src/main/java/org/apache/gravitino/cache/invalidation/LocalCacheInvalidationService.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.cache.invalidation;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import java.lang.management.ManagementFactory;
+import java.net.InetAddress;
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicLong;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** In-JVM cache invalidation service implementation. */
+public class LocalCacheInvalidationService implements CacheInvalidationService {
+  private static final Logger LOG = LoggerFactory.getLogger(LocalCacheInvalidationService.class);
+
+  private final boolean enabled;
+  private final String localNodeId;
+  private final Map<CacheDomain, ConcurrentMap<String, CacheInvalidationHandler>> handlers;
+  private final ConcurrentMap<String, AtomicLong> publishedCounters;
+  private final ConcurrentMap<String, AtomicLong> handledCounters;
+
+  public LocalCacheInvalidationService(boolean enabled) {
+    this.enabled = enabled;
+    this.localNodeId = buildLocalNodeId();
+    this.handlers = new EnumMap<>(CacheDomain.class);
+    for (CacheDomain domain : CacheDomain.values()) {
+      handlers.put(domain, new ConcurrentHashMap<>());
+    }
+    this.publishedCounters = new ConcurrentHashMap<>();
+    this.handledCounters = new ConcurrentHashMap<>();
+  }
+
+  @Override
+  public void publish(CacheInvalidationEvent event) {
+    Preconditions.checkNotNull(event, "event cannot be null");
+    if (!enabled) {
+      return;
+    }
+
+    String counterKey = getCounterKey(event.domain(), event.operation());
+    publishedCounters.computeIfAbsent(counterKey, key -> new AtomicLong()).incrementAndGet();
+
+    ConcurrentMap<String, CacheInvalidationHandler> domainHandlers = handlers.get(event.domain());
+    if (domainHandlers.isEmpty()) {
+      LOG.warn("No cache invalidation handlers registered for domain {}", event.domain());
+      return;
+    }
+
+    domainHandlers.forEach(
+        (handlerId, handler) -> {
+          handler.handle(event);
+          handledCounters.computeIfAbsent(counterKey, key -> new AtomicLong()).incrementAndGet();
+        });
+  }
+
+  @Override
+  public void registerHandler(
+      CacheDomain domain, String handlerId, CacheInvalidationHandler handler) {
+    Preconditions.checkNotNull(domain, "domain cannot be null");
+    Preconditions.checkArgument(handlerId != null && !handlerId.isBlank(), "handlerId is required");
+    Preconditions.checkNotNull(handler, "handler cannot be null");
+    handlers.get(domain).put(handlerId, handler);
+  }
+
+  @Override
+  public void unregisterHandler(CacheDomain domain, String handlerId) {
+    Preconditions.checkNotNull(domain, "domain cannot be null");
+    if (handlerId == null || handlerId.isBlank()) {
+      return;
+    }
+    handlers.get(domain).remove(handlerId);
+  }
+
+  @Override
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  @Override
+  public String localNodeId() {
+    return localNodeId;
+  }
+
+  @VisibleForTesting
+  long getPublishedCount(CacheDomain domain, CacheInvalidationOperation operation) {
+    return publishedCounters.getOrDefault(getCounterKey(domain, operation), new AtomicLong()).get();
+  }
+
+  @VisibleForTesting
+  long getHandledCount(CacheDomain domain, CacheInvalidationOperation operation) {
+    return handledCounters.getOrDefault(getCounterKey(domain, operation), new AtomicLong()).get();
+  }
+
+  private String getCounterKey(CacheDomain domain, CacheInvalidationOperation operation) {
+    return String.format("%s:%s", domain.name(), operation.name());
+  }
+
+  private String buildLocalNodeId() {
+    String host = "unknown-host";
+    try {
+      host = InetAddress.getLocalHost().getHostName();
+    } catch (Exception e) {
+      LOG.warn("Failed to resolve local host name for cache invalidation node id", e);
+    }
+    return host + "-" + ManagementFactory.getRuntimeMXBean().getName();
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/cache/invalidation/OwnerCacheInvalidationKey.java
+++ b/core/src/main/java/org/apache/gravitino/cache/invalidation/OwnerCacheInvalidationKey.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.cache.invalidation;
+
+import java.util.Objects;
+
+/** Invalidation key for metadata owner cache entries. */
+public final class OwnerCacheInvalidationKey {
+  private final Long metadataId;
+
+  private OwnerCacheInvalidationKey(Long metadataId) {
+    this.metadataId = metadataId;
+  }
+
+  public static OwnerCacheInvalidationKey of(Long metadataId) {
+    return new OwnerCacheInvalidationKey(metadataId);
+  }
+
+  public Long metadataId() {
+    return metadataId;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (!(o instanceof OwnerCacheInvalidationKey)) {
+      return false;
+    }
+    OwnerCacheInvalidationKey that = (OwnerCacheInvalidationKey) o;
+    return Objects.equals(metadataId, that.metadataId);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(metadataId);
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/cache/invalidation/RoleCacheInvalidationKey.java
+++ b/core/src/main/java/org/apache/gravitino/cache/invalidation/RoleCacheInvalidationKey.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.cache.invalidation;
+
+import java.util.Objects;
+
+/** Invalidation key for role cache entries. */
+public final class RoleCacheInvalidationKey {
+  private final Long roleId;
+
+  private RoleCacheInvalidationKey(Long roleId) {
+    this.roleId = roleId;
+  }
+
+  public static RoleCacheInvalidationKey of(Long roleId) {
+    return new RoleCacheInvalidationKey(roleId);
+  }
+
+  public Long roleId() {
+    return roleId;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (!(o instanceof RoleCacheInvalidationKey)) {
+      return false;
+    }
+    RoleCacheInvalidationKey that = (RoleCacheInvalidationKey) o;
+    return Objects.equals(roleId, that.roleId);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(roleId);
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/catalog/CatalogManager.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/CatalogManager.java
@@ -74,6 +74,12 @@ import org.apache.gravitino.EntityStore;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
 import org.apache.gravitino.StringIdentifier;
+import org.apache.gravitino.cache.invalidation.CacheDomain;
+import org.apache.gravitino.cache.invalidation.CacheInvalidationEvent;
+import org.apache.gravitino.cache.invalidation.CacheInvalidationOperation;
+import org.apache.gravitino.cache.invalidation.CacheInvalidationService;
+import org.apache.gravitino.cache.invalidation.CacheInvalidationServiceFactory;
+import org.apache.gravitino.cache.invalidation.CatalogCacheInvalidationKey;
 import org.apache.gravitino.connector.BaseCatalog;
 import org.apache.gravitino.connector.CatalogOperations;
 import org.apache.gravitino.connector.HasPropertyMetadata;
@@ -291,6 +297,8 @@ public class CatalogManager implements CatalogDispatcher, Closeable {
 
   private final IdGenerator idGenerator;
   private final List<Consumer<NameIdentifier>> removalListeners = Lists.newArrayList();
+  private final CacheInvalidationService cacheInvalidationService;
+  private final String cacheInvalidationHandlerId;
 
   /**
    * Constructs a CatalogManager instance.
@@ -303,6 +311,8 @@ public class CatalogManager implements CatalogDispatcher, Closeable {
     this.config = config;
     this.store = store;
     this.idGenerator = idGenerator;
+    this.cacheInvalidationService = CacheInvalidationServiceFactory.getOrCreate(config);
+    this.cacheInvalidationHandlerId = "catalog-manager-" + System.identityHashCode(this);
 
     long cacheEvictionIntervalInMs = config.get(Configs.CATALOG_CACHE_EVICTION_INTERVAL_MS);
     this.catalogCache =
@@ -327,6 +337,8 @@ public class CatalogManager implements CatalogDispatcher, Closeable {
                             .setNameFormat("catalog-cleaner-%d")
                             .build())))
             .build();
+    this.cacheInvalidationService.registerHandler(
+        CacheDomain.CATALOG, cacheInvalidationHandlerId, this::handleCatalogInvalidationEvent);
   }
 
   /**
@@ -335,7 +347,8 @@ public class CatalogManager implements CatalogDispatcher, Closeable {
    */
   @Override
   public void close() {
-    catalogCache.invalidateAll();
+    invalidateAllCatalogCache();
+    cacheInvalidationService.unregisterHandler(CacheDomain.CATALOG, cacheInvalidationHandlerId);
   }
 
   /**
@@ -493,7 +506,7 @@ public class CatalogManager implements CatalogDispatcher, Closeable {
             throw e2;
 
           } catch (Exception e3) {
-            catalogCache.invalidate(ident);
+            invalidateCatalogCache(ident);
             LOG.error("Failed to create catalog {}", ident, e3);
             if (e3 instanceof RuntimeException) {
               throw (RuntimeException) e3;
@@ -611,7 +624,7 @@ public class CatalogManager implements CatalogDispatcher, Closeable {
 
                   return newCatalogBuilder.build();
                 });
-            catalogCache.invalidate(ident);
+            invalidateCatalogCache(ident);
             return null;
           } catch (IOException e) {
             throw new RuntimeException(e);
@@ -651,7 +664,7 @@ public class CatalogManager implements CatalogDispatcher, Closeable {
 
                   return newCatalogBuilder.build();
                 });
-            catalogCache.invalidate(ident);
+            invalidateCatalogCache(ident);
             return null;
           } catch (IOException e) {
             throw new RuntimeException(e);
@@ -715,7 +728,7 @@ public class CatalogManager implements CatalogDispatcher, Closeable {
         nameIdentifierForLock,
         LockType.WRITE,
         () -> {
-          catalogCache.invalidate(ident);
+          invalidateCatalogCache(ident);
           try {
             CatalogEntity updatedCatalog =
                 store.update(
@@ -804,7 +817,7 @@ public class CatalogManager implements CatalogDispatcher, Closeable {
             }
 
             // Finally, delete the catalog entity as well as all its sub-entities from the store.
-            catalogCache.invalidate(ident);
+            invalidateCatalogCache(ident);
             return store.delete(ident, EntityType.CATALOG, true);
 
           } catch (NoSuchMetalakeException | NoSuchCatalogException ignored) {
@@ -1295,7 +1308,7 @@ public class CatalogManager implements CatalogDispatcher, Closeable {
 
             return newCatalogBuilder.build();
           });
-      catalogCache.invalidate(nameIdentifier);
+      invalidateCatalogCache(nameIdentifier);
 
     } catch (NoSuchCatalogException e) {
       LOG.error("Catalog {} does not exist", nameIdentifier, e);
@@ -1311,5 +1324,48 @@ public class CatalogManager implements CatalogDispatcher, Closeable {
       LOG.error("Failed to update catalog {} property {}", nameIdentifier, propertyKey, ioe);
       throw new RuntimeException(ioe);
     }
+  }
+
+  private void invalidateCatalogCache(NameIdentifier nameIdentifier) {
+    if (!cacheInvalidationService.isEnabled()) {
+      catalogCache.invalidate(nameIdentifier);
+      return;
+    }
+
+    cacheInvalidationService.publish(
+        CacheInvalidationEvent.of(
+            CacheDomain.CATALOG,
+            CacheInvalidationOperation.INVALIDATE_KEY,
+            CatalogCacheInvalidationKey.of(nameIdentifier),
+            cacheInvalidationService.localNodeId()));
+  }
+
+  private void invalidateAllCatalogCache() {
+    if (!cacheInvalidationService.isEnabled()) {
+      catalogCache.invalidateAll();
+      return;
+    }
+
+    cacheInvalidationService.publish(
+        CacheInvalidationEvent.of(
+            CacheDomain.CATALOG,
+            CacheInvalidationOperation.INVALIDATE_ALL,
+            null,
+            cacheInvalidationService.localNodeId()));
+  }
+
+  private void handleCatalogInvalidationEvent(CacheInvalidationEvent event) {
+    if (event.operation() == CacheInvalidationOperation.INVALIDATE_ALL) {
+      catalogCache.invalidateAll();
+      return;
+    }
+
+    if (event.operation() != CacheInvalidationOperation.INVALIDATE_KEY
+        || !(event.key() instanceof CatalogCacheInvalidationKey)) {
+      return;
+    }
+
+    CatalogCacheInvalidationKey key = (CatalogCacheInvalidationKey) event.key();
+    catalogCache.invalidate(key.nameIdentifier());
   }
 }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/RelationalEntityStore.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/RelationalEntityStore.java
@@ -42,6 +42,12 @@ import org.apache.gravitino.cache.CachedEntityIdResolver;
 import org.apache.gravitino.cache.EntityCache;
 import org.apache.gravitino.cache.EntityCacheRelationKey;
 import org.apache.gravitino.cache.NoOpsCache;
+import org.apache.gravitino.cache.invalidation.CacheDomain;
+import org.apache.gravitino.cache.invalidation.CacheInvalidationEvent;
+import org.apache.gravitino.cache.invalidation.CacheInvalidationOperation;
+import org.apache.gravitino.cache.invalidation.CacheInvalidationService;
+import org.apache.gravitino.cache.invalidation.CacheInvalidationServiceFactory;
+import org.apache.gravitino.cache.invalidation.EntityCacheInvalidationKey;
 import org.apache.gravitino.exceptions.NoSuchEntityException;
 import org.apache.gravitino.storage.relational.service.EntityIdService;
 import org.apache.gravitino.utils.Executable;
@@ -61,6 +67,8 @@ public class RelationalEntityStore implements EntityStore, SupportsRelationOpera
   private RelationalBackend backend;
   private RelationalGarbageCollector garbageCollector;
   private EntityCache cache;
+  private CacheInvalidationService cacheInvalidationService;
+  private String cacheInvalidationHandlerId;
 
   @VisibleForTesting
   public EntityCache getCache() {
@@ -81,6 +89,11 @@ public class RelationalEntityStore implements EntityStore, SupportsRelationOpera
     this.backend = createRelationalEntityBackend(config);
     this.garbageCollector = new RelationalGarbageCollector(backend, config);
     this.garbageCollector.start();
+
+    this.cacheInvalidationService = CacheInvalidationServiceFactory.getOrCreate(config);
+    this.cacheInvalidationHandlerId = "relational-entity-store-" + System.identityHashCode(this);
+    cacheInvalidationService.registerHandler(
+        CacheDomain.ENTITY, cacheInvalidationHandlerId, this::handleEntityInvalidationEvent);
   }
 
   private RelationalBackend createRelationalEntityBackend(Config config) {
@@ -126,14 +139,16 @@ public class RelationalEntityStore implements EntityStore, SupportsRelationOpera
       throws IOException, EntityAlreadyExistsException {
     backend.insert(e, overwritten);
     cache.put(e);
+    publishOrApplyEntityUpsert(e.nameIdentifier(), e.type());
   }
 
   @Override
   public <E extends Entity & HasIdentifier> E update(
       NameIdentifier ident, Class<E> type, Entity.EntityType entityType, Function<E, E> updater)
       throws IOException, NoSuchEntityException, EntityAlreadyExistsException {
-    cache.invalidate(ident, entityType);
-    return backend.update(ident, entityType, updater);
+    E entity = backend.update(ident, entityType, updater);
+    publishOrApplyEntityInvalidation(ident, entityType);
+    return entity;
   }
 
   @Override
@@ -179,8 +194,11 @@ public class RelationalEntityStore implements EntityStore, SupportsRelationOpera
   public boolean delete(NameIdentifier ident, Entity.EntityType entityType, boolean cascade)
       throws IOException {
     try {
-      cache.invalidate(ident, entityType);
-      return backend.delete(ident, entityType, cascade);
+      boolean deleted = backend.delete(ident, entityType, cascade);
+      if (deleted) {
+        publishOrApplyEntityInvalidation(ident, entityType);
+      }
+      return deleted;
     } catch (NoSuchEntityException e) {
       return false;
     }
@@ -194,6 +212,9 @@ public class RelationalEntityStore implements EntityStore, SupportsRelationOpera
   @Override
   public void close() throws IOException {
     cache.clear();
+    if (cacheInvalidationService != null && cacheInvalidationHandlerId != null) {
+      cacheInvalidationService.unregisterHandler(CacheDomain.ENTITY, cacheInvalidationHandlerId);
+    }
     garbageCollector.close();
     backend.close();
   }
@@ -274,9 +295,9 @@ public class RelationalEntityStore implements EntityStore, SupportsRelationOpera
       Entity.EntityType dstType,
       boolean override)
       throws IOException {
-    cache.invalidate(srcIdentifier, srcType, relType);
-    cache.invalidate(dstIdentifier, dstType, relType);
     backend.insertRelation(relType, srcIdentifier, srcType, dstIdentifier, dstType, override);
+    publishOrApplyRelationInvalidation(srcIdentifier, srcType, relType);
+    publishOrApplyRelationInvalidation(dstIdentifier, dstType, relType);
   }
 
   @Override
@@ -293,29 +314,98 @@ public class RelationalEntityStore implements EntityStore, SupportsRelationOpera
     // backend. For example, if we are adding a tag to table, we need to invalidate the cache for
     // that table and the tag being added or removed. Otherwise, we might return stale data if we
     // list all tags for that table or all tables for that tag.
-    cache.invalidate(srcEntityIdent, srcEntityType, relType);
+    List<E> updated =
+        backend.updateEntityRelations(
+            relType, srcEntityIdent, srcEntityType, destEntitiesToAdd, destEntitiesToRemove);
+    publishOrApplyRelationInvalidation(srcEntityIdent, srcEntityType, relType);
     for (NameIdentifier destToAdd : destEntitiesToAdd) {
-      cache.invalidate(destToAdd, srcEntityType, relType);
+      publishOrApplyRelationInvalidation(destToAdd, srcEntityType, relType);
     }
 
     for (NameIdentifier destToRemove : destEntitiesToRemove) {
-      cache.invalidate(destToRemove, srcEntityType, relType);
+      publishOrApplyRelationInvalidation(destToRemove, srcEntityType, relType);
     }
-
-    return backend.updateEntityRelations(
-        relType, srcEntityIdent, srcEntityType, destEntitiesToAdd, destEntitiesToRemove);
+    return updated;
   }
 
   @Override
   public int batchDelete(
       List<Pair<NameIdentifier, Entity.EntityType>> entitiesToDelete, boolean cascade)
       throws IOException {
-    return backend.batchDelete(entitiesToDelete, cascade);
+    int result = backend.batchDelete(entitiesToDelete, cascade);
+    for (Pair<NameIdentifier, Entity.EntityType> entity : entitiesToDelete) {
+      publishOrApplyEntityInvalidation(entity.getLeft(), entity.getRight());
+    }
+    return result;
   }
 
   @Override
   public <E extends Entity & HasIdentifier> void batchPut(List<E> entities, boolean overwritten)
       throws IOException, EntityAlreadyExistsException {
     backend.batchPut(entities, overwritten);
+    entities.forEach(entity -> publishOrApplyEntityUpsert(entity.nameIdentifier(), entity.type()));
+  }
+
+  private void publishOrApplyEntityInvalidation(
+      NameIdentifier ident, Entity.EntityType entityType) {
+    if (!cacheInvalidationService.isEnabled()) {
+      cache.invalidate(ident, entityType);
+      return;
+    }
+
+    cacheInvalidationService.publish(
+        CacheInvalidationEvent.of(
+            CacheDomain.ENTITY,
+            CacheInvalidationOperation.INVALIDATE_KEY,
+            EntityCacheInvalidationKey.of(ident, entityType, null),
+            cacheInvalidationService.localNodeId()));
+  }
+
+  private void publishOrApplyRelationInvalidation(
+      NameIdentifier ident, Entity.EntityType entityType, SupportsRelationOperations.Type relType) {
+    if (!cacheInvalidationService.isEnabled()) {
+      cache.invalidate(ident, entityType, relType);
+      return;
+    }
+
+    cacheInvalidationService.publish(
+        CacheInvalidationEvent.of(
+            CacheDomain.ENTITY,
+            CacheInvalidationOperation.INVALIDATE_KEY,
+            EntityCacheInvalidationKey.of(ident, entityType, relType),
+            cacheInvalidationService.localNodeId()));
+  }
+
+  private void publishOrApplyEntityUpsert(NameIdentifier ident, Entity.EntityType entityType) {
+    if (!cacheInvalidationService.isEnabled()) {
+      return;
+    }
+
+    cacheInvalidationService.publish(
+        CacheInvalidationEvent.of(
+            CacheDomain.ENTITY,
+            CacheInvalidationOperation.UPSERT_KEY,
+            EntityCacheInvalidationKey.of(ident, entityType, null),
+            cacheInvalidationService.localNodeId()));
+  }
+
+  private void handleEntityInvalidationEvent(CacheInvalidationEvent event) {
+    if (event.operation() == CacheInvalidationOperation.INVALIDATE_ALL) {
+      cache.clear();
+      return;
+    }
+
+    if (event.operation() != CacheInvalidationOperation.INVALIDATE_KEY
+        || !(event.key() instanceof EntityCacheInvalidationKey)) {
+      return;
+    }
+
+    EntityCacheInvalidationKey key = (EntityCacheInvalidationKey) event.key();
+    if (key.relationType() == null) {
+      cache.invalidate(key.identifier(), key.entityType());
+      return;
+    }
+
+    cache.invalidate(key.identifier(), key.entityType(), key.relationType());
   }
 }

--- a/core/src/test/java/org/apache/gravitino/cache/invalidation/TestLocalCacheInvalidationService.java
+++ b/core/src/test/java/org/apache/gravitino/cache/invalidation/TestLocalCacheInvalidationService.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.cache.invalidation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.gravitino.Entity;
+import org.apache.gravitino.NameIdentifier;
+import org.junit.jupiter.api.Test;
+
+public class TestLocalCacheInvalidationService {
+
+  @Test
+  void testPublishAndHandleEvent() {
+    LocalCacheInvalidationService service = new LocalCacheInvalidationService(true);
+    AtomicInteger handled = new AtomicInteger(0);
+    service.registerHandler(CacheDomain.CATALOG, "handler", event -> handled.incrementAndGet());
+
+    service.publish(
+        CacheInvalidationEvent.of(
+            CacheDomain.CATALOG,
+            CacheInvalidationOperation.INVALIDATE_KEY,
+            CatalogCacheInvalidationKey.of(NameIdentifier.of("metalake", "catalog")),
+            service.localNodeId()));
+
+    assertEquals(1, handled.get());
+    assertEquals(
+        1L,
+        service.getPublishedCount(CacheDomain.CATALOG, CacheInvalidationOperation.INVALIDATE_KEY));
+    assertEquals(
+        1L,
+        service.getHandledCount(CacheDomain.CATALOG, CacheInvalidationOperation.INVALIDATE_KEY));
+  }
+
+  @Test
+  void testDisableEventDispatch() {
+    LocalCacheInvalidationService service = new LocalCacheInvalidationService(false);
+    AtomicInteger handled = new AtomicInteger(0);
+    service.registerHandler(CacheDomain.ENTITY, "handler", event -> handled.incrementAndGet());
+
+    service.publish(
+        CacheInvalidationEvent.of(
+            CacheDomain.ENTITY,
+            CacheInvalidationOperation.INVALIDATE_KEY,
+            EntityCacheInvalidationKey.of(
+                NameIdentifier.of("metalake", "catalog"), Entity.EntityType.CATALOG, null),
+            service.localNodeId()));
+
+    assertEquals(0, handled.get());
+    assertEquals(
+        0L,
+        service.getPublishedCount(CacheDomain.ENTITY, CacheInvalidationOperation.INVALIDATE_KEY));
+  }
+
+  @Test
+  void testUnregisterHandler() {
+    LocalCacheInvalidationService service = new LocalCacheInvalidationService(true);
+    AtomicInteger handled = new AtomicInteger(0);
+    service.registerHandler(CacheDomain.AUTH_ROLE, "handler", event -> handled.incrementAndGet());
+    service.unregisterHandler(CacheDomain.AUTH_ROLE, "handler");
+
+    service.publish(
+        CacheInvalidationEvent.of(
+            CacheDomain.AUTH_ROLE,
+            CacheInvalidationOperation.INVALIDATE_KEY,
+            RoleCacheInvalidationKey.of(1L),
+            service.localNodeId()));
+
+    assertEquals(0, handled.get());
+    assertTrue(service.localNodeId().contains("-"));
+  }
+}

--- a/server-common/src/main/java/org/apache/gravitino/server/authorization/jcasbin/JcasbinAuthorizer.java
+++ b/server-common/src/main/java/org/apache/gravitino/server/authorization/jcasbin/JcasbinAuthorizer.java
@@ -51,6 +51,13 @@ import org.apache.gravitino.authorization.AuthorizationUtils;
 import org.apache.gravitino.authorization.GravitinoAuthorizer;
 import org.apache.gravitino.authorization.Privilege;
 import org.apache.gravitino.authorization.SecurableObject;
+import org.apache.gravitino.cache.invalidation.CacheDomain;
+import org.apache.gravitino.cache.invalidation.CacheInvalidationEvent;
+import org.apache.gravitino.cache.invalidation.CacheInvalidationOperation;
+import org.apache.gravitino.cache.invalidation.CacheInvalidationService;
+import org.apache.gravitino.cache.invalidation.CacheInvalidationServiceFactory;
+import org.apache.gravitino.cache.invalidation.OwnerCacheInvalidationKey;
+import org.apache.gravitino.cache.invalidation.RoleCacheInvalidationKey;
 import org.apache.gravitino.exceptions.NoSuchUserException;
 import org.apache.gravitino.meta.RoleEntity;
 import org.apache.gravitino.meta.UserEntity;
@@ -90,6 +97,9 @@ public class JcasbinAuthorizer implements GravitinoAuthorizer {
   private Cache<Long, Optional<Long>> ownerRel;
 
   private Executor executor = null;
+  private CacheInvalidationService cacheInvalidationService;
+  private String roleInvalidationHandlerId;
+  private String ownerInvalidationHandlerId;
 
   @Override
   public void initialize() {
@@ -126,6 +136,14 @@ public class JcasbinAuthorizer implements GravitinoAuthorizer {
             .expireAfterAccess(cacheExpirationSecs, TimeUnit.SECONDS)
             .maximumSize(ownerCacheSize)
             .build();
+    cacheInvalidationService =
+        CacheInvalidationServiceFactory.getOrCreate(GravitinoEnv.getInstance().config());
+    roleInvalidationHandlerId = "jcasbin-role-" + System.identityHashCode(this);
+    ownerInvalidationHandlerId = "jcasbin-owner-" + System.identityHashCode(this);
+    cacheInvalidationService.registerHandler(
+        CacheDomain.AUTH_ROLE, roleInvalidationHandlerId, this::handleRoleInvalidationEvent);
+    cacheInvalidationService.registerHandler(
+        CacheDomain.AUTH_OWNER, ownerInvalidationHandlerId, this::handleOwnerInvalidationEvent);
     executor =
         Executors.newFixedThreadPool(
             GravitinoEnv.getInstance()
@@ -401,7 +419,17 @@ public class JcasbinAuthorizer implements GravitinoAuthorizer {
 
   @Override
   public void handleRolePrivilegeChange(Long roleId) {
-    loadedRoles.invalidate(roleId);
+    if (!cacheInvalidationService.isEnabled()) {
+      loadedRoles.invalidate(roleId);
+      return;
+    }
+
+    cacheInvalidationService.publish(
+        CacheInvalidationEvent.of(
+            CacheDomain.AUTH_ROLE,
+            CacheInvalidationOperation.INVALIDATE_KEY,
+            RoleCacheInvalidationKey.of(roleId),
+            cacheInvalidationService.localNodeId()));
   }
 
   @Override
@@ -409,11 +437,26 @@ public class JcasbinAuthorizer implements GravitinoAuthorizer {
       String metalake, Long oldOwnerId, NameIdentifier nameIdentifier, Entity.EntityType type) {
     MetadataObject metadataObject = NameIdentifierUtil.toMetadataObject(nameIdentifier, type);
     Long metadataId = MetadataIdConverter.getID(metadataObject, metalake);
-    ownerRel.invalidate(metadataId);
+    if (!cacheInvalidationService.isEnabled()) {
+      ownerRel.invalidate(metadataId);
+      return;
+    }
+
+    cacheInvalidationService.publish(
+        CacheInvalidationEvent.of(
+            CacheDomain.AUTH_OWNER,
+            CacheInvalidationOperation.INVALIDATE_KEY,
+            OwnerCacheInvalidationKey.of(metadataId),
+            cacheInvalidationService.localNodeId()));
   }
 
   @Override
   public void close() throws IOException {
+    if (cacheInvalidationService != null) {
+      cacheInvalidationService.unregisterHandler(CacheDomain.AUTH_ROLE, roleInvalidationHandlerId);
+      cacheInvalidationService.unregisterHandler(
+          CacheDomain.AUTH_OWNER, ownerInvalidationHandlerId);
+    }
     if (executor != null) {
       if (executor instanceof ThreadPoolExecutor) {
         ThreadPoolExecutor threadPoolExecutor = (ThreadPoolExecutor) executor;
@@ -600,5 +643,25 @@ public class JcasbinAuthorizer implements GravitinoAuthorizer {
             condition.name().toLowerCase(java.util.Locale.ROOT));
       }
     }
+  }
+
+  private void handleRoleInvalidationEvent(CacheInvalidationEvent event) {
+    if (event.operation() != CacheInvalidationOperation.INVALIDATE_KEY
+        || !(event.key() instanceof RoleCacheInvalidationKey)) {
+      return;
+    }
+
+    RoleCacheInvalidationKey key = (RoleCacheInvalidationKey) event.key();
+    loadedRoles.invalidate(key.roleId());
+  }
+
+  private void handleOwnerInvalidationEvent(CacheInvalidationEvent event) {
+    if (event.operation() != CacheInvalidationOperation.INVALIDATE_KEY
+        || !(event.key() instanceof OwnerCacheInvalidationKey)) {
+      return;
+    }
+
+    OwnerCacheInvalidationKey key = (OwnerCacheInvalidationKey) event.key();
+    ownerRel.invalidate(key.metadataId());
   }
 }


### PR DESCRIPTION
### What changes were made?

This PR implements Phase-1 cache invalidation unification for #10414.

- Added a shared cache invalidation framework under core:
  - CacheDomain, CacheInvalidationEvent, CacheInvalidationOperation
  - CacheInvalidationHandler, CacheInvalidationService
  - local in-JVM dispatcher implementation and factory
  - typed invalidation keys for entity/catalog/role/owner caches
- Added config toggle:
  - gravitino.cache.invalidation.enabled (default: true)
- Wired unified invalidation into:
  - RelationalEntityStore (entity/relation mutations including batchPut and batchDelete)
  - CatalogManager (catalog cache invalidation paths)
  - JcasbinAuthorizer (loadedRoles and ownerRel invalidation)
- Added tests:
  - TestLocalCacheInvalidationService

### Why are the changes needed?

Cache invalidation logic was previously spread across modules with inconsistent mutation coverage. This change introduces a shared contract and local dispatcher so invalidation behavior is explicit and consistent across key high-risk modules.

### Does this PR introduce any user-facing change?

No functional API change. Internal cache invalidation behavior is standardized.

### How was this patch tested?

- ./gradlew :core:spotlessApply :server-common:spotlessApply --no-daemon
- ./gradlew :core:compileJava :server-common:compileJava :core:test --tests org.apache.gravitino.cache.invalidation.TestLocalCacheInvalidationService :core:test --tests org.apache.gravitino.catalog.TestCatalogManager :server-common:test --tests org.apache.gravitino.server.authorization.jcasbin.TestJcasbinAuthorizer --no-daemon

Closes #10414
