### PR TITLE
[#11696] improvement(helm): Make init-postgresql secret name configurable via postgresql.existingSecretName

### DIFF
--- a/dev/charts/gravitino/templates/deployment.yaml
+++ b/dev/charts/gravitino/templates/deployment.yaml
@@ -172,7 +172,7 @@ spec:
             - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Release.Name }}-postgresql
+                  name: {{ default (printf "%s-postgresql" .Release.Name) .Values.postgresql.existingSecretName }}
                   key: password
           volumeMounts:
             - mountPath: /scripts

--- a/dev/charts/gravitino/tests/deployment_test.yaml
+++ b/dev/charts/gravitino/tests/deployment_test.yaml
@@ -265,3 +265,36 @@ tests:
             name: GRAVITINO_DB
             value: gravitino
           any: true
+      - contains:
+          path: spec.template.spec.initContainers[?(@.name == "init-postgresql")].env
+          content:
+            name: POSTGRES_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: gravitino-postgresql
+                key: password
+          any: true
+
+  - it: renders custom PostgreSQL secret name when existingSecretName is set
+    template: deployment.yaml
+    release:
+      name: gravitino
+    set:
+      postgresql:
+        enabled: true
+        existingSecretName: gravitino-cnpg-secret
+    asserts:
+      - contains:
+          path: spec.template.spec.initContainers
+          content:
+            name: init-postgresql
+          any: true
+      - contains:
+          path: spec.template.spec.initContainers[?(@.name == "init-postgresql")].env
+          content:
+            name: POSTGRES_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: gravitino-cnpg-secret
+                key: password
+          any: true

--- a/dev/charts/gravitino/values.yaml
+++ b/dev/charts/gravitino/values.yaml
@@ -114,6 +114,13 @@ postgresql:
     ## The value is evaluated as a template.
     ##
     existingSecret: ""
+    ## @param auth.existingSecretName Name of existing secret to use in the init container's secretKeyRef
+    ## When set, this overrides the default `{{ .Release.Name }}-postgresql` secret name used by
+    ## the init-postgresql init container to retrieve the PostgreSQL password.
+    ## Useful when using an external PostgreSQL provider (e.g., CloudNativePG, AWS RDS) where the
+    ## secret name does not follow the Bitnami convention.
+    ##
+    existingSecretName: ""
 
 ## THE CONFIGURATION FOR Gravitino ENTITY STORE
 ##


### PR DESCRIPTION
### What changes were proposed in this pull request?

Make the Kubernetes secret name used by the `init-postgresql` init container configurable via a new `postgresql.auth.existingSecretName` values field, falling back to the Bitnami default `{{ .Release.Name }}-postgresql` when not set.

### Why are the changes needed?

The Helm chart's `init-postgresql` init container hardcodes the secret name as `{{ .Release.Name }}-postgresql`, which assumes the Bitnami PostgreSQL subchart is always used. This breaks compatibility with external PostgreSQL providers (CloudNativePG, CrunchyData, AWS RDS) where the secret name is user-defined.

Fix: https://github.com/apache/gravitino/issues/11696

### Does this PR introduce any user-facing change?

Yes, adds `postgresql.auth.existingSecretName` (default: `""`) to `values.yaml`.

### How was this patch tested?

- Existing helm unit tests pass (31 tests, 5 suites)
- New test case: default behavior produces `gravitino-postgresql`
- New test case: `existingSecretName=gravitino-cnpg-secret` produces that name