### PR TITLE
[#10683] fix(iceberg-rest-server): support Idempotency-Key header and replay for mutation endpoints

### DIFF
--- a/catalogs/catalog-common/src/main/java/org/apache/gravitino/catalog/lakehouse/iceberg/IcebergConstants.java
+++ b/catalogs/catalog-common/src/main/java/org/apache/gravitino/catalog/lakehouse/iceberg/IcebergConstants.java
@@ -110,4 +110,6 @@ public class IcebergConstants {
   public static final String SCAN_PLAN_CACHE_IMPL = "scan-plan-cache-impl";
   public static final String SCAN_PLAN_CACHE_CAPACITY = "scan-plan-cache-capacity";
   public static final String SCAN_PLAN_CACHE_EXPIRE_MINUTES = "scan-plan-cache-expire-minutes";
+
+  public static final String IDEMPOTENCY_KEY_LIFETIME_MINUTES = "idempotency-key-lifetime-minutes";
 }

--- a/catalogs/catalog-common/src/main/java/org/apache/gravitino/catalog/lakehouse/iceberg/IcebergConstants.java
+++ b/catalogs/catalog-common/src/main/java/org/apache/gravitino/catalog/lakehouse/iceberg/IcebergConstants.java
@@ -128,4 +128,6 @@ public class IcebergConstants {
   public static final String SCAN_PLAN_CACHE_IMPL = "scan-plan-cache-impl";
   public static final String SCAN_PLAN_CACHE_CAPACITY = "scan-plan-cache-capacity";
   public static final String SCAN_PLAN_CACHE_EXPIRE_MINUTES = "scan-plan-cache-expire-minutes";
+
+  public static final String IDEMPOTENCY_KEY_LIFETIME_MINUTES = "idempotency-key-lifetime-minutes";
 }

--- a/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/IcebergConfig.java
+++ b/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/IcebergConfig.java
@@ -307,6 +307,14 @@ public class IcebergConfig extends Config implements OverwriteDefaultConfig {
           .checkValue(value -> value > 0, ConfigConstants.POSITIVE_NUMBER_ERROR_MSG)
           .createWithDefault(60);
 
+  public static final ConfigEntry<Integer> IDEMPOTENCY_KEY_LIFETIME_MINUTES =
+      new ConfigBuilder(IcebergConstants.IDEMPOTENCY_KEY_LIFETIME_MINUTES)
+          .doc("Time in minutes to retain completed idempotent mutation responses.")
+          .version(ConfigConstants.VERSION_1_3_0)
+          .intConf()
+          .checkValue(value -> value > 0, ConfigConstants.POSITIVE_NUMBER_ERROR_MSG)
+          .createWithDefault(30);
+
   public String getJdbcDriver() {
     return get(JDBC_DRIVER);
   }

--- a/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/IcebergConfig.java
+++ b/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/IcebergConfig.java
@@ -397,6 +397,14 @@ public class IcebergConfig extends Config implements OverwriteDefaultConfig {
           .checkValue(value -> value > 0, ConfigConstants.POSITIVE_NUMBER_ERROR_MSG)
           .createWithDefault(720);
 
+  public static final ConfigEntry<Integer> IDEMPOTENCY_KEY_LIFETIME_MINUTES =
+      new ConfigBuilder(IcebergConstants.IDEMPOTENCY_KEY_LIFETIME_MINUTES)
+          .doc("Time in minutes to retain completed idempotent mutation responses.")
+          .version(ConfigConstants.VERSION_1_3_0)
+          .intConf()
+          .checkValue(value -> value > 0, ConfigConstants.POSITIVE_NUMBER_ERROR_MSG)
+          .createWithDefault(30);
+
   public String getJdbcDriver() {
     return get(JDBC_DRIVER);
   }

--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/RESTService.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/RESTService.java
@@ -30,6 +30,7 @@ import org.apache.gravitino.iceberg.common.IcebergConfig;
 import org.apache.gravitino.iceberg.service.IcebergAuthenticationFilter;
 import org.apache.gravitino.iceberg.service.IcebergCatalogWrapperManager;
 import org.apache.gravitino.iceberg.service.IcebergExceptionMapper;
+import org.apache.gravitino.iceberg.service.IcebergIdempotencyManager;
 import org.apache.gravitino.iceberg.service.IcebergObjectMapperProvider;
 import org.apache.gravitino.iceberg.service.authorization.IcebergRESTServerContext;
 import org.apache.gravitino.iceberg.service.dispatcher.IcebergNamespaceEventDispatcher;
@@ -112,6 +113,8 @@ public class RESTService implements GravitinoAuxiliaryService {
         IcebergRESTServerContext.create(
             configProvider, enableAuth, auxMode, icebergCatalogWrapperManager);
     this.icebergMetricsManager = new IcebergMetricsManager(icebergConfig);
+    IcebergIdempotencyManager icebergIdempotencyManager =
+        new IcebergIdempotencyManager(icebergConfig);
     IcebergTableOperationDispatcher icebergTableOperationDispatcher =
         new IcebergTableOperationExecutor(icebergCatalogWrapperManager);
     if (authorizationContext.isAuthorizationEnabled()) {
@@ -149,6 +152,7 @@ public class RESTService implements GravitinoAuxiliaryService {
             }
             bind(icebergCatalogWrapperManager).to(IcebergCatalogWrapperManager.class).ranked(1);
             bind(icebergMetricsManager).to(IcebergMetricsManager.class).ranked(1);
+            bind(icebergIdempotencyManager).to(IcebergIdempotencyManager.class).ranked(1);
             bind(icebergTableEventDispatcher).to(IcebergTableOperationDispatcher.class).ranked(1);
             bind(icebergViewEventDispatcher).to(IcebergViewOperationDispatcher.class).ranked(1);
             bind(icebergNamespaceEventDispatcher)

--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/RESTService.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/RESTService.java
@@ -32,6 +32,7 @@ import org.apache.gravitino.iceberg.service.IcebergAuthenticationFilter;
 import org.apache.gravitino.iceberg.service.IcebergCatalogWrapperManager;
 import org.apache.gravitino.iceberg.service.IcebergExceptionMapper;
 import org.apache.gravitino.iceberg.service.IcebergHealthCheckPathMatcher;
+import org.apache.gravitino.iceberg.service.IcebergIdempotencyManager;
 import org.apache.gravitino.iceberg.service.IcebergObjectMapperProvider;
 import org.apache.gravitino.iceberg.service.authorization.IcebergRESTServerContext;
 import org.apache.gravitino.iceberg.service.cleanup.IcebergCleanupJobStore;
@@ -148,6 +149,8 @@ public class RESTService implements GravitinoAuxiliaryService {
     IcebergNamespaceOperationDispatcher namespaceOperationDispatcher =
         new IcebergNamespaceOperationExecutor(icebergCatalogWrapperManager, cleanupManager);
 
+    IcebergIdempotencyManager icebergIdempotencyManager =
+        new IcebergIdempotencyManager(icebergConfig);
     // Table: HookDispatcher -> EventDispatcher -> OperationExecutor
     IcebergTableOperationDispatcher icebergTableOperationDispatcher =
         new IcebergTableOperationExecutor(icebergCatalogWrapperManager, cleanupManager);
@@ -194,6 +197,7 @@ public class RESTService implements GravitinoAuxiliaryService {
             bind(icebergMetricsManager).to(IcebergMetricsManager.class).ranked(1);
             cleanupManager.ifPresent(
                 manager -> bind(manager).to(IcebergCleanupManager.class).ranked(1));
+            bind(icebergIdempotencyManager).to(IcebergIdempotencyManager.class).ranked(1);
             bind(icebergTableDispatcher).to(IcebergTableOperationDispatcher.class).ranked(1);
             bind(icebergViewDispatcher).to(IcebergViewOperationDispatcher.class).ranked(1);
             bind(icebergNamespaceDispatcher)

--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/IcebergIdempotencyManager.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/IcebergIdempotencyManager.java
@@ -1,0 +1,222 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.iceberg.service;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.google.common.collect.ImmutableMap;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
+import java.util.regex.Pattern;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.gravitino.iceberg.common.IcebergConfig;
+
+/** Manages idempotent replay behavior for mutation requests that carry an Idempotency-Key. */
+public class IcebergIdempotencyManager {
+
+  public static final String IDEMPOTENCY_KEY_HEADER = "Idempotency-Key";
+  public static final String IDEMPOTENCY_KEY_LIFETIME = "idempotency-key-lifetime";
+
+  private static final Pattern UUID_V7_PATTERN =
+      Pattern.compile(
+          "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-7[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$");
+
+  private static final long MAX_CACHE_ENTRIES = 10_000L;
+
+  private final Cache<IdempotencyRequestKey, CachedResponse> responseCache;
+  private final ConcurrentHashMap<IdempotencyRequestKey, Object> keyLocks;
+  private final Duration idempotencyKeyLifetime;
+
+  public IcebergIdempotencyManager(IcebergConfig icebergConfig) {
+    this(Duration.ofMinutes(icebergConfig.get(IcebergConfig.IDEMPOTENCY_KEY_LIFETIME_MINUTES)));
+  }
+
+  IcebergIdempotencyManager(Duration idempotencyKeyLifetime) {
+    if (idempotencyKeyLifetime == null
+        || idempotencyKeyLifetime.isZero()
+        || idempotencyKeyLifetime.isNegative()) {
+      throw new IllegalArgumentException("Idempotency key lifetime must be positive");
+    }
+
+    this.idempotencyKeyLifetime = idempotencyKeyLifetime;
+    this.keyLocks = new ConcurrentHashMap<>();
+    this.responseCache =
+        Caffeine.newBuilder()
+            .maximumSize(MAX_CACHE_ENTRIES)
+            .expireAfterWrite(idempotencyKeyLifetime)
+            .build();
+  }
+
+  public Optional<String> getValidatedIdempotencyKey(String idempotencyKey) {
+    if (StringUtils.isBlank(idempotencyKey)) {
+      return Optional.empty();
+    }
+
+    String normalized = idempotencyKey.trim();
+    if (!UUID_V7_PATTERN.matcher(normalized).matches()) {
+      throw new IllegalArgumentException(
+          "Invalid Idempotency-Key header. Expect UUIDv7 format for mutation endpoints.");
+    }
+
+    return Optional.of(normalized);
+  }
+
+  public Response replayOrExecute(
+      String idempotencyKey, HttpServletRequest request, Supplier<Response> operation) {
+    IdempotencyRequestKey cacheKey =
+        new IdempotencyRequestKey(
+            idempotencyKey,
+            StringUtils.defaultString(request.getMethod()),
+            StringUtils.defaultString(request.getRequestURI()),
+            StringUtils.defaultString(request.getQueryString()));
+
+    CachedResponse cachedResponse = responseCache.getIfPresent(cacheKey);
+    if (cachedResponse != null) {
+      return cachedResponse.toResponse();
+    }
+
+    Object keyLock = keyLocks.computeIfAbsent(cacheKey, k -> new Object());
+    try {
+      synchronized (keyLock) {
+        cachedResponse = responseCache.getIfPresent(cacheKey);
+        if (cachedResponse != null) {
+          return cachedResponse.toResponse();
+        }
+
+        Response response = operation.get();
+        if (response.getStatusInfo().getFamily() == Response.Status.Family.SUCCESSFUL) {
+          responseCache.put(cacheKey, CachedResponse.from(response));
+        }
+
+        return response;
+      }
+    } finally {
+      keyLocks.remove(cacheKey, keyLock);
+    }
+  }
+
+  public String getIdempotencyKeyLifetime() {
+    return idempotencyKeyLifetime.toString();
+  }
+
+  private static class IdempotencyRequestKey {
+    private final String idempotencyKey;
+    private final String method;
+    private final String requestUri;
+    private final String query;
+
+    private IdempotencyRequestKey(
+        String idempotencyKey, String method, String requestUri, String query) {
+      this.idempotencyKey = idempotencyKey;
+      this.method = method;
+      this.requestUri = requestUri;
+      this.query = normalizeQueryString(query);
+    }
+
+    private static String normalizeQueryString(String queryString) {
+      if (StringUtils.isBlank(queryString)) {
+        return "";
+      }
+
+      String[] queryPairs = queryString.split("&");
+      Arrays.sort(queryPairs);
+      return String.join("&", queryPairs);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof IdempotencyRequestKey)) {
+        return false;
+      }
+      IdempotencyRequestKey that = (IdempotencyRequestKey) o;
+      return idempotencyKey.equals(that.idempotencyKey)
+          && method.equals(that.method)
+          && requestUri.equals(that.requestUri)
+          && query.equals(that.query);
+    }
+
+    @Override
+    public int hashCode() {
+      int result = idempotencyKey.hashCode();
+      result = 31 * result + method.hashCode();
+      result = 31 * result + requestUri.hashCode();
+      result = 31 * result + query.hashCode();
+      return result;
+    }
+  }
+
+  private static class CachedResponse {
+    private final int status;
+    private final Object entity;
+    private final MediaType mediaType;
+    private final Map<String, List<Object>> headers;
+
+    private CachedResponse(
+        int status, Object entity, MediaType mediaType, Map<String, List<Object>> headers) {
+      this.status = status;
+      this.entity = entity;
+      this.mediaType = mediaType;
+      this.headers = headers;
+    }
+
+    private static CachedResponse from(Response response) {
+      ImmutableMap.Builder<String, List<Object>> headersBuilder = ImmutableMap.builder();
+      response
+          .getHeaders()
+          .forEach((headerName, values) -> headersBuilder.put(headerName, new ArrayList<>(values)));
+      return new CachedResponse(
+          response.getStatus(),
+          response.getEntity(),
+          response.getMediaType(),
+          headersBuilder.build());
+    }
+
+    private Response toResponse() {
+      Response.ResponseBuilder builder = Response.status(status);
+      if (entity != null) {
+        builder.entity(entity);
+      }
+      if (mediaType != null) {
+        builder.type(mediaType);
+      }
+
+      headers.forEach(
+          (headerName, values) -> {
+            if (!HttpHeaders.CONTENT_TYPE.equalsIgnoreCase(headerName)) {
+              values.forEach(value -> builder.header(headerName, value));
+            }
+          });
+      return builder.build();
+    }
+  }
+}

--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/rest/IcebergConfigOperations.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/rest/IcebergConfigOperations.java
@@ -41,6 +41,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.gravitino.catalog.lakehouse.iceberg.IcebergConstants;
 import org.apache.gravitino.iceberg.service.CatalogWrapperForREST;
 import org.apache.gravitino.iceberg.service.IcebergCatalogWrapperManager;
+import org.apache.gravitino.iceberg.service.IcebergIdempotencyManager;
 import org.apache.gravitino.iceberg.service.IcebergRESTUtils;
 import org.apache.gravitino.metrics.MetricNames;
 import org.apache.iceberg.rest.Endpoint;
@@ -56,6 +57,7 @@ public class IcebergConfigOperations {
   private HttpServletRequest httpRequest;
 
   private final IcebergCatalogWrapperManager catalogWrapperManager;
+  private final IcebergIdempotencyManager idempotencyManager;
 
   private static final List<Endpoint> DEFAULT_ENDPOINTS =
       ImmutableList.<Endpoint>builder()
@@ -90,8 +92,11 @@ public class IcebergConfigOperations {
           .build();
 
   @Inject
-  public IcebergConfigOperations(IcebergCatalogWrapperManager catalogWrapperManager) {
+  public IcebergConfigOperations(
+      IcebergCatalogWrapperManager catalogWrapperManager,
+      IcebergIdempotencyManager idempotencyManager) {
     this.catalogWrapperManager = catalogWrapperManager;
+    this.idempotencyManager = idempotencyManager;
   }
 
   @GET
@@ -121,6 +126,9 @@ public class IcebergConfigOperations {
     Map<String, String> configs = new HashMap<>();
     CatalogWrapperForREST catalogWrapper = getCatalogWrapper(catalogName);
     configs.putAll(catalogWrapper.getCatalogConfigToClient());
+    configs.put(
+        IcebergIdempotencyManager.IDEMPOTENCY_KEY_LIFETIME,
+        idempotencyManager.getIdempotencyKeyLifetime());
     return configs;
   }
 

--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/rest/IcebergConfigOperations.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/rest/IcebergConfigOperations.java
@@ -41,6 +41,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.gravitino.catalog.lakehouse.iceberg.IcebergConstants;
 import org.apache.gravitino.iceberg.service.CatalogWrapperForREST;
 import org.apache.gravitino.iceberg.service.IcebergCatalogWrapperManager;
+import org.apache.gravitino.iceberg.service.IcebergIdempotencyManager;
 import org.apache.gravitino.iceberg.service.IcebergRESTUtils;
 import org.apache.gravitino.metrics.MetricNames;
 import org.apache.iceberg.rest.Endpoint;
@@ -56,6 +57,7 @@ public class IcebergConfigOperations {
   private HttpServletRequest httpRequest;
 
   private final IcebergCatalogWrapperManager catalogWrapperManager;
+  private final IcebergIdempotencyManager idempotencyManager;
 
   private static final List<Endpoint> DEFAULT_ENDPOINTS =
       ImmutableList.<Endpoint>builder()
@@ -91,8 +93,11 @@ public class IcebergConfigOperations {
           .build();
 
   @Inject
-  public IcebergConfigOperations(IcebergCatalogWrapperManager catalogWrapperManager) {
+  public IcebergConfigOperations(
+      IcebergCatalogWrapperManager catalogWrapperManager,
+      IcebergIdempotencyManager idempotencyManager) {
     this.catalogWrapperManager = catalogWrapperManager;
+    this.idempotencyManager = idempotencyManager;
   }
 
   @GET
@@ -122,6 +127,9 @@ public class IcebergConfigOperations {
     Map<String, String> configs = new HashMap<>();
     CatalogWrapperForREST catalogWrapper = getCatalogWrapper(catalogName);
     configs.putAll(catalogWrapper.getCatalogConfigToClient());
+    configs.put(
+        IcebergIdempotencyManager.IDEMPOTENCY_KEY_LIFETIME,
+        idempotencyManager.getIdempotencyKeyLifetime());
     return configs;
   }
 

--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/rest/IcebergNamespaceOperations.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/rest/IcebergNamespaceOperations.java
@@ -25,6 +25,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
+import java.util.function.Supplier;
 import javax.inject.Inject;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.Consumes;
@@ -33,6 +35,7 @@ import javax.ws.rs.DefaultValue;
 import javax.ws.rs.Encoded;
 import javax.ws.rs.GET;
 import javax.ws.rs.HEAD;
+import javax.ws.rs.HeaderParam;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -45,6 +48,7 @@ import org.apache.gravitino.Entity;
 import org.apache.gravitino.MetadataObject;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.iceberg.service.IcebergExceptionMapper;
+import org.apache.gravitino.iceberg.service.IcebergIdempotencyManager;
 import org.apache.gravitino.iceberg.service.IcebergObjectMapper;
 import org.apache.gravitino.iceberg.service.IcebergRESTUtils;
 import org.apache.gravitino.iceberg.service.authorization.IcebergRESTServerContext;
@@ -78,13 +82,16 @@ public class IcebergNamespaceOperations {
 
   private ObjectMapper icebergObjectMapper;
   private IcebergNamespaceOperationDispatcher namespaceOperationDispatcher;
+  private IcebergIdempotencyManager idempotencyManager;
 
   @Context private HttpServletRequest httpRequest;
 
   @Inject
   public IcebergNamespaceOperations(
-      IcebergNamespaceOperationDispatcher namespaceOperationDispatcher) {
+      IcebergNamespaceOperationDispatcher namespaceOperationDispatcher,
+      IcebergIdempotencyManager idempotencyManager) {
     this.namespaceOperationDispatcher = namespaceOperationDispatcher;
+    this.idempotencyManager = idempotencyManager;
     this.icebergObjectMapper = IcebergObjectMapper.getInstance();
   }
 
@@ -200,7 +207,8 @@ public class IcebergNamespaceOperations {
   public Response dropNamespace(
       @AuthorizationMetadata(type = Entity.EntityType.CATALOG) @PathParam("prefix") String prefix,
       @AuthorizationMetadata(type = Entity.EntityType.SCHEMA) @Encoded() @PathParam("namespace")
-          String namespace) {
+          String namespace,
+      @HeaderParam(IcebergIdempotencyManager.IDEMPOTENCY_KEY_HEADER) String idempotencyKey) {
     // todo check if table exists in namespace after table ops is added
     String catalogName = IcebergRESTUtils.getCatalogName(prefix);
     Namespace icebergNS = RESTUtil.decodeNamespace(namespace);
@@ -208,12 +216,15 @@ public class IcebergNamespaceOperations {
     try {
       return Utils.doAs(
           httpRequest,
-          () -> {
-            IcebergRequestContext context =
-                new IcebergRequestContext(httpServletRequest(), catalogName);
-            namespaceOperationDispatcher.dropNamespace(context, icebergNS);
-            return IcebergRESTUtils.noContent();
-          });
+          () ->
+              replayIfNeeded(
+                  idempotencyKey,
+                  () -> {
+                    IcebergRequestContext context =
+                        new IcebergRequestContext(httpServletRequest(), catalogName);
+                    namespaceOperationDispatcher.dropNamespace(context, icebergNS);
+                    return IcebergRESTUtils.noContent();
+                  }));
     } catch (Exception e) {
       return IcebergExceptionMapper.toRESTResponse(e);
     }
@@ -228,7 +239,8 @@ public class IcebergNamespaceOperations {
       accessMetadataType = MetadataObject.Type.CATALOG)
   public Response createNamespace(
       @AuthorizationMetadata(type = Entity.EntityType.CATALOG) @PathParam("prefix") String prefix,
-      CreateNamespaceRequest createNamespaceRequest) {
+      CreateNamespaceRequest createNamespaceRequest,
+      @HeaderParam(IcebergIdempotencyManager.IDEMPOTENCY_KEY_HEADER) String idempotencyKey) {
     String catalogName = IcebergRESTUtils.getCatalogName(prefix);
     LOG.info(
         "Create Iceberg namespace, catalog: {}, createNamespaceRequest: {}",
@@ -237,13 +249,17 @@ public class IcebergNamespaceOperations {
     try {
       return Utils.doAs(
           httpRequest,
-          () -> {
-            IcebergRequestContext context =
-                new IcebergRequestContext(httpServletRequest(), catalogName);
-            CreateNamespaceResponse createNamespaceResponse =
-                namespaceOperationDispatcher.createNamespace(context, createNamespaceRequest);
-            return IcebergRESTUtils.ok(createNamespaceResponse);
-          });
+          () ->
+              replayIfNeeded(
+                  idempotencyKey,
+                  () -> {
+                    IcebergRequestContext context =
+                        new IcebergRequestContext(httpServletRequest(), catalogName);
+                    CreateNamespaceResponse createNamespaceResponse =
+                        namespaceOperationDispatcher.createNamespace(
+                            context, createNamespaceRequest);
+                    return IcebergRESTUtils.ok(createNamespaceResponse);
+                  }));
     } catch (Exception e) {
       return IcebergExceptionMapper.toRESTResponse(e);
     }
@@ -261,7 +277,8 @@ public class IcebergNamespaceOperations {
       @AuthorizationMetadata(type = Entity.EntityType.CATALOG) @PathParam("prefix") String prefix,
       @AuthorizationMetadata(type = Entity.EntityType.SCHEMA) @Encoded() @PathParam("namespace")
           String namespace,
-      UpdateNamespacePropertiesRequest updateNamespacePropertiesRequest) {
+      UpdateNamespacePropertiesRequest updateNamespacePropertiesRequest,
+      @HeaderParam(IcebergIdempotencyManager.IDEMPOTENCY_KEY_HEADER) String idempotencyKey) {
     String catalogName = IcebergRESTUtils.getCatalogName(prefix);
     Namespace icebergNS = RESTUtil.decodeNamespace(namespace);
     LOG.info(
@@ -272,14 +289,17 @@ public class IcebergNamespaceOperations {
     try {
       return Utils.doAs(
           httpRequest,
-          () -> {
-            IcebergRequestContext context =
-                new IcebergRequestContext(httpServletRequest(), catalogName);
-            UpdateNamespacePropertiesResponse updateNamespacePropertiesResponse =
-                namespaceOperationDispatcher.updateNamespace(
-                    context, icebergNS, updateNamespacePropertiesRequest);
-            return IcebergRESTUtils.ok(updateNamespacePropertiesResponse);
-          });
+          () ->
+              replayIfNeeded(
+                  idempotencyKey,
+                  () -> {
+                    IcebergRequestContext context =
+                        new IcebergRequestContext(httpServletRequest(), catalogName);
+                    UpdateNamespacePropertiesResponse updateNamespacePropertiesResponse =
+                        namespaceOperationDispatcher.updateNamespace(
+                            context, icebergNS, updateNamespacePropertiesRequest);
+                    return IcebergRESTUtils.ok(updateNamespacePropertiesResponse);
+                  }));
     } catch (Exception e) {
       return IcebergExceptionMapper.toRESTResponse(e);
     }
@@ -300,7 +320,8 @@ public class IcebergNamespaceOperations {
       @AuthorizationMetadata(type = Entity.EntityType.CATALOG) @PathParam("prefix") String prefix,
       @AuthorizationMetadata(type = Entity.EntityType.SCHEMA) @Encoded() @PathParam("namespace")
           String namespace,
-      RegisterTableRequest registerTableRequest) {
+      RegisterTableRequest registerTableRequest,
+      @HeaderParam(IcebergIdempotencyManager.IDEMPOTENCY_KEY_HEADER) String idempotencyKey) {
     String catalogName = IcebergRESTUtils.getCatalogName(prefix);
     Namespace icebergNS = RESTUtil.decodeNamespace(namespace);
     LOG.info(
@@ -311,14 +332,17 @@ public class IcebergNamespaceOperations {
     try {
       return Utils.doAs(
           httpRequest,
-          () -> {
-            IcebergRequestContext context =
-                new IcebergRequestContext(httpServletRequest(), catalogName);
-            LoadTableResponse loadTableResponse =
-                namespaceOperationDispatcher.registerTable(
-                    context, icebergNS, registerTableRequest);
-            return IcebergRESTUtils.buildResponseWithETag(loadTableResponse);
-          });
+          () ->
+              replayIfNeeded(
+                  idempotencyKey,
+                  () -> {
+                    IcebergRequestContext context =
+                        new IcebergRequestContext(httpServletRequest(), catalogName);
+                    LoadTableResponse loadTableResponse =
+                        namespaceOperationDispatcher.registerTable(
+                            context, icebergNS, registerTableRequest);
+                    return IcebergRESTUtils.buildResponseWithETag(loadTableResponse);
+                  }));
     } catch (Exception e) {
       return IcebergExceptionMapper.toRESTResponse(e);
     }
@@ -372,5 +396,16 @@ public class IcebergNamespaceOperations {
       LOG.warn("Serialize update namespace properties failed", e);
       return updateNamespacePropertiesRequest.toString();
     }
+  }
+
+  private Response replayIfNeeded(String idempotencyKey, Supplier<Response> operation) {
+    Optional<String> validatedIdempotencyKey =
+        idempotencyManager.getValidatedIdempotencyKey(idempotencyKey);
+    if (!validatedIdempotencyKey.isPresent()) {
+      return operation.get();
+    }
+
+    return idempotencyManager.replayOrExecute(
+        validatedIdempotencyKey.get(), httpServletRequest(), operation);
   }
 }

--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/rest/IcebergNamespaceOperations.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/rest/IcebergNamespaceOperations.java
@@ -26,6 +26,7 @@ import com.google.common.annotations.VisibleForTesting;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Supplier;
 import java.util.regex.Pattern;
 import javax.inject.Inject;
 import javax.servlet.http.HttpServletRequest;
@@ -48,6 +49,7 @@ import org.apache.gravitino.Entity;
 import org.apache.gravitino.MetadataObject;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.iceberg.service.IcebergExceptionMapper;
+import org.apache.gravitino.iceberg.service.IcebergIdempotencyManager;
 import org.apache.gravitino.iceberg.service.IcebergObjectMapper;
 import org.apache.gravitino.iceberg.service.IcebergRESTUtils;
 import org.apache.gravitino.iceberg.service.authorization.IcebergRESTServerContext;
@@ -85,13 +87,16 @@ public class IcebergNamespaceOperations {
 
   private ObjectMapper icebergObjectMapper;
   private IcebergNamespaceOperationDispatcher namespaceOperationDispatcher;
+  private IcebergIdempotencyManager idempotencyManager;
 
   @Context private HttpServletRequest httpRequest;
 
   @Inject
   public IcebergNamespaceOperations(
-      IcebergNamespaceOperationDispatcher namespaceOperationDispatcher) {
+      IcebergNamespaceOperationDispatcher namespaceOperationDispatcher,
+      IcebergIdempotencyManager idempotencyManager) {
     this.namespaceOperationDispatcher = namespaceOperationDispatcher;
+    this.idempotencyManager = idempotencyManager;
     this.icebergObjectMapper = IcebergObjectMapper.getInstance();
   }
 
@@ -217,7 +222,8 @@ public class IcebergNamespaceOperations {
   public Response dropNamespace(
       @AuthorizationMetadata(type = Entity.EntityType.CATALOG) @PathParam("prefix") String prefix,
       @AuthorizationMetadata(type = Entity.EntityType.SCHEMA) @Encoded() @PathParam("namespace")
-          String namespace) {
+          String namespace,
+      @HeaderParam(IcebergIdempotencyManager.IDEMPOTENCY_KEY_HEADER) String idempotencyKey) {
     // todo check if table exists in namespace after table ops is added
     String catalogName = IcebergRESTUtils.getCatalogName(prefix);
     Namespace icebergNS =
@@ -226,12 +232,15 @@ public class IcebergNamespaceOperations {
     try {
       return Utils.doAs(
           httpRequest,
-          () -> {
-            IcebergRequestContext context =
-                new IcebergRequestContext(httpServletRequest(), catalogName);
-            namespaceOperationDispatcher.dropNamespace(context, icebergNS);
-            return IcebergRESTUtils.noContent();
-          });
+          () ->
+              replayIfNeeded(
+                  idempotencyKey,
+                  () -> {
+                    IcebergRequestContext context =
+                        new IcebergRequestContext(httpServletRequest(), catalogName);
+                    namespaceOperationDispatcher.dropNamespace(context, icebergNS);
+                    return IcebergRESTUtils.noContent();
+                  }));
     } catch (Exception e) {
       return IcebergExceptionMapper.toRESTResponse(e);
     }
@@ -248,7 +257,8 @@ public class IcebergNamespaceOperations {
       @AuthorizationMetadata(type = Entity.EntityType.CATALOG) @PathParam("prefix") String prefix,
       @IcebergAuthorizationMetadata(
               type = IcebergAuthorizationMetadata.RequestType.CREATE_NAMESPACE)
-          CreateNamespaceRequest createNamespaceRequest) {
+          CreateNamespaceRequest createNamespaceRequest,
+      @HeaderParam(IcebergIdempotencyManager.IDEMPOTENCY_KEY_HEADER) String idempotencyKey) {
     String catalogName = IcebergRESTUtils.getCatalogName(prefix);
     LOG.info(
         "Create Iceberg namespace, catalog: {}, createNamespaceRequest: {}",
@@ -257,13 +267,17 @@ public class IcebergNamespaceOperations {
     try {
       return Utils.doAs(
           httpRequest,
-          () -> {
-            IcebergRequestContext context =
-                new IcebergRequestContext(httpServletRequest(), catalogName);
-            CreateNamespaceResponse createNamespaceResponse =
-                namespaceOperationDispatcher.createNamespace(context, createNamespaceRequest);
-            return IcebergRESTUtils.ok(createNamespaceResponse);
-          });
+          () ->
+              replayIfNeeded(
+                  idempotencyKey,
+                  () -> {
+                    IcebergRequestContext context =
+                        new IcebergRequestContext(httpServletRequest(), catalogName);
+                    CreateNamespaceResponse createNamespaceResponse =
+                        namespaceOperationDispatcher.createNamespace(
+                            context, createNamespaceRequest);
+                    return IcebergRESTUtils.ok(createNamespaceResponse);
+                  }));
     } catch (Exception e) {
       return IcebergExceptionMapper.toRESTResponse(e);
     }
@@ -281,7 +295,8 @@ public class IcebergNamespaceOperations {
       @AuthorizationMetadata(type = Entity.EntityType.CATALOG) @PathParam("prefix") String prefix,
       @AuthorizationMetadata(type = Entity.EntityType.SCHEMA) @Encoded() @PathParam("namespace")
           String namespace,
-      UpdateNamespacePropertiesRequest updateNamespacePropertiesRequest) {
+      UpdateNamespacePropertiesRequest updateNamespacePropertiesRequest,
+      @HeaderParam(IcebergIdempotencyManager.IDEMPOTENCY_KEY_HEADER) String idempotencyKey) {
     String catalogName = IcebergRESTUtils.getCatalogName(prefix);
     Namespace icebergNS =
         RESTUtil.decodeNamespace(namespace, IcebergRESTUtils.NAMESPACE_SEPARATOR_URLENCODED_UTF_8);
@@ -293,14 +308,17 @@ public class IcebergNamespaceOperations {
     try {
       return Utils.doAs(
           httpRequest,
-          () -> {
-            IcebergRequestContext context =
-                new IcebergRequestContext(httpServletRequest(), catalogName);
-            UpdateNamespacePropertiesResponse updateNamespacePropertiesResponse =
-                namespaceOperationDispatcher.updateNamespace(
-                    context, icebergNS, updateNamespacePropertiesRequest);
-            return IcebergRESTUtils.ok(updateNamespacePropertiesResponse);
-          });
+          () ->
+              replayIfNeeded(
+                  idempotencyKey,
+                  () -> {
+                    IcebergRequestContext context =
+                        new IcebergRequestContext(httpServletRequest(), catalogName);
+                    UpdateNamespacePropertiesResponse updateNamespacePropertiesResponse =
+                        namespaceOperationDispatcher.updateNamespace(
+                            context, icebergNS, updateNamespacePropertiesRequest);
+                    return IcebergRESTUtils.ok(updateNamespacePropertiesResponse);
+                  }));
     } catch (Exception e) {
       return IcebergExceptionMapper.toRESTResponse(e);
     }
@@ -322,7 +340,8 @@ public class IcebergNamespaceOperations {
       @AuthorizationMetadata(type = Entity.EntityType.SCHEMA) @Encoded() @PathParam("namespace")
           String namespace,
       RegisterTableRequest registerTableRequest,
-      @HeaderParam(IcebergTableOperations.X_ICEBERG_ACCESS_DELEGATION) String accessDelegation) {
+      @HeaderParam(IcebergTableOperations.X_ICEBERG_ACCESS_DELEGATION) String accessDelegation,
+      @HeaderParam(IcebergIdempotencyManager.IDEMPOTENCY_KEY_HEADER) String idempotencyKey) {
     boolean isCredentialVending = IcebergTableOperations.isCredentialVending(accessDelegation);
     String catalogName = IcebergRESTUtils.getCatalogName(prefix);
     Namespace icebergNS =
@@ -338,14 +357,18 @@ public class IcebergNamespaceOperations {
     try {
       return Utils.doAs(
           httpRequest,
-          () -> {
-            IcebergRequestContext context =
-                new IcebergRequestContext(httpServletRequest(), catalogName, isCredentialVending);
-            LoadTableResponse loadTableResponse =
-                namespaceOperationDispatcher.registerTable(
-                    context, icebergNS, registerTableRequest);
-            return IcebergRESTUtils.buildResponseWithETag(loadTableResponse);
-          });
+          () ->
+              replayIfNeeded(
+                  idempotencyKey,
+                  () -> {
+                    IcebergRequestContext context =
+                        new IcebergRequestContext(
+                            httpServletRequest(), catalogName, isCredentialVending);
+                    LoadTableResponse loadTableResponse =
+                        namespaceOperationDispatcher.registerTable(
+                            context, icebergNS, registerTableRequest);
+                    return IcebergRESTUtils.buildResponseWithETag(loadTableResponse);
+                  }));
     } catch (Exception e) {
       return IcebergExceptionMapper.toRESTResponse(e);
     }
@@ -435,5 +458,16 @@ public class IcebergNamespaceOperations {
       LOG.warn("Serialize update namespace properties failed", e);
       return updateNamespacePropertiesRequest.toString();
     }
+  }
+
+  private Response replayIfNeeded(String idempotencyKey, Supplier<Response> operation) {
+    Optional<String> validatedIdempotencyKey =
+        idempotencyManager.getValidatedIdempotencyKey(idempotencyKey);
+    if (!validatedIdempotencyKey.isPresent()) {
+      return operation.get();
+    }
+
+    return idempotencyManager.replayOrExecute(
+        validatedIdempotencyKey.get(), httpServletRequest(), operation);
   }
 }

--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/rest/IcebergTableOperations.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/rest/IcebergTableOperations.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
 import javax.servlet.http.HttpServletRequest;
@@ -53,6 +54,7 @@ import org.apache.gravitino.Entity.EntityType;
 import org.apache.gravitino.MetadataObject;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.iceberg.service.IcebergExceptionMapper;
+import org.apache.gravitino.iceberg.service.IcebergIdempotencyManager;
 import org.apache.gravitino.iceberg.service.IcebergObjectMapper;
 import org.apache.gravitino.iceberg.service.IcebergRESTUtils;
 import org.apache.gravitino.iceberg.service.authorization.IcebergRESTServerContext;
@@ -96,6 +98,7 @@ public class IcebergTableOperations {
   @VisibleForTesting public static final String IF_NONE_MATCH = "If-None-Match";
 
   private IcebergMetricsManager icebergMetricsManager;
+  private IcebergIdempotencyManager idempotencyManager;
 
   private ObjectMapper icebergObjectMapper;
   private IcebergTableOperationDispatcher tableOperationDispatcher;
@@ -105,9 +108,11 @@ public class IcebergTableOperations {
   @Inject
   public IcebergTableOperations(
       IcebergMetricsManager icebergMetricsManager,
-      IcebergTableOperationDispatcher tableOperationDispatcher) {
+      IcebergTableOperationDispatcher tableOperationDispatcher,
+      IcebergIdempotencyManager idempotencyManager) {
     this.icebergMetricsManager = icebergMetricsManager;
     this.tableOperationDispatcher = tableOperationDispatcher;
+    this.idempotencyManager = idempotencyManager;
     this.icebergObjectMapper = IcebergObjectMapper.getInstance();
   }
 
@@ -162,7 +167,8 @@ public class IcebergTableOperations {
       @AuthorizationMetadata(type = Entity.EntityType.SCHEMA) @Encoded() @PathParam("namespace")
           String namespace,
       CreateTableRequest createTableRequest,
-      @HeaderParam(X_ICEBERG_ACCESS_DELEGATION) String accessDelegation) {
+      @HeaderParam(X_ICEBERG_ACCESS_DELEGATION) String accessDelegation,
+      @HeaderParam(IcebergIdempotencyManager.IDEMPOTENCY_KEY_HEADER) String idempotencyKey) {
     boolean isCredentialVending = isCredentialVending(accessDelegation);
     String catalogName = IcebergRESTUtils.getCatalogName(prefix);
     Namespace icebergNS = RESTUtil.decodeNamespace(namespace);
@@ -177,13 +183,18 @@ public class IcebergTableOperations {
     try {
       return Utils.doAs(
           httpRequest,
-          () -> {
-            IcebergRequestContext context =
-                new IcebergRequestContext(httpServletRequest(), catalogName, isCredentialVending);
-            LoadTableResponse loadTableResponse =
-                tableOperationDispatcher.createTable(context, icebergNS, createTableRequest);
-            return buildResponseWithETag(loadTableResponse);
-          });
+          () ->
+              replayIfNeeded(
+                  idempotencyKey,
+                  () -> {
+                    IcebergRequestContext context =
+                        new IcebergRequestContext(
+                            httpServletRequest(), catalogName, isCredentialVending);
+                    LoadTableResponse loadTableResponse =
+                        tableOperationDispatcher.createTable(
+                            context, icebergNS, createTableRequest);
+                    return buildResponseWithETag(loadTableResponse);
+                  }));
     } catch (Exception e) {
       return IcebergExceptionMapper.toRESTResponse(e);
     }
@@ -206,7 +217,8 @@ public class IcebergTableOperations {
           String namespace,
       @AuthorizationMetadata(type = Entity.EntityType.TABLE) @Encoded() @PathParam("table")
           String table,
-      UpdateTableRequest updateTableRequest) {
+      UpdateTableRequest updateTableRequest,
+      @HeaderParam(IcebergIdempotencyManager.IDEMPOTENCY_KEY_HEADER) String idempotencyKey) {
     String catalogName = IcebergRESTUtils.getCatalogName(prefix);
     Namespace icebergNS = RESTUtil.decodeNamespace(namespace);
     String tableName = RESTUtil.decodeString(table);
@@ -221,14 +233,18 @@ public class IcebergTableOperations {
     try {
       return Utils.doAs(
           httpRequest,
-          () -> {
-            IcebergRequestContext context =
-                new IcebergRequestContext(httpServletRequest(), catalogName);
-            TableIdentifier tableIdentifier = TableIdentifier.of(icebergNS, tableName);
-            LoadTableResponse loadTableResponse =
-                tableOperationDispatcher.updateTable(context, tableIdentifier, updateTableRequest);
-            return buildResponseWithETag(loadTableResponse);
-          });
+          () ->
+              replayIfNeeded(
+                  idempotencyKey,
+                  () -> {
+                    IcebergRequestContext context =
+                        new IcebergRequestContext(httpServletRequest(), catalogName);
+                    TableIdentifier tableIdentifier = TableIdentifier.of(icebergNS, tableName);
+                    LoadTableResponse loadTableResponse =
+                        tableOperationDispatcher.updateTable(
+                            context, tableIdentifier, updateTableRequest);
+                    return buildResponseWithETag(loadTableResponse);
+                  }));
     } catch (Exception e) {
       return IcebergExceptionMapper.toRESTResponse(e);
     }
@@ -251,7 +267,8 @@ public class IcebergTableOperations {
           String namespace,
       @AuthorizationMetadata(type = Entity.EntityType.TABLE) @Encoded() @PathParam("table")
           String table,
-      @DefaultValue("false") @QueryParam("purgeRequested") boolean purgeRequested) {
+      @DefaultValue("false") @QueryParam("purgeRequested") boolean purgeRequested,
+      @HeaderParam(IcebergIdempotencyManager.IDEMPOTENCY_KEY_HEADER) String idempotencyKey) {
     String catalogName = IcebergRESTUtils.getCatalogName(prefix);
     Namespace icebergNS = RESTUtil.decodeNamespace(namespace);
     String tableName = RESTUtil.decodeString(table);
@@ -264,16 +281,30 @@ public class IcebergTableOperations {
     try {
       return Utils.doAs(
           httpRequest,
-          () -> {
-            TableIdentifier tableIdentifier = TableIdentifier.of(icebergNS, tableName);
-            IcebergRequestContext context =
-                new IcebergRequestContext(httpServletRequest(), catalogName);
-            tableOperationDispatcher.dropTable(context, tableIdentifier, purgeRequested);
-            return IcebergRESTUtils.noContent();
-          });
+          () ->
+              replayIfNeeded(
+                  idempotencyKey,
+                  () -> {
+                    TableIdentifier tableIdentifier = TableIdentifier.of(icebergNS, tableName);
+                    IcebergRequestContext context =
+                        new IcebergRequestContext(httpServletRequest(), catalogName);
+                    tableOperationDispatcher.dropTable(context, tableIdentifier, purgeRequested);
+                    return IcebergRESTUtils.noContent();
+                  }));
     } catch (Exception e) {
       return IcebergExceptionMapper.toRESTResponse(e);
     }
+  }
+
+  private Response replayIfNeeded(String idempotencyKey, Supplier<Response> operation) {
+    Optional<String> validatedIdempotencyKey =
+        idempotencyManager.getValidatedIdempotencyKey(idempotencyKey);
+    if (!validatedIdempotencyKey.isPresent()) {
+      return operation.get();
+    }
+
+    return idempotencyManager.replayOrExecute(
+        validatedIdempotencyKey.get(), httpServletRequest(), operation);
   }
 
   @GET

--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/rest/IcebergTableOperations.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/rest/IcebergTableOperations.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
 import javax.servlet.http.HttpServletRequest;
@@ -54,6 +55,7 @@ import org.apache.gravitino.MetadataObject;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.iceberg.common.utils.IcebergIdentifierUtils;
 import org.apache.gravitino.iceberg.service.IcebergExceptionMapper;
+import org.apache.gravitino.iceberg.service.IcebergIdempotencyManager;
 import org.apache.gravitino.iceberg.service.IcebergObjectMapper;
 import org.apache.gravitino.iceberg.service.IcebergRESTUtils;
 import org.apache.gravitino.iceberg.service.authorization.IcebergRESTServerContext;
@@ -98,6 +100,7 @@ public class IcebergTableOperations {
   @VisibleForTesting public static final String IF_NONE_MATCH = "If-None-Match";
 
   private IcebergMetricsManager icebergMetricsManager;
+  private IcebergIdempotencyManager idempotencyManager;
 
   private ObjectMapper icebergObjectMapper;
   private IcebergTableOperationDispatcher tableOperationDispatcher;
@@ -107,9 +110,11 @@ public class IcebergTableOperations {
   @Inject
   public IcebergTableOperations(
       IcebergMetricsManager icebergMetricsManager,
-      IcebergTableOperationDispatcher tableOperationDispatcher) {
+      IcebergTableOperationDispatcher tableOperationDispatcher,
+      IcebergIdempotencyManager idempotencyManager) {
     this.icebergMetricsManager = icebergMetricsManager;
     this.tableOperationDispatcher = tableOperationDispatcher;
+    this.idempotencyManager = idempotencyManager;
     this.icebergObjectMapper = IcebergObjectMapper.getInstance();
   }
 
@@ -172,7 +177,8 @@ public class IcebergTableOperations {
       @AuthorizationMetadata(type = Entity.EntityType.SCHEMA) @Encoded() @PathParam("namespace")
           String namespace,
       CreateTableRequest createTableRequest,
-      @HeaderParam(X_ICEBERG_ACCESS_DELEGATION) String accessDelegation) {
+      @HeaderParam(X_ICEBERG_ACCESS_DELEGATION) String accessDelegation,
+      @HeaderParam(IcebergIdempotencyManager.IDEMPOTENCY_KEY_HEADER) String idempotencyKey) {
     boolean isCredentialVending = isCredentialVending(accessDelegation);
     String catalogName = IcebergRESTUtils.getCatalogName(prefix);
     Namespace icebergNS =
@@ -188,13 +194,18 @@ public class IcebergTableOperations {
     try {
       return Utils.doAs(
           httpRequest,
-          () -> {
-            IcebergRequestContext context =
-                new IcebergRequestContext(httpServletRequest(), catalogName, isCredentialVending);
-            LoadTableResponse loadTableResponse =
-                tableOperationDispatcher.createTable(context, icebergNS, createTableRequest);
-            return buildResponseWithETag(loadTableResponse);
-          });
+          () ->
+              replayIfNeeded(
+                  idempotencyKey,
+                  () -> {
+                    IcebergRequestContext context =
+                        new IcebergRequestContext(
+                            httpServletRequest(), catalogName, isCredentialVending);
+                    LoadTableResponse loadTableResponse =
+                        tableOperationDispatcher.createTable(
+                            context, icebergNS, createTableRequest);
+                    return buildResponseWithETag(loadTableResponse);
+                  }));
     } catch (Exception e) {
       return IcebergExceptionMapper.toRESTResponse(e);
     }
@@ -217,7 +228,8 @@ public class IcebergTableOperations {
           String namespace,
       @AuthorizationMetadata(type = Entity.EntityType.TABLE) @Encoded() @PathParam("table")
           String table,
-      UpdateTableRequest updateTableRequest) {
+      UpdateTableRequest updateTableRequest,
+      @HeaderParam(IcebergIdempotencyManager.IDEMPOTENCY_KEY_HEADER) String idempotencyKey) {
     String catalogName = IcebergRESTUtils.getCatalogName(prefix);
     Namespace icebergNS =
         RESTUtil.decodeNamespace(namespace, IcebergRESTUtils.NAMESPACE_SEPARATOR_URLENCODED_UTF_8);
@@ -233,14 +245,18 @@ public class IcebergTableOperations {
     try {
       return Utils.doAs(
           httpRequest,
-          () -> {
-            IcebergRequestContext context =
-                new IcebergRequestContext(httpServletRequest(), catalogName);
-            TableIdentifier tableIdentifier = TableIdentifier.of(icebergNS, tableName);
-            LoadTableResponse loadTableResponse =
-                tableOperationDispatcher.updateTable(context, tableIdentifier, updateTableRequest);
-            return buildResponseWithETag(loadTableResponse);
-          });
+          () ->
+              replayIfNeeded(
+                  idempotencyKey,
+                  () -> {
+                    IcebergRequestContext context =
+                        new IcebergRequestContext(httpServletRequest(), catalogName);
+                    TableIdentifier tableIdentifier = TableIdentifier.of(icebergNS, tableName);
+                    LoadTableResponse loadTableResponse =
+                        tableOperationDispatcher.updateTable(
+                            context, tableIdentifier, updateTableRequest);
+                    return buildResponseWithETag(loadTableResponse);
+                  }));
     } catch (Exception e) {
       return IcebergExceptionMapper.toRESTResponse(e);
     }
@@ -263,7 +279,8 @@ public class IcebergTableOperations {
           String namespace,
       @AuthorizationMetadata(type = Entity.EntityType.TABLE) @Encoded() @PathParam("table")
           String table,
-      @DefaultValue("false") @QueryParam("purgeRequested") boolean purgeRequested) {
+      @DefaultValue("false") @QueryParam("purgeRequested") boolean purgeRequested,
+      @HeaderParam(IcebergIdempotencyManager.IDEMPOTENCY_KEY_HEADER) String idempotencyKey) {
     String catalogName = IcebergRESTUtils.getCatalogName(prefix);
     Namespace icebergNS =
         RESTUtil.decodeNamespace(namespace, IcebergRESTUtils.NAMESPACE_SEPARATOR_URLENCODED_UTF_8);
@@ -277,16 +294,30 @@ public class IcebergTableOperations {
     try {
       return Utils.doAs(
           httpRequest,
-          () -> {
-            TableIdentifier tableIdentifier = TableIdentifier.of(icebergNS, tableName);
-            IcebergRequestContext context =
-                new IcebergRequestContext(httpServletRequest(), catalogName);
-            tableOperationDispatcher.dropTable(context, tableIdentifier, purgeRequested);
-            return IcebergRESTUtils.noContent();
-          });
+          () ->
+              replayIfNeeded(
+                  idempotencyKey,
+                  () -> {
+                    TableIdentifier tableIdentifier = TableIdentifier.of(icebergNS, tableName);
+                    IcebergRequestContext context =
+                        new IcebergRequestContext(httpServletRequest(), catalogName);
+                    tableOperationDispatcher.dropTable(context, tableIdentifier, purgeRequested);
+                    return IcebergRESTUtils.noContent();
+                  }));
     } catch (Exception e) {
       return IcebergExceptionMapper.toRESTResponse(e);
     }
+  }
+
+  private Response replayIfNeeded(String idempotencyKey, Supplier<Response> operation) {
+    Optional<String> validatedIdempotencyKey =
+        idempotencyManager.getValidatedIdempotencyKey(idempotencyKey);
+    if (!validatedIdempotencyKey.isPresent()) {
+      return operation.get();
+    }
+
+    return idempotencyManager.replayOrExecute(
+        validatedIdempotencyKey.get(), httpServletRequest(), operation);
   }
 
   @GET

--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/rest/IcebergViewOperations.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/rest/IcebergViewOperations.java
@@ -25,6 +25,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
+import java.util.function.Supplier;
 import javax.inject.Inject;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.Consumes;
@@ -32,6 +34,7 @@ import javax.ws.rs.DELETE;
 import javax.ws.rs.Encoded;
 import javax.ws.rs.GET;
 import javax.ws.rs.HEAD;
+import javax.ws.rs.HeaderParam;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -44,6 +47,7 @@ import org.apache.gravitino.Entity.EntityType;
 import org.apache.gravitino.MetadataObject;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.iceberg.service.IcebergExceptionMapper;
+import org.apache.gravitino.iceberg.service.IcebergIdempotencyManager;
 import org.apache.gravitino.iceberg.service.IcebergObjectMapper;
 import org.apache.gravitino.iceberg.service.IcebergRESTUtils;
 import org.apache.gravitino.iceberg.service.authorization.IcebergRESTServerContext;
@@ -74,12 +78,16 @@ public class IcebergViewOperations {
 
   private ObjectMapper icebergObjectMapper;
   private IcebergViewOperationDispatcher viewOperationDispatcher;
+  private IcebergIdempotencyManager idempotencyManager;
 
   @Context private HttpServletRequest httpRequest;
 
   @Inject
-  public IcebergViewOperations(IcebergViewOperationDispatcher viewOperationDispatcher) {
+  public IcebergViewOperations(
+      IcebergViewOperationDispatcher viewOperationDispatcher,
+      IcebergIdempotencyManager idempotencyManager) {
     this.viewOperationDispatcher = viewOperationDispatcher;
+    this.idempotencyManager = idempotencyManager;
     this.icebergObjectMapper = IcebergObjectMapper.getInstance();
   }
 
@@ -133,7 +141,8 @@ public class IcebergViewOperations {
       @AuthorizationMetadata(type = Entity.EntityType.CATALOG) @PathParam("prefix") String prefix,
       @AuthorizationMetadata(type = Entity.EntityType.SCHEMA) @Encoded() @PathParam("namespace")
           String namespace,
-      CreateViewRequest createViewRequest) {
+      CreateViewRequest createViewRequest,
+      @HeaderParam(IcebergIdempotencyManager.IDEMPOTENCY_KEY_HEADER) String idempotencyKey) {
     String catalogName = IcebergRESTUtils.getCatalogName(prefix);
     Namespace icebergNS = RESTUtil.decodeNamespace(namespace);
     LOG.info(
@@ -144,13 +153,16 @@ public class IcebergViewOperations {
     try {
       return Utils.doAs(
           httpRequest,
-          () -> {
-            IcebergRequestContext context =
-                new IcebergRequestContext(httpServletRequest(), catalogName);
-            LoadViewResponse loadViewResponse =
-                viewOperationDispatcher.createView(context, icebergNS, createViewRequest);
-            return IcebergRESTUtils.ok(loadViewResponse);
-          });
+          () ->
+              replayIfNeeded(
+                  idempotencyKey,
+                  () -> {
+                    IcebergRequestContext context =
+                        new IcebergRequestContext(httpServletRequest(), catalogName);
+                    LoadViewResponse loadViewResponse =
+                        viewOperationDispatcher.createView(context, icebergNS, createViewRequest);
+                    return IcebergRESTUtils.ok(loadViewResponse);
+                  }));
     } catch (Exception e) {
       return IcebergExceptionMapper.toRESTResponse(e);
     }
@@ -209,7 +221,8 @@ public class IcebergViewOperations {
       @AuthorizationMetadata(type = EntityType.SCHEMA) @Encoded() @PathParam("namespace")
           String namespace,
       @AuthorizationMetadata(type = EntityType.VIEW) @Encoded() @PathParam("view") String view,
-      UpdateTableRequest replaceViewRequest) {
+      UpdateTableRequest replaceViewRequest,
+      @HeaderParam(IcebergIdempotencyManager.IDEMPOTENCY_KEY_HEADER) String idempotencyKey) {
     String catalogName = IcebergRESTUtils.getCatalogName(prefix);
     Namespace icebergNS = RESTUtil.decodeNamespace(namespace);
     String viewName = RESTUtil.decodeString(view);
@@ -222,14 +235,18 @@ public class IcebergViewOperations {
     try {
       return Utils.doAs(
           httpRequest,
-          () -> {
-            IcebergRequestContext context =
-                new IcebergRequestContext(httpServletRequest(), catalogName);
-            TableIdentifier viewIdentifier = TableIdentifier.of(icebergNS, viewName);
-            LoadViewResponse loadViewResponse =
-                viewOperationDispatcher.replaceView(context, viewIdentifier, replaceViewRequest);
-            return IcebergRESTUtils.ok(loadViewResponse);
-          });
+          () ->
+              replayIfNeeded(
+                  idempotencyKey,
+                  () -> {
+                    IcebergRequestContext context =
+                        new IcebergRequestContext(httpServletRequest(), catalogName);
+                    TableIdentifier viewIdentifier = TableIdentifier.of(icebergNS, viewName);
+                    LoadViewResponse loadViewResponse =
+                        viewOperationDispatcher.replaceView(
+                            context, viewIdentifier, replaceViewRequest);
+                    return IcebergRESTUtils.ok(loadViewResponse);
+                  }));
     } catch (Exception e) {
       return IcebergExceptionMapper.toRESTResponse(e);
     }
@@ -250,7 +267,8 @@ public class IcebergViewOperations {
       @AuthorizationMetadata(type = Entity.EntityType.CATALOG) @PathParam("prefix") String prefix,
       @AuthorizationMetadata(type = EntityType.SCHEMA) @Encoded() @PathParam("namespace")
           String namespace,
-      @AuthorizationMetadata(type = EntityType.VIEW) @Encoded() @PathParam("view") String view) {
+      @AuthorizationMetadata(type = EntityType.VIEW) @Encoded() @PathParam("view") String view,
+      @HeaderParam(IcebergIdempotencyManager.IDEMPOTENCY_KEY_HEADER) String idempotencyKey) {
     String catalogName = IcebergRESTUtils.getCatalogName(prefix);
     Namespace icebergNS = RESTUtil.decodeNamespace(namespace);
     String viewName = RESTUtil.decodeString(view);
@@ -263,11 +281,15 @@ public class IcebergViewOperations {
       return Utils.doAs(
           httpRequest,
           () -> {
-            TableIdentifier viewIdentifier = TableIdentifier.of(icebergNS, viewName);
-            IcebergRequestContext context =
-                new IcebergRequestContext(httpServletRequest(), catalogName);
-            viewOperationDispatcher.dropView(context, viewIdentifier);
-            return IcebergRESTUtils.noContent();
+            return replayIfNeeded(
+                idempotencyKey,
+                () -> {
+                  TableIdentifier viewIdentifier = TableIdentifier.of(icebergNS, viewName);
+                  IcebergRequestContext context =
+                      new IcebergRequestContext(httpServletRequest(), catalogName);
+                  viewOperationDispatcher.dropView(context, viewIdentifier);
+                  return IcebergRESTUtils.noContent();
+                });
           });
     } catch (Exception e) {
       return IcebergExceptionMapper.toRESTResponse(e);
@@ -359,5 +381,16 @@ public class IcebergViewOperations {
         .addAll(filteredIdentifiers)
         .nextPageToken(listTablesResponse.nextPageToken())
         .build();
+  }
+
+  private Response replayIfNeeded(String idempotencyKey, Supplier<Response> operation) {
+    Optional<String> validatedIdempotencyKey =
+        idempotencyManager.getValidatedIdempotencyKey(idempotencyKey);
+    if (!validatedIdempotencyKey.isPresent()) {
+      return operation.get();
+    }
+
+    return idempotencyManager.replayOrExecute(
+        validatedIdempotencyKey.get(), httpServletRequest(), operation);
   }
 }

--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/rest/IcebergViewOperations.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/rest/IcebergViewOperations.java
@@ -26,6 +26,7 @@ import com.google.common.annotations.VisibleForTesting;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Supplier;
 import javax.inject.Inject;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.Consumes;
@@ -33,6 +34,7 @@ import javax.ws.rs.DELETE;
 import javax.ws.rs.Encoded;
 import javax.ws.rs.GET;
 import javax.ws.rs.HEAD;
+import javax.ws.rs.HeaderParam;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -47,6 +49,7 @@ import org.apache.gravitino.MetadataObject;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.iceberg.common.utils.IcebergIdentifierUtils;
 import org.apache.gravitino.iceberg.service.IcebergExceptionMapper;
+import org.apache.gravitino.iceberg.service.IcebergIdempotencyManager;
 import org.apache.gravitino.iceberg.service.IcebergObjectMapper;
 import org.apache.gravitino.iceberg.service.IcebergRESTUtils;
 import org.apache.gravitino.iceberg.service.authorization.IcebergRESTServerContext;
@@ -80,12 +83,16 @@ public class IcebergViewOperations {
 
   private ObjectMapper icebergObjectMapper;
   private IcebergViewOperationDispatcher viewOperationDispatcher;
+  private IcebergIdempotencyManager idempotencyManager;
 
   @Context private HttpServletRequest httpRequest;
 
   @Inject
-  public IcebergViewOperations(IcebergViewOperationDispatcher viewOperationDispatcher) {
+  public IcebergViewOperations(
+      IcebergViewOperationDispatcher viewOperationDispatcher,
+      IcebergIdempotencyManager idempotencyManager) {
     this.viewOperationDispatcher = viewOperationDispatcher;
+    this.idempotencyManager = idempotencyManager;
     this.icebergObjectMapper = IcebergObjectMapper.getInstance();
   }
 
@@ -144,7 +151,8 @@ public class IcebergViewOperations {
       @AuthorizationMetadata(type = Entity.EntityType.CATALOG) @PathParam("prefix") String prefix,
       @AuthorizationMetadata(type = Entity.EntityType.SCHEMA) @Encoded() @PathParam("namespace")
           String namespace,
-      CreateViewRequest createViewRequest) {
+      CreateViewRequest createViewRequest,
+      @HeaderParam(IcebergIdempotencyManager.IDEMPOTENCY_KEY_HEADER) String idempotencyKey) {
     String catalogName = IcebergRESTUtils.getCatalogName(prefix);
     Namespace icebergNS =
         RESTUtil.decodeNamespace(namespace, IcebergRESTUtils.NAMESPACE_SEPARATOR_URLENCODED_UTF_8);
@@ -156,13 +164,16 @@ public class IcebergViewOperations {
     try {
       return Utils.doAs(
           httpRequest,
-          () -> {
-            IcebergRequestContext context =
-                new IcebergRequestContext(httpServletRequest(), catalogName);
-            LoadViewResponse loadViewResponse =
-                viewOperationDispatcher.createView(context, icebergNS, createViewRequest);
-            return IcebergRESTUtils.ok(loadViewResponse);
-          });
+          () ->
+              replayIfNeeded(
+                  idempotencyKey,
+                  () -> {
+                    IcebergRequestContext context =
+                        new IcebergRequestContext(httpServletRequest(), catalogName);
+                    LoadViewResponse loadViewResponse =
+                        viewOperationDispatcher.createView(context, icebergNS, createViewRequest);
+                    return IcebergRESTUtils.ok(loadViewResponse);
+                  }));
     } catch (Exception e) {
       return IcebergExceptionMapper.toRESTResponse(e);
     }
@@ -226,7 +237,8 @@ public class IcebergViewOperations {
       @AuthorizationMetadata(type = EntityType.SCHEMA) @Encoded() @PathParam("namespace")
           String namespace,
       @AuthorizationMetadata(type = EntityType.VIEW) @Encoded() @PathParam("view") String view,
-      UpdateTableRequest replaceViewRequest) {
+      UpdateTableRequest replaceViewRequest,
+      @HeaderParam(IcebergIdempotencyManager.IDEMPOTENCY_KEY_HEADER) String idempotencyKey) {
     String catalogName = IcebergRESTUtils.getCatalogName(prefix);
     Namespace icebergNS =
         RESTUtil.decodeNamespace(namespace, IcebergRESTUtils.NAMESPACE_SEPARATOR_URLENCODED_UTF_8);
@@ -240,14 +252,18 @@ public class IcebergViewOperations {
     try {
       return Utils.doAs(
           httpRequest,
-          () -> {
-            IcebergRequestContext context =
-                new IcebergRequestContext(httpServletRequest(), catalogName);
-            TableIdentifier viewIdentifier = TableIdentifier.of(icebergNS, viewName);
-            LoadViewResponse loadViewResponse =
-                viewOperationDispatcher.replaceView(context, viewIdentifier, replaceViewRequest);
-            return IcebergRESTUtils.ok(loadViewResponse);
-          });
+          () ->
+              replayIfNeeded(
+                  idempotencyKey,
+                  () -> {
+                    IcebergRequestContext context =
+                        new IcebergRequestContext(httpServletRequest(), catalogName);
+                    TableIdentifier viewIdentifier = TableIdentifier.of(icebergNS, viewName);
+                    LoadViewResponse loadViewResponse =
+                        viewOperationDispatcher.replaceView(
+                            context, viewIdentifier, replaceViewRequest);
+                    return IcebergRESTUtils.ok(loadViewResponse);
+                  }));
     } catch (Exception e) {
       return IcebergExceptionMapper.toRESTResponse(e);
     }
@@ -265,7 +281,8 @@ public class IcebergViewOperations {
       @AuthorizationMetadata(type = Entity.EntityType.CATALOG) @PathParam("prefix") String prefix,
       @AuthorizationMetadata(type = EntityType.SCHEMA) @Encoded() @PathParam("namespace")
           String namespace,
-      @AuthorizationMetadata(type = EntityType.VIEW) @Encoded() @PathParam("view") String view) {
+      @AuthorizationMetadata(type = EntityType.VIEW) @Encoded() @PathParam("view") String view,
+      @HeaderParam(IcebergIdempotencyManager.IDEMPOTENCY_KEY_HEADER) String idempotencyKey) {
     String catalogName = IcebergRESTUtils.getCatalogName(prefix);
     Namespace icebergNS =
         RESTUtil.decodeNamespace(namespace, IcebergRESTUtils.NAMESPACE_SEPARATOR_URLENCODED_UTF_8);
@@ -279,11 +296,15 @@ public class IcebergViewOperations {
       return Utils.doAs(
           httpRequest,
           () -> {
-            TableIdentifier viewIdentifier = TableIdentifier.of(icebergNS, viewName);
-            IcebergRequestContext context =
-                new IcebergRequestContext(httpServletRequest(), catalogName);
-            viewOperationDispatcher.dropView(context, viewIdentifier);
-            return IcebergRESTUtils.noContent();
+            return replayIfNeeded(
+                idempotencyKey,
+                () -> {
+                  TableIdentifier viewIdentifier = TableIdentifier.of(icebergNS, viewName);
+                  IcebergRequestContext context =
+                      new IcebergRequestContext(httpServletRequest(), catalogName);
+                  viewOperationDispatcher.dropView(context, viewIdentifier);
+                  return IcebergRESTUtils.noContent();
+                });
           });
     } catch (Exception e) {
       return IcebergExceptionMapper.toRESTResponse(e);
@@ -383,5 +404,16 @@ public class IcebergViewOperations {
         .addAll(filteredIdentifiers)
         .nextPageToken(listTablesResponse.nextPageToken())
         .build();
+  }
+
+  private Response replayIfNeeded(String idempotencyKey, Supplier<Response> operation) {
+    Optional<String> validatedIdempotencyKey =
+        idempotencyManager.getValidatedIdempotencyKey(idempotencyKey);
+    if (!validatedIdempotencyKey.isPresent()) {
+      return operation.get();
+    }
+
+    return idempotencyManager.replayOrExecute(
+        validatedIdempotencyKey.get(), httpServletRequest(), operation);
   }
 }

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/IcebergRestTestUtil.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/IcebergRestTestUtil.java
@@ -35,6 +35,7 @@ import org.apache.gravitino.credential.CredentialConstants;
 import org.apache.gravitino.iceberg.common.IcebergConfig;
 import org.apache.gravitino.iceberg.service.IcebergCatalogWrapperManager;
 import org.apache.gravitino.iceberg.service.IcebergExceptionMapper;
+import org.apache.gravitino.iceberg.service.IcebergIdempotencyManager;
 import org.apache.gravitino.iceberg.service.IcebergObjectMapperProvider;
 import org.apache.gravitino.iceberg.service.authorization.IcebergRESTServerContext;
 import org.apache.gravitino.iceberg.service.dispatcher.IcebergNamespaceEventDispatcher;
@@ -156,12 +157,15 @@ public class IcebergRestTestUtil {
               icebergNamespaceOperationExecutor, eventBus, configProvider.getMetalakeName());
 
       IcebergMetricsManager icebergMetricsManager = new IcebergMetricsManager(new IcebergConfig());
+      IcebergIdempotencyManager icebergIdempotencyManager =
+          new IcebergIdempotencyManager(new IcebergConfig(catalogConf));
       resourceConfig.register(
           new AbstractBinder() {
             @Override
             protected void configure() {
               bind(icebergCatalogWrapperManager).to(IcebergCatalogWrapperManager.class).ranked(2);
               bind(icebergMetricsManager).to(IcebergMetricsManager.class).ranked(2);
+              bind(icebergIdempotencyManager).to(IcebergIdempotencyManager.class).ranked(2);
               bind(icebergTableEventDispatcher).to(IcebergTableOperationDispatcher.class).ranked(2);
               bind(icebergViewEventDispatcher).to(IcebergViewOperationDispatcher.class).ranked(2);
               bind(icebergNamespaceEventDispatcher)

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/IcebergRestTestUtil.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/IcebergRestTestUtil.java
@@ -36,6 +36,7 @@ import org.apache.gravitino.credential.CredentialConstants;
 import org.apache.gravitino.iceberg.common.IcebergConfig;
 import org.apache.gravitino.iceberg.service.IcebergCatalogWrapperManager;
 import org.apache.gravitino.iceberg.service.IcebergExceptionMapper;
+import org.apache.gravitino.iceberg.service.IcebergIdempotencyManager;
 import org.apache.gravitino.iceberg.service.IcebergObjectMapperProvider;
 import org.apache.gravitino.iceberg.service.IcebergRESTUtils;
 import org.apache.gravitino.iceberg.service.authorization.IcebergRESTServerContext;
@@ -166,12 +167,15 @@ public class IcebergRestTestUtil {
               icebergNamespaceOperationExecutor, eventBus, configProvider.getMetalakeName());
 
       IcebergMetricsManager icebergMetricsManager = new IcebergMetricsManager(new IcebergConfig());
+      IcebergIdempotencyManager icebergIdempotencyManager =
+          new IcebergIdempotencyManager(new IcebergConfig(catalogConf));
       resourceConfig.register(
           new AbstractBinder() {
             @Override
             protected void configure() {
               bind(icebergCatalogWrapperManager).to(IcebergCatalogWrapperManager.class).ranked(2);
               bind(icebergMetricsManager).to(IcebergMetricsManager.class).ranked(2);
+              bind(icebergIdempotencyManager).to(IcebergIdempotencyManager.class).ranked(2);
               bind(icebergTableEventDispatcher).to(IcebergTableOperationDispatcher.class).ranked(2);
               bind(icebergViewEventDispatcher).to(IcebergViewOperationDispatcher.class).ranked(2);
               bind(icebergNamespaceEventDispatcher)

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/MockIcebergNamespaceOperations.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/MockIcebergNamespaceOperations.java
@@ -21,14 +21,16 @@ package org.apache.gravitino.iceberg.service.rest;
 
 import javax.inject.Inject;
 import javax.servlet.http.HttpServletRequest;
+import org.apache.gravitino.iceberg.service.IcebergIdempotencyManager;
 import org.apache.gravitino.iceberg.service.dispatcher.IcebergNamespaceOperationDispatcher;
 
 public class MockIcebergNamespaceOperations extends IcebergNamespaceOperations {
 
   @Inject
   public MockIcebergNamespaceOperations(
-      IcebergNamespaceOperationDispatcher namespaceOperationDispatcher) {
-    super(namespaceOperationDispatcher);
+      IcebergNamespaceOperationDispatcher namespaceOperationDispatcher,
+      IcebergIdempotencyManager idempotencyManager) {
+    super(namespaceOperationDispatcher, idempotencyManager);
   }
 
   // HTTP request is null in Jersey test, create a mock request

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/MockIcebergTableOperations.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/MockIcebergTableOperations.java
@@ -21,6 +21,7 @@ package org.apache.gravitino.iceberg.service.rest;
 
 import javax.inject.Inject;
 import javax.servlet.http.HttpServletRequest;
+import org.apache.gravitino.iceberg.service.IcebergIdempotencyManager;
 import org.apache.gravitino.iceberg.service.dispatcher.IcebergTableOperationDispatcher;
 import org.apache.gravitino.iceberg.service.metrics.IcebergMetricsManager;
 
@@ -29,8 +30,9 @@ public class MockIcebergTableOperations extends IcebergTableOperations {
   @Inject
   public MockIcebergTableOperations(
       IcebergMetricsManager icebergMetricsManager,
-      IcebergTableOperationDispatcher tableOperationDispatcher) {
-    super(icebergMetricsManager, tableOperationDispatcher);
+      IcebergTableOperationDispatcher tableOperationDispatcher,
+      IcebergIdempotencyManager idempotencyManager) {
+    super(icebergMetricsManager, tableOperationDispatcher, idempotencyManager);
   }
 
   // HTTP request is null in Jersey test, create a mock request

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/MockIcebergViewOperations.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/MockIcebergViewOperations.java
@@ -21,13 +21,16 @@ package org.apache.gravitino.iceberg.service.rest;
 
 import javax.inject.Inject;
 import javax.servlet.http.HttpServletRequest;
+import org.apache.gravitino.iceberg.service.IcebergIdempotencyManager;
 import org.apache.gravitino.iceberg.service.dispatcher.IcebergViewOperationDispatcher;
 
 public class MockIcebergViewOperations extends IcebergViewOperations {
 
   @Inject
-  public MockIcebergViewOperations(IcebergViewOperationDispatcher viewOperationDispatcher) {
-    super(viewOperationDispatcher);
+  public MockIcebergViewOperations(
+      IcebergViewOperationDispatcher viewOperationDispatcher,
+      IcebergIdempotencyManager idempotencyManager) {
+    super(viewOperationDispatcher, idempotencyManager);
   }
 
   // HTTP request is null in Jersey test, create a mock request

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/TestIcebergConfig.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/TestIcebergConfig.java
@@ -25,6 +25,7 @@ import javax.ws.rs.core.Application;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import org.apache.gravitino.catalog.lakehouse.iceberg.IcebergConstants;
+import org.apache.gravitino.iceberg.service.IcebergIdempotencyManager;
 import org.apache.iceberg.rest.responses.ConfigResponse;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -45,7 +46,9 @@ public class TestIcebergConfig extends IcebergTestBase {
     Assertions.assertEquals(MediaType.APPLICATION_JSON_TYPE, resp.getMediaType());
 
     ConfigResponse response = resp.readEntity(ConfigResponse.class);
-    Assertions.assertEquals(0, response.defaults().size());
+    Assertions.assertEquals(1, response.defaults().size());
+    Assertions.assertEquals(
+        "PT30M", response.defaults().get(IcebergIdempotencyManager.IDEMPOTENCY_KEY_LIFETIME));
     Assertions.assertEquals(0, response.overrides().size());
   }
 
@@ -58,7 +61,9 @@ public class TestIcebergConfig extends IcebergTestBase {
     Assertions.assertEquals(MediaType.APPLICATION_JSON_TYPE, resp.getMediaType());
 
     ConfigResponse response = resp.readEntity(ConfigResponse.class);
-    Assertions.assertEquals(0, response.defaults().size());
+    Assertions.assertEquals(1, response.defaults().size());
+    Assertions.assertEquals(
+        "PT30M", response.defaults().get(IcebergIdempotencyManager.IDEMPOTENCY_KEY_LIFETIME));
     Assertions.assertEquals(0, response.overrides().size());
   }
 
@@ -84,7 +89,9 @@ public class TestIcebergConfig extends IcebergTestBase {
             IcebergConstants.ICEBERG_OSS_ENDPOINT,
             "https://oss-endpoint.example.com",
             IcebergConstants.ICEBERG_S3_PATH_STYLE_ACCESS,
-            "true");
+            "true",
+            IcebergIdempotencyManager.IDEMPOTENCY_KEY_LIFETIME,
+            "PT30M");
     Assertions.assertEquals(expectedConfig, response.defaults());
     Assertions.assertEquals(0, response.overrides().size());
   }

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/TestIcebergNamespaceOperations.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/TestIcebergNamespaceOperations.java
@@ -21,9 +21,12 @@ package org.apache.gravitino.iceberg.service.rest;
 import java.util.Arrays;
 import java.util.Optional;
 import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.Application;
 import javax.ws.rs.core.EntityTag;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import org.apache.gravitino.iceberg.service.IcebergIdempotencyManager;
 import org.apache.gravitino.iceberg.service.IcebergRESTUtils;
 import org.apache.gravitino.listener.api.event.Event;
 import org.apache.gravitino.listener.api.event.IcebergCreateNamespaceEvent;
@@ -44,6 +47,8 @@ import org.apache.gravitino.listener.api.event.IcebergUpdateNamespaceEvent;
 import org.apache.gravitino.listener.api.event.IcebergUpdateNamespaceFailureEvent;
 import org.apache.gravitino.listener.api.event.IcebergUpdateNamespacePreEvent;
 import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.rest.requests.ImmutableRegisterTableRequest;
+import org.apache.iceberg.rest.requests.RegisterTableRequest;
 import org.glassfish.jersey.internal.inject.AbstractBinder;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.junit.jupiter.api.Assertions;
@@ -193,6 +198,25 @@ public class TestIcebergNamespaceOperations extends IcebergNamespaceTestBase {
   }
 
   @Test
+  void testRegisterTableWithIdempotencyKey() {
+    Namespace namespace = Namespace.of("register_idempotent_ns");
+    String tableName = "register_idempotent_tbl";
+    String idempotencyKey = "018f4f74-7e58-7cc2-a2f0-6f53123abcde";
+
+    dummyEventListener.clearEvent();
+    Response first = doRegisterTableWithIdempotencyKey(tableName, namespace, idempotencyKey);
+    Assertions.assertEquals(Response.Status.OK.getStatusCode(), first.getStatus());
+
+    Response second = doRegisterTableWithIdempotencyKey(tableName, namespace, idempotencyKey);
+    Assertions.assertEquals(Response.Status.OK.getStatusCode(), second.getStatus());
+
+    Assertions.assertTrue(dummyEventListener.popPreEvent() instanceof IcebergRegisterTablePreEvent);
+    Assertions.assertTrue(dummyEventListener.popPostEvent() instanceof IcebergRegisterTableEvent);
+    Assertions.assertThrows(AssertionError.class, () -> dummyEventListener.popPreEvent());
+    Assertions.assertThrows(AssertionError.class, () -> dummyEventListener.popPostEvent());
+  }
+
+  @Test
   void testRegisterTableReturnsETag() {
     Namespace ns = Namespace.of("register_etag_ns");
     Response response = doRegisterTable("register_etag_foo1", ns);
@@ -256,5 +280,14 @@ public class TestIcebergNamespaceOperations extends IcebergNamespaceTestBase {
     verifyCreateNamespaceSucc(Namespace.of("update_foo3", "a"));
     dummyEventListener.clearEvent();
     verifyUpdateNamespaceSucc(Namespace.of("update_foo3", "a"));
+  }
+
+  private Response doRegisterTableWithIdempotencyKey(
+      String tableName, Namespace ns, String idempotencyKey) {
+    RegisterTableRequest request =
+        ImmutableRegisterTableRequest.builder().name(tableName).metadataLocation("mock").build();
+    return getNamespaceClientBuilder(Optional.of(ns), Optional.of("register"), Optional.empty())
+        .header(IcebergIdempotencyManager.IDEMPOTENCY_KEY_HEADER, idempotencyKey)
+        .post(Entity.entity(request, MediaType.APPLICATION_JSON_TYPE));
   }
 }

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/TestIcebergNamespaceOperations.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/TestIcebergNamespaceOperations.java
@@ -33,6 +33,7 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.credential.Credential;
+import org.apache.gravitino.iceberg.service.IcebergIdempotencyManager;
 import org.apache.gravitino.iceberg.service.IcebergRESTUtils;
 import org.apache.gravitino.iceberg.service.extension.DummyCredentialProvider;
 import org.apache.gravitino.listener.api.event.Event;
@@ -247,6 +248,25 @@ public class TestIcebergNamespaceOperations extends IcebergNamespaceTestBase {
   }
 
   @Test
+  void testRegisterTableWithIdempotencyKey() {
+    Namespace namespace = Namespace.of("register_idempotent_ns");
+    String tableName = "register_idempotent_tbl";
+    String idempotencyKey = "018f4f74-7e58-7cc2-a2f0-6f53123abcde";
+
+    dummyEventListener.clearEvent();
+    Response first = doRegisterTableWithIdempotencyKey(tableName, namespace, idempotencyKey);
+    Assertions.assertEquals(Response.Status.OK.getStatusCode(), first.getStatus());
+
+    Response second = doRegisterTableWithIdempotencyKey(tableName, namespace, idempotencyKey);
+    Assertions.assertEquals(Response.Status.OK.getStatusCode(), second.getStatus());
+
+    Assertions.assertTrue(dummyEventListener.popPreEvent() instanceof IcebergRegisterTablePreEvent);
+    Assertions.assertTrue(dummyEventListener.popPostEvent() instanceof IcebergRegisterTableEvent);
+    Assertions.assertThrows(AssertionError.class, () -> dummyEventListener.popPreEvent());
+    Assertions.assertThrows(AssertionError.class, () -> dummyEventListener.popPostEvent());
+  }
+
+  @Test
   void testRegisterTableReturnsETag() {
     Namespace ns = Namespace.of("register_etag_ns");
     Response response = doRegisterTable("register_etag_foo1", ns);
@@ -445,5 +465,14 @@ public class TestIcebergNamespaceOperations extends IcebergNamespaceTestBase {
             .header(IcebergTableOperations.X_ICEBERG_ACCESS_DELEGATION, "invalid-value")
             .post(Entity.entity(request, MediaType.APPLICATION_JSON_TYPE));
     Assertions.assertEquals(400, response.getStatus());
+  }
+
+  private Response doRegisterTableWithIdempotencyKey(
+      String tableName, Namespace ns, String idempotencyKey) {
+    RegisterTableRequest request =
+        ImmutableRegisterTableRequest.builder().name(tableName).metadataLocation("mock").build();
+    return getNamespaceClientBuilder(Optional.of(ns), Optional.of("register"), Optional.empty())
+        .header(IcebergIdempotencyManager.IDEMPOTENCY_KEY_HEADER, idempotencyKey)
+        .post(Entity.entity(request, MediaType.APPLICATION_JSON_TYPE));
   }
 }

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/TestIcebergTableOperations.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/TestIcebergTableOperations.java
@@ -36,6 +36,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import org.apache.gravitino.credential.Credential;
+import org.apache.gravitino.iceberg.service.IcebergIdempotencyManager;
 import org.apache.gravitino.iceberg.service.extension.DummyCredentialProvider;
 import org.apache.gravitino.listener.api.event.Event;
 import org.apache.gravitino.listener.api.event.IcebergCreateTableEvent;
@@ -90,6 +91,7 @@ import org.apache.iceberg.util.JsonUtil;
 import org.glassfish.jersey.internal.inject.AbstractBinder;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
@@ -148,6 +150,39 @@ public class TestIcebergTableOperations extends IcebergNamespaceTestBase {
 
     verifyCreateTableFail(namespace, "create_foo1", 409);
     verifyCreateTableFail(namespace, "", 400);
+  }
+
+  @Test
+  void testCreateTableWithIdempotencyKey() {
+    Namespace namespace = Namespace.of("idempotent_table_ns");
+    verifyCreateNamespaceSucc(namespace);
+
+    dummyEventListener.clearEvent();
+    String idempotencyKey = "018f4f74-7e58-7cc2-a2f0-6f53123abcde";
+
+    Response firstResponse =
+        doCreateTableWithIdempotencyKey(namespace, "idempotent_table_foo1", idempotencyKey);
+    Assertions.assertEquals(Status.OK.getStatusCode(), firstResponse.getStatus());
+
+    Response secondResponse =
+        doCreateTableWithIdempotencyKey(namespace, "idempotent_table_foo1", idempotencyKey);
+    Assertions.assertEquals(Status.OK.getStatusCode(), secondResponse.getStatus());
+
+    Assertions.assertTrue(dummyEventListener.popPreEvent() instanceof IcebergCreateTablePreEvent);
+    Assertions.assertTrue(dummyEventListener.popPostEvent() instanceof IcebergCreateTableEvent);
+    Assertions.assertThrows(AssertionError.class, () -> dummyEventListener.popPreEvent());
+    Assertions.assertThrows(AssertionError.class, () -> dummyEventListener.popPostEvent());
+
+    verifyLoadTableSucc(namespace, "idempotent_table_foo1");
+  }
+
+  @Test
+  void testCreateTableRejectsInvalidIdempotencyKey() {
+    Namespace namespace = Namespace.of("invalid_idempotency_table_ns");
+    verifyCreateNamespaceSucc(namespace);
+
+    Response response = doCreateTableWithIdempotencyKey(namespace, "invalid_key_table", "bad");
+    Assertions.assertEquals(Status.BAD_REQUEST.getStatusCode(), response.getStatus());
   }
 
   @ParameterizedTest
@@ -451,6 +486,15 @@ public class TestIcebergTableOperations extends IcebergNamespaceTestBase {
     }
     CreateTableRequest createTableRequest = builder.build();
     return getTableClientBuilder(ns, Optional.empty())
+        .post(Entity.entity(createTableRequest, MediaType.APPLICATION_JSON_TYPE));
+  }
+
+  private Response doCreateTableWithIdempotencyKey(
+      Namespace ns, String name, String idempotencyKey) {
+    CreateTableRequest createTableRequest =
+        CreateTableRequest.builder().withName(name).withSchema(tableSchema).build();
+    return getTableClientBuilder(ns, Optional.empty())
+        .header(IcebergIdempotencyManager.IDEMPOTENCY_KEY_HEADER, idempotencyKey)
         .post(Entity.entity(createTableRequest, MediaType.APPLICATION_JSON_TYPE));
   }
 

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/TestIcebergTableOperations.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/TestIcebergTableOperations.java
@@ -37,6 +37,7 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.credential.Credential;
+import org.apache.gravitino.iceberg.service.IcebergIdempotencyManager;
 import org.apache.gravitino.iceberg.service.IcebergRESTUtils;
 import org.apache.gravitino.iceberg.service.extension.DummyCredentialProvider;
 import org.apache.gravitino.listener.api.event.Event;
@@ -152,6 +153,39 @@ public class TestIcebergTableOperations extends IcebergNamespaceTestBase {
 
     verifyCreateTableFail(namespace, "create_foo1", 409);
     verifyCreateTableFail(namespace, "", 400);
+  }
+
+  @Test
+  void testCreateTableWithIdempotencyKey() {
+    Namespace namespace = Namespace.of("idempotent_table_ns");
+    verifyCreateNamespaceSucc(namespace);
+
+    dummyEventListener.clearEvent();
+    String idempotencyKey = "018f4f74-7e58-7cc2-a2f0-6f53123abcde";
+
+    Response firstResponse =
+        doCreateTableWithIdempotencyKey(namespace, "idempotent_table_foo1", idempotencyKey);
+    Assertions.assertEquals(Status.OK.getStatusCode(), firstResponse.getStatus());
+
+    Response secondResponse =
+        doCreateTableWithIdempotencyKey(namespace, "idempotent_table_foo1", idempotencyKey);
+    Assertions.assertEquals(Status.OK.getStatusCode(), secondResponse.getStatus());
+
+    Assertions.assertTrue(dummyEventListener.popPreEvent() instanceof IcebergCreateTablePreEvent);
+    Assertions.assertTrue(dummyEventListener.popPostEvent() instanceof IcebergCreateTableEvent);
+    Assertions.assertThrows(AssertionError.class, () -> dummyEventListener.popPreEvent());
+    Assertions.assertThrows(AssertionError.class, () -> dummyEventListener.popPostEvent());
+
+    verifyLoadTableSucc(namespace, "idempotent_table_foo1");
+  }
+
+  @Test
+  void testCreateTableRejectsInvalidIdempotencyKey() {
+    Namespace namespace = Namespace.of("invalid_idempotency_table_ns");
+    verifyCreateNamespaceSucc(namespace);
+
+    Response response = doCreateTableWithIdempotencyKey(namespace, "invalid_key_table", "bad");
+    Assertions.assertEquals(Status.BAD_REQUEST.getStatusCode(), response.getStatus());
   }
 
   @ParameterizedTest
@@ -506,6 +540,15 @@ public class TestIcebergTableOperations extends IcebergNamespaceTestBase {
     }
     CreateTableRequest createTableRequest = builder.build();
     return getTableClientBuilder(ns, Optional.empty())
+        .post(Entity.entity(createTableRequest, MediaType.APPLICATION_JSON_TYPE));
+  }
+
+  private Response doCreateTableWithIdempotencyKey(
+      Namespace ns, String name, String idempotencyKey) {
+    CreateTableRequest createTableRequest =
+        CreateTableRequest.builder().withName(name).withSchema(tableSchema).build();
+    return getTableClientBuilder(ns, Optional.empty())
+        .header(IcebergIdempotencyManager.IDEMPOTENCY_KEY_HEADER, idempotencyKey)
         .post(Entity.entity(createTableRequest, MediaType.APPLICATION_JSON_TYPE));
   }
 

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/TestIcebergViewOperations.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/TestIcebergViewOperations.java
@@ -29,6 +29,7 @@ import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.Application;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import org.apache.gravitino.iceberg.service.IcebergIdempotencyManager;
 import org.apache.gravitino.listener.api.event.Event;
 import org.apache.gravitino.listener.api.event.IcebergCreateViewEvent;
 import org.apache.gravitino.listener.api.event.IcebergCreateViewFailureEvent;
@@ -68,6 +69,7 @@ import org.apache.iceberg.view.ViewMetadata;
 import org.glassfish.jersey.internal.inject.AbstractBinder;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
@@ -143,6 +145,30 @@ public class TestIcebergViewOperations extends IcebergNamespaceTestBase {
 
     verifyCreateViewFail(namespace, "create_foo1", 409);
     verifyCreateViewFail(namespace, "", 400);
+  }
+
+  @Test
+  void testCreateViewWithIdempotencyKey() {
+    Namespace namespace = Namespace.of("idempotent_view_ns");
+    verifyCreateNamespaceSucc(namespace);
+
+    dummyEventListener.clearEvent();
+    String idempotencyKey = "018f4f74-7e58-7cc2-a2f0-6f53123abcde";
+
+    Response first =
+        doCreateViewWithIdempotencyKey(namespace, "idempotent_view_foo1", idempotencyKey);
+    Assertions.assertEquals(Response.Status.OK.getStatusCode(), first.getStatus());
+
+    Response second =
+        doCreateViewWithIdempotencyKey(namespace, "idempotent_view_foo1", idempotencyKey);
+    Assertions.assertEquals(Response.Status.OK.getStatusCode(), second.getStatus());
+
+    Assertions.assertTrue(dummyEventListener.popPreEvent() instanceof IcebergCreateViewPreEvent);
+    Assertions.assertTrue(dummyEventListener.popPostEvent() instanceof IcebergCreateViewEvent);
+    Assertions.assertThrows(AssertionError.class, () -> dummyEventListener.popPreEvent());
+    Assertions.assertThrows(AssertionError.class, () -> dummyEventListener.popPostEvent());
+
+    verifyLoadViewSucc(namespace, "idempotent_view_foo1");
   }
 
   @ParameterizedTest
@@ -314,6 +340,30 @@ public class TestIcebergViewOperations extends IcebergNamespaceTestBase {
                     .build())
             .build();
     return getViewClientBuilder(ns)
+        .post(Entity.entity(createViewRequest, MediaType.APPLICATION_JSON_TYPE));
+  }
+
+  private Response doCreateViewWithIdempotencyKey(
+      Namespace ns, String name, String idempotencyKey) {
+    CreateViewRequest createViewRequest =
+        ImmutableCreateViewRequest.builder()
+            .name(name)
+            .schema(viewSchema)
+            .viewVersion(
+                ImmutableViewVersion.builder()
+                    .versionId(1)
+                    .timestampMillis(System.currentTimeMillis())
+                    .schemaId(1)
+                    .defaultNamespace(IcebergRestTestUtil.TEST_NAMESPACE_NAME)
+                    .addRepresentations(
+                        ImmutableSQLViewRepresentation.builder()
+                            .sql(VIEW_QUERY)
+                            .dialect("spark")
+                            .build())
+                    .build())
+            .build();
+    return getViewClientBuilder(ns)
+        .header(IcebergIdempotencyManager.IDEMPOTENCY_KEY_HEADER, idempotencyKey)
         .post(Entity.entity(createViewRequest, MediaType.APPLICATION_JSON_TYPE));
   }
 

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/TestIcebergViewOperations.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/TestIcebergViewOperations.java
@@ -31,6 +31,7 @@ import javax.ws.rs.core.Application;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.iceberg.service.IcebergIdempotencyManager;
 import org.apache.gravitino.listener.api.event.Event;
 import org.apache.gravitino.listener.api.event.IcebergCreateViewEvent;
 import org.apache.gravitino.listener.api.event.IcebergCreateViewFailureEvent;
@@ -199,6 +200,30 @@ public class TestIcebergViewOperations extends IcebergNamespaceTestBase {
 
     verifyCreateViewFail(namespace, "create_foo1", 409);
     verifyCreateViewFail(namespace, "", 400);
+  }
+
+  @Test
+  void testCreateViewWithIdempotencyKey() {
+    Namespace namespace = Namespace.of("idempotent_view_ns");
+    verifyCreateNamespaceSucc(namespace);
+
+    dummyEventListener.clearEvent();
+    String idempotencyKey = "018f4f74-7e58-7cc2-a2f0-6f53123abcde";
+
+    Response first =
+        doCreateViewWithIdempotencyKey(namespace, "idempotent_view_foo1", idempotencyKey);
+    Assertions.assertEquals(Response.Status.OK.getStatusCode(), first.getStatus());
+
+    Response second =
+        doCreateViewWithIdempotencyKey(namespace, "idempotent_view_foo1", idempotencyKey);
+    Assertions.assertEquals(Response.Status.OK.getStatusCode(), second.getStatus());
+
+    Assertions.assertTrue(dummyEventListener.popPreEvent() instanceof IcebergCreateViewPreEvent);
+    Assertions.assertTrue(dummyEventListener.popPostEvent() instanceof IcebergCreateViewEvent);
+    Assertions.assertThrows(AssertionError.class, () -> dummyEventListener.popPreEvent());
+    Assertions.assertThrows(AssertionError.class, () -> dummyEventListener.popPostEvent());
+
+    verifyLoadViewSucc(namespace, "idempotent_view_foo1");
   }
 
   @ParameterizedTest
@@ -405,6 +430,30 @@ public class TestIcebergViewOperations extends IcebergNamespaceTestBase {
                     .build())
             .build();
     return getViewClientBuilder(ns)
+        .post(Entity.entity(createViewRequest, MediaType.APPLICATION_JSON_TYPE));
+  }
+
+  private Response doCreateViewWithIdempotencyKey(
+      Namespace ns, String name, String idempotencyKey) {
+    CreateViewRequest createViewRequest =
+        ImmutableCreateViewRequest.builder()
+            .name(name)
+            .schema(viewSchema)
+            .viewVersion(
+                ImmutableViewVersion.builder()
+                    .versionId(1)
+                    .timestampMillis(System.currentTimeMillis())
+                    .schemaId(1)
+                    .defaultNamespace(IcebergRestTestUtil.TEST_NAMESPACE_NAME)
+                    .addRepresentations(
+                        ImmutableSQLViewRepresentation.builder()
+                            .sql(VIEW_QUERY)
+                            .dialect("spark")
+                            .build())
+                    .build())
+            .build();
+    return getViewClientBuilder(ns)
+        .header(IcebergIdempotencyManager.IDEMPOTENCY_KEY_HEADER, idempotencyKey)
         .post(Entity.entity(createViewRequest, MediaType.APPLICATION_JSON_TYPE));
   }
 

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/authorization/TestIcebergViewAuthorizationExpression.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/authorization/TestIcebergViewAuthorizationExpression.java
@@ -46,7 +46,7 @@ public class TestIcebergViewAuthorizationExpression {
   public void testCreateView() throws NoSuchMethodException, OgnlException {
     Method method =
         IcebergViewOperations.class.getMethod(
-            "createView", String.class, String.class, CreateViewRequest.class);
+            "createView", String.class, String.class, CreateViewRequest.class, String.class);
     AuthorizationExpression annotation = method.getAnnotation(AuthorizationExpression.class);
     String expression = annotation.expression();
     MockAuthorizationExpressionEvaluator mockEvaluator =
@@ -253,7 +253,12 @@ public class TestIcebergViewAuthorizationExpression {
   public void testReplaceView() throws NoSuchMethodException, OgnlException {
     Method method =
         IcebergViewOperations.class.getMethod(
-            "replaceView", String.class, String.class, String.class, UpdateTableRequest.class);
+            "replaceView",
+            String.class,
+            String.class,
+            String.class,
+            UpdateTableRequest.class,
+            String.class);
     AuthorizationExpression annotation = method.getAnnotation(AuthorizationExpression.class);
     String expression = annotation.expression();
     MockAuthorizationExpressionEvaluator mockEvaluator =
@@ -300,7 +305,8 @@ public class TestIcebergViewAuthorizationExpression {
   @Test
   public void testDropView() throws NoSuchMethodException, OgnlException {
     Method method =
-        IcebergViewOperations.class.getMethod("dropView", String.class, String.class, String.class);
+        IcebergViewOperations.class.getMethod(
+            "dropView", String.class, String.class, String.class, String.class);
     AuthorizationExpression annotation = method.getAnnotation(AuthorizationExpression.class);
     String expression = annotation.expression();
     MockAuthorizationExpressionEvaluator mockEvaluator =


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add support for the `Idempotency-Key` HTTP header on all mutation (POST/DELETE) endpoints in the Iceberg REST server. When a client sends a valid UUIDv7 idempotency key with a mutation request, the server caches the successful response and replays it on subsequent retries, preventing duplicate side-effects.

**Key implementation details:**

- New `IcebergIdempotencyManager` class with:
  - UUIDv7 format validation for the header value
  - Caffeine-based response cache with configurable TTL (default 30 min, max 10K entries)
  - Thread-safe `replayOrExecute()` using `ConcurrentHashMap` key locks with double-check pattern
  - Cache key includes idempotency key + HTTP method + URI + normalized query string
- Added `@HeaderParam("Idempotency-Key")` to all mutation endpoints:
  - **Tables**: `createTable`, `updateTable`, `dropTable`
  - **Namespaces**: `createNamespace`, `updateNamespace`, `dropNamespace`, `registerTable`
  - **Views**: `createView`, `replaceView`, `dropView`
- Advertises `idempotency-key-lifetime` (ISO-8601 duration) in `GET /v1/config` defaults
- New config entry `idempotency-key-lifetime-minutes` (default: 30)

### Why are the changes needed?

Fixes #10683

Network failures and client retries against the Iceberg REST catalog can cause duplicate table/namespace/view creation or deletion. The Iceberg REST spec recommends idempotency key support for mutation endpoints to safely handle retries.

### Does this PR introduce _any_ user-facing change?

Yes:
- Clients can now send an `Idempotency-Key: <UUIDv7>` header on mutation requests for safe retry
- `GET /v1/config` response now includes `idempotency-key-lifetime` in defaults
- New server config: `idempotency-key-lifetime-minutes` (default 30)

### How was this patch tested?

- Unit tests added for all three operation classes:
  - `TestIcebergTableOperations`: `testCreateTableWithIdempotencyKey`, `testCreateTableRejectsInvalidIdempotencyKey`
  - `TestIcebergNamespaceOperations`: `testRegisterTableWithIdempotencyKey`
  - `TestIcebergViewOperations`: `testCreateViewWithIdempotencyKey`
- `TestIcebergConfig` updated to verify `idempotency-key-lifetime` in config response
- All 100 tests across 4 suites pass locally (JDK 17)
- Tests verify replay returns cached response on second call with same key
- Tests verify events fire exactly once (no duplicate side-effects)
- Tests verify invalid (non-UUIDv7) keys return 400 Bad Request