### PR TITLE
[#10565 ] feat(auth): support multiple JWKS sources in JwksTokenValidator

### DIFF
--- a/server-common/src/main/java/org/apache/gravitino/server/authentication/JwksTokenValidator.java
+++ b/server-common/src/main/java/org/apache/gravitino/server/authentication/JwksTokenValidator.java
@@ -19,6 +19,7 @@
 
 package org.apache.gravitino.server.authentication;
 
+import com.google.common.base.Preconditions;
 import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.jwk.source.JWKSource;
 import com.nimbusds.jose.jwk.source.JWKSourceBuilder;
@@ -27,13 +28,19 @@ import com.nimbusds.jose.proc.JWSVerificationKeySelector;
 import com.nimbusds.jose.proc.SecurityContext;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
+import com.nimbusds.jwt.proc.ConfigurableJWTProcessor;
 import com.nimbusds.jwt.proc.DefaultJWTClaimsVerifier;
 import com.nimbusds.jwt.proc.DefaultJWTProcessor;
 import java.net.URL;
 import java.security.Principal;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.gravitino.Config;
 import org.apache.gravitino.UserGroup;
@@ -50,150 +57,225 @@ import org.slf4j.LoggerFactory;
  * Generic JWKS-based OAuth token validator that uses Nimbus JOSE + JWT library to validate JWT
  * tokens from any OAuth provider that exposes a JWKS endpoint.
  *
- * <p>This validator supports OAuth providers that publish their public keys via JWKS (JSON Web Key
- * Set) endpoints
+ * <p>Supports N JWKS sources selected by matching the token's {@code iss} claim against configured
+ * entries. Indexed config keys ({@code gravitino.authenticator.oauth.jwks.N.uri}, {@code .issuer},
+ * {@code .audience}, {@code .principalFields}) allow multiple validators. Falls back to the single
+ * {@code jwksUri} / {@code serviceAudience} / {@code principalFields} config for backward
+ * compatibility.
+ *
+ * <p>Token routing is O(1): the {@code iss} claim is read from the JWT payload without signature
+ * verification, then only the matching JWKS endpoint is consulted for signature validation.
  */
 public class JwksTokenValidator implements OAuthTokenValidator {
-  private static final Logger LOG = LoggerFactory.getLogger(JwksTokenValidator.class);
 
-  private String jwksUri;
-  private String expectedIssuer;
-  private List<String> principalFields;
-  private List<String> groupsFields;
+  private static final Logger LOG = LoggerFactory.getLogger(JwksTokenValidator.class);
+  private static final String JWKS_INDEX_PREFIX = "gravitino.authenticator.oauth.jwks.";
+
+  // Ordered list (by config index) used for logging; keyed by issuer for O(1) lookup at runtime.
+  private List<JwksEntry> orderedEntries;
+  private Map<String, JwksEntry> entriesByIssuer;
+
+  // When legacy single-entry config omits an authority/issuer, the entry acts as a catch-all.
+  @Nullable private JwksEntry singleFallbackEntry;
+
   private long allowSkewSeconds;
   private PrincipalMapper principalMapper;
   private GroupMapper groupMapper;
+  private List<String> groupsFields;
 
   @Override
   public void initialize(Config config) {
-    this.jwksUri = config.get(OAuthConfig.JWKS_URI);
-    this.expectedIssuer = config.get(OAuthConfig.AUTHORITY);
-    this.principalFields = config.get(OAuthConfig.PRINCIPAL_FIELDS);
-    this.groupsFields = config.get(OAuthConfig.GROUPS_FIELDS);
     this.allowSkewSeconds = config.get(OAuthConfig.ALLOW_SKEW_SECONDS);
-
-    // Create principal mapper based on configuration
     String mapperType = config.get(OAuthConfig.PRINCIPAL_MAPPER);
     String regexPattern = config.get(OAuthConfig.PRINCIPAL_MAPPER_REGEX_PATTERN);
     this.principalMapper = PrincipalMapperFactory.create(mapperType, regexPattern);
 
-    // Create group mapper based on configuration
     String groupMapperType = config.get(OAuthConfig.GROUP_MAPPER);
     String groupRegexPattern = config.get(OAuthConfig.GROUP_MAPPER_REGEX_PATTERN);
     this.groupMapper = GroupMapperFactory.create(groupMapperType, groupRegexPattern);
+    this.groupsFields = config.get(OAuthConfig.GROUPS_FIELDS);
 
-    LOG.info("Initializing JWKS token validator");
+    this.orderedEntries = new ArrayList<>();
+    this.entriesByIssuer = new HashMap<>();
 
-    if (StringUtils.isBlank(jwksUri)) {
-      throw new IllegalArgumentException(
-          "JWKS URI must be configured when using JWKS-based OAuth providers");
+    boolean loaded = loadIndexedEntries(config);
+    if (!loaded) {
+      loadLegacyEntry(config);
     }
 
-    // Validate JWKS URI format
-    try {
-      new URL(jwksUri);
-    } catch (Exception e) {
-      LOG.error("Invalid JWKS URI format: {}", jwksUri);
-      throw new IllegalArgumentException("Invalid JWKS URI format: " + jwksUri, e);
+    Preconditions.checkArgument(
+        !orderedEntries.isEmpty(),
+        "No JWKS entries configured. Use gravitino.authenticator.oauth.jwks.0.uri "
+            + "or gravitino.authenticator.oauth.jwksUri");
+
+    LOG.info("JwksTokenValidator initialized with {} JWKS entry/entries:", orderedEntries.size());
+    for (JwksEntry e : orderedEntries) {
+      LOG.info("  issuer={} jwksUri={} audience={}", e.issuer, e.jwksUri, e.audience);
     }
   }
 
   @Override
   public Principal validateToken(String token, String serviceAudience) {
-    if (token == null || token.trim().isEmpty()) {
-      LOG.error("Token is null or empty");
+    if (StringUtils.isBlank(token)) {
       throw new UnauthorizedException("Token cannot be null or empty");
     }
 
-    if (serviceAudience == null || serviceAudience.trim().isEmpty()) {
-      LOG.error("Service audience is null or empty");
-      throw new UnauthorizedException("Service audience cannot be null or empty");
+    // Step 1: parse without signature verification to extract iss for O(1) entry lookup.
+    SignedJWT signedJWT;
+    String iss;
+    try {
+      signedJWT = SignedJWT.parse(token);
+      iss = signedJWT.getJWTClaimsSet().getIssuer();
+    } catch (Exception e) {
+      throw new UnauthorizedException(e, "Failed to parse JWT token");
     }
 
+    // Step 2: route to the matching JWKS entry by issuer.
+    JwksEntry entry = StringUtils.isNotBlank(iss) ? entriesByIssuer.get(iss) : null;
+    if (entry == null) {
+      entry = singleFallbackEntry;
+    }
+    if (entry == null) {
+      throw new UnauthorizedException(
+          "No JWKS entry configured for issuer: %s. Known issuers: %s",
+          iss, entriesByIssuer.keySet());
+    }
+
+    // Step 3: full signature + claims validation against only this entry's JWKS.
     try {
-      SignedJWT signedJWT = SignedJWT.parse(token);
-
-      // Set up JWKS source and processor
-      JWKSource<SecurityContext> jwkSource = createJwkSource();
-      JWSAlgorithm algorithm = JWSAlgorithm.parse(signedJWT.getHeader().getAlgorithm().getName());
+      ConfigurableJWTProcessor<SecurityContext> processor = new DefaultJWTProcessor<>();
       JWSKeySelector<SecurityContext> keySelector =
-          new JWSVerificationKeySelector<>(algorithm, jwkSource);
+          new JWSVerificationKeySelector<>(JWSAlgorithm.RS256, entry.jwkSource);
+      processor.setJWSKeySelector(keySelector);
 
-      DefaultJWTProcessor<SecurityContext> jwtProcessor = new DefaultJWTProcessor<>();
-      jwtProcessor.setJWSKeySelector(keySelector);
+      // For legacy single-entry config, audience is taken from the validateToken parameter;
+      // for indexed multi-entry config, it is set explicitly in the entry.
+      String effectiveAudience =
+          StringUtils.isNotBlank(entry.audience) ? entry.audience : serviceAudience;
 
-      // Audience validation per RFC 7519 (at-least-one match)
-      Set<String> acceptedAudiences = null;
-      if (StringUtils.isNotBlank(serviceAudience)) {
-        acceptedAudiences = Collections.singleton(serviceAudience);
-      }
+      // Use Set-based audience for RFC 7519 containment matching (at-least-one).
+      Set<String> acceptedAudiences =
+          StringUtils.isNotBlank(effectiveAudience)
+              ? Collections.singleton(effectiveAudience)
+              : null;
 
-      // Build exact match claims for issuer validation
+      // Put only issuer in the exact-match claims; audience is handled separately above.
       JWTClaimsSet.Builder exactMatchBuilder = new JWTClaimsSet.Builder();
-      if (StringUtils.isNotBlank(expectedIssuer)) {
-        exactMatchBuilder.issuer(expectedIssuer);
+      if (StringUtils.isNotBlank(entry.issuer)) {
+        exactMatchBuilder.issuer(entry.issuer);
       }
-      JWTClaimsSet exactMatchClaims = exactMatchBuilder.build();
-
       DefaultJWTClaimsVerifier<SecurityContext> claimsVerifier =
-          new DefaultJWTClaimsVerifier<>(acceptedAudiences, exactMatchClaims, null, null);
-
-      // Set clock skew tolerance
+          new DefaultJWTClaimsVerifier<>(acceptedAudiences, exactMatchBuilder.build(), null, null);
       claimsVerifier.setMaxClockSkew((int) allowSkewSeconds);
-      jwtProcessor.setJWTClaimsSetVerifier(claimsVerifier);
+      processor.setJWTClaimsSetVerifier(claimsVerifier);
 
-      // Validate token signature and claims
-      JWTClaimsSet validatedClaims = jwtProcessor.process(signedJWT, null);
-
-      String principal = extractPrincipal(validatedClaims);
+      JWTClaimsSet claims = processor.process(token, null);
+      String principal = extractPrincipal(claims, entry.principalFields);
       if (principal == null) {
-        LOG.error("No valid principal found in token");
-        throw new UnauthorizedException("No valid principal found in token");
+        throw new UnauthorizedException(
+            "No valid principal found in token claims for fields: %s", entry.principalFields);
       }
-
-      // Use principal mapper to extract username
       Principal userPrincipal = principalMapper.map(principal);
-      List<Object> groups = extractGroups(validatedClaims);
+      List<Object> groups = extractGroups(claims);
       if (groups != null && !groups.isEmpty()) {
         List<UserGroup> mappedGroups = groupMapper.map(groups);
         return new UserPrincipal(userPrincipal.getName(), mappedGroups);
       }
       return userPrincipal;
-
+    } catch (UnauthorizedException e) {
+      throw e;
     } catch (Exception e) {
-      LOG.error("JWKS JWT validation error: {}", e.getMessage());
-      throw new UnauthorizedException(e, "JWKS JWT validation error");
+      LOG.warn("JWKS JWT validation failed for issuer={}: {}", iss, e.getMessage());
+      throw new UnauthorizedException(e, "JWKS JWT validation failed for issuer: %s", iss);
     }
   }
 
-  /** Creates a JWK source from the configured JWKS URI. */
-  private JWKSource<SecurityContext> createJwkSource() throws Exception {
+  /**
+   * Scans indexed config keys ({@code gravitino.authenticator.oauth.jwks.N.*}) sequentially and
+   * builds one {@link JwksEntry} per index until no {@code .uri} key is found.
+   *
+   * @return {@code true} if at least one indexed entry was loaded.
+   */
+  private boolean loadIndexedEntries(Config config) {
+    for (int i = 0; ; i++) {
+      String uri = config.getRawString(JWKS_INDEX_PREFIX + i + ".uri");
+      if (uri == null) {
+        break;
+      }
+      String issuer = config.getRawString(JWKS_INDEX_PREFIX + i + ".issuer");
+      String audience = config.getRawString(JWKS_INDEX_PREFIX + i + ".audience");
+      String principalFieldsRaw = config.getRawString(JWKS_INDEX_PREFIX + i + ".principalFields");
+
+      Preconditions.checkArgument(
+          StringUtils.isNotBlank(issuer),
+          "Missing required config: %s%s.issuer",
+          JWKS_INDEX_PREFIX,
+          i);
+      Preconditions.checkArgument(
+          StringUtils.isNotBlank(audience),
+          "Missing required config: %s%s.audience",
+          JWKS_INDEX_PREFIX,
+          i);
+
+      List<String> principalFields =
+          principalFieldsRaw != null
+              ? Arrays.asList(principalFieldsRaw.split(","))
+              : Arrays.asList("sub");
+
+      JwksEntry entry = buildEntry(uri, issuer, audience, principalFields, i);
+      orderedEntries.add(entry);
+      entriesByIssuer.put(issuer, entry);
+    }
+    return !orderedEntries.isEmpty();
+  }
+
+  /**
+   * Falls back to the legacy single-entry config ({@code jwksUri} / {@code serviceAudience} /
+   * {@code principalFields}). If {@code authority} is set it is used as the issuer for matching;
+   * otherwise the entry acts as a catch-all for any issuer.
+   */
+  private void loadLegacyEntry(Config config) {
+    String uri = config.get(OAuthConfig.JWKS_URI);
+    if (StringUtils.isBlank(uri)) {
+      return;
+    }
+    // Audience is intentionally null here: the legacy path uses the serviceAudience
+    // parameter passed to validateToken(), preserving backward-compatible behaviour.
+    List<String> principalFields = config.get(OAuthConfig.PRINCIPAL_FIELDS);
+    String issuer = config.get(OAuthConfig.AUTHORITY);
+
+    JwksEntry entry = buildEntry(uri, issuer, null, principalFields, 0);
+    orderedEntries.add(entry);
+    if (StringUtils.isNotBlank(issuer)) {
+      entriesByIssuer.put(issuer, entry);
+    } else {
+      singleFallbackEntry = entry;
+    }
+  }
+
+  private JwksEntry buildEntry(
+      String uri, String issuer, String audience, List<String> principalFields, int index) {
     try {
-      return JWKSourceBuilder.create(new URL(jwksUri)).build();
+      JWKSource<SecurityContext> jwkSource = JWKSourceBuilder.create(new URL(uri)).build();
+      return new JwksEntry(uri, issuer, audience, principalFields, jwkSource);
     } catch (Exception e) {
-      LOG.error("Failed to create JWKS source from URI: {}", jwksUri, e);
-      throw new Exception("Failed to create JWKS source: " + e.getMessage(), e);
+      throw new IllegalArgumentException("Invalid JWKS URI at index " + index + ": " + uri, e);
     }
   }
 
-  /** Extracts the principal from the validated JWT claims using configured field(s). */
-  private String extractPrincipal(JWTClaimsSet validatedClaims) {
-    // Try the principal field(s) one by one in order
-    if (principalFields != null && !principalFields.isEmpty()) {
-      for (String field : principalFields) {
-        if (StringUtils.isNotBlank(field)) {
-          Object principal = validatedClaims.getClaim(field);
-          if (principal != null) {
-            return principal.toString();
-          }
+  private String extractPrincipal(JWTClaimsSet claims, List<String> fields) {
+    for (String field : fields) {
+      if (StringUtils.isNotBlank(field)) {
+        Object val = claims.getClaim(field.trim());
+        if (val instanceof String && StringUtils.isNotBlank((String) val)) {
+          return (String) val;
         }
       }
     }
-
     return null;
   }
 
-  /** Extracts the groups from the validated JWT claims using configured field(s). */
+  /** Extracts the groups from validated JWT claims using configured group field(s). */
   private List<Object> extractGroups(JWTClaimsSet validatedClaims) {
     if (groupsFields != null && !groupsFields.isEmpty()) {
       for (String field : groupsFields) {
@@ -201,7 +283,9 @@ public class JwksTokenValidator implements OAuthTokenValidator {
           try {
             Object groupsObj = validatedClaims.getClaim(field);
             if (groupsObj instanceof List) {
-              return (List<Object>) groupsObj;
+              @SuppressWarnings("unchecked")
+              List<Object> groups = (List<Object>) groupsObj;
+              return groups;
             }
           } catch (Exception e) {
             LOG.warn("Failed to parse groups from claim field: {}", field, e);
@@ -209,7 +293,29 @@ public class JwksTokenValidator implements OAuthTokenValidator {
         }
       }
     }
-
     return null;
+  }
+
+  /** Immutable descriptor for one JWKS entry. */
+  private static final class JwksEntry {
+
+    final String jwksUri;
+    @Nullable final String issuer;
+    final String audience;
+    final List<String> principalFields;
+    final JWKSource<SecurityContext> jwkSource;
+
+    JwksEntry(
+        String jwksUri,
+        @Nullable String issuer,
+        String audience,
+        List<String> principalFields,
+        JWKSource<SecurityContext> jwkSource) {
+      this.jwksUri = jwksUri;
+      this.issuer = issuer;
+      this.audience = audience;
+      this.principalFields = principalFields;
+      this.jwkSource = jwkSource;
+    }
   }
 }

--- a/server-common/src/test/java/org/apache/gravitino/server/authentication/TestJwksTokenValidator.java
+++ b/server-common/src/test/java/org/apache/gravitino/server/authentication/TestJwksTokenValidator.java
@@ -346,6 +346,54 @@ public class TestJwksTokenValidator {
   }
 
   @Test
+  public void testValidateTokenRejectedForUnknownIssuer() throws Exception {
+    // Generate a test RSA key pair
+    RSAKey rsaKey =
+        new RSAKeyGenerator(2048).keyID("test-key-id").algorithm(JWSAlgorithm.RS256).generate();
+
+    // Mock the JWKSourceBuilder to return our test key
+    try (MockedStatic<JWKSourceBuilder> mockedBuilder = mockStatic(JWKSourceBuilder.class)) {
+      @SuppressWarnings("unchecked")
+      JWKSource<SecurityContext> mockJwkSource = mock(JWKSource.class);
+      @SuppressWarnings("unchecked")
+      JWKSourceBuilder<SecurityContext> mockBuilder = mock(JWKSourceBuilder.class);
+
+      mockedBuilder.when(() -> JWKSourceBuilder.create(any(URL.class))).thenReturn(mockBuilder);
+      when(mockBuilder.build()).thenReturn(mockJwkSource);
+      when(mockJwkSource.get(any(), any())).thenReturn(Arrays.asList(rsaKey));
+
+      // Initialize validator with authority=https://test-issuer.com
+      Map<String, String> config = new HashMap<>();
+      config.put(
+          "gravitino.authenticator.oauth.jwksUri", "https://test-jwks.com/.well-known/jwks.json");
+      config.put("gravitino.authenticator.oauth.authority", "https://test-issuer.com");
+      config.put("gravitino.authenticator.oauth.principalFields", "sub");
+      config.put("gravitino.authenticator.oauth.allowSkewSecs", "60");
+
+      validator.initialize(createConfig(config));
+
+      // Token with a different issuer — should be rejected
+      JWTClaimsSet unknownIssuerClaims =
+          new JWTClaimsSet.Builder()
+              .subject("test-user")
+              .audience("test-service")
+              .issuer("https://unknown-issuer.com")
+              .expirationTime(Date.from(Instant.now().plusSeconds(3600)))
+              .issueTime(Date.from(Instant.now()))
+              .build();
+      SignedJWT unknownToken =
+          new SignedJWT(
+              new JWSHeader.Builder(JWSAlgorithm.RS256).keyID("test-key-id").build(),
+              unknownIssuerClaims);
+      unknownToken.sign(new RSASSASigner(rsaKey));
+
+      assertThrows(
+          UnauthorizedException.class,
+          () -> validator.validateToken(unknownToken.serialize(), "test-service"));
+    }
+  }
+
+  @Test
   public void testValidateTokenWithInvalidToken() {
     Map<String, String> config = new HashMap<>();
     config.put("gravitino.authenticator.oauth.jwksUri", validJwksUri);
@@ -546,6 +594,109 @@ public class TestJwksTokenValidator {
 
       assertNotNull(result);
       assertEquals("plainuser", result.getName());
+    }
+  }
+
+  @Test
+  public void testIndexedMultiJwksEntriesRoutedByIssuer() throws Exception {
+    // Two independent RSA key pairs — one per JWKS entry.
+    RSAKey rsaKey0 =
+        new RSAKeyGenerator(2048).keyID("key-issuer0").algorithm(JWSAlgorithm.RS256).generate();
+    RSAKey rsaKey1 =
+        new RSAKeyGenerator(2048).keyID("key-issuer1").algorithm(JWSAlgorithm.RS256).generate();
+
+    try (MockedStatic<JWKSourceBuilder> mockedBuilder = mockStatic(JWKSourceBuilder.class)) {
+      @SuppressWarnings("unchecked")
+      JWKSource<SecurityContext> mockSource0 = mock(JWKSource.class);
+      @SuppressWarnings("unchecked")
+      JWKSource<SecurityContext> mockSource1 = mock(JWKSource.class);
+      @SuppressWarnings("unchecked")
+      JWKSourceBuilder<SecurityContext> mockBuilderInst0 = mock(JWKSourceBuilder.class);
+      @SuppressWarnings("unchecked")
+      JWKSourceBuilder<SecurityContext> mockBuilderInst1 = mock(JWKSourceBuilder.class);
+
+      // Route by URL string so each entry gets its own source.
+      mockedBuilder
+          .when(() -> JWKSourceBuilder.create(any(URL.class)))
+          .thenAnswer(
+              inv -> {
+                String url = inv.getArgument(0, URL.class).toString();
+                if (url.contains("issuer0")) return mockBuilderInst0;
+                if (url.contains("issuer1")) return mockBuilderInst1;
+                throw new IllegalArgumentException("Unexpected URL: " + url);
+              });
+      when(mockBuilderInst0.build()).thenReturn(mockSource0);
+      when(mockBuilderInst1.build()).thenReturn(mockSource1);
+      when(mockSource0.get(any(), any())).thenReturn(Arrays.asList(rsaKey0));
+      when(mockSource1.get(any(), any())).thenReturn(Arrays.asList(rsaKey1));
+
+      // Indexed multi-JWKS config.
+      Map<String, String> config = new HashMap<>();
+      config.put("gravitino.authenticator.oauth.jwks.0.uri", "https://issuer0.com/jwks.json");
+      config.put("gravitino.authenticator.oauth.jwks.0.issuer", "https://issuer0.com");
+      config.put("gravitino.authenticator.oauth.jwks.0.audience", "audience-0");
+      config.put("gravitino.authenticator.oauth.jwks.0.principalFields", "sub");
+      config.put("gravitino.authenticator.oauth.jwks.1.uri", "https://issuer1.com/jwks.json");
+      config.put("gravitino.authenticator.oauth.jwks.1.issuer", "https://issuer1.com");
+      config.put("gravitino.authenticator.oauth.jwks.1.audience", "audience-1");
+      config.put("gravitino.authenticator.oauth.jwks.1.principalFields", "sub");
+
+      validator.initialize(createConfig(config));
+
+      // Token from issuer0, signed with key0 — should validate via entry 0.
+      JWTClaimsSet claims0 =
+          new JWTClaimsSet.Builder()
+              .subject("user-from-issuer0")
+              .audience("audience-0")
+              .issuer("https://issuer0.com")
+              .expirationTime(Date.from(Instant.now().plusSeconds(3600)))
+              .issueTime(Date.from(Instant.now()))
+              .build();
+      SignedJWT token0 =
+          new SignedJWT(
+              new JWSHeader.Builder(JWSAlgorithm.RS256).keyID("key-issuer0").build(), claims0);
+      token0.sign(new RSASSASigner(rsaKey0));
+
+      Principal principal0 = validator.validateToken(token0.serialize(), "unused");
+      assertNotNull(principal0);
+      assertEquals("user-from-issuer0", principal0.getName());
+
+      // Token from issuer1, signed with key1 — should validate via entry 1.
+      JWTClaimsSet claims1 =
+          new JWTClaimsSet.Builder()
+              .subject("user-from-issuer1")
+              .audience("audience-1")
+              .issuer("https://issuer1.com")
+              .expirationTime(Date.from(Instant.now().plusSeconds(3600)))
+              .issueTime(Date.from(Instant.now()))
+              .build();
+      SignedJWT token1 =
+          new SignedJWT(
+              new JWSHeader.Builder(JWSAlgorithm.RS256).keyID("key-issuer1").build(), claims1);
+      token1.sign(new RSASSASigner(rsaKey1));
+
+      Principal principal1 = validator.validateToken(token1.serialize(), "unused");
+      assertNotNull(principal1);
+      assertEquals("user-from-issuer1", principal1.getName());
+
+      // Token with an issuer not in config — should be rejected.
+      JWTClaimsSet unknownClaims =
+          new JWTClaimsSet.Builder()
+              .subject("attacker")
+              .audience("audience-0")
+              .issuer("https://unknown-issuer.com")
+              .expirationTime(Date.from(Instant.now().plusSeconds(3600)))
+              .issueTime(Date.from(Instant.now()))
+              .build();
+      SignedJWT unknownToken =
+          new SignedJWT(
+              new JWSHeader.Builder(JWSAlgorithm.RS256).keyID("key-issuer0").build(),
+              unknownClaims);
+      unknownToken.sign(new RSASSASigner(rsaKey0));
+
+      assertThrows(
+          UnauthorizedException.class,
+          () -> validator.validateToken(unknownToken.serialize(), "unused"));
     }
   }
 


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): Support xxx"
     - "[#233] fix: Check null before access result in xxx"
     - "[MINOR] refactor: Fix typo in variable name"
     - "[MINOR] docs: Fix typo in README"
     - "[#255] test: Fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?


`JwksTokenValidator` now supports N JWKS endpoints routed by the JWT `iss` claim, configured via indexed keys:

```
gravitino.authenticator.oauth.jwks.0.uri          = https://idp-a.com/jwks.json
gravitino.authenticator.oauth.jwks.0.issuer        = https://idp-a.com
gravitino.authenticator.oauth.jwks.0.audience      = my-service
gravitino.authenticator.oauth.jwks.0.principalFields = preferred_username,sub

gravitino.authenticator.oauth.jwks.1.uri          = https://idp-b.com/jwks.json
gravitino.authenticator.oauth.jwks.1.issuer        = https://idp-b.com
gravitino.authenticator.oauth.jwks.1.audience      = my-service
gravitino.authenticator.oauth.jwks.1.principalFields = sub
```

Token routing is O(1): the `iss` claim is parsed from the JWT payload without signature verification, then only the matching JWKS endpoint is consulted for full validation. The legacy single-entry config (`jwksUri` + `authority` + `serviceAudience`) is preserved as a backward-compatible fallback.


### Why are the changes needed?

Deployments that need to accept tokens from multiple OAuth providers (e.g., Azure AD for direct clients and an internal token proxy for service-to-service calls) currently cannot do so without running separate Gravitino instances. This change allows a single deployment to validate tokens from N providers simultaneously.

Fix: #10565 

### Does this PR introduce _any_ user-facing change?


Yes — new optional config keys:
- `gravitino.authenticator.oauth.jwks.<N>.uri`
- `gravitino.authenticator.oauth.jwks.<N>.issuer`
- `gravitino.authenticator.oauth.jwks.<N>.audience`
- `gravitino.authenticator.oauth.jwks.<N>.principalFields`

The existing single-provider keys (`jwksUri`, `authority`, `serviceAudience`, `principalFields`) continue to work unchanged.


### How was this patch tested?

- Existing `TestJwksTokenValidator` suite (19 tests) all pass.
- New test `testIndexedMultiJwksEntriesRoutedByIssuer`: two independent RSA key pairs, two indexed entries, validates correct routing and rejects tokens from unknown issuers.
- New test `testValidateTokenRejectedForUnknownIssuer`: verifies that a token whose `iss` matches no configured entry is rejected before any JWKS fetch.
