### PR TITLE
[#11090] test(helm): add unit and integration tests for Gravitino Lance REST Server

### DIFF
--- a/.github/workflows/chart-test.yaml
+++ b/.github/workflows/chart-test.yaml
@@ -66,6 +66,10 @@ jobs:
         if: steps.list-changed.outputs.changed == 'true'
         run: helm unittest --with-subchart=false dev/charts/gravitino-iceberg-rest-server
 
+      - name: Unit test Gravitino Lance REST Server chart
+        if: steps.list-changed.outputs.changed == 'true'
+        run: helm unittest --with-subchart=false dev/charts/gravitino-lance-rest-server
+
       - name: Set up kind cluster
         if: steps.list-changed.outputs.changed == 'true'
         uses: container-tools/kind-action@v2

--- a/dev/charts/gravitino-lance-rest-server/templates/service.yaml
+++ b/dev/charts/gravitino-lance-rest-server/templates/service.yaml
@@ -21,14 +21,23 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Values.service.name }}
+  namespace: {{ include "gravitino-lance-rest-server.namespace" . }}
   labels:
     {{- include "gravitino-lance-rest-server.labels" . | nindent 4 }}
+    {{- with .Values.service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- toYaml .Values.service.annotations | nindent 4 }}
 spec:
   type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.port }}
-      targetPort: http
+      targetPort: {{ .Values.service.targetPort }}
       protocol: TCP
-      name: http
+      name: {{ .Values.service.portName }}
+      {{- if and (eq .Values.service.type "NodePort") (.Values.service.nodePort) }}
+      nodePort: {{ .Values.service.nodePort }}
+      {{- end }}
   selector:
     {{- include "gravitino-lance-rest-server.selectorLabels" . | nindent 4 }}

