### PR TITLE
[#10957] fix(catalog-postgresql): Map serial types to integer types in PostgreSqlTypeConverter

### DIFF
--- a/catalogs/catalog-jdbc-postgresql/src/main/java/org/apache/gravitino/catalog/postgresql/converter/PostgreSqlTypeConverter.java
+++ b/catalogs/catalog-jdbc-postgresql/src/main/java/org/apache/gravitino/catalog/postgresql/converter/PostgreSqlTypeConverter.java
@@ -39,6 +39,12 @@ public class PostgreSqlTypeConverter extends JdbcTypeConverter {
   static final String NUMERIC = "numeric";
   static final String BPCHAR = "bpchar";
   static final String BYTEA = "bytea";
+  static final String SERIAL = "serial";
+  static final String SERIAL4 = "serial4";
+  static final String SMALLSERIAL = "smallserial";
+  static final String SERIAL2 = "serial2";
+  static final String BIGSERIAL = "bigserial";
+  static final String SERIAL8 = "serial8";
   @VisibleForTesting static final String JDBC_ARRAY_PREFIX = "_";
   @VisibleForTesting static final String ARRAY_TOKEN = "[]";
 
@@ -87,6 +93,15 @@ public class PostgreSqlTypeConverter extends JdbcTypeConverter {
         return Types.StringType.get();
       case BYTEA:
         return Types.BinaryType.get();
+      case SMALLSERIAL:
+      case SERIAL2:
+        return Types.ShortType.get();
+      case SERIAL:
+      case SERIAL4:
+        return Types.IntegerType.get();
+      case BIGSERIAL:
+      case SERIAL8:
+        return Types.LongType.get();
       default:
         return Types.ExternalType.of(typeBean.getTypeName());
     }

--- a/catalogs/catalog-jdbc-postgresql/src/main/java/org/apache/gravitino/catalog/postgresql/converter/PostgreSqlTypeConverter.java
+++ b/catalogs/catalog-jdbc-postgresql/src/main/java/org/apache/gravitino/catalog/postgresql/converter/PostgreSqlTypeConverter.java
@@ -41,11 +41,8 @@ public class PostgreSqlTypeConverter extends JdbcTypeConverter {
   static final String BYTEA = "bytea";
   static final String UUID = "uuid";
   static final String SERIAL = "serial";
-  static final String SERIAL4 = "serial4";
   static final String SMALLSERIAL = "smallserial";
-  static final String SERIAL2 = "serial2";
   static final String BIGSERIAL = "bigserial";
-  static final String SERIAL8 = "serial8";
   @VisibleForTesting static final String JDBC_ARRAY_PREFIX = "_";
   @VisibleForTesting static final String ARRAY_TOKEN = "[]";
   @VisibleForTesting static final int DEFAULT_NUMERIC_PRECISION = 38;
@@ -107,13 +104,10 @@ public class PostgreSqlTypeConverter extends JdbcTypeConverter {
       case UUID:
         return Types.UUIDType.get();
       case SMALLSERIAL:
-      case SERIAL2:
         return Types.ShortType.get();
       case SERIAL:
-      case SERIAL4:
         return Types.IntegerType.get();
       case BIGSERIAL:
-      case SERIAL8:
         return Types.LongType.get();
       default:
         return Types.ExternalType.of(typeBean.getTypeName());

--- a/catalogs/catalog-jdbc-postgresql/src/main/java/org/apache/gravitino/catalog/postgresql/converter/PostgreSqlTypeConverter.java
+++ b/catalogs/catalog-jdbc-postgresql/src/main/java/org/apache/gravitino/catalog/postgresql/converter/PostgreSqlTypeConverter.java
@@ -40,6 +40,12 @@ public class PostgreSqlTypeConverter extends JdbcTypeConverter {
   static final String BPCHAR = "bpchar";
   static final String BYTEA = "bytea";
   static final String UUID = "uuid";
+  static final String SERIAL = "serial";
+  static final String SERIAL4 = "serial4";
+  static final String SMALLSERIAL = "smallserial";
+  static final String SERIAL2 = "serial2";
+  static final String BIGSERIAL = "bigserial";
+  static final String SERIAL8 = "serial8";
   @VisibleForTesting static final String JDBC_ARRAY_PREFIX = "_";
   @VisibleForTesting static final String ARRAY_TOKEN = "[]";
   @VisibleForTesting static final int DEFAULT_NUMERIC_PRECISION = 38;
@@ -100,6 +106,15 @@ public class PostgreSqlTypeConverter extends JdbcTypeConverter {
         return Types.BinaryType.get();
       case UUID:
         return Types.UUIDType.get();
+      case SMALLSERIAL:
+      case SERIAL2:
+        return Types.ShortType.get();
+      case SERIAL:
+      case SERIAL4:
+        return Types.IntegerType.get();
+      case BIGSERIAL:
+      case SERIAL8:
+        return Types.LongType.get();
       default:
         return Types.ExternalType.of(typeBean.getTypeName());
     }

--- a/catalogs/catalog-jdbc-postgresql/src/test/java/org/apache/gravitino/catalog/postgresql/converter/TestPostgreSqlTypeConverter.java
+++ b/catalogs/catalog-jdbc-postgresql/src/test/java/org/apache/gravitino/catalog/postgresql/converter/TestPostgreSqlTypeConverter.java
@@ -24,6 +24,7 @@ import static org.apache.gravitino.catalog.jdbc.converter.JdbcTypeConverter.TIME
 import static org.apache.gravitino.catalog.jdbc.converter.JdbcTypeConverter.TIMESTAMP;
 import static org.apache.gravitino.catalog.jdbc.converter.JdbcTypeConverter.VARCHAR;
 import static org.apache.gravitino.catalog.postgresql.converter.PostgreSqlTypeConverter.ARRAY_TOKEN;
+import static org.apache.gravitino.catalog.postgresql.converter.PostgreSqlTypeConverter.BIGSERIAL;
 import static org.apache.gravitino.catalog.postgresql.converter.PostgreSqlTypeConverter.BOOL;
 import static org.apache.gravitino.catalog.postgresql.converter.PostgreSqlTypeConverter.BPCHAR;
 import static org.apache.gravitino.catalog.postgresql.converter.PostgreSqlTypeConverter.BYTEA;
@@ -34,6 +35,11 @@ import static org.apache.gravitino.catalog.postgresql.converter.PostgreSqlTypeCo
 import static org.apache.gravitino.catalog.postgresql.converter.PostgreSqlTypeConverter.INT_8;
 import static org.apache.gravitino.catalog.postgresql.converter.PostgreSqlTypeConverter.JDBC_ARRAY_PREFIX;
 import static org.apache.gravitino.catalog.postgresql.converter.PostgreSqlTypeConverter.NUMERIC;
+import static org.apache.gravitino.catalog.postgresql.converter.PostgreSqlTypeConverter.SERIAL;
+import static org.apache.gravitino.catalog.postgresql.converter.PostgreSqlTypeConverter.SERIAL2;
+import static org.apache.gravitino.catalog.postgresql.converter.PostgreSqlTypeConverter.SERIAL4;
+import static org.apache.gravitino.catalog.postgresql.converter.PostgreSqlTypeConverter.SERIAL8;
+import static org.apache.gravitino.catalog.postgresql.converter.PostgreSqlTypeConverter.SMALLSERIAL;
 
 import org.apache.gravitino.catalog.jdbc.converter.JdbcTypeConverter;
 import org.apache.gravitino.rel.types.Type;
@@ -72,6 +78,12 @@ public class TestPostgreSqlTypeConverter {
     checkJdbcTypeToGravitinoType(Types.FixedCharType.of(20), BPCHAR, 20, null, 0);
     checkJdbcTypeToGravitinoType(Types.StringType.get(), TEXT, null, null, 0);
     checkJdbcTypeToGravitinoType(Types.BinaryType.get(), BYTEA, null, null, 0);
+    checkJdbcTypeToGravitinoType(Types.ShortType.get(), SMALLSERIAL, null, null, 0);
+    checkJdbcTypeToGravitinoType(Types.ShortType.get(), SERIAL2, null, null, 0);
+    checkJdbcTypeToGravitinoType(Types.IntegerType.get(), SERIAL, null, null, 0);
+    checkJdbcTypeToGravitinoType(Types.IntegerType.get(), SERIAL4, null, null, 0);
+    checkJdbcTypeToGravitinoType(Types.LongType.get(), BIGSERIAL, null, null, 0);
+    checkJdbcTypeToGravitinoType(Types.LongType.get(), SERIAL8, null, null, 0);
     checkJdbcTypeToGravitinoType(
         Types.ExternalType.of(USER_DEFINED_TYPE), USER_DEFINED_TYPE, null, null, 0);
   }

--- a/catalogs/catalog-jdbc-postgresql/src/test/java/org/apache/gravitino/catalog/postgresql/converter/TestPostgreSqlTypeConverter.java
+++ b/catalogs/catalog-jdbc-postgresql/src/test/java/org/apache/gravitino/catalog/postgresql/converter/TestPostgreSqlTypeConverter.java
@@ -38,9 +38,6 @@ import static org.apache.gravitino.catalog.postgresql.converter.PostgreSqlTypeCo
 import static org.apache.gravitino.catalog.postgresql.converter.PostgreSqlTypeConverter.JDBC_ARRAY_PREFIX;
 import static org.apache.gravitino.catalog.postgresql.converter.PostgreSqlTypeConverter.NUMERIC;
 import static org.apache.gravitino.catalog.postgresql.converter.PostgreSqlTypeConverter.SERIAL;
-import static org.apache.gravitino.catalog.postgresql.converter.PostgreSqlTypeConverter.SERIAL2;
-import static org.apache.gravitino.catalog.postgresql.converter.PostgreSqlTypeConverter.SERIAL4;
-import static org.apache.gravitino.catalog.postgresql.converter.PostgreSqlTypeConverter.SERIAL8;
 import static org.apache.gravitino.catalog.postgresql.converter.PostgreSqlTypeConverter.SMALLSERIAL;
 import static org.apache.gravitino.catalog.postgresql.converter.PostgreSqlTypeConverter.UUID;
 
@@ -96,11 +93,8 @@ public class TestPostgreSqlTypeConverter {
     checkJdbcTypeToGravitinoType(Types.BinaryType.get(), BYTEA, null, null, 0);
     checkJdbcTypeToGravitinoType(Types.UUIDType.get(), UUID, null, null, 0);
     checkJdbcTypeToGravitinoType(Types.ShortType.get(), SMALLSERIAL, null, null, 0);
-    checkJdbcTypeToGravitinoType(Types.ShortType.get(), SERIAL2, null, null, 0);
     checkJdbcTypeToGravitinoType(Types.IntegerType.get(), SERIAL, null, null, 0);
-    checkJdbcTypeToGravitinoType(Types.IntegerType.get(), SERIAL4, null, null, 0);
     checkJdbcTypeToGravitinoType(Types.LongType.get(), BIGSERIAL, null, null, 0);
-    checkJdbcTypeToGravitinoType(Types.LongType.get(), SERIAL8, null, null, 0);
     checkJdbcTypeToGravitinoType(
         Types.ExternalType.of(USER_DEFINED_TYPE), USER_DEFINED_TYPE, null, null, 0);
   }

--- a/catalogs/catalog-jdbc-postgresql/src/test/java/org/apache/gravitino/catalog/postgresql/converter/TestPostgreSqlTypeConverter.java
+++ b/catalogs/catalog-jdbc-postgresql/src/test/java/org/apache/gravitino/catalog/postgresql/converter/TestPostgreSqlTypeConverter.java
@@ -24,6 +24,7 @@ import static org.apache.gravitino.catalog.jdbc.converter.JdbcTypeConverter.TIME
 import static org.apache.gravitino.catalog.jdbc.converter.JdbcTypeConverter.TIMESTAMP;
 import static org.apache.gravitino.catalog.jdbc.converter.JdbcTypeConverter.VARCHAR;
 import static org.apache.gravitino.catalog.postgresql.converter.PostgreSqlTypeConverter.ARRAY_TOKEN;
+import static org.apache.gravitino.catalog.postgresql.converter.PostgreSqlTypeConverter.BIGSERIAL;
 import static org.apache.gravitino.catalog.postgresql.converter.PostgreSqlTypeConverter.BOOL;
 import static org.apache.gravitino.catalog.postgresql.converter.PostgreSqlTypeConverter.BPCHAR;
 import static org.apache.gravitino.catalog.postgresql.converter.PostgreSqlTypeConverter.BYTEA;
@@ -37,6 +38,11 @@ import static org.apache.gravitino.catalog.postgresql.converter.PostgreSqlTypeCo
 import static org.apache.gravitino.catalog.postgresql.converter.PostgreSqlTypeConverter.JDBC_ARRAY_PREFIX;
 import static org.apache.gravitino.catalog.postgresql.converter.PostgreSqlTypeConverter.NUMERIC;
 import static org.apache.gravitino.catalog.postgresql.converter.PostgreSqlTypeConverter.UUID;
+import static org.apache.gravitino.catalog.postgresql.converter.PostgreSqlTypeConverter.SERIAL;
+import static org.apache.gravitino.catalog.postgresql.converter.PostgreSqlTypeConverter.SERIAL2;
+import static org.apache.gravitino.catalog.postgresql.converter.PostgreSqlTypeConverter.SERIAL4;
+import static org.apache.gravitino.catalog.postgresql.converter.PostgreSqlTypeConverter.SERIAL8;
+import static org.apache.gravitino.catalog.postgresql.converter.PostgreSqlTypeConverter.SMALLSERIAL;
 
 import org.apache.gravitino.catalog.jdbc.converter.JdbcTypeConverter;
 import org.apache.gravitino.rel.types.Type;
@@ -89,6 +95,12 @@ public class TestPostgreSqlTypeConverter {
     checkJdbcTypeToGravitinoType(Types.StringType.get(), TEXT, null, null, 0);
     checkJdbcTypeToGravitinoType(Types.BinaryType.get(), BYTEA, null, null, 0);
     checkJdbcTypeToGravitinoType(Types.UUIDType.get(), UUID, null, null, 0);
+    checkJdbcTypeToGravitinoType(Types.ShortType.get(), SMALLSERIAL, null, null, 0);
+    checkJdbcTypeToGravitinoType(Types.ShortType.get(), SERIAL2, null, null, 0);
+    checkJdbcTypeToGravitinoType(Types.IntegerType.get(), SERIAL, null, null, 0);
+    checkJdbcTypeToGravitinoType(Types.IntegerType.get(), SERIAL4, null, null, 0);
+    checkJdbcTypeToGravitinoType(Types.LongType.get(), BIGSERIAL, null, null, 0);
+    checkJdbcTypeToGravitinoType(Types.LongType.get(), SERIAL8, null, null, 0);
     checkJdbcTypeToGravitinoType(
         Types.ExternalType.of(USER_DEFINED_TYPE), USER_DEFINED_TYPE, null, null, 0);
   }

--- a/catalogs/catalog-jdbc-postgresql/src/test/java/org/apache/gravitino/catalog/postgresql/converter/TestPostgreSqlTypeConverter.java
+++ b/catalogs/catalog-jdbc-postgresql/src/test/java/org/apache/gravitino/catalog/postgresql/converter/TestPostgreSqlTypeConverter.java
@@ -37,12 +37,12 @@ import static org.apache.gravitino.catalog.postgresql.converter.PostgreSqlTypeCo
 import static org.apache.gravitino.catalog.postgresql.converter.PostgreSqlTypeConverter.INT_8;
 import static org.apache.gravitino.catalog.postgresql.converter.PostgreSqlTypeConverter.JDBC_ARRAY_PREFIX;
 import static org.apache.gravitino.catalog.postgresql.converter.PostgreSqlTypeConverter.NUMERIC;
-import static org.apache.gravitino.catalog.postgresql.converter.PostgreSqlTypeConverter.UUID;
 import static org.apache.gravitino.catalog.postgresql.converter.PostgreSqlTypeConverter.SERIAL;
 import static org.apache.gravitino.catalog.postgresql.converter.PostgreSqlTypeConverter.SERIAL2;
 import static org.apache.gravitino.catalog.postgresql.converter.PostgreSqlTypeConverter.SERIAL4;
 import static org.apache.gravitino.catalog.postgresql.converter.PostgreSqlTypeConverter.SERIAL8;
 import static org.apache.gravitino.catalog.postgresql.converter.PostgreSqlTypeConverter.SMALLSERIAL;
+import static org.apache.gravitino.catalog.postgresql.converter.PostgreSqlTypeConverter.UUID;
 
 import org.apache.gravitino.catalog.jdbc.converter.JdbcTypeConverter;
 import org.apache.gravitino.rel.types.Type;


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add type mappings for PostgreSQL's `serial`, `smallserial`, and `bigserial` type aliases in `PostgreSqlTypeConverter.toGravitino()`.

### Why are the changes needed?

When the JDBC driver reports `serial`/`smallserial`/`bigserial` as the TYPE_NAME, the converter falls through to `ExternalType.of("serial")`. The Trino connector has no mapping for `EXTERNAL` types, causing queries to fail with:

```
Unsupported gravitino datatype: external(serial)
```

These types are aliases for `int2`/`int4`/`int8` with an auto-increment sequence, so they map to `ShortType`/`IntegerType`/`LongType` respectively.

The shorthand aliases `serial2`/`serial4`/`serial8` are deliberately not handled. PostgreSQL resolves them to the canonical `smallserial`/`serial`/`bigserial` names in `pg_type`, so the JDBC driver never reports them as a column's TYPE_NAME, and cases for them would be unreachable.

Fix: #10957

### Does this PR introduce _any_ user-facing change?

No API changes. PostgreSQL tables with serial columns can now be queried through Trino without errors.

### How was this patch tested?

Added unit test assertions for the three serial types in `TestPostgreSqlTypeConverter.testToGravitinoType()`.

```
./gradlew :catalogs:catalog-jdbc-postgresql:test --tests '*TestPostgreSqlTypeConverter*' -PskipITs
```

3 tests, 0 failures.
