### PR TITLE
[#10131] improvement(core): TableHookDispatcher removes auth privileges when dropTable fails

### DIFF
--- a/core/src/main/java/org/apache/gravitino/hook/FilesetHookDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/hook/FilesetHookDispatcher.java
@@ -114,8 +114,10 @@ public class FilesetHookDispatcher implements FilesetDispatcher {
     List<String> locations =
         AuthorizationUtils.getMetadataObjectLocation(ident, Entity.EntityType.FILESET);
     boolean dropped = dispatcher.dropFileset(ident);
-    AuthorizationUtils.authorizationPluginRemovePrivileges(
-        ident, Entity.EntityType.FILESET, locations);
+    if (dropped) {
+      AuthorizationUtils.authorizationPluginRemovePrivileges(
+          ident, Entity.EntityType.FILESET, locations);
+    }
     return dropped;
   }
 

--- a/core/src/main/java/org/apache/gravitino/hook/SchemaHookDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/hook/SchemaHookDispatcher.java
@@ -89,8 +89,10 @@ public class SchemaHookDispatcher implements SchemaDispatcher {
     List<String> locations =
         AuthorizationUtils.getMetadataObjectLocation(ident, Entity.EntityType.SCHEMA);
     boolean dropped = dispatcher.dropSchema(ident, cascade);
-    AuthorizationUtils.authorizationPluginRemovePrivileges(
-        ident, Entity.EntityType.SCHEMA, locations);
+    if (dropped) {
+      AuthorizationUtils.authorizationPluginRemovePrivileges(
+          ident, Entity.EntityType.SCHEMA, locations);
+    }
     return dropped;
   }
 

--- a/core/src/main/java/org/apache/gravitino/hook/TableHookDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/hook/TableHookDispatcher.java
@@ -119,8 +119,10 @@ public class TableHookDispatcher implements TableDispatcher {
     List<String> locations =
         AuthorizationUtils.getMetadataObjectLocation(ident, Entity.EntityType.TABLE);
     boolean dropped = dispatcher.dropTable(ident);
-    AuthorizationUtils.authorizationPluginRemovePrivileges(
-        ident, Entity.EntityType.TABLE, locations);
+    if (dropped) {
+      AuthorizationUtils.authorizationPluginRemovePrivileges(
+          ident, Entity.EntityType.TABLE, locations);
+    }
     return dropped;
   }
 
@@ -129,8 +131,10 @@ public class TableHookDispatcher implements TableDispatcher {
     List<String> locations =
         AuthorizationUtils.getMetadataObjectLocation(ident, Entity.EntityType.TABLE);
     boolean purged = dispatcher.purgeTable(ident);
-    AuthorizationUtils.authorizationPluginRemovePrivileges(
-        ident, Entity.EntityType.TABLE, locations);
+    if (purged) {
+      AuthorizationUtils.authorizationPluginRemovePrivileges(
+          ident, Entity.EntityType.TABLE, locations);
+    }
     return purged;
   }
 

--- a/core/src/main/java/org/apache/gravitino/hook/TopicHookDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/hook/TopicHookDispatcher.java
@@ -88,8 +88,10 @@ public class TopicHookDispatcher implements TopicDispatcher {
     List<String> locations =
         AuthorizationUtils.getMetadataObjectLocation(ident, Entity.EntityType.TOPIC);
     boolean dropped = dispatcher.dropTopic(ident);
-    AuthorizationUtils.authorizationPluginRemovePrivileges(
-        ident, Entity.EntityType.TOPIC, locations);
+    if (dropped) {
+      AuthorizationUtils.authorizationPluginRemovePrivileges(
+          ident, Entity.EntityType.TOPIC, locations);
+    }
     return dropped;
   }
 

--- a/core/src/test/java/org/apache/gravitino/hook/TestFilesetHookDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/hook/TestFilesetHookDispatcher.java
@@ -36,17 +36,21 @@ import static org.apache.gravitino.Configs.TREE_LOCK_MIN_NODE_IN_MEMORY;
 import static org.apache.gravitino.Configs.VERSION_RETENTION_COUNT;
 import static org.mockito.ArgumentMatchers.any;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import java.io.IOException;
 import java.util.Map;
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.gravitino.Config;
+import org.apache.gravitino.Entity;
 import org.apache.gravitino.GravitinoEnv;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
 import org.apache.gravitino.authorization.AccessControlManager;
+import org.apache.gravitino.authorization.AuthorizationUtils;
 import org.apache.gravitino.catalog.CatalogManager;
+import org.apache.gravitino.catalog.FilesetDispatcher;
 import org.apache.gravitino.catalog.TestFilesetOperationDispatcher;
 import org.apache.gravitino.catalog.TestOperationDispatcher;
 import org.apache.gravitino.connector.BaseCatalog;
@@ -54,8 +58,10 @@ import org.apache.gravitino.connector.authorization.AuthorizationPlugin;
 import org.apache.gravitino.file.Fileset;
 import org.apache.gravitino.file.FilesetChange;
 import org.apache.gravitino.lock.LockManager;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 public class TestFilesetHookDispatcher extends TestOperationDispatcher {
@@ -148,5 +154,30 @@ public class TestFilesetHookDispatcher extends TestOperationDispatcher {
     FilesetChange renameChange = FilesetChange.rename("newName");
     filesetHookDispatcher.alterFileset(filesetIdent, renameChange);
     Mockito.verify(authorizationPlugin).onMetadataUpdated(any());
+  }
+
+  @Test
+  public void testDropFilesetShouldNotRemovePrivilegesWhenDropFails() {
+    FilesetDispatcher dispatcher = Mockito.mock(FilesetDispatcher.class);
+    FilesetHookDispatcher hookDispatcher = new FilesetHookDispatcher(dispatcher);
+    NameIdentifier ident = NameIdentifier.of("metalake", "catalog", "schema", "fileset");
+
+    Mockito.when(dispatcher.dropFileset(ident)).thenReturn(false);
+
+    try (MockedStatic<AuthorizationUtils> authz = Mockito.mockStatic(AuthorizationUtils.class)) {
+      authz
+          .when(
+              () -> AuthorizationUtils.getMetadataObjectLocation(ident, Entity.EntityType.FILESET))
+          .thenReturn(ImmutableList.of("/test"));
+
+      boolean dropped = hookDispatcher.dropFileset(ident);
+
+      Assertions.assertFalse(dropped);
+      authz.verify(
+          () ->
+              AuthorizationUtils.authorizationPluginRemovePrivileges(
+                  ident, Entity.EntityType.FILESET, ImmutableList.of("/test")),
+          Mockito.never());
+    }
   }
 }

--- a/core/src/test/java/org/apache/gravitino/hook/TestTableHookDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/hook/TestTableHookDispatcher.java
@@ -36,18 +36,22 @@ import static org.apache.gravitino.Configs.TREE_LOCK_MIN_NODE_IN_MEMORY;
 import static org.apache.gravitino.Configs.VERSION_RETENTION_COUNT;
 import static org.mockito.ArgumentMatchers.any;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import java.io.IOException;
 import java.util.Map;
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.gravitino.Config;
+import org.apache.gravitino.Entity;
 import org.apache.gravitino.GravitinoEnv;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
 import org.apache.gravitino.TestColumn;
 import org.apache.gravitino.authorization.AccessControlManager;
+import org.apache.gravitino.authorization.AuthorizationUtils;
 import org.apache.gravitino.catalog.CatalogManager;
+import org.apache.gravitino.catalog.TableDispatcher;
 import org.apache.gravitino.catalog.TestOperationDispatcher;
 import org.apache.gravitino.catalog.TestTableOperationDispatcher;
 import org.apache.gravitino.connector.BaseCatalog;
@@ -70,8 +74,10 @@ import org.apache.gravitino.rel.indexes.Indexes;
 import org.apache.gravitino.rel.partitions.Partitions;
 import org.apache.gravitino.rel.partitions.RangePartition;
 import org.apache.gravitino.rel.types.Types;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 public class TestTableHookDispatcher extends TestOperationDispatcher {
@@ -228,5 +234,53 @@ public class TestTableHookDispatcher extends TestOperationDispatcher {
     TableChange renameChange = TableChange.rename("newName");
     tableHookDispatcher.alterTable(tableIdent, renameChange);
     Mockito.verify(authorizationPlugin).onMetadataUpdated(any());
+  }
+
+  @Test
+  public void testDropTableShouldNotRemovePrivilegesWhenDropFails() {
+    TableDispatcher dispatcher = Mockito.mock(TableDispatcher.class);
+    TableHookDispatcher hookDispatcher = new TableHookDispatcher(dispatcher);
+    NameIdentifier ident = NameIdentifier.of("metalake", "catalog", "schema", "table");
+
+    Mockito.when(dispatcher.dropTable(ident)).thenReturn(false);
+
+    try (MockedStatic<AuthorizationUtils> authz = Mockito.mockStatic(AuthorizationUtils.class)) {
+      authz
+          .when(() -> AuthorizationUtils.getMetadataObjectLocation(ident, Entity.EntityType.TABLE))
+          .thenReturn(ImmutableList.of("/test"));
+
+      boolean dropped = hookDispatcher.dropTable(ident);
+
+      Assertions.assertFalse(dropped);
+      authz.verify(
+          () ->
+              AuthorizationUtils.authorizationPluginRemovePrivileges(
+                  ident, Entity.EntityType.TABLE, ImmutableList.of("/test")),
+          Mockito.never());
+    }
+  }
+
+  @Test
+  public void testPurgeTableShouldNotRemovePrivilegesWhenPurgeFails() {
+    TableDispatcher dispatcher = Mockito.mock(TableDispatcher.class);
+    TableHookDispatcher hookDispatcher = new TableHookDispatcher(dispatcher);
+    NameIdentifier ident = NameIdentifier.of("metalake", "catalog", "schema", "table");
+
+    Mockito.when(dispatcher.purgeTable(ident)).thenReturn(false);
+
+    try (MockedStatic<AuthorizationUtils> authz = Mockito.mockStatic(AuthorizationUtils.class)) {
+      authz
+          .when(() -> AuthorizationUtils.getMetadataObjectLocation(ident, Entity.EntityType.TABLE))
+          .thenReturn(ImmutableList.of("/test"));
+
+      boolean purged = hookDispatcher.purgeTable(ident);
+
+      Assertions.assertFalse(purged);
+      authz.verify(
+          () ->
+              AuthorizationUtils.authorizationPluginRemovePrivileges(
+                  ident, Entity.EntityType.TABLE, ImmutableList.of("/test")),
+          Mockito.never());
+    }
   }
 }

--- a/core/src/test/java/org/apache/gravitino/hook/TestTopicHookDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/hook/TestTopicHookDispatcher.java
@@ -20,21 +20,27 @@ package org.apache.gravitino.hook;
 
 import static org.mockito.ArgumentMatchers.any;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
 import java.util.Map;
 import org.apache.commons.lang3.reflect.FieldUtils;
+import org.apache.gravitino.Entity;
 import org.apache.gravitino.GravitinoEnv;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
 import org.apache.gravitino.authorization.AccessControlManager;
+import org.apache.gravitino.authorization.AuthorizationUtils;
 import org.apache.gravitino.catalog.CatalogManager;
 import org.apache.gravitino.catalog.TestOperationDispatcher;
 import org.apache.gravitino.catalog.TestTopicOperationDispatcher;
+import org.apache.gravitino.catalog.TopicDispatcher;
 import org.apache.gravitino.connector.BaseCatalog;
 import org.apache.gravitino.connector.authorization.AuthorizationPlugin;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 public class TestTopicHookDispatcher extends TestOperationDispatcher {
@@ -76,5 +82,29 @@ public class TestTopicHookDispatcher extends TestOperationDispatcher {
         () -> {
           topicHookDispatcher.dropTopic(topicIdent);
         });
+  }
+
+  @Test
+  public void testDropTopicShouldNotRemovePrivilegesWhenDropFails() {
+    TopicDispatcher dispatcher = Mockito.mock(TopicDispatcher.class);
+    TopicHookDispatcher hookDispatcher = new TopicHookDispatcher(dispatcher);
+    NameIdentifier ident = NameIdentifier.of("metalake", "catalog", "schema", "topic");
+
+    Mockito.when(dispatcher.dropTopic(ident)).thenReturn(false);
+
+    try (MockedStatic<AuthorizationUtils> authz = Mockito.mockStatic(AuthorizationUtils.class)) {
+      authz
+          .when(() -> AuthorizationUtils.getMetadataObjectLocation(ident, Entity.EntityType.TOPIC))
+          .thenReturn(ImmutableList.of("/test"));
+
+      boolean dropped = hookDispatcher.dropTopic(ident);
+
+      Assertions.assertFalse(dropped);
+      authz.verify(
+          () ->
+              AuthorizationUtils.authorizationPluginRemovePrivileges(
+                  ident, Entity.EntityType.TOPIC, ImmutableList.of("/test")),
+          Mockito.never());
+    }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Guarded `AuthorizationUtils.authorizationPluginRemovePrivileges()` behind a success check in all HookDispatcher drop/purge methods:
- `TableHookDispatcher.dropTable()` and `purgeTable()`
- `TopicHookDispatcher.dropTopic()`
- `SchemaHookDispatcher.dropSchema()`
- `FilesetHookDispatcher.dropFileset()`

Previously, authorization privileges were removed unconditionally, even when the underlying drop/purge operation returned `false`.

### Why are the changes needed?

When a drop/purge operation fails (returns `false`), the entity still exists but its authorization privileges were already removed. This created an inconsistency between the actual entity state and its authorization metadata.

Fix: #10131

### Does this PR introduce _any_ user-facing change?

No. This is an internal authorization consistency fix. The API behavior is unchanged.

### How was this patch tested?

Added new unit tests following the pattern suggested in the issue:
- `testDropTableShouldNotRemovePrivilegesWhenDropFails`
- `testPurgeTableShouldNotRemovePrivilegesWhenPurgeFails`
- `testDropTopicShouldNotRemovePrivilegesWhenDropFails`
- `testDropFilesetShouldNotRemovePrivilegesWhenDropFails`

Each test mocks the dispatcher to return `false` and verifies that `authorizationPluginRemovePrivileges` is never called.

```
./gradlew :core:test --tests "org.apache.gravitino.hook.TestTableHookDispatcher" --tests "org.apache.gravitino.hook.TestTopicHookDispatcher" --tests "org.apache.gravitino.hook.TestFilesetHookDispatcher" -PskipITs
```
All tests pass.
