### PR TITLE
[#10474] feat(lock): Introduce LockBackend SPI with in-process default and opt-in JDBC backend

### DIFF
--- a/core/src/main/java/org/apache/gravitino/Configs.java
+++ b/core/src/main/java/org/apache/gravitino/Configs.java
@@ -281,6 +281,81 @@ public class Configs {
           .longConf()
           .createWithDefault(CLEAN_INTERVAL_IN_SECS);
 
+  // The followings are configurations for the pluggable lock backend (see
+  // design-docs/treelock-ha.md). The default 'inprocess' backend preserves the historical
+  // single-JVM TreeLock behavior; 'jdbc' coordinates locks across nodes via the relational
+  // store and is intended for HA deployments.
+
+  public static final String LOCK_BACKEND_TYPE_INPROCESS = "inprocess";
+  public static final String LOCK_BACKEND_TYPE_JDBC = "jdbc";
+
+  public static final ConfigEntry<String> LOCK_BACKEND_TYPE =
+      new ConfigBuilder("gravitino.lock.backend.type")
+          .doc(
+              "The lock backend implementation: '"
+                  + LOCK_BACKEND_TYPE_INPROCESS
+                  + "' (default; in-JVM TreeLock) or '"
+                  + LOCK_BACKEND_TYPE_JDBC
+                  + "' (cross-node, requires a relational lock store)")
+          .version(ConfigConstants.VERSION_1_3_0)
+          .stringConf()
+          .createWithDefault(LOCK_BACKEND_TYPE_INPROCESS);
+
+  public static final ConfigEntry<String> LOCK_BACKEND_JDBC_URL =
+      new ConfigBuilder("gravitino.lock.backend.jdbc.url")
+          .doc(
+              "JDBC URL for the JDBC lock backend. When unset, falls back to "
+                  + ENTITY_RELATIONAL_JDBC_BACKEND_URL_KEY)
+          .version(ConfigConstants.VERSION_1_3_0)
+          .stringConf()
+          .createWithDefault("");
+
+  public static final ConfigEntry<String> LOCK_BACKEND_JDBC_USER =
+      new ConfigBuilder("gravitino.lock.backend.jdbc.user")
+          .doc(
+              "Username for the JDBC lock backend. When unset, falls back to "
+                  + ENTITY_RELATIONAL_JDBC_BACKEND_USER_KEY)
+          .version(ConfigConstants.VERSION_1_3_0)
+          .stringConf()
+          .createWithDefault("");
+
+  public static final ConfigEntry<String> LOCK_BACKEND_JDBC_PASSWORD =
+      new ConfigBuilder("gravitino.lock.backend.jdbc.password")
+          .doc(
+              "Password for the JDBC lock backend. When unset, falls back to "
+                  + ENTITY_RELATIONAL_JDBC_BACKEND_PASSWORD_KEY)
+          .version(ConfigConstants.VERSION_1_3_0)
+          .stringConf()
+          .createWithDefault("");
+
+  public static final ConfigEntry<String> LOCK_BACKEND_JDBC_DRIVER =
+      new ConfigBuilder("gravitino.lock.backend.jdbc.driver")
+          .doc(
+              "JDBC driver class name for the JDBC lock backend. When unset, falls back to "
+                  + ENTITY_RELATIONAL_JDBC_BACKEND_DRIVER_KEY)
+          .version(ConfigConstants.VERSION_1_3_0)
+          .stringConf()
+          .createWithDefault("");
+
+  public static final ConfigEntry<Integer> LOCK_BACKEND_JDBC_POOL_SIZE =
+      new ConfigBuilder("gravitino.lock.backend.jdbc.poolSize")
+          .doc(
+              "Maximum number of JDBC connections held by the JDBC lock backend. Each in-flight"
+                  + " lock holds one connection for the duration of the operation, so this caps"
+                  + " concurrent lock-holding operations on this server.")
+          .version(ConfigConstants.VERSION_1_3_0)
+          .intConf()
+          .createWithDefault(8);
+
+  public static final ConfigEntry<Long> LOCK_BACKEND_JDBC_ACQUIRE_TIMEOUT_MS =
+      new ConfigBuilder("gravitino.lock.backend.jdbc.acquireTimeoutMs")
+          .doc(
+              "Maximum time in milliseconds to wait for a single row lock to be granted before"
+                  + " the JDBC lock backend gives up and the operation fails")
+          .version(ConfigConstants.VERSION_1_3_0)
+          .longConf()
+          .createWithDefault(30_000L);
+
   public static final ConfigEntry<Boolean> ENABLE_AUTHORIZATION =
       new ConfigBuilder("gravitino.authorization.enable")
           .doc("Enable the authorization")

--- a/core/src/main/java/org/apache/gravitino/GravitinoEnv.java
+++ b/core/src/main/java/org/apache/gravitino/GravitinoEnv.java
@@ -523,6 +523,14 @@ public class GravitinoEnv {
       }
     }
 
+    if (lockManager != null) {
+      try {
+        lockManager.close();
+      } catch (Exception e) {
+        LOG.warn("Failed to close LockManager.", e);
+      }
+    }
+
     LOG.info("Gravitino Environment is shut down.");
   }
 

