### PR TITLE
[#11314] improvement(deps):  Remove unused htrace-core4 dependency from Hive and Hudi catalogs

### DIFF
--- a/catalogs/catalog-hive/build.gradle.kts
+++ b/catalogs/catalog-hive/build.gradle.kts
@@ -60,7 +60,6 @@ dependencies {
   implementation(libs.hadoop3.shaded.protobuf)
   implementation(libs.commons.configuration2)
   implementation(libs.re2j)
-  implementation(libs.htrace.core4)
   implementation(libs.slf4j.api)
   implementation(libs.woodstox.core)
 

--- a/catalogs/catalog-lakehouse-hudi/build.gradle.kts
+++ b/catalogs/catalog-lakehouse-hudi/build.gradle.kts
@@ -59,7 +59,6 @@ dependencies {
   implementation(libs.hadoop3.shaded.protobuf)
   implementation(libs.commons.configuration2)
   implementation(libs.re2j)
-  implementation(libs.htrace.core4)
   implementation(libs.slf4j.api)
   implementation(libs.woodstox.core)
 
@@ -131,7 +130,6 @@ dependencies {
   testImplementation(libs.hadoop3.shaded.protobuf)
   testImplementation(libs.commons.configuration2)
   testImplementation(libs.re2j)
-  testImplementation(libs.htrace.core4)
   testImplementation(libs.junit.jupiter.api)
   testImplementation(libs.mysql.driver)
   testImplementation(libs.postgresql.driver)

--- a/catalogs/hive-metastore-common/build.gradle.kts
+++ b/catalogs/hive-metastore-common/build.gradle.kts
@@ -126,7 +126,6 @@ dependencies {
     exclude("org.openjdk.jol")
     exclude("org.slf4j")
   }
-  testImplementation(libs.htrace.core4)
   testImplementation(libs.caffeine)
   testImplementation(libs.junit.jupiter.api)
   testImplementation(libs.mockito.core)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -47,7 +47,6 @@ hadoop3-aliyun = "3.3.6"
 hadoop3-thirdparty = "1.1.1"
 hadoop-minikdc = "3.3.6"
 re2j = "1.7"
-htrace-core4 = "4.1.0-incubating"
 httpclient = "4.4.1"
 httpclient5 = "5.4.4"
 httpcore5 = "5.3.4"
@@ -238,7 +237,6 @@ hadoop3-abs = { group = "org.apache.hadoop", name = "hadoop-azure", version.ref 
 hadoop3-shaded-guava = { group = "org.apache.hadoop.thirdparty", name = "hadoop-shaded-guava", version.ref = "hadoop3-thirdparty" }
 hadoop3-shaded-protobuf = { group = "org.apache.hadoop.thirdparty", name = "hadoop-shaded-protobuf_3_7", version.ref = "hadoop3-thirdparty" }
 re2j = { group = "com.google.re2j", name = "re2j", version.ref = "re2j" }
-htrace-core4 = { group = "org.apache.htrace", name = "htrace-core4", version.ref = "htrace-core4" }
 airlift-json = { group = "io.airlift", name = "json", version.ref = "airlift-json"}
 airlift-resolver = { group = "io.airlift.resolver", name = "resolver", version.ref = "airlift-resolver"}
 httpclient = { group = "org.apache.httpcomponents", name = "httpclient", version.ref = "httpclient" }


### PR DESCRIPTION


### What changes were proposed in this pull request?

Remove the `htrace-core4-4.1.0-incubating` dependency from the project. This library is no longer needed as Hadoop 3.3.x does not require it at runtime.
Changes:
- Remove `htrace-core4` version and library declaration from libs.versions.toml
- Remove `implementation(libs.htrace.core4)` from `catalog-hive` and `catalog-lakehouse-hudi`
- Remove `testImplementation(libs.htrace.core4)` from `catalog-lakehouse-hudi` and `hive-metastore-common`

### Why are the changes needed?

Apache HTrace has been retired (moved to Apache Attic) and is no longer maintained. Hadoop 3.3.x rewrote its tracing subsystem and no longer depends on htrace-core4 at runtime. The existing cleanup code in `ClassLoaderResourceCleanerUtils` already handles the absence of htrace gracefully via reflection with try-catch. Removing this unused dependency reduces the project's dependency footprint.

Fix: #11314 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

- Verified compilation of all affected modules (`catalog-hive`, `catalog-lakehouse-hudi`, `hive-metastore-common`)
- Ran unit tests for all affected modules — all passed
- Verified `htrace-core4` jar is no longer present in distribution output
- Confirmed no source code imports from `org.apache.htrace` (only reflection-based reference in `ClassLoaderResourceCleanerUtils` which is already guarded by try-catch)