--- a/dev/charts/gravitino-lance-rest-server/tests/configmap_test.yaml
+++ b/dev/charts/gravitino-lance-rest-server/tests/configmap_test.yaml
@@ -1,0 +1,137 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+suite: test gravitino lance rest server configmap
+templates:
+  - configmap.yaml
+tests:
+  - it: fails when Gravitino metalake is missing for the default backend
+    asserts:
+      - failedTemplate:
+          errorMessage: "lanceRest.gravitinoMetalake must be set when namespaceBackend is gravitino"
+
+  - it: renders default config files
+    release:
+      name: lance-rest
+      namespace: lance-system
+    set:
+      lanceRest:
+        gravitinoMetalake: lrs_test
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: metadata.name
+          value: lance-rest-gravitino-lance-rest-server-helm
+      - equal:
+          path: metadata.namespace
+          value: lance-system
+      - exists:
+          path: data["init.sh"]
+      - exists:
+          path: data["gravitino-lance-rest-server.conf"]
+      - exists:
+          path: data["gravitino-lance-rest-log4j2.properties"]
+      - matchRegex:
+          path: data["init.sh"]
+          pattern: "start-lance-rest-server\\.sh"
+      - matchRegex:
+          path: data["gravitino-lance-rest-server.conf"]
+          pattern: "gravitino\\.lance-rest\\.httpPort = 9101"
+      - matchRegex:
+          path: data["gravitino-lance-rest-server.conf"]
+          pattern: "gravitino\\.lance-rest\\.namespace-backend = gravitino"
+      - matchRegex:
+          path: data["gravitino-lance-rest-server.conf"]
+          pattern: "gravitino\\.lance-rest\\.gravitino-uri = http://gravitino-server:8090"
+      - matchRegex:
+          path: data["gravitino-lance-rest-server.conf"]
+          pattern: "gravitino\\.lance-rest\\.gravitino-metalake = lrs_test"
+      - matchRegex:
+          path: data["gravitino-lance-rest-log4j2.properties"]
+          pattern: "rootLogger\\.level = info"
+      - matchRegex:
+          path: data["gravitino-lance-rest-log4j2.properties"]
+          pattern: "appender\\.console\\.type = Console"
+
+  - it: renders customized Lance REST and log4j configuration
+    release:
+      name: custom-lance-rest
+    set:
+      lanceRest:
+        shutdownTimeout: 6000
+        host: 127.0.0.1
+        httpPort: 19101
+        minThreads: 12
+        maxThreads: 120
+        stopTimeout: 45000
+        idleTimeout: 45000
+        threadPoolWorkQueueSize: 64
+        requestHeaderSize: 65536
+        responseHeaderSize: 65536
+        namespaceBackend: gravitino
+        gravitinoUri: http://gravitino.test:8090
+        gravitinoMetalake: lrs_custom
+      additionalConfigItems:
+        gravitino.lance-rest.custom.setting: "{{ .Release.Name }}"
+      log4j2Properties:
+        status: error
+        rootLoggerLevel: debug
+      additionalLog4j2Properties:
+        logger.custom.name: org.apache.gravitino.Custom
+    asserts:
+      - matchRegex:
+          path: data["gravitino-lance-rest-server.conf"]
+          pattern: "gravitino\\.lance-rest\\.shutdown\\.timeout = 6000"
+      - matchRegex:
+          path: data["gravitino-lance-rest-server.conf"]
+          pattern: "gravitino\\.lance-rest\\.host = 127\\.0\\.0\\.1"
+      - matchRegex:
+          path: data["gravitino-lance-rest-server.conf"]
+          pattern: "gravitino\\.lance-rest\\.httpPort = 19101"
+      - matchRegex:
+          path: data["gravitino-lance-rest-server.conf"]
+          pattern: "gravitino\\.lance-rest\\.gravitino-uri = http://gravitino\\.test:8090"
+      - matchRegex:
+          path: data["gravitino-lance-rest-server.conf"]
+          pattern: "gravitino\\.lance-rest\\.gravitino-metalake = lrs_custom"
+      - matchRegex:
+          path: data["gravitino-lance-rest-server.conf"]
+          pattern: "gravitino\\.lance-rest\\.custom\\.setting = custom-lance-rest"
+      - matchRegex:
+          path: data["gravitino-lance-rest-log4j2.properties"]
+          pattern: "status = error"
+      - matchRegex:
+          path: data["gravitino-lance-rest-log4j2.properties"]
+          pattern: "rootLogger\\.level = debug"
+      - matchRegex:
+          path: data["gravitino-lance-rest-log4j2.properties"]
+          pattern: "logger\\.custom\\.name = org\\.apache\\.gravitino\\.Custom"
+
+  - it: skips Gravitino metalake when the backend is not gravitino
+    set:
+      lanceRest:
+        namespaceBackend: memory
+    asserts:
+      - matchRegex:
+          path: data["gravitino-lance-rest-server.conf"]
+          pattern: "gravitino\\.lance-rest\\.namespace-backend = memory"
+      - notMatchRegex:
+          path: data["gravitino-lance-rest-server.conf"]
+          pattern: "gravitino\\.lance-rest\\.gravitino-metalake ="

