### PR TITLE
[#10753] fix(client-python): use PUT method for alter_tag API call

### DIFF
--- a/clients/client-python/gravitino/client/gravitino_metalake.py
+++ b/clients/client-python/gravitino/client/gravitino_metalake.py
@@ -660,7 +660,7 @@ class GravitinoMetalake(
         url = self.API_METALAKES_TAG_PATH.format(
             encode_string(self.name()), encode_string(tag_name)
         )
-        response = self.rest_client.post(
+        response = self.rest_client.put(
             url,
             json=update_req,
             error_handler=TAG_ERROR_HANDLER,

--- a/clients/client-python/tests/unittests/test_tag_api.py
+++ b/clients/client-python/tests/unittests/test_tag_api.py
@@ -418,9 +418,9 @@ class TestTagAPI(unittest.TestCase):
         )
 
         with patch(
-            "gravitino.utils.http_client.HTTPClient.post",
+            "gravitino.utils.http_client.HTTPClient.put",
             return_value=mock_resp,
-        ):
+        ) as mock_put:
             rename_change = TagChange.rename("tagB")
             update_comment_change = TagChange.update_comment("mock tag B")
             update_properties_change = TagChange.set_property("key2", "value2")
@@ -440,6 +440,7 @@ class TestTagAPI(unittest.TestCase):
                 },
                 updated_tag.properties(),
             )
+            mock_put.assert_called_once()
 
     def test_gravitino_metalake_alter_tag_api_with_empty_tag_name(
         self, *mock_args


### PR DESCRIPTION
The alter_tag method in `GravitinoMetalake` was incorrectly using POST instead of PUT to send tag update requests. The server-side `TagOperations` endpoint is annotated with `@PUT`, so the client must use PUT to match.

Also fixed the corresponding unit test which was mocking `HTTPClient.post` instead of `HTTPClient.put`, and added an assertion to verify PUT is called.


### What changes were proposed in this pull request?

Changed `alter_tag` in `GravitinoMetalake` to use HTTP PUT instead of POST, matching the server-side `TagOperations` endpoint which is annotated with `@PUT`. Also updated the corresponding unit test to mock `HTTPClient.put` and added an assertion to verify the correct HTTP method is called.

### Why are the changes needed?

The `alter_tag` method was sending requests with HTTP POST, but the server expects PUT at the  `/api/metalakes/{metalake}/tags/{tag}` endpoint. This causes all `alter_tag` calls to fail with a 405 Method Not Allowed error when communicating with a real Gravitino server. The existing unit test did not catch this because it mocked `HTTPClient.post` and the integration-style tests in `mock_base.py` replaced the entire `alter_tag` method with a MagicMock, so the actual HTTP call was never exercised.

Fix: #10753

### Does this PR introduce _any_ user-facing change?

Yes. This fixes a bug where `GravitinoMetalake.alter_tag()` would always fail with an HTTP 405 error. After this fix, the method works correctly with the server's PUT endpoint.

### How was this patch tested?

  - Existing unit tests updated: `test_gravitino_metalake_alter_tag_api` now mocks `HTTPClient.put` and asserts `mock_put.assert_called_once()`.
  - All Python client unit tests pass: `./gradlew :clients:client-python:test -PskipITs`
  - End-to-end verified against a running Gravitino server with tag rename, comment update, and property set/remove operations.
