### PR TITLE
[#11623] web-v2(UI):Hide catalog properties not present in API response during edit mode

### DIFF
--- a/web-v2/web/src/app/catalogs/rightContent/CreateCatalogDialog.js
+++ b/web-v2/web/src/app/catalogs/rightContent/CreateCatalogDialog.js
@@ -115,6 +115,11 @@ export default function CreateCatalogDialog({ ...props }) {
 
   const isHidden = prop => {
     const { parentField, hide, key } = prop
+
+    // In edit mode, hide props not present in the loaded catalog response
+    if (editCatalog && cacheData?.properties && !(key in cacheData.properties)) {
+      return true
+    }
     switch (parentField) {
       case 'catalog-backend':
         return catalogBackend && hide && hide.includes(catalogBackend)


### PR DESCRIPTION
### What changes were proposed in this pull request?
<img width="2518" height="1698" alt="image" src="https://github.com/user-attachments/assets/48f5ef94-03a7-4349-857d-142e20d3a1c2" />
Fix the CreateCatalogDialog to hide required properties that are not returned in the catalog API response during edit mode. Previously, properties with `parentField` (e.g., `jdbc-user`, `jdbc-password` with `parentField: 'catalog-backend'`) were always shown based on the parent field value, even when the API response didn't include them.

### Why are the changes needed?
When editing a catalog (e.g., `lakehouse-iceberg` with `rest` backend), the API response may not include certain required properties like `jdbc-user` and `jdbc-password`. The form still displayed these fields and required validation, preventing users from submitting the form.

Root cause: The `isHidden` function checked `cacheData.properties` only in the `default` branch, but properties with `parentField` entered different branches (`case 'catalog-backend'`, `case 'authentication.type'`) and bypassed this check.

Fix: #11623

### Does this PR introduce _any_ user-facing change?
N/A

### How was this patch tested?
- Verify that `jdbc-user` and `jdbc-password` are hidden when editing a `lakehouse-iceberg` catalog with `rest` backend (properties not in API response)
- Verify that these fields are still shown when editing a `lakehouse-iceberg` catalog with `jdbc` backend (properties present in API response)
- Verify that other providers (e.g., `jdbc-mysql`, `hive`) still work correctly in both create and edit modes
