### PR TITLE
fix(client): preserve unauthorized/forbidden semantics for empty/non-JSON errors

### DIFF
--- a/clients/client-java/src/main/java/org/apache/gravitino/client/ErrorHandlers.java
+++ b/clients/client-java/src/main/java/org/apache/gravitino/client/ErrorHandlers.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Joiner;
 import java.util.List;
 import java.util.function.Consumer;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.gravitino.dto.responses.ErrorConstants;
 import org.apache.gravitino.dto.responses.ErrorResponse;
 import org.apache.gravitino.dto.responses.OAuth2ErrorResponse;
@@ -85,6 +86,7 @@ import org.apache.gravitino.exceptions.TopicAlreadyExistsException;
 import org.apache.gravitino.exceptions.UnauthorizedException;
 import org.apache.gravitino.exceptions.UnmodifiableStatisticException;
 import org.apache.gravitino.exceptions.UserAlreadyExistsException;
+import org.apache.hc.core5.http.HttpStatus;
 
 /**
  * Utility class providing error handling for REST requests and specific to Metalake errors.
@@ -311,6 +313,20 @@ public class ErrorHandlers {
       return message;
     } else {
       return String.format("%s%n%s", message, stack);
+    }
+  }
+
+  private static ErrorResponse buildStatusAwareErrorResponse(
+      int code, String message, Throwable throwable) {
+    switch (code) {
+      case HttpStatus.SC_UNAUTHORIZED:
+        return ErrorResponse.unauthorized(message, throwable);
+
+      case HttpStatus.SC_FORBIDDEN:
+        return ErrorResponse.forbidden(message, throwable);
+
+      default:
+        return ErrorResponse.unknownError(message);
     }
   }
 
@@ -1296,18 +1312,27 @@ public class ErrorHandlers {
 
     @Override
     public ErrorResponse parseResponse(int code, String json, ObjectMapper mapper) {
+      if (StringUtils.isBlank(json)) {
+        return buildStatusAwareErrorResponse(
+            code, String.format("Received HTTP %d response with empty body", code), null);
+      }
+
       try {
         return mapper.readValue(json, ErrorResponse.class);
       } catch (Exception e) {
         String errorMsg =
             String.format(
                 "Error code: %d, error message: %s, json string: %s", code, e.getMessage(), json);
-        return ErrorResponse.unknownError(errorMsg);
+        return buildStatusAwareErrorResponse(code, errorMsg, e);
       }
     }
 
     @Override
     public void accept(ErrorResponse errorResponse) {
+      if (errorResponse.getCode() == ErrorConstants.UNAUTHORIZED_CODE) {
+        throw new UnauthorizedException(
+            "%s", (Object) ("Unauthorized error: " + formatErrorMessage(errorResponse)));
+      }
       if (errorResponse.getCode() == ErrorConstants.FORBIDDEN_CODE) {
         throw new ForbiddenException("Forbidden error :%s", errorResponse.getMessage());
       }

--- a/clients/client-java/src/main/java/org/apache/gravitino/client/ErrorHandlers.java
+++ b/clients/client-java/src/main/java/org/apache/gravitino/client/ErrorHandlers.java
@@ -1313,8 +1313,11 @@ public class ErrorHandlers {
     @Override
     public ErrorResponse parseResponse(int code, String json, ObjectMapper mapper) {
       if (StringUtils.isBlank(json)) {
-        return buildStatusAwareErrorResponse(
-            code, String.format("Received HTTP %d response with empty body", code), null);
+        String errorMsg =
+            String.format(
+                "Error code: %d, error message: Received HTTP %d response with empty body",
+                code, code);
+        return buildStatusAwareErrorResponse(code, errorMsg, null);
       }
 
       try {

--- a/clients/client-java/src/main/java/org/apache/gravitino/client/HTTPClient.java
+++ b/clients/client-java/src/main/java/org/apache/gravitino/client/HTTPClient.java
@@ -188,7 +188,17 @@ public class HTTPClient implements RESTClient {
         responseReason != null && !responseReason.isEmpty()
             ? responseReason
             : EnglishReasonPhraseCatalog.INSTANCE.getReason(response.getCode(), null /* ignored */);
