### PR TITLE
[#10508] fix(client-java-runtime): Exclude JDBC utils from shadow JAR to prevent NoClassDefFoundError

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,8 @@ replay_pid*
 !.idea/vcs.xml
 **/.vscode
 **/build
+# Zed editor's Java language server (Eclipse JDT) compiles classes into bin/ for code intelligence
+**/bin
 gen
 **/.DS_Store
 **/*.iml

--- a/clients/client-java-runtime/build.gradle.kts
+++ b/clients/client-java-runtime/build.gradle.kts
@@ -41,6 +41,14 @@ tasks.withType<ShadowJar>(ShadowJar::class.java) {
   configurations = listOf(project.configurations.runtimeClasspath.get())
   archiveClassifier.set("")
 
+  // Exclude server-side JDBC pooling utilities. These classes reference commons-dbcp2 which is
+  // declared compileOnly in :common and therefore never bundled here. Including them produces a
+  // broken relocated reference (BasicDataSource renamed to the shaded package, but the actual
+  // shaded class absent). Connector runtime JARs placed on Spark/Flink/Hadoop classpaths would
+  // then shadow the working copy in gravitino-jobs.jar via parent-first class delegation, causing
+  // NoClassDefFoundError at runtime. See https://github.com/apache/gravitino/issues/10508
+  exclude("org/apache/gravitino/utils/jdbc/**")
+
   // Relocate dependencies to avoid conflicts
   relocate("com.google", "org.apache.gravitino.shaded.com.google")
   relocate("com.fasterxml", "org.apache.gravitino.shaded.com.fasterxml")


### PR DESCRIPTION
### What changes were proposed in this pull request?

Exclude `org/apache/gravitino/utils/jdbc/**` from the `client-java-runtime` shadow JAR.

Also add `**/bin` to `.gitignore` to suppress Zed editor's JDT-generated class output directories.

### Why are the changes needed?

Fixes: #10508

`JdbcDataSourceFactory` in `:common` references `commons-dbcp2`, which is declared `compileOnly` there and therefore never bundled into `client-java-runtime`'s shadow JAR. However, the shadow JAR's relocation rewrites the reference to the shaded package name, producing a broken dangling reference with no backing class.

Connector runtime JARs (Spark, Flink, filesystem-hadoop3) all bundle `client-java-runtime` and are typically placed on the engine's system classpath. Due to Java's parent-first class delegation, `AppClassLoader` picks up `JdbcDataSourceFactory` from the connector runtime JAR (shaded reference, no shaded class) rather than from `gravitino-jobs.jar`, which has the correct self-contained copy. This causes `NoClassDefFoundError` for the shaded `BasicDataSource` at runtime when running the built-in Iceberg update-stats job.

Removing these server-side JDBC utilities from `client-java-runtime` (client applications have no need for connection-pool utilities) allows class delegation to fall through to `gravitino-jobs.jar` where both the shaded reference and the shaded class are correctly bundled.

### Does this PR introduce any user-facing change?

#### User-facing API changes
- No

🤖 Generated with [Claude Code](https://claude.com/claude-code)