### PR TITLE
[#10223] Prevent sensitive Spark job environment values from being logged in SparkProcessBuilder

### DIFF
--- a/core/src/main/java/org/apache/gravitino/job/local/SparkProcessBuilder.java
+++ b/core/src/main/java/org/apache/gravitino/job/local/SparkProcessBuilder.java
@@ -125,9 +125,9 @@ public class SparkProcessBuilder extends LocalProcessBuilder {
     builder.redirectError(errorFile);
 
     LOG.info(
-        "Starting local Spark job with command: {}, environment variables: {}",
+        "Starting local Spark job with command: {}, environment variable names: {}",
         Joiner.on(" ").join(commandList),
-        sparkJobTemplate.environments().keySet());
+        Joiner.on(", ").join(sparkJobTemplate.environments().keySet()));
 
     try {
       return builder.start();

--- a/core/src/test/java/org/apache/gravitino/job/local/TestSparkProcessBuilder.java
+++ b/core/src/test/java/org/apache/gravitino/job/local/TestSparkProcessBuilder.java
@@ -19,9 +19,12 @@
 
 package org.apache.gravitino.job.local;
 
+import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import java.util.List;
+import java.util.Map;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.gravitino.job.SparkJobTemplate;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -139,5 +142,64 @@ public class TestSparkProcessBuilder {
     Assertions.assertTrue(command4.contains("/path/to/spark-demo.jar"));
     Assertions.assertTrue(command4.contains("arg1"));
     Assertions.assertTrue(command4.contains("arg2"));
+  }
+
+  @Test
+  public void testSparkEnvironmentInfoOutputWithoutValue() {
+    SparkJobTemplate template =
+        SparkJobTemplate.builder()
+            .withName("template4")
+            .withExecutable("/path/to/spark-demo.jar")
+            .withArguments(Lists.newArrayList("arg1", "arg2"))
+            .withClassName("com.example.MainClass")
+            .withConfigs(
+                ImmutableMap.of(
+                    "spark.executor.memory", "2g",
+                    "spark.executor.cores", "2"))
+            .withEnvironments(ImmutableMap.of("key1", "value1", "key2", "value2"))
+            .build();
+    Map<String, String> environments = template.environments();
+    String environmentKeys = Joiner.on(", ").join(environments.keySet());
+    Assertions.assertEquals("key1, key2", environmentKeys);
+  }
+
+  @Test
+  public void testSparkEnvironmentInfoWithEmptyMap() {
+    SparkJobTemplate template =
+        SparkJobTemplate.builder()
+            .withName("template4")
+            .withExecutable("/path/to/spark-demo.jar")
+            .withArguments(Lists.newArrayList("arg1", "arg2"))
+            .withClassName("com.example.MainClass")
+            .withConfigs(
+                ImmutableMap.of(
+                    "spark.executor.memory", "2g",
+                    "spark.executor.cores", "2"))
+            .withEnvironments(ImmutableMap.of())
+            .build();
+    Map<String, String> environments = template.environments();
+    String environmentKeys = Joiner.on(", ").join(environments.keySet());
+    Assertions.assertTrue(StringUtils.isBlank(environmentKeys));
+  }
+
+  @Test
+  public void testSparkEnvironmentInfoWithNullMap() {
+    SparkJobTemplate template =
+        SparkJobTemplate.builder()
+            .withName("template4")
+            .withExecutable("/path/to/spark-demo.jar")
+            .withArguments(Lists.newArrayList("arg1", "arg2"))
+            .withClassName("com.example.MainClass")
+            .withConfigs(
+                ImmutableMap.of(
+                    "spark.executor.memory", "2g",
+                    "spark.executor.cores", "2"))
+            .withEnvironments(null)
+            .build();
+    Map<String, String> environments = template.environments();
+    Assertions.assertNotNull(environments);
+    Assertions.assertTrue(environments.isEmpty());
+    String environmentKeys = Joiner.on(", ").join(environments.keySet());
+    Assertions.assertTrue(StringUtils.isBlank(environmentKeys));
   }
 }


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): Support xxx"
     - "[#233] fix: Check null before access result in xxx"
     - "[MINOR] refactor: Fix typo in variable name"
     - "[MINOR] docs: Fix typo in README"
     - "[#255] test: Fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

- Modified SparkProcessBuilder.start() method to log only environment variable names instead of full key-value pairs

### Why are the changes needed?



Fix: #10223

### Does this PR introduce _any_ user-facing change?


### How was this patch tested?

