### PR TITLE
[Cherry-pick to branch 1.2][#10262] refactor(build): remove release task and centralize JDK8 compatibility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,7 +84,7 @@ jobs:
 
       - name: Build with Gradle
         run: |
-          ./gradlew release -x test
+          ./gradlew assemble
 
   # To check the spark-connector is compatible with scala2.13
   spark-connector-build:
@@ -159,9 +159,6 @@ jobs:
       - name: Build with Gradle (skip mcp-server tests)
         if: needs.changes.outputs.mcp_server_changes != 'true'
         run: ./gradlew build -PskipITs -PskipDockerTests=false -x :clients:client-python:build -x :mcp-server:build -x :mcp-server:test -x :mcp-server:pylint -x :web-v2:web:build
-
-      - name: Release with Gradle
-        run: ./gradlew clean && ./gradlew release -x test --rerun-tasks
 
       - name: Upload unit tests report
         uses: actions/upload-artifact@v4

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,6 +24,7 @@ import com.github.jk1.license.render.InventoryHtmlReportRenderer
 import com.github.jk1.license.render.ReportRenderer
 import com.github.vlsi.gradle.dsl.configureEach
 import net.ltgt.gradle.errorprone.errorprone
+import org.gradle.api.attributes.java.TargetJvmVersion
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.internal.hash.ChecksumService
 import org.gradle.internal.os.OperatingSystem
@@ -331,39 +332,23 @@ subprojects {
     mavenLocal()
   }
 
+  val jdk8CompatibleProjectPathPrefixes = setOf(
+    ":api",
+    ":common",
+    ":catalogs:catalog-common",
+    ":catalogs:hadoop-common",
+    ":maintenance:jobs",
+    ":maintenance:optimizer-api",
+    ":maintenance:updaters",
+    ":clients",
+    ":bundles",
+    ":spark-connector",
+    ":flink-connector"
+  )
+
   fun compatibleWithJDK8(project: Project): Boolean {
-    val name = project.name.lowercase()
     val path = project.path.lowercase()
-    if (path.startsWith(":maintenance:jobs") ||
-      path.startsWith(":maintenance:optimizer-api") ||
-      path.startsWith(":maintenance:updaters") ||
-      path.startsWith(":clients:client-java") ||
-      name == "api" ||
-      name == "common" ||
-      name == "catalog-common" ||
-      name == "hadoop-common"
-    ) {
-      return true
-    }
-
-    val isReleaseRun = gradle.startParameter.taskNames.any {
-      it == "release" || it == "publish" || it == "publishToMavenLocal" || it.endsWith(":release") || it.endsWith(
-        ":publish"
-      ) || it.endsWith(":publishToMavenLocal")
-    }
-    if (!isReleaseRun) {
-      return false
-    }
-
-    if (path.startsWith(":client") ||
-      path.startsWith(":spark-connector") ||
-      path.startsWith(":flink-connector") ||
-      path.startsWith(":bundles")
-    ) {
-      return true
-    }
-
-    return false
+    return jdk8CompatibleProjectPathPrefixes.any { path.startsWith(it) }
   }
   extensions.extraProperties.set("excludePackagesForSparkConnector", ::excludePackagesForSparkConnector)
 
@@ -399,12 +384,6 @@ subprojects {
     }
   }
 
