### PR TITLE
[#11401] fix(trino-connector): drop_catalog falls back to server when local cache misses

### DIFF
--- a/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/system/storedprocedure/DropCatalogStoredProcedure.java
+++ b/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/system/storedprocedure/DropCatalogStoredProcedure.java
@@ -90,13 +90,16 @@ public class DropCatalogStoredProcedure extends GravitinoStoredProcedure {
           catalogConnectorManager.getCatalogConnector(
               catalogConnectorManager.getTrinoCatalogName(metalake, catalogName));
       if (catalogConnector == null) {
-        if (ignoreNotExist) {
-          return;
+        // Local cache miss — the catalog may still exist on the Gravitino server (e.g., connector
+        // failed to load after creation). Fall back to a direct server-side drop so zombie catalogs
+        // can be cleaned up.
+        if (!catalogConnectorManager.getMetalake(metalake).dropCatalog(catalogName, true)
+            && !ignoreNotExist) {
+          throw new TrinoException(
+              GravitinoErrorCode.GRAVITINO_CATALOG_NOT_EXISTS,
+              "Catalog " + NameIdentifier.of(metalake, catalogName) + " not exists.");
         }
-
-        throw new TrinoException(
-            GravitinoErrorCode.GRAVITINO_CATALOG_NOT_EXISTS,
-            "Catalog " + NameIdentifier.of(metalake, catalogName) + " not exists.");
+        return;
       }
       // Always ignore "ignoreNotExist" inside Metalake.dropCatalog()
       // because we already handled the null check above.


### PR DESCRIPTION
### What changes were proposed in this pull request?

When `drop_catalog` is called for a catalog that exists on the Gravitino server
but not in the Trino connector's local cache (zombie catalog), fall back to a
direct server-side drop instead of reporting "not exists". The `ignoreNotExist`
flag behavior is preserved.

### Why are the changes needed?

`drop_catalog` only checked the local connector cache. If a catalog was persisted
to the Gravitino server but the connector failed to instantiate it, the catalog
was stuck — it could neither be dropped nor re-created.

Fix: #11401 #11402

### Does this PR introduce _any_ user-facing change?

`drop_catalog` can now clean up zombie catalogs that exist on the server but are
absent from the local connector cache.

### How was this patch tested?

Manual verification against the scenario described in #11401.