### PR TITLE
[#11652] fix(docker): chmod 775 server home dir for non-root log creation

### DIFF
--- a/dev/docker/gravitino/Dockerfile
+++ b/dev/docker/gravitino/Dockerfile
@@ -26,7 +26,8 @@ WORKDIR /opt/gravitino
 
 COPY --chmod=775 packages/gravitino /opt/gravitino
 
-RUN chmod +x /opt/gravitino/docker/docker-entrypoint.sh \
+RUN chmod 775 /opt/gravitino \
+    && chmod +x /opt/gravitino/docker/docker-entrypoint.sh \
     && useradd -u 1000 -g 0 -M -s /sbin/nologin gravitino
 
 EXPOSE 8090

--- a/dev/docker/iceberg-rest-server/Dockerfile
+++ b/dev/docker/iceberg-rest-server/Dockerfile
@@ -27,7 +27,8 @@ WORKDIR /opt/gravitino-iceberg-rest-server
 
 COPY --chmod=775 packages/gravitino-iceberg-rest-server /opt/gravitino-iceberg-rest-server
 
-RUN chmod +x /opt/gravitino-iceberg-rest-server/bin/start-iceberg-rest-server.sh \
+RUN chmod 775 /opt/gravitino-iceberg-rest-server \
+    && chmod +x /opt/gravitino-iceberg-rest-server/bin/start-iceberg-rest-server.sh \
     && useradd -u 1000 -g 0 -M -s /sbin/nologin gravitino
 
 EXPOSE 9001

--- a/dev/docker/lance-rest-server/Dockerfile
+++ b/dev/docker/lance-rest-server/Dockerfile
@@ -27,7 +27,8 @@ WORKDIR /opt/gravitino-lance-rest-server
 
 COPY --chmod=775 packages/gravitino-lance-rest-server /opt/gravitino-lance-rest-server
 
-RUN chmod +x /opt/gravitino-lance-rest-server/bin/start-lance-rest-server.sh
+RUN chmod 775 /opt/gravitino-lance-rest-server \
+    && chmod +x /opt/gravitino-lance-rest-server/bin/start-lance-rest-server.sh
 
 EXPOSE 9101
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add `chmod 775 <server-home>` to the RUN step of the gravitino,
iceberg-rest-server and lance-rest-server Dockerfiles so the directory
created by `WORKDIR` becomes group-writable.

### Why are the changes needed?

PR #11533 replaced `chmod -R g+rwX <dir>` with `COPY --chmod=775`. However
`COPY --chmod` only applies to the copied contents, not to the target
directory itself, which was created earlier by `WORKDIR` and retains the
default `755 root:root` permission. The container runs as `uid=1000, gid=0`,
so the non-root user cannot create subdirectories such as
`/opt/gravitino/logs`, and the server fails at startup:

```
main ERROR Unable to create file /opt/gravitino/logs/gravitino-server.log
java.io.IOException: Could not create directory /opt/gravitino/logs
```

A single non-recursive `chmod 775` on the top directory fixes this while
preserving #11533's goal of not duplicating an image layer from a recursive
chmod.

Fix: #11652

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Built the real gravitino image via `dev/docker/build-docker.sh` and ran it
as `uid=1000, gid=0`:
- `/opt/gravitino` now has `drwxrwxr-x` (775) instead of `755`.
- The server starts, creates `/opt/gravitino/logs/gravitino-server.log`,
  and `GET /api/version` returns HTTP 200.
- Confirmed the previous `Could not create directory` error no longer appears.