### PR TITLE
[#10733] fix(core): Correct DBCP2 connection pool settings to avoid cold-start connection overhead

### DIFF
--- a/core/src/main/java/org/apache/gravitino/storage/relational/session/SqlSessionFactoryHelper.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/session/SqlSessionFactoryHelper.java
@@ -89,14 +89,14 @@ public class SqlSessionFactoryHelper {
           config.get(Configs.ENTITY_RELATIONAL_JDBC_BACKEND_WAIT_MILLISECONDS));
       dataSource.setMaxTotal(config.get(Configs.ENTITY_RELATIONAL_JDBC_BACKEND_MAX_CONNECTIONS));
       dataSource.setMaxIdle(5);
-      dataSource.setMinIdle(0);
+      dataSource.setMinIdle(5);
       dataSource.setLogAbandoned(true);
       dataSource.setRemoveAbandonedOnBorrow(true);
       dataSource.setRemoveAbandonedTimeout(60);
       dataSource.setTimeBetweenEvictionRunsMillis(Duration.ofMillis(10 * 60 * 1000L).toMillis());
       dataSource.setTestOnBorrow(true);
       dataSource.setTestWhileIdle(true);
-      dataSource.setMinEvictableIdleTimeMillis(1000);
+      dataSource.setMinEvictableIdleTimeMillis(Duration.ofSeconds(30).toMillis());
       dataSource.setNumTestsPerEvictionRun(BaseObjectPoolConfig.DEFAULT_NUM_TESTS_PER_EVICTION_RUN);
       dataSource.setTestOnReturn(BaseObjectPoolConfig.DEFAULT_TEST_ON_RETURN);
       dataSource.setSoftMinEvictableIdleTimeMillis(

--- a/core/src/main/java/org/apache/gravitino/storage/relational/session/SqlSessionFactoryHelper.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/session/SqlSessionFactoryHelper.java
@@ -46,6 +46,10 @@ import org.apache.ibatis.transaction.jdbc.JdbcTransactionFactory;
  * should be initialized only once.
  */
 public class SqlSessionFactoryHelper {
+  private static final int JDBC_BACKEND_MAX_IDLE_CONNECTIONS = 10;
+  private static final int JDBC_BACKEND_MIN_IDLE_CONNECTIONS = 5;
+  private static final Duration JDBC_BACKEND_MIN_EVICTABLE_IDLE_TIME = Duration.ofSeconds(30);
+
   private static volatile SqlSessionFactory sqlSessionFactory;
   private static final SqlSessionFactoryHelper INSTANCE = new SqlSessionFactoryHelper();
 
@@ -88,15 +92,15 @@ public class SqlSessionFactoryHelper {
       dataSource.setMaxWaitMillis(
           config.get(Configs.ENTITY_RELATIONAL_JDBC_BACKEND_WAIT_MILLISECONDS));
       dataSource.setMaxTotal(config.get(Configs.ENTITY_RELATIONAL_JDBC_BACKEND_MAX_CONNECTIONS));
-      dataSource.setMaxIdle(5);
-      dataSource.setMinIdle(5);
+      dataSource.setMaxIdle(JDBC_BACKEND_MAX_IDLE_CONNECTIONS);
+      dataSource.setMinIdle(JDBC_BACKEND_MIN_IDLE_CONNECTIONS);
       dataSource.setLogAbandoned(true);
       dataSource.setRemoveAbandonedOnBorrow(true);
       dataSource.setRemoveAbandonedTimeout(60);
       dataSource.setTimeBetweenEvictionRunsMillis(Duration.ofMillis(10 * 60 * 1000L).toMillis());
       dataSource.setTestOnBorrow(true);
       dataSource.setTestWhileIdle(true);
-      dataSource.setMinEvictableIdleTimeMillis(Duration.ofSeconds(30).toMillis());
+      dataSource.setMinEvictableIdleTimeMillis(JDBC_BACKEND_MIN_EVICTABLE_IDLE_TIME.toMillis());
       dataSource.setNumTestsPerEvictionRun(BaseObjectPoolConfig.DEFAULT_NUM_TESTS_PER_EVICTION_RUN);
       dataSource.setTestOnReturn(BaseObjectPoolConfig.DEFAULT_TEST_ON_RETURN);
       dataSource.setSoftMinEvictableIdleTimeMillis(

--- a/core/src/test/java/org/apache/gravitino/storage/relational/session/TestSqlSession.java
+++ b/core/src/test/java/org/apache/gravitino/storage/relational/session/TestSqlSession.java
@@ -39,6 +39,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.sql.SQLException;
+import java.time.Duration;
 import java.util.UUID;
 import org.apache.commons.dbcp2.BasicDataSource;
 import org.apache.commons.io.FileUtils;
@@ -107,6 +108,7 @@ public class TestSqlSession {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   public void testInit() throws SQLException {
     SqlSessionFactoryHelper.getInstance().close();
     SqlSessionFactoryHelper.getInstance().init(config);
@@ -120,6 +122,9 @@ public class TestSqlSession {
                 .getDataSource();
     assertEquals("org.h2.Driver", dataSource.getDriverClassName());
     assertEquals(config.get(ENTITY_RELATIONAL_JDBC_BACKEND_URL), dataSource.getUrl());
+    assertEquals(10, dataSource.getMaxIdle());
+    assertEquals(5, dataSource.getMinIdle());
+    assertEquals(Duration.ofSeconds(30).toMillis(), dataSource.getMinEvictableIdleTimeMillis());
   }
 
   @Test


### PR DESCRIPTION
### What changes were proposed in this pull request?

Two hardcoded DBCP2 settings in `SqlSessionFactoryHelper` are corrected:

- `minIdle`: `0` → `5`
- `minEvictableIdleTimeMillis`: `1000` ms (1 s) → `30000` ms (30 s, via `Duration.ofSeconds(30).toMillis()`)

### Why are the changes needed?

Fix: #10733

The evictor thread runs every 10 minutes (`timeBetweenEvictionRunsMillis = 10 min`). With `minEvictableIdleTimeMillis = 1 s`, every idle connection is eligible for eviction on each evictor run. After any quiet period ≥ 10 minutes, **all** connections are evicted. Combined with `minIdle = 0`, the pool shrinks to zero, so the next burst of requests must pay a DB connection-establishment cost (TCP handshake + auth, ~20–100 ms on MySQL/PostgreSQL) before they can execute.

`1000 ms` also reads as an accidental dev/test value. Replacing it with `Duration.ofSeconds(30).toMillis()` makes the intent explicit and guards against over-aggressive eviction if the evictor interval is ever shortened.

### Does this PR introduce _any_ user-facing change?

No. These are internal connection pool settings with no API or config surface change.

### How was this patch tested?

`./gradlew :core:test -PskipITs`