### PR TITLE
[#10762] fix(common): Lazy-initialize Version to fix TestVersion without jar task

### DIFF
--- a/common/src/main/java/org/apache/gravitino/Version.java
+++ b/common/src/main/java/org/apache/gravitino/Version.java
@@ -38,7 +38,9 @@ public class Version {
   private static final Pattern PATTERN =
       Pattern.compile("^(\\d+)\\.(\\d+)\\.(\\d+)(?:rc(0|[1-9]\\d*)|-.*|\\.([a-zA-Z].*))?$");
 
-  private static final Version INSTANCE = new Version();
+  private static class InstanceHolder {
+    private static final Version INSTANCE = new Version();
+  }
 
   private final VersionInfo versionInfo;
   private final VersionDTO versionDTO;
@@ -74,14 +76,14 @@ public class Version {
    * @return the current versionInfo
    */
   public static VersionInfo getCurrentVersion() {
-    return INSTANCE.versionInfo;
+    return InstanceHolder.INSTANCE.versionInfo;
   }
 
   /**
    * @return the current version DTO
    */
   public static VersionDTO getCurrentVersionDTO() {
-    return INSTANCE.versionDTO;
+    return InstanceHolder.INSTANCE.versionDTO;
   }
 
   /**


### PR DESCRIPTION
### What changes were proposed in this pull request?

Replace eager static initialization of `Version.INSTANCE` with the initialization-on-demand holder idiom. This ensures `parseVersionNumber()` can be called without triggering the properties file load.

### Why are the changes needed?

`TestVersion` fails when tests are run directly (`./gradlew clean :common:test -PskipITs`) without first running the `jar` task. The `gravitino-build-info.properties` file is only generated inside `jar { doFirst }`, not during `processResources`. Since `test` does not depend on `jar`, the file is absent, causing `Version`'s static initializer to throw — even though all `TestVersion` methods only call `parseVersionNumber()`, which never uses `INSTANCE`.

The holder pattern is already established in this codebase by `ObjectMapperProvider` and `GravitinoEnv`.

Fix: #10762

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

`./gradlew clean :common:test -PskipITs --tests "org.apache.gravitino.TestVersion"` — all 4 tests pass without a prior `jar` task.