### PR TITLE
[SPARK] Add bearer token file authentication mode

### DIFF
--- a/docs/spark-connector/spark-authentication-with-gravitino.md
+++ b/docs/spark-connector/spark-authentication-with-gravitino.md
@@ -7,11 +7,11 @@ license: "This software is licensed under the Apache License version 2."
 
 ## Overview
 
-Spark connector supports `simple` `oauth2` and `kerberos` authentication when accessing Gravitino server.
+Spark connector supports `simple`, `oauth2`, `bearer-token-file` and `kerberos` authentication when accessing Gravitino server.
 
 | Property                     | Type   | Default Value | Description                                                                                                         | Required | Since Version    |
 |------------------------------|--------|---------------|---------------------------------------------------------------------------------------------------------------------|----------|------------------|
-| spark.sql.gravitino.authType | string | `simple`      | The authentication mechanisms when communicating with Gravitino server, supports `simple`, `oauth2` and `kerberos`. | No       | 0.7.0-incubating |
+| spark.sql.gravitino.authType | string | `simple`      | The authentication mechanisms when communicating with Gravitino server, supports `simple`, `oauth2`, `bearer-token-file` and `kerberos`. | No       | 0.7.0-incubating |
 
 ## Simple mode
 
@@ -30,6 +30,14 @@ In the OAuth2 mode, you could use the following configuration to fetch an OAuth2
 | spark.sql.gravitino.oauth2.tokenPath  | string | None          | The path of token interface in OAuth2 server. | Yes, for OAuth2 mode | 0.7.0-incubating |
 | spark.sql.gravitino.oauth2.credential | string | None          | The credential to request the OAuth2 token.   | Yes, for OAuth2 mode | 0.7.0-incubating |
 | spark.sql.gravitino.oauth2.scope      | string | None          | The scope to request the OAuth2 token.        | Yes, for OAuth2 mode | 0.7.0-incubating |
+
+## Bearer token file mode
+
+In bearer token file mode, Spark connector reads an existing Bearer token from a local file when accessing Gravitino server. This is useful when another trusted runtime component, such as a sidecar, refreshes the token file outside the Spark connector.
+
+| Property                                | Type   | Default Value | Description                                                                                  | Required                         | Since Version |
+|-----------------------------------------|--------|---------------|----------------------------------------------------------------------------------------------|----------------------------------|---------------|
+| spark.sql.gravitino.bearer.tokenFile    | string | None          | The local file path containing a Bearer token. The file may contain either the raw token or a `Bearer ` prefixed value. | Yes, for bearer-token-file mode | TBD           |
 
 ## Kerberos mode
 

