### PR TITLE
[#10527] fix(build): Pin localstack docker image version to 4.14.0 to fix CI problem

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -192,7 +192,7 @@ allprojects {
       param.environment("GRAVITINO_CI_TRINO_DOCKER_IMAGE", "apache/gravitino-ci:trino-0.1.6")
       param.environment("GRAVITINO_CI_RANGER_DOCKER_IMAGE", "apache/gravitino-ci:ranger-0.1.2")
       param.environment("GRAVITINO_CI_KAFKA_DOCKER_IMAGE", "apache/kafka:3.7.0")
-      param.environment("GRAVITINO_CI_LOCALSTACK_DOCKER_IMAGE", "localstack/localstack:latest")
+      param.environment("GRAVITINO_CI_LOCALSTACK_DOCKER_IMAGE", "localstack/localstack:4.14.0")
 
       // Disable Ryuk for integration tests
       // Ryuk need privileged mode, if we want to rootless or run non-privileged mode, we need to disable it.


### PR DESCRIPTION
### What changes were proposed in this pull request?
Pin the `GRAVITINO_CI_LOCALSTACK_DOCKER_IMAGE` version from `latest` to `4.14.0` to
prevent CI failures caused by breaking changes in newer localstack releases.

### Why are the changes needed?
Fix: #10527

`FilesetS3CatalogIT` and related ITs have been failing since 2026-03-24 because
`localstack/localstack:latest` pulled a newer image that is incompatible with the
current test setup. Pinning to `4.14.0` (the last known-good version) restores
CI stability.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
N/A — this is a CI configuration fix. The ITs themselves remain unchanged.