### PR TITLE
[#11335] setting web v2 ui as default

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,16 +82,18 @@ Clone or download the [Gravitino Playground repository](https://github.com/apach
 
 Press `CTRL+C` to stop.
 
-5. (Optional) Use the new UI
+5. (Optional) Choose UI version
 
-  - To switch to the new UI at runtime: edit `conf/gravitino-env.sh` (or set the environment variable before starting) and set `GRAVITINO_USE_WEB_V2` to `true`:
+  - By default, Gravitino uses the Web V2 UI.
+
+  - To switch back to the legacy v1 UI at runtime, edit `conf/gravitino-env.sh` (or set the environment variable before starting) and set `GRAVITINO_USE_WEB_V2` to `false`:
 
 ```bash
-export GRAVITINO_USE_WEB_V2=true
-./bin/gravitino.sh start
+export GRAVITINO_USE_WEB_V2=false
+./bin/gravitino.sh restart
 ```
 
-  - Alternatively, you can remove the `GRAVITINO_USE_WEB_V2=...` line from `conf/gravitino-env.sh` (the template defaults to `false`); removing that line will revert the service to the legacy UI behavior.
+  - To use Web V2 explicitly, set `GRAVITINO_USE_WEB_V2=true`.
 
 
 ## 🧊 Iceberg REST Catalog

--- a/bin/gravitino.sh.template
+++ b/bin/gravitino.sh.template
@@ -183,23 +183,23 @@ fi
 
 addJarInDir "${GRAVITINO_HOME}/libs"
 
-# By default, prefer starting the legacy (old) UI war if present.
+# By default, prefer starting the new (v2) UI war when GRAVITINO_USE_WEB_V2 is unset.
 # Users may override by setting GRAVITINO_WAR to an explicit path, or
-# set GRAVITINO_USE_WEB_V2=true to prefer the new war when both exist.
+# set GRAVITINO_USE_WEB_V2=false to force the legacy war when both exist.
 if [[ -z "${GRAVITINO_WAR+x}" || -z "${GRAVITINO_WAR}" ]]; then
   # Compose expected war paths based on packaged layout and version
   WAR_V1_PATH="${GRAVITINO_HOME}/web/gravitino-web-${GRAVITINO_VERSION}.war"
   WAR_V2_PATH="${GRAVITINO_HOME}/web-v2/gravitino-web-${GRAVITINO_VERSION}.war"
 
-  if [[ -n "${GRAVITINO_USE_WEB_V2}" && "${GRAVITINO_USE_WEB_V2}" == "true" ]]; then
-    # User explicitly requests new UI if available
+  if [[ "${GRAVITINO_USE_WEB_V2:-true}" == "true" ]]; then
+    # Prefer new UI when enabled or unset
     if [[ -f "${WAR_V2_PATH}" ]]; then
       export GRAVITINO_WAR="${WAR_V2_PATH}"
     elif [[ -f "${WAR_V1_PATH}" ]]; then
       export GRAVITINO_WAR="${WAR_V1_PATH}"
     fi
   else
-    # Default behavior: prefer old UI war
+    # Explicitly disabled v2: prefer old UI war
     if [[ -f "${WAR_V1_PATH}" ]]; then
       export GRAVITINO_WAR="${WAR_V1_PATH}"
     elif [[ -f "${WAR_V2_PATH}" ]]; then

--- a/conf/gravitino-env.sh.template
+++ b/conf/gravitino-env.sh.template
@@ -33,6 +33,7 @@ GRAVITINO_VERSION=GRAVITINO_VERSION_PLACEHOLDER
 #                             # Appended to JAVA_OPTS by launch scripts; set GRAVITINO_MEM to change heap/metaspace sizes.
 
 # UI selection behaviour:
-# - By default this template does not set `GRAVITINO_USE_WEB_V2`, so the container or environment can control which UI is used.
-# - To force the v1 UI, explicitly set it to `false`; to enable the v2 UI, set it to `true` (for example: `export GRAVITINO_USE_WEB_V2=true`).
-# GRAVITINO_USE_WEB_V2=false
+# - Default to the v2 UI when GRAVITINO_USE_WEB_V2 is unset.
+# - If GRAVITINO_USE_WEB_V2 is already provided by container/k8s env, keep that value.
+# - To force the v1 UI, set GRAVITINO_USE_WEB_V2=false.
+export GRAVITINO_USE_WEB_V2=${GRAVITINO_USE_WEB_V2:-true}

--- a/conf/gravitino-env.sh.template
+++ b/conf/gravitino-env.sh.template
@@ -33,7 +33,7 @@ GRAVITINO_VERSION=GRAVITINO_VERSION_PLACEHOLDER
 #                             # Appended to JAVA_OPTS by launch scripts; set GRAVITINO_MEM to change heap/metaspace sizes.
 
 # UI selection behaviour:
-# - Default to the v2 UI when GRAVITINO_USE_WEB_V2 is unset.
-# - If GRAVITINO_USE_WEB_V2 is already provided by container/k8s env, keep that value.
+# - Default to the v2 UI when GRAVITINO_USE_WEB_V2 is unset or empty.
+# - If GRAVITINO_USE_WEB_V2 is already provided (non-empty) by container/k8s env, keep that value.
 # - To force the v1 UI, set GRAVITINO_USE_WEB_V2=false.
-export GRAVITINO_USE_WEB_V2=${GRAVITINO_USE_WEB_V2:-true}
+export GRAVITINO_USE_WEB_V2="${GRAVITINO_USE_WEB_V2:-true}"

--- a/docs/webui-v2.md
+++ b/docs/webui-v2.md
@@ -14,9 +14,11 @@ This document outlines how users can manage metadata within Apache Gravitino usi
 
 [Build](./how-to-build.md#quick-start) and [deploy](./getting-started/index.md#local-workstation) the Gravitino Web UI and open it in a browser at `http://<gravitino-host>:<gravitino-port>`. By default, it is [http://localhost:8090](http://localhost:8090).
 
-## Web V2 (UI Version 1.2.0)
+## Web V2 (UI Version 1.3.0)
 
-Starting with version 1.2.0, Gravitino introduces Web V2. By default, the template does not set `GRAVITINO_USE_WEB_V2`, so the container or environment controls which UI is used. To force the v1 UI, explicitly set it to `false`; to enable the v2 UI, set it to `true` (for example: `export GRAVITINO_USE_WEB_V2=true`). If you want to enable Web V2 from the server env file, set the following environment variable in `conf/gravitino-env.sh` before starting the server:
+Starting with version 1.3.0, Gravitino introduces Web V2. By default, Gravitino uses Web V2 (`GRAVITINO_USE_WEB_V2=true` when unset). To switch back to the legacy v1 UI, explicitly set `GRAVITINO_USE_WEB_V2=false`. To force Web V2 explicitly, set it to `true`.
+
+If you want to configure this from the server env file, set the following environment variable in `conf/gravitino-env.sh` before starting the server:
 
 ```bash
 # In <path-to-gravitino>/conf/gravitino-env.sh
@@ -31,7 +33,7 @@ After changing this value, restart the Gravitino server for the change to take e
 
 ## Web V2
 
-The sections below describe the Web V2 (requires `GRAVITINO_USE_WEB_V2=true` to enable).
+The sections below describe the Web V2. This is the default UI; set `GRAVITINO_USE_WEB_V2=false` to use the legacy v1 UI.
 The Web V2 introduces additional modules (such as Jobs, Job Templates, Data Compliance, and Access) and expands table creation and editing to support more complex data types across providers.
 
 Data Compliance includes **Tags** and **Policies**. The **Access** module is visible only when `gravitino.authorization.enable=true` and includes **Users**, **User Groups**, and **Roles**.


### PR DESCRIPTION
### What changes were proposed in this pull request?

1. set `GRAVITINO_USE_WEB_V2=${GRAVITINO_USE_WEB_V2:-true}`
2. update comment

<img width="2684" height="1384" alt="image" src="https://github.com/user-attachments/assets/a3234612-d0a2-4120-8c36-d215a0c35765" />

### Why are the changes needed?
N/A

Fix: #11335

### Does this PR introduce _any_ user-facing change?
N/A

### How was this patch tested?
manually
