### PR TITLE
[minor] improvement(CI): support branch-1.3 in auto cherry-pick workflow

### DIFF
--- a/.github/workflows/auto-cherry-pick.yml
+++ b/.github/workflows/auto-cherry-pick.yml
@@ -10,8 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     name: Detect cherry-pick labels from merged PR
     outputs:
-      branch-1-0: ${{ steps.check-labels.outputs.branch-1-0 }}
-      branch-1-1: ${{ steps.check-labels.outputs.branch-1-1 }}
       branch-1-2: ${{ steps.check-labels.outputs.branch-1-2 }}
       branch-1-3: ${{ steps.check-labels.outputs.branch-1-3 }}
       commit-sha: ${{ steps.get-commit.outputs.commit-sha }}
@@ -66,18 +64,6 @@ jobs:
           echo "PR #$PR_NUMBER labels: $LABELS"
           
           # Check for each branch label
-          if echo "$LABELS" | grep -q "branch-1.0"; then
-            echo "branch-1-0=true" >> $GITHUB_OUTPUT
-          else
-            echo "branch-1-0=false" >> $GITHUB_OUTPUT
-          fi
-          
-          if echo "$LABELS" | grep -q "branch-1.1"; then
-            echo "branch-1-1=true" >> $GITHUB_OUTPUT
-          else
-            echo "branch-1-1=false" >> $GITHUB_OUTPUT
-          fi
-          
           if echo "$LABELS" | grep -q "branch-1.2"; then
             echo "branch-1-2=true" >> $GITHUB_OUTPUT
           else
@@ -89,26 +75,6 @@ jobs:
           else
             echo "branch-1-3=false" >> $GITHUB_OUTPUT
           fi
-
-  cherry-pick-branch-1-0:
-    needs: detect-cherry-pick-labels
-    if: needs.detect-cherry-pick-labels.outputs.branch-1-0 == 'true'
-    uses: ./.github/workflows/cherry-pick-branch.yml
-    with:
-      target-branch: branch-1.0
-      commit-sha: ${{ needs.detect-cherry-pick-labels.outputs.commit-sha }}
-      commit-message: ${{ needs.detect-cherry-pick-labels.outputs.commit-message }}
-    secrets: inherit
-
-  cherry-pick-branch-1-1:
-    needs: detect-cherry-pick-labels
-    if: needs.detect-cherry-pick-labels.outputs.branch-1-1 == 'true'
-    uses: ./.github/workflows/cherry-pick-branch.yml
-    with:
-      target-branch: branch-1.1
-      commit-sha: ${{ needs.detect-cherry-pick-labels.outputs.commit-sha }}
-      commit-message: ${{ needs.detect-cherry-pick-labels.outputs.commit-message }}
-    secrets: inherit
 
   cherry-pick-branch-1-2:
     needs: detect-cherry-pick-labels

--- a/.github/workflows/auto-cherry-pick.yml
+++ b/.github/workflows/auto-cherry-pick.yml
@@ -13,6 +13,7 @@ jobs:
       branch-1-0: ${{ steps.check-labels.outputs.branch-1-0 }}
       branch-1-1: ${{ steps.check-labels.outputs.branch-1-1 }}
       branch-1-2: ${{ steps.check-labels.outputs.branch-1-2 }}
+      branch-1-3: ${{ steps.check-labels.outputs.branch-1-3 }}
       commit-sha: ${{ steps.get-commit.outputs.commit-sha }}
       commit-message: ${{ steps.get-commit.outputs.commit-message }}
     steps:
@@ -83,6 +84,12 @@ jobs:
             echo "branch-1-2=false" >> $GITHUB_OUTPUT
           fi
 
+          if echo "$LABELS" | grep -q "branch-1.3"; then
+            echo "branch-1-3=true" >> $GITHUB_OUTPUT
+          else
+            echo "branch-1-3=false" >> $GITHUB_OUTPUT
+          fi
+
   cherry-pick-branch-1-0:
     needs: detect-cherry-pick-labels
     if: needs.detect-cherry-pick-labels.outputs.branch-1-0 == 'true'
@@ -109,6 +116,16 @@ jobs:
     uses: ./.github/workflows/cherry-pick-branch.yml
     with:
       target-branch: branch-1.2
+      commit-sha: ${{ needs.detect-cherry-pick-labels.outputs.commit-sha }}
+      commit-message: ${{ needs.detect-cherry-pick-labels.outputs.commit-message }}
+    secrets: inherit
+
+  cherry-pick-branch-1-3:
+    needs: detect-cherry-pick-labels
+    if: needs.detect-cherry-pick-labels.outputs.branch-1-3 == 'true'
+    uses: ./.github/workflows/cherry-pick-branch.yml
+    with:
+      target-branch: branch-1.3
       commit-sha: ${{ needs.detect-cherry-pick-labels.outputs.commit-sha }}
       commit-message: ${{ needs.detect-cherry-pick-labels.outputs.commit-message }}
     secrets: inherit


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR updates the auto cherry-pick workflow to support the upcoming `branch-1.3` release branch.

- Add `branch-1-3` as an output from the label detection job.
- Add label detection for `branch-1.3`.
- Add a reusable workflow invocation to cherry-pick into `branch-1.3` when the label is present.

### Why are the changes needed?

We are preparing to cut `branch-1.3`. The auto cherry-pick workflow must recognize and route cherry-pick requests to this new branch.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

- Verified workflow diff locally for all three required sections (outputs, label checks, cherry-pick job).
- Confirmed branch naming and trigger conditions match existing branch-1.0/1.1/1.2 patterns.
