### PR TITLE
[#10633][followup] fix(docker): Hadoop UGI failure by adding non-root user to /etc/passwd

### DIFF
--- a/dev/docker/gravitino/Dockerfile
+++ b/dev/docker/gravitino/Dockerfile
@@ -27,7 +27,8 @@ WORKDIR /opt/gravitino
 COPY packages/gravitino /opt/gravitino
 
 RUN chmod -R g+rwX /opt/gravitino \
-    && chmod +x /opt/gravitino/bin/start-gravitino.sh
+    && chmod +x /opt/gravitino/bin/start-gravitino.sh \
+    && useradd -u 1000 -g 0 -M -s /sbin/nologin gravitino
 
 EXPOSE 8090
 EXPOSE 9001

--- a/dev/docker/iceberg-rest-server/Dockerfile
+++ b/dev/docker/iceberg-rest-server/Dockerfile
@@ -28,7 +28,8 @@ WORKDIR /opt/gravitino-iceberg-rest-server
 COPY packages/gravitino-iceberg-rest-server /opt/gravitino-iceberg-rest-server
 
 RUN chmod -R g+rwX /opt/gravitino-iceberg-rest-server \
-    && chmod +x /opt/gravitino-iceberg-rest-server/bin/start-iceberg-rest-server.sh
+    && chmod +x /opt/gravitino-iceberg-rest-server/bin/start-iceberg-rest-server.sh \
+    && useradd -u 1000 -g 0 -M -s /sbin/nologin gravitino
 
 EXPOSE 9001
 


### PR DESCRIPTION
https://github.com/apache/gravitino/pull/10681#issuecomment-4277869555

### What changes were proposed in this pull request?
Add useradd -u 1000 -g 0 -M -s /sbin/nologin gravitino to the gravitino and iceberg-rest-server Dockerfiles so that UID 1000 has a corresponding /etc/passwd entry.

### Why are the changes needed?

PR #10681 switched these Docker images to run as non-root (USER 1000) but did not create a corresponding /etc/passwd entry. This causes Hadoop's UserGroupInformation to fail with a NullPointerException in UnixLoginModule.login() when it cannot resolve the UID to a username via getpwuid().

In the iceberg-rest-server, this manifests as HTTP 500 errors after the IcebergCatalogWrapper cache is evicted (default TTL: 1 hour). The wrapper re-creation calls FileSystemUtils.createConfiguration() (added in PR #9766), which triggers Configuration.addResource() → UserGroupInformation.getCurrentUser() → UnixLoginModule.login() → NPE. The first request after server startup succeeds because Hadoop UGI's static state is not yet initialized at that point.

In the gravitino server, the same issue can occur through HDFSFileSystemProxy.initFileSystem(), HiveClientFactory, and HiveClientImpl.getUser(), all of which call UserGroupInformation.getCurrentUser() directly.

Fix: #10681

### Does this PR introduce _any_ user-facing change?
No. This only adds an internal /etc/passwd entry inside the container image. No APIs, configuration properties, or external behavior are changed.

### How was this patch tested?
Tested locally with Docker using the following procedure:

1. Built three containers from the official apache/gravitino-iceberg-rest:1.2.0 image, simulating the PR #10681 Dockerfile changes:
    - No useradd: USER 1000 without /etc/passwd entry (reproduces the bug)
    - With useradd: USER 1000 with useradd -u 1000 -g 0 -M -s /sbin/nologin gravitino (the fix)
    - Root baseline: Official image running as root
2. Set catalog-cache-eviction-interval-ms to 10 seconds to accelerate cache eviction.
3. Sent an initial request to populate the cache, waited 15 seconds for eviction, then sent a second request.

Results:
```
                             Phase1(init)  Phase3(after evict)
    PR#10681 (no useradd):   200            500    ← bug reproduced
    PR#10681 (+useradd):     200            200    ← fix confirmed
    Official (root):         200            200    ← baseline
```