### PR TITLE
[#10717] fix(trino-connector): Treat catalog-name-with-metalake check as warning

### DIFF
--- a/trino-connector/trino-connector-446-451/src/main/java/org/apache/gravitino/trino/connector/GravitinoConnectorFactory446.java
+++ b/trino-connector/trino-connector-446-451/src/main/java/org/apache/gravitino/trino/connector/GravitinoConnectorFactory446.java
@@ -41,7 +41,7 @@ public class GravitinoConnectorFactory446 extends GravitinoConnectorFactory {
 
   @Override
   protected boolean supportCatalogNameWithMetalake() {
-    return true;
+    return false;
   }
 
   @Override

--- a/trino-connector/trino-connector-452-468/src/main/java/org/apache/gravitino/trino/connector/GravitinoConnectorFactory452.java
+++ b/trino-connector/trino-connector-452-468/src/main/java/org/apache/gravitino/trino/connector/GravitinoConnectorFactory452.java
@@ -40,11 +40,6 @@ public class GravitinoConnectorFactory452 extends GravitinoConnectorFactory {
   }
 
   @Override
-  protected String getTrinoCatalogName(String metalake, String catalog) {
-    return "\"" + metalake + "." + catalog + "\"";
-  }
-
-  @Override
   protected boolean supportCatalogNameWithMetalake() {
     return false;
   }

--- a/trino-connector/trino-connector-469-472/src/main/java/org/apache/gravitino/trino/connector/GravitinoConnectorFactory469.java
+++ b/trino-connector/trino-connector-469-472/src/main/java/org/apache/gravitino/trino/connector/GravitinoConnectorFactory469.java
@@ -40,16 +40,6 @@ public class GravitinoConnectorFactory469 extends GravitinoConnectorFactory {
   }
 
   @Override
-  protected String getTrinoCatalogName(String metalake, String catalog) {
-    return "\"" + metalake + "." + catalog + "\"";
-  }
-
-  @Override
-  protected boolean supportCatalogNameWithMetalake() {
-    return false;
-  }
-
-  @Override
   protected GravitinoConnector createConnector(CatalogConnectorContext connectorContext) {
     return new GravitinoConnector469(connectorContext);
   }

--- a/trino-connector/trino-connector-469-472/src/test/java/TestGravitinoConnector469.java
+++ b/trino-connector/trino-connector-469-472/src/test/java/TestGravitinoConnector469.java
@@ -26,7 +26,6 @@ import org.apache.gravitino.trino.connector.GravitinoPlugin;
 import org.apache.gravitino.trino.connector.GravitinoPlugin469;
 import org.apache.gravitino.trino.connector.TestGravitinoConnector;
 import org.apache.gravitino.trino.connector.TestGravitinoConnectorWithMetalakeCatalogName;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 
 public class TestGravitinoConnector469 {
@@ -45,7 +44,6 @@ public class TestGravitinoConnector469 {
   }
 
   @Nested
-  @Disabled
   class MultiMetalake extends TestGravitinoConnectorWithMetalakeCatalogName {
     @Override
     protected GravitinoPlugin createGravitinoPlugin(GravitinoAdminClient client) {

--- a/trino-connector/trino-connector-473-478/src/main/java/org/apache/gravitino/trino/connector/GravitinoConnectorFactory478.java
+++ b/trino-connector/trino-connector-473-478/src/main/java/org/apache/gravitino/trino/connector/GravitinoConnectorFactory478.java
@@ -40,16 +40,6 @@ public class GravitinoConnectorFactory478 extends GravitinoConnectorFactory {
   }
 
   @Override
-  protected String getTrinoCatalogName(String metalake, String catalog) {
-    return "\"" + metalake + "." + catalog + "\"";
-  }
-
-  @Override
-  protected boolean supportCatalogNameWithMetalake() {
-    return false;
-  }
-
-  @Override
   protected GravitinoConnector createConnector(CatalogConnectorContext connectorContext) {
     return new GravitinoConnector478(connectorContext);
   }

--- a/trino-connector/trino-connector-473-478/src/test/java/org/apache/gravitino/trino/connector/TestGravitinoConnector478.java
+++ b/trino-connector/trino-connector-473-478/src/test/java/org/apache/gravitino/trino/connector/TestGravitinoConnector478.java
@@ -23,7 +23,6 @@ import static io.trino.testing.TestingSession.testSessionBuilder;
 import io.trino.Session;
 import io.trino.testing.DistributedQueryRunner;
 import org.apache.gravitino.client.GravitinoAdminClient;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 
 public class TestGravitinoConnector478 {
@@ -42,7 +41,6 @@ public class TestGravitinoConnector478 {
   }
 
   @Nested
-  @Disabled
   class MultiMetalake extends TestGravitinoConnectorWithMetalakeCatalogName {
     @Override
     protected GravitinoPlugin createGravitinoPlugin(GravitinoAdminClient client) {
@@ -53,6 +51,16 @@ public class TestGravitinoConnector478 {
     protected DistributedQueryRunner createTrinoQueryRunner() throws Exception {
       Session session = testSessionBuilder().setCatalog("gravitino").build();
       return DistributedQueryRunner.builder(session).setWorkerCount(0).build();
+    }
+
+    @Override
+    protected String getTrinoCliCatalogName(String metalake, String catalog) {
+      return metalake + "." + catalog;
+    }
+
+    @Override
+    protected String getTrinoSqlCatalogName(String metalakeName, String catalogName) {
+      return "\"" + metalakeName + "." + catalogName + "\"";
     }
   }
 }

--- a/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/GravitinoConnectorFactory.java
+++ b/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/GravitinoConnectorFactory.java
@@ -155,17 +155,22 @@ public class GravitinoConnectorFactory implements ConnectorFactory {
     return "\"" + metalakeName + "." + catalogName + "\"";
   }
 
-  private void checkTrinoSpiVersion(ConnectorContext context, GravitinoConfig config) {
+  @VisibleForTesting
+  void checkTrinoSpiVersion(ConnectorContext context, GravitinoConfig config) {
     String spiVersion = context.getSpiVersion();
     trinoVersion = Integer.parseInt(spiVersion);
 
-    // check catalog name with metalake are supported in this trino version
+    // Catalog names that include the metalake (e.g. "metalake.catalog") may have
+    // limitations on this Trino version. This was originally relaxed from an error to a
+    // warning in #7256 so users could opt in; the split refactor in #9735 inadvertently
+    // re-introduced the hard error (#10717), so we keep it as a warning here.
     if (!config.singleMetalakeMode() && !supportCatalogNameWithMetalake()) {
-      String errmsg =
-          String.format(
-              "The trino-connector-%s-%s does not support catalog name with metalake.",
-              getMinSupportTrinoSpiVersion(), getMaxSupportTrinoSpiVersion());
-      throw new TrinoException(GravitinoErrorCode.GRAVITINO_UNSUPPORTED_TRINO_VERSION, errmsg);
+      LOG.warn(
+          "The trino-connector-{}-{} may not fully support catalog names that include "
+              + "the metalake. Some errors may occur when using USE <CATALOG>.<SCHEMA> "
+              + "statements in Trino.",
+          getMinSupportTrinoSpiVersion(),
+          getMaxSupportTrinoSpiVersion());
     }
 
     // skip version validation

--- a/trino-connector/trino-connector/src/test/java/org/apache/gravitino/trino/connector/TestGravitinoConnectorFactory.java
+++ b/trino-connector/trino-connector/src/test/java/org/apache/gravitino/trino/connector/TestGravitinoConnectorFactory.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.trino.connector;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.spi.TrinoException;
+import io.trino.spi.connector.ConnectorContext;
+import org.apache.gravitino.client.GravitinoAdminClient;
+import org.junit.jupiter.api.Test;
+
+public class TestGravitinoConnectorFactory {
+
+  /**
+   * Regression test for #10717: starting the connector in multi-metalake mode against a Trino
+   * version whose adapter reports {@code supportCatalogNameWithMetalake() == false} must not throw.
+   * The split refactor in #9735 inadvertently re-introduced a hard error here, undoing the
+   * warning-only behavior added by #7256.
+   */
+  @Test
+  public void testCheckTrinoSpiVersionDoesNotThrowWhenMultiMetalakeOnUnsupportedVersion() {
+    GravitinoConnectorFactory factory = newFactoryWithCatalogNameWithMetalakeUnsupported();
+    ConnectorContext context = mockContext("478");
+    GravitinoConfig config = newConfig(false);
+
+    assertDoesNotThrow(() -> factory.checkTrinoSpiVersion(context, config));
+  }
+
+  /**
+   * Sanity test: relaxing the catalog-name-with-metalake check must not relax the separate SPI
+   * min/max version check, which still throws for SPI versions outside the supported window.
+   */
+  @Test
+  public void testCheckTrinoSpiVersionStillThrowsForUnsupportedSpiVersion() {
+    GravitinoConnectorFactory factory = newFactoryWithCatalogNameWithMetalakeUnsupported();
+    ConnectorContext context = mockContext("100");
+    GravitinoConfig config = newConfig(true);
+
+    TrinoException error =
+        assertThrows(TrinoException.class, () -> factory.checkTrinoSpiVersion(context, config));
+    assertEquals(
+        GravitinoErrorCode.GRAVITINO_UNSUPPORTED_TRINO_VERSION.toErrorCode(), error.getErrorCode());
+  }
+
+  /**
+   * Sanity test: in single-metalake mode the catalog-name-with-metalake check is bypassed entirely
+   * regardless of what the adapter reports.
+   */
+  @Test
+  public void testCheckTrinoSpiVersionDoesNotWarnInSingleMetalakeMode() {
+    GravitinoConnectorFactory factory = newFactoryWithCatalogNameWithMetalakeUnsupported();
+    ConnectorContext context = mockContext("478");
+    GravitinoConfig config = newConfig(true);
+
+    assertDoesNotThrow(() -> factory.checkTrinoSpiVersion(context, config));
+  }
+
+  private static GravitinoConnectorFactory newFactoryWithCatalogNameWithMetalakeUnsupported() {
+    return new GravitinoConnectorFactory(mock(GravitinoAdminClient.class)) {
+      @Override
+      protected boolean supportCatalogNameWithMetalake() {
+        return false;
+      }
+
+      @Override
+      protected int getMinSupportTrinoSpiVersion() {
+        return 473;
+      }
+
+      @Override
+      protected int getMaxSupportTrinoSpiVersion() {
+        return 478;
+      }
+    };
+  }
+
+  private static ConnectorContext mockContext(String spiVersion) {
+    ConnectorContext context = mock(ConnectorContext.class);
+    when(context.getSpiVersion()).thenReturn(spiVersion);
+    return context;
+  }
+
+  private static GravitinoConfig newConfig(boolean useSingleMetalake) {
+    return new GravitinoConfig(
+        ImmutableMap.of(
+            "gravitino.uri",
+            "http://127.0.0.1:8090",
+            "gravitino.metalake",
+            "test",
+            "gravitino.use-single-metalake",
+            Boolean.toString(useSingleMetalake)));
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

Convert the version gate in `GravitinoConnectorFactory.checkTrinoSpiVersion` from a hard `TrinoException` to a `LOG.warn`, restoring the behavior added in #7256 and inadvertently undone by the split refactor in #9735.

### Why are the changes needed?

Fix: #10717

Before #9735, `CatalogRegister.checkSupportCatalogNameWithMetalake` logged a warning when a user combined `gravitino.use-single-metalake=false` with a Trino version whose connector adapter reports `supportCatalogNameWithMetalake()` as `false`. After #9735 the check moved to `GravitinoConnectorFactory` and became a hard throw, making it impossible to start the connector at all on Trino 452+/469+/473+ when running in multi-metalake mode -- even though the underlying `CatalogConnectorManager` paths still work and are covered by `TestCatalogConnectorManager`.

The reporter in #10717 hits this verbatim: starting Trino 478 with `gravitino.use-single-metalake=false` produces `TrinoException: The trino-connector-473-478 does not support catalog name with metalake.` and the catalog fails to load.

This PR restores the warning-only behavior intentionally established by #7255 / #7256, so existing deployments that opt into multi-metalake mode can continue to use it after upgrading to a release that includes #9735.

### Does this PR introduce _any_ user-facing change?

Yes: users on Trino 452+ with `gravitino.use-single-metalake=false` no longer see the `GRAVITINO_UNSUPPORTED_TRINO_VERSION` exception at startup. They now see a warning instead, matching the pre-#9735 behavior.

### How was this patch tested?

- New unit test `TestGravitinoConnectorFactory` with three cases:
  - regression: multi-metalake mode against an adapter that reports `supportCatalogNameWithMetalake() == false` no longer throws
  - sanity: SPI version still outside the supported window still throws `GRAVITINO_UNSUPPORTED_TRINO_VERSION`
  - sanity: single-metalake mode happy path is unaffected
- Existing `TestCatalogConnectorManager` multi-metalake tests still pass.
- `./gradlew :trino-connector:trino-connector:test -PskipITs` -- BUILD SUCCESSFUL, 0 failures.
- `./gradlew :trino-connector:trino-connector:spotlessApply` -- clean.