-  tasks.withType<JavaCompile>().configureEach {
-    if (compatibleWithJDK8(project)) {
-      options.release.set(8)
-    }
-  }
-
   java {
     toolchain {
       // Some JDK vendors like Homebrew installed OpenJDK 17 have problems in building trino-connector:
@@ -424,6 +403,24 @@ subprojects {
         languageVersion.set(JavaLanguageVersion.of(17))
       }
     }
+  }
+
+  if (compatibleWithJDK8(project)) {
+    // Keep published/main classes Java 8-compatible for the selected modules.
+    tasks.named<JavaCompile>("compileJava") {
+      options.release.set(8)
+    }
+
+    // Tests still need Java 17 to compile against dependencies that only publish Java 17 variants.
+    tasks.named<JavaCompile>("compileTestJava") {
+      options.release.set(17)
+    }
+
+    val targetJvmVersionAttribute = TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE
+    configurations.matching { it.name in setOf("testCompileClasspath", "testRuntimeClasspath") }
+      .configureEach {
+        attributes.attribute(targetJvmVersionAttribute, 17)
+      }
   }
 
   gradle.projectsEvaluated {
@@ -450,6 +447,8 @@ subprojects {
   }
 
   tasks.withType<JavaCompile>().configureEach {
+    // Keep Java compilation independent of the host's default charset.
+    options.encoding = "UTF-8"
     options.errorprone.isEnabled.set(true)
     options.errorprone.disableWarningsInGeneratedCode.set(true)
     options.errorprone.disable(
@@ -1312,21 +1311,3 @@ fun checkOrbStackStatus() {
 }
 
 printDockerCheckInfo()
-
-tasks.register("release") {
-  group = "release"
-  description = "Builds and package a release version."
-  doFirst {
-    println("Releasing project...")
-  }
-
-  // Use 'assemble' instead of 'build' to skip tests during release
-  // Tests have JDK version conflicts (some need JDK 8, some need JDK 17)
-  // and should be run separately in CI/CD with appropriate JDK configurations
-  // Only include subprojects that apply the Java plugin (exclude client-python)
-  dependsOn(
-    subprojects
-      .filter { it.name != "client-python" }
-      .map { it.tasks.named("assemble") }
-  )
-}

--- a/clients/client-java/build.gradle.kts
+++ b/clients/client-java/build.gradle.kts
@@ -16,27 +16,10 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import org.gradle.api.attributes.java.TargetJvmVersion
-import org.gradle.api.tasks.compile.JavaCompile
-
 plugins {
   `maven-publish`
   id("java")
   id("idea")
-}
-
-tasks.named<JavaCompile>("compileTestJava") {
-  // client-java main artifact targets Java 8; tests depend on modules that publish Java 17 variants.
-  // Compile tests with release 17 to make Gradle variant matching for :core/:server test classpath deterministic.
-  options.release.set(17)
-}
-
-val targetJvmVersionAttribute = TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE
-configurations.named("testCompileClasspath") {
-  attributes.attribute(targetJvmVersionAttribute, 17)
-}
-configurations.named("testRuntimeClasspath") {
-  attributes.attribute(targetJvmVersionAttribute, 17)
 }
 
 dependencies {

--- a/dev/release/release-build.sh
+++ b/dev/release/release-build.sh
@@ -350,8 +350,8 @@ if [[ "$1" == "publish-release" ]]; then
   cd ..
 
   $GRADLE clean
-  $GRADLE release -x test -PdefaultScalaVersion=2.12
-  $GRADLE release -x test -PdefaultScalaVersion=2.13
+  $GRADLE assemble -PdefaultScalaVersion=2.12
+  $GRADLE assemble -PdefaultScalaVersion=2.13
 
   $GRADLE -Dmaven.repo.local=$tmp_repo publishToMavenLocal -PdefaultScalaVersion=2.12
   $GRADLE -Dmaven.repo.local=$tmp_repo publishToMavenLocal -PdefaultScalaVersion=2.13


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR backports #10385 to `branch-1.2`.

The backport removes the Gradle `release` task usage from the CI/release flow and centralizes the JDK8 compatibility logic in the root build script, instead of keeping scattered module-local handling.

### Why are the changes needed?

`branch-1.2` still carries the same build/release-task coupling and JDK8 compatibility fragmentation fixed in main. Backporting this change keeps the branch behavior aligned and avoids relying on the removed release task path.

Fix: #10262

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Verified by compiling the directly affected modules:

```bash
./gradlew :clients:client-java:compileJava :flink-connector:flink:compileJava :spark-connector:spark-common:compileJava --console=plain
```
