### PR TITLE
[#10862] improvement(ci): Pre-install JDK 24 to stabilize Trino connector build

### DIFF
--- a/.github/actions/setup-java-toolchains/action.yml
+++ b/.github/actions/setup-java-toolchains/action.yml
@@ -1,0 +1,31 @@
+name: 'Setup Java Toolchains'
+description: 'Install a primary JDK and JDK 24 (for Trino), register JDK 24 with Gradle toolchain'
+
+inputs:
+  java-version:
+    description: 'Primary Java version'
+    default: '17'
+  cache:
+    description: 'Gradle cache setting'
+    default: 'gradle'
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-java@v4
+      id: setup-jdk24
+      with:
+        java-version: 24
+        distribution: temurin
+
+    - uses: actions/setup-java@v4
+      with:
+        java-version: ${{ inputs.java-version }}
+        distribution: temurin
+        cache: ${{ inputs.cache }}
+
+    - name: Register JDK 24 with Gradle toolchain
+      shell: bash
+      run: |
+        mkdir -p ~/.gradle
+        echo "org.gradle.java.installations.paths=${{ steps.setup-jdk24.outputs.path }}" >> ~/.gradle/gradle.properties

--- a/.github/actions/setup-java-toolchains/action.yml
+++ b/.github/actions/setup-java-toolchains/action.yml
@@ -28,4 +28,10 @@ runs:
       shell: bash
       run: |
         mkdir -p ~/.gradle
-        echo "org.gradle.java.installations.paths=${{ steps.setup-jdk24.outputs.path }}" >> ~/.gradle/gradle.properties
+        GRADLE_PROPERTIES=~/.gradle/gradle.properties
+        TMP=$(mktemp)
+        if [ -f "${GRADLE_PROPERTIES}" ]; then
+          awk '!/^org\.gradle\.java\.installations\.paths=/' "${GRADLE_PROPERTIES}" > "${TMP}"
+        fi
+        echo "org.gradle.java.installations.paths=${{ steps.setup-jdk24.outputs.path }}" >> "${TMP}"
+        mv "${TMP}" "${GRADLE_PROPERTIES}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,11 +106,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-java@v4
+      - uses: ./.github/actions/setup-java-toolchains
         with:
           java-version: 17
-          distribution: 'temurin'
-          cache: 'gradle'
 
       - name: Build with Gradle
         run: |
@@ -164,11 +162,9 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-java@v4
+      - uses: ./.github/actions/setup-java-toolchains
         with:
           java-version: ${{ matrix.java-version }}
-          distribution: 'temurin'
-          cache: 'gradle'
 
       - name: Test publish to local
         run: ./gradlew publishToMavenLocal -PskipWeb=true -x test

--- a/.github/workflows/cron-integration-test.yml
+++ b/.github/workflows/cron-integration-test.yml
@@ -63,12 +63,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-java@v4
+      - uses: ./.github/actions/setup-java-toolchains
         with:
           java-version: ${{ matrix.java-version }}
-          distribution: 'temurin'
-          cache: 'gradle'
-
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0

--- a/.github/workflows/frontend-integration-test.yml
+++ b/.github/workflows/frontend-integration-test.yml
@@ -68,11 +68,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-java@v4
+      - uses: ./.github/actions/setup-java-toolchains
         with:
           java-version: ${{ matrix.java-version }}
-          distribution: 'temurin'
-          cache: 'gradle'
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0

--- a/.github/workflows/gvfs-fuse-build-test.yml
+++ b/.github/workflows/gvfs-fuse-build-test.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Integration test
         run: |
           ./gradlew build -PskipWeb=true -x :clients:client-python:build -x test -x web -PskipTrinoConnector=true
-          ./gradlew compileDistribution -PskipWeb=true -x :clients:client-python:build -x test -x web
+          ./gradlew compileDistribution -PskipWeb=true -x :clients:client-python:build -x test -x web -PskipTrinoConnector=true
           cd clients/filesystem-fuse
           make test-s3
           make test-fuse-it

--- a/.github/workflows/gvfs-fuse-build-test.yml
+++ b/.github/workflows/gvfs-fuse-build-test.yml
@@ -78,7 +78,7 @@ jobs:
 
       - name: Integration test
         run: |
-          ./gradlew build -PskipWeb=true -x :clients:client-python:build -x test -x web
+          ./gradlew build -PskipWeb=true -x :clients:client-python:build -x test -x web -PskipTrinoConnector=true
           ./gradlew compileDistribution -PskipWeb=true -x :clients:client-python:build -x test -x web
           cd clients/filesystem-fuse
           make test-s3

--- a/.github/workflows/trino-integration-test.yml
+++ b/.github/workflows/trino-integration-test.yml
@@ -61,11 +61,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-java@v4
+      - uses: ./.github/actions/setup-java-toolchains
         with:
           java-version: ${{ matrix.java-version }}
-          distribution: 'temurin'
-          cache: 'gradle'
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0

--- a/.github/workflows/trino-multi-version-test.yml
+++ b/.github/workflows/trino-multi-version-test.yml
@@ -12,11 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-java@v4
-        with:
-          java-version: 17
-          distribution: 'temurin'
-          cache: 'gradle'
+      - uses: ./.github/actions/setup-java-toolchains
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/docs/how-to-build.md
+++ b/docs/how-to-build.md
@@ -65,6 +65,12 @@ license: "This software is licensed under the Apache License version 2."
    ./gradlew build -PpythonVersion=3.12
    ```
 
+  If you don't need to build the Trino connector (for example, when building on a machine without JDK 24), you can skip it with:
+
+   ```shell
+   ./gradlew build -PskipTrinoConnector=true
+   ```
+
   If you want to build a module on its own, like the Spark connector, you can use Gradle to build a module with a specific name, like so:
 
    ```shell

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -69,7 +69,9 @@ include("iceberg:iceberg-rest-server")
 include("lance:lance-common")
 include("lance:lance-rest-server")
 include("authorizations:authorization-ranger", "authorizations:authorization-common", "authorizations:authorization-chain")
-if (gradle.startParameter.projectProperties["skipTrinoConnector"]?.toBoolean() != true) {
+val skipTrinoConnector: Boolean =
+  gradle.startParameter.projectProperties["skipTrinoConnector"]?.toBoolean() ?: false
+if (!skipTrinoConnector) {
   include(
     "trino-connector:trino-connector",
     "trino-connector:trino-connector-435-439",

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -69,16 +69,20 @@ include("iceberg:iceberg-rest-server")
 include("lance:lance-common")
 include("lance:lance-rest-server")
 include("authorizations:authorization-ranger", "authorizations:authorization-common", "authorizations:authorization-chain")
-include(
-  "trino-connector:trino-connector",
-  "trino-connector:trino-connector-435-439",
-  "trino-connector:trino-connector-440-445",
-  "trino-connector:trino-connector-446-451",
-  "trino-connector:trino-connector-452-468",
-  "trino-connector:trino-connector-469-472",
-  "trino-connector:trino-connector-473-478",
-  "trino-connector:integration-test"
-)
+if (gradle.startParameter.projectProperties["skipTrinoConnector"]?.toBoolean() != true) {
+  include(
+    "trino-connector:trino-connector",
+    "trino-connector:trino-connector-435-439",
+    "trino-connector:trino-connector-440-445",
+    "trino-connector:trino-connector-446-451",
+    "trino-connector:trino-connector-452-468",
+    "trino-connector:trino-connector-469-472",
+    "trino-connector:trino-connector-473-478",
+    "trino-connector:integration-test"
+  )
+} else {
+  println("Skipping trino-connector modules since skipTrinoConnector is set to true")
+}
 include("spark-connector:spark-common")
 if (scalaVersion == "2.12") {
   // flink only support scala 2.12


### PR DESCRIPTION
### What changes were proposed in this pull request?

- Add reusable composite action `.github/actions/setup-java-toolchains` that pre-installs JDK 24 alongside JDK 17 and registers JDK 24 with Gradle toolchain via `~/.gradle/gradle.properties`, eliminating unreliable Foojay downloads at build time.
- Apply the composite action to 5 workflows that build Trino connector modules: `build.yml`, `trino-integration-test.yml`, `trino-multi-version-test.yml`, `frontend-integration-test.yml`, `cron-integration-test.yml`.
- Add `skipTrinoConnector` property to `settings.gradle.kts` to conditionally exclude all Trino subprojects from the Gradle project graph. Use it in `gvfs-fuse-build-test.yml` which has no Trino dependency.

### Why are the changes needed?

Fix: #10862

Trino connector submodules require Java 24 via Gradle toolchain. When only JDK 17 is installed in CI, Gradle auto-downloads JDK 24 via the Foojay resolver plugin, which is unreliable and causes flaky CI failures.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

CI workflows validation.