### PR TITLE
[#10766] fix(iceberg): skip table import for staged creates in IcebergTableHookDispatcher

### DIFF
--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/dispatcher/IcebergTableHookDispatcher.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/dispatcher/IcebergTableHookDispatcher.java
@@ -61,14 +61,7 @@ public class IcebergTableHookDispatcher implements IcebergTableOperationDispatch
     // Skip import and ownership for staged creates (credential vending).
     // The table will be imported when the staged table is committed via updateTable.
     if (!createTableRequest.stageCreate()) {
-      importTable(context.catalogName(), namespace, createTableRequest.name());
-      IcebergOwnershipUtils.setTableOwner(
-          metalake,
-          context.catalogName(),
-          namespace,
-          createTableRequest.name(),
-          context.userName(),
-          GravitinoEnv.getInstance().ownerDispatcher());
+      importTableAndSetOwner(context, namespace, createTableRequest.name());
     }
 
     return response;
@@ -89,14 +82,7 @@ public class IcebergTableHookDispatcher implements IcebergTableOperationDispatch
           IcebergIdentifierUtils.toGravitinoTableIdentifier(
               metalake, context.catalogName(), tableIdentifier);
       if (store != null && !store.exists(gravitinoTableId, Entity.EntityType.TABLE)) {
-        importTable(context.catalogName(), tableIdentifier.namespace(), tableIdentifier.name());
-        IcebergOwnershipUtils.setTableOwner(
-            metalake,
-            context.catalogName(),
-            tableIdentifier.namespace(),
-            tableIdentifier.name(),
-            context.userName(),
-            GravitinoEnv.getInstance().ownerDispatcher());
+        importTableAndSetOwner(context, tableIdentifier.namespace(), tableIdentifier.name());
       }
     } catch (IOException ioe) {
       throw new RuntimeException("io exception when checking table entity existence", ioe);
@@ -212,12 +198,20 @@ public class IcebergTableHookDispatcher implements IcebergTableOperationDispatch
     return dispatcher.getTableMetadataLocation(context, tableIdentifier);
   }
 
-  private void importTable(String catalogName, Namespace namespace, String tableName) {
+  private void importTableAndSetOwner(
+      IcebergRequestContext context, Namespace namespace, String tableName) {
     TableDispatcher tableDispatcher = GravitinoEnv.getInstance().tableDispatcher();
     if (tableDispatcher != null) {
       tableDispatcher.loadTable(
           IcebergIdentifierUtils.toGravitinoTableIdentifier(
-              metalake, catalogName, TableIdentifier.of(namespace, tableName)));
+              metalake, context.catalogName(), TableIdentifier.of(namespace, tableName)));
     }
+    IcebergOwnershipUtils.setTableOwner(
+        metalake,
+        context.catalogName(),
+        namespace,
+        tableName,
+        context.userName(),
+        GravitinoEnv.getInstance().ownerDispatcher());
   }
 }

--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/dispatcher/IcebergTableHookDispatcher.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/dispatcher/IcebergTableHookDispatcher.java
@@ -58,14 +58,18 @@ public class IcebergTableHookDispatcher implements IcebergTableOperationDispatch
   public LoadTableResponse createTable(
       IcebergRequestContext context, Namespace namespace, CreateTableRequest createTableRequest) {
     LoadTableResponse response = dispatcher.createTable(context, namespace, createTableRequest);
-    importTable(context.catalogName(), namespace, createTableRequest.name());
-    IcebergOwnershipUtils.setTableOwner(
-        metalake,
-        context.catalogName(),
-        namespace,
-        createTableRequest.name(),
-        context.userName(),
-        GravitinoEnv.getInstance().ownerDispatcher());
+    // Skip import and ownership for staged creates (credential vending).
+    // The table will be imported when the staged table is committed via updateTable.
+    if (!createTableRequest.stageCreate()) {
+      importTable(context.catalogName(), namespace, createTableRequest.name());
+      IcebergOwnershipUtils.setTableOwner(
+          metalake,
+          context.catalogName(),
+          namespace,
+          createTableRequest.name(),
+          context.userName(),
+          GravitinoEnv.getInstance().ownerDispatcher());
+    }
 
     return response;
   }