--- a/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/GravitinoSparkConfig.java
+++ b/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/GravitinoSparkConfig.java
@@ -42,6 +42,8 @@ public class GravitinoSparkConfig {
       GRAVITINO_PREFIX + AuthProperties.GRAVITINO_OAUTH2_CREDENTIAL;
   public static final String GRAVITINO_OAUTH2_SCOPE =
       GRAVITINO_PREFIX + AuthProperties.GRAVITINO_OAUTH2_SCOPE;
+  public static final String GRAVITINO_BEARER_TOKEN_FILE =
+      GRAVITINO_PREFIX + "bearer.tokenFile";
   public static final String GRAVITINO_KERBEROS_PRINCIPAL = "spark.kerberos.principal";
   public static final String GRAVITINO_KERBEROS_KEYTAB_FILE_PATH = "spark.kerberos.keytab";
 

--- a/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/auth/BearerTokenFileProvider.java
+++ b/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/auth/BearerTokenFileProvider.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.spark.connector.auth;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.gravitino.client.CustomTokenProvider;
+
+/** Provides a Bearer token by reading a token file for each Gravitino client request. */
+public final class BearerTokenFileProvider extends CustomTokenProvider {
+  private static final String BEARER_PREFIX = "Bearer ";
+
+  private final Path tokenFile;
+
+  public BearerTokenFileProvider(String tokenFile) {
+    if (StringUtils.isBlank(tokenFile)) {
+      throw new IllegalArgumentException("tokenFile cannot be blank");
+    }
+
+    this.schemeName = "Bearer";
+    this.tokenFile = new File(tokenFile).toPath();
+  }
+
+  @Override
+  protected String getCustomTokenInfo() {
+    try {
+      String token = new String(Files.readAllBytes(tokenFile), StandardCharsets.UTF_8).trim();
+      if (token.startsWith(BEARER_PREFIX)) {
+        token = token.substring(BEARER_PREFIX.length()).trim();
+      }
+
+      if (StringUtils.isBlank(token)) {
+        throw new IllegalStateException("Bearer token file is empty: " + tokenFile);
+      }
+
+      return token;
+    } catch (IOException e) {
+      throw new IllegalStateException("Failed to read Bearer token file: " + tokenFile, e);
+    }
+  }
+}

--- a/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/plugin/GravitinoDriverPlugin.java
+++ b/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/plugin/GravitinoDriverPlugin.java
@@ -46,6 +46,7 @@ import org.apache.gravitino.client.GravitinoClient.ClientBuilder;
 import org.apache.gravitino.client.GravitinoClientConfiguration;
 import org.apache.gravitino.client.KerberosTokenProvider;
 import org.apache.gravitino.spark.connector.GravitinoSparkConfig;
+import org.apache.gravitino.spark.connector.auth.BearerTokenFileProvider;
 import org.apache.gravitino.spark.connector.catalog.GravitinoCatalogManager;
 import org.apache.gravitino.spark.connector.iceberg.extensions.GravitinoIcebergSparkSessionExtensions;
 import org.apache.gravitino.spark.connector.version.CatalogNameAdaptor;
@@ -206,6 +207,10 @@ public class GravitinoDriverPlugin implements DriverPlugin {
           !UserGroupInformation.isSecurityEnabled(),
           "Spark simple auth mode doesn't support setting kerberos configurations");
       builder.withSimpleAuth(sparkUser);
+    } else if ("bearer-token-file".equalsIgnoreCase(authType)) {
+      String tokenFile =
+          getRequiredConfig(sparkConf, GravitinoSparkConfig.GRAVITINO_BEARER_TOKEN_FILE);
+      builder.withCustomTokenAuth(new BearerTokenFileProvider(tokenFile));
     } else if (AuthProperties.isOAuth2(authType)) {
       String oAuthUri = getRequiredConfig(sparkConf, GravitinoSparkConfig.GRAVITINO_OAUTH2_URI);
       String credential =

--- a/spark-connector/spark-common/src/test/java/org/apache/gravitino/spark/connector/TestGravitinoSparkConfig.java
+++ b/spark-connector/spark-common/src/test/java/org/apache/gravitino/spark/connector/TestGravitinoSparkConfig.java
@@ -43,4 +43,11 @@ public class TestGravitinoSparkConfig {
     Assertions.assertEquals(clientConfig.get("gravitino.client.socketTimeoutMs"), "1000");
     Assertions.assertEquals(clientConfig.get("gravitino.client.connectionTimeoutMs"), "2000");
   }
+
+  @Test
+  void testBearerTokenFileConfig() {
+    Assertions.assertEquals(
+        "spark.sql.gravitino.bearer.tokenFile",
+        GravitinoSparkConfig.GRAVITINO_BEARER_TOKEN_FILE);
+  }
 }

