### PR TITLE
[#9418] fix(iceberg): refresh server-side FileIO credentials

### DIFF
--- a/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/io/GravitinoCredentialFileIO.java
+++ b/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/io/GravitinoCredentialFileIO.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.iceberg.common.io;
+
+import com.google.common.base.Preconditions;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.gravitino.catalog.lakehouse.iceberg.IcebergConstants;
+import org.apache.iceberg.CatalogUtil;
+import org.apache.iceberg.io.BulkDeletionFailureException;
+import org.apache.iceberg.io.DelegateFileIO;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.FileInfo;
+import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.io.SupportsBulkOperations;
+import org.apache.iceberg.io.SupportsPrefixOperations;
+import org.apache.iceberg.io.SupportsStorageCredentials;
+
+/** FileIO wrapper that refreshes Gravitino storage credentials before path operations. */
+public class GravitinoCredentialFileIO implements DelegateFileIO {
+
+  /** Property for the wrapped Iceberg FileIO implementation. */
+  public static final String DELEGATE_IO_IMPL = "gravitino.fileio.delegate-impl";
+
+  /**
+   * Property for the credential supplier registered in {@link GravitinoCredentialFileIORegistry}.
+   */
+  public static final String CREDENTIAL_SUPPLIER_ID = "gravitino.fileio.credential-supplier-id";
+
+  private FileIO delegate;
+  private GravitinoCredentialFileIORegistry.CredentialSupplier credentialSupplier;
+  private Map<String, String> properties;
+
+  /**
+   * Wraps an Iceberg FileIO configuration with Gravitino credential refresh support.
+   *
+   * @param properties original Iceberg FileIO properties
+   * @param credentialSupplierId registered credential supplier identifier
+   * @return wrapped properties
+   */
+  public static Map<String, String> wrapProperties(
+      Map<String, String> properties, String credentialSupplierId) {
+    Map<String, String> wrappedProperties = new HashMap<>(properties);
+    String delegateImpl = wrappedProperties.get(IcebergConstants.IO_IMPL);
+    Preconditions.checkArgument(delegateImpl != null, "Iceberg FileIO implementation is not set");
+    wrappedProperties.put(DELEGATE_IO_IMPL, delegateImpl);
+    wrappedProperties.put(IcebergConstants.IO_IMPL, GravitinoCredentialFileIO.class.getName());
+    wrappedProperties.put(CREDENTIAL_SUPPLIER_ID, credentialSupplierId);
+    return wrappedProperties;
+  }
+
+  @Override
+  public void initialize(Map<String, String> properties) {
+    this.properties = new HashMap<>(properties);
+    String delegateImpl = properties.get(DELEGATE_IO_IMPL);
+    String credentialSupplierId = properties.get(CREDENTIAL_SUPPLIER_ID);
+    Preconditions.checkArgument(delegateImpl != null, "Delegate FileIO implementation is not set");
+    Preconditions.checkArgument(
+        credentialSupplierId != null, "Gravitino credential supplier id is not set");
+    credentialSupplier = GravitinoCredentialFileIORegistry.get(credentialSupplierId);
+    Preconditions.checkState(
+        credentialSupplier != null,
+        "Gravitino credential supplier %s is not registered",
+        credentialSupplierId);
+
+    Map<String, String> delegateProperties = new HashMap<>(properties);
+    delegateProperties.put(IcebergConstants.IO_IMPL, delegateImpl);
+    delegateProperties.remove(DELEGATE_IO_IMPL);
+    delegateProperties.remove(CREDENTIAL_SUPPLIER_ID);
+    delegate = CatalogUtil.loadFileIO(delegateImpl, delegateProperties, null);
+  }
+
+  @Override
+  public InputFile newInputFile(String path) {
+    refreshCredentials(path);
+    return delegate.newInputFile(path);
+  }
+
+  @Override
+  public InputFile newInputFile(String path, long length) {
+    refreshCredentials(path);
+    return delegate.newInputFile(path, length);
+  }
+
+  @Override
+  public OutputFile newOutputFile(String path) {
+    refreshCredentials(path);
+    return delegate.newOutputFile(path);
+  }
+
+  @Override
+  public void deleteFile(String path) {
+    refreshCredentials(path);
+    delegate.deleteFile(path);
+  }
+
+  @Override
+  public Iterable<FileInfo> listPrefix(String prefix) {
+    refreshCredentials(prefix);
+    if (delegate instanceof SupportsPrefixOperations) {
+      return ((SupportsPrefixOperations) delegate).listPrefix(prefix);
+    }
+    throw new UnsupportedOperationException("Delegate FileIO does not support prefix operations");
+  }
+
+  @Override
+  public void deletePrefix(String prefix) {
+    refreshCredentials(prefix);
+    if (delegate instanceof SupportsPrefixOperations) {
+      ((SupportsPrefixOperations) delegate).deletePrefix(prefix);
+      return;
+    }
+    throw new UnsupportedOperationException("Delegate FileIO does not support prefix operations");
+  }
+
+  @Override
+  public void deleteFiles(Iterable<String> paths) throws BulkDeletionFailureException {
+    String path = paths.iterator().hasNext() ? paths.iterator().next() : null;
+    if (path != null) {
+      refreshCredentials(path);
+    }
+    if (delegate instanceof SupportsBulkOperations) {
+      ((SupportsBulkOperations) delegate).deleteFiles(paths);
+      return;
+    }
+
+    int failures = 0;
+    for (String deletePath : paths) {
+      try {
+        deleteFile(deletePath);
+      } catch (RuntimeException e) {
+        failures++;
+      }
+    }
+    if (failures > 0) {
+      throw new BulkDeletionFailureException(failures);
+    }
+  }
+
+  @Override
+  public Map<String, String> properties() {
+    return properties;
+  }
+
+  @Override
+  public void close() {
+    if (delegate != null) {
+      delegate.close();
+    }
+  }
+
+  private void refreshCredentials(String path) {
+    if (delegate instanceof SupportsStorageCredentials) {
+      ((SupportsStorageCredentials) delegate).setCredentials(credentialSupplier.load(path));
+    }
+  }
+}

--- a/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/io/GravitinoCredentialFileIORegistry.java
+++ b/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/io/GravitinoCredentialFileIORegistry.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.iceberg.common.io;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import org.apache.iceberg.io.StorageCredential;
+
+/** Registry that connects Iceberg FileIO instances with Gravitino credential suppliers. */
+public class GravitinoCredentialFileIORegistry {
+
+  private static final ConcurrentMap<String, CredentialSupplier> SUPPLIERS =
+      new ConcurrentHashMap<>();
+
+  private GravitinoCredentialFileIORegistry() {}
+
+  /** Supplies storage credentials for a storage path. */
+  public interface CredentialSupplier {
+
+    /**
+     * Loads credentials for a storage path.
+     *
+     * @param path the storage path
+     * @return storage credentials for the path
+     */
+    List<StorageCredential> load(String path);
+  }
+
+  /**
+   * Registers a credential supplier.
+   *
+   * @param supplier the supplier to register
+   * @return the generated supplier identifier
+   */
+  public static String register(CredentialSupplier supplier) {
+    String id = UUID.randomUUID().toString();
+    SUPPLIERS.put(id, supplier);
+    return id;
+  }
+
+  /**
+   * Gets a registered credential supplier.
+   *
+   * @param id the supplier identifier
+   * @return the registered supplier
+   */
+  public static CredentialSupplier get(String id) {
+    return SUPPLIERS.get(id);
+  }
+
+  /**
+   * Unregisters a credential supplier.
+   *
+   * @param id the supplier identifier
+   */
+  public static void unregister(String id) {
+    SUPPLIERS.remove(id);
+  }
+}

--- a/iceberg/iceberg-common/src/test/java/org/apache/gravitino/iceberg/common/io/TestGravitinoCredentialFileIO.java
+++ b/iceberg/iceberg-common/src/test/java/org/apache/gravitino/iceberg/common/io/TestGravitinoCredentialFileIO.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.iceberg.common.io;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.gravitino.catalog.lakehouse.iceberg.IcebergConstants;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.io.StorageCredential;
+import org.apache.iceberg.io.SupportsStorageCredentials;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TestGravitinoCredentialFileIO {
+
+  @Test
+  void testRefreshesCredentialsBeforePathOperations() throws Exception {
+    String supplierId =
+        GravitinoCredentialFileIORegistry.register(
+            path -> {
+              int tokenId = RecordingFileIO.refreshCount.incrementAndGet();
+              return Collections.singletonList(
+                  StorageCredential.create(
+                      "gs://bucket/warehouse",
+                      ImmutableMap.of("gcs.oauth2.token", "token-" + tokenId)));
+            });
+
+    try {
+      GravitinoCredentialFileIO fileIO = new GravitinoCredentialFileIO();
+      fileIO.initialize(
+          ImmutableMap.of(
+              GravitinoCredentialFileIO.DELEGATE_IO_IMPL,
+              RecordingFileIO.class.getName(),
+              GravitinoCredentialFileIO.CREDENTIAL_SUPPLIER_ID,
+              supplierId));
+
+      fileIO.newInputFile("gs://bucket/warehouse/table/metadata/v1.metadata.json");
+      fileIO.newOutputFile("gs://bucket/warehouse/table/metadata/v2.metadata.json");
+
+      Assertions.assertEquals(2, RecordingFileIO.refreshCount.get());
+      Assertions.assertEquals(
+          "token-2", RecordingFileIO.lastCredentials.get(0).config().get("gcs.oauth2.token"));
+    } finally {
+      GravitinoCredentialFileIORegistry.unregister(supplierId);
+      RecordingFileIO.refreshCount.set(0);
+      RecordingFileIO.lastCredentials = Collections.emptyList();
+    }
+  }
+
+  @Test
+  void testWrapsOriginalIoImpl() {
+    Map<String, String> properties =
+        GravitinoCredentialFileIO.wrapProperties(
+            ImmutableMap.of(IcebergConstants.IO_IMPL, RecordingFileIO.class.getName()), "id");
+
+    Assertions.assertEquals(
+        GravitinoCredentialFileIO.class.getName(), properties.get(IcebergConstants.IO_IMPL));
+    Assertions.assertEquals(
+        RecordingFileIO.class.getName(),
+        properties.get(GravitinoCredentialFileIO.DELEGATE_IO_IMPL));
+    Assertions.assertEquals("id", properties.get(GravitinoCredentialFileIO.CREDENTIAL_SUPPLIER_ID));
+  }
+
+  public static class RecordingFileIO implements FileIO, SupportsStorageCredentials {
+    static AtomicInteger refreshCount = new AtomicInteger();
+    static List<StorageCredential> lastCredentials = Collections.emptyList();
+
+    @Override
+    public InputFile newInputFile(String path) {
+      return null;
+    }
+
+    @Override
+    public OutputFile newOutputFile(String path) {
+      return null;
+    }
+
+    @Override
+    public void deleteFile(String path) {}
+
+    @Override
+    public void setCredentials(List<StorageCredential> credentials) {
+      lastCredentials = credentials;
+    }
+
+    @Override
+    public List<StorageCredential> credentials() {
+      return lastCredentials;
+    }
+  }
+}

--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/CatalogWrapperForREST.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/CatalogWrapperForREST.java
@@ -45,9 +45,13 @@ import org.apache.gravitino.credential.Credential;
 import org.apache.gravitino.credential.CredentialConstants;
 import org.apache.gravitino.credential.CredentialPrivilege;
 import org.apache.gravitino.credential.CredentialPropertyUtils;
+import org.apache.gravitino.credential.CredentialUtils;
 import org.apache.gravitino.credential.PathBasedCredentialContext;
 import org.apache.gravitino.iceberg.common.IcebergConfig;
+import org.apache.gravitino.iceberg.common.io.GravitinoCredentialFileIO;
+import org.apache.gravitino.iceberg.common.io.GravitinoCredentialFileIORegistry;
 import org.apache.gravitino.iceberg.common.ops.IcebergCatalogWrapper;
+import org.apache.gravitino.iceberg.common.utils.IcebergCatalogUtil;
 import org.apache.gravitino.iceberg.service.cache.ScanPlanCache;
 import org.apache.gravitino.iceberg.service.cache.ScanPlanCacheKey;
 import org.apache.gravitino.storage.GCSProperties;
@@ -80,6 +84,7 @@ import org.apache.iceberg.exceptions.ServiceUnavailableException;
 import org.apache.iceberg.inmemory.InMemoryFileIO;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.StorageCredential;
 import org.apache.iceberg.rest.CatalogHandlers;
 import org.apache.iceberg.rest.PlanStatus;
 import org.apache.iceberg.rest.RESTCatalog;
@@ -97,6 +102,9 @@ public class CatalogWrapperForREST extends IcebergCatalogWrapper {
 
   private static final String FORMAT_VERSION = "format-version";
   private final CatalogCredentialManager catalogCredentialManager;
+  private final boolean closeCatalogCredentialManager;
+  private final String credentialSupplierId;
+  private final IcebergConfig clientConfig;
 
   private volatile Map<String, String> catalogConfigToClients;
   private final Object catalogConfigToClientsLock = new Object();
@@ -124,13 +132,116 @@ public class CatalogWrapperForREST extends IcebergCatalogWrapper {
           "gcs-credential-file-path",
           GCSProperties.GRAVITINO_GCS_SERVICE_ACCOUNT_FILE);
 
-  public CatalogWrapperForREST(String catalogName, IcebergConfig config) {
-    super(config);
-    // To be compatible with old properties
+  private static WrapperContext createWrapperContext(String catalogName, IcebergConfig config) {
     Map<String, String> catalogProperties =
         checkForCompatibility(config.getAllConfig(), deprecatedProperties);
-    this.catalogCredentialManager = new CatalogCredentialManager(catalogName, catalogProperties);
-    this.scanPlanCache = loadScanPlanCache(config);
+    return createWrapperContext(
+        config, new CatalogCredentialManager(catalogName, catalogProperties), true);
+  }
+
+  private static WrapperContext createWrapperContext(
+      IcebergConfig config,
+      CatalogCredentialManager catalogCredentialManager,
+      boolean closeCatalogCredentialManager) {
+    Map<String, String> catalogProperties =
+        checkForCompatibility(config.getAllConfig(), deprecatedProperties);
+    Set<String> providers = CredentialUtils.getCredentialProvidersByOrder(() -> catalogProperties);
+    if (providers.isEmpty() || "rest".equalsIgnoreCase(config.get(IcebergConfig.CATALOG_BACKEND))) {
+      return new WrapperContext(
+          config, config, catalogCredentialManager, closeCatalogCredentialManager, null);
+    }
+
+    String credentialSupplierId =
+        GravitinoCredentialFileIORegistry.register(
+            path -> loadStorageCredentials(catalogCredentialManager, path));
+    Map<String, String> wrappedConfig = Maps.newHashMap(config.getAllConfig());
+    Map<String, String> fileIOProperties = Maps.newHashMap(config.getIcebergCatalogProperties());
+    IcebergCatalogUtil.applyDefaultResolvingFileIO(fileIOProperties);
+    wrappedConfig.putAll(
+        GravitinoCredentialFileIO.wrapProperties(fileIOProperties, credentialSupplierId));
+    return new WrapperContext(
+        new IcebergConfig(wrappedConfig),
+        config,
+        catalogCredentialManager,
+        closeCatalogCredentialManager,
+        credentialSupplierId);
+  }
+
+  private static List<StorageCredential> loadStorageCredentials(
+      CatalogCredentialManager catalogCredentialManager, String path) {
+    if (StringUtils.isBlank(path) || isLocalOrHdfsLocation(path)) {
+      return Collections.emptyList();
+    }
+
+    PathBasedCredentialContext context =
+        new PathBasedCredentialContext(
+            PrincipalUtils.getCurrentUserName(),
+            Collections.singleton(path),
+            Collections.singleton(path));
+    try {
+      return catalogCredentialManager
+          .getCredentialByPath(path, context)
+          .map(
+              credential ->
+                  Collections.singletonList(
+                      StorageCredential.create(
+                          path, CredentialPropertyUtils.toIcebergProperties(credential))))
+          .orElse(Collections.emptyList());
+    } catch (IllegalArgumentException e) {
+      String message = e.getMessage();
+      if (message != null
+          && (message.startsWith("No credential provider found")
+              || message.startsWith("No supported path in credential context"))) {
+        LOG.debug("No credential provider matched the Iceberg FileIO path {}", path, e);
+        return Collections.emptyList();
+      }
+      throw e;
+    }
+  }
+
+  private static class WrapperContext {
+    private final IcebergConfig config;
+    private final IcebergConfig clientConfig;
+    private final CatalogCredentialManager catalogCredentialManager;
+    private final boolean closeCatalogCredentialManager;
+    private final String credentialSupplierId;
+
+    private WrapperContext(
+        IcebergConfig config,
+        IcebergConfig clientConfig,
+        CatalogCredentialManager catalogCredentialManager,
+        boolean closeCatalogCredentialManager,
+        String credentialSupplierId) {
+      this.config = config;
+      this.clientConfig = clientConfig;
+      this.catalogCredentialManager = catalogCredentialManager;
+      this.closeCatalogCredentialManager = closeCatalogCredentialManager;
+      this.credentialSupplierId = credentialSupplierId;
+    }
+  }
+
+  public CatalogWrapperForREST(String catalogName, IcebergConfig config) {
+    this(createWrapperContext(catalogName, config));
+  }
+
+  /**
+   * Creates a REST catalog wrapper with an existing credential manager.
+   *
+   * @param config the Iceberg catalog config
+   * @param catalogCredentialManager the existing credential manager
+   */
+  public CatalogWrapperForREST(
+      IcebergConfig config, CatalogCredentialManager catalogCredentialManager) {
+    this(createWrapperContext(config, catalogCredentialManager, false));
+  }
+
+  private CatalogWrapperForREST(WrapperContext context) {
+    super(context.config);
+    this.clientConfig = context.clientConfig;
+    this.catalogCredentialManager = context.catalogCredentialManager;
+    this.closeCatalogCredentialManager = context.closeCatalogCredentialManager;
+    this.credentialSupplierId = context.credentialSupplierId;
+    this.scanPlanCache = loadScanPlanCache(context.config);
   }
 
   public LoadTableResponse createTable(
@@ -227,7 +338,10 @@ public class CatalogWrapperForREST extends IcebergCatalogWrapper {
   @Override
   public void close() throws Exception {
     try {
-      if (catalogCredentialManager != null) {
+      if (credentialSupplierId != null) {
+        GravitinoCredentialFileIORegistry.unregister(credentialSupplierId);
+      }
+      if (closeCatalogCredentialManager && catalogCredentialManager != null) {
         catalogCredentialManager.close();
       }
       if (scanPlanCache != null) {
@@ -250,7 +364,7 @@ public class CatalogWrapperForREST extends IcebergCatalogWrapper {
 
     synchronized (catalogConfigToClientsLock) {
       if (catalogConfigToClients == null) {
-        catalogConfigToClients = buildCatalogConfigToClients(getIcebergConfig(), getCatalog());
+        catalogConfigToClients = buildCatalogConfigToClients(clientConfig, getCatalog());
       }
       return catalogConfigToClients;
     }

--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/IcebergCatalogWrapperManager.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/IcebergCatalogWrapperManager.java
@@ -27,7 +27,11 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.gravitino.GravitinoEnv;
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.catalog.lakehouse.iceberg.IcebergConstants;
+import org.apache.gravitino.credential.CatalogCredentialManager;
 import org.apache.gravitino.exceptions.NoSuchCatalogException;
 import org.apache.gravitino.iceberg.common.IcebergConfig;
 import org.apache.gravitino.iceberg.common.authentication.AuthenticationConfig;
@@ -98,12 +102,25 @@ public class IcebergCatalogWrapperManager implements AutoCloseable {
   }
 
   public CatalogWrapperForREST getCatalogWrapper(String catalogName) {
+    String resolvedCatalogName = resolveCatalogName(catalogName);
     CatalogWrapperForREST catalogWrapperForREST =
-        catalogWrapperCache.get(catalogName, k -> createCatalogWrapper(catalogName));
+        catalogWrapperCache.get(
+            resolvedCatalogName, k -> createCatalogWrapper(resolvedCatalogName));
     // Reload conf to reset UserGroupInformation or icebergTableOps will always use
     // Simple auth.
     catalogWrapperForREST.reloadHadoopConf();
     return catalogWrapperForREST;
+  }
+
+  @VisibleForTesting
+  String resolveCatalogName(String catalogName) {
+    if (!(configProvider instanceof DynamicIcebergConfigProvider)
+        || !IcebergConstants.ICEBERG_REST_DEFAULT_CATALOG.equals(catalogName)) {
+      return catalogName;
+    }
+
+    String defaultCatalogName = configProvider.getDefaultCatalogName();
+    return StringUtils.isBlank(defaultCatalogName) ? catalogName : defaultCatalogName;
   }
 
   private CatalogWrapperForREST createCatalogWrapper(String catalogName) {
@@ -127,7 +144,10 @@ public class IcebergCatalogWrapperManager implements AutoCloseable {
   @VisibleForTesting
   protected CatalogWrapperForREST createCatalogWrapper(
       String catalogName, IcebergConfig icebergConfig) {
-    CatalogWrapperForREST rest = new CatalogWrapperForREST(catalogName, icebergConfig);
+    CatalogWrapperForREST rest =
+        loadCatalogCredentialManager(catalogName)
+            .map(manager -> new CatalogWrapperForREST(icebergConfig, manager))
+            .orElseGet(() -> new CatalogWrapperForREST(catalogName, icebergConfig));
     AuthenticationConfig authenticationConfig =
         new AuthenticationConfig(icebergConfig.getAllConfig());
     if (authenticationConfig.isKerberosAuth() && rest.getCatalog() instanceof SupportsKerberos) {
@@ -136,6 +156,20 @@ public class IcebergCatalogWrapperManager implements AutoCloseable {
     }
 
     return rest;
+  }
+
+  private Optional<CatalogCredentialManager> loadCatalogCredentialManager(String catalogName) {
+    IcebergRESTServerContext serverContext = IcebergRESTServerContext.getInstance();
+    if (!serverContext.isAuxMode() || !(configProvider instanceof DynamicIcebergConfigProvider)) {
+      return Optional.empty();
+    }
+
+    return Optional.of(
+        GravitinoEnv.getInstance()
+            .catalogManager()
+            .loadCatalogAndWrap(NameIdentifier.of(configProvider.getMetalakeName(), catalogName))
+            .catalog()
+            .catalogCredentialManager());
   }
 
   private void closeIcebergCatalogWrapper(IcebergCatalogWrapper catalogWrapper) {

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/TestCatalogWrapperForREST.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/TestCatalogWrapperForREST.java
@@ -38,7 +38,10 @@ import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import org.apache.gravitino.catalog.lakehouse.iceberg.IcebergConstants;
+import org.apache.gravitino.credential.CatalogCredentialManager;
+import org.apache.gravitino.credential.CredentialConstants;
 import org.apache.gravitino.iceberg.common.IcebergConfig;
+import org.apache.gravitino.iceberg.common.io.GravitinoCredentialFileIO;
 import org.apache.iceberg.BaseTransaction;
 import org.apache.iceberg.MetadataUpdate;
 import org.apache.iceberg.PartitionSpec;
@@ -222,6 +225,39 @@ public class TestCatalogWrapperForREST {
       Assertions.assertDoesNotThrow(() -> new LazyCheckCatalogWrapperForREST("test", config));
     } finally {
       CONSTRUCTION_IN_PROGRESS.set(false);
+    }
+  }
+
+  @Test
+  void testCredentialProviderWrapsServerSideFileIO() throws Exception {
+    IcebergConfig config =
+        new IcebergConfig(
+            ImmutableMap.of(
+                IcebergConstants.CATALOG_BACKEND,
+                "memory",
+                IcebergConstants.WAREHOUSE,
+                "gs://bucket/warehouse",
+                CredentialConstants.CREDENTIAL_PROVIDERS,
+                "gcs-token"));
+    CatalogCredentialManager credentialManager = mock(CatalogCredentialManager.class);
+
+    try (CatalogWrapperForREST wrapper = new CatalogWrapperForREST(config, credentialManager)) {
+      Map<String, String> properties = wrapper.getIcebergConfig().getIcebergCatalogProperties();
+
+      Assertions.assertEquals(
+          GravitinoCredentialFileIO.class.getName(), properties.get(IcebergConstants.IO_IMPL));
+      Assertions.assertEquals(
+          ResolvingFileIO.class.getName(),
+          properties.get(GravitinoCredentialFileIO.DELEGATE_IO_IMPL));
+      Assertions.assertTrue(
+          properties.containsKey(GravitinoCredentialFileIO.CREDENTIAL_SUPPLIER_ID));
+
+      Map<String, String> clientProperties = wrapper.getCatalogConfigToClient();
+      Assertions.assertFalse(clientProperties.containsKey(IcebergConstants.IO_IMPL));
+      Assertions.assertFalse(
+          clientProperties.containsKey(GravitinoCredentialFileIO.DELEGATE_IO_IMPL));
+      Assertions.assertFalse(
+          clientProperties.containsKey(GravitinoCredentialFileIO.CREDENTIAL_SUPPLIER_ID));
     }
   }
 

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/TestIcebergCatalogWrapperManagerForREST.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/TestIcebergCatalogWrapperManagerForREST.java
@@ -20,12 +20,20 @@ package org.apache.gravitino.iceberg.service;
 
 import com.google.common.collect.Maps;
 import java.util.Map;
+import java.util.Optional;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.gravitino.GravitinoEnv;
+import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.catalog.CatalogManager;
+import org.apache.gravitino.catalog.CatalogManager.CatalogWrapper;
+import org.apache.gravitino.catalog.lakehouse.iceberg.IcebergConstants;
+import org.apache.gravitino.connector.BaseCatalog;
+import org.apache.gravitino.credential.CatalogCredentialManager;
+import org.apache.gravitino.iceberg.common.IcebergConfig;
 import org.apache.gravitino.iceberg.common.ops.IcebergCatalogWrapper;
 import org.apache.gravitino.iceberg.service.authorization.IcebergRESTServerContext;
+import org.apache.gravitino.iceberg.service.provider.DynamicIcebergConfigProvider;
 import org.apache.gravitino.iceberg.service.provider.IcebergConfigProvider;
 import org.apache.gravitino.iceberg.service.provider.IcebergConfigProviderFactory;
 import org.junit.jupiter.api.AfterAll;
@@ -34,6 +42,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 public class TestIcebergCatalogWrapperManagerForREST {
@@ -90,6 +99,76 @@ public class TestIcebergCatalogWrapperManagerForREST {
     IcebergRESTServerContext.create(configProvider, false, false, true, manager);
 
     Assertions.assertThrowsExactly(IllegalArgumentException.class, () -> manager.getOps(rawPrefix));
+  }
+
+  @Test
+  public void testDynamicProviderLoadsCredentialManagerWithGravitinoCatalogName() {
+    String metalakeName = "test_metalake";
+    String catalogName = "iceberg";
+    String backendCatalogName = "jdbc";
+
+    DynamicIcebergConfigProvider configProvider = Mockito.mock(DynamicIcebergConfigProvider.class);
+    Mockito.when(configProvider.getMetalakeName()).thenReturn(metalakeName);
+    Mockito.when(configProvider.getDefaultCatalogName()).thenReturn(catalogName);
+
+    CatalogCredentialManager credentialManager = Mockito.mock(CatalogCredentialManager.class);
+    BaseCatalog baseCatalog = Mockito.mock(BaseCatalog.class);
+    Mockito.when(baseCatalog.catalogCredentialManager()).thenReturn(credentialManager);
+    CatalogManager catalogManager = GravitinoEnv.getInstance().catalogManager();
+    Mockito.reset(catalogManager);
+    Mockito.when(catalogManager.loadCatalogAndWrap(Mockito.any()))
+        .thenReturn(new CatalogWrapper(baseCatalog, null));
+
+    IcebergCatalogWrapperManager manager =
+        new IcebergCatalogWrapperManager(Maps.newHashMap(), configProvider, false, metalakeName);
+    IcebergRESTServerContext.create(configProvider, false, true, true, manager);
+
+    Map<String, String> config = Maps.newHashMap();
+    config.put(IcebergConstants.CATALOG_BACKEND, "memory");
+    config.put(IcebergConstants.CATALOG_BACKEND_NAME, backendCatalogName);
+    config.put(IcebergConstants.WAREHOUSE, "/tmp/warehouse");
+    manager.createCatalogWrapper(catalogName, new IcebergConfig(config));
+
+    ArgumentCaptor<NameIdentifier> identCaptor = ArgumentCaptor.forClass(NameIdentifier.class);
+    Mockito.verify(catalogManager).loadCatalogAndWrap(identCaptor.capture());
+    Assertions.assertEquals(NameIdentifier.of(metalakeName, catalogName), identCaptor.getValue());
+  }
+
+  @Test
+  public void testDynamicProviderResolvesDefaultCatalogToConfiguredDefaultCatalog() {
+    String metalakeName = "test_metalake";
+    String catalogName = "iceberg";
+
+    DynamicIcebergConfigProvider configProvider = Mockito.mock(DynamicIcebergConfigProvider.class);
+    Mockito.when(configProvider.getMetalakeName()).thenReturn(metalakeName);
+    Mockito.when(configProvider.getDefaultCatalogName()).thenReturn(catalogName);
+
+    CatalogCredentialManager credentialManager = Mockito.mock(CatalogCredentialManager.class);
+    BaseCatalog baseCatalog = Mockito.mock(BaseCatalog.class);
+    Mockito.when(baseCatalog.catalogCredentialManager()).thenReturn(credentialManager);
+    CatalogManager catalogManager = GravitinoEnv.getInstance().catalogManager();
+    Mockito.reset(catalogManager);
+    Mockito.when(catalogManager.loadCatalogAndWrap(Mockito.any()))
+        .thenReturn(new CatalogWrapper(baseCatalog, null));
+
+    IcebergCatalogWrapperManager manager =
+        new IcebergCatalogWrapperManager(Maps.newHashMap(), configProvider, false, metalakeName);
+    IcebergRESTServerContext.create(configProvider, false, true, true, manager);
+
+    Map<String, String> config = Maps.newHashMap();
+    config.put(IcebergConstants.CATALOG_BACKEND, "memory");
+    config.put(IcebergConstants.WAREHOUSE, "/tmp/warehouse");
+    Mockito.when(configProvider.getIcebergCatalogConfig(catalogName))
+        .thenReturn(Optional.of(new IcebergConfig(config)));
+
+    manager.getCatalogWrapper(IcebergConstants.ICEBERG_REST_DEFAULT_CATALOG);
+
+    ArgumentCaptor<NameIdentifier> identCaptor = ArgumentCaptor.forClass(NameIdentifier.class);
+    Mockito.verify(configProvider).getIcebergCatalogConfig(catalogName);
+    Mockito.verify(configProvider, Mockito.never())
+        .getIcebergCatalogConfig(IcebergConstants.ICEBERG_REST_DEFAULT_CATALOG);
+    Mockito.verify(catalogManager).loadCatalogAndWrap(identCaptor.capture());
+    Assertions.assertEquals(NameIdentifier.of(metalakeName, catalogName), identCaptor.getValue());
   }
 
   @Test


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds a Gravitino FileIO wrapper for non-REST Iceberg catalog backends used by the Iceberg REST service.

The wrapper:
- Preserves the original Iceberg `io-impl` as a delegate.
- Refreshes Gravitino storage credentials before FileIO path operations.
- Applies refreshed credentials to delegates that implement `SupportsStorageCredentials`.
- Uses the existing `CatalogCredentialManager`; in dynamic aux mode the REST wrapper reuses the manager from the loaded Gravitino `BaseCatalog`.

### Why are the changes needed?

When the Iceberg REST service creates a table, the server-side Iceberg catalog uses FileIO to write metadata. For GCS catalogs configured with Gravitino credential providers, that FileIO needs credentials during create/load/delete operations and needs refreshed credentials after token expiration.

Using a FileIO wrapper makes the behavior available to server-side FileIO across catalog backends that honor Iceberg `io-impl`, instead of only wiring JDBC catalog construction. It also avoids using Iceberg's refresh endpoint path.

Fix: #9418

### Does this PR introduce _any_ user-facing change?

No new public API or user-facing configuration key is introduced.

Existing Iceberg REST catalog credential provider configuration can now be used by server-side FileIO operations for non-REST Iceberg catalog backends.

### How was this patch tested?

- `./gradlew :iceberg:iceberg-common:test --tests org.apache.gravitino.iceberg.common.io.TestGravitinoCredentialFileIO`
- `./gradlew :iceberg:iceberg-rest-server:test --tests org.apache.gravitino.iceberg.service.TestCatalogWrapperForREST --tests org.apache.gravitino.iceberg.service.TestIcebergCatalogWrapperManagerForREST`
- `git diff --check HEAD~1`