### PR TITLE
[#11183] improvement(deps): enforce snakeyaml version for transitive dependencies

### DIFF
--- a/catalogs/catalog-lakehouse-paimon/build.gradle.kts
+++ b/catalogs/catalog-lakehouse-paimon/build.gradle.kts
@@ -103,6 +103,11 @@ dependencies {
   }
   implementation(libs.commons.lang3)
   implementation(libs.guava)
+
+  constraints {
+    implementation(libs.snakeyaml)
+  }
+
   implementation(libs.hadoop3.common) {
     exclude("com.github.spotbugs")
     exclude("com.sun.jersey")


### PR DESCRIPTION

### What changes were proposed in this pull request?

Added a dependency constraint in `catalogs/catalog-lakehouse-paimon/build.gradle.kts` to enforce `snakeyaml:2.0` for transitive dependencies.

### Why are the changes needed?

`paimon-shade-jackson-2` pulls in `snakeyaml:1.33` transitively, which has known issues. The constraint ensures it resolves to `2.0`.

Fix: #11183 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

- `./gradlew :catalogs:catalog-lakehouse-paimon:compileJava` passes.
- Verified via `dependencyInsight` that snakeyaml resolves to `2.0`.
