### PR TITLE
[#10338] fix(build): update log4j2 properties template names in build configuration (#10340)(cherry-pick)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -784,7 +784,7 @@ tasks {
           include(
             "${rootProject.name}-iceberg-rest-server.conf.template",
             "${rootProject.name}-env.sh.template",
-            "log4j2.properties.template"
+            "${rootProject.name}-iceberg-rest-log4j2.properties.template"
           )
           into("${rootProject.name}-iceberg-rest-server/conf")
         }
@@ -829,7 +829,7 @@ tasks {
           include(
             "${rootProject.name}-lance-rest-server.conf.template",
             "${rootProject.name}-env.sh.template",
-            "log4j2.properties.template"
+            "${rootProject.name}-lance-rest-log4j2.properties.template"
           )
           into("${rootProject.name}-lance-rest-server/conf")
         }

--- a/docs/lance-rest-service.md
+++ b/docs/lance-rest-service.md
@@ -171,7 +171,6 @@ Launch Lance REST service using Docker(You need to start Gravitino server first)
 
 ```shell
 docker run -d --name lance-rest-service -p 9101:9101 \
-  -e LANCE_REST_GRAVITINO_URI=http://gravitino-host:8090 \
   -e LANCE_REST_GRAVITINO_METALAKE_NAME=your_metalake_name \
   -e LANCE_REST_GRAVITINO_URI=http://gravitino-host:port \
   apache/gravitino-lance-rest:latest


### PR DESCRIPTION

### What changes were proposed in this pull request?

This pull request makes a minor update to the Docker launch instructions in the `lance-rest-service.md` documentation. The change clarifies the placeholder for the Gravitino server URI, making it more generic and consistent with the other environment variables.

* Documentation update:
* Updated the Docker command example in `lance-rest-service.md` to use a generic `http://gravitino-host:port` placeholder for the `LANCE_REST_GRAVITINO_URI` environment variable, improving clarity and consistency.

### Why are the changes needed?

It's a bug

Fix: #10338

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

Locally and CI.