### PR TITLE
[#11588] fix(lance): Return leaf table names from REST ListTables

### DIFF
--- a/lance/lance-common/src/main/java/org/apache/gravitino/lance/common/ops/gravitino/GravitinoLanceNameSpaceOperations.java
+++ b/lance/lance-common/src/main/java/org/apache/gravitino/lance/common/ops/gravitino/GravitinoLanceNameSpaceOperations.java
@@ -19,13 +19,13 @@
 
 package org.apache.gravitino.lance.common.ops.gravitino;
 
-import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -443,17 +443,14 @@ public class GravitinoLanceNameSpaceOperations implements LanceNamespaceOperatio
     String schemaName = nsId.levelAtListPos(1);
     List<String> tables =
         Arrays.stream(catalog.asTableCatalog().listTables(Namespace.of(schemaName)))
-            .map(ident -> Joiner.on(delimiter).join(catalogName, schemaName, ident.name()))
+            .map(ident -> ident.name())
             .sorted()
             .collect(Collectors.toList());
 
     PageUtil.Page page = PageUtil.splitPage(tables, pageToken, PageUtil.normalizePageSize(limit));
-    ListNamespacesResponse response = new ListNamespacesResponse();
-    response.setNamespaces(Sets.newHashSet(page.items()));
+    ListTablesResponse response = new ListTablesResponse();
+    response.setTables(new LinkedHashSet<>(page.items()));
     response.setPageToken(page.nextPageToken());
-
-    return new ListTablesResponse()
-        .tables(response.getNamespaces())
-        .pageToken(response.getPageToken());
+    return response;
   }
 }

--- a/lance/lance-rest-server/src/test/java/org/apache/gravitino/lance/integration/test/LanceRESTServiceIT.java
+++ b/lance/lance-rest-server/src/test/java/org/apache/gravitino/lance/integration/test/LanceRESTServiceIT.java
@@ -18,7 +18,6 @@
  */
 package org.apache.gravitino.lance.integration.test;
 
-import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
@@ -569,7 +568,8 @@ public class LanceRESTServiceIT extends BaseIT {
     var listResponse = ns.listTables(listRequest);
     Set<String> stringSet = listResponse.getTables();
     Assertions.assertEquals(1, stringSet.size());
-    Assertions.assertTrue(stringSet.contains(Joiner.on(".").join(ids)));
+    Assertions.assertTrue(stringSet.contains("table"));
+    Assertions.assertFalse(stringSet.contains(String.join(DELIMITER, ids)));
 
     // Now try to drop columns in the table
     AlterTableDropColumnsRequest dropColumnsRequest = new AlterTableDropColumnsRequest();

--- a/lance/lance-rest-server/src/test/java/org/apache/gravitino/lance/integration/test/LanceSparkRESTServiceIT.java
+++ b/lance/lance-rest-server/src/test/java/org/apache/gravitino/lance/integration/test/LanceSparkRESTServiceIT.java
@@ -548,7 +548,7 @@ public class LanceSparkRESTServiceIT extends BaseIT {
       }
 
       if (expectedSchema.equals(actualSchema.toLowerCase(Locale.ROOT))
-          && expectedTable.equals(extractLeafTableName(rawTableName).toLowerCase(Locale.ROOT))) {
+          && expectedTable.equals(rawTableName.toLowerCase(Locale.ROOT))) {
         return true;
       }
     }
@@ -580,15 +580,6 @@ public class LanceSparkRESTServiceIT extends BaseIT {
     }
 
     return null;
-  }
-
-  private String extractLeafTableName(String rawTableName) {
-    int delimiterIndex = Math.max(rawTableName.lastIndexOf('$'), rawTableName.lastIndexOf('.'));
-    if (delimiterIndex < 0) {
-      return rawTableName;
-    }
-
-    return rawTableName.substring(delimiterIndex + 1);
   }
 
   private void assertSparkAnalysisFailure(Throwable throwable, String... expectedMessageParts) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR fixes the Lance REST per-namespace `ListTables` implementation to return child table names instead of fully-qualified `catalog.schema.table` strings.

It also tightens the related REST and Spark integration tests:
- `LanceRESTServiceIT` now expects `ListTables` to return only the leaf table name.
- `LanceSparkRESTServiceIT` now validates the raw `SHOW TABLES` table name instead of stripping namespace prefixes.

### Why are the changes needed?

The Lance Namespace `ListTables` API lists child table names under the requested parent namespace. The current implementation returns fully-qualified names, causing Spark `SHOW TABLES` to display polluted table names such as `catalog.schema.table` instead of `table`.

Fix: #11588

### Does this PR introduce _any_ user-facing change?

Yes. The Lance REST per-namespace `ListTables` endpoint now returns leaf table names in the `tables` field.

The REST response shape is unchanged.

### How was this patch tested?

Ran:

```bash
./gradlew :lance:lance-rest-server:testClasses
./gradlew :lance:lance-rest-server:test --tests "org.apache.gravitino.lance.integration.test.LanceRESTServiceIT" -PskipDockerTests=false
./gradlew :lance:lance-rest-server:lanceSparkMatrixTest -PskipDockerTests=false