### PR TITLE
[#11345] improvement(deps): Exclude unused legacy netty dependency from hive-metastore2-libs

### DIFF
--- a/catalogs/hive-metastore2-libs/build.gradle.kts
+++ b/catalogs/hive-metastore2-libs/build.gradle.kts
@@ -62,6 +62,7 @@ dependencies {
     exclude(group = "com.google.code.findbugs")
     exclude(group = "com.google.guava")
     exclude(group = "com.sun.jersey")
+    exclude(group = "io.netty", module = "netty")
     exclude(group = "log4j")
     exclude(group = "org.apache.avro")
     exclude(group = "org.apache.logging.log4j")


### PR DESCRIPTION

### What changes were proposed in this pull request?

Exclude transitive i`o.netty:netty:3.10.6.Final` from `hadoop-mapreduce-client-core` in `build.gradle.kts`.

### Why are the changes needed?

The legacy `netty-3.x `is an unused transitive dependency brought in by Hadoop. It is not required by Hive Metastore or Gravitino runtime and should be excluded to keep the dependency tree clean.

Fix: #11345 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

- Verified `io.netty:netty:3.10.6.Final` no longer appears in `:catalogs:hive-metastore2-libs:dependencies`
- `./gradlew :catalogs:hive-metastore2-libs:build` passes successfully
