### PR TITLE
[#9710] docs(flink-connector): add Flink multi-version support spec

### DIFF
--- a/ai-code-spec/flink_2_0_adaptation_notes.md
+++ b/ai-code-spec/flink_2_0_adaptation_notes.md
@@ -1,0 +1,430 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+# Gravitino Flink Connector Flink 2.0 Adaptation Notes
+
+| Field | Value |
+| --- | --- |
+| Status | Draft |
+| Owner | FANNG |
+| Created | 2026-03-17 |
+| Target Release | 1.3.0 |
+| Related Issue | [#9710](https://github.com/apache/gravitino/issues/9710) |
+| Related PR | N/A |
+
+## Purpose
+
+This document records what changed between the Flink `1.x` lane and Flink `2.0`, why those changes matter to the Gravitino Flink connector, how the connector was adapted, and which parts were actually validated.
+
+This is not the main multi-version implementation spec. That broader document remains `ai-code-spec/flink_multi_version_support_spec.md`. This document focuses only on the Flink `2.0` compatibility lane and the implementation/debugging findings that came out of that work.
+
+## Scope
+
+The Gravitino Flink connector is mainly:
+
+- a `CatalogStore`
+- a set of Flink `Catalog` wrappers
+- conversion utilities between Flink table metadata and Gravitino metadata
+
+It is not primarily a DataStream runtime integration. For that reason, the Flink `2.0` adaptation is mainly about:
+
+- catalog/table API compatibility
+- provider factory compatibility
+- dependency and runtime artifact layout changes
+- real Flink `2.0.x` validation
+
+The main source areas involved are:
+
+- `flink-connector/flink-common`
+- `flink-connector/v2.0/flink`
+- `flink-connector/v2.0/flink-runtime`
+
+## High-Level Conclusion
+
+Flink `2.0` support is not a simple dependency bump from `1.20`.
+
+The main reasons are:
+
+1. Flink `2.0` removes legacy catalog/table construction APIs used directly by the shared connector code.
+2. Iceberg and JDBC both change their Flink-facing integration surface.
+3. Real Flink `2.0` distributions expose runtime behaviors that are not fully visible in repo-local tests.
+
+At the same time, the connector did not need a full rewrite. The chosen structure still works:
+
+- keep shared logic in `flink-common`
+- add `flink-2.0` and `flink-runtime-2.0`
+- bridge the actual API and ABI breakpoints through narrow compatibility helpers
+
+That result is important because it validates the general `flink-common + versioned modules + versioned runtime modules` architecture for future major-version work.
+
+## What Changed In Flink 2.0
+
+### 1. `CatalogTable.of(...)` is no longer available
+
+In Flink `1.20`, `CatalogTable` still exposes:
+
+- `CatalogTable.of(Schema, String, List<String>, Map<String, String>)`
+- `CatalogTable.of(Schema, String, List<String>, Map<String, String>, Long)`
+
+In Flink `2.0.1`, those static factory methods are no longer the supported path. The creation path is builder-based:
+
+- `CatalogTable.newBuilder()`
+
+Why this matters:
+
+- shared connector code used `CatalogTable.of(...)` directly
+- shared unit and integration tests also used `CatalogTable.of(...)`
+
+Affected connector paths included:
+
+- `flink-connector/flink-common/src/main/java/org/apache/gravitino/flink/connector/catalog/BaseCatalog.java`
+- `flink-connector/flink-common/src/main/java/org/apache/gravitino/flink/connector/hive/FlinkGenericTableUtil.java`
+- shared tests under `flink-connector/flink-common/src/test/java`
+
+### 2. `CatalogPropertiesUtil` needs a newer compatibility path
+
+The connector already used `CatalogPropertiesUtil`, which was better than relying on deprecated `CatalogTable.toProperties()`.
+
+However, Flink `2.0` introduced a newer `CatalogPropertiesUtil.serializeCatalogTable(...)` path that requires an additional `SqlFactory` parameter.
+
+Why this matters:
+
+- the connector must serialize `ResolvedCatalogTable` for generic-table handling
+- a single hard-coded method call is not sufficient across `1.x` and `2.0`
+
+### 3. The `Catalog` surface grows beyond the classic `1.x` lane
+
+Compared with `1.20`, the Flink `2.0` `Catalog` interface includes a broader surface such as model-related APIs.
+
+Why this matters:
+
+- it confirms that Flink `2.0` is a major compatibility lane, not just another minor
+- it means shared wrapper code should be prepared for additive or default-method-oriented API growth
+
+This was not the first blocker for the Gravitino connector, but it is part of the reason `2.0` should not be treated as `1.21`.
+
+### 4. The JDBC connector layout changes in Flink 2.0
+
+In the `1.x` lane, the connector typically works with artifacts like:
+
+- `flink-connector-jdbc-3.3.0-1.20`
+
+In Flink `2.0`, JDBC is split into artifacts such as:
+
+- `flink-connector-jdbc-core-4.0.0-2.0`
+- `flink-connector-jdbc-mysql-4.0.0-2.0`
+- `flink-connector-jdbc-postgres-4.0.0-2.0`
+
+Why this matters:
+
+- class packages changed
+- the connector cannot assume one old package layout
+- real SQL client behavior depends on how those jars are loaded
+
+### 5. Iceberg changes its Flink factory entry point
+
+For the Iceberg runtime used with the `1.x` lane, `org.apache.iceberg.flink.FlinkCatalogFactory` supports:
+
+- `createCatalog(String, Map<String, String>)`
+
+For the runtime used with Flink `2.0`, the supported entry point is:
+
+- `createCatalog(CatalogFactory.Context)`
+
+Why this matters:
+
+- the Gravitino Iceberg wrapper cannot use the same direct factory call in both lanes
+- this is a provider ABI break, not just a Flink core API change
+
+### 6. Real Flink distributions expose stricter runtime behavior
+
+This came from real validation, not just source comparison.
+
+Observed examples:
+
+- Iceberg REST needs the correct base URI shape, such as `http://127.0.0.1:9001/iceberg/`
+- JDBC depends on driver visibility and driver registration in the real SQL client runtime
+- local Flink distributions may still need Hadoop-related jars depending on the tested path
+
+Why this matters:
+
+- compile success plus embedded IT success is not enough to claim real Flink `2.0` support
+
+## How Gravitino Was Adapted
+
+### 1. Added a dedicated Flink 2.0 module and runtime module
+
+Relevant files:
+
+- `settings.gradle.kts`
+- `flink-connector/v2.0/flink/build.gradle.kts`
+- `flink-connector/v2.0/flink-runtime/build.gradle.kts`
+- `gradle/libs.versions.toml`
+
+What changed:
+
+- added `:flink-connector:flink-2.0`
+- added `:flink-connector:flink-runtime-2.0`
+- bound the `2.0` lane to explicit provider versions
+
+Why:
+
+- Flink `2.0` needs its own dependency and runtime artifact lane
+- the shared code can stay shared only if the version binding is kept out of `flink-common`
+
+### 2. Introduced `FlinkCatalogCompatUtils`
+
+Relevant file:
+
+- `flink-connector/flink-common/src/main/java/org/apache/gravitino/flink/connector/utils/FlinkCatalogCompatUtils.java`
+
+What changed:
+
+- if `CatalogTable.of(...)` exists, use it
+- otherwise create the table through `CatalogTable.newBuilder()`
+- if the legacy `CatalogPropertiesUtil.serializeCatalogTable(...)` path exists, use it
+- otherwise use the newer `SqlFactory`-based path
+
+Why:
+
+- this is the narrowest way to keep `BaseCatalog` and `FlinkGenericTableUtil` shared
+- it removes direct `1.x` assumptions from the common layer
+
+### 3. Moved `BaseCatalog` table construction behind the compat helper
+
+Relevant file:
+
+- `flink-connector/flink-common/src/main/java/org/apache/gravitino/flink/connector/catalog/BaseCatalog.java`
+
+What changed:
+
+- `newCatalogTable(...)` became the central construction hook
+- shared table conversion now calls `FlinkCatalogCompatUtils.createCatalogTable(...)`
+
+Why:
+
+- `BaseCatalog` is the main path that converts Gravitino table metadata back into Flink table metadata
+- if this path is version-sensitive, the whole connector is version-sensitive
+
+### 4. Updated Hive generic-table serialization and reconstruction
+
+Relevant file:
+
+- `flink-connector/flink-common/src/main/java/org/apache/gravitino/flink/connector/hive/FlinkGenericTableUtil.java`
+
+What changed:
+
+- generic-table serialization now goes through `FlinkCatalogCompatUtils.serializeCatalogTable(...)`
+- generic-table reconstruction now goes through `FlinkCatalogCompatUtils.createCatalogTable(...)`
+
+Why:
+
+- generic tables are one of the most direct places where Flink catalog metadata shape matters
+- this kept the shared Hive-side utility compatible with both the `1.x` and `2.0` lanes
+
+### 5. Introduced `IcebergCatalogCompatUtils`
+
+Relevant file:
+
+- `flink-connector/flink-common/src/main/java/org/apache/gravitino/flink/connector/utils/IcebergCatalogCompatUtils.java`
+
+What changed:
+
+- if the old Iceberg factory API is present, call `createCatalog(String, Map<String, String>)`
+- otherwise wrap the existing Flink `CatalogFactory.Context` and call `createCatalog(Context)`
+
+Related integration points:
+
+- `flink-connector/flink-common/src/main/java/org/apache/gravitino/flink/connector/iceberg/GravitinoIcebergCatalog.java`
+- `flink-connector/flink-common/src/main/java/org/apache/gravitino/flink/connector/iceberg/GravitinoIcebergCatalogFactory.java`
+
+Why:
+
+- Iceberg changed its Flink factory ABI
+- the connector needs a single shared wrapper that can bridge both styles
+
+### 6. Introduced `JdbcCatalogCompatUtils`
+
+Relevant file:
+
+- `flink-connector/flink-common/src/main/java/org/apache/gravitino/flink/connector/utils/JdbcCatalogCompatUtils.java`
+
+What changed:
+
+- try compatible JDBC catalog factory class names across lanes
+- try compatible JDBC dynamic table factory class names across lanes
+
+Related integration point:
+
+- `flink-connector/flink-common/src/main/java/org/apache/gravitino/flink/connector/jdbc/GravitinoJdbcCatalog.java`
+
+Why:
+
+- Flink `2.0` moves JDBC classes into the newer `core` package layout
+- a single direct import path is not stable enough across lanes
+
+Important limitation:
+
+- this solves the connector-side ABI problem
+- it does not by itself solve every real SQL client driver-loading issue in external Flink `2.0.x` environments
+
+### 7. Hardened `CatalogStore` service discovery
+
+Relevant file:
+
+- `flink-connector/flink-common/src/main/java/org/apache/gravitino/flink/connector/store/GravitinoCatalogStore.java`
+
+What changed:
+
+- `ServiceLoader` scanning now tolerates:
+  - `ServiceConfigurationError`
+  - `NoClassDefFoundError`
+  - `LinkageError`
+
+Why:
+
+- in a multi-provider, multi-version environment, some factories may be visible but not fully initializable on a given classpath
+- the connector should skip optional provider failures instead of failing catalog-store discovery completely
+
+### 8. Added Flink 2.0-specific test and runtime wiring
+
+Relevant files:
+
+- `flink-connector/v2.0/flink/build.gradle.kts`
+- `flink-connector/v2.0/flink-runtime/build.gradle.kts`
+- `flink-connector/v2.0/flink-runtime/src/test/java/org/apache/gravitino/flink/runtime/TestRuntimeJarDependencies.java`
+
+What changed:
+
+- reused shared tests from `flink-common`
+- bound the `2.0` lane to Flink `2.0.1`
+- bound provider jars to `2.0`-compatible versions
+- excluded unsupported Hive-oriented tests from the current `2.0` lane
+- added runtime jar assertions
+
+Why:
+
+- Flink `2.0` must be validated as its own lane, not as an alias of `1.20`
+
+### 9. Fixed Iceberg REST deploy validation issues
+
+Relevant files:
+
+- `integration-test-common/src/test/java/org/apache/gravitino/integration/test/util/BaseIT.java`
+- `integration-test-common/src/test/java/org/apache/gravitino/integration/test/util/TestBaseIT.java`
+- `flink-connector/flink-common/src/test/java/org/apache/gravitino/flink/connector/integration/test/iceberg/FlinkIcebergRestCatalogIT.java`
+
+What changed:
+
+- explicitly enabled the auxiliary Iceberg REST service in deploy mode
+- normalized wildcard hosts such as `0.0.0.0` to loopback for local test access
+- waited for auxiliary service readiness
+- aligned the REST SQL creation path with the actual REST backend expectation
+
+Why:
+
+- otherwise the deploy-mode validation failure can be mistaken for a Flink `2.0` compatibility failure
+- the same fixes benefit both `1.20` and `2.0`
+
+## Validation Summary
+
+### Repo-level validation
+
+The following areas were validated in the current `2.0` implementation work:
+
+- shared compatibility-helper tests in `flink-common`
+- `flink-2.0` compile and test lane
+- `flink-runtime-2.0` build and runtime jar checks
+- representative embedded integration tests for:
+  - catalog store
+  - JDBC
+  - Paimon
+  - Iceberg
+- deploy-mode Iceberg REST integration tests
+
+### Real external Flink 2.0.1 validation
+
+External validation was also run against a real Flink `2.0.1` distribution.
+
+Current result:
+
+- `Paimon filesystem`: passed
+- `Iceberg REST`: passed
+- `JDBC`: not yet passed in the real external SQL client environment
+
+The JDBC external failure currently shows up as:
+
+- `java.sql.SQLException: No suitable driver found for jdbc:mysql://127.0.0.1:3306/...`
+
+This was reproduced in both:
+
+- the catalog-store path
+- the direct `CREATE CATALOG` path
+
+This means the remaining JDBC issue is not specific to `CatalogStore`. It is a real external runtime and classloader issue that still needs dedicated follow-up.
+
+## Current Support Boundary For The Flink 2.0 Lane
+
+Based on current implementation and validation evidence, the Flink `2.0` lane is best described as:
+
+- validated and good candidates for initial support:
+  - core catalog lane
+  - Paimon
+  - Iceberg REST lane
+- adapted in repo-level code but still incomplete in real external validation:
+  - JDBC
+- not part of the current `2.0` support scope:
+  - Hive lane
+  - model support
+  - broader Flink `2.x` feature surface outside the current connector scope
+
+## Why This Is A Moderate Compatibility Project, Not A Rewrite
+
+The Flink `2.0` work is not a full connector rewrite because:
+
+- the connector architecture remains valid
+- most shared Gravitino conversion logic stays reusable
+- the breakpoints are concentrated in a few catalog and provider boundaries
+
+At the same time, it is not a trivial version bump because:
+
+- `CatalogTable.of(...)` disappeared
+- `CatalogPropertiesUtil` needs a new compatibility path
+- Iceberg factory entry points changed
+- JDBC packaging changed
+- real `2.0` runtime validation exposed environment-sensitive behavior
+
+In practice, the work is a focused compatibility project:
+
+- one new version lane
+- a few targeted compatibility helpers
+- provider-specific factory bridging
+- test and runtime validation updates
+
+## Summary
+
+The Flink `2.0` adaptation required concrete work in three places:
+
+1. Flink catalog/table API compatibility
+2. provider factory and packaging compatibility
+3. deploy and external runtime validation
+
+The key result is positive: the chosen `flink-common + versioned module + thin compatibility helper` architecture is sufficient for Flink `2.0`.
+
+The remaining JDBC external runtime issue is important, but it is now isolated. It should be treated as a focused follow-up in the `2.0` lane, not as evidence that the overall adaptation approach is wrong.

--- a/ai-code-spec/flink_multi_version_support_spec.md
+++ b/ai-code-spec/flink_multi_version_support_spec.md
@@ -1,0 +1,1080 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+# Gravitino Flink Connector Multi-Version Support Spec
+
+| Field | Value |
+| --- | --- |
+| Status | Proposal |
+| Owner | FANNG |
+| Created | 2026-03-16 |
+| Target Release | 1.3.0 |
+| Related Issue | [#9710](https://github.com/apache/gravitino/issues/9710) |
+| Related PR | N/A |
+
+## Goal
+
+Add maintained support for Flink `1.18`, `1.19`, and `1.20` with versioned runtime artifacts, similar to the Spark connector release model.
+
+The output of this work should be:
+
+- one shared `flink-common` module
+- one connector module per supported Flink minor
+- one runtime shadow jar per supported Flink minor
+- CI and docs that explicitly cover the supported Flink matrix
+
+## Non-Goals
+
+- Supporting Flink `1.17` or Flink `2.x`
+- Changing connector behavior beyond what is required for multi-version compatibility
+- Adding new connector features such as materialized table support
+- Reworking provider semantics for Hive, Iceberg, JDBC, or Paimon
+- Adding OAuth2 or Kerberos real-environment validation to the required test matrix for this delivery
+- Producing one universal jar that works across all Flink minors
+
+Note: Flink `2.0` support is explicitly out of scope for this delivery. It should be treated as a larger follow-up compatibility lane rather than a small extension of the `1.18` to `1.20` work, but the module split and extension hooks introduced here should keep a clean path for that future effort.
+
+## Current Connector Model
+
+The current Flink connector is not a generic table runtime connector. It is primarily a Flink `CatalogStore` plus a set of Flink `Catalog` implementations that proxy metadata operations to Gravitino and delegate data/table behavior to native Flink ecosystem catalogs.
+
+### Main Flink Interaction Points
+
+1. Catalog store bootstrapping
+
+- `flink-connector/flink/src/main/java/org/apache/gravitino/flink/connector/store/GravitinoCatalogStoreFactory.java`
+- `flink-connector/flink/src/main/java/org/apache/gravitino/flink/connector/store/GravitinoCatalogStore.java`
+
+These classes integrate with:
+
+- `CatalogStoreFactory`
+- `CatalogStore`
+- `CatalogDescriptor`
+- `FactoryUtil.createCatalogStoreFactoryHelper(...)`
+- ServiceLoader discovery of Flink `Factory`
+
+2. Catalog SPI implementations
+
+- `flink-connector/flink/src/main/java/org/apache/gravitino/flink/connector/catalog/BaseCatalog.java`
+- `flink-connector/flink/src/main/java/org/apache/gravitino/flink/connector/catalog/BaseCatalogFactory.java`
+
+These classes integrate with:
+
+- `AbstractCatalog`
+- `CatalogBaseTable`
+- `CatalogTable`
+- `ResolvedCatalogBaseTable`
+- `ResolvedCatalogTable`
+- `CatalogDatabase`
+- `ObjectPath`
+- Flink `TableChange`
+- Flink `Schema`
+
+3. Provider-specific wrappers around native Flink ecosystem catalogs
+
+- Hive: `GravitinoHiveCatalog`, `GravitinoHiveCatalogFactory`
+- Iceberg: `GravitinoIcebergCatalog`, `GravitinoIcebergCatalogFactory`
+- JDBC: `GravitinoJdbcCatalog`, `GravitinoJdbcCatalogFactory`
+- Paimon: `GravitinoPaimonCatalog`, `GravitinoPaimonCatalogFactory`
+
+These delegate to:
+
+- `org.apache.flink.table.catalog.hive.HiveCatalog`
+- `org.apache.iceberg.flink.FlinkCatalog`
+- `org.apache.flink.connector.jdbc.catalog.JdbcCatalog`
+- `org.apache.paimon.flink.FlinkCatalogFactory`
+
+4. Flink-to-Gravitino conversion utilities
+
+- `TypeUtils`
+- `TableUtils`
+- `CatalogPropertiesConverter`
+- `SchemaAndTablePropertiesConverter`
+- `PartitionConverter`
+- `FlinkGenericTableUtil`
+
+These are where Flink schema/type/property semantics are translated into Gravitino APIs.
+
+## Findings From Code Review
+
+### What the connector actually depends on
+
+The connector depends much more on the Flink Table/Catalog SPI than on the DataStream runtime. The version-sensitive surface is therefore:
+
+- Flink table/catalog API jars
+- native provider jars tied to the Flink minor
+- runtime shadow jar assembly
+- tests and workflows that hardcode a single module path today
+
+### Flink SPI stability from 1.18 to 1.20
+
+Reviewing local Flink sources under `/Users/fanng/opensource/flink` shows that the APIs used by the current connector are mostly stable across `release-1.18`, `release-1.19`, and `origin/release-1.20`.
+
+Observed changes are mostly additive:
+
+- `CatalogDescriptor` gained optional comment support in `1.20`
+- `CatalogTable` gained a builder and distribution-related API in `1.20`
+- `CatalogPropertiesUtil` gained materialized-table serialization in `1.20`
+- `Catalog` gained more documentation and some additional default-method-oriented expectations in `1.20`
+
+Important point: the connector currently uses APIs that remain present and source-compatible across `1.18`, `1.19`, and `1.20`, including:
+
+- `CatalogStoreFactory`
+- `CatalogDescriptor.of(name, configuration)`
+- `CatalogPropertiesUtil.serializeCatalogTable(...)`
+- `CatalogPropertiesUtil.deserializeCatalogTable(...)`
+- `CatalogTable.of(...)`
+- `ResolvedCatalogBaseTable`
+- `TableChange` classes used in `BaseCatalog`
+
+Conclusion: the Java implementation is likely to stay almost entirely shared. The hard part is the build and dependency matrix, not large API shims.
+
+### External dependency constraints are stricter than Flink SPI changes
+
+As of `March 16, 2026`, Maven Central metadata shows:
+
+- `org.apache.iceberg:iceberg-flink-runtime-1.20` starts at Iceberg `1.7.0`
+- `org.apache.iceberg:iceberg-flink-runtime-1.19` includes Iceberg `1.6.1`
+- `org.apache.iceberg:iceberg-flink-runtime-1.18` includes Iceberg `1.6.1`
+- `org.apache.paimon:paimon-flink-1.18`, `1.19`, and `1.20` all include Paimon `1.2.0`
+- `org.apache.flink:flink-connector-jdbc` publishes `3.2.0-1.18`, `3.2.0-1.19`, `3.3.0-1.19`, and `3.3.0-1.20`
+
+This means the current single global connector dependency model is not sufficient:
+
+- a single global `flink = 1.18.0` is not sufficient
+- a single global `flinkjdbc = 3.2.0-1.18` is not sufficient
+- a single global `iceberg4connector = 1.6.1` is not sufficient for Flink `1.20`
+
+This is the main reason the connector must be split by Flink minor.
+
+## Design Decision
+
+Follow the Spark connector model more directly:
+
+- introduce a compiled `:flink-connector:flink-common` module
+- keep `:flink-connector:flink-1.18`, `:flink-connector:flink-1.19`, and `:flink-connector:flink-1.20` as thin versioned modules
+- keep one runtime shadow module per Flink minor
+
+### Why this is acceptable
+
+This is workable if `flink-common` is treated as a binary-compatible common layer compiled against the lowest supported baseline and if version-sensitive code is isolated.
+
+Recommended rule set:
+
+- compile `flink-common` against Flink `1.18`
+- use `compileOnly` for Flink/provider dependencies in `flink-common`
+- allow versioned `flink-1.18`, `flink-1.19`, `flink-1.20` modules to add small overlays for minor-specific APIs
+- keep runtime packaging and test execution version-specific
+
+This intentionally differs from the Spark connector approach that compiles the common layer against the latest Spark minor. For Flink `1.18` to `1.20`, the catalog/table API drift is mostly additive, so compiling `flink-common` against the lowest supported baseline is the safer default because it reduces accidental references to newer API only present in `1.19` or `1.20`.
+
+Important clarification: `compileOnly` avoids bundling dependencies, but it does not solve binary compatibility by itself. The bytecode in `flink-common` is still compiled against a concrete API surface. Therefore:
+
+- `flink-common` must only use API and provider methods that remain binary-compatible across `1.18`, `1.19`, and `1.20`
+- anything version-sensitive must move into the versioned modules
+
+## Proposed Project Layout
+
+```text
+flink-connector/
+  flink-common/
+    build.gradle.kts
+    src/main/java/...
+    src/main/resources/...
+    src/test/java/...
+    src/test/resources/...
+  v1.18/
+    build.gradle.kts
+    flink/
+      build.gradle.kts          # depends on :flink-connector:flink-common
+      src/main/java/...         # only if a 1.18-only shim is needed
+      src/test/java/...         # only if a 1.18-only test is needed
+    flink-runtime/
+      build.gradle.kts
+      src/test/java/...
+  v1.19/
+    build.gradle.kts
+    flink/
+      build.gradle.kts
+      src/main/java/...
+      src/test/java/...
+    flink-runtime/
+      build.gradle.kts
+      src/test/java/...
+  v1.20/
+    build.gradle.kts
+    flink/
+      build.gradle.kts
+      src/main/java/...
+      src/test/java/...
+    flink-runtime/
+      build.gradle.kts
+      src/test/java/...
+```
+
+### Gradle project names
+
+Add these projects in `settings.gradle.kts` under the existing Scala `2.12` guard:
+
+- `:flink-connector:flink-common`
+- `:flink-connector:flink-1.18`
+- `:flink-connector:flink-runtime-1.18`
+- `:flink-connector:flink-1.19`
+- `:flink-connector:flink-runtime-1.19`
+- `:flink-connector:flink-1.20`
+- `:flink-connector:flink-runtime-1.20`
+
+Current-scope Scala note:
+
+- Flink `1.18`, `1.19`, and `1.20` in this delivery all use Scala `2.12` artifacts
+- the module layout and publication names should therefore consistently keep the `_2.12` suffix
+- supporting a different Scala suffix is out of scope for this change and should be treated as a separate compatibility question
+
+### Project migration rule
+
+After Phase 1:
+
+- `:flink-connector:flink` is replaced by `:flink-connector:flink-common` plus `:flink-connector:flink-1.18`
+- `:flink-connector:flink-runtime` is replaced by `:flink-connector:flink-runtime-1.18`
+- the old `:flink-connector:flink` and `:flink-connector:flink-runtime` entries should be removed from `settings.gradle.kts`
+- do not keep the old project names as Gradle aliases because that makes publication, workflow targeting, and review reasoning ambiguous
+- `settings.gradle.kts` should map the new project names to their explicit project directories
+
+### Module responsibility split
+
+`flink-common` should contain the implementation that is expected to remain common across all supported Flink minors, for example:
+
+- `catalog/BaseCatalog.java`
+- `catalog/BaseCatalogFactory.java`
+- `catalog/GravitinoCatalogManager.java`
+- property/type/partition conversion utilities
+- `GravitinoCatalogStore` and `GravitinoCatalogStoreFactory`
+- provider classes only if their used APIs are confirmed binary-compatible across `1.18` to `1.20`
+
+Versioned `flink-*` modules should contain:
+
+- the published version-specific connector artifact
+- minor-specific factory/catalog overlay classes if needed
+- minor-specific SPI resource files if needed
+- minor-specific tests if needed
+
+### Provider placement matrix
+
+The initial provider split should be reviewed explicitly instead of relying only on a general rule.
+
+| Provider | Initial placement | Why | Required validation | Move trigger |
+| --- | --- | --- | --- | --- |
+| Hive | start in `flink-common` only if shared code uses constructors and helpers that remain ABI-compatible | current wrapper logic is mostly shared, but Hive connector drift is historically the most likely provider risk inside `1.18` to `1.20` | compile on all versioned classpaths, instantiate factory/wrapper, and run real-environment smoke | `NoSuchMethodError`, `ClassNotFoundException`, compile break, or provider-specific test failure |
+| Iceberg | start in `flink-common` with versioned runtime dependencies | the wrapper logic is thin, but `iceberg-flink-runtime-*` versions must be matched by Flink minor | compile on all versioned classpaths, instantiate factory/wrapper, and run Iceberg smoke | constructor/method drift or runtime linkage failure on versioned artifact |
+| JDBC | start in `flink-common` with versioned connector dependencies | the wrapper is thin, but JDBC connector artifacts already differ by Flink minor | compile on all versioned classpaths, instantiate factory/wrapper, and run JDBC smoke | constructor drift, artifact layout drift, or runtime linkage failure |
+| Paimon | start in `flink-common` with versioned runtime dependencies | Paimon `1.2.0` is available for `1.18` to `1.20`, so a shared wrapper is a reasonable first cut | compile on all versioned classpaths, instantiate factory/wrapper, and run Paimon smoke | factory API drift or runtime linkage failure |
+
+This gives:
+
+- Spark-aligned repository structure
+- one shared compiled jar
+- one dependency graph per Flink minor at the published connector/runtime layer
+- a clean place for minor-specific shims if binary compatibility breaks appear later
+
+## Dependency Matrix
+
+Introduce version-specific aliases in `gradle/libs.versions.toml`.
+
+Minimum required split:
+
+- `flink18`, `flink19`, `flink20`
+- `flinkJdbc18`, `flinkJdbc19`, `flinkJdbc20`
+- `iceberg4flink18`, `iceberg4flink19`, `iceberg4flink20`
+
+Paimon can stay shared if the chosen version works for all three minors, but using explicit aliases is still cleaner:
+
+- `paimon4flink18`, `paimon4flink19`, `paimon4flink20`
+
+Also introduce version-specific library aliases where necessary so the versioned modules do not depend on one global Flink connector version.
+
+### Recommended baseline
+
+Keep the dependency decision explicit per Flink minor instead of trying to force one global value.
+
+Example direction:
+
+| Variant | Flink | JDBC connector | Iceberg runtime | Paimon runtime |
+| --- | --- | --- | --- | --- |
+| `1.18` | `1.18.x` | `3.2.0-1.18` | `1.6.1` or newer | `1.2.0` |
+| `1.19` | `1.19.x` | `3.2.0-1.19` or `3.3.0-1.19` | `1.6.1` or newer | `1.2.0` |
+| `1.20` | `1.20.x` | `3.3.0-1.20` | `>= 1.7.0` | `1.2.0` |
+
+Important rule: do not keep `iceberg4connector = 1.6.1` globally if Flink `1.20` is introduced.
+
+## `flink-common` Dependency Policy
+
+`flink-common` should compile against the lowest supported baseline, recommended as Flink `1.18`.
+
+Recommended dependency posture for `flink-common`:
+
+- `compileOnly` on Flink `1.18` table/catalog APIs
+- `compileOnly` on provider baseline artifacts used directly by shared code
+- `testImplementation` on the same baseline to keep common unit tests executable
+
+Versioned modules should then use their own version-specific dependencies:
+
+- `:flink-connector:flink-1.18` depends on `:flink-connector:flink-common` and Flink `1.18` deps
+- `:flink-connector:flink-1.19` depends on `:flink-connector:flink-common` and Flink `1.19` deps
+- `:flink-connector:flink-1.20` depends on `:flink-connector:flink-common` and Flink `1.20` deps
+
+### What `compileOnly` does and does not solve
+
+What it helps with:
+
+- keeps `flink-common` thin
+- avoids bundling Flink/provider jars in the common artifact
+- matches the Spark connector structure more closely
+
+What it does not help with:
+
+- method signature drift
+- constructor signature drift
+- removed classes
+- changed inheritance hierarchies
+
+Therefore reviewers should treat `compileOnly` as a packaging choice, not a compatibility mechanism.
+
+## Extension Model For Newer Catalog APIs
+
+Version-specific Flink catalog classes are exception-based, not default-based.
+
+That means:
+
+- do not create `GravitinoHiveCatalogFlink118`, `GravitinoHiveCatalogFlink119`, `GravitinoHiveCatalogFlink120` by default
+- keep provider catalog classes in `flink-common` as long as their used API remains compatible
+- add version-specific classes only when compilation, tests, or runtime ABI checks prove they are necessary
+
+### How Flink `1.20`-only catalog APIs should be supported
+
+If Flink `1.20` adds catalog-related API that should be supported, the implementation should prefer the following escalation order.
+
+1. Helper-level shim
+
+Use this when the difference is object construction or metadata enrichment.
+
+Examples:
+
+- `CatalogDescriptor` adds comment support
+- `CatalogTable` adds builder/distribution support
+- `CatalogPropertiesUtil` adds new serializable catalog metadata
+
+Recommended approach:
+
+- keep the shared algorithm in `flink-common`
+- move the version-sensitive object creation into an overridable helper
+- override that helper in `:flink-connector:flink-1.20`
+
+2. Base-layer shim
+
+Use this when the difference affects the common Gravitino catalog bridge rather than one provider.
+
+Examples:
+
+- new default methods on Flink `Catalog`
+- new table metadata conversion logic needed for all providers
+- new catalog-store descriptor assembly logic
+
+Recommended approach:
+
+- add `BaseCatalog120`, `GravitinoCatalogStore120`, or similar thin adaptors in `v1.20`
+- keep provider classes reusing the base-layer shim instead of duplicating logic
+
+3. Provider-level shim
+
+Use this only when the drift is provider-specific.
+
+Examples:
+
+- Hive-specific constructor or factory behavior changes
+- Iceberg/Paimon/JDBC wrapper behavior changes that do not affect the other providers
+
+Recommended approach:
+
+- introduce the smallest possible `v1.20` provider-specific subclass or factory class
+- do not fork all provider classes just because one provider changed
+
+### Hook points that should be pre-created in this implementation
+
+To make later `1.20` catalog API support cheap, this implementation should add explicit extension hooks now, even if the initial `1.18`, `1.19`, and `1.20` behavior is identical.
+
+Recommended hooks:
+
+1. Catalog descriptor construction hook
+
+Location:
+
+- `GravitinoCatalogStore`
+
+Purpose:
+
+- allow `v1.20` to build `CatalogDescriptor` with newer metadata such as comment support without rewriting store logic
+
+Example shape:
+
+```java
+protected CatalogDescriptor newCatalogDescriptor(
+    String catalogName,
+    Configuration configuration) {
+  return CatalogDescriptor.of(catalogName, configuration);
+}
+```
+
+Then `v1.20` can override if newer `CatalogDescriptor` fields should be populated.
+
+2. Flink table construction hook
+
+Location:
+
+- `BaseCatalog`
+
+Purpose:
+
+- isolate the version-sensitive creation of `CatalogTable` / `CatalogBaseTable`
+- make it possible for `v1.20` to switch from `CatalogTable.of(...)` to builder-based construction or set newer metadata such as distribution
+
+Example shape:
+
+```java
+protected CatalogTable newCatalogTable(
+    org.apache.flink.table.api.Schema schema,
+    String comment,
+    List<String> partitionKeys,
+    Map<String, String> options) {
+  return CatalogTable.of(schema, comment, partitionKeys, options);
+}
+```
+
+3. Generic table deserialize/serialize hook
+
+Location:
+
+- `FlinkGenericTableUtil`
+- or a thin helper owned by `BaseCatalog`
+
+Purpose:
+
+- isolate future changes in `CatalogPropertiesUtil` behavior
+- make it possible to support newer Flink catalog-table metadata without touching the shared alter/create flow
+
+4. Factory creation hook
+
+Location:
+
+- provider factories in `flink-common`
+
+Purpose:
+
+- allow a versioned module to swap in a version-specific factory class only if needed
+- keep ServiceLoader wiring minimal
+
+### What must be done now versus later
+
+Do now in this multi-version support change:
+
+- add the extension hooks above in `flink-common`
+- keep the default implementation behavior identical to the current connector
+- leave `v1.20` free to override those hooks later
+
+Do later only when required by real Flink `1.20` API usage:
+
+- add `v1.20`-specific subclasses
+- enrich descriptors/tables with `1.20`-only metadata
+- implement new `Catalog` methods that need non-default behavior
+
+## Future Flink 2.0 Compatibility Lane
+
+Flink `2.0` should not be implemented in this change set.
+
+However, this design should keep Flink `2.0` support possible without another repository-level reorganization.
+
+### Can this architecture support Flink `2.0`?
+
+Yes, with one important caveat:
+
+- the overall `flink-common + versioned modules + versioned runtime modules` architecture is still valid
+- but Flink `2.0` should be treated as a new major compatibility lane, not as just another `1.x` minor
+
+In practice, this means:
+
+- add `:flink-connector:flink-2.0`
+- add `:flink-connector:flink-runtime-2.0`
+- expect a real `v2.0` shim layer
+- do not assume `flink-common` bytecode compiled against `1.18` will run unchanged on `2.0`
+
+### Why Flink `2.0` is materially different
+
+Reviewing local Flink `release-2.0` sources under `/Users/fanng/opensource/flink` shows several changes relevant to the current connector:
+
+- `CatalogTable.of(...)` is no longer the construction path; builder-based construction is used instead
+- `CatalogBaseTable.TableKind` gains `MATERIALIZED_TABLE`
+- `Catalog` gains model-related APIs and more modern catalog surface area
+- legacy compatibility APIs continue to shrink
+- `TableSchema` references move to legacy package locations
+
+This is enough to require a `v2.0` adapter layer even if much of the business logic remains shared.
+
+### Minimum code changes likely required for Flink `2.0`
+
+At minimum, future Flink `2.0` support should expect the following changes:
+
+1. Add versioned modules
+
+- `:flink-connector:flink-2.0`
+- `:flink-connector:flink-runtime-2.0`
+
+2. Add `v2.0` catalog/table construction shims
+
+Current code paths that will not directly carry over include:
+
+- shared `CatalogTable` construction in `BaseCatalog`
+- generic table reconstruction in `FlinkGenericTableUtil`
+- tests that directly use `CatalogTable.of(...)`
+
+3. Add `v2.0` API adapters where new catalog surface should be supported
+
+Examples:
+
+- model-related methods on `Catalog`
+- newer catalog descriptor metadata
+- materialized-table-related table metadata if Gravitino chooses to expose it later
+
+4. Re-evaluate provider wrappers independently
+
+Flink `2.0` provider dependencies should not be assumed compatible with the `1.18` to `1.20` wrappers.
+
+### Provider compatibility expectations for Flink `2.0`
+
+As of `March 16, 2026`, the external ecosystem suggests the following:
+
+- Iceberg: `iceberg-flink-runtime-2.0` exists, but only from Iceberg `1.10.0`
+- Paimon: `paimon-flink-2.0` exists
+- JDBC: Flink `2.0` uses the newer JDBC artifact split such as `flink-connector-jdbc-core`, `flink-connector-jdbc-mysql`, and `flink-connector-jdbc-postgres`
+- Hive: a clear Flink `2.0` `flink-connector-hive_2.12` artifact was not found in Maven Central during this analysis
+
+Implication:
+
+- Iceberg and Paimon look feasible for a future `2.0` lane
+- JDBC likely needs provider-specific dependency and wrapper updates
+- Hive may be the highest-risk or blocked provider for a first `2.0` support cut
+
+### Recommended strategy for a future Flink `2.0` effort
+
+Do Flink `2.0` in two stages instead of trying to carry every provider at once.
+
+Stage 1: core compatibility lane
+
+- create `flink-2.0` and `flink-runtime-2.0`
+- make common catalog-store bootstrapping work
+- adapt common table/catalog object construction
+- run unit tests and minimal integration coverage
+
+Stage 2: provider enablement
+
+- validate Iceberg
+- validate Paimon
+- redesign JDBC provider dependency wiring for the new artifact layout
+- validate whether Hive is possible, partial, or must stay unsupported
+
+### What this current implementation should do now for future Flink `2.0`
+
+Even though Flink `2.0` is out of scope now, this implementation should avoid choices that would block it later.
+
+Required now:
+
+- keep all version-sensitive Flink object construction behind hooks
+- avoid hard-coding `CatalogTable.of(...)` deep inside shared logic
+- avoid putting too much provider-specific construction logic into `flink-common`
+- keep provider wrappers movable into version modules if `2.0` requires it
+
+Not required now:
+
+- creating `v2.0` source directories
+- adding `2.0` Gradle modules
+- changing provider support statements for the current release
+
+### Future Flink 2.0 acceptance for a separate follow-up
+
+Flink `2.0` should only be considered supported in a future task when all of the following are true:
+
+1. `:flink-connector:flink-2.0` and `:flink-connector:flink-runtime-2.0` build successfully.
+2. Shared common logic runs correctly through a `v2.0` shim layer.
+3. The supported provider matrix for `2.0` is explicitly documented.
+4. Docs do not imply that all `1.x` providers automatically carry over to `2.0`.
+5. CI has at least one dedicated Flink `2.0` validation path.
+
+## Artifact Naming
+
+Keep the existing naming pattern and extend it by Flink minor:
+
+- `gravitino-flink-1.18_2.12`
+- `gravitino-flink-1.19_2.12`
+- `gravitino-flink-1.20_2.12`
+- `gravitino-flink-connector-runtime-1.18_2.12`
+- `gravitino-flink-connector-runtime-1.19_2.12`
+- `gravitino-flink-connector-runtime-1.20_2.12`
+
+This is already aligned with how the current `1.18` jar is named.
+
+Naming note:
+
+- the connector jar intentionally keeps the existing `gravitino-flink-*` pattern instead of adding an extra `connector` token
+- the runtime jar intentionally keeps the existing `gravitino-flink-connector-runtime-*` pattern
+- this avoids renaming existing published coordinates while still making the Flink minor explicit
+
+## Detailed Implementation Plan
+
+### Phase 1: Mechanical split without behavior change
+
+1. Create `flink-common` and move the current shared implementation into it.
+2. Add `v1.18`, `v1.19`, and `v1.20` version folders.
+3. Create versioned Gradle subprojects and wire them in `settings.gradle.kts`.
+4. Extract the extension hooks needed for future `1.20` catalog API support into `flink-common`.
+5. Make `:flink-connector:flink-1.18` depend on `:flink-connector:flink-common`.
+6. Keep `1.18` behavior unchanged.
+7. Remove the old `:flink-connector:flink` and `:flink-connector:flink-runtime` project entries once `flink-common`, `flink-1.18`, and `flink-runtime-1.18` are wired.
+
+Acceptance for Phase 1:
+
+- `:flink-connector:flink-common:test` passes
+- `:flink-connector:flink-1.18:test -PskipITs` passes
+- `:flink-connector:flink-runtime-1.18:test` passes
+- the old `:flink-connector:flink` and `:flink-connector:flink-runtime` projects are no longer present in `settings.gradle.kts`
+
+### Phase 2: Add 1.19 with zero or near-zero Java divergence
+
+1. Create `:flink-connector:flink-1.19` and `:flink-connector:flink-runtime-1.19`.
+2. Make `:flink-connector:flink-1.19` depend on `:flink-connector:flink-common`.
+3. Use `1.19` dependency aliases.
+4. Compile and run unit tests.
+5. Only add `v1.19/flink/src/main/java` overlay files if compilation proves they are needed.
+6. Run provider runtime linkage validation on the `1.19` dependency graph, not only common baseline tests.
+
+Expected outcome:
+
+- no provider behavior changes
+- probably no Java shim classes needed
+- any provider wrapper that fails runtime linkage moves into the `1.19` module instead of staying in `flink-common`
+
+### Phase 3: Add 1.20 and handle dependency deltas first
+
+1. Create `:flink-connector:flink-1.20` and `:flink-connector:flink-runtime-1.20`.
+2. Make `:flink-connector:flink-1.20` depend on `:flink-connector:flink-common`.
+3. Use `1.20` dependency aliases.
+4. Set Iceberg runtime to a version that actually publishes `iceberg-flink-runtime-1.20`.
+5. Set JDBC connector to `3.3.0-1.20` or another validated `1.20` variant.
+6. Compile against the common jar plus `1.20` deps.
+7. Only if compilation or runtime linking breaks appear, add minimal `v1.20` overlay classes.
+8. Run provider runtime linkage validation on the `1.20` dependency graph before declaring the shared provider wrappers safe.
+
+### Phase 4: Keep SPI resources aligned
+
+Ensure the service registration remains available for each versioned module:
+
+- `META-INF/services/org.apache.flink.table.factories.Factory`
+
+If all factory classes remain in `flink-common`, the service file can remain there and the versioned modules should not contribute a duplicate `Factory` service file.
+
+If a version-specific factory class is introduced, the versioned module's service file should replace the common effective service list for that variant.
+
+Required rule in that case:
+
+- the versioned module must re-list every factory class that should be visible for that variant, including common factories that still apply
+- do not rely on resource merge order between `flink-common` and the versioned module
+- do not ship duplicated factory entries for the same identifier in the final runtime artifact
+
+### Phase 5: Update tests and workflows
+
+Update:
+
+- `.github/workflows/flink-integration-test-action.yml`
+- `.github/workflows/backend-integration-test-action.yml`
+- any other workflow or script that hardcodes `:flink-connector:flink`
+
+Recommended workflow strategy:
+
+- run unit tests for all three Flink variants
+- run runtime jar dependency tests for all three runtime variants
+- run Flink integration tests for all three variants, or at minimum add a matrix input that can target each variant explicitly
+
+### Phase 6: Update docs and build instructions
+
+Update all Flink docs that currently hardcode `1.18`, including at least:
+
+- `docs/flink-connector/flink-connector.md`
+- `docs/flink-connector/flink-catalog-hive.md`
+- `docs/flink-connector/flink-catalog-iceberg.md`
+- `docs/flink-connector/flink-catalog-jdbc.md`
+- `docs/flink-connector/flink-catalog-paimon.md`
+- `docs/how-to-build.md`
+- `docs/index.md`
+
+Docs should:
+
+- state the supported Flink matrix explicitly
+- show the correct runtime jar name pattern per Flink minor
+- mention provider-side dependency differences where users need extra jars
+
+## Testing Plan
+
+### Unit tests
+
+Run for each variant:
+
+```bash
+./gradlew :flink-connector:flink-common:test -PskipITs -PskipDockerTests=false
+./gradlew :flink-connector:flink-1.18:test -PskipITs -PskipDockerTests=false
+./gradlew :flink-connector:flink-1.19:test -PskipITs -PskipDockerTests=false
+./gradlew :flink-connector:flink-1.20:test -PskipITs -PskipDockerTests=false
+```
+
+### `flink-common` baseline test scope
+
+`flink-common:test` runs only against the Flink `1.18` baseline dependency graph.
+
+This means:
+
+- it validates shared logic against the lowest supported API surface
+- it does not by itself prove binary compatibility on `1.19` or `1.20`
+- any regression test that depends on `1.19` or `1.20` linkage should live in the corresponding versioned module
+- versioned module test runs are required to validate the shared bytecode under `1.19` and `1.20` classpaths
+
+### Versioned provider runtime linkage validation
+
+Compilation alone is not enough for `1.19` and `1.20`.
+
+For each versioned module, validation should include at least one provider-level runtime linkage check that proves shared wrappers can be loaded and used on that minor's classpath.
+
+Minimum expectation:
+
+- load or instantiate the provider factory and wrapper path for Hive, Iceberg, JDBC, and Paimon on the versioned module classpath
+- fail the version lane if the run hits `NoSuchMethodError`, `NoClassDefFoundError`, `ClassNotFoundException`, or equivalent constructor/method linkage errors
+- treat real-environment smoke coverage as the stronger confirmation, but still keep a smaller versioned-module linkage check in the repository test lane where practical
+
+### Runtime jar tests
+
+Run for each runtime variant:
+
+```bash
+./gradlew :flink-connector:flink-runtime-1.18:test
+./gradlew :flink-connector:flink-runtime-1.19:test
+./gradlew :flink-connector:flink-runtime-1.20:test
+```
+
+### Integration tests
+
+Run the existing integration suite against each variant in both existing modes:
+
+- `-PtestMode=embedded`
+- `-PtestMode=deploy`
+
+Minimum required coverage:
+
+- Hive catalog
+- JDBC catalog
+- Paimon catalog
+- Iceberg catalog
+- catalog store bootstrap path
+- generic Hive table flow
+
+### Real Flink environment validation
+
+Repository-local integration tests are necessary but not sufficient.
+
+For this delivery, the real-environment lane is a simple smoke-validation lane. In this document, `smoke` means a minimal real-distribution end-to-end check that proves the connector can load, bootstrap, and complete a basic documented catalog flow. It should prove that the versioned runtime jar can work in a real Flink distribution with the basic documented flow, but it does not need to cover the full authentication matrix.
+
+For every supported Flink minor, the connector must also be validated in a real Flink runtime environment to prove that:
+
+- the versioned runtime jar can be loaded by that Flink distribution
+- ServiceLoader-based factory discovery works with the real classloader layout
+- SQL examples from the public documentation actually work against that Flink version
+- Gravitino-managed catalogs can be used end-to-end from the real Flink client/session environment
+
+Current-scope rule:
+
+- require simple authentication mode only
+- do not require OAuth2 validation
+- do not require Kerberos validation
+
+This validation is required for:
+
+- Flink `1.18.x`
+- Flink `1.19.x`
+- Flink `1.20.x`
+
+### Real environment validation modes
+
+At minimum, each supported Flink minor should be validated with one simple real-distribution smoke path. The preferred options are:
+
+1. SQL/TableEnvironment mode
+
+- start a real Flink distribution of the target version
+- place the version-matched Gravitino runtime jar and required provider jars in the Flink classpath
+- create a real `TableEnvironment` or SQL client session
+- verify catalog-store bootstrap and catalog operations
+
+2. SQL client mode
+
+- launch the Flink SQL client from the real distribution
+- configure `table.catalog-store.kind=gravitino`
+- execute representative SQL flows from the connector documentation
+
+At least one of the two modes above must be automated per supported Flink minor in this delivery.
+
+`Deployed cluster` validation is useful but optional for this delivery and can be added later as a stronger compatibility lane.
+
+### Test content sources
+
+The real-environment validation suite should be derived from two sources:
+
+1. Existing integration tests under:
+
+- `flink-connector/flink/src/test/java/org/apache/gravitino/flink/connector/integration/test`
+
+2. Public Flink connector documentation under:
+
+- `docs/flink-connector/flink-connector.md`
+- `docs/flink-connector/flink-catalog-hive.md`
+- `docs/flink-connector/flink-catalog-iceberg.md`
+- `docs/flink-connector/flink-catalog-jdbc.md`
+- `docs/flink-connector/flink-catalog-paimon.md`
+
+The real-environment validation plan should not invent a separate product surface. It should prove that the documented usage and the current IT coverage both work on each supported Flink version.
+
+### Required real-environment smoke scenarios
+
+For every supported Flink minor, validate the following minimum scenario groups in a real Flink environment.
+
+1. Catalog store bootstrap
+
+- `table.catalog-store.kind=gravitino`
+- `table.catalog-store.gravitino.gravitino.uri`
+- `table.catalog-store.gravitino.gravitino.metalake`
+- representative client config pass-through under `table.catalog-store.gravitino.gravitino.client.*`
+
+2. Authentication
+
+- simple mode
+
+3. Hive catalog
+
+- create/use Hive catalog managed by Gravitino
+- create raw Hive table with `'connector'='hive'`
+- create generic table in Hive catalog
+- verify generic table round-trip behavior
+- verify documented native interoperability scenarios where applicable
+
+4. Iceberg catalog
+
+- create/use Iceberg catalog managed by Gravitino
+- create Iceberg table
+- create partitioned Iceberg table
+- validate Iceberg REST or Hive-backed scenarios covered by the current IT suite and docs
+
+5. JDBC catalog
+
+- create/use JDBC catalog managed by Gravitino
+- create database/table
+- insert/select through the documented SQL flow
+- verify version-specific JDBC provider jars are correctly loaded
+
+6. Paimon catalog
+
+- create/use Paimon catalog managed by Gravitino
+- validate at least one supported backend per release test lane
+- cover the documented SQL flow and current IT-backed table operations
+
+7. Common DDL and schema/table lifecycle
+
+- create schema/database
+- alter schema properties
+- create table
+- alter table comment
+- add/drop/rename columns
+- rename table
+- set/reset table properties
+
+### Mapping expectation between docs and tests
+
+The implementation should maintain an explicit mapping between:
+
+- documented examples
+- existing Java integration tests
+- real-environment validation scripts/jobs
+
+At review time, it should be possible to answer:
+
+- which doc example is validated by which automated job
+- which current integration test behavior is also exercised on real Flink `1.18`, `1.19`, and `1.20`
+
+### CI recommendation for real-environment validation
+
+The near-term target is a lightweight Flink-version smoke matrix in CI.
+
+Recommended minimum:
+
+- run repository integration tests per Flink versioned module
+- add at least one simple real-distribution smoke validation job per supported Flink minor
+- keep OAuth2, Kerberos, and broader deployed-cluster validation out of the required PR lane for this delivery
+
+Recommended matrix dimensions:
+
+- Flink version: `1.18`, `1.19`, `1.20`
+- mode: `embedded`, `deploy`, `real-distribution-smoke`
+
+### Real-environment validation acceptance
+
+Support for a Flink minor should not be declared complete until the corresponding simple real Flink environment smoke validation passes for that minor.
+
+### What must be verified across all minors
+
+- `table.catalog-store.kind=gravitino` still boots correctly
+- `CREATE CATALOG` still discovers the right factory
+- schema operations still translate to Gravitino correctly
+- table create/load/alter/drop still translate correctly
+- `TableChange` conversion still behaves the same
+- runtime shadow jars still exclude SLF4J classes
+- the connector works in a real Flink runtime of that minor, not only in repository-local tests
+
+## Acceptance Criteria
+
+The work is done when all of the following are true:
+
+1. Flink `1.18`, `1.19`, and `1.20` each have a dedicated connector module and runtime module.
+2. Shared code lives in `:flink-connector:flink-common`.
+3. Each runtime module produces a correctly versioned runtime jar.
+4. Existing behavior for the current `1.18` connector is preserved.
+5. Unit tests pass for the common module and all supported Flink minors.
+6. Integration tests can be run against all supported Flink minors.
+7. Simple real Flink environment smoke validation passes for all supported Flink minors.
+8. User docs no longer claim that only Flink `1.18` is supported.
+
+## Risks and Review Focus
+
+### Risk 1: Iceberg version drift
+
+`1.20` cannot reuse the current global Iceberg connector version if that version is `1.6.1`.
+
+Review focus:
+
+- verify the chosen Iceberg version exists for all intended Flink minors
+- verify the chosen version does not accidentally force Spark connector changes unless that is intentional
+
+### Risk 2: CI time growth
+
+Tripling the Flink matrix will increase test time.
+
+Review focus:
+
+- whether all three variants run on every PR
+- whether full integration tests should be split into a matrix or run selectively
+
+### Risk 3: Hidden provider-specific API drift
+
+Even if Flink SPI is stable, provider artifacts may drift across minors.
+
+Review focus:
+
+- Iceberg factory construction
+- Paimon factory construction
+- JDBC catalog factory/runtime
+- Hive catalog helper behavior
+
+### Risk 4: Mechanical refactor regressions
+
+Moving shared sources into `flink-common` can break:
+
+- service resource lookup
+- test resource lookup
+- Gradle source set wiring
+
+Review focus:
+
+- resource paths
+- service registration
+- test reports and workflow artifact upload paths
+
+### Risk 5: False confidence from `compileOnly`
+
+`compileOnly` may make the module graph look clean while still leaving runtime ABI problems.
+
+Review focus:
+
+- whether `flink-common` directly references constructors or methods whose signatures differ by minor
+- whether provider wrappers should stay in `flink-common` or move into versioned modules
+
+### Risk 6: Provider-level runtime ABI drift across `1.18` to `1.20`
+
+Even if the Flink SPI remains largely stable, the native provider connectors can still drift in ways that break shared wrappers at runtime.
+
+Concrete examples include:
+
+- `HiveCatalog` constructor or helper signature drift across Hive connector variants bundled with different Flink minors
+- `org.apache.iceberg.flink.FlinkCatalog` constructor or factory drift across `iceberg-flink-runtime-1.18`, `1.19`, and `1.20`
+- `JdbcCatalog` constructor drift across JDBC connector minors such as `3.2.0-1.18` and `3.3.0-1.20`
+
+Review focus:
+
+- whether shared provider wrappers only use methods and constructors proven stable across the supported minors
+- whether provider factories can be loaded and instantiated on each versioned classpath
+- whether a provider should be moved out of `flink-common` as soon as runtime linkage checks fail
+
+## AI Guardrails
+
+If an AI agent implements this spec, it should follow these rules:
+
+1. Treat the current `1.18` connector as the behavior baseline.
+2. Build `flink-common` first against the baseline Flink `1.18` API.
+3. Add extension hooks in `flink-common` before adding any `1.20`-specific implementation.
+4. Introduce version-specific Java shims only if compilation, tests, or runtime linking require them.
+5. Do not use reflection unless a compile-time version shim is impossible.
+6. Do not add version-specific Flink catalog classes unless compilation, tests, or runtime ABI checks require them.
+7. Do not rename factory identifiers or connector property keys.
+8. Keep the SPI service file content identical unless a version-specific factory class is introduced, and if one is introduced the versioned module must own the full final service list for that variant.
+9. Update docs and workflows in the same change set as the code split.
+
+## Expected Touched Areas
+
+At minimum, expect changes in:
+
+- `settings.gradle.kts`
+- `gradle/libs.versions.toml`
+- `flink-connector/`
+- `.github/workflows/flink-integration-test-action.yml`
+- `.github/workflows/backend-integration-test-action.yml`
+- `docs/flink-connector/*.md`
+- `docs/how-to-build.md`
+- `docs/index.md`
+
+## Recommended Execution Order
+
+1. Create `flink-common`.
+2. Move current shared implementation into `flink-common`.
+3. Extract extension hooks for future `1.20` catalog API support.
+4. Create versioned Gradle projects.
+5. Make `1.18` green again with `flink-common` in place.
+6. Add `1.19` and keep it common-backed if possible.
+7. Add `1.20` and solve dependency-version issues first.
+8. Add minor-specific shims only if compilation, tests, or runtime ABI checks prove they are necessary.
+9. Update CI.
+10. Update docs.

--- a/ai-code-spec/flink_multi_version_support_spec.md
+++ b/ai-code-spec/flink_multi_version_support_spec.md
@@ -17,179 +17,207 @@
   under the License.
 -->
 
-# Gravitino Flink Connector Multi-Version Support Spec
+# Gravitino Flink Connector Versioned Architecture Spec
 
 | Field | Value |
 | --- | --- |
 | Status | Proposal |
 | Owner | FANNG |
-| Created | 2026-03-16 |
+| Created | 2026-03-25 |
 | Target Release | 1.3.0 |
 | Related Issue | [#9710](https://github.com/apache/gravitino/issues/9710) |
 | Related PR | N/A |
 
 ## Goal
 
-Add maintained support for Flink `1.18`, `1.19`, and `1.20` with versioned runtime artifacts, similar to the Spark connector release model.
+Define the target architecture for versioned Gravitino Flink connector support and the staged
+delivery plan for Flink `1.18`, `1.19`, and `1.20`.
 
-The output of this work should be:
+The final output of this work should be:
 
-- one shared `flink-common` module
+- one shared `flink-common` module for stable base logic
 - one connector module per supported Flink minor
 - one runtime shadow jar per supported Flink minor
-- CI and docs that explicitly cover the supported Flink matrix
+- one set of version-specific catalog and factory entry classes per supported Flink minor
+- one set of version-specific integration-test entry classes per supported Flink minor
+- typed version compatibility hooks without reflection-based provider dispatch
 
 ## Non-Goals
 
-- Supporting Flink `1.17` or Flink `2.x`
-- Changing connector behavior beyond what is required for multi-version compatibility
-- Adding new connector features such as materialized table support
-- Reworking provider semantics for Hive, Iceberg, JDBC, or Paimon
-- Adding OAuth2 or Kerberos real-environment validation to the required test matrix for this delivery
-- Producing one universal jar that works across all Flink minors
+- Supporting Flink `1.17`
+- Supporting Flink `2.x` in this delivery
+- Producing one universal jar for all Flink minors
+- Adding new connector features unrelated to version compatibility
+- Reworking catalog semantics beyond what is needed for versioned support
+- Depending on a smoke helper shell script as part of the long-term validation model
 
-Note: Flink `2.0` support is explicitly out of scope for this delivery. It should be treated as a larger follow-up compatibility lane rather than a small extension of the `1.18` to `1.20` work, but the module split and extension hooks introduced here should keep a clean path for that future effort. Follow-up implementation findings for that lane are recorded in [flink_2_0_adaptation_notes.md](flink_2_0_adaptation_notes.md).
+Note: Flink `2.0` support remains out of scope for the current staged delivery. The architecture in
+this spec is intentionally `2.x`-ready, but the actual `2.0` lane should be delivered as a
+separate follow-up.
 
 ## Current Connector Model
 
-The current Flink connector is not a generic table runtime connector. It is primarily a Flink `CatalogStore` plus a set of Flink `Catalog` implementations that proxy metadata operations to Gravitino and delegate data/table behavior to native Flink ecosystem catalogs.
+The Gravitino Flink connector is not a generic table runtime connector. It is primarily:
 
-### Main Flink Interaction Points
+- a Flink `CatalogStore`
+- a set of Flink `Catalog` wrappers around Gravitino metadata
+- a bridge from Gravitino metadata operations to native Flink ecosystem catalogs
+
+The main interaction points are:
 
 1. Catalog store bootstrapping
 
 - `flink-connector/flink-common/src/main/java/org/apache/gravitino/flink/connector/store/GravitinoCatalogStoreFactory.java`
 - `flink-connector/flink-common/src/main/java/org/apache/gravitino/flink/connector/store/GravitinoCatalogStore.java`
 
-These classes integrate with:
-
-- `CatalogStoreFactory`
-- `CatalogStore`
-- `CatalogDescriptor`
-- `FactoryUtil.createCatalogStoreFactoryHelper(...)`
-- ServiceLoader discovery of Flink `Factory`
-
-2. Catalog SPI implementations
+2. Shared base catalog SPI implementation
 
 - `flink-connector/flink-common/src/main/java/org/apache/gravitino/flink/connector/catalog/BaseCatalog.java`
 - `flink-connector/flink-common/src/main/java/org/apache/gravitino/flink/connector/catalog/BaseCatalogFactory.java`
 
-These classes integrate with:
+3. Provider-specific wrappers
 
-- `AbstractCatalog`
-- `CatalogBaseTable`
-- `CatalogTable`
-- `ResolvedCatalogBaseTable`
-- `ResolvedCatalogTable`
-- `CatalogDatabase`
-- `ObjectPath`
-- Flink `TableChange`
-- Flink `Schema`
+- Hive
+- Iceberg
+- JDBC
+- Paimon
 
-3. Provider-specific wrappers around native Flink ecosystem catalogs
+4. Flink-to-Gravitino conversion helpers
 
-- Hive: `GravitinoHiveCatalog`, `GravitinoHiveCatalogFactory`
-- Iceberg: `GravitinoIcebergCatalog`, `GravitinoIcebergCatalogFactory`
-- JDBC: `GravitinoJdbcCatalog`, `GravitinoJdbcCatalogFactory`
-- Paimon: `GravitinoPaimonCatalog`, `GravitinoPaimonCatalogFactory`
-
-These delegate to:
-
-- `org.apache.flink.table.catalog.hive.HiveCatalog`
-- `org.apache.iceberg.flink.FlinkCatalog`
-- `org.apache.flink.connector.jdbc.catalog.JdbcCatalog`
-- `org.apache.paimon.flink.FlinkCatalogFactory`
-
-4. Flink-to-Gravitino conversion utilities
-
-- `TypeUtils`
-- `TableUtils`
 - `CatalogPropertiesConverter`
 - `SchemaAndTablePropertiesConverter`
 - `PartitionConverter`
+- `TypeUtils`
 - `FlinkGenericTableUtil`
-
-These are where Flink schema/type/property semantics are translated into Gravitino APIs.
-
-## Findings From Code Review
-
-### What the connector actually depends on
-
-The connector depends much more on the Flink Table/Catalog SPI than on the DataStream runtime. The version-sensitive surface is therefore:
-
-- Flink table/catalog API jars
-- native provider jars tied to the Flink minor
-- runtime shadow jar assembly
-- tests and workflows that hardcode a single module path today
-
-### Flink SPI stability from 1.18 to 1.20
-
-Reviewing local Flink sources shows that the APIs used by the current connector are mostly stable across `release-1.18`, `release-1.19`, and `origin/release-1.20`.
-
-Observed changes are mostly additive:
-
-- `CatalogDescriptor` gained optional comment support in `1.20`
-- `CatalogTable` gained a builder and distribution-related API in `1.20`
-- `CatalogPropertiesUtil` gained materialized-table serialization in `1.20`
-- `Catalog` gained more documentation and some additional default-method-oriented expectations in `1.20`
-
-Important point: the connector currently uses APIs that remain present and source-compatible across `1.18`, `1.19`, and `1.20`, including:
-
-- `CatalogStoreFactory`
-- `CatalogDescriptor.of(name, configuration)`
-- `CatalogPropertiesUtil.serializeCatalogTable(...)`
-- `CatalogPropertiesUtil.deserializeCatalogTable(...)`
-- `CatalogTable.of(...)`
-- `ResolvedCatalogBaseTable`
-- `TableChange` classes used in `BaseCatalog`
-
-Conclusion: the Java implementation is likely to stay almost entirely shared. The hard part is the build and dependency matrix, not large API shims.
-
-### External dependency constraints are stricter than Flink SPI changes
-
-As of `March 16, 2026`, Maven Central metadata shows:
-
-- `org.apache.iceberg:iceberg-flink-runtime-1.20` starts at Iceberg `1.7.0`
-- `org.apache.iceberg:iceberg-flink-runtime-1.19` includes Iceberg `1.6.1`
-- `org.apache.iceberg:iceberg-flink-runtime-1.18` includes Iceberg `1.6.1`
-- `org.apache.paimon:paimon-flink-1.18`, `1.19`, and `1.20` all include Paimon `1.2.0`
-- `org.apache.flink:flink-connector-jdbc` publishes `3.2.0-1.18`, `3.2.0-1.19`, `3.3.0-1.19`, and `3.3.0-1.20`
-
-This means the current single global connector dependency model is not sufficient:
-
-- a single global `flink = 1.18.0` is not sufficient
-- a single global `flinkjdbc = 3.2.0-1.18` is not sufficient
-- a single global `iceberg4connector = 1.6.1` is not sufficient for Flink `1.20`
-
-This is the main reason the connector must be split by Flink minor.
 
 ## Design Decision
 
-Follow the Spark connector model more directly:
+Follow the Spark connector model more directly, but adapted to Flink SPI usage:
 
-- introduce a compiled `:flink-connector:flink-common` module
-- keep `:flink-connector:flink-1.18`, `:flink-connector:flink-1.19`, and `:flink-connector:flink-1.20` as thin versioned modules
-- keep one runtime shadow module per Flink minor
+- keep shared base behavior in `flink-common`
+- move version selection into version-specific catalog and factory entry classes
+- give each supported Flink minor its own SPI service descriptor
+- give each supported Flink minor its own integration-test entry classes
+- keep compatibility logic typed and version-scoped instead of using shared reflection helpers
 
-### Why this is acceptable
+This means Flink version support is modeled as:
 
-This is workable if `flink-common` is treated as a binary-compatible common layer compiled against the lowest supported baseline and if version-sensitive code is isolated.
+- shared base implementation
+- version-specific entry layers
+- version-specific compatibility implementations
+- version-specific integration-test entry classes
 
-Recommended rule set:
+## Final Architecture
 
-- compile `flink-common` against Flink `1.18`
-- use `compileOnly` for Flink/provider dependencies in `flink-common`
-- allow versioned `flink-1.18`, `flink-1.19`, `flink-1.20` modules to add small overlays for minor-specific APIs
-- keep runtime packaging and test execution version-specific
+### Shared module
 
-This intentionally differs from the Spark connector approach that compiles the common layer against the latest Spark minor. For Flink `1.18` to `1.20`, the catalog/table API drift is mostly additive, so compiling `flink-common` against the lowest supported baseline is the safer default because it reduces accidental references to newer API only present in `1.19` or `1.20`.
+`flink-common` contains only stable shared logic:
 
-Important clarification: `compileOnly` avoids bundling dependencies, but it does not solve binary compatibility by itself. The bytecode in `flink-common` is still compiled against a concrete API surface. Therefore:
+- shared base catalog implementations
+- shared base factory implementations
+- shared property, type, and partition conversion logic
+- shared catalog-store implementation
+- shared integration-test base classes
+- shared compatibility interfaces and baseline helpers
 
-- `flink-common` must only use API and provider methods that remain binary-compatible across `1.18`, `1.19`, and `1.20`
-- anything version-sensitive must move into the versioned modules
+Representative classes in `flink-common`:
 
-## Proposed Project Layout
+- `BaseCatalog`
+- `BaseCatalogFactory`
+- `GravitinoCatalogStore`
+- `CatalogPropertiesConverter`
+- `SchemaAndTablePropertiesConverter`
+- `PartitionConverter`
+- `TypeUtils`
+- `CatalogCompat`
+- `DefaultCatalogCompat`
+
+### Versioned connector modules
+
+Each Flink minor owns its own connector entry module:
+
+- `:flink-connector:flink-1.18`
+- `:flink-connector:flink-1.19`
+- `:flink-connector:flink-1.20`
+
+Each version module contains:
+
+- version-specific catalog entry classes
+- version-specific factory entry classes
+- version-specific compatibility implementation
+- version-specific service descriptor
+- version-specific integration-test entry classes
+
+Examples:
+
+- `GravitinoHiveCatalogFlink118`
+- `GravitinoIcebergCatalogFlink118`
+- `GravitinoJdbcCatalogFlink118`
+- `GravitinoPaimonCatalogFlink118`
+- `CatalogCompatFlink118`
+
+The same pattern applies to `1.19` and `1.20`.
+
+### Versioned runtime modules
+
+Each supported Flink minor owns its own runtime jar:
+
+- `:flink-connector:flink-runtime-1.18`
+- `:flink-connector:flink-runtime-1.19`
+- `:flink-connector:flink-runtime-1.20`
+
+Each runtime module:
+
+- depends on the matching versioned connector module
+- builds a shadow jar for that Flink minor
+- merges service descriptors from common and versioned modules
+- validates runtime-jar contents in dedicated runtime tests
+
+## Compatibility Model
+
+### Compatibility must be typed and versioned
+
+Compatibility is expressed through version-specific typed classes, not shared reflection-heavy
+utilities.
+
+Rules:
+
+- version-specific provider behavior belongs in version-specific catalog and factory classes
+- version-specific Flink API adaptation belongs in version-specific `CatalogCompat`
+  implementations
+- shared compatibility interfaces may live in `flink-common`
+- reflection should not be the default compatibility mechanism
+
+### Recommended boundary
+
+Shared:
+
+- `CatalogCompat` interface
+- `DefaultCatalogCompat` for the lowest supported baseline if useful
+
+Versioned:
+
+- `CatalogCompatFlink118`
+- `CatalogCompatFlink119`
+- `CatalogCompatFlink120`
+
+`BaseCatalog` should call a version hook such as `catalogCompat()` instead of deciding version
+behavior itself.
+
+### Provider compatibility rule
+
+Provider differences should be expressed in version-specific provider classes whenever possible.
+
+Examples:
+
+- JDBC factory selection for Flink `1.19` and `1.20`
+- Iceberg factory path differences
+- Hive version-specific validation behavior
+- version-specific test expectation overrides
+
+Do not centralize provider version selection in one shared compatibility utility.
+
+## Project Layout
 
 ```text
 flink-connector/
@@ -199,38 +227,41 @@ flink-connector/
     src/main/resources/...
     src/test/java/...
     src/test/resources/...
+
   v1.18/
-    build.gradle.kts
     flink/
-      build.gradle.kts          # depends on :flink-connector:flink-common
-      src/main/java/...         # only if a 1.18-only shim is needed
-      src/test/java/...         # only if a 1.18-only test is needed
+      build.gradle.kts
+      src/main/java/...
+      src/main/resources/...
+      src/test/java/...
     flink-runtime/
       build.gradle.kts
       src/test/java/...
+
   v1.19/
-    build.gradle.kts
     flink/
       build.gradle.kts
       src/main/java/...
+      src/main/resources/...
       src/test/java/...
     flink-runtime/
       build.gradle.kts
       src/test/java/...
+
   v1.20/
-    build.gradle.kts
     flink/
       build.gradle.kts
       src/main/java/...
+      src/main/resources/...
       src/test/java/...
     flink-runtime/
       build.gradle.kts
       src/test/java/...
 ```
 
-### Gradle project names
+## Gradle Project Naming
 
-Add these projects in `settings.gradle.kts` under the existing Scala `2.12` guard:
+Under the existing Scala `2.12` guard, the target project set is:
 
 - `:flink-connector:flink-common`
 - `:flink-connector:flink-1.18`
@@ -240,854 +271,173 @@ Add these projects in `settings.gradle.kts` under the existing Scala `2.12` guar
 - `:flink-connector:flink-1.20`
 - `:flink-connector:flink-runtime-1.20`
 
-Current-scope Scala note:
+The old single-version projects:
 
-- Flink `1.18`, `1.19`, and `1.20` in this delivery all use Scala `2.12` artifacts
-- the module layout and publication names should therefore consistently keep the `_2.12` suffix
-- supporting a different Scala suffix is out of scope for this change and should be treated as a separate compatibility question
+- `:flink-connector:flink`
+- `:flink-connector:flink-runtime`
 
-### Project migration rule
+should be removed once the staged migration is complete.
 
-After Phase 1:
+## Staged Delivery Plan
 
-- `:flink-connector:flink` is replaced by `:flink-connector:flink-common` plus `:flink-connector:flink-1.18`
-- `:flink-connector:flink-runtime` is replaced by `:flink-connector:flink-runtime-1.18`
-- the old `:flink-connector:flink` and `:flink-connector:flink-runtime` entries should be removed from `settings.gradle.kts`
-- do not keep the old project names as Gradle aliases because that makes publication, workflow targeting, and review reasoning ambiguous
-- `settings.gradle.kts` should map the new project names to their explicit project directories
+### Phase 1: framework split plus Flink 1.18 baseline
 
-### Module responsibility split
+This phase establishes the architecture and one supported baseline lane.
 
-`flink-common` should contain the implementation that is expected to remain common across all supported Flink minors, for example:
+Scope:
 
-- `catalog/BaseCatalog.java`
-- `catalog/BaseCatalogFactory.java`
-- `catalog/GravitinoCatalogManager.java`
-- property/type/partition conversion utilities
-- `GravitinoCatalogStore` and `GravitinoCatalogStoreFactory`
-- provider classes only if their used APIs are confirmed binary-compatible across `1.18` to `1.20`
+- introduce `flink-common`
+- introduce `flink-1.18`
+- introduce `flink-runtime-1.18`
+- move shared code from the old `flink` module into `flink-common`
+- add version-specific `1.18` catalog, factory, compat, and integration-test entry classes
+- move `1.18` CI to run from `:flink-connector:flink-1.18:test`
+- ensure the `1.18` runtime jar merges service descriptors correctly
+- remove dependence on a smoke helper script
 
-Versioned `flink-*` modules should contain:
+Outcome:
 
-- the published version-specific connector artifact
-- minor-specific factory/catalog overlay classes if needed
-- minor-specific SPI resource files if needed
-- minor-specific tests if needed
+- the framework is reviewable with one concrete Flink baseline
+- later Flink minors can be added as follow-up PRs instead of in the same refactor
 
-### Provider placement matrix
+### Phase 2: add Flink 1.19 support
 
-The initial provider split should be reviewed explicitly instead of relying only on a general rule.
+Scope:
 
-| Provider | Initial placement | Why | Required validation | Move trigger |
-| --- | --- | --- | --- | --- |
-| Hive | start in `flink-common` only if shared code uses constructors and helpers that remain ABI-compatible | current wrapper logic is mostly shared, but Hive connector drift is historically the most likely provider risk inside `1.18` to `1.20` | compile on all versioned classpaths, instantiate factory/wrapper, and run real-environment smoke | `NoSuchMethodError`, `ClassNotFoundException`, compile break, or provider-specific test failure |
-| Iceberg | start in `flink-common` with versioned runtime dependencies | the wrapper logic is thin, but `iceberg-flink-runtime-*` versions must be matched by Flink minor | compile on all versioned classpaths, instantiate factory/wrapper, and run Iceberg smoke | constructor/method drift or runtime linkage failure on versioned artifact |
-| JDBC | start in `flink-common` with versioned connector dependencies | the wrapper is thin, but JDBC connector artifacts already differ by Flink minor | compile on all versioned classpaths, instantiate factory/wrapper, and run JDBC smoke | constructor drift, artifact layout drift, or runtime linkage failure |
-| Paimon | start in `flink-common` with versioned runtime dependencies | Paimon `1.2.0` is available for `1.18` to `1.20`, so a shared wrapper is a reasonable first cut | compile on all versioned classpaths, instantiate factory/wrapper, and run Paimon smoke | factory API drift or runtime linkage failure |
+- add `flink-1.19`
+- add `flink-runtime-1.19`
+- add `CatalogCompatFlink119`
+- add `1.19` version-specific catalog, factory, and integration-test classes
+- absorb `1.19` provider differences into `1.19` version classes
+- extend CI and runtime validation to `1.19`
 
-This gives:
+### Phase 3: add Flink 1.20 support
 
-- Spark-aligned repository structure
-- one shared compiled jar
-- one dependency graph per Flink minor at the published connector/runtime layer
-- a clean place for minor-specific shims if binary compatibility breaks appear later
+Scope:
 
-## Dependency Matrix
+- add `flink-1.20`
+- add `flink-runtime-1.20`
+- add `CatalogCompatFlink120`
+- add `1.20` version-specific catalog, factory, and integration-test classes
+- absorb `1.20` provider and API differences into `1.20` version classes
+- extend CI and runtime validation to `1.20`
 
-Introduce version-specific aliases in `gradle/libs.versions.toml`.
+## Testing Strategy
 
-Minimum required split:
+### Shared tests
 
-- `flink18`, `flink19`, `flink20`
-- `flinkJdbc18`, `flinkJdbc19`, `flinkJdbc20`
-- `iceberg4flink18`, `iceberg4flink19`, `iceberg4flink20`
+`flink-common` should contain:
 
-Paimon can stay shared if the chosen version works for all three minors, but using explicit aliases is still cleaner:
+- shared unit tests for common logic
+- shared integration-test base classes
+- shared test resources
 
-- `paimon4flink18`, `paimon4flink19`, `paimon4flink20`
+It should not be treated as the final execution target for version validation.
 
-Also introduce version-specific library aliases where necessary so the versioned modules do not depend on one global Flink connector version.
+### Versioned tests
 
-### Recommended baseline
+Each versioned connector module should contain:
 
-Keep the dependency decision explicit per Flink minor instead of trying to force one global value.
-
-Example direction:
-
-| Variant | Flink | JDBC connector | Iceberg runtime | Paimon runtime |
-| --- | --- | --- | --- | --- |
-| `1.18` | `1.18.x` | `3.2.0-1.18` | `1.6.1` or newer | `1.2.0` |
-| `1.19` | `1.19.x` | `3.2.0-1.19` or `3.3.0-1.19` | `1.6.1` or newer | `1.2.0` |
-| `1.20` | `1.20.x` | `3.3.0-1.20` | `>= 1.7.0` | `1.2.0` |
-
-Important rule: do not keep `iceberg4connector = 1.6.1` globally if Flink `1.20` is introduced.
-
-## `flink-common` Dependency Policy
-
-`flink-common` should compile against the lowest supported baseline, recommended as Flink `1.18`.
-
-Recommended dependency posture for `flink-common`:
-
-- `compileOnly` on Flink `1.18` table/catalog APIs
-- `compileOnly` on provider baseline artifacts used directly by shared code
-- `testImplementation` on the same baseline to keep common unit tests executable
-
-Versioned modules should then use their own version-specific dependencies:
-
-- `:flink-connector:flink-1.18` depends on `:flink-connector:flink-common` and Flink `1.18` deps
-- `:flink-connector:flink-1.19` depends on `:flink-connector:flink-common` and Flink `1.19` deps
-- `:flink-connector:flink-1.20` depends on `:flink-connector:flink-common` and Flink `1.20` deps
-
-### What `compileOnly` does and does not solve
-
-What it helps with:
-
-- keeps `flink-common` thin
-- avoids bundling Flink/provider jars in the common artifact
-- matches the Spark connector structure more closely
-
-What it does not help with:
-
-- method signature drift
-- constructor signature drift
-- removed classes
-- changed inheritance hierarchies
-
-Therefore reviewers should treat `compileOnly` as a packaging choice, not a compatibility mechanism.
-
-## Extension Model For Newer Catalog APIs
-
-Version-specific Flink catalog classes are exception-based, not default-based.
-
-That means:
-
-- do not create `GravitinoHiveCatalogFlink118`, `GravitinoHiveCatalogFlink119`, `GravitinoHiveCatalogFlink120` by default
-- keep provider catalog classes in `flink-common` as long as their used API remains compatible
-- add version-specific classes only when compilation, tests, or runtime ABI checks prove they are necessary
-
-### How Flink `1.20`-only catalog APIs should be supported
-
-If Flink `1.20` adds catalog-related API that should be supported, the implementation should prefer the following escalation order.
-
-1. Helper-level shim
-
-Use this when the difference is object construction or metadata enrichment.
+- version-specific integration-test entry classes
+- version-specific expectation overrides where needed
+- real execution against that Flink minor's classpath
 
 Examples:
 
-- `CatalogDescriptor` adds comment support
-- `CatalogTable` adds builder/distribution support
-- `CatalogPropertiesUtil` adds new serializable catalog metadata
+- `GravitinoCatalogManagerIT118`
+- `FlinkHiveCatalogIT118`
+- `FlinkHiveKerberosClientIT118`
+- `FlinkIcebergRestCatalogIT118`
+- `FlinkJdbcMysqlCatalogIT118`
+- `FlinkPaimonLocalFileSystemBackendIT118`
 
-Recommended approach:
+The same pattern should be used for later versions.
 
-- keep the shared algorithm in `flink-common`
-- move the version-sensitive object creation into an overridable helper
-- override that helper in `:flink-connector:flink-1.20`
+### Runtime tests
 
-2. Base-layer shim
+Each runtime module should validate:
 
-Use this when the difference affects the common Gravitino catalog bridge rather than one provider.
+- runtime-jar dependency boundaries
+- service descriptor merge correctness
+- presence of common and version-specific factories in the final shadow jar
 
-Examples:
+### CI rule
 
-- new default methods on Flink `Catalog`
-- new table metadata conversion logic needed for all providers
-- new catalog-store descriptor assembly logic
-
-Recommended approach:
-
-- add `BaseCatalog120`, `GravitinoCatalogStore120`, or similar thin adaptors in `v1.20`
-- keep provider classes reusing the base-layer shim instead of duplicating logic
-
-3. Provider-level shim
-
-Use this only when the drift is provider-specific.
+CI should run concrete version module tasks directly.
 
 Examples:
 
-- Hive-specific constructor or factory behavior changes
-- Iceberg/Paimon/JDBC wrapper behavior changes that do not affect the other providers
+- `:flink-connector:flink-1.18:test`
+- later `:flink-connector:flink-1.19:test`
+- later `:flink-connector:flink-1.20:test`
 
-Recommended approach:
+Do not rely on a dedicated smoke helper shell script for version validation.
 
-- introduce the smallest possible `v1.20` provider-specific subclass or factory class
-- do not fork all provider classes just because one provider changed
+## Runtime Packaging Rules
 
-### Hook points that should be pre-created in this implementation
+Runtime shadow jars must merge factory service descriptors from:
 
-To make later `1.20` catalog API support cheap, this implementation should add explicit extension hooks now, even if the initial `1.18`, `1.19`, and `1.20` behavior is identical.
+- `flink-common`
+- the matching versioned connector module
 
-Recommended hooks:
+The final runtime jar for a supported Flink minor must expose:
 
-1. Catalog descriptor construction hook
+- `GravitinoCatalogStoreFactory`
+- the version-specific catalog factories for that minor
 
-Location:
+This must be validated in runtime-jar tests.
 
-- `GravitinoCatalogStore`
+## Provider Strategy
 
-Purpose:
+### Hive
 
-- allow `v1.20` to build `CatalogDescriptor` with newer metadata such as comment support without rewriting store logic
+- shared Hive base logic stays in `flink-common`
+- version-specific entry classes own minor-specific behavior
+- version-specific test classes may override assertions where validation behavior differs
 
-Example shape:
+### Iceberg
 
-```java
-protected CatalogDescriptor newCatalogDescriptor(
-    String catalogName,
-    Configuration configuration) {
-  return CatalogDescriptor.of(catalogName, configuration);
-}
-```
+- shared conversion and base behavior stays in `flink-common`
+- version-specific catalog and factory classes own version-specific create paths
+- REST and deploy-path validation should run through versioned integration-test classes
 
-Then `v1.20` can override if newer `CatalogDescriptor` fields should be populated.
+### JDBC
 
-2. Flink table construction hook
+- JDBC minor-version differences are expected
+- JDBC provider selection and factory path differences should live in versioned classes
+- do not rely on one shared JDBC compatibility utility for version behavior
 
-Location:
+### Paimon
 
-- `BaseCatalog`
+- expected to stay relatively thin
+- still gets versioned catalog, factory, and integration-test entry classes for consistency
 
-Purpose:
+## Documentation Strategy
 
-- isolate the version-sensitive creation of `CatalogTable` / `CatalogBaseTable`
-- make it possible for `v1.20` to switch from `CatalogTable.of(...)` to builder-based construction or set newer metadata such as distribution
+Implementation-facing documentation should describe:
 
-Example shape:
+- the final versioned architecture
+- the staged delivery plan
+- the rule that each supported Flink minor owns its own entry classes and integration tests
 
-```java
-protected CatalogTable newCatalogTable(
-    org.apache.flink.table.api.Schema schema,
-    String comment,
-    List<String> partitionKeys,
-    Map<String, String> options) {
-  return CatalogTable.of(schema, comment, partitionKeys, options);
-}
-```
-
-3. Generic table deserialize/serialize hook
-
-Location:
-
-- `FlinkGenericTableUtil`
-- or a thin helper owned by `BaseCatalog`
-
-Purpose:
-
-- isolate future changes in `CatalogPropertiesUtil` behavior
-- make it possible to support newer Flink catalog-table metadata without touching the shared alter/create flow
-
-4. Factory creation hook
-
-Location:
-
-- provider factories in `flink-common`
-
-Purpose:
-
-- allow a versioned module to swap in a version-specific factory class only if needed
-- keep ServiceLoader wiring minimal
-
-### What must be done now versus later
-
-Do now in this multi-version support change:
-
-- add the extension hooks above in `flink-common`
-- keep the default implementation behavior identical to the current connector
-- leave `v1.20` free to override those hooks later
-
-Do later only when required by real Flink `1.20` API usage:
-
-- add `v1.20`-specific subclasses
-- enrich descriptors/tables with `1.20`-only metadata
-- implement new `Catalog` methods that need non-default behavior
-
-## Future Flink 2.0 Compatibility Lane
-
-Flink `2.0` is still out of scope for this delivery, but later implementation and debugging work has already confirmed the shape of that compatibility lane. This section records those findings so the future follow-up does not need to rediscover the same breakpoints.
-
-Detailed implementation notes for that follow-up are documented in [flink_2_0_adaptation_notes.md](flink_2_0_adaptation_notes.md).
-
-### Confirmed architectural conclusion
-
-Yes, this architecture can support Flink `2.0`, with one important caveat:
-
-- the overall `flink-common + versioned modules + versioned runtime modules` architecture is still valid
-- but Flink `2.0` must be treated as a new major compatibility lane, not as just another `1.x` minor
-
-In practice, this means:
-
-- add `:flink-connector:flink-2.0`
-- add `:flink-connector:flink-runtime-2.0`
-- add a real `v2.0` shim layer at the version-sensitive Flink API boundaries
-- do not assume `flink-common` bytecode compiled against `1.18` will run unchanged on `2.0`
-
-### Confirmed breakpoints from real implementation work
-
-Later Flink `2.0` implementation and validation work confirmed that the following are real breakpoints, not just theoretical risks:
-
-- `CatalogTable.of(...)` is no longer available; `CatalogTable.newBuilder()` must be supported
-- `CatalogPropertiesUtil.serializeCatalogTable(...)` requires a newer compatibility path in the `2.0` lane
-- Iceberg's `FlinkCatalogFactory` changed from `createCatalog(String, Map<String, String>)` to `createCatalog(CatalogFactory.Context)`
-- Flink `2.0` JDBC artifacts and class packages changed, so direct `1.x` imports are not stable enough
-- real Flink `2.0.x` distributions expose stricter runtime behavior than repo-local tests, especially for Iceberg REST URI handling and JDBC driver/classloader visibility
-
-This confirms that Flink `2.0` needs both:
-
-- versioned modules and dependencies
-- narrow compatibility helpers in shared code
-
-### Minimum code changes required for a future Flink `2.0` follow-up
-
-At minimum, future Flink `2.0` support should include all of the following:
-
-1. Add versioned modules
-
-- `:flink-connector:flink-2.0`
-- `:flink-connector:flink-runtime-2.0`
-
-2. Add shared compatibility helpers at the actual breakpoints
-
-The later implementation work showed that these hooks are required:
-
-- shared `CatalogTable` construction in `BaseCatalog`
-- generic table serialization/deserialization in `FlinkGenericTableUtil`
-- Iceberg factory creation in `GravitinoIcebergCatalog` and `GravitinoIcebergCatalogFactory`
-- JDBC factory creation in `GravitinoJdbcCatalog`
-- `ServiceLoader` discovery hardening in `GravitinoCatalogStore`
-- tests that directly used `CatalogTable.of(...)`
-
-3. Add `v2.0` API adapters where new catalog surface should be supported
-
-Examples:
-
-- model-related methods on `Catalog`
-- newer catalog descriptor metadata
-- materialized-table-related table metadata if Gravitino chooses to expose it later
-
-4. Re-evaluate provider wrappers independently
-
-Flink `2.0` provider dependencies should not be assumed compatible with the `1.18` to `1.20` wrappers even when the core catalog SPI is bridged.
-
-### Provider status from current Flink `2.0` experiments
-
-The later Flink `2.0` work produced a more concrete provider picture than this spec originally had:
-
-| Area | Repo-level status | Real external `2.0.1` status | Notes |
-| --- | --- | --- | --- |
-| Core catalog lane | validated | indirectly validated through Paimon and Iceberg REST flows | the shared architecture and compat-helper approach work |
-| Paimon | validated | passed | a good candidate for the initial supported provider set |
-| Iceberg REST | validated | passed | URI shape and REST auxiliary service handling matter |
-| JDBC | validated in repo-level tests | not yet passed | real SQL client still hits driver/classloader issues such as `No suitable driver found` |
-| Hive | not enabled | not validated | keep out of the initial `2.0` support claim unless separate proof is added |
-
-Implication:
-
-- Iceberg REST and Paimon look feasible for a first `2.0` support cut
-- JDBC requires a follow-up focused on real-distribution SQL client driver loading
-- Hive remains the highest-risk provider and should not be promised without direct evidence
-
-### Recommended staged strategy for a future Flink `2.0` effort
-
-Do Flink `2.0` in two stages instead of trying to carry every provider at once.
-
-Stage 1: core compatibility lane plus the validated provider subset
-
-- create `flink-2.0` and `flink-runtime-2.0`
-- keep common catalog-store bootstrapping working
-- adapt common table/catalog object construction through shared helpers
-- validate the core lane, Paimon, and Iceberg REST
-- add unit tests, runtime jar checks, and at least one real-distribution smoke path
-
-Stage 2: provider completion and broader surface
-
-- finish JDBC real-distribution validation and driver/classloader handling
-- validate whether Hive is possible, partial, or must stay unsupported
-- add any model/materialized-table handling only if the product scope actually requires it
-- extend CI once the supported provider matrix is explicit
-
-### What this current implementation should do now for future Flink `2.0`
-
-Even though Flink `2.0` is out of scope for this delivery, this implementation should avoid choices that would block it later.
-
-Required now:
-
-- keep all version-sensitive Flink object construction behind hooks
-- avoid hard-coding `CatalogTable.of(...)` deep inside shared logic
-- keep provider construction behind thin helpers or movable wrappers
-- keep provider wrappers movable into version modules if `2.0` requires it
-- make `ServiceLoader`-based factory discovery tolerant of optional provider linkage failures
-
-Not required now:
-
-- creating `v2.0` source directories
-- adding `2.0` Gradle modules
-- changing provider support statements for the current release
-
-### Future Flink 2.0 acceptance for a separate follow-up
-
-Flink `2.0` should only be considered supported in a future task when all of the following are true:
-
-1. `:flink-connector:flink-2.0` and `:flink-connector:flink-runtime-2.0` build successfully.
-2. Shared common logic runs correctly through a `v2.0` shim layer.
-3. The supported provider matrix for `2.0` is explicitly documented and does not overclaim Hive or JDBC.
-4. Repo-level tests pass for the declared `2.0` scope.
-5. At least one real-distribution `2.0` smoke lane passes for each declared supported provider.
-6. Docs do not imply that all `1.x` providers automatically carry over to `2.0`.
-7. CI has at least one dedicated Flink `2.0` validation path.
-
-## Artifact Naming
-
-Keep the existing naming pattern and extend it by Flink minor:
-
-- `gravitino-flink-1.18_2.12`
-- `gravitino-flink-1.19_2.12`
-- `gravitino-flink-1.20_2.12`
-- `gravitino-flink-connector-runtime-1.18_2.12`
-- `gravitino-flink-connector-runtime-1.19_2.12`
-- `gravitino-flink-connector-runtime-1.20_2.12`
-
-This is already aligned with how the current `1.18` jar is named.
-
-Naming note:
-
-- the connector jar intentionally keeps the existing `gravitino-flink-*` pattern instead of adding an extra `connector` token
-- the runtime jar intentionally keeps the existing `gravitino-flink-connector-runtime-*` pattern
-- this avoids renaming existing published coordinates while still making the Flink minor explicit
-
-## Detailed Implementation Plan
-
-### Phase 1: Mechanical split without behavior change
-
-1. Create `flink-common` and move the current shared implementation into it.
-2. Add `v1.18`, `v1.19`, and `v1.20` version folders.
-3. Create versioned Gradle subprojects and wire them in `settings.gradle.kts`.
-4. Extract the extension hooks needed for future `1.20` catalog API support into `flink-common`.
-5. Make `:flink-connector:flink-1.18` depend on `:flink-connector:flink-common`.
-6. Keep `1.18` behavior unchanged.
-7. Remove the old `:flink-connector:flink` and `:flink-connector:flink-runtime` project entries once `flink-common`, `flink-1.18`, and `flink-runtime-1.18` are wired.
-
-Acceptance for Phase 1:
-
-- `:flink-connector:flink-common:test` passes
-- `:flink-connector:flink-1.18:test -PskipITs` passes
-- `:flink-connector:flink-runtime-1.18:test` passes
-- the old `:flink-connector:flink` and `:flink-connector:flink-runtime` projects are no longer present in `settings.gradle.kts`
-
-### Phase 2: Add 1.19 with zero or near-zero Java divergence
-
-1. Create `:flink-connector:flink-1.19` and `:flink-connector:flink-runtime-1.19`.
-2. Make `:flink-connector:flink-1.19` depend on `:flink-connector:flink-common`.
-3. Use `1.19` dependency aliases.
-4. Compile and run unit tests.
-5. Only add `v1.19/flink/src/main/java` overlay files if compilation proves they are needed.
-6. Run provider runtime linkage validation on the `1.19` dependency graph, not only common baseline tests.
-
-Expected outcome:
-
-- no provider behavior changes
-- probably no Java shim classes needed
-- any provider wrapper that fails runtime linkage moves into the `1.19` module instead of staying in `flink-common`
-
-### Phase 3: Add 1.20 and handle dependency deltas first
-
-1. Create `:flink-connector:flink-1.20` and `:flink-connector:flink-runtime-1.20`.
-2. Make `:flink-connector:flink-1.20` depend on `:flink-connector:flink-common`.
-3. Use `1.20` dependency aliases.
-4. Set Iceberg runtime to a version that actually publishes `iceberg-flink-runtime-1.20`.
-5. Set JDBC connector to `3.3.0-1.20` or another validated `1.20` variant.
-6. Compile against the common jar plus `1.20` deps.
-7. Only if compilation or runtime linking breaks appear, add minimal `v1.20` overlay classes.
-8. Run provider runtime linkage validation on the `1.20` dependency graph before declaring the shared provider wrappers safe.
-
-### Phase 4: Keep SPI resources aligned
-
-Ensure the service registration remains available for each versioned module:
-
-- `META-INF/services/org.apache.flink.table.factories.Factory`
-
-If all factory classes remain in `flink-common`, the service file can remain there and the versioned modules should not contribute a duplicate `Factory` service file.
-
-If a version-specific factory class is introduced, the versioned module's service file should replace the common effective service list for that variant.
-
-Required rule in that case:
-
-- the versioned module must re-list every factory class that should be visible for that variant, including common factories that still apply
-- do not rely on resource merge order between `flink-common` and the versioned module
-- do not ship duplicated factory entries for the same identifier in the final runtime artifact
-
-### Phase 5: Update tests and workflows
-
-Update:
-
-- `.github/workflows/flink-integration-test-action.yml`
-- `.github/workflows/backend-integration-test-action.yml`
-- any other workflow or script that hardcodes `:flink-connector:flink`
-
-Recommended workflow strategy:
-
-- run unit tests for all three Flink variants
-- run runtime jar dependency tests for all three runtime variants
-- run Flink integration tests for all three variants, or at minimum add a matrix input that can target each variant explicitly
-
-### Phase 6: Update docs and build instructions
-
-Update all Flink docs that currently hardcode `1.18`, including at least:
-
-- `docs/flink-connector/flink-connector.md`
-- `docs/flink-connector/flink-catalog-hive.md`
-- `docs/flink-connector/flink-catalog-iceberg.md`
-- `docs/flink-connector/flink-catalog-jdbc.md`
-- `docs/flink-connector/flink-catalog-paimon.md`
-- `docs/how-to-build.md`
-- `docs/index.md`
-
-Docs should:
-
-- state the supported Flink matrix explicitly
-- show the correct runtime jar name pattern per Flink minor
-- mention provider-side dependency differences where users need extra jars
-
-## Testing Plan
-
-### Unit tests
-
-Run for each variant:
-
-```bash
-./gradlew :flink-connector:flink-common:test -PskipITs -PskipDockerTests=false
-./gradlew :flink-connector:flink-1.18:test -PskipITs -PskipDockerTests=false
-./gradlew :flink-connector:flink-1.19:test -PskipITs -PskipDockerTests=false
-./gradlew :flink-connector:flink-1.20:test -PskipITs -PskipDockerTests=false
-```
-
-### `flink-common` baseline test scope
-
-`flink-common:test` runs only against the Flink `1.18` baseline dependency graph.
+Release-facing user docs should describe only completed support lanes.
 
 This means:
 
-- it validates shared logic against the lowest supported API surface
-- it does not by itself prove binary compatibility on `1.19` or `1.20`
-- any regression test that depends on `1.19` or `1.20` linkage should live in the corresponding versioned module
-- versioned module test runs are required to validate the shared bytecode under `1.19` and `1.20` classpaths
+- Phase 1 release and docs should describe Flink `1.18` support on the new framework
+- Flink `1.19` and `1.20` should only be added to user-facing support documentation after their
+  phases are completed
 
-### Versioned provider runtime linkage validation
+## Future Flink 2.0 Lane
 
-Compilation alone is not enough for `1.19` and `1.20`.
+Flink `2.0` remains out of scope for the current staged delivery.
 
-For each versioned module, validation should include at least one provider-level runtime linkage check that proves shared wrappers can be loaded and used on that minor's classpath.
+However, this architecture is intentionally `2.x`-ready:
 
-Minimum expectation:
+- add `v2.0/flink`
+- add `v2.0/flink-runtime`
+- add `CatalogCompatFlink20`
+- add `Flink20` versioned catalog, factory, and integration-test entry classes
 
-- load or instantiate the provider factory and wrapper path for Hive, Iceberg, JDBC, and Paimon on the versioned module classpath
-- fail the version lane if the run hits `NoSuchMethodError`, `NoClassDefFoundError`, `ClassNotFoundException`, or equivalent constructor/method linkage errors
-- treat real-environment smoke coverage as the stronger confirmation, but still keep a smaller versioned-module linkage check in the repository test lane where practical
-
-### Runtime jar tests
-
-Run for each runtime variant:
-
-```bash
-./gradlew :flink-connector:flink-runtime-1.18:test
-./gradlew :flink-connector:flink-runtime-1.19:test
-./gradlew :flink-connector:flink-runtime-1.20:test
-```
-
-### Integration tests
-
-Run the existing integration suite against each variant in both existing modes:
-
-- `-PtestMode=embedded`
-- `-PtestMode=deploy`
-
-Minimum required coverage:
-
-- Hive catalog
-- JDBC catalog
-- Paimon catalog
-- Iceberg catalog
-- catalog store bootstrap path
-- generic Hive table flow
-
-### Real Flink environment validation
-
-Repository-local integration tests are necessary but not sufficient.
-
-For this delivery, the real-environment lane is a simple smoke-validation lane. In this document, `smoke` means a minimal real-distribution end-to-end check that proves the connector can load, bootstrap, and complete a basic documented catalog flow. It should prove that the versioned runtime jar can work in a real Flink distribution with the basic documented flow, but it does not need to cover the full authentication matrix.
-
-For every supported Flink minor, the connector must also be validated in a real Flink runtime environment to prove that:
-
-- the versioned runtime jar can be loaded by that Flink distribution
-- ServiceLoader-based factory discovery works with the real classloader layout
-- SQL examples from the public documentation actually work against that Flink version
-- Gravitino-managed catalogs can be used end-to-end from the real Flink client/session environment
-
-Current-scope rule:
-
-- require simple authentication mode only
-- do not require OAuth2 validation
-- do not require Kerberos validation
-
-This validation is required for:
-
-- Flink `1.18.x`
-- Flink `1.19.x`
-- Flink `1.20.x`
-
-### Real environment validation modes
-
-At minimum, each supported Flink minor should be validated with one simple real-distribution smoke path. The preferred options are:
-
-1. SQL/TableEnvironment mode
-
-- start a real Flink distribution of the target version
-- place the version-matched Gravitino runtime jar and required provider jars in the Flink classpath
-- create a real `TableEnvironment` or SQL client session
-- verify catalog-store bootstrap and catalog operations
-
-2. SQL client mode
-
-- launch the Flink SQL client from the real distribution
-- configure `table.catalog-store.kind=gravitino`
-- execute representative SQL flows from the connector documentation
-
-At least one of the two modes above must be automated per supported Flink minor in this delivery.
-
-`Deployed cluster` validation is useful but optional for this delivery and can be added later as a stronger compatibility lane.
-
-### Test content sources
-
-The real-environment validation suite should be derived from two sources:
-
-1. Existing integration tests under:
-
-- `flink-connector/flink-common/src/test/java/org/apache/gravitino/flink/connector/integration/test`
-
-2. Public Flink connector documentation under:
-
-- `docs/flink-connector/flink-connector.md`
-- `docs/flink-connector/flink-catalog-hive.md`
-- `docs/flink-connector/flink-catalog-iceberg.md`
-- `docs/flink-connector/flink-catalog-jdbc.md`
-- `docs/flink-connector/flink-catalog-paimon.md`
-
-The real-environment validation plan should not invent a separate product surface. It should prove that the documented usage and the current IT coverage both work on each supported Flink version.
-
-### Required real-environment smoke scenarios
-
-For every supported Flink minor, validate the following minimum scenario groups in a real Flink environment.
-
-1. Catalog store bootstrap
-
-- `table.catalog-store.kind=gravitino`
-- `table.catalog-store.gravitino.gravitino.uri`
-- `table.catalog-store.gravitino.gravitino.metalake`
-- representative client config pass-through under `table.catalog-store.gravitino.gravitino.client.*`
-
-2. Authentication
-
-- simple mode
-
-3. Hive catalog
-
-- create/use Hive catalog managed by Gravitino
-- create raw Hive table with `'connector'='hive'`
-- create generic table in Hive catalog
-- verify generic table round-trip behavior
-- verify documented native interoperability scenarios where applicable
-
-4. Iceberg catalog
-
-- create/use Iceberg catalog managed by Gravitino
-- create Iceberg table
-- create partitioned Iceberg table
-- validate Iceberg REST or Hive-backed scenarios covered by the current IT suite and docs
-
-5. JDBC catalog
-
-- create/use JDBC catalog managed by Gravitino
-- create database/table
-- insert/select through the documented SQL flow
-- verify version-specific JDBC provider jars are correctly loaded
-
-6. Paimon catalog
-
-- create/use Paimon catalog managed by Gravitino
-- validate at least one supported backend per release test lane
-- cover the documented SQL flow and current IT-backed table operations
-
-7. Common DDL and schema/table lifecycle
-
-- create schema/database
-- alter schema properties
-- create table
-- alter table comment
-- add/drop/rename columns
-- rename table
-- set/reset table properties
-
-### Mapping expectation between docs and tests
-
-The implementation should maintain an explicit mapping between:
-
-- documented examples
-- existing Java integration tests
-- real-environment validation scripts/jobs
-
-At review time, it should be possible to answer:
-
-- which doc example is validated by which automated job
-- which current integration test behavior is also exercised on real Flink `1.18`, `1.19`, and `1.20`
-
-### CI recommendation for real-environment validation
-
-The near-term target is a lightweight Flink-version smoke matrix in CI.
-
-Recommended minimum:
-
-- run repository integration tests per Flink versioned module
-- add at least one simple real-distribution smoke validation job per supported Flink minor
-- keep OAuth2, Kerberos, and broader deployed-cluster validation out of the required PR lane for this delivery
-
-Recommended matrix dimensions:
-
-- Flink version: `1.18`, `1.19`, `1.20`
-- mode: `embedded`, `deploy`, `real-distribution-smoke`
-
-### Real-environment validation acceptance
-
-Support for a Flink minor should not be declared complete until the corresponding simple real Flink environment smoke validation passes for that minor.
-
-### What must be verified across all minors
-
-- `table.catalog-store.kind=gravitino` still boots correctly
-- `CREATE CATALOG` still discovers the right factory
-- schema operations still translate to Gravitino correctly
-- table create/load/alter/drop still translate correctly
-- `TableChange` conversion still behaves the same
-- runtime shadow jars still exclude SLF4J classes
-- the connector works in a real Flink runtime of that minor, not only in repository-local tests
-
-## Acceptance Criteria
-
-The work is done when all of the following are true:
-
-1. Flink `1.18`, `1.19`, and `1.20` each have a dedicated connector module and runtime module.
-2. Shared code lives in `:flink-connector:flink-common`.
-3. Each runtime module produces a correctly versioned runtime jar.
-4. Existing behavior for the current `1.18` connector is preserved.
-5. Unit tests pass for the common module and all supported Flink minors.
-6. Integration tests can be run against all supported Flink minors.
-7. Simple real Flink environment smoke validation passes for all supported Flink minors.
-8. User docs no longer claim that only Flink `1.18` is supported.
-
-## Risks and Review Focus
-
-### Risk 1: Iceberg version drift
-
-`1.20` cannot reuse the current global Iceberg connector version if that version is `1.6.1`.
-
-Review focus:
-
-- verify the chosen Iceberg version exists for all intended Flink minors
-- verify the chosen version does not accidentally force Spark connector changes unless that is intentional
-
-### Risk 2: CI time growth
-
-Tripling the Flink matrix will increase test time.
-
-Review focus:
-
-- whether all three variants run on every PR
-- whether full integration tests should be split into a matrix or run selectively
-
-### Risk 3: Hidden provider-specific API drift
-
-Even if Flink SPI is stable, provider artifacts may drift across minors.
-
-Review focus:
-
-- Iceberg factory construction
-- Paimon factory construction
-- JDBC catalog factory/runtime
-- Hive catalog helper behavior
-
-### Risk 4: Mechanical refactor regressions
-
-Moving shared sources into `flink-common` can break:
-
-- service resource lookup
-- test resource lookup
-- Gradle source set wiring
-
-Review focus:
-
-- resource paths
-- service registration
-- test reports and workflow artifact upload paths
-
-### Risk 5: False confidence from `compileOnly`
-
-`compileOnly` may make the module graph look clean while still leaving runtime ABI problems.
-
-Review focus:
-
-- whether `flink-common` directly references constructors or methods whose signatures differ by minor
-- whether provider wrappers should stay in `flink-common` or move into versioned modules
-
-### Risk 6: Provider-level runtime ABI drift across `1.18` to `1.20`
-
-Even if the Flink SPI remains largely stable, the native provider connectors can still drift in ways that break shared wrappers at runtime.
-
-Concrete examples include:
-
-- `HiveCatalog` constructor or helper signature drift across Hive connector variants bundled with different Flink minors
-- `org.apache.iceberg.flink.FlinkCatalog` constructor or factory drift across `iceberg-flink-runtime-1.18`, `1.19`, and `1.20`
-- `JdbcCatalog` constructor drift across JDBC connector minors such as `3.2.0-1.18` and `3.3.0-1.20`
-
-Review focus:
-
-- whether shared provider wrappers only use methods and constructors proven stable across the supported minors
-- whether provider factories can be loaded and instantiated on each versioned classpath
-- whether a provider should be moved out of `flink-common` as soon as runtime linkage checks fail
-
-## AI Guardrails
-
-If an AI agent implements this spec, it should follow these rules:
-
-1. Treat the current `1.18` connector as the behavior baseline.
-2. Build `flink-common` first against the baseline Flink `1.18` API.
-3. Add extension hooks in `flink-common` before adding any `1.20`-specific implementation.
-4. Introduce version-specific Java shims only if compilation, tests, or runtime linking require them.
-5. Do not use reflection unless a compile-time version shim is impossible.
-6. Do not add version-specific Flink catalog classes unless compilation, tests, or runtime ABI checks require them.
-7. Do not rename factory identifiers or connector property keys.
-8. Keep the SPI service file content identical unless a version-specific factory class is introduced, and if one is introduced the versioned module must own the full final service list for that variant.
-9. Update docs and workflows in the same change set as the code split.
-
-## Expected Touched Areas
-
-At minimum, expect changes in:
-
-- `settings.gradle.kts`
-- `gradle/libs.versions.toml`
-- `flink-connector/`
-- `.github/workflows/flink-integration-test-action.yml`
-- `.github/workflows/backend-integration-test-action.yml`
-- `docs/flink-connector/*.md`
-- `docs/how-to-build.md`
-- `docs/index.md`
-
-## Recommended Execution Order
-
-1. Create `flink-common`.
-2. Move current shared implementation into `flink-common`.
-3. Extract extension hooks for future `1.20` catalog API support.
-4. Create versioned Gradle projects.
-5. Make `1.18` green again with `flink-common` in place.
-6. Add `1.19` and keep it common-backed if possible.
-7. Add `1.20` and solve dependency-version issues first.
-8. Add minor-specific shims only if compilation, tests, or runtime ABI checks prove they are necessary.
-9. Update CI.
-10. Update docs.
+That follow-up should be treated as a new major compatibility lane, not as a small extension of
+the `1.x` minor series.

--- a/ai-code-spec/flink_multi_version_support_spec.md
+++ b/ai-code-spec/flink_multi_version_support_spec.md
@@ -48,7 +48,7 @@ The output of this work should be:
 - Adding OAuth2 or Kerberos real-environment validation to the required test matrix for this delivery
 - Producing one universal jar that works across all Flink minors
 
-Note: Flink `2.0` support is explicitly out of scope for this delivery. It should be treated as a larger follow-up compatibility lane rather than a small extension of the `1.18` to `1.20` work, but the module split and extension hooks introduced here should keep a clean path for that future effort.
+Note: Flink `2.0` support is explicitly out of scope for this delivery. It should be treated as a larger follow-up compatibility lane rather than a small extension of the `1.18` to `1.20` work, but the module split and extension hooks introduced here should keep a clean path for that future effort. Follow-up implementation findings for that lane are recorded in [flink_2_0_adaptation_notes.md](flink_2_0_adaptation_notes.md).
 
 ## Current Connector Model
 
@@ -58,8 +58,8 @@ The current Flink connector is not a generic table runtime connector. It is prim
 
 1. Catalog store bootstrapping
 
-- `flink-connector/flink/src/main/java/org/apache/gravitino/flink/connector/store/GravitinoCatalogStoreFactory.java`
-- `flink-connector/flink/src/main/java/org/apache/gravitino/flink/connector/store/GravitinoCatalogStore.java`
+- `flink-connector/flink-common/src/main/java/org/apache/gravitino/flink/connector/store/GravitinoCatalogStoreFactory.java`
+- `flink-connector/flink-common/src/main/java/org/apache/gravitino/flink/connector/store/GravitinoCatalogStore.java`
 
 These classes integrate with:
 
@@ -71,8 +71,8 @@ These classes integrate with:
 
 2. Catalog SPI implementations
 
-- `flink-connector/flink/src/main/java/org/apache/gravitino/flink/connector/catalog/BaseCatalog.java`
-- `flink-connector/flink/src/main/java/org/apache/gravitino/flink/connector/catalog/BaseCatalogFactory.java`
+- `flink-connector/flink-common/src/main/java/org/apache/gravitino/flink/connector/catalog/BaseCatalog.java`
+- `flink-connector/flink-common/src/main/java/org/apache/gravitino/flink/connector/catalog/BaseCatalogFactory.java`
 
 These classes integrate with:
 
@@ -124,7 +124,7 @@ The connector depends much more on the Flink Table/Catalog SPI than on the DataS
 
 ### Flink SPI stability from 1.18 to 1.20
 
-Reviewing local Flink sources under `/Users/fanng/opensource/flink` shows that the APIs used by the current connector are mostly stable across `release-1.18`, `release-1.19`, and `origin/release-1.20`.
+Reviewing local Flink sources shows that the APIs used by the current connector are mostly stable across `release-1.18`, `release-1.19`, and `origin/release-1.20`.
 
 Observed changes are mostly additive:
 
@@ -504,52 +504,58 @@ Do later only when required by real Flink `1.20` API usage:
 
 ## Future Flink 2.0 Compatibility Lane
 
-Flink `2.0` should not be implemented in this change set.
+Flink `2.0` is still out of scope for this delivery, but later implementation and debugging work has already confirmed the shape of that compatibility lane. This section records those findings so the future follow-up does not need to rediscover the same breakpoints.
 
-However, this design should keep Flink `2.0` support possible without another repository-level reorganization.
+Detailed implementation notes for that follow-up are documented in [flink_2_0_adaptation_notes.md](flink_2_0_adaptation_notes.md).
 
-### Can this architecture support Flink `2.0`?
+### Confirmed architectural conclusion
 
-Yes, with one important caveat:
+Yes, this architecture can support Flink `2.0`, with one important caveat:
 
 - the overall `flink-common + versioned modules + versioned runtime modules` architecture is still valid
-- but Flink `2.0` should be treated as a new major compatibility lane, not as just another `1.x` minor
+- but Flink `2.0` must be treated as a new major compatibility lane, not as just another `1.x` minor
 
 In practice, this means:
 
 - add `:flink-connector:flink-2.0`
 - add `:flink-connector:flink-runtime-2.0`
-- expect a real `v2.0` shim layer
+- add a real `v2.0` shim layer at the version-sensitive Flink API boundaries
 - do not assume `flink-common` bytecode compiled against `1.18` will run unchanged on `2.0`
 
-### Why Flink `2.0` is materially different
+### Confirmed breakpoints from real implementation work
 
-Reviewing local Flink `release-2.0` sources under `/Users/fanng/opensource/flink` shows several changes relevant to the current connector:
+Later Flink `2.0` implementation and validation work confirmed that the following are real breakpoints, not just theoretical risks:
 
-- `CatalogTable.of(...)` is no longer the construction path; builder-based construction is used instead
-- `CatalogBaseTable.TableKind` gains `MATERIALIZED_TABLE`
-- `Catalog` gains model-related APIs and more modern catalog surface area
-- legacy compatibility APIs continue to shrink
-- `TableSchema` references move to legacy package locations
+- `CatalogTable.of(...)` is no longer available; `CatalogTable.newBuilder()` must be supported
+- `CatalogPropertiesUtil.serializeCatalogTable(...)` requires a newer compatibility path in the `2.0` lane
+- Iceberg's `FlinkCatalogFactory` changed from `createCatalog(String, Map<String, String>)` to `createCatalog(CatalogFactory.Context)`
+- Flink `2.0` JDBC artifacts and class packages changed, so direct `1.x` imports are not stable enough
+- real Flink `2.0.x` distributions expose stricter runtime behavior than repo-local tests, especially for Iceberg REST URI handling and JDBC driver/classloader visibility
 
-This is enough to require a `v2.0` adapter layer even if much of the business logic remains shared.
+This confirms that Flink `2.0` needs both:
 
-### Minimum code changes likely required for Flink `2.0`
+- versioned modules and dependencies
+- narrow compatibility helpers in shared code
 
-At minimum, future Flink `2.0` support should expect the following changes:
+### Minimum code changes required for a future Flink `2.0` follow-up
+
+At minimum, future Flink `2.0` support should include all of the following:
 
 1. Add versioned modules
 
 - `:flink-connector:flink-2.0`
 - `:flink-connector:flink-runtime-2.0`
 
-2. Add `v2.0` catalog/table construction shims
+2. Add shared compatibility helpers at the actual breakpoints
 
-Current code paths that will not directly carry over include:
+The later implementation work showed that these hooks are required:
 
 - shared `CatalogTable` construction in `BaseCatalog`
-- generic table reconstruction in `FlinkGenericTableUtil`
-- tests that directly use `CatalogTable.of(...)`
+- generic table serialization/deserialization in `FlinkGenericTableUtil`
+- Iceberg factory creation in `GravitinoIcebergCatalog` and `GravitinoIcebergCatalogFactory`
+- JDBC factory creation in `GravitinoJdbcCatalog`
+- `ServiceLoader` discovery hardening in `GravitinoCatalogStore`
+- tests that directly used `CatalogTable.of(...)`
 
 3. Add `v2.0` API adapters where new catalog surface should be supported
 
@@ -561,51 +567,56 @@ Examples:
 
 4. Re-evaluate provider wrappers independently
 
-Flink `2.0` provider dependencies should not be assumed compatible with the `1.18` to `1.20` wrappers.
+Flink `2.0` provider dependencies should not be assumed compatible with the `1.18` to `1.20` wrappers even when the core catalog SPI is bridged.
 
-### Provider compatibility expectations for Flink `2.0`
+### Provider status from current Flink `2.0` experiments
 
-As of `March 16, 2026`, the external ecosystem suggests the following:
+The later Flink `2.0` work produced a more concrete provider picture than this spec originally had:
 
-- Iceberg: `iceberg-flink-runtime-2.0` exists, but only from Iceberg `1.10.0`
-- Paimon: `paimon-flink-2.0` exists
-- JDBC: Flink `2.0` uses the newer JDBC artifact split such as `flink-connector-jdbc-core`, `flink-connector-jdbc-mysql`, and `flink-connector-jdbc-postgres`
-- Hive: a clear Flink `2.0` `flink-connector-hive_2.12` artifact was not found in Maven Central during this analysis
+| Area | Repo-level status | Real external `2.0.1` status | Notes |
+| --- | --- | --- | --- |
+| Core catalog lane | validated | indirectly validated through Paimon and Iceberg REST flows | the shared architecture and compat-helper approach work |
+| Paimon | validated | passed | a good candidate for the initial supported provider set |
+| Iceberg REST | validated | passed | URI shape and REST auxiliary service handling matter |
+| JDBC | validated in repo-level tests | not yet passed | real SQL client still hits driver/classloader issues such as `No suitable driver found` |
+| Hive | not enabled | not validated | keep out of the initial `2.0` support claim unless separate proof is added |
 
 Implication:
 
-- Iceberg and Paimon look feasible for a future `2.0` lane
-- JDBC likely needs provider-specific dependency and wrapper updates
-- Hive may be the highest-risk or blocked provider for a first `2.0` support cut
+- Iceberg REST and Paimon look feasible for a first `2.0` support cut
+- JDBC requires a follow-up focused on real-distribution SQL client driver loading
+- Hive remains the highest-risk provider and should not be promised without direct evidence
 
-### Recommended strategy for a future Flink `2.0` effort
+### Recommended staged strategy for a future Flink `2.0` effort
 
 Do Flink `2.0` in two stages instead of trying to carry every provider at once.
 
-Stage 1: core compatibility lane
+Stage 1: core compatibility lane plus the validated provider subset
 
 - create `flink-2.0` and `flink-runtime-2.0`
-- make common catalog-store bootstrapping work
-- adapt common table/catalog object construction
-- run unit tests and minimal integration coverage
+- keep common catalog-store bootstrapping working
+- adapt common table/catalog object construction through shared helpers
+- validate the core lane, Paimon, and Iceberg REST
+- add unit tests, runtime jar checks, and at least one real-distribution smoke path
 
-Stage 2: provider enablement
+Stage 2: provider completion and broader surface
 
-- validate Iceberg
-- validate Paimon
-- redesign JDBC provider dependency wiring for the new artifact layout
+- finish JDBC real-distribution validation and driver/classloader handling
 - validate whether Hive is possible, partial, or must stay unsupported
+- add any model/materialized-table handling only if the product scope actually requires it
+- extend CI once the supported provider matrix is explicit
 
 ### What this current implementation should do now for future Flink `2.0`
 
-Even though Flink `2.0` is out of scope now, this implementation should avoid choices that would block it later.
+Even though Flink `2.0` is out of scope for this delivery, this implementation should avoid choices that would block it later.
 
 Required now:
 
 - keep all version-sensitive Flink object construction behind hooks
 - avoid hard-coding `CatalogTable.of(...)` deep inside shared logic
-- avoid putting too much provider-specific construction logic into `flink-common`
+- keep provider construction behind thin helpers or movable wrappers
 - keep provider wrappers movable into version modules if `2.0` requires it
+- make `ServiceLoader`-based factory discovery tolerant of optional provider linkage failures
 
 Not required now:
 
@@ -619,9 +630,11 @@ Flink `2.0` should only be considered supported in a future task when all of the
 
 1. `:flink-connector:flink-2.0` and `:flink-connector:flink-runtime-2.0` build successfully.
 2. Shared common logic runs correctly through a `v2.0` shim layer.
-3. The supported provider matrix for `2.0` is explicitly documented.
-4. Docs do not imply that all `1.x` providers automatically carry over to `2.0`.
-5. CI has at least one dedicated Flink `2.0` validation path.
+3. The supported provider matrix for `2.0` is explicitly documented and does not overclaim Hive or JDBC.
+4. Repo-level tests pass for the declared `2.0` scope.
+5. At least one real-distribution `2.0` smoke lane passes for each declared supported provider.
+6. Docs do not imply that all `1.x` providers automatically carry over to `2.0`.
+7. CI has at least one dedicated Flink `2.0` validation path.
 
 ## Artifact Naming
 
@@ -849,7 +862,7 @@ The real-environment validation suite should be derived from two sources:
 
 1. Existing integration tests under:
 
-- `flink-connector/flink/src/test/java/org/apache/gravitino/flink/connector/integration/test`
+- `flink-connector/flink-common/src/test/java/org/apache/gravitino/flink/connector/integration/test`
 
 2. Public Flink connector documentation under:
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds a Flink multi-version support spec under `ai-code-spec/` for Gravitino Flink connector.

The spec covers:
- the current Flink connector architecture and its main Flink interaction points
- the proposed module split with `flink-common` plus versioned Flink modules and runtime modules
- dependency matrix considerations for Flink `1.18`, `1.19`, and `1.20`
- extension hooks for future `1.20` catalog API support
- a future compatibility lane for Flink `2.0` that is explicitly out of scope for this delivery
- testing, CI, and documentation expectations for the multi-version support work

This PR also refines the spec metadata and narrows the real Flink environment requirement to a smoke-validation lane for this delivery.

### Why are the changes needed?

The Flink connector currently targets a single Flink minor version. To support Flink `1.18`, `1.19`, and `1.20` in a maintainable way, the project needs a clear implementation spec that AI agents and human reviewers can follow consistently.

This spec is intended to reduce ambiguity before the actual code split starts and to provide a common review baseline for follow-up implementation work.

Fix: #9710

### Does this PR introduce _any_ user-facing change?

No runtime user-facing behavior is changed in this PR.

This PR adds a design/spec document only. It documents the intended multi-version support plan and the expected validation scope for future implementation work.

### How was this patch tested?

This is a documentation/spec-only change.

No automated tests were run.
