### PR TITLE
[#10700] test: Harden retention count assertions in TestFunctionMetaService and TestFilesetMetaService

### DIFF
--- a/core/src/test/java/org/apache/gravitino/storage/relational/service/TestFilesetMetaService.java
+++ b/core/src/test/java/org/apache/gravitino/storage/relational/service/TestFilesetMetaService.java
@@ -335,12 +335,16 @@ public class TestFilesetMetaService extends TestJDBCBackend {
                   auditInfo1,
                   "/tmp1");
             });
+    Map<Integer, Long> versionDeletedMap = listFilesetVersions(filesetEntity.id());
+    assertEquals(2, versionDeletedMap.size());
+    assertVersionActive(versionDeletedMap, 1);
+    assertVersionActive(versionDeletedMap, 2);
+
     FilesetMetaService.getInstance().deleteFilesetVersionsByRetentionCount(1L, 100);
-    List<Pair<Integer, String>> versionInfos = listFilesetInvalidVersions(filesetEntity.id());
-    // version 1 should be softly deleted
-    Assertions.assertEquals(1, versionInfos.size());
-    Assertions.assertEquals(1, versionInfos.get(0).getLeft());
-    Assertions.assertEquals(LOCATION_NAME_UNKNOWN, versionInfos.get(0).getRight());
+    versionDeletedMap = listFilesetVersions(filesetEntity.id());
+    assertEquals(2, versionDeletedMap.size());
+    assertVersionSoftDeleted(versionDeletedMap, 1);
+    assertVersionActive(versionDeletedMap, 2);
   }
 
   private List<Pair<Integer, String>> listFilesetInvalidVersions(Long filesetId) {
@@ -361,6 +365,16 @@ public class TestFilesetMetaService extends TestJDBCBackend {
       throw new RuntimeException("SQL execution failed", e);
     }
     return deletedVersions;
+  }
+
+  private void assertVersionActive(Map<Integer, Long> versionDeletedMap, int version) {
+    assertTrue(versionDeletedMap.containsKey(version));
+    assertEquals(0L, versionDeletedMap.get(version));
+  }
+
+  private void assertVersionSoftDeleted(Map<Integer, Long> versionDeletedMap, int version) {
+    assertTrue(versionDeletedMap.containsKey(version));
+    assertTrue(versionDeletedMap.get(version) > 0L);
   }
 
   private FilesetEntity createFilesetEntity(

--- a/core/src/test/java/org/apache/gravitino/storage/relational/service/TestFunctionMetaService.java
+++ b/core/src/test/java/org/apache/gravitino/storage/relational/service/TestFunctionMetaService.java
@@ -398,17 +398,25 @@ public class TestFunctionMetaService extends TestJDBCBackend {
       FunctionMetaService.getInstance().updateFunction(functionIdent, e -> updatedFunction);
     }
 
-    // Verify all 5 versions exist
-    assertEquals(5, listFunctionVersions(function.id()).size());
+    // Verify all 5 versions are active before retention cleanup
+    Map<Integer, Long> versionDeletedMap = listFunctionVersions(function.id());
+    assertEquals(5, versionDeletedMap.size());
+    for (int version = 1; version <= 5; version++) {
+      assertVersionActive(versionDeletedMap, version);
+    }
 
     // Soft delete versions by retention count (keep only 2)
     FunctionMetaService.getInstance().deleteFunctionVersionsByRetentionCount(2L, 100);
 
-    // Verify 3 versions are soft deleted
-    Map<Integer, Long> versionDeletedMap = listFunctionVersions(function.id());
+    // Verify versions 1-3 are soft deleted and versions 4-5 remain active
+    versionDeletedMap = listFunctionVersions(function.id());
     assertEquals(5, versionDeletedMap.size());
-    assertEquals(2, versionDeletedMap.values().stream().filter(value -> value == 0L).count());
-    assertEquals(3, versionDeletedMap.values().stream().filter(value -> value != 0L).count());
+    for (int version = 1; version <= 3; version++) {
+      assertVersionSoftDeleted(versionDeletedMap, version);
+    }
+    for (int version = 4; version <= 5; version++) {
+      assertVersionActive(versionDeletedMap, version);
+    }
   }
 
   @TestTemplate
@@ -495,5 +503,15 @@ public class TestFunctionMetaService extends TestJDBCBackend {
       throw new RuntimeException("SQL execution failed", e);
     }
     return versionDeletedTime;
+  }
+
+  private void assertVersionActive(Map<Integer, Long> versionDeletedMap, int version) {
+    assertTrue(versionDeletedMap.containsKey(version));
+    assertEquals(0L, versionDeletedMap.get(version));
+  }
+
+  private void assertVersionSoftDeleted(Map<Integer, Long> versionDeletedMap, int version) {
+    assertTrue(versionDeletedMap.containsKey(version));
+    assertTrue(versionDeletedMap.get(version) > 0L);
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR hardens the retention cleanup assertions in:

- `TestFunctionMetaService.testDeleteFunctionVersionsByRetentionCount()`
- `TestFilesetMetaService.testDeleteFilesetVersionsByRetentionCount()`

Instead of only checking aggregate active/deleted counts, the tests now:

- verify that all expected versions are active before retention cleanup
- verify exactly which versions are soft deleted after cleanup
- verify that the latest retained versions remain active

This is a test-only change. No product logic is modified.

### Why are the changes needed?

The previous assertions were brittle and low-signal for intermittent CI failures.

When a failure happened, the tests only reported that the number of active or deleted versions
did not match the expected count, but they did not reveal which version state was wrong or whether
the inconsistency was already present before retention cleanup started.

By asserting concrete version states, future failures become easier to diagnose and the tests more
accurately capture the intended behavior.

Fix: #10700

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

- `./gradlew --no-daemon :core:spotlessApply :core:test --tests org.apache.gravitino.storage.relational.service.TestFunctionMetaService.testDeleteFunctionVersionsByRetentionCount --tests org.apache.gravitino.storage.relational.service.TestFilesetMetaService.testDeleteFilesetVersionsByRetentionCount -PskipITs -PskipDockerTests=false`
- Repeated the same targeted test command 3 times locally in embedded mode