### PR TITLE
[#11055] improvement(deps): Upgrade libthrift from 0.9.3 to 0.12.0 in hive-metastore-libs

### DIFF
--- a/catalogs/hive-metastore2-libs/build.gradle.kts
+++ b/catalogs/hive-metastore2-libs/build.gradle.kts
@@ -29,6 +29,11 @@ plugins {
 // Guava and Logback are excluded because they are provided by the Gravitino runtime classpath.
 
 dependencies {
+  // Force libthrift upgrade from the outdated 0.9.3 pulled by Hive Metastore transitive deps
+  constraints {
+    implementation(libs.thrift)
+  }
+
   implementation(libs.hadoop3.common) {
     exclude(group = "ch.qos.logback")
     exclude(group = "ch.qos.reload4j")

--- a/catalogs/hive-metastore3-libs/build.gradle.kts
+++ b/catalogs/hive-metastore3-libs/build.gradle.kts
@@ -29,6 +29,11 @@ plugins {
 // Guava and Logback are excluded because they are provided by the Gravitino runtime classpath.
 
 dependencies {
+  // Force libthrift upgrade from the outdated 0.9.3 pulled by Hive Metastore transitive deps
+  constraints {
+    implementation(libs.thrift)
+  }
+
   implementation(libs.hadoop3.common) {
     exclude(group = "ch.qos.logback")
     exclude(group = "ch.qos.reload4j")


### PR DESCRIPTION


### What changes were proposed in this pull request?

Add `constraints { implementation(libs.thrift) }` in `hive-metastore2-libs` and `hive-metastore3-libs` to upgrade the transitive libthrift from 0.9.3 to 0.12.0.


### Why are the changes needed?

libthrift 0.9.3 is pulled transitively by Hive Metastore and has known issues in SASL negotiation and large message handling. Version 0.12.0 fixes these while maintaining binary compatibility with Hive 2.x/3.x.

Versions >= 0.14.0 relocate `TFramedTransport` to a different package, breaking Hive compatibility, so 0.12.0 is the highest safe version.

Fix: #11055 

### Does this PR introduce _any_ user-facing change?

No. The Thrift wire protocol is backward-compatible.

### How was this patch tested?

- `CatalogHive2IT` integration test — passes
- `CatalogHive3IT` integration test — passes
- `IcebergRESTHiveCatalogIT` integration test — passes