### PR TITLE
[#10172] improvement(server): Guard catch-block request dereferences in REST handlers

### DIFF
--- a/server/src/main/java/org/apache/gravitino/server/web/rest/CatalogOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/CatalogOperations.java
@@ -161,8 +161,9 @@ public class CatalogOperations {
           });
 
     } catch (Exception e) {
+      String catalogName = request != null ? request.getName() : "";
       return ExceptionHandlers.handleCatalogException(
-          OperationType.CREATE, request.getName(), metalake, e);
+          OperationType.CREATE, catalogName, metalake, e);
     }
   }
 
@@ -198,7 +199,8 @@ public class CatalogOperations {
           });
 
     } catch (Exception e) {
-      LOG.info("Failed to test connection for catalog: {}.{}", metalake, request.getName());
+      String catalogName = request != null ? request.getName() : "";
+      LOG.info("Failed to test connection for catalog: {}.{}", metalake, catalogName);
       return ExceptionHandlers.handleTestConnectionException(e);
     }
   }
@@ -219,7 +221,8 @@ public class CatalogOperations {
       CatalogSetRequest request) {
     LOG.info("Received set request for catalog: {}.{}", metalake, catalogName);
 
-    OperationType op = request.isInUse() ? OperationType.ENABLE : OperationType.DISABLE;
+    OperationType op =
+        request != null && request.isInUse() ? OperationType.ENABLE : OperationType.DISABLE;
 
     try {
       return Utils.doAs(
@@ -235,18 +238,15 @@ public class CatalogOperations {
             Response response = Utils.ok(new BaseResponse());
             LOG.info(
                 "Successfully {} catalog: {}.{}",
-                request.isInUse() ? "enable" : "disable",
+                op == OperationType.ENABLE ? "enable" : "disable",
                 metalake,
                 catalogName);
             return response;
           });
 
     } catch (Exception e) {
-      LOG.info(
-          "Failed to {} catalog: {}.{}",
-          request.isInUse() ? "enable" : "disable",
-          metalake,
-          catalogName);
+      String action = op == OperationType.ENABLE ? "enable" : "disable";
+      LOG.info("Failed to {} catalog: {}.{}", action, metalake, catalogName);
       return ExceptionHandlers.handleCatalogException(op, catalogName, metalake, e);
     }
   }

--- a/server/src/main/java/org/apache/gravitino/server/web/rest/FilesetOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/FilesetOperations.java
@@ -180,8 +180,8 @@ public class FilesetOperations {
           });
 
     } catch (Exception e) {
-      return ExceptionHandlers.handleFilesetException(
-          OperationType.CREATE, request.getName(), schema, e);
+      String filesetName = request != null ? request.getName() : "";
+      return ExceptionHandlers.handleFilesetException(OperationType.CREATE, filesetName, schema, e);
     }
   }
 

--- a/server/src/main/java/org/apache/gravitino/server/web/rest/FunctionOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/FunctionOperations.java
@@ -160,8 +160,9 @@ public class FunctionOperations {
             return response;
           });
     } catch (Exception e) {
+      String functionName = request != null ? request.getName() : "";
       return ExceptionHandlers.handleFunctionException(
-          OperationType.REGISTER, request.getName(), schema, e);
+          OperationType.REGISTER, functionName, schema, e);
     }
   }
 

--- a/server/src/main/java/org/apache/gravitino/server/web/rest/GroupOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/GroupOperations.java
@@ -115,8 +115,8 @@ public class GroupOperations {
                         accessControlManager.addGroup(metalake, request.getName()))));
           });
     } catch (Exception e) {
-      return ExceptionHandlers.handleGroupException(
-          OperationType.ADD, request.getName(), metalake, e);
+      String groupName = request != null ? request.getName() : "";
+      return ExceptionHandlers.handleGroupException(OperationType.ADD, groupName, metalake, e);
     }
   }
 

