### PR TITLE
[#11259] docs(open-api): Add OpenAPI spec for built-in IdP REST APIs

### DIFF
--- a/docs/build.gradle.kts
+++ b/docs/build.gradle.kts
@@ -45,5 +45,6 @@ tasks {
 
   build {
     dependsOn(lintOpenAPI)
+    dependsOn(lintIdpOpenAPI)
   }
 }

--- a/docs/build.gradle.kts
+++ b/docs/build.gradle.kts
@@ -33,7 +33,6 @@ tasks {
       listOf(
         "lint",
         "--extends=recommended-strict",
-        "${project.projectDir}/open-api/openapi.yaml",
         "${project.projectDir}/open-api/idp/openapi.yaml"
       )
     )

--- a/docs/build.gradle.kts
+++ b/docs/build.gradle.kts
@@ -29,7 +29,14 @@ configure<NodeExtension> {
 tasks {
   val lintOpenAPI by registering(NpxTask::class) {
     command.set("@redocly/cli@1.23.1")
-    args.set(listOf("lint", "--extends=recommended-strict", "${project.projectDir}/open-api/openapi.yaml"))
+    args.set(
+      listOf(
+        "lint",
+        "--extends=recommended-strict",
+        "${project.projectDir}/open-api/openapi.yaml",
+        "${project.projectDir}/open-api/idp/openapi.yaml"
+      )
+    )
   }
 
   build {

--- a/docs/build.gradle.kts
+++ b/docs/build.gradle.kts
@@ -29,6 +29,11 @@ configure<NodeExtension> {
 tasks {
   val lintOpenAPI by registering(NpxTask::class) {
     command.set("@redocly/cli@1.23.1")
+    args.set(listOf("lint", "--extends=recommended-strict", "${project.projectDir}/open-api/openapi.yaml"))
+  }
+
+  val lintIdpOpenAPI by registering(NpxTask::class) {
+    command.set("@redocly/cli@1.23.1")
     args.set(
       listOf(
         "lint",

--- a/docs/open-api/idp/idp.yaml
+++ b/docs/open-api/idp/idp.yaml
@@ -22,10 +22,10 @@ paths:
   /idp/users:
     post:
       tags:
-        - idp
-      summary: Add built-in IdP user
+        - IDP
+      summary: Add built-in IDP user
       description: >
-        Creates a built-in IdP user with the given username and password.
+        Creates a built-in IDP user with the given username and password.
         Requires the `basic` authenticator and the `idp-basic` plugin to be enabled.
       operationId: addIdpUser
       requestBody:
@@ -39,7 +39,7 @@ paths:
                 $ref: "#/components/examples/AddUserRequest"
       responses:
         "200":
-          description: Returns the added built-in IdP user
+          description: Returns the added built-in IDP user
           content:
             application/vnd.gravitino.v1+json:
               schema:
@@ -52,7 +52,7 @@ paths:
         "403":
           $ref: "#/components/responses/IdpForbiddenErrorResponse"
         "409":
-          description: Conflict - The built-in IdP user already exists
+          description: Conflict - The built-in IDP user already exists
           content:
             application/vnd.gravitino.v1+json:
               schema:
@@ -69,13 +69,13 @@ paths:
 
     get:
       tags:
-        - idp
-      summary: Get built-in IdP user
-      description: Returns the specified built-in IdP user, including group membership.
+        - IDP
+      summary: Get built-in IDP user
+      description: Returns the specified built-in IDP user, including group membership.
       operationId: getIdpUser
       responses:
         "200":
-          description: Returns the built-in IdP user object
+          description: Returns the built-in IDP user object
           content:
             application/vnd.gravitino.v1+json:
               schema:
@@ -86,7 +86,7 @@ paths:
         "403":
           $ref: "#/components/responses/IdpForbiddenErrorResponse"
         "404":
-          description: Not Found - The specified built-in IdP user does not exist
+          description: Not Found - The specified built-in IDP user does not exist
           content:
             application/vnd.gravitino.v1+json:
               schema:
@@ -99,9 +99,9 @@ paths:
 
     put:
       tags:
-        - idp
-      summary: Change built-in IdP user password
-      description: Updates the password of the specified built-in IdP user.
+        - IDP
+      summary: Change built-in IDP user password
+      description: Updates the password of the specified built-in IDP user.
       operationId: changeIdpUserPassword
       requestBody:
         required: true
@@ -114,7 +114,7 @@ paths:
                 $ref: "#/components/examples/ChangePasswordRequest"
       responses:
         "200":
-          description: Returns the built-in IdP user after the password change
+          description: Returns the built-in IDP user after the password change
           content:
             application/vnd.gravitino.v1+json:
               schema:
@@ -127,7 +127,7 @@ paths:
         "403":
           $ref: "#/components/responses/IdpForbiddenErrorResponse"
         "404":
-          description: Not Found - The specified built-in IdP user does not exist
+          description: Not Found - The specified built-in IDP user does not exist
           content:
             application/vnd.gravitino.v1+json:
               schema:
@@ -140,8 +140,8 @@ paths:
 
     delete:
       tags:
-        - idp
-      summary: Remove built-in IdP user
+        - IDP
+      summary: Remove built-in IDP user
       operationId: removeIdpUser
       responses:
         "200":
@@ -151,7 +151,7 @@ paths:
         "403":
           $ref: "#/components/responses/IdpForbiddenErrorResponse"
         "404":
-          description: Not Found - The specified built-in IdP user does not exist
+          description: Not Found - The specified built-in IDP user does not exist
           content:
             application/vnd.gravitino.v1+json:
               schema:
@@ -165,9 +165,9 @@ paths:
   /idp/groups:
     post:
       tags:
-        - idp
-      summary: Add built-in IdP group
-      description: Creates a built-in IdP group with the given name.
+        - IDP
+      summary: Add built-in IDP group
+      description: Creates a built-in IDP group with the given name.
       operationId: addIdpGroup
       requestBody:
         required: true
@@ -180,7 +180,7 @@ paths:
                 $ref: "#/components/examples/AddGroupRequest"
       responses:
         "200":
-          description: Returns the added built-in IdP group
+          description: Returns the added built-in IDP group
           content:
             application/vnd.gravitino.v1+json:
               schema:
@@ -193,7 +193,7 @@ paths:
         "403":
           $ref: "#/components/responses/IdpForbiddenErrorResponse"
         "409":
-          description: Conflict - The built-in IdP group already exists
+          description: Conflict - The built-in IDP group already exists
           content:
             application/vnd.gravitino.v1+json:
               schema:
@@ -210,13 +210,13 @@ paths:
 
     get:
       tags:
-        - idp
-      summary: Get built-in IdP group
-      description: Returns the specified built-in IdP group, including member usernames.
+        - IDP
+      summary: Get built-in IDP group
+      description: Returns the specified built-in IDP group, including member usernames.
       operationId: getIdpGroup
       responses:
         "200":
-          description: Returns the built-in IdP group object
+          description: Returns the built-in IDP group object
           content:
             application/vnd.gravitino.v1+json:
               schema:
@@ -227,7 +227,7 @@ paths:
         "403":
           $ref: "#/components/responses/IdpForbiddenErrorResponse"
         "404":
-          description: Not Found - The specified built-in IdP group does not exist
+          description: Not Found - The specified built-in IDP group does not exist
           content:
             application/vnd.gravitino.v1+json:
               schema:
@@ -240,8 +240,8 @@ paths:
 
     delete:
       tags:
-        - idp
-      summary: Remove built-in IdP group
+        - IDP
+      summary: Remove built-in IDP group
       operationId: removeIdpGroup
       parameters:
         - $ref: "./openapi.yaml#/components/parameters/force"
@@ -253,7 +253,7 @@ paths:
         "403":
           $ref: "#/components/responses/IdpForbiddenErrorResponse"
         "404":
-          description: Not Found - The specified built-in IdP group does not exist
+          description: Not Found - The specified built-in IDP group does not exist
           content:
             application/vnd.gravitino.v1+json:
               schema:
@@ -270,10 +270,10 @@ paths:
 
     put:
       tags:
-        - idp
-      summary: Change built-in IdP group membership
+        - IDP
+      summary: Change built-in IDP group membership
       description: >
-        Adds and/or removes users from the specified built-in IdP group in a single request,
+        Adds and/or removes users from the specified built-in IDP group in a single request,
         similar to tag association. At least one of `usersToAdd` or `usersToRemove` must be set.
       operationId: changeIdpGroupMembership
       requestBody:
@@ -287,7 +287,7 @@ paths:
                 $ref: "#/components/examples/GroupMembershipChangeRequest"
       responses:
         "200":
-          description: Returns the built-in IdP group after membership changes
+          description: Returns the built-in IDP group after membership changes
           content:
             application/vnd.gravitino.v1+json:
               schema:
@@ -300,7 +300,7 @@ paths:
         "403":
           $ref: "#/components/responses/IdpForbiddenErrorResponse"
         "404":
-          description: Not Found - The specified built-in IdP group or user does not exist
+          description: Not Found - The specified built-in IDP group or user does not exist
           content:
             application/vnd.gravitino.v1+json:
               schema:
@@ -320,12 +320,12 @@ components:
       properties:
         name:
           type: string
-          description: The username of the built-in IdP user
+          description: The username of the built-in IDP user
         groups:
           type: array
           items:
             type: string
-          description: The built-in IdP groups the user belongs to
+          description: The built-in IDP groups the user belongs to
 
     IdpGroup:
       type: object
@@ -334,12 +334,12 @@ components:
       properties:
         name:
           type: string
-          description: The name of the built-in IdP group
+          description: The name of the built-in IDP group
         users:
           type: array
           items:
             type: string
-          description: The usernames of members in the built-in IdP group
+          description: The usernames of members in the built-in IDP group
 
     AddUserRequest:
       type: object
@@ -349,11 +349,11 @@ components:
       properties:
         user:
           type: string
-          description: The username of the built-in IdP user to add
+          description: The username of the built-in IDP user to add
         password:
           type: string
           format: password
-          description: The password of the built-in IdP user to add
+          description: The password of the built-in IDP user to add
           writeOnly: true
 
     ChangePasswordRequest:
@@ -364,7 +364,7 @@ components:
         password:
           type: string
           format: password
-          description: The new password of the built-in IdP user
+          description: The new password of the built-in IDP user
           writeOnly: true
 
     AddGroupRequest:
@@ -374,7 +374,7 @@ components:
       properties:
         group:
           type: string
-          description: The name of the built-in IdP group to add
+          description: The name of the built-in IDP group to add
 
     GroupMembershipChangeRequest:
       type: object
@@ -383,13 +383,13 @@ components:
           type: array
           items:
             type: string
-          description: The usernames to add to the built-in IdP group
+          description: The usernames to add to the built-in IDP group
           nullable: true
         usersToRemove:
           type: array
           items:
             type: string
-          description: The usernames to remove from the built-in IdP group
+          description: The usernames to remove from the built-in IDP group
           nullable: true
 
   responses:
@@ -418,7 +418,7 @@ components:
           $ref: "#/components/schemas/IdpGroup"
 
     IdpForbiddenErrorResponse:
-      description: Forbidden - Built-in IdP REST APIs are disabled or the caller is not authorized
+      description: Forbidden - Built-in IDP REST APIs are disabled or the caller is not authorized
       content:
         application/vnd.gravitino.v1+json:
           schema:
@@ -469,12 +469,12 @@ components:
       value: {
         "code": 1003,
         "type": "NotFoundException",
-        "message": "Built-in IdP resource does not exist"
+        "message": "Built-in IDP resource does not exist"
       }
 
     IdpAlreadyExistsException:
       value: {
         "code": 1004,
         "type": "AlreadyExistsException",
-        "message": "Built-in IdP resource already exists"
+        "message": "Built-in IDP resource already exists"
       }

--- a/docs/open-api/idp/idp.yaml
+++ b/docs/open-api/idp/idp.yaml
@@ -43,7 +43,7 @@ paths:
           content:
             application/vnd.gravitino.v1+json:
               schema:
-                $ref: "#/components/responses/IdpUserResponse"
+                $ref: "#/components/schemas/IdpUserResponse"
               examples:
                 IdpUserResponse:
                   $ref: "#/components/examples/IdpUserResponse"
@@ -79,7 +79,7 @@ paths:
           content:
             application/vnd.gravitino.v1+json:
               schema:
-                $ref: "#/components/responses/IdpUserResponse"
+                $ref: "#/components/schemas/IdpUserResponse"
               examples:
                 IdpUserResponse:
                   $ref: "#/components/examples/IdpUserResponse"
@@ -118,7 +118,7 @@ paths:
           content:
             application/vnd.gravitino.v1+json:
               schema:
-                $ref: "#/components/responses/IdpUserResponse"
+                $ref: "#/components/schemas/IdpUserResponse"
               examples:
                 IdpUserResponse:
                   $ref: "#/components/examples/IdpUserResponse"
@@ -184,7 +184,7 @@ paths:
           content:
             application/vnd.gravitino.v1+json:
               schema:
-                $ref: "#/components/responses/IdpGroupResponse"
+                $ref: "#/components/schemas/IdpGroupResponse"
               examples:
                 IdpGroupResponse:
                   $ref: "#/components/examples/IdpGroupResponse"
@@ -220,7 +220,7 @@ paths:
           content:
             application/vnd.gravitino.v1+json:
               schema:
-                $ref: "#/components/responses/IdpGroupResponse"
+                $ref: "#/components/schemas/IdpGroupResponse"
               examples:
                 IdpGroupResponse:
                   $ref: "#/components/examples/IdpGroupResponse"
@@ -261,6 +261,15 @@ paths:
               examples:
                 NotFoundException:
                   $ref: "#/components/examples/IdpNotFoundException"
+        "405":
+          description: Method Not Allowed - The group is not empty and force is false
+          content:
+            application/vnd.gravitino.v1+json:
+              schema:
+                $ref: "../openapi.yaml#/components/schemas/ErrorModel"
+              examples:
+                GroupNotEmptyException:
+                  $ref: "#/components/examples/IdpGroupNotEmptyException"
         "5xx":
           $ref: "../openapi.yaml#/components/responses/ServerErrorResponse"
 
@@ -291,7 +300,7 @@ paths:
           content:
             application/vnd.gravitino.v1+json:
               schema:
-                $ref: "#/components/responses/IdpGroupResponse"
+                $ref: "#/components/schemas/IdpGroupResponse"
               examples:
                 IdpGroupResponse:
                   $ref: "#/components/examples/IdpGroupResponse"
@@ -349,7 +358,9 @@ components:
       properties:
         user:
           type: string
-          description: The username of the built-in IDP user to add
+          description: >
+            The username to add. Request payloads use `user`, while user objects in
+            responses use `name` (see IdpUser), matching the server JSON field names.
         password:
           type: string
           format: password
@@ -374,25 +385,31 @@ components:
       properties:
         group:
           type: string
-          description: The name of the built-in IDP group to add
+          description: >
+            The group name to add. Request payloads use `group`, while group objects in
+            responses use `name` (see IdpGroup), matching the server JSON field names.
 
     GroupMembershipChangeRequest:
       type: object
+      anyOf:
+        - required:
+            - usersToAdd
+        - required:
+            - usersToRemove
       properties:
         usersToAdd:
           type: array
           items:
             type: string
+          minItems: 1
           description: The usernames to add to the built-in IDP group
-          nullable: true
         usersToRemove:
           type: array
           items:
             type: string
+          minItems: 1
           description: The usernames to remove from the built-in IDP group
-          nullable: true
 
-  responses:
     IdpUserResponse:
       type: object
       properties:
@@ -417,6 +434,7 @@ components:
         group:
           $ref: "#/components/schemas/IdpGroup"
 
+  responses:
     IdpForbiddenErrorResponse:
       description: Forbidden - Built-in IDP REST APIs are disabled or the caller is not authorized
       content:
@@ -469,12 +487,19 @@ components:
       value: {
         "code": 1003,
         "type": "NotFoundException",
-        "message": "Built-in IDP resource does not exist"
+        "message": "Failed to operate built-in IdP user [alice] operation [GET], reason [User does not exist]"
       }
 
     IdpAlreadyExistsException:
       value: {
         "code": 1004,
         "type": "AlreadyExistsException",
-        "message": "Built-in IDP resource already exists"
+        "message": "Failed to operate built-in IdP user [] operation [ADD], reason [User already exists]"
+      }
+
+    IdpGroupNotEmptyException:
+      value: {
+        "code": 1003,
+        "type": "IllegalStateException",
+        "message": "Failed to operate built-in IdP group [engineers] operation [REMOVE], reason [Group is not empty]"
       }

--- a/docs/open-api/idp/idp.yaml
+++ b/docs/open-api/idp/idp.yaml
@@ -1,0 +1,480 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+---
+
+paths:
+
+  /idp/users:
+    post:
+      tags:
+        - idp
+      summary: Add built-in IdP user
+      description: >
+        Creates a built-in IdP user with the given username and password.
+        Requires the `basic` authenticator and the `idp-basic` plugin to be enabled.
+      operationId: addIdpUser
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AddUserRequest"
+            examples:
+              AddUserRequest:
+                $ref: "#/components/examples/AddUserRequest"
+      responses:
+        "200":
+          description: Returns the added built-in IdP user
+          content:
+            application/vnd.gravitino.v1+json:
+              schema:
+                $ref: "#/components/responses/IdpUserResponse"
+              examples:
+                IdpUserResponse:
+                  $ref: "#/components/examples/IdpUserResponse"
+        "400":
+          $ref: "../openapi.yaml#/components/responses/BadRequestErrorResponse"
+        "403":
+          $ref: "#/components/responses/IdpForbiddenErrorResponse"
+        "409":
+          description: Conflict - The built-in IdP user already exists
+          content:
+            application/vnd.gravitino.v1+json:
+              schema:
+                $ref: "../openapi.yaml#/components/schemas/ErrorModel"
+              examples:
+                AlreadyExistsException:
+                  $ref: "#/components/examples/IdpAlreadyExistsException"
+        "5xx":
+          $ref: "../openapi.yaml#/components/responses/ServerErrorResponse"
+
+  /idp/users/{user}:
+    parameters:
+      - $ref: "../openapi.yaml#/components/parameters/user"
+
+    get:
+      tags:
+        - idp
+      summary: Get built-in IdP user
+      description: Returns the specified built-in IdP user, including group membership.
+      operationId: getIdpUser
+      responses:
+        "200":
+          description: Returns the built-in IdP user object
+          content:
+            application/vnd.gravitino.v1+json:
+              schema:
+                $ref: "#/components/responses/IdpUserResponse"
+              examples:
+                IdpUserResponse:
+                  $ref: "#/components/examples/IdpUserResponse"
+        "403":
+          $ref: "#/components/responses/IdpForbiddenErrorResponse"
+        "404":
+          description: Not Found - The specified built-in IdP user does not exist
+          content:
+            application/vnd.gravitino.v1+json:
+              schema:
+                $ref: "../openapi.yaml#/components/schemas/ErrorModel"
+              examples:
+                NotFoundException:
+                  $ref: "#/components/examples/IdpNotFoundException"
+        "5xx":
+          $ref: "../openapi.yaml#/components/responses/ServerErrorResponse"
+
+    put:
+      tags:
+        - idp
+      summary: Change built-in IdP user password
+      description: Updates the password of the specified built-in IdP user.
+      operationId: changeIdpUserPassword
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ChangePasswordRequest"
+            examples:
+              ChangePasswordRequest:
+                $ref: "#/components/examples/ChangePasswordRequest"
+      responses:
+        "200":
+          description: Returns the built-in IdP user after the password change
+          content:
+            application/vnd.gravitino.v1+json:
+              schema:
+                $ref: "#/components/responses/IdpUserResponse"
+              examples:
+                IdpUserResponse:
+                  $ref: "#/components/examples/IdpUserResponse"
+        "400":
+          $ref: "../openapi.yaml#/components/responses/BadRequestErrorResponse"
+        "403":
+          $ref: "#/components/responses/IdpForbiddenErrorResponse"
+        "404":
+          description: Not Found - The specified built-in IdP user does not exist
+          content:
+            application/vnd.gravitino.v1+json:
+              schema:
+                $ref: "../openapi.yaml#/components/schemas/ErrorModel"
+              examples:
+                NotFoundException:
+                  $ref: "#/components/examples/IdpNotFoundException"
+        "5xx":
+          $ref: "../openapi.yaml#/components/responses/ServerErrorResponse"
+
+    delete:
+      tags:
+        - idp
+      summary: Remove built-in IdP user
+      operationId: removeIdpUser
+      responses:
+        "200":
+          $ref: "../openapi.yaml#/components/responses/RemoveResponse"
+        "400":
+          $ref: "../openapi.yaml#/components/responses/BadRequestErrorResponse"
+        "403":
+          $ref: "#/components/responses/IdpForbiddenErrorResponse"
+        "404":
+          description: Not Found - The specified built-in IdP user does not exist
+          content:
+            application/vnd.gravitino.v1+json:
+              schema:
+                $ref: "../openapi.yaml#/components/schemas/ErrorModel"
+              examples:
+                NotFoundException:
+                  $ref: "#/components/examples/IdpNotFoundException"
+        "5xx":
+          $ref: "../openapi.yaml#/components/responses/ServerErrorResponse"
+
+  /idp/groups:
+    post:
+      tags:
+        - idp
+      summary: Add built-in IdP group
+      description: Creates a built-in IdP group with the given name.
+      operationId: addIdpGroup
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AddGroupRequest"
+            examples:
+              AddGroupRequest:
+                $ref: "#/components/examples/AddGroupRequest"
+      responses:
+        "200":
+          description: Returns the added built-in IdP group
+          content:
+            application/vnd.gravitino.v1+json:
+              schema:
+                $ref: "#/components/responses/IdpGroupResponse"
+              examples:
+                IdpGroupResponse:
+                  $ref: "#/components/examples/IdpGroupResponse"
+        "400":
+          $ref: "../openapi.yaml#/components/responses/BadRequestErrorResponse"
+        "403":
+          $ref: "#/components/responses/IdpForbiddenErrorResponse"
+        "409":
+          description: Conflict - The built-in IdP group already exists
+          content:
+            application/vnd.gravitino.v1+json:
+              schema:
+                $ref: "../openapi.yaml#/components/schemas/ErrorModel"
+              examples:
+                AlreadyExistsException:
+                  $ref: "#/components/examples/IdpAlreadyExistsException"
+        "5xx":
+          $ref: "../openapi.yaml#/components/responses/ServerErrorResponse"
+
+  /idp/groups/{group}:
+    parameters:
+      - $ref: "../openapi.yaml#/components/parameters/group"
+
+    get:
+      tags:
+        - idp
+      summary: Get built-in IdP group
+      description: Returns the specified built-in IdP group, including member usernames.
+      operationId: getIdpGroup
+      responses:
+        "200":
+          description: Returns the built-in IdP group object
+          content:
+            application/vnd.gravitino.v1+json:
+              schema:
+                $ref: "#/components/responses/IdpGroupResponse"
+              examples:
+                IdpGroupResponse:
+                  $ref: "#/components/examples/IdpGroupResponse"
+        "403":
+          $ref: "#/components/responses/IdpForbiddenErrorResponse"
+        "404":
+          description: Not Found - The specified built-in IdP group does not exist
+          content:
+            application/vnd.gravitino.v1+json:
+              schema:
+                $ref: "../openapi.yaml#/components/schemas/ErrorModel"
+              examples:
+                NotFoundException:
+                  $ref: "#/components/examples/IdpNotFoundException"
+        "5xx":
+          $ref: "../openapi.yaml#/components/responses/ServerErrorResponse"
+
+    delete:
+      tags:
+        - idp
+      summary: Remove built-in IdP group
+      operationId: removeIdpGroup
+      parameters:
+        - $ref: "../openapi.yaml#/components/parameters/force"
+      responses:
+        "200":
+          $ref: "../openapi.yaml#/components/responses/RemoveResponse"
+        "400":
+          $ref: "../openapi.yaml#/components/responses/BadRequestErrorResponse"
+        "403":
+          $ref: "#/components/responses/IdpForbiddenErrorResponse"
+        "404":
+          description: Not Found - The specified built-in IdP group does not exist
+          content:
+            application/vnd.gravitino.v1+json:
+              schema:
+                $ref: "../openapi.yaml#/components/schemas/ErrorModel"
+              examples:
+                NotFoundException:
+                  $ref: "#/components/examples/IdpNotFoundException"
+        "5xx":
+          $ref: "../openapi.yaml#/components/responses/ServerErrorResponse"
+
+  /idp/groups/{group}/users:
+    parameters:
+      - $ref: "../openapi.yaml#/components/parameters/group"
+
+    put:
+      tags:
+        - idp
+      summary: Change built-in IdP group membership
+      description: >
+        Adds and/or removes users from the specified built-in IdP group in a single request,
+        similar to tag association. At least one of `usersToAdd` or `usersToRemove` must be set.
+      operationId: changeIdpGroupMembership
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/GroupMembershipChangeRequest"
+            examples:
+              GroupMembershipChangeRequest:
+                $ref: "#/components/examples/GroupMembershipChangeRequest"
+      responses:
+        "200":
+          description: Returns the built-in IdP group after membership changes
+          content:
+            application/vnd.gravitino.v1+json:
+              schema:
+                $ref: "#/components/responses/IdpGroupResponse"
+              examples:
+                IdpGroupResponse:
+                  $ref: "#/components/examples/IdpGroupResponse"
+        "400":
+          $ref: "../openapi.yaml#/components/responses/BadRequestErrorResponse"
+        "403":
+          $ref: "#/components/responses/IdpForbiddenErrorResponse"
+        "404":
+          description: Not Found - The specified built-in IdP group or user does not exist
+          content:
+            application/vnd.gravitino.v1+json:
+              schema:
+                $ref: "../openapi.yaml#/components/schemas/ErrorModel"
+              examples:
+                NotFoundException:
+                  $ref: "#/components/examples/IdpNotFoundException"
+        "5xx":
+          $ref: "../openapi.yaml#/components/responses/ServerErrorResponse"
+
+components:
+  schemas:
+    IdpUser:
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
+          description: The username of the built-in IdP user
+        groups:
+          type: array
+          items:
+            type: string
+          description: The built-in IdP groups the user belongs to
+
+    IdpGroup:
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
+          description: The name of the built-in IdP group
+        users:
+          type: array
+          items:
+            type: string
+          description: The usernames of members in the built-in IdP group
+
+    AddUserRequest:
+      type: object
+      required:
+        - user
+        - password
+      properties:
+        user:
+          type: string
+          description: The username of the built-in IdP user to add
+        password:
+          type: string
+          format: password
+          description: The password of the built-in IdP user to add
+          writeOnly: true
+
+    ChangePasswordRequest:
+      type: object
+      required:
+        - password
+      properties:
+        password:
+          type: string
+          format: password
+          description: The new password of the built-in IdP user
+          writeOnly: true
+
+    AddGroupRequest:
+      type: object
+      required:
+        - group
+      properties:
+        group:
+          type: string
+          description: The name of the built-in IdP group to add
+
+    GroupMembershipChangeRequest:
+      type: object
+      properties:
+        usersToAdd:
+          type: array
+          items:
+            type: string
+          description: The usernames to add to the built-in IdP group
+          nullable: true
+        usersToRemove:
+          type: array
+          items:
+            type: string
+          description: The usernames to remove from the built-in IdP group
+          nullable: true
+
+  responses:
+    IdpUserResponse:
+      type: object
+      properties:
+        code:
+          type: integer
+          format: int32
+          description: Status code of the response
+          enum:
+            - 0
+        user:
+          $ref: "#/components/schemas/IdpUser"
+
+    IdpGroupResponse:
+      type: object
+      properties:
+        code:
+          type: integer
+          format: int32
+          description: Status code of the response
+          enum:
+            - 0
+        group:
+          $ref: "#/components/schemas/IdpGroup"
+
+    IdpForbiddenErrorResponse:
+      description: Forbidden - Built-in IdP REST APIs are disabled or the caller is not authorized
+      content:
+        application/vnd.gravitino.v1+json:
+          schema:
+            $ref: "../openapi.yaml#/components/schemas/ErrorModel"
+
+  examples:
+    AddUserRequest:
+      value: {
+        "user": "alice",
+        "password": "secret"
+      }
+
+    ChangePasswordRequest:
+      value: {
+        "password": "new-secret"
+      }
+
+    AddGroupRequest:
+      value: {
+        "group": "engineers"
+      }
+
+    GroupMembershipChangeRequest:
+      value: {
+        "usersToAdd": ["alice", "bob"],
+        "usersToRemove": ["carol"]
+      }
+
+    IdpUserResponse:
+      value: {
+        "code": 0,
+        "user": {
+          "name": "alice",
+          "groups": ["engineers"]
+        }
+      }
+
+    IdpGroupResponse:
+      value: {
+        "code": 0,
+        "group": {
+          "name": "engineers",
+          "users": ["alice", "bob"]
+        }
+      }
+
+    IdpNotFoundException:
+      value: {
+        "code": 1003,
+        "type": "NotFoundException",
+        "message": "Built-in IdP resource does not exist"
+      }
+
+    IdpAlreadyExistsException:
+      value: {
+        "code": 1004,
+        "type": "AlreadyExistsException",
+        "message": "Built-in IdP resource already exists"
+      }

--- a/docs/open-api/idp/idp.yaml
+++ b/docs/open-api/idp/idp.yaml
@@ -48,7 +48,7 @@ paths:
                 IdpUserResponse:
                   $ref: "#/components/examples/IdpUserResponse"
         "400":
-          $ref: "./openapi.yaml#/components/responses/BadRequestErrorResponse"
+          $ref: "../openapi.yaml#/components/responses/BadRequestErrorResponse"
         "403":
           $ref: "#/components/responses/IdpForbiddenErrorResponse"
         "409":
@@ -56,16 +56,16 @@ paths:
           content:
             application/vnd.gravitino.v1+json:
               schema:
-                $ref: "./openapi.yaml#/components/schemas/ErrorModel"
+                $ref: "../openapi.yaml#/components/schemas/ErrorModel"
               examples:
                 AlreadyExistsException:
                   $ref: "#/components/examples/IdpAlreadyExistsException"
         "5xx":
-          $ref: "./openapi.yaml#/components/responses/ServerErrorResponse"
+          $ref: "../openapi.yaml#/components/responses/ServerErrorResponse"
 
   /idp/users/{user}:
     parameters:
-      - $ref: "./openapi.yaml#/components/parameters/user"
+      - $ref: "../openapi.yaml#/components/parameters/user"
 
     get:
       tags:
@@ -90,12 +90,12 @@ paths:
           content:
             application/vnd.gravitino.v1+json:
               schema:
-                $ref: "./openapi.yaml#/components/schemas/ErrorModel"
+                $ref: "../openapi.yaml#/components/schemas/ErrorModel"
               examples:
                 NotFoundException:
                   $ref: "#/components/examples/IdpNotFoundException"
         "5xx":
-          $ref: "./openapi.yaml#/components/responses/ServerErrorResponse"
+          $ref: "../openapi.yaml#/components/responses/ServerErrorResponse"
 
     put:
       tags:
@@ -123,7 +123,7 @@ paths:
                 IdpUserResponse:
                   $ref: "#/components/examples/IdpUserResponse"
         "400":
-          $ref: "./openapi.yaml#/components/responses/BadRequestErrorResponse"
+          $ref: "../openapi.yaml#/components/responses/BadRequestErrorResponse"
         "403":
           $ref: "#/components/responses/IdpForbiddenErrorResponse"
         "404":
@@ -131,12 +131,12 @@ paths:
           content:
             application/vnd.gravitino.v1+json:
               schema:
-                $ref: "./openapi.yaml#/components/schemas/ErrorModel"
+                $ref: "../openapi.yaml#/components/schemas/ErrorModel"
               examples:
                 NotFoundException:
                   $ref: "#/components/examples/IdpNotFoundException"
         "5xx":
-          $ref: "./openapi.yaml#/components/responses/ServerErrorResponse"
+          $ref: "../openapi.yaml#/components/responses/ServerErrorResponse"
 
     delete:
       tags:
@@ -145,9 +145,9 @@ paths:
       operationId: removeIdpUser
       responses:
         "200":
-          $ref: "./openapi.yaml#/components/responses/RemoveResponse"
+          $ref: "../openapi.yaml#/components/responses/RemoveResponse"
         "400":
-          $ref: "./openapi.yaml#/components/responses/BadRequestErrorResponse"
+          $ref: "../openapi.yaml#/components/responses/BadRequestErrorResponse"
         "403":
           $ref: "#/components/responses/IdpForbiddenErrorResponse"
         "404":
@@ -155,12 +155,12 @@ paths:
           content:
             application/vnd.gravitino.v1+json:
               schema:
-                $ref: "./openapi.yaml#/components/schemas/ErrorModel"
+                $ref: "../openapi.yaml#/components/schemas/ErrorModel"
               examples:
                 NotFoundException:
                   $ref: "#/components/examples/IdpNotFoundException"
         "5xx":
-          $ref: "./openapi.yaml#/components/responses/ServerErrorResponse"
+          $ref: "../openapi.yaml#/components/responses/ServerErrorResponse"
 
   /idp/groups:
     post:
@@ -189,7 +189,7 @@ paths:
                 IdpGroupResponse:
                   $ref: "#/components/examples/IdpGroupResponse"
         "400":
-          $ref: "./openapi.yaml#/components/responses/BadRequestErrorResponse"
+          $ref: "../openapi.yaml#/components/responses/BadRequestErrorResponse"
         "403":
           $ref: "#/components/responses/IdpForbiddenErrorResponse"
         "409":
@@ -197,16 +197,16 @@ paths:
           content:
             application/vnd.gravitino.v1+json:
               schema:
-                $ref: "./openapi.yaml#/components/schemas/ErrorModel"
+                $ref: "../openapi.yaml#/components/schemas/ErrorModel"
               examples:
                 AlreadyExistsException:
                   $ref: "#/components/examples/IdpAlreadyExistsException"
         "5xx":
-          $ref: "./openapi.yaml#/components/responses/ServerErrorResponse"
+          $ref: "../openapi.yaml#/components/responses/ServerErrorResponse"
 
   /idp/groups/{group}:
     parameters:
-      - $ref: "./openapi.yaml#/components/parameters/group"
+      - $ref: "../openapi.yaml#/components/parameters/group"
 
     get:
       tags:
@@ -231,12 +231,12 @@ paths:
           content:
             application/vnd.gravitino.v1+json:
               schema:
-                $ref: "./openapi.yaml#/components/schemas/ErrorModel"
+                $ref: "../openapi.yaml#/components/schemas/ErrorModel"
               examples:
                 NotFoundException:
                   $ref: "#/components/examples/IdpNotFoundException"
         "5xx":
-          $ref: "./openapi.yaml#/components/responses/ServerErrorResponse"
+          $ref: "../openapi.yaml#/components/responses/ServerErrorResponse"
 
     delete:
       tags:
@@ -244,12 +244,12 @@ paths:
       summary: Remove built-in IDP group
       operationId: removeIdpGroup
       parameters:
-        - $ref: "./openapi.yaml#/components/parameters/force"
+        - $ref: "../openapi.yaml#/components/parameters/force"
       responses:
         "200":
-          $ref: "./openapi.yaml#/components/responses/RemoveResponse"
+          $ref: "../openapi.yaml#/components/responses/RemoveResponse"
         "400":
-          $ref: "./openapi.yaml#/components/responses/BadRequestErrorResponse"
+          $ref: "../openapi.yaml#/components/responses/BadRequestErrorResponse"
         "403":
           $ref: "#/components/responses/IdpForbiddenErrorResponse"
         "404":
@@ -257,16 +257,16 @@ paths:
           content:
             application/vnd.gravitino.v1+json:
               schema:
-                $ref: "./openapi.yaml#/components/schemas/ErrorModel"
+                $ref: "../openapi.yaml#/components/schemas/ErrorModel"
               examples:
                 NotFoundException:
                   $ref: "#/components/examples/IdpNotFoundException"
         "5xx":
-          $ref: "./openapi.yaml#/components/responses/ServerErrorResponse"
+          $ref: "../openapi.yaml#/components/responses/ServerErrorResponse"
 
   /idp/groups/{group}/users:
     parameters:
-      - $ref: "./openapi.yaml#/components/parameters/group"
+      - $ref: "../openapi.yaml#/components/parameters/group"
 
     put:
       tags:
@@ -296,7 +296,7 @@ paths:
                 IdpGroupResponse:
                   $ref: "#/components/examples/IdpGroupResponse"
         "400":
-          $ref: "./openapi.yaml#/components/responses/BadRequestErrorResponse"
+          $ref: "../openapi.yaml#/components/responses/BadRequestErrorResponse"
         "403":
           $ref: "#/components/responses/IdpForbiddenErrorResponse"
         "404":
@@ -304,12 +304,12 @@ paths:
           content:
             application/vnd.gravitino.v1+json:
               schema:
-                $ref: "./openapi.yaml#/components/schemas/ErrorModel"
+                $ref: "../openapi.yaml#/components/schemas/ErrorModel"
               examples:
                 NotFoundException:
                   $ref: "#/components/examples/IdpNotFoundException"
         "5xx":
-          $ref: "./openapi.yaml#/components/responses/ServerErrorResponse"
+          $ref: "../openapi.yaml#/components/responses/ServerErrorResponse"
 
 components:
   schemas:
@@ -422,7 +422,7 @@ components:
       content:
         application/vnd.gravitino.v1+json:
           schema:
-            $ref: "./openapi.yaml#/components/schemas/ErrorModel"
+            $ref: "../openapi.yaml#/components/schemas/ErrorModel"
 
   examples:
     AddUserRequest:

--- a/docs/open-api/idp/idp.yaml
+++ b/docs/open-api/idp/idp.yaml
@@ -48,7 +48,7 @@ paths:
                 IdpUserResponse:
                   $ref: "#/components/examples/IdpUserResponse"
         "400":
-          $ref: "../openapi.yaml#/components/responses/BadRequestErrorResponse"
+          $ref: "./openapi.yaml#/components/responses/BadRequestErrorResponse"
         "403":
           $ref: "#/components/responses/IdpForbiddenErrorResponse"
         "409":
@@ -56,16 +56,16 @@ paths:
           content:
             application/vnd.gravitino.v1+json:
               schema:
-                $ref: "../openapi.yaml#/components/schemas/ErrorModel"
+                $ref: "./openapi.yaml#/components/schemas/ErrorModel"
               examples:
                 AlreadyExistsException:
                   $ref: "#/components/examples/IdpAlreadyExistsException"
         "5xx":
-          $ref: "../openapi.yaml#/components/responses/ServerErrorResponse"
+          $ref: "./openapi.yaml#/components/responses/ServerErrorResponse"
 
   /idp/users/{user}:
     parameters:
-      - $ref: "../openapi.yaml#/components/parameters/user"
+      - $ref: "./openapi.yaml#/components/parameters/user"
 
     get:
       tags:
@@ -90,12 +90,12 @@ paths:
           content:
             application/vnd.gravitino.v1+json:
               schema:
-                $ref: "../openapi.yaml#/components/schemas/ErrorModel"
+                $ref: "./openapi.yaml#/components/schemas/ErrorModel"
               examples:
                 NotFoundException:
                   $ref: "#/components/examples/IdpNotFoundException"
         "5xx":
-          $ref: "../openapi.yaml#/components/responses/ServerErrorResponse"
+          $ref: "./openapi.yaml#/components/responses/ServerErrorResponse"
 
     put:
       tags:
@@ -123,7 +123,7 @@ paths:
                 IdpUserResponse:
                   $ref: "#/components/examples/IdpUserResponse"
         "400":
-          $ref: "../openapi.yaml#/components/responses/BadRequestErrorResponse"
+          $ref: "./openapi.yaml#/components/responses/BadRequestErrorResponse"
         "403":
           $ref: "#/components/responses/IdpForbiddenErrorResponse"
         "404":
@@ -131,12 +131,12 @@ paths:
           content:
             application/vnd.gravitino.v1+json:
               schema:
-                $ref: "../openapi.yaml#/components/schemas/ErrorModel"
+                $ref: "./openapi.yaml#/components/schemas/ErrorModel"
               examples:
                 NotFoundException:
                   $ref: "#/components/examples/IdpNotFoundException"
         "5xx":
-          $ref: "../openapi.yaml#/components/responses/ServerErrorResponse"
+          $ref: "./openapi.yaml#/components/responses/ServerErrorResponse"
 
     delete:
       tags:
@@ -145,9 +145,9 @@ paths:
       operationId: removeIdpUser
       responses:
         "200":
-          $ref: "../openapi.yaml#/components/responses/RemoveResponse"
+          $ref: "./openapi.yaml#/components/responses/RemoveResponse"
         "400":
-          $ref: "../openapi.yaml#/components/responses/BadRequestErrorResponse"
+          $ref: "./openapi.yaml#/components/responses/BadRequestErrorResponse"
         "403":
           $ref: "#/components/responses/IdpForbiddenErrorResponse"
         "404":
@@ -155,12 +155,12 @@ paths:
           content:
             application/vnd.gravitino.v1+json:
               schema:
-                $ref: "../openapi.yaml#/components/schemas/ErrorModel"
+                $ref: "./openapi.yaml#/components/schemas/ErrorModel"
               examples:
                 NotFoundException:
                   $ref: "#/components/examples/IdpNotFoundException"
         "5xx":
-          $ref: "../openapi.yaml#/components/responses/ServerErrorResponse"
+          $ref: "./openapi.yaml#/components/responses/ServerErrorResponse"
 
   /idp/groups:
     post:
@@ -189,7 +189,7 @@ paths:
                 IdpGroupResponse:
                   $ref: "#/components/examples/IdpGroupResponse"
         "400":
-          $ref: "../openapi.yaml#/components/responses/BadRequestErrorResponse"
+          $ref: "./openapi.yaml#/components/responses/BadRequestErrorResponse"
         "403":
           $ref: "#/components/responses/IdpForbiddenErrorResponse"
         "409":
@@ -197,16 +197,16 @@ paths:
           content:
             application/vnd.gravitino.v1+json:
               schema:
-                $ref: "../openapi.yaml#/components/schemas/ErrorModel"
+                $ref: "./openapi.yaml#/components/schemas/ErrorModel"
               examples:
                 AlreadyExistsException:
                   $ref: "#/components/examples/IdpAlreadyExistsException"
         "5xx":
-          $ref: "../openapi.yaml#/components/responses/ServerErrorResponse"
+          $ref: "./openapi.yaml#/components/responses/ServerErrorResponse"
 
   /idp/groups/{group}:
     parameters:
-      - $ref: "../openapi.yaml#/components/parameters/group"
+      - $ref: "./openapi.yaml#/components/parameters/group"
 
     get:
       tags:
@@ -231,12 +231,12 @@ paths:
           content:
             application/vnd.gravitino.v1+json:
               schema:
-                $ref: "../openapi.yaml#/components/schemas/ErrorModel"
+                $ref: "./openapi.yaml#/components/schemas/ErrorModel"
               examples:
                 NotFoundException:
                   $ref: "#/components/examples/IdpNotFoundException"
         "5xx":
-          $ref: "../openapi.yaml#/components/responses/ServerErrorResponse"
+          $ref: "./openapi.yaml#/components/responses/ServerErrorResponse"
 
     delete:
       tags:
@@ -244,12 +244,12 @@ paths:
       summary: Remove built-in IdP group
       operationId: removeIdpGroup
       parameters:
-        - $ref: "../openapi.yaml#/components/parameters/force"
+        - $ref: "./openapi.yaml#/components/parameters/force"
       responses:
         "200":
-          $ref: "../openapi.yaml#/components/responses/RemoveResponse"
+          $ref: "./openapi.yaml#/components/responses/RemoveResponse"
         "400":
-          $ref: "../openapi.yaml#/components/responses/BadRequestErrorResponse"
+          $ref: "./openapi.yaml#/components/responses/BadRequestErrorResponse"
         "403":
           $ref: "#/components/responses/IdpForbiddenErrorResponse"
         "404":
@@ -257,16 +257,16 @@ paths:
           content:
             application/vnd.gravitino.v1+json:
               schema:
-                $ref: "../openapi.yaml#/components/schemas/ErrorModel"
+                $ref: "./openapi.yaml#/components/schemas/ErrorModel"
               examples:
                 NotFoundException:
                   $ref: "#/components/examples/IdpNotFoundException"
         "5xx":
-          $ref: "../openapi.yaml#/components/responses/ServerErrorResponse"
+          $ref: "./openapi.yaml#/components/responses/ServerErrorResponse"
 
   /idp/groups/{group}/users:
     parameters:
-      - $ref: "../openapi.yaml#/components/parameters/group"
+      - $ref: "./openapi.yaml#/components/parameters/group"
 
     put:
       tags:
@@ -296,7 +296,7 @@ paths:
                 IdpGroupResponse:
                   $ref: "#/components/examples/IdpGroupResponse"
         "400":
-          $ref: "../openapi.yaml#/components/responses/BadRequestErrorResponse"
+          $ref: "./openapi.yaml#/components/responses/BadRequestErrorResponse"
         "403":
           $ref: "#/components/responses/IdpForbiddenErrorResponse"
         "404":
@@ -304,12 +304,12 @@ paths:
           content:
             application/vnd.gravitino.v1+json:
               schema:
-                $ref: "../openapi.yaml#/components/schemas/ErrorModel"
+                $ref: "./openapi.yaml#/components/schemas/ErrorModel"
               examples:
                 NotFoundException:
                   $ref: "#/components/examples/IdpNotFoundException"
         "5xx":
-          $ref: "../openapi.yaml#/components/responses/ServerErrorResponse"
+          $ref: "./openapi.yaml#/components/responses/ServerErrorResponse"
 
 components:
   schemas:
@@ -422,7 +422,7 @@ components:
       content:
         application/vnd.gravitino.v1+json:
           schema:
-            $ref: "../openapi.yaml#/components/schemas/ErrorModel"
+            $ref: "./openapi.yaml#/components/schemas/ErrorModel"
 
   examples:
     AddUserRequest:

--- a/docs/open-api/idp/openapi.yaml
+++ b/docs/open-api/idp/openapi.yaml
@@ -65,8 +65,116 @@ paths:
     $ref: "./idp.yaml#/paths/~1idp~1groups~1%7Bgroup%7D~1users"
 
 components:
+  schemas:
+    ErrorModel:
+      type: object
+      description: JSON error payload returned in a response with further details on the error
+      required:
+        - message
+        - type
+        - code
+      properties:
+        code:
+          type: integer
+          minimum: 1000
+          maximum: 1100
+          description: HTTP response code
+          example: 1002
+        type:
+          type: string
+          description: Internal type definition of the error
+        message:
+          type: string
+          description: A human-readable message
+        stack:
+          type: array
+          items:
+            type: string
+
+  responses:
+    BadRequestErrorResponse:
+      description:
+        Indicates a bad request error. It could be caused by an unexpected request
+        body format or other forms of request validation failure, such as invalid json.
+      content:
+        application/vnd.gravitino.v1+json:
+          schema:
+            $ref: "#/components/schemas/ErrorModel"
+          example: {
+            "code": 1003,
+            "type": "BadRequestException",
+            "message": "Malformed request"
+          }
+
+    ServerErrorResponse:
+      description:
+        A server-side problem that might not be addressable from the client side.
+      content:
+        application/vnd.gravitino.v1+json:
+          schema:
+            $ref: "#/components/schemas/ErrorModel"
+          example: {
+            "code": 1002,
+            "type": "RuntimeException",
+            "message": "Internal Server Error",
+            "stack": [
+              "java.lang.RuntimeException: Internal Server Error"
+            ]
+          }
+
+    RemoveResponse:
+      description: Represents a response for a remove operation
+      content:
+        application/vnd.gravitino.v1+json:
+          schema:
+            type: object
+            properties:
+              code:
+                type: integer
+                format: int32
+                description: Status code of the response
+                enum:
+                  - 0
+              removed:
+                type: boolean
+                description: Whether the remove operation was successful
+
+  parameters:
+    user:
+      name: user
+      in: path
+      description: The username of the built-in IdP user
+      required: true
+      schema:
+        type: string
+
+    group:
+      name: group
+      in: path
+      description: The name of the built-in IdP group
+      required: true
+      schema:
+        type: string
+
+    force:
+      name: force
+      in: query
+      description: Force the operation to be executed
+      required: false
+      schema:
+        type: boolean
+        default: false
+
   securitySchemes:
     OAuth2WithJWT:
-      $ref: "../openapi.yaml#/components/securitySchemes/OAuth2WithJWT"
+      type: oauth2
+      description: OAuth2 with JWT
+      flows:
+        clientCredentials:
+          tokenUrl: https://external-oauth-server.com/token
+          scopes:
+            serviceAudience: The audience name when Gravitino uses OAuth as the authenticator.
+
     BasicAuth:
-      $ref: "../openapi.yaml#/components/securitySchemes/BasicAuth"
+      type: http
+      scheme: basic

--- a/docs/open-api/idp/openapi.yaml
+++ b/docs/open-api/idp/openapi.yaml
@@ -70,77 +70,15 @@ paths:
 components:
   schemas:
     ErrorModel:
-      type: object
-      description: JSON error payload returned in a response with further details on the error
-      required:
-        - message
-        - type
-        - code
-      properties:
-        code:
-          type: integer
-          minimum: 1000
-          maximum: 1100
-          description: HTTP response code
-          example: 1002
-        type:
-          type: string
-          description: Internal type definition of the error
-        message:
-          type: string
-          description: A human-readable message
-        stack:
-          type: array
-          items:
-            type: string
+      $ref: "../openapi.yaml#/components/schemas/ErrorModel"
 
   responses:
     BadRequestErrorResponse:
-      description:
-        Indicates a bad request error. It could be caused by an unexpected request
-        body format or other forms of request validation failure, such as invalid json.
-      content:
-        application/vnd.gravitino.v1+json:
-          schema:
-            $ref: "#/components/schemas/ErrorModel"
-          example: {
-            "code": 1003,
-            "type": "BadRequestException",
-            "message": "Malformed request"
-          }
-
+      $ref: "../openapi.yaml#/components/responses/BadRequestErrorResponse"
     ServerErrorResponse:
-      description:
-        A server-side problem that might not be addressable from the client side.
-      content:
-        application/vnd.gravitino.v1+json:
-          schema:
-            $ref: "#/components/schemas/ErrorModel"
-          example: {
-            "code": 1002,
-            "type": "RuntimeException",
-            "message": "Internal Server Error",
-            "stack": [
-              "java.lang.RuntimeException: Internal Server Error"
-            ]
-          }
-
+      $ref: "../openapi.yaml#/components/responses/ServerErrorResponse"
     RemoveResponse:
-      description: Represents a response for a remove operation
-      content:
-        application/vnd.gravitino.v1+json:
-          schema:
-            type: object
-            properties:
-              code:
-                type: integer
-                format: int32
-                description: Status code of the response
-                enum:
-                  - 0
-              removed:
-                type: boolean
-                description: Whether the remove operation was successful
+      $ref: "../openapi.yaml#/components/responses/RemoveResponse"
 
   parameters:
     user:
@@ -152,5 +90,4 @@ components:
 
   securitySchemes:
     BasicAuth:
-      type: http
-      scheme: basic
+      $ref: "../openapi.yaml#/components/securitySchemes/BasicAuth"

--- a/docs/open-api/idp/openapi.yaml
+++ b/docs/open-api/idp/openapi.yaml
@@ -18,14 +18,18 @@
 ---
 openapi: 3.0.3
 info:
-  title: Gravitino Built-in IdP REST API
+  title: Gravitino Built-in IDP REST API
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
   version: 1.3.0-SNAPSHOT
   description: |
-    OpenAPI specification for built-in IdP user and group management APIs exposed
+    OpenAPI specification for built-in IDP user and group management APIs exposed
     by the `idp-basic` plugin when the `basic` authenticator is enabled.
+
+    These APIs are available only with the `basic` authenticator. They are not
+    available when Gravitino is configured with OAuth-only authentication. Callers
+    must authenticate with HTTP Basic Auth and be listed in `gravitino.authorization.serviceAdmins`.
 
 servers:
   - url: "{scheme}://{host}:{port}/{basePath}"
@@ -45,7 +49,6 @@ servers:
         default: "api"
 
 security:
-  - OAuth2WithJWT: [serviceAudience]
   - BasicAuth: []
 
 paths:
@@ -141,40 +144,13 @@ components:
 
   parameters:
     user:
-      name: user
-      in: path
-      description: The username of the built-in IdP user
-      required: true
-      schema:
-        type: string
-
+      $ref: "../openapi.yaml#/components/parameters/user"
     group:
-      name: group
-      in: path
-      description: The name of the built-in IdP group
-      required: true
-      schema:
-        type: string
-
+      $ref: "../openapi.yaml#/components/parameters/group"
     force:
-      name: force
-      in: query
-      description: Force the operation to be executed
-      required: false
-      schema:
-        type: boolean
-        default: false
+      $ref: "../openapi.yaml#/components/parameters/force"
 
   securitySchemes:
-    OAuth2WithJWT:
-      type: oauth2
-      description: OAuth2 with JWT
-      flows:
-        clientCredentials:
-          tokenUrl: https://external-oauth-server.com/token
-          scopes:
-            serviceAudience: The audience name when Gravitino uses OAuth as the authenticator.
-
     BasicAuth:
       type: http
       scheme: basic

--- a/docs/open-api/idp/openapi.yaml
+++ b/docs/open-api/idp/openapi.yaml
@@ -1,0 +1,72 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+---
+openapi: 3.0.3
+info:
+  title: Gravitino Built-in IdP REST API
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0.html
+  version: 1.3.0-SNAPSHOT
+  description: |
+    OpenAPI specification for built-in IdP user and group management APIs exposed
+    by the `idp-basic` plugin when the `basic` authenticator is enabled.
+
+servers:
+  - url: "{scheme}://{host}:{port}/{basePath}"
+    description: Generic base server URL, with all parts configurable.
+    variables:
+      scheme:
+        description: The scheme of the URI, either http or https.
+        default: http
+      host:
+        description: The host address for the specified server
+        default: localhost
+      port:
+        description: The port used when addressing the host
+        default: "8090"
+      basePath:
+        description: Optional prefix to be appended to all routes
+        default: "api"
+
+security:
+  - OAuth2WithJWT: [serviceAudience]
+  - BasicAuth: []
+
+paths:
+  /idp/users:
+    $ref: "./idp.yaml#/paths/~1idp~1users"
+
+  /idp/users/{user}:
+    $ref: "./idp.yaml#/paths/~1idp~1users~1%7Buser%7D"
+
+  /idp/groups:
+    $ref: "./idp.yaml#/paths/~1idp~1groups"
+
+  /idp/groups/{group}:
+    $ref: "./idp.yaml#/paths/~1idp~1groups~1%7Bgroup%7D"
+
+  /idp/groups/{group}/users:
+    $ref: "./idp.yaml#/paths/~1idp~1groups~1%7Bgroup%7D~1users"
+
+components:
+  securitySchemes:
+    OAuth2WithJWT:
+      $ref: "../openapi.yaml#/components/securitySchemes/OAuth2WithJWT"
+    BasicAuth:
+      $ref: "../openapi.yaml#/components/securitySchemes/BasicAuth"

--- a/docs/open-api/idp/openapi.yaml
+++ b/docs/open-api/idp/openapi.yaml
@@ -27,10 +27,6 @@ info:
     OpenAPI specification for built-in IDP user and group management APIs exposed
     by the `idp-basic` plugin when the `basic` authenticator is enabled.
 
-    These APIs are available only with the `basic` authenticator. They are not
-    available when Gravitino is configured with OAuth-only authentication. Callers
-    must authenticate with HTTP Basic Auth and be listed in `gravitino.authorization.serviceAdmins`.
-
 servers:
   - url: "{scheme}://{host}:{port}/{basePath}"
     description: Generic base server URL, with all parts configurable.

--- a/docs/open-api/idp/openapi.yaml
+++ b/docs/open-api/idp/openapi.yaml
@@ -68,26 +68,6 @@ paths:
     $ref: "./idp.yaml#/paths/~1idp~1groups~1%7Bgroup%7D~1users"
 
 components:
-  schemas:
-    ErrorModel:
-      $ref: "../openapi.yaml#/components/schemas/ErrorModel"
-
-  responses:
-    BadRequestErrorResponse:
-      $ref: "../openapi.yaml#/components/responses/BadRequestErrorResponse"
-    ServerErrorResponse:
-      $ref: "../openapi.yaml#/components/responses/ServerErrorResponse"
-    RemoveResponse:
-      $ref: "../openapi.yaml#/components/responses/RemoveResponse"
-
-  parameters:
-    user:
-      $ref: "../openapi.yaml#/components/parameters/user"
-    group:
-      $ref: "../openapi.yaml#/components/parameters/group"
-    force:
-      $ref: "../openapi.yaml#/components/parameters/force"
-
   securitySchemes:
     BasicAuth:
       $ref: "../openapi.yaml#/components/securitySchemes/BasicAuth"

--- a/docs/open-api/openapi.yaml
+++ b/docs/open-api/openapi.yaml
@@ -242,6 +242,21 @@ paths:
   /authn/me:
     $ref: "./authn.yaml#/paths/~1authn~1me"
 
+  /idp/users:
+    $ref: "./idp/idp.yaml#/paths/~1idp~1users"
+
+  /idp/users/{user}:
+    $ref: "./idp/idp.yaml#/paths/~1idp~1users~1%7Buser%7D"
+
+  /idp/groups:
+    $ref: "./idp/idp.yaml#/paths/~1idp~1groups"
+
+  /idp/groups/{group}:
+    $ref: "./idp/idp.yaml#/paths/~1idp~1groups~1%7Bgroup%7D"
+
+  /idp/groups/{group}/users:
+    $ref: "./idp/idp.yaml#/paths/~1idp~1groups~1%7Bgroup%7D~1users"
+
 components:
 
   schemas:

--- a/docs/open-api/openapi.yaml
+++ b/docs/open-api/openapi.yaml
@@ -242,21 +242,6 @@ paths:
   /authn/me:
     $ref: "./authn.yaml#/paths/~1authn~1me"
 
-  /idp/users:
-    $ref: "./idp/idp.yaml#/paths/~1idp~1users"
-
-  /idp/users/{user}:
-    $ref: "./idp/idp.yaml#/paths/~1idp~1users~1%7Buser%7D"
-
-  /idp/groups:
-    $ref: "./idp/idp.yaml#/paths/~1idp~1groups"
-
-  /idp/groups/{group}:
-    $ref: "./idp/idp.yaml#/paths/~1idp~1groups~1%7Bgroup%7D"
-
-  /idp/groups/{group}/users:
-    $ref: "./idp/idp.yaml#/paths/~1idp~1groups~1%7Bgroup%7D~1users"
-
 components:
 
   schemas:


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add OpenAPI documentation for built-in IDP REST APIs exposed by the `idp-basic` plugin (when the `basic` authenticator is enabled):

- **`docs/open-api/idp/openapi.yaml`** — standalone entry spec (info, servers, security, path refs)
- **`docs/open-api/idp/idp.yaml`** — IdP paths, request/response schemas, and examples
- **`docs/build.gradle.kts`** — add `lintIdpOpenAPI` and run it in `docs:build` alongside the existing main spec lint

Documented endpoints:

| Method | Path | Description |
|--------|------|-------------|
| POST | `/idp/users` | Add IDP user |
| GET | `/idp/users/{user}` | Get IDP user |
| PUT | `/idp/users/{user}` | Change password |
| DELETE | `/idp/users/{user}` | Remove IDP user |
| POST | `/idp/groups` | Add IDP group |
| GET | `/idp/groups/{group}` | Get IDP group |
| DELETE | `/idp/groups/{group}` | Remove IDP group (`force` query) |
| PUT | `/idp/groups/{group}/users` | Change group membership (`usersToAdd` / `usersToRemove`) |

Shared components (`ErrorModel`, common error responses, path parameters, `BasicAuth`) are referenced from `docs/open-api/openapi.yaml` where applicable. IdP-specific payloads live under `components/schemas` in `idp.yaml`.

**Note:** IdP paths are **not** registered in the main `docs/open-api/openapi.yaml`; they are validated via the dedicated `idp/openapi.yaml` entry (see `lintIdpOpenAPI`).

### Why are the changes needed?

IdP REST endpoints are implemented but were missing from published OpenAPI documentation, making discovery and review harder for clients and contributors.

Fix: #11259

### Does this PR introduce _any_ user-facing change?

No runtime behavior change. Documentation-only: adds OpenAPI descriptions for existing IdP REST APIs.

### How was this patch tested?

```bash
./gradlew :docs:build
```

This runs Redocly lint (`recommended-strict`) for both:

- `docs/open-api/openapi.yaml`
- `docs/open-api/idp/openapi.yaml`