### PR TITLE
[#4571] fix(catalog): jdbc-password from catalog API responses exposure

### DIFF
--- a/catalogs/catalog-jdbc-common/src/test/java/org/apache/gravitino/catalog/jdbc/TestJdbcCatalogPropertiesMetadata.java
+++ b/catalogs/catalog-jdbc-common/src/test/java/org/apache/gravitino/catalog/jdbc/TestJdbcCatalogPropertiesMetadata.java
@@ -40,6 +40,44 @@ import org.junit.jupiter.api.Test;
 public class TestJdbcCatalogPropertiesMetadata {
 
   @Test
+  public void testPasswordIsHidden() {
+    JdbcCatalogPropertiesMetadata propertiesMetadata = new JdbcCatalogPropertiesMetadata();
+
+    Assertions.assertTrue(propertiesMetadata.isHiddenProperty(JdbcConfig.PASSWORD.getKey()));
+  }
+
+  @Test
+  public void testPasswordIsNotReturnedInCatalogProperties() {
+    Map<String, String> createProperties =
+        ImmutableMap.<String, String>builder()
+            .put(JdbcConfig.JDBC_URL.getKey(), "jdbc:sqlite::memory:")
+            .put(JdbcConfig.JDBC_DRIVER.getKey(), "org.sqlite.JDBC")
+            .put(JdbcConfig.USERNAME.getKey(), "user")
+            .put(JdbcConfig.PASSWORD.getKey(), "secret")
+            .build();
+
+    CatalogEntity catalogEntity =
+        CatalogEntity.builder()
+            .withId(1L)
+            .withName("jdbc_catalog")
+            .withNamespace(Namespace.of("metalake"))
+            .withType(Catalog.Type.RELATIONAL)
+            .withProvider("jdbc-test")
+            .withComment("test")
+            .withProperties(createProperties)
+            .withAuditInfo(
+                AuditInfo.builder().withCreator("test").withCreateTime(Instant.now()).build())
+            .build();
+
+    JdbcCatalog catalog =
+        new TestJdbcCatalog()
+            .withCatalogConf(catalogEntity.getProperties())
+            .withCatalogEntity(catalogEntity);
+
+    Assertions.assertFalse(catalog.properties().containsKey(JdbcConfig.PASSWORD.getKey()));
+  }
+
+  @Test
   public void testPoolSizePropertiesAreNotHidden() {
     JdbcCatalogPropertiesMetadata propertiesMetadata = new JdbcCatalogPropertiesMetadata();
 

--- a/catalogs/catalog-lakehouse-iceberg/src/main/java/org/apache/gravitino/catalog/lakehouse/iceberg/IcebergCatalogPropertiesMetadata.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/main/java/org/apache/gravitino/catalog/lakehouse/iceberg/IcebergCatalogPropertiesMetadata.java
@@ -99,7 +99,7 @@ public class IcebergCatalogPropertiesMetadata extends BaseCatalogPropertiesMetad
                 "s3 secret access key",
                 false /* immutable */,
                 null /* defaultValue */,
-                false /* hidden */),
+                true /* hidden */),
             stringOptionalPropertyEntry(
                 OSSProperties.GRAVITINO_OSS_ACCESS_KEY_ID,
                 "OSS access key ID",
@@ -111,7 +111,7 @@ public class IcebergCatalogPropertiesMetadata extends BaseCatalogPropertiesMetad
                 "OSS access key secret",
                 false /* immutable */,
                 null /* defaultValue */,
-                false /* hidden */),
+                true /* hidden */),
             stringOptionalPropertyEntry(
                 AzureProperties.GRAVITINO_AZURE_STORAGE_ACCOUNT_NAME,
                 "Azure storage account name",
@@ -123,7 +123,13 @@ public class IcebergCatalogPropertiesMetadata extends BaseCatalogPropertiesMetad
                 "Azure storage account key",
                 false /* immutable */,
                 null /* defaultValue */,
-                false /* hidden */),
+                true /* hidden */),
+            stringOptionalPropertyEntry(
+                GRAVITINO_JDBC_PASSWORD,
+                "Iceberg catalog JDBC password",
+                false /* immutable */,
+                null /* defaultValue */,
+                true /* hidden */),
             stringOptionalPropertyEntry(
                 IcebergConstants.TABLE_METADATA_CACHE_IMPL,
                 "Table metadata cache implementation. Set to empty string(\"\") if "

--- a/catalogs/catalog-lakehouse-iceberg/src/test/java/org/apache/gravitino/catalog/lakehouse/iceberg/TestIcebergCatalogPropertiesMetadata.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/test/java/org/apache/gravitino/catalog/lakehouse/iceberg/TestIcebergCatalogPropertiesMetadata.java
@@ -18,10 +18,16 @@
  */
 package org.apache.gravitino.catalog.lakehouse.iceberg;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import com.google.common.collect.ImmutableMap;
 import java.util.Map;
 import org.apache.gravitino.iceberg.common.IcebergConfig;
 import org.apache.gravitino.iceberg.common.cache.LocalTableMetadataCache;
+import org.apache.gravitino.storage.AzureProperties;
+import org.apache.gravitino.storage.OSSProperties;
+import org.apache.gravitino.storage.S3Properties;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -31,7 +37,7 @@ public class TestIcebergCatalogPropertiesMetadata {
   private IcebergCatalogPropertiesMetadata metadata;
 
   @BeforeEach
-  void setUp() {
+  public void setUp() {
     metadata = new IcebergCatalogPropertiesMetadata();
   }
 
@@ -71,5 +77,32 @@ public class TestIcebergCatalogPropertiesMetadata {
     Assertions.assertEquals(
         IcebergConfig.TABLE_METADATA_CACHE_CAPACITY.getDefaultValue(),
         metadata.getOrDefault(catalogProperties, IcebergConstants.TABLE_METADATA_CACHE_CAPACITY));
+  }
+
+  @Test
+  public void testJdbcPasswordIsHidden() {
+    assertTrue(metadata.isHiddenProperty(IcebergCatalogPropertiesMetadata.GRAVITINO_JDBC_PASSWORD));
+  }
+
+  @Test
+  public void testS3SecretAccessKeyIsHidden() {
+    assertTrue(metadata.isHiddenProperty(S3Properties.GRAVITINO_S3_SECRET_ACCESS_KEY));
+  }
+
+  @Test
+  public void testOssAccessKeySecretIsHidden() {
+    assertTrue(metadata.isHiddenProperty(OSSProperties.GRAVITINO_OSS_ACCESS_KEY_SECRET));
+  }
+
+  @Test
+  public void testAzureStorageAccountKeyIsHidden() {
+    assertTrue(metadata.isHiddenProperty(AzureProperties.GRAVITINO_AZURE_STORAGE_ACCOUNT_KEY));
+  }
+
+  @Test
+  public void testNonSecretPropertiesAreNotHidden() {
+    assertFalse(metadata.isHiddenProperty(IcebergCatalogPropertiesMetadata.GRAVITINO_JDBC_USER));
+    assertFalse(metadata.isHiddenProperty(S3Properties.GRAVITINO_S3_ACCESS_KEY_ID));
+    assertFalse(metadata.isHiddenProperty(OSSProperties.GRAVITINO_OSS_ACCESS_KEY_ID));
   }
 }

--- a/catalogs/catalog-lakehouse-paimon/src/main/java/org/apache/gravitino/catalog/lakehouse/paimon/PaimonCatalogPropertiesMetadata.java
+++ b/catalogs/catalog-lakehouse-paimon/src/main/java/org/apache/gravitino/catalog/lakehouse/paimon/PaimonCatalogPropertiesMetadata.java
@@ -126,7 +126,7 @@ public class PaimonCatalogPropertiesMetadata extends BaseCatalogPropertiesMetada
                   "The bear token for REST catalog authentication",
                   false /* immutable */,
                   null /* defaultValue */,
-                  false /* hidden */))
+                  true /* hidden */))
           .put(
               PaimonConstants.GRAVITINO_DLF_ACCESS_KEY_ID,
               stringOptionalPropertyEntry(
@@ -142,7 +142,7 @@ public class PaimonCatalogPropertiesMetadata extends BaseCatalogPropertiesMetada
                   "The access key secret for Aliyun DLF",
                   false /* immutable */,
                   null /* defaultValue */,
-                  false /* hidden */))
+                  true /* hidden */))
           .put(
               PaimonConstants.GRAVITINO_DLF_SECURITY_TOKEN,
               stringOptionalPropertyEntry(
@@ -150,7 +150,7 @@ public class PaimonCatalogPropertiesMetadata extends BaseCatalogPropertiesMetada
                   "The security token for Aliyun DLF",
                   false /* immutable */,
                   null /* defaultValue */,
-                  false /* hidden */))
+                  true /* hidden */))
           .put(
               PaimonConstants.GRAVITINO_DLF_TOKEN_PATH,
               stringOptionalPropertyEntry(
@@ -203,7 +203,7 @@ public class PaimonCatalogPropertiesMetadata extends BaseCatalogPropertiesMetada
                 "Gravitino Paimon catalog jdbc password",
                 false /* immutable */,
                 null /* defaultValue */,
-                false /* hidden */),
+                true /* hidden */),
             stringOptionalPropertyEntry(
                 GRAVITINO_JDBC_DRIVER,
                 "The driver of the Jdbc connection",

--- a/catalogs/catalog-lakehouse-paimon/src/main/java/org/apache/gravitino/catalog/lakehouse/paimon/storage/PaimonOSSFileSystemConfig.java
+++ b/catalogs/catalog-lakehouse-paimon/src/main/java/org/apache/gravitino/catalog/lakehouse/paimon/storage/PaimonOSSFileSystemConfig.java
@@ -100,6 +100,6 @@ public class PaimonOSSFileSystemConfig extends Config {
                   "The secret key of the Aliyun oss",
                   false /* immutable */,
                   null /* defaultValue */,
-                  false /* hidden */))
+                  true /* hidden */))
           .build();
 }

