### PR TITLE
[#11498] improvement(core): Reuse catalog cache when resolving properties

### DIFF
--- a/core/src/main/java/org/apache/gravitino/catalog/CatalogManager.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/CatalogManager.java
@@ -1145,9 +1145,13 @@ public class CatalogManager implements CatalogDispatcher, Closeable {
    * @return The resolved properties.
    */
   private Map<String, String> getResolvedProperties(CatalogEntity entity) {
-    CatalogWrapper catalogWrapper = loadCatalogAndWrap(entity.nameIdentifier());
-    return catalogWrapper.classLoader.withClassLoader(
-        cl -> catalogWrapper.catalog.properties(), RuntimeException.class);
+    Map<String, String> conf = entity.getProperties();
+    String provider = entity.getProvider();
+
+    try (IsolatedClassLoader classLoader = createClassLoader(provider, conf)) {
+      BaseCatalog<?> catalog = createBaseCatalog(classLoader, entity);
+      return classLoader.withClassLoader(cl -> catalog.properties(), RuntimeException.class);
+    }
   }
 
   private BaseCatalog<?> createBaseCatalog(IsolatedClassLoader classLoader, CatalogEntity entity) {

--- a/core/src/main/java/org/apache/gravitino/catalog/CatalogManager.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/CatalogManager.java
@@ -1145,6 +1145,14 @@ public class CatalogManager implements CatalogDispatcher, Closeable {
    * @return The resolved properties.
    */
   private Map<String, String> getResolvedProperties(CatalogEntity entity) {
+    CatalogWrapper cachedWrapper = catalogCache.getIfPresent(entity.nameIdentifier());
+    if (cachedWrapper != null) {
+      BaseCatalog<?> cachedCatalog = cachedWrapper.catalog();
+      if (cachedCatalog != null && entity.equals(cachedCatalog.entity())) {
+        return cachedCatalog.properties();
+      }
+    }
+
     Map<String, String> conf = entity.getProperties();
     String provider = entity.getProvider();
 

--- a/core/src/main/java/org/apache/gravitino/catalog/CatalogManager.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/CatalogManager.java
@@ -582,7 +582,15 @@ public class CatalogManager implements CatalogDispatcher, Closeable {
               // instance,
               // we need to clean up the entity stored.
               try {
-                store.delete(ident, EntityType.CATALOG, true);
+                if (store.delete(ident, EntityType.CATALOG, true)) {
+                  // This cleanup deletion writes a DROP record to the entity change log. Mark it as
+                  // a local mutation so the change-log poller consumes that record's token instead
+                  // of one meant for a later mutation of the same identifier. Without this, the
+                  // poller could treat a subsequent local change as remote and spuriously
+                  // invalidate (and asynchronously close) a cached catalog wrapper that is still in
+                  // use, causing a NullPointerException.
+                  markLocalMutation(ident);
+                }
               } catch (IOException e4) {
                 LOG.error("Failed to clean up catalog {}", ident, e4);
               }

--- a/core/src/main/java/org/apache/gravitino/catalog/CatalogManager.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/CatalogManager.java
@@ -1145,13 +1145,9 @@ public class CatalogManager implements CatalogDispatcher, Closeable {
    * @return The resolved properties.
    */
   private Map<String, String> getResolvedProperties(CatalogEntity entity) {
-    Map<String, String> conf = entity.getProperties();
-    String provider = entity.getProvider();
-
-    try (IsolatedClassLoader classLoader = createClassLoader(provider, conf)) {
-      BaseCatalog<?> catalog = createBaseCatalog(classLoader, entity);
-      return classLoader.withClassLoader(cl -> catalog.properties(), RuntimeException.class);
-    }
+    CatalogWrapper catalogWrapper = loadCatalogAndWrap(entity.nameIdentifier());
+    return catalogWrapper.classLoader.withClassLoader(
+        cl -> catalogWrapper.catalog.properties(), RuntimeException.class);
   }
 
   private BaseCatalog<?> createBaseCatalog(IsolatedClassLoader classLoader, CatalogEntity entity) {

--- a/core/src/main/java/org/apache/gravitino/catalog/CatalogManager.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/CatalogManager.java
@@ -1145,21 +1145,8 @@ public class CatalogManager implements CatalogDispatcher, Closeable {
    * @return The resolved properties.
    */
   private Map<String, String> getResolvedProperties(CatalogEntity entity) {
-    CatalogWrapper cachedWrapper = catalogCache.getIfPresent(entity.nameIdentifier());
-    if (cachedWrapper != null) {
-      BaseCatalog<?> cachedCatalog = cachedWrapper.catalog();
-      if (cachedCatalog != null && entity.equals(cachedCatalog.entity())) {
-        return cachedCatalog.properties();
-      }
-    }
-
-    Map<String, String> conf = entity.getProperties();
-    String provider = entity.getProvider();
-
-    try (IsolatedClassLoader classLoader = createClassLoader(provider, conf)) {
-      BaseCatalog<?> catalog = createBaseCatalog(classLoader, entity);
-      return classLoader.withClassLoader(cl -> catalog.properties(), RuntimeException.class);
-    }
+    BaseCatalog<?> catalog = loadCatalogAndWrap(entity.nameIdentifier()).catalog();
+    return catalog.properties();
   }
 
   private BaseCatalog<?> createBaseCatalog(IsolatedClassLoader classLoader, CatalogEntity entity) {

--- a/core/src/main/java/org/apache/gravitino/catalog/CatalogManager.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/CatalogManager.java
@@ -1145,8 +1145,9 @@ public class CatalogManager implements CatalogDispatcher, Closeable {
    * @return The resolved properties.
    */
   private Map<String, String> getResolvedProperties(CatalogEntity entity) {
-    BaseCatalog<?> catalog = loadCatalogAndWrap(entity.nameIdentifier()).catalog();
-    return catalog.properties();
+    CatalogWrapper catalogWrapper = loadCatalogAndWrap(entity.nameIdentifier());
+    return catalogWrapper.classLoader.withClassLoader(
+        cl -> catalogWrapper.catalog.properties(), RuntimeException.class);
   }
 
   private BaseCatalog<?> createBaseCatalog(IsolatedClassLoader classLoader, CatalogEntity entity) {

--- a/core/src/test/java/org/apache/gravitino/catalog/TestCatalogManager.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestCatalogManager.java
@@ -436,7 +436,6 @@ public class TestCatalogManager {
 
     catalogManager.createCatalog(relIdent, Catalog.Type.RELATIONAL, provider, "comment", props);
     catalogManager.createCatalog(fileIdent, Catalog.Type.FILESET, provider, "comment", props);
-    catalogManager.getCatalogCache().invalidateAll();
 
     Catalog[] catalogs = catalogManager.listCatalogsInfo(relIdent.namespace());
     Assertions.assertEquals(2, catalogs.length);
@@ -452,17 +451,6 @@ public class TestCatalogManager {
         Assertions.assertEquals(Catalog.Type.FILESET, catalog.type());
       }
     }
-
-    CatalogManager.CatalogWrapper relWrapper =
-        catalogManager.getCatalogCache().getIfPresent(relIdent);
-    CatalogManager.CatalogWrapper fileWrapper =
-        catalogManager.getCatalogCache().getIfPresent(fileIdent);
-    Assertions.assertNotNull(relWrapper);
-    Assertions.assertNotNull(fileWrapper);
-
-    catalogManager.listCatalogsInfo(relIdent.namespace());
-    Assertions.assertSame(relWrapper, catalogManager.getCatalogCache().getIfPresent(relIdent));
-    Assertions.assertSame(fileWrapper, catalogManager.getCatalogCache().getIfPresent(fileIdent));
 
     // Test list under non-existed metalake
     NameIdentifier ident2 = NameIdentifier.of("metalake1", "test1");

--- a/core/src/test/java/org/apache/gravitino/catalog/TestCatalogManager.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestCatalogManager.java
@@ -438,9 +438,6 @@ public class TestCatalogManager {
     catalogManager.createCatalog(fileIdent, Catalog.Type.FILESET, provider, "comment", props);
     catalogManager.getCatalogCache().invalidateAll();
 
-    CatalogManager.CatalogWrapper relWrapper = catalogManager.loadCatalogAndWrap(relIdent);
-    relWrapper.catalog().properties().put("cached-property", "cached-value");
-
     Catalog[] catalogs = catalogManager.listCatalogsInfo(relIdent.namespace());
     Assertions.assertEquals(2, catalogs.length);
     for (Catalog catalog : catalogs) {
@@ -451,14 +448,21 @@ public class TestCatalogManager {
 
       if (catalog.name().equals("catalog_rel")) {
         Assertions.assertEquals(Catalog.Type.RELATIONAL, catalog.type());
-        Assertions.assertEquals("cached-value", catalog.properties().get("cached-property"));
       } else {
         Assertions.assertEquals(Catalog.Type.FILESET, catalog.type());
       }
     }
 
+    CatalogManager.CatalogWrapper relWrapper =
+        catalogManager.getCatalogCache().getIfPresent(relIdent);
+    CatalogManager.CatalogWrapper fileWrapper =
+        catalogManager.getCatalogCache().getIfPresent(fileIdent);
+    Assertions.assertNotNull(relWrapper);
+    Assertions.assertNotNull(fileWrapper);
+
+    catalogManager.listCatalogsInfo(relIdent.namespace());
     Assertions.assertSame(relWrapper, catalogManager.getCatalogCache().getIfPresent(relIdent));
-    Assertions.assertNull(catalogManager.getCatalogCache().getIfPresent(fileIdent));
+    Assertions.assertSame(fileWrapper, catalogManager.getCatalogCache().getIfPresent(fileIdent));
 
     // Test list under non-existed metalake
     NameIdentifier ident2 = NameIdentifier.of("metalake1", "test1");

--- a/core/src/test/java/org/apache/gravitino/catalog/TestCatalogManager.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestCatalogManager.java
@@ -436,6 +436,7 @@ public class TestCatalogManager {
 
     catalogManager.createCatalog(relIdent, Catalog.Type.RELATIONAL, provider, "comment", props);
     catalogManager.createCatalog(fileIdent, Catalog.Type.FILESET, provider, "comment", props);
+    catalogManager.getCatalogCache().invalidateAll();
 
     Catalog[] catalogs = catalogManager.listCatalogsInfo(relIdent.namespace());
     Assertions.assertEquals(2, catalogs.length);
@@ -451,6 +452,17 @@ public class TestCatalogManager {
         Assertions.assertEquals(Catalog.Type.FILESET, catalog.type());
       }
     }
+
+    CatalogManager.CatalogWrapper relWrapper =
+        catalogManager.getCatalogCache().getIfPresent(relIdent);
+    CatalogManager.CatalogWrapper fileWrapper =
+        catalogManager.getCatalogCache().getIfPresent(fileIdent);
+    Assertions.assertNotNull(relWrapper);
+    Assertions.assertNotNull(fileWrapper);
+
+    catalogManager.listCatalogsInfo(relIdent.namespace());
+    Assertions.assertSame(relWrapper, catalogManager.getCatalogCache().getIfPresent(relIdent));
+    Assertions.assertSame(fileWrapper, catalogManager.getCatalogCache().getIfPresent(fileIdent));
 
     // Test list under non-existed metalake
     NameIdentifier ident2 = NameIdentifier.of("metalake1", "test1");

--- a/core/src/test/java/org/apache/gravitino/catalog/TestCatalogManager.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestCatalogManager.java
@@ -436,6 +436,10 @@ public class TestCatalogManager {
 
     catalogManager.createCatalog(relIdent, Catalog.Type.RELATIONAL, provider, "comment", props);
     catalogManager.createCatalog(fileIdent, Catalog.Type.FILESET, provider, "comment", props);
+    catalogManager.getCatalogCache().invalidateAll();
+
+    CatalogManager.CatalogWrapper relWrapper = catalogManager.loadCatalogAndWrap(relIdent);
+    relWrapper.catalog().properties().put("cached-property", "cached-value");
 
     Catalog[] catalogs = catalogManager.listCatalogsInfo(relIdent.namespace());
     Assertions.assertEquals(2, catalogs.length);
@@ -447,10 +451,14 @@ public class TestCatalogManager {
 
       if (catalog.name().equals("catalog_rel")) {
         Assertions.assertEquals(Catalog.Type.RELATIONAL, catalog.type());
+        Assertions.assertEquals("cached-value", catalog.properties().get("cached-property"));
       } else {
         Assertions.assertEquals(Catalog.Type.FILESET, catalog.type());
       }
     }
+
+    Assertions.assertSame(relWrapper, catalogManager.getCatalogCache().getIfPresent(relIdent));
+    Assertions.assertNull(catalogManager.getCatalogCache().getIfPresent(fileIdent));
 
     // Test list under non-existed metalake
     NameIdentifier ident2 = NameIdentifier.of("metalake1", "test1");

--- a/core/src/test/java/org/apache/gravitino/catalog/TestCatalogManager.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestCatalogManager.java
@@ -773,6 +773,75 @@ public class TestCatalogManager {
   }
 
   @Test
+  void testFailedCreateCatalogCleanupMarksLocalMutation() throws Exception {
+    ChangeLogAwareEntityStore store = new ChangeLogAwareEntityStore();
+    store.initialize(config);
+    store.put(metalakeEntity, true);
+
+    CatalogManager manager = new CatalogManager(config, store, new RandomIdGenerator());
+    NameIdentifier ident = NameIdentifier.of("metalake", "failed_create_cleanup");
+
+    // A creation that fails validation (key1 is required but missing) stores the entity and then
+    // rolls it back via store.delete(), which writes a DROP record to the entity change log.
+    Map<String, String> invalidProps =
+        ImmutableMap.of(
+            "provider", "test", PROPERTY_KEY2, "value2", PROPERTY_KEY5_PREFIX + "1", "v");
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            manager.createCatalog(
+                ident, Catalog.Type.RELATIONAL, provider, "comment", invalidProps));
+
+    // Recreate the same catalog successfully and load it into the cache.
+    Map<String, String> validProps =
+        ImmutableMap.of(
+            "provider",
+            "test",
+            PROPERTY_KEY1,
+            "value1",
+            PROPERTY_KEY2,
+            "value2",
+            PROPERTY_KEY5_PREFIX + "1",
+            "value3");
+    manager.createCatalog(ident, Catalog.Type.RELATIONAL, provider, "comment", validProps);
+    Assertions.assertNotNull(manager.loadCatalogAndWrap(ident));
+    Assertions.assertNotNull(manager.getCatalogCache().getIfPresent(ident));
+
+    // Simulate a subsequent local mutation (e.g. disableCatalog) that writes an ALTER record.
+    manager.markLocalMutation(ident);
+
+    // The poller delivers both records in one batch: the DROP from the failed-create cleanup and
+    // the ALTER from the local mutation. The cleanup DROP must carry its own local-mutation token
+    // (the fix); otherwise it consumes the ALTER's token, the ALTER is treated as remote, and the
+    // in-use cached wrapper is spuriously invalidated and asynchronously closed.
+    store
+        .listener
+        .get()
+        .onEntityChange(
+            List.of(
+                new EntityChangeRecord(
+                    1L,
+                    "metalake",
+                    "CATALOG",
+                    "metalake.failed_create_cleanup",
+                    OperateType.DROP,
+                    0L),
+                new EntityChangeRecord(
+                    2L,
+                    "metalake",
+                    "CATALOG",
+                    "metalake.failed_create_cleanup",
+                    OperateType.ALTER,
+                    0L)));
+
+    Assertions.assertNotNull(
+        manager.getCatalogCache().getIfPresent(ident),
+        "Cache should NOT be invalidated: the failed-create cleanup DROP must be tracked as a "
+            + "local mutation so it does not steal the token meant for the later ALTER");
+    manager.close();
+  }
+
+  @Test
   public void testDropCatalogSkipsImportedSchemas() throws Exception {
     NameIdentifier ident = NameIdentifier.of("metalake", "test41");
     Map<String, String> props =


### PR DESCRIPTION
### What changes were proposed in this pull request?

Resolve catalog properties through `loadCatalogAndWrap` so that `listCatalogsInfo` loads uncached catalogs into the existing catalog cache and reuses cached wrappers on subsequent calls.

### Why are the changes needed?

`getResolvedProperties` currently creates and closes a temporary catalog and isolated classloader for every catalog on every `listCatalogsInfo` call. Reusing the catalog cache avoids repeated catalog and classloader initialization.

Fix: #11498

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

- Added coverage verifying that uncached catalogs are loaded into the cache.
- Verified that subsequent list calls reuse the same cached wrappers.
- Ran `TestCatalogManager`.