### PR TITLE
[#10965] feat(idp-basic): Implement Basic authentication flow

### DIFF
--- a/common/src/main/java/org/apache/gravitino/auth/AuthenticatorType.java
+++ b/common/src/main/java/org/apache/gravitino/auth/AuthenticatorType.java
@@ -31,5 +31,8 @@ public enum AuthenticatorType {
   OAUTH,
 
   /** Authentication that uses Kerberos. */
-  KERBEROS
+  KERBEROS,
+
+  /** Authentication that uses built-in IdP username and password. */
+  BASIC
 }

--- a/plugins/idp-basic/build.gradle.kts
+++ b/plugins/idp-basic/build.gradle.kts
@@ -26,6 +26,8 @@ plugins {
 dependencies {
   annotationProcessor(libs.lombok)
 
+  compileOnly(project(":api"))
+  compileOnly(project(":server-common"))
   implementation(project(":common"))
   implementation(project(":core"))
 
@@ -37,11 +39,14 @@ dependencies {
   compileOnly(libs.lombok)
   compileOnly(libs.slf4j.api)
 
+  testImplementation(project(":api"))
   testImplementation(project(":common"))
   testImplementation(project(":core"))
+  testImplementation(project(":server-common"))
   testImplementation(project(":integration-test-common", "testArtifacts"))
 
   testImplementation(libs.awaitility)
+  testImplementation(libs.mockito.inline)
   testImplementation(libs.junit.jupiter.api)
   testImplementation(libs.junit.jupiter.params)
   testImplementation(libs.commons.io)

--- a/plugins/idp-basic/src/main/java/org/apache/gravitino/idp/auth/BasicAuthenticator.java
+++ b/plugins/idp-basic/src/main/java/org/apache/gravitino/idp/auth/BasicAuthenticator.java
@@ -26,6 +26,7 @@ import java.util.Base64;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.gravitino.Config;
 import org.apache.gravitino.UserGroup;
 import org.apache.gravitino.UserPrincipal;
@@ -100,7 +101,8 @@ public class BasicAuthenticator implements Authenticator {
 
   private BasicCredentials parseBasicCredentials(String authData) {
     String credential = authData.substring(AuthConstants.AUTHORIZATION_BASIC_HEADER.length());
-    if (credential.trim().isEmpty()) {
+    credential = credential.trim();
+    if (credential.isEmpty()) {
       throw new BadRequestException("Malformed Basic authorization header: missing credentials");
     }
 
@@ -120,7 +122,7 @@ public class BasicAuthenticator implements Authenticator {
       }
 
       String password = decodedCredential.substring(separatorIndex + 1);
-      if (password.isEmpty()) {
+      if (StringUtils.isBlank(password)) {
         throw invalidCredentials();
       }
       return new BasicCredentials(userName, password);

--- a/plugins/idp-basic/src/main/java/org/apache/gravitino/idp/auth/BasicAuthenticator.java
+++ b/plugins/idp-basic/src/main/java/org/apache/gravitino/idp/auth/BasicAuthenticator.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.idp.auth;
+
+import com.google.common.base.Preconditions;
+import java.nio.charset.StandardCharsets;
+import java.security.Principal;
+import java.util.Base64;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.apache.gravitino.Config;
+import org.apache.gravitino.UserGroup;
+import org.apache.gravitino.UserPrincipal;
+import org.apache.gravitino.auth.AuthConstants;
+import org.apache.gravitino.exceptions.BadRequestException;
+import org.apache.gravitino.exceptions.UnauthorizedException;
+import org.apache.gravitino.idp.basic.password.PasswordHasher;
+import org.apache.gravitino.idp.basic.password.PasswordHasherFactory;
+import org.apache.gravitino.idp.exception.NotFoundException;
+import org.apache.gravitino.idp.storage.po.IdpUserPO;
+import org.apache.gravitino.idp.storage.service.IdpUserMetaService;
+import org.apache.gravitino.server.authentication.Authenticator;
+
+/** Authenticates HTTP Basic credentials against built-in IdP user metadata. */
+public class BasicAuthenticator implements Authenticator {
+
+  private static final String BASIC_AUTH_CHALLENGE = "Basic";
+
+  private IdpUserMetaService userMetaService;
+  private PasswordHasher passwordHasher;
+
+  /** Creates a {@link BasicAuthenticator} for reflective loading. */
+  public BasicAuthenticator() {}
+
+  BasicAuthenticator(IdpUserMetaService userMetaService, PasswordHasher passwordHasher) {
+    this.userMetaService = userMetaService;
+    this.passwordHasher = passwordHasher;
+  }
+
+  @Override
+  public boolean isDataFromToken() {
+    return true;
+  }
+
+  @Override
+  public Principal authenticateToken(byte[] tokenData) {
+    Preconditions.checkState(
+        userMetaService != null && passwordHasher != null,
+        "Basic authenticator has not been initialized");
+    if (tokenData == null) {
+      throw new UnauthorizedException("Empty token authorization header", BASIC_AUTH_CHALLENGE);
+    }
+
+    String authData = new String(tokenData, StandardCharsets.UTF_8);
+    if (authData.trim().isEmpty()) {
+      throw new UnauthorizedException("Empty token authorization header", BASIC_AUTH_CHALLENGE);
+    }
+
+    if (!authData.startsWith(AuthConstants.AUTHORIZATION_BASIC_HEADER)) {
+      throw new UnauthorizedException("Invalid token authorization header", BASIC_AUTH_CHALLENGE);
+    }
+
+    String credential = authData.substring(AuthConstants.AUTHORIZATION_BASIC_HEADER.length());
+    if (credential.trim().isEmpty()) {
+      throw new BadRequestException("Malformed Basic authorization header: missing credentials");
+    }
+
+    try {
+      String decodedCredential =
+          new String(Base64.getDecoder().decode(credential), StandardCharsets.UTF_8);
+      int separatorIndex = decodedCredential.indexOf(':');
+      if (separatorIndex < 0) {
+        throw new BadRequestException(
+            "Malformed Basic authorization header: credentials must be in username:password format");
+      }
+
+      String userName = decodedCredential.substring(0, separatorIndex);
+      if (userName.isEmpty()) {
+        throw new BadRequestException(
+            "Malformed Basic authorization header: username must not be empty");
+      }
+
+      String password = decodedCredential.substring(separatorIndex + 1);
+      if (password.isEmpty()) {
+        throw new UnauthorizedException("Invalid username or password", BASIC_AUTH_CHALLENGE);
+      }
+
+      IdpUserPO userPO = loadUser(userName);
+      if (!passwordHasher.verify(password, userPO.getPasswordHash())) {
+        throw new UnauthorizedException("Invalid username or password", BASIC_AUTH_CHALLENGE);
+      }
+
+      List<UserGroup> groups =
+          userMetaService.listGroupNamesByUsername(userName).stream()
+              .map(groupName -> new UserGroup(Optional.empty(), groupName))
+              .collect(Collectors.toList());
+      return new UserPrincipal(userName, groups, authData);
+    } catch (IllegalArgumentException e) {
+      throw new BadRequestException(e, "Malformed Basic authorization header: invalid base64");
+    }
+  }
+
+  @Override
+  public void initialize(Config config) {
+    this.userMetaService = IdpUserMetaService.getInstance();
+    this.passwordHasher = PasswordHasherFactory.create();
+  }
+
+  @Override
+  public boolean supportsToken(byte[] tokenData) {
+    return tokenData != null
+        && new String(tokenData, StandardCharsets.UTF_8)
+            .startsWith(AuthConstants.AUTHORIZATION_BASIC_HEADER);
+  }
+
+  private IdpUserPO loadUser(String userName) {
+    try {
+      return userMetaService.getIdpUserByUsername(userName);
+    } catch (NotFoundException e) {
+      throw new UnauthorizedException("Invalid username or password", BASIC_AUTH_CHALLENGE);
+    }
+  }
+}

--- a/plugins/idp-basic/src/main/java/org/apache/gravitino/idp/auth/BasicAuthenticator.java
+++ b/plugins/idp-basic/src/main/java/org/apache/gravitino/idp/auth/BasicAuthenticator.java
@@ -42,7 +42,7 @@ import org.apache.gravitino.server.authentication.Authenticator;
 /** Authenticates HTTP Basic credentials against built-in IdP user metadata. */
 public class BasicAuthenticator implements Authenticator {
 
-  private static final String BASIC_AUTH_CHALLENGE = "Basic";
+  private static final String BASIC_CHALLENGE = AuthConstants.AUTHORIZATION_BASIC_HEADER.trim();
 
   private IdpUserMetaService userMetaService;
   private PasswordHasher passwordHasher;
@@ -65,19 +65,40 @@ public class BasicAuthenticator implements Authenticator {
     Preconditions.checkState(
         userMetaService != null && passwordHasher != null,
         "Basic authenticator has not been initialized");
+    String authData = requireBasicAuthHeader(tokenData);
+    BasicCredentials credentials = parseBasicCredentials(authData);
+    return authenticate(credentials, authData);
+  }
+
+  @Override
+  public void initialize(Config config) {
+    this.userMetaService = IdpUserMetaService.getInstance();
+    this.passwordHasher = PasswordHasherFactory.create();
+  }
+
+  @Override
+  public boolean supportsToken(byte[] tokenData) {
+    return tokenData != null
+        && new String(tokenData, StandardCharsets.UTF_8)
+            .startsWith(AuthConstants.AUTHORIZATION_BASIC_HEADER);
+  }
+
+  private String requireBasicAuthHeader(byte[] tokenData) {
     if (tokenData == null) {
-      throw new UnauthorizedException("Empty token authorization header", BASIC_AUTH_CHALLENGE);
+      throw unauthorized("Empty token authorization header");
     }
 
     String authData = new String(tokenData, StandardCharsets.UTF_8);
     if (authData.trim().isEmpty()) {
-      throw new UnauthorizedException("Empty token authorization header", BASIC_AUTH_CHALLENGE);
+      throw unauthorized("Empty token authorization header");
     }
-
     if (!authData.startsWith(AuthConstants.AUTHORIZATION_BASIC_HEADER)) {
-      throw new UnauthorizedException("Invalid token authorization header", BASIC_AUTH_CHALLENGE);
+      throw unauthorized("Invalid token authorization header");
     }
+    return authData;
+  }
 
+  private BasicCredentials parseBasicCredentials(String authData) {
     String credential = authData.substring(AuthConstants.AUTHORIZATION_BASIC_HEADER.length());
     if (credential.trim().isEmpty()) {
       throw new BadRequestException("Malformed Basic authorization header: missing credentials");
@@ -100,42 +121,58 @@ public class BasicAuthenticator implements Authenticator {
 
       String password = decodedCredential.substring(separatorIndex + 1);
       if (password.isEmpty()) {
-        throw new UnauthorizedException("Invalid username or password", BASIC_AUTH_CHALLENGE);
+        throw invalidCredentials();
       }
-
-      IdpUserPO userPO = loadUser(userName);
-      if (!passwordHasher.verify(password, userPO.getPasswordHash())) {
-        throw new UnauthorizedException("Invalid username or password", BASIC_AUTH_CHALLENGE);
-      }
-
-      List<UserGroup> groups =
-          userMetaService.listGroupNamesByUsername(userName).stream()
-              .map(groupName -> new UserGroup(Optional.empty(), groupName))
-              .collect(Collectors.toList());
-      return new UserPrincipal(userName, groups, authData);
+      return new BasicCredentials(userName, password);
     } catch (IllegalArgumentException e) {
       throw new BadRequestException(e, "Malformed Basic authorization header: invalid base64");
     }
   }
 
-  @Override
-  public void initialize(Config config) {
-    this.userMetaService = IdpUserMetaService.getInstance();
-    this.passwordHasher = PasswordHasherFactory.create();
-  }
+  private UserPrincipal authenticate(BasicCredentials credentials, String authData) {
+    IdpUserPO userPO = loadUser(credentials.userName());
+    if (!passwordHasher.verify(credentials.password(), userPO.getPasswordHash())) {
+      throw invalidCredentials();
+    }
 
-  @Override
-  public boolean supportsToken(byte[] tokenData) {
-    return tokenData != null
-        && new String(tokenData, StandardCharsets.UTF_8)
-            .startsWith(AuthConstants.AUTHORIZATION_BASIC_HEADER);
+    List<UserGroup> groups =
+        userMetaService.listGroupNamesByUsername(credentials.userName()).stream()
+            .map(groupName -> new UserGroup(Optional.empty(), groupName))
+            .collect(Collectors.toList());
+    return new UserPrincipal(credentials.userName(), groups, authData);
   }
 
   private IdpUserPO loadUser(String userName) {
     try {
       return userMetaService.getIdpUserByUsername(userName);
     } catch (NotFoundException e) {
-      throw new UnauthorizedException("Invalid username or password", BASIC_AUTH_CHALLENGE);
+      throw invalidCredentials();
+    }
+  }
+
+  private static UnauthorizedException unauthorized(String message) {
+    return new UnauthorizedException(message, BASIC_CHALLENGE);
+  }
+
+  private static UnauthorizedException invalidCredentials() {
+    return unauthorized("Invalid username or password");
+  }
+
+  private static final class BasicCredentials {
+    private final String userName;
+    private final String password;
+
+    private BasicCredentials(String userName, String password) {
+      this.userName = userName;
+      this.password = password;
+    }
+
+    private String userName() {
+      return userName;
+    }
+
+    private String password() {
+      return password;
     }
   }
 }

--- a/plugins/idp-basic/src/test/java/org/apache/gravitino/idp/auth/TestBasicAuthenticator.java
+++ b/plugins/idp-basic/src/test/java/org/apache/gravitino/idp/auth/TestBasicAuthenticator.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.idp.auth;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Base64;
+import org.apache.gravitino.UserPrincipal;
+import org.apache.gravitino.auth.AuthConstants;
+import org.apache.gravitino.exceptions.BadRequestException;
+import org.apache.gravitino.exceptions.UnauthorizedException;
+import org.apache.gravitino.idp.basic.password.PasswordHasher;
+import org.apache.gravitino.idp.exception.NotFoundException;
+import org.apache.gravitino.idp.storage.po.IdpUserPO;
+import org.apache.gravitino.idp.storage.service.IdpUserMetaService;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class TestBasicAuthenticator {
+
+  @Test
+  void testAuthenticateTokenThrowsWhenAuthenticatorNotInitialized() {
+    IllegalStateException exception =
+        Assertions.assertThrows(
+            IllegalStateException.class, () -> new BasicAuthenticator().authenticateToken(null));
+
+    Assertions.assertEquals("Basic authenticator has not been initialized", exception.getMessage());
+  }
+
+  @Test
+  void testAuthenticateTokenThrowsUnauthorizedWhenHeaderMissing() {
+    BasicAuthenticator authenticator = authenticator();
+    UnauthorizedException exception =
+        Assertions.assertThrows(
+            UnauthorizedException.class, () -> authenticator.authenticateToken(null));
+
+    Assertions.assertEquals("Empty token authorization header", exception.getMessage());
+    Assertions.assertEquals("Basic", exception.getChallenges().get(0));
+  }
+
+  @Test
+  void testAuthenticateTokenThrowsBadRequestWhenBasicCredentialMissing() {
+    BasicAuthenticator authenticator = authenticator();
+    BadRequestException exception =
+        Assertions.assertThrows(
+            BadRequestException.class,
+            () ->
+                authenticator.authenticateToken(
+                    AuthConstants.AUTHORIZATION_BASIC_HEADER.getBytes(StandardCharsets.UTF_8)));
+
+    Assertions.assertEquals(
+        "Malformed Basic authorization header: missing credentials", exception.getMessage());
+  }
+
+  @Test
+  void testAuthenticateTokenReturnsPrincipalWhenCredentialsValid() {
+    IdpUserMetaService userMetaService = mock(IdpUserMetaService.class);
+    PasswordHasher passwordHasher = mock(PasswordHasher.class);
+    IdpUserPO userPO = mock(IdpUserPO.class);
+    when(userMetaService.getIdpUserByUsername("alice")).thenReturn(userPO);
+    when(userPO.getPasswordHash()).thenReturn("hash-1");
+    when(passwordHasher.verify("Passw0rd-For-Alice", "hash-1")).thenReturn(true);
+    when(userMetaService.listGroupNamesByUsername("alice"))
+        .thenReturn(Arrays.asList("group-a", "group-b"));
+    BasicAuthenticator authenticator = new BasicAuthenticator(userMetaService, passwordHasher);
+    String authHeader =
+        AuthConstants.AUTHORIZATION_BASIC_HEADER
+            + Base64.getEncoder()
+                .encodeToString("alice:Passw0rd-For-Alice".getBytes(StandardCharsets.UTF_8));
+
+    UserPrincipal principal =
+        (UserPrincipal)
+            authenticator.authenticateToken(authHeader.getBytes(StandardCharsets.UTF_8));
+
+    Assertions.assertEquals("alice", principal.getName());
+    Assertions.assertEquals(authHeader, principal.getAccessToken().orElse(null));
+    Assertions.assertEquals(2, principal.getGroups().size());
+    Assertions.assertEquals("group-a", principal.getGroups().get(0).getGroupname());
+    Assertions.assertEquals("group-b", principal.getGroups().get(1).getGroupname());
+  }
+
+  @Test
+  void testAuthenticateTokenThrowsUnauthorizedWhenUserMissing() {
+    IdpUserMetaService userMetaService = mock(IdpUserMetaService.class);
+    PasswordHasher passwordHasher = mock(PasswordHasher.class);
+    when(userMetaService.getIdpUserByUsername("alice"))
+        .thenThrow(new NotFoundException("IdP user not found: %s", "alice"));
+    BasicAuthenticator authenticator = new BasicAuthenticator(userMetaService, passwordHasher);
+    String authHeader =
+        AuthConstants.AUTHORIZATION_BASIC_HEADER
+            + Base64.getEncoder()
+                .encodeToString("alice:Passw0rd-For-Alice".getBytes(StandardCharsets.UTF_8));
+
+    UnauthorizedException exception =
+        Assertions.assertThrows(
+            UnauthorizedException.class,
+            () -> authenticator.authenticateToken(authHeader.getBytes(StandardCharsets.UTF_8)));
+
+    Assertions.assertEquals("Invalid username or password", exception.getMessage());
+    Assertions.assertEquals("Basic", exception.getChallenges().get(0));
+  }
+
+  @Test
+  void testAuthenticateTokenThrowsUnauthorizedWhenPasswordMismatch() {
+    IdpUserMetaService userMetaService = mock(IdpUserMetaService.class);
+    PasswordHasher passwordHasher = mock(PasswordHasher.class);
+    IdpUserPO userPO = mock(IdpUserPO.class);
+    when(userMetaService.getIdpUserByUsername("alice")).thenReturn(userPO);
+    when(userPO.getPasswordHash()).thenReturn("hash-1");
+    when(passwordHasher.verify("Passw0rd-For-Alice", "hash-1")).thenReturn(false);
+    BasicAuthenticator authenticator = new BasicAuthenticator(userMetaService, passwordHasher);
+    String authHeader =
+        AuthConstants.AUTHORIZATION_BASIC_HEADER
+            + Base64.getEncoder()
+                .encodeToString("alice:Passw0rd-For-Alice".getBytes(StandardCharsets.UTF_8));
+
+    UnauthorizedException exception =
+        Assertions.assertThrows(
+            UnauthorizedException.class,
+            () -> authenticator.authenticateToken(authHeader.getBytes(StandardCharsets.UTF_8)));
+
+    Assertions.assertEquals("Invalid username or password", exception.getMessage());
+    Assertions.assertEquals("Basic", exception.getChallenges().get(0));
+  }
+
+  private BasicAuthenticator authenticator() {
+    return new BasicAuthenticator(mock(IdpUserMetaService.class), mock(PasswordHasher.class));
+  }
+}

--- a/plugins/idp-basic/src/test/java/org/apache/gravitino/idp/auth/TestBasicAuthenticator.java
+++ b/plugins/idp-basic/src/test/java/org/apache/gravitino/idp/auth/TestBasicAuthenticator.java
@@ -83,14 +83,10 @@ class TestBasicAuthenticator {
     when(userMetaService.listGroupNamesByUsername("alice"))
         .thenReturn(Arrays.asList("group-a", "group-b"));
     BasicAuthenticator authenticator = new BasicAuthenticator(userMetaService, passwordHasher);
-    String authHeader =
-        AuthConstants.AUTHORIZATION_BASIC_HEADER
-            + Base64.getEncoder()
-                .encodeToString("alice:Passw0rd-For-Alice".getBytes(StandardCharsets.UTF_8));
+    String authHeader = basicAuthHeader("alice", "Passw0rd-For-Alice");
 
     UserPrincipal principal =
-        (UserPrincipal)
-            authenticator.authenticateToken(authHeader.getBytes(StandardCharsets.UTF_8));
+        (UserPrincipal) authenticator.authenticateToken(basicAuthBytes(authHeader));
 
     Assertions.assertEquals("alice", principal.getName());
     Assertions.assertEquals(authHeader, principal.getAccessToken().orElse(null));
@@ -106,15 +102,13 @@ class TestBasicAuthenticator {
     when(userMetaService.getIdpUserByUsername("alice"))
         .thenThrow(new NotFoundException("IdP user not found: %s", "alice"));
     BasicAuthenticator authenticator = new BasicAuthenticator(userMetaService, passwordHasher);
-    String authHeader =
-        AuthConstants.AUTHORIZATION_BASIC_HEADER
-            + Base64.getEncoder()
-                .encodeToString("alice:Passw0rd-For-Alice".getBytes(StandardCharsets.UTF_8));
 
     UnauthorizedException exception =
         Assertions.assertThrows(
             UnauthorizedException.class,
-            () -> authenticator.authenticateToken(authHeader.getBytes(StandardCharsets.UTF_8)));
+            () ->
+                authenticator.authenticateToken(
+                    basicAuthBytes(basicAuthHeader("alice", "Passw0rd-For-Alice"))));
 
     Assertions.assertEquals("Invalid username or password", exception.getMessage());
     Assertions.assertEquals("Basic", exception.getChallenges().get(0));
@@ -129,18 +123,26 @@ class TestBasicAuthenticator {
     when(userPO.getPasswordHash()).thenReturn("hash-1");
     when(passwordHasher.verify("Passw0rd-For-Alice", "hash-1")).thenReturn(false);
     BasicAuthenticator authenticator = new BasicAuthenticator(userMetaService, passwordHasher);
-    String authHeader =
-        AuthConstants.AUTHORIZATION_BASIC_HEADER
-            + Base64.getEncoder()
-                .encodeToString("alice:Passw0rd-For-Alice".getBytes(StandardCharsets.UTF_8));
 
     UnauthorizedException exception =
         Assertions.assertThrows(
             UnauthorizedException.class,
-            () -> authenticator.authenticateToken(authHeader.getBytes(StandardCharsets.UTF_8)));
+            () ->
+                authenticator.authenticateToken(
+                    basicAuthBytes(basicAuthHeader("alice", "Passw0rd-For-Alice"))));
 
     Assertions.assertEquals("Invalid username or password", exception.getMessage());
     Assertions.assertEquals("Basic", exception.getChallenges().get(0));
+  }
+
+  private static String basicAuthHeader(String username, String password) {
+    return AuthConstants.AUTHORIZATION_BASIC_HEADER
+        + Base64.getEncoder()
+            .encodeToString((username + ":" + password).getBytes(StandardCharsets.UTF_8));
+  }
+
+  private static byte[] basicAuthBytes(String authHeader) {
+    return authHeader.getBytes(StandardCharsets.UTF_8);
   }
 
   private BasicAuthenticator authenticator() {

--- a/plugins/idp-basic/src/test/java/org/apache/gravitino/idp/auth/TestBasicAuthenticator.java
+++ b/plugins/idp-basic/src/test/java/org/apache/gravitino/idp/auth/TestBasicAuthenticator.java
@@ -115,6 +115,90 @@ class TestBasicAuthenticator {
   }
 
   @Test
+  void testInvalidBase64() {
+    BasicAuthenticator authenticator = authenticator();
+
+    BadRequestException exception =
+        Assertions.assertThrows(
+            BadRequestException.class,
+            () -> authenticator.authenticateToken(basicAuthBytesWithCredential("not-valid!!!")));
+
+    Assertions.assertEquals(
+        "Malformed Basic authorization header: invalid base64", exception.getMessage());
+  }
+
+  @Test
+  void testMissingSeparator() {
+    BasicAuthenticator authenticator = authenticator();
+    String credential =
+        Base64.getEncoder().encodeToString("aliceonly".getBytes(StandardCharsets.UTF_8));
+
+    BadRequestException exception =
+        Assertions.assertThrows(
+            BadRequestException.class,
+            () -> authenticator.authenticateToken(basicAuthBytesWithCredential(credential)));
+
+    Assertions.assertEquals(
+        "Malformed Basic authorization header: credentials must be in username:password format",
+        exception.getMessage());
+  }
+
+  @Test
+  void testEmptyUsername() {
+    BasicAuthenticator authenticator = authenticator();
+    String credential =
+        Base64.getEncoder().encodeToString(":password".getBytes(StandardCharsets.UTF_8));
+
+    BadRequestException exception =
+        Assertions.assertThrows(
+            BadRequestException.class,
+            () -> authenticator.authenticateToken(basicAuthBytesWithCredential(credential)));
+
+    Assertions.assertEquals(
+        "Malformed Basic authorization header: username must not be empty", exception.getMessage());
+  }
+
+  @Test
+  void testTrimmedCredential() {
+    IdpUserMetaService userMetaService = mock(IdpUserMetaService.class);
+    PasswordHasher passwordHasher = mock(PasswordHasher.class);
+    IdpUserPO userPO = mock(IdpUserPO.class);
+    when(userMetaService.getIdpUserByUsername("alice")).thenReturn(userPO);
+    when(userPO.getPasswordHash()).thenReturn("hash-1");
+    when(passwordHasher.verify("Passw0rd-For-Alice", "hash-1")).thenReturn(true);
+    when(userMetaService.listGroupNamesByUsername("alice")).thenReturn(Arrays.asList());
+    BasicAuthenticator authenticator = new BasicAuthenticator(userMetaService, passwordHasher);
+    String credential =
+        "  "
+            + Base64.getEncoder()
+                .encodeToString("alice:Passw0rd-For-Alice".getBytes(StandardCharsets.UTF_8))
+            + "  ";
+
+    UserPrincipal principal =
+        (UserPrincipal) authenticator.authenticateToken(basicAuthBytesWithCredential(credential));
+
+    Assertions.assertEquals("alice", principal.getName());
+  }
+
+  @Test
+  void testBlankPassword() {
+    IdpUserMetaService userMetaService = mock(IdpUserMetaService.class);
+    PasswordHasher passwordHasher = mock(PasswordHasher.class);
+    IdpUserPO userPO = mock(IdpUserPO.class);
+    when(userMetaService.getIdpUserByUsername("alice")).thenReturn(userPO);
+    when(userPO.getPasswordHash()).thenReturn("hash-1");
+    BasicAuthenticator authenticator = new BasicAuthenticator(userMetaService, passwordHasher);
+
+    UnauthorizedException exception =
+        Assertions.assertThrows(
+            UnauthorizedException.class,
+            () -> authenticator.authenticateToken(basicAuthBytes(basicAuthHeader("alice", " "))));
+
+    Assertions.assertEquals("Invalid username or password", exception.getMessage());
+    Assertions.assertEquals("Basic", exception.getChallenges().get(0));
+  }
+
+  @Test
   void testWrongPassword() {
     IdpUserMetaService userMetaService = mock(IdpUserMetaService.class);
     PasswordHasher passwordHasher = mock(PasswordHasher.class);
@@ -143,6 +227,10 @@ class TestBasicAuthenticator {
 
   private static byte[] basicAuthBytes(String authHeader) {
     return authHeader.getBytes(StandardCharsets.UTF_8);
+  }
+
+  private static byte[] basicAuthBytesWithCredential(String credential) {
+    return (AuthConstants.AUTHORIZATION_BASIC_HEADER + credential).getBytes(StandardCharsets.UTF_8);
   }
 
   private BasicAuthenticator authenticator() {

--- a/plugins/idp-basic/src/test/java/org/apache/gravitino/idp/auth/TestBasicAuthenticator.java
+++ b/plugins/idp-basic/src/test/java/org/apache/gravitino/idp/auth/TestBasicAuthenticator.java
@@ -19,6 +19,10 @@
 
 package org.apache.gravitino.idp.auth;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -33,7 +37,6 @@ import org.apache.gravitino.idp.basic.password.PasswordHasher;
 import org.apache.gravitino.idp.exception.NotFoundException;
 import org.apache.gravitino.idp.storage.po.IdpUserPO;
 import org.apache.gravitino.idp.storage.service.IdpUserMetaService;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 class TestBasicAuthenticator {
@@ -41,34 +44,42 @@ class TestBasicAuthenticator {
   @Test
   void testNotInitialized() {
     IllegalStateException exception =
-        Assertions.assertThrows(
+        assertThrows(
             IllegalStateException.class, () -> new BasicAuthenticator().authenticateToken(null));
 
-    Assertions.assertEquals("Basic authenticator has not been initialized", exception.getMessage());
+    assertEquals("Basic authenticator has not been initialized", exception.getMessage());
+  }
+
+  @Test
+  void testSupportsBasic() {
+    BasicAuthenticator authenticator = authenticator();
+
+    assertTrue(authenticator.supportsToken(basicAuthBytes(basicAuthHeader("alice", "secret"))));
+    assertFalse(authenticator.supportsToken("Bearer token".getBytes(StandardCharsets.UTF_8)));
+    assertFalse(authenticator.supportsToken(null));
   }
 
   @Test
   void testEmptyHeader() {
     BasicAuthenticator authenticator = authenticator();
     UnauthorizedException exception =
-        Assertions.assertThrows(
-            UnauthorizedException.class, () -> authenticator.authenticateToken(null));
+        assertThrows(UnauthorizedException.class, () -> authenticator.authenticateToken(null));
 
-    Assertions.assertEquals("Empty token authorization header", exception.getMessage());
-    Assertions.assertEquals("Basic", exception.getChallenges().get(0));
+    assertEquals("Empty token authorization header", exception.getMessage());
+    assertEquals("Basic", exception.getChallenges().get(0));
   }
 
   @Test
   void testMissingCredentials() {
     BasicAuthenticator authenticator = authenticator();
     BadRequestException exception =
-        Assertions.assertThrows(
+        assertThrows(
             BadRequestException.class,
             () ->
                 authenticator.authenticateToken(
                     AuthConstants.AUTHORIZATION_BASIC_HEADER.getBytes(StandardCharsets.UTF_8)));
 
-    Assertions.assertEquals(
+    assertEquals(
         "Malformed Basic authorization header: missing credentials", exception.getMessage());
   }
 
@@ -88,11 +99,11 @@ class TestBasicAuthenticator {
     UserPrincipal principal =
         (UserPrincipal) authenticator.authenticateToken(basicAuthBytes(authHeader));
 
-    Assertions.assertEquals("alice", principal.getName());
-    Assertions.assertEquals(authHeader, principal.getAccessToken().orElse(null));
-    Assertions.assertEquals(2, principal.getGroups().size());
-    Assertions.assertEquals("group-a", principal.getGroups().get(0).getGroupname());
-    Assertions.assertEquals("group-b", principal.getGroups().get(1).getGroupname());
+    assertEquals("alice", principal.getName());
+    assertEquals(authHeader, principal.getAccessToken().orElse(null));
+    assertEquals(2, principal.getGroups().size());
+    assertEquals("group-a", principal.getGroups().get(0).getGroupname());
+    assertEquals("group-b", principal.getGroups().get(1).getGroupname());
   }
 
   @Test
@@ -104,14 +115,13 @@ class TestBasicAuthenticator {
     BasicAuthenticator authenticator = new BasicAuthenticator(userMetaService, passwordHasher);
 
     UnauthorizedException exception =
-        Assertions.assertThrows(
+        assertThrows(
             UnauthorizedException.class,
             () ->
                 authenticator.authenticateToken(
                     basicAuthBytes(basicAuthHeader("alice", "Passw0rd-For-Alice"))));
 
-    Assertions.assertEquals("Invalid username or password", exception.getMessage());
-    Assertions.assertEquals("Basic", exception.getChallenges().get(0));
+    assertUnauthorized(exception);
   }
 
   @Test
@@ -119,12 +129,11 @@ class TestBasicAuthenticator {
     BasicAuthenticator authenticator = authenticator();
 
     BadRequestException exception =
-        Assertions.assertThrows(
+        assertThrows(
             BadRequestException.class,
             () -> authenticator.authenticateToken(basicAuthBytesWithCredential("not-valid!!!")));
 
-    Assertions.assertEquals(
-        "Malformed Basic authorization header: invalid base64", exception.getMessage());
+    assertEquals("Malformed Basic authorization header: invalid base64", exception.getMessage());
   }
 
   @Test
@@ -134,11 +143,11 @@ class TestBasicAuthenticator {
         Base64.getEncoder().encodeToString("aliceonly".getBytes(StandardCharsets.UTF_8));
 
     BadRequestException exception =
-        Assertions.assertThrows(
+        assertThrows(
             BadRequestException.class,
             () -> authenticator.authenticateToken(basicAuthBytesWithCredential(credential)));
 
-    Assertions.assertEquals(
+    assertEquals(
         "Malformed Basic authorization header: credentials must be in username:password format",
         exception.getMessage());
   }
@@ -150,11 +159,11 @@ class TestBasicAuthenticator {
         Base64.getEncoder().encodeToString(":password".getBytes(StandardCharsets.UTF_8));
 
     BadRequestException exception =
-        Assertions.assertThrows(
+        assertThrows(
             BadRequestException.class,
             () -> authenticator.authenticateToken(basicAuthBytesWithCredential(credential)));
 
-    Assertions.assertEquals(
+    assertEquals(
         "Malformed Basic authorization header: username must not be empty", exception.getMessage());
   }
 
@@ -177,7 +186,7 @@ class TestBasicAuthenticator {
     UserPrincipal principal =
         (UserPrincipal) authenticator.authenticateToken(basicAuthBytesWithCredential(credential));
 
-    Assertions.assertEquals("alice", principal.getName());
+    assertEquals("alice", principal.getName());
   }
 
   @Test
@@ -190,12 +199,11 @@ class TestBasicAuthenticator {
     BasicAuthenticator authenticator = new BasicAuthenticator(userMetaService, passwordHasher);
 
     UnauthorizedException exception =
-        Assertions.assertThrows(
+        assertThrows(
             UnauthorizedException.class,
             () -> authenticator.authenticateToken(basicAuthBytes(basicAuthHeader("alice", " "))));
 
-    Assertions.assertEquals("Invalid username or password", exception.getMessage());
-    Assertions.assertEquals("Basic", exception.getChallenges().get(0));
+    assertUnauthorized(exception);
   }
 
   @Test
@@ -209,14 +217,18 @@ class TestBasicAuthenticator {
     BasicAuthenticator authenticator = new BasicAuthenticator(userMetaService, passwordHasher);
 
     UnauthorizedException exception =
-        Assertions.assertThrows(
+        assertThrows(
             UnauthorizedException.class,
             () ->
                 authenticator.authenticateToken(
                     basicAuthBytes(basicAuthHeader("alice", "Passw0rd-For-Alice"))));
 
-    Assertions.assertEquals("Invalid username or password", exception.getMessage());
-    Assertions.assertEquals("Basic", exception.getChallenges().get(0));
+    assertUnauthorized(exception);
+  }
+
+  private static void assertUnauthorized(UnauthorizedException exception) {
+    assertEquals("Invalid username or password", exception.getMessage());
+    assertEquals("Basic", exception.getChallenges().get(0));
   }
 
   private static String basicAuthHeader(String username, String password) {

--- a/plugins/idp-basic/src/test/java/org/apache/gravitino/idp/auth/TestBasicAuthenticator.java
+++ b/plugins/idp-basic/src/test/java/org/apache/gravitino/idp/auth/TestBasicAuthenticator.java
@@ -39,7 +39,7 @@ import org.junit.jupiter.api.Test;
 class TestBasicAuthenticator {
 
   @Test
-  void testAuthenticateTokenThrowsWhenAuthenticatorNotInitialized() {
+  void testNotInitialized() {
     IllegalStateException exception =
         Assertions.assertThrows(
             IllegalStateException.class, () -> new BasicAuthenticator().authenticateToken(null));
@@ -48,7 +48,7 @@ class TestBasicAuthenticator {
   }
 
   @Test
-  void testAuthenticateTokenThrowsUnauthorizedWhenHeaderMissing() {
+  void testEmptyHeader() {
     BasicAuthenticator authenticator = authenticator();
     UnauthorizedException exception =
         Assertions.assertThrows(
@@ -59,7 +59,7 @@ class TestBasicAuthenticator {
   }
 
   @Test
-  void testAuthenticateTokenThrowsBadRequestWhenBasicCredentialMissing() {
+  void testMissingCredentials() {
     BasicAuthenticator authenticator = authenticator();
     BadRequestException exception =
         Assertions.assertThrows(
@@ -73,7 +73,7 @@ class TestBasicAuthenticator {
   }
 
   @Test
-  void testAuthenticateTokenReturnsPrincipalWhenCredentialsValid() {
+  void testValidCredentials() {
     IdpUserMetaService userMetaService = mock(IdpUserMetaService.class);
     PasswordHasher passwordHasher = mock(PasswordHasher.class);
     IdpUserPO userPO = mock(IdpUserPO.class);
@@ -96,7 +96,7 @@ class TestBasicAuthenticator {
   }
 
   @Test
-  void testAuthenticateTokenThrowsUnauthorizedWhenUserMissing() {
+  void testUserNotFound() {
     IdpUserMetaService userMetaService = mock(IdpUserMetaService.class);
     PasswordHasher passwordHasher = mock(PasswordHasher.class);
     when(userMetaService.getIdpUserByUsername("alice"))
@@ -115,7 +115,7 @@ class TestBasicAuthenticator {
   }
 
   @Test
-  void testAuthenticateTokenThrowsUnauthorizedWhenPasswordMismatch() {
+  void testWrongPassword() {
     IdpUserMetaService userMetaService = mock(IdpUserMetaService.class);
     PasswordHasher passwordHasher = mock(PasswordHasher.class);
     IdpUserPO userPO = mock(IdpUserPO.class);

--- a/server-common/build.gradle.kts
+++ b/server-common/build.gradle.kts
@@ -55,6 +55,7 @@ dependencies {
   implementation(libs.prometheus.servlet)
   implementation(libs.nimbus.jose.jwt)
 
+  testImplementation(project(":plugins:idp-basic"))
   testImplementation(libs.commons.io)
   testImplementation(libs.junit.jupiter.api)
   testImplementation(libs.junit.jupiter.params)

--- a/server-common/src/main/java/org/apache/gravitino/server/authentication/AuthenticatorFactory.java
+++ b/server-common/src/main/java/org/apache/gravitino/server/authentication/AuthenticatorFactory.java
@@ -40,7 +40,9 @@ public class AuthenticatorFactory {
           AuthenticatorType.OAUTH.name().toLowerCase(),
           OAuth2TokenAuthenticator.class.getCanonicalName(),
           AuthenticatorType.KERBEROS.name().toLowerCase(),
-          KerberosAuthenticator.class.getCanonicalName());
+          KerberosAuthenticator.class.getCanonicalName(),
+          AuthenticatorType.BASIC.name().toLowerCase(),
+          "org.apache.gravitino.idp.auth.BasicAuthenticator");
 
   private AuthenticatorFactory() {}
 

--- a/server-common/src/test/java/org/apache/gravitino/server/authentication/TestBasicAuthentication.java
+++ b/server-common/src/test/java/org/apache/gravitino/server/authentication/TestBasicAuthentication.java
@@ -1,0 +1,207 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.server.authentication;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.Lists;
+import java.lang.reflect.Constructor;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.List;
+import java.util.Vector;
+import javax.servlet.FilterChain;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.apache.gravitino.UserPrincipal;
+import org.apache.gravitino.auth.AuthConstants;
+import org.apache.gravitino.exceptions.BadRequestException;
+import org.apache.gravitino.exceptions.UnauthorizedException;
+import org.apache.gravitino.idp.auth.BasicAuthenticator;
+import org.apache.gravitino.idp.basic.password.PasswordHasher;
+import org.apache.gravitino.idp.exception.NotFoundException;
+import org.apache.gravitino.idp.storage.po.IdpUserPO;
+import org.apache.gravitino.idp.storage.service.IdpUserMetaService;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+public class TestBasicAuthentication {
+
+  private static final String USER = "alice";
+  private static final String PASSWORD = "Passw0rd-For-Alice";
+  private static final String PASSWORD_HASH = "hash-1";
+
+  @Test
+  public void testSupportsBasic() throws Exception {
+    BasicAuthenticator authenticator = authenticator();
+
+    assertTrue(authenticator.supportsToken(basicAuthBytes(USER, PASSWORD)));
+    assertFalse(authenticator.supportsToken("Bearer token".getBytes(StandardCharsets.UTF_8)));
+    assertFalse(authenticator.supportsToken(null));
+  }
+
+  @Test
+  public void testValidCredentials() throws Exception {
+    BasicAuthenticator authenticator =
+        aliceAuthenticator(true, Arrays.asList("group-a", "group-b"));
+    String authHeader = basicAuthHeader(USER, PASSWORD);
+
+    UserPrincipal principal =
+        (UserPrincipal) authenticator.authenticateToken(basicAuthBytes(authHeader));
+
+    assertEquals(USER, principal.getName());
+    assertEquals(authHeader, principal.getAccessToken().orElse(null));
+    assertEquals(2, principal.getGroups().size());
+    assertEquals("group-a", principal.getGroups().get(0).getGroupname());
+    assertEquals("group-b", principal.getGroups().get(1).getGroupname());
+  }
+
+  @Test
+  public void testInvalidCredentials() throws Exception {
+    BasicAuthenticator authenticator = aliceAuthenticator(false, Collections.emptyList());
+
+    UnauthorizedException exception =
+        assertThrows(
+            UnauthorizedException.class,
+            () -> authenticator.authenticateToken(basicAuthBytes(USER, PASSWORD)));
+
+    assertInvalidCredentials(exception);
+  }
+
+  @Test
+  public void testMissingCredentials() throws Exception {
+    BasicAuthenticator authenticator = authenticator();
+
+    BadRequestException exception =
+        assertThrows(
+            BadRequestException.class,
+            () ->
+                authenticator.authenticateToken(
+                    AuthConstants.AUTHORIZATION_BASIC_HEADER.getBytes(StandardCharsets.UTF_8)));
+
+    assertEquals(
+        "Malformed Basic authorization header: missing credentials", exception.getMessage());
+  }
+
+  @Test
+  public void testFilterSuccess() throws Exception {
+    BasicAuthenticator authenticator = aliceAuthenticator(true, Collections.emptyList());
+    FilterChain chain = mock(FilterChain.class);
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    HttpServletResponse response = mock(HttpServletResponse.class);
+    stubAuthHeader(request, USER, PASSWORD);
+
+    filterFor(authenticator).doFilter(request, response, chain);
+
+    verify(chain).doFilter(request, response);
+    verify(response, never()).sendError(anyInt(), anyString());
+    ArgumentCaptor<Object> principalCaptor = ArgumentCaptor.forClass(Object.class);
+    verify(request)
+        .setAttribute(
+            eq(AuthConstants.AUTHENTICATED_PRINCIPAL_ATTRIBUTE_NAME), principalCaptor.capture());
+    assertEquals(USER, ((UserPrincipal) principalCaptor.getValue()).getName());
+  }
+
+  @Test
+  public void testFilterUnauthorized() throws Exception {
+    IdpUserMetaService userMetaService = mock(IdpUserMetaService.class);
+    when(userMetaService.getIdpUserByUsername(USER))
+        .thenThrow(new NotFoundException("IdP user not found: %s", USER));
+    BasicAuthenticator authenticator =
+        createBasicAuthenticator(userMetaService, mock(PasswordHasher.class));
+    FilterChain chain = mock(FilterChain.class);
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    HttpServletResponse response = mock(HttpServletResponse.class);
+    stubAuthHeader(request, USER, "wrong");
+
+    filterFor(authenticator).doFilter(request, response, chain);
+
+    verify(response).setHeader(AuthConstants.HTTP_CHALLENGE_HEADER, "Basic");
+    verify(response).sendError(HttpServletResponse.SC_UNAUTHORIZED, "Invalid username or password");
+    verify(chain, never()).doFilter(request, response);
+  }
+
+  private static BasicAuthenticator authenticator() throws Exception {
+    return createBasicAuthenticator(mock(IdpUserMetaService.class), mock(PasswordHasher.class));
+  }
+
+  private static BasicAuthenticator aliceAuthenticator(boolean passwordValid, List<String> groups)
+      throws Exception {
+    IdpUserMetaService userMetaService = mock(IdpUserMetaService.class);
+    PasswordHasher passwordHasher = mock(PasswordHasher.class);
+    IdpUserPO userPO = mock(IdpUserPO.class);
+    when(userMetaService.getIdpUserByUsername(USER)).thenReturn(userPO);
+    when(userPO.getPasswordHash()).thenReturn(PASSWORD_HASH);
+    when(passwordHasher.verify(PASSWORD, PASSWORD_HASH)).thenReturn(passwordValid);
+    when(userMetaService.listGroupNamesByUsername(USER)).thenReturn(groups);
+    return createBasicAuthenticator(userMetaService, passwordHasher);
+  }
+
+  private static AuthenticationFilter filterFor(BasicAuthenticator authenticator) {
+    return new AuthenticationFilter(Lists.newArrayList(authenticator));
+  }
+
+  private static void stubAuthHeader(HttpServletRequest request, String username, String password) {
+    when(request.getHeaders(AuthConstants.HTTP_HEADER_AUTHORIZATION))
+        .thenReturn(
+            new Vector<>(Collections.singletonList(basicAuthHeader(username, password)))
+                .elements());
+  }
+
+  private static void assertInvalidCredentials(UnauthorizedException exception) {
+    assertEquals("Invalid username or password", exception.getMessage());
+    assertEquals("Basic", exception.getChallenges().get(0));
+  }
+
+  private static BasicAuthenticator createBasicAuthenticator(
+      IdpUserMetaService userMetaService, PasswordHasher passwordHasher) throws Exception {
+    Constructor<BasicAuthenticator> constructor =
+        BasicAuthenticator.class.getDeclaredConstructor(
+            IdpUserMetaService.class, PasswordHasher.class);
+    constructor.setAccessible(true);
+    return constructor.newInstance(userMetaService, passwordHasher);
+  }
+
+  private static String basicAuthHeader(String username, String password) {
+    return AuthConstants.AUTHORIZATION_BASIC_HEADER
+        + Base64.getEncoder()
+            .encodeToString((username + ":" + password).getBytes(StandardCharsets.UTF_8));
+  }
+
+  private static byte[] basicAuthBytes(String username, String password) {
+    return basicAuthHeader(username, password).getBytes(StandardCharsets.UTF_8);
+  }
+
+  private static byte[] basicAuthBytes(String authHeader) {
+    return authHeader.getBytes(StandardCharsets.UTF_8);
+  }
+}

--- a/server-common/src/test/java/org/apache/gravitino/server/authentication/TestBasicAuthentication.java
+++ b/server-common/src/test/java/org/apache/gravitino/server/authentication/TestBasicAuthentication.java
@@ -20,9 +20,6 @@
 package org.apache.gravitino.server.authentication;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -34,18 +31,14 @@ import static org.mockito.Mockito.when;
 import com.google.common.collect.Lists;
 import java.lang.reflect.Constructor;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collections;
-import java.util.List;
 import java.util.Vector;
 import javax.servlet.FilterChain;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.apache.gravitino.UserPrincipal;
 import org.apache.gravitino.auth.AuthConstants;
-import org.apache.gravitino.exceptions.BadRequestException;
-import org.apache.gravitino.exceptions.UnauthorizedException;
 import org.apache.gravitino.idp.auth.BasicAuthenticator;
 import org.apache.gravitino.idp.basic.password.PasswordHasher;
 import org.apache.gravitino.idp.exception.NotFoundException;
@@ -61,66 +54,14 @@ public class TestBasicAuthentication {
   private static final String PASSWORD_HASH = "hash-1";
 
   @Test
-  public void testSupportsBasic() throws Exception {
-    BasicAuthenticator authenticator = authenticator();
-
-    assertTrue(authenticator.supportsToken(basicAuthBytes(USER, PASSWORD)));
-    assertFalse(authenticator.supportsToken("Bearer token".getBytes(StandardCharsets.UTF_8)));
-    assertFalse(authenticator.supportsToken(null));
-  }
-
-  @Test
-  public void testValidCredentials() throws Exception {
-    BasicAuthenticator authenticator =
-        aliceAuthenticator(true, Arrays.asList("group-a", "group-b"));
-    String authHeader = basicAuthHeader(USER, PASSWORD);
-
-    UserPrincipal principal =
-        (UserPrincipal) authenticator.authenticateToken(basicAuthBytes(authHeader));
-
-    assertEquals(USER, principal.getName());
-    assertEquals(authHeader, principal.getAccessToken().orElse(null));
-    assertEquals(2, principal.getGroups().size());
-    assertEquals("group-a", principal.getGroups().get(0).getGroupname());
-    assertEquals("group-b", principal.getGroups().get(1).getGroupname());
-  }
-
-  @Test
-  public void testInvalidCredentials() throws Exception {
-    BasicAuthenticator authenticator = aliceAuthenticator(false, Collections.emptyList());
-
-    UnauthorizedException exception =
-        assertThrows(
-            UnauthorizedException.class,
-            () -> authenticator.authenticateToken(basicAuthBytes(USER, PASSWORD)));
-
-    assertInvalidCredentials(exception);
-  }
-
-  @Test
-  public void testMissingCredentials() throws Exception {
-    BasicAuthenticator authenticator = authenticator();
-
-    BadRequestException exception =
-        assertThrows(
-            BadRequestException.class,
-            () ->
-                authenticator.authenticateToken(
-                    AuthConstants.AUTHORIZATION_BASIC_HEADER.getBytes(StandardCharsets.UTF_8)));
-
-    assertEquals(
-        "Malformed Basic authorization header: missing credentials", exception.getMessage());
-  }
-
-  @Test
   public void testFilterSuccess() throws Exception {
-    BasicAuthenticator authenticator = aliceAuthenticator(true, Collections.emptyList());
+    BasicAuthenticator authenticator = aliceAuthenticator(true);
     FilterChain chain = mock(FilterChain.class);
     HttpServletRequest request = mock(HttpServletRequest.class);
     HttpServletResponse response = mock(HttpServletResponse.class);
     stubAuthHeader(request, USER, PASSWORD);
 
-    filterFor(authenticator).doFilter(request, response, chain);
+    new AuthenticationFilter(Lists.newArrayList(authenticator)).doFilter(request, response, chain);
 
     verify(chain).doFilter(request, response);
     verify(response, never()).sendError(anyInt(), anyString());
@@ -143,31 +84,22 @@ public class TestBasicAuthentication {
     HttpServletResponse response = mock(HttpServletResponse.class);
     stubAuthHeader(request, USER, "wrong");
 
-    filterFor(authenticator).doFilter(request, response, chain);
+    new AuthenticationFilter(Lists.newArrayList(authenticator)).doFilter(request, response, chain);
 
     verify(response).setHeader(AuthConstants.HTTP_CHALLENGE_HEADER, "Basic");
     verify(response).sendError(HttpServletResponse.SC_UNAUTHORIZED, "Invalid username or password");
     verify(chain, never()).doFilter(request, response);
   }
 
-  private static BasicAuthenticator authenticator() throws Exception {
-    return createBasicAuthenticator(mock(IdpUserMetaService.class), mock(PasswordHasher.class));
-  }
-
-  private static BasicAuthenticator aliceAuthenticator(boolean passwordValid, List<String> groups)
-      throws Exception {
+  private static BasicAuthenticator aliceAuthenticator(boolean passwordValid) throws Exception {
     IdpUserMetaService userMetaService = mock(IdpUserMetaService.class);
     PasswordHasher passwordHasher = mock(PasswordHasher.class);
     IdpUserPO userPO = mock(IdpUserPO.class);
     when(userMetaService.getIdpUserByUsername(USER)).thenReturn(userPO);
     when(userPO.getPasswordHash()).thenReturn(PASSWORD_HASH);
     when(passwordHasher.verify(PASSWORD, PASSWORD_HASH)).thenReturn(passwordValid);
-    when(userMetaService.listGroupNamesByUsername(USER)).thenReturn(groups);
+    when(userMetaService.listGroupNamesByUsername(USER)).thenReturn(Collections.emptyList());
     return createBasicAuthenticator(userMetaService, passwordHasher);
-  }
-
-  private static AuthenticationFilter filterFor(BasicAuthenticator authenticator) {
-    return new AuthenticationFilter(Lists.newArrayList(authenticator));
   }
 
   private static void stubAuthHeader(HttpServletRequest request, String username, String password) {
@@ -175,11 +107,6 @@ public class TestBasicAuthentication {
         .thenReturn(
             new Vector<>(Collections.singletonList(basicAuthHeader(username, password)))
                 .elements());
-  }
-
-  private static void assertInvalidCredentials(UnauthorizedException exception) {
-    assertEquals("Invalid username or password", exception.getMessage());
-    assertEquals("Basic", exception.getChallenges().get(0));
   }
 
   private static BasicAuthenticator createBasicAuthenticator(
@@ -195,13 +122,5 @@ public class TestBasicAuthentication {
     return AuthConstants.AUTHORIZATION_BASIC_HEADER
         + Base64.getEncoder()
             .encodeToString((username + ":" + password).getBytes(StandardCharsets.UTF_8));
-  }
-
-  private static byte[] basicAuthBytes(String username, String password) {
-    return basicAuthHeader(username, password).getBytes(StandardCharsets.UTF_8);
-  }
-
-  private static byte[] basicAuthBytes(String authHeader) {
-    return authHeader.getBytes(StandardCharsets.UTF_8);
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

- Add `BasicAuthenticator` in `plugins/idp-basic` to validate HTTP Basic credentials against built-in IdP user metadata (Argon2id password hash via `PasswordHasher`).
- Resolve authenticated user groups from `IdpUserMetaService.listGroupNamesByUsername()` and attach them to `UserPrincipal` for downstream authorization.
- Register `AuthenticatorType.BASIC` and wire `basic` → `org.apache.gravitino.idp.auth.BasicAuthenticator` in `AuthenticatorFactory`.
- Use `compileOnly` for `:api` and `:server-common` in `idp-basic` so the plugin JAR does not bundle server dependencies.
- Add unit tests in `idp-basic` and `server-common` (`TestBasicAuthentication`) covering authenticator behavior and `AuthenticationFilter` integration.

Fix: #10965

### Why are the changes needed?

Issue #10965 tracks the Basic authentication subtask under local authentication (#10959). Gravitino needs an HTTP Basic authenticator backed by the built-in IdP so clients can authenticate with username/password and receive group memberships for authorization.

### Does this PR introduce _any_ user-facing change?

Yes. When `gravitino.authenticators` includes `basic`, clients can authenticate with built-in IdP username/password via HTTP Basic. Requires the `idp-basic` plugin JAR on the server classpath.

### How was this patch tested?

- [x] `./gradlew :plugins:idp-basic:test --tests "org.apache.gravitino.idp.auth.TestBasicAuthenticator" -PskipITs -PskipDockerTests=true`
- [x] `./gradlew :server-common:test --tests "org.apache.gravitino.server.authentication.TestBasicAuthentication" -PskipITs -PskipDockerTests=true`

Made with [Cursor](https://cursor.com)