### PR TITLE
[MINOR] fix(helm): Remove hardcoded version in chart unit tests

### DIFF
--- a/dev/charts/gravitino-iceberg-rest-server/tests/deployment_test.yaml
+++ b/dev/charts/gravitino-iceberg-rest-server/tests/deployment_test.yaml
@@ -45,9 +45,9 @@ tests:
       - equal:
           path: spec.template.spec.serviceAccountName
           value: default
-      - equal:
+      - matchRegex:
           path: spec.template.spec.containers[0].image
-          value: apache/gravitino-iceberg-rest:1.4.0-SNAPSHOT
+          pattern: "^apache/gravitino-iceberg-rest:.+"
       - contains:
           path: spec.template.spec.containers[0].env
           content:

--- a/dev/charts/gravitino-lance-rest-server/tests/deployment_test.yaml
+++ b/dev/charts/gravitino-lance-rest-server/tests/deployment_test.yaml
@@ -44,9 +44,9 @@ tests:
       - equal:
           path: spec.template.spec.serviceAccountName
           value: default
-      - equal:
+      - matchRegex:
           path: spec.template.spec.containers[0].image
-          value: apache/gravitino-lance-rest:1.4.0-SNAPSHOT
+          pattern: "^apache/gravitino-lance-rest:.+"
       - contains:
           path: spec.template.spec.containers[0].env
           content:


### PR DESCRIPTION
### What changes were proposed in this pull request?

Replace hardcoded SNAPSHOT version assertions in Helm chart unit tests with matchRegex pattern matching, avoiding CI failures on every version bump.

Changed files:

deployment_test.yaml
deployment_test.yaml
Both files changed from:
```
- equal:
    path: spec.template.spec.containers[0].image
    value: apache/gravitino-xxx:1.3.0-SNAPSHOT
```
to:

```
- matchRegex:
    path: spec.template.spec.containers[0].image
    pattern: "^apache/gravitino-xxx:.+"
```
This aligns with the existing approach in 
deployment_test.yaml


### Why are the changes needed?

The chart unit tests hardcode SNAPSHOT version strings (e.g., 1.3.0-SNAPSHOT). After every version bump, these tests fail and require manual updates, adding unnecessary maintenance burden. For example, the current CI failure:
```
Expected: apache/gravitino-iceberg-rest:1.3.0-SNAPSHOT
Actual:   apache/gravitino-iceberg-rest:1.3.1-SNAPSHOT
```
Using matchRegex ensures the test validates the image repository is correct and a tag is present, without coupling to a specific version.

### Does this PR introduce _any_ user-facing change?

No.


### How was this patch tested?

helm unittest --with-subchart=false dev/charts/gravitino-iceberg-rest-server
helm unittest --with-subchart=false dev/charts/gravitino-lance-rest-server
helm unittest --with-subchart=false dev/charts/gravitino

