### PR TITLE
[#10710] improvement(catalog-hive): Exclude unused jasper-compiler/runtime from hive-metastore2-libs

### DIFF
--- a/catalogs/hive-metastore2-libs/build.gradle.kts
+++ b/catalogs/hive-metastore2-libs/build.gradle.kts
@@ -78,6 +78,8 @@ dependencies {
     exclude(group = "org.eclipse.jetty.orbit", module = "javax.servlet")
     exclude(group = "org.openjdk.jol")
     exclude(group = "org.slf4j")
+    exclude(group = "tomcat", module = "jasper-compiler")
+    exclude(group = "tomcat", module = "jasper-runtime")
   }
 }
 


### PR DESCRIPTION

### What changes were proposed in this pull request?

Added `exclude(group = "tomcat", module = "jasper-compiler")` and `exclude(group = "tomcat", module = "jasper-runtime")` to the `hive2.metastore` dependency in `build.gradle.kts`.

### Why are the changes needed?

These Tomcat 5.5 JSP engine JARs are unused transitive dependencies from Hive 2.3.x. Removing them reduces the dependency footprint and aligns with `hive-metastore3-libs` which already excludes them.

Fix: #10710 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Verified via `./gradlew :catalogs:hive-metastore2-libs:dependencies --configuration runtimeClasspath | grep jasper `— confirms jasper JARs are no longer resolved.