--- a/core/src/main/java/org/apache/gravitino/lock/InProcessLockBackend.java
+++ b/core/src/main/java/org/apache/gravitino/lock/InProcessLockBackend.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.lock;
+
+import org.apache.gravitino.NameIdentifier;
+
+/**
+ * The default {@link LockBackend}: a thin wrapper over the in-JVM {@link TreeLock} machinery owned
+ * by {@link LockManager}. Behavior is unchanged from the pre-SPI implementation.
+ *
+ * <p>This backend provides no cross-process coordination and therefore is unsuitable for HA
+ * deployments — see {@link JdbcLockBackend} for that.
+ */
+final class InProcessLockBackend implements LockBackend {
+
+  static final String NAME = "inprocess";
+
+  private final LockManager manager;
+
+  InProcessLockBackend(LockManager manager) {
+    this.manager = manager;
+  }
+
+  @Override
+  public LockHandle acquire(NameIdentifier identifier, LockType lockType) {
+    TreeLock lock = manager.createTreeLock(identifier);
+    try {
+      lock.lock(lockType);
+    } catch (RuntimeException e) {
+      // TreeLock.lock() rolls back partial acquisitions internally on failure; the references
+      // taken by createTreeLock are released by that internal unlock(). Nothing to do here.
+      throw e;
+    }
+    return new TreeLockHandle(lock);
+  }
+
+  @Override
+  public String name() {
+    return NAME;
+  }
+
+  /**
+   * Idempotent handle wrapping a single {@link TreeLock}.
+   *
+   * <p>Visible-for-testing because some legacy lock tests exercise the underlying {@link TreeLock}
+   * directly; nothing here is part of the public SPI.
+   */
+  private static final class TreeLockHandle implements LockHandle {
+    private final TreeLock lock;
+    private boolean closed = false;
+
+    TreeLockHandle(TreeLock lock) {
+      this.lock = lock;
+    }
+
+    @Override
+    public synchronized void close() {
+      if (closed) {
+        return;
+      }
+      closed = true;
+      lock.unlock();
+    }
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/lock/JdbcDialect.java
+++ b/core/src/main/java/org/apache/gravitino/lock/JdbcDialect.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.lock;
+
+import com.google.common.base.Preconditions;
+import java.util.Locale;
+
+/**
+ * SQL dialect differences for {@link JdbcLockBackend}. Detected from the JDBC URL prefix at backend
+ * construction time; the exact same heuristic the existing relational entity store uses.
+ *
+ * <p>Why this enum exists: portable {@code INSERT IF NOT EXISTS}, shared row locks, and lock-wait
+ * timeouts have non-portable syntax across H2/MySQL/Postgres. Centralising the differences here
+ * keeps {@link JdbcLockBackend} dialect-agnostic.
+ */
+enum JdbcDialect {
+  POSTGRES,
+  MYSQL,
+  H2;
+
+  static final String LOCK_TABLE = "gravitino_lock";
+
+  static JdbcDialect fromUrl(String url) {
+    Preconditions.checkArgument(url != null && !url.isEmpty(), "JDBC URL must not be empty");
+    String lower = url.toLowerCase(Locale.ROOT);
+    if (lower.startsWith("jdbc:postgresql:")) {
+      return POSTGRES;
+    }
+    if (lower.startsWith("jdbc:mysql:")) {
+      return MYSQL;
+    }
+    if (lower.startsWith("jdbc:h2:")) {
+      return H2;
+    }
+    throw new IllegalArgumentException(
+        "Unsupported JDBC URL for the lock backend: "
+            + url
+            + ". Supported prefixes: jdbc:postgresql:, jdbc:mysql:, jdbc:h2:");
+  }
+
+  /**
+   * SQL that creates the lock table if it does not already exist. The table has a single {@code
+   * lock_path VARCHAR PRIMARY KEY} column — observability columns (holder, txn id, acquired at) are
+   * intentionally omitted in v1; see {@code design-docs/treelock-ha.md} §6.7.
+   */
+  String createTableSql() {
+    switch (this) {
+      case POSTGRES:
+      case MYSQL:
+      case H2:
+        // VARCHAR(1024) accommodates the deepest reasonable metalake/catalog/schema/table path.
+        return "CREATE TABLE IF NOT EXISTS "
+            + LOCK_TABLE
+            + " (lock_path VARCHAR(1024) NOT NULL, PRIMARY KEY (lock_path))";
+      default:
+        throw new IllegalStateException("Unhandled dialect: " + this);
+    }
+  }
+
+  /**
+   * SQL that sets the per-transaction lock-wait timeout. Must be invoked after {@code BEGIN} and
+   * before any row-locking statements.
+   */
+  String lockTimeoutStatement(long timeoutMs) {
+    Preconditions.checkArgument(timeoutMs > 0, "Lock timeout must be positive");
+    switch (this) {
+      case POSTGRES:
+        return "SET LOCAL lock_timeout = '" + timeoutMs + "ms'";
+      case MYSQL:
+        // MySQL's innodb_lock_wait_timeout is integer seconds, minimum 1.
+        return "SET innodb_lock_wait_timeout = " + Math.max(1, timeoutMs / 1000);
+      case H2:
+        return "SET LOCK_TIMEOUT " + timeoutMs;
+      default:
+        throw new IllegalStateException("Unhandled dialect: " + this);
+    }
+  }
+
+  /** Idempotent INSERT — ensures a row exists for {@code lock_path} so subsequent locking works. */
+  String upsertSql() {
+    switch (this) {
+      case POSTGRES:
+        return "INSERT INTO " + LOCK_TABLE + " (lock_path) VALUES (?) ON CONFLICT DO NOTHING";
+      case MYSQL:
+        return "INSERT IGNORE INTO " + LOCK_TABLE + " (lock_path) VALUES (?)";
+      case H2:
+        return "MERGE INTO " + LOCK_TABLE + " (lock_path) KEY (lock_path) VALUES (?)";
+      default:
+        throw new IllegalStateException("Unhandled dialect: " + this);
+    }
+  }
+
+  /**
+   * Acquire an exclusive row lock on {@code lock_path}. Used for the leaf of {@link LockType#WRITE}
+   * acquisitions.
+   */
+  String selectForUpdateSql() {
+    return "SELECT 1 FROM " + LOCK_TABLE + " WHERE lock_path = ? FOR UPDATE";
+  }
+
+  /**
+   * Acquire a shared row lock on {@code lock_path}. Used for ancestor nodes and for the leaf of
+   * {@link LockType#READ} acquisitions.
+   *
+   * <p>H2's {@code FOR SHARE} is not as well-supported as Postgres/MySQL; on H2 we degrade to the
+   * exclusive lock. Operators using H2 are by definition not running an HA deployment, so the extra
+   * contention is acceptable.
+   */
+  String selectForShareSql() {
+    switch (this) {
+      case POSTGRES:
+      case MYSQL:
+        return "SELECT 1 FROM " + LOCK_TABLE + " WHERE lock_path = ? FOR SHARE";
+      case H2:
+        return selectForUpdateSql();
+      default:
+        throw new IllegalStateException("Unhandled dialect: " + this);
+    }
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/lock/JdbcLockBackend.java
+++ b/core/src/main/java/org/apache/gravitino/lock/JdbcLockBackend.java
@@ -1,0 +1,363 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.lock;
+
+import static org.apache.gravitino.Configs.ENTITY_RELATIONAL_JDBC_BACKEND_DRIVER;
+import static org.apache.gravitino.Configs.ENTITY_RELATIONAL_JDBC_BACKEND_PASSWORD;
+import static org.apache.gravitino.Configs.ENTITY_RELATIONAL_JDBC_BACKEND_URL;
+import static org.apache.gravitino.Configs.ENTITY_RELATIONAL_JDBC_BACKEND_USER;
+import static org.apache.gravitino.Configs.LOCK_BACKEND_JDBC_ACQUIRE_TIMEOUT_MS;
+import static org.apache.gravitino.Configs.LOCK_BACKEND_JDBC_DRIVER;
+import static org.apache.gravitino.Configs.LOCK_BACKEND_JDBC_PASSWORD;
+import static org.apache.gravitino.Configs.LOCK_BACKEND_JDBC_POOL_SIZE;
+import static org.apache.gravitino.Configs.LOCK_BACKEND_JDBC_URL;
+import static org.apache.gravitino.Configs.LOCK_BACKEND_JDBC_USER;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Sets;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import javax.sql.DataSource;
+import org.apache.commons.dbcp2.BasicDataSource;
+import org.apache.gravitino.Config;
+import org.apache.gravitino.NameIdentifier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A {@link LockBackend} that coordinates locks across Gravitino server instances using a single
+ * relational table and per-row {@code SELECT ... FOR UPDATE / FOR SHARE} statements.
+ *
+ * <p>This backend is opt-in via {@code gravitino.lock.backend.type=jdbc}. The default in-process
+ * backend remains in place for single-node deployments — see {@link InProcessLockBackend}.
+ *
+ * <p>Design notes (full discussion in {@code design-docs/treelock-ha.md}):
+ *
+ * <ul>
+ *   <li>Lock table schema is intentionally minimal: a single {@code lock_path VARCHAR PRIMARY KEY}
+ *       column. Observability columns (holder, txn id, acquired_at) are deferred.
+ *   <li>Acquire opens a dedicated JDBC connection from a private DBCP2 pool, runs all per-level
+ *       {@code INSERT / SELECT FOR ...} statements, and hands the connection to the returned {@link
+ *       LockHandle}. {@code close()} commits and returns the connection to the pool.
+ *   <li>Reentrant acquisition by the same thread on the same leaf path is rejected — a follow-up PR
+ *       may add thread-local connection threading.
+ *   <li>Process crash mid-lock is safe: the database releases the abandoned connection's row locks
+ *       within its own dead-connection-detection window.
+ * </ul>
+ */
+final class JdbcLockBackend implements LockBackend {
+
+  private static final Logger LOG = LoggerFactory.getLogger(JdbcLockBackend.class);
+
+  static final String NAME = "jdbc";
+  static final String ROOT_PATH = "/";
+
+  private static final ThreadLocal<Set<String>> ACTIVE_PATHS_PER_THREAD =
+      ThreadLocal.withInitial(HashSet::new);
+
+  private final BasicDataSource dataSource;
+  private final JdbcDialect dialect;
+  private final long acquireTimeoutMs;
+
+  JdbcLockBackend(Config config) {
+    String url =
+        resolve(
+            LOCK_BACKEND_JDBC_URL.getKey(),
+            ENTITY_RELATIONAL_JDBC_BACKEND_URL.getKey(),
+            config.get(LOCK_BACKEND_JDBC_URL),
+            config.get(ENTITY_RELATIONAL_JDBC_BACKEND_URL));
+    String user =
+        resolve(
+            LOCK_BACKEND_JDBC_USER.getKey(),
+            ENTITY_RELATIONAL_JDBC_BACKEND_USER.getKey(),
+            config.get(LOCK_BACKEND_JDBC_USER),
+            config.get(ENTITY_RELATIONAL_JDBC_BACKEND_USER));
+    String password =
+        resolveOrEmpty(
+            config.get(LOCK_BACKEND_JDBC_PASSWORD),
+            config.get(ENTITY_RELATIONAL_JDBC_BACKEND_PASSWORD));
+    String driver =
+        resolve(
+            LOCK_BACKEND_JDBC_DRIVER.getKey(),
+            ENTITY_RELATIONAL_JDBC_BACKEND_DRIVER.getKey(),
+            config.get(LOCK_BACKEND_JDBC_DRIVER),
+            config.get(ENTITY_RELATIONAL_JDBC_BACKEND_DRIVER));
+    int poolSize = config.get(LOCK_BACKEND_JDBC_POOL_SIZE);
+    Preconditions.checkArgument(
+        poolSize > 0, "gravitino.lock.backend.jdbc.poolSize must be positive, was %s", poolSize);
+    this.acquireTimeoutMs = config.get(LOCK_BACKEND_JDBC_ACQUIRE_TIMEOUT_MS);
+    Preconditions.checkArgument(
+        acquireTimeoutMs > 0,
+        "gravitino.lock.backend.jdbc.acquireTimeoutMs must be positive, was %s",
+        acquireTimeoutMs);
+
+    this.dialect = JdbcDialect.fromUrl(url);
+    this.dataSource = buildDataSource(url, user, password, driver, poolSize);
+    initSchema();
+    LOG.info(
+        "JdbcLockBackend initialized (dialect={}, poolSize={}, acquireTimeoutMs={})",
+        dialect,
+        poolSize,
+        acquireTimeoutMs);
+  }
+
+  /** Test-only: inject a pre-built data source and dialect to bypass JDBC URL resolution. */
+  @VisibleForTesting
+  JdbcLockBackend(BasicDataSource dataSource, JdbcDialect dialect, long acquireTimeoutMs) {
+    this.dataSource = dataSource;
+    this.dialect = dialect;
+    this.acquireTimeoutMs = acquireTimeoutMs;
+    initSchema();
+  }
+
+  @Override
+  public LockHandle acquire(NameIdentifier identifier, LockType lockType) {
+    List<String> paths = pathsRootDown(identifier);
+    String leafPath = paths.get(paths.size() - 1);
+
+    Set<String> activePaths = ACTIVE_PATHS_PER_THREAD.get();
+    if (!activePaths.add(leafPath)) {
+      throw new IllegalStateException(
+          "JdbcLockBackend does not support reentrant acquisition. "
+              + "Thread "
+              + Thread.currentThread().getName()
+              + " already holds lock for path: "
+              + leafPath);
+    }
+
+    Connection connection = null;
+    try {
+      connection = dataSource.getConnection();
+      connection.setAutoCommit(false);
+      try (Statement s = connection.createStatement()) {
+        s.execute(dialect.lockTimeoutStatement(acquireTimeoutMs));
+      }
+      for (int i = 0; i < paths.size(); i++) {
+        String path = paths.get(i);
+        LockType levelType = (i == paths.size() - 1) ? lockType : LockType.READ;
+        ensureRow(connection, path);
+        acquireRow(connection, path, levelType);
+      }
+      return new JdbcLockHandle(connection, leafPath);
+    } catch (SQLException e) {
+      activePaths.remove(leafPath);
+      rollbackAndClose(connection);
+      throw new LockBackendException(
+          "Failed to acquire " + lockType + " lock on " + identifier + " via JDBC backend", e);
+    } catch (RuntimeException e) {
+      activePaths.remove(leafPath);
+      rollbackAndClose(connection);
+      throw e;
+    }
+  }
+
+  @Override
+  public String name() {
+    return NAME;
+  }
+
+  @Override
+  public void close() {
+    try {
+      dataSource.close();
+    } catch (SQLException e) {
+      LOG.warn("Failed to close JdbcLockBackend data source", e);
+    }
+  }
+
+  /**
+   * Compute the root-down list of paths to lock for {@code identifier}. Mirrors the in-process
+   * backend's traversal in {@link LockManager#createTreeLock(NameIdentifier)}.
+   *
+   * <p>Examples:
+   *
+   * <ul>
+   *   <li>{@code NameIdentifier.of("/")} → {@code ["/"]}
+   *   <li>{@code NameIdentifier.of("metalake")} → {@code ["/", "/metalake"]}
+   *   <li>{@code NameIdentifier.of("metalake", "catalog", "db", "tbl")} → {@code ["/", "/metalake",
+   *       "/metalake/catalog", "/metalake/catalog/db", "/metalake/catalog/db/tbl"]}
+   * </ul>
+   */
+  @VisibleForTesting
+  @SuppressWarnings("ReferenceEquality") // mirrors LockManager.createTreeLock — ROOT is a singleton
+  static List<String> pathsRootDown(NameIdentifier identifier) {
+    List<String> paths = new ArrayList<>();
+    paths.add(ROOT_PATH);
+    if (identifier == LockManager.ROOT) {
+      return paths;
+    }
+    StringBuilder sb = new StringBuilder();
+    for (String level : identifier.namespace().levels()) {
+      sb.append('/').append(level);
+      paths.add(sb.toString());
+    }
+    sb.append('/').append(identifier.name());
+    paths.add(sb.toString());
+    return paths;
+  }
+
+  @VisibleForTesting
+  DataSource dataSource() {
+    return dataSource;
+  }
+
+  @VisibleForTesting
+  static Set<String> activePathsForCurrentThread() {
+    return Sets.newHashSet(ACTIVE_PATHS_PER_THREAD.get());
+  }
+
+  // -- private ---------------------------------------------------------------------------------
+
+  private static BasicDataSource buildDataSource(
+      String url, String user, String password, String driver, int poolSize) {
+    BasicDataSource ds = new BasicDataSource();
+    ds.setUrl(url);
+    ds.setUsername(user);
+    ds.setPassword(password);
+    ds.setDriverClassName(driver);
+    ds.setMaxTotal(poolSize);
+    ds.setMinIdle(0);
+    ds.setDefaultAutoCommit(false);
+    return ds;
+  }
+
+  private void initSchema() {
+    try (Connection c = dataSource.getConnection()) {
+      boolean previousAutoCommit = c.getAutoCommit();
+      c.setAutoCommit(true);
+      try (Statement s = c.createStatement()) {
+        s.execute(dialect.createTableSql());
+      } finally {
+        c.setAutoCommit(previousAutoCommit);
+      }
+    } catch (SQLException e) {
+      throw new LockBackendException(
+          "Failed to initialize lock table " + JdbcDialect.LOCK_TABLE, e);
+    }
+  }
+
+  private void ensureRow(Connection conn, String path) throws SQLException {
+    try (PreparedStatement ps = conn.prepareStatement(dialect.upsertSql())) {
+      ps.setString(1, path);
+      ps.executeUpdate();
+    }
+  }
+
+  private void acquireRow(Connection conn, String path, LockType type) throws SQLException {
+    String sql =
+        (type == LockType.READ) ? dialect.selectForShareSql() : dialect.selectForUpdateSql();
+    try (PreparedStatement ps = conn.prepareStatement(sql)) {
+      ps.setString(1, path);
+      try (ResultSet rs = ps.executeQuery()) {
+        // Result is irrelevant; the lock is held by the act of executing the statement.
+        rs.next();
+      }
+    }
+  }
+
+  private static void rollbackAndClose(Connection connection) {
+    if (connection == null) {
+      return;
+    }
+    try {
+      connection.rollback();
+    } catch (SQLException ignored) {
+      // The connection may already be in an unrecoverable state; closing it is what matters.
+    }
+    try {
+      connection.close();
+    } catch (SQLException ignored) {
+      // Returning to the pool failed — nothing useful to do beyond logging.
+    }
+  }
+
+  /**
+   * Resolve a primary config value, falling back to a secondary if the primary is empty. Throws
+   * with a clear message if both are empty.
+   */
+  private static String resolve(
+      String primaryKey, String fallbackKey, String primary, String fallback) {
+    if (primary != null && !primary.isEmpty()) {
+      return primary;
+    }
+    if (fallback != null && !fallback.isEmpty()) {
+      return fallback;
+    }
+    throw new IllegalStateException(
+        "JdbcLockBackend requires "
+            + primaryKey
+            + " (or, as a fallback, "
+            + fallbackKey
+            + ") to be set");
+  }
+
+  /** Resolve a config value that may legitimately be empty (e.g., password). */
+  private static String resolveOrEmpty(String primary, String fallback) {
+    if (primary != null && !primary.isEmpty()) {
+      return primary;
+    }
+    return fallback == null ? "" : fallback;
+  }
+
+  /** Idempotent handle that commits and releases the underlying JDBC connection. */
+  private static final class JdbcLockHandle implements LockHandle {
+    private final Connection connection;
+    private final String leafPath;
+    private boolean closed = false;
+
+    JdbcLockHandle(Connection connection, String leafPath) {
+      this.connection = connection;
+      this.leafPath = leafPath;
+    }
+
+    @Override
+    public synchronized void close() {
+      if (closed) {
+        return;
+      }
+      closed = true;
+      try {
+        connection.commit();
+      } catch (SQLException e) {
+        LOG.warn("Failed to commit lock release for path {}; attempting rollback", leafPath, e);
+        try {
+          connection.rollback();
+        } catch (SQLException ignored) {
+          // Connection is unusable; close() below will reclaim it.
+        }
+      } finally {
+        try {
+          connection.close();
+        } catch (SQLException ignored) {
+          // Pool will reap it.
+        }
+        ACTIVE_PATHS_PER_THREAD.get().remove(leafPath);
+      }
+    }
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/lock/LockBackend.java
+++ b/core/src/main/java/org/apache/gravitino/lock/LockBackend.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.lock;
+
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.annotation.Evolving;
+
+/**
+ * A pluggable backend that grants and releases hierarchical read/write locks keyed by {@link
+ * NameIdentifier} paths.
+ *
+ * <p>Two implementations ship today: {@link InProcessLockBackend} (the default; preserves the
+ * historical in-JVM {@link TreeLock} semantics) and {@link JdbcLockBackend} (cross-process
+ * coordination using a relational database, intended for HA deployments). Additional backends
+ * (ZooKeeper, etcd, Raft) can be added without touching the call sites in {@link TreeLockUtils}.
+ *
+ * <p>Implementations MUST acquire ancestor locks root-down to preserve the deadlock-free total
+ * acquisition order on which existing call sites rely. See {@code design-docs/treelock-ha.md}.
+ */
+@Evolving
+public interface LockBackend extends AutoCloseable {
+
+  /**
+   * Acquire a hierarchical lock on {@code identifier}. Ancestor nodes are taken with {@link
+   * LockType#READ}; the leaf is taken with the requested {@code lockType}.
+   *
+   * @param identifier the resource path
+   * @param lockType {@link LockType#READ} or {@link LockType#WRITE} for the leaf
+   * @return an idempotent handle that releases all locks acquired by this call when closed
+   * @throws RuntimeException if the lock cannot be acquired (timeout, backend unavailable, etc.).
+   *     The exact subtype is backend-defined.
+   */
+  LockHandle acquire(NameIdentifier identifier, LockType lockType);
+
+  /** Backend identifier for logs and metrics, e.g. {@code "inprocess"} or {@code "jdbc"}. */
+  String name();
+
+  /**
+   * Release backend-owned resources (connection pools, schedulers, etc.). Idempotent.
+   * Implementations that own no such resources may rely on the empty default.
+   */
+  @Override
+  default void close() {}
+}

--- a/core/src/main/java/org/apache/gravitino/lock/LockBackendException.java
+++ b/core/src/main/java/org/apache/gravitino/lock/LockBackendException.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.lock;
+
+/**
+ * Thrown by a {@link LockBackend} when an acquire fails for a recoverable reason — typically a
+ * timeout, a database-level deadlock, or transient backend unavailability.
+ *
+ * <p>Callers may catch and retry, surface as HTTP 503/409 to clients, or fail the operation. The
+ * exact response policy is dispatcher-specific; backends only translate underlying errors into this
+ * typed exception.
+ */
+public class LockBackendException extends RuntimeException {
+
+  private static final long serialVersionUID = 1L;
+
+  public LockBackendException(String message) {
+    super(message);
+  }
+
+  public LockBackendException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/lock/LockHandle.java
+++ b/core/src/main/java/org/apache/gravitino/lock/LockHandle.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.lock;
+
+import org.apache.gravitino.annotation.Evolving;
+
+/**
+ * A handle representing a successfully acquired lock from a {@link LockBackend}. {@link #close()}
+ * releases every lock acquired by the originating {@code acquire(...)} call, in reverse acquisition
+ * order, and must be idempotent.
+ *
+ * <p>Intended to be used with try-with-resources:
+ *
+ * <pre>{@code
+ * try (LockHandle handle = backend.acquire(ident, LockType.WRITE)) {
+ *   // operation runs while the lock is held
+ * }
+ * }</pre>
+ */
+@Evolving
+public interface LockHandle extends AutoCloseable {
+
+  /**
+   * Release all locks held by this handle. Idempotent — calling {@code close()} more than once is a
+   * no-op. Must not throw checked exceptions.
+   */
+  @Override
+  void close();
+}

--- a/core/src/main/java/org/apache/gravitino/lock/LockManager.java
+++ b/core/src/main/java/org/apache/gravitino/lock/LockManager.java
@@ -19,6 +19,9 @@
 
 package org.apache.gravitino.lock;
 
+import static org.apache.gravitino.Configs.LOCK_BACKEND_TYPE;
+import static org.apache.gravitino.Configs.LOCK_BACKEND_TYPE_INPROCESS;
+import static org.apache.gravitino.Configs.LOCK_BACKEND_TYPE_JDBC;
 import static org.apache.gravitino.Configs.TREE_LOCK_CLEAN_INTERVAL;
 import static org.apache.gravitino.Configs.TREE_LOCK_MAX_NODE_IN_MEMORY;
 import static org.apache.gravitino.Configs.TREE_LOCK_MIN_NODE_IN_MEMORY;
@@ -63,6 +66,11 @@ public class LockManager {
 
   // The interval in seconds to clean up the stale tree lock nodes.
   @VisibleForTesting long cleanTreeNodeIntervalInSecs;
+
+  // The lock backend selected at construction time. The default 'inprocess' backend wraps the
+  // existing in-JVM TreeLock machinery owned by this manager; the 'jdbc' backend coordinates
+  // locks across nodes via a relational store. See design-docs/treelock-ha.md.
+  private final LockBackend backend;
 
   private void initParameters(Config config) {
     long maxNodesInMemory = config.get(TREE_LOCK_MAX_NODE_IN_MEMORY);
@@ -191,6 +199,47 @@ public class LockManager {
 
     // Start deadlock checker.
     startDeadLockChecker();
+
+    // Select the lock backend. The in-process backend wraps the in-JVM tree above; alternative
+    // backends (currently only 'jdbc') ignore that tree and coordinate via their own mechanism.
+    // A null/empty value is treated as 'inprocess' to remain compatible with the many test
+    // fixtures that construct LockManager from a mocked Config without stubbing the new key.
+    String backendType = config.get(LOCK_BACKEND_TYPE);
+    if (backendType == null
+        || backendType.isEmpty()
+        || LOCK_BACKEND_TYPE_INPROCESS.equalsIgnoreCase(backendType)) {
+      this.backend = new InProcessLockBackend(this);
+    } else if (LOCK_BACKEND_TYPE_JDBC.equalsIgnoreCase(backendType)) {
+      this.backend = new JdbcLockBackend(config);
+      LOG.info(
+          "Lock backend 'jdbc' selected. The in-memory tree-lock cleaner and dead-lock checker"
+              + " continue to run but operate on an unused tree.");
+    } else {
+      throw new IllegalArgumentException(
+          "Unsupported value for "
+              + LOCK_BACKEND_TYPE.getKey()
+              + ": '"
+              + backendType
+              + "'. Supported values: '"
+              + LOCK_BACKEND_TYPE_INPROCESS
+              + "', '"
+              + LOCK_BACKEND_TYPE_JDBC
+              + "'");
+    }
+  }
+
+  /** Return the active {@link LockBackend}. */
+  public LockBackend backend() {
+    return backend;
+  }
+
+  /** Release backend-owned resources (connection pools, schedulers, etc.). Idempotent. */
+  public void close() {
+    try {
+      backend.close();
+    } catch (Exception e) {
+      LOG.warn("Failed to close lock backend '{}'", backend.name(), e);
+    }
   }
 
   /**

--- a/core/src/main/java/org/apache/gravitino/lock/TreeLockUtils.java
+++ b/core/src/main/java/org/apache/gravitino/lock/TreeLockUtils.java
@@ -31,7 +31,11 @@ public class TreeLockUtils {
   }
 
   /**
-   * Execute the given executable with the given tree lock.
+   * Execute the given executable while holding a hierarchical lock on {@code identifier}.
+   *
+   * <p>The lock is acquired via the configured {@link LockBackend} (default: in-process). All
+   * existing call sites are unchanged in semantics — see {@code design-docs/treelock-ha.md} for the
+   * full backend story.
    *
    * @param identifier The identifier of resource path that the lock attempts to lock.
    * @param lockType The type of lock to use.
@@ -43,12 +47,9 @@ public class TreeLockUtils {
    */
   public static <R, E extends Exception> R doWithTreeLock(
       NameIdentifier identifier, LockType lockType, Executable<R, E> executable) throws E {
-    TreeLock lock = GravitinoEnv.getInstance().lockManager().createTreeLock(identifier);
-    try {
-      lock.lock(lockType);
+    LockBackend backend = GravitinoEnv.getInstance().lockManager().backend();
+    try (LockHandle handle = backend.acquire(identifier, lockType)) {
       return executable.execute();
-    } finally {
-      lock.unlock();
     }
   }
 

--- a/core/src/test/java/org/apache/gravitino/lock/TestInProcessLockBackend.java
+++ b/core/src/test/java/org/apache/gravitino/lock/TestInProcessLockBackend.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.lock;
+
+import static org.apache.gravitino.Configs.LOCK_BACKEND_TYPE;
+import static org.apache.gravitino.Configs.LOCK_BACKEND_TYPE_INPROCESS;
+import static org.apache.gravitino.Configs.TREE_LOCK_CLEAN_INTERVAL;
+import static org.apache.gravitino.Configs.TREE_LOCK_MAX_NODE_IN_MEMORY;
+import static org.apache.gravitino.Configs.TREE_LOCK_MIN_NODE_IN_MEMORY;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+import org.apache.gravitino.Config;
+import org.apache.gravitino.NameIdentifier;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TestInProcessLockBackend {
+
+  private static Config newConfig() {
+    Config config = mock(Config.class);
+    doReturn(100_000L).when(config).get(TREE_LOCK_MAX_NODE_IN_MEMORY);
+    doReturn(1_000L).when(config).get(TREE_LOCK_MIN_NODE_IN_MEMORY);
+    doReturn(36_000L).when(config).get(TREE_LOCK_CLEAN_INTERVAL);
+    doReturn(LOCK_BACKEND_TYPE_INPROCESS).when(config).get(LOCK_BACKEND_TYPE);
+    return config;
+  }
+
+  @Test
+  void defaultBackendIsInProcess() {
+    LockManager manager = new LockManager(newConfig());
+    Assertions.assertEquals("inprocess", manager.backend().name());
+  }
+
+  @Test
+  void acquireWriteAndReleaseDecrementsReferenceCount() {
+    LockManager manager = new LockManager(newConfig());
+    LockBackend backend = manager.backend();
+
+    NameIdentifier ident = NameIdentifier.of("metalake", "catalog", "db", "tbl");
+    long beforeNodeCount = manager.totalNodeCount.get();
+
+    LockHandle handle = backend.acquire(ident, LockType.WRITE);
+    Assertions.assertNotNull(handle);
+    handle.close();
+
+    // The cleaner runs on a schedule; references should already be back to zero per node.
+    Assertions.assertTrue(manager.totalNodeCount.get() >= beforeNodeCount);
+  }
+
+  @Test
+  void acquireReadDoesNotBlockAnotherRead() {
+    LockManager manager = new LockManager(newConfig());
+    LockBackend backend = manager.backend();
+    NameIdentifier ident = NameIdentifier.of("metalake", "schema");
+
+    try (LockHandle h1 = backend.acquire(ident, LockType.READ);
+        LockHandle h2 = backend.acquire(ident, LockType.READ)) {
+      // Two READ locks on the same path co-exist — would have deadlocked under WRITE/WRITE.
+      Assertions.assertNotNull(h1);
+      Assertions.assertNotNull(h2);
+    }
+  }
+
+  @Test
+  void closeIsIdempotent() {
+    LockManager manager = new LockManager(newConfig());
+    LockBackend backend = manager.backend();
+
+    LockHandle handle = backend.acquire(NameIdentifier.of("metalake"), LockType.READ);
+    handle.close();
+    // Second close must be a no-op, not a double-unlock that throws or corrupts ref counts.
+    Assertions.assertDoesNotThrow(handle::close);
+  }
+
+  @Test
+  void rootLockHandleAcquiresAndReleasesCleanly() {
+    LockManager manager = new LockManager(newConfig());
+    LockBackend backend = manager.backend();
+    try (LockHandle h = backend.acquire(LockManager.ROOT, LockType.WRITE)) {
+      Assertions.assertNotNull(h);
+    }
+  }
+
+  @Test
+  void unsupportedBackendTypeThrows() {
+    Config config = newConfig();
+    doReturn("zookeeper").when(config).get(LOCK_BACKEND_TYPE);
+    Assertions.assertThrows(IllegalArgumentException.class, () -> new LockManager(config));
+  }
+}

--- a/core/src/test/java/org/apache/gravitino/lock/TestJdbcDialect.java
+++ b/core/src/test/java/org/apache/gravitino/lock/TestJdbcDialect.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.lock;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TestJdbcDialect {
+
+  @Test
+  void fromUrlMatchesPostgresPrefix() {
+    Assertions.assertEquals(
+        JdbcDialect.POSTGRES, JdbcDialect.fromUrl("jdbc:postgresql://localhost:5432/gravitino"));
+    Assertions.assertEquals(JdbcDialect.POSTGRES, JdbcDialect.fromUrl("JDBC:POSTGRESQL://host/db"));
+  }
+
+  @Test
+  void fromUrlMatchesMysqlPrefix() {
+    Assertions.assertEquals(
+        JdbcDialect.MYSQL, JdbcDialect.fromUrl("jdbc:mysql://localhost:3306/gravitino"));
+  }
+
+  @Test
+  void fromUrlMatchesH2Prefix() {
+    Assertions.assertEquals(JdbcDialect.H2, JdbcDialect.fromUrl("jdbc:h2:mem:test"));
+    Assertions.assertEquals(JdbcDialect.H2, JdbcDialect.fromUrl("jdbc:h2:file:/tmp/gravitino"));
+  }
+
+  @Test
+  void fromUrlRejectsUnknownPrefix() {
+    Assertions.assertThrows(
+        IllegalArgumentException.class, () -> JdbcDialect.fromUrl("jdbc:oracle:thin:@host:1521"));
+    Assertions.assertThrows(
+        IllegalArgumentException.class, () -> JdbcDialect.fromUrl("not-a-jdbc-url"));
+  }
+
+  @Test
+  void fromUrlRejectsEmpty() {
+    Assertions.assertThrows(IllegalArgumentException.class, () -> JdbcDialect.fromUrl(""));
+    Assertions.assertThrows(IllegalArgumentException.class, () -> JdbcDialect.fromUrl(null));
+  }
+
+  @Test
+  void createTableSqlReferencesLockTable() {
+    for (JdbcDialect d : JdbcDialect.values()) {
+      String sql = d.createTableSql();
+      Assertions.assertTrue(sql.contains(JdbcDialect.LOCK_TABLE), "missing table name in: " + sql);
+      Assertions.assertTrue(sql.contains("lock_path"), "missing column in: " + sql);
+      Assertions.assertTrue(
+          sql.toUpperCase(java.util.Locale.ROOT).contains("PRIMARY KEY"),
+          "missing PRIMARY KEY in: " + sql);
+    }
+  }
+
+  @Test
+  void lockTimeoutStatementHonorsDialectUnits() {
+    Assertions.assertTrue(JdbcDialect.POSTGRES.lockTimeoutStatement(15_000L).contains("15000ms"));
+    // MySQL uses seconds, integer; expect 15 (15000ms / 1000) or floor.
+    Assertions.assertTrue(JdbcDialect.MYSQL.lockTimeoutStatement(15_000L).contains("15"));
+    Assertions.assertTrue(JdbcDialect.H2.lockTimeoutStatement(15_000L).contains("15000"));
+  }
+
+  @Test
+  void lockTimeoutStatementClampsMysqlToOneSecondMinimum() {
+    // 500 ms / 1000 = 0, but innodb_lock_wait_timeout requires >= 1.
+    String sql = JdbcDialect.MYSQL.lockTimeoutStatement(500L);
+    Assertions.assertTrue(sql.endsWith(" 1"), "expected clamped to 1 second, got: " + sql);
+  }
+
+  @Test
+  void lockTimeoutStatementRejectsNonPositive() {
+    for (JdbcDialect d : JdbcDialect.values()) {
+      Assertions.assertThrows(IllegalArgumentException.class, () -> d.lockTimeoutStatement(0));
+      Assertions.assertThrows(IllegalArgumentException.class, () -> d.lockTimeoutStatement(-1));
+    }
+  }
+
+  @Test
+  void upsertSqlIsDialectSpecific() {
+    Assertions.assertTrue(JdbcDialect.POSTGRES.upsertSql().contains("ON CONFLICT DO NOTHING"));
+    Assertions.assertTrue(JdbcDialect.MYSQL.upsertSql().contains("INSERT IGNORE"));
+    Assertions.assertTrue(JdbcDialect.H2.upsertSql().startsWith("MERGE INTO"));
+  }
+
+  @Test
+  void selectForShareSqlDegradesOnH2() {
+    // H2's FOR SHARE is unreliable; backend degrades to FOR UPDATE.
+    Assertions.assertEquals(
+        JdbcDialect.H2.selectForUpdateSql(), JdbcDialect.H2.selectForShareSql());
+    Assertions.assertTrue(JdbcDialect.POSTGRES.selectForShareSql().endsWith("FOR SHARE"));
+    Assertions.assertTrue(JdbcDialect.MYSQL.selectForShareSql().endsWith("FOR SHARE"));
+  }
+
+  @Test
+  void selectForUpdateSqlIsUniformAcrossDialects() {
+    for (JdbcDialect d : JdbcDialect.values()) {
+      Assertions.assertTrue(d.selectForUpdateSql().endsWith("FOR UPDATE"), d.toString());
+    }
+  }
+}

--- a/core/src/test/java/org/apache/gravitino/lock/TestJdbcLockBackend.java
+++ b/core/src/test/java/org/apache/gravitino/lock/TestJdbcLockBackend.java
@@ -1,0 +1,180 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.lock;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import org.apache.commons.dbcp2.BasicDataSource;
+import org.apache.gravitino.NameIdentifier;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class TestJdbcLockBackend {
+
+  private BasicDataSource dataSource;
+  private JdbcLockBackend backend;
+
+  @BeforeEach
+  void setup() {
+    // Per-test in-memory H2 database (named so that the per-test DataSource sees its own).
+    String url = "jdbc:h2:mem:lock_" + UUID.randomUUID().toString().replace('-', '_');
+    dataSource = new BasicDataSource();
+    dataSource.setUrl(url);
+    dataSource.setUsername("sa");
+    dataSource.setPassword("");
+    dataSource.setDriverClassName("org.h2.Driver");
+    dataSource.setMaxTotal(4);
+    dataSource.setDefaultAutoCommit(false);
+    backend = new JdbcLockBackend(dataSource, JdbcDialect.H2, 10_000L);
+  }
+
+  @AfterEach
+  void teardown() throws Exception {
+    if (backend != null) {
+      backend.close();
+    }
+    if (dataSource != null && !dataSource.isClosed()) {
+      dataSource.close();
+    }
+  }
+
+  @Test
+  void backendNameIsJdbc() {
+    Assertions.assertEquals("jdbc", backend.name());
+  }
+
+  @Test
+  void initSchemaCreatesLockTable() throws Exception {
+    try (Connection c = dataSource.getConnection();
+        Statement s = c.createStatement();
+        ResultSet rs = s.executeQuery("SELECT COUNT(*) FROM " + JdbcDialect.LOCK_TABLE)) {
+      Assertions.assertTrue(rs.next());
+      Assertions.assertEquals(0, rs.getInt(1));
+    }
+  }
+
+  @Test
+  void acquireWriteAndReleaseInsertsLockRow() throws Exception {
+    NameIdentifier ident = NameIdentifier.of("metalake", "catalog", "db", "tbl");
+    try (LockHandle handle = backend.acquire(ident, LockType.WRITE)) {
+      Assertions.assertNotNull(handle);
+    }
+
+    // After release, the lock-path rows persist (the table is monotonic in v1).
+    try (Connection c = dataSource.getConnection();
+        Statement s = c.createStatement();
+        ResultSet rs = s.executeQuery("SELECT COUNT(*) FROM " + JdbcDialect.LOCK_TABLE)) {
+      Assertions.assertTrue(rs.next());
+      // Five rows: /, /metalake, /metalake/catalog, /metalake/catalog/db,
+      // /metalake/catalog/db/tbl
+      Assertions.assertEquals(5, rs.getInt(1));
+    }
+  }
+
+  @Test
+  void acquireRootLockUsesSinglePath() {
+    try (LockHandle handle = backend.acquire(LockManager.ROOT, LockType.WRITE)) {
+      Assertions.assertNotNull(handle);
+    }
+  }
+
+  @Test
+  void closeIsIdempotent() {
+    LockHandle handle = backend.acquire(NameIdentifier.of("ns"), LockType.READ);
+    handle.close();
+    Assertions.assertDoesNotThrow(handle::close);
+  }
+
+  @Test
+  void reentrantAcquisitionOnSameLeafThrows() {
+    NameIdentifier ident = NameIdentifier.of("metalake", "catalog");
+    try (LockHandle outer = backend.acquire(ident, LockType.WRITE)) {
+      Assertions.assertThrows(
+          IllegalStateException.class, () -> backend.acquire(ident, LockType.WRITE));
+    }
+    // After release, a fresh acquisition on the same leaf is allowed again.
+    try (LockHandle h = backend.acquire(ident, LockType.WRITE)) {
+      Assertions.assertNotNull(h);
+    }
+  }
+
+  @Test
+  void pathsRootDownProducesTreeWalkOrder() {
+    Assertions.assertEquals(List.of("/"), JdbcLockBackend.pathsRootDown(LockManager.ROOT));
+    Assertions.assertEquals(
+        List.of("/", "/metalake"), JdbcLockBackend.pathsRootDown(NameIdentifier.of("metalake")));
+    Assertions.assertEquals(
+        List.of("/", "/m", "/m/c", "/m/c/db", "/m/c/db/tbl"),
+        JdbcLockBackend.pathsRootDown(NameIdentifier.of("m", "c", "db", "tbl")));
+  }
+
+  /**
+   * Two threads acquiring WRITE on the same path must serialize. The second waits for the first to
+   * release before it can proceed.
+   */
+  @Test
+  void writeWriteOnSamePathSerializes() throws Exception {
+    NameIdentifier ident = NameIdentifier.of("ns", "shared");
+    CountDownLatch firstAcquired = new CountDownLatch(1);
+    ExecutorService pool = Executors.newFixedThreadPool(2);
+    try {
+      Future<Long> first =
+          pool.submit(
+              () -> {
+                LockHandle h = backend.acquire(ident, LockType.WRITE);
+                firstAcquired.countDown();
+                // Hold the lock long enough for the second thread to queue behind us.
+                Thread.sleep(500);
+                long t = System.nanoTime();
+                h.close();
+                return t;
+              });
+
+      Future<Long> second =
+          pool.submit(
+              () -> {
+                Assertions.assertTrue(firstAcquired.await(5, TimeUnit.SECONDS));
+                // Blocks here until the first thread releases.
+                LockHandle h = backend.acquire(ident, LockType.WRITE);
+                long t = System.nanoTime();
+                h.close();
+                return t;
+              });
+
+      long firstReleaseNanos = first.get(10, TimeUnit.SECONDS);
+      long secondAcquireNanos = second.get(10, TimeUnit.SECONDS);
+      Assertions.assertTrue(
+          secondAcquireNanos >= firstReleaseNanos,
+          "second WRITE acquired before first WRITE released — locks did not serialize");
+    } finally {
+      pool.shutdownNow();
+    }
+  }
+}

--- a/design-docs/treelock-ha.md
+++ b/design-docs/treelock-ha.md
@@ -1,0 +1,549 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+# TreeLock HA Design — `LockBackend` SPI + JDBC Backend
+
+Tracking issue: [#10474](https://github.com/apache/gravitino/issues/10474)
+
+---
+
+## 1. Background
+
+### 1.1 What `TreeLock` is today
+
+Gravitino guards every metadata operation with a hierarchical read–write lock implemented in
+`core/src/main/java/org/apache/gravitino/lock/`. The package is small (≈ 400 lines of Java
+across five files):
+
+| File | Responsibility |
+|------|----------------|
+| `LockType.java` | `enum { READ, WRITE }` |
+| `TreeLockNode.java` | One node in the lock tree. Wraps a `ReentrantReadWriteLock`. Tracks `holdingThreadTimestamp` keyed by `(thread, identifier)`, plus an `AtomicLong` reference count for eviction. |
+| `TreeLock.java` | A per-operation handle. `lock(LockType)` walks the path root → leaf, takes `READ` on every ancestor and the requested type on the leaf, and pushes acquired nodes onto a deque. `unlock()` pops in reverse order. |
+| `LockManager.java` | Singleton owner of the tree. `createTreeLock(identifier)` walks the path, creating missing nodes via `getOrCreateChild` (a `ConcurrentHashMap.computeIfAbsent`). Runs two daemon schedulers: a stale-node cleaner (BFS evicting nodes with `reference == 0` once total nodes exceed `0.5 × maxTreeNodeInMemory`) and a "deadlock checker" that, despite its name, only logs `WARN` when a node is held longer than 30 seconds. |
+| `TreeLockUtils.java` | Static facade — `doWithTreeLock(identifier, lockType, executable)` is the universal entry point and resolves the manager via `GravitinoEnv.getInstance().lockManager()`. |
+
+The pattern is the classic intention-locking convention: `READ` on every ancestor effectively
+acts as an `IS`/`IX` lock, and the actual `READ`/`WRITE` lives on the leaf.
+
+```
+loading metalake.catalog.db.tbl                renaming metalake.catalog.db.tbl
+  /                       READ                   /                       READ
+  /metalake               READ                   /metalake               READ
+  /metalake/catalog       READ                   /metalake/catalog       READ
+  /metalake/catalog/db    READ                   /metalake/catalog/db    WRITE  ← parent
+  /metalake/catalog/db/tbl READ
+```
+
+### 1.2 Why it exists
+
+`TreeLockUtils.doWithTreeLock(...)` is invoked from 19 source files in `core/`:
+
+```
+core/src/main/java/org/apache/gravitino/
+├── authorization/
+│   ├── AccessControlManager.java
+│   ├── OwnerManager.java
+│   └── PermissionManager.java
+├── catalog/
+│   ├── CatalogManager.java
+│   ├── FilesetOperationDispatcher.java
+│   ├── FunctionOperationDispatcher.java
+│   ├── ModelOperationDispatcher.java
+│   ├── PartitionOperationDispatcher.java
+│   ├── SchemaOperationDispatcher.java
+│   ├── TableOperationDispatcher.java
+│   ├── TopicOperationDispatcher.java
+│   └── ViewOperationDispatcher.java
+├── job/
+│   ├── BuiltInJobTemplateEventListener.java
+│   └── JobManager.java
+├── metalake/
+│   └── MetalakeManager.java
+├── policy/
+│   └── PolicyManager.java
+├── stats/
+│   └── StatisticManager.java
+└── tag/
+    └── TagManager.java
+```
+
+These are the synchronization points for almost every metadata mutation in the system.
+
+### 1.3 Configuration today
+
+`Configs.java` exposes three keys (all `gravitino.lock.*`):
+
+| Key | Default | Purpose |
+|-----|---------|---------|
+| `gravitino.lock.maxNodes` | `MAX_NODE_IN_MEMORY` | Cap on live `TreeLockNode`s; cleanup triggers above 0.5× this |
+| `gravitino.lock.minNodes` | `MIN_NODE_IN_MEMORY` | Floor below which the cleaner is a no-op |
+| `gravitino.lock.cleanIntervalInSecs` | `CLEAN_INTERVAL_IN_SECS` | Cleaner cadence |
+
+There is no key today selecting a *type* of lock backend — the in-process implementation is
+hard-wired in `GravitinoEnv.java:551` via `this.lockManager = new LockManager(config)`.
+
+---
+
+## 2. Problem Statement
+
+`TreeLock` has zero cross-process awareness. Each Gravitino server holds its own
+`LockManager` with its own `treeLockRootNode` in JVM memory. Under HA — the deployment
+mode Gravitino is moving toward — the lock tree on server A is invisible to server B.
+
+### 2.1 Concrete failure modes
+
+1. **Concurrent conflicting writes**. Two REST clients each hit a different node and rename
+   the same table. Both `WRITE` locks succeed locally; both proceed to the underlying store.
+   The result depends on the underlying store's atomicity — see §2.2.
+2. **Read-modify-write races on the metadata store**. Several call sites do
+   `load → mutate → save` against `EntityStore`. Without cross-process serialization, two
+   such sequences interleave and the second writer overwrites the first writer's effect
+   without observing it.
+3. **Per-JVM "deadlock" detection**. The check in `LockManager.checkDeadLock` only walks
+   the local tree, so a thread blocked waiting on a lock held in a *different* JVM is
+   invisible. (Strictly speaking even the local check is just a 30-second held-lock warning,
+   not a wait-for-graph analysis — see §1.1.)
+4. **Stale auth caches across nodes**. Indirectly: many auth-side mutations
+   (`AccessControlManager`, `PermissionManager`, `OwnerManager`) rely on TreeLock for
+   ordering. Combined with the per-node JCasbin caches (see
+   `design-docs/cache-improvement-design.md`), HA exposes both an ordering hole and a
+   coherence hole.
+
+### 2.2 Blast radius is not uniform
+
+The damage from a TreeLock miss depends on what the underlying store does:
+
+| Call-site category | Underlying state | What actually breaks under HA |
+|--------------------|------------------|-------------------------------|
+| Dispatchers writing to **`RelationalEntityStore`** (Gravitino-owned tables: metalake, catalog, schema, role, tag, policy, …) | Gravitino's JDBC store (H2/MySQL/Postgres) | Lost updates, phantom inserts on the metadata DB; no row-level guard exists today |
+| Dispatchers proxying to **external catalogs** (Hive Metastore, Iceberg, Kafka, JDBC catalogs) | The external system | The external system arbitrates writes; Gravitino's local view can drift, but corruption of external state is unlikely |
+| **Auth managers** writing role/permission/owner state | `RelationalEntityStore` + JCasbin policy cache | Same as the first row, plus stale caches on other nodes |
+
+The implication: a uniform "wrap every TreeLock call in a distributed lock" answer pays the
+network cost on every operation — including the proxy-only ones whose blast radius is
+already small. We can do better by combining a pluggable lock backend with storage-level
+guards.
+
+---
+
+## 3. Goals and Non-Goals
+
+### 3.1 Goals
+
+- Eliminate cross-process race conditions on **Gravitino's own metadata store** (the
+  largest blast-radius category).
+- Give operators a way to enable cross-node coordination *without* forcing them to deploy a
+  new component (ZooKeeper/etcd/Redis), so HA is reachable for everyone running Gravitino
+  on a relational backend.
+- Preserve the current zero-RPC, zero-allocation in-process lock as the default — single-node
+  Gravitino deployments must see no behavior change and no measurable performance change.
+- Keep the change reviewable: introduce a clear `LockBackend` SPI now so future backends
+  (ZooKeeper, etcd, Raft-on-store, …) can land as bounded follow-up PRs.
+
+### 3.2 Non-goals
+
+- **Solving consistency for external catalogs.** If a Hive table is mutated outside
+  Gravitino, no Gravitino-level lock can help. The external system owns its concurrency.
+- **Implementing ZooKeeper, etcd, or Redis backends in this PR.** Those are tracked as
+  follow-ups; the SPI surface is designed to accommodate them.
+- **Replacing the deadlock-warning mechanism with real distributed deadlock detection.**
+  The JDBC backend relies on the database's own lock-wait-timeout instead.
+- **Re-litigating which call sites need a lock.** A separate audit pass (Phase B in §8)
+  will examine whether some `doWithTreeLock` calls can be replaced by storage-level CAS,
+  but that work is out of scope here.
+
+---
+
+## 4. Solution Options
+
+### 4.1 Option A — Drop-in distributed lock
+
+Replace `LockManager` with a distributed implementation (ZooKeeper via Curator's
+`InterProcessReadWriteLock`, etcd, or Redis Redlock).
+
+| Dimension | Verdict |
+|-----------|---------|
+| Semantics | Equivalent — read/write hierarchy preserved |
+| Performance | **Bad.** Depth-N path = N coordinator round-trips per operation. At a 1 ms LAN RTT and depth 5, that's +5 ms on every metadata read |
+| Operational cost | New mandatory component to deploy/monitor/HA |
+| Correctness pitfalls | Lease expiry under JVM GC pauses, fencing tokens, split-brain (Redis specifically) |
+| Required call-site changes | None |
+
+### 4.2 Option B — Storage-level concurrency
+
+Delete `TreeLock`. Add a `version` column to `RelationalEntity`; rewrite mutations as
+`UPDATE … SET …, version = version + 1 WHERE id = ? AND version = ?` and retry on conflict.
+
+| Dimension | Verdict |
+|-----------|---------|
+| Semantics | Different — optimistic, no parent-level write locks; coarse "lock the whole schema during a rename" must be recreated via composite CAS or an explicit table-level lock |
+| Performance | Excellent — zero overhead on the read path; one extra column write |
+| Operational cost | None |
+| Correctness pitfalls | Doesn't help the proxy paths; multi-row atomic ops need either serializable isolation or careful ordering |
+| Required call-site changes | Significant — every mutation in `RelationalEntityStore` and every retry-handling caller |
+
+### 4.3 Option C — Hybrid (recommended)
+
+Two independent, sequenceable mechanisms:
+
+1. **Pluggable `LockBackend` SPI** behind `LockManager`. The default `InProcessLockBackend`
+   is byte-for-byte the current behavior. A new `JdbcLockBackend` reuses the relational
+   backend Gravitino *already* requires — no new operational dependency. ZooKeeper / etcd
+   backends slot in later via the same SPI.
+2. **Optimistic CAS in `RelationalEntityStore`** (a follow-up PR — flagged here as the next
+   step but not implemented in this change). Catches HA races on the metadata store even
+   if no distributed lock backend is configured, and keeps catching them when one is.
+
+This document and its companion PR introduce **(1)** end-to-end and ship a working JDBC
+backend. **(2)** is staged into a follow-up because it touches every entity persister and
+benefits from a separate review cycle.
+
+---
+
+## 5. Recommended Design
+
+### 5.1 SPI surface
+
+```java
+package org.apache.gravitino.lock;
+
+/** A pluggable backend that grants and releases path-keyed RW locks. */
+public interface LockBackend extends Closeable {
+
+  /**
+   * Acquire a hierarchical lock on the given identifier. Implementations MUST acquire
+   * locks root-down to preserve the deadlock-free total ordering already in place.
+   *
+   * @param identifier the resource to lock
+   * @param lockType   READ or WRITE; WRITE is exclusive on the leaf only
+   * @return a handle whose {@link LockHandle#close()} releases all locks acquired by
+   *         this call, in reverse acquisition order
+   */
+  LockHandle acquire(NameIdentifier identifier, LockType lockType);
+
+  /** Backend-specific identifier surfaced in logs and metrics. */
+  String name();
+}
+
+/** Acquired-lock handle. {@code close()} is idempotent. */
+public interface LockHandle extends AutoCloseable {
+  @Override
+  void close();
+}
+```
+
+`TreeLockUtils` becomes a thin wrapper:
+
+```java
+public static <R, E extends Exception> R doWithTreeLock(
+    NameIdentifier identifier, LockType lockType, Executable<R, E> executable) throws E {
+  LockBackend backend = GravitinoEnv.getInstance().lockManager().backend();
+  try (LockHandle handle = backend.acquire(identifier, lockType)) {
+    return executable.execute();
+  }
+}
+```
+
+`LockManager` keeps its existing constructor signature and its existing scheduler ownership;
+internally it instantiates a `LockBackend` from configuration and exposes `backend()` to
+`TreeLockUtils`. The existing `TreeLock` / `TreeLockNode` classes remain intact and become
+the implementation of `InProcessLockBackend`.
+
+### 5.2 Configuration additions
+
+| Key | Default | Purpose |
+|-----|---------|---------|
+| `gravitino.lock.backend.type` | `inprocess` | `inprocess` or `jdbc` |
+| `gravitino.lock.backend.jdbc.url` | *(unset → reuses `gravitino.entity.store.relational.jdbcUrl`)* | JDBC URL for the lock table; allowed to be a different DB if operators want to isolate |
+| `gravitino.lock.backend.jdbc.user` | *(unset → reuses entity-store user)* | Username |
+| `gravitino.lock.backend.jdbc.password` | *(unset → reuses entity-store password)* | Password |
+| `gravitino.lock.backend.jdbc.driver` | *(unset → reuses entity-store driver)* | JDBC driver class |
+| `gravitino.lock.backend.jdbc.acquireTimeoutMs` | `30000` | Maximum wait per individual acquire; backed by `SET LOCAL lock_timeout` (Postgres) / `SET innodb_lock_wait_timeout` (MySQL) |
+| `gravitino.lock.backend.jdbc.poolSize` | `8` | Dedicated connection pool — must not borrow from the entity-store pool because acquired locks hold a connection for the duration of the operation |
+
+The existing three `gravitino.lock.maxNodes` / `minNodes` / `cleanIntervalInSecs` keys
+continue to apply only to the in-process backend and are silently ignored (with a log
+message at startup) when `backend.type=jdbc`.
+
+### 5.3 Lifecycle & wiring in `GravitinoEnv`
+
+`GravitinoEnv.initialize` already constructs `LockManager` once. The change is contained:
+
+```java
+// before
+this.lockManager = new LockManager(config);
+
+// after
+this.lockManager = new LockManager(config);  // signature unchanged
+// LockManager constructor now picks the backend internally
+```
+
+Shutdown ordering: `LockManager.close()` (newly added) closes the backend, which releases
+any pool/connection resources. This must run before `EntityStore.close()` so that
+in-flight locks held against the JDBC backend can drain cleanly.
+
+---
+
+## 6. JDBC Backend — Detailed Design
+
+### 6.1 Schema
+
+A single new table, deployed via the existing Liquibase changelog mechanism the relational
+backend already uses for entity tables:
+
+```sql
+CREATE TABLE gravitino_lock (
+  lock_path     VARCHAR(1024) NOT NULL,
+  PRIMARY KEY (lock_path)
+);
+```
+
+Rationale for this minimal schema:
+
+- **No `lock_holder`/`acquired_at` columns are needed for correctness.** The actual lock is
+  the row's `SELECT ... FOR UPDATE` row lock, which the database tracks. Adding
+  observability columns (holder, txn id, acquired_at, server id) is straightforward but
+  deferred — it would require connection-affinity tracking inside the backend.
+- **Pre-populating rows is unnecessary.** Each `acquire` first ensures the row exists via
+  `INSERT ... ON CONFLICT DO NOTHING` (Postgres / H2 v2.0+) or `INSERT IGNORE`
+  (MySQL), then takes the row lock.
+- **`VARCHAR(1024)`** comfortably accommodates the deepest reasonable
+  metalake/catalog/schema/table/partition path. Hashing the path was considered and
+  rejected — the false-contention risk from collisions outweighs the few bytes saved.
+
+### 6.2 Acquire algorithm
+
+For path `/metalake/catalog/db/tbl` with `WRITE`:
+
+```
+BEGIN;                                  -- new dedicated connection from JdbcLockBackend pool
+SET LOCAL lock_timeout = '30s';         -- Postgres; equivalent on each dialect
+
+-- Acquire root-down. Every ancestor takes a SHARED lock; the leaf takes the requested type.
+INSERT ... ON CONFLICT DO NOTHING into gravitino_lock VALUES ('/');
+SELECT 1 FROM gravitino_lock WHERE lock_path='/'                FOR SHARE;
+
+INSERT ... ON CONFLICT DO NOTHING ... VALUES ('/metalake');
+SELECT 1 FROM gravitino_lock WHERE lock_path='/metalake'        FOR SHARE;
+
+INSERT ... ON CONFLICT DO NOTHING ... VALUES ('/metalake/catalog');
+SELECT 1 FROM gravitino_lock WHERE lock_path='/metalake/catalog' FOR SHARE;
+
+INSERT ... ON CONFLICT DO NOTHING ... VALUES ('/metalake/catalog/db');
+SELECT 1 FROM gravitino_lock WHERE lock_path='/metalake/catalog/db' FOR SHARE;
+
+INSERT ... ON CONFLICT DO NOTHING ... VALUES ('/metalake/catalog/db/tbl');
+SELECT 1 FROM gravitino_lock WHERE lock_path='/metalake/catalog/db/tbl' FOR UPDATE;
+-- ... operation runs while connection (and therefore the locks) are held
+COMMIT;                                  -- releases all locks atomically
+```
+
+`READ` requests use `FOR SHARE` on the leaf as well; `WRITE` uses `FOR UPDATE` only on the
+leaf (consistent with the in-process backend's "READ on ancestors, requested type on leaf"
+convention).
+
+### 6.3 Dialect portability
+
+| Database | `INSERT ... IF NOT EXISTS` | Shared row lock | Exclusive row lock | Lock-wait timeout |
+|----------|----------------------------|-----------------|--------------------|-------------------|
+| **Postgres** | `INSERT ... ON CONFLICT DO NOTHING` | `FOR SHARE` | `FOR UPDATE` | `SET LOCAL lock_timeout = '30s'` |
+| **MySQL ≥ 8.0** | `INSERT IGNORE` | `FOR SHARE` | `FOR UPDATE` | `SET innodb_lock_wait_timeout = 30` |
+| **H2 ≥ 2.0** | `MERGE INTO ... KEY(...)` | `FOR SHARE`¹ | `FOR UPDATE` | `SET LOCK_TIMEOUT 30000` |
+
+¹ H2's `FOR SHARE` is implemented but not as performant as Postgres/MySQL; the test suite
+treats H2 as a developer-only dialect.
+
+A small `JdbcDialect` enum in `JdbcLockBackend` switches the SQL strings. The dialect is
+detected from the JDBC URL prefix at backend construction time (the same heuristic
+`JDBCBackend` uses today).
+
+### 6.4 Connection management
+
+- **Dedicated pool.** Lock-holding connections must not borrow from the entity-store pool;
+  they would starve it. The lock backend opens its own HikariCP pool sized via
+  `gravitino.lock.backend.jdbc.poolSize` (default 8).
+- **Connection-per-operation.** The acquire phase opens a connection, runs all the
+  `INSERT/SELECT` statements, and stores the connection inside the returned `LockHandle`.
+  `LockHandle.close()` commits the transaction and returns the connection to the pool.
+- **JVM crash safety.** If the Gravitino process dies mid-operation, the database closes
+  the abandoned connection, which rolls back the transaction and releases all row locks.
+  This is the same property `SELECT ... FOR UPDATE` provides for ordinary application code.
+- **No reentrancy guarantee in this version.** A single thread that calls
+  `doWithTreeLock` recursively will get a *new* connection on the inner call and will
+  block waiting for itself on the outer connection's row locks. Fixing this requires
+  thread-local connection threading and is deferred to a follow-up; a defensive runtime
+  check inside `JdbcLockBackend.acquire` will throw a clear error if reentry is detected.
+
+### 6.5 Performance characteristics
+
+For a depth-5 path, an acquire issues 5 `INSERT IF NOT EXISTS` + 5 `SELECT FOR SHARE/UPDATE`
+= 10 round-trips. Against a co-located Postgres at 0.3 ms/RTT that's ≈ 3 ms of added
+latency per acquire, on top of the operation's own DB work. The release is one `COMMIT`
+(1 RTT, ≈ 0.3 ms).
+
+Mitigations available *inside the same backend* without changing the SPI:
+
+- **Leaf-only locking** when the caller opts in via a future `LockType.LEAF_ONLY` — for
+  operations that don't need the parent-stability guarantee. Out of scope here.
+- **Path-prefix caching.** A future revision can cache "this server has held a SHARED lock
+  on `/metalake/catalog` recently" and skip re-acquiring it within a short TTL; this
+  trades correctness for latency and is intentionally not part of the v1 design.
+- **Batched acquire.** Wrap the per-level `INSERT/SELECT` pairs in a JDBC `addBatch()` to
+  cut the round-trip count in half.
+
+The in-process backend stays at roughly zero overhead; operators who don't enable HA pay
+nothing.
+
+### 6.6 Failure semantics
+
+| Scenario | Behavior |
+|----------|----------|
+| Lock-table row contended longer than `acquireTimeoutMs` | DB throws `lock_not_available` (Postgres `55P03`) / `ER_LOCK_WAIT_TIMEOUT` (MySQL `1205`). Backend translates to `LockAcquisitionTimeoutException` (new), bubbled to caller. |
+| Connection pool exhausted | Hikari throws `SQLTransientConnectionException`. Backend wraps as `LockBackendUnavailableException` (new). |
+| JDBC URL unreachable at startup | Backend construction fails and `GravitinoEnv.initialize` aborts — operator sees the error immediately rather than at first request time. |
+| Process crash mid-lock | DB releases the abandoned connection's row locks within its own TCP keep-alive / dead-connection-detection window (Postgres default ~ minutes; tunable). |
+
+### 6.7 What this backend does NOT do
+
+- It does not implement reentrant locks across recursive `doWithTreeLock` calls (see §6.4).
+- It does not provide cross-node observability ("which node holds this lock?") — the lock
+  table carries no holder column in v1.
+- It does not solve the auth-cache staleness problem (`design-docs/cache-improvement-design.md`).
+- It does not replace the in-process deadlock-warning thread; that thread remains useful
+  for the in-process backend.
+
+---
+
+## 7. Correctness Analysis
+
+### 7.1 Mutual exclusion under HA
+
+Two servers attempting `WRITE` on the same path acquire the same lock-table row's
+`FOR UPDATE` lock. The database serializes them. The second writer either waits up to
+`acquireTimeoutMs` for the first to commit, or fails with a timeout. Reads (`FOR SHARE`)
+on different paths proceed in parallel; reads on the same path also proceed in parallel
+(modulo the DB's shared-lock implementation).
+
+### 7.2 Hierarchy is preserved
+
+Acquire order is strictly root-down on every path. Release order is reverse (achieved
+implicitly by `COMMIT` releasing all row locks at once). Two servers acquiring overlapping
+paths therefore acquire shared row locks in the same global order on the common ancestors
+and only contend on the leaf — the same property as the in-process backend.
+
+### 7.3 Deadlock freedom
+
+Within a single node: same-path reentry is the only intra-server deadlock risk, and it is
+detected and rejected (§6.4). Across nodes: the database's own deadlock detector handles
+genuine cycles (e.g., server A holds shared lock on `/m`, server B holds exclusive on
+`/m/c` and requests shared on `/m`). Postgres aborts one side with `ERROR: 40P01`; MySQL
+returns `ER_LOCK_DEADLOCK`. Both are translated to a retryable `LockDeadlockException`.
+
+### 7.4 What CAN still go wrong
+
+- A lock acquired on server A and a long GC pause on A → the operation takes longer than
+  the lock-wait timeout on server B, which gives up. This is a *liveness* failure (B
+  retries), not a *safety* failure (A's mutation still happens behind its lock).
+- A network partition between Gravitino and the lock DB. The in-progress operation's
+  connection dies; the DB releases the lock; the operation rolls back. Other servers
+  proceed. Same liveness-only outcome.
+- Misconfiguration: pointing two HA Gravitino clusters at the same lock DB but different
+  entity stores would cross-couple them. The deployment guide must call this out.
+
+---
+
+## 8. Migration Plan
+
+The introduction is purely additive and the new backend is opt-in.
+
+### Phase A — This PR
+
+1. Add `LockBackend` SPI and `InProcessLockBackend` (current behavior), default-on.
+2. Add `JdbcLockBackend` and configuration keys, default-off.
+3. Tests: SPI contract + JDBC backend integration test against H2.
+4. Document the new keys in `docs/gravitino-server-config.md`.
+
+### Phase B — Follow-up: optimistic CAS in `RelationalEntityStore`
+
+Add a `version` column to `RelationalEntity` and CAS-update mutations. This is the real
+correctness fix for the most-common HA case and is independent of which lock backend is
+configured. It belongs in its own PR with its own review cycle.
+
+### Phase C — Follow-up: per-call-site audit
+
+Walk the 19 `doWithTreeLock` call sites and classify each as:
+
+- **Required for HA correctness** → keep, runs against the configured backend.
+- **In-process invariant only** (e.g., guarding a non-persisted in-memory cache) → keep but
+  consider moving to a local-only lock helper that explicitly bypasses the SPI.
+- **Redundant given Phase B** → remove.
+
+This cleanup reduces the number of acquires per request and is gated on Phase B landing.
+
+### Phase D — Optional: ZooKeeper / etcd backends
+
+If operators ask for them. The SPI is shaped to accommodate Curator's
+`InterProcessReadWriteLock` directly; an etcd backend would use lease-based locks. Not
+needed for the foundational HA story.
+
+---
+
+## 9. Compatibility
+
+- **Existing single-node deployments.** No config change required. `gravitino.lock.backend.type`
+  defaults to `inprocess`, which is the current behavior. The existing
+  `gravitino.lock.{max,min}Nodes` / `cleanIntervalInSecs` keys keep their meaning.
+- **Existing tests.** The full `core` test suite passes unchanged because the in-process
+  backend wraps the existing `LockManager` logic with no behavioral delta.
+- **Wire/HTTP API.** Unchanged. This is internal plumbing.
+
+---
+
+## 10. Open Questions
+
+1. **Should the JDBC backend reuse the entity-store DataSource or always have its own pool?**
+   Current design: always its own, to avoid starvation. Operators with very small DBs may
+   want the option to share — exposing this would mean adding a third configuration mode
+   ("share with entity store"). Defer until requested.
+2. **Should `acquireTimeoutMs` cause the calling REST request to fail with `503` or be
+   transparently retried?** Current design: bubble up as a typed exception to the caller
+   and let the dispatcher decide. The job/scheduling dispatchers may want different
+   behaviour from the user-facing dispatchers.
+3. **Is there appetite for a `LockType.INTENT_SHARED`/`INTENT_EXCLUSIVE` extension** so the
+   ancestor locks can be cheaper than full shared locks? Postgres advisory locks (`pg_try_advisory_xact_lock`)
+   would map well, but it's only worth the additional complexity if profiling shows the
+   ancestor-lock cost is the bottleneck.
+4. **How aggressively should the lock table be vacuumed?** Today's design never deletes
+   rows; the row count is bounded by the number of distinct metadata paths the system has
+   ever locked, not by traffic. A periodic `DELETE FROM gravitino_lock WHERE lock_path NOT
+   IN (... entity table paths ...)` could prune orphans, but is unnecessary for correctness.
+
+---
+
+## 11. Future Work
+
+Beyond Phases B–D in §8:
+
+- **Distributed deadlock observability.** Surface DB-detected deadlocks as Gravitino metrics.
+- **Lock table holder columns** (`server_id`, `acquired_at`, `txn_id`) for ops tooling.
+- **Read-side lock elision** when the operation is a pure point read of an entity that
+  already supports MVCC at the storage layer.
+- **Cross-region considerations.** A globally-distributed deployment would want either a
+  geo-replicated DB or a Raft-based lock service; out of scope for now.


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR addresses TreeLock's in-process-only limitation for HA deployments
(#10474) by introducing a pluggable lock backend layer:

1. **`LockBackend` SPI** under `org.apache.gravitino.lock`. The default
   `InProcessLockBackend` wraps the existing in-JVM `TreeLock` machinery
   byte-for-byte — single-node deployments see no behavior change.
2. **`JdbcLockBackend`** (opt-in via `gravitino.lock.backend.type=jdbc`)
   coordinates locks across nodes using `SELECT ... FOR SHARE / FOR UPDATE`
   on a single `gravitino_lock(lock_path PRIMARY KEY)` table. Supports H2
   (with shared→exclusive degradation), MySQL, and PostgreSQL via a small
   `JdbcDialect` enum.
3. **Design document** `design-docs/treelock-ha.md` (~550 lines) walking
   through the current implementation, HA failure modes, the Option A/B/C
   trade-off space, the recommended hybrid, JDBC backend internals,
   correctness analysis, and a 4-phase migration plan.

No new dependency: `JdbcLockBackend` uses `commons-dbcp2` which is already
on `core`'s classpath.

### Why are the changes needed?

`TreeLock` is per-process — a write lock taken on server A is invisible to
server B, so HA deployments behind a load balancer can race on the same
metadata resource and corrupt state. Detailed failure-mode analysis is in
§2 of the design document.

This PR introduces the foundation (SPI + opt-in JDBC backend + design doc)
without forcing a behavior change. Phase B in §8 of the design doc is
optimistic CAS in `RelationalEntityStore` — the next staged PR — which is
the real correctness fix for the dominant case (internal metadata races)
and works regardless of which lock backend is configured.

Fix: #10474

### Does this PR introduce _any_ user-facing change?

Yes — additive only:

- **New configs** (defaults preserve current behavior):
  - `gravitino.lock.backend.type` (default `inprocess`)
  - `gravitino.lock.backend.jdbc.{url,user,password,driver,poolSize,acquireTimeoutMs}`
    — only consulted when `type=jdbc`; URL/user/password/driver fall back to
    the existing `gravitino.entity.store.relational.jdbc*` keys when unset.
- **New public Java APIs** in `org.apache.gravitino.lock`:
  `LockBackend`, `LockHandle`, `LockBackendException`. All marked
  `@Evolving`.
- **`LockManager.close()`** added and wired into `GravitinoEnv.shutdown()`.
- **No removed or renamed APIs.** All existing call sites of
  `TreeLockUtils.doWithTreeLock` are unchanged in semantics.

### How was this patch tested?

- `./gradlew :core:test -PskipITs --tests "org.apache.gravitino.lock.*"` —
  all lock tests pass. Existing `TestLockManager`, `TestTreeLock`,
  `TestTreeLockUtils` are unchanged. New tests:
  - `TestInProcessLockBackend` — exercises the default backend and the
    null/empty-config defensive path.
  - `TestJdbcLockBackend` — exercises acquire/release, schema initialization,
    root-only locks, idempotent close, reentrancy detection (rejected with a
    clear error in v1), and WRITE/WRITE serialization between two threads
    against H2 in-memory.
  - `TestJdbcDialect` — covers the SQL strings and timeout-clamping for all
    three supported dialects.
- Regression sample: `./gradlew :core:test -PskipITs --tests
  "org.apache.gravitino.catalog.TestCatalogManager"
  "org.apache.gravitino.catalog.TestOperationDispatcher"` — green.
- `./gradlew :core:spotlessApply` — clean.
- MySQL/PostgreSQL dialects are covered by `TestJdbcDialect` at the SQL-string
  level. Container-based integration tests against real MySQL/Postgres are
  intentionally deferred to land alongside Phase B (optimistic CAS) when the
  end-to-end HA story is exercised.
