### PR TITLE
[#11542] test(client-java): Configure Basic authenticator in BasicAuthOperationsIT

### DIFF
--- a/clients/client-java/src/test/java/org/apache/gravitino/client/integration/test/authorization/BasicAuthOperationsIT.java
+++ b/clients/client-java/src/test/java/org/apache/gravitino/client/integration/test/authorization/BasicAuthOperationsIT.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import org.apache.gravitino.Configs;
 import org.apache.gravitino.client.GravitinoAdminClient;
 import org.apache.gravitino.client.GravitinoVersion;
+import org.apache.gravitino.idp.auth.BasicAuthenticator;
 import org.apache.gravitino.idp.web.rest.feature.IdpRESTFeature;
 import org.apache.gravitino.integration.test.util.BaseIT;
 import org.apache.gravitino.integration.test.util.ITUtils;
@@ -52,6 +53,7 @@ public class BasicAuthOperationsIT extends BaseIT {
     configs.put(Configs.CACHE_ENABLED.getKey(), String.valueOf(false));
     configs.put(Configs.STORE_DELETE_AFTER_TIME.getKey(), String.valueOf(20 * 60 * 1000L));
     configs.put(Configs.SERVICE_ADMINS.getKey(), ADMIN);
+    configs.put(Configs.AUTHENTICATORS.getKey(), BasicAuthenticator.class.getCanonicalName());
     configs.put(
         Configs.REST_API_EXTENSION_PACKAGES.getKey(), IdpRESTFeature.IDP_REST_EXTENSION_PACKAGE);
     registerCustomConfigs(configs);


### PR DESCRIPTION
### What changes were proposed in this pull request?

Configure `BasicAuthOperationsIT` to use the built-in `BasicAuthenticator`.

### Why are the changes needed?

The test enables the built-in IdP extension while retaining the default `simple` authenticator. This incompatible configuration calls `System.exit(1)` and terminates the Gradle test executor.

Fix: #11542

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

- `./gradlew :clients:client-java:test --tests "org.apache.gravitino.client.integration.test.authorization.BasicAuthOperationsIT"`
- `./gradlew :clients:client-java:test`