### PR TITLE
[#10621] fix(core): use metadata object name for metalake identifier resolution

### DIFF
--- a/core/src/main/java/org/apache/gravitino/utils/MetadataObjectUtil.java
+++ b/core/src/main/java/org/apache/gravitino/utils/MetadataObjectUtil.java
@@ -110,7 +110,7 @@ public class MetadataObjectUtil {
 
     switch (metadataObject.type()) {
       case METALAKE:
-        return NameIdentifierUtil.ofMetalake(metalakeName);
+        return NameIdentifierUtil.ofMetalake(metadataObject.name());
       case ROLE:
         return AuthorizationUtils.ofRole(metalakeName, metadataObject.name());
       case TAG:

--- a/core/src/test/java/org/apache/gravitino/utils/TestMetadataObjectUtil.java
+++ b/core/src/test/java/org/apache/gravitino/utils/TestMetadataObjectUtil.java
@@ -97,6 +97,13 @@ public class TestMetadataObjectUtil {
         MetadataObjectUtil.toEntityIdent(
             "metalake", MetadataObjects.of(null, "metalake", MetadataObject.Type.METALAKE)));
 
+    // Verify that toEntityIdent uses the metadata object's name, not the context metalakeName
+    Assertions.assertEquals(
+        NameIdentifier.of("target_metalake"),
+        MetadataObjectUtil.toEntityIdent(
+            "request_metalake",
+            MetadataObjects.of(null, "target_metalake", MetadataObject.Type.METALAKE)));
+
     Assertions.assertEquals(
         NameIdentifier.of("metalake", "catalog"),
         MetadataObjectUtil.toEntityIdent(


### PR DESCRIPTION
### What changes were proposed in this pull request?

Updated the METALAKE branch in `MetadataObjectUtil.toEntityIdent` to build the identifier from `metadataObject.name()` instead of the `metalakeName` context parameter.

### Why are the changes needed?

When a request carried a METALAKE metadata object whose name differed from the surrounding `metalakeName` context, `toEntityIdent` resolved against the context metalake rather than the target object. This meant validation in `checkMetadataObject` could pass against the wrong metalake for generic REST flows like owner operations.

### Does this PR introduce any user-facing change?

No. This is an internal correctness fix. The existing validation in `checkMetadataObject` already rejects cases where `metalake.equals(object.name())` is false, so mismatched requests were caught there. This change makes `toEntityIdent` itself consistent with that expectation.

### How was this patch tested?

Added a test case to `TestMetadataObjectUtil` that verifies the metadata object's own name is used for the identifier rather than the surrounding context metalake name.

Fixes #10621