### PR TITLE
[#9517] fix(hive-catalog): Pre-resolve metastore URI hostnames to avoid Docker FQDN issue

### DIFF
--- a/catalogs/hive-metastore-common/src/main/java/org/apache/gravitino/hive/client/Util.java
+++ b/catalogs/hive-metastore-common/src/main/java/org/apache/gravitino/hive/client/Util.java
@@ -18,6 +18,8 @@
  */
 package org.apache.gravitino.hive.client;
 
+import static org.apache.gravitino.catalog.hive.HiveConstants.HIVE_METASTORE_URIS;
+
 import java.net.InetAddress;
 import java.net.URI;
 import java.util.Arrays;
@@ -34,7 +36,6 @@ public class Util {
   private static final Logger LOG = LoggerFactory.getLogger(Util.class);
 
   public static final String HIVE_CONFIG_RESOURCES = "hive.config.resources";
-  private static final String HIVE_METASTORE_URIS = "hive.metastore.uris";
 
   public static void updateConfigurationFromProperties(
       Properties properties, Configuration config) {
@@ -77,7 +78,14 @@ public class Util {
         return uriStr;
       }
       String ip = InetAddress.getByName(host).getHostAddress();
-      return new URI(uri.getScheme(), null, ip, uri.getPort(), uri.getPath(), null, null)
+      return new URI(
+              uri.getScheme(),
+              uri.getUserInfo(),
+              ip,
+              uri.getPort(),
+              uri.getPath(),
+              uri.getQuery(),
+              uri.getFragment())
           .toString();
     } catch (Exception e) {
       LOG.warn("Failed to resolve metastore URI host for '{}', using original", uriStr, e);

--- a/catalogs/hive-metastore-common/src/main/java/org/apache/gravitino/hive/client/Util.java
+++ b/catalogs/hive-metastore-common/src/main/java/org/apache/gravitino/hive/client/Util.java
@@ -18,14 +18,23 @@
  */
 package org.apache.gravitino.hive.client;
 
+import java.net.InetAddress;
+import java.net.URI;
+import java.util.Arrays;
 import java.util.Properties;
+import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class Util {
 
+  private static final Logger LOG = LoggerFactory.getLogger(Util.class);
+
   public static final String HIVE_CONFIG_RESOURCES = "hive.config.resources";
+  private static final String HIVE_METASTORE_URIS = "hive.metastore.uris";
 
   public static void updateConfigurationFromProperties(
       Properties properties, Configuration config) {
@@ -41,8 +50,38 @@ public class Util {
       }
 
       properties.forEach((k, v) -> config.set(k.toString(), v.toString()));
+      resolveMetastoreUriHosts(config);
     } catch (Exception e) {
       throw new RuntimeException("Failed to create configuration", e);
+    }
+  }
+
+  // Pre-resolve to IP so Hive's resolveUris() doesn't receive Docker FQDNs with underscores.
+  private static void resolveMetastoreUriHosts(Configuration config) {
+    String urisValue = config.get(HIVE_METASTORE_URIS);
+    if (StringUtils.isBlank(urisValue)) {
+      return;
+    }
+    String resolved =
+        Arrays.stream(urisValue.split(","))
+            .map(uri -> resolveUriHost(uri.trim()))
+            .collect(Collectors.joining(","));
+    config.set(HIVE_METASTORE_URIS, resolved);
+  }
+
+  private static String resolveUriHost(String uriStr) {
+    try {
+      URI uri = new URI(uriStr);
+      String host = uri.getHost();
+      if (StringUtils.isBlank(host)) {
+        return uriStr;
+      }
+      String ip = InetAddress.getByName(host).getHostAddress();
+      return new URI(uri.getScheme(), null, ip, uri.getPort(), uri.getPath(), null, null)
+          .toString();
+    } catch (Exception e) {
+      LOG.warn("Failed to resolve metastore URI host for '{}', using original", uriStr, e);
+      return uriStr;
     }
   }
 }

--- a/catalogs/hive-metastore-common/src/test/java/org/apache/gravitino/hive/client/TestUtil.java
+++ b/catalogs/hive-metastore-common/src/test/java/org/apache/gravitino/hive/client/TestUtil.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.hive.client;
+
+import java.util.Properties;
+import org.apache.hadoop.conf.Configuration;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TestUtil {
+
+  private static final String HIVE_METASTORE_URIS = "hive.metastore.uris";
+
+  @Test
+  void testMetastoreHostnameResolvedToIP() {
+    Properties props = new Properties();
+    props.setProperty(HIVE_METASTORE_URIS, "thrift://localhost:9083");
+    Configuration config = new Configuration();
+
+    Util.updateConfigurationFromProperties(props, config);
+
+    String resolved = config.get(HIVE_METASTORE_URIS);
+    Assertions.assertFalse(
+        resolved.contains("localhost"), "hostname should be replaced with IP, got: " + resolved);
+    Assertions.assertTrue(resolved.startsWith("thrift://") && resolved.endsWith(":9083"));
+  }
+
+  @Test
+  void testMetastoreIPAddressPassthrough() {
+    Properties props = new Properties();
+    props.setProperty(HIVE_METASTORE_URIS, "thrift://192.168.1.1:9083");
+    Configuration config = new Configuration();
+
+    Util.updateConfigurationFromProperties(props, config);
+
+    Assertions.assertEquals("thrift://192.168.1.1:9083", config.get(HIVE_METASTORE_URIS));
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

Pre-resolve hostnames in `hive.metastore.uris` to IP before passing to the Hive MetaStore client.

### Why are the changes needed?

Fixes #9517. Hive's `resolveUris()` calls `getCanonicalHostName()` on the configured host, which
in Docker Compose returns FQDNs containing underscores (e.g. `host.network_default`).
`java.net.URI` rejects underscores, causing `URISyntaxException`. Pre-resolving to IP avoids this.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Added unit tests in `TestUtil`.