### PR TITLE
[#8348] test(server): SchemaUpdatesRequest null updates unit test

### DIFF
--- a/server/src/test/java/org/apache/gravitino/server/web/rest/TestSchemaOperations.java
+++ b/server/src/test/java/org/apache/gravitino/server/web/rest/TestSchemaOperations.java
@@ -489,4 +489,13 @@ public class TestSchemaOperations extends BaseOperationsTest {
 
     return mockSchema;
   }
+
+  @Test
+  public void testSchemaUpdatesRequestWithUpdatesNull() {
+    SchemaUpdatesRequest schemaUpdatesRequest = new SchemaUpdatesRequest(null);
+
+    Throwable exception =
+        Assertions.assertThrows(IllegalArgumentException.class, schemaUpdatesRequest::validate);
+    Assertions.assertEquals("updates must not be null", exception.getMessage());
+  }
 }


### PR DESCRIPTION
  ### What changes were proposed in this pull request?

Adds a unit test to verify that SchemaUpdatesRequest properly validates null updates and throws an appropriate IllegalArgumentException with a descriptive error message.

  ### Why are the changes needed?

The SchemaUpdatesRequest.validate() method includes a precondition check to ensure the updates field is not null. However, this validation logic was not covered by unit tests. This test ensures the precondition is correctly
enforced and provides the expected error message when violated.

###  How was this patch tested?

  New unit test testSchemaUpdatesRequestWithUpdatesNull() in TestSchemaOperations verifies:
  - Passing null to SchemaUpdatesRequest constructor
  - Calling validate() throws IllegalArgumentException

  All existing unit tests and integration tests pass.

  Fix: #8348