### PR TITLE
fix(docs): remove MDX-incompatible curly braces in lance-rest-integration doc

### DIFF
--- a/docs/lance-rest-integration.md
+++ b/docs/lance-rest-integration.md
@@ -21,14 +21,14 @@ This documentation assumes familiarity with the Lance REST service setup as desc
 The following table outlines the tested compatibility between Gravitino versions and Lance connector versions:
 
 | Gravitino Version (Lance REST) | Supported lance-spark Versions | Supported lance-ray Versions                  |
-|--------------------------------|--------------------------------|-----------------------------------------------|
-| 1.1.1 - 1.2.1                  | 0.0.10 - 0.0.15                | 0.0.6 - 0.0.8                                 |
-| 1.3.0                          | {0.2.0, 0.4.0}                 | 0.3.0 - 0.4.2 (0.2.0 conditionally supported) |
+|--------------------------------|------------------------------|-----------------------------------------------|
+| 1.1.1 - 1.2.1                  | 0.0.10 - 0.0.15              | 0.0.6 - 0.0.8                                 |
+| 1.3.0                          | 0.2.0, 0.4.0                 | 0.3.0 - 0.4.2 (0.2.0 conditionally supported) |
 
 :::note
 - These version entries show which versions are expected to work together.
 - For Gravitino 1.3.0, the explicitly verified release versions are
-  `lance-spark` {0.2.0, 0.4.0} and `lance-ray` {0.3.0, 0.4.2}. `lance-ray`
+  `lance-spark`(0.2.0, 0.4.0) and `lance-ray` (0.3.0, 0.4.2). `lance-ray`
   0.2.0 is conditionally supported only with the conditions described below.
 
 - **`lance-spark` 0.1.0 and 0.1.1 are not supported on Gravitino 1.3.0.**

--- a/docs/lance-rest-integration.md
+++ b/docs/lance-rest-integration.md
@@ -21,14 +21,14 @@ This documentation assumes familiarity with the Lance REST service setup as desc
 The following table outlines the tested compatibility between Gravitino versions and Lance connector versions:
 
 | Gravitino Version (Lance REST) | Supported lance-spark Versions | Supported lance-ray Versions                  |
-|--------------------------------|------------------------------|-----------------------------------------------|
-| 1.1.1 - 1.2.1                  | 0.0.10 - 0.0.15              | 0.0.6 - 0.0.8                                 |
-| 1.3.0                          | 0.2.0, 0.4.0                 | 0.3.0 - 0.4.2 (0.2.0 conditionally supported) |
+|--------------------------------|--------------------------------|-----------------------------------------------|
+| 1.1.1 - 1.2.1                  | 0.0.10 - 0.0.15                | 0.0.6 - 0.0.8                                 |
+| 1.3.0                          | 0.2.0, 0.4.0                   | 0.3.0 - 0.4.2 (0.2.0 conditionally supported) |
 
 :::note
 - These version entries show which versions are expected to work together.
 - For Gravitino 1.3.0, the explicitly verified release versions are
-  `lance-spark`(0.2.0, 0.4.0) and `lance-ray` (0.3.0, 0.4.2). `lance-ray`
+  `lance-spark` (0.2.0, 0.4.0) and `lance-ray` (0.3.0, 0.4.2). `lance-ray`
   0.2.0 is conditionally supported only with the conditions described below.
 
 - **`lance-spark` 0.1.0 and 0.1.1 are not supported on Gravitino 1.3.0.**


### PR DESCRIPTION
### What changes were proposed in this pull request?

Remove curly-brace syntax (`{0.2.0, 0.4.0}`, `{0.3.0, 0.4.2}`) from
`docs/lance-rest-integration.md` that causes Docusaurus MDX compilation
failures (curly braces outside code spans are parsed as JSX expressions),
and align the Markdown table column widths accordingly.

### Why are the changes needed?

The `{...}` notation in the version compatibility table and the note block
triggers an MDX parse error when the docs site is built, breaking the
documentation build.

### Does this PR introduce _any_ user-facing change?

No (documentation only, no functional change).

### How was this patch tested?

Verified the Markdown renders correctly without curly braces.