### PR TITLE
[#11403] improvement(authz): use per-request cache for group owner check in JcasbinAuthorizer

### DIFF
--- a/core/src/main/java/org/apache/gravitino/UserGroup.java
+++ b/core/src/main/java/org/apache/gravitino/UserGroup.java
@@ -27,18 +27,18 @@ import java.util.Optional;
 public class UserGroup {
 
   private final Optional<String> groupExternalUID;
-  private final String groupname;
+  private final String groupName;
 
   /**
    * Constructs a UserGroup instance.
    *
    * @param groupExternalUID The external UID of the group.
-   * @param groupname The name of the group.
+   * @param groupName The name of the group.
    */
-  public UserGroup(Optional<String> groupExternalUID, String groupname) {
-    Preconditions.checkArgument(groupname != null, "groupname cannot be null");
+  public UserGroup(Optional<String> groupExternalUID, String groupName) {
+    Preconditions.checkArgument(groupName != null, "groupName cannot be null");
     this.groupExternalUID = groupExternalUID;
-    this.groupname = groupname;
+    this.groupName = groupName;
   }
 
   /**
@@ -55,8 +55,8 @@ public class UserGroup {
    *
    * @return The group name.
    */
-  public String getGroupname() {
-    return groupname;
+  public String getGroupName() {
+    return groupName;
   }
 
   @Override
@@ -69,12 +69,12 @@ public class UserGroup {
     }
     UserGroup userGroup = (UserGroup) o;
     return Objects.equals(groupExternalUID, userGroup.groupExternalUID)
-        && Objects.equals(groupname, userGroup.groupname);
+        && Objects.equals(groupName, userGroup.groupName);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(groupExternalUID, groupname);
+    return Objects.hash(groupExternalUID, groupName);
   }
 
   @Override
@@ -82,8 +82,8 @@ public class UserGroup {
     return "UserGroup{"
         + "groupExternalUID="
         + groupExternalUID
-        + ", groupname='"
-        + groupname
+        + ", groupName='"
+        + groupName
         + '\''
         + '}';
   }

--- a/core/src/test/java/org/apache/gravitino/auth/TestGroupMapperFactory.java
+++ b/core/src/test/java/org/apache/gravitino/auth/TestGroupMapperFactory.java
@@ -46,7 +46,7 @@ public class TestGroupMapperFactory {
 
     assertEquals(2, mappedGroups.size());
     List<String> groupNames =
-        mappedGroups.stream().map(UserGroup::getGroupname).collect(Collectors.toList());
+        mappedGroups.stream().map(UserGroup::getGroupName).collect(Collectors.toList());
     assertTrue(groupNames.contains("admin"));
     assertTrue(groupNames.contains("user"));
   }
@@ -63,7 +63,7 @@ public class TestGroupMapperFactory {
 
     assertEquals(2, mappedGroups.size());
     List<String> groupNames =
-        mappedGroups.stream().map(UserGroup::getGroupname).collect(Collectors.toList());
+        mappedGroups.stream().map(UserGroup::getGroupName).collect(Collectors.toList());
     assertTrue(groupNames.contains("admin"));
     assertTrue(groupNames.contains("user"));
   }
@@ -80,7 +80,7 @@ public class TestGroupMapperFactory {
 
     assertEquals(2, mappedGroups.size());
     List<String> groupNames =
-        mappedGroups.stream().map(UserGroup::getGroupname).collect(Collectors.toList());
+        mappedGroups.stream().map(UserGroup::getGroupName).collect(Collectors.toList());
     assertTrue(groupNames.contains("admin"));
     assertTrue(groupNames.contains("user"));
   }
@@ -120,6 +120,6 @@ public class TestGroupMapperFactory {
     List<UserGroup> mappedGroups = mapper.map(groups);
 
     assertEquals(1, mappedGroups.size());
-    assertEquals("custom:foo", mappedGroups.get(0).getGroupname());
+    assertEquals("custom:foo", mappedGroups.get(0).getGroupName());
   }
 }

--- a/plugins/idp-basic/src/test/java/org/apache/gravitino/idp/auth/TestBasicAuthenticator.java
+++ b/plugins/idp-basic/src/test/java/org/apache/gravitino/idp/auth/TestBasicAuthenticator.java
@@ -96,8 +96,8 @@ class TestBasicAuthenticator {
     assertEquals("alice", principal.getName());
     assertEquals(authHeader, principal.getAccessToken().orElse(null));
     assertEquals(2, principal.getGroups().size());
-    assertEquals("group-a", principal.getGroups().get(0).getGroupname());
-    assertEquals("group-b", principal.getGroups().get(1).getGroupname());
+    assertEquals("group-a", principal.getGroups().get(0).getGroupName());
+    assertEquals("group-b", principal.getGroups().get(1).getGroupName());
   }
 
   @Test

--- a/server-common/src/main/java/org/apache/gravitino/server/authorization/jcasbin/JcasbinAuthorizer.java
+++ b/server-common/src/main/java/org/apache/gravitino/server/authorization/jcasbin/JcasbinAuthorizer.java
@@ -890,8 +890,8 @@ public class JcasbinAuthorizer implements GravitinoAuthorizer {
     if (!Entity.EntityType.GROUP.name().equalsIgnoreCase(ownerInfo.getOwnerType())) {
       return false;
     }
-    for (String groupname : currentPrincipalGroupNames()) {
-      Optional<GroupUpdatedAt> groupInfo = loadGroupInfo(metalake, groupname, requestContext);
+    for (String groupName : currentPrincipalGroupNames()) {
+      Optional<GroupUpdatedAt> groupInfo = loadGroupInfo(metalake, groupName, requestContext);
       if (groupInfo.isPresent() && groupInfo.get().getGroupId() == ownerInfo.getOwnerId()) {
         return true;
       }

--- a/server-common/src/main/java/org/apache/gravitino/server/authorization/jcasbin/JcasbinAuthorizer.java
+++ b/server-common/src/main/java/org/apache/gravitino/server/authorization/jcasbin/JcasbinAuthorizer.java
@@ -1045,7 +1045,7 @@ public class JcasbinAuthorizer implements GravitinoAuthorizer {
     if (groups.isEmpty()) {
       return new ArrayList<>();
     }
-    return groups.stream().map(UserGroup::getGroupname).collect(Collectors.toList());
+    return groups.stream().map(UserGroup::getGroupName).collect(Collectors.toList());
   }
 
   private void versionCheckAndLoadRoles(

--- a/server-common/src/main/java/org/apache/gravitino/server/authorization/jcasbin/JcasbinAuthorizer.java
+++ b/server-common/src/main/java/org/apache/gravitino/server/authorization/jcasbin/JcasbinAuthorizer.java
@@ -55,7 +55,6 @@ import org.apache.gravitino.authorization.Privilege;
 import org.apache.gravitino.authorization.SecurableObject;
 import org.apache.gravitino.cache.CaffeineGravitinoCache;
 import org.apache.gravitino.cache.GravitinoCache;
-import org.apache.gravitino.meta.GroupEntity;
 import org.apache.gravitino.meta.RoleEntity;
 import org.apache.gravitino.server.authorization.MetadataIdConverter;
 import org.apache.gravitino.storage.relational.SupportsEntityChangeLog;
@@ -871,6 +870,8 @@ public class JcasbinAuthorizer implements GravitinoAuthorizer {
    * Returns true when the cached owner type and ID match the given principal or one of the
    * principal's groups. The user id is resolved via the version-validated {@link #loadUserInfo}
    * cache so back-to-back ownership checks in the same request do not re-query {@code user_meta}.
+   * Group ids are resolved via {@link #loadGroupInfo}, which deduplicates within the request via
+   * {@code requestContext.groupInfoCache} and avoids loading full group entity objects.
    */
   private boolean ownerMatchesUserOrGroups(
       Optional<OwnerInfo> owner,
@@ -889,9 +890,9 @@ public class JcasbinAuthorizer implements GravitinoAuthorizer {
     if (!Entity.EntityType.GROUP.name().equalsIgnoreCase(ownerInfo.getOwnerType())) {
       return false;
     }
-    EntityStore entityStore = GravitinoEnv.getInstance().entityStore();
-    for (GroupEntity groupEntity : resolveCurrentUserGroups(metalake, entityStore)) {
-      if (Objects.equals(groupEntity.id(), ownerInfo.getOwnerId())) {
+    for (String groupname : principalGroupNames(principal)) {
+      Optional<GroupUpdatedAt> groupInfo = loadGroupInfo(metalake, groupname, requestContext);
+      if (groupInfo.isPresent() && groupInfo.get().getGroupId() == ownerInfo.getOwnerId()) {
         return true;
       }
     }
@@ -1033,7 +1034,10 @@ public class JcasbinAuthorizer implements GravitinoAuthorizer {
    * or has no groups.
    */
   private List<String> currentPrincipalGroupNames() {
-    Principal principal = PrincipalUtils.getCurrentPrincipal();
+    return principalGroupNames(PrincipalUtils.getCurrentPrincipal());
+  }
+
+  private List<String> principalGroupNames(Principal principal) {
     if (!(principal instanceof UserPrincipal)) {
       return new ArrayList<>();
     }
@@ -1042,27 +1046,6 @@ public class JcasbinAuthorizer implements GravitinoAuthorizer {
       return new ArrayList<>();
     }
     return groups.stream().map(UserGroup::getGroupname).collect(Collectors.toList());
-  }
-
-  /**
-   * Resolves GroupEntity objects for the current principal's groups, skipping any that are stale or
-   * not found in the store. Used by owner checks that need full group entities instead of only
-   * group names.
-   */
-  private List<GroupEntity> resolveCurrentUserGroups(String metalake, EntityStore entityStore) {
-    Principal principal = PrincipalUtils.getCurrentPrincipal();
-    if (!(principal instanceof UserPrincipal)) {
-      return new ArrayList<>();
-    }
-    List<UserGroup> groups = ((UserPrincipal) principal).getGroups();
-    if (groups.isEmpty()) {
-      return new ArrayList<>();
-    }
-    List<NameIdentifier> groupIdents =
-        groups.stream()
-            .map(g -> NameIdentifierUtil.ofGroup(metalake, g.getGroupname()))
-            .collect(Collectors.toList());
-    return entityStore.batchGet(groupIdents, Entity.EntityType.GROUP, GroupEntity.class);
   }
 
   private void versionCheckAndLoadRoles(

--- a/server-common/src/main/java/org/apache/gravitino/server/authorization/jcasbin/JcasbinAuthorizer.java
+++ b/server-common/src/main/java/org/apache/gravitino/server/authorization/jcasbin/JcasbinAuthorizer.java
@@ -55,7 +55,6 @@ import org.apache.gravitino.authorization.Privilege;
 import org.apache.gravitino.authorization.SecurableObject;
 import org.apache.gravitino.cache.CaffeineGravitinoCache;
 import org.apache.gravitino.cache.GravitinoCache;
-import org.apache.gravitino.meta.GroupEntity;
 import org.apache.gravitino.meta.RoleEntity;
 import org.apache.gravitino.server.authorization.MetadataIdConverter;
 import org.apache.gravitino.storage.relational.SupportsEntityChangeLog;
@@ -871,6 +870,8 @@ public class JcasbinAuthorizer implements GravitinoAuthorizer {
    * Returns true when the cached owner type and ID match the given principal or one of the
    * principal's groups. The user id is resolved via the version-validated {@link #loadUserInfo}
    * cache so back-to-back ownership checks in the same request do not re-query {@code user_meta}.
+   * Group ids are resolved via {@link #loadGroupInfo}, which deduplicates within the request via
+   * {@code requestContext.groupInfoCache} and avoids loading full group entity objects.
    */
   private boolean ownerMatchesUserOrGroups(
       Optional<OwnerInfo> owner,
@@ -889,9 +890,9 @@ public class JcasbinAuthorizer implements GravitinoAuthorizer {
     if (!Entity.EntityType.GROUP.name().equalsIgnoreCase(ownerInfo.getOwnerType())) {
       return false;
     }
-    EntityStore entityStore = GravitinoEnv.getInstance().entityStore();
-    for (GroupEntity groupEntity : resolveCurrentUserGroups(metalake, entityStore)) {
-      if (Objects.equals(groupEntity.id(), ownerInfo.getOwnerId())) {
+    for (String groupname : currentPrincipalGroupNames()) {
+      Optional<GroupUpdatedAt> groupInfo = loadGroupInfo(metalake, groupname, requestContext);
+      if (groupInfo.isPresent() && groupInfo.get().getGroupId() == ownerInfo.getOwnerId()) {
         return true;
       }
     }
@@ -1042,27 +1043,6 @@ public class JcasbinAuthorizer implements GravitinoAuthorizer {
       return new ArrayList<>();
     }
     return groups.stream().map(UserGroup::getGroupname).collect(Collectors.toList());
-  }
-
-  /**
-   * Resolves GroupEntity objects for the current principal's groups, skipping any that are stale or
-   * not found in the store. Used by owner checks that need full group entities instead of only
-   * group names.
-   */
-  private List<GroupEntity> resolveCurrentUserGroups(String metalake, EntityStore entityStore) {
-    Principal principal = PrincipalUtils.getCurrentPrincipal();
-    if (!(principal instanceof UserPrincipal)) {
-      return new ArrayList<>();
-    }
-    List<UserGroup> groups = ((UserPrincipal) principal).getGroups();
-    if (groups.isEmpty()) {
-      return new ArrayList<>();
-    }
-    List<NameIdentifier> groupIdents =
-        groups.stream()
-            .map(g -> NameIdentifierUtil.ofGroup(metalake, g.getGroupname()))
-            .collect(Collectors.toList());
-    return entityStore.batchGet(groupIdents, Entity.EntityType.GROUP, GroupEntity.class);
   }
 
   private void versionCheckAndLoadRoles(

--- a/server-common/src/test/java/org/apache/gravitino/server/authentication/TestJwksTokenValidator.java
+++ b/server-common/src/test/java/org/apache/gravitino/server/authentication/TestJwksTokenValidator.java
@@ -606,9 +606,9 @@ public class TestJwksTokenValidator {
       assertEquals("test-subject", userPrincipal.getName());
       assertEquals(2, userPrincipal.getGroups().size());
       assertTrue(
-          userPrincipal.getGroups().stream().anyMatch(g -> g.getGroupname().equals("group1")));
+          userPrincipal.getGroups().stream().anyMatch(g -> g.getGroupName().equals("group1")));
       assertTrue(
-          userPrincipal.getGroups().stream().anyMatch(g -> g.getGroupname().equals("group2")));
+          userPrincipal.getGroups().stream().anyMatch(g -> g.getGroupName().equals("group2")));
     }
   }
 

--- a/server-common/src/test/java/org/apache/gravitino/server/authentication/TestStaticSignKeyValidator.java
+++ b/server-common/src/test/java/org/apache/gravitino/server/authentication/TestStaticSignKeyValidator.java
@@ -514,8 +514,8 @@ public class TestStaticSignKeyValidator {
     // Check if principal is UserPrincipal and has groups
     UserPrincipal userPrincipal = assertInstanceOf(UserPrincipal.class, principal);
     assertEquals(2, userPrincipal.getGroups().size());
-    assertTrue(userPrincipal.getGroups().stream().anyMatch(g -> g.getGroupname().equals("group1")));
-    assertTrue(userPrincipal.getGroups().stream().anyMatch(g -> g.getGroupname().equals("group2")));
+    assertTrue(userPrincipal.getGroups().stream().anyMatch(g -> g.getGroupName().equals("group1")));
+    assertTrue(userPrincipal.getGroups().stream().anyMatch(g -> g.getGroupName().equals("group2")));
   }
 
   @Test
@@ -584,7 +584,7 @@ public class TestStaticSignKeyValidator {
     // Check if principal is UserPrincipal and has groups
     UserPrincipal userPrincipal = assertInstanceOf(UserPrincipal.class, principal);
     assertEquals(2, userPrincipal.getGroups().size());
-    assertTrue(userPrincipal.getGroups().stream().anyMatch(g -> g.getGroupname().equals("groupa")));
-    assertTrue(userPrincipal.getGroups().stream().anyMatch(g -> g.getGroupname().equals("groupb")));
+    assertTrue(userPrincipal.getGroups().stream().anyMatch(g -> g.getGroupName().equals("groupa")));
+    assertTrue(userPrincipal.getGroups().stream().anyMatch(g -> g.getGroupName().equals("groupb")));
   }
 }

--- a/server-common/src/test/java/org/apache/gravitino/server/authorization/jcasbin/TestJcasbinAuthorizer.java
+++ b/server-common/src/test/java/org/apache/gravitino/server/authorization/jcasbin/TestJcasbinAuthorizer.java
@@ -618,27 +618,12 @@ public class TestJcasbinAuthorizer {
 
     NameIdentifier catalogIdent = NameIdentifierUtil.ofCatalog(METALAKE, "testCatalog");
 
-    // Mock entityStore.batchGet for group entity lookup (needed for ID-based ownership
-    // verification)
-    when(entityStore.batchGet(
-            eq(ImmutableList.of(NameIdentifierUtil.ofGroup(METALAKE, GROUP_NAME))),
-            eq(Entity.EntityType.GROUP),
-            eq(GroupEntity.class)))
-        .thenReturn(ImmutableList.of(getGroupEntity()));
-
-    // For non-member principal, mock batchGet for "otherGroup"
-    when(entityStore.batchGet(
-            eq(ImmutableList.of(NameIdentifierUtil.ofGroup(METALAKE, "otherGroup"))),
-            eq(Entity.EntityType.GROUP),
-            eq(GroupEntity.class)))
-        .thenReturn(
-            ImmutableList.of(
-                GroupEntity.builder()
-                    .withId(99L)
-                    .withName("otherGroup")
-                    .withNamespace(Namespace.of(METALAKE, "group"))
-                    .withAuditInfo(AuditInfo.EMPTY)
-                    .build()));
+    // Group identity is now resolved via groupMetaMapper.getGroupUpdatedAt (per-request cache path)
+    // instead of entityStore.batchGet(GROUP); verify the new path is wired correctly.
+    when(groupMetaMapper.getGroupUpdatedAt(eq(METALAKE), eq(GROUP_NAME)))
+        .thenReturn(new GroupUpdatedAt(GROUP_ID, groupVersionCounter.incrementAndGet()));
+    when(groupMetaMapper.getGroupUpdatedAt(eq(METALAKE), eq("otherGroup")))
+        .thenReturn(new GroupUpdatedAt(99L, groupVersionCounter.incrementAndGet()));
 
     // Mock owner_meta lookup returning a GROUP-typed OwnerInfo (the owner is GROUP_ID).
     OwnerInfo groupOwnerInfo = new OwnerInfo(GROUP_ID, "GROUP");
@@ -648,6 +633,10 @@ public class TestJcasbinAuthorizer {
 
     // The principal belongs to the owning group, so isOwner should return true
     assertTrue(doAuthorizeOwner(groupPrincipal));
+
+    // entityStore.batchGet must NOT be called for GROUP entity lookups in the owner-check path
+    Mockito.verify(entityStore, Mockito.never())
+        .batchGet(anyList(), eq(Entity.EntityType.GROUP), eq(GroupEntity.class));
 
     // Clear owner and verify it returns false
     when(ownerMetaMapper.selectOwnerByMetadataObjectIdAndType(eq(CATALOG_ID), eq("CATALOG")))
@@ -673,6 +662,59 @@ public class TestJcasbinAuthorizer {
     principalUtilsMockedStatic
         .when(PrincipalUtils::getCurrentPrincipal)
         .thenReturn(new UserPrincipal(USERNAME));
+  }
+
+  @Test
+  public void testGroupOwnerCheckDeduplicatesGroupInfoWithinRequest() throws Exception {
+    // Verify that repeated isOwner calls within the same AuthorizationRequestContext
+    // do not re-query group_meta; groupMetaMapper.getGroupUpdatedAt should be called at most once
+    // per (metalake, groupName) per request thanks to requestContext.groupInfoCache.
+    Mockito.clearInvocations(groupMetaMapper);
+
+    UserPrincipal groupPrincipal =
+        new UserPrincipal(USERNAME, ImmutableList.of(new UserGroup(Optional.empty(), GROUP_NAME)));
+    principalUtilsMockedStatic.when(PrincipalUtils::getCurrentPrincipal).thenReturn(groupPrincipal);
+
+    when(groupMetaMapper.getGroupUpdatedAt(eq(METALAKE), eq(GROUP_NAME)))
+        .thenReturn(new GroupUpdatedAt(GROUP_ID, groupVersionCounter.incrementAndGet()));
+
+    OwnerInfo groupOwnerInfo = new OwnerInfo(GROUP_ID, "GROUP");
+    when(ownerMetaMapper.selectOwnerByMetadataObjectIdAndType(eq(CATALOG_ID), eq("CATALOG")))
+        .thenReturn(groupOwnerInfo);
+    getOwnerRelCache(jcasbinAuthorizer).invalidateAll();
+
+    MetadataObject catalog = MetadataObjects.of(null, "testCatalog", MetadataObject.Type.CATALOG);
+
+    // Call isOwner twice within the same request context
+    AuthorizationRequestContext sharedContext = new AuthorizationRequestContext();
+    assertTrue(jcasbinAuthorizer.isOwner(groupPrincipal, METALAKE, catalog, sharedContext));
+    assertTrue(jcasbinAuthorizer.isOwner(groupPrincipal, METALAKE, catalog, sharedContext));
+
+    // group_meta should have been queried exactly once despite two isOwner calls
+    Mockito.verify(groupMetaMapper, Mockito.times(1))
+        .getGroupUpdatedAt(eq(METALAKE), eq(GROUP_NAME));
+  }
+
+  @Test
+  public void testGroupOwnerCheckUsesProvidedPrincipalGroups() throws Exception {
+    UserPrincipal ownerGroupPrincipal =
+        new UserPrincipal(USERNAME, ImmutableList.of(new UserGroup(Optional.empty(), GROUP_NAME)));
+    UserPrincipal currentPrincipalWithoutOwnerGroup =
+        new UserPrincipal(
+            USERNAME, ImmutableList.of(new UserGroup(Optional.empty(), "otherGroup")));
+    principalUtilsMockedStatic
+        .when(PrincipalUtils::getCurrentPrincipal)
+        .thenReturn(currentPrincipalWithoutOwnerGroup);
+
+    when(groupMetaMapper.getGroupUpdatedAt(eq(METALAKE), eq(GROUP_NAME)))
+        .thenReturn(new GroupUpdatedAt(GROUP_ID, groupVersionCounter.incrementAndGet()));
+
+    OwnerInfo groupOwnerInfo = new OwnerInfo(GROUP_ID, "GROUP");
+    when(ownerMetaMapper.selectOwnerByMetadataObjectIdAndType(eq(CATALOG_ID), eq("CATALOG")))
+        .thenReturn(groupOwnerInfo);
+    getOwnerRelCache(jcasbinAuthorizer).invalidateAll();
+
+    assertTrue(doAuthorizeOwner(ownerGroupPrincipal));
   }
 
   @Test

--- a/server-common/src/test/java/org/apache/gravitino/server/authorization/jcasbin/TestJcasbinAuthorizer.java
+++ b/server-common/src/test/java/org/apache/gravitino/server/authorization/jcasbin/TestJcasbinAuthorizer.java
@@ -618,27 +618,12 @@ public class TestJcasbinAuthorizer {
 
     NameIdentifier catalogIdent = NameIdentifierUtil.ofCatalog(METALAKE, "testCatalog");
 
-    // Mock entityStore.batchGet for group entity lookup (needed for ID-based ownership
-    // verification)
-    when(entityStore.batchGet(
-            eq(ImmutableList.of(NameIdentifierUtil.ofGroup(METALAKE, GROUP_NAME))),
-            eq(Entity.EntityType.GROUP),
-            eq(GroupEntity.class)))
-        .thenReturn(ImmutableList.of(getGroupEntity()));
-
-    // For non-member principal, mock batchGet for "otherGroup"
-    when(entityStore.batchGet(
-            eq(ImmutableList.of(NameIdentifierUtil.ofGroup(METALAKE, "otherGroup"))),
-            eq(Entity.EntityType.GROUP),
-            eq(GroupEntity.class)))
-        .thenReturn(
-            ImmutableList.of(
-                GroupEntity.builder()
-                    .withId(99L)
-                    .withName("otherGroup")
-                    .withNamespace(Namespace.of(METALAKE, "group"))
-                    .withAuditInfo(AuditInfo.EMPTY)
-                    .build()));
+    // Group identity is now resolved via groupMetaMapper.getGroupUpdatedAt (per-request cache path)
+    // instead of entityStore.batchGet(GROUP); verify the new path is wired correctly.
+    when(groupMetaMapper.getGroupUpdatedAt(eq(METALAKE), eq(GROUP_NAME)))
+        .thenReturn(new GroupUpdatedAt(GROUP_ID, groupVersionCounter.incrementAndGet()));
+    when(groupMetaMapper.getGroupUpdatedAt(eq(METALAKE), eq("otherGroup")))
+        .thenReturn(new GroupUpdatedAt(99L, groupVersionCounter.incrementAndGet()));
 
     // Mock owner_meta lookup returning a GROUP-typed OwnerInfo (the owner is GROUP_ID).
     OwnerInfo groupOwnerInfo = new OwnerInfo(GROUP_ID, "GROUP");
@@ -648,6 +633,10 @@ public class TestJcasbinAuthorizer {
 
     // The principal belongs to the owning group, so isOwner should return true
     assertTrue(doAuthorizeOwner(groupPrincipal));
+
+    // entityStore.batchGet must NOT be called for GROUP entity lookups in the owner-check path
+    Mockito.verify(entityStore, Mockito.never())
+        .batchGet(anyList(), eq(Entity.EntityType.GROUP), eq(GroupEntity.class));
 
     // Clear owner and verify it returns false
     when(ownerMetaMapper.selectOwnerByMetadataObjectIdAndType(eq(CATALOG_ID), eq("CATALOG")))
@@ -673,6 +662,37 @@ public class TestJcasbinAuthorizer {
     principalUtilsMockedStatic
         .when(PrincipalUtils::getCurrentPrincipal)
         .thenReturn(new UserPrincipal(USERNAME));
+  }
+
+  @Test
+  public void testGroupOwnerCheckDeduplicatesGroupInfoWithinRequest() throws Exception {
+    // Verify that repeated isOwner calls within the same AuthorizationRequestContext
+    // do not re-query group_meta; groupMetaMapper.getGroupUpdatedAt should be called at most once
+    // per (metalake, groupName) per request thanks to requestContext.groupInfoCache.
+    Mockito.clearInvocations(groupMetaMapper);
+
+    UserPrincipal groupPrincipal =
+        new UserPrincipal(USERNAME, ImmutableList.of(new UserGroup(Optional.empty(), GROUP_NAME)));
+    principalUtilsMockedStatic.when(PrincipalUtils::getCurrentPrincipal).thenReturn(groupPrincipal);
+
+    when(groupMetaMapper.getGroupUpdatedAt(eq(METALAKE), eq(GROUP_NAME)))
+        .thenReturn(new GroupUpdatedAt(GROUP_ID, groupVersionCounter.incrementAndGet()));
+
+    OwnerInfo groupOwnerInfo = new OwnerInfo(GROUP_ID, "GROUP");
+    when(ownerMetaMapper.selectOwnerByMetadataObjectIdAndType(eq(CATALOG_ID), eq("CATALOG")))
+        .thenReturn(groupOwnerInfo);
+    getOwnerRelCache(jcasbinAuthorizer).invalidateAll();
+
+    MetadataObject catalog = MetadataObjects.of(null, "testCatalog", MetadataObject.Type.CATALOG);
+
+    // Call isOwner twice within the same request context
+    AuthorizationRequestContext sharedContext = new AuthorizationRequestContext();
+    assertTrue(jcasbinAuthorizer.isOwner(groupPrincipal, METALAKE, catalog, sharedContext));
+    assertTrue(jcasbinAuthorizer.isOwner(groupPrincipal, METALAKE, catalog, sharedContext));
+
+    // group_meta should have been queried exactly once despite two isOwner calls
+    Mockito.verify(groupMetaMapper, Mockito.times(1))
+        .getGroupUpdatedAt(eq(METALAKE), eq(GROUP_NAME));
   }
 
   @Test


### PR DESCRIPTION
### What changes were proposed in this pull request?

Replace `resolveCurrentUserGroups(metalake, entityStore)` in `ownerMatchesUserOrGroups()` with `currentPrincipalGroupNames()` + `loadGroupInfo()`. The new path routes through `requestContext.groupInfoCache` (per-request dedup) before falling back to a lightweight `group_meta` query via `GroupMetaMapper#getGroupUpdatedAt`, and removes the need to load full `GroupEntity` objects. The now-unused `resolveCurrentUserGroups()` method and its `GroupEntity` import are removed.

### Why are the changes needed?

The old path bypassed all caches and issued an `entityStore.batchGet(GROUP)` DB call on every GROUP owner check. In `hasSetOwnerPermission`, which walks the full parent chain calling `isOwner` in a loop, this could fire multiple times per request when the owner is a group. The fix ensures group identity is resolved through the same version-validated cache path as all other identity lookups in the authorizer.

Fix: #11403

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

- Updated `testAuthorizeByGroupOwner` to mock `groupMetaMapper.getGroupUpdatedAt` instead of `entityStore.batchGet(GROUP)`, and added a `verify` assertion that `entityStore.batchGet(GROUP)` is never called.
- Added `testGroupOwnerCheckDeduplicatesGroupInfoWithinRequest` which calls `isOwner` twice within the same `AuthorizationRequestContext` and asserts that `groupMetaMapper.getGroupUpdatedAt` is invoked exactly once (per-request cache dedup).