--- a/dev/charts/gravitino-lance-rest-server/tests/deployment_test.yaml
+++ b/dev/charts/gravitino-lance-rest-server/tests/deployment_test.yaml
@@ -1,0 +1,246 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+suite: test gravitino lance rest server deployment
+templates:
+  - deployment.yaml
+  - configmap.yaml
+tests:
+  - it: renders the default deployment
+    template: deployment.yaml
+    release:
+      name: lance-rest
+    set:
+      lanceRest:
+        gravitinoMetalake: lrs_test
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: metadata.name
+          value: lance-rest-gravitino-lance-rest-server-helm
+      - equal:
+          path: spec.replicas
+          value: 1
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/instance"]
+          value: lance-rest
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: default
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: apache/gravitino-lance-rest:1.3.0-SNAPSHOT
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GRAVITINO_HOME
+            value: /opt/gravitino-lance-rest-server
+          any: true
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SKIP_CONFIG_REWRITE
+            value: "true"
+          any: true
+      - contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            name: http
+            containerPort: 9101
+            protocol: TCP
+          any: true
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.path
+          value: /lance/v1/namespace/%24/list
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /lance/v1/namespace/%24/list
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: lance-rest-server-config
+            configMap:
+              name: lance-rest-gravitino-lance-rest-server-helm
+          any: true
+
+  - it: renders pod customization, templated env, and scheduling options
+    template: deployment.yaml
+    release:
+      name: custom-lance-rest
+    set:
+      replicaCount: 3
+      lanceRest:
+        gravitinoMetalake: lrs_custom
+      image:
+        repository: registry.example.com/gravitino-lance-rest
+        tag: test-tag
+        pullPolicy: Always
+      imagePullSecrets:
+        - name: registry-secret
+      serviceAccount:
+        create: true
+        name: lance-rest-sa
+      podLabels:
+        app.kubernetes.io/part-of: gravitino
+      podAnnotations:
+        prometheus.io/scrape: "true"
+      envWithTpl:
+        - name: RELEASE_NAME
+          value: "{{ .Release.Name }}"
+      envFrom:
+        - configMapRef:
+            name: lance-rest-env
+      nodeSelector:
+        kubernetes.io/os: linux
+      tolerations:
+        - key: dedicated
+          operator: Equal
+          value: metadata
+          effect: NoSchedule
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/arch
+                    operator: In
+                    values:
+                      - amd64
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 3
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: lance-rest-sa
+      - contains:
+          path: spec.template.spec.imagePullSecrets
+          content:
+            name: registry-secret
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: registry.example.com/gravitino-lance-rest:test-tag
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: Always
+      - equal:
+          path: spec.template.metadata.labels["app.kubernetes.io/part-of"]
+          value: gravitino
+      - equal:
+          path: spec.template.metadata.annotations["prometheus.io/scrape"]
+          value: "true"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: RELEASE_NAME
+            value: custom-lance-rest
+          any: true
+      - contains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+            configMapRef:
+              name: lance-rest-env
+      - equal:
+          path: spec.template.spec.nodeSelector["kubernetes.io/os"]
+          value: linux
+      - contains:
+          path: spec.template.spec.tolerations
+          content:
+            key: dedicated
+            operator: Equal
+            value: metadata
+            effect: NoSchedule
+          any: true
+      - equal:
+          path: spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key
+          value: kubernetes.io/arch
+
+  - it: renders security contexts, resources, volumes, and custom probes
+    template: deployment.yaml
+    set:
+      lanceRest:
+        gravitinoMetalake: lrs_test
+      podSecurityContext:
+        fsGroup: 1000
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 2000
+        capabilities:
+          drop:
+            - ALL
+      resources:
+        requests:
+          cpu: 500m
+          memory: 1Gi
+        limits:
+          cpu: "2"
+          memory: 2Gi
+      livenessProbe:
+        httpGet:
+          path: /custom/live
+          port: http
+        initialDelaySeconds: 30
+        timeoutSeconds: 3
+      readinessProbe:
+        httpGet:
+          path: /custom/ready
+          port: http
+        initialDelaySeconds: 10
+        timeoutSeconds: 2
+      volumes:
+        - name: lance-data
+          emptyDir: {}
+      volumeMounts:
+        - name: lance-data
+          mountPath: /var/lib/lance
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.fsGroup
+          value: 1000
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsUser
+          value: 2000
+      - contains:
+          path: spec.template.spec.containers[0].securityContext.capabilities.drop
+          content: ALL
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.memory
+          value: 1Gi
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.cpu
+          value: "2"
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.path
+          value: /custom/live
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /custom/ready
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: lance-data
+            emptyDir: {}
+          any: true
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: lance-data
+            mountPath: /var/lib/lance
+          any: true

--- a/dev/charts/gravitino-lance-rest-server/tests/ingress_test.yaml
+++ b/dev/charts/gravitino-lance-rest-server/tests/ingress_test.yaml
@@ -1,0 +1,84 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+suite: test gravitino lance rest server ingress
+templates:
+  - ingress.yaml
+tests:
+  - it: does not render ingress by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders networking v1 ingress for supported Kubernetes versions
+    release:
+      name: lance-rest
+    capabilities:
+      majorVersion: 1
+      minorVersion: 29
+    set:
+      ingress:
+        enabled: true
+        className: nginx
+        annotations:
+          nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+        hosts:
+          - host: lance-rest.example.com
+            paths:
+              - path: /lance
+                pathType: Prefix
+        tls:
+          - secretName: lance-rest-tls
+            hosts:
+              - lance-rest.example.com
+    asserts:
+      - isAPIVersion:
+          of: networking.k8s.io/v1
+      - isKind:
+          of: Ingress
+      - equal:
+          path: metadata.name
+          value: lance-rest-gravitino-lance-rest-server-helm
+      - equal:
+          path: metadata.annotations["nginx.ingress.kubernetes.io/proxy-read-timeout"]
+          value: "3600"
+      - equal:
+          path: spec.ingressClassName
+          value: nginx
+      - equal:
+          path: spec.rules[0].host
+          value: lance-rest.example.com
+      - equal:
+          path: spec.rules[0].http.paths[0].path
+          value: /lance
+      - equal:
+          path: spec.rules[0].http.paths[0].pathType
+          value: Prefix
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.name
+          value: lance-rest-gravitino-lance-rest-server-helm
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.port.number
+          value: 9101
+      - equal:
+          path: spec.tls[0].secretName
+          value: lance-rest-tls
+      - contains:
+          path: spec.tls[0].hosts
+          content: lance-rest.example.com

