### PR TITLE
feat(helm): cleanups for chart

### DIFF
--- a/dev/charts/gravitino/resources/config/gravitino.conf
+++ b/dev/charts/gravitino/resources/config/gravitino.conf
@@ -48,6 +48,20 @@ gravitino.entity.store.relational.jdbcDriver = {{ if .Values.mysql.enabled }}com
 gravitino.entity.store.relational.jdbcUser = {{ if .Values.mysql.enabled }}{{ .Values.mysql.auth.username }}{{ else if .Values.postgresql.enabled }}{{ .Values.postgresql.auth.username }}{{ else }}{{ .Values.entity.jdbcUser }}{{ end }}
 gravitino.entity.store.relational.jdbcPassword = {{ if .Values.mysql.enabled }}{{ .Values.mysql.auth.password }}{{ else if .Values.postgresql.enabled }}{{ .Values.postgresql.auth.password }}{{ else }}{{ .Values.entity.jdbcPassword }}{{ end }}
 gravitino.entity.store.relational.storagePath = {{ .Values.entity.storagePath }}
+{{- if .Values.entity.maxConnections }}
+gravitino.entity.store.relational.maxConnections = {{ .Values.entity.maxConnections }}
+{{- end }}
+
+{{- if or .Values.lock.maxNodes .Values.lock.minNodes }}
+
+# THE CONFIGURATION FOR Gravitino TREE LOCK
+{{- if .Values.lock.maxNodes }}
+gravitino.lock.maxNodes = {{ .Values.lock.maxNodes }}
+{{- end }}
+{{- if .Values.lock.minNodes }}
+gravitino.lock.minNodes = {{ .Values.lock.minNodes }}
+{{- end }}
+{{- end }}
 
 # THE CONFIGURATION FOR Gravitino CATALOG
 gravitino.catalog.cache.evictionIntervalMs = {{ if .Values.catalog.evictionIntervalMs }}{{ .Values.catalog.evictionIntervalMs }}{{ else }}3600000{{ end }}
