### PR TITLE
[#11565][#11566] feat(mcp-server): add --token CLI param and inject Bearer token into Gravitino REST calls

### DIFF
--- a/mcp-server/mcp_server/client/factory.py
+++ b/mcp-server/mcp_server/client/factory.py
@@ -29,7 +29,7 @@ class RESTClientFactory:
 
     @classmethod
     def create_rest_client(
-        cls, metalake_name: str, uri: str
+        cls, metalake_name: str, uri: str, token: str = ""
     ) -> "PlainRESTClientOperation":
         """
         Create a new rest client instance with the specified parameters.
@@ -37,11 +37,12 @@ class RESTClientFactory:
         Args:
             metalake_name: Name of the metalake
             uri: URI of the Gravitino server endpoint
+            token: Bearer token for Authorization header (empty = anonymous)
 
         Returns:
             New instance of the configured rest client class
         """
-        return cls._rest_client_class(metalake_name, uri)
+        return cls._rest_client_class(metalake_name, uri, token)
 
     @classmethod
     def set_rest_client(cls, rest_client_class: type) -> None:

--- a/mcp-server/mcp_server/client/plain/plain_rest_client_operation.py
+++ b/mcp-server/mcp_server/client/plain/plain_rest_client_operation.py
@@ -62,8 +62,11 @@ from mcp_server.client.topic_operation import TopicOperation
 
 # pylint: disable=too-many-instance-attributes
 class PlainRESTClientOperation(GravitinoOperation):
-    def __init__(self, metalake_name: str, uri: str):
-        _rest_client = httpx.AsyncClient(base_url=uri)
+    def __init__(self, metalake_name: str, uri: str, token: str = ""):
+        headers = {}
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
+        _rest_client = httpx.AsyncClient(base_url=uri, headers=headers)
         self._catalog_operation = PlainRESTClientCatalogOperation(
             metalake_name, _rest_client
         )

--- a/mcp-server/mcp_server/core/context.py
+++ b/mcp-server/mcp_server/core/context.py
@@ -22,7 +22,7 @@ from mcp_server.core.setting import Setting
 class GravitinoContext:
     def __init__(self, setting: Setting):
         self.gravitino_client = RESTClientFactory.create_rest_client(
-            setting.metalake, setting.gravitino_uri
+            setting.metalake, setting.gravitino_uri, setting.token
         )
 
     def rest_client(self):

--- a/mcp-server/mcp_server/core/setting.py
+++ b/mcp-server/mcp_server/core/setting.py
@@ -33,3 +33,14 @@ class Setting:
     tags: Set[str] = field(default_factory=set)
     transport: str = DefaultSetting.default_transport
     mcp_url: str = DefaultSetting.default_mcp_url
+    # Bearer token forwarded to Gravitino on every request.
+    # Empty string means anonymous (no Authorization header sent).
+    token: str = ""
+
+    def __str__(self) -> str:
+        token_display = "***" if self.token else ""
+        return (
+            f"Setting(metalake={self.metalake}, gravitino_uri={self.gravitino_uri}, "
+            f"tags={self.tags}, transport={self.transport}, mcp_url={self.mcp_url}, "
+            f"token={token_display})"
+        )

--- a/mcp-server/mcp_server/core/setting.py
+++ b/mcp-server/mcp_server/core/setting.py
@@ -35,7 +35,8 @@ class Setting:
     mcp_url: str = DefaultSetting.default_mcp_url
     # Bearer token forwarded to Gravitino on every request.
     # Empty string means anonymous (no Authorization header sent).
-    token: str = ""
+    # repr=False keeps the raw value out of the dataclass-generated __repr__.
+    token: str = field(default="", repr=False)
 
     def __str__(self) -> str:
         token_display = "***" if self.token else ""

--- a/mcp-server/mcp_server/main.py
+++ b/mcp-server/mcp_server/main.py
@@ -17,6 +17,7 @@
 
 import argparse
 import logging
+import os
 
 from mcp_server.core.setting import DefaultSetting, Setting
 from mcp_server.server import GravitinoMCPServer
@@ -30,6 +31,7 @@ def do_main():
         tags=args.include_tool_tags,
         transport=args.transport,
         mcp_url=args.mcp_url,
+        token=args.token,
     )
     _init_logging(setting)
     logging.info("Gravitino MCP server setting: %s", setting)