--- a/dev/charts/gravitino-lance-rest-server/tests/poddisruptionbudget_test.yaml
+++ b/dev/charts/gravitino-lance-rest-server/tests/poddisruptionbudget_test.yaml
@@ -1,0 +1,111 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+suite: test gravitino lance rest server pod disruption budget
+templates:
+  - poddisruptionbudget.yaml
+tests:
+  - it: does not render a PodDisruptionBudget by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders minAvailable when enabled
+    set:
+      podDisruptionBudget:
+        enabled: true
+        minAvailable: 1
+    asserts:
+      - isKind:
+          of: PodDisruptionBudget
+      - equal:
+          path: spec.minAvailable
+          value: 1
+      - notExists:
+          path: spec.maxUnavailable
+
+  - it: renders maxUnavailable when minAvailable is empty
+    set:
+      podDisruptionBudget:
+        enabled: true
+        minAvailable: ""
+        maxUnavailable: 1
+    asserts:
+      - isKind:
+          of: PodDisruptionBudget
+      - equal:
+          path: spec.maxUnavailable
+          value: 1
+      - notExists:
+          path: spec.minAvailable
+
+  - it: renders a percentage minAvailable value
+    set:
+      podDisruptionBudget:
+        enabled: true
+        minAvailable: "50%"
+    asserts:
+      - isKind:
+          of: PodDisruptionBudget
+      - equal:
+          path: spec.minAvailable
+          value: "50%"
+      - notExists:
+          path: spec.maxUnavailable
+
+  - it: renders a percentage maxUnavailable value
+    set:
+      podDisruptionBudget:
+        enabled: true
+        minAvailable: ""
+        maxUnavailable: "25%"
+    asserts:
+      - isKind:
+          of: PodDisruptionBudget
+      - equal:
+          path: spec.maxUnavailable
+          value: "25%"
+      - notExists:
+          path: spec.minAvailable
+
+  - it: renders labels and annotations
+    set:
+      podDisruptionBudget:
+        enabled: true
+        labels:
+          exposure: protected
+        annotations:
+          policy.example.com/enabled: "true"
+    asserts:
+      - equal:
+          path: metadata.labels.exposure
+          value: protected
+      - equal:
+          path: metadata.annotations["policy.example.com/enabled"]
+          value: "true"
+
+  - it: fails when minAvailable and maxUnavailable are both specified
+    set:
+      podDisruptionBudget:
+        enabled: true
+        minAvailable: 1
+        maxUnavailable: 1
+    asserts:
+      - failedTemplate:
+          errorMessage: "podDisruptionBudget.minAvailable and podDisruptionBudget.maxUnavailable cannot both be specified. Please specify only one."

