### PR TITLE
[#11326] improvement(hive-metastore3-libs): Exclude unused Arrow transitive dependency

### DIFF
--- a/catalogs/hive-metastore3-libs/build.gradle.kts
+++ b/catalogs/hive-metastore3-libs/build.gradle.kts
@@ -69,6 +69,7 @@ dependencies {
     exclude(group = "javax.transaction", module = "transaction-api")
     exclude(group = "junit")
     exclude(group = "org.apache.ant")
+    exclude(group = "org.apache.arrow")
     exclude(group = "org.apache.avro")
     exclude(group = "org.apache.derby")
     exclude(group = "org.apache.hadoop", module = "hadoop-yarn-server-resourcemanager")


### PR DESCRIPTION

### What changes were proposed in this pull request?

 Exclude `org.apache.arrow` transitive dependency from `hive3.metastore` in hive-metastore3-libs module.

### Why are the changes needed?

 `hive-serde:3.1.3` pulls in `arrow-vector:0.8.0` as a transitive dependency. Gravitino only uses Hive
  Metastore via its Thrift client for metadata operations and does not use Arrow serialization. The project
  already ships Arrow 18.3.0 in lance-rest-server and main libs.

Fix: #11326 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

  - `./gradlew :catalogs:hive-metastore-common:test -PskipITs` — passed
  - `./gradlew :catalogs:catalog-hive:test -PskipITs` — passed 
  - Verified `arrow-*.jar` no longer appears in build output and distribution