@@ -94,6 +96,15 @@ def _parse_args():
         type=str,
         default=DefaultSetting.default_mcp_url,
         help=f"The url of MCP server if using http transport. (default: {DefaultSetting.default_mcp_url})",
+    )
+
+    parser.add_argument(
+        "--token",
+        type=str,
+        default=os.environ.get("GRAVITINO_TOKEN", ""),
+        help="Bearer token forwarded as Authorization header to Gravitino on every request. "
+        "Can also be set via the GRAVITINO_TOKEN environment variable. "
+        "When omitted, requests are sent without authentication.",
     )
 
     args = parser.parse_args()

--- a/mcp-server/tests/unit/test_auth_flow.py
+++ b/mcp-server/tests/unit/test_auth_flow.py
@@ -28,12 +28,17 @@ from mcp_server.core.setting import Setting
 from mcp_server.main import _parse_args
 
 
+def _shared_rest_client(operation: PlainRESTClientOperation):
+    # pylint: disable=protected-access
+    return operation._catalog_operation.rest_client
+
+
 def _headers_of(operation: PlainRESTClientOperation):
-    return operation._catalog_operation.rest_client.headers
+    return _shared_rest_client(operation).headers
 
 
 def _close(operation: PlainRESTClientOperation):
-    asyncio.run(operation._catalog_operation.rest_client.aclose())
+    asyncio.run(_shared_rest_client(operation).aclose())
 
 
 class TestTokenInjection(unittest.TestCase):

--- a/mcp-server/tests/unit/test_auth_flow.py
+++ b/mcp-server/tests/unit/test_auth_flow.py
@@ -1,0 +1,93 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import unittest
+
+from mcp_server.client.plain.plain_rest_client_operation import (
+    PlainRESTClientOperation,
+)
+from mcp_server.core.context import GravitinoContext
+from mcp_server.core.setting import Setting
+
+
+class TestTokenInjection(unittest.TestCase):
+    """Verify Bearer token is correctly injected into the httpx client."""
+
+    def test_token_sets_authorization_header(self):
+        """When a token is provided, the httpx client carries Authorization: Bearer."""
+        client = PlainRESTClientOperation(
+            "my_metalake", "http://localhost:8090", token="my-secret-token"
+        )
+        headers = dict(client._catalog_operation.rest_client.headers)
+        self.assertEqual(headers.get("authorization"), "Bearer my-secret-token")
+
+    def test_empty_token_no_authorization_header(self):
+        """When token is empty, no Authorization header is added."""
+        client = PlainRESTClientOperation(
+            "my_metalake", "http://localhost:8090", token=""
+        )
+        headers = dict(client._catalog_operation.rest_client.headers)
+        self.assertNotIn("authorization", headers)
+
+    def test_no_token_argument_no_authorization_header(self):
+        """When token argument is omitted entirely, no Authorization header is added."""
+        client = PlainRESTClientOperation("my_metalake", "http://localhost:8090")
+        headers = dict(client._catalog_operation.rest_client.headers)
+        self.assertNotIn("authorization", headers)
+
+
+class TestSettingTokenMasking(unittest.TestCase):
+    """Verify that the token is not exposed in Setting string representation."""
+
+    def test_token_masked_in_str(self):
+        """Token value must not appear in Setting.__str__."""
+        setting = Setting(metalake="ml", token="super-secret-token-value")
+        self.assertNotIn("super-secret-token-value", str(setting))
+        self.assertIn("***", str(setting))
+
+    def test_empty_token_shows_empty_in_str(self):
+        """When no token is set, __str__ shows empty placeholder."""
+        setting = Setting(metalake="ml", token="")
+        self.assertNotIn("***", str(setting))
+
+
+class TestGravitinoContextTokenPropagation(unittest.TestCase):
+    """Verify GravitinoContext passes token from Setting to the REST client."""
+
+    def test_context_propagates_token(self):
+        """Token from Setting reaches the httpx client Authorization header."""
+        setting = Setting(
+            metalake="ml",
+            gravitino_uri="http://localhost:8090",
+            token="ctx-token-xyz",
+        )
+        ctx = GravitinoContext(setting)
+        rest_client = ctx.rest_client()
+        headers = dict(rest_client._catalog_operation.rest_client.headers)
+        self.assertEqual(headers.get("authorization"), "Bearer ctx-token-xyz")
+
+    def test_context_anonymous_when_no_token(self):
+        """Empty token in Setting → no Authorization header in REST calls."""
+        setting = Setting(
+            metalake="ml",
+            gravitino_uri="http://localhost:8090",
+            token="",
+        )
+        ctx = GravitinoContext(setting)
+        rest_client = ctx.rest_client()
+        headers = dict(rest_client._catalog_operation.rest_client.headers)
+        self.assertNotIn("authorization", headers)