--- a/server/src/main/java/org/apache/gravitino/server/web/rest/JobOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/JobOperations.java
@@ -150,10 +150,10 @@ public class JobOperations {
       @PathParam("metalake") @AuthorizationMetadata(type = Entity.EntityType.METALAKE)
           String metalake,
       JobTemplateRegisterRequest request) {
+    String templateName =
+        request != null && request.getJobTemplate() != null ? request.getJobTemplate().name() : "";
     LOG.info(
-        "Received request to register job template {} in metalake: {}",
-        request.getJobTemplate().name(),
-        metalake);
+        "Received request to register job template {} in metalake: {}", templateName, metalake);
 
     try {
       return Utils.doAs(
@@ -173,7 +173,7 @@ public class JobOperations {
 
     } catch (Exception e) {
       return ExceptionHandlers.handleJobTemplateException(
-          OperationType.REGISTER, request.getJobTemplate().name(), metalake, e);
+          OperationType.REGISTER, templateName, metalake, e);
     }
   }
 

--- a/server/src/main/java/org/apache/gravitino/server/web/rest/MetalakeOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/MetalakeOperations.java
@@ -201,9 +201,10 @@ public class MetalakeOperations {
           });
 
     } catch (Exception e) {
-      LOG.info("Failed to {} metalake: {}", request.isInUse() ? "enable" : "disable", metalakeName);
+      boolean inUse = request != null && request.isInUse();
+      LOG.info("Failed to {} metalake: {}", inUse ? "enable" : "disable", metalakeName);
       return ExceptionHandlers.handleMetalakeException(
-          request.isInUse() ? OperationType.ENABLE : OperationType.DISABLE, metalakeName, e);
+          inUse ? OperationType.ENABLE : OperationType.DISABLE, metalakeName, e);
     }
   }
 

--- a/server/src/main/java/org/apache/gravitino/server/web/rest/ModelOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/ModelOperations.java
@@ -194,8 +194,8 @@ public class ModelOperations {
           });
 
     } catch (Exception e) {
-      return ExceptionHandlers.handleModelException(
-          OperationType.REGISTER, request.getName(), schema, e);
+      String modelName = request != null ? request.getName() : "";
+      return ExceptionHandlers.handleModelException(OperationType.REGISTER, modelName, schema, e);
     }
   }
 

--- a/server/src/main/java/org/apache/gravitino/server/web/rest/PermissionOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/PermissionOperations.java
@@ -101,8 +101,9 @@ public class PermissionOperations {
                             metalake, request.getRoleNames(), user))));
           });
     } catch (Exception e) {
+      String roleNames = request != null ? StringUtils.join(request.getRoleNames(), ",") : "";
       return ExceptionHandlers.handleUserPermissionOperationException(
-          OperationType.GRANT, StringUtils.join(request.getRoleNames(), ","), user, e);
+          OperationType.GRANT, roleNames, user, e);
     }
   }
 
@@ -130,8 +131,9 @@ public class PermissionOperations {
                             metalake, request.getRoleNames(), group))));
           });
     } catch (Exception e) {
+      String roleNames = request != null ? StringUtils.join(request.getRoleNames(), ",") : "";
       return ExceptionHandlers.handleGroupPermissionOperationException(
-          OperationType.GRANT, StringUtils.join(request.getRoleNames(), ","), group, e);
+          OperationType.GRANT, roleNames, group, e);
     }
   }
 
@@ -159,8 +161,9 @@ public class PermissionOperations {
                             metalake, request.getRoleNames(), user))));
           });
     } catch (Exception e) {
+      String roleNames = request != null ? StringUtils.join(request.getRoleNames(), ",") : "";
       return ExceptionHandlers.handleUserPermissionOperationException(
-          OperationType.REVOKE, StringUtils.join(request.getRoleNames(), ","), user, e);
+          OperationType.REVOKE, roleNames, user, e);
     }
   }
 
@@ -188,8 +191,9 @@ public class PermissionOperations {
                             metalake, request.getRoleNames(), group))));
           });
     } catch (Exception e) {
+      String roleNames = request != null ? StringUtils.join(request.getRoleNames(), ",") : "";
       return ExceptionHandlers.handleGroupPermissionOperationException(
-          OperationType.REVOKE, StringUtils.join(request.getRoleNames(), ","), group, e);
+          OperationType.REVOKE, roleNames, group, e);
     }
   }
 

