### PR TITLE
[#11165] improvement(deps): Upgrade commons-beanutils from 1.9.4 to 1.11.0 in hive-metastore-libs

### DIFF
--- a/catalogs/hive-metastore2-libs/build.gradle.kts
+++ b/catalogs/hive-metastore2-libs/build.gradle.kts
@@ -33,6 +33,7 @@ dependencies {
   constraints {
     implementation(libs.thrift)
     implementation(libs.snappy.java)
+    implementation(libs.commons.beanutils)
   }
 
   implementation(libs.hadoop3.common) {

--- a/catalogs/hive-metastore3-libs/build.gradle.kts
+++ b/catalogs/hive-metastore3-libs/build.gradle.kts
@@ -33,6 +33,7 @@ dependencies {
   constraints {
     implementation(libs.thrift)
     implementation(libs.snappy.java)
+    implementation(libs.commons.beanutils)
   }
 
   implementation(libs.hadoop3.common) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -59,6 +59,7 @@ commons-logging = "1.3.5"
 commons-io = "2.18.0"
 commons-collections4 = "4.4"
 commons-collections3 = "3.2.2"
+commons-beanutils = "1.11.0"
 commons-configuration1 = "1.6"
 commons-dbcp2 = "2.11.0"
 caffeine = "2.9.3"
@@ -240,6 +241,7 @@ commons-io = { group = "commons-io", name = "commons-io", version.ref = "commons
 caffeine = { group = "com.github.ben-manes.caffeine", name = "caffeine", version.ref = "caffeine" }
 commons-collections4 = { group = "org.apache.commons", name = "commons-collections4", version.ref = "commons-collections4" }
 commons-collections3 = { group = "commons-collections", name = "commons-collections", version.ref = "commons-collections3" }
+commons-beanutils = { group = "commons-beanutils", name = "commons-beanutils", version.ref = "commons-beanutils" }
 commons-configuration1 = { group = "commons-configuration", name = "commons-configuration", version.ref = "commons-configuration1" }
 commons-configuration2 = { group = "org.apache.commons", name = "commons-configuration2", version.ref = "commons-configuration2" }
 iceberg-aliyun = { group = "org.apache.iceberg", name = "iceberg-aliyun", version.ref = "iceberg" }


### PR DESCRIPTION


### What changes were proposed in this pull request?

Add commons-beanutils to the version catalog (1.11.0) and add `constraints { implementation(libs.commons.beanutils) }` in `hive-metastore2-libs` and `hive-metastore3-libs` to upgrade the transitive commons-beanutils from 1.9.4.


### Why are the changes needed?

commons-beanutils 1.9.4 does not enable `SuppressPropertiesBeanIntrospector` by default, allowing potential class-level property access. Version 1.11.0 fixes this by disallowing class-level access by default, and is API backward-compatible.


Fix: #11165

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

- `./gradlew :catalogs:hive-metastore2-libs:build :catalogs:hive-metastore3-libs:build` — passes
- `./gradlew :catalogs:hive-metastore-common:test :catalogs:catalog-hive:test -PskipITs` — passes
- Integration tests to be verified by CI
