### PR TITLE
[#10929]docs(deploy): Add GCS configuration guide for Helm Chart and Docker deployments

### DIFF
--- a/dev/charts/gravitino/values.yaml
+++ b/dev/charts/gravitino/values.yaml
@@ -289,7 +289,11 @@ icebergRest:
   #   tenantId: ""
   #   clientId: ""
   #   clientSecret: ""
-  ## No need to configure extra Google Cloud Storage configuration
+  ## Google Cloud Storage (GCS) configuration
+  ## If your catalog uses GCS as the object store, you must set the
+  ## GOOGLE_APPLICATION_CREDENTIALS environment variable in the container (see the "env" section below).
+  ## Mount the service account key file into the pod via extraVolumes/extraVolumeMounts.
+  ## No additional Iceberg REST properties are required beyond the credential file.
   ##
   ## Catalog configuration provider class name
   ##
@@ -356,12 +360,24 @@ additionalConfigItems: {}
 extraVolumes:
   - name: gravitino-log
     emptyDir: {}
+  ## Uncomment the following to mount a GCS service account key for catalogs using GCS as object store.
+  ## Create the secret first: kubectl create secret generic gcs-key --from-file=key.json=<path-to-key-file> -n gravitino
+  ##
+  # - name: gcs-key
+  #   secret:
+  #     secretName: gcs-key
 
 ## Additional volume mounts
 ##
 extraVolumeMounts:
   - name: gravitino-log
     mountPath: /opt/gravitino/logs
+  ## Uncomment the following to mount the GCS key into the container.
+  ## Ensure GOOGLE_APPLICATION_CREDENTIALS env is set to /etc/gcs/key.json (see env section).
+  ##
+  # - name: gcs-key
+  #   mountPath: /etc/gcs
+  #   readOnly: true
 
 ## ref: https://kubernetes.io/docs/concepts/storage/persistent-volumes/
 ## If you set enabled as "True", you need :
@@ -532,6 +548,11 @@ containerSecurityContext:
 env:
   - name: GRAVITINO_MEM
     value: "-Xms1024m -Xmx1024m -XX:MaxMetaspaceSize=512m"
+  ## Uncomment the following if your catalog uses Google Cloud Storage (GCS) as the object store.
+  ## You must also mount the service account key file via extraVolumes and extraVolumeMounts.
+  ##
+  # - name: GOOGLE_APPLICATION_CREDENTIALS
+  #   value: /etc/gcs/key.json
 
 ## The envWithTpl array below has the same usage as "env", but is using the tpl function to support templatable string.
 ## This can be useful when you want to pass dynamic values to the Chart using the helm argument "--set <variable>=<value>"

--- a/docs/chart.md
+++ b/docs/chart.md
@@ -27,7 +27,7 @@ helm pull oci://registry-1.docker.io/apache/gravitino-helm --version <VERSION>
 Or install directly:
 
 ```console
-helm upgrade --install gravitino oci://registry-1.docker.io/apache/gravitino-helm --version <VERSION> -n gravitino --create-namespace
+helm upgrade --install gravitino oci://registry-1.docker.io/apache/gravitino-helm --version <VERSION> -n <NAMESPACE> --create-namespace
 ```
 
 ### Install from Local Repository (For Development or Unreleased Versions)
@@ -48,7 +48,7 @@ helm dependency update gravitino
 Install the chart:
 
 ```console
-helm upgrade --install gravitino ./gravitino -n gravitino --create-namespace
+helm upgrade --install gravitino ./gravitino -n <NAMESPACE> --create-namespace
 ```
 
 ## View Chart Values
@@ -72,7 +72,7 @@ helm upgrade --install [RELEASE_NAME] oci://registry-1.docker.io/apache/gravitin
 Run the following command to deploy Gravitino using the default settings:
 
 ```console
-helm upgrade --install gravitino oci://registry-1.docker.io/apache/gravitino-helm --version <VERSION> -n gravitino --create-namespace
+helm upgrade --install gravitino oci://registry-1.docker.io/apache/gravitino-helm --version <VERSION> -n <NAMESPACE> --create-namespace
 ```
 
 ### Deploy with Custom Configuration
@@ -81,7 +81,7 @@ To customize the deployment, use the --set flag to override specific values:
 
 ```console
 helm upgrade --install gravitino oci://registry-1.docker.io/apache/gravitino-helm --version <VERSION> \
-  -n gravitino --create-namespace \
+  -n <NAMESPACE> --create-namespace \
   --set key1=val1,key2=val2,...
 ```
 
@@ -89,7 +89,7 @@ Alternatively, you can provide a custom values.yaml file:
 
 ```console
 helm upgrade --install gravitino oci://registry-1.docker.io/apache/gravitino-helm --version <VERSION> \
-  -n gravitino --create-namespace \
+  -n <NAMESPACE> --create-namespace \
   -f /path/to/values.yaml
 ```
 
@@ -99,7 +99,7 @@ To deploy both Gravitino and MySQL, where MySQL is used as the storage backend, 
 
 ```console
 helm upgrade --install gravitino oci://registry-1.docker.io/apache/gravitino-helm --version <VERSION> \
-  -n gravitino --create-namespace \
+  -n <NAMESPACE> --create-namespace \
   --set mysql.enabled=true
 ```
 
@@ -109,7 +109,7 @@ By default, the MySQL PersistentVolumeClaim(PVC) storage class is local-path. To
 
 ```console
 helm upgrade --install gravitino oci://registry-1.docker.io/apache/gravitino-helm --version <VERSION> \
-  -n gravitino --create-namespace \
+  -n <NAMESPACE> --create-namespace \
   --set mysql.enabled=true \
   --set global.defaultStorageClass="-"
 ```
@@ -130,7 +130,7 @@ Use Helm to install or upgrade Gravitino, specifying the MySQL connection detail
 
 ```console
 helm upgrade --install gravitino oci://registry-1.docker.io/apache/gravitino-helm --version <VERSION> \
-  -n gravitino --create-namespace \
+  -n <NAMESPACE> --create-namespace \
   --set entity.jdbcUrl="jdbc:mysql://database-1.***.***.rds.amazonaws.com:3306/gravitino" \
   --set entity.jdbcDriver="com.mysql.cj.jdbc.Driver" \
   --set entity.jdbcUser="admin" \
@@ -142,8 +142,48 @@ Replace database-1.***.***.rds.amazonaws.com with your actual MySQL host. \
 Change admin and admin123 to your actual MySQL username and password. \
 Ensure the target MySQL database (gravitino) exists before deployment._
 
+### Deploy Gravitino with GCS as Object Store
+
+If your catalog uses Google Cloud Storage (GCS) as the object store, you need to set the `GOOGLE_APPLICATION_CREDENTIALS` environment variable in the container and mount the service account key file.
+
+1. Create a Kubernetes secret from your GCS service account key:
+
+```console
+kubectl create secret generic gcs-key --from-file=key.json=/path/to/your-service-account-key.json -n <NAMESPACE>
+```
+
+2. Deploy Gravitino with GCS configuration in your custom `values.yaml`:
+
+```yaml
+env:
+  - name: GRAVITINO_MEM
+    value: "-Xms1024m -Xmx1024m -XX:MaxMetaspaceSize=512m"
+  - name: GOOGLE_APPLICATION_CREDENTIALS
+    value: /etc/gcs/key.json
+
+extraVolumes:
+  - name: gravitino-log
+    emptyDir: {}
+  - name: gcs-key
+    secret:
+      secretName: gcs-key
+
+extraVolumeMounts:
+  - name: gravitino-log
+    mountPath: /opt/gravitino/logs
+  - name: gcs-key
+    mountPath: /etc/gcs
+    readOnly: true
+```
+
+```console
+helm upgrade --install gravitino oci://registry-1.docker.io/apache/gravitino-helm --version <VERSION> \
+  -n <NAMESPACE> --create-namespace \
+  -f /path/to/values.yaml
+```
+
 ## Uninstall Helm Chart
 
 ```console
-helm uninstall [RELEASE_NAME] -n [NAMESPACE]
+helm uninstall [RELEASE_NAME] -n <NAMESPACE>
 ```

--- a/docs/how-to-install.md
+++ b/docs/how-to-install.md
@@ -150,6 +150,17 @@ curl -v -X GET -H "Accept: application/vnd.gravitino.v1+json" -H "Content-Type: 
 
 to make sure Gravitino is running.
 
+### Using GCS as Object Store with Docker
+
+If your catalog uses Google Cloud Storage (GCS) as the object store, set the `GOOGLE_APPLICATION_CREDENTIALS` environment variable and mount the service account key file into the container:
+
+```shell
+docker run -d -i -p 8090:8090 \
+  -v /path/to/your-service-account-key.json:/etc/gcs/key.json:ro \
+  -e GOOGLE_APPLICATION_CREDENTIALS=/etc/gcs/key.json \
+  apache/gravitino:<version>
+```
+
 ## Install Apache Gravitino using Docker compose
 
 The published Gravitino Docker image only contains the Gravitino server with a basic configuration. If you want to experience the whole Gravitino system with other components, use the Docker `compose` file.


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add documentation for configuring `GOOGLE_APPLICATION_CREDENTIALS` when using GCS as object store in both Helm Chart and Docker deployments:

1. **`dev/charts/gravitino/values.yaml`**: Added commented-out examples for GCS environment variable, extraVolumes, and extraVolumeMounts sections.
2. **`docs/chart.md`**: Added a new "Deploy Gravitino with GCS as Object Store" section with step-by-step instructions. Also replaced all hardcoded `-n gravitino` namespace with `<NAMESPACE>` placeholder for consistency.
3. **`docs/how-to-install.md`**: Added a "Using GCS as Object Store with Docker" section showing how to mount the key file and set the environment variable via `docker run`.

### Why are the changes needed?

When a catalog uses Google Cloud Storage (GCS) as the object store, the container requires the `GOOGLE_APPLICATION_CREDENTIALS` environment variable to be set and the service account key file to be mounted. Without this documentation, users have no clear guidance on how to configure GCS credentials for Chart/Docker deployments.

Fix: #10929

### Does this PR introduce _any_ user-facing change?

No code changes. Documentation only:
- New GCS configuration guidance in Helm Chart and Docker deployment docs.
- Namespace placeholder `<NAMESPACE>` replaces hardcoded `gravitino` in `chart.md` examples.

### How was this patch tested?

Documentation-only change. Verified markdown renders correctly and all examples are consistent.