### PR TITLE
[#11196] feat(maintenance): Add builtin-iceberg-rewrite-manifests job

### DIFF
--- a/maintenance/jobs/src/main/java/org/apache/gravitino/maintenance/jobs/BuiltInJobTemplateProvider.java
+++ b/maintenance/jobs/src/main/java/org/apache/gravitino/maintenance/jobs/BuiltInJobTemplateProvider.java
@@ -30,6 +30,7 @@ import org.apache.gravitino.maintenance.jobs.iceberg.IcebergUpdateStatsAndMetric
 import org.apache.gravitino.maintenance.jobs.spark.SparkPiJob;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.apache.gravitino.maintenance.jobs.iceberg.IcebergRewriteManifestsJob;
 
 /** Provides built-in job templates bundled with the Gravitino jobs module. */
 public class BuiltInJobTemplateProvider implements JobTemplateProvider {
@@ -45,7 +46,8 @@ public class BuiltInJobTemplateProvider implements JobTemplateProvider {
       ImmutableList.of(
           new SparkPiJob(),
           new IcebergRewriteDataFilesJob(),
-          new IcebergUpdateStatsAndMetricsJob());
+          new IcebergUpdateStatsAndMetricsJob()),
+          new IcebergRewriteManifestsJob());
 
   @Override
   public List<? extends JobTemplate> jobTemplates() {

--- a/maintenance/jobs/src/main/java/org/apache/gravitino/maintenance/jobs/iceberg/IcebergRewriteManifestsJob.java
+++ b/maintenance/jobs/src/main/java/org/apache/gravitino/maintenance/jobs/iceberg/IcebergRewriteManifestsJob.java
@@ -1,0 +1,234 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.maintenance.jobs.iceberg;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.gravitino.job.JobTemplateProvider;
+import org.apache.gravitino.job.SparkJobTemplate;
+import org.apache.gravitino.maintenance.jobs.BuiltInJob;
+import org.apache.gravitino.maintenance.optimizer.common.util.IcebergSparkConfigUtils;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+
+/**
+ * Built-in job for rewriting Iceberg table manifest files.
+ *
+ * <p>This job leverages Iceberg's RewriteManifestsProcedure to consolidate small manifest files
+ * and rewrite manifests with improved partition specs, which improves scan planning performance.
+ */
+public class IcebergRewriteManifestsJob implements BuiltInJob {
+
+  private static final String NAME =
+      JobTemplateProvider.BUILTIN_NAME_PREFIX + "iceberg-rewrite-manifests";
+  private static final String VERSION = "v1";
+
+  @Override
+  public SparkJobTemplate jobTemplate() {
+    return SparkJobTemplate.builder()
+        .withName(NAME)
+        .withComment(
+            "Built-in Iceberg rewrite manifests job template for scan planning optimization")
+        .withExecutable(resolveExecutable(IcebergRewriteManifestsJob.class))
+        .withClassName(IcebergRewriteManifestsJob.class.getName())
+        .withArguments(buildArguments())
+        .withConfigs(buildSparkConfigs())
+        .withCustomFields(
+            Collections.singletonMap(JobTemplateProvider.PROPERTY_VERSION_KEY, VERSION))
+        .build();
+  }
+
+  /**
+   * Main entry point for the rewrite manifests job.
+   *
+   * <p>Uses named arguments for flexibility:
+   *
+   * <ul>
+   *   <li>--catalog &lt;catalog_name&gt; Required. Iceberg catalog name.
+   *   <li>--table &lt;table_identifier&gt; Required. Table name (db.table)
+   *   <li>--use-caching &lt;boolean&gt; Optional. Whether to use caching (default: true)
+   *   <li>--spark-conf &lt;spark_conf_json&gt; Optional. JSON map of custom Spark configurations
+   * </ul>
+   *
+   * <p>Example via Gravitino API:
+   *
+   * <pre>{@code
+   * Map<String, String> jobConf = new HashMap<>();
+   * jobConf.put("catalog_name", "iceberg_catalog");
+   * jobConf.put("table_identifier", "db.sample");
+   * jobConf.put("use_caching", "true");
+   * metalake.runJob("builtin-iceberg-rewrite-manifests", jobConf);
+   * }</pre>
+   */
+  public static void main(String[] args) {
+    if (args.length < 4) {
+      printUsage();
+      System.exit(1);
+    }
+
+    Map<String, String> argMap = parseArguments(args);
+
+    String catalogName = argMap.get("catalog");
+    String tableIdentifier = argMap.get("table");
+
+    if (catalogName == null || tableIdentifier == null) {
+      System.err.println("Error: --catalog and --table are required arguments");
+      printUsage();
+      System.exit(1);
+    }
+
+    String useCaching = argMap.get("use-caching");
+    String sparkConfJson = argMap.get("spark-conf");
+
+    SparkSession.Builder sparkBuilder =
+        SparkSession.builder().appName("Gravitino Built-in Iceberg Rewrite Manifests");
+
+    if (sparkConfJson != null && !sparkConfJson.isEmpty()) {
+      try {
+        Map<String, String> customConfigs =
+            IcebergRewriteDataFilesJob.parseCustomSparkConfigs(sparkConfJson);
+        for (Map.Entry<String, String> entry : customConfigs.entrySet()) {
+          sparkBuilder.config(entry.getKey(), entry.getValue());
+        }
+        System.out.println("Applied custom Spark configurations: " + customConfigs);
+      } catch (IllegalArgumentException e) {
+        System.err.println("Error: " + e.getMessage());
+        printUsage();
+        System.exit(1);
+      }
+    }
+
+    SparkSession spark = sparkBuilder.getOrCreate();
+
+    try {
+      String sql = buildProcedureCall(catalogName, tableIdentifier, useCaching);
+      System.out.println("Executing Iceberg rewrite_manifests procedure: " + sql);
+
+      Row[] results = (Row[]) spark.sql(sql).collect();
+
+      if (results.length > 0) {
+        Row result = results[0];
+        System.out.printf(
+            "Rewrite Manifests Results:%n"
+                + "  Rewritten manifests: %d%n"
+                + "  Added manifests: %d%n",
+            result.getInt(0), result.getInt(1));
+      }
+
+      System.out.println("Rewrite manifests job completed successfully");
+    } catch (Exception e) {
+      System.err.println("Error executing rewrite manifests job: " + e.getMessage());
+      e.printStackTrace();
+      System.exit(1);
+    } finally {
+      spark.stop();
+    }
+  }
+
+  /**
+   * Build the SQL CALL statement for the rewrite_manifests procedure.
+   *
+   * @param catalogName Iceberg catalog name
+   * @param tableIdentifier Fully qualified table name
+   * @param useCaching Whether to use caching during rewrite
+   * @return SQL CALL statement
+   */
+  static String buildProcedureCall(
+      String catalogName, String tableIdentifier, String useCaching) {
+    StringBuilder sql = new StringBuilder();
+    sql.append("CALL ")
+        .append(IcebergRewriteDataFilesJob.escapeSqlIdentifier(catalogName))
+        .append(".system.rewrite_manifests(");
+    sql.append("table => '")
+        .append(IcebergRewriteDataFilesJob.escapeSqlString(tableIdentifier))
+        .append("'");
+
+    if (useCaching != null && !useCaching.isEmpty()) {
+      sql.append(", use_caching => ").append(Boolean.parseBoolean(useCaching));
+    }
+
+    sql.append(")");
+    return sql.toString();
+  }
+
+  /**
+   * Parse command line arguments in --key value format.
+   *
+   * @param args command line arguments
+   * @return map of argument names to values
+   */
+  static Map<String, String> parseArguments(String[] args) {
+    Map<String, String> argMap = new HashMap<>();
+    for (int i = 0; i < args.length; i++) {
+      if (args[i].startsWith("--")) {
+        String key = args[i].substring(2);
+        if (i + 1 < args.length && !args[i + 1].startsWith("--")) {
+          String value = args[i + 1];
+          if (value != null && !value.trim().isEmpty()) {
+            argMap.put(key, value);
+          }
+          i++;
+        } else {
+          System.err.println("Warning: Flag " + args[i] + " has no value, ignoring");
+        }
+      }
+    }
+    return argMap;
+  }
+
+  private static void printUsage() {
+    System.err.println(
+        "Usage: IcebergRewriteManifestsJob [OPTIONS]\n"
+            + "\n"
+            + "Required Options:\n"
+            + "  --catalog <name>          Iceberg catalog name registered in Spark\n"
+            + "  --table <identifier>      Fully qualified table name (e.g., db.table_name)\n"
+            + "\n"
+            + "Optional Options:\n"
+            + "  --use-caching <boolean>   Whether to use caching during rewrite (default: true)\n"
+            + "  --spark-conf <json>       JSON map of custom Spark configurations\n"
+            + "                              Example: '{\"spark.sql.shuffle.partitions\":\"200\"}'\n"
+            + "\n"
+            + "Examples:\n"
+            + "  # Basic rewrite\n"
+            + "  --catalog iceberg_prod --table db.sample\n"
+            + "\n"
+            + "  # Without caching\n"
+            + "  --catalog iceberg_prod --table db.sample --use-caching false\n");
+  }
+
+  private static List<String> buildArguments() {
+    return Arrays.asList(
+        "--catalog",
+        "{{catalog_name}}",
+        "--table",
+        "{{table_identifier}}",
+        "--use-caching",
+        "{{use_caching}}",
+        "--spark-conf",
+        "{{spark_conf}}");
+  }
+
+  private static Map<String, String> buildSparkConfigs() {
+    return IcebergSparkConfigUtils.buildTemplateSparkConfigs();
+  }
+}

--- a/maintenance/jobs/src/test/java/org/apache/gravitino/maintenance/jobs/iceberg/TestIcebergRewriteManifestsJob.java
+++ b/maintenance/jobs/src/test/java/org/apache/gravitino/maintenance/jobs/iceberg/TestIcebergRewriteManifestsJob.java
@@ -1,0 +1,254 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.maintenance.jobs.iceberg;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+import org.apache.gravitino.job.JobTemplateProvider;
+import org.apache.gravitino.job.SparkJobTemplate;
+import org.junit.jupiter.api.Test;
+
+public class TestIcebergRewriteManifestsJob {
+
+  @Test
+  public void testJobTemplateHasCorrectName() {
+    IcebergRewriteManifestsJob job = new IcebergRewriteManifestsJob();
+    SparkJobTemplate template = job.jobTemplate();
+
+    assertNotNull(template);
+    assertEquals("builtin-iceberg-rewrite-manifests", template.name());
+  }
+
+  @Test
+  public void testJobTemplateHasComment() {
+    IcebergRewriteManifestsJob job = new IcebergRewriteManifestsJob();
+    SparkJobTemplate template = job.jobTemplate();
+
+    assertNotNull(template.comment());
+    assertFalse(template.comment().trim().isEmpty());
+    assertTrue(template.comment().contains("Iceberg"));
+    assertTrue(template.comment().contains("manifests"));
+  }
+
+  @Test
+  public void testJobTemplateHasExecutable() {
+    IcebergRewriteManifestsJob job = new IcebergRewriteManifestsJob();
+    SparkJobTemplate template = job.jobTemplate();
+
+    assertNotNull(template.executable());
+    assertFalse(template.executable().trim().isEmpty());
+  }
+
+  @Test
+  public void testJobTemplateHasMainClass() {
+    IcebergRewriteManifestsJob job = new IcebergRewriteManifestsJob();
+    SparkJobTemplate template = job.jobTemplate();
+
+    assertNotNull(template.className());
+    assertEquals(IcebergRewriteManifestsJob.class.getName(), template.className());
+  }
+
+  @Test
+  public void testJobTemplateHasArguments() {
+    IcebergRewriteManifestsJob job = new IcebergRewriteManifestsJob();
+    SparkJobTemplate template = job.jobTemplate();
+
+    assertNotNull(template.arguments());
+    assertEquals(8, template.arguments().size()); // 4 flags * 2 (flag + value)
+
+    // Verify all expected arguments are present
+    assertTrue(template.arguments().contains("--catalog"));
+    assertTrue(template.arguments().contains("{{catalog_name}}"));
+    assertTrue(template.arguments().contains("--table"));
+    assertTrue(template.arguments().contains("{{table_identifier}}"));
+    assertTrue(template.arguments().contains("--use-caching"));
+    assertTrue(template.arguments().contains("{{use_caching}}"));
+    assertTrue(template.arguments().contains("--spark-conf"));
+    assertTrue(template.arguments().contains("{{spark_conf}}"));
+  }
+
+  @Test
+  public void testJobTemplateHasSparkConfigs() {
+    IcebergRewriteManifestsJob job = new IcebergRewriteManifestsJob();
+    SparkJobTemplate template = job.jobTemplate();
+
+    Map<String, String> configs = template.configs();
+    assertNotNull(configs);
+    assertFalse(configs.isEmpty());
+
+    // Verify Spark runtime configs
+    assertTrue(configs.containsKey("spark.master"));
+    assertTrue(configs.containsKey("spark.executor.instances"));
+    assertTrue(configs.containsKey("spark.executor.cores"));
+    assertTrue(configs.containsKey("spark.executor.memory"));
+    assertTrue(configs.containsKey("spark.driver.memory"));
+
+    // Verify Iceberg catalog configs
+    assertTrue(configs.containsKey("spark.sql.catalog.{{catalog_name}}"));
+    assertTrue(configs.containsKey("spark.sql.catalog.{{catalog_name}}.type"));
+    assertTrue(configs.containsKey("spark.sql.catalog.{{catalog_name}}.uri"));
+    assertTrue(configs.containsKey("spark.sql.catalog.{{catalog_name}}.warehouse"));
+  }
+
+  @Test
+  public void testJobTemplateHasVersion() {
+    IcebergRewriteManifestsJob job = new IcebergRewriteManifestsJob();
+    SparkJobTemplate template = job.jobTemplate();
+
+    Map<String, String> customFields = template.customFields();
+    assertNotNull(customFields);
+    assertTrue(customFields.containsKey(JobTemplateProvider.PROPERTY_VERSION_KEY));
+
+    String version = customFields.get(JobTemplateProvider.PROPERTY_VERSION_KEY);
+    assertEquals("v1", version);
+    assertTrue(version.matches(JobTemplateProvider.VERSION_VALUE_PATTERN));
+  }
+
+  @Test
+  public void testJobTemplateNameMatchesBuiltInPattern() {
+    IcebergRewriteManifestsJob job = new IcebergRewriteManifestsJob();
+    SparkJobTemplate template = job.jobTemplate();
+
+    assertTrue(template.name().matches(JobTemplateProvider.BUILTIN_NAME_PATTERN));
+    assertTrue(template.name().startsWith(JobTemplateProvider.BUILTIN_NAME_PREFIX));
+  }
+
+  // Test parseArguments method
+
+  @Test
+  public void testParseArgumentsWithAllRequired() {
+    String[] args = {"--catalog", "iceberg_prod", "--table", "db.sample"};
+    Map<String, String> result = IcebergRewriteManifestsJob.parseArguments(args);
+
+    assertEquals(2, result.size());
+    assertEquals("iceberg_prod", result.get("catalog"));
+    assertEquals("db.sample", result.get("table"));
+  }
+
+  @Test
+  public void testParseArgumentsWithOptional() {
+    String[] args = {
+      "--catalog", "iceberg_prod",
+      "--table", "db.sample",
+      "--use-caching", "false"
+    };
+    Map<String, String> result = IcebergRewriteManifestsJob.parseArguments(args);
+
+    assertEquals(3, result.size());
+    assertEquals("iceberg_prod", result.get("catalog"));
+    assertEquals("db.sample", result.get("table"));
+    assertEquals("false", result.get("use-caching"));
+  }
+
+  @Test
+  public void testParseArgumentsWithEmptyValues() {
+    String[] args = {"--catalog", "iceberg_prod", "--table", "db.sample", "--use-caching", ""};
+    Map<String, String> result = IcebergRewriteManifestsJob.parseArguments(args);
+
+    // Empty values should be ignored
+    assertEquals(2, result.size());
+    assertEquals("iceberg_prod", result.get("catalog"));
+    assertEquals("db.sample", result.get("table"));
+    assertFalse(result.containsKey("use-caching"));
+  }
+
+  @Test
+  public void testParseArgumentsWithMissingValues() {
+    String[] args = {"--catalog", "iceberg_prod", "--table"};
+    Map<String, String> result = IcebergRewriteManifestsJob.parseArguments(args);
+
+    // Only catalog should be parsed, table has no value
+    assertEquals(1, result.size());
+    assertEquals("iceberg_prod", result.get("catalog"));
+    assertFalse(result.containsKey("table"));
+  }
+
+  @Test
+  public void testParseArgumentsOrderIndependent() {
+    String[] args1 = {"--catalog", "cat1", "--table", "tbl1", "--use-caching", "true"};
+    String[] args2 = {"--use-caching", "true", "--table", "tbl1", "--catalog", "cat1"};
+
+    Map<String, String> result1 = IcebergRewriteManifestsJob.parseArguments(args1);
+    Map<String, String> result2 = IcebergRewriteManifestsJob.parseArguments(args2);
+
+    assertEquals(result1, result2);
+  }
+
+  // Test buildProcedureCall method
+
+  @Test
+  public void testBuildProcedureCallMinimal() {
+    String sql =
+        IcebergRewriteManifestsJob.buildProcedureCall("iceberg_prod", "db.sample", null);
+
+    assertEquals("CALL iceberg_prod.system.rewrite_manifests(table => 'db.sample')", sql);
+  }
+
+  @Test
+  public void testBuildProcedureCallWithCachingTrue() {
+    String sql =
+        IcebergRewriteManifestsJob.buildProcedureCall("iceberg_prod", "db.sample", "true");
+
+    assertEquals(
+        "CALL iceberg_prod.system.rewrite_manifests(table => 'db.sample', use_caching => true)",
+        sql);
+  }
+
+  @Test
+  public void testBuildProcedureCallWithCachingFalse() {
+    String sql =
+        IcebergRewriteManifestsJob.buildProcedureCall("iceberg_prod", "db.sample", "false");
+
+    assertEquals(
+        "CALL iceberg_prod.system.rewrite_manifests(table => 'db.sample', use_caching => false)",
+        sql);
+  }
+
+  @Test
+  public void testBuildProcedureCallWithEmptyCaching() {
+    String sql =
+        IcebergRewriteManifestsJob.buildProcedureCall("iceberg_prod", "db.sample", "");
+
+    assertEquals("CALL iceberg_prod.system.rewrite_manifests(table => 'db.sample')", sql);
+  }
+
+  @Test
+  public void testBuildProcedureCallWithSqlInjectionAttempt() {
+    // Test SQL injection attempt in table name
+    String maliciousTable = "db.table' OR '1'='1";
+    String sql =
+        IcebergRewriteManifestsJob.buildProcedureCall("iceberg_catalog", maliciousTable, null);
+
+    // Verify single quotes are escaped (becomes '')
+    assertTrue(sql.contains("db.table'' OR ''1''=''1"));
+    assertFalse(sql.contains("' OR '1'='1"));
+
+    // Test SQL injection attempt in catalog name
+    String maliciousCatalog = "catalog`; DROP TABLE users; --";
+    sql =
+        IcebergRewriteManifestsJob.buildProcedureCall(maliciousCatalog, "db.table", null);
+
+    // Verify backticks are escaped
+    assertTrue(sql.contains("catalog``; DROP TABLE users; --"));
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

- Added a new built-in Iceberg maintenance job named `builtin-iceberg-rewrite-manifests`.
- Implemented `IcebergRewriteManifestsJob` to execute Iceberg's `rewrite_manifests` action via Spark's SQL procedure (`CALL catalog.system.rewrite_manifests`).
- Supported configurable parameters: `--catalog`, `--table`, and an optional `--use-caching` argument.

### Why are the changes needed?

Over time, Iceberg tables accumulate many small manifest files from frequent commits. This slows down scan planning because the engine must open and read each manifest to determine which data files match a query filter. 

Rewriting manifests into fewer, larger files with better-aligned partition specs significantly improves query planning performance. While `IcebergRewriteDataFilesJob` addresses data file layout, this new job specifically addresses manifest file bloat, enabling automatic policy-driven manifest optimization on the server side.

Fix: #11196

### Does this PR introduce _any_ user-facing change?

Yes. Users can now run the `builtin-iceberg-rewrite-manifests` job via the Gravitino API to optimize Iceberg table manifest files.

### How was this patch tested?

- Added unit tests for `IcebergRewriteManifestsJob` to verify argument parsing and Spark SQL procedure string generation.
- Manually tested the job execution and verified that manifest files are successfully rewritten and consolidated.