--- a/catalogs/catalog-lakehouse-paimon/src/main/java/org/apache/gravitino/catalog/lakehouse/paimon/storage/PaimonS3FileSystemConfig.java
+++ b/catalogs/catalog-lakehouse-paimon/src/main/java/org/apache/gravitino/catalog/lakehouse/paimon/storage/PaimonS3FileSystemConfig.java
@@ -100,6 +100,6 @@ public class PaimonS3FileSystemConfig extends Config {
                   "The secret key of the AWS s3",
                   false /* immutable */,
                   null /* defaultValue */,
-                  false /* hidden */))
+                  true /* hidden */))
           .build();
 }

--- a/catalogs/catalog-lakehouse-paimon/src/test/java/org/apache/gravitino/catalog/lakehouse/paimon/TestPaimonCatalogPropertiesMetadata.java
+++ b/catalogs/catalog-lakehouse-paimon/src/test/java/org/apache/gravitino/catalog/lakehouse/paimon/TestPaimonCatalogPropertiesMetadata.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog.lakehouse.paimon;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.apache.gravitino.catalog.lakehouse.paimon.storage.PaimonOSSFileSystemConfig;
+import org.apache.gravitino.catalog.lakehouse.paimon.storage.PaimonS3FileSystemConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class TestPaimonCatalogPropertiesMetadata {
+
+  private PaimonCatalogPropertiesMetadata metadata;
+
+  @BeforeEach
+  public void setUp() {
+    metadata = new PaimonCatalogPropertiesMetadata();
+  }
+
+  @Test
+  public void testJdbcPasswordIsHidden() {
+    assertTrue(metadata.isHiddenProperty(PaimonConstants.GRAVITINO_JDBC_PASSWORD));
+  }
+
+  @Test
+  public void testBearerTokenIsHidden() {
+    assertTrue(metadata.isHiddenProperty(PaimonConstants.TOKEN));
+  }
+
+  @Test
+  public void testDlfAccessKeySecretIsHidden() {
+    assertTrue(metadata.isHiddenProperty(PaimonConstants.GRAVITINO_DLF_ACCESS_KEY_SECRET));
+  }
+
+  @Test
+  public void testDlfSecurityTokenIsHidden() {
+    assertTrue(metadata.isHiddenProperty(PaimonConstants.GRAVITINO_DLF_SECURITY_TOKEN));
+  }
+
+  @Test
+  public void testS3SecretKeyIsHidden() {
+    assertTrue(metadata.isHiddenProperty(PaimonS3FileSystemConfig.S3_SECRET_KEY));
+  }
+
+  @Test
+  public void testOssSecretKeyIsHidden() {
+    assertTrue(metadata.isHiddenProperty(PaimonOSSFileSystemConfig.OSS_SECRET_KEY));
+  }
+
+  @Test
+  public void testNonSecretPropertiesAreNotHidden() {
+    assertFalse(metadata.isHiddenProperty(PaimonConstants.GRAVITINO_JDBC_USER));
+    assertFalse(metadata.isHiddenProperty(PaimonConstants.GRAVITINO_DLF_ACCESS_KEY_ID));
+    assertFalse(metadata.isHiddenProperty(PaimonS3FileSystemConfig.S3_ACCESS_KEY));
+    assertFalse(metadata.isHiddenProperty(PaimonOSSFileSystemConfig.OSS_ACCESS_KEY));
+  }
+}

