### PR TITLE
[#10712] improvement(catalogs): Remove unused htrace-core4 runtime dependency

### DIFF
--- a/catalogs/catalog-hive/build.gradle.kts
+++ b/catalogs/catalog-hive/build.gradle.kts
@@ -55,7 +55,6 @@ dependencies {
   implementation(libs.hadoop2.common) {
     exclude("*")
   }
-  implementation(libs.htrace.core4)
   implementation(libs.slf4j.api)
   implementation(libs.woodstox.core)
 

--- a/catalogs/catalog-lakehouse-hudi/build.gradle.kts
+++ b/catalogs/catalog-lakehouse-hudi/build.gradle.kts
@@ -52,7 +52,6 @@ dependencies {
   implementation(libs.hadoop2.common) {
     exclude("*")
   }
-  implementation(libs.htrace.core4)
   implementation(libs.slf4j.api)
   implementation(libs.woodstox.core)
 
@@ -116,7 +115,6 @@ dependencies {
   testImplementation(libs.hadoop2.mapreduce.client.core) {
     exclude("*")
   }
-  testImplementation(libs.htrace.core4)
   testImplementation(libs.junit.jupiter.api)
   testImplementation(libs.mysql.driver)
   testImplementation(libs.postgresql.driver)


### PR DESCRIPTION


### What changes were proposed in this pull request?

1. Removed `implementation(libs.htrace.core4)` in `catalogs/catalog-hive/build.gradle.kts` and `catalogs/catalog-lakehouse-hudi/build.gradle.kts`
2. Removed `testImplementation(libs.htrace.core4)` from `catalogs/catalog-lakehouse-hudi/build.gradle.kts`
3. Kept testImplementation in `hive-metastore-common` (needed by embedded HMS in tests)


### Why are the changes needed?

HTrace is an optional Hadoop tracing framework unused by Gravitino. Removing it from runtime classpath reduces the dependency footprint across 15+ modules.

Fix: #10712 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Tests passed for `catalog-hive`, `catalog-lakehouse-hudi`, `hive-metastore-common`, `catalog-lakehouse-iceberg`, and `catalog-lakehouse-paimon`.
