### PR TITLE
[#11291] fix(web-v2): Suppress error toast when catalog doesn't support views

### DIFF
--- a/web-v2/web/src/lib/api/views/index.js
+++ b/web-v2/web/src/lib/api/views/index.js
@@ -34,16 +34,22 @@ const Apis = {
     )}/schemas/${encodeURIComponent(schema)}/views/${encodeURIComponent(view)}`
 }
 
-export const getViewsApi = params => {
-  return defHttp.get({
-    url: `${Apis.GET(params)}`
-  })
+export const getViewsApi = (params, options) => {
+  return defHttp.get(
+    {
+      url: `${Apis.GET(params)}`
+    },
+    options
+  )
 }
 
-export const getViewDetailsApi = ({ metalake, catalog, schema, view }) => {
-  return defHttp.get({
-    url: `${Apis.GET_DETAIL({ metalake, catalog, schema, view })}`
-  })
+export const getViewDetailsApi = ({ metalake, catalog, schema, view }, options) => {
+  return defHttp.get(
+    {
+      url: `${Apis.GET_DETAIL({ metalake, catalog, schema, view })}`
+    },
+    options
+  )
 }
 
 export const deleteViewApi = ({ metalake, catalog, schema, view }) => {

--- a/web-v2/web/src/lib/store/metalakes/index.js
+++ b/web-v2/web/src/lib/store/metalakes/index.js
@@ -294,7 +294,10 @@ export const setIntoTreeNodeWithFetch = createAsyncThunk(
           break
       }
 
-      const viewsPromise = type === 'relational' ? getViewsApi({ metalake, catalog, schema }) : Promise.resolve(null)
+      const viewsPromise =
+        type === 'relational'
+          ? getViewsApi({ metalake, catalog, schema }, { errorMessageMode: 'none' })
+          : Promise.resolve(null)
 
       const [funcResult, entityResult, viewResult] = await Promise.allSettled([
         getFunctionsApi({ metalake, catalog, schema, details: false }),
@@ -2185,10 +2188,16 @@ export const getFunctionDetails = createAsyncThunk(
 export const fetchViews = createAsyncThunk(
   'appMetalakes/fetchViews',
   async ({ init, metalake, catalog, schema }, { getState, dispatch }) => {
-    const [err, res] = await to(getViewsApi({ metalake, catalog, schema }))
+    const [err, res] = await to(getViewsApi({ metalake, catalog, schema }, { errorMessageMode: 'none' }))
 
-    if (init && (err || !res)) {
-      throw new Error(err)
+    if (err || !res) {
+      // Catalog doesn't support views (HTTP 405) — return empty views silently
+      if (err?.response?.status === 405) {
+        return { views: [], init }
+      }
+      if (init) {
+        throw new Error(err)
+      }
     }
 
     const { identifiers = [] } = res || {}
@@ -2233,9 +2242,13 @@ export const fetchViews = createAsyncThunk(
 export const getViewDetails = createAsyncThunk(
   'appMetalakes/getViewDetails',
   async ({ init, metalake, catalog, schema, view }) => {
-    const [err, res] = await to(getViewDetailsApi({ metalake, catalog, schema, view }))
+    const [err, res] = await to(getViewDetailsApi({ metalake, catalog, schema, view }, { errorMessageMode: 'none' }))
 
     if (err || !res) {
+      // Catalog doesn't support views (HTTP 405) — return empty result silently
+      if (err?.response?.status === 405) {
+        return { view: null, init }
+      }
       throw new Error(err)
     }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Suppress HTTP 405 error toasts in Web UI V2 when catalogs do not support view operations.

**Changes:**
1. **`views/index.js`**: Added an `options` parameter to `getViewsApi` and `getViewDetailsApi` so callers can pass Axios request options (e.g., `errorMessageMode`).
2. **`store/metalakes/index.js`**: In the `fetchViews` thunk, `getViewDetails` thunk, and `setIntoTreeNodeWithFetch`, pass `{ errorMessageMode: 'none' }` to the view API calls to suppress the Axios interceptor's automatic error toast. Then handle 405 locally by returning empty data (`[]` for views, `null` for view details).

Non-405 errors still surface: the thunks throw, and the existing Redux `rejected` extraReducers show a single toast.

### Why are the changes needed?

Relational catalogs (e.g., PostgreSQL, MySQL) that don't implement the `ViewCatalog` interface return HTTP 405 when the UI attempts to load views. The Axios response interceptor calls `checkStatus()` which shows an error toast *before* the Redux thunk can handle the error. This causes a disruptive toast every time a user navigates the metadata tree for these catalogs, even though not supporting views is expected behavior.

Fix: #11291

### Does this PR introduce _any_ user-facing change?

Yes — users will no longer see error toasts when browsing catalogs that don't support views in Web UI V2.

### How was this patch tested?

- Local testing with PostgreSQL and MySQL relational catalogs: verified the Views tab shows empty with no error toast.
- Verified that non-405 errors (e.g., 500) still produce a single toast via the Redux rejected handler.
- Verified no console errors after navigating catalog tree and switching tabs.
- Existing view-supporting catalogs are unaffected — `errorMessageMode: 'none'` is only passed from the 3 view-specific call sites.