--- a/server/src/main/java/org/apache/gravitino/server/web/rest/PolicyOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/PolicyOperations.java
@@ -162,8 +162,8 @@ public class PolicyOperations {
             return Utils.ok(new PolicyResponse(toDTO(policy, Optional.empty())));
           });
     } catch (Exception e) {
-      return ExceptionHandlers.handlePolicyException(
-          OperationType.CREATE, request.getName(), metalake, e);
+      String policyName = request != null ? request.getName() : "";
+      return ExceptionHandlers.handlePolicyException(OperationType.CREATE, policyName, metalake, e);
     }
   }
 
@@ -239,7 +239,8 @@ public class PolicyOperations {
       PolicySetRequest request) {
     LOG.info("Received set policy request for policy: {} under metalake: {}", name, metalake);
 
-    OperationType op = request.isEnable() ? OperationType.ENABLE : OperationType.DISABLE;
+    OperationType op =
+        request != null && request.isEnable() ? OperationType.ENABLE : OperationType.DISABLE;
 
     try {
       return Utils.doAs(
@@ -254,7 +255,7 @@ public class PolicyOperations {
             Response response = Utils.ok(new BaseResponse());
             LOG.info(
                 "Successfully {} policy: {} under metalake: {}",
-                request.isEnable() ? "enabled" : "disabled",
+                op == OperationType.ENABLE ? "enabled" : "disabled",
                 name,
                 metalake);
             return response;

--- a/server/src/main/java/org/apache/gravitino/server/web/rest/RoleOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/RoleOperations.java
@@ -197,8 +197,8 @@ public class RoleOperations {
           });
 
     } catch (Exception e) {
-      return ExceptionHandlers.handleRoleException(
-          OperationType.CREATE, request.getName(), metalake, e);
+      String roleName = request != null ? request.getName() : "";
+      return ExceptionHandlers.handleRoleException(OperationType.CREATE, roleName, metalake, e);
     }
   }
 

--- a/server/src/main/java/org/apache/gravitino/server/web/rest/SchemaOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/SchemaOperations.java
@@ -138,8 +138,8 @@ public class SchemaOperations {
           });
 
     } catch (Exception e) {
-      return ExceptionHandlers.handleSchemaException(
-          OperationType.CREATE, request.getName(), catalog, e);
+      String schemaName = request != null ? request.getName() : "";
+      return ExceptionHandlers.handleSchemaException(OperationType.CREATE, schemaName, catalog, e);
     }
   }
 

--- a/server/src/main/java/org/apache/gravitino/server/web/rest/StatisticOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/StatisticOperations.java
@@ -241,8 +241,8 @@ public class StatisticOperations {
             return Utils.ok(new DropResponse(dropped));
           });
     } catch (Exception e) {
-      return ExceptionHandlers.handleStatisticException(
-          OperationType.DROP, StringUtils.join(request.getNames(), ","), fullName, e);
+      String names = request != null ? StringUtils.join(request.getNames(), ",") : "";
+      return ExceptionHandlers.handleStatisticException(OperationType.DROP, names, fullName, e);
     }
   }
 

--- a/server/src/main/java/org/apache/gravitino/server/web/rest/TableOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/TableOperations.java
@@ -154,8 +154,8 @@ public class TableOperations {
           });
 
     } catch (Exception e) {
-      return ExceptionHandlers.handleTableException(
-          OperationType.CREATE, request.getName(), schema, e);
+      String tableName = request != null ? request.getName() : "";
+      return ExceptionHandlers.handleTableException(OperationType.CREATE, tableName, schema, e);
     }
   }
 

--- a/server/src/main/java/org/apache/gravitino/server/web/rest/TagOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/TagOperations.java
@@ -163,8 +163,8 @@ public class TagOperations {
             return Utils.ok(new TagResponse(DTOConverters.toDTO(tag, Optional.empty())));
           });
     } catch (Exception e) {
-      return ExceptionHandlers.handleTagException(
-          OperationType.CREATE, request.getName(), metalake, e);
+      String tagName = request != null ? request.getName() : "";
+      return ExceptionHandlers.handleTagException(OperationType.CREATE, tagName, metalake, e);
     }
   }
 

--- a/server/src/main/java/org/apache/gravitino/server/web/rest/TopicOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/TopicOperations.java
@@ -150,8 +150,8 @@ public class TopicOperations {
             return response;
           });
     } catch (Exception e) {
-      return ExceptionHandlers.handleTopicException(
-          OperationType.CREATE, request.getName(), schema, e);
+      String topicName = request != null ? request.getName() : "";
+      return ExceptionHandlers.handleTopicException(OperationType.CREATE, topicName, schema, e);
     }
   }
 

