### PR TITLE
[#10537] improvement(core): Complete v2 audit operation mapping coverage

### DIFF
--- a/core/src/main/java/org/apache/gravitino/audit/AuditLog.java
+++ b/core/src/main/java/org/apache/gravitino/audit/AuditLog.java
@@ -459,6 +459,18 @@ public interface AuditLog {
 
     GET_POLICY_FOR_METADATA_OBJECT,
 
+    REGISTER_FUNCTION,
+
+    GET_FUNCTION,
+
+    ALTER_FUNCTION,
+
+    DROP_FUNCTION,
+
+    LIST_FUNCTION,
+
+    LIST_FUNCTION_INFOS,
+
     UNKNOWN_OPERATION;
 
     public static Operation fromEvent(Event event) {

--- a/core/src/main/java/org/apache/gravitino/audit/v2/CompatibilityUtils.java
+++ b/core/src/main/java/org/apache/gravitino/audit/v2/CompatibilityUtils.java
@@ -174,6 +174,12 @@ public class CompatibilityUtils {
           .put(
               OperationType.GET_POLICY_FOR_METADATA_OBJECT,
               Operation.GET_POLICY_FOR_METADATA_OBJECT)
+          .put(OperationType.REGISTER_FUNCTION, Operation.REGISTER_FUNCTION)
+          .put(OperationType.GET_FUNCTION, Operation.GET_FUNCTION)
+          .put(OperationType.ALTER_FUNCTION, Operation.ALTER_FUNCTION)
+          .put(OperationType.DROP_FUNCTION, Operation.DROP_FUNCTION)
+          .put(OperationType.LIST_FUNCTION, Operation.LIST_FUNCTION)
+          .put(OperationType.LIST_FUNCTION_INFOS, Operation.LIST_FUNCTION_INFOS)
           .put(OperationType.UNKNOWN, Operation.UNKNOWN_OPERATION)
           .build();
 

--- a/core/src/test/java/org/apache/gravitino/audit/v2/TestCompatibilityUtils.java
+++ b/core/src/test/java/org/apache/gravitino/audit/v2/TestCompatibilityUtils.java
@@ -178,6 +178,12 @@ public class TestCompatibilityUtils {
         Operation.ASSOCIATE_POLICIES_FOR_METADATA_OBJECT
       },
       {OperationType.GET_POLICY_FOR_METADATA_OBJECT, Operation.GET_POLICY_FOR_METADATA_OBJECT},
+      {OperationType.REGISTER_FUNCTION, Operation.REGISTER_FUNCTION},
+      {OperationType.GET_FUNCTION, Operation.GET_FUNCTION},
+      {OperationType.ALTER_FUNCTION, Operation.ALTER_FUNCTION},
+      {OperationType.DROP_FUNCTION, Operation.DROP_FUNCTION},
+      {OperationType.LIST_FUNCTION, Operation.LIST_FUNCTION},
+      {OperationType.LIST_FUNCTION_INFOS, Operation.LIST_FUNCTION_INFOS},
       {OperationType.UNKNOWN, Operation.UNKNOWN_OPERATION},
       {null, Operation.UNKNOWN_OPERATION}
     };


### PR DESCRIPTION
### What changes were proposed in this pull request?

Added explicit v2 audit mappings for all known `OperationType` values in `CompatibilityUtils`, expanded `AuditLog.Operation` with the concrete audit operation values needed by v2, and added tests to verify all known operation types map to a non-unknown audit operation.

### Why are the changes needed?

The previous v2 compatibility mapping only covered part of the listener operation space. Many supported operations still fell back to `UNKNOWN_OPERATION`, which made audit output incomplete and inconsistent.

Fix: #10537

### Does this PR introduce _any_ user-facing change?

No. This change only completes internal audit operation mapping for v2 audit compatibility.

### How was this patch tested?

```bash
IT_SPARK_HOME=/Users/fanng/deploy/demo/spark-3.5.3-bin-hadoop3 \
IT_SPARK_ARGS='--conf spark.jars=/Users/fanng/deploy/demo/jars/iceberg-spark-runtime-3.5_2.12-1.9.2.jar,/Users/fanng/deploy/demo/jars/iceberg-aws-bundle-1.9.2.jar --conf spark.sql.extensions=org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions --conf spark.sql.catalog.rest=org.apache.iceberg.spark.SparkCatalog --conf spark.sql.catalog.rest.type=rest --conf spark.sql.catalog.rest.uri=http://127.0.0.1:9001/iceberg/ --conf spark.sql.catalog.rest.header.X-Iceberg-Access-Delegation=vended-credentials' \
IT_TABLE_IDENTIFIER=rest.ab.a1 \
GRAVITINO_ENV_IT=true \
./gradlew :core:test -PskipIT=true --tests 'org.apache.gravitino.audit.v2.TestCompatibilityUtils'
```
