### PR TITLE
[#11335] web(ui): setting web v2 ui as default

### DIFF
--- a/.github/workflows/frontend-integration-test.yml
+++ b/.github/workflows/frontend-integration-test.yml
@@ -81,7 +81,7 @@ jobs:
 
       - name: Package Gravitino
         run: |
-          GRAVITINO_USE_WEB_V2=true ./gradlew compileDistribution compileTrinoConnector -x test
+          ./gradlew compileDistribution compileTrinoConnector -x test
 
       - name: Free up disk space
         run: |
@@ -90,7 +90,7 @@ jobs:
       - name: Frontend Integration Test
         id: integrationTest
         run: |
-          GRAVITINO_USE_WEB_V2=true ./gradlew -PskipTests -PtestMode=deploy -PskipDockerTests=false :web-v2:integration-test:test
+          ./gradlew -PskipTests -PtestMode=deploy -PskipDockerTests=false :web-v2:integration-test:test
 
       - name: Upload integrate tests reports
         uses: actions/upload-artifact@v7

--- a/README.md
+++ b/README.md
@@ -82,16 +82,17 @@ Clone or download the [Gravitino Playground repository](https://github.com/apach
 
 Press `CTRL+C` to stop.
 
-5. (Optional) Use the new UI
+5. (Optional) Switch UI version
 
-  - To switch to the new UI at runtime: edit `conf/gravitino-env.sh` (or set the environment variable before starting) and set `GRAVITINO_USE_WEB_V2` to `true`:
+  - By default, Gravitino uses the new UI (Web V2) when `GRAVITINO_USE_WEB_V1` is unset or set to `false`.
+  - To switch to the legacy UI (Web V1) at runtime, edit `conf/gravitino-env.sh` (or set the environment variable before starting) and set `GRAVITINO_USE_WEB_V1=true`:
 
 ```bash
-export GRAVITINO_USE_WEB_V2=true
+export GRAVITINO_USE_WEB_V1=true
 ./bin/gravitino.sh start
 ```
 
-  - Alternatively, you can remove the `GRAVITINO_USE_WEB_V2=...` line from `conf/gravitino-env.sh` (the template defaults to `false`); removing that line will revert the service to the legacy UI behavior.
+  - To switch back to Web V2, remove `GRAVITINO_USE_WEB_V1=...` from `conf/gravitino-env.sh` or set `GRAVITINO_USE_WEB_V1=false`.
 
 
 ## 🧊 Iceberg REST Catalog

--- a/bin/gravitino.sh.template
+++ b/bin/gravitino.sh.template
@@ -183,27 +183,27 @@ fi
 
 addJarInDir "${GRAVITINO_HOME}/libs"
 
-# By default, prefer starting the legacy (old) UI war if present.
+# By default, prefer starting the new (v2) UI war if present.
 # Users may override by setting GRAVITINO_WAR to an explicit path, or
-# set GRAVITINO_USE_WEB_V2=true to prefer the new war when both exist.
+# set GRAVITINO_USE_WEB_V1=true to force the legacy (v1) UI when both exist.
 if [[ -z "${GRAVITINO_WAR+x}" || -z "${GRAVITINO_WAR}" ]]; then
   # Compose expected war paths based on packaged layout and version
   WAR_V1_PATH="${GRAVITINO_HOME}/web/gravitino-web-${GRAVITINO_VERSION}.war"
   WAR_V2_PATH="${GRAVITINO_HOME}/web-v2/gravitino-web-${GRAVITINO_VERSION}.war"
 
-  if [[ -n "${GRAVITINO_USE_WEB_V2}" && "${GRAVITINO_USE_WEB_V2}" == "true" ]]; then
-    # User explicitly requests new UI if available
-    if [[ -f "${WAR_V2_PATH}" ]]; then
-      export GRAVITINO_WAR="${WAR_V2_PATH}"
-    elif [[ -f "${WAR_V1_PATH}" ]]; then
-      export GRAVITINO_WAR="${WAR_V1_PATH}"
-    fi
-  else
-    # Default behavior: prefer old UI war
+  if [[ "${GRAVITINO_USE_WEB_V1:-false}" == "true" ]]; then
+    # User explicitly requests legacy UI if available.
     if [[ -f "${WAR_V1_PATH}" ]]; then
       export GRAVITINO_WAR="${WAR_V1_PATH}"
     elif [[ -f "${WAR_V2_PATH}" ]]; then
       export GRAVITINO_WAR="${WAR_V2_PATH}"
+    fi
+  else
+    # Default behavior: prefer new UI war.
+    if [[ -f "${WAR_V2_PATH}" ]]; then
+      export GRAVITINO_WAR="${WAR_V2_PATH}"
+    elif [[ -f "${WAR_V1_PATH}" ]]; then
+      export GRAVITINO_WAR="${WAR_V1_PATH}"
     fi
   fi
 fi

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -228,22 +228,22 @@ allprojects {
       project.delete("build/${project.name}-integration-test.log")
       if (testMode == "deploy") {
         param.environment("GRAVITINO_HOME", project.rootDir.path + "/distribution/package-all")
-        val useWebV2 = System.getenv("GRAVITINO_USE_WEB_V2")?.toBoolean() == true
-        val webWarPath = if (useWebV2) {
-          project.rootDir.path + "/distribution/package/web-v2/gravitino-web-${project.version}.war"
-        } else {
+        val useWebV1 = System.getenv("GRAVITINO_USE_WEB_V1")?.toBoolean() == true
+        val webWarPath = if (useWebV1) {
           project.rootDir.path + "/distribution/package/web/gravitino-web-${project.version}.war"
+        } else {
+          project.rootDir.path + "/distribution/package/web-v2/gravitino-web-${project.version}.war"
         }
         param.environment("GRAVITINO_WAR", webWarPath)
         param.systemProperty("testMode", "deploy")
       } else if (testMode == "embedded") {
         param.environment("GRAVITINO_HOME", project.rootDir.path)
         param.environment("GRAVITINO_TEST", "true")
-        val useWebV2 = System.getenv("GRAVITINO_USE_WEB_V2")?.toBoolean() == true
-        val webWarPath = if (useWebV2) {
-          project.rootDir.path + "/web-v2/web/dist/"
-        } else {
+        val useWebV1 = System.getenv("GRAVITINO_USE_WEB_V1")?.toBoolean() == true
+        val webWarPath = if (useWebV1) {
           project.rootDir.path + "/web/web/dist/"
+        } else {
+          project.rootDir.path + "/web-v2/web/dist/"
         }
         param.environment("GRAVITINO_WAR", webWarPath)
         param.systemProperty("testMode", "embedded")

--- a/conf/gravitino-env.sh.template
+++ b/conf/gravitino-env.sh.template
@@ -33,6 +33,6 @@ GRAVITINO_VERSION=GRAVITINO_VERSION_PLACEHOLDER
 #                             # Appended to JAVA_OPTS by launch scripts; set GRAVITINO_MEM to change heap/metaspace sizes.
 
 # UI selection behaviour:
-# - By default this template does not set `GRAVITINO_USE_WEB_V2`, so the container or environment can control which UI is used.
-# - To force the v1 UI, explicitly set it to `false`; to enable the v2 UI, set it to `true` (for example: `export GRAVITINO_USE_WEB_V2=true`).
-# GRAVITINO_USE_WEB_V2=false
+# - Leave `GRAVITINO_USE_WEB_V1` unset, or set it to `false`, to use the v2 UI.
+# - Set `GRAVITINO_USE_WEB_V1=true` only when you want to force the v1 UI.
+# GRAVITINO_USE_WEB_V1=false

--- a/docs/webui-v2.md
+++ b/docs/webui-v2.md
@@ -12,9 +12,9 @@ This document outlines how users can manage metadata within Apache Gravitino usi
 
 [Build](./how-to-build.md#quick-start) and [deploy](./getting-started/index.md#local-workstation) the Gravitino Web UI and open it in a browser at `http://<gravitino-host>:<gravitino-port>`. By default, it is [http://localhost:8090](http://localhost:8090).
 
-## UI Version 1.2.0 — Web V2 introduced
+## UI Version 1.3.0 — Web V2 introduced
 
-Starting with version 1.2.0, Gravitino introduces Web V2. By default, leave `GRAVITINO_USE_WEB_V1` unset (or set it to `false`) to use Web V2. Set `GRAVITINO_USE_WEB_V1=true` only when you want to force Web V1. If you want to force Web V1 from the server env file, set the following environment variable in `conf/gravitino-env.sh` before starting the server:
+Starting with version 1.3.0, Gravitino introduces Web V2. By default, leave `GRAVITINO_USE_WEB_V1` unset (or set it to `false`) to use Web V2. To force Web V1, set the following environment variable in `conf/gravitino-env.sh` before starting the server:
 
 ```bash
 # In <path-to-gravitino>/conf/gravitino-env.sh

--- a/docs/webui-v2.md
+++ b/docs/webui-v2.md
@@ -14,11 +14,11 @@ This document outlines how users can manage metadata within Apache Gravitino usi
 
 ## UI Version 1.2.0 — Web V2 introduced
 
-Starting with version 1.2.0, Gravitino introduces Web V2. By default, the template does not set `GRAVITINO_USE_WEB_V2`, so the container or environment controls which UI is used. To force the v1 UI, explicitly set it to `false`; to enable the v2 UI, set it to `true` (for example: `export GRAVITINO_USE_WEB_V2=true`). If you want to enable Web V2 from the server env file, set the following environment variable in `conf/gravitino-env.sh` before starting the server:
+Starting with version 1.2.0, Gravitino introduces Web V2. By default, leave `GRAVITINO_USE_WEB_V1` unset (or set it to `false`) to use Web V2. Set `GRAVITINO_USE_WEB_V1=true` only when you want to force Web V1. If you want to force Web V1 from the server env file, set the following environment variable in `conf/gravitino-env.sh` before starting the server:
 
 ```bash
 # In <path-to-gravitino>/conf/gravitino-env.sh
-GRAVITINO_USE_WEB_V2=true
+GRAVITINO_USE_WEB_V1=true
 ```
 
 After changing this value, restart the Gravitino server for the change to take effect:
@@ -29,7 +29,7 @@ After changing this value, restart the Gravitino server for the change to take e
 
 ## Web V2
 
-The sections below describe the Web V2 (requires `GRAVITINO_USE_WEB_V2=true` to enable).
+The sections below describe Web V2 (default when `GRAVITINO_USE_WEB_V1` is unset or `false`).
 The Web V2 introduces additional modules (such as Jobs, Job Templates, Data Compliance, and Access) and expands table creation and editing to support more complex data types across providers.
 
 Data Compliance includes **Tags** and **Policies**. The **Access** module is visible only when `gravitino.authorization.enable=true` and includes **Users**, **User Groups**, and **Roles**.

--- a/web-v2/web/README.md
+++ b/web-v2/web/README.md
@@ -31,6 +31,11 @@
 >
 > Before running commands, you must ensure that you are in the front-end directory `gravitino/web`. If not, run `cd web` first.
 
+> **ℹ️ UI Version Selection**
+>
+> Gravitino uses Web V2 by default when `GRAVITINO_USE_WEB_V1` is unset or set to `false`.
+> Set `GRAVITINO_USE_WEB_V1=true` in `conf/gravitino-env.sh` only when you want to force Web V1.
+
 ---
 
 ## Getting started

--- a/web/web/src/app/rootLayout/Layout.js
+++ b/web/web/src/app/rootLayout/Layout.js
@@ -79,12 +79,14 @@ const Layout = ({ children, scrollToTop }) => {
                 <Box sx={{ flex: 1 }}>
                   <Typography variant='body2' component='div'>
                     <Box component='span' sx={{ fontWeight: 600 }}>
-                      Try the new V2 Web UI.
+                      Try to use the V2 Web UI.
                     </Box>
                     <Box component='div' sx={{ fontFamily: 'monospace', mt: 1 }}>
                       # In &lt;path-to-gravitino&gt;/conf/gravitino-env.sh
                       <br />
-                      GRAVITINO_USE_WEB_V2=true
+                      Remove GRAVITINO_USE_WEB_V1, or set:
+                      <br />
+                      GRAVITINO_USE_WEB_V1=false
                     </Box>
                     <Box component='div' sx={{ fontFamily: 'monospace', mt: 1 }}>
                       &lt;path-to-gravitino&gt;/bin/gravitino.sh restart

--- a/web/web/src/app/rootLayout/Layout.js
+++ b/web/web/src/app/rootLayout/Layout.js
@@ -79,7 +79,7 @@ const Layout = ({ children, scrollToTop }) => {
                 <Box sx={{ flex: 1 }}>
                   <Typography variant='body2' component='div'>
                     <Box component='span' sx={{ fontWeight: 600 }}>
-                      Try to use the V2 Web UI.
+                      Try the V2 Web UI.
                     </Box>
                     <Box component='div' sx={{ fontFamily: 'monospace', mt: 1 }}>
                       # In &lt;path-to-gravitino&gt;/conf/gravitino-env.sh


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. setting web v2 ui as default
2. update md and readme
<img width="2684" height="1384" alt="image" src="https://github.com/user-attachments/assets/9257bbb1-8199-4fa0-b4e0-c1b5922ca658" />


### Why are the changes needed?
N/A

Fix: #11335

### Does this PR introduce _any_ user-facing change?
N/A

### How was this patch tested?
manually
