### PR TITLE
[#9087] feat(lance): support credential vending for Lance REST Server describeTable

### DIFF
--- a/common/src/main/java/org/apache/gravitino/credential/CredentialPropertyUtils.java
+++ b/common/src/main/java/org/apache/gravitino/credential/CredentialPropertyUtils.java
@@ -51,6 +51,24 @@ public class CredentialPropertyUtils {
 
   private static final String GCS_OAUTH_2_TOKEN_EXPIRES_AT = "gcs.oauth2.token-expires-at";
 
+  // Lance storage_options key constants
+  @VisibleForTesting static final String LANCE_S3_ACCESS_KEY_ID = "aws_access_key_id";
+  @VisibleForTesting static final String LANCE_S3_SECRET_ACCESS_KEY = "aws_secret_access_key";
+  @VisibleForTesting static final String LANCE_S3_SESSION_TOKEN = "aws_session_token";
+  @VisibleForTesting static final String LANCE_OSS_ACCESS_KEY_ID = "oss_access_key_id";
+  @VisibleForTesting static final String LANCE_OSS_SECRET_ACCESS_KEY = "oss_secret_access_key";
+  @VisibleForTesting static final String LANCE_OSS_SECURITY_TOKEN = "oss_security_token";
+  @VisibleForTesting static final String LANCE_GCS_TOKEN = "google_storage_token";
+  @VisibleForTesting static final String LANCE_AZURE_SAS_TOKEN = "azure_storage_sas_token";
+
+  @VisibleForTesting
+  static final String LANCE_AZURE_STORAGE_ACCOUNT_NAME = "azure_storage_account_name";
+
+  @VisibleForTesting
+  static final String LANCE_AZURE_STORAGE_ACCOUNT_KEY = "azure_storage_account_key";
+
+  @VisibleForTesting static final String LANCE_EXPIRES_AT_MILLIS = "expires_at_millis";
+
   private static Map<String, String> icebergCredentialPropertyMap =
       ImmutableMap.<String, String>builder()
           .put(GCSTokenCredential.GCS_TOKEN_NAME, ICEBERG_GCS_TOKEN)
@@ -73,6 +91,31 @@ public class CredentialPropertyUtils {
           .put(AwsIrsaCredential.ACCESS_KEY_ID, ICEBERG_S3_ACCESS_KEY_ID)
           .put(AwsIrsaCredential.SECRET_ACCESS_KEY, ICEBERG_S3_SECRET_ACCESS_KEY)
           .put(AwsIrsaCredential.SESSION_TOKEN, ICEBERG_S3_TOKEN)
+          .build();
+
+  private static Map<String, String> lanceCredentialPropertyMap =
+      ImmutableMap.<String, String>builder()
+          .put(S3SecretKeyCredential.GRAVITINO_S3_STATIC_ACCESS_KEY_ID, LANCE_S3_ACCESS_KEY_ID)
+          .put(
+              S3SecretKeyCredential.GRAVITINO_S3_STATIC_SECRET_ACCESS_KEY,
+              LANCE_S3_SECRET_ACCESS_KEY)
+          .put(S3TokenCredential.GRAVITINO_S3_TOKEN, LANCE_S3_SESSION_TOKEN)
+          .put(OSSTokenCredential.GRAVITINO_OSS_SESSION_ACCESS_KEY_ID, LANCE_OSS_ACCESS_KEY_ID)
+          .put(
+              OSSTokenCredential.GRAVITINO_OSS_SESSION_SECRET_ACCESS_KEY,
+              LANCE_OSS_SECRET_ACCESS_KEY)
+          .put(OSSTokenCredential.GRAVITINO_OSS_TOKEN, LANCE_OSS_SECURITY_TOKEN)
+          .put(GCSTokenCredential.GCS_TOKEN_NAME, LANCE_GCS_TOKEN)
+          .put(ADLSTokenCredential.GRAVITINO_ADLS_SAS_TOKEN, LANCE_AZURE_SAS_TOKEN)
+          .put(
+              ADLSTokenCredential.GRAVITINO_AZURE_STORAGE_ACCOUNT_NAME,
+              LANCE_AZURE_STORAGE_ACCOUNT_NAME)
+          .put(
+              AzureAccountKeyCredential.GRAVITINO_AZURE_STORAGE_ACCOUNT_KEY,
+              LANCE_AZURE_STORAGE_ACCOUNT_KEY)
+          .put(AwsIrsaCredential.ACCESS_KEY_ID, LANCE_S3_ACCESS_KEY_ID)
+          .put(AwsIrsaCredential.SECRET_ACCESS_KEY, LANCE_S3_SECRET_ACCESS_KEY)
+          .put(AwsIrsaCredential.SESSION_TOKEN, LANCE_S3_SESSION_TOKEN)
           .build();
 
   /**
@@ -135,6 +178,24 @@ public class CredentialPropertyUtils {
                 !credentialPropertyKeys.contains(entry.getKey())
                     && !entry.getKey().startsWith(ICEBERG_ADLS_TOKEN));
     return filteredProperties;
+  }
+
+  /**
+   * Transforms a specific credential into a map of Lance storage_options properties.
+   *
+   * @param credential the credential to be transformed into Lance storage_options properties
+   * @return a map of Lance storage_options properties derived from the credential
+   */
+  public static Map<String, String> toLanceProperties(Credential credential) {
+    Map<String, String> properties =
+        new HashMap<>(transformProperties(credential.credentialInfo(), lanceCredentialPropertyMap));
+
+    long expireTimeInMs = credential.expireTimeInMs();
+    if (expireTimeInMs > 0) {
+      properties.put(LANCE_EXPIRES_AT_MILLIS, String.valueOf(expireTimeInMs));
+    }
+
+    return properties;
   }
 
   private static Map<String, String> transformProperties(

--- a/common/src/test/java/org/apache/gravitino/credential/TestCredentialPropertiesUtils.java
+++ b/common/src/test/java/org/apache/gravitino/credential/TestCredentialPropertiesUtils.java
@@ -90,4 +90,117 @@ public class TestCredentialPropertiesUtils {
     Map<String, String> expectedProperties = ImmutableMap.of(sasTokenKey, sasToken);
     Assertions.assertEquals(expectedProperties, icebergProperties);
   }
+
+  @Test
+  void testToLancePropertiesS3Token() {
+    S3TokenCredential credential = new S3TokenCredential("key", "secret", "token", 1000);
+    Map<String, String> lanceProperties = CredentialPropertyUtils.toLanceProperties(credential);
+
+    Assertions.assertEquals(
+        "key", lanceProperties.get(CredentialPropertyUtils.LANCE_S3_ACCESS_KEY_ID));
+    Assertions.assertEquals(
+        "secret", lanceProperties.get(CredentialPropertyUtils.LANCE_S3_SECRET_ACCESS_KEY));
+    Assertions.assertEquals(
+        "token", lanceProperties.get(CredentialPropertyUtils.LANCE_S3_SESSION_TOKEN));
+    Assertions.assertEquals(
+        "1000", lanceProperties.get(CredentialPropertyUtils.LANCE_EXPIRES_AT_MILLIS));
+    Assertions.assertEquals(4, lanceProperties.size());
+  }
+
+  @Test
+  void testToLancePropertiesS3SecretKey() {
+    S3SecretKeyCredential credential = new S3SecretKeyCredential("key", "secret");
+    Map<String, String> lanceProperties = CredentialPropertyUtils.toLanceProperties(credential);
+
+    Assertions.assertEquals(
+        "key", lanceProperties.get(CredentialPropertyUtils.LANCE_S3_ACCESS_KEY_ID));
+    Assertions.assertEquals(
+        "secret", lanceProperties.get(CredentialPropertyUtils.LANCE_S3_SECRET_ACCESS_KEY));
+    Assertions.assertNull(lanceProperties.get(CredentialPropertyUtils.LANCE_EXPIRES_AT_MILLIS));
+    Assertions.assertEquals(2, lanceProperties.size());
+  }
+
+  @Test
+  void testToLancePropertiesOSSToken() {
+    OSSTokenCredential credential = new OSSTokenCredential("key", "secret", "security-token", 2000);
+    Map<String, String> lanceProperties = CredentialPropertyUtils.toLanceProperties(credential);
+
+    Assertions.assertEquals(
+        "key", lanceProperties.get(CredentialPropertyUtils.LANCE_OSS_ACCESS_KEY_ID));
+    Assertions.assertEquals(
+        "secret", lanceProperties.get(CredentialPropertyUtils.LANCE_OSS_SECRET_ACCESS_KEY));
+    Assertions.assertEquals(
+        "security-token", lanceProperties.get(CredentialPropertyUtils.LANCE_OSS_SECURITY_TOKEN));
+    Assertions.assertEquals(
+        "2000", lanceProperties.get(CredentialPropertyUtils.LANCE_EXPIRES_AT_MILLIS));
+    Assertions.assertEquals(4, lanceProperties.size());
+  }
+
+  @Test
+  void testToLancePropertiesOSSSecretKey() {
+    OSSSecretKeyCredential credential = new OSSSecretKeyCredential("key", "secret");
+    Map<String, String> lanceProperties = CredentialPropertyUtils.toLanceProperties(credential);
+
+    Assertions.assertEquals(
+        "key", lanceProperties.get(CredentialPropertyUtils.LANCE_OSS_ACCESS_KEY_ID));
+    Assertions.assertEquals(
+        "secret", lanceProperties.get(CredentialPropertyUtils.LANCE_OSS_SECRET_ACCESS_KEY));
+    Assertions.assertNull(lanceProperties.get(CredentialPropertyUtils.LANCE_EXPIRES_AT_MILLIS));
+    Assertions.assertEquals(2, lanceProperties.size());
+  }
+
+  @Test
+  void testToLancePropertiesGCSToken() {
+    GCSTokenCredential credential = new GCSTokenCredential("gcs-token", 3000);
+    Map<String, String> lanceProperties = CredentialPropertyUtils.toLanceProperties(credential);
+
+    Assertions.assertEquals(
+        "gcs-token", lanceProperties.get(CredentialPropertyUtils.LANCE_GCS_TOKEN));
+    Assertions.assertEquals(
+        "3000", lanceProperties.get(CredentialPropertyUtils.LANCE_EXPIRES_AT_MILLIS));
+    Assertions.assertEquals(2, lanceProperties.size());
+  }
+
+  @Test
+  void testToLancePropertiesADLSToken() {
+    ADLSTokenCredential credential = new ADLSTokenCredential("account", "sas-token", 4000);
+    Map<String, String> lanceProperties = CredentialPropertyUtils.toLanceProperties(credential);
+
+    Assertions.assertEquals(
+        "sas-token", lanceProperties.get(CredentialPropertyUtils.LANCE_AZURE_SAS_TOKEN));
+    Assertions.assertEquals(
+        "account", lanceProperties.get(CredentialPropertyUtils.LANCE_AZURE_STORAGE_ACCOUNT_NAME));
+    Assertions.assertEquals(
+        "4000", lanceProperties.get(CredentialPropertyUtils.LANCE_EXPIRES_AT_MILLIS));
+    Assertions.assertEquals(3, lanceProperties.size());
+  }
+
+  @Test
+  void testToLancePropertiesAzureAccountKey() {
+    AzureAccountKeyCredential credential = new AzureAccountKeyCredential("account", "key-value");
+    Map<String, String> lanceProperties = CredentialPropertyUtils.toLanceProperties(credential);
+
+    Assertions.assertEquals(
+        "account", lanceProperties.get(CredentialPropertyUtils.LANCE_AZURE_STORAGE_ACCOUNT_NAME));
+    Assertions.assertEquals(
+        "key-value", lanceProperties.get(CredentialPropertyUtils.LANCE_AZURE_STORAGE_ACCOUNT_KEY));
+    Assertions.assertNull(lanceProperties.get(CredentialPropertyUtils.LANCE_EXPIRES_AT_MILLIS));
+    Assertions.assertEquals(2, lanceProperties.size());
+  }
+
+  @Test
+  void testToLancePropertiesAwsIrsa() {
+    AwsIrsaCredential credential = new AwsIrsaCredential("key", "secret", "session", 5000);
+    Map<String, String> lanceProperties = CredentialPropertyUtils.toLanceProperties(credential);
+
+    Assertions.assertEquals(
+        "key", lanceProperties.get(CredentialPropertyUtils.LANCE_S3_ACCESS_KEY_ID));
+    Assertions.assertEquals(
+        "secret", lanceProperties.get(CredentialPropertyUtils.LANCE_S3_SECRET_ACCESS_KEY));
+    Assertions.assertEquals(
+        "session", lanceProperties.get(CredentialPropertyUtils.LANCE_S3_SESSION_TOKEN));
+    Assertions.assertEquals(
+        "5000", lanceProperties.get(CredentialPropertyUtils.LANCE_EXPIRES_AT_MILLIS));
+    Assertions.assertEquals(4, lanceProperties.size());
+  }
 }

--- a/lance/lance-common/src/main/java/org/apache/gravitino/lance/common/ops/LanceTableOperations.java
+++ b/lance/lance-common/src/main/java/org/apache/gravitino/lance/common/ops/LanceTableOperations.java
@@ -20,6 +20,8 @@ package org.apache.gravitino.lance.common.ops;
 
 import java.util.Map;
 import java.util.Optional;
+import javax.annotation.Nullable;
+import org.apache.gravitino.credential.CredentialPrivilege;
 import org.lance.namespace.model.CreateEmptyTableResponse;
 import org.lance.namespace.model.CreateTableResponse;
 import org.lance.namespace.model.DeclareTableResponse;
@@ -36,9 +38,15 @@ public interface LanceTableOperations {
    * @param tableId table ids are in the format of "{namespace}{delimiter}{table_name}"
    * @param delimiter the delimiter used in the namespace
    * @param version the version of the table to describe, if null, describe the latest version
+   * @param credentialPrivilege the privilege level for vended credentials, null means no credential
+   *     vending
    * @return the table description
    */
-  DescribeTableResponse describeTable(String tableId, String delimiter, Optional<Long> version);
+  DescribeTableResponse describeTable(
+      String tableId,
+      String delimiter,
+      Optional<Long> version,
+      @Nullable CredentialPrivilege credentialPrivilege);
 
   /**
    * Create a new table.

--- a/lance/lance-common/src/main/java/org/apache/gravitino/lance/common/ops/LanceTableOperations.java
+++ b/lance/lance-common/src/main/java/org/apache/gravitino/lance/common/ops/LanceTableOperations.java
@@ -20,7 +20,6 @@ package org.apache.gravitino.lance.common.ops;
 
 import java.util.Map;
 import java.util.Optional;
-import javax.annotation.Nullable;
 import org.apache.gravitino.credential.CredentialPrivilege;
 import org.lance.namespace.model.CreateEmptyTableResponse;
 import org.lance.namespace.model.CreateTableResponse;
@@ -38,15 +37,15 @@ public interface LanceTableOperations {
    * @param tableId table ids are in the format of "{namespace}{delimiter}{table_name}"
    * @param delimiter the delimiter used in the namespace
    * @param version the version of the table to describe, if null, describe the latest version
-   * @param credentialPrivilege the privilege level for vended credentials, null means no credential
-   *     vending
+   * @param credentialPrivilege the privilege level for vended credentials, empty means no
+   *     credential vending
    * @return the table description
    */
   DescribeTableResponse describeTable(
       String tableId,
       String delimiter,
       Optional<Long> version,
-      @Nullable CredentialPrivilege credentialPrivilege);
+      Optional<CredentialPrivilege> credentialPrivilege);
 
   /**
    * Create a new table.

--- a/lance/lance-common/src/main/java/org/apache/gravitino/lance/common/ops/gravitino/GravitinoLanceNamespaceWrapper.java
+++ b/lance/lance-common/src/main/java/org/apache/gravitino/lance/common/ops/gravitino/GravitinoLanceNamespaceWrapper.java
@@ -105,6 +105,13 @@ public class GravitinoLanceNamespaceWrapper extends NamespaceWrapper {
 
   @Override
   public void close() {
+    if (tableOperations != null) {
+      try {
+        ((GravitinoLanceTableOperations) tableOperations).close();
+      } catch (Exception e) {
+        LOG.warn("Error closing table operations", e);
+      }
+    }
     if (client != null) {
       try {
         client.close();

--- a/lance/lance-common/src/main/java/org/apache/gravitino/lance/common/ops/gravitino/GravitinoLanceTableOperations.java
+++ b/lance/lance-common/src/main/java/org/apache/gravitino/lance/common/ops/gravitino/GravitinoLanceTableOperations.java
@@ -164,7 +164,8 @@ public class GravitinoLanceTableOperations implements LanceTableOperations {
           buildVendedStorageOptions(catalogName, catalog, table, credentialPrivilege));
     } else {
       response.setStorageOptions(
-          LancePropertiesUtils.resolveLanceStorageOptions(catalog.properties(), table.properties()));
+          LancePropertiesUtils.resolveLanceStorageOptions(
+              catalog.properties(), table.properties()));
     }
     return response;
   }
@@ -190,12 +191,13 @@ public class GravitinoLanceTableOperations implements LanceTableOperations {
 
     Credential credential;
     try {
-      credential = credManager.getCredential(context);
+      credential = credManager.getCredentialByPath(tableLocation, context);
     } catch (IllegalArgumentException e) {
       LOG.debug(
           "No credential providers configured for catalog {}, falling back to original storage options",
           catalogName);
-      return LancePropertiesUtils.resolveLanceStorageOptions(catalog.properties(), table.properties());
+      return LancePropertiesUtils.resolveLanceStorageOptions(
+          catalog.properties(), table.properties());
     }
 
     if (credential == null) {

--- a/lance/lance-common/src/main/java/org/apache/gravitino/lance/common/ops/gravitino/GravitinoLanceTableOperations.java
+++ b/lance/lance-common/src/main/java/org/apache/gravitino/lance/common/ops/gravitino/GravitinoLanceTableOperations.java
@@ -29,18 +29,27 @@ import static org.apache.gravitino.rel.Column.DEFAULT_VALUE_NOT_SET;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.gravitino.Catalog;
 import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.credential.CatalogCredentialManager;
+import org.apache.gravitino.credential.Credential;
+import org.apache.gravitino.credential.CredentialPrivilege;
+import org.apache.gravitino.credential.CredentialPropertyUtils;
+import org.apache.gravitino.credential.PathBasedCredentialContext;
 import org.apache.gravitino.exceptions.NoSuchTableException;
 import org.apache.gravitino.lance.common.ops.LanceTableOperations;
 import org.apache.gravitino.lance.common.ops.gravitino.GravitinoLanceTableAlterHandler.AlterColumnsGravitinoLance;
@@ -50,6 +59,8 @@ import org.apache.gravitino.lance.common.utils.LancePropertiesUtils;
 import org.apache.gravitino.rel.Column;
 import org.apache.gravitino.rel.Table;
 import org.apache.gravitino.rel.TableChange;
+import org.apache.gravitino.utils.PrincipalUtils;
+import org.lance.namespace.errors.ServiceUnavailableException;
 import org.lance.namespace.errors.TableNotFoundException;
 import org.lance.namespace.model.AlterTableAlterColumnsRequest;
 import org.lance.namespace.model.AlterTableDropColumnsRequest;
@@ -75,6 +86,9 @@ public class GravitinoLanceTableOperations implements LanceTableOperations {
 
   private final GravitinoLanceNamespaceWrapper namespaceWrapper;
 
+  private final ConcurrentHashMap<String, CatalogCredentialManager> credentialManagers =
+      new ConcurrentHashMap<>();
+
   private enum CreateMode {
     CREATE,
     EXIST_OK,
@@ -98,9 +112,23 @@ public class GravitinoLanceTableOperations implements LanceTableOperations {
     this.namespaceWrapper = namespaceWrapper;
   }
 
+  public void close() {
+    for (Map.Entry<String, CatalogCredentialManager> entry : credentialManagers.entrySet()) {
+      try {
+        entry.getValue().close();
+      } catch (Exception e) {
+        LOG.warn("Error closing credential manager for catalog {}", entry.getKey(), e);
+      }
+    }
+    credentialManagers.clear();
+  }
+
   @Override
   public DescribeTableResponse describeTable(
-      String tableId, String delimiter, Optional<Long> version) {
+      String tableId,
+      String delimiter,
+      Optional<Long> version,
+      @Nullable CredentialPrivilege credentialPrivilege) {
     if (!version.isEmpty()) {
       throw new UnsupportedOperationException(
           "Describing specific table version is not supported. It should be null to indicate the"
@@ -131,9 +159,58 @@ public class GravitinoLanceTableOperations implements LanceTableOperations {
         Optional.ofNullable(table.properties().get(LANCE_TABLE_VERSION))
             .map(Long::valueOf)
             .orElse(null));
-    response.setStorageOptions(
-        LancePropertiesUtils.resolveLanceStorageOptions(catalog.properties(), table.properties()));
+    if (credentialPrivilege != null) {
+      response.setStorageOptions(
+          buildVendedStorageOptions(catalogName, catalog, table, credentialPrivilege));
+    } else {
+      response.setStorageOptions(
+          LancePropertiesUtils.resolveLanceStorageOptions(catalog.properties(), table.properties()));
+    }
     return response;
+  }
+
+  private Map<String, String> buildVendedStorageOptions(
+      String catalogName, Catalog catalog, Table table, CredentialPrivilege credentialPrivilege) {
+    String tableLocation = table.properties().get(LANCE_LOCATION);
+    Preconditions.checkArgument(
+        tableLocation != null && !tableLocation.isEmpty(),
+        "Table location is required for credential vending");
+
+    ImmutableSet<String> paths = ImmutableSet.of(tableLocation);
+    String userName = PrincipalUtils.getCurrentUserName();
+
+    PathBasedCredentialContext context =
+        credentialPrivilege == CredentialPrivilege.WRITE
+            ? new PathBasedCredentialContext(userName, paths, ImmutableSet.of())
+            : new PathBasedCredentialContext(userName, ImmutableSet.of(), paths);
+
+    CatalogCredentialManager credManager =
+        credentialManagers.computeIfAbsent(
+            catalogName, name -> new CatalogCredentialManager(name, catalog.properties()));
+
+    Credential credential;
+    try {
+      credential = credManager.getCredential(context);
+    } catch (IllegalArgumentException e) {
+      LOG.debug(
+          "No credential providers configured for catalog {}, falling back to original storage options",
+          catalogName);
+      return LancePropertiesUtils.resolveLanceStorageOptions(catalog.properties(), table.properties());
+    }
+
+    if (credential == null) {
+      LOG.warn("Failed to generate credential for table: {}", tableLocation);
+      throw new ServiceUnavailableException(
+          "Couldn't generate credential for table: " + tableLocation);
+    }
+
+    Map<String, String> baseStorageOptions =
+        LancePropertiesUtils.resolveLanceStorageOptions(catalog.properties(), table.properties());
+    Map<String, String> vendedProperties = CredentialPropertyUtils.toLanceProperties(credential);
+
+    Map<String, String> mergedOptions = new HashMap<>(baseStorageOptions);
+    mergedOptions.putAll(vendedProperties);
+    return mergedOptions;
   }
 
   @Override

--- a/lance/lance-common/src/main/java/org/apache/gravitino/lance/common/ops/gravitino/GravitinoLanceTableOperations.java
+++ b/lance/lance-common/src/main/java/org/apache/gravitino/lance/common/ops/gravitino/GravitinoLanceTableOperations.java
@@ -41,7 +41,6 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-import javax.annotation.Nullable;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.gravitino.Catalog;
 import org.apache.gravitino.NameIdentifier;
@@ -128,7 +127,7 @@ public class GravitinoLanceTableOperations implements LanceTableOperations {
       String tableId,
       String delimiter,
       Optional<Long> version,
-      @Nullable CredentialPrivilege credentialPrivilege) {
+      Optional<CredentialPrivilege> credentialPrivilege) {
     if (!version.isEmpty()) {
       throw new UnsupportedOperationException(
           "Describing specific table version is not supported. It should be null to indicate the"
@@ -139,8 +138,7 @@ public class GravitinoLanceTableOperations implements LanceTableOperations {
     Preconditions.checkArgument(
         nsId.levels() == 3, "Expected at 3-level namespace but got: %s", nsId.levels());
 
-    String catalogName = nsId.levelAtListPos(0);
-    Catalog catalog = namespaceWrapper.loadAndValidateLakehouseCatalog(catalogName);
+    Catalog catalog = namespaceWrapper.loadAndValidateLakehouseCatalog(nsId.levelAtListPos(0));
     NameIdentifier tableIdentifier =
         NameIdentifier.of(nsId.levelAtListPos(1), nsId.levelAtListPos(2));
 
@@ -159,9 +157,9 @@ public class GravitinoLanceTableOperations implements LanceTableOperations {
         Optional.ofNullable(table.properties().get(LANCE_TABLE_VERSION))
             .map(Long::valueOf)
             .orElse(null));
-    if (credentialPrivilege != null) {
+    if (credentialPrivilege.isPresent()) {
       response.setStorageOptions(
-          buildVendedStorageOptions(catalogName, catalog, table, credentialPrivilege));
+          buildVendedStorageOptions(catalog, table, credentialPrivilege.get()));
     } else {
       response.setStorageOptions(
           LancePropertiesUtils.resolveLanceStorageOptions(
@@ -171,7 +169,7 @@ public class GravitinoLanceTableOperations implements LanceTableOperations {
   }
 
   private Map<String, String> buildVendedStorageOptions(
-      String catalogName, Catalog catalog, Table table, CredentialPrivilege credentialPrivilege) {
+      Catalog catalog, Table table, CredentialPrivilege credentialPrivilege) {
     String tableLocation = table.properties().get(LANCE_LOCATION);
     Preconditions.checkArgument(
         tableLocation != null && !tableLocation.isEmpty(),
@@ -187,7 +185,7 @@ public class GravitinoLanceTableOperations implements LanceTableOperations {
 
     CatalogCredentialManager credManager =
         credentialManagers.computeIfAbsent(
-            catalogName, name -> new CatalogCredentialManager(name, catalog.properties()));
+            catalog.name(), name -> new CatalogCredentialManager(name, catalog.properties()));
 
     Credential credential;
     try {
@@ -195,7 +193,7 @@ public class GravitinoLanceTableOperations implements LanceTableOperations {
     } catch (IllegalArgumentException e) {
       LOG.debug(
           "No credential providers configured for catalog {}, falling back to original storage options",
-          catalogName);
+          catalog.name());
       return LancePropertiesUtils.resolveLanceStorageOptions(
           catalog.properties(), table.properties());
     }

--- a/lance/lance-rest-server/src/main/java/org/apache/gravitino/lance/service/rest/LanceTableOperations.java
+++ b/lance/lance-rest-server/src/main/java/org/apache/gravitino/lance/service/rest/LanceTableOperations.java
@@ -29,6 +29,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
 import java.util.Map;
 import java.util.Optional;
+import java.util.regex.Pattern;
 import javax.inject.Inject;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DefaultValue;
@@ -43,11 +44,16 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.gravitino.Entity;
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.credential.CredentialPrivilege;
 import org.apache.gravitino.lance.common.ops.NamespaceWrapper;
 import org.apache.gravitino.lance.common.utils.LanceConstants;
 import org.apache.gravitino.lance.common.utils.SerializationUtils;
 import org.apache.gravitino.lance.service.LanceExceptionMapper;
 import org.apache.gravitino.metrics.MetricNames;
+import org.apache.gravitino.server.authorization.MetadataAuthzHelper;
+import org.apache.gravitino.server.authorization.expression.AuthorizationExpressionConstants;
 import org.lance.namespace.errors.TableNotFoundException;
 import org.lance.namespace.model.AlterColumnsEntry;
 import org.lance.namespace.model.AlterTableAlterColumnsRequest;
@@ -90,14 +96,36 @@ public class LanceTableOperations {
       DescribeTableRequest request) {
     try {
       validateDescribeTableRequest(request);
+      boolean vendCredentials =
+          request.getVendCredentials() == null || Boolean.TRUE.equals(request.getVendCredentials());
+      CredentialPrivilege privilege =
+          vendCredentials ? getCredentialPrivilege(tableId, delimiter) : null;
       DescribeTableResponse response =
           lanceNamespace
               .asTableOps()
-              .describeTable(tableId, delimiter, Optional.ofNullable(request.getVersion()));
+              .describeTable(
+                  tableId, delimiter, Optional.ofNullable(request.getVersion()), privilege);
       return Response.ok(response).build();
     } catch (Exception e) {
       return LanceExceptionMapper.toRESTResponse(tableId, e);
     }
+  }
+
+  private CredentialPrivilege getCredentialPrivilege(String tableId, String delimiter) {
+    String[] parts = tableId.split(Pattern.quote(delimiter));
+    if (parts.length != 3) {
+      throw new IllegalArgumentException(
+          "Expected 3-level namespace (catalog/schema/table) but got: " + tableId);
+    }
+
+    String metalake = lanceNamespace.config().getGravitinoMetalake();
+    NameIdentifier identifier = NameIdentifier.of(metalake, parts[0], parts[1], parts[2]);
+    boolean writable =
+        MetadataAuthzHelper.checkAccess(
+            identifier,
+            Entity.EntityType.TABLE,
+            AuthorizationExpressionConstants.FILTER_MODIFY_TABLE_AUTHORIZATION_EXPRESSION);
+    return writable ? CredentialPrivilege.WRITE : CredentialPrivilege.READ;
   }
 
   @POST

--- a/lance/lance-rest-server/src/main/java/org/apache/gravitino/lance/service/rest/LanceTableOperations.java
+++ b/lance/lance-rest-server/src/main/java/org/apache/gravitino/lance/service/rest/LanceTableOperations.java
@@ -104,7 +104,10 @@ public class LanceTableOperations {
           lanceNamespace
               .asTableOps()
               .describeTable(
-                  tableId, delimiter, Optional.ofNullable(request.getVersion()), privilege);
+                  tableId,
+                  delimiter,
+                  Optional.ofNullable(request.getVersion()),
+                  Optional.ofNullable(privilege));
       return Response.ok(response).build();
     } catch (Exception e) {
       return LanceExceptionMapper.toRESTResponse(tableId, e);

--- a/lance/lance-rest-server/src/test/java/org/apache/gravitino/lance/integration/test/LanceRESTServiceIT.java
+++ b/lance/lance-rest-server/src/test/java/org/apache/gravitino/lance/integration/test/LanceRESTServiceIT.java
@@ -44,13 +44,16 @@ import org.apache.gravitino.Schema;
 import org.apache.gravitino.client.GravitinoMetalake;
 import org.apache.gravitino.integration.test.util.BaseIT;
 import org.apache.gravitino.integration.test.util.GravitinoITUtils;
+import org.apache.gravitino.integration.test.util.ITUtils;
 import org.apache.gravitino.json.JsonUtils;
 import org.apache.gravitino.lance.common.utils.ArrowUtils;
 import org.apache.gravitino.lance.common.utils.LanceConstants;
+import org.apache.gravitino.lance.service.extension.LanceDummyCredentialProvider;
 import org.apache.gravitino.rel.Table;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.lance.namespace.LanceNamespace;
@@ -1002,6 +1005,63 @@ public class LanceRESTServiceIT extends BaseIT {
     Assertions.assertEquals(anotherLocation, anotherResponse.getLocation());
     // Will not touch storage, so the path should not be created.
     Assertions.assertFalse(new File(anotherLocation).exists());
+  }
+
+  @Test
+  void testDescribeTableWithCredentialVending() {
+    // Skip in deploy mode: the dummy credential provider is only available in test classpath
+    Assumptions.assumeTrue(
+        ITUtils.EMBEDDED_TEST_MODE.equals(testMode),
+        "Credential vending IT only runs in embedded mode");
+
+    // Create a catalog with credential-providers configured to use the dummy provider
+    String credCatalogName = GravitinoITUtils.genRandomName("lance_cred_catalog");
+    Map<String, String> credCatalogProps =
+        new HashMap<>() {
+          {
+            put("credential-providers", LanceDummyCredentialProvider.CREDENTIAL_TYPE);
+          }
+        };
+    Catalog credCatalog =
+        metalake.createCatalog(
+            credCatalogName,
+            Catalog.Type.RELATIONAL,
+            "lakehouse-generic",
+            "catalog for credential vending test",
+            credCatalogProps);
+
+    // Create schema
+    String credSchemaName = GravitinoITUtils.genRandomName("lance_cred_schema");
+    credCatalog.asSchemas().createSchema(credSchemaName, null, null);
+
+    // Create an empty table with a location
+    String tableName = GravitinoITUtils.genRandomName("lance_cred_table");
+    String tableLocation = tempDir + "/" + tableName + "/";
+    List<String> ids = List.of(credCatalogName, credSchemaName, tableName);
+
+    CreateEmptyTableRequest createRequest = new CreateEmptyTableRequest();
+    createRequest.setId(ids);
+    createRequest.setLocation(tableLocation);
+    CreateEmptyTableResponse createResponse = ns.createEmptyTable(createRequest);
+    Assertions.assertNotNull(createResponse);
+    Assertions.assertEquals(tableLocation, createResponse.getLocation());
+
+    // Describe table with vendCredentials = true (explicit)
+    DescribeTableRequest describeRequest = new DescribeTableRequest();
+    describeRequest.setId(ids);
+    describeRequest.setVendCredentials(true);
+
+    DescribeTableResponse response = ns.describeTable(describeRequest);
+    Assertions.assertNotNull(response);
+    Assertions.assertEquals(tableLocation, response.getLocation());
+
+    // Verify vended credentials are present in storage options
+    Map<String, String> storageOptions = response.getStorageOptions();
+    Assertions.assertNotNull(storageOptions);
+    Assertions.assertEquals("test-access-key-id", storageOptions.get("aws_access_key_id"));
+    Assertions.assertEquals("test-secret-access-key", storageOptions.get("aws_secret_access_key"));
+    Assertions.assertEquals("test-session-token", storageOptions.get("aws_session_token"));
+    Assertions.assertEquals("3600000", storageOptions.get("expires_at_millis"));
   }
 
   private CreateTableResponse createTable(

--- a/lance/lance-rest-server/src/test/java/org/apache/gravitino/lance/service/extension/LanceDummyCredentialProvider.java
+++ b/lance/lance-rest-server/src/test/java/org/apache/gravitino/lance/service/extension/LanceDummyCredentialProvider.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.lance.service.extension;
+
+import java.io.IOException;
+import java.util.Map;
+import javax.annotation.Nullable;
+import org.apache.gravitino.credential.Credential;
+import org.apache.gravitino.credential.CredentialContext;
+import org.apache.gravitino.credential.CredentialProvider;
+import org.apache.gravitino.credential.S3TokenCredential;
+
+/**
+ * A test credential provider that returns a fixed S3TokenCredential. Used in IT tests to verify
+ * credential vending without requiring real AWS infrastructure.
+ */
+public class LanceDummyCredentialProvider implements CredentialProvider {
+
+  public static final String CREDENTIAL_TYPE = "lance-dummy-test";
+  private static final String DUMMY_AK = "test-access-key-id";
+  private static final String DUMMY_SK = "test-secret-access-key";
+  private static final String DUMMY_TOKEN = "test-session-token";
+  private static final long DUMMY_EXPIRE_MS = 3600000L;
+
+  @Override
+  public void initialize(Map<String, String> properties) {}
+
+  @Override
+  public String credentialType() {
+    return CREDENTIAL_TYPE;
+  }
+
+  @Nullable
+  @Override
+  public Credential getCredential(CredentialContext context) {
+    return new S3TokenCredential(DUMMY_AK, DUMMY_SK, DUMMY_TOKEN, DUMMY_EXPIRE_MS);
+  }
+
+  @Override
+  public void close() throws IOException {}
+}

--- a/lance/lance-rest-server/src/test/java/org/apache/gravitino/lance/service/rest/TestGravitinoLanceTableOpsCredentialVending.java
+++ b/lance/lance-rest-server/src/test/java/org/apache/gravitino/lance/service/rest/TestGravitinoLanceTableOpsCredentialVending.java
@@ -1,0 +1,232 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.lance.service.rest;
+
+import static org.apache.gravitino.lance.common.utils.LanceConstants.LANCE_LOCATION;
+import static org.apache.gravitino.lance.common.utils.LanceConstants.LANCE_TABLE_VERSION;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import org.apache.gravitino.Catalog;
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.credential.CatalogCredentialManager;
+import org.apache.gravitino.credential.CredentialPrivilege;
+import org.apache.gravitino.credential.PathBasedCredentialContext;
+import org.apache.gravitino.credential.S3TokenCredential;
+import org.apache.gravitino.lance.common.ops.gravitino.GravitinoLanceNamespaceWrapper;
+import org.apache.gravitino.lance.common.ops.gravitino.GravitinoLanceTableOperations;
+import org.apache.gravitino.rel.Column;
+import org.apache.gravitino.rel.Table;
+import org.apache.gravitino.rel.TableCatalog;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.lance.namespace.errors.ServiceUnavailableException;
+import org.lance.namespace.model.DescribeTableResponse;
+import org.mockito.ArgumentCaptor;
+
+class TestGravitinoLanceTableOpsCredentialVending {
+
+  private static final String CATALOG_NAME = "testCatalog";
+  private static final String SCHEMA_NAME = "testSchema";
+  private static final String TABLE_NAME = "testTable";
+  private static final String TABLE_ID = CATALOG_NAME + "$" + SCHEMA_NAME + "$" + TABLE_NAME;
+  private static final String DELIMITER = "$";
+  private static final String TABLE_LOCATION = "s3://test-bucket/path/to/table";
+
+  private GravitinoLanceNamespaceWrapper namespaceWrapper;
+  private Catalog catalog;
+  private TableCatalog tableCatalog;
+  private Table table;
+  private CatalogCredentialManager credentialManager;
+  private GravitinoLanceTableOperations ops;
+
+  @BeforeEach
+  @SuppressWarnings("unchecked")
+  void setUp() throws Exception {
+    namespaceWrapper = mock(GravitinoLanceNamespaceWrapper.class);
+    catalog = mock(Catalog.class);
+    tableCatalog = mock(TableCatalog.class);
+    table = mock(Table.class);
+    credentialManager = mock(CatalogCredentialManager.class);
+
+    ops = new GravitinoLanceTableOperations(namespaceWrapper);
+
+    // Inject mock CatalogCredentialManager via reflection so computeIfAbsent uses the mock
+    Field field = GravitinoLanceTableOperations.class.getDeclaredField("credentialManagers");
+    field.setAccessible(true);
+    ConcurrentHashMap<String, CatalogCredentialManager> map =
+        (ConcurrentHashMap<String, CatalogCredentialManager>) field.get(ops);
+    map.put(CATALOG_NAME, credentialManager);
+
+    // Common mock setup
+    when(namespaceWrapper.loadAndValidateLakehouseCatalog(CATALOG_NAME)).thenReturn(catalog);
+    when(catalog.asTableCatalog()).thenReturn(tableCatalog);
+    when(tableCatalog.loadTable(NameIdentifier.of(SCHEMA_NAME, TABLE_NAME))).thenReturn(table);
+    when(table.columns()).thenReturn(new Column[] {});
+    when(table.properties())
+        .thenReturn(
+            Map.of(
+                LANCE_LOCATION,
+                TABLE_LOCATION,
+                LANCE_TABLE_VERSION,
+                "5",
+                "lance.storage.region",
+                "us-east-1"));
+  }
+
+  @Test
+  void testDescribeTableWithCredentialVending() {
+    S3TokenCredential s3Credential = new S3TokenCredential("ak", "sk", "session-token", 12345L);
+    when(credentialManager.getCredential(any(PathBasedCredentialContext.class)))
+        .thenReturn(s3Credential);
+
+    DescribeTableResponse response =
+        ops.describeTable(TABLE_ID, DELIMITER, Optional.empty(), CredentialPrivilege.WRITE);
+
+    // Verify vended credential keys
+    Map<String, String> storageOptions = response.getStorageOptions();
+    assertNotNull(storageOptions);
+    assertEquals("ak", storageOptions.get("aws_access_key_id"));
+    assertEquals("sk", storageOptions.get("aws_secret_access_key"));
+    assertEquals("session-token", storageOptions.get("aws_session_token"));
+    assertEquals("12345", storageOptions.get("expires_at_millis"));
+
+    // Verify base storage options are preserved after merge
+    assertEquals("us-east-1", storageOptions.get("region"));
+
+    // Verify other response fields
+    assertEquals(TABLE_LOCATION, response.getLocation());
+    assertEquals(5L, response.getVersion());
+  }
+
+  @Test
+  void testDescribeTableWithoutCredentialVending() {
+    DescribeTableResponse response = ops.describeTable(TABLE_ID, DELIMITER, Optional.empty(), null);
+
+    Map<String, String> storageOptions = response.getStorageOptions();
+    assertNotNull(storageOptions);
+    // Should only contain base storage options (prefixed keys stripped)
+    assertEquals("us-east-1", storageOptions.get("region"));
+    // No credential keys
+    assertNull(storageOptions.get("aws_access_key_id"));
+    assertNull(storageOptions.get("aws_secret_access_key"));
+    assertNull(storageOptions.get("aws_session_token"));
+  }
+
+  @Test
+  void testDescribeTableCredentialFallbackOnNoProviders() {
+    // Simulates catalog with no credential providers configured
+    when(credentialManager.getCredential(any(PathBasedCredentialContext.class)))
+        .thenThrow(new IllegalArgumentException("No credential providers configured"));
+
+    DescribeTableResponse response =
+        ops.describeTable(TABLE_ID, DELIMITER, Optional.empty(), CredentialPrivilege.READ);
+
+    // Should fall back to original storage options
+    Map<String, String> storageOptions = response.getStorageOptions();
+    assertNotNull(storageOptions);
+    assertEquals("us-east-1", storageOptions.get("region"));
+    assertNull(storageOptions.get("aws_access_key_id"));
+  }
+
+  @Test
+  void testDescribeTableNullCredentialThrowsServiceUnavailable() {
+    when(credentialManager.getCredential(any(PathBasedCredentialContext.class))).thenReturn(null);
+
+    assertThrows(
+        ServiceUnavailableException.class,
+        () -> ops.describeTable(TABLE_ID, DELIMITER, Optional.empty(), CredentialPrivilege.WRITE));
+  }
+
+  @Test
+  void testDescribeTableWritePrivilegePassesWritePaths() {
+    S3TokenCredential s3Credential = new S3TokenCredential("ak", "sk", "token", 100L);
+    when(credentialManager.getCredential(any(PathBasedCredentialContext.class)))
+        .thenReturn(s3Credential);
+
+    ops.describeTable(TABLE_ID, DELIMITER, Optional.empty(), CredentialPrivilege.WRITE);
+
+    ArgumentCaptor<PathBasedCredentialContext> captor =
+        ArgumentCaptor.forClass(PathBasedCredentialContext.class);
+    verify(credentialManager).getCredential(captor.capture());
+
+    PathBasedCredentialContext context = captor.getValue();
+    assertTrue(context.getWritePaths().contains(TABLE_LOCATION));
+    assertTrue(context.getReadPaths().isEmpty());
+  }
+
+  @Test
+  void testDescribeTableReadPrivilegePassesReadPaths() {
+    S3TokenCredential s3Credential = new S3TokenCredential("ak", "sk", "token", 100L);
+    when(credentialManager.getCredential(any(PathBasedCredentialContext.class)))
+        .thenReturn(s3Credential);
+
+    ops.describeTable(TABLE_ID, DELIMITER, Optional.empty(), CredentialPrivilege.READ);
+
+    ArgumentCaptor<PathBasedCredentialContext> captor =
+        ArgumentCaptor.forClass(PathBasedCredentialContext.class);
+    verify(credentialManager).getCredential(captor.capture());
+
+    PathBasedCredentialContext context = captor.getValue();
+    assertTrue(context.getReadPaths().contains(TABLE_LOCATION));
+    assertTrue(context.getWritePaths().isEmpty());
+  }
+
+  @Test
+  void testDescribeTableCredentialVendingMergesWithExistingOptions() {
+    // Table has both base storage options and will receive vended credentials
+    when(table.properties())
+        .thenReturn(
+            Map.of(
+                LANCE_LOCATION,
+                TABLE_LOCATION,
+                "lance.storage.region",
+                "us-west-2",
+                "lance.storage.endpoint",
+                "https://s3.example.com"));
+
+    S3TokenCredential s3Credential = new S3TokenCredential("ak", "sk", "token", 500L);
+    when(credentialManager.getCredential(any(PathBasedCredentialContext.class)))
+        .thenReturn(s3Credential);
+
+    DescribeTableResponse response =
+        ops.describeTable(TABLE_ID, DELIMITER, Optional.empty(), CredentialPrivilege.WRITE);
+
+    Map<String, String> storageOptions = response.getStorageOptions();
+    // Base options preserved
+    assertEquals("us-west-2", storageOptions.get("region"));
+    assertEquals("https://s3.example.com", storageOptions.get("endpoint"));
+    // Vended credentials added
+    assertEquals("ak", storageOptions.get("aws_access_key_id"));
+    assertEquals("sk", storageOptions.get("aws_secret_access_key"));
+    assertEquals("token", storageOptions.get("aws_session_token"));
+    assertEquals("500", storageOptions.get("expires_at_millis"));
+  }
+}

--- a/lance/lance-rest-server/src/test/java/org/apache/gravitino/lance/service/rest/TestGravitinoLanceTableOpsCredentialVending.java
+++ b/lance/lance-rest-server/src/test/java/org/apache/gravitino/lance/service/rest/TestGravitinoLanceTableOpsCredentialVending.java
@@ -87,6 +87,7 @@ class TestGravitinoLanceTableOpsCredentialVending {
 
     // Common mock setup
     when(namespaceWrapper.loadAndValidateLakehouseCatalog(CATALOG_NAME)).thenReturn(catalog);
+    when(catalog.name()).thenReturn(CATALOG_NAME);
     when(catalog.asTableCatalog()).thenReturn(tableCatalog);
     when(tableCatalog.loadTable(NameIdentifier.of(SCHEMA_NAME, TABLE_NAME))).thenReturn(table);
     when(table.columns()).thenReturn(new Column[] {});
@@ -109,7 +110,8 @@ class TestGravitinoLanceTableOpsCredentialVending {
         .thenReturn(s3Credential);
 
     DescribeTableResponse response =
-        ops.describeTable(TABLE_ID, DELIMITER, Optional.empty(), CredentialPrivilege.WRITE);
+        ops.describeTable(
+            TABLE_ID, DELIMITER, Optional.empty(), Optional.of(CredentialPrivilege.WRITE));
 
     // Verify vended credential keys
     Map<String, String> storageOptions = response.getStorageOptions();
@@ -129,7 +131,8 @@ class TestGravitinoLanceTableOpsCredentialVending {
 
   @Test
   void testDescribeTableWithoutCredentialVending() {
-    DescribeTableResponse response = ops.describeTable(TABLE_ID, DELIMITER, Optional.empty(), null);
+    DescribeTableResponse response =
+        ops.describeTable(TABLE_ID, DELIMITER, Optional.empty(), Optional.empty());
 
     Map<String, String> storageOptions = response.getStorageOptions();
     assertNotNull(storageOptions);
@@ -149,7 +152,8 @@ class TestGravitinoLanceTableOpsCredentialVending {
         .thenThrow(new IllegalArgumentException("No credential providers configured"));
 
     DescribeTableResponse response =
-        ops.describeTable(TABLE_ID, DELIMITER, Optional.empty(), CredentialPrivilege.READ);
+        ops.describeTable(
+            TABLE_ID, DELIMITER, Optional.empty(), Optional.of(CredentialPrivilege.READ));
 
     // Should fall back to original storage options
     Map<String, String> storageOptions = response.getStorageOptions();
@@ -166,7 +170,9 @@ class TestGravitinoLanceTableOpsCredentialVending {
 
     assertThrows(
         ServiceUnavailableException.class,
-        () -> ops.describeTable(TABLE_ID, DELIMITER, Optional.empty(), CredentialPrivilege.WRITE));
+        () ->
+            ops.describeTable(
+                TABLE_ID, DELIMITER, Optional.empty(), Optional.of(CredentialPrivilege.WRITE)));
   }
 
   @Test
@@ -176,7 +182,8 @@ class TestGravitinoLanceTableOpsCredentialVending {
             any(String.class), any(PathBasedCredentialContext.class)))
         .thenReturn(s3Credential);
 
-    ops.describeTable(TABLE_ID, DELIMITER, Optional.empty(), CredentialPrivilege.WRITE);
+    ops.describeTable(
+        TABLE_ID, DELIMITER, Optional.empty(), Optional.of(CredentialPrivilege.WRITE));
 
     ArgumentCaptor<PathBasedCredentialContext> captor =
         ArgumentCaptor.forClass(PathBasedCredentialContext.class);
@@ -194,7 +201,7 @@ class TestGravitinoLanceTableOpsCredentialVending {
             any(String.class), any(PathBasedCredentialContext.class)))
         .thenReturn(s3Credential);
 
-    ops.describeTable(TABLE_ID, DELIMITER, Optional.empty(), CredentialPrivilege.READ);
+    ops.describeTable(TABLE_ID, DELIMITER, Optional.empty(), Optional.of(CredentialPrivilege.READ));
 
     ArgumentCaptor<PathBasedCredentialContext> captor =
         ArgumentCaptor.forClass(PathBasedCredentialContext.class);
@@ -224,7 +231,8 @@ class TestGravitinoLanceTableOpsCredentialVending {
         .thenReturn(s3Credential);
 
     DescribeTableResponse response =
-        ops.describeTable(TABLE_ID, DELIMITER, Optional.empty(), CredentialPrivilege.WRITE);
+        ops.describeTable(
+            TABLE_ID, DELIMITER, Optional.empty(), Optional.of(CredentialPrivilege.WRITE));
 
     Map<String, String> storageOptions = response.getStorageOptions();
     // Base options preserved

--- a/lance/lance-rest-server/src/test/java/org/apache/gravitino/lance/service/rest/TestGravitinoLanceTableOpsCredentialVending.java
+++ b/lance/lance-rest-server/src/test/java/org/apache/gravitino/lance/service/rest/TestGravitinoLanceTableOpsCredentialVending.java
@@ -104,7 +104,8 @@ class TestGravitinoLanceTableOpsCredentialVending {
   @Test
   void testDescribeTableWithCredentialVending() {
     S3TokenCredential s3Credential = new S3TokenCredential("ak", "sk", "session-token", 12345L);
-    when(credentialManager.getCredential(any(PathBasedCredentialContext.class)))
+    when(credentialManager.getCredentialByPath(
+            any(String.class), any(PathBasedCredentialContext.class)))
         .thenReturn(s3Credential);
 
     DescribeTableResponse response =
@@ -143,7 +144,8 @@ class TestGravitinoLanceTableOpsCredentialVending {
   @Test
   void testDescribeTableCredentialFallbackOnNoProviders() {
     // Simulates catalog with no credential providers configured
-    when(credentialManager.getCredential(any(PathBasedCredentialContext.class)))
+    when(credentialManager.getCredentialByPath(
+            any(String.class), any(PathBasedCredentialContext.class)))
         .thenThrow(new IllegalArgumentException("No credential providers configured"));
 
     DescribeTableResponse response =
@@ -158,7 +160,9 @@ class TestGravitinoLanceTableOpsCredentialVending {
 
   @Test
   void testDescribeTableNullCredentialThrowsServiceUnavailable() {
-    when(credentialManager.getCredential(any(PathBasedCredentialContext.class))).thenReturn(null);
+    when(credentialManager.getCredentialByPath(
+            any(String.class), any(PathBasedCredentialContext.class)))
+        .thenReturn(null);
 
     assertThrows(
         ServiceUnavailableException.class,
@@ -168,14 +172,15 @@ class TestGravitinoLanceTableOpsCredentialVending {
   @Test
   void testDescribeTableWritePrivilegePassesWritePaths() {
     S3TokenCredential s3Credential = new S3TokenCredential("ak", "sk", "token", 100L);
-    when(credentialManager.getCredential(any(PathBasedCredentialContext.class)))
+    when(credentialManager.getCredentialByPath(
+            any(String.class), any(PathBasedCredentialContext.class)))
         .thenReturn(s3Credential);
 
     ops.describeTable(TABLE_ID, DELIMITER, Optional.empty(), CredentialPrivilege.WRITE);
 
     ArgumentCaptor<PathBasedCredentialContext> captor =
         ArgumentCaptor.forClass(PathBasedCredentialContext.class);
-    verify(credentialManager).getCredential(captor.capture());
+    verify(credentialManager).getCredentialByPath(any(String.class), captor.capture());
 
     PathBasedCredentialContext context = captor.getValue();
     assertTrue(context.getWritePaths().contains(TABLE_LOCATION));
@@ -185,14 +190,15 @@ class TestGravitinoLanceTableOpsCredentialVending {
   @Test
   void testDescribeTableReadPrivilegePassesReadPaths() {
     S3TokenCredential s3Credential = new S3TokenCredential("ak", "sk", "token", 100L);
-    when(credentialManager.getCredential(any(PathBasedCredentialContext.class)))
+    when(credentialManager.getCredentialByPath(
+            any(String.class), any(PathBasedCredentialContext.class)))
         .thenReturn(s3Credential);
 
     ops.describeTable(TABLE_ID, DELIMITER, Optional.empty(), CredentialPrivilege.READ);
 
     ArgumentCaptor<PathBasedCredentialContext> captor =
         ArgumentCaptor.forClass(PathBasedCredentialContext.class);
-    verify(credentialManager).getCredential(captor.capture());
+    verify(credentialManager).getCredentialByPath(any(String.class), captor.capture());
 
     PathBasedCredentialContext context = captor.getValue();
     assertTrue(context.getReadPaths().contains(TABLE_LOCATION));
@@ -213,7 +219,8 @@ class TestGravitinoLanceTableOpsCredentialVending {
                 "https://s3.example.com"));
 
     S3TokenCredential s3Credential = new S3TokenCredential("ak", "sk", "token", 500L);
-    when(credentialManager.getCredential(any(PathBasedCredentialContext.class)))
+    when(credentialManager.getCredentialByPath(
+            any(String.class), any(PathBasedCredentialContext.class)))
         .thenReturn(s3Credential);
 
     DescribeTableResponse response =

--- a/lance/lance-rest-server/src/test/java/org/apache/gravitino/lance/service/rest/TestLanceNamespaceOperations.java
+++ b/lance/lance-rest-server/src/test/java/org/apache/gravitino/lance/service/rest/TestLanceNamespaceOperations.java
@@ -136,6 +136,10 @@ public class TestLanceNamespaceOperations extends JerseyTest {
   public static void setup() {
     when(namespaceWrapper.asNamespaceOps()).thenReturn(namespaceOps);
     when(namespaceWrapper.asTableOps()).thenReturn(tableOps);
+    org.apache.gravitino.lance.common.config.LanceConfig lanceConfig =
+        mock(org.apache.gravitino.lance.common.config.LanceConfig.class);
+    when(namespaceWrapper.config()).thenReturn(lanceConfig);
+    when(lanceConfig.getGravitinoMetalake()).thenReturn("test-metalake");
   }
 
   @Test
@@ -730,7 +734,7 @@ public class TestLanceNamespaceOperations extends JerseyTest {
     DescribeTableResponse createTableResponse = new DescribeTableResponse();
     createTableResponse.setLocation("/path/to/describe_table");
     createTableResponse.setMetadata(ImmutableMap.of("key", "value"));
-    when(tableOps.describeTable(any(), any(), any())).thenReturn(createTableResponse);
+    when(tableOps.describeTable(any(), any(), any(), any())).thenReturn(createTableResponse);
 
     DescribeTableRequest tableRequest = new DescribeTableRequest();
     Response resp =
@@ -747,7 +751,7 @@ public class TestLanceNamespaceOperations extends JerseyTest {
 
     // Test not found exception
     Mockito.reset(tableOps);
-    when(tableOps.describeTable(any(), any(), any()))
+    when(tableOps.describeTable(any(), any(), any(), any()))
         .thenThrow(new TableNotFoundException("Table not found", "", tableIds));
     resp =
         target(String.format("/v1/table/%s/describe", tableIds))
@@ -758,7 +762,7 @@ public class TestLanceNamespaceOperations extends JerseyTest {
 
     // Test runtime exception
     Mockito.reset(tableOps);
-    when(tableOps.describeTable(any(), any(), any()))
+    when(tableOps.describeTable(any(), any(), any(), any()))
         .thenThrow(new RuntimeException("Runtime exception"));
     resp =
         target(String.format("/v1/table/%s/describe", tableIds))
@@ -1087,5 +1091,84 @@ public class TestLanceNamespaceOperations extends JerseyTest {
     Assertions.assertEquals(MediaType.APPLICATION_JSON_TYPE, resp.getMediaType());
     ErrorResponse errorResp = resp.readEntity(ErrorResponse.class);
     Assertions.assertEquals("Runtime exception", errorResp.getError());
+  }
+
+  @Test
+  void testDescribeTableVendCredentialsDefaultTrue() {
+    String tableIds = "catalog.scheme.vend_table";
+    String delimiter = ".";
+
+    DescribeTableResponse expectedResponse = new DescribeTableResponse();
+    expectedResponse.setLocation("/path/to/vend_table");
+    expectedResponse.setStorageOptions(
+        ImmutableMap.of(
+            "aws_access_key_id",
+            "temp_key",
+            "aws_secret_access_key",
+            "temp_secret",
+            "aws_session_token",
+            "temp_token",
+            "expires_at_millis",
+            "1234567890"));
+    when(tableOps.describeTable(any(), any(), any(), any())).thenReturn(expectedResponse);
+
+    DescribeTableRequest request = new DescribeTableRequest();
+    Response resp =
+        target(String.format("/v1/table/%s/describe", tableIds))
+            .queryParam("delimiter", delimiter)
+            .request(MediaType.APPLICATION_JSON_TYPE)
+            .post(Entity.entity(request, MediaType.APPLICATION_JSON_TYPE));
+
+    Assertions.assertEquals(Response.Status.OK.getStatusCode(), resp.getStatus());
+    DescribeTableResponse response = resp.readEntity(DescribeTableResponse.class);
+    Assertions.assertNotNull(response.getStorageOptions());
+    Assertions.assertTrue(response.getStorageOptions().containsKey("expires_at_millis"));
+
+    Mockito.verify(tableOps).describeTable(any(), any(), any(), any());
+  }
+
+  @Test
+  void testDescribeTableVendCredentialsExplicitFalse() {
+    Mockito.reset(tableOps);
+    String tableIds = "catalog.scheme.no_vend";
+    String delimiter = ".";
+
+    DescribeTableResponse expectedResponse = new DescribeTableResponse();
+    expectedResponse.setLocation("/path/to/no_vend");
+    expectedResponse.setStorageOptions(ImmutableMap.of("aws_region", "us-east-1"));
+    when(tableOps.describeTable(any(), any(), any(), eq(null))).thenReturn(expectedResponse);
+
+    DescribeTableRequest request = new DescribeTableRequest();
+    request.setVendCredentials(false);
+    Response resp =
+        target(String.format("/v1/table/%s/describe", tableIds))
+            .queryParam("delimiter", delimiter)
+            .request(MediaType.APPLICATION_JSON_TYPE)
+            .post(Entity.entity(request, MediaType.APPLICATION_JSON_TYPE));
+
+    Assertions.assertEquals(Response.Status.OK.getStatusCode(), resp.getStatus());
+    Mockito.verify(tableOps).describeTable(any(), any(), any(), eq(null));
+  }
+
+  @Test
+  void testDescribeTableVendCredentialsExplicitTrue() {
+    Mockito.reset(tableOps);
+    String tableIds = "catalog.scheme.explicit_vend";
+    String delimiter = ".";
+
+    DescribeTableResponse expectedResponse = new DescribeTableResponse();
+    expectedResponse.setLocation("/path/to/explicit_vend");
+    when(tableOps.describeTable(any(), any(), any(), any())).thenReturn(expectedResponse);
+
+    DescribeTableRequest request = new DescribeTableRequest();
+    request.setVendCredentials(true);
+    Response resp =
+        target(String.format("/v1/table/%s/describe", tableIds))
+            .queryParam("delimiter", delimiter)
+            .request(MediaType.APPLICATION_JSON_TYPE)
+            .post(Entity.entity(request, MediaType.APPLICATION_JSON_TYPE));
+
+    Assertions.assertEquals(Response.Status.OK.getStatusCode(), resp.getStatus());
+    Mockito.verify(tableOps).describeTable(any(), any(), any(), any());
   }
 }

--- a/lance/lance-rest-server/src/test/java/org/apache/gravitino/lance/service/rest/TestLanceNamespaceOperations.java
+++ b/lance/lance-rest-server/src/test/java/org/apache/gravitino/lance/service/rest/TestLanceNamespaceOperations.java
@@ -35,6 +35,7 @@ import com.google.common.collect.Sets;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.regex.Pattern;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.client.Entity;
@@ -1136,7 +1137,8 @@ public class TestLanceNamespaceOperations extends JerseyTest {
     DescribeTableResponse expectedResponse = new DescribeTableResponse();
     expectedResponse.setLocation("/path/to/no_vend");
     expectedResponse.setStorageOptions(ImmutableMap.of("aws_region", "us-east-1"));
-    when(tableOps.describeTable(any(), any(), any(), eq(null))).thenReturn(expectedResponse);
+    when(tableOps.describeTable(any(), any(), any(), eq(Optional.empty())))
+        .thenReturn(expectedResponse);
 
     DescribeTableRequest request = new DescribeTableRequest();
     request.setVendCredentials(false);
@@ -1147,7 +1149,7 @@ public class TestLanceNamespaceOperations extends JerseyTest {
             .post(Entity.entity(request, MediaType.APPLICATION_JSON_TYPE));
 
     Assertions.assertEquals(Response.Status.OK.getStatusCode(), resp.getStatus());
-    Mockito.verify(tableOps).describeTable(any(), any(), any(), eq(null));
+    Mockito.verify(tableOps).describeTable(any(), any(), any(), eq(Optional.empty()));
   }
 
   @Test

--- a/lance/lance-rest-server/src/test/resources/META-INF/services/org.apache.gravitino.credential.CredentialProvider
+++ b/lance/lance-rest-server/src/test/resources/META-INF/services/org.apache.gravitino.credential.CredentialProvider
@@ -1,0 +1,19 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+org.apache.gravitino.lance.service.extension.LanceDummyCredentialProvider


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add temporary credential vending support to the Lance REST Server's `describeTable` API, enabling clients to receive short-lived storage credentials instead of relying on long-term access keys.

Key changes:

1. **`CredentialPropertyUtils`** — Add Lance-specific credential property transformation: convert `S3TokenCredential`, `GCSTokenCredential`, and `S3SecretKeyCredential` into Lance `storage_options` format (`aws_access_key_id`, `aws_secret_access_key`, `aws_session_token`, `expires_at_millis`).

2. **`GravitinoLanceTableOps.describeTable()`** — Integrate with `CatalogCredentialManager` to generate per-request temporary credentials based on the caller's privilege level (READ or WRITE). Merge vended credentials into `DescribeTableResponse.storageOptions`.

3. **`LanceTableOperations` (REST layer)** — Accept `vendCredentials` flag from `DescribeTableRequest`, determine caller privilege via `MetadataAuthzHelper`, and pass it down to the ops layer.

4. **Tests** — Unit tests for credential transformation, ops layer credential merging, REST layer vending flag handling, and end-to-end IT with `LanceDummyCredentialProvider` via Java SPI.

### Why are the changes needed?

Currently the Lance REST Server returns static storage configuration without generating temporary credentials. When Lance clients access table data on S3/GCS, they need long-term access keys embedded in catalog properties, which poses a security risk. This aligns with the credential vending pattern already used by the Iceberg REST Server.

Fix: #9087

### Does this PR introduce _any_ user-facing change?

No. Credential vending is opt-in via the `credential-providers` catalog property and the `vendCredentials` request flag. Existing behavior is preserved when these are not configured.

### How was this patch tested?

- Unit tests: `TestCredentialPropertiesUtils`, `TestGravitinoLanceTableOpsCredentialVending`, `TestLanceNamespaceOperations` (vend credentials tests)
- IT: `LanceRESTServiceIT.testDescribeTableWithCredentialVending` using `LanceDummyCredentialProvider` via SPI