-    return ErrorResponse.restError(message);
+
+    switch (response.getCode()) {
+      case HttpStatus.SC_UNAUTHORIZED:
+        return ErrorResponse.unauthorized(message, null);
+
+      case HttpStatus.SC_FORBIDDEN:
+        return ErrorResponse.forbidden(message, null);
+
+      default:
+        return ErrorResponse.restError(message);
+    }
   }
 
   /**

--- a/clients/client-java/src/main/java/org/apache/gravitino/client/HTTPClient.java
+++ b/clients/client-java/src/main/java/org/apache/gravitino/client/HTTPClient.java
@@ -197,7 +197,8 @@ public class HTTPClient implements RESTClient {
         return ErrorResponse.forbidden(message, null);
 
       default:
-        return ErrorResponse.restError(message);
+        return ErrorResponse.restError(
+            String.format("Error code: %d, error message: %s", response.getCode(), message));
     }
   }
 

--- a/clients/client-java/src/test/java/org/apache/gravitino/client/TestHTTPClient.java
+++ b/clients/client-java/src/test/java/org/apache/gravitino/client/TestHTTPClient.java
@@ -367,8 +367,9 @@ public class TestHTTPClient {
             () ->
                 restClient.get(
                     path, Item.class, ImmutableMap.of(), ErrorHandlers.schemaErrorHandler()));
-    Assertions.assertEquals(
-        "Unauthorized error: Received HTTP 401 response with empty body", exception.getMessage());
+    Assertions.assertTrue(exception.getMessage().contains("Unauthorized error:"));
+    Assertions.assertTrue(exception.getMessage().contains("Error code: 401"));
+    Assertions.assertTrue(exception.getMessage().contains("empty body"));
   }
 
   @Test
@@ -384,8 +385,9 @@ public class TestHTTPClient {
             () ->
                 restClient.get(
                     path, Item.class, ImmutableMap.of(), ErrorHandlers.schemaErrorHandler()));
-    Assertions.assertEquals(
-        "Unauthorized error: Received HTTP 401 response with empty body", exception.getMessage());
+    Assertions.assertTrue(exception.getMessage().contains("Unauthorized error:"));
+    Assertions.assertTrue(exception.getMessage().contains("Error code: 401"));
+    Assertions.assertTrue(exception.getMessage().contains("empty body"));
   }
 
   @Test

--- a/clients/client-java/src/test/java/org/apache/gravitino/client/TestHTTPClient.java
+++ b/clients/client-java/src/test/java/org/apache/gravitino/client/TestHTTPClient.java
@@ -41,6 +41,7 @@ import java.util.function.Consumer;
 import org.apache.gravitino.dto.responses.ErrorResponse;
 import org.apache.gravitino.exceptions.NotFoundException;
 import org.apache.gravitino.exceptions.RESTException;
+import org.apache.gravitino.exceptions.UnauthorizedException;
 import org.apache.gravitino.rest.RESTRequest;
 import org.apache.gravitino.rest.RESTResponse;
 import org.apache.hc.client5.http.config.ConnectionConfig;
@@ -351,6 +352,57 @@ public class TestHTTPClient {
       Assertions.assertInstanceOf(SocketTimeoutException.class, throwable.getCause());
       Assertions.assertEquals("Read timed out", throwable.getCause().getMessage());
     }
+  }
+
+  @Test
+  public void testSchemaErrorHandlerReturnsUnauthorizedForEmptyBody() {
+    String path = "schema_unauthorized_empty_body";
+    mockServer
+        .when(request().withPath("/" + path).withMethod(Method.GET.name().toUpperCase(Locale.ROOT)))
+        .respond(response().withStatusCode(401).withBody(""));
+
+    UnauthorizedException exception =
+        Assertions.assertThrows(
+            UnauthorizedException.class,
+            () ->
+                restClient.get(
+                    path, Item.class, ImmutableMap.of(), ErrorHandlers.schemaErrorHandler()));
+    Assertions.assertEquals(
+        "Unauthorized error: Received HTTP 401 response with empty body", exception.getMessage());
+  }
+
+  @Test
+  public void testSchemaErrorHandlerReturnsUnauthorizedForMissingBody() {
+    String path = "schema_unauthorized_missing_body";
+    mockServer
+        .when(request().withPath("/" + path).withMethod(Method.GET.name().toUpperCase(Locale.ROOT)))
+        .respond(response().withStatusCode(401));
+
+    UnauthorizedException exception =
+        Assertions.assertThrows(
+            UnauthorizedException.class,
+            () ->
+                restClient.get(
+                    path, Item.class, ImmutableMap.of(), ErrorHandlers.schemaErrorHandler()));
+    Assertions.assertEquals(
+        "Unauthorized error: Received HTTP 401 response with empty body", exception.getMessage());
+  }
+
+  @Test
+  public void testSchemaErrorHandlerReturnsUnauthorizedForNonJsonBody() {
+    String path = "schema_unauthorized_non_json_body";
+    mockServer
+        .when(request().withPath("/" + path).withMethod(Method.GET.name().toUpperCase(Locale.ROOT)))
+        .respond(response().withStatusCode(401).withBody("unauthorized"));
+
+    UnauthorizedException exception =
+        Assertions.assertThrows(
+            UnauthorizedException.class,
+            () ->
+                restClient.get(
+                    path, Item.class, ImmutableMap.of(), ErrorHandlers.schemaErrorHandler()));
+    Assertions.assertTrue(exception.getMessage().contains("Unauthorized error: Error code: 401"));
+    Assertions.assertTrue(exception.getMessage().contains("json string: unauthorized"));
   }
 
   public static void testHttpMethodOnSuccess(

--- a/common/src/main/java/org/apache/gravitino/dto/responses/ErrorConstants.java
+++ b/common/src/main/java/org/apache/gravitino/dto/responses/ErrorConstants.java
@@ -54,6 +54,9 @@ public class ErrorConstants {
   /** Error codes for drop an in use entity. */
   public static final int IN_USE_CODE = 1010;
 
