### PR TITLE
[#11342] web-v2(UI): glue catalog table follow up issue

### DIFF
--- a/web-v2/web/src/app/catalogs/rightContent/CreateSchemaDialog.js
+++ b/web-v2/web/src/app/catalogs/rightContent/CreateSchemaDialog.js
@@ -265,7 +265,16 @@ export default function CreateSchemaDialog({ ...props }) {
                   rules={[
                     { required: true },
                     { type: 'string', max: 64 },
-                    { pattern: isIcebergJdbcCatalog ? dynamicSchemaNameRegex : new RegExp(nameRegex) }
+                    { pattern: isIcebergJdbcCatalog ? dynamicSchemaNameRegex : new RegExp(nameRegex) },
+                    {
+                      validator: (_, value) => {
+                        if (!isGlueProvider || !value || !value.includes('-')) {
+                          return Promise.resolve()
+                        }
+
+                        return Promise.reject(new Error('Glue schema name does not support hyphen (-).'))
+                      }
+                    }
                   ]}
                   messageVariables={{ label: 'schema name' }}
                 >

--- a/web-v2/web/src/app/catalogs/rightContent/CreateTableDialog.js
+++ b/web-v2/web/src/app/catalogs/rightContent/CreateTableDialog.js
@@ -137,6 +137,27 @@ export default function CreateTableDialog({ ...props }) {
   const isSupportDefaultValue = defaultValueSupported.includes(provider)
   const dispatch = useAppDispatch()
 
+  const getActiveTableDefaultProps = () => {
+    const props = tableDefaultProps[provider] || []
+    if (provider !== 'glue') {
+      return props
+    }
+
+    const tableFormat = values?.['table-format']?.toLowerCase()
+
+    return props.filter(prop => {
+      if (!prop.hide?.length) {
+        return true
+      }
+
+      if (!tableFormat) {
+        return false
+      }
+
+      return !prop.hide.map(item => item.toLowerCase()).includes(tableFormat)
+    })
+  }
+
   useResetFormOnCloseModal({
     form,
     open
@@ -749,8 +770,9 @@ export default function CreateTableDialog({ ...props }) {
             submitData.columns.forEach(col => {
               delete col.uniqueId
             })
-            if (tableDefaultProps[provider]) {
-              tableDefaultProps[provider].forEach(item => {
+            const activeDefaultProps = getActiveTableDefaultProps()
+            if (activeDefaultProps.length) {
+              activeDefaultProps.forEach(item => {
                 if (values[item.key]) {
                   submitData.properties[item.key] = values[item.key]
                 }
@@ -1570,7 +1592,7 @@ export default function CreateTableDialog({ ...props }) {
                     <div className='flex flex-col gap-2'>
                       {!editTable &&
                         tableDefaultProps[provider] &&
-                        tableDefaultProps[provider].map((prop, idx) => {
+                        getActiveTableDefaultProps().map((prop, idx) => {
                           const isLocationRequired =
                             prop.key === 'location' &&
                             provider === 'lakehouse-generic' &&

--- a/web-v2/web/src/config/catalog.js
+++ b/web-v2/web/src/config/catalog.js
@@ -140,6 +140,11 @@ export const tableDefaultProps = {
   ],
   glue: [
     {
+      key: 'location',
+      defaultValue: '',
+      description: 'Table storage location, e.g. s3://my-bucket/path'
+    },
+    {
       key: 'table-format',
       defaultValue: '',
       select: ['ICEBERG', 'HIVE'],
@@ -148,16 +153,19 @@ export const tableDefaultProps = {
     {
       key: 'metadata_location',
       defaultValue: '',
+      hide: ['hive'],
       description: 'Iceberg metadata file path'
     },
     {
       key: 'format',
       defaultValue: '',
+      hide: ['iceberg'],
       select: ['TEXTFILE', 'SEQUENCEFILE', 'RCFILE', 'ORC', 'PARQUET', 'AVRO', 'JSON', 'CSV', 'REGEX']
     },
     {
       key: 'input-format',
       defaultValue: 'org.apache.hadoop.mapred.TextInputFormat',
+      hide: ['iceberg'],
       defaultValueOptions: {
         TEXTFILE: 'org.apache.hadoop.mapred.TextInputFormat',
         SEQUENCEFILE: 'org.apache.hadoop.mapred.SequenceFileInputFormat',
@@ -173,6 +181,7 @@ export const tableDefaultProps = {
     {
       key: 'output-format',
       defaultValue: 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat',
+      hide: ['iceberg'],
       defaultValueOptions: {
         TEXTFILE: 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat',
         SEQUENCEFILE: 'org.apache.hadoop.mapred.SequenceFileOutputFormat',
@@ -188,6 +197,7 @@ export const tableDefaultProps = {
     {
       key: 'serde-lib',
       defaultValue: 'org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe',
+      hide: ['iceberg'],
       defaultValueOptions: {
         TEXTFILE: 'org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe',
         SEQUENCEFILE: 'org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe',

--- a/web-v2/web/src/config/catalog.js
+++ b/web-v2/web/src/config/catalog.js
@@ -158,13 +158,13 @@ export const tableDefaultProps = {
     },
     {
       key: 'format',
-      defaultValue: '',
+      defaultValue: 'PARQUET',
       hide: ['iceberg'],
       select: ['TEXTFILE', 'SEQUENCEFILE', 'RCFILE', 'ORC', 'PARQUET', 'AVRO', 'JSON', 'CSV', 'REGEX']
     },
     {
       key: 'input-format',
-      defaultValue: 'org.apache.hadoop.mapred.TextInputFormat',
+      defaultValue: 'org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat',
       hide: ['iceberg'],
       defaultValueOptions: {
         TEXTFILE: 'org.apache.hadoop.mapred.TextInputFormat',
@@ -180,7 +180,7 @@ export const tableDefaultProps = {
     },
     {
       key: 'output-format',
-      defaultValue: 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat',
+      defaultValue: 'org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat',
       hide: ['iceberg'],
       defaultValueOptions: {
         TEXTFILE: 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat',
@@ -196,7 +196,7 @@ export const tableDefaultProps = {
     },
     {
       key: 'serde-lib',
-      defaultValue: 'org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe',
+      defaultValue: 'org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe',
       hide: ['iceberg'],
       defaultValueOptions: {
         TEXTFILE: 'org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe',


### PR DESCRIPTION
### What changes were proposed in this pull request?

1. glue schema name not support hyphen (-)
2. glue table props table-format mapping props
3. add location prop for glue table

<img width="1872" height="1094" alt="image" src="https://github.com/user-attachments/assets/c08bbd2d-7bf6-4b72-bf59-daca2c0a98bc" />
<img width="2272" height="1472" alt="image" src="https://github.com/user-attachments/assets/711f8aea-7796-4030-bf62-e18e2b8f2d49" />
<img width="2076" height="1438" alt="image" src="https://github.com/user-attachments/assets/9910ffad-46e5-4e1a-8273-a3d26737f14f" />


### Why are the changes needed?
N/A

Fix: #11342

### Does this PR introduce _any_ user-facing change?
N/A

### How was this patch tested?
manually
