### PR TITLE
[#10825] fix(spark-connector): yield to Spark DataSource shortcut for built-in format names

### DIFF
--- a/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/catalog/BaseCatalog.java
+++ b/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/catalog/BaseCatalog.java
@@ -19,10 +19,13 @@
 
 package org.apache.gravitino.spark.connector.catalog;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import org.apache.commons.lang3.StringUtils;
@@ -239,8 +242,25 @@ public abstract class BaseCatalog implements TableCatalog, SupportsNamespaces, F
     }
   }
 
+  /**
+   * Spark built-in DataSource format names that can appear as the first part of a multipart
+   * identifier when a user writes {@code SELECT * FROM <format>.`<path>`}. When this catalog
+   * intercepts such a lookup, the server-side authorization filter would call {@code
+   * MetadataObjects.of(TABLE, names)} which requires {@code names.length == 3} and throws an {@code
+   * IllegalArgumentException} because the path is counted as a single name.
+   *
+   * <p>Short-circuiting those lookups with {@code NoSuchTableException} makes the Spark analyzer
+   * fall back to its DataSource shortcut resolver and build a {@code HadoopFsRelation} directly —
+   * the same path vanilla Spark takes when no CatalogPlugin is installed.
+   */
+  private static final ImmutableSet<String> BUILTIN_DATASOURCE_FORMATS =
+      ImmutableSet.of("parquet", "csv", "json", "orc", "text", "avro", "binaryfile");
+
   @Override
   public Table loadTable(Identifier ident) throws NoSuchTableException {
+    if (isBuiltinDataSourceReference(ident)) {
+      throw new NoSuchTableException(ident);
+    }
     try {
       org.apache.gravitino.rel.Table gravitinoTable = loadGravitinoTable(ident);
       org.apache.spark.sql.connector.catalog.Table sparkTable = loadSparkTable(ident);
@@ -256,6 +276,15 @@ public abstract class BaseCatalog implements TableCatalog, SupportsNamespaces, F
     } catch (org.apache.gravitino.exceptions.NoSuchTableException e) {
       throw new NoSuchTableException(ident);
     }
+  }
+
+  @VisibleForTesting
+  static boolean isBuiltinDataSourceReference(Identifier ident) {
+    String[] namespace = ident.namespace();
+    if (namespace.length != 1) {
+      return false;
+    }
+    return BUILTIN_DATASOURCE_FORMATS.contains(namespace[0].toLowerCase(Locale.ROOT));
   }
 
   @Override
