### PR TITLE
[#10771] improvement(authz): Add GravitinoCache interface and per-request owner/user caching

### DIFF
--- a/common/src/main/java/org/apache/gravitino/config/ConfigConstants.java
+++ b/common/src/main/java/org/apache/gravitino/config/ConfigConstants.java
@@ -93,5 +93,5 @@ public final class ConfigConstants {
   public static final String VERSION_1_3_0 = "1.3.0";
 
   /** The current version of backend storage initialization script. */
-  public static final String CURRENT_SCRIPT_VERSION = VERSION_1_2_0;
+  public static final String CURRENT_SCRIPT_VERSION = VERSION_1_3_0;
 }

--- a/core/src/main/java/org/apache/gravitino/Configs.java
+++ b/core/src/main/java/org/apache/gravitino/Configs.java
@@ -329,6 +329,15 @@ public class Configs {
           .longConf()
           .createWithDefault(DEFAULT_GRAVITINO_AUTHORIZATION_OWNER_CACHE_SIZE);
 
+  public static final long DEFAULT_GRAVITINO_AUTHORIZATION_USER_ROLE_CACHE_SIZE = 50000L;
+
+  public static final ConfigEntry<Long> GRAVITINO_AUTHORIZATION_USER_ROLE_CACHE_SIZE =
+      new ConfigBuilder("gravitino.authorization.jcasbin.userRoleCacheSize")
+          .doc("The maximum number of user→(roleIds, version) entries in the auth cache")
+          .version(ConfigConstants.VERSION_1_3_0)
+          .longConf()
+          .createWithDefault(DEFAULT_GRAVITINO_AUTHORIZATION_USER_ROLE_CACHE_SIZE);
+
   public static final ConfigEntry<List<String>> SERVICE_ADMINS =
       new ConfigBuilder("gravitino.authorization.serviceAdmins")
           .doc("The admins of Gravitino service")

--- a/core/src/main/java/org/apache/gravitino/authorization/AuthorizationRequestContext.java
+++ b/core/src/main/java/org/apache/gravitino/authorization/AuthorizationRequestContext.java
@@ -18,8 +18,10 @@
 package org.apache.gravitino.authorization;
 
 import java.security.Principal;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
@@ -35,6 +37,15 @@ public class AuthorizationRequestContext {
 
   /** Used to determine whether the role has already been loaded. */
   private final AtomicBoolean hasLoadRole = new AtomicBoolean();
+
+  /**
+   * Per-request cache of metadata-object-id → owner user id. Maps to Optional.empty() when the
+   * object has no user owner. {@code null} means "not yet cached".
+   */
+  private final Map<Long, Optional<Long>> ownerCache = new HashMap<>();
+
+  /** The resolved user ID for the current request principal, cached after first resolution. */
+  private volatile Long resolvedUserId;
 
   private volatile String originalAuthorizationExpression;
 
@@ -101,6 +112,46 @@ public class AuthorizationRequestContext {
 
   public void setOriginalAuthorizationExpression(String originalAuthorizationExpression) {
     this.originalAuthorizationExpression = originalAuthorizationExpression;
+  }
+
+  public Long getResolvedUserId() {
+    return resolvedUserId;
+  }
+
+  public void setResolvedUserId(Long resolvedUserId) {
+    this.resolvedUserId = resolvedUserId;
+  }
+
+  /**
+   * Returns true if the owner entry for {@code metadataId} is present in the per-request cache.
+   *
+   * @param metadataId the metadata object ID
+   * @return true if cached
+   */
+  public boolean isOwnerCached(Long metadataId) {
+    return ownerCache.containsKey(metadataId);
+  }
+
+  /**
+   * Returns the cached owner for the given metadata object ID.
+   *
+   * <p>Call {@link #isOwnerCached(Long)} first to distinguish "not cached" from "no owner".
+   *
+   * @param metadataId the metadata object ID
+   * @return Optional.of(userId) if there is a user owner, Optional.empty() if no user owner
+   */
+  public Optional<Long> getCachedOwner(Long metadataId) {
+    return ownerCache.get(metadataId);
+  }
+
+  /**
+   * Stores the resolved owner (or "no owner") for the given metadata object ID.
+   *
+   * @param metadataId the metadata object ID
+   * @param owner Optional.of(userId) or Optional.empty()
+   */
+  public void cacheOwner(Long metadataId, Optional<Long> owner) {
+    ownerCache.put(metadataId, owner);
   }
 
   public static class AuthorizationKey {

--- a/core/src/main/java/org/apache/gravitino/cache/CaffeineGravitinoCache.java
+++ b/core/src/main/java/org/apache/gravitino/cache/CaffeineGravitinoCache.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.cache;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.RemovalListener;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A {@link GravitinoCache} implementation backed by a Caffeine cache with configurable TTL and
+ * maximum size.
+ *
+ * @param <K> key type
+ * @param <V> value type
+ */
+public class CaffeineGravitinoCache<K, V> implements GravitinoCache<K, V> {
+
+  private final Cache<K, V> cache;
+
+  /**
+   * Creates a cache with the given maximum size and expiration, with no removal listener.
+   *
+   * @param maxSize maximum number of entries
+   * @param expirationSecs expire-after-access duration in seconds
+   */
+  public CaffeineGravitinoCache(long maxSize, long expirationSecs) {
+    this.cache =
+        Caffeine.newBuilder()
+            .expireAfterAccess(expirationSecs, TimeUnit.SECONDS)
+            .maximumSize(maxSize)
+            .executor(Runnable::run)
+            .build();
+  }
+
+  /**
+   * Creates a cache with the given maximum size, expiration, and a removal listener.
+   *
+   * @param maxSize maximum number of entries
+   * @param expirationSecs expire-after-access duration in seconds
+   * @param removalListener called on every eviction or explicit invalidation
+   */
+  public CaffeineGravitinoCache(
+      long maxSize, long expirationSecs, RemovalListener<K, V> removalListener) {
+    this.cache =
+        Caffeine.newBuilder()
+            .expireAfterAccess(expirationSecs, TimeUnit.SECONDS)
+            .maximumSize(maxSize)
+            .executor(Runnable::run)
+            .removalListener(removalListener)
+            .build();
+  }
+
+  @Override
+  public Optional<V> getIfPresent(K key) {
+    return Optional.ofNullable(cache.getIfPresent(key));
+  }
+
+  @Override
+  public void put(K key, V value) {
+    cache.put(key, value);
+  }
+
+  @Override
+  public void invalidate(K key) {
+    cache.invalidate(key);
+  }
+
+  @Override
+  public void invalidateAll() {
+    cache.invalidateAll();
+  }
+
+  @Override
+  public long size() {
+    return cache.estimatedSize();
+  }
+
+  /** Forces pending maintenance tasks (e.g. removal listener calls) to run synchronously. */
+  public void cleanUp() {
+    cache.cleanUp();
+  }
+
+  @Override
+  public void close() {
+    cache.cleanUp();
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/cache/GravitinoCache.java
+++ b/core/src/main/java/org/apache/gravitino/cache/GravitinoCache.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.cache;
+
+import java.io.Closeable;
+import java.util.Optional;
+
+/**
+ * A lightweight general-purpose cache interface used by the authorization layer.
+ *
+ * <p>Implementations include {@link CaffeineGravitinoCache} (backed by Caffeine) and {@link
+ * NoOpsGravitinoCache} (no-op, for tests or when caching is disabled).
+ *
+ * @param <K> cache key type
+ * @param <V> cache value type
+ */
+public interface GravitinoCache<K, V> extends Closeable {
+
+  /**
+   * Returns the cached value for the given key, or {@link Optional#empty()} if absent.
+   *
+   * @param key the cache key
+   * @return the cached value wrapped in {@link Optional}, or empty if not present
+   */
+  Optional<V> getIfPresent(K key);
+
+  /**
+   * Inserts or overwrites the entry for the given key.
+   *
+   * @param key the cache key
+   * @param value the value to cache
+   */
+  void put(K key, V value);
+
+  /**
+   * Removes the entry for the given key if it is present.
+   *
+   * @param key the cache key to evict
+   */
+  void invalidate(K key);
+
+  /** Removes all entries from the cache. */
+  void invalidateAll();
+
+  /**
+   * Returns an estimate of the number of entries currently in the cache.
+   *
+   * @return estimated size
+   */
+  long size();
+}

--- a/core/src/main/java/org/apache/gravitino/cache/NoOpsGravitinoCache.java
+++ b/core/src/main/java/org/apache/gravitino/cache/NoOpsGravitinoCache.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.cache;
+
+import java.util.Optional;
+
+/**
+ * A no-operation {@link GravitinoCache} that never stores any entry. Useful in tests and when
+ * caching should be bypassed entirely.
+ *
+ * @param <K> key type
+ * @param <V> value type
+ */
+public class NoOpsGravitinoCache<K, V> implements GravitinoCache<K, V> {
+
+  @Override
+  public Optional<V> getIfPresent(K key) {
+    return Optional.empty();
+  }
+
+  @Override
+  public void put(K key, V value) {}
+
+  @Override
+  public void invalidate(K key) {}
+
+  @Override
+  public void invalidateAll() {}
+
+  @Override
+  public long size() {
+    return 0L;
+  }
+
+  @Override
+  public void close() {}
+}

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/GroupMetaMapper.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/GroupMetaMapper.java
@@ -88,4 +88,7 @@ public interface GroupMetaMapper {
       method = "deleteGroupMetasByLegacyTimeline")
   Integer deleteGroupMetasByLegacyTimeline(
       @Param("legacyTimeline") Long legacyTimeline, @Param("limit") int limit);
+
+  @UpdateProvider(type = GroupMetaSQLProviderFactory.class, method = "bumpRoleGrantsVersion")
+  void bumpRoleGrantsVersion(@Param("groupId") long groupId);
 }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/GroupMetaSQLProviderFactory.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/GroupMetaSQLProviderFactory.java
@@ -95,4 +95,8 @@ public class GroupMetaSQLProviderFactory {
       @Param("legacyTimeline") Long legacyTimeline, @Param("limit") int limit) {
     return getProvider().deleteGroupMetasByLegacyTimeline(legacyTimeline, limit);
   }
+
+  public static String bumpRoleGrantsVersion(@Param("groupId") long groupId) {
+    return getProvider().bumpRoleGrantsVersion(groupId);
+  }
 }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/OwnerMetaMapper.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/OwnerMetaMapper.java
@@ -20,6 +20,7 @@ package org.apache.gravitino.storage.relational.mapper;
 
 import java.util.List;
 import org.apache.gravitino.storage.relational.po.GroupPO;
+import org.apache.gravitino.storage.relational.po.OwnerRelInfoPO;
 import org.apache.gravitino.storage.relational.po.OwnerRelPO;
 import org.apache.gravitino.storage.relational.po.UserOwnerRelPO;
 import org.apache.gravitino.storage.relational.po.UserPO;
@@ -95,4 +96,9 @@ public interface OwnerMetaMapper {
       method = "deleteOwnerMetasByLegacyTimeline")
   Integer deleteOwnerMetasByLegacyTimeline(
       @Param("legacyTimeline") Long legacyTimeline, @Param("limit") int limit);
+
+  @SelectProvider(
+      type = OwnerMetaSQLProviderFactory.class,
+      method = "selectOwnerByMetadataObjectId")
+  OwnerRelInfoPO selectOwnerByMetadataObjectId(@Param("metadataObjectId") long metadataObjectId);
 }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/OwnerMetaSQLProviderFactory.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/OwnerMetaSQLProviderFactory.java
@@ -104,4 +104,9 @@ public class OwnerMetaSQLProviderFactory {
     return getProvider()
         .batchSelectUserOwnerMetaByMetadataObjectIdAndType(metadataObjectIds, metadataObjectType);
   }
+
+  public static String selectOwnerByMetadataObjectId(
+      @Param("metadataObjectId") long metadataObjectId) {
+    return getProvider().selectOwnerByMetadataObjectId(metadataObjectId);
+  }
 }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/RoleMetaMapper.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/RoleMetaMapper.java
@@ -21,6 +21,7 @@ package org.apache.gravitino.storage.relational.mapper;
 
 import java.util.List;
 import org.apache.gravitino.storage.relational.po.RolePO;
+import org.apache.gravitino.storage.relational.po.RoleVersionInfoPO;
 import org.apache.ibatis.annotations.DeleteProvider;
 import org.apache.ibatis.annotations.InsertProvider;
 import org.apache.ibatis.annotations.Param;
@@ -93,4 +94,12 @@ public interface RoleMetaMapper {
       method = "deleteRoleMetasByLegacyTimeline")
   Integer deleteRoleMetasByLegacyTimeline(
       @Param("legacyTimeline") Long legacyTimeline, @Param("limit") int limit);
+
+  @UpdateProvider(type = RoleMetaSQLProviderFactory.class, method = "bumpSecurableObjectsVersion")
+  void bumpSecurableObjectsVersion(@Param("roleId") long roleId);
+
+  @SelectProvider(
+      type = RoleMetaSQLProviderFactory.class,
+      method = "batchGetSecurableObjectsVersions")
+  List<RoleVersionInfoPO> batchGetSecurableObjectsVersions(@Param("roleIds") List<Long> roleIds);
 }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/RoleMetaSQLProviderFactory.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/RoleMetaSQLProviderFactory.java
@@ -19,6 +19,7 @@
 package org.apache.gravitino.storage.relational.mapper;
 
 import com.google.common.collect.ImmutableMap;
+import java.util.List;
 import java.util.Map;
 import org.apache.gravitino.storage.relational.JDBCBackend.JDBCBackendType;
 import org.apache.gravitino.storage.relational.mapper.provider.base.RoleMetaBaseSQLProvider;
@@ -100,5 +101,13 @@ public class RoleMetaSQLProviderFactory {
   public static String deleteRoleMetasByLegacyTimeline(
       @Param("legacyTimeline") Long legacyTimeline, @Param("limit") int limit) {
     return getProvider().deleteRoleMetasByLegacyTimeline(legacyTimeline, limit);
+  }
+
+  public static String bumpSecurableObjectsVersion(@Param("roleId") long roleId) {
+    return getProvider().bumpSecurableObjectsVersion(roleId);
+  }
+
+  public static String batchGetSecurableObjectsVersions(@Param("roleIds") List<Long> roleIds) {
+    return getProvider().batchGetSecurableObjectsVersions(roleIds);
   }
 }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/UserMetaMapper.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/UserMetaMapper.java
@@ -22,6 +22,7 @@ package org.apache.gravitino.storage.relational.mapper;
 import java.util.List;
 import org.apache.gravitino.storage.relational.po.ExtendedUserPO;
 import org.apache.gravitino.storage.relational.po.UserPO;
+import org.apache.gravitino.storage.relational.po.UserVersionInfoPO;
 import org.apache.ibatis.annotations.DeleteProvider;
 import org.apache.ibatis.annotations.InsertProvider;
 import org.apache.ibatis.annotations.Param;
@@ -88,4 +89,11 @@ public interface UserMetaMapper {
       method = "deleteUserMetasByLegacyTimeline")
   Integer deleteUserMetasByLegacyTimeline(
       @Param("legacyTimeline") Long legacyTimeline, @Param("limit") int limit);
+
+  @UpdateProvider(type = UserMetaSQLProviderFactory.class, method = "bumpRoleGrantsVersion")
+  void bumpRoleGrantsVersion(@Param("userId") long userId);
+
+  @SelectProvider(type = UserMetaSQLProviderFactory.class, method = "getUserVersionInfo")
+  UserVersionInfoPO getUserVersionInfo(
+      @Param("metalakeName") String metalakeName, @Param("userName") String userName);
 }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/UserMetaSQLProviderFactory.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/UserMetaSQLProviderFactory.java
@@ -97,4 +97,13 @@ public class UserMetaSQLProviderFactory {
       @Param("legacyTimeline") Long legacyTimeline, @Param("limit") int limit) {
     return getProvider().deleteUserMetasByLegacyTimeline(legacyTimeline, limit);
   }
+
+  public static String bumpRoleGrantsVersion(@Param("userId") long userId) {
+    return getProvider().bumpRoleGrantsVersion(userId);
+  }
+
+  public static String getUserVersionInfo(
+      @Param("metalakeName") String metalakeName, @Param("userName") String userName) {
+    return getProvider().getUserVersionInfo(metalakeName, userName);
+  }
 }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/GroupMetaBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/GroupMetaBaseSQLProvider.java
@@ -182,4 +182,11 @@ public class GroupMetaBaseSQLProvider {
         + GROUP_TABLE_NAME
         + " WHERE deleted_at > 0 AND deleted_at < #{legacyTimeline} LIMIT #{limit}";
   }
+
+  public String bumpRoleGrantsVersion(@Param("groupId") long groupId) {
+    return "UPDATE "
+        + GROUP_TABLE_NAME
+        + " SET role_grants_version = role_grants_version + 1"
+        + " WHERE group_id = #{groupId} AND deleted_at = 0";
+  }
 }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/OwnerMetaBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/OwnerMetaBaseSQLProvider.java
