### PR TITLE
[#10905] feat(trino-connector): make trino-connector compatible with Starburst/Trino, with 3 little fix and a new documentation page

### DIFF
--- a/docs/trino-connector/index.md
+++ b/docs/trino-connector/index.md
@@ -22,3 +22,4 @@ Apache Gravitino Trino connector index:
   - [Supported SQL](sql-support.md)
   - [UDF support](udf-support.md)
   - [Development](development.md)
+  - [Starburst compatibility](starburst-compatibility.md)

--- a/docs/trino-connector/starburst-compatibility.md
+++ b/docs/trino-connector/starburst-compatibility.md
@@ -1,0 +1,139 @@
+---
+title: "Apache Gravitino Trino connector with Starburst"
+slug: /trino-connector/starburst-compatibility
+keyword: gravitino connector trino starburst
+license: "This software is licensed under the Apache License version 2."
+---
+
+This page describes, **for indication only**, how you can build the Apache Gravitino
+Trino connector against the **Starburst** SPI — a commercial, proprietary product —
+instead of the open-source Trino SPI.
+
+:::caution Read this first — this is your responsibility, not Gravitino's
+Apache Gravitino is an open-source project licensed under the Apache License 2.0, and
+it builds **exclusively against the open-source `io.trino:trino-spi` artifacts** published
+on Maven Central.
+
+**Starburst Enterprise / Starburst Galaxy are commercial, proprietary products.** Their
+`trino-spi` jar is **not** an Apache artifact, is **not** redistributable by Gravitino, and
+is **not** published to Maven Central. For this reason the Gravitino project:
+
+- does **not** ship, bundle, or depend on any Starburst artifact,
+- does **not** officially support or test the connector against Starburst,
+- cannot commit any of the build changes described below into the repository.
+
+If you choose to build the connector against a Starburst SPI, you do so **entirely within your own private usage**,
+under the terms of the Starburst license you
+already hold for your deployment. You are responsible for obtaining the jar legitimately from
+your own licensed Starburst installation and for complying with its license.
+:::
+
+:::note This document is agnostic and purely indicative
+Although the author of this documentation has performed a successful test for a specific Starburst
+and Trino version between 473 and 478, every value below — version numbers, jar file names,
+file system paths, and the exact set of transitive dependencies you must re-declare — **depends on your
+specific Starburst release and deployment** and **will change over time**. Treat the snippets
+as a starting point to adapt to your environment, not as a guaranteed, supported recipe.
+Nothing here is globally tested or maintained by the Gravitino project, unless Starburst users
+volunteer to maintain it.
+:::
+
+## Why this is possible at all
+
+The shared connector source code is written to stay **cross-version compatible**. Where a method
+exists only in some Trino/Starburst SPI variants (for example
+`DynamicFilter#getPreferredDynamicFilterTimeout()`), it is implemented **without** the `@Override`
+annotation so the source compiles against SPI versions that do not declare it, while still being
+dispatched at runtime by signature on SPI versions that do. This means that, in most cases, you only
+need to **swap the SPI dependency** at build time — **no source code modification is required** —
+only a few build-time changes, described below.
+
+## Steps
+
+The example below targets the `trino-connector-473-478` version-segment module and a Starburst
+SPI version `476-e.0.26`. Pick the [version-segment module](development.md#multi-version-architecture)
+that matches your Starburst-based Trino version, and replace the version/file names accordingly.
+
+### 1. Obtain the Starburst `trino-spi` jar
+
+Retrieve the `io.trino_trino-spi-<starburstVersion>.jar` from your own licensed Starburst
+deployment. The exact location depends on how Starburst was installed — for a typical server
+install it is found under the Starburst libraries directory (for example,
+`/usr/lib/starburst/lib/`), or inside the distribution tarball/RPM you deployed from.
+
+:::note
+The jar name and version suffix (`-e.0.x`, etc.) are Starburst-specific and vary by release.
+Use whatever name your deployment actually provides.
+:::
+
+### 2. Place the jar in a local folder
+
+Create a folder at the root of the Gravitino project and copy the jar into it:
+
+```shell
+mkdir -p starburst-libs
+cp /usr/lib/starburst/lib/io.trino_trino-spi-476-e.0.26.jar starburst-libs/
+```
+
+:::caution
+Do **not** commit this folder or the jar. It is a proprietary artifact for your private build only.
+Consider adding `starburst-libs/` to your local `.gitignore`.
+:::
+
+### 3. Point the version-segment module at the Starburst jar
+
+Edit the `build.gradle.kts` of your chosen version-segment module (here
+`trino-connector/trino-connector-473-478/build.gradle.kts`).
+
+**Remove** the open-source SPI dependency:
+
+```kotlin
+compileOnly("io.trino:trino-spi:$trinoVersion") {
+  exclude("org.apache.logging.log4j")
+}
+```
+
+**Add** the local Starburst jar instead, plus any transitive dependency the raw jar no longer
+brings in. A file dependency carries no POM, so transitive libraries such as `io.airlift:slice`
+must be declared explicitly:
+
+```kotlin
+compileOnly(files("../starburst-libs/io.trino_trino-spi-$starburstVersion.jar"))
+compileOnly("io.airlift:slice:0.46")
+```
+
+:::note
+`io.airlift:slice` is one common example. Depending on your Starburst SPI version you may need
+to re-declare additional `compileOnly` dependencies that the published `trino-spi` POM used to
+provide transitively. Add them as the compiler reports missing symbols.
+:::
+
+### 4. Declare the `starburstVersion` build property
+
+Still in the same `build.gradle.kts`, read the property so the snippet above can resolve
+`$starburstVersion`:
+
+```kotlin
+val starburstVersion: String = project.properties["starburstVersion"] as String
+```
+
+### 5. Build with the Starburst version argument
+
+Pass the property on the Gradle command line:
+
+```shell
+./gradlew :trino-connector:trino-connector-473-478:build -PstarburstVersion=476-e.0.26
+```
+
+:::note
+Each version-segment module still validates the `-PtrinoVersion` range. If the module rejects your
+Starburst-based version number, set a `-PtrinoVersion` value inside the supported range of the
+module you selected, since the actual SPI now comes from the local jar.
+:::
+
+## Disclaimer
+
+This integration path is provided as community guidance only. It is **not** part of the Apache
+Gravitino release, is **not** covered by Gravitino support, and may break with any Starburst or
+Gravitino update. Validate the resulting connector thoroughly in your own environment before any
+use.

--- a/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/GravitinoConnectorFactory.java
+++ b/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/GravitinoConnectorFactory.java
@@ -156,8 +156,8 @@ public class GravitinoConnectorFactory implements ConnectorFactory {
   }
 
   private void checkTrinoSpiVersion(ConnectorContext context, GravitinoConfig config) {
-    String spiVersion = context.getSpiVersion();
-    trinoVersion = Integer.parseInt(spiVersion);
+    String numericSpiVersion = spiVersion.split("[^0-9]")[0];
+    trinoVersion = Integer.parseInt(numericSpiVersion);
 
     // check catalog name with metalake are supported in this trino version
     if (!config.singleMetalakeMode() && !supportCatalogNameWithMetalake()) {

--- a/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/GravitinoConnectorFactory.java
+++ b/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/GravitinoConnectorFactory.java
@@ -156,6 +156,7 @@ public class GravitinoConnectorFactory implements ConnectorFactory {
   }
 
   private void checkTrinoSpiVersion(ConnectorContext context, GravitinoConfig config) {
+    String spiVersion = context.getSpiVersion();
     String numericSpiVersion = spiVersion.split("[^0-9]")[0];
     trinoVersion = Integer.parseInt(numericSpiVersion);
 

--- a/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/GravitinoDynamicFilter.java
+++ b/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/GravitinoDynamicFilter.java
@@ -56,6 +56,11 @@ class GravitinoDynamicFilter implements DynamicFilter {
   }
 
   @Override
+  public OptionalLong getPreferredDynamicFilterTimeout() {
+    return OptionalLong.empty();
+  }
+
+  @Override
   public TupleDomain<ColumnHandle> getCurrentPredicate() {
     return delegate.getCurrentPredicate().transformKeys(GravitinoHandle::unWrap);
   }

--- a/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/GravitinoDynamicFilter.java
+++ b/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/GravitinoDynamicFilter.java
@@ -21,6 +21,7 @@ package org.apache.gravitino.trino.connector;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.DynamicFilter;
 import io.trino.spi.predicate.TupleDomain;
+import java.util.OptionalLong;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
@@ -55,7 +56,10 @@ class GravitinoDynamicFilter implements DynamicFilter {
     return delegate.isAwaitable();
   }
 
-  @Override
+  // Note: this method is not annotated with @Override because it does not exist in the
+  // DynamicFilter interface of the baseline open-source Trino SPI version this connector compiles
+  // against. It is present in newer Trino/Starburst SPI versions, where it is dispatched at
+  // runtime by signature, providing cross-version compatibility.
   public OptionalLong getPreferredDynamicFilterTimeout() {
     return OptionalLong.empty();
   }

--- a/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/util/json/JsonCodec.java
+++ b/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/util/json/JsonCodec.java
@@ -107,101 +107,98 @@ public class JsonCodec {
   static BlockEncodingSerde createBlockEncodingSerde(TypeManager typeManager) throws Exception {
     ClassLoader classLoader = typeManager.getClass().getClassLoader();
     Class<?> blockEncodingManagerClass =
-            classLoader.loadClass("io.trino.metadata.BlockEncodingManager");
+        classLoader.loadClass("io.trino.metadata.BlockEncodingManager");
     Class<?> internalBlockEncodingSerdeClass =
-            classLoader.loadClass("io.trino.metadata.InternalBlockEncodingSerde");
+        classLoader.loadClass("io.trino.metadata.InternalBlockEncodingSerde");
     Object blockEncodingManager =
-            instantiateBlockEncodingManager(blockEncodingManagerClass, classLoader);
+        instantiateBlockEncodingManager(blockEncodingManagerClass, classLoader);
     return (BlockEncodingSerde)
-          internalBlockEncodingSerdeClass
-                    .getConstructor(blockEncodingManagerClass, TypeManager.class)
-                    .newInstance(blockEncodingManager, typeManager);
+        internalBlockEncodingSerdeClass
+            .getConstructor(blockEncodingManagerClass, TypeManager.class)
+            .newInstance(blockEncodingManager, typeManager);
   }
 
   /**
-   * Instantiate BlockEncodingManager across Trino/Starburst variants. OSS Trino exposes
-   * a public no-arg constructor; Starburst replaces it with
-   * BlockEncodingManager(FeaturesConfig) (used to gate type-specific encodings via feature flags).
-   * Newer Trino branches additionally publish a Set<BlockEncoding> variant for Guice
-   * multibindings. We probe each known signature in order, then fall back to a generic constructor
-   * scan that fills unknown reference parameters with null as a last resort, for a very agnostic.
+   * Instantiate BlockEncodingManager across Trino/Starburst variants. OSS Trino exposes a public
+   * no-arg constructor; Starburst replaces it with BlockEncodingManager(FeaturesConfig) (used to
+   * gate type-specific encodings via feature flags). Newer Trino branches additionally publish a
+   * Set<BlockEncoding> variant for Guice multibindings. We probe each known signature in order,
+   * then fall back to a generic constructor scan that fills unknown reference parameters with null
+   * as a last resort, for a very agnostic.
    */
   private static Object instantiateBlockEncodingManager(
-          Class<?> blockEncodingManagerClass, ClassLoader classLoader) throws Exception {
-      try {
-          return blockEncodingManagerClass.getConstructor().newInstance();
-      } catch (NoSuchMethodException ignored) {
-          // fall through to parameterized variants
-      }
+      Class<?> blockEncodingManagerClass, ClassLoader classLoader) throws Exception {
+    try {
+      return blockEncodingManagerClass.getConstructor().newInstance();
+    } catch (NoSuchMethodException ignored) {
+      // fall through to parameterized variants
+    }
 
-      try {
-          Class<?> featuresConfigClass = classLoader.loadClass("io.trino.FeaturesConfig");
-          Constructor<?> ctor = blockEncodingManagerClass.getConstructor(featuresConfigClass);
-          Object featuresConfig = featuresConfigClass.getConstructor().newInstance();
-          return ctor.newInstance(featuresConfig);
-      } catch (NoSuchMethodException | ClassNotFoundException ignored) {
-          // fall through
-      }
+    try {
+      Class<?> featuresConfigClass = classLoader.loadClass("io.trino.FeaturesConfig");
+      Constructor<?> ctor = blockEncodingManagerClass.getConstructor(featuresConfigClass);
+      Object featuresConfig = featuresConfigClass.getConstructor().newInstance();
+      return ctor.newInstance(featuresConfig);
+    } catch (NoSuchMethodException | ClassNotFoundException ignored) {
+      // fall through
+    }
 
-      try {
-          Constructor<?> setCtor = blockEncodingManagerClass.getConstructor(Set.class);
-          return setCtor.newInstance(Collections.emptySet());
-      } catch (NoSuchMethodException ignored) {
-          // fall through to last-resort scan
-      }
+    try {
+      Constructor<?> setCtor = blockEncodingManagerClass.getConstructor(Set.class);
+      return setCtor.newInstance(Collections.emptySet());
+    } catch (NoSuchMethodException ignored) {
+      // fall through to last-resort scan
+    }
 
-      NoSuchMethodException lastError = null;
-      for (Constructor<?> ctor : blockEncodingManagerClass.getDeclaredConstructors()) {
-          try {
-              ctor.setAccessible(true);
-              Class<?>[] paramTypes = ctor.getParameterTypes();
-              Object[] args = new Object[paramTypes.length];
-              for (int i = 0; i < paramTypes.length; i++) {
-                  if (Set.class.isAssignableFrom(paramTypes[i])) {
-                      args[i] = Collections.emptySet();
-                  } else if (paramTypes[i].isPrimitive()) {
-                      args[i] = defaultPrimitive(paramTypes[i]);
-                  } else {
-                      args[i] = tryDefaultInstance(paramTypes[i]);
-                  }
-              }
-              return ctor.newInstance(args);
-          } catch (ReflectiveOperationException e) {
-              lastError =
-                      new NoSuchMethodException(
-                              "Failed invoking BlockEncodingManager constructor "
-                                      + ctor
-                                      + ": "
-                                      + e.getMessage());
+    NoSuchMethodException lastError = null;
+    for (Constructor<?> ctor : blockEncodingManagerClass.getDeclaredConstructors()) {
+      try {
+        ctor.setAccessible(true);
+        Class<?>[] paramTypes = ctor.getParameterTypes();
+        Object[] args = new Object[paramTypes.length];
+        for (int i = 0; i < paramTypes.length; i++) {
+          if (Set.class.isAssignableFrom(paramTypes[i])) {
+            args[i] = Collections.emptySet();
+          } else if (paramTypes[i].isPrimitive()) {
+            args[i] = defaultPrimitive(paramTypes[i]);
+          } else {
+            args[i] = tryDefaultInstance(paramTypes[i]);
           }
+        }
+        return ctor.newInstance(args);
+      } catch (ReflectiveOperationException e) {
+        lastError =
+            new NoSuchMethodException(
+                "Failed invoking BlockEncodingManager constructor " + ctor + ": " + e.getMessage());
       }
+    }
 
-      throw new NoSuchMethodException(
-              "No usable BlockEncodingManager constructor found in "
-                      + blockEncodingManagerClass.getName()
-                      + (lastError == null ? "" : " (last error: " + lastError.getMessage() + ")"));
+    throw new NoSuchMethodException(
+        "No usable BlockEncodingManager constructor found in "
+            + blockEncodingManagerClass.getName()
+            + (lastError == null ? "" : " (last error: " + lastError.getMessage() + ")"));
   }
 
   private static Object tryDefaultInstance(Class<?> type) {
-      try {
-          Constructor<?> ctor = type.getConstructor();
-          ctor.setAccessible(true);
-          return ctor.newInstance();
-      } catch (ReflectiveOperationException e) {
-          return null;
-      }
+    try {
+      Constructor<?> ctor = type.getConstructor();
+      ctor.setAccessible(true);
+      return ctor.newInstance();
+    } catch (ReflectiveOperationException e) {
+      return null;
+    }
   }
 
   private static Object defaultPrimitive(Class<?> type) {
-      if (type == boolean.class) return false;
-      if (type == char.class) return '\0';
-      if (type == byte.class) return (byte) 0;
-      if (type == short.class) return (short) 0;
-      if (type == int.class) return 0;
-      if (type == long.class) return 0L;
-      if (type == float.class) return 0f;
-      if (type == double.class) return 0d;
-      throw new IllegalArgumentException("Unsupported primitive type: " + type);
+    if (type == boolean.class) return false;
+    if (type == char.class) return '\0';
+    if (type == byte.class) return (byte) 0;
+    if (type == short.class) return (short) 0;
+    if (type == int.class) return 0;
+    if (type == long.class) return 0L;
+    if (type == float.class) return 0f;
+    if (type == double.class) return 0d;
+    throw new IllegalArgumentException("Unsupported primitive type: " + type);
   }
 
   static void registerHandleSerializationModule(ObjectMapper objectMapper) {

--- a/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/util/json/JsonCodec.java
+++ b/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/util/json/JsonCodec.java
@@ -122,9 +122,9 @@ public class JsonCodec {
    * Instantiate BlockEncodingManager across Trino/Starburst variants. OSS Trino exposes a public
    * no-arg constructor; Starburst replaces it with BlockEncodingManager(FeaturesConfig) (used to
    * gate type-specific encodings via feature flags). Newer Trino branches additionally publish a
-   * Set<BlockEncoding> variant for Guice multibindings. We probe each known signature in order,
-   * then fall back to a generic constructor scan that fills unknown reference parameters with null
-   * as a last resort, for a very agnostic.
+   * {@code Set<BlockEncoding>} variant for Guice multibindings. We probe each known signature in
+   * order, then fall back to a generic constructor scan that fills unknown reference parameters
+   * with null as a last resort, for a very agnostic.
    */
   private static Object instantiateBlockEncodingManager(
       Class<?> blockEncodingManagerClass, ClassLoader classLoader) throws Exception {

--- a/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/util/json/JsonCodec.java
+++ b/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/util/json/JsonCodec.java
@@ -47,7 +47,10 @@ import io.trino.spi.type.StandardTypes;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeManager;
 import io.trino.spi.type.TypeSignature;
+import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
+import java.util.Collections;
+import java.util.Set;
 import java.util.function.Function;
 import org.apache.gravitino.trino.connector.GravitinoConnectorPluginManager;
 
@@ -103,14 +106,102 @@ public class JsonCodec {
 
   static BlockEncodingSerde createBlockEncodingSerde(TypeManager typeManager) throws Exception {
     ClassLoader classLoader = typeManager.getClass().getClassLoader();
-    Class blockEncodingManagerClass =
-        classLoader.loadClass("io.trino.metadata.BlockEncodingManager");
-    Class internalBlockEncodingSerdeClass =
-        classLoader.loadClass("io.trino.metadata.InternalBlockEncodingSerde");
+    Class<?> blockEncodingManagerClass =
+            classLoader.loadClass("io.trino.metadata.BlockEncodingManager");
+    Class<?> internalBlockEncodingSerdeClass =
+            classLoader.loadClass("io.trino.metadata.InternalBlockEncodingSerde");
+    Object blockEncodingManager =
+            instantiateBlockEncodingManager(blockEncodingManagerClass, classLoader);
     return (BlockEncodingSerde)
-        internalBlockEncodingSerdeClass
-            .getConstructor(blockEncodingManagerClass, TypeManager.class)
-            .newInstance(blockEncodingManagerClass.getConstructor().newInstance(), typeManager);
+          internalBlockEncodingSerdeClass
+                    .getConstructor(blockEncodingManagerClass, TypeManager.class)
+                    .newInstance(blockEncodingManager, typeManager);
+  }
+
+  /**
+   * Instantiate BlockEncodingManager across Trino/Starburst variants. OSS Trino exposes
+   * a public no-arg constructor; Starburst replaces it with
+   * BlockEncodingManager(FeaturesConfig) (used to gate type-specific encodings via feature flags).
+   * Newer Trino branches additionally publish a Set<BlockEncoding> variant for Guice
+   * multibindings. We probe each known signature in order, then fall back to a generic constructor
+   * scan that fills unknown reference parameters with null as a last resort, for a very agnostic.
+   */
+  private static Object instantiateBlockEncodingManager(
+          Class<?> blockEncodingManagerClass, ClassLoader classLoader) throws Exception {
+      try {
+          return blockEncodingManagerClass.getConstructor().newInstance();
+      } catch (NoSuchMethodException ignored) {
+          // fall through to parameterized variants
+      }
+
+      try {
+          Class<?> featuresConfigClass = classLoader.loadClass("io.trino.FeaturesConfig");
+          Constructor<?> ctor = blockEncodingManagerClass.getConstructor(featuresConfigClass);
+          Object featuresConfig = featuresConfigClass.getConstructor().newInstance();
+          return ctor.newInstance(featuresConfig);
+      } catch (NoSuchMethodException | ClassNotFoundException ignored) {
+          // fall through
+      }
+
+      try {
+          Constructor<?> setCtor = blockEncodingManagerClass.getConstructor(Set.class);
+          return setCtor.newInstance(Collections.emptySet());
+      } catch (NoSuchMethodException ignored) {
+          // fall through to last-resort scan
+      }
+
+      NoSuchMethodException lastError = null;
+      for (Constructor<?> ctor : blockEncodingManagerClass.getDeclaredConstructors()) {
+          try {
+              ctor.setAccessible(true);
+              Class<?>[] paramTypes = ctor.getParameterTypes();
+              Object[] args = new Object[paramTypes.length];
+              for (int i = 0; i < paramTypes.length; i++) {
+                  if (Set.class.isAssignableFrom(paramTypes[i])) {
+                      args[i] = Collections.emptySet();
+                  } else if (paramTypes[i].isPrimitive()) {
+                      args[i] = defaultPrimitive(paramTypes[i]);
+                  } else {
+                      args[i] = tryDefaultInstance(paramTypes[i]);
+                  }
+              }
+              return ctor.newInstance(args);
+          } catch (ReflectiveOperationException e) {
+              lastError =
+                      new NoSuchMethodException(
+                              "Failed invoking BlockEncodingManager constructor "
+                                      + ctor
+                                      + ": "
+                                      + e.getMessage());
+          }
+      }
+
+      throw new NoSuchMethodException(
+              "No usable BlockEncodingManager constructor found in "
+                      + blockEncodingManagerClass.getName()
+                      + (lastError == null ? "" : " (last error: " + lastError.getMessage() + ")"));
+  }
+
+  private static Object tryDefaultInstance(Class<?> type) {
+      try {
+          Constructor<?> ctor = type.getConstructor();
+          ctor.setAccessible(true);
+          return ctor.newInstance();
+      } catch (ReflectiveOperationException e) {
+          return null;
+      }
+  }
+
+  private static Object defaultPrimitive(Class<?> type) {
+      if (type == boolean.class) return false;
+      if (type == char.class) return '\0';
+      if (type == byte.class) return (byte) 0;
+      if (type == short.class) return (short) 0;
+      if (type == int.class) return 0;
+      if (type == long.class) return 0L;
+      if (type == float.class) return 0f;
+      if (type == double.class) return 0d;
+      throw new IllegalArgumentException("Unsupported primitive type: " + type);
   }
 
   static void registerHandleSerializationModule(ObjectMapper objectMapper) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR makes the Gravitino Trino connector build cleanly across both open-source Trino and Starburst SPI variants, and documents how a user can build it against a Starburst SPI, for his private usage (because Starburst is a commercial and private product).
This PR is the result of a little discussion about this idea at [#10905].

- GravitinoConnectorFactory: a little agnostic change into the declaration inside the checkTrinoSpiVersion method. The numeric version is still parsed with spiVersion.split("[^0-9]")[0], so non-numeric Starburst version strings (e.g. 476-e.0.26) are handled.

- **GravitinoDynamicFilter**: add the getPreferredDynamicFilterTimeout() method with an optionalLong empty as return. That method is absent from the baseline open-source trino-spi DynamicFilter interface but present in newer Trino/Starburst SPIs, where it is still dispatched at runtime by signature. A comment documents why @Override is intentionally omitted, to prevent a failure at build time for trino SPI users.

- **JsonCodec**: the previous implementation assumed a no-arg public constructor for BlockEncodingManager, which broke compatibility with Starburst distributions (which require a FeaturesConfig argument) and newer Trino branches (which expose a Set<BlockEncoding> variant for Guice multibindings).
This change introduces a dedicated instantiateBlockEncodingManager helper that probes known constructor signatures in order — no-arg, then FeaturesConfig, then Set<BlockEncoding> — before falling back to a generic reflective scan that attempts to fill unknown parameters with safe defaults (null for objects, JVM defaults for primitives).
This makes the Trino connector resilient to constructor signature differences across OSS Trino and Starburst versions without requiring version-specific code paths.

**Docs** : add docs/trino-connector/starburst-compatibility.md (with a link from docs/trino-connector/index.md) describing, for indication only, how to build the connector against a Starburst SPI jar, including the licensing rationale and caveats.

### Why are the changes needed?

These changes keep the shared source cross-version compatible, to allow to the Starburst users to benefit and (eventually) maintain an alternative trino-connector adapted and built for a specific Starburst/Trino SPI version, without any code changes, but just with little changes during the trino-connector build time of the gravitino project.
The new doc page explains the Starburst build path for the TrinoStarburst users which the project cannot ship itself because the Starburst trino-spi jar is a proprietary, non-redistributable artifact.

Fix: [#10905]

### Does this PR introduce _any_ user-facing change?

No API or property-key changes. The only user-facing addition is a new documentation page, [Starburst compatibility](vscode-webview://07991g9jc13v4i7rtg7544n4okvc96gfo7q714pqcv6rf2b24682/docs/trino-connector/starburst-compatibility.md), linked from the Trino connector docs index.

### How was this patch tested?

Built locally with JDK 17: JAVA_HOME=/opt/jdk-17 ./gradlew :trino-connector:trino-connector:compileJava succeeds with no errors.
./gradlew :trino-connector:trino-connector:spotlessApply is clean.
./gradlew :docs:build (OpenAPI validation) passes.
and manually verified the documented Starburst build path for one Starburst-based Trino version in the 473–478 range.
