### PR TITLE
Fix invalid metadata object type returning 500 instead of 400

### DIFF
--- a/server/src/main/java/org/apache/gravitino/server/web/filter/ParameterUtil.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/filter/ParameterUtil.java
@@ -82,8 +82,16 @@ public class ParameterUtil {
     if (fullName.isPresent() && metadataObjectType.isPresent()) {
       String metalake = entities.get(Entity.EntityType.METALAKE);
       if (metalake != null) {
-        MetadataObject.Type type =
-            MetadataObject.Type.valueOf(metadataObjectType.get().toUpperCase(Locale.ROOT));
+        MetadataObject.Type type;
+        try {
+          type = MetadataObject.Type.valueOf(metadataObjectType.get().toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException e) {
+          throw new IllegalArgumentException(
+              "Invalid metadata object type: "
+                  + metadataObjectType.get()
+                  + ". Valid types are: METALAKE, CATALOG, SCHEMA, FILESET, TABLE, VIEW, TOPIC, COLUMN, ROLE, MODEL, TAG, POLICY, JOB, JOB_TEMPLATE",
+              e);
+        }
         NameIdentifier nameIdentifier =
             MetadataObjectUtil.toEntityIdent(metalake, MetadataObjects.parse(fullName.get(), type));
         nameIdentifierMap.putAll(

--- a/server/src/test/java/org/apache/gravitino/server/web/rest/TestMetadataObjectTagOperations.java
+++ b/server/src/test/java/org/apache/gravitino/server/web/rest/TestMetadataObjectTagOperations.java
@@ -674,6 +674,42 @@ public class TestMetadataObjectTagOperations extends BaseOperationsTest {
     Assertions.assertEquals(RuntimeException.class.getSimpleName(), errorResponse1.getType());
   }
 
+  @Test
+  public void testInvalidMetadataObjectType() {
+    // Test with completely invalid metadata object type
+    Response response =
+        target(basePath(metalake))
+            .path("INVALID_TYPE")
+            .path("catalog.schema.table")
+            .path("tags")
+            .request(MediaType.APPLICATION_JSON_TYPE)
+            .accept("application/vnd.gravitino.v1+json")
+            .get();
+
+    Assertions.assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+
+    ErrorResponse errorResponse = response.readEntity(ErrorResponse.class);
+    Assertions.assertEquals(ErrorConstants.ILLEGAL_ARGUMENTS_CODE, errorResponse.getCode());
+    Assertions.assertTrue(errorResponse.getMessage().contains("Invalid metadata object type"));
+    Assertions.assertTrue(errorResponse.getMessage().contains("INVALID_TYPE"));
+
+    // Test with another invalid type
+    Response response2 =
+        target(basePath(metalake))
+            .path("UNKNOWN")
+            .path("catalog.schema")
+            .path("tags")
+            .request(MediaType.APPLICATION_JSON_TYPE)
+            .accept("application/vnd.gravitino.v1+json")
+            .get();
+
+    Assertions.assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response2.getStatus());
+
+    ErrorResponse errorResponse2 = response2.readEntity(ErrorResponse.class);
+    Assertions.assertEquals(ErrorConstants.ILLEGAL_ARGUMENTS_CODE, errorResponse2.getCode());
+    Assertions.assertTrue(errorResponse2.getMessage().contains("Invalid metadata object type"));
+  }
+
   private String basePath(String metalake) {
     return "/metalakes/" + metalake + "/objects";
   }


### PR DESCRIPTION
## Summary
Fixes #10626 - Invalid metadata object type now returns HTTP 400 Bad Request with a clear error message instead of HTTP 500 Internal Server Error.

## Root Cause
When a REST API request includes an unsupported `metadataObjectType` path parameter:
1. `ParameterUtil.extractNameIdentifierFromParameters()` calls `MetadataObject.Type.valueOf()`
2. `valueOf()` throws `IllegalArgumentException` for invalid enum values
3. Exception propagates to authorization interceptor's generic exception handler
4. Generic handler treats all exceptions as internal errors (HTTP 500)

**File**: `server/src/main/java/org/apache/gravitino/server/web/filter/ParameterUtil.java:86`

## Changes
- Added try-catch around `MetadataObject.Type.valueOf()` in `ParameterUtil.java`
- Throw descriptive `IllegalArgumentException` with list of valid types
- Added regression test in `TestMetadataObjectTagOperations.java`

## Why This Is Safe
- Only affects error handling path (invalid user input)
- `IllegalArgumentException` already handled correctly by `ExceptionHandlers.java` (returns 400)
- No changes to successful request flow
- Follows existing error handling patterns in the codebase

## Testing

**Before fix:**
```bash
curl -X GET "http://localhost:8090/api/metalakes/test/objects/INVALID_TYPE/catalog.schema.table/tags"
# Returns: 500 Internal Server Error
# Message: "Authorization failed due to system internal error"
```

**After fix:**
```bash
curl -X GET "http://localhost:8090/api/metalakes/test/objects/INVALID_TYPE/catalog.schema.table/tags"
# Returns: 400 Bad Request
# Message: "Invalid metadata object type: INVALID_TYPE. Valid types are: METALAKE, CATALOG, SCHEMA, FILESET, TABLE, VIEW, TOPIC, COLUMN, ROLE, MODEL, TAG, POLICY, JOB, JOB_TEMPLATE"
```

**Regression test added:**
- Tests invalid metadata object type returns 400
- Verifies error message contains invalid type and helpful guidance
- Tests multiple invalid type scenarios

## Related
- Investigation posted to issue: https://github.com/apache/gravitino/issues/10626#issuecomment-4168253810
- Similar fix: #9271 (improved error responses in authorization flow)