### PR TITLE
feat(cache): add id-mapping caches and change poller to JcasbinAuthorizer

### DIFF
--- a/core/src/main/java/org/apache/gravitino/authorization/GravitinoAuthorizer.java
+++ b/core/src/main/java/org/apache/gravitino/authorization/GravitinoAuthorizer.java
@@ -164,4 +164,18 @@ public interface GravitinoAuthorizer extends Closeable {
    */
   void handleMetadataOwnerChange(
       String metalake, Long oldOwnerId, NameIdentifier nameIdentifier, Entity.EntityType type);
+
+  /**
+   * Notifies the authorizer that an entity structural change (create, alter, drop) has occurred.
+   * Implementations should invalidate any cached name-to-id mappings for the affected entity.
+   *
+   * <p>This default no-op implementation exists to maintain backward compatibility with
+   * implementations that do not cache name-to-id mappings.
+   *
+   * @param metalake the metalake the entity belongs to
+   * @param nameIdent the name identifier of the affected entity
+   * @param type the entity type
+   */
+  default void handleEntityStructuralChange(
+      String metalake, NameIdentifier nameIdent, Entity.EntityType type) {}
 }

--- a/core/src/main/java/org/apache/gravitino/cache/CaffeineGravitinoCache.java
+++ b/core/src/main/java/org/apache/gravitino/cache/CaffeineGravitinoCache.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.cache;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A {@link GravitinoCache} implementation backed by a Caffeine cache.
+ *
+ * <p>{@link #invalidateByPrefix(String)} performs an O(n) scan over the cache key set. This is
+ * bounded and acceptable because DDL operations (which trigger invalidation) are rare.
+ */
+public class CaffeineGravitinoCache<K, V> implements GravitinoCache<K, V> {
+
+  private final Cache<K, V> cache;
+
+  public CaffeineGravitinoCache(long maxSize, long ttlSeconds) {
+    this.cache =
+        Caffeine.newBuilder()
+            .maximumSize(maxSize)
+            .expireAfterWrite(ttlSeconds, TimeUnit.SECONDS)
+            .build();
+  }
+
+  @Override
+  public Optional<V> getIfPresent(K key) {
+    return Optional.ofNullable(cache.getIfPresent(key));
+  }
+
+  @Override
+  public void put(K key, V value) {
+    cache.put(key, value);
+  }
+
+  @Override
+  public void invalidate(K key) {
+    cache.invalidate(key);
+  }
+
+  @Override
+  public void invalidateAll() {
+    cache.invalidateAll();
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public void invalidateByPrefix(String prefix) {
+    cache.asMap().keySet().stream()
+        .filter(k -> ((String) k).startsWith(prefix))
+        .forEach(cache::invalidate);
+  }
+
+  @Override
+  public long size() {
+    return cache.estimatedSize();
+  }
+
+  @Override
+  public void close() {
+    cache.invalidateAll();
+    cache.cleanUp();
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/cache/GravitinoCache.java
+++ b/core/src/main/java/org/apache/gravitino/cache/GravitinoCache.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.cache;
+
+import java.io.Closeable;
+import java.util.Optional;
+
+/**
+ * A generic cache abstraction for Gravitino's auth path.
+ *
+ * <p>Implementations must be thread-safe. The {@code invalidateByPrefix} method is only meaningful
+ * when {@code K = String}; callers are responsible for ensuring key type compatibility.
+ */
+public interface GravitinoCache<K, V> extends Closeable {
+
+  /** Returns the value for {@code key} if present, otherwise {@link Optional#empty()}. */
+  Optional<V> getIfPresent(K key);
+
+  /** Associates {@code value} with {@code key} in the cache. */
+  void put(K key, V value);
+
+  /** Discards the entry for {@code key} if it exists. */
+  void invalidate(K key);
+
+  /** Discards all entries in the cache. */
+  void invalidateAll();
+
+  /**
+   * Evicts all entries whose key starts with the given {@code prefix}.
+   *
+   * <p>Only applicable when {@code K = String}. Used by {@code metadataIdCache} for cascade
+   * invalidation: dropping a catalog evicts the catalog entry plus all schema/table/fileset/...
+   * entries beneath it in one call.
+   */
+  void invalidateByPrefix(String prefix);
+
+  /** Returns the approximate number of entries in the cache. */
+  long size();
+
+  @Override
+  void close();
+}

--- a/core/src/main/java/org/apache/gravitino/cache/NoOpsGravitinoCache.java
+++ b/core/src/main/java/org/apache/gravitino/cache/NoOpsGravitinoCache.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.cache;
+
+import java.util.Optional;
+
+/** A no-op {@link GravitinoCache} implementation for testing. */
+public class NoOpsGravitinoCache<K, V> implements GravitinoCache<K, V> {
+
+  @Override
+  public Optional<V> getIfPresent(K key) {
+    return Optional.empty();
+  }
+
+  @Override
+  public void put(K key, V value) {}
+
+  @Override
+  public void invalidate(K key) {}
+
+  @Override
+  public void invalidateAll() {}
+
+  @Override
+  public void invalidateByPrefix(String prefix) {}
+
+  @Override
+  public long size() {
+    return 0;
+  }
+
+  @Override
+  public void close() {}
+}

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/EntityChangeLogMapper.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/EntityChangeLogMapper.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.storage.relational.mapper;
+
+import java.util.List;
+import org.apache.gravitino.storage.relational.po.auth.EntityChangeRecord;
+import org.apache.ibatis.annotations.DeleteProvider;
+import org.apache.ibatis.annotations.InsertProvider;
+import org.apache.ibatis.annotations.Param;
+import org.apache.ibatis.annotations.SelectProvider;
+
+/**
+ * A MyBatis Mapper for entity_change_log table operations.
+ *
+ * <p>This append-only log tracks structural changes to entities (create, alter, drop) and is used
+ * by the entity change poller to drive targeted invalidation of the metadataIdCache on HA peer
+ * nodes.
+ */
+public interface EntityChangeLogMapper {
+
+  String ENTITY_CHANGE_LOG_TABLE_NAME = "entity_change_log";
+
+  @SelectProvider(
+      type = EntityChangeLogSQLProviderFactory.class,
+      method = "selectEntityChanges")
+  List<EntityChangeRecord> selectChanges(
+      @Param("createdAtAfter") long createdAtAfter, @Param("maxRows") int maxRows);
+
+  @InsertProvider(type = EntityChangeLogSQLProviderFactory.class, method = "insertEntityChange")
+  void insertChange(
+      @Param("metalakeName") String metalakeName,
+      @Param("entityType") String entityType,
+      @Param("fullName") String fullName,
+      @Param("operateType") String operateType,
+      @Param("createdAt") long createdAt);
+
+  @DeleteProvider(
+      type = EntityChangeLogSQLProviderFactory.class,
+      method = "pruneOldEntityChanges")
+  void pruneOldEntries(@Param("before") long before);
+}

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/EntityChangeLogSQLProviderFactory.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/EntityChangeLogSQLProviderFactory.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.storage.relational.mapper;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import org.apache.gravitino.storage.relational.JDBCBackend.JDBCBackendType;
+import org.apache.gravitino.storage.relational.mapper.provider.base.EntityChangeLogBaseSQLProvider;
+import org.apache.gravitino.storage.relational.session.SqlSessionFactoryHelper;
+import org.apache.ibatis.annotations.Param;
+
+public class EntityChangeLogSQLProviderFactory {
+
+  private static final Map<JDBCBackendType, EntityChangeLogBaseSQLProvider>
+      ENTITY_CHANGE_LOG_SQL_PROVIDER_MAP =
+          ImmutableMap.of(
+              JDBCBackendType.MYSQL, new EntityChangeLogMySQLProvider(),
+              JDBCBackendType.H2, new EntityChangeLogH2Provider(),
+              JDBCBackendType.POSTGRESQL, new EntityChangeLogPostgreSQLProvider());
+
+  public static EntityChangeLogBaseSQLProvider getProvider() {
+    String databaseId =
+        SqlSessionFactoryHelper.getInstance()
+            .getSqlSessionFactory()
+            .getConfiguration()
+            .getDatabaseId();
+    JDBCBackendType jdbcBackendType = JDBCBackendType.fromString(databaseId);
+    return ENTITY_CHANGE_LOG_SQL_PROVIDER_MAP.get(jdbcBackendType);
+  }
+
+  static class EntityChangeLogMySQLProvider extends EntityChangeLogBaseSQLProvider {}
+
+  static class EntityChangeLogH2Provider extends EntityChangeLogBaseSQLProvider {}
+
+  static class EntityChangeLogPostgreSQLProvider extends EntityChangeLogBaseSQLProvider {}
+
+  public static String selectEntityChanges(
+      @Param("createdAtAfter") long createdAtAfter, @Param("maxRows") int maxRows) {
+    return getProvider().selectEntityChanges(createdAtAfter, maxRows);
+  }
+
+  public static String insertEntityChange(
+      @Param("metalakeName") String metalakeName,
+      @Param("entityType") String entityType,
+      @Param("fullName") String fullName,
+      @Param("operateType") String operateType,
+      @Param("createdAt") long createdAt) {
+    return getProvider().insertEntityChange(metalakeName, entityType, fullName, operateType, createdAt);
+  }
+
+  public static String pruneOldEntityChanges(@Param("before") long before) {
+    return getProvider().pruneOldEntityChanges(before);
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/GroupMetaMapper.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/GroupMetaMapper.java
@@ -22,6 +22,7 @@ package org.apache.gravitino.storage.relational.mapper;
 import java.util.List;
 import org.apache.gravitino.storage.relational.po.ExtendedGroupPO;
 import org.apache.gravitino.storage.relational.po.GroupPO;
+import org.apache.gravitino.storage.relational.po.auth.GroupAuthInfo;
 import org.apache.ibatis.annotations.DeleteProvider;
 import org.apache.ibatis.annotations.InsertProvider;
 import org.apache.ibatis.annotations.Param;
@@ -88,4 +89,10 @@ public interface GroupMetaMapper {
       method = "deleteGroupMetasByLegacyTimeline")
   Integer deleteGroupMetasByLegacyTimeline(
       @Param("legacyTimeline") Long legacyTimeline, @Param("limit") int limit);
+
+  @UpdateProvider(type = GroupMetaSQLProviderFactory.class, method = "touchGroupUpdatedAt")
+  void touchUpdatedAt(@Param("groupId") long groupId, @Param("now") long now);
+
+  @SelectProvider(type = GroupMetaSQLProviderFactory.class, method = "getGroupInfoByUserId")
+  List<GroupAuthInfo> getGroupInfoByUserId(@Param("userId") long userId);
 }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/GroupMetaSQLProviderFactory.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/GroupMetaSQLProviderFactory.java
@@ -95,4 +95,13 @@ public class GroupMetaSQLProviderFactory {
       @Param("legacyTimeline") Long legacyTimeline, @Param("limit") int limit) {
     return getProvider().deleteGroupMetasByLegacyTimeline(legacyTimeline, limit);
   }
+
+  public static String touchGroupUpdatedAt(
+      @Param("groupId") long groupId, @Param("now") long now) {
+    return getProvider().touchGroupUpdatedAt(groupId, now);
+  }
+
+  public static String getGroupInfoByUserId(@Param("userId") long userId) {
+    return getProvider().getGroupInfoByUserId(userId);
+  }
 }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/OwnerMetaMapper.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/OwnerMetaMapper.java
@@ -23,6 +23,8 @@ import org.apache.gravitino.storage.relational.po.GroupPO;
 import org.apache.gravitino.storage.relational.po.OwnerRelPO;
 import org.apache.gravitino.storage.relational.po.UserOwnerRelPO;
 import org.apache.gravitino.storage.relational.po.UserPO;
+import org.apache.gravitino.storage.relational.po.auth.ChangedOwnerInfo;
+import org.apache.gravitino.storage.relational.po.auth.OwnerInfo;
 import org.apache.ibatis.annotations.InsertProvider;
 import org.apache.ibatis.annotations.Param;
 import org.apache.ibatis.annotations.SelectProvider;
@@ -95,4 +97,12 @@ public interface OwnerMetaMapper {
       method = "deleteOwnerMetasByLegacyTimeline")
   Integer deleteOwnerMetasByLegacyTimeline(
       @Param("legacyTimeline") Long legacyTimeline, @Param("limit") int limit);
+
+  @SelectProvider(
+      type = OwnerMetaSQLProviderFactory.class,
+      method = "selectOwnerByMetadataObjectId")
+  OwnerInfo selectOwnerByMetadataObjectId(@Param("metadataObjectId") long metadataObjectId);
+
+  @SelectProvider(type = OwnerMetaSQLProviderFactory.class, method = "selectChangedOwners")
+  List<ChangedOwnerInfo> selectChangedOwners(@Param("updatedAtAfter") long updatedAtAfter);
 }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/OwnerMetaSQLProviderFactory.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/OwnerMetaSQLProviderFactory.java
@@ -104,4 +104,13 @@ public class OwnerMetaSQLProviderFactory {
     return getProvider()
         .batchSelectUserOwnerMetaByMetadataObjectIdAndType(metadataObjectIds, metadataObjectType);
   }
+
+  public static String selectOwnerByMetadataObjectId(
+      @Param("metadataObjectId") long metadataObjectId) {
+    return getProvider().selectOwnerByMetadataObjectId(metadataObjectId);
+  }
+
+  public static String selectChangedOwners(@Param("updatedAtAfter") long updatedAtAfter) {
+    return getProvider().selectChangedOwners(updatedAtAfter);
+  }
 }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/RoleMetaMapper.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/RoleMetaMapper.java
@@ -21,6 +21,7 @@ package org.apache.gravitino.storage.relational.mapper;
 
 import java.util.List;
 import org.apache.gravitino.storage.relational.po.RolePO;
+import org.apache.gravitino.storage.relational.po.auth.RoleUpdatedAt;
 import org.apache.ibatis.annotations.DeleteProvider;
 import org.apache.ibatis.annotations.InsertProvider;
 import org.apache.ibatis.annotations.Param;
@@ -93,4 +94,10 @@ public interface RoleMetaMapper {
       method = "deleteRoleMetasByLegacyTimeline")
   Integer deleteRoleMetasByLegacyTimeline(
       @Param("legacyTimeline") Long legacyTimeline, @Param("limit") int limit);
+
+  @UpdateProvider(type = RoleMetaSQLProviderFactory.class, method = "touchRoleUpdatedAt")
+  void touchUpdatedAt(@Param("roleId") long roleId, @Param("now") long now);
+
+  @SelectProvider(type = RoleMetaSQLProviderFactory.class, method = "batchGetRoleUpdatedAt")
+  List<RoleUpdatedAt> batchGetUpdatedAt(@Param("roleIds") List<Long> roleIds);
 }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/RoleMetaSQLProviderFactory.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/RoleMetaSQLProviderFactory.java
@@ -19,6 +19,7 @@
 package org.apache.gravitino.storage.relational.mapper;
 
 import com.google.common.collect.ImmutableMap;
+import java.util.List;
 import java.util.Map;
 import org.apache.gravitino.storage.relational.JDBCBackend.JDBCBackendType;
 import org.apache.gravitino.storage.relational.mapper.provider.base.RoleMetaBaseSQLProvider;
@@ -100,5 +101,13 @@ public class RoleMetaSQLProviderFactory {
   public static String deleteRoleMetasByLegacyTimeline(
       @Param("legacyTimeline") Long legacyTimeline, @Param("limit") int limit) {
     return getProvider().deleteRoleMetasByLegacyTimeline(legacyTimeline, limit);
+  }
+
+  public static String touchRoleUpdatedAt(@Param("roleId") long roleId, @Param("now") long now) {
+    return getProvider().touchRoleUpdatedAt(roleId, now);
+  }
+
+  public static String batchGetRoleUpdatedAt(@Param("roleIds") List<Long> roleIds) {
+    return getProvider().batchGetRoleUpdatedAt(roleIds);
   }
 }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/UserMetaMapper.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/UserMetaMapper.java
@@ -22,6 +22,7 @@ package org.apache.gravitino.storage.relational.mapper;
 import java.util.List;
 import org.apache.gravitino.storage.relational.po.ExtendedUserPO;
 import org.apache.gravitino.storage.relational.po.UserPO;
+import org.apache.gravitino.storage.relational.po.auth.UserAuthInfo;
 import org.apache.ibatis.annotations.DeleteProvider;
 import org.apache.ibatis.annotations.InsertProvider;
 import org.apache.ibatis.annotations.Param;
@@ -88,4 +89,11 @@ public interface UserMetaMapper {
       method = "deleteUserMetasByLegacyTimeline")
   Integer deleteUserMetasByLegacyTimeline(
       @Param("legacyTimeline") Long legacyTimeline, @Param("limit") int limit);
+
+  @UpdateProvider(type = UserMetaSQLProviderFactory.class, method = "touchUserUpdatedAt")
+  void touchUpdatedAt(@Param("userId") long userId, @Param("now") long now);
+
+  @SelectProvider(type = UserMetaSQLProviderFactory.class, method = "getUserInfo")
+  UserAuthInfo getUserInfo(
+      @Param("metalakeName") String metalakeName, @Param("userName") String userName);
 }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/UserMetaSQLProviderFactory.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/UserMetaSQLProviderFactory.java
