### PR TITLE
[#10421] improvement (docs): Update Apache Gravitino copyright year to 2026 in NOTICE files (#10422)

### DIFF
--- a/NOTICE.bin
+++ b/NOTICE.bin
@@ -1,5 +1,5 @@
 Apache Gravitino
-Copyright 2024 The Apache Software Foundation
+Copyright 2026 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/NOTICE.iceberg
+++ b/NOTICE.iceberg
@@ -1,5 +1,5 @@
 Apache Gravitino
-Copyright 2025 The Apache Software Foundation
+Copyright 2026 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
@@ -256,7 +256,7 @@ AWS EventStream for Java
 Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 Apache Gravitino
-Copyright 2024 The Apache Software Foundation
+Copyright 2026 The Apache Software Foundation
 
 The initial code for the Gravitino project was donated
 to the ASF by Datastrato (https://datastrato.ai/) copyright 2023-2024.

--- a/NOTICE.lance
+++ b/NOTICE.lance
@@ -1,5 +1,5 @@
 Apache Gravitino
-Copyright 2025 The Apache Software Foundation
+Copyright 2026 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/NOTICE.trino
+++ b/NOTICE.trino
@@ -1,5 +1,5 @@
 Apache Gravitino
-Copyright 2025 The Apache Software Foundation
+Copyright 2026 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).


### PR DESCRIPTION
### What changes were proposed in this pull request?

Cherry-pick of #10422 from branch-1.2 to main.

Update the Apache Gravitino copyright year to 2026 in `NOTICE.bin`, `NOTICE.iceberg`, `NOTICE.lance`, and `NOTICE.trino`. Only the "Apache Gravitino" product copyright lines are changed; third-party component copyright lines are left untouched.

### Why are the changes needed?

Fix: #10421

The copyright year for the Apache Gravitino product itself was outdated (2024/2025) in four NOTICE files.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

N/A — documentation/metadata change only.