### PR TITLE
docs: mention MariaDB in README feature list

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Apache Gravitino is a high-performance, geo-distributed, and federated metadata 
 
 ## 🚀 Key Features
 
-- **Unified Metadata Management**: Manage diverse metadata sources through a single model and API (e.g., Hive, MySQL, HDFS, S3).
+- **Unified Metadata Management**: Manage diverse metadata sources through a single model and API (e.g., Hive, MySQL, MariaDB, HDFS, S3).
 - **End-to-End Data Governance**: Features like access control, auditing, and discovery across all metadata assets.
 - **Direct Metadata Integration**: Changes in underlying systems are immediately reflected via Gravitino’s connectors.
 - **Geo-Distribution Support**: Share metadata across regions and clouds to support global architectures.


### PR DESCRIPTION
## Summary

Adds MariaDB to the README example list of metadata sources Gravitino can manage. The project already supports `jdbc:mariadb` URLs (e.g. in `JdbcUrlUtils`); the README listed Hive, MySQL, HDFS, and S3 but not MariaDB.

Documentation only; no code or deployment changes.

## Test plan

- [x] README only