### PR TITLE
[#11220] docs(spec): Add design documents for async hard deletion

### DIFF
--- a/design-docs/async-iceberg-rest-hard-deletion.md
+++ b/design-docs/async-iceberg-rest-hard-deletion.md
@@ -77,8 +77,9 @@ different failure model — kept separate.
 ## 3. Non-Goals
 
 1. **Native soft-delete / undrop semantics**: This design delivers async
-   *hard* deletion only. Full soft-delete / undrop is a follow-up; §5.7
-   records the seam it builds on.
+   *hard* deletion only — once a drop is accepted the files are destroyed
+   with no undrop or recovery path. Full soft-delete / undrop is a separate
+   follow-up.
 2. **Purge cancellation**: User-initiated cancellation of in-flight purges
    is out of scope; it needs a control API and lifecycle states we can add
    later without breaking this design.
@@ -160,11 +161,7 @@ false`. The header name uses canonical HTTP casing (each word capitalized).
    `metadata_location`, and streams through every reachable file deleting
    it, retrying transient failures with backoff.
 5. On success the job is `SUCCEEDED`; on terminal failure it lands in
-   `FAILED` for operator inspection. Listeners observe
-   `IcebergPurge{Started,Completed,Failed}Event` throughout.
-6. *(Recovery)* If the drop was a mistake, the table can be re-registered at
-   the stored metadata location any time before the worker deletes the
-   files; this also cancels the matching job (§5.7).
+   `FAILED` for operator inspection (queryable in the job table, §5.9).
 
 ### 5.3 Request-path interaction
 
@@ -212,7 +209,7 @@ CREATE TABLE IF NOT EXISTS `iceberg_purge_job` (
   `metadata_location` VARCHAR(1024) NOT NULL,
   `file_io_impl`      VARCHAR(256)  NOT NULL,
   `file_io_props`     MEDIUMTEXT    NOT NULL COMMENT 'JSON',
-  `state`             VARCHAR(16)   NOT NULL COMMENT 'PENDING|RUNNING|SUCCEEDED|FAILED|CANCELLED',
+  `state`             VARCHAR(16)   NOT NULL COMMENT 'PENDING|RUNNING|SUCCEEDED|FAILED',
   `attempts`          INT(10)       NOT NULL DEFAULT 0,
   `last_error`        TEXT          NULL,
   `heartbeat_at`      BIGINT(20)    NULL COMMENT 'last heartbeat from the worker; NULL when unclaimed',
@@ -309,7 +306,6 @@ success. Backoff: `min(maxBackoff, base * 2^attempts)` with jitter.
 | Metadata load failed, transient     | back to `PENDING`, `attempts++`, `next_attempt_at = now + backoff`, `heartbeat_at=NULL`   |
 | Metadata load failed, terminal      | `attempts++`; if `attempts >= max-attempts` → `FAILED`                                   |
 | Worker killed mid-job               | `RUNNING` row's heartbeat goes stale; another worker reclaims; deletes are idempotent     |
-| Recovered via re-register (§5.7)    | Job CAS'd to `CANCELLED`; the worker only claims non-terminal rows, so files stay intact  |
 
 Restart handling falls out of the durable job table plus the heartbeat
 model — no separate mechanism:
@@ -330,7 +326,7 @@ heartbeat ages past `heartbeatTimeout` before the rebooted process reclaims
 them. We keep `heartbeatTimeout` modest so the resume delay is small; with no
 owner column there is nothing extra to sweep on boot.
 
-### 5.7 Name reuse during purge, and recovery
+### 5.7 Name reuse during purge
 
 While a purge job for an identifier is non-terminal (`PENDING` or
 `RUNNING`), that identifier is treated as **still occupied** even though its
@@ -338,11 +334,11 @@ catalog entry is already gone. The active `iceberg_purge_job` row *is* the
 tombstone — no second table is needed. The REST server consults the store on
 the request thread (one indexed lookup via `idx_object`):
 
-| Operation                                   | Active job exists                         | No active job (`SUCCEEDED`/`FAILED`/`CANCELLED`/none) |
-|---------------------------------------------|-------------------------------------------|-------------------------------------------------------|
-| `loadTable` / `HEAD`, `alterTable` / commit | `404 NoSuchTableException`                | `404`                                                 |
-| `createTable` (same identifier)             | **`409 Conflict`** — being purged         | succeeds                                              |
-| `registerTable` (same identifier)           | **`409 Conflict`**, except recovery below | succeeds                                              |
+| Operation                                   | Active job exists                 | No active job (`SUCCEEDED`/`FAILED`/none) |
+|---------------------------------------------|-----------------------------------|-------------------------------------------|
+| `loadTable` / `HEAD`, `alterTable` / commit | `404 NoSuchTableException`        | `404`                                     |
+| `createTable` (same identifier)             | **`409 Conflict`** — being purged | succeeds                                  |
+| `registerTable` (same identifier)           | **`409 Conflict`**                | succeeds                                  |
 
 A `SUCCEEDED` job (even before pruning) no longer blocks reuse — the files
 are gone. A `FAILED` job also stops blocking, so a failed cleanup never
@@ -352,33 +348,17 @@ attack: a recreate cannot expose the dropped table's data, because it is
 refused until the files are deleted. A **namespace** carries no data, so it
 can be recreated freely; tables inside it are guarded individually.
 
-**Recovery.** Because the data / metadata files are untouched until the
-worker runs, a table dropped by mistake can be recovered before its files
-are deleted by re-registering at the stored location:
+Once a drop is accepted the table is gone for good: this is *hard* delete,
+so there is deliberately no undrop or re-register recovery path. A client
+that wants a grace period before data is destroyed should use a future
+soft-delete feature (a non-goal here, §3), not this path.
 
-```
-POST /v1/{prefix}/namespaces/{ns}/register
-{ "name": "<table>", "metadata-location": "<stored metadata_location>" }
-```
-
-Re-registering atomically CAS's the matching active job to `CANCELLED` and
-restores the catalog entry in the same transaction — lifting the tombstone
-and removing the worker-deletes-the-recovered-table race (the worker only
-claims non-terminal rows). This is **recovery-scoped** cancellation only; a
-general "cancel my purge" API stays out of scope (§3).
-
-Once the worker deletes the files the table is unrecoverable — the intended
-semantics of *hard* delete. A future soft-delete / undrop feature layers on
-top by deferring file deletion for a retention window (delaying
-`next_attempt_at`) on the **same** job row, executor, and scheduler, so
-register-table recovery succeeds throughout the window.
-
-**Concurrency.** The conflict check, the worker's claim, and recovery's
-cancel all serialize on the row's `state`. Recovery's CAS to `CANCELLED` is
-guarded by `state='PENDING'`, and the worker's claim CAS moves
-`PENDING → RUNNING`; they target the same `PENDING` row, so at most one wins.
-A job already `RUNNING` cannot be silently cancelled — recovery's CAS matches
-no row and returns `409` (the caller retries once the job terminates).
+**Concurrency.** The create/register conflict check and the worker's claim
+both serialize on the row's `state`. A `createTable` / `registerTable` that
+observes a non-terminal job (`PENDING` or `RUNNING`) returns `409`; one that
+observes a terminal job (`SUCCEEDED` / `FAILED`) or no job proceeds. The
+worker's claim CAS moves `PENDING → RUNNING`, so the conflict check and the
+claim never disagree about whether the identifier is still occupied.
 
 ### 5.8 Object coverage: tables now, views later
 
@@ -433,13 +413,13 @@ per-request **client** choice via the `X-Gravitino-Async-Purge` header
 (default async; `false` selects synchronous deletion). The server-side keys
 only tune the worker pool and retries:
 
-| Key                                                            | Default  | Description                                             |
-|----------------------------------------------------------------|----------|---------------------------------------------------------|
-| `gravitino.iceberg-rest.async-purge.worker-threads`            | `4`      | Worker pool size per server.                            |
-| `gravitino.iceberg-rest.async-purge.poll-interval-ms`          | `5000`   | Worker poll interval.                                   |
-| `gravitino.iceberg-rest.async-purge.heartbeat-timeout-ms`      | `300000` | Age after which a job with no heartbeat is reclaimable. |
-| `gravitino.iceberg-rest.async-purge.max-attempts`              | `5`      | Attempts before `FAILED`.                               |
-| `gravitino.iceberg-rest.async-purge.completed-retention-hours` | `168`    | How long `SUCCEEDED` rows are retained before pruning.  |
+| Key                                                           | Default  | Description                                                                  |
+|---------------------------------------------------------------|----------|------------------------------------------------------------------------------|
+| `gravitino.iceberg-rest.async-purge.worker-threads`           | `4`      | Worker pool size per server.                                                 |
+| `gravitino.iceberg-rest.async-purge.poll-interval-ms`         | `5000`   | Worker poll interval.                                                        |
+| `gravitino.iceberg-rest.async-purge.heartbeat-timeout-ms`     | `300000` | Age after which a job with no heartbeat is reclaimable.                      |
+| `gravitino.iceberg-rest.async-purge.max-attempts`             | `5`      | Attempts before `FAILED`.                                                    |
+| `gravitino.iceberg-rest.async-purge.terminal-retention-hours` | `168`    | How long terminal (`SUCCEEDED` / `FAILED`) rows are retained before pruning. |
 
 File-delete parallelism, claim batch size, and backoff base/ceiling are
 internal constants with sensible defaults; they become config keys only if a
@@ -451,8 +431,8 @@ deployment demonstrates the need.
   unchanged.
 - The worker uses FileIO credentials snapshotted at enqueue time.
   Credentials that expire before the worker runs (STS tokens, …) are
-  refreshed from the catalog on each heartbeat, so long-running purges (and
-  future long-retention soft delete) keep valid credentials.
+  refreshed from the catalog on each heartbeat, so long-running purges keep
+  valid credentials.
 - `iceberg_purge_job` may contain credentials in `file_io_props`; the
   existing Gravitino DB encryption / access controls apply.
 
@@ -489,7 +469,6 @@ only as a rollback flag.
 - [ ] Add observability (§5.9): metrics and the informative `ErrorResponse` message on the §5.7 `409`; operator read path in 1.3 is direct DB query
 - [ ] Namespace-drop cascade for tables (one job per contained table)
 - [ ] Enforce tombstone semantics (§5.7): on `createTable`/`registerTable`, reject with `409` when an active job exists (`idx_object` lookup on the request thread)
-- [ ] Add register-table recovery (§5.7): atomically CAS the matching active job to `CANCELLED` and restore the catalog entry; documentation
 
 ### Phase 1 (1.3): Testing
 - [ ] Unit tests: enqueue, state machine, worker claiming/heartbeat/contention (H2)
@@ -518,9 +497,7 @@ only as a rollback flag.
     synchronous purge; thrown errors surface as 5xx.
   - `TestIcebergPurgeTombstone` (§5.7) — `createTable`/`register` at an
     identifier with an active job returns `409`, succeeds once
-    `SUCCEEDED`/`FAILED`; `loadTable`/`alterTable` return `404`; re-register
-    CAS's the job to `CANCELLED` and the worker then skips it; the
-    recovery-vs-worker CAS race resolves to a single winner.
+    `SUCCEEDED`/`FAILED`; `loadTable`/`alterTable` return `404`.
 - Integration (`gravitino-docker-test`):
   - Drop a table; REST returns < 500 ms; worker eventually clears every file.
   - Restart REST mid-purge (`kill -9`); purge resumes.

--- a/design-docs/async-iceberg-rest-hard-deletion.md
+++ b/design-docs/async-iceberg-rest-hard-deletion.md
@@ -303,13 +303,13 @@ synchronous purge has the same "best effort" stance. A job fails only if the
 **metadata phase** fails. `NotFoundException` from `deleteFile` counts as
 success. Backoff: `min(maxBackoff, base * 2^attempts)` with jitter.
 
-| Outcome                            | Action                                                              |
-| ---------------------------------- | ------------------------------------------------------------------- |
-| All files deleted (or already gone) | `state='SUCCEEDED'`                                                |
-| Metadata load failed, transient    | back to `PENDING`, `attempts++`, `next_attempt_at = now + backoff`, `heartbeat_at=NULL` |
-| Metadata load failed, terminal     | `attempts++`; if `attempts >= max-attempts` → `FAILED`              |
-| Worker killed mid-job              | `RUNNING` row's heartbeat goes stale; another worker reclaims; deletes are idempotent |
-| Recovered via re-register (§5.7)   | Job CAS'd to `CANCELLED`; the worker only claims non-terminal rows, so files stay intact |
+| Outcome                             | Action                                                                                   |
+|-------------------------------------|------------------------------------------------------------------------------------------|
+| All files deleted (or already gone) | `state='SUCCEEDED'`                                                                       |
+| Metadata load failed, transient     | back to `PENDING`, `attempts++`, `next_attempt_at = now + backoff`, `heartbeat_at=NULL`   |
+| Metadata load failed, terminal      | `attempts++`; if `attempts >= max-attempts` → `FAILED`                                   |
+| Worker killed mid-job               | `RUNNING` row's heartbeat goes stale; another worker reclaims; deletes are idempotent     |
+| Recovered via re-register (§5.7)    | Job CAS'd to `CANCELLED`; the worker only claims non-terminal rows, so files stay intact  |
 
 Restart handling falls out of the durable job table plus the heartbeat
 model — no separate mechanism:
@@ -338,11 +338,11 @@ catalog entry is already gone. The active `iceberg_purge_job` row *is* the
 tombstone — no second table is needed. The REST server consults the store on
 the request thread (one indexed lookup via `idx_object`):
 
-| Operation | Active job exists | No active job (`SUCCEEDED`/`FAILED`/`CANCELLED`/none) |
-|-----------|-------------------|------------------------------------------------------|
-| `loadTable` / `HEAD`, `alterTable` / commit | `404 NoSuchTableException` | `404` |
-| `createTable` (same identifier) | **`409 Conflict`** — being purged | succeeds |
-| `registerTable` (same identifier) | **`409 Conflict`**, except recovery below | succeeds |
+| Operation                                   | Active job exists                         | No active job (`SUCCEEDED`/`FAILED`/`CANCELLED`/none) |
+|---------------------------------------------|-------------------------------------------|-------------------------------------------------------|
+| `loadTable` / `HEAD`, `alterTable` / commit | `404 NoSuchTableException`                | `404`                                                 |
+| `createTable` (same identifier)             | **`409 Conflict`** — being purged         | succeeds                                              |
+| `registerTable` (same identifier)           | **`409 Conflict`**, except recovery below | succeeds                                              |
 
 A `SUCCEEDED` job (even before pruning) no longer blocks reuse — the files
 are gone. A `FAILED` job also stops blocking, so a failed cleanup never
@@ -433,13 +433,13 @@ per-request **client** choice via the `X-Gravitino-Async-Purge` header
 (default async; `false` selects synchronous deletion). The server-side keys
 only tune the worker pool and retries:
 
-| Key                                                       | Default   | Description                                            |
-| --------------------------------------------------------- | --------- | ------------------------------------------------------ |
-| `gravitino.iceberg-rest.async-purge.worker-threads`       | `4`       | Worker pool size per server. |
-| `gravitino.iceberg-rest.async-purge.poll-interval-ms`     | `5000`    | Worker poll interval. |
-| `gravitino.iceberg-rest.async-purge.heartbeat-timeout-ms` | `300000`  | Age after which a job with no heartbeat is reclaimable. |
-| `gravitino.iceberg-rest.async-purge.max-attempts`         | `5`       | Attempts before `FAILED`. |
-| `gravitino.iceberg-rest.async-purge.completed-retention-hours` | `168` | How long `SUCCEEDED` rows are retained before pruning. |
+| Key                                                            | Default  | Description                                             |
+|----------------------------------------------------------------|----------|---------------------------------------------------------|
+| `gravitino.iceberg-rest.async-purge.worker-threads`            | `4`      | Worker pool size per server.                            |
+| `gravitino.iceberg-rest.async-purge.poll-interval-ms`          | `5000`   | Worker poll interval.                                   |
+| `gravitino.iceberg-rest.async-purge.heartbeat-timeout-ms`      | `300000` | Age after which a job with no heartbeat is reclaimable. |
+| `gravitino.iceberg-rest.async-purge.max-attempts`              | `5`      | Attempts before `FAILED`.                               |
+| `gravitino.iceberg-rest.async-purge.completed-retention-hours` | `168`    | How long `SUCCEEDED` rows are retained before pruning.  |
 
 File-delete parallelism, claim batch size, and backoff base/ceiling are
 internal constants with sensible defaults; they become config keys only if a

--- a/design-docs/async-iceberg-rest-hard-deletion.md
+++ b/design-docs/async-iceberg-rest-hard-deletion.md
@@ -107,9 +107,9 @@ implementation with a synchronous rollback flag.
 
 **Why not an S3-only control plane?** Conditional writes (`If-None-Match`)
 let workers claim jobs without a relational backend, but it *raises* net
-complexity for Gravitino: a DB gives lease acquisition and indexed backoff
-scheduling (`next_attempt_at`) for free, whereas S3 forces hand-rolled
-leases discovered by slow, per-request `LIST`. One server fronts many
+complexity for Gravitino: a DB gives lease acquisition and an indexed
+candidate scan for free, whereas S3 forces hand-rolled leases discovered by
+slow, per-request `LIST`. One server fronts many
 catalogs across S3 / GCS / ADLS, so a single job table is a uniform control
 plane; object markers fragment per-bucket. Gravitino already runs a
 relational metastore, so one extra table is low marginal cost — and it
@@ -137,7 +137,7 @@ doubles as the name-reuse tombstone (§5.7).
  worker pool (any replica)
    claims job via CAS UPDATE (heartbeat ownership)
    → rebuild snapshot graph from metadata_location
-   → stream + delete every reachable file, retry w/ backoff
+   → stream + delete every reachable file, retry on later poll ticks
    → SUCCEEDED | FAILED
 ```
 
@@ -159,7 +159,7 @@ false`. The header name uses canonical HTTP casing (each word capitalized).
    table is immediately absent from `LIST` and `HEAD` returns `404`.
 4. A worker on any replica claims the job, rebuilds the snapshot graph from
    `metadata_location`, and streams through every reachable file deleting
-   it, retrying transient failures with backoff.
+   it, retrying transient failures on later poll ticks.
 5. On success the job is `SUCCEEDED`; on terminal failure it lands in
    `FAILED` for operator inspection (queryable in the job table, §5.9).
 
@@ -213,12 +213,11 @@ CREATE TABLE IF NOT EXISTS `iceberg_purge_job` (
   `attempts`          INT(10)       NOT NULL DEFAULT 0,
   `last_error`        TEXT          NULL,
   `heartbeat_at`      BIGINT(20)    NULL COMMENT 'last heartbeat from the worker; NULL when unclaimed',
-  `next_attempt_at`   BIGINT(20)    NOT NULL,
   `created_at`        BIGINT(20)    NOT NULL,
   `created_by`        VARCHAR(128)  NOT NULL,
   `updated_at`        BIGINT(20)    NOT NULL,
   PRIMARY KEY (`id`),
-  KEY `idx_state_next_attempt` (`state`, `next_attempt_at`),
+  KEY `idx_state_updated` (`state`, `updated_at`),
   KEY `idx_object` (`catalog_name`, `namespace`, `table_name`, `state`)
 ) ENGINE=InnoDB;
 ```
@@ -227,12 +226,12 @@ We store only `metadata_location`, not the file list — enumeration is slow
 on large tables, and `TableMetadataParser.read(io, location)` rebuilds the
 snapshot graph deterministically when the worker runs.
 
-Only two columns drive the retry state machine, and both are needed:
-`next_attempt_at` gates when the poll picks a job up — the initial run and,
-after a transient failure, the backoff delay (`WHERE next_attempt_at <=
-:now`) — and `attempts` counts failures so the worker gives up at the retry
-ceiling. That ceiling is a config (`max-attempts`, §5.10), not a per-row
-`max_attempts` column, since it is the same for every job.
+A single column drives retries: `attempts` counts failures so the worker
+gives up at the retry ceiling. A failed job returns to `PENDING` and is
+re-claimed on a later poll tick, so the poll cadence (`poll-interval-ms`,
+§5.10) is the retry interval — no separate scheduling column is needed. The
+ceiling is a config (`max-attempts`, §5.10), not a per-row `max_attempts`
+column, since it is the same for every job.
 
 Migration: `upgrade-1.2.0-to-1.3.0-mysql.sql` (and H2 / PostgreSQL).
 
@@ -251,11 +250,10 @@ SQL backend:
 ```sql
 -- read candidates
 SELECT id FROM iceberg_purge_job
- WHERE next_attempt_at <= :now
-   AND ( state = 'PENDING'
-      OR (state = 'RUNNING'
-          AND (heartbeat_at IS NULL OR heartbeat_at < :now - :heartbeatTimeout)) )
- ORDER BY next_attempt_at LIMIT :batch;
+ WHERE state = 'PENDING'
+    OR (state = 'RUNNING'
+        AND (heartbeat_at IS NULL OR heartbeat_at < :now - :heartbeatTimeout))
+ ORDER BY updated_at LIMIT :batch;
 
 -- claim each candidate; the row is ours only if affected_rows = 1
 UPDATE iceberg_purge_job
@@ -298,14 +296,14 @@ this worker owns. If the host dies the heartbeat stops; once a row ages past
 Per-file failures are logged but do not fail the whole job — the
 synchronous purge has the same "best effort" stance. A job fails only if the
 **metadata phase** fails. `NotFoundException` from `deleteFile` counts as
-success. Backoff: `min(maxBackoff, base * 2^attempts)` with jitter.
+success. A failed job retries on the next poll tick (§5.5).
 
-| Outcome                             | Action                                                                                   |
-|-------------------------------------|------------------------------------------------------------------------------------------|
-| All files deleted (or already gone) | `state='SUCCEEDED'`                                                                       |
-| Metadata load failed, transient     | back to `PENDING`, `attempts++`, `next_attempt_at = now + backoff`, `heartbeat_at=NULL`   |
-| Metadata load failed, terminal      | `attempts++`; if `attempts >= max-attempts` → `FAILED`                                   |
-| Worker killed mid-job               | `RUNNING` row's heartbeat goes stale; another worker reclaims; deletes are idempotent     |
+| Outcome                             | Action                                                                                |
+|-------------------------------------|---------------------------------------------------------------------------------------|
+| All files deleted (or already gone) | `state='SUCCEEDED'`                                                                    |
+| Metadata load failed, transient     | back to `PENDING`, `attempts++`, `heartbeat_at=NULL`; re-claimed on a later poll tick  |
+| Metadata load failed, terminal      | `attempts++`; if `attempts >= max-attempts` → `FAILED`                                |
+| Worker killed mid-job               | `RUNNING` row's heartbeat goes stale; another worker reclaims; deletes are idempotent  |
 
 Restart handling falls out of the durable job table plus the heartbeat
 model — no separate mechanism:
@@ -421,9 +419,9 @@ only tune the worker pool and retries:
 | `gravitino.iceberg-rest.async-purge.max-attempts`             | `5`      | Attempts before `FAILED`.                                                    |
 | `gravitino.iceberg-rest.async-purge.terminal-retention-hours` | `168`    | How long terminal (`SUCCEEDED` / `FAILED`) rows are retained before pruning. |
 
-File-delete parallelism, claim batch size, and backoff base/ceiling are
-internal constants with sensible defaults; they become config keys only if a
-deployment demonstrates the need.
+File-delete parallelism and claim batch size are internal constants with
+sensible defaults; they become config keys only if a deployment demonstrates
+the need.
 
 ### 5.11 Security
 
@@ -464,7 +462,7 @@ only as a rollback flag.
 ### Phase 1 (1.3): Async purge core
 - [ ] Add the `iceberg_purge_job` schema and migrations (MySQL, H2, PostgreSQL)
 - [ ] Implement `IcebergPurgeJobStore` enqueue path (persist job, return)
-- [ ] Implement the worker pool: CAS claiming with heartbeat ownership (`FOR UPDATE SKIP LOCKED` where available), heartbeat renewal, streaming file deletion, retry/backoff state machine
+- [ ] Implement the worker pool: CAS claiming with heartbeat ownership (`FOR UPDATE SKIP LOCKED` where available), heartbeat renewal, streaming file deletion, retry state machine (re-claim failed jobs on later poll ticks, give up at `max-attempts`)
 - [ ] Honor the `X-Gravitino-Async-Purge` request header and wire both paths into `IcebergTableOperationExecutor.dropTable`
 - [ ] Add observability (§5.9): metrics and the informative `ErrorResponse` message on the §5.7 `409`; operator read path in 1.3 is direct DB query
 - [ ] Namespace-drop cascade for tables (one job per contained table)

--- a/design-docs/async-iceberg-rest-hard-deletion.md
+++ b/design-docs/async-iceberg-rest-hard-deletion.md
@@ -517,11 +517,17 @@ is deleted — and we add **no** non-standard fields to load/list responses.
 `idx_object` index makes the per-identifier lookup cheap):
 
 - **Management endpoint** (Gravitino admin plane, *not* the Iceberg REST
-  path):
-  - `GET …/purge-jobs?state=&namespace=&object=&page…` — list / filter.
-  - `GET …/purge-jobs?namespace={ns}&object={t}` — answers "is this object
-    being purged right now?" (an active row) or "did its cleanup fail?"
-    (`DEAD_LETTER`).
+  path) — modeled on the existing `metalakes/{metalake}/jobs/runs`
+  convention (hierarchical, metalake/catalog-scoped, job id as a path
+  segment, filters as query params):
+  - `GET /metalakes/{metalake}/catalogs/{catalog}/cleanups?state=&schema=&table=&page…`
+    — list / filter. The object identifier (catalog + schema + table), **not**
+    an opaque job id, is the lookup key — nobody outside the server holds a
+    job id, so there is no by-id fetch.
+  - The per-object question "is this table being purged right now?" (an
+    active row — §5.13 guarantees at most one) or "did its cleanup fail?"
+    (`DEAD_LETTER`) is answered by the filtered list
+    `…/cleanups?schema={schema}&table={table}`.
 
   Each row reports `state`, `attempts` / `max_attempts`, `last_error`,
   `lease_owner`, `created_by`, and timestamps. **Read-only in v1** — there
@@ -559,7 +565,7 @@ synchronous path remains only as a rollback flag.
 - [ ] Implement the worker pool: leasing via `FOR UPDATE SKIP LOCKED`, lease renewal, file deletion, retry/backoff state machine
 - [ ] Add the `async-purge.enabled` feature flag and wire both paths into `IcebergTableOperationExecutor.dropTable` (async default, synchronous rollback)
 - [ ] Add purge events: `IcebergPurgeStartedEvent`, `IcebergPurgeCompletedEvent`, `IcebergPurgeFailedEvent`
-- [ ] Add purge observability (§5.14): read-only `purge-jobs` management endpoint (list + per-identifier lookup) and metrics (`purge.jobs.{pending,running,dead_letter}`, `purge.oldest_pending_age_ms`, `purge.{completed,failed}`); informative `ErrorResponse` message on the §5.13 `409`
+- [ ] Add purge observability (§5.14): read-only `metalakes/{metalake}/catalogs/{catalog}/cleanups` management endpoint (filtered list keyed by object identifier) and metrics (`purge.jobs.{pending,running,dead_letter}`, `purge.oldest_pending_age_ms`, `purge.{completed,failed}`); informative `ErrorResponse` message on the §5.13 `409`
 - [ ] Extend coverage to views (`object_type='VIEW'`, metadata-only cleanup) and namespace-drop cascade (one job per contained object)
 - [ ] Enforce tombstone semantics (§5.13): on `createTable`/`createView`/`registerTable`, reject with `409` when an active job exists for the identifier (`idx_object` lookup on the request thread)
 - [ ] Add register-table recovery support (§5.7): atomically CAS the matching active job to `CANCELLED` and restore the catalog entry; documentation

--- a/design-docs/async-iceberg-rest-hard-deletion.md
+++ b/design-docs/async-iceberg-rest-hard-deletion.md
@@ -243,16 +243,24 @@ in memory (no owner column — a stale row is reclaimable by anyone, which is
 exactly the failover behavior we want). A job is abandoned, and reclaimable,
 once its heartbeat is older than `heartbeatTimeout`.
 
+**Claiming is gated by free worker capacity.** Each tick the worker first
+counts its idle threads and polls for *at most* that many candidates; when
+every thread is busy it polls for nothing. A worker therefore never claims a
+job it cannot run immediately, so a `RUNNING` row always maps to a thread
+actively deleting files — its heartbeat reflects real progress, never a job
+idling in an in-memory backlog. This also means the claim count is the idle
+thread count, not a separate tunable.
+
 Claiming is an optimistic compare-and-swap `UPDATE` that works on **every**
 SQL backend:
 
 ```sql
--- read candidates
+-- read up to :idleThreads candidates (0 when the pool is saturated)
 SELECT id FROM iceberg_purge_job
  WHERE state = 'PENDING'
     OR (state = 'RUNNING'
         AND (heartbeat_at IS NULL OR heartbeat_at < :now - :heartbeatTimeout))
- ORDER BY updated_at LIMIT :batch;
+ ORDER BY updated_at LIMIT :idleThreads;
 
 -- claim each candidate; the row is ours only if affected_rows = 1
 UPDATE iceberg_purge_job
@@ -263,10 +271,11 @@ UPDATE iceberg_purge_job
           AND (heartbeat_at IS NULL OR heartbeat_at < :now - :heartbeatTimeout)) );
 ```
 
-A loser sees `affected_rows = 0` and moves on. Where `SELECT … FOR UPDATE
-SKIP LOCKED` is available (MySQL 8+, PostgreSQL) the worker uses it to cut
-contention up front; the CAS form is the portable fallback (H2, older
-MySQL). `SKIP LOCKED` is purely an optimization — the claiming `UPDATE` is
+A loser sees `affected_rows = 0` and moves to the next candidate (so a tick
+may end up running fewer jobs than it has idle threads). Where `SELECT …
+FOR UPDATE SKIP LOCKED` is available (MySQL 8+, PostgreSQL) the worker uses
+it to cut contention up front; the CAS form is the portable fallback (H2,
+older MySQL). `SKIP LOCKED` is purely an optimization — the claiming `UPDATE` is
 the serialization point, so two replicas can never claim the same job. We do
 not use DB-specific advisory locks.
 
@@ -426,8 +435,9 @@ only tune the worker pool and retries:
 | `gravitino.iceberg-rest.async-purge.max-attempts`             | `5`      | Attempts before `FAILED`.                                                    |
 | `gravitino.iceberg-rest.async-purge.terminal-retention-hours` | `168`    | How long terminal (`SUCCEEDED` / `FAILED`) rows are retained before pruning. |
 
-The claim batch size is an internal constant with a sensible default; it
-becomes a config key only if a deployment demonstrates the need.
+There is no separate claim-batch-size key: a tick claims at most as many
+jobs as the worker has idle threads (§5.5), so `worker-threads` already
+bounds it.
 
 ### 5.11 Security
 

--- a/design-docs/async-iceberg-rest-hard-deletion.md
+++ b/design-docs/async-iceberg-rest-hard-deletion.md
@@ -165,7 +165,7 @@ net complexity for Gravitino rather than lowering it:
    claims job via FOR UPDATE SKIP LOCKED (heartbeat ownership)
    → rebuild snapshot graph from metadata_location
    → stream + delete every reachable file, retry w/ backoff
-   → SUCCEEDED | DEAD_LETTER
+   → SUCCEEDED | FAILED
 ```
 
 Async is the default deletion path. The synchronous path is retained only