--- a/mcp-server/tests/unit/test_auth_flow.py
+++ b/mcp-server/tests/unit/test_auth_flow.py
@@ -15,13 +15,25 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import asyncio
+import sys
 import unittest
+from unittest import mock
 
 from mcp_server.client.plain.plain_rest_client_operation import (
     PlainRESTClientOperation,
 )
 from mcp_server.core.context import GravitinoContext
 from mcp_server.core.setting import Setting
+from mcp_server.main import _parse_args
+
+
+def _headers_of(operation: PlainRESTClientOperation):
+    return operation._catalog_operation.rest_client.headers
+
+
+def _close(operation: PlainRESTClientOperation):
+    asyncio.run(operation._catalog_operation.rest_client.aclose())
 
 
 class TestTokenInjection(unittest.TestCase):
@@ -32,26 +44,37 @@ class TestTokenInjection(unittest.TestCase):
         client = PlainRESTClientOperation(
             "my_metalake", "http://localhost:8090", token="my-secret-token"
         )
-        headers = dict(client._catalog_operation.rest_client.headers)
-        self.assertEqual(headers.get("authorization"), "Bearer my-secret-token")
+        try:
+            self.assertEqual(
+                _headers_of(client).get("Authorization"),
+                "Bearer my-secret-token",
+            )
+        finally:
+            _close(client)
 
     def test_empty_token_no_authorization_header(self):
         """When token is empty, no Authorization header is added."""
         client = PlainRESTClientOperation(
             "my_metalake", "http://localhost:8090", token=""
         )
-        headers = dict(client._catalog_operation.rest_client.headers)
-        self.assertNotIn("authorization", headers)
+        try:
+            self.assertIsNone(_headers_of(client).get("Authorization"))
+        finally:
+            _close(client)
 
     def test_no_token_argument_no_authorization_header(self):
         """When token argument is omitted entirely, no Authorization header is added."""
-        client = PlainRESTClientOperation("my_metalake", "http://localhost:8090")
-        headers = dict(client._catalog_operation.rest_client.headers)
-        self.assertNotIn("authorization", headers)
+        client = PlainRESTClientOperation(
+            "my_metalake", "http://localhost:8090"
+        )
+        try:
+            self.assertIsNone(_headers_of(client).get("Authorization"))
+        finally:
+            _close(client)
 
 
 class TestSettingTokenMasking(unittest.TestCase):
-    """Verify that the token is not exposed in Setting string representation."""
+    """Verify that the token is not exposed in Setting string representations."""
 
     def test_token_masked_in_str(self):
         """Token value must not appear in Setting.__str__."""
@@ -59,10 +82,45 @@ class TestSettingTokenMasking(unittest.TestCase):
         self.assertNotIn("super-secret-token-value", str(setting))
         self.assertIn("***", str(setting))
 
+    def test_token_not_in_repr(self):
+        """Token value must not appear in Setting.__repr__ either."""
+        setting = Setting(metalake="ml", token="super-secret-token-value")
+        self.assertNotIn("super-secret-token-value", repr(setting))
+
     def test_empty_token_shows_empty_in_str(self):
         """When no token is set, __str__ shows empty placeholder."""
         setting = Setting(metalake="ml", token="")
         self.assertNotIn("***", str(setting))
