### PR TITLE
[#11051] improvement(deps): Exclude Derby from hive-metastore-libs runtime classpath

### DIFF
--- a/catalogs/hive-metastore2-libs/build.gradle.kts
+++ b/catalogs/hive-metastore2-libs/build.gradle.kts
@@ -77,6 +77,7 @@ dependencies {
     exclude(group = "junit")
     exclude(group = "org.apache.ant")
     exclude(group = "org.apache.avro")
+    exclude(group = "org.apache.derby")
     exclude(group = "org.apache.hadoop", module = "hadoop-yarn-server-resourcemanager")
     exclude(group = "org.apache.hbase")
     exclude(group = "org.apache.logging.log4j")

--- a/catalogs/hive-metastore3-libs/build.gradle.kts
+++ b/catalogs/hive-metastore3-libs/build.gradle.kts
@@ -62,6 +62,7 @@ dependencies {
     exclude(group = "junit")
     exclude(group = "org.apache.ant")
     exclude(group = "org.apache.avro")
+    exclude(group = "org.apache.derby")
     exclude(group = "org.apache.hadoop", module = "hadoop-yarn-server-resourcemanager")
     exclude(group = "org.apache.hbase")
     exclude(group = "org.apache.logging.log4j")


### PR DESCRIPTION

### What changes were proposed in this pull request?

Exclude `org.apache.derby` from the Hive Metastore transitive dependencies in `hive-metastore2-libs` and `hive-metastore3-libs`.

### Why are the changes needed?

Derby is transitively pulled into the runtime classpath of both hive-metastore-libs modules through Hive Metastore. It is only needed as an embedded database for HMS in tests — production uses MySQL/PostgreSQL. Other modules (`iceberg-common`, `hive-metastore-common`, `catalog-lakehouse-paimon`) already exclude Derby from runtime. This change makes the two libs modules consistent and removes an unnecessary dependency from the production distribution.

Fix: #11051 

### Does this PR introduce _any_ user-facing change?

No. Derby was never intentionally included in the production distribution and is not used at runtime.

### How was this patch tested?

- Verified `runtimeClasspath` of both modules no longer contains Derby via `./gradlew :catalogs:hive-metastore2-libs:dependencies --configuration runtimeClasspath`
- Build passes for both affected modules
