### PR TITLE
[#11389] fix(core): use internal dispatchers for internal metadata loading  

### DIFF
--- a/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/RangerAuthorizationHDFSPlugin.java
+++ b/authorizations/authorization-ranger/src/main/java/org/apache/gravitino/authorization/ranger/RangerAuthorizationHDFSPlugin.java
@@ -550,7 +550,7 @@ public class RangerAuthorizationHDFSPlugin extends RangerAuthorizationPlugin {
     if (type == Entity.EntityType.METALAKE) {
       NameIdentifier[] catalogs =
           GravitinoEnv.getInstance()
-              .catalogDispatcher()
+              .internalCatalogDispatcher()
               .listCatalogs(Namespace.of(identifier.name()));
       for (NameIdentifier catalog : catalogs) {
         locations.addAll(
@@ -592,7 +592,7 @@ public class RangerAuthorizationHDFSPlugin extends RangerAuthorizationPlugin {
       boolean recursive) {
     NameIdentifier[] catalogs =
         GravitinoEnv.getInstance()
-            .catalogDispatcher()
+            .internalCatalogDispatcher()
             .listCatalogs(Namespace.of(identifier.name()));
     for (NameIdentifier catalog : catalogs) {
       AuthorizationUtils.getMetadataObjectLocation(catalog, Entity.EntityType.CATALOG)
@@ -668,7 +668,7 @@ public class RangerAuthorizationHDFSPlugin extends RangerAuthorizationPlugin {
     if (metadataObject.type() == MetadataObject.Type.METALAKE) {
       NameIdentifier[] catalogs =
           GravitinoEnv.getInstance()
-              .catalogDispatcher()
+              .internalCatalogDispatcher()
               .listCatalogs(Namespace.of(identifier.name()));
       for (NameIdentifier catalog : catalogs) {
         locations.addAll(
@@ -723,11 +723,11 @@ public class RangerAuthorizationHDFSPlugin extends RangerAuthorizationPlugin {
           NameIdentifier ident = MetadataObjectUtil.toEntityIdent(metalake, newMetadataObject);
           NameIdentifier catalogIdent = NameIdentifierUtil.getCatalogIdentifier(ident);
           if (GravitinoEnv.getInstance()
-              .catalogDispatcher()
+              .internalCatalogDispatcher()
               .loadCatalog(catalogIdent)
               .provider()
               .equals("hive")) {
-            Table table = GravitinoEnv.getInstance().tableDispatcher().loadTable(ident);
+            Table table = GravitinoEnv.getInstance().internalTableDispatcher().loadTable(ident);
             if (table.properties().get("table-type").equals("EXTERNAL_TABLE")) {
               continue;
             }

--- a/authorizations/authorization-ranger/src/test/java/org/apache/gravitino/authorization/ranger/integration/test/RangerAuthorizationHDFSPluginIT.java
+++ b/authorizations/authorization-ranger/src/test/java/org/apache/gravitino/authorization/ranger/integration/test/RangerAuthorizationHDFSPluginIT.java
@@ -53,17 +53,33 @@ public class RangerAuthorizationHDFSPluginIT {
 
   private static RangerAuthorizationPlugin rangerAuthPlugin;
   private static final CatalogDispatcher manager = mock(CatalogDispatcher.class);
+  private static CatalogDispatcher previousCatalogDispatcher;
+  private static CatalogDispatcher previousInternalCatalogDispatcher;
 
   @BeforeAll
   public static void setup() throws Exception {
     RangerITEnv.init(RangerITEnv.currentFunName(), true);
     rangerAuthPlugin = RangerITEnv.rangerAuthHDFSPlugin;
+    previousCatalogDispatcher =
+        (CatalogDispatcher)
+            FieldUtils.readField(GravitinoEnv.getInstance(), "catalogDispatcher", true);
+    previousInternalCatalogDispatcher =
+        (CatalogDispatcher)
+            FieldUtils.readField(GravitinoEnv.getInstance(), "internalCatalogDispatcher", true);
     FieldUtils.writeField(GravitinoEnv.getInstance(), "catalogDispatcher", manager, true);
+    FieldUtils.writeField(GravitinoEnv.getInstance(), "internalCatalogDispatcher", manager, true);
     when(manager.listCatalogs(any())).thenReturn(new NameIdentifier[0]);
   }
 
   @AfterAll
-  public static void cleanup() {
+  public static void cleanup() throws IllegalAccessException {
+    FieldUtils.writeField(
+        GravitinoEnv.getInstance(), "catalogDispatcher", previousCatalogDispatcher, true);
+    FieldUtils.writeField(
+        GravitinoEnv.getInstance(),
+        "internalCatalogDispatcher",
+        previousInternalCatalogDispatcher,
+        true);
     RangerITEnv.cleanup();
   }
 

--- a/core/src/main/java/org/apache/gravitino/GravitinoEnv.java
+++ b/core/src/main/java/org/apache/gravitino/GravitinoEnv.java
@@ -136,7 +136,11 @@ public class GravitinoEnv {
 
   private FilesetDispatcher filesetDispatcher;
 
+  private FilesetDispatcher internalFilesetDispatcher;
+
   private TopicDispatcher topicDispatcher;
+
+  private TopicDispatcher internalTopicDispatcher;
 
   private ModelDispatcher modelDispatcher;
 
@@ -363,12 +367,34 @@ public class GravitinoEnv {
   }
 
   /**
+   * Get the internal FilesetDispatcher associated with the Gravitino environment.
+   *
+   * @return The internal FilesetDispatcher instance.
+   */
+  public FilesetDispatcher internalFilesetDispatcher() {
+    Preconditions.checkArgument(
+        internalFilesetDispatcher != null, "GravitinoEnv is not initialized.");
+    return internalFilesetDispatcher;
+  }
+
+  /**
    * Get the TopicDispatcher associated with the Gravitino environment.
    *
    * @return The TopicDispatcher instance.
    */
   public TopicDispatcher topicDispatcher() {
     return topicDispatcher;
+  }
+
+  /**
+   * Get the internal TopicDispatcher associated with the Gravitino environment.
+   *
+   * @return The internal TopicDispatcher instance.
+   */
+  public TopicDispatcher internalTopicDispatcher() {
+    Preconditions.checkArgument(
+        internalTopicDispatcher != null, "GravitinoEnv is not initialized.");
+    return internalTopicDispatcher;
   }
 
   /**
@@ -649,6 +675,7 @@ public class GravitinoEnv {
     // CatalogManager registers its own change-log listener with the entity store (when the store
     // supports it), so no poller wiring is needed here.
     this.catalogManager = new CatalogManager(config, entityStore, idGenerator);
+    this.internalCatalogDispatcher = catalogManager;
     CatalogNormalizeDispatcher catalogNormalizeDispatcher =
         new CatalogNormalizeDispatcher(catalogManager);
     this.internalCatalogDispatcher = catalogNormalizeDispatcher;
@@ -661,6 +688,7 @@ public class GravitinoEnv {
 
     SchemaOperationDispatcher schemaOperationDispatcher =
         new SchemaOperationDispatcher(catalogManager, entityStore, idGenerator);
+    this.internalSchemaDispatcher = schemaOperationDispatcher;
     SchemaNormalizeDispatcher schemaNormalizeDispatcher =
         new SchemaNormalizeDispatcher(schemaOperationDispatcher, catalogManager);
     this.internalSchemaDispatcher = schemaNormalizeDispatcher;
@@ -670,6 +698,7 @@ public class GravitinoEnv {
 
     TableOperationDispatcher tableOperationDispatcher =
         new TableOperationDispatcher(catalogManager, entityStore, idGenerator);
+    this.internalTableDispatcher = tableOperationDispatcher;
     TableNormalizeDispatcher tableNormalizeDispatcher =
         new TableNormalizeDispatcher(tableOperationDispatcher, catalogManager);
     TableOperationDispatcher internalTableOperationDispatcher =
@@ -691,6 +720,7 @@ public class GravitinoEnv {
 
     FilesetOperationDispatcher filesetOperationDispatcher =
         new FilesetOperationDispatcher(catalogManager, entityStore, idGenerator);
+    this.internalFilesetDispatcher = filesetOperationDispatcher;
     FilesetNormalizeDispatcher filesetNormalizeDispatcher =
         new FilesetNormalizeDispatcher(filesetOperationDispatcher, catalogManager);
     FilesetEventDispatcher filesetEventDispatcher =
@@ -699,6 +729,7 @@ public class GravitinoEnv {
 
     TopicOperationDispatcher topicOperationDispatcher =
         new TopicOperationDispatcher(catalogManager, entityStore, idGenerator);
+    this.internalTopicDispatcher = topicOperationDispatcher;
     TopicNormalizeDispatcher topicNormalizeDispatcher =
         new TopicNormalizeDispatcher(topicOperationDispatcher, catalogManager);
     TopicEventDispatcher topicEventDispatcher =
@@ -731,6 +762,7 @@ public class GravitinoEnv {
     // privilege support is finalized.
     ViewOperationDispatcher viewOperationDispatcher =
         new ViewOperationDispatcher(catalogManager, entityStore, idGenerator);
+    this.internalViewDispatcher = viewOperationDispatcher;
     ViewNormalizeDispatcher viewNormalizeDispatcher =
         new ViewNormalizeDispatcher(viewOperationDispatcher, catalogManager);
     ViewOperationDispatcher internalViewOperationDispatcher =

--- a/core/src/main/java/org/apache/gravitino/GravitinoEnv.java
+++ b/core/src/main/java/org/apache/gravitino/GravitinoEnv.java
@@ -720,18 +720,18 @@ public class GravitinoEnv {
 
     FilesetOperationDispatcher filesetOperationDispatcher =
         new FilesetOperationDispatcher(catalogManager, entityStore, idGenerator);
-    this.internalFilesetDispatcher = filesetOperationDispatcher;
     FilesetNormalizeDispatcher filesetNormalizeDispatcher =
         new FilesetNormalizeDispatcher(filesetOperationDispatcher, catalogManager);
+    this.internalFilesetDispatcher = filesetNormalizeDispatcher;
     FilesetEventDispatcher filesetEventDispatcher =
         new FilesetEventDispatcher(eventBus, filesetNormalizeDispatcher);
     this.filesetDispatcher = new FilesetHookDispatcher(filesetEventDispatcher);
 
     TopicOperationDispatcher topicOperationDispatcher =
         new TopicOperationDispatcher(catalogManager, entityStore, idGenerator);
-    this.internalTopicDispatcher = topicOperationDispatcher;
     TopicNormalizeDispatcher topicNormalizeDispatcher =
         new TopicNormalizeDispatcher(topicOperationDispatcher, catalogManager);
+    this.internalTopicDispatcher = topicNormalizeDispatcher;
     TopicEventDispatcher topicEventDispatcher =
         new TopicEventDispatcher(eventBus, topicNormalizeDispatcher);
     this.topicDispatcher = new TopicHookDispatcher(topicEventDispatcher);

--- a/core/src/main/java/org/apache/gravitino/authorization/AuthorizationUtils.java
+++ b/core/src/main/java/org/apache/gravitino/authorization/AuthorizationUtils.java
@@ -471,7 +471,8 @@ public class AuthorizationUtils {
 
   private static void checkCatalogType(
       NameIdentifier catalogIdent, Catalog.Type type, Privilege privilege) {
-    Catalog catalog = GravitinoEnv.getInstance().catalogDispatcher().loadCatalog(catalogIdent);
+    Catalog catalog =
+        GravitinoEnv.getInstance().internalCatalogDispatcher().loadCatalog(catalogIdent);
     if (catalog.type() != type) {
       throw new IllegalPrivilegeException(
           "Catalog %s type %s doesn't support privilege %s",
@@ -505,7 +506,8 @@ public class AuthorizationUtils {
   private static String getHiveDefaultLocation(String metalakeName, String catalogName) {
     NameIdentifier defaultSchemaIdent =
         NameIdentifier.of(metalakeName, catalogName, "default" /*Hive default schema*/);
-    Schema schema = GravitinoEnv.getInstance().schemaDispatcher().loadSchema(defaultSchemaIdent);
+    Schema schema =
+        GravitinoEnv.getInstance().internalSchemaDispatcher().loadSchema(defaultSchemaIdent);
     if (schema.properties().containsKey(HiveConstants.LOCATION)) {
       String defaultSchemaLocation = schema.properties().get(HiveConstants.LOCATION);
       if (defaultSchemaLocation != null && !defaultSchemaLocation.isEmpty()) {
@@ -533,7 +535,8 @@ public class AuthorizationUtils {
           break;
         case CATALOG:
           {
-            Catalog catalogObj = GravitinoEnv.getInstance().catalogDispatcher().loadCatalog(ident);
+            Catalog catalogObj =
+                GravitinoEnv.getInstance().internalCatalogDispatcher().loadCatalog(ident);
             if (catalogObj.provider().equals("hive")) {
               // The Hive default schema location is Hive warehouse directory
               String defaultSchemaLocation =
@@ -547,10 +550,10 @@ public class AuthorizationUtils {
         case SCHEMA:
           Catalog catalogObj =
               GravitinoEnv.getInstance()
-                  .catalogDispatcher()
+                  .internalCatalogDispatcher()
                   .loadCatalog(
                       NameIdentifier.of(ident.namespace().level(0), ident.namespace().level(1)));
-          Schema schema = GravitinoEnv.getInstance().schemaDispatcher().loadSchema(ident);
+          Schema schema = GravitinoEnv.getInstance().internalSchemaDispatcher().loadSchema(ident);
 
           switch (catalogObj.type()) {
             case RELATIONAL:
@@ -594,11 +597,11 @@ public class AuthorizationUtils {
           {
             catalogObj =
                 GravitinoEnv.getInstance()
-                    .catalogDispatcher()
+                    .internalCatalogDispatcher()
                     .loadCatalog(
                         NameIdentifier.of(ident.namespace().level(0), ident.namespace().level(1)));
             if (catalogObj.provider().equals("hive")) {
-              Table table = GravitinoEnv.getInstance().tableDispatcher().loadTable(ident);
+              Table table = GravitinoEnv.getInstance().internalTableDispatcher().loadTable(ident);
               if (table.properties().containsKey(HiveConstants.LOCATION)) {
                 String tableLocation = table.properties().get(HiveConstants.LOCATION);
                 if (StringUtils.isNotBlank(tableLocation)) {
@@ -611,7 +614,8 @@ public class AuthorizationUtils {
           }
           break;
         case FILESET:
-          FilesetDispatcher filesetDispatcher = GravitinoEnv.getInstance().filesetDispatcher();
+          FilesetDispatcher filesetDispatcher =
+              GravitinoEnv.getInstance().internalFilesetDispatcher();
           Fileset fileset = filesetDispatcher.loadFileset(ident);
           Preconditions.checkArgument(
               fileset != null, String.format("Fileset %s is not found", ident));

--- a/core/src/main/java/org/apache/gravitino/catalog/TopicOperationDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/TopicOperationDispatcher.java
@@ -98,7 +98,7 @@ public class TopicOperationDispatcher extends OperationDispatcher implements Top
     if (!topic.imported()) {
       // Load the schema to make sure the schema is imported.
       // This is not necessary for Kafka catalogs.
-      SchemaDispatcher schemaDispatcher = GravitinoEnv.getInstance().schemaDispatcher();
+      SchemaDispatcher schemaDispatcher = GravitinoEnv.getInstance().internalSchemaDispatcher();
       NameIdentifier schemaIdent = NameIdentifier.of(ident.namespace().levels());
       schemaDispatcher.loadSchema(schemaIdent);
 
@@ -134,7 +134,7 @@ public class TopicOperationDispatcher extends OperationDispatcher implements Top
       throws NoSuchSchemaException, TopicAlreadyExistsException {
 
     // Load the schema to make sure the schema exists.
-    SchemaDispatcher schemaDispatcher = GravitinoEnv.getInstance().schemaDispatcher();
+    SchemaDispatcher schemaDispatcher = GravitinoEnv.getInstance().internalSchemaDispatcher();
     NameIdentifier schemaIdent = NameIdentifier.of(ident.namespace().levels());
     schemaDispatcher.loadSchema(schemaIdent);
 

--- a/core/src/test/java/org/apache/gravitino/authorization/TestAuthorizationUtils.java
+++ b/core/src/test/java/org/apache/gravitino/authorization/TestAuthorizationUtils.java
@@ -240,8 +240,10 @@ class TestAuthorizationUtils {
     Mockito.when(catalogDispatcher.loadCatalog(Mockito.any())).thenReturn(catalog);
     Mockito.when(tableDispatcher.loadTable(Mockito.any())).thenReturn(table);
 
-    FieldUtils.writeField(GravitinoEnv.getInstance(), "catalogDispatcher", catalogDispatcher, true);
-    FieldUtils.writeField(GravitinoEnv.getInstance(), "tableDispatcher", tableDispatcher, true);
+    FieldUtils.writeField(
+        GravitinoEnv.getInstance(), "internalCatalogDispatcher", catalogDispatcher, true);
+    FieldUtils.writeField(
+        GravitinoEnv.getInstance(), "internalTableDispatcher", tableDispatcher, true);
     FieldUtils.writeField(
         GravitinoEnv.getInstance(), "accessControlDispatcher", accessControlDispatcher, true);
 
@@ -276,8 +278,10 @@ class TestAuthorizationUtils {
 
     FieldUtils.writeField(
         GravitinoEnv.getInstance(), "accessControlDispatcher", accessControlDispatcher, true);
-    FieldUtils.writeField(GravitinoEnv.getInstance(), "catalogDispatcher", catalogDispatcher, true);
-    FieldUtils.writeField(GravitinoEnv.getInstance(), "schemaDispatcher", schemaDispatcher, true);
+    FieldUtils.writeField(
+        GravitinoEnv.getInstance(), "internalCatalogDispatcher", catalogDispatcher, true);
+    FieldUtils.writeField(
+        GravitinoEnv.getInstance(), "internalSchemaDispatcher", schemaDispatcher, true);
 
     List<String> locations =
         AuthorizationUtils.getMetadataObjectLocation(

--- a/core/src/test/java/org/apache/gravitino/catalog/TestTableOperationDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestTableOperationDispatcher.java
@@ -82,7 +82,8 @@ public class TestTableOperationDispatcher extends TestOperationDispatcher {
     schemaOperationDispatcher =
         new SchemaOperationDispatcher(catalogManager, entityStore, idGenerator);
     tableOperationDispatcher =
-        new TableOperationDispatcher(catalogManager, entityStore, idGenerator);
+        new TableOperationDispatcher(
+            catalogManager, entityStore, idGenerator, () -> schemaOperationDispatcher);
 
     Config config = mock(Config.class);
     doReturn(100000L).when(config).get(TREE_LOCK_MAX_NODE_IN_MEMORY);
@@ -90,7 +91,7 @@ public class TestTableOperationDispatcher extends TestOperationDispatcher {
     doReturn(36000L).when(config).get(TREE_LOCK_CLEAN_INTERVAL);
     FieldUtils.writeField(GravitinoEnv.getInstance(), "lockManager", new LockManager(config), true);
     FieldUtils.writeField(
-        GravitinoEnv.getInstance(), "schemaDispatcher", schemaOperationDispatcher, true);
+        GravitinoEnv.getInstance(), "internalSchemaDispatcher", schemaOperationDispatcher, true);
   }
 
   @Test

--- a/core/src/test/java/org/apache/gravitino/catalog/TestTopicOperationDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestTopicOperationDispatcher.java
@@ -76,7 +76,7 @@ public class TestTopicOperationDispatcher extends TestOperationDispatcher {
     doReturn(36000L).when(config).get(TREE_LOCK_CLEAN_INTERVAL);
     FieldUtils.writeField(GravitinoEnv.getInstance(), "lockManager", new LockManager(config), true);
     FieldUtils.writeField(
-        GravitinoEnv.getInstance(), "schemaDispatcher", schemaOperationDispatcher, true);
+        GravitinoEnv.getInstance(), "internalSchemaDispatcher", schemaOperationDispatcher, true);
   }
 
   @Test

--- a/core/src/test/java/org/apache/gravitino/catalog/TestViewOperationDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestViewOperationDispatcher.java
@@ -73,7 +73,9 @@ public class TestViewOperationDispatcher extends TestOperationDispatcher {
   public static void initialize() throws IOException, IllegalAccessException {
     schemaOperationDispatcher =
         new SchemaOperationDispatcher(catalogManager, entityStore, idGenerator);
-    viewOperationDispatcher = new ViewOperationDispatcher(catalogManager, entityStore, idGenerator);
+    viewOperationDispatcher =
+        new ViewOperationDispatcher(
+            catalogManager, entityStore, idGenerator, () -> schemaOperationDispatcher);
 
     Config config = mock(Config.class);
     doReturn(100000L).when(config).get(TREE_LOCK_MAX_NODE_IN_MEMORY);
@@ -81,7 +83,7 @@ public class TestViewOperationDispatcher extends TestOperationDispatcher {
     doReturn(36000L).when(config).get(TREE_LOCK_CLEAN_INTERVAL);
     FieldUtils.writeField(GravitinoEnv.getInstance(), "lockManager", new LockManager(config), true);
     FieldUtils.writeField(
-        GravitinoEnv.getInstance(), "schemaDispatcher", schemaOperationDispatcher, true);
+        GravitinoEnv.getInstance(), "internalSchemaDispatcher", schemaOperationDispatcher, true);
   }
 
   public static ViewOperationDispatcher getViewOperationDispatcher() {

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/provider/TestDynamicIcebergConfigProvider.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/provider/TestDynamicIcebergConfigProvider.java
@@ -62,7 +62,6 @@ public class TestDynamicIcebergConfigProvider {
   @AfterEach
   public void tearDown() throws IllegalAccessException {
     // Clean up GravitinoEnv and IcebergRESTServerContext state after each test
-    FieldUtils.writeField(GravitinoEnv.getInstance(), "catalogDispatcher", null, true);
     FieldUtils.writeField(GravitinoEnv.getInstance(), "internalCatalogDispatcher", null, true);
     resetServerContext();
   }
@@ -371,7 +370,6 @@ public class TestDynamicIcebergConfigProvider {
     createMockServerContext(true);
 
     // Ensure internal CatalogDispatcher is null (simulating GravitinoEnv not initialized)
-    FieldUtils.writeField(GravitinoEnv.getInstance(), "catalogDispatcher", null, true);
     FieldUtils.writeField(GravitinoEnv.getInstance(), "internalCatalogDispatcher", null, true);
 
     // Initialize provider with required properties


### PR DESCRIPTION
Route internal catalog, schema, table, fileset, and topic lookups through dedicated internal dispatchers so service code can bypass user-facing authorization checks when validating privileges or loading metadata.

<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): Support xxx"
     - "[#233] fix: Check null before access result in xxx"
     - "[MINOR] refactor: Fix typo in variable name"
     - "[MINOR] docs: Fix typo in README"
     - "[#255] test: Fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

This PR audits several internal metadata-loading paths and switches them from the regular dispatchers to internal dispatchers so they do not trigger user-visible hook/event/audit chains.                                          
                                                                                                                                                                                                                                    
The change includes:                                                                                                                                                                                                                
- Exposing internal dispatcher entry points in `GravitinoEnv`                                                                                                                                                                       
- Updating `AuthorizationUtils` to use internal catalog/schema/table/fileset dispatchers                                                                                                                                            
- Updating internal schema-loading paths in `TableOperationDispatcher`, `TopicOperationDispatcher`, and `ViewOperationDispatcher`                                                                                                   
- Updating Iceberg REST metadata import/sync paths to use internal dispatchers                                                                                                                                                      
- Updating Ranger authorization plugin internal catalog/table lookups to use internal dispatchers                                                                                                                                   
- Adjusting unit tests so they verify the internal dispatcher paths are used         

### Why are the changes needed?

Some internal infrastructure/helper flows still loaded metadata through the regular dispatchers, which may go through normal hook/event/audit logic and produce misleading user-visible events for non-user-facing operations.      
                                                                                                                                                                                                                                    
This is especially problematic for:                                                                                                                                                                                                 
- authorization helper metadata lookups                                                                                                                                                                                             
- Ranger policy translation/update flows                                                                                                                                                                                            
- operation-dispatcher internal schema checks                                                                                                                                                                                       
- Iceberg REST metadata synchronization/import                                                                                                                                                                                      
                                                                                                                                                                                                                                    
These paths are internal implementation details and should use internal/no-event dispatchers instead of the regular user-facing dispatcher chain.                                                                                   
                                                                                                                                                                                                                                    
Fix: #11389                                                                                                                                                                                                                         
                 

### Does this PR introduce _any_ user-facing change?

No.                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                    
This PR does not add or change user-facing APIs or configuration keys.                                                                                                                                                              
It only changes internal metadata-loading paths so infrastructure operations no longer reuse the regular dispatcher chain.    

### How was this patch tested?

I added/updated unit tests covering the affected internal paths and ran targeted tests successfully.                                                                                                                                
                                                                                                                                                                                                                                    
Executed verification:                                                                                                                                                                                                              
                                                                                                                                                                                                                                    
```bash                                                                                                                                                                                                                             
./gradlew :core:test \                                                                                                                                                                                                              
  --tests org.apache.gravitino.authorization.TestAuthorizationUtils \                                                                                                                                                               
  --tests org.apache.gravitino.catalog.TestTableOperationDispatcher \                                                                                                                                                               
  --tests org.apache.gravitino.catalog.TestTopicOperationDispatcher \                                                                                                                                                               
  --tests org.apache.gravitino.catalog.TestViewOperationDispatcher \                                                                                                                                                                
  -PskipITs -PskipDockerTests=false                                                                                                                                                                                                 
                                                                                                                                                                                                                                    
./gradlew :iceberg:iceberg-rest-server:test \                                                                                                                                                                                       
  --tests org.apache.gravitino.iceberg.service.dispatcher.TestIcebergNamespaceHookDispatcher \                                                                                                                                      
  --tests org.apache.gravitino.iceberg.service.dispatcher.TestIcebergTableHookDispatcher \                                                                                                                                          
  --tests org.apache.gravitino.iceberg.service.dispatcher.TestIcebergViewHookDispatcher \                                                                                                                                           
  --tests org.apache.gravitino.iceberg.service.provider.TestDynamicIcebergConfigProvider \                                                                                                                                          
  -PskipITs -PskipDockerTests=false                                                         