### PR TITLE
[#11578] fix(lance): Gravitino Lance REST does not support describeTable(version), causing Spark Lance write failures

### DIFF
--- a/.github/workflows/lance-compatibility-matrix-test.yml
+++ b/.github/workflows/lance-compatibility-matrix-test.yml
@@ -6,7 +6,7 @@ on:
       lance_spark_versions:
         description: "Comma-separated lance-spark-bundle versions"
         required: false
-        default: "0.2.0,0.4.0"
+        default: "0.2.0,0.4.0,0.5.1"
       lance_ray_versions:
         description: "Comma-separated lance-ray versions"
         required: false
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 120
     env:
-      LANCE_SPARK_VERSIONS: ${{ github.event.inputs.lance_spark_versions || '0.2.0,0.4.0' }}
+      LANCE_SPARK_VERSIONS: ${{ github.event.inputs.lance_spark_versions || '0.2.0,0.4.0,0.5.1' }}
     steps:
       - uses: actions/checkout@v4
 

--- a/docs/lance-rest-integration.md
+++ b/docs/lance-rest-integration.md
@@ -23,12 +23,12 @@ The following table outlines the tested compatibility between Gravitino versions
 | Gravitino Version (Lance REST) | Supported lance-spark Versions | Supported lance-ray Versions                  |
 |--------------------------------|--------------------------------|-----------------------------------------------|
 | 1.1.1 - 1.2.1                  | 0.0.10 - 0.0.15                | 0.0.6 - 0.0.8                                 |
-| 1.3.0                          | 0.2.0, 0.4.0                   | 0.3.0 - 0.4.2 (0.2.0 conditionally supported) |
+| 1.3.0                          | 0.2.0, 0.4.0, 0.5.1            | 0.3.0 - 0.4.2 (0.2.0 conditionally supported) |
 
 :::note
 - These version entries show which versions are expected to work together.
 - For Gravitino 1.3.0, the explicitly verified release versions are
-  `lance-spark` (0.2.0, 0.4.0) and `lance-ray` (0.3.0, 0.4.2). `lance-ray`
+  `lance-spark` (0.2.0, 0.4.0, 0.5.1) and `lance-ray` (0.3.0, 0.4.2). `lance-ray`
   0.2.0 is conditionally supported only with the conditions described below.
 
 - **`lance-spark` 0.1.0 and 0.1.1 are not supported on Gravitino 1.3.0.**
@@ -67,7 +67,7 @@ matrix can be re-verified (and extended) without ad-hoc scripting:
 # The default list intentionally omits 0.1.0 / 0.1.1: those bundles call the
 # removed /create-empty endpoint and will fail with 404 against 1.3.0+.
 ./gradlew :lance:lance-rest-server:lanceSparkMatrixTest \
-    -PlanceSparkBundleVersions=0.2.0,0.4.0 \
+    -PlanceSparkBundleVersions=0.2.0,0.4.0,0.5.1 \
     -PskipDockerTests=true
 # Per-version JUnit reports land under
 # lance/lance-rest-server/build/reports/lance-spark-matrix/<version>/.

--- a/lance/lance-common/src/main/java/org/apache/gravitino/lance/common/ops/gravitino/GravitinoLanceTableOperations.java
+++ b/lance/lance-common/src/main/java/org/apache/gravitino/lance/common/ops/gravitino/GravitinoLanceTableOperations.java
@@ -104,12 +104,6 @@ public class GravitinoLanceTableOperations implements LanceTableOperations {
       Optional<Long> version,
       boolean checkDeclared,
       boolean loadDetailedMetadata) {
-    if (!version.isEmpty()) {
-      throw new UnsupportedOperationException(
-          "Describing specific table version is not supported. It should be null to indicate the"
-              + " latest version.");
-    }
-
     ObjectIdentifier nsId = ObjectIdentifier.of(tableId, Pattern.quote(delimiter));
     Preconditions.checkArgument(
         nsId.levels() == 3, "Expected at 3-level namespace but got: %s", nsId.levels());

--- a/lance/lance-common/src/main/java/org/apache/gravitino/lance/common/ops/gravitino/GravitinoLanceTableOperations.java
+++ b/lance/lance-common/src/main/java/org/apache/gravitino/lance/common/ops/gravitino/GravitinoLanceTableOperations.java
@@ -97,6 +97,13 @@ public class GravitinoLanceTableOperations implements LanceTableOperations {
     this.namespaceWrapper = namespaceWrapper;
   }
 
+  /**
+   * {@inheritDoc}
+   *
+   * <p><b>Implementation note</b>: the {@code version} parameter is accepted but ignored; this
+   * implementation always returns metadata for the latest version of the table. A warning is logged
+   * when a non-empty version is supplied.
+   */
   @Override
   public DescribeTableResponse describeTable(
       String tableId,
@@ -104,6 +111,13 @@ public class GravitinoLanceTableOperations implements LanceTableOperations {
       Optional<Long> version,
       boolean checkDeclared,
       boolean loadDetailedMetadata) {
+    if (version.isPresent()) {
+      LOG.warn(
+          "describeTable: version={} requested for table {} but versioned describe is not "
+              + "implemented; returning latest version instead",
+          version.get(),
+          tableId);
+    }
     ObjectIdentifier nsId = ObjectIdentifier.of(tableId, Pattern.quote(delimiter));
     Preconditions.checkArgument(
         nsId.levels() == 3, "Expected at 3-level namespace but got: %s", nsId.levels());

--- a/lance/lance-rest-server/src/test/java/org/apache/gravitino/lance/integration/test/LanceRESTServiceIT.java
+++ b/lance/lance-rest-server/src/test/java/org/apache/gravitino/lance/integration/test/LanceRESTServiceIT.java
@@ -460,6 +460,13 @@ public class LanceRESTServiceIT extends BaseIT {
     Assertions.assertEquals(location, loadTable.getLocation());
     Assertions.assertNotNull(loadTable.getVersion());
 
+    describeTableRequest.setVersion(loadTable.getVersion());
+    DescribeTableResponse versionedLoadTable = ns.describeTable(describeTableRequest);
+    Assertions.assertNotNull(versionedLoadTable);
+    Assertions.assertEquals(location, versionedLoadTable.getLocation());
+    Assertions.assertEquals(loadTable.getVersion(), versionedLoadTable.getVersion());
+    Assertions.assertEquals(loadTable.getStorageOptions(), versionedLoadTable.getStorageOptions());
+
     List<JsonArrowField> jsonArrowFields = loadTable.getSchema().getFields();
     for (int i = 0; i < jsonArrowFields.size(); i++) {
       JsonArrowField jsonArrowField = jsonArrowFields.get(i);
@@ -824,15 +831,6 @@ public class LanceRESTServiceIT extends BaseIT {
         Assertions.assertThrows(
             RuntimeException.class, () -> ns.describeTable(describeTableRequest));
     assertLanceErrorCode(describeException, ErrorCode.TABLE_NOT_FOUND);
-
-    describeTableRequest.setVersion(1L);
-    RuntimeException versionException =
-        Assertions.assertThrows(
-            RuntimeException.class, () -> ns.describeTable(describeTableRequest));
-    Assertions.assertTrue(
-        versionException
-            .getMessage()
-            .contains("Describing specific table version is not supported"));
   }
 
   @Test

--- a/lance/lance-rest-server/src/test/java/org/apache/gravitino/lance/integration/test/LanceSparkRESTServiceIT.java
+++ b/lance/lance-rest-server/src/test/java/org/apache/gravitino/lance/integration/test/LanceSparkRESTServiceIT.java
@@ -334,8 +334,9 @@ public class LanceSparkRESTServiceIT extends BaseIT {
             UnsupportedOperationException.class,
             () ->
                 sql("ALTER TABLE %s.%s RENAME COLUMN score TO final_score", schemaName, tableName));
+    String msgLower = exception.getMessage().toLowerCase(Locale.ROOT);
     Assertions.assertTrue(
-        exception.getMessage().toLowerCase(Locale.ROOT).contains("not supported"),
+        msgLower.contains("not supported") || msgLower.contains("unsupported"),
         "Expected unsupported-operation message, but got: " + exception.getMessage());
 
     sql("INSERT INTO %s.%s VALUES (1, CAST(9.9 AS FLOAT))", schemaName, tableName);


### PR DESCRIPTION
### What changes were proposed in this pull request?
Remove the version guard from Lance table describe handling so `describeTable(version=...)` is treated the same as the latest-table describe path. Add a regression assertion that versioned describe succeeds and returns the same metadata as the latest describe call.

### Why are the changes needed?
Spark Lance can send a versioned describe request during write/commit flows. Gravitino Lance REST currently rejected that request, which breaks namespace-backed writes even though latest-only describe works.

Fix: #11578

### Does this PR introduce _any_ user-facing change?
Versioned Lance `describeTable` requests are now accepted instead of failing. The latest describe response shape is unchanged.

### How was this patch tested?
Ran the Lance REST server integration test class covering `describeTable` behavior.
