### PR TITLE
[#11232][#11233] improvement(core): Global EntityChangeLogPoller with CatalogManager cache invalidation and automatic retention cleanup

### DIFF
--- a/core/src/main/java/org/apache/gravitino/Configs.java
+++ b/core/src/main/java/org/apache/gravitino/Configs.java
@@ -184,6 +184,34 @@ public class Configs {
           .longConf()
           .createWithDefault(60 * 60 * 1000L);
 
+  public static final long DEFAULT_ENTITY_CHANGE_LOG_POLL_INTERVAL_SECS = 3L;
+  public static final long DEFAULT_ENTITY_CHANGE_LOG_RETENTION_SECS = 24 * 60 * 60L;
+  public static final long DEFAULT_ENTITY_CHANGE_LOG_CLEANUP_INTERVAL_SECS = 60 * 60L;
+
+  public static final ConfigEntry<Long> ENTITY_CHANGE_LOG_POLL_INTERVAL_SECS =
+      new ConfigBuilder("gravitino.entityChangeLog.pollIntervalSecs")
+          .doc("The interval in seconds for polling entity change logs")
+          .version(ConfigConstants.VERSION_1_3_0)
+          .longConf()
+          .checkValue(value -> value > 0, ConfigConstants.POSITIVE_NUMBER_ERROR_MSG)
+          .createWithDefault(DEFAULT_ENTITY_CHANGE_LOG_POLL_INTERVAL_SECS);
+
+  public static final ConfigEntry<Long> ENTITY_CHANGE_LOG_RETENTION_SECS =
+      new ConfigBuilder("gravitino.entityChangeLog.retentionSecs")
+          .doc("The retention time in seconds for entity change logs. Set 0 to disable cleanup")
+          .version(ConfigConstants.VERSION_1_3_0)
+          .longConf()
+          .checkValue(value -> value >= 0, ConfigConstants.NON_NEGATIVE_NUMBER_ERROR_MSG)
+          .createWithDefault(DEFAULT_ENTITY_CHANGE_LOG_RETENTION_SECS);
+
+  public static final ConfigEntry<Long> ENTITY_CHANGE_LOG_CLEANUP_INTERVAL_SECS =
+      new ConfigBuilder("gravitino.entityChangeLog.cleanupIntervalSecs")
+          .doc("The interval in seconds for pruning expired entity change logs")
+          .version(ConfigConstants.VERSION_1_3_0)
+          .longConf()
+          .checkValue(value -> value > 0, ConfigConstants.POSITIVE_NUMBER_ERROR_MSG)
+          .createWithDefault(DEFAULT_ENTITY_CHANGE_LOG_CLEANUP_INTERVAL_SECS);
+
   public static final ConfigEntry<Boolean> CATALOG_LOAD_ISOLATED =
       new ConfigBuilder("gravitino.catalog.classloader.isolated")
           .doc("Whether to load the catalog in an isolated classloader")

--- a/core/src/main/java/org/apache/gravitino/GravitinoEnv.java
+++ b/core/src/main/java/org/apache/gravitino/GravitinoEnv.java
@@ -19,6 +19,8 @@
 package org.apache.gravitino;
 
 import com.google.common.base.Preconditions;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
 import org.apache.gravitino.audit.AuditLogManager;
 import org.apache.gravitino.authorization.AccessControlDispatcher;
 import org.apache.gravitino.authorization.AccessControlManager;
@@ -28,6 +30,7 @@ import org.apache.gravitino.authorization.OwnerDispatcher;
 import org.apache.gravitino.authorization.OwnerEventManager;
 import org.apache.gravitino.authorization.OwnerManager;
 import org.apache.gravitino.auxiliary.AuxiliaryServiceManager;
+import org.apache.gravitino.catalog.CatalogChangeLogListener;
 import org.apache.gravitino.catalog.CatalogDispatcher;
 import org.apache.gravitino.catalog.CatalogManager;
 import org.apache.gravitino.catalog.CatalogNormalizeDispatcher;
@@ -101,6 +104,8 @@ import org.apache.gravitino.stats.StatisticDispatcher;
 import org.apache.gravitino.stats.StatisticManager;
 import org.apache.gravitino.storage.IdGenerator;
 import org.apache.gravitino.storage.RandomIdGenerator;
+import org.apache.gravitino.storage.relational.EntityChangeLogPoller;
+import org.apache.gravitino.storage.relational.RelationalEntityStore;
 import org.apache.gravitino.tag.TagDispatcher;
 import org.apache.gravitino.tag.TagManager;
 import org.slf4j.Logger;
@@ -118,6 +123,9 @@ public class GravitinoEnv {
   private boolean manageFullComponents = true;
 
   private EntityStore entityStore;
+
+  private EntityChangeLogPoller entityChangeLogPoller;
+  private CatalogChangeLogListener catalogChangeLogListener;
 
   private CatalogDispatcher catalogDispatcher;
 
@@ -437,6 +445,16 @@ public class GravitinoEnv {
   }
 
   /**
+   * Get the global entity change log poller if the current entity store supports it.
+   *
+   * @return the global entity change log poller, or null when it is not available
+   */
+  @Nullable
+  public EntityChangeLogPoller entityChangeLogPoller() {
+    return entityChangeLogPoller;
+  }
+
+  /**
    * Get The GravitinoAuthorizer
    *
    * @return the GravitinoAuthorizer instance
@@ -466,6 +484,9 @@ public class GravitinoEnv {
   public void start() {
     metricsSystem.start();
     eventListenerManager.start();
+    if (entityChangeLogPoller != null) {
+      entityChangeLogPoller.start();
+    }
     if (manageFullComponents) {
       auxServiceManager.serviceStart();
     }
@@ -474,6 +495,17 @@ public class GravitinoEnv {
   /** Shutdown the Gravitino environment. */
   public void shutdown() {
     LOG.info("Shutting down Gravitino Environment...");
+
+    if (entityChangeLogPoller != null) {
+      if (catalogChangeLogListener != null) {
+        entityChangeLogPoller.unregisterListener(catalogChangeLogListener);
+      }
+      try {
+        entityChangeLogPoller.close();
+      } catch (Exception e) {
+        LOG.warn("Failed to close EntityChangeLogPoller.", e);
+      }
+    }
 
     if (entityStore != null) {
       try {
@@ -565,6 +597,18 @@ public class GravitinoEnv {
     // CatalogHookDispatcher -> CatalogEventDispatcher -> CatalogNormalizeDispatcher ->
     // CatalogManager
     this.catalogManager = new CatalogManager(config, entityStore, idGenerator);
+    this.entityChangeLogPoller = null;
+    this.catalogChangeLogListener = null;
+    if (entityStore instanceof RelationalEntityStore) {
+      this.entityChangeLogPoller =
+          new EntityChangeLogPoller(
+              config.get(Configs.ENTITY_CHANGE_LOG_POLL_INTERVAL_SECS),
+              TimeUnit.SECONDS.toMillis(config.get(Configs.ENTITY_CHANGE_LOG_RETENTION_SECS)),
+              TimeUnit.SECONDS.toMillis(
+                  config.get(Configs.ENTITY_CHANGE_LOG_CLEANUP_INTERVAL_SECS)));
+      this.catalogChangeLogListener = new CatalogChangeLogListener(catalogManager);
+      this.entityChangeLogPoller.registerListener(catalogChangeLogListener);
+    }
     CatalogNormalizeDispatcher catalogNormalizeDispatcher =
         new CatalogNormalizeDispatcher(catalogManager);
     CatalogEventDispatcher catalogEventDispatcher =

--- a/core/src/main/java/org/apache/gravitino/catalog/CatalogChangeLogListener.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/CatalogChangeLogListener.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog;
+
+import java.util.List;
+import java.util.Locale;
+import org.apache.gravitino.Entity.EntityType;
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.storage.relational.EntityChangeLogListener;
+import org.apache.gravitino.storage.relational.po.cache.EntityChangeRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Invalidates {@link CatalogManager}'s local catalog cache from {@code entity_change_log}. */
+public class CatalogChangeLogListener implements EntityChangeLogListener {
+
+  private static final Logger LOG = LoggerFactory.getLogger(CatalogChangeLogListener.class);
+
+  private final CatalogManager catalogManager;
+
+  /**
+   * Creates a listener for a catalog manager.
+   *
+   * @param catalogManager the catalog manager whose local cache should be invalidated
+   */
+  public CatalogChangeLogListener(CatalogManager catalogManager) {
+    this.catalogManager = catalogManager;
+  }
+
+  @Override
+  public void onEntityChange(List<EntityChangeRecord> changes) {
+    for (EntityChangeRecord change : changes) {
+      if (!EntityType.CATALOG.name().equals(change.getEntityType().toUpperCase(Locale.ROOT))) {
+        continue;
+      }
+
+      NameIdentifier ident = catalogIdentifier(change);
+      if (ident == null) {
+        continue;
+      }
+
+      LOG.debug("Invalidating catalog cache due to entity change log: {}", ident);
+      catalogManager.getCatalogCache().invalidate(ident);
+    }
+  }
+
+  private NameIdentifier catalogIdentifier(EntityChangeRecord change) {
+    String[] names = change.getFullName().split("\\.");
+    if (names.length != 2) {
+      LOG.warn("Invalid catalog full name in entity change log: {}", change.getFullName());
+      return null;
+    }
+    return NameIdentifier.of(names[0], names[1]);
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/storage/relational/EntityChangeLogListener.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/EntityChangeLogListener.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.storage.relational;
+
+import java.util.List;
+import org.apache.gravitino.storage.relational.po.cache.EntityChangeRecord;
+
+/** Listener for batches consumed from {@code entity_change_log}. */
+@FunctionalInterface
+public interface EntityChangeLogListener {
+
+  /**
+   * Handles a batch of entity changes.
+   *
+   * @param changes the entity changes fetched in one poller cycle
+   */
+  void onEntityChange(List<EntityChangeRecord> changes);
+}

--- a/core/src/main/java/org/apache/gravitino/storage/relational/EntityChangeLogPoller.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/EntityChangeLogPoller.java
@@ -1,0 +1,208 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.storage.relational;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.function.LongSupplier;
+import org.apache.gravitino.storage.relational.mapper.EntityChangeLogMapper;
+import org.apache.gravitino.storage.relational.po.cache.EntityChangeRecord;
+import org.apache.gravitino.storage.relational.utils.SessionUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Global poller for {@code entity_change_log}.
+ *
+ * <p>The poller owns the single high-water mark for a Gravitino server process and dispatches each
+ * consumed batch to registered listeners. Listeners should only perform idempotent local cache
+ * invalidation. The cursor always advances after dispatch regardless of individual listener
+ * failures, so a faulty listener cannot block other listeners or prevent pruning.
+ */
+public class EntityChangeLogPoller implements AutoCloseable {
+
+  private static final Logger LOG = LoggerFactory.getLogger(EntityChangeLogPoller.class);
+
+  /** Max entity-change rows to fetch per poller cycle. */
+  private static final int ENTITY_CHANGE_POLLER_MAX_ROWS = 500;
+
+  private final List<EntityChangeLogListener> listeners = new CopyOnWriteArrayList<>();
+  private final long pollIntervalSecs;
+  private final long retentionMs;
+  private final long cleanupIntervalMs;
+  private final LongSupplier clockMs;
+
+  private ScheduledExecutorService scheduler;
+  private volatile long entityPollHighWaterId = 0;
+  private volatile long lastCleanupMs = Long.MIN_VALUE;
+
+  /**
+   * Creates an {@link EntityChangeLogPoller}.
+   *
+   * @param pollIntervalSecs interval between successive polling cycles
+   */
+  public EntityChangeLogPoller(long pollIntervalSecs) {
+    this(
+        pollIntervalSecs,
+        TimeUnit.DAYS.toMillis(1),
+        TimeUnit.HOURS.toMillis(1),
+        System::currentTimeMillis);
+  }
+
+  /**
+   * Creates an {@link EntityChangeLogPoller}.
+   *
+   * @param pollIntervalSecs interval between successive polling cycles
+   * @param retentionMs entity change retention in milliseconds, or 0 to disable cleanup
+   * @param cleanupIntervalMs interval between successive cleanup attempts in milliseconds
+   */
+  public EntityChangeLogPoller(long pollIntervalSecs, long retentionMs, long cleanupIntervalMs) {
+    this(pollIntervalSecs, retentionMs, cleanupIntervalMs, System::currentTimeMillis);
+  }
+
+  @VisibleForTesting
+  EntityChangeLogPoller(
+      long pollIntervalSecs, long retentionMs, long cleanupIntervalMs, LongSupplier clockMs) {
+    Preconditions.checkArgument(pollIntervalSecs > 0, "pollIntervalSecs must be positive");
+    Preconditions.checkArgument(retentionMs >= 0, "retentionMs must be non-negative");
+    Preconditions.checkArgument(cleanupIntervalMs > 0, "cleanupIntervalMs must be positive");
+    this.pollIntervalSecs = pollIntervalSecs;
+    this.retentionMs = retentionMs;
+    this.cleanupIntervalMs = cleanupIntervalMs;
+    this.clockMs = clockMs;
+  }
+
+  /**
+   * Registers a listener to receive future entity change batches.
+   *
+   * @param listener the listener to register
+   */
+  public void registerListener(EntityChangeLogListener listener) {
+    listeners.add(listener);
+  }
+
+  /**
+   * Unregisters a previously registered listener.
+   *
+   * @param listener the listener to unregister
+   */
+  public void unregisterListener(EntityChangeLogListener listener) {
+    listeners.remove(listener);
+  }
+
+  /**
+   * Initializes the high-water cursor to the current DB tail and schedules periodic polling.
+   *
+   * <p>Startup does not scan historical changes because this process has no warm local cache yet.
+   */
+  public void start() {
+    entityPollHighWaterId =
+        getOrDefault(
+            SessionUtils.getWithoutCommit(
+                EntityChangeLogMapper.class, EntityChangeLogMapper::selectMaxChangeId));
+
+    scheduler =
+        Executors.newSingleThreadScheduledExecutor(
+            r -> {
+              Thread t = new Thread(r);
+              t.setName("Gravitino-EntityChangeLogPoller");
+              t.setDaemon(true);
+              return t;
+            });
+    scheduler.scheduleWithFixedDelay(
+        this::pollChanges, pollIntervalSecs, pollIntervalSecs, TimeUnit.SECONDS);
+  }
+
+  @VisibleForTesting
+  synchronized void pollChanges() {
+    List<EntityChangeRecord> changes = fetchEntityChanges();
+    if (changes.isEmpty()) {
+      pruneExpiredChangesIfNeeded();
+      return;
+    }
+
+    long maxSeenId = entityPollHighWaterId;
+    for (EntityChangeRecord change : changes) {
+      if (change.getId() > maxSeenId) {
+        maxSeenId = change.getId();
+      }
+    }
+
+    for (EntityChangeLogListener listener : listeners) {
+      try {
+        listener.onEntityChange(changes);
+      } catch (Exception e) {
+        LOG.warn("Entity change listener {} failed", listener.getClass().getName(), e);
+      }
+    }
+
+    entityPollHighWaterId = maxSeenId;
+    pruneExpiredChangesIfNeeded();
+  }
+
+  private List<EntityChangeRecord> fetchEntityChanges() {
+    return SessionUtils.getWithoutCommit(
+        EntityChangeLogMapper.class,
+        m -> m.selectEntityChanges(entityPollHighWaterId, ENTITY_CHANGE_POLLER_MAX_ROWS));
+  }
+
+  private void pruneExpiredChangesIfNeeded() {
+    if (retentionMs <= 0) {
+      return;
+    }
+
+    long now = clockMs.getAsLong();
+    if (lastCleanupMs != Long.MIN_VALUE && now - lastCleanupMs < cleanupIntervalMs) {
+      return;
+    }
+
+    long before = now - retentionMs;
+    try {
+      SessionUtils.doWithoutCommit(
+          EntityChangeLogMapper.class, mapper -> mapper.pruneOldEntityChanges(before));
+      lastCleanupMs = now;
+    } catch (Exception e) {
+      LOG.warn("Failed to prune expired entity change logs before {}", before, e);
+    }
+  }
+
+  @Override
+  public void close() {
+    if (scheduler != null) {
+      scheduler.shutdown();
+      try {
+        if (!scheduler.awaitTermination(5, TimeUnit.SECONDS)) {
+          scheduler.shutdownNow();
+        }
+      } catch (InterruptedException e) {
+        scheduler.shutdownNow();
+        Thread.currentThread().interrupt();
+      }
+    }
+  }
+
+  private static long getOrDefault(Long value) {
+    return value == null ? 0L : value;
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/CatalogMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/CatalogMetaService.java
@@ -225,8 +225,6 @@ public class CatalogMetaService {
     String metalakeName = identifier.namespace().level(0);
     String oldFullName =
         NameIdentifierUtil.ofCatalog(metalakeName, oldCatalogEntity.name()).toString();
-    String newFullName = NameIdentifierUtil.ofCatalog(metalakeName, newEntity.name()).toString();
-    boolean isRenamed = !Objects.equals(oldFullName, newFullName);
 
     AtomicInteger updateResult = new AtomicInteger(0);
     try {
@@ -241,7 +239,7 @@ public class CatalogMetaService {
                                   oldCatalogPO, newEntity, oldCatalogPO.getMetalakeId()),
                               oldCatalogPO))),
           () -> {
-            if (isRenamed && updateResult.get() > 0) {
+            if (updateResult.get() > 0) {
               SessionUtils.doWithoutCommit(
                   EntityChangeLogMapper.class,
                   mapper ->

--- a/core/src/test/java/org/apache/gravitino/catalog/TestCatalogManager.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestCatalogManager.java
@@ -35,6 +35,7 @@ import com.google.common.collect.Sets;
 import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -65,6 +66,8 @@ import org.apache.gravitino.meta.SchemaVersion;
 import org.apache.gravitino.storage.RandomIdGenerator;
 import org.apache.gravitino.storage.memory.TestMemoryEntityStore;
 import org.apache.gravitino.storage.memory.TestMemoryEntityStore.InMemoryEntityStore;
+import org.apache.gravitino.storage.relational.po.cache.EntityChangeRecord;
+import org.apache.gravitino.storage.relational.po.cache.OperateType;
 import org.apache.gravitino.utils.PrincipalUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
@@ -602,6 +605,33 @@ public class TestCatalogManager {
     Mockito.doCallRealMethod()
         .when(catalogManager)
         .createCatalogWrapper(any(CatalogEntity.class), eq(null));
+  }
+
+  @Test
+  void testCatalogChangeLogListenerInvalidatesCatalogCache() throws Exception {
+    NameIdentifier ident = NameIdentifier.of("metalake", "change_log_catalog");
+    Map<String, String> props =
+        ImmutableMap.of(
+            "provider",
+            "test",
+            PROPERTY_KEY1,
+            "value1",
+            PROPERTY_KEY2,
+            "value2",
+            PROPERTY_KEY5_PREFIX + "1",
+            "value3");
+
+    catalogManager.createCatalog(ident, Catalog.Type.RELATIONAL, provider, "comment", props);
+    Assertions.assertNotNull(catalogManager.loadCatalogAndWrap(ident));
+    Assertions.assertNotNull(catalogManager.getCatalogCache().getIfPresent(ident));
+
+    CatalogChangeLogListener listener = new CatalogChangeLogListener(catalogManager);
+    listener.onEntityChange(
+        List.of(
+            new EntityChangeRecord(
+                1L, "metalake", "CATALOG", "metalake.change_log_catalog", OperateType.ALTER, 0L)));
+
+    Assertions.assertNull(catalogManager.getCatalogCache().getIfPresent(ident));
   }
 
   @Test

--- a/core/src/test/java/org/apache/gravitino/storage/relational/TestEntityChangeLogPoller.java
+++ b/core/src/test/java/org/apache/gravitino/storage/relational/TestEntityChangeLogPoller.java
@@ -1,0 +1,190 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.storage.relational;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import org.apache.gravitino.storage.relational.mapper.EntityChangeLogMapper;
+import org.apache.gravitino.storage.relational.po.cache.EntityChangeRecord;
+import org.apache.gravitino.storage.relational.po.cache.OperateType;
+import org.apache.gravitino.storage.relational.utils.SessionUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+public class TestEntityChangeLogPoller {
+
+  @Test
+  void testRejectsNonPositivePollInterval() {
+    Assertions.assertThrows(IllegalArgumentException.class, () -> new EntityChangeLogPoller(0));
+    Assertions.assertThrows(IllegalArgumentException.class, () -> new EntityChangeLogPoller(-1));
+  }
+
+  @Test
+  void testPollChangesDispatchesSameBatchToAllListenersAndAdvancesCursor() {
+    EntityChangeLogMapper mapper = mock(EntityChangeLogMapper.class);
+    EntityChangeRecord first = change(1L, "CATALOG", "ml1.cat1");
+    EntityChangeRecord second = change(2L, "SCHEMA", "ml1.cat1.sch1");
+    when(mapper.selectEntityChanges(0L, 500)).thenReturn(List.of(first, second));
+    when(mapper.selectEntityChanges(2L, 500)).thenReturn(List.of());
+
+    List<EntityChangeRecord> firstListenerRecords = new ArrayList<>();
+    List<EntityChangeRecord> secondListenerRecords = new ArrayList<>();
+
+    try (MockedStatic<SessionUtils> sessionUtils = mockStatic(SessionUtils.class)) {
+      sessionUtils
+          .when(() -> SessionUtils.getWithoutCommit(any(), any()))
+          .thenAnswer(
+              invocation -> {
+                Function<Object, Object> func = invocation.getArgument(1);
+                return func.apply(mapper);
+              });
+
+      EntityChangeLogPoller poller = new EntityChangeLogPoller(1);
+      poller.registerListener(firstListenerRecords::addAll);
+      poller.registerListener(secondListenerRecords::addAll);
+
+      poller.pollChanges();
+      poller.pollChanges();
+    }
+
+    Assertions.assertEquals(List.of(first, second), firstListenerRecords);
+    Assertions.assertEquals(List.of(first, second), secondListenerRecords);
+  }
+
+  @Test
+  void testListenerFailureDoesNotBlockOtherListenersAndCursorStillAdvances() {
+    EntityChangeLogMapper mapper = mock(EntityChangeLogMapper.class);
+    EntityChangeRecord change = change(1L, "CATALOG", "ml1.cat1");
+    when(mapper.selectEntityChanges(0L, 500)).thenReturn(List.of(change));
+    when(mapper.selectEntityChanges(1L, 500)).thenReturn(List.of());
+
+    List<EntityChangeRecord> received = new ArrayList<>();
+
+    try (MockedStatic<SessionUtils> sessionUtils = mockStatic(SessionUtils.class)) {
+      sessionUtils
+          .when(() -> SessionUtils.getWithoutCommit(any(), any()))
+          .thenAnswer(
+              invocation -> {
+                Function<Object, Object> func = invocation.getArgument(1);
+                return func.apply(mapper);
+              });
+
+      EntityChangeLogPoller poller = new EntityChangeLogPoller(1);
+      poller.registerListener(
+          changes -> {
+            throw new RuntimeException("listener failed");
+          });
+      poller.registerListener(received::addAll);
+
+      poller.pollChanges();
+      poller.pollChanges();
+    }
+
+    Assertions.assertEquals(List.of(change), received);
+  }
+
+  @Test
+  void testPrunesExpiredChangesAfterCleanupInterval() {
+    EntityChangeLogMapper mapper = mock(EntityChangeLogMapper.class);
+    when(mapper.selectEntityChanges(0L, 500)).thenReturn(List.of());
+
+    try (MockedStatic<SessionUtils> sessionUtils = mockStatic(SessionUtils.class)) {
+      mockSessionUtils(sessionUtils, mapper);
+
+      EntityChangeLogPoller poller =
+          new EntityChangeLogPoller(
+              1, TimeUnit.DAYS.toMillis(1), TimeUnit.HOURS.toMillis(1), () -> 100_000_000L);
+
+      poller.pollChanges();
+    }
+
+    verify(mapper).pruneOldEntityChanges(100_000_000L - TimeUnit.DAYS.toMillis(1));
+  }
+
+  @Test
+  void testSkipsPruneBeforeCleanupInterval() {
+    EntityChangeLogMapper mapper = mock(EntityChangeLogMapper.class);
+    when(mapper.selectEntityChanges(0L, 500)).thenReturn(List.of());
+
+    try (MockedStatic<SessionUtils> sessionUtils = mockStatic(SessionUtils.class)) {
+      mockSessionUtils(sessionUtils, mapper);
+
+      EntityChangeLogPoller poller =
+          new EntityChangeLogPoller(
+              1, TimeUnit.DAYS.toMillis(1), TimeUnit.HOURS.toMillis(1), () -> 100_000_000L);
+
+      poller.pollChanges();
+      poller.pollChanges();
+    }
+
+    verify(mapper).pruneOldEntityChanges(100_000_000L - TimeUnit.DAYS.toMillis(1));
+  }
+
+  @Test
+  void testDisablesPruneWhenRetentionIsZero() {
+    EntityChangeLogMapper mapper = mock(EntityChangeLogMapper.class);
+    when(mapper.selectEntityChanges(0L, 500)).thenReturn(List.of());
+
+    try (MockedStatic<SessionUtils> sessionUtils = mockStatic(SessionUtils.class)) {
+      mockSessionUtils(sessionUtils, mapper);
+
+      EntityChangeLogPoller poller =
+          new EntityChangeLogPoller(1, 0L, TimeUnit.HOURS.toMillis(1), () -> 100_000_000L);
+
+      poller.pollChanges();
+    }
+
+    verify(mapper, never()).pruneOldEntityChanges(anyLong());
+  }
+
+  private static EntityChangeRecord change(long id, String type, String fullName) {
+    return new EntityChangeRecord(id, "ml1", type, fullName, OperateType.ALTER, 0L);
+  }
+
+  private static void mockSessionUtils(
+      MockedStatic<SessionUtils> sessionUtils, EntityChangeLogMapper mapper) {
+    sessionUtils
+        .when(() -> SessionUtils.getWithoutCommit(any(), any()))
+        .thenAnswer(
+            invocation -> {
+              Function<Object, Object> func = invocation.getArgument(1);
+              return func.apply(mapper);
+            });
+    sessionUtils
+        .when(() -> SessionUtils.doWithoutCommit(any(), any()))
+        .thenAnswer(
+            invocation -> {
+              Consumer<Object> consumer = invocation.getArgument(1);
+              consumer.accept(mapper);
+              return null;
+            });
+  }
+}

--- a/core/src/test/java/org/apache/gravitino/storage/relational/service/TestEntityChangeLogService.java
+++ b/core/src/test/java/org/apache/gravitino/storage/relational/service/TestEntityChangeLogService.java
@@ -21,6 +21,7 @@ package org.apache.gravitino.storage.relational.service;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import org.apache.gravitino.Catalog;
 import org.apache.gravitino.Entity;
 import org.apache.gravitino.Namespace;
 import org.apache.gravitino.meta.BaseMetalake;
@@ -109,14 +110,40 @@ public class TestEntityChangeLogService extends TestJDBCBackend {
     createAndInsertMakeLake(METALAKE_NAME);
 
     CatalogEntity catalog = createAndInsertCatalog(METALAKE_NAME, CATALOG_NAME);
-    long maxIdBeforeCatalogRename = maxEntityChangeId();
-    CatalogEntity renamedCatalog =
+    long maxIdBeforeCatalogAlter = maxEntityChangeId();
+    CatalogEntity alteredCatalog =
         backend.update(
             catalog.nameIdentifier(),
             Entity.EntityType.CATALOG,
             entity ->
+                CatalogEntity.builder()
+                    .withId(catalog.id())
+                    .withNamespace(catalog.namespace())
+                    .withName(CATALOG_NAME)
+                    .withType(Catalog.Type.RELATIONAL)
+                    .withProvider("test")
+                    .withComment("updated comment")
+                    .withProperties(null)
+                    .withAuditInfo(AUDIT_INFO)
+                    .build());
+    assertEntityChange(
+        maxIdBeforeCatalogAlter,
+        METALAKE_NAME,
+        Entity.EntityType.CATALOG,
+        NameIdentifierUtil.ofCatalog(METALAKE_NAME, CATALOG_NAME).toString(),
+        OperateType.ALTER);
+
+    long maxIdBeforeCatalogRename = maxEntityChangeId();
+    CatalogEntity renamedCatalog =
+        backend.update(
+            alteredCatalog.nameIdentifier(),
+            Entity.EntityType.CATALOG,
+            entity ->
                 createCatalog(
-                    catalog.id(), catalog.namespace(), CATALOG_NAME + "_renamed", AUDIT_INFO));
+                    alteredCatalog.id(),
+                    alteredCatalog.namespace(),
+                    CATALOG_NAME + "_renamed",
+                    AUDIT_INFO));
     assertEntityChange(
         maxIdBeforeCatalogRename,
         METALAKE_NAME,

--- a/server-common/src/main/java/org/apache/gravitino/server/authorization/jcasbin/JcasbinAuthorizationLookups.java
+++ b/server-common/src/main/java/org/apache/gravitino/server/authorization/jcasbin/JcasbinAuthorizationLookups.java
@@ -35,8 +35,8 @@ import org.apache.gravitino.storage.relational.utils.SessionUtils;
  * falls back to a shared {@link GravitinoCache} on a request miss, and finally issues a single DB
  * query on a cache miss. A successful DB fetch populates both tiers so subsequent calls — in this
  * request and later ones — hit the cache. The two underlying caches are invalidated externally by
- * {@link JcasbinChangePoller} (HA peers) and by the {@link
- * org.apache.gravitino.authorization.GravitinoAuthorizer#handleMetadataOwnerChange} / {@link
+ * the global entity change log poller, {@link JcasbinChangePoller} (owner changes), and by the
+ * {@link org.apache.gravitino.authorization.GravitinoAuthorizer#handleMetadataOwnerChange} / {@link
  * org.apache.gravitino.authorization.GravitinoAuthorizer#handleEntityNameIdMappingChange} hooks
  * (local mutations).
  */
@@ -103,15 +103,30 @@ public class JcasbinAuthorizationLookups {
       AuthorizationRequestContext requestContext) {
     return requestContext.computeOwnerIfAbsent(
         metadataId,
-        id ->
-            ownerRelCache.get(
-                id,
-                ignored -> {
-                  OwnerInfo ownerInfo =
-                      SessionUtils.getWithoutCommit(
-                          OwnerMetaMapper.class,
-                          m -> m.selectOwnerByMetadataObjectIdAndType(id, metadataType.name()));
-                  return ownerInfo == null ? Optional.empty() : Optional.of(ownerInfo);
-                }));
+        id -> {
+          try {
+            return ownerRelCache.get(id, ignored -> loadOwnerInfo(id, metadataType));
+          } catch (NoSuchOwnerInfoException e) {
+            return Optional.empty();
+          }
+        });
+  }
+
+  private static Optional<OwnerInfo> loadOwnerInfo(
+      Long metadataId, MetadataObject.Type metadataType) {
+    OwnerInfo ownerInfo =
+        SessionUtils.getWithoutCommit(
+            OwnerMetaMapper.class,
+            m -> m.selectOwnerByMetadataObjectIdAndType(metadataId, metadataType.name()));
+    if (ownerInfo == null) {
+      throw new NoSuchOwnerInfoException(metadataId);
+    }
+    return Optional.of(ownerInfo);
+  }
+
+  private static class NoSuchOwnerInfoException extends RuntimeException {
+    private NoSuchOwnerInfoException(Long metadataId) {
+      super(String.format("No owner info found for metadata object id %s", metadataId));
+    }
   }
 }

--- a/server-common/src/main/java/org/apache/gravitino/server/authorization/jcasbin/JcasbinAuthorizer.java
+++ b/server-common/src/main/java/org/apache/gravitino/server/authorization/jcasbin/JcasbinAuthorizer.java
@@ -95,11 +95,10 @@ import org.slf4j.LoggerFactory;
  *       correctness — TTL eviction only bounds memory. User/group role snapshots use write-based
  *       TTLs through {@link CaffeineGravitinoCache}; loaded role policies use access-based TTLs
  *       through {@link JcasbinLoadedRolesCache}.
- *   <li><b>Eventual-consistency caches</b> — {@link #metadataIdCache} and {@link #ownerRelCache}. A
- *       single background poller ({@link #changePoller}) drains {@code entity_change_log} and
- *       {@code owner_meta} change rows since a high-water-mark cursor and invalidates the affected
- *       keys. Other Gravitino nodes therefore observe ALTER/DROP and owner changes within one poll
- *       interval.
+ *   <li><b>Eventual-consistency caches</b> — {@link #metadataIdCache} and {@link #ownerRelCache}.
+ *       The global entity change log poller dispatches {@code entity_change_log} batches to {@link
+ *       #changePoller}, while {@link #changePoller} polls {@code owner_meta}. Other Gravitino nodes
+ *       therefore observe ALTER/DROP and owner changes within one poll interval.
  * </ol>
  *
  * <p>The pollers are best-effort and intentionally cheap; see {@link JcasbinChangePoller} for the
@@ -199,6 +198,9 @@ public class JcasbinAuthorizer implements GravitinoAuthorizer {
     ownerRelCache = new CaffeineGravitinoCache<>(ttlMs, ownerCacheSize);
     lookups = new JcasbinAuthorizationLookups(metadataIdCache, ownerRelCache);
     changePoller = new JcasbinChangePoller(metadataIdCache, ownerRelCache, pollIntervalSecs);
+    if (GravitinoEnv.getInstance().entityChangeLogPoller() != null) {
+      GravitinoEnv.getInstance().entityChangeLogPoller().registerListener(changePoller);
+    }
     changePoller.start();
   }
 
@@ -540,6 +542,9 @@ public class JcasbinAuthorizer implements GravitinoAuthorizer {
   @Override
   public void close() throws IOException {
     if (changePoller != null) {
+      if (GravitinoEnv.getInstance().entityChangeLogPoller() != null) {
+        GravitinoEnv.getInstance().entityChangeLogPoller().unregisterListener(changePoller);
+      }
       changePoller.close();
     }
     if (userRoleCache != null) {
@@ -893,8 +898,8 @@ public class JcasbinAuthorizer implements GravitinoAuthorizer {
 
   /**
    * Resolves GroupEntity objects for the current principal's groups, skipping any that are stale or
-   * not found in the store. Used by {@link #isSelf} (ROLE branch) and owner checks that need full
-   * group entities instead of only group names.
+   * not found in the store. Used by role self-checks and owner checks that need full group entities
+   * instead of only group names.
    */
   private List<GroupEntity> resolveCurrentUserGroups(String metalake, EntityStore entityStore) {
     Principal principal = PrincipalUtils.getCurrentPrincipal();

--- a/server-common/src/main/java/org/apache/gravitino/server/authorization/jcasbin/JcasbinChangePoller.java
+++ b/server-common/src/main/java/org/apache/gravitino/server/authorization/jcasbin/JcasbinChangePoller.java
@@ -34,7 +34,7 @@ import java.util.concurrent.TimeUnit;
 import org.apache.gravitino.MetadataObject;
 import org.apache.gravitino.MetadataObjects;
 import org.apache.gravitino.cache.GravitinoCache;
-import org.apache.gravitino.storage.relational.mapper.EntityChangeLogMapper;
+import org.apache.gravitino.storage.relational.EntityChangeLogListener;
 import org.apache.gravitino.storage.relational.mapper.OwnerMetaMapper;
 import org.apache.gravitino.storage.relational.po.auth.ChangedOwnerInfo;
 import org.apache.gravitino.storage.relational.po.auth.OwnerInfo;
@@ -47,18 +47,14 @@ import org.slf4j.LoggerFactory;
  * Eventual-consistency invalidator for {@link JcasbinAuthorizer}'s {@code metadataIdCache} and
  * {@code ownerRelCache}.
  *
- * <p>One scheduled thread drains {@code entity_change_log} and {@code owner_meta} change rows since
- * a high-water-mark cursor and invalidates the affected keys. Other Gravitino nodes therefore
- * observe ALTER/DROP and owner changes within one poll interval.
+ * <p>This class polls {@code owner_meta} itself and receives {@code entity_change_log} batches from
+ * the global entity change log poller.
  *
- * <p>Both polls run on every tick — a failure in one does not stop the other.
+ * <p>Other Gravitino nodes therefore observe ALTER/DROP and owner changes within one poll interval.
  */
-public class JcasbinChangePoller implements AutoCloseable {
+public class JcasbinChangePoller implements EntityChangeLogListener, AutoCloseable {
 
   private static final Logger LOG = LoggerFactory.getLogger(JcasbinChangePoller.class);
-
-  /** Max entity-change rows to fetch per poller cycle. */
-  private static final int ENTITY_CHANGE_POLLER_MAX_ROWS = 500;
 
   private final GravitinoCache<String, Long> metadataIdCache;
   private final GravitinoCache<Long, Optional<OwnerInfo>> ownerRelCache;
@@ -66,7 +62,6 @@ public class JcasbinChangePoller implements AutoCloseable {
 
   private ScheduledExecutorService scheduler;
   private volatile long ownerPollHighWaterId = 0;
-  private volatile long entityPollHighWaterId = 0;
 
   /**
    * @param metadataIdCache the metadata-id cache to invalidate on entity changes
@@ -84,26 +79,14 @@ public class JcasbinChangePoller implements AutoCloseable {
   }
 
   /**
-   * Initializes the high-water cursors to the current DB tail (so startup does not scan historical
-   * changes) and schedules periodic polling.
-   *
-   * <p>Known trade-off: an id-based high-water mark can miss rows whose id is allocated before the
-   * cursor snapshot but whose commit lands after it. Concretely, if writer A holds {@code id=N-1}
-   * uncommitted while writer B commits {@code id=N}, {@code selectMaxChangeId()} returns N and the
-   * next poll queries {@code id > N} — A's row is never consumed. In that case the affected cache
-   * entry stays stale until either (a) a request-side path catches it on the next request, or (b)
-   * TTL eviction. Acceptable for the eventual-consistency caches targeted here; revisit if we ever
-   * route strong-consistency data through this poller.
+   * Initializes the owner-change high-water cursor to the current DB tail and schedules periodic
+   * polling.
    */
   public void start() {
     ownerPollHighWaterId =
         getOrDefault(
             SessionUtils.getWithoutCommit(
                 OwnerMetaMapper.class, OwnerMetaMapper::selectMaxChangeId));
-    entityPollHighWaterId =
-        getOrDefault(
-            SessionUtils.getWithoutCommit(
-                EntityChangeLogMapper.class, EntityChangeLogMapper::selectMaxChangeId));
 
     scheduler =
         Executors.newSingleThreadScheduledExecutor(
@@ -127,16 +110,6 @@ public class JcasbinChangePoller implements AutoCloseable {
         return;
       }
       LOG.warn("Owner change poll failed", e);
-    }
-
-    try {
-      LOG.debug("Polling for entity changes after id {}", entityPollHighWaterId);
-      pollEntityChanges();
-    } catch (Exception e) {
-      if (handleInterruptIfAny(e, "Entity change poll")) {
-        return;
-      }
-      LOG.warn("Entity change poll failed", e);
     }
   }
 
@@ -202,8 +175,7 @@ public class JcasbinChangePoller implements AutoCloseable {
   }
 
   /**
-   * Drains entity-change rows past {@link #entityPollHighWaterId} and invalidates the affected
-   * {@code metadataIdCache} keys.
+   * Invalidates the affected {@code metadataIdCache} keys from an entity-change batch.
    *
    * <p><b>Contract with the writer side:</b> {@code entity_change_log.full_name} must be the
    * <i>pre-mutation</i> name (the name that consumers currently have cached). The writers in {@code
@@ -216,13 +188,8 @@ public class JcasbinChangePoller implements AutoCloseable {
    * for the rationale. The single-threaded scheduler already prevents overlapping runs in
    * production, and the per-batch invalidation atomicity is provided by the cache itself.
    */
-  private synchronized void pollEntityChanges() {
-    List<EntityChangeRecord> changes =
-        SessionUtils.getWithoutCommit(
-            EntityChangeLogMapper.class,
-            m -> m.selectEntityChanges(entityPollHighWaterId, ENTITY_CHANGE_POLLER_MAX_ROWS));
-
-    long maxSeenId = entityPollHighWaterId;
+  @Override
+  public synchronized void onEntityChange(List<EntityChangeRecord> changes) {
     Set<String> containerPrefixes = new LinkedHashSet<>();
     Set<String> leafKeys = new LinkedHashSet<>();
     for (EntityChangeRecord change : changes) {
@@ -235,9 +202,6 @@ public class JcasbinChangePoller implements AutoCloseable {
         mdType = MetadataObject.Type.valueOf(entityType.toUpperCase(Locale.ROOT));
       } catch (IllegalArgumentException e) {
         LOG.warn("Unknown entity type in change log: {}", entityType);
-        if (change.getId() > maxSeenId) {
-          maxSeenId = change.getId();
-        }
         continue;
       }
 
@@ -249,13 +213,8 @@ public class JcasbinChangePoller implements AutoCloseable {
       } else {
         leafKeys.add(cacheKey);
       }
-
-      if (change.getId() > maxSeenId) {
-        maxSeenId = change.getId();
-      }
     }
     invalidateCoalescedKeys(containerPrefixes, leafKeys);
-    entityPollHighWaterId = maxSeenId;
   }
 
   @Override

--- a/server-common/src/test/java/org/apache/gravitino/server/authorization/jcasbin/TestJcasbinChangePoller.java
+++ b/server-common/src/test/java/org/apache/gravitino/server/authorization/jcasbin/TestJcasbinChangePoller.java
@@ -18,29 +18,18 @@
  */
 package org.apache.gravitino.server.authorization.jcasbin;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.mockStatic;
-import static org.mockito.Mockito.when;
-
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.function.Function;
 import org.apache.gravitino.MetadataObject;
 import org.apache.gravitino.cache.GravitinoCache;
-import org.apache.gravitino.storage.relational.mapper.EntityChangeLogMapper;
-import org.apache.gravitino.storage.relational.mapper.OwnerMetaMapper;
 import org.apache.gravitino.storage.relational.po.auth.OwnerInfo;
 import org.apache.gravitino.storage.relational.po.cache.EntityChangeRecord;
 import org.apache.gravitino.storage.relational.po.cache.OperateType;
-import org.apache.gravitino.storage.relational.utils.SessionUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.mockito.MockedStatic;
 
 /** Tests for {@link JcasbinChangePoller} static helpers. */
 public class TestJcasbinChangePoller {
@@ -95,37 +84,14 @@ public class TestJcasbinChangePoller {
   void testPollEntityChangesCoalescesContainerPrefixes() {
     RecordingCache<String, Long> metadataIdCache = new RecordingCache<>();
     RecordingCache<Long, Optional<OwnerInfo>> ownerRelCache = new RecordingCache<>();
-    EntityChangeLogMapper entityChangeLogMapper = mock(EntityChangeLogMapper.class);
-    OwnerMetaMapper ownerMetaMapper = mock(OwnerMetaMapper.class);
 
-    when(ownerMetaMapper.selectChangedOwners(0L)).thenReturn(Collections.emptyList());
-    when(entityChangeLogMapper.selectEntityChanges(0L, 500))
-        .thenReturn(
-            List.of(
-                change(1L, MetadataObject.Type.CATALOG, "ml1.cat1"),
-                change(2L, MetadataObject.Type.SCHEMA, "ml1.cat1.sch1"),
-                change(3L, MetadataObject.Type.TABLE, "ml1.cat1.sch1.tbl1"),
-                change(4L, MetadataObject.Type.TABLE, "ml1.cat2.sch1.tbl1")));
-
-    try (MockedStatic<SessionUtils> sessionUtils = mockStatic(SessionUtils.class)) {
-      sessionUtils
-          .when(() -> SessionUtils.getWithoutCommit(any(), any()))
-          .thenAnswer(
-              invocation -> {
-                Class<?> mapperClass = invocation.getArgument(0);
-                Function<Object, Object> func = invocation.getArgument(1);
-                if (mapperClass == OwnerMetaMapper.class) {
-                  return func.apply(ownerMetaMapper);
-                }
-                if (mapperClass == EntityChangeLogMapper.class) {
-                  return func.apply(entityChangeLogMapper);
-                }
-                return null;
-              });
-
-      JcasbinChangePoller poller = new JcasbinChangePoller(metadataIdCache, ownerRelCache, 1);
-      poller.pollChanges();
-    }
+    JcasbinChangePoller poller = new JcasbinChangePoller(metadataIdCache, ownerRelCache, 1);
+    poller.onEntityChange(
+        List.of(
+            change(1L, MetadataObject.Type.CATALOG, "ml1.cat1"),
+            change(2L, MetadataObject.Type.SCHEMA, "ml1.cat1.sch1"),
+            change(3L, MetadataObject.Type.TABLE, "ml1.cat1.sch1.tbl1"),
+            change(4L, MetadataObject.Type.TABLE, "ml1.cat2.sch1.tbl1")));
 
     Assertions.assertEquals(
         List.of(
@@ -138,10 +104,11 @@ public class TestJcasbinChangePoller {
   @Test
   void testPollCursorAdvancementIsSynchronized() throws NoSuchMethodException {
     Method pollOwnerChanges = JcasbinChangePoller.class.getDeclaredMethod("pollOwnerChanges");
-    Method pollEntityChanges = JcasbinChangePoller.class.getDeclaredMethod("pollEntityChanges");
+    Method onEntityChange =
+        JcasbinChangePoller.class.getDeclaredMethod("onEntityChange", List.class);
 
     Assertions.assertTrue(Modifier.isSynchronized(pollOwnerChanges.getModifiers()));
-    Assertions.assertTrue(Modifier.isSynchronized(pollEntityChanges.getModifiers()));
+    Assertions.assertTrue(Modifier.isSynchronized(onEntityChange.getModifiers()));
   }
 
   private static String key(String... parts) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

1. Extract entity change log polling into a shared `EntityChangeLogPoller` in `core` with a listener-based dispatch pattern, replacing the per-consumer polling in `JcasbinChangePoller`.
2. Add `CatalogChangeLogListener` that invalidates `CatalogManager`'s local catalog cache when catalog ALTER/RENAME/DROP changes are consumed, providing eventual consistency across HA nodes.
3. Add automatic retention cleanup for `entity_change_log` — expired rows are pruned periodically (default: 1-hour interval, 1-day retention), with configurable settings.
4. Write change log on all catalog updates (not just renames) so that property-only changes also trigger cross-node cache invalidation.

### Why are the changes needed?

In a multi-node deployment, catalog changes on one server do not invalidate the `CatalogManager` cache on peer servers until local TTL eviction. This can leave peers using stale catalog entities or class loaders. Additionally, `entity_change_log` grows unboundedly without automatic cleanup.

Fix: #11232
Fix: #11233

### Does this PR introduce _any_ user-facing change?

Yes — three new configuration keys:
- `gravitino.entityChangeLog.pollIntervalSecs` (default 3)
- `gravitino.entityChangeLog.retentionSecs` (default 86400)
- `gravitino.entityChangeLog.cleanupIntervalSecs` (default 3600)

### How was this patch tested?

- `TestEntityChangeLogPoller` — unit tests for dispatch, cursor advancement, listener failure semantics, retention pruning, and cleanup interval gating.
- `TestCatalogManager.testCatalogChangeLogListenerInvalidatesCatalogCache` — verifies cache invalidation on entity change.
- `TestEntityChangeLogService` — extended to cover ALTER (non-rename) change log writing.
- `TestJcasbinChangePoller` — updated for listener-based entity change delivery.