### PR TITLE
[#10605] fix(server): avoid secondary NPE in dropPartitionStatistics

### DIFF
--- a/server/src/main/java/org/apache/gravitino/server/web/rest/StatisticOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/StatisticOperations.java
@@ -455,12 +455,7 @@ public class StatisticOperations {
           fullName,
           metalake,
           e);
-      String partitions =
-          StringUtils.joinWith(
-              ",",
-              request.getDrops().stream()
-                  .map(PartitionStatisticsDropDTO::partitionName)
-                  .collect(Collectors.toList()));
+      String partitions = getDropPartitionNames(request);
       return ExceptionHandlers.handlePartitionStatsException(
           OperationType.DROP, partitions, fullName, e);
     }
@@ -513,6 +508,18 @@ public class StatisticOperations {
         ",",
         request.getUpdates().stream()
             .map(PartitionStatisticsUpdateDTO::partitionName)
+            .collect(Collectors.toList()));
+  }
+
+  private static String getDropPartitionNames(PartitionStatisticsDropRequest request) {
+    if (request == null || request.getDrops() == null) {
+      return "";
+    }
+
+    return StringUtils.joinWith(
+        ",",
+        request.getDrops().stream()
+            .map(PartitionStatisticsDropDTO::partitionName)
             .collect(Collectors.toList()));
   }
 }

--- a/server/src/test/java/org/apache/gravitino/server/web/rest/TestStatisticOperations.java
+++ b/server/src/test/java/org/apache/gravitino/server/web/rest/TestStatisticOperations.java
@@ -864,6 +864,35 @@ public class TestStatisticOperations extends JerseyTest {
   }
 
   @Test
+  public void testDropPartitionStatisticsWithNullDrops() {
+    when(tableDispatcher.tableExists(any())).thenReturn(true);
+    MetadataObject tableObject =
+        MetadataObjects.parse(
+            String.format("%s.%s.%s", catalog, schema, table), MetadataObject.Type.TABLE);
+
+    Response response =
+        target(
+                "/metalakes/"
+                    + metalake
+                    + "/objects/"
+                    + tableObject.type()
+                    + "/"
+                    + tableObject.fullName()
+                    + "/statistics/partitions")
+            .request(MediaType.APPLICATION_JSON_TYPE)
+            .accept("application/vnd.gravitino.v1+json")
+            .post(entity("{\"drops\":null}", MediaType.APPLICATION_JSON_TYPE));
+
+    Assertions.assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+    Assertions.assertEquals(MediaType.APPLICATION_JSON_TYPE, response.getMediaType());
+
+    ErrorResponse errorResponse = response.readEntity(ErrorResponse.class);
+    Assertions.assertEquals(ErrorConstants.ILLEGAL_ARGUMENTS_CODE, errorResponse.getCode());
+    Assertions.assertEquals(
+        IllegalArgumentException.class.getSimpleName(), errorResponse.getType());
+  }
+
+  @Test
   public void testGetBoundType() {
     Assertions.assertEquals(
         PartitionRange.BoundType.CLOSED, StatisticOperations.getFromBoundType(true));


### PR DESCRIPTION
#10605 
## What changes were proposed in this pull request?

Fix `dropPartitionStatistics` so the REST exception handler does not throw a secondary
`NullPointerException` when the request body is invalid and `drops` is null.

Previously, the catch block in `StatisticOperations` called `request.getDrops().stream()`
while building the partition name string for the error response. If `request` or
`request.getDrops()` was null, that masked the original validation failure and could turn
a client-side bad request into an internal server error.

This PR:
- adds a null-safe helper for extracting drop partition names
- uses that helper in the `dropPartitionStatistics` catch block
- adds a regression test for `{"drops": null}`

## How was this patch tested?

```bash
./gradlew :server:test --tests org.apache.gravitino.server.web.rest.TestStatisticOperations