### PR TITLE
[MINOR] fix(release): fix LICENSE/NOTICE issues and add v1.1.1 Docker changelog entries for branch-1.1

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -280,7 +280,7 @@
    ./core/src/main/java/org/apache/gravitino/utils/Bytes.java
 
    Apache Submarine
-   ./bin/common.sh
+   ./bin/common.sh.template
 
    Confluent Kafka Streams Examples
    ./catalogs/catalog-kafka/src/test/java/org/apache/gravitino/catalog/kafka/embedded/KafkaClusterEmbedded.java
@@ -294,6 +294,10 @@
    ./integration-test-common/src/test/java/org/apache/gravitino/integration/test/util/CloseableGroup.java
    ./trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/catalog/hive/SortingColumn.java
    ./trino-connector/integration-test/src/test/resources/trino-ci-testset/testsets/hive/00012_format.sql
+   ./trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/util/json/AbstractTypedJacksonModule.java
+   ./trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/util/json/BlockJsonSerde.java
+   ./trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/util/json/TypeDeserializer.java
+   ./trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/util/json/TypeSignatureDeserializer.java
 
    Apache Arrow
    ./dev/ci/util_free_space.sh
@@ -323,6 +327,6 @@
 
     This product bundles a third-party component under the
     BSD License.
-   .dev/docker/kerberos-hive/kadm5.acl
-   .dev/docker/kerberos-hive/kdc.acl
-   .dev/docker/kerberos-hive/krb5.acl
+   ./dev/docker/kerberos-hive/kadm5.acl
+   ./dev/docker/kerberos-hive/kdc.conf
+   ./dev/docker/kerberos-hive/krb5.conf

--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Apache Gravitino
-Copyright 2025 The Apache Software Foundation
+Copyright 2026 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/clients/client-python/NOTICE
+++ b/clients/client-python/NOTICE
@@ -1,5 +1,5 @@
 Apache Gravitino
-Copyright 2025 The Apache Software Foundation
+Copyright 2026 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/dev/release/release-build.sh
+++ b/dev/release/release-build.sh
@@ -210,8 +210,14 @@ if [[ "$1" == "package" ]]; then
   rm -f gravitino-$GRAVITINO_VERSION-src/NOTICE.rest
   rm -f gravitino-$GRAVITINO_VERSION-src/LICENSE.trino
   rm -f gravitino-$GRAVITINO_VERSION-src/NOTICE.trino
+  rm -f gravitino-$GRAVITINO_VERSION-src/LICENSE.iceberg
+  rm -f gravitino-$GRAVITINO_VERSION-src/NOTICE.iceberg
+  rm -f gravitino-$GRAVITINO_VERSION-src/LICENSE.lance
+  rm -f gravitino-$GRAVITINO_VERSION-src/NOTICE.lance
   rm -f gravitino-$GRAVITINO_VERSION-src/web/web/LICENSE.bin
   rm -f gravitino-$GRAVITINO_VERSION-src/web/web/NOTICE.bin
+  rm -f gravitino-$GRAVITINO_VERSION-src/web-v2/web/LICENSE.bin
+  rm -f gravitino-$GRAVITINO_VERSION-src/web-v2/web/NOTICE.bin
 
   rm -f *.asc
   tar cvzf gravitino-$GRAVITINO_VERSION-src.tar.gz --exclude gravitino-$GRAVITINO_VERSION-src/.git gravitino-$GRAVITINO_VERSION-src

