### PR TITLE
[MINOR] feat: add health check endpoints for Iceberg and Lance REST servers

### DIFF
--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/rest/IcebergHealthOperations.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/rest/IcebergHealthOperations.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.iceberg.service.rest;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import org.apache.gravitino.iceberg.service.IcebergRESTUtils;
+
+@Path("/health")
+@Produces(MediaType.APPLICATION_JSON)
+public class IcebergHealthOperations {
+
+  @GET
+  public Response health() {
+    Map<String, String> healthStatus = new HashMap<>();
+    healthStatus.put("status", "UP");
+    return IcebergRESTUtils.ok(healthStatus);
+  }
+}

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/TestIcebergHealthOperations.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/TestIcebergHealthOperations.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.iceberg.service.rest;
+
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TestIcebergHealthOperations extends IcebergTestBase {
+
+  @Override
+  protected Application configure() {
+    return IcebergRestTestUtil.getIcebergResourceConfig(
+        IcebergHealthOperations.class, false, java.util.Arrays.asList());
+  }
+
+  @Test
+  public void testHealthCheck() {
+    Response resp = target("/health").request(MediaType.APPLICATION_JSON_TYPE).get();
+    Assertions.assertEquals(Response.Status.OK.getStatusCode(), resp.getStatus());
+    Assertions.assertEquals(MediaType.APPLICATION_JSON_TYPE, resp.getMediaType());
+
+    HealthResponse response = resp.readEntity(HealthResponse.class);
+    Assertions.assertEquals("UP", response.getStatus());
+  }
+
+  public static class HealthResponse {
+    private String status;
+
+    public HealthResponse() {}
+
+    public HealthResponse(String status) {
+      this.status = status;
+    }
+
+    public String getStatus() {
+      return status;
+    }
+
+    public void setStatus(String status) {
+      this.status = status;
+    }
+  }
+}

--- a/lance/lance-rest-server/src/main/java/org/apache/gravitino/lance/service/rest/LanceHealthOperations.java
+++ b/lance/lance-rest-server/src/main/java/org/apache/gravitino/lance/service/rest/LanceHealthOperations.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.lance.service.rest;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+@Path("/health")
+@Produces(MediaType.APPLICATION_JSON)
+public class LanceHealthOperations {
+
+  @GET
+  public Response health() {
+    Map<String, String> healthStatus = new HashMap<>();
+    healthStatus.put("status", "UP");
+    return Response.ok(healthStatus).type(MediaType.APPLICATION_JSON).build();
+  }
+}

--- a/lance/lance-rest-server/src/test/java/org/apache/gravitino/lance/service/rest/TestLanceHealthOperations.java
+++ b/lance/lance-rest-server/src/test/java/org/apache/gravitino/lance/service/rest/TestLanceHealthOperations.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.lance.service.rest;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import org.glassfish.jersey.internal.inject.AbstractBinder;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.glassfish.jersey.test.JerseyTest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TestLanceHealthOperations extends JerseyTest {
+
+  private static class MockServletRequestFactory extends ServletRequestFactoryBase {
+    @Override
+    public HttpServletRequest get() {
+      return null;
+    }
+  }
+
+  @Override
+  protected Application configure() {
+    ResourceConfig resourceConfig = new ResourceConfig();
+    resourceConfig.register(LanceHealthOperations.class);
+    resourceConfig.register(
+        new AbstractBinder() {
+          @Override
+          protected void configure() {
+            bindFactory(MockServletRequestFactory.class).to(HttpServletRequest.class);
+          }
+        });
+
+    return resourceConfig;
+  }
+
+  @Test
+  public void testHealthCheck() {
+    Response resp = target("/health").request(MediaType.APPLICATION_JSON_TYPE).get();
+    Assertions.assertEquals(Response.Status.OK.getStatusCode(), resp.getStatus());
+    Assertions.assertEquals(MediaType.APPLICATION_JSON_TYPE, resp.getMediaType());
+
+    HealthResponse response = resp.readEntity(HealthResponse.class);
+    Assertions.assertEquals("UP", response.getStatus());
+  }
+
+  public static class HealthResponse {
+    private String status;
+
+    public HealthResponse() {}
+
+    public HealthResponse(String status) {
+      this.status = status;
+    }
+
+    public String getStatus() {
+      return status;
+    }
+
+    public void setStatus(String status) {
+      this.status = status;
+    }
+  }
+}