@@ -75,7 +79,29 @@ public class IcebergTableHookDispatcher implements IcebergTableOperationDispatch
       IcebergRequestContext context,
       TableIdentifier tableIdentifier,
       UpdateTableRequest updateTableRequest) {
-    return dispatcher.updateTable(context, tableIdentifier, updateTableRequest);
+    LoadTableResponse response =
+        dispatcher.updateTable(context, tableIdentifier, updateTableRequest);
+    // Import the table and set ownership if the entity does not yet exist,
+    // e.g. when committing a staged table create.
+    try {
+      EntityStore store = GravitinoEnv.getInstance().entityStore();
+      NameIdentifier gravitinoTableId =
+          IcebergIdentifierUtils.toGravitinoTableIdentifier(
+              metalake, context.catalogName(), tableIdentifier);
+      if (store != null && !store.exists(gravitinoTableId, Entity.EntityType.TABLE)) {
+        importTable(context.catalogName(), tableIdentifier.namespace(), tableIdentifier.name());
+        IcebergOwnershipUtils.setTableOwner(
+            metalake,
+            context.catalogName(),
+            tableIdentifier.namespace(),
+            tableIdentifier.name(),
+            context.userName(),
+            GravitinoEnv.getInstance().ownerDispatcher());
+      }
+    } catch (IOException ioe) {
+      throw new RuntimeException("io exception when checking table entity existence", ioe);
+    }
+    return response;
   }
 
   @Override

--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/dispatcher/IcebergTableHookDispatcher.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/dispatcher/IcebergTableHookDispatcher.java
@@ -33,6 +33,7 @@ import org.apache.gravitino.listener.api.event.IcebergRequestContext;
 import org.apache.gravitino.meta.AuditInfo;
 import org.apache.gravitino.meta.TableEntity;
 import org.apache.gravitino.utils.PrincipalUtils;
