### PR TITLE
[#11084] improvement(deps): Add global snappy-java version constraint added in build.gradle.kts

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -60,7 +60,9 @@ plugins {
   alias(libs.plugins.tasktree)
   alias(libs.plugins.errorprone)
 }
-val snappyJavaVersion = "1.1.10.8"
+
+val snappyJavaVersion: String = libs.versions.snappy.java.get()
+
 val scalaVersion: String = project.properties["scalaVersion"] as? String ?: extra["defaultScalaVersion"].toString()
 if (scalaVersion !in listOf("2.12", "2.13")) {
   throw GradleException("Scala version $scalaVersion is not supported.")
@@ -331,10 +333,12 @@ subprojects {
   apply(plugin = "maven-publish")
   apply(plugin = "java")
 
-  // Force upgrade commons-beanutils for all subprojects to resolve outdated transitive versions
-  // pulled by Hadoop, Hive, Spark, Flink, etc.
+  // Force upgrade commons-beanutils/snappy-java for all subprojects to resolve outdated transitive versions
+  // commons-beanutils: pulled by Hadoop, Hive, Spark, Flink, etc.
+  // snappy-java: pulled by Hadoop, Kafka, Iceberg, etc.
   configurations.all {
     resolutionStrategy.force("commons-beanutils:commons-beanutils:$commonsBeanutilsVersion")
+    resolutionStrategy.force("org.xerial.snappy:snappy-java:$snappyJavaVersion")
   }
 
   repositories {
@@ -454,11 +458,6 @@ subprojects {
   apply(plugin = "net.ltgt.errorprone")
   dependencies {
     errorprone("com.google.errorprone:error_prone_core:2.10.0")
-
-    // Force upgrades for outdated transitive dependencies with known issues
-    constraints {
-      implementation("org.xerial.snappy:snappy-java:$snappyJavaVersion")
-    }
   }
 
   tasks.withType<JavaCompile>().configureEach {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -60,7 +60,7 @@ plugins {
   alias(libs.plugins.tasktree)
   alias(libs.plugins.errorprone)
 }
-
+val snappyJavaVersion = "1.1.10.8"
 val scalaVersion: String = project.properties["scalaVersion"] as? String ?: extra["defaultScalaVersion"].toString()
 if (scalaVersion !in listOf("2.12", "2.13")) {
   throw GradleException("Scala version $scalaVersion is not supported.")
@@ -454,6 +454,11 @@ subprojects {
   apply(plugin = "net.ltgt.errorprone")
   dependencies {
     errorprone("com.google.errorprone:error_prone_core:2.10.0")
+
+    // Force upgrades for outdated transitive dependencies with known issues
+    constraints {
+      implementation("org.xerial.snappy:snappy-java:$snappyJavaVersion")
+    }
   }
 
   tasks.withType<JavaCompile>().configureEach {


### PR DESCRIPTION

### What changes were proposed in this pull request?

- Add the global `constraints { implementation("org.xerial.snappy:snappy-java:$snappyJavaVersion") }` from the root `build.gradle.kts` file.
- Also add the temporary `val snappyJavaVersion = "1.1.10.8"` defined at the top of the root build script.
- The necessary version upgrade is already enforced in `:catalogs:hive-metastore2-libs` and `:catalogs:hive-metastore3-libs` via PR #11085 (`implementation(libs.snappy.java)` in their `constraints` block).

### Why are the changes needed?

- The global constraint forces `snappy-java` 1.1.10.8 on **all** subprojects.
- The original issue (#11084) only required fixing the Hive Metastore library modules.

Fix: #11084 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

(Please test your changes, and provide instructions on how to test it:
- Ensured all modules still show `1.1.8.2 -> 1.1.10.8` in dependency insight.
=== :authorizations:authorization-ranger ===
org.xerial.snappy:snappy-java:1.1.8.2 -> 1.1.10.8
=== :bundles:aliyun-bundle ===
org.xerial.snappy:snappy-java:1.1.8.2 -> 1.1.10.8
=== :bundles:aws-bundle ===
org.xerial.snappy:snappy-java:1.1.8.2 -> 1.1.10.8
=== :bundles:azure-bundle ===
org.xerial.snappy:snappy-java:1.1.8.2 -> 1.1.10.8
=== :bundles:gcp-bundle ===
org.xerial.snappy:snappy-java:1.1.8.2 -> 1.1.10.8
=== :catalogs:catalog-fileset ===
org.xerial.snappy:snappy-java:1.1.8.2 -> 1.1.10.8
=== :catalogs:catalog-kafka ===
org.xerial.snappy:snappy-java:1.1.8.4 -> 1.1.10.8
=== :catalogs:catalog-lakehouse-iceberg ===
org.xerial.snappy:snappy-java:1.1.8.2 -> 1.1.10.8
=== :catalogs:catalog-lakehouse-paimon ===
org.xerial.snappy:snappy-java:1.1.8.2 -> 1.1.10.8
=== :catalogs:hadoop-common ===
org.xerial.snappy:snappy-java:1.1.8.2 -> 1.1.10.8
=== :catalogs:hive-metastore2-libs ===
org.xerial.snappy:snappy-java:1.1.8.2 -> 1.1.10.8
=== :catalogs:hive-metastore3-libs ===
org.xerial.snappy:snappy-java:1.1.8.2 -> 1.1.10.8
=== :iceberg:iceberg-common ===
org.xerial.snappy:snappy-java:1.1.8.2 -> 1.1.10.8
=== :iceberg:iceberg-rest-server ===
org.xerial.snappy:snappy-java:1.1.8.2 -> 1.1.10.8