### PR TITLE
[#10369] improvement(docs): Add KEYS file location to release verification guide

### DIFF
--- a/docs/how-to-sign-releases.md
+++ b/docs/how-to-sign-releases.md
@@ -159,7 +159,7 @@ Keep your private key secure and saved somewhere other than just on your compute
 
 1. **Import public keys:**
 
-    Download the KEYS file. Import the public keys used to sign all previous releases with this command. It doesn't matter if you have already imported the keys.
+    Download the KEYS file from https://downloads.apache.org/gravitino/KEYS. Import the public keys used to sign all previous releases with this command. It doesn't matter if you have already imported the keys.
 
     ```shell
     gpg --import KEYS


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add the KEYS file URL to the "Verifying a release" section of the how-to-sign-releases doc, so users know where to download it.

### Why are the changes needed?

The verification guide told users to "Download the KEYS file" but didn't say where to get it, making it impossible to follow the steps without prior knowledge.

Fix: #10369

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Doc-only change.