### PR TITLE
[#10772] improvement(authz): Refactor JcasbinAuthorizer to use version-validated authorization cache

### DIFF
--- a/common/src/main/java/org/apache/gravitino/config/ConfigConstants.java
+++ b/common/src/main/java/org/apache/gravitino/config/ConfigConstants.java
@@ -93,5 +93,5 @@ public final class ConfigConstants {
   public static final String VERSION_1_3_0 = "1.3.0";
 
   /** The current version of backend storage initialization script. */
-  public static final String CURRENT_SCRIPT_VERSION = VERSION_1_2_0;
+  public static final String CURRENT_SCRIPT_VERSION = VERSION_1_3_0;
 }

--- a/core/src/main/java/org/apache/gravitino/Configs.java
+++ b/core/src/main/java/org/apache/gravitino/Configs.java
@@ -329,6 +329,15 @@ public class Configs {
           .longConf()
           .createWithDefault(DEFAULT_GRAVITINO_AUTHORIZATION_OWNER_CACHE_SIZE);
 
+  public static final long DEFAULT_GRAVITINO_AUTHORIZATION_USER_ROLE_CACHE_SIZE = 50000L;
+
+  public static final ConfigEntry<Long> GRAVITINO_AUTHORIZATION_USER_ROLE_CACHE_SIZE =
+      new ConfigBuilder("gravitino.authorization.jcasbin.userRoleCacheSize")
+          .doc("The maximum number of user→(roleIds, version) entries in the auth cache")
+          .version(ConfigConstants.VERSION_1_3_0)
+          .longConf()
+          .createWithDefault(DEFAULT_GRAVITINO_AUTHORIZATION_USER_ROLE_CACHE_SIZE);
+
   public static final ConfigEntry<List<String>> SERVICE_ADMINS =
       new ConfigBuilder("gravitino.authorization.serviceAdmins")
           .doc("The admins of Gravitino service")

--- a/core/src/main/java/org/apache/gravitino/authorization/AuthorizationRequestContext.java
+++ b/core/src/main/java/org/apache/gravitino/authorization/AuthorizationRequestContext.java
@@ -18,8 +18,10 @@
 package org.apache.gravitino.authorization;
 
 import java.security.Principal;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
@@ -35,6 +37,15 @@ public class AuthorizationRequestContext {
 
   /** Used to determine whether the role has already been loaded. */
   private final AtomicBoolean hasLoadRole = new AtomicBoolean();
+
+  /**
+   * Per-request cache of metadata-object-id → owner user id. Maps to Optional.empty() when the
+   * object has no user owner. {@code null} means "not yet cached".
+   */
+  private final Map<Long, Optional<Long>> ownerCache = new HashMap<>();
+
+  /** The resolved user ID for the current request principal, cached after first resolution. */
+  private volatile Long resolvedUserId;
 
   private volatile String originalAuthorizationExpression;
 
@@ -101,6 +112,46 @@ public class AuthorizationRequestContext {
 
   public void setOriginalAuthorizationExpression(String originalAuthorizationExpression) {
     this.originalAuthorizationExpression = originalAuthorizationExpression;
+  }
+
+  public Long getResolvedUserId() {
+    return resolvedUserId;
+  }
+
+  public void setResolvedUserId(Long resolvedUserId) {
+    this.resolvedUserId = resolvedUserId;
+  }
+
+  /**
+   * Returns true if the owner entry for {@code metadataId} is present in the per-request cache.
+   *
+   * @param metadataId the metadata object ID
+   * @return true if cached
+   */
+  public boolean isOwnerCached(Long metadataId) {
+    return ownerCache.containsKey(metadataId);
+  }
+
+  /**
+   * Returns the cached owner for the given metadata object ID.
+   *
+   * <p>Call {@link #isOwnerCached(Long)} first to distinguish "not cached" from "no owner".
+   *
+   * @param metadataId the metadata object ID
+   * @return Optional.of(userId) if there is a user owner, Optional.empty() if no user owner
+   */
+  public Optional<Long> getCachedOwner(Long metadataId) {
+    return ownerCache.get(metadataId);
+  }
+
+  /**
+   * Stores the resolved owner (or "no owner") for the given metadata object ID.
+   *
+   * @param metadataId the metadata object ID
+   * @param owner Optional.of(userId) or Optional.empty()
+   */
+  public void cacheOwner(Long metadataId, Optional<Long> owner) {
+    ownerCache.put(metadataId, owner);
   }
 
   public static class AuthorizationKey {

--- a/core/src/main/java/org/apache/gravitino/cache/CaffeineGravitinoCache.java
+++ b/core/src/main/java/org/apache/gravitino/cache/CaffeineGravitinoCache.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.cache;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.RemovalListener;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A {@link GravitinoCache} implementation backed by a Caffeine cache with configurable TTL and
+ * maximum size.
+ *
+ * @param <K> key type
+ * @param <V> value type
+ */
+public class CaffeineGravitinoCache<K, V> implements GravitinoCache<K, V> {
+
+  private final Cache<K, V> cache;
+
+  /**
+   * Creates a cache with the given maximum size and expiration, with no removal listener.
+   *
+   * @param maxSize maximum number of entries
+   * @param expirationSecs expire-after-access duration in seconds
+   */
+  public CaffeineGravitinoCache(long maxSize, long expirationSecs) {
+    this.cache =
+        Caffeine.newBuilder()
+            .expireAfterAccess(expirationSecs, TimeUnit.SECONDS)
+            .maximumSize(maxSize)
+            .executor(Runnable::run)
+            .build();
+  }
+
+  /**
+   * Creates a cache with the given maximum size, expiration, and a removal listener.
+   *
+   * @param maxSize maximum number of entries
+   * @param expirationSecs expire-after-access duration in seconds
+   * @param removalListener called on every eviction or explicit invalidation
+   */
+  public CaffeineGravitinoCache(
+      long maxSize, long expirationSecs, RemovalListener<K, V> removalListener) {
+    this.cache =
+        Caffeine.newBuilder()
+            .expireAfterAccess(expirationSecs, TimeUnit.SECONDS)
+            .maximumSize(maxSize)
+            .executor(Runnable::run)
+            .removalListener(removalListener)
+            .build();
+  }
+
+  @Override
+  public Optional<V> getIfPresent(K key) {
+    return Optional.ofNullable(cache.getIfPresent(key));
+  }
+
+  @Override
+  public void put(K key, V value) {
+    cache.put(key, value);
+  }
+
+  @Override
+  public void invalidate(K key) {
+    cache.invalidate(key);
+  }
+
+  @Override
+  public void invalidateAll() {
+    cache.invalidateAll();
+  }
+
+  @Override
+  public long size() {
+    return cache.estimatedSize();
+  }
+
+  /** Forces pending maintenance tasks (e.g. removal listener calls) to run synchronously. */
+  public void cleanUp() {
+    cache.cleanUp();
+  }
+
+  @Override
+  public void close() {
+    cache.cleanUp();
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/cache/GravitinoCache.java
+++ b/core/src/main/java/org/apache/gravitino/cache/GravitinoCache.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.cache;
+
+import java.io.Closeable;
+import java.util.Optional;
+
+/**
+ * A lightweight general-purpose cache interface used by the authorization layer.
+ *
+ * <p>Implementations include {@link CaffeineGravitinoCache} (backed by Caffeine) and {@link
+ * NoOpsGravitinoCache} (no-op, for tests or when caching is disabled).
+ *
+ * @param <K> cache key type
+ * @param <V> cache value type
+ */
+public interface GravitinoCache<K, V> extends Closeable {
+
+  /**
+   * Returns the cached value for the given key, or {@link Optional#empty()} if absent.
+   *
+   * @param key the cache key
+   * @return the cached value wrapped in {@link Optional}, or empty if not present
+   */
+  Optional<V> getIfPresent(K key);
+
+  /**
+   * Inserts or overwrites the entry for the given key.
+   *
+   * @param key the cache key
+   * @param value the value to cache
+   */
+  void put(K key, V value);
+
+  /**
+   * Removes the entry for the given key if it is present.
+   *
+   * @param key the cache key to evict
+   */
+  void invalidate(K key);
+
+  /** Removes all entries from the cache. */
+  void invalidateAll();
+
+  /**
+   * Returns an estimate of the number of entries currently in the cache.
+   *
+   * @return estimated size
+   */
+  long size();
+}

--- a/core/src/main/java/org/apache/gravitino/cache/NoOpsGravitinoCache.java
+++ b/core/src/main/java/org/apache/gravitino/cache/NoOpsGravitinoCache.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.cache;
+
+import java.util.Optional;
+
+/**
+ * A no-operation {@link GravitinoCache} that never stores any entry. Useful in tests and when
+ * caching should be bypassed entirely.
+ *
+ * @param <K> key type
+ * @param <V> value type
+ */
+public class NoOpsGravitinoCache<K, V> implements GravitinoCache<K, V> {
+
+  @Override
+  public Optional<V> getIfPresent(K key) {
+    return Optional.empty();
+  }
+
+  @Override
+  public void put(K key, V value) {}
+
+  @Override
+  public void invalidate(K key) {}
+
+  @Override
+  public void invalidateAll() {}
+
+  @Override
+  public long size() {
+    return 0L;
+  }
+
+  @Override
+  public void close() {}
+}

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/GroupMetaMapper.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/GroupMetaMapper.java
@@ -88,4 +88,7 @@ public interface GroupMetaMapper {
       method = "deleteGroupMetasByLegacyTimeline")
   Integer deleteGroupMetasByLegacyTimeline(
       @Param("legacyTimeline") Long legacyTimeline, @Param("limit") int limit);
+
+  @UpdateProvider(type = GroupMetaSQLProviderFactory.class, method = "bumpRoleGrantsVersion")
+  void bumpRoleGrantsVersion(@Param("groupId") long groupId);
 }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/GroupMetaSQLProviderFactory.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/GroupMetaSQLProviderFactory.java
@@ -95,4 +95,8 @@ public class GroupMetaSQLProviderFactory {
       @Param("legacyTimeline") Long legacyTimeline, @Param("limit") int limit) {
     return getProvider().deleteGroupMetasByLegacyTimeline(legacyTimeline, limit);
   }
+
+  public static String bumpRoleGrantsVersion(@Param("groupId") long groupId) {
+    return getProvider().bumpRoleGrantsVersion(groupId);
+  }
 }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/OwnerMetaMapper.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/OwnerMetaMapper.java
@@ -20,6 +20,7 @@ package org.apache.gravitino.storage.relational.mapper;
 
 import java.util.List;
 import org.apache.gravitino.storage.relational.po.GroupPO;
+import org.apache.gravitino.storage.relational.po.OwnerRelInfoPO;
 import org.apache.gravitino.storage.relational.po.OwnerRelPO;
 import org.apache.gravitino.storage.relational.po.UserOwnerRelPO;
 import org.apache.gravitino.storage.relational.po.UserPO;
@@ -95,4 +96,9 @@ public interface OwnerMetaMapper {
       method = "deleteOwnerMetasByLegacyTimeline")
   Integer deleteOwnerMetasByLegacyTimeline(
       @Param("legacyTimeline") Long legacyTimeline, @Param("limit") int limit);
+
+  @SelectProvider(
+      type = OwnerMetaSQLProviderFactory.class,
+      method = "selectOwnerByMetadataObjectId")
+  OwnerRelInfoPO selectOwnerByMetadataObjectId(@Param("metadataObjectId") long metadataObjectId);
 }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/OwnerMetaSQLProviderFactory.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/OwnerMetaSQLProviderFactory.java
@@ -104,4 +104,9 @@ public class OwnerMetaSQLProviderFactory {
     return getProvider()
         .batchSelectUserOwnerMetaByMetadataObjectIdAndType(metadataObjectIds, metadataObjectType);
   }
+
+  public static String selectOwnerByMetadataObjectId(
+      @Param("metadataObjectId") long metadataObjectId) {
+    return getProvider().selectOwnerByMetadataObjectId(metadataObjectId);
+  }
 }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/RoleMetaMapper.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/RoleMetaMapper.java
@@ -21,6 +21,7 @@ package org.apache.gravitino.storage.relational.mapper;
 
 import java.util.List;
 import org.apache.gravitino.storage.relational.po.RolePO;
+import org.apache.gravitino.storage.relational.po.RoleVersionInfoPO;
 import org.apache.ibatis.annotations.DeleteProvider;
 import org.apache.ibatis.annotations.InsertProvider;
 import org.apache.ibatis.annotations.Param;
@@ -93,4 +94,12 @@ public interface RoleMetaMapper {
       method = "deleteRoleMetasByLegacyTimeline")
   Integer deleteRoleMetasByLegacyTimeline(
       @Param("legacyTimeline") Long legacyTimeline, @Param("limit") int limit);
+
+  @UpdateProvider(type = RoleMetaSQLProviderFactory.class, method = "bumpSecurableObjectsVersion")
+  void bumpSecurableObjectsVersion(@Param("roleId") long roleId);
+
+  @SelectProvider(
+      type = RoleMetaSQLProviderFactory.class,
+      method = "batchGetSecurableObjectsVersions")
+  List<RoleVersionInfoPO> batchGetSecurableObjectsVersions(@Param("roleIds") List<Long> roleIds);
 }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/RoleMetaSQLProviderFactory.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/RoleMetaSQLProviderFactory.java
@@ -19,6 +19,7 @@
 package org.apache.gravitino.storage.relational.mapper;
 
 import com.google.common.collect.ImmutableMap;
+import java.util.List;
 import java.util.Map;
 import org.apache.gravitino.storage.relational.JDBCBackend.JDBCBackendType;
 import org.apache.gravitino.storage.relational.mapper.provider.base.RoleMetaBaseSQLProvider;
@@ -100,5 +101,13 @@ public class RoleMetaSQLProviderFactory {
   public static String deleteRoleMetasByLegacyTimeline(
       @Param("legacyTimeline") Long legacyTimeline, @Param("limit") int limit) {
     return getProvider().deleteRoleMetasByLegacyTimeline(legacyTimeline, limit);
+  }
+
+  public static String bumpSecurableObjectsVersion(@Param("roleId") long roleId) {
+    return getProvider().bumpSecurableObjectsVersion(roleId);
+  }
+
+  public static String batchGetSecurableObjectsVersions(@Param("roleIds") List<Long> roleIds) {
+    return getProvider().batchGetSecurableObjectsVersions(roleIds);
   }
 }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/UserMetaMapper.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/UserMetaMapper.java
@@ -22,6 +22,7 @@ package org.apache.gravitino.storage.relational.mapper;
 import java.util.List;
 import org.apache.gravitino.storage.relational.po.ExtendedUserPO;
 import org.apache.gravitino.storage.relational.po.UserPO;
+import org.apache.gravitino.storage.relational.po.UserVersionInfoPO;
 import org.apache.ibatis.annotations.DeleteProvider;
 import org.apache.ibatis.annotations.InsertProvider;
 import org.apache.ibatis.annotations.Param;
@@ -88,4 +89,11 @@ public interface UserMetaMapper {
       method = "deleteUserMetasByLegacyTimeline")
   Integer deleteUserMetasByLegacyTimeline(
       @Param("legacyTimeline") Long legacyTimeline, @Param("limit") int limit);
+
+  @UpdateProvider(type = UserMetaSQLProviderFactory.class, method = "bumpRoleGrantsVersion")
+  void bumpRoleGrantsVersion(@Param("userId") long userId);
+
+  @SelectProvider(type = UserMetaSQLProviderFactory.class, method = "getUserVersionInfo")
+  UserVersionInfoPO getUserVersionInfo(
+      @Param("metalakeName") String metalakeName, @Param("userName") String userName);
 }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/UserMetaSQLProviderFactory.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/UserMetaSQLProviderFactory.java
@@ -97,4 +97,13 @@ public class UserMetaSQLProviderFactory {
       @Param("legacyTimeline") Long legacyTimeline, @Param("limit") int limit) {
     return getProvider().deleteUserMetasByLegacyTimeline(legacyTimeline, limit);
   }
+
+  public static String bumpRoleGrantsVersion(@Param("userId") long userId) {
+    return getProvider().bumpRoleGrantsVersion(userId);
+  }
+
+  public static String getUserVersionInfo(
+      @Param("metalakeName") String metalakeName, @Param("userName") String userName) {
+    return getProvider().getUserVersionInfo(metalakeName, userName);
+  }
 }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/GroupMetaBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/GroupMetaBaseSQLProvider.java
@@ -182,4 +182,11 @@ public class GroupMetaBaseSQLProvider {
         + GROUP_TABLE_NAME
         + " WHERE deleted_at > 0 AND deleted_at < #{legacyTimeline} LIMIT #{limit}";
   }
+
+  public String bumpRoleGrantsVersion(@Param("groupId") long groupId) {
+    return "UPDATE "
+        + GROUP_TABLE_NAME
+        + " SET role_grants_version = role_grants_version + 1"
+        + " WHERE group_id = #{groupId} AND deleted_at = 0";
+  }
 }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/OwnerMetaBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/OwnerMetaBaseSQLProvider.java
@@ -225,4 +225,11 @@ public class OwnerMetaBaseSQLProvider {
         + OWNER_TABLE_NAME
         + " WHERE deleted_at > 0 AND deleted_at < #{legacyTimeline} LIMIT #{limit}";
   }
+
+  public String selectOwnerByMetadataObjectId(@Param("metadataObjectId") long metadataObjectId) {
+    return "SELECT owner_id as ownerId, owner_type as ownerType"
+        + " FROM "
+        + OWNER_TABLE_NAME
+        + " WHERE metadata_object_id = #{metadataObjectId} AND deleted_at = 0";
+  }
 }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/RoleMetaBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/RoleMetaBaseSQLProvider.java
@@ -22,6 +22,7 @@ import static org.apache.gravitino.storage.relational.mapper.RoleMetaMapper.GROU
 import static org.apache.gravitino.storage.relational.mapper.RoleMetaMapper.ROLE_TABLE_NAME;
 import static org.apache.gravitino.storage.relational.mapper.RoleMetaMapper.USER_ROLE_RELATION_TABLE_NAME;
 
+import java.util.List;
 import org.apache.gravitino.storage.relational.mapper.MetalakeMetaMapper;
 import org.apache.gravitino.storage.relational.mapper.SecurableObjectMapper;
 import org.apache.gravitino.storage.relational.po.RolePO;
@@ -191,5 +192,23 @@ public class RoleMetaBaseSQLProvider {
     return "DELETE FROM "
         + ROLE_TABLE_NAME
         + " WHERE deleted_at > 0 AND deleted_at < #{legacyTimeline} LIMIT #{limit}";
+  }
+
+  public String bumpSecurableObjectsVersion(@Param("roleId") long roleId) {
+    return "UPDATE "
+        + ROLE_TABLE_NAME
+        + " SET securable_objects_version = securable_objects_version + 1"
+        + " WHERE role_id = #{roleId} AND deleted_at = 0";
+  }
+
+  public String batchGetSecurableObjectsVersions(@Param("roleIds") List<Long> roleIds) {
+    return "<script>"
+        + "SELECT role_id as roleId, securable_objects_version as securableObjectsVersion"
+        + " FROM "
+        + ROLE_TABLE_NAME
+        + " WHERE role_id IN "
+        + "<foreach item='id' collection='roleIds' open='(' separator=',' close=')'>#{id}</foreach>"
+        + " AND deleted_at = 0"
+        + "</script>";
   }
 }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/UserMetaBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/UserMetaBaseSQLProvider.java
@@ -187,4 +187,23 @@ public class UserMetaBaseSQLProvider {
         + USER_TABLE_NAME
         + " WHERE deleted_at > 0 AND deleted_at < #{legacyTimeline} LIMIT #{limit}";
   }
+
+  public String bumpRoleGrantsVersion(@Param("userId") long userId) {
+    return "UPDATE "
+        + USER_TABLE_NAME
+        + " SET role_grants_version = role_grants_version + 1"
+        + " WHERE user_id = #{userId} AND deleted_at = 0";
+  }
+
+  public String getUserVersionInfo(
+      @Param("metalakeName") String metalakeName, @Param("userName") String userName) {
+    return "SELECT um.user_id as userId, um.role_grants_version as roleGrantsVersion"
+        + " FROM "
+        + USER_TABLE_NAME
+        + " um JOIN "
+        + MetalakeMetaMapper.TABLE_NAME
+        + " mm ON um.metalake_id = mm.metalake_id"
+        + " WHERE mm.metalake_name = #{metalakeName} AND um.user_name = #{userName}"
+        + " AND um.deleted_at = 0 AND mm.deleted_at = 0";
+  }
 }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/po/OwnerRelInfoPO.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/po/OwnerRelInfoPO.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.storage.relational.po;
