### PR TITLE
[#11190] fix(iceberg): handle missing catalog during authorization skip

### DIFF
--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/server/web/filter/IcebergMetadataAuthorizationMethodInterceptor.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/server/web/filter/IcebergMetadataAuthorizationMethodInterceptor.java
@@ -26,6 +26,7 @@ import java.util.Optional;
 import org.apache.gravitino.Entity;
 import org.apache.gravitino.Entity.EntityType;
 import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.exceptions.NoSuchCatalogException;
 import org.apache.gravitino.iceberg.common.ops.IcebergCatalogWrapper;
 import org.apache.gravitino.iceberg.service.IcebergCatalogWrapperManager;
 import org.apache.gravitino.iceberg.service.IcebergRESTUtils;
@@ -159,7 +160,12 @@ public class IcebergMetadataAuthorizationMethodInterceptor
       return false;
     }
 
-    IcebergCatalogWrapper catalogWrapper = wrapperManager.getCatalogWrapper(catalogId.name());
+    IcebergCatalogWrapper catalogWrapper;
+    try {
+      catalogWrapper = wrapperManager.getCatalogWrapper(catalogId.name());
+    } catch (NoSuchCatalogException e) {
+      return false;
+    }
     // When IRC2 is another Gravitino server, IRC1 acts as a proxy and does not perform
     // authorization. IRC2 handles authorization.
     return catalogWrapper.isRESTCatalog();

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/server/web/filter/TestIcebergMetadataAuthorizationMethodInterceptor.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/server/web/filter/TestIcebergMetadataAuthorizationMethodInterceptor.java
@@ -37,6 +37,7 @@ import org.apache.gravitino.Configs;
 import org.apache.gravitino.Entity;
 import org.apache.gravitino.GravitinoEnv;
 import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.exceptions.NoSuchCatalogException;
 import org.apache.gravitino.iceberg.service.CatalogWrapperForREST;
 import org.apache.gravitino.iceberg.service.IcebergCatalogWrapperManager;
 import org.apache.gravitino.iceberg.service.authorization.IcebergRESTServerContext;
@@ -334,6 +335,24 @@ public class TestIcebergMetadataAuthorizationMethodInterceptor {
     Object result = interceptor.invoke(invocation);
 
     assertNotEquals("PROCEEDED", result);
+  }
+
+  @Test
+  public void testShouldSkipAuthorizationReturnsFalseWhenCatalogDoesNotExist() {
+    IcebergCatalogWrapperManager wrapperManager = Mockito.mock(IcebergCatalogWrapperManager.class);
+    Mockito.when(wrapperManager.getCatalogWrapper(TEST_CATALOG))
+        .thenThrow(
+            new NoSuchCatalogException(
+                "Couldn't find Iceberg configuration for catalog %s", TEST_CATALOG));
+    resetContext(wrapperManager, true);
+
+    IcebergMetadataAuthorizationMethodInterceptor interceptor =
+        new IcebergMetadataAuthorizationMethodInterceptor();
+
+    assertFalse(
+        interceptor.shouldSkipAuthorization(
+            Map.of(Entity.EntityType.CATALOG, NameIdentifier.of(TEST_METALAKE, TEST_CATALOG))));
+    Mockito.verify(wrapperManager).getCatalogWrapper(TEST_CATALOG);
   }
 
   private void resetContext(IcebergCatalogWrapperManager wrapperManager) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR handles the missing catalog case in Iceberg REST authorization skip checks.

When `shouldSkipAuthorization()` checks whether the target catalog is a REST catalog, `getCatalogWrapper()` may throw `NoSuchCatalogException` if the catalog does not exist. This PR catches that exception and returns `false`, allowing the request to continue through the normal path where the missing catalog can be reported as a catalog-not-found error.

### Why are the changes needed?

Fix: #11190

Without this change, a missing catalog during the authorization skip check can be surfaced as an authorization internal error instead of the expected catalog-not-found behavior.

### Does this PR introduce any user-facing change?

No API change.

The error handling path is corrected for missing Iceberg REST catalogs.

### How was this patch tested?

Added a unit test for the missing catalog skip-check path.

Ran:

`./gradlew :iceberg:iceberg-rest-server:test --tests org.apache.gravitino.server.web.filter.TestIcebergMetadataAuthorizationMethodInterceptor -PskipITs -PskipDockerTests=true`