--- a/docs/docker-image-details.md
+++ b/docs/docker-image-details.md
@@ -23,6 +23,9 @@ JVM heap and metaspace are controlled by `GRAVITINO_MEM` (default `-Xms1024m -Xm
 
 Changelog
 
+- apache/gravitino:1.1.1
+  - Based on Gravitino 1.1.1, you can know more information from 1.1.1 [release notes](https://github.com/apache/gravitino/releases/tag/v1.1.1).
+
 - apache/gravitino:1.1.0
   - Based on Gravitino 1.1.0, you can know more information from 1.1.0 [release notes](https://github.com/apache/gravitino/releases/tag/v1.1.0).
 
@@ -83,6 +86,9 @@ Use `GRAVITINO_MEM` to size the JVM (default `-Xms1024m -Xmx1024m -XX:MaxMetaspa
 
 Changelog
 
+- apache/gravitino-iceberg-rest:1.1.1
+  - Based on Gravitino 1.1.1, you can know more information from 1.1.1 [release notes](https://github.com/apache/gravitino/releases/tag/v1.1.1).
+
 - apache/gravitino-iceberg-rest:1.1.0
   - Support scan planning endpoint
   - Support get credentials endpoint
@@ -135,6 +141,9 @@ docker run --rm -d -p 8000:8000 apache/gravitino-mcp-server:latest --metalake te
 
 Changelog
 
+- apache/gravitino-mcp-server:1.1.1
+  - Built with Gravitino 1.1.1. For more information, see 1.1.1 [release notes](https://github.com/apache/gravitino/releases/tag/v1.1.1).
+
 - apache/gravitino-mcp-server:1.1.0
   - Built with Gravitino 1.1.0. For more information, see 1.1.0 [release notes](https://github.com/apache/gravitino/releases/tag/v1.1.0).
 
@@ -167,6 +176,9 @@ It's not advised to change `LANCE_REST_NAMESPACE_BACKEND`, `LANCE_REST_HOST` and
 
 Changelog
 
+- apache/gravitino-lance-rest:1.1.1
+  - Built with Gravitino 1.1.1. For more information, see 1.1.1 [release notes](https://github.com/apache/gravitino/releases/tag/v1.1.1).
+
 - apache/gravitino-lance-rest:1.1.0
   - Initial release of Lance REST server
   - Support Lance tables integration through REST API
@@ -196,6 +208,9 @@ Changelog
 ### Trino image
 
 Changelog
+
+- apache/gravitino-playground:trino-435-gravitino-1.1.1
+  - Use Gravitino release 1.1.1 Dockerfile to build the image.
 
 - apache/gravitino-playground:trino-435-gravitino-1.1.0
   - Use Gravitino release 1.1.0 Dockerfile to build the image.

--- a/mcp-server/NOTICE
+++ b/mcp-server/NOTICE
@@ -1,5 +1,5 @@
 Apache Gravitino
-Copyright 2025 The Apache Software Foundation
+Copyright 2026 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/web/web/NOTICE
+++ b/web/web/NOTICE
@@ -1,5 +1,5 @@
 Apache Gravitino
-Copyright 2024 The Apache Software Foundation
+Copyright 2026 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).


### PR DESCRIPTION
### What changes were proposed in this pull request?

Mimicking PRs #10197 and #10395 for the branch-1.1 (v1.1.1 release):

1. **NOTICE copyright year**: Updated to 2026 in 4 NOTICE files (`NOTICE`, `clients/client-python/NOTICE`, `mcp-server/NOTICE`, `web/web/NOTICE`)
2. **LICENSE fixes**:
   - Fix `./bin/common.sh` → `./bin/common.sh.template` under Apache Submarine section
   - Add 4 Trino-derived JSON utility files under the Trino section
   - Fix BSD section paths: add leading `./` and rename `kdc.acl→kdc.conf`, `krb5.acl→krb5.conf`
3. **release-build.sh**: Add removal of `LICENSE/NOTICE.iceberg`, `LICENSE/NOTICE.lance`, `web-v2/web/LICENSE/NOTICE.bin` from source packages
4. **docs/docker-image-details.md**: Add v1.1.1 changelog entries for all 5 Docker images

### Why are the changes needed?

Required for a clean v1.1.1 Apache release: correct copyright years, accurate LICENSE file paths, and proper source package cleanup.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review of file changes against the reference PRs (#10197, #10395).