+
+
+class TestTokenArgParsing(unittest.TestCase):
+    """Verify --token CLI argument and GRAVITINO_TOKEN env var precedence."""
+
+    def test_env_var_used_when_token_omitted(self):
+        """GRAVITINO_TOKEN is used when --token is not passed."""
+        with mock.patch.dict(
+            "os.environ", {"GRAVITINO_TOKEN": "env-token"}
+        ), mock.patch.object(sys, "argv", ["prog", "--metalake", "ml"]):
+            args = _parse_args()
+        self.assertEqual(args.token, "env-token")
+
+    def test_cli_token_overrides_env_var(self):
+        """--token takes precedence over GRAVITINO_TOKEN when both are set."""
+        with mock.patch.dict(
+            "os.environ", {"GRAVITINO_TOKEN": "env-token"}
+        ), mock.patch.object(
+            sys, "argv", ["prog", "--metalake", "ml", "--token", "cli-token"]
+        ):
+            args = _parse_args()
+        self.assertEqual(args.token, "cli-token")
+
+    def test_no_token_anywhere_defaults_to_empty(self):
+        """Without --token and GRAVITINO_TOKEN, token defaults to empty string."""
+        with mock.patch.dict("os.environ", {}, clear=True), mock.patch.object(
+            sys, "argv", ["prog", "--metalake", "ml"]
+        ):
+            args = _parse_args()
+        self.assertEqual(args.token, "")
 
 
 class TestGravitinoContextTokenPropagation(unittest.TestCase):
@@ -77,8 +135,13 @@ class TestGravitinoContextTokenPropagation(unittest.TestCase):
         )
         ctx = GravitinoContext(setting)
         rest_client = ctx.rest_client()
-        headers = dict(rest_client._catalog_operation.rest_client.headers)
-        self.assertEqual(headers.get("authorization"), "Bearer ctx-token-xyz")
+        try:
+            self.assertEqual(
+                _headers_of(rest_client).get("Authorization"),
+                "Bearer ctx-token-xyz",
+            )
+        finally:
+            _close(rest_client)
 
     def test_context_anonymous_when_no_token(self):
         """Empty token in Setting → no Authorization header in REST calls."""
@@ -89,5 +152,7 @@ class TestGravitinoContextTokenPropagation(unittest.TestCase):
         )
         ctx = GravitinoContext(setting)
         rest_client = ctx.rest_client()
-        headers = dict(rest_client._catalog_operation.rest_client.headers)
-        self.assertNotIn("authorization", headers)
+        try:
+            self.assertIsNone(_headers_of(rest_client).get("Authorization"))
+        finally:
+            _close(rest_client)

--- a/mcp-server/tests/unit/tools/mock_operation.py
+++ b/mcp-server/tests/unit/tools/mock_operation.py
@@ -31,7 +31,7 @@ from mcp_server.client.statistic_operation import StatisticOperation
 
 
 class MockOperation(GravitinoOperation):
-    def __init__(self, metalake, uri):
+    def __init__(self, metalake, uri, token=""):
         pass
 
     def as_table_operation(self) -> TableOperation:


### PR DESCRIPTION
### What changes were proposed in this pull request?

- Add a `token` field to `Setting`, masking its value in `__str__` to avoid leaking it into logs.
- Add a `--token` CLI argument to `main.py`, falling back to the `GRAVITINO_TOKEN` environment variable.
- `PlainRESTClientOperation` accepts a token and sets the `Authorization: Bearer` header on the httpx client when non-empty.
- `RESTClientFactory.create_rest_client` passes the token through, and `GravitinoContext` propagates `setting.token` to the factory.
- Update `MockOperation` to accept the token parameter for test compatibility.

### Why are the changes needed?

The MCP server currently has no way to pass an authentication token to Gravitino REST calls, so it cannot work against a Gravitino server with auth enabled.

Fix: #11565
Fix: #11566

### Does this PR introduce _any_ user-facing change?

Yes. Adds a new `--token` CLI option (and `GRAVITINO_TOKEN` env var fallback) to the MCP server.

### How was this patch tested?

Added 7 unit tests in `mcp-server/tests/unit/test_auth_flow.py` covering token injection, masking, and context propagation.