### PR TITLE
[#10925] fix(iceberg): Make setViewOwner best-effort in IcebergViewHookDispatcher

### DIFF
--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/dispatcher/IcebergViewHookDispatcher.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/dispatcher/IcebergViewHookDispatcher.java
@@ -69,13 +69,23 @@ public class IcebergViewHookDispatcher implements IcebergViewOperationDispatcher
     importView(context.catalogName(), namespace, createViewRequest.name());
 
     // Set ownership for the newly created view
-    IcebergOwnershipUtils.setViewOwner(
-        metalake,
-        context.catalogName(),
-        namespace,
-        createViewRequest.name(),
-        context.userName(),
-        GravitinoEnv.getInstance().ownerDispatcher());
+    try {
+      IcebergOwnershipUtils.setViewOwner(
+          metalake,
+          context.catalogName(),
+          namespace,
+          createViewRequest.name(),
+          context.userName(),
+          GravitinoEnv.getInstance().ownerDispatcher());
+    } catch (Exception e) {
+      LOG.warn(
+          "Failed to set owner for view: {}.{}.{}.{} - {}",
+          metalake,
+          context.catalogName(),
+          namespace,
+          createViewRequest.name(),
+          e.getMessage());
+    }
 
     return response;
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Wrap `setViewOwner()` in a try-catch in `IcebergViewHookDispatcher.createView()` so that ownership-setting failures do not fail the entire create view operation.

### Why are the changes needed?

When creating a view via Trino against a remote Iceberg REST Catalog, the view is successfully created in the underlying Iceberg catalog. However, if the post-creation `setViewOwner()` call fails (e.g., because the view entity was not yet imported into the EntityStore), it throws `NoSuchMetadataObjectException` which propagates as a 500 error back to Trino — killing the entire create view response.

The `importView()` call on the line above is already best-effort (wrapped in try-catch). The `setViewOwner()` call should follow the same pattern: post-creation hooks should not break the Iceberg REST response when the view was already created successfully.

Fixes #10925

### Does this PR introduce _any_ user-facing change?

No API changes. View creation via Iceberg REST will no longer fail when ownership setting encounters an error.

### How was this patch tested?

Existing unit tests in `iceberg-rest-server` module pass:
```
./gradlew :iceberg:iceberg-rest-server:test -PskipITs
```