### PR TITLE
[#9538] feat: Add Ray and Dask AI engine integration for UDF management

### DIFF
--- a/api/src/main/java/org/apache/gravitino/function/FunctionImpl.java
+++ b/api/src/main/java/org/apache/gravitino/function/FunctionImpl.java
@@ -47,7 +47,11 @@ public abstract class FunctionImpl {
     /** Spark runtime. */
     SPARK,
     /** Trino runtime. */
-    TRINO;
+    TRINO,
+    /** Ray runtime. */
+    RAY,
+    /** Dask runtime. */
+    DASK;
 
     /**
      * Parse a runtime value from string.

--- a/clients/client-python/gravitino/ai_engine/__init__.py
+++ b/clients/client-python/gravitino/ai_engine/__init__.py
@@ -1,0 +1,21 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""AI engine integration for Gravitino UDF management.
+
+This package provides connectors that enable AI compute engines (Ray, Dask)
+to load and execute UDFs registered in Gravitino.
+"""

--- a/clients/client-python/gravitino/ai_engine/base_connector.py
+++ b/clients/client-python/gravitino/ai_engine/base_connector.py
@@ -1,0 +1,207 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Base connector for AI engine UDF integration with Gravitino."""
+
+import importlib
+import logging
+import types as builtin_types
+from abc import ABC, abstractmethod
+from typing import Any, Callable, Dict, List, Optional
+
+from gravitino.api.function.function import Function
+from gravitino.api.function.function_definition import FunctionDefinition
+from gravitino.api.function.function_impl import FunctionImpl
+from gravitino.api.function.python_impl import PythonImpl
+from gravitino.client.gravitino_client import GravitinoClient
+from gravitino.name_identifier import NameIdentifier
+from gravitino.namespace import Namespace
+
+logger = logging.getLogger(__name__)
+
+
+class BaseAIEngineConnector(ABC):
+    """Base class for AI engine connectors that load Gravitino UDFs.
+
+    Subclasses implement engine-specific wrapping of loaded Python functions
+    (e.g. ``ray.remote`` for Ray, ``dask.delayed`` for Dask).
+    """
+
+    def __init__(
+        self,
+        gravitino_uri: str,
+        metalake: str,
+        catalog: str,
+        schema: str,
+    ):
+        """Create a BaseAIEngineConnector.
+
+        Args:
+            gravitino_uri: The URI of the Gravitino server (e.g. ``http://localhost:8090``).
+            metalake: The metalake name.
+            catalog: The catalog name.
+            schema: The schema name.
+        """
+        self._gravitino_uri = gravitino_uri
+        self._metalake = metalake
+        self._catalog = catalog
+        self._schema = schema
+        self._client = GravitinoClient(
+            uri=gravitino_uri, metalake_name=metalake
+        )
+        self._catalog_client = self._client.load_catalog(catalog)
+        self._function_catalog = self._catalog_client.as_function_catalog()
+
+    @property
+    @abstractmethod
+    def runtime_type(self) -> FunctionImpl.RuntimeType:
+        """The runtime type this connector targets."""
+
+    @abstractmethod
+    def _wrap_function(self, func: Callable, function_meta: Function) -> Any:
+        """Wrap a loaded Python callable for the target engine.
+
+        Args:
+            func: The raw Python callable.
+            function_meta: The Gravitino function metadata.
+
+        Returns:
+            An engine-specific wrapped callable.
+        """
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def list_functions(self) -> List[str]:
+        """List names of functions that have an implementation for this engine's runtime.
+
+        Returns:
+            A list of function names.
+        """
+        namespace = Namespace.of(self._schema)
+        functions = self._function_catalog.list_function_infos(namespace)
+        return [
+            f.name()
+            for f in functions
+            if self._has_matching_impl(f)
+        ]
+
+    def load_function(self, function_name: str) -> Any:
+        """Load a Gravitino UDF and wrap it for the target AI engine.
+
+        The method resolves the first matching ``PythonImpl`` whose runtime matches
+        this connector's ``runtime_type``.  Inline ``code_block`` definitions are
+        supported as well as module-level ``handler`` references.
+
+        Args:
+            function_name: The name of the function to load.
+
+        Returns:
+            An engine-specific wrapped callable.
+
+        Raises:
+            ValueError: If no matching implementation is found.
+        """
+        ident = NameIdentifier.of(self._schema, function_name)
+        function = self._function_catalog.get_function(ident)
+        python_impl = self._find_matching_impl(function)
+        if python_impl is None:
+            raise ValueError(
+                f"No {self.runtime_type.name} Python implementation found "
+                f"for function '{function_name}'"
+            )
+        raw_callable = self._resolve_callable(python_impl)
+        return self._wrap_function(raw_callable, function)
+
+    def load_functions(self) -> Dict[str, Any]:
+        """Load all functions with a matching runtime implementation.
+
+        Returns:
+            A dict mapping function name to engine-wrapped callable.
+        """
+        result: Dict[str, Any] = {}
+        for name in self.list_functions():
+            result[name] = self.load_function(name)
+        return result
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _has_matching_impl(self, function: Function) -> bool:
+        return self._find_matching_impl(function) is not None
+
+    def _find_matching_impl(
+        self, function: Function
+    ) -> Optional[PythonImpl]:
+        """Find the first PythonImpl with a matching runtime type."""
+        for definition in function.definitions():
+            for impl in definition.impls():
+                if (
+                    isinstance(impl, PythonImpl)
+                    and impl.runtime() == self.runtime_type
+                ):
+                    return impl
+        return None
+
+    @staticmethod
+    def _resolve_callable(impl: PythonImpl) -> Callable:
+        """Resolve a PythonImpl to a Python callable.
+
+        If ``code_block`` is set, compile and execute it then look up ``handler``
+        inside the resulting namespace.  Otherwise, import ``handler`` as a
+        dotted module path (e.g. ``my_module.my_func``).
+
+        Args:
+            impl: The PythonImpl to resolve.
+
+        Returns:
+            A Python callable.
+
+        Raises:
+            ImportError: If the handler module cannot be imported.
+            AttributeError: If the handler function is not found.
+            ValueError: If the resolved object is not callable.
+        """
+        handler = impl.handler()
+
+        if impl.code_block():
+            # Execute inline code and extract the handler
+            namespace: Dict[str, Any] = {}
+            # The code_block is executed in an isolated namespace
+            compiled = compile(impl.code_block(), f"<gravitino-udf:{handler}>", "exec")
+            exec(compiled, namespace)  # noqa: S102 – trusted UDF code from Gravitino server
+            if handler not in namespace:
+                raise AttributeError(
+                    f"Handler '{handler}' not found in code block. "
+                    f"Available names: {list(namespace.keys())}"
+                )
+            func = namespace[handler]
+        else:
+            # Import from installed module
+            module_path, _, func_name = handler.rpartition(".")
+            if not module_path:
+                raise ImportError(
+                    f"Handler '{handler}' must be a dotted path (e.g. module.func)"
+                )
+            module = importlib.import_module(module_path)
+            func = getattr(module, func_name)
+
+        if not callable(func):
+            raise ValueError(f"Resolved handler '{handler}' is not callable")
+        return func

--- a/clients/client-python/gravitino/ai_engine/dask_connector.py
+++ b/clients/client-python/gravitino/ai_engine/dask_connector.py
@@ -1,0 +1,113 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Dask connector for Gravitino UDF management.
+
+This module provides the :class:`DaskConnector` that loads UDFs registered
+in Gravitino and wraps them as ``dask.delayed`` callables so they can be
+executed lazily across a Dask cluster.
+
+Usage example::
+
+    from gravitino.ai_engine.dask_connector import DaskConnector
+
+    connector = DaskConnector(
+        gravitino_uri="http://localhost:8090",
+        metalake="my_metalake",
+        catalog="my_catalog",
+        schema="my_schema",
+    )
+
+    # Load a single function
+    delayed_fn = connector.load_function("add_one")
+    result = delayed_fn(41).compute()
+
+    # Load all Dask-runtime functions at once
+    functions = connector.load_functions()
+"""
+
+import logging
+from typing import Any, Callable, Dict, List, Optional
+
+from gravitino.ai_engine.base_connector import BaseAIEngineConnector
+from gravitino.api.function.function import Function
+from gravitino.api.function.function_impl import FunctionImpl
+
+logger = logging.getLogger(__name__)
+
+
+class DaskConnector(BaseAIEngineConnector):
+    """Gravitino UDF connector for the Dask parallel compute engine.
+
+    Functions loaded through this connector are wrapped with ``dask.delayed``
+    so they can participate in Dask's lazy task-graph execution model.
+    """
+
+    def __init__(
+        self,
+        gravitino_uri: str,
+        metalake: str,
+        catalog: str,
+        schema: str,
+        dask_options: Optional[Dict[str, Any]] = None,
+    ):
+        """Create a DaskConnector.
+
+        Args:
+            gravitino_uri: The URI of the Gravitino server.
+            metalake: The metalake name.
+            catalog: The catalog name.
+            schema: The schema name.
+            dask_options: Optional dict of keyword arguments forwarded to
+                ``dask.delayed`` (e.g. ``{"pure": True, "nout": 1}``).
+
+        Raises:
+            ImportError: If the ``dask`` package is not installed.
+        """
+        super().__init__(gravitino_uri, metalake, catalog, schema)
+        try:
+            import dask  # noqa: F401 – availability check
+        except ImportError as exc:
+            raise ImportError(
+                "The 'dask' package is required for DaskConnector. "
+                "Install it with: pip install dask"
+            ) from exc
+        self._dask_options: Dict[str, Any] = dask_options or {}
+
+    @property
+    def runtime_type(self) -> FunctionImpl.RuntimeType:
+        """Returns the DASK runtime type."""
+        return FunctionImpl.RuntimeType.DASK
+
+    def _wrap_function(self, func: Callable, function_meta: Function) -> Any:
+        """Wrap *func* as a ``dask.delayed`` callable.
+
+        Args:
+            func: The raw Python callable resolved from the Gravitino UDF.
+            function_meta: The Gravitino function metadata.
+
+        Returns:
+            A ``dask.delayed`` wrapper around the callable.
+        """
+        import dask
+
+        delayed_fn = dask.delayed(func, **self._dask_options)
+        logger.info(
+            "Loaded Gravitino UDF '%s' as Dask delayed function",
+            function_meta.name(),
+        )
+        return delayed_fn

--- a/clients/client-python/gravitino/ai_engine/ray_connector.py
+++ b/clients/client-python/gravitino/ai_engine/ray_connector.py
@@ -1,0 +1,117 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Ray connector for Gravitino UDF management.
+
+This module provides the :class:`RayConnector` that loads UDFs registered in
+Gravitino and wraps them as Ray remote functions so they can be distributed
+across a Ray cluster.
+
+Usage example::
+
+    from gravitino.ai_engine.ray_connector import RayConnector
+
+    connector = RayConnector(
+        gravitino_uri="http://localhost:8090",
+        metalake="my_metalake",
+        catalog="my_catalog",
+        schema="my_schema",
+    )
+
+    # Load a single function
+    remote_fn = connector.load_function("add_one")
+    result = ray.get(remote_fn.remote(41))
+
+    # Load all Ray-runtime functions at once
+    functions = connector.load_functions()
+"""
+
+import logging
+from typing import Any, Callable, Dict, Optional
+
+from gravitino.ai_engine.base_connector import BaseAIEngineConnector
+from gravitino.api.function.function import Function
+from gravitino.api.function.function_impl import FunctionImpl
+
+logger = logging.getLogger(__name__)
+
+
+class RayConnector(BaseAIEngineConnector):
+    """Gravitino UDF connector for the Ray distributed compute engine.
+
+    Functions loaded through this connector are wrapped with ``ray.remote``
+    so they can be submitted as tasks on a Ray cluster.  Optional
+    ``ray_options`` (num_cpus, num_gpus, etc.) can be passed at construction
+    time and will be forwarded to every ``ray.remote`` call.
+    """
+
+    def __init__(
+        self,
+        gravitino_uri: str,
+        metalake: str,
+        catalog: str,
+        schema: str,
+        ray_options: Optional[Dict[str, Any]] = None,
+    ):
+        """Create a RayConnector.
+
+        Args:
+            gravitino_uri: The URI of the Gravitino server.
+            metalake: The metalake name.
+            catalog: The catalog name.
+            schema: The schema name.
+            ray_options: Optional dict of Ray resource options forwarded to
+                ``ray.remote`` (e.g. ``{"num_cpus": 2, "num_gpus": 1}``).
+
+        Raises:
+            ImportError: If the ``ray`` package is not installed.
+        """
+        super().__init__(gravitino_uri, metalake, catalog, schema)
+        try:
+            import ray  # noqa: F401 – availability check
+        except ImportError as exc:
+            raise ImportError(
+                "The 'ray' package is required for RayConnector. "
+                "Install it with: pip install ray"
+            ) from exc
+        self._ray_options: Dict[str, Any] = ray_options or {}
+
+    @property
+    def runtime_type(self) -> FunctionImpl.RuntimeType:
+        """Returns the RAY runtime type."""
+        return FunctionImpl.RuntimeType.RAY
+
+    def _wrap_function(self, func: Callable, function_meta: Function) -> Any:
+        """Wrap *func* as a ``ray.remote`` function.
+
+        Args:
+            func: The raw Python callable resolved from the Gravitino UDF.
+            function_meta: The Gravitino function metadata.
+
+        Returns:
+            A Ray ``RemoteFunction`` that can be invoked with ``.remote()``.
+        """
+        import ray
+
+        if self._ray_options:
+            remote_fn = ray.remote(**self._ray_options)(func)
+        else:
+            remote_fn = ray.remote(func)
+        logger.info(
+            "Loaded Gravitino UDF '%s' as Ray remote function", function_meta.name()
+        )
+        return remote_fn

--- a/clients/client-python/gravitino/api/function/function_impl.py
+++ b/clients/client-python/gravitino/api/function/function_impl.py
@@ -50,6 +50,12 @@ class FunctionImpl(ABC):
         TRINO = "TRINO"
         """Trino runtime."""
 
+        RAY = "RAY"
+        """Ray runtime."""
+
+        DASK = "DASK"
+        """Dask runtime."""
+
         @classmethod
         def from_string(cls, value: str) -> "FunctionImpl.RuntimeType":
             """Parse a runtime value from string.

--- a/clients/client-python/tests/unittests/test_ai_engine_connectors.py
+++ b/clients/client-python/tests/unittests/test_ai_engine_connectors.py
@@ -1,0 +1,481 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from gravitino.ai_engine.base_connector import BaseAIEngineConnector
+from gravitino.api.function.function import Function
+from gravitino.api.function.function_definition import FunctionDefinition
+from gravitino.api.function.function_impl import FunctionImpl
+from gravitino.api.function.function_type import FunctionType
+from gravitino.api.function.python_impl import PythonImpl
+from gravitino.api.function.sql_impl import SQLImpl
+
+
+def _make_function(
+    name: str,
+    impls: list,
+    function_type: FunctionType = FunctionType.SCALAR,
+) -> MagicMock:
+    """Create a mock Function with the given implementations."""
+    mock_definition = MagicMock(spec=FunctionDefinition)
+    mock_definition.impls.return_value = impls
+
+    mock_function = MagicMock(spec=Function)
+    mock_function.name.return_value = name
+    mock_function.function_type.return_value = function_type
+    mock_function.deterministic.return_value = True
+    mock_function.definitions.return_value = [mock_definition]
+    return mock_function
+
+
+class ConcreteConnector(BaseAIEngineConnector):
+    """Concrete test implementation of BaseAIEngineConnector."""
+
+    @property
+    def runtime_type(self) -> FunctionImpl.RuntimeType:
+        return FunctionImpl.RuntimeType.RAY
+
+    def _wrap_function(self, func, function_meta):
+        return func  # no wrapping for base tests
+
+
+class TestBaseAIEngineConnector(unittest.TestCase):
+    """Tests for BaseAIEngineConnector logic."""
+
+    @patch(
+        "gravitino.ai_engine.base_connector.GravitinoClient",
+        autospec=True,
+    )
+    def setUp(self, mock_client_cls):
+        self.mock_client = mock_client_cls.return_value
+        self.mock_catalog = MagicMock()
+        self.mock_function_catalog = MagicMock()
+        self.mock_client.load_catalog.return_value = self.mock_catalog
+        self.mock_catalog.as_function_catalog.return_value = (
+            self.mock_function_catalog
+        )
+        self.connector = ConcreteConnector(
+            gravitino_uri="http://localhost:8090",
+            metalake="test_ml",
+            catalog="test_cat",
+            schema="test_schema",
+        )
+
+    def test_list_functions_filters_by_runtime(self):
+        ray_impl = PythonImpl(
+            runtime=FunctionImpl.RuntimeType.RAY,
+            handler="my_module.add_one",
+        )
+        spark_impl = PythonImpl(
+            runtime=FunctionImpl.RuntimeType.SPARK,
+            handler="my_module.other",
+        )
+        func_ray = _make_function("ray_func", [ray_impl])
+        func_spark = _make_function("spark_func", [spark_impl])
+
+        self.mock_function_catalog.list_function_infos.return_value = [
+            func_ray,
+            func_spark,
+        ]
+
+        names = self.connector.list_functions()
+        self.assertEqual(["ray_func"], names)
+
+    def test_load_function_with_handler(self):
+        ray_impl = PythonImpl(
+            runtime=FunctionImpl.RuntimeType.RAY,
+            handler="os.path.join",
+        )
+        func = _make_function("path_join", [ray_impl])
+        self.mock_function_catalog.get_function.return_value = func
+
+        result = self.connector.load_function("path_join")
+        import os.path
+
+        self.assertIs(result, os.path.join)
+
+    def test_load_function_with_code_block(self):
+        code = "def add_one(x):\n    return x + 1\n"
+        ray_impl = PythonImpl(
+            runtime=FunctionImpl.RuntimeType.RAY,
+            handler="add_one",
+            code_block=code,
+        )
+        func = _make_function("add_one", [ray_impl])
+        self.mock_function_catalog.get_function.return_value = func
+
+        loaded = self.connector.load_function("add_one")
+        self.assertEqual(loaded(41), 42)
+
+    def test_load_function_no_matching_impl(self):
+        spark_impl = PythonImpl(
+            runtime=FunctionImpl.RuntimeType.SPARK,
+            handler="my_module.func",
+        )
+        func = _make_function("spark_only", [spark_impl])
+        self.mock_function_catalog.get_function.return_value = func
+
+        with self.assertRaises(ValueError) as ctx:
+            self.connector.load_function("spark_only")
+        self.assertIn("No RAY Python implementation", str(ctx.exception))
+
+    def test_load_function_skips_non_python_impl(self):
+        sql_impl = MagicMock(spec=SQLImpl)
+        sql_impl.runtime.return_value = FunctionImpl.RuntimeType.RAY
+
+        ray_impl = PythonImpl(
+            runtime=FunctionImpl.RuntimeType.RAY,
+            handler="os.path.exists",
+        )
+        func = _make_function("mixed", [sql_impl, ray_impl])
+        self.mock_function_catalog.get_function.return_value = func
+
+        result = self.connector.load_function("mixed")
+        import os.path
+
+        self.assertIs(result, os.path.exists)
+
+    def test_load_functions_returns_all(self):
+        ray_impl1 = PythonImpl(
+            runtime=FunctionImpl.RuntimeType.RAY,
+            handler="os.path.join",
+        )
+        ray_impl2 = PythonImpl(
+            runtime=FunctionImpl.RuntimeType.RAY,
+            handler="os.path.exists",
+        )
+        func1 = _make_function("join_fn", [ray_impl1])
+        func2 = _make_function("exists_fn", [ray_impl2])
+
+        self.mock_function_catalog.list_function_infos.return_value = [
+            func1,
+            func2,
+        ]
+        self.mock_function_catalog.get_function.side_effect = [func1, func2]
+
+        result = self.connector.load_functions()
+        self.assertEqual(set(result.keys()), {"join_fn", "exists_fn"})
+
+    def test_resolve_callable_bad_handler_no_dot(self):
+        impl = PythonImpl(
+            runtime=FunctionImpl.RuntimeType.RAY,
+            handler="no_dot_handler",
+        )
+        with self.assertRaises(ImportError):
+            BaseAIEngineConnector._resolve_callable(impl)
+
+    def test_resolve_callable_code_block_handler_missing(self):
+        impl = PythonImpl(
+            runtime=FunctionImpl.RuntimeType.RAY,
+            handler="missing_func",
+            code_block="x = 1\n",
+        )
+        with self.assertRaises(AttributeError) as ctx:
+            BaseAIEngineConnector._resolve_callable(impl)
+        self.assertIn("missing_func", str(ctx.exception))
+
+    def test_resolve_callable_not_callable(self):
+        impl = PythonImpl(
+            runtime=FunctionImpl.RuntimeType.RAY,
+            handler="my_var",
+            code_block="my_var = 42\n",
+        )
+        with self.assertRaises(ValueError) as ctx:
+            BaseAIEngineConnector._resolve_callable(impl)
+        self.assertIn("not callable", str(ctx.exception))
+
+
+class TestRayConnector(unittest.TestCase):
+    """Tests for RayConnector."""
+
+    @patch(
+        "gravitino.ai_engine.base_connector.GravitinoClient",
+        autospec=True,
+    )
+    @patch("gravitino.ai_engine.ray_connector.ray", create=True)
+    def test_wrap_function_calls_ray_remote(self, mock_ray, mock_client_cls):
+        mock_client = mock_client_cls.return_value
+        mock_catalog = MagicMock()
+        mock_function_catalog = MagicMock()
+        mock_client.load_catalog.return_value = mock_catalog
+        mock_catalog.as_function_catalog.return_value = mock_function_catalog
+
+        # Patch the import check
+        import sys
+
+        mock_ray_module = MagicMock()
+        sys.modules["ray"] = mock_ray_module
+
+        try:
+            from gravitino.ai_engine.ray_connector import RayConnector
+
+            connector = RayConnector(
+                gravitino_uri="http://localhost:8090",
+                metalake="ml",
+                catalog="cat",
+                schema="sch",
+            )
+
+            func = lambda x: x + 1  # noqa: E731
+            function_meta = _make_function("add_one", [])
+            mock_ray_module.remote.return_value = "wrapped"
+
+            result = connector._wrap_function(func, function_meta)
+            mock_ray_module.remote.assert_called_once_with(func)
+            self.assertEqual(result, "wrapped")
+        finally:
+            del sys.modules["ray"]
+
+    @patch(
+        "gravitino.ai_engine.base_connector.GravitinoClient",
+        autospec=True,
+    )
+    def test_ray_connector_import_error(self, mock_client_cls):
+        """RayConnector should raise ImportError if ray is not installed."""
+        mock_client = mock_client_cls.return_value
+        mock_catalog = MagicMock()
+        mock_client.load_catalog.return_value = mock_catalog
+        mock_catalog.as_function_catalog.return_value = MagicMock()
+
+        import sys
+
+        # Ensure ray is not importable
+        original = sys.modules.pop("ray", None)
+        try:
+            with patch.dict(sys.modules, {"ray": None}):
+                # Need to reload to trigger the import check
+                from gravitino.ai_engine import ray_connector
+
+                with self.assertRaises(ImportError) as ctx:
+                    ray_connector.RayConnector(
+                        gravitino_uri="http://localhost:8090",
+                        metalake="ml",
+                        catalog="cat",
+                        schema="sch",
+                    )
+                self.assertIn("ray", str(ctx.exception))
+        finally:
+            if original is not None:
+                sys.modules["ray"] = original
+
+    @patch(
+        "gravitino.ai_engine.base_connector.GravitinoClient",
+        autospec=True,
+    )
+    def test_ray_connector_with_options(self, mock_client_cls):
+        mock_client = mock_client_cls.return_value
+        mock_catalog = MagicMock()
+        mock_function_catalog = MagicMock()
+        mock_client.load_catalog.return_value = mock_catalog
+        mock_catalog.as_function_catalog.return_value = mock_function_catalog
+
+        import sys
+
+        mock_ray_module = MagicMock()
+        sys.modules["ray"] = mock_ray_module
+
+        try:
+            from gravitino.ai_engine.ray_connector import RayConnector
+
+            options = {"num_cpus": 2, "num_gpus": 1}
+            connector = RayConnector(
+                gravitino_uri="http://localhost:8090",
+                metalake="ml",
+                catalog="cat",
+                schema="sch",
+                ray_options=options,
+            )
+
+            func = lambda x: x + 1  # noqa: E731
+            function_meta = _make_function("add_one", [])
+
+            # ray.remote(**options) returns a decorator, then that decorator wraps func
+            mock_decorator = MagicMock(return_value="wrapped_with_opts")
+            mock_ray_module.remote.return_value = mock_decorator
+
+            result = connector._wrap_function(func, function_meta)
+            mock_ray_module.remote.assert_called_once_with(num_cpus=2, num_gpus=1)
+            mock_decorator.assert_called_once_with(func)
+            self.assertEqual(result, "wrapped_with_opts")
+        finally:
+            del sys.modules["ray"]
+
+    @patch(
+        "gravitino.ai_engine.base_connector.GravitinoClient",
+        autospec=True,
+    )
+    def test_ray_connector_runtime_type(self, mock_client_cls):
+        mock_client = mock_client_cls.return_value
+        mock_catalog = MagicMock()
+        mock_client.load_catalog.return_value = mock_catalog
+        mock_catalog.as_function_catalog.return_value = MagicMock()
+
+        import sys
+
+        sys.modules["ray"] = MagicMock()
+        try:
+            from gravitino.ai_engine.ray_connector import RayConnector
+
+            connector = RayConnector(
+                gravitino_uri="http://localhost:8090",
+                metalake="ml",
+                catalog="cat",
+                schema="sch",
+            )
+            self.assertEqual(connector.runtime_type, FunctionImpl.RuntimeType.RAY)
+        finally:
+            del sys.modules["ray"]
+
+
+class TestDaskConnector(unittest.TestCase):
+    """Tests for DaskConnector."""
+
+    @patch(
+        "gravitino.ai_engine.base_connector.GravitinoClient",
+        autospec=True,
+    )
+    def test_wrap_function_calls_dask_delayed(self, mock_client_cls):
+        mock_client = mock_client_cls.return_value
+        mock_catalog = MagicMock()
+        mock_function_catalog = MagicMock()
+        mock_client.load_catalog.return_value = mock_catalog
+        mock_catalog.as_function_catalog.return_value = mock_function_catalog
+
+        import sys
+
+        mock_dask_module = MagicMock()
+        sys.modules["dask"] = mock_dask_module
+
+        try:
+            from gravitino.ai_engine.dask_connector import DaskConnector
+
+            connector = DaskConnector(
+                gravitino_uri="http://localhost:8090",
+                metalake="ml",
+                catalog="cat",
+                schema="sch",
+            )
+
+            func = lambda x: x + 1  # noqa: E731
+            function_meta = _make_function("add_one", [])
+            mock_dask_module.delayed.return_value = "delayed_fn"
+
+            result = connector._wrap_function(func, function_meta)
+            mock_dask_module.delayed.assert_called_once_with(func)
+            self.assertEqual(result, "delayed_fn")
+        finally:
+            del sys.modules["dask"]
+
+    @patch(
+        "gravitino.ai_engine.base_connector.GravitinoClient",
+        autospec=True,
+    )
+    def test_dask_connector_import_error(self, mock_client_cls):
+        """DaskConnector should raise ImportError if dask is not installed."""
+        mock_client = mock_client_cls.return_value
+        mock_catalog = MagicMock()
+        mock_client.load_catalog.return_value = mock_catalog
+        mock_catalog.as_function_catalog.return_value = MagicMock()
+
+        import sys
+
+        original = sys.modules.pop("dask", None)
+        try:
+            with patch.dict(sys.modules, {"dask": None}):
+                from gravitino.ai_engine import dask_connector
+
+                with self.assertRaises(ImportError) as ctx:
+                    dask_connector.DaskConnector(
+                        gravitino_uri="http://localhost:8090",
+                        metalake="ml",
+                        catalog="cat",
+                        schema="sch",
+                    )
+                self.assertIn("dask", str(ctx.exception))
+        finally:
+            if original is not None:
+                sys.modules["dask"] = original
+
+    @patch(
+        "gravitino.ai_engine.base_connector.GravitinoClient",
+        autospec=True,
+    )
+    def test_dask_connector_runtime_type(self, mock_client_cls):
+        mock_client = mock_client_cls.return_value
+        mock_catalog = MagicMock()
+        mock_client.load_catalog.return_value = mock_catalog
+        mock_catalog.as_function_catalog.return_value = MagicMock()
+
+        import sys
+
+        sys.modules["dask"] = MagicMock()
+        try:
+            from gravitino.ai_engine.dask_connector import DaskConnector
+
+            connector = DaskConnector(
+                gravitino_uri="http://localhost:8090",
+                metalake="ml",
+                catalog="cat",
+                schema="sch",
+            )
+            self.assertEqual(connector.runtime_type, FunctionImpl.RuntimeType.DASK)
+        finally:
+            del sys.modules["dask"]
+
+    @patch(
+        "gravitino.ai_engine.base_connector.GravitinoClient",
+        autospec=True,
+    )
+    def test_dask_connector_with_options(self, mock_client_cls):
+        mock_client = mock_client_cls.return_value
+        mock_catalog = MagicMock()
+        mock_function_catalog = MagicMock()
+        mock_client.load_catalog.return_value = mock_catalog
+        mock_catalog.as_function_catalog.return_value = mock_function_catalog
+
+        import sys
+
+        mock_dask_module = MagicMock()
+        sys.modules["dask"] = mock_dask_module
+
+        try:
+            from gravitino.ai_engine.dask_connector import DaskConnector
+
+            options = {"pure": True, "nout": 1}
+            connector = DaskConnector(
+                gravitino_uri="http://localhost:8090",
+                metalake="ml",
+                catalog="cat",
+                schema="sch",
+                dask_options=options,
+            )
+
+            func = lambda x: x + 1  # noqa: E731
+            function_meta = _make_function("add_one", [])
+            mock_dask_module.delayed.return_value = "delayed_fn"
+
+            result = connector._wrap_function(func, function_meta)
+            mock_dask_module.delayed.assert_called_once_with(func, pure=True, nout=1)
+            self.assertEqual(result, "delayed_fn")
+        finally:
+            del sys.modules["dask"]
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/common/src/test/java/org/apache/gravitino/dto/function/TestFunctionDTO.java
+++ b/common/src/test/java/org/apache/gravitino/dto/function/TestFunctionDTO.java
@@ -290,4 +290,53 @@ public class TestFunctionDTO {
     Assertions.assertEquals(2, deserialized.returnColumns().length);
     Assertions.assertEquals("id", deserialized.returnColumns()[0].name());
   }
+
+  @Test
+  public void testRuntimeTypeFromString() {
+    Assertions.assertEquals(FunctionImpl.RuntimeType.SPARK, FunctionImpl.RuntimeType.fromString("SPARK"));
+    Assertions.assertEquals(FunctionImpl.RuntimeType.TRINO, FunctionImpl.RuntimeType.fromString("trino"));
+    Assertions.assertEquals(FunctionImpl.RuntimeType.RAY, FunctionImpl.RuntimeType.fromString("ray"));
+    Assertions.assertEquals(FunctionImpl.RuntimeType.DASK, FunctionImpl.RuntimeType.fromString("Dask"));
+    Assertions.assertThrows(
+        IllegalArgumentException.class, () -> FunctionImpl.RuntimeType.fromString(""));
+    Assertions.assertThrows(
+        IllegalArgumentException.class, () -> FunctionImpl.RuntimeType.fromString("unknown"));
+  }
+
+  @Test
+  public void testPythonImplDTOWithAIEngineRuntime() throws JsonProcessingException {
+    // Test Python UDF with RAY runtime
+    PythonImplDTO rayPythonImpl =
+        new PythonImplDTO(
+            FunctionImpl.RuntimeType.RAY.name(),
+            null,
+            ImmutableMap.of(),
+            "add_one",
+            "def add_one(x):\n    return x + 1");
+    String rayJson = JsonUtils.objectMapper().writeValueAsString(rayPythonImpl);
+    FunctionImplDTO deserializedRay =
+        JsonUtils.objectMapper().readValue(rayJson, FunctionImplDTO.class);
+    Assertions.assertTrue(deserializedRay instanceof PythonImplDTO);
+    Assertions.assertEquals(FunctionImpl.Language.PYTHON, deserializedRay.language());
+    Assertions.assertEquals("RAY", deserializedRay.getRuntime());
+    Assertions.assertEquals("add_one", ((PythonImplDTO) deserializedRay).getHandler());
+    Assertions.assertNotNull(((PythonImplDTO) deserializedRay).getCodeBlock());
+
+    // Test Python UDF with DASK runtime
+    PythonImplDTO daskPythonImpl =
+        new PythonImplDTO(
+            FunctionImpl.RuntimeType.DASK.name(),
+            null,
+            ImmutableMap.of("dask.npartitions", "4"),
+            "my_module.transform",
+            null);
+    String daskJson = JsonUtils.objectMapper().writeValueAsString(daskPythonImpl);
+    FunctionImplDTO deserializedDask =
+        JsonUtils.objectMapper().readValue(daskJson, FunctionImplDTO.class);
+    Assertions.assertTrue(deserializedDask instanceof PythonImplDTO);
+    Assertions.assertEquals("DASK", deserializedDask.getRuntime());
+    Assertions.assertEquals(
+        "my_module.transform", ((PythonImplDTO) deserializedDask).getHandler());
+    Assertions.assertNull(((PythonImplDTO) deserializedDask).getCodeBlock());
+  }
 }

--- a/docs/ai-engine-udf-integration.md
+++ b/docs/ai-engine-udf-integration.md
@@ -1,0 +1,195 @@
+---
+title: AI engine UDF integration
+slug: /ai-engine-udf-integration
+keyword: Gravitino UDF Ray Dask AI engine integration
+license: This software is licensed under the Apache License version 2.
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+This page describes how to use Gravitino-registered UDFs with AI compute engines
+such as [Ray](https://www.ray.io/) and [Dask](https://www.dask.org/).
+
+## Overview
+
+Gravitino's AI engine connectors allow Python-based AI/ML pipelines to load
+user-defined functions that are centrally managed in Gravitino and execute them
+as distributed tasks on Ray or Dask clusters. Each connector:
+
+1. Connects to the Gravitino server and retrieves function metadata.
+2. Filters for implementations that match the target runtime (`RAY` or `DASK`).
+3. Resolves the `PythonImpl` handler (either from an installed module or an
+   inline code block).
+4. Wraps the resolved callable with the engine-specific primitive
+   (`ray.remote` or `dask.delayed`).
+
+### Supported runtimes
+
+| Runtime | Wrapper          | Connector class    |
+|---------|------------------|--------------------|
+| `RAY`   | `ray.remote`     | `RayConnector`     |
+| `DASK`  | `dask.delayed`   | `DaskConnector`    |
+
+## Prerequisites
+
+- A running Gravitino server.
+- A metalake, catalog, and schema already created.
+- Functions registered with a `PythonImpl` implementation targeting the `RAY`
+  or `DASK` runtime.
+- The `ray` or `dask` Python package installed in your environment.
+
+```bash
+# For Ray
+pip install apache-gravitino ray
+
+# For Dask
+pip install apache-gravitino dask distributed
+```
+
+## Registering a function for AI engines
+
+When registering a UDF, add a `PythonImpl` with the desired `RuntimeType`.
+The implementation can reference either an installed Python module or provide
+inline code.
+
+### Module-level handler
+
+```python
+from gravitino.api.function.function_impl import FunctionImpl
+from gravitino.api.function.python_impl import PythonImpl
+
+ray_impl = (
+    PythonImpl.builder()
+    .with_runtime_type(FunctionImpl.RuntimeType.RAY)
+    .with_handler("my_package.transforms.add_one")
+    .build()
+)
+```
+
+### Inline code block
+
+```python
+code = """
+def add_one(x):
+    return x + 1
+"""
+
+ray_impl = (
+    PythonImpl.builder()
+    .with_runtime_type(FunctionImpl.RuntimeType.RAY)
+    .with_handler("add_one")
+    .with_code_block(code)
+    .build()
+)
+```
+
+Register the function using the Python client as described in the
+[UDF management guide](manage-user-defined-function-using-gravitino.md).
+
+## Using the Ray connector
+
+```python
+import ray
+from gravitino.ai_engine.ray_connector import RayConnector
+
+ray.init()
+
+connector = RayConnector(
+    gravitino_uri="http://localhost:8090",
+    metalake="my_metalake",
+    catalog="my_catalog",
+    schema="my_schema",
+)
+
+# List available Ray functions
+print(connector.list_functions())
+
+# Load and invoke a single function
+add_one = connector.load_function("add_one")
+result = ray.get(add_one.remote(41))
+print(result)  # 42
+
+# Load all Ray-runtime functions
+all_fns = connector.load_functions()
+```
+
+### Ray resource options
+
+You can pass resource hints (CPU, GPU, memory) when constructing the connector.
+These options are forwarded to every `ray.remote` call:
+
+```python
+connector = RayConnector(
+    gravitino_uri="http://localhost:8090",
+    metalake="my_metalake",
+    catalog="my_catalog",
+    schema="my_schema",
+    ray_options={"num_cpus": 2, "num_gpus": 1},
+)
+```
+
+## Using the Dask connector
+
+```python
+from dask.distributed import Client
+from gravitino.ai_engine.dask_connector import DaskConnector
+
+client = Client()  # connect to a Dask cluster
+
+connector = DaskConnector(
+    gravitino_uri="http://localhost:8090",
+    metalake="my_metalake",
+    catalog="my_catalog",
+    schema="my_schema",
+)
+
+# List available Dask functions
+print(connector.list_functions())
+
+# Load and invoke a single function
+add_one = connector.load_function("add_one")
+result = add_one(41).compute()
+print(result)  # 42
+
+# Load all Dask-runtime functions
+all_fns = connector.load_functions()
+```
+
+### Dask delayed options
+
+You can pass options to `dask.delayed` via the `dask_options` parameter:
+
+```python
+connector = DaskConnector(
+    gravitino_uri="http://localhost:8090",
+    metalake="my_metalake",
+    catalog="my_catalog",
+    schema="my_schema",
+    dask_options={"pure": True},
+)
+```
+
+## Architecture
+
+```
+┌──────────────────────────────────────────────┐
+│                  User Code                    │
+│  connector.load_function("add_one")           │
+└──────────┬───────────────────────────────────┘
+           │
+           ▼
+┌──────────────────────────────────────────────┐
+│       RayConnector / DaskConnector            │
+│  1. list / get function from Gravitino        │
+│  2. Filter PythonImpl by runtime (RAY/DASK)   │
+│  3. Resolve handler → Python callable         │
+│  4. Wrap: ray.remote(fn) / dask.delayed(fn)   │
+└──────────┬───────────────────────────────────┘
+           │  REST API
+           ▼
+┌──────────────────────────────────────────────┐
+│            Gravitino Server                   │
+│  /api/metalakes/.../functions/{name}          │
+└──────────────────────────────────────────────┘
+```

--- a/docs/manage-user-defined-function-using-gravitino.md
+++ b/docs/manage-user-defined-function-using-gravitino.md
@@ -697,6 +697,8 @@ implementation based on the runtime.
 | Engine | Runtime             | Documentation                                                                      |
 |--------|---------------------|------------------------------------------------------------------------------------|
 | Spark  | `RuntimeType.SPARK` | [Spark connector - User-defined functions](spark-connector/spark-connector-udf.md) |
+| Ray    | `RuntimeType.RAY`   | [AI engine integration](ai-engine-udf-integration.md)                              |
+| Dask   | `RuntimeType.DASK`  | [AI engine integration](ai-engine-udf-integration.md)                              |
 
 :::note
 Support for additional engines (e.g. Trino, Flink) will be documented as they become available.


### PR DESCRIPTION
- Add RAY and DASK runtime types to FunctionImpl.RuntimeType (Java + Python)
- Implement BaseAIEngineConnector with shared UDF loading logic
- Implement RayConnector wrapping UDFs with ray.remote
- Implement DaskConnector wrapping UDFs with dask.delayed
- Add 17 unit tests for all connector classes
- Add Java tests for new RuntimeType enum values and PythonImplDTO with AI runtimes
- Add AI engine UDF integration documentation
- Update UDF management docs with Ray/Dask engine references