### PR TITLE
[#10737] fix(core): Avoid blocking dropCatalog on imported schemas

### DIFF
--- a/core/src/main/java/org/apache/gravitino/catalog/CatalogManager.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/CatalogManager.java
@@ -73,6 +73,7 @@ import org.apache.gravitino.EntityAlreadyExistsException;
 import org.apache.gravitino.EntityStore;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
+import org.apache.gravitino.Schema;
 import org.apache.gravitino.StringIdentifier;
 import org.apache.gravitino.connector.BaseCatalog;
 import org.apache.gravitino.connector.CatalogOperations;
@@ -87,6 +88,7 @@ import org.apache.gravitino.exceptions.GravitinoRuntimeException;
 import org.apache.gravitino.exceptions.NoSuchCatalogException;
 import org.apache.gravitino.exceptions.NoSuchEntityException;
 import org.apache.gravitino.exceptions.NoSuchMetalakeException;
+import org.apache.gravitino.exceptions.NoSuchSchemaException;
 import org.apache.gravitino.exceptions.NonEmptyCatalogException;
 import org.apache.gravitino.exceptions.NonEmptyEntityException;
 import org.apache.gravitino.file.FilesetCatalog;
@@ -877,9 +879,39 @@ public class CatalogManager implements CatalogDispatcher, Closeable {
     Set<String> availableSchemaNames =
         Arrays.stream(allSchemas).map(NameIdentifier::name).collect(Collectors.toSet());
 
-    // some schemas are dropped externally, but still exist in the entity store, those schemas are
-    // invalid
-    return schemaEntities.stream().map(SchemaEntity::name).anyMatch(availableSchemaNames::contains);
+    // Some schemas are dropped externally, but still exist in the entity store — those are invalid.
+    // Among schemas that still exist in the underlying catalog, only count those created via
+    // Gravitino. New schemas carry an entity-store marker; older schemas fall back to the embedded
+    // StringIdentifier in external catalog metadata.
+    return schemaEntities.stream()
+        .filter(e -> availableSchemaNames.contains(e.name()))
+        .anyMatch(
+            e -> {
+              Map<String, String> entityProps = e.properties();
+              if (entityProps != null
+                  && "true"
+                      .equals(entityProps.get(SchemaOperationDispatcher.SCHEMA_CREATED_BY_GRAVITINO))) {
+                return true;
+              }
+
+              try {
+                Schema schema =
+                    catalogWrapper.doWithSchemaOps(ops -> ops.loadSchema(e.nameIdentifier()));
+                return StringIdentifier.fromProperties(schema.properties()) != null;
+              } catch (NoSuchSchemaException ex) {
+                LOG.warn(
+                    "Schema {} no longer exists while checking whether it is user-created",
+                    e.nameIdentifier(),
+                    ex);
+                return false;
+              } catch (Exception ex) {
+                throw new RuntimeException(
+                    String.format(
+                        "Failed to determine whether schema %s is user-created",
+                        e.nameIdentifier()),
+                    ex);
+              }
+            });
   }
 
   /**

--- a/core/src/main/java/org/apache/gravitino/catalog/CatalogManager.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/CatalogManager.java
@@ -879,20 +879,12 @@ public class CatalogManager implements CatalogDispatcher, Closeable {
     Set<String> availableSchemaNames =
         Arrays.stream(allSchemas).map(NameIdentifier::name).collect(Collectors.toSet());
 
-    // Some schemas are dropped externally, but still exist in the entity store — those are invalid.
-    // Among schemas that still exist in the underlying catalog, only count those created via
-    // Gravitino. New schemas carry an entity-store marker; older schemas fall back to the embedded
-    // StringIdentifier in external catalog metadata.
+    // Some schemas are dropped externally but still exist in the entity store — those are invalid.
+    // Among schemas that exist in the underlying catalog, only those created via Gravitino carry a
+    // StringIdentifier in their external properties; imported schemas do not.
     for (SchemaEntity schemaEntity : schemaEntities) {
       if (!availableSchemaNames.contains(schemaEntity.name())) {
         continue;
-      }
-
-      Map<String, String> entityProps = schemaEntity.properties();
-      if (entityProps != null
-          && SchemaOperationDispatcher.SCHEMA_CREATED_BY_GRAVITINO_VALUE.equals(
-              entityProps.get(SchemaOperationDispatcher.SCHEMA_CREATED_BY_GRAVITINO))) {
-        return true;
       }
 
       try {

--- a/core/src/main/java/org/apache/gravitino/catalog/CatalogManager.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/CatalogManager.java
@@ -890,7 +890,13 @@ public class CatalogManager implements CatalogDispatcher, Closeable {
       try {
         Schema schema =
             catalogWrapper.doWithSchemaOps(ops -> ops.loadSchema(schemaEntity.nameIdentifier()));
-        if (StringIdentifier.fromProperties(schema.properties()) != null) {
+        Map<String, String> props = schema.properties();
+        // If the backend cannot store a StringIdentifier (null properties, e.g. MySQL schema),
+        // we cannot tell whether the schema was created by Gravitino or imported. Be conservative
+        // and treat it as user-created to avoid accidental data loss.
+        // Only skip a schema when properties are non-null and contain no StringIdentifier,
+        // which is the reliable signal that the schema was imported from an external catalog.
+        if (props == null || StringIdentifier.fromProperties(props) != null) {
           return true;
         }
       } catch (NoSuchSchemaException ex) {

--- a/core/src/main/java/org/apache/gravitino/catalog/CatalogManager.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/CatalogManager.java
@@ -890,7 +890,8 @@ public class CatalogManager implements CatalogDispatcher, Closeable {
               Map<String, String> entityProps = e.properties();
               if (entityProps != null
                   && "true"
-                      .equals(entityProps.get(SchemaOperationDispatcher.SCHEMA_CREATED_BY_GRAVITINO))) {
+                      .equals(
+                          entityProps.get(SchemaOperationDispatcher.SCHEMA_CREATED_BY_GRAVITINO))) {
                 return true;
               }
 

--- a/core/src/main/java/org/apache/gravitino/catalog/CatalogManager.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/CatalogManager.java
@@ -883,36 +883,33 @@ public class CatalogManager implements CatalogDispatcher, Closeable {
     // Among schemas that still exist in the underlying catalog, only count those created via
     // Gravitino. New schemas carry an entity-store marker; older schemas fall back to the embedded
     // StringIdentifier in external catalog metadata.
-    return schemaEntities.stream()
-        .filter(e -> availableSchemaNames.contains(e.name()))
-        .anyMatch(
-            e -> {
-              Map<String, String> entityProps = e.properties();
-              if (entityProps != null
-                  && "true"
-                      .equals(
-                          entityProps.get(SchemaOperationDispatcher.SCHEMA_CREATED_BY_GRAVITINO))) {
-                return true;
-              }
+    for (SchemaEntity schemaEntity : schemaEntities) {
+      if (!availableSchemaNames.contains(schemaEntity.name())) {
+        continue;
+      }
 
-              try {
-                Schema schema =
-                    catalogWrapper.doWithSchemaOps(ops -> ops.loadSchema(e.nameIdentifier()));
-                return StringIdentifier.fromProperties(schema.properties()) != null;
-              } catch (NoSuchSchemaException ex) {
-                LOG.warn(
-                    "Schema {} no longer exists while checking whether it is user-created",
-                    e.nameIdentifier(),
-                    ex);
-                return false;
-              } catch (Exception ex) {
-                throw new RuntimeException(
-                    String.format(
-                        "Failed to determine whether schema %s is user-created",
-                        e.nameIdentifier()),
-                    ex);
-              }
-            });
+      Map<String, String> entityProps = schemaEntity.properties();
+      if (entityProps != null
+          && "true"
+              .equals(entityProps.get(SchemaOperationDispatcher.SCHEMA_CREATED_BY_GRAVITINO))) {
+        return true;
+      }
+
+      try {
+        Schema schema =
+            catalogWrapper.doWithSchemaOps(ops -> ops.loadSchema(schemaEntity.nameIdentifier()));
+        if (StringIdentifier.fromProperties(schema.properties()) != null) {
+          return true;
+        }
+      } catch (NoSuchSchemaException ex) {
+        // A race between listSchemas and loadSchema is expected; treat as non-user-created.
+        LOG.debug(
+            "Schema {} no longer exists while checking whether it is user-created",
+            schemaEntity.nameIdentifier());
+      }
+    }
+
+    return false;
   }
 
   /**

--- a/core/src/main/java/org/apache/gravitino/catalog/CatalogManager.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/CatalogManager.java
@@ -891,12 +891,14 @@ public class CatalogManager implements CatalogDispatcher, Closeable {
         Schema schema =
             catalogWrapper.doWithSchemaOps(ops -> ops.loadSchema(schemaEntity.nameIdentifier()));
         Map<String, String> props = schema.properties();
-        // If the backend cannot store a StringIdentifier (null properties, e.g. MySQL schema),
-        // we cannot tell whether the schema was created by Gravitino or imported. Be conservative
-        // and treat it as user-created to avoid accidental data loss.
-        // Only skip a schema when properties are non-null and contain no StringIdentifier,
-        // which is the reliable signal that the schema was imported from an external catalog.
-        if (props == null || StringIdentifier.fromProperties(props) != null) {
+        // If the backend cannot store a StringIdentifier (null or empty properties, e.g. MySQL
+        // which does not support schema comments), we cannot tell whether the schema was created
+        // by Gravitino or imported. Be conservative and treat it as user-created to avoid
+        // accidental data loss.
+        // Only skip a schema when properties are non-null, non-empty, and contain no
+        // StringIdentifier — the reliable signal that the schema was imported from an external
+        // catalog on a backend that does support identifier storage.
+        if (props == null || props.isEmpty() || StringIdentifier.fromProperties(props) != null) {
           return true;
         }
       } catch (NoSuchSchemaException ex) {

--- a/core/src/main/java/org/apache/gravitino/catalog/CatalogManager.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/CatalogManager.java
@@ -890,8 +890,8 @@ public class CatalogManager implements CatalogDispatcher, Closeable {
 
       Map<String, String> entityProps = schemaEntity.properties();
       if (entityProps != null
-          && "true"
-              .equals(entityProps.get(SchemaOperationDispatcher.SCHEMA_CREATED_BY_GRAVITINO))) {
+          && SchemaOperationDispatcher.SCHEMA_CREATED_BY_GRAVITINO_VALUE.equals(
+              entityProps.get(SchemaOperationDispatcher.SCHEMA_CREATED_BY_GRAVITINO))) {
         return true;
       }
 

--- a/core/src/main/java/org/apache/gravitino/catalog/SchemaOperationDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/SchemaOperationDispatcher.java
@@ -53,6 +53,7 @@ import org.slf4j.LoggerFactory;
 public class SchemaOperationDispatcher extends OperationDispatcher implements SchemaDispatcher {
 
   static final String SCHEMA_CREATED_BY_GRAVITINO = "gravitino.created";
+  static final String SCHEMA_CREATED_BY_GRAVITINO_VALUE = "true";
 
   private static final Logger LOG = LoggerFactory.getLogger(SchemaOperationDispatcher.class);
 
@@ -151,7 +152,9 @@ public class SchemaOperationDispatcher extends OperationDispatcher implements Sc
                   .withId(uid)
                   .withName(ident.name())
                   .withNamespace(ident.namespace())
-                  .withProperties(ImmutableMap.of(SCHEMA_CREATED_BY_GRAVITINO, "true"))
+                  .withProperties(
+                      ImmutableMap.of(
+                          SCHEMA_CREATED_BY_GRAVITINO, SCHEMA_CREATED_BY_GRAVITINO_VALUE))
                   .withAuditInfo(
                       AuditInfo.builder()
                           .withCreator(PrincipalUtils.getCurrentPrincipal().getName())

--- a/core/src/main/java/org/apache/gravitino/catalog/SchemaOperationDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/SchemaOperationDispatcher.java
@@ -23,7 +23,6 @@ import static org.apache.gravitino.catalog.OperationDispatcher.FormattedErrorMes
 import static org.apache.gravitino.catalog.PropertiesMetadataHelpers.validatePropertyForCreate;
 import static org.apache.gravitino.utils.NameIdentifierUtil.getCatalogIdentifier;
 
-import com.google.common.collect.ImmutableMap;
 import java.time.Instant;
 import java.util.Map;
 import org.apache.gravitino.EntityAlreadyExistsException;
@@ -51,9 +50,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class SchemaOperationDispatcher extends OperationDispatcher implements SchemaDispatcher {
-
-  static final String SCHEMA_CREATED_BY_GRAVITINO = "gravitino.created";
-  static final String SCHEMA_CREATED_BY_GRAVITINO_VALUE = "true";
 
   private static final Logger LOG = LoggerFactory.getLogger(SchemaOperationDispatcher.class);
 
@@ -152,9 +148,6 @@ public class SchemaOperationDispatcher extends OperationDispatcher implements Sc
                   .withId(uid)
                   .withName(ident.name())
                   .withNamespace(ident.namespace())
-                  .withProperties(
-                      ImmutableMap.of(
-                          SCHEMA_CREATED_BY_GRAVITINO, SCHEMA_CREATED_BY_GRAVITINO_VALUE))
                   .withAuditInfo(
                       AuditInfo.builder()
                           .withCreator(PrincipalUtils.getCurrentPrincipal().getName())

--- a/core/src/main/java/org/apache/gravitino/catalog/SchemaOperationDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/SchemaOperationDispatcher.java
@@ -23,6 +23,7 @@ import static org.apache.gravitino.catalog.OperationDispatcher.FormattedErrorMes
 import static org.apache.gravitino.catalog.PropertiesMetadataHelpers.validatePropertyForCreate;
 import static org.apache.gravitino.utils.NameIdentifierUtil.getCatalogIdentifier;
 
+import com.google.common.collect.ImmutableMap;
 import java.time.Instant;
 import java.util.Map;
 import org.apache.gravitino.EntityAlreadyExistsException;
@@ -50,6 +51,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class SchemaOperationDispatcher extends OperationDispatcher implements SchemaDispatcher {
+
+  static final String SCHEMA_CREATED_BY_GRAVITINO = "gravitino.created";
 
   private static final Logger LOG = LoggerFactory.getLogger(SchemaOperationDispatcher.class);
 
@@ -148,6 +151,7 @@ public class SchemaOperationDispatcher extends OperationDispatcher implements Sc
                   .withId(uid)
                   .withName(ident.name())
                   .withNamespace(ident.namespace())
+                  .withProperties(ImmutableMap.of(SCHEMA_CREATED_BY_GRAVITINO, "true"))
                   .withAuditInfo(
                       AuditInfo.builder()
                           .withCreator(PrincipalUtils.getCurrentPrincipal().getName())

--- a/core/src/test/java/org/apache/gravitino/catalog/TestCatalogManager.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestCatalogManager.java
@@ -582,13 +582,37 @@ public class TestCatalogManager {
     boolean dropped = catalogManager.dropCatalog(ident);
     Assertions.assertTrue(dropped);
 
-    Catalog catalogImported =
+    // Test drop non-existed catalog
+    NameIdentifier ident1 = NameIdentifier.of("metalake", "test42");
+    boolean dropped1 = catalogManager.dropCatalog(ident1);
+    Assertions.assertFalse(dropped1);
+
+    // Drop operation will update the cache
+    Assertions.assertNull(catalogManager.getCatalogCache().getIfPresent(ident));
+  }
+
+  @Test
+  public void testDropCatalogSkipsImportedSchemas() throws Exception {
+    NameIdentifier ident = NameIdentifier.of("metalake", "test41");
+    Map<String, String> props =
+        ImmutableMap.of(
+            "provider",
+            "test",
+            PROPERTY_KEY1,
+            "value1",
+            PROPERTY_KEY2,
+            "value2",
+            PROPERTY_KEY5_PREFIX + "1",
+            "value3");
+    String comment = "comment";
+
+    Catalog catalog =
         catalogManager.createCatalog(ident, Catalog.Type.RELATIONAL, provider, comment, props);
     Mockito.doCallRealMethod().when(catalogManager).loadCatalogAndWrap(ident);
     Assertions.assertDoesNotThrow(() -> catalogManager.disableCatalog(ident));
-    CatalogEntity importedCatalogEntity =
-        entityStore.get(ident, EntityType.CATALOG, CatalogEntity.class);
-    FieldUtils.writeField(catalogImported, "entity", importedCatalogEntity, true);
+    CatalogEntity catalogEntity = entityStore.get(ident, EntityType.CATALOG, CatalogEntity.class);
+    FieldUtils.writeField(catalog, "entity", catalogEntity, true);
+
     SchemaEntity importedSchemaEntity =
         SchemaEntity.builder()
             .withId(RandomIdGenerator.INSTANCE.nextId())
@@ -601,47 +625,86 @@ public class TestCatalogManager {
                     .build())
             .build();
     entityStore.put(importedSchemaEntity);
+
     Schema importedSchema = Mockito.mock(Schema.class);
     Mockito.doReturn(ImmutableMap.of()).when(importedSchema).properties();
-    CatalogManager.CatalogWrapper importedCatalogWrapper =
-        Mockito.mock(CatalogManager.CatalogWrapper.class);
-    Capability importedCapability = Mockito.mock(Capability.class);
-    Mockito.doReturn(importedCatalogWrapper).when(catalogManager).loadCatalogAndWrap(ident);
-    Mockito.doReturn(catalogImported).when(importedCatalogWrapper).catalog();
-    Mockito.doReturn(importedCapability).when(importedCatalogWrapper).capabilities();
-    Mockito.doReturn(unsupportedResult).when(importedCapability).managedStorage(any());
+    CatalogManager.CatalogWrapper wrapper = Mockito.mock(CatalogManager.CatalogWrapper.class);
+    Capability capability = Mockito.mock(Capability.class);
+    CapabilityResult unsupportedResult = CapabilityResult.unsupported("Not managed");
+    Mockito.doReturn(wrapper).when(catalogManager).loadCatalogAndWrap(ident);
+    Mockito.doReturn(catalog).when(wrapper).catalog();
+    Mockito.doReturn(capability).when(wrapper).capabilities();
+    Mockito.doReturn(unsupportedResult).when(capability).managedStorage(any());
     Mockito.doReturn(
             new NameIdentifier[] {NameIdentifier.of("metalake", "test41", "imported_schema")})
         .doReturn(importedSchema)
-        .when(importedCatalogWrapper)
+        .when(wrapper)
         .doWithSchemaOps(any());
-    Assertions.assertTrue(catalogManager.dropCatalog(ident));
 
-    Catalog catalog2 =
+    // Imported schema (no StringIdentifier, no gravitino.created marker) should not block drop.
+    Assertions.assertTrue(catalogManager.dropCatalog(ident));
+  }
+
+  @Test
+  public void testDropCatalogIgnoresMissingSchema() throws Exception {
+    NameIdentifier ident = NameIdentifier.of("metalake", "test41");
+    Map<String, String> props =
+        ImmutableMap.of(
+            "provider",
+            "test",
+            PROPERTY_KEY1,
+            "value1",
+            PROPERTY_KEY2,
+            "value2",
+            PROPERTY_KEY5_PREFIX + "1",
+            "value3");
+    String comment = "comment";
+
+    Catalog catalog =
         catalogManager.createCatalog(ident, Catalog.Type.RELATIONAL, provider, comment, props);
     Mockito.doCallRealMethod().when(catalogManager).loadCatalogAndWrap(ident);
     Assertions.assertDoesNotThrow(() -> catalogManager.disableCatalog(ident));
-    CatalogEntity oldEntity2 = entityStore.get(ident, EntityType.CATALOG, CatalogEntity.class);
-    FieldUtils.writeField(catalog2, "entity", oldEntity2, true);
-    CatalogManager.CatalogWrapper missingSchemaCatalogWrapper =
-        Mockito.mock(CatalogManager.CatalogWrapper.class);
-    Capability missingSchemaCapability = Mockito.mock(Capability.class);
-    Mockito.doReturn(missingSchemaCatalogWrapper).when(catalogManager).loadCatalogAndWrap(ident);
-    Mockito.doReturn(catalog2).when(missingSchemaCatalogWrapper).catalog();
-    Mockito.doReturn(missingSchemaCapability).when(missingSchemaCatalogWrapper).capabilities();
-    Mockito.doReturn(unsupportedResult).when(missingSchemaCapability).managedStorage(any());
+    CatalogEntity catalogEntity = entityStore.get(ident, EntityType.CATALOG, CatalogEntity.class);
+    FieldUtils.writeField(catalog, "entity", catalogEntity, true);
+
+    CatalogManager.CatalogWrapper wrapper = Mockito.mock(CatalogManager.CatalogWrapper.class);
+    Capability capability = Mockito.mock(Capability.class);
+    CapabilityResult unsupportedResult = CapabilityResult.unsupported("Not managed");
+    Mockito.doReturn(wrapper).when(catalogManager).loadCatalogAndWrap(ident);
+    Mockito.doReturn(catalog).when(wrapper).catalog();
+    Mockito.doReturn(capability).when(wrapper).capabilities();
+    Mockito.doReturn(unsupportedResult).when(capability).managedStorage(any());
     Mockito.doReturn(new NameIdentifier[] {NameIdentifier.of("metalake", "test41", "default")})
         .doThrow(new NoSuchSchemaException("Schema not found"))
-        .when(missingSchemaCatalogWrapper)
+        .when(wrapper)
         .doWithSchemaOps(any());
-    Assertions.assertTrue(catalogManager.dropCatalog(ident));
 
-    Catalog catalog3 =
+    // Schema disappearing between listSchemas and loadSchema should not block drop.
+    Assertions.assertTrue(catalogManager.dropCatalog(ident));
+  }
+
+  @Test
+  public void testDropCatalogFailsOnSchemaClassificationError() throws Exception {
+    NameIdentifier ident = NameIdentifier.of("metalake", "test41");
+    Map<String, String> props =
+        ImmutableMap.of(
+            "provider",
+            "test",
+            PROPERTY_KEY1,
+            "value1",
+            PROPERTY_KEY2,
+            "value2",
+            PROPERTY_KEY5_PREFIX + "1",
+            "value3");
+    String comment = "comment";
+
+    Catalog catalog =
         catalogManager.createCatalog(ident, Catalog.Type.RELATIONAL, provider, comment, props);
     Mockito.doCallRealMethod().when(catalogManager).loadCatalogAndWrap(ident);
     Assertions.assertDoesNotThrow(() -> catalogManager.disableCatalog(ident));
-    CatalogEntity oldEntity3 = entityStore.get(ident, EntityType.CATALOG, CatalogEntity.class);
-    FieldUtils.writeField(catalog3, "entity", oldEntity3, true);
+    CatalogEntity catalogEntity = entityStore.get(ident, EntityType.CATALOG, CatalogEntity.class);
+    FieldUtils.writeField(catalog, "entity", catalogEntity, true);
+
     SchemaEntity schemaEntity =
         SchemaEntity.builder()
             .withId(RandomIdGenerator.INSTANCE.nextId())
@@ -654,32 +717,23 @@ public class TestCatalogManager {
                     .build())
             .build();
     entityStore.put(schemaEntity);
-    CatalogManager.CatalogWrapper runtimeErrorCatalogWrapper =
-        Mockito.mock(CatalogManager.CatalogWrapper.class);
-    Capability runtimeErrorCapability = Mockito.mock(Capability.class);
-    Mockito.doReturn(runtimeErrorCatalogWrapper).when(catalogManager).loadCatalogAndWrap(ident);
-    Mockito.doReturn(catalog3).when(runtimeErrorCatalogWrapper).catalog();
-    Mockito.doReturn(runtimeErrorCapability).when(runtimeErrorCatalogWrapper).capabilities();
-    Mockito.doReturn(unsupportedResult).when(runtimeErrorCapability).managedStorage(any());
+
+    CatalogManager.CatalogWrapper wrapper = Mockito.mock(CatalogManager.CatalogWrapper.class);
+    Capability capability = Mockito.mock(Capability.class);
+    CapabilityResult unsupportedResult = CapabilityResult.unsupported("Not managed");
+    Mockito.doReturn(wrapper).when(catalogManager).loadCatalogAndWrap(ident);
+    Mockito.doReturn(catalog).when(wrapper).catalog();
+    Mockito.doReturn(capability).when(wrapper).capabilities();
+    Mockito.doReturn(unsupportedResult).when(capability).managedStorage(any());
     Mockito.doReturn(new NameIdentifier[] {NameIdentifier.of("metalake", "test41", "test_schema1")})
         .doThrow(new RuntimeException("Failed connect"))
-        .when(runtimeErrorCatalogWrapper)
+        .when(wrapper)
         .doWithSchemaOps(any());
-    RuntimeException runtimeException =
+
+    // Unexpected errors during schema classification should propagate (fail-closed).
+    RuntimeException ex =
         Assertions.assertThrows(RuntimeException.class, () -> catalogManager.dropCatalog(ident));
-    Assertions.assertTrue(
-        runtimeException
-            .getMessage()
-            .contains(
-                "Failed to determine whether schema metalake.test41.test_schema1 is user-created"));
-
-    // Test drop non-existed catalog
-    NameIdentifier ident1 = NameIdentifier.of("metalake", "test42");
-    boolean dropped1 = catalogManager.dropCatalog(ident1);
-    Assertions.assertFalse(dropped1);
-
-    // Drop operation will update the cache
-    Assertions.assertNull(catalogManager.getCatalogCache().getIfPresent(ident));
+    Assertions.assertTrue(ex.getCause().getMessage().contains("Failed connect"));
   }
 
   @Test

--- a/core/src/test/java/org/apache/gravitino/catalog/TestCatalogManager.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestCatalogManager.java
@@ -610,7 +610,8 @@ public class TestCatalogManager {
     Mockito.doReturn(catalogImported).when(importedCatalogWrapper).catalog();
     Mockito.doReturn(importedCapability).when(importedCatalogWrapper).capabilities();
     Mockito.doReturn(unsupportedResult).when(importedCapability).managedStorage(any());
-    Mockito.doReturn(new NameIdentifier[] {NameIdentifier.of("metalake", "test41", "imported_schema")})
+    Mockito.doReturn(
+            new NameIdentifier[] {NameIdentifier.of("metalake", "test41", "imported_schema")})
         .doReturn(importedSchema)
         .when(importedCatalogWrapper)
         .doWithSchemaOps(any());

--- a/core/src/test/java/org/apache/gravitino/catalog/TestCatalogManager.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestCatalogManager.java
@@ -627,7 +627,10 @@ public class TestCatalogManager {
     entityStore.put(importedSchemaEntity);
 
     Schema importedSchema = Mockito.mock(Schema.class);
-    Mockito.doReturn(ImmutableMap.of()).when(importedSchema).properties();
+    // Non-empty properties without StringIdentifier simulate an imported schema on a backend
+    // that supports property storage (e.g., Hive, Iceberg) but did not create this schema
+    // via Gravitino.
+    Mockito.doReturn(ImmutableMap.of("owner", "external")).when(importedSchema).properties();
     CatalogManager.CatalogWrapper wrapper = Mockito.mock(CatalogManager.CatalogWrapper.class);
     Capability capability = Mockito.mock(Capability.class);
     CapabilityResult unsupportedResult = CapabilityResult.unsupported("Not managed");

--- a/core/src/test/java/org/apache/gravitino/catalog/TestCatalogManager.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestCatalogManager.java
@@ -46,12 +46,14 @@ import org.apache.gravitino.EntityStore;
 import org.apache.gravitino.GravitinoEnv;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
+import org.apache.gravitino.Schema;
 import org.apache.gravitino.connector.capability.Capability;
 import org.apache.gravitino.connector.capability.CapabilityResult;
 import org.apache.gravitino.exceptions.CatalogAlreadyExistsException;
 import org.apache.gravitino.exceptions.CatalogInUseException;
 import org.apache.gravitino.exceptions.NoSuchCatalogException;
 import org.apache.gravitino.exceptions.NoSuchMetalakeException;
+import org.apache.gravitino.exceptions.NoSuchSchemaException;
 import org.apache.gravitino.lock.LockManager;
 import org.apache.gravitino.meta.AuditInfo;
 import org.apache.gravitino.meta.BaseMetalake;
@@ -579,6 +581,96 @@ public class TestCatalogManager {
 
     boolean dropped = catalogManager.dropCatalog(ident);
     Assertions.assertTrue(dropped);
+
+    Catalog catalogImported =
+        catalogManager.createCatalog(ident, Catalog.Type.RELATIONAL, provider, comment, props);
+    Mockito.doCallRealMethod().when(catalogManager).loadCatalogAndWrap(ident);
+    Assertions.assertDoesNotThrow(() -> catalogManager.disableCatalog(ident));
+    CatalogEntity importedCatalogEntity =
+        entityStore.get(ident, EntityType.CATALOG, CatalogEntity.class);
+    FieldUtils.writeField(catalogImported, "entity", importedCatalogEntity, true);
+    SchemaEntity importedSchemaEntity =
+        SchemaEntity.builder()
+            .withId(RandomIdGenerator.INSTANCE.nextId())
+            .withName("imported_schema")
+            .withNamespace(Namespace.of("metalake", "test41"))
+            .withAuditInfo(
+                AuditInfo.builder()
+                    .withCreator(PrincipalUtils.getCurrentPrincipal().getName())
+                    .withCreateTime(Instant.now())
+                    .build())
+            .build();
+    entityStore.put(importedSchemaEntity);
+    Schema importedSchema = Mockito.mock(Schema.class);
+    Mockito.doReturn(ImmutableMap.of()).when(importedSchema).properties();
+    CatalogManager.CatalogWrapper importedCatalogWrapper =
+        Mockito.mock(CatalogManager.CatalogWrapper.class);
+    Capability importedCapability = Mockito.mock(Capability.class);
+    Mockito.doReturn(importedCatalogWrapper).when(catalogManager).loadCatalogAndWrap(ident);
+    Mockito.doReturn(catalogImported).when(importedCatalogWrapper).catalog();
+    Mockito.doReturn(importedCapability).when(importedCatalogWrapper).capabilities();
+    Mockito.doReturn(unsupportedResult).when(importedCapability).managedStorage(any());
+    Mockito.doReturn(new NameIdentifier[] {NameIdentifier.of("metalake", "test41", "imported_schema")})
+        .doReturn(importedSchema)
+        .when(importedCatalogWrapper)
+        .doWithSchemaOps(any());
+    Assertions.assertTrue(catalogManager.dropCatalog(ident));
+
+    Catalog catalog2 =
+        catalogManager.createCatalog(ident, Catalog.Type.RELATIONAL, provider, comment, props);
+    Mockito.doCallRealMethod().when(catalogManager).loadCatalogAndWrap(ident);
+    Assertions.assertDoesNotThrow(() -> catalogManager.disableCatalog(ident));
+    CatalogEntity oldEntity2 = entityStore.get(ident, EntityType.CATALOG, CatalogEntity.class);
+    FieldUtils.writeField(catalog2, "entity", oldEntity2, true);
+    CatalogManager.CatalogWrapper missingSchemaCatalogWrapper =
+        Mockito.mock(CatalogManager.CatalogWrapper.class);
+    Capability missingSchemaCapability = Mockito.mock(Capability.class);
+    Mockito.doReturn(missingSchemaCatalogWrapper).when(catalogManager).loadCatalogAndWrap(ident);
+    Mockito.doReturn(catalog2).when(missingSchemaCatalogWrapper).catalog();
+    Mockito.doReturn(missingSchemaCapability).when(missingSchemaCatalogWrapper).capabilities();
+    Mockito.doReturn(unsupportedResult).when(missingSchemaCapability).managedStorage(any());
+    Mockito.doReturn(new NameIdentifier[] {NameIdentifier.of("metalake", "test41", "default")})
+        .doThrow(new NoSuchSchemaException("Schema not found"))
+        .when(missingSchemaCatalogWrapper)
+        .doWithSchemaOps(any());
+    Assertions.assertTrue(catalogManager.dropCatalog(ident));
+
+    Catalog catalog3 =
+        catalogManager.createCatalog(ident, Catalog.Type.RELATIONAL, provider, comment, props);
+    Mockito.doCallRealMethod().when(catalogManager).loadCatalogAndWrap(ident);
+    Assertions.assertDoesNotThrow(() -> catalogManager.disableCatalog(ident));
+    CatalogEntity oldEntity3 = entityStore.get(ident, EntityType.CATALOG, CatalogEntity.class);
+    FieldUtils.writeField(catalog3, "entity", oldEntity3, true);
+    SchemaEntity schemaEntity =
+        SchemaEntity.builder()
+            .withId(RandomIdGenerator.INSTANCE.nextId())
+            .withName("test_schema1")
+            .withNamespace(Namespace.of("metalake", "test41"))
+            .withAuditInfo(
+                AuditInfo.builder()
+                    .withCreator(PrincipalUtils.getCurrentPrincipal().getName())
+                    .withCreateTime(Instant.now())
+                    .build())
+            .build();
+    entityStore.put(schemaEntity);
+    CatalogManager.CatalogWrapper runtimeErrorCatalogWrapper =
+        Mockito.mock(CatalogManager.CatalogWrapper.class);
+    Capability runtimeErrorCapability = Mockito.mock(Capability.class);
+    Mockito.doReturn(runtimeErrorCatalogWrapper).when(catalogManager).loadCatalogAndWrap(ident);
+    Mockito.doReturn(catalog3).when(runtimeErrorCatalogWrapper).catalog();
+    Mockito.doReturn(runtimeErrorCapability).when(runtimeErrorCatalogWrapper).capabilities();
+    Mockito.doReturn(unsupportedResult).when(runtimeErrorCapability).managedStorage(any());
+    Mockito.doReturn(new NameIdentifier[] {NameIdentifier.of("metalake", "test41", "test_schema1")})
+        .doThrow(new RuntimeException("Failed connect"))
+        .when(runtimeErrorCatalogWrapper)
+        .doWithSchemaOps(any());
+    RuntimeException runtimeException =
+        Assertions.assertThrows(RuntimeException.class, () -> catalogManager.dropCatalog(ident));
+    Assertions.assertTrue(
+        runtimeException
+            .getMessage()
+            .contains(
+                "Failed to determine whether schema metalake.test41.test_schema1 is user-created"));
 
     // Test drop non-existed catalog
     NameIdentifier ident1 = NameIdentifier.of("metalake", "test42");

--- a/core/src/test/java/org/apache/gravitino/catalog/TestCatalogManager.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestCatalogManager.java
@@ -641,7 +641,7 @@ public class TestCatalogManager {
         .when(wrapper)
         .doWithSchemaOps(any());
 
-    // Imported schema (no StringIdentifier, no gravitino.created marker) should not block drop.
+    // Imported schema (no StringIdentifier in external catalog properties) should not block drop.
     Assertions.assertTrue(catalogManager.dropCatalog(ident));
   }
 
@@ -666,6 +666,19 @@ public class TestCatalogManager {
     Assertions.assertDoesNotThrow(() -> catalogManager.disableCatalog(ident));
     CatalogEntity catalogEntity = entityStore.get(ident, EntityType.CATALOG, CatalogEntity.class);
     FieldUtils.writeField(catalog, "entity", catalogEntity, true);
+
+    SchemaEntity schemaEntity =
+        SchemaEntity.builder()
+            .withId(RandomIdGenerator.INSTANCE.nextId())
+            .withName("default")
+            .withNamespace(Namespace.of("metalake", "test41"))
+            .withAuditInfo(
+                AuditInfo.builder()
+                    .withCreator(PrincipalUtils.getCurrentPrincipal().getName())
+                    .withCreateTime(Instant.now())
+                    .build())
+            .build();
+    entityStore.put(schemaEntity);
 
     CatalogManager.CatalogWrapper wrapper = Mockito.mock(CatalogManager.CatalogWrapper.class);
     Capability capability = Mockito.mock(Capability.class);


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix schema classification in `dropCatalog(force = false)` so imported schemas do not block catalog deletion.

### Why are the changes needed?

Imported schemas can be written into the entity store during metadata synchronization and later be misclassified as user-created schemas.

That makes `dropCatalog(force = false)` fail with `NonEmptyCatalogException` even though the remaining schema was imported from the external catalog.

Fix: #10737

### Does this PR introduce _any_ user-facing change?

`dropCatalog(force = false)` no longer incorrectly fails when only imported schemas remain.

### How was this patch tested?

- added unit coverage in `TestCatalogManager`