@@ -165,9 +179,15 @@ gravitino.iceberg-rest.azure-client-secret = {{.Values.icebergRest.azure.clientS
 gravitino.iceberg-rest.catalog-config-provider = {{ .Values.icebergRest.catalogConfigProvider }}
 {{- end }}
 {{- if .Values.icebergRest.dynamicConfigProvider }}
+{{- if .Values.icebergRest.dynamicConfigProvider.uri }}
 gravitino.iceberg-rest.gravitino-uri = {{ .Values.icebergRest.dynamicConfigProvider.uri }}
+{{- end }}
+{{- if .Values.icebergRest.dynamicConfigProvider.metalake }}
 gravitino.iceberg-rest.gravitino-metalake = {{ .Values.icebergRest.dynamicConfigProvider.metalake }}
+{{- end }}
+{{- if .Values.icebergRest.dynamicConfigProvider.defaultCatalogName }}
 gravitino.iceberg-rest.default-catalog-name = {{ .Values.icebergRest.dynamicConfigProvider.defaultCatalogName }}
+{{- end }}
 {{- end }}
 
 # Audit log configuration

--- a/dev/charts/gravitino/resources/scenarios/ci-values.yaml
+++ b/dev/charts/gravitino/resources/scenarios/ci-values.yaml
@@ -19,17 +19,16 @@
 mysql:
   enabled: true
 
-visibleConfigs: "gravitino.datastrato.custom.authorization.ranger.admin.url,gravitino.datastrato.custom.authorization.ranger.username,gravitino.datastrato.custom.authorization.ranger.password,gravitino.datastrato.custom.authorization.ranger.auth.type"
+visibleConfigs: "gravitino.custom.example.url,gravitino.custom.example.username,gravitino.custom.example.password,gravitino.custom.example.auth.type"
 
 visibleConfigsItems:
-  gravitino.datastrato.custom.authorization.ranger.admin.url: "http://ranger:6080"
-  gravitino.datastrato.custom.authorization.ranger.username: admin
-  gravitino.datastrato.custom.authorization.ranger.password: "rangerR0cks!"
-  gravitino.datastrato.custom.authorization.ranger.auth.type: simple
+  gravitino.custom.example.url: "http://example:6080"
+  gravitino.custom.example.username: admin
+  gravitino.custom.example.password: "exampleR0cks!"
+  gravitino.custom.example.auth.type: simple
 
 additionalConfigItems:
-  gravitino.testAdditionalConfigItems.names: audit,sync
-  gravitino.testAdditionalConfigItems.names.test: test
+  gravitino.eventListener.names: "audit,sync"
 
 extraVolumeMounts:
   - name: gravitino-log

--- a/dev/charts/gravitino/resources/scenarios/dev-values.yaml
+++ b/dev/charts/gravitino/resources/scenarios/dev-values.yaml
@@ -1,0 +1,42 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# Dev scenario for the Apache Gravitino Helm chart.
+#
+# Mirrors the development sample gravitino.conf in
+# docs/gravitino-server-config.md#development.
+#
+# Defaults from the chart's values.yaml are appropriate for local
+# development with the embedded H2 metadata backend. This file opts in
+# to the Iceberg REST server in auxiliary mode with the dynamic config
+# provider so the IRC server federates the local Gravitino metalake.
+#
+# Authentication remains the default "simple" mode (anonymous user).
+# To enable OAuth or Kerberos, see prod-values.yaml or the canonical
+# samples in docs/gravitino-server-config.md.
+#
+# Apply with:
+#   helm install gravitino oci://registry-1.docker.io/apache/gravitino-helm \
+#     --version <VERSION> -n gravitino --create-namespace \
+#     -f https://raw.githubusercontent.com/apache/gravitino/main/dev/charts/gravitino/resources/scenarios/dev-values.yaml
+
+icebergRest:
+  catalogConfigProvider: dynamic-config-provider
+  dynamicConfigProvider:
+    metalake: test

--- a/dev/charts/gravitino/resources/scenarios/prod-values.yaml
+++ b/dev/charts/gravitino/resources/scenarios/prod-values.yaml
@@ -1,0 +1,93 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# Production scenario for the Apache Gravitino Helm chart.
+#
+# Mirrors the production sample gravitino.conf in
+# docs/gravitino-server-config.md#production.
+#
+# Configures externally managed MySQL as the metadata backend, larger
+# cache and tree-lock limits, audit logging, the Iceberg REST server
+# in auxiliary mode with the dynamic config provider, and OAuth 2.0
+# OIDC authentication with JWKS-based token validation.
+#
+# Placeholders use the convention <placeholder-name>. Fill in your own
+# values for the JDBC URL/user/password, OIDC tenant ID, client ID,
+# and service audience before applying this file. Sensitive values
+# (JDBC password, OAuth client secret) should be sourced from a
+# Kubernetes Secret rather than embedded as plaintext; the Secret-
+# reference mechanism is tracked separately in the chart's enterprise
+# readiness work.
+#
+# Initialize the MySQL metadata backend before installing. See
+# docs/how-to-use-relational-backend-storage.md for setup steps and
+# SQL scripts.
+#
+# Apply with:
+#   curl -O https://raw.githubusercontent.com/apache/gravitino/main/dev/charts/gravitino/resources/scenarios/prod-values.yaml
+#   # edit placeholders below to fill in your environment
+#   helm install gravitino oci://registry-1.docker.io/apache/gravitino-helm \
+#     --version <VERSION> -n gravitino --create-namespace -f prod-values.yaml
+
+# Externally managed MySQL metadata backend.
+# Leave mysql.enabled and postgresql.enabled at their defaults (false)
+# so the chart does not deploy an in-cluster database. Provide the
+# external JDBC URL directly.
+entity:
+  jdbcUrl: jdbc:mysql://<your-mysql-host>:3306/<your-database>
+  jdbcDriver: com.mysql.cj.jdbc.Driver
+  jdbcUser: <your-mysql-user>
+  jdbcPassword: <your-mysql-password>
+  maxConnections: 200
+
+# Tree-lock tuning for production load.
+lock:
+  maxNodes: 500000
+  minNodes: 5000
+
+# Cache tuning for production load.
+cache:
+  maxEntries: 100000
+  enableStats: true
+
+# Audit logging.
+audit:
+  enabled: true
+
+# Iceberg REST server in auxiliary mode with shared Gravitino catalogs.
+icebergRest:
+  catalogConfigProvider: dynamic-config-provider
+  dynamicConfigProvider:
+    metalake: production
+
+# OAuth 2.0 / OIDC authentication with JWKS-based token validation.
+# Example values shown for Azure AD; substitute your identity provider's
+# URLs and identifiers. For Kerberos, simple auth, or static-key OAuth,
+# see the Authentication section of gravitino-server-config.md.
+authenticators: oauth
+authenticator:
+  oauth:
+    provider: oidc
+    tokenValidatorClass: org.apache.gravitino.server.authentication.JwksTokenValidator
+    authority: https://login.microsoftonline.com/<your-tenant-id>/v2.0
+    jwksUri: https://login.microsoftonline.com/<your-tenant-id>/discovery/v2.0/keys
+    clientId: <your-app-client-id>
+    serviceAudience: <your-app-client-id-or-api-identifier>
+    scope: openid profile email
+    principalFields: preferred_username,email,sub

--- a/dev/charts/gravitino/templates/NOTES.txt
+++ b/dev/charts/gravitino/templates/NOTES.txt
@@ -16,10 +16,72 @@
   specific language governing permissions and limitations
   under the License.
   */}}
