### PR TITLE
[#11029] fix(web): Handle null URI in WebUIFilter

### DIFF
--- a/server/src/main/java/org/apache/gravitino/server/web/ui/WebUIFilter.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/ui/WebUIFilter.java
@@ -36,6 +36,11 @@ public class WebUIFilter implements Filter {
 
     HttpServletRequest httpRequest = (HttpServletRequest) request;
     String path = httpRequest.getRequestURI();
+    if (path == null) {
+      chain.doFilter(request, response);
+      return;
+    }
+
     String lastPathSegment = path.substring(path.lastIndexOf("/") + 1);
 
     if (path.equals("/") || path.equals("/ui") || path.equals("/ui/")) {

--- a/server/src/test/java/org/apache/gravitino/server/web/ui/WebUIFilterTest.java
+++ b/server/src/test/java/org/apache/gravitino/server/web/ui/WebUIFilterTest.java
@@ -35,6 +35,21 @@ import org.junit.jupiter.api.Test;
 
 public class WebUIFilterTest {
   @Test
+  public void testNullRequestUriPassesThroughFilterChain() throws ServletException, IOException {
+    WebUIFilter filter = new WebUIFilter();
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    ServletResponse response = mock(ServletResponse.class);
+    FilterChain chain = mock(FilterChain.class);
+
+    when(request.getRequestURI()).thenReturn(null);
+
+    filter.doFilter(request, response, chain);
+
+    verify(chain).doFilter(request, response);
+    verify(request, never()).getRequestDispatcher(any());
+  }
+
+  @Test
   public void testNestedDirectoryRequestForwardsToIndexHtml() throws ServletException, IOException {
     WebUIFilter filter = new WebUIFilter();
     HttpServletRequest request = mock(HttpServletRequest.class);


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add a null guard for `HttpServletRequest#getRequestURI()` in `WebUIFilter`. When the request URI is null, the filter now passes the request through the filter chain instead of trying to rewrite it to a Web UI static resource.

This PR also adds a unit test covering the null URI path.

### Why are the changes needed?

`WebUIFilter` previously called `path.lastIndexOf("/")` without checking whether `path` was null. If `getRequestURI()` returned null, the request failed with a `NullPointerException` and Jetty returned 500.

Fix: #11029

### Does this PR introduce _any_ user-facing change?

No API or configuration changes. Malformed or proxy-affected requests with a null request URI no longer fail in `WebUIFilter` with an NPE.

### How was this patch tested?

```bash
./gradlew :server:spotlessApply
./gradlew :server:test --tests org.apache.gravitino.server.web.ui.WebUIFilterTest -PskipITs
```