### PR TITLE
[#11305] feat(spark-connector): Support native Iceberg REST access mode

### DIFF
--- a/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/GravitinoSparkConfig.java
+++ b/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/GravitinoSparkConfig.java
@@ -19,6 +19,7 @@
 
 package org.apache.gravitino.spark.connector;
 
+import java.util.Locale;
 import org.apache.gravitino.auth.AuthProperties;
 
 public class GravitinoSparkConfig {
@@ -30,6 +31,7 @@ public class GravitinoSparkConfig {
       GRAVITINO_PREFIX + "enableIcebergSupport";
   public static final String GRAVITINO_ENABLE_PAIMON_SUPPORT =
       GRAVITINO_PREFIX + "enablePaimonSupport";
+  public static final String GRAVITINO_ENGINE_ACCESS_MODE = "engine-access-mode";
   public static final String GRAVITINO_CLIENT_CONFIG_PREFIX = GRAVITINO_PREFIX + "client.";
 
   public static final String GRAVITINO_AUTH_TYPE =
@@ -47,6 +49,19 @@ public class GravitinoSparkConfig {
 
   public static final String GRAVITINO_HIVE_METASTORE_URI = "metastore.uris";
   public static final String SPARK_HIVE_METASTORE_URI = "hive.metastore.uris";
+
+  /**
+   * Returns the Spark config key for the given Gravitino provider's engine access mode.
+   *
+   * @param provider Gravitino catalog provider.
+   * @return Spark config key for the provider's engine access mode.
+   */
+  public static String engineAccessModeConfig(String provider) {
+    return GRAVITINO_PREFIX
+        + provider.toLowerCase(Locale.ROOT)
+        + "."
+        + GRAVITINO_ENGINE_ACCESS_MODE;
+  }
 
   private GravitinoSparkConfig() {}
 }

--- a/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/plugin/GravitinoDriverPlugin.java
+++ b/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/plugin/GravitinoDriverPlugin.java
@@ -40,6 +40,7 @@ import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.gravitino.Catalog;
 import org.apache.gravitino.auth.AuthProperties;
+import org.apache.gravitino.catalog.lakehouse.iceberg.IcebergConstants;
 import org.apache.gravitino.client.DefaultOAuth2TokenProvider;
 import org.apache.gravitino.client.GravitinoClient;
 import org.apache.gravitino.client.GravitinoClient.ClientBuilder;
@@ -50,6 +51,8 @@ import org.apache.gravitino.spark.connector.catalog.GravitinoCatalogManager;
 import org.apache.gravitino.spark.connector.iceberg.extensions.GravitinoIcebergSparkSessionExtensions;
 import org.apache.gravitino.spark.connector.version.CatalogNameAdaptor;
 import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.iceberg.CatalogProperties;
+import org.apache.iceberg.CatalogUtil;
 import org.apache.spark.SparkConf;
 import org.apache.spark.SparkContext;
 import org.apache.spark.api.plugin.DriverPlugin;
@@ -65,6 +68,16 @@ import org.slf4j.LoggerFactory;
 public class GravitinoDriverPlugin implements DriverPlugin {
 
   private static final Logger LOG = LoggerFactory.getLogger(GravitinoDriverPlugin.class);
+
+  @VisibleForTesting
+  static final String ICEBERG_SPARK_CATALOG = "org.apache.iceberg.spark.SparkCatalog";
+
+  @VisibleForTesting
+  static final String ICEBERG_ACCESS_DELEGATION_HEADER = "header.X-Iceberg-Access-Delegation";
+
+  @VisibleForTesting static final String VENDED_CREDENTIALS = "vended-credentials";
+
+  private static final String LAKEHOUSE_ICEBERG_PROVIDER = "lakehouse-iceberg";
 
   @VisibleForTesting
   static final String PAIMON_SPARK_EXTENSIONS =
@@ -107,7 +120,7 @@ public class GravitinoDriverPlugin implements DriverPlugin {
       gravitinoDriverExtensions.addAll(gravitinoPaimonExtensions);
     }
     if (enableIcebergSupport) {
-      gravitinoDriverExtensions.addAll(gravitinoIcebergExtensions);
+      gravitinoDriverExtensions.addAll(getIcebergExtensions(conf));
     }
 
     this.catalogManager =
@@ -137,7 +150,11 @@ public class GravitinoDriverPlugin implements DriverPlugin {
               String catalogName = entry.getKey();
               Catalog gravitinoCatalog = entry.getValue();
               String provider = gravitinoCatalog.provider();
-              if ("lakehouse-iceberg".equals(provider.toLowerCase(Locale.ROOT))
+              if (StringUtils.isBlank(provider)) {
+                LOG.warn("Skip registering {} because catalog provider is empty.", catalogName);
+                return;
+              }
+              if (LAKEHOUSE_ICEBERG_PROVIDER.equals(provider.toLowerCase(Locale.ROOT))
                   && !enableIcebergSupport) {
                 return;
               }
@@ -146,16 +163,25 @@ public class GravitinoDriverPlugin implements DriverPlugin {
                 return;
               }
               try {
-                registerCatalog(sparkConf, catalogName, provider);
+                registerCatalog(sparkConf, catalogName, gravitinoCatalog);
               } catch (Exception e) {
+                if (isNativeIcebergCatalog(sparkConf, provider)) {
+                  throw e;
+                }
                 LOG.warn("Register catalog {} failed.", catalogName, e);
               }
             });
   }
 
-  private void registerCatalog(SparkConf sparkConf, String catalogName, String provider) {
+  private void registerCatalog(SparkConf sparkConf, String catalogName, Catalog gravitinoCatalog) {
+    String provider = gravitinoCatalog.provider();
     if (StringUtils.isBlank(provider)) {
       LOG.warn("Skip registering {} because catalog provider is empty.", catalogName);
+      return;
+    }
+
+    if (isNativeIcebergCatalog(sparkConf, provider)) {
+      registerNativeIcebergCatalog(sparkConf, catalogName, gravitinoCatalog.properties());
       return;
     }
 
@@ -171,6 +197,75 @@ public class GravitinoDriverPlugin implements DriverPlugin {
         catalogName + " is already registered to SparkCatalogManager");
     sparkConf.set(sparkCatalogConfigName, catalogClassName);
     LOG.info("Register {} catalog to Spark catalog manager.", catalogName);
+  }
+
+  private static boolean isNativeIcebergCatalog(SparkConf sparkConf, String provider) {
+    return StringUtils.isNotBlank(provider)
+        && LAKEHOUSE_ICEBERG_PROVIDER.equals(provider.toLowerCase(Locale.ROOT))
+        && getEngineAccessMode(sparkConf, provider) == EngineAccessMode.NATIVE;
+  }
+
+  @VisibleForTesting
+  static EngineAccessMode getEngineAccessMode(SparkConf sparkConf, String provider) {
+    return EngineAccessMode.from(
+        sparkConf.get(GravitinoSparkConfig.engineAccessModeConfig(provider), null));
+  }
+
+  private static void registerNativeIcebergCatalog(
+      SparkConf sparkConf, String catalogName, Map<String, String> properties) {
+    String sparkCatalogConfigName = "spark.sql.catalog." + catalogName;
+    Preconditions.checkArgument(
+        !sparkConf.contains(sparkCatalogConfigName),
+        catalogName + " is already registered to SparkCatalogManager");
+
+    buildNativeIcebergCatalogConfigurations(catalogName, properties).forEach(sparkConf::set);
+    LOG.info(
+        "Register {} catalog to Spark catalog manager with native Iceberg REST catalog.",
+        catalogName);
+  }
+
+  @VisibleForTesting
+  static Map<String, String> buildNativeIcebergCatalogConfigurations(
+      String catalogName, Map<String, String> properties) {
+    Preconditions.checkArgument(
+        properties != null, "Iceberg catalog properties should not be null");
+
+    String catalogBackend = properties.get(IcebergConstants.CATALOG_BACKEND);
+    Preconditions.checkArgument(
+        CatalogUtil.ICEBERG_CATALOG_TYPE_REST.equalsIgnoreCase(catalogBackend),
+        "Native Iceberg Spark catalog only supports catalog-backend=rest");
+
+    String uri = properties.get(IcebergConstants.URI);
+    Preconditions.checkArgument(
+        StringUtils.isNotBlank(uri), "uri should not be empty for native Iceberg REST catalog");
+
+    ImmutableMap.Builder<String, String> configs = ImmutableMap.builder();
+    String catalogConfigPrefix = "spark.sql.catalog." + catalogName;
+    configs.put(catalogConfigPrefix, ICEBERG_SPARK_CATALOG);
+    configs.put(
+        catalogConfigPrefix + "." + CatalogUtil.ICEBERG_CATALOG_TYPE,
+        CatalogUtil.ICEBERG_CATALOG_TYPE_REST);
+    configs.put(catalogConfigPrefix + "." + CatalogProperties.URI, uri);
+
+    String warehouse = properties.get(IcebergConstants.WAREHOUSE);
+    if (StringUtils.isNotBlank(warehouse)) {
+      configs.put(catalogConfigPrefix + "." + CatalogProperties.WAREHOUSE_LOCATION, warehouse);
+    }
+
+    String dataAccess = properties.get(IcebergConstants.DATA_ACCESS);
+    if (VENDED_CREDENTIALS.equalsIgnoreCase(dataAccess)) {
+      configs.put(catalogConfigPrefix + "." + ICEBERG_ACCESS_DELEGATION_HEADER, VENDED_CREDENTIALS);
+    }
+
+    return configs.build();
+  }
+
+  @VisibleForTesting
+  List<String> getIcebergExtensions(SparkConf conf) {
+    if (getEngineAccessMode(conf, LAKEHOUSE_ICEBERG_PROVIDER) == EngineAccessMode.NATIVE) {
+      return Collections.singletonList(ICEBERG_SPARK_EXTENSIONS);
+    }
+    return gravitinoIcebergExtensions;
   }
 
   private void registerSqlExtensions(SparkConf conf) {
@@ -261,5 +356,28 @@ public class GravitinoDriverPlugin implements DriverPlugin {
                             t -> t._2,
                             (oldVal, newVal) -> newVal)))
         .orElse(ImmutableMap.of());
+  }
+
+  @VisibleForTesting
+  enum EngineAccessMode {
+    AUTO,
+    GRAVITINO,
+    NATIVE;
+
+    static EngineAccessMode from(@Nullable String value) {
+      if (StringUtils.isBlank(value)) {
+        return AUTO;
+      }
+
+      try {
+        return EngineAccessMode.valueOf(value.trim().toUpperCase(Locale.ROOT));
+      } catch (IllegalArgumentException e) {
+        throw new IllegalArgumentException(
+            String.format(
+                "Unsupported engine access mode: %s. Supported values are: auto, gravitino, native",
+                value),
+            e);
+      }
+    }
   }
 }

--- a/spark-connector/spark-common/src/test/java/org/apache/gravitino/spark/connector/TestGravitinoSparkConfig.java
+++ b/spark-connector/spark-common/src/test/java/org/apache/gravitino/spark/connector/TestGravitinoSparkConfig.java
@@ -43,4 +43,14 @@ public class TestGravitinoSparkConfig {
     Assertions.assertEquals(clientConfig.get("gravitino.client.socketTimeoutMs"), "1000");
     Assertions.assertEquals(clientConfig.get("gravitino.client.connectionTimeoutMs"), "2000");
   }
+
+  @Test
+  void testEngineAccessModeConfig() {
+    Assertions.assertEquals(
+        "spark.sql.gravitino.lakehouse-iceberg.engine-access-mode",
+        GravitinoSparkConfig.engineAccessModeConfig("lakehouse-iceberg"));
+    Assertions.assertEquals(
+        "spark.sql.gravitino.lakehouse-iceberg.engine-access-mode",
+        GravitinoSparkConfig.engineAccessModeConfig("LAKEHOUSE-ICEBERG"));
+  }
 }

