### PR TITLE
[#11412] feat(auth): Add initialize(Config) to PrincipalMapper and GroupMapper interfaces

### DIFF
--- a/core/src/main/java/org/apache/gravitino/auth/GroupMapper.java
+++ b/core/src/main/java/org/apache/gravitino/auth/GroupMapper.java
@@ -20,6 +20,7 @@
 package org.apache.gravitino.auth;
 
 import java.util.List;
+import org.apache.gravitino.Config;
 import org.apache.gravitino.UserGroup;
 
 /**
@@ -29,6 +30,16 @@ import org.apache.gravitino.UserGroup;
  * requests.
  */
 public interface GroupMapper {
+
+  /**
+   * Initializes the mapper with server configuration. Called by the factory after instantiation.
+   *
+   * <p>Custom implementations can override this to read additional configuration properties. The
+   * default implementation is a no-op for backward compatibility.
+   *
+   * @param config the server configuration
+   */
+  default void initialize(Config config) {}
 
   /**
    * Maps a list of group strings to a new list of group strings.

--- a/core/src/main/java/org/apache/gravitino/auth/GroupMapperFactory.java
+++ b/core/src/main/java/org/apache/gravitino/auth/GroupMapperFactory.java
@@ -19,6 +19,7 @@
 
 package org.apache.gravitino.auth;
 
+import org.apache.gravitino.Config;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,30 +35,34 @@ public class GroupMapperFactory {
    *
    * @param mapperType the type of the mapper (e.g., "regex" or fully qualified class name)
    * @param regexPattern the regex pattern to use (only for "regex" mapper type)
+   * @param config the server configuration passed to {@link GroupMapper#initialize(Config)}
    * @return a configured GroupMapper instance
    * @throws IllegalArgumentException if the mapper type is invalid or initialization fails
    */
-  public static GroupMapper create(String mapperType, String regexPattern) {
+  public static GroupMapper create(String mapperType, String regexPattern, Config config) {
+    GroupMapper mapper;
     if ("regex".equalsIgnoreCase(mapperType)) {
       if (regexPattern == null) {
         throw new IllegalArgumentException("Regex pattern cannot be null for regex mapper");
       }
-      return new RegexGroupMapper(regexPattern);
-    }
-
-    try {
-      Class<?> clazz = Class.forName(mapperType);
-      if (!GroupMapper.class.isAssignableFrom(clazz)) {
-        throw new IllegalArgumentException(
-            "Class " + mapperType + " does not implement GroupMapper");
+      mapper = new RegexGroupMapper(regexPattern);
+    } else {
+      try {
+        Class<?> clazz = Class.forName(mapperType);
+        if (!GroupMapper.class.isAssignableFrom(clazz)) {
+          throw new IllegalArgumentException(
+              "Class " + mapperType + " does not implement GroupMapper");
+        }
+        mapper = (GroupMapper) clazz.getDeclaredConstructor().newInstance();
+      } catch (ClassNotFoundException e) {
+        LOG.error("Failed to load GroupMapper class: {}", mapperType, e);
+        throw new IllegalArgumentException("Failed to load GroupMapper class: " + mapperType, e);
+      } catch (Exception e) {
+        LOG.error("Failed to create GroupMapper: {}", mapperType, e);
+        throw new IllegalArgumentException("Failed to create GroupMapper: " + mapperType, e);
       }
-      return (GroupMapper) clazz.getDeclaredConstructor().newInstance();
-    } catch (ClassNotFoundException e) {
-      LOG.error("Failed to load GroupMapper class: {}", mapperType, e);
-      throw new IllegalArgumentException("Failed to load GroupMapper class: " + mapperType, e);
-    } catch (Exception e) {
-      LOG.error("Failed to create GroupMapper: {}", mapperType, e);
-      throw new IllegalArgumentException("Failed to create GroupMapper: " + mapperType, e);
     }
+    mapper.initialize(config);
+    return mapper;
   }
 }

--- a/core/src/main/java/org/apache/gravitino/auth/PrincipalMapper.java
+++ b/core/src/main/java/org/apache/gravitino/auth/PrincipalMapper.java
@@ -20,6 +20,7 @@
 package org.apache.gravitino.auth;
 
 import java.security.Principal;
+import org.apache.gravitino.Config;
 
 /**
  * Interface for mapping authenticated principals to user identities.
@@ -28,6 +29,16 @@ import java.security.Principal;
  * requests.
  */
 public interface PrincipalMapper {
+
+  /**
+   * Initializes the mapper with server configuration. Called by the factory after instantiation.
+   *
+   * <p>Custom implementations can override this to read additional configuration properties. The
+   * default implementation is a no-op for backward compatibility.
+   *
+   * @param config the server configuration
+   */
+  default void initialize(Config config) {}
 
   /**
    * Maps a principal string to a Principal object.

--- a/core/src/main/java/org/apache/gravitino/auth/PrincipalMapperFactory.java
+++ b/core/src/main/java/org/apache/gravitino/auth/PrincipalMapperFactory.java
@@ -19,6 +19,8 @@
 
 package org.apache.gravitino.auth;
 
+import org.apache.gravitino.Config;
+
 /** Factory class for creating {@link PrincipalMapper} instances. */
 public class PrincipalMapperFactory {
 
@@ -30,27 +32,31 @@ public class PrincipalMapperFactory {
    * @param mapperType "regex" for built-in regex mapper, or fully qualified class name for custom
    *     mapper
    * @param regexPattern the regex pattern (only used when mapperType is "regex")
+   * @param config the server configuration passed to {@link PrincipalMapper#initialize(Config)}
    * @return a configured PrincipalMapper instance
    * @throws IllegalArgumentException if the mapper cannot be created
    */
-  public static PrincipalMapper create(String mapperType, String regexPattern) {
+  public static PrincipalMapper create(String mapperType, String regexPattern, Config config) {
+    PrincipalMapper mapper;
     if ("regex".equalsIgnoreCase(mapperType)) {
-      return new RegexPrincipalMapper(regexPattern);
-    }
-
-    // Load custom mapper class
-    try {
-      Class<?> clazz = Class.forName(mapperType);
-      if (!PrincipalMapper.class.isAssignableFrom(clazz)) {
+      mapper = new RegexPrincipalMapper(regexPattern);
+    } else {
+      // Load custom mapper class
+      try {
+        Class<?> clazz = Class.forName(mapperType);
+        if (!PrincipalMapper.class.isAssignableFrom(clazz)) {
+          throw new IllegalArgumentException(
+              "Class " + mapperType + " does not implement PrincipalMapper");
+        }
+        mapper = (PrincipalMapper) clazz.getDeclaredConstructor().newInstance();
+      } catch (ClassNotFoundException e) {
+        throw new IllegalArgumentException("Unknown principal mapper type: " + mapperType, e);
+      } catch (Exception e) {
         throw new IllegalArgumentException(
-            "Class " + mapperType + " does not implement PrincipalMapper");
+            "Failed to instantiate principal mapper: " + mapperType, e);
       }
-      return (PrincipalMapper) clazz.getDeclaredConstructor().newInstance();
-    } catch (ClassNotFoundException e) {
-      throw new IllegalArgumentException("Unknown principal mapper type: " + mapperType, e);
-    } catch (Exception e) {
-      throw new IllegalArgumentException(
-          "Failed to instantiate principal mapper: " + mapperType, e);
     }
+    mapper.initialize(config);
+    return mapper;
   }
 }

--- a/core/src/test/java/org/apache/gravitino/auth/TestGroupMapperFactory.java
+++ b/core/src/test/java/org/apache/gravitino/auth/TestGroupMapperFactory.java
@@ -29,14 +29,17 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import org.apache.gravitino.Config;
 import org.apache.gravitino.UserGroup;
 import org.junit.jupiter.api.Test;
 
 public class TestGroupMapperFactory {
 
+  private final Config config = new Config(false) {};
+
   @Test
   public void testCreateRegexMapper() {
-    GroupMapper mapper = GroupMapperFactory.create("regex", "group-(.*)");
+    GroupMapper mapper = GroupMapperFactory.create("regex", "group-(.*)", config);
 
     assertNotNull(mapper);
     assertTrue(mapper instanceof RegexGroupMapper);
@@ -53,7 +56,7 @@ public class TestGroupMapperFactory {
 
   @Test
   public void testCreateRegexMapperWithDefaultPattern() {
-    GroupMapper mapper = GroupMapperFactory.create("regex", "^(.*)$");
+    GroupMapper mapper = GroupMapperFactory.create("regex", "^(.*)$", config);
 
     assertNotNull(mapper);
     assertTrue(mapper instanceof RegexGroupMapper);
@@ -70,7 +73,7 @@ public class TestGroupMapperFactory {
 
   @Test
   public void testCreateRegexMapperWithSlash() {
-    GroupMapper mapper = GroupMapperFactory.create("regex", "/(.*)");
+    GroupMapper mapper = GroupMapperFactory.create("regex", "/(.*)", config);
 
     assertNotNull(mapper);
     assertTrue(mapper instanceof RegexGroupMapper);
@@ -91,12 +94,21 @@ public class TestGroupMapperFactory {
         assertThrows(
             IllegalArgumentException.class,
             () -> {
-              GroupMapperFactory.create("unknown.InvalidClass", null);
+              GroupMapperFactory.create("unknown.InvalidClass", null, config);
             });
     assertTrue(exception.getMessage().contains("Failed to load GroupMapper class"));
   }
 
   public static class TestCustomGroupMapper implements GroupMapper {
+    private boolean initialized = false;
+    private Config receivedConfig;
+
+    @Override
+    public void initialize(Config config) {
+      this.initialized = true;
+      this.receivedConfig = config;
+    }
+
     @Override
     public List<UserGroup> map(List<Object> groups) {
       if (groups == null) {
@@ -106,12 +118,16 @@ public class TestGroupMapperFactory {
           .map(g -> new UserGroup(Optional.empty(), "custom:" + g.toString()))
           .collect(Collectors.toList());
     }
+
+    public boolean isInitialized() {
+      return initialized;
+    }
   }
 
   @Test
   public void testCreateCustomMapperWithInlineClass() {
     String className = TestCustomGroupMapper.class.getName();
-    GroupMapper mapper = GroupMapperFactory.create(className, null);
+    GroupMapper mapper = GroupMapperFactory.create(className, null, config);
 
     assertNotNull(mapper);
     assertTrue(mapper instanceof TestCustomGroupMapper);
@@ -121,5 +137,14 @@ public class TestGroupMapperFactory {
 
     assertEquals(1, mappedGroups.size());
     assertEquals("custom:foo", mappedGroups.get(0).getGroupname());
+  }
+
+  @Test
+  public void testCustomMapperInitializeCalledWithConfig() {
+    String className = TestCustomGroupMapper.class.getName();
+    GroupMapper mapper = GroupMapperFactory.create(className, null, config);
+    TestCustomGroupMapper custom = (TestCustomGroupMapper) mapper;
+    assertTrue(custom.isInitialized());
+    assertEquals(config, custom.receivedConfig);
   }
 }

--- a/core/src/test/java/org/apache/gravitino/auth/TestPrincipalMapperFactory.java
+++ b/core/src/test/java/org/apache/gravitino/auth/TestPrincipalMapperFactory.java
@@ -25,14 +25,17 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.security.Principal;
+import org.apache.gravitino.Config;
 import org.apache.gravitino.UserPrincipal;
 import org.junit.jupiter.api.Test;
 
 public class TestPrincipalMapperFactory {
 
+  private final Config config = new Config(false) {};
+
   @Test
   public void testCreateRegexMapper() {
-    PrincipalMapper mapper = PrincipalMapperFactory.create("regex", "([^@]+)@.*");
+    PrincipalMapper mapper = PrincipalMapperFactory.create("regex", "([^@]+)@.*", config);
 
     assertNotNull(mapper);
     assertTrue(mapper instanceof RegexPrincipalMapper);
@@ -43,7 +46,7 @@ public class TestPrincipalMapperFactory {
 
   @Test
   public void testCreateRegexMapperWithDefaultPattern() {
-    PrincipalMapper mapper = PrincipalMapperFactory.create("regex", "^(.*)$");
+    PrincipalMapper mapper = PrincipalMapperFactory.create("regex", "^(.*)$", config);
 
     assertNotNull(mapper);
     assertTrue(mapper instanceof RegexPrincipalMapper);
@@ -59,25 +62,47 @@ public class TestPrincipalMapperFactory {
         assertThrows(
             IllegalArgumentException.class,
             () -> {
-              PrincipalMapperFactory.create("unknown.InvalidClass", null);
+              PrincipalMapperFactory.create("unknown.InvalidClass", null, config);
             });
     assertTrue(exception.getMessage().contains("Unknown principal mapper type"));
   }
 
   public static class TestCustomMapper implements PrincipalMapper {
+    private boolean initialized = false;
+    private Config receivedConfig;
+
+    @Override
+    public void initialize(Config config) {
+      this.initialized = true;
+      this.receivedConfig = config;
+    }
+
     @Override
     public Principal map(String principal) {
       return new UserPrincipal("custom:" + principal);
+    }
+
+    public boolean isInitialized() {
+      return initialized;
     }
   }
 
   @Test
   public void testCreateCustomMapperWithInlineClass() {
     String className = TestCustomMapper.class.getName();
-    PrincipalMapper mapper = PrincipalMapperFactory.create(className, null);
+    PrincipalMapper mapper = PrincipalMapperFactory.create(className, null, config);
     assertNotNull(mapper);
     assertTrue(mapper instanceof TestCustomMapper);
     Principal principal = mapper.map("foo");
     assertEquals("custom:foo", principal.getName());
+  }
+
+  @Test
+  public void testCustomMapperInitializeCalledWithConfig() {
+    String className = TestCustomMapper.class.getName();
+    PrincipalMapper mapper = PrincipalMapperFactory.create(className, null, config);
+    TestCustomMapper custom = (TestCustomMapper) mapper;
+    assertTrue(custom.isInitialized());
+    assertEquals(config, custom.receivedConfig);
   }
 }

--- a/server-common/src/main/java/org/apache/gravitino/server/authentication/JwksTokenValidator.java
+++ b/server-common/src/main/java/org/apache/gravitino/server/authentication/JwksTokenValidator.java
@@ -78,12 +78,12 @@ public class JwksTokenValidator implements OAuthTokenValidator {
     // Create principal mapper based on configuration
     String mapperType = config.get(OAuthConfig.PRINCIPAL_MAPPER);
     String regexPattern = config.get(OAuthConfig.PRINCIPAL_MAPPER_REGEX_PATTERN);
-    this.principalMapper = PrincipalMapperFactory.create(mapperType, regexPattern);
+    this.principalMapper = PrincipalMapperFactory.create(mapperType, regexPattern, config);
 
     // Create group mapper based on configuration
     String groupMapperType = config.get(OAuthConfig.GROUP_MAPPER);
     String groupRegexPattern = config.get(OAuthConfig.GROUP_MAPPER_REGEX_PATTERN);
-    this.groupMapper = GroupMapperFactory.create(groupMapperType, groupRegexPattern);
+    this.groupMapper = GroupMapperFactory.create(groupMapperType, groupRegexPattern, config);
 
     LOG.info("Initializing JWKS token validator");
 

--- a/server-common/src/main/java/org/apache/gravitino/server/authentication/KerberosAuthenticator.java
+++ b/server-common/src/main/java/org/apache/gravitino/server/authentication/KerberosAuthenticator.java
@@ -81,7 +81,7 @@ public class KerberosAuthenticator implements Authenticator {
       // "HTTP/host" from "HTTP/host@REALM")
       String mapperType = config.get(KerberosConfig.PRINCIPAL_MAPPER);
       String regexPattern = config.get(KerberosConfig.PRINCIPAL_MAPPER_REGEX_PATTERN);
-      this.principalMapper = PrincipalMapperFactory.create(mapperType, regexPattern);
+      this.principalMapper = PrincipalMapperFactory.create(mapperType, regexPattern, config);
 
       gssManager =
           Subject.doAs(

--- a/server-common/src/main/java/org/apache/gravitino/server/authentication/StaticSignKeyValidator.java
+++ b/server-common/src/main/java/org/apache/gravitino/server/authentication/StaticSignKeyValidator.java
@@ -85,12 +85,12 @@ public class StaticSignKeyValidator implements OAuthTokenValidator {
     // Create principal mapper based on configuration
     String mapperType = config.get(OAuthConfig.PRINCIPAL_MAPPER);
     String regexPattern = config.get(OAuthConfig.PRINCIPAL_MAPPER_REGEX_PATTERN);
-    this.principalMapper = PrincipalMapperFactory.create(mapperType, regexPattern);
+    this.principalMapper = PrincipalMapperFactory.create(mapperType, regexPattern, config);
 
     // Create group mapper based on configuration
     String groupMapperType = config.get(OAuthConfig.GROUP_MAPPER);
     String groupRegexPattern = config.get(OAuthConfig.GROUP_MAPPER_REGEX_PATTERN);
-    this.groupMapper = GroupMapperFactory.create(groupMapperType, groupRegexPattern);
+    this.groupMapper = GroupMapperFactory.create(groupMapperType, groupRegexPattern, config);
   }
 
   @Override


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add a `default void initialize(Config config) {}` method to `PrincipalMapper` and `GroupMapper` interfaces, following the same lifecycle pattern already used by `OAuthTokenValidator` and `Authenticator`.

Changes:
- Add `default void initialize(Config config) {}` to `PrincipalMapper`
- Add `default void initialize(Config config) {}` to `GroupMapper`
- Update `PrincipalMapperFactory` and `GroupMapperFactory` to accept `Config` and call `initialize()` after construction
- Update `JwksTokenValidator`, `StaticSignKeyValidator`, and `KerberosAuthenticator` to pass `Config` to factories
- Add tests verifying `initialize()` is called for custom mapper implementations

### Why are the changes needed?

Custom `PrincipalMapper` and `GroupMapper` implementations loaded via FQCN have no way to receive server configuration. The factories instantiate them via no-arg constructor but never pass config, unlike `OAuthTokenValidator` and `Authenticator` which both have `initialize(Config config)` called after construction.

This gap prevents building config-driven mappers (e.g., a static mapping table for Azure AD service principal GUIDs to friendly names).

Fix: #11412 

### Does this PR introduce _any_ user-facing change?

No breaking changes. The `initialize(Config)` method is a default no-op, so existing custom implementations continue to work unchanged. Custom mappers can now optionally override `initialize(Config)` to receive configuration.

### How was this patch tested?

- Added `TestCustomMapper` / `TestCustomGroupMapper` inner classes in existing factory tests
- Added `testCustomMapperInitializeCalledWithConfig` tests verifying `initialize()` is called with the correct `Config` instance
- All existing tests continue to pass
- `./gradlew :core:test :server-common:compileJava` — BUILD SUCCESSFUL