### PR TITLE
[#11192] fix: Support UUID type mapping in PostgreSQL catalog and Spark converter

### DIFF
--- a/catalogs/catalog-jdbc-postgresql/src/main/java/org/apache/gravitino/catalog/postgresql/converter/PostgreSqlTypeConverter.java
+++ b/catalogs/catalog-jdbc-postgresql/src/main/java/org/apache/gravitino/catalog/postgresql/converter/PostgreSqlTypeConverter.java
@@ -39,6 +39,7 @@ public class PostgreSqlTypeConverter extends JdbcTypeConverter {
   static final String NUMERIC = "numeric";
   static final String BPCHAR = "bpchar";
   static final String BYTEA = "bytea";
+  static final String UUID = "uuid";
   @VisibleForTesting static final String JDBC_ARRAY_PREFIX = "_";
   @VisibleForTesting static final String ARRAY_TOKEN = "[]";
   @VisibleForTesting static final int DEFAULT_NUMERIC_PRECISION = 38;
@@ -97,6 +98,8 @@ public class PostgreSqlTypeConverter extends JdbcTypeConverter {
         return Types.StringType.get();
       case BYTEA:
         return Types.BinaryType.get();
+      case UUID:
+        return Types.UUIDType.get();
       default:
         return Types.ExternalType.of(typeBean.getTypeName());
     }
@@ -141,6 +144,8 @@ public class PostgreSqlTypeConverter extends JdbcTypeConverter {
       return BPCHAR + "(" + ((Types.FixedCharType) type).length() + ")";
     } else if (type instanceof Types.BinaryType) {
       return BYTEA;
+    } else if (type instanceof Types.UUIDType) {
+      return UUID;
     } else if (type instanceof Types.ListType) {
       return fromGravitinoArrayType((ListType) type);
     } else if (type instanceof Types.ExternalType) {

--- a/catalogs/catalog-jdbc-postgresql/src/test/java/org/apache/gravitino/catalog/postgresql/converter/TestPostgreSqlTypeConverter.java
+++ b/catalogs/catalog-jdbc-postgresql/src/test/java/org/apache/gravitino/catalog/postgresql/converter/TestPostgreSqlTypeConverter.java
@@ -36,6 +36,7 @@ import static org.apache.gravitino.catalog.postgresql.converter.PostgreSqlTypeCo
 import static org.apache.gravitino.catalog.postgresql.converter.PostgreSqlTypeConverter.INT_8;
 import static org.apache.gravitino.catalog.postgresql.converter.PostgreSqlTypeConverter.JDBC_ARRAY_PREFIX;
 import static org.apache.gravitino.catalog.postgresql.converter.PostgreSqlTypeConverter.NUMERIC;
+import static org.apache.gravitino.catalog.postgresql.converter.PostgreSqlTypeConverter.UUID;
 
 import org.apache.gravitino.catalog.jdbc.converter.JdbcTypeConverter;
 import org.apache.gravitino.rel.types.Type;
@@ -87,6 +88,7 @@ public class TestPostgreSqlTypeConverter {
     checkJdbcTypeToGravitinoType(Types.FixedCharType.of(20), BPCHAR, 20, null, 0);
     checkJdbcTypeToGravitinoType(Types.StringType.get(), TEXT, null, null, 0);
     checkJdbcTypeToGravitinoType(Types.BinaryType.get(), BYTEA, null, null, 0);
+    checkJdbcTypeToGravitinoType(Types.UUIDType.get(), UUID, null, null, 0);
     checkJdbcTypeToGravitinoType(
         Types.ExternalType.of(USER_DEFINED_TYPE), USER_DEFINED_TYPE, null, null, 0);
   }
@@ -128,6 +130,7 @@ public class TestPostgreSqlTypeConverter {
     checkGravitinoTypeToJdbcType(BPCHAR + "(20)", Types.FixedCharType.of(20));
     checkGravitinoTypeToJdbcType(TEXT, Types.StringType.get());
     checkGravitinoTypeToJdbcType(BYTEA, Types.BinaryType.get());
+    checkGravitinoTypeToJdbcType(UUID, Types.UUIDType.get());
     checkGravitinoTypeToJdbcType(USER_DEFINED_TYPE, Types.ExternalType.of(USER_DEFINED_TYPE));
     Assertions.assertThrows(
         IllegalArgumentException.class,

--- a/catalogs/catalog-jdbc-postgresql/src/test/java/org/apache/gravitino/catalog/postgresql/integration/test/CatalogPostgreSqlIT.java
+++ b/catalogs/catalog-jdbc-postgresql/src/test/java/org/apache/gravitino/catalog/postgresql/integration/test/CatalogPostgreSqlIT.java
@@ -1115,6 +1115,9 @@ public class CatalogPostgreSqlIT extends BaseIT {
               Literals.decimalLiteral(Decimal.of("1.2", 6, 2)), column.defaultValue());
           break;
         case "uuid":
+          Assertions.assertEquals(Types.UUIDType.get(), column.dataType());
+          Assertions.assertEquals(Column.DEFAULT_VALUE_NOT_SET, column.defaultValue());
+          break;
         case "character_col_1":
         case "jsonb":
           Assertions.assertEquals(Column.DEFAULT_VALUE_NOT_SET, column.defaultValue());

--- a/docs/jdbc-postgresql-catalog.md
+++ b/docs/jdbc-postgresql-catalog.md
@@ -108,10 +108,11 @@ Please refer to [Manage Relational Metadata Using Gravitino](./manage-relational
 | `VarChar`         | `Varchar`        |
 | `FixedChar`       | `Bpchar`         |
 | `Binary`          | `Bytea`          |
+| `UUID`            | `Uuid`           |
 | `List`            | `Array`          |
 
 :::info
-PostgreSQL doesn't support Gravitino `Fixed` `Struct` `Map` `IntervalDay` `IntervalYear` `Union` `UUID` type.
+PostgreSQL doesn't support Gravitino `Fixed` `Struct` `Map` `IntervalDay` `IntervalYear` `Union` type.
 Meanwhile, the data types other than listed above are mapped to Gravitino **[External Type](./manage-relational-metadata-using-gravitino.md#external-type)** that represents an unresolvable data type since 0.6.0-incubating.
 :::
 

--- a/docs/spark-connector/spark-connector.md
+++ b/docs/spark-connector/spark-connector.md
@@ -104,3 +104,8 @@ Gravitino spark connector support the following datatype mapping between Spark a
 | `ArrayType`                       | `array`                       | 0.5.0         |
 | `MapType`                         | `map`                         | 0.5.0         |
 | `StructType`                      | `struct`                      | 0.5.0         |
+
+:::note
+For Gravitino `UUID` type, Spark connector represents it as `StringType` because Spark has no native UUID type.
+This behavior is consistent with Spark built-in PostgreSQL JDBC mapping (`uuid` -> `StringType`).
+:::

--- a/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/SparkTypeConverter.java
+++ b/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/SparkTypeConverter.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.gravitino.rel.types.Type;
 import org.apache.gravitino.rel.types.Types;
+import org.apache.gravitino.rel.types.Types.UUIDType;
 import org.apache.spark.sql.types.ArrayType;
 import org.apache.spark.sql.types.BinaryType;
 import org.apache.spark.sql.types.BooleanType;
@@ -149,6 +150,8 @@ public class SparkTypeConverter {
     } else if (gravitinoType instanceof Types.FixedCharType) {
       Types.FixedCharType charType = (Types.FixedCharType) gravitinoType;
       return CharType.apply((charType.length()));
+    } else if (gravitinoType instanceof UUIDType) {
+      return DataTypes.StringType;
     } else if (gravitinoType instanceof Types.BinaryType) {
       return DataTypes.BinaryType;
     } else if (gravitinoType instanceof Types.BooleanType) {

--- a/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/SparkTypeConverter.java
+++ b/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/SparkTypeConverter.java
@@ -151,6 +151,8 @@ public class SparkTypeConverter {
       Types.FixedCharType charType = (Types.FixedCharType) gravitinoType;
       return CharType.apply((charType.length()));
     } else if (gravitinoType instanceof UUIDType) {
+      // Spark has no native UUID type. Represent UUID as StringType to align with
+      // Spark built-in PostgreSQL JDBC mapping (uuid -> StringType).
       return DataTypes.StringType;
     } else if (gravitinoType instanceof Types.BinaryType) {
       return DataTypes.BinaryType;

--- a/spark-connector/spark-common/src/test/java/org/apache/gravitino/spark/connector/TestSparkTypeConverter.java
+++ b/spark-connector/spark-common/src/test/java/org/apache/gravitino/spark/connector/TestSparkTypeConverter.java
@@ -40,6 +40,7 @@ import org.apache.gravitino.rel.types.Types.ShortType;
 import org.apache.gravitino.rel.types.Types.StringType;
 import org.apache.gravitino.rel.types.Types.StructType;
 import org.apache.gravitino.rel.types.Types.TimestampType;
+import org.apache.gravitino.rel.types.Types.UUIDType;
 import org.apache.gravitino.rel.types.Types.VarCharType;
 import org.apache.spark.sql.types.CharType;
 import org.apache.spark.sql.types.DataType;
@@ -93,6 +94,8 @@ public class TestSparkTypeConverter {
     gravitinoToSparkTypeMapper.forEach(
         (gravitinoType, sparkType) ->
             Assertions.assertEquals(sparkType, sparkTypeConverter.toSparkType(gravitinoType)));
+
+    Assertions.assertEquals(DataTypes.StringType, sparkTypeConverter.toSparkType(UUIDType.get()));
 
     notSupportGravitinoTypes.forEach(
         gravitinoType ->


### PR DESCRIPTION
### What changes were proposed in this pull request?
- Added native UUID mapping in PostgreSqlTypeConverter:
  - PostgreSQL uuid -> Gravitino UUIDType
  - Gravitino UUIDType -> PostgreSQL uuid
- Added Spark UUID handling in SparkTypeConverter:
  - UUIDType -> Spark StringType, so schema conversion no longer fails in Spark connector paths.
- Extended existing tests (without creating new test methods where possible):
  - PostgreSQL converter unit tests
  - Spark converter unit tests
  - PostgreSQL integration test assertion for uuid column type
- Updated PostgreSQL JDBC catalog docs to include UUID mapping support.

### Why are the changes needed?
Issue #11192 reports failures around UUID type handling, where UUID could be treated as unresolved and break Spark-side type conversion flows (for example metadata/schema paths used by SHOW CREATE TABLE).
This patch makes UUID a first-class mapped type for PostgreSQL and ensures Spark converter can consume it safely.

Fix: #11192

### Does this PR introduce _any_ user-facing change?
Yes.
- PostgreSQL uuid columns are now recognized as Gravitino UUIDType instead of unresolved external type in this path.
- Spark connector can convert UUIDType to Spark schema (StringType), avoiding unsupported type errors.
- PostgreSQL catalog type mapping documentation now lists UUID support.

### How was this patch tested?
- ./gradlew :catalogs:catalog-jdbc-postgresql:spotlessApply
- ./gradlew :spark-connector:spark-common:spotlessApply
- ./gradlew :catalogs:catalog-jdbc-postgresql:test --tests org.apache.gravitino.catalog.postgresql.converter.TestPostgreSqlTypeConverter -PskipITs -PskipDockerTests=true
- ./gradlew :spark-connector:spark-common:test --tests org.apache.gravitino.spark.connector.TestSparkTypeConverter -PskipITs -PskipDockerTests=true
- Docker image check passed for postgres:13
- ./gradlew :catalogs:catalog-jdbc-postgresql:test --tests org.apache.gravitino.catalog.postgresql.integration.test.CatalogPostgreSqlIT -PskipDockerTests=false
