### PR TITLE
[#7833] fix(iceberg): Populate audit info for tables loaded from Iceberg catalog

### DIFF
--- a/catalogs/catalog-lakehouse-iceberg/src/main/java/org/apache/gravitino/catalog/lakehouse/iceberg/IcebergTable.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/main/java/org/apache/gravitino/catalog/lakehouse/iceberg/IcebergTable.java
@@ -23,6 +23,7 @@ import static org.apache.iceberg.TableProperties.DEFAULT_FILE_FORMAT;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 import lombok.Getter;
@@ -154,13 +155,22 @@ public class IcebergTable extends BaseTable {
     SortOrder[] sortOrder = FromIcebergSortOrder.fromSortOrder(table.sortOrder());
     IcebergColumn[] icebergColumns =
         schema.columns().stream().map(ConvertUtil::fromNestedField).toArray(IcebergColumn[]::new);
+    AuditInfo.Builder auditInfoBuilder = AuditInfo.builder();
+    String owner = properties.get(IcebergConstants.OWNER);
+    if (owner != null) {
+      auditInfoBuilder.withCreator(owner);
+    }
+    if (table.lastUpdatedMillis() > 0) {
+      auditInfoBuilder.withCreateTime(Instant.ofEpochMilli(table.lastUpdatedMillis()));
+    }
+
     return IcebergTable.builder()
         .withComment(table.property(IcebergTablePropertiesMetadata.COMMENT, null))
         .withLocation(table.location())
         .withProperties(properties)
         .withColumns(icebergColumns)
         .withName(tableName)
-        .withAuditInfo(AuditInfo.EMPTY)
+        .withAuditInfo(auditInfoBuilder.build())
         .withPartitioning(partitionSpec)
         .withSortOrders(sortOrder)
         .withDistribution(getDistribution(properties))

--- a/catalogs/catalog-lakehouse-iceberg/src/test/java/org/apache/gravitino/catalog/lakehouse/iceberg/TestIcebergTable.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/test/java/org/apache/gravitino/catalog/lakehouse/iceberg/TestIcebergTable.java
@@ -56,6 +56,12 @@ import org.apache.gravitino.rel.expressions.sorts.SortOrders;
 import org.apache.gravitino.rel.expressions.transforms.Transform;
 import org.apache.gravitino.rel.types.Types;
 import org.apache.iceberg.DistributionMode;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.types.Types.IntegerType;
+import org.apache.iceberg.types.Types.NestedField;
+import org.apache.iceberg.types.Types.StringType;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
@@ -707,5 +713,47 @@ public class TestIcebergTable {
 
   protected static String genRandomName() {
     return UUID.randomUUID().toString().replace("-", "");
+  }
+
+  @Test
+  void testFromIcebergTablePopulatesAuditInfoWithOwner() {
+    Schema icebergSchema =
+        new Schema(
+            NestedField.required(1, "id", IntegerType.get()),
+            NestedField.optional(2, "name", StringType.get()));
+
+    Map<String, String> properties = new HashMap<>();
+    properties.put(IcebergConstants.OWNER, "test_user");
+
+    TableMetadata metadata =
+        TableMetadata.newTableMetadata(
+            icebergSchema, PartitionSpec.unpartitioned(), "/tmp/test_table", properties);
+
+    IcebergTable table = IcebergTable.fromIcebergTable(metadata, "test_table");
+
+    Assertions.assertNotNull(table.auditInfo());
+    Assertions.assertEquals("test_user", table.auditInfo().creator());
+    Assertions.assertNotNull(table.auditInfo().createTime());
+    Assertions.assertTrue(table.auditInfo().createTime().toEpochMilli() > 0);
+  }
+
+  @Test
+  void testFromIcebergTableWithoutOwnerProperty() {
+    Schema icebergSchema =
+        new Schema(
+            NestedField.required(1, "id", IntegerType.get()),
+            NestedField.optional(2, "name", StringType.get()));
+
+    Map<String, String> properties = new HashMap<>();
+
+    TableMetadata metadata =
+        TableMetadata.newTableMetadata(
+            icebergSchema, PartitionSpec.unpartitioned(), "/tmp/test_table", properties);
+
+    IcebergTable table = IcebergTable.fromIcebergTable(metadata, "test_table");
+
+    Assertions.assertNotNull(table.auditInfo());
+    Assertions.assertNull(table.auditInfo().creator());
+    Assertions.assertNotNull(table.auditInfo().createTime());
   }
 }

--- a/core/src/main/java/org/apache/gravitino/catalog/EntityCombinedTable.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/EntityCombinedTable.java
@@ -139,17 +139,28 @@ public final class EntityCombinedTable implements Table {
 
   @Override
   public Audit auditInfo() {
-    AuditInfo mergedAudit =
-        AuditInfo.builder()
-            .withCreator(table.auditInfo().creator())
-            .withCreateTime(table.auditInfo().createTime())
-            .withLastModifier(table.auditInfo().lastModifier())
-            .withLastModifiedTime(table.auditInfo().lastModifiedTime())
-            .build();
+    if (tableEntity == null) {
+      return table.auditInfo();
+    }
 
-    return tableEntity == null
-        ? table.auditInfo()
-        : mergedAudit.merge(tableEntity.auditInfo(), true /* overwrite */);
+    Audit catalogAudit = table.auditInfo();
+    Audit entityAudit = tableEntity.auditInfo();
+
+    // Entity store values take priority when non-null (they track actual Gravitino operations),
+    // but fall back to catalog-provided values (e.g., owner from Iceberg metadata).
+    return AuditInfo.builder()
+        .withCreator(entityAudit.creator() != null ? entityAudit.creator() : catalogAudit.creator())
+        .withCreateTime(
+            entityAudit.createTime() != null ? entityAudit.createTime() : catalogAudit.createTime())
+        .withLastModifier(
+            entityAudit.lastModifier() != null
+                ? entityAudit.lastModifier()
+                : catalogAudit.lastModifier())
+        .withLastModifiedTime(
+            entityAudit.lastModifiedTime() != null
+                ? entityAudit.lastModifiedTime()
+                : catalogAudit.lastModifiedTime())
+        .build();
   }
 
   StringIdentifier stringIdentifier() {

--- a/core/src/test/java/org/apache/gravitino/meta/TestEntityCombinedObject.java
+++ b/core/src/test/java/org/apache/gravitino/meta/TestEntityCombinedObject.java
@@ -113,6 +113,37 @@ public class TestEntityCombinedObject {
   }
 
   @Test
+  public void testTableAuditMergePreservesCatalogValues() {
+    // Simulate: catalog provides creator/createTime (from Iceberg metadata),
+    // entity store only has lastModifier/lastModifiedTime (no creator/createTime).
+    AuditInfo entityAudit =
+        AuditInfo.builder()
+            .withLastModifier("entityModifier")
+            .withLastModifiedTime(Instant.parse("2025-06-01T00:00:00Z"))
+            .build();
+
+    TableEntity tableEntity =
+        TableEntity.builder()
+            .withId(1L)
+            .withName("testTable")
+            .withNamespace(org.apache.gravitino.Namespace.of("metalake", "catalog", "schema"))
+            .withAuditInfo(entityAudit)
+            .build();
+
+    EntityCombinedTable combined =
+        EntityCombinedTable.of(originTable, tableEntity).withHiddenProperties(hiddenProperties);
+
+    // Entity store's lastModifier/lastModifiedTime should win
+    Assertions.assertEquals("entityModifier", combined.auditInfo().lastModifier());
+    Assertions.assertEquals(
+        Instant.parse("2025-06-01T00:00:00Z"), combined.auditInfo().lastModifiedTime());
+    // Catalog-level creator/createTime should be preserved (not overwritten with null)
+    Assertions.assertEquals("creator", combined.auditInfo().creator());
+    Assertions.assertEquals(
+        Instant.parse("2025-01-01T00:00:00Z"), combined.auditInfo().createTime());
+  }
+
+  @Test
   public void testFileset() {
     EntityCombinedFileset entityCombinedFileset =
         EntityCombinedFileset.of(originFileset).withHiddenProperties(hiddenProperties);


### PR DESCRIPTION
### What changes were proposed in this pull request?

Populate `AuditInfo` (creator and create time) when loading Iceberg tables via
`IcebergTable.fromIcebergTable()`, instead of hardcoding `AuditInfo.EMPTY`.

- Extract the `owner` table property as the `creator`
- Use `lastUpdatedMillis` from Iceberg `TableMetadata` as the `createTime`

### Why are the changes needed?

When tables are created or updated outside the Gravitino Web UI (e.g., via
Iceberg REST Catalog, Spark, or other Iceberg clients), the "Created by" /
"Updated by" user and timestamp fields are not populated in Gravitino's metadata
UI. This is because `IcebergTable.fromIcebergTable()` discards the available
audit information by using `AuditInfo.EMPTY`.

Fix: #7833

### Does this PR introduce _any_ user-facing change?

Yes. Tables loaded from Iceberg catalogs will now show the creator (from the
`owner` table property) and creation timestamp in the Gravitino Web UI and API
responses, where previously these fields were empty.

### How was this patch tested?

Added two unit tests in `TestIcebergTable`:
- `testFromIcebergTablePopulatesAuditInfoWithOwner` — verifies creator and
  createTime are populated when the `owner` property is set
- `testFromIcebergTableWithoutOwnerProperty` — verifies no regression when
  `owner` is absent (creator is null, createTime is still set)

All existing `TestIcebergTable` tests continue to pass.