### PR TITLE
[#11287] feat(spark-connector): Add view support for Hive catalog

### DIFF
--- a/catalogs/catalog-hive/src/main/java/org/apache/gravitino/catalog/hive/HiveView.java
+++ b/catalogs/catalog-hive/src/main/java/org/apache/gravitino/catalog/hive/HiveView.java
@@ -52,7 +52,7 @@ import org.apache.gravitino.rel.View;
 @ToString
 public class HiveView implements View {
 
-  private static final String SPARK_VERSION_KEY = "spark.sql.create.version";
+  static final String SPARK_VERSION_KEY = "spark.sql.create.version";
   static final String SPARK_DEFAULT_CATALOG_KEY = "gravitino.view.default.catalog";
   static final String SPARK_DEFAULT_SCHEMA_KEY = "gravitino.view.default.schema";
   static final String FLINK_PROPERTY_PREFIX = "flink.";
@@ -132,14 +132,6 @@ public class HiveView implements View {
       return Dialects.FLINK;
     }
     return Dialects.HIVE;
-  }
-
-  /**
-   * Returns true if {@code properties} contains the Spark dialect marker key {@code
-   * spark.sql.create.version}, which {@link #detectDialect} requires to identify a view as Spark.
-   */
-  static boolean hasSparkMarker(Map<String, String> properties) {
-    return properties.containsKey(SPARK_VERSION_KEY);
   }
 
   /** Builder for {@link HiveView}. */

--- a/catalogs/catalog-hive/src/main/java/org/apache/gravitino/catalog/hive/HiveView.java
+++ b/catalogs/catalog-hive/src/main/java/org/apache/gravitino/catalog/hive/HiveView.java
@@ -53,6 +53,8 @@ import org.apache.gravitino.rel.View;
 public class HiveView implements View {
 
   static final String SPARK_VERSION_KEY = "spark.sql.create.version";
+  static final String SPARK_DEFAULT_CATALOG_KEY = "gravitino.view.default.catalog";
+  static final String SPARK_DEFAULT_SCHEMA_KEY = "gravitino.view.default.schema";
   private static final String TRINO_VIEW_MARKER_KEY = "presto_view";
   private static final String TRINO_VIEW_PREFIX = "/* Presto View:";
 

--- a/catalogs/catalog-hive/src/main/java/org/apache/gravitino/catalog/hive/HiveView.java
+++ b/catalogs/catalog-hive/src/main/java/org/apache/gravitino/catalog/hive/HiveView.java
@@ -53,8 +53,6 @@ import org.apache.gravitino.rel.View;
 public class HiveView implements View {
 
   static final String SPARK_VERSION_KEY = "spark.sql.create.version";
-  static final String VIEW_DEFAULT_CATALOG_KEY = "gravitino.view.default.catalog";
-  static final String VIEW_DEFAULT_SCHEMA_KEY = "gravitino.view.default.schema";
   static final String FLINK_PROPERTY_PREFIX = "flink.";
   private static final String TRINO_VIEW_MARKER_KEY = "presto_view";
   private static final String TRINO_VIEW_PREFIX = "/* Presto View:";

--- a/catalogs/catalog-hive/src/main/java/org/apache/gravitino/catalog/hive/HiveView.java
+++ b/catalogs/catalog-hive/src/main/java/org/apache/gravitino/catalog/hive/HiveView.java
@@ -52,7 +52,7 @@ import org.apache.gravitino.rel.View;
 @ToString
 public class HiveView implements View {
 
-  private static final String SPARK_VERSION_KEY = "spark.sql.create.version";
+  static final String SPARK_VERSION_KEY = "spark.sql.create.version";
   private static final String TRINO_VIEW_MARKER_KEY = "presto_view";
   private static final String TRINO_VIEW_PREFIX = "/* Presto View:";
 

--- a/catalogs/catalog-hive/src/main/java/org/apache/gravitino/catalog/hive/HiveView.java
+++ b/catalogs/catalog-hive/src/main/java/org/apache/gravitino/catalog/hive/HiveView.java
@@ -52,7 +52,7 @@ import org.apache.gravitino.rel.View;
 @ToString
 public class HiveView implements View {
 
-  static final String SPARK_VERSION_KEY = "spark.sql.create.version";
+  private static final String SPARK_VERSION_KEY = "spark.sql.create.version";
   static final String SPARK_DEFAULT_CATALOG_KEY = "gravitino.view.default.catalog";
   static final String SPARK_DEFAULT_SCHEMA_KEY = "gravitino.view.default.schema";
   static final String FLINK_PROPERTY_PREFIX = "flink.";
@@ -132,6 +132,14 @@ public class HiveView implements View {
       return Dialects.FLINK;
     }
     return Dialects.HIVE;
+  }
+
+  /**
+   * Returns true if {@code properties} contains the Spark dialect marker key {@code
+   * spark.sql.create.version}, which {@link #detectDialect} requires to identify a view as Spark.
+   */
+  static boolean hasSparkMarker(Map<String, String> properties) {
+    return properties.containsKey(SPARK_VERSION_KEY);
   }
 
   /** Builder for {@link HiveView}. */

--- a/catalogs/catalog-hive/src/main/java/org/apache/gravitino/catalog/hive/HiveView.java
+++ b/catalogs/catalog-hive/src/main/java/org/apache/gravitino/catalog/hive/HiveView.java
@@ -55,6 +55,7 @@ public class HiveView implements View {
   static final String SPARK_VERSION_KEY = "spark.sql.create.version";
   static final String SPARK_DEFAULT_CATALOG_KEY = "gravitino.view.default.catalog";
   static final String SPARK_DEFAULT_SCHEMA_KEY = "gravitino.view.default.schema";
+  static final String FLINK_PROPERTY_PREFIX = "flink.";
   private static final String TRINO_VIEW_MARKER_KEY = "presto_view";
   private static final String TRINO_VIEW_PREFIX = "/* Presto View:";
 
@@ -126,7 +127,8 @@ public class HiveView implements View {
     if (parameters != null && parameters.containsKey(SPARK_VERSION_KEY)) {
       return Dialects.SPARK;
     }
-    if (parameters != null && parameters.keySet().stream().anyMatch(k -> k.startsWith("flink."))) {
+    if (parameters != null
+        && parameters.keySet().stream().anyMatch(k -> k.startsWith(FLINK_PROPERTY_PREFIX))) {
       return Dialects.FLINK;
     }
     return Dialects.HIVE;

--- a/catalogs/catalog-hive/src/main/java/org/apache/gravitino/catalog/hive/HiveView.java
+++ b/catalogs/catalog-hive/src/main/java/org/apache/gravitino/catalog/hive/HiveView.java
@@ -53,8 +53,8 @@ import org.apache.gravitino.rel.View;
 public class HiveView implements View {
 
   static final String SPARK_VERSION_KEY = "spark.sql.create.version";
-  static final String SPARK_DEFAULT_CATALOG_KEY = "gravitino.view.default.catalog";
-  static final String SPARK_DEFAULT_SCHEMA_KEY = "gravitino.view.default.schema";
+  static final String VIEW_DEFAULT_CATALOG_KEY = "gravitino.view.default.catalog";
+  static final String VIEW_DEFAULT_SCHEMA_KEY = "gravitino.view.default.schema";
   static final String FLINK_PROPERTY_PREFIX = "flink.";
   private static final String TRINO_VIEW_MARKER_KEY = "presto_view";
   private static final String TRINO_VIEW_PREFIX = "/* Presto View:";

--- a/catalogs/catalog-hive/src/main/java/org/apache/gravitino/catalog/hive/HiveViewCatalogOperations.java
+++ b/catalogs/catalog-hive/src/main/java/org/apache/gravitino/catalog/hive/HiveViewCatalogOperations.java
@@ -458,11 +458,10 @@ class HiveViewCatalogOperations implements ViewCatalog {
         return selected;
       case Dialects.SPARK:
         Preconditions.checkArgument(
-            properties.containsKey(HiveView.SPARK_VERSION_KEY),
-            "Spark dialect view '%s' requires property '%s' to be set; "
+            HiveView.hasSparkMarker(properties),
+            "Spark dialect view '%s' requires property 'spark.sql.create.version' to be set; "
                 + "without it the view silently round-trips as Hive dialect on reload",
-            ident,
-            HiveView.SPARK_VERSION_KEY);
+            ident);
         return selected;
       default:
         // TODO(design-docs/gravitino-logical-view-management.md): support creating trino HMS views.

--- a/catalogs/catalog-hive/src/main/java/org/apache/gravitino/catalog/hive/HiveViewCatalogOperations.java
+++ b/catalogs/catalog-hive/src/main/java/org/apache/gravitino/catalog/hive/HiveViewCatalogOperations.java
@@ -364,13 +364,13 @@ class HiveViewCatalogOperations implements ViewCatalog {
     String representationSql = viewOriginalText;
     String detectedDialect = HiveView.detectDialect(representationSql, params);
     if (!Dialects.HIVE.equalsIgnoreCase(detectedDialect)
-        && !Dialects.FLINK.equalsIgnoreCase(detectedDialect)) {
-      // TODO(design-docs/gravitino-logical-view-management.md): support loading trino/spark HMS
-      // views.
+        && !Dialects.FLINK.equalsIgnoreCase(detectedDialect)
+        && !Dialects.SPARK.equalsIgnoreCase(detectedDialect)) {
+      // TODO(design-docs/gravitino-logical-view-management.md): support loading trino HMS views.
       throw new UnsupportedOperationException(
           String.format(
-              "Hive catalog currently supports only '%s' and '%s' view dialects, but found '%s' for view %s",
-              Dialects.HIVE, Dialects.FLINK, detectedDialect, ident));
+              "Hive catalog currently supports only '%s', '%s' and '%s' view dialects, but found '%s' for view %s",
+              Dialects.HIVE, Dialects.FLINK, Dialects.SPARK, detectedDialect, ident));
     }
 
     SQLRepresentation rep =
@@ -418,25 +418,27 @@ class HiveViewCatalogOperations implements ViewCatalog {
             defaultSchema,
             ident);
         return selected;
+      case Dialects.SPARK:
+        return selected;
       default:
-        // TODO(design-docs/gravitino-logical-view-management.md): support creating trino/spark HMS
-        // views.
+        // TODO(design-docs/gravitino-logical-view-management.md): support creating trino HMS views.
         throw new UnsupportedOperationException(
             String.format(
-                "Hive catalog currently supports only '%s' and '%s' view dialects, but got '%s' for view %s",
-                Dialects.HIVE, Dialects.FLINK, selected.dialect(), ident));
+                "Hive catalog currently supports only '%s', '%s' and '%s' view dialects, but got '%s' for view %s",
+                Dialects.HIVE, Dialects.FLINK, Dialects.SPARK, selected.dialect(), ident));
     }
   }
 
   private String toHmsViewOriginalText(SQLRepresentation representation, NameIdentifier ident) {
     if (!Dialects.HIVE.equalsIgnoreCase(representation.dialect())
-        && !Dialects.FLINK.equalsIgnoreCase(representation.dialect())) {
-      // TODO(design-docs/gravitino-logical-view-management.md): support serializing trino/spark HMS
+        && !Dialects.FLINK.equalsIgnoreCase(representation.dialect())
+        && !Dialects.SPARK.equalsIgnoreCase(representation.dialect())) {
+      // TODO(design-docs/gravitino-logical-view-management.md): support serializing trino HMS
       // view definitions.
       throw new UnsupportedOperationException(
           String.format(
-              "Hive catalog currently supports only '%s' and '%s' view dialects, but got '%s' for view %s",
-              Dialects.HIVE, Dialects.FLINK, representation.dialect(), ident));
+              "Hive catalog currently supports only '%s', '%s' and '%s' view dialects, but got '%s' for view %s",
+              Dialects.HIVE, Dialects.FLINK, Dialects.SPARK, representation.dialect(), ident));
     }
     return representation.sql();
   }

--- a/catalogs/catalog-hive/src/main/java/org/apache/gravitino/catalog/hive/HiveViewCatalogOperations.java
+++ b/catalogs/catalog-hive/src/main/java/org/apache/gravitino/catalog/hive/HiveViewCatalogOperations.java
@@ -127,6 +127,13 @@ class HiveViewCatalogOperations implements ViewCatalog {
                 + "without it the view silently round-trips as Hive dialect on reload",
             ident,
             HiveView.SPARK_VERSION_KEY);
+      } else if (Dialects.FLINK.equalsIgnoreCase(sqlRepresentation.dialect())) {
+        Preconditions.checkArgument(
+            params.keySet().stream().anyMatch(k -> k.startsWith(HiveView.FLINK_PROPERTY_PREFIX)),
+            "Flink dialect view '%s' requires at least one property with prefix '%s' to be set; "
+                + "without it the view silently round-trips as Hive dialect on reload",
+            ident,
+            HiveView.FLINK_PROPERTY_PREFIX);
       }
       if (defaultCatalog != null) {
         params.put(HiveView.SPARK_DEFAULT_CATALOG_KEY, defaultCatalog);

--- a/catalogs/catalog-hive/src/main/java/org/apache/gravitino/catalog/hive/HiveViewCatalogOperations.java
+++ b/catalogs/catalog-hive/src/main/java/org/apache/gravitino/catalog/hive/HiveViewCatalogOperations.java
@@ -119,6 +119,9 @@ class HiveViewCatalogOperations implements ViewCatalog {
       Map<String, String> params =
           Maps.newHashMap(properties == null ? ImmutableMap.of() : properties);
       params.put(TABLE_TYPE, TableType.VIRTUAL_VIEW.name());
+      if (Dialects.SPARK.equalsIgnoreCase(sqlRepresentation.dialect())) {
+        params.putIfAbsent(HiveView.SPARK_VERSION_KEY, "gravitino");
+      }
       String viewOriginalText = toHmsViewOriginalText(sqlRepresentation, ident);
 
       HiveTable hiveTable =
@@ -428,7 +431,7 @@ class HiveViewCatalogOperations implements ViewCatalog {
   }
 
   private String toHmsViewOriginalText(SQLRepresentation representation, NameIdentifier ident) {
-    if (!Dialects.TRINO.equalsIgnoreCase(representation.dialect())) {
+    if (Dialects.TRINO.equalsIgnoreCase(representation.dialect())) {
       // TODO(design-docs/gravitino-logical-view-management.md): support serializing trino HMS
       // view definitions.
       throw new UnsupportedOperationException(

--- a/catalogs/catalog-hive/src/main/java/org/apache/gravitino/catalog/hive/HiveViewCatalogOperations.java
+++ b/catalogs/catalog-hive/src/main/java/org/apache/gravitino/catalog/hive/HiveViewCatalogOperations.java
@@ -119,9 +119,6 @@ class HiveViewCatalogOperations implements ViewCatalog {
       Map<String, String> params =
           Maps.newHashMap(properties == null ? ImmutableMap.of() : properties);
       params.put(TABLE_TYPE, TableType.VIRTUAL_VIEW.name());
-      if (Dialects.SPARK.equalsIgnoreCase(sqlRepresentation.dialect())) {
-        params.putIfAbsent(HiveView.SPARK_VERSION_KEY, "gravitino");
-      }
       String viewOriginalText = toHmsViewOriginalText(sqlRepresentation, ident);
 
       HiveTable hiveTable =
@@ -366,12 +363,17 @@ class HiveViewCatalogOperations implements ViewCatalog {
         Maps.newHashMap(properties != null ? properties : ImmutableMap.of());
     String representationSql = viewOriginalText;
     String detectedDialect = HiveView.detectDialect(representationSql, params);
-    if (Dialects.TRINO.equalsIgnoreCase(detectedDialect)) {
-      // TODO(design-docs/gravitino-logical-view-management.md): support loading trino HMS views.
-      throw new UnsupportedOperationException(
-          String.format(
-              "Hive catalog currently supports only '%s', '%s' and '%s' view dialects, but found '%s' for view %s",
-              Dialects.HIVE, Dialects.FLINK, Dialects.SPARK, detectedDialect, ident));
+    switch (detectedDialect.toLowerCase(java.util.Locale.ROOT)) {
+      case Dialects.HIVE:
+      case Dialects.FLINK:
+      case Dialects.SPARK:
+        break;
+      default:
+        // TODO(design-docs/gravitino-logical-view-management.md): support loading trino HMS views.
+        throw new UnsupportedOperationException(
+            String.format(
+                "Hive catalog currently supports only '%s', '%s' and '%s' view dialects, but found '%s' for view %s",
+                Dialects.HIVE, Dialects.FLINK, Dialects.SPARK, detectedDialect, ident));
     }
 
     SQLRepresentation rep =
@@ -431,15 +433,19 @@ class HiveViewCatalogOperations implements ViewCatalog {
   }
 
   private String toHmsViewOriginalText(SQLRepresentation representation, NameIdentifier ident) {
-    if (Dialects.TRINO.equalsIgnoreCase(representation.dialect())) {
-      // TODO(design-docs/gravitino-logical-view-management.md): support serializing trino HMS
-      // view definitions.
-      throw new UnsupportedOperationException(
-          String.format(
-              "Hive catalog currently supports only '%s', '%s' and '%s' view dialects, but got '%s' for view %s",
-              Dialects.HIVE, Dialects.FLINK, Dialects.SPARK, representation.dialect(), ident));
+    switch (representation.dialect().toLowerCase(java.util.Locale.ROOT)) {
+      case Dialects.HIVE:
+      case Dialects.FLINK:
+      case Dialects.SPARK:
+        return representation.sql();
+      default:
+        // TODO(design-docs/gravitino-logical-view-management.md): support serializing trino HMS
+        // view definitions.
+        throw new UnsupportedOperationException(
+            String.format(
+                "Hive catalog currently supports only '%s', '%s' and '%s' view dialects, but got '%s' for view %s",
+                Dialects.HIVE, Dialects.FLINK, Dialects.SPARK, representation.dialect(), ident));
     }
-    return representation.sql();
   }
 
   private String extractRenameTargetName(String originalName, ViewChange[] changes) {

--- a/catalogs/catalog-hive/src/main/java/org/apache/gravitino/catalog/hive/HiveViewCatalogOperations.java
+++ b/catalogs/catalog-hive/src/main/java/org/apache/gravitino/catalog/hive/HiveViewCatalogOperations.java
@@ -119,6 +119,12 @@ class HiveViewCatalogOperations implements ViewCatalog {
       Map<String, String> params =
           Maps.newHashMap(properties == null ? ImmutableMap.of() : properties);
       params.put(TABLE_TYPE, TableType.VIRTUAL_VIEW.name());
+      if (defaultCatalog != null) {
+        params.put(HiveView.SPARK_DEFAULT_CATALOG_KEY, defaultCatalog);
+      }
+      if (defaultSchema != null) {
+        params.put(HiveView.SPARK_DEFAULT_SCHEMA_KEY, defaultSchema);
+      }
       String viewOriginalText = toHmsViewOriginalText(sqlRepresentation, ident);
 
       HiveTable hiveTable =
@@ -387,6 +393,8 @@ class HiveViewCatalogOperations implements ViewCatalog {
         .withComment(comment)
         .withColumns(copyColumns(columns))
         .withRepresentations(new SQLRepresentation[] {rep})
+        .withDefaultCatalog(params.remove(HiveView.SPARK_DEFAULT_CATALOG_KEY))
+        .withDefaultSchema(params.remove(HiveView.SPARK_DEFAULT_SCHEMA_KEY))
         .withProperties(params)
         .withAuditInfo(auditInfo)
         .build();

--- a/catalogs/catalog-hive/src/main/java/org/apache/gravitino/catalog/hive/HiveViewCatalogOperations.java
+++ b/catalogs/catalog-hive/src/main/java/org/apache/gravitino/catalog/hive/HiveViewCatalogOperations.java
@@ -31,6 +31,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
+import javax.annotation.Nullable;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.gravitino.NameIdentifier;
@@ -114,27 +115,13 @@ class HiveViewCatalogOperations implements ViewCatalog {
       throw new NoSuchSchemaException("Schema %s does not exist", schemaIdent);
     }
     SQLRepresentation sqlRepresentation =
-        validateSQLRepresentation(representations, defaultCatalog, defaultSchema, ident);
+        validateSQLRepresentation(
+            representations, defaultCatalog, defaultSchema, properties, ident);
 
     try {
       Map<String, String> params =
           Maps.newHashMap(properties == null ? ImmutableMap.of() : properties);
       params.put(TABLE_TYPE, TableType.VIRTUAL_VIEW.name());
-      if (Dialects.SPARK.equalsIgnoreCase(sqlRepresentation.dialect())) {
-        Preconditions.checkArgument(
-            params.containsKey(HiveView.SPARK_VERSION_KEY),
-            "Spark dialect view '%s' requires property '%s' to be set; "
-                + "without it the view silently round-trips as Hive dialect on reload",
-            ident,
-            HiveView.SPARK_VERSION_KEY);
-      } else if (Dialects.FLINK.equalsIgnoreCase(sqlRepresentation.dialect())) {
-        Preconditions.checkArgument(
-            params.keySet().stream().anyMatch(k -> k.startsWith(HiveView.FLINK_PROPERTY_PREFIX)),
-            "Flink dialect view '%s' requires at least one property with prefix '%s' to be set; "
-                + "without it the view silently round-trips as Hive dialect on reload",
-            ident,
-            HiveView.FLINK_PROPERTY_PREFIX);
-      }
       if (defaultCatalog != null) {
         params.put(HiveView.SPARK_DEFAULT_CATALOG_KEY, defaultCatalog);
       }
@@ -234,6 +221,7 @@ class HiveViewCatalogOperations implements ViewCatalog {
                   replace.getRepresentations(),
                   replace.getDefaultCatalog(),
                   replace.getDefaultSchema(),
+                  null,
                   ident);
           updatedColumns = copyColumns(replace.getColumns());
           updatedComment = replace.getComment();
@@ -416,10 +404,19 @@ class HiveViewCatalogOperations implements ViewCatalog {
         .build();
   }
 
+  /**
+   * Validates that {@code representations} contains exactly one {@link SQLRepresentation} with a
+   * supported dialect, and that dialect-specific constraints are satisfied.
+   *
+   * @param properties caller-supplied view properties; when non-null, marker-property presence is
+   *     validated (required for create; null is passed by alter to skip this check because the
+   *     markers are already stored in HMS from the original create)
+   */
   private SQLRepresentation validateSQLRepresentation(
       Representation[] representations,
       String defaultCatalog,
       String defaultSchema,
+      @Nullable Map<String, String> properties,
       NameIdentifier ident) {
     int representationCount = representations == null ? 0 : representations.length;
     Representation firstRepresentation =
@@ -444,8 +441,25 @@ class HiveViewCatalogOperations implements ViewCatalog {
             defaultCatalog,
             defaultSchema,
             ident);
+        if (Dialects.FLINK.equalsIgnoreCase(selected.dialect()) && properties != null) {
+          Preconditions.checkArgument(
+              properties.keySet().stream()
+                  .anyMatch(k -> k.startsWith(HiveView.FLINK_PROPERTY_PREFIX)),
+              "Flink dialect view '%s' requires at least one property with prefix '%s' to be set; "
+                  + "without it the view silently round-trips as Hive dialect on reload",
+              ident,
+              HiveView.FLINK_PROPERTY_PREFIX);
+        }
         return selected;
       case Dialects.SPARK:
+        if (properties != null) {
+          Preconditions.checkArgument(
+              properties.containsKey(HiveView.SPARK_VERSION_KEY),
+              "Spark dialect view '%s' requires property '%s' to be set; "
+                  + "without it the view silently round-trips as Hive dialect on reload",
+              ident,
+              HiveView.SPARK_VERSION_KEY);
+        }
         return selected;
       default:
         // TODO(design-docs/gravitino-logical-view-management.md): support creating trino HMS views.

--- a/catalogs/catalog-hive/src/main/java/org/apache/gravitino/catalog/hive/HiveViewCatalogOperations.java
+++ b/catalogs/catalog-hive/src/main/java/org/apache/gravitino/catalog/hive/HiveViewCatalogOperations.java
@@ -430,6 +430,15 @@ class HiveViewCatalogOperations implements ViewCatalog {
     SQLRepresentation selected = (SQLRepresentation) firstRepresentation;
     switch (selected.dialect().toLowerCase(Locale.ROOT)) {
       case Dialects.HIVE:
+        Preconditions.checkArgument(
+            defaultCatalog == null && defaultSchema == null,
+            "Dialect '%s' does not support non-null defaultCatalog/defaultSchema, but got "
+                + "defaultCatalog=%s, defaultSchema=%s for view %s",
+            selected.dialect(),
+            defaultCatalog,
+            defaultSchema,
+            ident);
+        return selected;
       case Dialects.FLINK:
         Preconditions.checkArgument(
             defaultCatalog == null && defaultSchema == null,
@@ -439,15 +448,13 @@ class HiveViewCatalogOperations implements ViewCatalog {
             defaultCatalog,
             defaultSchema,
             ident);
-        if (Dialects.FLINK.equalsIgnoreCase(selected.dialect())) {
-          Preconditions.checkArgument(
-              properties.keySet().stream()
-                  .anyMatch(k -> k.startsWith(HiveView.FLINK_PROPERTY_PREFIX)),
-              "Flink dialect view '%s' requires at least one property with prefix '%s' to be set; "
-                  + "without it the view silently round-trips as Hive dialect on reload",
-              ident,
-              HiveView.FLINK_PROPERTY_PREFIX);
-        }
+        Preconditions.checkArgument(
+            properties.keySet().stream()
+                .anyMatch(k -> k.startsWith(HiveView.FLINK_PROPERTY_PREFIX)),
+            "Flink dialect view '%s' requires at least one property with prefix '%s' to be set; "
+                + "without it the view silently round-trips as Hive dialect on reload",
+            ident,
+            HiveView.FLINK_PROPERTY_PREFIX);
         return selected;
       case Dialects.SPARK:
         Preconditions.checkArgument(

--- a/catalogs/catalog-hive/src/main/java/org/apache/gravitino/catalog/hive/HiveViewCatalogOperations.java
+++ b/catalogs/catalog-hive/src/main/java/org/apache/gravitino/catalog/hive/HiveViewCatalogOperations.java
@@ -31,7 +31,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
-import javax.annotation.Nullable;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.gravitino.NameIdentifier;
@@ -114,13 +113,13 @@ class HiveViewCatalogOperations implements ViewCatalog {
     if (!schemaExistsChecker.test(schemaIdent)) {
       throw new NoSuchSchemaException("Schema %s does not exist", schemaIdent);
     }
+    Map<String, String> safeProperties = properties == null ? ImmutableMap.of() : properties;
     SQLRepresentation sqlRepresentation =
         validateSQLRepresentation(
-            representations, defaultCatalog, defaultSchema, properties, ident);
+            representations, defaultCatalog, defaultSchema, safeProperties, ident);
 
     try {
-      Map<String, String> params =
-          Maps.newHashMap(properties == null ? ImmutableMap.of() : properties);
+      Map<String, String> params = Maps.newHashMap(safeProperties);
       params.put(TABLE_TYPE, TableType.VIRTUAL_VIEW.name());
       if (defaultCatalog != null) {
         params.put(HiveView.SPARK_DEFAULT_CATALOG_KEY, defaultCatalog);
@@ -221,7 +220,7 @@ class HiveViewCatalogOperations implements ViewCatalog {
                   replace.getRepresentations(),
                   replace.getDefaultCatalog(),
                   replace.getDefaultSchema(),
-                  null,
+                  updatedProperties,
                   ident);
           updatedColumns = copyColumns(replace.getColumns());
           updatedComment = replace.getComment();
@@ -408,15 +407,14 @@ class HiveViewCatalogOperations implements ViewCatalog {
    * Validates that {@code representations} contains exactly one {@link SQLRepresentation} with a
    * supported dialect, and that dialect-specific constraints are satisfied.
    *
-   * @param properties caller-supplied view properties; when non-null, marker-property presence is
-   *     validated (required for create; null is passed by alter to skip this check because the
-   *     markers are already stored in HMS from the original create)
+   * @param properties view properties used to verify dialect marker keys are present (e.g. {@code
+   *     spark.sql.create.version} for Spark, a {@code flink.*} key for Flink)
    */
   private SQLRepresentation validateSQLRepresentation(
       Representation[] representations,
       String defaultCatalog,
       String defaultSchema,
-      @Nullable Map<String, String> properties,
+      Map<String, String> properties,
       NameIdentifier ident) {
     int representationCount = representations == null ? 0 : representations.length;
     Representation firstRepresentation =
@@ -441,7 +439,7 @@ class HiveViewCatalogOperations implements ViewCatalog {
             defaultCatalog,
             defaultSchema,
             ident);
-        if (Dialects.FLINK.equalsIgnoreCase(selected.dialect()) && properties != null) {
+        if (Dialects.FLINK.equalsIgnoreCase(selected.dialect())) {
           Preconditions.checkArgument(
               properties.keySet().stream()
                   .anyMatch(k -> k.startsWith(HiveView.FLINK_PROPERTY_PREFIX)),
@@ -452,14 +450,12 @@ class HiveViewCatalogOperations implements ViewCatalog {
         }
         return selected;
       case Dialects.SPARK:
-        if (properties != null) {
-          Preconditions.checkArgument(
-              properties.containsKey(HiveView.SPARK_VERSION_KEY),
-              "Spark dialect view '%s' requires property '%s' to be set; "
-                  + "without it the view silently round-trips as Hive dialect on reload",
-              ident,
-              HiveView.SPARK_VERSION_KEY);
-        }
+        Preconditions.checkArgument(
+            properties.containsKey(HiveView.SPARK_VERSION_KEY),
+            "Spark dialect view '%s' requires property '%s' to be set; "
+                + "without it the view silently round-trips as Hive dialect on reload",
+            ident,
+            HiveView.SPARK_VERSION_KEY);
         return selected;
       default:
         // TODO(design-docs/gravitino-logical-view-management.md): support creating trino HMS views.

--- a/catalogs/catalog-hive/src/main/java/org/apache/gravitino/catalog/hive/HiveViewCatalogOperations.java
+++ b/catalogs/catalog-hive/src/main/java/org/apache/gravitino/catalog/hive/HiveViewCatalogOperations.java
@@ -121,12 +121,6 @@ class HiveViewCatalogOperations implements ViewCatalog {
     try {
       Map<String, String> params = Maps.newHashMap(safeProperties);
       params.put(TABLE_TYPE, TableType.VIRTUAL_VIEW.name());
-      if (defaultCatalog != null) {
-        params.put(HiveView.VIEW_DEFAULT_CATALOG_KEY, defaultCatalog);
-      }
-      if (defaultSchema != null) {
-        params.put(HiveView.VIEW_DEFAULT_SCHEMA_KEY, defaultSchema);
-      }
       String viewOriginalText = toHmsViewOriginalText(sqlRepresentation, ident);
 
       HiveTable hiveTable =
@@ -396,8 +390,6 @@ class HiveViewCatalogOperations implements ViewCatalog {
         .withComment(comment)
         .withColumns(copyColumns(columns))
         .withRepresentations(new SQLRepresentation[] {rep})
-        .withDefaultCatalog(params.remove(HiveView.VIEW_DEFAULT_CATALOG_KEY))
-        .withDefaultSchema(params.remove(HiveView.VIEW_DEFAULT_SCHEMA_KEY))
         .withProperties(params)
         .withAuditInfo(auditInfo)
         .build();

--- a/catalogs/catalog-hive/src/main/java/org/apache/gravitino/catalog/hive/HiveViewCatalogOperations.java
+++ b/catalogs/catalog-hive/src/main/java/org/apache/gravitino/catalog/hive/HiveViewCatalogOperations.java
@@ -363,9 +363,7 @@ class HiveViewCatalogOperations implements ViewCatalog {
         Maps.newHashMap(properties != null ? properties : ImmutableMap.of());
     String representationSql = viewOriginalText;
     String detectedDialect = HiveView.detectDialect(representationSql, params);
-    if (!Dialects.HIVE.equalsIgnoreCase(detectedDialect)
-        && !Dialects.FLINK.equalsIgnoreCase(detectedDialect)
-        && !Dialects.SPARK.equalsIgnoreCase(detectedDialect)) {
+    if (Dialects.TRINO.equalsIgnoreCase(detectedDialect)) {
       // TODO(design-docs/gravitino-logical-view-management.md): support loading trino HMS views.
       throw new UnsupportedOperationException(
           String.format(
@@ -430,9 +428,7 @@ class HiveViewCatalogOperations implements ViewCatalog {
   }
 
   private String toHmsViewOriginalText(SQLRepresentation representation, NameIdentifier ident) {
-    if (!Dialects.HIVE.equalsIgnoreCase(representation.dialect())
-        && !Dialects.FLINK.equalsIgnoreCase(representation.dialect())
-        && !Dialects.SPARK.equalsIgnoreCase(representation.dialect())) {
+    if (!Dialects.TRINO.equalsIgnoreCase(representation.dialect())) {
       // TODO(design-docs/gravitino-logical-view-management.md): support serializing trino HMS
       // view definitions.
       throw new UnsupportedOperationException(

--- a/catalogs/catalog-hive/src/main/java/org/apache/gravitino/catalog/hive/HiveViewCatalogOperations.java
+++ b/catalogs/catalog-hive/src/main/java/org/apache/gravitino/catalog/hive/HiveViewCatalogOperations.java
@@ -27,6 +27,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import java.time.Instant;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
@@ -119,6 +120,14 @@ class HiveViewCatalogOperations implements ViewCatalog {
       Map<String, String> params =
           Maps.newHashMap(properties == null ? ImmutableMap.of() : properties);
       params.put(TABLE_TYPE, TableType.VIRTUAL_VIEW.name());
+      if (Dialects.SPARK.equalsIgnoreCase(sqlRepresentation.dialect())) {
+        Preconditions.checkArgument(
+            params.containsKey(HiveView.SPARK_VERSION_KEY),
+            "Spark dialect view '%s' requires property '%s' to be set; "
+                + "without it the view silently round-trips as Hive dialect on reload",
+            ident,
+            HiveView.SPARK_VERSION_KEY);
+      }
       if (defaultCatalog != null) {
         params.put(HiveView.SPARK_DEFAULT_CATALOG_KEY, defaultCatalog);
       }
@@ -369,7 +378,7 @@ class HiveViewCatalogOperations implements ViewCatalog {
         Maps.newHashMap(properties != null ? properties : ImmutableMap.of());
     String representationSql = viewOriginalText;
     String detectedDialect = HiveView.detectDialect(representationSql, params);
-    switch (detectedDialect.toLowerCase(java.util.Locale.ROOT)) {
+    switch (detectedDialect.toLowerCase(Locale.ROOT)) {
       case Dialects.HIVE:
       case Dialects.FLINK:
       case Dialects.SPARK:
@@ -417,7 +426,7 @@ class HiveViewCatalogOperations implements ViewCatalog {
         firstRepresentation == null ? "null" : firstRepresentation.getClass().getSimpleName());
 
     SQLRepresentation selected = (SQLRepresentation) firstRepresentation;
-    switch (selected.dialect().toLowerCase(java.util.Locale.ROOT)) {
+    switch (selected.dialect().toLowerCase(Locale.ROOT)) {
       case Dialects.HIVE:
       case Dialects.FLINK:
         Preconditions.checkArgument(
@@ -441,7 +450,7 @@ class HiveViewCatalogOperations implements ViewCatalog {
   }
 
   private String toHmsViewOriginalText(SQLRepresentation representation, NameIdentifier ident) {
-    switch (representation.dialect().toLowerCase(java.util.Locale.ROOT)) {
+    switch (representation.dialect().toLowerCase(Locale.ROOT)) {
       case Dialects.HIVE:
       case Dialects.FLINK:
       case Dialects.SPARK:

--- a/catalogs/catalog-hive/src/main/java/org/apache/gravitino/catalog/hive/HiveViewCatalogOperations.java
+++ b/catalogs/catalog-hive/src/main/java/org/apache/gravitino/catalog/hive/HiveViewCatalogOperations.java
@@ -122,10 +122,10 @@ class HiveViewCatalogOperations implements ViewCatalog {
       Map<String, String> params = Maps.newHashMap(safeProperties);
       params.put(TABLE_TYPE, TableType.VIRTUAL_VIEW.name());
       if (defaultCatalog != null) {
-        params.put(HiveView.SPARK_DEFAULT_CATALOG_KEY, defaultCatalog);
+        params.put(HiveView.VIEW_DEFAULT_CATALOG_KEY, defaultCatalog);
       }
       if (defaultSchema != null) {
-        params.put(HiveView.SPARK_DEFAULT_SCHEMA_KEY, defaultSchema);
+        params.put(HiveView.VIEW_DEFAULT_SCHEMA_KEY, defaultSchema);
       }
       String viewOriginalText = toHmsViewOriginalText(sqlRepresentation, ident);
 
@@ -396,8 +396,8 @@ class HiveViewCatalogOperations implements ViewCatalog {
         .withComment(comment)
         .withColumns(copyColumns(columns))
         .withRepresentations(new SQLRepresentation[] {rep})
-        .withDefaultCatalog(params.remove(HiveView.SPARK_DEFAULT_CATALOG_KEY))
-        .withDefaultSchema(params.remove(HiveView.SPARK_DEFAULT_SCHEMA_KEY))
+        .withDefaultCatalog(params.remove(HiveView.VIEW_DEFAULT_CATALOG_KEY))
+        .withDefaultSchema(params.remove(HiveView.VIEW_DEFAULT_SCHEMA_KEY))
         .withProperties(params)
         .withAuditInfo(auditInfo)
         .build();

--- a/catalogs/catalog-hive/src/main/java/org/apache/gravitino/catalog/hive/HiveViewCatalogOperations.java
+++ b/catalogs/catalog-hive/src/main/java/org/apache/gravitino/catalog/hive/HiveViewCatalogOperations.java
@@ -458,10 +458,11 @@ class HiveViewCatalogOperations implements ViewCatalog {
         return selected;
       case Dialects.SPARK:
         Preconditions.checkArgument(
-            HiveView.hasSparkMarker(properties),
-            "Spark dialect view '%s' requires property 'spark.sql.create.version' to be set; "
+            properties.containsKey(HiveView.SPARK_VERSION_KEY),
+            "Spark dialect view '%s' requires property '%s' to be set; "
                 + "without it the view silently round-trips as Hive dialect on reload",
-            ident);
+            ident,
+            HiveView.SPARK_VERSION_KEY);
         return selected;
       default:
         // TODO(design-docs/gravitino-logical-view-management.md): support creating trino HMS views.

--- a/catalogs/catalog-hive/src/test/java/org/apache/gravitino/catalog/hive/TestHiveCatalogOperations.java
+++ b/catalogs/catalog-hive/src/test/java/org/apache/gravitino/catalog/hive/TestHiveCatalogOperations.java
@@ -409,6 +409,48 @@ class TestHiveCatalogOperations {
     SQLRepresentation rep = (SQLRepresentation) view.representations()[0];
     Assertions.assertEquals("spark", rep.dialect());
     Assertions.assertEquals("SELECT 1", rep.sql());
+    Assertions.assertNull(view.defaultCatalog());
+    Assertions.assertNull(view.defaultSchema());
+  }
+
+  @Test
+  void testCreateViewPersistsDefaultCatalogAndSchema() throws Exception {
+    HiveCatalogOperations op = new HiveCatalogOperations();
+    op.initialize(Maps.newHashMap(), null, HIVE_PROPERTIES_METADATA);
+
+    CachedClientPool clientPool = mock(CachedClientPool.class);
+    HiveClient hiveClient = mock(HiveClient.class);
+    HiveSchema schema = HiveSchema.builder().withCatalogName("hive").withName("db").build();
+    when(hiveClient.getDatabase(anyString(), anyString())).thenReturn(schema);
+    doNothing().when(hiveClient).createTable(any());
+    when(clientPool.run(any()))
+        .thenAnswer(
+            invocation -> {
+              ClientPool.Action<?, HiveClient, ?> action = invocation.getArgument(0);
+              return action.run(hiveClient);
+            });
+    op.clientPool = clientPool;
+
+    View view =
+        op.createView(
+            NameIdentifier.of("db", "v_spark_defaults"),
+            null,
+            new Column[0],
+            new SQLRepresentation[] {
+              SQLRepresentation.builder().withDialect("spark").withSql("SELECT 1").build()
+            },
+            "my_catalog",
+            "my_schema",
+            Maps.newHashMap(ImmutableMap.of("spark.sql.create.version", "3.5.3")));
+
+    Assertions.assertEquals("my_catalog", view.defaultCatalog());
+    Assertions.assertEquals("my_schema", view.defaultSchema());
+    Assertions.assertFalse(
+        view.properties().containsKey("gravitino.view.default.catalog"),
+        "defaultCatalog should be removed from properties after extraction");
+    Assertions.assertFalse(
+        view.properties().containsKey("gravitino.view.default.schema"),
+        "defaultSchema should be removed from properties after extraction");
   }
 
   @Test

--- a/catalogs/catalog-hive/src/test/java/org/apache/gravitino/catalog/hive/TestHiveCatalogOperations.java
+++ b/catalogs/catalog-hive/src/test/java/org/apache/gravitino/catalog/hive/TestHiveCatalogOperations.java
@@ -409,48 +409,6 @@ class TestHiveCatalogOperations {
     SQLRepresentation rep = (SQLRepresentation) view.representations()[0];
     Assertions.assertEquals("spark", rep.dialect());
     Assertions.assertEquals("SELECT 1", rep.sql());
-    Assertions.assertNull(view.defaultCatalog());
-    Assertions.assertNull(view.defaultSchema());
-  }
-
-  @Test
-  void testCreateViewPersistsDefaultCatalogAndSchema() throws Exception {
-    HiveCatalogOperations op = new HiveCatalogOperations();
-    op.initialize(Maps.newHashMap(), null, HIVE_PROPERTIES_METADATA);
-
-    CachedClientPool clientPool = mock(CachedClientPool.class);
-    HiveClient hiveClient = mock(HiveClient.class);
-    HiveSchema schema = HiveSchema.builder().withCatalogName("hive").withName("db").build();
-    when(hiveClient.getDatabase(anyString(), anyString())).thenReturn(schema);
-    doNothing().when(hiveClient).createTable(any());
-    when(clientPool.run(any()))
-        .thenAnswer(
-            invocation -> {
-              ClientPool.Action<?, HiveClient, ?> action = invocation.getArgument(0);
-              return action.run(hiveClient);
-            });
-    op.clientPool = clientPool;
-
-    View view =
-        op.createView(
-            NameIdentifier.of("db", "v_spark_defaults"),
-            null,
-            new Column[0],
-            new SQLRepresentation[] {
-              SQLRepresentation.builder().withDialect("spark").withSql("SELECT 1").build()
-            },
-            "my_catalog",
-            "my_schema",
-            Maps.newHashMap(ImmutableMap.of("spark.sql.create.version", "3.5.3")));
-
-    Assertions.assertEquals("my_catalog", view.defaultCatalog());
-    Assertions.assertEquals("my_schema", view.defaultSchema());
-    Assertions.assertFalse(
-        view.properties().containsKey("gravitino.view.default.catalog"),
-        "defaultCatalog should be removed from properties after extraction");
-    Assertions.assertFalse(
-        view.properties().containsKey("gravitino.view.default.schema"),
-        "defaultSchema should be removed from properties after extraction");
   }
 
   @Test

--- a/catalogs/catalog-hive/src/test/java/org/apache/gravitino/catalog/hive/TestHiveCatalogOperations.java
+++ b/catalogs/catalog-hive/src/test/java/org/apache/gravitino/catalog/hive/TestHiveCatalogOperations.java
@@ -390,6 +390,8 @@ class TestHiveCatalogOperations {
             });
     op.clientPool = clientPool;
 
+    // Callers must supply spark.sql.create.version so HMS detectDialect identifies the view as
+    // Spark
     View view =
         op.createView(
             NameIdentifier.of("db", "v_spark"),
@@ -400,7 +402,7 @@ class TestHiveCatalogOperations {
             },
             null,
             null,
-            Maps.newHashMap());
+            Maps.newHashMap(ImmutableMap.of("spark.sql.create.version", "3.5.3")));
 
     Assertions.assertNotNull(view);
     Assertions.assertEquals(1, view.representations().length);

--- a/catalogs/catalog-hive/src/test/java/org/apache/gravitino/catalog/hive/TestHiveCatalogOperations.java
+++ b/catalogs/catalog-hive/src/test/java/org/apache/gravitino/catalog/hive/TestHiveCatalogOperations.java
@@ -373,7 +373,7 @@ class TestHiveCatalogOperations {
   }
 
   @Test
-  void testCreateViewRejectsSparkDialect() throws Exception {
+  void testCreateViewAcceptsSparkDialect() throws Exception {
     HiveCatalogOperations op = new HiveCatalogOperations();
     op.initialize(Maps.newHashMap(), null, HIVE_PROPERTIES_METADATA);
 
@@ -381,6 +381,7 @@ class TestHiveCatalogOperations {
     HiveClient hiveClient = mock(HiveClient.class);
     HiveSchema schema = HiveSchema.builder().withCatalogName("hive").withName("db").build();
     when(hiveClient.getDatabase(anyString(), anyString())).thenReturn(schema);
+    doNothing().when(hiveClient).createTable(any());
     when(clientPool.run(any()))
         .thenAnswer(
             invocation -> {
@@ -389,21 +390,23 @@ class TestHiveCatalogOperations {
             });
     op.clientPool = clientPool;
 
-    UnsupportedOperationException exception =
-        Assertions.assertThrows(
-            UnsupportedOperationException.class,
-            () ->
-                op.createView(
-                    NameIdentifier.of("db", "v_spark"),
-                    null,
-                    new Column[0],
-                    new SQLRepresentation[] {
-                      SQLRepresentation.builder().withDialect("spark").withSql("SELECT 1").build()
-                    },
-                    null,
-                    null,
-                    Maps.newHashMap()));
-    Assertions.assertTrue(exception.getMessage().contains("supports only"));
+    View view =
+        op.createView(
+            NameIdentifier.of("db", "v_spark"),
+            null,
+            new Column[0],
+            new SQLRepresentation[] {
+              SQLRepresentation.builder().withDialect("spark").withSql("SELECT 1").build()
+            },
+            null,
+            null,
+            Maps.newHashMap());
+
+    Assertions.assertNotNull(view);
+    Assertions.assertEquals(1, view.representations().length);
+    SQLRepresentation rep = (SQLRepresentation) view.representations()[0];
+    Assertions.assertEquals("spark", rep.dialect());
+    Assertions.assertEquals("SELECT 1", rep.sql());
   }
 
   @Test

--- a/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/catalog/BaseCatalog.java
+++ b/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/catalog/BaseCatalog.java
@@ -450,7 +450,7 @@ public abstract class BaseCatalog implements TableCatalog, SupportsNamespaces, F
           gravitinoCatalogClient
               .asViewCatalog()
               .loadView(NameIdentifier.of(getDatabase(ident), ident.name()));
-    } catch (NoSuchViewException | UnsupportedOperationException e) {
+    } catch (NoSuchViewException | UnsupportedOperationException | ForbiddenException e) {
       throw new NoSuchTableException(ident);
     }
     // Call sparkCatalog.loadTable directly to surface NoSuchTableException as checked,

--- a/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/catalog/BaseCatalog.java
+++ b/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/catalog/BaseCatalog.java
@@ -324,7 +324,11 @@ public abstract class BaseCatalog implements TableCatalog, SupportsNamespaces, F
       return gravitinoCatalogClient
           .asViewCatalog()
           .viewExists(NameIdentifier.of(getDatabase(ident), ident.name()));
-    } catch (UnsupportedOperationException | ForbiddenException e) {
+    } catch (UnsupportedOperationException e) {
+      return false;
+    } catch (ForbiddenException e) {
+      // Same rationale as the table check above: lacking LOAD_VIEW privilege is treated as
+      // non-existence so that CREATE TABLE IF NOT EXISTS can proceed.
       return false;
     }
   }
@@ -440,24 +444,19 @@ public abstract class BaseCatalog implements TableCatalog, SupportsNamespaces, F
    * @throws NoSuchTableException if no view exists or views are not supported by this catalog
    */
   protected Table loadViewAsTable(Identifier ident) throws NoSuchTableException {
+    View gravitinoView;
     try {
-      View gravitinoView =
+      gravitinoView =
           gravitinoCatalogClient
               .asViewCatalog()
               .loadView(NameIdentifier.of(getDatabase(ident), ident.name()));
-      // Load the Kyuubi HiveTable for the view's HMS entry (VIRTUAL_VIEW) to reuse its
-      // catalogTable metadata when constructing SparkHiveView's parent HiveTable.
-      Table sparkTable = loadSparkTable(ident);
-      return createSparkView(ident, gravitinoView, sparkTable);
     } catch (NoSuchViewException | UnsupportedOperationException e) {
       throw new NoSuchTableException(ident);
-    } catch (RuntimeException e) {
-      if (e.getCause() instanceof NoSuchTableException) {
-        // loadSparkTable found no HMS entry for the view identifier
-        throw new NoSuchTableException(ident);
-      }
-      throw e;
     }
+    // Call sparkCatalog.loadTable directly to surface NoSuchTableException as checked,
+    // avoiding the RuntimeException wrapping in loadSparkTable.
+    Table sparkTable = sparkCatalog.loadTable(ident);
+    return createSparkView(ident, gravitinoView, sparkTable);
   }
 
   /**

--- a/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/catalog/BaseCatalog.java
+++ b/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/catalog/BaseCatalog.java
@@ -34,12 +34,14 @@ import org.apache.gravitino.SchemaChange;
 import org.apache.gravitino.authorization.Privilege;
 import org.apache.gravitino.exceptions.ForbiddenException;
 import org.apache.gravitino.exceptions.NoSuchSchemaException;
+import org.apache.gravitino.exceptions.NoSuchViewException;
 import org.apache.gravitino.exceptions.NonEmptySchemaException;
 import org.apache.gravitino.exceptions.SchemaAlreadyExistsException;
 import org.apache.gravitino.function.Function;
 import org.apache.gravitino.function.FunctionDefinition;
 import org.apache.gravitino.function.FunctionImpl;
 import org.apache.gravitino.function.JavaImpl;
+import org.apache.gravitino.rel.View;
 import org.apache.gravitino.spark.connector.ConnectorConstants;
 import org.apache.gravitino.spark.connector.PropertiesConverter;
 import org.apache.gravitino.spark.connector.SparkTableChangeConverter;
@@ -65,6 +67,8 @@ import org.apache.spark.sql.connector.expressions.Transform;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 import org.apache.spark.sql.util.CaseInsensitiveStringMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * BaseCatalog acts as the foundational class for Apache Spark CatalogManager registration, enabling
@@ -79,6 +83,8 @@ import org.apache.spark.sql.util.CaseInsensitiveStringMap;
  * initialization.
  */
 public abstract class BaseCatalog implements TableCatalog, SupportsNamespaces, FunctionCatalog {
+
+  private static final Logger LOG = LoggerFactory.getLogger(BaseCatalog.class);
 
   // The specific Spark catalog to do IO operations, different catalogs have different spark catalog
   // implementations, like HiveTableCatalog for Hive, JDBCTableCatalog for JDBC, SparkCatalog for
@@ -241,21 +247,22 @@ public abstract class BaseCatalog implements TableCatalog, SupportsNamespaces, F
 
   @Override
   public Table loadTable(Identifier ident) throws NoSuchTableException {
+    org.apache.gravitino.rel.Table gravitinoTable;
     try {
-      org.apache.gravitino.rel.Table gravitinoTable = loadGravitinoTable(ident);
-      org.apache.spark.sql.connector.catalog.Table sparkTable = loadSparkTable(ident);
-      // Will create a catalog specific table
-      return createSparkTable(
-          ident,
-          gravitinoTable,
-          sparkTable,
-          sparkCatalog,
-          propertiesConverter,
-          sparkTransformConverter,
-          sparkTypeConverter);
-    } catch (org.apache.gravitino.exceptions.NoSuchTableException e) {
-      throw new NoSuchTableException(ident);
+      gravitinoTable = loadGravitinoTable(ident);
+    } catch (NoSuchTableException e) {
+      // Not a table in Gravitino; try as a view.
+      return loadViewAsTable(ident);
     }
+    Table sparkTable = loadSparkTable(ident);
+    return createSparkTable(
+        ident,
+        gravitinoTable,
+        sparkTable,
+        sparkCatalog,
+        propertiesConverter,
+        sparkTransformConverter,
+        sparkTypeConverter);
   }
 
   @Override
@@ -312,9 +319,17 @@ public abstract class BaseCatalog implements TableCatalog, SupportsNamespaces, F
       loadGravitinoTable(ident);
       return true;
     } catch (NoSuchTableException e) {
-      return false;
+      // fall through to view check
     } catch (ForbiddenException e) {
       // User lacks LOAD_TABLE privilege, return false to allow CREATE TABLE IF NOT EXISTS
+      return false;
+    }
+    try {
+      return gravitinoCatalogClient
+          .asViewCatalog()
+          .viewExists(NameIdentifier.of(getDatabase(ident), ident.name()));
+    } catch (UnsupportedOperationException e) {
+      LOG.debug("Catalog does not support views for {}, treating viewExists as false", ident);
       return false;
     }
   }
@@ -419,6 +434,49 @@ public abstract class BaseCatalog implements TableCatalog, SupportsNamespaces, F
     } catch (NonEmptySchemaException e) {
       throw new NonEmptyNamespaceException(namespace);
     }
+  }
+
+  /**
+   * Loads a Gravitino view as a Spark Table when {@link #loadTable(Identifier)} fails because the
+   * object is a view. Subclasses can override {@link #createSparkView} to enable view support.
+   *
+   * @param ident the identifier to load
+   * @return Spark Table wrapping the view
+   * @throws NoSuchTableException if no view exists or views are not supported by this catalog
+   */
+  protected Table loadViewAsTable(Identifier ident) throws NoSuchTableException {
+    View gravitinoView;
+    try {
+      gravitinoView =
+          gravitinoCatalogClient
+              .asViewCatalog()
+              .loadView(NameIdentifier.of(getDatabase(ident), ident.name()));
+    } catch (NoSuchViewException | UnsupportedOperationException e) {
+      throw new NoSuchTableException(ident);
+    }
+    Table sparkTable;
+    try {
+      sparkTable = loadSparkTable(ident);
+    } catch (RuntimeException e) {
+      LOG.warn("Failed to load Spark-side table for view {}: {}", ident, e.getMessage());
+      throw new NoSuchTableException(ident);
+    }
+    return createSparkView(ident, gravitinoView, sparkTable);
+  }
+
+  /**
+   * Creates a catalog-specific Spark Table wrapping a Gravitino view. Subclasses that support views
+   * must override this method.
+   *
+   * @param ident the identifier
+   * @param gravitinoView the Gravitino view metadata
+   * @param sparkTable the underlying Spark table for IO (view expansion)
+   * @return a Spark Table representing the view
+   * @throws UnsupportedOperationException if views are not supported by this catalog
+   */
+  protected Table createSparkView(Identifier ident, View gravitinoView, Table sparkTable) {
+    throw new UnsupportedOperationException(
+        "View not supported by catalog: " + ident.namespace()[0]);
   }
 
   protected org.apache.gravitino.rel.Table loadGravitinoTable(Identifier ident)

--- a/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/catalog/BaseCatalog.java
+++ b/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/catalog/BaseCatalog.java
@@ -462,7 +462,11 @@ public abstract class BaseCatalog implements TableCatalog, SupportsNamespaces, F
       LOG.warn("Failed to load Spark-side table for view {}: {}", ident, e.getMessage());
       throw new NoSuchTableException(ident);
     }
-    return createSparkView(ident, gravitinoView, sparkTable);
+    try {
+      return createSparkView(ident, gravitinoView, sparkTable);
+    } catch (UnsupportedOperationException e) {
+      throw new NoSuchTableException(ident);
+    }
   }
 
   /**

--- a/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/catalog/BaseCatalog.java
+++ b/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/catalog/BaseCatalog.java
@@ -304,20 +304,13 @@ public abstract class BaseCatalog implements TableCatalog, SupportsNamespaces, F
         .purgeTable(NameIdentifier.of(getDatabase(ident), ident.name()));
   }
 
-  /**
-   * Returns true if a table <b>or a view</b> with the given identifier exists in Gravitino.
-   *
-   * <p>The check is performed in two steps: first the table catalog is queried, then — if no table
-   * is found — the view catalog is queried. This allows Spark to discover Gravitino views via
-   * {@code DESCRIBE TABLE} and {@code SELECT} without requiring full {@code ViewCatalog} support.
-   *
-   * <p>{@link org.apache.gravitino.exceptions.ForbiddenException} (missing {@code LOAD_TABLE} or
-   * {@code LOAD_VIEW} privilege) is treated as non-existence so that {@code CREATE TABLE IF NOT
-   * EXISTS} can proceed when the caller only holds {@code CREATE_TABLE} privilege. See <a
-   * href="https://github.com/apache/gravitino/issues/9180">issue #9180</a>.
-   */
   @Override
   public boolean tableExists(Identifier ident) {
+    // Gravitino uses loadTable() to verify table existence, which requires LOAD_TABLE privilege.
+    // For CREATE TABLE IF NOT EXISTS operations, users may only have CREATE_TABLE privilege.
+    // When ForbiddenException is thrown (lacking LOAD_TABLE privilege), we return false to allow
+    // the CREATE TABLE operation to proceed.
+    // See: https://github.com/apache/gravitino/issues/9180
     try {
       loadGravitinoTable(ident);
       return true;

--- a/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/catalog/BaseCatalog.java
+++ b/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/catalog/BaseCatalog.java
@@ -304,13 +304,20 @@ public abstract class BaseCatalog implements TableCatalog, SupportsNamespaces, F
         .purgeTable(NameIdentifier.of(getDatabase(ident), ident.name()));
   }
 
+  /**
+   * Returns true if a table <b>or a view</b> with the given identifier exists in Gravitino.
+   *
+   * <p>The check is performed in two steps: first the table catalog is queried, then — if no table
+   * is found — the view catalog is queried. This allows Spark to discover Gravitino views via
+   * {@code DESCRIBE TABLE} and {@code SELECT} without requiring full {@code ViewCatalog} support.
+   *
+   * <p>{@link org.apache.gravitino.exceptions.ForbiddenException} (missing {@code LOAD_TABLE} or
+   * {@code LOAD_VIEW} privilege) is treated as non-existence so that {@code CREATE TABLE IF NOT
+   * EXISTS} can proceed when the caller only holds {@code CREATE_TABLE} privilege. See <a
+   * href="https://github.com/apache/gravitino/issues/9180">issue #9180</a>.
+   */
   @Override
   public boolean tableExists(Identifier ident) {
-    // Gravitino uses loadTable() to verify table existence, which requires LOAD_TABLE privilege.
-    // For CREATE TABLE IF NOT EXISTS operations, users may only have CREATE_TABLE privilege.
-    // When ForbiddenException is thrown (lacking LOAD_TABLE privilege), we return false to allow
-    // the CREATE TABLE operation to proceed.
-    // See: https://github.com/apache/gravitino/issues/9180
     try {
       loadGravitinoTable(ident);
       return true;

--- a/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/catalog/BaseCatalog.java
+++ b/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/catalog/BaseCatalog.java
@@ -329,7 +329,6 @@ public abstract class BaseCatalog implements TableCatalog, SupportsNamespaces, F
           .asViewCatalog()
           .viewExists(NameIdentifier.of(getDatabase(ident), ident.name()));
     } catch (UnsupportedOperationException e) {
-      LOG.debug("Catalog does not support views for {}, treating viewExists as false", ident);
       return false;
     }
   }

--- a/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/catalog/BaseCatalog.java
+++ b/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/catalog/BaseCatalog.java
@@ -67,8 +67,6 @@ import org.apache.spark.sql.connector.expressions.Transform;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 import org.apache.spark.sql.util.CaseInsensitiveStringMap;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * BaseCatalog acts as the foundational class for Apache Spark CatalogManager registration, enabling
@@ -83,8 +81,6 @@ import org.slf4j.LoggerFactory;
  * initialization.
  */
 public abstract class BaseCatalog implements TableCatalog, SupportsNamespaces, FunctionCatalog {
-
-  private static final Logger LOG = LoggerFactory.getLogger(BaseCatalog.class);
 
   // The specific Spark catalog to do IO operations, different catalogs have different spark catalog
   // implementations, like HiveTableCatalog for Hive, JDBCTableCatalog for JDBC, SparkCatalog for
@@ -328,7 +324,7 @@ public abstract class BaseCatalog implements TableCatalog, SupportsNamespaces, F
       return gravitinoCatalogClient
           .asViewCatalog()
           .viewExists(NameIdentifier.of(getDatabase(ident), ident.name()));
-    } catch (UnsupportedOperationException e) {
+    } catch (UnsupportedOperationException | ForbiddenException e) {
       return false;
     }
   }
@@ -456,8 +452,11 @@ public abstract class BaseCatalog implements TableCatalog, SupportsNamespaces, F
     } catch (NoSuchViewException | UnsupportedOperationException e) {
       throw new NoSuchTableException(ident);
     } catch (RuntimeException e) {
-      LOG.warn("Failed to load Spark-side table for view {}: {}", ident, e.getMessage());
-      throw new NoSuchTableException(ident);
+      if (e.getCause() instanceof NoSuchTableException) {
+        // loadSparkTable found no HMS entry for the view identifier
+        throw new NoSuchTableException(ident);
+      }
+      throw e;
     }
   }
 
@@ -473,7 +472,7 @@ public abstract class BaseCatalog implements TableCatalog, SupportsNamespaces, F
    */
   protected Table createSparkView(Identifier ident, View gravitinoView, Table sparkTable) {
     throw new UnsupportedOperationException(
-        "View not supported by catalog: " + ident.namespace()[0]);
+        "View not supported by catalog: " + getDatabase(ident) + "." + ident.name());
   }
 
   protected org.apache.gravitino.rel.Table loadGravitinoTable(Identifier ident)

--- a/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/catalog/BaseCatalog.java
+++ b/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/catalog/BaseCatalog.java
@@ -444,27 +444,19 @@ public abstract class BaseCatalog implements TableCatalog, SupportsNamespaces, F
    * @throws NoSuchTableException if no view exists or views are not supported by this catalog
    */
   protected Table loadViewAsTable(Identifier ident) throws NoSuchTableException {
-    View gravitinoView;
     try {
-      gravitinoView =
+      View gravitinoView =
           gravitinoCatalogClient
               .asViewCatalog()
               .loadView(NameIdentifier.of(getDatabase(ident), ident.name()));
+      // Load the Kyuubi HiveTable for the view's HMS entry (VIRTUAL_VIEW) to reuse its
+      // catalogTable metadata when constructing SparkHiveView's parent HiveTable.
+      Table sparkTable = loadSparkTable(ident);
+      return createSparkView(ident, gravitinoView, sparkTable);
     } catch (NoSuchViewException | UnsupportedOperationException e) {
       throw new NoSuchTableException(ident);
-    }
-    // Load the Kyuubi HiveTable for the view's HMS entry (VIRTUAL_VIEW) to reuse its
-    // catalogTable metadata when constructing SparkHiveView's parent HiveTable.
-    Table sparkTable;
-    try {
-      sparkTable = loadSparkTable(ident);
     } catch (RuntimeException e) {
       LOG.warn("Failed to load Spark-side table for view {}: {}", ident, e.getMessage());
-      throw new NoSuchTableException(ident);
-    }
-    try {
-      return createSparkView(ident, gravitinoView, sparkTable);
-    } catch (UnsupportedOperationException e) {
       throw new NoSuchTableException(ident);
     }
   }

--- a/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/catalog/BaseCatalog.java
+++ b/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/catalog/BaseCatalog.java
@@ -453,6 +453,8 @@ public abstract class BaseCatalog implements TableCatalog, SupportsNamespaces, F
     } catch (NoSuchViewException | UnsupportedOperationException e) {
       throw new NoSuchTableException(ident);
     }
+    // Load the Kyuubi HiveTable for the view's HMS entry (VIRTUAL_VIEW) to reuse its
+    // catalogTable metadata when constructing SparkHiveView's parent HiveTable.
     Table sparkTable;
     try {
       sparkTable = loadSparkTable(ident);

--- a/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/hive/GravitinoHiveCatalog.java
+++ b/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/hive/GravitinoHiveCatalog.java
@@ -84,15 +84,6 @@ public class GravitinoHiveCatalog extends BaseCatalog {
       Identifier ident,
       View gravitinoView,
       org.apache.spark.sql.connector.catalog.Table sparkTable) {
-    if (!(sparkTable instanceof HiveTable)) {
-      throw new IllegalStateException(
-          String.format(
-              "Expected HiveTable for view %s but got %s", ident, sparkTable.getClass().getName()));
-    }
-    if (!(sparkCatalog instanceof HiveTableCatalog)) {
-      throw new IllegalStateException(
-          String.format("Expected HiveTableCatalog but got %s", sparkCatalog.getClass().getName()));
-    }
     return new SparkHiveView(
         gravitinoView,
         (HiveTable) sparkTable,

--- a/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/hive/GravitinoHiveCatalog.java
+++ b/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/hive/GravitinoHiveCatalog.java
@@ -21,6 +21,7 @@ package org.apache.gravitino.spark.connector.hive;
 
 import java.util.Map;
 import org.apache.gravitino.rel.Table;
+import org.apache.gravitino.rel.View;
 import org.apache.gravitino.spark.connector.PropertiesConverter;
 import org.apache.gravitino.spark.connector.SparkTransformConverter;
 import org.apache.gravitino.spark.connector.SparkTypeConverter;
@@ -76,5 +77,26 @@ public class GravitinoHiveCatalog extends BaseCatalog {
   @Override
   protected SparkTypeConverter getSparkTypeConverter() {
     return new SparkHiveTypeConverter();
+  }
+
+  @Override
+  protected org.apache.spark.sql.connector.catalog.Table createSparkView(
+      Identifier ident,
+      View gravitinoView,
+      org.apache.spark.sql.connector.catalog.Table sparkTable) {
+    if (!(sparkTable instanceof HiveTable)) {
+      throw new IllegalStateException(
+          String.format(
+              "Expected HiveTable for view %s but got %s", ident, sparkTable.getClass().getName()));
+    }
+    if (!(sparkCatalog instanceof HiveTableCatalog)) {
+      throw new IllegalStateException(
+          String.format("Expected HiveTableCatalog but got %s", sparkCatalog.getClass().getName()));
+    }
+    return new SparkHiveView(
+        gravitinoView,
+        (HiveTable) sparkTable,
+        (HiveTableCatalog) sparkCatalog,
+        getSparkTypeConverter());
   }
 }

--- a/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/hive/SparkHiveView.java
+++ b/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/hive/SparkHiveView.java
@@ -21,7 +21,6 @@ package org.apache.gravitino.spark.connector.hive;
 
 import com.google.common.base.Preconditions;
 import java.util.Arrays;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -34,10 +33,7 @@ import org.apache.kyuubi.spark.connector.hive.HiveTable;
 import org.apache.kyuubi.spark.connector.hive.HiveTableCatalog;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalyst.InternalRow;
-import org.apache.spark.sql.connector.read.Batch;
-import org.apache.spark.sql.connector.read.InputPartition;
-import org.apache.spark.sql.connector.read.PartitionReader;
-import org.apache.spark.sql.connector.read.PartitionReaderFactory;
+import org.apache.spark.sql.connector.read.LocalScan;
 import org.apache.spark.sql.connector.read.Scan;
 import org.apache.spark.sql.connector.read.ScanBuilder;
 import org.apache.spark.sql.types.DataTypes;
@@ -54,9 +50,8 @@ import org.slf4j.LoggerFactory;
  * the view's SQL (spark dialect preferred, hive as fallback) instead of using Kyuubi's file-based
  * scan, which returns empty results for VIRTUAL_VIEW entries.
  *
- * <p><b>Note:</b> View results are materialized on the driver via {@code executeCollect()}. This is
- * intentional to avoid executor-side SparkSession access, but limits scalability to views whose
- * results fit in driver memory.
+ * <p>Uses {@link LocalScan} so Spark executes the view on the driver without serializing rows to
+ * executors.
  */
 public class SparkHiveView extends HiveTable {
 
@@ -91,8 +86,14 @@ public class SparkHiveView extends HiveTable {
   @Override
   @SuppressWarnings("deprecation")
   public StructType schema() {
+    org.apache.gravitino.rel.Column[] columns = gravitinoView.columns();
+    if (columns.length == 0) {
+      // View API allows an empty column array when the output schema is unknown;
+      // fall back to the HMS-derived schema from the parent HiveTable.
+      return super.schema();
+    }
     List<StructField> fields =
-        Arrays.stream(gravitinoView.columns())
+        Arrays.stream(columns)
             .map(
                 column -> {
                   String comment = column.comment();
@@ -148,10 +149,10 @@ public class SparkHiveView extends HiveTable {
   }
 
   /**
-   * A ScanBuilder that executes the view's SQL via SparkSession and returns the resulting rows.
-   * This is used for views in V2 catalogs where Kyuubi's file-based scan cannot expand the view.
+   * A ScanBuilder that executes the view's SQL via SparkSession using {@link LocalScan}. Spark
+   * treats LocalScan results as driver-local data and never serializes rows to executors.
    */
-  private static class ViewScanBuilder implements ScanBuilder, Scan, Batch, PartitionReaderFactory {
+  private static class ViewScanBuilder implements ScanBuilder, Scan, LocalScan {
 
     private final SparkSession spark;
     private final String viewSql;
@@ -174,57 +175,12 @@ public class SparkHiveView extends HiveTable {
     }
 
     @Override
-    public Batch toBatch() {
-      return this;
-    }
-
-    @Override
-    public InputPartition[] planInputPartitions() {
+    public InternalRow[] rows() {
       try {
-        InternalRow[] rows = spark.sql(viewSql).queryExecution().executedPlan().executeCollect();
-        return new InputPartition[] {new ViewPartition(rows)};
+        return spark.sql(viewSql).queryExecution().executedPlan().executeCollect();
       } catch (RuntimeException e) {
         throw new RuntimeException(
             String.format("Failed to execute view SQL [%s]: %s", viewSql, e.getMessage()), e);
-      }
-    }
-
-    @Override
-    public PartitionReaderFactory createReaderFactory() {
-      return this;
-    }
-
-    @Override
-    public PartitionReader<InternalRow> createReader(InputPartition partition) {
-      InternalRow[] rows = ((ViewPartition) partition).rows;
-      Iterator<InternalRow> iter = Arrays.asList(rows).iterator();
-      return new PartitionReader<InternalRow>() {
-        private InternalRow current;
-
-        @Override
-        public boolean next() {
-          if (iter.hasNext()) {
-            current = iter.next();
-            return true;
-          }
-          return false;
-        }
-
-        @Override
-        public InternalRow get() {
-          return current;
-        }
-
-        @Override
-        public void close() {}
-      };
-    }
-
-    private static class ViewPartition implements InputPartition {
-      final InternalRow[] rows;
-
-      ViewPartition(InternalRow[] rows) {
-        this.rows = rows;
       }
     }
   }

--- a/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/hive/SparkHiveView.java
+++ b/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/hive/SparkHiveView.java
@@ -176,6 +176,8 @@ public class SparkHiveView extends HiveTable {
 
     @Override
     public InternalRow[] rows() {
+      // WARNING: executeCollect() materializes the entire result set to driver memory.
+      // Suitable only for small/bounded views; large result sets may cause OutOfMemoryError.
       try {
         return spark.sql(viewSql).queryExecution().executedPlan().executeCollect();
       } catch (RuntimeException e) {

--- a/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/hive/SparkHiveView.java
+++ b/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/hive/SparkHiveView.java
@@ -183,7 +183,7 @@ public class SparkHiveView extends HiveTable {
       try {
         InternalRow[] rows = spark.sql(viewSql).queryExecution().executedPlan().executeCollect();
         return new InputPartition[] {new ViewPartition(rows)};
-      } catch (Exception e) {
+      } catch (RuntimeException e) {
         throw new RuntimeException(
             String.format("Failed to execute view SQL [%s]: %s", viewSql, e.getMessage()), e);
       }

--- a/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/hive/SparkHiveView.java
+++ b/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/hive/SparkHiveView.java
@@ -1,0 +1,231 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.spark.connector.hive;
+
+import com.google.common.base.Preconditions;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.apache.gravitino.rel.Dialects;
+import org.apache.gravitino.rel.SQLRepresentation;
+import org.apache.gravitino.rel.View;
+import org.apache.gravitino.spark.connector.ConnectorConstants;
+import org.apache.gravitino.spark.connector.SparkTypeConverter;
+import org.apache.kyuubi.spark.connector.hive.HiveTable;
+import org.apache.kyuubi.spark.connector.hive.HiveTableCatalog;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.connector.read.Batch;
+import org.apache.spark.sql.connector.read.InputPartition;
+import org.apache.spark.sql.connector.read.PartitionReader;
+import org.apache.spark.sql.connector.read.PartitionReaderFactory;
+import org.apache.spark.sql.connector.read.Scan;
+import org.apache.spark.sql.connector.read.ScanBuilder;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.Metadata;
+import org.apache.spark.sql.types.MetadataBuilder;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+import org.apache.spark.sql.util.CaseInsensitiveStringMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Wraps a Hive view stored in HMS with Gravitino view metadata. Overrides newScanBuilder to execute
+ * the view's SQL (spark dialect preferred, hive as fallback) instead of using Kyuubi's file-based
+ * scan, which returns empty results for VIRTUAL_VIEW entries.
+ *
+ * <p><b>Note:</b> View results are materialized on the driver via {@code executeCollect()}. This is
+ * intentional to avoid executor-side SparkSession access, but limits scalability to views whose
+ * results fit in driver memory.
+ */
+public class SparkHiveView extends HiveTable {
+
+  private static final Logger LOG = LoggerFactory.getLogger(SparkHiveView.class);
+
+  private final View gravitinoView;
+  private final SparkTypeConverter sparkTypeConverter;
+
+  /**
+   * Creates a SparkHiveView that wraps a Gravitino view with Hive HMS backing.
+   *
+   * @param gravitinoView the Gravitino view metadata
+   * @param hiveTable the backing Kyuubi HiveTable from HMS
+   * @param hiveTableCatalog the Kyuubi HiveTableCatalog for HMS access
+   * @param sparkTypeConverter converter for Gravitino-to-Spark type mapping
+   */
+  public SparkHiveView(
+      View gravitinoView,
+      HiveTable hiveTable,
+      HiveTableCatalog hiveTableCatalog,
+      SparkTypeConverter sparkTypeConverter) {
+    super(SparkSession.active(), hiveTable.catalogTable(), hiveTableCatalog);
+    this.gravitinoView = gravitinoView;
+    this.sparkTypeConverter = sparkTypeConverter;
+  }
+
+  @Override
+  public String name() {
+    return gravitinoView.name();
+  }
+
+  @Override
+  @SuppressWarnings("deprecation")
+  public StructType schema() {
+    List<StructField> fields =
+        Arrays.stream(gravitinoView.columns())
+            .map(
+                column -> {
+                  String comment = column.comment();
+                  Metadata metadata =
+                      comment != null
+                          ? new MetadataBuilder()
+                              .putString(ConnectorConstants.COMMENT, comment)
+                              .build()
+                          : Metadata.empty();
+                  return StructField.apply(
+                      column.name(),
+                      sparkTypeConverter.toSparkType(column.dataType()),
+                      column.nullable(),
+                      metadata);
+                })
+            .collect(Collectors.toList());
+    return DataTypes.createStructType(fields);
+  }
+
+  @Override
+  public Map<String, String> properties() {
+    return gravitinoView.properties();
+  }
+
+  @Override
+  public ScanBuilder newScanBuilder(CaseInsensitiveStringMap options) {
+    SparkSession spark = SparkSession.active();
+    Preconditions.checkState(
+        spark != null && !spark.sparkContext().isStopped(),
+        "No active SparkSession available to execute view '%s'",
+        gravitinoView.name());
+    String viewSql =
+        gravitinoView
+            .sqlFor(Dialects.SPARK)
+            .map(SQLRepresentation::sql)
+            .orElseGet(
+                () -> {
+                  String hiveSql =
+                      gravitinoView
+                          .sqlFor(Dialects.HIVE)
+                          .map(SQLRepresentation::sql)
+                          .orElseThrow(
+                              () ->
+                                  new UnsupportedOperationException(
+                                      "No SQL representation for view: " + gravitinoView.name()));
+                  LOG.warn(
+                      "View '{}' has no Spark SQL representation; falling back to Hive SQL. "
+                          + "Results may differ if the SQL uses Hive-specific syntax.",
+                      gravitinoView.name());
+                  return hiveSql;
+                });
+    return new ViewScanBuilder(spark, viewSql, schema());
+  }
+
+  /**
+   * A ScanBuilder that executes the view's SQL via SparkSession and returns the resulting rows.
+   * This is used for views in V2 catalogs where Kyuubi's file-based scan cannot expand the view.
+   */
+  private static class ViewScanBuilder implements ScanBuilder, Scan, Batch, PartitionReaderFactory {
+
+    private final SparkSession spark;
+    private final String viewSql;
+    private final StructType schema;
+
+    ViewScanBuilder(SparkSession spark, String viewSql, StructType schema) {
+      this.spark = spark;
+      this.viewSql = viewSql;
+      this.schema = schema;
+    }
+
+    @Override
+    public Scan build() {
+      return this;
+    }
+
+    @Override
+    public StructType readSchema() {
+      return schema;
+    }
+
+    @Override
+    public Batch toBatch() {
+      return this;
+    }
+
+    @Override
+    public InputPartition[] planInputPartitions() {
+      try {
+        InternalRow[] rows = spark.sql(viewSql).queryExecution().executedPlan().executeCollect();
+        return new InputPartition[] {new ViewPartition(rows)};
+      } catch (Exception e) {
+        throw new RuntimeException(
+            String.format("Failed to execute view SQL [%s]: %s", viewSql, e.getMessage()), e);
+      }
+    }
+
+    @Override
+    public PartitionReaderFactory createReaderFactory() {
+      return this;
+    }
+
+    @Override
+    public PartitionReader<InternalRow> createReader(InputPartition partition) {
+      InternalRow[] rows = ((ViewPartition) partition).rows;
+      Iterator<InternalRow> iter = Arrays.asList(rows).iterator();
+      return new PartitionReader<InternalRow>() {
+        private InternalRow current;
+
+        @Override
+        public boolean next() {
+          if (iter.hasNext()) {
+            current = iter.next();
+            return true;
+          }
+          return false;
+        }
+
+        @Override
+        public InternalRow get() {
+          return current;
+        }
+
+        @Override
+        public void close() {}
+      };
+    }
+
+    private static class ViewPartition implements InputPartition {
+      final InternalRow[] rows;
+
+      ViewPartition(InternalRow[] rows) {
+        this.rows = rows;
+      }
+    }
+  }
+}

--- a/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/hive/SparkHiveView.java
+++ b/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/hive/SparkHiveView.java
@@ -50,8 +50,12 @@ import org.slf4j.LoggerFactory;
  * the view's SQL (spark dialect preferred, hive as fallback) instead of using Kyuubi's file-based
  * scan, which returns empty results for VIRTUAL_VIEW entries.
  *
- * <p>Uses {@link LocalScan} so Spark executes the view on the driver without serializing rows to
- * executors.
+ * <p>Uses {@link LocalScan} to materialize view results on the driver. This is a known limitation:
+ * the proper fix (expanding the view SQL into the query plan at analysis time) requires Spark's V2
+ * catalog framework to route view operations to named catalogs, which Spark does not yet support —
+ * {@code ResolveSessionCatalog} unconditionally throws for any non-session catalog view. Until
+ * Spark adds that support, driver-side materialization via {@code executeCollect()} is the only
+ * viable approach. <b>This implementation is suitable only for small/bounded views.</b>
  */
 public class SparkHiveView extends HiveTable {
 
@@ -176,8 +180,7 @@ public class SparkHiveView extends HiveTable {
 
     @Override
     public InternalRow[] rows() {
-      // WARNING: executeCollect() materializes the entire result set to driver memory.
-      // Suitable only for small/bounded views; large result sets may cause OutOfMemoryError.
+      // executeCollect() pulls all rows to driver memory — see class-level Javadoc for why.
       try {
         return spark.sql(viewSql).queryExecution().executedPlan().executeCollect();
       } catch (RuntimeException e) {

--- a/spark-connector/spark-common/src/test/java/org/apache/gravitino/spark/connector/integration/test/SparkEnvIT.java
+++ b/spark-connector/spark-common/src/test/java/org/apache/gravitino/spark/connector/integration/test/SparkEnvIT.java
@@ -84,6 +84,11 @@ public abstract class SparkEnvIT extends SparkUtilIT {
     return true;
   }
 
+  /** Returns the Gravitino {@link Catalog} for the catalog under test. */
+  protected Catalog getGravitinoCatalog() {
+    return client.loadMetalake(metalakeName).loadCatalog(getCatalogName());
+  }
+
   @Override
   protected SparkSession getSparkSession() {
     Assertions.assertNotNull(sparkSession);

--- a/spark-connector/spark-common/src/test/java/org/apache/gravitino/spark/connector/integration/test/hive/SparkHiveCatalogIT.java
+++ b/spark-connector/spark-common/src/test/java/org/apache/gravitino/spark/connector/integration/test/hive/SparkHiveCatalogIT.java
@@ -22,7 +22,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -591,7 +590,7 @@ public abstract class SparkHiveCatalogIT extends SparkCommonIT {
         new SQLRepresentation[] {sparkRep},
         getCatalogName(),
         schemaName,
-        Collections.emptyMap());
+        ImmutableMap.of("spark.sql.create.version", getSparkSession().version()));
 
     try {
       List<String> data =
@@ -629,7 +628,7 @@ public abstract class SparkHiveCatalogIT extends SparkCommonIT {
         new SQLRepresentation[] {sparkRep},
         null,
         null,
-        Collections.emptyMap());
+        ImmutableMap.of("spark.sql.create.version", getSparkSession().version()));
 
     try {
       Assertions.assertDoesNotThrow(
@@ -671,7 +670,7 @@ public abstract class SparkHiveCatalogIT extends SparkCommonIT {
         new SQLRepresentation[] {sparkRep},
         getCatalogName(),
         schemaName,
-        Collections.emptyMap());
+        ImmutableMap.of("spark.sql.create.version", getSparkSession().version()));
 
     try {
       Set<String> tableNames = listTableNames(schemaName);

--- a/spark-connector/spark-common/src/test/java/org/apache/gravitino/spark/connector/integration/test/hive/SparkHiveCatalogIT.java
+++ b/spark-connector/spark-common/src/test/java/org/apache/gravitino/spark/connector/integration/test/hive/SparkHiveCatalogIT.java
@@ -550,8 +550,8 @@ public abstract class SparkHiveCatalogIT extends SparkCommonIT {
                           schemaName,
                           tableName)));
       Assertions.assertTrue(
-          ex.getMessage().toUpperCase().contains("VIEW"),
-          "Expected error about CREATE VIEW, got: " + ex.getMessage());
+          ex.getMessage().contains("does not support views"),
+          "Expected error about view support, got: " + ex.getMessage());
     } finally {
       dropTableIfExists(tableName);
     }

--- a/spark-connector/spark-common/src/test/java/org/apache/gravitino/spark/connector/integration/test/hive/SparkHiveCatalogIT.java
+++ b/spark-connector/spark-common/src/test/java/org/apache/gravitino/spark/connector/integration/test/hive/SparkHiveCatalogIT.java
@@ -22,8 +22,16 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.rel.Column;
+import org.apache.gravitino.rel.SQLRepresentation;
+import org.apache.gravitino.rel.ViewCatalog;
+import org.apache.gravitino.rel.types.Types;
 import org.apache.gravitino.spark.connector.GravitinoSparkConfig;
 import org.apache.gravitino.spark.connector.hive.HivePropertiesConstants;
 import org.apache.gravitino.spark.connector.integration.test.SparkCommonIT;
@@ -31,6 +39,7 @@ import org.apache.gravitino.spark.connector.integration.test.util.SparkTableInfo
 import org.apache.gravitino.spark.connector.integration.test.util.SparkTableInfo.SparkColumnInfo;
 import org.apache.gravitino.spark.connector.integration.test.util.SparkTableInfoChecker;
 import org.apache.hadoop.fs.Path;
+import org.apache.spark.sql.AnalysisException;
 import org.apache.spark.sql.connector.catalog.TableCatalog;
 import org.apache.spark.sql.types.DataTypes;
 import org.junit.jupiter.api.Assertions;
@@ -516,5 +525,161 @@ public abstract class SparkHiveCatalogIT extends SparkCommonIT {
             SparkColumnInfo.of("id", DataTypes.IntegerType),
             SparkColumnInfo.of("ts", DataTypes.TimestampType));
     checkTableColumns(tableName, expectedSparkInfo, tableInfo);
+  }
+
+  @Test
+  void testCreateViewViaSql() {
+    String tableName = "cv_base_table";
+    String viewName = "cv_test_view";
+    String schemaName = getDefaultDatabase();
+    dropTableIfExists(tableName);
+    createSimpleTable(tableName);
+    try {
+      // Spark V2 named catalogs do not support CREATE VIEW via SQL; this documents the limitation.
+      AnalysisException ex =
+          Assertions.assertThrows(
+              AnalysisException.class,
+              () ->
+                  sql(
+                      String.format(
+                          "CREATE VIEW %s.%s.%s AS SELECT * FROM %s.%s.%s",
+                          getCatalogName(),
+                          schemaName,
+                          viewName,
+                          getCatalogName(),
+                          schemaName,
+                          tableName)));
+      Assertions.assertTrue(
+          ex.getMessage().toUpperCase().contains("VIEW"),
+          "Expected error about CREATE VIEW, got: " + ex.getMessage());
+    } finally {
+      dropTableIfExists(tableName);
+    }
+  }
+
+  @Test
+  void testSelectHiveView() {
+    String tableName = "view_base_table";
+    String viewName = "test_hive_view";
+    String schemaName = getDefaultDatabase();
+
+    dropTableIfExists(tableName);
+    createSimpleTable(tableName);
+    sql(String.format("INSERT INTO %s VALUES (1, '1', 1),(2, '2', 2),(3, '3', 3)", tableName));
+
+    ViewCatalog viewCatalog =
+        client.loadMetalake("test").loadCatalog(getCatalogName()).asViewCatalog();
+    NameIdentifier viewIdent = NameIdentifier.of(schemaName, viewName);
+    if (viewCatalog.viewExists(viewIdent)) {
+      viewCatalog.dropView(viewIdent);
+    }
+
+    SQLRepresentation sparkRep =
+        SQLRepresentation.builder()
+            .withDialect("spark")
+            .withSql(
+                String.format("SELECT * FROM %s.%s.%s", getCatalogName(), schemaName, tableName))
+            .build();
+    viewCatalog.createView(
+        viewIdent,
+        "test view",
+        new Column[] {
+          Column.of("id", Types.IntegerType.get(), null),
+          Column.of("name", Types.StringType.get(), null),
+          Column.of("age", Types.IntegerType.get(), null)
+        },
+        new SQLRepresentation[] {sparkRep},
+        getCatalogName(),
+        schemaName,
+        Collections.emptyMap());
+
+    try {
+      List<String> data =
+          getQueryData(
+              String.format("SELECT * FROM %s.%s.%s", getCatalogName(), schemaName, viewName));
+      data.sort(Comparator.naturalOrder());
+      Assertions.assertEquals(3, data.size());
+      Assertions.assertEquals("1,1,1", data.get(0));
+      Assertions.assertEquals("2,2,2", data.get(1));
+      Assertions.assertEquals("3,3,3", data.get(2));
+    } finally {
+      viewCatalog.dropView(viewIdent);
+      dropTableIfExists(tableName);
+    }
+  }
+
+  @Test
+  void testTableExistsForView() {
+    String viewName = "test_view_exists";
+    String schemaName = getDefaultDatabase();
+
+    ViewCatalog viewCatalog =
+        client.loadMetalake("test").loadCatalog(getCatalogName()).asViewCatalog();
+    NameIdentifier viewIdent = NameIdentifier.of(schemaName, viewName);
+    if (viewCatalog.viewExists(viewIdent)) {
+      viewCatalog.dropView(viewIdent);
+    }
+
+    SQLRepresentation sparkRep =
+        SQLRepresentation.builder().withDialect("spark").withSql("SELECT 1 AS id").build();
+    viewCatalog.createView(
+        viewIdent,
+        null,
+        new Column[] {Column.of("id", Types.IntegerType.get(), null)},
+        new SQLRepresentation[] {sparkRep},
+        null,
+        null,
+        Collections.emptyMap());
+
+    try {
+      Assertions.assertDoesNotThrow(
+          () ->
+              sql(
+                  String.format(
+                      "DESCRIBE TABLE %s.%s.%s", getCatalogName(), schemaName, viewName)));
+    } finally {
+      viewCatalog.dropView(viewIdent);
+    }
+  }
+
+  @Test
+  void testShowTablesExcludesViews() {
+    String tableName = "show_tables_base_table";
+    String viewName = "show_tables_view";
+    String schemaName = getDefaultDatabase();
+
+    dropTableIfExists(tableName);
+    createSimpleTable(tableName);
+
+    ViewCatalog viewCatalog =
+        client.loadMetalake("test").loadCatalog(getCatalogName()).asViewCatalog();
+    NameIdentifier viewIdent = NameIdentifier.of(schemaName, viewName);
+    if (viewCatalog.viewExists(viewIdent)) {
+      viewCatalog.dropView(viewIdent);
+    }
+
+    SQLRepresentation sparkRep =
+        SQLRepresentation.builder()
+            .withDialect("spark")
+            .withSql(
+                String.format("SELECT * FROM %s.%s.%s", getCatalogName(), schemaName, tableName))
+            .build();
+    viewCatalog.createView(
+        viewIdent,
+        null,
+        new Column[0],
+        new SQLRepresentation[] {sparkRep},
+        getCatalogName(),
+        schemaName,
+        Collections.emptyMap());
+
+    try {
+      Set<String> tableNames = listTableNames(schemaName);
+      Assertions.assertTrue(tableNames.contains(tableName));
+      Assertions.assertFalse(tableNames.contains(viewName));
+    } finally {
+      viewCatalog.dropView(viewIdent);
+      dropTableIfExists(tableName);
+    }
   }
 }

--- a/spark-connector/spark-common/src/test/java/org/apache/gravitino/spark/connector/integration/test/hive/SparkHiveCatalogIT.java
+++ b/spark-connector/spark-common/src/test/java/org/apache/gravitino/spark/connector/integration/test/hive/SparkHiveCatalogIT.java
@@ -566,8 +566,7 @@ public abstract class SparkHiveCatalogIT extends SparkCommonIT {
     createSimpleTable(tableName);
     sql(String.format("INSERT INTO %s VALUES (1, '1', 1),(2, '2', 2),(3, '3', 3)", tableName));
 
-    ViewCatalog viewCatalog =
-        client.loadMetalake("test").loadCatalog(getCatalogName()).asViewCatalog();
+    ViewCatalog viewCatalog = getGravitinoCatalog().asViewCatalog();
     NameIdentifier viewIdent = NameIdentifier.of(schemaName, viewName);
     if (viewCatalog.viewExists(viewIdent)) {
       viewCatalog.dropView(viewIdent);
@@ -612,8 +611,7 @@ public abstract class SparkHiveCatalogIT extends SparkCommonIT {
     String viewName = "test_view_exists";
     String schemaName = getDefaultDatabase();
 
-    ViewCatalog viewCatalog =
-        client.loadMetalake("test").loadCatalog(getCatalogName()).asViewCatalog();
+    ViewCatalog viewCatalog = getGravitinoCatalog().asViewCatalog();
     NameIdentifier viewIdent = NameIdentifier.of(schemaName, viewName);
     if (viewCatalog.viewExists(viewIdent)) {
       viewCatalog.dropView(viewIdent);
@@ -650,8 +648,7 @@ public abstract class SparkHiveCatalogIT extends SparkCommonIT {
     dropTableIfExists(tableName);
     createSimpleTable(tableName);
 
-    ViewCatalog viewCatalog =
-        client.loadMetalake("test").loadCatalog(getCatalogName()).asViewCatalog();
+    ViewCatalog viewCatalog = getGravitinoCatalog().asViewCatalog();
     NameIdentifier viewIdent = NameIdentifier.of(schemaName, viewName);
     if (viewCatalog.viewExists(viewIdent)) {
       viewCatalog.dropView(viewIdent);

--- a/spark-connector/spark-common/src/test/java/org/apache/gravitino/spark/connector/integration/test/hive/SparkHiveCatalogIT.java
+++ b/spark-connector/spark-common/src/test/java/org/apache/gravitino/spark/connector/integration/test/hive/SparkHiveCatalogIT.java
@@ -534,7 +534,11 @@ public abstract class SparkHiveCatalogIT extends SparkCommonIT {
     dropTableIfExists(tableName);
     createSimpleTable(tableName);
     try {
-      // Spark V2 named catalogs do not support CREATE VIEW via SQL; this documents the limitation.
+      // CREATE VIEW via SQL is not supported for V2 named catalogs. Spark's
+      // ResolveSessionCatalog unconditionally throws for any non-session catalog
+      // (see the "case CreateView(ResolvedIdentifier(catalog, _), ...)" branch), regardless of
+      // whether the catalog implements ViewCatalog. Views must be created through the
+      // Gravitino API (ViewCatalog.createView) and are readable via SELECT.
       AnalysisException ex =
           Assertions.assertThrows(
               AnalysisException.class,


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add read-only view support to the Gravitino Spark Hive connector:

- `HiveViewCatalogOperations`: accept Spark dialect in view creation and loading.
- `BaseCatalog`: fall through to view lookup in `loadTable` when identifier is
  not a table; check view existence in `tableExists`.
- `SparkHiveView`: new V2 Table that executes view SQL via SparkSession on the
  driver and returns rows as a single in-memory partition.
- `GravitinoHiveCatalog`: override `createSparkView` to return `SparkHiveView`.

### Why are the changes needed?

Fix: #11287

### Does this PR introduce _any_ user-facing change?

Yes — users can now SELECT from Gravitino views via Spark SQL on Hive catalogs.
Note: CREATE VIEW via Spark SQL is not supported due to a Spark V2 named catalog
limitation; views must be created through the Gravitino API.

### How was this patch tested?

- Unit test: `testCreateViewAcceptsSparkDialect` in `TestHiveCatalogOperations`
- Integration tests: 4 new cases in `SparkHiveCatalogIT`:
  `testSelectHiveView`, `testTableExistsForView`, `testShowTablesExcludesViews`,
  `testCreateViewViaSql`