+
+/** Projection for the owner ID and owner type of a metadata object. */
+public class OwnerRelInfoPO {
+
+  private Long ownerId;
+  private String ownerType;
+
+  public Long getOwnerId() {
+    return ownerId;
+  }
+
+  public void setOwnerId(Long ownerId) {
+    this.ownerId = ownerId;
+  }
+
+  public String getOwnerType() {
+    return ownerType;
+  }
+
+  public void setOwnerType(String ownerType) {
+    this.ownerType = ownerType;
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/storage/relational/po/RoleVersionInfoPO.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/po/RoleVersionInfoPO.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.storage.relational.po;
+
+/** Projection for a role's ID and current securable-objects version number. */
+public class RoleVersionInfoPO {
+
+  private Long roleId;
+  private Integer securableObjectsVersion;
+
+  public Long getRoleId() {
+    return roleId;
+  }
+
+  public void setRoleId(Long roleId) {
+    this.roleId = roleId;
+  }
+
+  public Integer getSecurableObjectsVersion() {
+    return securableObjectsVersion;
+  }
+
+  public void setSecurableObjectsVersion(Integer securableObjectsVersion) {
+    this.securableObjectsVersion = securableObjectsVersion;
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/storage/relational/po/UserVersionInfoPO.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/po/UserVersionInfoPO.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.storage.relational.po;
+
+/** Projection for a user's ID and current role-grants version number. */
+public class UserVersionInfoPO {
+
+  private Long userId;
+  private Integer roleGrantsVersion;
+
+  public Long getUserId() {
+    return userId;
+  }
+
+  public void setUserId(Long userId) {
+    this.userId = userId;
+  }
+
+  public Integer getRoleGrantsVersion() {
+    return roleGrantsVersion;
+  }
+
+  public void setRoleGrantsVersion(Integer roleGrantsVersion) {
+    this.roleGrantsVersion = roleGrantsVersion;
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/GroupMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/GroupMetaService.java
@@ -259,7 +259,11 @@ public class GroupMetaService {
                 mapper ->
                     mapper.softDeleteGroupRoleRelByGroupAndRoles(
                         newEntity.id(), Lists.newArrayList(deleteRoleIds)));
-          });
+          },
+          () ->
+              SessionUtils.doWithoutCommit(
+                  GroupMetaMapper.class,
+                  mapper -> mapper.bumpRoleGrantsVersion(oldGroupPO.getGroupId())));
     } catch (RuntimeException re) {
       ExceptionUtils.checkSQLException(
           re, Entity.EntityType.GROUP, newEntity.nameIdentifier().toString());

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/RoleMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/RoleMetaService.java
@@ -259,7 +259,11 @@ public class RoleMetaService {
             SessionUtils.doWithoutCommit(
                 SecurableObjectMapper.class,
                 mapper -> mapper.batchInsertSecurableObjects(insertSecurableObjectPOs));
-          });
+          },
+          () ->
+              SessionUtils.doWithoutCommit(
+                  RoleMetaMapper.class,
+                  mapper -> mapper.bumpSecurableObjectsVersion(rolePO.getRoleId())));
 
       return newRoleEntity;
     } catch (RuntimeException re) {

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/UserMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/UserMetaService.java
@@ -252,7 +252,11 @@ public class UserMetaService {
                 mapper ->
                     mapper.softDeleteUserRoleRelByUserAndRoles(
                         newEntity.id(), Lists.newArrayList(deleteRoleIds)));
-          });
+          },
+          () ->
+              SessionUtils.doWithoutCommit(
+                  UserMetaMapper.class,
+                  mapper -> mapper.bumpRoleGrantsVersion(oldUserPO.getUserId())));
     } catch (RuntimeException re) {
       ExceptionUtils.checkSQLException(
           re, Entity.EntityType.USER, newEntity.nameIdentifier().toString());

--- a/core/src/test/java/org/apache/gravitino/cache/TestGravitinoCache.java
+++ b/core/src/test/java/org/apache/gravitino/cache/TestGravitinoCache.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.cache;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for {@link CaffeineGravitinoCache} and {@link NoOpsGravitinoCache}. */
+public class TestGravitinoCache {
+
+  @Test
+  public void testCaffeinePutAndGet() throws IOException {
+    try (GravitinoCache<String, Integer> cache = new CaffeineGravitinoCache<>(100, 3600)) {
+      cache.put("key1", 42);
+      Optional<Integer> result = cache.getIfPresent("key1");
+      assertTrue(result.isPresent());
+      assertEquals(42, result.get());
+    }
+  }
+
+  @Test
+  public void testCaffeineGetMissReturnsEmpty() throws IOException {
+    try (GravitinoCache<String, Integer> cache = new CaffeineGravitinoCache<>(100, 3600)) {
+      assertFalse(cache.getIfPresent("missing").isPresent());
+    }
+  }
+
+  @Test
+  public void testCaffeineInvalidate() throws IOException {
+    try (GravitinoCache<Long, String> cache = new CaffeineGravitinoCache<>(100, 3600)) {
+      cache.put(1L, "value");
+      assertTrue(cache.getIfPresent(1L).isPresent());
+
+      cache.invalidate(1L);
+      assertFalse(cache.getIfPresent(1L).isPresent());
+    }
+  }
+
+  @Test
+  public void testCaffeineInvalidateAll() throws IOException {
+    try (GravitinoCache<Long, String> cache = new CaffeineGravitinoCache<>(100, 3600)) {
+      cache.put(1L, "a");
+      cache.put(2L, "b");
+      cache.put(3L, "c");
+
+      cache.invalidateAll();
+
+      assertFalse(cache.getIfPresent(1L).isPresent());
+      assertFalse(cache.getIfPresent(2L).isPresent());
+      assertFalse(cache.getIfPresent(3L).isPresent());
+    }
+  }
+
+  @Test
+  public void testCaffeineSize() throws IOException {
+    try (GravitinoCache<Integer, String> cache = new CaffeineGravitinoCache<>(100, 3600)) {
+      assertEquals(0, cache.size());
+      cache.put(1, "a");
+      cache.put(2, "b");
+      // Caffeine size is eventually consistent; force cleanup
+      ((CaffeineGravitinoCache<Integer, String>) cache).cleanUp();
+      assertEquals(2, cache.size());
+    }
+  }
+
+  @Test
+  public void testCaffeineRemovalListenerFires() throws IOException {
+    List<Long> evicted = new ArrayList<>();
+    try (GravitinoCache<Long, Integer> cache =
+        new CaffeineGravitinoCache<>(100, 3600, (key, value, cause) -> evicted.add(key))) {
+      cache.put(10L, 1);
+      cache.invalidate(10L);
+      // Force Caffeine to run pending removal tasks synchronously
+      ((CaffeineGravitinoCache<Long, Integer>) cache).cleanUp();
+      assertTrue(evicted.contains(10L), "Removal listener should have been called for key 10");
+    }
+  }
+
+  @Test
+  public void testCaffeineOverwrite() throws IOException {
+    try (GravitinoCache<String, Integer> cache = new CaffeineGravitinoCache<>(100, 3600)) {
+      cache.put("k", 1);
+      cache.put("k", 2);
+      assertEquals(2, cache.getIfPresent("k").get());
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // NoOpsGravitinoCache
+  // -----------------------------------------------------------------------
+
+  @Test
+  public void testNoOpsCacheAlwaysEmpty() throws IOException {
+    try (GravitinoCache<String, Integer> cache = new NoOpsGravitinoCache<>()) {
+      cache.put("key", 99);
+      assertFalse(cache.getIfPresent("key").isPresent());
+      assertEquals(0, cache.size());
+    }
+  }
+
+  @Test
+  public void testNoOpsCacheInvalidateIsNoOp() throws IOException {
+    try (GravitinoCache<String, Integer> cache = new NoOpsGravitinoCache<>()) {
+      // Should not throw
+      cache.invalidate("anything");
+      cache.invalidateAll();
+    }
+  }
+}

--- a/scripts/h2/schema-1.3.0-h2.sql
+++ b/scripts/h2/schema-1.3.0-h2.sql
@@ -1,0 +1,542 @@
+--
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file--
+--  distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"). You may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--  http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+--
+
+CREATE TABLE IF NOT EXISTS `metalake_meta` (
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `metalake_name` VARCHAR(128) NOT NULL COMMENT 'metalake name',
+    `metalake_comment` VARCHAR(256) DEFAULT '' COMMENT 'metalake comment',
+    `properties` CLOB DEFAULT NULL COMMENT 'metalake properties',
+    `audit_info` CLOB NOT NULL COMMENT 'metalake audit info',
+    `schema_version` CLOB NOT NULL COMMENT 'metalake schema version info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'metalake current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'metalake last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'metalake deleted at',
+    PRIMARY KEY (metalake_id),
+    CONSTRAINT uk_mn_del UNIQUE (metalake_name, deleted_at)
+) ENGINE = InnoDB;
+
+
+CREATE TABLE IF NOT EXISTS `catalog_meta` (
+    `catalog_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'catalog id',
+    `catalog_name` VARCHAR(128) NOT NULL COMMENT 'catalog name',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `type` VARCHAR(64) NOT NULL COMMENT 'catalog type',
+    `provider` VARCHAR(64) NOT NULL COMMENT 'catalog provider',
+    `catalog_comment` VARCHAR(256) DEFAULT '' COMMENT 'catalog comment',
+    `properties` CLOB DEFAULT NULL COMMENT 'catalog properties',
+    `audit_info` CLOB NOT NULL COMMENT 'catalog audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'catalog current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'catalog last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'catalog deleted at',
+    PRIMARY KEY (catalog_id),
+    CONSTRAINT uk_mid_cn_del UNIQUE (metalake_id, catalog_name, deleted_at)
+) ENGINE=InnoDB;
+
+
+CREATE TABLE IF NOT EXISTS `schema_meta` (
+    `schema_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'schema id',
+    `schema_name` VARCHAR(128) NOT NULL COMMENT 'schema name',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `catalog_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'catalog id',
+    `schema_comment` VARCHAR(256) DEFAULT '' COMMENT 'schema comment',
+    `properties` CLOB DEFAULT NULL COMMENT 'schema properties',
+    `audit_info` CLOB NOT NULL COMMENT 'schema audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'schema current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'schema last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'schema deleted at',
+    PRIMARY KEY (schema_id),
+    CONSTRAINT uk_cid_sn_del UNIQUE (catalog_id, schema_name, deleted_at),
+    -- Aliases are used here, and indexes with the same name in H2 can only be created once.
+    KEY idx_smid (metalake_id)
+) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS `table_meta` (
+    `table_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'table id',
+    `table_name` VARCHAR(128) NOT NULL COMMENT 'table name',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `catalog_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'catalog id',
+    `schema_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'schema id',
+    `audit_info` CLOB NOT NULL COMMENT 'table audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'table current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'table last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'table deleted at',
+    PRIMARY KEY (table_id),
+    CONSTRAINT uk_sid_tn_del UNIQUE (schema_id, table_name, deleted_at),
+    -- Aliases are used here, and indexes with the same name in H2 can only be created once.
+    KEY idx_tmid (metalake_id),
+    KEY idx_tcid (catalog_id)
+) ENGINE=InnoDB;
+
+
+CREATE TABLE IF NOT EXISTS `table_column_version_info` (
+    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'auto increment id',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `catalog_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'catalog id',
+    `schema_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'schema id',
+    `table_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'table id',
+    `table_version` INT UNSIGNED NOT NULL COMMENT 'table version',
+    `column_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'column id',
+    `column_name` VARCHAR(128) NOT NULL COMMENT 'column name',
+    `column_position` INT UNSIGNED NOT NULL COMMENT 'column position, starting from 0',
+    `column_type` CLOB NOT NULL COMMENT 'column type',
+    `column_comment` VARCHAR(256) DEFAULT '' COMMENT 'column comment',
+    `column_nullable` TINYINT(1) NOT NULL DEFAULT 1 COMMENT 'column nullable, 0 is not nullable, 1 is nullable',
+    `column_auto_increment` TINYINT(1) NOT NULL DEFAULT 0 COMMENT 'column auto increment, 0 is not auto increment, 1 is auto increment',
+    `column_default_value` CLOB DEFAULT NULL COMMENT 'column default value',
+    `column_op_type` TINYINT(1) NOT NULL COMMENT 'column operation type, 1 is create, 2 is update, 3 is delete',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'column deleted at',
+    `audit_info` CLOB NOT NULL COMMENT 'column audit info',
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `uk_tid_ver_cid_del` (`table_id`, `table_version`, `column_id`, `deleted_at`),
+    KEY `idx_tcmid` (`metalake_id`),
+    KEY `idx_tccid` (`catalog_id`),
+    KEY `idx_tcsid` (`schema_id`)
+) ENGINE=InnoDB;
+
+
+CREATE TABLE IF NOT EXISTS `fileset_meta` (
+    `fileset_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'fileset id',
+    `fileset_name` VARCHAR(128) NOT NULL COMMENT 'fileset name',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `catalog_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'catalog id',
+    `schema_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'schema id',
+    `type` VARCHAR(64) NOT NULL COMMENT 'fileset type',
+    `audit_info` CLOB NOT NULL COMMENT 'fileset audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'fileset current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'fileset last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'fileset deleted at',
+    PRIMARY KEY (fileset_id),
+    CONSTRAINT uk_sid_fn_del UNIQUE (schema_id, fileset_name, deleted_at),
+    -- Aliases are used here, and indexes with the same name in H2 can only be created once.
+    KEY idx_fmid (metalake_id),
+    KEY idx_fcid (catalog_id)
+) ENGINE=InnoDB;
+
+
+CREATE TABLE IF NOT EXISTS `fileset_version_info` (
+    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'auto increment id',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `catalog_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'catalog id',
+    `schema_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'schema id',
+    `fileset_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'fileset id',
+    `version` INT UNSIGNED NOT NULL COMMENT 'fileset info version',
+    `fileset_comment` VARCHAR(256) DEFAULT '' COMMENT 'fileset comment',
+    `properties` CLOB DEFAULT NULL COMMENT 'fileset properties',
+    `storage_location_name` VARCHAR(128) NOT NULL DEFAULT 'default' COMMENT 'fileset storage location name',
+    `storage_location` CLOB DEFAULT NULL COMMENT 'fileset storage location',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'fileset deleted at',
+    PRIMARY KEY (id),
+    CONSTRAINT uk_fid_ver_del UNIQUE (fileset_id, version, storage_location_name, deleted_at),
+    -- Aliases are used here, and indexes with the same name in H2 can only be created once.
+    KEY idx_fvmid (metalake_id),
+    KEY idx_fvcid (catalog_id)
+) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS `topic_meta` (
+    `topic_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'topic id',
+    `topic_name` VARCHAR(128) NOT NULL COMMENT 'topic name',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `catalog_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'catalog id',
+    `schema_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'schema id',
+    `comment` VARCHAR(256) DEFAULT '' COMMENT 'topic comment',
+    `properties` CLOB DEFAULT NULL COMMENT 'topic properties',
+    `audit_info` CLOB NOT NULL COMMENT 'topic audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'topic current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'topic last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'topic deleted at',
+    PRIMARY KEY (topic_id),
+    CONSTRAINT uk_cid_tn_del UNIQUE (schema_id, topic_name, deleted_at),
+    -- Aliases are used here, and indexes with the same name in H2 can only be created once.
+    KEY idx_tvmid (metalake_id),
+    KEY idx_tvcid (catalog_id)
+) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS `user_meta` (
+    `user_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'user id',
+    `user_name` VARCHAR(128) NOT NULL COMMENT 'username',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `audit_info` CLOB NOT NULL COMMENT 'user audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'user current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'user last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'user deleted at',
+    `role_grants_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'version bumped on any role assignment change for this user',
+    PRIMARY KEY (`user_id`),
+    CONSTRAINT `uk_mid_us_del` UNIQUE (`metalake_id`, `user_name`, `deleted_at`)
+) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS `role_meta` (
+    `role_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'role id',
+    `role_name` VARCHAR(128) NOT NULL COMMENT 'role name',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `properties` CLOB DEFAULT NULL COMMENT 'schema properties',
+    `audit_info` CLOB NOT NULL COMMENT 'role audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'role current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'role last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'role deleted at',
+    `securable_objects_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'version bumped on any privilege change for this role',
+    PRIMARY KEY (`role_id`),
+    CONSTRAINT `uk_mid_rn_del` UNIQUE (`metalake_id`, `role_name`, `deleted_at`)
+) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS `role_meta_securable_object` (
+    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'auto increment id',
+    `role_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'role id',
+    `metadata_object_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'securable object entity id',
+    `type`  VARCHAR(128) NOT NULL COMMENT 'securable object type',
+    `privilege_names` CLOB(81920) NOT NULL COMMENT 'securable object privilege names',
+    `privilege_conditions` CLOB(81920) NOT NULL COMMENT 'securable object privilege conditions',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'securable objectcurrent version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'securable object last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'securable object deleted at',
+    PRIMARY KEY (`id`),
+    KEY `idx_obj_rid` (`role_id`),
+    KEY `idx_obj_eid` (`metadata_object_id`)
+) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS `user_role_rel` (
+    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'auto increment id',
+    `user_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'user id',
+    `role_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'role id',
+    `audit_info` CLOB NOT NULL COMMENT 'relation audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'relation current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'relation last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'relation deleted at',
+    PRIMARY KEY (`id`),
+    CONSTRAINT `uk_ui_ri_del` UNIQUE (`user_id`, `role_id`, `deleted_at`),
+    KEY `idx_rid` (`role_id`)
+) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS `group_meta` (
+    `group_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'group id',
+    `group_name` VARCHAR(128) NOT NULL COMMENT 'group name',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `audit_info` CLOB NOT NULL COMMENT 'group audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'group current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'group last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'group deleted at',
+    `role_grants_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'version bumped on any role assignment change for this group',
+    PRIMARY KEY (`group_id`),
+    CONSTRAINT `uk_mid_gr_del` UNIQUE (`metalake_id`, `group_name`, `deleted_at`)
+) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS `group_role_rel` (
+    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'auto increment id',
+    `group_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'group id',
+    `role_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'role id',
+    `audit_info` CLOB NOT NULL COMMENT 'relation audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'relation current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'relation last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'relation deleted at',
+    PRIMARY KEY (`id`),
+    CONSTRAINT `uk_gi_ri_del` UNIQUE (`group_id`, `role_id`, `deleted_at`),
+    KEY `idx_gid` (`group_id`)
+) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS `tag_meta` (
+    `tag_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'tag id',
+    `tag_name` VARCHAR(128) NOT NULL COMMENT 'tag name',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `tag_comment` VARCHAR(256) DEFAULT '' COMMENT 'tag comment',
+    `properties` CLOB DEFAULT NULL COMMENT 'tag properties',
+    `audit_info` CLOB NOT NULL COMMENT 'tag audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'tag current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'tag last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'tag deleted at',
+    PRIMARY KEY (`tag_id`),
+    UNIQUE KEY `uk_mn_tn_del` (`metalake_id`, `tag_name`, `deleted_at`)
+) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS `tag_relation_meta` (
+    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'auto increment id',
+    `tag_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'tag id',
+    `metadata_object_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metadata object id',
+    `metadata_object_type` VARCHAR(64) NOT NULL COMMENT 'metadata object type',
+    `audit_info` CLOB NOT NULL COMMENT 'tag relation audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'tag relation current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'tag relation last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'tag relation deleted at',
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `uk_ti_mi_del` (`tag_id`, `metadata_object_id`, `deleted_at`),
+    KEY `idx_tid` (`tag_id`),
+    KEY `idx_mid` (`metadata_object_id`)
+) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS `owner_meta` (
+    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'auto increment id',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `owner_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'owner id',
+    `owner_type` VARCHAR(64) NOT NULL COMMENT 'owner type',
+    `metadata_object_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metadata object id',
+    `metadata_object_type` VARCHAR(64) NOT NULL COMMENT 'metadata object type',
+    `audit_info` CLOB NOT NULL COMMENT 'owner relation audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'owner relation current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'owner relation last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'owner relation deleted at',
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `uk_ow_me_del` (`owner_id`, `metadata_object_id`, `metadata_object_type`, `deleted_at`),
+    KEY `idx_oid` (`owner_id`),
+    KEY `idx_meid` (`metadata_object_id`)
+) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS `model_meta` (
+    `model_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'model id',
+    `model_name` VARCHAR(128) NOT NULL COMMENT 'model name',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `catalog_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'catalog id',
+    `schema_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'schema id',
+    `model_comment` CLOB DEFAULT NULL COMMENT 'model comment',
+    `model_properties` CLOB DEFAULT NULL COMMENT 'model properties',
+    `model_latest_version` INT UNSIGNED DEFAULT 0 COMMENT 'model latest version',
+    `audit_info` CLOB NOT NULL COMMENT 'model audit info',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'model deleted at',
+    PRIMARY KEY (`model_id`),
+    UNIQUE KEY `uk_sid_mn_del` (`schema_id`, `model_name`, `deleted_at`),
+    KEY `idx_mmid` (`metalake_id`),
+    KEY `idx_mcid` (`catalog_id`)
+) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS `model_version_info` (
+    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'auto increment id',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `catalog_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'catalog id',
+    `schema_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'schema id',
+    `model_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'model id',
+    `version` INT UNSIGNED NOT NULL COMMENT 'model version',
+    `model_version_comment` CLOB DEFAULT NULL COMMENT 'model version comment',
+    `model_version_properties` CLOB DEFAULT NULL COMMENT 'model version properties',
+    `model_version_uri_name` VARCHAR(128) NOT NULL COMMENT 'model version uri name',
+    `model_version_uri` CLOB NOT NULL COMMENT 'model storage uri',
+    `audit_info` CLOB NOT NULL COMMENT 'model version audit info',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'model version deleted at',
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `uk_mid_ver_uri_del` (`model_id`, `version`, `model_version_uri_name`, `deleted_at`),
+    KEY `idx_vmid` (`metalake_id`),
+    KEY `idx_vcid` (`catalog_id`),
+    KEY `idx_vsid` (`schema_id`)
+) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS `model_version_alias_rel` (
+    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'auto increment id',
+    `model_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'model id',
+    `model_version` INT UNSIGNED NOT NULL COMMENT 'model version',
+    `model_version_alias` VARCHAR(128) NOT NULL COMMENT 'model version alias',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'model version alias deleted at',
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `uk_mi_mva_del` (`model_id`, `model_version_alias`, `deleted_at`),
+    KEY `idx_mva` (`model_version_alias`)
+) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS `policy_meta` (
+    `policy_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'policy id',
+    `policy_name` VARCHAR(128) NOT NULL COMMENT 'policy name',
+    `policy_type` VARCHAR(64) NOT NULL COMMENT 'policy type',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `audit_info` CLOB NOT NULL COMMENT 'policy audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'policy current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'policy last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'policy deleted at',
+    PRIMARY KEY (`policy_id`),
+    UNIQUE KEY `uk_mi_pn_del` (`metalake_id`, `policy_name`, `deleted_at`)
+) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS `policy_version_info` (
+    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'auto increment id',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `policy_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'policy id',
+    `version` INT UNSIGNED NOT NULL COMMENT 'policy info version',
+    `policy_comment` CLOB DEFAULT NULL COMMENT 'policy info comment',
+    `enabled` TINYINT(1) DEFAULT 1 COMMENT 'whether the policy is enabled, 0 is disabled, 1 is enabled',
+    `content` CLOB DEFAULT NULL COMMENT 'policy content',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'policy deleted at',
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `uk_pod_ver_del` (`policy_id`, `version`, `deleted_at`),
+    KEY `idx_pmid` (`metalake_id`)
+) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS `policy_relation_meta` (
+    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'auto increment id',
+    `policy_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'policy id',
+    `metadata_object_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metadata object id',
+    `metadata_object_type` VARCHAR(64) NOT NULL COMMENT 'metadata object type',
+    `audit_info` CLOB NOT NULL COMMENT 'policy relation audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'policy relation current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'policy relation last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'policy relation deleted at',
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `uk_pi_mi_mo_del` (`policy_id`, `metadata_object_id`, `metadata_object_type`, `deleted_at`),
+    KEY `idx_pid` (`policy_id`),
+    KEY `idx_prmid` (`metadata_object_id`)
+) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS `statistic_meta` (
+    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'auto increment id',
+    `statistic_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'statistic id',
+    `statistic_name` VARCHAR(128) NOT NULL COMMENT 'statistic name',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `statistic_value` CLOB NOT NULL COMMENT 'statistic value',
+    `metadata_object_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metadata object id',
+    `metadata_object_type` VARCHAR(64) NOT NULL COMMENT 'metadata object type',
+    `audit_info` CLOB NOT NULL COMMENT 'statistic audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'statistic current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'statistic last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'statistic deleted at',
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `uk_si_mi_mo_del` (`statistic_name`, `metadata_object_id`, `deleted_at`),
+    KEY `idx_stid` (`statistic_id`),
+    KEY `idx_moid` (`metadata_object_id`)
+) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS `job_template_meta` (
+    `job_template_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'job template id',
+    `job_template_name` VARCHAR(128) NOT NULL COMMENT 'job template name',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `job_template_comment` CLOB DEFAULT NULL COMMENT 'job template comment',
+    `job_template_content` CLOB NOT NULL COMMENT 'job template content',
+    `audit_info` CLOB NOT NULL COMMENT 'job template audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'job template current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'job template last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'job template deleted at',
+    PRIMARY KEY (`job_template_id`),
+    UNIQUE KEY `uk_mid_jtn_del` (`metalake_id`, `job_template_name`, `deleted_at`)
+) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS `job_run_meta` (
+    `job_run_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'job run id',
+    `job_template_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'job template id',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `job_execution_id` varchar(256) NOT NULL COMMENT 'job execution id',
+    `job_run_status` varchar(64) NOT NULL COMMENT 'job run status',
+    `job_finished_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'job finished at',
+    `audit_info` CLOB NOT NULL COMMENT 'job run audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'job run current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'job run last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'job run deleted at',
+    PRIMARY KEY (`job_run_id`),
+    UNIQUE KEY `uk_mid_jei_del` (`metalake_id`, `job_execution_id`, `deleted_at`),
+    KEY `idx_job_template_id` (`job_template_id`),
+    KEY `idx_job_execution_id` (`job_execution_id`)
+) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS `table_version_info` (
+    `table_id`        BIGINT(20) UNSIGNED NOT NULL COMMENT 'table id',
+    `format`          VARCHAR(64) COMMENT 'table format, such as Lance, Iceberg and so on, it will be null if it is not a lakehouse table' ,
+    `properties`      CLOB DEFAULT NULL COMMENT 'table properties',
+    `partitioning`  CLOB DEFAULT NULL COMMENT 'table partition info',
+    `distribution` CLOB DEFAULT NULL COMMENT 'table distribution info',
+    `sort_orders` CLOB DEFAULT NULL COMMENT 'table sort order info',
+    `indexes`      CLOB DEFAULT NULL COMMENT 'table index info',
+    `comment`   CLOB DEFAULT NULL COMMENT 'table comment',
+    `version` BIGINT(20) UNSIGNED COMMENT 'table current version',
+    `deleted_at`      BIGINT(20) UNSIGNED DEFAULT 0 COMMENT 'table deletion timestamp, 0 means not deleted',
+    UNIQUE KEY `uk_table_id_version_deleted_at` (`table_id`, `version`, `deleted_at`)
+) ENGINE=InnoDB COMMENT 'table detail information including format, location, properties, partition, distribution, sort order, index and so on';
+
+CREATE TABLE IF NOT EXISTS `function_meta` (
+    `function_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'function id',
+    `function_name` VARCHAR(128) NOT NULL COMMENT 'function name',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `catalog_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'catalog id',
+    `schema_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'schema id',
+    `function_type` VARCHAR(64) NOT NULL COMMENT 'function type',
+    `deterministic` TINYINT(1) DEFAULT 1 COMMENT 'whether the function result is deterministic',
+    `function_current_version` INT UNSIGNED DEFAULT 1 COMMENT 'function current version',
+    `function_latest_version` INT UNSIGNED DEFAULT 1 COMMENT 'function latest version',
+    `audit_info` CLOB NOT NULL COMMENT 'function audit info',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'function deleted at',
+    PRIMARY KEY (`function_id`),
+    UNIQUE KEY `uk_sid_fun_del` (`schema_id`, `function_name`, `deleted_at`),
+    KEY `idx_funmid` (`metalake_id`),
+    KEY `idx_funcid` (`catalog_id`)
+) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS `function_version_info` (
+    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'auto increment id',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `catalog_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'catalog id',
+    `schema_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'schema id',
+    `function_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'function id',
+    `version` INT UNSIGNED NOT NULL COMMENT 'function version',
+    `function_comment` CLOB DEFAULT NULL COMMENT 'function version comment',
+    `definitions` CLOB NOT NULL COMMENT 'function definitions details',
+    `audit_info` CLOB NOT NULL COMMENT 'function version audit info',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'function version deleted at',
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `uk_funid_ver_del` (`function_id`, `version`, `deleted_at`),
+    KEY `idx_funvmid` (`metalake_id`),
+    KEY `idx_funvcid` (`catalog_id`),
+    KEY `idx_funvsid` (`schema_id`)
+) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS `view_meta` (
+    `view_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'view id',
+    `view_name` VARCHAR(128) NOT NULL COMMENT 'view name',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `catalog_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'catalog id',
+    `schema_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'schema id',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'view current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'view last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'view deleted at',
+    PRIMARY KEY (`view_id`),
+    UNIQUE KEY `uk_sid_vn_del` (`schema_id`, `view_name`, `deleted_at`),
+    KEY `idx_vemid` (`metalake_id`),
+    KEY `idx_vecid` (`catalog_id`)
+) ENGINE=InnoDB;
+
+-- This schema extends version 1.1.0 with partition statistics storage support
+-- The partition_statistic_meta table stores partition-level statistics for tables
+
+CREATE TABLE IF NOT EXISTS partition_statistic_meta (
+    table_id BIGINT NOT NULL COMMENT 'table id from table_meta',
+    partition_name VARCHAR(1024) NOT NULL COMMENT 'partition name',
+    statistic_name VARCHAR(128) NOT NULL COMMENT 'statistic name',
+    statistic_value CLOB NOT NULL COMMENT 'statistic value as JSON',
+    audit_info CLOB NOT NULL COMMENT 'audit information as JSON',
+    created_at BIGINT NOT NULL COMMENT 'creation timestamp in milliseconds',
+    updated_at BIGINT NOT NULL COMMENT 'last update timestamp in milliseconds',
+    PRIMARY KEY (table_id, partition_name, statistic_name)
+);
+
+CREATE INDEX IF NOT EXISTS idx_table_partition ON partition_statistic_meta(table_id, partition_name);
+
+-- Optimizer metrics schema
+CREATE TABLE IF NOT EXISTS `table_metrics` (
+    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'auto increment id',
+    `table_identifier` VARCHAR(1024) NOT NULL COMMENT 'normalized table identifier',
+    `metric_name` VARCHAR(1024) NOT NULL COMMENT 'metric name',
+    `table_partition` VARCHAR(1024) DEFAULT NULL COMMENT 'normalized partition identifier',
+    `metric_ts` BIGINT(20) NOT NULL COMMENT 'metric timestamp in epoch seconds',
+    `metric_value` VARCHAR(1024) NOT NULL COMMENT 'metric value payload',
+    PRIMARY KEY (`id`)
+) ENGINE=InnoDB COMMENT='optimizer table metrics';
+
+CREATE TABLE IF NOT EXISTS `job_metrics` (
+    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'auto increment id',
+    `job_identifier` VARCHAR(1024) NOT NULL COMMENT 'normalized job identifier',
+    `metric_name` VARCHAR(1024) NOT NULL COMMENT 'metric name',
+    `metric_ts` BIGINT(20) NOT NULL COMMENT 'metric timestamp in epoch seconds',
+    `metric_value` VARCHAR(1024) NOT NULL COMMENT 'metric value payload',
+    PRIMARY KEY (`id`)
+) ENGINE=InnoDB COMMENT='optimizer job metrics';
+
+CREATE INDEX IF NOT EXISTS `idx_table_metrics_metric_ts` ON `table_metrics`(`metric_ts`);
+CREATE INDEX IF NOT EXISTS `idx_job_metrics_metric_ts` ON `job_metrics`(`metric_ts`);
+CREATE INDEX IF NOT EXISTS `idx_table_metrics_composite`
+  ON `table_metrics`(`table_identifier`, `table_partition`, `metric_ts`);
+CREATE INDEX IF NOT EXISTS `idx_job_metrics_identifier_metric_ts`
+  ON `job_metrics`(`job_identifier`, `metric_ts`);

--- a/scripts/h2/upgrade-1.2.0-to-1.3.0-h2.sql
+++ b/scripts/h2/upgrade-1.2.0-to-1.3.0-h2.sql
@@ -1,0 +1,32 @@
+--
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file--
+--  distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"). You may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--  http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+--
+
+-- Add version columns for Phase 2 version-validated auth cache
+
+ALTER TABLE `role_meta`
+    ADD COLUMN `securable_objects_version` INT UNSIGNED NOT NULL DEFAULT 1
+    COMMENT 'Incremented atomically with any privilege grant/revoke for this role';
+
+ALTER TABLE `user_meta`
+    ADD COLUMN `role_grants_version` INT UNSIGNED NOT NULL DEFAULT 1
+    COMMENT 'Incremented atomically with any role assignment/revocation for this user';
+
+ALTER TABLE `group_meta`
+    ADD COLUMN `role_grants_version` INT UNSIGNED NOT NULL DEFAULT 1
+    COMMENT 'Incremented atomically with any role assignment/revocation for this group';

--- a/scripts/mysql/schema-1.3.0-mysql.sql
+++ b/scripts/mysql/schema-1.3.0-mysql.sql
@@ -1,0 +1,529 @@
+--
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file--
+--  distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"). You may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--  http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+--
+
+CREATE TABLE IF NOT EXISTS `metalake_meta` (
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `metalake_name` VARCHAR(128) NOT NULL COMMENT 'metalake name',
+    `metalake_comment` VARCHAR(256) DEFAULT '' COMMENT 'metalake comment',
+    `properties` MEDIUMTEXT DEFAULT NULL COMMENT 'metalake properties',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'metalake audit info',
+    `schema_version` MEDIUMTEXT NOT NULL COMMENT 'metalake schema version info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'metalake current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'metalake last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'metalake deleted at',
+    PRIMARY KEY (`metalake_id`),
+    UNIQUE KEY `uk_mn_del` (`metalake_name`, `deleted_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'metalake metadata';
+
+CREATE TABLE IF NOT EXISTS `catalog_meta` (
+    `catalog_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'catalog id',
+    `catalog_name` VARCHAR(128) NOT NULL COMMENT 'catalog name',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `type` VARCHAR(64) NOT NULL COMMENT 'catalog type',
+    `provider` VARCHAR(64) NOT NULL COMMENT 'catalog provider',
+    `catalog_comment` VARCHAR(256) DEFAULT '' COMMENT 'catalog comment',
+    `properties` MEDIUMTEXT DEFAULT NULL COMMENT 'catalog properties',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'catalog audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'catalog current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'catalog last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'catalog deleted at',
+    PRIMARY KEY (`catalog_id`),
+    UNIQUE KEY `uk_mid_cn_del` (`metalake_id`, `catalog_name`, `deleted_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'catalog metadata';
+
+CREATE TABLE IF NOT EXISTS `schema_meta` (
+    `schema_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'schema id',
+    `schema_name` VARCHAR(128) NOT NULL COMMENT 'schema name',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `catalog_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'catalog id',
+    `schema_comment` VARCHAR(256) DEFAULT '' COMMENT 'schema comment',
+    `properties` MEDIUMTEXT DEFAULT NULL COMMENT 'schema properties',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'schema audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'schema current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'schema last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'schema deleted at',
+    PRIMARY KEY (`schema_id`),
+    UNIQUE KEY `uk_cid_sn_del` (`catalog_id`, `schema_name`, `deleted_at`),
+    KEY `idx_mid` (`metalake_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'schema metadata';
+
+CREATE TABLE IF NOT EXISTS `table_meta` (
+    `table_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'table id',
+    `table_name` VARCHAR(128) NOT NULL COMMENT 'table name',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `catalog_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'catalog id',
+    `schema_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'schema id',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'table audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'table current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'table last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'table deleted at',
+    PRIMARY KEY (`table_id`),
+    UNIQUE KEY `uk_sid_tn_del` (`schema_id`, `table_name`, `deleted_at`),
+    KEY `idx_mid` (`metalake_id`),
+    KEY `idx_cid` (`catalog_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'table metadata';
+
+CREATE TABLE IF NOT EXISTS `table_column_version_info` (
+    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'auto increment id',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `catalog_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'catalog id',
+    `schema_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'schema id',
+    `table_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'table id',
+    `table_version` INT UNSIGNED NOT NULL COMMENT 'table version',
+    `column_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'column id',
+    `column_name` VARCHAR(128) NOT NULL COMMENT 'column name',
+    `column_position` INT UNSIGNED NOT NULL COMMENT 'column position, starting from 0',
+    `column_type` TEXT NOT NULL COMMENT 'column type',
+    `column_comment` VARCHAR(256) DEFAULT '' COMMENT 'column comment',
+    `column_nullable` TINYINT(1) NOT NULL DEFAULT 1 COMMENT 'column nullable, 0 is not nullable, 1 is nullable',
+    `column_auto_increment` TINYINT(1) NOT NULL DEFAULT 0 COMMENT 'column auto increment, 0 is not auto increment, 1 is auto increment',
+    `column_default_value` TEXT DEFAULT NULL COMMENT 'column default value',
+    `column_op_type` TINYINT(1) NOT NULL COMMENT 'column operation type, 1 is create, 2 is update, 3 is delete',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'column deleted at',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'column audit info',
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `uk_tid_ver_cid_del` (`table_id`, `table_version`, `column_id`, `deleted_at`),
+    KEY `idx_mid` (`metalake_id`),
+    KEY `idx_cid` (`catalog_id`),
+    KEY `idx_sid` (`schema_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'table column version info';
+
+CREATE TABLE IF NOT EXISTS `fileset_meta` (
+    `fileset_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'fileset id',
+    `fileset_name` VARCHAR(128) NOT NULL COMMENT 'fileset name',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `catalog_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'catalog id',
+    `schema_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'schema id',
+    `type` VARCHAR(64) NOT NULL COMMENT 'fileset type',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'fileset audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'fileset current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'fileset last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'fileset deleted at',
+    PRIMARY KEY (`fileset_id`),
+    UNIQUE KEY `uk_sid_fn_del` (`schema_id`, `fileset_name`, `deleted_at`),
+    KEY `idx_mid` (`metalake_id`),
+    KEY `idx_cid` (`catalog_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'fileset metadata';
+
+CREATE TABLE IF NOT EXISTS `fileset_version_info` (
+    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'auto increment id',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `catalog_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'catalog id',
+    `schema_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'schema id',
+    `fileset_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'fileset id',
+    `version` INT UNSIGNED NOT NULL COMMENT 'fileset info version',
+    `fileset_comment` VARCHAR(256) DEFAULT '' COMMENT 'fileset comment',
+    `properties` MEDIUMTEXT DEFAULT NULL COMMENT 'fileset properties',
+    `storage_location_name` VARCHAR(256) NOT NULL DEFAULT 'default' COMMENT 'fileset storage location name',
+    `storage_location` MEDIUMTEXT NOT NULL COMMENT 'fileset storage location',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'fileset deleted at',
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `uk_fid_ver_sto_del` (`fileset_id`, `version`, `storage_location_name`, `deleted_at`),
+    KEY `idx_mid` (`metalake_id`),
+    KEY `idx_cid` (`catalog_id`),
+    KEY `idx_sid` (`schema_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'fileset version info';
+
+CREATE TABLE IF NOT EXISTS `topic_meta` (
+    `topic_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'topic id',
+    `topic_name` VARCHAR(128) NOT NULL COMMENT 'topic name',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `catalog_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'catalog id',
+    `schema_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'schema id',
+    `comment` VARCHAR(256) DEFAULT '' COMMENT 'topic comment',
+    `properties` MEDIUMTEXT DEFAULT NULL COMMENT 'topic properties',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'topic audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'topic current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'topic last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'topic deleted at',
+    PRIMARY KEY (`topic_id`),
+    UNIQUE KEY `uk_sid_tn_del` (`schema_id`, `topic_name`, `deleted_at`),
+    KEY `idx_mid` (`metalake_id`),
+    KEY `idx_cid` (`catalog_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'topic metadata';
+
+CREATE TABLE IF NOT EXISTS `user_meta` (
+    `user_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'user id',
+    `user_name` VARCHAR(128) NOT NULL COMMENT 'username',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'user audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'user current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'user last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'user deleted at',
+    `role_grants_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'version bumped on any role assignment change for this user',
+    PRIMARY KEY (`user_id`),
+    UNIQUE KEY `uk_mid_us_del` (`metalake_id`, `user_name`, `deleted_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'user metadata';
+
+CREATE TABLE IF NOT EXISTS `role_meta` (
+    `role_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'role id',
+    `role_name` VARCHAR(128) NOT NULL COMMENT 'role name',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `properties` MEDIUMTEXT DEFAULT NULL COMMENT 'schema properties',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'role audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'role current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'role last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'role deleted at',
+    `securable_objects_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'version bumped on any privilege change for this role',
+    PRIMARY KEY (`role_id`),
+    UNIQUE KEY `uk_mid_rn_del` (`metalake_id`, `role_name`, `deleted_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'role metadata';
+
+CREATE TABLE IF NOT EXISTS `role_meta_securable_object` (
+    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'auto increment id',
+    `role_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'role id',
+    `metadata_object_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'The entity id of securable object',
+    `type`  VARCHAR(128) NOT NULL COMMENT 'securable object type',
+    `privilege_names` TEXT(81920) NOT NULL COMMENT 'securable object privilege names',
+    `privilege_conditions` TEXT(81920) NOT NULL COMMENT 'securable object privilege conditions',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'securable object current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'securable object last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'securable object deleted at',
+    PRIMARY KEY (`id`),
+    KEY `idx_obj_rid` (`role_id`),
+    KEY `idx_obj_eid` (`metadata_object_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'securable object meta';
+
+CREATE TABLE IF NOT EXISTS `user_role_rel` (
+    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'auto increment id',
+    `user_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'user id',
+    `role_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'role id',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'relation audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'relation current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'relation last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'relation deleted at',
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `uk_ui_ri_del` (`user_id`, `role_id`, `deleted_at`),
+    KEY `idx_rid` (`role_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'user role relation';
+
+CREATE TABLE IF NOT EXISTS `group_meta` (
+    `group_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'group id',
+    `group_name` VARCHAR(128) NOT NULL COMMENT 'group name',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'group audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'group current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'group last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'group deleted at',
+    `role_grants_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'version bumped on any role assignment change for this group',
+    PRIMARY KEY (`group_id`),
+    UNIQUE KEY `uk_mid_gr_del` (`metalake_id`, `group_name`, `deleted_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'group metadata';
+
+CREATE TABLE IF NOT EXISTS `group_role_rel` (
+    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'auto increment id',
+    `group_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'group id',
+    `role_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'role id',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'relation audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'relation current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'relation last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'relation deleted at',
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `uk_gi_ri_del` (`group_id`, `role_id`, `deleted_at`),
+    KEY `idx_rid` (`group_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'group role relation';
+
+CREATE TABLE IF NOT EXISTS `tag_meta` (
+    `tag_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'tag id',
+    `tag_name` VARCHAR(128) NOT NULL COMMENT 'tag name',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `tag_comment` VARCHAR(256) DEFAULT '' COMMENT 'tag comment',
+    `properties` MEDIUMTEXT DEFAULT NULL COMMENT 'tag properties',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'tag audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'tag current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'tag last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'tag deleted at',
+    PRIMARY KEY (`tag_id`),
+    UNIQUE KEY `uk_mi_tn_del` (`metalake_id`, `tag_name`, `deleted_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'tag metadata';
+
+CREATE TABLE IF NOT EXISTS `tag_relation_meta` (
+    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'auto increment id',
+    `tag_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'tag id',
+    `metadata_object_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metadata object id',
+    `metadata_object_type` VARCHAR(64) NOT NULL COMMENT 'metadata object type',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'tag relation audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'tag relation current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'tag relation last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'tag relation deleted at',
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `uk_ti_mi_mo_del` (`tag_id`, `metadata_object_id`, `metadata_object_type`, `deleted_at`),
+    KEY `idx_tid` (`tag_id`),
+    KEY `idx_mid` (`metadata_object_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'tag metadata object relation';
+
+CREATE TABLE IF NOT EXISTS `owner_meta` (
+    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'auto increment id',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `owner_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'owner id',
+    `owner_type` VARCHAR(64) NOT NULL COMMENT 'owner type',
+    `metadata_object_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metadata object id',
+    `metadata_object_type` VARCHAR(64) NOT NULL COMMENT 'metadata object type',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'owner relation audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'owner relation current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'owner relation last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'owner relation deleted at',
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `uk_ow_me_del` (`owner_id`, `metadata_object_id`, `metadata_object_type`,`deleted_at`),
+    KEY `idx_oid` (`owner_id`),
+    KEY `idx_meid` (`metadata_object_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'owner relation';
+
+CREATE TABLE IF NOT EXISTS `model_meta` (
+    `model_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'model id',
+    `model_name` VARCHAR(128) NOT NULL COMMENT 'model name',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `catalog_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'catalog id',
+    `schema_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'schema id',
+    `model_comment` TEXT DEFAULT NULL COMMENT 'model comment',
+    `model_properties` MEDIUMTEXT DEFAULT NULL COMMENT 'model properties',
+    `model_latest_version` INT UNSIGNED DEFAULT 0 COMMENT 'model latest version',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'model audit info',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'model deleted at',
+    PRIMARY KEY (`model_id`),
+    UNIQUE KEY `uk_sid_mn_del` (`schema_id`, `model_name`, `deleted_at`),
+    KEY `idx_mid` (`metalake_id`),
+    KEY `idx_cid` (`catalog_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'model metadata';
+
+CREATE TABLE IF NOT EXISTS `model_version_info` (
+    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'auto increment id',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `catalog_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'catalog id',
+    `schema_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'schema id',
+    `model_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'model id',
+    `version` INT UNSIGNED NOT NULL COMMENT 'model version',
+    `model_version_comment` TEXT DEFAULT NULL COMMENT 'model version comment',
+    `model_version_properties` MEDIUMTEXT DEFAULT NULL COMMENT 'model version properties',
+    `model_version_uri_name` VARCHAR(256) NOT NULL COMMENT 'model version uri name',
+    `model_version_uri` TEXT NOT NULL COMMENT 'model storage uri',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'model version audit info',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'model version deleted at',
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `uk_mid_ver_uri_del` (`model_id`, `version`, `model_version_uri_name`, `deleted_at`),
+    KEY `idx_mid` (`metalake_id`),
+    KEY `idx_cid` (`catalog_id`),
+    KEY `idx_sid` (`schema_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'model version info';
+
+CREATE TABLE IF NOT EXISTS `model_version_alias_rel` (
+    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'auto increment id',
+    `model_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'model id',
+    `model_version` INT UNSIGNED NOT NULL COMMENT 'model version',
+    `model_version_alias` VARCHAR(128) NOT NULL COMMENT 'model version alias',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'model version alias deleted at',
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `uk_mi_mva_del` (`model_id`, `model_version_alias`, `deleted_at`),
+    KEY `idx_mva` (`model_version_alias`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'model_version_alias_rel';
+
+CREATE TABLE IF NOT EXISTS `policy_meta` (
+    `policy_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'policy id',
+    `policy_name` VARCHAR(128) NOT NULL COMMENT 'policy name',
+    `policy_type` VARCHAR(64) NOT NULL COMMENT 'policy type',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'policy audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'policy current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'policy last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'policy deleted at',
+    PRIMARY KEY (`policy_id`),
+    UNIQUE KEY `uk_mi_pn_del` (`metalake_id`, `policy_name`, `deleted_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'policy metadata';
+
+CREATE TABLE IF NOT EXISTS `policy_version_info` (
+    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'auto increment id',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `policy_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'policy id',
+    `version` INT UNSIGNED NOT NULL COMMENT 'policy info version',
+    `policy_comment` TEXT DEFAULT NULL COMMENT 'policy info comment',
+    `enabled` TINYINT(1) DEFAULT 1 COMMENT 'whether the policy is enabled, 0 is disabled, 1 is enabled',
+    `content` MEDIUMTEXT DEFAULT NULL COMMENT 'policy content',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'policy deleted at',
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `uk_pod_ver_del` (`policy_id`, `version`, `deleted_at`),
+    KEY `idx_mid` (`metalake_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'policy version info';
+
+CREATE TABLE IF NOT EXISTS `policy_relation_meta` (
+    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'auto increment id',
+    `policy_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'policy id',
+    `metadata_object_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metadata object id',
+    `metadata_object_type` VARCHAR(64) NOT NULL COMMENT 'metadata object type',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'policy relation audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'policy relation current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'policy relation last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'policy relation deleted at',
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `uk_pi_mi_mo_del` (`policy_id`, `metadata_object_id`, `metadata_object_type`, `deleted_at`),
+    KEY `idx_pid` (`policy_id`),
+    KEY `idx_mid` (`metadata_object_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'policy metadata object relation';
+
+CREATE TABLE IF NOT EXISTS `statistic_meta` (
+    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'auto increment id',
+    `statistic_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'statistic id',
+    `statistic_name` VARCHAR(128) NOT NULL COMMENT 'statistic name',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `statistic_value` MEDIUMTEXT NOT NULL COMMENT 'statistic value',
+    `metadata_object_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metadata object id',
+    `metadata_object_type` VARCHAR(64) NOT NULL COMMENT 'metadata object type',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'statistic audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'statistic current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'statistic last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'statistic deleted at',
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `uk_si_mi_mo_del` (`statistic_name`, `metadata_object_id`, `deleted_at`),
+    KEY `idx_stid` (`statistic_id`),
+    KEY `idx_moid` (`metadata_object_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'statistic metadata';
+
+CREATE TABLE IF NOT EXISTS `job_template_meta` (
+    `job_template_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'job template id',
+    `job_template_name` VARCHAR(128) NOT NULL COMMENT 'job template name',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `job_template_comment` TEXT DEFAULT NULL COMMENT 'job template comment',
+    `job_template_content` MEDIUMTEXT NOT NULL COMMENT 'job template content',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'job template audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'job template current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'job template last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'job template deleted at',
+    PRIMARY KEY (`job_template_id`),
+    UNIQUE KEY `uk_mid_jtn_del` (`metalake_id`, `job_template_name`, `deleted_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'job template metadata';
+
+CREATE TABLE IF NOT EXISTS `job_run_meta` (
+    `job_run_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'job run id',
+    `job_template_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'job template id',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `job_execution_id` varchar(256) NOT NULL COMMENT 'job execution id',
+    `job_run_status` varchar(64) NOT NULL COMMENT 'job run status',
+    `job_finished_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'job finished at',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'job run audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'job run current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'job run last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'job run deleted at',
+    PRIMARY KEY (`job_run_id`),
+    UNIQUE KEY `uk_mid_jei_del` (`metalake_id`, `job_execution_id`, `deleted_at`),
+    KEY `idx_job_template_id` (`job_template_id`),
+    KEY `idx_job_execution_id` (`job_execution_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'job run metadata';
+
+CREATE TABLE IF NOT EXISTS `table_version_info` (
+    `table_id`        BIGINT(20) UNSIGNED NOT NULL COMMENT 'table id',
+    `format`          VARCHAR(64) COMMENT 'table format, such as Lance, Iceberg and so on, it will be null if it is not a lakehouse table',
+    `properties`      MEDIUMTEXT DEFAULT NULL COMMENT 'table properties',
+    `partitioning`  MEDIUMTEXT DEFAULT NULL COMMENT 'table partition info',
+    `distribution` MEDIUMTEXT DEFAULT NULL COMMENT 'table distribution info',
+    `sort_orders` MEDIUMTEXT DEFAULT NULL COMMENT 'table sort order info',
+    `indexes`      MEDIUMTEXT DEFAULT NULL COMMENT 'table index info',
+    `comment`   MEDIUMTEXT DEFAULT NULL COMMENT 'table comment',
+    `version` BIGINT(20) UNSIGNED COMMENT 'table current version',
+    `deleted_at`      BIGINT(20) UNSIGNED DEFAULT 0 COMMENT 'table deletion timestamp, 0 means not deleted',
+    UNIQUE KEY `uk_table_id_version_deleted_at` (`table_id`, `version`, `deleted_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'table detail information including format, location, properties, partition, distribution, sort order, index and so on';
+
+CREATE TABLE IF NOT EXISTS `function_meta` (
+    `function_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'function id',
+    `function_name` VARCHAR(128) NOT NULL COMMENT 'function name',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `catalog_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'catalog id',
+    `schema_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'schema id',
+    `function_type` VARCHAR(64) NOT NULL COMMENT 'function type',
+    `deterministic` TINYINT(1) DEFAULT 1 COMMENT 'whether the function result is deterministic',
+    `function_current_version` INT UNSIGNED DEFAULT 1 COMMENT 'function current version',
+    `function_latest_version` INT UNSIGNED DEFAULT 1 COMMENT 'function latest version',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'function audit info',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'function deleted at',
+    PRIMARY KEY (`function_id`),
+    UNIQUE KEY `uk_sid_fn_del` (`schema_id`, `function_name`, `deleted_at`),
+    KEY `idx_mid` (`metalake_id`),
+    KEY `idx_cid` (`catalog_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'function metadata';
+
+CREATE TABLE IF NOT EXISTS `function_version_info` (
+    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'auto increment id',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `catalog_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'catalog id',
+    `schema_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'schema id',
+    `function_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'function id',
+    `version` INT UNSIGNED NOT NULL COMMENT 'function version',
+    `function_comment` TEXT DEFAULT NULL COMMENT 'function version comment',
+    `definitions` MEDIUMTEXT NOT NULL COMMENT 'function definitions details',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'function version audit info',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'function version deleted at',
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `uk_fid_ver_del` (`function_id`, `version`, `deleted_at`),
+    KEY `idx_mid` (`metalake_id`),
+    KEY `idx_cid` (`catalog_id`),
+    KEY `idx_sid` (`schema_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'function version info';
+
+CREATE TABLE IF NOT EXISTS `view_meta` (
+    `view_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'view id',
+    `view_name` VARCHAR(128) NOT NULL COMMENT 'view name',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `catalog_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'catalog id',
+    `schema_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'schema id',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'view current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'view last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'view deleted at',
+    PRIMARY KEY (`view_id`),
+    UNIQUE KEY `uk_sid_vn_del` (`schema_id`, `view_name`, `deleted_at`),
+    KEY `idx_vemid` (`metalake_id`),
+    KEY `idx_vecid` (`catalog_id`)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'view metadata';
+
+-- This schema extends version 1.1.0 with partition statistics storage support
+-- The partition_statistic_meta table stores partition-level statistics for tables
+
+CREATE TABLE IF NOT EXISTS `partition_statistic_meta` (
+    `table_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'table id from table_meta',
+    `partition_name` VARCHAR(1024) NOT NULL COMMENT 'partition name',
+    `statistic_name` VARCHAR(128) NOT NULL COMMENT 'statistic name',
+    `statistic_value` MEDIUMTEXT NOT NULL COMMENT 'statistic value as JSON',
+    `audit_info` TEXT NOT NULL COMMENT 'audit information as JSON',
+    `created_at` BIGINT(20) UNSIGNED NOT NULL COMMENT 'creation timestamp in milliseconds',
+    `updated_at` BIGINT(20) UNSIGNED NOT NULL COMMENT 'last update timestamp in milliseconds',
+    PRIMARY KEY (`table_id`, `partition_name`(255), `statistic_name`),
+    KEY `idx_table_partition` (`table_id`, `partition_name`(255))
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'partition statistics metadata';
+
+-- Optimizer metrics schema
+CREATE TABLE IF NOT EXISTS `table_metrics` (
+    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'auto increment id',
+    `table_identifier` VARCHAR(1024) NOT NULL COMMENT 'normalized table identifier',
+    `metric_name` VARCHAR(1024) NOT NULL COMMENT 'metric name',
+    `table_partition` VARCHAR(1024) DEFAULT NULL COMMENT 'normalized partition identifier',
+    `metric_ts` BIGINT(20) NOT NULL COMMENT 'metric timestamp in epoch seconds',
+    `metric_value` VARCHAR(1024) NOT NULL COMMENT 'metric value payload',
+    PRIMARY KEY (`id`),
+    KEY `idx_table_metrics_metric_ts` (`metric_ts`),
+    KEY `idx_table_metrics_composite` (`table_identifier`(255), `table_partition`(255), `metric_ts`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'optimizer table metrics';
+
+CREATE TABLE IF NOT EXISTS `job_metrics` (
+    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'auto increment id',
+    `job_identifier` VARCHAR(1024) NOT NULL COMMENT 'normalized job identifier',
+    `metric_name` VARCHAR(1024) NOT NULL COMMENT 'metric name',
+    `metric_ts` BIGINT(20) NOT NULL COMMENT 'metric timestamp in epoch seconds',
+    `metric_value` VARCHAR(1024) NOT NULL COMMENT 'metric value payload',
+    PRIMARY KEY (`id`),
+    KEY `idx_job_metrics_metric_ts` (`metric_ts`),
+    KEY `idx_job_metrics_identifier_metric_ts` (`job_identifier`(255), `metric_ts`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'optimizer job metrics';

--- a/scripts/mysql/upgrade-1.2.0-to-1.3.0-mysql.sql
+++ b/scripts/mysql/upgrade-1.2.0-to-1.3.0-mysql.sql
@@ -1,0 +1,32 @@
+--
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file--
+--  distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"). You may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--  http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+--
+
+-- Add version columns for Phase 2 version-validated auth cache
+
+ALTER TABLE `role_meta`
+    ADD COLUMN `securable_objects_version` INT UNSIGNED NOT NULL DEFAULT 1
+    COMMENT 'Incremented atomically with any privilege grant/revoke for this role';
+
+ALTER TABLE `user_meta`
+    ADD COLUMN `role_grants_version` INT UNSIGNED NOT NULL DEFAULT 1
+    COMMENT 'Incremented atomically with any role assignment/revocation for this user';
+
+ALTER TABLE `group_meta`
+    ADD COLUMN `role_grants_version` INT UNSIGNED NOT NULL DEFAULT 1
+    COMMENT 'Incremented atomically with any role assignment/revocation for this group';

--- a/scripts/postgresql/schema-1.3.0-postgresql.sql
+++ b/scripts/postgresql/schema-1.3.0-postgresql.sql
@@ -1,0 +1,931 @@
+--
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file--
+--  distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"). You may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--  http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+--
+
+-- Note: Database and schema creation is not included in this script. Please create the database and
+-- schema before running this script. for example in psql:
+-- CREATE DATABASE example_db;
+-- \c example_db
+-- CREATE SCHEMA example_schema;
+-- set search_path to example_schema;
+
+CREATE TABLE IF NOT EXISTS metalake_meta (
+    metalake_id BIGINT NOT NULL,
+    metalake_name VARCHAR(128) NOT NULL,
+    metalake_comment VARCHAR(256) DEFAULT '',
+    properties TEXT DEFAULT NULL,
+    audit_info TEXT NOT NULL,
+    schema_version TEXT NOT NULL,
+    current_version INT NOT NULL DEFAULT 1,
+    last_version INT NOT NULL DEFAULT 1,
+    deleted_at BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (metalake_id),
+    UNIQUE (metalake_name, deleted_at)
+);
+COMMENT ON TABLE metalake_meta IS 'metalake metadata';
+
+COMMENT ON COLUMN metalake_meta.metalake_id IS 'metalake id';
+COMMENT ON COLUMN metalake_meta.metalake_name IS 'metalake name';
+COMMENT ON COLUMN metalake_meta.metalake_comment IS 'metalake comment';
+COMMENT ON COLUMN metalake_meta.properties IS 'metalake properties';
+COMMENT ON COLUMN metalake_meta.audit_info IS 'metalake audit info';
+COMMENT ON COLUMN metalake_meta.schema_version IS 'metalake schema version info';
+COMMENT ON COLUMN metalake_meta.current_version IS 'metalake current version';
+COMMENT ON COLUMN metalake_meta.last_version IS 'metalake last version';
+COMMENT ON COLUMN metalake_meta.deleted_at IS 'metalake deleted at';
+
+
+CREATE TABLE IF NOT EXISTS catalog_meta (
+    catalog_id BIGINT NOT NULL,
+    catalog_name VARCHAR(128) NOT NULL,
+    metalake_id BIGINT NOT NULL,
+    type VARCHAR(64) NOT NULL,
+    provider VARCHAR(64) NOT NULL,
+    catalog_comment VARCHAR(256) DEFAULT '',
+    properties TEXT DEFAULT NULL,
+    audit_info TEXT NOT NULL,
+    current_version INT NOT NULL DEFAULT 1,
+    last_version INT NOT NULL DEFAULT 1,
+    deleted_at BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (catalog_id),
+    UNIQUE (metalake_id, catalog_name, deleted_at)
+);
+
+COMMENT ON TABLE catalog_meta IS 'catalog metadata';
+
+COMMENT ON COLUMN catalog_meta.catalog_id IS 'catalog id';
+COMMENT ON COLUMN catalog_meta.catalog_name IS 'catalog name';
+COMMENT ON COLUMN catalog_meta.metalake_id IS 'metalake id';
+COMMENT ON COLUMN catalog_meta.type IS 'catalog type';
+COMMENT ON COLUMN catalog_meta.provider IS 'catalog provider';
+COMMENT ON COLUMN catalog_meta.catalog_comment IS 'catalog comment';
+COMMENT ON COLUMN catalog_meta.properties IS 'catalog properties';
+COMMENT ON COLUMN catalog_meta.audit_info IS 'catalog audit info';
+COMMENT ON COLUMN catalog_meta.current_version IS 'catalog current version';
+COMMENT ON COLUMN catalog_meta.last_version IS 'catalog last version';
+COMMENT ON COLUMN catalog_meta.deleted_at IS 'catalog deleted at';
+
+
+CREATE TABLE IF NOT EXISTS schema_meta (
+    schema_id BIGINT NOT NULL,
+    schema_name VARCHAR(128) NOT NULL,
+    metalake_id BIGINT NOT NULL,
+    catalog_id BIGINT NOT NULL,
+    schema_comment VARCHAR(256) DEFAULT '',
+    properties TEXT DEFAULT NULL,
+    audit_info TEXT NOT NULL,
+    current_version INT NOT NULL DEFAULT 1,
+    last_version INT NOT NULL DEFAULT 1,
+    deleted_at BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (schema_id),
+    UNIQUE (catalog_id, schema_name, deleted_at)
+);
+
+CREATE INDEX IF NOT EXISTS schema_meta_idx_metalake_id ON schema_meta (metalake_id);
+COMMENT ON TABLE schema_meta IS 'schema metadata';
+
+COMMENT ON COLUMN schema_meta.schema_id IS 'schema id';
+COMMENT ON COLUMN schema_meta.schema_name IS 'schema name';
+COMMENT ON COLUMN schema_meta.metalake_id IS 'metalake id';
+COMMENT ON COLUMN schema_meta.catalog_id IS 'catalog id';
+COMMENT ON COLUMN schema_meta.schema_comment IS 'schema comment';
+COMMENT ON COLUMN schema_meta.properties IS 'schema properties';
+COMMENT ON COLUMN schema_meta.audit_info IS 'schema audit info';
+COMMENT ON COLUMN schema_meta.current_version IS 'schema current version';
+COMMENT ON COLUMN schema_meta.last_version IS 'schema last version';
+COMMENT ON COLUMN schema_meta.deleted_at IS 'schema deleted at';
+
+
+CREATE TABLE IF NOT EXISTS table_meta (
+    table_id BIGINT NOT NULL,
+    table_name VARCHAR(128) NOT NULL,
+    metalake_id BIGINT NOT NULL,
+    catalog_id BIGINT NOT NULL,
+    schema_id BIGINT NOT NULL,
+    audit_info TEXT NOT NULL,
+    current_version INT NOT NULL DEFAULT 1,
+    last_version INT NOT NULL DEFAULT 1,
+    deleted_at BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (table_id),
+    UNIQUE (schema_id, table_name, deleted_at)
+);
+
+CREATE INDEX IF NOT EXISTS table_meta_idx_metalake_id ON table_meta (metalake_id);
+CREATE INDEX IF NOT EXISTS table_meta_idx_catalog_id ON table_meta (catalog_id);
+COMMENT ON TABLE table_meta IS 'table metadata';
+
+COMMENT ON COLUMN table_meta.table_id IS 'table id';
+COMMENT ON COLUMN table_meta.table_name IS 'table name';
+COMMENT ON COLUMN table_meta.metalake_id IS 'metalake id';
+COMMENT ON COLUMN table_meta.catalog_id IS 'catalog id';
+COMMENT ON COLUMN table_meta.schema_id IS 'schema id';
+COMMENT ON COLUMN table_meta.audit_info IS 'table audit info';
+COMMENT ON COLUMN table_meta.current_version IS 'table current version';
+COMMENT ON COLUMN table_meta.last_version IS 'table last version';
+COMMENT ON COLUMN table_meta.deleted_at IS 'table deleted at';
+
+CREATE TABLE IF NOT EXISTS table_column_version_info (
+    id BIGINT NOT NULL GENERATED BY DEFAULT AS IDENTITY,
+    metalake_id BIGINT NOT NULL,
+    catalog_id BIGINT NOT NULL,
+    schema_id BIGINT NOT NULL,
+    table_id BIGINT NOT NULL,
+    table_version INT NOT NULL,
+    column_id BIGINT NOT NULL,
+    column_name VARCHAR(128) NOT NULL,
+    column_position INT NOT NULL,
+    column_type TEXT NOT NULL,
+    column_comment VARCHAR(256) DEFAULT '',
+    column_nullable SMALLINT NOT NULL DEFAULT 1,
+    column_auto_increment SMALLINT NOT NULL DEFAULT 0,
+    column_default_value TEXT DEFAULT NULL,
+    column_op_type SMALLINT NOT NULL,
+    deleted_at BIGINT NOT NULL DEFAULT 0,
+    audit_info TEXT NOT NULL,
+    PRIMARY KEY (id),
+    UNIQUE (table_id, table_version, column_id, deleted_at)
+);
+CREATE INDEX table_column_version_info_idx_mid ON table_column_version_info (metalake_id);
+CREATE INDEX table_column_version_info_idx_cid ON table_column_version_info (catalog_id);
+CREATE INDEX table_column_version_info_idx_sid ON table_column_version_info (schema_id);
+COMMENT ON TABLE table_column_version_info IS 'table column version information';
+
+COMMENT ON COLUMN table_column_version_info.id IS 'auto increment id';
+COMMENT ON COLUMN table_column_version_info.metalake_id IS 'metalake id';
+COMMENT ON COLUMN table_column_version_info.catalog_id IS 'catalog id';
+COMMENT ON COLUMN table_column_version_info.schema_id IS 'schema id';
+COMMENT ON COLUMN table_column_version_info.table_id IS 'table id';
+COMMENT ON COLUMN table_column_version_info.table_version IS 'table version';
+COMMENT ON COLUMN table_column_version_info.column_id IS 'column id';
+COMMENT ON COLUMN table_column_version_info.column_name IS 'column name';
+COMMENT ON COLUMN table_column_version_info.column_position IS 'column position, starting from 0';
+COMMENT ON COLUMN table_column_version_info.column_type IS 'column type';
+COMMENT ON COLUMN table_column_version_info.column_comment IS 'column comment';
+COMMENT ON COLUMN table_column_version_info.column_nullable IS 'column nullable, 0 is not nullable, 1 is nullable';
+COMMENT ON COLUMN table_column_version_info.column_auto_increment IS 'column auto increment, 0 is not auto increment, 1 is auto increment';
+COMMENT ON COLUMN table_column_version_info.column_default_value IS 'column default value';
+COMMENT ON COLUMN table_column_version_info.column_op_type IS 'column operation type, 1 is create, 2 is update, 3 is delete';
+COMMENT ON COLUMN table_column_version_info.deleted_at IS 'column deleted at';
+COMMENT ON COLUMN table_column_version_info.audit_info IS 'column audit info';
+
+
+CREATE TABLE IF NOT EXISTS fileset_meta (
+    fileset_id BIGINT NOT NULL,
+    fileset_name VARCHAR(128) NOT NULL,
+    metalake_id BIGINT NOT NULL,
+    catalog_id BIGINT NOT NULL,
+    schema_id BIGINT NOT NULL,
+    type VARCHAR(64) NOT NULL,
+    audit_info TEXT NOT NULL,
+    current_version INT NOT NULL DEFAULT 1,
+    last_version INT NOT NULL DEFAULT 1,
+    deleted_at BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (fileset_id),
+    UNIQUE (schema_id, fileset_name, deleted_at)
+);
+
+CREATE INDEX IF NOT EXISTS fileset_meta_idx_metalake_id ON fileset_meta (metalake_id);
+CREATE INDEX IF NOT EXISTS fileset_meta_idx_catalog_id ON fileset_meta (catalog_id);
+COMMENT ON TABLE fileset_meta IS 'fileset metadata';
+
+COMMENT ON COLUMN fileset_meta.fileset_id IS 'fileset id';
+COMMENT ON COLUMN fileset_meta.fileset_name IS 'fileset name';
+COMMENT ON COLUMN fileset_meta.metalake_id IS 'metalake id';
+COMMENT ON COLUMN fileset_meta.catalog_id IS 'catalog id';
+COMMENT ON COLUMN fileset_meta.schema_id IS 'schema id';
+COMMENT ON COLUMN fileset_meta.type IS 'fileset type';
+COMMENT ON COLUMN fileset_meta.audit_info IS 'fileset audit info';
+COMMENT ON COLUMN fileset_meta.current_version IS 'fileset current version';
+COMMENT ON COLUMN fileset_meta.last_version IS 'fileset last version';
+COMMENT ON COLUMN fileset_meta.deleted_at IS 'fileset deleted at';
+
+
+CREATE TABLE IF NOT EXISTS fileset_version_info (
+    id BIGINT NOT NULL GENERATED BY DEFAULT AS IDENTITY,
+    metalake_id BIGINT NOT NULL,
+    catalog_id BIGINT NOT NULL,
+    schema_id BIGINT NOT NULL,
+    fileset_id BIGINT NOT NULL,
+    version INT NOT NULL,
+    fileset_comment VARCHAR(256) DEFAULT '',
+    properties TEXT DEFAULT NULL,
+    storage_location_name VARCHAR(256) NOT NULL DEFAULT 'default',
+    storage_location TEXT NOT NULL,
+    deleted_at BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (id),
+    UNIQUE (fileset_id, version, storage_location_name, deleted_at)
+);
+
+CREATE INDEX IF NOT EXISTS fileset_version_info_idx_metalake_id ON fileset_version_info (metalake_id);
+CREATE INDEX IF NOT EXISTS fileset_version_info_idx_idx_catalog_id ON fileset_version_info (catalog_id);
+CREATE INDEX IF NOT EXISTS fileset_version_info_idx_idx_schema_id ON fileset_version_info (schema_id);
+COMMENT ON TABLE fileset_version_info IS 'fileset version information';
+
+COMMENT ON COLUMN fileset_version_info.id IS 'auto increment id';
+COMMENT ON COLUMN fileset_version_info.metalake_id IS 'metalake id';
+COMMENT ON COLUMN fileset_version_info.catalog_id IS 'catalog id';
+COMMENT ON COLUMN fileset_version_info.schema_id IS 'schema id';
+COMMENT ON COLUMN fileset_version_info.fileset_id IS 'fileset id';
+COMMENT ON COLUMN fileset_version_info.version IS 'fileset info version';
+COMMENT ON COLUMN fileset_version_info.fileset_comment IS 'fileset comment';
+COMMENT ON COLUMN fileset_version_info.properties IS 'fileset properties';
+COMMENT ON COLUMN fileset_version_info.storage_location_name IS 'fileset storage location name';
+COMMENT ON COLUMN fileset_version_info.storage_location IS 'fileset storage location';
+COMMENT ON COLUMN fileset_version_info.deleted_at IS 'fileset deleted at';
+
+
+CREATE TABLE IF NOT EXISTS topic_meta (
+    topic_id BIGINT NOT NULL,
+    topic_name VARCHAR(128) NOT NULL,
+    metalake_id BIGINT NOT NULL,
+    catalog_id BIGINT NOT NULL,
+    schema_id BIGINT NOT NULL,
+    comment VARCHAR(256) DEFAULT '',
+    properties TEXT DEFAULT NULL,
+    audit_info TEXT NOT NULL,
+    current_version INT NOT NULL DEFAULT 1,
+    last_version INT NOT NULL DEFAULT 1,
+    deleted_at BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (topic_id),
+    UNIQUE (schema_id, topic_name, deleted_at)
+);
+
+CREATE INDEX IF NOT EXISTS topic_meta_idx_metalake_id ON topic_meta (metalake_id);
+CREATE INDEX IF NOT EXISTS topic_meta_idx_catalog_id ON topic_meta (catalog_id);
+COMMENT ON TABLE topic_meta IS 'topic metadata';
+
+COMMENT ON COLUMN topic_meta.topic_id IS 'topic id';
+COMMENT ON COLUMN topic_meta.topic_name IS 'topic name';
+COMMENT ON COLUMN topic_meta.metalake_id IS 'metalake id';
+COMMENT ON COLUMN topic_meta.catalog_id IS 'catalog id';
+COMMENT ON COLUMN topic_meta.schema_id IS 'schema id';
+COMMENT ON COLUMN topic_meta.comment IS 'topic comment';
+COMMENT ON COLUMN topic_meta.properties IS 'topic properties';
+COMMENT ON COLUMN topic_meta.audit_info IS 'topic audit info';
+COMMENT ON COLUMN topic_meta.current_version IS 'topic current version';
+COMMENT ON COLUMN topic_meta.last_version IS 'topic last version';
+COMMENT ON COLUMN topic_meta.deleted_at IS 'topic deleted at';
+
+
+CREATE TABLE IF NOT EXISTS user_meta (
+    user_id BIGINT NOT NULL,
+    user_name VARCHAR(128) NOT NULL,
+    metalake_id BIGINT NOT NULL,
+    audit_info TEXT NOT NULL,
+    current_version INT NOT NULL DEFAULT 1,
+    last_version INT NOT NULL DEFAULT 1,
+    deleted_at BIGINT NOT NULL DEFAULT 0,
+    role_grants_version INT NOT NULL DEFAULT 1,
+    PRIMARY KEY (user_id),
+    UNIQUE (metalake_id, user_name, deleted_at)
+);
+COMMENT ON TABLE user_meta IS 'user metadata';
+
+COMMENT ON COLUMN user_meta.user_id IS 'user id';
+COMMENT ON COLUMN user_meta.user_name IS 'username';
+COMMENT ON COLUMN user_meta.metalake_id IS 'metalake id';
+COMMENT ON COLUMN user_meta.audit_info IS 'user audit info';
+COMMENT ON COLUMN user_meta.current_version IS 'user current version';
+COMMENT ON COLUMN user_meta.last_version IS 'user last version';
+COMMENT ON COLUMN user_meta.deleted_at IS 'user deleted at';
+COMMENT ON COLUMN user_meta.role_grants_version IS 'version bumped on any role assignment change for this user';
+
+CREATE TABLE IF NOT EXISTS role_meta (
+    role_id BIGINT NOT NULL,
+    role_name VARCHAR(128) NOT NULL,
+    metalake_id BIGINT NOT NULL,
+    properties TEXT DEFAULT NULL,
+    audit_info TEXT NOT NULL,
+    current_version INT NOT NULL DEFAULT 1,
+    last_version INT NOT NULL DEFAULT 1,
+    deleted_at BIGINT NOT NULL DEFAULT 0,
+    securable_objects_version INT NOT NULL DEFAULT 1,
+    PRIMARY KEY (role_id),
+    UNIQUE (metalake_id, role_name, deleted_at)
+);
+
+COMMENT ON TABLE role_meta IS 'role metadata';
+
+COMMENT ON COLUMN role_meta.role_id IS 'role id';
+COMMENT ON COLUMN role_meta.role_name IS 'role name';
+COMMENT ON COLUMN role_meta.metalake_id IS 'metalake id';
+COMMENT ON COLUMN role_meta.properties IS 'role properties';
+COMMENT ON COLUMN role_meta.audit_info IS 'role audit info';
+COMMENT ON COLUMN role_meta.current_version IS 'role current version';
+COMMENT ON COLUMN role_meta.last_version IS 'role last version';
+COMMENT ON COLUMN role_meta.deleted_at IS 'role deleted at';
+COMMENT ON COLUMN role_meta.securable_objects_version IS 'version bumped on any privilege change for this role';
+
+
+CREATE TABLE IF NOT EXISTS role_meta_securable_object (
+    id BIGINT NOT NULL GENERATED BY DEFAULT AS IDENTITY,
+    role_id BIGINT NOT NULL,
+    metadata_object_id BIGINT NOT NULL,
+    type  VARCHAR(128) NOT NULL,
+    privilege_names VARCHAR(81920) NOT NULL,
+    privilege_conditions VARCHAR(81920) NOT NULL,
+    current_version INT NOT NULL DEFAULT 1,
+    last_version INT NOT NULL DEFAULT 1,
+    deleted_at BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (id)
+);
+
+CREATE INDEX IF NOT EXISTS role_meta_securable_object_idx_role_id ON role_meta_securable_object (role_id);
+COMMENT ON TABLE role_meta_securable_object IS 'role to securable object relation metadata';
+
+COMMENT ON COLUMN role_meta_securable_object.id IS 'auto increment id';
+COMMENT ON COLUMN role_meta_securable_object.role_id IS 'role id';
+COMMENT ON COLUMN role_meta_securable_object.metadata_object_id IS 'The entity id of securable object';
+COMMENT ON COLUMN role_meta_securable_object.type IS 'securable object type';
+COMMENT ON COLUMN role_meta_securable_object.privilege_names IS 'securable object privilege names';
+COMMENT ON COLUMN role_meta_securable_object.privilege_conditions IS 'securable object privilege conditions';
+COMMENT ON COLUMN role_meta_securable_object.current_version IS 'securable object current version';
+COMMENT ON COLUMN role_meta_securable_object.last_version IS 'securable object last version';
+COMMENT ON COLUMN role_meta_securable_object.deleted_at IS 'securable object deleted at';
+
+
+CREATE TABLE IF NOT EXISTS user_role_rel (
+    id BIGINT NOT NULL GENERATED BY DEFAULT AS IDENTITY,
+    user_id BIGINT NOT NULL,
+    role_id BIGINT NOT NULL,
+    audit_info TEXT NOT NULL,
+    current_version INT NOT NULL DEFAULT 1,
+    last_version INT NOT NULL DEFAULT 1,
+    deleted_at BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (id),
+    UNIQUE (user_id, role_id, deleted_at)
+);
+
+CREATE INDEX IF NOT EXISTS user_role_rel_idx_user_id ON user_role_rel (user_id);
+COMMENT ON TABLE user_role_rel IS 'user role relation metadata';
+
+COMMENT ON COLUMN user_role_rel.id IS 'auto increment id';
+COMMENT ON COLUMN user_role_rel.user_id IS 'user id';
+COMMENT ON COLUMN user_role_rel.role_id IS 'role id';
+COMMENT ON COLUMN user_role_rel.audit_info IS 'relation audit info';
+COMMENT ON COLUMN user_role_rel.current_version IS 'relation current version';
+COMMENT ON COLUMN user_role_rel.last_version IS 'relation last version';
+COMMENT ON COLUMN user_role_rel.deleted_at IS 'relation deleted at';
+
+
+CREATE TABLE IF NOT EXISTS group_meta (
+    group_id BIGINT NOT NULL,
+    group_name VARCHAR(128) NOT NULL,
+    metalake_id BIGINT NOT NULL,
+    audit_info TEXT NOT NULL,
+    current_version INT NOT NULL DEFAULT 1,
+    last_version INT NOT NULL DEFAULT 1,
+    deleted_at BIGINT NOT NULL DEFAULT 0,
+    role_grants_version INT NOT NULL DEFAULT 1,
+    PRIMARY KEY (group_id),
+    UNIQUE (metalake_id, group_name, deleted_at)
+);
+COMMENT ON TABLE group_meta IS 'group metadata';
+
+COMMENT ON COLUMN group_meta.group_id IS 'group id';
+COMMENT ON COLUMN group_meta.group_name IS 'group name';
+COMMENT ON COLUMN group_meta.metalake_id IS 'metalake id';
+COMMENT ON COLUMN group_meta.audit_info IS 'group audit info';
+COMMENT ON COLUMN group_meta.current_version IS 'group current version';
+COMMENT ON COLUMN group_meta.last_version IS 'group last version';
+COMMENT ON COLUMN group_meta.deleted_at IS 'group deleted at';
+COMMENT ON COLUMN group_meta.role_grants_version IS 'version bumped on any role assignment change for this group';
+
+
+CREATE TABLE IF NOT EXISTS group_role_rel (
+    id BIGSERIAL NOT NULL,
+    group_id BIGINT NOT NULL,
+    role_id BIGINT NOT NULL,
+    audit_info TEXT NOT NULL,
+    current_version INT NOT NULL DEFAULT 1,
+    last_version INT NOT NULL DEFAULT 1,
+    deleted_at BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (id),
+    UNIQUE (group_id, role_id, deleted_at)
+);
+
+CREATE INDEX IF NOT EXISTS group_role_rel_idx_group_id ON group_role_rel (group_id);
+COMMENT ON TABLE group_role_rel IS 'relation between group and role';
+COMMENT ON COLUMN group_role_rel.id IS 'auto increment id';
+COMMENT ON COLUMN group_role_rel.group_id IS 'group id';
+COMMENT ON COLUMN group_role_rel.role_id IS 'role id';
+COMMENT ON COLUMN group_role_rel.audit_info IS 'relation audit info';
+COMMENT ON COLUMN group_role_rel.current_version IS 'relation current version';
+COMMENT ON COLUMN group_role_rel.last_version IS 'relation last version';
+COMMENT ON COLUMN group_role_rel.deleted_at IS 'relation deleted at';
+
+CREATE TABLE IF NOT EXISTS tag_meta (
+    tag_id BIGINT NOT NULL,
+    tag_name VARCHAR(128) NOT NULL,
+    metalake_id BIGINT NOT NULL,
+    tag_comment VARCHAR(256) DEFAULT '',
+    properties TEXT DEFAULT NULL,
+    audit_info TEXT NOT NULL,
+    current_version INT NOT NULL DEFAULT 1,
+    last_version INT NOT NULL DEFAULT 1,
+    deleted_at BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (tag_id),
+    UNIQUE (metalake_id, tag_name, deleted_at)
+);
+
+COMMENT ON TABLE tag_meta IS 'tag metadata';
+
+COMMENT ON COLUMN tag_meta.tag_id IS 'tag id';
+COMMENT ON COLUMN tag_meta.tag_name IS 'tag name';
+COMMENT ON COLUMN tag_meta.metalake_id IS 'metalake id';
+COMMENT ON COLUMN tag_meta.tag_comment IS 'tag comment';
+COMMENT ON COLUMN tag_meta.properties IS 'tag properties';
+COMMENT ON COLUMN tag_meta.audit_info IS 'tag audit info';
+
+
+CREATE TABLE IF NOT EXISTS tag_relation_meta (
+    id BIGINT GENERATED BY DEFAULT AS IDENTITY,
+    tag_id BIGINT NOT NULL,
+    metadata_object_id BIGINT NOT NULL,
+    metadata_object_type VARCHAR(64) NOT NULL,
+    audit_info TEXT NOT NULL,
+    current_version INT NOT NULL DEFAULT 1,
+    last_version INT NOT NULL DEFAULT 1,
+    deleted_at BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (id),
+    UNIQUE (tag_id, metadata_object_id, metadata_object_type, deleted_at)
+);
+
+CREATE INDEX IF NOT EXISTS tag_relation_meta_idx_tag_id ON tag_relation_meta (tag_id);
+CREATE INDEX IF NOT EXISTS tag_relation_meta_idx_metadata_object_id ON tag_relation_meta (metadata_object_id);
+COMMENT ON TABLE tag_relation_meta IS 'tag metadata object relation';
+COMMENT ON COLUMN tag_relation_meta.id IS 'auto increment id';
+COMMENT ON COLUMN tag_relation_meta.tag_id IS 'tag id';
+COMMENT ON COLUMN tag_relation_meta.metadata_object_id IS 'metadata object id';
+COMMENT ON COLUMN tag_relation_meta.metadata_object_type IS 'metadata object type';
+COMMENT ON COLUMN tag_relation_meta.audit_info IS 'tag relation audit info';
+COMMENT ON COLUMN tag_relation_meta.current_version IS 'tag relation current version';
+COMMENT ON COLUMN tag_relation_meta.last_version IS 'tag relation last version';
+COMMENT ON COLUMN tag_relation_meta.deleted_at IS 'tag relation deleted at';
+
+CREATE TABLE IF NOT EXISTS owner_meta (
+    id BIGINT GENERATED BY DEFAULT AS IDENTITY,
+    metalake_id BIGINT NOT NULL,
+    owner_id BIGINT NOT NULL,
+    owner_type VARCHAR(64) NOT NULL,
+    metadata_object_id BIGINT NOT NULL,
+    metadata_object_type VARCHAR(64) NOT NULL,
+    audit_info TEXT NOT NULL,
+    current_version INT NOT NULL DEFAULT 1,
+    last_version INT NOT NULL DEFAULT 1,
+    deleted_at BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (id),
+    UNIQUE (owner_id, metadata_object_id, metadata_object_type, deleted_at)
+);
+
+CREATE INDEX IF NOT EXISTS owner_meta_idx_owner_id ON owner_meta (owner_id);
+CREATE INDEX IF NOT EXISTS owner_meta_idx_metadata_object_id ON owner_meta (metadata_object_id);
+COMMENT ON TABLE owner_meta IS 'owner relation';
+COMMENT ON COLUMN owner_meta.id IS 'auto increment id';
+COMMENT ON COLUMN owner_meta.metalake_id IS 'metalake id';
+COMMENT ON COLUMN owner_meta.owner_id IS 'owner id';
+COMMENT ON COLUMN owner_meta.owner_type IS 'owner type';
+COMMENT ON COLUMN owner_meta.metadata_object_id IS 'metadata object id';
+COMMENT ON COLUMN owner_meta.metadata_object_type IS 'metadata object type';
+COMMENT ON COLUMN owner_meta.audit_info IS 'owner relation audit info';
+COMMENT ON COLUMN owner_meta.current_version IS 'owner relation current version';
+COMMENT ON COLUMN owner_meta.last_version IS 'owner relation last version';
+COMMENT ON COLUMN owner_meta.deleted_at IS 'owner relation deleted at';
+
+
+CREATE TABLE IF NOT EXISTS model_meta (
+    model_id BIGINT NOT NULL,
+    model_name VARCHAR(128) NOT NULL,
+    metalake_id BIGINT NOT NULL,
+    catalog_id BIGINT NOT NULL,
+    schema_id BIGINT NOT NULL,
+    model_comment VARCHAR(65535) DEFAULT NULL,
+    model_properties TEXT DEFAULT NULL,
+    model_latest_version INT NOT NULL DEFAULT 0,
+    audit_info TEXT NOT NULL,
+    deleted_at BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (model_id),
+    UNIQUE (schema_id, model_name, deleted_at)
+);
+
+CREATE INDEX IF NOT EXISTS model_meta_idx_metalake_id ON model_meta (metalake_id);
+CREATE INDEX IF NOT EXISTS model_meta_idx_catalog_id ON model_meta (catalog_id);
+COMMENT ON TABLE model_meta IS 'model metadata';
+
+COMMENT ON COLUMN model_meta.model_id IS 'model id';
+COMMENT ON COLUMN model_meta.model_name IS 'model name';
+COMMENT ON COLUMN model_meta.metalake_id IS 'metalake id';
+COMMENT ON COLUMN model_meta.catalog_id IS 'catalog id';
+COMMENT ON COLUMN model_meta.schema_id IS 'schema id';
+COMMENT ON COLUMN model_meta.model_comment IS 'model comment';
+COMMENT ON COLUMN model_meta.model_properties IS 'model properties';
+COMMENT ON COLUMN model_meta.model_latest_version IS 'model max version';
+COMMENT ON COLUMN model_meta.audit_info IS 'model audit info';
+COMMENT ON COLUMN model_meta.deleted_at IS 'model deleted at';
+
+
+CREATE TABLE IF NOT EXISTS model_version_info (
+    id BIGINT NOT NULL GENERATED BY DEFAULT AS IDENTITY,
+    metalake_id BIGINT NOT NULL,
+    catalog_id BIGINT NOT NULL,
+    schema_id BIGINT NOT NULL,
+    model_id BIGINT NOT NULL,
+    version INT NOT NULL,
+    model_version_comment VARCHAR(65535) DEFAULT NULL,
+    model_version_properties TEXT DEFAULT NULL,
+    model_version_uri_name VARCHAR(256) NOT NULL,
+    model_version_uri TEXT NOT NULL,
+    audit_info TEXT NOT NULL,
+    deleted_at BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (id),
+    UNIQUE (model_id, version, model_version_uri_name, deleted_at)
+);
+
+CREATE INDEX IF NOT EXISTS model_version_info_idx_metalake_id ON model_version_info (metalake_id);
+CREATE INDEX IF NOT EXISTS model_version_info_idx_catalog_id ON model_version_info (catalog_id);
+CREATE INDEX IF NOT EXISTS model_version_info_idx_schema_id ON model_version_info (schema_id);
+COMMENT ON TABLE model_version_info IS 'model version information';
+
+COMMENT ON COLUMN model_version_info.id IS 'auto increment id';
+COMMENT ON COLUMN model_version_info.metalake_id IS 'metalake id';
+COMMENT ON COLUMN model_version_info.catalog_id IS 'catalog id';
+COMMENT ON COLUMN model_version_info.schema_id IS 'schema id';
+COMMENT ON COLUMN model_version_info.model_id IS 'model id';
+COMMENT ON COLUMN model_version_info.version IS 'model version';
+COMMENT ON COLUMN model_version_info.model_version_comment IS 'model version comment';
+COMMENT ON COLUMN model_version_info.model_version_properties IS 'model version properties';
+COMMENT ON COLUMN model_version_info.model_version_uri_name IS 'model version uri name';
+COMMENT ON COLUMN model_version_info.model_version_uri IS 'model storage uri';
+COMMENT ON COLUMN model_version_info.audit_info IS 'model version audit info';
+COMMENT ON COLUMN model_version_info.deleted_at IS 'model version deleted at';
+
+
+CREATE TABLE IF NOT EXISTS model_version_alias_rel (
+    id BIGINT NOT NULL GENERATED BY DEFAULT AS IDENTITY,
+    model_id BIGINT NOT NULL,
+    model_version INT NOT NULL,
+    model_version_alias VARCHAR(128) NOT NULL,
+    deleted_at BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (id),
+    UNIQUE (model_id, model_version_alias, deleted_at)
+);
+
+CREATE INDEX IF NOT EXISTS model_version_alias_rel_idx_model_version_alias on model_version_alias_rel (model_version_alias);
+COMMENT ON TABLE model_version_alias_rel IS 'model version alias relation';
+
+COMMENT ON COLUMN model_version_alias_rel.id IS 'auto increment id';
+COMMENT ON COLUMN model_version_alias_rel.model_id IS 'model id';
+COMMENT ON COLUMN model_version_alias_rel.model_version IS 'model version';
+COMMENT ON COLUMN model_version_alias_rel.model_version_alias IS 'model version alias';
+COMMENT ON COLUMN model_version_alias_rel.deleted_at IS 'model version alias deleted at';
+
+
+CREATE TABLE IF NOT EXISTS policy_meta (
+    policy_id BIGINT NOT NULL,
+    policy_name VARCHAR(128) NOT NULL,
+    policy_type VARCHAR(64) NOT NULL,
+    metalake_id BIGINT NOT NULL,
+    audit_info TEXT NOT NULL,
+    current_version INT NOT NULL DEFAULT 1,
+    last_version INT NOT NULL DEFAULT 1,
+    deleted_at BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (policy_id),
+    UNIQUE (metalake_id, policy_name, deleted_at)
+);
+
+COMMENT ON TABLE policy_meta IS 'policy metadata';
+COMMENT ON COLUMN policy_meta.policy_id IS 'policy id';
+COMMENT ON COLUMN policy_meta.policy_name IS 'policy name';
+COMMENT ON COLUMN policy_meta.policy_type IS 'policy type';
+COMMENT ON COLUMN policy_meta.metalake_id IS 'metalake id';
+COMMENT ON COLUMN policy_meta.audit_info IS 'policy audit info';
+COMMENT ON COLUMN policy_meta.current_version IS 'policy current version';
+COMMENT ON COLUMN policy_meta.last_version IS 'policy last version';
+COMMENT ON COLUMN policy_meta.deleted_at IS 'policy deleted at';
+
+
+CREATE TABLE IF NOT EXISTS policy_version_info (
+    id BIGINT NOT NULL GENERATED BY DEFAULT AS IDENTITY,
+    metalake_id BIGINT NOT NULL,
+    policy_id BIGINT NOT NULL,
+    version INT NOT NULL,
+    policy_comment TEXT DEFAULT NULL,
+    enabled BOOLEAN DEFAULT TRUE,
+    content TEXT DEFAULT NULL,
+    deleted_at BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (id),
+    UNIQUE (policy_id, version, deleted_at)
+);
+
+CREATE INDEX IF NOT EXISTS policy_version_info_idx_metalake_id ON policy_version_info (metalake_id);
+COMMENT ON TABLE policy_version_info IS 'policy version info';
+COMMENT ON COLUMN policy_version_info.id IS 'auto increment id';
+COMMENT ON COLUMN policy_version_info.metalake_id IS 'metalake id';
+COMMENT ON COLUMN policy_version_info.policy_id IS 'policy id';
+COMMENT ON COLUMN policy_version_info.version IS 'policy info version';
+COMMENT ON COLUMN policy_version_info.policy_comment IS 'policy info comment';
+COMMENT ON COLUMN policy_version_info.enabled IS 'whether the policy is enabled, 0 is disabled, 1 is enabled';
+COMMENT ON COLUMN policy_version_info.content IS 'policy content';
+COMMENT ON COLUMN policy_version_info.deleted_at IS 'policy deleted at';
+
+
+CREATE TABLE IF NOT EXISTS policy_relation_meta (
+    id BIGINT NOT NULL GENERATED BY DEFAULT AS IDENTITY,
+    policy_id BIGINT NOT NULL,
+    metadata_object_id BIGINT NOT NULL,
+    metadata_object_type VARCHAR(64) NOT NULL,
+    audit_info TEXT NOT NULL,
+    current_version INT NOT NULL DEFAULT 1,
+    last_version INT NOT NULL DEFAULT 1,
+    deleted_at BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (id),
+    UNIQUE (policy_id, metadata_object_id, metadata_object_type, deleted_at)
+);
+
+CREATE INDEX IF NOT EXISTS policy_relation_meta_idx_policy_id ON policy_relation_meta (policy_id);
+CREATE INDEX IF NOT EXISTS policy_relation_meta_idx_metadata_object_id ON policy_relation_meta (metadata_object_id);
+COMMENT ON TABLE policy_relation_meta IS 'policy metadata object relation';
+COMMENT ON COLUMN policy_relation_meta.id IS 'auto increment id';
+COMMENT ON COLUMN policy_relation_meta.policy_id IS 'policy id';
+COMMENT ON COLUMN policy_relation_meta.metadata_object_id IS 'metadata object id';
+COMMENT ON COLUMN policy_relation_meta.metadata_object_type IS 'metadata object type';
+COMMENT ON COLUMN policy_relation_meta.audit_info IS 'policy relation audit info';
+COMMENT ON COLUMN policy_relation_meta.current_version IS 'policy relation current version';
+COMMENT ON COLUMN policy_relation_meta.last_version IS 'policy relation last version';
+COMMENT ON COLUMN policy_relation_meta.deleted_at IS 'policy relation deleted at';
+
+CREATE TABLE IF NOT EXISTS statistic_meta (
+    id BIGINT NOT NULL GENERATED BY DEFAULT AS IDENTITY,
+    statistic_id BIGINT NOT NULL,
+    statistic_name VARCHAR(128) NOT NULL,
+    metalake_id BIGINT NOT NULL,
+    statistic_value TEXT NOT NULL,
+    metadata_object_id BIGINT NOT NULL,
+    metadata_object_type VARCHAR(64) NOT NULL,
+    audit_info TEXT NOT NULL,
+    current_version INT NOT NULL DEFAULT 1,
+    last_version INT NOT NULL DEFAULT 1,
+    deleted_at BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (statistic_id),
+    UNIQUE (statistic_name, metadata_object_id, deleted_at)
+);
+
+CREATE INDEX IF NOT EXISTS statistic_meta_idx_stid ON statistic_meta (statistic_id);
+CREATE INDEX IF NOT EXISTS statistic_meta_idx_moid ON statistic_meta (metadata_object_id);
+COMMENT ON TABLE statistic_meta IS 'statistic metadata';
+COMMENT ON COLUMN statistic_meta.id IS 'auto increment id';
+COMMENT ON COLUMN statistic_meta.statistic_id IS 'statistic id';
+COMMENT ON COLUMN statistic_meta.statistic_name IS 'statistic name';
+COMMENT ON COLUMN statistic_meta.metalake_id IS 'metalake id';
+COMMENT ON COLUMN statistic_meta.statistic_value IS 'statistic value';
+COMMENT ON COLUMN statistic_meta.metadata_object_id IS 'metadata object id';
+COMMENT ON COLUMN statistic_meta.metadata_object_type IS 'metadata object type';
+COMMENT ON COLUMN statistic_meta.audit_info IS 'statistic audit info';
+COMMENT ON COLUMN statistic_meta.current_version IS 'statistic current version';
+COMMENT ON COLUMN statistic_meta.last_version IS 'statistic last version';
+COMMENT ON COLUMN statistic_meta.deleted_at IS 'statistic deleted at';
+
+CREATE TABLE IF NOT EXISTS job_template_meta (
+    job_template_id BIGINT NOT NULL,
+    job_template_name VARCHAR(128) NOT NULL,
+    metalake_id BIGINT NOT NULL,
+    job_template_comment TEXT DEFAULT NULL,
+    job_template_content TEXT NOT NULL,
+    audit_info TEXT NOT NULL,
+    current_version INT NOT NULL DEFAULT 1,
+    last_version INT NOT NULL DEFAULT 1,
+    deleted_at BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (job_template_id),
+    UNIQUE (metalake_id, job_template_name, deleted_at)
+);
+
+COMMENT ON TABLE job_template_meta IS 'job template metadata';
+COMMENT ON COLUMN job_template_meta.job_template_id IS 'job template id';
+COMMENT ON COLUMN job_template_meta.job_template_name IS 'job template name';
+COMMENT ON COLUMN job_template_meta.metalake_id IS 'metalake id';
+COMMENT ON COLUMN job_template_meta.job_template_comment IS 'job template comment';
+COMMENT ON COLUMN job_template_meta.job_template_content IS 'job template content';
+COMMENT ON COLUMN job_template_meta.audit_info IS 'job template audit info';
+COMMENT ON COLUMN job_template_meta.current_version IS 'job template current version';
+COMMENT ON COLUMN job_template_meta.last_version IS 'job template last version';
+COMMENT ON COLUMN job_template_meta.deleted_at IS 'job template deleted at';
+
+
+CREATE TABLE IF NOT EXISTS job_run_meta (
+    job_run_id BIGINT NOT NULL,
+    job_template_id BIGINT NOT NULL,
+    metalake_id BIGINT NOT NULL,
+    job_execution_id VARCHAR(256) NOT NULL,
+    job_run_status VARCHAR(64) NOT NULL,
+    job_finished_at BIGINT NOT NULL DEFAULT 0,
+    audit_info TEXT NOT NULL,
+    current_version INT NOT NULL DEFAULT 1,
+    last_version INT NOT NULL DEFAULT 1,
+    deleted_at BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (job_run_id),
+    UNIQUE (metalake_id, job_execution_id, deleted_at)
+);
+
+CREATE INDEX IF NOT EXISTS job_run_meta_idx_job_template_id ON job_run_meta (job_template_id);
+CREATE INDEX IF NOT EXISTS job_run_meta_idx_job_execution_id ON job_run_meta (job_execution_id);
+COMMENT ON TABLE job_run_meta IS 'job run metadata';
+COMMENT ON COLUMN job_run_meta.job_run_id IS 'job run id';
+COMMENT ON COLUMN job_run_meta.job_template_id IS 'job template id';
+COMMENT ON COLUMN job_run_meta.metalake_id IS 'metalake id';
+COMMENT ON COLUMN job_run_meta.job_execution_id IS 'job execution id';
+COMMENT ON COLUMN job_run_meta.job_run_status IS 'job run status';
+COMMENT ON COLUMN job_run_meta.job_finished_at IS 'job run finished at';
+COMMENT ON COLUMN job_run_meta.audit_info IS 'job run audit info';
+COMMENT ON COLUMN job_run_meta.current_version IS 'job run current version';
+COMMENT ON COLUMN job_run_meta.last_version IS 'job run last version';
+COMMENT ON COLUMN job_run_meta.deleted_at IS 'job run deleted at';
+
+CREATE TABLE IF NOT EXISTS table_version_info (
+    table_id        BIGINT NOT NULL,
+    format          VARCHAR(64),
+    properties      TEXT,
+    partitioning  TEXT,
+    distribution TEXT,
+    sort_orders TEXT,
+    indexes      TEXT,
+    "comment"   TEXT,
+    version BIGINT,
+    deleted_at      BIGINT DEFAULT 0,
+    UNIQUE (table_id, version, deleted_at)
+);
+COMMENT ON TABLE table_version_info                  IS 'table detail information including format, location, properties, partition, distribution, sort order, index and so on';
+COMMENT ON COLUMN table_version_info.table_id        IS 'table id';
+COMMENT ON COLUMN table_version_info.format          IS 'table format, such as Lance, Iceberg and so on, it will be null if it is not a lakehouse table';
+COMMENT ON COLUMN table_version_info.properties      IS 'table properties';
+COMMENT ON COLUMN table_version_info.partitioning      IS 'table partition info';
+COMMENT on COLUMN table_version_info.distribution    IS 'table distribution info';
+COMMENT ON COLUMN table_version_info.sort_orders     IS 'table sort order info';
+COMMENT ON COLUMN table_version_info.indexes         IS 'table index info';
+COMMENT ON COLUMN table_version_info."comment"       IS 'table comment';
+COMMENT ON COLUMN table_version_info.version IS 'table current version';
+COMMENT ON COLUMN table_version_info.deleted_at      IS 'table deletion timestamp, 0 means not deleted';
+
+CREATE TABLE IF NOT EXISTS function_meta (
+    function_id BIGINT NOT NULL,
+    function_name VARCHAR(128) NOT NULL,
+    metalake_id BIGINT NOT NULL,
+    catalog_id BIGINT NOT NULL,
+    schema_id BIGINT NOT NULL,
+    function_type VARCHAR(64) NOT NULL,
+    deterministic SMALLINT DEFAULT 1,
+    function_current_version INT DEFAULT 1,
+    function_latest_version INT DEFAULT 1,
+    audit_info TEXT NOT NULL,
+    deleted_at BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (function_id),
+    UNIQUE (schema_id, function_name, deleted_at)
+);
+CREATE INDEX idx_function_meta_metalake_id ON function_meta (metalake_id);
+CREATE INDEX idx_function_meta_catalog_id ON function_meta (catalog_id);
+
+COMMENT ON TABLE function_meta IS 'function metadata';
+COMMENT ON COLUMN function_meta.function_id IS 'function id';
+COMMENT ON COLUMN function_meta.function_name IS 'function name';
+COMMENT ON COLUMN function_meta.metalake_id IS 'metalake id';
+COMMENT ON COLUMN function_meta.catalog_id IS 'catalog id';
+COMMENT ON COLUMN function_meta.schema_id IS 'schema id';
+COMMENT ON COLUMN function_meta.function_type IS 'function type';
+COMMENT ON COLUMN function_meta.deterministic IS 'whether the function result is deterministic';
+COMMENT ON COLUMN function_meta.function_latest_version IS 'function latest version';
+COMMENT ON COLUMN function_meta.audit_info IS 'function audit info';
+COMMENT ON COLUMN function_meta.deleted_at IS 'function deleted at';
+
+CREATE TABLE IF NOT EXISTS function_version_info (
+    id BIGINT NOT NULL GENERATED BY DEFAULT AS IDENTITY,
+    metalake_id BIGINT NOT NULL,
+    catalog_id BIGINT NOT NULL,
+    schema_id BIGINT NOT NULL,
+    function_id BIGINT NOT NULL,
+    version INT NOT NULL,
+    function_comment TEXT DEFAULT NULL,
+    definitions TEXT NOT NULL,
+    audit_info TEXT NOT NULL,
+    deleted_at BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (id),
+    UNIQUE (function_id, version, deleted_at)
+);
+CREATE INDEX idx_function_version_metalake_id ON function_version_info (metalake_id);
+CREATE INDEX idx_function_version_catalog_id ON function_version_info (catalog_id);
+CREATE INDEX idx_function_version_schema_id ON function_version_info (schema_id);
+
+COMMENT ON TABLE function_version_info IS 'function version info';
+COMMENT ON COLUMN function_version_info.id IS 'auto increment id';
+COMMENT ON COLUMN function_version_info.metalake_id IS 'metalake id';
+COMMENT ON COLUMN function_version_info.catalog_id IS 'catalog id';
+COMMENT ON COLUMN function_version_info.schema_id IS 'schema id';
+COMMENT ON COLUMN function_version_info.function_id IS 'function id';
+COMMENT ON COLUMN function_version_info.version IS 'function version';
+COMMENT ON COLUMN function_version_info.function_comment IS 'function version comment';
+COMMENT ON COLUMN function_version_info.definitions IS 'function definitions details';
+COMMENT ON COLUMN function_version_info.audit_info IS 'function version audit info';
+COMMENT ON COLUMN function_version_info.deleted_at IS 'function version deleted at';
+
+CREATE TABLE IF NOT EXISTS view_meta (
+    view_id BIGINT NOT NULL,
+    view_name VARCHAR(128) NOT NULL,
+    metalake_id BIGINT NOT NULL,
+    catalog_id BIGINT NOT NULL,
+    schema_id BIGINT NOT NULL,
+    current_version INT NOT NULL DEFAULT 1,
+    last_version INT NOT NULL DEFAULT 1,
+    deleted_at BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (view_id),
+    UNIQUE (schema_id, view_name, deleted_at)
+);
+
+CREATE INDEX IF NOT EXISTS view_meta_idx_metalake_id ON view_meta (metalake_id);
+CREATE INDEX IF NOT EXISTS view_meta_idx_catalog_id ON view_meta (catalog_id);
+COMMENT ON TABLE view_meta IS 'view metadata';
+
+COMMENT ON COLUMN view_meta.view_id IS 'view id';
+COMMENT ON COLUMN view_meta.view_name IS 'view name';
+COMMENT ON COLUMN view_meta.metalake_id IS 'metalake id';
+COMMENT ON COLUMN view_meta.catalog_id IS 'catalog id';
+COMMENT ON COLUMN view_meta.schema_id IS 'schema id';
+COMMENT ON COLUMN view_meta.current_version IS 'view current version';
+COMMENT ON COLUMN view_meta.last_version IS 'view last version';
+COMMENT ON COLUMN view_meta.deleted_at IS 'view deleted at';
+
+-- This schema extends version 1.1.0 with partition statistics storage support
+-- The partition_statistic_meta table stores partition-level statistics for tables
+
+CREATE TABLE IF NOT EXISTS partition_statistic_meta (
+    table_id BIGINT NOT NULL,
+    partition_name VARCHAR(1024) NOT NULL,
+    statistic_name VARCHAR(128) NOT NULL,
+    statistic_value TEXT NOT NULL,
+    audit_info TEXT NOT NULL,
+    created_at BIGINT NOT NULL,
+    updated_at BIGINT NOT NULL,
+    PRIMARY KEY (table_id, partition_name, statistic_name)
+);
+
+CREATE INDEX IF NOT EXISTS idx_table_partition ON partition_statistic_meta(table_id, partition_name);
+
+COMMENT ON TABLE partition_statistic_meta IS 'partition statistics metadata';
+COMMENT ON COLUMN partition_statistic_meta.table_id IS 'table id from table_meta';
+COMMENT ON COLUMN partition_statistic_meta.partition_name IS 'partition name';
+COMMENT ON COLUMN partition_statistic_meta.statistic_name IS 'statistic name';
+COMMENT ON COLUMN partition_statistic_meta.statistic_value IS 'statistic value as JSON';
+COMMENT ON COLUMN partition_statistic_meta.audit_info IS 'audit information as JSON';
+COMMENT ON COLUMN partition_statistic_meta.created_at IS 'creation timestamp in milliseconds';
+COMMENT ON COLUMN partition_statistic_meta.updated_at IS 'last update timestamp in milliseconds';
+
+-- Optimizer metrics schema
+CREATE TABLE IF NOT EXISTS table_metrics (
+    id BIGSERIAL PRIMARY KEY,
+    table_identifier VARCHAR(1024) NOT NULL,
+    metric_name VARCHAR(1024) NOT NULL,
+    table_partition VARCHAR(1024),
+    metric_ts BIGINT NOT NULL,
+    metric_value VARCHAR(1024) NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS job_metrics (
+    id BIGSERIAL PRIMARY KEY,
+    job_identifier VARCHAR(1024) NOT NULL,
+    metric_name VARCHAR(1024) NOT NULL,
+    metric_ts BIGINT NOT NULL,
+    metric_value VARCHAR(1024) NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_table_metrics_metric_ts ON table_metrics(metric_ts);
+CREATE INDEX IF NOT EXISTS idx_job_metrics_metric_ts ON job_metrics(metric_ts);
+CREATE INDEX IF NOT EXISTS idx_table_metrics_composite
+  ON table_metrics(table_identifier, table_partition, metric_ts);
+CREATE INDEX IF NOT EXISTS idx_job_metrics_identifier_metric_ts
+  ON job_metrics(job_identifier, metric_ts);
+
+COMMENT ON TABLE table_metrics IS 'optimizer table metrics';
+COMMENT ON TABLE job_metrics IS 'optimizer job metrics';
+COMMENT ON COLUMN table_metrics.id IS 'auto increment id';
+COMMENT ON COLUMN table_metrics.table_identifier IS 'normalized table identifier';
+COMMENT ON COLUMN table_metrics.metric_name IS 'metric name';
+COMMENT ON COLUMN table_metrics.table_partition IS 'normalized partition identifier';
+COMMENT ON COLUMN table_metrics.metric_ts IS 'metric timestamp in epoch seconds';
+COMMENT ON COLUMN table_metrics.metric_value IS 'metric value payload';
+COMMENT ON COLUMN job_metrics.id IS 'auto increment id';
+COMMENT ON COLUMN job_metrics.job_identifier IS 'normalized job identifier';
+COMMENT ON COLUMN job_metrics.metric_name IS 'metric name';
+COMMENT ON COLUMN job_metrics.metric_ts IS 'metric timestamp in epoch seconds';
+COMMENT ON COLUMN job_metrics.metric_value IS 'metric value payload';

--- a/scripts/postgresql/upgrade-1.2.0-to-1.3.0-postgresql.sql
+++ b/scripts/postgresql/upgrade-1.2.0-to-1.3.0-postgresql.sql
@@ -1,0 +1,38 @@
+--
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file--
+--  distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"). You may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--  http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+--
+
+-- Add version columns for Phase 2 version-validated auth cache
+
+ALTER TABLE role_meta
+    ADD COLUMN securable_objects_version INT NOT NULL DEFAULT 1;
+
+COMMENT ON COLUMN role_meta.securable_objects_version IS
+    'Incremented atomically with any privilege grant/revoke for this role';
+
+ALTER TABLE user_meta
+    ADD COLUMN role_grants_version INT NOT NULL DEFAULT 1;
+
+COMMENT ON COLUMN user_meta.role_grants_version IS
+    'Incremented atomically with any role assignment/revocation for this user';
+
+ALTER TABLE group_meta
+    ADD COLUMN role_grants_version INT NOT NULL DEFAULT 1;
+
+COMMENT ON COLUMN group_meta.role_grants_version IS
+    'Incremented atomically with any role assignment/revocation for this group';

--- a/server-common/src/main/java/org/apache/gravitino/server/authorization/jcasbin/JcasbinAuthorizer.java
+++ b/server-common/src/main/java/org/apache/gravitino/server/authorization/jcasbin/JcasbinAuthorizer.java
@@ -17,8 +17,7 @@
 
 package org.apache.gravitino.server.authorization.jcasbin;
 
-import com.github.benmanes.caffeine.cache.Cache;
-import com.github.benmanes.caffeine.cache.Caffeine;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import java.io.IOException;
@@ -27,19 +26,17 @@ import java.nio.charset.StandardCharsets;
 import java.security.Principal;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executor;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.gravitino.Configs;
 import org.apache.gravitino.Entity;
-import org.apache.gravitino.EntityStore;
 import org.apache.gravitino.GravitinoEnv;
 import org.apache.gravitino.MetadataObject;
 import org.apache.gravitino.MetadataObjects;
@@ -50,12 +47,22 @@ import org.apache.gravitino.authorization.AuthorizationRequestContext;
 import org.apache.gravitino.authorization.AuthorizationUtils;
 import org.apache.gravitino.authorization.GravitinoAuthorizer;
 import org.apache.gravitino.authorization.Privilege;
-import org.apache.gravitino.authorization.SecurableObject;
+import org.apache.gravitino.cache.CaffeineGravitinoCache;
+import org.apache.gravitino.cache.GravitinoCache;
 import org.apache.gravitino.exceptions.NoSuchUserException;
+import org.apache.gravitino.json.JsonUtils;
 import org.apache.gravitino.meta.RoleEntity;
-import org.apache.gravitino.meta.UserEntity;
 import org.apache.gravitino.server.authorization.MetadataIdConverter;
-import org.apache.gravitino.utils.MetadataObjectUtil;
+import org.apache.gravitino.storage.relational.mapper.OwnerMetaMapper;
+import org.apache.gravitino.storage.relational.mapper.RoleMetaMapper;
+import org.apache.gravitino.storage.relational.mapper.UserMetaMapper;
+import org.apache.gravitino.storage.relational.po.OwnerRelInfoPO;
+import org.apache.gravitino.storage.relational.po.RolePO;
+import org.apache.gravitino.storage.relational.po.RoleVersionInfoPO;
+import org.apache.gravitino.storage.relational.po.SecurableObjectPO;
+import org.apache.gravitino.storage.relational.po.UserVersionInfoPO;
+import org.apache.gravitino.storage.relational.service.RoleMetaService;
+import org.apache.gravitino.storage.relational.utils.SessionUtils;
 import org.apache.gravitino.utils.NameIdentifierUtil;
 import org.apache.gravitino.utils.PrincipalUtils;
 import org.casbin.jcasbin.main.Enforcer;
@@ -82,14 +89,30 @@ public class JcasbinAuthorizer implements GravitinoAuthorizer {
   private InternalAuthorizer denyInternalAuthorizer;
 
   /**
-   * loadedRoles is used to cache roles that have loaded permissions. When the permissions of a role
-   * are updated, they should be removed from it.
+   * Per-role policy version cache. Maps roleId → securableObjectsVersion. When the version in the
+   * DB differs from the cached value, the role's policies are reloaded. The removal listener clears
+   * stale policies from both enforcers on eviction.
    */
-  private Cache<Long, Boolean> loadedRoles;
+  private GravitinoCache<Long, Integer> loadedRoles;
 
-  private Cache<Long, Optional<Long>> ownerRel;
+  /**
+   * Per-user role cache. Maps "metalake:username" → CachedUserRoles (userId, roleGrantsVersion,
+   * roleIds). Validated against the DB version on every request before use.
+   */
+  private GravitinoCache<String, CachedUserRoles> userRoleCache;
 
-  private Executor executor = null;
+  /** Holds a snapshot of user role assignments for a single request lifetime. */
+  private static final class CachedUserRoles {
+    final long userId;
+    final int roleGrantsVersion;
+    final List<Long> roleIds;
+
+    CachedUserRoles(long userId, int roleGrantsVersion, List<Long> roleIds) {
+      this.userId = userId;
+      this.roleGrantsVersion = roleGrantsVersion;
+      this.roleIds = roleIds;
+    }
+  }
 
   @Override
   public void initialize() {
@@ -99,8 +122,10 @@ public class JcasbinAuthorizer implements GravitinoAuthorizer {
             .get(Configs.GRAVITINO_AUTHORIZATION_CACHE_EXPIRATION_SECS);
     long roleCacheSize =
         GravitinoEnv.getInstance().config().get(Configs.GRAVITINO_AUTHORIZATION_ROLE_CACHE_SIZE);
-    long ownerCacheSize =
-        GravitinoEnv.getInstance().config().get(Configs.GRAVITINO_AUTHORIZATION_OWNER_CACHE_SIZE);
+    long userRoleCacheSize =
+        GravitinoEnv.getInstance()
+            .config()
+            .get(Configs.GRAVITINO_AUTHORIZATION_USER_ROLE_CACHE_SIZE);
 
     // Initialize enforcers before the caches that reference them in removal listeners
     allowEnforcer = new SyncedEnforcer(getModel("/jcasbin_model.conf"), new GravitinoAdapter());
@@ -109,33 +134,17 @@ public class JcasbinAuthorizer implements GravitinoAuthorizer {
     denyInternalAuthorizer = new InternalAuthorizer(denyEnforcer);
 
     loadedRoles =
-        Caffeine.newBuilder()
-            .expireAfterAccess(cacheExpirationSecs, TimeUnit.SECONDS)
-            .maximumSize(roleCacheSize)
-            .executor(Runnable::run)
-            .removalListener(
-                (roleId, value, cause) -> {
-                  if (roleId != null) {
-                    allowEnforcer.deleteRole(String.valueOf(roleId));
-                    denyEnforcer.deleteRole(String.valueOf(roleId));
-                  }
-                })
-            .build();
-    ownerRel =
-        Caffeine.newBuilder()
-            .expireAfterAccess(cacheExpirationSecs, TimeUnit.SECONDS)
-            .maximumSize(ownerCacheSize)
-            .build();
-    executor =
-        Executors.newFixedThreadPool(
-            GravitinoEnv.getInstance()
-                .config()
-                .get(Configs.GRAVITINO_AUTHORIZATION_THREAD_POOL_SIZE),
-            runnable -> {
-              Thread thread = new Thread(runnable);
-              thread.setName("GravitinoAuthorizer-ThreadPool-" + thread.getId());
-              return thread;
+        new CaffeineGravitinoCache<>(
+            roleCacheSize,
+            cacheExpirationSecs,
+            (roleId, version, cause) -> {
+              if (roleId != null) {
+                allowEnforcer.deleteRole(String.valueOf(roleId));
+                denyEnforcer.deleteRole(String.valueOf(roleId));
+              }
             });
+
+    userRoleCache = new CaffeineGravitinoCache<>(userRoleCacheSize, cacheExpirationSecs);
   }
 
   private Model getModel(String modelFilePath) {
@@ -218,17 +227,43 @@ public class JcasbinAuthorizer implements GravitinoAuthorizer {
       String metalake,
       MetadataObject metadataObject,
       AuthorizationRequestContext requestContext) {
-    Long userId;
     boolean result;
     try {
       Long metadataId = MetadataIdConverter.getID(metadataObject, metalake);
-      loadOwnerPolicy(metalake, metadataObject, metadataId);
-      UserEntity userEntity = getUserEntity(principal.getName(), metalake);
-      userId = userEntity.id();
-      metadataId = MetadataIdConverter.getID(metadataObject, metalake);
-      result = Objects.equals(Optional.of(userId), ownerRel.getIfPresent(metadataId));
+
+      // Resolve userId — use cached value if this request already resolved it
+      Long userId = requestContext.getResolvedUserId();
+      if (userId == null) {
+        UserVersionInfoPO versionInfo =
+            SessionUtils.getWithoutCommit(
+                UserMetaMapper.class,
+                mapper -> mapper.getUserVersionInfo(metalake, principal.getName()));
+        if (versionInfo == null) {
+          return false;
+        }
+        userId = versionInfo.getUserId();
+        requestContext.setResolvedUserId(userId);
+      }
+
+      // Resolve owner — use per-request cache to deduplicate DB lookups across ancestor chain
+      Optional<Long> ownerOpt;
+      if (requestContext.isOwnerCached(metadataId)) {
+        ownerOpt = requestContext.getCachedOwner(metadataId);
+      } else {
+        OwnerRelInfoPO ownerRow =
+            SessionUtils.getWithoutCommit(
+                OwnerMetaMapper.class, mapper -> mapper.selectOwnerByMetadataObjectId(metadataId));
+        if (ownerRow == null || !"USER".equals(ownerRow.getOwnerType())) {
+          ownerOpt = Optional.empty();
+        } else {
+          ownerOpt = Optional.of(ownerRow.getOwnerId());
+        }
+        requestContext.cacheOwner(metadataId, ownerOpt);
+      }
+
+      result = ownerOpt.isPresent() && Objects.equals(userId, ownerOpt.get());
     } catch (Exception e) {
-      LOG.debug("Can not get entity id", e);
+      LOG.debug("Can not get entity id for owner check", e);
       result = false;
     }
     LOG.debug(
@@ -276,18 +311,15 @@ public class JcasbinAuthorizer implements GravitinoAuthorizer {
         Long roleId =
             MetadataIdConverter.getID(
                 NameIdentifierUtil.toMetadataObject(nameIdentifier, type), metalake);
-        EntityStore entityStore = GravitinoEnv.getInstance().entityStore();
-        NameIdentifier userNameIdentifier =
-            NameIdentifierUtil.ofUser(metalake, PrincipalUtils.getCurrentUserName());
         List<RoleEntity> entities =
-            entityStore
+            GravitinoEnv.getInstance()
+                .entityStore()
                 .relationOperations()
                 .listEntitiesByRelation(
                     SupportsRelationOperations.Type.ROLE_USER_REL,
-                    userNameIdentifier,
+                    NameIdentifierUtil.ofUser(metalake, PrincipalUtils.getCurrentUserName()),
                     Entity.EntityType.USER);
         return entities.stream().anyMatch(roleEntity -> Objects.equals(roleEntity.id(), roleId));
-
       } catch (Exception e) {
         LOG.warn("can not get user id or role id.", e);
         return false;
@@ -372,16 +404,12 @@ public class JcasbinAuthorizer implements GravitinoAuthorizer {
       String metalake, String type, String fullName, AuthorizationRequestContext requestContext) {
     Principal currentPrincipal = PrincipalUtils.getCurrentPrincipal();
     // Check whether the principal holds MANAGE_GRANTS on the target object or any ancestor.
-    // A grant at a broader level (e.g. CATALOG or SCHEMA) implicitly covers all objects beneath it.
     MetadataObject.Type metadataType;
     try {
       metadataType = MetadataObject.Type.valueOf(type.toUpperCase());
     } catch (IllegalArgumentException e) {
       throw new IllegalArgumentException("Unknown metadata object type: " + type, e);
     }
-    // Build the full ancestor chain from the target object up to and including the metalake.
-    // MetadataObjects.parent(CATALOG) returns null (CATALOG is a root in the parent API), so the
-    // metalake is appended manually at the end.
     List<MetadataObject> chain = new ArrayList<>();
     for (MetadataObject obj = MetadataObjects.parse(fullName, metadataType);
         obj != null;
@@ -404,21 +432,23 @@ public class JcasbinAuthorizer implements GravitinoAuthorizer {
     loadedRoles.invalidate(roleId);
   }
 
+  /**
+   * No-op: owner lookups are now done per-request via the DB, without a long-lived owner cache.
+   * This hook is kept for interface compatibility.
+   */
   @Override
   public void handleMetadataOwnerChange(
       String metalake, Long oldOwnerId, NameIdentifier nameIdentifier, Entity.EntityType type) {
-    MetadataObject metadataObject = NameIdentifierUtil.toMetadataObject(nameIdentifier, type);
-    Long metadataId = MetadataIdConverter.getID(metadataObject, metalake);
-    ownerRel.invalidate(metadataId);
+    // No persistent owner cache to invalidate — owner is resolved fresh per-request.
   }
 
   @Override
   public void close() throws IOException {
-    if (executor != null) {
-      if (executor instanceof ThreadPoolExecutor) {
-        ThreadPoolExecutor threadPoolExecutor = (ThreadPoolExecutor) executor;
-        threadPoolExecutor.shutdown();
-      }
+    if (loadedRoles != null) {
+      loadedRoles.close();
+    }
+    if (userRoleCache != null) {
+      userRoleCache.close();
     }
   }
 
@@ -447,24 +477,29 @@ public class JcasbinAuthorizer implements GravitinoAuthorizer {
         String privilege,
         AuthorizationRequestContext requestContext) {
       Long metadataId;
-      Long userId;
       try {
-        UserEntity userEntity = getUserEntity(username, metalake);
-        userId = userEntity.id();
         metadataId = MetadataIdConverter.getID(metadataObject, metalake);
       } catch (Exception e) {
-        LOG.debug("Can not get entity id", e);
+        LOG.debug("Can not get metadata id", e);
         return false;
       }
-      loadRolePrivilege(metalake, username, userId, requestContext);
-      return authorizeByJcasbin(userId, metadataObject, metadataId, privilege);
+      loadRolePrivilege(metalake, username, requestContext);
+      Long userId = requestContext.getResolvedUserId();
+      if (userId == null) {
+        return false;
+      }
+      return authorizeByJcasbin(userId, metadataObject, metadataId, privilege, requestContext);
     }
 
     private boolean authorizeByJcasbin(
-        Long userId, MetadataObject metadataObject, Long metadataId, String privilege) {
+        Long userId,
+        MetadataObject metadataObject,
+        Long metadataId,
+        String privilege,
+        AuthorizationRequestContext requestContext) {
       if (AuthConstants.OWNER.equals(privilege)) {
-        Optional<Long> owner = ownerRel.getIfPresent(metadataId);
-        return Objects.equals(Optional.of(userId), owner);
+        Optional<Long> ownerOpt = requestContext.getCachedOwner(metadataId);
+        return ownerOpt != null && ownerOpt.isPresent() && Objects.equals(userId, ownerOpt.get());
       }
       return enforcer.enforce(
           String.valueOf(userId),
@@ -474,130 +509,149 @@ public class JcasbinAuthorizer implements GravitinoAuthorizer {
     }
   }
 
-  private static UserEntity getUserEntity(String username, String metalake) throws IOException {
-    EntityStore entityStore = GravitinoEnv.getInstance().entityStore();
-    UserEntity userEntity =
-        entityStore.get(
-            NameIdentifierUtil.ofUser(metalake, username),
-            Entity.EntityType.USER,
-            UserEntity.class);
-    return userEntity;
-  }
-
+  /**
+   * Version-validated role loading. Runs at most once per request (guarded by
+   * requestContext.loadRole). On each execution:
+   *
+   * <ol>
+   *   <li>Fetches userId and roleGrantsVersion from DB.
+   *   <li>Compares DB version with userRoleCache; reloads role IDs if stale.
+   *   <li>For each role, compares DB securableObjectsVersion with loadedRoles; reloads policies if
+   *       stale.
+   *   <li>Wires user→role relationships in both JCasbin enforcers.
+   * </ol>
+   */
   private void loadRolePrivilege(
-      String metalake, String username, Long userId, AuthorizationRequestContext requestContext) {
+      String metalake, String username, AuthorizationRequestContext requestContext) {
     requestContext.loadRole(
         () -> {
-          EntityStore entityStore = GravitinoEnv.getInstance().entityStore();
-          NameIdentifier userNameIdentifier = NameIdentifierUtil.ofUser(metalake, username);
-          List<RoleEntity> entities;
-          try {
-            entities =
-                entityStore
-                    .relationOperations()
-                    .listEntitiesByRelation(
-                        SupportsRelationOperations.Type.ROLE_USER_REL,
-                        userNameIdentifier,
-                        Entity.EntityType.USER);
-            List<CompletableFuture<Void>> loadRoleFutures = new ArrayList<>();
-            for (RoleEntity role : entities) {
-              Long roleId = role.id();
-              allowEnforcer.addRoleForUser(String.valueOf(userId), String.valueOf(roleId));
-              denyEnforcer.addRoleForUser(String.valueOf(userId), String.valueOf(roleId));
-              if (loadedRoles.getIfPresent(roleId) != null) {
-                continue;
-              }
-              CompletableFuture<Void> loadRoleFuture =
-                  CompletableFuture.supplyAsync(
-                          () -> {
-                            try {
-                              return entityStore.get(
-                                  NameIdentifierUtil.ofRole(metalake, role.name()),
-                                  Entity.EntityType.ROLE,
-                                  RoleEntity.class);
-                            } catch (Exception e) {
-                              throw new RuntimeException("Failed to load role: " + role.name(), e);
-                            }
-                          },
-                          executor)
-                      .thenAcceptAsync(
-                          roleEntity -> {
-                            loadPolicyByRoleEntity(roleEntity);
-                            loadedRoles.put(roleId, true);
-                          },
-                          executor);
-              loadRoleFutures.add(loadRoleFuture);
+          // Step 1: Fetch userId + roleGrantsVersion from DB
+          UserVersionInfoPO versionInfo =
+              SessionUtils.getWithoutCommit(
+                  UserMetaMapper.class, mapper -> mapper.getUserVersionInfo(metalake, username));
+          if (versionInfo == null) {
+            LOG.debug("User {} not found in metalake {}", username, metalake);
+            return;
+          }
+          long userId = versionInfo.getUserId();
+          int dbRoleGrantsVersion = versionInfo.getRoleGrantsVersion();
+          requestContext.setResolvedUserId(userId);
+
+          // Step 2: Check/update userRoleCache
+          String cacheKey = metalake + ":" + username;
+          CachedUserRoles cached = userRoleCache.getIfPresent(cacheKey).orElse(null);
+
+          List<Long> roleIds;
+          boolean roleListStale = cached == null || cached.roleGrantsVersion != dbRoleGrantsVersion;
+          if (!roleListStale) {
+            roleIds = cached.roleIds;
+          } else {
+            List<RolePO> rolePOs =
+                SessionUtils.getWithoutCommit(
+                    RoleMetaMapper.class, mapper -> mapper.listRolesByUserId(userId));
+            roleIds = rolePOs.stream().map(RolePO::getRoleId).collect(Collectors.toList());
+            userRoleCache.put(cacheKey, new CachedUserRoles(userId, dbRoleGrantsVersion, roleIds));
+            // Clear stale user→role links in JCasbin before re-wiring
+            allowEnforcer.deleteRolesForUser(String.valueOf(userId));
+            denyEnforcer.deleteRolesForUser(String.valueOf(userId));
+          }
+
+          if (roleIds.isEmpty()) {
+            return;
+          }
+
+          // Step 3: Check per-role policy versions, reload stale roles
+          Map<Long, Integer> dbRoleVersions = fetchRoleVersionsFromDB(roleIds);
+          for (Long roleId : roleIds) {
+            Integer dbVersion = dbRoleVersions.get(roleId);
+            if (dbVersion == null) {
+              // Role may have been deleted; skip
+              continue;
             }
-            CompletableFuture.allOf(loadRoleFutures.toArray(new CompletableFuture[0])).join();
-          } catch (IOException e) {
-            throw new RuntimeException(e);
+            Optional<Integer> cachedVersion = loadedRoles.getIfPresent(roleId);
+            if (cachedVersion.isPresent() && cachedVersion.get().intValue() == dbVersion) {
+              // Policies for this role are up-to-date
+              continue;
+            }
+            // Invalidate first: triggers the removal listener which deletes stale policies from
+            // JCasbin. Then re-add fresh policies. Calling put() directly would also trigger the
+            // listener on REPLACED, wiping the newly loaded policies.
+            loadedRoles.invalidate(roleId);
+            List<SecurableObjectPO> pos = RoleMetaService.listSecurableObjectsByRoleId(roleId);
+            loadPoliciesFromPOs(roleId, pos);
+            loadedRoles.put(roleId, dbVersion);
+          }
+
+          // Step 4: Wire user → roles in JCasbin
+          for (Long roleId : roleIds) {
+            allowEnforcer.addRoleForUser(String.valueOf(userId), String.valueOf(roleId));
+            denyEnforcer.addRoleForUser(String.valueOf(userId), String.valueOf(roleId));
           }
         });
   }
 
-  private void loadOwnerPolicy(String metalake, MetadataObject metadataObject, Long metadataId) {
-    if (ownerRel.getIfPresent(metadataId) != null) {
-      LOG.debug("Metadata {} OWNER has been loaded.", metadataId);
-      return;
+  private Map<Long, Integer> fetchRoleVersionsFromDB(List<Long> roleIds) {
+    List<RoleVersionInfoPO> rows =
+        SessionUtils.getWithoutCommit(
+            RoleMetaMapper.class, mapper -> mapper.batchGetSecurableObjectsVersions(roleIds));
+    Map<Long, Integer> result = new HashMap<>();
+    for (RoleVersionInfoPO row : rows) {
+      result.put(row.getRoleId(), row.getSecurableObjectsVersion());
     }
-    try {
-      NameIdentifier entityIdent = MetadataObjectUtil.toEntityIdent(metalake, metadataObject);
-      EntityStore entityStore = GravitinoEnv.getInstance().entityStore();
-      List<? extends Entity> owners =
-          entityStore
-              .relationOperations()
-              .listEntitiesByRelation(
-                  SupportsRelationOperations.Type.OWNER_REL,
-                  entityIdent,
-                  Entity.EntityType.valueOf(metadataObject.type().name()));
-      if (owners.isEmpty()) {
-        ownerRel.put(metadataId, Optional.empty());
-      } else {
-        for (Entity ownerEntity : owners) {
-          if (ownerEntity instanceof UserEntity) {
-            UserEntity user = (UserEntity) ownerEntity;
-            ownerRel.put(metadataId, Optional.of(user.id()));
-          }
-        }
-      }
-    } catch (IOException e) {
-      LOG.warn("Can not load metadata owner", e);
-    }
+    return result;
   }
 
-  private void loadPolicyByRoleEntity(RoleEntity roleEntity) {
-    String metalake = NameIdentifierUtil.getMetalake(roleEntity.nameIdentifier());
-    List<SecurableObject> securableObjects = roleEntity.securableObjects();
+  /**
+   * Loads privilege policies for a role directly from {@link SecurableObjectPO} records, avoiding
+   * the need to resolve integer metadata IDs through {@link MetadataIdConverter}.
+   *
+   * <p>DENY-condition privileges are added to the denyEnforcer with "allow" effect, and also to
+   * allowEnforcer with "deny" effect so that concurrent allow+deny grants on the same object return
+   * false.
+   */
+  @SuppressWarnings("unchecked")
+  private void loadPoliciesFromPOs(long roleId, List<SecurableObjectPO> pos) {
+    String roleIdStr = String.valueOf(roleId);
+    for (SecurableObjectPO po : pos) {
+      List<String> privilegeNames;
+      List<String> privilegeConditions;
+      try {
+        privilegeNames = JsonUtils.anyFieldMapper().readValue(po.getPrivilegeNames(), List.class);
+        privilegeConditions =
+            JsonUtils.anyFieldMapper().readValue(po.getPrivilegeConditions(), List.class);
+      } catch (JsonProcessingException e) {
+        LOG.warn(
+            "Failed to parse privilege JSON for role {} securable object {}: {}",
+            roleId,
+            po.getMetadataObjectId(),
+            e.getMessage());
+        continue;
+      }
 
-    for (SecurableObject securableObject : securableObjects) {
-      for (Privilege privilege : securableObject.privileges()) {
-        Privilege.Condition condition = privilege.condition();
-        if (AuthConstants.DENY.equalsIgnoreCase(condition.name())) {
-          denyEnforcer.addPolicy(
-              String.valueOf(roleEntity.id()),
-              securableObject.type().name(),
-              String.valueOf(MetadataIdConverter.getID(securableObject, metalake)),
-              AuthorizationUtils.replaceLegacyPrivilegeName(privilege.name())
-                  .name()
-                  .toUpperCase(java.util.Locale.ROOT),
-              AuthConstants.ALLOW);
-        }
-        // Since different roles of a user may simultaneously hold both "allow" and "deny"
-        // permissions
-        // for the same privilege on a given MetadataObject, the allowEnforcer must also incorporate
-        // the "deny" privilege to ensure that the authorize method correctly returns false in such
-        // cases. For example, if role1 has an "allow" privilege for SELECT_TABLE on table1, while
-        // role2 has a "deny" privilege for the same action on table1, then a user assigned both
-        // roles should receive a false result when calling the authorize method.
+      String objectType = po.getType();
+      String objectIdStr = String.valueOf(po.getMetadataObjectId());
 
-        allowEnforcer.addPolicy(
-            String.valueOf(roleEntity.id()),
-            securableObject.type().name(),
-            String.valueOf(MetadataIdConverter.getID(securableObject, metalake)),
-            AuthorizationUtils.replaceLegacyPrivilegeName(privilege.name())
+      for (int i = 0; i < privilegeNames.size(); i++) {
+        String rawPrivName = privilegeNames.get(i);
+        String condition = privilegeConditions.get(i);
+
+        String normalizedPrivName =
+            AuthorizationUtils.replaceLegacyPrivilegeName(
+                    Privilege.Name.valueOf(rawPrivName.toUpperCase(Locale.ROOT)))
                 .name()
-                .toUpperCase(java.util.Locale.ROOT),
-            condition.name().toLowerCase(java.util.Locale.ROOT));
+                .toUpperCase(Locale.ROOT);
+
+        if (AuthConstants.DENY.equalsIgnoreCase(condition)) {
+          denyEnforcer.addPolicy(
+              roleIdStr, objectType, objectIdStr, normalizedPrivName, AuthConstants.ALLOW);
+        }
+        // allowEnforcer carries both ALLOW and DENY effects so that deny overrides allow
+        allowEnforcer.addPolicy(
+            roleIdStr,
+            objectType,
+            objectIdStr,
+            normalizedPrivName,
+            condition.toLowerCase(Locale.ROOT));
       }
     }
   }

--- a/server-common/src/test/java/org/apache/gravitino/server/authorization/jcasbin/TestJcasbinAuthorizer.java
+++ b/server-common/src/test/java/org/apache/gravitino/server/authorization/jcasbin/TestJcasbinAuthorizer.java
@@ -20,41 +20,33 @@ package org.apache.gravitino.server.authorization.jcasbin;
 import static org.apache.gravitino.authorization.Privilege.Name.USE_CATALOG;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.github.benmanes.caffeine.cache.Cache;
 import com.google.common.collect.ImmutableList;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.security.Principal;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
-import java.util.concurrent.Executor;
-import java.util.stream.Collectors;
-import org.apache.commons.lang3.reflect.FieldUtils;
+import java.util.function.Function;
 import org.apache.gravitino.Entity;
 import org.apache.gravitino.EntityStore;
 import org.apache.gravitino.GravitinoEnv;
 import org.apache.gravitino.MetadataObject;
 import org.apache.gravitino.MetadataObjects;
-import org.apache.gravitino.NameIdentifier;
-import org.apache.gravitino.Namespace;
 import org.apache.gravitino.SupportsRelationOperations;
 import org.apache.gravitino.UserPrincipal;
 import org.apache.gravitino.authorization.AuthorizationRequestContext;
-import org.apache.gravitino.authorization.Privilege;
 import org.apache.gravitino.authorization.SecurableObject;
+import org.apache.gravitino.cache.GravitinoCache;
 import org.apache.gravitino.meta.AuditInfo;
 import org.apache.gravitino.meta.BaseMetalake;
 import org.apache.gravitino.meta.RoleEntity;
@@ -62,9 +54,16 @@ import org.apache.gravitino.meta.SchemaVersion;
 import org.apache.gravitino.meta.UserEntity;
 import org.apache.gravitino.server.ServerConfig;
 import org.apache.gravitino.server.authorization.MetadataIdConverter;
+import org.apache.gravitino.storage.relational.mapper.OwnerMetaMapper;
+import org.apache.gravitino.storage.relational.mapper.RoleMetaMapper;
+import org.apache.gravitino.storage.relational.mapper.UserMetaMapper;
+import org.apache.gravitino.storage.relational.po.OwnerRelInfoPO;
+import org.apache.gravitino.storage.relational.po.RolePO;
+import org.apache.gravitino.storage.relational.po.RoleVersionInfoPO;
 import org.apache.gravitino.storage.relational.po.SecurableObjectPO;
-import org.apache.gravitino.storage.relational.service.OwnerMetaService;
-import org.apache.gravitino.storage.relational.utils.POConverters;
+import org.apache.gravitino.storage.relational.po.UserVersionInfoPO;
+import org.apache.gravitino.storage.relational.service.RoleMetaService;
+import org.apache.gravitino.storage.relational.utils.SessionUtils;
 import org.apache.gravitino.utils.NameIdentifierUtil;
 import org.apache.gravitino.utils.NamespaceUtil;
 import org.apache.gravitino.utils.PrincipalUtils;
@@ -87,6 +86,8 @@ public class TestJcasbinAuthorizer {
 
   private static final Long CATALOG_ID = 4L;
 
+  private static final Integer ROLE_VERSION_1 = 1;
+
   private static final String USERNAME = "tester";
 
   private static final String METALAKE = "testMetalake";
@@ -104,22 +105,29 @@ public class TestJcasbinAuthorizer {
 
   private static MockedStatic<MetadataIdConverter> metadataIdConverterMockedStatic;
 
-  private static MockedStatic<OwnerMetaService> ownerMetaServiceMockedStatic;
+  private static MockedStatic<SessionUtils> sessionUtilsMockedStatic;
+
+  private static MockedStatic<RoleMetaService> roleMetaServiceMockedStatic;
 
   private static JcasbinAuthorizer jcasbinAuthorizer;
 
   private static ObjectMapper objectMapper = new ObjectMapper();
 
+  /** Default role PO list returned by the DB mock. */
+  private static List<RolePO> defaultRolePOs;
+
+  /** Default role version list returned by the DB mock. */
+  private static List<RoleVersionInfoPO> defaultRoleVersions;
+
   @BeforeAll
   public static void setup() throws IOException {
-    OwnerMetaService ownerMetaService = mock(OwnerMetaService.class);
-    ownerMetaServiceMockedStatic = mockStatic(OwnerMetaService.class);
-    ownerMetaServiceMockedStatic.when(OwnerMetaService::getInstance).thenReturn(ownerMetaService);
     gravitinoEnvMockedStatic = mockStatic(GravitinoEnv.class);
     gravitinoEnvMockedStatic.when(GravitinoEnv::getInstance).thenReturn(gravitinoEnv);
     when(gravitinoEnv.config()).thenReturn(new ServerConfig());
+
     principalUtilsMockedStatic = mockStatic(PrincipalUtils.class);
     metadataIdConverterMockedStatic = mockStatic(MetadataIdConverter.class);
+
     principalUtilsMockedStatic
         .when(PrincipalUtils::getCurrentPrincipal)
         .thenReturn(new UserPrincipal(USERNAME));
@@ -127,15 +135,33 @@ public class TestJcasbinAuthorizer {
     metadataIdConverterMockedStatic
         .when(() -> MetadataIdConverter.getID(any(), eq(METALAKE)))
         .thenReturn(CATALOG_ID);
+
     when(gravitinoEnv.entityStore()).thenReturn(entityStore);
     when(entityStore.relationOperations()).thenReturn(supportsRelationOperations);
-    when(entityStore.get(
-            eq(NameIdentifierUtil.ofUser(METALAKE, USERNAME)),
-            eq(Entity.EntityType.USER),
-            eq(UserEntity.class)))
-        .thenReturn(getUserEntity());
+
+    // Set up default DB mock data
+    RolePO allowRolePO = mock(RolePO.class);
+    when(allowRolePO.getRoleId()).thenReturn(ALLOW_ROLE_ID);
+    defaultRolePOs = ImmutableList.of(allowRolePO);
+
+    defaultRoleVersions = ImmutableList.of(makeRoleVersionInfo(ALLOW_ROLE_ID, ROLE_VERSION_1));
+
+    // Mock SessionUtils to dispatch to mock mappers
+    sessionUtilsMockedStatic = mockStatic(SessionUtils.class);
+    setupDefaultSessionMocks();
+
+    // Mock RoleMetaService.listSecurableObjectsByRoleId
+    roleMetaServiceMockedStatic = mockStatic(RoleMetaService.class);
+    roleMetaServiceMockedStatic
+        .when(() -> RoleMetaService.listSecurableObjectsByRoleId(eq(ALLOW_ROLE_ID)))
+        .thenReturn(ImmutableList.of(getAllowSecurableObjectPO()));
+    roleMetaServiceMockedStatic
+        .when(() -> RoleMetaService.listSecurableObjectsByRoleId(eq(DENY_ROLE_ID)))
+        .thenReturn(ImmutableList.of(getDenySecurableObjectPO()));
+
     jcasbinAuthorizer = new JcasbinAuthorizer();
     jcasbinAuthorizer.initialize();
+
     BaseMetalake baseMetalake =
         BaseMetalake.builder()
             .withId(USER_METALAKE_ID)
@@ -150,268 +176,156 @@ public class TestJcasbinAuthorizer {
         .thenReturn(baseMetalake);
   }
 
+  /** Configures SessionUtils mock to return default user version info and empty role lists. */
+  private static void setupDefaultSessionMocks() {
+    // By default, return no roles (no DB user)
+    sessionUtilsMockedStatic
+        .when(() -> SessionUtils.getWithoutCommit(eq(UserMetaMapper.class), any()))
+        .thenReturn(null);
+    sessionUtilsMockedStatic
+        .when(() -> SessionUtils.getWithoutCommit(eq(RoleMetaMapper.class), any()))
+        .thenReturn(ImmutableList.of());
+    sessionUtilsMockedStatic
+        .when(() -> SessionUtils.getWithoutCommit(eq(OwnerMetaMapper.class), any()))
+        .thenReturn(null);
+  }
+
+  /**
+   * Configures UserMetaMapper mock to return a user with the given userId and roleGrantsVersion.
+   */
+  private static void mockUserVersionInfo(long userId, int roleGrantsVersion) {
+    UserVersionInfoPO info = makeUserVersionInfo(userId, roleGrantsVersion);
+    sessionUtilsMockedStatic
+        .when(() -> SessionUtils.getWithoutCommit(eq(UserMetaMapper.class), any()))
+        .thenAnswer(
+            invocation -> {
+              Function<UserMetaMapper, ?> fn = invocation.getArgument(1);
+              UserMetaMapper mockMapper = mock(UserMetaMapper.class);
+              when(mockMapper.getUserVersionInfo(any(), any())).thenReturn(info);
+              return fn.apply(mockMapper);
+            });
+  }
+
+  /** Configures RoleMetaMapper mock to return the given rolePOs and roleVersions. */
+  private static void mockRoleData(List<RolePO> rolePOs, List<RoleVersionInfoPO> roleVersions) {
+    sessionUtilsMockedStatic
+        .when(() -> SessionUtils.getWithoutCommit(eq(RoleMetaMapper.class), any()))
+        .thenAnswer(
+            invocation -> {
+              Function<RoleMetaMapper, ?> fn = invocation.getArgument(1);
+              RoleMetaMapper mockMapper = mock(RoleMetaMapper.class);
+              when(mockMapper.listRolesByUserId(anyLong())).thenReturn(rolePOs);
+              when(mockMapper.batchGetSecurableObjectsVersions(any())).thenReturn(roleVersions);
+              return fn.apply(mockMapper);
+            });
+  }
+
+  /** Configures OwnerMetaMapper mock to return the given owner info. */
+  private static void mockOwnerData(OwnerRelInfoPO ownerInfo) {
+    sessionUtilsMockedStatic
+        .when(() -> SessionUtils.getWithoutCommit(eq(OwnerMetaMapper.class), any()))
+        .thenAnswer(
+            invocation -> {
+              Function<OwnerMetaMapper, ?> fn = invocation.getArgument(1);
+              OwnerMetaMapper mockMapper = mock(OwnerMetaMapper.class);
+              when(mockMapper.selectOwnerByMetadataObjectId(anyLong())).thenReturn(ownerInfo);
+              return fn.apply(mockMapper);
+            });
+  }
+
   @AfterAll
-  public static void stop() {
+  public static void stop() throws IOException {
     if (principalUtilsMockedStatic != null) {
       principalUtilsMockedStatic.close();
     }
     if (metadataIdConverterMockedStatic != null) {
       metadataIdConverterMockedStatic.close();
     }
-    if (ownerMetaServiceMockedStatic != null) {
-      ownerMetaServiceMockedStatic.close();
+    if (sessionUtilsMockedStatic != null) {
+      sessionUtilsMockedStatic.close();
+    }
+    if (roleMetaServiceMockedStatic != null) {
+      roleMetaServiceMockedStatic.close();
     }
     if (gravitinoEnvMockedStatic != null) {
       gravitinoEnvMockedStatic.close();
+    }
+    if (jcasbinAuthorizer != null) {
+      jcasbinAuthorizer.close();
     }
   }
 
   @Test
   public void testAuthorize() throws Exception {
-    makeCompletableFutureUseCurrentThread(jcasbinAuthorizer);
     Principal currentPrincipal = PrincipalUtils.getCurrentPrincipal();
-    assertFalse(doAuthorize(currentPrincipal));
-    RoleEntity allowRole =
-        getRoleEntity(ALLOW_ROLE_ID, "allowRole", ImmutableList.of(getAllowSecurableObject()));
-    when(entityStore.get(
-            eq(NameIdentifierUtil.ofRole(METALAKE, allowRole.name())),
-            eq(Entity.EntityType.ROLE),
-            eq(RoleEntity.class)))
-        .thenReturn(allowRole);
-    NameIdentifier userNameIdentifier = NameIdentifierUtil.ofUser(METALAKE, USERNAME);
-    // Mock adds roles to users.
-    when(supportsRelationOperations.listEntitiesByRelation(
-            eq(SupportsRelationOperations.Type.ROLE_USER_REL),
-            eq(userNameIdentifier),
-            eq(Entity.EntityType.USER)))
-        .thenReturn(ImmutableList.of(allowRole));
-    assertTrue(doAuthorize(currentPrincipal));
-    // Test role cache.
-    // When permissions are changed but handleRolePrivilegeChange is not executed, the system will
-    // use the cached permissions in JCasbin, so authorize can succeed.
-    Long newRoleId = -1L;
-    RoleEntity tempNewRole = getRoleEntity(newRoleId, "tempNewRole", ImmutableList.of());
-    when(entityStore.get(
-            eq(NameIdentifierUtil.ofRole(METALAKE, tempNewRole.name())),
-            eq(Entity.EntityType.ROLE),
-            eq(RoleEntity.class)))
-        .thenReturn(tempNewRole);
-    when(supportsRelationOperations.listEntitiesByRelation(
-            eq(SupportsRelationOperations.Type.ROLE_USER_REL),
-            eq(userNameIdentifier),
-            eq(Entity.EntityType.USER)))
-        .thenReturn(ImmutableList.of(tempNewRole));
-    assertTrue(doAuthorize(currentPrincipal));
-    // After clearing the cache, authorize will fail
-    jcasbinAuthorizer.handleRolePrivilegeChange(ALLOW_ROLE_ID);
-    //    assertFalse(doAuthorize(currentPrincipal));
-    // When the user is re-assigned the correct role, the authorization will succeed.
-    when(supportsRelationOperations.listEntitiesByRelation(
-            eq(SupportsRelationOperations.Type.ROLE_USER_REL),
-            eq(userNameIdentifier),
-            eq(Entity.EntityType.USER)))
-        .thenReturn(ImmutableList.of(allowRole));
-    when(entityStore.get(
-            eq(NameIdentifierUtil.ofRole(METALAKE, allowRole.name())),
-            eq(Entity.EntityType.ROLE),
-            eq(RoleEntity.class)))
-        .thenReturn(allowRole);
-    assertTrue(doAuthorize(currentPrincipal));
-    // Test deny
-    RoleEntity denyRole =
-        getRoleEntity(DENY_ROLE_ID, "denyRole", ImmutableList.of(getDenySecurableObject()));
-    when(entityStore.get(
-            eq(NameIdentifierUtil.ofRole(METALAKE, denyRole.name())),
-            eq(Entity.EntityType.ROLE),
-            eq(RoleEntity.class)))
-        .thenReturn(denyRole);
-    when(supportsRelationOperations.listEntitiesByRelation(
-            eq(SupportsRelationOperations.Type.ROLE_USER_REL),
-            eq(userNameIdentifier),
-            eq(Entity.EntityType.USER)))
-        .thenReturn(ImmutableList.of(allowRole, denyRole));
 
+    // No user in DB → authorize fails
+    setupDefaultSessionMocks();
+    assertFalse(doAuthorize(currentPrincipal));
+
+    // User exists with ALLOW role
+    mockUserVersionInfo(USER_ID, 1);
+    mockRoleData(defaultRolePOs, defaultRoleVersions);
+    assertTrue(doAuthorize(currentPrincipal));
+
+    // Test deny: add a deny role alongside the allow role
+    RolePO denyRolePO = mock(RolePO.class);
+    when(denyRolePO.getRoleId()).thenReturn(DENY_ROLE_ID);
+    List<RolePO> bothRoles = ImmutableList.of(defaultRolePOs.get(0), denyRolePO);
+    List<RoleVersionInfoPO> bothVersions =
+        ImmutableList.of(
+            defaultRoleVersions.get(0), makeRoleVersionInfo(DENY_ROLE_ID, ROLE_VERSION_1));
+
+    // Bump the user's roleGrantsVersion so the cache is invalidated and roles are reloaded
+    mockUserVersionInfo(USER_ID, 2);
+    mockRoleData(bothRoles, bothVersions);
     assertFalse(doAuthorize(currentPrincipal));
   }
 
   @Test
   public void testAuthorizeByOwner() throws Exception {
     Principal currentPrincipal = PrincipalUtils.getCurrentPrincipal();
-    assertFalse(doAuthorizeOwner(currentPrincipal));
-    NameIdentifier catalogIdent = NameIdentifierUtil.ofCatalog(METALAKE, "testCatalog");
-    List<UserEntity> owners = ImmutableList.of(getUserEntity());
-    doReturn(owners)
-        .when(supportsRelationOperations)
-        .listEntitiesByRelation(
-            eq(SupportsRelationOperations.Type.OWNER_REL),
-            eq(catalogIdent),
-            eq(Entity.EntityType.CATALOG));
-    getOwnerRelCache(jcasbinAuthorizer).invalidateAll();
+
+    // Owner is the current user → isOwner = true
+    mockUserVersionInfo(USER_ID, 1);
+    mockOwnerData(makeOwnerInfo(USER_ID, "USER"));
     assertTrue(doAuthorizeOwner(currentPrincipal));
-    doReturn(new ArrayList<>())
-        .when(supportsRelationOperations)
-        .listEntitiesByRelation(
-            eq(SupportsRelationOperations.Type.OWNER_REL),
-            eq(catalogIdent),
-            eq(Entity.EntityType.CATALOG));
-    jcasbinAuthorizer.handleMetadataOwnerChange(
-        METALAKE, USER_ID, catalogIdent, Entity.EntityType.CATALOG);
+
+    // Different owner → isOwner = false
+    mockOwnerData(makeOwnerInfo(999L, "USER"));
     assertFalse(doAuthorizeOwner(currentPrincipal));
-  }
 
-  private Boolean doAuthorize(Principal currentPrincipal) {
-    return jcasbinAuthorizer.authorize(
-        currentPrincipal,
-        "testMetalake",
-        MetadataObjects.of(null, "testCatalog", MetadataObject.Type.CATALOG),
-        USE_CATALOG,
-        new AuthorizationRequestContext());
-  }
-
-  private Boolean doAuthorizeOwner(Principal currentPrincipal) {
-    AuthorizationRequestContext authorizationRequestContext = new AuthorizationRequestContext();
-    return jcasbinAuthorizer.isOwner(
-        currentPrincipal,
-        "testMetalake",
-        MetadataObjects.of(null, "testCatalog", MetadataObject.Type.CATALOG),
-        authorizationRequestContext);
-  }
-
-  private static UserEntity getUserEntity() {
-    return UserEntity.builder()
-        .withId(USER_ID)
-        .withName(USERNAME)
-        .withAuditInfo(AuditInfo.EMPTY)
-        .build();
-  }
-
-  private static RoleEntity getRoleEntity(
-      Long roleId, String roleName, List<SecurableObject> securableObjects) {
-    Namespace namespace = NamespaceUtil.ofRole(METALAKE);
-    return RoleEntity.builder()
-        .withNamespace(namespace)
-        .withId(roleId)
-        .withName(roleName)
-        .withAuditInfo(AuditInfo.EMPTY)
-        .withSecurableObjects(securableObjects)
-        .build();
-  }
-
-  private static SecurableObjectPO getAllowSecurableObjectPO() {
-    ImmutableList<Privilege.Name> privileges = ImmutableList.of(USE_CATALOG);
-    List<String> privilegeNames = privileges.stream().map(Enum::name).collect(Collectors.toList());
-    ImmutableList<String> conditions = ImmutableList.of("ALLOW");
-
-    try {
-      return SecurableObjectPO.builder()
-          .withType(String.valueOf(MetadataObject.Type.CATALOG))
-          .withMetadataObjectId(CATALOG_ID)
-          .withRoleId(ALLOW_ROLE_ID)
-          .withPrivilegeNames(objectMapper.writeValueAsString(privilegeNames))
-          .withPrivilegeConditions(objectMapper.writeValueAsString(conditions))
-          .withDeletedAt(0L)
-          .withCurrentVersion(1L)
-          .withLastVersion(1L)
-          .build();
-    } catch (JsonProcessingException e) {
-      throw new RuntimeException(e);
-    }
-  }
-
-  private static SecurableObject getAllowSecurableObject() {
-    return POConverters.fromSecurableObjectPO(
-        "testCatalog", getAllowSecurableObjectPO(), MetadataObject.Type.CATALOG);
-  }
-
-  private static SecurableObjectPO getDenySecurableObjectPO() {
-    ImmutableList<Privilege.Name> privileges = ImmutableList.of(USE_CATALOG);
-    ImmutableList<String> conditions = ImmutableList.of("DENY");
-    try {
-      return SecurableObjectPO.builder()
-          .withType(String.valueOf(MetadataObject.Type.CATALOG))
-          .withMetadataObjectId(CATALOG_ID)
-          .withRoleId(DENY_ROLE_ID)
-          .withPrivilegeNames(objectMapper.writeValueAsString(privileges))
-          .withPrivilegeConditions(objectMapper.writeValueAsString(conditions))
-          .withDeletedAt(0L)
-          .withCurrentVersion(1L)
-          .withLastVersion(1L)
-          .build();
-    } catch (JsonProcessingException e) {
-      throw new RuntimeException(e);
-    }
-  }
-
-  private static SecurableObject getDenySecurableObject() {
-    return POConverters.fromSecurableObjectPO(
-        "testCatalog2", getDenySecurableObjectPO(), MetadataObject.Type.CATALOG);
-  }
-
-  private static void makeCompletableFutureUseCurrentThread(JcasbinAuthorizer jcasbinAuthorizer) {
-    try {
-      Executor currentThread = Runnable::run;
-      Class<JcasbinAuthorizer> jcasbinAuthorizerClass = JcasbinAuthorizer.class;
-      Field field = jcasbinAuthorizerClass.getDeclaredField("executor");
-      field.setAccessible(true);
-      FieldUtils.writeField(field, jcasbinAuthorizer, currentThread);
-    } catch (Exception e) {
-      throw new RuntimeException(e);
-    }
+    // No owner row → isOwner = false
+    mockOwnerData(null);
+    assertFalse(doAuthorizeOwner(currentPrincipal));
   }
 
   @Test
   public void testRoleCacheInvalidation() throws Exception {
-    makeCompletableFutureUseCurrentThread(jcasbinAuthorizer);
+    GravitinoCache<Long, Integer> loadedRoles = getLoadedRolesCache(jcasbinAuthorizer);
 
-    // Get the loadedRoles cache via reflection
-    Cache<Long, Boolean> loadedRoles = getLoadedRolesCache(jcasbinAuthorizer);
-
-    // Manually add a role to the cache
+    // Manually add a role version to the cache
     Long testRoleId = 100L;
-    loadedRoles.put(testRoleId, true);
+    loadedRoles.put(testRoleId, 1);
 
     // Verify it's in the cache
-    assertNotNull(loadedRoles.getIfPresent(testRoleId));
+    assertTrue(loadedRoles.getIfPresent(testRoleId).isPresent());
 
     // Call handleRolePrivilegeChange which should invalidate the cache entry
     jcasbinAuthorizer.handleRolePrivilegeChange(testRoleId);
 
     // Verify it's removed from the cache
-    assertNull(loadedRoles.getIfPresent(testRoleId));
-  }
-
-  @Test
-  public void testOwnerCacheInvalidation() throws Exception {
-    // Get the ownerRel cache via reflection
-    Cache<Long, Optional<Long>> ownerRel = getOwnerRelCache(jcasbinAuthorizer);
-
-    // Manually add an owner relation to the cache
-    ownerRel.put(CATALOG_ID, Optional.of(USER_ID));
-
-    // Verify it's in the cache
-    assertNotNull(ownerRel.getIfPresent(CATALOG_ID));
-
-    // Create a mock NameIdentifier for the metadata object
-    NameIdentifier catalogIdent = NameIdentifierUtil.ofCatalog(METALAKE, "testCatalog");
-
-    // Call handleMetadataOwnerChange which should invalidate the cache entry
-    jcasbinAuthorizer.handleMetadataOwnerChange(
-        METALAKE, USER_ID, catalogIdent, Entity.EntityType.CATALOG);
-
-    // Verify it's removed from the cache
-    assertNull(ownerRel.getIfPresent(CATALOG_ID));
+    assertFalse(loadedRoles.getIfPresent(testRoleId).isPresent());
   }
 
   @Test
   public void testRoleCacheSynchronousRemovalListenerDeletesPolicy() throws Exception {
-    makeCompletableFutureUseCurrentThread(jcasbinAuthorizer);
-
     // Get the enforcers via reflection
     Enforcer allowEnforcer = getAllowEnforcer(jcasbinAuthorizer);
     Enforcer denyEnforcer = getDenyEnforcer(jcasbinAuthorizer);
 
     // Get the loadedRoles cache
-    Cache<Long, Boolean> loadedRoles = getLoadedRolesCache(jcasbinAuthorizer);
+    GravitinoCache<Long, Integer> loadedRoles = getLoadedRolesCache(jcasbinAuthorizer);
 
     // Add a role and its policy to the enforcer
     Long testRoleId = 300L;
@@ -421,44 +335,64 @@ public class TestJcasbinAuthorizer {
     allowEnforcer.addPolicy(roleIdStr, "CATALOG", "999", "USE_CATALOG", "allow");
     denyEnforcer.addPolicy(roleIdStr, "CATALOG", "999", "USE_CATALOG", "allow");
 
-    // Add role to cache
-    loadedRoles.put(testRoleId, true);
+    // Add role version to cache
+    loadedRoles.put(testRoleId, 1);
 
-    // Verify role exists in enforcer (has policy)
+    // Verify policy exists in enforcer
     assertTrue(allowEnforcer.hasPolicy(roleIdStr, "CATALOG", "999", "USE_CATALOG", "allow"));
     assertTrue(denyEnforcer.hasPolicy(roleIdStr, "CATALOG", "999", "USE_CATALOG", "allow"));
 
-    // Invalidate the cache entry - this triggers the synchronous removal listener
-    // (using executor(Runnable::run) to ensure synchronous execution)
+    // Invalidate the cache entry — this triggers the synchronous removal listener
     loadedRoles.invalidate(testRoleId);
 
-    // Verify the role's policies have been deleted from enforcers (synchronous, no need to wait)
+    // Verify the role's policies have been deleted from enforcers
     assertFalse(allowEnforcer.hasPolicy(roleIdStr, "CATALOG", "999", "USE_CATALOG", "allow"));
     assertFalse(denyEnforcer.hasPolicy(roleIdStr, "CATALOG", "999", "USE_CATALOG", "allow"));
   }
 
   @Test
   public void testCacheInitialization() throws Exception {
-    // Verify that caches are initialized
-    Cache<Long, Boolean> loadedRoles = getLoadedRolesCache(jcasbinAuthorizer);
-    Cache<Long, Optional<Long>> ownerRel = getOwnerRelCache(jcasbinAuthorizer);
+    // Verify that both caches are initialized after initialize()
+    GravitinoCache<Long, Integer> loadedRoles = getLoadedRolesCache(jcasbinAuthorizer);
+    GravitinoCache<String, ?> userRoleCache = getUserRoleCache(jcasbinAuthorizer);
 
     assertNotNull(loadedRoles, "loadedRoles cache should be initialized");
-    assertNotNull(ownerRel, "ownerRel cache should be initialized");
+    assertNotNull(userRoleCache, "userRoleCache should be initialized");
+  }
+
+  @Test
+  public void testVersionValidation() throws Exception {
+    // Set up user with role at version 1
+    mockUserVersionInfo(USER_ID, 1);
+    mockRoleData(defaultRolePOs, defaultRoleVersions);
+
+    // First call — loads and caches
+    assertTrue(doAuthorize(PrincipalUtils.getCurrentPrincipal()));
+
+    GravitinoCache<Long, Integer> loadedRoles = getLoadedRolesCache(jcasbinAuthorizer);
+
+    // Verify role is in the version cache
+    assertTrue(loadedRoles.getIfPresent(ALLOW_ROLE_ID).isPresent());
+
+    // Simulate a role privilege change via handleRolePrivilegeChange
+    jcasbinAuthorizer.handleRolePrivilegeChange(ALLOW_ROLE_ID);
+
+    // Role should no longer be in version cache
+    assertFalse(loadedRoles.getIfPresent(ALLOW_ROLE_ID).isPresent());
+
+    // Next call reloads the role (DB version returned as 2)
+    mockRoleData(defaultRolePOs, ImmutableList.of(makeRoleVersionInfo(ALLOW_ROLE_ID, 2)));
+    assertTrue(doAuthorize(PrincipalUtils.getCurrentPrincipal()));
+
+    // Now the cache should hold version 2
+    assertTrue(loadedRoles.getIfPresent(ALLOW_ROLE_ID).isPresent());
   }
 
   /** Tests {@link JcasbinAuthorizer#hasMetadataPrivilegePermission} hierarchy walk */
   @Test
   public void testHasMetadataPrivilegePermission() throws Exception {
-    makeCompletableFutureUseCurrentThread(jcasbinAuthorizer);
-    NameIdentifier userNameIdentifier = NameIdentifierUtil.ofUser(METALAKE, USERNAME);
-
     // --- Case 1: no MANAGE_GRANTS anywhere → false ---
-    when(supportsRelationOperations.listEntitiesByRelation(
-            eq(SupportsRelationOperations.Type.ROLE_USER_REL),
-            eq(userNameIdentifier),
-            eq(Entity.EntityType.USER)))
-        .thenReturn(ImmutableList.of());
+    setupDefaultSessionMocks(); // no user
     assertFalse(
         jcasbinAuthorizer.hasMetadataPrivilegePermission(
             METALAKE,
@@ -469,23 +403,20 @@ public class TestJcasbinAuthorizer {
 
     // --- Case 2: METALAKE-level MANAGE_GRANTS covers a TABLE ---
     Long metalakeGrantRoleId = 201L;
-    RoleEntity metalakeGrantRole =
-        getRoleEntity(
-            metalakeGrantRoleId,
-            "metalakeGrantRole",
+    RolePO metalakeGrantRolePO = mock(RolePO.class);
+    when(metalakeGrantRolePO.getRoleId()).thenReturn(metalakeGrantRoleId);
+
+    roleMetaServiceMockedStatic
+        .when(() -> RoleMetaService.listSecurableObjectsByRoleId(eq(metalakeGrantRoleId)))
+        .thenReturn(
             ImmutableList.of(
-                buildManageGrantsSecurableObject(
-                    metalakeGrantRoleId, MetadataObject.Type.METALAKE, METALAKE)));
-    when(entityStore.get(
-            eq(NameIdentifierUtil.ofRole(METALAKE, metalakeGrantRole.name())),
-            eq(Entity.EntityType.ROLE),
-            eq(RoleEntity.class)))
-        .thenReturn(metalakeGrantRole);
-    when(supportsRelationOperations.listEntitiesByRelation(
-            eq(SupportsRelationOperations.Type.ROLE_USER_REL),
-            eq(userNameIdentifier),
-            eq(Entity.EntityType.USER)))
-        .thenReturn(ImmutableList.of(metalakeGrantRole));
+                buildManageGrantsSecurableObjectPO(
+                    metalakeGrantRoleId, MetadataObject.Type.METALAKE)));
+
+    mockUserVersionInfo(USER_ID, 10);
+    mockRoleData(
+        ImmutableList.of(metalakeGrantRolePO),
+        ImmutableList.of(makeRoleVersionInfo(metalakeGrantRoleId, 1)));
     assertTrue(
         jcasbinAuthorizer.hasMetadataPrivilegePermission(
             METALAKE,
@@ -496,23 +427,20 @@ public class TestJcasbinAuthorizer {
 
     // --- Case 3: CATALOG-level MANAGE_GRANTS covers TABLE/SCHEMA ---
     Long catalogGrantRoleId = 200L;
-    RoleEntity catalogGrantRole =
-        getRoleEntity(
-            catalogGrantRoleId,
-            "catalogGrantRole",
+    RolePO catalogGrantRolePO = mock(RolePO.class);
+    when(catalogGrantRolePO.getRoleId()).thenReturn(catalogGrantRoleId);
+
+    roleMetaServiceMockedStatic
+        .when(() -> RoleMetaService.listSecurableObjectsByRoleId(eq(catalogGrantRoleId)))
+        .thenReturn(
             ImmutableList.of(
-                buildManageGrantsSecurableObject(
-                    catalogGrantRoleId, MetadataObject.Type.CATALOG, "testCatalog")));
-    when(entityStore.get(
-            eq(NameIdentifierUtil.ofRole(METALAKE, catalogGrantRole.name())),
-            eq(Entity.EntityType.ROLE),
-            eq(RoleEntity.class)))
-        .thenReturn(catalogGrantRole);
-    when(supportsRelationOperations.listEntitiesByRelation(
-            eq(SupportsRelationOperations.Type.ROLE_USER_REL),
-            eq(userNameIdentifier),
-            eq(Entity.EntityType.USER)))
-        .thenReturn(ImmutableList.of(catalogGrantRole));
+                buildManageGrantsSecurableObjectPO(
+                    catalogGrantRoleId, MetadataObject.Type.CATALOG)));
+
+    mockUserVersionInfo(USER_ID, 11);
+    mockRoleData(
+        ImmutableList.of(catalogGrantRolePO),
+        ImmutableList.of(makeRoleVersionInfo(catalogGrantRoleId, 1)));
     assertTrue(
         jcasbinAuthorizer.hasMetadataPrivilegePermission(
             METALAKE,
@@ -527,25 +455,19 @@ public class TestJcasbinAuthorizer {
 
     // --- Case 4: TABLE-level MANAGE_GRANTS covers the table itself ---
     Long tableGrantRoleId = 202L;
-    RoleEntity tableGrantRole =
-        getRoleEntity(
-            tableGrantRoleId,
-            "tableGrantRole",
+    RolePO tableGrantRolePO = mock(RolePO.class);
+    when(tableGrantRolePO.getRoleId()).thenReturn(tableGrantRoleId);
+
+    roleMetaServiceMockedStatic
+        .when(() -> RoleMetaService.listSecurableObjectsByRoleId(eq(tableGrantRoleId)))
+        .thenReturn(
             ImmutableList.of(
-                buildManageGrantsSecurableObject(
-                    tableGrantRoleId,
-                    MetadataObject.Type.TABLE,
-                    "testCatalog.testSchema.testTable")));
-    when(entityStore.get(
-            eq(NameIdentifierUtil.ofRole(METALAKE, tableGrantRole.name())),
-            eq(Entity.EntityType.ROLE),
-            eq(RoleEntity.class)))
-        .thenReturn(tableGrantRole);
-    when(supportsRelationOperations.listEntitiesByRelation(
-            eq(SupportsRelationOperations.Type.ROLE_USER_REL),
-            eq(userNameIdentifier),
-            eq(Entity.EntityType.USER)))
-        .thenReturn(ImmutableList.of(tableGrantRole));
+                buildManageGrantsSecurableObjectPO(tableGrantRoleId, MetadataObject.Type.TABLE)));
+
+    mockUserVersionInfo(USER_ID, 12);
+    mockRoleData(
+        ImmutableList.of(tableGrantRolePO),
+        ImmutableList.of(makeRoleVersionInfo(tableGrantRoleId, 1)));
     assertTrue(
         jcasbinAuthorizer.hasMetadataPrivilegePermission(
             METALAKE,
@@ -562,46 +484,118 @@ public class TestJcasbinAuthorizer {
                 METALAKE, "INVALID_TYPE", "testCatalog", new AuthorizationRequestContext()));
   }
 
+  private Boolean doAuthorize(Principal currentPrincipal) {
+    return jcasbinAuthorizer.authorize(
+        currentPrincipal,
+        METALAKE,
+        MetadataObjects.of(null, "testCatalog", MetadataObject.Type.CATALOG),
+        USE_CATALOG,
+        new AuthorizationRequestContext());
+  }
+
+  private Boolean doAuthorizeOwner(Principal currentPrincipal) {
+    return jcasbinAuthorizer.isOwner(
+        currentPrincipal,
+        METALAKE,
+        MetadataObjects.of(null, "testCatalog", MetadataObject.Type.CATALOG),
+        new AuthorizationRequestContext());
+  }
+
+  private static UserEntity getUserEntity() {
+    return UserEntity.builder()
+        .withId(USER_ID)
+        .withName(USERNAME)
+        .withAuditInfo(AuditInfo.EMPTY)
+        .build();
+  }
+
+  private static RoleEntity getRoleEntity(
+      Long roleId, String roleName, List<SecurableObject> securableObjects) {
+    return RoleEntity.builder()
+        .withNamespace(NamespaceUtil.ofRole(METALAKE))
+        .withId(roleId)
+        .withName(roleName)
+        .withAuditInfo(AuditInfo.EMPTY)
+        .withSecurableObjects(securableObjects)
+        .build();
+  }
+
+  private static SecurableObjectPO getAllowSecurableObjectPO() {
+    ImmutableList<String> privilegeNames = ImmutableList.of(USE_CATALOG.name());
+    ImmutableList<String> conditions = ImmutableList.of("ALLOW");
+    try {
+      return SecurableObjectPO.builder()
+          .withType(String.valueOf(MetadataObject.Type.CATALOG))
+          .withMetadataObjectId(CATALOG_ID)
+          .withRoleId(ALLOW_ROLE_ID)
+          .withPrivilegeNames(objectMapper.writeValueAsString(privilegeNames))
+          .withPrivilegeConditions(objectMapper.writeValueAsString(conditions))
+          .withDeletedAt(0L)
+          .withCurrentVersion(1L)
+          .withLastVersion(1L)
+          .build();
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private static SecurableObjectPO getDenySecurableObjectPO() {
+    ImmutableList<String> privilegeNames = ImmutableList.of(USE_CATALOG.name());
+    ImmutableList<String> conditions = ImmutableList.of("DENY");
+    try {
+      return SecurableObjectPO.builder()
+          .withType(String.valueOf(MetadataObject.Type.CATALOG))
+          .withMetadataObjectId(CATALOG_ID)
+          .withRoleId(DENY_ROLE_ID)
+          .withPrivilegeNames(objectMapper.writeValueAsString(privilegeNames))
+          .withPrivilegeConditions(objectMapper.writeValueAsString(conditions))
+          .withDeletedAt(0L)
+          .withCurrentVersion(1L)
+          .withLastVersion(1L)
+          .build();
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
   /**
-   * Builds a {@link SecurableObject} carrying an ALLOW {@code MANAGE_GRANTS} privilege bound to
-   * {@code type} with the shared test metadata ID ({@link #CATALOG_ID}).
+   * Builds a {@link SecurableObjectPO} carrying an ALLOW {@code MANAGE_GRANTS} privilege bound to
+   * the given type with the shared test metadata ID ({@link #CATALOG_ID}).
    */
-  private static SecurableObject buildManageGrantsSecurableObject(
-      Long roleId, MetadataObject.Type type, String objectName) {
+  private static SecurableObjectPO buildManageGrantsSecurableObjectPO(
+      Long roleId, MetadataObject.Type type) {
     try {
       ImmutableList<String> privilegeNames = ImmutableList.of("MANAGE_GRANTS");
       ImmutableList<String> conditions = ImmutableList.of("ALLOW");
-      SecurableObjectPO po =
-          SecurableObjectPO.builder()
-              .withType(String.valueOf(type))
-              .withMetadataObjectId(CATALOG_ID)
-              .withRoleId(roleId)
-              .withPrivilegeNames(objectMapper.writeValueAsString(privilegeNames))
-              .withPrivilegeConditions(objectMapper.writeValueAsString(conditions))
-              .withDeletedAt(0L)
-              .withCurrentVersion(1L)
-              .withLastVersion(1L)
-              .build();
-      return POConverters.fromSecurableObjectPO(objectName, po, type);
+      return SecurableObjectPO.builder()
+          .withType(String.valueOf(type))
+          .withMetadataObjectId(CATALOG_ID)
+          .withRoleId(roleId)
+          .withPrivilegeNames(objectMapper.writeValueAsString(privilegeNames))
+          .withPrivilegeConditions(objectMapper.writeValueAsString(conditions))
+          .withDeletedAt(0L)
+          .withCurrentVersion(1L)
+          .withLastVersion(1L)
+          .build();
     } catch (JsonProcessingException e) {
       throw new RuntimeException(e);
     }
   }
 
   @SuppressWarnings("unchecked")
-  private static Cache<Long, Boolean> getLoadedRolesCache(JcasbinAuthorizer authorizer)
+  private static GravitinoCache<Long, Integer> getLoadedRolesCache(JcasbinAuthorizer authorizer)
       throws Exception {
     Field field = JcasbinAuthorizer.class.getDeclaredField("loadedRoles");
     field.setAccessible(true);
-    return (Cache<Long, Boolean>) field.get(authorizer);
+    return (GravitinoCache<Long, Integer>) field.get(authorizer);
   }
 
   @SuppressWarnings("unchecked")
-  private static Cache<Long, Optional<Long>> getOwnerRelCache(JcasbinAuthorizer authorizer)
+  private static GravitinoCache<String, ?> getUserRoleCache(JcasbinAuthorizer authorizer)
       throws Exception {
-    Field field = JcasbinAuthorizer.class.getDeclaredField("ownerRel");
+    Field field = JcasbinAuthorizer.class.getDeclaredField("userRoleCache");
     field.setAccessible(true);
-    return (Cache<Long, Optional<Long>>) field.get(authorizer);
+    return (GravitinoCache<String, ?>) field.get(authorizer);
   }
 
   private static Enforcer getAllowEnforcer(JcasbinAuthorizer authorizer) throws Exception {
@@ -614,5 +608,26 @@ public class TestJcasbinAuthorizer {
     Field field = JcasbinAuthorizer.class.getDeclaredField("denyEnforcer");
     field.setAccessible(true);
     return (Enforcer) field.get(authorizer);
+  }
+
+  private static UserVersionInfoPO makeUserVersionInfo(long userId, int roleGrantsVersion) {
+    UserVersionInfoPO po = new UserVersionInfoPO();
+    po.setUserId(userId);
+    po.setRoleGrantsVersion(roleGrantsVersion);
+    return po;
+  }
+
+  private static RoleVersionInfoPO makeRoleVersionInfo(long roleId, int securableObjectsVersion) {
+    RoleVersionInfoPO po = new RoleVersionInfoPO();
+    po.setRoleId(roleId);
+    po.setSecurableObjectsVersion(securableObjectsVersion);
+    return po;
+  }
+
+  private static OwnerRelInfoPO makeOwnerInfo(long ownerId, String ownerType) {
+    OwnerRelInfoPO po = new OwnerRelInfoPO();
+    po.setOwnerId(ownerId);
+    po.setOwnerType(ownerType);
+    return po;
   }
 }


### PR DESCRIPTION
> **Stacked PR** — depends on #10774 and #10775. Please review/merge those PRs first.

### What changes were proposed in this pull request?

- Replace TTL-based cache in `JcasbinAuthorizer` with DB-version-validated caches:
  - `loadedRoles: GravitinoCache<Long, Integer>` (roleId → securableObjectsVersion)
  - `userRoleCache: GravitinoCache<String, CachedUserRoles>` (metalake:user → roleGrantsVersion + roleIds)
- On each `authorize()` call: fetch user's `roleGrantsVersion` from DB; on version mismatch re-load role list and re-validate each role's `securableObjectsVersion`
- Owner check uses `OwnerRelInfoPO` projection instead of fetching full entity
- Remove async `executor` field; all cache operations are now synchronous
- Rewrite `TestJcasbinAuthorizer` to match the new synchronous implementation

### Why are the changes needed?

TTL-based cache eviction can leave stale policies active for up to N seconds after a permission change. Version-validated invalidation detects staleness on the next request, improving both security and correctness.

Fix: #10772

### Does this PR introduce _any_ user-facing change?

No user-facing API changes. Authorization behaviour is unchanged; only the caching mechanism is improved.

### How was this patch tested?

`TestJcasbinAuthorizer` covers: basic authorize, owner-based authorize, role cache invalidation on version mismatch, synchronous removal listener deleting Casbin policy, cache initialization, version validation, and metadata-privilege check (7 test cases total).