### PR TITLE
[#11615] fix(idp): Disable idp plugin when simple is listed in authenticators

### DIFF
--- a/design-docs/gravitino-local-authentication.md
+++ b/design-docs/gravitino-local-authentication.md
@@ -319,8 +319,9 @@ fresh Gravitino deployment.
    gravitino.authorization.serviceAdmins=admin1,admin2
    ```
 
-   Built-in IdP is incompatible with the `simple` authenticator. When the `idp-basic` plugin is
-   enabled, `gravitino.authenticators` must not include `simple`.
+   Built-in IdP is incompatible with the `simple` authenticator. If `simple` is listed in
+   `gravitino.authenticators`, the `idp-basic` plugin is disabled at startup. Configure
+   `gravitino.authenticators` without `simple` to enable the plugin.
 
 2. Export the initial service admin password before starting Gravitino:
 
@@ -402,9 +403,9 @@ credentials are otherwise exposed on the wire.
 | `gravitino.server.rest.extensionPackages`   | `org.apache.gravitino.idp.web.rest.feature`     | Yes                              |
 | `gravitino.authorization.serviceAdmins`     | Comma-separated service admin                   | Yes                              |
 
-List `org.apache.gravitino.idp.web.rest.feature` in `gravitino.server.rest.extensionPackages` so
-Jersey registers `/api/idp/*` management APIs. Callers must use Basic authentication with a username
-in `gravitino.authorization.serviceAdmins` and a password stored in `idp_user_meta`.
+List `org.apache.gravitino.idp.web.rest.feature` in `gravitino.server.rest.extensionPackages` and
+configure `gravitino.authenticators` without `simple`. Callers must use Basic authentication with
+a username in `gravitino.authorization.serviceAdmins` and a password stored in `idp_user_meta`.
 
 ### 8.2 Password Algorithm
 
@@ -416,7 +417,8 @@ The initial implementation uses Argon2id as the fixed password hashing algorithm
 
 Service admins manage local users and groups under `/api/idp` (global paths, no `{metalake}`).
 Operations are available when `org.apache.gravitino.idp.web.rest.feature` is listed in
-`gravitino.server.rest.extensionPackages`.
+`gravitino.server.rest.extensionPackages` and `gravitino.authenticators` is configured without
+`simple`.
 
 ### 9.1 HTTP Interface Design
 

--- a/docs/open-api/idp/openapi.yaml
+++ b/docs/open-api/idp/openapi.yaml
@@ -27,8 +27,8 @@ info:
     OpenAPI specification for built-in IDP user and group management APIs exposed
     by the `idp-basic` plugin. Clients authenticate with Basic credentials
     validated against built-in IdP user metadata. Enable the plugin via
-    `gravitino.server.rest.extensionPackages`; `gravitino.authenticators` must not
-    include `simple` when IdP is enabled.
+    `gravitino.server.rest.extensionPackages`, with `gravitino.authenticators`
+    configured without `simple`.
 
 servers:
   - url: "{scheme}://{host}:{port}/{basePath}"

--- a/docs/security/how-to-use-built-in-idp.md
+++ b/docs/security/how-to-use-built-in-idp.md
@@ -40,9 +40,9 @@ Before you call `/api/idp/*`, ensure the following:
    gravitino.server.rest.extensionPackages = org.apache.gravitino.idp.web.rest.feature
    ```
 
-2. **Server authenticator** — Built-in IdP is **incompatible** with the `simple` authenticator
-   (the default). When the `idp-basic` plugin is enabled, `gravitino.authenticators` must not
-   include `simple`.
+2. **Server authenticator** — Configure `gravitino.authenticators` without `simple`
+   (the default). If `simple` is listed in `gravitino.authenticators`, the `idp-basic` plugin is
+   disabled at startup and `/api/idp/*` is not registered.
 
 3. **Service admin passwords** — Built-in IDP requires every username in
    `gravitino.authorization.serviceAdmins` to have a password stored in `idp_user_meta` before you
@@ -327,9 +327,9 @@ Replace these with values that match your deployment.
    gravitino.authorization.serviceAdmins = admin
    ```
 
-   Built-in IdP is **incompatible** with the `simple` authenticator. Remove `simple` from
-   `gravitino.authenticators` (the default). For example, use `oauth` when the Web UI authenticates
-   through an external IdP; see [How to authenticate](how-to-authenticate.md).
+   Built-in IdP is **incompatible** with the `simple` authenticator. Configure
+   `gravitino.authenticators` without `simple` (the default); otherwise the plugin is disabled at
+   startup.
 
 2. Before the first start, set the initial service admin password (see
    [password rules](#password-and-username-rules)):

--- a/plugins/idp-basic/src/main/java/org/apache/gravitino/idp/web/rest/feature/IdpRESTFeature.java
+++ b/plugins/idp-basic/src/main/java/org/apache/gravitino/idp/web/rest/feature/IdpRESTFeature.java
@@ -45,6 +45,9 @@ import org.slf4j.LoggerFactory;
  * org.apache.gravitino.idp.web.rest.feature} so Jersey auto-discovers this feature. IdP REST
  * resource classes remain in {@code org.apache.gravitino.idp.web.rest} and are registered here.
  * Also initializes configured service admins in the built-in IdP when they do not yet exist.
+ *
+ * <p>When {@code simple} is listed in {@link Configs#AUTHENTICATORS}, built-in IdP is not
+ * initialized because it is incompatible with Simple authentication.
  */
 @Provider
 public class IdpRESTFeature implements Feature {
@@ -60,7 +63,15 @@ public class IdpRESTFeature implements Feature {
   public boolean configure(FeatureContext context) {
     GravitinoEnv env = GravitinoEnv.getInstance();
     Config config = env.config();
-    validateConfiguration(config);
+    if (config.get(Configs.AUTHENTICATORS).stream()
+        .anyMatch(name -> AuthenticatorType.SIMPLE.name().equalsIgnoreCase(name.trim()))) {
+      LOG.warn(
+          "Built-in IdP is incompatible with Simple authentication: both handle Authorization: "
+              + "Basic headers. Because 'simple' is configured in gravitino.authenticators, the "
+              + "idp-basic plugin is disabled and requests will use 'simple'.");
+      return true;
+    }
+
     registerBasicAuthenticator(config);
 
     try {
@@ -76,23 +87,6 @@ public class IdpRESTFeature implements Feature {
     context.register(IdpGroupOperations.class);
     context.register(IdpAuthorizationFilter.class);
     return true;
-  }
-
-  /**
-   * Validates that the server configuration is compatible with the built-in IdP plugin.
-   *
-   * @param config The server configuration.
-   */
-  static void validateConfiguration(Config config) {
-    boolean usesSimple =
-        config.get(Configs.AUTHENTICATORS).stream()
-            .anyMatch(name -> AuthenticatorType.SIMPLE.name().equalsIgnoreCase(name.trim()));
-    if (usesSimple) {
-      LOG.error(
-          "Built-in IdP is incompatible with Simple authentication. "
-              + "Remove 'simple' from gravitino.authenticators (default is simple).");
-      System.exit(1);
-    }
   }
 
   private static void registerBasicAuthenticator(Config config) {

--- a/plugins/idp-basic/src/test/java/org/apache/gravitino/idp/web/rest/feature/TestIdpRESTFeature.java
+++ b/plugins/idp-basic/src/test/java/org/apache/gravitino/idp/web/rest/feature/TestIdpRESTFeature.java
@@ -19,80 +19,103 @@
 
 package org.apache.gravitino.idp.web.rest.feature;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 import com.google.common.collect.Lists;
+import javax.ws.rs.core.FeatureContext;
+import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.gravitino.Config;
 import org.apache.gravitino.Configs;
+import org.apache.gravitino.GravitinoEnv;
 import org.apache.gravitino.auth.AuthenticatorType;
+import org.apache.gravitino.idp.IdpUserGroupManager;
+import org.apache.gravitino.idp.web.rest.IdpAuthorizationFilter;
+import org.apache.gravitino.idp.web.rest.IdpBasicBinder;
+import org.apache.gravitino.idp.web.rest.IdpGroupOperations;
+import org.apache.gravitino.idp.web.rest.IdpUserOperations;
+import org.apache.gravitino.storage.IdGenerator;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 
 class TestIdpRESTFeature {
 
-  @Test
-  void testSimpleFails() {
-    Config config = newConfig(AuthenticatorType.SIMPLE.name().toLowerCase());
+  private Config originalConfig;
+  private IdGenerator originalIdGenerator;
 
-    SystemExitException exception =
-        assertThrows(SystemExitException.class, () -> validateWithExitGuard(config));
+  @BeforeEach
+  void saveGravitinoEnvConfig() throws IllegalAccessException {
+    GravitinoEnv env = GravitinoEnv.getInstance();
+    originalConfig = (Config) FieldUtils.readField(env, "config", true);
+    originalIdGenerator = (IdGenerator) FieldUtils.readField(env, "idGenerator", true);
+  }
 
-    assertEquals(1, exception.status());
+  @AfterEach
+  void restoreGravitinoEnvConfig() throws IllegalAccessException {
+    GravitinoEnv env = GravitinoEnv.getInstance();
+    FieldUtils.writeField(env, "config", originalConfig, true);
+    FieldUtils.writeField(env, "idGenerator", originalIdGenerator, true);
   }
 
   @Test
-  void testDefaultSimpleFails() {
-    Config config = new Config(false) {};
-
-    assertThrows(SystemExitException.class, () -> validateWithExitGuard(config));
+  void testSimpleSkips() throws IllegalAccessException {
+    configureWithAuthenticators(AuthenticatorType.SIMPLE.name().toLowerCase());
+    assertConfigureSkipsIdp();
   }
 
   @Test
-  void testOAuthOk() {
-    Config config = newConfig(AuthenticatorType.OAUTH.name().toLowerCase());
-
-    assertDoesNotThrow(() -> IdpRESTFeature.validateConfiguration(config));
+  void testDefaultSimpleSkips() throws IllegalAccessException {
+    FieldUtils.writeField(GravitinoEnv.getInstance(), "config", new Config(false) {}, true);
+    assertConfigureSkipsIdp();
   }
 
-  private static Config newConfig(String... authenticators) {
+  @Test
+  void testSimpleWithOAuthSkips() throws IllegalAccessException {
+    configureWithAuthenticators(
+        AuthenticatorType.OAUTH.name().toLowerCase(),
+        AuthenticatorType.SIMPLE.name().toLowerCase());
+    assertConfigureSkipsIdp();
+  }
+
+  @Test
+  void testOAuthRegisters() throws Exception {
+    configureWithAuthenticators(AuthenticatorType.OAUTH.name().toLowerCase());
+    FieldUtils.writeField(GravitinoEnv.getInstance(), "idGenerator", mock(IdGenerator.class), true);
+
+    IdpUserGroupManager manager = mock(IdpUserGroupManager.class);
+    try (MockedStatic<IdpUserGroupManager> ignored = mockStatic(IdpUserGroupManager.class)) {
+      ignored
+          .when(() -> IdpUserGroupManager.getInstance(any(Config.class), any(IdGenerator.class)))
+          .thenReturn(manager);
+
+      FeatureContext context = mock(FeatureContext.class);
+      assertTrue(new IdpRESTFeature().configure(context));
+
+      verify(manager).initializeConfiguredServiceAdmins(any(Config.class), nullable(String.class));
+      verify(context).register(IdpBasicBinder.class);
+      verify(context).register(IdpUserOperations.class);
+      verify(context).register(IdpGroupOperations.class);
+      verify(context).register(IdpAuthorizationFilter.class);
+    }
+  }
+
+  private static void assertConfigureSkipsIdp() {
+    FeatureContext context = mock(FeatureContext.class);
+    assertTrue(new IdpRESTFeature().configure(context));
+    verifyNoInteractions(context);
+  }
+
+  private static void configureWithAuthenticators(String... authenticators)
+      throws IllegalAccessException {
     Config config = new Config(false) {};
     config.set(Configs.AUTHENTICATORS, Lists.newArrayList(authenticators));
-    return config;
-  }
-
-  @SuppressWarnings("removal")
-  private static void validateWithExitGuard(Config config) {
-    SecurityManager original = System.getSecurityManager();
-    System.setSecurityManager(
-        new SecurityManager() {
-          @Override
-          public void checkExit(int status) {
-            throw new SystemExitException(status);
-          }
-
-          @Override
-          public void checkPermission(java.security.Permission perm) {
-            // Allow test execution.
-          }
-        });
-    try {
-      IdpRESTFeature.validateConfiguration(config);
-    } finally {
-      System.setSecurityManager(original);
-    }
-  }
-
-  private static final class SystemExitException extends SecurityException {
-    private final int status;
-
-    private SystemExitException(int status) {
-      super("System.exit(" + status + ")");
-      this.status = status;
-    }
-
-    private int status() {
-      return status;
-    }
+    FieldUtils.writeField(GravitinoEnv.getInstance(), "config", config, true);
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

When `simple` is listed in `gravitino.authenticators`, the `idp-basic` plugin now logs a warning and skips IdP initialization instead of calling `System.exit(1)`. The server continues to start and requests use `simple`. IdP REST resources (`/api/idp/*`), service-admin initialization, and built-in Basic authenticator registration are not performed in this case.

Docs are updated to describe the runtime behavior and the requirement to configure `gravitino.authenticators` without `simple` to enable built-in IdP.

### Why are the changes needed?

Issue #11615 highlights friction when built-in IdP is enabled while `simple` (the default authenticator) remains configured. The previous fail-fast behavior blocked server startup. This change allows coexistence of the extension package with default/simple auth by disabling IdP at startup when the conflict is detected.

Note: #11615 proposes automatically excluding `simple` from the active authenticator chain. This PR takes the alternative approach of keeping `simple` and disabling the `idp-basic` plugin, because both mechanisms handle `Authorization: Basic` headers.

Fix: #11615

### Does this PR introduce _any_ user-facing change?

1. Server startup no longer fails when `idp-basic` is enabled and `simple` is listed in `gravitino.authenticators`.
2. A WARN log is emitted and built-in IdP APIs are not registered in that configuration.
3. Documentation updates for built-in IdP setup and OpenAPI description.

### How was this patch tested?

1. `./gradlew :plugins:idp-basic:test -PskipITs` 
2. `./gradlew :docs:build`
3. `./gradlew spotlessApply`