@@ -97,4 +97,13 @@ public class UserMetaSQLProviderFactory {
       @Param("legacyTimeline") Long legacyTimeline, @Param("limit") int limit) {
     return getProvider().deleteUserMetasByLegacyTimeline(legacyTimeline, limit);
   }
+
+  public static String touchUserUpdatedAt(@Param("userId") long userId, @Param("now") long now) {
+    return getProvider().touchUserUpdatedAt(userId, now);
+  }
+
+  public static String getUserInfo(
+      @Param("metalakeName") String metalakeName, @Param("userName") String userName) {
+    return getProvider().getUserInfo(metalakeName, userName);
+  }
 }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/DefaultMapperPackageProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/DefaultMapperPackageProvider.java
@@ -21,6 +21,7 @@ package org.apache.gravitino.storage.relational.mapper.provider;
 import com.google.common.collect.ImmutableList;
 import java.util.List;
 import org.apache.gravitino.storage.relational.mapper.CatalogMetaMapper;
+import org.apache.gravitino.storage.relational.mapper.EntityChangeLogMapper;
 import org.apache.gravitino.storage.relational.mapper.FilesetMetaMapper;
 import org.apache.gravitino.storage.relational.mapper.FilesetVersionMapper;
 import org.apache.gravitino.storage.relational.mapper.FunctionMetaMapper;
