### PR TITLE
[#11580] feat(iceberg): Support credential vending in planTableScan endpoint

### DIFF
--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/rest/IcebergTableOperations.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/rest/IcebergTableOperations.java
@@ -511,15 +511,20 @@ public class IcebergTableOperations {
       @Encoded() @PathParam("namespace") @AuthorizationMetadata(type = EntityType.SCHEMA)
           String namespace,
       @Encoded() @PathParam("table") @AuthorizationMetadata(type = EntityType.TABLE) String table,
-      PlanTableScanRequest scanRequest) {
+      PlanTableScanRequest scanRequest,
+      @HeaderParam(X_ICEBERG_ACCESS_DELEGATION) String accessDelegation) {
+    boolean isCredentialVending = isCredentialVending(accessDelegation);
     String catalogName = IcebergRESTUtils.getCatalogName(prefix);
     Namespace icebergNS = RESTUtil.decodeNamespace(namespace);
     String tableName = RESTUtil.decodeString(table);
     LOG.info(
-        "Plan table scan, catalog: {}, namespace: {}, table: {}",
+        "Plan table scan, catalog: {}, namespace: {}, table: {}, accessDelegation: {}, "
+            + "isCredentialVending: {}",
         catalogName,
         icebergNS,
-        tableName);
+        tableName,
+        accessDelegation,
+        isCredentialVending);
 
     try {
       return Utils.doAs(
@@ -527,7 +532,7 @@ public class IcebergTableOperations {
           () -> {
             TableIdentifier tableIdentifier = TableIdentifier.of(icebergNS, tableName);
             IcebergRequestContext context =
-                new IcebergRequestContext(httpServletRequest(), catalogName);
+                new IcebergRequestContext(httpServletRequest(), catalogName, isCredentialVending);
 
             PlanTableScanResponse scanResponse =
                 tableOperationDispatcher.planTableScan(context, tableIdentifier, scanRequest);

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/TestIcebergTableOperations.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/TestIcebergTableOperations.java
@@ -203,6 +203,66 @@ public class TestIcebergTableOperations extends IcebergNamespaceTestBase {
 
   @ParameterizedTest
   @MethodSource("org.apache.gravitino.iceberg.service.rest.IcebergRestTestUtil#testNamespaces")
+  void testPlanTableScanWithCredentialVending(Namespace namespace) {
+    verifyCreateNamespaceSucc(namespace);
+    verifyCreateTableSucc(namespace, "plan_scan_cred_vending", true);
+
+    dummyEventListener.clearEvent();
+    TableMetadata metadata = getTableMeta(namespace, "plan_scan_cred_vending");
+    Long snapshotId = metadata.ref(SnapshotRef.MAIN_BRANCH).snapshotId();
+
+    PlanTableScanRequest request = buildPlanTableScanRequest(snapshotId);
+    Response response =
+        doPlanTableScanWithAccessDelegation(
+            namespace, "plan_scan_cred_vending", request, "vended-credentials");
+    Assertions.assertEquals(Status.OK.getStatusCode(), response.getStatus());
+
+    Assertions.assertTrue(dummyEventListener.popPreEvent() instanceof IcebergPlanTableScanPreEvent);
+    Assertions.assertTrue(dummyEventListener.popPostEvent() instanceof IcebergPlanTableScanEvent);
+  }
+
+  @ParameterizedTest
+  @MethodSource("org.apache.gravitino.iceberg.service.rest.IcebergRestTestUtil#testNamespaces")
+  void testPlanTableScanRemoteSigningNotSupported(Namespace namespace) {
+    verifyCreateNamespaceSucc(namespace);
+    verifyCreateTableSucc(namespace, "plan_scan_remote_signing", true);
+
+    TableMetadata metadata = getTableMeta(namespace, "plan_scan_remote_signing");
+    Long snapshotId = metadata.ref(SnapshotRef.MAIN_BRANCH).snapshotId();
+
+    PlanTableScanRequest request = buildPlanTableScanRequest(snapshotId);
+    Response response =
+        doPlanTableScanWithAccessDelegation(
+            namespace, "plan_scan_remote_signing", request, "remote-signing");
+    Assertions.assertEquals(406, response.getStatus());
+    String errorBody = response.readEntity(String.class);
+    Assertions.assertTrue(
+        errorBody.contains("remote signing") || errorBody.contains("remote-signing"),
+        "Error message should mention remote signing: " + errorBody);
+  }
+
+  @ParameterizedTest
+  @MethodSource("org.apache.gravitino.iceberg.service.rest.IcebergRestTestUtil#testNamespaces")
+  void testPlanTableScanInvalidAccessDelegation(Namespace namespace) {
+    verifyCreateNamespaceSucc(namespace);
+    verifyCreateTableSucc(namespace, "plan_scan_invalid_delegation", true);
+
+    TableMetadata metadata = getTableMeta(namespace, "plan_scan_invalid_delegation");
+    Long snapshotId = metadata.ref(SnapshotRef.MAIN_BRANCH).snapshotId();
+
+    PlanTableScanRequest request = buildPlanTableScanRequest(snapshotId);
+    Response response =
+        doPlanTableScanWithAccessDelegation(
+            namespace, "plan_scan_invalid_delegation", request, "invalid-value");
+    Assertions.assertEquals(400, response.getStatus());
+    String errorBody = response.readEntity(String.class);
+    Assertions.assertTrue(
+        errorBody.contains("vended-credentials") && errorBody.contains("illegal"),
+        "Error message should mention valid values: " + errorBody);
+  }
+
+  @ParameterizedTest
+  @MethodSource("org.apache.gravitino.iceberg.service.rest.IcebergRestTestUtil#testNamespaces")
   void testPlanTableScanWithIncrementalAppendScanValidRange(Namespace namespace) {
     verifyCreateNamespaceSucc(namespace);
     verifyCreateTableSucc(namespace, "incremental_scan_valid_table", true);
@@ -495,6 +555,14 @@ public class TestIcebergTableOperations extends IcebergNamespaceTestBase {
 
   private Response doPlanTableScan(Namespace ns, String tableName, PlanTableScanRequest request) {
     Invocation.Builder builder = getTableClientBuilder(ns, Optional.of(tableName + "/plan"));
+    return builder.post(Entity.entity(request, MediaType.APPLICATION_JSON_TYPE));
+  }
+
+  private Response doPlanTableScanWithAccessDelegation(
+      Namespace ns, String tableName, PlanTableScanRequest request, String accessDelegation) {
+    Invocation.Builder builder =
+        getTableClientBuilder(ns, Optional.of(tableName + "/plan"))
+            .header(IcebergTableOperations.X_ICEBERG_ACCESS_DELEGATION, accessDelegation);
     return builder.post(Entity.entity(request, MediaType.APPLICATION_JSON_TYPE));
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add `X-Iceberg-Access-Delegation` header support to the `planTableScan` endpoint, mirroring the existing behavior in `loadTable` and `createTable`:

- Add `@HeaderParam(X_ICEBERG_ACCESS_DELEGATION) String accessDelegation` parameter to `planTableScan`
- Derive `isCredentialVending` via the existing `isCredentialVending()` helper
- Pass `isCredentialVending` into the `IcebergRequestContext` 3-arg constructor
- Update logging to include access delegation info

### Why are the changes needed?

The `planTableScan` endpoint does not honor the `X-Iceberg-Access-Delegation` header. Unlike `loadTable` and `createTable`, which accept the header and construct an `IcebergRequestContext` with `isCredentialVending=true`, `planTableScan` builds the context without it. As a result, scan-planning responses cannot carry vended storage credentials, forcing clients to make a separate `loadTable` call to obtain them.

Fix: #11580

### Does this PR introduce _any_ user-facing change?

The `planTableScan` REST endpoint now accepts the `X-Iceberg-Access-Delegation` header. When `vended-credentials` is specified, the response can include vended storage credentials (consistent with `loadTable` / `createTable`).

### How was this patch tested?

Added three new parameterized tests in `TestIcebergTableOperations`:

- `testPlanTableScanWithCredentialVending` — verifies the vended-credentials path returns 200 OK
- `testPlanTableScanRemoteSigningNotSupported` — verifies remote-signing returns 406
- `testPlanTableScanInvalidAccessDelegation` — verifies invalid values return 400

All 66 tests in `TestIcebergTableOperations` pass (0 failures).