### PR TITLE
[#11001] feat(catalog-jdbc): Add view list/load support for MySQL and PostgreSQL catalogs

### DIFF
--- a/api/src/main/java/org/apache/gravitino/rel/Dialects.java
+++ b/api/src/main/java/org/apache/gravitino/rel/Dialects.java
@@ -39,5 +39,11 @@ public final class Dialects {
   /** The Apache Flink SQL dialect. */
   public static final String FLINK = "flink";
 
+  /** The MySQL SQL dialect. */
+  public static final String MYSQL = "mysql";
+
+  /** The PostgreSQL SQL dialect. */
+  public static final String POSTGRESQL = "postgresql";
+
   private Dialects() {}
 }

--- a/catalogs/catalog-jdbc-common/src/main/java/org/apache/gravitino/catalog/jdbc/JdbcCatalogOperations.java
+++ b/catalogs/catalog-jdbc-common/src/main/java/org/apache/gravitino/catalog/jdbc/JdbcCatalogOperations.java
@@ -192,6 +192,48 @@ public class JdbcCatalogOperations implements CatalogOperations, SupportsSchemas
     }
   }
 
+  /**
+   * Returns the data source used by this catalog.
+   *
+   * @return The JDBC data source.
+   */
+  protected DataSource getDataSource() {
+    return dataSource;
+  }
+
+  /**
+   * Returns the exception converter used by this catalog.
+   *
+   * @return The JDBC exception converter.
+   */
+  protected JdbcExceptionConverter getExceptionConverter() {
+    return exceptionConverter;
+  }
+
+  /**
+   * Returns the type converter used by this catalog.
+   *
+   * @return The JDBC type converter.
+   */
+  protected JdbcTypeConverter getJdbcTypeConverter() {
+    return jdbcTypeConverter;
+  }
+
+  /**
+   * Checks whether a schema (database) exists.
+   *
+   * @param schemaName The schema name.
+   * @return {@code true} if the schema exists, {@code false} otherwise.
+   */
+  protected boolean schemaExists(String schemaName) {
+    try {
+      databaseOperation.load(schemaName);
+      return true;
+    } catch (NoSuchSchemaException e) {
+      return false;
+    }
+  }
+
   /** Closes the Jdbc catalog and releases the associated client pool. */
   @Override
   public void close() {

--- a/catalogs/catalog-jdbc-common/src/main/java/org/apache/gravitino/catalog/jdbc/JdbcView.java
+++ b/catalogs/catalog-jdbc-common/src/main/java/org/apache/gravitino/catalog/jdbc/JdbcView.java
@@ -1,0 +1,212 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog.jdbc;
+
+import com.google.common.base.Preconditions;
+import java.util.Collections;
+import java.util.Map;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import org.apache.gravitino.annotation.Unstable;
+import org.apache.gravitino.meta.AuditInfo;
+import org.apache.gravitino.rel.Column;
+import org.apache.gravitino.rel.Representation;
+import org.apache.gravitino.rel.SQLRepresentation;
+import org.apache.gravitino.rel.View;
+
+/** Represents a view stored in a JDBC-compatible database. */
+@Unstable
+@EqualsAndHashCode
+@ToString
+public class JdbcView implements View {
+
+  private String name;
+  private String comment;
+  private Column[] columns;
+  private Map<String, String> properties;
+  private AuditInfo auditInfo;
+  private SQLRepresentation[] representations;
+  private String defaultCatalog;
+  private String defaultSchema;
+
+  private JdbcView() {}
+
+  @Override
+  public String name() {
+    return name;
+  }
+
+  @Override
+  public String comment() {
+    return comment;
+  }
+
+  @Override
+  public Column[] columns() {
+    return columns == null ? new Column[0] : columns;
+  }
+
+  @Override
+  public Representation[] representations() {
+    return representations == null ? new SQLRepresentation[0] : representations;
+  }
+
+  @Override
+  public String defaultCatalog() {
+    return defaultCatalog;
+  }
+
+  @Override
+  public String defaultSchema() {
+    return defaultSchema;
+  }
+
+  @Override
+  public Map<String, String> properties() {
+    return properties == null ? Collections.emptyMap() : properties;
+  }
+
+  @Override
+  public AuditInfo auditInfo() {
+    return auditInfo;
+  }
+
+  /**
+   * Returns a new {@link Builder} for constructing a {@code JdbcView}.
+   *
+   * @return A fresh builder instance.
+   */
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  /** Builder for {@link JdbcView}. */
+  public static class Builder {
+    private final JdbcView view;
+
+    private Builder() {
+      view = new JdbcView();
+    }
+
+    /**
+     * Sets the view name.
+     *
+     * @param name The view name.
+     * @return This builder.
+     */
+    public Builder withName(String name) {
+      view.name = name;
+      return this;
+    }
+
+    /**
+     * Sets the view comment.
+     *
+     * @param comment The view comment.
+     * @return This builder.
+     */
+    public Builder withComment(String comment) {
+      view.comment = comment;
+      return this;
+    }
+
+    /**
+     * Sets the output columns.
+     *
+     * @param columns The view output columns.
+     * @return This builder.
+     */
+    public Builder withColumns(Column[] columns) {
+      view.columns = columns;
+      return this;
+    }
+
+    /**
+     * Sets the view properties.
+     *
+     * @param properties The properties map.
+     * @return This builder.
+     */
+    public Builder withProperties(Map<String, String> properties) {
+      view.properties = properties;
+      return this;
+    }
+
+    /**
+     * Sets the audit info.
+     *
+     * @param auditInfo The audit info.
+     * @return This builder.
+     */
+    public Builder withAuditInfo(AuditInfo auditInfo) {
+      view.auditInfo = auditInfo;
+      return this;
+    }
+
+    /**
+     * Sets the SQL representations.
+     *
+     * @param representations The representations array.
+     * @return This builder.
+     */
+    public Builder withRepresentations(SQLRepresentation[] representations) {
+      view.representations = representations;
+      return this;
+    }
+
+    /**
+     * Sets the default catalog for unqualified identifier resolution.
+     *
+     * @param defaultCatalog The default catalog name, may be {@code null}.
+     * @return This builder.
+     */
+    public Builder withDefaultCatalog(String defaultCatalog) {
+      view.defaultCatalog = defaultCatalog;
+      return this;
+    }
+
+    /**
+     * Sets the default schema for unqualified identifier resolution.
+     *
+     * @param defaultSchema The default schema name, may be {@code null}.
+     * @return This builder.
+     */
+    public Builder withDefaultSchema(String defaultSchema) {
+      view.defaultSchema = defaultSchema;
+      return this;
+    }
+
+    /**
+     * Builds the {@link JdbcView} instance.
+     *
+     * @return The constructed view.
+     */
+    public JdbcView build() {
+      Preconditions.checkArgument(
+          view.name != null && !view.name.isEmpty(), "name cannot be null or empty");
+      Preconditions.checkArgument(
+          view.representations != null && view.representations.length > 0,
+          "representations cannot be null or empty");
+      for (SQLRepresentation rep : view.representations) {
+        Preconditions.checkArgument(rep != null, "representation must not be null");
+      }
+      return view;
+    }
+  }
+}

--- a/catalogs/catalog-jdbc-common/src/main/java/org/apache/gravitino/catalog/jdbc/JdbcViewCatalogOperations.java
+++ b/catalogs/catalog-jdbc-common/src/main/java/org/apache/gravitino/catalog/jdbc/JdbcViewCatalogOperations.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog.jdbc;
+
+import java.util.function.Predicate;
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.Namespace;
+import org.apache.gravitino.catalog.jdbc.operation.JdbcViewOperations;
+import org.apache.gravitino.exceptions.NoSuchSchemaException;
+import org.apache.gravitino.exceptions.NoSuchViewException;
+import org.apache.gravitino.rel.View;
+import org.apache.gravitino.rel.ViewCatalog;
+
+/**
+ * Shared helper that implements {@link ViewCatalog} read methods for JDBC catalogs. Both MySQL and
+ * PostgreSQL catalog operations classes delegate to this helper to avoid duplicating namespace
+ * extraction and exception-handling logic.
+ */
+public class JdbcViewCatalogOperations implements ViewCatalog {
+
+  private final JdbcViewOperations viewOps;
+  private final Predicate<String> schemaExistsChecker;
+
+  /**
+   * Creates a new helper.
+   *
+   * @param viewOps The database-specific view operations.
+   * @param schemaExistsChecker A predicate that checks whether a schema/database exists by name.
+   */
+  public JdbcViewCatalogOperations(
+      JdbcViewOperations viewOps, Predicate<String> schemaExistsChecker) {
+    this.viewOps = viewOps;
+    this.schemaExistsChecker = schemaExistsChecker;
+  }
+
+  @Override
+  public NameIdentifier[] listViews(Namespace namespace) throws NoSuchSchemaException {
+    String databaseName = NameIdentifier.of(namespace.levels()).name();
+    if (!schemaExistsChecker.test(databaseName)) {
+      throw new NoSuchSchemaException("Schema %s does not exist", databaseName);
+    }
+    return viewOps.listViews(databaseName).stream()
+        .map(name -> NameIdentifier.of(namespace, name))
+        .toArray(NameIdentifier[]::new);
+  }
+
+  @Override
+  public View loadView(NameIdentifier ident) throws NoSuchViewException {
+    String databaseName = NameIdentifier.of(ident.namespace().levels()).name();
+    return viewOps.load(databaseName, ident.name());
+  }
+}

--- a/catalogs/catalog-jdbc-common/src/main/java/org/apache/gravitino/catalog/jdbc/operation/JdbcViewOperations.java
+++ b/catalogs/catalog-jdbc-common/src/main/java/org/apache/gravitino/catalog/jdbc/operation/JdbcViewOperations.java
@@ -1,0 +1,236 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog.jdbc.operation;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import javax.sql.DataSource;
+import org.apache.gravitino.catalog.jdbc.JdbcColumn;
+import org.apache.gravitino.catalog.jdbc.JdbcView;
+import org.apache.gravitino.catalog.jdbc.converter.JdbcExceptionConverter;
+import org.apache.gravitino.catalog.jdbc.converter.JdbcTypeConverter;
+import org.apache.gravitino.exceptions.NoSuchViewException;
+import org.apache.gravitino.rel.Column;
+import org.apache.gravitino.rel.SQLRepresentation;
+
+/** Abstract base class for database-specific JDBC view operations. */
+public abstract class JdbcViewOperations {
+
+  protected DataSource dataSource;
+  protected JdbcExceptionConverter exceptionMapper;
+  protected JdbcTypeConverter typeConverter;
+
+  /**
+   * Initializes the view operations with the given data source and converters.
+   *
+   * @param dataSource The JDBC data source.
+   * @param exceptionMapper The exception converter.
+   * @param typeConverter The type converter.
+   * @param conf The configuration map.
+   */
+  public void initialize(
+      DataSource dataSource,
+      JdbcExceptionConverter exceptionMapper,
+      JdbcTypeConverter typeConverter,
+      Map<String, String> conf) {
+    this.dataSource = dataSource;
+    this.exceptionMapper = exceptionMapper;
+    this.typeConverter = typeConverter;
+  }
+
+  /**
+   * Lists all view names in the given database/schema.
+   *
+   * @param databaseName The database or schema name.
+   * @return A list of view names.
+   */
+  public List<String> listViews(String databaseName) {
+    try (Connection connection = getConnection(databaseName)) {
+      String sql = generateListViewsSql();
+      try (PreparedStatement stmt = connection.prepareStatement(sql)) {
+        bindListViewsParameters(stmt, databaseName);
+        try (ResultSet rs = stmt.executeQuery()) {
+          List<String> views = new ArrayList<>();
+          while (rs.next()) {
+            views.add(rs.getString(1));
+          }
+          return views;
+        }
+      }
+    } catch (SQLException e) {
+      throw exceptionMapper.toGravitinoException(e);
+    }
+  }
+
+  /**
+   * Loads view metadata from the database.
+   *
+   * @param databaseName The database or schema name.
+   * @param viewName The view name.
+   * @return The loaded view.
+   * @throws NoSuchViewException If the view does not exist.
+   */
+  public JdbcView load(String databaseName, String viewName) throws NoSuchViewException {
+    try (Connection connection = getConnection(databaseName)) {
+      String viewDefinition = loadViewDefinition(connection, databaseName, viewName);
+      Preconditions.checkNotNull(
+          viewDefinition, "View definition is null for view %s in %s", viewName, databaseName);
+      Column[] columns = discoverColumns(connection, viewName);
+
+      SQLRepresentation rep =
+          SQLRepresentation.builder().withDialect(dialectName()).withSql(viewDefinition).build();
+
+      return JdbcView.builder()
+          .withName(viewName)
+          .withColumns(columns)
+          .withRepresentations(new SQLRepresentation[] {rep})
+          .withProperties(ImmutableMap.of())
+          .build();
+    } catch (NoSuchViewException e) {
+      throw e;
+    } catch (SQLException e) {
+      throw exceptionMapper.toGravitinoException(e);
+    }
+  }
+
+  /**
+   * Returns the SQL dialect name for this database (e.g. "mysql", "postgresql").
+   *
+   * @return The dialect name.
+   */
+  public abstract String dialectName();
+
+  /**
+   * Returns a parameterized SQL template to list all views. Use {@code ?} placeholders for
+   * parameters. Override {@link #bindListViewsParameters} to bind them.
+   *
+   * @return The SQL template string with {@code ?} placeholders.
+   */
+  protected abstract String generateListViewsSql();
+
+  /**
+   * Binds parameters for the list-views query. Default binds parameter 1 as databaseName.
+   *
+   * @param stmt The prepared statement.
+   * @param databaseName The database or schema name.
+   * @throws SQLException If parameter binding fails.
+   */
+  protected void bindListViewsParameters(PreparedStatement stmt, String databaseName)
+      throws SQLException {
+    stmt.setString(1, databaseName);
+  }
+
+  /**
+   * Returns a parameterized SQL template to load a view definition. Use {@code ?} placeholders for
+   * parameters. Override {@link #bindLoadViewParameters} to bind them.
+   *
+   * @return The SQL template string with {@code ?} placeholders.
+   */
+  protected abstract String generateLoadViewSql();
+
+  /**
+   * Binds parameters for the load-view query. Default binds parameter 1 as databaseName and
+   * parameter 2 as viewName.
+   *
+   * @param stmt The prepared statement.
+   * @param databaseName The database or schema name.
+   * @param viewName The view name.
+   * @throws SQLException If parameter binding fails.
+   */
+  protected void bindLoadViewParameters(
+      PreparedStatement stmt, String databaseName, String viewName) throws SQLException {
+    stmt.setString(1, databaseName);
+    stmt.setString(2, viewName);
+  }
+
+  /**
+   * Obtains a JDBC connection routed to the given database/schema.
+   *
+   * @param databaseName The target database or schema.
+   * @return A connection routed to the given database.
+   * @throws SQLException If a connection cannot be obtained.
+   */
+  protected Connection getConnection(String databaseName) throws SQLException {
+    Connection connection = dataSource.getConnection();
+    connection.setCatalog(databaseName);
+    return connection;
+  }
+
+  /**
+   * Quotes an identifier according to the database's quoting convention.
+   *
+   * @param identifier The identifier to quote.
+   * @return The quoted identifier.
+   */
+  protected abstract String quoteIdentifier(String identifier);
+
+  private String loadViewDefinition(Connection connection, String databaseName, String viewName)
+      throws SQLException, NoSuchViewException {
+    String sql = generateLoadViewSql();
+    try (PreparedStatement stmt = connection.prepareStatement(sql)) {
+      bindLoadViewParameters(stmt, databaseName, viewName);
+      try (ResultSet rs = stmt.executeQuery()) {
+        if (rs.next()) {
+          return rs.getString(1);
+        }
+        throw new NoSuchViewException("View %s does not exist in %s", viewName, databaseName);
+      }
+    }
+  }
+
+  private Column[] discoverColumns(Connection connection, String viewName) throws SQLException {
+    String quotedView = quoteIdentifier(viewName);
+    String sql = "SELECT * FROM " + quotedView + " WHERE 1=0";
+    try (Statement stmt = connection.createStatement();
+        ResultSet rs = stmt.executeQuery(sql)) {
+      ResultSetMetaData metaData = rs.getMetaData();
+      int columnCount = metaData.getColumnCount();
+      Column[] columns = new Column[columnCount];
+      for (int i = 1; i <= columnCount; i++) {
+        String colName = metaData.getColumnName(i);
+        String typeName = metaData.getColumnTypeName(i);
+        int precision = metaData.getPrecision(i);
+        boolean nullable = metaData.isNullable(i) != ResultSetMetaData.columnNoNulls;
+
+        int scale = metaData.getScale(i);
+
+        JdbcTypeConverter.JdbcTypeBean typeBean = new JdbcTypeConverter.JdbcTypeBean(typeName);
+        typeBean.setColumnSize(precision);
+        typeBean.setScale(scale);
+
+        columns[i - 1] =
+            JdbcColumn.builder()
+                .withName(colName)
+                .withType(typeConverter.toGravitino(typeBean))
+                .withNullable(nullable)
+                .build();
+      }
+      return columns;
+    }
+  }
+}

--- a/catalogs/catalog-jdbc-common/src/main/java/org/apache/gravitino/catalog/jdbc/operation/JdbcViewOperations.java
+++ b/catalogs/catalog-jdbc-common/src/main/java/org/apache/gravitino/catalog/jdbc/operation/JdbcViewOperations.java
@@ -101,12 +101,14 @@ public abstract class JdbcViewOperations {
       Preconditions.checkNotNull(
           viewDefinition, "View definition is null for view %s in %s", viewName, databaseName);
       Column[] columns = discoverColumns(connection, viewName);
+      String comment = loadComment(connection, databaseName, viewName);
 
       SQLRepresentation rep =
           SQLRepresentation.builder().withDialect(dialectName()).withSql(viewDefinition).build();
 
       return JdbcView.builder()
           .withName(viewName)
+          .withComment(comment)
           .withColumns(columns)
           .withRepresentations(new SQLRepresentation[] {rep})
           .withProperties(ImmutableMap.of())
@@ -188,6 +190,22 @@ public abstract class JdbcViewOperations {
    * @return The quoted identifier.
    */
   protected abstract String quoteIdentifier(String identifier);
+
+  /**
+   * Loads the comment for a view from the database. The default implementation returns {@code null}
+   * for databases that do not support view comments (e.g., MySQL). Subclasses should override this
+   * to read comments from the backend (e.g., PostgreSQL's {@code pg_description}).
+   *
+   * @param connection The JDBC connection.
+   * @param databaseName The database or schema name.
+   * @param viewName The view name.
+   * @return The view comment, or {@code null} if not available.
+   * @throws SQLException If the comment cannot be loaded.
+   */
+  protected String loadComment(Connection connection, String databaseName, String viewName)
+      throws SQLException {
+    return null;
+  }
 
   private String loadViewDefinition(Connection connection, String databaseName, String viewName)
       throws SQLException, NoSuchViewException {

--- a/catalogs/catalog-jdbc-common/src/test/java/org/apache/gravitino/catalog/jdbc/TestJdbcViewCatalogOperations.java
+++ b/catalogs/catalog-jdbc-common/src/test/java/org/apache/gravitino/catalog/jdbc/TestJdbcViewCatalogOperations.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog.jdbc;
+
+import com.google.common.collect.ImmutableMap;
+import java.sql.Connection;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.Namespace;
+import org.apache.gravitino.catalog.jdbc.operation.JdbcViewOperations;
+import org.apache.gravitino.exceptions.NoSuchSchemaException;
+import org.apache.gravitino.exceptions.NoSuchViewException;
+import org.apache.gravitino.rel.Column;
+import org.apache.gravitino.rel.SQLRepresentation;
+import org.apache.gravitino.rel.View;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/** Tests for {@link JdbcViewCatalogOperations}. */
+public class TestJdbcViewCatalogOperations {
+
+  private StubViewOperations stubViewOps;
+  private JdbcViewCatalogOperations catalogOps;
+
+  @BeforeEach
+  void setUp() {
+    stubViewOps = new StubViewOperations();
+    catalogOps = new JdbcViewCatalogOperations(stubViewOps, schema -> "existing_db".equals(schema));
+  }
+
+  @Test
+  public void testListViewsInExistingSchema() {
+    stubViewOps.addView("existing_db", "v1", "SELECT 1");
+    stubViewOps.addView("existing_db", "v2", "SELECT 2");
+
+    NameIdentifier[] result = catalogOps.listViews(Namespace.of("existing_db"));
+
+    Assertions.assertEquals(2, result.length);
+    List<String> names =
+        Arrays.stream(result).map(NameIdentifier::name).sorted().collect(Collectors.toList());
+    Assertions.assertEquals(Arrays.asList("v1", "v2"), names);
+  }
+
+  @Test
+  public void testListViewsInNonExistentSchema() {
+    Assertions.assertThrows(
+        NoSuchSchemaException.class, () -> catalogOps.listViews(Namespace.of("no_such_db")));
+  }
+
+  @Test
+  public void testLoadView() {
+    stubViewOps.addView("existing_db", "my_view", "SELECT id FROM users");
+
+    View loaded = catalogOps.loadView(NameIdentifier.of(Namespace.of("existing_db"), "my_view"));
+
+    Assertions.assertEquals("my_view", loaded.name());
+    Assertions.assertEquals(1, loaded.representations().length);
+  }
+
+  @Test
+  public void testLoadNonExistentView() {
+    Assertions.assertThrows(
+        NoSuchViewException.class,
+        () -> catalogOps.loadView(NameIdentifier.of(Namespace.of("existing_db"), "no_view")));
+  }
+
+  @Test
+  public void testViewExists() {
+    stubViewOps.addView("existing_db", "v1", "SELECT 1");
+
+    Assertions.assertTrue(
+        catalogOps.viewExists(NameIdentifier.of(Namespace.of("existing_db"), "v1")));
+  }
+
+  @Test
+  public void testViewDoesNotExist() {
+    Assertions.assertFalse(
+        catalogOps.viewExists(NameIdentifier.of(Namespace.of("existing_db"), "no_view")));
+  }
+
+  @Test
+  public void testJdbcViewPropertiesNeverNull() {
+    JdbcView view =
+        JdbcView.builder()
+            .withName("v")
+            .withRepresentations(
+                new SQLRepresentation[] {
+                  SQLRepresentation.builder().withDialect("test").withSql("SELECT 1").build()
+                })
+            .build();
+    Assertions.assertNotNull(view.properties(), "properties() must not return null");
+  }
+
+  /** In-memory stub of {@link JdbcViewOperations} for testing without a real database. */
+  private static class StubViewOperations extends JdbcViewOperations {
+
+    final Map<String, Map<String, String>> views = new HashMap<>();
+
+    void addView(String db, String viewName, String sql) {
+      views.computeIfAbsent(db, k -> new HashMap<>()).put(viewName, sql);
+    }
+
+    @Override
+    public List<String> listViews(String databaseName) {
+      Map<String, String> dbViews = views.getOrDefault(databaseName, new HashMap<>());
+      return new ArrayList<>(dbViews.keySet());
+    }
+
+    @Override
+    public JdbcView load(String databaseName, String viewName) throws NoSuchViewException {
+      Map<String, String> dbViews = views.get(databaseName);
+      if (dbViews == null || !dbViews.containsKey(viewName)) {
+        throw new NoSuchViewException("View %s not found in %s", viewName, databaseName);
+      }
+      SQLRepresentation rep =
+          SQLRepresentation.builder()
+              .withDialect(dialectName())
+              .withSql(dbViews.get(viewName))
+              .build();
+      return JdbcView.builder()
+          .withName(viewName)
+          .withColumns(new Column[0])
+          .withRepresentations(new SQLRepresentation[] {rep})
+          .withProperties(ImmutableMap.of())
+          .build();
+    }
+
+    @Override
+    public String dialectName() {
+      return "stub";
+    }
+
+    @Override
+    protected String generateListViewsSql() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected String generateLoadViewSql() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected String quoteIdentifier(String identifier) {
+      return "\"" + identifier + "\"";
+    }
+
+    @Override
+    protected Connection getConnection(String databaseName) {
+      throw new UnsupportedOperationException();
+    }
+  }
+}

--- a/catalogs/catalog-jdbc-common/src/test/java/org/apache/gravitino/catalog/jdbc/operation/SqliteViewOperations.java
+++ b/catalogs/catalog-jdbc-common/src/test/java/org/apache/gravitino/catalog/jdbc/operation/SqliteViewOperations.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog.jdbc.operation;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+/** SQLite-specific implementation of JDBC view operations for testing template methods. */
+public class SqliteViewOperations extends JdbcViewOperations {
+
+  @Override
+  public String dialectName() {
+    return "sqlite";
+  }
+
+  @Override
+  protected String quoteIdentifier(String identifier) {
+    return "\"" + identifier.replace("\"", "\"\"") + "\"";
+  }
+
+  @Override
+  protected String generateListViewsSql() {
+    return "SELECT name FROM sqlite_master WHERE type = 'view' AND name NOT LIKE 'sqlite_%'";
+  }
+
+  @Override
+  protected void bindListViewsParameters(PreparedStatement stmt, String databaseName)
+      throws SQLException {
+    // SQLite list-views query has no parameters
+  }
+
+  @Override
+  protected String generateLoadViewSql() {
+    return "SELECT sql FROM sqlite_master WHERE type = 'view' AND name = ?";
+  }
+
+  @Override
+  protected void bindLoadViewParameters(
+      PreparedStatement stmt, String databaseName, String viewName) throws SQLException {
+    stmt.setString(1, viewName);
+  }
+
+  @Override
+  protected Connection getConnection(String databaseName) throws SQLException {
+    return dataSource.getConnection();
+  }
+}

--- a/catalogs/catalog-jdbc-common/src/test/java/org/apache/gravitino/catalog/jdbc/operation/TestJdbcViewOperations.java
+++ b/catalogs/catalog-jdbc-common/src/test/java/org/apache/gravitino/catalog/jdbc/operation/TestJdbcViewOperations.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog.jdbc.operation;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Collections;
+import java.util.List;
+import org.apache.commons.dbcp2.BasicDataSource;
+import org.apache.gravitino.catalog.jdbc.JdbcView;
+import org.apache.gravitino.catalog.jdbc.converter.SqliteExceptionConverter;
+import org.apache.gravitino.catalog.jdbc.converter.SqliteTypeConverter;
+import org.apache.gravitino.exceptions.NoSuchViewException;
+import org.apache.gravitino.rel.Column;
+import org.apache.gravitino.rel.SQLRepresentation;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+
+/**
+ * Tests the template methods in {@link JdbcViewOperations} against an in-memory SQLite database.
+ */
+@TestInstance(Lifecycle.PER_CLASS)
+public class TestJdbcViewOperations {
+
+  private SqliteViewOperations viewOps;
+  private BasicDataSource dataSource;
+
+  @BeforeAll
+  void startDb() {
+    dataSource = new BasicDataSource();
+    dataSource.setUrl("jdbc:sqlite::memory:");
+    dataSource.setMaxTotal(1);
+    dataSource.setMinIdle(1);
+    dataSource.setMaxIdle(1);
+
+    viewOps = new SqliteViewOperations();
+    viewOps.initialize(
+        dataSource,
+        new SqliteExceptionConverter(),
+        new SqliteTypeConverter(),
+        Collections.emptyMap());
+  }
+
+  @AfterAll
+  void stopDb() throws Exception {
+    if (dataSource != null) {
+      dataSource.close();
+    }
+  }
+
+  @BeforeEach
+  void resetViews() throws SQLException {
+    try (Connection conn = dataSource.getConnection();
+        Statement stmt = conn.createStatement()) {
+      stmt.execute("DROP VIEW IF EXISTS \"test_view\"");
+      stmt.execute("DROP VIEW IF EXISTS \"view_a\"");
+      stmt.execute("DROP VIEW IF EXISTS \"view_b\"");
+      stmt.execute("DROP TABLE IF EXISTS \"base_table\"");
+      stmt.execute("CREATE TABLE base_table (id INTEGER, name TEXT)");
+    }
+  }
+
+  @Test
+  public void testListViewsEmpty() {
+    List<String> views = viewOps.listViews("main");
+    Assertions.assertTrue(views.isEmpty());
+  }
+
+  @Test
+  public void testListViewsFindsCreatedViews() throws SQLException {
+    createRawView("view_a", "SELECT id FROM base_table");
+    createRawView("view_b", "SELECT name FROM base_table");
+
+    List<String> views = viewOps.listViews("main");
+    Assertions.assertEquals(2, views.size());
+    Assertions.assertTrue(views.contains("view_a"));
+    Assertions.assertTrue(views.contains("view_b"));
+  }
+
+  @Test
+  public void testLoadViewReturnsColumnsAndRepresentation() throws SQLException {
+    createRawView("test_view", "SELECT id, name FROM base_table");
+
+    JdbcView view = viewOps.load("main", "test_view");
+    Assertions.assertEquals("test_view", view.name());
+
+    Column[] columns = view.columns();
+    Assertions.assertEquals(2, columns.length);
+    Assertions.assertEquals("id", columns[0].name());
+    Assertions.assertEquals("name", columns[1].name());
+
+    Assertions.assertEquals(1, view.representations().length);
+    SQLRepresentation rep = (SQLRepresentation) view.representations()[0];
+    Assertions.assertEquals("sqlite", rep.dialect());
+    Assertions.assertFalse(rep.sql().isEmpty());
+  }
+
+  @Test
+  public void testLoadNonExistentViewThrows() {
+    Assertions.assertThrows(NoSuchViewException.class, () -> viewOps.load("main", "no_such_view"));
+  }
+
+  @Test
+  public void testDiscoverColumnsTypes() throws SQLException {
+    createRawView("test_view", "SELECT id, name FROM base_table");
+
+    JdbcView view = viewOps.load("main", "test_view");
+    for (Column col : view.columns()) {
+      Assertions.assertNotNull(col.dataType());
+    }
+  }
+
+  private void createRawView(String name, String sql) throws SQLException {
+    try (Connection conn = dataSource.getConnection();
+        Statement stmt = conn.createStatement()) {
+      stmt.execute("CREATE VIEW \"" + name + "\" AS " + sql);
+    }
+  }
+}

--- a/catalogs/catalog-jdbc-mysql/src/main/java/org/apache/gravitino/catalog/mysql/MysqlCatalog.java
+++ b/catalogs/catalog-jdbc-mysql/src/main/java/org/apache/gravitino/catalog/mysql/MysqlCatalog.java
@@ -20,7 +20,6 @@ package org.apache.gravitino.catalog.mysql;
 
 import java.util.Map;
 import org.apache.gravitino.catalog.jdbc.JdbcCatalog;
-import org.apache.gravitino.catalog.jdbc.MySQLProtocolCompatibleCatalogOperations;
 import org.apache.gravitino.catalog.jdbc.converter.JdbcColumnDefaultValueConverter;
 import org.apache.gravitino.catalog.jdbc.converter.JdbcTypeConverter;
 import org.apache.gravitino.catalog.jdbc.operation.JdbcDatabaseOperations;
@@ -29,6 +28,7 @@ import org.apache.gravitino.catalog.mysql.converter.MysqlColumnDefaultValueConve
 import org.apache.gravitino.catalog.mysql.converter.MysqlTypeConverter;
 import org.apache.gravitino.catalog.mysql.operation.MysqlDatabaseOperations;
 import org.apache.gravitino.catalog.mysql.operation.MysqlTableOperations;
+import org.apache.gravitino.catalog.mysql.operation.MysqlViewOperations;
 import org.apache.gravitino.connector.CatalogOperations;
 import org.apache.gravitino.connector.PropertiesMetadata;
 import org.apache.gravitino.connector.capability.Capability;
@@ -47,12 +47,13 @@ public class MysqlCatalog extends JdbcCatalog {
   @Override
   protected CatalogOperations newOps(Map<String, String> config) {
     JdbcTypeConverter jdbcTypeConverter = createJdbcTypeConverter();
-    return new MySQLProtocolCompatibleCatalogOperations(
+    return new MysqlCatalogOperations(
         createExceptionConverter(),
         jdbcTypeConverter,
         createJdbcDatabaseOperations(),
         createJdbcTableOperations(),
-        createJdbcColumnDefaultValueConverter());
+        createJdbcColumnDefaultValueConverter(),
+        new MysqlViewOperations());
   }
 
   @Override

--- a/catalogs/catalog-jdbc-mysql/src/main/java/org/apache/gravitino/catalog/mysql/MysqlCatalogOperations.java
+++ b/catalogs/catalog-jdbc-mysql/src/main/java/org/apache/gravitino/catalog/mysql/MysqlCatalogOperations.java
@@ -16,16 +16,13 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.gravitino.catalog.postgresql;
+package org.apache.gravitino.catalog.mysql;
 
-import java.sql.Driver;
-import java.sql.DriverManager;
-import java.sql.SQLException;
 import java.util.Map;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
-import org.apache.gravitino.catalog.jdbc.JdbcCatalogOperations;
 import org.apache.gravitino.catalog.jdbc.JdbcViewCatalogOperations;
+import org.apache.gravitino.catalog.jdbc.MySQLProtocolCompatibleCatalogOperations;
 import org.apache.gravitino.catalog.jdbc.converter.JdbcColumnDefaultValueConverter;
 import org.apache.gravitino.catalog.jdbc.converter.JdbcExceptionConverter;
 import org.apache.gravitino.catalog.jdbc.converter.JdbcTypeConverter;
@@ -39,14 +36,15 @@ import org.apache.gravitino.exceptions.NoSuchViewException;
 import org.apache.gravitino.rel.View;
 import org.apache.gravitino.rel.ViewCatalog;
 
-/** PostgreSQL-specific catalog operations with view support. */
-public class PostgreSQLCatalogOperations extends JdbcCatalogOperations implements ViewCatalog {
+/** MySQL-specific catalog operations with view support. */
+public class MysqlCatalogOperations extends MySQLProtocolCompatibleCatalogOperations
+    implements ViewCatalog {
 
   private final JdbcViewOperations viewOperations;
   private JdbcViewCatalogOperations viewCatalogOps;
 
   /**
-   * Constructs a new instance of PostgreSQLCatalogOperations.
+   * Constructs a new instance of MysqlCatalogOperations.
    *
    * @param exceptionConverter The exception converter.
    * @param jdbcTypeConverter The type converter.
@@ -55,7 +53,7 @@ public class PostgreSQLCatalogOperations extends JdbcCatalogOperations implement
    * @param columnDefaultValueConverter The column default value converter.
    * @param viewOperations The view operations.
    */
-  public PostgreSQLCatalogOperations(
+  public MysqlCatalogOperations(
       JdbcExceptionConverter exceptionConverter,
       JdbcTypeConverter jdbcTypeConverter,
       JdbcDatabaseOperations databaseOperation,
@@ -79,11 +77,6 @@ public class PostgreSQLCatalogOperations extends JdbcCatalogOperations implement
     viewOperations.initialize(
         getDataSource(), getExceptionConverter(), getJdbcTypeConverter(), conf);
     this.viewCatalogOps = new JdbcViewCatalogOperations(viewOperations, this::schemaExists);
-  }
-
-  @Override
-  protected Driver getDriver() throws SQLException {
-    return DriverManager.getDriver("jdbc:postgresql://dummy_address:12345/");
   }
 
   @Override

--- a/catalogs/catalog-jdbc-mysql/src/main/java/org/apache/gravitino/catalog/mysql/operation/MysqlViewOperations.java
+++ b/catalogs/catalog-jdbc-mysql/src/main/java/org/apache/gravitino/catalog/mysql/operation/MysqlViewOperations.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog.mysql.operation;
+
+import org.apache.gravitino.catalog.jdbc.operation.JdbcViewOperations;
+import org.apache.gravitino.rel.Dialects;
+
+/** MySQL-specific implementation of JDBC view operations. */
+public class MysqlViewOperations extends JdbcViewOperations {
+
+  @Override
+  public String dialectName() {
+    return Dialects.MYSQL;
+  }
+
+  @Override
+  protected String quoteIdentifier(String identifier) {
+    return "`" + identifier.replace("`", "``") + "`";
+  }
+
+  @Override
+  protected String generateListViewsSql() {
+    return "SELECT TABLE_NAME FROM information_schema.VIEWS WHERE TABLE_SCHEMA = ?";
+  }
+
+  @Override
+  protected String generateLoadViewSql() {
+    return "SELECT VIEW_DEFINITION FROM information_schema.VIEWS"
+        + " WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ?";
+  }
+}

--- a/catalogs/catalog-jdbc-mysql/src/test/java/org/apache/gravitino/catalog/mysql/integration/test/CatalogMysqlViewReadIT.java
+++ b/catalogs/catalog-jdbc-mysql/src/test/java/org/apache/gravitino/catalog/mysql/integration/test/CatalogMysqlViewReadIT.java
@@ -44,6 +44,7 @@ import org.apache.gravitino.rel.Column;
 import org.apache.gravitino.rel.SQLRepresentation;
 import org.apache.gravitino.rel.View;
 import org.apache.gravitino.rel.ViewCatalog;
+import org.apache.gravitino.rel.types.Types;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -144,9 +145,11 @@ public class CatalogMysqlViewReadIT extends BaseIT {
     Column[] columns = view.columns();
     Assertions.assertEquals(2, columns.length);
     Assertions.assertEquals("id", columns[0].name());
-    Assertions.assertNotNull(columns[0].dataType());
+    Assertions.assertEquals(Types.IntegerType.get(), columns[0].dataType());
     Assertions.assertEquals("name", columns[1].name());
-    Assertions.assertNotNull(columns[1].dataType());
+    Assertions.assertEquals(Types.VarCharType.of(255), columns[1].dataType());
+
+    Assertions.assertNull(view.comment());
 
     Assertions.assertEquals(1, view.representations().length);
     Assertions.assertInstanceOf(SQLRepresentation.class, view.representations()[0]);

--- a/catalogs/catalog-jdbc-mysql/src/test/java/org/apache/gravitino/catalog/mysql/integration/test/CatalogMysqlViewReadIT.java
+++ b/catalogs/catalog-jdbc-mysql/src/test/java/org/apache/gravitino/catalog/mysql/integration/test/CatalogMysqlViewReadIT.java
@@ -1,0 +1,233 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog.mysql.integration.test;
+
+import com.google.common.collect.Maps;
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.gravitino.Catalog;
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.Namespace;
+import org.apache.gravitino.catalog.jdbc.config.JdbcConfig;
+import org.apache.gravitino.catalog.mysql.integration.test.service.MysqlService;
+import org.apache.gravitino.client.GravitinoMetalake;
+import org.apache.gravitino.exceptions.NoSuchSchemaException;
+import org.apache.gravitino.exceptions.NoSuchViewException;
+import org.apache.gravitino.integration.test.container.ContainerSuite;
+import org.apache.gravitino.integration.test.container.MySQLContainer;
+import org.apache.gravitino.integration.test.util.BaseIT;
+import org.apache.gravitino.integration.test.util.GravitinoITUtils;
+import org.apache.gravitino.integration.test.util.TestDatabaseName;
+import org.apache.gravitino.rel.Column;
+import org.apache.gravitino.rel.SQLRepresentation;
+import org.apache.gravitino.rel.View;
+import org.apache.gravitino.rel.ViewCatalog;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+
+/** Integration tests for MySQL view read operations (list/load). */
+@Tag("gravitino-docker-test")
+@TestInstance(Lifecycle.PER_CLASS)
+public class CatalogMysqlViewReadIT extends BaseIT {
+
+  private static final ContainerSuite containerSuite = ContainerSuite.getInstance();
+  private static final String provider = "jdbc-mysql";
+
+  private final String metalakeName = GravitinoITUtils.genRandomName("mysql_view_it_metalake");
+  private final String catalogName = GravitinoITUtils.genRandomName("mysql_view_it_catalog");
+  private final String schemaName = GravitinoITUtils.genRandomName("mysql_view_it_schema");
+
+  private GravitinoMetalake metalake;
+  private Catalog catalog;
+  private MysqlService mysqlService;
+  private MySQLContainer mysqlContainer;
+  private TestDatabaseName testDbName;
+
+  @BeforeAll
+  public void startup() throws IOException, SQLException {
+    testDbName = TestDatabaseName.MYSQL_CATALOG_MYSQL_IT;
+    containerSuite.startMySQLContainer(testDbName);
+    mysqlContainer = containerSuite.getMySQLContainer();
+    mysqlService = new MysqlService(mysqlContainer, testDbName);
+
+    createMetalake();
+    catalog = createCatalog();
+    createSchema();
+    createBaseTableAndViews();
+  }
+
+  @AfterAll
+  public void stop() {
+    cleanupViewsAndTables();
+    catalog.asSchemas().dropSchema(schemaName, false);
+    metalake.disableCatalog(catalogName);
+    metalake.dropCatalog(catalogName);
+    client.disableMetalake(metalakeName);
+    client.dropMetalake(metalakeName);
+    mysqlService.close();
+  }
+
+  @AfterEach
+  public void resetSchema() {
+    cleanupViewsAndTables();
+    catalog.asSchemas().dropSchema(schemaName, false);
+    createSchema();
+    createBaseTableAndViews();
+  }
+
+  @Test
+  public void testListViews() {
+    ViewCatalog viewCatalog = catalog.asViewCatalog();
+    NameIdentifier[] views = viewCatalog.listViews(Namespace.of(schemaName));
+
+    List<String> names =
+        Arrays.stream(views).map(NameIdentifier::name).sorted().collect(Collectors.toList());
+    Assertions.assertEquals(Arrays.asList("test_view_1", "test_view_2"), names);
+  }
+
+  @Test
+  public void testListViewsInEmptySchema() {
+    String emptySchema = GravitinoITUtils.genRandomName("empty_schema");
+    catalog.asSchemas().createSchema(emptySchema, null, Collections.emptyMap());
+    try {
+      NameIdentifier[] views = catalog.asViewCatalog().listViews(Namespace.of(emptySchema));
+      Assertions.assertEquals(0, views.length);
+    } finally {
+      catalog.asSchemas().dropSchema(emptySchema, false);
+    }
+  }
+
+  @Test
+  public void testListViewsInNonExistentSchema() {
+    Assertions.assertThrows(
+        NoSuchSchemaException.class,
+        () -> catalog.asViewCatalog().listViews(Namespace.of("no_such_schema_xyz")));
+  }
+
+  @Test
+  public void testLoadView() {
+    View view =
+        catalog
+            .asViewCatalog()
+            .loadView(NameIdentifier.of(Namespace.of(schemaName), "test_view_1"));
+
+    Assertions.assertEquals("test_view_1", view.name());
+
+    Column[] columns = view.columns();
+    Assertions.assertEquals(2, columns.length);
+    Assertions.assertEquals("id", columns[0].name());
+    Assertions.assertNotNull(columns[0].dataType());
+    Assertions.assertEquals("name", columns[1].name());
+    Assertions.assertNotNull(columns[1].dataType());
+
+    Assertions.assertEquals(1, view.representations().length);
+    Assertions.assertInstanceOf(SQLRepresentation.class, view.representations()[0]);
+    SQLRepresentation rep = (SQLRepresentation) view.representations()[0];
+    Assertions.assertEquals("mysql", rep.dialect());
+    Assertions.assertFalse(rep.sql().isEmpty());
+  }
+
+  @Test
+  public void testLoadNonExistentView() {
+    Assertions.assertThrows(
+        NoSuchViewException.class,
+        () ->
+            catalog
+                .asViewCatalog()
+                .loadView(NameIdentifier.of(Namespace.of(schemaName), "no_such_view")));
+  }
+
+  @Test
+  public void testViewExists() {
+    Assertions.assertTrue(
+        catalog
+            .asViewCatalog()
+            .viewExists(NameIdentifier.of(Namespace.of(schemaName), "test_view_1")));
+  }
+
+  @Test
+  public void testViewDoesNotExist() {
+    Assertions.assertFalse(
+        catalog
+            .asViewCatalog()
+            .viewExists(NameIdentifier.of(Namespace.of(schemaName), "no_such_view")));
+  }
+
+  private void createMetalake() {
+    client.createMetalake(metalakeName, "comment", Collections.emptyMap());
+    metalake = client.loadMetalake(metalakeName);
+  }
+
+  private Catalog createCatalog() throws SQLException {
+    Map<String, String> catalogProperties = Maps.newHashMap();
+    catalogProperties.put(
+        JdbcConfig.JDBC_URL.getKey(),
+        StringUtils.substring(
+                mysqlContainer.getJdbcUrl(testDbName),
+                0,
+                mysqlContainer.getJdbcUrl(testDbName).lastIndexOf("/"))
+            + "?useSSL=false&allowPublicKeyRetrieval=true");
+    catalogProperties.put(
+        JdbcConfig.JDBC_DRIVER.getKey(), mysqlContainer.getDriverClassName(testDbName));
+    catalogProperties.put(JdbcConfig.USERNAME.getKey(), mysqlContainer.getUsername());
+    catalogProperties.put(JdbcConfig.PASSWORD.getKey(), mysqlContainer.getPassword());
+
+    return metalake.createCatalog(
+        catalogName, Catalog.Type.RELATIONAL, provider, "comment", catalogProperties);
+  }
+
+  private void createSchema() {
+    catalog.asSchemas().createSchema(schemaName, null, Collections.emptyMap());
+  }
+
+  private void createBaseTableAndViews() {
+    mysqlService.executeQuery(
+        "CREATE TABLE " + schemaName + ".base_table (id INT, name VARCHAR(255), score DOUBLE)");
+    mysqlService.executeQuery(
+        "CREATE VIEW "
+            + schemaName
+            + ".test_view_1 AS SELECT id, name FROM "
+            + schemaName
+            + ".base_table");
+    mysqlService.executeQuery(
+        "CREATE VIEW "
+            + schemaName
+            + ".test_view_2 AS SELECT id FROM "
+            + schemaName
+            + ".base_table WHERE id > 0");
+  }
+
+  private void cleanupViewsAndTables() {
+    mysqlService.executeQuery("DROP VIEW IF EXISTS " + schemaName + ".test_view_1");
+    mysqlService.executeQuery("DROP VIEW IF EXISTS " + schemaName + ".test_view_2");
+    mysqlService.executeQuery("DROP TABLE IF EXISTS " + schemaName + ".base_table");
+  }
+}

--- a/catalogs/catalog-jdbc-mysql/src/test/java/org/apache/gravitino/catalog/mysql/operation/TestMysqlViewOperations.java
+++ b/catalogs/catalog-jdbc-mysql/src/test/java/org/apache/gravitino/catalog/mysql/operation/TestMysqlViewOperations.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog.mysql.operation;
+
+import org.apache.gravitino.rel.Dialects;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/** Tests for {@link MysqlViewOperations}. */
+public class TestMysqlViewOperations {
+
+  private MysqlViewOperations ops;
+
+  @BeforeEach
+  void setUp() {
+    ops = new MysqlViewOperations();
+  }
+
+  @Test
+  public void testDialectName() {
+    Assertions.assertEquals(Dialects.MYSQL, ops.dialectName());
+  }
+
+  @Test
+  public void testQuoteIdentifier() {
+    Assertions.assertEquals("`my_view`", ops.quoteIdentifier("my_view"));
+  }
+
+  @Test
+  public void testQuoteIdentifierEscapesBacktick() {
+    Assertions.assertEquals("`my``view`", ops.quoteIdentifier("my`view"));
+  }
+
+  @Test
+  public void testGenerateListViewsSqlIsParameterized() {
+    String sql = ops.generateListViewsSql();
+    Assertions.assertTrue(sql.contains("?"), "SQL should contain parameter placeholder");
+    Assertions.assertTrue(
+        sql.toLowerCase().contains("information_schema"), "SQL should query information_schema");
+  }
+
+  @Test
+  public void testGenerateLoadViewSqlIsParameterized() {
+    String sql = ops.generateLoadViewSql();
+    Assertions.assertTrue(sql.contains("?"), "SQL should contain parameter placeholder");
+    Assertions.assertTrue(
+        sql.toLowerCase().contains("view_definition"), "SQL should select VIEW_DEFINITION");
+  }
+}

--- a/catalogs/catalog-jdbc-postgresql/src/main/java/org/apache/gravitino/catalog/postgresql/PostgreSqlCatalog.java
+++ b/catalogs/catalog-jdbc-postgresql/src/main/java/org/apache/gravitino/catalog/postgresql/PostgreSqlCatalog.java
@@ -30,6 +30,7 @@ import org.apache.gravitino.catalog.postgresql.converter.PostgreSqlExceptionConv
 import org.apache.gravitino.catalog.postgresql.converter.PostgreSqlTypeConverter;
 import org.apache.gravitino.catalog.postgresql.operation.PostgreSqlSchemaOperations;
 import org.apache.gravitino.catalog.postgresql.operation.PostgreSqlTableOperations;
+import org.apache.gravitino.catalog.postgresql.operation.PostgreSqlViewOperations;
 import org.apache.gravitino.connector.CatalogOperations;
 import org.apache.gravitino.connector.capability.Capability;
 
@@ -48,7 +49,8 @@ public class PostgreSqlCatalog extends JdbcCatalog {
         jdbcTypeConverter,
         createJdbcDatabaseOperations(),
         createJdbcTableOperations(),
-        createJdbcColumnDefaultValueConverter());
+        createJdbcColumnDefaultValueConverter(),
+        new PostgreSqlViewOperations());
   }
 
   @Override

--- a/catalogs/catalog-jdbc-postgresql/src/main/java/org/apache/gravitino/catalog/postgresql/operation/PostgreSqlViewOperations.java
+++ b/catalogs/catalog-jdbc-postgresql/src/main/java/org/apache/gravitino/catalog/postgresql/operation/PostgreSqlViewOperations.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog.postgresql.operation;
+
+import com.google.common.base.Preconditions;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.Map;
+import javax.sql.DataSource;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.gravitino.catalog.jdbc.config.JdbcConfig;
+import org.apache.gravitino.catalog.jdbc.converter.JdbcExceptionConverter;
+import org.apache.gravitino.catalog.jdbc.converter.JdbcTypeConverter;
+import org.apache.gravitino.catalog.jdbc.operation.JdbcViewOperations;
+import org.apache.gravitino.rel.Dialects;
+
+/** PostgreSQL-specific implementation of JDBC view operations. */
+public class PostgreSqlViewOperations extends JdbcViewOperations {
+
+  private String database;
+
+  @Override
+  public void initialize(
+      DataSource dataSource,
+      JdbcExceptionConverter exceptionMapper,
+      JdbcTypeConverter typeConverter,
+      Map<String, String> conf) {
+    super.initialize(dataSource, exceptionMapper, typeConverter, conf);
+    this.database = new JdbcConfig(conf).getJdbcDatabase();
+    Preconditions.checkArgument(
+        StringUtils.isNotBlank(database),
+        "The `jdbc-database` configuration item is mandatory in PostgreSQL.");
+  }
+
+  @Override
+  public String dialectName() {
+    return Dialects.POSTGRESQL;
+  }
+
+  @Override
+  protected String quoteIdentifier(String identifier) {
+    return "\"" + identifier.replace("\"", "\"\"") + "\"";
+  }
+
+  @Override
+  protected String generateListViewsSql() {
+    return "SELECT table_name FROM information_schema.views"
+        + " WHERE table_schema = ? AND table_catalog = ?";
+  }
+
+  @Override
+  protected void bindListViewsParameters(PreparedStatement stmt, String schemaName)
+      throws SQLException {
+    stmt.setString(1, schemaName);
+    stmt.setString(2, database);
+  }
+
+  @Override
+  protected String generateLoadViewSql() {
+    return "SELECT view_definition FROM information_schema.views"
+        + " WHERE table_schema = ? AND table_name = ? AND table_catalog = ?";
+  }
+
+  @Override
+  protected void bindLoadViewParameters(PreparedStatement stmt, String schemaName, String viewName)
+      throws SQLException {
+    stmt.setString(1, schemaName);
+    stmt.setString(2, viewName);
+    stmt.setString(3, database);
+  }
+
+  @Override
+  protected Connection getConnection(String schema) throws SQLException {
+    Connection connection = dataSource.getConnection();
+    connection.setCatalog(database);
+    connection.setSchema(schema);
+    return connection;
+  }
+}

--- a/catalogs/catalog-jdbc-postgresql/src/main/java/org/apache/gravitino/catalog/postgresql/operation/PostgreSqlViewOperations.java
+++ b/catalogs/catalog-jdbc-postgresql/src/main/java/org/apache/gravitino/catalog/postgresql/operation/PostgreSqlViewOperations.java
@@ -21,6 +21,7 @@ package org.apache.gravitino.catalog.postgresql.operation;
 import com.google.common.base.Preconditions;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Map;
 import javax.sql.DataSource;
@@ -84,6 +85,26 @@ public class PostgreSqlViewOperations extends JdbcViewOperations {
     stmt.setString(1, schemaName);
     stmt.setString(2, viewName);
     stmt.setString(3, database);
+  }
+
+  @Override
+  protected String loadComment(Connection connection, String databaseName, String viewName)
+      throws SQLException {
+    String sql =
+        "SELECT obj_description(c.oid, 'pg_class')"
+            + " FROM pg_catalog.pg_class c"
+            + " JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid"
+            + " WHERE c.relname = ? AND n.nspname = ? AND c.relkind = 'v'";
+    try (PreparedStatement stmt = connection.prepareStatement(sql)) {
+      stmt.setString(1, viewName);
+      stmt.setString(2, databaseName);
+      try (ResultSet rs = stmt.executeQuery()) {
+        if (rs.next()) {
+          return rs.getString(1);
+        }
+      }
+    }
+    return null;
   }
 
   @Override

--- a/catalogs/catalog-jdbc-postgresql/src/test/java/org/apache/gravitino/catalog/postgresql/integration/test/CatalogPostgreSqlViewReadIT.java
+++ b/catalogs/catalog-jdbc-postgresql/src/test/java/org/apache/gravitino/catalog/postgresql/integration/test/CatalogPostgreSqlViewReadIT.java
@@ -1,0 +1,230 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog.postgresql.integration.test;
+
+import com.google.common.collect.Maps;
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.apache.gravitino.Catalog;
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.Namespace;
+import org.apache.gravitino.catalog.jdbc.config.JdbcConfig;
+import org.apache.gravitino.catalog.postgresql.integration.test.service.PostgreSqlService;
+import org.apache.gravitino.client.GravitinoMetalake;
+import org.apache.gravitino.exceptions.NoSuchSchemaException;
+import org.apache.gravitino.exceptions.NoSuchViewException;
+import org.apache.gravitino.integration.test.container.ContainerSuite;
+import org.apache.gravitino.integration.test.container.PGImageName;
+import org.apache.gravitino.integration.test.container.PostgreSQLContainer;
+import org.apache.gravitino.integration.test.util.BaseIT;
+import org.apache.gravitino.integration.test.util.GravitinoITUtils;
+import org.apache.gravitino.integration.test.util.TestDatabaseName;
+import org.apache.gravitino.rel.Column;
+import org.apache.gravitino.rel.SQLRepresentation;
+import org.apache.gravitino.rel.View;
+import org.apache.gravitino.rel.ViewCatalog;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+
+/** Integration tests for PostgreSQL view read operations (list/load). */
+@Tag("gravitino-docker-test")
+@TestInstance(Lifecycle.PER_CLASS)
+public class CatalogPostgreSqlViewReadIT extends BaseIT {
+
+  private static final ContainerSuite containerSuite = ContainerSuite.getInstance();
+  private static final String provider = "jdbc-postgresql";
+
+  private final String metalakeName = GravitinoITUtils.genRandomName("pg_view_it_metalake");
+  private final String catalogName = GravitinoITUtils.genRandomName("pg_view_it_catalog");
+  private final String schemaName = GravitinoITUtils.genRandomName("pg_view_it_schema");
+
+  private GravitinoMetalake metalake;
+  private Catalog catalog;
+  private PostgreSqlService postgreSqlService;
+  private PostgreSQLContainer postgresContainer;
+  private final TestDatabaseName testDbName = TestDatabaseName.PG_CATALOG_POSTGRESQL_IT;
+
+  @BeforeAll
+  public void startup() throws IOException, SQLException {
+    containerSuite.startPostgreSQLContainer(testDbName, PGImageName.VERSION_13);
+    postgresContainer = containerSuite.getPostgreSQLContainer(PGImageName.VERSION_13);
+    postgreSqlService = new PostgreSqlService(postgresContainer, testDbName);
+
+    createMetalake();
+    catalog = createCatalog();
+    createSchema();
+    createBaseTableAndViews();
+  }
+
+  @AfterAll
+  public void stop() {
+    cleanupViewsAndTables();
+    catalog.asSchemas().dropSchema(schemaName, false);
+    metalake.disableCatalog(catalogName);
+    metalake.dropCatalog(catalogName);
+    client.disableMetalake(metalakeName);
+    client.dropMetalake(metalakeName);
+    postgreSqlService.close();
+  }
+
+  @AfterEach
+  public void resetSchema() {
+    cleanupViewsAndTables();
+    catalog.asSchemas().dropSchema(schemaName, false);
+    createSchema();
+    createBaseTableAndViews();
+  }
+
+  @Test
+  public void testListViews() {
+    ViewCatalog viewCatalog = catalog.asViewCatalog();
+    NameIdentifier[] views = viewCatalog.listViews(Namespace.of(schemaName));
+
+    List<String> names =
+        Arrays.stream(views).map(NameIdentifier::name).sorted().collect(Collectors.toList());
+    Assertions.assertEquals(Arrays.asList("test_view_1", "test_view_2"), names);
+  }
+
+  @Test
+  public void testListViewsInEmptySchema() {
+    String emptySchema = GravitinoITUtils.genRandomName("empty_schema");
+    catalog.asSchemas().createSchema(emptySchema, null, Collections.emptyMap());
+    try {
+      NameIdentifier[] views = catalog.asViewCatalog().listViews(Namespace.of(emptySchema));
+      Assertions.assertEquals(0, views.length);
+    } finally {
+      catalog.asSchemas().dropSchema(emptySchema, false);
+    }
+  }
+
+  @Test
+  public void testListViewsInNonExistentSchema() {
+    Assertions.assertThrows(
+        NoSuchSchemaException.class,
+        () -> catalog.asViewCatalog().listViews(Namespace.of("no_such_schema_xyz")));
+  }
+
+  @Test
+  public void testLoadView() {
+    View view =
+        catalog
+            .asViewCatalog()
+            .loadView(NameIdentifier.of(Namespace.of(schemaName), "test_view_1"));
+
+    Assertions.assertEquals("test_view_1", view.name());
+
+    Column[] columns = view.columns();
+    Assertions.assertEquals(2, columns.length);
+    Assertions.assertEquals("id", columns[0].name());
+    Assertions.assertNotNull(columns[0].dataType());
+    Assertions.assertEquals("name", columns[1].name());
+    Assertions.assertNotNull(columns[1].dataType());
+
+    Assertions.assertEquals(1, view.representations().length);
+    Assertions.assertInstanceOf(SQLRepresentation.class, view.representations()[0]);
+    SQLRepresentation rep = (SQLRepresentation) view.representations()[0];
+    Assertions.assertEquals("postgresql", rep.dialect());
+    Assertions.assertFalse(rep.sql().isEmpty());
+  }
+
+  @Test
+  public void testLoadNonExistentView() {
+    Assertions.assertThrows(
+        NoSuchViewException.class,
+        () ->
+            catalog
+                .asViewCatalog()
+                .loadView(NameIdentifier.of(Namespace.of(schemaName), "no_such_view")));
+  }
+
+  @Test
+  public void testViewExists() {
+    Assertions.assertTrue(
+        catalog
+            .asViewCatalog()
+            .viewExists(NameIdentifier.of(Namespace.of(schemaName), "test_view_1")));
+  }
+
+  @Test
+  public void testViewDoesNotExist() {
+    Assertions.assertFalse(
+        catalog
+            .asViewCatalog()
+            .viewExists(NameIdentifier.of(Namespace.of(schemaName), "no_such_view")));
+  }
+
+  private void createMetalake() {
+    client.createMetalake(metalakeName, "comment", Collections.emptyMap());
+    metalake = client.loadMetalake(metalakeName);
+  }
+
+  private Catalog createCatalog() throws SQLException {
+    Map<String, String> catalogProperties = Maps.newHashMap();
+    String jdbcUrl = postgresContainer.getJdbcUrl(testDbName);
+    catalogProperties.put(
+        JdbcConfig.JDBC_DRIVER.getKey(), postgresContainer.getDriverClassName(testDbName));
+    catalogProperties.put(JdbcConfig.JDBC_URL.getKey(), jdbcUrl);
+    catalogProperties.put(JdbcConfig.JDBC_DATABASE.getKey(), testDbName.toString());
+    catalogProperties.put(JdbcConfig.USERNAME.getKey(), postgresContainer.getUsername());
+    catalogProperties.put(JdbcConfig.PASSWORD.getKey(), postgresContainer.getPassword());
+
+    return metalake.createCatalog(
+        catalogName, Catalog.Type.RELATIONAL, provider, "comment", catalogProperties);
+  }
+
+  private void createSchema() {
+    catalog.asSchemas().createSchema(schemaName, "view test schema", Collections.emptyMap());
+  }
+
+  private void createBaseTableAndViews() {
+    postgreSqlService.executeQuery(
+        "CREATE TABLE \""
+            + schemaName
+            + "\".base_table (id INT, name VARCHAR(255), score DOUBLE PRECISION)");
+    postgreSqlService.executeQuery(
+        "CREATE VIEW \""
+            + schemaName
+            + "\".test_view_1 AS SELECT id, name FROM \""
+            + schemaName
+            + "\".base_table");
+    postgreSqlService.executeQuery(
+        "CREATE VIEW \""
+            + schemaName
+            + "\".test_view_2 AS SELECT id FROM \""
+            + schemaName
+            + "\".base_table WHERE id > 0");
+  }
+
+  private void cleanupViewsAndTables() {
+    postgreSqlService.executeQuery("DROP VIEW IF EXISTS \"" + schemaName + "\".test_view_1");
+    postgreSqlService.executeQuery("DROP VIEW IF EXISTS \"" + schemaName + "\".test_view_2");
+    postgreSqlService.executeQuery("DROP TABLE IF EXISTS \"" + schemaName + "\".base_table");
+  }
+}

--- a/catalogs/catalog-jdbc-postgresql/src/test/java/org/apache/gravitino/catalog/postgresql/integration/test/CatalogPostgreSqlViewReadIT.java
+++ b/catalogs/catalog-jdbc-postgresql/src/test/java/org/apache/gravitino/catalog/postgresql/integration/test/CatalogPostgreSqlViewReadIT.java
@@ -44,6 +44,7 @@ import org.apache.gravitino.rel.Column;
 import org.apache.gravitino.rel.SQLRepresentation;
 import org.apache.gravitino.rel.View;
 import org.apache.gravitino.rel.ViewCatalog;
+import org.apache.gravitino.rel.types.Types;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -143,9 +144,11 @@ public class CatalogPostgreSqlViewReadIT extends BaseIT {
     Column[] columns = view.columns();
     Assertions.assertEquals(2, columns.length);
     Assertions.assertEquals("id", columns[0].name());
-    Assertions.assertNotNull(columns[0].dataType());
+    Assertions.assertEquals(Types.IntegerType.get(), columns[0].dataType());
     Assertions.assertEquals("name", columns[1].name());
-    Assertions.assertNotNull(columns[1].dataType());
+    Assertions.assertEquals(Types.VarCharType.of(255), columns[1].dataType());
+
+    Assertions.assertEquals("test view comment", view.comment());
 
     Assertions.assertEquals(1, view.representations().length);
     Assertions.assertInstanceOf(SQLRepresentation.class, view.representations()[0]);
@@ -214,6 +217,8 @@ public class CatalogPostgreSqlViewReadIT extends BaseIT {
             + "\".test_view_1 AS SELECT id, name FROM \""
             + schemaName
             + "\".base_table");
+    postgreSqlService.executeQuery(
+        "COMMENT ON VIEW \"" + schemaName + "\".test_view_1 IS 'test view comment'");
     postgreSqlService.executeQuery(
         "CREATE VIEW \""
             + schemaName

--- a/catalogs/catalog-jdbc-postgresql/src/test/java/org/apache/gravitino/catalog/postgresql/operation/TestPostgreSqlViewOperations.java
+++ b/catalogs/catalog-jdbc-postgresql/src/test/java/org/apache/gravitino/catalog/postgresql/operation/TestPostgreSqlViewOperations.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog.postgresql.operation;
+
+import org.apache.gravitino.rel.Dialects;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/** Tests for {@link PostgreSqlViewOperations}. */
+public class TestPostgreSqlViewOperations {
+
+  private PostgreSqlViewOperations ops;
+
+  @BeforeEach
+  void setUp() {
+    ops = new PostgreSqlViewOperations();
+  }
+
+  @Test
+  public void testDialectName() {
+    Assertions.assertEquals(Dialects.POSTGRESQL, ops.dialectName());
+  }
+
+  @Test
+  public void testQuoteIdentifier() {
+    Assertions.assertEquals("\"my_view\"", ops.quoteIdentifier("my_view"));
+  }
+
+  @Test
+  public void testQuoteIdentifierEscapesDoubleQuote() {
+    Assertions.assertEquals("\"my\"\"view\"", ops.quoteIdentifier("my\"view"));
+  }
+
+  @Test
+  public void testGenerateListViewsSqlIsParameterized() {
+    String sql = ops.generateListViewsSql();
+    Assertions.assertTrue(sql.contains("?"), "SQL should contain parameter placeholder");
+    Assertions.assertTrue(
+        sql.toLowerCase().contains("information_schema"), "SQL should query information_schema");
+  }
+
+  @Test
+  public void testGenerateLoadViewSqlIsParameterized() {
+    String sql = ops.generateLoadViewSql();
+    Assertions.assertTrue(sql.contains("?"), "SQL should contain parameter placeholder");
+    Assertions.assertTrue(
+        sql.toLowerCase().contains("view_definition"), "SQL should select view_definition");
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add read-only view operations (`listViews`, `loadView`) for JDBC catalogs covering MySQL and PostgreSQL. This is the first of two PRs split from #11123 per maintainer feedback to facilitate easier review.

Key changes:
- Introduce `JdbcViewOperations` abstract base with read methods and dialect-specific SQL hooks
- Add `JdbcViewCatalogOperations` helper implementing `ViewCatalog` read methods
- Add `JdbcView` entity class
- Add `MysqlViewOperations` and `PostgreSqlViewOperations` with dialect-specific SQL
- Wire view support into `MysqlCatalogOperations` and `PostgreSQLCatalogOperations`
- Add `MYSQL` and `POSTGRESQL` constants to `Dialects`

### Why are the changes needed?

JDBC catalogs (MySQL, PostgreSQL) currently do not support view operations. This PR adds the read path so users can discover and inspect views that exist in their databases. Write operations (create, alter, drop) will follow in a stacked PR.

Fix: #11000

### Does this PR introduce _any_ user-facing change?

Yes. `catalog.asViewCatalog().listViews()` and `catalog.asViewCatalog().loadView()` now work for MySQL and PostgreSQL JDBC catalogs. Write methods (`createView`, `alterView`, `dropView`) throw `UnsupportedOperationException` until the follow-up PR.

### How was this patch tested?

- Unit tests: `TestJdbcViewCatalogOperations`, `TestMysqlViewOperations`, `TestPostgreSqlViewOperations`
- Integration tests: `CatalogMysqlViewReadIT`, `CatalogPostgreSqlViewReadIT` (pre-create views via raw JDBC, test list/load through Gravitino API)