### PR TITLE
[#11275] improvement(deps): Upgrade libthrift to 0.12.0 in remaining modules

### DIFF
--- a/catalogs/hive-metastore-common/build.gradle.kts
+++ b/catalogs/hive-metastore-common/build.gradle.kts
@@ -24,6 +24,12 @@ plugins {
 }
 
 dependencies {
+  // Force upgrade for outdated transitive libthrift pulled by Hive Metastore
+  constraints {
+    compileOnly(libs.thrift)
+    testImplementation(libs.thrift)
+  }
+
   compileOnly(project(":api"))
   compileOnly(project(":common"))
   compileOnly(project(":core"))

--- a/flink-connector/flink-common/build.gradle.kts
+++ b/flink-connector/flink-common/build.gradle.kts
@@ -40,6 +40,12 @@ val scalaVersion: String = "2.12"
 val artifactName = "${rootProject.name}-flink-common"
 
 dependencies {
+  // Force upgrade for outdated transitive libthrift pulled by Hive Metastore
+  constraints {
+    compileOnly(libs.thrift)
+    testImplementation(libs.thrift)
+  }
+
   implementation(project(":catalogs:catalog-common")) {
     exclude("org.apache.logging.log4j")
   }

--- a/flink-connector/v1.18/flink/build.gradle.kts
+++ b/flink-connector/v1.18/flink/build.gradle.kts
@@ -39,6 +39,12 @@ val scalaVersion: String = "2.12"
 val artifactName = "${rootProject.name}-flink-${flinkMajorVersion}_$scalaVersion"
 
 dependencies {
+  // Force upgrade for outdated transitive libthrift pulled by Hive Metastore
+  constraints {
+    compileOnly(libs.thrift)
+    testImplementation(libs.thrift)
+  }
+
   implementation(commonProject)
 
   compileOnly(project(":clients:client-java-runtime", configuration = "shadow"))

--- a/flink-connector/v1.19/flink/build.gradle.kts
+++ b/flink-connector/v1.19/flink/build.gradle.kts
@@ -39,6 +39,12 @@ val scalaVersion: String = "2.12"
 val artifactName = "${rootProject.name}-flink-${flinkMajorVersion}_$scalaVersion"
 
 dependencies {
+  // Force upgrade for outdated transitive libthrift pulled by Hive Metastore
+  constraints {
+    compileOnly(libs.thrift)
+    testImplementation(libs.thrift)
+  }
+
   implementation(commonProject)
 
   compileOnly(project(":clients:client-java-runtime", configuration = "shadow"))

--- a/flink-connector/v1.20/flink/build.gradle.kts
+++ b/flink-connector/v1.20/flink/build.gradle.kts
@@ -39,6 +39,12 @@ val scalaVersion: String = "2.12"
 val artifactName = "${rootProject.name}-flink-${flinkMajorVersion}_$scalaVersion"
 
 dependencies {
+  // Force upgrade for outdated transitive libthrift pulled by Hive Metastore
+  constraints {
+    compileOnly(libs.thrift)
+    testImplementation(libs.thrift)
+  }
+
   implementation(commonProject)
 
   compileOnly(project(":clients:client-java-runtime", configuration = "shadow"))

--- a/iceberg/iceberg-common/build.gradle.kts
+++ b/iceberg/iceberg-common/build.gradle.kts
@@ -25,6 +25,11 @@ plugins {
 }
 
 dependencies {
+  // Force upgrade for outdated transitive libthrift pulled by Hive Metastore
+  constraints {
+    implementation(libs.thrift)
+  }
+
   implementation(project(":api"))
   implementation(project(":catalogs:catalog-common"))
   implementation(project(":catalogs:hadoop-common")) {

--- a/trino-connector/integration-test/build.gradle.kts
+++ b/trino-connector/integration-test/build.gradle.kts
@@ -28,6 +28,11 @@ repositories {
 }
 
 dependencies {
+  // Force upgrade for outdated transitive libthrift pulled by Hive Metastore
+  constraints {
+    testImplementation(libs.thrift)
+  }
+
   testImplementation(project(":api"))
   testImplementation(project(":clients:client-java"))
   testImplementation(project(":common"))


### PR DESCRIPTION


### What changes were proposed in this pull request?

Add `constraints { ... libs.thrift }` in the following modules to upgrade the transitive libthrift from 0.9.3 to 0.12.0:

- `iceberg/iceberg-common` — `implementation` constraint
- `catalogs/hive-metastore-common` — `compileOnly` + `testImplementation` constraints
- `flink-connector/flink-common` — `compileOnly` + `testImplementation` constraints
- `flink-connector/v1.18/flink` — `compileOnly` + `testImplementation` constraints
- `flink-connector/v1.19/flink` — `compileOnly` + `testImplementation` constraints
- `flink-connector/v1.20/flink` — `compileOnly` + `testImplementation` constraints
- `trino-connector/integration-test` — `testImplementation` constraint

### Why are the changes needed?

Follow-up to #11056. libthrift 0.9.3 is still pulled transitively in the above modules. Version 0.12.0 fixes known issues in SASL negotiation and large message handling while maintaining binary compatibility with Hive 2.x/3.x.

Fix: #11275 

### Does this PR introduce _any_ user-facing change?

No. The Thrift wire protocol is backward-compatible.

### How was this patch tested?

- `iceberg-rest-server` integration tests — pass
- `catalog-hive` integration tests — pass
- `catalog-lakehouse-iceberg` integration tests — pass
- `flink-connector:flink-1.20` integration tests — pass
- `hive-metastore-common` integration tests — pass
- Verified all affected modules resolve libthrift to 0.12.0 via `./gradlew :module:dependencies`
