### PR TITLE
[#10220] improvement(core): Keep the consistency of column schema_id when table namespace and columns change together

### DIFF
--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/TableColumnMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/TableColumnMetaService.java
@@ -182,15 +182,18 @@ public class TableColumnMetaService {
       }
     }
 
+    // If the namespace has changed, align existing column records to the new schema_id.
+    // This runs independently of the column diff inserts below: any UPDATE/DELETE column
+    // version rows added afterwards will still be inserted under the new schema_id.
+    if (!newTable.namespace().equals(oldTable.namespace())) {
+      SessionUtils.doWithoutCommit(
+          TableColumnMapper.class,
+          mapper ->
+              mapper.updateSchemaIdByTableId(newTablePO.getTableId(), newTablePO.getSchemaId()));
+    }
+
     // If there is no change, directly return
     if (columnPOsToInsert.isEmpty()) {
-      // If namespace is changed, just update the schema_id of the columns.
-      if (!newTable.namespace().equals(oldTable.namespace())) {
-        SessionUtils.doWithoutCommit(
-            TableColumnMapper.class,
-            mapper ->
-                mapper.updateSchemaIdByTableId(newTablePO.getTableId(), newTablePO.getSchemaId()));
-      }
       return;
     }
 

--- a/core/src/test/java/org/apache/gravitino/storage/relational/service/TestTableColumnMetaService.java
+++ b/core/src/test/java/org/apache/gravitino/storage/relational/service/TestTableColumnMetaService.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import org.apache.gravitino.Entity;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
 import org.apache.gravitino.exceptions.NoSuchEntityException;
@@ -591,6 +592,80 @@ public class TestTableColumnMetaService extends TestJDBCBackend {
         TableColumnMetaService.getInstance()
             .getColumnIdByTableIdAndName(retrievedTable.id(), newColumn.name());
     Assertions.assertEquals(newColumn.id(), selectedColumnId);
+  }
+
+  @TestTemplate
+  public void testUpdateTableWithSchemaAndColumnChangesUpdatesAllColumnSchemaIds()
+      throws IOException {
+    String catalogName = "catalog1";
+    String oldSchemaName = "schema1";
+    String newSchemaName = "schema2";
+    createParentEntities(METALAKE_NAME, catalogName, oldSchemaName, AUDIT_INFO);
+    createAndInsertSchema(METALAKE_NAME, catalogName, newSchemaName);
+
+    ColumnEntity existingColumn =
+        ColumnEntity.builder()
+            .withId(RandomIdGenerator.INSTANCE.nextId())
+            .withName("column1")
+            .withPosition(0)
+            .withComment("comment1")
+            .withDataType(Types.IntegerType.get())
+            .withNullable(true)
+            .withAutoIncrement(false)
+            .withDefaultValue(Literals.integerLiteral(1))
+            .withAuditInfo(AUDIT_INFO)
+            .build();
+
+    TableEntity createdTable =
+        TableEntity.builder()
+            .withId(RandomIdGenerator.INSTANCE.nextId())
+            .withName("table_move_schema")
+            .withNamespace(Namespace.of(METALAKE_NAME, catalogName, oldSchemaName))
+            .withColumns(Lists.newArrayList(existingColumn))
+            .withAuditInfo(AUDIT_INFO)
+            .build();
+    TableMetaService.getInstance().insertTable(createdTable, false);
+
+    ColumnEntity newColumn =
+        ColumnEntity.builder()
+            .withId(RandomIdGenerator.INSTANCE.nextId())
+            .withName("column2")
+            .withPosition(1)
+            .withComment("comment2")
+            .withDataType(Types.StringType.get())
+            .withNullable(true)
+            .withAutoIncrement(false)
+            .withDefaultValue(Literals.stringLiteral("v2"))
+            .withAuditInfo(AUDIT_INFO)
+            .build();
+
+    TableEntity movedAndUpdatedTable =
+        TableEntity.builder()
+            .withId(createdTable.id())
+            .withName(createdTable.name())
+            .withNamespace(Namespace.of(METALAKE_NAME, catalogName, newSchemaName))
+            .withColumns(Lists.newArrayList(existingColumn, newColumn))
+            .withAuditInfo(AUDIT_INFO)
+            .build();
+
+    TableMetaService.getInstance()
+        .updateTable(createdTable.nameIdentifier(), old -> movedAndUpdatedTable);
+
+    long newSchemaId =
+        EntityIdService.getEntityId(
+            NameIdentifier.of(METALAKE_NAME, catalogName, newSchemaName), Entity.EntityType.SCHEMA);
+    ColumnPO existingColumnPO =
+        TableColumnMetaService.getInstance().getColumnPOById(existingColumn.id());
+    ColumnPO newColumnPO = TableColumnMetaService.getInstance().getColumnPOById(newColumn.id());
+
+    Assertions.assertEquals(
+        newSchemaId,
+        existingColumnPO.getSchemaId(),
+        "Existing column schema id should be updated to new schema id");
+    Assertions.assertEquals(
+        newSchemaId,
+        newColumnPO.getSchemaId(),
+        "Newly inserted column schema id should also point to new schema id");
   }
 
   private void compareTwoColumns(


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): Support xxx"
     - "[#233] fix: Check null before access result in xxx"
     - "[MINOR] refactor: Fix typo in variable name"
     - "[MINOR] docs: Fix typo in README"
     - "[#255] test: Fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Keeping column schema_id consistant when table namespace and columns change together

### Why are the changes needed?

(Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, describe the bug.)

Fix: https://github.com/apache/gravitino/issues/10220

### Does this PR introduce _any_ user-facing change?

no

### How was this patch tested?

UTs