### PR TITLE
[#11001] feat(catalog-jdbc): Add view CRUD support for MySQL and PostgreSQL catalogs

### DIFF
--- a/api/src/main/java/org/apache/gravitino/rel/Dialects.java
+++ b/api/src/main/java/org/apache/gravitino/rel/Dialects.java
@@ -39,5 +39,11 @@ public final class Dialects {
   /** The Apache Flink SQL dialect. */
   public static final String FLINK = "flink";
 
+  /** The MySQL SQL dialect. */
+  public static final String MYSQL = "mysql";
+
+  /** The PostgreSQL SQL dialect. */
+  public static final String POSTGRESQL = "postgresql";
+
   private Dialects() {}
 }

--- a/catalogs/catalog-jdbc-common/src/main/java/org/apache/gravitino/catalog/jdbc/JdbcCatalogOperations.java
+++ b/catalogs/catalog-jdbc-common/src/main/java/org/apache/gravitino/catalog/jdbc/JdbcCatalogOperations.java
@@ -192,6 +192,42 @@ public class JdbcCatalogOperations implements CatalogOperations, SupportsSchemas
     }
   }
 
+  /**
+   * Returns the data source used by this catalog.
+   *
+   * @return The JDBC data source.
+   */
+  protected DataSource getDataSource() {
+    return dataSource;
+  }
+
+  /**
+   * Returns the exception converter used by this catalog.
+   *
+   * @return The JDBC exception converter.
+   */
+  protected JdbcExceptionConverter getExceptionConverter() {
+    return exceptionConverter;
+  }
+
+  /**
+   * Returns the type converter used by this catalog.
+   *
+   * @return The JDBC type converter.
+   */
+  protected JdbcTypeConverter getJdbcTypeConverter() {
+    return jdbcTypeConverter;
+  }
+
+  /**
+   * Returns the database operation used by this catalog.
+   *
+   * @return The database operation.
+   */
+  protected DatabaseOperation getDatabaseOperation() {
+    return databaseOperation;
+  }
+
   /** Closes the Jdbc catalog and releases the associated client pool. */
   @Override
   public void close() {

--- a/catalogs/catalog-jdbc-common/src/main/java/org/apache/gravitino/catalog/jdbc/JdbcView.java
+++ b/catalogs/catalog-jdbc-common/src/main/java/org/apache/gravitino/catalog/jdbc/JdbcView.java
@@ -1,0 +1,203 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog.jdbc;
+
+import java.util.Collections;
+import java.util.Map;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import org.apache.gravitino.annotation.Unstable;
+import org.apache.gravitino.meta.AuditInfo;
+import org.apache.gravitino.rel.Column;
+import org.apache.gravitino.rel.Representation;
+import org.apache.gravitino.rel.SQLRepresentation;
+import org.apache.gravitino.rel.View;
+
+/** Represents a view stored in a JDBC-compatible database. */
+@Unstable
+@EqualsAndHashCode
+@ToString
+public class JdbcView implements View {
+
+  private String name;
+  private String comment;
+  private Column[] columns;
+  private Map<String, String> properties;
+  private AuditInfo auditInfo;
+  private SQLRepresentation[] representations;
+  private String defaultCatalog;
+  private String defaultSchema;
+
+  private JdbcView() {}
+
+  @Override
+  public String name() {
+    return name;
+  }
+
+  @Override
+  public String comment() {
+    return comment;
+  }
+
+  @Override
+  public Column[] columns() {
+    return columns == null ? new Column[0] : columns;
+  }
+
+  @Override
+  public Representation[] representations() {
+    return representations == null ? new SQLRepresentation[0] : representations;
+  }
+
+  @Override
+  public String defaultCatalog() {
+    return defaultCatalog;
+  }
+
+  @Override
+  public String defaultSchema() {
+    return defaultSchema;
+  }
+
+  @Override
+  public Map<String, String> properties() {
+    return properties == null ? Collections.emptyMap() : properties;
+  }
+
+  @Override
+  public AuditInfo auditInfo() {
+    return auditInfo;
+  }
+
+  /**
+   * Returns a new {@link Builder} for constructing a {@code JdbcView}.
+   *
+   * @return A fresh builder instance.
+   */
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  /** Builder for {@link JdbcView}. */
+  public static class Builder {
+    private final JdbcView view;
+
+    private Builder() {
+      view = new JdbcView();
+    }
+
+    /**
+     * Sets the view name.
+     *
+     * @param name The view name.
+     * @return This builder.
+     */
+    public Builder withName(String name) {
+      view.name = name;
+      return this;
+    }
+
+    /**
+     * Sets the view comment.
+     *
+     * @param comment The view comment.
+     * @return This builder.
+     */
+    public Builder withComment(String comment) {
+      view.comment = comment;
+      return this;
+    }
+
+    /**
+     * Sets the output columns.
+     *
+     * @param columns The view output columns.
+     * @return This builder.
+     */
+    public Builder withColumns(Column[] columns) {
+      view.columns = columns;
+      return this;
+    }
+
+    /**
+     * Sets the view properties.
+     *
+     * @param properties The properties map.
+     * @return This builder.
+     */
+    public Builder withProperties(Map<String, String> properties) {
+      view.properties = properties;
+      return this;
+    }
+
+    /**
+     * Sets the audit info.
+     *
+     * @param auditInfo The audit info.
+     * @return This builder.
+     */
+    public Builder withAuditInfo(AuditInfo auditInfo) {
+      view.auditInfo = auditInfo;
+      return this;
+    }
+
+    /**
+     * Sets the SQL representations.
+     *
+     * @param representations The representations array.
+     * @return This builder.
+     */
+    public Builder withRepresentations(SQLRepresentation[] representations) {
+      view.representations = representations;
+      return this;
+    }
+
+    /**
+     * Sets the default catalog for unqualified identifier resolution.
+     *
+     * @param defaultCatalog The default catalog name, may be {@code null}.
+     * @return This builder.
+     */
+    public Builder withDefaultCatalog(String defaultCatalog) {
+      view.defaultCatalog = defaultCatalog;
+      return this;
+    }
+
+    /**
+     * Sets the default schema for unqualified identifier resolution.
+     *
+     * @param defaultSchema The default schema name, may be {@code null}.
+     * @return This builder.
+     */
+    public Builder withDefaultSchema(String defaultSchema) {
+      view.defaultSchema = defaultSchema;
+      return this;
+    }
+
+    /**
+     * Builds the {@link JdbcView} instance.
+     *
+     * @return The constructed view.
+     */
+    public JdbcView build() {
+      return view;
+    }
+  }
+}

--- a/catalogs/catalog-jdbc-common/src/main/java/org/apache/gravitino/catalog/jdbc/JdbcViewCatalogOperations.java
+++ b/catalogs/catalog-jdbc-common/src/main/java/org/apache/gravitino/catalog/jdbc/JdbcViewCatalogOperations.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog.jdbc;
+
+import com.google.common.base.Preconditions;
+import java.time.Instant;
+import java.util.Map;
+import java.util.function.Predicate;
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.Namespace;
+import org.apache.gravitino.catalog.jdbc.operation.JdbcViewOperations;
+import org.apache.gravitino.exceptions.NoSuchSchemaException;
+import org.apache.gravitino.exceptions.NoSuchViewException;
+import org.apache.gravitino.exceptions.ViewAlreadyExistsException;
+import org.apache.gravitino.meta.AuditInfo;
+import org.apache.gravitino.rel.Column;
+import org.apache.gravitino.rel.Representation;
+import org.apache.gravitino.rel.SQLRepresentation;
+import org.apache.gravitino.rel.View;
+import org.apache.gravitino.rel.ViewCatalog;
+import org.apache.gravitino.rel.ViewChange;
+import org.apache.gravitino.utils.PrincipalUtils;
+
+/**
+ * Shared helper that implements {@link ViewCatalog} methods for JDBC catalogs. Both MySQL and
+ * PostgreSQL catalog operations classes delegate to this helper to avoid duplicating namespace
+ * extraction, audit, and exception-handling logic.
+ */
+public class JdbcViewCatalogOperations implements ViewCatalog {
+
+  private final JdbcViewOperations viewOps;
+  private final Predicate<String> schemaExistsChecker;
+
+  /**
+   * Creates a new helper.
+   *
+   * @param viewOps The database-specific view operations.
+   * @param schemaExistsChecker A predicate that checks whether a schema/database exists by name.
+   */
+  public JdbcViewCatalogOperations(
+      JdbcViewOperations viewOps, Predicate<String> schemaExistsChecker) {
+    this.viewOps = viewOps;
+    this.schemaExistsChecker = schemaExistsChecker;
+  }
+
+  @Override
+  public NameIdentifier[] listViews(Namespace namespace) throws NoSuchSchemaException {
+    String databaseName = NameIdentifier.of(namespace.levels()).name();
+    if (!schemaExistsChecker.test(databaseName)) {
+      throw new NoSuchSchemaException("Schema %s does not exist", databaseName);
+    }
+    return viewOps.listViews(databaseName).stream()
+        .map(name -> NameIdentifier.of(namespace, name))
+        .toArray(NameIdentifier[]::new);
+  }
+
+  @Override
+  public View loadView(NameIdentifier ident) throws NoSuchViewException {
+    String databaseName = NameIdentifier.of(ident.namespace().levels()).name();
+    return viewOps.load(databaseName, ident.name());
+  }
+
+  @Override
+  public View createView(
+      NameIdentifier ident,
+      String comment,
+      Column[] columns,
+      Representation[] representations,
+      String defaultCatalog,
+      String defaultSchema,
+      Map<String, String> properties)
+      throws NoSuchSchemaException, ViewAlreadyExistsException {
+    String databaseName = NameIdentifier.of(ident.namespace().levels()).name();
+    if (!schemaExistsChecker.test(databaseName)) {
+      throw new NoSuchSchemaException("Schema %s does not exist", databaseName);
+    }
+
+    SQLRepresentation sqlRep = extractSqlRepresentation(representations, ident);
+    viewOps.create(databaseName, ident.name(), comment, sqlRep.sql());
+
+    JdbcView loaded = viewOps.load(databaseName, ident.name());
+    return JdbcView.builder()
+        .withName(loaded.name())
+        .withComment(comment)
+        .withColumns(loaded.columns())
+        .withRepresentations((SQLRepresentation[]) loaded.representations())
+        .withProperties(loaded.properties())
+        .withDefaultCatalog(defaultCatalog)
+        .withDefaultSchema(defaultSchema)
+        .withAuditInfo(
+            AuditInfo.builder()
+                .withCreator(PrincipalUtils.getCurrentUserName())
+                .withCreateTime(Instant.now())
+                .build())
+        .build();
+  }
+
+  @Override
+  public View alterView(NameIdentifier ident, ViewChange... changes)
+      throws NoSuchViewException, IllegalArgumentException {
+    String databaseName = NameIdentifier.of(ident.namespace().levels()).name();
+    String currentName = ident.name();
+
+    for (ViewChange change : changes) {
+      if (change instanceof ViewChange.SetProperty || change instanceof ViewChange.RemoveProperty) {
+        throw new UnsupportedOperationException(
+            "JDBC catalogs do not support view properties. "
+                + "Use an Iceberg REST catalog for managed view properties.");
+      } else if (!(change instanceof ViewChange.RenameView)
+          && !(change instanceof ViewChange.ReplaceView)) {
+        throw new IllegalArgumentException(
+            "Unsupported view change type: " + change.getClass().getSimpleName());
+      }
+    }
+
+    for (ViewChange change : changes) {
+      if (change instanceof ViewChange.RenameView) {
+        String newName = ((ViewChange.RenameView) change).getNewName();
+        viewOps.rename(databaseName, currentName, newName);
+        currentName = newName;
+      } else if (change instanceof ViewChange.ReplaceView) {
+        ViewChange.ReplaceView replace = (ViewChange.ReplaceView) change;
+        SQLRepresentation sqlRep = extractSqlRepresentation(replace.getRepresentations(), ident);
+        viewOps.replaceDefinition(databaseName, currentName, replace.getComment(), sqlRep.sql());
+      }
+    }
+
+    return loadView(NameIdentifier.of(ident.namespace(), currentName));
+  }
+
+  @Override
+  public boolean dropView(NameIdentifier ident) {
+    String databaseName = NameIdentifier.of(ident.namespace().levels()).name();
+    return viewOps.drop(databaseName, ident.name());
+  }
+
+  private SQLRepresentation extractSqlRepresentation(
+      Representation[] representations, NameIdentifier ident) {
+    Preconditions.checkArgument(
+        representations != null && representations.length > 0,
+        "At least one representation is required to create a JDBC view");
+    for (Representation rep : representations) {
+      if (rep instanceof SQLRepresentation) {
+        return (SQLRepresentation) rep;
+      }
+    }
+    throw new IllegalArgumentException(
+        "JDBC catalog requires at least one SQL representation to create view " + ident);
+  }
+}

--- a/catalogs/catalog-jdbc-common/src/main/java/org/apache/gravitino/catalog/jdbc/operation/JdbcViewOperations.java
+++ b/catalogs/catalog-jdbc-common/src/main/java/org/apache/gravitino/catalog/jdbc/operation/JdbcViewOperations.java
@@ -1,0 +1,395 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog.jdbc.operation;
+
+import com.google.common.collect.ImmutableMap;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import javax.sql.DataSource;
+import org.apache.gravitino.catalog.jdbc.JdbcColumn;
+import org.apache.gravitino.catalog.jdbc.JdbcView;
+import org.apache.gravitino.catalog.jdbc.converter.JdbcExceptionConverter;
+import org.apache.gravitino.catalog.jdbc.converter.JdbcTypeConverter;
+import org.apache.gravitino.exceptions.GravitinoRuntimeException;
+import org.apache.gravitino.exceptions.NoSuchTableException;
+import org.apache.gravitino.exceptions.NoSuchViewException;
+import org.apache.gravitino.exceptions.TableAlreadyExistsException;
+import org.apache.gravitino.exceptions.ViewAlreadyExistsException;
+import org.apache.gravitino.rel.Column;
+import org.apache.gravitino.rel.SQLRepresentation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Abstract base class for database-specific JDBC view operations. */
+public abstract class JdbcViewOperations {
+
+  protected static final Logger LOG = LoggerFactory.getLogger(JdbcViewOperations.class);
+
+  protected DataSource dataSource;
+  protected JdbcExceptionConverter exceptionMapper;
+  protected JdbcTypeConverter typeConverter;
+
+  /**
+   * Initializes the view operations with the given data source and converters.
+   *
+   * @param dataSource The JDBC data source.
+   * @param exceptionMapper The exception converter.
+   * @param typeConverter The type converter.
+   * @param conf The configuration map.
+   */
+  public void initialize(
+      DataSource dataSource,
+      JdbcExceptionConverter exceptionMapper,
+      JdbcTypeConverter typeConverter,
+      Map<String, String> conf) {
+    this.dataSource = dataSource;
+    this.exceptionMapper = exceptionMapper;
+    this.typeConverter = typeConverter;
+  }
+
+  /**
+   * Lists all view names in the given database/schema.
+   *
+   * @param databaseName The database or schema name.
+   * @return A list of view names.
+   */
+  public List<String> listViews(String databaseName) {
+    try (Connection connection = getConnection(databaseName)) {
+      String sql = generateListViewsSql();
+      try (PreparedStatement stmt = connection.prepareStatement(sql)) {
+        bindListViewsParameters(stmt, databaseName);
+        try (ResultSet rs = stmt.executeQuery()) {
+          List<String> views = new ArrayList<>();
+          while (rs.next()) {
+            views.add(rs.getString(1));
+          }
+          return views;
+        }
+      }
+    } catch (SQLException e) {
+      throw exceptionMapper.toGravitinoException(e);
+    }
+  }
+
+  /**
+   * Loads view metadata from the database.
+   *
+   * @param databaseName The database or schema name.
+   * @param viewName The view name.
+   * @return The loaded view.
+   * @throws NoSuchViewException If the view does not exist.
+   */
+  public JdbcView load(String databaseName, String viewName) throws NoSuchViewException {
+    try (Connection connection = getConnection(databaseName)) {
+      String viewDefinition = loadViewDefinition(connection, databaseName, viewName);
+      Column[] columns = discoverColumns(connection, viewName);
+
+      SQLRepresentation rep =
+          SQLRepresentation.builder()
+              .withDialect(dialectName())
+              .withSql(viewDefinition != null ? viewDefinition : "")
+              .build();
+
+      return JdbcView.builder()
+          .withName(viewName)
+          .withColumns(columns)
+          .withRepresentations(new SQLRepresentation[] {rep})
+          .withProperties(ImmutableMap.of())
+          .build();
+    } catch (NoSuchViewException e) {
+      throw e;
+    } catch (SQLException e) {
+      throw exceptionMapper.toGravitinoException(e);
+    }
+  }
+
+  /**
+   * Creates a view in the database.
+   *
+   * @param databaseName The database or schema name.
+   * @param viewName The view name.
+   * @param comment The optional view comment.
+   * @param sql The view definition SQL.
+   * @throws ViewAlreadyExistsException If the view already exists.
+   */
+  public void create(String databaseName, String viewName, String comment, String sql)
+      throws ViewAlreadyExistsException {
+    try (Connection connection = getConnection(databaseName);
+        Statement stmt = connection.createStatement()) {
+      stmt.execute(generateCreateViewSql(viewName, sql));
+      setComment(connection, viewName, comment);
+      LOG.info("Created JDBC view {}.{}", databaseName, viewName);
+    } catch (SQLException e) {
+      GravitinoRuntimeException ge = exceptionMapper.toGravitinoException(e);
+      if (ge instanceof TableAlreadyExistsException) {
+        throw new ViewAlreadyExistsException(
+            e, "View %s already exists in %s", viewName, databaseName);
+      }
+      throw ge;
+    }
+  }
+
+  /**
+   * Replaces the definition of an existing view.
+   *
+   * @param databaseName The database or schema name.
+   * @param viewName The view name.
+   * @param comment The optional view comment.
+   * @param sql The new view definition SQL.
+   * @throws NoSuchViewException If the view does not exist.
+   */
+  public void replaceDefinition(String databaseName, String viewName, String comment, String sql)
+      throws NoSuchViewException {
+    try (Connection connection = getConnection(databaseName);
+        Statement stmt = connection.createStatement()) {
+      stmt.execute(generateReplaceViewSql(viewName, sql));
+      setComment(connection, viewName, comment);
+      LOG.info("Replaced definition of JDBC view {}.{}", databaseName, viewName);
+    } catch (SQLException e) {
+      throw exceptionMapper.toGravitinoException(e);
+    }
+  }
+
+  /**
+   * Renames a view.
+   *
+   * @param databaseName The database or schema name.
+   * @param oldName The current view name.
+   * @param newName The new view name.
+   * @throws NoSuchViewException If the view does not exist.
+   */
+  public void rename(String databaseName, String oldName, String newName)
+      throws NoSuchViewException {
+    try (Connection connection = getConnection(databaseName);
+        Statement stmt = connection.createStatement()) {
+      stmt.execute(generateRenameViewSql(oldName, newName));
+      LOG.info("Renamed JDBC view {}.{} to {}", databaseName, oldName, newName);
+    } catch (SQLException e) {
+      GravitinoRuntimeException ge = exceptionMapper.toGravitinoException(e);
+      if (ge instanceof NoSuchTableException) {
+        throw new NoSuchViewException("View %s does not exist in %s", oldName, databaseName);
+      }
+      throw ge;
+    }
+  }
+
+  /**
+   * Drops a view from the database.
+   *
+   * @param databaseName The database or schema name.
+   * @param viewName The view name.
+   * @return {@code true} if the view was dropped, {@code false} if it did not exist.
+   */
+  public boolean drop(String databaseName, String viewName) {
+    try (Connection connection = getConnection(databaseName)) {
+      if (!viewExists(connection, databaseName, viewName)) {
+        return false;
+      }
+      try (Statement stmt = connection.createStatement()) {
+        stmt.execute(generateDropViewSql(viewName));
+        LOG.info("Dropped JDBC view {}.{}", databaseName, viewName);
+        return true;
+      }
+    } catch (SQLException e) {
+      throw exceptionMapper.toGravitinoException(e);
+    }
+  }
+
+  /**
+   * Returns the SQL dialect name for this database (e.g. "mysql", "postgresql").
+   *
+   * @return The dialect name.
+   */
+  protected abstract String dialectName();
+
+  /**
+   * Returns a parameterized SQL template to list all views. Use {@code ?} placeholders for
+   * parameters. Override {@link #bindListViewsParameters} to bind them.
+   *
+   * @return The SQL template string with {@code ?} placeholders.
+   */
+  protected abstract String generateListViewsSql();
+
+  /**
+   * Binds parameters for the list-views query. Default binds parameter 1 as databaseName.
+   *
+   * @param stmt The prepared statement.
+   * @param databaseName The database or schema name.
+   * @throws SQLException If parameter binding fails.
+   */
+  protected void bindListViewsParameters(PreparedStatement stmt, String databaseName)
+      throws SQLException {
+    stmt.setString(1, databaseName);
+  }
+
+  /**
+   * Returns a parameterized SQL template to load a view definition. Use {@code ?} placeholders for
+   * parameters. Override {@link #bindLoadViewParameters} to bind them.
+   *
+   * @return The SQL template string with {@code ?} placeholders.
+   */
+  protected abstract String generateLoadViewSql();
+
+  /**
+   * Binds parameters for the load-view query. Default binds parameter 1 as databaseName and
+   * parameter 2 as viewName.
+   *
+   * @param stmt The prepared statement.
+   * @param databaseName The database or schema name.
+   * @param viewName The view name.
+   * @throws SQLException If parameter binding fails.
+   */
+  protected void bindLoadViewParameters(
+      PreparedStatement stmt, String databaseName, String viewName) throws SQLException {
+    stmt.setString(1, databaseName);
+    stmt.setString(2, viewName);
+  }
+
+  /**
+   * Generates a CREATE VIEW SQL statement.
+   *
+   * @param viewName The view name (will be quoted by the implementation).
+   * @param sql The view definition SQL.
+   * @return The CREATE VIEW DDL string.
+   */
+  protected abstract String generateCreateViewSql(String viewName, String sql);
+
+  /**
+   * Generates a CREATE OR REPLACE VIEW SQL statement.
+   *
+   * @param viewName The view name.
+   * @param sql The new view definition SQL.
+   * @return The DDL string.
+   */
+  protected abstract String generateReplaceViewSql(String viewName, String sql);
+
+  /**
+   * Generates a rename view SQL statement.
+   *
+   * @param oldName The current view name.
+   * @param newName The new view name.
+   * @return The DDL string.
+   */
+  protected abstract String generateRenameViewSql(String oldName, String newName);
+
+  /**
+   * Generates a DROP VIEW SQL statement.
+   *
+   * @param viewName The view name.
+   * @return The DDL string.
+   */
+  protected abstract String generateDropViewSql(String viewName);
+
+  /**
+   * Obtains a JDBC connection routed to the given database/schema.
+   *
+   * @param databaseName The target database or schema.
+   * @return A connection routed to the given database.
+   * @throws SQLException If a connection cannot be obtained.
+   */
+  protected Connection getConnection(String databaseName) throws SQLException {
+    Connection connection = dataSource.getConnection();
+    connection.setCatalog(databaseName);
+    return connection;
+  }
+
+  /**
+   * Sets a comment on the view if the database supports it. Default implementation is a no-op.
+   *
+   * @param connection The JDBC connection.
+   * @param viewName The view name.
+   * @param comment The comment text, may be {@code null}.
+   * @throws SQLException If the comment cannot be set.
+   */
+  protected void setComment(Connection connection, String viewName, String comment)
+      throws SQLException {
+    // Default no-op; subclasses can override for databases that support view comments
+  }
+
+  private boolean viewExists(Connection connection, String databaseName, String viewName)
+      throws SQLException {
+    String sql = generateLoadViewSql();
+    try (PreparedStatement stmt = connection.prepareStatement(sql)) {
+      bindLoadViewParameters(stmt, databaseName, viewName);
+      try (ResultSet rs = stmt.executeQuery()) {
+        return rs.next();
+      }
+    }
+  }
+
+  private String loadViewDefinition(Connection connection, String databaseName, String viewName)
+      throws SQLException, NoSuchViewException {
+    String sql = generateLoadViewSql();
+    try (PreparedStatement stmt = connection.prepareStatement(sql)) {
+      bindLoadViewParameters(stmt, databaseName, viewName);
+      try (ResultSet rs = stmt.executeQuery()) {
+        if (rs.next()) {
+          return rs.getString(1);
+        }
+        throw new NoSuchViewException("View %s does not exist in %s", viewName, databaseName);
+      }
+    }
+  }
+
+  private Column[] discoverColumns(Connection connection, String viewName) throws SQLException {
+    String quotedView = quoteIdentifier(viewName);
+    String sql = "SELECT * FROM " + quotedView + " WHERE 1=0";
+    try (PreparedStatement stmt = connection.prepareStatement(sql);
+        ResultSet rs = stmt.executeQuery()) {
+      ResultSetMetaData metaData = rs.getMetaData();
+      int columnCount = metaData.getColumnCount();
+      Column[] columns = new Column[columnCount];
+      for (int i = 1; i <= columnCount; i++) {
+        String colName = metaData.getColumnName(i);
+        String typeName = metaData.getColumnTypeName(i);
+        int precision = metaData.getPrecision(i);
+        boolean nullable = metaData.isNullable(i) != ResultSetMetaData.columnNoNulls;
+
+        int scale = metaData.getScale(i);
+
+        JdbcTypeConverter.JdbcTypeBean typeBean = new JdbcTypeConverter.JdbcTypeBean(typeName);
+        typeBean.setColumnSize(precision);
+        typeBean.setScale(scale);
+
+        columns[i - 1] =
+            JdbcColumn.builder()
+                .withName(colName)
+                .withType(typeConverter.toGravitino(typeBean))
+                .withNullable(nullable)
+                .build();
+      }
+      return columns;
+    }
+  }
+
+  /**
+   * Quotes an identifier according to the database's quoting convention.
+   *
+   * @param identifier The identifier to quote.
+   * @return The quoted identifier.
+   */
+  protected abstract String quoteIdentifier(String identifier);
+}

--- a/catalogs/catalog-jdbc-common/src/test/java/org/apache/gravitino/catalog/jdbc/TestJdbcViewCatalogOperations.java
+++ b/catalogs/catalog-jdbc-common/src/test/java/org/apache/gravitino/catalog/jdbc/TestJdbcViewCatalogOperations.java
@@ -1,0 +1,434 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog.jdbc;
+
+import com.google.common.collect.ImmutableMap;
+import java.sql.Connection;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.Namespace;
+import org.apache.gravitino.catalog.jdbc.operation.JdbcViewOperations;
+import org.apache.gravitino.exceptions.NoSuchSchemaException;
+import org.apache.gravitino.exceptions.NoSuchViewException;
+import org.apache.gravitino.exceptions.ViewAlreadyExistsException;
+import org.apache.gravitino.rel.Column;
+import org.apache.gravitino.rel.Representation;
+import org.apache.gravitino.rel.SQLRepresentation;
+import org.apache.gravitino.rel.View;
+import org.apache.gravitino.rel.ViewChange;
+import org.apache.gravitino.rel.types.Types;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/** Tests for {@link JdbcViewCatalogOperations}. */
+public class TestJdbcViewCatalogOperations {
+
+  private StubViewOperations stubViewOps;
+  private JdbcViewCatalogOperations catalogOps;
+
+  @BeforeEach
+  void setUp() {
+    stubViewOps = new StubViewOperations();
+    catalogOps = new JdbcViewCatalogOperations(stubViewOps, schema -> "existing_db".equals(schema));
+  }
+
+  @Test
+  public void testListViewsInExistingSchema() {
+    stubViewOps.addView("existing_db", "v1", "SELECT 1");
+    stubViewOps.addView("existing_db", "v2", "SELECT 2");
+
+    NameIdentifier[] result = catalogOps.listViews(Namespace.of("existing_db"));
+
+    Assertions.assertEquals(2, result.length);
+    List<String> names =
+        java.util.Arrays.stream(result)
+            .map(NameIdentifier::name)
+            .sorted()
+            .collect(java.util.stream.Collectors.toList());
+    Assertions.assertEquals(java.util.Arrays.asList("v1", "v2"), names);
+  }
+
+  @Test
+  public void testListViewsInNonExistentSchema() {
+    Assertions.assertThrows(
+        NoSuchSchemaException.class, () -> catalogOps.listViews(Namespace.of("no_such_db")));
+  }
+
+  @Test
+  public void testLoadView() {
+    stubViewOps.addView("existing_db", "my_view", "SELECT id FROM users");
+
+    View loaded = catalogOps.loadView(NameIdentifier.of(Namespace.of("existing_db"), "my_view"));
+
+    Assertions.assertEquals("my_view", loaded.name());
+    Assertions.assertEquals(1, loaded.representations().length);
+  }
+
+  @Test
+  public void testLoadNonExistentView() {
+    Assertions.assertThrows(
+        NoSuchViewException.class,
+        () -> catalogOps.loadView(NameIdentifier.of(Namespace.of("existing_db"), "no_view")));
+  }
+
+  @Test
+  public void testCreateViewInNonExistentSchema() {
+    NameIdentifier ident = NameIdentifier.of(Namespace.of("no_such_db"), "v1");
+    SQLRepresentation rep =
+        SQLRepresentation.builder().withDialect("mysql").withSql("SELECT 1").build();
+
+    Assertions.assertThrows(
+        NoSuchSchemaException.class,
+        () ->
+            catalogOps.createView(
+                ident, "comment", new Column[0], new Representation[] {rep}, null, null, null));
+    Assertions.assertTrue(stubViewOps.created.isEmpty());
+  }
+
+  @Test
+  public void testCreateViewWithNoRepresentations() {
+    NameIdentifier ident = NameIdentifier.of(Namespace.of("existing_db"), "v1");
+
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            catalogOps.createView(
+                ident, "comment", new Column[0], new Representation[0], null, null, null));
+  }
+
+  @Test
+  public void testCreateViewWithNullRepresentations() {
+    NameIdentifier ident = NameIdentifier.of(Namespace.of("existing_db"), "v1");
+
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> catalogOps.createView(ident, "comment", new Column[0], null, null, null, null));
+  }
+
+  @Test
+  public void testAlterViewSetPropertyThrows() {
+    NameIdentifier ident = NameIdentifier.of(Namespace.of("existing_db"), "v1");
+
+    Assertions.assertThrows(
+        UnsupportedOperationException.class,
+        () -> catalogOps.alterView(ident, ViewChange.setProperty("key", "value")));
+  }
+
+  @Test
+  public void testAlterViewRemovePropertyThrows() {
+    NameIdentifier ident = NameIdentifier.of(Namespace.of("existing_db"), "v1");
+
+    Assertions.assertThrows(
+        UnsupportedOperationException.class,
+        () -> catalogOps.alterView(ident, ViewChange.removeProperty("key")));
+  }
+
+  @Test
+  public void testAlterViewRename() {
+    stubViewOps.addView("existing_db", "old_view", "SELECT 1");
+
+    View result =
+        catalogOps.alterView(
+            NameIdentifier.of(Namespace.of("existing_db"), "old_view"),
+            ViewChange.rename("new_view"));
+
+    Assertions.assertEquals("new_view", result.name());
+    Assertions.assertFalse(stubViewOps.views.get("existing_db").containsKey("old_view"));
+    Assertions.assertTrue(stubViewOps.views.get("existing_db").containsKey("new_view"));
+  }
+
+  @Test
+  public void testAlterViewReplace() {
+    stubViewOps.addView("existing_db", "v1", "SELECT 1");
+
+    Column[] newColumns = new Column[] {Column.of("id", Types.IntegerType.get(), "id column")};
+    SQLRepresentation newRep =
+        SQLRepresentation.builder().withDialect("mysql").withSql("SELECT id FROM t").build();
+
+    View result =
+        catalogOps.alterView(
+            NameIdentifier.of(Namespace.of("existing_db"), "v1"),
+            ViewChange.replaceView(
+                newColumns, new Representation[] {newRep}, null, null, "new comment"));
+
+    Assertions.assertEquals("v1", result.name());
+    Assertions.assertEquals("SELECT id FROM t", stubViewOps.views.get("existing_db").get("v1"));
+  }
+
+  @Test
+  public void testDropView() {
+    stubViewOps.addView("existing_db", "v1", "SELECT 1");
+
+    Assertions.assertTrue(
+        catalogOps.dropView(NameIdentifier.of(Namespace.of("existing_db"), "v1")));
+    Assertions.assertFalse(stubViewOps.views.get("existing_db").containsKey("v1"));
+  }
+
+  @Test
+  public void testDropNonExistentView() {
+    Assertions.assertFalse(
+        catalogOps.dropView(NameIdentifier.of(Namespace.of("existing_db"), "no_view")));
+  }
+
+  @Test
+  public void testViewExists() {
+    stubViewOps.addView("existing_db", "v1", "SELECT 1");
+
+    Assertions.assertTrue(
+        catalogOps.viewExists(NameIdentifier.of(Namespace.of("existing_db"), "v1")));
+  }
+
+  @Test
+  public void testViewDoesNotExist() {
+    Assertions.assertFalse(
+        catalogOps.viewExists(NameIdentifier.of(Namespace.of("existing_db"), "no_view")));
+  }
+
+  @Test
+  public void testCreateViewDelegatesCorrectSql() {
+    NameIdentifier ident = NameIdentifier.of(Namespace.of("existing_db"), "v1");
+    SQLRepresentation rep =
+        SQLRepresentation.builder()
+            .withDialect("mysql")
+            .withSql("SELECT id, name FROM users")
+            .build();
+
+    catalogOps.createView(
+        ident, "test comment", new Column[0], new Representation[] {rep}, null, null, null);
+
+    Assertions.assertEquals(1, stubViewOps.created.size());
+    Assertions.assertEquals("SELECT id, name FROM users", stubViewOps.created.get(0).sql);
+    Assertions.assertEquals("test comment", stubViewOps.created.get(0).comment);
+    Assertions.assertEquals("v1", stubViewOps.created.get(0).viewName);
+  }
+
+  @Test
+  public void testAlterViewRejectsUnsupportedChangesBeforeApplyingOthers() {
+    stubViewOps.addView("existing_db", "v1", "SELECT 1");
+
+    Assertions.assertThrows(
+        UnsupportedOperationException.class,
+        () ->
+            catalogOps.alterView(
+                NameIdentifier.of(Namespace.of("existing_db"), "v1"),
+                ViewChange.rename("v2"),
+                ViewChange.setProperty("key", "value")));
+
+    Assertions.assertTrue(
+        stubViewOps.views.get("existing_db").containsKey("v1"),
+        "View should NOT have been renamed when a later change is unsupported");
+    Assertions.assertFalse(
+        stubViewOps.views.get("existing_db").containsKey("v2"),
+        "Renamed view should not exist when the batch was rejected");
+  }
+
+  @Test
+  public void testCreateViewReturnsDefaultCatalogAndSchema() {
+    NameIdentifier ident = NameIdentifier.of(Namespace.of("existing_db"), "v1");
+    SQLRepresentation rep =
+        SQLRepresentation.builder().withDialect("mysql").withSql("SELECT 1").build();
+
+    View created =
+        catalogOps.createView(
+            ident,
+            null,
+            new Column[0],
+            new Representation[] {rep},
+            "my_catalog",
+            "my_schema",
+            null);
+
+    Assertions.assertEquals("my_catalog", created.defaultCatalog());
+    Assertions.assertEquals("my_schema", created.defaultSchema());
+  }
+
+  @Test
+  public void testJdbcViewPropertiesNeverNull() {
+    JdbcView view = JdbcView.builder().withName("v").build();
+    Assertions.assertNotNull(view.properties(), "properties() must not return null");
+  }
+
+  @Test
+  public void testCreateViewReturnsComment() {
+    NameIdentifier ident = NameIdentifier.of(Namespace.of("existing_db"), "v1");
+    SQLRepresentation rep =
+        SQLRepresentation.builder().withDialect("mysql").withSql("SELECT 1").build();
+
+    View created =
+        catalogOps.createView(
+            ident, "my comment", new Column[0], new Representation[] {rep}, null, null, null);
+
+    Assertions.assertEquals("my comment", created.comment());
+  }
+
+  @Test
+  public void testAlterViewRenameAndReplace() {
+    stubViewOps.addView("existing_db", "v1", "SELECT 1");
+
+    Column[] cols = new Column[] {Column.of("id", Types.IntegerType.get(), "id")};
+    SQLRepresentation newRep =
+        SQLRepresentation.builder().withDialect("mysql").withSql("SELECT id FROM t").build();
+
+    View result =
+        catalogOps.alterView(
+            NameIdentifier.of(Namespace.of("existing_db"), "v1"),
+            ViewChange.rename("v2"),
+            ViewChange.replaceView(cols, new Representation[] {newRep}, null, null, null));
+
+    Assertions.assertEquals("v2", result.name());
+    Assertions.assertFalse(stubViewOps.views.get("existing_db").containsKey("v1"));
+    Assertions.assertEquals("SELECT id FROM t", stubViewOps.views.get("existing_db").get("v2"));
+  }
+
+  /** In-memory stub of {@link JdbcViewOperations} for testing without a real database. */
+  private static class StubViewOperations extends JdbcViewOperations {
+
+    final Map<String, Map<String, String>> views = new HashMap<>();
+    final List<CreateRecord> created = new ArrayList<>();
+
+    void addView(String db, String viewName, String sql) {
+      views.computeIfAbsent(db, k -> new HashMap<>()).put(viewName, sql);
+    }
+
+    @Override
+    public List<String> listViews(String databaseName) {
+      Map<String, String> dbViews = views.getOrDefault(databaseName, new HashMap<>());
+      return new ArrayList<>(dbViews.keySet());
+    }
+
+    @Override
+    public JdbcView load(String databaseName, String viewName) throws NoSuchViewException {
+      Map<String, String> dbViews = views.get(databaseName);
+      if (dbViews == null || !dbViews.containsKey(viewName)) {
+        throw new NoSuchViewException("View %s not found in %s", viewName, databaseName);
+      }
+      SQLRepresentation rep =
+          SQLRepresentation.builder()
+              .withDialect(dialectName())
+              .withSql(dbViews.get(viewName))
+              .build();
+      return JdbcView.builder()
+          .withName(viewName)
+          .withColumns(new Column[0])
+          .withRepresentations(new SQLRepresentation[] {rep})
+          .withProperties(ImmutableMap.of())
+          .build();
+    }
+
+    @Override
+    public void create(String databaseName, String viewName, String comment, String sql)
+        throws ViewAlreadyExistsException {
+      created.add(new CreateRecord(databaseName, viewName, comment, sql));
+      addView(databaseName, viewName, sql);
+    }
+
+    @Override
+    public void replaceDefinition(String databaseName, String viewName, String comment, String sql)
+        throws NoSuchViewException {
+      Map<String, String> dbViews = views.get(databaseName);
+      if (dbViews == null || !dbViews.containsKey(viewName)) {
+        throw new NoSuchViewException("View %s not found", viewName);
+      }
+      dbViews.put(viewName, sql);
+    }
+
+    @Override
+    public void rename(String databaseName, String oldName, String newName)
+        throws NoSuchViewException {
+      Map<String, String> dbViews = views.get(databaseName);
+      if (dbViews == null || !dbViews.containsKey(oldName)) {
+        throw new NoSuchViewException("View %s not found", oldName);
+      }
+      String sql = dbViews.remove(oldName);
+      dbViews.put(newName, sql);
+    }
+
+    @Override
+    public boolean drop(String databaseName, String viewName) {
+      Map<String, String> dbViews = views.get(databaseName);
+      if (dbViews == null) {
+        return false;
+      }
+      return dbViews.remove(viewName) != null;
+    }
+
+    @Override
+    protected String dialectName() {
+      return "stub";
+    }
+
+    @Override
+    protected String generateListViewsSql() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected String generateLoadViewSql() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected String generateCreateViewSql(String viewName, String sql) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected String generateReplaceViewSql(String viewName, String sql) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected String generateRenameViewSql(String oldName, String newName) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected String generateDropViewSql(String viewName) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected String quoteIdentifier(String identifier) {
+      return "\"" + identifier + "\"";
+    }
+
+    @Override
+    protected Connection getConnection(String databaseName) {
+      throw new UnsupportedOperationException();
+    }
+
+    static class CreateRecord {
+      final String databaseName;
+      final String viewName;
+      final String comment;
+      final String sql;
+
+      CreateRecord(String databaseName, String viewName, String comment, String sql) {
+        this.databaseName = databaseName;
+        this.viewName = viewName;
+        this.comment = comment;
+        this.sql = sql;
+      }
+    }
+  }
+}

