### PR TITLE
[#10271] fix(core): Roll back submitted job when persistence fails

### DIFF
--- a/core/src/main/java/org/apache/gravitino/job/JobManager.java
+++ b/core/src/main/java/org/apache/gravitino/job/JobManager.java
@@ -464,6 +464,31 @@ public class JobManager implements JobOperationDispatcher {
     try {
       entityStore.put(jobEntity, false /* overwrite */);
     } catch (IOException e) {
+      // Attempt to cancel the submitted job to avoid orphaned executions
+      try {
+        jobExecutor.cancelJob(jobExecutionId);
+        LOG.info(
+            "Successfully cancelled submitted job {} after persistence failure", jobExecutionId);
+      } catch (Exception cancelException) {
+        LOG.warn(
+            "Failed to cancel submitted job {} after persistence failure",
+            jobExecutionId,
+            cancelException);
+      }
+
+      // Best-effort cleanup of staging directory
+      try {
+        FileUtils.deleteDirectory(jobStagingDir);
+        LOG.info(
+            "Successfully cleaned up staging directory {} after persistence failure",
+            jobStagingDir);
+      } catch (IOException cleanupException) {
+        LOG.warn(
+            "Failed to clean up staging directory {} after persistence failure",
+            jobStagingDir,
+            cleanupException);
+      }
+
       throw new RuntimeException("Failed to register the job entity " + jobEntity, e);
     }
 

--- a/core/src/test/java/org/apache/gravitino/job/TestJobManager.java
+++ b/core/src/test/java/org/apache/gravitino/job/TestJobManager.java
@@ -500,14 +500,19 @@ public class TestJobManager {
         RuntimeException.class,
         () -> jobManager.runJob(metalake, "shell_job", Collections.emptyMap()));
 
-    // Test when entity store fails
+    // Test when entity store fails, the submitted job should be cancelled
+    String rollbackExecutionId = "job_execution_id_for_rollback";
+    when(jobExecutor.submitJob(any())).thenReturn(rollbackExecutionId);
     doThrow(new IOException("Entity store error"))
         .when(entityStore)
         .put(any(JobEntity.class), anyBoolean());
+    doNothing().when(jobExecutor).cancelJob(rollbackExecutionId);
 
     Assertions.assertThrows(
         RuntimeException.class,
         () -> jobManager.runJob(metalake, "shell_job", Collections.emptyMap()));
+
+    verify(jobExecutor, times(1)).cancelJob(rollbackExecutionId);
   }
 
   @Test


### PR DESCRIPTION
### What changes were proposed in this pull request?

Added compensation logic in `JobManager.runJob` to cancel submitted jobs when entity persistence fails:
- When `entityStore.put()` throws `IOException` after a successful `jobExecutor.submitJob()`, the method now calls `jobExecutor.cancelJob(jobExecutionId)` to roll back the orphaned execution.
- Logs both successful and failed rollback attempts.
- Best-effort cleanup of the staging directory via `FileUtils.deleteDirectory()`.
- The original `RuntimeException` is still re-thrown, preserving existing failure semantics.

### Why are the changes needed?

`JobManager.runJob` submits jobs to `jobExecutor` before persisting `JobEntity` in `entityStore`. If the persistence operation throws `IOException`, the submitted job continues running as an orphaned execution that cannot be tracked or managed. This change makes submit+persist effectively atomic from the caller's perspective.

Fix: #10271

### Does this PR introduce _any_ user-facing change?

No. This is an internal robustness improvement. The API behavior remains the same, the caller still receives a `RuntimeException` on persistence failure.

### How was this patch tested?

Updated existing unit test in `TestJobManager.testRunJob` to verify rollback behavior:
```
./gradlew :core:test --tests "org.apache.gravitino.job.TestJobManager" -PskipITs
```
The test verifies that when `entityStore.put()` fails, `jobExecutor.cancelJob()` is invoked exactly once with the correct execution ID.
