### PR TITLE
[MINOR] chore: Update ASF GitHub settings

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -61,6 +61,7 @@ github:
     - geyanggang
     - markhoerth
     - danhuawang
+    - lasdf1234
 
 notifications:
   commits: commits@gravitino.apache.org


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR updates `.asf.yaml` to add `lasdf1234` to the GitHub settings list.

### Why are the changes needed?

The ASF GitHub repository settings need to include the latest reviewer entry in `.asf.yaml`.

Fix: #

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Verified the `.asf.yaml` update locally.