--- a/spark-connector/spark-common/src/test/java/org/apache/gravitino/spark/connector/integration/test/SparkEnvIT.java
+++ b/spark-connector/spark-common/src/test/java/org/apache/gravitino/spark/connector/integration/test/SparkEnvIT.java
@@ -84,6 +84,8 @@ public abstract class SparkEnvIT extends SparkUtilIT {
     return true;
   }
 
+  protected void customizeSparkConf(SparkConf sparkConf) {}
+
   @Override
   protected SparkSession getSparkSession() {
     Assertions.assertNotNull(sparkSession);
@@ -275,6 +277,7 @@ public abstract class SparkEnvIT extends SparkUtilIT {
             .set("hive.exec.dynamic.partition.mode", "nonstrict")
             .set("spark.sql.warehouse.dir", warehouse)
             .set("spark.sql.session.timeZone", TIME_ZONE_UTC);
+    customizeSparkConf(sparkConf);
     sparkSession =
         SparkSession.builder()
             .master("local[1]")

--- a/spark-connector/spark-common/src/test/java/org/apache/gravitino/spark/connector/integration/test/iceberg/SparkIcebergNativeRestCatalogIT.java
+++ b/spark-connector/spark-common/src/test/java/org/apache/gravitino/spark/connector/integration/test/iceberg/SparkIcebergNativeRestCatalogIT.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.spark.connector.integration.test.iceberg;
+
+import com.google.common.collect.Maps;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import org.apache.gravitino.spark.connector.GravitinoSparkConfig;
+import org.apache.gravitino.spark.connector.iceberg.IcebergPropertiesConstants;
+import org.apache.gravitino.spark.connector.integration.test.SparkEnvIT;
+import org.apache.iceberg.spark.SparkCatalog;
+import org.apache.spark.SparkConf;
+import org.apache.spark.sql.connector.catalog.CatalogPlugin;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIf;
+
+/** Tests Spark native Iceberg REST catalog registration through Gravitino Spark plugin. */
+@Tag("gravitino-docker-test")
+@DisabledIf("org.apache.gravitino.integration.test.util.ITUtils#isEmbedded")
+public abstract class SparkIcebergNativeRestCatalogIT extends SparkEnvIT {
+
+  private static final String DATABASE = "native_iceberg_rest_db";
+
+  @Override
+  protected String getCatalogName() {
+    return "iceberg_native";
+  }
+
+  @Override
+  protected String getProvider() {
+    return "lakehouse-iceberg";
+  }
+
+  @Override
+  protected Map<String, String> getCatalogConfigs() {
+    Map<String, String> catalogProperties = Maps.newHashMap();
+    catalogProperties.put(
+        IcebergPropertiesConstants.GRAVITINO_ICEBERG_CATALOG_BACKEND,
+        IcebergPropertiesConstants.ICEBERG_CATALOG_BACKEND_REST);
+    catalogProperties.put(
+        IcebergPropertiesConstants.GRAVITINO_ICEBERG_CATALOG_URI, icebergRestServiceUri);
+    return catalogProperties;
+  }
+
+  @Override
+  protected boolean supportsFunction() {
+    return false;
+  }
+
+  @Override
+  protected void customizeSparkConf(SparkConf sparkConf) {
+    sparkConf.set(GravitinoSparkConfig.engineAccessModeConfig(getProvider()), "native");
+  }
+
+  @BeforeAll
+  void initDefaultDatabase() {
+    sql("USE " + getCatalogName());
+    sql("CREATE DATABASE IF NOT EXISTS " + DATABASE);
+  }
+
+  @BeforeEach
+  void init() {
+    sql("USE " + getCatalogName());
+    sql("USE " + DATABASE);
+  }
+
+  @AfterAll
+  void cleanUp() throws IOException {
+    if (getSparkSession() != null) {
+      sql("USE " + getCatalogName());
+      sql("DROP TABLE IF EXISTS " + DATABASE + ".native_table");
+      sql("DROP DATABASE IF EXISTS " + DATABASE);
+    }
+  }
+
+  @Test
+  void testSparkUsesNativeIcebergCatalog() {
+    CatalogPlugin catalogPlugin =
+        getSparkSession().sessionState().catalogManager().catalog(getCatalogName());
+    Assertions.assertInstanceOf(SparkCatalog.class, catalogPlugin);
+  }
+
+  @Test
+  void testCreateAndQueryTableWithNativeIcebergRestCatalog() {
+    sql("DROP TABLE IF EXISTS native_table");
+    sql("CREATE TABLE native_table (id INT, name STRING) USING iceberg");
+    sql("INSERT INTO native_table VALUES (1, 'a'), (2, 'b')");
+
+    List<String> rows = getQueryData("SELECT id, name FROM native_table ORDER BY id");
+    Assertions.assertEquals(2, rows.size());
+    Assertions.assertEquals("1,a;2,b", String.join(";", rows));
+  }
+}

--- a/spark-connector/spark-common/src/test/java/org/apache/gravitino/spark/connector/plugin/TestGravitinoDriverPlugin.java
+++ b/spark-connector/spark-common/src/test/java/org/apache/gravitino/spark/connector/plugin/TestGravitinoDriverPlugin.java
@@ -19,7 +19,17 @@
 
 package org.apache.gravitino.spark.connector.plugin;
 
+import com.google.common.collect.ImmutableMap;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+import org.apache.gravitino.catalog.lakehouse.iceberg.IcebergConstants;
+import org.apache.gravitino.spark.connector.GravitinoSparkConfig;
+import org.apache.gravitino.spark.connector.iceberg.extensions.GravitinoIcebergSparkSessionExtensions;
+import org.apache.iceberg.CatalogProperties;
+import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions;
+import org.apache.spark.SparkConf;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -30,5 +40,137 @@ public class TestGravitinoDriverPlugin {
     Assertions.assertEquals(
         IcebergSparkSessionExtensions.class.getName(),
         GravitinoDriverPlugin.ICEBERG_SPARK_EXTENSIONS);
+  }
+
+  @Test
+  void testEngineAccessMode() {
+    Assertions.assertEquals(
+        GravitinoDriverPlugin.EngineAccessMode.AUTO,
+        GravitinoDriverPlugin.EngineAccessMode.from(null));
+    Assertions.assertEquals(
+        GravitinoDriverPlugin.EngineAccessMode.AUTO,
+        GravitinoDriverPlugin.EngineAccessMode.from(""));
+    Assertions.assertEquals(
+        GravitinoDriverPlugin.EngineAccessMode.AUTO,
+        GravitinoDriverPlugin.EngineAccessMode.from(" auto "));
+    Assertions.assertEquals(
+        GravitinoDriverPlugin.EngineAccessMode.GRAVITINO,
+        GravitinoDriverPlugin.EngineAccessMode.from("gravitino"));
+    Assertions.assertEquals(
+        GravitinoDriverPlugin.EngineAccessMode.NATIVE,
+        GravitinoDriverPlugin.EngineAccessMode.from("NATIVE"));
+
+    IllegalArgumentException exception =
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () -> GravitinoDriverPlugin.EngineAccessMode.from("unsupported"));
+    Assertions.assertTrue(exception.getMessage().contains("auto, gravitino, native"));
+  }
+
+  @Test
+  void testGetProviderEngineAccessMode() {
+    SparkConf conf = new SparkConf();
+    Assertions.assertEquals(
+        GravitinoDriverPlugin.EngineAccessMode.AUTO,
+        GravitinoDriverPlugin.getEngineAccessMode(conf, "lakehouse-iceberg"));
+
+    conf.set(GravitinoSparkConfig.engineAccessModeConfig("lakehouse-iceberg"), "native");
+    Assertions.assertEquals(
+        GravitinoDriverPlugin.EngineAccessMode.NATIVE,
+        GravitinoDriverPlugin.getEngineAccessMode(conf, "lakehouse-iceberg"));
+  }
+
+  @Test
+  void testGetIcebergExtensions() {
+    GravitinoDriverPlugin plugin = new GravitinoDriverPlugin();
+    SparkConf conf = new SparkConf();
+    Assertions.assertEquals(
+        Arrays.asList(
+            GravitinoIcebergSparkSessionExtensions.class.getName(),
+            GravitinoDriverPlugin.ICEBERG_SPARK_EXTENSIONS),
+        plugin.getIcebergExtensions(conf));
+
+    conf.set(GravitinoSparkConfig.engineAccessModeConfig("lakehouse-iceberg"), "native");
+    Assertions.assertEquals(
+        Collections.singletonList(GravitinoDriverPlugin.ICEBERG_SPARK_EXTENSIONS),
+        plugin.getIcebergExtensions(conf));
+  }
+
+  @Test
+  void testBuildNativeIcebergCatalogConfigurations() {
+    Map<String, String> configs =
+        GravitinoDriverPlugin.buildNativeIcebergCatalogConfigurations(
+            "iceberg_catalog",
+            ImmutableMap.of(
+                IcebergConstants.CATALOG_BACKEND,
+                "REST",
+                IcebergConstants.URI,
+                "http://localhost:8181",
+                IcebergConstants.WAREHOUSE,
+                "s3://warehouse",
+                IcebergConstants.DATA_ACCESS,
+                "vended-credentials"));
+
+    String catalogConfigPrefix = "spark.sql.catalog.iceberg_catalog";
+    Assertions.assertEquals(
+        GravitinoDriverPlugin.ICEBERG_SPARK_CATALOG, configs.get(catalogConfigPrefix));
+    Assertions.assertEquals(
+        CatalogUtil.ICEBERG_CATALOG_TYPE_REST,
+        configs.get(catalogConfigPrefix + "." + CatalogUtil.ICEBERG_CATALOG_TYPE));
+    Assertions.assertEquals(
+        "http://localhost:8181", configs.get(catalogConfigPrefix + "." + CatalogProperties.URI));
+    Assertions.assertEquals(
+        "s3://warehouse",
+        configs.get(catalogConfigPrefix + "." + CatalogProperties.WAREHOUSE_LOCATION));
+    Assertions.assertEquals(
+        GravitinoDriverPlugin.VENDED_CREDENTIALS,
+        configs.get(
+            catalogConfigPrefix + "." + GravitinoDriverPlugin.ICEBERG_ACCESS_DELEGATION_HEADER));
+  }
+
+  @Test
+  void testBuildNativeIcebergCatalogConfigurationsWithoutOptionalProperties() {
+    Map<String, String> configs =
+        GravitinoDriverPlugin.buildNativeIcebergCatalogConfigurations(
+            "iceberg_catalog",
+            ImmutableMap.of(
+                IcebergConstants.CATALOG_BACKEND,
+                "rest",
+                IcebergConstants.URI,
+                "http://localhost:8181"));
+
+    String catalogConfigPrefix = "spark.sql.catalog.iceberg_catalog";
+    Assertions.assertFalse(
+        configs.containsKey(catalogConfigPrefix + "." + CatalogProperties.WAREHOUSE_LOCATION));
+    Assertions.assertFalse(
+        configs.containsKey(
+            catalogConfigPrefix + "." + GravitinoDriverPlugin.ICEBERG_ACCESS_DELEGATION_HEADER));
+  }
+
+  @Test
+  void testBuildNativeIcebergCatalogConfigurationsWithInvalidBackend() {
+    IllegalArgumentException exception =
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                GravitinoDriverPlugin.buildNativeIcebergCatalogConfigurations(
+                    "iceberg_catalog",
+                    ImmutableMap.of(
+                        IcebergConstants.CATALOG_BACKEND,
+                        "hive",
+                        IcebergConstants.URI,
+                        "thrift://localhost:9083")));
+    Assertions.assertTrue(exception.getMessage().contains("catalog-backend=rest"));
+  }
+
+  @Test
+  void testBuildNativeIcebergCatalogConfigurationsWithMissingUri() {
+    IllegalArgumentException exception =
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                GravitinoDriverPlugin.buildNativeIcebergCatalogConfigurations(
+                    "iceberg_catalog", ImmutableMap.of(IcebergConstants.CATALOG_BACKEND, "rest")));
+    Assertions.assertTrue(exception.getMessage().contains("uri should not be empty"));
   }
 }