@@ -58,6 +59,7 @@ public class DefaultMapperPackageProvider implements MapperPackageProvider {
   public List<Class<?>> getMapperClasses() {
     return ImmutableList.of(
         CatalogMetaMapper.class,
+        EntityChangeLogMapper.class,
         FilesetMetaMapper.class,
         FilesetVersionMapper.class,
         FunctionMetaMapper.class,

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/EntityChangeLogBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/EntityChangeLogBaseSQLProvider.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.storage.relational.mapper.provider.base;
+
+import static org.apache.gravitino.storage.relational.mapper.EntityChangeLogMapper.ENTITY_CHANGE_LOG_TABLE_NAME;
+
+import org.apache.ibatis.annotations.Param;
+
+public class EntityChangeLogBaseSQLProvider {
+
+  public String selectEntityChanges(
+      @Param("createdAtAfter") long createdAtAfter, @Param("maxRows") int maxRows) {
+    return "SELECT metalake_name as metalakeName, entity_type as entityType,"
+        + " full_name as fullName, operate_type as operateType, created_at as createdAt"
+        + " FROM "
+        + ENTITY_CHANGE_LOG_TABLE_NAME
+        + " WHERE created_at > #{createdAtAfter} ORDER BY created_at LIMIT #{maxRows}";
+  }
+
+  public String insertEntityChange(
+      @Param("metalakeName") String metalakeName,
+      @Param("entityType") String entityType,
+      @Param("fullName") String fullName,
+      @Param("operateType") String operateType,
+      @Param("createdAt") long createdAt) {
+    return "INSERT INTO "
+        + ENTITY_CHANGE_LOG_TABLE_NAME
+        + " (metalake_name, entity_type, full_name, operate_type, created_at)"
+        + " VALUES (#{metalakeName}, #{entityType}, #{fullName}, #{operateType}, #{createdAt})";
+  }
+
+  public String pruneOldEntityChanges(@Param("before") long before) {
+    return "DELETE FROM "
+        + ENTITY_CHANGE_LOG_TABLE_NAME
+        + " WHERE created_at < #{before} LIMIT 1000";
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/GroupMetaBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/GroupMetaBaseSQLProvider.java
@@ -182,4 +182,17 @@ public class GroupMetaBaseSQLProvider {
         + GROUP_TABLE_NAME
         + " WHERE deleted_at > 0 AND deleted_at < #{legacyTimeline} LIMIT #{limit}";
   }
+
+  public String touchGroupUpdatedAt(@Param("groupId") long groupId, @Param("now") long now) {
+    return "UPDATE " + GROUP_TABLE_NAME + " SET updated_at = #{now} WHERE group_id = #{groupId}";
+  }
+
+  public String getGroupInfoByUserId(@Param("userId") long userId) {
+    return "SELECT gm.group_id as groupId, gm.updated_at as updatedAt"
+        + " FROM "
+        + GROUP_TABLE_NAME
+        + " gm"
+        + " JOIN group_user_rel gu ON gm.group_id = gu.group_id AND gu.deleted_at = 0"
+        + " WHERE gu.user_id = #{userId} AND gm.deleted_at = 0";
+  }
 }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/OwnerMetaBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/OwnerMetaBaseSQLProvider.java
@@ -236,4 +236,17 @@ public class OwnerMetaBaseSQLProvider {
         + OWNER_TABLE_NAME
         + " WHERE deleted_at > 0 AND deleted_at < #{legacyTimeline} LIMIT #{limit}";
   }
+
+  public String selectOwnerByMetadataObjectId(@Param("metadataObjectId") long metadataObjectId) {
+    return "SELECT owner_id as ownerId, owner_type as ownerType FROM "
+        + OWNER_TABLE_NAME
+        + " WHERE metadata_object_id = #{metadataObjectId} AND deleted_at = 0";
+  }
+
+  public String selectChangedOwners(@Param("updatedAtAfter") long updatedAtAfter) {
+    return "SELECT metadata_object_id as metadataObjectId, updated_at as updatedAt"
+        + " FROM "
+        + OWNER_TABLE_NAME
+        + " WHERE updated_at > #{updatedAtAfter} ORDER BY updated_at";
+  }
 }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/RoleMetaBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/RoleMetaBaseSQLProvider.java
@@ -22,6 +22,7 @@ import static org.apache.gravitino.storage.relational.mapper.RoleMetaMapper.GROU
 import static org.apache.gravitino.storage.relational.mapper.RoleMetaMapper.ROLE_TABLE_NAME;
 import static org.apache.gravitino.storage.relational.mapper.RoleMetaMapper.USER_ROLE_RELATION_TABLE_NAME;
 
+import java.util.List;
 import org.apache.gravitino.storage.relational.mapper.MetalakeMetaMapper;
 import org.apache.gravitino.storage.relational.mapper.SecurableObjectMapper;
 import org.apache.gravitino.storage.relational.po.RolePO;
@@ -191,5 +192,16 @@ public class RoleMetaBaseSQLProvider {
     return "DELETE FROM "
         + ROLE_TABLE_NAME
         + " WHERE deleted_at > 0 AND deleted_at < #{legacyTimeline} LIMIT #{limit}";
+  }
+
+  public String touchRoleUpdatedAt(@Param("roleId") long roleId, @Param("now") long now) {
+    return "UPDATE " + ROLE_TABLE_NAME + " SET updated_at = #{now} WHERE role_id = #{roleId}";
+  }
+
+  public String batchGetRoleUpdatedAt(@Param("roleIds") List<Long> roleIds) {
+    return "<script>SELECT role_id as roleId, updated_at as updatedAt FROM "
+        + ROLE_TABLE_NAME
+        + " WHERE role_id IN <foreach item='id' collection='roleIds' open='(' separator=',' close=')'>#{id}</foreach>"
+        + " AND deleted_at = 0</script>";
   }
 }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/UserMetaBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/UserMetaBaseSQLProvider.java
@@ -187,4 +187,21 @@ public class UserMetaBaseSQLProvider {
         + USER_TABLE_NAME
         + " WHERE deleted_at > 0 AND deleted_at < #{legacyTimeline} LIMIT #{limit}";
   }
+
+  public String touchUserUpdatedAt(@Param("userId") long userId, @Param("now") long now) {
+    return "UPDATE " + USER_TABLE_NAME + " SET updated_at = #{now} WHERE user_id = #{userId}";
+  }
+
+  public String getUserInfo(
+      @Param("metalakeName") String metalakeName, @Param("userName") String userName) {
+    return "SELECT um.user_id as userId, um.updated_at as updatedAt"
+        + " FROM "
+        + USER_TABLE_NAME
+        + " um"
+        + " JOIN "
+        + MetalakeMetaMapper.TABLE_NAME
+        + " mm ON um.metalake_id = mm.metalake_id AND mm.deleted_at = 0"
+        + " WHERE mm.metalake_name = #{metalakeName} AND um.user_name = #{userName}"
+        + " AND um.deleted_at = 0";
+  }
 }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/po/auth/ChangedOwnerInfo.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/po/auth/ChangedOwnerInfo.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.storage.relational.po.auth;
+
+/** Owner change poller result -- one row per changed owner_meta entry. */
+public record ChangedOwnerInfo(long metadataObjectId, long updatedAt) {}

--- a/core/src/main/java/org/apache/gravitino/storage/relational/po/auth/EntityChangeRecord.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/po/auth/EntityChangeRecord.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.storage.relational.po.auth;
+
+/** Entity change poller result -- one row per entity_change_log entry. */
+public record EntityChangeRecord(
+    String metalakeName,
+    String entityType,
+    String fullName,
+    String operateType,
+    long createdAt) {}

--- a/core/src/main/java/org/apache/gravitino/storage/relational/po/auth/GroupAuthInfo.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/po/auth/GroupAuthInfo.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.storage.relational.po.auth;
+
+/** Step 1b result: one row per group the user belongs to. */
+public record GroupAuthInfo(long groupId, long updatedAt) {}

--- a/core/src/main/java/org/apache/gravitino/storage/relational/po/auth/OwnerInfo.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/po/auth/OwnerInfo.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.storage.relational.po.auth;
+
+/** Step 2.5: owner identity for a single metadata object. */
+public record OwnerInfo(long ownerId, String ownerType) {}

--- a/core/src/main/java/org/apache/gravitino/storage/relational/po/auth/RoleUpdatedAt.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/po/auth/RoleUpdatedAt.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.storage.relational.po.auth;
+
+/** Step 3: role version sentinel returned by batch query. */
+public record RoleUpdatedAt(long roleId, long updatedAt) {}

--- a/core/src/main/java/org/apache/gravitino/storage/relational/po/auth/UserAuthInfo.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/po/auth/UserAuthInfo.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.storage.relational.po.auth;
+
+/** Step 1a result: user identity + role-list staleness sentinel. */
+public record UserAuthInfo(long userId, long updatedAt) {}

--- a/scripts/mysql/upgrade-1.2.0-to-1.3.0-mysql.sql
+++ b/scripts/mysql/upgrade-1.2.0-to-1.3.0-mysql.sql
@@ -1,0 +1,81 @@
+--
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"). You may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--  http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+--
+
+-- Role privilege tracking (strong consistency -- Step 3 version check)
+ALTER TABLE `role_meta`
+    ADD COLUMN `updated_at` BIGINT NOT NULL DEFAULT 0
+    COMMENT 'Set to currentTimeMillis() on any privilege grant/revoke for this role.
+             JcasbinAuthorizer compares db.updated_at vs cached updated_at per request
+             to decide whether to reload JCasbin policies for this role.';
+
+-- User role assignment tracking (strong consistency -- Step 1a version check)
+ALTER TABLE `user_meta`
+    ADD COLUMN `updated_at` BIGINT NOT NULL DEFAULT 0
+    COMMENT 'Set to currentTimeMillis() on any role assign/revoke for this user.
+             JcasbinAuthorizer compares db.updated_at vs cached updated_at per request
+             to decide whether to reload the user-role mapping.';
+
+-- Group role assignment tracking (strong consistency -- Step 1b version check)
+ALTER TABLE `group_meta`
+    ADD COLUMN `updated_at` BIGINT NOT NULL DEFAULT 0
+    COMMENT 'Set to currentTimeMillis() on any role assign/revoke for this group.
+             JcasbinAuthorizer compares db.updated_at vs cached updated_at per request
+             to decide whether to reload the group-role mapping.';
+
+-- Ownership mutation tracking (eventual consistency -- owner change poller)
+ALTER TABLE `owner_meta`
+    ADD COLUMN `updated_at` BIGINT NOT NULL DEFAULT 0
+    COMMENT 'Set to currentTimeMillis() on any ownership transfer.
+             The owner change poller reads updated_at > maxSeen to find changed rows
+             and invalidates only the specific metadataObjectIds in ownerRelCache.';
+
+-- Covering indexes for high-frequency read predicates
+CREATE INDEX idx_user_meta_name_del_upd
+    ON user_meta (metalake_id, user_name, deleted_at, updated_at);
+CREATE INDEX idx_group_meta_del_upd
+    ON group_meta (group_id, deleted_at, updated_at);
+CREATE INDEX idx_role_meta_del_upd
+    ON role_meta (role_id, deleted_at, updated_at);
+CREATE INDEX idx_owner_meta_obj_del_upd
+    ON owner_meta (metadata_object_id, deleted_at, updated_at);
+
+-- Backfill: set updated_at = audit_info-extracted time (use 1 as safe default for existing rows)
+UPDATE `role_meta`  SET `updated_at` = 1 WHERE `updated_at` = 0 AND `deleted_at` = 0;
+UPDATE `user_meta`  SET `updated_at` = 1 WHERE `updated_at` = 0 AND `deleted_at` = 0;
+UPDATE `group_meta` SET `updated_at` = 1 WHERE `updated_at` = 0 AND `deleted_at` = 0;
+UPDATE `owner_meta` SET `updated_at` = 1 WHERE `updated_at` = 0 AND `deleted_at` = 0;
+
+-- Entity name->id mutation tracking (eventual consistency -- entity change poller)
+CREATE TABLE IF NOT EXISTS `entity_change_log` (
+  `id`            BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  `metalake_name` VARCHAR(128)    NOT NULL,
+  `entity_type`   VARCHAR(32)     NOT NULL
+      COMMENT 'METALAKE | CATALOG | SCHEMA | TABLE | FILESET | TOPIC | MODEL | VIEW',
+  `full_name`     VARCHAR(512)    NOT NULL
+      COMMENT 'Dot-separated full name of the affected entity. For RENAME, stores the
+               OLD name (the stale key to invalidate). For DROP/ALTER, the entity name.',
+  `operate_type`  VARCHAR(16)     NOT NULL
+      COMMENT 'DROP | CREATE | ALTER (ALTER covers rename and other structural changes)',
+  `created_at`    BIGINT          NOT NULL,
+  PRIMARY KEY (`id`),
+  INDEX `idx_created_at` (`created_at`)
+) COMMENT 'Append-only log of entity structural changes.
+           One row per affected entity per operation. The entity change poller reads
+           this table to drive targeted invalidation of metadataIdCache on HA peer nodes.
+           Rows older than the retention window (default 1 h) are pruned periodically.';

--- a/server-common/src/main/java/org/apache/gravitino/server/authorization/jcasbin/JcasbinAuthorizer.java
+++ b/server-common/src/main/java/org/apache/gravitino/server/authorization/jcasbin/JcasbinAuthorizer.java
@@ -33,8 +33,10 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.gravitino.Configs;
@@ -51,10 +53,17 @@ import org.apache.gravitino.authorization.AuthorizationUtils;
 import org.apache.gravitino.authorization.GravitinoAuthorizer;
 import org.apache.gravitino.authorization.Privilege;
 import org.apache.gravitino.authorization.SecurableObject;
+import org.apache.gravitino.cache.CaffeineGravitinoCache;
+import org.apache.gravitino.cache.GravitinoCache;
 import org.apache.gravitino.exceptions.NoSuchUserException;
 import org.apache.gravitino.meta.RoleEntity;
 import org.apache.gravitino.meta.UserEntity;
 import org.apache.gravitino.server.authorization.MetadataIdConverter;
+import org.apache.gravitino.storage.relational.mapper.EntityChangeLogMapper;
+import org.apache.gravitino.storage.relational.mapper.OwnerMetaMapper;
+import org.apache.gravitino.storage.relational.po.auth.ChangedOwnerInfo;
+import org.apache.gravitino.storage.relational.po.auth.EntityChangeRecord;
+import org.apache.gravitino.storage.relational.utils.SessionUtils;
 import org.apache.gravitino.utils.MetadataObjectUtil;
 import org.apache.gravitino.utils.NameIdentifierUtil;
 import org.apache.gravitino.utils.PrincipalUtils;
@@ -91,6 +100,33 @@ public class JcasbinAuthorizer implements GravitinoAuthorizer {
 
   private Executor executor = null;
 
+  /** Caches metalakeName:userName -&gt; cached user roles (userId, updatedAt, roleIds). */
+  private GravitinoCache<String, CachedUserRoles> userRoleCache;
+
+  /** Caches metalakeName:groupName -&gt; cached group roles (groupId, updatedAt, roleIds). */
+  private GravitinoCache<String, CachedGroupRoles> groupRoleCache;
+
+  /** Caches name -&gt; integer id for MetadataObjects referenced in OGNL expressions. */
+  private GravitinoCache<String, Long> metadataIdCache;
+
+  /** Replaces ownerRel — persistent cache with hook + poller invalidation. */
+  private GravitinoCache<Long, Optional<Long>> ownerRelCache;
+
+  /** Max updated_at seen across all owner_meta rows so far (for poller). */
+  private final AtomicLong maxOwnerUpdatedAt = new AtomicLong(0L);
+
+  /** Max created_at seen across all entity_change_log rows so far (for poller). */
+  private final AtomicLong maxEntityCreatedAt = new AtomicLong(0L);
+
+  /** Single-thread scheduled executor for the two targeted poll tasks. */
+  private ScheduledExecutorService changePoller;
+
+  /** Inner record: cached user role membership with version sentinel. */
+  record CachedUserRoles(long userId, long updatedAt, List<Long> roleIds) {}
+
+  /** Inner record: cached group role membership with version sentinel. */
+  record CachedGroupRoles(long groupId, long updatedAt, List<Long> roleIds) {}
+
   @Override
   public void initialize() {
     long cacheExpirationSecs =
@@ -126,6 +162,19 @@ public class JcasbinAuthorizer implements GravitinoAuthorizer {
             .expireAfterAccess(cacheExpirationSecs, TimeUnit.SECONDS)
             .maximumSize(ownerCacheSize)
             .build();
+
+    long userGroupCacheSize =
+        GravitinoEnv.getInstance()
+            .config()
+            .get(Configs.GRAVITINO_AUTHORIZATION_ROLE_CACHE_SIZE);
+    userRoleCache = new CaffeineGravitinoCache<>(userGroupCacheSize, cacheExpirationSecs);
+    groupRoleCache = new CaffeineGravitinoCache<>(userGroupCacheSize, cacheExpirationSecs);
+    metadataIdCache = new CaffeineGravitinoCache<>(userGroupCacheSize * 10, cacheExpirationSecs);
+    ownerRelCache = new CaffeineGravitinoCache<>(ownerCacheSize, cacheExpirationSecs);
+
+    long pollerIntervalMs = 5_000L;
+    startChangePoller(pollerIntervalMs);
+
     executor =
         Executors.newFixedThreadPool(
             GravitinoEnv.getInstance()
@@ -410,16 +459,112 @@ public class JcasbinAuthorizer implements GravitinoAuthorizer {
     MetadataObject metadataObject = NameIdentifierUtil.toMetadataObject(nameIdentifier, type);
     Long metadataId = MetadataIdConverter.getID(metadataObject, metalake);
     ownerRel.invalidate(metadataId);
+    ownerRelCache.invalidate(metadataId);
+  }
+
+  @Override
+  public void handleEntityStructuralChange(
+      String metalake, NameIdentifier nameIdent, Entity.EntityType type) {
+    String cacheKey = buildCacheKey(metalake, type, nameIdent.name());
+    metadataIdCache.invalidateByPrefix(cacheKey);
   }
 
   @Override
   public void close() throws IOException {
+    if (changePoller != null) {
+      changePoller.shutdownNow();
+    }
     if (executor != null) {
       if (executor instanceof ThreadPoolExecutor) {
         ThreadPoolExecutor threadPoolExecutor = (ThreadPoolExecutor) executor;
         threadPoolExecutor.shutdown();
       }
     }
+    if (userRoleCache != null) {
+      userRoleCache.close();
+    }
+    if (groupRoleCache != null) {
+      groupRoleCache.close();
+    }
+    if (metadataIdCache != null) {
+      metadataIdCache.close();
+    }
+    if (ownerRelCache != null) {
+      ownerRelCache.close();
+    }
+  }
+
+  private void startChangePoller(long intervalMs) {
+    changePoller =
+        Executors.newSingleThreadScheduledExecutor(
+            r -> new Thread(r, "gravitino-change-poller"));
+    changePoller.scheduleAtFixedRate(
+        this::pollChanges, intervalMs, intervalMs, TimeUnit.MILLISECONDS);
+  }
+
+  private void pollChanges() {
+    pollOwnerChanges();
+    pollEntityChanges();
+  }
+
+  private void pollOwnerChanges() {
+    try {
+      long since = maxOwnerUpdatedAt.get();
+      List<ChangedOwnerInfo> rows =
+          SessionUtils.getWithoutCommit(
+              OwnerMetaMapper.class, mapper -> mapper.selectChangedOwners(since));
+      long maxAt = since;
+      for (ChangedOwnerInfo row : rows) {
+        ownerRelCache.invalidate(row.metadataObjectId());
+        if (row.updatedAt() > maxAt) {
+          maxAt = row.updatedAt();
+        }
+      }
+      maxOwnerUpdatedAt.set(maxAt);
+    } catch (Exception e) {
+      LOG.warn("Owner change poller failed, will retry", e);
+    }
+  }
+
+  private void pollEntityChanges() {
+    try {
+      long since = maxEntityCreatedAt.get();
+      List<EntityChangeRecord> rows =
+          SessionUtils.getWithoutCommit(
+              EntityChangeLogMapper.class,
+              mapper -> mapper.selectChanges(since, 1000));
+      long maxAt = since;
+      for (EntityChangeRecord row : rows) {
+        Entity.EntityType type = Entity.EntityType.valueOf(row.entityType());
+        String cacheKey = buildCacheKey(row.metalakeName(), type, row.fullName());
+        metadataIdCache.invalidateByPrefix(cacheKey);
+        if (row.createdAt() > maxAt) {
+          maxAt = row.createdAt();
+        }
+      }
+      maxEntityCreatedAt.set(maxAt);
+    } catch (Exception e) {
+      LOG.warn("Entity change poller failed, will retry", e);
+    }
+  }
+
+  static String buildCacheKey(String metalake, Entity.EntityType type, String fullName) {
+    StringBuilder sb = new StringBuilder(metalake);
+    for (String part : fullName.split("\\.")) {
+      sb.append("::").append(part);
+    }
+    if (isNonLeaf(type)) {
+      sb.append("::");
+    } else {
+      sb.append("::").append(type.name());
+    }
+    return sb.toString();
+  }
+
+  private static boolean isNonLeaf(Entity.EntityType type) {
+    return type == Entity.EntityType.METALAKE
+        || type == Entity.EntityType.CATALOG
+        || type == Entity.EntityType.SCHEMA;
   }
 
   private class InternalAuthorizer {


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Adds `handleEntityStructuralChange` default no-op method to `GravitinoAuthorizer` interface for backward compatibility
- Adds new fields to `JcasbinAuthorizer`:
  - `userRoleCache` (`GravitinoCache<String, CachedUserRoles>`)
  - `groupRoleCache` (`GravitinoCache<String, CachedGroupRoles>`)
  - `metadataIdCache` (`GravitinoCache<String, Long>`)
  - `ownerRelCache` (`GravitinoCache<Long, Optional<Long>>`)
  - `maxOwnerUpdatedAt` / `maxEntityCreatedAt` (`AtomicLong` version pointers)
  - `changePoller` (`ScheduledExecutorService`)
- Adds `CachedUserRoles` and `CachedGroupRoles` inner records with version sentinel
- Implements `startChangePoller`, `pollOwnerChanges`, `pollEntityChanges` using `SessionUtils` with `OwnerMetaMapper` and `EntityChangeLogMapper`
- Implements `handleEntityStructuralChange` using `metadataIdCache.invalidateByPrefix`
- Adds `buildCacheKey` / `isNonLeaf` static helpers for cache key construction
- Wires `ownerRelCache` invalidation into `handleMetadataOwnerChange`
- Shuts down `changePoller` and closes new caches in `close()`

Builds on: #10794

## Why are the changes needed?

Pre-populates the id-mapping and owner caches so subsequent auth requests do not need to hit the DB for name→id resolution. The change poller drives targeted cache invalidation on HA peer nodes using the DB tables added in the Phase 1 PR.

## Does this PR introduce _any_ user-facing changes?

No.

## How was this patch tested?

- [ ] `./gradlew :server-common:test -PskipITs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)