--- a/server/src/main/java/org/apache/gravitino/server/web/rest/UserOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/UserOperations.java
@@ -165,8 +165,8 @@ public class UserOperations {
                         accessControlManager.addUser(metalake, request.getName()))));
           });
     } catch (Exception e) {
-      return ExceptionHandlers.handleUserException(
-          OperationType.ADD, request.getName(), metalake, e);
+      String userName = request != null ? request.getName() : "";
+      return ExceptionHandlers.handleUserException(OperationType.ADD, userName, metalake, e);
     }
   }
 

--- a/server/src/test/java/org/apache/gravitino/server/web/rest/TestCatalogOperations.java
+++ b/server/src/test/java/org/apache/gravitino/server/web/rest/TestCatalogOperations.java
@@ -588,6 +588,22 @@ public class TestCatalogOperations extends BaseOperationsTest {
     Assertions.assertEquals(RuntimeException.class.getSimpleName(), errorResponse1.getType());
   }
 
+  @Test
+  public void testCreateCatalogWithNullRequest() {
+    Response resp =
+        target("/metalakes/metalake1/catalogs")
+            .request(MediaType.APPLICATION_JSON_TYPE)
+            .accept("application/vnd.gravitino.v1+json")
+            .post(Entity.entity("null", MediaType.APPLICATION_JSON_TYPE));
+
+    Assertions.assertEquals(INTERNAL_SERVER_ERROR.getStatusCode(), resp.getStatus());
+
+    ErrorResponse errorResponse = resp.readEntity(ErrorResponse.class);
+    Assertions.assertNotNull(
+        errorResponse, "Null request should return a structured error, not crash the handler");
+    Assertions.assertEquals(ErrorConstants.INTERNAL_ERROR_CODE, errorResponse.getCode());
+  }
+
   private static TestCatalog buildCatalog(String metalake, String catalogName) {
     CatalogEntity entity =
         CatalogEntity.builder()

--- a/server/src/test/java/org/apache/gravitino/server/web/rest/TestGroupOperations.java
+++ b/server/src/test/java/org/apache/gravitino/server/web/rest/TestGroupOperations.java
@@ -481,6 +481,23 @@ public class TestGroupOperations extends BaseOperationsTest {
     Assertions.assertEquals(RuntimeException.class.getSimpleName(), errorResponse.getType());
   }
 
+  @Test
+  public void testAddGroupWithNullRequest() {
+    Response resp =
+        target("/metalakes/metalake1/groups")
+            .request(MediaType.APPLICATION_JSON_TYPE)
+            .accept("application/vnd.gravitino.v1+json")
+            .post(Entity.entity("null", MediaType.APPLICATION_JSON_TYPE));
+
+    Assertions.assertEquals(
+        Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), resp.getStatus());
+
+    ErrorResponse errorResponse = resp.readEntity(ErrorResponse.class);
+    Assertions.assertNotNull(
+        errorResponse, "Null request should return a structured error, not crash the handler");
+    Assertions.assertEquals(ErrorConstants.INTERNAL_ERROR_CODE, errorResponse.getCode());
+  }
+
   private Group buildGroup(String group) {
     return GroupEntity.builder()
         .withId(1L)

--- a/server/src/test/java/org/apache/gravitino/server/web/rest/TestJobOperations.java
+++ b/server/src/test/java/org/apache/gravitino/server/web/rest/TestJobOperations.java
@@ -327,6 +327,23 @@ public class TestJobOperations extends JerseyTest {
   }
 
   @Test
+  public void testRegisterJobTemplateWithNullRequest() {
+    Response resp =
+        target(jobTemplatePath())
+            .request(APPLICATION_JSON_TYPE)
+            .accept("application/vnd.gravitino.v1+json")
+            .post(Entity.entity("null", APPLICATION_JSON_TYPE));
+
+    Assertions.assertEquals(
+        Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), resp.getStatus());
+
+    ErrorResponse errorResponse = resp.readEntity(ErrorResponse.class);
+    Assertions.assertNotNull(
+        errorResponse, "Null request should return a structured error, not crash the handler");
+    Assertions.assertEquals(ErrorConstants.INTERNAL_ERROR_CODE, errorResponse.getCode());
+  }
+
+  @Test
   public void testGetJobTemplate() {
     JobTemplateEntity template =
         newShellJobTemplateEntity("shell_template_1", "Test Shell Template 1");

--- a/server/src/test/java/org/apache/gravitino/server/web/rest/TestPermissionOperations.java
+++ b/server/src/test/java/org/apache/gravitino/server/web/rest/TestPermissionOperations.java
@@ -138,6 +138,23 @@ public class TestPermissionOperations extends BaseOperationsTest {
   }
 
   @Test
+  public void testGrantRolesToUserWithNullRequest() {
+    Response resp =
+        target("/metalakes/metalake1/permissions/users/user1/grant/")
+            .request(MediaType.APPLICATION_JSON_TYPE)
+            .accept("application/vnd.gravitino.v1+json")
+            .put(Entity.entity("null", MediaType.APPLICATION_JSON_TYPE));
+
+    Assertions.assertEquals(
+        Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), resp.getStatus());
+
+    ErrorResponse errorResponse = resp.readEntity(ErrorResponse.class);
+    Assertions.assertNotNull(
+        errorResponse, "Null request should return a structured error, not crash the handler");
+    Assertions.assertEquals(ErrorConstants.INTERNAL_ERROR_CODE, errorResponse.getCode());
+  }
+
+  @Test
   public void testGrantRolesToUser() throws IOException {
     UserEntity userEntity =
         UserEntity.builder()


### PR DESCRIPTION
### What changes were proposed in this pull request?

Multiple REST handlers dereference `request` (e.g. `request.getName()`, `request.getRoleNames()`, `request.getJobTemplate().name()`) inside `catch (Exception e)` blocks. When `request` is `null` (e.g. from an empty or malformed POST body), the catch block throws a secondary `NullPointerException` that masks the real failure.

This PR replaces all catch-path request dereferences with null-safe precomputed local variables across 16 REST handler files:

- Simple `getName()` pattern (11 files): Table, Fileset, Function, Model, Schema, Catalog, User, Group, Role, Policy, Tag, Topic
- `getRoleNames()` pattern: PermissionOperations (4 catch sites)
- Nested `getJobTemplate().name()`: JobOperations
- `isInUse()` / `isEnable()` pattern: MetalakeOperations, CatalogOperations, PolicyOperations
- `getNames()` pattern: StatisticOperations

**Note on StatisticOperations scope:** The issue lists 4 methods (`updateStatistics`, `dropStatistics`, `updatePartitionStatistics`, `dropPartitionStatistics`), but only `dropStatistics` is actually vulnerable — the other 3 already use null-safe helpers (`getStatisticNames`, `getPartitionNames`, `getDropPartitionNames`).

### Why are the changes needed?

When `request` is null and an exception occurs in the method body, the catch block tries to dereference `request.get*()`, throwing a secondary NPE that masks the original exception. This makes debugging harder as the real error is lost. The fix ensures catch blocks always preserve the primary error through existing `ExceptionHandlers`.

Additionally, `JobOperations.registerJobTemplate` and `PolicyOperations.setPolicy` had pre-try `request` dereferences (outside the try-catch entirely), meaning a null request would NPE before the catch block could handle it at all.

Reproducible by sending an empty body to any affected endpoint:
```
POST /api/metalakes/m/catalogs/c/schemas
Content-Type: application/json
Accept: application/vnd.gravitino.v1+json
(empty body)
```

Fix: #10172

### Does this PR introduce _any_ user-facing change?

No. Error handling behavior is preserved — endpoints return the same error responses, but the original exception is no longer masked by a secondary NPE.

### How was this patch tested?

- Added null-request-body regression tests covering all main dereference patterns:
  - `TestGroupOperations.testAddGroupWithNullRequest` — `getName()` pattern
  - `TestPermissionOperations.testGrantRolesToUserWithNullRequest` — `getRoleNames()` pattern
  - `TestCatalogOperations.testCreateCatalogWithNullRequest` — `getName()` pattern in CatalogOperations
  - `TestJobOperations.testRegisterJobTemplateWithNullRequest` — nested `getJobTemplate().name()` pattern
- All existing tests pass: `./gradlew :server:test -PskipITs`