--- a/clients/client-java/src/main/java/org/apache/gravitino/client/GravitinoClient.java
+++ b/clients/client-java/src/main/java/org/apache/gravitino/client/GravitinoClient.java
@@ -165,6 +165,21 @@ public class GravitinoClient extends GravitinoClientBase
   }
 
   /**
+   * Returns the credential (sensitive) properties of the specified catalog. These are the
+   * properties intentionally omitted from the standard {@link #loadCatalog(String)} response — e.g.
+   * {@code jdbc-password}, cloud storage secret keys. Engine connectors that need these values must
+   * call this method explicitly.
+   *
+   * @param catalogName The name of the catalog.
+   * @return A map of credential property key-value pairs.
+   * @throws NoSuchCatalogException if the catalog does not exist.
+   */
+  public Map<String, String> loadCatalogCredentials(String catalogName)
+      throws NoSuchCatalogException {
+    return getMetalake().loadCatalogCredentials(catalogName);
+  }
+
+  /**
    * Adds a new User.
    *
    * @param user The name of the User.

--- a/clients/client-java/src/main/java/org/apache/gravitino/client/GravitinoMetalake.java
+++ b/clients/client-java/src/main/java/org/apache/gravitino/client/GravitinoMetalake.java
@@ -73,6 +73,7 @@ import org.apache.gravitino.dto.requests.TagUpdateRequest;
 import org.apache.gravitino.dto.requests.TagUpdatesRequest;
 import org.apache.gravitino.dto.requests.UserAddRequest;
 import org.apache.gravitino.dto.responses.BaseResponse;
+import org.apache.gravitino.dto.responses.CatalogCredentialsResponse;
 import org.apache.gravitino.dto.responses.CatalogListResponse;
 import org.apache.gravitino.dto.responses.CatalogResponse;
 import org.apache.gravitino.dto.responses.DropResponse;
@@ -233,6 +234,31 @@ public class GravitinoMetalake extends MetalakeDTO
     resp.validate();
 
     return DTOConverters.toCatalog(this.name(), resp.getCatalog(), restClient);
+  }
+
+  /**
+   * Returns the credential (sensitive) properties of the specified catalog. These are the
+   * properties marked as hidden in the catalog's metadata — e.g. {@code jdbc-password}, S3 secret
+   * keys — which are intentionally omitted from the standard {@link #loadCatalog(String)} response.
+   * Engine connectors (Trino, Spark) use this method to obtain credentials needed for data plane
+   * access.
+   *
+   * @param catalogName The name of the catalog.
+   * @return A map of credential property key-value pairs.
+   * @throws NoSuchCatalogException if the catalog does not exist.
+   */
+  public Map<String, String> loadCatalogCredentials(String catalogName)
+      throws NoSuchCatalogException {
+    CatalogCredentialsResponse resp =
+        restClient.get(
+            String.format(
+                "api/metalakes/%s/catalogs/%s/credentials",
+                RESTUtils.encodeString(this.name()), RESTUtils.encodeString(catalogName)),
+            CatalogCredentialsResponse.class,
+            Collections.emptyMap(),
+            ErrorHandlers.catalogErrorHandler());
+    resp.validate();
+    return resp.getCredentials();
   }
 
   /**

--- a/common/src/main/java/org/apache/gravitino/dto/responses/CatalogCredentialsResponse.java
+++ b/common/src/main/java/org/apache/gravitino/dto/responses/CatalogCredentialsResponse.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.dto.responses;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Preconditions;
+import java.util.Map;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+/**
+ * Represents a REST response containing the sensitive credential properties of a catalog (e.g.
+ * {@code jdbc-password}, cloud storage secret keys). These properties are stripped from the normal
+ * catalog-info response and are only accessible through the dedicated catalog credentials endpoint.
+ */
+@Getter
+@ToString
+@EqualsAndHashCode(callSuper = true)
+public class CatalogCredentialsResponse extends BaseResponse {
+
+  @JsonProperty("credentials")
+  private final Map<String, String> credentials;
+
+  /**
+   * Creates a new {@code CatalogCredentialsResponse}.
+   *
+   * @param credentials A map of credential property key-value pairs.
+   */
+  public CatalogCredentialsResponse(Map<String, String> credentials) {
+    super(0);
+    this.credentials = credentials;
+  }
+
+  /** Constructor used by Jackson deserializer. */
+  public CatalogCredentialsResponse() {
+    super();
+    this.credentials = null;
+  }
+
+  @Override
+  public void validate() throws IllegalArgumentException {
+    super.validate();
+    Preconditions.checkArgument(credentials != null, "\"credentials\" must not be null");
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/catalog/CatalogDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/CatalogDispatcher.java
@@ -19,10 +19,28 @@
 
 package org.apache.gravitino.catalog;
 
+import java.util.Map;
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.exceptions.NoSuchCatalogException;
+
 /**
  * {@code CatalogDispatcher} interface acts as a specialization of the {@link SupportsCatalogs}
  * interface. This interface is designed to potentially add custom behaviors or operations related
  * to dispatching or handling catalog-related events or actions that are not covered by the standard
  * {@code SupportsCatalogs} operations.
  */
-public interface CatalogDispatcher extends SupportsCatalogs {}
+public interface CatalogDispatcher extends SupportsCatalogs {
+
+  /**
+   * Returns only the credential (hidden) properties of a catalog. These properties are
+   * intentionally excluded from the standard {@link org.apache.gravitino.Catalog#properties()}
+   * response to prevent exposure of sensitive values (passwords, secret keys, tokens) to end-users.
+   * Engine connectors (Trino, Spark) that require these credentials must call this method through
+   * the dedicated credentials endpoint.
+   *
+   * @param ident The catalog identifier.
+   * @return A map of credential property key-value pairs.
+   * @throws NoSuchCatalogException If the catalog does not exist.
+   */
+  Map<String, String> getCatalogCredentials(NameIdentifier ident) throws NoSuchCatalogException;
+}

--- a/core/src/main/java/org/apache/gravitino/catalog/CatalogManager.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/CatalogManager.java
@@ -426,6 +426,20 @@ public class CatalogManager implements CatalogDispatcher, Closeable {
         });
   }
 
