### PR TITLE
[#11165] improvement(deps): Force commons-beanutils to 1.11.0 globally for all subprojects

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -313,6 +313,8 @@ fun excludePackagesForSparkConnector(project: Project) {
   }
 }
 
+val commonsBeanutilsVersion: String = libs.versions.commons.beanutils.get()
+
 subprojects {
   // Gravitino Python client project didn't need to apply the java plugin
   if (project.name == "client-python") {
@@ -328,6 +330,12 @@ subprojects {
   apply(plugin = "jacoco")
   apply(plugin = "maven-publish")
   apply(plugin = "java")
+
+  // Force upgrade commons-beanutils for all subprojects to resolve outdated transitive versions
+  // pulled by Hadoop, Hive, Spark, Flink, etc.
+  configurations.all {
+    resolutionStrategy.force("commons-beanutils:commons-beanutils:$commonsBeanutilsVersion")
+  }
 
   repositories {
     mavenCentral()


### PR DESCRIPTION


### What changes were proposed in this pull request?

Add a global `resolutionStrategy.force` in the root `build.gradle.kts` to
upgrade transitive `commons-beanutils` from 1.9.4 (and older) to 1.11.0
across all subprojects.

The previous fix (#11166) only applied `constraints` to `hive-metastore2-libs`
and `hive-metastore3-libs`. Other modules (catalog-hive, catalog-fileset,
catalog-lakehouse-paimon, catalog-lakehouse-generic, client-java,
filesystem-hadoop3, flink-connector, maintenance:jobs, etc.) still resolved
the outdated transitive version.

### Why are the changes needed?

Multiple modules still pulled `commons-beanutils:1.9.4` (or older) as a
transitive dependency from Hadoop, Hive, Spark, and Flink. The
`resolutionStrategy.force` approach ensures all configurations in all
subprojects resolve to 1.11.0, regardless of what version is requested
transitively.

Fix: #11165 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

- Verified all modules resolve `commons-beanutils` to 1.11.0 via
  `./gradlew <module>:dependencies`
- Full compilation: `./gradlew build -x test`
- Unit tests: `./gradlew test -PskipITs`
