### PR TITLE
[#11525] improvement(license): Add AWS SDK license entries for catalog-glue

### DIFF
--- a/LICENSE.bin
+++ b/LICENSE.bin
@@ -256,6 +256,9 @@
    Apache Commons Pool
    Air Compressor
    Airlift
+   AWS Java SDK annotations
+   AWS SDK for Java 2.0
+   AWS EventStream for Java
    The Netty Project
    Open Telemetry
    Open Lineage

--- a/LICENSE.bin
+++ b/LICENSE.bin
@@ -256,7 +256,7 @@
    Apache Commons Pool
    Air Compressor
    Airlift
-   AWS Java SDK annotations
+   AWS SDK for Java 2.0 Annotations
    AWS SDK for Java 2.0
    AWS EventStream for Java
    The Netty Project

--- a/NOTICE.bin
+++ b/NOTICE.bin
@@ -14,7 +14,7 @@ AWS SDK for Java 2.0
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 This product includes software developed by
-Amazon Technologies, Inc (http://www.amazon.com/).
+Amazon Technologies, Inc. (http://www.amazon.com/).
 
 **********************
 THIRD PARTY COMPONENTS

--- a/NOTICE.bin
+++ b/NOTICE.bin
@@ -10,6 +10,26 @@ to the ASF by Datastrato (https://datastrato.ai/) copyright 2023-2024.
 The Web UI also has a NOTICE file please see web/NOTICE
 for it's contents.
 
+AWS SDK for Java 2.0
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+This product includes software developed by
+Amazon Technologies, Inc (http://www.amazon.com/).
+
+**********************
+THIRD PARTY COMPONENTS
+**********************
+This software includes third party software subject to the following copyrights:
+- XML parsing and utility functions from JetS3t - Copyright 2006-2009 James Murty.
+- PKCS#1 PEM encoded private key parsing and utility functions from oauth.googlecode.com - Copyright 1998-2010 AOL Inc.
+- Apache Commons Lang - https://github.com/apache/commons-lang
+- Netty Reactive Streams - https://github.com/playframework/netty-reactive-streams
+- Jackson-core - https://github.com/FasterXML/jackson-core
+- Jackson-dataformat-cbor - https://github.com/FasterXML/jackson-dataformats-binary
+
+AWS EventStream for Java
+Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
 Apache Iceberg
 Copyright 2017-2022 The Apache Software Foundation
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add AWS SDK for Java 2.0 entries to LICENSE.bin and NOTICE.bin.

### Why are the changes needed?
catalog-glue bundles AWS SDK for Java 2.0 (glue, kms, s3, sts, eventstream)
at runtime, but LICENSE.bin and NOTICE.bin were missing the required entries.

Fix: #11525

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
No test needed.