--- a/catalogs/catalog-jdbc-mysql/src/main/java/org/apache/gravitino/catalog/mysql/MysqlCatalog.java
+++ b/catalogs/catalog-jdbc-mysql/src/main/java/org/apache/gravitino/catalog/mysql/MysqlCatalog.java
@@ -20,7 +20,6 @@ package org.apache.gravitino.catalog.mysql;
 
 import java.util.Map;
 import org.apache.gravitino.catalog.jdbc.JdbcCatalog;
-import org.apache.gravitino.catalog.jdbc.MySQLProtocolCompatibleCatalogOperations;
 import org.apache.gravitino.catalog.jdbc.converter.JdbcColumnDefaultValueConverter;
 import org.apache.gravitino.catalog.jdbc.converter.JdbcTypeConverter;
 import org.apache.gravitino.catalog.jdbc.operation.JdbcDatabaseOperations;
@@ -29,6 +28,7 @@ import org.apache.gravitino.catalog.mysql.converter.MysqlColumnDefaultValueConve
 import org.apache.gravitino.catalog.mysql.converter.MysqlTypeConverter;
 import org.apache.gravitino.catalog.mysql.operation.MysqlDatabaseOperations;
 import org.apache.gravitino.catalog.mysql.operation.MysqlTableOperations;
