### PR TITLE
[#10715] improvement(catalog-lakehouse-hudi): Exclude unused transitive commons-beanutils

### DIFF
--- a/catalogs/catalog-lakehouse-hudi/build.gradle.kts
+++ b/catalogs/catalog-lakehouse-hudi/build.gradle.kts
@@ -42,7 +42,9 @@ dependencies {
   implementation(project(":catalogs:hive-metastore-common"))
 
   implementation(libs.commons.collections3)
-  implementation(libs.commons.configuration1)
+  implementation(libs.commons.configuration1) {
+    exclude(group = "commons-beanutils")
+  }
   implementation(libs.commons.io)
   implementation(libs.commons.lang3)
   implementation(libs.guava)
@@ -103,7 +105,9 @@ dependencies {
   testImplementation(libs.bundles.jersey)
   testImplementation(libs.bundles.jetty)
   testImplementation(libs.commons.collections3)
-  testImplementation(libs.commons.configuration1)
+  testImplementation(libs.commons.configuration1) {
+    exclude(group = "commons-beanutils")
+  }
   testImplementation(libs.datanucleus.api.jdo)
   testImplementation(libs.datanucleus.core)
   testImplementation(libs.datanucleus.jdo)


### PR DESCRIPTION


### What changes were proposed in this pull request?

Added `exclude(group = "commons-beanutils") `to `commons-configuration1` dependency in `build.gradle.kts` for both implementation and testImplementation. Consistent with the same fix applied to catalog-hive in #10580.

### Why are the changes needed?

`commons-beanutils:1.7.0` and `commons-beanutils-core:1.8.0` are unused transitive dependencies from `commons-configuration:1.6` → `commons-digester:1.8`.

Fix: #10715

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Verified `commons-beanutils` no longer appears in runtimeClasspath. Compilation and unit tests pass with `-PskipITs` and CI run passes.
