### PR TITLE
[#10524] improvement(catalog-lakehouse-paimon): exclude unnecessary tomcat transitive dependency 

### DIFF
--- a/catalogs/catalog-lakehouse-paimon/build.gradle.kts
+++ b/catalogs/catalog-lakehouse-paimon/build.gradle.kts
@@ -85,6 +85,7 @@ dependencies {
     exclude("commons-codec")
     exclude("commons-cli")
     exclude("tomcat")
+    exclude("org.apache.tomcat.embed")
     exclude("org.apache.avro")
     exclude("net.sf.opencsv")
     exclude("javolution")


### PR DESCRIPTION

### What changes were proposed in this pull request?

Added exclude("org.apache.tomcat.embed")  to the Paimon bundle dependency block in 
build.gradle.kts.

### Why are the changes needed?

tomcat-embed-core:8.5.46 is pulled in transitively via libthrift:0.14.1 (used only for thrift's optional HTTP transport). The Paimon catalog does not use it at runtime. Excluding it keeps the dependency footprint clean, consistent with the many other excludes already in this block.

Fix: #10524 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

1. Verified compileJava, jar, and test  all pass for :catalogs:catalog-lakehouse-paimon
2. Confirmed tomcat-embed-core no longer appears in runtimeClasspath dependency tree or build/libs
