### PR TITLE
[#10576] improvement(catalog-lakehouse-paimon): Exclude unused transitive Avro from hadoop-common

### DIFF
--- a/catalogs/catalog-lakehouse-paimon/build.gradle.kts
+++ b/catalogs/catalog-lakehouse-paimon/build.gradle.kts
@@ -107,6 +107,7 @@ dependencies {
     exclude("com.github.spotbugs")
     exclude("com.sun.jersey")
     exclude("javax.servlet")
+    exclude("org.apache.avro")
     exclude("org.apache.curator")
     exclude("org.apache.zookeeper")
     exclude("org.mortbay.jetty")


### PR DESCRIPTION

### What changes were proposed in this pull request?

Added `exclude("org.apache.avro")` to the hadoop2.common dependency in `build.gradle.kts`. The hive2.metastore dependency already excludes Avro; this change applies the same exclusion to hadoop-common for consistency.

### Why are the changes needed?

`hadoop-common:2.10.2` transitively brings in avro-1.7.7, which is outdated and unused by the Paimon catalog. Removing it reduces the dependency footprint and avoids potential conflicts with newer Avro versions used elsewhere.

Fix: #10576 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Verified via `./gradlew :catalogs:catalog-lakehouse-paimon:dependencyInsight --dependency org.apache.avro:avro --configuration runtimeClasspath`, confirms Avro is no longer resolved in the runtime classpath.