--- a/spark-connector/v3.3/spark/src/test/java/org/apache/gravitino/spark/connector/integration/test/iceberg/SparkIcebergNativeRestCatalogIT33.java
+++ b/spark-connector/v3.3/spark/src/test/java/org/apache/gravitino/spark/connector/integration/test/iceberg/SparkIcebergNativeRestCatalogIT33.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.spark.connector.integration.test.iceberg;
+
+import org.junit.jupiter.api.condition.DisabledIf;
+
+@DisabledIf("org.apache.gravitino.integration.test.util.ITUtils#isEmbedded")
+public class SparkIcebergNativeRestCatalogIT33 extends SparkIcebergNativeRestCatalogIT {}

--- a/spark-connector/v3.4/spark/src/test/java/org/apache/gravitino/spark/connector/integration/test/iceberg/SparkIcebergNativeRestCatalogIT34.java
+++ b/spark-connector/v3.4/spark/src/test/java/org/apache/gravitino/spark/connector/integration/test/iceberg/SparkIcebergNativeRestCatalogIT34.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.spark.connector.integration.test.iceberg;
+
+import org.junit.jupiter.api.condition.DisabledIf;
+
+@DisabledIf("org.apache.gravitino.integration.test.util.ITUtils#isEmbedded")
+public class SparkIcebergNativeRestCatalogIT34 extends SparkIcebergNativeRestCatalogIT {}

