### PR TITLE
[#11001] feat(catalog-jdbc): Add view create/alter/drop support for MySQL and PostgreSQL catalogs

### DIFF
--- a/api/src/main/java/org/apache/gravitino/rel/Dialects.java
+++ b/api/src/main/java/org/apache/gravitino/rel/Dialects.java
@@ -39,5 +39,11 @@ public final class Dialects {
   /** The Apache Flink SQL dialect. */
   public static final String FLINK = "flink";
 
+  /** The MySQL SQL dialect. */
+  public static final String MYSQL = "mysql";
+
+  /** The PostgreSQL SQL dialect. */
+  public static final String POSTGRESQL = "postgresql";
+
   private Dialects() {}
 }

--- a/catalogs/catalog-jdbc-common/src/main/java/org/apache/gravitino/catalog/jdbc/JdbcCatalogOperations.java
+++ b/catalogs/catalog-jdbc-common/src/main/java/org/apache/gravitino/catalog/jdbc/JdbcCatalogOperations.java
@@ -192,6 +192,48 @@ public class JdbcCatalogOperations implements CatalogOperations, SupportsSchemas
     }
   }
 
+  /**
+   * Returns the data source used by this catalog.
+   *
+   * @return The JDBC data source.
+   */
+  protected DataSource getDataSource() {
+    return dataSource;
+  }
+
+  /**
+   * Returns the exception converter used by this catalog.
+   *
+   * @return The JDBC exception converter.
+   */
+  protected JdbcExceptionConverter getExceptionConverter() {
+    return exceptionConverter;
+  }
+
+  /**
+   * Returns the type converter used by this catalog.
+   *
+   * @return The JDBC type converter.
+   */
+  protected JdbcTypeConverter getJdbcTypeConverter() {
+    return jdbcTypeConverter;
+  }
+
+  /**
+   * Checks whether a schema (database) exists.
+   *
+   * @param schemaName The schema name.
+   * @return {@code true} if the schema exists, {@code false} otherwise.
+   */
+  protected boolean schemaExists(String schemaName) {
+    try {
+      databaseOperation.load(schemaName);
+      return true;
+    } catch (NoSuchSchemaException e) {
+      return false;
+    }
+  }
+
   /** Closes the Jdbc catalog and releases the associated client pool. */
   @Override
   public void close() {

--- a/catalogs/catalog-jdbc-common/src/main/java/org/apache/gravitino/catalog/jdbc/JdbcView.java
+++ b/catalogs/catalog-jdbc-common/src/main/java/org/apache/gravitino/catalog/jdbc/JdbcView.java
@@ -1,0 +1,212 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog.jdbc;
+
+import com.google.common.base.Preconditions;
+import java.util.Collections;
+import java.util.Map;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import org.apache.gravitino.annotation.Unstable;
+import org.apache.gravitino.meta.AuditInfo;
+import org.apache.gravitino.rel.Column;
+import org.apache.gravitino.rel.Representation;
+import org.apache.gravitino.rel.SQLRepresentation;
+import org.apache.gravitino.rel.View;
+
+/** Represents a view stored in a JDBC-compatible database. */
+@Unstable
+@EqualsAndHashCode
+@ToString
+public class JdbcView implements View {
+
+  private String name;
+  private String comment;
+  private Column[] columns;
+  private Map<String, String> properties;
+  private AuditInfo auditInfo;
+  private SQLRepresentation[] representations;
+  private String defaultCatalog;
+  private String defaultSchema;
+
+  private JdbcView() {}
+
+  @Override
+  public String name() {
+    return name;
+  }
+
+  @Override
+  public String comment() {
+    return comment;
+  }
+
+  @Override
+  public Column[] columns() {
+    return columns == null ? new Column[0] : columns;
+  }
+
+  @Override
+  public Representation[] representations() {
+    return representations == null ? new SQLRepresentation[0] : representations;
+  }
+
+  @Override
+  public String defaultCatalog() {
+    return defaultCatalog;
+  }
+
+  @Override
+  public String defaultSchema() {
+    return defaultSchema;
+  }
+
+  @Override
+  public Map<String, String> properties() {
+    return properties == null ? Collections.emptyMap() : properties;
+  }
+
+  @Override
+  public AuditInfo auditInfo() {
+    return auditInfo;
+  }
+
+  /**
+   * Returns a new {@link Builder} for constructing a {@code JdbcView}.
+   *
+   * @return A fresh builder instance.
+   */
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  /** Builder for {@link JdbcView}. */
+  public static class Builder {
+    private final JdbcView view;
+
+    private Builder() {
+      view = new JdbcView();
+    }
+
+    /**
+     * Sets the view name.
+     *
+     * @param name The view name.
+     * @return This builder.
+     */
+    public Builder withName(String name) {
+      view.name = name;
+      return this;
+    }
+
+    /**
+     * Sets the view comment.
+     *
+     * @param comment The view comment.
+     * @return This builder.
+     */
+    public Builder withComment(String comment) {
+      view.comment = comment;
+      return this;
+    }
+
+    /**
+     * Sets the output columns.
+     *
+     * @param columns The view output columns.
+     * @return This builder.
+     */
+    public Builder withColumns(Column[] columns) {
+      view.columns = columns;
+      return this;
+    }
+
+    /**
+     * Sets the view properties.
+     *
+     * @param properties The properties map.
+     * @return This builder.
+     */
+    public Builder withProperties(Map<String, String> properties) {
+      view.properties = properties;
+      return this;
+    }
+
+    /**
+     * Sets the audit info.
+     *
+     * @param auditInfo The audit info.
+     * @return This builder.
+     */
+    public Builder withAuditInfo(AuditInfo auditInfo) {
+      view.auditInfo = auditInfo;
+      return this;
+    }
+
+    /**
+     * Sets the SQL representations.
+     *
+     * @param representations The representations array.
+     * @return This builder.
+     */
+    public Builder withRepresentations(SQLRepresentation[] representations) {
+      view.representations = representations;
+      return this;
+    }
+
+    /**
+     * Sets the default catalog for unqualified identifier resolution.
+     *
+     * @param defaultCatalog The default catalog name, may be {@code null}.
+     * @return This builder.
+     */
+    public Builder withDefaultCatalog(String defaultCatalog) {
+      view.defaultCatalog = defaultCatalog;
+      return this;
+    }
+
+    /**
+     * Sets the default schema for unqualified identifier resolution.
+     *
+     * @param defaultSchema The default schema name, may be {@code null}.
+     * @return This builder.
+     */
+    public Builder withDefaultSchema(String defaultSchema) {
+      view.defaultSchema = defaultSchema;
+      return this;
+    }
+
+    /**
+     * Builds the {@link JdbcView} instance.
+     *
+     * @return The constructed view.
+     */
+    public JdbcView build() {
+      Preconditions.checkArgument(
+          view.name != null && !view.name.isEmpty(), "name cannot be null or empty");
+      Preconditions.checkArgument(
+          view.representations != null && view.representations.length > 0,
+          "representations cannot be null or empty");
+      for (SQLRepresentation rep : view.representations) {
+        Preconditions.checkArgument(rep != null, "representation must not be null");
+      }
+      return view;
+    }
+  }
+}

--- a/catalogs/catalog-jdbc-common/src/main/java/org/apache/gravitino/catalog/jdbc/JdbcViewCatalogOperations.java
+++ b/catalogs/catalog-jdbc-common/src/main/java/org/apache/gravitino/catalog/jdbc/JdbcViewCatalogOperations.java
@@ -18,19 +18,30 @@
  */
 package org.apache.gravitino.catalog.jdbc;
 
+import com.google.common.base.Preconditions;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Map;
 import java.util.function.Predicate;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
 import org.apache.gravitino.catalog.jdbc.operation.JdbcViewOperations;
 import org.apache.gravitino.exceptions.NoSuchSchemaException;
 import org.apache.gravitino.exceptions.NoSuchViewException;
+import org.apache.gravitino.exceptions.ViewAlreadyExistsException;
+import org.apache.gravitino.meta.AuditInfo;
+import org.apache.gravitino.rel.Column;
+import org.apache.gravitino.rel.Representation;
+import org.apache.gravitino.rel.SQLRepresentation;
 import org.apache.gravitino.rel.View;
 import org.apache.gravitino.rel.ViewCatalog;
+import org.apache.gravitino.rel.ViewChange;
+import org.apache.gravitino.utils.PrincipalUtils;
 
 /**
- * Shared helper that implements {@link ViewCatalog} read methods for JDBC catalogs. Both MySQL and
+ * Shared helper that implements {@link ViewCatalog} methods for JDBC catalogs. Both MySQL and
  * PostgreSQL catalog operations classes delegate to this helper to avoid duplicating namespace
- * extraction and exception-handling logic.
+ * extraction, audit, and exception-handling logic.
  */
 public class JdbcViewCatalogOperations implements ViewCatalog {
 
@@ -64,5 +75,105 @@ public class JdbcViewCatalogOperations implements ViewCatalog {
   public View loadView(NameIdentifier ident) throws NoSuchViewException {
     String databaseName = NameIdentifier.of(ident.namespace().levels()).name();
     return viewOps.load(databaseName, ident.name());
+  }
+
+  @Override
+  public View createView(
+      NameIdentifier ident,
+      String comment,
+      Column[] columns,
+      Representation[] representations,
+      String defaultCatalog,
+      String defaultSchema,
+      Map<String, String> properties)
+      throws NoSuchSchemaException, ViewAlreadyExistsException {
+    String databaseName = NameIdentifier.of(ident.namespace().levels()).name();
+    if (!schemaExistsChecker.test(databaseName)) {
+      throw new NoSuchSchemaException("Schema %s does not exist", databaseName);
+    }
+
+    SQLRepresentation sqlRep =
+        extractSqlRepresentation(representations, viewOps.dialectName(), ident);
+    viewOps.create(databaseName, ident.name(), comment, sqlRep.sql());
+
+    JdbcView loaded = viewOps.load(databaseName, ident.name());
+    return JdbcView.builder()
+        .withName(loaded.name())
+        .withComment(comment)
+        .withColumns(loaded.columns())
+        .withRepresentations(
+            Arrays.stream(loaded.representations())
+                .filter(SQLRepresentation.class::isInstance)
+                .map(SQLRepresentation.class::cast)
+                .toArray(SQLRepresentation[]::new))
+        .withProperties(loaded.properties())
+        .withDefaultCatalog(defaultCatalog)
+        .withDefaultSchema(defaultSchema)
+        .withAuditInfo(
+            AuditInfo.builder()
+                .withCreator(PrincipalUtils.getCurrentUserName())
+                .withCreateTime(Instant.now())
+                .build())
+        .build();
+  }
+
+  @Override
+  public View alterView(NameIdentifier ident, ViewChange... changes)
+      throws NoSuchViewException, IllegalArgumentException {
+    String databaseName = NameIdentifier.of(ident.namespace().levels()).name();
+    String currentName = ident.name();
+
+    for (ViewChange change : changes) {
+      if (change instanceof ViewChange.SetProperty || change instanceof ViewChange.RemoveProperty) {
+        throw new UnsupportedOperationException(
+            "JDBC catalogs do not support view properties. "
+                + "Use an Iceberg REST catalog for managed view properties.");
+      } else if (!(change instanceof ViewChange.RenameView)
+          && !(change instanceof ViewChange.ReplaceView)) {
+        throw new IllegalArgumentException(
+            "Unsupported view change type: " + change.getClass().getSimpleName());
+      }
+    }
+
+    for (ViewChange change : changes) {
+      if (change instanceof ViewChange.RenameView) {
+        String newName = ((ViewChange.RenameView) change).getNewName();
+        viewOps.rename(databaseName, currentName, newName);
+        currentName = newName;
+      } else if (change instanceof ViewChange.ReplaceView) {
+        ViewChange.ReplaceView replace = (ViewChange.ReplaceView) change;
+        SQLRepresentation sqlRep =
+            extractSqlRepresentation(replace.getRepresentations(), viewOps.dialectName(), ident);
+        viewOps.replaceDefinition(databaseName, currentName, replace.getComment(), sqlRep.sql());
+      }
+    }
+
+    return loadView(NameIdentifier.of(ident.namespace(), currentName));
+  }
+
+  @Override
+  public boolean dropView(NameIdentifier ident) {
+    String databaseName = NameIdentifier.of(ident.namespace().levels()).name();
+    return viewOps.drop(databaseName, ident.name());
+  }
+
+  private static SQLRepresentation extractSqlRepresentation(
+      Representation[] representations, String dialect, NameIdentifier ident) {
+    Preconditions.checkArgument(
+        representations != null && representations.length > 0,
+        "At least one representation is required to create a JDBC view");
+    for (Representation rep : representations) {
+      if (rep instanceof SQLRepresentation
+          && dialect.equalsIgnoreCase(((SQLRepresentation) rep).dialect())) {
+        return (SQLRepresentation) rep;
+      }
+    }
+    for (Representation rep : representations) {
+      if (rep instanceof SQLRepresentation) {
+        return (SQLRepresentation) rep;
+      }
+    }
+    throw new IllegalArgumentException(
+        "JDBC catalog requires at least one SQL representation to create view " + ident);
   }
 }

--- a/catalogs/catalog-jdbc-common/src/main/java/org/apache/gravitino/catalog/jdbc/JdbcViewCatalogOperations.java
+++ b/catalogs/catalog-jdbc-common/src/main/java/org/apache/gravitino/catalog/jdbc/JdbcViewCatalogOperations.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog.jdbc;
+
+import java.util.function.Predicate;
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.Namespace;
+import org.apache.gravitino.catalog.jdbc.operation.JdbcViewOperations;
+import org.apache.gravitino.exceptions.NoSuchSchemaException;
+import org.apache.gravitino.exceptions.NoSuchViewException;
+import org.apache.gravitino.rel.View;
+import org.apache.gravitino.rel.ViewCatalog;
+
+/**
+ * Shared helper that implements {@link ViewCatalog} read methods for JDBC catalogs. Both MySQL and
+ * PostgreSQL catalog operations classes delegate to this helper to avoid duplicating namespace
+ * extraction and exception-handling logic.
+ */
+public class JdbcViewCatalogOperations implements ViewCatalog {
+
+  private final JdbcViewOperations viewOps;
+  private final Predicate<String> schemaExistsChecker;
+
+  /**
+   * Creates a new helper.
+   *
+   * @param viewOps The database-specific view operations.
+   * @param schemaExistsChecker A predicate that checks whether a schema/database exists by name.
+   */
+  public JdbcViewCatalogOperations(
+      JdbcViewOperations viewOps, Predicate<String> schemaExistsChecker) {
+    this.viewOps = viewOps;
+    this.schemaExistsChecker = schemaExistsChecker;
+  }
+
+  @Override
+  public NameIdentifier[] listViews(Namespace namespace) throws NoSuchSchemaException {
+    String databaseName = NameIdentifier.of(namespace.levels()).name();
+    if (!schemaExistsChecker.test(databaseName)) {
+      throw new NoSuchSchemaException("Schema %s does not exist", databaseName);
+    }
+    return viewOps.listViews(databaseName).stream()
+        .map(name -> NameIdentifier.of(namespace, name))
+        .toArray(NameIdentifier[]::new);
+  }
+
+  @Override
+  public View loadView(NameIdentifier ident) throws NoSuchViewException {
+    String databaseName = NameIdentifier.of(ident.namespace().levels()).name();
+    return viewOps.load(databaseName, ident.name());
+  }
+}

--- a/catalogs/catalog-jdbc-common/src/main/java/org/apache/gravitino/catalog/jdbc/operation/JdbcViewOperations.java
+++ b/catalogs/catalog-jdbc-common/src/main/java/org/apache/gravitino/catalog/jdbc/operation/JdbcViewOperations.java
@@ -34,12 +34,20 @@ import org.apache.gravitino.catalog.jdbc.JdbcColumn;
 import org.apache.gravitino.catalog.jdbc.JdbcView;
 import org.apache.gravitino.catalog.jdbc.converter.JdbcExceptionConverter;
 import org.apache.gravitino.catalog.jdbc.converter.JdbcTypeConverter;
+import org.apache.gravitino.exceptions.GravitinoRuntimeException;
+import org.apache.gravitino.exceptions.NoSuchTableException;
 import org.apache.gravitino.exceptions.NoSuchViewException;
+import org.apache.gravitino.exceptions.TableAlreadyExistsException;
+import org.apache.gravitino.exceptions.ViewAlreadyExistsException;
 import org.apache.gravitino.rel.Column;
 import org.apache.gravitino.rel.SQLRepresentation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** Abstract base class for database-specific JDBC view operations. */
 public abstract class JdbcViewOperations {
+
+  protected static final Logger LOG = LoggerFactory.getLogger(JdbcViewOperations.class);
 
   protected DataSource dataSource;
   protected JdbcExceptionConverter exceptionMapper;
@@ -171,6 +179,161 @@ public abstract class JdbcViewOperations {
   }
 
   /**
+   * Creates a view in the database.
+   *
+   * @param databaseName The database or schema name.
+   * @param viewName The view name.
+   * @param comment The optional view comment.
+   * @param sql The view definition SQL.
+   * @throws ViewAlreadyExistsException If the view already exists.
+   */
+  public void create(String databaseName, String viewName, String comment, String sql)
+      throws ViewAlreadyExistsException {
+    try (Connection connection = getConnection(databaseName);
+        Statement stmt = connection.createStatement()) {
+      stmt.execute(generateCreateViewSql(viewName, sql));
+      setComment(connection, viewName, comment);
+      LOG.info("Created JDBC view {}.{}", databaseName, viewName);
+    } catch (SQLException e) {
+      GravitinoRuntimeException ge = exceptionMapper.toGravitinoException(e);
+      // The exception converter is table-oriented; remap to the view-specific exception.
+      if (ge instanceof TableAlreadyExistsException) {
+        throw new ViewAlreadyExistsException(
+            e, "View %s already exists in %s", viewName, databaseName);
+      }
+      throw ge;
+    }
+  }
+
+  /**
+   * Replaces the definition of an existing view.
+   *
+   * @param databaseName The database or schema name.
+   * @param viewName The view name.
+   * @param comment The optional view comment.
+   * @param sql The new view definition SQL.
+   * @throws NoSuchViewException If the view does not exist.
+   */
+  public void replaceDefinition(String databaseName, String viewName, String comment, String sql)
+      throws NoSuchViewException {
+    try (Connection connection = getConnection(databaseName)) {
+      if (!viewExists(connection, databaseName, viewName)) {
+        throw new NoSuchViewException("View %s does not exist in %s", viewName, databaseName);
+      }
+      try (Statement stmt = connection.createStatement()) {
+        stmt.execute(generateReplaceViewSql(viewName, sql));
+        setComment(connection, viewName, comment);
+        LOG.info("Replaced definition of JDBC view {}.{}", databaseName, viewName);
+      }
+    } catch (NoSuchViewException e) {
+      throw e;
+    } catch (SQLException e) {
+      throw exceptionMapper.toGravitinoException(e);
+    }
+  }
+
+  /**
+   * Renames a view.
+   *
+   * @param databaseName The database or schema name.
+   * @param oldName The current view name.
+   * @param newName The new view name.
+   * @throws NoSuchViewException If the view does not exist.
+   */
+  public void rename(String databaseName, String oldName, String newName)
+      throws NoSuchViewException {
+    try (Connection connection = getConnection(databaseName);
+        Statement stmt = connection.createStatement()) {
+      stmt.execute(generateRenameViewSql(oldName, newName));
+      LOG.info("Renamed JDBC view {}.{} to {}", databaseName, oldName, newName);
+    } catch (SQLException e) {
+      GravitinoRuntimeException ge = exceptionMapper.toGravitinoException(e);
+      // The exception converter is table-oriented; remap to the view-specific exception.
+      if (ge instanceof NoSuchTableException) {
+        throw new NoSuchViewException("View %s does not exist in %s", oldName, databaseName);
+      }
+      throw ge;
+    }
+  }
+
+  /**
+   * Drops a view from the database.
+   *
+   * @param databaseName The database or schema name.
+   * @param viewName The view name.
+   * @return {@code true} if the view was dropped, {@code false} if it did not exist.
+   */
+  public boolean drop(String databaseName, String viewName) {
+    try (Connection connection = getConnection(databaseName);
+        Statement stmt = connection.createStatement()) {
+      stmt.execute(generateDropViewSql(viewName));
+      LOG.info("Dropped JDBC view {}.{}", databaseName, viewName);
+      return true;
+    } catch (SQLException e) {
+      GravitinoRuntimeException ge = exceptionMapper.toGravitinoException(e);
+      // The exception converter is table-oriented; treat "no such table" as "view did not exist".
+      if (ge instanceof NoSuchTableException) {
+        return false;
+      }
+      throw ge;
+    }
+  }
+
+  /**
+   * Generates a CREATE VIEW SQL statement.
+   *
+   * @param viewName The view name (will be quoted by the implementation).
+   * @param sql The view definition SQL.
+   * @return The CREATE VIEW DDL string.
+   */
+  protected abstract String generateCreateViewSql(String viewName, String sql);
+
+  /**
+   * Generates a CREATE OR REPLACE VIEW SQL statement.
+   *
+   * @param viewName The view name.
+   * @param sql The new view definition SQL.
+   * @return The DDL string.
+   */
+  protected abstract String generateReplaceViewSql(String viewName, String sql);
+
+  /**
+   * Generates a rename view SQL statement.
+   *
+   * @param oldName The current view name.
+   * @param newName The new view name.
+   * @return The DDL string.
+   */
+  protected abstract String generateRenameViewSql(String oldName, String newName);
+
+  /**
+   * Generates a DROP VIEW SQL statement.
+   *
+   * @param viewName The view name.
+   * @return The DDL string.
+   */
+  protected abstract String generateDropViewSql(String viewName);
+
+  /**
+   * Sets a comment on the view if the database supports it. The default implementation is a no-op
+   * -- comments are silently discarded for databases that do not override this method (e.g., MySQL
+   * does not support standalone view comments via DDL).
+   *
+   * @param connection The JDBC connection.
+   * @param viewName The view name.
+   * @param comment The comment text, may be {@code null}.
+   * @throws SQLException If the comment cannot be set.
+   */
+  protected void setComment(Connection connection, String viewName, String comment)
+      throws SQLException {
+    if (comment != null) {
+      LOG.warn(
+          "View comments are not supported by {} dialect; comment will be discarded",
+          dialectName());
+    }
+  }
+
+  /**
    * Obtains a JDBC connection routed to the given database/schema.
    *
    * @param databaseName The target database or schema.
@@ -217,6 +380,17 @@ public abstract class JdbcViewOperations {
           return rs.getString(1);
         }
         throw new NoSuchViewException("View %s does not exist in %s", viewName, databaseName);
+      }
+    }
+  }
+
+  private boolean viewExists(Connection connection, String databaseName, String viewName)
+      throws SQLException {
+    String sql = generateLoadViewSql();
+    try (PreparedStatement stmt = connection.prepareStatement(sql)) {
+      bindLoadViewParameters(stmt, databaseName, viewName);
+      try (ResultSet rs = stmt.executeQuery()) {
+        return rs.next();
       }
     }
   }

--- a/catalogs/catalog-jdbc-common/src/main/java/org/apache/gravitino/catalog/jdbc/operation/JdbcViewOperations.java
+++ b/catalogs/catalog-jdbc-common/src/main/java/org/apache/gravitino/catalog/jdbc/operation/JdbcViewOperations.java
@@ -315,6 +315,22 @@ public abstract class JdbcViewOperations {
   protected abstract String generateDropViewSql(String viewName);
 
   /**
+   * Loads the comment for a view from the database. The default implementation returns {@code null}
+   * for databases that do not support view comments (e.g., MySQL). Subclasses should override this
+   * to read comments from the backend (e.g., PostgreSQL's {@code pg_description}).
+   *
+   * @param connection The JDBC connection.
+   * @param databaseName The database or schema name.
+   * @param viewName The view name.
+   * @return The view comment, or {@code null} if not available.
+   * @throws SQLException If the comment cannot be loaded.
+   */
+  protected String loadComment(Connection connection, String databaseName, String viewName)
+      throws SQLException {
+    return null;
+  }
+
+  /**
    * Sets a comment on the view if the database supports it. The default implementation is a no-op
    * -- comments are silently discarded for databases that do not override this method (e.g., MySQL
    * does not support standalone view comments via DDL).
@@ -353,22 +369,6 @@ public abstract class JdbcViewOperations {
    * @return The quoted identifier.
    */
   protected abstract String quoteIdentifier(String identifier);
-
-  /**
-   * Loads the comment for a view from the database. The default implementation returns {@code null}
-   * for databases that do not support view comments (e.g., MySQL). Subclasses should override this
-   * to read comments from the backend (e.g., PostgreSQL's {@code pg_description}).
-   *
-   * @param connection The JDBC connection.
-   * @param databaseName The database or schema name.
-   * @param viewName The view name.
-   * @return The view comment, or {@code null} if not available.
-   * @throws SQLException If the comment cannot be loaded.
-   */
-  protected String loadComment(Connection connection, String databaseName, String viewName)
-      throws SQLException {
-    return null;
-  }
 
   private String loadViewDefinition(Connection connection, String databaseName, String viewName)
       throws SQLException, NoSuchViewException {

--- a/catalogs/catalog-jdbc-common/src/main/java/org/apache/gravitino/catalog/jdbc/operation/JdbcViewOperations.java
+++ b/catalogs/catalog-jdbc-common/src/main/java/org/apache/gravitino/catalog/jdbc/operation/JdbcViewOperations.java
@@ -1,0 +1,236 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog.jdbc.operation;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import javax.sql.DataSource;
+import org.apache.gravitino.catalog.jdbc.JdbcColumn;
+import org.apache.gravitino.catalog.jdbc.JdbcView;
+import org.apache.gravitino.catalog.jdbc.converter.JdbcExceptionConverter;
+import org.apache.gravitino.catalog.jdbc.converter.JdbcTypeConverter;
+import org.apache.gravitino.exceptions.NoSuchViewException;
+import org.apache.gravitino.rel.Column;
+import org.apache.gravitino.rel.SQLRepresentation;
+
+/** Abstract base class for database-specific JDBC view operations. */
+public abstract class JdbcViewOperations {
+
+  protected DataSource dataSource;
+  protected JdbcExceptionConverter exceptionMapper;
+  protected JdbcTypeConverter typeConverter;
+
+  /**
+   * Initializes the view operations with the given data source and converters.
+   *
+   * @param dataSource The JDBC data source.
+   * @param exceptionMapper The exception converter.
+   * @param typeConverter The type converter.
+   * @param conf The configuration map.
+   */
+  public void initialize(
+      DataSource dataSource,
+      JdbcExceptionConverter exceptionMapper,
+      JdbcTypeConverter typeConverter,
+      Map<String, String> conf) {
+    this.dataSource = dataSource;
+    this.exceptionMapper = exceptionMapper;
+    this.typeConverter = typeConverter;
+  }
+
+  /**
+   * Lists all view names in the given database/schema.
+   *
+   * @param databaseName The database or schema name.
+   * @return A list of view names.
+   */
+  public List<String> listViews(String databaseName) {
+    try (Connection connection = getConnection(databaseName)) {
+      String sql = generateListViewsSql();
+      try (PreparedStatement stmt = connection.prepareStatement(sql)) {
+        bindListViewsParameters(stmt, databaseName);
+        try (ResultSet rs = stmt.executeQuery()) {
+          List<String> views = new ArrayList<>();
+          while (rs.next()) {
+            views.add(rs.getString(1));
+          }
+          return views;
+        }
+      }
+    } catch (SQLException e) {
+      throw exceptionMapper.toGravitinoException(e);
+    }
+  }
+
+  /**
+   * Loads view metadata from the database.
+   *
+   * @param databaseName The database or schema name.
+   * @param viewName The view name.
+   * @return The loaded view.
+   * @throws NoSuchViewException If the view does not exist.
+   */
+  public JdbcView load(String databaseName, String viewName) throws NoSuchViewException {
+    try (Connection connection = getConnection(databaseName)) {
+      String viewDefinition = loadViewDefinition(connection, databaseName, viewName);
+      Preconditions.checkNotNull(
+          viewDefinition, "View definition is null for view %s in %s", viewName, databaseName);
+      Column[] columns = discoverColumns(connection, viewName);
+
+      SQLRepresentation rep =
+          SQLRepresentation.builder().withDialect(dialectName()).withSql(viewDefinition).build();
+
+      return JdbcView.builder()
+          .withName(viewName)
+          .withColumns(columns)
+          .withRepresentations(new SQLRepresentation[] {rep})
+          .withProperties(ImmutableMap.of())
+          .build();
+    } catch (NoSuchViewException e) {
+      throw e;
+    } catch (SQLException e) {
+      throw exceptionMapper.toGravitinoException(e);
+    }
+  }
+
+  /**
+   * Returns the SQL dialect name for this database (e.g. "mysql", "postgresql").
+   *
+   * @return The dialect name.
+   */
+  public abstract String dialectName();
+
+  /**
+   * Returns a parameterized SQL template to list all views. Use {@code ?} placeholders for
+   * parameters. Override {@link #bindListViewsParameters} to bind them.
+   *
+   * @return The SQL template string with {@code ?} placeholders.
+   */
+  protected abstract String generateListViewsSql();
+
+  /**
+   * Binds parameters for the list-views query. Default binds parameter 1 as databaseName.
+   *
+   * @param stmt The prepared statement.
+   * @param databaseName The database or schema name.
+   * @throws SQLException If parameter binding fails.
+   */
+  protected void bindListViewsParameters(PreparedStatement stmt, String databaseName)
+      throws SQLException {
+    stmt.setString(1, databaseName);
+  }
+
+  /**
+   * Returns a parameterized SQL template to load a view definition. Use {@code ?} placeholders for
+   * parameters. Override {@link #bindLoadViewParameters} to bind them.
+   *
+   * @return The SQL template string with {@code ?} placeholders.
+   */
+  protected abstract String generateLoadViewSql();
+
+  /**
+   * Binds parameters for the load-view query. Default binds parameter 1 as databaseName and
+   * parameter 2 as viewName.
+   *
+   * @param stmt The prepared statement.
+   * @param databaseName The database or schema name.
+   * @param viewName The view name.
+   * @throws SQLException If parameter binding fails.
+   */
+  protected void bindLoadViewParameters(
+      PreparedStatement stmt, String databaseName, String viewName) throws SQLException {
+    stmt.setString(1, databaseName);
+    stmt.setString(2, viewName);
+  }
+
+  /**
+   * Obtains a JDBC connection routed to the given database/schema.
+   *
+   * @param databaseName The target database or schema.
+   * @return A connection routed to the given database.
+   * @throws SQLException If a connection cannot be obtained.
+   */
+  protected Connection getConnection(String databaseName) throws SQLException {
+    Connection connection = dataSource.getConnection();
+    connection.setCatalog(databaseName);
+    return connection;
+  }
+
+  /**
+   * Quotes an identifier according to the database's quoting convention.
+   *
+   * @param identifier The identifier to quote.
+   * @return The quoted identifier.
+   */
+  protected abstract String quoteIdentifier(String identifier);
+
+  private String loadViewDefinition(Connection connection, String databaseName, String viewName)
+      throws SQLException, NoSuchViewException {
+    String sql = generateLoadViewSql();
+    try (PreparedStatement stmt = connection.prepareStatement(sql)) {
+      bindLoadViewParameters(stmt, databaseName, viewName);
+      try (ResultSet rs = stmt.executeQuery()) {
+        if (rs.next()) {
+          return rs.getString(1);
+        }
+        throw new NoSuchViewException("View %s does not exist in %s", viewName, databaseName);
+      }
+    }
+  }
+
+  private Column[] discoverColumns(Connection connection, String viewName) throws SQLException {
+    String quotedView = quoteIdentifier(viewName);
+    String sql = "SELECT * FROM " + quotedView + " WHERE 1=0";
+    try (Statement stmt = connection.createStatement();
+        ResultSet rs = stmt.executeQuery(sql)) {
+      ResultSetMetaData metaData = rs.getMetaData();
+      int columnCount = metaData.getColumnCount();
+      Column[] columns = new Column[columnCount];
+      for (int i = 1; i <= columnCount; i++) {
+        String colName = metaData.getColumnName(i);
+        String typeName = metaData.getColumnTypeName(i);
+        int precision = metaData.getPrecision(i);
+        boolean nullable = metaData.isNullable(i) != ResultSetMetaData.columnNoNulls;
+
+        int scale = metaData.getScale(i);
+
+        JdbcTypeConverter.JdbcTypeBean typeBean = new JdbcTypeConverter.JdbcTypeBean(typeName);
+        typeBean.setColumnSize(precision);
+        typeBean.setScale(scale);
+
+        columns[i - 1] =
+            JdbcColumn.builder()
+                .withName(colName)
+                .withType(typeConverter.toGravitino(typeBean))
+                .withNullable(nullable)
+                .build();
+      }
+      return columns;
+    }
+  }
+}

--- a/catalogs/catalog-jdbc-common/src/main/java/org/apache/gravitino/catalog/jdbc/operation/JdbcViewOperations.java
+++ b/catalogs/catalog-jdbc-common/src/main/java/org/apache/gravitino/catalog/jdbc/operation/JdbcViewOperations.java
@@ -101,12 +101,14 @@ public abstract class JdbcViewOperations {
       Preconditions.checkNotNull(
           viewDefinition, "View definition is null for view %s in %s", viewName, databaseName);
       Column[] columns = discoverColumns(connection, viewName);
+      String comment = loadComment(connection, databaseName, viewName);
 
       SQLRepresentation rep =
           SQLRepresentation.builder().withDialect(dialectName()).withSql(viewDefinition).build();
 
       return JdbcView.builder()
           .withName(viewName)
+          .withComment(comment)
           .withColumns(columns)
           .withRepresentations(new SQLRepresentation[] {rep})
           .withProperties(ImmutableMap.of())
@@ -188,6 +190,22 @@ public abstract class JdbcViewOperations {
    * @return The quoted identifier.
    */
   protected abstract String quoteIdentifier(String identifier);
+
+  /**
+   * Loads the comment for a view from the database. The default implementation returns {@code null}
+   * for databases that do not support view comments (e.g., MySQL). Subclasses should override this
+   * to read comments from the backend (e.g., PostgreSQL's {@code pg_description}).
+   *
+   * @param connection The JDBC connection.
+   * @param databaseName The database or schema name.
+   * @param viewName The view name.
+   * @return The view comment, or {@code null} if not available.
+   * @throws SQLException If the comment cannot be loaded.
+   */
+  protected String loadComment(Connection connection, String databaseName, String viewName)
+      throws SQLException {
+    return null;
+  }
 
   private String loadViewDefinition(Connection connection, String databaseName, String viewName)
       throws SQLException, NoSuchViewException {

--- a/catalogs/catalog-jdbc-common/src/test/java/org/apache/gravitino/catalog/jdbc/TestJdbcViewCatalogOperations.java
+++ b/catalogs/catalog-jdbc-common/src/test/java/org/apache/gravitino/catalog/jdbc/TestJdbcViewCatalogOperations.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog.jdbc;
+
+import com.google.common.collect.ImmutableMap;
+import java.sql.Connection;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.Namespace;
+import org.apache.gravitino.catalog.jdbc.operation.JdbcViewOperations;
+import org.apache.gravitino.exceptions.NoSuchSchemaException;
+import org.apache.gravitino.exceptions.NoSuchViewException;
+import org.apache.gravitino.rel.Column;
+import org.apache.gravitino.rel.SQLRepresentation;
+import org.apache.gravitino.rel.View;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/** Tests for {@link JdbcViewCatalogOperations}. */
+public class TestJdbcViewCatalogOperations {
+
+  private StubViewOperations stubViewOps;
+  private JdbcViewCatalogOperations catalogOps;
+
+  @BeforeEach
+  void setUp() {
+    stubViewOps = new StubViewOperations();
+    catalogOps = new JdbcViewCatalogOperations(stubViewOps, schema -> "existing_db".equals(schema));
+  }
+
+  @Test
+  public void testListViewsInExistingSchema() {
+    stubViewOps.addView("existing_db", "v1", "SELECT 1");
+    stubViewOps.addView("existing_db", "v2", "SELECT 2");
+
+    NameIdentifier[] result = catalogOps.listViews(Namespace.of("existing_db"));
+
+    Assertions.assertEquals(2, result.length);
+    List<String> names =
+        Arrays.stream(result).map(NameIdentifier::name).sorted().collect(Collectors.toList());
+    Assertions.assertEquals(Arrays.asList("v1", "v2"), names);
+  }
+
+  @Test
+  public void testListViewsInNonExistentSchema() {
+    Assertions.assertThrows(
+        NoSuchSchemaException.class, () -> catalogOps.listViews(Namespace.of("no_such_db")));
+  }
+
+  @Test
+  public void testLoadView() {
+    stubViewOps.addView("existing_db", "my_view", "SELECT id FROM users");
+
+    View loaded = catalogOps.loadView(NameIdentifier.of(Namespace.of("existing_db"), "my_view"));
+
+    Assertions.assertEquals("my_view", loaded.name());
+    Assertions.assertEquals(1, loaded.representations().length);
+  }
+
+  @Test
+  public void testLoadNonExistentView() {
+    Assertions.assertThrows(
+        NoSuchViewException.class,
+        () -> catalogOps.loadView(NameIdentifier.of(Namespace.of("existing_db"), "no_view")));
+  }
+
+  @Test
+  public void testViewExists() {
+    stubViewOps.addView("existing_db", "v1", "SELECT 1");
+
+    Assertions.assertTrue(
+        catalogOps.viewExists(NameIdentifier.of(Namespace.of("existing_db"), "v1")));
+  }
+
+  @Test
+  public void testViewDoesNotExist() {
+    Assertions.assertFalse(
+        catalogOps.viewExists(NameIdentifier.of(Namespace.of("existing_db"), "no_view")));
+  }
+
+  @Test
+  public void testJdbcViewPropertiesNeverNull() {
+    JdbcView view =
+        JdbcView.builder()
+            .withName("v")
+            .withRepresentations(
+                new SQLRepresentation[] {
+                  SQLRepresentation.builder().withDialect("test").withSql("SELECT 1").build()
+                })
+            .build();
+    Assertions.assertNotNull(view.properties(), "properties() must not return null");
+  }
+
+  /** In-memory stub of {@link JdbcViewOperations} for testing without a real database. */
+  private static class StubViewOperations extends JdbcViewOperations {
+
+    final Map<String, Map<String, String>> views = new HashMap<>();
+
+    void addView(String db, String viewName, String sql) {
+      views.computeIfAbsent(db, k -> new HashMap<>()).put(viewName, sql);
+    }
+
+    @Override
+    public List<String> listViews(String databaseName) {
+      Map<String, String> dbViews = views.getOrDefault(databaseName, new HashMap<>());
+      return new ArrayList<>(dbViews.keySet());
+    }
+
+    @Override
+    public JdbcView load(String databaseName, String viewName) throws NoSuchViewException {
+      Map<String, String> dbViews = views.get(databaseName);
+      if (dbViews == null || !dbViews.containsKey(viewName)) {
+        throw new NoSuchViewException("View %s not found in %s", viewName, databaseName);
+      }
+      SQLRepresentation rep =
+          SQLRepresentation.builder()
+              .withDialect(dialectName())
+              .withSql(dbViews.get(viewName))
+              .build();
+      return JdbcView.builder()
+          .withName(viewName)
+          .withColumns(new Column[0])
+          .withRepresentations(new SQLRepresentation[] {rep})
+          .withProperties(ImmutableMap.of())
+          .build();
+    }
+
+    @Override
+    public String dialectName() {
+      return "stub";
+    }
+
+    @Override
+    protected String generateListViewsSql() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected String generateLoadViewSql() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected String quoteIdentifier(String identifier) {
+      return "\"" + identifier + "\"";
+    }
+
+    @Override
+    protected Connection getConnection(String databaseName) {
+      throw new UnsupportedOperationException();
+    }
+  }
+}

--- a/catalogs/catalog-jdbc-common/src/test/java/org/apache/gravitino/catalog/jdbc/TestJdbcViewCatalogOperations.java
+++ b/catalogs/catalog-jdbc-common/src/test/java/org/apache/gravitino/catalog/jdbc/TestJdbcViewCatalogOperations.java
@@ -306,6 +306,25 @@ public class TestJdbcViewCatalogOperations {
     Assertions.assertEquals("SELECT id FROM t", stubViewOps.views.get("existing_db").get("v2"));
   }
 
+  @Test
+  public void testAlterViewReplaceAndRename() {
+    stubViewOps.addView("existing_db", "v1", "SELECT 1");
+
+    Column[] cols = new Column[] {Column.of("id", Types.IntegerType.get(), "id")};
+    SQLRepresentation newRep =
+        SQLRepresentation.builder().withDialect("stub").withSql("SELECT id FROM t").build();
+
+    View result =
+        catalogOps.alterView(
+            NameIdentifier.of(Namespace.of("existing_db"), "v1"),
+            ViewChange.replaceView(cols, new Representation[] {newRep}, null, null, null),
+            ViewChange.rename("v2"));
+
+    Assertions.assertEquals("v2", result.name());
+    Assertions.assertFalse(stubViewOps.views.get("existing_db").containsKey("v1"));
+    Assertions.assertEquals("SELECT id FROM t", stubViewOps.views.get("existing_db").get("v2"));
+  }
+
   /** In-memory stub of {@link JdbcViewOperations} for testing without a real database. */
   private static class StubViewOperations extends JdbcViewOperations {
 

--- a/catalogs/catalog-jdbc-common/src/test/java/org/apache/gravitino/catalog/jdbc/TestJdbcViewCatalogOperations.java
+++ b/catalogs/catalog-jdbc-common/src/test/java/org/apache/gravitino/catalog/jdbc/TestJdbcViewCatalogOperations.java
@@ -31,9 +31,13 @@ import org.apache.gravitino.Namespace;
 import org.apache.gravitino.catalog.jdbc.operation.JdbcViewOperations;
 import org.apache.gravitino.exceptions.NoSuchSchemaException;
 import org.apache.gravitino.exceptions.NoSuchViewException;
+import org.apache.gravitino.exceptions.ViewAlreadyExistsException;
 import org.apache.gravitino.rel.Column;
+import org.apache.gravitino.rel.Representation;
 import org.apache.gravitino.rel.SQLRepresentation;
 import org.apache.gravitino.rel.View;
+import org.apache.gravitino.rel.ViewChange;
+import org.apache.gravitino.rel.types.Types;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -87,6 +91,105 @@ public class TestJdbcViewCatalogOperations {
   }
 
   @Test
+  public void testCreateViewInNonExistentSchema() {
+    NameIdentifier ident = NameIdentifier.of(Namespace.of("no_such_db"), "v1");
+    SQLRepresentation rep =
+        SQLRepresentation.builder().withDialect("stub").withSql("SELECT 1").build();
+
+    Assertions.assertThrows(
+        NoSuchSchemaException.class,
+        () ->
+            catalogOps.createView(
+                ident, "comment", new Column[0], new Representation[] {rep}, null, null, null));
+    Assertions.assertTrue(stubViewOps.created.isEmpty());
+  }
+
+  @Test
+  public void testCreateViewWithNoRepresentations() {
+    NameIdentifier ident = NameIdentifier.of(Namespace.of("existing_db"), "v1");
+
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            catalogOps.createView(
+                ident, "comment", new Column[0], new Representation[0], null, null, null));
+  }
+
+  @Test
+  public void testCreateViewWithNullRepresentations() {
+    NameIdentifier ident = NameIdentifier.of(Namespace.of("existing_db"), "v1");
+
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> catalogOps.createView(ident, "comment", new Column[0], null, null, null, null));
+  }
+
+  @Test
+  public void testAlterViewSetPropertyThrows() {
+    NameIdentifier ident = NameIdentifier.of(Namespace.of("existing_db"), "v1");
+
+    Assertions.assertThrows(
+        UnsupportedOperationException.class,
+        () -> catalogOps.alterView(ident, ViewChange.setProperty("key", "value")));
+  }
+
+  @Test
+  public void testAlterViewRemovePropertyThrows() {
+    NameIdentifier ident = NameIdentifier.of(Namespace.of("existing_db"), "v1");
+
+    Assertions.assertThrows(
+        UnsupportedOperationException.class,
+        () -> catalogOps.alterView(ident, ViewChange.removeProperty("key")));
+  }
+
+  @Test
+  public void testAlterViewRename() {
+    stubViewOps.addView("existing_db", "old_view", "SELECT 1");
+
+    View result =
+        catalogOps.alterView(
+            NameIdentifier.of(Namespace.of("existing_db"), "old_view"),
+            ViewChange.rename("new_view"));
+
+    Assertions.assertEquals("new_view", result.name());
+    Assertions.assertFalse(stubViewOps.views.get("existing_db").containsKey("old_view"));
+    Assertions.assertTrue(stubViewOps.views.get("existing_db").containsKey("new_view"));
+  }
+
+  @Test
+  public void testAlterViewReplace() {
+    stubViewOps.addView("existing_db", "v1", "SELECT 1");
+
+    Column[] newColumns = new Column[] {Column.of("id", Types.IntegerType.get(), "id column")};
+    SQLRepresentation newRep =
+        SQLRepresentation.builder().withDialect("stub").withSql("SELECT id FROM t").build();
+
+    View result =
+        catalogOps.alterView(
+            NameIdentifier.of(Namespace.of("existing_db"), "v1"),
+            ViewChange.replaceView(
+                newColumns, new Representation[] {newRep}, null, null, "new comment"));
+
+    Assertions.assertEquals("v1", result.name());
+    Assertions.assertEquals("SELECT id FROM t", stubViewOps.views.get("existing_db").get("v1"));
+  }
+
+  @Test
+  public void testDropView() {
+    stubViewOps.addView("existing_db", "v1", "SELECT 1");
+
+    Assertions.assertTrue(
+        catalogOps.dropView(NameIdentifier.of(Namespace.of("existing_db"), "v1")));
+    Assertions.assertFalse(stubViewOps.views.get("existing_db").containsKey("v1"));
+  }
+
+  @Test
+  public void testDropNonExistentView() {
+    Assertions.assertFalse(
+        catalogOps.dropView(NameIdentifier.of(Namespace.of("existing_db"), "no_view")));
+  }
+
+  @Test
   public void testViewExists() {
     stubViewOps.addView("existing_db", "v1", "SELECT 1");
 
@@ -98,6 +201,64 @@ public class TestJdbcViewCatalogOperations {
   public void testViewDoesNotExist() {
     Assertions.assertFalse(
         catalogOps.viewExists(NameIdentifier.of(Namespace.of("existing_db"), "no_view")));
+  }
+
+  @Test
+  public void testCreateViewDelegatesCorrectSql() {
+    NameIdentifier ident = NameIdentifier.of(Namespace.of("existing_db"), "v1");
+    SQLRepresentation rep =
+        SQLRepresentation.builder()
+            .withDialect("stub")
+            .withSql("SELECT id, name FROM users")
+            .build();
+
+    catalogOps.createView(
+        ident, "test comment", new Column[0], new Representation[] {rep}, null, null, null);
+
+    Assertions.assertEquals(1, stubViewOps.created.size());
+    Assertions.assertEquals("SELECT id, name FROM users", stubViewOps.created.get(0).sql);
+    Assertions.assertEquals("test comment", stubViewOps.created.get(0).comment);
+    Assertions.assertEquals("v1", stubViewOps.created.get(0).viewName);
+  }
+
+  @Test
+  public void testAlterViewRejectsUnsupportedChangesBeforeApplyingOthers() {
+    stubViewOps.addView("existing_db", "v1", "SELECT 1");
+
+    Assertions.assertThrows(
+        UnsupportedOperationException.class,
+        () ->
+            catalogOps.alterView(
+                NameIdentifier.of(Namespace.of("existing_db"), "v1"),
+                ViewChange.rename("v2"),
+                ViewChange.setProperty("key", "value")));
+
+    Assertions.assertTrue(
+        stubViewOps.views.get("existing_db").containsKey("v1"),
+        "View should NOT have been renamed when a later change is unsupported");
+    Assertions.assertFalse(
+        stubViewOps.views.get("existing_db").containsKey("v2"),
+        "Renamed view should not exist when the batch was rejected");
+  }
+
+  @Test
+  public void testCreateViewReturnsDefaultCatalogAndSchema() {
+    NameIdentifier ident = NameIdentifier.of(Namespace.of("existing_db"), "v1");
+    SQLRepresentation rep =
+        SQLRepresentation.builder().withDialect("stub").withSql("SELECT 1").build();
+
+    View created =
+        catalogOps.createView(
+            ident,
+            null,
+            new Column[0],
+            new Representation[] {rep},
+            "my_catalog",
+            "my_schema",
+            null);
+
+    Assertions.assertEquals("my_catalog", created.defaultCatalog());
+    Assertions.assertEquals("my_schema", created.defaultSchema());
   }
 
   @Test
@@ -113,10 +274,43 @@ public class TestJdbcViewCatalogOperations {
     Assertions.assertNotNull(view.properties(), "properties() must not return null");
   }
 
+  @Test
+  public void testCreateViewReturnsComment() {
+    NameIdentifier ident = NameIdentifier.of(Namespace.of("existing_db"), "v1");
+    SQLRepresentation rep =
+        SQLRepresentation.builder().withDialect("stub").withSql("SELECT 1").build();
+
+    View created =
+        catalogOps.createView(
+            ident, "my comment", new Column[0], new Representation[] {rep}, null, null, null);
+
+    Assertions.assertEquals("my comment", created.comment());
+  }
+
+  @Test
+  public void testAlterViewRenameAndReplace() {
+    stubViewOps.addView("existing_db", "v1", "SELECT 1");
+
+    Column[] cols = new Column[] {Column.of("id", Types.IntegerType.get(), "id")};
+    SQLRepresentation newRep =
+        SQLRepresentation.builder().withDialect("stub").withSql("SELECT id FROM t").build();
+
+    View result =
+        catalogOps.alterView(
+            NameIdentifier.of(Namespace.of("existing_db"), "v1"),
+            ViewChange.rename("v2"),
+            ViewChange.replaceView(cols, new Representation[] {newRep}, null, null, null));
+
+    Assertions.assertEquals("v2", result.name());
+    Assertions.assertFalse(stubViewOps.views.get("existing_db").containsKey("v1"));
+    Assertions.assertEquals("SELECT id FROM t", stubViewOps.views.get("existing_db").get("v2"));
+  }
+
   /** In-memory stub of {@link JdbcViewOperations} for testing without a real database. */
   private static class StubViewOperations extends JdbcViewOperations {
 
     final Map<String, Map<String, String>> views = new HashMap<>();
+    final List<CreateRecord> created = new ArrayList<>();
 
     void addView(String db, String viewName, String sql) {
       views.computeIfAbsent(db, k -> new HashMap<>()).put(viewName, sql);
@@ -148,6 +342,43 @@ public class TestJdbcViewCatalogOperations {
     }
 
     @Override
+    public void create(String databaseName, String viewName, String comment, String sql)
+        throws ViewAlreadyExistsException {
+      created.add(new CreateRecord(databaseName, viewName, comment, sql));
+      addView(databaseName, viewName, sql);
+    }
+
+    @Override
+    public void replaceDefinition(String databaseName, String viewName, String comment, String sql)
+        throws NoSuchViewException {
+      Map<String, String> dbViews = views.get(databaseName);
+      if (dbViews == null || !dbViews.containsKey(viewName)) {
+        throw new NoSuchViewException("View %s not found", viewName);
+      }
+      dbViews.put(viewName, sql);
+    }
+
+    @Override
+    public void rename(String databaseName, String oldName, String newName)
+        throws NoSuchViewException {
+      Map<String, String> dbViews = views.get(databaseName);
+      if (dbViews == null || !dbViews.containsKey(oldName)) {
+        throw new NoSuchViewException("View %s not found", oldName);
+      }
+      String sql = dbViews.remove(oldName);
+      dbViews.put(newName, sql);
+    }
+
+    @Override
+    public boolean drop(String databaseName, String viewName) {
+      Map<String, String> dbViews = views.get(databaseName);
+      if (dbViews == null) {
+        return false;
+      }
+      return dbViews.remove(viewName) != null;
+    }
+
+    @Override
     public String dialectName() {
       return "stub";
     }
@@ -163,6 +394,26 @@ public class TestJdbcViewCatalogOperations {
     }
 
     @Override
+    protected String generateCreateViewSql(String viewName, String sql) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected String generateReplaceViewSql(String viewName, String sql) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected String generateRenameViewSql(String oldName, String newName) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected String generateDropViewSql(String viewName) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
     protected String quoteIdentifier(String identifier) {
       return "\"" + identifier + "\"";
     }
@@ -170,6 +421,20 @@ public class TestJdbcViewCatalogOperations {
     @Override
     protected Connection getConnection(String databaseName) {
       throw new UnsupportedOperationException();
+    }
+
+    static class CreateRecord {
+      final String databaseName;
+      final String viewName;
+      final String comment;
+      final String sql;
+
+      CreateRecord(String databaseName, String viewName, String comment, String sql) {
+        this.databaseName = databaseName;
+        this.viewName = viewName;
+        this.comment = comment;
+        this.sql = sql;
+      }
     }
   }
 }

--- a/catalogs/catalog-jdbc-common/src/test/java/org/apache/gravitino/catalog/jdbc/operation/SqliteViewOperations.java
+++ b/catalogs/catalog-jdbc-common/src/test/java/org/apache/gravitino/catalog/jdbc/operation/SqliteViewOperations.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog.jdbc.operation;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+/** SQLite-specific implementation of JDBC view operations for testing template methods. */
+public class SqliteViewOperations extends JdbcViewOperations {
+
+  @Override
+  public String dialectName() {
+    return "sqlite";
+  }
+
+  @Override
+  protected String quoteIdentifier(String identifier) {
+    return "\"" + identifier.replace("\"", "\"\"") + "\"";
+  }
+
+  @Override
+  protected String generateListViewsSql() {
+    return "SELECT name FROM sqlite_master WHERE type = 'view' AND name NOT LIKE 'sqlite_%'";
+  }
+
+  @Override
+  protected void bindListViewsParameters(PreparedStatement stmt, String databaseName)
+      throws SQLException {
+    // SQLite list-views query has no parameters
+  }
+
+  @Override
+  protected String generateLoadViewSql() {
+    return "SELECT sql FROM sqlite_master WHERE type = 'view' AND name = ?";
+  }
+
+  @Override
+  protected void bindLoadViewParameters(
+      PreparedStatement stmt, String databaseName, String viewName) throws SQLException {
+    stmt.setString(1, viewName);
+  }
+
+  @Override
+  protected Connection getConnection(String databaseName) throws SQLException {
+    return dataSource.getConnection();
+  }
+}

--- a/catalogs/catalog-jdbc-common/src/test/java/org/apache/gravitino/catalog/jdbc/operation/SqliteViewOperations.java
+++ b/catalogs/catalog-jdbc-common/src/test/java/org/apache/gravitino/catalog/jdbc/operation/SqliteViewOperations.java
@@ -58,6 +58,26 @@ public class SqliteViewOperations extends JdbcViewOperations {
   }
 
   @Override
+  protected String generateCreateViewSql(String viewName, String sql) {
+    return "CREATE VIEW " + quoteIdentifier(viewName) + " AS " + sql;
+  }
+
+  @Override
+  protected String generateReplaceViewSql(String viewName, String sql) {
+    return "CREATE VIEW " + quoteIdentifier(viewName) + " AS " + sql;
+  }
+
+  @Override
+  protected String generateRenameViewSql(String oldName, String newName) {
+    return "ALTER TABLE " + quoteIdentifier(oldName) + " RENAME TO " + quoteIdentifier(newName);
+  }
+
+  @Override
+  protected String generateDropViewSql(String viewName) {
+    return "DROP VIEW " + quoteIdentifier(viewName);
+  }
+
+  @Override
   protected Connection getConnection(String databaseName) throws SQLException {
     return dataSource.getConnection();
   }

--- a/catalogs/catalog-jdbc-common/src/test/java/org/apache/gravitino/catalog/jdbc/operation/TestJdbcViewOperations.java
+++ b/catalogs/catalog-jdbc-common/src/test/java/org/apache/gravitino/catalog/jdbc/operation/TestJdbcViewOperations.java
@@ -77,6 +77,7 @@ public class TestJdbcViewOperations {
       stmt.execute("DROP VIEW IF EXISTS \"test_view\"");
       stmt.execute("DROP VIEW IF EXISTS \"view_a\"");
       stmt.execute("DROP VIEW IF EXISTS \"view_b\"");
+      stmt.execute("DROP VIEW IF EXISTS \"created_view\"");
       stmt.execute("DROP TABLE IF EXISTS \"base_table\"");
       stmt.execute("CREATE TABLE base_table (id INTEGER, name TEXT)");
     }
@@ -130,6 +131,28 @@ public class TestJdbcViewOperations {
     for (Column col : view.columns()) {
       Assertions.assertNotNull(col.dataType());
     }
+  }
+
+  @Test
+  public void testCreateAndLoad() {
+    viewOps.create("main", "created_view", null, "SELECT id FROM base_table");
+
+    JdbcView view = viewOps.load("main", "created_view");
+    Assertions.assertEquals("created_view", view.name());
+    Assertions.assertEquals(1, view.columns().length);
+    Assertions.assertEquals("id", view.columns()[0].name());
+  }
+
+  @Test
+  public void testDropExistingViewReturnsTrue() throws SQLException {
+    createRawView("test_view", "SELECT 1");
+    Assertions.assertTrue(viewOps.drop("main", "test_view"));
+    Assertions.assertThrows(NoSuchViewException.class, () -> viewOps.load("main", "test_view"));
+  }
+
+  @Test
+  public void testDropNonExistentViewReturnsFalse() {
+    Assertions.assertFalse(viewOps.drop("main", "no_such_view"));
   }
 
   private void createRawView(String name, String sql) throws SQLException {

--- a/catalogs/catalog-jdbc-common/src/test/java/org/apache/gravitino/catalog/jdbc/operation/TestJdbcViewOperations.java
+++ b/catalogs/catalog-jdbc-common/src/test/java/org/apache/gravitino/catalog/jdbc/operation/TestJdbcViewOperations.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog.jdbc.operation;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Collections;
+import java.util.List;
+import org.apache.commons.dbcp2.BasicDataSource;
+import org.apache.gravitino.catalog.jdbc.JdbcView;
+import org.apache.gravitino.catalog.jdbc.converter.SqliteExceptionConverter;
+import org.apache.gravitino.catalog.jdbc.converter.SqliteTypeConverter;
+import org.apache.gravitino.exceptions.NoSuchViewException;
+import org.apache.gravitino.rel.Column;
+import org.apache.gravitino.rel.SQLRepresentation;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+
+/**
+ * Tests the template methods in {@link JdbcViewOperations} against an in-memory SQLite database.
+ */
+@TestInstance(Lifecycle.PER_CLASS)
+public class TestJdbcViewOperations {
+
+  private SqliteViewOperations viewOps;
+  private BasicDataSource dataSource;
+
+  @BeforeAll
+  void startDb() {
+    dataSource = new BasicDataSource();
+    dataSource.setUrl("jdbc:sqlite::memory:");
+    dataSource.setMaxTotal(1);
+    dataSource.setMinIdle(1);
+    dataSource.setMaxIdle(1);
+
+    viewOps = new SqliteViewOperations();
+    viewOps.initialize(
+        dataSource,
+        new SqliteExceptionConverter(),
+        new SqliteTypeConverter(),
+        Collections.emptyMap());
+  }
+
+  @AfterAll
+  void stopDb() throws Exception {
+    if (dataSource != null) {
+      dataSource.close();
+    }
+  }
+
+  @BeforeEach
+  void resetViews() throws SQLException {
+    try (Connection conn = dataSource.getConnection();
+        Statement stmt = conn.createStatement()) {
+      stmt.execute("DROP VIEW IF EXISTS \"test_view\"");
+      stmt.execute("DROP VIEW IF EXISTS \"view_a\"");
+      stmt.execute("DROP VIEW IF EXISTS \"view_b\"");
+      stmt.execute("DROP TABLE IF EXISTS \"base_table\"");
+      stmt.execute("CREATE TABLE base_table (id INTEGER, name TEXT)");
+    }
+  }
+
+  @Test
+  public void testListViewsEmpty() {
+    List<String> views = viewOps.listViews("main");
+    Assertions.assertTrue(views.isEmpty());
+  }
+
+  @Test
+  public void testListViewsFindsCreatedViews() throws SQLException {
+    createRawView("view_a", "SELECT id FROM base_table");
+    createRawView("view_b", "SELECT name FROM base_table");
+
+    List<String> views = viewOps.listViews("main");
+    Assertions.assertEquals(2, views.size());
+    Assertions.assertTrue(views.contains("view_a"));
+    Assertions.assertTrue(views.contains("view_b"));
+  }
+
+  @Test
+  public void testLoadViewReturnsColumnsAndRepresentation() throws SQLException {
+    createRawView("test_view", "SELECT id, name FROM base_table");
+
+    JdbcView view = viewOps.load("main", "test_view");
+    Assertions.assertEquals("test_view", view.name());
+
+    Column[] columns = view.columns();
+    Assertions.assertEquals(2, columns.length);
+    Assertions.assertEquals("id", columns[0].name());
+    Assertions.assertEquals("name", columns[1].name());
+
+    Assertions.assertEquals(1, view.representations().length);
+    SQLRepresentation rep = (SQLRepresentation) view.representations()[0];
+    Assertions.assertEquals("sqlite", rep.dialect());
+    Assertions.assertFalse(rep.sql().isEmpty());
+  }
+
+  @Test
+  public void testLoadNonExistentViewThrows() {
+    Assertions.assertThrows(NoSuchViewException.class, () -> viewOps.load("main", "no_such_view"));
+  }
+
+  @Test
+  public void testDiscoverColumnsTypes() throws SQLException {
+    createRawView("test_view", "SELECT id, name FROM base_table");
+
+    JdbcView view = viewOps.load("main", "test_view");
+    for (Column col : view.columns()) {
+      Assertions.assertNotNull(col.dataType());
+    }
+  }
+
+  private void createRawView(String name, String sql) throws SQLException {
+    try (Connection conn = dataSource.getConnection();
+        Statement stmt = conn.createStatement()) {
+      stmt.execute("CREATE VIEW \"" + name + "\" AS " + sql);
+    }
+  }
+}

--- a/catalogs/catalog-jdbc-mysql/src/main/java/org/apache/gravitino/catalog/mysql/MysqlCatalog.java
+++ b/catalogs/catalog-jdbc-mysql/src/main/java/org/apache/gravitino/catalog/mysql/MysqlCatalog.java
@@ -20,7 +20,6 @@ package org.apache.gravitino.catalog.mysql;
 
 import java.util.Map;
 import org.apache.gravitino.catalog.jdbc.JdbcCatalog;
-import org.apache.gravitino.catalog.jdbc.MySQLProtocolCompatibleCatalogOperations;
 import org.apache.gravitino.catalog.jdbc.converter.JdbcColumnDefaultValueConverter;
 import org.apache.gravitino.catalog.jdbc.converter.JdbcTypeConverter;
 import org.apache.gravitino.catalog.jdbc.operation.JdbcDatabaseOperations;
@@ -29,6 +28,7 @@ import org.apache.gravitino.catalog.mysql.converter.MysqlColumnDefaultValueConve
 import org.apache.gravitino.catalog.mysql.converter.MysqlTypeConverter;
 import org.apache.gravitino.catalog.mysql.operation.MysqlDatabaseOperations;
 import org.apache.gravitino.catalog.mysql.operation.MysqlTableOperations;
+import org.apache.gravitino.catalog.mysql.operation.MysqlViewOperations;
 import org.apache.gravitino.connector.CatalogOperations;
 import org.apache.gravitino.connector.PropertiesMetadata;
 import org.apache.gravitino.connector.capability.Capability;
@@ -47,12 +47,13 @@ public class MysqlCatalog extends JdbcCatalog {
   @Override
   protected CatalogOperations newOps(Map<String, String> config) {
     JdbcTypeConverter jdbcTypeConverter = createJdbcTypeConverter();
-    return new MySQLProtocolCompatibleCatalogOperations(
+    return new MysqlCatalogOperations(
         createExceptionConverter(),
         jdbcTypeConverter,
         createJdbcDatabaseOperations(),
         createJdbcTableOperations(),
-        createJdbcColumnDefaultValueConverter());
+        createJdbcColumnDefaultValueConverter(),
+        new MysqlViewOperations());
   }
 
   @Override

--- a/catalogs/catalog-jdbc-mysql/src/main/java/org/apache/gravitino/catalog/mysql/MysqlCatalogOperations.java
+++ b/catalogs/catalog-jdbc-mysql/src/main/java/org/apache/gravitino/catalog/mysql/MysqlCatalogOperations.java
@@ -16,16 +16,13 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.gravitino.catalog.postgresql;
+package org.apache.gravitino.catalog.mysql;
 
-import java.sql.Driver;
-import java.sql.DriverManager;
-import java.sql.SQLException;
 import java.util.Map;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
-import org.apache.gravitino.catalog.jdbc.JdbcCatalogOperations;
 import org.apache.gravitino.catalog.jdbc.JdbcViewCatalogOperations;
+import org.apache.gravitino.catalog.jdbc.MySQLProtocolCompatibleCatalogOperations;
 import org.apache.gravitino.catalog.jdbc.converter.JdbcColumnDefaultValueConverter;
 import org.apache.gravitino.catalog.jdbc.converter.JdbcExceptionConverter;
 import org.apache.gravitino.catalog.jdbc.converter.JdbcTypeConverter;
@@ -39,14 +36,15 @@ import org.apache.gravitino.exceptions.NoSuchViewException;
 import org.apache.gravitino.rel.View;
 import org.apache.gravitino.rel.ViewCatalog;
 
-/** PostgreSQL-specific catalog operations with view support. */
-public class PostgreSQLCatalogOperations extends JdbcCatalogOperations implements ViewCatalog {
+/** MySQL-specific catalog operations with view support. */
+public class MysqlCatalogOperations extends MySQLProtocolCompatibleCatalogOperations
+    implements ViewCatalog {
 
   private final JdbcViewOperations viewOperations;
   private JdbcViewCatalogOperations viewCatalogOps;
 
   /**
-   * Constructs a new instance of PostgreSQLCatalogOperations.
+   * Constructs a new instance of MysqlCatalogOperations.
    *
    * @param exceptionConverter The exception converter.
    * @param jdbcTypeConverter The type converter.
@@ -55,7 +53,7 @@ public class PostgreSQLCatalogOperations extends JdbcCatalogOperations implement
    * @param columnDefaultValueConverter The column default value converter.
    * @param viewOperations The view operations.
    */
-  public PostgreSQLCatalogOperations(
+  public MysqlCatalogOperations(
       JdbcExceptionConverter exceptionConverter,
       JdbcTypeConverter jdbcTypeConverter,
       JdbcDatabaseOperations databaseOperation,
@@ -79,11 +77,6 @@ public class PostgreSQLCatalogOperations extends JdbcCatalogOperations implement
     viewOperations.initialize(
         getDataSource(), getExceptionConverter(), getJdbcTypeConverter(), conf);
     this.viewCatalogOps = new JdbcViewCatalogOperations(viewOperations, this::schemaExists);
-  }
-
-  @Override
-  protected Driver getDriver() throws SQLException {
-    return DriverManager.getDriver("jdbc:postgresql://dummy_address:12345/");
   }
 
   @Override

--- a/catalogs/catalog-jdbc-mysql/src/main/java/org/apache/gravitino/catalog/mysql/MysqlCatalogOperations.java
+++ b/catalogs/catalog-jdbc-mysql/src/main/java/org/apache/gravitino/catalog/mysql/MysqlCatalogOperations.java
@@ -33,8 +33,12 @@ import org.apache.gravitino.connector.CatalogInfo;
 import org.apache.gravitino.connector.HasPropertyMetadata;
 import org.apache.gravitino.exceptions.NoSuchSchemaException;
 import org.apache.gravitino.exceptions.NoSuchViewException;
+import org.apache.gravitino.exceptions.ViewAlreadyExistsException;
+import org.apache.gravitino.rel.Column;
+import org.apache.gravitino.rel.Representation;
 import org.apache.gravitino.rel.View;
 import org.apache.gravitino.rel.ViewCatalog;
+import org.apache.gravitino.rel.ViewChange;
 
 /** MySQL-specific catalog operations with view support. */
 public class MysqlCatalogOperations extends MySQLProtocolCompatibleCatalogOperations
@@ -87,5 +91,30 @@ public class MysqlCatalogOperations extends MySQLProtocolCompatibleCatalogOperat
   @Override
   public View loadView(NameIdentifier ident) throws NoSuchViewException {
     return viewCatalogOps.loadView(ident);
+  }
+
+  @Override
+  public View createView(
+      NameIdentifier ident,
+      String comment,
+      Column[] columns,
+      Representation[] representations,
+      String defaultCatalog,
+      String defaultSchema,
+      Map<String, String> properties)
+      throws NoSuchSchemaException, ViewAlreadyExistsException {
+    return viewCatalogOps.createView(
+        ident, comment, columns, representations, defaultCatalog, defaultSchema, properties);
+  }
+
+  @Override
+  public View alterView(NameIdentifier ident, ViewChange... changes)
+      throws NoSuchViewException, IllegalArgumentException {
+    return viewCatalogOps.alterView(ident, changes);
+  }
+
+  @Override
+  public boolean dropView(NameIdentifier ident) {
+    return viewCatalogOps.dropView(ident);
   }
 }

--- a/catalogs/catalog-jdbc-mysql/src/main/java/org/apache/gravitino/catalog/mysql/operation/MysqlViewOperations.java
+++ b/catalogs/catalog-jdbc-mysql/src/main/java/org/apache/gravitino/catalog/mysql/operation/MysqlViewOperations.java
@@ -44,4 +44,24 @@ public class MysqlViewOperations extends JdbcViewOperations {
     return "SELECT VIEW_DEFINITION FROM information_schema.VIEWS"
         + " WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ?";
   }
+
+  @Override
+  protected String generateCreateViewSql(String viewName, String sql) {
+    return "CREATE VIEW " + quoteIdentifier(viewName) + " AS " + sql;
+  }
+
+  @Override
+  protected String generateReplaceViewSql(String viewName, String sql) {
+    return "CREATE OR REPLACE VIEW " + quoteIdentifier(viewName) + " AS " + sql;
+  }
+
+  @Override
+  protected String generateRenameViewSql(String oldName, String newName) {
+    return "RENAME TABLE " + quoteIdentifier(oldName) + " TO " + quoteIdentifier(newName);
+  }
+
+  @Override
+  protected String generateDropViewSql(String viewName) {
+    return "DROP VIEW " + quoteIdentifier(viewName);
+  }
 }

--- a/catalogs/catalog-jdbc-mysql/src/main/java/org/apache/gravitino/catalog/mysql/operation/MysqlViewOperations.java
+++ b/catalogs/catalog-jdbc-mysql/src/main/java/org/apache/gravitino/catalog/mysql/operation/MysqlViewOperations.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog.mysql.operation;
+
+import org.apache.gravitino.catalog.jdbc.operation.JdbcViewOperations;
+import org.apache.gravitino.rel.Dialects;
+
+/** MySQL-specific implementation of JDBC view operations. */
+public class MysqlViewOperations extends JdbcViewOperations {
+
+  @Override
+  public String dialectName() {
+    return Dialects.MYSQL;
+  }
+
+  @Override
+  protected String quoteIdentifier(String identifier) {
+    return "`" + identifier.replace("`", "``") + "`";
+  }
+
+  @Override
+  protected String generateListViewsSql() {
+    return "SELECT TABLE_NAME FROM information_schema.VIEWS WHERE TABLE_SCHEMA = ?";
+  }
+
+  @Override
+  protected String generateLoadViewSql() {
+    return "SELECT VIEW_DEFINITION FROM information_schema.VIEWS"
+        + " WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ?";
+  }
+}

--- a/catalogs/catalog-jdbc-mysql/src/test/java/org/apache/gravitino/catalog/mysql/integration/test/CatalogMysqlViewReadIT.java
+++ b/catalogs/catalog-jdbc-mysql/src/test/java/org/apache/gravitino/catalog/mysql/integration/test/CatalogMysqlViewReadIT.java
@@ -44,6 +44,7 @@ import org.apache.gravitino.rel.Column;
 import org.apache.gravitino.rel.SQLRepresentation;
 import org.apache.gravitino.rel.View;
 import org.apache.gravitino.rel.ViewCatalog;
+import org.apache.gravitino.rel.types.Types;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -144,9 +145,11 @@ public class CatalogMysqlViewReadIT extends BaseIT {
     Column[] columns = view.columns();
     Assertions.assertEquals(2, columns.length);
     Assertions.assertEquals("id", columns[0].name());
-    Assertions.assertNotNull(columns[0].dataType());
+    Assertions.assertEquals(Types.IntegerType.get(), columns[0].dataType());
     Assertions.assertEquals("name", columns[1].name());
-    Assertions.assertNotNull(columns[1].dataType());
+    Assertions.assertEquals(Types.VarCharType.of(255), columns[1].dataType());
+
+    Assertions.assertNull(view.comment());
 
     Assertions.assertEquals(1, view.representations().length);
     Assertions.assertInstanceOf(SQLRepresentation.class, view.representations()[0]);

--- a/catalogs/catalog-jdbc-mysql/src/test/java/org/apache/gravitino/catalog/mysql/integration/test/CatalogMysqlViewReadIT.java
+++ b/catalogs/catalog-jdbc-mysql/src/test/java/org/apache/gravitino/catalog/mysql/integration/test/CatalogMysqlViewReadIT.java
@@ -1,0 +1,233 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog.mysql.integration.test;
+
+import com.google.common.collect.Maps;
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.gravitino.Catalog;
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.Namespace;
+import org.apache.gravitino.catalog.jdbc.config.JdbcConfig;
+import org.apache.gravitino.catalog.mysql.integration.test.service.MysqlService;
+import org.apache.gravitino.client.GravitinoMetalake;
+import org.apache.gravitino.exceptions.NoSuchSchemaException;
+import org.apache.gravitino.exceptions.NoSuchViewException;
+import org.apache.gravitino.integration.test.container.ContainerSuite;
+import org.apache.gravitino.integration.test.container.MySQLContainer;
+import org.apache.gravitino.integration.test.util.BaseIT;
+import org.apache.gravitino.integration.test.util.GravitinoITUtils;
+import org.apache.gravitino.integration.test.util.TestDatabaseName;
+import org.apache.gravitino.rel.Column;
+import org.apache.gravitino.rel.SQLRepresentation;
+import org.apache.gravitino.rel.View;
+import org.apache.gravitino.rel.ViewCatalog;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+
+/** Integration tests for MySQL view read operations (list/load). */
+@Tag("gravitino-docker-test")
+@TestInstance(Lifecycle.PER_CLASS)
+public class CatalogMysqlViewReadIT extends BaseIT {
+
+  private static final ContainerSuite containerSuite = ContainerSuite.getInstance();
+  private static final String provider = "jdbc-mysql";
+
+  private final String metalakeName = GravitinoITUtils.genRandomName("mysql_view_it_metalake");
+  private final String catalogName = GravitinoITUtils.genRandomName("mysql_view_it_catalog");
+  private final String schemaName = GravitinoITUtils.genRandomName("mysql_view_it_schema");
+
+  private GravitinoMetalake metalake;
+  private Catalog catalog;
+  private MysqlService mysqlService;
+  private MySQLContainer mysqlContainer;
+  private TestDatabaseName testDbName;
+
+  @BeforeAll
+  public void startup() throws IOException, SQLException {
+    testDbName = TestDatabaseName.MYSQL_CATALOG_MYSQL_IT;
+    containerSuite.startMySQLContainer(testDbName);
+    mysqlContainer = containerSuite.getMySQLContainer();
+    mysqlService = new MysqlService(mysqlContainer, testDbName);
+
+    createMetalake();
+    catalog = createCatalog();
+    createSchema();
+    createBaseTableAndViews();
+  }
+
+  @AfterAll
+  public void stop() {
+    cleanupViewsAndTables();
+    catalog.asSchemas().dropSchema(schemaName, false);
+    metalake.disableCatalog(catalogName);
+    metalake.dropCatalog(catalogName);
+    client.disableMetalake(metalakeName);
+    client.dropMetalake(metalakeName);
+    mysqlService.close();
+  }
+
+  @AfterEach
+  public void resetSchema() {
+    cleanupViewsAndTables();
+    catalog.asSchemas().dropSchema(schemaName, false);
+    createSchema();
+    createBaseTableAndViews();
+  }
+
+  @Test
+  public void testListViews() {
+    ViewCatalog viewCatalog = catalog.asViewCatalog();
+    NameIdentifier[] views = viewCatalog.listViews(Namespace.of(schemaName));
+
+    List<String> names =
+        Arrays.stream(views).map(NameIdentifier::name).sorted().collect(Collectors.toList());
+    Assertions.assertEquals(Arrays.asList("test_view_1", "test_view_2"), names);
+  }
+
+  @Test
+  public void testListViewsInEmptySchema() {
+    String emptySchema = GravitinoITUtils.genRandomName("empty_schema");
+    catalog.asSchemas().createSchema(emptySchema, null, Collections.emptyMap());
+    try {
+      NameIdentifier[] views = catalog.asViewCatalog().listViews(Namespace.of(emptySchema));
+      Assertions.assertEquals(0, views.length);
+    } finally {
+      catalog.asSchemas().dropSchema(emptySchema, false);
+    }
+  }
+
+  @Test
+  public void testListViewsInNonExistentSchema() {
+    Assertions.assertThrows(
+        NoSuchSchemaException.class,
+        () -> catalog.asViewCatalog().listViews(Namespace.of("no_such_schema_xyz")));
+  }
+
+  @Test
+  public void testLoadView() {
+    View view =
+        catalog
+            .asViewCatalog()
+            .loadView(NameIdentifier.of(Namespace.of(schemaName), "test_view_1"));
+
+    Assertions.assertEquals("test_view_1", view.name());
+
+    Column[] columns = view.columns();
+    Assertions.assertEquals(2, columns.length);
+    Assertions.assertEquals("id", columns[0].name());
+    Assertions.assertNotNull(columns[0].dataType());
+    Assertions.assertEquals("name", columns[1].name());
+    Assertions.assertNotNull(columns[1].dataType());
+
+    Assertions.assertEquals(1, view.representations().length);
+    Assertions.assertInstanceOf(SQLRepresentation.class, view.representations()[0]);
+    SQLRepresentation rep = (SQLRepresentation) view.representations()[0];
+    Assertions.assertEquals("mysql", rep.dialect());
+    Assertions.assertFalse(rep.sql().isEmpty());
+  }
+
+  @Test
+  public void testLoadNonExistentView() {
+    Assertions.assertThrows(
+        NoSuchViewException.class,
+        () ->
+            catalog
+                .asViewCatalog()
+                .loadView(NameIdentifier.of(Namespace.of(schemaName), "no_such_view")));
+  }
+
+  @Test
+  public void testViewExists() {
+    Assertions.assertTrue(
+        catalog
+            .asViewCatalog()
+            .viewExists(NameIdentifier.of(Namespace.of(schemaName), "test_view_1")));
+  }
+
+  @Test
+  public void testViewDoesNotExist() {
+    Assertions.assertFalse(
+        catalog
+            .asViewCatalog()
+            .viewExists(NameIdentifier.of(Namespace.of(schemaName), "no_such_view")));
+  }
+
+  private void createMetalake() {
+    client.createMetalake(metalakeName, "comment", Collections.emptyMap());
+    metalake = client.loadMetalake(metalakeName);
+  }
+
+  private Catalog createCatalog() throws SQLException {
+    Map<String, String> catalogProperties = Maps.newHashMap();
+    catalogProperties.put(
+        JdbcConfig.JDBC_URL.getKey(),
+        StringUtils.substring(
+                mysqlContainer.getJdbcUrl(testDbName),
+                0,
+                mysqlContainer.getJdbcUrl(testDbName).lastIndexOf("/"))
+            + "?useSSL=false&allowPublicKeyRetrieval=true");
+    catalogProperties.put(
+        JdbcConfig.JDBC_DRIVER.getKey(), mysqlContainer.getDriverClassName(testDbName));
+    catalogProperties.put(JdbcConfig.USERNAME.getKey(), mysqlContainer.getUsername());
+    catalogProperties.put(JdbcConfig.PASSWORD.getKey(), mysqlContainer.getPassword());
+
+    return metalake.createCatalog(
+        catalogName, Catalog.Type.RELATIONAL, provider, "comment", catalogProperties);
+  }
+
+  private void createSchema() {
+    catalog.asSchemas().createSchema(schemaName, null, Collections.emptyMap());
+  }
+
+  private void createBaseTableAndViews() {
+    mysqlService.executeQuery(
+        "CREATE TABLE " + schemaName + ".base_table (id INT, name VARCHAR(255), score DOUBLE)");
+    mysqlService.executeQuery(
+        "CREATE VIEW "
+            + schemaName
+            + ".test_view_1 AS SELECT id, name FROM "
+            + schemaName
+            + ".base_table");
+    mysqlService.executeQuery(
+        "CREATE VIEW "
+            + schemaName
+            + ".test_view_2 AS SELECT id FROM "
+            + schemaName
+            + ".base_table WHERE id > 0");
+  }
+
+  private void cleanupViewsAndTables() {
+    mysqlService.executeQuery("DROP VIEW IF EXISTS " + schemaName + ".test_view_1");
+    mysqlService.executeQuery("DROP VIEW IF EXISTS " + schemaName + ".test_view_2");
+    mysqlService.executeQuery("DROP TABLE IF EXISTS " + schemaName + ".base_table");
+  }
+}

--- a/catalogs/catalog-jdbc-mysql/src/test/java/org/apache/gravitino/catalog/mysql/integration/test/CatalogMysqlViewWriteIT.java
+++ b/catalogs/catalog-jdbc-mysql/src/test/java/org/apache/gravitino/catalog/mysql/integration/test/CatalogMysqlViewWriteIT.java
@@ -1,0 +1,313 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog.mysql.integration.test;
+
+import com.google.common.collect.Maps;
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.gravitino.Catalog;
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.Namespace;
+import org.apache.gravitino.catalog.jdbc.config.JdbcConfig;
+import org.apache.gravitino.catalog.mysql.integration.test.service.MysqlService;
+import org.apache.gravitino.client.GravitinoMetalake;
+import org.apache.gravitino.exceptions.NoSuchSchemaException;
+import org.apache.gravitino.exceptions.ViewAlreadyExistsException;
+import org.apache.gravitino.integration.test.container.ContainerSuite;
+import org.apache.gravitino.integration.test.container.MySQLContainer;
+import org.apache.gravitino.integration.test.util.BaseIT;
+import org.apache.gravitino.integration.test.util.GravitinoITUtils;
+import org.apache.gravitino.integration.test.util.TestDatabaseName;
+import org.apache.gravitino.rel.Column;
+import org.apache.gravitino.rel.Dialects;
+import org.apache.gravitino.rel.Representation;
+import org.apache.gravitino.rel.SQLRepresentation;
+import org.apache.gravitino.rel.View;
+import org.apache.gravitino.rel.ViewCatalog;
+import org.apache.gravitino.rel.ViewChange;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+
+/** Integration tests for MySQL view write operations (create/alter/drop). */
+@Tag("gravitino-docker-test")
+@TestInstance(Lifecycle.PER_CLASS)
+public class CatalogMysqlViewWriteIT extends BaseIT {
+
+  private static final ContainerSuite containerSuite = ContainerSuite.getInstance();
+  private static final String provider = "jdbc-mysql";
+
+  private final String metalakeName =
+      GravitinoITUtils.genRandomName("mysql_view_write_it_metalake");
+  private final String catalogName = GravitinoITUtils.genRandomName("mysql_view_write_it_catalog");
+  private final String schemaName = GravitinoITUtils.genRandomName("mysql_view_write_it_schema");
+
+  private GravitinoMetalake metalake;
+  private Catalog catalog;
+  private MysqlService mysqlService;
+  private MySQLContainer mysqlContainer;
+  private TestDatabaseName testDbName;
+
+  @BeforeAll
+  public void startup() throws IOException, SQLException {
+    testDbName = TestDatabaseName.MYSQL_CATALOG_MYSQL_IT;
+    containerSuite.startMySQLContainer(testDbName);
+    mysqlContainer = containerSuite.getMySQLContainer();
+    mysqlService = new MysqlService(mysqlContainer, testDbName);
+
+    createMetalake();
+    catalog = createCatalog();
+    createSchema();
+    createBaseTable();
+  }
+
+  @AfterAll
+  public void stop() {
+    cleanupAll();
+    catalog.asSchemas().dropSchema(schemaName, true);
+    metalake.disableCatalog(catalogName);
+    metalake.dropCatalog(catalogName);
+    client.disableMetalake(metalakeName);
+    client.dropMetalake(metalakeName);
+    mysqlService.close();
+  }
+
+  @AfterEach
+  public void resetSchema() {
+    cleanupAll();
+    catalog.asSchemas().dropSchema(schemaName, true);
+    createSchema();
+    createBaseTable();
+  }
+
+  @Test
+  public void testCreateViewAndLoad() {
+    ViewCatalog viewCatalog = catalog.asViewCatalog();
+    NameIdentifier ident = NameIdentifier.of(Namespace.of(schemaName), "created_view");
+    SQLRepresentation rep =
+        SQLRepresentation.builder()
+            .withDialect(Dialects.MYSQL)
+            .withSql("SELECT id, name FROM base_table")
+            .build();
+
+    View created =
+        viewCatalog.createView(
+            ident, "test comment", new Column[0], new Representation[] {rep}, null, null, null);
+
+    Assertions.assertEquals("created_view", created.name());
+
+    View loaded = viewCatalog.loadView(ident);
+    Assertions.assertEquals("created_view", loaded.name());
+    Assertions.assertTrue(loaded.columns().length >= 2);
+  }
+
+  @Test
+  public void testCreateViewAlreadyExistsThrows() {
+    ViewCatalog viewCatalog = catalog.asViewCatalog();
+    NameIdentifier ident = NameIdentifier.of(Namespace.of(schemaName), "dup_view");
+    SQLRepresentation rep =
+        SQLRepresentation.builder().withDialect(Dialects.MYSQL).withSql("SELECT 1").build();
+
+    viewCatalog.createView(
+        ident, null, new Column[0], new Representation[] {rep}, null, null, null);
+
+    Assertions.assertThrows(
+        ViewAlreadyExistsException.class,
+        () ->
+            viewCatalog.createView(
+                ident, null, new Column[0], new Representation[] {rep}, null, null, null));
+  }
+
+  @Test
+  public void testCreateViewInNonExistentSchemaThrows() {
+    ViewCatalog viewCatalog = catalog.asViewCatalog();
+    NameIdentifier ident = NameIdentifier.of(Namespace.of("no_such_schema"), "v1");
+    SQLRepresentation rep =
+        SQLRepresentation.builder().withDialect(Dialects.MYSQL).withSql("SELECT 1").build();
+
+    Assertions.assertThrows(
+        NoSuchSchemaException.class,
+        () ->
+            viewCatalog.createView(
+                ident, null, new Column[0], new Representation[] {rep}, null, null, null));
+  }
+
+  @Test
+  public void testAlterViewRename() {
+    ViewCatalog viewCatalog = catalog.asViewCatalog();
+    NameIdentifier ident = NameIdentifier.of(Namespace.of(schemaName), "rename_me");
+    SQLRepresentation rep =
+        SQLRepresentation.builder()
+            .withDialect(Dialects.MYSQL)
+            .withSql("SELECT id FROM base_table")
+            .build();
+    viewCatalog.createView(
+        ident, null, new Column[0], new Representation[] {rep}, null, null, null);
+
+    View renamed = viewCatalog.alterView(ident, ViewChange.rename("renamed_view"));
+    Assertions.assertEquals("renamed_view", renamed.name());
+    Assertions.assertTrue(
+        viewCatalog.viewExists(NameIdentifier.of(Namespace.of(schemaName), "renamed_view")));
+    Assertions.assertFalse(viewCatalog.viewExists(ident));
+  }
+
+  @Test
+  public void testAlterViewReplace() {
+    ViewCatalog viewCatalog = catalog.asViewCatalog();
+    NameIdentifier ident = NameIdentifier.of(Namespace.of(schemaName), "replace_me");
+    SQLRepresentation rep =
+        SQLRepresentation.builder()
+            .withDialect(Dialects.MYSQL)
+            .withSql("SELECT id FROM base_table")
+            .build();
+    viewCatalog.createView(
+        ident, null, new Column[0], new Representation[] {rep}, null, null, null);
+
+    SQLRepresentation newRep =
+        SQLRepresentation.builder()
+            .withDialect(Dialects.MYSQL)
+            .withSql("SELECT id, name FROM base_table")
+            .build();
+    viewCatalog.alterView(
+        ident,
+        ViewChange.replaceView(new Column[0], new Representation[] {newRep}, null, null, null));
+
+    View loaded = viewCatalog.loadView(ident);
+    Assertions.assertTrue(loaded.columns().length >= 2, "Replaced view should have 2+ columns");
+  }
+
+  @Test
+  public void testDropView() {
+    ViewCatalog viewCatalog = catalog.asViewCatalog();
+    NameIdentifier ident = NameIdentifier.of(Namespace.of(schemaName), "drop_me");
+    SQLRepresentation rep =
+        SQLRepresentation.builder().withDialect(Dialects.MYSQL).withSql("SELECT 1").build();
+    viewCatalog.createView(
+        ident, null, new Column[0], new Representation[] {rep}, null, null, null);
+
+    Assertions.assertTrue(viewCatalog.dropView(ident));
+    Assertions.assertFalse(viewCatalog.viewExists(ident));
+  }
+
+  @Test
+  public void testDropNonExistentViewReturnsFalse() {
+    Assertions.assertFalse(
+        catalog
+            .asViewCatalog()
+            .dropView(NameIdentifier.of(Namespace.of(schemaName), "no_such_view")));
+  }
+
+  @Test
+  public void testListViewsAfterCreateAndDrop() {
+    ViewCatalog viewCatalog = catalog.asViewCatalog();
+    SQLRepresentation rep =
+        SQLRepresentation.builder().withDialect(Dialects.MYSQL).withSql("SELECT 1").build();
+
+    viewCatalog.createView(
+        NameIdentifier.of(Namespace.of(schemaName), "list_v1"),
+        null,
+        new Column[0],
+        new Representation[] {rep},
+        null,
+        null,
+        null);
+    viewCatalog.createView(
+        NameIdentifier.of(Namespace.of(schemaName), "list_v2"),
+        null,
+        new Column[0],
+        new Representation[] {rep},
+        null,
+        null,
+        null);
+    viewCatalog.createView(
+        NameIdentifier.of(Namespace.of(schemaName), "list_v3"),
+        null,
+        new Column[0],
+        new Representation[] {rep},
+        null,
+        null,
+        null);
+
+    List<String> names =
+        Arrays.stream(viewCatalog.listViews(Namespace.of(schemaName)))
+            .map(NameIdentifier::name)
+            .sorted()
+            .collect(Collectors.toList());
+    Assertions.assertEquals(Arrays.asList("list_v1", "list_v2", "list_v3"), names);
+
+    viewCatalog.dropView(NameIdentifier.of(Namespace.of(schemaName), "list_v2"));
+
+    List<String> afterDrop =
+        Arrays.stream(viewCatalog.listViews(Namespace.of(schemaName)))
+            .map(NameIdentifier::name)
+            .sorted()
+            .collect(Collectors.toList());
+    Assertions.assertEquals(Arrays.asList("list_v1", "list_v3"), afterDrop);
+  }
+
+  private void createMetalake() {
+    client.createMetalake(metalakeName, "comment", Collections.emptyMap());
+    metalake = client.loadMetalake(metalakeName);
+  }
+
+  private Catalog createCatalog() throws SQLException {
+    Map<String, String> catalogProperties = Maps.newHashMap();
+    catalogProperties.put(
+        JdbcConfig.JDBC_URL.getKey(),
+        StringUtils.substring(
+                mysqlContainer.getJdbcUrl(testDbName),
+                0,
+                mysqlContainer.getJdbcUrl(testDbName).lastIndexOf("/"))
+            + "?useSSL=false&allowPublicKeyRetrieval=true");
+    catalogProperties.put(
+        JdbcConfig.JDBC_DRIVER.getKey(), mysqlContainer.getDriverClassName(testDbName));
+    catalogProperties.put(JdbcConfig.USERNAME.getKey(), mysqlContainer.getUsername());
+    catalogProperties.put(JdbcConfig.PASSWORD.getKey(), mysqlContainer.getPassword());
+
+    return metalake.createCatalog(
+        catalogName, Catalog.Type.RELATIONAL, provider, "comment", catalogProperties);
+  }
+
+  private void createSchema() {
+    catalog.asSchemas().createSchema(schemaName, null, Collections.emptyMap());
+  }
+
+  private void createBaseTable() {
+    mysqlService.executeQuery(
+        "CREATE TABLE " + schemaName + ".base_table (id INT, name VARCHAR(255))");
+  }
+
+  private void cleanupAll() {
+    NameIdentifier[] views = catalog.asViewCatalog().listViews(Namespace.of(schemaName));
+    for (NameIdentifier view : views) {
+      catalog.asViewCatalog().dropView(view);
+    }
+  }
+}

--- a/catalogs/catalog-jdbc-mysql/src/test/java/org/apache/gravitino/catalog/mysql/operation/TestMysqlViewOperations.java
+++ b/catalogs/catalog-jdbc-mysql/src/test/java/org/apache/gravitino/catalog/mysql/operation/TestMysqlViewOperations.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog.mysql.operation;
+
+import org.apache.gravitino.rel.Dialects;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/** Tests for {@link MysqlViewOperations}. */
+public class TestMysqlViewOperations {
+
+  private MysqlViewOperations ops;
+
+  @BeforeEach
+  void setUp() {
+    ops = new MysqlViewOperations();
+  }
+
+  @Test
+  public void testDialectName() {
+    Assertions.assertEquals(Dialects.MYSQL, ops.dialectName());
+  }
+
+  @Test
+  public void testQuoteIdentifier() {
+    Assertions.assertEquals("`my_view`", ops.quoteIdentifier("my_view"));
+  }
+
+  @Test
+  public void testQuoteIdentifierEscapesBacktick() {
+    Assertions.assertEquals("`my``view`", ops.quoteIdentifier("my`view"));
+  }
+
+  @Test
+  public void testGenerateListViewsSqlIsParameterized() {
+    String sql = ops.generateListViewsSql();
+    Assertions.assertTrue(sql.contains("?"), "SQL should contain parameter placeholder");
+    Assertions.assertTrue(
+        sql.toLowerCase().contains("information_schema"), "SQL should query information_schema");
+  }
+
+  @Test
+  public void testGenerateLoadViewSqlIsParameterized() {
+    String sql = ops.generateLoadViewSql();
+    Assertions.assertTrue(sql.contains("?"), "SQL should contain parameter placeholder");
+    Assertions.assertTrue(
+        sql.toLowerCase().contains("view_definition"), "SQL should select VIEW_DEFINITION");
+  }
+}

--- a/catalogs/catalog-jdbc-mysql/src/test/java/org/apache/gravitino/catalog/mysql/operation/TestMysqlViewOperations.java
+++ b/catalogs/catalog-jdbc-mysql/src/test/java/org/apache/gravitino/catalog/mysql/operation/TestMysqlViewOperations.java
@@ -63,4 +63,35 @@ public class TestMysqlViewOperations {
     Assertions.assertTrue(
         sql.toLowerCase().contains("view_definition"), "SQL should select VIEW_DEFINITION");
   }
+
+  @Test
+  public void testGenerateCreateViewSql() {
+    String sql = ops.generateCreateViewSql("my_view", "SELECT 1");
+    Assertions.assertTrue(sql.contains("CREATE VIEW"), "Should contain CREATE VIEW");
+    Assertions.assertTrue(sql.contains("`my_view`"), "Should quote view name with backticks");
+    Assertions.assertTrue(sql.contains("SELECT 1"), "Should contain the view definition");
+  }
+
+  @Test
+  public void testGenerateReplaceViewSql() {
+    String sql = ops.generateReplaceViewSql("my_view", "SELECT 2");
+    Assertions.assertTrue(
+        sql.contains("CREATE OR REPLACE VIEW"), "Should contain CREATE OR REPLACE VIEW");
+    Assertions.assertTrue(sql.contains("`my_view`"), "Should quote view name");
+  }
+
+  @Test
+  public void testGenerateRenameViewSql() {
+    String sql = ops.generateRenameViewSql("old_view", "new_view");
+    Assertions.assertTrue(sql.contains("RENAME TABLE"), "MySQL uses RENAME TABLE for views");
+    Assertions.assertTrue(sql.contains("`old_view`"), "Should quote old name");
+    Assertions.assertTrue(sql.contains("`new_view`"), "Should quote new name");
+  }
+
+  @Test
+  public void testGenerateDropViewSql() {
+    String sql = ops.generateDropViewSql("my_view");
+    Assertions.assertTrue(sql.contains("DROP VIEW"), "Should contain DROP VIEW");
+    Assertions.assertTrue(sql.contains("`my_view`"), "Should quote view name");
+  }
 }

--- a/catalogs/catalog-jdbc-postgresql/src/main/java/org/apache/gravitino/catalog/postgresql/PostgreSQLCatalogOperations.java
+++ b/catalogs/catalog-jdbc-postgresql/src/main/java/org/apache/gravitino/catalog/postgresql/PostgreSQLCatalogOperations.java
@@ -36,8 +36,12 @@ import org.apache.gravitino.connector.CatalogInfo;
 import org.apache.gravitino.connector.HasPropertyMetadata;
 import org.apache.gravitino.exceptions.NoSuchSchemaException;
 import org.apache.gravitino.exceptions.NoSuchViewException;
+import org.apache.gravitino.exceptions.ViewAlreadyExistsException;
+import org.apache.gravitino.rel.Column;
+import org.apache.gravitino.rel.Representation;
 import org.apache.gravitino.rel.View;
 import org.apache.gravitino.rel.ViewCatalog;
+import org.apache.gravitino.rel.ViewChange;
 
 /** PostgreSQL-specific catalog operations with view support. */
 public class PostgreSQLCatalogOperations extends JdbcCatalogOperations implements ViewCatalog {
@@ -94,5 +98,30 @@ public class PostgreSQLCatalogOperations extends JdbcCatalogOperations implement
   @Override
   public View loadView(NameIdentifier ident) throws NoSuchViewException {
     return viewCatalogOps.loadView(ident);
+  }
+
+  @Override
+  public View createView(
+      NameIdentifier ident,
+      String comment,
+      Column[] columns,
+      Representation[] representations,
+      String defaultCatalog,
+      String defaultSchema,
+      Map<String, String> properties)
+      throws NoSuchSchemaException, ViewAlreadyExistsException {
+    return viewCatalogOps.createView(
+        ident, comment, columns, representations, defaultCatalog, defaultSchema, properties);
+  }
+
+  @Override
+  public View alterView(NameIdentifier ident, ViewChange... changes)
+      throws NoSuchViewException, IllegalArgumentException {
+    return viewCatalogOps.alterView(ident, changes);
+  }
+
+  @Override
+  public boolean dropView(NameIdentifier ident) {
+    return viewCatalogOps.dropView(ident);
   }
 }

--- a/catalogs/catalog-jdbc-postgresql/src/main/java/org/apache/gravitino/catalog/postgresql/PostgreSqlCatalog.java
+++ b/catalogs/catalog-jdbc-postgresql/src/main/java/org/apache/gravitino/catalog/postgresql/PostgreSqlCatalog.java
@@ -30,6 +30,7 @@ import org.apache.gravitino.catalog.postgresql.converter.PostgreSqlExceptionConv
 import org.apache.gravitino.catalog.postgresql.converter.PostgreSqlTypeConverter;
 import org.apache.gravitino.catalog.postgresql.operation.PostgreSqlSchemaOperations;
 import org.apache.gravitino.catalog.postgresql.operation.PostgreSqlTableOperations;
+import org.apache.gravitino.catalog.postgresql.operation.PostgreSqlViewOperations;
 import org.apache.gravitino.connector.CatalogOperations;
 import org.apache.gravitino.connector.capability.Capability;
 
@@ -48,7 +49,8 @@ public class PostgreSqlCatalog extends JdbcCatalog {
         jdbcTypeConverter,
         createJdbcDatabaseOperations(),
         createJdbcTableOperations(),
-        createJdbcColumnDefaultValueConverter());
+        createJdbcColumnDefaultValueConverter(),
+        new PostgreSqlViewOperations());
   }
 
   @Override

--- a/catalogs/catalog-jdbc-postgresql/src/main/java/org/apache/gravitino/catalog/postgresql/operation/PostgreSqlViewOperations.java
+++ b/catalogs/catalog-jdbc-postgresql/src/main/java/org/apache/gravitino/catalog/postgresql/operation/PostgreSqlViewOperations.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog.postgresql.operation;
+
+import com.google.common.base.Preconditions;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.Map;
+import javax.sql.DataSource;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.gravitino.catalog.jdbc.config.JdbcConfig;
+import org.apache.gravitino.catalog.jdbc.converter.JdbcExceptionConverter;
+import org.apache.gravitino.catalog.jdbc.converter.JdbcTypeConverter;
+import org.apache.gravitino.catalog.jdbc.operation.JdbcViewOperations;
+import org.apache.gravitino.rel.Dialects;
+
+/** PostgreSQL-specific implementation of JDBC view operations. */
+public class PostgreSqlViewOperations extends JdbcViewOperations {
+
+  private String database;
+
+  @Override
+  public void initialize(
+      DataSource dataSource,
+      JdbcExceptionConverter exceptionMapper,
+      JdbcTypeConverter typeConverter,
+      Map<String, String> conf) {
+    super.initialize(dataSource, exceptionMapper, typeConverter, conf);
+    this.database = new JdbcConfig(conf).getJdbcDatabase();
+    Preconditions.checkArgument(
+        StringUtils.isNotBlank(database),
+        "The `jdbc-database` configuration item is mandatory in PostgreSQL.");
+  }
+
+  @Override
+  public String dialectName() {
+    return Dialects.POSTGRESQL;
+  }
+
+  @Override
+  protected String quoteIdentifier(String identifier) {
+    return "\"" + identifier.replace("\"", "\"\"") + "\"";
+  }
+
+  @Override
+  protected String generateListViewsSql() {
+    return "SELECT table_name FROM information_schema.views"
+        + " WHERE table_schema = ? AND table_catalog = ?";
+  }
+
+  @Override
+  protected void bindListViewsParameters(PreparedStatement stmt, String schemaName)
+      throws SQLException {
+    stmt.setString(1, schemaName);
+    stmt.setString(2, database);
+  }
+
+  @Override
+  protected String generateLoadViewSql() {
+    return "SELECT view_definition FROM information_schema.views"
+        + " WHERE table_schema = ? AND table_name = ? AND table_catalog = ?";
+  }
+
+  @Override
+  protected void bindLoadViewParameters(PreparedStatement stmt, String schemaName, String viewName)
+      throws SQLException {
+    stmt.setString(1, schemaName);
+    stmt.setString(2, viewName);
+    stmt.setString(3, database);
+  }
+
+  @Override
+  protected Connection getConnection(String schema) throws SQLException {
+    Connection connection = dataSource.getConnection();
+    connection.setCatalog(database);
+    connection.setSchema(schema);
+    return connection;
+  }
+}

--- a/catalogs/catalog-jdbc-postgresql/src/main/java/org/apache/gravitino/catalog/postgresql/operation/PostgreSqlViewOperations.java
+++ b/catalogs/catalog-jdbc-postgresql/src/main/java/org/apache/gravitino/catalog/postgresql/operation/PostgreSqlViewOperations.java
@@ -108,6 +108,39 @@ public class PostgreSqlViewOperations extends JdbcViewOperations {
   }
 
   @Override
+  protected String generateCreateViewSql(String viewName, String sql) {
+    return "CREATE VIEW " + quoteIdentifier(viewName) + " AS " + sql;
+  }
+
+  @Override
+  protected String generateReplaceViewSql(String viewName, String sql) {
+    return "CREATE OR REPLACE VIEW " + quoteIdentifier(viewName) + " AS " + sql;
+  }
+
+  @Override
+  protected String generateRenameViewSql(String oldName, String newName) {
+    return "ALTER VIEW " + quoteIdentifier(oldName) + " RENAME TO " + quoteIdentifier(newName);
+  }
+
+  @Override
+  protected String generateDropViewSql(String viewName) {
+    return "DROP VIEW " + quoteIdentifier(viewName);
+  }
+
+  @Override
+  protected void setComment(Connection connection, String viewName, String comment)
+      throws SQLException {
+    if (comment == null) {
+      return;
+    }
+    String sql = "COMMENT ON VIEW " + quoteIdentifier(viewName) + " IS ?";
+    try (PreparedStatement stmt = connection.prepareStatement(sql)) {
+      stmt.setString(1, comment);
+      stmt.execute();
+    }
+  }
+
+  @Override
   protected Connection getConnection(String schema) throws SQLException {
     Connection connection = dataSource.getConnection();
     connection.setCatalog(database);

--- a/catalogs/catalog-jdbc-postgresql/src/main/java/org/apache/gravitino/catalog/postgresql/operation/PostgreSqlViewOperations.java
+++ b/catalogs/catalog-jdbc-postgresql/src/main/java/org/apache/gravitino/catalog/postgresql/operation/PostgreSqlViewOperations.java
@@ -21,6 +21,7 @@ package org.apache.gravitino.catalog.postgresql.operation;
 import com.google.common.base.Preconditions;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Map;
 import javax.sql.DataSource;
@@ -84,6 +85,26 @@ public class PostgreSqlViewOperations extends JdbcViewOperations {
     stmt.setString(1, schemaName);
     stmt.setString(2, viewName);
     stmt.setString(3, database);
+  }
+
+  @Override
+  protected String loadComment(Connection connection, String databaseName, String viewName)
+      throws SQLException {
+    String sql =
+        "SELECT obj_description(c.oid, 'pg_class')"
+            + " FROM pg_catalog.pg_class c"
+            + " JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid"
+            + " WHERE c.relname = ? AND n.nspname = ? AND c.relkind = 'v'";
+    try (PreparedStatement stmt = connection.prepareStatement(sql)) {
+      stmt.setString(1, viewName);
+      stmt.setString(2, databaseName);
+      try (ResultSet rs = stmt.executeQuery()) {
+        if (rs.next()) {
+          return rs.getString(1);
+        }
+      }
+    }
+    return null;
   }
 
   @Override

--- a/catalogs/catalog-jdbc-postgresql/src/test/java/org/apache/gravitino/catalog/postgresql/integration/test/CatalogPostgreSqlViewReadIT.java
+++ b/catalogs/catalog-jdbc-postgresql/src/test/java/org/apache/gravitino/catalog/postgresql/integration/test/CatalogPostgreSqlViewReadIT.java
@@ -1,0 +1,230 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog.postgresql.integration.test;
+
+import com.google.common.collect.Maps;
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.apache.gravitino.Catalog;
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.Namespace;
+import org.apache.gravitino.catalog.jdbc.config.JdbcConfig;
+import org.apache.gravitino.catalog.postgresql.integration.test.service.PostgreSqlService;
+import org.apache.gravitino.client.GravitinoMetalake;
+import org.apache.gravitino.exceptions.NoSuchSchemaException;
+import org.apache.gravitino.exceptions.NoSuchViewException;
+import org.apache.gravitino.integration.test.container.ContainerSuite;
+import org.apache.gravitino.integration.test.container.PGImageName;
+import org.apache.gravitino.integration.test.container.PostgreSQLContainer;
+import org.apache.gravitino.integration.test.util.BaseIT;
+import org.apache.gravitino.integration.test.util.GravitinoITUtils;
+import org.apache.gravitino.integration.test.util.TestDatabaseName;
+import org.apache.gravitino.rel.Column;
+import org.apache.gravitino.rel.SQLRepresentation;
+import org.apache.gravitino.rel.View;
+import org.apache.gravitino.rel.ViewCatalog;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+
+/** Integration tests for PostgreSQL view read operations (list/load). */
+@Tag("gravitino-docker-test")
+@TestInstance(Lifecycle.PER_CLASS)
+public class CatalogPostgreSqlViewReadIT extends BaseIT {
+
+  private static final ContainerSuite containerSuite = ContainerSuite.getInstance();
+  private static final String provider = "jdbc-postgresql";
+
+  private final String metalakeName = GravitinoITUtils.genRandomName("pg_view_it_metalake");
+  private final String catalogName = GravitinoITUtils.genRandomName("pg_view_it_catalog");
+  private final String schemaName = GravitinoITUtils.genRandomName("pg_view_it_schema");
+
+  private GravitinoMetalake metalake;
+  private Catalog catalog;
+  private PostgreSqlService postgreSqlService;
+  private PostgreSQLContainer postgresContainer;
+  private final TestDatabaseName testDbName = TestDatabaseName.PG_CATALOG_POSTGRESQL_IT;
+
+  @BeforeAll
+  public void startup() throws IOException, SQLException {
+    containerSuite.startPostgreSQLContainer(testDbName, PGImageName.VERSION_13);
+    postgresContainer = containerSuite.getPostgreSQLContainer(PGImageName.VERSION_13);
+    postgreSqlService = new PostgreSqlService(postgresContainer, testDbName);
+
+    createMetalake();
+    catalog = createCatalog();
+    createSchema();
+    createBaseTableAndViews();
+  }
+
+  @AfterAll
+  public void stop() {
+    cleanupViewsAndTables();
+    catalog.asSchemas().dropSchema(schemaName, false);
+    metalake.disableCatalog(catalogName);
+    metalake.dropCatalog(catalogName);
+    client.disableMetalake(metalakeName);
+    client.dropMetalake(metalakeName);
+    postgreSqlService.close();
+  }
+
+  @AfterEach
+  public void resetSchema() {
+    cleanupViewsAndTables();
+    catalog.asSchemas().dropSchema(schemaName, false);
+    createSchema();
+    createBaseTableAndViews();
+  }
+
+  @Test
+  public void testListViews() {
+    ViewCatalog viewCatalog = catalog.asViewCatalog();
+    NameIdentifier[] views = viewCatalog.listViews(Namespace.of(schemaName));
+
+    List<String> names =
+        Arrays.stream(views).map(NameIdentifier::name).sorted().collect(Collectors.toList());
+    Assertions.assertEquals(Arrays.asList("test_view_1", "test_view_2"), names);
+  }
+
+  @Test
+  public void testListViewsInEmptySchema() {
+    String emptySchema = GravitinoITUtils.genRandomName("empty_schema");
+    catalog.asSchemas().createSchema(emptySchema, null, Collections.emptyMap());
+    try {
+      NameIdentifier[] views = catalog.asViewCatalog().listViews(Namespace.of(emptySchema));
+      Assertions.assertEquals(0, views.length);
+    } finally {
+      catalog.asSchemas().dropSchema(emptySchema, false);
+    }
+  }
+
+  @Test
+  public void testListViewsInNonExistentSchema() {
+    Assertions.assertThrows(
+        NoSuchSchemaException.class,
+        () -> catalog.asViewCatalog().listViews(Namespace.of("no_such_schema_xyz")));
+  }
+
+  @Test
+  public void testLoadView() {
+    View view =
+        catalog
+            .asViewCatalog()
+            .loadView(NameIdentifier.of(Namespace.of(schemaName), "test_view_1"));
+
+    Assertions.assertEquals("test_view_1", view.name());
+
+    Column[] columns = view.columns();
+    Assertions.assertEquals(2, columns.length);
+    Assertions.assertEquals("id", columns[0].name());
+    Assertions.assertNotNull(columns[0].dataType());
+    Assertions.assertEquals("name", columns[1].name());
+    Assertions.assertNotNull(columns[1].dataType());
+
+    Assertions.assertEquals(1, view.representations().length);
+    Assertions.assertInstanceOf(SQLRepresentation.class, view.representations()[0]);
+    SQLRepresentation rep = (SQLRepresentation) view.representations()[0];
+    Assertions.assertEquals("postgresql", rep.dialect());
+    Assertions.assertFalse(rep.sql().isEmpty());
+  }
+
+  @Test
+  public void testLoadNonExistentView() {
+    Assertions.assertThrows(
+        NoSuchViewException.class,
+        () ->
+            catalog
+                .asViewCatalog()
+                .loadView(NameIdentifier.of(Namespace.of(schemaName), "no_such_view")));
+  }
+
+  @Test
+  public void testViewExists() {
+    Assertions.assertTrue(
+        catalog
+            .asViewCatalog()
+            .viewExists(NameIdentifier.of(Namespace.of(schemaName), "test_view_1")));
+  }
+
+  @Test
+  public void testViewDoesNotExist() {
+    Assertions.assertFalse(
+        catalog
+            .asViewCatalog()
+            .viewExists(NameIdentifier.of(Namespace.of(schemaName), "no_such_view")));
+  }
+
+  private void createMetalake() {
+    client.createMetalake(metalakeName, "comment", Collections.emptyMap());
+    metalake = client.loadMetalake(metalakeName);
+  }
+
+  private Catalog createCatalog() throws SQLException {
+    Map<String, String> catalogProperties = Maps.newHashMap();
+    String jdbcUrl = postgresContainer.getJdbcUrl(testDbName);
+    catalogProperties.put(
+        JdbcConfig.JDBC_DRIVER.getKey(), postgresContainer.getDriverClassName(testDbName));
+    catalogProperties.put(JdbcConfig.JDBC_URL.getKey(), jdbcUrl);
+    catalogProperties.put(JdbcConfig.JDBC_DATABASE.getKey(), testDbName.toString());
+    catalogProperties.put(JdbcConfig.USERNAME.getKey(), postgresContainer.getUsername());
+    catalogProperties.put(JdbcConfig.PASSWORD.getKey(), postgresContainer.getPassword());
+
+    return metalake.createCatalog(
+        catalogName, Catalog.Type.RELATIONAL, provider, "comment", catalogProperties);
+  }
+
+  private void createSchema() {
+    catalog.asSchemas().createSchema(schemaName, "view test schema", Collections.emptyMap());
+  }
+
+  private void createBaseTableAndViews() {
+    postgreSqlService.executeQuery(
+        "CREATE TABLE \""
+            + schemaName
+            + "\".base_table (id INT, name VARCHAR(255), score DOUBLE PRECISION)");
+    postgreSqlService.executeQuery(
+        "CREATE VIEW \""
+            + schemaName
+            + "\".test_view_1 AS SELECT id, name FROM \""
+            + schemaName
+            + "\".base_table");
+    postgreSqlService.executeQuery(
+        "CREATE VIEW \""
+            + schemaName
+            + "\".test_view_2 AS SELECT id FROM \""
+            + schemaName
+            + "\".base_table WHERE id > 0");
+  }
+
+  private void cleanupViewsAndTables() {
+    postgreSqlService.executeQuery("DROP VIEW IF EXISTS \"" + schemaName + "\".test_view_1");
+    postgreSqlService.executeQuery("DROP VIEW IF EXISTS \"" + schemaName + "\".test_view_2");
+    postgreSqlService.executeQuery("DROP TABLE IF EXISTS \"" + schemaName + "\".base_table");
+  }
+}

--- a/catalogs/catalog-jdbc-postgresql/src/test/java/org/apache/gravitino/catalog/postgresql/integration/test/CatalogPostgreSqlViewReadIT.java
+++ b/catalogs/catalog-jdbc-postgresql/src/test/java/org/apache/gravitino/catalog/postgresql/integration/test/CatalogPostgreSqlViewReadIT.java
@@ -44,6 +44,7 @@ import org.apache.gravitino.rel.Column;
 import org.apache.gravitino.rel.SQLRepresentation;
 import org.apache.gravitino.rel.View;
 import org.apache.gravitino.rel.ViewCatalog;
+import org.apache.gravitino.rel.types.Types;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -143,9 +144,11 @@ public class CatalogPostgreSqlViewReadIT extends BaseIT {
     Column[] columns = view.columns();
     Assertions.assertEquals(2, columns.length);
     Assertions.assertEquals("id", columns[0].name());
-    Assertions.assertNotNull(columns[0].dataType());
+    Assertions.assertEquals(Types.IntegerType.get(), columns[0].dataType());
     Assertions.assertEquals("name", columns[1].name());
-    Assertions.assertNotNull(columns[1].dataType());
+    Assertions.assertEquals(Types.VarCharType.of(255), columns[1].dataType());
+
+    Assertions.assertEquals("test view comment", view.comment());
 
     Assertions.assertEquals(1, view.representations().length);
     Assertions.assertInstanceOf(SQLRepresentation.class, view.representations()[0]);
@@ -214,6 +217,8 @@ public class CatalogPostgreSqlViewReadIT extends BaseIT {
             + "\".test_view_1 AS SELECT id, name FROM \""
             + schemaName
             + "\".base_table");
+    postgreSqlService.executeQuery(
+        "COMMENT ON VIEW \"" + schemaName + "\".test_view_1 IS 'test view comment'");
     postgreSqlService.executeQuery(
         "CREATE VIEW \""
             + schemaName

--- a/catalogs/catalog-jdbc-postgresql/src/test/java/org/apache/gravitino/catalog/postgresql/integration/test/CatalogPostgreSqlViewWriteIT.java
+++ b/catalogs/catalog-jdbc-postgresql/src/test/java/org/apache/gravitino/catalog/postgresql/integration/test/CatalogPostgreSqlViewWriteIT.java
@@ -1,0 +1,307 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog.postgresql.integration.test;
+
+import com.google.common.collect.Maps;
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.apache.gravitino.Catalog;
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.Namespace;
+import org.apache.gravitino.catalog.jdbc.config.JdbcConfig;
+import org.apache.gravitino.catalog.postgresql.integration.test.service.PostgreSqlService;
+import org.apache.gravitino.client.GravitinoMetalake;
+import org.apache.gravitino.exceptions.NoSuchSchemaException;
+import org.apache.gravitino.exceptions.ViewAlreadyExistsException;
+import org.apache.gravitino.integration.test.container.ContainerSuite;
+import org.apache.gravitino.integration.test.container.PGImageName;
+import org.apache.gravitino.integration.test.container.PostgreSQLContainer;
+import org.apache.gravitino.integration.test.util.BaseIT;
+import org.apache.gravitino.integration.test.util.GravitinoITUtils;
+import org.apache.gravitino.integration.test.util.TestDatabaseName;
+import org.apache.gravitino.rel.Column;
+import org.apache.gravitino.rel.Dialects;
+import org.apache.gravitino.rel.Representation;
+import org.apache.gravitino.rel.SQLRepresentation;
+import org.apache.gravitino.rel.View;
+import org.apache.gravitino.rel.ViewCatalog;
+import org.apache.gravitino.rel.ViewChange;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+
+/** Integration tests for PostgreSQL view write operations (create/alter/drop). */
+@Tag("gravitino-docker-test")
+@TestInstance(Lifecycle.PER_CLASS)
+public class CatalogPostgreSqlViewWriteIT extends BaseIT {
+
+  private static final ContainerSuite containerSuite = ContainerSuite.getInstance();
+  private static final String provider = "jdbc-postgresql";
+
+  private final String metalakeName = GravitinoITUtils.genRandomName("pg_view_write_it_metalake");
+  private final String catalogName = GravitinoITUtils.genRandomName("pg_view_write_it_catalog");
+  private final String schemaName = GravitinoITUtils.genRandomName("pg_view_write_it_schema");
+
+  private GravitinoMetalake metalake;
+  private Catalog catalog;
+  private PostgreSqlService postgreSqlService;
+  private PostgreSQLContainer postgresContainer;
+  private final TestDatabaseName testDbName = TestDatabaseName.PG_CATALOG_POSTGRESQL_IT;
+
+  @BeforeAll
+  public void startup() throws IOException, SQLException {
+    containerSuite.startPostgreSQLContainer(testDbName, PGImageName.VERSION_13);
+    postgresContainer = containerSuite.getPostgreSQLContainer(PGImageName.VERSION_13);
+    postgreSqlService = new PostgreSqlService(postgresContainer, testDbName);
+
+    createMetalake();
+    catalog = createCatalog();
+    createSchema();
+    createBaseTable();
+  }
+
+  @AfterAll
+  public void stop() {
+    cleanupAll();
+    catalog.asSchemas().dropSchema(schemaName, true);
+    metalake.disableCatalog(catalogName);
+    metalake.dropCatalog(catalogName);
+    client.disableMetalake(metalakeName);
+    client.dropMetalake(metalakeName);
+    postgreSqlService.close();
+  }
+
+  @AfterEach
+  public void resetSchema() {
+    cleanupAll();
+    catalog.asSchemas().dropSchema(schemaName, true);
+    createSchema();
+    createBaseTable();
+  }
+
+  @Test
+  public void testCreateViewAndLoad() {
+    ViewCatalog viewCatalog = catalog.asViewCatalog();
+    NameIdentifier ident = NameIdentifier.of(Namespace.of(schemaName), "created_view");
+    SQLRepresentation rep =
+        SQLRepresentation.builder()
+            .withDialect(Dialects.POSTGRESQL)
+            .withSql("SELECT id, name FROM base_table")
+            .build();
+
+    View created =
+        viewCatalog.createView(
+            ident, "test comment", new Column[0], new Representation[] {rep}, null, null, null);
+
+    Assertions.assertEquals("created_view", created.name());
+
+    View loaded = viewCatalog.loadView(ident);
+    Assertions.assertEquals("created_view", loaded.name());
+    Assertions.assertTrue(loaded.columns().length >= 2);
+  }
+
+  @Test
+  public void testCreateViewAlreadyExistsThrows() {
+    ViewCatalog viewCatalog = catalog.asViewCatalog();
+    NameIdentifier ident = NameIdentifier.of(Namespace.of(schemaName), "dup_view");
+    SQLRepresentation rep =
+        SQLRepresentation.builder().withDialect(Dialects.POSTGRESQL).withSql("SELECT 1").build();
+
+    viewCatalog.createView(
+        ident, null, new Column[0], new Representation[] {rep}, null, null, null);
+
+    Assertions.assertThrows(
+        ViewAlreadyExistsException.class,
+        () ->
+            viewCatalog.createView(
+                ident, null, new Column[0], new Representation[] {rep}, null, null, null));
+  }
+
+  @Test
+  public void testCreateViewInNonExistentSchemaThrows() {
+    ViewCatalog viewCatalog = catalog.asViewCatalog();
+    NameIdentifier ident = NameIdentifier.of(Namespace.of("no_such_schema"), "v1");
+    SQLRepresentation rep =
+        SQLRepresentation.builder().withDialect(Dialects.POSTGRESQL).withSql("SELECT 1").build();
+
+    Assertions.assertThrows(
+        NoSuchSchemaException.class,
+        () ->
+            viewCatalog.createView(
+                ident, null, new Column[0], new Representation[] {rep}, null, null, null));
+  }
+
+  @Test
+  public void testAlterViewRename() {
+    ViewCatalog viewCatalog = catalog.asViewCatalog();
+    NameIdentifier ident = NameIdentifier.of(Namespace.of(schemaName), "rename_me");
+    SQLRepresentation rep =
+        SQLRepresentation.builder()
+            .withDialect(Dialects.POSTGRESQL)
+            .withSql("SELECT id FROM base_table")
+            .build();
+    viewCatalog.createView(
+        ident, null, new Column[0], new Representation[] {rep}, null, null, null);
+
+    View renamed = viewCatalog.alterView(ident, ViewChange.rename("renamed_view"));
+    Assertions.assertEquals("renamed_view", renamed.name());
+    Assertions.assertTrue(
+        viewCatalog.viewExists(NameIdentifier.of(Namespace.of(schemaName), "renamed_view")));
+    Assertions.assertFalse(viewCatalog.viewExists(ident));
+  }
+
+  @Test
+  public void testAlterViewReplace() {
+    ViewCatalog viewCatalog = catalog.asViewCatalog();
+    NameIdentifier ident = NameIdentifier.of(Namespace.of(schemaName), "replace_me");
+    SQLRepresentation rep =
+        SQLRepresentation.builder()
+            .withDialect(Dialects.POSTGRESQL)
+            .withSql("SELECT id FROM base_table")
+            .build();
+    viewCatalog.createView(
+        ident, null, new Column[0], new Representation[] {rep}, null, null, null);
+
+    SQLRepresentation newRep =
+        SQLRepresentation.builder()
+            .withDialect(Dialects.POSTGRESQL)
+            .withSql("SELECT id, name FROM base_table")
+            .build();
+    viewCatalog.alterView(
+        ident,
+        ViewChange.replaceView(new Column[0], new Representation[] {newRep}, null, null, null));
+
+    View loaded = viewCatalog.loadView(ident);
+    Assertions.assertTrue(loaded.columns().length >= 2, "Replaced view should have 2+ columns");
+  }
+
+  @Test
+  public void testDropView() {
+    ViewCatalog viewCatalog = catalog.asViewCatalog();
+    NameIdentifier ident = NameIdentifier.of(Namespace.of(schemaName), "drop_me");
+    SQLRepresentation rep =
+        SQLRepresentation.builder().withDialect(Dialects.POSTGRESQL).withSql("SELECT 1").build();
+    viewCatalog.createView(
+        ident, null, new Column[0], new Representation[] {rep}, null, null, null);
+
+    Assertions.assertTrue(viewCatalog.dropView(ident));
+    Assertions.assertFalse(viewCatalog.viewExists(ident));
+  }
+
+  @Test
+  public void testDropNonExistentViewReturnsFalse() {
+    Assertions.assertFalse(
+        catalog
+            .asViewCatalog()
+            .dropView(NameIdentifier.of(Namespace.of(schemaName), "no_such_view")));
+  }
+
+  @Test
+  public void testListViewsAfterCreateAndDrop() {
+    ViewCatalog viewCatalog = catalog.asViewCatalog();
+    SQLRepresentation rep =
+        SQLRepresentation.builder().withDialect(Dialects.POSTGRESQL).withSql("SELECT 1").build();
+
+    viewCatalog.createView(
+        NameIdentifier.of(Namespace.of(schemaName), "list_v1"),
+        null,
+        new Column[0],
+        new Representation[] {rep},
+        null,
+        null,
+        null);
+    viewCatalog.createView(
+        NameIdentifier.of(Namespace.of(schemaName), "list_v2"),
+        null,
+        new Column[0],
+        new Representation[] {rep},
+        null,
+        null,
+        null);
+    viewCatalog.createView(
+        NameIdentifier.of(Namespace.of(schemaName), "list_v3"),
+        null,
+        new Column[0],
+        new Representation[] {rep},
+        null,
+        null,
+        null);
+
+    List<String> names =
+        Arrays.stream(viewCatalog.listViews(Namespace.of(schemaName)))
+            .map(NameIdentifier::name)
+            .sorted()
+            .collect(Collectors.toList());
+    Assertions.assertEquals(Arrays.asList("list_v1", "list_v2", "list_v3"), names);
+
+    viewCatalog.dropView(NameIdentifier.of(Namespace.of(schemaName), "list_v2"));
+
+    List<String> afterDrop =
+        Arrays.stream(viewCatalog.listViews(Namespace.of(schemaName)))
+            .map(NameIdentifier::name)
+            .sorted()
+            .collect(Collectors.toList());
+    Assertions.assertEquals(Arrays.asList("list_v1", "list_v3"), afterDrop);
+  }
+
+  private void createMetalake() {
+    client.createMetalake(metalakeName, "comment", Collections.emptyMap());
+    metalake = client.loadMetalake(metalakeName);
+  }
+
+  private Catalog createCatalog() throws SQLException {
+    Map<String, String> catalogProperties = Maps.newHashMap();
+    String jdbcUrl = postgresContainer.getJdbcUrl(testDbName);
+    catalogProperties.put(
+        JdbcConfig.JDBC_DRIVER.getKey(), postgresContainer.getDriverClassName(testDbName));
+    catalogProperties.put(JdbcConfig.JDBC_URL.getKey(), jdbcUrl);
+    catalogProperties.put(JdbcConfig.JDBC_DATABASE.getKey(), testDbName.toString());
+    catalogProperties.put(JdbcConfig.USERNAME.getKey(), postgresContainer.getUsername());
+    catalogProperties.put(JdbcConfig.PASSWORD.getKey(), postgresContainer.getPassword());
+
+    return metalake.createCatalog(
+        catalogName, Catalog.Type.RELATIONAL, provider, "comment", catalogProperties);
+  }
+
+  private void createSchema() {
+    catalog.asSchemas().createSchema(schemaName, "view write test schema", Collections.emptyMap());
+  }
+
+  private void createBaseTable() {
+    postgreSqlService.executeQuery(
+        "CREATE TABLE \"" + schemaName + "\".base_table (id INT, name VARCHAR(255))");
+  }
+
+  private void cleanupAll() {
+    NameIdentifier[] views = catalog.asViewCatalog().listViews(Namespace.of(schemaName));
+    for (NameIdentifier view : views) {
+      catalog.asViewCatalog().dropView(view);
+    }
+  }
+}

--- a/catalogs/catalog-jdbc-postgresql/src/test/java/org/apache/gravitino/catalog/postgresql/operation/TestPostgreSqlViewOperations.java
+++ b/catalogs/catalog-jdbc-postgresql/src/test/java/org/apache/gravitino/catalog/postgresql/operation/TestPostgreSqlViewOperations.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog.postgresql.operation;
+
+import org.apache.gravitino.rel.Dialects;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/** Tests for {@link PostgreSqlViewOperations}. */
+public class TestPostgreSqlViewOperations {
+
+  private PostgreSqlViewOperations ops;
+
+  @BeforeEach
+  void setUp() {
+    ops = new PostgreSqlViewOperations();
+  }
+
+  @Test
+  public void testDialectName() {
+    Assertions.assertEquals(Dialects.POSTGRESQL, ops.dialectName());
+  }
+
+  @Test
+  public void testQuoteIdentifier() {
+    Assertions.assertEquals("\"my_view\"", ops.quoteIdentifier("my_view"));
+  }
+
+  @Test
+  public void testQuoteIdentifierEscapesDoubleQuote() {
+    Assertions.assertEquals("\"my\"\"view\"", ops.quoteIdentifier("my\"view"));
+  }
+
+  @Test
+  public void testGenerateListViewsSqlIsParameterized() {
+    String sql = ops.generateListViewsSql();
+    Assertions.assertTrue(sql.contains("?"), "SQL should contain parameter placeholder");
+    Assertions.assertTrue(
+        sql.toLowerCase().contains("information_schema"), "SQL should query information_schema");
+  }
+
+  @Test
+  public void testGenerateLoadViewSqlIsParameterized() {
+    String sql = ops.generateLoadViewSql();
+    Assertions.assertTrue(sql.contains("?"), "SQL should contain parameter placeholder");
+    Assertions.assertTrue(
+        sql.toLowerCase().contains("view_definition"), "SQL should select view_definition");
+  }
+}

--- a/catalogs/catalog-jdbc-postgresql/src/test/java/org/apache/gravitino/catalog/postgresql/operation/TestPostgreSqlViewOperations.java
+++ b/catalogs/catalog-jdbc-postgresql/src/test/java/org/apache/gravitino/catalog/postgresql/operation/TestPostgreSqlViewOperations.java
@@ -63,4 +63,36 @@ public class TestPostgreSqlViewOperations {
     Assertions.assertTrue(
         sql.toLowerCase().contains("view_definition"), "SQL should select view_definition");
   }
+
+  @Test
+  public void testGenerateCreateViewSql() {
+    String sql = ops.generateCreateViewSql("my_view", "SELECT 1");
+    Assertions.assertTrue(sql.contains("CREATE VIEW"), "Should contain CREATE VIEW");
+    Assertions.assertTrue(sql.contains("\"my_view\""), "Should quote view name with double quotes");
+    Assertions.assertTrue(sql.contains("SELECT 1"), "Should contain the view definition");
+  }
+
+  @Test
+  public void testGenerateReplaceViewSql() {
+    String sql = ops.generateReplaceViewSql("my_view", "SELECT 2");
+    Assertions.assertTrue(
+        sql.contains("CREATE OR REPLACE VIEW"), "Should contain CREATE OR REPLACE VIEW");
+    Assertions.assertTrue(sql.contains("\"my_view\""), "Should quote view name");
+  }
+
+  @Test
+  public void testGenerateRenameViewSql() {
+    String sql = ops.generateRenameViewSql("old_view", "new_view");
+    Assertions.assertTrue(sql.contains("ALTER VIEW"), "PostgreSQL uses ALTER VIEW for rename");
+    Assertions.assertTrue(sql.contains("RENAME TO"), "Should contain RENAME TO");
+    Assertions.assertTrue(sql.contains("\"old_view\""), "Should quote old name");
+    Assertions.assertTrue(sql.contains("\"new_view\""), "Should quote new name");
+  }
+
+  @Test
+  public void testGenerateDropViewSql() {
+    String sql = ops.generateDropViewSql("my_view");
+    Assertions.assertTrue(sql.contains("DROP VIEW"), "Should contain DROP VIEW");
+    Assertions.assertTrue(sql.contains("\"my_view\""), "Should quote view name");
+  }
 }


### PR DESCRIPTION
> **Depends on:** #11207 (view list/load support). Please review and merge #11207 first.
> **Note:** This PR is rebased on top of #11207. The GitHub diff includes both PRs since the base branch is `main`. The incremental write-only changes are ~1300 lines.

### What changes were proposed in this pull request?

Add write view operations (`createView`, `alterView`, `dropView`) for JDBC catalogs covering MySQL and PostgreSQL. This is the second of two PRs split from #11123, stacked on #11207 (read operations).

Key changes:
- Add `create`, `replaceDefinition`, `rename`, `drop` methods to `JdbcViewOperations`
- Add `createView`, `alterView`, `dropView` to `JdbcViewCatalogOperations`
- Add write SQL generation to `MysqlViewOperations` and `PostgreSqlViewOperations`
- Wire write methods into `MysqlCatalogOperations` and `PostgreSQLCatalogOperations`
- Add `setComment` support for PostgreSQL views via `COMMENT ON VIEW`

Includes review fixes:
- `replaceDefinition` checks view existence before executing `CREATE OR REPLACE VIEW`
- `extractSqlRepresentation` prefers matching dialect when multiple representations are provided
- `schemaExists` catches `NoSuchSchemaException` instead of broad `Exception`
- Safe stream-based `SQLRepresentation[]` conversion instead of direct array cast

### Why are the changes needed?

Completes the JDBC view CRUD support started in #11207. Users can now create, rename, replace, and drop views through the Gravitino API for MySQL and PostgreSQL catalogs.

Fix: #11001

### Does this PR introduce _any_ user-facing change?

Yes. `catalog.asViewCatalog().createView()`, `alterView()`, and `dropView()` now work for MySQL and PostgreSQL JDBC catalogs.

### How was this patch tested?

- Unit tests: Extended `TestJdbcViewCatalogOperations`, `TestMysqlViewOperations`, `TestPostgreSqlViewOperations` with write operation tests
- Integration tests: `CatalogMysqlViewWriteIT`, `CatalogPostgreSqlViewWriteIT` (test create/alter/drop through Gravitino API against Docker containers)

### Known Limitations

- **MySQL view comments**: MySQL does not support view-level comments via DDL. Comments passed to `createView()` are silently discarded on MySQL.
- **PostgreSQL comment round-trip**: Comments are set via `COMMENT ON VIEW` but `loadView()` does not read them back from `pg_description`. Follow-up item.
- **Non-transactional alterView**: Changes are applied sequentially without a transaction. Unlike `alterTable` (which batches non-rename changes into a single SQL and forbids mixing rename with other changes), `alterView` applies each change as a separate SQL statement and allows rename to be combined with other changes. The validation pass rejects unsupported changes before any are applied.