### PR TITLE
[#10657] fix(core): Add missing @Param("metalakeId") to GroupRoleRelMapper.softDeleteGroupRoleRelByMetalakeId

### DIFF
--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/GroupMetaMapper.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/GroupMetaMapper.java
@@ -58,7 +58,7 @@ public interface GroupMetaMapper {
   @SelectProvider(
       type = GroupMetaSQLProviderFactory.class,
       method = "listExtendedGroupPOsByMetalakeId")
-  List<ExtendedGroupPO> listExtendedGroupPOsByMetalakeId(Long metalakeId);
+  List<ExtendedGroupPO> listExtendedGroupPOsByMetalakeId(@Param("metalakeId") Long metalakeId);
 
   @InsertProvider(type = GroupMetaSQLProviderFactory.class, method = "insertGroupMeta")
   void insertGroupMeta(@Param("groupMeta") GroupPO groupPO);

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/GroupRoleRelMapper.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/GroupRoleRelMapper.java
@@ -60,12 +60,12 @@ public interface GroupRoleRelMapper {
   @UpdateProvider(
       type = GroupRoleRelSQLProviderFactory.class,
       method = "softDeleteGroupRoleRelByMetalakeId")
-  void softDeleteGroupRoleRelByMetalakeId(Long metalakeId);
+  void softDeleteGroupRoleRelByMetalakeId(@Param("metalakeId") Long metalakeId);
 
   @UpdateProvider(
       type = GroupRoleRelSQLProviderFactory.class,
       method = "softDeleteGroupRoleRelByRoleId")
-  void softDeleteGroupRoleRelByRoleId(Long roleId);
+  void softDeleteGroupRoleRelByRoleId(@Param("roleId") Long roleId);
 
   @UpdateProvider(
       type = GroupRoleRelSQLProviderFactory.class,

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/GroupRoleRelSQLProviderFactory.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/GroupRoleRelSQLProviderFactory.java
@@ -71,11 +71,11 @@ public class GroupRoleRelSQLProviderFactory {
     return getProvider().softDeleteGroupRoleRelByGroupAndRoles(groupId, roleIds);
   }
 
-  public static String softDeleteGroupRoleRelByMetalakeId(Long metalakeId) {
+  public static String softDeleteGroupRoleRelByMetalakeId(@Param("metalakeId") Long metalakeId) {
     return getProvider().softDeleteGroupRoleRelByMetalakeId(metalakeId);
   }
 
-  public static String softDeleteGroupRoleRelByRoleId(Long roleId) {
+  public static String softDeleteGroupRoleRelByRoleId(@Param("roleId") Long roleId) {
     return getProvider().softDeleteGroupRoleRelByRoleId(roleId);
   }
 

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/JobTemplateMetaMapper.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/JobTemplateMetaMapper.java
@@ -78,7 +78,7 @@ public interface JobTemplateMetaMapper {
       @Param("metalakeId") long metalakeId, @Param("jobTemplateName") String jobTemplateName);
 
   @SelectProvider(type = JobTemplateMetaSQLProviderFactory.class, method = "selectJobTemplateById")
-  JobTemplatePO selectJobTemplateById(Long jobTemplateId);
+  JobTemplatePO selectJobTemplateById(@Param("jobTemplateId") Long jobTemplateId);
 
   @SelectProvider(
       type = JobTemplateMetaSQLProviderFactory.class,

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/RoleMetaMapper.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/RoleMetaMapper.java
@@ -56,7 +56,7 @@ public interface RoleMetaMapper {
   List<RolePO> listRolesByUserId(@Param("userId") Long userId);
 
   @SelectProvider(type = RoleMetaSQLProviderFactory.class, method = "listRolesByGroupId")
-  List<RolePO> listRolesByGroupId(Long groupId);
+  List<RolePO> listRolesByGroupId(@Param("groupId") Long groupId);
 
   @SelectProvider(
       type = RoleMetaSQLProviderFactory.class,
@@ -81,7 +81,7 @@ public interface RoleMetaMapper {
       @Param("newRoleMeta") RolePO newRolePO, @Param("oldRoleMeta") RolePO oldRolePO);
 
   @UpdateProvider(type = RoleMetaSQLProviderFactory.class, method = "softDeleteRoleMetaByRoleId")
-  void softDeleteRoleMetaByRoleId(Long roleId);
+  void softDeleteRoleMetaByRoleId(@Param("roleId") Long roleId);
 
   @UpdateProvider(
       type = RoleMetaSQLProviderFactory.class,

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/RoleMetaSQLProviderFactory.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/RoleMetaSQLProviderFactory.java
@@ -63,7 +63,7 @@ public class RoleMetaSQLProviderFactory {
     return getProvider().listRolesByUserId(userId);
   }
 
-  public static String listRolesByGroupId(Long groupId) {
+  public static String listRolesByGroupId(@Param("groupId") Long groupId) {
     return getProvider().listRolesByGroupId(groupId);
   }
 
@@ -89,7 +89,7 @@ public class RoleMetaSQLProviderFactory {
     return getProvider().updateRoleMeta(newRolePO, oldRolePO);
   }
 
-  public static String softDeleteRoleMetaByRoleId(Long roleId) {
+  public static String softDeleteRoleMetaByRoleId(@Param("roleId") Long roleId) {
     return getProvider().softDeleteRoleMetaByRoleId(roleId);
   }
 

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/GroupMetaBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/GroupMetaBaseSQLProvider.java
@@ -47,7 +47,7 @@ public class GroupMetaBaseSQLProvider {
         + " AND gt.deleted_at = 0 AND mt.deleted_at = 0";
   }
 
-  public String listExtendedGroupPOsByMetalakeId(Long metalakeId) {
+  public String listExtendedGroupPOsByMetalakeId(@Param("metalakeId") Long metalakeId) {
     return "SELECT gt.group_id as groupId, gt.group_name as groupName,"
         + " gt.metalake_id as metalakeId,"
         + " gt.audit_info as auditInfo,"

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/GroupRoleRelBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/GroupRoleRelBaseSQLProvider.java
@@ -97,7 +97,7 @@ public class GroupRoleRelBaseSQLProvider {
         + "</script>";
   }
 
-  public String softDeleteGroupRoleRelByMetalakeId(Long metalakeId) {
+  public String softDeleteGroupRoleRelByMetalakeId(@Param("metalakeId") Long metalakeId) {
     return "UPDATE "
         + GROUP_ROLE_RELATION_TABLE_NAME
         + " SET deleted_at = (UNIX_TIMESTAMP() * 1000.0)"
@@ -108,7 +108,7 @@ public class GroupRoleRelBaseSQLProvider {
         + " AND deleted_at = 0";
   }
 
-  public String softDeleteGroupRoleRelByRoleId(Long roleId) {
+  public String softDeleteGroupRoleRelByRoleId(@Param("roleId") Long roleId) {
     return "UPDATE "
         + GROUP_ROLE_RELATION_TABLE_NAME
         + " SET deleted_at = (UNIX_TIMESTAMP() * 1000.0)"

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/RoleMetaBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/RoleMetaBaseSQLProvider.java
@@ -63,7 +63,7 @@ public class RoleMetaBaseSQLProvider {
         + " AND ro.deleted_at = 0 AND re.deleted_at = 0";
   }
 
-  public String listRolesByGroupId(Long groupId) {
+  public String listRolesByGroupId(@Param("groupId") Long groupId) {
     return "SELECT ro.role_id as roleId, ro.role_name as roleName,"
         + " ro.metalake_id as metalakeId, ro.properties as properties,"
         + " ro.audit_info as auditInfo, ro.current_version as currentVersion,"
@@ -170,7 +170,7 @@ public class RoleMetaBaseSQLProvider {
         + " AND deleted_at = 0";
   }
 
-  public String softDeleteRoleMetaByRoleId(Long roleId) {
+  public String softDeleteRoleMetaByRoleId(@Param("roleId") Long roleId) {
     return "UPDATE "
         + ROLE_TABLE_NAME
         + " SET deleted_at = (UNIX_TIMESTAMP() * 1000.0)"

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/GroupMetaPostgreSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/GroupMetaPostgreSQLProvider.java
@@ -69,7 +69,7 @@ public class GroupMetaPostgreSQLProvider extends GroupMetaBaseSQLProvider {
   }
 
   @Override
-  public String listExtendedGroupPOsByMetalakeId(Long metalakeId) {
+  public String listExtendedGroupPOsByMetalakeId(@Param("metalakeId") Long metalakeId) {
     return "SELECT gt.group_id as groupId, gt.group_name as groupName,"
         + " gt.metalake_id as metalakeId,"
         + " gt.audit_info as auditInfo,"

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/GroupRoleRelPostgreSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/GroupRoleRelPostgreSQLProvider.java
@@ -50,7 +50,7 @@ public class GroupRoleRelPostgreSQLProvider extends GroupRoleRelBaseSQLProvider 
   }
 
   @Override
-  public String softDeleteGroupRoleRelByMetalakeId(Long metalakeId) {
+  public String softDeleteGroupRoleRelByMetalakeId(@Param("metalakeId") Long metalakeId) {
     return "UPDATE "
         + GROUP_ROLE_RELATION_TABLE_NAME
         + " SET deleted_at = CAST(EXTRACT(EPOCH FROM CURRENT_TIMESTAMP) * 1000 AS BIGINT)"
@@ -61,7 +61,7 @@ public class GroupRoleRelPostgreSQLProvider extends GroupRoleRelBaseSQLProvider 
   }
 
   @Override
-  public String softDeleteGroupRoleRelByRoleId(Long roleId) {
+  public String softDeleteGroupRoleRelByRoleId(@Param("roleId") Long roleId) {
     return "UPDATE "
         + GROUP_ROLE_RELATION_TABLE_NAME
         + " SET deleted_at = CAST(EXTRACT(EPOCH FROM CURRENT_TIMESTAMP) * 1000 AS BIGINT)"

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/RoleMetaPostgreSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/RoleMetaPostgreSQLProvider.java
@@ -26,7 +26,7 @@ import org.apache.ibatis.annotations.Param;
 
 public class RoleMetaPostgreSQLProvider extends RoleMetaBaseSQLProvider {
   @Override
-  public String softDeleteRoleMetaByRoleId(Long roleId) {
+  public String softDeleteRoleMetaByRoleId(@Param("roleId") Long roleId) {
     return "UPDATE "
         + ROLE_TABLE_NAME
         + " SET deleted_at = CAST(EXTRACT(EPOCH FROM CURRENT_TIMESTAMP) * 1000 AS BIGINT)"


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add `@Param("metalakeId")` annotation to `softDeleteGroupRoleRelByMetalakeId` in the mapper, SQL provider factory, base SQL provider, and PostgreSQL provider.

### Why are the changes needed?

`GroupRoleRelMapper.softDeleteGroupRoleRelByMetalakeId(Long metalakeId)` is missing the `@Param("metalakeId")` annotation, unlike every other soft-delete method in the same mapper. The SQL templates reference `#{metalakeId}`, so without the annotation MyBatis relies on runtime-retained parameter names, which is fragile and can cause binding failures during metalake deletion.

Fix: #10657

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing unit and integration tests cover the metalake deletion path that invokes this mapper method. The change is additive — it makes the parameter binding explicit rather than implicit.