### PR TITLE
[#11296] test(iceberg): cover JDBC hierarchical schema drop

### DIFF
--- a/clients/client-java/src/test/java/org/apache/gravitino/client/integration/test/authorization/HierarchicalSchemaAuthorizationIT.java
+++ b/clients/client-java/src/test/java/org/apache/gravitino/client/integration/test/authorization/HierarchicalSchemaAuthorizationIT.java
@@ -41,6 +41,7 @@ import org.apache.gravitino.authorization.SecurableObjects;
 import org.apache.gravitino.client.GravitinoMetalake;
 import org.apache.gravitino.exceptions.ForbiddenException;
 import org.apache.gravitino.exceptions.NoSuchSchemaException;
+import org.apache.gravitino.exceptions.NonEmptySchemaException;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
@@ -326,5 +327,21 @@ public class HierarchicalSchemaAuthorizationIT extends BaseRestApiAuthorizationI
     List<String> children = Arrays.asList(catalog.asSchemas().listSchemas("P:Q"));
     assertTrue(children.contains("P:Q:R"), "listSchemas(\"P:Q\") should include P:Q:R");
     assertTrue(children.contains("P:Q:S"), "listSchemas(\"P:Q\") should include P:Q:S");
+  }
+
+  @Test
+  @Order(10)
+  public void testDropParentHierarchicalSchemaWithChildFails() {
+    Catalog catalog = client.loadMetalake(METALAKE).loadCatalog(CATALOG);
+    String parent = "DROP_PARENT";
+    String child = "DROP_PARENT:CHILD";
+
+    catalog.asSchemas().createSchema(parent, "parent schema", new HashMap<>());
+    catalog.asSchemas().createSchema(child, "child schema", new HashMap<>());
+
+    assertThrows(
+        NonEmptySchemaException.class, () -> catalog.asSchemas().dropSchema(parent, false));
+    assertEquals(parent, catalog.asSchemas().loadSchema(parent).name());
+    assertEquals(child, catalog.asSchemas().loadSchema(child).name());
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add a hierarchical schema integration test for a JDBC-backed Iceberg catalog. The test creates a child hierarchical schema through the Gravitino catalog API and verifies dropping the parent schema fails with `NonEmptySchemaException` while both parent and child schemas remain.

### Why are the changes needed?

This documents the current behavior discussed in #11296 using the Gravitino API path and the existing `HierarchicalSchemaAuthorizationIT` JDBC-backed Iceberg catalog: parent hierarchical schemas cannot be dropped while child schemas exist.

@danhuawang could you take a look and confirm whether this matches your reproduction environment?

Related: #11296

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

- `git diff --check`
- `./gradlew :clients:client-java:test --tests org.apache.gravitino.client.integration.test.authorization.HierarchicalSchemaAuthorizationIT.testDropParentHierarchicalSchemaWithChildFails -PskipTests -PskipDockerTests=false`
