### PR TITLE
[#10502] fix(ci): pin docker actions to SHA for v4.0.0 (#10504)(cherry-pick-to-1.2)

### DIFF
--- a/.github/workflows/access-control-integration-test.yml
+++ b/.github/workflows/access-control-integration-test.yml
@@ -70,7 +70,7 @@ jobs:
           cache: 'gradle'
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
 
       - name: Check required command
         run: |

--- a/.github/workflows/backend-integration-test-action.yml
+++ b/.github/workflows/backend-integration-test-action.yml
@@ -43,7 +43,7 @@ jobs:
           cache: 'gradle'
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
 
       - name: Check required command
         run: |

--- a/.github/workflows/cron-integration-test.yml
+++ b/.github/workflows/cron-integration-test.yml
@@ -71,7 +71,7 @@ jobs:
 
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
 
       - name: Package Gravitino
         run: |

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -115,16 +115,16 @@ jobs:
           fi
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
         with:
           username: ${{ github.event.inputs.username }}
           password: ${{ secrets.DOCKER_REPOSITORY_PASSWORD }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - uses: actions/checkout@v4
 

--- a/.github/workflows/flink-integration-test-action.yml
+++ b/.github/workflows/flink-integration-test-action.yml
@@ -30,7 +30,7 @@ jobs:
           cache: 'gradle'
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
 
       - name: Check required command
         run: |

--- a/.github/workflows/frontend-integration-test.yml
+++ b/.github/workflows/frontend-integration-test.yml
@@ -75,7 +75,7 @@ jobs:
           cache: 'gradle'
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
 
       - name: Check required command
         run: |

--- a/.github/workflows/gvfs-fuse-build-test.yml
+++ b/.github/workflows/gvfs-fuse-build-test.yml
@@ -66,7 +66,7 @@ jobs:
           cache: 'gradle'
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
 
       - name: Check required command
         run: |

--- a/.github/workflows/python-integration-test.yml
+++ b/.github/workflows/python-integration-test.yml
@@ -66,7 +66,7 @@ jobs:
           cache: 'gradle'
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
 
       - name: Free up disk space
         run: |

--- a/.github/workflows/spark-integration-test-action.yml
+++ b/.github/workflows/spark-integration-test-action.yml
@@ -38,7 +38,7 @@ jobs:
           cache: 'gradle'
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
 
       - name: Check required command
         run: |

--- a/.github/workflows/trino-integration-test.yml
+++ b/.github/workflows/trino-integration-test.yml
@@ -68,7 +68,7 @@ jobs:
           cache: 'gradle'
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
 
       - name: Check required command
         run: |


### PR DESCRIPTION
### What changes were proposed in this pull request?

Pin all `docker/*` GitHub Actions to their exact commit SHA (v4.0.0) in every CI workflow file, as required by the Apache GitHub organization policy.

The Apache allowlist at
https://github.com/apache/infrastructure-actions/blob/main/actions.yml requires SHA-pinned references, not floating tags like `@v3` or `@v3.6.0`.

Updated SHAs (from the Apache allowlist):
| Action | SHA | Tag |
|--------|-----|-----|
| `docker/setup-qemu-action` |
`ce360397dd3f832beb865e1373c09c0e9f86d70a` | v4.0.0 | | `docker/login-action` | `b45d80f862d83dbcd57f89517bcf500b2ab88fb2` | v4.0.0 |
| `docker/setup-buildx-action` |
`4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd` | v4.0.0 |

Affected files (10):
- `.github/workflows/access-control-integration-test.yml`
- `.github/workflows/python-integration-test.yml`
- `.github/workflows/trino-integration-test.yml`
- `.github/workflows/backend-integration-test-action.yml`
- `.github/workflows/cron-integration-test.yml`
- `.github/workflows/gvfs-fuse-build-test.yml`
- `.github/workflows/flink-integration-test-action.yml`
- `.github/workflows/spark-integration-test-action.yml`
- `.github/workflows/frontend-integration-test.yml`
- `.github/workflows/docker-image.yml`

### Why are the changes needed?

Fix #10502

The Apache GitHub organization policy requires actions to be referenced by their exact commit SHA. Using floating tags (`@v3`, `@v3.6.0`) causes all CI runs to fail with:

> The action docker/setup-qemu-action@v3.6.0 is not allowed in
apache/gravitino because all actions must be from a repository owned by your enterprise, created by GitHub, or match one of the patterns

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

CI-only change; no logic modified.