### PR TITLE
[#11040] improvement(core): Make concurrent entity import idempotent

### DIFF
--- a/core/src/main/java/org/apache/gravitino/catalog/SchemaOperationDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/SchemaOperationDispatcher.java
@@ -387,10 +387,9 @@ public class SchemaOperationDispatcher extends OperationDispatcher implements Sc
     try {
       store.put(schemaEntity, true);
     } catch (EntityAlreadyExistsException e) {
-      LOG.error("Failed to import schema {} with id {} to the store.", identifier, uid, e);
-      throw new UnsupportedOperationException(
-          "Schema managed by multiple catalogs. This may cause unexpected issues such as privilege conflicts. "
-              + "To resolve: Remove all catalogs managing this schema, then recreate one catalog to ensure single-catalog management.");
+      LOG.warn(
+          "Schema {} was concurrently imported by another node, reusing existing entity.",
+          identifier);
     } catch (Exception e) {
       LOG.error(FormattedErrorMessages.STORE_OP_FAILURE, "put", identifier, e);
       throw new RuntimeException("Fail to import schema entity to the store.", e);

--- a/core/src/main/java/org/apache/gravitino/catalog/TableOperationDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/TableOperationDispatcher.java
@@ -477,10 +477,10 @@ public class TableOperationDispatcher extends OperationDispatcher implements Tab
     try {
       store.put(tableEntity, true);
     } catch (EntityAlreadyExistsException e) {
-      LOG.error("Failed to import table {} with id {} to the store.", identifier, uid, e);
-      throw new UnsupportedOperationException(
-          "Table managed by multiple catalogs. This may cause unexpected issues such as privilege conflicts. "
-              + "To resolve: Remove all catalogs managing this table, then recreate one catalog to ensure single-catalog management.");
+      LOG.warn(
+          "Table {} was concurrently imported by another node, reusing existing entity.",
+          identifier);
+      return internalLoadTable(identifier);
     } catch (Exception e) {
       LOG.error(FormattedErrorMessages.STORE_OP_FAILURE, "put", identifier, e);
       throw new RuntimeException("Fail to import the table entity to the store.", e);

--- a/core/src/main/java/org/apache/gravitino/catalog/ViewOperationDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/ViewOperationDispatcher.java
@@ -509,10 +509,9 @@ public class ViewOperationDispatcher extends OperationDispatcher implements View
     try {
       store.put(viewEntity, true /* overwrite */);
     } catch (EntityAlreadyExistsException e) {
-      LOG.error("Failed to import view {} with id {} to the store.", ident, uid, e);
-      throw new UnsupportedOperationException(
-          "View managed by multiple catalogs. This may cause unexpected issues such as privilege conflicts. "
-              + "To resolve: Remove all catalogs managing this view, then recreate one catalog to ensure single-catalog management.");
+      LOG.warn(
+          "View {} was concurrently imported by another node, reusing existing entity.", ident);
+      return internalLoadView(ident);
     } catch (Exception e) {
       LOG.error(FormattedErrorMessages.STORE_OP_FAILURE, "put", ident, e);
       throw new RuntimeException("Fail to import the view entity to the store.", e);

--- a/core/src/test/java/org/apache/gravitino/catalog/TestSchemaOperationDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestSchemaOperationDispatcher.java
@@ -40,6 +40,7 @@ import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.gravitino.Config;
 import org.apache.gravitino.Configs;
 import org.apache.gravitino.Entity;
+import org.apache.gravitino.EntityAlreadyExistsException;
 import org.apache.gravitino.GravitinoEnv;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
@@ -294,5 +295,25 @@ public class TestSchemaOperationDispatcher extends TestOperationDispatcher {
     doThrow(new IOException()).when(entityStore).delete(any(), any(), anyBoolean());
     Assertions.assertThrows(
         RuntimeException.class, () -> dispatcher.dropSchema(schemaIdent, false));
+  }
+
+  @Test
+  public void testLoadSchemaConcurrentImport() throws IOException {
+    NameIdentifier schemaIdent = NameIdentifier.of(metalake, catalog, "schema_concurrent");
+    Map<String, String> props = ImmutableMap.of("k1", "v1", "k2", "v2");
+    dispatcher.createSchema(schemaIdent, "comment", props);
+
+    reset(entityStore);
+    entityStore.delete(schemaIdent, SCHEMA);
+    doThrow(new NoSuchEntityException(""))
+        .when(entityStore)
+        .get(any(), eq(Entity.EntityType.SCHEMA), any());
+    doThrow(new EntityAlreadyExistsException("concurrent import"))
+        .when(entityStore)
+        .put(any(), anyBoolean());
+
+    Schema loadedSchema = dispatcher.loadSchema(schemaIdent);
+    Assertions.assertNotNull(loadedSchema);
+    Assertions.assertEquals("schema_concurrent", loadedSchema.name());
   }
 }

--- a/core/src/test/java/org/apache/gravitino/catalog/TestTableOperationDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestTableOperationDispatcher.java
@@ -47,6 +47,7 @@ import java.util.stream.Collectors;
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.gravitino.Config;
 import org.apache.gravitino.Entity;
+import org.apache.gravitino.EntityAlreadyExistsException;
 import org.apache.gravitino.GravitinoEnv;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
@@ -874,6 +875,38 @@ public class TestTableOperationDispatcher extends TestOperationDispatcher {
           Assertions.assertEquals(e.autoIncrement(), actualColumn.autoIncrement());
           Assertions.assertEquals(e.defaultValue(), actualColumn.defaultValue());
         });
+  }
+
+  @Test
+  public void testLoadTableConcurrentImport() throws IOException {
+    Namespace tableNs = Namespace.of(metalake, catalog, "schema_concurrent");
+    Map<String, String> props = ImmutableMap.of("k1", "v1", "k2", "v2");
+    schemaOperationDispatcher.createSchema(NameIdentifier.of(tableNs.levels()), "comment", props);
+
+    NameIdentifier tableIdent = NameIdentifier.of(tableNs, "table_concurrent");
+    Column[] columns =
+        new Column[] {
+          TestColumn.builder()
+              .withName("col1")
+              .withPosition(0)
+              .withType(Types.StringType.get())
+              .build()
+        };
+    tableOperationDispatcher.createTable(tableIdent, columns, "comment", props, new Transform[0]);
+
+    reset(entityStore);
+    doThrow(new NoSuchEntityException(""))
+        .doThrow(new NoSuchEntityException(""))
+        .doCallRealMethod()
+        .when(entityStore)
+        .get(any(), eq(Entity.EntityType.TABLE), any());
+    doThrow(new EntityAlreadyExistsException("concurrent import"))
+        .when(entityStore)
+        .put(any(), anyBoolean());
+
+    Table loadedTable = tableOperationDispatcher.loadTable(tableIdent);
+    Assertions.assertNotNull(loadedTable);
+    Assertions.assertEquals("table_concurrent", loadedTable.name());
   }
 
   public static TableOperationDispatcher getTableOperationDispatcher() {

--- a/core/src/test/java/org/apache/gravitino/catalog/TestViewOperationDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestViewOperationDispatcher.java
@@ -24,8 +24,13 @@ import static org.apache.gravitino.Configs.TREE_LOCK_MIN_NODE_IN_MEMORY;
 import static org.apache.gravitino.Entity.EntityType.VIEW;
 import static org.apache.gravitino.StringIdentifier.ID_KEY;
 import static org.apache.gravitino.TestBasePropertiesMetadata.COMMENT_KEY;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
 
 import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
@@ -43,6 +48,7 @@ import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.gravitino.Config;
 import org.apache.gravitino.Entity;
+import org.apache.gravitino.EntityAlreadyExistsException;
 import org.apache.gravitino.GravitinoEnv;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
@@ -570,5 +576,39 @@ public class TestViewOperationDispatcher extends TestOperationDispatcher {
                 .findFirst()
                 .orElseThrow(AssertionError::new);
     Assertions.assertEquals("SELECT 2", trino.sql());
+  }
+
+  @Test
+  public void testLoadViewConcurrentImport() throws IOException {
+    Namespace viewNs = Namespace.of(metalake, catalog, "schema_concurrent_view");
+    Map<String, String> props = ImmutableMap.of("k1", "v1", "k2", "v2");
+    schemaOperationDispatcher.createSchema(NameIdentifier.of(viewNs.levels()), "comment", props);
+
+    NameIdentifier viewIdent = NameIdentifier.of(viewNs, "view_concurrent");
+
+    AuditInfo auditInfo =
+        AuditInfo.builder().withCreator("test").withCreateTime(Instant.now()).build();
+    View mockView = createMockView("view_concurrent", props, auditInfo);
+
+    TestCatalog testCatalog =
+        (TestCatalog) catalogManager.loadCatalog(NameIdentifier.of(metalake, catalog));
+    TestCatalogOperations testCatalogOperations = (TestCatalogOperations) testCatalog.ops();
+    testCatalogOperations.views.put(viewIdent, mockView);
+
+    viewOperationDispatcher.loadView(viewIdent);
+
+    reset(entityStore);
+    doThrow(new NoSuchEntityException(""))
+        .doThrow(new NoSuchEntityException(""))
+        .doCallRealMethod()
+        .when(entityStore)
+        .get(any(), eq(Entity.EntityType.VIEW), any());
+    doThrow(new EntityAlreadyExistsException("concurrent import"))
+        .when(entityStore)
+        .put(any(), anyBoolean());
+
+    View loadedView = viewOperationDispatcher.loadView(viewIdent);
+    Assertions.assertNotNull(loadedView);
+    Assertions.assertEquals("view_concurrent", loadedView.name());
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

When `EntityAlreadyExistsException` is raised during schema/table/view import, catch it and reuse the existing entity instead of throwing `UnsupportedOperationException`.

Changed the `catch (EntityAlreadyExistsException)` blocks in:
- `SchemaOperationDispatcher.importSchema()` — log warning and return
- `TableOperationDispatcher.importTable()` — log warning and reload via `internalLoadTable()`
- `ViewOperationDispatcher.importView()` — log warning and reload via `internalLoadView()`

### Why are the changes needed?

In HA deployments with multiple Gravitino nodes, concurrent imports of the same entity fail because `TreeLock` is JVM-local and does not prevent cross-node races. The current behavior throws `UnsupportedOperationException("... managed by multiple catalogs...")`, which is incorrect for the concurrent-import case — the entity is managed by the same catalog, just imported by another node first.

Fixes #11040

### Does this PR introduce _any_ user-facing change?

No. Concurrent import requests that previously failed with `UnsupportedOperationException` now succeed.

### How was this patch tested?

Added unit tests for each dispatcher:
- `TestSchemaOperationDispatcher.testLoadSchemaConcurrentImport()`
- `TestTableOperationDispatcher.testLoadTableConcurrentImport()`
- `TestViewOperationDispatcher.testLoadViewConcurrentImport()`

Each test mocks `store.put()` to throw `EntityAlreadyExistsException` and verifies that the load operation succeeds without exception.