### PR TITLE
[#10122] fix(core): handle non-BasicDataSource in JdbcCatalogMetricsSource safely

### DIFF
--- a/core/src/main/java/org/apache/gravitino/metrics/source/JdbcCatalogMetricsSource.java
+++ b/core/src/main/java/org/apache/gravitino/metrics/source/JdbcCatalogMetricsSource.java
@@ -23,14 +23,24 @@ import com.codahale.metrics.Gauge;
 import javax.sql.DataSource;
 import org.apache.commons.dbcp2.BasicDataSource;
 import org.apache.gravitino.metrics.MetricNames;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class JdbcCatalogMetricsSource extends CatalogMetricsSource {
+
+  private static final Logger LOG = LoggerFactory.getLogger(JdbcCatalogMetricsSource.class);
 
   public JdbcCatalogMetricsSource(String metalakeName, String catalogName) {
     super("jdbc", metalakeName, catalogName);
   }
 
   public void registerDatasourceMetrics(DataSource dataSource) {
+    if (!(dataSource instanceof BasicDataSource)) {
+      LOG.warn(
+          "DataSource is not a BasicDataSource (actual: {}), skipping datasource metrics registration",
+          dataSource.getClass().getName());
+      return;
+    }
     BasicDataSource basicDataSource = (BasicDataSource) dataSource;
     registerGauge(
         MetricNames.DATASOURCE_ACTIVE_CONNECTIONS, (Gauge<Integer>) basicDataSource::getNumActive);

--- a/core/src/test/java/org/apache/gravitino/metrics/source/TestJdbcCatalogMetricsSource.java
+++ b/core/src/test/java/org/apache/gravitino/metrics/source/TestJdbcCatalogMetricsSource.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.metrics.source;
+
+import java.io.PrintWriter;
+import java.sql.Connection;
+import java.sql.SQLException;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TestJdbcCatalogMetricsSource {
+
+  @Test
+  public void testRegisterDatasourceMetricsWithNonBasicDataSource() {
+    JdbcCatalogMetricsSource source = new JdbcCatalogMetricsSource("metalake", "catalog");
+
+    DataSource nonBasicDataSource =
+        new DataSource() {
+          @Override
+          public Connection getConnection() {
+            return null;
+          }
+
+          @Override
+          public Connection getConnection(String username, String password) {
+            return null;
+          }
+
+          @Override
+          public PrintWriter getLogWriter() {
+            return null;
+          }
+
+          @Override
+          public void setLogWriter(PrintWriter out) {}
+
+          @Override
+          public void setLoginTimeout(int seconds) {}
+
+          @Override
+          public int getLoginTimeout() {
+            return 0;
+          }
+
+          @Override
+          public java.util.logging.Logger getParentLogger() {
+            return java.util.logging.Logger.getGlobal();
+          }
+
+          @Override
+          public <T> T unwrap(Class<T> iface) throws SQLException {
+            throw new SQLException("Not a wrapper");
+          }
+
+          @Override
+          public boolean isWrapperFor(Class<?> iface) {
+            return false;
+          }
+        };
+
+    Assertions.assertDoesNotThrow(() -> source.registerDatasourceMetrics(nonBasicDataSource));
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

Added an `instanceof` check in `JdbcCatalogMetricsSource.registerDatasourceMetrics()` before casting to `BasicDataSource`. If the provided `DataSource` is not a `BasicDataSource`, the method logs a warning and returns early instead of throwing a `ClassCastException`.

### Why are the changes needed?

The original implementation performed an unconditional cast of `DataSource` to `BasicDataSource`, which would throw a `ClassCastException` at runtime for any non-DBCP `DataSource` implementation. This makes the method unsafe for callers that may pass a different `DataSource` type.

Fix: #10122

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

Added `TestJdbcCatalogMetricsSource.testRegisterDatasourceMetricsWithNonBasicDataSource()` which passes an anonymous `DataSource` implementation (non-DBCP) and asserts that no exception is thrown.