### PR TITLE
[MINOR] Fix Python formatting in client and matrix script

### DIFF
--- a/clients/client-python/gravitino/client/gravitino_metalake.py
+++ b/clients/client-python/gravitino/client/gravitino_metalake.py
@@ -14,7 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
 # pylint: disable=too-many-lines
 import logging
 from typing import Dict, List, Optional

--- a/clients/client-python/scripts/run_lance_ray_matrix.py
+++ b/clients/client-python/scripts/run_lance_ray_matrix.py
@@ -146,7 +146,9 @@ def ensure_venv(python: str, venv_dir: Path) -> Path:
     return venv_python
 
 
-def _deps_sentinel(venv_dir: Path, version: str, ray_spec: str, lance_namespace_spec: str) -> Path:
+def _deps_sentinel(
+    venv_dir: Path, version: str, ray_spec: str, lance_namespace_spec: str
+) -> Path:
     """Return the path to the sentinel file that marks a fully-installed venv.
 
     The sentinel encodes all dep specs so any change in pinned versions forces
@@ -171,7 +173,9 @@ def install_deps(
     """
     sentinel = _deps_sentinel(venv_dir, version, ray_spec, lance_namespace_spec)
     if sentinel.exists():
-        print(f"[matrix] venv for lance-ray=={version} already populated, skipping pip install")
+        print(
+            f"[matrix] venv for lance-ray=={version} already populated, skipping pip install"
+        )
         return
 
     rc = run(


### PR DESCRIPTION
## What changes were proposed in this pull request?

Minor Python formatting fixes:
- Remove an extra blank line in `gravitino_metalake.py`
- Reformat long function signatures in `run_lance_ray_matrix.py` to comply with line length limits

## Why are the changes needed?

Code style/formatting cleanup.

## Does this PR introduce _any_ user-facing change?

No.

## How was this pull request tested?

No logic changes; formatting only.