### PR TITLE
[#11279] [MINOR] docs: Add how-to guide for built-in IdP

### DIFF
--- a/design-docs/gravitino-local-authentication.md
+++ b/design-docs/gravitino-local-authentication.md
@@ -278,6 +278,12 @@ preserving the requirement that local identity tables remain global and metalake
 
 ## 6. Service Admin Initialization
 
+> **Implementation status (current codebase):** Not implemented. There is no startup logic that
+> reads `GRAVITINO_INITIAL_ADMIN_PASSWORD` or auto-creates built-in IdP users for
+> `gravitino.authorization.serviceAdmins`. Operators must create the first built-in IdP users through
+> the management REST APIs (once those APIs are deployable) or direct database operations. The
+> section below remains the target design.
+
 To keep local authentication usable immediately after installation without introducing a hard-coded
 default password, Gravitino should initialize service admin accounts from an environment variable
 during startup when the `basic` authenticator is enabled.
@@ -352,6 +358,12 @@ fresh Gravitino deployment.
 ---
 
 ## 7. Authentication Flow
+
+> **Implementation status (current codebase):** Not implemented. `AuthenticatorFactory` only
+> registers `simple`, `oauth`, and `kerberos`. Listing `basic` in `gravitino.authenticators`
+> causes startup failure because no `Authenticator` class is bound to that name. The flows below
+> describe the intended HTTP Basic authentication behavior once a built-in IdP authenticator is
+> added.
 
 ### 7.1 User Verification
 
@@ -430,11 +442,25 @@ The local authentication management capability is enabled only when `basic` is i
 `gravitino.authenticators`. If `basic` is not enabled, Gravitino should not allow local authentication
 management APIs to be used.
 
-### 8.2 Password Algorithm
+> **Implementation note:** Today, `basic` is only checked by `IdpRESTFeature` to register
+> `/api/idp/*` resources. It is not yet skipped or mapped in `AuthenticatorFactory`, so production
+> configs must not list `basic` until authenticator wiring is completed. Management API callers
+> currently authenticate with another mode (for example `simple`) and must be service admins.
+
+### 8.2 REST extension package
+
+| Key | Value | Required when using built-in IdP |
+|-----|--------|----------------------------------|
+| `gravitino.server.rest.extensionPackages` | `org.apache.gravitino.idp.web.rest.feature` | Yes |
+
+Jersey discovers `IdpRESTFeature`, which registers `IdpUserOperations`, `IdpGroupOperations`,
+`IdpBasicBinder`, and `IdpAuthorizationFilter` when `basic` is present in `gravitino.authenticators`.
+
+### 8.3 Password Algorithm
 
 The initial implementation uses Argon2id as the fixed password hashing algorithm.
 
-### 8.3 How Trino Accesses IRC with Basic Authentication
+### 8.4 How Trino Accesses IRC with Basic Authentication
 
 For Trino to access IRC with Basic authentication, Trino must act as an HTTP client for IRC requests
 and attach the required authentication information to the outbound REST catalog requests.
@@ -680,18 +706,19 @@ curl -X DELETE -H "Accept: application/vnd.gravitino.v1+json" \
 }
 ```
 
-#### 9.1.8 Add users to a local group
+#### 9.1.8 Change local group membership
 
-You can add users to a local group by providing the group name in the path and the target user
-names in the request body.
+Add and/or remove users from a local group in a single request. At least one of `usersToAdd` or
+`usersToRemove` must be provided.
 
-The request path for REST API is `/api/idp/groups/{group}/add`.
+The request path for REST API is `/api/idp/groups/{group}/users`.
 
 ```shell
 curl -X PUT -H "Accept: application/vnd.gravitino.v1+json" \
 -H "Content-Type: application/json" -d '{
-  "users": ["alice", "bob"]
-}' http://localhost:8090/api/idp/groups/engineering/add
+  "usersToAdd": ["alice", "bob"],
+  "usersToRemove": ["carol"]
+}' http://localhost:8090/api/idp/groups/engineering/users
 ```
 
 **Response:**
@@ -706,31 +733,6 @@ curl -X PUT -H "Accept: application/vnd.gravitino.v1+json" \
 }
 ```
 
-#### 9.1.9 Remove users from a local group
-
-You can remove users from a local group by providing the group name in the path and the target
-user names in the request body.
-
-The request path for REST API is `/api/idp/groups/{group}/remove`.
-
-```shell
-curl -X PUT -H "Accept: application/vnd.gravitino.v1+json" \
--H "Content-Type: application/json" -d '{
-  "users": ["alice"]
-}' http://localhost:8090/api/idp/groups/engineering/remove
-```
-
-**Response:**
-
-```json
-{
-  "code": 0,
-  "group": {
-    "name": "engineering",
-    "users": ["bob"]
-  }
-}
-```
 ---
 
 ## 10. Work Plan and Checklist

