### PR TITLE
[#7189] feat(client): Add password support to simple authentication

### DIFF
--- a/clients/client-java/src/main/java/org/apache/gravitino/client/GravitinoClientBase.java
+++ b/clients/client-java/src/main/java/org/apache/gravitino/client/GravitinoClientBase.java
@@ -277,6 +277,20 @@ public abstract class GravitinoClientBase implements Closeable {
     }
 
     /**
+     * Sets the simple mode authentication for Gravitino with a specific username and password.
+     *
+     * @param userName The username of the user.
+     * @param password The password of the user.
+     * @return This Builder instance for method chaining.
+     */
+    public Builder<T> withSimpleAuth(String userName, String password) {
+      Preconditions.checkArgument(StringUtils.isNotBlank(userName), "userName can't be blank");
+      Preconditions.checkArgument(password != null, "password can't be null");
+      this.authDataProvider = new SimpleTokenProvider(userName, password);
+      return this;
+    }
+
+    /**
      * Sets HTTP Basic authentication for Gravitino.
      *
      * @param username The username for Basic authentication.

--- a/clients/client-java/src/main/java/org/apache/gravitino/client/SimpleTokenProvider.java
+++ b/clients/client-java/src/main/java/org/apache/gravitino/client/SimpleTokenProvider.java
@@ -24,35 +24,49 @@ import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import org.apache.gravitino.auth.AuthConstants;
 
-/* *
- * SimpleAuthProvider will use the environment variable `GRAVITINO_USER` or
- * the user of the system to generate a basic token for every request.
+/**
+ * SimpleAuthProvider will use the environment variable {@code GRAVITINO_USER} or the user of the
+ * system to generate a basic token for every request.
  */
 final class SimpleTokenProvider implements AuthDataProvider {
 
   private final byte[] token;
 
+  /** Creates a SimpleTokenProvider using the {@code GRAVITINO_USER} env var or system username. */
   public SimpleTokenProvider() {
     String gravitinoUser = System.getenv("GRAVITINO_USER");
     if (gravitinoUser == null) {
       gravitinoUser = System.getProperty("user.name");
     }
-    this.token = buildToken(gravitinoUser);
+    this.token = buildToken(gravitinoUser, "dummy");
   }
 
+  /**
+   * Creates a SimpleTokenProvider with an explicit username.
+   *
+   * @param gravitinoUser The username to authenticate with.
+   */
   public SimpleTokenProvider(String gravitinoUser) {
-    this.token = buildToken(gravitinoUser);
+    this.token = buildToken(gravitinoUser, "dummy");
   }
 
-  private byte[] buildToken(String gravitinoUser) {
-    String userInformation = gravitinoUser + ":dummy";
-    byte[] token =
-        (AuthConstants.AUTHORIZATION_BASIC_HEADER
-                + new String(
-                    Base64.getEncoder().encode(userInformation.getBytes(StandardCharsets.UTF_8)),
-                    StandardCharsets.UTF_8))
-            .getBytes(StandardCharsets.UTF_8);
-    return token;
+  /**
+   * Creates a SimpleTokenProvider with an explicit username and password.
+   *
+   * @param gravitinoUser The username to authenticate with.
+   * @param password The password to authenticate with.
+   */
+  public SimpleTokenProvider(String gravitinoUser, String password) {
+    this.token = buildToken(gravitinoUser, password);
+  }
+
+  private static byte[] buildToken(String gravitinoUser, String password) {
+    String userInformation = gravitinoUser + ":" + password;
+    return (AuthConstants.AUTHORIZATION_BASIC_HEADER
+            + new String(
+                Base64.getEncoder().encode(userInformation.getBytes(StandardCharsets.UTF_8)),
+                StandardCharsets.UTF_8))
+        .getBytes(StandardCharsets.UTF_8);
   }
 
   @Override

--- a/clients/client-java/src/test/java/org/apache/gravitino/client/TestSimpleTokenProvider.java
+++ b/clients/client-java/src/test/java/org/apache/gravitino/client/TestSimpleTokenProvider.java
@@ -50,4 +50,38 @@ public class TestSimpleTokenProvider {
       }
     }
   }
+
+  @Test
+  public void testAuthenticationWithPassword() throws IOException {
+    try (AuthDataProvider provider = new SimpleTokenProvider("alice", "secret")) {
+      Assertions.assertTrue(provider.hasTokenData());
+      String token = new String(provider.getTokenData(), StandardCharsets.UTF_8);
+      Assertions.assertTrue(token.startsWith(AuthConstants.AUTHORIZATION_BASIC_HEADER));
+      String decoded =
+          new String(
+              Base64.getDecoder()
+                  .decode(
+                      token
+                          .substring(AuthConstants.AUTHORIZATION_BASIC_HEADER.length())
+                          .getBytes(StandardCharsets.UTF_8)),
+              StandardCharsets.UTF_8);
+      Assertions.assertEquals("alice:secret", decoded);
+    }
+  }
+
+  @Test
+  public void testSingleArgConstructorUsesDummyPassword() throws IOException {
+    try (AuthDataProvider provider = new SimpleTokenProvider("bob")) {
+      String token = new String(provider.getTokenData(), StandardCharsets.UTF_8);
+      String decoded =
+          new String(
+              Base64.getDecoder()
+                  .decode(
+                      token
+                          .substring(AuthConstants.AUTHORIZATION_BASIC_HEADER.length())
+                          .getBytes(StandardCharsets.UTF_8)),
+              StandardCharsets.UTF_8);
+      Assertions.assertEquals("bob:dummy", decoded);
+    }
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Added a new `withSimpleAuth(String userName, String password)` overload to `GravitinoClientBase.Builder` and a corresponding `SimpleTokenProvider(String, String)` constructor, allowing callers to supply an explicit password when using simple authentication.

Previously, `withSimpleAuth` always encoded `username:dummy` as the Basic auth credential, with no way to pass a real password.

### Why are the changes needed?

The simple auth path hardcoded `"dummy"` as the password in `SimpleTokenProvider.buildToken()`. There was no API to provide an actual password on the client side, which blocked use cases where the server or a proxy expects a real credential in the Basic auth header.

Fix: #7189

### Does this PR introduce _any_ user-facing change?

Yes.
* New builder method: `GravitinoClientBase.Builder.withSimpleAuth(String userName, String password)`
* Existing `withSimpleAuth()` and `withSimpleAuth(String userName)` overloads are unchanged and continue to use `"dummy"` as the password for backwards compatibility.

### How was this patch tested?

Unit tests added to `TestSimpleTokenProvider`:
* `testAuthenticationWithPassword` verifies new `SimpleTokenProvider("alice", "secret")` encodes `alice:secret` 
* `testSingleArgConstructorUsesDummyPassword` verifies the existing single-arg path still encodes `bob:dummy`

Run with: 
`./gradlew :clients:client-java:test -PskipITs`