@@ -303,6 +332,13 @@ public abstract class BaseCatalog implements TableCatalog, SupportsNamespaces, F
 
   @Override
   public boolean tableExists(Identifier ident) {
+    // Spark's DataSource shortcut resolver asks the CatalogManager whether the identifier exists
+    // before falling back to format-based resolution. Answer "no" so the authorization filter for
+    // TABLE (which wants 3 name parts) never fires on a namespace that is actually a DataSource
+    // format name such as `parquet`, `csv`, or `json`.
+    if (isBuiltinDataSourceReference(ident)) {
+      return false;
+    }
     // Gravitino uses loadTable() to verify table existence, which requires LOAD_TABLE privilege.
     // For CREATE TABLE IF NOT EXISTS operations, users may only have CREATE_TABLE privilege.
     // When ForbiddenException is thrown (lacking LOAD_TABLE privilege), we return false to allow

--- a/spark-connector/spark-common/src/test/java/org/apache/gravitino/spark/connector/catalog/TestBaseCatalog.java
+++ b/spark-connector/spark-common/src/test/java/org/apache/gravitino/spark/connector/catalog/TestBaseCatalog.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.spark.connector.catalog;
+
+import org.apache.spark.sql.connector.catalog.Identifier;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TestBaseCatalog {
+
+  @Test
+  void builtinDataSourceFormatsShouldBeRecognized() {
+    String[] formats = {"parquet", "csv", "json", "orc", "text", "avro", "binaryFile"};
+    for (String format : formats) {
+      Identifier ident = Identifier.of(new String[] {format}, "s3a://bucket/file");
+      Assertions.assertTrue(
+          BaseCatalog.isBuiltinDataSourceReference(ident),
+          "Expected " + format + " to be recognized as a built-in DataSource format");
+    }
+  }
+
+  @Test
+  void builtinDataSourceFormatsAreCaseInsensitive() {
+    Identifier upper = Identifier.of(new String[] {"PARQUET"}, "s3a://bucket/file.parquet");
+    Identifier mixed = Identifier.of(new String[] {"BinaryFile"}, "s3a://bucket/folder");
+    Assertions.assertTrue(BaseCatalog.isBuiltinDataSourceReference(upper));
+    Assertions.assertTrue(BaseCatalog.isBuiltinDataSourceReference(mixed));
+  }
+
+  @Test
+  void regularGravitinoTableNamespacesAreNotTreatedAsBuiltin() {
+    // A Gravitino table reference typically has a schema-name namespace, not a format name.
+    Identifier schemaIdent = Identifier.of(new String[] {"my_schema"}, "my_table");
+    Assertions.assertFalse(BaseCatalog.isBuiltinDataSourceReference(schemaIdent));
+  }
+
+  @Test
+  void multipartNamespaceIsNotTreatedAsBuiltin() {
+    // A multipart namespace (e.g. catalog.schema) should not match — the guard targets Spark's
+    // single-part "<format>" shortcut only.
+    Identifier threePart = Identifier.of(new String[] {"parquet", "extra"}, "table");
+    Assertions.assertFalse(BaseCatalog.isBuiltinDataSourceReference(threePart));
+  }
+
+  @Test
+  void emptyNamespaceIsNotTreatedAsBuiltin() {
+    Identifier noNamespace = Identifier.of(new String[] {}, "parquet");
+    Assertions.assertFalse(BaseCatalog.isBuiltinDataSourceReference(noNamespace));
+  }
+
+  @Test
+  void unknownFormatIsNotTreatedAsBuiltin() {
+    Identifier unknown = Identifier.of(new String[] {"xml"}, "some_path");
+    Assertions.assertFalse(BaseCatalog.isBuiltinDataSourceReference(unknown));
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

Short-circuit `BaseCatalog.loadTable` and `BaseCatalog.tableExists` with `NoSuchTableException` when the identifier's namespace is a single built-in Spark DataSource format name (`parquet`, `csv`, `json`, `orc`, `text`, `avro`, `binaryfile`). When the connector declines these lookups, the Spark analyzer falls back to its DataSource shortcut resolver and builds a `HadoopFsRelation` directly — the same path vanilla Spark takes.

Unqualified Gravitino catalogs/tables are unaffected: they arrive with a namespace that references a registered catalog, not a format name, so they continue through the existing `loadGravitinoTable` path and the usual authorization filter.

### Why are the changes needed?

`SELECT * FROM parquet.\`path\`` is a long-standing Spark built-in syntax. Today, when `GravitinoSparkPlugin` is registered, the analyzer sends `(namespace=[parquet], name=<path>)` to `BaseCatalog.loadTable`, which forwards it to the server. The server-side authorization filter calls `MetadataObjects.of(TABLE, names)` which requires `names.length == 3` (catalog.schema.table), so every such query fails with `IllegalArgumentException: If the type is TABLE, the length of names must be 3`.

Users expect Spark's built-in shortcut to keep working when the connector is installed; today it does not.

Fix: #10825

### Does this PR introduce _any_ user-facing change?

Yes. After this PR, the following queries work when \`GravitinoSparkPlugin\` is enabled:

\`\`\`sql
SELECT * FROM parquet.\`s3a://bucket/file.parquet\`;
SELECT * FROM csv.\`/data/file.csv\`;
SELECT * FROM json.\`hdfs:///events.json\`;
SELECT * FROM orc.\`/data/file.orc\`;
SELECT * FROM text.\`/data/file.txt\`;
SELECT * FROM avro.\`/data/file.avro\`;
SELECT * FROM binaryFile.\`/data/folder/\`;
\`\`\`

Previously all of these failed at the server-side 3-part-name assertion.

No API or property-key changes. No behavior change for user Gravitino tables.

### How was this patch tested?

- New \`TestBaseCatalog\` covering six cases for the new \`isBuiltinDataSourceReference\` helper: built-in formats recognized, case-insensitive match, regular schema namespaces ignored, multipart namespaces ignored, empty namespaces ignored, unknown formats ignored.
- \`./gradlew :spark-connector:spark-common:test --tests org.apache.gravitino.spark.connector.catalog.TestBaseCatalog\` → all tests pass.
- \`./gradlew :spark-connector:spark-common:spotlessCheck\` → clean.
- End-to-end manual verification on Spark 3.5.8 + Gravitino 1.2.0 with GVFS: \`SELECT * FROM parquet.\`gvfs://fileset/.../file.parquet\`\` now returns rows; \`SELECT * FROM <gravitino_iceberg_cat>.db.t\` remains unaffected.