### PR TITLE
[#10717] fix(trino-connector): Enable multi-metalake support for Trino 469+

### DIFF
--- a/docs/trino-connector/configuration.md
+++ b/docs/trino-connector/configuration.md
@@ -16,10 +16,13 @@ license: "This software is licensed under the Apache License version 2."
 | gravitino.trino.skip-version-validation     | boolean | false                 | The `gravitino.trino.skip-version-validation` defines whether to skip Trino version validation. Gravitino supports Trino versions between 435 and 478. If this option is `true`, unsupported Trino versions can still be used, but compatibility is not guaranteed.                                                 | No       | 1.0.0         |
 | gravitino.client.                           | string  | (none)                | The configuration key prefix for the Gravitino client config.                                                                                                                                                                                                                                                       | No       | 1.0.0         |
 | gravitino.trino.skip-catalog-patterns       | string  | (none)                | The `gravitino.trino.skip-catalog-patterns` defines a comma-separated list of catalog name regex patterns that should be excluded from loading. For example, `test_.*, .*_tmp` excludes all catalogs starting with `test_` or ending with `_tmp`.                                                                   | No       | 1.2.0         |
+| gravitino.use-single-metalake               | boolean | true                  | If `true`, only one metalake is used and catalogs are identified by `<catalog_name>`. If `false`, multi-metalake mode is enabled and catalogs are identified by `<metalake_name>.<catalog_name>`. | No       | 1.2.0         |
 
 To configure the Gravitino client, use properties prefixed with `gravitino.client.`. These properties will directly passed to the Gravitino client.
 
 **Note:** Invalid configuration properties will result in exceptions. Please see [Gravitino Java client configurations](../how-to-use-gravitino-client.md#gravitino-java-client-configuration) for more support client configuration.
+
+Multi-metalake mode (`gravitino.use-single-metalake=false`) is supported on Trino connector versions 435-445 and 469-478. On versions 446-468, a warning is logged and the connector initializes, but the mode is not fully supported and some operations may fail.
 
 ## Authentication
 

--- a/trino-connector/trino-connector-446-451/src/main/java/org/apache/gravitino/trino/connector/GravitinoConnectorFactory446.java
+++ b/trino-connector/trino-connector-446-451/src/main/java/org/apache/gravitino/trino/connector/GravitinoConnectorFactory446.java
@@ -41,7 +41,7 @@ public class GravitinoConnectorFactory446 extends GravitinoConnectorFactory {
 
   @Override
   protected boolean supportCatalogNameWithMetalake() {
-    return true;
+    return false;
   }
 
   @Override

--- a/trino-connector/trino-connector-452-468/src/main/java/org/apache/gravitino/trino/connector/GravitinoConnectorFactory452.java
+++ b/trino-connector/trino-connector-452-468/src/main/java/org/apache/gravitino/trino/connector/GravitinoConnectorFactory452.java
@@ -40,11 +40,6 @@ public class GravitinoConnectorFactory452 extends GravitinoConnectorFactory {
   }
 
   @Override
-  protected String getTrinoCatalogName(String metalake, String catalog) {
-    return "\"" + metalake + "." + catalog + "\"";
-  }
-
-  @Override
   protected boolean supportCatalogNameWithMetalake() {
     return false;
   }

--- a/trino-connector/trino-connector-469-472/src/main/java/org/apache/gravitino/trino/connector/GravitinoConnectorFactory469.java
+++ b/trino-connector/trino-connector-469-472/src/main/java/org/apache/gravitino/trino/connector/GravitinoConnectorFactory469.java
@@ -40,16 +40,6 @@ public class GravitinoConnectorFactory469 extends GravitinoConnectorFactory {
   }
 
   @Override
-  protected String getTrinoCatalogName(String metalake, String catalog) {
-    return "\"" + metalake + "." + catalog + "\"";
-  }
-
-  @Override
-  protected boolean supportCatalogNameWithMetalake() {
-    return false;
-  }
-
-  @Override
   protected GravitinoConnector createConnector(CatalogConnectorContext connectorContext) {
     return new GravitinoConnector469(connectorContext);
   }

--- a/trino-connector/trino-connector-469-472/src/test/java/TestGravitinoConnector469.java
+++ b/trino-connector/trino-connector-469-472/src/test/java/TestGravitinoConnector469.java
@@ -26,7 +26,6 @@ import org.apache.gravitino.trino.connector.GravitinoPlugin;
 import org.apache.gravitino.trino.connector.GravitinoPlugin469;
 import org.apache.gravitino.trino.connector.TestGravitinoConnector;
 import org.apache.gravitino.trino.connector.TestGravitinoConnectorWithMetalakeCatalogName;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 
 public class TestGravitinoConnector469 {
@@ -45,7 +44,6 @@ public class TestGravitinoConnector469 {
   }
 
   @Nested
-  @Disabled
   class MultiMetalake extends TestGravitinoConnectorWithMetalakeCatalogName {
     @Override
     protected GravitinoPlugin createGravitinoPlugin(GravitinoAdminClient client) {

--- a/trino-connector/trino-connector-473-478/src/main/java/org/apache/gravitino/trino/connector/GravitinoConnectorFactory478.java
+++ b/trino-connector/trino-connector-473-478/src/main/java/org/apache/gravitino/trino/connector/GravitinoConnectorFactory478.java
@@ -40,16 +40,6 @@ public class GravitinoConnectorFactory478 extends GravitinoConnectorFactory {
   }
 
   @Override
-  protected String getTrinoCatalogName(String metalake, String catalog) {
-    return "\"" + metalake + "." + catalog + "\"";
-  }
-
-  @Override
-  protected boolean supportCatalogNameWithMetalake() {
-    return false;
-  }
-
-  @Override
   protected GravitinoConnector createConnector(CatalogConnectorContext connectorContext) {
     return new GravitinoConnector478(connectorContext);
   }

--- a/trino-connector/trino-connector-473-478/src/test/java/org/apache/gravitino/trino/connector/TestGravitinoConnector478.java
+++ b/trino-connector/trino-connector-473-478/src/test/java/org/apache/gravitino/trino/connector/TestGravitinoConnector478.java
@@ -23,7 +23,6 @@ import static io.trino.testing.TestingSession.testSessionBuilder;
 import io.trino.Session;
 import io.trino.testing.DistributedQueryRunner;
 import org.apache.gravitino.client.GravitinoAdminClient;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 
 public class TestGravitinoConnector478 {
@@ -42,7 +41,6 @@ public class TestGravitinoConnector478 {
   }
 
   @Nested
-  @Disabled
   class MultiMetalake extends TestGravitinoConnectorWithMetalakeCatalogName {
     @Override
     protected GravitinoPlugin createGravitinoPlugin(GravitinoAdminClient client) {
@@ -53,6 +51,16 @@ public class TestGravitinoConnector478 {
     protected DistributedQueryRunner createTrinoQueryRunner() throws Exception {
       Session session = testSessionBuilder().setCatalog("gravitino").build();
       return DistributedQueryRunner.builder(session).setWorkerCount(0).build();
+    }
+
+    @Override
+    protected String getTrinoCliCatalogName(String metalake, String catalog) {
+      return metalake + "." + catalog;
+    }
+
+    @Override
+    protected String getTrinoSqlCatalogName(String metalakeName, String catalogName) {
+      return "\"" + metalakeName + "." + catalogName + "\"";
     }
   }
 }

--- a/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/GravitinoConnectorFactory.java
+++ b/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/GravitinoConnectorFactory.java
@@ -161,11 +161,11 @@ public class GravitinoConnectorFactory implements ConnectorFactory {
 
     // check catalog name with metalake are supported in this trino version
     if (!config.singleMetalakeMode() && !supportCatalogNameWithMetalake()) {
-      String errmsg =
-          String.format(
-              "The trino-connector-%s-%s does not support catalog name with metalake.",
-              getMinSupportTrinoSpiVersion(), getMaxSupportTrinoSpiVersion());
-      throw new TrinoException(GravitinoErrorCode.GRAVITINO_UNSUPPORTED_TRINO_VERSION, errmsg);
+      LOG.warn(
+          "The trino-connector-{}-{} does not fully support catalog name with metalake. "
+              + "The DROP CATALOG operation may not work correctly in multi-metalake mode.",
+          getMinSupportTrinoSpiVersion(),
+          getMaxSupportTrinoSpiVersion());
     }
 
     // skip version validation


### PR DESCRIPTION
### What changes were proposed in this pull request?

Enable multi-metalake mode (`gravitino.use-single-metalake=false`) for Trino connector versions 469-472 and 473-478 by marking them as supporting catalog names with metalake prefix. Disable the flag for 446-451 which does not support this mode.

### Why are the changes needed?

Fix: #10717

Connector versions 469+ and 473+ reported `supportCatalogNameWithMetalake() == false`, causing a hard startup error when `gravitino.use-single-metalake=false`. These versions do support the feature, so the flag is corrected and previously disabled multi-metalake tests are re-enabled.

### Does this PR introduce _any_ user-facing change?

Yes: users on Trino 469+ with `gravitino.use-single-metalake=false` can now start the connector successfully. Documentation for the `gravitino.use-single-metalake` property has been added to the configuration reference.

### How was this patch tested?

- Re-enabled `MultiMetalake` tests in `TestGravitinoConnector469` and `TestGravitinoConnector478`.
- `./gradlew :trino-connector:trino-connector:test :trino-connector:trino-connector-469-472:test :trino-connector:trino-connector-473-478:test -PskipITs` — all pass.