### PR TITLE
[#11107] improvement(docs): clarify Trino timezone behavior

### DIFF
--- a/docs/iceberg-rest-engine/trino.md
+++ b/docs/iceberg-rest-engine/trino.md
@@ -171,7 +171,7 @@ To convert a `TIMESTAMP WITH TIME ZONE` value to the current client session time
 SELECT
   id,
   at_timezone(timestamp_with_timezone_column, current_timezone())
-FROM gravitino_irc.<namespace>.<table>;
+FROM <catalog>.<namespace>.<table>;
 ```
 
 ## Gravitino connector vs Iceberg REST

--- a/docs/iceberg-rest-engine/trino.md
+++ b/docs/iceberg-rest-engine/trino.md
@@ -164,10 +164,6 @@ For `TIMESTAMP WITH TIME ZONE` values, Trino does not adjust query results based
 endpoint time zone. Unlike Spark and Flink, Trino displays these values according to how they are
 stored.
 
-This behavior is consistent with Trino's design. A previous attempt to change it was discussed in
-[trinodb/trino#21929](https://github.com/trinodb/trino/pull/21929), but the proposal was not
-accepted.
-
 If you need to convert a `TIMESTAMP WITH TIME ZONE` value to the current client session time zone,
 use `at_timezone` together with `current_timezone()`:
 

--- a/docs/iceberg-rest-engine/trino.md
+++ b/docs/iceberg-rest-engine/trino.md
@@ -160,12 +160,12 @@ WITH (
 
 ## Timestamp with time zone behavior
 
-For `TIMESTAMP WITH TIME ZONE` values, Trino does not adjust query results based on the client
-endpoint time zone. Unlike Spark and Flink, Trino displays these values according to how they are
-stored.
+For `TIMESTAMP WITH TIME ZONE` values, Trino does not adjust query results according to the client
+session time zone. Unlike Spark and Flink, Trino displays these values based on the stored
+timestamp-with-time-zone value.
 
-If you need to convert a `TIMESTAMP WITH TIME ZONE` value to the current client session time zone,
-use `at_timezone` together with `current_timezone()`:
+To convert a `TIMESTAMP WITH TIME ZONE` value to the current client session time zone, use
+`at_timezone` together with `current_timezone()`:
 
 ```sql
 SELECT

--- a/docs/iceberg-rest-engine/trino.md
+++ b/docs/iceberg-rest-engine/trino.md
@@ -158,7 +158,9 @@ WITH (
 );
 ```
 
-## Timestamp with time zone behavior
+## Known issues
+
+### `TIMESTAMP WITH TIME ZONE` values are not adjusted to the client session time zone
 
 For `TIMESTAMP WITH TIME ZONE` values, Trino does not adjust query results according to the client
 session time zone. Unlike Spark and Flink, Trino displays these values based on the stored

--- a/docs/iceberg-rest-engine/trino.md
+++ b/docs/iceberg-rest-engine/trino.md
@@ -158,6 +158,26 @@ WITH (
 );
 ```
 
+## Timestamp with time zone behavior
+
+For `TIMESTAMP WITH TIME ZONE` values, Trino does not adjust query results based on the client
+endpoint time zone. Unlike Spark and Flink, Trino displays these values according to how they are
+stored.
+
+This behavior is consistent with Trino's design. A previous attempt to change it was discussed in
+[trinodb/trino#21929](https://github.com/trinodb/trino/pull/21929), but the proposal was not
+accepted.
+
+If you need to convert a `TIMESTAMP WITH TIME ZONE` value to the current client session time zone,
+use `at_timezone` together with `current_timezone()`:
+
+```sql
+SELECT
+  id,
+  at_timezone(timestamp_with_timezone_column, current_timezone())
+FROM gravitino_irc.<namespace>.<table>;
+```
+
 ## Gravitino connector vs Iceberg REST
 
 | Feature                  | Gravitino Engine Connector  | Iceberg REST                  |


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add a Trino-specific note to `docs/iceberg-rest-engine/trino.md` that explains how `TIMESTAMP WITH TIME ZONE` values are displayed, why Trino does not adjust them based on the client session time zone, and how to convert them with `at_timezone(..., current_timezone())`.

### Why are the changes needed?

Users need explicit guidance on Trino's timezone behavior when querying timestamp values through the Gravitino Iceberg REST Catalog.

Fixes #11107

### Does this PR introduce _any_ user-facing change?

Yes. The Trino Iceberg REST documentation now explains timezone behavior for `TIMESTAMP WITH TIME ZONE` values and provides a SQL workaround.

### How was this patch tested?

Documentation update only.