+import org.apache.iceberg.UpdateRequirement;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.rest.requests.CreateTableRequest;
@@ -74,18 +75,26 @@ public class IcebergTableHookDispatcher implements IcebergTableOperationDispatch
       UpdateTableRequest updateTableRequest) {
     LoadTableResponse response =
         dispatcher.updateTable(context, tableIdentifier, updateTableRequest);
-    // Import the table and set ownership if the entity does not yet exist,
-    // e.g. when committing a staged table create.
-    try {
-      EntityStore store = GravitinoEnv.getInstance().entityStore();
-      NameIdentifier gravitinoTableId =
-          IcebergIdentifierUtils.toGravitinoTableIdentifier(
-              metalake, context.catalogName(), tableIdentifier);
-      if (store != null && !store.exists(gravitinoTableId, Entity.EntityType.TABLE)) {
-        importTableAndSetOwner(context, tableIdentifier.namespace(), tableIdentifier.name());
+    // Import the table and set ownership only when committing a staged table create.
+    // A staged create commit is identified by the AssertTableDoesNotExist requirement,
+    // which is set by UpdateRequirements.forCreateTable(). Regular updates (e.g. property
+    // changes) do not carry this requirement, so we must not set ownership for them even
+    // if the entity does not yet exist in the store.
+    boolean isStagedCreateCommit =
+        updateTableRequest.requirements().stream()
+            .anyMatch(UpdateRequirement.AssertTableDoesNotExist.class::isInstance);
+    if (isStagedCreateCommit) {
+      try {
+        EntityStore store = GravitinoEnv.getInstance().entityStore();
+        NameIdentifier gravitinoTableId =
+            IcebergIdentifierUtils.toGravitinoTableIdentifier(
+                metalake, context.catalogName(), tableIdentifier);
+        if (store != null && !store.exists(gravitinoTableId, Entity.EntityType.TABLE)) {
+          importTableAndSetOwner(context, tableIdentifier.namespace(), tableIdentifier.name());
+        }
+      } catch (IOException ioe) {
+        throw new RuntimeException("io exception when checking table entity existence", ioe);
       }
-    } catch (IOException ioe) {
-      throw new RuntimeException("io exception when checking table entity existence", ioe);
     }
     return response;
   }

--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/dispatcher/IcebergTableHookDispatcher.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/dispatcher/IcebergTableHookDispatcher.java
@@ -77,24 +77,12 @@ public class IcebergTableHookDispatcher implements IcebergTableOperationDispatch
         dispatcher.updateTable(context, tableIdentifier, updateTableRequest);
     // Import the table and set ownership only when committing a staged table create.
     // A staged create commit is identified by the AssertTableDoesNotExist requirement,
-    // which is set by UpdateRequirements.forCreateTable(). Regular updates (e.g. property
-    // changes) do not carry this requirement, so we must not set ownership for them even
-    // if the entity does not yet exist in the store.
+    // which is set by UpdateRequirements.forCreateTable().
     boolean isStagedCreateCommit =
         updateTableRequest.requirements().stream()
             .anyMatch(UpdateRequirement.AssertTableDoesNotExist.class::isInstance);
     if (isStagedCreateCommit) {
-      try {
-        EntityStore store = GravitinoEnv.getInstance().entityStore();
-        NameIdentifier gravitinoTableId =
-            IcebergIdentifierUtils.toGravitinoTableIdentifier(
-                metalake, context.catalogName(), tableIdentifier);
-        if (store != null && !store.exists(gravitinoTableId, Entity.EntityType.TABLE)) {
-          importTableAndSetOwner(context, tableIdentifier.namespace(), tableIdentifier.name());
-        }
-      } catch (IOException ioe) {
-        throw new RuntimeException("io exception when checking table entity existence", ioe);
-      }
+      importTableAndSetOwner(context, tableIdentifier.namespace(), tableIdentifier.name());
     }
     return response;
   }

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/dispatcher/TestIcebergTableHookDispatcher.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/dispatcher/TestIcebergTableHookDispatcher.java
@@ -279,7 +279,7 @@ public class TestIcebergTableHookDispatcher {
   }
 
   @Test
-  public void testUpdateTableImportsAndSetsOwnershipForStagedCommit() throws IOException {
+  public void testUpdateTableImportsAndSetsOwnershipForStagedCommit() {
     TableIdentifier tableId = TableIdentifier.of("test_schema", "test_table");
     // A staged create commit carries AssertTableDoesNotExist as its requirement.
     UpdateTableRequest request =
@@ -289,17 +289,14 @@ public class TestIcebergTableHookDispatcher {
 
     when(mockDispatcher.updateTable(mockContext, tableId, request)).thenReturn(mockResponse);
 
-    // Entity does not exist yet (staged table being committed)
-    NameIdentifier gravitinoTableId =
-        IcebergIdentifierUtils.toGravitinoTableIdentifier(TEST_METALAKE, TEST_CATALOG, tableId);
-    when(mockEntityStore.exists(gravitinoTableId, Entity.EntityType.TABLE)).thenReturn(false);
-
     LoadTableResponse result = hookDispatcher.updateTable(mockContext, tableId, request);
 
     Assertions.assertEquals(mockResponse, result);
     verify(mockDispatcher).updateTable(mockContext, tableId, request);
 
     // Verify table import was called
+    NameIdentifier gravitinoTableId =
+        IcebergIdentifierUtils.toGravitinoTableIdentifier(TEST_METALAKE, TEST_CATALOG, tableId);
     verify(mockTableDispatcher).loadTable(gravitinoTableId);
 
     // Verify ownership was set
@@ -310,66 +307,10 @@ public class TestIcebergTableHookDispatcher {
   }
 
   @Test
-  public void testUpdateTableSkipsImportForStagedCommitWhenEntityAlreadyExists()
-      throws IOException {
-    TableIdentifier tableId = TableIdentifier.of("test_schema", "test_table");
-    // A staged create commit carries AssertTableDoesNotExist, but the entity already exists
-    // (e.g. idempotent retry). Import and ownership should be skipped.
-    UpdateTableRequest request =
-        new UpdateTableRequest(
-            List.of(new UpdateRequirement.AssertTableDoesNotExist()), Collections.emptyList());
-    LoadTableResponse mockResponse = mock(LoadTableResponse.class);
-
-    when(mockDispatcher.updateTable(mockContext, tableId, request)).thenReturn(mockResponse);
-
-    NameIdentifier gravitinoTableId =
-        IcebergIdentifierUtils.toGravitinoTableIdentifier(TEST_METALAKE, TEST_CATALOG, tableId);
-    when(mockEntityStore.exists(gravitinoTableId, Entity.EntityType.TABLE)).thenReturn(true);
-
-    LoadTableResponse result = hookDispatcher.updateTable(mockContext, tableId, request);
-
-    Assertions.assertEquals(mockResponse, result);
-    verify(mockDispatcher).updateTable(mockContext, tableId, request);
-
-    // Verify table import was NOT called since entity already exists
-    verify(mockTableDispatcher, never()).loadTable(any());
-
-    // Verify ownership was NOT set since entity already exists
-    verify(mockOwnerDispatcher, never()).setOwner(any(), any(), any(), any());
-  }
-
-  @Test
-  public void testUpdateTableSkipsImportForRegularUpdateWhenEntityMissing() throws IOException {
+  public void testUpdateTableSkipsImportForRegularUpdate() {
     TableIdentifier tableId = TableIdentifier.of("test_schema", "test_table");
     // Regular table update (e.g. property change): no AssertTableDoesNotExist requirement.
-    UpdateTableRequest request =
-        new UpdateTableRequest(Collections.emptyList(), Collections.emptyList());
-    LoadTableResponse mockResponse = mock(LoadTableResponse.class);
-
-    when(mockDispatcher.updateTable(mockContext, tableId, request)).thenReturn(mockResponse);
-
-    // Entity does not exist (e.g. table pre-dates Gravitino tracking), but this is NOT a staged
-    // create commit, so we must NOT import or set ownership.
-    NameIdentifier gravitinoTableId =
-        IcebergIdentifierUtils.toGravitinoTableIdentifier(TEST_METALAKE, TEST_CATALOG, tableId);
-    when(mockEntityStore.exists(gravitinoTableId, Entity.EntityType.TABLE)).thenReturn(false);
-
-    LoadTableResponse result = hookDispatcher.updateTable(mockContext, tableId, request);
-
-    Assertions.assertEquals(mockResponse, result);
-    verify(mockDispatcher).updateTable(mockContext, tableId, request);
-
-    // Verify table import was NOT called for a plain property update
-    verify(mockTableDispatcher, never()).loadTable(any());
-
-    // Verify ownership was NOT set
-    verify(mockOwnerDispatcher, never()).setOwner(any(), any(), any(), any());
-  }
-
-  @Test
-  public void testUpdateTablePassesThrough() throws IOException {
-    TableIdentifier tableId = TableIdentifier.of("test_schema", "test_table");
-    // Regular update without AssertTableDoesNotExist — entity exists.
+    // Import and ownership must NOT be triggered regardless of entity store state.
     UpdateTableRequest request =
         new UpdateTableRequest(Collections.emptyList(), Collections.emptyList());
     LoadTableResponse mockResponse = mock(LoadTableResponse.class);
@@ -381,37 +322,11 @@ public class TestIcebergTableHookDispatcher {
     Assertions.assertEquals(mockResponse, result);
     verify(mockDispatcher).updateTable(mockContext, tableId, request);
 
-    // Verify table import was NOT called
+    // Verify table import was NOT called for a regular update
     verify(mockTableDispatcher, never()).loadTable(any());
 
     // Verify ownership was NOT set
     verify(mockOwnerDispatcher, never()).setOwner(any(), any(), any(), any());
-  }
-
-  @Test
-  public void testUpdateTableThrowsRuntimeExceptionOnIOException() throws IOException {
-    TableIdentifier tableId = TableIdentifier.of("test_schema", "test_table");
-    // Use AssertTableDoesNotExist so the code path reaches store.exists().
-    UpdateTableRequest request =
-        new UpdateTableRequest(
-            List.of(new UpdateRequirement.AssertTableDoesNotExist()), Collections.emptyList());
-
-    when(mockDispatcher.updateTable(mockContext, tableId, request))
-        .thenReturn(mock(LoadTableResponse.class));
-
-    NameIdentifier gravitinoTableId =
-        IcebergIdentifierUtils.toGravitinoTableIdentifier(TEST_METALAKE, TEST_CATALOG, tableId);
-    when(mockEntityStore.exists(gravitinoTableId, Entity.EntityType.TABLE))
-        .thenThrow(new IOException("IO error"));
-
-    RuntimeException exception =
-        Assertions.assertThrows(
-            RuntimeException.class,
-            () -> hookDispatcher.updateTable(mockContext, tableId, request));
-
-    Assertions.assertTrue(
-        exception.getMessage().contains("io exception when checking table entity existence"));
-    verify(mockDispatcher).updateTable(mockContext, tableId, request);
   }
 
   @Test

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/dispatcher/TestIcebergTableHookDispatcher.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/dispatcher/TestIcebergTableHookDispatcher.java
@@ -30,6 +30,7 @@ import java.io.IOException;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.gravitino.Entity;
 import org.apache.gravitino.EntityStore;
@@ -46,6 +47,7 @@ import org.apache.gravitino.listener.api.event.IcebergRequestContext;
 import org.apache.gravitino.meta.AuditInfo;
 import org.apache.gravitino.meta.TableEntity;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.UpdateRequirement;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.rest.requests.CreateTableRequest;
@@ -279,7 +281,10 @@ public class TestIcebergTableHookDispatcher {
   @Test
   public void testUpdateTableImportsAndSetsOwnershipForStagedCommit() throws IOException {
     TableIdentifier tableId = TableIdentifier.of("test_schema", "test_table");
-    UpdateTableRequest request = mock(UpdateTableRequest.class);
+    // A staged create commit carries AssertTableDoesNotExist as its requirement.
+    UpdateTableRequest request =
+        new UpdateTableRequest(
+            List.of(new UpdateRequirement.AssertTableDoesNotExist()), Collections.emptyList());
     LoadTableResponse mockResponse = mock(LoadTableResponse.class);
 
     when(mockDispatcher.updateTable(mockContext, tableId, request)).thenReturn(mockResponse);
@@ -305,14 +310,18 @@ public class TestIcebergTableHookDispatcher {
   }
 
   @Test
-  public void testUpdateTablePassesThrough() throws IOException {
+  public void testUpdateTableSkipsImportForStagedCommitWhenEntityAlreadyExists()
+      throws IOException {
     TableIdentifier tableId = TableIdentifier.of("test_schema", "test_table");
-    UpdateTableRequest request = mock(UpdateTableRequest.class);
+    // A staged create commit carries AssertTableDoesNotExist, but the entity already exists
+    // (e.g. idempotent retry). Import and ownership should be skipped.
+    UpdateTableRequest request =
+        new UpdateTableRequest(
+            List.of(new UpdateRequirement.AssertTableDoesNotExist()), Collections.emptyList());
     LoadTableResponse mockResponse = mock(LoadTableResponse.class);
 
     when(mockDispatcher.updateTable(mockContext, tableId, request)).thenReturn(mockResponse);
 
-    // Entity already exists (regular update, not a staged commit)
     NameIdentifier gravitinoTableId =
         IcebergIdentifierUtils.toGravitinoTableIdentifier(TEST_METALAKE, TEST_CATALOG, tableId);
     when(mockEntityStore.exists(gravitinoTableId, Entity.EntityType.TABLE)).thenReturn(true);
@@ -322,20 +331,73 @@ public class TestIcebergTableHookDispatcher {
     Assertions.assertEquals(mockResponse, result);
     verify(mockDispatcher).updateTable(mockContext, tableId, request);
 
-    // Verify table import was NOT called for existing entity
+    // Verify table import was NOT called since entity already exists
     verify(mockTableDispatcher, never()).loadTable(any());
 
-    // Verify ownership was NOT set for existing entity
+    // Verify ownership was NOT set since entity already exists
+    verify(mockOwnerDispatcher, never()).setOwner(any(), any(), any(), any());
+  }
+
+  @Test
+  public void testUpdateTableSkipsImportForRegularUpdateWhenEntityMissing() throws IOException {
+    TableIdentifier tableId = TableIdentifier.of("test_schema", "test_table");
+    // Regular table update (e.g. property change): no AssertTableDoesNotExist requirement.
+    UpdateTableRequest request =
+        new UpdateTableRequest(Collections.emptyList(), Collections.emptyList());
+    LoadTableResponse mockResponse = mock(LoadTableResponse.class);
+
+    when(mockDispatcher.updateTable(mockContext, tableId, request)).thenReturn(mockResponse);
+
+    // Entity does not exist (e.g. table pre-dates Gravitino tracking), but this is NOT a staged
+    // create commit, so we must NOT import or set ownership.
+    NameIdentifier gravitinoTableId =
+        IcebergIdentifierUtils.toGravitinoTableIdentifier(TEST_METALAKE, TEST_CATALOG, tableId);
+    when(mockEntityStore.exists(gravitinoTableId, Entity.EntityType.TABLE)).thenReturn(false);
+
+    LoadTableResponse result = hookDispatcher.updateTable(mockContext, tableId, request);
+
+    Assertions.assertEquals(mockResponse, result);
+    verify(mockDispatcher).updateTable(mockContext, tableId, request);
+
+    // Verify table import was NOT called for a plain property update
+    verify(mockTableDispatcher, never()).loadTable(any());
+
+    // Verify ownership was NOT set
+    verify(mockOwnerDispatcher, never()).setOwner(any(), any(), any(), any());
+  }
+
+  @Test
+  public void testUpdateTablePassesThrough() throws IOException {
+    TableIdentifier tableId = TableIdentifier.of("test_schema", "test_table");
+    // Regular update without AssertTableDoesNotExist — entity exists.
+    UpdateTableRequest request =
+        new UpdateTableRequest(Collections.emptyList(), Collections.emptyList());
+    LoadTableResponse mockResponse = mock(LoadTableResponse.class);
+
+    when(mockDispatcher.updateTable(mockContext, tableId, request)).thenReturn(mockResponse);
+
+    LoadTableResponse result = hookDispatcher.updateTable(mockContext, tableId, request);
+
+    Assertions.assertEquals(mockResponse, result);
+    verify(mockDispatcher).updateTable(mockContext, tableId, request);
+
+    // Verify table import was NOT called
+    verify(mockTableDispatcher, never()).loadTable(any());
+
+    // Verify ownership was NOT set
     verify(mockOwnerDispatcher, never()).setOwner(any(), any(), any(), any());
   }
 
   @Test
   public void testUpdateTableThrowsRuntimeExceptionOnIOException() throws IOException {
     TableIdentifier tableId = TableIdentifier.of("test_schema", "test_table");
-    UpdateTableRequest request = mock(UpdateTableRequest.class);
-    LoadTableResponse mockResponse = mock(LoadTableResponse.class);
+    // Use AssertTableDoesNotExist so the code path reaches store.exists().
+    UpdateTableRequest request =
+        new UpdateTableRequest(
+            List.of(new UpdateRequirement.AssertTableDoesNotExist()), Collections.emptyList());
 
-    when(mockDispatcher.updateTable(mockContext, tableId, request)).thenReturn(mockResponse);
+    when(mockDispatcher.updateTable(mockContext, tableId, request))
+        .thenReturn(mock(LoadTableResponse.class));
 
     NameIdentifier gravitinoTableId =
         IcebergIdentifierUtils.toGravitinoTableIdentifier(TEST_METALAKE, TEST_CATALOG, tableId);

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/dispatcher/TestIcebergTableHookDispatcher.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/dispatcher/TestIcebergTableHookDispatcher.java
@@ -22,6 +22,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -251,16 +252,103 @@ public class TestIcebergTableHookDispatcher {
   }
 
   @Test
-  public void testUpdateTablePassesThrough() {
+  public void testCreateTableSkipsImportAndOwnershipForStageCreate() {
+    Namespace namespace = Namespace.of("test_schema");
+    CreateTableRequest request =
+        CreateTableRequest.builder()
+            .withName("test_table")
+            .withSchema(TABLE_SCHEMA)
+            .stageCreate()
+            .build();
+
+    LoadTableResponse mockResponse = mock(LoadTableResponse.class);
+    when(mockDispatcher.createTable(mockContext, namespace, request)).thenReturn(mockResponse);
+
+    LoadTableResponse result = hookDispatcher.createTable(mockContext, namespace, request);
+
+    Assertions.assertEquals(mockResponse, result);
+    verify(mockDispatcher).createTable(mockContext, namespace, request);
+
+    // Verify table import was NOT called for staged create
+    verify(mockTableDispatcher, never()).loadTable(any());
+
+    // Verify ownership was NOT set for staged create
+    verify(mockOwnerDispatcher, never()).setOwner(any(), any(), any(), any());
+  }
+
+  @Test
+  public void testUpdateTableImportsAndSetsOwnershipForStagedCommit() throws IOException {
     TableIdentifier tableId = TableIdentifier.of("test_schema", "test_table");
     UpdateTableRequest request = mock(UpdateTableRequest.class);
     LoadTableResponse mockResponse = mock(LoadTableResponse.class);
 
     when(mockDispatcher.updateTable(mockContext, tableId, request)).thenReturn(mockResponse);
 
+    // Entity does not exist yet (staged table being committed)
+    NameIdentifier gravitinoTableId =
+        IcebergIdentifierUtils.toGravitinoTableIdentifier(TEST_METALAKE, TEST_CATALOG, tableId);
+    when(mockEntityStore.exists(gravitinoTableId, Entity.EntityType.TABLE)).thenReturn(false);
+
     LoadTableResponse result = hookDispatcher.updateTable(mockContext, tableId, request);
 
     Assertions.assertEquals(mockResponse, result);
+    verify(mockDispatcher).updateTable(mockContext, tableId, request);
+
+    // Verify table import was called
+    verify(mockTableDispatcher).loadTable(gravitinoTableId);
+
+    // Verify ownership was set
+    ArgumentCaptor<String> userCaptor = ArgumentCaptor.forClass(String.class);
+    verify(mockOwnerDispatcher)
+        .setOwner(eq(TEST_METALAKE), any(), userCaptor.capture(), eq(Owner.Type.USER));
+    Assertions.assertEquals(TEST_USER, userCaptor.getValue());
+  }
+
+  @Test
+  public void testUpdateTablePassesThrough() throws IOException {
+    TableIdentifier tableId = TableIdentifier.of("test_schema", "test_table");
+    UpdateTableRequest request = mock(UpdateTableRequest.class);
+    LoadTableResponse mockResponse = mock(LoadTableResponse.class);
+
+    when(mockDispatcher.updateTable(mockContext, tableId, request)).thenReturn(mockResponse);
+
+    // Entity already exists (regular update, not a staged commit)
+    NameIdentifier gravitinoTableId =
+        IcebergIdentifierUtils.toGravitinoTableIdentifier(TEST_METALAKE, TEST_CATALOG, tableId);
+    when(mockEntityStore.exists(gravitinoTableId, Entity.EntityType.TABLE)).thenReturn(true);
+
+    LoadTableResponse result = hookDispatcher.updateTable(mockContext, tableId, request);
+
+    Assertions.assertEquals(mockResponse, result);
+    verify(mockDispatcher).updateTable(mockContext, tableId, request);
+
+    // Verify table import was NOT called for existing entity
+    verify(mockTableDispatcher, never()).loadTable(any());
+
+    // Verify ownership was NOT set for existing entity
+    verify(mockOwnerDispatcher, never()).setOwner(any(), any(), any(), any());
+  }
+
+  @Test
+  public void testUpdateTableThrowsRuntimeExceptionOnIOException() throws IOException {
+    TableIdentifier tableId = TableIdentifier.of("test_schema", "test_table");
+    UpdateTableRequest request = mock(UpdateTableRequest.class);
+    LoadTableResponse mockResponse = mock(LoadTableResponse.class);
+
+    when(mockDispatcher.updateTable(mockContext, tableId, request)).thenReturn(mockResponse);
+
+    NameIdentifier gravitinoTableId =
+        IcebergIdentifierUtils.toGravitinoTableIdentifier(TEST_METALAKE, TEST_CATALOG, tableId);
+    when(mockEntityStore.exists(gravitinoTableId, Entity.EntityType.TABLE))
+        .thenThrow(new IOException("IO error"));
+
+    RuntimeException exception =
+        Assertions.assertThrows(
+            RuntimeException.class,
+            () -> hookDispatcher.updateTable(mockContext, tableId, request));
+
+    Assertions.assertTrue(
+        exception.getMessage().contains("io exception when checking table entity existence"));
     verify(mockDispatcher).updateTable(mockContext, tableId, request);
   }
 


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): Support xxx"
     - "[#233] fix: Check null before access result in xxx"
     - "[MINOR] refactor: Fix typo in variable name"
     - "[MINOR] docs: Fix typo in README"
     - "[#255] test: Fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

When credential vending is enabled, `IcebergTableHookDispatcher.createTable()` now
skips `importTable()` and `setTableOwner()` for staged creates (`stageCreate=true`).
Instead, the import and ownership assignment are deferred to `updateTable()`, which
checks if the table entity already exists in the EntityStore and, if not (i.e., a
staged create being committed), performs the import and ownership setup at that point.


### Why are the changes needed?

With credential vending enabled, Trino sends all CREATE TABLE requests with
`stageCreate=true`. The Iceberg REST protocol stages the table (builds metadata
in memory without committing) and returns vended credentials. The table is only
committed to the catalog when the client later calls `updateTable`.

`IcebergTableHookDispatcher.createTable()` unconditionally called `importTable()`,
which tried to load the non-existent table from the catalog and threw
`NoSuchTableException`, failing every table create when credential vending is active.

Fix: #10766 

### Does this PR introduce _any_ user-facing change?

No. This fixes an internal error that prevented table creation when credential
vending was enabled. No API or property changes.

### How was this patch tested?

- Unit tests
- Also tested this with a dev Gravitino deployment