### PR TITLE
[MINOR] docs: clarify Java import guidance in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,9 +22,11 @@
 ## General Coding Standards
 - **Language**: Use English for all code, comments, and documentation.
 - **Style**: Follow rigid Google Java Style. Run `./gradlew spotlessApply` to format.
-- **Imports**: prioritizing standard imports over Fully Qualified Class Names (FQN).
+- **Imports**: Always use normal `import` statements instead of Fully Qualified Class Names (FQN) in Java code whenever possible.
   - **Bad**: `org.apache.gravitino.rel.Table table = ...;`
   - **Good**: `Table table = ...;` (with `import org.apache.gravitino.rel.Table;`)
+  - Do not write inline types like `java.nio.file.Paths` or `org.apache.xxx.Table` unless there is a real class name conflict that cannot be resolved cleanly.
+  - If two classes share the same simple name, prefer imports plus small refactors over keeping FQNs throughout the code.
 - **Safety**: Use `@Nullable` annotations. Handle resources with try-with-resources.
 - **Logging**: Use SLF4J. No `System.out.println`.
 - **Testing**:
@@ -65,4 +67,3 @@
 - When hitting a problem, search memory first for known solutions before debugging from scratch.
 - After completing a task, save key findings and solutions to claude-mem for future reference.
 - Use multiple keyword combinations when searching (e.g., module name + issue type, class name + error).
-


### PR DESCRIPTION
### What changes were proposed in this pull request?

Clarify the Java import guidance in `AGENTS.md` by making the existing rule more explicit:
- require normal `import` statements instead of inline fully qualified class names when possible
- add concrete examples for disallowed inline usages such as `java.nio.file.Paths`
- document the preferred handling when two classes share the same simple name

### Why are the changes needed?

The previous wording only said to prioritize imports over fully qualified class names, which was too weak and still allowed agents to generate Java code with unnecessary inline FQNs. This update makes the expectation explicit and reduces that behavior.

Fix: #10537

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Documentation only change. Verified the updated wording in `AGENTS.md`.