@@ -225,4 +225,11 @@ public class OwnerMetaBaseSQLProvider {
         + OWNER_TABLE_NAME
         + " WHERE deleted_at > 0 AND deleted_at < #{legacyTimeline} LIMIT #{limit}";
   }
+
+  public String selectOwnerByMetadataObjectId(@Param("metadataObjectId") long metadataObjectId) {
+    return "SELECT owner_id as ownerId, owner_type as ownerType"
+        + " FROM "
+        + OWNER_TABLE_NAME
+        + " WHERE metadata_object_id = #{metadataObjectId} AND deleted_at = 0";
+  }
 }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/RoleMetaBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/RoleMetaBaseSQLProvider.java
@@ -22,6 +22,7 @@ import static org.apache.gravitino.storage.relational.mapper.RoleMetaMapper.GROU
 import static org.apache.gravitino.storage.relational.mapper.RoleMetaMapper.ROLE_TABLE_NAME;
 import static org.apache.gravitino.storage.relational.mapper.RoleMetaMapper.USER_ROLE_RELATION_TABLE_NAME;
 
+import java.util.List;
 import org.apache.gravitino.storage.relational.mapper.MetalakeMetaMapper;
 import org.apache.gravitino.storage.relational.mapper.SecurableObjectMapper;
 import org.apache.gravitino.storage.relational.po.RolePO;
@@ -191,5 +192,23 @@ public class RoleMetaBaseSQLProvider {
     return "DELETE FROM "
         + ROLE_TABLE_NAME
         + " WHERE deleted_at > 0 AND deleted_at < #{legacyTimeline} LIMIT #{limit}";
+  }
+
+  public String bumpSecurableObjectsVersion(@Param("roleId") long roleId) {
+    return "UPDATE "
+        + ROLE_TABLE_NAME
+        + " SET securable_objects_version = securable_objects_version + 1"
+        + " WHERE role_id = #{roleId} AND deleted_at = 0";
+  }
+
+  public String batchGetSecurableObjectsVersions(@Param("roleIds") List<Long> roleIds) {
+    return "<script>"
+        + "SELECT role_id as roleId, securable_objects_version as securableObjectsVersion"
+        + " FROM "
+        + ROLE_TABLE_NAME
+        + " WHERE role_id IN "
+        + "<foreach item='id' collection='roleIds' open='(' separator=',' close=')'>#{id}</foreach>"
+        + " AND deleted_at = 0"
+        + "</script>";
   }
 }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/UserMetaBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/UserMetaBaseSQLProvider.java
@@ -187,4 +187,23 @@ public class UserMetaBaseSQLProvider {
         + USER_TABLE_NAME
         + " WHERE deleted_at > 0 AND deleted_at < #{legacyTimeline} LIMIT #{limit}";
   }
+
+  public String bumpRoleGrantsVersion(@Param("userId") long userId) {
+    return "UPDATE "
+        + USER_TABLE_NAME
+        + " SET role_grants_version = role_grants_version + 1"
+        + " WHERE user_id = #{userId} AND deleted_at = 0";
+  }
+
+  public String getUserVersionInfo(
+      @Param("metalakeName") String metalakeName, @Param("userName") String userName) {
+    return "SELECT um.user_id as userId, um.role_grants_version as roleGrantsVersion"
+        + " FROM "
+        + USER_TABLE_NAME
+        + " um JOIN "
+        + MetalakeMetaMapper.TABLE_NAME
+        + " mm ON um.metalake_id = mm.metalake_id"
+        + " WHERE mm.metalake_name = #{metalakeName} AND um.user_name = #{userName}"
+        + " AND um.deleted_at = 0 AND mm.deleted_at = 0";
+  }
 }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/po/OwnerRelInfoPO.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/po/OwnerRelInfoPO.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.storage.relational.po;
