### PR TITLE
[#10837] fix(web-v2): Preserve hidden properties when editing a catalog

### DIFF
--- a/web-v2/web/src/app/catalogs/rightContent/CreateCatalogDialog.js
+++ b/web-v2/web/src/app/catalogs/rightContent/CreateCatalogDialog.js
@@ -294,6 +294,17 @@ export default function CreateCatalogDialog({ ...props }) {
         setConfirmLoading(true)
         const submitData = getSubmitData()
         if (editCatalog) {
+          // Backfill hidden default props that the form doesn't render during edit
+          const allDefaultProps =
+            (catalogType === 'model'
+              ? providerBase['model'].defaultProps
+              : providerBase[currentProvider]?.defaultProps) || []
+          allDefaultProps.forEach(prop => {
+            if (isHidden(prop) && !(prop.key in submitData.properties) && cacheData?.properties?.[prop.key] != null) {
+              submitData.properties[prop.key] = cacheData.properties[prop.key]
+            }
+          })
+
           // update catalog
           const reqData = { updates: genUpdates(cacheData, submitData) }
           if (reqData.updates.length) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

When editing a catalog in the web-v2 UI, hidden `defaultProps` (properties that `isHidden()` returns `true` for) are now backfilled from the cached catalog data before computing the update diff. This prevents `genUpdates()` from generating spurious `removeProperty` operations for properties the user never touched.

### Why are the changes needed?

During catalog edit, `isHidden()` hides all non-required, non-region/location default properties (e.g. `warehouse` for lakehouse-iceberg with hive backend). `getSubmitData()` then filters these out via `.filter(item => !isHidden(item))`, so they are absent from the submitted payload. `genUpdates()` sees these keys in the original catalog but not in the new data, and generates `removeProperty` updates — which causes the backend to return a 400 error.

The fix adds a targeted backfill step in `handleSubmit` that iterates over all `defaultProps`, and for each one that is hidden and missing from the submit data, copies the original value from `cacheData.properties`.

Fix: #10837

### Does this PR introduce _any_ user-facing change?

No API changes. Catalog edit in web-v2 now correctly preserves properties that are not displayed in the edit form.

### How was this patch tested?

Manually tested by:
1. Creating a lakehouse-iceberg catalog (hive backend) with warehouse and uri
2. Editing the catalog (changing only the comment)
3. Verifying the edit succeeds without a 400 error
4. Verifying the warehouse property is preserved after edit