### PR TITLE
[#9736][followup] feat(iceberg-rest): Implement snapshots=refs filtering in loadTable

### DIFF
--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/rest/IcebergTableOperations.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/rest/IcebergTableOperations.java
@@ -28,7 +28,10 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 import javax.inject.Inject;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.Consumes;
@@ -67,6 +70,8 @@ import org.apache.gravitino.server.authorization.annotations.IcebergAuthorizatio
 import org.apache.gravitino.server.authorization.annotations.IcebergAuthorizationMetadata.RequestType;
 import org.apache.gravitino.server.authorization.expression.AuthorizationExpressionConstants;
 import org.apache.gravitino.server.web.Utils;
+import org.apache.iceberg.SnapshotRef;
+import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.rest.RESTUtil;
@@ -94,6 +99,7 @@ public class IcebergTableOperations {
   @VisibleForTesting public static final String IF_NONE_MATCH = "If-None-Match";
 
   @VisibleForTesting static final String DEFAULT_SNAPSHOTS = "all";
+  @VisibleForTesting static final String SNAPSHOTS_REFS = "refs";
 
   private IcebergMetricsManager icebergMetricsManager;
 
@@ -306,7 +312,6 @@ public class IcebergTableOperations {
         tableName,
         accessDelegation,
         isCredentialVending);
-    // todo support snapshots
     try {
       return Utils.doAs(
           httpRequest,
@@ -333,6 +338,9 @@ public class IcebergTableOperations {
                 generateETag(loadTableResponse.tableMetadata().metadataFileLocation(), snapshots);
             if (etag != null && etagMatches(ifNoneMatch, etag)) {
               return Response.notModified(etag).build();
+            }
+            if (SNAPSHOTS_REFS.equals(snapshots)) {
+              loadTableResponse = filterSnapshotsByRefs(loadTableResponse);
             }
             return buildResponseWithETag(loadTableResponse, etag);
           });
@@ -534,6 +542,33 @@ public class IcebergTableOperations {
       LOG.error("Failed to plan table scan: {}", e.getMessage(), e);
       return IcebergExceptionMapper.toRESTResponse(e);
     }
+  }
+
+  /**
+   * Filters the {@link LoadTableResponse} to include only snapshots that are directly referenced by
+   * the table's refs (branches and tags). This implements the {@code snapshots=refs} query
+   * parameter behavior per the Iceberg REST specification.
+   *
+   * @param loadTableResponse the original response containing all snapshots
+   * @return a new response with only ref-referenced snapshots
+   */
+  @VisibleForTesting
+  static LoadTableResponse filterSnapshotsByRefs(LoadTableResponse loadTableResponse) {
+    TableMetadata metadata = loadTableResponse.tableMetadata();
+    Map<String, SnapshotRef> refs = metadata.refs();
+    Set<Long> referencedSnapshotIds =
+        refs.values().stream().map(SnapshotRef::snapshotId).collect(Collectors.toSet());
+    // If all snapshots are already referenced by refs, return the original response
+    if (metadata.snapshots().stream()
+        .allMatch(s -> referencedSnapshotIds.contains(s.snapshotId()))) {
+      return loadTableResponse;
+    }
+    TableMetadata filteredMetadata =
+        TableMetadata.buildFrom(metadata).suppressHistoricalSnapshots().build();
+    return LoadTableResponse.builder()
+        .withTableMetadata(filteredMetadata)
+        .addAllConfig(loadTableResponse.config())
+        .build();
   }
 
   /**

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/TestIcebergTableOperations.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/TestIcebergTableOperations.java
@@ -66,6 +66,7 @@ import org.apache.gravitino.server.authorization.GravitinoAuthorizerProvider;
 import org.apache.iceberg.MetadataUpdate;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.SnapshotRef;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.UpdateRequirement;
 import org.apache.iceberg.UpdateRequirements;
@@ -980,5 +981,69 @@ public class TestIcebergTableOperations extends IcebergNamespaceTestBase {
     String allEtag2 = allResponse2.getHeaderString("ETag");
     Assertions.assertEquals(
         allEtag, allEtag2, "ETag should be consistent for the same snapshots value");
+  }
+
+  @ParameterizedTest
+  @MethodSource("org.apache.gravitino.iceberg.service.rest.IcebergRestTestUtil#testNamespaces")
+  void testLoadTableSnapshotsRefsFiltering(Namespace namespace) {
+    verifyCreateNamespaceSucc(namespace);
+    // Create table with data; generatePlanData=true produces two snapshots (create + append),
+    // but only the latest snapshot is referenced by the "main" branch.
+    verifyCreateTableSucc(namespace, "snapshots_refs_foo1", true);
+
+    // Load with snapshots=all: should return all snapshots
+    Response allResponse = doLoadTableWithSnapshots(namespace, "snapshots_refs_foo1", "all");
+    Assertions.assertEquals(Status.OK.getStatusCode(), allResponse.getStatus());
+    LoadTableResponse allTableResponse = allResponse.readEntity(LoadTableResponse.class);
+    List<Snapshot> allSnapshots = allTableResponse.tableMetadata().snapshots();
+    Assertions.assertTrue(
+        allSnapshots.size() >= 2,
+        "Table with data should have at least 2 snapshots, got " + allSnapshots.size());
+
+    // Collect snapshot IDs referenced by refs
+    Map<String, SnapshotRef> refs = allTableResponse.tableMetadata().refs();
+    Set<Long> referencedSnapshotIds =
+        refs.values().stream().map(SnapshotRef::snapshotId).collect(Collectors.toSet());
+
+    // Load with snapshots=refs: should return only ref-referenced snapshots
+    Response refsResponse = doLoadTableWithSnapshots(namespace, "snapshots_refs_foo1", "refs");
+    Assertions.assertEquals(Status.OK.getStatusCode(), refsResponse.getStatus());
+    LoadTableResponse refsTableResponse = refsResponse.readEntity(LoadTableResponse.class);
+    List<Snapshot> refsSnapshots = refsTableResponse.tableMetadata().snapshots();
+
+    // The returned snapshots should be exactly the ref-referenced snapshots
+    Assertions.assertEquals(
+        referencedSnapshotIds,
+        refsSnapshots.stream().map(Snapshot::snapshotId).collect(Collectors.toSet()),
+        "snapshots=refs should return exactly the ref-referenced snapshots");
+
+    // Refs should be preserved in the filtered response
+    Assertions.assertEquals(
+        refs.keySet(),
+        refsTableResponse.tableMetadata().refs().keySet(),
+        "Refs should be preserved in filtered response");
+  }
+
+  @ParameterizedTest
+  @MethodSource("org.apache.gravitino.iceberg.service.rest.IcebergRestTestUtil#testNamespaces")
+  void testLoadTableSnapshotsAllReturnsAllSnapshots(Namespace namespace) {
+    verifyCreateNamespaceSucc(namespace);
+    verifyCreateTableSucc(namespace, "snapshots_all_foo1", true);
+
+    // Load with default snapshots=all
+    Response defaultResponse = doLoadTable(namespace, "snapshots_all_foo1");
+    Assertions.assertEquals(Status.OK.getStatusCode(), defaultResponse.getStatus());
+    LoadTableResponse defaultTableResponse = defaultResponse.readEntity(LoadTableResponse.class);
+
+    // Load with explicit snapshots=all
+    Response allResponse = doLoadTableWithSnapshots(namespace, "snapshots_all_foo1", "all");
+    Assertions.assertEquals(Status.OK.getStatusCode(), allResponse.getStatus());
+    LoadTableResponse allTableResponse = allResponse.readEntity(LoadTableResponse.class);
+
+    // Both should return the same number of snapshots
+    Assertions.assertEquals(
+        defaultTableResponse.tableMetadata().snapshots().size(),
+        allTableResponse.tableMetadata().snapshots().size(),
+        "Default load and snapshots=all should return the same number of snapshots");
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Implement the `snapshots` query parameter filtering for the Iceberg REST `loadTable` endpoint. When `snapshots=refs`, the response is filtered to only include snapshots directly referenced by the table's refs (branches and tags), per the Iceberg REST specification.

Follow-up to: #10536 (comment by @roryqi)

### Why are the changes needed?

The `snapshots` query parameter was accepted but not implemented (marked with `// todo support snapshots`). Per the Iceberg REST spec, `snapshots=refs` should return only ref-referenced snapshots, reducing payload size for clients that don't need the full snapshot history.

### Does this PR introduce _any_ user-facing change?

Yes - `loadTable` with `snapshots=refs` now returns a filtered response containing only snapshots referenced by branches/tags, instead of all snapshots.

### How was this patch tested?

- Added `testLoadTableSnapshotsRefsFiltering`: creates a multi-snapshot table and verifies `snapshots=refs` returns fewer snapshots, all of which are ref-referenced
- Added `testLoadTableSnapshotsAllReturnsAllSnapshots`: verifies default behavior is unchanged
- All 60 existing tests pass
