### PR TITLE
[MINOR] fix(auth): Log principal identity on JWKS JWT validation failure

### DIFF
--- a/server-common/src/main/java/org/apache/gravitino/server/authentication/JwksTokenValidator.java
+++ b/server-common/src/main/java/org/apache/gravitino/server/authentication/JwksTokenValidator.java
@@ -110,8 +110,9 @@ public class JwksTokenValidator implements OAuthTokenValidator {
       throw new UnauthorizedException("Service audience cannot be null or empty");
     }
 
+    SignedJWT signedJWT = null;
     try {
-      SignedJWT signedJWT = SignedJWT.parse(token);
+      signedJWT = SignedJWT.parse(token);
 
       // Set up JWKS source and processor
       JWKSource<SecurityContext> jwkSource = createJwkSource();
@@ -161,8 +162,27 @@ public class JwksTokenValidator implements OAuthTokenValidator {
       return userPrincipal;
 
     } catch (Exception e) {
-      LOG.error("JWKS JWT validation error: {}", e.getMessage());
+      LOG.error(
+          "JWKS JWT validation error for principal [{}]: {}",
+          extractPrincipalForLogging(signedJWT),
+          e.getMessage());
       throw new UnauthorizedException(e, "JWKS JWT validation error");
+    }
+  }
+
+  /**
+   * Extracts the principal from a parsed (but not yet verified) JWT for diagnostic logging. Safe to
+   * call with a null or invalid JWT.
+   */
+  String extractPrincipalForLogging(SignedJWT signedJWT) {
+    if (signedJWT == null) {
+      return "unknown";
+    }
+    try {
+      String principal = extractPrincipal(signedJWT.getJWTClaimsSet());
+      return principal != null ? principal : "unknown";
+    } catch (Exception ex) {
+      return "unknown";
     }
   }
 

--- a/server-common/src/test/java/org/apache/gravitino/server/authentication/TestJwksTokenValidator.java
+++ b/server-common/src/test/java/org/apache/gravitino/server/authentication/TestJwksTokenValidator.java
@@ -668,4 +668,57 @@ public class TestJwksTokenValidator {
       assertTrue(userPrincipal.getGroups().isEmpty());
     }
   }
+
+  @Test
+  public void testExtractPrincipalForLogging_nullToken() {
+    Map<String, String> config = new HashMap<>();
+    config.put("gravitino.authenticator.oauth.jwksUri", validJwksUri);
+    validator.initialize(createConfig(config));
+
+    assertEquals("unknown", validator.extractPrincipalForLogging(null));
+  }
+
+  @Test
+  public void testExtractPrincipalForLogging_withSubClaim() throws Exception {
+    Map<String, String> config = new HashMap<>();
+    config.put("gravitino.authenticator.oauth.jwksUri", validJwksUri);
+    config.put("gravitino.authenticator.oauth.principalFields", "sub");
+    validator.initialize(createConfig(config));
+
+    RSAKey rsaKey =
+        new RSAKeyGenerator(2048).keyID("test-key-id").algorithm(JWSAlgorithm.RS256).generate();
+    JWTClaimsSet claims =
+        new JWTClaimsSet.Builder()
+            .subject("alice")
+            .expirationTime(Date.from(Instant.now().plusSeconds(3600)))
+            .build();
+    SignedJWT jwt =
+        new SignedJWT(
+            new JWSHeader.Builder(JWSAlgorithm.RS256).keyID("test-key-id").build(), claims);
+    jwt.sign(new RSASSASigner(rsaKey));
+
+    assertEquals("alice", validator.extractPrincipalForLogging(jwt));
+  }
+
+  @Test
+  public void testExtractPrincipalForLogging_missingPrincipalField() throws Exception {
+    Map<String, String> config = new HashMap<>();
+    config.put("gravitino.authenticator.oauth.jwksUri", validJwksUri);
+    config.put("gravitino.authenticator.oauth.principalFields", "preferred_username");
+    validator.initialize(createConfig(config));
+
+    RSAKey rsaKey =
+        new RSAKeyGenerator(2048).keyID("test-key-id").algorithm(JWSAlgorithm.RS256).generate();
+    JWTClaimsSet claims =
+        new JWTClaimsSet.Builder()
+            .subject("alice") // only sub, no preferred_username
+            .expirationTime(Date.from(Instant.now().plusSeconds(3600)))
+            .build();
+    SignedJWT jwt =
+        new SignedJWT(
+            new JWSHeader.Builder(JWSAlgorithm.RS256).keyID("test-key-id").build(), claims);
+    jwt.sign(new RSASSASigner(rsaKey));
+
+    assertEquals("unknown", validator.extractPrincipalForLogging(jwt));
+  }
 }


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): Support xxx"
     - "[#233] fix: Check null before access result in xxx"
     - "[MINOR] refactor: Fix typo in variable name"
     - "[MINOR] docs: Fix typo in README"
     - "[#255] test: Fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

When JWKS JWT validation fails (e.g., expired token), the error log now includes the principal identity extracted from the unverified JWT claims, making it much easier to identify which user's session is causing repeated failures.

Added extractPrincipalForLogging(SignedJWT) (package-private) that safely reads the configured principalFields from unverified JWT claims and falls back to "unknown".

### Why are the changes needed?

Previously the log only said JWKS JWT validation error: Expired JWT with no indication of who sent the token. With many active sessions this made it impossible to identify the source without a full token decode.
```
2026-03-31 00:29:53 ERROR [iceberg-rest-87] JwksTokenValidator:146 - JWKS JWT validation error: Expired JWT
2026-03-31 00:29:54 ERROR [iceberg-rest-44] JwksTokenValidator:146 - JWKS JWT validation error: Expired JWT
2026-03-31 00:29:56 ERROR [iceberg-rest-87] JwksTokenValidator:146 - JWKS JWT validation error: Expired JWT
2026-03-31 00:29:57 ERROR [iceberg-rest-44] JwksTokenValidator:146 - JWKS JWT validation error: Expired JWT
2026-03-31 00:29:58 ERROR [iceberg-rest-87] JwksTokenValidator:146 - JWKS JWT validation error: Expired JWT
2026-03-31 00:29:59 ERROR [iceberg-rest-44] JwksTokenValidator:146 - JWKS JWT validation error: Expired JWT
```

Fix: N/A (MINOR improvement)

### Does this PR introduce _any_ user-facing change?

No. Log output changes only (internal diagnostic improvement).

### How was this patch tested?

Three unit tests added in TestJwksTokenValidator