### PR TITLE
[#10596] Fix listModelVersionInfos dispatches inconsistent operation types for pre/success/failure listener events

### DIFF
--- a/core/src/main/java/org/apache/gravitino/listener/ModelEventDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/listener/ModelEventDispatcher.java
@@ -59,6 +59,8 @@ import org.apache.gravitino.listener.api.event.ListModelFailureEvent;
 import org.apache.gravitino.listener.api.event.ListModelPreEvent;
 import org.apache.gravitino.listener.api.event.ListModelVersionFailureEvent;
 import org.apache.gravitino.listener.api.event.ListModelVersionInfosEvent;
+import org.apache.gravitino.listener.api.event.ListModelVersionInfosFailureEvent;
+import org.apache.gravitino.listener.api.event.ListModelVersionInfosPreEvent;
 import org.apache.gravitino.listener.api.event.ListModelVersionPreEvent;
 import org.apache.gravitino.listener.api.event.ListModelVersionsEvent;
 import org.apache.gravitino.listener.api.event.RegisterAndLinkModelEvent;
@@ -411,7 +413,7 @@ public class ModelEventDispatcher implements ModelDispatcher {
   public ModelVersion[] listModelVersionInfos(NameIdentifier ident) throws NoSuchModelException {
     String user = PrincipalUtils.getCurrentUserName();
 
-    eventBus.dispatchEvent(new ListModelVersionPreEvent(user, ident));
+    eventBus.dispatchEvent(new ListModelVersionInfosPreEvent(user, ident));
     try {
       ModelVersion[] modelVersions = dispatcher.listModelVersionInfos(ident);
       ModelVersionInfo[] modelVersionInfos =
@@ -419,7 +421,7 @@ public class ModelEventDispatcher implements ModelDispatcher {
       eventBus.dispatchEvent(new ListModelVersionInfosEvent(user, ident, modelVersionInfos));
       return modelVersions;
     } catch (Exception e) {
-      eventBus.dispatchEvent(new ListModelVersionFailureEvent(user, ident, e));
+      eventBus.dispatchEvent(new ListModelVersionInfosFailureEvent(user, ident, e));
       throw e;
     }
   }

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/ListModelVersionInfosFailureEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/ListModelVersionInfosFailureEvent.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.listener.api.event;
+
+import org.apache.gravitino.NameIdentifier;
+
+public class ListModelVersionInfosFailureEvent extends FailureEvent {
+  /**
+   * Constructs a new {@code FailureEvent} instance with the specified user, resource identifier,
+   * and the exception that was thrown.
+   *
+   * @param user The user associated with the operation that resulted in a failure.
+   * @param identifier The identifier of the resource involved in the operation that failed. This
+   *     provides a clear reference to what was being acted upon when the exception occurred.
+   * @param exception The exception that was thrown during the operation. This is the primary piece
+   *     of information indicating what went wrong.
+   */
+  public ListModelVersionInfosFailureEvent(
+      String user, NameIdentifier identifier, Exception exception) {
+    super(user, identifier, exception);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public OperationType operationType() {
+    return OperationType.LIST_MODEL_VERSION_INFOS;
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/ListModelVersionInfosPreEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/ListModelVersionInfosPreEvent.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.listener.api.event;
+
+import org.apache.gravitino.NameIdentifier;
+
+public class ListModelVersionInfosPreEvent extends ModelPreEvent {
+  /**
+   * Create a new {@link ModelPreEvent} instance.
+   *
+   * @param user the user who triggered the event.
+   * @param identifier the identifier of the model being operated on.
+   */
+  public ListModelVersionInfosPreEvent(String user, NameIdentifier identifier) {
+    super(user, identifier);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public OperationType operationType() {
+    return OperationType.LIST_MODEL_VERSION_INFOS;
+  }
+}

--- a/core/src/test/java/org/apache/gravitino/listener/api/event/TestModelEvent.java
+++ b/core/src/test/java/org/apache/gravitino/listener/api/event/TestModelEvent.java
@@ -48,7 +48,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class TestModelEvent {
+class TestModelEvent {
   private ModelEventDispatcher dispatcher;
   private ModelEventDispatcher failureDispatcher;
   private DummyEventListener dummyEventListener;
@@ -913,11 +913,12 @@ public class TestModelEvent {
 
     // validate pre-event
     PreEvent preEvent = dummyEventListener.popPreEvent();
-    Assertions.assertEquals(ListModelVersionPreEvent.class, preEvent.getClass());
-    Assertions.assertEquals(OperationType.LIST_MODEL_VERSIONS, preEvent.operationType());
+    Assertions.assertEquals(ListModelVersionInfosPreEvent.class, preEvent.getClass());
+    Assertions.assertEquals(OperationType.LIST_MODEL_VERSION_INFOS, preEvent.operationType());
     Assertions.assertEquals(OperationStatus.UNPROCESSED, preEvent.operationStatus());
 
-    ListModelVersionPreEvent listModelVersionsPreEvent = (ListModelVersionPreEvent) preEvent;
+    ListModelVersionInfosPreEvent listModelVersionsPreEvent =
+        (ListModelVersionInfosPreEvent) preEvent;
     Assertions.assertEquals(existingIdentA, listModelVersionsPreEvent.identifier());
 
     // validate post-event
@@ -930,6 +931,26 @@ public class TestModelEvent {
     Assertions.assertEquals(existingIdentA, listModelVersionInfosEvent.identifier());
     Assertions.assertEquals(1, listModelVersionInfosEvent.versions().length);
     checkModelVersionInfo(listModelVersionInfosEvent.versions()[0], firstModelVersion);
+  }
+
+  @Test
+  void testListModelVersionInfosFailureEvent() {
+    Assertions.assertThrowsExactly(
+        GravitinoRuntimeException.class,
+        () -> failureDispatcher.listModelVersionInfos(existingIdentA));
+
+    Event event = dummyEventListener.popPostEvent();
+
+    Assertions.assertEquals(ListModelVersionInfosFailureEvent.class, event.getClass());
+    Assertions.assertEquals(
+        GravitinoRuntimeException.class,
+        ((ListModelVersionInfosFailureEvent) event).exception().getClass());
+    Assertions.assertEquals(OperationType.LIST_MODEL_VERSION_INFOS, event.operationType());
+    Assertions.assertEquals(OperationStatus.FAILURE, event.operationStatus());
+
+    ListModelVersionInfosFailureEvent listModelVersionInfosFailureEvent =
+        (ListModelVersionInfosFailureEvent) event;
+    Assertions.assertEquals(existingIdentA, listModelVersionInfosFailureEvent.identifier());
   }
 
   @Test


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add dedicated pre-event and failure-event classes for `listModelVersionInfos()`, with `operationType()` returning `LIST_MODEL_VERSION_INFOS`, and `update ModelEventDispatcher.listModelVersionInfos()` to use them.

### Why are the changes needed?

Fix: #10596 

### Does this PR introduce _any_ user-facing change?

no

### How was this patch tested?

local test.