### PR TITLE
[#9287] fix(flink-connector): delegate paimon table factory to underlying catalog

### DIFF
--- a/flink-connector/flink-common/src/main/java/org/apache/gravitino/flink/connector/paimon/GravitinoPaimonCatalog.java
+++ b/flink-connector/flink-common/src/main/java/org/apache/gravitino/flink/connector/paimon/GravitinoPaimonCatalog.java
@@ -44,7 +44,6 @@ import org.apache.gravitino.rel.expressions.distributions.Distribution;
 import org.apache.gravitino.rel.expressions.distributions.Distributions;
 import org.apache.gravitino.rel.expressions.distributions.Strategy;
 import org.apache.paimon.flink.FlinkCatalogFactory;
-import org.apache.paimon.flink.FlinkTableFactory;
 
 /**
  * The GravitinoPaimonCatalog class is an implementation of the BaseCatalog class that is used to
@@ -88,7 +87,7 @@ public class GravitinoPaimonCatalog extends BaseCatalog {
 
   @Override
   public Optional<Factory> getFactory() {
-    return Optional.of(new FlinkTableFactory());
+    return paimonCatalog.getFactory();
   }
 
   @Override


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR fixes the Paimon Flink factory wiring in Gravitino:
- Change GravitinoPaimonCatalog#getFactory to delegate to the underlying paimon catalog factory.
- Remove the now-unused FlinkTableFactory direct import.

### Why are the changes needed?

In the previous implementation, Gravitino returned a no-arg FlinkTableFactory, which does not bind the concrete FlinkCatalog context.  
For metastore.partitioned-table=true, this may break expected Hive Metastore partition sync behavior in Flink path.

Fix: #9287

### Does this PR introduce _any_ user-facing change?

- For Flink + Paimon catalog usage, table factory behavior now aligns with underlying Paimon catalog wiring.
- No user-facing API change.
- No property key addition/removal.

### How was this patch tested?

"org.apache.gravitino.flink.connector.integration.test.**" passed
