### PR TITLE
[#11368] fix(docker): Build bundle jars for Docker image

### DIFF
--- a/dev/docker/gravitino/gravitino-dependency.sh
+++ b/dev/docker/gravitino/gravitino-dependency.sh
@@ -47,12 +47,18 @@ download_gcs_connector() {
   rm "${temp_file}"
 }
 
-# Build the Gravitino project
-${gravitino_home}/gradlew clean build -x test
-
 rm -rf ${gravitino_home}/distribution
 # Prepare compile Gravitino packages
-${gravitino_home}/gradlew compileDistribution -x test
+${gravitino_home}/gradlew compileDistribution \
+  :bundles:aliyun-bundle:shadowJar \
+  :bundles:aws-bundle:shadowJar \
+  :bundles:gcp-bundle:shadowJar \
+  :bundles:azure-bundle:shadowJar \
+  :bundles:iceberg-gcp-bundle:shadowJar \
+  :bundles:iceberg-aws-bundle:shadowJar \
+  :bundles:iceberg-azure-bundle:shadowJar \
+  :bundles:iceberg-aliyun-bundle:shadowJar \
+  -x test
 
 # Removed old packages, Avoid multiple re-executions using the wrong file
 rm -rf "${gravitino_dir}/packages"


### PR DESCRIPTION
### What changes were proposed in this pull request?

Explicitly build the Fileset and Iceberg bundle shadow jars in `dev/docker/gravitino/gravitino-dependency.sh` when preparing the Gravitino Docker image package.

This removes the previous broad `clean build` invocation and makes the Docker package depend directly on the bundle artifacts it later copies.

### Why are the changes needed?

After #11180, `compileDistribution` runs `cleanDistributionPackage`, which removes subproject `build/libs` outputs. The Docker dependency script previously generated bundle jars with `clean build`, then ran `compileDistribution`, which removed those jars before the later copy step.

Fix: #11368

### Does this PR introduce _any_ user-facing change?

No user-facing API or configuration changes.

### How was this patch tested?

- `bash -n dev/docker/gravitino/gravitino-dependency.sh`
- `git diff --check origin/main...HEAD`
