### PR TITLE
[#11317] fix(core): reject listing schemas under a parent for non-hierarchical catalogs

### DIFF
--- a/catalogs/catalog-hive/src/test/java/org/apache/gravitino/catalog/hive/integration/test/CatalogHive2IT.java
+++ b/catalogs/catalog-hive/src/test/java/org/apache/gravitino/catalog/hive/integration/test/CatalogHive2IT.java
@@ -772,6 +772,14 @@ public class CatalogHive2IT extends BaseIT {
   }
 
   @Test
+  public void testListSchemasWithParentSchemaUnsupported() {
+    // Hive does not support hierarchical (nested) schemas, so listing schemas under a parent
+    // schema must be rejected instead of returning the catalog's flat schemas (see issue #11317).
+    SupportsSchemas schemas = catalog.asSchemas();
+    assertThrows(UnsupportedOperationException.class, () -> schemas.listSchemas(schemaName));
+  }
+
+  @Test
   public void testFunctions() throws InterruptedException {
     // test list functions in a schema which not created by Gravitino
     String schemaName1 = GravitinoITUtils.genRandomName(SCHEMA_PREFIX);

--- a/catalogs/catalog-lakehouse-iceberg/src/main/java/org/apache/gravitino/catalog/lakehouse/iceberg/IcebergCatalogCapability.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/main/java/org/apache/gravitino/catalog/lakehouse/iceberg/IcebergCatalogCapability.java
@@ -42,6 +42,12 @@ public class IcebergCatalogCapability implements Capability {
     return CapabilityResult.unsupported("Iceberg does not support column default value.");
   }
 
+  @Override
+  public CapabilityResult supportsHierarchicalSchema() {
+    // Iceberg namespaces can be multi-level, so Iceberg supports hierarchical (nested) schemas.
+    return CapabilityResult.SUPPORTED;
+  }
+
   /**
    * Validates the schema name specification for Iceberg.
    *

--- a/catalogs/catalog-lakehouse-iceberg/src/test/java/org/apache/gravitino/catalog/lakehouse/iceberg/TestIcebergCatalogCapability.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/test/java/org/apache/gravitino/catalog/lakehouse/iceberg/TestIcebergCatalogCapability.java
@@ -92,6 +92,13 @@ public class TestIcebergCatalogCapability {
   }
 
   @Test
+  public void testSupportsHierarchicalSchema() {
+    IcebergCatalogCapability capability = new IcebergCatalogCapability(":");
+
+    Assertions.assertTrue(capability.supportsHierarchicalSchema().supported());
+  }
+
+  @Test
   public void testCustomSeparatorSlash() {
     IcebergCatalogCapability capability = new IcebergCatalogCapability("/");
 

--- a/core/src/main/java/org/apache/gravitino/catalog/SchemaNormalizeDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/SchemaNormalizeDispatcher.java
@@ -45,6 +45,18 @@ public class SchemaNormalizeDispatcher implements SchemaDispatcher {
 
   @Override
   public NameIdentifier[] listSchemas(Namespace namespace) throws NoSuchCatalogException {
+    // A namespace with more than two levels ([metalake, catalog]) carries a parentSchema, i.e. the
+    // caller is listing sub-schemas under a parent schema. Catalogs that do not support
+    // hierarchical schemas have no sub-schemas, so we must reject the request instead of returning
+    // the catalog's flat schemas as if they were children of the parent schema (see issue #11317).
+    if (namespace.length() > 2 && !supportsHierarchicalSchema(namespace)) {
+      throw new UnsupportedOperationException(
+          String.format(
+              "The catalog [%s] does not support hierarchical schemas, so listing schemas under a "
+                  + "parent schema is not supported.",
+              NameIdentifier.of(namespace.levels())));
+    }
+
     NameIdentifier[] identifiers = dispatcher.listSchemas(namespace);
     // The constraints of the name spec may be more strict than underlying catalog,
     // and for compatibility reasons, we only apply case-sensitive capabilities here.
@@ -82,6 +94,11 @@ public class SchemaNormalizeDispatcher implements SchemaDispatcher {
   @Override
   public boolean dropSchema(NameIdentifier ident, boolean cascade) throws NonEmptySchemaException {
     return dispatcher.dropSchema(normalizeNameIdentifier(ident), cascade);
+  }
+
+  private boolean supportsHierarchicalSchema(Namespace namespace) {
+    Capability capabilities = getCapability(NameIdentifier.of(namespace.levels()), catalogManager);
+    return capabilities.supportsHierarchicalSchema().supported();
   }
 
   private NameIdentifier normalizeNameIdentifier(NameIdentifier schemaIdent) {

--- a/core/src/main/java/org/apache/gravitino/connector/capability/Capability.java
+++ b/core/src/main/java/org/apache/gravitino/connector/capability/Capability.java
@@ -97,6 +97,19 @@ public interface Capability {
     return DEFAULT.managedStorage(scope);
   }
 
+  /**
+   * Check if the catalog supports hierarchical (nested) schemas. A hierarchical schema is a schema
+   * that can contain sub-schemas, addressed by a logical name using the configured external
+   * separator (e.g. {@code "A:B:C"}). Catalogs that only support flat schemas (such as Hive or JDBC
+   * catalogs) should keep the default unsupported result so that listing schemas under a parent
+   * schema is rejected instead of returning misleading data.
+   *
+   * @return The capability of the hierarchical schema support.
+   */
+  default CapabilityResult supportsHierarchicalSchema() {
+    return DEFAULT.supportsHierarchicalSchema();
+  }
+
   /** The default implementation of the capability. */
   class DefaultCapability implements Capability {
 
@@ -152,6 +165,12 @@ public interface Capability {
 
       return CapabilityResult.unsupported(
           String.format("The %s entity is not fully managed by Gravitino.", scope));
+    }
+
+    @Override
+    public CapabilityResult supportsHierarchicalSchema() {
+      return CapabilityResult.unsupported(
+          "The catalog does not support hierarchical (nested) schemas.");
     }
   }
 }

--- a/core/src/test/java/org/apache/gravitino/catalog/TestSchemaNormalizeDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestSchemaNormalizeDispatcher.java
@@ -72,6 +72,21 @@ public class TestSchemaNormalizeDispatcher extends TestOperationDispatcher {
   }
 
   @Test
+  public void testListSchemasUnderParentSchemaUnsupported() {
+    // The test catalog does not support hierarchical schemas, so listing schemas under a parent
+    // schema (a namespace deeper than [metalake, catalog]) must be rejected instead of returning
+    // the catalog's flat schemas (see issue #11317).
+    Namespace nestedNamespace = Namespace.of(metalake, catalog, "parent");
+    UnsupportedOperationException exception =
+        Assertions.assertThrows(
+            UnsupportedOperationException.class,
+            () -> schemaNormalizeDispatcher.listSchemas(nestedNamespace));
+    Assertions.assertTrue(
+        exception.getMessage().contains("does not support hierarchical schemas"),
+        exception.getMessage());
+  }
+
+  @Test
   public void testNameSpec() {
     NameIdentifier schemaIdent1 =
         NameIdentifier.of(metalake, catalog, MetadataObjects.METADATA_OBJECT_RESERVED_NAME);


### PR DESCRIPTION
### What changes were proposed in this pull request?

When listing schemas with a `parentSchema` query parameter against a catalog that
does not support hierarchical (nested) schemas (e.g. Hive), Gravitino incorrectly
returned the catalog's flat schemas as if they were children of the parent schema.

This PR adds a catalog capability for hierarchical schemas and rejects the
unsupported request:

- **`Capability.supportsHierarchicalSchema()`**: new capability method, defaulting
  to *unsupported* in `DefaultCapability`. Flat-schema catalogs (Hive, JDBC, Kafka,
  Paimon, ...) inherit the default with no per-catalog change.
- **`IcebergCatalogCapability`**: overrides it to *supported*, since Iceberg
  namespaces can be multi-level.
- **`SchemaNormalizeDispatcher.listSchemas`**: when a `parentSchema` is supplied
  (namespace deeper than `[metalake, catalog]`) and the catalog does not support
  hierarchical schemas, throw `UnsupportedOperationException`. This is mapped to an
  unsupported-operation REST error and surfaced as `UnsupportedOperationException`
  on the Java client.

### Why are the changes needed?

`GET .../catalogs/{hive}/schemas?parentSchema=default` returned:

```json
{ "code": 0, "identifiers": [ { "namespace": ["test","catalog_hive_edited","default"], "name": "default" } ] }
```

i.e. the schema `default` was returned as a child of itself. Non-hierarchical
catalogs have no sub-schemas, so this is misleading data.

Fix: #11317

### Does this PR introduce _any_ user-facing change?

Listing schemas with a `parentSchema` against a non-hierarchical catalog now returns
an unsupported-operation error (`UnsupportedOperationException` on the Java client)
instead of misleading results.

### How was this patch tested?

- `TestSchemaNormalizeDispatcher.testListSchemasUnderParentSchemaUnsupported` (core)
- `TestIcebergCatalogCapability.testSupportsHierarchicalSchema` (iceberg)
- `CatalogHive2IT.testListSchemasWithParentSchemaUnsupported` (Hive integration test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)