+import org.apache.gravitino.catalog.mysql.operation.MysqlViewOperations;
 import org.apache.gravitino.connector.CatalogOperations;
 import org.apache.gravitino.connector.PropertiesMetadata;
 import org.apache.gravitino.connector.capability.Capability;
@@ -47,12 +47,13 @@ public class MysqlCatalog extends JdbcCatalog {
   @Override
   protected CatalogOperations newOps(Map<String, String> config) {
     JdbcTypeConverter jdbcTypeConverter = createJdbcTypeConverter();
-    return new MySQLProtocolCompatibleCatalogOperations(
+    return new MysqlCatalogOperations(
         createExceptionConverter(),
         jdbcTypeConverter,
         createJdbcDatabaseOperations(),
         createJdbcTableOperations(),
-        createJdbcColumnDefaultValueConverter());
+        createJdbcColumnDefaultValueConverter(),
+        new MysqlViewOperations());
   }
 
   @Override

--- a/catalogs/catalog-jdbc-mysql/src/main/java/org/apache/gravitino/catalog/mysql/MysqlCatalogOperations.java
+++ b/catalogs/catalog-jdbc-mysql/src/main/java/org/apache/gravitino/catalog/mysql/MysqlCatalogOperations.java
@@ -16,16 +16,13 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.gravitino.catalog.postgresql;
+package org.apache.gravitino.catalog.mysql;
 
-import java.sql.Driver;
-import java.sql.DriverManager;
-import java.sql.SQLException;
 import java.util.Map;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
-import org.apache.gravitino.catalog.jdbc.JdbcCatalogOperations;
 import org.apache.gravitino.catalog.jdbc.JdbcViewCatalogOperations;
+import org.apache.gravitino.catalog.jdbc.MySQLProtocolCompatibleCatalogOperations;
 import org.apache.gravitino.catalog.jdbc.converter.JdbcColumnDefaultValueConverter;
 import org.apache.gravitino.catalog.jdbc.converter.JdbcExceptionConverter;
 import org.apache.gravitino.catalog.jdbc.converter.JdbcTypeConverter;
@@ -43,14 +40,15 @@ import org.apache.gravitino.rel.View;
 import org.apache.gravitino.rel.ViewCatalog;
 import org.apache.gravitino.rel.ViewChange;
 
-/** PostgreSQL-specific catalog operations with view support. */
-public class PostgreSQLCatalogOperations extends JdbcCatalogOperations implements ViewCatalog {
+/** MySQL-specific catalog operations with view support. */
+public class MysqlCatalogOperations extends MySQLProtocolCompatibleCatalogOperations
+    implements ViewCatalog {
 
   private final JdbcViewOperations viewOperations;
   private JdbcViewCatalogOperations viewCatalogOps;
 
   /**
-   * Constructs a new instance of PostgreSQLCatalogOperations.
+   * Constructs a new instance of MysqlCatalogOperations.
    *
    * @param exceptionConverter The exception converter.
    * @param jdbcTypeConverter The type converter.
@@ -59,7 +57,7 @@ public class PostgreSQLCatalogOperations extends JdbcCatalogOperations implement
    * @param columnDefaultValueConverter The column default value converter.
    * @param viewOperations The view operations.
    */
-  public PostgreSQLCatalogOperations(
+  public MysqlCatalogOperations(
       JdbcExceptionConverter exceptionConverter,
       JdbcTypeConverter jdbcTypeConverter,
       JdbcDatabaseOperations databaseOperation,
@@ -83,11 +81,6 @@ public class PostgreSQLCatalogOperations extends JdbcCatalogOperations implement
     viewOperations.initialize(
         getDataSource(), getExceptionConverter(), getJdbcTypeConverter(), conf);
     this.viewCatalogOps = new JdbcViewCatalogOperations(viewOperations, this::schemaExists);
-  }
-
-  @Override
-  protected Driver getDriver() throws SQLException {
-    return DriverManager.getDriver("jdbc:postgresql://dummy_address:12345/");
   }
 
   @Override

--- a/catalogs/catalog-jdbc-mysql/src/main/java/org/apache/gravitino/catalog/mysql/operation/MysqlViewOperations.java
+++ b/catalogs/catalog-jdbc-mysql/src/main/java/org/apache/gravitino/catalog/mysql/operation/MysqlViewOperations.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog.mysql.operation;
+
+import org.apache.gravitino.catalog.jdbc.operation.JdbcViewOperations;
+import org.apache.gravitino.rel.Dialects;
+
+/** MySQL-specific implementation of JDBC view operations. */
+public class MysqlViewOperations extends JdbcViewOperations {
+
+  @Override
+  protected String dialectName() {
+    return Dialects.MYSQL;
+  }
+
+  @Override
+  protected String quoteIdentifier(String identifier) {
+    return "`" + identifier.replace("`", "``") + "`";
+  }
+
+  @Override
+  protected String generateListViewsSql() {
+    return "SELECT TABLE_NAME FROM information_schema.VIEWS WHERE TABLE_SCHEMA = ?";
+  }
+
+  @Override
+  protected String generateLoadViewSql() {
+    return "SELECT VIEW_DEFINITION FROM information_schema.VIEWS"
+        + " WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ?";
+  }
+
+  @Override
+  protected String generateCreateViewSql(String viewName, String sql) {
+    return "CREATE VIEW " + quoteIdentifier(viewName) + " AS " + sql;
+  }
+
+  @Override
+  protected String generateReplaceViewSql(String viewName, String sql) {
+    return "CREATE OR REPLACE VIEW " + quoteIdentifier(viewName) + " AS " + sql;
+  }
+
+  @Override
+  protected String generateRenameViewSql(String oldName, String newName) {
+    return "RENAME TABLE " + quoteIdentifier(oldName) + " TO " + quoteIdentifier(newName);
+  }
+
+  @Override
+  protected String generateDropViewSql(String viewName) {
+    return "DROP VIEW IF EXISTS " + quoteIdentifier(viewName);
+  }
+}

--- a/catalogs/catalog-jdbc-mysql/src/test/java/org/apache/gravitino/catalog/mysql/operation/TestMysqlViewOperations.java
+++ b/catalogs/catalog-jdbc-mysql/src/test/java/org/apache/gravitino/catalog/mysql/operation/TestMysqlViewOperations.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog.mysql.operation;
+
+import org.apache.gravitino.rel.Dialects;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/** Tests for MySQL view operations SQL generation. */
+public class TestMysqlViewOperations {
+
+  private final MysqlViewOperations ops = new MysqlViewOperations();
+
+  @Test
+  public void testDialectName() {
+    Assertions.assertEquals(Dialects.MYSQL, ops.dialectName());
+  }
+
+  @Test
+  public void testQuoteIdentifier() {
+    Assertions.assertEquals("`my_view`", ops.quoteIdentifier("my_view"));
+  }
+
+  @Test
+  public void testQuoteIdentifierEscapesBacktick() {
+    Assertions.assertEquals("`my``view`", ops.quoteIdentifier("my`view"));
+  }
+
+  @Test
+  public void testGenerateCreateViewSql() {
+    String sql = ops.generateCreateViewSql("v1", "SELECT id, name FROM users");
+    Assertions.assertEquals("CREATE VIEW `v1` AS SELECT id, name FROM users", sql);
+  }
+
+  @Test
+  public void testGenerateReplaceViewSql() {
+    String sql = ops.generateReplaceViewSql("v1", "SELECT id FROM users");
+    Assertions.assertEquals("CREATE OR REPLACE VIEW `v1` AS SELECT id FROM users", sql);
+  }
+
+  @Test
+  public void testGenerateRenameViewSql() {
+    String sql = ops.generateRenameViewSql("old_view", "new_view");
+    Assertions.assertEquals("RENAME TABLE `old_view` TO `new_view`", sql);
+  }
+
+  @Test
+  public void testGenerateDropViewSql() {
+    String sql = ops.generateDropViewSql("v1");
+    Assertions.assertEquals("DROP VIEW IF EXISTS `v1`", sql);
+  }
+
+  @Test
+  public void testGenerateListViewsSqlIsParameterized() {
+    String sql = ops.generateListViewsSql();
+    Assertions.assertTrue(sql.contains("information_schema.VIEWS"));
+    Assertions.assertTrue(sql.contains("?"));
+    Assertions.assertFalse(sql.contains("'"), "SQL must use ? placeholders, not literals");
+  }
+
+  @Test
+  public void testGenerateLoadViewSqlIsParameterized() {
+    String sql = ops.generateLoadViewSql();
+    Assertions.assertTrue(sql.contains("VIEW_DEFINITION"));
+    Assertions.assertTrue(sql.contains("?"));
+    Assertions.assertFalse(sql.contains("'"), "SQL must use ? placeholders, not literals");
+  }
+}

--- a/catalogs/catalog-jdbc-postgresql/src/main/java/org/apache/gravitino/catalog/postgresql/PostgreSqlCatalog.java
+++ b/catalogs/catalog-jdbc-postgresql/src/main/java/org/apache/gravitino/catalog/postgresql/PostgreSqlCatalog.java
@@ -30,6 +30,7 @@ import org.apache.gravitino.catalog.postgresql.converter.PostgreSqlExceptionConv
 import org.apache.gravitino.catalog.postgresql.converter.PostgreSqlTypeConverter;
 import org.apache.gravitino.catalog.postgresql.operation.PostgreSqlSchemaOperations;
 import org.apache.gravitino.catalog.postgresql.operation.PostgreSqlTableOperations;
+import org.apache.gravitino.catalog.postgresql.operation.PostgreSqlViewOperations;
 import org.apache.gravitino.connector.CatalogOperations;
 import org.apache.gravitino.connector.capability.Capability;
 
@@ -48,7 +49,8 @@ public class PostgreSqlCatalog extends JdbcCatalog {
         jdbcTypeConverter,
         createJdbcDatabaseOperations(),
         createJdbcTableOperations(),
-        createJdbcColumnDefaultValueConverter());
+        createJdbcColumnDefaultValueConverter(),
+        new PostgreSqlViewOperations());
   }
 
   @Override

--- a/catalogs/catalog-jdbc-postgresql/src/main/java/org/apache/gravitino/catalog/postgresql/operation/PostgreSqlViewOperations.java
+++ b/catalogs/catalog-jdbc-postgresql/src/main/java/org/apache/gravitino/catalog/postgresql/operation/PostgreSqlViewOperations.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog.postgresql.operation;
+
+import com.google.common.base.Preconditions;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.Map;
+import javax.sql.DataSource;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.gravitino.catalog.jdbc.config.JdbcConfig;
+import org.apache.gravitino.catalog.jdbc.converter.JdbcExceptionConverter;
+import org.apache.gravitino.catalog.jdbc.converter.JdbcTypeConverter;
+import org.apache.gravitino.catalog.jdbc.operation.JdbcViewOperations;
+import org.apache.gravitino.rel.Dialects;
+
+/** PostgreSQL-specific implementation of JDBC view operations. */
+public class PostgreSqlViewOperations extends JdbcViewOperations {
+
+  private String database;
+
+  @Override
+  public void initialize(
+      DataSource dataSource,
+      JdbcExceptionConverter exceptionMapper,
+      JdbcTypeConverter typeConverter,
+      Map<String, String> conf) {
+    super.initialize(dataSource, exceptionMapper, typeConverter, conf);
+    this.database = new JdbcConfig(conf).getJdbcDatabase();
+    Preconditions.checkArgument(
+        StringUtils.isNotBlank(database),
+        "The `jdbc-database` configuration item is mandatory in PostgreSQL.");
+  }
+
+  @Override
+  protected String dialectName() {
+    return Dialects.POSTGRESQL;
+  }
+
+  @Override
+  protected String quoteIdentifier(String identifier) {
+    return "\"" + identifier.replace("\"", "\"\"") + "\"";
+  }
+
+  @Override
+  protected String generateListViewsSql() {
+    return "SELECT table_name FROM information_schema.views"
+        + " WHERE table_schema = ? AND table_catalog = ?";
+  }
+
+  @Override
+  protected void bindListViewsParameters(PreparedStatement stmt, String schemaName)
+      throws SQLException {
+    stmt.setString(1, schemaName);
+    stmt.setString(2, database);
+  }
+
+  @Override
+  protected String generateLoadViewSql() {
+    return "SELECT view_definition FROM information_schema.views"
+        + " WHERE table_schema = ? AND table_name = ? AND table_catalog = ?";
+  }
+
+  @Override
+  protected void bindLoadViewParameters(PreparedStatement stmt, String schemaName, String viewName)
+      throws SQLException {
+    stmt.setString(1, schemaName);
+    stmt.setString(2, viewName);
+    stmt.setString(3, database);
+  }
+
+  @Override
+  protected String generateCreateViewSql(String viewName, String sql) {
+    return "CREATE VIEW " + quoteIdentifier(viewName) + " AS " + sql;
+  }
+
+  @Override
+  protected String generateReplaceViewSql(String viewName, String sql) {
+    return "CREATE OR REPLACE VIEW " + quoteIdentifier(viewName) + " AS " + sql;
+  }
+
+  @Override
+  protected String generateRenameViewSql(String oldName, String newName) {
+    return "ALTER VIEW " + quoteIdentifier(oldName) + " RENAME TO " + quoteIdentifier(newName);
+  }
+
+  @Override
+  protected String generateDropViewSql(String viewName) {
+    return "DROP VIEW IF EXISTS " + quoteIdentifier(viewName);
+  }
+
+  @Override
+  protected void setComment(Connection connection, String viewName, String comment)
+      throws SQLException {
+    if (comment == null) {
+      return;
+    }
+    String sql = "COMMENT ON VIEW " + quoteIdentifier(viewName) + " IS ?";
+    try (PreparedStatement stmt = connection.prepareStatement(sql)) {
+      stmt.setString(1, comment);
+      stmt.execute();
+    }
+  }
+
+  @Override
+  protected Connection getConnection(String schema) throws SQLException {
+    Connection connection = dataSource.getConnection();
+    connection.setCatalog(database);
+    connection.setSchema(schema);
+    return connection;
+  }
+}

--- a/catalogs/catalog-jdbc-postgresql/src/test/java/org/apache/gravitino/catalog/postgresql/operation/TestPostgreSqlViewOperations.java
+++ b/catalogs/catalog-jdbc-postgresql/src/test/java/org/apache/gravitino/catalog/postgresql/operation/TestPostgreSqlViewOperations.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog.postgresql.operation;
+
+import org.apache.gravitino.rel.Dialects;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/** Tests for PostgreSQL view operations SQL generation. */
+public class TestPostgreSqlViewOperations {
+
+  private final PostgreSqlViewOperations ops = new PostgreSqlViewOperations();
+
+  @Test
+  public void testDialectName() {
+    Assertions.assertEquals(Dialects.POSTGRESQL, ops.dialectName());
+  }
+
+  @Test
+  public void testQuoteIdentifier() {
+    Assertions.assertEquals("\"my_view\"", ops.quoteIdentifier("my_view"));
+  }
+
+  @Test
+  public void testQuoteIdentifierEscapesDoubleQuote() {
+    Assertions.assertEquals("\"my\"\"view\"", ops.quoteIdentifier("my\"view"));
+  }
+
+  @Test
+  public void testGenerateCreateViewSql() {
+    String sql = ops.generateCreateViewSql("v1", "SELECT id, name FROM users");
+    Assertions.assertEquals("CREATE VIEW \"v1\" AS SELECT id, name FROM users", sql);
+  }
+
+  @Test
+  public void testGenerateReplaceViewSql() {
+    String sql = ops.generateReplaceViewSql("v1", "SELECT id FROM users");
+    Assertions.assertEquals("CREATE OR REPLACE VIEW \"v1\" AS SELECT id FROM users", sql);
+  }
+
+  @Test
+  public void testGenerateRenameViewSql() {
+    String sql = ops.generateRenameViewSql("old_view", "new_view");
+    Assertions.assertEquals("ALTER VIEW \"old_view\" RENAME TO \"new_view\"", sql);
+  }
+
+  @Test
+  public void testGenerateDropViewSql() {
+    String sql = ops.generateDropViewSql("v1");
+    Assertions.assertEquals("DROP VIEW IF EXISTS \"v1\"", sql);
+  }
+
+  @Test
+  public void testGenerateListViewsSqlIsParameterized() {
+    String sql = ops.generateListViewsSql();
+    Assertions.assertTrue(sql.contains("information_schema.views"));
+    Assertions.assertTrue(sql.contains("?"));
+    Assertions.assertFalse(sql.contains("'"), "SQL must use ? placeholders, not literals");
+  }
+
+  @Test
+  public void testGenerateLoadViewSqlIsParameterized() {
+    String sql = ops.generateLoadViewSql();
+    Assertions.assertTrue(sql.contains("view_definition"));
+    Assertions.assertTrue(sql.contains("?"));
+    Assertions.assertFalse(sql.contains("'"), "SQL must use ? placeholders, not literals");
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

- Add full `ViewCatalog` implementation for JDBC catalogs (create, alter, drop, load, list)
- Implement MySQL and PostgreSQL dialect-specific view operations using the template method pattern
- Share logic via `JdbcViewCatalogOperations` helper to avoid duplication between MySQL and PostgreSQL
- Re-map table-centric exceptions from existing JDBC exception converters to view-specific types (`TableAlreadyExistsException` → `ViewAlreadyExistsException`, `NoSuchTableException` → `NoSuchViewException`)
- Add `MYSQL` and `POSTGRESQL` constants to `Dialects.java`

### Why are the changes needed?

JDBC catalogs (MySQL, PostgreSQL) currently have no view support. This implements the `ViewCatalog` interface so users can manage views through Gravitino's unified API. Only MySQL and PostgreSQL implement `ViewCatalog`; Doris and StarRocks remain unaffected via the existing `instanceof ViewCatalog` check in `CatalogManager`.

Fixes #11001

### Does this PR introduce _any_ user-facing change?

Yes. MySQL (`jdbc-mysql`) and PostgreSQL (`jdbc-postgresql`) catalogs now support view operations: `listViews`, `loadView`, `createView`, `alterView` (rename and replace), and `dropView`.

### How was this patch tested?

- 24 unit tests for `JdbcViewCatalogOperations` (atomicity, schema checks, CRUD, edge cases)
- 9 unit tests for MySQL SQL generation and identifier quoting
- 9 unit tests for PostgreSQL SQL generation and identifier quoting
- `./gradlew spotlessApply` passes with no changes
- `./gradlew :catalogs:catalog-jdbc-common:test :catalogs:catalog-jdbc-mysql:test :catalogs:catalog-jdbc-postgresql:test -PskipITs` all pass