### PR TITLE
[#10448] feat(release): enhance do-release scripts to support non-interactive mode

### DIFF
--- a/dev/release/do-release.sh
+++ b/dev/release/do-release.sh
@@ -80,6 +80,18 @@ export RELEASE_TAG=${RELEASE_TAG:-}
 export ASF_PASSWORD=${ASF_PASSWORD:-}
 export GPG_PASSPHRASE=${GPG_PASSPHRASE:-}
 
+if [[ "${RC_COUNT}" != "0" ]] && ! [[ "${RC_COUNT}" =~ ^[1-9][0-9]*$ ]]; then
+  echo "Error: RC number must be a positive integer, got: '${RC_COUNT}'" >&2
+  exit 1
+fi
+
+if [ -n "${RELEASE_STEP}" ]; then
+  case "${RELEASE_STEP}" in
+    tag|build|docs|publish|finalize) ;;
+    *) echo "Error: invalid release step '${RELEASE_STEP}'. Valid steps: tag, build, docs, publish, finalize" >&2; exit 1 ;;
+  esac
+fi
+
 cmds=("git" "gpg" "svn" "twine" "shasum" "sha1sum" "jq" "make")
 for cmd in "${cmds[@]}"; do
   if ! command -v "$cmd" &> /dev/null; then
@@ -104,7 +116,7 @@ fi
 
 if [ "$RUNNING_IN_DOCKER" = "1" ]; then
   # Inside docker, need to import the GPG key stored in the current directory.
-  echo "${GPG_PASSPHRASE:-}" | $GPG --passphrase-fd 0 --import "$SELF/gpg.key"
+  printf '%s\n' "${GPG_PASSPHRASE:-}" | $GPG --passphrase-fd 0 --import "$SELF/gpg.key"
 
   # We may need to adjust the path since JAVA_HOME may be overridden by the driver script.
   if [ -n "${JAVA_HOME:-}" ]; then

--- a/dev/release/release-util.sh
+++ b/dev/release/release-util.sh
@@ -37,10 +37,14 @@ function read_config {
   local ENV_VAR_NAME="$3"  # Optional: env var name to use in non-interactive (force) mode
   local REPLY=
 
-  # In force/non-interactive mode, use the env var value directly if available.
-  if [ -n "$ENV_VAR_NAME" ] && [ -n "${!ENV_VAR_NAME:-}" ] && is_force; then
-    echo "${!ENV_VAR_NAME}"
-    return
+  # In force/non-interactive mode, the env var must be set; error if missing.
+  if is_force; then
+    if [ -n "$ENV_VAR_NAME" ] && [ -n "${!ENV_VAR_NAME:-}" ]; then
+      echo "${!ENV_VAR_NAME}"
+      return
+    else
+      error "Force mode requires '$PROMPT' to be set via environment variable ${ENV_VAR_NAME:-<none>}."
+    fi
   fi
 
   if [ -n "$DEFAULT" ]; then


### PR DESCRIPTION
### What changes were proposed in this pull request?

- `do-release.sh`: add `-y` (force) flag, `-s/-r/-p/-t` options for full CLI control; skip interactive prompts when in force mode; add `set -euo pipefail` for stricter error handling
- `release-util.sh`: read release info from environment variables when in force mode; auto-detect latest branch and RC count; fix duplicate `JAVA_VERSION` assignment in `init_java`

### Why are the changes needed?

The release process requires manual input at multiple steps. Non-interactive mode allows the release pipeline to be driven by automation without human intervention.

Fix: #10448

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manually verified with `bash -n` syntax check on all modified scripts.