### PR TITLE
[#11513] fix(catalog-mysql): Fix MySQL catalog incompatible with MariaDB due to case-sensitive CURRENT_TIMESTAMP check

### DIFF
--- a/catalogs/catalog-jdbc-mysql/src/main/java/org/apache/gravitino/catalog/mysql/converter/MysqlColumnDefaultValueConverter.java
+++ b/catalogs/catalog-jdbc-mysql/src/main/java/org/apache/gravitino/catalog/mysql/converter/MysqlColumnDefaultValueConverter.java
@@ -25,6 +25,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.format.DateTimeParseException;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.gravitino.catalog.jdbc.converter.JdbcColumnDefaultValueConverter;
 import org.apache.gravitino.catalog.jdbc.converter.JdbcTypeConverter;
 import org.apache.gravitino.rel.expressions.Expression;
@@ -50,7 +51,7 @@ public class MysqlColumnDefaultValueConverter extends JdbcColumnDefaultValueConv
     }
 
     if (isExpression) {
-      if (columnDefaultValue.startsWith(CURRENT_TIMESTAMP)) {
+      if (StringUtils.startsWithIgnoreCase(columnDefaultValue, CURRENT_TIMESTAMP)) {
         return DEFAULT_VALUE_OF_CURRENT_TIMESTAMP;
       }
       // The parsing of MySQL expressions is complex, so we are not currently undertaking the
@@ -89,7 +90,7 @@ public class MysqlColumnDefaultValueConverter extends JdbcColumnDefaultValueConv
         return Literals.timeLiteral(LocalTime.parse(columnDefaultValue, TIME_FORMATTER));
       case JdbcTypeConverter.TIMESTAMP:
       case MysqlTypeConverter.DATETIME:
-        if (columnDefaultValue.startsWith(CURRENT_TIMESTAMP)) {
+        if (StringUtils.startsWithIgnoreCase(columnDefaultValue, CURRENT_TIMESTAMP)) {
           return DEFAULT_VALUE_OF_CURRENT_TIMESTAMP;
         }
         try {


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->
Fix https://github.com/apache/gravitino/issues/11513
### What changes were proposed in this pull request?

Changed the `CURRENT_TIMESTAMP` comparison in `MysqlColumnDefaultValueConverter` from case-sensitive `startsWith` to case-insensitive `StringUtils.startsWithIgnoreCase`.

### Why are the changes needed?

MariaDB returns default values with different casing (e.g., `current_timestamp` in lowercase) compared to MySQL (e.g., `CURRENT_TIMESTAMP` in uppercase). The existing `String.startsWith()` check is case-sensitive, which causes it to fail when connecting to a MariaDB database via the MySQL catalog, resulting in incorrect default value parsing.

### Does this PR introduce _any_ user-facing change?

No user-facing API changes. This fix ensures MariaDB users can correctly use the MySQL catalog with proper default value handling.

### How was this patch tested?

Manually tested by connecting the MySQL catalog to a MariaDB instance and verifying that columns with `CURRENT_TIMESTAMP` as default value are correctly parsed.