-🚀 {{ $.Chart.Name }} has been installed. Check its status by running:
+🚀 Apache Gravitino has been installed in namespace {{ include "gravitino.namespace" . }}.
+
+Deployment summary:
+- Release name: {{ .Release.Name }}
+- Service name: {{ .Values.service.name }}
+- Replicas: {{ .Values.replicas }}
+- Metadata backend: {{ if .Values.mysql.enabled }}MySQL (in-chart){{ else if .Values.postgresql.enabled }}PostgreSQL (in-chart){{ else if and .Values.entity.jdbcUrl (ne .Values.entity.jdbcUrl "jdbc:h2") }}External ({{ .Values.entity.jdbcUrl }}){{ else }}Embedded H2 (testing only){{ end }}
+- Persistence: {{ if .Values.persistence.enabled }}Enabled ({{ .Values.persistence.size }}){{ else }}Disabled (emptyDir){{ end }}
+- Iceberg REST server: {{ if contains "iceberg-rest" .Values.auxService.names }}Enabled on port {{ .Values.icebergRest.httpPort | default 9001 }}{{ else }}Disabled{{ end }}
+- Authentication: {{ .Values.authenticators | default "simple (anonymous)" }}
+- Service type: {{ .Values.service.type }}
+
+{{- if and (not .Values.mysql.enabled) (not .Values.postgresql.enabled) (or (not .Values.entity.jdbcUrl) (eq .Values.entity.jdbcUrl "jdbc:h2")) }}
+
+WARNING: This deployment uses the embedded H2 metadata backend on an
+emptyDir volume. All metadata will be lost when the pod restarts. For
+any non-throwaway use, configure an external metadata backend (MySQL
+or PostgreSQL) via the entity.* values, or enable an in-chart database
+via mysql.enabled or postgresql.enabled.
+{{- end }}
+
+{{- if and (contains "iceberg-rest" .Values.auxService.names) (not .Values.icebergRest.catalogConfigProvider) (eq (.Values.icebergRest.catalogBackend | default "memory") "memory") }}
+
+WARNING: The Iceberg REST server is enabled with the default in-memory
+catalog backend. Tables registered through this server will be lost
+when the pod restarts. For real use, configure icebergRest.catalogConfigProvider
+to use the dynamic-config-provider with a persistent metadata backend,
+or set icebergRest.catalogBackend to jdbc or hive with a persistent store.
+{{- end }}
+
+{{- if or (eq .Values.authenticators "") (eq .Values.authenticators "simple") }}
+
+WARNING: Authentication is set to simple mode (anonymous). The deployed
+server accepts all requests without credentials. Configure authenticators
+to "oauth" or "kerberos" before exposing the server beyond a trusted
+network.
+{{- end }}
+
+{{- if and .Values.mysql.enabled (or (eq .Values.mysql.auth.rootPassword "admin") (eq .Values.mysql.auth.password "gravitino")) }}
+
+WARNING: The in-chart MySQL is using default credentials (root password
+"admin" and/or user password "gravitino"). Override mysql.auth.rootPassword
+and mysql.auth.password (or set mysql.auth.existingSecret) before any
+non-trial deployment.
+{{- end }}
+
+{{- if and .Values.postgresql.enabled (eq .Values.postgresql.auth.password "gravitino") }}
+
+WARNING: The in-chart PostgreSQL is using the default password "gravitino".
+Override postgresql.auth.password (or set postgresql.auth.existingSecret)
+before any non-trial deployment.
+{{- end }}
+
+To check pod status:
 
   kubectl get pods --namespace {{ include "gravitino.namespace" . }}
 
