### PR TITLE
[#11132] fix(iceberg-rest): Fix NamespaceNotEmptyException to return HTTP 409

### DIFF
--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/IcebergExceptionMapper.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/IcebergExceptionMapper.java
@@ -59,7 +59,7 @@ public class IcebergExceptionMapper implements ExceptionMapper<Exception> {
           .put(IllegalArgumentException.class, 400)
           .put(ValidationException.class, 400)
           .put(IllegalNameIdentifierException.class, 400)
-          .put(NamespaceNotEmptyException.class, 400)
+          .put(NamespaceNotEmptyException.class, 409)
           .put(NotAuthorizedException.class, 401)
           .put(UnauthorizedException.class, 401)
           .put(AuthenticationTimeoutException.class, 419)
@@ -111,8 +111,7 @@ public class IcebergExceptionMapper implements ExceptionMapper<Exception> {
     }
     if (e instanceof IllegalArgumentException
         || e instanceof IllegalNameIdentifierException
-        || e instanceof ValidationException
-        || e instanceof NamespaceNotEmptyException) {
+        || e instanceof ValidationException) {
       return new BadRequestException("%s", message);
     }
     if (EXCEPTION_ERROR_CODES.containsKey(e.getClass())) {

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/TestIcebergExceptionMapper.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/TestIcebergExceptionMapper.java
@@ -48,7 +48,7 @@ public class TestIcebergExceptionMapper {
   public void testIcebergExceptionMapper() {
     checkExceptionStatus(new IllegalArgumentException(""), 400);
     checkExceptionStatus(new ValidationException(""), 400);
-    checkExceptionStatus(new NamespaceNotEmptyException(""), 400);
+    checkExceptionStatus(new NamespaceNotEmptyException(""), 409);
     checkExceptionStatus(new NotAuthorizedException(""), 401);
     checkExceptionStatus(new TokenExpiredException("expired"), 419);
     checkExceptionStatus(new AuthenticationTimeoutException("expired"), 419);

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/TestIcebergNamespaceOperations.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/TestIcebergNamespaceOperations.java
@@ -183,6 +183,12 @@ public class TestIcebergNamespaceOperations extends IcebergNamespaceTestBase {
     verifyCreateNamespaceSucc(Namespace.of("drop_foo3", "a"));
     verifyDropNamespaceFail(404, Namespace.of("drop_foo3", "b"));
     verifyDropNamespaceSucc(Namespace.of("drop_foo3", "a"));
+
+    // drop non-empty namespace should return 409 Conflict per Iceberg REST spec
+    Namespace nonEmptyNs = Namespace.of("drop_nonempty_foo");
+    verifyCreateNamespaceSucc(nonEmptyNs);
+    verifyRegisterTableSucc("drop_nonempty_table", nonEmptyNs);
+    verifyDropNamespaceFail(409, nonEmptyNs);
   }
 
   @Test

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/TestIcebergNamespaceOperations.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/TestIcebergNamespaceOperations.java
@@ -48,10 +48,14 @@ import org.apache.gravitino.listener.api.event.IcebergRegisterTablePreEvent;
 import org.apache.gravitino.listener.api.event.IcebergUpdateNamespaceEvent;
 import org.apache.gravitino.listener.api.event.IcebergUpdateNamespaceFailureEvent;
 import org.apache.gravitino.listener.api.event.IcebergUpdateNamespacePreEvent;
+import org.apache.iceberg.Schema;
 import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.rest.requests.CreateTableRequest;
 import org.apache.iceberg.rest.requests.ImmutableRegisterTableRequest;
 import org.apache.iceberg.rest.requests.RegisterTableRequest;
 import org.apache.iceberg.rest.responses.LoadTableResponse;
+import org.apache.iceberg.types.Types.NestedField;
+import org.apache.iceberg.types.Types.StringType;
 import org.glassfish.jersey.internal.inject.AbstractBinder;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.junit.jupiter.api.Assertions;
@@ -60,7 +64,11 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mockito;
 
+@SuppressWarnings("deprecation")
 public class TestIcebergNamespaceOperations extends IcebergNamespaceTestBase {
+
+  private static final Schema DROP_NONEMPTY_TABLE_SCHEMA =
+      new Schema(NestedField.of(1, false, "foo_string", StringType.get()));
 
   private DummyEventListener dummyEventListener;
 
@@ -70,6 +78,7 @@ public class TestIcebergNamespaceOperations extends IcebergNamespaceTestBase {
     ResourceConfig resourceConfig =
         IcebergRestTestUtil.getIcebergResourceConfig(
             MockIcebergNamespaceOperations.class, true, Arrays.asList(dummyEventListener));
+    resourceConfig.register(MockIcebergTableOperations.class);
 
     // register a mock HttpServletRequest with user info
     resourceConfig.register(
@@ -185,11 +194,29 @@ public class TestIcebergNamespaceOperations extends IcebergNamespaceTestBase {
     verifyDropNamespaceSucc(Namespace.of("drop_foo3", "a"));
 
     // drop non-empty namespace should return 409 Conflict per Iceberg REST spec
-    String uniqueSuffix = String.valueOf(System.nanoTime());
-    Namespace nonEmptyNs = Namespace.of("drop_nonempty_foo_" + uniqueSuffix);
+    Namespace nonEmptyNs = Namespace.of("drop_nonempty_foo");
     verifyCreateNamespaceSucc(nonEmptyNs);
-    verifyRegisterTableSucc("drop_nonempty_table_" + uniqueSuffix, nonEmptyNs);
+    verifyCreateTableSucc(nonEmptyNs, "drop_nonempty_table");
     verifyDropNamespaceFail(409, nonEmptyNs);
+    verifyDropTableSucc(nonEmptyNs, "drop_nonempty_table");
+    verifyDropNamespaceSucc(nonEmptyNs);
+  }
+
+  private void verifyCreateTableSucc(Namespace ns, String tableName) {
+    CreateTableRequest createTableRequest =
+        CreateTableRequest.builder()
+            .withName(tableName)
+            .withSchema(DROP_NONEMPTY_TABLE_SCHEMA)
+            .build();
+    Response response =
+        getTableClientBuilder(ns, Optional.empty())
+            .post(Entity.entity(createTableRequest, MediaType.APPLICATION_JSON_TYPE));
+    Assertions.assertEquals(Status.OK.getStatusCode(), response.getStatus());
+  }
+
+  private void verifyDropTableSucc(Namespace ns, String tableName) {
+    Response response = getTableClientBuilder(ns, Optional.of(tableName)).delete();
+    Assertions.assertEquals(Status.NO_CONTENT.getStatusCode(), response.getStatus());
   }
 
   @Test

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/TestIcebergNamespaceOperations.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/TestIcebergNamespaceOperations.java
@@ -185,9 +185,10 @@ public class TestIcebergNamespaceOperations extends IcebergNamespaceTestBase {
     verifyDropNamespaceSucc(Namespace.of("drop_foo3", "a"));
 
     // drop non-empty namespace should return 409 Conflict per Iceberg REST spec
-    Namespace nonEmptyNs = Namespace.of("drop_nonempty_foo");
+    String uniqueSuffix = String.valueOf(System.nanoTime());
+    Namespace nonEmptyNs = Namespace.of("drop_nonempty_foo_" + uniqueSuffix);
     verifyCreateNamespaceSucc(nonEmptyNs);
-    verifyRegisterTableSucc("drop_nonempty_table", nonEmptyNs);
+    verifyRegisterTableSucc("drop_nonempty_table_" + uniqueSuffix, nonEmptyNs);
     verifyDropNamespaceFail(409, nonEmptyNs);
   }
 

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/TestIcebergNamespaceOperations.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/TestIcebergNamespaceOperations.java
@@ -64,11 +64,10 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mockito;
 
-@SuppressWarnings("deprecation")
 public class TestIcebergNamespaceOperations extends IcebergNamespaceTestBase {
 
   private static final Schema DROP_NONEMPTY_TABLE_SCHEMA =
-      new Schema(NestedField.of(1, false, "foo_string", StringType.get()));
+      new Schema(NestedField.required(1, "foo_string", StringType.get()));
 
   private DummyEventListener dummyEventListener;
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Map `NamespaceNotEmptyException` to HTTP 409 Conflict in `IcebergExceptionMapper`, aligned with the Iceberg REST spec and upstream `RESTCatalogAdapter`. Stop converting `NamespaceNotEmptyException` to `BadRequestException` in `convertToIcebergException`. Update unit tests and add REST test coverage for dropping a non-empty namespace.

### Why are the changes needed?

The Iceberg REST spec requires HTTP 409 Conflict when `dropNamespace` is called on a non-empty namespace. Gravitino currently returns 400 Bad Request, which is non-conformant.

Fix: #11132

### Does this PR introduce _any_ user-facing change?

Yes. Clients receive HTTP 409 Conflict instead of 400 Bad Request when dropping a non-empty namespace. The error type remains `NamespaceNotEmptyException`.

### How was this patch tested?

- `./gradlew :iceberg:iceberg-rest-server:test --tests "org.apache.gravitino.iceberg.service.TestIcebergExceptionMapper" -PskipITs`
- `./gradlew :iceberg:iceberg-rest-server:test --tests "org.apache.gravitino.iceberg.service.rest.TestIcebergNamespaceOperations#testDropNamespace" -PskipITs`
- `./gradlew :iceberg:iceberg-rest-server:test --tests "org.apache.gravitino.iceberg.integration.test.IcebergRESTMemoryCatalogIT#testDropNameSpace" -PskipITs`