+
+/** Projection for the owner ID and owner type of a metadata object. */
+public class OwnerRelInfoPO {
+
+  private Long ownerId;
+  private String ownerType;
+
+  public Long getOwnerId() {
+    return ownerId;
+  }
+
+  public void setOwnerId(Long ownerId) {
+    this.ownerId = ownerId;
+  }
+
+  public String getOwnerType() {
+    return ownerType;
+  }
+
+  public void setOwnerType(String ownerType) {
+    this.ownerType = ownerType;
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/storage/relational/po/RoleVersionInfoPO.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/po/RoleVersionInfoPO.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.storage.relational.po;
+
+/** Projection for a role's ID and current securable-objects version number. */
+public class RoleVersionInfoPO {
+
+  private Long roleId;
+  private Integer securableObjectsVersion;
+
+  public Long getRoleId() {
+    return roleId;
+  }
+
+  public void setRoleId(Long roleId) {
+    this.roleId = roleId;
+  }
+
+  public Integer getSecurableObjectsVersion() {
+    return securableObjectsVersion;
+  }
+
+  public void setSecurableObjectsVersion(Integer securableObjectsVersion) {
+    this.securableObjectsVersion = securableObjectsVersion;
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/storage/relational/po/UserVersionInfoPO.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/po/UserVersionInfoPO.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.storage.relational.po;
+
+/** Projection for a user's ID and current role-grants version number. */
+public class UserVersionInfoPO {
+
+  private Long userId;
+  private Integer roleGrantsVersion;
+
+  public Long getUserId() {
+    return userId;
+  }
+
+  public void setUserId(Long userId) {
+    this.userId = userId;
+  }
+
+  public Integer getRoleGrantsVersion() {
+    return roleGrantsVersion;
+  }
+
+  public void setRoleGrantsVersion(Integer roleGrantsVersion) {
+    this.roleGrantsVersion = roleGrantsVersion;
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/GroupMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/GroupMetaService.java
@@ -259,7 +259,11 @@ public class GroupMetaService {
                 mapper ->
                     mapper.softDeleteGroupRoleRelByGroupAndRoles(
                         newEntity.id(), Lists.newArrayList(deleteRoleIds)));
-          });
+          },
+          () ->
+              SessionUtils.doWithoutCommit(
+                  GroupMetaMapper.class,
+                  mapper -> mapper.bumpRoleGrantsVersion(oldGroupPO.getGroupId())));
     } catch (RuntimeException re) {
       ExceptionUtils.checkSQLException(
           re, Entity.EntityType.GROUP, newEntity.nameIdentifier().toString());

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/RoleMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/RoleMetaService.java
@@ -259,7 +259,11 @@ public class RoleMetaService {
             SessionUtils.doWithoutCommit(
                 SecurableObjectMapper.class,
                 mapper -> mapper.batchInsertSecurableObjects(insertSecurableObjectPOs));
-          });
+          },
+          () ->
+              SessionUtils.doWithoutCommit(
+                  RoleMetaMapper.class,
+                  mapper -> mapper.bumpSecurableObjectsVersion(rolePO.getRoleId())));
 
       return newRoleEntity;
     } catch (RuntimeException re) {

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/UserMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/UserMetaService.java
@@ -252,7 +252,11 @@ public class UserMetaService {
                 mapper ->
                     mapper.softDeleteUserRoleRelByUserAndRoles(
                         newEntity.id(), Lists.newArrayList(deleteRoleIds)));
-          });
+          },
+          () ->
+              SessionUtils.doWithoutCommit(
+                  UserMetaMapper.class,
+                  mapper -> mapper.bumpRoleGrantsVersion(oldUserPO.getUserId())));
     } catch (RuntimeException re) {
       ExceptionUtils.checkSQLException(
           re, Entity.EntityType.USER, newEntity.nameIdentifier().toString());

--- a/core/src/test/java/org/apache/gravitino/cache/TestGravitinoCache.java
+++ b/core/src/test/java/org/apache/gravitino/cache/TestGravitinoCache.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.cache;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for {@link CaffeineGravitinoCache} and {@link NoOpsGravitinoCache}. */
+public class TestGravitinoCache {
+
+  @Test
+  public void testCaffeinePutAndGet() throws IOException {
+    try (GravitinoCache<String, Integer> cache = new CaffeineGravitinoCache<>(100, 3600)) {
+      cache.put("key1", 42);
+      Optional<Integer> result = cache.getIfPresent("key1");
+      assertTrue(result.isPresent());
+      assertEquals(42, result.get());
+    }
+  }
+
+  @Test
+  public void testCaffeineGetMissReturnsEmpty() throws IOException {
+    try (GravitinoCache<String, Integer> cache = new CaffeineGravitinoCache<>(100, 3600)) {
+      assertFalse(cache.getIfPresent("missing").isPresent());
+    }
+  }
+
+  @Test
+  public void testCaffeineInvalidate() throws IOException {
+    try (GravitinoCache<Long, String> cache = new CaffeineGravitinoCache<>(100, 3600)) {
+      cache.put(1L, "value");
+      assertTrue(cache.getIfPresent(1L).isPresent());
+
+      cache.invalidate(1L);
+      assertFalse(cache.getIfPresent(1L).isPresent());
+    }
+  }
+
+  @Test
+  public void testCaffeineInvalidateAll() throws IOException {
+    try (GravitinoCache<Long, String> cache = new CaffeineGravitinoCache<>(100, 3600)) {
+      cache.put(1L, "a");
+      cache.put(2L, "b");
+      cache.put(3L, "c");
+
+      cache.invalidateAll();
+
+      assertFalse(cache.getIfPresent(1L).isPresent());
+      assertFalse(cache.getIfPresent(2L).isPresent());
+      assertFalse(cache.getIfPresent(3L).isPresent());
+    }
+  }
+
+  @Test
+  public void testCaffeineSize() throws IOException {
+    try (GravitinoCache<Integer, String> cache = new CaffeineGravitinoCache<>(100, 3600)) {
+      assertEquals(0, cache.size());
+      cache.put(1, "a");
+      cache.put(2, "b");
+      // Caffeine size is eventually consistent; force cleanup
+      ((CaffeineGravitinoCache<Integer, String>) cache).cleanUp();
+      assertEquals(2, cache.size());
+    }
+  }
+
+  @Test
+  public void testCaffeineRemovalListenerFires() throws IOException {
+    List<Long> evicted = new ArrayList<>();
+    try (GravitinoCache<Long, Integer> cache =
+        new CaffeineGravitinoCache<>(100, 3600, (key, value, cause) -> evicted.add(key))) {
+      cache.put(10L, 1);
+      cache.invalidate(10L);
+      // Force Caffeine to run pending removal tasks synchronously
+      ((CaffeineGravitinoCache<Long, Integer>) cache).cleanUp();
+      assertTrue(evicted.contains(10L), "Removal listener should have been called for key 10");
+    }
+  }
+
+  @Test
+  public void testCaffeineOverwrite() throws IOException {
+    try (GravitinoCache<String, Integer> cache = new CaffeineGravitinoCache<>(100, 3600)) {
+      cache.put("k", 1);
+      cache.put("k", 2);
+      assertEquals(2, cache.getIfPresent("k").get());
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // NoOpsGravitinoCache
+  // -----------------------------------------------------------------------
+
+  @Test
+  public void testNoOpsCacheAlwaysEmpty() throws IOException {
+    try (GravitinoCache<String, Integer> cache = new NoOpsGravitinoCache<>()) {
+      cache.put("key", 99);
+      assertFalse(cache.getIfPresent("key").isPresent());
+      assertEquals(0, cache.size());
+    }
+  }
+
+  @Test
+  public void testNoOpsCacheInvalidateIsNoOp() throws IOException {
+    try (GravitinoCache<String, Integer> cache = new NoOpsGravitinoCache<>()) {
+      // Should not throw
+      cache.invalidate("anything");
+      cache.invalidateAll();
+    }
+  }
+}

--- a/scripts/h2/schema-1.3.0-h2.sql
+++ b/scripts/h2/schema-1.3.0-h2.sql
@@ -1,0 +1,542 @@
+--
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file--
+--  distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"). You may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--  http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+--
+
+CREATE TABLE IF NOT EXISTS `metalake_meta` (
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `metalake_name` VARCHAR(128) NOT NULL COMMENT 'metalake name',
+    `metalake_comment` VARCHAR(256) DEFAULT '' COMMENT 'metalake comment',
+    `properties` CLOB DEFAULT NULL COMMENT 'metalake properties',
+    `audit_info` CLOB NOT NULL COMMENT 'metalake audit info',
+    `schema_version` CLOB NOT NULL COMMENT 'metalake schema version info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'metalake current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'metalake last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'metalake deleted at',
+    PRIMARY KEY (metalake_id),
+    CONSTRAINT uk_mn_del UNIQUE (metalake_name, deleted_at)
+) ENGINE = InnoDB;
+
+
+CREATE TABLE IF NOT EXISTS `catalog_meta` (
+    `catalog_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'catalog id',
+    `catalog_name` VARCHAR(128) NOT NULL COMMENT 'catalog name',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `type` VARCHAR(64) NOT NULL COMMENT 'catalog type',
+    `provider` VARCHAR(64) NOT NULL COMMENT 'catalog provider',
+    `catalog_comment` VARCHAR(256) DEFAULT '' COMMENT 'catalog comment',
+    `properties` CLOB DEFAULT NULL COMMENT 'catalog properties',
+    `audit_info` CLOB NOT NULL COMMENT 'catalog audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'catalog current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'catalog last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'catalog deleted at',
+    PRIMARY KEY (catalog_id),
+    CONSTRAINT uk_mid_cn_del UNIQUE (metalake_id, catalog_name, deleted_at)
+) ENGINE=InnoDB;
+
+
+CREATE TABLE IF NOT EXISTS `schema_meta` (
+    `schema_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'schema id',
+    `schema_name` VARCHAR(128) NOT NULL COMMENT 'schema name',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `catalog_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'catalog id',
+    `schema_comment` VARCHAR(256) DEFAULT '' COMMENT 'schema comment',
+    `properties` CLOB DEFAULT NULL COMMENT 'schema properties',
+    `audit_info` CLOB NOT NULL COMMENT 'schema audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'schema current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'schema last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'schema deleted at',
+    PRIMARY KEY (schema_id),
+    CONSTRAINT uk_cid_sn_del UNIQUE (catalog_id, schema_name, deleted_at),
+    -- Aliases are used here, and indexes with the same name in H2 can only be created once.
+    KEY idx_smid (metalake_id)
+) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS `table_meta` (
+    `table_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'table id',
+    `table_name` VARCHAR(128) NOT NULL COMMENT 'table name',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `catalog_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'catalog id',
+    `schema_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'schema id',
+    `audit_info` CLOB NOT NULL COMMENT 'table audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'table current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'table last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'table deleted at',
+    PRIMARY KEY (table_id),
+    CONSTRAINT uk_sid_tn_del UNIQUE (schema_id, table_name, deleted_at),
+    -- Aliases are used here, and indexes with the same name in H2 can only be created once.
+    KEY idx_tmid (metalake_id),
+    KEY idx_tcid (catalog_id)
+) ENGINE=InnoDB;
+
+
+CREATE TABLE IF NOT EXISTS `table_column_version_info` (
+    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'auto increment id',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `catalog_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'catalog id',
+    `schema_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'schema id',
+    `table_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'table id',
+    `table_version` INT UNSIGNED NOT NULL COMMENT 'table version',
+    `column_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'column id',
+    `column_name` VARCHAR(128) NOT NULL COMMENT 'column name',
+    `column_position` INT UNSIGNED NOT NULL COMMENT 'column position, starting from 0',
+    `column_type` CLOB NOT NULL COMMENT 'column type',
+    `column_comment` VARCHAR(256) DEFAULT '' COMMENT 'column comment',
+    `column_nullable` TINYINT(1) NOT NULL DEFAULT 1 COMMENT 'column nullable, 0 is not nullable, 1 is nullable',
+    `column_auto_increment` TINYINT(1) NOT NULL DEFAULT 0 COMMENT 'column auto increment, 0 is not auto increment, 1 is auto increment',
+    `column_default_value` CLOB DEFAULT NULL COMMENT 'column default value',
+    `column_op_type` TINYINT(1) NOT NULL COMMENT 'column operation type, 1 is create, 2 is update, 3 is delete',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'column deleted at',
+    `audit_info` CLOB NOT NULL COMMENT 'column audit info',
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `uk_tid_ver_cid_del` (`table_id`, `table_version`, `column_id`, `deleted_at`),
+    KEY `idx_tcmid` (`metalake_id`),
+    KEY `idx_tccid` (`catalog_id`),
+    KEY `idx_tcsid` (`schema_id`)
+) ENGINE=InnoDB;
+
+
+CREATE TABLE IF NOT EXISTS `fileset_meta` (
+    `fileset_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'fileset id',
+    `fileset_name` VARCHAR(128) NOT NULL COMMENT 'fileset name',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `catalog_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'catalog id',
+    `schema_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'schema id',
+    `type` VARCHAR(64) NOT NULL COMMENT 'fileset type',
+    `audit_info` CLOB NOT NULL COMMENT 'fileset audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'fileset current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'fileset last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'fileset deleted at',
+    PRIMARY KEY (fileset_id),
+    CONSTRAINT uk_sid_fn_del UNIQUE (schema_id, fileset_name, deleted_at),
+    -- Aliases are used here, and indexes with the same name in H2 can only be created once.
+    KEY idx_fmid (metalake_id),
+    KEY idx_fcid (catalog_id)
+) ENGINE=InnoDB;
+
+
+CREATE TABLE IF NOT EXISTS `fileset_version_info` (
+    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'auto increment id',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `catalog_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'catalog id',
+    `schema_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'schema id',
+    `fileset_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'fileset id',
+    `version` INT UNSIGNED NOT NULL COMMENT 'fileset info version',
+    `fileset_comment` VARCHAR(256) DEFAULT '' COMMENT 'fileset comment',
+    `properties` CLOB DEFAULT NULL COMMENT 'fileset properties',
+    `storage_location_name` VARCHAR(128) NOT NULL DEFAULT 'default' COMMENT 'fileset storage location name',
+    `storage_location` CLOB DEFAULT NULL COMMENT 'fileset storage location',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'fileset deleted at',
+    PRIMARY KEY (id),
+    CONSTRAINT uk_fid_ver_del UNIQUE (fileset_id, version, storage_location_name, deleted_at),
+    -- Aliases are used here, and indexes with the same name in H2 can only be created once.
+    KEY idx_fvmid (metalake_id),
+    KEY idx_fvcid (catalog_id)
+) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS `topic_meta` (
+    `topic_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'topic id',
+    `topic_name` VARCHAR(128) NOT NULL COMMENT 'topic name',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `catalog_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'catalog id',
+    `schema_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'schema id',
+    `comment` VARCHAR(256) DEFAULT '' COMMENT 'topic comment',
+    `properties` CLOB DEFAULT NULL COMMENT 'topic properties',
+    `audit_info` CLOB NOT NULL COMMENT 'topic audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'topic current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'topic last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'topic deleted at',
+    PRIMARY KEY (topic_id),
+    CONSTRAINT uk_cid_tn_del UNIQUE (schema_id, topic_name, deleted_at),
+    -- Aliases are used here, and indexes with the same name in H2 can only be created once.
+    KEY idx_tvmid (metalake_id),
+    KEY idx_tvcid (catalog_id)
+) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS `user_meta` (
+    `user_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'user id',
+    `user_name` VARCHAR(128) NOT NULL COMMENT 'username',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `audit_info` CLOB NOT NULL COMMENT 'user audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'user current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'user last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'user deleted at',
+    `role_grants_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'version bumped on any role assignment change for this user',
+    PRIMARY KEY (`user_id`),
+    CONSTRAINT `uk_mid_us_del` UNIQUE (`metalake_id`, `user_name`, `deleted_at`)
+) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS `role_meta` (
+    `role_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'role id',
+    `role_name` VARCHAR(128) NOT NULL COMMENT 'role name',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `properties` CLOB DEFAULT NULL COMMENT 'schema properties',
+    `audit_info` CLOB NOT NULL COMMENT 'role audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'role current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'role last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'role deleted at',
+    `securable_objects_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'version bumped on any privilege change for this role',
+    PRIMARY KEY (`role_id`),
+    CONSTRAINT `uk_mid_rn_del` UNIQUE (`metalake_id`, `role_name`, `deleted_at`)
+) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS `role_meta_securable_object` (
+    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'auto increment id',
+    `role_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'role id',
+    `metadata_object_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'securable object entity id',
+    `type`  VARCHAR(128) NOT NULL COMMENT 'securable object type',
+    `privilege_names` CLOB(81920) NOT NULL COMMENT 'securable object privilege names',
+    `privilege_conditions` CLOB(81920) NOT NULL COMMENT 'securable object privilege conditions',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'securable objectcurrent version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'securable object last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'securable object deleted at',
+    PRIMARY KEY (`id`),
+    KEY `idx_obj_rid` (`role_id`),
+    KEY `idx_obj_eid` (`metadata_object_id`)
+) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS `user_role_rel` (
+    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'auto increment id',
+    `user_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'user id',
+    `role_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'role id',
+    `audit_info` CLOB NOT NULL COMMENT 'relation audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'relation current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'relation last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'relation deleted at',
+    PRIMARY KEY (`id`),
+    CONSTRAINT `uk_ui_ri_del` UNIQUE (`user_id`, `role_id`, `deleted_at`),
+    KEY `idx_rid` (`role_id`)
+) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS `group_meta` (
+    `group_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'group id',
+    `group_name` VARCHAR(128) NOT NULL COMMENT 'group name',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `audit_info` CLOB NOT NULL COMMENT 'group audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'group current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'group last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'group deleted at',
+    `role_grants_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'version bumped on any role assignment change for this group',
+    PRIMARY KEY (`group_id`),
+    CONSTRAINT `uk_mid_gr_del` UNIQUE (`metalake_id`, `group_name`, `deleted_at`)
+) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS `group_role_rel` (
+    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'auto increment id',
+    `group_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'group id',
+    `role_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'role id',
+    `audit_info` CLOB NOT NULL COMMENT 'relation audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'relation current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'relation last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'relation deleted at',
+    PRIMARY KEY (`id`),
+    CONSTRAINT `uk_gi_ri_del` UNIQUE (`group_id`, `role_id`, `deleted_at`),
+    KEY `idx_gid` (`group_id`)
+) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS `tag_meta` (
+    `tag_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'tag id',
+    `tag_name` VARCHAR(128) NOT NULL COMMENT 'tag name',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `tag_comment` VARCHAR(256) DEFAULT '' COMMENT 'tag comment',
+    `properties` CLOB DEFAULT NULL COMMENT 'tag properties',
+    `audit_info` CLOB NOT NULL COMMENT 'tag audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'tag current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'tag last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'tag deleted at',
+    PRIMARY KEY (`tag_id`),
+    UNIQUE KEY `uk_mn_tn_del` (`metalake_id`, `tag_name`, `deleted_at`)
+) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS `tag_relation_meta` (
+    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'auto increment id',
+    `tag_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'tag id',
+    `metadata_object_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metadata object id',
+    `metadata_object_type` VARCHAR(64) NOT NULL COMMENT 'metadata object type',
+    `audit_info` CLOB NOT NULL COMMENT 'tag relation audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'tag relation current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'tag relation last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'tag relation deleted at',
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `uk_ti_mi_del` (`tag_id`, `metadata_object_id`, `deleted_at`),
+    KEY `idx_tid` (`tag_id`),
+    KEY `idx_mid` (`metadata_object_id`)
+) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS `owner_meta` (
+    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'auto increment id',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `owner_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'owner id',
+    `owner_type` VARCHAR(64) NOT NULL COMMENT 'owner type',
+    `metadata_object_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metadata object id',
+    `metadata_object_type` VARCHAR(64) NOT NULL COMMENT 'metadata object type',
+    `audit_info` CLOB NOT NULL COMMENT 'owner relation audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'owner relation current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'owner relation last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'owner relation deleted at',
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `uk_ow_me_del` (`owner_id`, `metadata_object_id`, `metadata_object_type`, `deleted_at`),
+    KEY `idx_oid` (`owner_id`),
+    KEY `idx_meid` (`metadata_object_id`)
+) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS `model_meta` (
+    `model_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'model id',
+    `model_name` VARCHAR(128) NOT NULL COMMENT 'model name',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `catalog_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'catalog id',
+    `schema_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'schema id',
+    `model_comment` CLOB DEFAULT NULL COMMENT 'model comment',
+    `model_properties` CLOB DEFAULT NULL COMMENT 'model properties',
+    `model_latest_version` INT UNSIGNED DEFAULT 0 COMMENT 'model latest version',
+    `audit_info` CLOB NOT NULL COMMENT 'model audit info',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'model deleted at',
+    PRIMARY KEY (`model_id`),
+    UNIQUE KEY `uk_sid_mn_del` (`schema_id`, `model_name`, `deleted_at`),
+    KEY `idx_mmid` (`metalake_id`),
+    KEY `idx_mcid` (`catalog_id`)
+) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS `model_version_info` (
+    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'auto increment id',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `catalog_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'catalog id',
+    `schema_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'schema id',
+    `model_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'model id',
+    `version` INT UNSIGNED NOT NULL COMMENT 'model version',
+    `model_version_comment` CLOB DEFAULT NULL COMMENT 'model version comment',
+    `model_version_properties` CLOB DEFAULT NULL COMMENT 'model version properties',
+    `model_version_uri_name` VARCHAR(128) NOT NULL COMMENT 'model version uri name',
+    `model_version_uri` CLOB NOT NULL COMMENT 'model storage uri',
+    `audit_info` CLOB NOT NULL COMMENT 'model version audit info',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'model version deleted at',
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `uk_mid_ver_uri_del` (`model_id`, `version`, `model_version_uri_name`, `deleted_at`),
+    KEY `idx_vmid` (`metalake_id`),
+    KEY `idx_vcid` (`catalog_id`),
+    KEY `idx_vsid` (`schema_id`)
+) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS `model_version_alias_rel` (
+    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'auto increment id',
+    `model_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'model id',
+    `model_version` INT UNSIGNED NOT NULL COMMENT 'model version',
+    `model_version_alias` VARCHAR(128) NOT NULL COMMENT 'model version alias',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'model version alias deleted at',
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `uk_mi_mva_del` (`model_id`, `model_version_alias`, `deleted_at`),
+    KEY `idx_mva` (`model_version_alias`)
+) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS `policy_meta` (
+    `policy_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'policy id',
+    `policy_name` VARCHAR(128) NOT NULL COMMENT 'policy name',
+    `policy_type` VARCHAR(64) NOT NULL COMMENT 'policy type',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `audit_info` CLOB NOT NULL COMMENT 'policy audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'policy current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'policy last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'policy deleted at',
+    PRIMARY KEY (`policy_id`),
+    UNIQUE KEY `uk_mi_pn_del` (`metalake_id`, `policy_name`, `deleted_at`)
+) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS `policy_version_info` (
+    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'auto increment id',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `policy_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'policy id',
+    `version` INT UNSIGNED NOT NULL COMMENT 'policy info version',
+    `policy_comment` CLOB DEFAULT NULL COMMENT 'policy info comment',
+    `enabled` TINYINT(1) DEFAULT 1 COMMENT 'whether the policy is enabled, 0 is disabled, 1 is enabled',
+    `content` CLOB DEFAULT NULL COMMENT 'policy content',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'policy deleted at',
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `uk_pod_ver_del` (`policy_id`, `version`, `deleted_at`),
+    KEY `idx_pmid` (`metalake_id`)
+) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS `policy_relation_meta` (
+    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'auto increment id',
+    `policy_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'policy id',
+    `metadata_object_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metadata object id',
+    `metadata_object_type` VARCHAR(64) NOT NULL COMMENT 'metadata object type',
+    `audit_info` CLOB NOT NULL COMMENT 'policy relation audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'policy relation current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'policy relation last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'policy relation deleted at',
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `uk_pi_mi_mo_del` (`policy_id`, `metadata_object_id`, `metadata_object_type`, `deleted_at`),
+    KEY `idx_pid` (`policy_id`),
+    KEY `idx_prmid` (`metadata_object_id`)
+) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS `statistic_meta` (
+    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'auto increment id',
+    `statistic_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'statistic id',
+    `statistic_name` VARCHAR(128) NOT NULL COMMENT 'statistic name',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `statistic_value` CLOB NOT NULL COMMENT 'statistic value',
+    `metadata_object_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metadata object id',
+    `metadata_object_type` VARCHAR(64) NOT NULL COMMENT 'metadata object type',
+    `audit_info` CLOB NOT NULL COMMENT 'statistic audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'statistic current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'statistic last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'statistic deleted at',
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `uk_si_mi_mo_del` (`statistic_name`, `metadata_object_id`, `deleted_at`),
+    KEY `idx_stid` (`statistic_id`),
+    KEY `idx_moid` (`metadata_object_id`)
+) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS `job_template_meta` (
+    `job_template_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'job template id',
+    `job_template_name` VARCHAR(128) NOT NULL COMMENT 'job template name',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `job_template_comment` CLOB DEFAULT NULL COMMENT 'job template comment',
+    `job_template_content` CLOB NOT NULL COMMENT 'job template content',
+    `audit_info` CLOB NOT NULL COMMENT 'job template audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'job template current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'job template last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'job template deleted at',
+    PRIMARY KEY (`job_template_id`),
+    UNIQUE KEY `uk_mid_jtn_del` (`metalake_id`, `job_template_name`, `deleted_at`)
+) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS `job_run_meta` (
+    `job_run_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'job run id',
+    `job_template_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'job template id',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `job_execution_id` varchar(256) NOT NULL COMMENT 'job execution id',
+    `job_run_status` varchar(64) NOT NULL COMMENT 'job run status',
+    `job_finished_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'job finished at',
+    `audit_info` CLOB NOT NULL COMMENT 'job run audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'job run current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'job run last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'job run deleted at',
+    PRIMARY KEY (`job_run_id`),
+    UNIQUE KEY `uk_mid_jei_del` (`metalake_id`, `job_execution_id`, `deleted_at`),
+    KEY `idx_job_template_id` (`job_template_id`),
+    KEY `idx_job_execution_id` (`job_execution_id`)
+) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS `table_version_info` (
+    `table_id`        BIGINT(20) UNSIGNED NOT NULL COMMENT 'table id',
+    `format`          VARCHAR(64) COMMENT 'table format, such as Lance, Iceberg and so on, it will be null if it is not a lakehouse table' ,
+    `properties`      CLOB DEFAULT NULL COMMENT 'table properties',
+    `partitioning`  CLOB DEFAULT NULL COMMENT 'table partition info',
+    `distribution` CLOB DEFAULT NULL COMMENT 'table distribution info',
+    `sort_orders` CLOB DEFAULT NULL COMMENT 'table sort order info',
+    `indexes`      CLOB DEFAULT NULL COMMENT 'table index info',
+    `comment`   CLOB DEFAULT NULL COMMENT 'table comment',
+    `version` BIGINT(20) UNSIGNED COMMENT 'table current version',
+    `deleted_at`      BIGINT(20) UNSIGNED DEFAULT 0 COMMENT 'table deletion timestamp, 0 means not deleted',
+    UNIQUE KEY `uk_table_id_version_deleted_at` (`table_id`, `version`, `deleted_at`)
+) ENGINE=InnoDB COMMENT 'table detail information including format, location, properties, partition, distribution, sort order, index and so on';
+
+CREATE TABLE IF NOT EXISTS `function_meta` (
+    `function_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'function id',
+    `function_name` VARCHAR(128) NOT NULL COMMENT 'function name',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `catalog_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'catalog id',
+    `schema_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'schema id',
+    `function_type` VARCHAR(64) NOT NULL COMMENT 'function type',
+    `deterministic` TINYINT(1) DEFAULT 1 COMMENT 'whether the function result is deterministic',
+    `function_current_version` INT UNSIGNED DEFAULT 1 COMMENT 'function current version',
+    `function_latest_version` INT UNSIGNED DEFAULT 1 COMMENT 'function latest version',
+    `audit_info` CLOB NOT NULL COMMENT 'function audit info',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'function deleted at',
+    PRIMARY KEY (`function_id`),
+    UNIQUE KEY `uk_sid_fun_del` (`schema_id`, `function_name`, `deleted_at`),
+    KEY `idx_funmid` (`metalake_id`),
+    KEY `idx_funcid` (`catalog_id`)
+) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS `function_version_info` (
+    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'auto increment id',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `catalog_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'catalog id',
+    `schema_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'schema id',
+    `function_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'function id',
+    `version` INT UNSIGNED NOT NULL COMMENT 'function version',
+    `function_comment` CLOB DEFAULT NULL COMMENT 'function version comment',
+    `definitions` CLOB NOT NULL COMMENT 'function definitions details',
+    `audit_info` CLOB NOT NULL COMMENT 'function version audit info',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'function version deleted at',
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `uk_funid_ver_del` (`function_id`, `version`, `deleted_at`),
+    KEY `idx_funvmid` (`metalake_id`),
+    KEY `idx_funvcid` (`catalog_id`),
+    KEY `idx_funvsid` (`schema_id`)
+) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS `view_meta` (
+    `view_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'view id',
+    `view_name` VARCHAR(128) NOT NULL COMMENT 'view name',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `catalog_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'catalog id',
+    `schema_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'schema id',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'view current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'view last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'view deleted at',
+    PRIMARY KEY (`view_id`),
+    UNIQUE KEY `uk_sid_vn_del` (`schema_id`, `view_name`, `deleted_at`),
+    KEY `idx_vemid` (`metalake_id`),
+    KEY `idx_vecid` (`catalog_id`)
+) ENGINE=InnoDB;
+
+-- This schema extends version 1.1.0 with partition statistics storage support
+-- The partition_statistic_meta table stores partition-level statistics for tables
+
+CREATE TABLE IF NOT EXISTS partition_statistic_meta (
+    table_id BIGINT NOT NULL COMMENT 'table id from table_meta',
+    partition_name VARCHAR(1024) NOT NULL COMMENT 'partition name',
+    statistic_name VARCHAR(128) NOT NULL COMMENT 'statistic name',
+    statistic_value CLOB NOT NULL COMMENT 'statistic value as JSON',
+    audit_info CLOB NOT NULL COMMENT 'audit information as JSON',
+    created_at BIGINT NOT NULL COMMENT 'creation timestamp in milliseconds',
+    updated_at BIGINT NOT NULL COMMENT 'last update timestamp in milliseconds',
+    PRIMARY KEY (table_id, partition_name, statistic_name)
+);
+
+CREATE INDEX IF NOT EXISTS idx_table_partition ON partition_statistic_meta(table_id, partition_name);
+
+-- Optimizer metrics schema
+CREATE TABLE IF NOT EXISTS `table_metrics` (
+    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'auto increment id',
+    `table_identifier` VARCHAR(1024) NOT NULL COMMENT 'normalized table identifier',
+    `metric_name` VARCHAR(1024) NOT NULL COMMENT 'metric name',
+    `table_partition` VARCHAR(1024) DEFAULT NULL COMMENT 'normalized partition identifier',
+    `metric_ts` BIGINT(20) NOT NULL COMMENT 'metric timestamp in epoch seconds',
+    `metric_value` VARCHAR(1024) NOT NULL COMMENT 'metric value payload',
+    PRIMARY KEY (`id`)
+) ENGINE=InnoDB COMMENT='optimizer table metrics';
+
+CREATE TABLE IF NOT EXISTS `job_metrics` (
+    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'auto increment id',
+    `job_identifier` VARCHAR(1024) NOT NULL COMMENT 'normalized job identifier',
+    `metric_name` VARCHAR(1024) NOT NULL COMMENT 'metric name',
+    `metric_ts` BIGINT(20) NOT NULL COMMENT 'metric timestamp in epoch seconds',
+    `metric_value` VARCHAR(1024) NOT NULL COMMENT 'metric value payload',
+    PRIMARY KEY (`id`)
+) ENGINE=InnoDB COMMENT='optimizer job metrics';
+
+CREATE INDEX IF NOT EXISTS `idx_table_metrics_metric_ts` ON `table_metrics`(`metric_ts`);
+CREATE INDEX IF NOT EXISTS `idx_job_metrics_metric_ts` ON `job_metrics`(`metric_ts`);
+CREATE INDEX IF NOT EXISTS `idx_table_metrics_composite`
+  ON `table_metrics`(`table_identifier`, `table_partition`, `metric_ts`);
+CREATE INDEX IF NOT EXISTS `idx_job_metrics_identifier_metric_ts`
+  ON `job_metrics`(`job_identifier`, `metric_ts`);

--- a/scripts/h2/upgrade-1.2.0-to-1.3.0-h2.sql
+++ b/scripts/h2/upgrade-1.2.0-to-1.3.0-h2.sql
@@ -1,0 +1,32 @@
+--
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file--
+--  distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"). You may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--  http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+--
+
+-- Add version columns for Phase 2 version-validated auth cache
+
+ALTER TABLE `role_meta`
+    ADD COLUMN `securable_objects_version` INT UNSIGNED NOT NULL DEFAULT 1
+    COMMENT 'Incremented atomically with any privilege grant/revoke for this role';
+
+ALTER TABLE `user_meta`
+    ADD COLUMN `role_grants_version` INT UNSIGNED NOT NULL DEFAULT 1
+    COMMENT 'Incremented atomically with any role assignment/revocation for this user';
+
+ALTER TABLE `group_meta`
+    ADD COLUMN `role_grants_version` INT UNSIGNED NOT NULL DEFAULT 1
+    COMMENT 'Incremented atomically with any role assignment/revocation for this group';

--- a/scripts/mysql/schema-1.3.0-mysql.sql
+++ b/scripts/mysql/schema-1.3.0-mysql.sql
@@ -1,0 +1,529 @@
+--
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file--
+--  distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"). You may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--  http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+--
+
+CREATE TABLE IF NOT EXISTS `metalake_meta` (
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `metalake_name` VARCHAR(128) NOT NULL COMMENT 'metalake name',
+    `metalake_comment` VARCHAR(256) DEFAULT '' COMMENT 'metalake comment',
+    `properties` MEDIUMTEXT DEFAULT NULL COMMENT 'metalake properties',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'metalake audit info',
+    `schema_version` MEDIUMTEXT NOT NULL COMMENT 'metalake schema version info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'metalake current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'metalake last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'metalake deleted at',
+    PRIMARY KEY (`metalake_id`),
+    UNIQUE KEY `uk_mn_del` (`metalake_name`, `deleted_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'metalake metadata';
+
+CREATE TABLE IF NOT EXISTS `catalog_meta` (
+    `catalog_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'catalog id',
+    `catalog_name` VARCHAR(128) NOT NULL COMMENT 'catalog name',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `type` VARCHAR(64) NOT NULL COMMENT 'catalog type',
+    `provider` VARCHAR(64) NOT NULL COMMENT 'catalog provider',
+    `catalog_comment` VARCHAR(256) DEFAULT '' COMMENT 'catalog comment',
+    `properties` MEDIUMTEXT DEFAULT NULL COMMENT 'catalog properties',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'catalog audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'catalog current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'catalog last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'catalog deleted at',
+    PRIMARY KEY (`catalog_id`),
+    UNIQUE KEY `uk_mid_cn_del` (`metalake_id`, `catalog_name`, `deleted_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'catalog metadata';
+
+CREATE TABLE IF NOT EXISTS `schema_meta` (
+    `schema_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'schema id',
+    `schema_name` VARCHAR(128) NOT NULL COMMENT 'schema name',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `catalog_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'catalog id',
+    `schema_comment` VARCHAR(256) DEFAULT '' COMMENT 'schema comment',
+    `properties` MEDIUMTEXT DEFAULT NULL COMMENT 'schema properties',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'schema audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'schema current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'schema last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'schema deleted at',
+    PRIMARY KEY (`schema_id`),
+    UNIQUE KEY `uk_cid_sn_del` (`catalog_id`, `schema_name`, `deleted_at`),
+    KEY `idx_mid` (`metalake_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'schema metadata';
+
+CREATE TABLE IF NOT EXISTS `table_meta` (
+    `table_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'table id',
+    `table_name` VARCHAR(128) NOT NULL COMMENT 'table name',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `catalog_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'catalog id',
+    `schema_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'schema id',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'table audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'table current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'table last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'table deleted at',
+    PRIMARY KEY (`table_id`),
+    UNIQUE KEY `uk_sid_tn_del` (`schema_id`, `table_name`, `deleted_at`),
+    KEY `idx_mid` (`metalake_id`),
+    KEY `idx_cid` (`catalog_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'table metadata';
+
+CREATE TABLE IF NOT EXISTS `table_column_version_info` (
+    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'auto increment id',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `catalog_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'catalog id',
+    `schema_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'schema id',
+    `table_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'table id',
+    `table_version` INT UNSIGNED NOT NULL COMMENT 'table version',
+    `column_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'column id',
+    `column_name` VARCHAR(128) NOT NULL COMMENT 'column name',
+    `column_position` INT UNSIGNED NOT NULL COMMENT 'column position, starting from 0',
+    `column_type` TEXT NOT NULL COMMENT 'column type',
+    `column_comment` VARCHAR(256) DEFAULT '' COMMENT 'column comment',
+    `column_nullable` TINYINT(1) NOT NULL DEFAULT 1 COMMENT 'column nullable, 0 is not nullable, 1 is nullable',
+    `column_auto_increment` TINYINT(1) NOT NULL DEFAULT 0 COMMENT 'column auto increment, 0 is not auto increment, 1 is auto increment',
+    `column_default_value` TEXT DEFAULT NULL COMMENT 'column default value',
+    `column_op_type` TINYINT(1) NOT NULL COMMENT 'column operation type, 1 is create, 2 is update, 3 is delete',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'column deleted at',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'column audit info',
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `uk_tid_ver_cid_del` (`table_id`, `table_version`, `column_id`, `deleted_at`),
+    KEY `idx_mid` (`metalake_id`),
+    KEY `idx_cid` (`catalog_id`),
+    KEY `idx_sid` (`schema_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'table column version info';
+
+CREATE TABLE IF NOT EXISTS `fileset_meta` (
+    `fileset_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'fileset id',
+    `fileset_name` VARCHAR(128) NOT NULL COMMENT 'fileset name',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `catalog_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'catalog id',
+    `schema_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'schema id',
+    `type` VARCHAR(64) NOT NULL COMMENT 'fileset type',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'fileset audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'fileset current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'fileset last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'fileset deleted at',
+    PRIMARY KEY (`fileset_id`),
+    UNIQUE KEY `uk_sid_fn_del` (`schema_id`, `fileset_name`, `deleted_at`),
+    KEY `idx_mid` (`metalake_id`),
+    KEY `idx_cid` (`catalog_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'fileset metadata';
+
+CREATE TABLE IF NOT EXISTS `fileset_version_info` (
+    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'auto increment id',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `catalog_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'catalog id',
+    `schema_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'schema id',
+    `fileset_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'fileset id',
+    `version` INT UNSIGNED NOT NULL COMMENT 'fileset info version',
+    `fileset_comment` VARCHAR(256) DEFAULT '' COMMENT 'fileset comment',
+    `properties` MEDIUMTEXT DEFAULT NULL COMMENT 'fileset properties',
+    `storage_location_name` VARCHAR(256) NOT NULL DEFAULT 'default' COMMENT 'fileset storage location name',
+    `storage_location` MEDIUMTEXT NOT NULL COMMENT 'fileset storage location',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'fileset deleted at',
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `uk_fid_ver_sto_del` (`fileset_id`, `version`, `storage_location_name`, `deleted_at`),
+    KEY `idx_mid` (`metalake_id`),
+    KEY `idx_cid` (`catalog_id`),
+    KEY `idx_sid` (`schema_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'fileset version info';
+
+CREATE TABLE IF NOT EXISTS `topic_meta` (
+    `topic_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'topic id',
+    `topic_name` VARCHAR(128) NOT NULL COMMENT 'topic name',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `catalog_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'catalog id',
+    `schema_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'schema id',
+    `comment` VARCHAR(256) DEFAULT '' COMMENT 'topic comment',
+    `properties` MEDIUMTEXT DEFAULT NULL COMMENT 'topic properties',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'topic audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'topic current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'topic last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'topic deleted at',
+    PRIMARY KEY (`topic_id`),
+    UNIQUE KEY `uk_sid_tn_del` (`schema_id`, `topic_name`, `deleted_at`),
+    KEY `idx_mid` (`metalake_id`),
+    KEY `idx_cid` (`catalog_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'topic metadata';
+
+CREATE TABLE IF NOT EXISTS `user_meta` (
+    `user_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'user id',
+    `user_name` VARCHAR(128) NOT NULL COMMENT 'username',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'user audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'user current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'user last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'user deleted at',
+    `role_grants_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'version bumped on any role assignment change for this user',
+    PRIMARY KEY (`user_id`),
+    UNIQUE KEY `uk_mid_us_del` (`metalake_id`, `user_name`, `deleted_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'user metadata';
+
+CREATE TABLE IF NOT EXISTS `role_meta` (
+    `role_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'role id',
+    `role_name` VARCHAR(128) NOT NULL COMMENT 'role name',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `properties` MEDIUMTEXT DEFAULT NULL COMMENT 'schema properties',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'role audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'role current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'role last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'role deleted at',
+    `securable_objects_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'version bumped on any privilege change for this role',
+    PRIMARY KEY (`role_id`),
+    UNIQUE KEY `uk_mid_rn_del` (`metalake_id`, `role_name`, `deleted_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'role metadata';
+
+CREATE TABLE IF NOT EXISTS `role_meta_securable_object` (
+    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'auto increment id',
+    `role_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'role id',
+    `metadata_object_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'The entity id of securable object',
+    `type`  VARCHAR(128) NOT NULL COMMENT 'securable object type',
+    `privilege_names` TEXT(81920) NOT NULL COMMENT 'securable object privilege names',
+    `privilege_conditions` TEXT(81920) NOT NULL COMMENT 'securable object privilege conditions',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'securable object current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'securable object last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'securable object deleted at',
+    PRIMARY KEY (`id`),
+    KEY `idx_obj_rid` (`role_id`),
+    KEY `idx_obj_eid` (`metadata_object_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'securable object meta';
+
+CREATE TABLE IF NOT EXISTS `user_role_rel` (
+    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'auto increment id',
+    `user_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'user id',
+    `role_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'role id',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'relation audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'relation current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'relation last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'relation deleted at',
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `uk_ui_ri_del` (`user_id`, `role_id`, `deleted_at`),
+    KEY `idx_rid` (`role_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'user role relation';
+
+CREATE TABLE IF NOT EXISTS `group_meta` (
+    `group_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'group id',
+    `group_name` VARCHAR(128) NOT NULL COMMENT 'group name',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'group audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'group current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'group last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'group deleted at',
+    `role_grants_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'version bumped on any role assignment change for this group',
+    PRIMARY KEY (`group_id`),
+    UNIQUE KEY `uk_mid_gr_del` (`metalake_id`, `group_name`, `deleted_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'group metadata';
+
+CREATE TABLE IF NOT EXISTS `group_role_rel` (
+    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'auto increment id',
+    `group_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'group id',
+    `role_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'role id',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'relation audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'relation current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'relation last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'relation deleted at',
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `uk_gi_ri_del` (`group_id`, `role_id`, `deleted_at`),
+    KEY `idx_rid` (`group_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'group role relation';
+
+CREATE TABLE IF NOT EXISTS `tag_meta` (
+    `tag_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'tag id',
+    `tag_name` VARCHAR(128) NOT NULL COMMENT 'tag name',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `tag_comment` VARCHAR(256) DEFAULT '' COMMENT 'tag comment',
+    `properties` MEDIUMTEXT DEFAULT NULL COMMENT 'tag properties',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'tag audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'tag current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'tag last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'tag deleted at',
+    PRIMARY KEY (`tag_id`),
+    UNIQUE KEY `uk_mi_tn_del` (`metalake_id`, `tag_name`, `deleted_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'tag metadata';
+
+CREATE TABLE IF NOT EXISTS `tag_relation_meta` (
+    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'auto increment id',
+    `tag_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'tag id',
+    `metadata_object_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metadata object id',
+    `metadata_object_type` VARCHAR(64) NOT NULL COMMENT 'metadata object type',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'tag relation audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'tag relation current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'tag relation last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'tag relation deleted at',
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `uk_ti_mi_mo_del` (`tag_id`, `metadata_object_id`, `metadata_object_type`, `deleted_at`),
+    KEY `idx_tid` (`tag_id`),
+    KEY `idx_mid` (`metadata_object_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'tag metadata object relation';
+
+CREATE TABLE IF NOT EXISTS `owner_meta` (
+    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'auto increment id',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `owner_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'owner id',
+    `owner_type` VARCHAR(64) NOT NULL COMMENT 'owner type',
+    `metadata_object_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metadata object id',
+    `metadata_object_type` VARCHAR(64) NOT NULL COMMENT 'metadata object type',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'owner relation audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'owner relation current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'owner relation last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'owner relation deleted at',
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `uk_ow_me_del` (`owner_id`, `metadata_object_id`, `metadata_object_type`,`deleted_at`),
+    KEY `idx_oid` (`owner_id`),
+    KEY `idx_meid` (`metadata_object_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'owner relation';
+
+CREATE TABLE IF NOT EXISTS `model_meta` (
+    `model_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'model id',
+    `model_name` VARCHAR(128) NOT NULL COMMENT 'model name',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `catalog_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'catalog id',
+    `schema_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'schema id',
+    `model_comment` TEXT DEFAULT NULL COMMENT 'model comment',
+    `model_properties` MEDIUMTEXT DEFAULT NULL COMMENT 'model properties',
+    `model_latest_version` INT UNSIGNED DEFAULT 0 COMMENT 'model latest version',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'model audit info',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'model deleted at',
+    PRIMARY KEY (`model_id`),
+    UNIQUE KEY `uk_sid_mn_del` (`schema_id`, `model_name`, `deleted_at`),
+    KEY `idx_mid` (`metalake_id`),
+    KEY `idx_cid` (`catalog_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'model metadata';
+
+CREATE TABLE IF NOT EXISTS `model_version_info` (
+    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'auto increment id',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `catalog_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'catalog id',
+    `schema_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'schema id',
+    `model_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'model id',
+    `version` INT UNSIGNED NOT NULL COMMENT 'model version',
+    `model_version_comment` TEXT DEFAULT NULL COMMENT 'model version comment',
+    `model_version_properties` MEDIUMTEXT DEFAULT NULL COMMENT 'model version properties',
+    `model_version_uri_name` VARCHAR(256) NOT NULL COMMENT 'model version uri name',
+    `model_version_uri` TEXT NOT NULL COMMENT 'model storage uri',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'model version audit info',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'model version deleted at',
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `uk_mid_ver_uri_del` (`model_id`, `version`, `model_version_uri_name`, `deleted_at`),
+    KEY `idx_mid` (`metalake_id`),
+    KEY `idx_cid` (`catalog_id`),
+    KEY `idx_sid` (`schema_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'model version info';
+
+CREATE TABLE IF NOT EXISTS `model_version_alias_rel` (
+    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'auto increment id',
+    `model_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'model id',
+    `model_version` INT UNSIGNED NOT NULL COMMENT 'model version',
+    `model_version_alias` VARCHAR(128) NOT NULL COMMENT 'model version alias',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'model version alias deleted at',
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `uk_mi_mva_del` (`model_id`, `model_version_alias`, `deleted_at`),
+    KEY `idx_mva` (`model_version_alias`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'model_version_alias_rel';
+
+CREATE TABLE IF NOT EXISTS `policy_meta` (
+    `policy_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'policy id',
+    `policy_name` VARCHAR(128) NOT NULL COMMENT 'policy name',
+    `policy_type` VARCHAR(64) NOT NULL COMMENT 'policy type',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'policy audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'policy current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'policy last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'policy deleted at',
+    PRIMARY KEY (`policy_id`),
+    UNIQUE KEY `uk_mi_pn_del` (`metalake_id`, `policy_name`, `deleted_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'policy metadata';
+
+CREATE TABLE IF NOT EXISTS `policy_version_info` (
+    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'auto increment id',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `policy_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'policy id',
+    `version` INT UNSIGNED NOT NULL COMMENT 'policy info version',
+    `policy_comment` TEXT DEFAULT NULL COMMENT 'policy info comment',
+    `enabled` TINYINT(1) DEFAULT 1 COMMENT 'whether the policy is enabled, 0 is disabled, 1 is enabled',
+    `content` MEDIUMTEXT DEFAULT NULL COMMENT 'policy content',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'policy deleted at',
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `uk_pod_ver_del` (`policy_id`, `version`, `deleted_at`),
+    KEY `idx_mid` (`metalake_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'policy version info';
+
+CREATE TABLE IF NOT EXISTS `policy_relation_meta` (
+    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'auto increment id',
+    `policy_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'policy id',
+    `metadata_object_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metadata object id',
+    `metadata_object_type` VARCHAR(64) NOT NULL COMMENT 'metadata object type',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'policy relation audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'policy relation current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'policy relation last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'policy relation deleted at',
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `uk_pi_mi_mo_del` (`policy_id`, `metadata_object_id`, `metadata_object_type`, `deleted_at`),
+    KEY `idx_pid` (`policy_id`),
+    KEY `idx_mid` (`metadata_object_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'policy metadata object relation';
+
+CREATE TABLE IF NOT EXISTS `statistic_meta` (
+    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'auto increment id',
+    `statistic_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'statistic id',
+    `statistic_name` VARCHAR(128) NOT NULL COMMENT 'statistic name',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `statistic_value` MEDIUMTEXT NOT NULL COMMENT 'statistic value',
+    `metadata_object_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metadata object id',
+    `metadata_object_type` VARCHAR(64) NOT NULL COMMENT 'metadata object type',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'statistic audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'statistic current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'statistic last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'statistic deleted at',
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `uk_si_mi_mo_del` (`statistic_name`, `metadata_object_id`, `deleted_at`),
+    KEY `idx_stid` (`statistic_id`),
+    KEY `idx_moid` (`metadata_object_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'statistic metadata';
+
+CREATE TABLE IF NOT EXISTS `job_template_meta` (
+    `job_template_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'job template id',
+    `job_template_name` VARCHAR(128) NOT NULL COMMENT 'job template name',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `job_template_comment` TEXT DEFAULT NULL COMMENT 'job template comment',
+    `job_template_content` MEDIUMTEXT NOT NULL COMMENT 'job template content',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'job template audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'job template current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'job template last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'job template deleted at',
+    PRIMARY KEY (`job_template_id`),
+    UNIQUE KEY `uk_mid_jtn_del` (`metalake_id`, `job_template_name`, `deleted_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'job template metadata';
+
+CREATE TABLE IF NOT EXISTS `job_run_meta` (
+    `job_run_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'job run id',
+    `job_template_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'job template id',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `job_execution_id` varchar(256) NOT NULL COMMENT 'job execution id',
+    `job_run_status` varchar(64) NOT NULL COMMENT 'job run status',
+    `job_finished_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'job finished at',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'job run audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'job run current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'job run last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'job run deleted at',
+    PRIMARY KEY (`job_run_id`),
+    UNIQUE KEY `uk_mid_jei_del` (`metalake_id`, `job_execution_id`, `deleted_at`),
+    KEY `idx_job_template_id` (`job_template_id`),
+    KEY `idx_job_execution_id` (`job_execution_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'job run metadata';
+
+CREATE TABLE IF NOT EXISTS `table_version_info` (
+    `table_id`        BIGINT(20) UNSIGNED NOT NULL COMMENT 'table id',
+    `format`          VARCHAR(64) COMMENT 'table format, such as Lance, Iceberg and so on, it will be null if it is not a lakehouse table',
+    `properties`      MEDIUMTEXT DEFAULT NULL COMMENT 'table properties',
+    `partitioning`  MEDIUMTEXT DEFAULT NULL COMMENT 'table partition info',
+    `distribution` MEDIUMTEXT DEFAULT NULL COMMENT 'table distribution info',
+    `sort_orders` MEDIUMTEXT DEFAULT NULL COMMENT 'table sort order info',
+    `indexes`      MEDIUMTEXT DEFAULT NULL COMMENT 'table index info',
+    `comment`   MEDIUMTEXT DEFAULT NULL COMMENT 'table comment',
+    `version` BIGINT(20) UNSIGNED COMMENT 'table current version',
+    `deleted_at`      BIGINT(20) UNSIGNED DEFAULT 0 COMMENT 'table deletion timestamp, 0 means not deleted',
+    UNIQUE KEY `uk_table_id_version_deleted_at` (`table_id`, `version`, `deleted_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'table detail information including format, location, properties, partition, distribution, sort order, index and so on';
+
+CREATE TABLE IF NOT EXISTS `function_meta` (
+    `function_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'function id',
+    `function_name` VARCHAR(128) NOT NULL COMMENT 'function name',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `catalog_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'catalog id',
+    `schema_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'schema id',
+    `function_type` VARCHAR(64) NOT NULL COMMENT 'function type',
+    `deterministic` TINYINT(1) DEFAULT 1 COMMENT 'whether the function result is deterministic',
+    `function_current_version` INT UNSIGNED DEFAULT 1 COMMENT 'function current version',
+    `function_latest_version` INT UNSIGNED DEFAULT 1 COMMENT 'function latest version',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'function audit info',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'function deleted at',
+    PRIMARY KEY (`function_id`),
+    UNIQUE KEY `uk_sid_fn_del` (`schema_id`, `function_name`, `deleted_at`),
+    KEY `idx_mid` (`metalake_id`),
+    KEY `idx_cid` (`catalog_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'function metadata';
+
+CREATE TABLE IF NOT EXISTS `function_version_info` (
+    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'auto increment id',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `catalog_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'catalog id',
+    `schema_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'schema id',
+    `function_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'function id',
+    `version` INT UNSIGNED NOT NULL COMMENT 'function version',
+    `function_comment` TEXT DEFAULT NULL COMMENT 'function version comment',
+    `definitions` MEDIUMTEXT NOT NULL COMMENT 'function definitions details',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'function version audit info',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'function version deleted at',
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `uk_fid_ver_del` (`function_id`, `version`, `deleted_at`),
+    KEY `idx_mid` (`metalake_id`),
+    KEY `idx_cid` (`catalog_id`),
+    KEY `idx_sid` (`schema_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'function version info';
+
+CREATE TABLE IF NOT EXISTS `view_meta` (
+    `view_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'view id',
+    `view_name` VARCHAR(128) NOT NULL COMMENT 'view name',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `catalog_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'catalog id',
+    `schema_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'schema id',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'view current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'view last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'view deleted at',
+    PRIMARY KEY (`view_id`),
+    UNIQUE KEY `uk_sid_vn_del` (`schema_id`, `view_name`, `deleted_at`),
+    KEY `idx_vemid` (`metalake_id`),
+    KEY `idx_vecid` (`catalog_id`)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'view metadata';
+
+-- This schema extends version 1.1.0 with partition statistics storage support
+-- The partition_statistic_meta table stores partition-level statistics for tables
+
+CREATE TABLE IF NOT EXISTS `partition_statistic_meta` (
+    `table_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'table id from table_meta',
+    `partition_name` VARCHAR(1024) NOT NULL COMMENT 'partition name',
+    `statistic_name` VARCHAR(128) NOT NULL COMMENT 'statistic name',
+    `statistic_value` MEDIUMTEXT NOT NULL COMMENT 'statistic value as JSON',
+    `audit_info` TEXT NOT NULL COMMENT 'audit information as JSON',
+    `created_at` BIGINT(20) UNSIGNED NOT NULL COMMENT 'creation timestamp in milliseconds',
+    `updated_at` BIGINT(20) UNSIGNED NOT NULL COMMENT 'last update timestamp in milliseconds',
+    PRIMARY KEY (`table_id`, `partition_name`(255), `statistic_name`),
+    KEY `idx_table_partition` (`table_id`, `partition_name`(255))
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'partition statistics metadata';
+
+-- Optimizer metrics schema
+CREATE TABLE IF NOT EXISTS `table_metrics` (
+    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'auto increment id',
+    `table_identifier` VARCHAR(1024) NOT NULL COMMENT 'normalized table identifier',
+    `metric_name` VARCHAR(1024) NOT NULL COMMENT 'metric name',
+    `table_partition` VARCHAR(1024) DEFAULT NULL COMMENT 'normalized partition identifier',
+    `metric_ts` BIGINT(20) NOT NULL COMMENT 'metric timestamp in epoch seconds',
+    `metric_value` VARCHAR(1024) NOT NULL COMMENT 'metric value payload',
+    PRIMARY KEY (`id`),
+    KEY `idx_table_metrics_metric_ts` (`metric_ts`),
+    KEY `idx_table_metrics_composite` (`table_identifier`(255), `table_partition`(255), `metric_ts`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'optimizer table metrics';
+
+CREATE TABLE IF NOT EXISTS `job_metrics` (
+    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'auto increment id',
+    `job_identifier` VARCHAR(1024) NOT NULL COMMENT 'normalized job identifier',
+    `metric_name` VARCHAR(1024) NOT NULL COMMENT 'metric name',
+    `metric_ts` BIGINT(20) NOT NULL COMMENT 'metric timestamp in epoch seconds',
+    `metric_value` VARCHAR(1024) NOT NULL COMMENT 'metric value payload',
+    PRIMARY KEY (`id`),
+    KEY `idx_job_metrics_metric_ts` (`metric_ts`),
+    KEY `idx_job_metrics_identifier_metric_ts` (`job_identifier`(255), `metric_ts`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'optimizer job metrics';

--- a/scripts/mysql/upgrade-1.2.0-to-1.3.0-mysql.sql
+++ b/scripts/mysql/upgrade-1.2.0-to-1.3.0-mysql.sql
@@ -1,0 +1,32 @@
+--
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file--
+--  distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"). You may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--  http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+--
+
+-- Add version columns for Phase 2 version-validated auth cache
+
+ALTER TABLE `role_meta`
+    ADD COLUMN `securable_objects_version` INT UNSIGNED NOT NULL DEFAULT 1
+    COMMENT 'Incremented atomically with any privilege grant/revoke for this role';
+
+ALTER TABLE `user_meta`
+    ADD COLUMN `role_grants_version` INT UNSIGNED NOT NULL DEFAULT 1
+    COMMENT 'Incremented atomically with any role assignment/revocation for this user';
+
+ALTER TABLE `group_meta`
+    ADD COLUMN `role_grants_version` INT UNSIGNED NOT NULL DEFAULT 1
+    COMMENT 'Incremented atomically with any role assignment/revocation for this group';

--- a/scripts/postgresql/schema-1.3.0-postgresql.sql
+++ b/scripts/postgresql/schema-1.3.0-postgresql.sql
@@ -1,0 +1,931 @@
+--
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file--
+--  distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"). You may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--  http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+--
+
+-- Note: Database and schema creation is not included in this script. Please create the database and
+-- schema before running this script. for example in psql:
+-- CREATE DATABASE example_db;
+-- \c example_db
+-- CREATE SCHEMA example_schema;
+-- set search_path to example_schema;
+
+CREATE TABLE IF NOT EXISTS metalake_meta (
+    metalake_id BIGINT NOT NULL,
+    metalake_name VARCHAR(128) NOT NULL,
+    metalake_comment VARCHAR(256) DEFAULT '',
+    properties TEXT DEFAULT NULL,
+    audit_info TEXT NOT NULL,
+    schema_version TEXT NOT NULL,
+    current_version INT NOT NULL DEFAULT 1,
+    last_version INT NOT NULL DEFAULT 1,
+    deleted_at BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (metalake_id),
+    UNIQUE (metalake_name, deleted_at)
+);
+COMMENT ON TABLE metalake_meta IS 'metalake metadata';
+
+COMMENT ON COLUMN metalake_meta.metalake_id IS 'metalake id';
+COMMENT ON COLUMN metalake_meta.metalake_name IS 'metalake name';
+COMMENT ON COLUMN metalake_meta.metalake_comment IS 'metalake comment';
+COMMENT ON COLUMN metalake_meta.properties IS 'metalake properties';
+COMMENT ON COLUMN metalake_meta.audit_info IS 'metalake audit info';
+COMMENT ON COLUMN metalake_meta.schema_version IS 'metalake schema version info';
+COMMENT ON COLUMN metalake_meta.current_version IS 'metalake current version';
+COMMENT ON COLUMN metalake_meta.last_version IS 'metalake last version';
+COMMENT ON COLUMN metalake_meta.deleted_at IS 'metalake deleted at';
+
+
+CREATE TABLE IF NOT EXISTS catalog_meta (
+    catalog_id BIGINT NOT NULL,
+    catalog_name VARCHAR(128) NOT NULL,
+    metalake_id BIGINT NOT NULL,
+    type VARCHAR(64) NOT NULL,
+    provider VARCHAR(64) NOT NULL,
+    catalog_comment VARCHAR(256) DEFAULT '',
+    properties TEXT DEFAULT NULL,
+    audit_info TEXT NOT NULL,
+    current_version INT NOT NULL DEFAULT 1,
+    last_version INT NOT NULL DEFAULT 1,
+    deleted_at BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (catalog_id),
+    UNIQUE (metalake_id, catalog_name, deleted_at)
+);
+
+COMMENT ON TABLE catalog_meta IS 'catalog metadata';
+
+COMMENT ON COLUMN catalog_meta.catalog_id IS 'catalog id';
+COMMENT ON COLUMN catalog_meta.catalog_name IS 'catalog name';
+COMMENT ON COLUMN catalog_meta.metalake_id IS 'metalake id';
+COMMENT ON COLUMN catalog_meta.type IS 'catalog type';
+COMMENT ON COLUMN catalog_meta.provider IS 'catalog provider';
+COMMENT ON COLUMN catalog_meta.catalog_comment IS 'catalog comment';
+COMMENT ON COLUMN catalog_meta.properties IS 'catalog properties';
+COMMENT ON COLUMN catalog_meta.audit_info IS 'catalog audit info';
+COMMENT ON COLUMN catalog_meta.current_version IS 'catalog current version';
+COMMENT ON COLUMN catalog_meta.last_version IS 'catalog last version';
+COMMENT ON COLUMN catalog_meta.deleted_at IS 'catalog deleted at';
+
+
+CREATE TABLE IF NOT EXISTS schema_meta (
+    schema_id BIGINT NOT NULL,
+    schema_name VARCHAR(128) NOT NULL,
+    metalake_id BIGINT NOT NULL,
+    catalog_id BIGINT NOT NULL,
+    schema_comment VARCHAR(256) DEFAULT '',
+    properties TEXT DEFAULT NULL,
+    audit_info TEXT NOT NULL,
+    current_version INT NOT NULL DEFAULT 1,
+    last_version INT NOT NULL DEFAULT 1,
+    deleted_at BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (schema_id),
+    UNIQUE (catalog_id, schema_name, deleted_at)
+);
+
+CREATE INDEX IF NOT EXISTS schema_meta_idx_metalake_id ON schema_meta (metalake_id);
+COMMENT ON TABLE schema_meta IS 'schema metadata';
+
+COMMENT ON COLUMN schema_meta.schema_id IS 'schema id';
+COMMENT ON COLUMN schema_meta.schema_name IS 'schema name';
+COMMENT ON COLUMN schema_meta.metalake_id IS 'metalake id';
+COMMENT ON COLUMN schema_meta.catalog_id IS 'catalog id';
+COMMENT ON COLUMN schema_meta.schema_comment IS 'schema comment';
+COMMENT ON COLUMN schema_meta.properties IS 'schema properties';
+COMMENT ON COLUMN schema_meta.audit_info IS 'schema audit info';
+COMMENT ON COLUMN schema_meta.current_version IS 'schema current version';
+COMMENT ON COLUMN schema_meta.last_version IS 'schema last version';
+COMMENT ON COLUMN schema_meta.deleted_at IS 'schema deleted at';
+
+
+CREATE TABLE IF NOT EXISTS table_meta (
+    table_id BIGINT NOT NULL,
+    table_name VARCHAR(128) NOT NULL,
+    metalake_id BIGINT NOT NULL,
+    catalog_id BIGINT NOT NULL,
+    schema_id BIGINT NOT NULL,
+    audit_info TEXT NOT NULL,
+    current_version INT NOT NULL DEFAULT 1,
+    last_version INT NOT NULL DEFAULT 1,
+    deleted_at BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (table_id),
+    UNIQUE (schema_id, table_name, deleted_at)
+);
+
+CREATE INDEX IF NOT EXISTS table_meta_idx_metalake_id ON table_meta (metalake_id);
+CREATE INDEX IF NOT EXISTS table_meta_idx_catalog_id ON table_meta (catalog_id);
+COMMENT ON TABLE table_meta IS 'table metadata';
+
+COMMENT ON COLUMN table_meta.table_id IS 'table id';
+COMMENT ON COLUMN table_meta.table_name IS 'table name';
+COMMENT ON COLUMN table_meta.metalake_id IS 'metalake id';
+COMMENT ON COLUMN table_meta.catalog_id IS 'catalog id';
+COMMENT ON COLUMN table_meta.schema_id IS 'schema id';
+COMMENT ON COLUMN table_meta.audit_info IS 'table audit info';
+COMMENT ON COLUMN table_meta.current_version IS 'table current version';
+COMMENT ON COLUMN table_meta.last_version IS 'table last version';
+COMMENT ON COLUMN table_meta.deleted_at IS 'table deleted at';
+
+CREATE TABLE IF NOT EXISTS table_column_version_info (
+    id BIGINT NOT NULL GENERATED BY DEFAULT AS IDENTITY,
+    metalake_id BIGINT NOT NULL,
+    catalog_id BIGINT NOT NULL,
+    schema_id BIGINT NOT NULL,
+    table_id BIGINT NOT NULL,
+    table_version INT NOT NULL,
+    column_id BIGINT NOT NULL,
+    column_name VARCHAR(128) NOT NULL,
+    column_position INT NOT NULL,
+    column_type TEXT NOT NULL,
+    column_comment VARCHAR(256) DEFAULT '',
+    column_nullable SMALLINT NOT NULL DEFAULT 1,
+    column_auto_increment SMALLINT NOT NULL DEFAULT 0,
+    column_default_value TEXT DEFAULT NULL,
+    column_op_type SMALLINT NOT NULL,
+    deleted_at BIGINT NOT NULL DEFAULT 0,
+    audit_info TEXT NOT NULL,
+    PRIMARY KEY (id),
+    UNIQUE (table_id, table_version, column_id, deleted_at)
+);
+CREATE INDEX table_column_version_info_idx_mid ON table_column_version_info (metalake_id);
+CREATE INDEX table_column_version_info_idx_cid ON table_column_version_info (catalog_id);
+CREATE INDEX table_column_version_info_idx_sid ON table_column_version_info (schema_id);
+COMMENT ON TABLE table_column_version_info IS 'table column version information';
+
+COMMENT ON COLUMN table_column_version_info.id IS 'auto increment id';
+COMMENT ON COLUMN table_column_version_info.metalake_id IS 'metalake id';
+COMMENT ON COLUMN table_column_version_info.catalog_id IS 'catalog id';
+COMMENT ON COLUMN table_column_version_info.schema_id IS 'schema id';
+COMMENT ON COLUMN table_column_version_info.table_id IS 'table id';
+COMMENT ON COLUMN table_column_version_info.table_version IS 'table version';
+COMMENT ON COLUMN table_column_version_info.column_id IS 'column id';
+COMMENT ON COLUMN table_column_version_info.column_name IS 'column name';
+COMMENT ON COLUMN table_column_version_info.column_position IS 'column position, starting from 0';
+COMMENT ON COLUMN table_column_version_info.column_type IS 'column type';
+COMMENT ON COLUMN table_column_version_info.column_comment IS 'column comment';
+COMMENT ON COLUMN table_column_version_info.column_nullable IS 'column nullable, 0 is not nullable, 1 is nullable';
+COMMENT ON COLUMN table_column_version_info.column_auto_increment IS 'column auto increment, 0 is not auto increment, 1 is auto increment';
+COMMENT ON COLUMN table_column_version_info.column_default_value IS 'column default value';
+COMMENT ON COLUMN table_column_version_info.column_op_type IS 'column operation type, 1 is create, 2 is update, 3 is delete';
+COMMENT ON COLUMN table_column_version_info.deleted_at IS 'column deleted at';
+COMMENT ON COLUMN table_column_version_info.audit_info IS 'column audit info';
+
+
+CREATE TABLE IF NOT EXISTS fileset_meta (
+    fileset_id BIGINT NOT NULL,
+    fileset_name VARCHAR(128) NOT NULL,
+    metalake_id BIGINT NOT NULL,
+    catalog_id BIGINT NOT NULL,
+    schema_id BIGINT NOT NULL,
+    type VARCHAR(64) NOT NULL,
+    audit_info TEXT NOT NULL,
+    current_version INT NOT NULL DEFAULT 1,
+    last_version INT NOT NULL DEFAULT 1,
+    deleted_at BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (fileset_id),
+    UNIQUE (schema_id, fileset_name, deleted_at)
+);
+
+CREATE INDEX IF NOT EXISTS fileset_meta_idx_metalake_id ON fileset_meta (metalake_id);
+CREATE INDEX IF NOT EXISTS fileset_meta_idx_catalog_id ON fileset_meta (catalog_id);
+COMMENT ON TABLE fileset_meta IS 'fileset metadata';
+
+COMMENT ON COLUMN fileset_meta.fileset_id IS 'fileset id';
+COMMENT ON COLUMN fileset_meta.fileset_name IS 'fileset name';
+COMMENT ON COLUMN fileset_meta.metalake_id IS 'metalake id';
+COMMENT ON COLUMN fileset_meta.catalog_id IS 'catalog id';
+COMMENT ON COLUMN fileset_meta.schema_id IS 'schema id';
+COMMENT ON COLUMN fileset_meta.type IS 'fileset type';
+COMMENT ON COLUMN fileset_meta.audit_info IS 'fileset audit info';
+COMMENT ON COLUMN fileset_meta.current_version IS 'fileset current version';
+COMMENT ON COLUMN fileset_meta.last_version IS 'fileset last version';
+COMMENT ON COLUMN fileset_meta.deleted_at IS 'fileset deleted at';
+
+
+CREATE TABLE IF NOT EXISTS fileset_version_info (
+    id BIGINT NOT NULL GENERATED BY DEFAULT AS IDENTITY,
+    metalake_id BIGINT NOT NULL,
+    catalog_id BIGINT NOT NULL,
+    schema_id BIGINT NOT NULL,
+    fileset_id BIGINT NOT NULL,
+    version INT NOT NULL,
+    fileset_comment VARCHAR(256) DEFAULT '',
+    properties TEXT DEFAULT NULL,
+    storage_location_name VARCHAR(256) NOT NULL DEFAULT 'default',
+    storage_location TEXT NOT NULL,
+    deleted_at BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (id),
+    UNIQUE (fileset_id, version, storage_location_name, deleted_at)
+);
+
+CREATE INDEX IF NOT EXISTS fileset_version_info_idx_metalake_id ON fileset_version_info (metalake_id);
+CREATE INDEX IF NOT EXISTS fileset_version_info_idx_idx_catalog_id ON fileset_version_info (catalog_id);
+CREATE INDEX IF NOT EXISTS fileset_version_info_idx_idx_schema_id ON fileset_version_info (schema_id);
+COMMENT ON TABLE fileset_version_info IS 'fileset version information';
+
+COMMENT ON COLUMN fileset_version_info.id IS 'auto increment id';
+COMMENT ON COLUMN fileset_version_info.metalake_id IS 'metalake id';
+COMMENT ON COLUMN fileset_version_info.catalog_id IS 'catalog id';
+COMMENT ON COLUMN fileset_version_info.schema_id IS 'schema id';
+COMMENT ON COLUMN fileset_version_info.fileset_id IS 'fileset id';
+COMMENT ON COLUMN fileset_version_info.version IS 'fileset info version';
+COMMENT ON COLUMN fileset_version_info.fileset_comment IS 'fileset comment';
+COMMENT ON COLUMN fileset_version_info.properties IS 'fileset properties';
+COMMENT ON COLUMN fileset_version_info.storage_location_name IS 'fileset storage location name';
+COMMENT ON COLUMN fileset_version_info.storage_location IS 'fileset storage location';
+COMMENT ON COLUMN fileset_version_info.deleted_at IS 'fileset deleted at';
+
+
+CREATE TABLE IF NOT EXISTS topic_meta (
+    topic_id BIGINT NOT NULL,
+    topic_name VARCHAR(128) NOT NULL,
+    metalake_id BIGINT NOT NULL,
+    catalog_id BIGINT NOT NULL,
+    schema_id BIGINT NOT NULL,
+    comment VARCHAR(256) DEFAULT '',
+    properties TEXT DEFAULT NULL,
+    audit_info TEXT NOT NULL,
+    current_version INT NOT NULL DEFAULT 1,
+    last_version INT NOT NULL DEFAULT 1,
+    deleted_at BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (topic_id),
+    UNIQUE (schema_id, topic_name, deleted_at)
+);
+
+CREATE INDEX IF NOT EXISTS topic_meta_idx_metalake_id ON topic_meta (metalake_id);
+CREATE INDEX IF NOT EXISTS topic_meta_idx_catalog_id ON topic_meta (catalog_id);
+COMMENT ON TABLE topic_meta IS 'topic metadata';
+
+COMMENT ON COLUMN topic_meta.topic_id IS 'topic id';
+COMMENT ON COLUMN topic_meta.topic_name IS 'topic name';
+COMMENT ON COLUMN topic_meta.metalake_id IS 'metalake id';
+COMMENT ON COLUMN topic_meta.catalog_id IS 'catalog id';
+COMMENT ON COLUMN topic_meta.schema_id IS 'schema id';
+COMMENT ON COLUMN topic_meta.comment IS 'topic comment';
+COMMENT ON COLUMN topic_meta.properties IS 'topic properties';
+COMMENT ON COLUMN topic_meta.audit_info IS 'topic audit info';
+COMMENT ON COLUMN topic_meta.current_version IS 'topic current version';
+COMMENT ON COLUMN topic_meta.last_version IS 'topic last version';
+COMMENT ON COLUMN topic_meta.deleted_at IS 'topic deleted at';
+
+
+CREATE TABLE IF NOT EXISTS user_meta (
+    user_id BIGINT NOT NULL,
+    user_name VARCHAR(128) NOT NULL,
+    metalake_id BIGINT NOT NULL,
+    audit_info TEXT NOT NULL,
+    current_version INT NOT NULL DEFAULT 1,
+    last_version INT NOT NULL DEFAULT 1,
+    deleted_at BIGINT NOT NULL DEFAULT 0,
+    role_grants_version INT NOT NULL DEFAULT 1,
+    PRIMARY KEY (user_id),
+    UNIQUE (metalake_id, user_name, deleted_at)
+);
+COMMENT ON TABLE user_meta IS 'user metadata';
+
+COMMENT ON COLUMN user_meta.user_id IS 'user id';
+COMMENT ON COLUMN user_meta.user_name IS 'username';
+COMMENT ON COLUMN user_meta.metalake_id IS 'metalake id';
+COMMENT ON COLUMN user_meta.audit_info IS 'user audit info';
+COMMENT ON COLUMN user_meta.current_version IS 'user current version';
+COMMENT ON COLUMN user_meta.last_version IS 'user last version';
+COMMENT ON COLUMN user_meta.deleted_at IS 'user deleted at';
+COMMENT ON COLUMN user_meta.role_grants_version IS 'version bumped on any role assignment change for this user';
+
+CREATE TABLE IF NOT EXISTS role_meta (
+    role_id BIGINT NOT NULL,
+    role_name VARCHAR(128) NOT NULL,
+    metalake_id BIGINT NOT NULL,
+    properties TEXT DEFAULT NULL,
+    audit_info TEXT NOT NULL,
+    current_version INT NOT NULL DEFAULT 1,
+    last_version INT NOT NULL DEFAULT 1,
+    deleted_at BIGINT NOT NULL DEFAULT 0,
+    securable_objects_version INT NOT NULL DEFAULT 1,
+    PRIMARY KEY (role_id),
+    UNIQUE (metalake_id, role_name, deleted_at)
+);
+
+COMMENT ON TABLE role_meta IS 'role metadata';
+
+COMMENT ON COLUMN role_meta.role_id IS 'role id';
+COMMENT ON COLUMN role_meta.role_name IS 'role name';
+COMMENT ON COLUMN role_meta.metalake_id IS 'metalake id';
+COMMENT ON COLUMN role_meta.properties IS 'role properties';
+COMMENT ON COLUMN role_meta.audit_info IS 'role audit info';
+COMMENT ON COLUMN role_meta.current_version IS 'role current version';
+COMMENT ON COLUMN role_meta.last_version IS 'role last version';
+COMMENT ON COLUMN role_meta.deleted_at IS 'role deleted at';
+COMMENT ON COLUMN role_meta.securable_objects_version IS 'version bumped on any privilege change for this role';
+
+
+CREATE TABLE IF NOT EXISTS role_meta_securable_object (
+    id BIGINT NOT NULL GENERATED BY DEFAULT AS IDENTITY,
+    role_id BIGINT NOT NULL,
+    metadata_object_id BIGINT NOT NULL,
+    type  VARCHAR(128) NOT NULL,
+    privilege_names VARCHAR(81920) NOT NULL,
+    privilege_conditions VARCHAR(81920) NOT NULL,
+    current_version INT NOT NULL DEFAULT 1,
+    last_version INT NOT NULL DEFAULT 1,
+    deleted_at BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (id)
+);
+
+CREATE INDEX IF NOT EXISTS role_meta_securable_object_idx_role_id ON role_meta_securable_object (role_id);
+COMMENT ON TABLE role_meta_securable_object IS 'role to securable object relation metadata';
+
+COMMENT ON COLUMN role_meta_securable_object.id IS 'auto increment id';
+COMMENT ON COLUMN role_meta_securable_object.role_id IS 'role id';
+COMMENT ON COLUMN role_meta_securable_object.metadata_object_id IS 'The entity id of securable object';
+COMMENT ON COLUMN role_meta_securable_object.type IS 'securable object type';
+COMMENT ON COLUMN role_meta_securable_object.privilege_names IS 'securable object privilege names';
+COMMENT ON COLUMN role_meta_securable_object.privilege_conditions IS 'securable object privilege conditions';
+COMMENT ON COLUMN role_meta_securable_object.current_version IS 'securable object current version';
+COMMENT ON COLUMN role_meta_securable_object.last_version IS 'securable object last version';
+COMMENT ON COLUMN role_meta_securable_object.deleted_at IS 'securable object deleted at';
+
+
+CREATE TABLE IF NOT EXISTS user_role_rel (
+    id BIGINT NOT NULL GENERATED BY DEFAULT AS IDENTITY,
+    user_id BIGINT NOT NULL,
+    role_id BIGINT NOT NULL,
+    audit_info TEXT NOT NULL,
+    current_version INT NOT NULL DEFAULT 1,
+    last_version INT NOT NULL DEFAULT 1,
+    deleted_at BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (id),
+    UNIQUE (user_id, role_id, deleted_at)
+);
+
+CREATE INDEX IF NOT EXISTS user_role_rel_idx_user_id ON user_role_rel (user_id);
+COMMENT ON TABLE user_role_rel IS 'user role relation metadata';
+
+COMMENT ON COLUMN user_role_rel.id IS 'auto increment id';
+COMMENT ON COLUMN user_role_rel.user_id IS 'user id';
+COMMENT ON COLUMN user_role_rel.role_id IS 'role id';
+COMMENT ON COLUMN user_role_rel.audit_info IS 'relation audit info';
+COMMENT ON COLUMN user_role_rel.current_version IS 'relation current version';
+COMMENT ON COLUMN user_role_rel.last_version IS 'relation last version';
+COMMENT ON COLUMN user_role_rel.deleted_at IS 'relation deleted at';
+
+
+CREATE TABLE IF NOT EXISTS group_meta (
+    group_id BIGINT NOT NULL,
+    group_name VARCHAR(128) NOT NULL,
+    metalake_id BIGINT NOT NULL,
+    audit_info TEXT NOT NULL,
+    current_version INT NOT NULL DEFAULT 1,
+    last_version INT NOT NULL DEFAULT 1,
+    deleted_at BIGINT NOT NULL DEFAULT 0,
+    role_grants_version INT NOT NULL DEFAULT 1,
+    PRIMARY KEY (group_id),
+    UNIQUE (metalake_id, group_name, deleted_at)
+);
+COMMENT ON TABLE group_meta IS 'group metadata';
+
+COMMENT ON COLUMN group_meta.group_id IS 'group id';
+COMMENT ON COLUMN group_meta.group_name IS 'group name';
+COMMENT ON COLUMN group_meta.metalake_id IS 'metalake id';
+COMMENT ON COLUMN group_meta.audit_info IS 'group audit info';
+COMMENT ON COLUMN group_meta.current_version IS 'group current version';
+COMMENT ON COLUMN group_meta.last_version IS 'group last version';
+COMMENT ON COLUMN group_meta.deleted_at IS 'group deleted at';
+COMMENT ON COLUMN group_meta.role_grants_version IS 'version bumped on any role assignment change for this group';
+
+
+CREATE TABLE IF NOT EXISTS group_role_rel (
+    id BIGSERIAL NOT NULL,
+    group_id BIGINT NOT NULL,
+    role_id BIGINT NOT NULL,
+    audit_info TEXT NOT NULL,
+    current_version INT NOT NULL DEFAULT 1,
+    last_version INT NOT NULL DEFAULT 1,
+    deleted_at BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (id),
+    UNIQUE (group_id, role_id, deleted_at)
+);
+
+CREATE INDEX IF NOT EXISTS group_role_rel_idx_group_id ON group_role_rel (group_id);
+COMMENT ON TABLE group_role_rel IS 'relation between group and role';
+COMMENT ON COLUMN group_role_rel.id IS 'auto increment id';
+COMMENT ON COLUMN group_role_rel.group_id IS 'group id';
+COMMENT ON COLUMN group_role_rel.role_id IS 'role id';
+COMMENT ON COLUMN group_role_rel.audit_info IS 'relation audit info';
+COMMENT ON COLUMN group_role_rel.current_version IS 'relation current version';
+COMMENT ON COLUMN group_role_rel.last_version IS 'relation last version';
+COMMENT ON COLUMN group_role_rel.deleted_at IS 'relation deleted at';
+
+CREATE TABLE IF NOT EXISTS tag_meta (
+    tag_id BIGINT NOT NULL,
+    tag_name VARCHAR(128) NOT NULL,
+    metalake_id BIGINT NOT NULL,
+    tag_comment VARCHAR(256) DEFAULT '',
+    properties TEXT DEFAULT NULL,
+    audit_info TEXT NOT NULL,
+    current_version INT NOT NULL DEFAULT 1,
+    last_version INT NOT NULL DEFAULT 1,
+    deleted_at BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (tag_id),
+    UNIQUE (metalake_id, tag_name, deleted_at)
+);
+
+COMMENT ON TABLE tag_meta IS 'tag metadata';
+
+COMMENT ON COLUMN tag_meta.tag_id IS 'tag id';
+COMMENT ON COLUMN tag_meta.tag_name IS 'tag name';
+COMMENT ON COLUMN tag_meta.metalake_id IS 'metalake id';
+COMMENT ON COLUMN tag_meta.tag_comment IS 'tag comment';
+COMMENT ON COLUMN tag_meta.properties IS 'tag properties';
+COMMENT ON COLUMN tag_meta.audit_info IS 'tag audit info';
+
+
+CREATE TABLE IF NOT EXISTS tag_relation_meta (
+    id BIGINT GENERATED BY DEFAULT AS IDENTITY,
+    tag_id BIGINT NOT NULL,
+    metadata_object_id BIGINT NOT NULL,
+    metadata_object_type VARCHAR(64) NOT NULL,
+    audit_info TEXT NOT NULL,
+    current_version INT NOT NULL DEFAULT 1,
+    last_version INT NOT NULL DEFAULT 1,
+    deleted_at BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (id),
+    UNIQUE (tag_id, metadata_object_id, metadata_object_type, deleted_at)
+);
+
+CREATE INDEX IF NOT EXISTS tag_relation_meta_idx_tag_id ON tag_relation_meta (tag_id);
+CREATE INDEX IF NOT EXISTS tag_relation_meta_idx_metadata_object_id ON tag_relation_meta (metadata_object_id);
+COMMENT ON TABLE tag_relation_meta IS 'tag metadata object relation';
+COMMENT ON COLUMN tag_relation_meta.id IS 'auto increment id';
+COMMENT ON COLUMN tag_relation_meta.tag_id IS 'tag id';
+COMMENT ON COLUMN tag_relation_meta.metadata_object_id IS 'metadata object id';
+COMMENT ON COLUMN tag_relation_meta.metadata_object_type IS 'metadata object type';
+COMMENT ON COLUMN tag_relation_meta.audit_info IS 'tag relation audit info';
+COMMENT ON COLUMN tag_relation_meta.current_version IS 'tag relation current version';
+COMMENT ON COLUMN tag_relation_meta.last_version IS 'tag relation last version';
+COMMENT ON COLUMN tag_relation_meta.deleted_at IS 'tag relation deleted at';
+
+CREATE TABLE IF NOT EXISTS owner_meta (
+    id BIGINT GENERATED BY DEFAULT AS IDENTITY,
+    metalake_id BIGINT NOT NULL,
+    owner_id BIGINT NOT NULL,
+    owner_type VARCHAR(64) NOT NULL,
+    metadata_object_id BIGINT NOT NULL,
+    metadata_object_type VARCHAR(64) NOT NULL,
+    audit_info TEXT NOT NULL,
+    current_version INT NOT NULL DEFAULT 1,
+    last_version INT NOT NULL DEFAULT 1,
+    deleted_at BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (id),
+    UNIQUE (owner_id, metadata_object_id, metadata_object_type, deleted_at)
+);
+
+CREATE INDEX IF NOT EXISTS owner_meta_idx_owner_id ON owner_meta (owner_id);
+CREATE INDEX IF NOT EXISTS owner_meta_idx_metadata_object_id ON owner_meta (metadata_object_id);
+COMMENT ON TABLE owner_meta IS 'owner relation';
+COMMENT ON COLUMN owner_meta.id IS 'auto increment id';
+COMMENT ON COLUMN owner_meta.metalake_id IS 'metalake id';
+COMMENT ON COLUMN owner_meta.owner_id IS 'owner id';
+COMMENT ON COLUMN owner_meta.owner_type IS 'owner type';
+COMMENT ON COLUMN owner_meta.metadata_object_id IS 'metadata object id';
+COMMENT ON COLUMN owner_meta.metadata_object_type IS 'metadata object type';
+COMMENT ON COLUMN owner_meta.audit_info IS 'owner relation audit info';
+COMMENT ON COLUMN owner_meta.current_version IS 'owner relation current version';
+COMMENT ON COLUMN owner_meta.last_version IS 'owner relation last version';
+COMMENT ON COLUMN owner_meta.deleted_at IS 'owner relation deleted at';
+
+
+CREATE TABLE IF NOT EXISTS model_meta (
+    model_id BIGINT NOT NULL,
+    model_name VARCHAR(128) NOT NULL,
+    metalake_id BIGINT NOT NULL,
+    catalog_id BIGINT NOT NULL,
+    schema_id BIGINT NOT NULL,
+    model_comment VARCHAR(65535) DEFAULT NULL,
+    model_properties TEXT DEFAULT NULL,
+    model_latest_version INT NOT NULL DEFAULT 0,
+    audit_info TEXT NOT NULL,
+    deleted_at BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (model_id),
+    UNIQUE (schema_id, model_name, deleted_at)
+);
+
+CREATE INDEX IF NOT EXISTS model_meta_idx_metalake_id ON model_meta (metalake_id);
+CREATE INDEX IF NOT EXISTS model_meta_idx_catalog_id ON model_meta (catalog_id);
+COMMENT ON TABLE model_meta IS 'model metadata';
+
+COMMENT ON COLUMN model_meta.model_id IS 'model id';
+COMMENT ON COLUMN model_meta.model_name IS 'model name';
+COMMENT ON COLUMN model_meta.metalake_id IS 'metalake id';
+COMMENT ON COLUMN model_meta.catalog_id IS 'catalog id';
+COMMENT ON COLUMN model_meta.schema_id IS 'schema id';
+COMMENT ON COLUMN model_meta.model_comment IS 'model comment';
+COMMENT ON COLUMN model_meta.model_properties IS 'model properties';
+COMMENT ON COLUMN model_meta.model_latest_version IS 'model max version';
+COMMENT ON COLUMN model_meta.audit_info IS 'model audit info';
+COMMENT ON COLUMN model_meta.deleted_at IS 'model deleted at';
+
+
+CREATE TABLE IF NOT EXISTS model_version_info (
+    id BIGINT NOT NULL GENERATED BY DEFAULT AS IDENTITY,
+    metalake_id BIGINT NOT NULL,
+    catalog_id BIGINT NOT NULL,
+    schema_id BIGINT NOT NULL,
+    model_id BIGINT NOT NULL,
+    version INT NOT NULL,
+    model_version_comment VARCHAR(65535) DEFAULT NULL,
+    model_version_properties TEXT DEFAULT NULL,
+    model_version_uri_name VARCHAR(256) NOT NULL,
+    model_version_uri TEXT NOT NULL,
+    audit_info TEXT NOT NULL,
+    deleted_at BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (id),
+    UNIQUE (model_id, version, model_version_uri_name, deleted_at)
+);
+
+CREATE INDEX IF NOT EXISTS model_version_info_idx_metalake_id ON model_version_info (metalake_id);
+CREATE INDEX IF NOT EXISTS model_version_info_idx_catalog_id ON model_version_info (catalog_id);
+CREATE INDEX IF NOT EXISTS model_version_info_idx_schema_id ON model_version_info (schema_id);
+COMMENT ON TABLE model_version_info IS 'model version information';
+
+COMMENT ON COLUMN model_version_info.id IS 'auto increment id';
+COMMENT ON COLUMN model_version_info.metalake_id IS 'metalake id';
+COMMENT ON COLUMN model_version_info.catalog_id IS 'catalog id';
+COMMENT ON COLUMN model_version_info.schema_id IS 'schema id';
+COMMENT ON COLUMN model_version_info.model_id IS 'model id';
+COMMENT ON COLUMN model_version_info.version IS 'model version';
+COMMENT ON COLUMN model_version_info.model_version_comment IS 'model version comment';
+COMMENT ON COLUMN model_version_info.model_version_properties IS 'model version properties';
+COMMENT ON COLUMN model_version_info.model_version_uri_name IS 'model version uri name';
+COMMENT ON COLUMN model_version_info.model_version_uri IS 'model storage uri';
+COMMENT ON COLUMN model_version_info.audit_info IS 'model version audit info';
+COMMENT ON COLUMN model_version_info.deleted_at IS 'model version deleted at';
+
+
+CREATE TABLE IF NOT EXISTS model_version_alias_rel (
+    id BIGINT NOT NULL GENERATED BY DEFAULT AS IDENTITY,
+    model_id BIGINT NOT NULL,
+    model_version INT NOT NULL,
+    model_version_alias VARCHAR(128) NOT NULL,
+    deleted_at BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (id),
+    UNIQUE (model_id, model_version_alias, deleted_at)
+);
+
+CREATE INDEX IF NOT EXISTS model_version_alias_rel_idx_model_version_alias on model_version_alias_rel (model_version_alias);
+COMMENT ON TABLE model_version_alias_rel IS 'model version alias relation';
+
+COMMENT ON COLUMN model_version_alias_rel.id IS 'auto increment id';
+COMMENT ON COLUMN model_version_alias_rel.model_id IS 'model id';
+COMMENT ON COLUMN model_version_alias_rel.model_version IS 'model version';
+COMMENT ON COLUMN model_version_alias_rel.model_version_alias IS 'model version alias';
+COMMENT ON COLUMN model_version_alias_rel.deleted_at IS 'model version alias deleted at';
+
+
+CREATE TABLE IF NOT EXISTS policy_meta (
+    policy_id BIGINT NOT NULL,
+    policy_name VARCHAR(128) NOT NULL,
+    policy_type VARCHAR(64) NOT NULL,
+    metalake_id BIGINT NOT NULL,
+    audit_info TEXT NOT NULL,
+    current_version INT NOT NULL DEFAULT 1,
+    last_version INT NOT NULL DEFAULT 1,
+    deleted_at BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (policy_id),
+    UNIQUE (metalake_id, policy_name, deleted_at)
+);
+
+COMMENT ON TABLE policy_meta IS 'policy metadata';
+COMMENT ON COLUMN policy_meta.policy_id IS 'policy id';
+COMMENT ON COLUMN policy_meta.policy_name IS 'policy name';
+COMMENT ON COLUMN policy_meta.policy_type IS 'policy type';
+COMMENT ON COLUMN policy_meta.metalake_id IS 'metalake id';
+COMMENT ON COLUMN policy_meta.audit_info IS 'policy audit info';
+COMMENT ON COLUMN policy_meta.current_version IS 'policy current version';
+COMMENT ON COLUMN policy_meta.last_version IS 'policy last version';
+COMMENT ON COLUMN policy_meta.deleted_at IS 'policy deleted at';
+
+
+CREATE TABLE IF NOT EXISTS policy_version_info (
+    id BIGINT NOT NULL GENERATED BY DEFAULT AS IDENTITY,
+    metalake_id BIGINT NOT NULL,
+    policy_id BIGINT NOT NULL,
+    version INT NOT NULL,
+    policy_comment TEXT DEFAULT NULL,
+    enabled BOOLEAN DEFAULT TRUE,
+    content TEXT DEFAULT NULL,
+    deleted_at BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (id),
+    UNIQUE (policy_id, version, deleted_at)
+);
+
+CREATE INDEX IF NOT EXISTS policy_version_info_idx_metalake_id ON policy_version_info (metalake_id);
+COMMENT ON TABLE policy_version_info IS 'policy version info';
+COMMENT ON COLUMN policy_version_info.id IS 'auto increment id';
+COMMENT ON COLUMN policy_version_info.metalake_id IS 'metalake id';
+COMMENT ON COLUMN policy_version_info.policy_id IS 'policy id';
+COMMENT ON COLUMN policy_version_info.version IS 'policy info version';
+COMMENT ON COLUMN policy_version_info.policy_comment IS 'policy info comment';
+COMMENT ON COLUMN policy_version_info.enabled IS 'whether the policy is enabled, 0 is disabled, 1 is enabled';
+COMMENT ON COLUMN policy_version_info.content IS 'policy content';
+COMMENT ON COLUMN policy_version_info.deleted_at IS 'policy deleted at';
+
+
+CREATE TABLE IF NOT EXISTS policy_relation_meta (
+    id BIGINT NOT NULL GENERATED BY DEFAULT AS IDENTITY,
+    policy_id BIGINT NOT NULL,
+    metadata_object_id BIGINT NOT NULL,
+    metadata_object_type VARCHAR(64) NOT NULL,
+    audit_info TEXT NOT NULL,
+    current_version INT NOT NULL DEFAULT 1,
+    last_version INT NOT NULL DEFAULT 1,
+    deleted_at BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (id),
+    UNIQUE (policy_id, metadata_object_id, metadata_object_type, deleted_at)
+);
+
+CREATE INDEX IF NOT EXISTS policy_relation_meta_idx_policy_id ON policy_relation_meta (policy_id);
+CREATE INDEX IF NOT EXISTS policy_relation_meta_idx_metadata_object_id ON policy_relation_meta (metadata_object_id);
+COMMENT ON TABLE policy_relation_meta IS 'policy metadata object relation';
+COMMENT ON COLUMN policy_relation_meta.id IS 'auto increment id';
+COMMENT ON COLUMN policy_relation_meta.policy_id IS 'policy id';
+COMMENT ON COLUMN policy_relation_meta.metadata_object_id IS 'metadata object id';
+COMMENT ON COLUMN policy_relation_meta.metadata_object_type IS 'metadata object type';
+COMMENT ON COLUMN policy_relation_meta.audit_info IS 'policy relation audit info';
+COMMENT ON COLUMN policy_relation_meta.current_version IS 'policy relation current version';
+COMMENT ON COLUMN policy_relation_meta.last_version IS 'policy relation last version';
+COMMENT ON COLUMN policy_relation_meta.deleted_at IS 'policy relation deleted at';
+
+CREATE TABLE IF NOT EXISTS statistic_meta (
+    id BIGINT NOT NULL GENERATED BY DEFAULT AS IDENTITY,
+    statistic_id BIGINT NOT NULL,
+    statistic_name VARCHAR(128) NOT NULL,
+    metalake_id BIGINT NOT NULL,
+    statistic_value TEXT NOT NULL,
+    metadata_object_id BIGINT NOT NULL,
+    metadata_object_type VARCHAR(64) NOT NULL,
+    audit_info TEXT NOT NULL,
+    current_version INT NOT NULL DEFAULT 1,
+    last_version INT NOT NULL DEFAULT 1,
+    deleted_at BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (statistic_id),
+    UNIQUE (statistic_name, metadata_object_id, deleted_at)
+);
+
+CREATE INDEX IF NOT EXISTS statistic_meta_idx_stid ON statistic_meta (statistic_id);
+CREATE INDEX IF NOT EXISTS statistic_meta_idx_moid ON statistic_meta (metadata_object_id);
+COMMENT ON TABLE statistic_meta IS 'statistic metadata';
+COMMENT ON COLUMN statistic_meta.id IS 'auto increment id';
+COMMENT ON COLUMN statistic_meta.statistic_id IS 'statistic id';
+COMMENT ON COLUMN statistic_meta.statistic_name IS 'statistic name';
+COMMENT ON COLUMN statistic_meta.metalake_id IS 'metalake id';
+COMMENT ON COLUMN statistic_meta.statistic_value IS 'statistic value';
+COMMENT ON COLUMN statistic_meta.metadata_object_id IS 'metadata object id';
+COMMENT ON COLUMN statistic_meta.metadata_object_type IS 'metadata object type';
+COMMENT ON COLUMN statistic_meta.audit_info IS 'statistic audit info';
+COMMENT ON COLUMN statistic_meta.current_version IS 'statistic current version';
+COMMENT ON COLUMN statistic_meta.last_version IS 'statistic last version';
+COMMENT ON COLUMN statistic_meta.deleted_at IS 'statistic deleted at';
+
+CREATE TABLE IF NOT EXISTS job_template_meta (
+    job_template_id BIGINT NOT NULL,
+    job_template_name VARCHAR(128) NOT NULL,
+    metalake_id BIGINT NOT NULL,
+    job_template_comment TEXT DEFAULT NULL,
+    job_template_content TEXT NOT NULL,
+    audit_info TEXT NOT NULL,
+    current_version INT NOT NULL DEFAULT 1,
+    last_version INT NOT NULL DEFAULT 1,
+    deleted_at BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (job_template_id),
+    UNIQUE (metalake_id, job_template_name, deleted_at)
+);
+
+COMMENT ON TABLE job_template_meta IS 'job template metadata';
+COMMENT ON COLUMN job_template_meta.job_template_id IS 'job template id';
+COMMENT ON COLUMN job_template_meta.job_template_name IS 'job template name';
+COMMENT ON COLUMN job_template_meta.metalake_id IS 'metalake id';
+COMMENT ON COLUMN job_template_meta.job_template_comment IS 'job template comment';
+COMMENT ON COLUMN job_template_meta.job_template_content IS 'job template content';
+COMMENT ON COLUMN job_template_meta.audit_info IS 'job template audit info';
+COMMENT ON COLUMN job_template_meta.current_version IS 'job template current version';
+COMMENT ON COLUMN job_template_meta.last_version IS 'job template last version';
+COMMENT ON COLUMN job_template_meta.deleted_at IS 'job template deleted at';
+
+
+CREATE TABLE IF NOT EXISTS job_run_meta (
+    job_run_id BIGINT NOT NULL,
+    job_template_id BIGINT NOT NULL,
+    metalake_id BIGINT NOT NULL,
+    job_execution_id VARCHAR(256) NOT NULL,
+    job_run_status VARCHAR(64) NOT NULL,
+    job_finished_at BIGINT NOT NULL DEFAULT 0,
+    audit_info TEXT NOT NULL,
+    current_version INT NOT NULL DEFAULT 1,
+    last_version INT NOT NULL DEFAULT 1,
+    deleted_at BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (job_run_id),
+    UNIQUE (metalake_id, job_execution_id, deleted_at)
+);
+
+CREATE INDEX IF NOT EXISTS job_run_meta_idx_job_template_id ON job_run_meta (job_template_id);
+CREATE INDEX IF NOT EXISTS job_run_meta_idx_job_execution_id ON job_run_meta (job_execution_id);
+COMMENT ON TABLE job_run_meta IS 'job run metadata';
+COMMENT ON COLUMN job_run_meta.job_run_id IS 'job run id';
+COMMENT ON COLUMN job_run_meta.job_template_id IS 'job template id';
+COMMENT ON COLUMN job_run_meta.metalake_id IS 'metalake id';
+COMMENT ON COLUMN job_run_meta.job_execution_id IS 'job execution id';
+COMMENT ON COLUMN job_run_meta.job_run_status IS 'job run status';
+COMMENT ON COLUMN job_run_meta.job_finished_at IS 'job run finished at';
+COMMENT ON COLUMN job_run_meta.audit_info IS 'job run audit info';
+COMMENT ON COLUMN job_run_meta.current_version IS 'job run current version';
+COMMENT ON COLUMN job_run_meta.last_version IS 'job run last version';
+COMMENT ON COLUMN job_run_meta.deleted_at IS 'job run deleted at';
+
+CREATE TABLE IF NOT EXISTS table_version_info (
+    table_id        BIGINT NOT NULL,
+    format          VARCHAR(64),
+    properties      TEXT,
+    partitioning  TEXT,
+    distribution TEXT,
+    sort_orders TEXT,
+    indexes      TEXT,
+    "comment"   TEXT,
+    version BIGINT,
+    deleted_at      BIGINT DEFAULT 0,
+    UNIQUE (table_id, version, deleted_at)
+);
+COMMENT ON TABLE table_version_info                  IS 'table detail information including format, location, properties, partition, distribution, sort order, index and so on';
+COMMENT ON COLUMN table_version_info.table_id        IS 'table id';
+COMMENT ON COLUMN table_version_info.format          IS 'table format, such as Lance, Iceberg and so on, it will be null if it is not a lakehouse table';
+COMMENT ON COLUMN table_version_info.properties      IS 'table properties';
+COMMENT ON COLUMN table_version_info.partitioning      IS 'table partition info';
+COMMENT on COLUMN table_version_info.distribution    IS 'table distribution info';
+COMMENT ON COLUMN table_version_info.sort_orders     IS 'table sort order info';
+COMMENT ON COLUMN table_version_info.indexes         IS 'table index info';
+COMMENT ON COLUMN table_version_info."comment"       IS 'table comment';
+COMMENT ON COLUMN table_version_info.version IS 'table current version';
+COMMENT ON COLUMN table_version_info.deleted_at      IS 'table deletion timestamp, 0 means not deleted';
+
+CREATE TABLE IF NOT EXISTS function_meta (
+    function_id BIGINT NOT NULL,
+    function_name VARCHAR(128) NOT NULL,
+    metalake_id BIGINT NOT NULL,
+    catalog_id BIGINT NOT NULL,
+    schema_id BIGINT NOT NULL,
+    function_type VARCHAR(64) NOT NULL,
+    deterministic SMALLINT DEFAULT 1,
+    function_current_version INT DEFAULT 1,
+    function_latest_version INT DEFAULT 1,
+    audit_info TEXT NOT NULL,
+    deleted_at BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (function_id),
+    UNIQUE (schema_id, function_name, deleted_at)
+);
+CREATE INDEX idx_function_meta_metalake_id ON function_meta (metalake_id);
+CREATE INDEX idx_function_meta_catalog_id ON function_meta (catalog_id);
+
+COMMENT ON TABLE function_meta IS 'function metadata';
+COMMENT ON COLUMN function_meta.function_id IS 'function id';
+COMMENT ON COLUMN function_meta.function_name IS 'function name';
+COMMENT ON COLUMN function_meta.metalake_id IS 'metalake id';
+COMMENT ON COLUMN function_meta.catalog_id IS 'catalog id';
+COMMENT ON COLUMN function_meta.schema_id IS 'schema id';
+COMMENT ON COLUMN function_meta.function_type IS 'function type';
+COMMENT ON COLUMN function_meta.deterministic IS 'whether the function result is deterministic';
+COMMENT ON COLUMN function_meta.function_latest_version IS 'function latest version';
+COMMENT ON COLUMN function_meta.audit_info IS 'function audit info';
+COMMENT ON COLUMN function_meta.deleted_at IS 'function deleted at';
+
+CREATE TABLE IF NOT EXISTS function_version_info (
+    id BIGINT NOT NULL GENERATED BY DEFAULT AS IDENTITY,
+    metalake_id BIGINT NOT NULL,
+    catalog_id BIGINT NOT NULL,
+    schema_id BIGINT NOT NULL,
+    function_id BIGINT NOT NULL,
+    version INT NOT NULL,
+    function_comment TEXT DEFAULT NULL,
+    definitions TEXT NOT NULL,
+    audit_info TEXT NOT NULL,
+    deleted_at BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (id),
+    UNIQUE (function_id, version, deleted_at)
+);
+CREATE INDEX idx_function_version_metalake_id ON function_version_info (metalake_id);
+CREATE INDEX idx_function_version_catalog_id ON function_version_info (catalog_id);
+CREATE INDEX idx_function_version_schema_id ON function_version_info (schema_id);
+
+COMMENT ON TABLE function_version_info IS 'function version info';
+COMMENT ON COLUMN function_version_info.id IS 'auto increment id';
+COMMENT ON COLUMN function_version_info.metalake_id IS 'metalake id';
+COMMENT ON COLUMN function_version_info.catalog_id IS 'catalog id';
+COMMENT ON COLUMN function_version_info.schema_id IS 'schema id';
+COMMENT ON COLUMN function_version_info.function_id IS 'function id';
+COMMENT ON COLUMN function_version_info.version IS 'function version';
+COMMENT ON COLUMN function_version_info.function_comment IS 'function version comment';
+COMMENT ON COLUMN function_version_info.definitions IS 'function definitions details';
+COMMENT ON COLUMN function_version_info.audit_info IS 'function version audit info';
+COMMENT ON COLUMN function_version_info.deleted_at IS 'function version deleted at';
+
+CREATE TABLE IF NOT EXISTS view_meta (
+    view_id BIGINT NOT NULL,
+    view_name VARCHAR(128) NOT NULL,
+    metalake_id BIGINT NOT NULL,
+    catalog_id BIGINT NOT NULL,
+    schema_id BIGINT NOT NULL,
+    current_version INT NOT NULL DEFAULT 1,
+    last_version INT NOT NULL DEFAULT 1,
+    deleted_at BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (view_id),
+    UNIQUE (schema_id, view_name, deleted_at)
+);
+
+CREATE INDEX IF NOT EXISTS view_meta_idx_metalake_id ON view_meta (metalake_id);
+CREATE INDEX IF NOT EXISTS view_meta_idx_catalog_id ON view_meta (catalog_id);
+COMMENT ON TABLE view_meta IS 'view metadata';
+
+COMMENT ON COLUMN view_meta.view_id IS 'view id';
+COMMENT ON COLUMN view_meta.view_name IS 'view name';
+COMMENT ON COLUMN view_meta.metalake_id IS 'metalake id';
+COMMENT ON COLUMN view_meta.catalog_id IS 'catalog id';
+COMMENT ON COLUMN view_meta.schema_id IS 'schema id';
+COMMENT ON COLUMN view_meta.current_version IS 'view current version';
+COMMENT ON COLUMN view_meta.last_version IS 'view last version';
+COMMENT ON COLUMN view_meta.deleted_at IS 'view deleted at';
+
+-- This schema extends version 1.1.0 with partition statistics storage support
+-- The partition_statistic_meta table stores partition-level statistics for tables
+
+CREATE TABLE IF NOT EXISTS partition_statistic_meta (
+    table_id BIGINT NOT NULL,
+    partition_name VARCHAR(1024) NOT NULL,
+    statistic_name VARCHAR(128) NOT NULL,
+    statistic_value TEXT NOT NULL,
+    audit_info TEXT NOT NULL,
+    created_at BIGINT NOT NULL,
+    updated_at BIGINT NOT NULL,
+    PRIMARY KEY (table_id, partition_name, statistic_name)
+);
+
+CREATE INDEX IF NOT EXISTS idx_table_partition ON partition_statistic_meta(table_id, partition_name);
+
+COMMENT ON TABLE partition_statistic_meta IS 'partition statistics metadata';
+COMMENT ON COLUMN partition_statistic_meta.table_id IS 'table id from table_meta';
+COMMENT ON COLUMN partition_statistic_meta.partition_name IS 'partition name';
+COMMENT ON COLUMN partition_statistic_meta.statistic_name IS 'statistic name';
+COMMENT ON COLUMN partition_statistic_meta.statistic_value IS 'statistic value as JSON';
+COMMENT ON COLUMN partition_statistic_meta.audit_info IS 'audit information as JSON';
+COMMENT ON COLUMN partition_statistic_meta.created_at IS 'creation timestamp in milliseconds';
+COMMENT ON COLUMN partition_statistic_meta.updated_at IS 'last update timestamp in milliseconds';
+
+-- Optimizer metrics schema
+CREATE TABLE IF NOT EXISTS table_metrics (
+    id BIGSERIAL PRIMARY KEY,
+    table_identifier VARCHAR(1024) NOT NULL,
+    metric_name VARCHAR(1024) NOT NULL,
+    table_partition VARCHAR(1024),
+    metric_ts BIGINT NOT NULL,
+    metric_value VARCHAR(1024) NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS job_metrics (
+    id BIGSERIAL PRIMARY KEY,
+    job_identifier VARCHAR(1024) NOT NULL,
+    metric_name VARCHAR(1024) NOT NULL,
+    metric_ts BIGINT NOT NULL,
+    metric_value VARCHAR(1024) NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_table_metrics_metric_ts ON table_metrics(metric_ts);
+CREATE INDEX IF NOT EXISTS idx_job_metrics_metric_ts ON job_metrics(metric_ts);
+CREATE INDEX IF NOT EXISTS idx_table_metrics_composite
+  ON table_metrics(table_identifier, table_partition, metric_ts);
+CREATE INDEX IF NOT EXISTS idx_job_metrics_identifier_metric_ts
+  ON job_metrics(job_identifier, metric_ts);
+
+COMMENT ON TABLE table_metrics IS 'optimizer table metrics';
+COMMENT ON TABLE job_metrics IS 'optimizer job metrics';
+COMMENT ON COLUMN table_metrics.id IS 'auto increment id';
+COMMENT ON COLUMN table_metrics.table_identifier IS 'normalized table identifier';
+COMMENT ON COLUMN table_metrics.metric_name IS 'metric name';
+COMMENT ON COLUMN table_metrics.table_partition IS 'normalized partition identifier';
+COMMENT ON COLUMN table_metrics.metric_ts IS 'metric timestamp in epoch seconds';
+COMMENT ON COLUMN table_metrics.metric_value IS 'metric value payload';
+COMMENT ON COLUMN job_metrics.id IS 'auto increment id';
+COMMENT ON COLUMN job_metrics.job_identifier IS 'normalized job identifier';
+COMMENT ON COLUMN job_metrics.metric_name IS 'metric name';
+COMMENT ON COLUMN job_metrics.metric_ts IS 'metric timestamp in epoch seconds';
+COMMENT ON COLUMN job_metrics.metric_value IS 'metric value payload';

--- a/scripts/postgresql/upgrade-1.2.0-to-1.3.0-postgresql.sql
+++ b/scripts/postgresql/upgrade-1.2.0-to-1.3.0-postgresql.sql
@@ -1,0 +1,38 @@
+--
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file--
+--  distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"). You may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--  http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+--
+
+-- Add version columns for Phase 2 version-validated auth cache
+
+ALTER TABLE role_meta
+    ADD COLUMN securable_objects_version INT NOT NULL DEFAULT 1;
+
+COMMENT ON COLUMN role_meta.securable_objects_version IS
+    'Incremented atomically with any privilege grant/revoke for this role';
+
+ALTER TABLE user_meta
+    ADD COLUMN role_grants_version INT NOT NULL DEFAULT 1;
+
+COMMENT ON COLUMN user_meta.role_grants_version IS
+    'Incremented atomically with any role assignment/revocation for this user';
+
+ALTER TABLE group_meta
+    ADD COLUMN role_grants_version INT NOT NULL DEFAULT 1;
+
+COMMENT ON COLUMN group_meta.role_grants_version IS
+    'Incremented atomically with any role assignment/revocation for this group';


### PR DESCRIPTION
> **Stacked PR** — depends on #10774. Please review/merge that PR first.

### What changes were proposed in this pull request?

- Add `GravitinoCache<K,V>` interface (`getIfPresent`, `put`, `invalidate`, `invalidateAll`, `size`, `close`)
- Add `CaffeineGravitinoCache<K,V>` — Caffeine-backed implementation with configurable TTL, max-size, and optional removal listener
- Add `NoOpsGravitinoCache<K,V>` — no-op implementation used when caching is disabled
- Add cache config keys to `Configs.java` (max size, expiration seconds)
- Extend `AuthorizationRequestContext` with per-request owner and user version caches

### Why are the changes needed?

Provides the caching infrastructure (PR 2 of 3) consumed by the refactored `JcasbinAuthorizer` in PR #10772.

Fix: #10771

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

`TestGravitinoCache` covers all `CaffeineGravitinoCache` and `NoOpsGravitinoCache` behaviours including put/get, invalidate, size, overwrite, and removal listener firing.