### PR TITLE
[#10216] improvement(server): Avoid success drop/purge log when partition deletion returns false

### DIFF
--- a/server/src/main/java/org/apache/gravitino/server/web/rest/PartitionOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/PartitionOperations.java
@@ -247,21 +247,22 @@ public class PartitionOperations {
                     : dispatcher.dropPartition(tableIdent, partition);
             if (!dropped) {
               LOG.warn(
-                  "Failed to drop partition {} under table {} under schema {}",
+                  "Failed to {} partition {} under table {} under schema {}",
+                  purge ? "purge" : "drop",
                   partition,
                   table,
                   schema);
+            } else {
+              LOG.info(
+                  "Partition {} {} in table {}.{}.{}.{}",
+                  partition,
+                  purge ? "purged" : "dropped",
+                  metalake,
+                  catalog,
+                  schema,
+                  table);
             }
-            Response response = Utils.ok(new DropResponse(dropped));
-            LOG.info(
-                "Partition {} {} in table {}.{}.{}.{}",
-                partition,
-                purge ? "purged" : "dropped",
-                metalake,
-                catalog,
-                schema,
-                table);
-            return response;
+            return Utils.ok(new DropResponse(dropped));
           });
     } catch (Exception e) {
       return ExceptionHandlers.handlePartitionException(OperationType.DROP, "", table, e);


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fixed logging in `PartitionOperations.dropPartition` to only emit the success log when the partition is actually dropped/purged:
- Moved the success `LOG.info` inside an `else` block so it only fires when `dropped == true`.
- Improved the warning log to include the operation type (`drop`/`purge`) instead of hardcoding "drop".
- Removed an unnecessary intermediate `response` variable.

### Why are the changes needed?

The success `LOG.info` message was emitted unconditionally, even when the deletion returned `false`. This caused misleading log output where a warning about a failed drop was immediately followed by a success message for the same operation.

Fix: #10216

### Does this PR introduce _any_ user-facing change?

No. This is an internal logging improvement. The REST API response is unchanged.

### How was this patch tested?

Ran existing unit tests to verify no regressions:
```
./gradlew :server:test --tests "org.apache.gravitino.server.web.rest.TestPartitionOperations" -PskipITs
```
All tests pass.
