### PR TITLE
[Cherry-pick to branch-1.2] [#10844] fix(hive): close HiveClientFactory on pool shutdown (#10854)

### DIFF
--- a/catalogs/hive-metastore-common/src/main/java/org/apache/gravitino/hive/HiveClientPool.java
+++ b/catalogs/hive-metastore-common/src/main/java/org/apache/gravitino/hive/HiveClientPool.java
@@ -18,6 +18,7 @@
  */
 package org.apache.gravitino.hive;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.util.Properties;
 import org.apache.gravitino.exceptions.GravitinoRuntimeException;
 import org.apache.gravitino.hive.client.HiveClient;
@@ -67,6 +68,24 @@ public class HiveClientPool extends ClientPoolImpl<HiveClient, GravitinoRuntimeE
   protected boolean isConnectionException(Exception e) {
     // Pool-level reconnection is not required by design.
     return false;
+  }
+
+  @Override
+  public void close() {
+    if (isClosed()) {
+      return;
+    }
+
+    try {
+      super.close();
+    } finally {
+      closeClientFactory();
+    }
+  }
+
+  @VisibleForTesting
+  void closeClientFactory() {
+    clientFactory.close();
   }
 
   @Override

--- a/catalogs/hive-metastore-common/src/test/java/org/apache/gravitino/hive/TestHiveClientPool.java
+++ b/catalogs/hive-metastore-common/src/test/java/org/apache/gravitino/hive/TestHiveClientPool.java
@@ -90,6 +90,7 @@ public class TestHiveClientPool {
     clients.close();
     assertTrue(clients.isClosed());
     Mockito.verify(hiveClient).close();
+    Mockito.verify(clients).closeClientFactory();
   }
 
   private HiveClient newClient() {


### PR DESCRIPTION
**Cherry-pick Information:**
- Original commit: a22daa068
- Target branch: `branch-1.2`
- Status: ✅ Clean cherry-pick (no conflicts)