### PR TITLE
[#9535] docs(function-privilege): document function privileges

### DIFF
--- a/docs/open-api/roles.yaml
+++ b/docs/open-api/roles.yaml
@@ -214,6 +214,9 @@ components:
             - REGISTER_MODEL
             - LINK_MODEL_VERSION
             - USE_MODEL
+            - REGISTER_FUNCTION
+            - EXECUTE_FUNCTION
+            - MODIFY_FUNCTION
             - CREATE_TAG
             - APPLY_TAG
             - CREATE_POLICY
@@ -249,6 +252,7 @@ components:
             - "TOPIC"
             - "ROLE"
             - "MODEL"
+            - "FUNCTION"
             - "TAG"
             - "POLICY"
             - "JOB_TEMPLATE"
@@ -419,6 +423,7 @@ components:
           - "TOPIC"
           - "ROLE"
           - "MODEL"
+          - "FUNCTION"
           - "TAG"
           - "POLICY"
           - "JOB_TEMPLATE"

--- a/docs/security/access-control.md
+++ b/docs/security/access-control.md
@@ -152,6 +152,7 @@ The following metadata objects support ownership:
 | Fileset              |
 | Role                 |
 | Model                |
+| Function             |
 | Tag                  |
 | JobTemplate          |
 | Job                  |
@@ -178,7 +179,7 @@ Groups can be granted roles and privileges, but they cannot be owners of securab
 
 ### Metadata Objects
 
-Metadata objects are entities managed by Gravitino, such as catalogs, schemas, tables, filesets, topics, roles, and metalakes.
+Metadata objects are entities managed by Gravitino, such as catalogs, schemas, tables, filesets, topics, models, functions, roles, and metalakes.
 
 **Naming Convention:**
 - Each metadata object has a **type** and a **name**
@@ -205,7 +206,9 @@ Metalake (top level)
         ├── Table
         ├── View
         ├── Topic
-        └── Fileset
+        ├── Fileset
+        ├── Model
+        └── Function
 ```
 
 ![object_image](../assets/security/object.png)
@@ -272,7 +275,7 @@ Gravitino provides a comprehensive set of privileges organized by the type of op
 
 | Name          | Supports Securable Object | Operation                                                                                                     |
 |---------------|---------------------------|---------------------------------------------------------------------------------------------------------------|
-| MANAGE_GRANTS | Metalake, Catalog, Schema, Table, View, Topic, Fileset, Model | Grants the ability to manage privileges on securable objects. When bound to a **Metalake**, also allows assigning and revoking roles for users and groups across the entire metalake. When bound to a **Catalog, Schema, Table, View, Topic, Fileset, or Model**, privilege management is scoped to that object and its descendants only. |
+| MANAGE_GRANTS | Metalake, Catalog, Schema, Table, View, Topic, Fileset, Model, Function | Grants the ability to manage privileges on securable objects. When bound to a **Metalake**, also allows assigning and revoking roles for users and groups across the entire metalake. When bound to a **Catalog, Schema, Table, View, Topic, Fileset, Model, or Function**, privilege management is scoped to that object and its descendants only. |
 
 ### Catalog privileges
 

--- a/docs/security/access-control.md
+++ b/docs/security/access-control.md
@@ -360,6 +360,14 @@ The privileges `CREATE_MODEL` and `CREATE_MODEL_VERSION` are deprecated and will
 | CREATE_MODEL         | Metalake, Catalog, Schema        | Register a model, this is deprecated. Please use `REGISTER_MODEL` instead.         |
 | CREATE_MODEL_VERSION | Metalake, Catalog, Schema, Model | Link a model version, this is deprecated. Please use `LINK_MODEL_VERSION` instead. |
 
+### Function privileges
+
+| Name              | Supports Securable Object           | Operation                                                                             |
+|-------------------|-------------------------------------|---------------------------------------------------------------------------------------|
+| REGISTER_FUNCTION | Metalake, Catalog, Schema           | Register a function                                                                   |
+| EXECUTE_FUNCTION  | Metalake, Catalog, Schema, Function | View the metadata of the function and execute the function                            |
+| MODIFY_FUNCTION   | Metalake, Catalog, Schema, Function | Alter or drop the function                                                            |
+
 ### Tag privileges
 
 | Name       | Supports Securable Object | Operation                             |
@@ -1312,6 +1320,11 @@ The following table lists the required privileges for each API.
 | delete model version              | First, you should have the privilege to load the catalog and the schema. Then, you are one of the owners of the model, schema, metalake, catalog.                                                                                             |
 | alter model version               | First, you should have the privilege to load the catalog and the schema. Then, you are one of the owners of the model, schema, metalake, catalog.                                                                                             |
 | delete model version alias        | First, you should have the privilege to load the catalog and the schema. Then, you are one of the owners of the model, schema, metalake, catalog.                                                                                             |
+| register function                 | First, you should have the privilege to load the catalog and the schema. Then, you have `REGISTER_FUNCTION` on the metalake, catalog, schema or are the owner of the metalake, catalog, schema                                                |
+| alter function                    | First, you should have the privilege to load the catalog and the schema. Then, you have `MODIFY_FUNCTION` on the metalake, catalog, schema, function or are one of the owners of the metalake, catalog, schema, function                      |
+| drop function                     | First, you should have the privilege to load the catalog and the schema. Then, you have `MODIFY_FUNCTION` on the metalake, catalog, schema, function or are one of the owners of the metalake, catalog, schema, function                      |
+| list functions                    | First, you should have the privilege to load the catalog and the schema. Then the owner of the schema, catalog, metalake can see all the functions, others can see the functions which they can load                                          |
+| load function                     | First, you should have the privilege to load the catalog and the schema. Then, you are one of the owners of the function, schema, catalog, metalake or have `EXECUTE_FUNCTION` or `MODIFY_FUNCTION` on the function, schema, catalog, metalake |
 | add user                          | `MANAGE_USERS` on the metalake  or the owner of the metalake                                                                                                                                                                                  |
 | remove user                       | `MANAGE_USERS` on the metalake  or the owner of the metalake                                                                                                                                                                                  |
 | get user                          | `MANAGE_USERS` on the metalake  or the owner of the metalake or himself                                                                                                                                                                       |


### PR DESCRIPTION
### What changes were proposed in this pull request?

Update the authorization documentation to cover the three new function privileges
introduced in #10811.

Changes:
- `docs/security/access-control.md` — add a **Function privileges** section with a privilege table (`REGISTER_FUNCTION`, `EXECUTE_FUNCTION`, `MODIFY_FUNCTION`) and corresponding rows in the operation-to-privilege reference table
- `docs/open-api/roles.yaml` — add `REGISTER_FUNCTION`, `EXECUTE_FUNCTION`, `MODIFY_FUNCTION` to the `Privilege.name` enum and `FUNCTION` to the `SecurableObject.type` enum (both in the schema and the path-parameter enum)

### Why are the changes needed?

The new function privileges are unusable without documentation.
Users and integrators need to know which privilege grants which operation and at which securable-object level.

Fix: #9535

### Does this PR introduce _any_ user-facing change?

Documentation only — no code changes.

### How was this patch tested?

`./gradlew :docs:build` — OpenAPI specification validation passes.