### PR TITLE
[#10543] docs(flink): Update connector version compatibility

### DIFF
--- a/docs/flink-connector/flink-catalog-iceberg.md
+++ b/docs/flink-connector/flink-catalog-iceberg.md
@@ -31,6 +31,21 @@ To enable the Flink connector, you must download the Iceberg Flink runtime JAR a
 - `DELETE` clause
 - `CREATE TABLE LIKE` clause
 
+## Getting Started
+
+### Prerequisites
+
+Place the following JAR files in the lib directory of your Flink installation:
+
+- The Iceberg Flink runtime JAR that matches your Flink minor version
+- The Gravitino Flink connector runtime JAR that matches your Flink minor version
+
+| Flink version | Iceberg runtime artifact | Gravitino runtime artifact |
+|---------------|--------------------------|----------------------------|
+| 1.18          | `iceberg-flink-runtime-1.18-${iceberg-version}.jar` | `gravitino-flink-connector-runtime-1.18_2.12-${gravitino-version}.jar` |
+| 1.19          | `iceberg-flink-runtime-1.19-${iceberg-version}.jar` | `gravitino-flink-connector-runtime-1.19_2.12-${gravitino-version}.jar` |
+| 1.20          | `iceberg-flink-runtime-1.20-${iceberg-version}.jar` | `gravitino-flink-connector-runtime-1.20_2.12-${gravitino-version}.jar` |
+
 ## SQL example
 
 ```sql
@@ -62,7 +77,7 @@ The Gravitino Flink connector transforms the following properties in a catalog t
 
 | Gravitino catalog property name | Flink Iceberg connector configuration | Description                                                                                                   | Since Version    |
 |---------------------------------|---------------------------------------|---------------------------------------------------------------------------------------------------------------|------------------|
-| `catalog-backend`               | `catalog-type`                        | Catalog backend type, currently, only `Hive` Catalog is supported, `JDBC` and `Rest` in Continuous Validation | 0.8.0-incubating |
+| `catalog-backend`               | `catalog-type`                        | Catalog backend type, currently, `Hive` and `REST` catalogs are supported, and `JDBC` is in continuous validation | 0.8.0-incubating |
 | `uri`                           | `uri`                                 | Catalog backend URI                                                                                           | 0.8.0-incubating |
 | `warehouse`                     | `warehouse`                           | Catalog backend warehouse                                                                                     | 0.8.0-incubating |
 | `io-impl`                       | `io-impl`                             | The IO implementation for `FileIO` in Iceberg.                                                                | 0.8.0-incubating |

--- a/docs/flink-connector/flink-catalog-jdbc.md
+++ b/docs/flink-connector/flink-catalog-jdbc.md
@@ -19,9 +19,15 @@ This document provides a comprehensive guide on configuring and using Apache Gra
 
 Place the following JAR files in the lib directory of your Flink installation:
 
-- [`flink-connector-jdbc-${flinkJdbcConnectorVersion}.jar`](https://nightlies.apache.org/flink/flink-docs-release-1.18/docs/connectors/table/jdbc/)
-- [`gravitino-flink-connector-runtime-1.18_2.12-${gravitino-version}.jar`](https://mvnrepository.com/artifact/org.apache.gravitino/gravitino-flink-connector-runtime-1.18)
+- The Flink JDBC connector JAR that matches your Flink minor version
+- The Gravitino Flink connector runtime JAR that matches your Flink minor version
 - JDBC driver
+
+| Flink version | Flink JDBC connector version | Gravitino runtime artifact |
+|---------------|------------------------------|----------------------------|
+| 1.18          | `3.2.0-1.18`                 | `gravitino-flink-connector-runtime-1.18_2.12-${gravitino-version}.jar` |
+| 1.19          | `3.3.0-1.19`                 | `gravitino-flink-connector-runtime-1.19_2.12-${gravitino-version}.jar` |
+| 1.20          | `3.3.0-1.20`                 | `gravitino-flink-connector-runtime-1.20_2.12-${gravitino-version}.jar` |
 
 Next, when you create the JDBC catalog in Gravitino, add the `flink.bypass.default-database` property with the value of the default database name.
 
@@ -125,4 +131,3 @@ Gravitino Flink connector will transform below property names which are defined 
 | `username`                      | `username`                         | Username of MySQL account      | 0.9.0-incubating |
 | `password`                      | `password`                         | Password of the account        | 0.9.0-incubating |
 | `flink.bypass.default-database` | `default-database`                 | Default database to connect to | 0.9.0-incubating |
-

--- a/docs/flink-connector/flink-catalog-paimon.md
+++ b/docs/flink-connector/flink-catalog-paimon.md
@@ -38,9 +38,9 @@ Supports most DDL and DML operations in Flink SQL, except such operations:
 
 ## Requirement
 
-* Paimon 0.8
+* Paimon 1.2.0 is fully tested.
 
-Higher version like 0.9 or above may also support but have not been tested fully.
+Other Paimon versions may also work but have not been tested fully.
 
 ## Getting Started
 
@@ -48,8 +48,14 @@ Higher version like 0.9 or above may also support but have not been tested fully
 
 Place the following JAR files in the lib directory of your Flink installation:
 
-- `paimon-flink-1.18-${paimon-version}.jar`
-- `gravitino-flink-connector-runtime-1.18_2.12-${gravitino-version}.jar`
+- The Paimon Flink connector JAR that matches your Flink minor version
+- The Gravitino Flink connector runtime JAR that matches your Flink minor version
+
+| Flink version | Paimon connector artifact | Gravitino runtime artifact |
+|---------------|---------------------------|----------------------------|
+| 1.18          | `paimon-flink-1.18-${paimon-version}.jar` | `gravitino-flink-connector-runtime-1.18_2.12-${gravitino-version}.jar` |
+| 1.19          | `paimon-flink-1.19-${paimon-version}.jar` | `gravitino-flink-connector-runtime-1.19_2.12-${gravitino-version}.jar` |
+| 1.20          | `paimon-flink-1.20-${paimon-version}.jar` | `gravitino-flink-connector-runtime-1.20_2.12-${gravitino-version}.jar` |
 
 ### SQL Example
 

--- a/docs/flink-connector/flink-connector.md
+++ b/docs/flink-connector/flink-connector.md
@@ -7,8 +7,10 @@ license: "This software is licensed under the Apache License version 2."
 
 ## Overview
 
-The Apache Gravitino Flink connector implements the [Catalog Store](https://nightlies.apache.org/flink/flink-docs-release-1.18/docs/dev/table/catalogs/#catalog-store) to manage the catalogs under Gravitino.
+The Apache Gravitino Flink connector implements the [Catalog Store](https://nightlies.apache.org/flink/flink-docs-release-1.20/docs/dev/table/catalogs/#catalog-store) to manage the catalogs under Gravitino.
 This capability allows users to perform federation queries, accessing data from various catalogs through a unified interface and consistent access control.
+
+The connector is published as a version-specific runtime JAR for each supported Flink minor version. Internally, Gravitino uses shared connector logic with version-specific catalog and factory entry points so that each runtime artifact matches the Flink APIs it runs against.
 
 ## Capabilities
 
@@ -20,13 +22,21 @@ This capability allows users to perform federation queries, accessing data from 
 
 ## Requirement
 
-* Flink 1.18
 * Scala 2.12
+* Flink 1.18, 1.19, or 1.20
 * JDK 8, 11 or 17
 
 ## How to use it
 
-1. [Build](../how-to-build.md) or [download](https://mvnrepository.com/artifact/org.apache.gravitino/gravitino-flink-connector-runtime-1.18) the Gravitino flink connector runtime jar, and place it to the classpath of Flink.
+1. [Build](../how-to-build.md) or download the Gravitino Flink connector runtime JAR that matches your Flink minor version, and place it in the classpath of Flink.
+
+| Flink version | Runtime artifact |
+|---------------|------------------|
+| 1.18          | `gravitino-flink-connector-runtime-1.18_2.12-${gravitino-version}.jar` |
+| 1.19          | `gravitino-flink-connector-runtime-1.19_2.12-${gravitino-version}.jar` |
+| 1.20          | `gravitino-flink-connector-runtime-1.20_2.12-${gravitino-version}.jar` |
+
+Do not mix runtime JARs from different Flink minor versions in the same Flink deployment.
 
 2. Configure the Flink configuration to use the Gravitino flink connector.
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR updates the Flink connector documentation to describe the supported Flink minor versions and the matching runtime artifacts for Flink 1.18, 1.19, and 1.20.

It also updates the JDBC, Paimon, and Iceberg catalog docs to clarify which dependency artifacts should be used with each Flink version.

### Why are the changes needed?

The Flink connector now supports multiple Flink minor versions, but the user-facing documentation still primarily referenced Flink 1.18 artifacts.

Fix: #10543

### Does this PR introduce _any_ user-facing change?

Yes. This is a documentation-only change that clarifies supported Flink versions and required runtime artifacts.

### How was this patch tested?

- ./gradlew :docs:build