### PR TITLE
fix: add missing Glue catalog icon in Web UI catalog tree

### DIFF
--- a/web-v2/web/src/config/catalog.js
+++ b/web-v2/web/src/config/catalog.js
@@ -43,6 +43,8 @@ export const checkCatalogIcon = ({ type, provider }) => {
           return 'custom-icons-starrocks'
         case 'lakehouse-generic':
           return 'custom-icons-lakehouse'
+        case 'glue':
+          return 'logos:aws-glue'
         case 'jdbc-clickhouse':
           return 'custom-icons-clickhouse'
         default:


### PR DESCRIPTION
Fixes #11397

## Problem
When a Glue catalog is displayed in the Web UI catalog tree, it shows 
the default book icon instead of a Glue-specific logo.

## Solution
Added `logos:aws-glue` from Iconify to the `checkCatalogIcon` function 
in `catalog.js`, following the same pattern used by other providers 
(e.g. `openmoji:iceberg` for lakehouse-iceberg).