--- a/server-common/src/main/java/org/apache/gravitino/server/authentication/AuthenticationFilter.java
+++ b/server-common/src/main/java/org/apache/gravitino/server/authentication/AuthenticationFilter.java
@@ -38,6 +38,9 @@ import org.apache.gravitino.utils.PrincipalUtils;
 
 public class AuthenticationFilter implements Filter {
 
+  private static final String ICEBERG_HEALTH_CHECK_PATH = "/iceberg/health";
+  private static final String LANCE_HEALTH_CHECK_PATH = "/lance/health";
+
   private final List<Authenticator> filterAuthenticators;
 
   public AuthenticationFilter() {
@@ -56,13 +59,24 @@ public class AuthenticationFilter implements Filter {
   public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
       throws IOException, ServletException {
     try {
+      HttpServletRequest req = (HttpServletRequest) request;
+      // Skip authentication for health check endpoints so that
+      // Kubernetes probes and monitoring systems can check
+      // service status without credentials.
+      String requestUri = req.getRequestURI();
+      if (requestUri != null
+          && (requestUri.equals(ICEBERG_HEALTH_CHECK_PATH)
+              || requestUri.equals(LANCE_HEALTH_CHECK_PATH))) {
+        chain.doFilter(request, response);
+        return;
+      }
+
       List<Authenticator> authenticators;
       if (filterAuthenticators == null || filterAuthenticators.isEmpty()) {
         authenticators = ServerAuthenticator.getInstance().authenticators();
       } else {
         authenticators = filterAuthenticators;
       }
-      HttpServletRequest req = (HttpServletRequest) request;
       Enumeration<String> headerData = req.getHeaders(AuthConstants.HTTP_HEADER_AUTHORIZATION);
       byte[] authData = null;
       if (headerData.hasMoreElements()) {

--- a/server-common/src/test/java/org/apache/gravitino/server/authentication/TestAuthenticationFilter.java
+++ b/server-common/src/test/java/org/apache/gravitino/server/authentication/TestAuthenticationFilter.java
@@ -122,4 +122,37 @@ public class TestAuthenticationFilter {
     filter.doFilter(mockRequest, mockResponse, mockChain);
     verify(mockResponse).sendError(HttpServletResponse.SC_UNAUTHORIZED, "UNAUTHORIZED");
   }
+
+  @Test
+  public void testDoFilterSkipsHealthCheckEndpoint() throws ServletException, IOException {
+    Authenticator authenticator = mock(Authenticator.class);
+    AuthenticationFilter filter = new AuthenticationFilter(Lists.newArrayList(authenticator));
+    FilterChain mockChain = mock(FilterChain.class);
+    HttpServletRequest mockRequest = mock(HttpServletRequest.class);
+    HttpServletResponse mockResponse = mock(HttpServletResponse.class);
+    when(mockRequest.getRequestURI()).thenReturn("/iceberg/health");
+    // Should skip authentication and directly proceed to filter chain
+    filter.doFilter(mockRequest, mockResponse, mockChain);
+    verify(mockChain).doFilter(mockRequest, mockResponse);
+    // Authenticator should never be called
+    verify(authenticator, never()).supportsToken(any());
+    verify(authenticator, never()).authenticateToken(any());
+  }
+
+  @Test
+  public void testDoFilterSkipsHealthCheckEndpointWithPrefix()
+      throws ServletException, IOException {
+    Authenticator authenticator = mock(Authenticator.class);
+    AuthenticationFilter filter = new AuthenticationFilter(Lists.newArrayList(authenticator));
+    FilterChain mockChain = mock(FilterChain.class);
+    HttpServletRequest mockRequest = mock(HttpServletRequest.class);
+    HttpServletResponse mockResponse = mock(HttpServletResponse.class);
+    when(mockRequest.getRequestURI()).thenReturn("/lance/health");
+    // Should skip authentication and directly proceed to filter chain
+    filter.doFilter(mockRequest, mockResponse, mockChain);
+    verify(mockChain).doFilter(mockRequest, mockResponse);
+    // Authenticator should never be called
+    verify(authenticator, never()).supportsToken(any());
+    verify(authenticator, never()).authenticateToken(any());
+  }
 }


### PR DESCRIPTION

### What changes were proposed in this pull request?

1、Add IcebergHealthOperations — GET /iceberg/health, returns {"status": "UP"}, located in org.apache.gravitino.iceberg.service.rest package, auto-discovered via Jersey package scanning.

2、Add LanceHealthOperations — GET /lance/health, returns {"status": "UP"}, located in org.apache.gravitino.lance.service.rest package, similarly auto-discovered.

3、Update AuthenticationFilter — Skip authentication in doFilter() for /iceberg/health and /lance/health, allowing Kubernetes probes and monitoring systems to check service status without credentials. Also removed the dead constant HEALTH_CHECK_PATH = "/health" which had no corresponding endpoint.

4、Add unit tests:
TestIcebergHealthOperations — verifies health endpoint returns 200 and {"status": "UP"}
TestLanceHealthOperations — same
TestAuthenticationFilter — two new test cases verifying /iceberg/health and /lance/health properly bypass authentication

### Why are the changes needed?

The Iceberg and Lance REST servers currently expose no health check endpoints. In Kubernetes deployments, this prevents liveness/readiness probes from working correctly, and load balancers and monitoring systems cannot verify service status without hitting authenticated endpoints. Adding a simple health check and bypassing authentication enables operators to reliably monitor service health in production.

Fix: #(#11153 )

### Does this PR introduce _any_ user-facing change?

Two new REST API endpoints:

- GET /iceberg/health — returns 200 OK + {"status": "UP"}
- GET /lance/health — returns 200 OK + {"status": "UP"}

No configuration changes required; both endpoints are available immediately once the servers start.

### How was this patch tested?

- TestIcebergHealthOperations — covers normal response, path matching, Content-Type validation
- TestLanceHealthOperations — same
- TestAuthenticationFilter.testDoFilterSkipsHealthCheckEndpoint — verifies /iceberg/health bypasses auth
- TestAuthenticationFilter.testDoFilterSkipsHealthCheckEndpointWithPrefix — verifies /lance/health bypasses auth
- ./gradlew :server-common:spotlessApply :iceberg:iceberg-rest-server:spotlessApply :lance:lance-rest-server:spotlessApply all pass