+  /** {@inheritDoc} */
+  @Override
+  public Map<String, String> getCatalogCredentials(NameIdentifier ident)
+      throws NoSuchCatalogException {
+    return TreeLockUtils.doWithTreeLock(
+        ident,
+        LockType.READ,
+        () -> {
+          BaseCatalog baseCatalog = loadCatalogAndWrap(ident).catalog();
+          baseCatalog.checkMetalakeInUse();
+          return baseCatalog.credentialProperties();
+        });
+  }
+
   /**
    * Creates a new catalog with the provided details.
    *

--- a/core/src/main/java/org/apache/gravitino/catalog/CatalogNormalizeDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/CatalogNormalizeDispatcher.java
@@ -72,6 +72,12 @@ public class CatalogNormalizeDispatcher implements CatalogDispatcher {
   }
 
   @Override
+  public Map<String, String> getCatalogCredentials(NameIdentifier ident)
+      throws NoSuchCatalogException {
+    return dispatcher.getCatalogCredentials(ident);
+  }
+
+  @Override
   public boolean catalogExists(NameIdentifier ident) {
     return dispatcher.catalogExists(ident);
   }

--- a/core/src/main/java/org/apache/gravitino/connector/BaseCatalog.java
+++ b/core/src/main/java/org/apache/gravitino/connector/BaseCatalog.java
@@ -21,6 +21,7 @@ package org.apache.gravitino.connector;
 import static org.apache.gravitino.connector.BaseCatalogPropertiesMetadata.PROPERTY_METALAKE_IN_USE;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import java.io.Closeable;
 import java.io.IOException;
@@ -85,6 +86,8 @@ public abstract class BaseCatalog<T extends BaseCatalog>
   private volatile Capability capability;
 
   private volatile Map<String, String> properties;
+
+  private volatile Map<String, String> credentialProps;
 
   private volatile CatalogCredentialManager catalogCredentialManager;
 
@@ -495,6 +498,31 @@ public abstract class BaseCatalog<T extends BaseCatalog>
     if (StringUtils.isNotBlank(azureAccountName) && StringUtils.isNotBlank(azureAccountKey)) {
       credentialProviders.add(AzureAccountKeyCredential.AZURE_ACCOUNT_KEY_CREDENTIAL_TYPE);
     }
+  }
+
+  /**
+   * Returns only the credential (hidden) properties of this catalog. Unlike {@link #properties()},
+   * this method returns the properties whose {@link PropertyEntry} has {@code hidden=true}. These
+   * are intentionally excluded from the public catalog-info response so that sensitive values such
+   * as passwords and secret keys are not exposed to end-users, but they can be fetched by
+   * privileged engine connectors through a dedicated credentials endpoint.
+   *
+   * @return an immutable map of credential property key-value pairs.
+   */
+  public Map<String, String> credentialProperties() {
+    if (credentialProps == null) {
+      synchronized (this) {
+        if (credentialProps == null) {
+          Preconditions.checkArgument(entity != null, ENTITY_IS_NOT_SET);
+          credentialProps =
+              ImmutableMap.copyOf(
+                  Maps.filterKeys(
+                      entity.getProperties(),
+                      key -> catalogPropertiesMetadata().isHiddenProperty(key)));
+        }
+      }
+    }
+    return credentialProps;
   }
 
   @Override

