### PR TITLE
[#10599] Improvement(core): fix ListModelFailureEvent uses the schema name as the event identifier name on list failures

### DIFF
--- a/core/src/main/java/org/apache/gravitino/listener/api/event/ListModelFailureEvent.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/ListModelFailureEvent.java
@@ -29,6 +29,8 @@ import org.apache.gravitino.annotation.DeveloperApi;
  */
 @DeveloperApi
 public class ListModelFailureEvent extends ModelFailureEvent {
+  private static final String LIST_MODEL_NAME = "__list_models__";
+
   private final Namespace namespace;
 
   /**
@@ -39,7 +41,7 @@ public class ListModelFailureEvent extends ModelFailureEvent {
    * @param exception The exception encountered during the attempt to list models.
    */
   public ListModelFailureEvent(String user, Namespace namespace, Exception exception) {
-    super(user, NameIdentifier.of(namespace.levels()), exception);
+    super(user, NameIdentifier.of(namespace, LIST_MODEL_NAME), exception);
     this.namespace = namespace;
   }
 

--- a/core/src/test/java/org/apache/gravitino/listener/api/event/TestModelEvent.java
+++ b/core/src/test/java/org/apache/gravitino/listener/api/event/TestModelEvent.java
@@ -428,6 +428,8 @@ class TestModelEvent {
     Assertions.assertEquals(OperationStatus.FAILURE, event.operationStatus());
 
     ListModelFailureEvent listModelFailureEvent = (ListModelFailureEvent) event;
+    Assertions.assertEquals("__list_models__", listModelFailureEvent.identifier().name());
+    Assertions.assertEquals(namespace, listModelFailureEvent.identifier().namespace());
     checkArray(namespace.levels(), listModelFailureEvent.namespace().levels());
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

fix ListModelFailureEvent uses the schema name as the event identifier name on list failures

### Why are the changes needed?

Fix: #10599 

### Does this PR introduce _any_ user-facing change?

fix ListModelFailureEvent constructor logic.

### How was this patch tested?

local test