### PR TITLE
[Cherry-pick to branch-1.3] [MINOR] fix(helm): Remove hardcoded version in chart unit tests (#11494)

### DIFF
--- a/dev/charts/gravitino-iceberg-rest-server/tests/deployment_test.yaml
+++ b/dev/charts/gravitino-iceberg-rest-server/tests/deployment_test.yaml
@@ -47,11 +47,7 @@ tests:
           value: default
       - matchRegex:
           path: spec.template.spec.containers[0].image
-<<<<<<< HEAD
-          value: apache/gravitino-iceberg-rest:1.3.0-SNAPSHOT
-=======
           pattern: "^apache/gravitino-iceberg-rest:.+"
->>>>>>> 3b1249548 ([MINOR] fix(helm): Remove hardcoded version in chart unit tests (#11494))
       - contains:
           path: spec.template.spec.containers[0].env
           content:

--- a/dev/charts/gravitino-lance-rest-server/tests/deployment_test.yaml
+++ b/dev/charts/gravitino-lance-rest-server/tests/deployment_test.yaml
@@ -46,11 +46,7 @@ tests:
           value: default
       - matchRegex:
           path: spec.template.spec.containers[0].image
-<<<<<<< HEAD
-          value: apache/gravitino-lance-rest:1.3.0-SNAPSHOT
-=======
           pattern: "^apache/gravitino-lance-rest:.+"
->>>>>>> 3b1249548 ([MINOR] fix(helm): Remove hardcoded version in chart unit tests (#11494))
       - contains:
           path: spec.template.spec.containers[0].env
           content:


### PR DESCRIPTION
Cherry-pick Information:

Original commit: https://github.com/apache/gravitino/commit/3b1249548ee7fc45e5cd147cbb4a8190c0896eb6
Target branch: branch-1.3
Status: ⚠️ Has conflicts - manual resolution required
Please review and resolve the conflicts before merging.