### PR TITLE
[#11090] test(helm): Add unit tests for Gravitino Iceberg REST Server chart

### DIFF
--- a/.github/workflows/chart-test.yaml
+++ b/.github/workflows/chart-test.yaml
@@ -58,6 +58,14 @@ jobs:
           helm repo add bitnami https://charts.bitnami.com/bitnami
           ct lint --chart-dirs=dev/charts --chart-yaml-schema=dev/ci/chart_schema.yaml --lint-conf=dev/ci/lintconf.yaml --target-branch ${{ github.event.pull_request.base.ref }} --check-version-increment=false
 
+      - name: Set up helm-unittest
+        if: steps.list-changed.outputs.changed == 'true'
+        run: helm plugin install https://github.com/helm-unittest/helm-unittest.git --version v1.1.0
+
+      - name: Unit test Gravitino Iceberg REST Server chart
+        if: steps.list-changed.outputs.changed == 'true'
+        run: helm unittest --with-subchart=false dev/charts/gravitino-iceberg-rest-server
+
       - name: Set up kind cluster
         if: steps.list-changed.outputs.changed == 'true'
         uses: container-tools/kind-action@v2

--- a/.github/workflows/chart-test.yaml
+++ b/.github/workflows/chart-test.yaml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Set up helm-unittest
         if: steps.list-changed.outputs.changed == 'true'
-        run: helm plugin install https://github.com/helm-unittest/helm-unittest.git --version v1.1.0
+        run: helm plugin install https://github.com/helm-unittest/helm-unittest.git --version v1.1.0 --verify=false
 
       - name: Unit test Gravitino Iceberg REST Server chart
         if: steps.list-changed.outputs.changed == 'true'

--- a/dev/charts/gravitino-iceberg-rest-server/templates/service.yaml
+++ b/dev/charts/gravitino-iceberg-rest-server/templates/service.yaml
@@ -68,7 +68,7 @@ spec:
 
     # Extra exposed ports
   {{- if .Values.extraExposePorts }}
-    - {{ tpl (toYaml .Values.extraExposePorts) . | trim }}
+    {{- tpl (toYaml .Values.extraExposePorts) . | nindent 4 }}
   {{- end }}
 
     # Selector for pods

--- a/dev/charts/gravitino-iceberg-rest-server/tests/configmap_test.yaml
+++ b/dev/charts/gravitino-iceberg-rest-server/tests/configmap_test.yaml
@@ -1,0 +1,156 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+suite: test gravitino iceberg rest server configmap
+templates:
+  - configmap.yaml
+tests:
+  - it: renders default config files
+    release:
+      name: iceberg-rest
+      namespace: iceberg-system
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: metadata.name
+          value: iceberg-rest-gravitino-iceberg-rest-server-helm
+      - equal:
+          path: metadata.namespace
+          value: iceberg-system
+      - exists:
+          path: data["init.sh"]
+      - exists:
+          path: data["gravitino-iceberg-rest-server.conf"]
+      - exists:
+          path: data["gravitino-iceberg-rest-log4j2.properties"]
+      - exists:
+          path: data["core-site.xml"]
+      - exists:
+          path: data["hdfs-site.xml"]
+      - matchRegex:
+          path: data["init.sh"]
+          pattern: "start-iceberg-rest-server\\.sh"
+      - matchRegex:
+          path: data["gravitino-iceberg-rest-server.conf"]
+          pattern: "gravitino\\.iceberg-rest\\.httpPort = 9001"
+      - matchRegex:
+          path: data["gravitino-iceberg-rest-server.conf"]
+          pattern: "gravitino\\.iceberg-rest\\.catalog-backend = memory"
+      - matchRegex:
+          path: data["gravitino-iceberg-rest-server.conf"]
+          pattern: "gravitino\\.iceberg-rest\\.warehouse = /tmp/"
+      - matchRegex:
+          path: data["gravitino-iceberg-rest-log4j2.properties"]
+          pattern: "rootLogger\\.level = info"
+      - matchRegex:
+          path: data["gravitino-iceberg-rest-log4j2.properties"]
+          pattern: "appender\\.console\\.type = Console"
+
+  - it: renders customized Iceberg REST and log4j configuration
+    release:
+      name: custom-iceberg-rest
+    set:
+      icebergRest:
+        httpPort: 19001
+        catalogBackend: jdbc
+        warehouse: s3://warehouse/iceberg
+        uri: jdbc:postgresql://postgresql:5432/iceberg
+        catalogBackendName: jdbc_catalog
+        ioImpl: org.apache.iceberg.aws.s3.S3FileIO
+        credentialProviders: s3-token
+        jdbc:
+          user: iceberg_user
+          password: iceberg_password
+          initialize: true
+          driver: org.postgresql.Driver
+          schemaVersion: V1
+        s3:
+          accessKeyId: access_key
+          secretAccessKey: secret_key
+          endpoint: http://minio:9000
+          region: us-east-1
+          pathStyleAccess: true
+        dynamicConfigProvider:
+          uri: http://gravitino:8090
+          metalake: metalake_demo
+          defaultCatalogName: iceberg_catalog
+      additionalConfigItems:
+        gravitino.iceberg-rest.custom.setting: "{{ .Release.Name }}"
+      log4j2Properties:
+        rootLoggerLevel: debug
+      additionalLog4j2Properties:
+        logger.custom.name: org.apache.gravitino.Custom
+    asserts:
+      - matchRegex:
+          path: data["gravitino-iceberg-rest-server.conf"]
+          pattern: "gravitino\\.iceberg-rest\\.httpPort = 19001"
+      - matchRegex:
+          path: data["gravitino-iceberg-rest-server.conf"]
+          pattern: "gravitino\\.iceberg-rest\\.catalog-backend = jdbc"
+      - matchRegex:
+          path: data["gravitino-iceberg-rest-server.conf"]
+          pattern: "gravitino\\.iceberg-rest\\.warehouse = s3://warehouse/iceberg"
+      - matchRegex:
+          path: data["gravitino-iceberg-rest-server.conf"]
+          pattern: "gravitino\\.iceberg-rest\\.uri = jdbc:postgresql://postgresql:5432/iceberg"
+      - matchRegex:
+          path: data["gravitino-iceberg-rest-server.conf"]
+          pattern: "gravitino\\.iceberg-rest\\.jdbc-user = iceberg_user"
+      - matchRegex:
+          path: data["gravitino-iceberg-rest-server.conf"]
+          pattern: "gravitino\\.iceberg-rest\\.jdbc-initialize = true"
+      - matchRegex:
+          path: data["gravitino-iceberg-rest-server.conf"]
+          pattern: "gravitino\\.iceberg-rest\\.jdbc\\.schema-version = V1"
+      - matchRegex:
+          path: data["gravitino-iceberg-rest-server.conf"]
+          pattern: "gravitino\\.iceberg-rest\\.s3-endpoint = http://minio:9000"
+      - matchRegex:
+          path: data["gravitino-iceberg-rest-server.conf"]
+          pattern: "gravitino\\.iceberg-rest\\.gravitino-metalake = metalake_demo"
+      - matchRegex:
+          path: data["gravitino-iceberg-rest-server.conf"]
+          pattern: "gravitino\\.iceberg-rest\\.custom\\.setting = custom-iceberg-rest"
+      - matchRegex:
+          path: data["gravitino-iceberg-rest-log4j2.properties"]
+          pattern: "rootLogger\\.level = debug"
+      - matchRegex:
+          path: data["gravitino-iceberg-rest-log4j2.properties"]
+          pattern: "logger\\.custom\\.name = org\\.apache\\.gravitino\\.Custom"
+
+  - it: renders Hadoop XML properties
+    set:
+      coreSiteProperties:
+        fs.defaultFS: hdfs://namenode:8020
+      hdfsSiteProperties:
+        dfs.replication: "3"
+    asserts:
+      - matchRegex:
+          path: data["core-site.xml"]
+          pattern: "<name>fs\\.defaultFS</name>"
+      - matchRegex:
+          path: data["core-site.xml"]
+          pattern: "<value>hdfs://namenode:8020</value>"
+      - matchRegex:
+          path: data["hdfs-site.xml"]
+          pattern: "<name>dfs\\.replication</name>"
+      - matchRegex:
+          path: data["hdfs-site.xml"]
+          pattern: "<value>3</value>"

--- a/dev/charts/gravitino-iceberg-rest-server/tests/deployment_test.yaml
+++ b/dev/charts/gravitino-iceberg-rest-server/tests/deployment_test.yaml
@@ -1,0 +1,225 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+suite: test gravitino iceberg rest server deployment
+templates:
+  - deployment.yaml
+  - configmap.yaml
+tests:
+  - it: renders the default deployment
+    template: deployment.yaml
+    release:
+      name: iceberg-rest
+      namespace: iceberg-system
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: metadata.name
+          value: iceberg-rest-gravitino-iceberg-rest-server-helm
+      - equal:
+          path: metadata.namespace
+          value: iceberg-system
+      - equal:
+          path: spec.replicas
+          value: 1
+      - equal:
+          path: spec.selector.matchLabels.release
+          value: iceberg-rest
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: default
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: apache/gravitino-iceberg-rest:1.3.0-SNAPSHOT
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GRAVITINO_HOME
+            value: /opt/gravitino-iceberg-rest-server
+          any: true
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SKIP_CONFIG_REWRITE
+            value: "true"
+          any: true
+      - contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            name: http
+            containerPort: 9001
+            protocol: TCP
+          any: true
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.path
+          value: /iceberg/v1/config
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /iceberg/v1/config
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: iceberg-rest-server-config
+            configMap:
+              name: iceberg-rest-gravitino-iceberg-rest-server-helm
+          any: true
+
+  - it: renders pod customization, templated env, and scheduling options
+    template: deployment.yaml
+    release:
+      name: custom-iceberg-rest
+    set:
+      replicas: 3
+      image:
+        repository: registry.example.com/gravitino-iceberg-rest
+        tag: test-tag
+        pullPolicy: Always
+        pullSecrets:
+          - name: registry-secret
+      serviceAccount:
+        create: true
+        name: iceberg-rest-sa
+      podLabels:
+        app.kubernetes.io/part-of: gravitino
+      podAnnotations:
+        prometheus.io/scrape: "true"
+      envWithTpl:
+        - name: RELEASE_NAME
+          value: "{{ .Release.Name }}"
+      envFrom:
+        - configMapRef:
+            name: iceberg-rest-env
+      nodeSelector:
+        kubernetes.io/os: linux
+      tolerations:
+        - key: dedicated
+          operator: Equal
+          value: metadata
+          effect: NoSchedule
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/arch
+                    operator: In
+                    values:
+                      - amd64
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 3
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: iceberg-rest-sa
+      - contains:
+          path: spec.template.spec.imagePullSecrets
+          content:
+            name: registry-secret
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: registry.example.com/gravitino-iceberg-rest:test-tag
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: Always
+      - equal:
+          path: spec.template.metadata.labels["app.kubernetes.io/part-of"]
+          value: gravitino
+      - equal:
+          path: spec.template.metadata.annotations["prometheus.io/scrape"]
+          value: "true"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: RELEASE_NAME
+            value: custom-iceberg-rest
+          any: true
+      - contains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+            configMapRef:
+              name: iceberg-rest-env
+      - equal:
+          path: spec.template.spec.nodeSelector["kubernetes.io/os"]
+          value: linux
+      - contains:
+          path: spec.template.spec.tolerations
+          content:
+            key: dedicated
+            operator: Equal
+            value: metadata
+            effect: NoSchedule
+          any: true
+      - equal:
+          path: spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key
+          value: kubernetes.io/arch
+
+  - it: renders security contexts, resources, and custom probes
+    template: deployment.yaml
+    set:
+      podSecurityContext:
+        fsGroup: 1000
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 2000
+        capabilities:
+          drop:
+            - ALL
+      resources:
+        requests:
+          cpu: 500m
+          memory: 1Gi
+        limits:
+          cpu: "2"
+          memory: 2Gi
+      livenessProbe:
+        httpGet:
+          path: /custom/live
+          port: http
+        initialDelaySeconds: 30
+        timeoutSeconds: 3
+      readinessProbe:
+        httpGet:
+          path: /custom/ready
+          port: http
+        initialDelaySeconds: 10
+        timeoutSeconds: 2
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.fsGroup
+          value: 1000
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsUser
+          value: 2000
+      - contains:
+          path: spec.template.spec.containers[0].securityContext.capabilities.drop
+          content: ALL
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.memory
+          value: 1Gi
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.cpu
+          value: "2"
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.path
+          value: /custom/live
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /custom/ready

--- a/dev/charts/gravitino-iceberg-rest-server/tests/ingress_test.yaml
+++ b/dev/charts/gravitino-iceberg-rest-server/tests/ingress_test.yaml
@@ -1,0 +1,84 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+suite: test gravitino iceberg rest server ingress
+templates:
+  - ingress.yaml
+tests:
+  - it: does not render ingress by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders networking v1 ingress for supported Kubernetes versions
+    release:
+      name: iceberg-rest
+    capabilities:
+      majorVersion: 1
+      minorVersion: 29
+    set:
+      ingress:
+        enabled: true
+        className: nginx
+        annotations:
+          nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+        hosts:
+          - host: iceberg-rest.example.com
+            paths:
+              - path: /iceberg
+                pathType: Prefix
+        tls:
+          - secretName: iceberg-rest-tls
+            hosts:
+              - iceberg-rest.example.com
+    asserts:
+      - isAPIVersion:
+          of: networking.k8s.io/v1
+      - isKind:
+          of: Ingress
+      - equal:
+          path: metadata.name
+          value: iceberg-rest-gravitino-iceberg-rest-server-helm
+      - equal:
+          path: metadata.annotations["nginx.ingress.kubernetes.io/proxy-read-timeout"]
+          value: "3600"
+      - equal:
+          path: spec.ingressClassName
+          value: nginx
+      - equal:
+          path: spec.rules[0].host
+          value: iceberg-rest.example.com
+      - equal:
+          path: spec.rules[0].http.paths[0].path
+          value: /iceberg
+      - equal:
+          path: spec.rules[0].http.paths[0].pathType
+          value: Prefix
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.name
+          value: iceberg-rest-gravitino-iceberg-rest-server-helm
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.port.number
+          value: 9001
+      - equal:
+          path: spec.tls[0].secretName
+          value: iceberg-rest-tls
+      - contains:
+          path: spec.tls[0].hosts
+          content: iceberg-rest.example.com

--- a/dev/charts/gravitino-iceberg-rest-server/tests/poddisruptionbudget_test.yaml
+++ b/dev/charts/gravitino-iceberg-rest-server/tests/poddisruptionbudget_test.yaml
@@ -1,0 +1,111 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+suite: test gravitino iceberg rest server pod disruption budget
+templates:
+  - poddisruptionbudget.yaml
+tests:
+  - it: does not render a PodDisruptionBudget by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders minAvailable when enabled
+    set:
+      podDisruptionBudget:
+        enabled: true
+        minAvailable: 1
+    asserts:
+      - isKind:
+          of: PodDisruptionBudget
+      - equal:
+          path: spec.minAvailable
+          value: 1
+      - notExists:
+          path: spec.maxUnavailable
+
+  - it: renders maxUnavailable when minAvailable is empty
+    set:
+      podDisruptionBudget:
+        enabled: true
+        minAvailable: ""
+        maxUnavailable: 1
+    asserts:
+      - isKind:
+          of: PodDisruptionBudget
+      - equal:
+          path: spec.maxUnavailable
+          value: 1
+      - notExists:
+          path: spec.minAvailable
+
+  - it: renders a percentage minAvailable value
+    set:
+      podDisruptionBudget:
+        enabled: true
+        minAvailable: "50%"
+    asserts:
+      - isKind:
+          of: PodDisruptionBudget
+      - equal:
+          path: spec.minAvailable
+          value: "50%"
+      - notExists:
+          path: spec.maxUnavailable
+
+  - it: renders a percentage maxUnavailable value
+    set:
+      podDisruptionBudget:
+        enabled: true
+        minAvailable: ""
+        maxUnavailable: "25%"
+    asserts:
+      - isKind:
+          of: PodDisruptionBudget
+      - equal:
+          path: spec.maxUnavailable
+          value: "25%"
+      - notExists:
+          path: spec.minAvailable
+
+  - it: renders labels and annotations
+    set:
+      podDisruptionBudget:
+        enabled: true
+        labels:
+          exposure: protected
+        annotations:
+          policy.example.com/enabled: "true"
+    asserts:
+      - equal:
+          path: metadata.labels.exposure
+          value: protected
+      - equal:
+          path: metadata.annotations["policy.example.com/enabled"]
+          value: "true"
+
+  - it: fails when minAvailable and maxUnavailable are both specified
+    set:
+      podDisruptionBudget:
+        enabled: true
+        minAvailable: 1
+        maxUnavailable: 1
+    asserts:
+      - failedTemplate:
+          errorMessage: "podDisruptionBudget.minAvailable and podDisruptionBudget.maxUnavailable cannot both be specified. Please specify only one."

--- a/dev/charts/gravitino-iceberg-rest-server/tests/service_test.yaml
+++ b/dev/charts/gravitino-iceberg-rest-server/tests/service_test.yaml
@@ -1,0 +1,117 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+suite: test gravitino iceberg rest server service
+templates:
+  - service.yaml
+tests:
+  - it: renders the default ClusterIP service
+    release:
+      name: iceberg-rest
+      namespace: iceberg-system
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: metadata.name
+          value: gravitino-iceberg-rest-server
+      - equal:
+          path: metadata.namespace
+          value: iceberg-system
+      - equal:
+          path: spec.type
+          value: ClusterIP
+      - contains:
+          path: spec.ports
+          content:
+            name: http
+            port: 9001
+            protocol: TCP
+            targetPort: 9001
+          any: true
+      - equal:
+          path: spec.selector.release
+          value: iceberg-rest
+
+  - it: renders NodePort when requested
+    set:
+      service:
+        type: NodePort
+        nodePort: 30091
+    asserts:
+      - equal:
+          path: spec.type
+          value: NodePort
+      - equal:
+          path: spec.ports[0].nodePort
+          value: 30091
+
+  - it: renders LoadBalancer options
+    set:
+      service:
+        type: LoadBalancer
+        loadBalancerClass: service.k8s.aws/nlb
+        loadBalancerIP: 10.0.0.10
+        loadBalancerSourceRanges:
+          - 10.0.0.0/24
+        externalIPs:
+          - 192.168.0.10
+        labels:
+          exposure: public
+        annotations:
+          service.beta.kubernetes.io/aws-load-balancer-type: nlb
+    asserts:
+      - equal:
+          path: spec.type
+          value: LoadBalancer
+      - equal:
+          path: spec.loadBalancerClass
+          value: service.k8s.aws/nlb
+      - equal:
+          path: spec.loadBalancerIP
+          value: 10.0.0.10
+      - contains:
+          path: spec.loadBalancerSourceRanges
+          content: 10.0.0.0/24
+      - contains:
+          path: spec.externalIPs
+          content: 192.168.0.10
+      - equal:
+          path: metadata.labels.exposure
+          value: public
+      - equal:
+          path: metadata.annotations["service.beta.kubernetes.io/aws-load-balancer-type"]
+          value: nlb
+
+  - it: renders extra exposed ports
+    set:
+      extraExposePorts:
+        - name: metrics
+          port: 9090
+          protocol: TCP
+          targetPort: 9090
+    asserts:
+      - contains:
+          path: spec.ports
+          content:
+            name: metrics
+            port: 9090
+            protocol: TCP
+            targetPort: 9090
+          any: true

--- a/dev/charts/gravitino-iceberg-rest-server/tests/serviceaccount_test.yaml
+++ b/dev/charts/gravitino-iceberg-rest-server/tests/serviceaccount_test.yaml
@@ -1,0 +1,55 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+suite: test gravitino iceberg rest server service account
+templates:
+  - serviceaccount.yaml
+tests:
+  - it: does not render a service account by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders a generated service account when requested
+    release:
+      name: iceberg-rest
+    set:
+      serviceAccount:
+        create: true
+        annotations:
+          iam.amazonaws.com/role: iceberg-rest-role
+    asserts:
+      - isKind:
+          of: ServiceAccount
+      - equal:
+          path: metadata.name
+          value: iceberg-rest-gravitino-iceberg-rest-server-helm
+      - equal:
+          path: metadata.annotations["iam.amazonaws.com/role"]
+          value: iceberg-rest-role
+
+  - it: renders a named service account when requested
+    set:
+      serviceAccount:
+        create: true
+        name: iceberg-rest-sa
+    asserts:
+      - equal:
+          path: metadata.name
+          value: iceberg-rest-sa

--- a/dev/charts/gravitino-iceberg-rest-server/tests/test_connection_test.yaml
+++ b/dev/charts/gravitino-iceberg-rest-server/tests/test_connection_test.yaml
@@ -1,0 +1,58 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+suite: test gravitino iceberg rest server test connection hook
+templates:
+  - tests/test-connection.yaml
+tests:
+  - it: renders the helm test connection pod
+    release:
+      name: iceberg-rest
+      namespace: iceberg-system
+    set:
+      service:
+        name: custom-iceberg-rest
+        port: 19001
+    asserts:
+      - isKind:
+          of: Pod
+      - equal:
+          path: metadata.name
+          value: iceberg-rest-gravitino-iceberg-rest-server-helm-test-connection
+      - equal:
+          path: metadata.namespace
+          value: iceberg-system
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: test
+      - contains:
+          path: spec.containers[0].env
+          content:
+            name: SERVICE_NAME
+            value: custom-iceberg-rest
+          any: true
+      - contains:
+          path: spec.containers[0].env
+          content:
+            name: SERVICE_PORT
+            value: "19001"
+          any: true
+      - matchRegex:
+          path: spec.containers[0].command[2]
+          pattern: "/iceberg/v1/config"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds Helm unit tests for the Gravitino Iceberg REST Server chart under `dev/charts/gravitino-iceberg-rest-server/tests`.

It also wires the chart unit tests into the chart test workflow and fixes the `extraExposePorts` rendering in the Iceberg REST Server Service template.

### Why are the changes needed?

The Gravitino Iceberg REST Server Helm chart currently relies mainly on chart linting and install tests. These checks verify broad deployability, but they do not provide focused unit coverage for important rendered resources and values-driven branches.

This is a follow-up to #11091.

Fix: #11090

### Does this PR introduce _any_ user-facing change?

No user-facing behavior change is introduced.

### How was this patch tested?

The following commands were run:

```bash
helm unittest --with-subchart=false dev/charts/gravitino-iceberg-rest-server
helm lint dev/charts/gravitino-iceberg-rest-server