### PR TITLE
[#9970][followup] improvement(core): Batch hierarchical schema cascade deletion

### DIFF
--- a/core/src/main/java/org/apache/gravitino/catalog/SchemaOperationDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/SchemaOperationDispatcher.java
@@ -351,9 +351,11 @@ public class SchemaOperationDispatcher extends OperationDispatcher implements Sc
   /**
    * Reconciles auto-created ancestor entities after a hierarchical schema leaf is dropped. This
    * mirrors {@code IcebergNamespaceHookDispatcher.dropNamespace}: walk the ancestors
-   * innermost-to-outermost and delete the orphaned Gravitino entity for each ancestor that no
-   * longer exists in the catalog, stopping at the first ancestor that still exists (its existence
-   * implies all of its outer ancestors exist). For a flat schema name this is a no-op.
+   * innermost-to-outermost to find the outermost ancestor that no longer exists in the catalog,
+   * stopping at the first ancestor that still exists (its existence implies all of its outer
+   * ancestors exist). A single cascade delete of that outermost orphaned ancestor removes it and
+   * all descendant schema entities (the intermediate ancestors) in one batched operation, rather
+   * than issuing one delete per ancestor. For a flat schema name this is a no-op.
    *
    * @param catalogIdent the identifier of the catalog the schema belongs to
    * @param ident the identifier of the dropped (leaf) schema
@@ -363,6 +365,7 @@ public class SchemaOperationDispatcher extends OperationDispatcher implements Sc
     List<String> ancestorNames = HierarchicalSchemaUtil.getAncestorNames(ident.name(), separator);
     String metalake = ident.namespace().level(0);
     String catalog = ident.namespace().level(1);
+    NameIdentifier outermostOrphan = null;
     for (int i = ancestorNames.size() - 1; i >= 0; i--) {
       NameIdentifier ancestorIdent =
           NameIdentifierUtil.ofSchema(metalake, catalog, ancestorNames.get(i));
@@ -374,13 +377,20 @@ public class SchemaOperationDispatcher extends OperationDispatcher implements Sc
       if (ancestorExistsInCatalog) {
         break;
       }
-      try {
-        store.delete(ancestorIdent, SCHEMA, true);
-      } catch (NoSuchEntityException e) {
-        LOG.warn("The orphaned ancestor schema does not exist in the store: {}", ancestorIdent, e);
-      } catch (Exception e) {
-        throw new RuntimeException(e);
-      }
+      outermostOrphan = ancestorIdent;
+    }
+    if (outermostOrphan == null) {
+      return;
+    }
+    // The leaf was already deleted by the caller; cascade-deleting the outermost orphaned ancestor
+    // cleans up it and every intermediate ancestor (the relational store matches descendant schemas
+    // by name prefix) in a single batched delete.
+    try {
+      store.delete(outermostOrphan, SCHEMA, true);
+    } catch (NoSuchEntityException e) {
+      LOG.warn("The orphaned ancestor schema does not exist in the store: {}", outermostOrphan, e);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
     }
   }
 

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/FilesetMetaMapper.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/FilesetMetaMapper.java
@@ -240,11 +240,6 @@ public interface FilesetMetaMapper {
 
   @UpdateProvider(
       type = FilesetMetaSQLProviderFactory.class,
-      method = "softDeleteFilesetMetasBySchemaId")
-  Integer softDeleteFilesetMetasBySchemaId(@Param("schemaId") Long schemaId);
-
-  @UpdateProvider(
-      type = FilesetMetaSQLProviderFactory.class,
       method = "softDeleteFilesetMetasBySchemaIds")
   Integer softDeleteFilesetMetasBySchemaIds(@Param("schemaIds") List<Long> schemaIds);
 

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/FilesetMetaMapper.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/FilesetMetaMapper.java
@@ -245,6 +245,11 @@ public interface FilesetMetaMapper {
 
   @UpdateProvider(
       type = FilesetMetaSQLProviderFactory.class,
+      method = "softDeleteFilesetMetasBySchemaIds")
+  Integer softDeleteFilesetMetasBySchemaIds(@Param("schemaIds") List<Long> schemaIds);
+
+  @UpdateProvider(
+      type = FilesetMetaSQLProviderFactory.class,
       method = "softDeleteFilesetMetasByFilesetId")
   Integer softDeleteFilesetMetasByFilesetId(@Param("filesetId") Long filesetId);
 

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/FilesetMetaSQLProviderFactory.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/FilesetMetaSQLProviderFactory.java
@@ -117,6 +117,11 @@ public class FilesetMetaSQLProviderFactory {
     return getProvider().softDeleteFilesetMetasBySchemaId(schemaId);
   }
 
+  public static String softDeleteFilesetMetasBySchemaIds(
+      @Param("schemaIds") List<Long> schemaIds) {
+    return getProvider().softDeleteFilesetMetasBySchemaIds(schemaIds);
+  }
+
   public String softDeleteFilesetMetasByFilesetId(@Param("filesetId") Long filesetId) {
     return getProvider().softDeleteFilesetMetasByFilesetId(filesetId);
   }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/FilesetMetaSQLProviderFactory.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/FilesetMetaSQLProviderFactory.java
@@ -113,12 +113,7 @@ public class FilesetMetaSQLProviderFactory {
     return getProvider().softDeleteFilesetMetasByCatalogId(catalogId);
   }
 
-  public static String softDeleteFilesetMetasBySchemaId(@Param("schemaId") Long schemaId) {
-    return getProvider().softDeleteFilesetMetasBySchemaId(schemaId);
-  }
-
-  public static String softDeleteFilesetMetasBySchemaIds(
-      @Param("schemaIds") List<Long> schemaIds) {
+  public static String softDeleteFilesetMetasBySchemaIds(@Param("schemaIds") List<Long> schemaIds) {
     return getProvider().softDeleteFilesetMetasBySchemaIds(schemaIds);
   }
 

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/FilesetVersionMapper.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/FilesetVersionMapper.java
@@ -60,11 +60,6 @@ public interface FilesetVersionMapper {
 
   @UpdateProvider(
       type = FilesetVersionSQLProviderFactory.class,
-      method = "softDeleteFilesetVersionsBySchemaId")
-  Integer softDeleteFilesetVersionsBySchemaId(@Param("schemaId") Long schemaId);
-
-  @UpdateProvider(
-      type = FilesetVersionSQLProviderFactory.class,
       method = "softDeleteFilesetVersionsBySchemaIds")
   Integer softDeleteFilesetVersionsBySchemaIds(@Param("schemaIds") List<Long> schemaIds);
 

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/FilesetVersionMapper.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/FilesetVersionMapper.java
@@ -65,6 +65,11 @@ public interface FilesetVersionMapper {
 
   @UpdateProvider(
       type = FilesetVersionSQLProviderFactory.class,
+      method = "softDeleteFilesetVersionsBySchemaIds")
+  Integer softDeleteFilesetVersionsBySchemaIds(@Param("schemaIds") List<Long> schemaIds);
+
+  @UpdateProvider(
+      type = FilesetVersionSQLProviderFactory.class,
       method = "softDeleteFilesetVersionsByFilesetId")
   Integer softDeleteFilesetVersionsByFilesetId(@Param("filesetId") Long filesetId);
 

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/FilesetVersionSQLProviderFactory.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/FilesetVersionSQLProviderFactory.java
@@ -69,10 +69,6 @@ public class FilesetVersionSQLProviderFactory {
     return getProvider().softDeleteFilesetVersionsByCatalogId(catalogId);
   }
 
-  public static String softDeleteFilesetVersionsBySchemaId(@Param("schemaId") Long schemaId) {
-    return getProvider().softDeleteFilesetVersionsBySchemaId(schemaId);
-  }
-
   public static String softDeleteFilesetVersionsBySchemaIds(
       @Param("schemaIds") List<Long> schemaIds) {
     return getProvider().softDeleteFilesetVersionsBySchemaIds(schemaIds);

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/FilesetVersionSQLProviderFactory.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/FilesetVersionSQLProviderFactory.java
@@ -73,6 +73,11 @@ public class FilesetVersionSQLProviderFactory {
     return getProvider().softDeleteFilesetVersionsBySchemaId(schemaId);
   }
 
+  public static String softDeleteFilesetVersionsBySchemaIds(
+      @Param("schemaIds") List<Long> schemaIds) {
+    return getProvider().softDeleteFilesetVersionsBySchemaIds(schemaIds);
+  }
+
   public static String softDeleteFilesetVersionsByFilesetId(@Param("filesetId") Long filesetId) {
     return getProvider().softDeleteFilesetVersionsByFilesetId(filesetId);
   }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/FunctionMetaMapper.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/FunctionMetaMapper.java
@@ -168,6 +168,11 @@ public interface FunctionMetaMapper {
       method = "softDeleteFunctionMetasBySchemaId")
   Integer softDeleteFunctionMetasBySchemaId(@Param("schemaId") Long schemaId);
 
+  @UpdateProvider(
+      type = FunctionMetaSQLProviderFactory.class,
+      method = "softDeleteFunctionMetasBySchemaIds")
+  Integer softDeleteFunctionMetasBySchemaIds(@Param("schemaIds") List<Long> schemaIds);
+
   @DeleteProvider(
       type = FunctionMetaSQLProviderFactory.class,
       method = "deleteFunctionMetasByLegacyTimeline")

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/FunctionMetaMapper.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/FunctionMetaMapper.java
@@ -165,11 +165,6 @@ public interface FunctionMetaMapper {
 
   @UpdateProvider(
       type = FunctionMetaSQLProviderFactory.class,
-      method = "softDeleteFunctionMetasBySchemaId")
-  Integer softDeleteFunctionMetasBySchemaId(@Param("schemaId") Long schemaId);
-
-  @UpdateProvider(
-      type = FunctionMetaSQLProviderFactory.class,
       method = "softDeleteFunctionMetasBySchemaIds")
   Integer softDeleteFunctionMetasBySchemaIds(@Param("schemaIds") List<Long> schemaIds);
 

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/FunctionMetaSQLProviderFactory.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/FunctionMetaSQLProviderFactory.java
@@ -107,10 +107,6 @@ public class FunctionMetaSQLProviderFactory {
     return getProvider().softDeleteFunctionMetasByMetalakeId(metalakeId);
   }
 
-  public static String softDeleteFunctionMetasBySchemaId(@Param("schemaId") Long schemaId) {
-    return getProvider().softDeleteFunctionMetasBySchemaId(schemaId);
-  }
-
   public static String softDeleteFunctionMetasBySchemaIds(
       @Param("schemaIds") List<Long> schemaIds) {
     return getProvider().softDeleteFunctionMetasBySchemaIds(schemaIds);

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/FunctionMetaSQLProviderFactory.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/FunctionMetaSQLProviderFactory.java
@@ -111,6 +111,11 @@ public class FunctionMetaSQLProviderFactory {
     return getProvider().softDeleteFunctionMetasBySchemaId(schemaId);
   }
 
+  public static String softDeleteFunctionMetasBySchemaIds(
+      @Param("schemaIds") List<Long> schemaIds) {
+    return getProvider().softDeleteFunctionMetasBySchemaIds(schemaIds);
+  }
+
   public static String deleteFunctionMetasByLegacyTimeline(
       @Param("legacyTimeline") Long legacyTimeline, @Param("limit") int limit) {
     return getProvider().deleteFunctionMetasByLegacyTimeline(legacyTimeline, limit);

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/FunctionVersionMetaMapper.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/FunctionVersionMetaMapper.java
@@ -45,11 +45,6 @@ public interface FunctionVersionMetaMapper {
 
   @UpdateProvider(
       type = FunctionVersionMetaSQLProviderFactory.class,
-      method = "softDeleteFunctionVersionMetasBySchemaId")
-  Integer softDeleteFunctionVersionMetasBySchemaId(@Param("schemaId") Long schemaId);
-
-  @UpdateProvider(
-      type = FunctionVersionMetaSQLProviderFactory.class,
       method = "softDeleteFunctionVersionMetasBySchemaIds")
   Integer softDeleteFunctionVersionMetasBySchemaIds(@Param("schemaIds") List<Long> schemaIds);
 

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/FunctionVersionMetaMapper.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/FunctionVersionMetaMapper.java
@@ -50,6 +50,11 @@ public interface FunctionVersionMetaMapper {
 
   @UpdateProvider(
       type = FunctionVersionMetaSQLProviderFactory.class,
+      method = "softDeleteFunctionVersionMetasBySchemaIds")
+  Integer softDeleteFunctionVersionMetasBySchemaIds(@Param("schemaIds") List<Long> schemaIds);
+
+  @UpdateProvider(
+      type = FunctionVersionMetaSQLProviderFactory.class,
       method = "softDeleteFunctionVersionMetasByCatalogId")
   Integer softDeleteFunctionVersionMetasByCatalogId(@Param("catalogId") Long catalogId);
 

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/FunctionVersionMetaSQLProviderFactory.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/FunctionVersionMetaSQLProviderFactory.java
@@ -62,10 +62,6 @@ public class FunctionVersionMetaSQLProviderFactory {
     return getProvider().insertFunctionVersionMetaOnDuplicateKeyUpdate(functionVersionPO);
   }
 
-  public static String softDeleteFunctionVersionMetasBySchemaId(@Param("schemaId") Long schemaId) {
-    return getProvider().softDeleteFunctionVersionMetasBySchemaId(schemaId);
-  }
-
   public static String softDeleteFunctionVersionMetasBySchemaIds(
       @Param("schemaIds") List<Long> schemaIds) {
     return getProvider().softDeleteFunctionVersionMetasBySchemaIds(schemaIds);

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/FunctionVersionMetaSQLProviderFactory.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/FunctionVersionMetaSQLProviderFactory.java
@@ -19,6 +19,7 @@
 package org.apache.gravitino.storage.relational.mapper;
 
 import com.google.common.collect.ImmutableMap;
+import java.util.List;
 import java.util.Map;
 import org.apache.gravitino.storage.relational.JDBCBackend.JDBCBackendType;
 import org.apache.gravitino.storage.relational.mapper.provider.base.FunctionVersionMetaBaseSQLProvider;
@@ -63,6 +64,11 @@ public class FunctionVersionMetaSQLProviderFactory {
 
   public static String softDeleteFunctionVersionMetasBySchemaId(@Param("schemaId") Long schemaId) {
     return getProvider().softDeleteFunctionVersionMetasBySchemaId(schemaId);
+  }
+
+  public static String softDeleteFunctionVersionMetasBySchemaIds(
+      @Param("schemaIds") List<Long> schemaIds) {
+    return getProvider().softDeleteFunctionVersionMetasBySchemaIds(schemaIds);
   }
 
   public static String softDeleteFunctionVersionMetasByCatalogId(

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/ModelMetaMapper.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/ModelMetaMapper.java
@@ -93,8 +93,8 @@ public interface ModelMetaMapper {
 
   @UpdateProvider(
       type = ModelMetaSQLProviderFactory.class,
-      method = "softDeleteModelMetasBySchemaId")
-  Integer softDeleteModelMetasBySchemaId(@Param("schemaId") Long schemaId);
+      method = "softDeleteModelMetasBySchemaIds")
+  Integer softDeleteModelMetasBySchemaIds(@Param("schemaIds") List<Long> schemaIds);
 
   @DeleteProvider(
       type = ModelMetaSQLProviderFactory.class,

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/ModelMetaSQLProviderFactory.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/ModelMetaSQLProviderFactory.java
@@ -110,8 +110,8 @@ public class ModelMetaSQLProviderFactory {
     return getProvider().softDeleteModelMetasByMetalakeId(metalakeId);
   }
 
-  public static String softDeleteModelMetasBySchemaId(@Param("schemaId") Long schemaId) {
-    return getProvider().softDeleteModelMetasBySchemaId(schemaId);
+  public static String softDeleteModelMetasBySchemaIds(@Param("schemaIds") List<Long> schemaIds) {
+    return getProvider().softDeleteModelMetasBySchemaIds(schemaIds);
   }
 
   public static String deleteModelMetasByLegacyTimeline(

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/ModelVersionAliasRelMapper.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/ModelVersionAliasRelMapper.java
@@ -84,6 +84,11 @@ public interface ModelVersionAliasRelMapper {
 
   @UpdateProvider(
       type = ModelVersionAliasSQLProviderFactory.class,
+      method = "softDeleteModelVersionAliasRelsBySchemaIds")
+  Integer softDeleteModelVersionAliasRelsBySchemaIds(@Param("schemaIds") List<Long> schemaIds);
+
+  @UpdateProvider(
+      type = ModelVersionAliasSQLProviderFactory.class,
       method = "softDeleteModelVersionAliasRelsByCatalogId")
   Integer softDeleteModelVersionAliasRelsByCatalogId(@Param("catalogId") Long catalogId);
 

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/ModelVersionAliasRelMapper.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/ModelVersionAliasRelMapper.java
@@ -79,11 +79,6 @@ public interface ModelVersionAliasRelMapper {
 
   @UpdateProvider(
       type = ModelVersionAliasSQLProviderFactory.class,
-      method = "softDeleteModelVersionAliasRelsBySchemaId")
-  Integer softDeleteModelVersionAliasRelsBySchemaId(@Param("schemaId") Long schemaId);
-
-  @UpdateProvider(
-      type = ModelVersionAliasSQLProviderFactory.class,
       method = "softDeleteModelVersionAliasRelsBySchemaIds")
   Integer softDeleteModelVersionAliasRelsBySchemaIds(@Param("schemaIds") List<Long> schemaIds);
 

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/ModelVersionAliasSQLProviderFactory.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/ModelVersionAliasSQLProviderFactory.java
@@ -85,10 +85,6 @@ public class ModelVersionAliasSQLProviderFactory {
     return getProvider().softDeleteModelVersionAliasRelsByModelIdAndAlias(modelId, alias);
   }
 
-  public static String softDeleteModelVersionAliasRelsBySchemaId(@Param("schemaId") Long schemaId) {
-    return getProvider().softDeleteModelVersionAliasRelsBySchemaId(schemaId);
-  }
-
   public static String softDeleteModelVersionAliasRelsBySchemaIds(
       @Param("schemaIds") List<Long> schemaIds) {
     return getProvider().softDeleteModelVersionAliasRelsBySchemaIds(schemaIds);

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/ModelVersionAliasSQLProviderFactory.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/ModelVersionAliasSQLProviderFactory.java
@@ -89,6 +89,11 @@ public class ModelVersionAliasSQLProviderFactory {
     return getProvider().softDeleteModelVersionAliasRelsBySchemaId(schemaId);
   }
 
+  public static String softDeleteModelVersionAliasRelsBySchemaIds(
+      @Param("schemaIds") List<Long> schemaIds) {
+    return getProvider().softDeleteModelVersionAliasRelsBySchemaIds(schemaIds);
+  }
+
   public static String softDeleteModelVersionAliasRelsByCatalogId(
       @Param("catalogId") Long catalogId) {
     return getProvider().softDeleteModelVersionAliasRelsByCatalogId(catalogId);

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/ModelVersionMetaMapper.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/ModelVersionMetaMapper.java
@@ -83,6 +83,11 @@ public interface ModelVersionMetaMapper {
 
   @UpdateProvider(
       type = ModelVersionMetaSQLProviderFactory.class,
+      method = "softDeleteModelVersionMetasBySchemaIds")
+  Integer softDeleteModelVersionMetasBySchemaIds(@Param("schemaIds") List<Long> schemaIds);
+
+  @UpdateProvider(
+      type = ModelVersionMetaSQLProviderFactory.class,
       method = "softDeleteModelVersionMetasByCatalogId")
   Integer softDeleteModelVersionMetasByCatalogId(@Param("catalogId") Long catalogId);
 

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/ModelVersionMetaMapper.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/ModelVersionMetaMapper.java
@@ -78,11 +78,6 @@ public interface ModelVersionMetaMapper {
 
   @UpdateProvider(
       type = ModelVersionMetaSQLProviderFactory.class,
-      method = "softDeleteModelVersionMetasBySchemaId")
-  Integer softDeleteModelVersionMetasBySchemaId(@Param("schemaId") Long schemaId);
-
-  @UpdateProvider(
-      type = ModelVersionMetaSQLProviderFactory.class,
       method = "softDeleteModelVersionMetasBySchemaIds")
   Integer softDeleteModelVersionMetasBySchemaIds(@Param("schemaIds") List<Long> schemaIds);
 

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/ModelVersionMetaSQLProviderFactory.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/ModelVersionMetaSQLProviderFactory.java
@@ -94,6 +94,11 @@ public class ModelVersionMetaSQLProviderFactory {
     return getProvider().softDeleteModelVersionMetasBySchemaId(schemaId);
   }
 
+  public static String softDeleteModelVersionMetasBySchemaIds(
+      @Param("schemaIds") List<Long> schemaIds) {
+    return getProvider().softDeleteModelVersionMetasBySchemaIds(schemaIds);
+  }
+
   public static String softDeleteModelVersionMetasByCatalogId(@Param("catalogId") Long catalogId) {
     return getProvider().softDeleteModelVersionMetasByCatalogId(catalogId);
   }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/ModelVersionMetaSQLProviderFactory.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/ModelVersionMetaSQLProviderFactory.java
@@ -90,10 +90,6 @@ public class ModelVersionMetaSQLProviderFactory {
     return getProvider().softDeleteModelVersionMetaByModelIdAndAlias(modelId, alias);
   }
 
-  public static String softDeleteModelVersionMetasBySchemaId(@Param("schemaId") Long schemaId) {
-    return getProvider().softDeleteModelVersionMetasBySchemaId(schemaId);
-  }
-
   public static String softDeleteModelVersionMetasBySchemaIds(
       @Param("schemaIds") List<Long> schemaIds) {
     return getProvider().softDeleteModelVersionMetasBySchemaIds(schemaIds);

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/OwnerMetaMapper.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/OwnerMetaMapper.java
@@ -99,9 +99,6 @@ public interface OwnerMetaMapper {
       method = "softDeleteOwnerRelByCatalogId")
   void softDeleteOwnerRelByCatalogId(@Param("catalogId") Long catalogId);
 
-  @UpdateProvider(type = OwnerMetaSQLProviderFactory.class, method = "softDeleteOwnerRelBySchemaId")
-  void softDeleteOwnerRelBySchemaId(@Param("schemaId") Long schemaId);
-
   @UpdateProvider(
       type = OwnerMetaSQLProviderFactory.class,
       method = "softDeleteOwnerRelBySchemaIds")

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/OwnerMetaMapper.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/OwnerMetaMapper.java
@@ -104,6 +104,11 @@ public interface OwnerMetaMapper {
 
   @UpdateProvider(
       type = OwnerMetaSQLProviderFactory.class,
+      method = "softDeleteOwnerRelBySchemaIds")
+  void softDeleteOwnerRelBySchemaIds(@Param("schemaIds") List<Long> schemaIds);
+
+  @UpdateProvider(
+      type = OwnerMetaSQLProviderFactory.class,
       method = "deleteOwnerMetasByLegacyTimeline")
   Integer deleteOwnerMetasByLegacyTimeline(
       @Param("legacyTimeline") Long legacyTimeline, @Param("limit") int limit);

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/OwnerMetaSQLProviderFactory.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/OwnerMetaSQLProviderFactory.java
@@ -103,6 +103,10 @@ public class OwnerMetaSQLProviderFactory {
     return getProvider().softDeleteOwnerRelBySchemaId(schemaId);
   }
 
+  public static String softDeleteOwnerRelBySchemaIds(@Param("schemaIds") List<Long> schemaIds) {
+    return getProvider().softDeleteOwnerRelBySchemaIds(schemaIds);
+  }
+
   public static String deleteOwnerMetasByLegacyTimeline(
       @Param("legacyTimeline") Long legacyTimeline, @Param("limit") int limit) {
     return getProvider().deleteOwnerMetasByLegacyTimeline(legacyTimeline, limit);

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/OwnerMetaSQLProviderFactory.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/OwnerMetaSQLProviderFactory.java
@@ -99,10 +99,6 @@ public class OwnerMetaSQLProviderFactory {
     return getProvider().softDeleteOwnerRelByCatalogId(catalogId);
   }
 
-  public static String softDeleteOwnerRelBySchemaId(@Param("schemaId") Long schemaId) {
-    return getProvider().softDeleteOwnerRelBySchemaId(schemaId);
-  }
-
   public static String softDeleteOwnerRelBySchemaIds(@Param("schemaIds") List<Long> schemaIds) {
     return getProvider().softDeleteOwnerRelBySchemaIds(schemaIds);
   }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/PolicyMetadataObjectRelMapper.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/PolicyMetadataObjectRelMapper.java
@@ -133,6 +133,11 @@ public interface PolicyMetadataObjectRelMapper {
 
   @UpdateProvider(
       type = PolicyMetadataObjectRelSQLProviderFactory.class,
+      method = "softDeletePolicyMetadataObjectRelsBySchemaIds")
+  void softDeletePolicyMetadataObjectRelsBySchemaIds(@Param("schemaIds") List<Long> schemaIds);
+
+  @UpdateProvider(
+      type = PolicyMetadataObjectRelSQLProviderFactory.class,
       method = "softDeletePolicyMetadataObjectRelsByTableId")
   void softDeletePolicyMetadataObjectRelsByTableId(@Param("tableId") Long tableId);
 

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/PolicyMetadataObjectRelMapper.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/PolicyMetadataObjectRelMapper.java
@@ -128,11 +128,6 @@ public interface PolicyMetadataObjectRelMapper {
 
   @UpdateProvider(
       type = PolicyMetadataObjectRelSQLProviderFactory.class,
-      method = "softDeletePolicyMetadataObjectRelsBySchemaId")
-  void softDeletePolicyMetadataObjectRelsBySchemaId(@Param("schemaId") Long schemaId);
-
-  @UpdateProvider(
-      type = PolicyMetadataObjectRelSQLProviderFactory.class,
       method = "softDeletePolicyMetadataObjectRelsBySchemaIds")
   void softDeletePolicyMetadataObjectRelsBySchemaIds(@Param("schemaIds") List<Long> schemaIds);
 

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/PolicyMetadataObjectRelSQLProviderFactory.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/PolicyMetadataObjectRelSQLProviderFactory.java
@@ -117,6 +117,11 @@ public class PolicyMetadataObjectRelSQLProviderFactory {
     return getProvider().softDeletePolicyMetadataObjectRelsBySchemaId(schemaId);
   }
 
+  public static String softDeletePolicyMetadataObjectRelsBySchemaIds(
+      @Param("schemaIds") List<Long> schemaIds) {
+    return getProvider().softDeletePolicyMetadataObjectRelsBySchemaIds(schemaIds);
+  }
+
   public static String softDeletePolicyMetadataObjectRelsByTableId(@Param("tableId") Long tableId) {
     return getProvider().softDeletePolicyMetadataObjectRelsByTableId(tableId);
   }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/PolicyMetadataObjectRelSQLProviderFactory.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/PolicyMetadataObjectRelSQLProviderFactory.java
@@ -112,11 +112,6 @@ public class PolicyMetadataObjectRelSQLProviderFactory {
     return getProvider().softDeletePolicyMetadataObjectRelsByCatalogId(catalogId);
   }
 
-  public static String softDeletePolicyMetadataObjectRelsBySchemaId(
-      @Param("schemaId") Long schemaId) {
-    return getProvider().softDeletePolicyMetadataObjectRelsBySchemaId(schemaId);
-  }
-
   public static String softDeletePolicyMetadataObjectRelsBySchemaIds(
       @Param("schemaIds") List<Long> schemaIds) {
     return getProvider().softDeletePolicyMetadataObjectRelsBySchemaIds(schemaIds);

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/SchemaMetaMapper.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/SchemaMetaMapper.java
@@ -53,6 +53,14 @@ public interface SchemaMetaMapper {
 
   @SelectProvider(
       type = SchemaMetaSQLProviderFactory.class,
+      method = "listSchemaPOsByCatalogIdAndNamePrefix")
+  List<SchemaPO> listSchemaPOsByCatalogIdAndNamePrefix(
+      @Param("catalogId") Long catalogId,
+      @Param("schemaName") String schemaName,
+      @Param("descendantPrefix") String descendantPrefix);
+
+  @SelectProvider(
+      type = SchemaMetaSQLProviderFactory.class,
       method = "selectSchemaIdByCatalogIdAndName")
   Long selectSchemaIdByCatalogIdAndName(
       @Param("catalogId") Long catalogId, @Param("schemaName") String name);
@@ -98,6 +106,11 @@ public interface SchemaMetaMapper {
       type = SchemaMetaSQLProviderFactory.class,
       method = "softDeleteSchemaMetasBySchemaId")
   Integer softDeleteSchemaMetasBySchemaId(@Param("schemaId") Long schemaId);
+
+  @UpdateProvider(
+      type = SchemaMetaSQLProviderFactory.class,
+      method = "softDeleteSchemaMetasBySchemaIds")
+  Integer softDeleteSchemaMetasBySchemaIds(@Param("schemaIds") List<Long> schemaIds);
 
   @UpdateProvider(
       type = SchemaMetaSQLProviderFactory.class,

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/SchemaMetaMapper.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/SchemaMetaMapper.java
@@ -104,11 +104,6 @@ public interface SchemaMetaMapper {
 
   @UpdateProvider(
       type = SchemaMetaSQLProviderFactory.class,
-      method = "softDeleteSchemaMetasBySchemaId")
-  Integer softDeleteSchemaMetasBySchemaId(@Param("schemaId") Long schemaId);
-
-  @UpdateProvider(
-      type = SchemaMetaSQLProviderFactory.class,
       method = "softDeleteSchemaMetasBySchemaIds")
   Integer softDeleteSchemaMetasBySchemaIds(@Param("schemaIds") List<Long> schemaIds);
 

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/SchemaMetaSQLProviderFactory.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/SchemaMetaSQLProviderFactory.java
@@ -116,12 +116,7 @@ public class SchemaMetaSQLProviderFactory {
     return getProvider().updateSchemaMeta(newSchemaPO, oldSchemaPO);
   }
 
-  public static String softDeleteSchemaMetasBySchemaId(@Param("schemaId") Long schemaId) {
-    return getProvider().softDeleteSchemaMetasBySchemaId(schemaId);
-  }
-
-  public static String softDeleteSchemaMetasBySchemaIds(
-      @Param("schemaIds") List<Long> schemaIds) {
+  public static String softDeleteSchemaMetasBySchemaIds(@Param("schemaIds") List<Long> schemaIds) {
     return getProvider().softDeleteSchemaMetasBySchemaIds(schemaIds);
   }
 

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/SchemaMetaSQLProviderFactory.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/SchemaMetaSQLProviderFactory.java
@@ -60,6 +60,14 @@ public class SchemaMetaSQLProviderFactory {
     return getProvider().listSchemaPOsBySchemaIds(schemaIds);
   }
 
+  public static String listSchemaPOsByCatalogIdAndNamePrefix(
+      @Param("catalogId") Long catalogId,
+      @Param("schemaName") String schemaName,
+      @Param("descendantPrefix") String descendantPrefix) {
+    return getProvider()
+        .listSchemaPOsByCatalogIdAndNamePrefix(catalogId, schemaName, descendantPrefix);
+  }
+
   public static String listSchemaPOsByCatalogId(@Param("catalogId") Long catalogId) {
     return getProvider().listSchemaPOsByCatalogId(catalogId);
   }
@@ -110,6 +118,11 @@ public class SchemaMetaSQLProviderFactory {
 
   public static String softDeleteSchemaMetasBySchemaId(@Param("schemaId") Long schemaId) {
     return getProvider().softDeleteSchemaMetasBySchemaId(schemaId);
+  }
+
+  public static String softDeleteSchemaMetasBySchemaIds(
+      @Param("schemaIds") List<Long> schemaIds) {
+    return getProvider().softDeleteSchemaMetasBySchemaIds(schemaIds);
   }
 
   public static String softDeleteSchemaMetasByMetalakeId(@Param("metalakeId") Long metalakeId) {

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/SecurableObjectMapper.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/SecurableObjectMapper.java
@@ -78,6 +78,11 @@ public interface SecurableObjectMapper {
       method = "softDeleteObjectRelsBySchemaId")
   void softDeleteObjectRelsBySchemaId(@Param("schemaId") Long schemaId);
 
+  @UpdateProvider(
+      type = SecurableObjectSQLProviderFactory.class,
+      method = "softDeleteObjectRelsBySchemaIds")
+  void softDeleteObjectRelsBySchemaIds(@Param("schemaIds") List<Long> schemaIds);
+
   @SelectProvider(
       type = SecurableObjectSQLProviderFactory.class,
       method = "listSecurableObjectsByRoleId")

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/SecurableObjectMapper.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/SecurableObjectMapper.java
@@ -75,11 +75,6 @@ public interface SecurableObjectMapper {
 
   @UpdateProvider(
       type = SecurableObjectSQLProviderFactory.class,
-      method = "softDeleteObjectRelsBySchemaId")
-  void softDeleteObjectRelsBySchemaId(@Param("schemaId") Long schemaId);
-
-  @UpdateProvider(
-      type = SecurableObjectSQLProviderFactory.class,
       method = "softDeleteObjectRelsBySchemaIds")
   void softDeleteObjectRelsBySchemaIds(@Param("schemaIds") List<Long> schemaIds);
 

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/SecurableObjectSQLProviderFactory.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/SecurableObjectSQLProviderFactory.java
@@ -85,6 +85,10 @@ public class SecurableObjectSQLProviderFactory {
     return getProvider().softDeleteObjectRelsBySchemaId(schemaId);
   }
 
+  public static String softDeleteObjectRelsBySchemaIds(@Param("schemaIds") List<Long> schemaIds) {
+    return getProvider().softDeleteObjectRelsBySchemaIds(schemaIds);
+  }
+
   public static String listSecurableObjectsByRoleId(@Param("roleId") Long roleId) {
     return getProvider().listSecurableObjectsByRoleId(roleId);
   }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/SecurableObjectSQLProviderFactory.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/SecurableObjectSQLProviderFactory.java
@@ -81,10 +81,6 @@ public class SecurableObjectSQLProviderFactory {
     return getProvider().softDeleteObjectRelsByCatalogId(catalogId);
   }
 
-  public static String softDeleteObjectRelsBySchemaId(@Param("schemaId") Long schemaId) {
-    return getProvider().softDeleteObjectRelsBySchemaId(schemaId);
-  }
-
   public static String softDeleteObjectRelsBySchemaIds(@Param("schemaIds") List<Long> schemaIds) {
     return getProvider().softDeleteObjectRelsBySchemaIds(schemaIds);
   }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/StatisticMetaMapper.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/StatisticMetaMapper.java
@@ -64,6 +64,11 @@ public interface StatisticMetaMapper {
       method = "softDeleteStatisticsBySchemaId")
   Integer softDeleteStatisticsBySchemaId(@Param("schemaId") Long schemaId);
 
+  @UpdateProvider(
+      type = StatisticSQLProviderFactory.class,
+      method = "softDeleteStatisticsBySchemaIds")
+  Integer softDeleteStatisticsBySchemaIds(@Param("schemaIds") List<Long> schemaIds);
+
   @DeleteProvider(
       type = StatisticSQLProviderFactory.class,
       method = "deleteStatisticsByLegacyTimeline")

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/StatisticMetaMapper.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/StatisticMetaMapper.java
@@ -61,11 +61,6 @@ public interface StatisticMetaMapper {
 
   @UpdateProvider(
       type = StatisticSQLProviderFactory.class,
-      method = "softDeleteStatisticsBySchemaId")
-  Integer softDeleteStatisticsBySchemaId(@Param("schemaId") Long schemaId);
-
-  @UpdateProvider(
-      type = StatisticSQLProviderFactory.class,
       method = "softDeleteStatisticsBySchemaIds")
   Integer softDeleteStatisticsBySchemaIds(@Param("schemaIds") List<Long> schemaIds);
 

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/StatisticSQLProviderFactory.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/StatisticSQLProviderFactory.java
@@ -83,10 +83,6 @@ public class StatisticSQLProviderFactory {
     return getProvider().softDeleteStatisticsByCatalogId(catalogId);
   }
 
-  public static String softDeleteStatisticsBySchemaId(@Param("schemaId") Long schemaId) {
-    return getProvider().softDeleteStatisticsBySchemaId(schemaId);
-  }
-
   public static String softDeleteStatisticsBySchemaIds(@Param("schemaIds") List<Long> schemaIds) {
     return getProvider().softDeleteStatisticsBySchemaIds(schemaIds);
   }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/StatisticSQLProviderFactory.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/StatisticSQLProviderFactory.java
@@ -87,6 +87,10 @@ public class StatisticSQLProviderFactory {
     return getProvider().softDeleteStatisticsBySchemaId(schemaId);
   }
 
+  public static String softDeleteStatisticsBySchemaIds(@Param("schemaIds") List<Long> schemaIds) {
+    return getProvider().softDeleteStatisticsBySchemaIds(schemaIds);
+  }
+
   public static String deleteStatisticsByLegacyTimeline(
       @Param("legacyTimeline") Long legacyTimeline, @Param("limit") int limit) {
     return getProvider().deleteStatisticsByLegacyTimeline(legacyTimeline, limit);

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/TableColumnMapper.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/TableColumnMapper.java
@@ -58,11 +58,6 @@ public interface TableColumnMapper {
 
   @UpdateProvider(
       type = TableColumnSQLProviderFactory.class,
-      method = "softDeleteColumnsBySchemaId")
-  Integer softDeleteColumnsBySchemaId(@Param("schemaId") Long schemaId);
-
-  @UpdateProvider(
-      type = TableColumnSQLProviderFactory.class,
       method = "softDeleteColumnsBySchemaIds")
   Integer softDeleteColumnsBySchemaIds(@Param("schemaIds") List<Long> schemaIds);
 

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/TableColumnMapper.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/TableColumnMapper.java
@@ -61,6 +61,11 @@ public interface TableColumnMapper {
       method = "softDeleteColumnsBySchemaId")
   Integer softDeleteColumnsBySchemaId(@Param("schemaId") Long schemaId);
 
+  @UpdateProvider(
+      type = TableColumnSQLProviderFactory.class,
+      method = "softDeleteColumnsBySchemaIds")
+  Integer softDeleteColumnsBySchemaIds(@Param("schemaIds") List<Long> schemaIds);
+
   @DeleteProvider(
       type = TableColumnSQLProviderFactory.class,
       method = "deleteColumnPOsByLegacyTimeline")

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/TableColumnSQLProviderFactory.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/TableColumnSQLProviderFactory.java
@@ -87,6 +87,10 @@ public class TableColumnSQLProviderFactory {
     return getProvider().softDeleteColumnsBySchemaId(schemaId);
   }
 
+  public static String softDeleteColumnsBySchemaIds(@Param("schemaIds") List<Long> schemaIds) {
+    return getProvider().softDeleteColumnsBySchemaIds(schemaIds);
+  }
+
   public static String selectColumnIdByTableIdAndName(
       @Param("tableId") Long tableId, @Param("columnName") String name) {
     return getProvider().selectColumnIdByTableIdAndName(tableId, name);

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/TableColumnSQLProviderFactory.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/TableColumnSQLProviderFactory.java
@@ -83,10 +83,6 @@ public class TableColumnSQLProviderFactory {
     return getProvider().softDeleteColumnsByCatalogId(catalogId);
   }
 
-  public static String softDeleteColumnsBySchemaId(@Param("schemaId") Long schemaId) {
-    return getProvider().softDeleteColumnsBySchemaId(schemaId);
-  }
-
   public static String softDeleteColumnsBySchemaIds(@Param("schemaIds") List<Long> schemaIds) {
     return getProvider().softDeleteColumnsBySchemaIds(schemaIds);
   }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/TableMetaMapper.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/TableMetaMapper.java
@@ -107,6 +107,11 @@ public interface TableMetaMapper {
       method = "softDeleteTableMetasBySchemaId")
   Integer softDeleteTableMetasBySchemaId(@Param("schemaId") Long schemaId);
 
+  @UpdateProvider(
+      type = TableMetaSQLProviderFactory.class,
+      method = "softDeleteTableMetasBySchemaIds")
+  Integer softDeleteTableMetasBySchemaIds(@Param("schemaIds") List<Long> schemaIds);
+
   @DeleteProvider(
       type = TableMetaSQLProviderFactory.class,
       method = "deleteTableMetasByLegacyTimeline")

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/TableMetaMapper.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/TableMetaMapper.java
@@ -104,11 +104,6 @@ public interface TableMetaMapper {
 
   @UpdateProvider(
       type = TableMetaSQLProviderFactory.class,
-      method = "softDeleteTableMetasBySchemaId")
-  Integer softDeleteTableMetasBySchemaId(@Param("schemaId") Long schemaId);
-
-  @UpdateProvider(
-      type = TableMetaSQLProviderFactory.class,
       method = "softDeleteTableMetasBySchemaIds")
   Integer softDeleteTableMetasBySchemaIds(@Param("schemaIds") List<Long> schemaIds);
 

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/TableMetaSQLProviderFactory.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/TableMetaSQLProviderFactory.java
@@ -116,10 +116,6 @@ public class TableMetaSQLProviderFactory {
     return getProvider().softDeleteTableMetasByCatalogId(catalogId);
   }
 
-  public static String softDeleteTableMetasBySchemaId(@Param("schemaId") Long schemaId) {
-    return getProvider().softDeleteTableMetasBySchemaId(schemaId);
-  }
-
   public static String softDeleteTableMetasBySchemaIds(@Param("schemaIds") List<Long> schemaIds) {
     return getProvider().softDeleteTableMetasBySchemaIds(schemaIds);
   }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/TableMetaSQLProviderFactory.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/TableMetaSQLProviderFactory.java
@@ -120,6 +120,10 @@ public class TableMetaSQLProviderFactory {
     return getProvider().softDeleteTableMetasBySchemaId(schemaId);
   }
 
+  public static String softDeleteTableMetasBySchemaIds(@Param("schemaIds") List<Long> schemaIds) {
+    return getProvider().softDeleteTableMetasBySchemaIds(schemaIds);
+  }
+
   public static String deleteTableMetasByLegacyTimeline(
       @Param("legacyTimeline") Long legacyTimeline, @Param("limit") int limit) {
     return getProvider().deleteTableMetasByLegacyTimeline(legacyTimeline, limit);

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/TagMetadataObjectRelMapper.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/TagMetadataObjectRelMapper.java
@@ -89,11 +89,6 @@ public interface TagMetadataObjectRelMapper {
 
   @UpdateProvider(
       type = TagMetadataObjectRelSQLProviderFactory.class,
-      method = "softDeleteTagMetadataObjectRelsBySchemaId")
-  void softDeleteTagMetadataObjectRelsBySchemaId(@Param("schemaId") Long schemaId);
-
-  @UpdateProvider(
-      type = TagMetadataObjectRelSQLProviderFactory.class,
       method = "softDeleteTagMetadataObjectRelsBySchemaIds")
   void softDeleteTagMetadataObjectRelsBySchemaIds(@Param("schemaIds") List<Long> schemaIds);
 

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/TagMetadataObjectRelMapper.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/TagMetadataObjectRelMapper.java
@@ -94,6 +94,11 @@ public interface TagMetadataObjectRelMapper {
 
   @UpdateProvider(
       type = TagMetadataObjectRelSQLProviderFactory.class,
+      method = "softDeleteTagMetadataObjectRelsBySchemaIds")
+  void softDeleteTagMetadataObjectRelsBySchemaIds(@Param("schemaIds") List<Long> schemaIds);
+
+  @UpdateProvider(
+      type = TagMetadataObjectRelSQLProviderFactory.class,
       method = "softDeleteTagMetadataObjectRelsByTableId")
   void softDeleteTagMetadataObjectRelsByTableId(@Param("tableId") Long tableId);
 

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/TagMetadataObjectRelSQLProviderFactory.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/TagMetadataObjectRelSQLProviderFactory.java
@@ -107,10 +107,6 @@ public class TagMetadataObjectRelSQLProviderFactory {
     return getProvider().softDeleteTagMetadataObjectRelsByCatalogId(catalogId);
   }
 
-  public static String softDeleteTagMetadataObjectRelsBySchemaId(@Param("schemaId") Long schemaId) {
-    return getProvider().softDeleteTagMetadataObjectRelsBySchemaId(schemaId);
-  }
-
   public static String softDeleteTagMetadataObjectRelsBySchemaIds(
       @Param("schemaIds") List<Long> schemaIds) {
     return getProvider().softDeleteTagMetadataObjectRelsBySchemaIds(schemaIds);

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/TagMetadataObjectRelSQLProviderFactory.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/TagMetadataObjectRelSQLProviderFactory.java
@@ -111,6 +111,11 @@ public class TagMetadataObjectRelSQLProviderFactory {
     return getProvider().softDeleteTagMetadataObjectRelsBySchemaId(schemaId);
   }
 
+  public static String softDeleteTagMetadataObjectRelsBySchemaIds(
+      @Param("schemaIds") List<Long> schemaIds) {
+    return getProvider().softDeleteTagMetadataObjectRelsBySchemaIds(schemaIds);
+  }
+
   public static String softDeleteTagMetadataObjectRelsByTableId(@Param("tableId") Long tableId) {
     return getProvider().softDeleteTagMetadataObjectRelsByTableId(tableId);
   }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/TopicMetaMapper.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/TopicMetaMapper.java
@@ -96,11 +96,6 @@ public interface TopicMetaMapper {
 
   @UpdateProvider(
       type = TopicMetaSQLProviderFactory.class,
-      method = "softDeleteTopicMetasBySchemaId")
-  Integer softDeleteTopicMetasBySchemaId(@Param("schemaId") Long schemaId);
-
-  @UpdateProvider(
-      type = TopicMetaSQLProviderFactory.class,
       method = "softDeleteTopicMetasBySchemaIds")
   Integer softDeleteTopicMetasBySchemaIds(@Param("schemaIds") List<Long> schemaIds);
 

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/TopicMetaMapper.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/TopicMetaMapper.java
@@ -99,6 +99,11 @@ public interface TopicMetaMapper {
       method = "softDeleteTopicMetasBySchemaId")
   Integer softDeleteTopicMetasBySchemaId(@Param("schemaId") Long schemaId);
 
+  @UpdateProvider(
+      type = TopicMetaSQLProviderFactory.class,
+      method = "softDeleteTopicMetasBySchemaIds")
+  Integer softDeleteTopicMetasBySchemaIds(@Param("schemaIds") List<Long> schemaIds);
+
   @DeleteProvider(
       type = TopicMetaSQLProviderFactory.class,
       method = "deleteTopicMetasByLegacyTimeline")

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/TopicMetaSQLProviderFactory.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/TopicMetaSQLProviderFactory.java
@@ -119,6 +119,10 @@ public class TopicMetaSQLProviderFactory {
     return getProvider().softDeleteTopicMetasBySchemaId(schemaId);
   }
 
+  public static String softDeleteTopicMetasBySchemaIds(@Param("schemaIds") List<Long> schemaIds) {
+    return getProvider().softDeleteTopicMetasBySchemaIds(schemaIds);
+  }
+
   public static String deleteTopicMetasByLegacyTimeline(
       @Param("legacyTimeline") Long legacyTimeline, @Param("limit") int limit) {
     return getProvider().deleteTopicMetasByLegacyTimeline(legacyTimeline, limit);

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/TopicMetaSQLProviderFactory.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/TopicMetaSQLProviderFactory.java
@@ -115,10 +115,6 @@ public class TopicMetaSQLProviderFactory {
     return getProvider().softDeleteTopicMetasByMetalakeId(metalakeId);
   }
 
-  public static String softDeleteTopicMetasBySchemaId(@Param("schemaId") Long schemaId) {
-    return getProvider().softDeleteTopicMetasBySchemaId(schemaId);
-  }
-
   public static String softDeleteTopicMetasBySchemaIds(@Param("schemaIds") List<Long> schemaIds) {
     return getProvider().softDeleteTopicMetasBySchemaIds(schemaIds);
   }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/ViewMetaMapper.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/ViewMetaMapper.java
@@ -140,8 +140,10 @@ public interface ViewMetaMapper {
       method = "softDeleteViewMetasByCatalogId")
   Integer softDeleteViewMetasByCatalogId(@Param("catalogId") Long catalogId);
 
-  @UpdateProvider(type = ViewMetaSQLProviderFactory.class, method = "softDeleteViewMetasBySchemaId")
-  Integer softDeleteViewMetasBySchemaId(@Param("schemaId") Long schemaId);
+  @UpdateProvider(
+      type = ViewMetaSQLProviderFactory.class,
+      method = "softDeleteViewMetasBySchemaIds")
+  Integer softDeleteViewMetasBySchemaIds(@Param("schemaIds") List<Long> schemaIds);
 
   @DeleteProvider(
       type = ViewMetaSQLProviderFactory.class,

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/ViewMetaSQLProviderFactory.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/ViewMetaSQLProviderFactory.java
@@ -110,8 +110,8 @@ public class ViewMetaSQLProviderFactory {
     return getProvider().softDeleteViewMetasByCatalogId(catalogId);
   }
 
-  public static String softDeleteViewMetasBySchemaId(@Param("schemaId") Long schemaId) {
-    return getProvider().softDeleteViewMetasBySchemaId(schemaId);
+  public static String softDeleteViewMetasBySchemaIds(@Param("schemaIds") List<Long> schemaIds) {
+    return getProvider().softDeleteViewMetasBySchemaIds(schemaIds);
   }
 
   public static String deleteViewMetasByLegacyTimeline(

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/FilesetMetaBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/FilesetMetaBaseSQLProvider.java
@@ -323,6 +323,20 @@ public class FilesetMetaBaseSQLProvider {
         + " WHERE schema_id = #{schemaId} AND deleted_at = 0";
   }
 
+  public String softDeleteFilesetMetasBySchemaIds(@Param("schemaIds") List<Long> schemaIds) {
+    return "<script>"
+        + "UPDATE "
+        + META_TABLE_NAME
+        + " SET deleted_at = (UNIX_TIMESTAMP() * 1000.0)"
+        + " + EXTRACT(MICROSECOND FROM CURRENT_TIMESTAMP(3)) / 1000"
+        + " WHERE schema_id IN ("
+        + "<foreach collection='schemaIds' item='schemaId' separator=','>"
+        + "#{schemaId}"
+        + "</foreach>"
+        + ") AND deleted_at = 0"
+        + "</script>";
+  }
+
   public String softDeleteFilesetMetasByFilesetId(@Param("filesetId") Long filesetId) {
     return "UPDATE "
         + META_TABLE_NAME

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/FilesetMetaBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/FilesetMetaBaseSQLProvider.java
@@ -315,14 +315,6 @@ public class FilesetMetaBaseSQLProvider {
         + " WHERE catalog_id = #{catalogId} AND deleted_at = 0";
   }
 
-  public String softDeleteFilesetMetasBySchemaId(@Param("schemaId") Long schemaId) {
-    return "UPDATE "
-        + META_TABLE_NAME
-        + " SET deleted_at = (UNIX_TIMESTAMP() * 1000.0)"
-        + " + EXTRACT(MICROSECOND FROM CURRENT_TIMESTAMP(3)) / 1000"
-        + " WHERE schema_id = #{schemaId} AND deleted_at = 0";
-  }
-
   public String softDeleteFilesetMetasBySchemaIds(@Param("schemaIds") List<Long> schemaIds) {
     return "<script>"
         + "UPDATE "

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/FilesetVersionBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/FilesetVersionBaseSQLProvider.java
@@ -87,14 +87,6 @@ public class FilesetVersionBaseSQLProvider {
         + " WHERE catalog_id = #{catalogId} AND deleted_at = 0";
   }
 
-  public String softDeleteFilesetVersionsBySchemaId(@Param("schemaId") Long schemaId) {
-    return "UPDATE "
-        + VERSION_TABLE_NAME
-        + " SET deleted_at = (UNIX_TIMESTAMP() * 1000.0)"
-        + " + EXTRACT(MICROSECOND FROM CURRENT_TIMESTAMP(3)) / 1000"
-        + " WHERE schema_id = #{schemaId} AND deleted_at = 0";
-  }
-
   public String softDeleteFilesetVersionsBySchemaIds(@Param("schemaIds") List<Long> schemaIds) {
     return "<script>"
         + "UPDATE "

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/FilesetVersionBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/FilesetVersionBaseSQLProvider.java
@@ -95,6 +95,20 @@ public class FilesetVersionBaseSQLProvider {
         + " WHERE schema_id = #{schemaId} AND deleted_at = 0";
   }
 
+  public String softDeleteFilesetVersionsBySchemaIds(@Param("schemaIds") List<Long> schemaIds) {
+    return "<script>"
+        + "UPDATE "
+        + VERSION_TABLE_NAME
+        + " SET deleted_at = (UNIX_TIMESTAMP() * 1000.0)"
+        + " + EXTRACT(MICROSECOND FROM CURRENT_TIMESTAMP(3)) / 1000"
+        + " WHERE schema_id IN ("
+        + "<foreach collection='schemaIds' item='schemaId' separator=','>"
+        + "#{schemaId}"
+        + "</foreach>"
+        + ") AND deleted_at = 0"
+        + "</script>";
+  }
+
   public String softDeleteFilesetVersionsByFilesetId(@Param("filesetId") Long filesetId) {
     return "UPDATE "
         + VERSION_TABLE_NAME

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/FunctionMetaBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/FunctionMetaBaseSQLProvider.java
@@ -266,14 +266,6 @@ public class FunctionMetaBaseSQLProvider {
         + " WHERE metalake_id = #{metalakeId} AND deleted_at = 0";
   }
 
-  public String softDeleteFunctionMetasBySchemaId(@Param("schemaId") Long schemaId) {
-    return "UPDATE "
-        + TABLE_NAME
-        + " SET deleted_at = (UNIX_TIMESTAMP() * 1000.0)"
-        + " + EXTRACT(MICROSECOND FROM CURRENT_TIMESTAMP(3)) / 1000"
-        + " WHERE schema_id = #{schemaId} AND deleted_at = 0";
-  }
-
   public String softDeleteFunctionMetasBySchemaIds(@Param("schemaIds") List<Long> schemaIds) {
     return "<script>"
         + "UPDATE "

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/FunctionMetaBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/FunctionMetaBaseSQLProvider.java
@@ -274,6 +274,20 @@ public class FunctionMetaBaseSQLProvider {
         + " WHERE schema_id = #{schemaId} AND deleted_at = 0";
   }
 
+  public String softDeleteFunctionMetasBySchemaIds(@Param("schemaIds") List<Long> schemaIds) {
+    return "<script>"
+        + "UPDATE "
+        + TABLE_NAME
+        + " SET deleted_at = (UNIX_TIMESTAMP() * 1000.0)"
+        + " + EXTRACT(MICROSECOND FROM CURRENT_TIMESTAMP(3)) / 1000"
+        + " WHERE schema_id IN ("
+        + "<foreach collection='schemaIds' item='schemaId' separator=','>"
+        + "#{schemaId}"
+        + "</foreach>"
+        + ") AND deleted_at = 0"
+        + "</script>";
+  }
+
   public String deleteFunctionMetasByLegacyTimeline(
       @Param("legacyTimeline") Long legacyTimeline, @Param("limit") int limit) {
     return "DELETE FROM "

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/FunctionVersionMetaBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/FunctionVersionMetaBaseSQLProvider.java
@@ -18,6 +18,7 @@
  */
 package org.apache.gravitino.storage.relational.mapper.provider.base;
 
+import java.util.List;
 import org.apache.gravitino.storage.relational.mapper.FunctionVersionMetaMapper;
 import org.apache.gravitino.storage.relational.po.FunctionVersionPO;
 import org.apache.ibatis.annotations.Param;
@@ -61,6 +62,21 @@ public class FunctionVersionMetaBaseSQLProvider {
         + " SET deleted_at = (UNIX_TIMESTAMP() * 1000.0)"
         + " + EXTRACT(MICROSECOND FROM CURRENT_TIMESTAMP(3)) / 1000"
         + " WHERE schema_id = #{schemaId} AND deleted_at = 0";
+  }
+
+  public String softDeleteFunctionVersionMetasBySchemaIds(
+      @Param("schemaIds") List<Long> schemaIds) {
+    return "<script>"
+        + "UPDATE "
+        + FunctionVersionMetaMapper.TABLE_NAME
+        + " SET deleted_at = (UNIX_TIMESTAMP() * 1000.0)"
+        + " + EXTRACT(MICROSECOND FROM CURRENT_TIMESTAMP(3)) / 1000"
+        + " WHERE schema_id IN ("
+        + "<foreach collection='schemaIds' item='schemaId' separator=','>"
+        + "#{schemaId}"
+        + "</foreach>"
+        + ") AND deleted_at = 0"
+        + "</script>";
   }
 
   public String softDeleteFunctionVersionMetasByCatalogId(@Param("catalogId") Long catalogId) {

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/FunctionVersionMetaBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/FunctionVersionMetaBaseSQLProvider.java
@@ -56,14 +56,6 @@ public class FunctionVersionMetaBaseSQLProvider {
         + " deleted_at = #{functionVersionMeta.deletedAt}";
   }
 
-  public String softDeleteFunctionVersionMetasBySchemaId(@Param("schemaId") Long schemaId) {
-    return "UPDATE "
-        + FunctionVersionMetaMapper.TABLE_NAME
-        + " SET deleted_at = (UNIX_TIMESTAMP() * 1000.0)"
-        + " + EXTRACT(MICROSECOND FROM CURRENT_TIMESTAMP(3)) / 1000"
-        + " WHERE schema_id = #{schemaId} AND deleted_at = 0";
-  }
-
   public String softDeleteFunctionVersionMetasBySchemaIds(
       @Param("schemaIds") List<Long> schemaIds) {
     return "<script>"

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/ModelMetaBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/ModelMetaBaseSQLProvider.java
@@ -223,12 +223,18 @@ public class ModelMetaBaseSQLProvider {
         + " WHERE metalake_id = #{metalakeId} AND deleted_at = 0";
   }
 
-  public String softDeleteModelMetasBySchemaId(@Param("schemaId") Long schemaId) {
-    return "UPDATE "
+  public String softDeleteModelMetasBySchemaIds(@Param("schemaIds") List<Long> schemaIds) {
+    return "<script>"
+        + "UPDATE "
         + ModelMetaMapper.TABLE_NAME
         + " SET deleted_at = (UNIX_TIMESTAMP() * 1000.0)"
         + " + EXTRACT(MICROSECOND FROM CURRENT_TIMESTAMP(3)) / 1000"
-        + " WHERE schema_id = #{schemaId} AND deleted_at = 0";
+        + " WHERE schema_id IN ("
+        + "<foreach collection='schemaIds' item='schemaId' separator=','>"
+        + "#{schemaId}"
+        + "</foreach>"
+        + ") AND deleted_at = 0"
+        + "</script>";
   }
 
   public String deleteModelMetasByLegacyTimeline(

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/ModelVersionAliasRelBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/ModelVersionAliasRelBaseSQLProvider.java
@@ -121,6 +121,24 @@ public class ModelVersionAliasRelBaseSQLProvider {
         + " WHERE schema_id = #{schemaId} AND deleted_at = 0) AND deleted_at = 0";
   }
 
+  public String softDeleteModelVersionAliasRelsBySchemaIds(
+      @Param("schemaIds") List<Long> schemaIds) {
+    return "<script>"
+        + "UPDATE "
+        + ModelVersionAliasRelMapper.TABLE_NAME
+        + " SET deleted_at = (UNIX_TIMESTAMP() * 1000.0)"
+        + " + EXTRACT(MICROSECOND FROM CURRENT_TIMESTAMP(3)) / 1000"
+        + " WHERE model_id IN ("
+        + " SELECT model_id FROM "
+        + ModelMetaMapper.TABLE_NAME
+        + " WHERE schema_id IN "
+        + "<foreach collection='schemaIds' item='schemaId' open='(' close=')' separator=','>"
+        + "#{schemaId}"
+        + "</foreach>"
+        + " AND deleted_at = 0) AND deleted_at = 0"
+        + "</script>";
+  }
+
   public String softDeleteModelVersionAliasRelsByCatalogId(@Param("catalogId") Long catalogId) {
     return "UPDATE "
         + ModelVersionAliasRelMapper.TABLE_NAME

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/ModelVersionAliasRelBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/ModelVersionAliasRelBaseSQLProvider.java
@@ -110,17 +110,6 @@ public class ModelVersionAliasRelBaseSQLProvider {
         + " WHERE mvar.model_id = #{modelId} AND mvar.deleted_at = 0";
   }
 
-  public String softDeleteModelVersionAliasRelsBySchemaId(@Param("schemaId") Long schemaId) {
-    return "UPDATE "
-        + ModelVersionAliasRelMapper.TABLE_NAME
-        + " SET deleted_at = (UNIX_TIMESTAMP() * 1000.0)"
-        + " + EXTRACT(MICROSECOND FROM CURRENT_TIMESTAMP(3)) / 1000"
-        + " WHERE model_id IN ("
-        + " SELECT model_id FROM "
-        + ModelMetaMapper.TABLE_NAME
-        + " WHERE schema_id = #{schemaId} AND deleted_at = 0) AND deleted_at = 0";
-  }
-
   public String softDeleteModelVersionAliasRelsBySchemaIds(
       @Param("schemaIds") List<Long> schemaIds) {
     return "<script>"

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/ModelVersionMetaBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/ModelVersionMetaBaseSQLProvider.java
@@ -154,12 +154,18 @@ public class ModelVersionMetaBaseSQLProvider {
         + " AND deleted_at = 0";
   }
 
-  public String softDeleteModelVersionMetasBySchemaId(@Param("schemaId") Long schemaId) {
-    return "UPDATE "
+  public String softDeleteModelVersionMetasBySchemaIds(@Param("schemaIds") List<Long> schemaIds) {
+    return "<script>"
+        + "UPDATE "
         + ModelVersionMetaMapper.TABLE_NAME
         + " SET deleted_at = (UNIX_TIMESTAMP() * 1000.0)"
         + " + EXTRACT(MICROSECOND FROM CURRENT_TIMESTAMP(3)) / 1000"
-        + " WHERE schema_id = #{schemaId} AND deleted_at = 0";
+        + " WHERE schema_id IN ("
+        + "<foreach collection='schemaIds' item='schemaId' separator=','>"
+        + "#{schemaId}"
+        + "</foreach>"
+        + ") AND deleted_at = 0"
+        + "</script>";
   }
 
   public String softDeleteModelVersionMetasByCatalogId(@Param("catalogId") Long catalogId) {

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/OwnerMetaBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/OwnerMetaBaseSQLProvider.java
@@ -229,49 +229,6 @@ public class OwnerMetaBaseSQLProvider {
         + ")";
   }
 
-  public String softDeleteOwnerRelBySchemaId(@Param("schemaId") Long schemaId) {
-    return "UPDATE "
-        + OWNER_TABLE_NAME
-        + " ot SET ot.deleted_at = (UNIX_TIMESTAMP() * 1000.0)"
-        + " + EXTRACT(MICROSECOND FROM CURRENT_TIMESTAMP(3)) / 1000"
-        + " WHERE ot.deleted_at = 0 AND EXISTS ("
-        + " SELECT st.schema_id FROM "
-        + SchemaMetaMapper.TABLE_NAME
-        + " st WHERE st.schema_id = #{schemaId} AND"
-        + " st.schema_id = ot.metadata_object_id AND ot.metadata_object_type = 'SCHEMA'"
-        + " UNION"
-        + " SELECT tt.schema_id FROM "
-        + TopicMetaMapper.TABLE_NAME
-        + " tt WHERE tt.schema_id = #{schemaId} AND"
-        + " tt.topic_id = ot.metadata_object_id AND ot.metadata_object_type = 'TOPIC'"
-        + " UNION"
-        + " SELECT tat.schema_id FROM "
-        + TableMetaMapper.TABLE_NAME
-        + " tat WHERE tat.schema_id = #{schemaId} AND"
-        + " tat.table_id = ot.metadata_object_id AND ot.metadata_object_type = 'TABLE'"
-        + " UNION"
-        + " SELECT ft.schema_id FROM "
-        + FilesetMetaMapper.META_TABLE_NAME
-        + " ft WHERE ft.schema_id = #{schemaId} AND"
-        + " ft.fileset_id = ot.metadata_object_id AND ot.metadata_object_type = 'FILESET'"
-        + " UNION"
-        + " SELECT mt.schema_id FROM "
-        + ModelMetaMapper.TABLE_NAME
-        + " mt WHERE mt.schema_id = #{schemaId} AND"
-        + " mt.model_id = ot.metadata_object_id AND ot.metadata_object_type = 'MODEL'"
-        + " UNION"
-        + " SELECT vt.schema_id FROM "
-        + ViewMetaMapper.TABLE_NAME
-        + " vt WHERE vt.schema_id = #{schemaId} AND"
-        + " vt.view_id = ot.metadata_object_id AND ot.metadata_object_type = 'VIEW'"
-        + " UNION"
-        + " SELECT fnt.schema_id FROM "
-        + FunctionMetaMapper.TABLE_NAME
-        + " fnt WHERE fnt.schema_id = #{schemaId} AND"
-        + " fnt.function_id = ot.metadata_object_id AND ot.metadata_object_type = 'FUNCTION'"
-        + ")";
-  }
-
   public String softDeleteOwnerRelBySchemaIds(@Param("schemaIds") List<Long> schemaIds) {
     return "<script>"
         + "UPDATE "

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/OwnerMetaBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/OwnerMetaBaseSQLProvider.java
@@ -272,6 +272,72 @@ public class OwnerMetaBaseSQLProvider {
         + ")";
   }
 
+  public String softDeleteOwnerRelBySchemaIds(@Param("schemaIds") List<Long> schemaIds) {
+    return "<script>"
+        + "UPDATE "
+        + OWNER_TABLE_NAME
+        + " ot SET ot.deleted_at = (UNIX_TIMESTAMP() * 1000.0)"
+        + " + EXTRACT(MICROSECOND FROM CURRENT_TIMESTAMP(3)) / 1000"
+        + " WHERE ot.deleted_at = 0 AND EXISTS ("
+        + " SELECT st.schema_id FROM "
+        + SchemaMetaMapper.TABLE_NAME
+        + " st WHERE st.schema_id IN "
+        + "<foreach collection='schemaIds' item='schemaId' open='(' close=')' separator=','>"
+        + "#{schemaId}"
+        + "</foreach>"
+        + " AND st.schema_id = ot.metadata_object_id AND ot.metadata_object_type = 'SCHEMA'"
+        + " UNION"
+        + " SELECT tt.schema_id FROM "
+        + TopicMetaMapper.TABLE_NAME
+        + " tt WHERE tt.schema_id IN "
+        + "<foreach collection='schemaIds' item='schemaId' open='(' close=')' separator=','>"
+        + "#{schemaId}"
+        + "</foreach>"
+        + " AND tt.topic_id = ot.metadata_object_id AND ot.metadata_object_type = 'TOPIC'"
+        + " UNION"
+        + " SELECT tat.schema_id FROM "
+        + TableMetaMapper.TABLE_NAME
+        + " tat WHERE tat.schema_id IN "
+        + "<foreach collection='schemaIds' item='schemaId' open='(' close=')' separator=','>"
+        + "#{schemaId}"
+        + "</foreach>"
+        + " AND tat.table_id = ot.metadata_object_id AND ot.metadata_object_type = 'TABLE'"
+        + " UNION"
+        + " SELECT ft.schema_id FROM "
+        + FilesetMetaMapper.META_TABLE_NAME
+        + " ft WHERE ft.schema_id IN "
+        + "<foreach collection='schemaIds' item='schemaId' open='(' close=')' separator=','>"
+        + "#{schemaId}"
+        + "</foreach>"
+        + " AND ft.fileset_id = ot.metadata_object_id AND ot.metadata_object_type = 'FILESET'"
+        + " UNION"
+        + " SELECT mt.schema_id FROM "
+        + ModelMetaMapper.TABLE_NAME
+        + " mt WHERE mt.schema_id IN "
+        + "<foreach collection='schemaIds' item='schemaId' open='(' close=')' separator=','>"
+        + "#{schemaId}"
+        + "</foreach>"
+        + " AND mt.model_id = ot.metadata_object_id AND ot.metadata_object_type = 'MODEL'"
+        + " UNION"
+        + " SELECT vt.schema_id FROM "
+        + ViewMetaMapper.TABLE_NAME
+        + " vt WHERE vt.schema_id IN "
+        + "<foreach collection='schemaIds' item='schemaId' open='(' close=')' separator=','>"
+        + "#{schemaId}"
+        + "</foreach>"
+        + " AND vt.view_id = ot.metadata_object_id AND ot.metadata_object_type = 'VIEW'"
+        + " UNION"
+        + " SELECT fnt.schema_id FROM "
+        + FunctionMetaMapper.TABLE_NAME
+        + " fnt WHERE fnt.schema_id IN "
+        + "<foreach collection='schemaIds' item='schemaId' open='(' close=')' separator=','>"
+        + "#{schemaId}"
+        + "</foreach>"
+        + " AND fnt.function_id = ot.metadata_object_id AND ot.metadata_object_type = 'FUNCTION'"
+        + ")"
+        + "</script>";
+  }
+
   public String deleteOwnerMetasByLegacyTimeline(
       @Param("legacyTimeline") Long legacyTimeline, @Param("limit") int limit) {
     // Keep this cutoff comfortably behind the present time. These deleted owner rows are also used

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/PolicyMetadataObjectRelBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/PolicyMetadataObjectRelBaseSQLProvider.java
@@ -215,6 +215,50 @@ public class PolicyMetadataObjectRelBaseSQLProvider {
         + " )";
   }
 
+  public String softDeletePolicyMetadataObjectRelsBySchemaIds(
+      @Param("schemaIds") List<Long> schemaIds) {
+    return "<script>"
+        + "UPDATE "
+        + PolicyMetadataObjectRelMapper.POLICY_METADATA_OBJECT_RELATION_TABLE_NAME
+        + " SET deleted_at = (UNIX_TIMESTAMP() * 1000.0) + EXTRACT(MICROSECOND FROM CURRENT_TIMESTAMP(3)) / 1000"
+        + " WHERE deleted_at = 0 AND ("
+        + "   (metadata_object_type = 'SCHEMA' AND metadata_object_id IN "
+        + "<foreach collection='schemaIds' item='schemaId' open='(' close=')' separator=','>"
+        + "#{schemaId}"
+        + "</foreach>"
+        + ")"
+        + "   OR (metadata_object_type = 'TOPIC' AND metadata_object_id IN (SELECT topic_id FROM "
+        + TopicMetaMapper.TABLE_NAME
+        + " WHERE schema_id IN "
+        + "<foreach collection='schemaIds' item='schemaId' open='(' close=')' separator=','>"
+        + "#{schemaId}"
+        + "</foreach>"
+        + "))"
+        + "   OR (metadata_object_type = 'TABLE' AND metadata_object_id IN (SELECT table_id FROM "
+        + TableMetaMapper.TABLE_NAME
+        + " WHERE schema_id IN "
+        + "<foreach collection='schemaIds' item='schemaId' open='(' close=')' separator=','>"
+        + "#{schemaId}"
+        + "</foreach>"
+        + "))"
+        + "   OR (metadata_object_type = 'FILESET' AND metadata_object_id IN (SELECT fileset_id FROM "
+        + FilesetMetaMapper.META_TABLE_NAME
+        + " WHERE schema_id IN "
+        + "<foreach collection='schemaIds' item='schemaId' open='(' close=')' separator=','>"
+        + "#{schemaId}"
+        + "</foreach>"
+        + "))"
+        + "   OR (metadata_object_type = 'MODEL' AND metadata_object_id IN (SELECT model_id FROM "
+        + ModelMetaMapper.TABLE_NAME
+        + " WHERE schema_id IN "
+        + "<foreach collection='schemaIds' item='schemaId' open='(' close=')' separator=','>"
+        + "#{schemaId}"
+        + "</foreach>"
+        + "))"
+        + " )"
+        + "</script>";
+  }
+
   public String softDeletePolicyMetadataObjectRelsByTableId(@Param("tableId") Long tableId) {
     return "UPDATE "
         + PolicyMetadataObjectRelMapper.POLICY_METADATA_OBJECT_RELATION_TABLE_NAME

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/PolicyMetadataObjectRelBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/PolicyMetadataObjectRelBaseSQLProvider.java
@@ -194,27 +194,6 @@ public class PolicyMetadataObjectRelBaseSQLProvider {
         + " )";
   }
 
-  public String softDeletePolicyMetadataObjectRelsBySchemaId(@Param("schemaId") Long schemaId) {
-    return "UPDATE "
-        + PolicyMetadataObjectRelMapper.POLICY_METADATA_OBJECT_RELATION_TABLE_NAME
-        + " SET deleted_at = (UNIX_TIMESTAMP() * 1000.0) + EXTRACT(MICROSECOND FROM CURRENT_TIMESTAMP(3)) / 1000"
-        + " WHERE deleted_at = 0 AND ("
-        + "   (metadata_object_type = 'SCHEMA' AND metadata_object_id = #{schemaId})"
-        + "   OR (metadata_object_type = 'TOPIC' AND metadata_object_id IN (SELECT topic_id FROM "
-        + TopicMetaMapper.TABLE_NAME
-        + " WHERE schema_id = #{schemaId}))"
-        + "   OR (metadata_object_type = 'TABLE' AND metadata_object_id IN (SELECT table_id FROM "
-        + TableMetaMapper.TABLE_NAME
-        + " WHERE schema_id = #{schemaId}))"
-        + "   OR (metadata_object_type = 'FILESET' AND metadata_object_id IN (SELECT fileset_id FROM "
-        + FilesetMetaMapper.META_TABLE_NAME
-        + " WHERE schema_id = #{schemaId}))"
-        + "   OR (metadata_object_type = 'MODEL' AND metadata_object_id IN (SELECT model_id FROM "
-        + ModelMetaMapper.TABLE_NAME
-        + " WHERE schema_id = #{schemaId}))"
-        + " )";
-  }
-
   public String softDeletePolicyMetadataObjectRelsBySchemaIds(
       @Param("schemaIds") List<Long> schemaIds) {
     return "<script>"

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/SchemaMetaBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/SchemaMetaBaseSQLProvider.java
@@ -86,6 +86,22 @@ public class SchemaMetaBaseSQLProvider {
         + "</script>";
   }
 
+  public String listSchemaPOsByCatalogIdAndNamePrefix(
+      @Param("catalogId") Long catalogId,
+      @Param("schemaName") String schemaName,
+      @Param("descendantPrefix") String descendantPrefix) {
+    return "SELECT schema_id as schemaId, schema_name as schemaName,"
+        + " metalake_id as metalakeId, catalog_id as catalogId,"
+        + " schema_comment as schemaComment, properties, audit_info as auditInfo,"
+        + " current_version as currentVersion, last_version as lastVersion,"
+        + " deleted_at as deletedAt"
+        + " FROM "
+        + TABLE_NAME
+        + " WHERE catalog_id = #{catalogId}"
+        + " AND (schema_name = #{schemaName} OR schema_name LIKE CONCAT(#{descendantPrefix}, '%'))"
+        + " AND deleted_at = 0";
+  }
+
   public String selectSchemaIdByCatalogIdAndName(
       @Param("catalogId") Long catalogId, @Param("schemaName") String name) {
     return "SELECT schema_id as schemaId FROM "
@@ -271,6 +287,20 @@ public class SchemaMetaBaseSQLProvider {
         + " SET deleted_at = (UNIX_TIMESTAMP() * 1000.0)"
         + " + EXTRACT(MICROSECOND FROM CURRENT_TIMESTAMP(3)) / 1000"
         + " WHERE schema_id = #{schemaId} AND deleted_at = 0";
+  }
+
+  public String softDeleteSchemaMetasBySchemaIds(@Param("schemaIds") List<Long> schemaIds) {
+    return "<script>"
+        + "UPDATE "
+        + TABLE_NAME
+        + " SET deleted_at = (UNIX_TIMESTAMP() * 1000.0)"
+        + " + EXTRACT(MICROSECOND FROM CURRENT_TIMESTAMP(3)) / 1000"
+        + " WHERE schema_id IN ("
+        + "<foreach collection='schemaIds' item='schemaId' separator=','>"
+        + "#{schemaId}"
+        + "</foreach>"
+        + ") AND deleted_at = 0"
+        + "</script>";
   }
 
   public String softDeleteSchemaMetasByMetalakeId(@Param("metalakeId") Long metalakeId) {

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/SchemaMetaBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/SchemaMetaBaseSQLProvider.java
@@ -281,14 +281,6 @@ public class SchemaMetaBaseSQLProvider {
         + " AND deleted_at = 0";
   }
 
-  public String softDeleteSchemaMetasBySchemaId(@Param("schemaId") Long schemaId) {
-    return "UPDATE "
-        + TABLE_NAME
-        + " SET deleted_at = (UNIX_TIMESTAMP() * 1000.0)"
-        + " + EXTRACT(MICROSECOND FROM CURRENT_TIMESTAMP(3)) / 1000"
-        + " WHERE schema_id = #{schemaId} AND deleted_at = 0";
-  }
-
   public String softDeleteSchemaMetasBySchemaIds(@Param("schemaIds") List<Long> schemaIds) {
     return "<script>"
         + "UPDATE "

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/SchemaMetaBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/SchemaMetaBaseSQLProvider.java
@@ -98,7 +98,11 @@ public class SchemaMetaBaseSQLProvider {
         + " FROM "
         + TABLE_NAME
         + " WHERE catalog_id = #{catalogId}"
-        + " AND (schema_name = #{schemaName} OR schema_name LIKE CONCAT(#{descendantPrefix}, '%'))"
+        // The descendantPrefix has its LIKE metacharacters escaped with '!' by the caller
+        // (SchemaPOStorageOps#escapeLikeMetacharacters), so '!' is declared as the ESCAPE
+        // character to keep the prefix match literal across MySQL, H2, and PostgreSQL.
+        + " AND (schema_name = #{schemaName}"
+        + " OR schema_name LIKE CONCAT(#{descendantPrefix}, '%') ESCAPE '!')"
         + " AND deleted_at = 0";
   }
 

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/SecurableObjectBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/SecurableObjectBaseSQLProvider.java
@@ -192,6 +192,72 @@ public class SecurableObjectBaseSQLProvider {
         + ")";
   }
 
+  public String softDeleteObjectRelsBySchemaIds(@Param("schemaIds") List<Long> schemaIds) {
+    return "<script>"
+        + "UPDATE "
+        + SECURABLE_OBJECT_TABLE_NAME
+        + " sect SET deleted_at = (UNIX_TIMESTAMP() * 1000.0)"
+        + " + EXTRACT(MICROSECOND FROM CURRENT_TIMESTAMP(3)) / 1000"
+        + " WHERE sect.deleted_at = 0 AND EXISTS ("
+        + " SELECT st.schema_id FROM "
+        + SchemaMetaMapper.TABLE_NAME
+        + " st WHERE st.schema_id IN "
+        + "<foreach collection='schemaIds' item='schemaId' open='(' close=')' separator=','>"
+        + "#{schemaId}"
+        + "</foreach>"
+        + " AND st.schema_id = sect.metadata_object_id AND sect.type = 'SCHEMA'"
+        + " UNION"
+        + " SELECT tt.schema_id FROM "
+        + TopicMetaMapper.TABLE_NAME
+        + " tt WHERE tt.schema_id IN "
+        + "<foreach collection='schemaIds' item='schemaId' open='(' close=')' separator=','>"
+        + "#{schemaId}"
+        + "</foreach>"
+        + " AND tt.topic_id = sect.metadata_object_id AND sect.type = 'TOPIC'"
+        + " UNION"
+        + " SELECT tat.schema_id FROM "
+        + TableMetaMapper.TABLE_NAME
+        + " tat WHERE tat.schema_id IN "
+        + "<foreach collection='schemaIds' item='schemaId' open='(' close=')' separator=','>"
+        + "#{schemaId}"
+        + "</foreach>"
+        + " AND tat.table_id = sect.metadata_object_id AND sect.type = 'TABLE'"
+        + " UNION"
+        + " SELECT ft.schema_id FROM "
+        + FilesetMetaMapper.META_TABLE_NAME
+        + " ft WHERE ft.schema_id IN "
+        + "<foreach collection='schemaIds' item='schemaId' open='(' close=')' separator=','>"
+        + "#{schemaId}"
+        + "</foreach>"
+        + " AND ft.fileset_id = sect.metadata_object_id AND sect.type = 'FILESET'"
+        + " UNION"
+        + " SELECT mt.schema_id FROM "
+        + ModelMetaMapper.TABLE_NAME
+        + " mt WHERE mt.schema_id IN "
+        + "<foreach collection='schemaIds' item='schemaId' open='(' close=')' separator=','>"
+        + "#{schemaId}"
+        + "</foreach>"
+        + " AND mt.model_id = sect.metadata_object_id AND sect.type = 'MODEL'"
+        + " UNION"
+        + " SELECT vt.schema_id FROM "
+        + ViewMetaMapper.TABLE_NAME
+        + " vt WHERE vt.schema_id IN "
+        + "<foreach collection='schemaIds' item='schemaId' open='(' close=')' separator=','>"
+        + "#{schemaId}"
+        + "</foreach>"
+        + " AND vt.view_id = sect.metadata_object_id AND sect.type = 'VIEW'"
+        + " UNION"
+        + " SELECT fnt.schema_id FROM "
+        + FunctionMetaMapper.TABLE_NAME
+        + " fnt WHERE fnt.schema_id IN "
+        + "<foreach collection='schemaIds' item='schemaId' open='(' close=')' separator=','>"
+        + "#{schemaId}"
+        + "</foreach>"
+        + " AND fnt.function_id = sect.metadata_object_id AND sect.type = 'FUNCTION'"
+        + ")"
+        + "</script>";
+  }
+
   public String listSecurableObjectsByRoleId(@Param("roleId") Long roleId) {
     return "SELECT role_id as roleId, metadata_object_id as metadataObjectId,"
         + " type as type, privilege_names as privilegeNames,"

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/SecurableObjectBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/SecurableObjectBaseSQLProvider.java
@@ -149,49 +149,6 @@ public class SecurableObjectBaseSQLProvider {
         + ")";
   }
 
-  public String softDeleteObjectRelsBySchemaId(@Param("schemaId") Long schemaId) {
-    return "UPDATE "
-        + SECURABLE_OBJECT_TABLE_NAME
-        + " sect SET deleted_at = (UNIX_TIMESTAMP() * 1000.0)"
-        + " + EXTRACT(MICROSECOND FROM CURRENT_TIMESTAMP(3)) / 1000"
-        + " WHERE sect.deleted_at = 0 AND EXISTS ("
-        + " SELECT st.schema_id FROM "
-        + SchemaMetaMapper.TABLE_NAME
-        + " st WHERE st.schema_id = #{schemaId}"
-        + " AND st.schema_id = sect.metadata_object_id AND sect.type = 'SCHEMA'"
-        + " UNION"
-        + " SELECT tt.schema_id FROM "
-        + TopicMetaMapper.TABLE_NAME
-        + " tt WHERE tt.schema_id = #{schemaId} AND"
-        + " tt.topic_id = sect.metadata_object_id AND sect.type = 'TOPIC'"
-        + " UNION"
-        + " SELECT tat.schema_id FROM "
-        + TableMetaMapper.TABLE_NAME
-        + " tat WHERE tat.schema_id = #{schemaId} AND"
-        + " tat.table_id = sect.metadata_object_id AND sect.type = 'TABLE'"
-        + " UNION"
-        + " SELECT ft.schema_id FROM "
-        + FilesetMetaMapper.META_TABLE_NAME
-        + " ft WHERE ft.schema_id = #{schemaId} AND"
-        + " ft.fileset_id = sect.metadata_object_id AND sect.type = 'FILESET'"
-        + " UNION"
-        + " SELECT mt.schema_id FROM "
-        + ModelMetaMapper.TABLE_NAME
-        + " mt WHERE mt.schema_id = #{schemaId} AND"
-        + " mt.model_id = sect.metadata_object_id AND sect.type = 'MODEL'"
-        + " UNION"
-        + " SELECT vt.schema_id FROM "
-        + ViewMetaMapper.TABLE_NAME
-        + " vt WHERE vt.schema_id = #{schemaId} AND"
-        + " vt.view_id = sect.metadata_object_id AND sect.type = 'VIEW'"
-        + " UNION"
-        + " SELECT fnt.schema_id FROM "
-        + FunctionMetaMapper.TABLE_NAME
-        + " fnt WHERE fnt.schema_id = #{schemaId} AND"
-        + " fnt.function_id = sect.metadata_object_id AND sect.type = 'FUNCTION'"
-        + ")";
-  }
-
   public String softDeleteObjectRelsBySchemaIds(@Param("schemaIds") List<Long> schemaIds) {
     return "<script>"
         + "UPDATE "

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/StatisticBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/StatisticBaseSQLProvider.java
@@ -138,39 +138,6 @@ public class StatisticBaseSQLProvider {
         + ")";
   }
 
-  public String softDeleteStatisticsBySchemaId(@Param("schemaId") Long schemaId) {
-    return "UPDATE "
-        + STATISTIC_META_TABLE_NAME
-        + " stat "
-        + softDeleteSQL()
-        + " WHERE stat.deleted_at = 0 AND EXISTS ("
-        + " SELECT st.schema_id FROM "
-        + SchemaMetaMapper.TABLE_NAME
-        + " st WHERE st.schema_id = #{schemaId}"
-        + " AND st.schema_id = stat.metadata_object_id AND stat.metadata_object_type = 'SCHEMA'"
-        + " UNION"
-        + " SELECT tt.schema_id FROM "
-        + TopicMetaMapper.TABLE_NAME
-        + " tt WHERE tt.schema_id = #{schemaId} AND"
-        + " tt.topic_id = stat.metadata_object_id AND stat.metadata_object_type = 'TOPIC'"
-        + " UNION"
-        + " SELECT tat.schema_id FROM "
-        + TableMetaMapper.TABLE_NAME
-        + " tat WHERE tat.schema_id = #{schemaId} AND"
-        + " tat.table_id = stat.metadata_object_id AND stat.metadata_object_type = 'TABLE'"
-        + " UNION"
-        + " SELECT ft.schema_id FROM "
-        + FilesetMetaMapper.META_TABLE_NAME
-        + " ft WHERE ft.schema_id = #{schemaId} AND"
-        + " ft.fileset_id = stat.metadata_object_id AND stat.metadata_object_type = 'FILESET'"
-        + " UNION"
-        + " SELECT mt.schema_id FROM "
-        + ModelMetaMapper.TABLE_NAME
-        + " mt WHERE mt.schema_id = #{schemaId} AND"
-        + " mt.model_id = stat.metadata_object_id AND stat.metadata_object_type = 'MODEL'"
-        + ")";
-  }
-
   public String softDeleteStatisticsBySchemaIds(@Param("schemaIds") List<Long> schemaIds) {
     return "<script>"
         + "UPDATE "

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/StatisticBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/StatisticBaseSQLProvider.java
@@ -171,6 +171,56 @@ public class StatisticBaseSQLProvider {
         + ")";
   }
 
+  public String softDeleteStatisticsBySchemaIds(@Param("schemaIds") List<Long> schemaIds) {
+    return "<script>"
+        + "UPDATE "
+        + STATISTIC_META_TABLE_NAME
+        + " stat "
+        + softDeleteSQL()
+        + " WHERE stat.deleted_at = 0 AND EXISTS ("
+        + " SELECT st.schema_id FROM "
+        + SchemaMetaMapper.TABLE_NAME
+        + " st WHERE st.schema_id IN "
+        + "<foreach collection='schemaIds' item='schemaId' open='(' close=')' separator=','>"
+        + "#{schemaId}"
+        + "</foreach>"
+        + " AND st.schema_id = stat.metadata_object_id AND stat.metadata_object_type = 'SCHEMA'"
+        + " UNION"
+        + " SELECT tt.schema_id FROM "
+        + TopicMetaMapper.TABLE_NAME
+        + " tt WHERE tt.schema_id IN "
+        + "<foreach collection='schemaIds' item='schemaId' open='(' close=')' separator=','>"
+        + "#{schemaId}"
+        + "</foreach>"
+        + " AND tt.topic_id = stat.metadata_object_id AND stat.metadata_object_type = 'TOPIC'"
+        + " UNION"
+        + " SELECT tat.schema_id FROM "
+        + TableMetaMapper.TABLE_NAME
+        + " tat WHERE tat.schema_id IN "
+        + "<foreach collection='schemaIds' item='schemaId' open='(' close=')' separator=','>"
+        + "#{schemaId}"
+        + "</foreach>"
+        + " AND tat.table_id = stat.metadata_object_id AND stat.metadata_object_type = 'TABLE'"
+        + " UNION"
+        + " SELECT ft.schema_id FROM "
+        + FilesetMetaMapper.META_TABLE_NAME
+        + " ft WHERE ft.schema_id IN "
+        + "<foreach collection='schemaIds' item='schemaId' open='(' close=')' separator=','>"
+        + "#{schemaId}"
+        + "</foreach>"
+        + " AND ft.fileset_id = stat.metadata_object_id AND stat.metadata_object_type = 'FILESET'"
+        + " UNION"
+        + " SELECT mt.schema_id FROM "
+        + ModelMetaMapper.TABLE_NAME
+        + " mt WHERE mt.schema_id IN "
+        + "<foreach collection='schemaIds' item='schemaId' open='(' close=')' separator=','>"
+        + "#{schemaId}"
+        + "</foreach>"
+        + " AND mt.model_id = stat.metadata_object_id AND stat.metadata_object_type = 'MODEL'"
+        + ")"
+        + "</script>";
+  }
+
   public String deleteStatisticsByLegacyTimeline(
       @Param("legacyTimeline") Long legacyTimeline, @Param("limit") int limit) {
     return "DELETE FROM "

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/TableColumnBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/TableColumnBaseSQLProvider.java
@@ -106,6 +106,20 @@ public class TableColumnBaseSQLProvider {
         + " WHERE schema_id = #{schemaId} AND deleted_at = 0";
   }
 
+  public String softDeleteColumnsBySchemaIds(@Param("schemaIds") List<Long> schemaIds) {
+    return "<script>"
+        + "UPDATE "
+        + TableColumnMapper.COLUMN_TABLE_NAME
+        + " SET deleted_at = (UNIX_TIMESTAMP() * 1000.0)"
+        + " + EXTRACT(MICROSECOND FROM CURRENT_TIMESTAMP(3)) / 1000"
+        + " WHERE schema_id IN ("
+        + "<foreach collection='schemaIds' item='schemaId' separator=','>"
+        + "#{schemaId}"
+        + "</foreach>"
+        + ") AND deleted_at = 0"
+        + "</script>";
+  }
+
   public String deleteColumnPOsByLegacyTimeline(
       @Param("legacyTimeline") Long legacyTimeline, @Param("limit") int limit) {
     return "DELETE FROM "

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/TableColumnBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/TableColumnBaseSQLProvider.java
@@ -98,14 +98,6 @@ public class TableColumnBaseSQLProvider {
         + " WHERE catalog_id = #{catalogId} AND deleted_at = 0";
   }
 
-  public String softDeleteColumnsBySchemaId(@Param("schemaId") Long schemaId) {
-    return "UPDATE "
-        + TableColumnMapper.COLUMN_TABLE_NAME
-        + " SET deleted_at = (UNIX_TIMESTAMP() * 1000.0)"
-        + " + EXTRACT(MICROSECOND FROM CURRENT_TIMESTAMP(3)) / 1000"
-        + " WHERE schema_id = #{schemaId} AND deleted_at = 0";
-  }
-
   public String softDeleteColumnsBySchemaIds(@Param("schemaIds") List<Long> schemaIds) {
     return "<script>"
         + "UPDATE "

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/TableMetaBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/TableMetaBaseSQLProvider.java
@@ -274,14 +274,6 @@ public class TableMetaBaseSQLProvider {
         + " WHERE catalog_id = #{catalogId} AND deleted_at = 0";
   }
 
-  public String softDeleteTableMetasBySchemaId(@Param("schemaId") Long schemaId) {
-    return "UPDATE "
-        + TABLE_NAME
-        + " SET deleted_at = (UNIX_TIMESTAMP() * 1000.0)"
-        + " + EXTRACT(MICROSECOND FROM CURRENT_TIMESTAMP(3)) / 1000"
-        + " WHERE schema_id = #{schemaId} AND deleted_at = 0";
-  }
-
   public String softDeleteTableMetasBySchemaIds(@Param("schemaIds") List<Long> schemaIds) {
     return "<script>"
         + "UPDATE "

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/TableMetaBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/TableMetaBaseSQLProvider.java
@@ -282,6 +282,20 @@ public class TableMetaBaseSQLProvider {
         + " WHERE schema_id = #{schemaId} AND deleted_at = 0";
   }
 
+  public String softDeleteTableMetasBySchemaIds(@Param("schemaIds") List<Long> schemaIds) {
+    return "<script>"
+        + "UPDATE "
+        + TABLE_NAME
+        + " SET deleted_at = (UNIX_TIMESTAMP() * 1000.0)"
+        + " + EXTRACT(MICROSECOND FROM CURRENT_TIMESTAMP(3)) / 1000"
+        + " WHERE schema_id IN ("
+        + "<foreach collection='schemaIds' item='schemaId' separator=','>"
+        + "#{schemaId}"
+        + "</foreach>"
+        + ") AND deleted_at = 0"
+        + "</script>";
+  }
+
   public String deleteTableMetasByLegacyTimeline(
       @Param("legacyTimeline") Long legacyTimeline, @Param("limit") int limit) {
     return "DELETE FROM "

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/TagMetadataObjectRelBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/TagMetadataObjectRelBaseSQLProvider.java
@@ -207,44 +207,6 @@ public class TagMetadataObjectRelBaseSQLProvider {
         + ")";
   }
 
-  public String softDeleteTagMetadataObjectRelsBySchemaId(@Param("schemaId") Long schemaId) {
-    return " UPDATE "
-        + TagMetadataObjectRelMapper.TAG_METADATA_OBJECT_RELATION_TABLE_NAME
-        + " tmt SET deleted_at = (UNIX_TIMESTAMP() * 1000.0)"
-        + " + EXTRACT(MICROSECOND FROM CURRENT_TIMESTAMP(3)) / 1000"
-        + " WHERE tmt.deleted_at = 0 AND EXISTS ("
-        + " SELECT st.schema_id FROM "
-        + SchemaMetaMapper.TABLE_NAME
-        + " st WHERE st.schema_id = #{schemaId} AND"
-        + " st.schema_id = tmt.metadata_object_id AND tmt.metadata_object_type = 'SCHEMA'"
-        + " UNION"
-        + " SELECT tt.schema_id FROM "
-        + TopicMetaMapper.TABLE_NAME
-        + " tt WHERE tt.schema_id = #{schemaId} AND"
-        + " tt.topic_id = tmt.metadata_object_id AND tmt.metadata_object_type = 'TOPIC'"
-        + " UNION"
-        + " SELECT tat.schema_id FROM "
-        + TableMetaMapper.TABLE_NAME
-        + " tat WHERE tat.schema_id = #{schemaId} AND"
-        + " tat.table_id = tmt.metadata_object_id AND tmt.metadata_object_type = 'TABLE'"
-        + " UNION"
-        + " SELECT ft.schema_id FROM "
-        + FilesetMetaMapper.META_TABLE_NAME
-        + " ft WHERE ft.schema_id = #{schemaId} AND"
-        + " ft.fileset_id = tmt.metadata_object_id AND tmt.metadata_object_type = 'FILESET'"
-        + " UNION"
-        + " SELECT cot.schema_id FROM "
-        + TableColumnMapper.COLUMN_TABLE_NAME
-        + " cot WHERE cot.schema_id = #{schemaId} AND"
-        + " cot.column_id = tmt.metadata_object_id AND tmt.metadata_object_type = 'COLUMN'"
-        + " UNION"
-        + " SELECT mt.schema_id FROM "
-        + ModelMetaMapper.TABLE_NAME
-        + " mt WHERE mt.schema_id = #{schemaId} AND"
-        + " mt.model_id = tmt.metadata_object_id AND tmt.metadata_object_type = 'MODEL'"
-        + ")";
-  }
-
   public String softDeleteTagMetadataObjectRelsBySchemaIds(
       @Param("schemaIds") List<Long> schemaIds) {
     return "<script>"

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/TagMetadataObjectRelBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/TagMetadataObjectRelBaseSQLProvider.java
@@ -245,6 +245,65 @@ public class TagMetadataObjectRelBaseSQLProvider {
         + ")";
   }
 
+  public String softDeleteTagMetadataObjectRelsBySchemaIds(
+      @Param("schemaIds") List<Long> schemaIds) {
+    return "<script>"
+        + " UPDATE "
+        + TagMetadataObjectRelMapper.TAG_METADATA_OBJECT_RELATION_TABLE_NAME
+        + " tmt SET deleted_at = (UNIX_TIMESTAMP() * 1000.0)"
+        + " + EXTRACT(MICROSECOND FROM CURRENT_TIMESTAMP(3)) / 1000"
+        + " WHERE tmt.deleted_at = 0 AND EXISTS ("
+        + " SELECT st.schema_id FROM "
+        + SchemaMetaMapper.TABLE_NAME
+        + " st WHERE st.schema_id IN "
+        + "<foreach collection='schemaIds' item='schemaId' open='(' close=')' separator=','>"
+        + "#{schemaId}"
+        + "</foreach>"
+        + " AND st.schema_id = tmt.metadata_object_id AND tmt.metadata_object_type = 'SCHEMA'"
+        + " UNION"
+        + " SELECT tt.schema_id FROM "
+        + TopicMetaMapper.TABLE_NAME
+        + " tt WHERE tt.schema_id IN "
+        + "<foreach collection='schemaIds' item='schemaId' open='(' close=')' separator=','>"
+        + "#{schemaId}"
+        + "</foreach>"
+        + " AND tt.topic_id = tmt.metadata_object_id AND tmt.metadata_object_type = 'TOPIC'"
+        + " UNION"
+        + " SELECT tat.schema_id FROM "
+        + TableMetaMapper.TABLE_NAME
+        + " tat WHERE tat.schema_id IN "
+        + "<foreach collection='schemaIds' item='schemaId' open='(' close=')' separator=','>"
+        + "#{schemaId}"
+        + "</foreach>"
+        + " AND tat.table_id = tmt.metadata_object_id AND tmt.metadata_object_type = 'TABLE'"
+        + " UNION"
+        + " SELECT ft.schema_id FROM "
+        + FilesetMetaMapper.META_TABLE_NAME
+        + " ft WHERE ft.schema_id IN "
+        + "<foreach collection='schemaIds' item='schemaId' open='(' close=')' separator=','>"
+        + "#{schemaId}"
+        + "</foreach>"
+        + " AND ft.fileset_id = tmt.metadata_object_id AND tmt.metadata_object_type = 'FILESET'"
+        + " UNION"
+        + " SELECT cot.schema_id FROM "
+        + TableColumnMapper.COLUMN_TABLE_NAME
+        + " cot WHERE cot.schema_id IN "
+        + "<foreach collection='schemaIds' item='schemaId' open='(' close=')' separator=','>"
+        + "#{schemaId}"
+        + "</foreach>"
+        + " AND cot.column_id = tmt.metadata_object_id AND tmt.metadata_object_type = 'COLUMN'"
+        + " UNION"
+        + " SELECT mt.schema_id FROM "
+        + ModelMetaMapper.TABLE_NAME
+        + " mt WHERE mt.schema_id IN "
+        + "<foreach collection='schemaIds' item='schemaId' open='(' close=')' separator=','>"
+        + "#{schemaId}"
+        + "</foreach>"
+        + " AND mt.model_id = tmt.metadata_object_id AND tmt.metadata_object_type = 'MODEL'"
+        + ")"
+        + "</script>";
+  }
+
   public String softDeleteTagMetadataObjectRelsByTableId(@Param("tableId") Long tableId) {
     return " UPDATE "
         + TagMetadataObjectRelMapper.TAG_METADATA_OBJECT_RELATION_TABLE_NAME

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/TopicMetaBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/TopicMetaBaseSQLProvider.java
@@ -287,6 +287,20 @@ public class TopicMetaBaseSQLProvider {
         + " WHERE schema_id = #{schemaId} AND deleted_at = 0";
   }
 
+  public String softDeleteTopicMetasBySchemaIds(@Param("schemaIds") List<Long> schemaIds) {
+    return "<script>"
+        + "UPDATE "
+        + TABLE_NAME
+        + " SET deleted_at = (UNIX_TIMESTAMP() * 1000.0)"
+        + " + EXTRACT(MICROSECOND FROM CURRENT_TIMESTAMP(3)) / 1000"
+        + " WHERE schema_id IN ("
+        + "<foreach collection='schemaIds' item='schemaId' separator=','>"
+        + "#{schemaId}"
+        + "</foreach>"
+        + ") AND deleted_at = 0"
+        + "</script>";
+  }
+
   public String deleteTopicMetasByLegacyTimeline(
       @Param("legacyTimeline") Long legacyTimeline, @Param("limit") int limit) {
     return "DELETE FROM "

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/TopicMetaBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/TopicMetaBaseSQLProvider.java
@@ -279,14 +279,6 @@ public class TopicMetaBaseSQLProvider {
         + " WHERE metalake_id = #{metalakeId} AND deleted_at = 0";
   }
 
-  public String softDeleteTopicMetasBySchemaId(@Param("schemaId") Long schemaId) {
-    return "UPDATE "
-        + TABLE_NAME
-        + " SET deleted_at = (UNIX_TIMESTAMP() * 1000.0)"
-        + " + EXTRACT(MICROSECOND FROM CURRENT_TIMESTAMP(3)) / 1000"
-        + " WHERE schema_id = #{schemaId} AND deleted_at = 0";
-  }
-
   public String softDeleteTopicMetasBySchemaIds(@Param("schemaIds") List<Long> schemaIds) {
     return "<script>"
         + "UPDATE "

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/ViewMetaBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/ViewMetaBaseSQLProvider.java
@@ -238,12 +238,18 @@ public class ViewMetaBaseSQLProvider {
         + " WHERE catalog_id = #{catalogId} AND deleted_at = 0";
   }
 
-  public String softDeleteViewMetasBySchemaId(@Param("schemaId") Long schemaId) {
-    return "UPDATE "
+  public String softDeleteViewMetasBySchemaIds(@Param("schemaIds") List<Long> schemaIds) {
+    return "<script>"
+        + "UPDATE "
         + TABLE_NAME
         + " SET deleted_at = (UNIX_TIMESTAMP() * 1000.0)"
         + " + EXTRACT(MICROSECOND FROM CURRENT_TIMESTAMP(3)) / 1000"
-        + " WHERE schema_id = #{schemaId} AND deleted_at = 0";
+        + " WHERE schema_id IN ("
+        + "<foreach collection='schemaIds' item='schemaId' separator=','>"
+        + "#{schemaId}"
+        + "</foreach>"
+        + ") AND deleted_at = 0"
+        + "</script>";
   }
 
   public String deleteViewMetasByLegacyTimeline(

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/FilesetMetaPostgreSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/FilesetMetaPostgreSQLProvider.java
@@ -43,14 +43,6 @@ public class FilesetMetaPostgreSQLProvider extends FilesetMetaBaseSQLProvider {
   }
 
   @Override
-  public String softDeleteFilesetMetasBySchemaId(Long schemaId) {
-    return "UPDATE "
-        + META_TABLE_NAME
-        + " SET deleted_at = CAST(EXTRACT(EPOCH FROM CURRENT_TIMESTAMP) * 1000 AS BIGINT)"
-        + " WHERE schema_id = #{schemaId} AND deleted_at = 0";
-  }
-
-  @Override
   public String softDeleteFilesetMetasBySchemaIds(List<Long> schemaIds) {
     return "<script>"
         + "UPDATE "

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/FilesetMetaPostgreSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/FilesetMetaPostgreSQLProvider.java
@@ -20,6 +20,7 @@ package org.apache.gravitino.storage.relational.mapper.provider.postgresql;
 
 import static org.apache.gravitino.storage.relational.mapper.FilesetMetaMapper.META_TABLE_NAME;
 
+import java.util.List;
 import org.apache.gravitino.storage.relational.mapper.provider.base.FilesetMetaBaseSQLProvider;
 import org.apache.gravitino.storage.relational.po.FilesetPO;
 import org.apache.ibatis.annotations.Param;
@@ -47,6 +48,20 @@ public class FilesetMetaPostgreSQLProvider extends FilesetMetaBaseSQLProvider {
         + META_TABLE_NAME
         + " SET deleted_at = CAST(EXTRACT(EPOCH FROM CURRENT_TIMESTAMP) * 1000 AS BIGINT)"
         + " WHERE schema_id = #{schemaId} AND deleted_at = 0";
+  }
+
+  @Override
+  public String softDeleteFilesetMetasBySchemaIds(List<Long> schemaIds) {
+    return "<script>"
+        + "UPDATE "
+        + META_TABLE_NAME
+        + " SET deleted_at = CAST(EXTRACT(EPOCH FROM CURRENT_TIMESTAMP) * 1000 AS BIGINT)"
+        + " WHERE schema_id IN ("
+        + "<foreach collection='schemaIds' item='schemaId' separator=','>"
+        + "#{schemaId}"
+        + "</foreach>"
+        + ") AND deleted_at = 0"
+        + "</script>";
   }
 
   @Override

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/FilesetVersionPostgreSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/FilesetVersionPostgreSQLProvider.java
@@ -43,14 +43,6 @@ public class FilesetVersionPostgreSQLProvider extends FilesetVersionBaseSQLProvi
   }
 
   @Override
-  public String softDeleteFilesetVersionsBySchemaId(Long schemaId) {
-    return "UPDATE "
-        + VERSION_TABLE_NAME
-        + " SET deleted_at = CAST(EXTRACT(EPOCH FROM CURRENT_TIMESTAMP) * 1000 AS BIGINT)"
-        + " WHERE schema_id = #{schemaId} AND deleted_at = 0";
-  }
-
-  @Override
   public String softDeleteFilesetVersionsBySchemaIds(List<Long> schemaIds) {
     return "<script>"
         + "UPDATE "

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/FilesetVersionPostgreSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/FilesetVersionPostgreSQLProvider.java
@@ -51,6 +51,20 @@ public class FilesetVersionPostgreSQLProvider extends FilesetVersionBaseSQLProvi
   }
 
   @Override
+  public String softDeleteFilesetVersionsBySchemaIds(List<Long> schemaIds) {
+    return "<script>"
+        + "UPDATE "
+        + VERSION_TABLE_NAME
+        + " SET deleted_at = CAST(EXTRACT(EPOCH FROM CURRENT_TIMESTAMP) * 1000 AS BIGINT)"
+        + " WHERE schema_id IN ("
+        + "<foreach collection='schemaIds' item='schemaId' separator=','>"
+        + "#{schemaId}"
+        + "</foreach>"
+        + ") AND deleted_at = 0"
+        + "</script>";
+  }
+
+  @Override
   public String softDeleteFilesetVersionsByFilesetId(Long filesetId) {
     return "UPDATE "
         + VERSION_TABLE_NAME

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/FunctionMetaPostgreSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/FunctionMetaPostgreSQLProvider.java
@@ -18,6 +18,7 @@
  */
 package org.apache.gravitino.storage.relational.mapper.provider.postgresql;
 
+import java.util.List;
 import org.apache.gravitino.storage.relational.mapper.FunctionMetaMapper;
 import org.apache.gravitino.storage.relational.mapper.provider.base.FunctionMetaBaseSQLProvider;
 import org.apache.gravitino.storage.relational.po.FunctionPO;
@@ -129,6 +130,20 @@ public class FunctionMetaPostgreSQLProvider extends FunctionMetaBaseSQLProvider 
         + FunctionMetaMapper.TABLE_NAME
         + " SET deleted_at = CAST(EXTRACT(EPOCH FROM CURRENT_TIMESTAMP) * 1000 AS BIGINT)"
         + " WHERE schema_id = #{schemaId} AND deleted_at = 0";
+  }
+
+  @Override
+  public String softDeleteFunctionMetasBySchemaIds(@Param("schemaIds") List<Long> schemaIds) {
+    return "<script>"
+        + "UPDATE "
+        + FunctionMetaMapper.TABLE_NAME
+        + " SET deleted_at = CAST(EXTRACT(EPOCH FROM CURRENT_TIMESTAMP) * 1000 AS BIGINT)"
+        + " WHERE schema_id IN ("
+        + "<foreach collection='schemaIds' item='schemaId' separator=','>"
+        + "#{schemaId}"
+        + "</foreach>"
+        + ") AND deleted_at = 0"
+        + "</script>";
   }
 
   @Override

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/FunctionMetaPostgreSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/FunctionMetaPostgreSQLProvider.java
@@ -125,14 +125,6 @@ public class FunctionMetaPostgreSQLProvider extends FunctionMetaBaseSQLProvider 
   }
 
   @Override
-  public String softDeleteFunctionMetasBySchemaId(@Param("schemaId") Long schemaId) {
-    return "UPDATE "
-        + FunctionMetaMapper.TABLE_NAME
-        + " SET deleted_at = CAST(EXTRACT(EPOCH FROM CURRENT_TIMESTAMP) * 1000 AS BIGINT)"
-        + " WHERE schema_id = #{schemaId} AND deleted_at = 0";
-  }
-
-  @Override
   public String softDeleteFunctionMetasBySchemaIds(@Param("schemaIds") List<Long> schemaIds) {
     return "<script>"
         + "UPDATE "

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/FunctionVersionMetaPostgreSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/FunctionVersionMetaPostgreSQLProvider.java
@@ -18,6 +18,7 @@
  */
 package org.apache.gravitino.storage.relational.mapper.provider.postgresql;
 
+import java.util.List;
 import org.apache.gravitino.storage.relational.mapper.FunctionVersionMetaMapper;
 import org.apache.gravitino.storage.relational.mapper.provider.base.FunctionVersionMetaBaseSQLProvider;
 import org.apache.gravitino.storage.relational.po.FunctionVersionPO;
@@ -50,6 +51,21 @@ public class FunctionVersionMetaPostgreSQLProvider extends FunctionVersionMetaBa
         + FunctionVersionMetaMapper.TABLE_NAME
         + " SET deleted_at = CAST(EXTRACT(EPOCH FROM CURRENT_TIMESTAMP) * 1000 AS BIGINT)"
         + " WHERE schema_id = #{schemaId} AND deleted_at = 0";
+  }
+
+  @Override
+  public String softDeleteFunctionVersionMetasBySchemaIds(
+      @Param("schemaIds") List<Long> schemaIds) {
+    return "<script>"
+        + "UPDATE "
+        + FunctionVersionMetaMapper.TABLE_NAME
+        + " SET deleted_at = CAST(EXTRACT(EPOCH FROM CURRENT_TIMESTAMP) * 1000 AS BIGINT)"
+        + " WHERE schema_id IN ("
+        + "<foreach collection='schemaIds' item='schemaId' separator=','>"
+        + "#{schemaId}"
+        + "</foreach>"
+        + ") AND deleted_at = 0"
+        + "</script>";
   }
 
   @Override

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/FunctionVersionMetaPostgreSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/FunctionVersionMetaPostgreSQLProvider.java
@@ -46,14 +46,6 @@ public class FunctionVersionMetaPostgreSQLProvider extends FunctionVersionMetaBa
   }
 
   @Override
-  public String softDeleteFunctionVersionMetasBySchemaId(@Param("schemaId") Long schemaId) {
-    return "UPDATE "
-        + FunctionVersionMetaMapper.TABLE_NAME
-        + " SET deleted_at = CAST(EXTRACT(EPOCH FROM CURRENT_TIMESTAMP) * 1000 AS BIGINT)"
-        + " WHERE schema_id = #{schemaId} AND deleted_at = 0";
-  }
-
-  @Override
   public String softDeleteFunctionVersionMetasBySchemaIds(
       @Param("schemaIds") List<Long> schemaIds) {
     return "<script>"

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/ModelMetaPostgreSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/ModelMetaPostgreSQLProvider.java
@@ -18,6 +18,7 @@
  */
 package org.apache.gravitino.storage.relational.mapper.provider.postgresql;
 
+import java.util.List;
 import org.apache.gravitino.storage.relational.mapper.ModelMetaMapper;
 import org.apache.gravitino.storage.relational.mapper.provider.base.ModelMetaBaseSQLProvider;
 import org.apache.gravitino.storage.relational.po.ModelPO;
@@ -73,11 +74,17 @@ public class ModelMetaPostgreSQLProvider extends ModelMetaBaseSQLProvider {
   }
 
   @Override
-  public String softDeleteModelMetasBySchemaId(@Param("schemaId") Long schemaId) {
-    return "UPDATE "
+  public String softDeleteModelMetasBySchemaIds(@Param("schemaIds") List<Long> schemaIds) {
+    return "<script>"
+        + "UPDATE "
         + ModelMetaMapper.TABLE_NAME
         + " SET deleted_at = CAST(EXTRACT(EPOCH FROM CURRENT_TIMESTAMP) * 1000 AS BIGINT)"
-        + " WHERE schema_id = #{schemaId} AND deleted_at = 0";
+        + " WHERE schema_id IN ("
+        + "<foreach collection='schemaIds' item='schemaId' separator=','>"
+        + "#{schemaId}"
+        + "</foreach>"
+        + ") AND deleted_at = 0"
+        + "</script>";
   }
 
   @Override

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/ModelVersionAliasRelPostgreSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/ModelVersionAliasRelPostgreSQLProvider.java
@@ -18,6 +18,7 @@
  */
 package org.apache.gravitino.storage.relational.mapper.provider.postgresql;
 
+import java.util.List;
 import org.apache.gravitino.storage.relational.mapper.ModelMetaMapper;
 import org.apache.gravitino.storage.relational.mapper.ModelVersionAliasRelMapper;
 import org.apache.gravitino.storage.relational.mapper.provider.base.ModelVersionAliasRelBaseSQLProvider;
@@ -69,6 +70,24 @@ public class ModelVersionAliasRelPostgreSQLProvider extends ModelVersionAliasRel
         + " SELECT model_id FROM "
         + ModelMetaMapper.TABLE_NAME
         + " WHERE schema_id = #{schemaId} AND deleted_at = 0) AND deleted_at = 0";
+  }
+
+  @Override
+  public String softDeleteModelVersionAliasRelsBySchemaIds(
+      @Param("schemaIds") List<Long> schemaIds) {
+    return "<script>"
+        + "UPDATE "
+        + ModelVersionAliasRelMapper.TABLE_NAME
+        + " SET deleted_at = CAST(EXTRACT(EPOCH FROM CURRENT_TIMESTAMP) * 1000 AS BIGINT)"
+        + " WHERE model_id IN ("
+        + " SELECT model_id FROM "
+        + ModelMetaMapper.TABLE_NAME
+        + " WHERE schema_id IN "
+        + "<foreach collection='schemaIds' item='schemaId' open='(' close=')' separator=','>"
+        + "#{schemaId}"
+        + "</foreach>"
+        + " AND deleted_at = 0) AND deleted_at = 0"
+        + "</script>";
   }
 
   @Override

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/ModelVersionAliasRelPostgreSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/ModelVersionAliasRelPostgreSQLProvider.java
@@ -62,17 +62,6 @@ public class ModelVersionAliasRelPostgreSQLProvider extends ModelVersionAliasRel
   }
 
   @Override
-  public String softDeleteModelVersionAliasRelsBySchemaId(@Param("schemaId") Long schemaId) {
-    return "UPDATE "
-        + ModelVersionAliasRelMapper.TABLE_NAME
-        + " SET deleted_at = CAST(EXTRACT(EPOCH FROM CURRENT_TIMESTAMP) * 1000 AS BIGINT)"
-        + " WHERE model_id IN ("
-        + " SELECT model_id FROM "
-        + ModelMetaMapper.TABLE_NAME
-        + " WHERE schema_id = #{schemaId} AND deleted_at = 0) AND deleted_at = 0";
-  }
-
-  @Override
   public String softDeleteModelVersionAliasRelsBySchemaIds(
       @Param("schemaIds") List<Long> schemaIds) {
     return "<script>"

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/ModelVersionMetaPostgreSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/ModelVersionMetaPostgreSQLProvider.java
@@ -18,6 +18,7 @@
  */
 package org.apache.gravitino.storage.relational.mapper.provider.postgresql;
 
+import java.util.List;
 import org.apache.gravitino.storage.relational.mapper.ModelMetaMapper;
 import org.apache.gravitino.storage.relational.mapper.ModelVersionAliasRelMapper;
 import org.apache.gravitino.storage.relational.mapper.ModelVersionMetaMapper;
@@ -63,11 +64,17 @@ public class ModelVersionMetaPostgreSQLProvider extends ModelVersionMetaBaseSQLP
   }
 
   @Override
-  public String softDeleteModelVersionMetasBySchemaId(@Param("schemaId") Long schemaId) {
-    return "UPDATE "
+  public String softDeleteModelVersionMetasBySchemaIds(@Param("schemaIds") List<Long> schemaIds) {
+    return "<script>"
+        + "UPDATE "
         + ModelVersionMetaMapper.TABLE_NAME
         + " SET deleted_at = CAST(EXTRACT(EPOCH FROM CURRENT_TIMESTAMP) * 1000 AS BIGINT)"
-        + " WHERE schema_id = #{schemaId} AND deleted_at = 0";
+        + " WHERE schema_id IN ("
+        + "<foreach collection='schemaIds' item='schemaId' separator=','>"
+        + "#{schemaId}"
+        + "</foreach>"
+        + ") AND deleted_at = 0"
+        + "</script>";
   }
 
   @Override

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/OwnerMetaPostgreSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/OwnerMetaPostgreSQLProvider.java
@@ -151,6 +151,72 @@ public class OwnerMetaPostgreSQLProvider extends OwnerMetaBaseSQLProvider {
   }
 
   @Override
+  public String softDeleteOwnerRelBySchemaIds(@Param("schemaIds") List<Long> schemaIds) {
+    return "<script>"
+        + "UPDATE "
+        + OWNER_TABLE_NAME
+        + " ot SET deleted_at = CAST(EXTRACT(EPOCH FROM CURRENT_TIMESTAMP) * 1000 AS BIGINT)"
+        + " WHERE ot.deleted_at = 0 AND EXISTS ("
+        + " SELECT st.schema_id FROM "
+        + SchemaMetaMapper.TABLE_NAME
+        + " st WHERE st.schema_id IN "
+        + "<foreach collection='schemaIds' item='schemaId' open='(' close=')' separator=','>"
+        + "#{schemaId}"
+        + "</foreach>"
+        + " AND st.schema_id = ot.metadata_object_id AND ot.metadata_object_type = 'SCHEMA'"
+        + " UNION"
+        + " SELECT tt.schema_id FROM "
+        + TopicMetaMapper.TABLE_NAME
+        + " tt WHERE tt.schema_id IN "
+        + "<foreach collection='schemaIds' item='schemaId' open='(' close=')' separator=','>"
+        + "#{schemaId}"
+        + "</foreach>"
+        + " AND tt.topic_id = ot.metadata_object_id AND ot.metadata_object_type = 'TOPIC'"
+        + " UNION"
+        + " SELECT tat.schema_id FROM "
+        + TableMetaMapper.TABLE_NAME
+        + " tat WHERE tat.schema_id IN "
+        + "<foreach collection='schemaIds' item='schemaId' open='(' close=')' separator=','>"
+        + "#{schemaId}"
+        + "</foreach>"
+        + " AND tat.table_id = ot.metadata_object_id AND ot.metadata_object_type = 'TABLE'"
+        + " UNION"
+        + " SELECT ft.schema_id FROM "
+        + FilesetMetaMapper.META_TABLE_NAME
+        + " ft WHERE ft.schema_id IN "
+        + "<foreach collection='schemaIds' item='schemaId' open='(' close=')' separator=','>"
+        + "#{schemaId}"
+        + "</foreach>"
+        + " AND ft.fileset_id = ot.metadata_object_id AND ot.metadata_object_type = 'FILESET'"
+        + " UNION"
+        + " SELECT mt.schema_id FROM "
+        + ModelMetaMapper.TABLE_NAME
+        + " mt WHERE mt.schema_id IN "
+        + "<foreach collection='schemaIds' item='schemaId' open='(' close=')' separator=','>"
+        + "#{schemaId}"
+        + "</foreach>"
+        + " AND mt.model_id = ot.metadata_object_id AND ot.metadata_object_type = 'MODEL'"
+        + " UNION"
+        + " SELECT vt.schema_id FROM "
+        + ViewMetaMapper.TABLE_NAME
+        + " vt WHERE vt.schema_id IN "
+        + "<foreach collection='schemaIds' item='schemaId' open='(' close=')' separator=','>"
+        + "#{schemaId}"
+        + "</foreach>"
+        + " AND vt.view_id = ot.metadata_object_id AND ot.metadata_object_type = 'VIEW'"
+        + " UNION"
+        + " SELECT fnt.schema_id FROM "
+        + FunctionMetaMapper.TABLE_NAME
+        + " fnt WHERE fnt.schema_id IN "
+        + "<foreach collection='schemaIds' item='schemaId' open='(' close=')' separator=','>"
+        + "#{schemaId}"
+        + "</foreach>"
+        + " AND fnt.function_id = ot.metadata_object_id AND ot.metadata_object_type = 'FUNCTION'"
+        + ")"
+        + "</script>";
+  }
+
+  @Override
   public String batchSoftDeleteOwnerRelByMetadataObjects(
       @Param("deletions") List<OwnerRelForDeletion> deletions) {
     return "<script>"

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/OwnerMetaPostgreSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/OwnerMetaPostgreSQLProvider.java
@@ -108,49 +108,6 @@ public class OwnerMetaPostgreSQLProvider extends OwnerMetaBaseSQLProvider {
   }
 
   @Override
-  public String softDeleteOwnerRelBySchemaId(Long schemaId) {
-    return "UPDATE "
-        + OWNER_TABLE_NAME
-        + " ot SET deleted_at = CAST(EXTRACT(EPOCH FROM CURRENT_TIMESTAMP) * 1000 AS BIGINT)"
-        + " WHERE ot.deleted_at = 0 AND EXISTS ("
-        + " SELECT st.schema_id FROM "
-        + SchemaMetaMapper.TABLE_NAME
-        + " st WHERE st.schema_id = #{schemaId}"
-        + " AND st.schema_id = ot.metadata_object_id AND ot.metadata_object_type = 'SCHEMA'"
-        + " UNION"
-        + " SELECT tt.schema_id FROM "
-        + TopicMetaMapper.TABLE_NAME
-        + " tt WHERE tt.schema_id = #{schemaId} AND"
-        + " tt.topic_id = ot.metadata_object_id AND ot.metadata_object_type = 'TOPIC'"
-        + " UNION"
-        + " SELECT tat.schema_id FROM "
-        + TableMetaMapper.TABLE_NAME
-        + " tat WHERE tat.schema_id = #{schemaId} AND"
-        + " tat.table_id = ot.metadata_object_id AND ot.metadata_object_type = 'TABLE'"
-        + " UNION"
-        + " SELECT ft.schema_id FROM "
-        + FilesetMetaMapper.META_TABLE_NAME
-        + " ft WHERE ft.schema_id = #{schemaId} AND"
-        + " ft.fileset_id = ot.metadata_object_id AND ot.metadata_object_type = 'FILESET'"
-        + " UNION"
-        + " SELECT mt.schema_id FROM "
-        + ModelMetaMapper.TABLE_NAME
-        + " mt WHERE mt.schema_id = #{schemaId} AND"
-        + " mt.model_id = ot.metadata_object_id AND ot.metadata_object_type = 'MODEL'"
-        + " UNION"
-        + " SELECT vt.schema_id FROM "
-        + ViewMetaMapper.TABLE_NAME
-        + " vt WHERE vt.schema_id = #{schemaId} AND"
-        + " vt.view_id = ot.metadata_object_id AND ot.metadata_object_type = 'VIEW'"
-        + " UNION"
-        + " SELECT fnt.schema_id FROM "
-        + FunctionMetaMapper.TABLE_NAME
-        + " fnt WHERE fnt.schema_id = #{schemaId} AND"
-        + " fnt.function_id = ot.metadata_object_id AND ot.metadata_object_type = 'FUNCTION'"
-        + ")";
-  }
-
-  @Override
   public String softDeleteOwnerRelBySchemaIds(@Param("schemaIds") List<Long> schemaIds) {
     return "<script>"
         + "UPDATE "

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/PolicyMetadataObjectRelPostgreSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/PolicyMetadataObjectRelPostgreSQLProvider.java
@@ -110,36 +110,6 @@ public class PolicyMetadataObjectRelPostgreSQLProvider
   }
 
   @Override
-  public String softDeletePolicyMetadataObjectRelsBySchemaId(@Param("schemaId") Long schemaId) {
-    return "UPDATE "
-        + POLICY_METADATA_OBJECT_RELATION_TABLE_NAME
-        + " pe SET deleted_at ="
-        + DELETED_AT_NOW_EXPRESSION
-        + " FROM "
-        + POLICY_METADATA_OBJECT_RELATION_TABLE_NAME
-        + " pe_alias"
-        + " LEFT JOIN "
-        + SchemaMetaMapper.TABLE_NAME
-        + " st ON pe_alias.metadata_object_id = st.schema_id AND pe_alias.metadata_object_type = 'SCHEMA'"
-        + " LEFT JOIN "
-        + TopicMetaMapper.TABLE_NAME
-        + " tt ON pe_alias.metadata_object_id = tt.topic_id AND pe_alias.metadata_object_type = 'TOPIC'"
-        + " LEFT JOIN "
-        + TableMetaMapper.TABLE_NAME
-        + " tat ON pe_alias.metadata_object_id = tat.table_id AND pe_alias.metadata_object_type = 'TABLE'"
-        + " LEFT JOIN "
-        + FilesetMetaMapper.META_TABLE_NAME
-        + " ft ON pe_alias.metadata_object_id = ft.fileset_id AND pe_alias.metadata_object_type = 'FILESET'"
-        + " LEFT JOIN "
-        + ModelMetaMapper.TABLE_NAME
-        + " mt ON pe_alias.metadata_object_id = mt.model_id AND pe_alias.metadata_object_type = 'MODEL'"
-        + " WHERE pe.id = pe_alias.id AND pe.deleted_at = 0 AND ("
-        + "   st.schema_id = #{schemaId} OR tt.schema_id = #{schemaId} OR tat.schema_id = #{schemaId}"
-        + "   OR ft.schema_id = #{schemaId} OR mt.schema_id = #{schemaId}"
-        + " )";
-  }
-
-  @Override
   public String softDeletePolicyMetadataObjectRelsBySchemaIds(
       @Param("schemaIds") List<Long> schemaIds) {
     return "<script>"

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/PolicyMetadataObjectRelPostgreSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/PolicyMetadataObjectRelPostgreSQLProvider.java
@@ -140,6 +140,57 @@ public class PolicyMetadataObjectRelPostgreSQLProvider
   }
 
   @Override
+  public String softDeletePolicyMetadataObjectRelsBySchemaIds(
+      @Param("schemaIds") List<Long> schemaIds) {
+    return "<script>"
+        + "UPDATE "
+        + POLICY_METADATA_OBJECT_RELATION_TABLE_NAME
+        + " pe SET deleted_at ="
+        + DELETED_AT_NOW_EXPRESSION
+        + " FROM "
+        + POLICY_METADATA_OBJECT_RELATION_TABLE_NAME
+        + " pe_alias"
+        + " LEFT JOIN "
+        + SchemaMetaMapper.TABLE_NAME
+        + " st ON pe_alias.metadata_object_id = st.schema_id AND pe_alias.metadata_object_type = 'SCHEMA'"
+        + " LEFT JOIN "
+        + TopicMetaMapper.TABLE_NAME
+        + " tt ON pe_alias.metadata_object_id = tt.topic_id AND pe_alias.metadata_object_type = 'TOPIC'"
+        + " LEFT JOIN "
+        + TableMetaMapper.TABLE_NAME
+        + " tat ON pe_alias.metadata_object_id = tat.table_id AND pe_alias.metadata_object_type = 'TABLE'"
+        + " LEFT JOIN "
+        + FilesetMetaMapper.META_TABLE_NAME
+        + " ft ON pe_alias.metadata_object_id = ft.fileset_id AND pe_alias.metadata_object_type = 'FILESET'"
+        + " LEFT JOIN "
+        + ModelMetaMapper.TABLE_NAME
+        + " mt ON pe_alias.metadata_object_id = mt.model_id AND pe_alias.metadata_object_type = 'MODEL'"
+        + " WHERE pe.id = pe_alias.id AND pe.deleted_at = 0 AND ("
+        + "   st.schema_id IN "
+        + "<foreach collection='schemaIds' item='schemaId' open='(' close=')' separator=','>"
+        + "#{schemaId}"
+        + "</foreach>"
+        + "   OR tt.schema_id IN "
+        + "<foreach collection='schemaIds' item='schemaId' open='(' close=')' separator=','>"
+        + "#{schemaId}"
+        + "</foreach>"
+        + "   OR tat.schema_id IN "
+        + "<foreach collection='schemaIds' item='schemaId' open='(' close=')' separator=','>"
+        + "#{schemaId}"
+        + "</foreach>"
+        + "   OR ft.schema_id IN "
+        + "<foreach collection='schemaIds' item='schemaId' open='(' close=')' separator=','>"
+        + "#{schemaId}"
+        + "</foreach>"
+        + "   OR mt.schema_id IN "
+        + "<foreach collection='schemaIds' item='schemaId' open='(' close=')' separator=','>"
+        + "#{schemaId}"
+        + "</foreach>"
+        + " )"
+        + "</script>";
+  }
+
+  @Override
   public String softDeletePolicyMetadataObjectRelsByTableId(@Param("tableId") Long tableId) {
     return "UPDATE "
         + POLICY_METADATA_OBJECT_RELATION_TABLE_NAME

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/SchemaMetaPostgreSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/SchemaMetaPostgreSQLProvider.java
@@ -112,14 +112,6 @@ public class SchemaMetaPostgreSQLProvider extends SchemaMetaBaseSQLProvider {
   }
 
   @Override
-  public String softDeleteSchemaMetasBySchemaId(Long schemaId) {
-    return "UPDATE "
-        + TABLE_NAME
-        + " SET deleted_at = CAST(EXTRACT(EPOCH FROM CURRENT_TIMESTAMP) * 1000 AS BIGINT)"
-        + " WHERE schema_id = #{schemaId} AND deleted_at = 0";
-  }
-
-  @Override
   public String softDeleteSchemaMetasBySchemaIds(List<Long> schemaIds) {
     return "<script>"
         + "UPDATE "

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/SchemaMetaPostgreSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/SchemaMetaPostgreSQLProvider.java
@@ -120,6 +120,20 @@ public class SchemaMetaPostgreSQLProvider extends SchemaMetaBaseSQLProvider {
   }
 
   @Override
+  public String softDeleteSchemaMetasBySchemaIds(List<Long> schemaIds) {
+    return "<script>"
+        + "UPDATE "
+        + TABLE_NAME
+        + " SET deleted_at = CAST(EXTRACT(EPOCH FROM CURRENT_TIMESTAMP) * 1000 AS BIGINT)"
+        + " WHERE schema_id IN ("
+        + "<foreach collection='schemaIds' item='schemaId' separator=','>"
+        + "#{schemaId}"
+        + "</foreach>"
+        + ") AND deleted_at = 0"
+        + "</script>";
+  }
+
+  @Override
   public String softDeleteSchemaMetasByMetalakeId(Long metalakeId) {
     return "UPDATE "
         + TABLE_NAME

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/SecurableObjectPostgreSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/SecurableObjectPostgreSQLProvider.java
@@ -171,6 +171,72 @@ public class SecurableObjectPostgreSQLProvider extends SecurableObjectBaseSQLPro
   }
 
   @Override
+  public String softDeleteObjectRelsBySchemaIds(@Param("schemaIds") List<Long> schemaIds) {
+    return "<script>"
+        + "UPDATE "
+        + SECURABLE_OBJECT_TABLE_NAME
+        + " sect SET deleted_at = CAST(EXTRACT(EPOCH FROM CURRENT_TIMESTAMP) * 1000 AS BIGINT)"
+        + " WHERE sect.deleted_at = 0 AND EXISTS ("
+        + " SELECT st.schema_id FROM "
+        + SchemaMetaMapper.TABLE_NAME
+        + " st WHERE st.schema_id IN "
+        + "<foreach collection='schemaIds' item='schemaId' open='(' close=')' separator=','>"
+        + "#{schemaId}"
+        + "</foreach>"
+        + " AND st.schema_id = sect.metadata_object_id AND sect.type = 'SCHEMA'"
+        + " UNION"
+        + " SELECT tt.schema_id FROM "
+        + TopicMetaMapper.TABLE_NAME
+        + " tt WHERE tt.schema_id IN "
+        + "<foreach collection='schemaIds' item='schemaId' open='(' close=')' separator=','>"
+        + "#{schemaId}"
+        + "</foreach>"
+        + " AND tt.topic_id = sect.metadata_object_id AND sect.type = 'TOPIC'"
+        + " UNION"
+        + " SELECT tat.schema_id FROM "
+        + TableMetaMapper.TABLE_NAME
+        + " tat WHERE tat.schema_id IN "
+        + "<foreach collection='schemaIds' item='schemaId' open='(' close=')' separator=','>"
+        + "#{schemaId}"
+        + "</foreach>"
+        + " AND tat.table_id = sect.metadata_object_id AND sect.type = 'TABLE'"
+        + " UNION"
+        + " SELECT ft.schema_id FROM "
+        + FilesetMetaMapper.META_TABLE_NAME
+        + " ft WHERE ft.schema_id IN "
+        + "<foreach collection='schemaIds' item='schemaId' open='(' close=')' separator=','>"
+        + "#{schemaId}"
+        + "</foreach>"
+        + " AND ft.fileset_id = sect.metadata_object_id AND sect.type = 'FILESET'"
+        + " UNION"
+        + " SELECT mt.schema_id FROM "
+        + ModelMetaMapper.TABLE_NAME
+        + " mt WHERE mt.schema_id IN "
+        + "<foreach collection='schemaIds' item='schemaId' open='(' close=')' separator=','>"
+        + "#{schemaId}"
+        + "</foreach>"
+        + " AND mt.model_id = sect.metadata_object_id AND sect.type = 'MODEL'"
+        + " UNION"
+        + " SELECT vt.schema_id FROM "
+        + ViewMetaMapper.TABLE_NAME
+        + " vt WHERE vt.schema_id IN "
+        + "<foreach collection='schemaIds' item='schemaId' open='(' close=')' separator=','>"
+        + "#{schemaId}"
+        + "</foreach>"
+        + " AND vt.view_id = sect.metadata_object_id AND sect.type = 'VIEW'"
+        + " UNION"
+        + " SELECT fnt.schema_id FROM "
+        + FunctionMetaMapper.TABLE_NAME
+        + " fnt WHERE fnt.schema_id IN "
+        + "<foreach collection='schemaIds' item='schemaId' open='(' close=')' separator=','>"
+        + "#{schemaId}"
+        + "</foreach>"
+        + " AND fnt.function_id = sect.metadata_object_id AND sect.type = 'FUNCTION'"
+        + ")"
+        + "</script>";
+  }
+
+  @Override
   public String deleteSecurableObjectsByLegacyTimeline(
       @Param("legacyTimeline") Long legacyTimeline, @Param("limit") int limit) {
     return "DELETE FROM "

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/SecurableObjectPostgreSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/SecurableObjectPostgreSQLProvider.java
@@ -128,49 +128,6 @@ public class SecurableObjectPostgreSQLProvider extends SecurableObjectBaseSQLPro
   }
 
   @Override
-  public String softDeleteObjectRelsBySchemaId(@Param("schemaId") Long schemaId) {
-    return "UPDATE "
-        + SECURABLE_OBJECT_TABLE_NAME
-        + " sect SET deleted_at = CAST(EXTRACT(EPOCH FROM CURRENT_TIMESTAMP) * 1000 AS BIGINT)"
-        + " WHERE sect.deleted_at = 0 AND EXISTS ("
-        + " SELECT st.schema_id FROM "
-        + SchemaMetaMapper.TABLE_NAME
-        + " st WHERE st.schema_id = #{schemaId}"
-        + " AND st.schema_id = sect.metadata_object_id AND sect.type = 'SCHEMA'"
-        + " UNION"
-        + " SELECT tt.schema_id FROM "
-        + TopicMetaMapper.TABLE_NAME
-        + " tt WHERE tt.schema_id = #{schemaId} AND"
-        + " tt.topic_id = sect.metadata_object_id AND sect.type = 'TOPIC'"
-        + " UNION"
-        + " SELECT tat.schema_id FROM "
-        + TableMetaMapper.TABLE_NAME
-        + " tat WHERE tat.schema_id = #{schemaId} AND"
-        + " tat.table_id = sect.metadata_object_id AND sect.type = 'TABLE'"
-        + " UNION"
-        + " SELECT ft.schema_id FROM "
-        + FilesetMetaMapper.META_TABLE_NAME
-        + " ft WHERE ft.schema_id = #{schemaId} AND"
-        + " ft.fileset_id = sect.metadata_object_id AND sect.type = 'FILESET'"
-        + " UNION"
-        + " SELECT mt.schema_id FROM "
-        + ModelMetaMapper.TABLE_NAME
-        + " mt WHERE mt.schema_id = #{schemaId} AND"
-        + " mt.model_id = sect.metadata_object_id AND sect.type = 'MODEL'"
-        + " UNION"
-        + " SELECT vt.schema_id FROM "
-        + ViewMetaMapper.TABLE_NAME
-        + " vt WHERE vt.schema_id = #{schemaId} AND"
-        + " vt.view_id = sect.metadata_object_id AND sect.type = 'VIEW'"
-        + " UNION"
-        + " SELECT fnt.schema_id FROM "
-        + FunctionMetaMapper.TABLE_NAME
-        + " fnt WHERE fnt.schema_id = #{schemaId} AND"
-        + " fnt.function_id = sect.metadata_object_id AND sect.type = 'FUNCTION'"
-        + ")";
-  }
-
-  @Override
   public String softDeleteObjectRelsBySchemaIds(@Param("schemaIds") List<Long> schemaIds) {
     return "<script>"
         + "UPDATE "

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/TableColumnPostgreSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/TableColumnPostgreSQLProvider.java
@@ -50,14 +50,6 @@ public class TableColumnPostgreSQLProvider extends TableColumnBaseSQLProvider {
   }
 
   @Override
-  public String softDeleteColumnsBySchemaId(@Param("schemaId") Long schemaId) {
-    return "UPDATE "
-        + TableColumnMapper.COLUMN_TABLE_NAME
-        + " SET deleted_at = CAST(EXTRACT(EPOCH FROM CURRENT_TIMESTAMP) * 1000 AS BIGINT)"
-        + " WHERE schema_id = #{schemaId} AND deleted_at = 0";
-  }
-
-  @Override
   public String softDeleteColumnsBySchemaIds(@Param("schemaIds") List<Long> schemaIds) {
     return "<script>"
         + "UPDATE "

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/TableColumnPostgreSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/TableColumnPostgreSQLProvider.java
@@ -18,6 +18,7 @@
  */
 package org.apache.gravitino.storage.relational.mapper.provider.postgresql;
 
+import java.util.List;
 import org.apache.gravitino.storage.relational.mapper.TableColumnMapper;
 import org.apache.gravitino.storage.relational.mapper.provider.base.TableColumnBaseSQLProvider;
 import org.apache.ibatis.annotations.Param;
@@ -54,6 +55,20 @@ public class TableColumnPostgreSQLProvider extends TableColumnBaseSQLProvider {
         + TableColumnMapper.COLUMN_TABLE_NAME
         + " SET deleted_at = CAST(EXTRACT(EPOCH FROM CURRENT_TIMESTAMP) * 1000 AS BIGINT)"
         + " WHERE schema_id = #{schemaId} AND deleted_at = 0";
+  }
+
+  @Override
+  public String softDeleteColumnsBySchemaIds(@Param("schemaIds") List<Long> schemaIds) {
+    return "<script>"
+        + "UPDATE "
+        + TableColumnMapper.COLUMN_TABLE_NAME
+        + " SET deleted_at = CAST(EXTRACT(EPOCH FROM CURRENT_TIMESTAMP) * 1000 AS BIGINT)"
+        + " WHERE schema_id IN ("
+        + "<foreach collection='schemaIds' item='schemaId' separator=','>"
+        + "#{schemaId}"
+        + "</foreach>"
+        + ") AND deleted_at = 0"
+        + "</script>";
   }
 
   @Override

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/TableMetaPostgreSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/TableMetaPostgreSQLProvider.java
@@ -20,6 +20,7 @@ package org.apache.gravitino.storage.relational.mapper.provider.postgresql;
 
 import static org.apache.gravitino.storage.relational.mapper.TableMetaMapper.TABLE_NAME;
 
+import java.util.List;
 import org.apache.gravitino.storage.relational.mapper.provider.base.TableMetaBaseSQLProvider;
 import org.apache.gravitino.storage.relational.po.TablePO;
 import org.apache.ibatis.annotations.Param;
@@ -84,6 +85,20 @@ public class TableMetaPostgreSQLProvider extends TableMetaBaseSQLProvider {
         + TABLE_NAME
         + " SET deleted_at = CAST(EXTRACT(EPOCH FROM CURRENT_TIMESTAMP) * 1000 AS BIGINT)"
         + " WHERE schema_id = #{schemaId} AND deleted_at = 0";
+  }
+
+  @Override
+  public String softDeleteTableMetasBySchemaIds(List<Long> schemaIds) {
+    return "<script>"
+        + "UPDATE "
+        + TABLE_NAME
+        + " SET deleted_at = CAST(EXTRACT(EPOCH FROM CURRENT_TIMESTAMP) * 1000 AS BIGINT)"
+        + " WHERE schema_id IN ("
+        + "<foreach collection='schemaIds' item='schemaId' separator=','>"
+        + "#{schemaId}"
+        + "</foreach>"
+        + ") AND deleted_at = 0"
+        + "</script>";
   }
 
   @Override

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/TableMetaPostgreSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/TableMetaPostgreSQLProvider.java
@@ -80,14 +80,6 @@ public class TableMetaPostgreSQLProvider extends TableMetaBaseSQLProvider {
   }
 
   @Override
-  public String softDeleteTableMetasBySchemaId(Long schemaId) {
-    return "UPDATE "
-        + TABLE_NAME
-        + " SET deleted_at = CAST(EXTRACT(EPOCH FROM CURRENT_TIMESTAMP) * 1000 AS BIGINT)"
-        + " WHERE schema_id = #{schemaId} AND deleted_at = 0";
-  }
-
-  @Override
   public String softDeleteTableMetasBySchemaIds(List<Long> schemaIds) {
     return "<script>"
         + "UPDATE "

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/TagMetadataObjectRelPostgreSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/TagMetadataObjectRelPostgreSQLProvider.java
@@ -115,44 +115,6 @@ public class TagMetadataObjectRelPostgreSQLProvider extends TagMetadataObjectRel
   }
 
   @Override
-  public String softDeleteTagMetadataObjectRelsBySchemaId(@Param("schemaId") Long schemaId) {
-    return " UPDATE "
-        + TagMetadataObjectRelMapper.TAG_METADATA_OBJECT_RELATION_TABLE_NAME
-        + " tmt SET deleted_at = CAST(EXTRACT(EPOCH FROM CURRENT_TIMESTAMP) * 1000 AS BIGINT)"
-        + " WHERE tmt.deleted_at = 0 AND EXISTS ("
-        + " SELECT st.schema_id FROM "
-        + SchemaMetaMapper.TABLE_NAME
-        + " st WHERE st.schema_id = #{schemaId} AND"
-        + " st.schema_id = tmt.metadata_object_id AND tmt.metadata_object_type = 'SCHEMA'"
-        + " UNION"
-        + " SELECT tt.schema_id FROM "
-        + TopicMetaMapper.TABLE_NAME
-        + " tt WHERE tt.schema_id = #{schemaId} AND"
-        + " tt.topic_id = tmt.metadata_object_id AND tmt.metadata_object_type = 'TOPIC'"
-        + " UNION"
-        + " SELECT tat.schema_id FROM "
-        + TableMetaMapper.TABLE_NAME
-        + " tat WHERE tat.schema_id = #{schemaId} AND"
-        + " tat.table_id = tmt.metadata_object_id AND tmt.metadata_object_type = 'TABLE'"
-        + " UNION"
-        + " SELECT ft.schema_id FROM "
-        + FilesetMetaMapper.META_TABLE_NAME
-        + " ft WHERE ft.schema_id = #{schemaId} AND"
-        + " ft.fileset_id = tmt.metadata_object_id AND tmt.metadata_object_type = 'FILESET'"
-        + " UNION"
-        + " SELECT cot.schema_id FROM "
-        + TableColumnMapper.COLUMN_TABLE_NAME
-        + " cot WHERE cot.schema_id = #{schemaId} AND"
-        + " cot.column_id = tmt.metadata_object_id AND tmt.metadata_object_type = 'COLUMN'"
-        + " UNION"
-        + " SELECT mt.schema_id FROM "
-        + ModelMetaMapper.TABLE_NAME
-        + " mt WHERE mt.schema_id = #{schemaId} AND"
-        + " mt.model_id = tmt.metadata_object_id AND tmt.metadata_object_type = 'MODEL'"
-        + ")";
-  }
-
-  @Override
   public String softDeleteTagMetadataObjectRelsBySchemaIds(
       @Param("schemaIds") List<Long> schemaIds) {
     return "<script>"

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/TagMetadataObjectRelPostgreSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/TagMetadataObjectRelPostgreSQLProvider.java
@@ -153,6 +153,65 @@ public class TagMetadataObjectRelPostgreSQLProvider extends TagMetadataObjectRel
   }
 
   @Override
+  public String softDeleteTagMetadataObjectRelsBySchemaIds(
+      @Param("schemaIds") List<Long> schemaIds) {
+    return "<script>"
+        + " UPDATE "
+        + TagMetadataObjectRelMapper.TAG_METADATA_OBJECT_RELATION_TABLE_NAME
+        + " tmt SET deleted_at = CAST(EXTRACT(EPOCH FROM CURRENT_TIMESTAMP) * 1000 AS BIGINT)"
+        + " WHERE tmt.deleted_at = 0 AND EXISTS ("
+        + " SELECT st.schema_id FROM "
+        + SchemaMetaMapper.TABLE_NAME
+        + " st WHERE st.schema_id IN "
+        + "<foreach collection='schemaIds' item='schemaId' open='(' close=')' separator=','>"
+        + "#{schemaId}"
+        + "</foreach>"
+        + " AND st.schema_id = tmt.metadata_object_id AND tmt.metadata_object_type = 'SCHEMA'"
+        + " UNION"
+        + " SELECT tt.schema_id FROM "
+        + TopicMetaMapper.TABLE_NAME
+        + " tt WHERE tt.schema_id IN "
+        + "<foreach collection='schemaIds' item='schemaId' open='(' close=')' separator=','>"
+        + "#{schemaId}"
+        + "</foreach>"
+        + " AND tt.topic_id = tmt.metadata_object_id AND tmt.metadata_object_type = 'TOPIC'"
+        + " UNION"
+        + " SELECT tat.schema_id FROM "
+        + TableMetaMapper.TABLE_NAME
+        + " tat WHERE tat.schema_id IN "
+        + "<foreach collection='schemaIds' item='schemaId' open='(' close=')' separator=','>"
+        + "#{schemaId}"
+        + "</foreach>"
+        + " AND tat.table_id = tmt.metadata_object_id AND tmt.metadata_object_type = 'TABLE'"
+        + " UNION"
+        + " SELECT ft.schema_id FROM "
+        + FilesetMetaMapper.META_TABLE_NAME
+        + " ft WHERE ft.schema_id IN "
+        + "<foreach collection='schemaIds' item='schemaId' open='(' close=')' separator=','>"
+        + "#{schemaId}"
+        + "</foreach>"
+        + " AND ft.fileset_id = tmt.metadata_object_id AND tmt.metadata_object_type = 'FILESET'"
+        + " UNION"
+        + " SELECT cot.schema_id FROM "
+        + TableColumnMapper.COLUMN_TABLE_NAME
+        + " cot WHERE cot.schema_id IN "
+        + "<foreach collection='schemaIds' item='schemaId' open='(' close=')' separator=','>"
+        + "#{schemaId}"
+        + "</foreach>"
+        + " AND cot.column_id = tmt.metadata_object_id AND tmt.metadata_object_type = 'COLUMN'"
+        + " UNION"
+        + " SELECT mt.schema_id FROM "
+        + ModelMetaMapper.TABLE_NAME
+        + " mt WHERE mt.schema_id IN "
+        + "<foreach collection='schemaIds' item='schemaId' open='(' close=')' separator=','>"
+        + "#{schemaId}"
+        + "</foreach>"
+        + " AND mt.model_id = tmt.metadata_object_id AND tmt.metadata_object_type = 'MODEL'"
+        + ")"
+        + "</script>";
+  }
+
+  @Override
   public String softDeleteTagMetadataObjectRelsByTableId(@Param("tableId") Long tableId) {
     return " UPDATE "
         + TagMetadataObjectRelMapper.TAG_METADATA_OBJECT_RELATION_TABLE_NAME

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/TopicMetaPostgreSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/TopicMetaPostgreSQLProvider.java
@@ -82,14 +82,6 @@ public class TopicMetaPostgreSQLProvider extends TopicMetaBaseSQLProvider {
   }
 
   @Override
-  public String softDeleteTopicMetasBySchemaId(Long schemaId) {
-    return "UPDATE "
-        + TABLE_NAME
-        + " SET deleted_at = CAST(EXTRACT(EPOCH FROM CURRENT_TIMESTAMP) * 1000 AS BIGINT)"
-        + " WHERE schema_id = #{schemaId} AND deleted_at = 0";
-  }
-
-  @Override
   public String softDeleteTopicMetasBySchemaIds(List<Long> schemaIds) {
     return "<script>"
         + "UPDATE "

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/TopicMetaPostgreSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/TopicMetaPostgreSQLProvider.java
@@ -20,6 +20,7 @@ package org.apache.gravitino.storage.relational.mapper.provider.postgresql;
 
 import static org.apache.gravitino.storage.relational.mapper.TopicMetaMapper.TABLE_NAME;
 
+import java.util.List;
 import org.apache.gravitino.storage.relational.mapper.provider.base.TopicMetaBaseSQLProvider;
 import org.apache.gravitino.storage.relational.po.TopicPO;
 import org.apache.ibatis.annotations.Param;
@@ -86,6 +87,20 @@ public class TopicMetaPostgreSQLProvider extends TopicMetaBaseSQLProvider {
         + TABLE_NAME
         + " SET deleted_at = CAST(EXTRACT(EPOCH FROM CURRENT_TIMESTAMP) * 1000 AS BIGINT)"
         + " WHERE schema_id = #{schemaId} AND deleted_at = 0";
+  }
+
+  @Override
+  public String softDeleteTopicMetasBySchemaIds(List<Long> schemaIds) {
+    return "<script>"
+        + "UPDATE "
+        + TABLE_NAME
+        + " SET deleted_at = CAST(EXTRACT(EPOCH FROM CURRENT_TIMESTAMP) * 1000 AS BIGINT)"
+        + " WHERE schema_id IN ("
+        + "<foreach collection='schemaIds' item='schemaId' separator=','>"
+        + "#{schemaId}"
+        + "</foreach>"
+        + ") AND deleted_at = 0"
+        + "</script>";
   }
 
   @Override

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/ViewMetaPostgreSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/postgresql/ViewMetaPostgreSQLProvider.java
@@ -21,6 +21,7 @@ package org.apache.gravitino.storage.relational.mapper.provider.postgresql;
 import static org.apache.gravitino.storage.relational.mapper.ViewMetaMapper.TABLE_NAME;
 import static org.apache.gravitino.storage.relational.mapper.ViewMetaMapper.VERSION_TABLE_NAME;
 
+import java.util.List;
 import org.apache.gravitino.storage.relational.mapper.provider.base.ViewMetaBaseSQLProvider;
 import org.apache.gravitino.storage.relational.po.ViewPO;
 import org.apache.ibatis.annotations.Param;
@@ -117,11 +118,17 @@ public class ViewMetaPostgreSQLProvider extends ViewMetaBaseSQLProvider {
   }
 
   @Override
-  public String softDeleteViewMetasBySchemaId(@Param("schemaId") Long schemaId) {
-    return "UPDATE "
+  public String softDeleteViewMetasBySchemaIds(@Param("schemaIds") List<Long> schemaIds) {
+    return "<script>"
+        + "UPDATE "
         + TABLE_NAME
         + " SET deleted_at = CAST(EXTRACT(EPOCH FROM CURRENT_TIMESTAMP) * 1000 AS BIGINT)"
-        + " WHERE schema_id = #{schemaId} AND deleted_at = 0";
+        + " WHERE schema_id IN ("
+        + "<foreach collection='schemaIds' item='schemaId' separator=','>"
+        + "#{schemaId}"
+        + "</foreach>"
+        + ") AND deleted_at = 0"
+        + "</script>";
   }
 
   @Override

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/BasePOStorageOps.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/BasePOStorageOps.java
@@ -75,4 +75,14 @@ public abstract class BasePOStorageOps<PO, Mapper> {
     throw new UnsupportedOperationException(
         "listPOsByNSFullName is not supported by " + getClass().getSimpleName());
   }
+
+  /**
+   * Lists the PO identified by {@code (parentId, name)} together with every descendant under it
+   * (where the notion of "descendant" is implementation-specific). For non-hierarchical entities,
+   * this typically returns the single matching row.
+   */
+  public List<PO> listPOsForCascade(Mapper mapper, Long parentId, String name) {
+    throw new UnsupportedOperationException(
+        "listPOsForCascade is not supported by " + getClass().getSimpleName());
+  }
 }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/BasePOStorageOps.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/BasePOStorageOps.java
@@ -77,12 +77,12 @@ public abstract class BasePOStorageOps<PO, Mapper> {
   }
 
   /**
-   * Lists the PO identified by {@code (parentId, name)} together with every descendant under it
-   * (where the notion of "descendant" is implementation-specific). For non-hierarchical entities,
-   * this typically returns the single matching row.
+   * Lists the PO identified by {@code (parentId, name)} together with every descendant whose name
+   * shares the same prefix (the notion of "descendant" is implementation-specific). For
+   * non-hierarchical entities, this typically returns the single matching row.
    */
-  public List<PO> listPOsForCascade(Mapper mapper, Long parentId, String name) {
+  public List<PO> listPOsByNamePrefix(Mapper mapper, Long parentId, String name) {
     throw new UnsupportedOperationException(
-        "listPOsForCascade is not supported by " + getClass().getSimpleName());
+        "listPOsByNamePrefix is not supported by " + getClass().getSimpleName());
   }
 }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/HierarchicalConversionPOStorageOps.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/HierarchicalConversionPOStorageOps.java
@@ -112,9 +112,9 @@ public class HierarchicalConversionPOStorageOps<PO, Mapper> extends BasePOStorag
   }
 
   @Override
-  public List<PO> listPOsForCascade(Mapper mapper, Long parentId, String logicalName) {
+  public List<PO> listPOsByNamePrefix(Mapper mapper, Long parentId, String logicalName) {
     String physicalName = toPhysicalIfHierarchical(logicalName);
-    return convertPhysicalToLogical(delegate.listPOsForCascade(mapper, parentId, physicalName));
+    return convertPhysicalToLogical(delegate.listPOsByNamePrefix(mapper, parentId, physicalName));
   }
 
   @Override

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/HierarchicalConversionPOStorageOps.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/HierarchicalConversionPOStorageOps.java
@@ -112,6 +112,12 @@ public class HierarchicalConversionPOStorageOps<PO, Mapper> extends BasePOStorag
   }
 
   @Override
+  public List<PO> listPOsForCascade(Mapper mapper, Long parentId, String logicalName) {
+    String physicalName = toPhysicalIfHierarchical(logicalName);
+    return convertPhysicalToLogical(delegate.listPOsForCascade(mapper, parentId, physicalName));
+  }
+
+  @Override
   public boolean supportsParentIdRelationalRead() {
     return delegate.supportsParentIdRelationalRead();
   }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/SchemaMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/SchemaMetaService.java
@@ -279,69 +279,78 @@ public class SchemaMetaService {
         NameIdentifierUtil.ofSchema(metalakeName, catalogName, schemaName).toString();
 
     if (cascade) {
+      // For HierarchicalSchema, deleting `A:B` must also cascade into all descendant schemas
+      // such as `A:B:C`, `A:B:C:D`, etc. Collect the descendant schema ids up-front and run a
+      // single batch UPDATE per child table so the total SQL cost stays bounded regardless of
+      // how many descendants exist.
+      List<Long> schemaIds = listSchemaIdsForCascade(schemaPO);
       SessionUtils.doMultipleWithCommit(
           () ->
               SessionUtils.doWithoutCommit(
                   SchemaMetaMapper.class,
-                  mapper -> mapper.softDeleteSchemaMetasBySchemaId(schemaId)),
+                  mapper -> mapper.softDeleteSchemaMetasBySchemaIds(schemaIds)),
           () ->
               SessionUtils.doWithoutCommit(
-                  TableMetaMapper.class, mapper -> mapper.softDeleteTableMetasBySchemaId(schemaId)),
+                  TableMetaMapper.class,
+                  mapper -> mapper.softDeleteTableMetasBySchemaIds(schemaIds)),
           () ->
               SessionUtils.doWithoutCommit(
-                  TableColumnMapper.class, mapper -> mapper.softDeleteColumnsBySchemaId(schemaId)),
+                  TableColumnMapper.class,
+                  mapper -> mapper.softDeleteColumnsBySchemaIds(schemaIds)),
           () ->
               SessionUtils.doWithoutCommit(
                   FilesetMetaMapper.class,
-                  mapper -> mapper.softDeleteFilesetMetasBySchemaId(schemaId)),
+                  mapper -> mapper.softDeleteFilesetMetasBySchemaIds(schemaIds)),
           () ->
               SessionUtils.doWithoutCommit(
                   FilesetVersionMapper.class,
-                  mapper -> mapper.softDeleteFilesetVersionsBySchemaId(schemaId)),
+                  mapper -> mapper.softDeleteFilesetVersionsBySchemaIds(schemaIds)),
           () ->
               SessionUtils.doWithoutCommit(
-                  TopicMetaMapper.class, mapper -> mapper.softDeleteTopicMetasBySchemaId(schemaId)),
+                  TopicMetaMapper.class,
+                  mapper -> mapper.softDeleteTopicMetasBySchemaIds(schemaIds)),
           () ->
               SessionUtils.doWithoutCommit(
                   FunctionMetaMapper.class,
-                  mapper -> mapper.softDeleteFunctionMetasBySchemaId(schemaId)),
+                  mapper -> mapper.softDeleteFunctionMetasBySchemaIds(schemaIds)),
           () ->
               SessionUtils.doWithoutCommit(
                   FunctionVersionMetaMapper.class,
-                  mapper -> mapper.softDeleteFunctionVersionMetasBySchemaId(schemaId)),
+                  mapper -> mapper.softDeleteFunctionVersionMetasBySchemaIds(schemaIds)),
           () ->
               SessionUtils.doWithoutCommit(
-                  OwnerMetaMapper.class, mapper -> mapper.softDeleteOwnerRelBySchemaId(schemaId)),
+                  OwnerMetaMapper.class, mapper -> mapper.softDeleteOwnerRelBySchemaIds(schemaIds)),
           () ->
               SessionUtils.doWithoutCommit(
                   SecurableObjectMapper.class,
-                  mapper -> mapper.softDeleteObjectRelsBySchemaId(schemaId)),
+                  mapper -> mapper.softDeleteObjectRelsBySchemaIds(schemaIds)),
           () ->
               SessionUtils.doWithoutCommit(
                   TagMetadataObjectRelMapper.class,
-                  mapper -> mapper.softDeleteTagMetadataObjectRelsBySchemaId(schemaId)),
+                  mapper -> mapper.softDeleteTagMetadataObjectRelsBySchemaIds(schemaIds)),
           () ->
               SessionUtils.doWithoutCommit(
                   PolicyMetadataObjectRelMapper.class,
-                  mapper -> mapper.softDeletePolicyMetadataObjectRelsBySchemaId(schemaId)),
+                  mapper -> mapper.softDeletePolicyMetadataObjectRelsBySchemaIds(schemaIds)),
           () ->
               SessionUtils.doWithoutCommit(
                   ModelVersionAliasRelMapper.class,
-                  mapper -> mapper.softDeleteModelVersionAliasRelsBySchemaId(schemaId)),
+                  mapper -> mapper.softDeleteModelVersionAliasRelsBySchemaIds(schemaIds)),
           () ->
               SessionUtils.doWithoutCommit(
                   ModelVersionMetaMapper.class,
-                  mapper -> mapper.softDeleteModelVersionMetasBySchemaId(schemaId)),
+                  mapper -> mapper.softDeleteModelVersionMetasBySchemaIds(schemaIds)),
           () ->
               SessionUtils.doWithoutCommit(
-                  ModelMetaMapper.class, mapper -> mapper.softDeleteModelMetasBySchemaId(schemaId)),
+                  ModelMetaMapper.class,
+                  mapper -> mapper.softDeleteModelMetasBySchemaIds(schemaIds)),
           () ->
               SessionUtils.doWithoutCommit(
                   StatisticMetaMapper.class,
-                  mapper -> mapper.softDeleteStatisticsBySchemaId(schemaId)),
+                  mapper -> mapper.softDeleteStatisticsBySchemaIds(schemaIds)),
           () ->
               SessionUtils.doWithoutCommit(
-                  ViewMetaMapper.class, mapper -> mapper.softDeleteViewMetasBySchemaId(schemaId)),
+                  ViewMetaMapper.class, mapper -> mapper.softDeleteViewMetasBySchemaIds(schemaIds)),
           () -> {
             SessionUtils.doWithoutCommit(
                 EntityChangeLogMapper.class,
@@ -399,11 +408,12 @@ public class SchemaMetaService {
             "Entity %s has sub-entities, you should remove sub-entities first", identifier);
       }
 
+      List<Long> singleSchemaId = Collections.singletonList(schemaId);
       SessionUtils.doMultipleWithCommit(
           () ->
               SessionUtils.doWithoutCommit(
                   SchemaMetaMapper.class,
-                  mapper -> mapper.softDeleteSchemaMetasBySchemaId(schemaId)),
+                  mapper -> mapper.softDeleteSchemaMetasBySchemaIds(singleSchemaId)),
           () ->
               SessionUtils.doWithoutCommit(
                   OwnerMetaMapper.class,
@@ -477,6 +487,24 @@ public class SchemaMetaService {
     return SessionUtils.getWithoutCommit(
         SchemaMetaMapper.class,
         mapper -> POStorageReadRouting.listPOs(mapper, namespace, ops, Entity.EntityType.SCHEMA));
+  }
+
+  /**
+   * Collects the schema ids that participate in a cascade delete: the target schema itself plus
+   * every HierarchicalSchema descendant. The {@link SchemaPO} arrives in logical form (e.g. {@code
+   * A:B}); {@link HierarchicalConversionPOStorageOps} translates to storage form before running the
+   * SQL prefix match, so this method only deals in logical names.
+   */
+  private List<Long> listSchemaIdsForCascade(SchemaPO schemaPO) {
+    List<SchemaPO> matched =
+        SessionUtils.getWithoutCommit(
+            SchemaMetaMapper.class,
+            mapper ->
+                ops.listPOsForCascade(mapper, schemaPO.getCatalogId(), schemaPO.getSchemaName()));
+    if (matched == null || matched.isEmpty()) {
+      return Collections.singletonList(schemaPO.getSchemaId());
+    }
+    return matched.stream().map(SchemaPO::getSchemaId).collect(Collectors.toList());
   }
 
   private void fillSchemaPOBuilderParentEntityId(SchemaPO.Builder builder, Namespace namespace) {

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/SchemaMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/SchemaMetaService.java
@@ -285,7 +285,7 @@ public class SchemaMetaService {
       // how many descendants exist.
       List<Long> schemaIds = listSchemaIdsForCascade(schemaPO);
       if (schemaIds.isEmpty()) {
-          return false;
+        return false;
       }
       SessionUtils.doMultipleWithCommit(
           () ->

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/SchemaMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/SchemaMetaService.java
@@ -284,6 +284,9 @@ public class SchemaMetaService {
       // single batch UPDATE per child table so the total SQL cost stays bounded regardless of
       // how many descendants exist.
       List<Long> schemaIds = listSchemaIdsForCascade(schemaPO);
+      if (schemaIds.isEmpty()) {
+          return false;
+      }
       SessionUtils.doMultipleWithCommit(
           () ->
               SessionUtils.doWithoutCommit(

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/SchemaMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/SchemaMetaService.java
@@ -500,8 +500,7 @@ public class SchemaMetaService {
         SessionUtils.getWithoutCommit(
             SchemaMetaMapper.class,
             mapper ->
-                ops.listPOsByNamePrefix(
-                    mapper, schemaPO.getCatalogId(), schemaPO.getSchemaName()));
+                ops.listPOsByNamePrefix(mapper, schemaPO.getCatalogId(), schemaPO.getSchemaName()));
     if (matched == null || matched.isEmpty()) {
       return Collections.singletonList(schemaPO.getSchemaId());
     }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/SchemaMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/SchemaMetaService.java
@@ -502,7 +502,7 @@ public class SchemaMetaService {
             mapper ->
                 ops.listPOsByNamePrefix(mapper, schemaPO.getCatalogId(), schemaPO.getSchemaName()));
     if (matched == null || matched.isEmpty()) {
-      return Collections.singletonList(schemaPO.getSchemaId());
+      return Collections.emptyList();
     }
     return matched.stream().map(SchemaPO::getSchemaId).collect(Collectors.toList());
   }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/SchemaMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/SchemaMetaService.java
@@ -500,7 +500,8 @@ public class SchemaMetaService {
         SessionUtils.getWithoutCommit(
             SchemaMetaMapper.class,
             mapper ->
-                ops.listPOsForCascade(mapper, schemaPO.getCatalogId(), schemaPO.getSchemaName()));
+                ops.listPOsByNamePrefix(
+                    mapper, schemaPO.getCatalogId(), schemaPO.getSchemaName()));
     if (matched == null || matched.isEmpty()) {
       return Collections.singletonList(schemaPO.getSchemaId());
     }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/SchemaPOStorageOps.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/SchemaPOStorageOps.java
@@ -26,6 +26,7 @@ import org.apache.gravitino.Namespace;
 import org.apache.gravitino.exceptions.NoSuchEntityException;
 import org.apache.gravitino.storage.relational.mapper.SchemaMetaMapper;
 import org.apache.gravitino.storage.relational.po.SchemaPO;
+import org.apache.gravitino.utils.HierarchicalSchemaUtil;
 
 public class SchemaPOStorageOps extends BasePOStorageOps<SchemaPO, SchemaMetaMapper> {
 
@@ -108,5 +109,17 @@ public class SchemaPOStorageOps extends BasePOStorageOps<SchemaPO, SchemaMetaMap
   @Override
   public boolean supportsParentIdRelationalRead() {
     return true;
+  }
+
+  /**
+   * For HierarchicalSchema, the name passed in is in storage (physical) form. Descendants are
+   * stored as {@code <name><physicalSeparator>...}; we build that prefix once and let SQL match the
+   * exact row plus everything starting with the prefix.
+   */
+  @Override
+  public List<SchemaPO> listPOsForCascade(
+      SchemaMetaMapper mapper, Long catalogId, String physicalName) {
+    String descendantPrefix = physicalName + HierarchicalSchemaUtil.physicalSeparator();
+    return mapper.listSchemaPOsByCatalogIdAndNamePrefix(catalogId, physicalName, descendantPrefix);
   }
 }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/SchemaPOStorageOps.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/SchemaPOStorageOps.java
@@ -30,6 +30,9 @@ import org.apache.gravitino.utils.HierarchicalSchemaUtil;
 
 public class SchemaPOStorageOps extends BasePOStorageOps<SchemaPO, SchemaMetaMapper> {
 
+  /** Escape character used when matching the cascade-delete name prefix with SQL {@code LIKE}. */
+  private static final String LIKE_ESCAPE_CHAR = "!";
+
   public SchemaPOStorageOps() {}
 
   @Override
@@ -115,11 +118,31 @@ public class SchemaPOStorageOps extends BasePOStorageOps<SchemaPO, SchemaMetaMap
    * For HierarchicalSchema, the name passed in is in storage (physical) form. Descendants are
    * stored as {@code <name><physicalSeparator>...}; we build that prefix once and let SQL match the
    * exact row plus everything starting with the prefix.
+   *
+   * <p>Schema names may contain SQL {@code LIKE} metacharacters ({@code %} and {@code _}), so the
+   * literal prefix is escaped here and matched with an {@code ESCAPE} clause (see {@link
+   * org.apache.gravitino.storage.relational.mapper.provider.base.SchemaMetaBaseSQLProvider}). This
+   * guarantees a literal prefix match and prevents e.g. {@code a_b} from also matching {@code axb}.
    */
   @Override
   public List<SchemaPO> listPOsByNamePrefix(
       SchemaMetaMapper mapper, Long catalogId, String physicalName) {
-    String descendantPrefix = physicalName + HierarchicalSchemaUtil.physicalSeparator();
+    String descendantPrefix =
+        escapeLikeMetacharacters(physicalName) + HierarchicalSchemaUtil.physicalSeparator();
     return mapper.listSchemaPOsByCatalogIdAndNamePrefix(catalogId, physicalName, descendantPrefix);
+  }
+
+  /**
+   * Escapes SQL {@code LIKE} metacharacters so the value matches literally. The escape character
+   * itself is escaped first, then the {@code %} and {@code _} wildcards. The {@code !} escape
+   * character is chosen to avoid the backslash string-literal escaping differences between MySQL,
+   * H2, and PostgreSQL, and must stay in sync with the {@code ESCAPE} clause in {@link
+   * org.apache.gravitino.storage.relational.mapper.provider.base.SchemaMetaBaseSQLProvider#listSchemaPOsByCatalogIdAndNamePrefix}.
+   */
+  private static String escapeLikeMetacharacters(String value) {
+    return value
+        .replace(LIKE_ESCAPE_CHAR, LIKE_ESCAPE_CHAR + LIKE_ESCAPE_CHAR)
+        .replace("%", LIKE_ESCAPE_CHAR + "%")
+        .replace("_", LIKE_ESCAPE_CHAR + "_");
   }
 }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/SchemaPOStorageOps.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/SchemaPOStorageOps.java
@@ -117,7 +117,7 @@ public class SchemaPOStorageOps extends BasePOStorageOps<SchemaPO, SchemaMetaMap
    * exact row plus everything starting with the prefix.
    */
   @Override
-  public List<SchemaPO> listPOsForCascade(
+  public List<SchemaPO> listPOsByNamePrefix(
       SchemaMetaMapper mapper, Long catalogId, String physicalName) {
     String descendantPrefix = physicalName + HierarchicalSchemaUtil.physicalSeparator();
     return mapper.listSchemaPOsByCatalogIdAndNamePrefix(catalogId, physicalName, descendantPrefix);

--- a/core/src/test/java/org/apache/gravitino/storage/memory/TestMemoryEntityStore.java
+++ b/core/src/test/java/org/apache/gravitino/storage/memory/TestMemoryEntityStore.java
@@ -58,6 +58,7 @@ import org.apache.gravitino.meta.SchemaVersion;
 import org.apache.gravitino.meta.TableEntity;
 import org.apache.gravitino.meta.UserEntity;
 import org.apache.gravitino.utils.Executable;
+import org.apache.gravitino.utils.HierarchicalSchemaUtil;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -156,6 +157,19 @@ public class TestMemoryEntityStore {
     public boolean delete(NameIdentifier ident, EntityType entityType, boolean cascade)
         throws IOException {
       Entity prev = entityMap.remove(ident);
+      if (cascade && entityType == EntityType.SCHEMA) {
+        // Mirror the relational store: a cascade delete of a hierarchical schema also removes its
+        // descendant schemas, i.e. the schemas in the same (metalake, catalog) namespace whose
+        // name carries the "<name><separator>" prefix. Tables and other child entities live under a
+        // deeper namespace, so the namespace check leaves them untouched here.
+        String descendantPrefix = ident.name() + HierarchicalSchemaUtil.schemaSeparator();
+        entityMap
+            .keySet()
+            .removeIf(
+                key ->
+                    key.namespace().equals(ident.namespace())
+                        && key.name().startsWith(descendantPrefix));
+      }
       return prev != null;
     }
 

--- a/core/src/test/java/org/apache/gravitino/storage/relational/service/TestSchemaMetaService.java
+++ b/core/src/test/java/org/apache/gravitino/storage/relational/service/TestSchemaMetaService.java
@@ -244,6 +244,86 @@ public class TestSchemaMetaService extends TestJDBCBackend {
   }
 
   @TestTemplate
+  public void testDeleteHierarchicalSchemaCascadeRemovesDescendantsAndChildren()
+      throws IOException {
+    createAndInsertMakeLake(metalakeName);
+    createAndInsertCatalog(metalakeName, catalogName);
+
+    SchemaMetaService schemaMetaService = SchemaMetaService.getInstance();
+    TopicMetaService topicMetaService = TopicMetaService.getInstance();
+
+    // Insert a leaf schema A:B:C; this auto-creates ancestor rows A and A:B.
+    String leafName = "anc_a:anc_b:leaf_c";
+    SchemaEntity leaf =
+        createSchemaEntity(
+            RandomIdGenerator.INSTANCE.nextId(),
+            NamespaceUtil.ofSchema(metalakeName, catalogName),
+            leafName,
+            AUDIT_INFO);
+    schemaMetaService.insertSchema(leaf, false);
+
+    // Topic under the leaf, to verify child entities are also cascade-deleted.
+    TopicEntity leafTopic =
+        createTopicEntity(
+            RandomIdGenerator.INSTANCE.nextId(),
+            NamespaceUtil.ofTopic(metalakeName, catalogName, leafName),
+            "leaf_topic",
+            AUDIT_INFO);
+    topicMetaService.insertTopic(leafTopic, false);
+
+    // Topic under the middle ancestor A:B.
+    String middleName = "anc_a:anc_b";
+    TopicEntity middleTopic =
+        createTopicEntity(
+            RandomIdGenerator.INSTANCE.nextId(),
+            NamespaceUtil.ofTopic(metalakeName, catalogName, middleName),
+            "middle_topic",
+            AUDIT_INFO);
+    topicMetaService.insertTopic(middleTopic, false);
+
+    // A sibling schema outside the deleted subtree to confirm it survives.
+    String siblingName = "anc_a:sibling_d";
+    SchemaEntity sibling =
+        createSchemaEntity(
+            RandomIdGenerator.INSTANCE.nextId(),
+            NamespaceUtil.ofSchema(metalakeName, catalogName),
+            siblingName,
+            AUDIT_INFO);
+    schemaMetaService.insertSchema(sibling, false);
+
+    TopicEntity siblingTopic =
+        createTopicEntity(
+            RandomIdGenerator.INSTANCE.nextId(),
+            NamespaceUtil.ofTopic(metalakeName, catalogName, siblingName),
+            "sibling_topic",
+            AUDIT_INFO);
+    topicMetaService.insertTopic(siblingTopic, false);
+
+    // Cascade-delete the middle ancestor; both A:B and A:B:C (plus their topics) must go.
+    schemaMetaService.deleteSchema(NameIdentifier.of(metalakeName, catalogName, middleName), true);
+
+    Assertions.assertFalse(
+        backend.exists(
+            NameIdentifier.of(metalakeName, catalogName, middleName), Entity.EntityType.SCHEMA));
+    Assertions.assertFalse(
+        backend.exists(
+            NameIdentifier.of(metalakeName, catalogName, leafName), Entity.EntityType.SCHEMA));
+    Assertions.assertFalse(backend.exists(leafTopic.nameIdentifier(), Entity.EntityType.TOPIC));
+    Assertions.assertFalse(backend.exists(middleTopic.nameIdentifier(), Entity.EntityType.TOPIC));
+
+    // Sibling subtree must still exist.
+    Assertions.assertTrue(
+        backend.exists(
+            NameIdentifier.of(metalakeName, catalogName, siblingName), Entity.EntityType.SCHEMA));
+    Assertions.assertTrue(backend.exists(siblingTopic.nameIdentifier(), Entity.EntityType.TOPIC));
+
+    // The shared top-level ancestor A is outside the deleted subtree and must remain too.
+    Assertions.assertTrue(
+        backend.exists(
+            NameIdentifier.of(metalakeName, catalogName, "anc_a"), Entity.EntityType.SCHEMA));
+  }
+
+  @TestTemplate
   public void testInsertHierarchicalSecondLeafReusesAncestorsWithoutUpsert() throws IOException {
     createAndInsertMakeLake(metalakeName);
     createAndInsertCatalog(metalakeName, catalogName);

--- a/core/src/test/java/org/apache/gravitino/storage/relational/service/TestSchemaMetaService.java
+++ b/core/src/test/java/org/apache/gravitino/storage/relational/service/TestSchemaMetaService.java
@@ -324,6 +324,53 @@ public class TestSchemaMetaService extends TestJDBCBackend {
   }
 
   @TestTemplate
+  public void testDeleteHierarchicalSchemaCascadeEscapesLikeMetacharacters() throws IOException {
+    createAndInsertMakeLake(metalakeName);
+    createAndInsertCatalog(metalakeName, catalogName);
+
+    SchemaMetaService schemaMetaService = SchemaMetaService.getInstance();
+
+    // Deleted subtree under ancestor "pa_b". The '_' is a LIKE wildcard, so without escaping the
+    // cascade prefix "pa_b<sep>%" would also match the unrelated "paxb<sep>..." subtree below.
+    String targetLeaf = "pa_b:leaf";
+    schemaMetaService.insertSchema(
+        createSchemaEntity(
+            RandomIdGenerator.INSTANCE.nextId(),
+            NamespaceUtil.ofSchema(metalakeName, catalogName),
+            targetLeaf,
+            AUDIT_INFO),
+        false);
+
+    // Decoy subtree that the unescaped '_' wildcard would falsely match ('x' in place of '_').
+    String decoyLeaf = "paxb:leaf";
+    schemaMetaService.insertSchema(
+        createSchemaEntity(
+            RandomIdGenerator.INSTANCE.nextId(),
+            NamespaceUtil.ofSchema(metalakeName, catalogName),
+            decoyLeaf,
+            AUDIT_INFO),
+        false);
+
+    // Cascade-delete the literal "pa_b" ancestor.
+    schemaMetaService.deleteSchema(NameIdentifier.of(metalakeName, catalogName, "pa_b"), true);
+
+    Assertions.assertFalse(
+        backend.exists(
+            NameIdentifier.of(metalakeName, catalogName, "pa_b"), Entity.EntityType.SCHEMA));
+    Assertions.assertFalse(
+        backend.exists(
+            NameIdentifier.of(metalakeName, catalogName, targetLeaf), Entity.EntityType.SCHEMA));
+
+    // The decoy subtree must survive: literal-prefix matching only escapes the deleted subtree.
+    Assertions.assertTrue(
+        backend.exists(
+            NameIdentifier.of(metalakeName, catalogName, "paxb"), Entity.EntityType.SCHEMA));
+    Assertions.assertTrue(
+        backend.exists(
+            NameIdentifier.of(metalakeName, catalogName, decoyLeaf), Entity.EntityType.SCHEMA));
+  }
+
+  @TestTemplate
   public void testInsertHierarchicalSecondLeafReusesAncestorsWithoutUpsert() throws IOException {
     createAndInsertMakeLake(metalakeName);
     createAndInsertCatalog(metalakeName, catalogName);

--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/dispatcher/IcebergNamespaceHookDispatcher.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/dispatcher/IcebergNamespaceHookDispatcher.java
@@ -18,7 +18,6 @@
  */
 package org.apache.gravitino.iceberg.service.dispatcher;
 
-import com.google.common.collect.Lists;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -148,16 +147,22 @@ public class IcebergNamespaceHookDispatcher implements IcebergNamespaceOperation
         () -> {
           dispatcher.dropNamespace(context, namespace);
 
-          // TODO: Use cascade mode deletion
-          // Current behavior: only the leaf namespace is dropped from the Iceberg catalog above.
-          // We walk ancestors outermost-to-leaf and clean up a Gravitino entity only while the
-          // corresponding Iceberg namespace no longer exists, stopping at the first ancestor that
-          // still exists. As a result, ancestor entities are cleaned up only when the underlying
-          // Iceberg catalog also removes the empty parent namespaces on leaf-drop, which is
-          // catalog-implementation-dependent. For catalogs that keep empty parents, operators may
-          // need to drop empty parent namespaces manually.
+          // Only the leaf namespace is dropped from the Iceberg catalog above. Walk its
+          // ancestors outermost-to-leaf to find the outermost ancestor whose Iceberg namespace
+          // no longer exists, stopping at the first ancestor that still exists. Everything from
+          // that outermost empty namespace down to the leaf is now stale in Gravitino.
+          //
+          // An inner Iceberg namespace cannot exist unless all of its outer ancestors do, so an
+          // ancestor missing from the catalog implies none of its descendants exist there
+          // either. A single cascade delete of the outermost empty namespace therefore removes
+          // it and every descendant Gravitino entity (the leaf plus the intermediate ancestors)
+          // in one batched operation, rather than issuing one delete per target.
+          //
+          // Ancestor entities are still only cleaned up when the underlying Iceberg catalog
+          // removes the empty parents on leaf-drop, which is catalog-implementation-dependent.
+          // For catalogs that keep empty parents, operators may need to drop them manually.
           String separator = HierarchicalSchemaUtil.schemaSeparator();
-          List<Namespace> deleteTargets = Lists.newArrayList(namespace);
+          Namespace outermostStale = namespace;
           String namespaceName = String.join(separator, namespace.levels());
           List<String> ancestorNames =
               HierarchicalSchemaUtil.getAncestorNames(namespaceName, separator);
@@ -166,22 +171,21 @@ public class IcebergNamespaceHookDispatcher implements IcebergNamespaceOperation
             if (dispatcher.namespaceExists(context, ancestor)) {
               break;
             }
-            deleteTargets.add(ancestor);
+            outermostStale = ancestor;
           }
 
           EntityStore store = GravitinoEnv.getInstance().entityStore();
           if (store != null) {
-            for (Namespace target : deleteTargets) {
-              try {
-                store.delete(
-                    IcebergIdentifierUtils.toGravitinoSchemaIdentifier(
-                        metalake, catalogName, target, separator),
-                    Entity.EntityType.SCHEMA);
-              } catch (NoSuchEntityException ignore) {
-                // Already gone.
-              } catch (IOException ioe) {
-                throw new RuntimeException("io exception when deleting schema entity", ioe);
-              }
+            try {
+              store.delete(
+                  IcebergIdentifierUtils.toGravitinoSchemaIdentifier(
+                      metalake, catalogName, outermostStale, separator),
+                  Entity.EntityType.SCHEMA,
+                  true);
+            } catch (NoSuchEntityException ignore) {
+              // Already gone.
+            } catch (IOException ioe) {
+              throw new RuntimeException("io exception when deleting schema entity", ioe);
             }
           }
           return null;

--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/dispatcher/IcebergNamespaceHookDispatcher.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/dispatcher/IcebergNamespaceHookDispatcher.java
@@ -147,10 +147,12 @@ public class IcebergNamespaceHookDispatcher implements IcebergNamespaceOperation
         () -> {
           dispatcher.dropNamespace(context, namespace);
 
-          // Only the leaf namespace is dropped from the Iceberg catalog above. Walk its
-          // ancestors outermost-to-leaf to find the outermost ancestor whose Iceberg namespace
-          // no longer exists, stopping at the first ancestor that still exists. Everything from
-          // that outermost empty namespace down to the leaf is now stale in Gravitino.
+          // Only the leaf namespace is dropped from the Iceberg catalog above. getAncestorNames
+          // returns ancestors outermost-to-innermost, so we walk it in reverse (innermost outward),
+          // advancing outermostStale past every ancestor whose Iceberg namespace no longer exists
+          // and stopping at the first ancestor that still exists. outermostStale therefore ends up
+          // as the outermost missing ancestor; everything from there down to the leaf is now stale
+          // in Gravitino.
           //
           // An inner Iceberg namespace cannot exist unless all of its outer ancestors do, so an
           // ancestor missing from the catalog implies none of its descendants exist there

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/dispatcher/TestIcebergNamespaceHookDispatcher.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/dispatcher/TestIcebergNamespaceHookDispatcher.java
@@ -23,6 +23,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -271,7 +272,7 @@ public class TestIcebergNamespaceHookDispatcher {
     // The leaf and both phantom ancestors are stale, so a single cascade delete of the outermost
     // empty ancestor (A) removes the whole stale chain in one batched operation.
     ArgumentCaptor<NameIdentifier> captor = ArgumentCaptor.forClass(NameIdentifier.class);
-    verify(mockEntityStore, org.mockito.Mockito.times(1))
+    verify(mockEntityStore, times(1))
         .delete(captor.capture(), eq(Entity.EntityType.SCHEMA), eq(true));
     Assertions.assertEquals("A", captor.getValue().name());
   }
@@ -294,7 +295,7 @@ public class TestIcebergNamespaceHookDispatcher {
 
     // The parent still exists, so only the leaf is stale; it is cascade-deleted on its own.
     ArgumentCaptor<NameIdentifier> captor = ArgumentCaptor.forClass(NameIdentifier.class);
-    verify(mockEntityStore, org.mockito.Mockito.times(1))
+    verify(mockEntityStore, times(1))
         .delete(captor.capture(), eq(Entity.EntityType.SCHEMA), eq(true));
     Assertions.assertEquals("A:B:C", captor.getValue().name());
   }

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/dispatcher/TestIcebergNamespaceHookDispatcher.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/dispatcher/TestIcebergNamespaceHookDispatcher.java
@@ -268,12 +268,12 @@ public class TestIcebergNamespaceHookDispatcher {
     verify(mockDispatcher, never()).dropNamespace(mockContext, parent);
     verify(mockDispatcher, never()).dropNamespace(mockContext, grandparent);
 
+    // The leaf and both phantom ancestors are stale, so a single cascade delete of the outermost
+    // empty ancestor (A) removes the whole stale chain in one batched operation.
     ArgumentCaptor<NameIdentifier> captor = ArgumentCaptor.forClass(NameIdentifier.class);
-    verify(mockEntityStore, org.mockito.Mockito.times(3))
-        .delete(captor.capture(), eq(Entity.EntityType.SCHEMA));
-    List<String> deletedNames =
-        captor.getAllValues().stream().map(NameIdentifier::name).collect(Collectors.toList());
-    Assertions.assertEquals(Arrays.asList("A:B:C", "A:B", "A"), deletedNames);
+    verify(mockEntityStore, org.mockito.Mockito.times(1))
+        .delete(captor.capture(), eq(Entity.EntityType.SCHEMA), eq(true));
+    Assertions.assertEquals("A", captor.getValue().name());
   }
 
   @Test
@@ -292,9 +292,10 @@ public class TestIcebergNamespaceHookDispatcher {
     verify(mockDispatcher).namespaceExists(mockContext, parent);
     verify(mockDispatcher, never()).namespaceExists(mockContext, grandparent);
 
+    // The parent still exists, so only the leaf is stale; it is cascade-deleted on its own.
     ArgumentCaptor<NameIdentifier> captor = ArgumentCaptor.forClass(NameIdentifier.class);
     verify(mockEntityStore, org.mockito.Mockito.times(1))
-        .delete(captor.capture(), eq(Entity.EntityType.SCHEMA));
+        .delete(captor.capture(), eq(Entity.EntityType.SCHEMA), eq(true));
     Assertions.assertEquals("A:B:C", captor.getValue().name());
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Optimize hierarchical-schema cascade deletion so the number of SQL statements stays bounded regardless of how many descendant schemas exist:

- **Relational store** (`SchemaMetaService`): cascade deletion of a `HierarchicalSchema` collects the target schema plus all descendants via a single prefix query, then issues one batched `softDelete...BySchemaIds(List<Long>)` per child-entity table. Unused single-id mapper variants were removed.
- **Dispatchers**: `IcebergNamespaceHookDispatcher.dropNamespace` and `SchemaOperationDispatcher.cleanupOrphanedAncestors` previously issued one `store.delete` per orphaned ancestor. They now do a single cascade delete of the outermost orphaned ancestor, which the relational store expands by name prefix.
- `TestMemoryEntityStore` now models hierarchical cascade so dispatcher unit tests exercise the real behavior.

### Why are the changes needed?

The original hierarchical-schema deletion (#11118, #11175) deleted descendants/ancestors one at a time, producing an unbounded number of SQL statements / transactions for deep or wide hierarchies. Batching bounds the cost.

Fix: #9970

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Added/updated unit tests: `TestSchemaMetaService.testDeleteHierarchicalSchemaCascadeRemovesDescendantsAndChildren`, `TestSchemaOperationDispatcher` (orphaned-ancestor cleanup), and `TestIcebergNamespaceHookDispatcher`. Ran `./gradlew :core:test :iceberg:iceberg-rest-server:test -PskipITs` for the affected classes.
