### PR TITLE
[#11550] docs(authn): Clarify Web UI Basic auth limits and relocate BasicAuthOperationsIT

### DIFF
--- a/.github/workflows/idp-basic-test.yml
+++ b/.github/workflows/idp-basic-test.yml
@@ -22,6 +22,9 @@ jobs:
           filters: |
             source_changes:
               - plugins/idp-basic/**
+              - clients/client-java/**
+              - clients/client-java-runtime/**
+              - integration-test-common/**
               - core/**
               - gradle/**
               - gradlew

--- a/clients/client-java/build.gradle.kts
+++ b/clients/client-java/build.gradle.kts
@@ -44,7 +44,6 @@ dependencies {
 
   testImplementation(project(":core"))
   testImplementation(project(":integration-test-common", "testArtifacts"))
-  testImplementation(project(":plugins:idp-basic"))
   testImplementation(project(":server"))
   testImplementation(project(":server-common"))
 

--- a/docs/security/how-to-authenticate.md
+++ b/docs/security/how-to-authenticate.md
@@ -86,6 +86,13 @@ curl -v -X GET \
   http://localhost:8090/api/version
 ```
 
+:::note
+The Web UI does not provide a username/password login form for built-in IDP Basic authentication.
+Use REST clients, the Java/Python client, or engine connectors instead. See
+[Built-in IDP — Web UI](how-to-use-built-in-idp.md#web-ui) and
+[Web V2 initial page](../webui-v2.md#initial-page).
+:::
+
 ### OAuth Mode
 
 Gravitino supports external OAuth 2.0 servers with two token validation methods:
@@ -368,6 +375,9 @@ This example shows how to enable built-in Basic authentication.
 
 Built-in IdP is **incompatible** with the `simple` authenticator (the default). When the
 `idp-basic` plugin is enabled, `gravitino.authenticators` must not include `simple`.
+
+The Web UI does not support built-in IDP Basic login. Use REST or client APIs for this mode, or
+configure [OAuth mode](#oauth-mode) if you need browser-based sign-in.
 
 **Configuration:**
 

--- a/docs/security/how-to-authenticate.md
+++ b/docs/security/how-to-authenticate.md
@@ -373,11 +373,9 @@ This example shows how to enable built-in Basic authentication.
 **Prerequisites:**
 
 - Gravitino distribution package (includes the idp-basic plugin on the server classpath)
-- Built-in IdP is **incompatible** with the `simple` authenticator (the default). When the
-  `idp-basic` plugin is enabled, `gravitino.authenticators` must not include `simple`.
-- For Web UI limitations with Basic authentication, see
-  [built-in IDP Web UI](how-to-use-built-in-idp.md#web-ui). For browser-based sign-in, configure
-  [OAuth mode](#oauth-mode).
+
+Built-in IdP is **incompatible** with the `simple` authenticator (the default). When the
+`idp-basic` plugin is enabled, `gravitino.authenticators` must not include `simple`.
 
 **Configuration:**
 

--- a/docs/security/how-to-authenticate.md
+++ b/docs/security/how-to-authenticate.md
@@ -89,7 +89,8 @@ curl -v -X GET \
 :::note
 The Web UI does not provide a username/password login form for built-in IDP Basic authentication.
 Use REST clients, the Java/Python client, or engine connectors instead. See
-[Built-in IDP — Web UI](how-to-use-built-in-idp.md#web-ui) and
+[built-in IDP Web UI](how-to-use-built-in-idp.md#web-ui), the
+[Web UI initial page](../webui.md#initial-page), and the
 [Web V2 initial page](../webui-v2.md#initial-page).
 :::
 
@@ -372,12 +373,11 @@ This example shows how to enable built-in Basic authentication.
 **Prerequisites:**
 
 - Gravitino distribution package (includes the idp-basic plugin on the server classpath)
-
-Built-in IdP is **incompatible** with the `simple` authenticator (the default). When the
-`idp-basic` plugin is enabled, `gravitino.authenticators` must not include `simple`.
-
-The Web UI does not support built-in IDP Basic login. Use REST or client APIs for this mode, or
-configure [OAuth mode](#oauth-mode) if you need browser-based sign-in.
+- Built-in IdP is **incompatible** with the `simple` authenticator (the default). When the
+  `idp-basic` plugin is enabled, `gravitino.authenticators` must not include `simple`.
+- For Web UI limitations with Basic authentication, see
+  [built-in IDP Web UI](how-to-use-built-in-idp.md#web-ui). For browser-based sign-in, configure
+  [OAuth mode](#oauth-mode).
 
 **Configuration:**
 

--- a/docs/security/how-to-use-built-in-idp.md
+++ b/docs/security/how-to-use-built-in-idp.md
@@ -19,6 +19,15 @@ and prefer [HTTPS](how-to-use-https.md) when credentials travel over the network
 This guide describes how to enable and operate the management APIs in `plugins:idp-basic`. For
 request and response schemas, see the [Built-in IDP OpenAPI](../open-api/idp/openapi.yaml).
 
+### Web UI
+
+The Gravitino Web UI (v1 and Web V2) does **not** support signing in with built-in IDP Basic
+credentials. Login pages only handle `simple` (username-only when authorization is enabled) and
+`oauth` (OIDC/OAuth) flows. Use the REST API, [Java/Python clients](how-to-authenticate.md), or
+engine connectors for Basic authentication. To access the Web UI with interactive login, configure
+[OAuth mode](how-to-authenticate.md#oauth-mode) with an external identity provider, or use `simple`
+mode only in development scenarios where the username-only flow is acceptable.
+
 ---
 
 ## Prerequisites
@@ -319,8 +328,9 @@ Replace these with values that match your deployment.
    ```
 
    Built-in IdP is **incompatible** with the `simple` authenticator. Remove `simple` from
-   `gravitino.authenticators` (the default). For example, use `oauth` when the Web UI authenticates
-   through an external IdP; see [How to authenticate](how-to-authenticate.md).
+   `gravitino.authenticators` (the default). The Web UI does not support built-in IDP Basic login
+   (see [Web UI](#web-ui)). Use `oauth` when the Web UI should authenticate through an external IdP;
+   see [How to authenticate](how-to-authenticate.md).
 
 2. Before the first start, set the initial service admin password (see
    [password rules](#password-and-username-rules)):

--- a/docs/security/how-to-use-built-in-idp.md
+++ b/docs/security/how-to-use-built-in-idp.md
@@ -19,11 +19,13 @@ and prefer [HTTPS](how-to-use-https.md) when credentials travel over the network
 This guide describes how to enable and operate the management APIs in `plugins:idp-basic`. For
 request and response schemas, see the [Built-in IDP OpenAPI](../open-api/idp/openapi.yaml).
 
-### Web UI
+## Web UI
 
 The Gravitino Web UI (v1 and Web V2) does **not** support signing in with built-in IDP Basic
-credentials. Login pages only handle `simple` (username-only when authorization is enabled) and
-`oauth` (OIDC/OAuth) flows. Use the REST API, [Java/Python clients](how-to-authenticate.md), or
+credentials. Configure `gravitino.authenticators` with
+`org.apache.gravitino.idp.auth.BasicAuthenticator` for server and client Basic authentication.
+Login pages only handle `simple` (username-only when authorization is enabled) and `oauth`
+(OIDC/OAuth) flows. Use the REST API, [Java/Python clients](how-to-authenticate.md#basic-mode), or
 engine connectors for Basic authentication.
 
 ---

--- a/docs/security/how-to-use-built-in-idp.md
+++ b/docs/security/how-to-use-built-in-idp.md
@@ -21,12 +21,12 @@ request and response schemas, see the [Built-in IDP OpenAPI](../open-api/idp/ope
 
 ## Web UI
 
-The Gravitino Web UI (v1 and Web V2) does **not** support signing in with built-in IDP Basic
-credentials. Configure `gravitino.authenticators` with
-`org.apache.gravitino.idp.auth.BasicAuthenticator` for server and client Basic authentication.
-Login pages only handle `simple` (username-only when authorization is enabled) and `oauth`
-(OIDC/OAuth) flows. Use the REST API, [Java/Python clients](how-to-authenticate.md#basic-mode), or
-engine connectors for Basic authentication.
+Built-in IdP is **incompatible** with the `simple` authenticator (the default). The Web UI does not
+support signing in with built-in IDP Basic credentials. Login pages only handle `simple`
+(username-only when authorization is enabled) and `oauth` (OIDC/OAuth) flows. If you need the Web UI
+while built-in IdP is enabled, prefer [OAuth mode](how-to-authenticate.md#oauth-mode). For Basic
+authentication, use the REST API, [Java/Python clients](how-to-authenticate.md#basic-mode), or
+engine connectors instead.
 
 ---
 

--- a/docs/security/how-to-use-built-in-idp.md
+++ b/docs/security/how-to-use-built-in-idp.md
@@ -24,9 +24,7 @@ request and response schemas, see the [Built-in IDP OpenAPI](../open-api/idp/ope
 The Gravitino Web UI (v1 and Web V2) does **not** support signing in with built-in IDP Basic
 credentials. Login pages only handle `simple` (username-only when authorization is enabled) and
 `oauth` (OIDC/OAuth) flows. Use the REST API, [Java/Python clients](how-to-authenticate.md), or
-engine connectors for Basic authentication. To access the Web UI with interactive login, configure
-[OAuth mode](how-to-authenticate.md#oauth-mode) with an external identity provider, or use `simple`
-mode only in development scenarios where the username-only flow is acceptable.
+engine connectors for Basic authentication.
 
 ---
 
@@ -329,8 +327,7 @@ Replace these with values that match your deployment.
 
    Built-in IdP is **incompatible** with the `simple` authenticator. Remove `simple` from
    `gravitino.authenticators` (the default). The Web UI does not support built-in IDP Basic login
-   (see [Web UI](#web-ui)). Use `oauth` when the Web UI should authenticate through an external IdP;
-   see [How to authenticate](how-to-authenticate.md).
+   (see [Web UI](#web-ui)).
 
 2. Before the first start, set the initial service admin password (see
    [password rules](#password-and-username-rules)):

--- a/docs/security/how-to-use-built-in-idp.md
+++ b/docs/security/how-to-use-built-in-idp.md
@@ -328,8 +328,8 @@ Replace these with values that match your deployment.
    ```
 
    Built-in IdP is **incompatible** with the `simple` authenticator. Remove `simple` from
-   `gravitino.authenticators` (the default). The Web UI does not support built-in IDP Basic login
-   (see [Web UI](#web-ui)).
+   `gravitino.authenticators` (the default). For example, use `oauth` when the Web UI authenticates
+   through an external IdP; see [How to authenticate](how-to-authenticate.md).
 
 2. Before the first start, set the initial service admin password (see
    [password rules](#password-and-username-rules)):

--- a/docs/webui-v2.md
+++ b/docs/webui-v2.md
@@ -55,9 +55,9 @@ The Web V2 landing page depends on both the authentication mode and whether auth
   ![oauth-login](./assets/webui-v2/oauth-login.png)
 
 :::note
-Built-in IDP Basic authentication is not supported in the Web UI. The UI does not collect username
-and password for this mode. Use the REST API, Java/Python clients, or engine connectors instead.
-See [built-in IDP Web UI](security/how-to-use-built-in-idp.md#web-ui).
+Built-in IDP Basic authentication is not supported in the Web UI. The UI does not collect
+username and password for this mode. Use the REST API, Java/Python clients, or engine connectors
+instead. See [built-in IDP Web UI](security/how-to-use-built-in-idp.md#web-ui).
 :::
 
 ### Metalakes

--- a/docs/webui-v2.md
+++ b/docs/webui-v2.md
@@ -54,10 +54,11 @@ The Web V2 landing page depends on both the authentication mode and whether auth
 
   ![oauth-login](./assets/webui-v2/oauth-login.png)
 
-- Built-in IDP **Basic** authentication (`org.apache.gravitino.idp.auth.BasicAuthenticator`) is
-  **not** supported in the Web UI. The UI does not collect username and password for this mode. Use
-  the REST API, Java/Python clients, or engine connectors instead. See
-  [Built-in IDP — Web UI](security/how-to-use-built-in-idp.md#web-ui).
+:::note
+Built-in IDP Basic authentication is not supported in the Web UI. The UI does not collect username
+and password for this mode. Use the REST API, Java/Python clients, or engine connectors instead.
+See [built-in IDP Web UI](security/how-to-use-built-in-idp.md#web-ui).
+:::
 
 ### Metalakes
 

--- a/docs/webui-v2.md
+++ b/docs/webui-v2.md
@@ -54,6 +54,11 @@ The Web V2 landing page depends on both the authentication mode and whether auth
 
   ![oauth-login](./assets/webui-v2/oauth-login.png)
 
+- Built-in IDP **Basic** authentication (`org.apache.gravitino.idp.auth.BasicAuthenticator`) is
+  **not** supported in the Web UI. The UI does not collect username and password for this mode. Use
+  the REST API, Java/Python clients, or engine connectors instead. See
+  [Built-in IDP — Web UI](security/how-to-use-built-in-idp.md#web-ui).
+
 ### Metalakes
 
 Overview for Metalake in the Web V2.

--- a/docs/webui.md
+++ b/docs/webui.md
@@ -23,9 +23,9 @@ The web UI homepage displayed in Gravitino depends on the configuration paramete
 Set parameter for `gravitino.authenticators`, [`simple`](#simple-mode) or [`oauth`](#oauth-mode). Simple mode is the default authentication option. If multiple authenticators are set, the first one is taken by default.
 
 :::note
-Built-in IDP Basic authentication is not supported in the Web UI (v1 or Web V2). The login flow
-only covers `simple` and `oauth`. For Basic mode, use REST APIs or clients. See
-[built-in IDP Web UI](security/how-to-use-built-in-idp.md#web-ui).
+Built-in IDP Basic authentication is not supported in the Web UI. The UI does not collect
+username and password for this mode. Use the REST API, Java/Python clients, or engine connectors
+instead. See [built-in IDP Web UI](security/how-to-use-built-in-idp.md#web-ui).
 :::
 
 :::tip

--- a/docs/webui.md
+++ b/docs/webui.md
@@ -22,6 +22,10 @@ The web UI homepage displayed in Gravitino depends on the configuration paramete
 
 Set parameter for `gravitino.authenticators`, [`simple`](#simple-mode) or [`oauth`](#oauth-mode). Simple mode is the default authentication option. If multiple authenticators are set, the first one is taken by default.
 
+Built-in IDP **Basic** authentication is not supported in the Web UI. The login flow only covers
+`simple` and `oauth`. For Basic mode, use REST APIs or clients; see
+[Built-in IDP — Web UI](security/how-to-use-built-in-idp.md#web-ui).
+
 :::tip
 After changing the configuration, make sure to restart the Gravitino server.
 

--- a/docs/webui.md
+++ b/docs/webui.md
@@ -22,9 +22,11 @@ The web UI homepage displayed in Gravitino depends on the configuration paramete
 
 Set parameter for `gravitino.authenticators`, [`simple`](#simple-mode) or [`oauth`](#oauth-mode). Simple mode is the default authentication option. If multiple authenticators are set, the first one is taken by default.
 
-Built-in IDP **Basic** authentication is not supported in the Web UI. The login flow only covers
-`simple` and `oauth`. For Basic mode, use REST APIs or clients; see
-[Built-in IDP — Web UI](security/how-to-use-built-in-idp.md#web-ui).
+:::note
+Built-in IDP Basic authentication is not supported in the Web UI (v1 or Web V2). The login flow
+only covers `simple` and `oauth`. For Basic mode, use REST APIs or clients. See
+[built-in IDP Web UI](security/how-to-use-built-in-idp.md#web-ui).
+:::
 
 :::tip
 After changing the configuration, make sure to restart the Gravitino server.

--- a/plugins/idp-basic/src/test/java/org/apache/gravitino/idp/integration/test/BasicAuthOperationsIT.java
+++ b/plugins/idp-basic/src/test/java/org/apache/gravitino/idp/integration/test/BasicAuthOperationsIT.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.gravitino.client.integration.test.authorization;
+package org.apache.gravitino.idp.integration.test;
 
 import static org.apache.gravitino.integration.test.util.BaseIT.setEnv;
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

1. **Documentation** — State that the Gravitino Web UI (v1 and Web V2) does not provide a username/password login flow for built-in IDP Basic authentication. Login pages only support `simple` and `oauth`. Users enabling Basic auth should use REST APIs, Java/Python clients, or engine connectors instead.

   Updated:
   - `docs/security/how-to-use-built-in-idp.md` — **Web UI** subsection and end-to-end setup note
   - `docs/security/how-to-authenticate.md` — note in Basic mode and example section
   - `docs/webui.md` and `docs/webui-v2.md` — initial-page guidance

2. **Test** — Move `BasicAuthOperationsIT` from `clients/client-java` to `plugins/idp-basic` (alongside `IdpRESTApiIT`) and remove the `idp-basic` test dependency from `client-java`.

### Why are the changes needed?

Built-in IDP Basic authentication works for the server REST API and clients, but the Web UI has no interactive Basic login. Without documentation, users may assume browser sign-in is supported and waste time debugging failed logins.

Relocating the integration test keeps IdP-related ITs in the `idp-basic` module and avoids a circular-style test dependency from `client-java` on `idp-basic`.

Fix: #11550

### Does this PR introduce _any_ user-facing change?

Documentation only. No API or configuration changes. The test relocation does not change product behavior.

### How was this patch tested?

- Docs reviewed for link targets and consistency with Web UI auth code paths (`simple` / `oauth` only in `session.js`).
- `./gradlew :plugins:idp-basic:test --tests org.apache.gravitino.idp.integration.test.BasicAuthOperationsIT`