### PR TITLE
[#10956] fix(catalog-glue): Move AWS Glue integration tests to integration/test path

### DIFF
--- a/catalogs/catalog-glue/src/test/java/org/apache/gravitino/catalog/glue/AbstractGlueSchemaTest.java
+++ b/catalogs/catalog-glue/src/test/java/org/apache/gravitino/catalog/glue/AbstractGlueSchemaTest.java
@@ -34,7 +34,7 @@ import software.amazon.awssdk.services.glue.model.Database;
  * <p>Subclasses provide a {@link Database} object however they like (SDK builder, real AWS API,
  * etc.). The test scenarios are defined once here and shared across all implementations.
  */
-abstract class AbstractGlueSchemaTest {
+public abstract class AbstractGlueSchemaTest {
 
   /**
    * Returns a Glue {@link Database} with the given fields. Subclasses may create this via the SDK

--- a/catalogs/catalog-glue/src/test/java/org/apache/gravitino/catalog/glue/AbstractGlueTableTest.java
+++ b/catalogs/catalog-glue/src/test/java/org/apache/gravitino/catalog/glue/AbstractGlueTableTest.java
@@ -37,7 +37,7 @@ import software.amazon.awssdk.services.glue.model.Table;
  * <p>Subclasses supply the {@link Table} object — either via SDK builder (synthetic) or via the
  * real Glue API — while the test scenarios are defined once here.
  */
-abstract class AbstractGlueTableTest {
+public abstract class AbstractGlueTableTest {
 
   private static final GlueTypeConverter TYPE_CONVERTER = new GlueTypeConverter();
 

--- a/catalogs/catalog-glue/src/test/java/org/apache/gravitino/catalog/glue/integration/test/TestAwsGlueSchema.java
+++ b/catalogs/catalog-glue/src/test/java/org/apache/gravitino/catalog/glue/integration/test/TestAwsGlueSchema.java
@@ -16,10 +16,13 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.gravitino.catalog.glue;
+package org.apache.gravitino.catalog.glue.integration.test;
 
 import java.util.HashMap;
 import java.util.Map;
+import org.apache.gravitino.catalog.glue.AbstractGlueSchemaTest;
+import org.apache.gravitino.catalog.glue.GlueClientProvider;
+import org.apache.gravitino.catalog.glue.GlueConstants;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
@@ -45,8 +48,8 @@ import software.amazon.awssdk.services.glue.model.GlueException;
  * </ul>
  *
  * <p>Each test creates a real Glue database, retrieves it via the API (getting a real serialized
- * response), converts it to a {@link GlueSchema}, and asserts the field mapping. The database is
- * deleted in {@link #cleanup} regardless of test outcome.
+ * response), converts it to a {@link org.apache.gravitino.catalog.glue.GlueSchema}, and asserts the
+ * field mapping. The database is deleted in {@link #cleanup} regardless of test outcome.
  */
 @EnabledIfEnvironmentVariable(named = "AWS_ACCESS_KEY_ID", matches = ".+")
 class TestAwsGlueSchema extends AbstractGlueSchemaTest {

--- a/catalogs/catalog-glue/src/test/java/org/apache/gravitino/catalog/glue/integration/test/TestAwsGlueTable.java
+++ b/catalogs/catalog-glue/src/test/java/org/apache/gravitino/catalog/glue/integration/test/TestAwsGlueTable.java
@@ -16,10 +16,13 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.gravitino.catalog.glue;
+package org.apache.gravitino.catalog.glue.integration.test;
 
 import java.util.HashMap;
 import java.util.Map;
+import org.apache.gravitino.catalog.glue.AbstractGlueTableTest;
+import org.apache.gravitino.catalog.glue.GlueClientProvider;
+import org.apache.gravitino.catalog.glue.GlueConstants;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
@@ -51,8 +54,8 @@ import software.amazon.awssdk.services.glue.model.TableInput;
  * </ul>
  *
  * <p>Each test creates a real Glue table in a pre-created database, retrieves it via the API,
- * converts it to a {@link GlueTable}, and asserts the field mapping. The table (and schema) is
- * deleted in {@link #cleanup} regardless of test outcome.
+ * converts it to a {@link org.apache.gravitino.catalog.glue.GlueTable}, and asserts the field
+ * mapping. The table (and schema) is deleted in {@link #cleanup} regardless of test outcome.
  */
 @EnabledIfEnvironmentVariable(named = "AWS_ACCESS_KEY_ID", matches = ".+")
 class TestAwsGlueTable extends AbstractGlueTableTest {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Move `TestAwsGlueSchema` and `TestAwsGlueTable` from the unit test directory into the `integration/test/` subdirectory so they are excluded by the existing `skipITs` Gradle rule. Widen the abstract base classes (`AbstractGlueSchemaTest`, `AbstractGlueTableTest`) to `public` with `@VisibleForTesting` for cross-package access.

### Why are the changes needed?

These tests hit real AWS Glue endpoints and run automatically when a developer has ambient AWS credentials (`AWS_ACCESS_KEY_ID`) set. Because they reside outside the `integration/test/` path, the `exclude("**/integration/test/**")` rule in `build.gradle.kts` does not filter them out during `./gradlew test -PskipITs`. This can cause unintended resource creation, security alerts, or API costs.

Fixes #10956

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Ran `./gradlew :catalogs:catalog-glue:test -PskipITs` and verified `TestAwsGlueSchema` and `TestAwsGlueTable` no longer appear in the test report while all other unit tests pass.