### PR TITLE
[#10457] fix(hive): Exclude vulnerable log4j transitive deps from hive-metastore-common

### DIFF
--- a/catalogs/hive-metastore-common/build.gradle.kts
+++ b/catalogs/hive-metastore-common/build.gradle.kts
@@ -34,7 +34,10 @@ dependencies {
   compileOnly(project(":common"))
   compileOnly(project(":core"))
 
-  compileOnly(libs.hive2.metastore)
+  compileOnly(libs.hive2.metastore) {
+    exclude(group = "log4j")
+    exclude(group = "org.apache.logging.log4j")
+  }
   compileOnly(libs.immutables.value)
   compileOnly(libs.lombok)
   compileOnly(libs.caffeine)


### PR DESCRIPTION
### What changes were proposed in this pull request?

Exclude `log4j` and `org.apache.logging.log4j` transitive dependencies from the `compileOnly(libs.hive2.metastore)` declaration in `catalogs/hive-metastore-common/build.gradle.kts`.

### Why are the changes needed?

**Build fails when using JFrog Artifactory as a Maven proxy.**

When Artifactory is configured with JFrog Xray security policies, it blocks downloads of artifacts with known critical CVEs. The `hive-metastore:2.3.9` dependency pulls in `log4j-core:2.6.2` (CVE-2021-44228, CVSS 10.0) transitively:

```
hive-metastore:2.3.9
  → hive-serde:2.3.9
    → hive-common:2.3.9
      → log4j-1.2-api:2.6.2
        → log4j-core:2.6.2   ← blocked by Xray
```

Even though `hive-metastore-common` uses `compileOnly` scope, Gradle still resolves all transitive dependencies at compile time. When Artifactory blocks `log4j-core:2.6.2`, the build fails at dependency resolution before compilation begins.

Builds against Maven Central directly are unaffected since Maven Central serves all artifacts regardless of CVE status — this is why upstream CI passes.

**The exclusion is zero-risk:** `hive-metastore-common` source code never imports log4j — it exclusively uses SLF4J. The log4j artifacts are purely unused transitive baggage from Hive.

PR #10465 already added the same exclusions to `hive-metastore2-libs` and `hive-metastore3-libs`. This PR applies the same pattern to `hive-metastore-common` for consistency.

### Does this PR introduce any user-facing change?

No. The excluded dependencies were never used by the code and are `compileOnly` (not shipped).

### How was this patch tested?

- `./gradlew :catalogs:hive-metastore-common:build` — BUILD SUCCESSFUL
- `./gradlew :catalogs:hive-metastore-common:spotlessCheck` — passed
- Verified via `./gradlew :catalogs:hive-metastore-common:dependencies --configuration compileClasspath` that all log4j transitive deps are removed
- Verified via `grep -r "import.*log4j" catalogs/hive-metastore-common/src/` that no source files import log4j
- Confirmed the exclusion pattern matches what was already applied in `hive-metastore2-libs` and `hive-metastore3-libs` by PR #10465