### PR TITLE
[#11241] fix(audit): distinguish Iceberg replace-view operation type

### DIFF
--- a/core/src/main/java/org/apache/gravitino/audit/AuditLog.java
+++ b/core/src/main/java/org/apache/gravitino/audit/AuditLog.java
@@ -333,6 +333,8 @@ public interface AuditLog {
 
     ALTER_VIEW,
 
+    REPLACE_VIEW,
+
     DROP_VIEW,
 
     LOAD_VIEW,

--- a/core/src/main/java/org/apache/gravitino/audit/v2/CompatibilityUtils.java
+++ b/core/src/main/java/org/apache/gravitino/audit/v2/CompatibilityUtils.java
@@ -96,6 +96,7 @@ public class CompatibilityUtils {
           .put(OperationType.LOAD_TOPIC, Operation.LOAD_TOPIC)
           .put(OperationType.CREATE_VIEW, Operation.CREATE_VIEW)
           .put(OperationType.ALTER_VIEW, Operation.ALTER_VIEW)
+          .put(OperationType.REPLACE_VIEW, Operation.REPLACE_VIEW)
           .put(OperationType.DROP_VIEW, Operation.DROP_VIEW)
           .put(OperationType.LOAD_VIEW, Operation.LOAD_VIEW)
           .put(OperationType.VIEW_EXISTS, Operation.VIEW_EXISTS)

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/OperationType.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/OperationType.java
@@ -100,6 +100,7 @@ public enum OperationType {
   // View event
   CREATE_VIEW,
   ALTER_VIEW,
+  REPLACE_VIEW,
   DROP_VIEW,
   LOAD_VIEW,
   VIEW_EXISTS,

--- a/core/src/test/java/org/apache/gravitino/audit/v2/TestCompatibilityUtils.java
+++ b/core/src/test/java/org/apache/gravitino/audit/v2/TestCompatibilityUtils.java
@@ -104,6 +104,7 @@ public class TestCompatibilityUtils {
       {OperationType.LIST_TOPIC, Operation.LIST_TOPIC},
       {OperationType.CREATE_VIEW, Operation.CREATE_VIEW},
       {OperationType.ALTER_VIEW, Operation.ALTER_VIEW},
+      {OperationType.REPLACE_VIEW, Operation.REPLACE_VIEW},
       {OperationType.DROP_VIEW, Operation.DROP_VIEW},
       {OperationType.LOAD_VIEW, Operation.LOAD_VIEW},
       {OperationType.VIEW_EXISTS, Operation.VIEW_EXISTS},

--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/listener/api/event/IcebergReplaceViewEvent.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/listener/api/event/IcebergReplaceViewEvent.java
@@ -44,7 +44,7 @@ public class IcebergReplaceViewEvent extends IcebergViewEvent {
         IcebergRESTUtils.cloneIcebergRESTObject(loadViewResponse, LoadViewResponse.class);
   }
 
-  public UpdateTableRequest renameViewRequest() {
+  public UpdateTableRequest replaceViewRequest() {
     return replaceViewRequest;
   }
 

--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/listener/api/event/IcebergReplaceViewEvent.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/listener/api/event/IcebergReplaceViewEvent.java
@@ -54,6 +54,6 @@ public class IcebergReplaceViewEvent extends IcebergViewEvent {
 
   @Override
   public OperationType operationType() {
-    return OperationType.ALTER_VIEW;
+    return OperationType.REPLACE_VIEW;
   }
 }

--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/listener/api/event/IcebergReplaceViewFailureEvent.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/listener/api/event/IcebergReplaceViewFailureEvent.java
@@ -45,6 +45,6 @@ public class IcebergReplaceViewFailureEvent extends IcebergViewFailureEvent {
 
   @Override
   public OperationType operationType() {
-    return OperationType.ALTER_VIEW;
+    return OperationType.REPLACE_VIEW;
   }
 }

--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/listener/api/event/IcebergReplaceViewPreEvent.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/listener/api/event/IcebergReplaceViewPreEvent.java
@@ -48,6 +48,6 @@ public class IcebergReplaceViewPreEvent extends IcebergViewPreEvent
    */
   @Override
   public OperationType operationType() {
-    return OperationType.ALTER_VIEW;
+    return OperationType.REPLACE_VIEW;
   }
 }

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/TestIcebergViewOperations.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/TestIcebergViewOperations.java
@@ -50,6 +50,8 @@ import org.apache.gravitino.listener.api.event.IcebergReplaceViewFailureEvent;
 import org.apache.gravitino.listener.api.event.IcebergReplaceViewPreEvent;
 import org.apache.gravitino.listener.api.event.IcebergViewExistsEvent;
 import org.apache.gravitino.listener.api.event.IcebergViewExistsPreEvent;
+import org.apache.gravitino.listener.api.event.OperationType;
+import org.apache.gravitino.listener.api.event.PreEvent;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.UpdateRequirements;
 import org.apache.iceberg.catalog.Namespace;
@@ -172,16 +174,23 @@ public class TestIcebergViewOperations extends IcebergNamespaceTestBase {
 
     dummyEventListener.clearEvent();
     verifyReplaceSucc(namespace, "replace_foo1", metadata);
-    Assertions.assertTrue(dummyEventListener.popPreEvent() instanceof IcebergReplaceViewPreEvent);
-    Assertions.assertTrue(dummyEventListener.popPostEvent() instanceof IcebergReplaceViewEvent);
+    PreEvent replacePreEvent = dummyEventListener.popPreEvent();
+    Event replacePostEvent = dummyEventListener.popPostEvent();
+    Assertions.assertTrue(replacePreEvent instanceof IcebergReplaceViewPreEvent);
+    Assertions.assertTrue(replacePostEvent instanceof IcebergReplaceViewEvent);
+    Assertions.assertEquals(OperationType.REPLACE_VIEW, replacePreEvent.operationType());
+    Assertions.assertEquals(OperationType.REPLACE_VIEW, replacePostEvent.operationType());
 
     verifyDropViewSucc(namespace, "replace_foo1");
 
     dummyEventListener.clearEvent();
     verifyUpdateViewFail(namespace, "replace_foo1", 404, metadata);
-    Assertions.assertTrue(dummyEventListener.popPreEvent() instanceof IcebergReplaceViewPreEvent);
-    Assertions.assertTrue(
-        dummyEventListener.popPostEvent() instanceof IcebergReplaceViewFailureEvent);
+    PreEvent replaceFailurePreEvent = dummyEventListener.popPreEvent();
+    Event replaceFailurePostEvent = dummyEventListener.popPostEvent();
+    Assertions.assertTrue(replaceFailurePreEvent instanceof IcebergReplaceViewPreEvent);
+    Assertions.assertTrue(replaceFailurePostEvent instanceof IcebergReplaceViewFailureEvent);
+    Assertions.assertEquals(OperationType.REPLACE_VIEW, replaceFailurePreEvent.operationType());
+    Assertions.assertEquals(OperationType.REPLACE_VIEW, replaceFailurePostEvent.operationType());
 
     verifyDropNamespaceSucc(namespace);
     verifyUpdateViewFail(namespace, "replace_foo1", 404, metadata);

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/TestIcebergViewOperations.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/TestIcebergViewOperations.java
@@ -178,6 +178,8 @@ public class TestIcebergViewOperations extends IcebergNamespaceTestBase {
     Event replacePostEvent = dummyEventListener.popPostEvent();
     Assertions.assertTrue(replacePreEvent instanceof IcebergReplaceViewPreEvent);
     Assertions.assertTrue(replacePostEvent instanceof IcebergReplaceViewEvent);
+    IcebergReplaceViewEvent replaceViewEvent = (IcebergReplaceViewEvent) replacePostEvent;
+    Assertions.assertNotNull(replaceViewEvent.replaceViewRequest());
     Assertions.assertEquals(OperationType.REPLACE_VIEW, replacePreEvent.operationType());
     Assertions.assertEquals(OperationType.REPLACE_VIEW, replacePostEvent.operationType());
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR introduces a dedicated `REPLACE_VIEW` operation type for Iceberg replace-view events and propagates it through audit operation mapping.

Changes include:
- Add `REPLACE_VIEW` to listener `OperationType`.
- Add `REPLACE_VIEW` to `AuditLog.Operation`.
- Map `OperationType.REPLACE_VIEW` to `Operation.REPLACE_VIEW` in compatibility mapping.
- Update `IcebergReplaceViewPreEvent`, `IcebergReplaceViewEvent`, and `IcebergReplaceViewFailureEvent` to return `REPLACE_VIEW`.
- Update tests:
  - `TestCompatibilityUtils`
  - `TestIcebergViewOperations`

### Why are the changes needed?

Previously, Iceberg replace-view events were audited as `ALTER_VIEW`, which made it impossible to distinguish alter vs replace from audit rows alone.

Fix: #11241

### Does this PR introduce _any_ user-facing change?

Yes.
Audit `operationType` now emits `REPLACE_VIEW` for Iceberg replace-view operations.

### How was this patch tested?

- `./gradlew :core:spotlessApply :iceberg:iceberg-rest-server:spotlessApply`
- `./gradlew :core:test --tests org.apache.gravitino.audit.v2.TestCompatibilityUtils :iceberg:iceberg-rest-server:test --tests org.apache.gravitino.iceberg.service.rest.TestIcebergViewOperations`
