### PR TITLE
[#11101] feat(iceberg-rest-server): Add health check endpoints to the Iceberg REST Catalog server

### DIFF
--- a/clients/client-python/gravitino/dto/requests/owner_set_request.py
+++ b/clients/client-python/gravitino/dto/requests/owner_set_request.py
@@ -38,8 +38,6 @@ class OwnerSetRequest(RESTRequest):
         self._type = owner_type
 
     def validate(self) -> None:
-        Precondition.check_string_not_empty(
-            self._name, '"name" field is required'
-        )
+        Precondition.check_string_not_empty(self._name, '"name" field is required')
         if self._type is None:
             raise IllegalArgumentException('"type" field is required')

--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/RESTService.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/RESTService.java
@@ -50,6 +50,7 @@ import org.apache.gravitino.iceberg.service.provider.IcebergConfigProviderFactor
 import org.apache.gravitino.listener.EventBus;
 import org.apache.gravitino.metrics.MetricsSystem;
 import org.apache.gravitino.metrics.source.MetricsSource;
+import org.apache.gravitino.server.web.HealthAliasServlet;
 import org.apache.gravitino.server.web.HttpServerMetricsSource;
 import org.apache.gravitino.server.web.JettyServer;
 import org.apache.gravitino.server.web.JettyServerConfig;
@@ -174,6 +175,11 @@ public class RESTService implements GravitinoAuxiliaryService {
     server.addServlet(servlet, ICEBERG_SPEC);
     server.addCustomFilters(ICEBERG_SPEC);
     server.addSystemFilters(ICEBERG_SPEC);
+
+    // Root-level aliases for health checks to improve compatibility with various monitoring
+    // systems that expect a /health endpoint.
+    server.addServlet(new HealthAliasServlet("/iceberg"), "/health/*");
+    server.addServlet(new HealthAliasServlet("/iceberg"), "/health.html");
   }
 
   @Override

--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/IcebergAuthenticationFilter.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/IcebergAuthenticationFilter.java
@@ -21,6 +21,8 @@ package org.apache.gravitino.iceberg.service;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import javax.servlet.ServletRequest;
+import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.gravitino.server.authentication.AuthenticationFilter;
@@ -39,6 +41,21 @@ import org.eclipse.jetty.http.HttpStatus;
 public class IcebergAuthenticationFilter extends AuthenticationFilter {
 
   private static final ObjectMapper MAPPER = IcebergObjectMapper.getInstance();
+
+  @Override
+  protected boolean isHealthCheckRequest(ServletRequest request) {
+    if (super.isHealthCheckRequest(request)) {
+      return true;
+    }
+    if (!(request instanceof HttpServletRequest)) {
+      return false;
+    }
+    String path = ((HttpServletRequest) request).getRequestURI();
+    if (path == null) {
+      return false;
+    }
+    return path.equals("/iceberg/health") || path.startsWith("/iceberg/health/");
+  }
 
   @Override
   protected void sendAuthErrorResponse(HttpServletResponse response, Exception exception)

--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/IcebergAuthenticationFilter.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/IcebergAuthenticationFilter.java
@@ -47,13 +47,8 @@ public class IcebergAuthenticationFilter extends AuthenticationFilter {
     if (super.isHealthCheckRequest(request)) {
       return true;
     }
-    if (!(request instanceof HttpServletRequest)) {
-      return false;
-    }
+
     String path = ((HttpServletRequest) request).getRequestURI();
-    if (path == null) {
-      return false;
-    }
     return path.equals("/iceberg/health") || path.startsWith("/iceberg/health/");
   }
 

--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/rest/IcebergHealthOperations.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/rest/IcebergHealthOperations.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.iceberg.service.rest;
+
+import com.codahale.metrics.annotation.ResponseMetered;
+import com.codahale.metrics.annotation.Timed;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import javax.inject.Inject;
+import javax.servlet.http.HttpServlet;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import org.apache.gravitino.dto.HealthCheckDTO;
+import org.apache.gravitino.dto.responses.HealthResponse;
+import org.apache.gravitino.iceberg.service.IcebergCatalogWrapperManager;
+import org.apache.gravitino.metrics.MetricNames;
+
+/**
+ * Health check endpoints for the Iceberg REST server. Follows the same MicroProfile Health
+ * semantics as the main Gravitino server.
+ *
+ * <ul>
+ *   <li>{@code GET /iceberg/health/live} — liveness, 200 as long as the HTTP thread can respond
+ *   <li>{@code GET /iceberg/health/ready} — readiness, 200 when the catalog wrapper manager is
+ *       initialized
+ *   <li>{@code GET /iceberg/health} — aggregate, 200 when both pass
+ * </ul>
+ *
+ * All endpoints return 503 with a JSON body describing the failed check(s) when unhealthy.
+ */
+@Path("/health")
+@Produces(MediaType.APPLICATION_JSON)
+public class IcebergHealthOperations extends HttpServlet {
+
+  private static final String CHECK_HTTP_SERVER = "httpServer";
+  private static final String CHECK_CATALOG_WRAPPER_MANAGER = "catalogWrapperManager";
+
+  @Inject private IcebergCatalogWrapperManager catalogWrapperManager;
+
+  /** Default constructor for Jersey auto-discovery. */
+  public IcebergHealthOperations() {}
+
+  @GET
+  @Path("/live")
+  @Timed(name = "iceberg.health.live." + MetricNames.HTTP_PROCESS_DURATION, absolute = true)
+  @ResponseMetered(name = "iceberg.health.live", absolute = true)
+  public Response live() {
+    HealthCheckDTO check = up(CHECK_HTTP_SERVER, Collections.emptyMap());
+    return ok(new HealthResponse(HealthCheckDTO.Status.UP, Collections.singletonList(check)));
+  }
+
+  @GET
+  @Path("/ready")
+  @Timed(name = "iceberg.health.ready." + MetricNames.HTTP_PROCESS_DURATION, absolute = true)
+  @ResponseMetered(name = "iceberg.health.ready", absolute = true)
+  public Response ready() {
+    HealthCheckDTO managerCheck = checkCatalogWrapperManager();
+    HealthCheckDTO.Status overall = managerCheck.getStatus();
+    HealthResponse body = new HealthResponse(overall, Collections.singletonList(managerCheck));
+    return overall == HealthCheckDTO.Status.UP ? ok(body) : serviceUnavailable(body);
+  }
+
+  @GET
+  @Timed(name = "iceberg.health." + MetricNames.HTTP_PROCESS_DURATION, absolute = true)
+  @ResponseMetered(name = "iceberg.health", absolute = true)
+  public Response health() {
+    List<HealthCheckDTO> checks = new ArrayList<>(2);
+    checks.add(up(CHECK_HTTP_SERVER, Collections.emptyMap()));
+    checks.add(checkCatalogWrapperManager());
+
+    HealthCheckDTO.Status overall =
+        checks.stream().anyMatch(c -> c.getStatus() == HealthCheckDTO.Status.DOWN)
+            ? HealthCheckDTO.Status.DOWN
+            : HealthCheckDTO.Status.UP;
+
+    HealthResponse body = new HealthResponse(overall, checks);
+    return overall == HealthCheckDTO.Status.UP ? ok(body) : serviceUnavailable(body);
+  }
+
+  private HealthCheckDTO checkCatalogWrapperManager() {
+    if (getCatalogWrapperManager() == null) {
+      return down(
+          CHECK_CATALOG_WRAPPER_MANAGER, "reason", "catalog wrapper manager not initialized");
+    }
+    return up(CHECK_CATALOG_WRAPPER_MANAGER, Collections.emptyMap());
+  }
+
+  /** Visible for testing — subclasses override to inject a different manager instance. */
+  IcebergCatalogWrapperManager getCatalogWrapperManager() {
+    return catalogWrapperManager;
+  }
+
+  private static HealthCheckDTO up(String name, java.util.Map<String, String> details) {
+    return new HealthCheckDTO(name, HealthCheckDTO.Status.UP, details);
+  }
+
+  private static HealthCheckDTO down(String name, String detailKey, String detailValue) {
+    return new HealthCheckDTO(
+        name, HealthCheckDTO.Status.DOWN, Collections.singletonMap(detailKey, detailValue));
+  }
+
+  private static Response ok(HealthResponse body) {
+    return Response.status(Response.Status.OK)
+        .entity(body)
+        .type(MediaType.APPLICATION_JSON)
+        .build();
+  }
+
+  private static Response serviceUnavailable(HealthResponse body) {
+    return Response.status(Response.Status.SERVICE_UNAVAILABLE)
+        .entity(body)
+        .type(MediaType.APPLICATION_JSON)
+        .build();
+  }
+}

--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/rest/IcebergHealthOperations.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/rest/IcebergHealthOperations.java
@@ -23,6 +23,7 @@ import com.codahale.metrics.annotation.Timed;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -59,6 +60,11 @@ public class IcebergHealthOperations {
   /** Default constructor for Jersey auto-discovery. */
   public IcebergHealthOperations() {}
 
+  /**
+   * Liveness probe. Returns 200 as long as the HTTP thread can respond.
+   *
+   * @return 200 OK with an UP {@link HealthResponse}
+   */
   @GET
   @Path("/live")
   @Timed(name = "iceberg.health.live." + MetricNames.HTTP_PROCESS_DURATION, absolute = true)
@@ -68,6 +74,12 @@ public class IcebergHealthOperations {
     return ok(new HealthResponse(HealthCheckDTO.Status.UP, Collections.singletonList(check)));
   }
 
+  /**
+   * Readiness probe. Returns 200 when the {@link IcebergCatalogWrapperManager} is initialized, 503
+   * otherwise.
+   *
+   * @return 200 OK when ready, 503 Service Unavailable with a DOWN {@link HealthResponse} otherwise
+   */
   @GET
   @Path("/ready")
   @Timed(name = "iceberg.health.ready." + MetricNames.HTTP_PROCESS_DURATION, absolute = true)
@@ -79,6 +91,11 @@ public class IcebergHealthOperations {
     return overall == HealthCheckDTO.Status.UP ? ok(body) : serviceUnavailable(body);
   }
 
+  /**
+   * Aggregate health check. Returns 200 when both liveness and readiness pass, 503 otherwise.
+   *
+   * @return 200 OK when healthy, 503 Service Unavailable with failing checks described in the body
+   */
   @GET
   @Timed(name = "iceberg.health." + MetricNames.HTTP_PROCESS_DURATION, absolute = true)
   @ResponseMetered(name = "iceberg.health", absolute = true)
@@ -109,7 +126,7 @@ public class IcebergHealthOperations {
     return catalogWrapperManager;
   }
 
-  private static HealthCheckDTO up(String name, java.util.Map<String, String> details) {
+  private static HealthCheckDTO up(String name, Map<String, String> details) {
     return new HealthCheckDTO(name, HealthCheckDTO.Status.UP, details);
   }
 

--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/rest/IcebergHealthOperations.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/rest/IcebergHealthOperations.java
@@ -24,7 +24,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import javax.inject.Inject;
-import javax.servlet.http.HttpServlet;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
@@ -50,7 +49,7 @@ import org.apache.gravitino.metrics.MetricNames;
  */
 @Path("/health")
 @Produces(MediaType.APPLICATION_JSON)
-public class IcebergHealthOperations extends HttpServlet {
+public class IcebergHealthOperations {
 
   private static final String CHECK_HTTP_SERVER = "httpServer";
   private static final String CHECK_CATALOG_WRAPPER_MANAGER = "catalogWrapperManager";

--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/rest/IcebergHealthOperations.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/rest/IcebergHealthOperations.java
@@ -34,6 +34,7 @@ import org.apache.gravitino.dto.HealthCheckDTO;
 import org.apache.gravitino.dto.responses.HealthResponse;
 import org.apache.gravitino.iceberg.service.IcebergCatalogWrapperManager;
 import org.apache.gravitino.metrics.MetricNames;
+import org.apache.gravitino.server.web.Utils;
 
 /**
  * Health check endpoints for the Iceberg REST server. Follows the same MicroProfile Health
@@ -71,7 +72,7 @@ public class IcebergHealthOperations {
   @ResponseMetered(name = "iceberg.health.live", absolute = true)
   public Response live() {
     HealthCheckDTO check = up(CHECK_HTTP_SERVER, Collections.emptyMap());
-    return ok(new HealthResponse(HealthCheckDTO.Status.UP, Collections.singletonList(check)));
+    return Utils.ok(new HealthResponse(HealthCheckDTO.Status.UP, Collections.singletonList(check)));
   }
 
   /**
@@ -88,7 +89,7 @@ public class IcebergHealthOperations {
     HealthCheckDTO managerCheck = checkCatalogWrapperManager();
     HealthCheckDTO.Status overall = managerCheck.getStatus();
     HealthResponse body = new HealthResponse(overall, Collections.singletonList(managerCheck));
-    return overall == HealthCheckDTO.Status.UP ? ok(body) : serviceUnavailable(body);
+    return overall == HealthCheckDTO.Status.UP ? Utils.ok(body) : Utils.serviceUnavailable(body);
   }
 
   /**
@@ -110,7 +111,7 @@ public class IcebergHealthOperations {
             : HealthCheckDTO.Status.UP;
 
     HealthResponse body = new HealthResponse(overall, checks);
-    return overall == HealthCheckDTO.Status.UP ? ok(body) : serviceUnavailable(body);
+    return overall == HealthCheckDTO.Status.UP ? Utils.ok(body) : Utils.serviceUnavailable(body);
   }
 
   private HealthCheckDTO checkCatalogWrapperManager() {
@@ -133,19 +134,5 @@ public class IcebergHealthOperations {
   private static HealthCheckDTO down(String name, String detailKey, String detailValue) {
     return new HealthCheckDTO(
         name, HealthCheckDTO.Status.DOWN, Collections.singletonMap(detailKey, detailValue));
-  }
-
-  private static Response ok(HealthResponse body) {
-    return Response.status(Response.Status.OK)
-        .entity(body)
-        .type(MediaType.APPLICATION_JSON)
-        .build();
-  }
-
-  private static Response serviceUnavailable(HealthResponse body) {
-    return Response.status(Response.Status.SERVICE_UNAVAILABLE)
-        .entity(body)
-        .type(MediaType.APPLICATION_JSON)
-        .build();
   }
 }

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/TestIcebergAuthenticationFilter.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/TestIcebergAuthenticationFilter.java
@@ -25,16 +25,63 @@ import static org.mockito.Mockito.when;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import javax.servlet.ServletRequest;
+import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.apache.gravitino.exceptions.TokenExpiredException;
 import org.apache.gravitino.exceptions.UnauthorizedException;
 import org.apache.iceberg.rest.responses.ErrorResponse;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public class TestIcebergAuthenticationFilter {
 
   private static final ObjectMapper MAPPER = IcebergObjectMapper.getInstance();
+
+  /** Exposes the protected {@code isHealthCheckRequest} method for white-box testing. */
+  private static class TestableFilter extends IcebergAuthenticationFilter {
+    boolean isHealth(ServletRequest request) {
+      return isHealthCheckRequest(request);
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "/iceberg/health",
+        "/iceberg/health/live",
+        "/iceberg/health/ready",
+        "/health",
+        "/health/live",
+        "/health/ready",
+        "/health.html",
+        "/api/health",
+        "/api/health/live",
+        "/api/health/ready"
+      })
+  public void testHealthPathsBypassAuth(String path) {
+    TestableFilter filter = new TestableFilter();
+    HttpServletRequest req = mock(HttpServletRequest.class);
+    when(req.getRequestURI()).thenReturn(path);
+    Assertions.assertTrue(filter.isHealth(req), "Expected health bypass for path: " + path);
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "/iceberg/v1/namespaces",
+        "/iceberg/v1/config",
+        "/iceberg/healthcheck",
+        "/api/metalakes"
+      })
+  public void testNonHealthPathsRequireAuth(String path) {
+    TestableFilter filter = new TestableFilter();
+    HttpServletRequest req = mock(HttpServletRequest.class);
+    when(req.getRequestURI()).thenReturn(path);
+    Assertions.assertFalse(filter.isHealth(req), "Expected auth required for path: " + path);
+  }
 
   @Test
   public void testUnauthorizedErrorReturnsJson() throws Exception {

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/TestIcebergHealthOperations.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/TestIcebergHealthOperations.java
@@ -18,6 +18,8 @@
  */
 package org.apache.gravitino.iceberg.service.rest;
 
+import static org.mockito.Mockito.mock;
+
 import javax.ws.rs.core.Response;
 import org.apache.gravitino.dto.HealthCheckDTO;
 import org.apache.gravitino.dto.responses.HealthResponse;
@@ -48,8 +50,7 @@ public class TestIcebergHealthOperations {
 
   @Test
   public void testReadyReturns200WhenManagerInitialized() {
-    IcebergCatalogWrapperManager manager =
-        org.mockito.Mockito.mock(IcebergCatalogWrapperManager.class);
+    IcebergCatalogWrapperManager manager = mock(IcebergCatalogWrapperManager.class);
     IcebergHealthOperations ops = operationsWithManager(manager);
     Response resp = ops.ready();
     Assertions.assertEquals(Response.Status.OK.getStatusCode(), resp.getStatus());
@@ -70,8 +71,7 @@ public class TestIcebergHealthOperations {
 
   @Test
   public void testHealthReturns200WhenManagerInitialized() {
-    IcebergCatalogWrapperManager manager =
-        org.mockito.Mockito.mock(IcebergCatalogWrapperManager.class);
+    IcebergCatalogWrapperManager manager = mock(IcebergCatalogWrapperManager.class);
     IcebergHealthOperations ops = operationsWithManager(manager);
     Response resp = ops.health();
     Assertions.assertEquals(Response.Status.OK.getStatusCode(), resp.getStatus());

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/TestIcebergHealthOperations.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/TestIcebergHealthOperations.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.iceberg.service.rest;
+
+import javax.ws.rs.core.Response;
+import org.apache.gravitino.dto.HealthCheckDTO;
+import org.apache.gravitino.dto.responses.HealthResponse;
+import org.apache.gravitino.iceberg.service.IcebergCatalogWrapperManager;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TestIcebergHealthOperations {
+
+  private static IcebergHealthOperations operationsWithManager(
+      IcebergCatalogWrapperManager manager) {
+    return new IcebergHealthOperations() {
+      @Override
+      IcebergCatalogWrapperManager getCatalogWrapperManager() {
+        return manager;
+      }
+    };
+  }
+
+  @Test
+  public void testLiveReturns200() {
+    IcebergHealthOperations ops = operationsWithManager(null);
+    Response resp = ops.live();
+    Assertions.assertEquals(Response.Status.OK.getStatusCode(), resp.getStatus());
+    HealthResponse body = (HealthResponse) resp.getEntity();
+    Assertions.assertEquals(HealthCheckDTO.Status.UP, body.getStatus());
+  }
+
+  @Test
+  public void testReadyReturns200WhenManagerInitialized() {
+    IcebergCatalogWrapperManager manager =
+        org.mockito.Mockito.mock(IcebergCatalogWrapperManager.class);
+    IcebergHealthOperations ops = operationsWithManager(manager);
+    Response resp = ops.ready();
+    Assertions.assertEquals(Response.Status.OK.getStatusCode(), resp.getStatus());
+    HealthResponse body = (HealthResponse) resp.getEntity();
+    Assertions.assertEquals(HealthCheckDTO.Status.UP, body.getStatus());
+  }
+
+  @Test
+  public void testReadyReturns503WhenManagerNotInitialized() {
+    IcebergHealthOperations ops = operationsWithManager(null);
+    Response resp = ops.ready();
+    Assertions.assertEquals(Response.Status.SERVICE_UNAVAILABLE.getStatusCode(), resp.getStatus());
+    HealthResponse body = (HealthResponse) resp.getEntity();
+    Assertions.assertEquals(HealthCheckDTO.Status.DOWN, body.getStatus());
+    Assertions.assertFalse(body.getChecks().isEmpty());
+    Assertions.assertEquals("catalogWrapperManager", body.getChecks().get(0).getName());
+  }
+
+  @Test
+  public void testHealthReturns200WhenManagerInitialized() {
+    IcebergCatalogWrapperManager manager =
+        org.mockito.Mockito.mock(IcebergCatalogWrapperManager.class);
+    IcebergHealthOperations ops = operationsWithManager(manager);
+    Response resp = ops.health();
+    Assertions.assertEquals(Response.Status.OK.getStatusCode(), resp.getStatus());
+    HealthResponse body = (HealthResponse) resp.getEntity();
+    Assertions.assertEquals(HealthCheckDTO.Status.UP, body.getStatus());
+    Assertions.assertEquals(2, body.getChecks().size());
+  }
+
+  @Test
+  public void testHealthReturns503WhenManagerNotInitialized() {
+    IcebergHealthOperations ops = operationsWithManager(null);
+    Response resp = ops.health();
+    Assertions.assertEquals(Response.Status.SERVICE_UNAVAILABLE.getStatusCode(), resp.getStatus());
+    HealthResponse body = (HealthResponse) resp.getEntity();
+    Assertions.assertEquals(HealthCheckDTO.Status.DOWN, body.getStatus());
+    boolean hasCatalogCheck =
+        body.getChecks().stream().anyMatch(c -> "catalogWrapperManager".equals(c.getName()));
+    Assertions.assertTrue(hasCatalogCheck);
+  }
+}

--- a/server-common/src/main/java/org/apache/gravitino/server/authentication/AuthenticationFilter.java
+++ b/server-common/src/main/java/org/apache/gravitino/server/authentication/AuthenticationFilter.java
@@ -132,7 +132,7 @@ public class AuthenticationFilter implements Filter {
     response.sendError(status, exception.getMessage());
   }
 
-  private static boolean isHealthCheckRequest(ServletRequest request) {
+  protected boolean isHealthCheckRequest(ServletRequest request) {
     if (!(request instanceof HttpServletRequest)) {
       return false;
     }

--- a/server-common/src/main/java/org/apache/gravitino/server/authentication/AuthenticationFilter.java
+++ b/server-common/src/main/java/org/apache/gravitino/server/authentication/AuthenticationFilter.java
@@ -132,6 +132,13 @@ public class AuthenticationFilter implements Filter {
     response.sendError(status, exception.getMessage());
   }
 
+  /**
+   * Returns {@code true} if the request targets a health check endpoint that should bypass
+   * authentication. Subclasses may override this to add additional bypass paths.
+   *
+   * @param request the incoming servlet request
+   * @return {@code true} if the request should skip authentication
+   */
   protected boolean isHealthCheckRequest(ServletRequest request) {
     if (!(request instanceof HttpServletRequest)) {
       return false;

--- a/server-common/src/main/java/org/apache/gravitino/server/web/HealthAliasServlet.java
+++ b/server-common/src/main/java/org/apache/gravitino/server/web/HealthAliasServlet.java
@@ -26,22 +26,39 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 /**
- * Serves root-level health paths ({@code /health}, {@code /health/live}, {@code /health/ready},
- * {@code /health.html}) by forwarding to the canonical {@code /api/health/*} endpoints.
+ * Forwards root-level health probe paths to canonical health endpoints.
+ *
+ * <p>The no-arg constructor targets {@code /api/health} (for the main Gravitino server). Pass a
+ * custom {@code targetPrefix} (e.g. {@code "/iceberg"}) to forward to a different base path.
  *
  * <p>This alias exists for compatibility with enterprise global traffic managers that require
- * probes at well-known root paths. The canonical implementation remains at {@code /api/health}.
+ * probes at well-known root paths such as {@code /health}, {@code /health/live}, {@code
+ * /health/ready}, and {@code /health.html}.
  */
 public class HealthAliasServlet extends HttpServlet {
+
+  private final String targetPrefix;
+
+  /** Forwards to {@code /api/health*} (main Gravitino server default). */
+  public HealthAliasServlet() {
+    this.targetPrefix = "/api";
+  }
+
+  /**
+   * Forwards to {@code <targetPrefix>/health*}.
+   *
+   * @param targetPrefix the path prefix of the canonical health endpoint, e.g. {@code "/iceberg"}
+   */
+  public HealthAliasServlet(String targetPrefix) {
+    this.targetPrefix = targetPrefix;
+  }
 
   @Override
   protected void doGet(HttpServletRequest req, HttpServletResponse resp)
       throws ServletException, IOException {
-    // Map root-level health paths to their canonical /api/health counterparts.
-    // /health and /health.html both target the aggregate /api/health; legacy GTM
-    // standards sometimes hardcode the .html extension.
+    // /health.html maps to the aggregate endpoint; other paths keep their sub-path.
     String uri = req.getRequestURI();
-    String targetPath = "/health.html".equals(uri) ? "/api/health" : "/api" + uri;
+    String targetPath = "/health.html".equals(uri) ? targetPrefix + "/health" : targetPrefix + uri;
     RequestDispatcher dispatcher = req.getRequestDispatcher(targetPath);
     if (dispatcher == null) {
       resp.sendError(HttpServletResponse.SC_SERVICE_UNAVAILABLE, "health dispatcher unavailable");

--- a/server-common/src/main/java/org/apache/gravitino/server/web/Utils.java
+++ b/server-common/src/main/java/org/apache/gravitino/server/web/Utils.java
@@ -191,6 +191,13 @@ public class Utils {
         .build();
   }
 
+  public static <T> Response serviceUnavailable(T t) {
+    return Response.status(Response.Status.SERVICE_UNAVAILABLE)
+        .entity(t)
+        .type(MediaType.APPLICATION_JSON)
+        .build();
+  }
+
   public static Response doAs(
       HttpServletRequest httpRequest, PrivilegedExceptionAction<Response> action) throws Exception {
     UserPrincipal principal =

--- a/server-common/src/test/java/org/apache/gravitino/server/web/TestHealthAliasServlet.java
+++ b/server-common/src/test/java/org/apache/gravitino/server/web/TestHealthAliasServlet.java
@@ -51,6 +51,26 @@ public class TestHealthAliasServlet {
     verify(dispatcher).forward(req, resp);
   }
 
+  @ParameterizedTest
+  @CsvSource({
+    "/health,        /iceberg/health",
+    "/health.html,   /iceberg/health",
+    "/health/live,   /iceberg/health/live",
+    "/health/ready,  /iceberg/health/ready"
+  })
+  public void testDoGetForwardsWithCustomPrefix(String incoming, String expected) throws Exception {
+    HealthAliasServlet servlet = new HealthAliasServlet("/iceberg");
+    HttpServletRequest req = mock(HttpServletRequest.class);
+    HttpServletResponse resp = mock(HttpServletResponse.class);
+    RequestDispatcher dispatcher = mock(RequestDispatcher.class);
+    when(req.getRequestURI()).thenReturn(incoming.strip());
+    when(req.getRequestDispatcher(expected.strip())).thenReturn(dispatcher);
+
+    servlet.doGet(req, resp);
+
+    verify(dispatcher).forward(req, resp);
+  }
+
   @Test
   public void testDoGetReturns503WhenDispatcherIsNull() throws Exception {
     HealthAliasServlet servlet = new HealthAliasServlet();

--- a/server/src/main/java/org/apache/gravitino/server/web/rest/HealthOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/HealthOperations.java
@@ -34,7 +34,6 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
-import javax.servlet.http.HttpServlet;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
@@ -66,7 +65,7 @@ import org.slf4j.LoggerFactory;
  */
 @Path("/health")
 @Produces(MediaType.APPLICATION_JSON)
-public class HealthOperations extends HttpServlet {
+public class HealthOperations {
 
   private static final Logger LOG = LoggerFactory.getLogger(HealthOperations.class);
 

--- a/server/src/main/java/org/apache/gravitino/server/web/rest/HealthOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/HealthOperations.java
@@ -47,6 +47,7 @@ import org.apache.gravitino.dto.HealthCheckDTO;
 import org.apache.gravitino.dto.responses.HealthResponse;
 import org.apache.gravitino.metrics.MetricNames;
 import org.apache.gravitino.server.ServerConfig;
+import org.apache.gravitino.server.web.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -109,7 +110,7 @@ public class HealthOperations {
   @ResponseMetered(name = "health.live", absolute = true)
   public Response live() {
     HealthCheckDTO check = up(CHECK_HTTP_SERVER, Collections.emptyMap());
-    return ok(new HealthResponse(HealthCheckDTO.Status.UP, Collections.singletonList(check)));
+    return Utils.ok(new HealthResponse(HealthCheckDTO.Status.UP, Collections.singletonList(check)));
   }
 
   @GET
@@ -121,7 +122,7 @@ public class HealthOperations {
     HealthCheckDTO entityStoreCheck = checkEntityStore();
     HealthCheckDTO.Status overall = entityStoreCheck.getStatus();
     HealthResponse body = new HealthResponse(overall, Collections.singletonList(entityStoreCheck));
-    return overall == HealthCheckDTO.Status.UP ? ok(body) : serviceUnavailable(body);
+    return overall == HealthCheckDTO.Status.UP ? Utils.ok(body) : Utils.serviceUnavailable(body);
   }
 
   @GET
@@ -139,7 +140,7 @@ public class HealthOperations {
             : HealthCheckDTO.Status.UP;
 
     HealthResponse body = new HealthResponse(overall, checks);
-    return overall == HealthCheckDTO.Status.UP ? ok(body) : serviceUnavailable(body);
+    return overall == HealthCheckDTO.Status.UP ? Utils.ok(body) : Utils.serviceUnavailable(body);
   }
 
   private HealthCheckDTO checkEntityStore() {
@@ -225,19 +226,5 @@ public class HealthOperations {
   private static HealthCheckDTO down(String name, String detailKey, String detailValue) {
     return new HealthCheckDTO(
         name, HealthCheckDTO.Status.DOWN, Collections.singletonMap(detailKey, detailValue));
-  }
-
-  private static Response ok(HealthResponse body) {
-    return Response.status(Response.Status.OK)
-        .entity(body)
-        .type(MediaType.APPLICATION_JSON)
-        .build();
-  }
-
-  private static Response serviceUnavailable(HealthResponse body) {
-    return Response.status(Response.Status.SERVICE_UNAVAILABLE)
-        .entity(body)
-        .type(MediaType.APPLICATION_JSON)
-        .build();
   }
 }

--- a/server/src/main/java/org/apache/gravitino/server/web/rest/VersionOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/VersionOperations.java
@@ -20,7 +20,6 @@ package org.apache.gravitino.server.web.rest;
 
 import com.codahale.metrics.annotation.ResponseMetered;
 import com.codahale.metrics.annotation.Timed;
-import javax.servlet.http.HttpServlet;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -35,7 +34,7 @@ import org.apache.gravitino.server.web.Utils;
 @Path("/version")
 @Consumes(MediaType.APPLICATION_JSON)
 @Produces(MediaType.APPLICATION_JSON)
-public class VersionOperations extends HttpServlet {
+public class VersionOperations {
   @GET
   @Produces("application/vnd.gravitino.v1+json")
   @Timed(name = "version." + MetricNames.HTTP_PROCESS_DURATION, absolute = true)


### PR DESCRIPTION
### What changes were proposed in this pull request?

Adds MicroProfile-style health check endpoints to the Iceberg REST Catalog (IRC) server, mirroring the existing endpoints on the main Gravitino server:

- `GET /iceberg/health/live` — liveness probe; always 200 while the HTTP thread is responsive
- `GET /iceberg/health/ready` — readiness probe; 200 when `IcebergCatalogWrapperManager` is initialized, 503 otherwise
- `GET /iceberg/health` — aggregate; 200 only when both pass

Root-level GTM aliases (`/health/*`, `/health.html`) are registered unconditionally (standalone and auxiliary mode) and forward to `/iceberg/health*`.

All health paths bypass `IcebergAuthenticationFilter` so infrastructure probes work without credentials.

`HealthAliasServlet` is moved from `:server` to `:server-common` so it can be shared by both modules. `AuthenticationFilter.isHealthCheckRequest` is widened from `private` to `protected` to allow the override in `IcebergAuthenticationFilter`.

### Why are the changes needed?

The IRC server runs on its own Jetty instance and has no health endpoints, making it impossible for Kubernetes probes, load balancers, and enterprise GTMs to monitor its availability.

Fix: #11101

### Does this PR introduce _any_ user-facing change?

Yes — three new REST endpoints are available on the IRC server: `GET /iceberg/health`, `GET /iceberg/health/live`, `GET /iceberg/health/ready`, plus root-level GTM aliases `/health`, `/health/live`, `/health/ready`, `/health.html`.

### How was this patch tested?

- `TestIcebergHealthOperations` — 5 unit tests covering all UP/DOWN combinations for liveness, readiness, and aggregate endpoints
- `TestIcebergAuthenticationFilter` — 2 new parametrized tests verifying `/iceberg/health*` paths bypass auth and non-health paths do not
- `TestHealthAliasServlet` — extended with custom-prefix cases covering `/iceberg` forwarding