--- a/spark-connector/spark-common/src/test/java/org/apache/gravitino/spark/connector/auth/TestBearerTokenFileProvider.java
+++ b/spark-connector/spark-common/src/test/java/org/apache/gravitino/spark/connector/auth/TestBearerTokenFileProvider.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.spark.connector.auth;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TestBearerTokenFileProvider {
+
+  @Test
+  void testReadRawTokenFromFile() throws Exception {
+    Path tokenFile = Files.createTempFile("gravitino-token", ".txt");
+    Files.write(tokenFile, "token-value
+".getBytes(StandardCharsets.UTF_8));
+
+    try (BearerTokenFileProvider provider = new BearerTokenFileProvider(tokenFile.toString())) {
+      Assertions.assertEquals(
+          "Bearer token-value", new String(provider.getTokenData(), StandardCharsets.UTF_8));
+    } finally {
+      Files.deleteIfExists(tokenFile);
+    }
+  }
+
+  @Test
+  void testStripBearerPrefixFromFile() throws Exception {
+    Path tokenFile = Files.createTempFile("gravitino-token", ".txt");
+    Files.write(tokenFile, "Bearer token-value
+".getBytes(StandardCharsets.UTF_8));
+
+    try (BearerTokenFileProvider provider = new BearerTokenFileProvider(tokenFile.toString())) {
+      Assertions.assertEquals(
+          "Bearer token-value", new String(provider.getTokenData(), StandardCharsets.UTF_8));
+    } finally {
+      Files.deleteIfExists(tokenFile);
+    }
+  }
+
+  @Test
+  void testRejectBlankTokenFile() throws Exception {
+    Path tokenFile = Files.createTempFile("gravitino-token", ".txt");
+    Files.write(tokenFile, " 
+".getBytes(StandardCharsets.UTF_8));
+
+    try (BearerTokenFileProvider provider = new BearerTokenFileProvider(tokenFile.toString())) {
+      Assertions.assertThrows(IllegalStateException.class, provider::getTokenData);
+    } finally {
+      Files.deleteIfExists(tokenFile);
+    }
+  }
+}

--- a/spark-connector/spark-common/src/test/java/org/apache/gravitino/spark/connector/auth/TestBearerTokenFileProvider.java
+++ b/spark-connector/spark-common/src/test/java/org/apache/gravitino/spark/connector/auth/TestBearerTokenFileProvider.java
@@ -30,8 +30,7 @@ public class TestBearerTokenFileProvider {
   @Test
   void testReadRawTokenFromFile() throws Exception {
     Path tokenFile = Files.createTempFile("gravitino-token", ".txt");
-    Files.write(tokenFile, "token-value
-".getBytes(StandardCharsets.UTF_8));
+    Files.write(tokenFile, "token-value\n".getBytes(StandardCharsets.UTF_8));
 
     try (BearerTokenFileProvider provider = new BearerTokenFileProvider(tokenFile.toString())) {
       Assertions.assertEquals(
@@ -44,8 +43,7 @@ public class TestBearerTokenFileProvider {
   @Test
   void testStripBearerPrefixFromFile() throws Exception {
     Path tokenFile = Files.createTempFile("gravitino-token", ".txt");
-    Files.write(tokenFile, "Bearer token-value
-".getBytes(StandardCharsets.UTF_8));
+    Files.write(tokenFile, "Bearer token-value\n".getBytes(StandardCharsets.UTF_8));
 
     try (BearerTokenFileProvider provider = new BearerTokenFileProvider(tokenFile.toString())) {
       Assertions.assertEquals(
@@ -58,8 +56,7 @@ public class TestBearerTokenFileProvider {
   @Test
   void testRejectBlankTokenFile() throws Exception {
     Path tokenFile = Files.createTempFile("gravitino-token", ".txt");
-    Files.write(tokenFile, " 
-".getBytes(StandardCharsets.UTF_8));
+    Files.write(tokenFile, " \n".getBytes(StandardCharsets.UTF_8));
 
     try (BearerTokenFileProvider provider = new BearerTokenFileProvider(tokenFile.toString())) {
       Assertions.assertThrows(IllegalStateException.class, provider::getTokenData);


### PR DESCRIPTION
## What is changed

This PR adds a `bearer-token-file` authentication mode to the Spark connector.

New configuration:

```properties
spark.sql.gravitino.authType=bearer-token-file
spark.sql.gravitino.bearer.tokenFile=/path/to/token
```

The connector reads an existing Bearer token from the configured local file and sends it to Gravitino using the existing custom token provider path:

```text
Authorization: Bearer <token>
```

The token file may contain either the raw token or a `Bearer ` prefixed value.

## Why

Some runtime environments refresh short-lived user or workload tokens outside the Spark connector, for example with a trusted sidecar or workload identity component. The existing OAuth2 mode requires the connector to request a token from an OAuth2 endpoint with configured credentials, which is not appropriate for those deployments.

This change keeps token acquisition outside the Spark connector and only adds a generic way for the connector to reuse an existing local Bearer token.

## Notes

- The Gravitino server does not read the token file.
- The token file is local to the Spark driver runtime.
- The feature is not tied to JupyterHub, Kubernetes, or any specific identity provider.
- The implementation uses the existing `CustomTokenProvider` extension point.

## Tests

Added unit tests for:

- Reading a raw token from a file.
- Reading a `Bearer ` prefixed token from a file.
- Rejecting an empty token file.
- Verifying the Spark config key.


Closes #11181.

Related to #10978, but this PR does not attempt to close it because that issue appears to involve Iceberg REST / authorization cache behavior beyond Spark connector token-file authentication.

