### PR TITLE
[#10625] fix(core): Use Optional.ofNullable in CustomStatistic.value() to prevent NPE

### DIFF
--- a/core/src/main/java/org/apache/gravitino/stats/StatisticManager.java
+++ b/core/src/main/java/org/apache/gravitino/stats/StatisticManager.java
@@ -384,7 +384,7 @@ public class StatisticManager implements Closeable, StatisticDispatcher {
 
     @Override
     public Optional<StatisticValue<?>> value() {
-      return Optional.of(value);
+      return Optional.ofNullable(value);
     }
 
     @Override

--- a/core/src/test/java/org/apache/gravitino/stats/TestStatisticManager.java
+++ b/core/src/test/java/org/apache/gravitino/stats/TestStatisticManager.java
@@ -41,6 +41,7 @@ import java.io.IOException;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.reflect.FieldUtils;
@@ -390,5 +391,17 @@ public class TestStatisticManager {
       Assertions.assertEquals(
           value, statistic.value().get(), "Statistic value type mismatch: " + statistic.name());
     }
+  }
+
+  @Test
+  public void testCustomStatisticWithNullValue() {
+    AuditInfo audit = AuditInfo.builder().withCreator("test").withCreateTime(Instant.now()).build();
+    StatisticManager.CustomStatistic stat =
+        new StatisticManager.CustomStatistic("null-value-stat", null, audit);
+
+    Assertions.assertEquals("null-value-stat", stat.name());
+    Assertions.assertDoesNotThrow(() -> stat.value());
+    Assertions.assertEquals(Optional.empty(), stat.value());
+    Assertions.assertEquals(audit, stat.auditInfo());
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Changed `Optional.of(value)` to `Optional.ofNullable(value)` in `CustomStatistic.value()` and added a unit test covering the null value case.

### Why are the changes needed?

`CustomStatistic.value()` throws `NullPointerException` when value is null, instead of returning an empty `Optional` as specified by the `Statistic` interface contract. `StatisticDTO` already correctly uses `Optional.ofNullable`.

Fix: #10625

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Added `testCustomStatisticWithNullValue()` in `TestStatisticManager` that constructs a `CustomStatistic` with a null value and verifies no NPE is thrown and `Optional.empty()` is returned.