### PR TITLE
[#10453] web-v2(UI): support "delta" value for generic table format property 

### DIFF
--- a/web-v2/web/src/config/catalog.js
+++ b/web-v2/web/src/config/catalog.js
@@ -143,7 +143,7 @@ export const tableDefaultProps = {
     {
       key: 'format',
       defaultValue: 'lance',
-      disabled: true,
+      select: ['lance', 'delta'],
       description: 'The format of the table'
     }
   ]


### PR DESCRIPTION
### What changes were proposed in this pull request?
Support "delta" value for generic table format property for web UI v2
<img width="2320" height="1564" alt="image" src="https://github.com/user-attachments/assets/d7414ead-d32d-40fe-90c4-1068cac693a6" />


### Why are the changes needed?
We already support "delta", so we should loose this constraint.

Fix: #10453

### Does this PR introduce _any_ user-facing change?
N/A

### How was this patch tested?
manually
