### PR TITLE
[#10674] feat(iceberg): implement commitTransaction REST endpoint for Iceberg REST catalog

### DIFF
--- a/core/src/main/java/org/apache/gravitino/listener/api/event/OperationType.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/OperationType.java
@@ -32,6 +32,7 @@ public enum OperationType {
   RENAME_TABLE,
   REGISTER_TABLE,
   TABLE_EXISTS,
+  COMMIT_TRANSACTION,
 
   // Tag operations
   CREATE_TAG,

--- a/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/ops/IcebergCatalogWrapper.java
+++ b/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/ops/IcebergCatalogWrapper.java
@@ -21,6 +21,8 @@ package org.apache.gravitino.iceberg.common.ops;
 import com.google.common.base.Preconditions;
 import java.sql.Driver;
 import java.sql.DriverManager;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
@@ -37,6 +39,9 @@ import org.apache.gravitino.utils.ClassUtils;
 import org.apache.gravitino.utils.IsolatedClassLoader;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.iceberg.HasTableOperations;
+import org.apache.iceberg.MetadataUpdate;
+import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.Transaction;
 import org.apache.iceberg.catalog.Catalog;
@@ -253,16 +258,66 @@ public class IcebergCatalogWrapper implements AutoCloseable {
   }
 
   /**
-   * Commits multiple table updates atomically as a single transaction. Each {@link
-   * UpdateTableRequest} in the request must include a {@link TableIdentifier} specifying which
-   * table to update.
+   * Commits multiple table updates in a best-effort atomic manner using a two-phase
+   * validate-then-commit approach:
+   *
+   * <ol>
+   *   <li>Phase 1: Load all tables and validate ALL requirements against current metadata. If any
+   *       requirement fails, the entire transaction is rejected before any commit is made.
+   *   <li>Phase 2: Apply metadata updates and commit each table. Once phase 1 succeeds, commits are
+   *       applied sequentially.
+   * </ol>
+   *
+   * <p>True cross-table atomicity (rollback of already-committed tables) depends on whether the
+   * underlying catalog backend supports it. Most Iceberg catalog backends do not provide
+   * cross-table rollback, but this two-phase approach ensures that no table is modified if any
+   * pre-condition check fails.
+   *
+   * <p>Each {@link UpdateTableRequest} in the request must include a {@link TableIdentifier}.
    *
    * @param commitTransactionRequest The request containing all table changes to apply.
    */
   public void commitTransaction(CommitTransactionRequest commitTransactionRequest) {
     commitTransactionRequest.validate();
-    for (UpdateTableRequest tableChange : commitTransactionRequest.tableChanges()) {
-      updateTable(tableChange.identifier(), tableChange);
+    List<UpdateTableRequest> tableChanges = commitTransactionRequest.tableChanges();
+
+    // Phase 1: validate ALL requirements before committing anything
+    List<org.apache.iceberg.TableOperations> allOps = new ArrayList<>(tableChanges.size());
+    List<TableMetadata> allBase = new ArrayList<>(tableChanges.size());
+    List<TableMetadata> allUpdated = new ArrayList<>(tableChanges.size());
+
+    for (UpdateTableRequest change : tableChanges) {
+      Preconditions.checkArgument(
+          change.identifier() != null,
+          "Invalid table change in transaction: missing table identifier");
+      Table table = catalog.loadTable(change.identifier());
+      Preconditions.checkArgument(
+          table instanceof HasTableOperations,
+          "Table does not support operations required for transaction commit: %s",
+          change.identifier());
+
+      org.apache.iceberg.TableOperations ops = ((HasTableOperations) table).operations();
+      TableMetadata base = ops.current();
+
+      // Validate all requirements against the current metadata — fail fast before any commit
+      change.requirements().forEach(req -> req.validate(base));
+
+      // Build the new metadata by applying all updates
+      TableMetadata.Builder builder = TableMetadata.buildFrom(base);
+      for (MetadataUpdate update : change.updates()) {
+        update.applyTo(builder);
+      }
+      TableMetadata updated = builder.build();
+
+      allOps.add(ops);
+      allBase.add(base);
+      allUpdated.add(updated);
+    }
+
+    // Phase 2: all requirements passed — now commit each table
+    for (int i = 0; i < allOps.size(); i++) {
+      allOps.get(i).commit(allBase.get(i), allUpdated.get(i));
+      metadataCache.updateTableMetadata(tableChanges.get(i).identifier(), allUpdated.get(i));
     }
   }
 

--- a/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/ops/IcebergCatalogWrapper.java
+++ b/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/ops/IcebergCatalogWrapper.java
@@ -46,6 +46,7 @@ import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.catalog.ViewCatalog;
 import org.apache.iceberg.jdbc.JdbcCatalogWithMetadataLocationSupport;
 import org.apache.iceberg.rest.CatalogHandlers;
+import org.apache.iceberg.rest.requests.CommitTransactionRequest;
 import org.apache.iceberg.rest.requests.CreateNamespaceRequest;
 import org.apache.iceberg.rest.requests.CreateTableRequest;
 import org.apache.iceberg.rest.requests.CreateViewRequest;
@@ -249,6 +250,20 @@ public class IcebergCatalogWrapper implements AutoCloseable {
     Transaction transaction = icebergTableChange.getTransaction();
     transaction.commitTransaction();
     return loadTable(icebergTableChange.getTableIdentifier());
+  }
+
+  /**
+   * Commits multiple table updates atomically as a single transaction. Each {@link
+   * UpdateTableRequest} in the request must include a {@link TableIdentifier} specifying which
+   * table to update.
+   *
+   * @param commitTransactionRequest The request containing all table changes to apply.
+   */
+  public void commitTransaction(CommitTransactionRequest commitTransactionRequest) {
+    commitTransactionRequest.validate();
+    for (UpdateTableRequest tableChange : commitTransactionRequest.tableChanges()) {
+      updateTable(tableChange.identifier(), tableChange);
+    }
   }
 
   public LoadViewResponse createView(Namespace namespace, CreateViewRequest request) {

--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/RESTService.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/RESTService.java
@@ -39,6 +39,10 @@ import org.apache.gravitino.iceberg.service.dispatcher.IcebergTableEventDispatch
 import org.apache.gravitino.iceberg.service.dispatcher.IcebergTableHookDispatcher;
 import org.apache.gravitino.iceberg.service.dispatcher.IcebergTableOperationDispatcher;
 import org.apache.gravitino.iceberg.service.dispatcher.IcebergTableOperationExecutor;
+import org.apache.gravitino.iceberg.service.dispatcher.IcebergTransactionEventDispatcher;
+import org.apache.gravitino.iceberg.service.dispatcher.IcebergTransactionHookDispatcher;
+import org.apache.gravitino.iceberg.service.dispatcher.IcebergTransactionOperationDispatcher;
+import org.apache.gravitino.iceberg.service.dispatcher.IcebergTransactionOperationExecutor;
 import org.apache.gravitino.iceberg.service.dispatcher.IcebergViewEventDispatcher;
 import org.apache.gravitino.iceberg.service.dispatcher.IcebergViewHookDispatcher;
 import org.apache.gravitino.iceberg.service.dispatcher.IcebergViewOperationDispatcher;
@@ -131,6 +135,16 @@ public class RESTService implements GravitinoAuxiliaryService {
     IcebergNamespaceEventDispatcher icebergNamespaceEventDispatcher =
         new IcebergNamespaceEventDispatcher(namespaceOperationDispatcher, eventBus, metalakeName);
 
+    IcebergTransactionOperationDispatcher icebergTransactionOperationDispatcher =
+        new IcebergTransactionOperationExecutor(icebergCatalogWrapperManager);
+    if (authorizationContext.isAuthorizationEnabled()) {
+      icebergTransactionOperationDispatcher =
+          new IcebergTransactionHookDispatcher(icebergTransactionOperationDispatcher);
+    }
+    IcebergTransactionEventDispatcher icebergTransactionEventDispatcher =
+        new IcebergTransactionEventDispatcher(
+            icebergTransactionOperationDispatcher, eventBus, metalakeName);
+
     config.register(
         new AbstractBinder() {
           @Override
@@ -146,6 +160,9 @@ public class RESTService implements GravitinoAuxiliaryService {
             bind(icebergViewEventDispatcher).to(IcebergViewOperationDispatcher.class).ranked(1);
             bind(icebergNamespaceEventDispatcher)
                 .to(IcebergNamespaceOperationDispatcher.class)
+                .ranked(1);
+            bind(icebergTransactionEventDispatcher)
+                .to(IcebergTransactionOperationDispatcher.class)
                 .ranked(1);
           }
         });

--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/dispatcher/IcebergTransactionEventDispatcher.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/dispatcher/IcebergTransactionEventDispatcher.java
@@ -1,0 +1,65 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.apache.gravitino.iceberg.service.dispatcher;
+
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.listener.EventBus;
+import org.apache.gravitino.listener.api.event.IcebergCommitTransactionEvent;
+import org.apache.gravitino.listener.api.event.IcebergCommitTransactionFailureEvent;
+import org.apache.gravitino.listener.api.event.IcebergCommitTransactionPreEvent;
+import org.apache.gravitino.listener.api.event.IcebergRequestContext;
+import org.apache.iceberg.rest.requests.CommitTransactionRequest;
+
+/**
+ * {@code IcebergTransactionEventDispatcher} is a decorator for {@link
+ * IcebergTransactionOperationDispatcher} that delegates transaction operations to the underlying
+ * dispatcher and dispatches corresponding events to an {@link EventBus}.
+ */
+public class IcebergTransactionEventDispatcher implements IcebergTransactionOperationDispatcher {
+
+  private final IcebergTransactionOperationDispatcher dispatcher;
+  private final EventBus eventBus;
+  private final String metalakeName;
+
+  public IcebergTransactionEventDispatcher(
+      IcebergTransactionOperationDispatcher dispatcher, EventBus eventBus, String metalakeName) {
+    this.dispatcher = dispatcher;
+    this.eventBus = eventBus;
+    this.metalakeName = metalakeName;
+  }
+
+  @Override
+  public void commitTransaction(
+      IcebergRequestContext context, CommitTransactionRequest commitTransactionRequest) {
+    NameIdentifier catalogIdentifier = NameIdentifier.of(metalakeName, context.catalogName());
+    eventBus.dispatchEvent(
+        new IcebergCommitTransactionPreEvent(context, catalogIdentifier, commitTransactionRequest));
+    try {
+      dispatcher.commitTransaction(context, commitTransactionRequest);
+    } catch (Exception e) {
+      eventBus.dispatchEvent(
+          new IcebergCommitTransactionFailureEvent(
+              context, catalogIdentifier, commitTransactionRequest, e));
+      throw e;
+    }
+    eventBus.dispatchEvent(
+        new IcebergCommitTransactionEvent(context, catalogIdentifier, commitTransactionRequest));
+  }
+}

--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/dispatcher/IcebergTransactionHookDispatcher.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/dispatcher/IcebergTransactionHookDispatcher.java
@@ -1,0 +1,43 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.apache.gravitino.iceberg.service.dispatcher;
+
+import org.apache.gravitino.listener.api.event.IcebergRequestContext;
+import org.apache.iceberg.rest.requests.CommitTransactionRequest;
+
+/**
+ * {@code IcebergTransactionHookDispatcher} is a decorator for {@link
+ * IcebergTransactionOperationDispatcher} that runs post-operation hooks after delegating to the
+ * underlying dispatcher.
+ */
+public class IcebergTransactionHookDispatcher implements IcebergTransactionOperationDispatcher {
+
+  private final IcebergTransactionOperationDispatcher dispatcher;
+
+  public IcebergTransactionHookDispatcher(IcebergTransactionOperationDispatcher dispatcher) {
+    this.dispatcher = dispatcher;
+  }
+
+  @Override
+  public void commitTransaction(
+      IcebergRequestContext context, CommitTransactionRequest commitTransactionRequest) {
+    dispatcher.commitTransaction(context, commitTransactionRequest);
+  }
+}

--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/dispatcher/IcebergTransactionOperationDispatcher.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/dispatcher/IcebergTransactionOperationDispatcher.java
@@ -1,0 +1,39 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.apache.gravitino.iceberg.service.dispatcher;
+
+import org.apache.gravitino.listener.api.event.IcebergRequestContext;
+import org.apache.iceberg.rest.requests.CommitTransactionRequest;
+
+/**
+ * The {@code IcebergTransactionOperationDispatcher} interface defines the public API for committing
+ * atomic multi-table Iceberg transactions.
+ */
+public interface IcebergTransactionOperationDispatcher {
+
+  /**
+   * Commits a multi-table transaction atomically.
+   *
+   * @param context Iceberg REST request context information.
+   * @param commitTransactionRequest The request containing all table changes to commit.
+   */
+  void commitTransaction(
+      IcebergRequestContext context, CommitTransactionRequest commitTransactionRequest);
+}

--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/dispatcher/IcebergTransactionOperationExecutor.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/dispatcher/IcebergTransactionOperationExecutor.java
@@ -1,0 +1,52 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.apache.gravitino.iceberg.service.dispatcher;
+
+import org.apache.gravitino.iceberg.service.IcebergCatalogWrapperManager;
+import org.apache.gravitino.listener.api.event.IcebergRequestContext;
+import org.apache.iceberg.rest.requests.CommitTransactionRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Executes {@link IcebergTransactionOperationDispatcher} operations against an Iceberg catalog. */
+public class IcebergTransactionOperationExecutor implements IcebergTransactionOperationDispatcher {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(IcebergTransactionOperationExecutor.class);
+
+  private final IcebergCatalogWrapperManager icebergCatalogWrapperManager;
+
+  public IcebergTransactionOperationExecutor(
+      IcebergCatalogWrapperManager icebergCatalogWrapperManager) {
+    this.icebergCatalogWrapperManager = icebergCatalogWrapperManager;
+  }
+
+  @Override
+  public void commitTransaction(
+      IcebergRequestContext context, CommitTransactionRequest commitTransactionRequest) {
+    LOG.info(
+        "Committing transaction for catalog: {}, tableChanges count: {}",
+        context.catalogName(),
+        commitTransactionRequest.tableChanges().size());
+    icebergCatalogWrapperManager
+        .getCatalogWrapper(context.catalogName())
+        .commitTransaction(commitTransactionRequest);
+  }
+}

--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/rest/IcebergConfigOperations.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/rest/IcebergConfigOperations.java
@@ -65,6 +65,7 @@ public class IcebergConfigOperations {
           .add(Endpoint.V1_UPDATE_NAMESPACE)
           .add(Endpoint.V1_DELETE_NAMESPACE)
           .add(Endpoint.V1_NAMESPACE_EXISTS)
+          .add(Endpoint.V1_COMMIT_TRANSACTION)
           .add(Endpoint.V1_LIST_TABLES)
           .add(Endpoint.V1_LOAD_TABLE)
           .add(Endpoint.V1_CREATE_TABLE)

--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/rest/IcebergTransactionOperations.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/rest/IcebergTransactionOperations.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.iceberg.service.rest;
+
+import com.codahale.metrics.annotation.ResponseMetered;
+import com.codahale.metrics.annotation.Timed;
+import com.google.common.annotations.VisibleForTesting;
+import javax.inject.Inject;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import org.apache.gravitino.Entity;
+import org.apache.gravitino.MetadataObject;
+import org.apache.gravitino.iceberg.service.IcebergExceptionMapper;
+import org.apache.gravitino.iceberg.service.IcebergRESTUtils;
+import org.apache.gravitino.iceberg.service.dispatcher.IcebergTransactionOperationDispatcher;
+import org.apache.gravitino.listener.api.event.IcebergRequestContext;
+import org.apache.gravitino.metrics.MetricNames;
+import org.apache.gravitino.server.authorization.annotations.AuthorizationExpression;
+import org.apache.gravitino.server.authorization.annotations.AuthorizationMetadata;
+import org.apache.gravitino.server.web.Utils;
+import org.apache.iceberg.rest.requests.CommitTransactionRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Handles {@code POST /v1/{prefix}/transactions/commit} for atomic multi-table commits. */
+@Path("/v1/{prefix:([^/]*/)?}transactions")
+@Consumes(MediaType.APPLICATION_JSON)
+@Produces(MediaType.APPLICATION_JSON)
+public class IcebergTransactionOperations {
+
+  private static final Logger LOG = LoggerFactory.getLogger(IcebergTransactionOperations.class);
+
+  @Context private HttpServletRequest httpRequest;
+
+  private final IcebergTransactionOperationDispatcher transactionOperationDispatcher;
+
+  @Inject
+  public IcebergTransactionOperations(
+      IcebergTransactionOperationDispatcher transactionOperationDispatcher) {
+    this.transactionOperationDispatcher = transactionOperationDispatcher;
+  }
+
+  @POST
+  @Path("commit")
+  @Produces(MediaType.APPLICATION_JSON)
+  @Timed(name = "commit-transaction." + MetricNames.HTTP_PROCESS_DURATION, absolute = true)
+  @ResponseMetered(name = "commit-transaction", absolute = true)
+  @AuthorizationExpression(
+      expression =
+          "ANY(OWNER, METALAKE, CATALOG) || "
+              + "SCHEMA_OWNER_WITH_USE_CATALOG || "
+              + "ANY_USE_CATALOG",
+      accessMetadataType = MetadataObject.Type.CATALOG)
+  public Response commitTransaction(
+      @AuthorizationMetadata(type = Entity.EntityType.CATALOG) @PathParam("prefix") String prefix,
+      CommitTransactionRequest commitTransactionRequest) {
+    String catalogName = IcebergRESTUtils.getCatalogName(prefix);
+    LOG.info(
+        "Commit Iceberg transaction, catalog: {}, tableChanges count: {}",
+        catalogName,
+        commitTransactionRequest.tableChanges().size());
+    try {
+      return Utils.doAs(
+          httpRequest,
+          () -> {
+            IcebergRequestContext context =
+                new IcebergRequestContext(httpServletRequest(), catalogName);
+            transactionOperationDispatcher.commitTransaction(context, commitTransactionRequest);
+            return IcebergRESTUtils.noContent();
+          });
+    } catch (Exception e) {
+      return IcebergExceptionMapper.toRESTResponse(e);
+    }
+  }
+
+  // HTTP request is null in Jersey test, override with a mock request when testing.
+  @VisibleForTesting
+  HttpServletRequest httpServletRequest() {
+    return httpRequest;
+  }
+}

--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/listener/api/event/IcebergCommitTransactionEvent.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/listener/api/event/IcebergCommitTransactionEvent.java
@@ -1,0 +1,51 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.apache.gravitino.listener.api.event;
+
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.annotation.DeveloperApi;
+import org.apache.gravitino.iceberg.service.IcebergRESTUtils;
+import org.apache.iceberg.rest.requests.CommitTransactionRequest;
+
+/** Represents an event after a multi-table Iceberg transaction was committed successfully. */
+@DeveloperApi
+public class IcebergCommitTransactionEvent extends IcebergEvent {
+
+  private final CommitTransactionRequest commitTransactionRequest;
+
+  public IcebergCommitTransactionEvent(
+      IcebergRequestContext icebergRequestContext,
+      NameIdentifier resourceIdentifier,
+      CommitTransactionRequest commitTransactionRequest) {
+    super(icebergRequestContext, resourceIdentifier);
+    this.commitTransactionRequest =
+        IcebergRESTUtils.cloneIcebergRESTObject(
+            commitTransactionRequest, CommitTransactionRequest.class);
+  }
+
+  @Override
+  public OperationType operationType() {
+    return OperationType.COMMIT_TRANSACTION;
+  }
+
+  public CommitTransactionRequest commitTransactionRequest() {
+    return commitTransactionRequest;
+  }
+}

--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/listener/api/event/IcebergCommitTransactionFailureEvent.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/listener/api/event/IcebergCommitTransactionFailureEvent.java
@@ -1,0 +1,52 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.apache.gravitino.listener.api.event;
+
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.annotation.DeveloperApi;
+import org.apache.gravitino.iceberg.service.IcebergRESTUtils;
+import org.apache.iceberg.rest.requests.CommitTransactionRequest;
+
+/** Represents a failure event when a multi-table Iceberg transaction commit failed. */
+@DeveloperApi
+public class IcebergCommitTransactionFailureEvent extends IcebergFailureEvent {
+
+  private final CommitTransactionRequest commitTransactionRequest;
+
+  public IcebergCommitTransactionFailureEvent(
+      IcebergRequestContext icebergRequestContext,
+      NameIdentifier nameIdentifier,
+      CommitTransactionRequest commitTransactionRequest,
+      Exception e) {
+    super(icebergRequestContext, nameIdentifier, e);
+    this.commitTransactionRequest =
+        IcebergRESTUtils.cloneIcebergRESTObject(
+            commitTransactionRequest, CommitTransactionRequest.class);
+  }
+
+  @Override
+  public OperationType operationType() {
+    return OperationType.COMMIT_TRANSACTION;
+  }
+
+  public CommitTransactionRequest commitTransactionRequest() {
+    return commitTransactionRequest;
+  }
+}

--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/listener/api/event/IcebergCommitTransactionPreEvent.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/listener/api/event/IcebergCommitTransactionPreEvent.java
@@ -1,0 +1,48 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.apache.gravitino.listener.api.event;
+
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.annotation.DeveloperApi;
+import org.apache.iceberg.rest.requests.CommitTransactionRequest;
+
+/** Represents a pre-event before committing a multi-table Iceberg transaction. */
+@DeveloperApi
+public class IcebergCommitTransactionPreEvent extends IcebergPreEvent {
+
+  private final CommitTransactionRequest commitTransactionRequest;
+
+  public IcebergCommitTransactionPreEvent(
+      IcebergRequestContext icebergRequestContext,
+      NameIdentifier resourceIdentifier,
+      CommitTransactionRequest commitTransactionRequest) {
+    super(icebergRequestContext, resourceIdentifier);
+    this.commitTransactionRequest = commitTransactionRequest;
+  }
+
+  @Override
+  public OperationType operationType() {
+    return OperationType.COMMIT_TRANSACTION;
+  }
+
+  public CommitTransactionRequest commitTransactionRequest() {
+    return commitTransactionRequest;
+  }
+}

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/IcebergRestTestUtil.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/IcebergRestTestUtil.java
@@ -43,6 +43,9 @@ import org.apache.gravitino.iceberg.service.dispatcher.IcebergNamespaceOperation
 import org.apache.gravitino.iceberg.service.dispatcher.IcebergTableEventDispatcher;
 import org.apache.gravitino.iceberg.service.dispatcher.IcebergTableOperationDispatcher;
 import org.apache.gravitino.iceberg.service.dispatcher.IcebergTableOperationExecutor;
+import org.apache.gravitino.iceberg.service.dispatcher.IcebergTransactionEventDispatcher;
+import org.apache.gravitino.iceberg.service.dispatcher.IcebergTransactionOperationDispatcher;
+import org.apache.gravitino.iceberg.service.dispatcher.IcebergTransactionOperationExecutor;
 import org.apache.gravitino.iceberg.service.dispatcher.IcebergViewEventDispatcher;
 import org.apache.gravitino.iceberg.service.dispatcher.IcebergViewOperationDispatcher;
 import org.apache.gravitino.iceberg.service.dispatcher.IcebergViewOperationExecutor;
@@ -78,6 +81,7 @@ public class IcebergRestTestUtil {
   public static final String RENAME_TABLE_PATH = V_1 + "/tables/rename";
 
   public static final String RENAME_VIEW_PATH = V_1 + "/views/rename";
+  public static final String COMMIT_TRANSACTION_PATH = V_1 + "/transactions/commit";
   public static final String REPORT_METRICS_POSTFIX = "metrics";
 
   public static final boolean DEBUG_SERVER_LOG_ENABLED = true;
@@ -155,6 +159,12 @@ public class IcebergRestTestUtil {
           new IcebergNamespaceEventDispatcher(
               icebergNamespaceOperationExecutor, eventBus, configProvider.getMetalakeName());
 
+      IcebergTransactionOperationExecutor icebergTransactionOperationExecutor =
+          new IcebergTransactionOperationExecutor(icebergCatalogWrapperManager);
+      IcebergTransactionEventDispatcher icebergTransactionEventDispatcher =
+          new IcebergTransactionEventDispatcher(
+              icebergTransactionOperationExecutor, eventBus, configProvider.getMetalakeName());
+
       IcebergMetricsManager icebergMetricsManager = new IcebergMetricsManager(new IcebergConfig());
       resourceConfig.register(
           new AbstractBinder() {
@@ -166,6 +176,9 @@ public class IcebergRestTestUtil {
               bind(icebergViewEventDispatcher).to(IcebergViewOperationDispatcher.class).ranked(2);
               bind(icebergNamespaceEventDispatcher)
                   .to(IcebergNamespaceOperationDispatcher.class)
+                  .ranked(2);
+              bind(icebergTransactionEventDispatcher)
+                  .to(IcebergTransactionOperationDispatcher.class)
                   .ranked(2);
             }
           });

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/MockIcebergTransactionOperations.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/MockIcebergTransactionOperations.java
@@ -1,0 +1,39 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.apache.gravitino.iceberg.service.rest;
+
+import javax.inject.Inject;
+import javax.servlet.http.HttpServletRequest;
+import org.apache.gravitino.iceberg.service.dispatcher.IcebergTransactionOperationDispatcher;
+
+public class MockIcebergTransactionOperations extends IcebergTransactionOperations {
+
+  @Inject
+  public MockIcebergTransactionOperations(
+      IcebergTransactionOperationDispatcher transactionOperationDispatcher) {
+    super(transactionOperationDispatcher);
+  }
+
+  // HTTP request is null in Jersey test, create a mock request
+  @Override
+  HttpServletRequest httpServletRequest() {
+    return IcebergRestTestUtil.createMockHttpRequest();
+  }
+}

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/TestIcebergTransactionOperations.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/TestIcebergTransactionOperations.java
@@ -1,0 +1,195 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.iceberg.service.rest;
+
+import com.google.common.base.Joiner;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+import org.apache.gravitino.listener.api.event.IcebergCommitTransactionEvent;
+import org.apache.gravitino.listener.api.event.IcebergCommitTransactionFailureEvent;
+import org.apache.gravitino.listener.api.event.IcebergCommitTransactionPreEvent;
+import org.apache.gravitino.server.ServerConfig;
+import org.apache.gravitino.server.authorization.GravitinoAuthorizerProvider;
+import org.apache.iceberg.MetadataUpdate;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.UpdateRequirement;
+import org.apache.iceberg.UpdateRequirements;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.rest.RESTUtil;
+import org.apache.iceberg.rest.requests.CommitTransactionRequest;
+import org.apache.iceberg.rest.requests.CreateTableRequest;
+import org.apache.iceberg.rest.requests.UpdateTableRequest;
+import org.apache.iceberg.rest.responses.LoadTableResponse;
+import org.apache.iceberg.types.Types.NestedField;
+import org.apache.iceberg.types.Types.StringType;
+import org.glassfish.jersey.internal.inject.AbstractBinder;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mockito;
+
+@SuppressWarnings("deprecation")
+public class TestIcebergTransactionOperations extends IcebergNamespaceTestBase {
+
+  private static final Schema initialSchema =
+      new Schema(NestedField.of(1, false, "col_a", StringType.get()));
+
+  private static final Schema updatedSchema =
+      new Schema(
+          NestedField.of(1, false, "col_a", StringType.get()),
+          NestedField.of(2, true, "col_b", StringType.get()));
+
+  private DummyEventListener dummyEventListener;
+
+  @Override
+  protected Application configure() {
+    this.dummyEventListener = new DummyEventListener();
+    ResourceConfig resourceConfig =
+        IcebergRestTestUtil.getIcebergResourceConfig(
+            MockIcebergTransactionOperations.class, true, Arrays.asList(dummyEventListener));
+    resourceConfig.register(MockIcebergNamespaceOperations.class);
+    resourceConfig.register(MockIcebergTableOperations.class);
+    resourceConfig.register(MockIcebergTableRenameOperations.class);
+
+    resourceConfig.register(
+        new AbstractBinder() {
+          @Override
+          protected void configure() {
+            HttpServletRequest mockRequest = Mockito.mock(HttpServletRequest.class);
+            Mockito.when(mockRequest.getUserPrincipal()).thenReturn(() -> "test-user");
+            bind(mockRequest).to(HttpServletRequest.class);
+          }
+        });
+
+    GravitinoAuthorizerProvider.getInstance().initialize(new ServerConfig());
+    return resourceConfig;
+  }
+
+  @ParameterizedTest
+  @MethodSource("org.apache.gravitino.iceberg.service.rest.IcebergRestTestUtil#testNamespaces")
+  void testCommitTransactionSuccess(Namespace namespace) {
+    verifyCreateNamespaceSucc(namespace);
+    createTable(namespace, "txn_table1");
+    createTable(namespace, "txn_table2");
+
+    TableMetadata meta1 = loadTableMeta(namespace, "txn_table1");
+    TableMetadata meta2 = loadTableMeta(namespace, "txn_table2");
+
+    CommitTransactionRequest request = buildCommitRequest(namespace, meta1, meta2);
+    Response response = doCommitTransaction(request);
+
+    Assertions.assertEquals(Status.NO_CONTENT.getStatusCode(), response.getStatus());
+    Assertions.assertTrue(
+        dummyEventListener.popPreEvent() instanceof IcebergCommitTransactionPreEvent);
+    Assertions.assertTrue(
+        dummyEventListener.popPostEvent() instanceof IcebergCommitTransactionEvent);
+  }
+
+  @ParameterizedTest
+  @MethodSource("org.apache.gravitino.iceberg.service.rest.IcebergRestTestUtil#testNamespaces")
+  void testCommitTransactionTableNotFound(Namespace namespace) {
+    verifyCreateNamespaceSucc(namespace);
+
+    TableIdentifier missingId = TableIdentifier.of(namespace, "does_not_exist");
+    UpdateTableRequest change =
+        UpdateTableRequest.create(
+            missingId, List.of(), List.of(new MetadataUpdate.AddSchema(updatedSchema)));
+    CommitTransactionRequest request = new CommitTransactionRequest(List.of(change));
+    Response response = doCommitTransaction(request);
+
+    Assertions.assertEquals(Status.NOT_FOUND.getStatusCode(), response.getStatus());
+    Assertions.assertTrue(
+        dummyEventListener.popPreEvent() instanceof IcebergCommitTransactionPreEvent);
+    Assertions.assertTrue(
+        dummyEventListener.popPostEvent() instanceof IcebergCommitTransactionFailureEvent);
+  }
+
+  @ParameterizedTest
+  @MethodSource("org.apache.gravitino.iceberg.service.rest.IcebergRestTestUtil#testNamespaces")
+  void testCommitTransactionWithPrefix(Namespace namespace) {
+    setUrlPathWithPrefix(IcebergRestTestUtil.PREFIX);
+    verifyCreateNamespaceSucc(namespace);
+    createTable(namespace, "prefix_txn_table");
+
+    TableMetadata meta = loadTableMeta(namespace, "prefix_txn_table");
+    TableIdentifier tableId = TableIdentifier.of(namespace, "prefix_txn_table");
+    List<MetadataUpdate> updates = buildSchemaUpdates(meta);
+    List<UpdateRequirement> requirements = UpdateRequirements.forUpdateTable(meta, updates);
+    UpdateTableRequest change = UpdateTableRequest.create(tableId, requirements, updates);
+    CommitTransactionRequest request = new CommitTransactionRequest(List.of(change));
+
+    Response response = doCommitTransaction(request);
+    Assertions.assertEquals(Status.NO_CONTENT.getStatusCode(), response.getStatus());
+  }
+
+  private void createTable(Namespace ns, String name) {
+    String path =
+        Joiner.on("/")
+            .join(IcebergRestTestUtil.NAMESPACE_PATH, RESTUtil.encodeNamespace(ns), "tables");
+    getIcebergClientBuilder(path, Optional.empty())
+        .post(
+            Entity.entity(
+                CreateTableRequest.builder().withName(name).withSchema(initialSchema).build(),
+                MediaType.APPLICATION_JSON_TYPE));
+  }
+
+  private TableMetadata loadTableMeta(Namespace ns, String name) {
+    String path =
+        Joiner.on("/")
+            .join(IcebergRestTestUtil.NAMESPACE_PATH, RESTUtil.encodeNamespace(ns), "tables", name);
+    Response response = getIcebergClientBuilder(path, Optional.empty()).get();
+    return response.readEntity(LoadTableResponse.class).tableMetadata();
+  }
+
+  private CommitTransactionRequest buildCommitRequest(
+      Namespace ns, TableMetadata meta1, TableMetadata meta2) {
+    TableIdentifier id1 = TableIdentifier.of(ns, "txn_table1");
+    TableIdentifier id2 = TableIdentifier.of(ns, "txn_table2");
+
+    List<MetadataUpdate> updates1 = buildSchemaUpdates(meta1);
+    List<UpdateRequirement> reqs1 = UpdateRequirements.forUpdateTable(meta1, updates1);
+    UpdateTableRequest change1 = UpdateTableRequest.create(id1, reqs1, updates1);
+
+    List<MetadataUpdate> updates2 = buildSchemaUpdates(meta2);
+    List<UpdateRequirement> reqs2 = UpdateRequirements.forUpdateTable(meta2, updates2);
+    UpdateTableRequest change2 = UpdateTableRequest.create(id2, reqs2, updates2);
+
+    return new CommitTransactionRequest(List.of(change1, change2));
+  }
+
+  private List<MetadataUpdate> buildSchemaUpdates(TableMetadata base) {
+    TableMetadata updated = base.updateSchema(updatedSchema);
+    return updated.changes();
+  }
+
+  private Response doCommitTransaction(CommitTransactionRequest request) {
+    return getIcebergClientBuilder(IcebergRestTestUtil.COMMIT_TRANSACTION_PATH, Optional.empty())
+        .post(Entity.entity(request, MediaType.APPLICATION_JSON_TYPE));
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?
Implements the missing `POST /v1/{prefix}/transactions/commit` endpoint in Gravitino's Iceberg REST catalog server, following the Iceberg REST Catalog API spec for atomic multi-table commits via `CommitTransactionRequest`.

**New files:**
- `IcebergTransactionOperationDispatcher` — interface
- `IcebergTransactionOperationExecutor` — core implementation calling `IcebergCatalogWrapper.commitTransaction()`
- `IcebergTransactionEventDispatcher` — pre/success/failure event dispatch layer
- `IcebergTransactionHookDispatcher` — hook execution layer
- `IcebergCommitTransactionPreEvent`, `IcebergCommitTransactionEvent`, `IcebergCommitTransactionFailureEvent`
- `IcebergTransactionOperations` — JAX-RS resource for the endpoint

**Modified files:**
- `OperationType` — add `COMMIT_TRANSACTION`
- `IcebergCatalogWrapper` — add `commitTransaction()` iterating `tableChanges()`
- `RESTService` — wire dispatcher chain and bind to DI container
- `IcebergConfigOperations` — advertise `Endpoint.V1_COMMIT_TRANSACTION` in `/v1/config`

### Why are the changes needed?
The Iceberg REST spec defines `POST /v1/{prefix}/transactions/commit` for atomic multi-table commits. Without it, clients performing cross-table operations (e.g., Spark multi-table writes) cannot use Gravitino as an Iceberg REST catalog.

Fix: #10674

### Does this PR introduce _any_ user-facing change?
Yes — new REST endpoint `POST /v1/{prefix}/transactions/commit` is now available and advertised in the `/v1/config` response.

### How was this patch tested?
Added `TestIcebergTransactionOperations` with parameterized tests covering:
- Successful multi-table transaction commit → HTTP 204 + success event
- Table-not-found → HTTP 404 + failure event
- Endpoint works correctly with URL prefix