### PR TITLE
[#11604] fix(bundle): Include Gravitino credential providers in Iceberg cloud bundles

### DIFF
--- a/bundles/iceberg-aliyun-bundle/build.gradle.kts
+++ b/bundles/iceberg-aliyun-bundle/build.gradle.kts
@@ -30,6 +30,8 @@ dependencies {
   // Aliyun oss SDK depends on this package, and JDK >= 9 requires manual add
   // https://www.alibabacloud.com/help/en/oss/developer-reference/java-installation?spm=a2c63.p38356.0.i1
   implementation(libs.sun.activation)
+  // Include Gravitino Aliyun credential providers (OSSSecretKeyProvider, etc.) for credential vending
+  implementation(project(":bundles:aliyun"))
 }
 
 tasks.withType(ShadowJar::class.java) {
@@ -39,6 +41,11 @@ tasks.withType(ShadowJar::class.java) {
 
   dependencies {
     exclude(dependency("org.slf4j:slf4j-api"))
+    // Exclude Gravitino modules to prevent class duplication with server classpath
+    exclude(project(":api"))
+    exclude(project(":common"))
+    exclude(project(":catalogs:catalog-common"))
+    exclude(project(":catalogs:hadoop-common"))
   }
 
   mergeServiceFiles()

--- a/bundles/iceberg-aws-bundle/build.gradle.kts
+++ b/bundles/iceberg-aws-bundle/build.gradle.kts
@@ -30,6 +30,8 @@ dependencies {
     exclude("*")
   }
   implementation(libs.iceberg.aws.bundle)
+  // Include Gravitino AWS credential providers (S3SecretKeyProvider, etc.) for credential vending
+  implementation(project(":bundles:aws"))
 }
 
 tasks.withType(ShadowJar::class.java) {
@@ -39,6 +41,11 @@ tasks.withType(ShadowJar::class.java) {
 
   dependencies {
     exclude(dependency("org.slf4j:slf4j-api"))
+    // Exclude Gravitino modules to prevent class duplication with server classpath
+    exclude(project(":api"))
+    exclude(project(":common"))
+    exclude(project(":catalogs:catalog-common"))
+    exclude(project(":catalogs:hadoop-common"))
   }
 
   // Iceberg AWS bundle includes Log4j (before 1.10.1), so exclude to avoid conflicts

--- a/bundles/iceberg-azure-bundle/build.gradle.kts
+++ b/bundles/iceberg-azure-bundle/build.gradle.kts
@@ -30,9 +30,9 @@ configurations.shadow {
 }
 
 dependencies {
-  // The iceberg-azure-bundle already includes the dependencies
-  // required by Gravitino for credential vending.
   implementation(libs.iceberg.azure.bundle)
+  // Include Gravitino Azure credential providers (AzureAccountKeyProvider, etc.) for credential vending
+  implementation(project(":bundles:azure"))
 }
 
 tasks.withType(ShadowJar::class.java) {
@@ -42,6 +42,11 @@ tasks.withType(ShadowJar::class.java) {
 
   dependencies {
     exclude(dependency("org.slf4j:slf4j-api"))
+    // Exclude Gravitino modules to prevent class duplication with server classpath
+    exclude(project(":api"))
+    exclude(project(":common"))
+    exclude(project(":catalogs:catalog-common"))
+    exclude(project(":catalogs:hadoop-common"))
   }
 
   mergeServiceFiles()


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add `bundles:aws`, `bundles:aliyun`, and `bundles:azure` as dependencies of `iceberg-aws-bundle`, `iceberg-aliyun-bundle`, and `iceberg-azure-bundle` respectively, so that `S3SecretKeyProvider`, `OSSSecretKeyProvider`, and `AzureAccountKeyProvider` are included via SPI and discoverable by `ServiceLoader` in the catalog `IsolatedClassLoader`.

### Why are the changes needed?

Fix #11604

When users place `gravitino-iceberg-aws-bundle` in `catalogs/lakehouse-iceberg/libs/` as documented, credential vending fails with `No credential provider found for: s3-secret-key` because the provider SPI was missing from the bundle.

### Does this PR introduce _any_ user-facing change?

Yes. Users who place the Iceberg cloud bundle in `catalogs/lakehouse-iceberg/libs/` as documented will now get credential vending working automatically.

### How was this patch tested?

Manually created an Iceberg catalog with S3 static credentials and called the credentials API to confirm the fix.