### PR TITLE
[#11667] improvement(helm): Add OAuth group/principal mapper configs to Helm chart

### DIFF
--- a/dev/charts/gravitino/resources/config/gravitino.conf
+++ b/dev/charts/gravitino/resources/config/gravitino.conf
@@ -113,6 +113,21 @@ gravitino.authenticator.oauth.tokenValidatorClass = {{ .tokenValidatorClass }}
 {{- if .principalFields }}
 gravitino.authenticator.oauth.principalFields = {{ .principalFields }}
 {{- end }}
+{{- if .principalMapper }}
+gravitino.authenticator.oauth.principalMapper = {{ .principalMapper }}
+{{- end }}
+{{- if .principalMapperRegexPattern }}
+gravitino.authenticator.oauth.principalMapper.regex.pattern = {{ .principalMapperRegexPattern }}
+{{- end }}
+{{- if .groupsFields }}
+gravitino.authenticator.oauth.groupsFields = {{ .groupsFields }}
+{{- end }}
+{{- if .groupMapper }}
+gravitino.authenticator.oauth.groupMapper = {{ .groupMapper }}
+{{- end }}
+{{- if .groupMapperRegexPattern }}
+gravitino.authenticator.oauth.groupMapper.regex.pattern = {{ .groupMapperRegexPattern }}
+{{- end }}
 {{- end }}
 {{- end }}
 

--- a/dev/charts/gravitino/tests/configmap_test.yaml
+++ b/dev/charts/gravitino/tests/configmap_test.yaml
@@ -162,6 +162,11 @@ tests:
           jwksUri: https://auth.example.com/.well-known/jwks.json
           tokenValidatorClass: org.apache.gravitino.server.authentication.JwksTokenValidator
           principalFields: preferred_username,email
+          principalMapper: regex
+          principalMapperRegexPattern: "^(.*)$"
+          groupsFields: groups
+          groupMapper: regex
+          groupMapperRegexPattern: "^(.*)$"
     asserts:
       - matchRegex:
           path: data["gravitino.conf"]
@@ -193,6 +198,21 @@ tests:
       - matchRegex:
           path: data["gravitino.conf"]
           pattern: "gravitino\\.authenticator\\.oauth\\.principalFields = preferred_username,email"
+      - matchRegex:
+          path: data["gravitino.conf"]
+          pattern: "gravitino\\.authenticator\\.oauth\\.principalMapper = regex"
+      - matchRegex:
+          path: data["gravitino.conf"]
+          pattern: "gravitino\\.authenticator\\.oauth\\.principalMapper\\.regex\\.pattern"
+      - matchRegex:
+          path: data["gravitino.conf"]
+          pattern: "gravitino\\.authenticator\\.oauth\\.groupsFields = groups"
+      - matchRegex:
+          path: data["gravitino.conf"]
+          pattern: "gravitino\\.authenticator\\.oauth\\.groupMapper = regex"
+      - matchRegex:
+          path: data["gravitino.conf"]
+          pattern: "gravitino\\.authenticator\\.oauth\\.groupMapper\\.regex\\.pattern"
 
   - it: does not render empty OAuth sub-properties when only some are set
     release:
@@ -216,6 +236,15 @@ tests:
       - notMatchRegex:
           path: data["gravitino.conf"]
           pattern: "gravitino\\.authenticator\\.oauth\\.serverUri"
+      - matchRegex:
+          path: data["gravitino.conf"]
+          pattern: "gravitino\\.authenticator\\.oauth\\.principalMapper = regex"
+      - matchRegex:
+          path: data["gravitino.conf"]
+          pattern: "gravitino\\.authenticator\\.oauth\\.groupsFields = groups"
+      - matchRegex:
+          path: data["gravitino.conf"]
+          pattern: "gravitino\\.authenticator\\.oauth\\.groupMapper = regex"
 
   - it: renders entity.maxConnections only when set
     release:

--- a/dev/charts/gravitino/values.yaml
+++ b/dev/charts/gravitino/values.yaml
@@ -348,6 +348,16 @@ authenticator:
     defaultSignKey: ""
     serverUri: ""
     tokenPath: /realms/myrealm/protocol/openid-connect/token
+    ## Principal mapper type for OAuth (default: regex)
+    principalMapper: "regex"
+    ## Regex pattern for OAuth principal mapping (default: ^(.*)$)
+    principalMapperRegexPattern: "^(.*)$"
+    ## JWT claim field(s) to use for group membership (default: groups)
+    groupsFields: "groups"
+    ## Group mapper type for OAuth (default: regex)
+    groupMapper: "regex"
+    ## Regex pattern for OAuth group mapping (default: ^(.*)$)
+    groupMapperRegexPattern: "^(.*)$"
 
 ## Audit log configuration
 ##


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add 5 missing OAuth configuration properties to the Helm chart:
- `gravitino.authenticator.oauth.principalMapper`
- `gravitino.authenticator.oauth.principalMapper.regex.pattern`
- `gravitino.authenticator.oauth.groupsFields`
- `gravitino.authenticator.oauth.groupMapper`
- `gravitino.authenticator.oauth.groupMapper.regex.pattern`

These properties were added to the Gravitino server in v1.2.0 and v1.3.0 but were never wired into the Helm chart template.

### Why are the changes needed?

Users currently must use the `additionalConfigItems` escape hatch to configure group and principal mapping, which is error-prone and not discoverable. Adding native support makes the Helm chart fully feature-complete with the server-side OAuth configuration capabilities.

Fix: #11667

### Does this PR introduce any user-facing change?

Yes, adds 5 new configurable values under `authenticator.oauth` in the Helm chart:
- `principalMapper` (default: `regex`)
- `principalMapperRegexPattern` (default: `^(.*)$`)
- `groupsFields` (default: `groups`)
- `groupMapper` (default: `regex`)
- `groupMapperRegexPattern` (default: `^(.*)$`)

### How was this patch tested?

Ran `helm unittest --strict dev/charts/gravitino/` — all 30 tests pass, including new asserts for the added properties.