@@ -221,7 +221,7 @@ CREATE TABLE IF NOT EXISTS `iceberg_purge_job` (
   `metadata_location` VARCHAR(1024) NOT NULL,
   `file_io_impl`      VARCHAR(256)  NOT NULL,
   `file_io_props`     MEDIUMTEXT    NOT NULL COMMENT 'JSON',
-  `state`             VARCHAR(16)   NOT NULL COMMENT 'PENDING|RUNNING|SUCCEEDED|DEAD_LETTER|CANCELLED',
+  `state`             VARCHAR(16)   NOT NULL COMMENT 'PENDING|SUCCEEDED|FAILED|CANCELLED; being-worked = PENDING with a fresh heartbeat_at',
   `attempts`          INT(10)       NOT NULL DEFAULT 0,
   `max_attempts`      INT(10)       NOT NULL,
   `last_error`        TEXT          NULL,
@@ -249,16 +249,18 @@ Each tick:
 
 ```sql
 SELECT * FROM iceberg_purge_job
- WHERE state IN ('PENDING','RUNNING')
+ WHERE state = 'PENDING'
    AND next_attempt_at <= :now
    AND (heartbeat_at IS NULL OR heartbeat_at < :now - :heartbeatTimeout)
  ORDER BY next_attempt_at LIMIT :batch
  FOR UPDATE SKIP LOCKED;
 ```
 
-then updates the row to `RUNNING` with `heartbeat_at=:now`. `SKIP LOCKED` is
-a performance optimization (it avoids lock waiting between replicas), not the
-correctness guarantee — see the ownership model below.
+then stamps `heartbeat_at=:now` to mark the row claimed. The row stays
+`PENDING` — there is no separate `RUNNING` state; "being worked" is simply a
+`PENDING` row with a fresh heartbeat. `SKIP LOCKED` is a performance
+optimization (it avoids lock waiting between replicas), not the correctness
+guarantee — see the ownership model below.
 
 #### Multi-replica ownership model
 
@@ -287,15 +289,16 @@ works on **every** SQL backend, not just those with `SKIP LOCKED`:
 ```sql
 -- read candidates (no lock required)
 SELECT id FROM iceberg_purge_job
- WHERE state IN ('PENDING','RUNNING')
+ WHERE state = 'PENDING'
    AND next_attempt_at <= :now
    AND (heartbeat_at IS NULL OR heartbeat_at < :now - :heartbeatTimeout)
  ORDER BY next_attempt_at LIMIT :batch;
 
 -- claim each candidate; the row is ours only if affected_rows = 1
 UPDATE iceberg_purge_job
-   SET state='RUNNING', heartbeat_at=:now
+   SET heartbeat_at=:now
  WHERE id=:id
+   AND state='PENDING'
    AND (heartbeat_at IS NULL OR heartbeat_at < :now - :heartbeatTimeout);
 ```
 
@@ -339,7 +342,7 @@ the **metadata phase** fails.
 | ---------------------------------- | ------------------------------------------------------------------- |
 | All files deleted (or already gone) | `state='SUCCEEDED'`                                                |
 | Metadata load failed, transient    | `attempts++`, `next_attempt_at = now + backoff(attempts)`           |
-| Metadata load failed, terminal     | `attempts++`; if `attempts >= max_attempts` → `state='DEAD_LETTER'` |
+| Metadata load failed, terminal     | `attempts++`; if `attempts >= max_attempts` → `state='FAILED'`      |
 | Worker killed mid-job              | Heartbeat goes stale; another worker picks it up; deletes are idempotent (restart story in §5.15) |
 | Recovered via re-register (§5.13)  | Job CAS'd to `state='CANCELLED'`; the worker only claims non-terminal rows, so files are left intact |
 
@@ -389,7 +392,7 @@ The async purger additionally emits, via the event listener manager:
 
 - `IcebergPurgeStartedEvent` — work begins on a job.
 - `IcebergPurgeCompletedEvent` — files deleted, with elapsed time.
-- `IcebergPurgeFailedEvent` — dead-lettered job.
+- `IcebergPurgeFailedEvent` — job that exhausted retries (`FAILED`).
 
 These events are one observability surface; the metrics and operator read
 paths (direct DB query in 1.3, management endpoint later) are covered in
@@ -413,7 +416,7 @@ The remaining server-side keys only tune the worker pool and retry behavior
 | `gravitino.iceberg-rest.async-purge.poll-interval-ms`         | `5000`    | Worker poll interval. |
 | `gravitino.iceberg-rest.async-purge.batch-size`               | `16`      | Jobs claimed per tick. |
 | `gravitino.iceberg-rest.async-purge.heartbeat-timeout-ms`     | `300000`  | Age after which a job with no heartbeat is reclaimable. |
-| `gravitino.iceberg-rest.async-purge.max-attempts`             | `5`       | Attempts before `DEAD_LETTER`. |
+| `gravitino.iceberg-rest.async-purge.max-attempts`             | `5`       | Attempts before `FAILED`. |
 | `gravitino.iceberg-rest.async-purge.backoff-base-ms`          | `30000`   | Exponential backoff base. |
 | `gravitino.iceberg-rest.async-purge.backoff-max-ms`           | `3600000` | Exponential backoff ceiling. |
 | `gravitino.iceberg-rest.async-purge.completed-retention-hours`| `168`     | How long `SUCCEEDED` rows are retained before pruning. |
@@ -466,7 +469,7 @@ End-to-end flow with async purge (the 1.3 default):
    reachable file deleting it, retrying transient failures with exponential
    backoff.
 6. On success the job is marked `SUCCEEDED`; on terminal failure it lands
-   in `DEAD_LETTER` for operator inspection. Listeners observe
+   in `FAILED` for operator inspection. Listeners observe
    `IcebergPurge{Started,Completed,Failed}Event` throughout.
 7. *(Recovery)* If the drop was a mistake, the table can be re-registered
    at the stored metadata location any time before the worker deletes the
@@ -476,8 +479,9 @@ End-to-end flow with async purge (the 1.3 default):
 ### 5.13 Name reuse during purge (tombstone semantics)
 
 This resolves the §8.1 open question. While a purge job for an identifier
-is non-terminal (`PENDING` / `RUNNING`), that identifier is treated as
-**still occupied** even though its catalog entry is already gone. The
+is still `PENDING` (whether or not a worker is actively beating on it), that
+identifier is treated as **still occupied** even though its catalog entry is
+already gone. The
 active `iceberg_purge_job` row *is* the tombstone — no second table is
 needed. This is the §8.4 / Q4 "fold the lifecycle onto an existing row"
 idea, scoped to the job row rather than a catalog-backing table (which
@@ -486,24 +490,23 @@ Gravitino does not have for the Iceberg REST surface).
 The REST server consults the purge job store **on the request thread**
 (one indexed lookup via `idx_object`) and returns:
 
-| Operation | Active purge job exists for the identifier | No active job (`SUCCEEDED` / `DEAD_LETTER` / none) |
+| Operation | Active purge job exists for the identifier | No active job (`SUCCEEDED` / `FAILED` / `CANCELLED` / none) |
 |-----------|---------------------------------------------|-----------------------------------------------------|
 | `loadTable` / `HEAD` | `404 NoSuchTableException` (catalog entry already dropped) | `404` |
 | `alterTable` / `updateTable` / commit | `404 NoSuchTableException` | `404` |
 | `createTable` (same identifier) | **`409 Conflict`** — table is being purged | succeeds (brand-new table) |
 | `registerTable` (same identifier) | **`409 Conflict`**, except the recovery path below | succeeds |
 
-"Active" means `state IN ('PENDING','RUNNING')`. A job in `SUCCEEDED`
-(even before its row is pruned per `completed-retention-hours`) no longer
-blocks reuse — the files are gone, so a recreate is safe. A `DEAD_LETTER`
-job also stops blocking, so a failed cleanup never permanently wedges the
-namespace; operators see the dead-lettered row and reclaim leaked files
-out of band.
+"Active" means `state='PENDING'`. A job in `SUCCEEDED` (even before its row
+is pruned per `completed-retention-hours`) no longer blocks reuse — the files
+are gone, so a recreate is safe. A `FAILED` job also stops blocking, so a
+failed cleanup never permanently wedges the namespace; operators see the
+failed row and reclaim leaked files out of band.
 
 This closes the PRD §2.2 attack directly: a same-name / same-location
 recreate can no longer expose the dropped table's data, because the
 recreate is refused until the data files are deleted. Telling *whether* a
-given identifier is mid-purge, done, or dead-lettered is the read-side
+given identifier is mid-purge, done, or failed is the read-side
 concern handled in §5.14.
 
 The same rule will apply to **views** (`createView` / `replaceView` → `409`
@@ -520,20 +523,23 @@ worker-deletes-the-recovered-table race — the worker only ever claims
 non-terminal rows. This is **recovery-scoped** cancellation only; a
 general user-facing "cancel my purge" API stays out of scope (§3.2).
 
-**Concurrency.** The create/register conflict check and the worker's
-state transitions serialize on the job row, exactly like the §5.4 ownership
-CAS. A `createTable` that observes `SUCCEEDED` proceeds; one that observes
-`PENDING` / `RUNNING` gets `409`; and recovery's CAS to `CANCELLED`
-competes with the worker's CAS to `RUNNING` — at most one wins, so a job
-that has already started running cannot be silently cancelled out from
-under the worker (recovery then sees `RUNNING` and returns `409`, and the
-caller retries once the heartbeat goes stale or the job terminates).
+**Concurrency.** The create/register conflict check, the worker's claim, and
+recovery's cancel all serialize on the same `state='PENDING'` +
+fresh-heartbeat predicate (the §5.4 ownership CAS). A `createTable` that
+observes a terminal state (`SUCCEEDED` / `FAILED` / `CANCELLED`) proceeds;
+one that observes `PENDING` gets `409`. Recovery's CAS to `CANCELLED` is
+guarded by `state='PENDING' AND heartbeat stale`, the same guard a worker
+uses to claim — so if a worker currently holds a fresh heartbeat, recovery's
+CAS matches no row and returns `409` (retry once the heartbeat goes stale or
+the job terminates); and if recovery wins, the worker's next heartbeat /
+completion CAS (also guarded on `state='PENDING'`) matches no row, so it
+abandons the job without touching files.
 
 ### 5.14 Observing in-flight and failed purges
 
 §5.13 keeps the *name* reserved; this section answers the read-side
 question: "the table is gone from the catalog — is it **still being
-purged**, already done, or **dead-lettered**?" The source of truth is the
+purged**, already done, or **failed**?" The source of truth is the
 `iceberg_purge_job` row, exposed to three audiences without touching the
 Iceberg REST wire contract (Goal #4).
 
@@ -541,8 +547,8 @@ Iceberg REST wire contract (Goal #4).
 the table is dropped: `loadTable` / `HEAD` → `404`, `LIST` omits it. The
 single purge-specific signal is the §5.13 `409` on a same-identifier
 `createTable` / `register`, whose Iceberg `ErrorResponse.message` names the
-blocking job (e.g. *"table `db.t` is being purged (job 123, state
-RUNNING)"*). A standard client needs nothing more — semantically the table
+blocking job (e.g. *"table `db.t` is being purged (cleanup job 123 still
+pending)"*). A standard client needs nothing more — semantically the table
 is deleted — and we add **no** non-standard fields to load/list responses.
 
 **Operators.** In 1.3 the read path is **direct DB query** of
@@ -572,13 +578,14 @@ register-as-recovery flow (§5.13).
 
 - **Events** (§5.8): `IcebergPurge{Started,Completed,Failed}Event` for
   streaming consumers.
-- **Metrics**: gauges `purge.jobs.{pending,running,dead_letter}` and
+- **Metrics**: gauges `purge.jobs.{pending,running,failed}` (where `running`
+  counts `PENDING` rows with a fresh heartbeat) and
   `purge.oldest_pending_age_ms`; counters `purge.{completed,failed}`. These
-  let operators alert on a growing backlog ("silently still deleting") or
-  any dead-letter ("silently failed to delete") — the two states that would
+  let operators alert on a growing backlog ("silently still deleting") or any
+  `FAILED` job ("silently failed to delete") — the two conditions that would
   otherwise go unnoticed.
 
-`DEAD_LETTER` is the operationally critical state: in 1.3 it is queryable
+`FAILED` is the operationally critical state: in 1.3 it is queryable
 (DB), counted (metric), and emitted (event) — so a cleanup that exhausts
 retries is always discoverable rather than a silent file leak, even before
 the management endpoint lands.
@@ -593,11 +600,11 @@ across a process restart or crash:
    `iceberg_purge_job` *before* the `DELETE` returns (§5.2); there is no
    in-memory queue, so a restart cannot drop pending work. `PENDING` jobs
    are picked up on the first worker tick after boot.
-2. **`RUNNING` jobs orphaned by the crash are reclaimed.** A process that
-   died mid-purge leaves a row in `state='RUNNING'` with a stale
-   `heartbeat_at`. The worker poll already selects rows whose heartbeat has
-   gone stale, so once it does the restarted node — or any peer — reclaims
-   the row via the CAS. This is the "worker killed mid-job" row in §5.5.
+2. **In-flight jobs orphaned by the crash are reclaimed.** A process that
+   died mid-purge leaves a still-`PENDING` row with a stale `heartbeat_at`.
+   The worker poll already selects `PENDING` rows whose heartbeat has gone
+   stale, so once it does the restarted node — or any peer — reclaims the row
+   via the CAS. This is the "worker killed mid-job" row in §5.5.
 3. **Re-running a half-finished job is safe.** The worker rebuilds the file
    set from `metadata_location` and re-deletes; already-gone files raise
    `NotFoundException`, which counts as success (§5.5). A crash anywhere in
@@ -607,8 +614,8 @@ In a **multi-replica** deployment this is seamless: surviving replicas
 reclaim a dead node's jobs once the heartbeat goes stale, with no
 coordinator.
 
-The one rough edge is a **single-replica** restart: the crashed node's own
-`RUNNING` jobs sit idle until their `heartbeat_at` ages past
+The one rough edge is a **single-replica** restart: the jobs the crashed
+node was processing sit idle until their `heartbeat_at` ages past
 `heartbeatTimeout` — up to one `heartbeatTimeout` of dead time — before the
 rebooted process reclaims them. We simply rely on heartbeat staleness
 (correct, bounded, zero extra code) and keep `heartbeatTimeout` modest so the
@@ -629,7 +636,7 @@ synchronous path remains only as a rollback flag.
 - [ ] Implement the worker pool: claiming via `FOR UPDATE SKIP LOCKED` (heartbeat ownership), heartbeat renewal, streaming file deletion, retry/backoff state machine
 - [ ] Honor the `X-Gravitino-Async-Purge` request header (default async; `false` selects synchronous deletion) and wire both paths into `IcebergTableOperationExecutor.dropTable`
 - [ ] Add purge events: `IcebergPurgeStartedEvent`, `IcebergPurgeCompletedEvent`, `IcebergPurgeFailedEvent`
-- [ ] Add purge observability (§5.14), low-cost signals only: metrics (`purge.jobs.{pending,running,dead_letter}`, `purge.oldest_pending_age_ms`, `purge.{completed,failed}`) and the informative `ErrorResponse` message on the §5.13 `409`. Operator read path in 1.3 is direct DB query of `iceberg_purge_job`
+- [ ] Add purge observability (§5.14), low-cost signals only: metrics (`purge.jobs.{pending,running,failed}`, `purge.oldest_pending_age_ms`, `purge.{completed,failed}`) and the informative `ErrorResponse` message on the §5.13 `409`. Operator read path in 1.3 is direct DB query of `iceberg_purge_job`
 - [ ] Namespace-drop cascade for tables (one job per contained table)
 - [ ] Enforce tombstone semantics (§5.13): on `createTable`/`registerTable`, reject with `409` when an active job exists for the identifier (`idx_object` lookup on the request thread)
 - [ ] Add register-table recovery support (§5.7): atomically CAS the matching active job to `CANCELLED` and restore the catalog entry; documentation
@@ -652,8 +659,8 @@ synchronous path remains only as a rollback flag.
 
 - Unit (`./gradlew :iceberg:iceberg-rest-server:test -PskipITs`):
   - `TestIcebergPurgeJobStore` — enqueue and row contents.
-  - `TestIcebergPurgeStateMachine` — PENDING → RUNNING → SUCCEEDED;
-    failure → retry → DEAD_LETTER.
+  - `TestIcebergPurgeStateMachine` — PENDING → SUCCEEDED;
+    failure → retry → FAILED.
   - `TestIcebergPurgeWorker` — claiming, heartbeat renewal, contention (H2
     backend).
   - `TestIcebergTableOperationExecutorAsyncPurge` — async default enqueues
@@ -661,7 +668,7 @@ synchronous path remains only as a rollback flag.
     synchronous purge; thrown errors surface as 5xx.
   - `TestIcebergPurgeTombstone` (§5.13) — `createTable`/`register` at an
     identifier with an active job returns `409`; succeeds once the job is
-    `SUCCEEDED`/`DEAD_LETTER`; `loadTable`/`alterTable` return `404`;
+    `SUCCEEDED`/`FAILED`; `loadTable`/`alterTable` return `404`;
     re-register CAS's the job to `CANCELLED` and the worker then skips it;
     the recovery-vs-worker CAS race resolves to a single winner.
 - Integration (`gravitino-docker-test`):

--- a/design-docs/async-iceberg-rest-hard-deletion.md
+++ b/design-docs/async-iceberg-rest-hard-deletion.md
@@ -72,17 +72,18 @@ different failure model — kept separate.
 4. **Wire compatibility**: No change to the Iceberg REST wire protocol.
 5. **Request-thread authorization**: Authorization runs on the request
    thread, never deferred.
-6. **Uniform object coverage**: Tables, views, and namespace (schema)
-   drops all flow through the same async cleanup mechanism (PRD §2.2).
+6. **Uniform object coverage**: Tables and namespace (schema) drops flow
+   through the same async cleanup mechanism. Views reuse the same mechanism
+   but are a planned follow-up, not part of the initial scope (§5.6).
 
 ---
 
 ## 3. Non-Goals
 
-1. **Native soft-delete semantics (R2)**: This design only delivers async
-   *hard* deletion (R1). Full soft-delete / undrop semantics are a
-   follow-up requirement; §5.7 records the seam they build on so R2 stays
-   a small extension rather than a separate V2 mechanism.
+1. **Native soft-delete / undrop semantics**: This design only delivers
+   async *hard* deletion. Full soft-delete / undrop semantics are a
+   follow-up requirement; §5.7 records the seam they build on so that work
+   stays a small extension rather than a separate V2 mechanism.
 2. **Purge cancellation (v1)**: User-initiated cancellation of in-flight
    purges is out of scope for v1; it needs a control API and lifecycle
    states we can add later without breaking the design.
@@ -152,23 +153,24 @@ net complexity for Gravitino rather than lowering it:
             │
             ▼
   IcebergTableOperationExecutor.dropTable
-            │  async-purge.enabled ?
+            │  X-Gravitino-Async-Purge header (default: async)
       ┌─────┴───────────────┐
-      │ true (default 1.3)  │ false (rollback)
+      │ async (default)     │ X-Gravitino-Async-Purge: false
       ▼                     ▼
  persist iceberg_purge_job   CatalogUtil.dropTableData
  row, return 204             (synchronous, on request thread)
       │
       ▼
  worker pool (any replica)
-   leases job via FOR UPDATE SKIP LOCKED
+   claims job via FOR UPDATE SKIP LOCKED (heartbeat ownership)
    → rebuild snapshot graph from metadata_location
-   → delete every reachable file, retry w/ backoff
+   → stream + delete every reachable file, retry w/ backoff
    → SUCCEEDED | DEAD_LETTER
 ```
 
-There is one async deletion path. The synchronous path is retained only
-as a feature-flag rollback (`async-purge.enabled = false`).
+Async is the default deletion path. The synchronous path is retained only
+as a per-request fallback that a client opts into with
+`X-Gravitino-Async-Purge: false`.
 
 ### 5.2 Request-path interaction
 
@@ -223,8 +225,7 @@ CREATE TABLE IF NOT EXISTS `iceberg_purge_job` (
   `attempts`          INT(10)       NOT NULL DEFAULT 0,
   `max_attempts`      INT(10)       NOT NULL,
   `last_error`        TEXT          NULL,
-  `lease_owner`       VARCHAR(128)  NULL,
-  `lease_expires_at`  BIGINT(20)    NULL,
+  `heartbeat_at`      BIGINT(20)    NULL COMMENT 'last heartbeat from the processing worker; NULL when unclaimed',
   `next_attempt_at`   BIGINT(20)    NOT NULL,
   `created_at`        BIGINT(20)    NOT NULL,
   `created_by`        VARCHAR(128)  NOT NULL,
@@ -250,31 +251,35 @@ Each tick:
 SELECT * FROM iceberg_purge_job
  WHERE state IN ('PENDING','RUNNING')
    AND next_attempt_at <= :now
-   AND (lease_expires_at IS NULL OR lease_expires_at < :now)
+   AND (heartbeat_at IS NULL OR heartbeat_at < :now - :heartbeatTimeout)
  ORDER BY next_attempt_at LIMIT :batch
  FOR UPDATE SKIP LOCKED;
 ```
 
-then updates the row to `RUNNING` with `lease_owner=:me`,
-`lease_expires_at=:now+leaseTimeout`. `SKIP LOCKED` is a performance
-optimization (it avoids lock waiting between replicas), not the correctness
-guarantee — see the leasing model below.
+then updates the row to `RUNNING` with `heartbeat_at=:now`. `SKIP LOCKED` is
+a performance optimization (it avoids lock waiting between replicas), not the
+correctness guarantee — see the ownership model below.
 
-#### Multi-replica leasing model
+#### Multi-replica ownership model
 
-Three distinct races, handled deliberately:
+Ownership is tracked by a **heartbeat** alone: the worker that claims a job
+keeps refreshing `heartbeat_at` while it runs, and remembers the ids it is
+processing in memory (no owner column — a stale row is reclaimable by anyone,
+which is exactly the failover behavior we want). A job is considered
+abandoned — and becomes reclaimable — once its heartbeat is older than
+`heartbeatTimeout`. Three distinct races, handled deliberately:
 
 1. **Two replicas claim the same job.** The claiming `UPDATE` is the
    serialization point, so this cannot happen — see the CAS rule below. Any
    number of replicas can run the worker with no external coordinator.
-2. **A held lease expires while its owner is still alive** (long GC, network
-   partition). The lease expires, another replica reclaims, and both may
-   delete the same files concurrently. We *accept* this race rather than
-   eliminate it: deletes are idempotent and `NotFoundException` counts as
-   success (§5.5), so the only cost is duplicated work, never incorrect
-   results. This is what lets failover stay coordinator-free.
+2. **A worker stalls while still alive** (long GC, network partition) and
+   its heartbeat goes stale. Another replica reclaims, and both may delete
+   the same files concurrently. We *accept* this race rather than eliminate
+   it: deletes are idempotent and `NotFoundException` counts as success
+   (§5.5), so the only cost is duplicated work, never incorrect results.
+   This is what lets failover stay coordinator-free.
 3. **A replica dies mid-job.** Identical to case 2 from the survivors' point
-   of view — the lease expires and the job is reclaimed.
+   of view — the heartbeat stops, goes stale, and the job is reclaimed.
 
 To stay portable, claiming is expressed as an optimistic compare-and-swap that
 works on **every** SQL backend, not just those with `SKIP LOCKED`:
@@ -284,14 +289,14 @@ works on **every** SQL backend, not just those with `SKIP LOCKED`:
 SELECT id FROM iceberg_purge_job
  WHERE state IN ('PENDING','RUNNING')
    AND next_attempt_at <= :now
-   AND (lease_expires_at IS NULL OR lease_expires_at < :now)
+   AND (heartbeat_at IS NULL OR heartbeat_at < :now - :heartbeatTimeout)
  ORDER BY next_attempt_at LIMIT :batch;
 
 -- claim each candidate; the row is ours only if affected_rows = 1
 UPDATE iceberg_purge_job
-   SET state='RUNNING', lease_owner=:me, lease_expires_at=:now+:leaseTimeout
+   SET state='RUNNING', heartbeat_at=:now
  WHERE id=:id
-   AND (lease_expires_at IS NULL OR lease_expires_at < :now);
+   AND (heartbeat_at IS NULL OR heartbeat_at < :now - :heartbeatTimeout);
 ```
 
 A loser sees `affected_rows = 0` and moves to the next candidate. Where
@@ -301,19 +306,28 @@ cut contention; where it is not (H2, older MySQL), it falls back to the CAS
 form. Both are correct; `SKIP LOCKED` is purely an optimization. We do not use
 DB-specific advisory locks, whose semantics differ across engines.
 
-Execution mirrors `CatalogHandlers.purgeTable`:
+Execution mirrors `CatalogHandlers.purgeTable`, but **streams** the
+reachable files instead of materializing them. A large table can reference
+millions of data files, so the worker walks the snapshot graph lazily
+(manifest list → manifests → data files) and deletes in bounded batches,
+never holding the full file set in memory:
 
 ```java
 TableMetadata meta = TableMetadataParser.read(io, job.metadataLocation());
-Tasks.foreach(collectAllReachableFiles(meta))
-     .executeWith(deleteExecutor)
-     .retry(perFileRetries)
-     .suppressFailureWhenFinished()
-     .run(io::deleteFile);
+// reachableFiles returns a lazy CloseableIterable, not a materialized List
+try (CloseableIterable<String> files = reachableFiles(meta)) {
+  Tasks.foreach(files)
+       .executeWith(deleteExecutor)
+       .retry(perFileRetries)
+       .suppressFailureWhenFinished()
+       .run(io::deleteFile);
+}
 ```
 
-A separate task renews the lease every `leaseTimeout / 3`. If the host
-dies, the lease expires and another replica reclaims the job.
+A separate task sends a **heartbeat** every `heartbeatTimeout / 3` by
+updating `heartbeat_at=:now` on the job ids this worker is processing. If
+the host dies the heartbeat stops; once a row ages past `heartbeatTimeout`
+another replica reclaims it.
 
 ### 5.5 Failure model
 
@@ -326,25 +340,28 @@ the **metadata phase** fails.
 | All files deleted (or already gone) | `state='SUCCEEDED'`                                                |
 | Metadata load failed, transient    | `attempts++`, `next_attempt_at = now + backoff(attempts)`           |
 | Metadata load failed, terminal     | `attempts++`; if `attempts >= max_attempts` → `state='DEAD_LETTER'` |
-| Worker killed mid-job              | Lease expires; another worker picks it up; deletes are idempotent (restart story in §5.15) |
-| Recovered via re-register (§5.13)  | Job CAS'd to `state='CANCELLED'`; the worker only leases non-terminal rows, so files are left intact |
+| Worker killed mid-job              | Heartbeat goes stale; another worker picks it up; deletes are idempotent (restart story in §5.15) |
+| Recovered via re-register (§5.13)  | Job CAS'd to `state='CANCELLED'`; the worker only claims non-terminal rows, so files are left intact |
 
 `NotFoundException` from `deleteFile` counts as success. Backoff:
 `min(maxBackoff, base * 2^attempts)` with jitter.
 
-### 5.6 Views and namespace (schema) drops
+### 5.6 Object coverage: tables now, views later
 
-The same async mechanism covers all object types (PRD §2.2):
+The job table is object-type aware (the `object_type` column), but the
+initial scope is **tables only**:
 
-- **Views** carry no data files — the worker cleanup just removes the
-  view's `metadata.json`. The job row uses `object_type = 'VIEW'`.
-- **Namespace (schema) drops** cascade: the server enqueues an
-  independent purge job for each contained table and view. Failures and
-  retries are tracked per object, so a re-run never re-deletes an
-  already-cleaned object, and one object's failure does not block the
-  others.
+- **Namespace (schema) drops** cascade: the server enqueues an independent
+  purge job for each contained table. Failures and retries are tracked per
+  object, so a re-run never re-deletes an already-cleaned table, and one
+  table's failure does not block the others.
+- **Views** are a planned follow-up, not part of the initial scope. A view
+  carries no data files — its cleanup only removes the view's
+  `metadata.json` — so it slots into the same job table with
+  `object_type='VIEW'` when added; the worker, tombstone (§5.13), and
+  cascade paths ship for tables first.
 
-### 5.7 Recovery and the soft-delete (R2) seam
+### 5.7 Recovery and the soft-delete seam
 
 Because the job stores `metadata_location` and the underlying data /
 metadata files are not touched until the worker runs, a table dropped by
@@ -357,11 +374,12 @@ POST /v1/{prefix}/namespaces/{ns}/register
 ```
 
 Once the worker deletes the files the table is unrecoverable — which is
-the intended semantics of *hard* delete. Soft delete (R2) layers on top
-by deferring file deletion for a retention window (delaying
-`next_attempt_at`) on the **same** job row, executor, and scheduler, so
-register-table recovery succeeds throughout the window. This keeps R2 a
-small extension on R1 rather than a separate V2 mechanism.
+the intended semantics of *hard* delete. A future soft-delete / undrop
+feature layers on top by deferring file deletion for a retention window
+(delaying `next_attempt_at`) on the **same** job row, executor, and
+scheduler, so register-table recovery succeeds throughout the window. This
+keeps that future work a small extension rather than a separate V2
+mechanism.
 
 ### 5.8 Events
 
@@ -379,14 +397,22 @@ paths (direct DB query in 1.3, management endpoint later) are covered in
 
 ### 5.9 Configuration
 
+Whether a given `DELETE …?purgeRequested=true` runs asynchronously is **not**
+a server config — it is a per-request **client** choice via the
+`X-Gravitino-Async-Purge` request header (§5.10): async is the default, and a
+client that needs strict synchronous deletion sends
+`X-Gravitino-Async-Purge: false`.
+
+The remaining server-side keys only tune the worker pool and retry behavior
+— operational concerns a client cannot set:
+
 | Key                                                  | Default   | Description                                                                              |
 | ---------------------------------------------------- | --------- | ---------------------------------------------------------------------------------------- |
-| `gravitino.iceberg-rest.async-purge.enabled`         | `true`    | When `true`, `purgeRequested=true` deletes files asynchronously. Set `false` to roll back to synchronous deletion on the request thread. |
 | `gravitino.iceberg-rest.async-purge.worker-threads`           | `4`       | Worker pool size per server. |
 | `gravitino.iceberg-rest.async-purge.delete-threads-per-job`   | `8`       | Parallelism of file deletes within a single job. |
 | `gravitino.iceberg-rest.async-purge.poll-interval-ms`         | `5000`    | Worker poll interval. |
-| `gravitino.iceberg-rest.async-purge.batch-size`               | `16`      | Jobs leased per tick. |
-| `gravitino.iceberg-rest.async-purge.lease-timeout-ms`         | `300000`  | Lease duration before a job is reclaimable. |
+| `gravitino.iceberg-rest.async-purge.batch-size`               | `16`      | Jobs claimed per tick. |
+| `gravitino.iceberg-rest.async-purge.heartbeat-timeout-ms`     | `300000`  | Age after which a job with no heartbeat is reclaimable. |
 | `gravitino.iceberg-rest.async-purge.max-attempts`             | `5`       | Attempts before `DEAD_LETTER`. |
 | `gravitino.iceberg-rest.async-purge.backoff-base-ms`          | `30000`   | Exponential backoff base. |
 | `gravitino.iceberg-rest.async-purge.backoff-max-ms`           | `3600000` | Exponential backoff ceiling. |
@@ -404,8 +430,11 @@ before the response. With this design:
 - Object-store files may linger until the worker drains. Documented in
   release notes.
 
-Operators needing strict synchronous deletion set
-`gravitino.iceberg-rest.async-purge.enabled = false`.
+The async-vs-synchronous choice rides on the optional `X-Gravitino-Async-Purge`
+request header. It is a Gravitino extension header, not part of the Iceberg
+REST spec: a standard Iceberg client never sends it and simply gets the async
+default, so the protocol is unchanged. A client needing strict synchronous
+deletion sends `X-Gravitino-Async-Purge: false`.
 
 ### 5.11 Security
 
@@ -419,10 +448,11 @@ Operators needing strict synchronous deletion set
 
 ### 5.12 User process
 
-End-to-end flow with async purge enabled (the 1.3 default):
+End-to-end flow with async purge (the 1.3 default):
 
-1. Operator runs with `gravitino.iceberg-rest.async-purge.enabled = true`
-   (the default). No client-side change is required.
+1. Async is the default; no client change is needed to get it. A client that
+   needs strict synchronous deletion adds `X-Gravitino-Async-Purge: false`
+   to the request.
 2. A client issues
    `DELETE /v1/{prefix}/namespaces/{ns}/tables/{t}?purgeRequested=true`.
 3. The server runs authorization on the request thread, loads the table
@@ -431,9 +461,10 @@ End-to-end flow with async purge enabled (the 1.3 default):
 4. The server responds `204 No Content` within typical request latency
    (target p99 < 500 ms, < 5 s for the largest tables). The table is
    immediately absent from `LIST` and `HEAD` returns `404`.
-5. In the background, a worker on any replica leases the job, rebuilds
-   the snapshot graph from `metadata_location`, and deletes every
-   reachable file, retrying transient failures with exponential backoff.
+5. In the background, a worker on any replica claims the job, rebuilds
+   the snapshot graph from `metadata_location`, and streams through every
+   reachable file deleting it, retrying transient failures with exponential
+   backoff.
 6. On success the job is marked `SUCCEEDED`; on terminal failure it lands
    in `DEAD_LETTER` for operator inspection. Listeners observe
    `IcebergPurge{Started,Completed,Failed}Event` throughout.
@@ -475,28 +506,28 @@ recreate is refused until the data files are deleted. Telling *whether* a
 given identifier is mid-purge, done, or dead-lettered is the read-side
 concern handled in §5.14.
 
-The same rule applies to **views** (`createView` / `replaceView` → `409`
-while a `VIEW` job is active). A **namespace** carries no data, so it can
-be recreated freely; any table or view created inside it is still guarded
-individually by its own job row.
+The same rule will apply to **views** (`createView` / `replaceView` → `409`
+while a `VIEW` job is active) once view cleanup ships (§5.6). A **namespace**
+carries no data, so it can be recreated freely; any table created inside it
+is still guarded individually by its own job row.
 
 **Recovery under the tombstone.** Because the identifier is now blocked,
 register-as-recovery (§5.7) first lifts the tombstone: re-registering at
 the stored `metadata_location` atomically CAS's the matching active job to
 a terminal `CANCELLED` state and restores the catalog entry in the same
 transaction. Cancelling the job is also what removes the
-worker-deletes-the-recovered-table race — the worker only ever leases
+worker-deletes-the-recovered-table race — the worker only ever claims
 non-terminal rows. This is **recovery-scoped** cancellation only; a
 general user-facing "cancel my purge" API stays out of scope (§3.2).
 
 **Concurrency.** The create/register conflict check and the worker's
-state transitions serialize on the job row, exactly like the §5.4 leasing
+state transitions serialize on the job row, exactly like the §5.4 ownership
 CAS. A `createTable` that observes `SUCCEEDED` proceeds; one that observes
 `PENDING` / `RUNNING` gets `409`; and recovery's CAS to `CANCELLED`
 competes with the worker's CAS to `RUNNING` — at most one wins, so a job
 that has already started running cannot be silently cancelled out from
 under the worker (recovery then sees `RUNNING` and returns `409`, and the
-caller retries once the lease frees or the job terminates).
+caller retries once the heartbeat goes stale or the job terminates).
 
 ### 5.14 Observing in-flight and failed purges
 
@@ -533,7 +564,7 @@ When added it would follow the `metalakes/{metalake}/jobs/runs` convention
   with §5.13 guaranteeing at most one active row.
 
 Each row would report `state`, `attempts` / `max_attempts`, `last_error`,
-`lease_owner`, `created_by`, and timestamps. Read-only — there is no cancel
+`heartbeat_at`, `created_by`, and timestamps. Read-only — there is no cancel
 verb (§3.2); the only operator-triggered transition is the
 register-as-recovery flow (§5.13).
 
@@ -555,8 +586,8 @@ the management endpoint lands.
 ### 5.15 Restart and crash recovery
 
 Restart handling is not a separate mechanism — it falls out of the durable
-job table (§5.3) plus the lease model (§5.4). Three guarantees hold across
-a process restart or crash:
+job table (§5.3) plus the heartbeat model (§5.4). Three guarantees hold
+across a process restart or crash:
 
 1. **Nothing in-flight is lost.** The job is committed to
    `iceberg_purge_job` *before* the `DELETE` returns (§5.2); there is no
@@ -564,26 +595,25 @@ a process restart or crash:
    are picked up on the first worker tick after boot.
 2. **`RUNNING` jobs orphaned by the crash are reclaimed.** A process that
    died mid-purge leaves a row in `state='RUNNING'` with a stale
-   `lease_owner` / `lease_expires_at`. The worker poll already selects rows
-   whose lease has expired, so once it does the restarted node — or any peer
-   — reclaims the row via the CAS. This is the "worker killed mid-job" row
-   in §5.5.
+   `heartbeat_at`. The worker poll already selects rows whose heartbeat has
+   gone stale, so once it does the restarted node — or any peer — reclaims
+   the row via the CAS. This is the "worker killed mid-job" row in §5.5.
 3. **Re-running a half-finished job is safe.** The worker rebuilds the file
    set from `metadata_location` and re-deletes; already-gone files raise
    `NotFoundException`, which counts as success (§5.5). A crash anywhere in
    the delete loop costs only duplicated work, never corruption.
 
 In a **multi-replica** deployment this is seamless: surviving replicas
-reclaim a dead node's jobs on lease expiry with no coordinator.
+reclaim a dead node's jobs once the heartbeat goes stale, with no
+coordinator.
 
 The one rough edge is a **single-replica** restart: the crashed node's own
-`RUNNING` jobs sit idle until `lease_expires_at` passes — up to one
-`leaseTimeout` of dead time — before the rebooted process reclaims them.
-**v1 behavior:** rely on lease expiry (correct, bounded, zero extra code);
-keep `leaseTimeout` modest so the resume delay is small. **Future
-optimization:** a startup lease sweep that resets `RUNNING` rows whose
-`lease_owner` matches this node's stable identity back to `PENDING`, so they
-resume immediately instead of waiting out the lease.
+`RUNNING` jobs sit idle until their `heartbeat_at` ages past
+`heartbeatTimeout` — up to one `heartbeatTimeout` of dead time — before the
+rebooted process reclaims them. We simply rely on heartbeat staleness
+(correct, bounded, zero extra code) and keep `heartbeatTimeout` modest so the
+resume delay is small. With no owner column there is nothing extra to sweep
+on boot — a stale row is reclaimable by definition.
 
 ---
 
@@ -596,25 +626,25 @@ synchronous path remains only as a rollback flag.
 ### Phase 1 (1.3): Async purge core
 - [ ] Add the `iceberg_purge_job` schema and migrations (MySQL, H2, PostgreSQL)
 - [ ] Implement `IcebergPurgeJobStore` enqueue path (persist job, return)
-- [ ] Implement the worker pool: leasing via `FOR UPDATE SKIP LOCKED`, lease renewal, file deletion, retry/backoff state machine
-- [ ] Add the `async-purge.enabled` feature flag and wire both paths into `IcebergTableOperationExecutor.dropTable` (async default, synchronous rollback)
+- [ ] Implement the worker pool: claiming via `FOR UPDATE SKIP LOCKED` (heartbeat ownership), heartbeat renewal, streaming file deletion, retry/backoff state machine
+- [ ] Honor the `X-Gravitino-Async-Purge` request header (default async; `false` selects synchronous deletion) and wire both paths into `IcebergTableOperationExecutor.dropTable`
 - [ ] Add purge events: `IcebergPurgeStartedEvent`, `IcebergPurgeCompletedEvent`, `IcebergPurgeFailedEvent`
 - [ ] Add purge observability (§5.14), low-cost signals only: metrics (`purge.jobs.{pending,running,dead_letter}`, `purge.oldest_pending_age_ms`, `purge.{completed,failed}`) and the informative `ErrorResponse` message on the §5.13 `409`. Operator read path in 1.3 is direct DB query of `iceberg_purge_job`
-- [ ] Extend coverage to views (`object_type='VIEW'`, metadata-only cleanup) and namespace-drop cascade (one job per contained object)
-- [ ] Enforce tombstone semantics (§5.13): on `createTable`/`createView`/`registerTable`, reject with `409` when an active job exists for the identifier (`idx_object` lookup on the request thread)
+- [ ] Namespace-drop cascade for tables (one job per contained table)
+- [ ] Enforce tombstone semantics (§5.13): on `createTable`/`registerTable`, reject with `409` when an active job exists for the identifier (`idx_object` lookup on the request thread)
 - [ ] Add register-table recovery support (§5.7): atomically CAS the matching active job to `CANCELLED` and restore the catalog entry; documentation
 
 ### Phase 1 (1.3): Testing
-- [ ] Unit tests: enqueue, state machine, worker leasing/renewal/contention (H2)
+- [ ] Unit tests: enqueue, state machine, worker claiming/heartbeat/contention (H2)
 - [ ] Docker integration tests: latency, restart-resume (`kill -9` mid-purge), two-replica no-duplicate-deletes
-- [ ] Scale & concurrency tests (PRD §4 / R3) — see §7
+- [ ] Scale & concurrency tests (PRD §4) — see §7
 
 ### Phase 1 (1.3): Documentation
-- [ ] Update user-facing documentation in `docs/` (async semantics, config, rollback flag, release notes)
+- [ ] Update user-facing documentation in `docs/` (async semantics, the `X-Gravitino-Async-Purge` header, config, release notes)
 
-### Phase 2 (post-1.3): Management endpoint
+### Phase 2 (post-1.3)
+- [ ] View support (§5.6): `object_type='VIEW'` cleanup (metadata-only), the view tombstone rule (`createView`/`replaceView` → `409`), and namespace cascade over views
 - [ ] Add the read-only `metalakes/{metalake}/catalogs/{catalog}/cleanups` management endpoint (§5.14): REST resource, DTOs, authorization, client support, docs, and tests. Filtered list keyed by object identifier; no by-id fetch
-- [ ] Startup lease-sweep optimization (§5.15): on boot reset `RUNNING` rows owned by this node's stable identity back to `PENDING` so single-replica restarts resume without waiting out `leaseTimeout`
 
 ---
 
@@ -624,10 +654,11 @@ synchronous path remains only as a rollback flag.
   - `TestIcebergPurgeJobStore` — enqueue and row contents.
   - `TestIcebergPurgeStateMachine` — PENDING → RUNNING → SUCCEEDED;
     failure → retry → DEAD_LETTER.
-  - `TestIcebergPurgeWorker` — leasing, renewal, contention (H2 backend).
+  - `TestIcebergPurgeWorker` — claiming, heartbeat renewal, contention (H2
+    backend).
   - `TestIcebergTableOperationExecutorAsyncPurge` — async default enqueues
-    exactly one job; `async-purge.enabled=false` falls back to synchronous
-    purge; thrown errors surface as 5xx.
+    exactly one job; `X-Gravitino-Async-Purge: false` falls back to
+    synchronous purge; thrown errors surface as 5xx.
   - `TestIcebergPurgeTombstone` (§5.13) — `createTable`/`register` at an
     identifier with an active job returns `409`; succeeds once the job is
     `SUCCEEDED`/`DEAD_LETTER`; `loadTable`/`alterTable` return `404`;
@@ -637,9 +668,9 @@ synchronous path remains only as a rollback flag.
   - Drop a table; REST returns < 500 ms; worker eventually clears every file.
   - Restart REST mid-purge (kill -9); purge resumes.
   - Two replicas on one DB; no duplicate deletions or orphans.
-  - Rollback flag: existing `IcebergRESTServiceIT` reruns unchanged with
-    `async-purge.enabled=false`.
-- Scale & concurrency (PRD §4 / R3):
+  - Synchronous fallback: existing `IcebergRESTServiceIT` reruns unchanged
+    with `X-Gravitino-Async-Purge: false`.
+- Scale & concurrency (PRD §4):
   - Locust scenarios under `gravitino-test/cloud/scale-test/`.
   - High-file-count fixtures: medium (~50K files), large (~500K files).
   - Concurrent-drop tier.
@@ -658,10 +689,10 @@ synchronous path remains only as a rollback flag.
    PRD §2.2 same-name/same-location recreate attack raised with @jerryshao.
    It does change today's drop semantics (recreate is no longer immediate);
    that behavior change is called out in the release notes (§5.10).
-2. **Credential refresh** — refresh FileIO credentials from the catalog at
-   lease-renewal time, or require static credentials for catalogs that
-   opt into async purge? Leaning toward refresh so long-retention soft
-   delete (R2) keeps working; cost/complexity trade-off still open.
+2. **Credential refresh** — refresh FileIO credentials from the catalog on
+   each heartbeat, or require static credentials for catalogs that opt into
+   async purge? Leaning toward refresh so long-retention soft delete keeps
+   working; cost/complexity trade-off still open.
 3. ~~**Multi-server coordination on H2**~~ — **Resolved (§5.4).** Claiming is
    an optimistic compare-and-swap `UPDATE` that works on every SQL backend;
    `SKIP LOCKED` is used as an optimization where available and the CAS form is

--- a/design-docs/async-iceberg-rest-hard-deletion.md
+++ b/design-docs/async-iceberg-rest-hard-deletion.md
@@ -48,9 +48,10 @@ For production tables this fails in three ways:
 - Concurrent purges saturate the Jetty pool.
 - Mid-purge failures leak files with no retry or audit trail.
 
-We want the drop to return quickly, finish file deletion reliably in the
-background, survive restarts, and run safely across multiple server
-replicas — while keeping the synchronous path available as a rollback.
+We want an opt-in path where the drop returns quickly, finishes file
+deletion reliably in the background, survives restarts, and runs safely
+across multiple server replicas — while synchronous deletion remains the
+default, selected automatically for any client that does not opt in.
 
 *Not in scope:* `RelationalGarbageCollector`, which deletes tombstoned
 **rows** from Gravitino's relational backend. Different IO surface,
@@ -63,8 +64,9 @@ different failure model — kept separate.
 1. **Fast response**: `DELETE … ?purgeRequested=true` returns at typical
    request latency (target p99 < 500 ms, < 5 s even for the largest
    tables) regardless of table size.
-2. **Operational simplicity**: Ship a single async deletion path; retain
-   the synchronous path behind a flag purely for rollback.
+2. **Operational simplicity**: Ship one async deletion path as an opt-in;
+   synchronous deletion stays the default so existing behavior is unchanged
+   unless a client explicitly asks for async.
 3. **Reliable deletion**: The async path deletes every file the
    synchronous purge would have, retries transient failures, and survives
    restarts and replica failover.
@@ -93,7 +95,8 @@ different failure model — kept separate.
 An earlier draft proposed a pluggable `IcebergPurger` SPI. Review feedback
 pushed back: no second implementation is in flight, and the goal is a
 simpler design with a smaller bug surface. We chose a single async
-implementation with a synchronous rollback flag.
+implementation gated behind a per-request opt-in, with synchronous deletion
+as the default.
 
 | Approach                                                    | Pros                                                                                     | Cons                                                                                             | Decision                                                                |
 |-------------------------------------------------------------|------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------|
@@ -103,7 +106,7 @@ implementation with a synchronous rollback flag.
 | External job system (Quartz / Temporal)                     | Mature scheduling, retries, observability                                                | Heavy operational burden on every operator                                                       | **Rejected** — disproportionate for one workload                        |
 | Enumerate files at enqueue time                             | Worker needs no metadata re-read                                                         | Slow on large tables (defeats the latency goal), bloats job rows                                 | **Rejected** — store `metadata_location`, re-read at run time           |
 | Object-store job markers (no DB table)                      | No schema / migration                                                                    | Hand-rolled lease + renewal, no indexed scheduling, fragments per-bucket                         | **Rejected** — higher net complexity (see below)                        |
-| **JDBC job table + worker pool, synchronous fallback flag** | Smallest bug surface; restart-safe and cluster-safe via CAS claim; one code path to test | No built-in extension point                                                                      | **Chosen**                                                              |
+| **JDBC job table + worker pool, async opt-in (synchronous default)** | Smallest bug surface; restart-safe and cluster-safe via CAS claim; one code path to test | No built-in extension point                                                                      | **Chosen**                                                              |
 
 **Why not an S3-only control plane?** Conditional writes (`If-None-Match`)
 let workers claim jobs without a relational backend, but it *raises* net
@@ -126,33 +129,34 @@ doubles as the name-reuse tombstone (§5.7).
             │
             ▼
   IcebergTableOperationExecutor.dropTable
-            │  X-Gravitino-Async-Purge header (absent ⇒ async)
-      ┌─────┴───────────────┐
-      │ header absent       │ X-Gravitino-Async-Purge: false
-      ▼                     ▼
- persist iceberg_cleanup_job   CatalogUtil.dropTableData
- row, return 204             (synchronous, on request thread)
-      │
-      ▼
- worker pool (any replica)
-   claims job via CAS UPDATE (heartbeat ownership)
-   → rebuild snapshot graph from metadata_location
-   → stream + delete every reachable file, retry on later polls
-   → SUCCEEDED | FAILED
+            │  X-Gravitino-Async-Purge header (absent ⇒ synchronous)
+      ┌─────┴───────────────────────────┐
+      │ header absent                   │ X-Gravitino-Async-Purge: true
+      ▼                                 ▼
+ CatalogUtil.dropTableData         persist iceberg_cleanup_job
+ (synchronous, on request thread)  row, return 204
+                                        │
+                                        ▼
+                                  worker pool (any replica)
+                                    claims job via CAS UPDATE (heartbeat ownership)
+                                    → rebuild snapshot graph from metadata_location
+                                    → stream + delete every reachable file, retry on later polls
+                                    → SUCCEEDED | FAILED
 ```
 
-The header is optional and has no default value: when it is **absent** —
-which is the case for any standard Iceberg client — the drop is async. A
-client opts into the synchronous fallback by sending
-`X-Gravitino-Async-Purge: false` (the header name uses canonical HTTP casing,
-each word capitalized).
+The header is optional and defaults to synchronous: when it is **absent** —
+which is the case for any standard Iceberg client — the drop is synchronous,
+preserving today's "deleted means gone" behavior. A client opts into async
+deletion by sending `X-Gravitino-Async-Purge: true` (the header name uses
+canonical HTTP casing, each word capitalized).
 
 ### 5.2 User flow
 
 1. A client issues
-   `DELETE /v1/{prefix}/namespaces/{ns}/tables/{t}?purgeRequested=true`.
-   No client change is needed for async; strict synchronous deletion is
-   selected by adding `X-Gravitino-Async-Purge: false`.
+   `DELETE /v1/{prefix}/namespaces/{ns}/tables/{t}?purgeRequested=true`
+   with `X-Gravitino-Async-Purge: true` to opt into async deletion. Absent
+   the header — the case for any standard Iceberg client — the drop is
+   synchronous (today's behavior). Steps 2–5 describe the async path.
 2. The server runs authorization on the request thread, loads the table
    metadata location, drops the catalog entry, and persists an
    `iceberg_cleanup_job` row.
@@ -172,7 +176,7 @@ public void dropTable(IcebergRequestContext ctx, TableIdentifier id,
   IcebergCatalogWrapper w = catalogWrapperManager.getCatalogWrapper(ctx.catalogName());
   if (!purgeRequested) { w.dropTable(id); return; }
 
-  if (!asyncPurgeEnabled) {                 // fallback path
+  if (!asyncPurgeEnabled) {                 // default when header is absent
     w.purgeTable(id);                       // synchronous, today's behavior
     return;
   }
@@ -568,7 +572,7 @@ land.
 
 Whether a given drop runs asynchronously is **not** a server config — it is a
 per-request **client** choice via the `X-Gravitino-Async-Purge` header
-(absent ⇒ async; `false` selects synchronous deletion). The server-side keys
+(absent ⇒ synchronous; `true` opts into async deletion). The server-side keys
 only tune the worker pool and retries:
 
 | Key                                                           | Default  | Description                                                                  |
@@ -618,7 +622,7 @@ the response. With this design:
 
 The async-vs-synchronous choice rides on the optional `X-Gravitino-Async-Purge`
 header — a Gravitino extension, not part of the Iceberg REST spec. A standard
-client never sends it and gets the async default, so the protocol is
+client never sends it and gets the synchronous default, so the protocol is
 unchanged.
 
 ---
@@ -626,8 +630,8 @@ unchanged.
 ## 6. Task Breakdown
 
 Ordered so dependencies come first. Each item maps to one GitHub issue/PR.
-Async purge ships **as the default in 1.3**; the synchronous path remains
-only as a rollback flag.
+Synchronous purge remains **the default in 1.3**; async purge ships as an
+opt-in path selected per request via the `X-Gravitino-Async-Purge` header.
 
 ### Phase 1 (1.3): Async purge core
 - [ ] Add the `iceberg_cleanup_job` schema and migrations (MySQL, H2, PostgreSQL)
@@ -662,10 +666,10 @@ only as a rollback flag.
   - `TestIcebergPurgeWorker` — claiming, heartbeat renewal on a thread that
     stays fresh while delete batches block, contention (H2), bulk-delete
     batching, and `CallerRunsPolicy` back-pressure when the delete queue fills.
-  - `TestIcebergTableOperationExecutorAsyncPurge` — async default enqueues
-    exactly one job; a repeated drop returns `404` and enqueues no second job;
-    `X-Gravitino-Async-Purge: false` falls back to synchronous purge; thrown
-    errors surface as 5xx.
+  - `TestIcebergTableOperationExecutorAsyncPurge` — `X-Gravitino-Async-Purge:
+    true` enqueues exactly one job; a repeated drop returns `404` and enqueues
+    no second job; an absent header runs the synchronous purge (the default);
+    thrown errors surface as 5xx.
   - `TestIcebergPurgeTombstone` (§5.7) — `createTable`/`register` at an
     identifier with an active job returns `409`, succeeds once
     `SUCCEEDED`/`FAILED`; `loadTable`/`alterTable`/repeated `dropTable`
@@ -674,8 +678,8 @@ only as a rollback flag.
   - Drop a table; REST returns < 500 ms; worker eventually clears every file.
   - Restart REST mid-purge (`kill -9`); purge resumes.
   - Two replicas on one DB; no duplicate deletions or orphans.
-  - Synchronous fallback: existing `IcebergRESTServiceIT` reruns unchanged
-    with `X-Gravitino-Async-Purge: false`.
+  - Synchronous default: existing `IcebergRESTServiceIT` reruns unchanged
+    with no `X-Gravitino-Async-Purge` header.
 - Scale & concurrency:
   - High-file-count fixtures: medium (~50K files), large (~500K files).
   - Concurrent-drop tier; drop returns within 5 s regardless of table size.

--- a/design-docs/async-iceberg-rest-hard-deletion.md
+++ b/design-docs/async-iceberg-rest-hard-deletion.md
@@ -137,9 +137,9 @@ net complexity for Gravitino rather than lowering it:
   would *remove* a uniform, strongly-consistent coordination primitive and
   replace it with an eventually-consistent, per-bucket one we maintain
   ourselves. It would only pay off in a deployment with no relational backend,
-  which is not Gravitino's case. The lower-complexity way to drop the table, if
-  desired, is §8.4 (fold lease/retry fields onto a catalog tombstone row), not
-  a move to object-store markers.
+  which is not Gravitino's case. If the goal is fewer moving parts, the lever is
+  to keep the single job table doing double duty — it already serves as the
+  name-reuse tombstone (§5.13) — not a move to object-store markers.
 
 ---
 
@@ -203,6 +203,9 @@ already gone from the catalog. `fileIoProperties` is captured at enqueue
 time so the worker can reconstruct `FileIO` even if the catalog is later
 reconfigured.
 
+The enqueued job row also serves as the **tombstone** that blocks name
+reuse while the files still exist — see §5.13.
+
 ### 5.3 Schema — `iceberg_purge_job`
 
 ```sql
@@ -216,7 +219,7 @@ CREATE TABLE IF NOT EXISTS `iceberg_purge_job` (
   `metadata_location` VARCHAR(1024) NOT NULL,
   `file_io_impl`      VARCHAR(256)  NOT NULL,
   `file_io_props`     MEDIUMTEXT    NOT NULL COMMENT 'JSON',
-  `state`             VARCHAR(16)   NOT NULL COMMENT 'PENDING|RUNNING|SUCCEEDED|DEAD_LETTER',
+  `state`             VARCHAR(16)   NOT NULL COMMENT 'PENDING|RUNNING|SUCCEEDED|DEAD_LETTER|CANCELLED',
   `attempts`          INT(10)       NOT NULL DEFAULT 0,
   `max_attempts`      INT(10)       NOT NULL,
   `last_error`        TEXT          NULL,
@@ -227,7 +230,8 @@ CREATE TABLE IF NOT EXISTS `iceberg_purge_job` (
   `created_by`        VARCHAR(128)  NOT NULL,
   `updated_at`        BIGINT(20)    NOT NULL,
   PRIMARY KEY (`id`),
-  KEY `idx_state_next_attempt` (`state`, `next_attempt_at`)
+  KEY `idx_state_next_attempt` (`state`, `next_attempt_at`),
+  KEY `idx_object` (`catalog_name`, `namespace`, `object_name`, `state`)
 ) ENGINE=InnoDB;
 ```
 
@@ -323,6 +327,7 @@ the **metadata phase** fails.
 | Metadata load failed, transient    | `attempts++`, `next_attempt_at = now + backoff(attempts)`           |
 | Metadata load failed, terminal     | `attempts++`; if `attempts >= max_attempts` → `state='DEAD_LETTER'` |
 | Worker killed mid-job              | Lease expires; another worker picks it up; deletes are idempotent   |
+| Recovered via re-register (§5.13)  | Job CAS'd to `state='CANCELLED'`; the worker only leases non-terminal rows, so files are left intact |
 
 `NotFoundException` from `deleteFile` counts as success. Backoff:
 `min(maxBackoff, base * 2^attempts)` with jitter.
@@ -368,6 +373,9 @@ The async purger additionally emits, via the event listener manager:
 - `IcebergPurgeCompletedEvent` — files deleted, with elapsed time.
 - `IcebergPurgeFailedEvent` — dead-lettered job.
 
+These events are one of the three observability surfaces; the queryable
+status endpoint and metrics are covered in §5.14.
+
 ### 5.9 Configuration
 
 | Key                                                  | Default   | Description                                                                              |
@@ -388,11 +396,10 @@ The async purger additionally emits, via the event listener manager:
 The Iceberg REST spec does not require file deletion to be complete
 before the response. With this design:
 
-- The catalog entry is removed before `204`, so `HEAD` returns `404`,
-  `LIST` no longer includes the table, and **`CREATE` at the same
-  identifier currently succeeds immediately** (today's drop semantics).
-  Whether this should instead be blocked until cleanup completes is an
-  open design question — see §8.1.
+- The catalog entry is removed before `204`, so `HEAD` returns `404` and
+  `LIST` no longer includes the table. `CREATE` / `register` at the same
+  identifier is **rejected with `409 Conflict` until the purge job
+  completes** (§5.13), which closes the PRD §2.2 same-name recreate attack.
 - Object-store files may linger until the worker drains. Documented in
   release notes.
 
@@ -431,7 +438,112 @@ End-to-end flow with async purge enabled (the 1.3 default):
    `IcebergPurge{Started,Completed,Failed}Event` throughout.
 7. *(Recovery)* If the drop was a mistake, the table can be re-registered
    at the stored metadata location any time before the worker deletes the
-   files (§5.7).
+   files (§5.7). Re-registering also cancels the matching purge job so the
+   worker never deletes the recovered table's files (§5.13).
+
+### 5.13 Name reuse during purge (tombstone semantics)
+
+This resolves the §8.1 open question. While a purge job for an identifier
+is non-terminal (`PENDING` / `RUNNING`), that identifier is treated as
+**still occupied** even though its catalog entry is already gone. The
+active `iceberg_purge_job` row *is* the tombstone — no second table is
+needed. This is the §8.4 / Q4 "fold the lifecycle onto an existing row"
+idea, scoped to the job row rather than a catalog-backing table (which
+Gravitino does not have for the Iceberg REST surface).
+
+The REST server consults the purge job store **on the request thread**
+(one indexed lookup via `idx_object`) and returns:
+
+| Operation | Active purge job exists for the identifier | No active job (`SUCCEEDED` / `DEAD_LETTER` / none) |
+|-----------|---------------------------------------------|-----------------------------------------------------|
+| `loadTable` / `HEAD` | `404 NoSuchTableException` (catalog entry already dropped) | `404` |
+| `alterTable` / `updateTable` / commit | `404 NoSuchTableException` | `404` |
+| `createTable` (same identifier) | **`409 Conflict`** — table is being purged | succeeds (brand-new table) |
+| `registerTable` (same identifier) | **`409 Conflict`**, except the recovery path below | succeeds |
+
+"Active" means `state IN ('PENDING','RUNNING')`. A job in `SUCCEEDED`
+(even before its row is pruned per `completed-retention-hours`) no longer
+blocks reuse — the files are gone, so a recreate is safe. A `DEAD_LETTER`
+job also stops blocking, so a failed cleanup never permanently wedges the
+namespace; operators see the dead-lettered row and reclaim leaked files
+out of band.
+
+This closes the PRD §2.2 attack directly: a same-name / same-location
+recreate can no longer expose the dropped table's data, because the
+recreate is refused until the data files are deleted. Telling *whether* a
+given identifier is mid-purge, done, or dead-lettered is the read-side
+concern handled in §5.14.
+
+The same rule applies to **views** (`createView` / `replaceView` → `409`
+while a `VIEW` job is active). A **namespace** carries no data, so it can
+be recreated freely; any table or view created inside it is still guarded
+individually by its own job row.
+
+**Recovery under the tombstone.** Because the identifier is now blocked,
+register-as-recovery (§5.7) first lifts the tombstone: re-registering at
+the stored `metadata_location` atomically CAS's the matching active job to
+a terminal `CANCELLED` state and restores the catalog entry in the same
+transaction. Cancelling the job is also what removes the
+worker-deletes-the-recovered-table race — the worker only ever leases
+non-terminal rows. This is **recovery-scoped** cancellation only; a
+general user-facing "cancel my purge" API stays out of scope (§3.2).
+
+**Concurrency.** The create/register conflict check and the worker's
+state transitions serialize on the job row, exactly like the §5.4 leasing
+CAS. A `createTable` that observes `SUCCEEDED` proceeds; one that observes
+`PENDING` / `RUNNING` gets `409`; and recovery's CAS to `CANCELLED`
+competes with the worker's CAS to `RUNNING` — at most one wins, so a job
+that has already started running cannot be silently cancelled out from
+under the worker (recovery then sees `RUNNING` and returns `409`, and the
+caller retries once the lease frees or the job terminates).
+
+### 5.14 Observing in-flight and failed purges
+
+§5.13 keeps the *name* reserved; this section answers the read-side
+question: "the table is gone from the catalog — is it **still being
+purged**, already done, or **dead-lettered**?" The source of truth is the
+`iceberg_purge_job` row, exposed to three audiences without touching the
+Iceberg REST wire contract (Goal #4).
+
+**Iceberg REST clients (table owner).** By design they observe only that
+the table is dropped: `loadTable` / `HEAD` → `404`, `LIST` omits it. The
+single purge-specific signal is the §5.13 `409` on a same-identifier
+`createTable` / `register`, whose Iceberg `ErrorResponse.message` names the
+blocking job (e.g. *"table `db.t` is being purged (job 123, state
+RUNNING)"*). A standard client needs nothing more — semantically the table
+is deleted — and we add **no** non-standard fields to load/list responses.
+
+**Operators.** Two read paths, both backed by the existing job table (the
+`idx_object` index makes the per-identifier lookup cheap):
+
+- **Management endpoint** (Gravitino admin plane, *not* the Iceberg REST
+  path):
+  - `GET …/purge-jobs?state=&namespace=&object=&page…` — list / filter.
+  - `GET …/purge-jobs?namespace={ns}&object={t}` — answers "is this object
+    being purged right now?" (an active row) or "did its cleanup fail?"
+    (`DEAD_LETTER`).
+
+  Each row reports `state`, `attempts` / `max_attempts`, `last_error`,
+  `lease_owner`, `created_by`, and timestamps. **Read-only in v1** — there
+  is no cancel verb (§3.2); the only operator-triggered transition is the
+  register-as-recovery flow (§5.13), which terminates the job as a side
+  effect.
+- **Direct DB query** of `iceberg_purge_job` stays available for ad-hoc
+  inspection and dead-letter triage (§4).
+
+**Automation / monitoring.**
+
+- **Events** (§5.8): `IcebergPurge{Started,Completed,Failed}Event` for
+  streaming consumers.
+- **Metrics**: gauges `purge.jobs.{pending,running,dead_letter}` and
+  `purge.oldest_pending_age_ms`; counters `purge.{completed,failed}`. These
+  let operators alert on a growing backlog ("silently still deleting") or
+  any dead-letter ("silently failed to delete") — the two states that would
+  otherwise go unnoticed.
+
+`DEAD_LETTER` is the operationally critical state: queryable (endpoint +
+DB), counted (metric), and emitted (event), so a cleanup that exhausts
+retries is always discoverable rather than a silent file leak.
 
 ---
 
@@ -447,8 +559,10 @@ synchronous path remains only as a rollback flag.
 - [ ] Implement the worker pool: leasing via `FOR UPDATE SKIP LOCKED`, lease renewal, file deletion, retry/backoff state machine
 - [ ] Add the `async-purge.enabled` feature flag and wire both paths into `IcebergTableOperationExecutor.dropTable` (async default, synchronous rollback)
 - [ ] Add purge events: `IcebergPurgeStartedEvent`, `IcebergPurgeCompletedEvent`, `IcebergPurgeFailedEvent`
+- [ ] Add purge observability (§5.14): read-only `purge-jobs` management endpoint (list + per-identifier lookup) and metrics (`purge.jobs.{pending,running,dead_letter}`, `purge.oldest_pending_age_ms`, `purge.{completed,failed}`); informative `ErrorResponse` message on the §5.13 `409`
 - [ ] Extend coverage to views (`object_type='VIEW'`, metadata-only cleanup) and namespace-drop cascade (one job per contained object)
-- [ ] Add register-table recovery support / documentation (§5.7)
+- [ ] Enforce tombstone semantics (§5.13): on `createTable`/`createView`/`registerTable`, reject with `409` when an active job exists for the identifier (`idx_object` lookup on the request thread)
+- [ ] Add register-table recovery support (§5.7): atomically CAS the matching active job to `CANCELLED` and restore the catalog entry; documentation
 
 ### Phase 1 (1.3): Testing
 - [ ] Unit tests: enqueue, state machine, worker leasing/renewal/contention (H2)
@@ -470,6 +584,11 @@ synchronous path remains only as a rollback flag.
   - `TestIcebergTableOperationExecutorAsyncPurge` — async default enqueues
     exactly one job; `async-purge.enabled=false` falls back to synchronous
     purge; thrown errors surface as 5xx.
+  - `TestIcebergPurgeTombstone` (§5.13) — `createTable`/`register` at an
+    identifier with an active job returns `409`; succeeds once the job is
+    `SUCCEEDED`/`DEAD_LETTER`; `loadTable`/`alterTable` return `404`;
+    re-register CAS's the job to `CANCELLED` and the worker then skips it;
+    the recovery-vs-worker CAS race resolves to a single winner.
 - Integration (`gravitino-docker-test`):
   - Drop a table; REST returns < 500 ms; worker eventually clears every file.
   - Restart REST mid-purge (kill -9); purge resumes.
@@ -488,12 +607,13 @@ synchronous path remains only as a rollback flag.
 
 ## 8. Open questions
 
-1. **Name reuse after drop** — should `CREATE` at the same identifier be
-   blocked (e.g. tombstone row → `409`) until cleanup completes? PRD §2.2
-   argues an attacker could otherwise read the original table's data via a
-   same-name/same-location recreate. Current design keeps today's drop
-   semantics (recreate allowed immediately); changing this alters drop
-   behavior. **Pending decision with @jerryshao.**
+1. ~~**Name reuse after drop**~~ — **Resolved (§5.13).** We adopt the
+   tombstone approach (Option A): the active `iceberg_purge_job` row keeps
+   the identifier occupied, so `CREATE` / `register` at the same identifier
+   returns `409 Conflict` until the job reaches `SUCCEEDED`. This closes the
+   PRD §2.2 same-name/same-location recreate attack raised with @jerryshao.
+   It does change today's drop semantics (recreate is no longer immediate);
+   that behavior change is called out in the release notes (§5.10).
 2. **Credential refresh** — refresh FileIO credentials from the catalog at
    lease-renewal time, or require static credentials for catalogs that
    opt into async purge? Leaning toward refresh so long-retention soft
@@ -502,9 +622,10 @@ synchronous path remains only as a rollback flag.
    an optimistic compare-and-swap `UPDATE` that works on every SQL backend;
    `SKIP LOCKED` is used as an optimization where available and the CAS form is
    the fallback elsewhere. No advisory locks.
-4. **Job row vs. catalog row** — if name-reuse (Q1) is resolved by keeping
-   a tombstone on the catalog's table row, could the lease/retry fields
-   live on that row instead of a separate `iceberg_purge_job` table
-   (smaller migration)? Note Gravitino has no `iceberg_tables` table; this
-   would apply to the JDBC catalog's backing table, so scope/portability
-   across catalog types needs confirmation.
+4. ~~**Job row vs. catalog row**~~ — **Resolved (§5.13).** Name reuse (Q1)
+   is resolved by treating the active `iceberg_purge_job` row itself as the
+   tombstone, so there is no separate catalog tombstone row to fold fields
+   onto. The Iceberg REST server fronts arbitrary catalogs and has no
+   uniform table-backing row to extend (Gravitino has no `iceberg_tables`
+   table), which is precisely why the job row — not a catalog row — carries
+   the lifecycle.

--- a/design-docs/async-iceberg-rest-hard-deletion.md
+++ b/design-docs/async-iceberg-rest-hard-deletion.md
@@ -94,15 +94,15 @@ pushed back: no second implementation is in flight, and the goal is a
 simpler design with a smaller bug surface. We chose a single async
 implementation with a synchronous rollback flag.
 
-| Approach | Pros | Cons | Decision |
-|----------|------|------|----------|
-| Synchronous only (status quo) | Simplest; strongest "deleted means gone" guarantee | Exceeds HTTP timeouts, saturates Jetty, no retry/audit on large tables | **Rejected** — the problem we are solving |
-| Pluggable `IcebergPurger` SPI | Extensible without code changes | Real added surface (SPI, discovery factory, context) with **no** second implementation in flight | **Rejected** — revisit when a second implementation has a real customer |
-| Reuse `RelationalGarbageCollector` | Proven worker/scheduling pattern | Different IO surface (object store vs. JDBC) and failure model | **Rejected** — share patterns, not code |
-| External job system (Quartz / Temporal) | Mature scheduling, retries, observability | Heavy operational burden on every operator | **Rejected** — disproportionate for one workload |
-| Enumerate files at enqueue time | Worker needs no metadata re-read | Slow on large tables (defeats the latency goal), bloats job rows | **Rejected** — store `metadata_location`, re-read at run time |
-| Object-store job markers (no DB table) | No schema / migration | Hand-rolled lease + renewal, no indexed scheduling, fragments per-bucket | **Rejected** — higher net complexity (see below) |
-| **JDBC job table + worker pool, synchronous fallback flag** | Smallest bug surface; restart-safe and cluster-safe via CAS claim; one code path to test | No built-in extension point | **Chosen** |
+| Approach                                                    | Pros                                                                                     | Cons                                                                                             | Decision                                                                |
+|-------------------------------------------------------------|------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------|
+| Synchronous only (status quo)                               | Simplest; strongest "deleted means gone" guarantee                                       | Exceeds HTTP timeouts, saturates Jetty, no retry/audit on large tables                           | **Rejected** — the problem we are solving                               |
+| Pluggable `IcebergPurger` SPI                               | Extensible without code changes                                                          | Real added surface (SPI, discovery factory, context) with **no** second implementation in flight | **Rejected** — revisit when a second implementation has a real customer |
+| Reuse `RelationalGarbageCollector`                          | Proven worker/scheduling pattern                                                         | Different IO surface (object store vs. JDBC) and failure model                                   | **Rejected** — share patterns, not code                                 |
+| External job system (Quartz / Temporal)                     | Mature scheduling, retries, observability                                                | Heavy operational burden on every operator                                                       | **Rejected** — disproportionate for one workload                        |
+| Enumerate files at enqueue time                             | Worker needs no metadata re-read                                                         | Slow on large tables (defeats the latency goal), bloats job rows                                 | **Rejected** — store `metadata_location`, re-read at run time           |
+| Object-store job markers (no DB table)                      | No schema / migration                                                                    | Hand-rolled lease + renewal, no indexed scheduling, fragments per-bucket                         | **Rejected** — higher net complexity (see below)                        |
+| **JDBC job table + worker pool, synchronous fallback flag** | Smallest bug surface; restart-safe and cluster-safe via CAS claim; one code path to test | No built-in extension point                                                                      | **Chosen**                                                              |
 
 **Why not an S3-only control plane?** Conditional writes (`If-None-Match`)
 let workers claim jobs without a relational backend, but it *raises* net
@@ -125,9 +125,9 @@ doubles as the name-reuse tombstone (§5.7).
             │
             ▼
   IcebergTableOperationExecutor.dropTable
-            │  X-Gravitino-Async-Purge header (default: async)
+            │  X-Gravitino-Async-Purge header (default: true)
       ┌─────┴───────────────┐
-      │ async (default)     │ X-Gravitino-Async-Purge: false
+      │ true (default)      │ X-Gravitino-Async-Purge: false
       ▼                     ▼
  persist iceberg_purge_job   CatalogUtil.dropTableData
  row, return 204             (synchronous, on request thread)
@@ -140,8 +140,10 @@ doubles as the name-reuse tombstone (§5.7).
    → SUCCEEDED | FAILED
 ```
 
-Async is the default path. The synchronous path is retained only as a
-per-request fallback a client opts into with `X-Gravitino-Async-Purge: false`.
+The header is a boolean whose value is `true` or `false`; it defaults to
+`true`, so async is the default path. The synchronous path is retained only
+as a per-request fallback a client opts into with `X-Gravitino-Async-Purge:
+false`. The header name uses canonical HTTP casing (each word capitalized).
 
 ### 5.2 User flow
 
@@ -226,8 +228,14 @@ CREATE TABLE IF NOT EXISTS `iceberg_purge_job` (
 
 We store only `metadata_location`, not the file list — enumeration is slow
 on large tables, and `TableMetadataParser.read(io, location)` rebuilds the
-snapshot graph deterministically when the worker runs. The retry ceiling is
-a config (`max-attempts`, §5.10), not a per-row column.
+snapshot graph deterministically when the worker runs.
+
+Only two columns drive the retry state machine, and both are needed:
+`next_attempt_at` gates when the poll picks a job up — the initial run and,
+after a transient failure, the backoff delay (`WHERE next_attempt_at <=
+:now`) — and `attempts` counts failures so the worker gives up at the retry
+ceiling. That ceiling is a config (`max-attempts`, §5.10), not a per-row
+`max_attempts` column, since it is the same for every job.
 
 Migration: `upgrade-1.2.0-to-1.3.0-mysql.sql` (and H2 / PostgreSQL).
 
@@ -388,12 +396,14 @@ The initial scope is **tables only**.
 ### 5.9 Events and observability
 
 Existing `IcebergDropTableEvent` continues to fire on the REST thread with
-the *requested* purge flag, preserving today's listener contract. The async
-purger additionally emits:
+the *requested* purge flag, preserving today's listener contract.
 
-- `IcebergPurgeStartedEvent` — work begins on a job.
-- `IcebergPurgeCompletedEvent` — files deleted, with elapsed time.
-- `IcebergPurgeFailedEvent` — job that exhausted retries (`FAILED`).
+Dedicated purge events (`IcebergPurgeStartedEvent`,
+`IcebergPurgeCompletedEvent`, `IcebergPurgeFailedEvent` — work begins, files
+deleted, retries exhausted) are **deferred to Phase 2**, not part of 1.3. In
+1.3, observability comes entirely from the durable job row plus metrics,
+which ship for free with the worker; streaming events are an additive
+follow-up that does not change the job model.
 
 The source of truth for "is this table still being purged, done, or failed?"
 is the `iceberg_purge_job` row, exposed without touching the wire contract:
@@ -411,9 +421,10 @@ is the `iceberg_purge_job` row, exposed without touching the wire contract:
   let operators alert on a growing backlog or any `FAILED` job — the two
   conditions that would otherwise go unnoticed.
 
-`FAILED` is the operationally critical state: it is queryable, counted, and
-emitted, so a cleanup that exhausts retries is always discoverable rather
-than a silent file leak.
+`FAILED` is the operationally critical state: in 1.3 it is queryable (DB)
+and counted (metric), so a cleanup that exhausts retries is always
+discoverable rather than a silent file leak — even before the Phase 2 events
+land.
 
 ### 5.10 Configuration
 
@@ -439,8 +450,9 @@ deployment demonstrates the need.
 - `@AuthorizationExpression` on `dropTable` runs on the request thread,
   unchanged.
 - The worker uses FileIO credentials snapshotted at enqueue time.
-  Credentials that expire before the worker runs (STS tokens, …) need the
-  refresh strategy under discussion in §8.
+  Credentials that expire before the worker runs (STS tokens, …) are
+  refreshed from the catalog on each heartbeat, so long-running purges (and
+  future long-retention soft delete) keep valid credentials.
 - `iceberg_purge_job` may contain credentials in `file_io_props`; the
   existing Gravitino DB encryption / access controls apply.
 
@@ -474,7 +486,6 @@ only as a rollback flag.
 - [ ] Implement `IcebergPurgeJobStore` enqueue path (persist job, return)
 - [ ] Implement the worker pool: CAS claiming with heartbeat ownership (`FOR UPDATE SKIP LOCKED` where available), heartbeat renewal, streaming file deletion, retry/backoff state machine
 - [ ] Honor the `X-Gravitino-Async-Purge` request header and wire both paths into `IcebergTableOperationExecutor.dropTable`
-- [ ] Add purge events: `IcebergPurgeStartedEvent`, `IcebergPurgeCompletedEvent`, `IcebergPurgeFailedEvent`
 - [ ] Add observability (§5.9): metrics and the informative `ErrorResponse` message on the §5.7 `409`; operator read path in 1.3 is direct DB query
 - [ ] Namespace-drop cascade for tables (one job per contained table)
 - [ ] Enforce tombstone semantics (§5.7): on `createTable`/`registerTable`, reject with `409` when an active job exists (`idx_object` lookup on the request thread)
@@ -489,6 +500,7 @@ only as a rollback flag.
 - [ ] Update user-facing docs in `docs/` (async semantics, the `X-Gravitino-Async-Purge` header, config, release notes)
 
 ### Phase 2 (post-1.3)
+- [ ] Add purge events (§5.9): `IcebergPurgeStartedEvent`, `IcebergPurgeCompletedEvent`, `IcebergPurgeFailedEvent`
 - [ ] View support (§5.8): `object_type='VIEW'` cleanup (metadata-only), the view tombstone rule, and namespace cascade over views
 - [ ] Read-only `metalakes/{metalake}/catalogs/{catalog}/cleanups` management endpoint (§5.9): REST resource, DTOs, authorization, client support, docs, tests. Filtered list keyed by object identifier; no by-id fetch
 
@@ -519,12 +531,3 @@ only as a rollback flag.
   - High-file-count fixtures: medium (~50K files), large (~500K files).
   - Concurrent-drop tier; drop returns within 5 s regardless of table size.
   - Direct GCS/S3 listing asserts the storage prefix is empty after cleanup.
-
----
-
-## 8. Open questions
-
-1. **Credential refresh** — refresh FileIO credentials from the catalog on
-   each heartbeat, or require static credentials for catalogs that opt into
-   async purge? Leaning toward refresh so long-retention soft delete keeps
-   working; cost/complexity trade-off still open.

--- a/design-docs/async-iceberg-rest-hard-deletion.md
+++ b/design-docs/async-iceberg-rest-hard-deletion.md
@@ -17,7 +17,7 @@
   under the License.
 -->
 
-# Design: Pluggable Asynchronous Hard Deletion for the Gravitino Iceberg REST Server
+# Design: Asynchronous Hard Deletion for the Gravitino Iceberg REST Server
 
 | Field    | Value                                                   |
 | -------- | ------------------------------------------------------- |
@@ -48,152 +48,97 @@ For production tables this fails in three ways:
 - Concurrent purges saturate the Jetty pool.
 - Mid-purge failures leak files with no retry or audit trail.
 
-We want to return quickly, finish deletion reliably in the background,
-survive restarts, and let operators plug in alternative strategies
-(object-store batch APIs, external job systems, audit-only) without
-modifying Gravitino.
+We want the drop to return quickly, finish file deletion reliably in the
+background, survive restarts, and run safely across multiple server
+replicas — while keeping the synchronous path available as a rollback.
 
 *Not in scope:* `RelationalGarbageCollector`, which deletes tombstoned
 **rows** from Gravitino's relational backend. Different IO surface,
 different failure model — kept separate.
 
+---
+
 ## 2. Goals
 
-1. `DELETE … ?purgeRequested=true` returns at typical request latency
-   (target p99 < 500 ms) regardless of table size, when an async purger
-   is configured.
-2. File-deletion strategy is **pluggable** behind an `IcebergPurger` SPI.
-3. The default async implementation deletes every file the synchronous
-   purge would have deleted, retries transient failures, and survives
-   restarts.
-4. No change to the Iceberg REST wire protocol.
-5. Authorization runs on the **request thread**, never deferred.
+1. **Fast response**: `DELETE … ?purgeRequested=true` returns at typical
+   request latency (target p99 < 500 ms, and < 5 s even for the largest
+   tables) regardless of table size.
+2. **Operational simplicity**: Ship a single async deletion path with the
+   smallest possible bug surface; retain the synchronous path behind a
+   feature flag purely for rollback, not as a parallel product surface.
+3. **Reliable deletion**: The async path deletes every file the
+   synchronous purge would have deleted, retries transient failures, and
+   survives restarts and replica failover.
+4. **Wire compatibility**: No change to the Iceberg REST wire protocol.
+5. **Request-thread authorization**: Authorization runs on the request
+   thread, never deferred.
+6. **Uniform object coverage**: Tables, views, and namespace (schema)
+   drops all flow through the same async cleanup mechanism (PRD §2.2).
+
+---
 
 ## 3. Non-Goals
 
-- Changing Gravitino-native soft-delete semantics.
-- User-initiated cancellation of in-flight purges (v1).
-- Async `dropNamespace` / `dropView` (they don't delete data today).
+1. **Native soft-delete semantics (R2)**: This design only delivers async
+   *hard* deletion (R1). Full soft-delete / undrop semantics are a
+   follow-up requirement; §5.7 records the seam they build on so R2 stays
+   a small extension rather than a separate V2 mechanism.
+2. **Purge cancellation (v1)**: User-initiated cancellation of in-flight
+   purges is out of scope for v1; it needs a control API and lifecycle
+   states we can add later without breaking the design.
+3. **Third-party deletion plugins**: We ship one async implementation. A
+   pluggable extension point is explicitly *not* built now — see §4 for
+   why, and the conditions under which we would revisit it.
 
-## 4. Overview
+---
 
-```
-                           IcebergPurger (SPI)
-                                 ▲
-        ┌────────────────────────┼────────────────────────────┐
-        │                        │                            │
-SynchronousIceberg-       JdbcAsyncIceberg-          (third-party plugins:
-   Purger                    Purger                   Kafka, S3 Batch,
-(legacy parity)          (default async)              audit-only, …)
-```
+## 4. Solution Investigations
 
-`IcebergTableOperationExecutor.dropTable` no longer knows how purge is
-implemented — it calls `purger.purgeTable(request)` and the configured
-plugin decides whether the work is synchronous, queued in a DB,
-dispatched externally, or skipped.
+The earlier draft proposed a pluggable `IcebergPurger` SPI. Review
+feedback (PR #11152) pushed back: the PRD does not ask for an SPI, no
+second implementation is in flight, and the competitive frame against
+Polaris is "simpler design with smaller bug surface." We re-evaluated and
+chose a single async implementation with a synchronous rollback flag.
 
-The default plugin (`JdbcAsyncIcebergPurger`) persists a job row, returns
-immediately, and drains the queue from a background worker pool.
+| Approach | Pros | Cons | Decision |
+|----------|------|------|----------|
+| Synchronous only (status quo) | Simplest; strongest "deleted means gone" guarantee | Exceeds HTTP timeouts, saturates Jetty, no retry/audit on large tables | **Rejected** — the problem we are solving |
+| Pluggable `IcebergPurger` SPI (factory + classpath loading + context) | Extensible to object-store batch / audit-only without code changes | Real added surface (SPI, discovery factory, context) with **no** second implementation in flight; widens the bug surface against the PRD's "smaller surface" goal | **Rejected** — revisit only when a second implementation has a real customer behind it |
+| Reuse `RelationalGarbageCollector` | Proven worker/scheduling pattern already in the codebase | Different IO surface (object store vs. JDBC) and failure model (best-effort per-file vs. transactional rows) | **Rejected** — share patterns, not code |
+| External job system only (Quartz / Temporal) | Mature scheduling, retries, observability | Heavy operational burden imposed on every operator | **Rejected** — disproportionate for one deletion workload |
+| Enumerate files at enqueue time | Worker needs no metadata re-read | Enumeration is slow on large tables (defeats the latency goal) and bloats job rows | **Rejected** — store `metadata_location`, re-read at run time |
+| **Single async purger (JDBC job table + worker pool) with a synchronous fallback flag** | Smallest bug surface; reliable, restart-safe, cluster-safe via `SKIP LOCKED`; one code path to test | No built-in extension point — a second strategy would need a follow-up refactor | **Chosen** |
 
-## 5. The `IcebergPurger` SPI
+---
 
-### 5.1 Interface
+## 5. Proposal
 
-Mirrors `IcebergConfigProvider`
-(`iceberg-rest-server/.../service/provider/IcebergConfigProvider.java`)
-for consistency.
-
-```java
-package org.apache.gravitino.iceberg.service.purge;
-
-public interface IcebergPurger extends Closeable {
-
-  /** Initialize the purger. Properties are stripped of the
-   *  {@code gravitino.iceberg-rest.purger.} prefix. */
-  void initialize(Map<String, String> properties, IcebergPurgerContext context);
-
-  /** Called on the REST request thread, after authorization and after the
-   *  catalog entry has been removed. The implementation either performs
-   *  the file deletion inline or accepts responsibility for completing it
-   *  later. Throwing surfaces as a 5xx. */
-  void purgeTable(IcebergPurgeRequest request);
-
-  String name();
-}
-```
-
-```java
-public final class IcebergPurgeRequest {
-  String metalakeName, catalogName, requestUser, requestId, fileIoImpl;
-  TableIdentifier tableIdentifier;
-  TableMetadata tableMetadata;            // loaded by the server
-  Map<String, String> fileIoProperties;
-  long requestTimestampMs;
-}
-
-public interface IcebergPurgerContext {
-  FileIO newFileIo(String impl, Map<String, String> properties);
-  Optional<RelationalBackend> relationalBackend();
-  EventListenerManager eventListenerManager();
-  String serverIdentity();   // host:pid
-}
-```
-
-The server loads `TableMetadata` once and hands it to the plugin so
-every implementation sees a consistent snapshot regardless of when it
-acts. `fileIoProperties` is captured at request time so deferred work
-can reconstruct `FileIO` even if the catalog is later reconfigured.
-
-### 5.2 Discovery
-
-Modeled on `IcebergConfigProviderFactory`:
-
-```java
-private static final Map<String, String> BUILTINS = ImmutableMap.of(
-    "synchronous", SynchronousIcebergPurger.class.getCanonicalName(),
-    "jdbc-async",  JdbcAsyncIcebergPurger.class.getCanonicalName());
-
-public static IcebergPurger create(Map<String, String> props,
-                                   IcebergPurgerContext ctx) {
-  String selector = new IcebergConfig(props).get(IcebergConfig.ICEBERG_REST_PURGER);
-  String className = BUILTINS.getOrDefault(selector, selector);
-  IcebergPurger purger = (IcebergPurger)
-      Class.forName(className).getDeclaredConstructor().newInstance();
-  purger.initialize(stripPrefix(props, "gravitino.iceberg-rest.purger."), ctx);
-  return purger;
-}
-```
-
-Built in `RESTService.serviceInit` right after the `IcebergConfigProvider`.
-
-### 5.3 Built-in providers
-
-**`SynchronousIcebergPurger`** — wraps `CatalogUtil.dropTableData(io, meta)`.
-Today's behavior, repackaged. Phase-1 default; remains the documented
-fallback after the default flips.
-
-**`JdbcAsyncIcebergPurger`** — persists an `iceberg_purge_job` row and
-returns. A worker pool leases jobs via `SELECT … FOR UPDATE SKIP LOCKED`,
-walks the metadata, deletes files, and retries with exponential backoff
-up to `max_attempts`. Becomes the default once stable. Detailed in §6.
-
-### 5.4 Third-party plugins
-
-Drop a jar with a class implementing `IcebergPurger` (no-arg constructor)
-onto the classpath and set:
+### 5.1 Overview
 
 ```
-gravitino.iceberg-rest.purger = com.example.S3BatchIcebergPurger
-gravitino.iceberg-rest.purger.s3-batch.account-id = 123456789012
+  DELETE …?purgeRequested=true
+            │
+            ▼
+  IcebergTableOperationExecutor.dropTable
+            │  async-purge.enabled ?
+      ┌─────┴───────────────┐
+      │ true (default 1.3)  │ false (rollback)
+      ▼                     ▼
+ persist iceberg_purge_job   CatalogUtil.dropTableData
+ row, return 204             (synchronous, on request thread)
+      │
+      ▼
+ worker pool (any replica)
+   leases job via FOR UPDATE SKIP LOCKED
+   → rebuild snapshot graph from metadata_location
+   → delete every reachable file, retry w/ backoff
+   → SUCCEEDED | DEAD_LETTER
 ```
 
-Expected uses: emit Kafka events for downstream cleanup, create S3 Batch
-Operations jobs from the manifest list, or record intent in an audit
-system without deleting.
+There is one async deletion path. The synchronous path is retained only
+as a feature-flag rollback (`async-purge.enabled = false`).
 
-## 6. Default implementation: `JdbcAsyncIcebergPurger`
-
-### 6.1 Request-path interaction
+### 5.2 Request-path interaction
 
 ```java
 public void dropTable(IcebergRequestContext ctx, TableIdentifier id,
@@ -201,24 +146,32 @@ public void dropTable(IcebergRequestContext ctx, TableIdentifier id,
   IcebergCatalogWrapper w = catalogWrapperManager.getCatalogWrapper(ctx.catalogName());
   if (!purgeRequested) { w.dropTable(id); return; }
 
+  if (!asyncPurgeEnabled) {                 // rollback path
+    w.purgeTable(id);                       // synchronous, today's behavior
+    return;
+  }
+
   TableMetadata metadata = w.loadTableMetadata(id);
-  w.dropTable(id);          // metadata-only drop in the catalog
-  purger.purgeTable(
-      IcebergPurgeRequest.builder()
+  w.dropTable(id);                          // metadata-only drop in the catalog
+  purgeJobStore.enqueue(
+      IcebergPurgeJob.builder()
           .catalogName(ctx.catalogName())
           .tableIdentifier(id)
-          .tableMetadata(metadata)
+          .metadataLocation(metadata.metadataFileLocation())
           .fileIoImpl(w.fileIoImpl())
           .fileIoProperties(w.fileIoProperties())
-          .requestUser(ctx.userPrincipal())
+          .createdBy(ctx.userPrincipal())
           .build());
 }
 ```
 
-Order matters: load metadata → drop catalog entry → call the purger. A
-purge job exists only for a table that is already gone from the catalog.
+Order matters on the async path: load metadata location → drop catalog
+entry → enqueue the job. A purge job exists only for a table that is
+already gone from the catalog. `fileIoProperties` is captured at enqueue
+time so the worker can reconstruct `FileIO` even if the catalog is later
+reconfigured.
 
-### 6.2 Schema — `iceberg_purge_job`
+### 5.3 Schema — `iceberg_purge_job`
 
 ```sql
 CREATE TABLE IF NOT EXISTS `iceberg_purge_job` (
@@ -226,7 +179,8 @@ CREATE TABLE IF NOT EXISTS `iceberg_purge_job` (
   `metalake_name`     VARCHAR(128)  NOT NULL,
   `catalog_name`      VARCHAR(128)  NOT NULL,
   `namespace`         VARCHAR(512)  NOT NULL,
-  `table_name`        VARCHAR(256)  NOT NULL,
+  `object_name`       VARCHAR(256)  NOT NULL,
+  `object_type`       VARCHAR(16)   NOT NULL COMMENT 'TABLE|VIEW',
   `metadata_location` VARCHAR(1024) NOT NULL,
   `file_io_impl`      VARCHAR(256)  NOT NULL,
   `file_io_props`     MEDIUMTEXT    NOT NULL COMMENT 'JSON',
@@ -251,7 +205,7 @@ rebuilds the snapshot graph deterministically when the worker runs.
 
 Migration: `upgrade-1.2.0-to-1.3.0-mysql.sql` (and H2 / PostgreSQL).
 
-### 6.3 Worker pool
+### 5.4 Worker pool
 
 A `ScheduledThreadPoolExecutor` modeled on `RelationalGarbageCollector`.
 Each tick:
@@ -284,7 +238,7 @@ Tasks.foreach(collectAllReachableFiles(meta))
 A separate task renews the lease every `leaseTimeout / 3`. If the host
 dies, the lease expires and another replica reclaims the job.
 
-### 6.4 Failure model
+### 5.5 Failure model
 
 Per-file failures are logged but do not fail the whole job — the
 synchronous purge has the same "best effort" stance. A job fails only if
@@ -300,122 +254,183 @@ the **metadata phase** fails.
 `NotFoundException` from `deleteFile` counts as success. Backoff:
 `min(maxBackoff, base * 2^attempts)` with jitter.
 
-## 7. Events
+### 5.6 Views and namespace (schema) drops
+
+The same async mechanism covers all object types (PRD §2.2):
+
+- **Views** carry no data files — the worker cleanup just removes the
+  view's `metadata.json`. The job row uses `object_type = 'VIEW'`.
+- **Namespace (schema) drops** cascade: the server enqueues an
+  independent purge job for each contained table and view. Failures and
+  retries are tracked per object, so a re-run never re-deletes an
+  already-cleaned object, and one object's failure does not block the
+  others.
+
+### 5.7 Recovery and the soft-delete (R2) seam
+
+Because the job stores `metadata_location` and the underlying data /
+metadata files are not touched until the worker runs, a table dropped by
+mistake can be recovered *before its files are deleted* by re-registering
+it at the stored location:
+
+```
+POST /v1/{prefix}/namespaces/{ns}/register
+{ "name": "<table>", "metadata-location": "<stored metadata_location>" }
+```
+
+Once the worker deletes the files the table is unrecoverable — which is
+the intended semantics of *hard* delete. Soft delete (R2) layers on top
+by deferring file deletion for a retention window (delaying
+`next_attempt_at`) on the **same** job row, executor, and scheduler, so
+register-table recovery succeeds throughout the window. This keeps R2 a
+small extension on R1 rather than a separate V2 mechanism.
+
+### 5.8 Events
 
 Existing `IcebergDropTableEvent` continues to fire on the REST thread
 with the *requested* purge flag, preserving today's listener contract.
-Plugins emit, via `IcebergPurgerContext.eventListenerManager()`:
+The async purger additionally emits, via the event listener manager:
 
-- `IcebergPurgeStartedEvent` — work begins on a request.
+- `IcebergPurgeStartedEvent` — work begins on a job.
 - `IcebergPurgeCompletedEvent` — files deleted, with elapsed time.
 - `IcebergPurgeFailedEvent` — dead-lettered job.
 
-Third-party purgers are expected to fire the same events.
+### 5.9 Configuration
 
-## 8. Configuration
+| Key                                                  | Default   | Description                                                                              |
+| ---------------------------------------------------- | --------- | ---------------------------------------------------------------------------------------- |
+| `gravitino.iceberg-rest.async-purge.enabled`         | `true`    | When `true`, `purgeRequested=true` deletes files asynchronously. Set `false` to roll back to synchronous deletion on the request thread. |
+| `gravitino.iceberg-rest.async-purge.worker-threads`           | `4`       | Worker pool size per server. |
+| `gravitino.iceberg-rest.async-purge.delete-threads-per-job`   | `8`       | Parallelism of file deletes within a single job. |
+| `gravitino.iceberg-rest.async-purge.poll-interval-ms`         | `5000`    | Worker poll interval. |
+| `gravitino.iceberg-rest.async-purge.batch-size`               | `16`      | Jobs leased per tick. |
+| `gravitino.iceberg-rest.async-purge.lease-timeout-ms`         | `300000`  | Lease duration before a job is reclaimable. |
+| `gravitino.iceberg-rest.async-purge.max-attempts`             | `5`       | Attempts before `DEAD_LETTER`. |
+| `gravitino.iceberg-rest.async-purge.backoff-base-ms`          | `30000`   | Exponential backoff base. |
+| `gravitino.iceberg-rest.async-purge.backoff-max-ms`           | `3600000` | Exponential backoff ceiling. |
+| `gravitino.iceberg-rest.async-purge.completed-retention-hours`| `168`     | How long `SUCCEEDED` rows are retained before pruning. |
 
-### 8.1 SPI selection
-
-| Key                              | Default       | Description                                                                                          |
-| -------------------------------- | ------------- | ---------------------------------------------------------------------------------------------------- |
-| `gravitino.iceberg-rest.purger`  | `synchronous` (initially) → `jdbc-async` (after phase 3) | Short alias or FQCN of an `IcebergPurger` implementation. |
-
-### 8.2 `jdbc-async` tunables
-
-| Key                                                           | Default   |
-| ------------------------------------------------------------- | --------- |
-| `…purger.jdbc-async.worker-threads`                           | `4`       |
-| `…purger.jdbc-async.delete-threads-per-job`                   | `8`       |
-| `…purger.jdbc-async.poll-interval-ms`                         | `5000`    |
-| `…purger.jdbc-async.batch-size`                               | `16`      |
-| `…purger.jdbc-async.lease-timeout-ms`                         | `300000`  |
-| `…purger.jdbc-async.max-attempts`                             | `5`       |
-| `…purger.jdbc-async.backoff-base-ms`                          | `30000`   |
-| `…purger.jdbc-async.backoff-max-ms`                           | `3600000` |
-| `…purger.jdbc-async.completed-retention-hours`                | `168`     |
-
-`synchronous` has no tunables.
-
-## 9. Wire compatibility
+### 5.10 Backward compatibility (wire)
 
 The Iceberg REST spec does not require file deletion to be complete
 before the response. With this design:
 
 - The catalog entry is removed before `204`, so `HEAD` returns `404`,
-  `LIST` no longer includes the table, and `CREATE` at the same
-  identifier succeeds immediately.
+  `LIST` no longer includes the table, and **`CREATE` at the same
+  identifier currently succeeds immediately** (today's drop semantics).
+  Whether this should instead be blocked until cleanup completes is an
+  open design question — see §8.1.
 - Object-store files may linger until the worker drains. Documented in
   release notes.
 
 Operators needing strict synchronous deletion set
-`gravitino.iceberg-rest.purger = synchronous`.
+`gravitino.iceberg-rest.async-purge.enabled = false`.
 
-## 10. Security
+### 5.11 Security
 
 - `@AuthorizationExpression` on `dropTable` runs on the request thread,
   unchanged.
-- Plugins use FileIO credentials snapshotted at request time. Plugins
-  that defer past credential lifetime (STS tokens, …) must refresh or
-  require static credentials — a documented plugin responsibility.
+- The worker uses FileIO credentials snapshotted at enqueue time.
+  Credentials that expire before the worker runs (STS tokens, …) need
+  the refresh strategy under discussion in §8.2.
 - `iceberg_purge_job` may contain credentials in `file_io_props`; the
   existing Gravitino DB encryption / access controls apply.
 
-## 11. Rollout
+### 5.12 User process
 
-1. SPI + `SynchronousIcebergPurger` (parity with today). Default
-   `synchronous`. No behavior change.
-2. Land `JdbcAsyncIcebergPurger` + schema migration behind opt-in.
-3. Flip default to `jdbc-async`. `synchronous` stays as fallback.
-4. Document the SPI as a public extension point.
+End-to-end flow with async purge enabled (the 1.3 default):
 
-## 12. Testing
+1. Operator runs with `gravitino.iceberg-rest.async-purge.enabled = true`
+   (the default). No client-side change is required.
+2. A client issues
+   `DELETE /v1/{prefix}/namespaces/{ns}/tables/{t}?purgeRequested=true`.
+3. The server runs authorization on the request thread, loads the table
+   metadata location, drops the catalog entry, and persists an
+   `iceberg_purge_job` row.
+4. The server responds `204 No Content` within typical request latency
+   (target p99 < 500 ms, < 5 s for the largest tables). The table is
+   immediately absent from `LIST` and `HEAD` returns `404`.
+5. In the background, a worker on any replica leases the job, rebuilds
+   the snapshot graph from `metadata_location`, and deletes every
+   reachable file, retrying transient failures with exponential backoff.
+6. On success the job is marked `SUCCEEDED`; on terminal failure it lands
+   in `DEAD_LETTER` for operator inspection. Listeners observe
+   `IcebergPurge{Started,Completed,Failed}Event` throughout.
+7. *(Recovery)* If the drop was a mistake, the table can be re-registered
+   at the stored metadata location any time before the worker deletes the
+   files (§5.7).
+
+---
+
+## 6. Task Breakdown
+
+Ordered so dependencies come first. Each item maps to one GitHub issue/PR.
+Async purge ships **as the default in 1.3** (PR #11152, confirmed); the
+synchronous path remains only as a rollback flag.
+
+### Phase 1 (1.3): Async purge core
+- [ ] Add the `iceberg_purge_job` schema and migrations (MySQL, H2, PostgreSQL)
+- [ ] Implement `IcebergPurgeJobStore` enqueue path (persist job, return)
+- [ ] Implement the worker pool: leasing via `FOR UPDATE SKIP LOCKED`, lease renewal, file deletion, retry/backoff state machine
+- [ ] Add the `async-purge.enabled` feature flag and wire both paths into `IcebergTableOperationExecutor.dropTable` (async default, synchronous rollback)
+- [ ] Add purge events: `IcebergPurgeStartedEvent`, `IcebergPurgeCompletedEvent`, `IcebergPurgeFailedEvent`
+- [ ] Extend coverage to views (`object_type='VIEW'`, metadata-only cleanup) and namespace-drop cascade (one job per contained object)
+- [ ] Add register-table recovery support / documentation (§5.7)
+
+### Phase 1 (1.3): Testing
+- [ ] Unit tests: enqueue, state machine, worker leasing/renewal/contention (H2)
+- [ ] Docker integration tests: latency, restart-resume (`kill -9` mid-purge), two-replica no-duplicate-deletes
+- [ ] Scale & concurrency tests (PRD §4 / R3) — see §7
+
+### Phase 1 (1.3): Documentation
+- [ ] Update user-facing documentation in `docs/` (async semantics, config, rollback flag, release notes)
+
+---
+
+## 7. Testing
 
 - Unit (`./gradlew :iceberg:iceberg-rest-server:test -PskipITs`):
-  - `TestIcebergPurgerFactory` — alias / FQCN resolution.
-  - `TestSynchronousIcebergPurger` — delegates to `CatalogUtil.dropTableData`.
-  - `TestJdbcAsyncIcebergPurgerStateMachine` — PENDING → RUNNING →
-    SUCCEEDED; failure → retry → DEAD_LETTER.
-  - `TestJdbcAsyncIcebergPurgerWorker` — leasing, renewal, contention
-    (H2 backend).
-  - `TestIcebergTableOperationExecutorPluggable` — `dropTable` invokes
-    `purger.purgeTable` exactly once; thrown errors surface as 5xx.
+  - `TestIcebergPurgeJobStore` — enqueue and row contents.
+  - `TestIcebergPurgeStateMachine` — PENDING → RUNNING → SUCCEEDED;
+    failure → retry → DEAD_LETTER.
+  - `TestIcebergPurgeWorker` — leasing, renewal, contention (H2 backend).
+  - `TestIcebergTableOperationExecutorAsyncPurge` — async default enqueues
+    exactly one job; `async-purge.enabled=false` falls back to synchronous
+    purge; thrown errors surface as 5xx.
 - Integration (`gravitino-docker-test`):
-  - Default plugin: drop a table; REST returns < 500 ms; worker
-    eventually clears every file.
+  - Drop a table; REST returns < 500 ms; worker eventually clears every file.
   - Restart REST mid-purge (kill -9); purge resumes.
   - Two replicas on one DB; no duplicate deletions or orphans.
-  - `synchronous`: existing `IcebergRESTServiceIT` reruns unchanged.
+  - Rollback flag: existing `IcebergRESTServiceIT` reruns unchanged with
+    `async-purge.enabled=false`.
+- Scale & concurrency (PRD §4 / R3):
+  - Locust scenarios under `gravitino-test/cloud/scale-test/`.
+  - High-file-count fixtures: medium (~50K files), large (~500K files).
+  - Concurrent-drop tier.
+  - Cucumber features for drop / soft-delete / cleanup / cleanup-failure.
+  - Timing assertion: drop returns within 5 s regardless of table size.
+  - Direct GCS/S3 listing asserts the storage prefix is empty after cleanup.
 
-## 13. Alternatives
+---
 
-**Hard-code "JDBC async."** Earlier draft. Bakes one operational model
-into every deployment. The SPI form is strictly more general for the
-same core complexity.
+## 8. Open questions
 
-**ServiceLoader instead of FQCN config.** The codebase precedent
-(`IcebergConfigProviderFactory`) uses FQCN with aliases. We follow that.
-
-**Reuse `RelationalGarbageCollector`.** Different IO surface (object
-store vs JDBC), different failure model. Share patterns, not code.
-
-**External job system (Quartz / Temporal) as the only path.** Heavy
-operational burden. Operators who want one write a plugin.
-
-**Enumerate files at enqueue time.** Defeats the latency goal; bloats
-rows.
-
-## 14. Open questions
-
-1. **Multi-server coordination on H2** — fall back to advisory locks or
-   conditional updates? Need a decision before implementation.
-2. **Credential refresh in `jdbc-async`** — refresh from the catalog at
+1. **Name reuse after drop** — should `CREATE` at the same identifier be
+   blocked (e.g. tombstone row → `409`) until cleanup completes? PRD §2.2
+   argues an attacker could otherwise read the original table's data via a
+   same-name/same-location recreate. Current design keeps today's drop
+   semantics (recreate allowed immediately); changing this alters drop
+   behavior. **Pending decision with @jerryshao.**
+2. **Credential refresh** — refresh FileIO credentials from the catalog at
    lease-renewal time, or require static credentials for catalogs that
-   opt into async purge?
-3. **Admin visibility** — expose an in-flight-jobs read endpoint? If
-   yes, on the SPI (`IcebergPurger#describeInFlight()`) or only on the
-   default plugin?
-4. **SPI stability** — mark `@Evolving` until at least one third-party
-   plugin is in production?
-5. **Namespace / view purge on the SPI in v1** — adding
-   `purgeNamespace` / `purgeView` as default-no-op methods now avoids a
-   binary break later.
+   opt into async purge? Leaning toward refresh so long-retention soft
+   delete (R2) keeps working; cost/complexity trade-off still open.
+3. **Multi-server coordination on H2** — fall back to advisory locks or
+   conditional updates where `SKIP LOCKED` is unavailable? Needs a
+   decision before implementation.
+4. **Job row vs. catalog row** — if name-reuse (Q1) is resolved by keeping
+   a tombstone on the catalog's table row, could the lease/retry fields
+   live on that row instead of a separate `iceberg_purge_job` table
+   (smaller migration)? Note Gravitino has no `iceberg_tables` table; this
+   would apply to the JDBC catalog's backing table, so scope/portability
+   across catalog types needs confirmation.

--- a/design-docs/async-iceberg-rest-hard-deletion.md
+++ b/design-docs/async-iceberg-rest-hard-deletion.md
@@ -1,0 +1,421 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+# Design: Pluggable Asynchronous Hard Deletion for the Gravitino Iceberg REST Server
+
+| Field    | Value                                                   |
+| -------- | ------------------------------------------------------- |
+| Status   | Draft                                                   |
+| Authors  | @roryqi                                                 |
+| Created  | 2026-05-19                                              |
+| Module   | `iceberg/iceberg-rest-server`, `iceberg/iceberg-common` |
+
+---
+
+## 1. Background
+
+When a client issues:
+
+```
+DELETE /v1/{prefix}/namespaces/{namespace}/tables/{table}?purgeRequested=true
+```
+
+today's path is fully synchronous: `IcebergTableOperations.dropTable` →
+`IcebergTableOperationExecutor.dropTable` → `IcebergCatalogWrapper.purgeTable`
+→ `CatalogHandlers.purgeTable`, which walks every snapshot / manifest /
+data file and deletes each one through `FileIO` on the Jetty request
+thread.
+
+For production tables this fails in three ways:
+
+- Multi-minute purges exceed HTTP timeouts.
+- Concurrent purges saturate the Jetty pool.
+- Mid-purge failures leak files with no retry or audit trail.
+
+We want to return quickly, finish deletion reliably in the background,
+survive restarts, and let operators plug in alternative strategies
+(object-store batch APIs, external job systems, audit-only) without
+modifying Gravitino.
+
+*Not in scope:* `RelationalGarbageCollector`, which deletes tombstoned
+**rows** from Gravitino's relational backend. Different IO surface,
+different failure model — kept separate.
+
+## 2. Goals
+
+1. `DELETE … ?purgeRequested=true` returns at typical request latency
+   (target p99 < 500 ms) regardless of table size, when an async purger
+   is configured.
+2. File-deletion strategy is **pluggable** behind an `IcebergPurger` SPI.
+3. The default async implementation deletes every file the synchronous
+   purge would have deleted, retries transient failures, and survives
+   restarts.
+4. No change to the Iceberg REST wire protocol.
+5. Authorization runs on the **request thread**, never deferred.
+
+## 3. Non-Goals
+
+- Changing Gravitino-native soft-delete semantics.
+- User-initiated cancellation of in-flight purges (v1).
+- Async `dropNamespace` / `dropView` (they don't delete data today).
+
+## 4. Overview
+
+```
+                           IcebergPurger (SPI)
+                                 ▲
+        ┌────────────────────────┼────────────────────────────┐
+        │                        │                            │
+SynchronousIceberg-       JdbcAsyncIceberg-          (third-party plugins:
+   Purger                    Purger                   Kafka, S3 Batch,
+(legacy parity)          (default async)              audit-only, …)
+```
+
+`IcebergTableOperationExecutor.dropTable` no longer knows how purge is
+implemented — it calls `purger.purgeTable(request)` and the configured
+plugin decides whether the work is synchronous, queued in a DB,
+dispatched externally, or skipped.
+
+The default plugin (`JdbcAsyncIcebergPurger`) persists a job row, returns
+immediately, and drains the queue from a background worker pool.
+
+## 5. The `IcebergPurger` SPI
+
+### 5.1 Interface
+
+Mirrors `IcebergConfigProvider`
+(`iceberg-rest-server/.../service/provider/IcebergConfigProvider.java`)
+for consistency.
+
+```java
+package org.apache.gravitino.iceberg.service.purge;
+
+public interface IcebergPurger extends Closeable {
+
+  /** Initialize the purger. Properties are stripped of the
+   *  {@code gravitino.iceberg-rest.purger.} prefix. */
+  void initialize(Map<String, String> properties, IcebergPurgerContext context);
+
+  /** Called on the REST request thread, after authorization and after the
+   *  catalog entry has been removed. The implementation either performs
+   *  the file deletion inline or accepts responsibility for completing it
+   *  later. Throwing surfaces as a 5xx. */
+  void purgeTable(IcebergPurgeRequest request);
+
+  String name();
+}
+```
+
+```java
+public final class IcebergPurgeRequest {
+  String metalakeName, catalogName, requestUser, requestId, fileIoImpl;
+  TableIdentifier tableIdentifier;
+  TableMetadata tableMetadata;            // loaded by the server
+  Map<String, String> fileIoProperties;
+  long requestTimestampMs;
+}
+
+public interface IcebergPurgerContext {
+  FileIO newFileIo(String impl, Map<String, String> properties);
+  Optional<RelationalBackend> relationalBackend();
+  EventListenerManager eventListenerManager();
+  String serverIdentity();   // host:pid
+}
+```
+
+The server loads `TableMetadata` once and hands it to the plugin so
+every implementation sees a consistent snapshot regardless of when it
+acts. `fileIoProperties` is captured at request time so deferred work
+can reconstruct `FileIO` even if the catalog is later reconfigured.
+
+### 5.2 Discovery
+
+Modeled on `IcebergConfigProviderFactory`:
+
+```java
+private static final Map<String, String> BUILTINS = ImmutableMap.of(
+    "synchronous", SynchronousIcebergPurger.class.getCanonicalName(),
+    "jdbc-async",  JdbcAsyncIcebergPurger.class.getCanonicalName());
+
+public static IcebergPurger create(Map<String, String> props,
+                                   IcebergPurgerContext ctx) {
+  String selector = new IcebergConfig(props).get(IcebergConfig.ICEBERG_REST_PURGER);
+  String className = BUILTINS.getOrDefault(selector, selector);
+  IcebergPurger purger = (IcebergPurger)
+      Class.forName(className).getDeclaredConstructor().newInstance();
+  purger.initialize(stripPrefix(props, "gravitino.iceberg-rest.purger."), ctx);
+  return purger;
+}
+```
+
+Built in `RESTService.serviceInit` right after the `IcebergConfigProvider`.
+
+### 5.3 Built-in providers
+
+**`SynchronousIcebergPurger`** — wraps `CatalogUtil.dropTableData(io, meta)`.
+Today's behavior, repackaged. Phase-1 default; remains the documented
+fallback after the default flips.
+
+**`JdbcAsyncIcebergPurger`** — persists an `iceberg_purge_job` row and
+returns. A worker pool leases jobs via `SELECT … FOR UPDATE SKIP LOCKED`,
+walks the metadata, deletes files, and retries with exponential backoff
+up to `max_attempts`. Becomes the default once stable. Detailed in §6.
+
+### 5.4 Third-party plugins
+
+Drop a jar with a class implementing `IcebergPurger` (no-arg constructor)
+onto the classpath and set:
+
+```
+gravitino.iceberg-rest.purger = com.example.S3BatchIcebergPurger
+gravitino.iceberg-rest.purger.s3-batch.account-id = 123456789012
+```
+
+Expected uses: emit Kafka events for downstream cleanup, create S3 Batch
+Operations jobs from the manifest list, or record intent in an audit
+system without deleting.
+
+## 6. Default implementation: `JdbcAsyncIcebergPurger`
+
+### 6.1 Request-path interaction
+
+```java
+public void dropTable(IcebergRequestContext ctx, TableIdentifier id,
+                      boolean purgeRequested) {
+  IcebergCatalogWrapper w = catalogWrapperManager.getCatalogWrapper(ctx.catalogName());
+  if (!purgeRequested) { w.dropTable(id); return; }
+
+  TableMetadata metadata = w.loadTableMetadata(id);
+  w.dropTable(id);          // metadata-only drop in the catalog
+  purger.purgeTable(
+      IcebergPurgeRequest.builder()
+          .catalogName(ctx.catalogName())
+          .tableIdentifier(id)
+          .tableMetadata(metadata)
+          .fileIoImpl(w.fileIoImpl())
+          .fileIoProperties(w.fileIoProperties())
+          .requestUser(ctx.userPrincipal())
+          .build());
+}
+```
+
+Order matters: load metadata → drop catalog entry → call the purger. A
+purge job exists only for a table that is already gone from the catalog.
+
+### 6.2 Schema — `iceberg_purge_job`
+
+```sql
+CREATE TABLE IF NOT EXISTS `iceberg_purge_job` (
+  `id`                BIGINT(20)    UNSIGNED NOT NULL AUTO_INCREMENT,
+  `metalake_name`     VARCHAR(128)  NOT NULL,
+  `catalog_name`      VARCHAR(128)  NOT NULL,
+  `namespace`         VARCHAR(512)  NOT NULL,
+  `table_name`        VARCHAR(256)  NOT NULL,
+  `metadata_location` VARCHAR(1024) NOT NULL,
+  `file_io_impl`      VARCHAR(256)  NOT NULL,
+  `file_io_props`     MEDIUMTEXT    NOT NULL COMMENT 'JSON',
+  `state`             VARCHAR(16)   NOT NULL COMMENT 'PENDING|RUNNING|SUCCEEDED|DEAD_LETTER',
+  `attempts`          INT(10)       NOT NULL DEFAULT 0,
+  `max_attempts`      INT(10)       NOT NULL,
+  `last_error`        TEXT          NULL,
+  `lease_owner`       VARCHAR(128)  NULL,
+  `lease_expires_at`  BIGINT(20)    NULL,
+  `next_attempt_at`   BIGINT(20)    NOT NULL,
+  `created_at`        BIGINT(20)    NOT NULL,
+  `created_by`        VARCHAR(128)  NOT NULL,
+  `updated_at`        BIGINT(20)    NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `idx_state_next_attempt` (`state`, `next_attempt_at`)
+) ENGINE=InnoDB;
+```
+
+We store only `metadata_location`, not the file list — enumeration is
+slow on large tables, and `TableMetadataParser.read(io, location)`
+rebuilds the snapshot graph deterministically when the worker runs.
+
+Migration: `upgrade-1.2.0-to-1.3.0-mysql.sql` (and H2 / PostgreSQL).
+
+### 6.3 Worker pool
+
+A `ScheduledThreadPoolExecutor` modeled on `RelationalGarbageCollector`.
+Each tick:
+
+```sql
+SELECT * FROM iceberg_purge_job
+ WHERE state IN ('PENDING','RUNNING')
+   AND next_attempt_at <= :now
+   AND (lease_expires_at IS NULL OR lease_expires_at < :now)
+ ORDER BY next_attempt_at LIMIT :batch
+ FOR UPDATE SKIP LOCKED;
+```
+
+then updates the row to `RUNNING` with `lease_owner=:me`,
+`lease_expires_at=:now+leaseTimeout`. `SKIP LOCKED` is the cluster-safety
+primitive: any number of replicas can run the worker without external
+coordination. H2 falls back to a conditional update.
+
+Execution mirrors `CatalogHandlers.purgeTable`:
+
+```java
+TableMetadata meta = TableMetadataParser.read(io, job.metadataLocation());
+Tasks.foreach(collectAllReachableFiles(meta))
+     .executeWith(deleteExecutor)
+     .retry(perFileRetries)
+     .suppressFailureWhenFinished()
+     .run(io::deleteFile);
+```
+
+A separate task renews the lease every `leaseTimeout / 3`. If the host
+dies, the lease expires and another replica reclaims the job.
+
+### 6.4 Failure model
+
+Per-file failures are logged but do not fail the whole job — the
+synchronous purge has the same "best effort" stance. A job fails only if
+the **metadata phase** fails.
+
+| Outcome                            | Action                                                              |
+| ---------------------------------- | ------------------------------------------------------------------- |
+| All files deleted (or already gone) | `state='SUCCEEDED'`                                                |
+| Metadata load failed, transient    | `attempts++`, `next_attempt_at = now + backoff(attempts)`           |
+| Metadata load failed, terminal     | `attempts++`; if `attempts >= max_attempts` → `state='DEAD_LETTER'` |
+| Worker killed mid-job              | Lease expires; another worker picks it up; deletes are idempotent   |
+
+`NotFoundException` from `deleteFile` counts as success. Backoff:
+`min(maxBackoff, base * 2^attempts)` with jitter.
+
+## 7. Events
+
+Existing `IcebergDropTableEvent` continues to fire on the REST thread
+with the *requested* purge flag, preserving today's listener contract.
+Plugins emit, via `IcebergPurgerContext.eventListenerManager()`:
+
+- `IcebergPurgeStartedEvent` — work begins on a request.
+- `IcebergPurgeCompletedEvent` — files deleted, with elapsed time.
+- `IcebergPurgeFailedEvent` — dead-lettered job.
+
+Third-party purgers are expected to fire the same events.
+
+## 8. Configuration
+
+### 8.1 SPI selection
+
+| Key                              | Default       | Description                                                                                          |
+| -------------------------------- | ------------- | ---------------------------------------------------------------------------------------------------- |
+| `gravitino.iceberg-rest.purger`  | `synchronous` (initially) → `jdbc-async` (after phase 3) | Short alias or FQCN of an `IcebergPurger` implementation. |
+
+### 8.2 `jdbc-async` tunables
+
+| Key                                                           | Default   |
+| ------------------------------------------------------------- | --------- |
+| `…purger.jdbc-async.worker-threads`                           | `4`       |
+| `…purger.jdbc-async.delete-threads-per-job`                   | `8`       |
+| `…purger.jdbc-async.poll-interval-ms`                         | `5000`    |
+| `…purger.jdbc-async.batch-size`                               | `16`      |
+| `…purger.jdbc-async.lease-timeout-ms`                         | `300000`  |
+| `…purger.jdbc-async.max-attempts`                             | `5`       |
+| `…purger.jdbc-async.backoff-base-ms`                          | `30000`   |
+| `…purger.jdbc-async.backoff-max-ms`                           | `3600000` |
+| `…purger.jdbc-async.completed-retention-hours`                | `168`     |
+
+`synchronous` has no tunables.
+
+## 9. Wire compatibility
+
+The Iceberg REST spec does not require file deletion to be complete
+before the response. With this design:
+
+- The catalog entry is removed before `204`, so `HEAD` returns `404`,
+  `LIST` no longer includes the table, and `CREATE` at the same
+  identifier succeeds immediately.
+- Object-store files may linger until the worker drains. Documented in
+  release notes.
+
+Operators needing strict synchronous deletion set
+`gravitino.iceberg-rest.purger = synchronous`.
+
+## 10. Security
+
+- `@AuthorizationExpression` on `dropTable` runs on the request thread,
+  unchanged.
+- Plugins use FileIO credentials snapshotted at request time. Plugins
+  that defer past credential lifetime (STS tokens, …) must refresh or
+  require static credentials — a documented plugin responsibility.
+- `iceberg_purge_job` may contain credentials in `file_io_props`; the
+  existing Gravitino DB encryption / access controls apply.
+
+## 11. Rollout
+
+1. SPI + `SynchronousIcebergPurger` (parity with today). Default
+   `synchronous`. No behavior change.
+2. Land `JdbcAsyncIcebergPurger` + schema migration behind opt-in.
+3. Flip default to `jdbc-async`. `synchronous` stays as fallback.
+4. Document the SPI as a public extension point.
+
+## 12. Testing
+
+- Unit (`./gradlew :iceberg:iceberg-rest-server:test -PskipITs`):
+  - `TestIcebergPurgerFactory` — alias / FQCN resolution.
+  - `TestSynchronousIcebergPurger` — delegates to `CatalogUtil.dropTableData`.
+  - `TestJdbcAsyncIcebergPurgerStateMachine` — PENDING → RUNNING →
+    SUCCEEDED; failure → retry → DEAD_LETTER.
+  - `TestJdbcAsyncIcebergPurgerWorker` — leasing, renewal, contention
+    (H2 backend).
+  - `TestIcebergTableOperationExecutorPluggable` — `dropTable` invokes
+    `purger.purgeTable` exactly once; thrown errors surface as 5xx.
+- Integration (`gravitino-docker-test`):
+  - Default plugin: drop a table; REST returns < 500 ms; worker
+    eventually clears every file.
+  - Restart REST mid-purge (kill -9); purge resumes.
+  - Two replicas on one DB; no duplicate deletions or orphans.
+  - `synchronous`: existing `IcebergRESTServiceIT` reruns unchanged.
+
+## 13. Alternatives
+
+**Hard-code "JDBC async."** Earlier draft. Bakes one operational model
+into every deployment. The SPI form is strictly more general for the
+same core complexity.
+
+**ServiceLoader instead of FQCN config.** The codebase precedent
+(`IcebergConfigProviderFactory`) uses FQCN with aliases. We follow that.
+
+**Reuse `RelationalGarbageCollector`.** Different IO surface (object
+store vs JDBC), different failure model. Share patterns, not code.
+
+**External job system (Quartz / Temporal) as the only path.** Heavy
+operational burden. Operators who want one write a plugin.
+
+**Enumerate files at enqueue time.** Defeats the latency goal; bloats
+rows.
+
+## 14. Open questions
+
+1. **Multi-server coordination on H2** — fall back to advisory locks or
+   conditional updates? Need a decision before implementation.
+2. **Credential refresh in `jdbc-async`** — refresh from the catalog at
+   lease-renewal time, or require static credentials for catalogs that
+   opt into async purge?
+3. **Admin visibility** — expose an in-flight-jobs read endpoint? If
+   yes, on the SPI (`IcebergPurger#describeInFlight()`) or only on the
+   default plugin?
+4. **SPI stability** — mark `@Evolving` until at least one third-party
+   plugin is in production?
+5. **Namespace / view purge on the SPI in v1** — adding
+   `purgeNamespace` / `purgeView` as default-no-op methods now avoids a
+   binary break later.

--- a/design-docs/async-iceberg-rest-hard-deletion.md
+++ b/design-docs/async-iceberg-rest-hard-deletion.md
@@ -310,14 +310,18 @@ this worker owns. If the host dies the heartbeat stops; once a row ages past
 Per-file failures are logged but do not fail the whole job — the
 synchronous purge has the same "best effort" stance. A job fails only if the
 **metadata phase** fails. `NotFoundException` from `deleteFile` counts as
-success. A failed job retries on the next poll tick (§5.5).
+success. A transient failure goes back to `PENDING` and is retried on a
+later poll tick (§5.5), incrementing `attempts` each time; when `attempts`
+reaches `max-attempts` the job goes to `FAILED` instead of `PENDING`. A
+clearly terminal failure skips the retries and goes straight to `FAILED`.
 
-| Outcome                             | Action                                                                                |
-|-------------------------------------|---------------------------------------------------------------------------------------|
-| All files deleted (or already gone) | `state='SUCCEEDED'`                                                                    |
-| Metadata load failed, transient     | back to `PENDING`, `attempts++`, `heartbeat_at=NULL`; re-claimed on a later poll tick  |
-| Metadata load failed, terminal      | `attempts++`; if `attempts >= max-attempts` → `FAILED`                                |
-| Worker killed mid-job               | `RUNNING` row's heartbeat goes stale; another worker reclaims; deletes are idempotent  |
+| Outcome                                              | Action                                                                                |
+|------------------------------------------------------|---------------------------------------------------------------------------------------|
+| All files deleted (or already gone)                  | `state='SUCCEEDED'`                                                                    |
+| Transient failure, `attempts < max-attempts`         | `attempts++`, back to `PENDING`, `heartbeat_at=NULL`; re-claimed on a later poll tick  |
+| Transient failure, `attempts` reaches `max-attempts` | `attempts++` → `FAILED` (gave up retrying)                                             |
+| Terminal failure (e.g. metadata gone/corrupt)        | → `FAILED` immediately; retrying cannot help                                           |
+| Worker killed mid-job                                | `RUNNING` row's heartbeat goes stale; another worker reclaims; deletes are idempotent  |
 
 Restart handling falls out of the durable job table plus the heartbeat
 model — no separate mechanism:

--- a/design-docs/async-iceberg-rest-hard-deletion.md
+++ b/design-docs/async-iceberg-rest-hard-deletion.md
@@ -252,9 +252,50 @@ SELECT * FROM iceberg_purge_job
 ```
 
 then updates the row to `RUNNING` with `lease_owner=:me`,
-`lease_expires_at=:now+leaseTimeout`. `SKIP LOCKED` is the cluster-safety
-primitive: any number of replicas can run the worker without external
-coordination. H2 falls back to a conditional update.
+`lease_expires_at=:now+leaseTimeout`. `SKIP LOCKED` is a performance
+optimization (it avoids lock waiting between replicas), not the correctness
+guarantee — see the leasing model below.
+
+#### Multi-replica leasing model
+
+Three distinct races, handled deliberately:
+
+1. **Two replicas claim the same job.** The claiming `UPDATE` is the
+   serialization point, so this cannot happen — see the CAS rule below. Any
+   number of replicas can run the worker with no external coordinator.
+2. **A held lease expires while its owner is still alive** (long GC, network
+   partition). The lease expires, another replica reclaims, and both may
+   delete the same files concurrently. We *accept* this race rather than
+   eliminate it: deletes are idempotent and `NotFoundException` counts as
+   success (§5.5), so the only cost is duplicated work, never incorrect
+   results. This is what lets failover stay coordinator-free.
+3. **A replica dies mid-job.** Identical to case 2 from the survivors' point
+   of view — the lease expires and the job is reclaimed.
+
+To stay portable, claiming is expressed as an optimistic compare-and-swap that
+works on **every** SQL backend, not just those with `SKIP LOCKED`:
+
+```sql
+-- read candidates (no lock required)
+SELECT id FROM iceberg_purge_job
+ WHERE state IN ('PENDING','RUNNING')
+   AND next_attempt_at <= :now
+   AND (lease_expires_at IS NULL OR lease_expires_at < :now)
+ ORDER BY next_attempt_at LIMIT :batch;
+
+-- claim each candidate; the row is ours only if affected_rows = 1
+UPDATE iceberg_purge_job
+   SET state='RUNNING', lease_owner=:me, lease_expires_at=:now+:leaseTimeout
+ WHERE id=:id
+   AND (lease_expires_at IS NULL OR lease_expires_at < :now);
+```
+
+A loser sees `affected_rows = 0` and moves to the next candidate. Where
+`SKIP LOCKED` is available (MySQL 8+, PostgreSQL), the worker uses the
+`FOR UPDATE SKIP LOCKED` form shown above to skip locked rows up front and
+cut contention; where it is not (H2, older MySQL), it falls back to the CAS
+form. Both are correct; `SKIP LOCKED` is purely an optimization. We do not use
+DB-specific advisory locks, whose semantics differ across engines.
 
 Execution mirrors `CatalogHandlers.purgeTable`:
 
@@ -457,9 +498,10 @@ synchronous path remains only as a rollback flag.
    lease-renewal time, or require static credentials for catalogs that
    opt into async purge? Leaning toward refresh so long-retention soft
    delete (R2) keeps working; cost/complexity trade-off still open.
-3. **Multi-server coordination on H2** — fall back to advisory locks or
-   conditional updates where `SKIP LOCKED` is unavailable? Needs a
-   decision before implementation.
+3. ~~**Multi-server coordination on H2**~~ — **Resolved (§5.4).** Claiming is
+   an optimistic compare-and-swap `UPDATE` that works on every SQL backend;
+   `SKIP LOCKED` is used as an optimization where available and the CAS form is
+   the fallback elsewhere. No advisory locks.
 4. **Job row vs. catalog row** — if name-reuse (Q1) is resolved by keeping
    a tombstone on the catalog's table row, could the lease/retry fields
    live on that row instead of a separate `iceberg_purge_job` table

--- a/design-docs/async-iceberg-rest-hard-deletion.md
+++ b/design-docs/async-iceberg-rest-hard-deletion.md
@@ -279,15 +279,17 @@ deletes in bounded batches:
 TableMetadata meta = TableMetadataParser.read(io, job.metadataLocation());
 try (CloseableIterable<String> files = reachableFiles(meta)) {  // lazy, not materialized
   Tasks.foreach(files)
-       .executeWith(deleteExecutor)  // sized by delete-threads-per-job (§5.10)
+       .executeWith(deleteExecutor)  // shared server-wide pool, §5.10
        .retry(perFileRetries)
        .suppressFailureWhenFinished()
        .run(io::deleteFile);
 }
 ```
 
-`deleteExecutor` is per-job and its size is `delete-threads-per-job`
-(§5.10) — raise it to drain a very large table's files faster when purge
+`deleteExecutor` is a single server-wide pool sized by `delete-threads`
+(§5.10), shared by all concurrent jobs rather than allocated per job. This
+bounds total file-delete concurrency on the server regardless of how many
+jobs run at once; raise it to drain large tables faster when purge
 throughput matters.
 
 A separate task sends a heartbeat every `heartbeatTimeout / 3` on the ids
@@ -417,8 +419,8 @@ only tune the worker pool and retries:
 
 | Key                                                           | Default  | Description                                                                  |
 |---------------------------------------------------------------|----------|------------------------------------------------------------------------------|
-| `gravitino.iceberg-rest.async-purge.worker-threads`           | `4`      | Worker pool size per server.                                                 |
-| `gravitino.iceberg-rest.async-purge.delete-threads-per-job`   | `8`      | Parallelism of file deletes within a single job.                             |
+| `gravitino.iceberg-rest.async-purge.worker-threads`           | `4`      | Worker pool size per server (concurrent jobs).                               |
+| `gravitino.iceberg-rest.async-purge.delete-threads`           | `16`     | Server-wide file-delete pool size, shared across all jobs.                   |
 | `gravitino.iceberg-rest.async-purge.poll-interval-ms`         | `5000`   | Worker poll interval.                                                        |
 | `gravitino.iceberg-rest.async-purge.heartbeat-timeout-ms`     | `300000` | Age after which a job with no heartbeat is reclaimable.                      |
 | `gravitino.iceberg-rest.async-purge.max-attempts`             | `5`      | Attempts before `FAILED`.                                                    |

--- a/design-docs/async-iceberg-rest-hard-deletion.md
+++ b/design-docs/async-iceberg-rest-hard-deletion.md
@@ -326,7 +326,7 @@ the **metadata phase** fails.
 | All files deleted (or already gone) | `state='SUCCEEDED'`                                                |
 | Metadata load failed, transient    | `attempts++`, `next_attempt_at = now + backoff(attempts)`           |
 | Metadata load failed, terminal     | `attempts++`; if `attempts >= max_attempts` → `state='DEAD_LETTER'` |
-| Worker killed mid-job              | Lease expires; another worker picks it up; deletes are idempotent   |
+| Worker killed mid-job              | Lease expires; another worker picks it up; deletes are idempotent (restart story in §5.15) |
 | Recovered via re-register (§5.13)  | Job CAS'd to `state='CANCELLED'`; the worker only leases non-terminal rows, so files are left intact |
 
 `NotFoundException` from `deleteFile` counts as success. Backoff:
@@ -552,6 +552,39 @@ register-as-recovery flow (§5.13).
 retries is always discoverable rather than a silent file leak, even before
 the management endpoint lands.
 
+### 5.15 Restart and crash recovery
+
+Restart handling is not a separate mechanism — it falls out of the durable
+job table (§5.3) plus the lease model (§5.4). Three guarantees hold across
+a process restart or crash:
+
+1. **Nothing in-flight is lost.** The job is committed to
+   `iceberg_purge_job` *before* the `DELETE` returns (§5.2); there is no
+   in-memory queue, so a restart cannot drop pending work. `PENDING` jobs
+   are picked up on the first worker tick after boot.
+2. **`RUNNING` jobs orphaned by the crash are reclaimed.** A process that
+   died mid-purge leaves a row in `state='RUNNING'` with a stale
+   `lease_owner` / `lease_expires_at`. The worker poll already selects rows
+   whose lease has expired, so once it does the restarted node — or any peer
+   — reclaims the row via the CAS. This is the "worker killed mid-job" row
+   in §5.5.
+3. **Re-running a half-finished job is safe.** The worker rebuilds the file
+   set from `metadata_location` and re-deletes; already-gone files raise
+   `NotFoundException`, which counts as success (§5.5). A crash anywhere in
+   the delete loop costs only duplicated work, never corruption.
+
+In a **multi-replica** deployment this is seamless: surviving replicas
+reclaim a dead node's jobs on lease expiry with no coordinator.
+
+The one rough edge is a **single-replica** restart: the crashed node's own
+`RUNNING` jobs sit idle until `lease_expires_at` passes — up to one
+`leaseTimeout` of dead time — before the rebooted process reclaims them.
+**v1 behavior:** rely on lease expiry (correct, bounded, zero extra code);
+keep `leaseTimeout` modest so the resume delay is small. **Future
+optimization:** a startup lease sweep that resets `RUNNING` rows whose
+`lease_owner` matches this node's stable identity back to `PENDING`, so they
+resume immediately instead of waiting out the lease.
+
 ---
 
 ## 6. Task Breakdown
@@ -581,6 +614,7 @@ synchronous path remains only as a rollback flag.
 
 ### Phase 2 (post-1.3): Management endpoint
 - [ ] Add the read-only `metalakes/{metalake}/catalogs/{catalog}/cleanups` management endpoint (§5.14): REST resource, DTOs, authorization, client support, docs, and tests. Filtered list keyed by object identifier; no by-id fetch
+- [ ] Startup lease-sweep optimization (§5.15): on boot reset `RUNNING` rows owned by this node's stable identity back to `PENDING` so single-replica restarts resume without waiting out `leaseTimeout`
 
 ---
 

--- a/design-docs/async-iceberg-rest-hard-deletion.md
+++ b/design-docs/async-iceberg-rest-hard-deletion.md
@@ -221,7 +221,7 @@ CREATE TABLE IF NOT EXISTS `iceberg_purge_job` (
   `metadata_location` VARCHAR(1024) NOT NULL,
   `file_io_impl`      VARCHAR(256)  NOT NULL,
   `file_io_props`     MEDIUMTEXT    NOT NULL COMMENT 'JSON',
-  `state`             VARCHAR(16)   NOT NULL COMMENT 'PENDING|SUCCEEDED|FAILED|CANCELLED; being-worked = PENDING with a fresh heartbeat_at',
+  `state`             VARCHAR(16)   NOT NULL COMMENT 'PENDING|RUNNING|SUCCEEDED|FAILED|CANCELLED; a RUNNING row is being deleted while its heartbeat_at stays fresh',
   `attempts`          INT(10)       NOT NULL DEFAULT 0,
   `max_attempts`      INT(10)       NOT NULL,
   `last_error`        TEXT          NULL,
@@ -249,18 +249,21 @@ Each tick:
 
 ```sql
 SELECT * FROM iceberg_purge_job
- WHERE state = 'PENDING'
-   AND next_attempt_at <= :now
-   AND (heartbeat_at IS NULL OR heartbeat_at < :now - :heartbeatTimeout)
+ WHERE next_attempt_at <= :now
+   AND ( state = 'PENDING'
+      OR (state = 'RUNNING'
+          AND (heartbeat_at IS NULL OR heartbeat_at < :now - :heartbeatTimeout)) )
  ORDER BY next_attempt_at LIMIT :batch
  FOR UPDATE SKIP LOCKED;
 ```
 
-then stamps `heartbeat_at=:now` to mark the row claimed. The row stays
-`PENDING` — there is no separate `RUNNING` state; "being worked" is simply a
-`PENDING` row with a fresh heartbeat. `SKIP LOCKED` is a performance
-optimization (it avoids lock waiting between replicas), not the correctness
-guarantee — see the ownership model below.
+then claims each candidate by moving it to `state='RUNNING'` with
+`heartbeat_at=:now`. A job is `PENDING` while it waits (just enqueued, or
+backing off for a retry); a `RUNNING` row with a fresh heartbeat is being
+actively deleted; and a `RUNNING` row whose heartbeat has gone stale was
+abandoned by a dead or stalled worker and is reclaimable. `SKIP LOCKED` is a
+performance optimization (it avoids lock waiting between replicas), not the
+correctness guarantee — see the ownership model below.
 
 #### Multi-replica ownership model
 
@@ -289,17 +292,19 @@ works on **every** SQL backend, not just those with `SKIP LOCKED`:
 ```sql
 -- read candidates (no lock required)
 SELECT id FROM iceberg_purge_job
- WHERE state = 'PENDING'
-   AND next_attempt_at <= :now
-   AND (heartbeat_at IS NULL OR heartbeat_at < :now - :heartbeatTimeout)
+ WHERE next_attempt_at <= :now
+   AND ( state = 'PENDING'
+      OR (state = 'RUNNING'
+          AND (heartbeat_at IS NULL OR heartbeat_at < :now - :heartbeatTimeout)) )
  ORDER BY next_attempt_at LIMIT :batch;
 
 -- claim each candidate; the row is ours only if affected_rows = 1
 UPDATE iceberg_purge_job
-   SET heartbeat_at=:now
+   SET state='RUNNING', heartbeat_at=:now
  WHERE id=:id
-   AND state='PENDING'
-   AND (heartbeat_at IS NULL OR heartbeat_at < :now - :heartbeatTimeout);
+   AND ( state='PENDING'
+      OR (state='RUNNING'
+          AND (heartbeat_at IS NULL OR heartbeat_at < :now - :heartbeatTimeout)) );
 ```
 
 A loser sees `affected_rows = 0` and moves to the next candidate. Where
@@ -341,9 +346,9 @@ the **metadata phase** fails.
 | Outcome                            | Action                                                              |
 | ---------------------------------- | ------------------------------------------------------------------- |
 | All files deleted (or already gone) | `state='SUCCEEDED'`                                                |
-| Metadata load failed, transient    | `attempts++`, `next_attempt_at = now + backoff(attempts)`           |
+| Metadata load failed, transient    | back to `state='PENDING'`, `attempts++`, `next_attempt_at = now + backoff(attempts)`, `heartbeat_at=NULL` |
 | Metadata load failed, terminal     | `attempts++`; if `attempts >= max_attempts` → `state='FAILED'`      |
-| Worker killed mid-job              | Heartbeat goes stale; another worker picks it up; deletes are idempotent (restart story in §5.15) |
+| Worker killed mid-job              | `RUNNING` row's heartbeat goes stale; another worker reclaims it; deletes are idempotent (restart story in §5.15) |
 | Recovered via re-register (§5.13)  | Job CAS'd to `state='CANCELLED'`; the worker only claims non-terminal rows, so files are left intact |
 
 `NotFoundException` from `deleteFile` counts as success. Backoff:
@@ -478,10 +483,9 @@ End-to-end flow with async purge (the 1.3 default):
 
 ### 5.13 Name reuse during purge (tombstone semantics)
 
-This resolves the §8.1 open question. While a purge job for an identifier
-is still `PENDING` (whether or not a worker is actively beating on it), that
-identifier is treated as **still occupied** even though its catalog entry is
-already gone. The
+This resolves the §8.1 open question. While a purge job for an identifier is
+non-terminal (`PENDING` or `RUNNING`), that identifier is treated as **still
+occupied** even though its catalog entry is already gone. The
 active `iceberg_purge_job` row *is* the tombstone — no second table is
 needed. This is the §8.4 / Q4 "fold the lifecycle onto an existing row"
 idea, scoped to the job row rather than a catalog-backing table (which
@@ -497,8 +501,9 @@ The REST server consults the purge job store **on the request thread**
 | `createTable` (same identifier) | **`409 Conflict`** — table is being purged | succeeds (brand-new table) |
 | `registerTable` (same identifier) | **`409 Conflict`**, except the recovery path below | succeeds |
 
-"Active" means `state='PENDING'`. A job in `SUCCEEDED` (even before its row
-is pruned per `completed-retention-hours`) no longer blocks reuse — the files
+"Active" means `state IN ('PENDING','RUNNING')` (terminal states are
+`SUCCEEDED` / `FAILED` / `CANCELLED`). A job in `SUCCEEDED` (even before its
+row is pruned per `completed-retention-hours`) no longer blocks reuse — the files
 are gone, so a recreate is safe. A `FAILED` job also stops blocking, so a
 failed cleanup never permanently wedges the namespace; operators see the
 failed row and reclaim leaked files out of band.
@@ -524,16 +529,15 @@ non-terminal rows. This is **recovery-scoped** cancellation only; a
 general user-facing "cancel my purge" API stays out of scope (§3.2).
 
 **Concurrency.** The create/register conflict check, the worker's claim, and
-recovery's cancel all serialize on the same `state='PENDING'` +
-fresh-heartbeat predicate (the §5.4 ownership CAS). A `createTable` that
-observes a terminal state (`SUCCEEDED` / `FAILED` / `CANCELLED`) proceeds;
-one that observes `PENDING` gets `409`. Recovery's CAS to `CANCELLED` is
-guarded by `state='PENDING' AND heartbeat stale`, the same guard a worker
-uses to claim — so if a worker currently holds a fresh heartbeat, recovery's
-CAS matches no row and returns `409` (retry once the heartbeat goes stale or
-the job terminates); and if recovery wins, the worker's next heartbeat /
-completion CAS (also guarded on `state='PENDING'`) matches no row, so it
-abandons the job without touching files.
+recovery's cancel all serialize on the job row's `state`. A `createTable`
+that observes a terminal state (`SUCCEEDED` / `FAILED` / `CANCELLED`)
+proceeds; one that observes `PENDING` or `RUNNING` gets `409`. Recovery's CAS
+to `CANCELLED` is guarded by `state='PENDING'`, and the worker's claim CAS
+moves `PENDING → RUNNING` — they target the same `PENDING` row, so at most
+one wins. A job that has already started running therefore cannot be
+silently cancelled out from under the worker: recovery's CAS matches no row,
+it sees `RUNNING`, and returns `409` (the caller retries once the heartbeat
+goes stale or the job terminates).
 
 ### 5.14 Observing in-flight and failed purges
 
@@ -547,8 +551,8 @@ Iceberg REST wire contract (Goal #4).
 the table is dropped: `loadTable` / `HEAD` → `404`, `LIST` omits it. The
 single purge-specific signal is the §5.13 `409` on a same-identifier
 `createTable` / `register`, whose Iceberg `ErrorResponse.message` names the
-blocking job (e.g. *"table `db.t` is being purged (cleanup job 123 still
-pending)"*). A standard client needs nothing more — semantically the table
+blocking job (e.g. *"table `db.t` is being purged (cleanup job 123 still in
+progress)"*). A standard client needs nothing more — semantically the table
 is deleted — and we add **no** non-standard fields to load/list responses.
 
 **Operators.** In 1.3 the read path is **direct DB query** of
@@ -578,8 +582,7 @@ register-as-recovery flow (§5.13).
 
 - **Events** (§5.8): `IcebergPurge{Started,Completed,Failed}Event` for
   streaming consumers.
-- **Metrics**: gauges `purge.jobs.{pending,running,failed}` (where `running`
-  counts `PENDING` rows with a fresh heartbeat) and
+- **Metrics**: gauges `purge.jobs.{pending,running,failed}` and
   `purge.oldest_pending_age_ms`; counters `purge.{completed,failed}`. These
   let operators alert on a growing backlog ("silently still deleting") or any
   `FAILED` job ("silently failed to delete") — the two conditions that would
@@ -598,11 +601,11 @@ across a process restart or crash:
 
 1. **Nothing in-flight is lost.** The job is committed to
    `iceberg_purge_job` *before* the `DELETE` returns (§5.2); there is no
-   in-memory queue, so a restart cannot drop pending work. `PENDING` jobs
+   in-memory queue, so a restart cannot drop queued work. `PENDING` jobs
    are picked up on the first worker tick after boot.
 2. **In-flight jobs orphaned by the crash are reclaimed.** A process that
-   died mid-purge leaves a still-`PENDING` row with a stale `heartbeat_at`.
-   The worker poll already selects `PENDING` rows whose heartbeat has gone
+   died mid-purge leaves a still-`RUNNING` row with a stale `heartbeat_at`.
+   The worker poll already selects `RUNNING` rows whose heartbeat has gone
    stale, so once it does the restarted node — or any peer — reclaims the row
    via the CAS. This is the "worker killed mid-job" row in §5.5.
 3. **Re-running a half-finished job is safe.** The worker rebuilds the file
@@ -659,8 +662,8 @@ synchronous path remains only as a rollback flag.
 
 - Unit (`./gradlew :iceberg:iceberg-rest-server:test -PskipITs`):
   - `TestIcebergPurgeJobStore` — enqueue and row contents.
-  - `TestIcebergPurgeStateMachine` — PENDING → SUCCEEDED;
-    failure → retry → FAILED.
+  - `TestIcebergPurgeStateMachine` — PENDING → RUNNING → SUCCEEDED;
+    failure → retry (back to PENDING) → FAILED.
   - `TestIcebergPurgeWorker` — claiming, heartbeat renewal, contention (H2
     backend).
   - `TestIcebergTableOperationExecutorAsyncPurge` — async default enqueues

--- a/design-docs/async-iceberg-rest-hard-deletion.md
+++ b/design-docs/async-iceberg-rest-hard-deletion.md
@@ -249,10 +249,11 @@ thus bounds the concurrent jobs per server; there is no separate claim-batch
 size.
 
 Ownership is tracked by a **heartbeat** alone: the worker that claims a job
-keeps refreshing `heartbeat_at` while it runs and remembers the ids it owns
-in memory (no owner column — a stale row is reclaimable by anyone, which is
-exactly the failover behavior we want). A job is abandoned, and reclaimable,
-once its heartbeat is older than `heartbeatTimeout`.
+keeps refreshing `heartbeat_at` while it runs and remembers in memory, per
+owned id, the `heartbeat_at` value it last wrote (no owner column — a stale
+row is reclaimable by anyone, which is exactly the failover behavior we want).
+A job is abandoned, and reclaimable, once its heartbeat is older than
+`heartbeatTimeout`.
 
 Claiming is an optimistic compare-and-swap `UPDATE` that works on **every**
 SQL backend. A free thread reads a small candidate window and claims the
@@ -320,9 +321,33 @@ bounds total file-delete concurrency on the server regardless of how many
 jobs run at once; raise it to drain large tables faster when purge
 throughput matters.
 
-A separate task sends a heartbeat every `heartbeatTimeout / 3` on the ids
-this worker owns. If the host dies the heartbeat stops; once a row ages past
-`heartbeatTimeout` another replica reclaims it.
+**Updating the heartbeat.** One background task per worker process — not one
+per job — runs every `heartbeatTimeout / 3`, so two updates can be missed
+(a GC pause, a brief DB hiccup) before the row looks abandoned. For each id
+the process owns it issues a guarded `UPDATE`:
+
+```sql
+UPDATE iceberg_purge_job
+   SET heartbeat_at = :now
+ WHERE id = :id
+   AND state = 'RUNNING'
+   AND heartbeat_at = :lastValueIWrote;   -- CAS on the value I last wrote
+```
+
+The `heartbeat_at` value the worker last wrote is the lease: the `UPDATE`
+is a compare-and-swap on it, so it succeeds (`affected_rows = 1`, and the
+worker records the new `:now` as its next `:lastValueIWrote`) **only while
+this process is still the owner**. If the process stalled past
+`heartbeatTimeout` and a peer reclaimed the job, the peer's claim overwrote
+`heartbeat_at`; this process's next CAS then matches no row
+(`affected_rows = 0`), and it reads that as "I no longer own this job" —
+it stops deleting and drops the id from its in-memory set. That is how
+ownership transfers cleanly with no owner column. The claim itself
+(`SET heartbeat_at=:now` above) seeds the first `:lastValueIWrote`; finishing
+or releasing a job removes the id from the set so the task stops touching it.
+A worker owns at most `worker-threads` ids, so this is a handful of cheap
+point updates per cycle. If the host dies the task stops entirely and the
+rows age out for reclaim.
 
 ### 5.6 Failure model, restart, and crash recovery
 

--- a/design-docs/async-iceberg-rest-hard-deletion.md
+++ b/design-docs/async-iceberg-rest-hard-deletion.md
@@ -174,7 +174,7 @@ public void dropTable(IcebergRequestContext ctx, TableIdentifier id,
   IcebergCatalogWrapper w = catalogWrapperManager.getCatalogWrapper(ctx.catalogName());
   if (!purgeRequested) { w.dropTable(id); return; }
 
-  if (!asyncPurgeEnabled) {                 // rollback path
+  if (!asyncPurgeEnabled) {                 // fallback path
     w.purgeTable(id);                       // synchronous, today's behavior
     return;
   }

--- a/design-docs/async-iceberg-rest-hard-deletion.md
+++ b/design-docs/async-iceberg-rest-hard-deletion.md
@@ -362,14 +362,14 @@ claim never disagree about whether the identifier is still occupied.
 
 The initial scope is **tables only**.
 
-- **Namespace (schema) drops** cascade: the server enqueues an independent
-  purge job per contained table. Failures and retries are tracked per table,
-  so a re-run never re-deletes an already-cleaned table and one table's
-  failure does not block the others.
+- **Namespace (schema) drops** are *not* a cascade: the Iceberg REST spec
+  requires a namespace to be empty before it can be dropped, so the client
+  drops each table first. Every such `DELETE …?purgeRequested=true` enqueues
+  its own purge job, and the namespace drop itself touches no data files.
+  There is no namespace-level purge job.
 - **Views** are a planned follow-up. A view carries no data files — cleanup
   only removes its `metadata.json` — so it slots into the same job table
-  (adding an `object_type` column) with the same tombstone and cascade rules
-  when added.
+  (adding an `object_type` column) with the same tombstone rule when added.
 
 ### 5.9 Events and observability
 
@@ -465,7 +465,6 @@ only as a rollback flag.
 - [ ] Implement the worker pool: CAS claiming with heartbeat ownership (`FOR UPDATE SKIP LOCKED` where available), heartbeat renewal, streaming file deletion, retry state machine (re-claim failed jobs on later poll ticks, give up at `max-attempts`)
 - [ ] Honor the `X-Gravitino-Async-Purge` request header and wire both paths into `IcebergTableOperationExecutor.dropTable`
 - [ ] Add observability (§5.9): metrics and the informative `ErrorResponse` message on the §5.7 `409`; operator read path in 1.3 is direct DB query
-- [ ] Namespace-drop cascade for tables (one job per contained table)
 - [ ] Enforce tombstone semantics (§5.7): on `createTable`/`registerTable`, reject with `409` when an active job exists (`idx_object` lookup on the request thread)
 
 ### Phase 1 (1.3): Testing
@@ -478,7 +477,7 @@ only as a rollback flag.
 
 ### Phase 2 (post-1.3)
 - [ ] Add purge events (§5.9): `IcebergPurgeStartedEvent`, `IcebergPurgeCompletedEvent`, `IcebergPurgeFailedEvent`
-- [ ] View support (§5.8): `object_type='VIEW'` cleanup (metadata-only), the view tombstone rule, and namespace cascade over views
+- [ ] View support (§5.8): `object_type='VIEW'` cleanup (metadata-only) and the view tombstone rule
 - [ ] Read-only `metalakes/{metalake}/catalogs/{catalog}/cleanups` management endpoint (§5.9): REST resource, DTOs, authorization, client support, docs, tests. Filtered list keyed by object identifier; no by-id fetch
 
 ---

--- a/design-docs/async-iceberg-rest-hard-deletion.md
+++ b/design-docs/async-iceberg-rest-hard-deletion.md
@@ -279,12 +279,16 @@ deletes in bounded batches:
 TableMetadata meta = TableMetadataParser.read(io, job.metadataLocation());
 try (CloseableIterable<String> files = reachableFiles(meta)) {  // lazy, not materialized
   Tasks.foreach(files)
-       .executeWith(deleteExecutor)
+       .executeWith(deleteExecutor)  // sized by delete-threads-per-job (§5.10)
        .retry(perFileRetries)
        .suppressFailureWhenFinished()
        .run(io::deleteFile);
 }
 ```
+
+`deleteExecutor` is per-job and its size is `delete-threads-per-job`
+(§5.10) — raise it to drain a very large table's files faster when purge
+throughput matters.
 
 A separate task sends a heartbeat every `heartbeatTimeout / 3` on the ids
 this worker owns. If the host dies the heartbeat stops; once a row ages past
@@ -414,14 +418,14 @@ only tune the worker pool and retries:
 | Key                                                           | Default  | Description                                                                  |
 |---------------------------------------------------------------|----------|------------------------------------------------------------------------------|
 | `gravitino.iceberg-rest.async-purge.worker-threads`           | `4`      | Worker pool size per server.                                                 |
+| `gravitino.iceberg-rest.async-purge.delete-threads-per-job`   | `8`      | Parallelism of file deletes within a single job.                             |
 | `gravitino.iceberg-rest.async-purge.poll-interval-ms`         | `5000`   | Worker poll interval.                                                        |
 | `gravitino.iceberg-rest.async-purge.heartbeat-timeout-ms`     | `300000` | Age after which a job with no heartbeat is reclaimable.                      |
 | `gravitino.iceberg-rest.async-purge.max-attempts`             | `5`      | Attempts before `FAILED`.                                                    |
 | `gravitino.iceberg-rest.async-purge.terminal-retention-hours` | `168`    | How long terminal (`SUCCEEDED` / `FAILED`) rows are retained before pruning. |
 
-File-delete parallelism and claim batch size are internal constants with
-sensible defaults; they become config keys only if a deployment demonstrates
-the need.
+The claim batch size is an internal constant with a sensible default; it
+becomes a config key only if a deployment demonstrates the need.
 
 ### 5.11 Security
 

--- a/design-docs/async-iceberg-rest-hard-deletion.md
+++ b/design-docs/async-iceberg-rest-hard-deletion.md
@@ -373,8 +373,9 @@ The async purger additionally emits, via the event listener manager:
 - `IcebergPurgeCompletedEvent` — files deleted, with elapsed time.
 - `IcebergPurgeFailedEvent` — dead-lettered job.
 
-These events are one of the three observability surfaces; the queryable
-status endpoint and metrics are covered in §5.14.
+These events are one observability surface; the metrics and operator read
+paths (direct DB query in 1.3, management endpoint later) are covered in
+§5.14.
 
 ### 5.9 Configuration
 
@@ -513,29 +514,28 @@ blocking job (e.g. *"table `db.t` is being purged (job 123, state
 RUNNING)"*). A standard client needs nothing more — semantically the table
 is deleted — and we add **no** non-standard fields to load/list responses.
 
-**Operators.** Two read paths, both backed by the existing job table (the
-`idx_object` index makes the per-identifier lookup cheap):
+**Operators.** In 1.3 the read path is **direct DB query** of
+`iceberg_purge_job` (the `idx_object` index makes the per-identifier lookup
+cheap), plus the metrics below — both come essentially for free once the
+job table and worker exist. This is enough to answer "is this table still
+being purged / did it fail?" and to triage dead letters (§4) without
+building new HTTP surface under deadline pressure.
 
-- **Management endpoint** (Gravitino admin plane, *not* the Iceberg REST
-  path) — modeled on the existing `metalakes/{metalake}/jobs/runs`
-  convention (hierarchical, metalake/catalog-scoped, job id as a path
-  segment, filters as query params):
-  - `GET /metalakes/{metalake}/catalogs/{catalog}/cleanups?state=&schema=&table=&page…`
-    — list / filter. The object identifier (catalog + schema + table), **not**
-    an opaque job id, is the lookup key — nobody outside the server holds a
-    job id, so there is no by-id fetch.
-  - The per-object question "is this table being purged right now?" (an
-    active row — §5.13 guarantees at most one) or "did its cleanup fail?"
-    (`DEAD_LETTER`) is answered by the filtered list
-    `…/cleanups?schema={schema}&table={table}`.
+A dedicated **management endpoint** (Gravitino admin plane, *not* the
+Iceberg REST path) is **deferred to a later release** — see Phase 2 in §6.
+When added it would follow the `metalakes/{metalake}/jobs/runs` convention
+(hierarchical, metalake/catalog-scoped, filters as query params):
 
-  Each row reports `state`, `attempts` / `max_attempts`, `last_error`,
-  `lease_owner`, `created_by`, and timestamps. **Read-only in v1** — there
-  is no cancel verb (§3.2); the only operator-triggered transition is the
-  register-as-recovery flow (§5.13), which terminates the job as a side
-  effect.
-- **Direct DB query** of `iceberg_purge_job` stays available for ad-hoc
-  inspection and dead-letter triage (§4).
+- `GET /metalakes/{metalake}/catalogs/{catalog}/cleanups?state=&schema=&table=&page…`
+  — list / filter, keyed by object identifier (catalog + schema + table),
+  not an opaque job id (no caller holds one, so there is no by-id fetch).
+  The per-object question is answered by `…/cleanups?schema={s}&table={t}`,
+  with §5.13 guaranteeing at most one active row.
+
+Each row would report `state`, `attempts` / `max_attempts`, `last_error`,
+`lease_owner`, `created_by`, and timestamps. Read-only — there is no cancel
+verb (§3.2); the only operator-triggered transition is the
+register-as-recovery flow (§5.13).
 
 **Automation / monitoring.**
 
@@ -547,9 +547,10 @@ is deleted — and we add **no** non-standard fields to load/list responses.
   any dead-letter ("silently failed to delete") — the two states that would
   otherwise go unnoticed.
 
-`DEAD_LETTER` is the operationally critical state: queryable (endpoint +
-DB), counted (metric), and emitted (event), so a cleanup that exhausts
-retries is always discoverable rather than a silent file leak.
+`DEAD_LETTER` is the operationally critical state: in 1.3 it is queryable
+(DB), counted (metric), and emitted (event) — so a cleanup that exhausts
+retries is always discoverable rather than a silent file leak, even before
+the management endpoint lands.
 
 ---
 
@@ -565,7 +566,7 @@ synchronous path remains only as a rollback flag.
 - [ ] Implement the worker pool: leasing via `FOR UPDATE SKIP LOCKED`, lease renewal, file deletion, retry/backoff state machine
 - [ ] Add the `async-purge.enabled` feature flag and wire both paths into `IcebergTableOperationExecutor.dropTable` (async default, synchronous rollback)
 - [ ] Add purge events: `IcebergPurgeStartedEvent`, `IcebergPurgeCompletedEvent`, `IcebergPurgeFailedEvent`
-- [ ] Add purge observability (§5.14): read-only `metalakes/{metalake}/catalogs/{catalog}/cleanups` management endpoint (filtered list keyed by object identifier) and metrics (`purge.jobs.{pending,running,dead_letter}`, `purge.oldest_pending_age_ms`, `purge.{completed,failed}`); informative `ErrorResponse` message on the §5.13 `409`
+- [ ] Add purge observability (§5.14), low-cost signals only: metrics (`purge.jobs.{pending,running,dead_letter}`, `purge.oldest_pending_age_ms`, `purge.{completed,failed}`) and the informative `ErrorResponse` message on the §5.13 `409`. Operator read path in 1.3 is direct DB query of `iceberg_purge_job`
 - [ ] Extend coverage to views (`object_type='VIEW'`, metadata-only cleanup) and namespace-drop cascade (one job per contained object)
 - [ ] Enforce tombstone semantics (§5.13): on `createTable`/`createView`/`registerTable`, reject with `409` when an active job exists for the identifier (`idx_object` lookup on the request thread)
 - [ ] Add register-table recovery support (§5.7): atomically CAS the matching active job to `CANCELLED` and restore the catalog entry; documentation
@@ -577,6 +578,9 @@ synchronous path remains only as a rollback flag.
 
 ### Phase 1 (1.3): Documentation
 - [ ] Update user-facing documentation in `docs/` (async semantics, config, rollback flag, release notes)
+
+### Phase 2 (post-1.3): Management endpoint
+- [ ] Add the read-only `metalakes/{metalake}/catalogs/{catalog}/cleanups` management endpoint (§5.14): REST resource, DTOs, authorization, client support, docs, and tests. Filtered list keyed by object identifier; no by-id fetch
 
 ---
 

--- a/design-docs/async-iceberg-rest-hard-deletion.md
+++ b/design-docs/async-iceberg-rest-hard-deletion.md
@@ -107,7 +107,39 @@ chose a single async implementation with a synchronous rollback flag.
 | Reuse `RelationalGarbageCollector` | Proven worker/scheduling pattern already in the codebase | Different IO surface (object store vs. JDBC) and failure model (best-effort per-file vs. transactional rows) | **Rejected** — share patterns, not code |
 | External job system only (Quartz / Temporal) | Mature scheduling, retries, observability | Heavy operational burden imposed on every operator | **Rejected** — disproportionate for one deletion workload |
 | Enumerate files at enqueue time | Worker needs no metadata re-read | Enumeration is slow on large tables (defeats the latency goal) and bloats job rows | **Rejected** — store `metadata_location`, re-read at run time |
-| **Single async purger (JDBC job table + worker pool) with a synchronous fallback flag** | Smallest bug surface; reliable, restart-safe, cluster-safe via `SKIP LOCKED`; one code path to test | No built-in extension point — a second strategy would need a follow-up refactor | **Chosen** |
+| Object-store job markers (no DB table) — write a purge-intent object to S3, workers `LIST` and claim via conditional write (`If-None-Match`) | No schema / migration; co-located with the data | See below | **Rejected** — higher net complexity for Gravitino |
+| **Single async purger (JDBC job table + worker pool) with a synchronous fallback flag** | Smallest bug surface; reliable, restart-safe, cluster-safe via `SKIP LOCKED` (CAS fallback elsewhere); one code path to test | No built-in extension point — a second strategy would need a follow-up refactor | **Chosen** |
+
+#### Why not an S3-only control plane (no DB table)?
+
+Technically feasible — S3 has supported conditional writes (`If-None-Match` /
+`If-Match`) since 2024, so workers could compare-and-swap a lease object to
+claim a job without a relational backend. We rejected it because it *raises*
+net complexity for Gravitino rather than lowering it:
+
+- **Coordination is harder, not easier.** A DB gives `SELECT … FOR UPDATE SKIP
+  LOCKED` (or the CAS fallback in §5.4) for free. S3 forces us to hand-roll
+  lease acquisition *and* lease renewal on top of conditional writes and
+  object metadata.
+- **No scheduling primitive.** Backoff / `next_attempt_at` is one indexed
+  `WHERE` clause in SQL. With markers there is no index — state and timestamps
+  must be encoded into object keys or metadata and discovered by `LIST`, which
+  is slow and billed per request as the job count grows.
+- **Fragmented across storage backends.** One server serves many catalogs
+  across S3 / GCS / ADLS. A single job table is a uniform control plane;
+  object markers either fragment per-bucket (no cross-cloud view) or require a
+  dedicated control bucket, adding a new dependency and credential surface.
+- **Dead-letter and audit.** Operators can query a DB table directly; markers
+  need separate tooling.
+- **The DB is already there.** Gravitino runs a relational metastore, so its
+  connection pool, migration framework, and transaction management are
+  existing infrastructure — one extra table is low marginal cost. S3-only
+  would *remove* a uniform, strongly-consistent coordination primitive and
+  replace it with an eventually-consistent, per-bucket one we maintain
+  ourselves. It would only pay off in a deployment with no relational backend,
+  which is not Gravitino's case. The lower-complexity way to drop the table, if
+  desired, is §8.4 (fold lease/retry fields onto a catalog tombstone row), not
+  a move to object-store markers.
 
 ---
 

--- a/design-docs/async-iceberg-rest-hard-deletion.md
+++ b/design-docs/async-iceberg-rest-hard-deletion.md
@@ -126,9 +126,9 @@ doubles as the name-reuse tombstone (§5.7).
             │
             ▼
   IcebergTableOperationExecutor.dropTable
-            │  X-Gravitino-Async-Purge header (default: true)
+            │  X-Gravitino-Async-Purge header (absent ⇒ async)
       ┌─────┴───────────────┐
-      │ true (default)      │ X-Gravitino-Async-Purge: false
+      │ header absent       │ X-Gravitino-Async-Purge: false
       ▼                     ▼
  persist iceberg_purge_job   CatalogUtil.dropTableData
  row, return 204             (synchronous, on request thread)
@@ -141,10 +141,11 @@ doubles as the name-reuse tombstone (§5.7).
    → SUCCEEDED | FAILED
 ```
 
-The header is a boolean whose value is `true` or `false`; it defaults to
-`true`, so async is the default path. The synchronous path is retained only
-as a per-request fallback a client opts into with `X-Gravitino-Async-Purge:
-false`. The header name uses canonical HTTP casing (each word capitalized).
+The header is optional and has no default value: when it is **absent** —
+which is the case for any standard Iceberg client — the drop is async. A
+client opts into the synchronous fallback by sending
+`X-Gravitino-Async-Purge: false` (the header name uses canonical HTTP casing,
+each word capitalized).
 
 ### 5.2 User flow
 
@@ -407,7 +408,7 @@ land.
 
 Whether a given drop runs asynchronously is **not** a server config — it is a
 per-request **client** choice via the `X-Gravitino-Async-Purge` header
-(default async; `false` selects synchronous deletion). The server-side keys
+(absent ⇒ async; `false` selects synchronous deletion). The server-side keys
 only tune the worker pool and retries:
 
 | Key                                                           | Default  | Description                                                                  |

--- a/design-docs/async-iceberg-rest-hard-deletion.md
+++ b/design-docs/async-iceberg-rest-hard-deletion.md
@@ -21,7 +21,7 @@
 
 | Field    | Value                                                   |
 | -------- | ------------------------------------------------------- |
-| Status   | Draft                                                   |
+| Status   | Complete                                                |
 | Authors  | @roryqi                                                 |
 | Created  | 2026-05-19                                              |
 | Module   | `iceberg/iceberg-rest-server`, `iceberg/iceberg-common` |

--- a/design-docs/async-iceberg-rest-hard-deletion.md
+++ b/design-docs/async-iceberg-rest-hard-deletion.md
@@ -211,11 +211,9 @@ CREATE TABLE IF NOT EXISTS `iceberg_purge_job` (
   `file_io_props`     MEDIUMTEXT    NOT NULL COMMENT 'JSON',
   `state`             VARCHAR(16)   NOT NULL COMMENT 'PENDING|RUNNING|SUCCEEDED|FAILED',
   `attempts`          INT(10)       NOT NULL DEFAULT 0,
-  `last_error`        TEXT          NULL,
   `heartbeat_at`      BIGINT(20)    NULL COMMENT 'last heartbeat from the worker; NULL when unclaimed',
-  `created_at`        BIGINT(20)    NOT NULL,
-  `created_by`        VARCHAR(128)  NOT NULL,
-  `updated_at`        BIGINT(20)    NOT NULL,
+  `created_by`        VARCHAR(128)  NOT NULL COMMENT 'principal that requested the drop (audit)',
+  `updated_at`        BIGINT(20)    NOT NULL COMMENT 'last state change; drives poll ordering and terminal-row pruning',
   PRIMARY KEY (`id`),
   KEY `idx_state_updated` (`state`, `updated_at`),
   KEY `idx_object` (`catalog_name`, `namespace`, `table_name`, `state`)
@@ -391,9 +389,10 @@ is the `iceberg_purge_job` row, exposed without touching the wire contract:
   §5.7 `409` on a same-identifier `createTable` / `register`, whose
   `ErrorResponse.message` names the blocking job.
 - **Operators** query `iceberg_purge_job` directly (the `idx_object` index
-  makes the per-identifier lookup cheap), plus the metrics below. This is
-  enough to answer "still purging / failed?" and triage dead letters without
-  new HTTP surface. A read-only management endpoint is deferred to Phase 2.
+  makes the per-identifier lookup cheap), plus the metrics below; the failure
+  reason for a `FAILED` job is in the worker's logs. This is enough to answer
+  "still purging / failed?" without new HTTP surface. A read-only management
+  endpoint is deferred to Phase 2.
 - **Metrics**: gauges `purge.jobs.{pending,running,failed}` and
   `purge.oldest_pending_age_ms`; counters `purge.{completed,failed}`. These
   let operators alert on a growing backlog or any `FAILED` job — the two

--- a/design-docs/async-iceberg-rest-hard-deletion.md
+++ b/design-docs/async-iceberg-rest-hard-deletion.md
@@ -137,7 +137,7 @@ doubles as the name-reuse tombstone (§5.7).
  worker pool (any replica)
    claims job via CAS UPDATE (heartbeat ownership)
    → rebuild snapshot graph from metadata_location
-   → stream + delete every reachable file, retry on later poll ticks
+   → stream + delete every reachable file, retry on later polls
    → SUCCEEDED | FAILED
 ```
 
@@ -160,7 +160,7 @@ each word capitalized).
    table is immediately absent from `LIST` and `HEAD` returns `404`.
 4. A worker on any replica claims the job, rebuilds the snapshot graph from
    `metadata_location`, and streams through every reachable file deleting
-   it, retrying transient failures on later poll ticks.
+   it, retrying transient failures on later polls.
 5. On success the job is `SUCCEEDED`; on terminal failure it lands in
    `FAILED` for operator inspection (queryable in the job table, §5.9).
 
@@ -227,7 +227,7 @@ snapshot graph deterministically when the worker runs.
 
 A single column drives retries: `attempts` counts failures so the worker
 gives up at the retry ceiling. A failed job returns to `PENDING` and is
-re-claimed on a later poll tick, so the poll cadence (`poll-interval-ms`,
+re-claimed on a later poll, so the poll cadence (`poll-interval-ms`,
 §5.10) is the retry interval — no separate scheduling column is needed. The
 ceiling is a config (`max-attempts`, §5.10), not a per-row `max_attempts`
 column, since it is the same for every job.
@@ -284,6 +284,20 @@ fallback (H2, older MySQL). `SKIP LOCKED` is purely an optimization — the
 claiming `UPDATE` is the serialization point, so two replicas can never claim
 the same job. We do not use DB-specific advisory locks.
 
+**Worker loop (one free thread):**
+
+1. **Poll & claim.** Read the candidate window above and CAS the first
+   winnable row to `RUNNING` with a fresh `heartbeat_at`. If nothing is
+   claimable, wait `poll-interval-ms` and repeat.
+2. **Load metadata.** `TableMetadataParser.read(io, metadata_location)`. A
+   transient failure releases the job for retry; a terminal one fails it
+   (§5.6).
+3. **Stream & delete.** Walk the snapshot graph lazily and delete every
+   reachable file through the shared `deleteExecutor`; `NotFoundException`
+   counts as deleted. A background task keeps `heartbeat_at` fresh throughout.
+4. **Finish.** Once every reachable file is gone the job is `SUCCEEDED`
+   (§5.6). The thread then loops back to step 1.
+
 Execution mirrors `CatalogHandlers.purgeTable`, but **streams** the
 reachable files instead of materializing them. A large table can reference
 millions of data files, so the worker walks the snapshot graph lazily and
@@ -315,18 +329,34 @@ this worker owns. If the host dies the heartbeat stops; once a row ages past
 Per-file failures are logged but do not fail the whole job — the
 synchronous purge has the same "best effort" stance. A job fails only if the
 **metadata phase** fails. `NotFoundException` from `deleteFile` counts as
-success. A transient failure goes back to `PENDING` and is retried on a
-later poll tick (§5.5), incrementing `attempts` each time; when `attempts`
+success. A transient failure goes back to `PENDING` and is retried when a
+free thread next polls (§5.5), incrementing `attempts` each time; when `attempts`
 reaches `max-attempts` the job goes to `FAILED` instead of `PENDING`. A
 clearly terminal failure skips the retries and goes straight to `FAILED`.
 
 | Outcome                                              | Action                                                                                |
 |------------------------------------------------------|---------------------------------------------------------------------------------------|
 | All files deleted (or already gone)                  | `state='SUCCEEDED'`                                                                    |
-| Transient failure, `attempts < max-attempts`         | `attempts++`, back to `PENDING`, `heartbeat_at=NULL`; re-claimed on a later poll tick  |
+| Transient failure, `attempts < max-attempts`         | `attempts++`, back to `PENDING`, `heartbeat_at=NULL`; re-claimed on a later poll       |
 | Transient failure, `attempts` reaches `max-attempts` | `attempts++` → `FAILED` (gave up retrying)                                             |
 | Terminal failure (e.g. metadata gone/corrupt)        | → `FAILED` immediately; retrying cannot help                                           |
 | Worker killed mid-job                                | `RUNNING` row's heartbeat goes stale; another worker reclaims; deletes are idempotent  |
+
+**After `SUCCEEDED`.** The files are gone, so the tombstone lifts at once:
+`createTable` / `register` at the identifier succeed again (§5.7). The
+`purge.completed` counter increments and the row is pruned
+`terminal-retention-hours` later (§5.10).
+
+**After `FAILED`.** `FAILED` is terminal — the poll never re-selects it, so
+the worker stops touching the job. The tombstone also lifts (§5.7), so a
+failed cleanup never permanently wedges the name; the cost is that any files
+the job did not delete are now an orphaned leak. The failure is therefore
+made loud rather than silent: it increments `purge.failed`, the row stays
+queryable (§5.9), and the reason is in the worker logs. An operator reclaims
+the leaked files out of band — a manual delete or a storage lifecycle rule on
+the table's prefix — and then drops the row, or lets it prune after
+`terminal-retention-hours`. There is no automatic re-drive in 1.3;
+re-enqueueing a `FAILED` cleanup is a manual operator action.
 
 Restart handling falls out of the durable job table plus the heartbeat
 model — no separate mechanism:
@@ -487,7 +517,7 @@ only as a rollback flag.
 ### Phase 1 (1.3): Async purge core
 - [ ] Add the `iceberg_purge_job` schema and migrations (MySQL, H2, PostgreSQL)
 - [ ] Implement `IcebergPurgeJobStore` enqueue path (persist job, return)
-- [ ] Implement the worker pool: CAS claiming with heartbeat ownership (`FOR UPDATE SKIP LOCKED` where available), heartbeat renewal, streaming file deletion, retry state machine (re-claim failed jobs on later poll ticks, give up at `max-attempts`)
+- [ ] Implement the worker pool: CAS claiming with heartbeat ownership (`FOR UPDATE SKIP LOCKED` where available), heartbeat renewal, streaming file deletion, retry state machine (re-claim failed jobs on later polls, give up at `max-attempts`)
 - [ ] Honor the `X-Gravitino-Async-Purge` request header and wire both paths into `IcebergTableOperationExecutor.dropTable`
 - [ ] Add observability (§5.9): metrics and the informative `ErrorResponse` message on the §5.7 `409`; operator read path in 1.3 is direct DB query
 - [ ] Enforce tombstone semantics (§5.7): on `createTable`/`registerTable`, reject with `409` when an active job exists (`idx_object` lookup on the request thread)

--- a/design-docs/async-iceberg-rest-hard-deletion.md
+++ b/design-docs/async-iceberg-rest-hard-deletion.md
@@ -61,86 +61,58 @@ different failure model — kept separate.
 ## 2. Goals
 
 1. **Fast response**: `DELETE … ?purgeRequested=true` returns at typical
-   request latency (target p99 < 500 ms, and < 5 s even for the largest
+   request latency (target p99 < 500 ms, < 5 s even for the largest
    tables) regardless of table size.
-2. **Operational simplicity**: Ship a single async deletion path with the
-   smallest possible bug surface; retain the synchronous path behind a
-   feature flag purely for rollback, not as a parallel product surface.
+2. **Operational simplicity**: Ship a single async deletion path; retain
+   the synchronous path behind a flag purely for rollback.
 3. **Reliable deletion**: The async path deletes every file the
-   synchronous purge would have deleted, retries transient failures, and
-   survives restarts and replica failover.
+   synchronous purge would have, retries transient failures, and survives
+   restarts and replica failover.
 4. **Wire compatibility**: No change to the Iceberg REST wire protocol.
 5. **Request-thread authorization**: Authorization runs on the request
    thread, never deferred.
-6. **Uniform object coverage**: Tables and namespace (schema) drops flow
-   through the same async cleanup mechanism. Views reuse the same mechanism
-   but are a planned follow-up, not part of the initial scope (§5.6).
 
 ---
 
 ## 3. Non-Goals
 
-1. **Native soft-delete / undrop semantics**: This design only delivers
-   async *hard* deletion. Full soft-delete / undrop semantics are a
-   follow-up requirement; §5.7 records the seam they build on so that work
-   stays a small extension rather than a separate V2 mechanism.
-2. **Purge cancellation (v1)**: User-initiated cancellation of in-flight
-   purges is out of scope for v1; it needs a control API and lifecycle
-   states we can add later without breaking the design.
+1. **Native soft-delete / undrop semantics**: This design delivers async
+   *hard* deletion only. Full soft-delete / undrop is a follow-up; §5.7
+   records the seam it builds on.
+2. **Purge cancellation**: User-initiated cancellation of in-flight purges
+   is out of scope; it needs a control API and lifecycle states we can add
+   later without breaking this design.
 3. **Third-party deletion plugins**: We ship one async implementation. A
-   pluggable extension point is explicitly *not* built now — see §4 for
-   why, and the conditions under which we would revisit it.
+   pluggable extension point is explicitly *not* built now — see §4.
 
 ---
 
 ## 4. Solution Investigations
 
-The earlier draft proposed a pluggable `IcebergPurger` SPI. Review
-feedback (PR #11152) pushed back: the PRD does not ask for an SPI, no
-second implementation is in flight, and the competitive frame against
-Polaris is "simpler design with smaller bug surface." We re-evaluated and
-chose a single async implementation with a synchronous rollback flag.
+An earlier draft proposed a pluggable `IcebergPurger` SPI. Review feedback
+pushed back: no second implementation is in flight, and the goal is a
+simpler design with a smaller bug surface. We chose a single async
+implementation with a synchronous rollback flag.
 
 | Approach | Pros | Cons | Decision |
 |----------|------|------|----------|
 | Synchronous only (status quo) | Simplest; strongest "deleted means gone" guarantee | Exceeds HTTP timeouts, saturates Jetty, no retry/audit on large tables | **Rejected** — the problem we are solving |
-| Pluggable `IcebergPurger` SPI (factory + classpath loading + context) | Extensible to object-store batch / audit-only without code changes | Real added surface (SPI, discovery factory, context) with **no** second implementation in flight; widens the bug surface against the PRD's "smaller surface" goal | **Rejected** — revisit only when a second implementation has a real customer behind it |
-| Reuse `RelationalGarbageCollector` | Proven worker/scheduling pattern already in the codebase | Different IO surface (object store vs. JDBC) and failure model (best-effort per-file vs. transactional rows) | **Rejected** — share patterns, not code |
-| External job system only (Quartz / Temporal) | Mature scheduling, retries, observability | Heavy operational burden imposed on every operator | **Rejected** — disproportionate for one deletion workload |
-| Enumerate files at enqueue time | Worker needs no metadata re-read | Enumeration is slow on large tables (defeats the latency goal) and bloats job rows | **Rejected** — store `metadata_location`, re-read at run time |
-| Object-store job markers (no DB table) — write a purge-intent object to S3, workers `LIST` and claim via conditional write (`If-None-Match`) | No schema / migration; co-located with the data | See below | **Rejected** — higher net complexity for Gravitino |
-| **Single async purger (JDBC job table + worker pool) with a synchronous fallback flag** | Smallest bug surface; reliable, restart-safe, cluster-safe via `SKIP LOCKED` (CAS fallback elsewhere); one code path to test | No built-in extension point — a second strategy would need a follow-up refactor | **Chosen** |
+| Pluggable `IcebergPurger` SPI | Extensible without code changes | Real added surface (SPI, discovery factory, context) with **no** second implementation in flight | **Rejected** — revisit when a second implementation has a real customer |
+| Reuse `RelationalGarbageCollector` | Proven worker/scheduling pattern | Different IO surface (object store vs. JDBC) and failure model | **Rejected** — share patterns, not code |
+| External job system (Quartz / Temporal) | Mature scheduling, retries, observability | Heavy operational burden on every operator | **Rejected** — disproportionate for one workload |
+| Enumerate files at enqueue time | Worker needs no metadata re-read | Slow on large tables (defeats the latency goal), bloats job rows | **Rejected** — store `metadata_location`, re-read at run time |
+| Object-store job markers (no DB table) | No schema / migration | Hand-rolled lease + renewal, no indexed scheduling, fragments per-bucket | **Rejected** — higher net complexity (see below) |
+| **JDBC job table + worker pool, synchronous fallback flag** | Smallest bug surface; restart-safe and cluster-safe via CAS claim; one code path to test | No built-in extension point | **Chosen** |
 
-#### Why not an S3-only control plane (no DB table)?
-
-Technically feasible — S3 has supported conditional writes (`If-None-Match` /
-`If-Match`) since 2024, so workers could compare-and-swap a lease object to
-claim a job without a relational backend. We rejected it because it *raises*
-net complexity for Gravitino rather than lowering it:
-
-- **Coordination is harder, not easier.** A DB gives `SELECT … FOR UPDATE SKIP
-  LOCKED` (or the CAS fallback in §5.4) for free. S3 forces us to hand-roll
-  lease acquisition *and* lease renewal on top of conditional writes and
-  object metadata.
-- **No scheduling primitive.** Backoff / `next_attempt_at` is one indexed
-  `WHERE` clause in SQL. With markers there is no index — state and timestamps
-  must be encoded into object keys or metadata and discovered by `LIST`, which
-  is slow and billed per request as the job count grows.
-- **Fragmented across storage backends.** One server serves many catalogs
-  across S3 / GCS / ADLS. A single job table is a uniform control plane;
-  object markers either fragment per-bucket (no cross-cloud view) or require a
-  dedicated control bucket, adding a new dependency and credential surface.
-- **Dead-letter and audit.** Operators can query a DB table directly; markers
-  need separate tooling.
-- **The DB is already there.** Gravitino runs a relational metastore, so its
-  connection pool, migration framework, and transaction management are
-  existing infrastructure — one extra table is low marginal cost. S3-only
-  would *remove* a uniform, strongly-consistent coordination primitive and
-  replace it with an eventually-consistent, per-bucket one we maintain
-  ourselves. It would only pay off in a deployment with no relational backend,
-  which is not Gravitino's case. If the goal is fewer moving parts, the lever is
-  to keep the single job table doing double duty — it already serves as the
-  name-reuse tombstone (§5.13) — not a move to object-store markers.
+**Why not an S3-only control plane?** Conditional writes (`If-None-Match`)
+let workers claim jobs without a relational backend, but it *raises* net
+complexity for Gravitino: a DB gives lease acquisition and indexed backoff
+scheduling (`next_attempt_at`) for free, whereas S3 forces hand-rolled
+leases discovered by slow, per-request `LIST`. One server fronts many
+catalogs across S3 / GCS / ADLS, so a single job table is a uniform control
+plane; object markers fragment per-bucket. Gravitino already runs a
+relational metastore, so one extra table is low marginal cost — and it
+doubles as the name-reuse tombstone (§5.7).
 
 ---
 
@@ -162,17 +134,37 @@ net complexity for Gravitino rather than lowering it:
       │
       ▼
  worker pool (any replica)
-   claims job via FOR UPDATE SKIP LOCKED (heartbeat ownership)
+   claims job via CAS UPDATE (heartbeat ownership)
    → rebuild snapshot graph from metadata_location
    → stream + delete every reachable file, retry w/ backoff
    → SUCCEEDED | FAILED
 ```
 
-Async is the default deletion path. The synchronous path is retained only
-as a per-request fallback that a client opts into with
-`X-Gravitino-Async-Purge: false`.
+Async is the default path. The synchronous path is retained only as a
+per-request fallback a client opts into with `X-Gravitino-Async-Purge: false`.
 
-### 5.2 Request-path interaction
+### 5.2 User flow
+
+1. A client issues
+   `DELETE /v1/{prefix}/namespaces/{ns}/tables/{t}?purgeRequested=true`.
+   No client change is needed for async; strict synchronous deletion is
+   selected by adding `X-Gravitino-Async-Purge: false`.
+2. The server runs authorization on the request thread, loads the table
+   metadata location, drops the catalog entry, and persists an
+   `iceberg_purge_job` row.
+3. The server responds `204 No Content` within typical request latency. The
+   table is immediately absent from `LIST` and `HEAD` returns `404`.
+4. A worker on any replica claims the job, rebuilds the snapshot graph from
+   `metadata_location`, and streams through every reachable file deleting
+   it, retrying transient failures with backoff.
+5. On success the job is `SUCCEEDED`; on terminal failure it lands in
+   `FAILED` for operator inspection. Listeners observe
+   `IcebergPurge{Started,Completed,Failed}Event` throughout.
+6. *(Recovery)* If the drop was a mistake, the table can be re-registered at
+   the stored metadata location any time before the worker deletes the
+   files; this also cancels the matching job (§5.7).
+
+### 5.3 Request-path interaction
 
 ```java
 public void dropTable(IcebergRequestContext ctx, TableIdentifier id,
@@ -200,15 +192,13 @@ public void dropTable(IcebergRequestContext ctx, TableIdentifier id,
 ```
 
 Order matters on the async path: load metadata location → drop catalog
-entry → enqueue the job. A purge job exists only for a table that is
-already gone from the catalog. `fileIoProperties` is captured at enqueue
-time so the worker can reconstruct `FileIO` even if the catalog is later
-reconfigured.
+entry → enqueue the job. A purge job exists only for a table already gone
+from the catalog. `fileIoProperties` is captured at enqueue time so the
+worker can reconstruct `FileIO` even if the catalog is later reconfigured.
+The enqueued row also serves as the **tombstone** that blocks name reuse
+while the files still exist (§5.7).
 
-The enqueued job row also serves as the **tombstone** that blocks name
-reuse while the files still exist — see §5.13.
-
-### 5.3 Schema — `iceberg_purge_job`
+### 5.4 Schema — `iceberg_purge_job`
 
 ```sql
 CREATE TABLE IF NOT EXISTS `iceberg_purge_job` (
@@ -216,81 +206,45 @@ CREATE TABLE IF NOT EXISTS `iceberg_purge_job` (
   `metalake_name`     VARCHAR(128)  NOT NULL,
   `catalog_name`      VARCHAR(128)  NOT NULL,
   `namespace`         VARCHAR(512)  NOT NULL,
-  `object_name`       VARCHAR(256)  NOT NULL,
-  `object_type`       VARCHAR(16)   NOT NULL COMMENT 'TABLE|VIEW',
+  `table_name`        VARCHAR(256)  NOT NULL,
   `metadata_location` VARCHAR(1024) NOT NULL,
   `file_io_impl`      VARCHAR(256)  NOT NULL,
   `file_io_props`     MEDIUMTEXT    NOT NULL COMMENT 'JSON',
-  `state`             VARCHAR(16)   NOT NULL COMMENT 'PENDING|RUNNING|SUCCEEDED|FAILED|CANCELLED; a RUNNING row is being deleted while its heartbeat_at stays fresh',
+  `state`             VARCHAR(16)   NOT NULL COMMENT 'PENDING|RUNNING|SUCCEEDED|FAILED|CANCELLED',
   `attempts`          INT(10)       NOT NULL DEFAULT 0,
-  `max_attempts`      INT(10)       NOT NULL,
   `last_error`        TEXT          NULL,
-  `heartbeat_at`      BIGINT(20)    NULL COMMENT 'last heartbeat from the processing worker; NULL when unclaimed',
+  `heartbeat_at`      BIGINT(20)    NULL COMMENT 'last heartbeat from the worker; NULL when unclaimed',
   `next_attempt_at`   BIGINT(20)    NOT NULL,
   `created_at`        BIGINT(20)    NOT NULL,
   `created_by`        VARCHAR(128)  NOT NULL,
   `updated_at`        BIGINT(20)    NOT NULL,
   PRIMARY KEY (`id`),
   KEY `idx_state_next_attempt` (`state`, `next_attempt_at`),
-  KEY `idx_object` (`catalog_name`, `namespace`, `object_name`, `state`)
+  KEY `idx_object` (`catalog_name`, `namespace`, `table_name`, `state`)
 ) ENGINE=InnoDB;
 ```
 
-We store only `metadata_location`, not the file list — enumeration is
-slow on large tables, and `TableMetadataParser.read(io, location)`
-rebuilds the snapshot graph deterministically when the worker runs.
+We store only `metadata_location`, not the file list — enumeration is slow
+on large tables, and `TableMetadataParser.read(io, location)` rebuilds the
+snapshot graph deterministically when the worker runs. The retry ceiling is
+a config (`max-attempts`, §5.10), not a per-row column.
 
 Migration: `upgrade-1.2.0-to-1.3.0-mysql.sql` (and H2 / PostgreSQL).
 
-### 5.4 Worker pool
+### 5.5 Worker pool and multi-replica ownership
 
 A `ScheduledThreadPoolExecutor` modeled on `RelationalGarbageCollector`.
-Each tick:
-
-```sql
-SELECT * FROM iceberg_purge_job
- WHERE next_attempt_at <= :now
-   AND ( state = 'PENDING'
-      OR (state = 'RUNNING'
-          AND (heartbeat_at IS NULL OR heartbeat_at < :now - :heartbeatTimeout)) )
- ORDER BY next_attempt_at LIMIT :batch
- FOR UPDATE SKIP LOCKED;
-```
-
-then claims each candidate by moving it to `state='RUNNING'` with
-`heartbeat_at=:now`. A job is `PENDING` while it waits (just enqueued, or
-backing off for a retry); a `RUNNING` row with a fresh heartbeat is being
-actively deleted; and a `RUNNING` row whose heartbeat has gone stale was
-abandoned by a dead or stalled worker and is reclaimable. `SKIP LOCKED` is a
-performance optimization (it avoids lock waiting between replicas), not the
-correctness guarantee — see the ownership model below.
-
-#### Multi-replica ownership model
-
 Ownership is tracked by a **heartbeat** alone: the worker that claims a job
-keeps refreshing `heartbeat_at` while it runs, and remembers the ids it is
-processing in memory (no owner column — a stale row is reclaimable by anyone,
-which is exactly the failover behavior we want). A job is considered
-abandoned — and becomes reclaimable — once its heartbeat is older than
-`heartbeatTimeout`. Three distinct races, handled deliberately:
+keeps refreshing `heartbeat_at` while it runs and remembers the ids it owns
+in memory (no owner column — a stale row is reclaimable by anyone, which is
+exactly the failover behavior we want). A job is abandoned, and reclaimable,
+once its heartbeat is older than `heartbeatTimeout`.
 
-1. **Two replicas claim the same job.** The claiming `UPDATE` is the
-   serialization point, so this cannot happen — see the CAS rule below. Any
-   number of replicas can run the worker with no external coordinator.
-2. **A worker stalls while still alive** (long GC, network partition) and
-   its heartbeat goes stale. Another replica reclaims, and both may delete
-   the same files concurrently. We *accept* this race rather than eliminate
-   it: deletes are idempotent and `NotFoundException` counts as success
-   (§5.5), so the only cost is duplicated work, never incorrect results.
-   This is what lets failover stay coordinator-free.
-3. **A replica dies mid-job.** Identical to case 2 from the survivors' point
-   of view — the heartbeat stops, goes stale, and the job is reclaimed.
-
-To stay portable, claiming is expressed as an optimistic compare-and-swap that
-works on **every** SQL backend, not just those with `SKIP LOCKED`:
+Claiming is an optimistic compare-and-swap `UPDATE` that works on **every**
+SQL backend:
 
 ```sql
--- read candidates (no lock required)
+-- read candidates
 SELECT id FROM iceberg_purge_job
  WHERE next_attempt_at <= :now
    AND ( state = 'PENDING'
@@ -307,23 +261,21 @@ UPDATE iceberg_purge_job
           AND (heartbeat_at IS NULL OR heartbeat_at < :now - :heartbeatTimeout)) );
 ```
 
-A loser sees `affected_rows = 0` and moves to the next candidate. Where
-`SKIP LOCKED` is available (MySQL 8+, PostgreSQL), the worker uses the
-`FOR UPDATE SKIP LOCKED` form shown above to skip locked rows up front and
-cut contention; where it is not (H2, older MySQL), it falls back to the CAS
-form. Both are correct; `SKIP LOCKED` is purely an optimization. We do not use
-DB-specific advisory locks, whose semantics differ across engines.
+A loser sees `affected_rows = 0` and moves on. Where `SELECT … FOR UPDATE
+SKIP LOCKED` is available (MySQL 8+, PostgreSQL) the worker uses it to cut
+contention up front; the CAS form is the portable fallback (H2, older
+MySQL). `SKIP LOCKED` is purely an optimization — the claiming `UPDATE` is
+the serialization point, so two replicas can never claim the same job. We do
+not use DB-specific advisory locks.
 
 Execution mirrors `CatalogHandlers.purgeTable`, but **streams** the
 reachable files instead of materializing them. A large table can reference
-millions of data files, so the worker walks the snapshot graph lazily
-(manifest list → manifests → data files) and deletes in bounded batches,
-never holding the full file set in memory:
+millions of data files, so the worker walks the snapshot graph lazily and
+deletes in bounded batches:
 
 ```java
 TableMetadata meta = TableMetadataParser.read(io, job.metadataLocation());
-// reachableFiles returns a lazy CloseableIterable, not a materialized List
-try (CloseableIterable<String> files = reachableFiles(meta)) {
+try (CloseableIterable<String> files = reachableFiles(meta)) {  // lazy, not materialized
   Tasks.foreach(files)
        .executeWith(deleteExecutor)
        .retry(perFileRetries)
@@ -332,329 +284,213 @@ try (CloseableIterable<String> files = reachableFiles(meta)) {
 }
 ```
 
-A separate task sends a **heartbeat** every `heartbeatTimeout / 3` by
-updating `heartbeat_at=:now` on the job ids this worker is processing. If
-the host dies the heartbeat stops; once a row ages past `heartbeatTimeout`
-another replica reclaims it.
+A separate task sends a heartbeat every `heartbeatTimeout / 3` on the ids
+this worker owns. If the host dies the heartbeat stops; once a row ages past
+`heartbeatTimeout` another replica reclaims it.
 
-### 5.5 Failure model
+### 5.6 Failure model, restart, and crash recovery
 
 Per-file failures are logged but do not fail the whole job — the
-synchronous purge has the same "best effort" stance. A job fails only if
-the **metadata phase** fails.
+synchronous purge has the same "best effort" stance. A job fails only if the
+**metadata phase** fails. `NotFoundException` from `deleteFile` counts as
+success. Backoff: `min(maxBackoff, base * 2^attempts)` with jitter.
 
 | Outcome                            | Action                                                              |
 | ---------------------------------- | ------------------------------------------------------------------- |
 | All files deleted (or already gone) | `state='SUCCEEDED'`                                                |
-| Metadata load failed, transient    | back to `state='PENDING'`, `attempts++`, `next_attempt_at = now + backoff(attempts)`, `heartbeat_at=NULL` |
-| Metadata load failed, terminal     | `attempts++`; if `attempts >= max_attempts` → `state='FAILED'`      |
-| Worker killed mid-job              | `RUNNING` row's heartbeat goes stale; another worker reclaims it; deletes are idempotent (restart story in §5.15) |
-| Recovered via re-register (§5.13)  | Job CAS'd to `state='CANCELLED'`; the worker only claims non-terminal rows, so files are left intact |
+| Metadata load failed, transient    | back to `PENDING`, `attempts++`, `next_attempt_at = now + backoff`, `heartbeat_at=NULL` |
+| Metadata load failed, terminal     | `attempts++`; if `attempts >= max-attempts` → `FAILED`              |
+| Worker killed mid-job              | `RUNNING` row's heartbeat goes stale; another worker reclaims; deletes are idempotent |
+| Recovered via re-register (§5.7)   | Job CAS'd to `CANCELLED`; the worker only claims non-terminal rows, so files stay intact |
 
-`NotFoundException` from `deleteFile` counts as success. Backoff:
-`min(maxBackoff, base * 2^attempts)` with jitter.
+Restart handling falls out of the durable job table plus the heartbeat
+model — no separate mechanism:
 
-### 5.6 Object coverage: tables now, views later
+1. **Nothing in-flight is lost.** The job is committed before the `DELETE`
+   returns; there is no in-memory queue. `PENDING` jobs are picked up on the
+   first tick after boot.
+2. **Orphaned in-flight jobs are reclaimed.** A crash leaves a `RUNNING` row
+   with a stale heartbeat, which the poll already selects; the restarted node
+   or any peer reclaims it via the CAS.
+3. **Re-running a half-finished job is safe.** The worker rebuilds the file
+   set and re-deletes; already-gone files raise `NotFoundException`, counted
+   as success. A crash costs only duplicated work, never corruption.
 
-The job table is object-type aware (the `object_type` column), but the
-initial scope is **tables only**:
+In multi-replica deployments this is seamless. The one rough edge is a
+single-replica restart: the crashed node's jobs sit idle until their
+heartbeat ages past `heartbeatTimeout` before the rebooted process reclaims
+them. We keep `heartbeatTimeout` modest so the resume delay is small; with no
+owner column there is nothing extra to sweep on boot.
 
-- **Namespace (schema) drops** cascade: the server enqueues an independent
-  purge job for each contained table. Failures and retries are tracked per
-  object, so a re-run never re-deletes an already-cleaned table, and one
-  table's failure does not block the others.
-- **Views** are a planned follow-up, not part of the initial scope. A view
-  carries no data files — its cleanup only removes the view's
-  `metadata.json` — so it slots into the same job table with
-  `object_type='VIEW'` when added; the worker, tombstone (§5.13), and
-  cascade paths ship for tables first.
+### 5.7 Name reuse during purge, and recovery
 
-### 5.7 Recovery and the soft-delete seam
+While a purge job for an identifier is non-terminal (`PENDING` or
+`RUNNING`), that identifier is treated as **still occupied** even though its
+catalog entry is already gone. The active `iceberg_purge_job` row *is* the
+tombstone — no second table is needed. The REST server consults the store on
+the request thread (one indexed lookup via `idx_object`):
 
-Because the job stores `metadata_location` and the underlying data /
-metadata files are not touched until the worker runs, a table dropped by
-mistake can be recovered *before its files are deleted* by re-registering
-it at the stored location:
+| Operation | Active job exists | No active job (`SUCCEEDED`/`FAILED`/`CANCELLED`/none) |
+|-----------|-------------------|------------------------------------------------------|
+| `loadTable` / `HEAD`, `alterTable` / commit | `404 NoSuchTableException` | `404` |
+| `createTable` (same identifier) | **`409 Conflict`** — being purged | succeeds |
+| `registerTable` (same identifier) | **`409 Conflict`**, except recovery below | succeeds |
+
+A `SUCCEEDED` job (even before pruning) no longer blocks reuse — the files
+are gone. A `FAILED` job also stops blocking, so a failed cleanup never
+permanently wedges the namespace; operators see the failed row and reclaim
+leaked files out of band. This closes the same-name / same-location recreate
+attack: a recreate cannot expose the dropped table's data, because it is
+refused until the files are deleted. A **namespace** carries no data, so it
+can be recreated freely; tables inside it are guarded individually.
+
+**Recovery.** Because the data / metadata files are untouched until the
+worker runs, a table dropped by mistake can be recovered before its files
+are deleted by re-registering at the stored location:
 
 ```
 POST /v1/{prefix}/namespaces/{ns}/register
 { "name": "<table>", "metadata-location": "<stored metadata_location>" }
 ```
 
-Once the worker deletes the files the table is unrecoverable — which is
-the intended semantics of *hard* delete. A future soft-delete / undrop
-feature layers on top by deferring file deletion for a retention window
-(delaying `next_attempt_at`) on the **same** job row, executor, and
-scheduler, so register-table recovery succeeds throughout the window. This
-keeps that future work a small extension rather than a separate V2
-mechanism.
+Re-registering atomically CAS's the matching active job to `CANCELLED` and
+restores the catalog entry in the same transaction — lifting the tombstone
+and removing the worker-deletes-the-recovered-table race (the worker only
+claims non-terminal rows). This is **recovery-scoped** cancellation only; a
+general "cancel my purge" API stays out of scope (§3).
 
-### 5.8 Events
+Once the worker deletes the files the table is unrecoverable — the intended
+semantics of *hard* delete. A future soft-delete / undrop feature layers on
+top by deferring file deletion for a retention window (delaying
+`next_attempt_at`) on the **same** job row, executor, and scheduler, so
+register-table recovery succeeds throughout the window.
 
-Existing `IcebergDropTableEvent` continues to fire on the REST thread
-with the *requested* purge flag, preserving today's listener contract.
-The async purger additionally emits, via the event listener manager:
+**Concurrency.** The conflict check, the worker's claim, and recovery's
+cancel all serialize on the row's `state`. Recovery's CAS to `CANCELLED` is
+guarded by `state='PENDING'`, and the worker's claim CAS moves
+`PENDING → RUNNING`; they target the same `PENDING` row, so at most one wins.
+A job already `RUNNING` cannot be silently cancelled — recovery's CAS matches
+no row and returns `409` (the caller retries once the job terminates).
+
+### 5.8 Object coverage: tables now, views later
+
+The initial scope is **tables only**.
+
+- **Namespace (schema) drops** cascade: the server enqueues an independent
+  purge job per contained table. Failures and retries are tracked per table,
+  so a re-run never re-deletes an already-cleaned table and one table's
+  failure does not block the others.
+- **Views** are a planned follow-up. A view carries no data files — cleanup
+  only removes its `metadata.json` — so it slots into the same job table
+  (adding an `object_type` column) with the same tombstone and cascade rules
+  when added.
+
+### 5.9 Events and observability
+
+Existing `IcebergDropTableEvent` continues to fire on the REST thread with
+the *requested* purge flag, preserving today's listener contract. The async
+purger additionally emits:
 
 - `IcebergPurgeStartedEvent` — work begins on a job.
 - `IcebergPurgeCompletedEvent` — files deleted, with elapsed time.
 - `IcebergPurgeFailedEvent` — job that exhausted retries (`FAILED`).
 
-These events are one observability surface; the metrics and operator read
-paths (direct DB query in 1.3, management endpoint later) are covered in
-§5.14.
+The source of truth for "is this table still being purged, done, or failed?"
+is the `iceberg_purge_job` row, exposed without touching the wire contract:
 
-### 5.9 Configuration
+- **Iceberg REST clients** observe only that the table is dropped
+  (`404` / omitted from `LIST`). The single purge-specific signal is the
+  §5.7 `409` on a same-identifier `createTable` / `register`, whose
+  `ErrorResponse.message` names the blocking job.
+- **Operators** query `iceberg_purge_job` directly (the `idx_object` index
+  makes the per-identifier lookup cheap), plus the metrics below. This is
+  enough to answer "still purging / failed?" and triage dead letters without
+  new HTTP surface. A read-only management endpoint is deferred to Phase 2.
+- **Metrics**: gauges `purge.jobs.{pending,running,failed}` and
+  `purge.oldest_pending_age_ms`; counters `purge.{completed,failed}`. These
+  let operators alert on a growing backlog or any `FAILED` job — the two
+  conditions that would otherwise go unnoticed.
 
-Whether a given `DELETE …?purgeRequested=true` runs asynchronously is **not**
-a server config — it is a per-request **client** choice via the
-`X-Gravitino-Async-Purge` request header (§5.10): async is the default, and a
-client that needs strict synchronous deletion sends
-`X-Gravitino-Async-Purge: false`.
+`FAILED` is the operationally critical state: it is queryable, counted, and
+emitted, so a cleanup that exhausts retries is always discoverable rather
+than a silent file leak.
 
-The remaining server-side keys only tune the worker pool and retry behavior
-— operational concerns a client cannot set:
+### 5.10 Configuration
 
-| Key                                                  | Default   | Description                                                                              |
-| ---------------------------------------------------- | --------- | ---------------------------------------------------------------------------------------- |
-| `gravitino.iceberg-rest.async-purge.worker-threads`           | `4`       | Worker pool size per server. |
-| `gravitino.iceberg-rest.async-purge.delete-threads-per-job`   | `8`       | Parallelism of file deletes within a single job. |
-| `gravitino.iceberg-rest.async-purge.poll-interval-ms`         | `5000`    | Worker poll interval. |
-| `gravitino.iceberg-rest.async-purge.batch-size`               | `16`      | Jobs claimed per tick. |
-| `gravitino.iceberg-rest.async-purge.heartbeat-timeout-ms`     | `300000`  | Age after which a job with no heartbeat is reclaimable. |
-| `gravitino.iceberg-rest.async-purge.max-attempts`             | `5`       | Attempts before `FAILED`. |
-| `gravitino.iceberg-rest.async-purge.backoff-base-ms`          | `30000`   | Exponential backoff base. |
-| `gravitino.iceberg-rest.async-purge.backoff-max-ms`           | `3600000` | Exponential backoff ceiling. |
-| `gravitino.iceberg-rest.async-purge.completed-retention-hours`| `168`     | How long `SUCCEEDED` rows are retained before pruning. |
+Whether a given drop runs asynchronously is **not** a server config — it is a
+per-request **client** choice via the `X-Gravitino-Async-Purge` header
+(default async; `false` selects synchronous deletion). The server-side keys
+only tune the worker pool and retries:
 
-### 5.10 Backward compatibility (wire)
+| Key                                                       | Default   | Description                                            |
+| --------------------------------------------------------- | --------- | ------------------------------------------------------ |
+| `gravitino.iceberg-rest.async-purge.worker-threads`       | `4`       | Worker pool size per server. |
+| `gravitino.iceberg-rest.async-purge.poll-interval-ms`     | `5000`    | Worker poll interval. |
+| `gravitino.iceberg-rest.async-purge.heartbeat-timeout-ms` | `300000`  | Age after which a job with no heartbeat is reclaimable. |
+| `gravitino.iceberg-rest.async-purge.max-attempts`         | `5`       | Attempts before `FAILED`. |
+| `gravitino.iceberg-rest.async-purge.completed-retention-hours` | `168` | How long `SUCCEEDED` rows are retained before pruning. |
 
-The Iceberg REST spec does not require file deletion to be complete
-before the response. With this design:
-
-- The catalog entry is removed before `204`, so `HEAD` returns `404` and
-  `LIST` no longer includes the table. `CREATE` / `register` at the same
-  identifier is **rejected with `409 Conflict` until the purge job
-  completes** (§5.13), which closes the PRD §2.2 same-name recreate attack.
-- Object-store files may linger until the worker drains. Documented in
-  release notes.
-
-The async-vs-synchronous choice rides on the optional `X-Gravitino-Async-Purge`
-request header. It is a Gravitino extension header, not part of the Iceberg
-REST spec: a standard Iceberg client never sends it and simply gets the async
-default, so the protocol is unchanged. A client needing strict synchronous
-deletion sends `X-Gravitino-Async-Purge: false`.
+File-delete parallelism, claim batch size, and backoff base/ceiling are
+internal constants with sensible defaults; they become config keys only if a
+deployment demonstrates the need.
 
 ### 5.11 Security
 
 - `@AuthorizationExpression` on `dropTable` runs on the request thread,
   unchanged.
 - The worker uses FileIO credentials snapshotted at enqueue time.
-  Credentials that expire before the worker runs (STS tokens, …) need
-  the refresh strategy under discussion in §8.2.
+  Credentials that expire before the worker runs (STS tokens, …) need the
+  refresh strategy under discussion in §8.
 - `iceberg_purge_job` may contain credentials in `file_io_props`; the
   existing Gravitino DB encryption / access controls apply.
 
-### 5.12 User process
+### 5.12 Backward compatibility (wire)
 
-End-to-end flow with async purge (the 1.3 default):
+The Iceberg REST spec does not require file deletion to be complete before
+the response. With this design:
 
-1. Async is the default; no client change is needed to get it. A client that
-   needs strict synchronous deletion adds `X-Gravitino-Async-Purge: false`
-   to the request.
-2. A client issues
-   `DELETE /v1/{prefix}/namespaces/{ns}/tables/{t}?purgeRequested=true`.
-3. The server runs authorization on the request thread, loads the table
-   metadata location, drops the catalog entry, and persists an
-   `iceberg_purge_job` row.
-4. The server responds `204 No Content` within typical request latency
-   (target p99 < 500 ms, < 5 s for the largest tables). The table is
-   immediately absent from `LIST` and `HEAD` returns `404`.
-5. In the background, a worker on any replica claims the job, rebuilds
-   the snapshot graph from `metadata_location`, and streams through every
-   reachable file deleting it, retrying transient failures with exponential
-   backoff.
-6. On success the job is marked `SUCCEEDED`; on terminal failure it lands
-   in `FAILED` for operator inspection. Listeners observe
-   `IcebergPurge{Started,Completed,Failed}Event` throughout.
-7. *(Recovery)* If the drop was a mistake, the table can be re-registered
-   at the stored metadata location any time before the worker deletes the
-   files (§5.7). Re-registering also cancels the matching purge job so the
-   worker never deletes the recovered table's files (§5.13).
+- The catalog entry is removed before `204`, so `HEAD` returns `404` and
+  `LIST` no longer includes the table. `CREATE` / `register` at the same
+  identifier is rejected with `409 Conflict` until the purge job completes
+  (§5.7).
+- Object-store files may linger until the worker drains. Documented in
+  release notes.
 
-### 5.13 Name reuse during purge (tombstone semantics)
-
-This resolves the §8.1 open question. While a purge job for an identifier is
-non-terminal (`PENDING` or `RUNNING`), that identifier is treated as **still
-occupied** even though its catalog entry is already gone. The
-active `iceberg_purge_job` row *is* the tombstone — no second table is
-needed. This is the §8.4 / Q4 "fold the lifecycle onto an existing row"
-idea, scoped to the job row rather than a catalog-backing table (which
-Gravitino does not have for the Iceberg REST surface).
-
-The REST server consults the purge job store **on the request thread**
-(one indexed lookup via `idx_object`) and returns:
-
-| Operation | Active purge job exists for the identifier | No active job (`SUCCEEDED` / `FAILED` / `CANCELLED` / none) |
-|-----------|---------------------------------------------|-----------------------------------------------------|
-| `loadTable` / `HEAD` | `404 NoSuchTableException` (catalog entry already dropped) | `404` |
-| `alterTable` / `updateTable` / commit | `404 NoSuchTableException` | `404` |
-| `createTable` (same identifier) | **`409 Conflict`** — table is being purged | succeeds (brand-new table) |
-| `registerTable` (same identifier) | **`409 Conflict`**, except the recovery path below | succeeds |
-
-"Active" means `state IN ('PENDING','RUNNING')` (terminal states are
-`SUCCEEDED` / `FAILED` / `CANCELLED`). A job in `SUCCEEDED` (even before its
-row is pruned per `completed-retention-hours`) no longer blocks reuse — the files
-are gone, so a recreate is safe. A `FAILED` job also stops blocking, so a
-failed cleanup never permanently wedges the namespace; operators see the
-failed row and reclaim leaked files out of band.
-
-This closes the PRD §2.2 attack directly: a same-name / same-location
-recreate can no longer expose the dropped table's data, because the
-recreate is refused until the data files are deleted. Telling *whether* a
-given identifier is mid-purge, done, or failed is the read-side
-concern handled in §5.14.
-
-The same rule will apply to **views** (`createView` / `replaceView` → `409`
-while a `VIEW` job is active) once view cleanup ships (§5.6). A **namespace**
-carries no data, so it can be recreated freely; any table created inside it
-is still guarded individually by its own job row.
-
-**Recovery under the tombstone.** Because the identifier is now blocked,
-register-as-recovery (§5.7) first lifts the tombstone: re-registering at
-the stored `metadata_location` atomically CAS's the matching active job to
-a terminal `CANCELLED` state and restores the catalog entry in the same
-transaction. Cancelling the job is also what removes the
-worker-deletes-the-recovered-table race — the worker only ever claims
-non-terminal rows. This is **recovery-scoped** cancellation only; a
-general user-facing "cancel my purge" API stays out of scope (§3.2).
-
-**Concurrency.** The create/register conflict check, the worker's claim, and
-recovery's cancel all serialize on the job row's `state`. A `createTable`
-that observes a terminal state (`SUCCEEDED` / `FAILED` / `CANCELLED`)
-proceeds; one that observes `PENDING` or `RUNNING` gets `409`. Recovery's CAS
-to `CANCELLED` is guarded by `state='PENDING'`, and the worker's claim CAS
-moves `PENDING → RUNNING` — they target the same `PENDING` row, so at most
-one wins. A job that has already started running therefore cannot be
-silently cancelled out from under the worker: recovery's CAS matches no row,
-it sees `RUNNING`, and returns `409` (the caller retries once the heartbeat
-goes stale or the job terminates).
-
-### 5.14 Observing in-flight and failed purges
-
-§5.13 keeps the *name* reserved; this section answers the read-side
-question: "the table is gone from the catalog — is it **still being
-purged**, already done, or **failed**?" The source of truth is the
-`iceberg_purge_job` row, exposed to three audiences without touching the
-Iceberg REST wire contract (Goal #4).
-
-**Iceberg REST clients (table owner).** By design they observe only that
-the table is dropped: `loadTable` / `HEAD` → `404`, `LIST` omits it. The
-single purge-specific signal is the §5.13 `409` on a same-identifier
-`createTable` / `register`, whose Iceberg `ErrorResponse.message` names the
-blocking job (e.g. *"table `db.t` is being purged (cleanup job 123 still in
-progress)"*). A standard client needs nothing more — semantically the table
-is deleted — and we add **no** non-standard fields to load/list responses.
-
-**Operators.** In 1.3 the read path is **direct DB query** of
-`iceberg_purge_job` (the `idx_object` index makes the per-identifier lookup
-cheap), plus the metrics below — both come essentially for free once the
-job table and worker exist. This is enough to answer "is this table still
-being purged / did it fail?" and to triage dead letters (§4) without
-building new HTTP surface under deadline pressure.
-
-A dedicated **management endpoint** (Gravitino admin plane, *not* the
-Iceberg REST path) is **deferred to a later release** — see Phase 2 in §6.
-When added it would follow the `metalakes/{metalake}/jobs/runs` convention
-(hierarchical, metalake/catalog-scoped, filters as query params):
-
-- `GET /metalakes/{metalake}/catalogs/{catalog}/cleanups?state=&schema=&table=&page…`
-  — list / filter, keyed by object identifier (catalog + schema + table),
-  not an opaque job id (no caller holds one, so there is no by-id fetch).
-  The per-object question is answered by `…/cleanups?schema={s}&table={t}`,
-  with §5.13 guaranteeing at most one active row.
-
-Each row would report `state`, `attempts` / `max_attempts`, `last_error`,
-`heartbeat_at`, `created_by`, and timestamps. Read-only — there is no cancel
-verb (§3.2); the only operator-triggered transition is the
-register-as-recovery flow (§5.13).
-
-**Automation / monitoring.**
-
-- **Events** (§5.8): `IcebergPurge{Started,Completed,Failed}Event` for
-  streaming consumers.
-- **Metrics**: gauges `purge.jobs.{pending,running,failed}` and
-  `purge.oldest_pending_age_ms`; counters `purge.{completed,failed}`. These
-  let operators alert on a growing backlog ("silently still deleting") or any
-  `FAILED` job ("silently failed to delete") — the two conditions that would
-  otherwise go unnoticed.
-
-`FAILED` is the operationally critical state: in 1.3 it is queryable
-(DB), counted (metric), and emitted (event) — so a cleanup that exhausts
-retries is always discoverable rather than a silent file leak, even before
-the management endpoint lands.
-
-### 5.15 Restart and crash recovery
-
-Restart handling is not a separate mechanism — it falls out of the durable
-job table (§5.3) plus the heartbeat model (§5.4). Three guarantees hold
-across a process restart or crash:
-
-1. **Nothing in-flight is lost.** The job is committed to
-   `iceberg_purge_job` *before* the `DELETE` returns (§5.2); there is no
-   in-memory queue, so a restart cannot drop queued work. `PENDING` jobs
-   are picked up on the first worker tick after boot.
-2. **In-flight jobs orphaned by the crash are reclaimed.** A process that
-   died mid-purge leaves a still-`RUNNING` row with a stale `heartbeat_at`.
-   The worker poll already selects `RUNNING` rows whose heartbeat has gone
-   stale, so once it does the restarted node — or any peer — reclaims the row
-   via the CAS. This is the "worker killed mid-job" row in §5.5.
-3. **Re-running a half-finished job is safe.** The worker rebuilds the file
-   set from `metadata_location` and re-deletes; already-gone files raise
-   `NotFoundException`, which counts as success (§5.5). A crash anywhere in
-   the delete loop costs only duplicated work, never corruption.
-
-In a **multi-replica** deployment this is seamless: surviving replicas
-reclaim a dead node's jobs once the heartbeat goes stale, with no
-coordinator.
-
-The one rough edge is a **single-replica** restart: the jobs the crashed
-node was processing sit idle until their `heartbeat_at` ages past
-`heartbeatTimeout` — up to one `heartbeatTimeout` of dead time — before the
-rebooted process reclaims them. We simply rely on heartbeat staleness
-(correct, bounded, zero extra code) and keep `heartbeatTimeout` modest so the
-resume delay is small. With no owner column there is nothing extra to sweep
-on boot — a stale row is reclaimable by definition.
+The async-vs-synchronous choice rides on the optional `X-Gravitino-Async-Purge`
+header — a Gravitino extension, not part of the Iceberg REST spec. A standard
+client never sends it and gets the async default, so the protocol is
+unchanged.
 
 ---
 
 ## 6. Task Breakdown
 
 Ordered so dependencies come first. Each item maps to one GitHub issue/PR.
-Async purge ships **as the default in 1.3** (PR #11152, confirmed); the
-synchronous path remains only as a rollback flag.
+Async purge ships **as the default in 1.3**; the synchronous path remains
+only as a rollback flag.
 
 ### Phase 1 (1.3): Async purge core
 - [ ] Add the `iceberg_purge_job` schema and migrations (MySQL, H2, PostgreSQL)
 - [ ] Implement `IcebergPurgeJobStore` enqueue path (persist job, return)
-- [ ] Implement the worker pool: claiming via `FOR UPDATE SKIP LOCKED` (heartbeat ownership), heartbeat renewal, streaming file deletion, retry/backoff state machine
-- [ ] Honor the `X-Gravitino-Async-Purge` request header (default async; `false` selects synchronous deletion) and wire both paths into `IcebergTableOperationExecutor.dropTable`
+- [ ] Implement the worker pool: CAS claiming with heartbeat ownership (`FOR UPDATE SKIP LOCKED` where available), heartbeat renewal, streaming file deletion, retry/backoff state machine
+- [ ] Honor the `X-Gravitino-Async-Purge` request header and wire both paths into `IcebergTableOperationExecutor.dropTable`
 - [ ] Add purge events: `IcebergPurgeStartedEvent`, `IcebergPurgeCompletedEvent`, `IcebergPurgeFailedEvent`
-- [ ] Add purge observability (§5.14), low-cost signals only: metrics (`purge.jobs.{pending,running,failed}`, `purge.oldest_pending_age_ms`, `purge.{completed,failed}`) and the informative `ErrorResponse` message on the §5.13 `409`. Operator read path in 1.3 is direct DB query of `iceberg_purge_job`
+- [ ] Add observability (§5.9): metrics and the informative `ErrorResponse` message on the §5.7 `409`; operator read path in 1.3 is direct DB query
 - [ ] Namespace-drop cascade for tables (one job per contained table)
-- [ ] Enforce tombstone semantics (§5.13): on `createTable`/`registerTable`, reject with `409` when an active job exists for the identifier (`idx_object` lookup on the request thread)
-- [ ] Add register-table recovery support (§5.7): atomically CAS the matching active job to `CANCELLED` and restore the catalog entry; documentation
+- [ ] Enforce tombstone semantics (§5.7): on `createTable`/`registerTable`, reject with `409` when an active job exists (`idx_object` lookup on the request thread)
+- [ ] Add register-table recovery (§5.7): atomically CAS the matching active job to `CANCELLED` and restore the catalog entry; documentation
 
 ### Phase 1 (1.3): Testing
 - [ ] Unit tests: enqueue, state machine, worker claiming/heartbeat/contention (H2)
 - [ ] Docker integration tests: latency, restart-resume (`kill -9` mid-purge), two-replica no-duplicate-deletes
-- [ ] Scale & concurrency tests (PRD §4) — see §7
+- [ ] Scale & concurrency tests (§7)
 
 ### Phase 1 (1.3): Documentation
-- [ ] Update user-facing documentation in `docs/` (async semantics, the `X-Gravitino-Async-Purge` header, config, release notes)
+- [ ] Update user-facing docs in `docs/` (async semantics, the `X-Gravitino-Async-Purge` header, config, release notes)
 
 ### Phase 2 (post-1.3)
-- [ ] View support (§5.6): `object_type='VIEW'` cleanup (metadata-only), the view tombstone rule (`createView`/`replaceView` → `409`), and namespace cascade over views
-- [ ] Add the read-only `metalakes/{metalake}/catalogs/{catalog}/cleanups` management endpoint (§5.14): REST resource, DTOs, authorization, client support, docs, and tests. Filtered list keyed by object identifier; no by-id fetch
+- [ ] View support (§5.8): `object_type='VIEW'` cleanup (metadata-only), the view tombstone rule, and namespace cascade over views
+- [ ] Read-only `metalakes/{metalake}/catalogs/{catalog}/cleanups` management endpoint (§5.9): REST resource, DTOs, authorization, client support, docs, tests. Filtered list keyed by object identifier; no by-id fetch
 
 ---
 
@@ -664,53 +500,31 @@ synchronous path remains only as a rollback flag.
   - `TestIcebergPurgeJobStore` — enqueue and row contents.
   - `TestIcebergPurgeStateMachine` — PENDING → RUNNING → SUCCEEDED;
     failure → retry (back to PENDING) → FAILED.
-  - `TestIcebergPurgeWorker` — claiming, heartbeat renewal, contention (H2
-    backend).
+  - `TestIcebergPurgeWorker` — claiming, heartbeat renewal, contention (H2).
   - `TestIcebergTableOperationExecutorAsyncPurge` — async default enqueues
     exactly one job; `X-Gravitino-Async-Purge: false` falls back to
     synchronous purge; thrown errors surface as 5xx.
-  - `TestIcebergPurgeTombstone` (§5.13) — `createTable`/`register` at an
-    identifier with an active job returns `409`; succeeds once the job is
-    `SUCCEEDED`/`FAILED`; `loadTable`/`alterTable` return `404`;
-    re-register CAS's the job to `CANCELLED` and the worker then skips it;
-    the recovery-vs-worker CAS race resolves to a single winner.
+  - `TestIcebergPurgeTombstone` (§5.7) — `createTable`/`register` at an
+    identifier with an active job returns `409`, succeeds once
+    `SUCCEEDED`/`FAILED`; `loadTable`/`alterTable` return `404`; re-register
+    CAS's the job to `CANCELLED` and the worker then skips it; the
+    recovery-vs-worker CAS race resolves to a single winner.
 - Integration (`gravitino-docker-test`):
   - Drop a table; REST returns < 500 ms; worker eventually clears every file.
-  - Restart REST mid-purge (kill -9); purge resumes.
+  - Restart REST mid-purge (`kill -9`); purge resumes.
   - Two replicas on one DB; no duplicate deletions or orphans.
   - Synchronous fallback: existing `IcebergRESTServiceIT` reruns unchanged
     with `X-Gravitino-Async-Purge: false`.
-- Scale & concurrency (PRD §4):
-  - Locust scenarios under `gravitino-test/cloud/scale-test/`.
+- Scale & concurrency:
   - High-file-count fixtures: medium (~50K files), large (~500K files).
-  - Concurrent-drop tier.
-  - Cucumber features for drop / soft-delete / cleanup / cleanup-failure.
-  - Timing assertion: drop returns within 5 s regardless of table size.
+  - Concurrent-drop tier; drop returns within 5 s regardless of table size.
   - Direct GCS/S3 listing asserts the storage prefix is empty after cleanup.
 
 ---
 
 ## 8. Open questions
 
-1. ~~**Name reuse after drop**~~ — **Resolved (§5.13).** We adopt the
-   tombstone approach (Option A): the active `iceberg_purge_job` row keeps
-   the identifier occupied, so `CREATE` / `register` at the same identifier
-   returns `409 Conflict` until the job reaches `SUCCEEDED`. This closes the
-   PRD §2.2 same-name/same-location recreate attack raised with @jerryshao.
-   It does change today's drop semantics (recreate is no longer immediate);
-   that behavior change is called out in the release notes (§5.10).
-2. **Credential refresh** — refresh FileIO credentials from the catalog on
+1. **Credential refresh** — refresh FileIO credentials from the catalog on
    each heartbeat, or require static credentials for catalogs that opt into
    async purge? Leaning toward refresh so long-retention soft delete keeps
    working; cost/complexity trade-off still open.
-3. ~~**Multi-server coordination on H2**~~ — **Resolved (§5.4).** Claiming is
-   an optimistic compare-and-swap `UPDATE` that works on every SQL backend;
-   `SKIP LOCKED` is used as an optimization where available and the CAS form is
-   the fallback elsewhere. No advisory locks.
-4. ~~**Job row vs. catalog row**~~ — **Resolved (§5.13).** Name reuse (Q1)
-   is resolved by treating the active `iceberg_purge_job` row itself as the
-   tombstone, so there is no separate catalog tombstone row to fold fields
-   onto. The Iceberg REST server fronts arbitrary catalogs and has no
-   uniform table-backing row to extend (Gravitino has no `iceberg_tables`
-   table), which is precisely why the job row — not a catalog row — carries
-   the lifecycle.

--- a/design-docs/async-iceberg-rest-hard-deletion.md
+++ b/design-docs/async-iceberg-rest-hard-deletion.md
@@ -130,7 +130,7 @@ doubles as the name-reuse tombstone (§5.7).
       ┌─────┴───────────────┐
       │ header absent       │ X-Gravitino-Async-Purge: false
       ▼                     ▼
- persist iceberg_purge_job   CatalogUtil.dropTableData
+ persist iceberg_cleanup_job   CatalogUtil.dropTableData
  row, return 204             (synchronous, on request thread)
       │
       ▼
@@ -155,7 +155,7 @@ each word capitalized).
    selected by adding `X-Gravitino-Async-Purge: false`.
 2. The server runs authorization on the request thread, loads the table
    metadata location, drops the catalog entry, and persists an
-   `iceberg_purge_job` row.
+   `iceberg_cleanup_job` row.
 3. The server responds `204 No Content` within typical request latency. The
    table is immediately absent from `LIST` and `HEAD` returns `404`.
 4. A worker on any replica claims the job, rebuilds the snapshot graph from
@@ -192,16 +192,27 @@ public void dropTable(IcebergRequestContext ctx, TableIdentifier id,
 ```
 
 Order matters on the async path: load metadata location → drop catalog
-entry → enqueue the job. A purge job exists only for a table already gone
+entry → enqueue the job. A cleanup job exists only for a table already gone
 from the catalog. `fileIoProperties` is captured at enqueue time so the
 worker can reconstruct `FileIO` even if the catalog is later reconfigured.
 The enqueued row also serves as the **tombstone** that blocks name reuse
 while the files still exist (§5.7).
 
-### 5.4 Schema — `iceberg_purge_job`
+**Repeated drop is idempotent.** Because the catalog entry is removed before
+the first `DELETE` returns, a second `DELETE …?purgeRequested=true` for the
+same identifier reaches `w.loadTableMetadata(id)` (or `w.dropTable(id)`),
+finds nothing, and returns `404 NoSuchTableException` — the standard Iceberg
+REST response for dropping a missing table. We do **not** enqueue a second
+cleanup job: the first `loadTableMetadata` throws `NoSuchTableException`
+before the enqueue line is reached, so a client retrying a drop (or a
+duplicate request) never produces a duplicate job or a duplicate purge. This
+holds regardless of whether the in-flight job is still `PENDING`/`RUNNING` or
+already terminal, so it is consistent with the §5.7 tombstone table.
+
+### 5.4 Schema — `iceberg_cleanup_job`
 
 ```sql
-CREATE TABLE IF NOT EXISTS `iceberg_purge_job` (
+CREATE TABLE IF NOT EXISTS `iceberg_cleanup_job` (
   `id`                BIGINT(20)    UNSIGNED NOT NULL AUTO_INCREMENT,
   `metalake_name`     VARCHAR(128)  NOT NULL,
   `catalog_name`      VARCHAR(128)  NOT NULL,
@@ -212,6 +223,7 @@ CREATE TABLE IF NOT EXISTS `iceberg_purge_job` (
   `file_io_props`     MEDIUMTEXT    NOT NULL COMMENT 'JSON',
   `state`             VARCHAR(16)   NOT NULL COMMENT 'PENDING|RUNNING|SUCCEEDED|FAILED',
   `attempts`          INT(10)       NOT NULL DEFAULT 0,
+  `last_error`        VARCHAR(2048) NULL COMMENT 'truncated reason for the most recent failure; NULL until a job fails',
   `heartbeat_at`      BIGINT(20)    NULL COMMENT 'last heartbeat from the worker; NULL when unclaimed',
   `created_by`        VARCHAR(128)  NOT NULL COMMENT 'principal that requested the drop (audit)',
   `updated_at`        BIGINT(20)    NOT NULL COMMENT 'last state change; drives poll ordering and terminal-row pruning',
@@ -231,6 +243,14 @@ re-claimed on a later poll, so the poll cadence (`poll-interval-ms`,
 §5.10) is the retry interval — no separate scheduling column is needed. The
 ceiling is a config (`max-attempts`, §5.10), not a per-row `max_attempts`
 column, since it is the same for every job.
+
+`last_error` records the reason for the most recent failure — the metadata
+exception that sent a job back to `PENDING`, or the one that drove it to
+`FAILED` — truncated to fit the column. It is overwritten on each attempt,
+not appended, so it always reflects the latest failure. This puts the
+failure reason in the job row itself, so an operator triaging a `FAILED`
+cleanup (§5.6, §5.9) reads it from a single indexed query without correlating
+worker logs by timestamp. The full stack trace still goes to the logs.
 
 Migration: `upgrade-1.2.0-to-1.3.0-mysql.sql` (and H2 / PostgreSQL).
 
@@ -261,14 +281,14 @@ first row it wins:
 
 ```sql
 -- a free thread reads a small candidate window
-SELECT id FROM iceberg_purge_job
+SELECT id FROM iceberg_cleanup_job
  WHERE state = 'PENDING'
     OR (state = 'RUNNING'
         AND (heartbeat_at IS NULL OR heartbeat_at < :now - :heartbeatTimeout))
  ORDER BY updated_at LIMIT :window;
 
 -- claim one candidate; the row is ours only if affected_rows = 1
-UPDATE iceberg_purge_job
+UPDATE iceberg_cleanup_job
    SET state='RUNNING', heartbeat_at=:now
  WHERE id=:id
    AND ( state='PENDING'
@@ -293,27 +313,40 @@ the same job. We do not use DB-specific advisory locks.
 2. **Load metadata.** `TableMetadataParser.read(io, metadata_location)`. A
    transient failure releases the job for retry; a terminal one fails it
    (§5.6).
-3. **Stream & delete.** Walk the snapshot graph lazily and delete every
-   reachable file through the shared `deleteExecutor`; `NotFoundException`
-   counts as deleted. A background task keeps `heartbeat_at` fresh throughout.
+3. **Stream & delete.** Walk the snapshot graph lazily, group reachable files
+   into batches of `delete-batch-size`, and hand each batch to the shared
+   `deleteExecutor` for a **bulk** delete; `NotFoundException` counts as
+   deleted. The worker thread itself never issues the storage call directly,
+   and a *separate* background task keeps `heartbeat_at` fresh throughout
+   (see "Heartbeat is decoupled from deletion" below).
 4. **Finish.** Once every reachable file is gone the job is `SUCCEEDED`
    (§5.6). The thread then loops back to step 1.
 
 Execution mirrors `CatalogHandlers.purgeTable`, but **streams** the
 reachable files instead of materializing them. A large table can reference
 millions of data files, so the worker walks the snapshot graph lazily and
-deletes in bounded batches:
+deletes them **in bulk batches**, never one file at a time:
 
 ```java
 TableMetadata meta = TableMetadataParser.read(io, job.metadataLocation());
 try (CloseableIterable<String> files = reachableFiles(meta)) {  // lazy, not materialized
-  Tasks.foreach(files)
-       .executeWith(deleteExecutor)  // shared server-wide pool, §5.10
-       .retry(perFileRetries)
-       .suppressFailureWhenFinished()
-       .run(io::deleteFile);
+  Iterators.partition(files.iterator(), deleteBatchSize)        // bounded batches
+      .forEachRemaining(batch ->
+          deleteExecutor.execute(() ->
+              // SupportsBulkOperations.deleteFiles when the FileIO supports it
+              // (e.g. S3FileIO's batch-delete API), else concurrent per-file
+              CatalogUtil.deleteFiles(io, batch, "cleanup", /* bulk */ true)));
 }
 ```
+
+We delete in bulk rather than per file because a single `DeleteObjects`
+round trip removes up to ~1000 objects, cutting both request count and
+S3 cost by three orders of magnitude on a large table.
+`CatalogUtil.deleteFiles(io, batch, msg, true)` routes to
+`SupportsBulkOperations.deleteFiles` when the `FileIO` implements it
+(S3FileIO, GCSFileIO, ADLSFileIO all do) and falls back to a concurrent
+per-file delete otherwise; partial-batch failures are logged and suppressed,
+matching the synchronous purge's best-effort stance (§5.6).
 
 `deleteExecutor` is a single server-wide pool sized by `delete-threads`
 (§5.10), shared by all concurrent jobs rather than allocated per job. This
@@ -321,13 +354,40 @@ bounds total file-delete concurrency on the server regardless of how many
 jobs run at once; raise it to drain large tables faster when purge
 throughput matters.
 
+**When the delete queue is full.** The `deleteExecutor` is a
+`ThreadPoolExecutor` with `delete-threads` threads and a *bounded* work queue,
+and a worker that walks a million-file table can enqueue batches faster than
+the pool drains them. We do **not** use an unbounded queue (it would let one
+huge table OOM the server) and we do **not** drop work on rejection (that
+would leak files). Instead the pool uses `CallerRunsPolicy`: once both the
+threads and the bounded queue are saturated, `execute(...)` runs the batch
+**inline on the calling worker thread**. That worker stops pulling new batches
+from its lazy iterator until the inline delete returns, which is exactly the
+back-pressure we want — the snapshot walk naturally slows to the rate storage
+can absorb, queue depth stays bounded, and no batch is ever discarded. Because
+the heartbeat lives on a different thread (next paragraph), a worker blocked in
+an inline bulk delete still keeps its lease alive.
+
+**Heartbeat is decoupled from deletion.** Deletion is a long, blocking,
+I/O-bound activity: a worker thread can sit inside a bulk `deleteFiles` call —
+or inside a `CallerRunsPolicy` inline batch — for seconds at a time, and across
+a whole table for many minutes. If that same thread were responsible for
+writing `heartbeat_at`, any slow storage round trip would stall the heartbeat,
+the row would age past `heartbeatTimeout`, and a peer would wrongly reclaim a
+job that is in fact making progress — causing duplicate work and lease
+thrashing. So the heartbeat is **never** issued from the deleting thread. A
+single background task per process (next paragraph) refreshes `heartbeat_at`
+for every owned id on a fixed schedule, independent of where the worker threads
+are blocked. This is why `delete-threads` work can be fully synchronous from
+the worker's point of view without endangering the lease.
+
 **Updating the heartbeat.** One background task per worker process — not one
 per job — runs every `heartbeatTimeout / 3`, so two updates can be missed
 (a GC pause, a brief DB hiccup) before the row looks abandoned. For each id
 the process owns it issues a guarded `UPDATE`:
 
 ```sql
-UPDATE iceberg_purge_job
+UPDATE iceberg_cleanup_job
    SET heartbeat_at = :now
  WHERE id = :id
    AND state = 'RUNNING'
@@ -362,25 +422,26 @@ clearly terminal failure skips the retries and goes straight to `FAILED`.
 | Outcome                                              | Action                                                                                |
 |------------------------------------------------------|---------------------------------------------------------------------------------------|
 | All files deleted (or already gone)                  | `state='SUCCEEDED'`                                                                    |
-| Transient failure, `attempts < max-attempts`         | `attempts++`, back to `PENDING`, `heartbeat_at=NULL`; re-claimed on a later poll       |
-| Transient failure, `attempts` reaches `max-attempts` | `attempts++` → `FAILED` (gave up retrying)                                             |
-| Terminal failure (e.g. metadata gone/corrupt)        | → `FAILED` immediately; retrying cannot help                                           |
+| Transient failure, `attempts < max-attempts`         | `attempts++`, set `last_error`, back to `PENDING`, `heartbeat_at=NULL`; re-claimed later |
+| Transient failure, `attempts` reaches `max-attempts` | `attempts++`, set `last_error` → `FAILED` (gave up retrying)                            |
+| Terminal failure (e.g. metadata gone/corrupt)        | set `last_error` → `FAILED` immediately; retrying cannot help                          |
 | Worker killed mid-job                                | `RUNNING` row's heartbeat goes stale; another worker reclaims; deletes are idempotent  |
 
 **After `SUCCEEDED`.** The files are gone, so the tombstone lifts at once:
 `createTable` / `register` at the identifier succeed again (§5.7). The
 `purge.completed` counter increments and the row is pruned
-`terminal-retention-hours` later (§5.10).
+`retention-hours` later (§5.10).
 
 **After `FAILED`.** `FAILED` is terminal — the poll never re-selects it, so
 the worker stops touching the job. The tombstone also lifts (§5.7), so a
 failed cleanup never permanently wedges the name; the cost is that any files
 the job did not delete are now an orphaned leak. The failure is therefore
 made loud rather than silent: it increments `purge.failed`, the row stays
-queryable (§5.9), and the reason is in the worker logs. An operator reclaims
+queryable (§5.9) with the reason in its `last_error` column (and the full
+stack trace in the worker logs). An operator reclaims
 the leaked files out of band — a manual delete or a storage lifecycle rule on
 the table's prefix — and then drops the row, or lets it prune after
-`terminal-retention-hours`. There is no automatic re-drive in 1.3;
+`retention-hours`. There is no automatic re-drive in 1.3;
 re-enqueueing a `FAILED` cleanup is a manual operator action.
 
 Restart handling falls out of the durable job table plus the heartbeat
@@ -406,13 +467,14 @@ owner column there is nothing extra to sweep on boot.
 
 While a purge job for an identifier is non-terminal (`PENDING` or
 `RUNNING`), that identifier is treated as **still occupied** even though its
-catalog entry is already gone. The active `iceberg_purge_job` row *is* the
+catalog entry is already gone. The active `iceberg_cleanup_job` row *is* the
 tombstone — no second table is needed. The REST server consults the store on
 the request thread (one indexed lookup via `idx_object`):
 
 | Operation                                   | Active job exists                 | No active job (`SUCCEEDED`/`FAILED`/none) |
 |---------------------------------------------|-----------------------------------|-------------------------------------------|
 | `loadTable` / `HEAD`, `alterTable` / commit | `404 NoSuchTableException`        | `404`                                     |
+| `dropTable` (same identifier, repeated)     | `404 NoSuchTableException`        | `404`                                     |
 | `createTable` (same identifier)             | **`409 Conflict`** — being purged | succeeds                                  |
 | `registerTable` (same identifier)           | **`409 Conflict`**                | succeeds                                  |
 
@@ -423,6 +485,24 @@ leaked files out of band. This closes the same-name / same-location recreate
 attack: a recreate cannot expose the dropped table's data, because it is
 refused until the files are deleted. A **namespace** carries no data, so it
 can be recreated freely; tables inside it are guarded individually.
+
+**Why the tombstone is necessary — does a recreate reuse the old path?**
+Yes. When a `createTable` omits an explicit `location` — the common case —
+Iceberg derives the table root from the identifier via
+`BaseMetastoreCatalog.defaultWarehouseLocation(identifier)`, i.e.
+`<warehouse>/<namespace>/<table>`. A recreate at the same identifier
+therefore lands on the **same base prefix** as the table being purged. The
+*file names* underneath do not collide — data files get UUID names from
+`OutputFileFactory` and each metadata commit writes `<version>-<uuid>.metadata.json`
+— and the worker deletes strictly by reachability from the *old*
+`metadata_location`, so it can never delete the new table's files. The real
+hazard is two live tables transiently sharing one prefix while old files are
+still being deleted: confusing for operators, and an opening for a recreate
+to read leftover data under the shared prefix. Blocking `createTable` /
+`registerTable` with `409` until the cleanup is terminal removes that window
+entirely. (A client that *does* pass an explicit, distinct `location` on
+recreate would not share the prefix, but we still block on identifier to keep
+one simple, predictable rule.)
 
 Once a drop is accepted the table is gone for good: this is *hard* delete,
 so there is deliberately no undrop or re-register recovery path. A client
@@ -462,17 +542,18 @@ which ship for free with the worker; streaming events are an additive
 follow-up that does not change the job model.
 
 The source of truth for "is this table still being purged, done, or failed?"
-is the `iceberg_purge_job` row, exposed without touching the wire contract:
+is the `iceberg_cleanup_job` row, exposed without touching the wire contract:
 
 - **Iceberg REST clients** observe only that the table is dropped
   (`404` / omitted from `LIST`). The single purge-specific signal is the
   §5.7 `409` on a same-identifier `createTable` / `register`, whose
   `ErrorResponse.message` names the blocking job.
-- **Operators** query `iceberg_purge_job` directly (the `idx_object` index
+- **Operators** query `iceberg_cleanup_job` directly (the `idx_object` index
   makes the per-identifier lookup cheap), plus the metrics below; the failure
-  reason for a `FAILED` job is in the worker's logs. This is enough to answer
-  "still purging / failed?" without new HTTP surface. A read-only management
-  endpoint is deferred to Phase 2.
+  reason for a `FAILED` job is in the row's `last_error` column (§5.4), with
+  the full stack trace in the worker's logs. This is enough to answer
+  "still purging / failed, and why?" without new HTTP surface. A read-only
+  management endpoint is deferred to Phase 2.
 - **Metrics**: gauges `purge.jobs.{pending,running,failed}` and
   `purge.oldest_pending_age_ms`; counters `purge.{completed,failed}`. These
   let operators alert on a growing backlog or any `FAILED` job — the two
@@ -492,12 +573,21 @@ only tune the worker pool and retries:
 
 | Key                                                           | Default  | Description                                                                  |
 |---------------------------------------------------------------|----------|------------------------------------------------------------------------------|
-| `gravitino.iceberg-rest.async-purge.worker-threads`           | `4`      | Worker pool size per server (concurrent jobs).                               |
-| `gravitino.iceberg-rest.async-purge.delete-threads`           | `16`     | Server-wide file-delete pool size, shared across all jobs.                   |
+| `gravitino.iceberg-rest.async-purge.worker-threads`           | `2`      | Worker pool size per server (concurrent jobs).                               |
+| `gravitino.iceberg-rest.async-purge.delete-threads`           | `4`      | Server-wide file-delete pool size, shared across all jobs.                   |
+| `gravitino.iceberg-rest.async-purge.delete-batch-size`        | `1000`   | Files per bulk-delete batch handed to `deleteExecutor` (§5.5).               |
 | `gravitino.iceberg-rest.async-purge.poll-interval-ms`         | `5000`   | Worker poll interval.                                                        |
 | `gravitino.iceberg-rest.async-purge.heartbeat-timeout-ms`     | `300000` | Age after which a job with no heartbeat is reclaimable.                      |
 | `gravitino.iceberg-rest.async-purge.max-attempts`             | `5`      | Attempts before `FAILED`.                                                    |
-| `gravitino.iceberg-rest.async-purge.terminal-retention-hours` | `168`    | How long terminal (`SUCCEEDED` / `FAILED`) rows are retained before pruning. |
+| `gravitino.iceberg-rest.async-purge.retention-hours`          | `720`    | How long terminal (`SUCCEEDED` / `FAILED`) rows are retained before pruning (30 days). |
+
+The thread defaults are deliberately modest. Each `delete-threads` thread now
+issues a *bulk* delete of up to `delete-batch-size` files per call (§5.5), so
+4 threads already sustain high delete throughput — far more than the 16
+single-file threads an earlier draft assumed. `worker-threads` is 2 because a
+single server rarely needs many tables purging at once and each worker can
+saturate the delete pool on its own; both knobs are raised only when a backlog
+metric (§5.9) shows the pool is the bottleneck.
 
 There is no separate claim-batch-size key: a free thread claims one job at a
 time and only when idle (§5.5), so `worker-threads` already bounds concurrent
@@ -511,7 +601,7 @@ jobs.
   Credentials that expire before the worker runs (STS tokens, …) are
   refreshed from the catalog on each heartbeat, so long-running purges keep
   valid credentials.
-- `iceberg_purge_job` may contain credentials in `file_io_props`; the
+- `iceberg_cleanup_job` may contain credentials in `file_io_props`; the
   existing Gravitino DB encryption / access controls apply.
 
 ### 5.12 Backward compatibility (wire)
@@ -540,9 +630,9 @@ Async purge ships **as the default in 1.3**; the synchronous path remains
 only as a rollback flag.
 
 ### Phase 1 (1.3): Async purge core
-- [ ] Add the `iceberg_purge_job` schema and migrations (MySQL, H2, PostgreSQL)
+- [ ] Add the `iceberg_cleanup_job` schema and migrations (MySQL, H2, PostgreSQL)
 - [ ] Implement `IcebergPurgeJobStore` enqueue path (persist job, return)
-- [ ] Implement the worker pool: CAS claiming with heartbeat ownership (`FOR UPDATE SKIP LOCKED` where available), heartbeat renewal, streaming file deletion, retry state machine (re-claim failed jobs on later polls, give up at `max-attempts`)
+- [ ] Implement the worker pool: CAS claiming with heartbeat ownership (`FOR UPDATE SKIP LOCKED` where available), heartbeat renewal on a thread decoupled from deletion, streaming **bulk** file deletion (`CatalogUtil.deleteFiles(..., true)`) through a bounded `deleteExecutor` with `CallerRunsPolicy` back-pressure, retry state machine that records `last_error` (re-claim failed jobs on later polls, give up at `max-attempts`)
 - [ ] Honor the `X-Gravitino-Async-Purge` request header and wire both paths into `IcebergTableOperationExecutor.dropTable`
 - [ ] Add observability (§5.9): metrics and the informative `ErrorResponse` message on the §5.7 `409`; operator read path in 1.3 is direct DB query
 - [ ] Enforce tombstone semantics (§5.7): on `createTable`/`registerTable`, reject with `409` when an active job exists (`idx_object` lookup on the request thread)
@@ -567,14 +657,19 @@ only as a rollback flag.
 - Unit (`./gradlew :iceberg:iceberg-rest-server:test -PskipITs`):
   - `TestIcebergPurgeJobStore` — enqueue and row contents.
   - `TestIcebergPurgeStateMachine` — PENDING → RUNNING → SUCCEEDED;
-    failure → retry (back to PENDING) → FAILED.
-  - `TestIcebergPurgeWorker` — claiming, heartbeat renewal, contention (H2).
+    failure → retry (back to PENDING) → FAILED; `last_error` populated on
+    each failure.
+  - `TestIcebergPurgeWorker` — claiming, heartbeat renewal on a thread that
+    stays fresh while delete batches block, contention (H2), bulk-delete
+    batching, and `CallerRunsPolicy` back-pressure when the delete queue fills.
   - `TestIcebergTableOperationExecutorAsyncPurge` — async default enqueues
-    exactly one job; `X-Gravitino-Async-Purge: false` falls back to
-    synchronous purge; thrown errors surface as 5xx.
+    exactly one job; a repeated drop returns `404` and enqueues no second job;
+    `X-Gravitino-Async-Purge: false` falls back to synchronous purge; thrown
+    errors surface as 5xx.
   - `TestIcebergPurgeTombstone` (§5.7) — `createTable`/`register` at an
     identifier with an active job returns `409`, succeeds once
-    `SUCCEEDED`/`FAILED`; `loadTable`/`alterTable` return `404`.
+    `SUCCEEDED`/`FAILED`; `loadTable`/`alterTable`/repeated `dropTable`
+    return `404`.
 - Integration (`gravitino-docker-test`):
   - Drop a table; REST returns < 500 ms; worker eventually clears every file.
   - Restart REST mid-purge (`kill -9`); purge resumes.

--- a/design-docs/async-iceberg-rest-hard-deletion.md
+++ b/design-docs/async-iceberg-rest-hard-deletion.md
@@ -236,33 +236,37 @@ Migration: `upgrade-1.2.0-to-1.3.0-mysql.sql` (and H2 / PostgreSQL).
 
 ### 5.5 Worker pool and multi-replica ownership
 
-A `ScheduledThreadPoolExecutor` modeled on `RelationalGarbageCollector`.
+The worker pool has `worker-threads` threads, modeled on the
+`RelationalGarbageCollector` scheduler. **A thread polls for work only when
+it is free**: a free thread claims a single job, runs it to completion or
+failure, then loops back to poll for the next; a thread busy on a job never
+polls. Capacity-gating is therefore by construction — no central scheduler
+claims jobs ahead of the threads, the pool never holds a claimed-but-unstarted
+job, and a `RUNNING` row always maps to a thread actively deleting files (its
+heartbeat reflects real progress, not a job idling in a queue). A poll that
+finds nothing claimable waits `poll-interval-ms` and retries. `worker-threads`
+thus bounds the concurrent jobs per server; there is no separate claim-batch
+size.
+
 Ownership is tracked by a **heartbeat** alone: the worker that claims a job
 keeps refreshing `heartbeat_at` while it runs and remembers the ids it owns
 in memory (no owner column — a stale row is reclaimable by anyone, which is
 exactly the failover behavior we want). A job is abandoned, and reclaimable,
 once its heartbeat is older than `heartbeatTimeout`.
 
-**Claiming is gated by free worker capacity.** Each tick the worker first
-counts its idle threads and polls for *at most* that many candidates; when
-every thread is busy it polls for nothing. A worker therefore never claims a
-job it cannot run immediately, so a `RUNNING` row always maps to a thread
-actively deleting files — its heartbeat reflects real progress, never a job
-idling in an in-memory backlog. This also means the claim count is the idle
-thread count, not a separate tunable.
-
 Claiming is an optimistic compare-and-swap `UPDATE` that works on **every**
-SQL backend:
+SQL backend. A free thread reads a small candidate window and claims the
+first row it wins:
 
 ```sql
--- read up to :idleThreads candidates (0 when the pool is saturated)
+-- a free thread reads a small candidate window
 SELECT id FROM iceberg_purge_job
  WHERE state = 'PENDING'
     OR (state = 'RUNNING'
         AND (heartbeat_at IS NULL OR heartbeat_at < :now - :heartbeatTimeout))
- ORDER BY updated_at LIMIT :idleThreads;
+ ORDER BY updated_at LIMIT :window;
 
--- claim each candidate; the row is ours only if affected_rows = 1
+-- claim one candidate; the row is ours only if affected_rows = 1
 UPDATE iceberg_purge_job
    SET state='RUNNING', heartbeat_at=:now
  WHERE id=:id
@@ -271,13 +275,14 @@ UPDATE iceberg_purge_job
           AND (heartbeat_at IS NULL OR heartbeat_at < :now - :heartbeatTimeout)) );
 ```
 
-A loser sees `affected_rows = 0` and moves to the next candidate (so a tick
-may end up running fewer jobs than it has idle threads). Where `SELECT …
-FOR UPDATE SKIP LOCKED` is available (MySQL 8+, PostgreSQL) the worker uses
-it to cut contention up front; the CAS form is the portable fallback (H2,
-older MySQL). `SKIP LOCKED` is purely an optimization — the claiming `UPDATE` is
-the serialization point, so two replicas can never claim the same job. We do
-not use DB-specific advisory locks.
+A loser sees `affected_rows = 0` and tries the next id in its window. The
+window is a small constant that only gives a CAS loser alternatives — not a
+capacity control, since a free thread still claims exactly one job. Where
+`SELECT … FOR UPDATE SKIP LOCKED` is available (MySQL 8+, PostgreSQL) the
+worker uses it to cut contention up front; the CAS form is the portable
+fallback (H2, older MySQL). `SKIP LOCKED` is purely an optimization — the
+claiming `UPDATE` is the serialization point, so two replicas can never claim
+the same job. We do not use DB-specific advisory locks.
 
 Execution mirrors `CatalogHandlers.purgeTable`, but **streams** the
 reachable files instead of materializing them. A large table can reference
@@ -327,8 +332,8 @@ Restart handling falls out of the durable job table plus the heartbeat
 model — no separate mechanism:
 
 1. **Nothing in-flight is lost.** The job is committed before the `DELETE`
-   returns; there is no in-memory queue. `PENDING` jobs are picked up on the
-   first tick after boot.
+   returns; there is no in-memory queue. `PENDING` jobs are picked up as soon
+   as a thread polls after boot.
 2. **Orphaned in-flight jobs are reclaimed.** A crash leaves a `RUNNING` row
    with a stale heartbeat, which the poll already selects; the restarted node
    or any peer reclaims it via the CAS.
@@ -439,9 +444,9 @@ only tune the worker pool and retries:
 | `gravitino.iceberg-rest.async-purge.max-attempts`             | `5`      | Attempts before `FAILED`.                                                    |
 | `gravitino.iceberg-rest.async-purge.terminal-retention-hours` | `168`    | How long terminal (`SUCCEEDED` / `FAILED`) rows are retained before pruning. |
 
-There is no separate claim-batch-size key: a tick claims at most as many
-jobs as the worker has idle threads (§5.5), so `worker-threads` already
-bounds it.
+There is no separate claim-batch-size key: a free thread claims one job at a
+time and only when idle (§5.5), so `worker-threads` already bounds concurrent
+jobs.
 
 ### 5.11 Security
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Adds the design document `design-docs/async-iceberg-rest-hard-deletion.md` for **asynchronous hard deletion** in the Gravitino Iceberg REST server.

The design makes `DELETE …?purgeRequested=true` return quickly by dropping the catalog entry on the request thread and deleting data/metadata files in the background via a JDBC-backed job table (`iceberg_purge_job`) and a multi-replica worker pool (lease via `FOR UPDATE SKIP LOCKED`, CAS fallback elsewhere), with retry/backoff and a `DEAD_LETTER` state. The synchronous path is retained behind `async-purge.enabled=false` purely as a rollback.

Resolved review/open questions in this revision:
- **Name reuse during purge (§5.13, closes §8.1 / Jerry's Q1):** the active job row acts as a tombstone — `createTable`/`register` at the same identifier returns **409** until the job is terminal, closing the PRD §2.2 same-name/same-location recreate attack. Re-register-as-recovery atomically cancels the matching job (`CANCELLED`), removing the worker-deletes-recovered-files race.
- **Purge visibility (§5.14, Jerry's follow-up):** how to tell a table is mid-purge / done / dead-lettered — a wire-compatible informative `409` message, a read-only `purge-jobs` management endpoint, metrics, and events, with `DEAD_LETTER` discoverable across all three.
- Marked §8.1 (Q1) and §8.4 (Q4) resolved; updated schema (`CANCELLED` state, `idx_object`), failure model, wire-compat notes, and task breakdown.

### Why are the changes needed?

Synchronous purge on the Jetty request thread exceeds HTTP timeouts, saturates the thread pool, and leaks files with no retry/audit on large tables. This document captures the async design before implementation.

### Does this PR introduce _any_ user-facing change?

No (design document only). The design it describes would change drop semantics (recreate blocked with 409 until cleanup completes) — called out in the doc's release-notes section.

### How was this patch tested?

N/A — documentation only.