--- a/dev/charts/gravitino-lance-rest-server/tests/service_test.yaml
+++ b/dev/charts/gravitino-lance-rest-server/tests/service_test.yaml
@@ -1,0 +1,89 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+suite: test gravitino lance rest server service
+templates:
+  - service.yaml
+tests:
+  - it: renders the default ClusterIP service
+    release:
+      name: lance-rest
+      namespace: lance-system
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: metadata.name
+          value: gravitino-lance-rest-server
+      - equal:
+          path: metadata.namespace
+          value: lance-system
+      - equal:
+          path: spec.type
+          value: ClusterIP
+      - contains:
+          path: spec.ports
+          content:
+            name: http
+            port: 9101
+            protocol: TCP
+            targetPort: 9101
+          any: true
+      - equal:
+          path: spec.selector["app.kubernetes.io/instance"]
+          value: lance-rest
+
+  - it: renders NodePort when requested
+    set:
+      service:
+        type: NodePort
+        nodePort: 30101
+    asserts:
+      - equal:
+          path: spec.type
+          value: NodePort
+      - equal:
+          path: spec.ports[0].nodePort
+          value: 30101
+
+  - it: renders service customization
+    set:
+      service:
+        port: 19101
+        targetPort: 19102
+        portName: lance
+        labels:
+          exposure: public
+        annotations:
+          service.beta.kubernetes.io/aws-load-balancer-type: nlb
+    asserts:
+      - contains:
+          path: spec.ports
+          content:
+            name: lance
+            port: 19101
+            protocol: TCP
+            targetPort: 19102
+          any: true
+      - equal:
+          path: metadata.labels.exposure
+          value: public
+      - equal:
+          path: metadata.annotations["service.beta.kubernetes.io/aws-load-balancer-type"]
+          value: nlb

--- a/dev/charts/gravitino-lance-rest-server/tests/serviceaccount_test.yaml
+++ b/dev/charts/gravitino-lance-rest-server/tests/serviceaccount_test.yaml
@@ -1,0 +1,59 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+suite: test gravitino lance rest server service account
+templates:
+  - serviceaccount.yaml
+tests:
+  - it: does not render a service account by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders a generated service account when requested
+    release:
+      name: lance-rest
+    set:
+      serviceAccount:
+        create: true
+        automount: false
+        annotations:
+          iam.amazonaws.com/role: lance-rest-role
+    asserts:
+      - isKind:
+          of: ServiceAccount
+      - equal:
+          path: metadata.name
+          value: lance-rest-gravitino-lance-rest-server-helm
+      - equal:
+          path: automountServiceAccountToken
+          value: false
+      - equal:
+          path: metadata.annotations["iam.amazonaws.com/role"]
+          value: lance-rest-role
+
+  - it: renders a named service account when requested
+    set:
+      serviceAccount:
+        create: true
+        name: lance-rest-sa
+    asserts:
+      - equal:
+          path: metadata.name
+          value: lance-rest-sa

--- a/dev/charts/gravitino-lance-rest-server/tests/test_connection_test.yaml
+++ b/dev/charts/gravitino-lance-rest-server/tests/test_connection_test.yaml
@@ -1,0 +1,61 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+suite: test gravitino lance rest server test connection hook
+templates:
+  - tests/test-connection.yaml
+tests:
+  - it: renders the helm test connection pod
+    release:
+      name: lance-rest
+      namespace: lance-system
+    set:
+      service:
+        name: custom-lance-rest
+        port: 19101
+    asserts:
+      - isKind:
+          of: Pod
+      - equal:
+          path: metadata.name
+          value: lance-rest-gravitino-lance-rest-server-helm-test-connection
+      - equal:
+          path: metadata.namespace
+          value: lance-system
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: test
+      - contains:
+          path: spec.containers[0].env
+          content:
+            name: SERVICE_NAME
+            value: custom-lance-rest
+          any: true
+      - contains:
+          path: spec.containers[0].env
+          content:
+            name: SERVICE_PORT
+            value: "19101"
+          any: true
+      - contains:
+          path: spec.containers[0].env
+          content:
+            name: TEST_PATH
+            value: /lance/v1/namespace/%24/list
+          any: true


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds Helm unit tests for the Gravitino Lance REST Server chart under `dev/charts/gravitino-lance-rest-server/tests`.

It also wires the chart unit tests into the chart test workflow and updates the Lance REST Server Service template to honor existing service values such as namespace, labels, annotations, targetPort, portName, and nodePort.

### Why are the changes needed?

The Gravitino Lance REST Server Helm chart currently relies mainly on chart linting and install tests. These checks verify broad deployability, but they do not provide focused unit coverage for important rendered resources and values-driven branches.

This is a follow-up to #11091.

Fix: N/A

### Does this PR introduce _any_ user-facing change?

No user-facing behavior change is introduced.

### How was this patch tested?

The following commands were run:

```bash
helm unittest --with-subchart=false dev/charts/gravitino-lance-rest-server
helm lint dev/charts/gravitino-lance-rest-server