-Check the "gravitino.conf" by running:
+To view the rendered gravitino.conf:
 
   kubectl get cm {{ include "gravitino.fullname" . }} -n {{ include "gravitino.namespace" . }} -o json | jq -r '.data["gravitino.conf"]'
+
+To access the Gravitino server locally:
+
+  kubectl -n {{ include "gravitino.namespace" . }} port-forward svc/{{ .Values.service.name }} 8090:8090
+
+Then open http://localhost:8090 in a browser.
+
+For production deployment patterns, see:
+https://gravitino.apache.org/docs/latest/chart

--- a/dev/charts/gravitino/values.yaml
+++ b/dev/charts/gravitino/values.yaml
@@ -37,6 +37,10 @@ image:
 ## MySQL chart configuration
 ## ref: https://github.com/bitnami/charts/blob/main/bitnami/mysql/values.yaml
 ##
+## WARNING: The defaults below (auth.rootPassword=admin, auth.password=gravitino)
+## are for trial use only. Override both passwords, or use auth.existingSecret to
+## source credentials from a Kubernetes Secret, before any non-trial deployment.
+##
 mysql:
   ## @param mysql.enabled Deploy MySQL container(s)
   ##
@@ -71,6 +75,10 @@ mysql:
 
 ## PostgreSQL chart configuration
 ## ref: https://github.com/bitnami/charts/blob/master/bitnami/postgresql/values.yaml
+##
+## WARNING: The default below (auth.password=gravitino) is for trial use only.
+## Override the password, or use auth.existingSecret to source credentials from
+## a Kubernetes Secret, before any non-trial deployment.
 ##
 postgresql:
   ## @param postgresql.enabled Deploy PostgreSQL container(s)
@@ -132,6 +140,23 @@ entity:
   ##
   jdbcPassword: gravitino
   storagePath: /opt/gravitino/data/jdbc
+  ## Maximum number of JDBC connections in the relational backend pool.
+  ## Leave unset to use the server default. Production recommendation: 200.
+  ##
+  maxConnections: ""
+
+## THE CONFIGURATION FOR Gravitino TREE LOCK
+##
+lock:
+  ## Maximum number of tree-lock nodes the lock manager will hold concurrently.
+  ## Used to tune tree-lock memory for high-concurrency deployments.
+  ## Leave unset to use the server default. Production recommendation: 500000.
+  ##
+  maxNodes: ""
+  ## Minimum number of tree-lock nodes the lock manager preserves across cleanup.
+  ## Leave unset to use the server default. Production recommendation: 5000.
+  ##
+  minNodes: ""
 
 ## THE CONFIGURATION FOR Gravitino SERVER
 ##
@@ -338,13 +363,13 @@ metrics:
 ## Custom Gravitino configuration items
 ##
 visibleConfigs: ""
-# visibleConfigs: "gravitino.datastrato.custom.authorization.ranger.admin.url,gravitino.datastrato.custom.authorization.ranger.username,gravitino.datastrato.custom.authorization.ranger.password,gravitino.datastrato.custom.authorization.ranger.auth.type"
+# visibleConfigs: "gravitino.custom.example.url,gravitino.custom.example.username,gravitino.custom.example.password,gravitino.custom.example.auth.type"
 
 visibleConfigsItems: {}
-  # gravitino.datastrato.custom.authorization.ranger.admin.url: "http://ranger:6080"
-  # gravitino.datastrato.custom.authorization.ranger.username: admin
-  # gravitino.datastrato.custom.authorization.ranger.password: "rangerR0cks!"
-  # gravitino.datastrato.custom.authorization.ranger.auth.type: simple
+  # gravitino.custom.example.url: "http://example:6080"
+  # gravitino.custom.example.username: admin
+  # gravitino.custom.example.password: "exampleR0cks!"
+  # gravitino.custom.example.auth.type: simple
 
 ## Additional Gravitino configuration items in gravitino.conf can be added
 ##


### PR DESCRIPTION
All items are small-scope, none depend on each other, and the bundle deliberately excludes the items tracked separately.

## Items in scope

