### PR TITLE
[#11164] improvement(build): Clean distribution package before copying files

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -69,6 +69,9 @@ if (scalaVersion !in listOf("2.12", "2.13")) {
 }
 
 val skipWeb: Boolean = (project.findProperty("skipWeb") as? String)?.toBoolean() ?: false
+val distributionPackageDir = layout.projectDirectory.dir("distribution/package")
+val distributionPackageAllDir = layout.projectDirectory.dir("distribution/package-all")
+val subprojectJarOutputDirs = subprojects.map { it.layout.buildDirectory.dir("libs") }
 
 project.extra["extraJvmArgs"] =
   listOf(
@@ -790,6 +793,12 @@ jacoco {
 tasks {
   val projectDir = layout.projectDirectory
   val outputDir = projectDir.dir("distribution")
+  val cleanDistributionPackage by registering(Delete::class) {
+    group = "gravitino distribution"
+    delete(distributionPackageDir, distributionPackageAllDir)
+    delete(subprojectJarOutputDirs)
+  }
+
   val compileDistribution by registering {
     val dependencies =
       mutableListOf(
@@ -808,10 +817,12 @@ tasks {
       dependencies.add(":web:web:build")
       dependencies.add(":web-v2:web:build")
     }
+    dependsOn(cleanDistributionPackage)
     dependsOn(dependencies)
 
     group = "gravitino distribution"
-    outputs.dir(projectDir.dir("distribution/package"))
+    outputs.dir(distributionPackageDir)
+    outputs.dir(distributionPackageAllDir)
     doLast {
       copy {
         from(projectDir.dir("conf")) { into("package/conf") }
@@ -867,8 +878,8 @@ tasks {
 
       // Copy the all directory distribution/package to distribution/package-all
       copy {
-        from(projectDir.dir("distribution/package"))
-        into(projectDir.dir("distribution/package-all"))
+        from(distributionPackageDir)
+        into(distributionPackageAllDir)
       }
 
       // remove catalogs-contrib modules from distribution/package
@@ -978,6 +989,7 @@ tasks {
 
   val assembleDistribution by registering(Tar::class) {
     dependsOn(
+      compileDistribution,
       ":trino-connector:trino-connector-435-439:assembleTrinoConnector",
       ":trino-connector:trino-connector-440-445:assembleTrinoConnector",
       ":trino-connector:trino-connector-446-451:assembleTrinoConnector",
@@ -990,7 +1002,7 @@ tasks {
     group = "gravitino distribution"
     finalizedBy("checksumDistribution")
     into("${rootProject.name}-$version-bin")
-    from(compileDistribution.map { it.outputs.files.single() })
+    from(distributionPackageDir)
     compression = Compression.GZIP
     archiveFileName.set("${rootProject.name}-$version-bin.tar.gz")
     destinationDirectory.set(projectDir.dir("distribution"))
@@ -1207,6 +1219,32 @@ tasks {
 
   clean {
     dependsOn(cleanDistribution)
+  }
+}
+
+gradle.projectsEvaluated {
+  val cleanDistributionPackageTask = rootProject.tasks.named("cleanDistributionPackage")
+  val distributionPackagePaths =
+    listOf(distributionPackageDir, distributionPackageAllDir)
+      .map { it.asFile.toPath().toAbsolutePath().normalize() }
+  val subprojectJarOutputPaths =
+    subprojectJarOutputDirs.map { it.get().asFile.toPath().toAbsolutePath().normalize() }
+
+  allprojects {
+    tasks.withType<Jar>().configureEach {
+      mustRunAfter(cleanDistributionPackageTask)
+    }
+
+    tasks.withType<Copy>().configureEach {
+      val copyDestinationDir = destinationDir ?: return@configureEach
+      val destinationPath = copyDestinationDir.toPath().toAbsolutePath().normalize()
+      if (distributionPackagePaths.any { destinationPath.startsWith(it) }) {
+        dependsOn(cleanDistributionPackageTask)
+      }
+      if (subprojectJarOutputPaths.any { destinationPath.startsWith(it) }) {
+        mustRunAfter(cleanDistributionPackageTask)
+      }
+    }
   }
 }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This change adds a dedicated `cleanDistributionPackage` task to remove stale distribution package outputs and subproject jar outputs before distribution artifacts are copied.

The task cleans:
- `distribution/package`
- `distribution/package-all`
- subproject `build/libs` directories

Copy tasks that write into the distribution package directories are wired to depend on `cleanDistributionPackage`. Jar-producing tasks and copy tasks that write into subproject `build/libs` are ordered to run after the clean task, so stale jars are removed before new artifacts are generated and copied.

### Why are the changes needed?

`compileDistribution` previously copied new files into distribution package directories without removing files that were no longer produced by the current build. After dependency version bumps, stale jars could remain either in the distribution package outputs or in subproject `build/libs` directories that are used as copy sources.

This may cause non-deterministic local failures when old and new versions of the same jar coexist.

I avoided deleting the package directories directly in `compileDistribution.doFirst` because `compileDistribution` depends on several copy tasks. A `doFirst` action on `compileDistribution` may run after those dependent copy tasks and delete files that were just copied.

This approach avoids a full repository clean while still cleaning the jar/package outputs relevant to `compileDistribution`.

Fix: #11164

### Does this PR introduce _any_ user-facing change?

No. This only changes the local distribution build behavior.

### How was this patch tested?

- `./gradlew compileDistribution -PskipWeb=true -x test --dry-run`
  - Verified `:cleanDistributionPackage` is scheduled before jar/copy tasks.
  - Verified there is no dependency cycle.

- `./gradlew compileDistribution -PskipWeb=true -x test`
  - Build succeeded with `lance = "2.0.1"`.

- Changed `lance` in `gradle/libs.versions.toml` from `2.0.1` to `2.0.0`.

- Re-ran `./gradlew compileDistribution -PskipWeb=true -x test`
  - Build succeeded with `lance = "2.0.0"`.

- Verified the old Lance jar was removed:
  - `find lance/lance-rest-server/build/libs distribution/package distribution/package-all -name 'lance-core-2.0.1.jar' -print`
  - Result: no output.

- Verified the current Lance jar exists in expected locations:
  - `find lance/lance-rest-server/build/libs distribution/package distribution/package-all -name 'lance-core-2.0.0.jar' -print`
  - Result includes:
    - `lance/lance-rest-server/build/libs/lance-core-2.0.0.jar`
    - `distribution/package/libs/lance-core-2.0.0.jar`
    - `distribution/package/lance-rest-server/libs/lance-core-2.0.0.jar`
    - `distribution/package-all/libs/lance-core-2.0.0.jar`
    - `distribution/package-all/lance-rest-server/libs/lance-core-2.0.0.jar`

- Restored `lance` in `gradle/libs.versions.toml` from `2.0.0` to `2.0.1`.

- Re-ran `./gradlew compileDistribution -PskipWeb=true -x test`
  - Build succeeded with `lance = "2.0.1"`.

- Verified the temporary Lance jar was removed:
  - `find lance/lance-rest-server/build/libs distribution/package distribution/package-all -name 'lance-core-2.0.0.jar' -print`
  - Result: no output.

- Verified the restored Lance jar exists in expected locations:
  - `find lance/lance-rest-server/build/libs distribution/package distribution/package-all -name 'lance-core-2.0.1.jar' -print`

- `./gradlew spotlessApply`
- `git diff --check`