### PR TITLE
[#10580] improvement(catalog-hive): Exclude unused transitive commons-beanutils from commons-configuration

### DIFF
--- a/catalogs/catalog-hive/build.gradle.kts
+++ b/catalogs/catalog-hive/build.gradle.kts
@@ -43,7 +43,9 @@ dependencies {
   implementation(project(":catalogs:hive-metastore-common"))
 
   implementation(libs.commons.collections3)
-  implementation(libs.commons.configuration1)
+  implementation(libs.commons.configuration1) {
+    exclude(group = "commons-beanutils")
+  }
   implementation(libs.commons.io)
   implementation(libs.commons.lang3)
   implementation(libs.guava)


### PR DESCRIPTION

### What changes were proposed in this pull request?

Added `exclude(group = "commons-beanutils")` to the commons-configuration1 dependency block in `catalogs/catalog-hive/build.gradle.kts`.

### Why are the changes needed?

`commons-beanutils:1.7.0` and `commons-beanutils-core:1.8.0` are transitive dependencies pulled in via `commons-configuration:1.6 `→ `commons-digester:1.8`. Gravitino does not use commons-beanutils at runtime. Excluding them keeps the dependency footprint clean.

Fix: #10580 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

1. Verified compileJava passes for catalog-hive.
2. Verified unit tests pass for catalog-hive.
3. Confirmed `commons-beanutils` and `commons-beanutils-core` no longer appear in the runtimeClasspath dependency tree.
