### PR TITLE
[#11532] fix(docker): avoid duplicate image layer from recursive chmod

### DIFF
--- a/dev/docker/gravitino/Dockerfile
+++ b/dev/docker/gravitino/Dockerfile
@@ -24,10 +24,9 @@ RUN apt-get update && apt-get install -y \
 
 WORKDIR /opt/gravitino
 
-COPY packages/gravitino /opt/gravitino
+COPY --chmod=775 packages/gravitino /opt/gravitino
 
-RUN chmod -R g+rwX /opt/gravitino \
-    && chmod +x /opt/gravitino/docker/docker-entrypoint.sh \
+RUN chmod +x /opt/gravitino/docker/docker-entrypoint.sh \
     && useradd -u 1000 -g 0 -M -s /sbin/nologin gravitino
 
 EXPOSE 8090

--- a/dev/docker/iceberg-rest-server/Dockerfile
+++ b/dev/docker/iceberg-rest-server/Dockerfile
@@ -25,10 +25,9 @@ RUN apt-get update && apt-get install -y \
 
 WORKDIR /opt/gravitino-iceberg-rest-server
 
-COPY packages/gravitino-iceberg-rest-server /opt/gravitino-iceberg-rest-server
+COPY --chmod=775 packages/gravitino-iceberg-rest-server /opt/gravitino-iceberg-rest-server
 
-RUN chmod -R g+rwX /opt/gravitino-iceberg-rest-server \
-    && chmod +x /opt/gravitino-iceberg-rest-server/bin/start-iceberg-rest-server.sh \
+RUN chmod +x /opt/gravitino-iceberg-rest-server/bin/start-iceberg-rest-server.sh \
     && useradd -u 1000 -g 0 -M -s /sbin/nologin gravitino
 
 EXPOSE 9001

--- a/dev/docker/lance-rest-server/Dockerfile
+++ b/dev/docker/lance-rest-server/Dockerfile
@@ -25,10 +25,9 @@ RUN apt-get update && apt-get install -y \
 
 WORKDIR /opt/gravitino-lance-rest-server
 
-COPY packages/gravitino-lance-rest-server /opt/gravitino-lance-rest-server
+COPY --chmod=775 packages/gravitino-lance-rest-server /opt/gravitino-lance-rest-server
 
-RUN chmod -R g+rwX /opt/gravitino-lance-rest-server \
-    && chmod +x /opt/gravitino-lance-rest-server/bin/start-lance-rest-server.sh
+RUN chmod +x /opt/gravitino-lance-rest-server/bin/start-lance-rest-server.sh
 
 EXPOSE 9101
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Replace the post-COPY `RUN chmod -R g+rwX <dir>` step with `COPY --chmod=775` in three Dockerfiles:
- `dev/docker/gravitino/Dockerfile`
- `dev/docker/iceberg-rest-server/Dockerfile`
- `dev/docker/lance-rest-server/Dockerfile`

### Why are the changes needed?

`chmod -R` after `COPY` rewrites the mode of every file. With OverlayFS each modified file is copied up into the `RUN` layer, so the whole application tree (~1.9GB for the gravitino image) is stored twice, roughly doubling the image size. `COPY --chmod` sets the mode as the files are written, so there is only one copy.

Measured on the gravitino image (`docker history`):

| layer | before | after |
|-------|--------|-------|
| COPY app tree | 1.89 GB | 1.89 GB |
| permission step | `chmod -R` = **1.89 GB** | `chmod +x`+`useradd` = **369 kB** |

Fix: #11532

### Does this PR introduce _any_ user-facing change?

No API change. Published Docker images are ~1.9GB smaller. Note: files are now mode 775 instead of the previous `g+rwX` (which preserved existing execute bits); this only adds the execute bit to regular files and does not affect runtime behavior.

### How was this patch tested?

Built the fixed image and verified with `docker history` that the duplicate ~1.9GB chmod layer is gone (replaced by a 369kB permission layer). Ran the image as the non-root user (uid 1000): the server starts and serves the Gravitino REST (`/api/version`, metalake CRUD), Iceberg REST (`/iceberg/v1/config`) and Lance REST endpoints successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)