### PR TITLE
fix(test): Use in-memory H2 database instead of file-based in TestGravitinoMetricsUpdater

### DIFF
--- a/maintenance/optimizer/src/test/java/org/apache/gravitino/maintenance/optimizer/updater/metrics/TestGravitinoMetricsUpdater.java
+++ b/maintenance/optimizer/src/test/java/org/apache/gravitino/maintenance/optimizer/updater/metrics/TestGravitinoMetricsUpdater.java
@@ -160,8 +160,10 @@ class TestGravitinoMetricsUpdater {
   @Test
   void testInitializeDefaultUsesGenericJdbcRepository() throws Exception {
     GravitinoMetricsUpdater updater = new GravitinoMetricsUpdater();
-    String storagePath = "data/test-metrics-updater-default-" + System.nanoTime() + ".db";
-    String jdbcUrl = "jdbc:h2:file:./" + storagePath + ";DB_CLOSE_DELAY=-1;MODE=MYSQL";
+    String jdbcUrl =
+        "jdbc:h2:mem:test_metrics_updater_default_"
+            + System.nanoTime()
+            + ";DB_CLOSE_DELAY=-1;MODE=MYSQL";
     updater.initialize(
         new OptimizerEnv(
             new OptimizerConfig(


### PR DESCRIPTION

##  What changes were proposed in this pull request?
                                                                                                                                                           
  Changed testInitializeDefaultUsesGenericJdbcRepository to use an in-memory H2 database (jdbc:h2:mem:) instead of a file-based H2 database
  (jdbc:h2:file:).                                                                                                                                         
   
##  Why are the changes needed?                                                                                                                              
                                                                  
  The test was creating file-based H2 databases at data/test-metrics-updater-default-<nanoTime>.db that were never cleaned up, leaving leftover .db files  
  on disk after each test run. The other similar test (testInitializeWithJdbcConfigStillUsesGenericJdbcRepository) already uses in-memory H2 correctly.
                                                                                                                                                           
  Fix: #                                                          

##  Does this PR introduce any user-facing change?

  No.

##  How was this patch tested?

  Ran ./gradlew :maintenance:optimizer:test --tests "org.apache.gravitino.maintenance.optimizer.updater.metrics.TestGravitinoMetricsUpdater" -PskipITs —   
  all 8 tests pass.