--- a/spark-connector/v3.5/spark/src/test/java/org/apache/gravitino/spark/connector/integration/test/iceberg/SparkIcebergNativeRestCatalogIT35.java
+++ b/spark-connector/v3.5/spark/src/test/java/org/apache/gravitino/spark/connector/integration/test/iceberg/SparkIcebergNativeRestCatalogIT35.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.spark.connector.integration.test.iceberg;
+
+import org.junit.jupiter.api.condition.DisabledIf;
+
+@DisabledIf("org.apache.gravitino.integration.test.util.ITUtils#isEmbedded")
+public class SparkIcebergNativeRestCatalogIT35 extends SparkIcebergNativeRestCatalogIT {}


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds Spark connector support for registering Gravitino Iceberg REST catalogs through Spark's native Iceberg `SparkCatalog` when explicitly requested with:

`spark.sql.gravitino.lakehouse-iceberg.engine-access-mode=native`

It also adds parser/config tests and native Iceberg REST catalog config generation tests. The integration coverage adds a native Iceberg REST Spark IT that verifies Spark registers `org.apache.iceberg.spark.SparkCatalog` and can create/query a table through the REST catalog.

### Why are the changes needed?

This is the first implementation step for unified engine access mode. It lets Spark use native Iceberg REST access while preserving the existing Gravitino Spark connector behavior by default.

