### PR TITLE
[MINOR] ci: Add idp-basic test workflow

### DIFF
--- a/.github/workflows/idp-basic-test.yml
+++ b/.github/workflows/idp-basic-test.yml
@@ -1,0 +1,75 @@
+name: IdP Basic Test
+
+on:
+  push:
+    branches: ["main", "branch-*"]
+  pull_request:
+    branches: ["main", "branch-*"]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  changes:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36
+        id: filter
+        with:
+          filters: |
+            source_changes:
+              - plugins/idp-basic/**
+              - gradle/**
+              - gradlew
+              - dev/**
+              - build.gradle.kts
+              - gradle.properties
+              - settings.gradle.kts
+              - .github/workflows/idp-basic-test.yml
+      - name: Detect idp-basic module
+        id: module
+        run: |
+          if [ -f plugins/idp-basic/build.gradle.kts ]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+    outputs:
+      source_changes: ${{ steps.filter.outputs.source_changes }}
+      module_exists: ${{ steps.module.outputs.exists }}
+
+  idp-basic-test:
+    needs: changes
+    if: needs.changes.outputs.source_changes == 'true' && needs.changes.outputs.module_exists == 'true'
+    runs-on: ubuntu-22.04
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          java-version: 17
+          distribution: "temurin"
+          cache: "gradle"
+
+      - name: Free up disk space
+        run: |
+          dev/ci/util_free_space.sh
+
+      - name: Run idp-basic tests
+        env:
+          dockerTest: true
+        run: |
+          ./gradlew :plugins:idp-basic:test -PskipITs -PskipDockerTests=false -PskipWeb=true
+
+      - name: Upload idp-basic test reports
+        uses: actions/upload-artifact@v7
+        if: failure()
+        with:
+          name: idp-basic-test-reports
+          path: |
+            plugins/idp-basic/build/reports
+            plugins/idp-basic/build/test-results

--- a/.github/workflows/idp-basic-test.yml
+++ b/.github/workflows/idp-basic-test.yml
@@ -22,6 +22,7 @@ jobs:
           filters: |
             source_changes:
               - plugins/idp-basic/**
+              - core/**
               - gradle/**
               - gradlew
               - dev/**

--- a/plugins/idp-basic/src/test/java/org/apache/gravitino/idp/basic/password/TestArgon2idPasswordHasher.java
+++ b/plugins/idp-basic/src/test/java/org/apache/gravitino/idp/basic/password/TestArgon2idPasswordHasher.java
@@ -147,6 +147,20 @@ public class TestArgon2idPasswordHasher {
     Assertions.assertEquals("Unsupported Argon2id hash parameters", exception.getMessage());
   }
 
+  @Test
+  public void testVerifyRejectsUnexpectedArgon2Version() {
+    String hashedPassword = passwordHasher.hash("test-password");
+    String unsupportedHash =
+        hashedPassword.replace("v=" + Argon2idDefaults.DEFAULT_VERSION, "v=16");
+
+    IllegalArgumentException exception =
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () -> passwordHasher.verify("test-password", unsupportedHash));
+
+    Assertions.assertEquals("Unsupported Argon2id hash parameters", exception.getMessage());
+  }
+
   private static byte[] decodeBase64(String value) {
     int remainder = value.length() % 4;
     String paddedValue = remainder == 0 ? value : value + "====".substring(0, 4 - remainder);


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds a dedicated GitHub Actions workflow for `:plugins:idp-basic:test`.

It introduces:
- a standalone `idp-basic` workflow under `.github/workflows/idp-basic-test.yml`
- path filtering so the workflow mainly runs for `idp-basic` and build-related changes
- `dockerTest=true` in the test step so the workflow is ready for multi-database execution when `idp-basic` backend tests are present
- artifact upload for `plugins/idp-basic` test reports on failure

### Why are the changes needed?

`idp-basic` currently does not have a dedicated module-level CI workflow. Adding one makes the module easier to validate independently and prepares CI coverage for future backend tests in this module.

Fix: #11076

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

```bash
./gradlew :plugins:idp-basic:test -PskipITs -PskipDockerTests=false -PskipWeb=true
```
