### PR TITLE
[#10621] fix(core): Use metadataObject.name() for METALAKE identifier resolution

### DIFF
--- a/core/src/main/java/org/apache/gravitino/utils/MetadataObjectUtil.java
+++ b/core/src/main/java/org/apache/gravitino/utils/MetadataObjectUtil.java
@@ -110,7 +110,7 @@ public class MetadataObjectUtil {
 
     switch (metadataObject.type()) {
       case METALAKE:
-        return NameIdentifierUtil.ofMetalake(metalakeName);
+        return NameIdentifierUtil.ofMetalake(metadataObject.name());
       case ROLE:
         return AuthorizationUtils.ofRole(metalakeName, metadataObject.name());
       case TAG:

--- a/core/src/test/java/org/apache/gravitino/utils/TestMetadataObjectUtil.java
+++ b/core/src/test/java/org/apache/gravitino/utils/TestMetadataObjectUtil.java
@@ -97,6 +97,12 @@ public class TestMetadataObjectUtil {
         MetadataObjectUtil.toEntityIdent(
             "metalake", MetadataObjects.of(null, "metalake", MetadataObject.Type.METALAKE)));
 
+    // Verify that toEntityIdent uses metadataObject.name(), not the metalakeName parameter
+    Assertions.assertEquals(
+        NameIdentifier.of("otherMetalake"),
+        MetadataObjectUtil.toEntityIdent(
+            "metalake", MetadataObjects.of(null, "otherMetalake", MetadataObject.Type.METALAKE)));
+
     Assertions.assertEquals(
         NameIdentifier.of("metalake", "catalog"),
         MetadataObjectUtil.toEntityIdent(


### PR DESCRIPTION
### What changes were proposed in this pull request?

Changed `MetadataObjectUtil.toEntityIdent()` to use `metadataObject.name()` instead of the `metalakeName` parameter when handling `MetadataObject.Type.METALAKE`.

### Why are the changes needed?

The METALAKE case was the only branch using the context parameter `metalakeName` instead of the object's own name. All other type branches (ROLE, TAG, CATALOG, SCHEMA, etc.) already use `metadataObject.name()` or `metadataObject.fullName()`. This inconsistency means a mismatched metalake name in the request silently resolves to the wrong metalake.

Fix: #10621

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Added a unit test in `TestMetadataObjectUtil` that passes a different `metalakeName` parameter than the metadata object's name, verifying the object's name is used in the returned `NameIdentifier`.

```bash
./gradlew :core:test --tests "org.apache.gravitino.utils.TestMetadataObjectUtil" -PskipITs
```