Fix: #11305

### Does this PR introduce _any_ user-facing change?

Yes. It adds a new Spark config:

`spark.sql.gravitino.<provider>.engine-access-mode=auto|gravitino|native`

For Iceberg:
- default `auto` preserves existing behavior
- `native` registers Spark's native Iceberg REST catalog for `catalog-backend=rest`

### How was this patch tested?

Ran:

`./gradlew :spark-connector:spark-common:test --tests org.apache.gravitino.spark.connector.plugin.TestGravitinoDriverPlugin --tests org.apache.gravitino.spark.connector.TestGravitinoSparkConfig`

`./gradlew :spark-connector:spark-3.3:test --tests org.apache.gravitino.spark.connector.integration.test.iceberg.SparkIcebergNativeRestCatalogIT33`

`./gradlew :spark-connector:spark-3.4:test --tests org.apache.gravitino.spark.connector.integration.test.iceberg.SparkIcebergNativeRestCatalogIT34`

`./gradlew :spark-connector:spark-3.5:test --tests org.apache.gravitino.spark.connector.integration.test.iceberg.SparkIcebergNativeRestCatalogIT35`

`./gradlew :spark-connector:spark-3.5:test --tests org.apache.gravitino.spark.connector.integration.test.iceberg.SparkIcebergNativeRestCatalogIT35 -PskipDockerTests=false`

Also checked:

`git diff --check`

Note: the local environment is detected as embedded, so the Iceberg REST docker IT class is compiled and selected but skipped by the existing `@DisabledIf(isEmbedded)` guard, matching the existing REST backend IT behavior.