### PR TITLE
[#9515] fix(catalog-starrocks): fallback to NONE when no DISTRIBUTED BY

### DIFF
--- a/catalogs/catalog-jdbc-starrocks/src/main/java/org/apache/gravitino/catalog/starrocks/utils/StarRocksUtils.java
+++ b/catalogs/catalog-jdbc-starrocks/src/main/java/org/apache/gravitino/catalog/starrocks/utils/StarRocksUtils.java
@@ -57,12 +57,14 @@ public class StarRocksUtils {
       Pattern.compile(
           "DISTRIBUTED BY\\s+(HASH|RANDOM)\\s*(\\(([^)]+)\\))?\\s*(BUCKETS\\s+(\\d+))?");
 
-  // Match only top-level DISTRIBUTED BY clause boundaries to avoid false positives
-  // from column comments. For strategy shape, RANDOM has no column list while
-  // others are expected to start with "strategy(".
+  // Match DISTRIBUTED BY clause presence in a formatting-independent way.
+  // Accept any whitespace before DISTRIBUTED so single-line SQL, CRLF line endings,
+  // and clauses following other table options (for example ENGINE=...) are detected.
+  // Keep the strategy-shape guard so RANDOM has no column list while others are
+  // still expected to start with "strategy(".
   private static final Pattern DISTRIBUTED_BY_CLAUSE_PATTERN =
       Pattern.compile(
-          "(?:^|\\n|\\))\\s*DISTRIBUTED\\s+BY\\s+(?:RANDOM\\b|\\w+\\s*\\()",
+          "(?:^|\\s|\\))DISTRIBUTED\\s+BY\\s+(?:RANDOM\\b|\\w+\\s*\\()",
           Pattern.CASE_INSENSITIVE);
 
   private static final Pattern TABLE_COMMENT_PATTERN =

--- a/catalogs/catalog-jdbc-starrocks/src/main/java/org/apache/gravitino/catalog/starrocks/utils/StarRocksUtils.java
+++ b/catalogs/catalog-jdbc-starrocks/src/main/java/org/apache/gravitino/catalog/starrocks/utils/StarRocksUtils.java
@@ -64,8 +64,7 @@ public class StarRocksUtils {
   // still expected to start with "strategy(".
   private static final Pattern DISTRIBUTED_BY_CLAUSE_PATTERN =
       Pattern.compile(
-          "(?:^|\\s|\\))DISTRIBUTED\\s+BY\\s+(?:RANDOM\\b|\\w+\\s*\\()",
-          Pattern.CASE_INSENSITIVE);
+          "(?:^|\\s|\\))DISTRIBUTED\\s+BY\\s+(?:RANDOM\\b|\\w+\\s*\\()", Pattern.CASE_INSENSITIVE);
 
   private static final Pattern TABLE_COMMENT_PATTERN =
       Pattern.compile("COMMENT\\s*\"([^\\(]+?)\\s*\\(From Gravitino,.*\\)\"");

--- a/catalogs/catalog-jdbc-starrocks/src/main/java/org/apache/gravitino/catalog/starrocks/utils/StarRocksUtils.java
+++ b/catalogs/catalog-jdbc-starrocks/src/main/java/org/apache/gravitino/catalog/starrocks/utils/StarRocksUtils.java
@@ -57,6 +57,14 @@ public class StarRocksUtils {
       Pattern.compile(
           "DISTRIBUTED BY\\s+(HASH|RANDOM)\\s*(\\(([^)]+)\\))?\\s*(BUCKETS\\s+(\\d+))?");
 
+  // Match only top-level DISTRIBUTED BY clause boundaries to avoid false positives
+  // from column comments. For strategy shape, RANDOM has no column list while
+  // others are expected to start with "strategy(".
+  private static final Pattern DISTRIBUTED_BY_CLAUSE_PATTERN =
+      Pattern.compile(
+          "(?:^|\\n|\\))\\s*DISTRIBUTED\\s+BY\\s+(?:RANDOM\\b|\\w+\\s*\\()",
+          Pattern.CASE_INSENSITIVE);
+
   private static final Pattern TABLE_COMMENT_PATTERN =
       Pattern.compile("COMMENT\\s*\"([^\\(]+?)\\s*\\(From Gravitino,.*\\)\"");
 
@@ -175,6 +183,10 @@ public class StarRocksUtils {
                   .map(col -> NamedReference.field(new String[] {col}))
                   .toArray(NamedReference[]::new))
           .build();
+    }
+
+    if (!DISTRIBUTED_BY_CLAUSE_PATTERN.matcher(createTableSql).find()) {
+      return Distributions.NONE;
     }
 
     throw new RuntimeException("Failed to extract distribution info in sql:" + createTableSql);

--- a/catalogs/catalog-jdbc-starrocks/src/test/java/org/apache/gravitino/catalog/starrocks/utils/TestStarRocksUtils.java
+++ b/catalogs/catalog-jdbc-starrocks/src/test/java/org/apache/gravitino/catalog/starrocks/utils/TestStarRocksUtils.java
@@ -27,6 +27,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import org.apache.gravitino.rel.expressions.distributions.Distribution;
+import org.apache.gravitino.rel.expressions.distributions.Distributions;
 import org.apache.gravitino.rel.expressions.literals.Literal;
 import org.apache.gravitino.rel.expressions.literals.Literals;
 import org.apache.gravitino.rel.expressions.transforms.Transform;
@@ -34,6 +35,7 @@ import org.apache.gravitino.rel.expressions.transforms.Transforms;
 import org.apache.gravitino.rel.partitions.Partition;
 import org.apache.gravitino.rel.partitions.Partitions;
 import org.apache.gravitino.rel.types.Types;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class TestStarRocksUtils {
@@ -205,5 +207,23 @@ public class TestStarRocksUtils {
     Distribution distribution2 =
         StarRocksUtils.extractDistributionInfoFromSql(createTableSqlWithAuto);
     assertEquals(distribution2.number(), -1);
+
+    String createTableSqlWithoutDistribution =
+        "CREATE TABLE `testTable` (\n`col1` date NOT NULL\n) PROPERTIES (\"location\" = \"hdfs://path/table\")";
+    Distribution distribution3 =
+        StarRocksUtils.extractDistributionInfoFromSql(createTableSqlWithoutDistribution);
+    assertEquals(Distributions.NONE.strategy(), distribution3.strategy());
+
+    String createTableSqlWithKeywordInColumnComment =
+        "CREATE TABLE `testTable` (\n`col1` date NOT NULL COMMENT \"contains DISTRIBUTED BY in comment\"\n) PROPERTIES (\"location\" = \"hdfs://path/table\")";
+    Distribution distribution4 =
+        StarRocksUtils.extractDistributionInfoFromSql(createTableSqlWithKeywordInColumnComment);
+    assertEquals(Distributions.NONE.strategy(), distribution4.strategy());
+
+    String createTableSqlWithInvalidDistribution =
+        "CREATE TABLE `testTable` (\n`col1` date NOT NULL\n) DISTRIBUTED BY INVALID(`col1`) BUCKETS 2";
+    Assertions.assertThrows(
+        RuntimeException.class,
+        () -> StarRocksUtils.extractDistributionInfoFromSql(createTableSqlWithInvalidDistribution));
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR fixes StarRocks distribution parsing when loading tables whose `SHOW CREATE TABLE` SQL does not include a valid `DISTRIBUTED BY` clause (for example, external/Paimon-like table definitions).

- In `StarRocksUtils.extractDistributionInfoFromSql`, return `Distributions.NONE` when a top-level distribution clause is absent.
- Keep strict behavior when a distribution clause exists but cannot be parsed (still throw runtime exception).
- Tighten distribution-clause presence detection to top-level clause boundaries and strategy shape (`RANDOM` or `strategy(`), to avoid false positives from column comments containing `DISTRIBUTED BY`.
- Extend existing `TestStarRocksUtils.testDistributedInfoPattern` with:
  - a no-distribution SQL case expecting `Distributions.NONE`
  - a column-comment case containing `DISTRIBUTED BY` that still expects `Distributions.NONE`
  - an invalid distribution clause case expecting exception

### Why are the changes needed?

Issue #9515 reports table load failures with:

`Failed to extract distribution info in sql: CREATE TABLE ... PROPERTIES (...)`

The root cause is that current StarRocks loading logic always parses distribution info, while some table SQL does not contain a valid top-level `DISTRIBUTED BY` clause. This patch makes that scenario loadable while preserving fail-fast behavior for malformed distribution syntax.

Fix: #9515

### Does this PR introduce _any_ user-facing change?

- StarRocks table loading no longer fails for table SQL that does not define a valid top-level `DISTRIBUTED BY` clause.
- False positives caused by `DISTRIBUTED BY` appearing in column comments are avoided.
- No API changes.
- No property key additions/removals.

### How was this patch tested?

- Formatting:
  - `./gradlew :catalogs:catalog-jdbc-starrocks:spotlessApply`
- Unit test:
  - `./gradlew :catalogs:catalog-jdbc-starrocks:test --tests org.apache.gravitino.catalog.starrocks.utils.TestStarRocksUtils -PskipITs`
- Result: BUILD SUCCESSFUL.
