### PR TITLE
[#11337] deps(paimon): Exclude transitive tomcat-embed-core from hive-exec

### DIFF
--- a/catalogs/catalog-lakehouse-paimon/build.gradle.kts
+++ b/catalogs/catalog-lakehouse-paimon/build.gradle.kts
@@ -150,6 +150,7 @@ dependencies {
     exclude("org.apache.hive", "hive-vector-code-gen")
     exclude("org.apache.ivy")
     exclude("org.apache.logging.log4j")
+    exclude("org.apache.tomcat.embed")
     exclude("org.apache.zookeeper")
     exclude("org.codehaus.groovy")
     exclude("org.datanucleus")


### PR DESCRIPTION


### What changes were proposed in this pull request?

Added `exclude("org.apache.tomcat.embed")` to the `runtimeOnly(libs.hive2.exec)` block in `build.gradle.kts`.

### Why are the changes needed?

`tomcat-embed-core:8.5.46` is transitively pulled in via `hive-exec` → `hive-shims-common` → `libthrift:0.14.1`. The Paimon catalog does not use Thrift's HTTP transport at runtime. A prior exclude on the paimon bundle only blocked one dependency path; this change closes the remaining path through `hive-exec`.

Fix: #11337 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

- Verified with `./gradlew :catalogs:catalog-lakehouse-paimon:dependencyInsight --dependency tomcat-embed-core --configuration runtimeClasspath` — reports "No dependencies matching given input".
- `./gradlew :catalogs:catalog-lakehouse-paimon:build -x test` passes.