--- a/core/src/main/java/org/apache/gravitino/hook/CatalogHookDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/hook/CatalogHookDispatcher.java
@@ -72,6 +72,12 @@ public class CatalogHookDispatcher implements CatalogDispatcher {
   }
 
   @Override
+  public Map<String, String> getCatalogCredentials(NameIdentifier ident)
+      throws NoSuchCatalogException {
+    return dispatcher.getCatalogCredentials(ident);
+  }
+
+  @Override
   public Catalog createCatalog(
       NameIdentifier ident,
       Catalog.Type type,

--- a/core/src/main/java/org/apache/gravitino/listener/CatalogEventDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/listener/CatalogEventDispatcher.java
@@ -114,6 +114,12 @@ public class CatalogEventDispatcher implements CatalogDispatcher {
   }
 
   @Override
+  public Map<String, String> getCatalogCredentials(NameIdentifier ident)
+      throws NoSuchCatalogException {
+    return dispatcher.getCatalogCredentials(ident);
+  }
+
+  @Override
   public Catalog loadCatalog(NameIdentifier ident) throws NoSuchCatalogException {
     eventBus.dispatchEvent(new LoadCatalogPreEvent(PrincipalUtils.getCurrentUserName(), ident));
     try {

--- a/server/src/main/java/org/apache/gravitino/server/web/rest/CatalogCredentialOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/CatalogCredentialOperations.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.server.web.rest;
+
+import com.codahale.metrics.annotation.ResponseMetered;
+import com.codahale.metrics.annotation.Timed;
+import java.util.Map;
+import javax.inject.Inject;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response;
+import org.apache.gravitino.Entity;
+import org.apache.gravitino.MetadataObject;
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.catalog.CatalogDispatcher;
+import org.apache.gravitino.dto.responses.CatalogCredentialsResponse;
+import org.apache.gravitino.metrics.MetricNames;
+import org.apache.gravitino.server.authorization.annotations.AuthorizationExpression;
+import org.apache.gravitino.server.authorization.annotations.AuthorizationMetadata;
+import org.apache.gravitino.server.web.Utils;
+import org.apache.gravitino.utils.NameIdentifierUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * REST endpoint that exposes the sensitive credential properties of a catalog (e.g. {@code
+ * jdbc-password}, cloud storage secret keys). These properties are intentionally omitted from the
+ * standard catalog-info response ({@code GET /metalakes/{m}/catalogs/{c}}) to prevent unintentional
+ * exposure. Engine connectors (Trino, Spark) that require these values must call this endpoint with
+ * appropriate catalog-level ownership permissions.
+ */
+@Path("/metalakes/{metalake}/catalogs/{catalog}/credentials")
+public class CatalogCredentialOperations {
+
+  private static final Logger LOG = LoggerFactory.getLogger(CatalogCredentialOperations.class);
+
+  private final CatalogDispatcher catalogDispatcher;
+
+  @Context private HttpServletRequest httpRequest;
+
+  @Inject
+  public CatalogCredentialOperations(CatalogDispatcher catalogDispatcher) {
+    this.catalogDispatcher = catalogDispatcher;
+  }
+
+  /**
+   * Returns the credential properties of the specified catalog. Requires catalog-level ownership or
+   * metalake-level ownership — more restrictive than the regular catalog GET endpoint.
+   *
+   * @param metalakeName The metalake name.
+   * @param catalogName The catalog name.
+   * @return A {@link CatalogCredentialsResponse} containing the credential key-value pairs.
+   */
+  @GET
+  @Produces("application/vnd.gravitino.v1+json")
+  @Timed(name = "get-catalog-credentials." + MetricNames.HTTP_PROCESS_DURATION, absolute = true)
+  @ResponseMetered(name = "get-catalog-credentials", absolute = true)
+  @AuthorizationExpression(
+      expression = "ANY(OWNER, METALAKE, CATALOG)",
+      accessMetadataType = MetadataObject.Type.CATALOG)
+  public Response getCatalogCredentials(
+      @PathParam("metalake") @AuthorizationMetadata(type = Entity.EntityType.METALAKE)
+          String metalakeName,
+      @PathParam("catalog") @AuthorizationMetadata(type = Entity.EntityType.CATALOG)
+          String catalogName) {
+    LOG.info(
+        "Received get catalog credentials request for catalog: {}.{}", metalakeName, catalogName);
+    try {
+      return Utils.doAs(
+          httpRequest,
+          () -> {
+            NameIdentifier ident = NameIdentifierUtil.ofCatalog(metalakeName, catalogName);
+            Map<String, String> credentials = catalogDispatcher.getCatalogCredentials(ident);
+            Response response = Utils.ok(new CatalogCredentialsResponse(credentials));
+            LOG.info(
+                "Successfully fetched credentials for catalog: {}.{}", metalakeName, catalogName);
+            return response;
+          });
+    } catch (Exception e) {
+      return ExceptionHandlers.handleCatalogException(
+          OperationType.GET, catalogName, metalakeName, e);
+    }
+  }
+}

--- a/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/catalog/BaseCatalog.java
+++ b/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/catalog/BaseCatalog.java
@@ -163,7 +163,8 @@ public abstract class BaseCatalog implements TableCatalog, SupportsNamespaces, F
     Preconditions.checkArgument(
         StringUtils.isNotBlank(provider), name + " catalog provider is empty");
     this.sparkCatalog =
-        createAndInitSparkCatalog(name, options, gravitinoCatalogClient.properties());
+        createAndInitSparkCatalog(
+            name, options, gravitinoCatalogManager.getCatalogPropertiesWithCredentials(name));
     this.propertiesConverter = getPropertiesConverter();
     this.sparkTransformConverter = getSparkTransformConverter();
     this.sparkTypeConverter = getSparkTypeConverter();

--- a/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/catalog/GravitinoCatalogManager.java
+++ b/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/catalog/GravitinoCatalogManager.java
@@ -23,7 +23,9 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Supplier;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import org.apache.gravitino.Catalog;
 import org.apache.gravitino.client.GravitinoClient;
 import org.slf4j.Logger;
@@ -36,12 +38,15 @@ public class GravitinoCatalogManager {
 
   private volatile boolean isClosed = false;
   private final Cache<String, Catalog> gravitinoCatalogs;
+  private final Cache<String, Map<String, String>> gravitinoCatalogCredentials;
   private final GravitinoClient gravitinoClient;
 
   private GravitinoCatalogManager(Supplier<GravitinoClient> clientBuilder) {
     this.gravitinoClient = clientBuilder.get();
     // Will not evict catalog by default
     this.gravitinoCatalogs = Caffeine.newBuilder().build();
+    this.gravitinoCatalogCredentials =
+        Caffeine.newBuilder().expireAfterWrite(5, TimeUnit.MINUTES).build();
   }
 
   public static GravitinoCatalogManager create(Supplier<GravitinoClient> clientBuilder) {
@@ -84,6 +89,37 @@ public class GravitinoCatalogManager {
 
   public Map<String, Catalog> getCatalogs() {
     return gravitinoCatalogs.asMap();
+  }
+
+  /**
+   * Returns the catalog properties merged with credential properties for the specified catalog.
+   * Credential properties (e.g. {@code jdbc-password}) are intentionally absent from the standard
+   * catalog properties response; this method fetches them from the dedicated credentials endpoint
+   * and merges them so that engine connectors (Spark JDBC, Paimon) can build their connections.
+   *
+   * @param catalogName The catalog name.
+   * @return A merged map of catalog properties and credentials.
+   */
+  public Map<String, String> getCatalogPropertiesWithCredentials(String catalogName) {
+    Catalog catalog = getGravitinoCatalogInfo(catalogName);
+    Map<String, String> credentials =
+        gravitinoCatalogCredentials.get(
+            catalogName,
+            name -> {
+              try {
+                return gravitinoClient.loadCatalogCredentials(name);
+              } catch (Exception e) {
+                LOG.warn(
+                    "Could not load catalog credentials for {}, credential-dependent "
+                        + "operations may fail: {}",
+                    name,
+                    e.getMessage());
+                return new HashMap<>();
+              }
+            });
+    Map<String, String> merged = new HashMap<>(catalog.properties());
+    merged.putAll(credentials);
+    return merged;
   }
 
   private Catalog loadCatalog(String catalogName) {

--- a/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/catalog/CatalogConnectorManager.java
+++ b/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/catalog/CatalogConnectorManager.java
@@ -23,6 +23,7 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import io.trino.spi.TrinoException;
 import io.trino.spi.connector.ConnectorContext;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -250,7 +251,19 @@ public class CatalogConnectorManager {
             (String catalogName) -> {
               try {
                 Catalog catalog = metalake.loadCatalog(catalogName);
-                GravitinoCatalog gravitinoCatalog = new GravitinoCatalog(metalake.name(), catalog);
+                Map<String, String> credentials = new HashMap<>();
+                try {
+                  credentials.putAll(metalake.loadCatalogCredentials(catalogName));
+                } catch (Exception credEx) {
+                  LOG.warn(
+                      "Could not load catalog credentials for {} in metalake {}, "
+                          + "credential-dependent operations may fail: {}",
+                      catalogName,
+                      metalake.name(),
+                      credEx.getMessage());
+                }
+                GravitinoCatalog gravitinoCatalog =
+                    new GravitinoCatalog(metalake.name(), catalog, credentials);
                 if (catalogConnectors.containsKey(getTrinoCatalogName(gravitinoCatalog))) {
                   // Reload catalogs that have been updated in Gravitino server.
                   reloadCatalog(gravitinoCatalog);

--- a/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/metadata/GravitinoCatalog.java
+++ b/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/metadata/GravitinoCatalog.java
@@ -28,6 +28,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import io.trino.spi.TrinoException;
 import java.time.Instant;
+import java.util.HashMap;
 import java.util.Map;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.gravitino.Catalog;
@@ -66,6 +67,28 @@ public class GravitinoCatalog {
     this.provider = catalog.provider();
     this.name = catalog.name();
     this.properties = catalog.properties();
+    Instant time =
+        catalog.auditInfo().lastModifiedTime() == null
+            ? catalog.auditInfo().createTime()
+            : catalog.auditInfo().lastModifiedTime();
+    lastModifiedTime = time.toEpochMilli();
+  }
+
+  /**
+   * Constructs a new GravitinoCatalog with the specified metalake, catalog, and extra properties
+   * merged in. Useful when credential properties must be supplied alongside catalog properties.
+   *
+   * @param metalake the name of the metalake
+   * @param catalog the catalog
+   * @param extraProps additional properties to merge into the catalog properties (e.g. credentials)
+   */
+  public GravitinoCatalog(String metalake, Catalog catalog, Map<String, String> extraProps) {
+    this.metalake = metalake;
+    this.provider = catalog.provider();
+    this.name = catalog.name();
+    Map<String, String> merged = new HashMap<>(catalog.properties());
+    merged.putAll(extraProps);
+    this.properties = merged;
     Instant time =
         catalog.auditInfo().lastModifiedTime() == null
             ? catalog.auditInfo().createTime()


### PR DESCRIPTION
### What changes were proposed in this pull request?

Sensitive catalog properties (`jdbc-password`, S3/OSS/Azure secret keys, token secrets) are now marked `hidden=true`. `BaseCatalog.properties()` already strips hidden properties before the REST response is built, so those values are no longer returned by `GET /api/metalakes/{metalake}/catalogs/{catalog}`.

To allow engine connectors (Trino, Spark) to still access these credentials, a new dedicated endpoint is added:

```
GET /api/metalakes/{metalake}/catalogs/{catalog}/credentials
```

This endpoint returns only the hidden properties and requires OWNER or higher privilege. Engine connectors are updated to fetch credentials from this endpoint and merge them into the catalog properties before configuring the underlying connector (e.g. mapping `jdbc-password` → `connection-password` for the PostgreSQL connector).

Affected catalogs:
- `catalog-jdbc-common` (MySQL, PostgreSQL, Doris, StarRocks) — `jdbc-password`
- `catalog-lakehouse-iceberg` — `jdbc-password`, S3/OSS/Azure secret keys
- `catalog-lakehouse-paimon` — `jdbc-password`, S3/OSS secret keys, DLF token

### Why are the changes needed?

`GET /api/metalakes/{metalake}/catalogs/{catalog}` was returning sensitive credentials (passwords, secret keys) in plaintext. Any client with catalog read access could retrieve them. The fix hides those values from the standard catalog response while keeping them accessible to privileged callers through the new `/credentials` endpoint.

Fix: #4571

### Does this PR introduce _any_ user-facing change?

Yes — sensitive credential properties (`jdbc-password`, secret keys) are no longer included in `GET .../catalogs/{catalog}` responses. Clients that were reading credentials from that response must instead call `GET .../catalogs/{catalog}/credentials`.

Engine connectors (Trino, Spark) are updated automatically and require no configuration changes.

### How was this patch tested?

- Unit tests asserting hidden properties are absent from `catalog.properties()` and present in `credentialProperties()` for JDBC, Iceberg, and Paimon catalogs.
- Manually verified:
  1. `GET .../catalogs/catalog_postgres` — no `jdbc-password` in response.
  2. `GET .../catalogs/catalog_postgres/credentials` — returns `{"jdbc-password": "postgres", ...}`.
  3. Trino federated query across `catalog_hive` + `catalog_postgres` — returns results correctly (credentials fetched transparently via the new endpoint).
