### PR TITLE
[#11252] improvement(deps): Upgrade gson version in lance-rest-server

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,6 +25,7 @@ reactor-netty-core = "1.2.1"
 junit = "5.8.1"
 jackson = "2.15.2"
 snakeyaml = "2.0"
+gson = "2.11.0"
 guava = "32.1.3-jre"
 lombok = "1.18.20"
 slf4j = "2.0.16"
@@ -177,6 +178,7 @@ jackson-dataformat-yaml = { group = "com.fasterxml.jackson.dataformat", name = "
 snakeyaml = { group = "org.yaml", name = "snakeyaml", version.ref = "snakeyaml" }
 jackson-jaxrs-json-provider = { group = "com.fasterxml.jackson.jaxrs", name = "jackson-jaxrs-json-provider", version.ref = "jackson" }
 guava = { group = "com.google.guava", name = "guava", version.ref = "guava" }
+gson = { group = "com.google.code.gson", name = "gson", version.ref = "gson" }
 kerby-core = { group = "org.apache.kerby", name = "kerb-core", version.ref = "kerby"}
 kerby-simplekdc = { group = "org.apache.kerby", name = "kerb-simplekdc", version.ref = "kerby"}
 lombok = { group = "org.projectlombok", name = "lombok", version.ref = "lombok" }

--- a/lance/lance-rest-server/build.gradle.kts
+++ b/lance/lance-rest-server/build.gradle.kts
@@ -56,6 +56,10 @@ dependencies {
   implementation(libs.bundles.log4j)
   implementation(libs.bundles.metrics)
   implementation(libs.bundles.prometheus)
+
+  constraints {
+    implementation(libs.gson)
+  }
   implementation(libs.commons.lang3)
   implementation(libs.lance.namespace.core) {
     exclude(group = "org.lance", module = "lance-core")


### PR DESCRIPTION

### What changes were proposed in this pull request?

1. Defined gson:2.11.0 in `gradle/libs.versions.toml`.
2. Added a dependency constraint in `lance/lance-rest-server/build.gradle.kts` to enforce the version.

### Why are the changes needed?

`jjwt-gson:0.11.1` pulls in `gson:2.8.5` which has known issues. This module has no other dependency that brings a newer gson, so the old version remains unresolved.
Fix: #11252 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

- `./gradlew :lance:lance-rest-server:compileJava` passes.
- Verified via `dependencyInsight` that gson resolves to `2.11.0`.
