### PR TITLE
[MINOR] fix(helm): add serviceAccountName to pod spec in deployment.yaml

### DIFF
--- a/dev/charts/gravitino/templates/deployment.yaml
+++ b/dev/charts/gravitino/templates/deployment.yaml
@@ -47,6 +47,7 @@ spec:
           {{- toYaml . | nindent 8 }}
           {{- end }}
     spec:
+      serviceAccountName: {{ .Values.serviceAccountName }}
       {{- with .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/dev/charts/gravitino/values.yaml
+++ b/dev/charts/gravitino/values.yaml
@@ -470,6 +470,10 @@ ingress:
 ##
 annotations: {}
 
+## Service account name for the Gravitino pod
+##
+serviceAccountName: default
+
 ## Deployment replicas
 ##
 replicas: 1


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): Support xxx"
     - "[#233] fix: Check null before access result in xxx"
     - "[MINOR] refactor: Fix typo in variable name"
     - "[MINOR] docs: Fix typo in README"
     - "[#255] test: Fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Add serviceAccountName: {{ .Values.serviceAccountName | default "default" }} so the configured KSA (with WI annotation) is used.


### Why are the changes needed?

The upstream chart had no serviceAccountName field in the pod spec, causing the pod to always run as the 'default' KSA regardless of the values file. This meant Workload Identity bindings on the gravitino KSA were silently ignored, resulting in 403s from GCS.

### Does this PR introduce _any_ user-facing change?

no

### How was this patch tested?

Test with helm deployment