### PR TITLE
[#11602] fix(test): Fix flaky TopicAuthorizationIT

### DIFF
--- a/clients/client-java/src/test/java/org/apache/gravitino/client/integration/test/authorization/TopicAuthorizationIT.java
+++ b/clients/client-java/src/test/java/org/apache/gravitino/client/integration/test/authorization/TopicAuthorizationIT.java
@@ -151,24 +151,31 @@ public class TopicAuthorizationIT extends BaseRestApiAuthorizationIT {
   @Order(2)
   public void testListTopic() {
     TopicCatalog topicCatalog = client.loadMetalake(METALAKE).loadCatalog(CATALOG).asTopicCatalog();
-    NameIdentifier[] topicsList = topicCatalog.listTopics(Namespace.of(SCHEMA));
-    assertArrayEquals(
-        new NameIdentifier[] {
-          NameIdentifier.of(SCHEMA, "topic1"),
-          NameIdentifier.of(SCHEMA, "topic2"),
-          NameIdentifier.of(SCHEMA, "topic3")
-        },
-        topicsList);
     // normal user can only see topics they have privilege for
     TopicCatalog topicCatalogNormalUser =
         normalUserClient.loadMetalake(METALAKE).loadCatalog(CATALOG).asTopicCatalog();
 
-    NameIdentifier[] topicsListNormalUser = topicCatalogNormalUser.listTopics(Namespace.of(SCHEMA));
-    assertArrayEquals(
-        new NameIdentifier[] {
-          NameIdentifier.of(SCHEMA, "topic2"), NameIdentifier.of(SCHEMA, "topic3")
-        },
-        topicsListNormalUser);
+    Awaitility.await()
+        .atMost(30, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              NameIdentifier[] topicsList = topicCatalog.listTopics(Namespace.of(SCHEMA));
+              assertArrayEquals(
+                  new NameIdentifier[] {
+                    NameIdentifier.of(SCHEMA, "topic1"),
+                    NameIdentifier.of(SCHEMA, "topic2"),
+                    NameIdentifier.of(SCHEMA, "topic3")
+                  },
+                  topicsList);
+
+              NameIdentifier[] topicsListNormalUser =
+                  topicCatalogNormalUser.listTopics(Namespace.of(SCHEMA));
+              assertArrayEquals(
+                  new NameIdentifier[] {
+                    NameIdentifier.of(SCHEMA, "topic2"), NameIdentifier.of(SCHEMA, "topic3")
+                  },
+                  topicsListNormalUser);
+            });
   }
 
   @Test


### PR DESCRIPTION
### What changes were proposed in this pull request?

Use Awaitility in `TopicAuthorizationIT.testListTopic()` to wait until all created Kafka topics are visible to both the owner and the normal user.

### Why are the changes needed?

Kafka topic metadata may not be immediately visible after topic creation, causing `testListTopic()` to intermittently return only two of the three expected topics.

Fix: #11602

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

- `./gradlew :clients:client-java:spotlessApply`
- `./gradlew :clients:client-java:compileTestJava -PskipITs`

The Kafka integration test was not run locally because Docker was unavailable.