### PR TITLE
[MINOR] docs: update MAINTAINERS information

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -98,7 +98,7 @@ All contributions from the people listed are licensed under the Apache License v
 | Minghuang Li  | mchades             | Datastrato       |
 | Xun Liu       | xunliu              | Datastrato       |
 | Hui Yu        | diqiu50             | Datastrato       |
-| Xiaojing Fang | FANNG1              | Datastrato       |
+| Xiaojing Fang | FANNG1              | China Mobile     |
 | Qi Yu         | yuqi1129            | Datastrato       |
 | Decheng Liu   | ch3yne              | Datastrato       |
 | Saisai Shao   | jerryshao           | Datastrato       |


### PR DESCRIPTION
### What changes were proposed in this pull request?

Update Xiaojing Fang's affiliation in MAINTAINERS.md from Datastrato to China Mobile.

### Why are the changes needed?

The maintainer information in the document should reflect the latest affiliation for this entry.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Not applicable. This is a documentation-only change.