--- a/docs/how-to-use-idp.md
+++ b/docs/how-to-use-idp.md
@@ -1,0 +1,314 @@
+---
+title: How to use built-in IdP (local authentication)
+slug: /how-to-use-idp
+license: "This software is licensed under the Apache License version 2."
+---
+
+## Introduction
+
+Apache Gravitino can store **built-in IdP** (identity provider) users and groups in the relational
+metadata store through the `idp-basic` plugin. This gives you a self-contained way to manage
+**global** login identities (usernames, password hashes, and group membership) without an external
+OAuth server.
+
+Built-in IdP is aimed at POC, offline, and isolated deployments. It is **not** a replacement for
+enterprise IdPs such as Okta, Azure AD, or Keycloak.
+
+This guide is based on the current `plugins:idp-basic` implementation. For design background, see
+[Design of local authentication support](../design-docs/gravitino-local-authentication.md). For
+the machine-readable API contract, see the [Built-in IdP OpenAPI](../open-api/idp/openapi.yaml).
+
+### What is implemented today
+
+| Capability | Status |
+|----------|--------|
+| Relational tables `idp_user_meta`, `idp_group_meta`, `idp_user_group_rel` | Implemented (schema in 1.3.0 upgrade scripts) |
+| Argon2id password hashing (`password_hash` column) | Implemented |
+| REST management APIs under `/api/idp/...` | Implemented in `idp-basic` |
+| Service-admin authorization on management APIs | Implemented (`IdpAuthorizationFilter`) |
+| HTTP Basic authentication against `idp_user_meta` for all Gravitino APIs | **Not implemented** (no `basic` entry in `AuthenticatorFactory`) |
+| Startup initialization via `GRAVITINO_INITIAL_ADMIN_PASSWORD` | **Not implemented** |
+
+The value `basic` in `gravitino.authenticators` is used today only as a **feature flag** to
+register IdP management REST resources (`IdpRESTFeature`). It is **not** a working HTTP
+authenticator name yet: if you list `basic` in `gravitino.authenticators`, server startup fails
+because `AuthenticatorFactory` tries to load a Java class named `basic`. Until authenticator
+wiring is completed, treat the management APIs below as the implemented contract, not as a
+fully enabled production path.
+
+---
+
+## Prerequisites
+
+1. **Gravitino server** with **relational** entity store (`gravitino.entity.store = relational`).
+2. **Database schema** that includes the IdP tables. For MySQL/PostgreSQL, run the appropriate
+   upgrade script under `${GRAVITINO_HOME}/scripts/` (for example
+   `scripts/mysql/upgrade-1.2.0-to-1.3.0-mysql.sql` creates `idp_user_meta`, `idp_group_meta`, and
+   `idp_user_group_rel`). See [How to use relational backend storage](./how-to-use-relational-backend-storage.md).
+3. **Plugin JARs** in `${GRAVITINO_HOME}/libs/`:
+   - `gravitino-idp-basic-*.jar` (from `./gradlew :plugins:idp-basic:copyLibAndConfigs`)
+   - `bcprov-jdk18on-*.jar` (Argon2id dependency; copied by the same task)
+4. **Authorization enabled** with at least one **service admin** if you call management APIs
+   (see [Access control](./security/access-control.md)).
+
+---
+
+## Server configuration
+
+Add the following to `gravitino.conf` when built-in IdP management is enabled (after
+authenticator wiring supports the `basic` flag without breaking startup):
+
+| Configuration item | Description | Example |
+|--------------------|-------------|---------|
+| `gravitino.authenticators` | Must include `basic` to register IdP REST APIs (`IdpRESTFeature`) | `simple,basic` (once `basic` is a non-loading flag or a real authenticator exists) |
+| `gravitino.server.rest.extensionPackages` | Jersey package that discovers `IdpRESTFeature` | `org.apache.gravitino.idp.web.rest.feature` |
+| `gravitino.authorization.enable` | Required for service-admin checks on IdP APIs | `true` |
+| `gravitino.authorization.serviceAdmins` | Usernames allowed to call `/api/idp/*` | `admin` |
+
+Example (intended end state):
+
+```properties
+gravitino.authenticators = simple,basic
+gravitino.server.rest.extensionPackages = org.apache.gravitino.idp.web.rest.feature
+gravitino.authorization.enable = true
+gravitino.authorization.serviceAdmins = admin
+```
+
+`IdpRESTFeature` registers management resources only when `basic` appears in
+`gravitino.authenticators` **and** `org.apache.gravitino.idp.web.rest.feature` is listed in
+`gravitino.server.rest.extensionPackages`. If `basic` is absent, `/api/idp/*` routes are not
+registered (HTTP 404).
+
+---
+
+## Calling management APIs
+
+### Authentication for `/api/idp/*`
+
+Management APIs do **not** use built-in IdP passwords for authorization today. `IdpAuthorizationFilter`
+requires the **already authenticated** caller to be listed in `gravitino.authorization.serviceAdmins`.
+
+Until HTTP Basic login against `idp_user_meta` exists, use another configured authenticator (for
+example **simple**) to authenticate as a service admin, then call IdP APIs.
+
+Example with **simple** mode (empty password is allowed):
+
+```shell
+export GRAVITINO_USER=admin
+curl -s -H "Accept: application/vnd.gravitino.v1+json" \
+  -H "Authorization: Basic $(echo -n 'admin:' | base64)" \
+  http://localhost:8090/api/idp/users/alice
+```
+
+If the caller is not a service admin, the server returns **403** with a message like
+`Only service admins can manage built-in IdP users and groups.`
+
+### Common headers
+
+| Header | Value |
+|--------|--------|
+| `Accept` | `application/vnd.gravitino.v1+json` |
+| `Content-Type` | `application/json` (for POST/PUT bodies) |
+
+Base URL prefix: `http://<host>:<port>/api/idp`.
+
+---
+
+## Password and username rules
+
+Enforced by `IdpCredentialValidator` on add-user and change-password requests:
+
+| Rule | Value |
+|------|--------|
+| Username | Required; must **not** contain `:` |
+| Password length | 12–64 characters (inclusive) |
+| Password storage | Argon2id PHC string in `idp_user_meta.password_hash` |
+
+Password reset is **admin-only** (no `oldPassword`, no self-service).
+
+---
+
+## User APIs
+
+### Get user
+
+`GET /api/idp/users/{user}`
+
+```shell
+curl -s -H "Accept: application/vnd.gravitino.v1+json" \
+  -H "Authorization: Basic $(echo -n 'admin:' | base64)" \
+  http://localhost:8090/api/idp/users/alice
+```
+
+Response:
+
+```json
+{
+  "code": 0,
+  "user": {
+    "name": "alice",
+    "groups": ["engineering"]
+  }
+}
+```
+
+### Add user
+
+`POST /api/idp/users`
+
+Request body uses field `user` (not `name`):
+
+```shell
+curl -s -X POST -H "Accept: application/vnd.gravitino.v1+json" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Basic $(echo -n 'admin:' | base64)" \
+  -d '{"user":"alice","password":"Passw0rd-Alice"}' \
+  http://localhost:8090/api/idp/users
+```
+
+| HTTP status | Meaning |
+|-------------|---------|
+| 200 | User created |
+| 400 | Invalid username/password |
+| 403 | Not a service admin |
+| 409 | User already exists |
+
+### Change password (admin reset)
+
+`PUT /api/idp/users/{user}`
+
+```shell
+curl -s -X PUT -H "Accept: application/vnd.gravitino.v1+json" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Basic $(echo -n 'admin:' | base64)" \
+  -d '{"password":"Passw0rd-Alice-V2"}' \
+  http://localhost:8090/api/idp/users/alice
+```
+
+| HTTP status | Meaning |
+|-------------|---------|
+| 404 | User does not exist |
+
+### Remove user
+
+`DELETE /api/idp/users/{user}`
+
+Soft-deletes the user (`deleted_at`); physical removal is handled by the IdP garbage collector.
+
+```shell
+curl -s -X DELETE -H "Accept: application/vnd.gravitino.v1+json" \
+  -H "Authorization: Basic $(echo -n 'admin:' | base64)" \
+  http://localhost:8090/api/idp/users/alice
+```
+
+Response:
+
+```json
+{
+  "code": 0,
+  "removed": true
+}
+```
+
+---
+
+## Group APIs
+
+### Get group
+
+`GET /api/idp/groups/{group}`
+
+```shell
+curl -s -H "Accept: application/vnd.gravitino.v1+json" \
+  -H "Authorization: Basic $(echo -n 'admin:' | base64)" \
+  http://localhost:8090/api/idp/groups/engineering
+```
+
+Response:
+
+```json
+{
+  "code": 0,
+  "group": {
+    "name": "engineering",
+    "users": ["alice", "bob"]
+  }
+}
+```
+
+### Add group
+
+`POST /api/idp/groups`
+
+Request body uses field `group` (not `name`):
+
+```shell
+curl -s -X POST -H "Accept: application/vnd.gravitino.v1+json" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Basic $(echo -n 'admin:' | base64)" \
+  -d '{"group":"engineering"}' \
+  http://localhost:8090/api/idp/groups
+```
+
+### Remove group
+
+`DELETE /api/idp/groups/{group}?force={true|false}`
+
+If the group still has members, deletion fails unless `force=true` (**405** /
+`IllegalStateException` in the implementation).
+
+```shell
+curl -s -X DELETE -H "Accept: application/vnd.gravitino.v1+json" \
+  -H "Authorization: Basic $(echo -n 'admin:' | base64)" \
+  'http://localhost:8090/api/idp/groups/engineering?force=true'
+```
+
+### Change group membership
+
+`PUT /api/idp/groups/{group}/users`
+
+Adds and/or removes members in one request. At least one of `usersToAdd` or `usersToRemove` must be
+set (this replaces the older separate `/add` and `/remove` paths from early design drafts).
+
+```shell
+curl -s -X PUT -H "Accept: application/vnd.gravitino.v1+json" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Basic $(echo -n 'admin:' | base64)" \
+  -d '{"usersToAdd":["alice","bob"],"usersToRemove":["carol"]}' \
+  http://localhost:8090/api/idp/groups/engineering/users
+```
+
+| HTTP status | Meaning |
+|-------------|---------|
+| 404 | Group or referenced user does not exist |
+
+---
+
+## Relationship to Gravitino authorization users
+
+Built-in IdP tables are **global** (no `metalake_id`). Gravitino metalake-scoped `user_meta` /
+`group_meta` used by access control are separate. The link is **logical**, by matching
+`user_name` / `group_name` strings across metalakes—not a database foreign key.
+
+Typical flow after HTTP Basic auth is wired:
+
+1. Create built-in IdP users/groups via `/api/idp/*`.
+2. Create matching Gravitino users/groups in each metalake for RBAC.
+3. Assign roles and privileges using [access control](./security/access-control.md).
+
+---
+
+## Security notes
+
+- Store only **password hashes** in the database; never log plaintext passwords.
+- Use [HTTPS](./security/how-to-use-https.md) when sending credentials once HTTP Basic auth is enabled.
+- Restrict IdP management to **service admins**; do not expose `/api/idp/*` anonymously.
+- Built-in IdP is recommended for **POC and isolated** environments, not as a full enterprise IdP.
+
+---
+
+## OpenAPI and further reading
+
+- OpenAPI: [docs/open-api/idp/openapi.yaml](./open-api/idp/openapi.yaml)
+- Design doc: [design-docs/gravitino-local-authentication.md](../design-docs/gravitino-local-authentication.md)
+- General authentication modes: [How to authenticate](./security/how-to-authenticate.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -211,6 +211,7 @@ Gravitino provides security configurations for Gravitino, including HTTPS, authe
 
 * [HTTPS](./security/how-to-use-https.md): provides HTTPS configurations.
 * [Authentication](./security/how-to-authenticate.md): provides authentication configurations including simple, OAuth, Kerberos.
+* [Built-in IdP](./how-to-use-idp.md): manage built-in IdP users and groups via `/api/idp` (idp-basic plugin).
 * [Access Control](./security/access-control.md): provides access control configurations.
 * [CORS](./security/how-to-use-cors.md): provides CORS configurations.
 

--- a/docs/security/security.md
+++ b/docs/security/security.md
@@ -17,6 +17,8 @@ Gravitino has supported the following security features:
 
 ### [Authentication](how-to-authenticate.md)
 
+### [Built-in IdP (local authentication)](../how-to-use-idp.md)
+
 ### [HTTPS](how-to-use-https.md)
 
 ### [Access Control](access-control.md)


### PR DESCRIPTION
### What changes were proposed in this pull request?

- Add `docs/how-to-use-idp.md`, a practical guide for the built-in IdP (`idp-basic` plugin): configuration, management REST APIs, password rules, and current deployment limitations.
- Update `design-docs/gravitino-local-authentication.md` to match implemented behavior (group membership API, extension package config, mark startup init and HTTP Basic auth as not yet implemented).
- Link the new guide from `docs/index.md` and `docs/security/security.md`.

### Why are the changes needed?

The built-in IdP is landing across multiple PRs; operators need a single how-to that reflects the code today (including known gaps such as `basic` not being wired in `AuthenticatorFactory`).

Fix: #11279

### Does this PR introduce _any_ user-facing change?

Documentation only.

### How was this patch tested?

- Reviewed against `plugins/idp-basic` REST handlers and server auth wiring.
- No code changes; docs build not required for markdown-only edits.