### PR TITLE
[#11706] fix(catalog-hive): replace switch-on-enum with if-else in HiveCatalogCapability.caseSensitiveOnName()

### DIFF
--- a/catalogs/catalog-hive/src/main/java/org/apache/gravitino/catalog/hive/HiveCatalogCapability.java
+++ b/catalogs/catalog-hive/src/main/java/org/apache/gravitino/catalog/hive/HiveCatalogCapability.java
@@ -49,6 +49,9 @@ public class HiveCatalogCapability implements Capability {
     // if-else with == compiles to if_acmpeq (reference comparison) with no synthetic class.
     // Hive is case insensitive, see
     // https://cwiki.apache.org/confluence/display/Hive/User+FAQ#UserFAQ-AreHiveSQLidentifiers(e.g.tablenames,columnnames,etc)casesensitive?
+    if (scope == null) {
+      throw new NullPointerException("scope");
+    }
     if (scope == Scope.SCHEMA || scope == Scope.TABLE || scope == Scope.COLUMN) {
       return CapabilityResult.unsupported("Hive is case insensitive.");
     }

--- a/catalogs/catalog-hive/src/main/java/org/apache/gravitino/catalog/hive/HiveCatalogCapability.java
+++ b/catalogs/catalog-hive/src/main/java/org/apache/gravitino/catalog/hive/HiveCatalogCapability.java
@@ -18,6 +18,7 @@
  */
 package org.apache.gravitino.catalog.hive;
 
+import com.google.common.base.Preconditions;
 import org.apache.gravitino.connector.capability.Capability;
 import org.apache.gravitino.connector.capability.CapabilityResult;
 
@@ -49,9 +50,7 @@ public class HiveCatalogCapability implements Capability {
     // if-else with == compiles to if_acmpeq (reference comparison) with no synthetic class.
     // Hive is case insensitive, see
     // https://cwiki.apache.org/confluence/display/Hive/User+FAQ#UserFAQ-AreHiveSQLidentifiers(e.g.tablenames,columnnames,etc)casesensitive?
-    if (scope == null) {
-      throw new NullPointerException("scope");
-    }
+    Preconditions.checkArgument(scope != null, "scope cannot be null");
     if (scope == Scope.SCHEMA || scope == Scope.TABLE || scope == Scope.COLUMN) {
       return CapabilityResult.unsupported("Hive is case insensitive.");
     }

--- a/catalogs/catalog-hive/src/main/java/org/apache/gravitino/catalog/hive/HiveCatalogCapability.java
+++ b/catalogs/catalog-hive/src/main/java/org/apache/gravitino/catalog/hive/HiveCatalogCapability.java
@@ -42,15 +42,16 @@ public class HiveCatalogCapability implements Capability {
 
   @Override
   public CapabilityResult caseSensitiveOnName(Scope scope) {
-    switch (scope) {
-      case SCHEMA:
-      case TABLE:
-      case COLUMN:
-        // Hive is case insensitive, see
-        // https://cwiki.apache.org/confluence/display/Hive/User+FAQ#UserFAQ-AreHiveSQLidentifiers(e.g.tablenames,columnnames,etc)casesensitive?
-        return CapabilityResult.unsupported("Hive is case insensitive.");
-      default:
-        return CapabilityResult.SUPPORTED;
+    // Use if-else instead of switch-on-enum to avoid the compiler-generated synthetic class $1.
+    // SchemaNormalizeDispatcher calls this method outside the IsolatedClassLoader.withClassLoader()
+    // boundary. A switch-on-enum causes the JVM to load $1 via the server classloader, which
+    // cannot find it, and the JVM permanently caches the failure for the process lifetime.
+    // if-else with == compiles to if_acmpeq (reference comparison) with no synthetic class.
+    // Hive is case insensitive, see
+    // https://cwiki.apache.org/confluence/display/Hive/User+FAQ#UserFAQ-AreHiveSQLidentifiers(e.g.tablenames,columnnames,etc)casesensitive?
+    if (scope == Scope.SCHEMA || scope == Scope.TABLE || scope == Scope.COLUMN) {
+      return CapabilityResult.unsupported("Hive is case insensitive.");
     }
+    return CapabilityResult.SUPPORTED;
   }
 }

--- a/catalogs/catalog-hive/src/test/java/org/apache/gravitino/catalog/hive/TestHiveCatalogCapability.java
+++ b/catalogs/catalog-hive/src/test/java/org/apache/gravitino/catalog/hive/TestHiveCatalogCapability.java
@@ -50,7 +50,7 @@ public class TestHiveCatalogCapability {
   }
 
   @Test
-  public void testCaseSensitiveOnNameSyntheticClassAbsent() throws ClassNotFoundException {
+  public void testCaseSensitiveOnNameSyntheticClassAbsent() {
     // The implementation must use if-else rather than switch-on-enum so that the Java compiler
     // does not generate the synthetic HiveCatalogCapability$1 helper class.
     // SchemaNormalizeDispatcher

--- a/catalogs/catalog-hive/src/test/java/org/apache/gravitino/catalog/hive/TestHiveCatalogCapability.java
+++ b/catalogs/catalog-hive/src/test/java/org/apache/gravitino/catalog/hive/TestHiveCatalogCapability.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog.hive;
+
+import org.apache.gravitino.connector.capability.Capability;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class TestHiveCatalogCapability {
+
+  private HiveCatalogCapability capability;
+
+  @BeforeEach
+  public void setUp() {
+    capability = new HiveCatalogCapability();
+  }
+
+  @Test
+  public void testCaseSensitiveOnNameForCaseInsensitiveScopes() {
+    // Hive is case insensitive for SCHEMA, TABLE and COLUMN names.
+    Assertions.assertFalse(capability.caseSensitiveOnName(Capability.Scope.SCHEMA).supported());
+    Assertions.assertFalse(capability.caseSensitiveOnName(Capability.Scope.TABLE).supported());
+    Assertions.assertFalse(capability.caseSensitiveOnName(Capability.Scope.COLUMN).supported());
+  }
+
+  @Test
+  public void testCaseSensitiveOnNameForCaseSensitiveScopes() {
+    // All other scopes are case sensitive (default behaviour).
+    Assertions.assertTrue(capability.caseSensitiveOnName(Capability.Scope.FILESET).supported());
+    Assertions.assertTrue(capability.caseSensitiveOnName(Capability.Scope.TOPIC).supported());
+    Assertions.assertTrue(capability.caseSensitiveOnName(Capability.Scope.PARTITION).supported());
+    Assertions.assertTrue(capability.caseSensitiveOnName(Capability.Scope.MODEL).supported());
+  }
+
+  @Test
+  public void testCaseSensitiveOnNameSyntheticClassAbsent() throws ClassNotFoundException {
+    // The implementation must use if-else rather than switch-on-enum so that the Java compiler
+    // does not generate the synthetic HiveCatalogCapability$1 helper class.
+    // SchemaNormalizeDispatcher
+    // calls caseSensitiveOnName() outside IsolatedClassLoader.withClassLoader(); if $1 exists and
+    // is requested from the server classloader, the JVM permanently caches the load failure,
+    // breaking every subsequent call until process restart.
+    ClassLoader cl = HiveCatalogCapability.class.getClassLoader();
+    Assertions.assertThrows(
+        ClassNotFoundException.class,
+        () -> Class.forName("org.apache.gravitino.catalog.hive.HiveCatalogCapability$1", false, cl),
+        "HiveCatalogCapability$1 must not exist; use if-else instead of switch-on-enum");
+  }
+}

--- a/catalogs/catalog-hive/src/test/java/org/apache/gravitino/catalog/hive/TestHiveCatalogCapability.java
+++ b/catalogs/catalog-hive/src/test/java/org/apache/gravitino/catalog/hive/TestHiveCatalogCapability.java
@@ -50,6 +50,15 @@ public class TestHiveCatalogCapability {
   }
 
   @Test
+  public void testCaseSensitiveOnNameNullScopeThrows() {
+    // Preconditions.checkArgument preserves fail-fast semantics for null scope.
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> capability.caseSensitiveOnName(null),
+        "caseSensitiveOnName must reject null scope");
+  }
+
+  @Test
   public void testCaseSensitiveOnNameSyntheticClassAbsent() {
     // The implementation must use if-else rather than switch-on-enum so that the Java compiler
     // does not generate the synthetic HiveCatalogCapability$1 helper class.


### PR DESCRIPTION
### What changes were proposed in this pull request?

Replace the `switch`-on-enum with `if`-`else` in
`HiveCatalogCapability.caseSensitiveOnName()`, and add unit tests to
verify both the functional behavior and the absence of the synthetic
`$1` class in the compiled output.

### Why are the changes needed?

Fix: #11706

`SchemaNormalizeDispatcher` calls `caseSensitiveOnName()` **after**
`IsolatedClassLoader.withClassLoader()` exits — i.e. outside the catalog's
isolated classloader context. The `switch`-on-enum causes the Java compiler
to generate a synthetic helper class `HiveCatalogCapability$1`. In certain
classloader initialization timing windows, the server classloader is involved
in loading `$1` but cannot find it in the server classpath. **The JVM
permanently caches this load failure for the process lifetime**, causing all
subsequent calls to throw `NoClassDefFoundError` until restart.

Replacing `switch` with `if`-`else` using `==` on enum constants compiles to
`if_acmpeq` (reference comparison) with no synthetic class dependency, making
`caseSensitiveOnName()` safe to call from any classloader context.

### Does this PR introduce _any_ user-facing change?

No. The method behavior is identical; only the compiled representation changes.

### How was this patch tested?

Added `TestHiveCatalogCapability` with three test methods:
- Case-insensitive scopes (`SCHEMA`, `TABLE`, `COLUMN`) return `unsupported`
- Case-sensitive scopes (`FILESET`, `TOPIC`, `PARTITION`, `MODEL`) return `supported`
- `HiveCatalogCapability$1` does not exist in the compiled output
  (guards against future regression back to `switch`)