### PR TITLE
[Cherry-pick to branch-1.3] build(deps-dev): bump banks from 2.4.1 to 2.4.2 in /clients/client-python (#11383)

### DIFF
--- a/clients/client-python/requirements-dev.txt
+++ b/clients/client-python/requirements-dev.txt
@@ -32,7 +32,7 @@ pyjwt[crypto]==2.11.0
 jwcrypto==1.5.6
 sphinx==7.1.2
 furo==2024.8.6
-banks==2.4.1
+banks==2.4.2
 
 # Lance integration deps. Pinned so the default integration test runs against
 # a single, known-good (server-side `lance-namespace-core` 0.7.5+) combination.


### PR DESCRIPTION
Cherry-pick #11383 to branch-1.3.

### What changes were proposed in this pull request?

Bumps `banks` from 2.4.1 to 2.4.2 in `/clients/client-python`.

### Why are the changes needed?

Dependency version update for the Python client.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

N/A (dependency bump only)