### PR TITLE
[#10115] improvement(ci): Optimize build workflow for maintenance changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -187,7 +187,7 @@ jobs:
           if [ "${{ needs.changes.outputs.maintenance_module_only_changes }}" = "true" ]; then
             ./gradlew \
               :maintenance:optimizer-api:build \
-              :maintenance:gravitino-updaters:build \
+              :maintenance:updaters:build \
               :maintenance:optimizer:build \
               :maintenance:jobs:build \
               -PskipITs \


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR updates the `build` workflow to handle maintenance changes without introducing a separate maintenance workflow.

It adds maintenance-aware routing in the existing `build` job:
- pure `maintenance/**` source changes run only the targeted maintenance module build path
- mixed changes still run the normal root build and then run maintenance unit tests
- upstream dependency changes for maintenance also keep maintenance validation enabled

### Why are the changes needed?

Maintenance-only changes do not need the full root build and release flow.
This change reduces unnecessary CI work for those changes while keeping maintenance validation enabled when maintenance sources or their dependencies are affected.

Fix: #10115

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Verified locally with YAML validation and Gradle dry-run for:
- the maintenance-only build path
- the normal root build path with maintenance tests excluded
- the maintenance unit test path

Validated with temporary upstream CI runs for:
- maintenance-only changes
- maintenance and common mixed changes
- common-only changes
- web-only changes
