### PR TITLE
[#10330] improvement(bin): Output clear error message when Java is not found or version is unsupported

### DIFF
--- a/bin/common.sh.template
+++ b/bin/common.sh.template
@@ -58,22 +58,20 @@ function check_java_version() {
   if [[ -n "${JAVA_HOME+x}" ]]; then
     JAVA="$JAVA_HOME/bin/java"
   fi
+  if ! command -v "${JAVA:-java}" > /dev/null 2>&1; then
+    echo "Error: Java not found. Please install Java 17 or newer and set JAVA_HOME or add java to PATH."
+    exit 1
+  fi
   java_ver_output=$("${JAVA:-java}" -version 2>&1)
   jvmver=$(echo "$java_ver_output" | grep '[openjdk|java] version' | awk -F'"' 'NR==1 {print $2}' | cut -d\- -f1)
   JVM_VERSION=$(echo "$jvmver"|sed -e 's|^\([0-9][0-9]*\)\..*$|\1|')
-  if [ "$JVM_VERSION" = "1" ]; then
+  if [[ "$JVM_VERSION" = "1" ]]; then
     JVM_VERSION=$(echo "$jvmver"|sed -e 's|^1\.\([0-9][0-9]*\)\..*$|\1|')
   fi
 
-  if [ "$JVM_VERSION" -lt 8 ]; then
-    echo "Gravitino requires either Java 8 or newer"
+  if [[ "$JVM_VERSION" -lt 17 ]]; then
+    echo "Error: Gravitino requires Java 17 or newer, but found Java ${JVM_VERSION}."
     exit 1
-  fi
-
-  # JDK 8u151 version fixed a number of security vulnerabilities and issues to improve system stability and security.
-  # https://www.oracle.com/java/technologies/javase/8u151-relnotes.html
-  if [[ "$JVM_VERSION" -eq 8 && "${jvmver#*_}" -lt 151 ]]; then
-    echo "[WARNING] Gravitino highly recommends using either Java 8 update 151 or newer"
   fi
 }
 

--- a/bin/gravitino-iceberg-rest-server.sh.template
+++ b/bin/gravitino-iceberg-rest-server.sh.template
@@ -152,7 +152,7 @@ JAVA_OPTS+=" -Dlog4j2.configurationFile=file://${GRAVITINO_CONF_DIR}/gravitino-i
 JAVA_OPTS+=" -Dgravitino.iceberg-rest-server.log.path=${GRAVITINO_LOG_DIR}"
 JAVA_OPTS+=" -Dgravitino.iceberg-rest-server.name=${GRAVITINO_SIMPLE_SERVER_NAME}"
 JAVA_OPTS+=" ${GRAVITINO_MEM}"
-if [ "$JVM_VERSION" -eq 17 ]; then
+if [[ "$JVM_VERSION" -eq 17 ]]; then
   JAVA_OPTS+=" -XX:+IgnoreUnrecognizedVMOptions"
   JAVA_OPTS+=" --add-opens java.base/java.io=ALL-UNNAMED"
   JAVA_OPTS+=" --add-opens java.base/java.lang.invoke=ALL-UNNAMED"

--- a/bin/gravitino-lance-rest-server.sh.template
+++ b/bin/gravitino-lance-rest-server.sh.template
@@ -152,7 +152,7 @@ JAVA_OPTS+=" -Dlog4j2.configurationFile=file://${GRAVITINO_CONF_DIR}/gravitino-l
 JAVA_OPTS+=" -Dgravitino.lance-rest-server.log.path=${GRAVITINO_LOG_DIR}"
 JAVA_OPTS+=" -Dgravitino.lance-rest-server.name=${GRAVITINO_SIMPLE_SERVER_NAME}"
 JAVA_OPTS+=" ${GRAVITINO_MEM}"
-if [ "$JVM_VERSION" -eq 17 ]; then
+if [[ "$JVM_VERSION" -eq 17 ]]; then
   JAVA_OPTS+=" -XX:+IgnoreUnrecognizedVMOptions"
   JAVA_OPTS+=" --add-opens java.base/java.io=ALL-UNNAMED"
   JAVA_OPTS+=" --add-opens java.base/java.lang.invoke=ALL-UNNAMED"

--- a/bin/gravitino-optimizer.sh.template
+++ b/bin/gravitino-optimizer.sh.template
@@ -50,7 +50,7 @@ JAVA_OPTS+=" -Dfile.encoding=UTF-8"
 JAVA_OPTS+=" -Dlog4j2.configurationFile=file://${GRAVITINO_CONF_DIR}/log4j2.properties"
 JAVA_OPTS+=" -Dgravitino.log.path=${GRAVITINO_LOG_DIR} ${GRAVITINO_MEM}"
 JAVA_OPTS+=" -Dgravitino.server.name=${GRAVITINO_LOG_NAME}"
-if [ "$JVM_VERSION" -eq 17 ]; then
+if [[ "$JVM_VERSION" -eq 17 ]]; then
   JAVA_OPTS+=" -XX:+IgnoreUnrecognizedVMOptions"
   JAVA_OPTS+=" --add-opens java.base/java.io=ALL-UNNAMED"
   JAVA_OPTS+=" --add-opens java.base/java.lang.invoke=ALL-UNNAMED"

--- a/bin/gravitino.sh.template
+++ b/bin/gravitino.sh.template
@@ -153,7 +153,7 @@ JAVA_OPTS+=" -Dgravitino.log.path=${GRAVITINO_LOG_DIR}"
 JAVA_OPTS+=" -Dgravitino.server.name=${GRAVITINO_SIMPLE_SERVER_NAME}"
 JAVA_OPTS+=" ${GRAVITINO_MEM}"
 
-if [ "$JVM_VERSION" -eq 17 ]; then
+if [[ "$JVM_VERSION" -eq 17 ]]; then
   JAVA_OPTS+=" -XX:+IgnoreUnrecognizedVMOptions"
   JAVA_OPTS+=" --add-opens java.base/java.io=ALL-UNNAMED"
   JAVA_OPTS+=" --add-opens java.base/java.lang.invoke=ALL-UNNAMED"


### PR DESCRIPTION
### What changes were proposed in this pull request?

- Add an explicit Java existence check in `check_java_version()` in `bin/common.sh.template` to print a clear error message when `java` is not on `PATH` and `JAVA_HOME` is not set, instead of the cryptic `integer expression expected` errors.
- Bump the minimum required Java version from 8 to 17 with a clear error message.
- Replace single-bracket `[ ]` with double-bracket `[[ ]]` for `JVM_VERSION` comparisons across all shell script templates (`gravitino.sh`, `gravitino-iceberg-rest-server.sh`, `gravitino-lance-rest-server.sh`, `gravitino-optimizer.sh`).

### Why are the changes needed?

When Java is not installed or not on `PATH`, running `gravitino.sh` produces confusing errors:
```
common.sh: line 68: [: : integer expression expected
gravitino.sh: line 154: [: : integer expression expected
```
Users should get a clear, actionable message instead.

Fix: #10330

### Does this PR introduce _any_ user-facing change?

Yes — users running Gravitino with Java older than 17 will now see a clear error message instead of a cryptic one.

### How was this patch tested?

Reproduced the issue locally with `env PATH=/usr/bin:/bin JAVA_HOME="" ./distribution/package/bin/gravitino.sh status` and verified the fix outputs the correct error message.