- **Item 2**: Remove `gravitino.datastrato.*` property references from `ci-values.yaml` and the commented examples in `values.yaml`. Vendor-neutral example names used so the `visibleConfigs` mechanism remains documented and exercised in CI.
- **Item 3**: Add structured `values.yaml` paths for `entity.maxConnections`, `lock.maxNodes`, and `lock.minNodes`. Properties used by the production sample in `docs/gravitino-server-config.md#production` that previously required `additionalConfigItems` workarounds. Emitted conditionally from the `gravitino.conf` template so server defaults apply when unset.
- **Item 5**: Ship `dev-values.yaml` and `prod-values.yaml` scenario files derived from the development and production samples in `gravitino-server-config.md`. The prod scenario uses structured paths for the properties added by item 3 (no `additionalConfigItems`).
- **Item 6**: Replace `NOTES.txt` with a post-install deployment summary that surfaces the actual backend, persistence, IRC, and auth configuration. Adds warnings for ephemeral H2 metadata, in-memory IRC backend, and simple-mode authentication.
- **Item 7**: Remove `testAdditionalConfigItems` test-fixture properties from `ci-values.yaml`. Replaced with a realistic `gravitino.eventListener.names` example.
- **Item 8**: Default-credential warnings above the `mysql` and `postgresql` sections in `values.yaml`. `NOTES.txt` fires runtime warnings when in-chart databases are enabled with default passwords.
- **Item 9**: Emit dynamic-config-provider sub-properties (`gravitino-uri`, `gravitino-metalake`, `default-catalog-name`) conditionally, so unset values do not render as empty-string property assignments.

## Items deliberately out of scope

- **Item 1 (Kubernetes Secret references for sensitive values)**: P0 blocker for some customers. Touches `templates/deployment.yaml` and flips `SKIP_CONFIG_REWRITE`. Tracked as a separate PR.
- **Item 4 (`existingConfigMap` support)**: Deferred. Niche GitOps unlock; no current customer pressure.
- **Item 10 (OIDC OAuth values schema)**: In progress on a separate branch.

## Validation

- `helm lint` clean against defaults and both new scenario files (`dev-values.yaml`, `prod-values.yaml`).
- `helm template` renders expected `gravitino.conf` content for default, dev, and prod scenarios.
- Item 3's structured paths verified: emit correctly when set (prod scenario produces `gravitino.entity.store.relational.maxConnections = 200`, `gravitino.lock.maxNodes = 500000`, `gravitino.lock.minNodes = 5000`), omit cleanly when unset.
- Item 9's conditional emission verified: dev scenario produces a single `gravitino.iceberg-rest.gravitino-metalake = test` line with no empty `gravitino-uri =` or `default-catalog-name =` lines.
- `NOTES.txt` warnings verified via `helm install --dry-run` for H2 ephemeral, IRC in-memory, simple auth, and default MySQL/PostgreSQL credentials.
- Vendor branding and test-fixture cleanups verified: `grep -r datastrato dev/charts/gravitino/` and `grep -r testAdditionalConfigItems dev/charts/gravitino/` both return no results.
- Prod scenario uses only structured paths: `grep additionalConfigItems dev/charts/gravitino/resources/scenarios/prod-values.yaml` returns no results.

## Runtime validation

Runtime validation is **blocked by #11267** (chart-vs-image path mismatch in all currently published Gravitino images). The chart hardcodes `/opt/gravitino` but published images (`1.2.0` and `1.3.0-SNAPSHOT` both verified) install Gravitino at `/root/gravitino`. A default `helm install` against `main` fails with `CrashLoopBackOff` identically to this branch, so the blocker is not introduced by this PR.

The path bug has a second layer where `/root/` has 700 permissions incompatible with the chart's non-root container security context (`runAsNonRoot: true, runAsUser: 1000`). Any chart-side workaround requires disabling `runAsNonRoot`, which is a security regression unacceptable for enterprise deployments. This is why Option A in #11267 (move the image install location to `/opt/gravitino`) is the only viable resolution.

Once #11267 is resolved, this PR's edits will runtime-validate without modification since none of them touch the deployment template or path assumptions.

## Documentation followup

Once this PR and the separate item 1 PR (Secret references) land, `docs/chart.md` can describe a complete install-to-production flow including the dev and prod scenario files. The scenario files in `resources/scenarios/` are the canonical source the docs should link via raw GitHub URLs.
