### PR TITLE
[#10457][followup]fix(deps): Exclude log4j 1.x globally (CVE-2020-9493)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -342,6 +342,10 @@ subprojects {
   configurations.all {
     resolutionStrategy.force("commons-beanutils:commons-beanutils:$commonsBeanutilsVersion")
     resolutionStrategy.force("org.xerial.snappy:snappy-java:$snappyJavaVersion")
+
+    // Exclude log4j 1.x (CVE-2020-9493, CVSS 9.8) pulled transitively by Hive and Hadoop.
+    // The safe log4j-1.2-api bridge from Log4j 2.x is already included in the log4j bundle.
+    exclude(group = "log4j", module = "log4j")
   }
 
   repositories {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add a global `exclude(group = "log4j", module = "log4j")` in the root `configurations.all` block to prevent the vulnerable Log4j 1.x artifact from being resolved anywhere in the project.

### Why are the changes needed?

Hive 2.3.9 and Hadoop 2.10.2 transitively pull in `log4j:log4j:1.2.17`, which is vulnerable to [CVE-2020-9493](https://nvd.nist.gov/vuln/detail/CVE-2020-9493).

The safe `log4j-1.2-api` bridge from Log4j 2.x is already included in the log4j bundle (`libs.versions.toml`), so this exclusion does not break any logging functionality. No source files in the project import `org.apache.log4j`.

PR #10465 already excludes `log4j` from `hive-metastore2-libs` and `hive-metastore3-libs`, but `log4j:log4j:1.2.17` is still resolved as a transitive **test** dependency in `catalog-hive` and `catalog-lakehouse-paimon` (via Hadoop's `slf4j-log4j12` → `log4j:log4j`). It does not end up in the distribution package, but it does get downloaded to `~/.gradle/caches/` during builds, triggering vulnerability scanners on developer machines.

This global exclusion provides defense-in-depth: it removes the vulnerable JAR from all configurations (including test) and prevents future modules from accidentally pulling it in.

Followup to #10465.

### Does this PR introduce _any_ user-facing change?

No. This only removes a vulnerable transitive dependency that is already replaced by the `log4j-1.2-api` bridge.

### How was this patch tested?

1. Verified `./gradlew :catalogs:hive-metastore-common:compileJava :catalogs:hive-metastore2-libs:compileJava :catalogs:hive-metastore3-libs:compileJava :catalogs:catalog-hive:compileJava` passes (BUILD SUCCESSFUL).
2. Confirmed `log4j:log4j` no longer appears in the dependency tree.
3. Confirmed zero source imports of `org.apache.log4j` across the entire project.