### PR TITLE
[#10584] improvement(catalogs): Exclude unused transitive jackson-databind from hive-metastore libs

### DIFF
--- a/catalogs/hive-metastore2-libs/build.gradle.kts
+++ b/catalogs/hive-metastore2-libs/build.gradle.kts
@@ -27,9 +27,11 @@ plugins {
 
 // Note: exclusion lists here are intentionally kept in sync with hive-metastore3-libs/build.gradle.kts.
 // Guava and Logback are excluded because they are provided by the Gravitino runtime classpath.
+
 dependencies {
   implementation(libs.hadoop2.common) {
     exclude(group = "ch.qos.logback")
+    exclude(group = "com.fasterxml.jackson.core")
     exclude(group = "com.github.spotbugs")
     exclude(group = "com.google.code.findbugs")
     exclude(group = "com.google.guava")
@@ -54,6 +56,7 @@ dependencies {
     exclude(group = "ant")
     exclude(group = "ch.qos.logback")
     exclude(group = "co.cask.tephra")
+    exclude(group = "com.fasterxml.jackson.core")
     exclude(group = "com.github.joshelser")
     exclude(group = "com.github.spotbugs")
     exclude(group = "com.google.code.findbugs")

--- a/catalogs/hive-metastore3-libs/build.gradle.kts
+++ b/catalogs/hive-metastore3-libs/build.gradle.kts
@@ -27,9 +27,11 @@ plugins {
 
 // Note: exclusion lists here are intentionally kept in sync with hive-metastore2-libs/build.gradle.kts.
 // Guava and Logback are excluded because they are provided by the Gravitino runtime classpath.
+
 dependencies {
   implementation(libs.hadoop2.common) {
     exclude(group = "ch.qos.logback")
+    exclude(group = "com.fasterxml.jackson.core")
     exclude(group = "com.github.spotbugs")
     exclude(group = "com.google.code.findbugs")
     exclude(group = "com.google.guava")
@@ -44,6 +46,7 @@ dependencies {
     exclude(group = "ant")
     exclude(group = "ch.qos.logback")
     exclude(group = "co.cask.tephra")
+    exclude(group = "com.fasterxml.jackson.core")
     exclude(group = "com.github.joshelser")
     exclude(group = "com.github.spotbugs")
     exclude(group = "com.google.code.findbugs")


### PR DESCRIPTION

### What changes were proposed in this pull request?

Added `exclude(group = "com.fasterxml.jackson.core")` to the `hadoop2.common` and `hive2.metastore`/`hive3.metastore `dependency blocks in `build.gradle.kts`.

### Why are the changes needed?

`jackson-databind:2.6.5` (in hive-metastore2-libs) and `jackson-databind:2.12.0` (in `hive-metastore3-libs`) are outdated transitive dependencies pulled in via `hive-metastore` → `hive-serde` → `hive-common`.

Although `hive-common `references `com.fasterxml.jackson` at the bytecode level (in `CodahaleMetrics$JsonFileReporter` and `StatsSetupConst$ColumnStatsAccurate`), these classes are never loaded in Gravitino's runtime path:

`CodahaleMetrics$JsonFileReporter` is a Hive server-side metrics component, only activated when Hive Server configures a specific metrics class.
`StatsSetupConst$ColumnStatsAccurate` is an inner class loaded lazily by the JVM; HiveMetaStoreClient (used by Gravitino) does not invoke any method that triggers its loading.
Gravitino code has zero references to either class.
Therefore, `com.fasterxml.jackson.core` can be safely excluded. Jackson 1.x (`org.codehaus.jackson`), which is used by Hive metastore's JSON messaging layer, is unaffected.
Fix: #10584 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

1. Verified build passes for `hive-metastore2-libs`, `hive-metastore3-libs`, `hive-metastore-common`, and `catalog-hive`.
2. Verified tests pass for `hive-metastore-common` and `catalog-hive`.
3. Confirmed `jackson-databind`, `jackson-core`, and `jackson-annotations (2.x)` no longer appear in the build/libs after a clean build.
