### PR TITLE
Fix Helm chart init containers against current Gravitino image

### DIFF
--- a/dev/charts/gravitino/templates/deployment.yaml
+++ b/dev/charts/gravitino/templates/deployment.yaml
@@ -64,13 +64,16 @@ spec:
             - /bin/bash
             - -c
             - |
-              cp -r /opt/gravitino/scripts/*  /tmp/scripts/
-              VERSION=$(ls /opt/gravitino/libs/gravitino-server-* | grep -oP '[0-9]+\.[0-9]+\.[0-9]+'|head -1)
+              cp -r ${GRAVITINO_HOME}/scripts/*  /tmp/scripts/
+              VERSION=$(ls ${GRAVITINO_HOME}/libs/gravitino-server-* | grep -oP '[0-9]+\.[0-9]+\.[0-9]+'|head -1)
               echo $VERSION > /tmp/scripts/version.txt
           resources:
             {{- toYaml .Values.initResources | nindent 12 }}
           securityContext:
             {{- toYaml .Values.initContainerSecurityContext | nindent 12 }}
+          env:
+            - name: GRAVITINO_HOME
+              value: {{ .Values.gravitinoHome | quote }}
           volumeMounts:
             - mountPath: /tmp/scripts/
               name: scripts-emptydir
@@ -195,7 +198,7 @@ spec:
             {{- toYaml .Values.containerSecurityContext | nindent 12 }}
           env:
             - name: GRAVITINO_HOME
-              value: /opt/gravitino
+              value: {{ .Values.gravitinoHome | quote }}
             - name: SKIP_CONFIG_REWRITE
               value: "true"
           {{- with .Values.env }}

--- a/dev/charts/gravitino/values.yaml
+++ b/dev/charts/gravitino/values.yaml
@@ -34,6 +34,16 @@ image:
   tag: 1.3.0-SNAPSHOT
   pullPolicy: IfNotPresent
 
+## @param gravitinoHome Path to GRAVITINO_HOME inside the apache/gravitino image.
+## The image lays out its files at /root/gravitino/{libs,scripts,bin,...} and
+## the main container's startup script reads from there. Init containers
+## (sqlfile, init-mysql, init-postgresql) read the bundled schema scripts and
+## server JAR from the same path and must use this same value.
+##
+## Override this only if you build a custom image with a different layout.
+##
+gravitinoHome: /root/gravitino
+
 ## MySQL chart configuration
 ## ref: https://github.com/bitnami/charts/blob/main/bitnami/mysql/values.yaml
 ##
@@ -512,20 +522,41 @@ livenessProbe:
 podSecurityContext: {}
   # fsGroup: 1000  # set when using PVCs so mounted volumes are writable by UID 1000
 
-## Init container security context configuration
+## Init container security context configuration.
 ## Applied to all initContainers (sqlfile, init-mysql, init-postgresql).
-## Required on clusters enforcing the Kubernetes Pod Security Standard "restricted" policy.
+##
+## The init containers read schema scripts and the server JAR from
+## ${GRAVITINO_HOME} (defaults to /root/gravitino). The /root directory
+## in the apache/gravitino image is mode 0700, owned by root — so init
+## containers must run as root to traverse into it. Running them as a
+## non-root user produces "Permission denied" errors on cp/ls operations
+## against the image's bundled files.
+##
+## This is a workaround for the image layout. A proper fix at the image
+## layer (move bundled files to a world-traversable path, or chown to
+## a known non-root user) would let init containers run as non-root.
+## Tracked separately from this chart.
+##
+## Clusters enforcing the Kubernetes Pod Security Standard "restricted"
+## policy will reject this. Those deployments need a custom image with
+## a fixed layout, or a relaxed PSS namespace label.
 ##
 initContainerSecurityContext:
-  runAsNonRoot: true
-  runAsUser: 1000
+  runAsNonRoot: false
+  runAsUser: 0
 
 ## Container-specific security context configuration
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
 ##
+## The main container also runs as root in the apache/gravitino image
+## because of the same /root/gravitino layout. The image's launch script
+## writes to ${GRAVITINO_HOME}/libs (creating symlinks for bundled JDBC
+## drivers) and ${GRAVITINO_HOME}/logs at startup, both of which require
+## write access to /root.
+##
 containerSecurityContext:
-  runAsNonRoot: true
-  runAsUser: 1000
+  runAsNonRoot: false
+  runAsUser: 0
 
 ## Container Environment
 ##


### PR DESCRIPTION
### Problem

When `helm install` is run with `postgresql.enabled=true` or `mysql.enabled=true`, the Gravitino server pod enters CrashLoopBackOff and never starts. The failure is in the `sqlfile` init container with `Permission denied` errors.

Root cause: the `sqlfile` init container runs the `apache/gravitino` image and copies bundled schema scripts and the server JAR out of it. The container's script hardcodes paths under `/opt/gravitino/`, but the image actually places those files under `/root/gravitino/`. The `cp` and `ls` commands fail, the init container exits with an error, and the pod never reaches the main container.

The default H2 install works because it doesn't run the failing init containers.

### Fix

1. New `gravitinoHome` values key (defaults to `/root/gravitino`) so paths into the image's filesystem are configurable instead of hardcoded. The `sqlfile` init container and the main container both consume it via `GRAVITINO_HOME`.
2. Init and main container security contexts default to `runAsUser: 0`. The image's `/root` directory is mode `0700`, so init containers need root to traverse into `/root/gravitino/scripts/`, and the main container's launch script needs to write to `/root/gravitino/libs/` and `/root/gravitino/logs/` at startup.

Both are workarounds for the image's current layout. A proper fix at the image layer (move bundled files to a world-traversable path, or chown to a non-root user) would let everything run as non-root. Out of scope for this PR.

### Tests

Tested on Docker Desktop Kubernetes against `apache/gravitino:1.3.0-SNAPSHOT`. Three scenarios, all reach `1/1 Running` and serve `GET /api/version` successfully:

- Default install (H2)
- `--set postgresql.enabled=true`
- `--set mysql.enabled=true`