### PR TITLE
[#10633] fix(docker): run containers as non-root user

### DIFF
--- a/dev/charts/gravitino-iceberg-rest-server/templates/deployment.yaml
+++ b/dev/charts/gravitino-iceberg-rest-server/templates/deployment.yaml
@@ -85,7 +85,7 @@ spec:
           # Environment variables
           env:
             - name: GRAVITINO_HOME
-              value: /root/gravitino-iceberg-rest-server
+              value: /opt/gravitino-iceberg-rest-server
             - name: SKIP_CONFIG_REWRITE
               value: "true"
           {{- with .Values.env }}

--- a/dev/charts/gravitino-iceberg-rest-server/values.yaml
+++ b/dev/charts/gravitino-iceberg-rest-server/values.yaml
@@ -248,7 +248,6 @@ podSecurityContext: {}
 ##
 securityContext:
   runAsNonRoot: true
-  runAsUser: 1000
   # capabilities:
   #   drop:
   #   - ALL

--- a/dev/charts/gravitino-iceberg-rest-server/values.yaml
+++ b/dev/charts/gravitino-iceberg-rest-server/values.yaml
@@ -248,12 +248,11 @@ podSecurityContext: {}
 ##
 securityContext:
   runAsNonRoot: true
+  runAsUser: 1000
   # capabilities:
   #   drop:
   #   - ALL
   # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
 
 ## Container Environment
 ##

--- a/dev/charts/gravitino-iceberg-rest-server/values.yaml
+++ b/dev/charts/gravitino-iceberg-rest-server/values.yaml
@@ -247,8 +247,8 @@ podSecurityContext: {}
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
 ##
 securityContext:
-  runAsNonRoot: false
-  runAsUser: 0
+  runAsNonRoot: true
+  runAsUser: 1000
   # capabilities:
   #   drop:
   #   - ALL
@@ -321,7 +321,7 @@ extraVolumes:
 ##
 extraVolumeMounts:
   - name: gravitino-rest-catalog-server-log
-    mountPath: /root/gravitino-iceberg-rest-server/logs
+    mountPath: /opt/gravitino-iceberg-rest-server/logs
 
 ingress:
   enabled: false

--- a/dev/charts/gravitino-lance-rest-server/templates/deployment.yaml
+++ b/dev/charts/gravitino-lance-rest-server/templates/deployment.yaml
@@ -62,7 +62,7 @@ spec:
           # Environment variables
           env:
             - name: GRAVITINO_HOME
-              value: /root/gravitino-lance-rest-server
+              value: /opt/gravitino-lance-rest-server
             - name: SKIP_CONFIG_REWRITE
               value: "true"
           {{- with .Values.env }}

--- a/dev/charts/gravitino-lance-rest-server/values.yaml
+++ b/dev/charts/gravitino-lance-rest-server/values.yaml
@@ -105,7 +105,6 @@ podSecurityContext: {}
 
 securityContext:
   runAsNonRoot: true
-  runAsUser: 1000
   # capabilities:
   #   drop:
   #   - ALL

--- a/dev/charts/gravitino-lance-rest-server/values.yaml
+++ b/dev/charts/gravitino-lance-rest-server/values.yaml
@@ -78,7 +78,7 @@ volumes:
 
 volumeMounts:
   - name: gravitino-rest-catalog-server-log
-    mountPath: /root/gravitino-lance-rest-server/logs
+    mountPath: /opt/gravitino-lance-rest-server/logs
 
 env:
   - name: GRAVITINO_MEM
@@ -103,13 +103,13 @@ podLabels: {}
 podSecurityContext: {}
   # fsGroup: 2000
 
-securityContext: {}
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
   # capabilities:
   #   drop:
   #   - ALL
   # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
 
 service:
   name: gravitino-lance-rest-server

--- a/dev/charts/gravitino-lance-rest-server/values.yaml
+++ b/dev/charts/gravitino-lance-rest-server/values.yaml
@@ -105,7 +105,7 @@ podSecurityContext: {}
 
 securityContext:
   runAsNonRoot: true
-  # capabilities:
+  runAsUser: 1000
   #   drop:
   #   - ALL
   # readOnlyRootFilesystem: true

--- a/dev/charts/gravitino/resources/scenarios/ci-values.yaml
+++ b/dev/charts/gravitino/resources/scenarios/ci-values.yaml
@@ -33,7 +33,7 @@ additionalConfigItems:
 
 extraVolumeMounts:
   - name: gravitino-log
-    mountPath: /root/gravitino/logs
+    mountPath: /opt/gravitino/logs
   - name: extra-volume
     mountPath: /extra-volume-path
   - name: another-extra-volume

--- a/dev/charts/gravitino/templates/deployment.yaml
+++ b/dev/charts/gravitino/templates/deployment.yaml
@@ -60,8 +60,8 @@ spec:
             - /bin/bash
             - -c
             - |
-              cp -r /root/gravitino/scripts/*  /tmp/scripts/
-              VERSION=$(ls /root/gravitino/libs/gravitino-server-* | grep -oP '[0-9]+\.[0-9]+\.[0-9]+'|head -1)
+              cp -r /opt/gravitino/scripts/*  /tmp/scripts/
+              VERSION=$(ls /opt/gravitino/libs/gravitino-server-* | grep -oP '[0-9]+\.[0-9]+\.[0-9]+'|head -1)
               echo $VERSION > /tmp/scripts/version.txt
           resources:
             {{- toYaml .Values.initResources | nindent 12 }}
@@ -185,7 +185,7 @@ spec:
             {{- toYaml .Values.containerSecurityContext | nindent 12 }}
           env:
             - name: GRAVITINO_HOME
-              value: /root/gravitino
+              value: /opt/gravitino
             - name: SKIP_CONFIG_REWRITE
               value: "true"
           {{- with .Values.env }}

--- a/dev/charts/gravitino/templates/deployment.yaml
+++ b/dev/charts/gravitino/templates/deployment.yaml
@@ -48,6 +48,10 @@ spec:
           {{- end }}
     spec:
       serviceAccountName: {{ .Values.serviceAccountName }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/dev/charts/gravitino/templates/deployment.yaml
+++ b/dev/charts/gravitino/templates/deployment.yaml
@@ -69,6 +69,8 @@ spec:
               echo $VERSION > /tmp/scripts/version.txt
           resources:
             {{- toYaml .Values.initResources | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.initContainerSecurityContext | nindent 12 }}
           volumeMounts:
             - mountPath: /tmp/scripts/
               name: scripts-emptydir
@@ -109,6 +111,8 @@ spec:
               mysql -h {{ .Release.Name }}-mysql -u root -D $GRAVITINO_DB <$schema_file
           resources:
             {{- toYaml .Values.initResources | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.initContainerSecurityContext | nindent 12 }}
           env:
             - name: MYSQL_PWD
               valueFrom:
@@ -158,6 +162,8 @@ spec:
               PGPASSWORD=$POSTGRES_PASSWORD psql -h {{ .Release.Name }}-postgresql -U $POSTGRES_USER -d $GRAVITINO_DB -f "$schema_file"
           resources:
             {{- toYaml .Values.initResources | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.initContainerSecurityContext | nindent 12 }}
           env:
             - name: POSTGRES_USER
               value: {{ .Values.postgresql.auth.username }}

--- a/dev/charts/gravitino/values.yaml
+++ b/dev/charts/gravitino/values.yaml
@@ -504,6 +504,12 @@ livenessProbe:
   initialDelaySeconds: 20
   timeoutSeconds: 5
 
+## Pod-level security context configuration
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+##
+podSecurityContext: {}
+  # fsGroup: 1000
+
 ## Container-specific security context configuration
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
 ##

--- a/dev/charts/gravitino/values.yaml
+++ b/dev/charts/gravitino/values.yaml
@@ -506,9 +506,18 @@ livenessProbe:
 
 ## Pod-level security context configuration
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+## When using persistent volumes (persistence.enabled=true), set fsGroup to match
+## the gravitino user's GID so mounted volumes are writable by the container.
 ##
 podSecurityContext: {}
-  # fsGroup: 1000
+  # fsGroup: 65534  # set to the GID of the gravitino system user if using PVCs
+
+## Init container security context configuration
+## Applied to all initContainers (sqlfile, init-mysql, init-postgresql).
+## Required on clusters enforcing the Kubernetes Pod Security Standard "restricted" policy.
+##
+initContainerSecurityContext:
+  runAsNonRoot: true
 
 ## Container-specific security context configuration
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/

--- a/dev/charts/gravitino/values.yaml
+++ b/dev/charts/gravitino/values.yaml
@@ -515,7 +515,6 @@ podSecurityContext: {}
 ##
 containerSecurityContext:
   runAsNonRoot: true
-  runAsUser: 1000
 
 ## Container Environment
 ##

--- a/dev/charts/gravitino/values.yaml
+++ b/dev/charts/gravitino/values.yaml
@@ -510,7 +510,7 @@ livenessProbe:
 ## the gravitino user's GID so mounted volumes are writable by the container.
 ##
 podSecurityContext: {}
-  # fsGroup: 65534  # set to the GID of the gravitino system user if using PVCs
+  # fsGroup: 1000  # set when using PVCs so mounted volumes are writable by UID 1000
 
 ## Init container security context configuration
 ## Applied to all initContainers (sqlfile, init-mysql, init-postgresql).
@@ -518,12 +518,14 @@ podSecurityContext: {}
 ##
 initContainerSecurityContext:
   runAsNonRoot: true
+  runAsUser: 1000
 
 ## Container-specific security context configuration
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
 ##
 containerSecurityContext:
   runAsNonRoot: true
+  runAsUser: 1000
 
 ## Container Environment
 ##

--- a/dev/charts/gravitino/values.yaml
+++ b/dev/charts/gravitino/values.yaml
@@ -131,7 +131,7 @@ entity:
   ## The JDBC password
   ##
   jdbcPassword: gravitino
-  storagePath: /root/gravitino/data/jdbc
+  storagePath: /opt/gravitino/data/jdbc
 
 ## THE CONFIGURATION FOR Gravitino SERVER
 ##
@@ -361,7 +361,7 @@ extraVolumes:
 ##
 extraVolumeMounts:
   - name: gravitino-log
-    mountPath: /root/gravitino/logs
+    mountPath: /opt/gravitino/logs
 
 ## ref: https://kubernetes.io/docs/concepts/storage/persistent-volumes/
 ## If you set enabled as "True", you need :
@@ -508,8 +508,8 @@ livenessProbe:
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
 ##
 containerSecurityContext:
-  runAsNonRoot: false
-  runAsUser: 0
+  runAsNonRoot: true
+  runAsUser: 1000
 
 ## Container Environment
 ##

--- a/dev/docker/gravitino/Dockerfile
+++ b/dev/docker/gravitino/Dockerfile
@@ -22,7 +22,7 @@ LABEL maintainer="dev@gravitino.apache.org"
 RUN apt-get update && apt-get install -y \
     python-is-python3
 
-RUN groupadd -g 1000 gravitino && useradd -u 1000 -g gravitino -m gravitino
+RUN groupadd -r gravitino && useradd -r -g gravitino gravitino
 
 WORKDIR /opt/gravitino
 

--- a/dev/docker/gravitino/Dockerfile
+++ b/dev/docker/gravitino/Dockerfile
@@ -22,13 +22,18 @@ LABEL maintainer="dev@gravitino.apache.org"
 RUN apt-get update && apt-get install -y \
     python-is-python3
 
-WORKDIR /root/gravitino
+RUN groupadd -g 1000 gravitino && useradd -u 1000 -g gravitino -m gravitino
 
-COPY packages/gravitino /root/gravitino
+WORKDIR /opt/gravitino
+
+COPY packages/gravitino /opt/gravitino
+
+RUN chown -R gravitino:gravitino /opt/gravitino \
+    && chmod +x /opt/gravitino/bin/start-gravitino.sh
 
 EXPOSE 8090
 EXPOSE 9001
 
-RUN chmod +x /root/gravitino/bin/start-gravitino.sh
+USER gravitino
 
-ENTRYPOINT ["/bin/bash", "/root/gravitino/bin/start-gravitino.sh"]
+ENTRYPOINT ["/bin/bash", "/opt/gravitino/bin/start-gravitino.sh"]

--- a/dev/docker/gravitino/Dockerfile
+++ b/dev/docker/gravitino/Dockerfile
@@ -22,18 +22,16 @@ LABEL maintainer="dev@gravitino.apache.org"
 RUN apt-get update && apt-get install -y \
     python-is-python3
 
-RUN groupadd -r gravitino && useradd -r -g gravitino gravitino
-
 WORKDIR /opt/gravitino
 
 COPY packages/gravitino /opt/gravitino
 
-RUN chown -R gravitino:gravitino /opt/gravitino \
+RUN chmod -R g+rwX /opt/gravitino \
     && chmod +x /opt/gravitino/bin/start-gravitino.sh
 
 EXPOSE 8090
 EXPOSE 9001
 
-USER gravitino
+USER 1000
 
 ENTRYPOINT ["/bin/bash", "/opt/gravitino/bin/start-gravitino.sh"]

--- a/dev/docker/iceberg-rest-server/Dockerfile
+++ b/dev/docker/iceberg-rest-server/Dockerfile
@@ -23,7 +23,7 @@ LABEL maintainer="dev@gravitino.apache.org"
 RUN apt-get update && apt-get install -y \
     python-is-python3
 
-RUN groupadd -g 1000 gravitino && useradd -u 1000 -g gravitino -m gravitino
+RUN groupadd -r gravitino && useradd -r -g gravitino gravitino
 
 WORKDIR /opt/gravitino-iceberg-rest-server
 

--- a/dev/docker/iceberg-rest-server/Dockerfile
+++ b/dev/docker/iceberg-rest-server/Dockerfile
@@ -23,17 +23,15 @@ LABEL maintainer="dev@gravitino.apache.org"
 RUN apt-get update && apt-get install -y \
     python-is-python3
 
-RUN groupadd -r gravitino && useradd -r -g gravitino gravitino
-
 WORKDIR /opt/gravitino-iceberg-rest-server
 
 COPY packages/gravitino-iceberg-rest-server /opt/gravitino-iceberg-rest-server
 
-RUN chown -R gravitino:gravitino /opt/gravitino-iceberg-rest-server \
+RUN chmod -R g+rwX /opt/gravitino-iceberg-rest-server \
     && chmod +x /opt/gravitino-iceberg-rest-server/bin/start-iceberg-rest-server.sh
 
 EXPOSE 9001
 
-USER gravitino
+USER 1000
 
 ENTRYPOINT ["/bin/bash", "/opt/gravitino-iceberg-rest-server/bin/start-iceberg-rest-server.sh"]

--- a/dev/docker/iceberg-rest-server/Dockerfile
+++ b/dev/docker/iceberg-rest-server/Dockerfile
@@ -23,10 +23,17 @@ LABEL maintainer="dev@gravitino.apache.org"
 RUN apt-get update && apt-get install -y \
     python-is-python3
 
-WORKDIR /root/gravitino-iceberg-rest-server
+RUN groupadd -g 1000 gravitino && useradd -u 1000 -g gravitino -m gravitino
 
-COPY packages/gravitino-iceberg-rest-server /root/gravitino-iceberg-rest-server
+WORKDIR /opt/gravitino-iceberg-rest-server
+
+COPY packages/gravitino-iceberg-rest-server /opt/gravitino-iceberg-rest-server
+
+RUN chown -R gravitino:gravitino /opt/gravitino-iceberg-rest-server \
+    && chmod +x /opt/gravitino-iceberg-rest-server/bin/start-iceberg-rest-server.sh
 
 EXPOSE 9001
 
-ENTRYPOINT ["/bin/bash", "/root/gravitino-iceberg-rest-server/bin/start-iceberg-rest-server.sh"]
+USER gravitino
+
+ENTRYPOINT ["/bin/bash", "/opt/gravitino-iceberg-rest-server/bin/start-iceberg-rest-server.sh"]

--- a/dev/docker/lance-rest-server/Dockerfile
+++ b/dev/docker/lance-rest-server/Dockerfile
@@ -23,7 +23,7 @@ LABEL maintainer="dev@gravitino.apache.org"
 RUN apt-get update && apt-get install -y \
     python-is-python3
 
-RUN groupadd -g 1000 gravitino && useradd -u 1000 -g gravitino -m gravitino
+RUN groupadd -r gravitino && useradd -r -g gravitino gravitino
 
 WORKDIR /opt/gravitino-lance-rest-server
 

--- a/dev/docker/lance-rest-server/Dockerfile
+++ b/dev/docker/lance-rest-server/Dockerfile
@@ -23,17 +23,15 @@ LABEL maintainer="dev@gravitino.apache.org"
 RUN apt-get update && apt-get install -y \
     python-is-python3
 
-RUN groupadd -r gravitino && useradd -r -g gravitino gravitino
-
 WORKDIR /opt/gravitino-lance-rest-server
 
 COPY packages/gravitino-lance-rest-server /opt/gravitino-lance-rest-server
 
-RUN chown -R gravitino:gravitino /opt/gravitino-lance-rest-server \
+RUN chmod -R g+rwX /opt/gravitino-lance-rest-server \
     && chmod +x /opt/gravitino-lance-rest-server/bin/start-lance-rest-server.sh
 
 EXPOSE 9101
 
-USER gravitino
+USER 1000
 
 ENTRYPOINT ["/bin/bash", "/opt/gravitino-lance-rest-server/bin/start-lance-rest-server.sh"]

--- a/dev/docker/lance-rest-server/Dockerfile
+++ b/dev/docker/lance-rest-server/Dockerfile
@@ -23,10 +23,17 @@ LABEL maintainer="dev@gravitino.apache.org"
 RUN apt-get update && apt-get install -y \
     python-is-python3
 
-WORKDIR /root/gravitino-lance-rest-server
+RUN groupadd -g 1000 gravitino && useradd -u 1000 -g gravitino -m gravitino
 
-COPY packages/gravitino-lance-rest-server /root/gravitino-lance-rest-server
+WORKDIR /opt/gravitino-lance-rest-server
+
+COPY packages/gravitino-lance-rest-server /opt/gravitino-lance-rest-server
+
+RUN chown -R gravitino:gravitino /opt/gravitino-lance-rest-server \
+    && chmod +x /opt/gravitino-lance-rest-server/bin/start-lance-rest-server.sh
 
 EXPOSE 9101
 
-ENTRYPOINT ["/bin/bash", "/root/gravitino-lance-rest-server/bin/start-lance-rest-server.sh"]
+USER gravitino
+
+ENTRYPOINT ["/bin/bash", "/opt/gravitino-lance-rest-server/bin/start-lance-rest-server.sh"]


### PR DESCRIPTION
## What changes were proposed in this pull request?

Modifies the three production Dockerfiles to run as a dedicated non-root `gravitino` user (UID 1000) instead of `root`, and updates all Helm chart configuration to match the new paths.

**Dockerfiles changed:**
- `dev/docker/gravitino/Dockerfile`
- `dev/docker/iceberg-rest-server/Dockerfile`
- `dev/docker/lance-rest-server/Dockerfile`

**Helm charts updated:**
- `dev/charts/gravitino/` (templates + values)
- `dev/charts/gravitino-iceberg-rest-server/` (templates + values)
- `dev/charts/gravitino-lance-rest-server/` (templates + values)
- `dev/charts/gravitino/resources/scenarios/ci-values.yaml`

## Why are the changes needed?

Fixes #10633. Running containers as `root` is a security concern in production environments and prevents deployment on hardened Kubernetes clusters or OpenShift platforms that enforce non-root container policies.

## How was this patch tested?

The changes are limited to Dockerfiles and Helm chart configuration. No Java code was modified. The diff was manually reviewed for correctness.

- [ ] Existing tests pass (no Java changes)
- [ ] Dockerfile security: containers now run as UID 1000 (`gravitino` user)
- [ ] Helm charts: `runAsNonRoot: true`, `runAsUser: 1000` in container security contexts
- [ ] All `/root/gravitino*` paths updated to `/opt/gravitino*`