+  /** Error codes for unauthorized operation. */
+  public static final int UNAUTHORIZED_CODE = 1099;
+
   /** Error codes for invalid state. */
   public static final int UNKNOWN_ERROR_CODE = 1100;
 

--- a/common/src/main/java/org/apache/gravitino/dto/responses/ErrorResponse.java
+++ b/common/src/main/java/org/apache/gravitino/dto/responses/ErrorResponse.java
@@ -30,6 +30,7 @@ import lombok.Getter;
 import org.apache.gravitino.exceptions.ConnectionFailedException;
 import org.apache.gravitino.exceptions.ForbiddenException;
 import org.apache.gravitino.exceptions.RESTException;
+import org.apache.gravitino.exceptions.UnauthorizedException;
 
 /** Represents an error response. */
 @Getter
@@ -344,6 +345,21 @@ public class ErrorResponse extends BaseResponse {
     return new ErrorResponse(
         ErrorConstants.FORBIDDEN_CODE,
         ForbiddenException.class.getSimpleName(),
+        message,
+        getStackTrace(throwable));
+  }
+
+  /**
+   * Create a new unauthorized operation error instance of {@link ErrorResponse}.
+   *
+   * @param message The message of the error.
+   * @param throwable The throwable that caused the error.
+   * @return The new instance.
+   */
+  public static ErrorResponse unauthorized(String message, Throwable throwable) {
+    return new ErrorResponse(
+        ErrorConstants.UNAUTHORIZED_CODE,
+        UnauthorizedException.class.getSimpleName(),
         message,
         getStackTrace(throwable));
   }


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): Support xxx"
     - "[#233] fix: Check null before access result in xxx"
     - "[MINOR] refactor: Fix typo in variable name"
     - "[MINOR] docs: Fix typo in README"
     - "[#255] test: Fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

This PR improves error handling in the Java client when the server (or an auth gateway/filter) returns HTTP 401/403 with an empty or non-JSON response body.

Specifically, it makes the HTTP client build a status-aware ErrorResponse for 401/403 when the body is missing/unparseable, and ensures the generic REST error handler throws UnauthorizedException / ForbiddenException accordingly.

It also keeps HTTP status code context in empty-body error messages to preserve existing expectations in client tests.

### Why are the changes needed?

In real deployments, authentication/authorization failures are frequently generated by gateways or filters and may not return a Gravitino JSON error body. Previously, such responses could be surfaced as a generic RESTException, losing the 401/403 semantics and making it harder for applications to handle auth errors reliably.

Fix: N/A

### Does this PR introduce _any_ user-facing change?

Yes.

Java client calls that receive HTTP 401/403 may now consistently throw UnauthorizedException / ForbiddenException even when the response body is empty or not JSON (previously could be a generic RESTException).

### How was this patch tested?

```bash
./gradlew :clients:client-java:test \
  --tests org.apache.gravitino.client.TestGravitinoAdminClient \
  --tests org.apache.gravitino.client.TestHTTPClient
```
