### PR TITLE
[#11645] improvement(docs): Warn about credential leakage risk in bypass properties

### DIFF
--- a/docs/gravitino-server-config.md
+++ b/docs/gravitino-server-config.md
@@ -394,10 +394,10 @@ There are three types of catalog properties:
    Gravitino and pass directly to the underlying system for advanced usage.
 
 :::warning
-Using `gravitino.bypass.` properties to pass credentials has a risk of credential leakage, because
-these properties are not fully managed by Gravitino and may be returned in REST API responses as
-plain text. If an underlying system requires credentials to be passed this way, restrict access to
-the related REST APIs.
+Using `gravitino.bypass.` properties to pass credentials, tokens, or access keys can expose
+sensitive values in plaintext, because these properties are not fully managed by Gravitino and may
+be returned in REST API responses. If an underlying system requires credentials to be passed this
+way, restrict access to the related REST APIs.
 :::
 
 3. **Other properties**: Gravitino doesn't leverage these properties, just store them. Users

--- a/docs/gravitino-server-config.md
+++ b/docs/gravitino-server-config.md
@@ -392,6 +392,14 @@ There are three types of catalog properties:
    configurations for the catalog to work properly.
 2. **Properties with the `gravitino.bypass.` prefix**: These properties are not managed by
    Gravitino and pass directly to the underlying system for advanced usage.
+
+:::warning
+Using `gravitino.bypass.` properties to pass credentials has a risk of credential leakage, because
+these properties are not fully managed by Gravitino and may be returned in REST API responses as
+plain text. If an underlying system requires credentials to be passed this way, restrict access to
+the related REST APIs.
+:::
+
 3. **Other properties**: Gravitino doesn't leverage these properties, just store them. Users
    can use them for their own purposes.
 

--- a/docs/gravitino-server-config.md
+++ b/docs/gravitino-server-config.md
@@ -396,8 +396,8 @@ There are three types of catalog properties:
 :::warning
 Using `gravitino.bypass.` properties to pass credentials, tokens, or access keys can expose
 sensitive values in plaintext, because these properties are not fully managed by Gravitino and may
-be returned in REST API responses. If an underlying system requires credentials to be passed this
-way, restrict access to the related REST APIs.
+be returned in plaintext via REST API responses. If an underlying system requires credentials to be
+passed this way, restrict access to the related REST APIs.
 :::
 
 3. **Other properties**: Gravitino doesn't leverage these properties, just store them. Users

--- a/docs/lakehouse-iceberg-catalog.md
+++ b/docs/lakehouse-iceberg-catalog.md
@@ -161,8 +161,7 @@ Gravitino Iceberg REST service supports using static access-key-id and secret-ac
 | `oss-endpoint`          | The endpoint of Aliyun OSS service.                                                                                             | (none)                                  | No       | 0.7.0-incubating |
 
 For other Iceberg OSS properties not managed by Gravitino like `client.security-token`, you could config it directly by `gravitino.bypass.client.security-token`.
-Passing credentials or security tokens through `gravitino.bypass.` properties can expose sensitive values in plaintext. See
-[Catalog Properties Configuration](./gravitino-server-config.md#catalog-properties-configuration) for details.
+See [Catalog Properties Configuration](./gravitino-server-config.md#catalog-properties-configuration) for credential leakage risks when passing credentials or security tokens through `gravitino.bypass.` properties.
 
 :::info
 Please set the `warehouse` parameter to `oss://{bucket_name}/${prefix_name}`. Additionally, download the [Gravitino Iceberg Aliyun bundle](https://mvnrepository.com/artifact/org.apache.gravitino/gravitino-iceberg-aliyun-bundle) and place it in the `catalogs/lakehouse-iceberg/libs/` directory.
@@ -221,8 +220,7 @@ For other storages that are not managed by Gravitino directly, you can manage th
 | `io-impl`          | The IO implementation for `FileIO` in Iceberg. Use the fully qualified class name to override the default implementation. | `org.apache.iceberg.io.ResolvingFileIO` | No       | 0.6.0-incubating |
 
 To pass custom properties such as `security-token` to your custom `FileIO`, you can directly configure it by `gravitino.bypass.security-token`. `security-token` will be included in the properties when the initialize method of `FileIO` is invoked.
-Passing credentials or security tokens through `gravitino.bypass.` properties can expose sensitive values in plaintext. See
-[Catalog Properties Configuration](./gravitino-server-config.md#catalog-properties-configuration) for details.
+See [Catalog Properties Configuration](./gravitino-server-config.md#catalog-properties-configuration) for credential leakage risks when passing credentials or security tokens through `gravitino.bypass.` properties.
 
 :::info
 Please set the `warehouse` parameter to `{storage_prefix}://{bucket_name}/${prefix_name}`. Additionally, download corresponding jars in the `catalogs/lakehouse-iceberg/libs/` directory.

--- a/docs/lakehouse-iceberg-catalog.md
+++ b/docs/lakehouse-iceberg-catalog.md
@@ -161,7 +161,7 @@ Gravitino Iceberg REST service supports using static access-key-id and secret-ac
 | `oss-endpoint`          | The endpoint of Aliyun OSS service.                                                                                             | (none)                                  | No       | 0.7.0-incubating |
 
 For other Iceberg OSS properties not managed by Gravitino like `client.security-token`, you could config it directly by `gravitino.bypass.client.security-token`.
-Passing credentials or security tokens through `gravitino.bypass.` properties has a credential leakage risk. See
+Passing credentials or security tokens through `gravitino.bypass.` properties can expose sensitive values in plaintext. See
 [Catalog Properties Configuration](./gravitino-server-config.md#catalog-properties-configuration) for details.
 
 :::info
@@ -221,7 +221,7 @@ For other storages that are not managed by Gravitino directly, you can manage th
 | `io-impl`          | The IO implementation for `FileIO` in Iceberg. Use the fully qualified class name to override the default implementation. | `org.apache.iceberg.io.ResolvingFileIO` | No       | 0.6.0-incubating |
 
 To pass custom properties such as `security-token` to your custom `FileIO`, you can directly configure it by `gravitino.bypass.security-token`. `security-token` will be included in the properties when the initialize method of `FileIO` is invoked.
-Passing credentials or security tokens through `gravitino.bypass.` properties has a credential leakage risk. See
+Passing credentials or security tokens through `gravitino.bypass.` properties can expose sensitive values in plaintext. See
 [Catalog Properties Configuration](./gravitino-server-config.md#catalog-properties-configuration) for details.
 
 :::info

--- a/docs/lakehouse-iceberg-catalog.md
+++ b/docs/lakehouse-iceberg-catalog.md
@@ -161,6 +161,8 @@ Gravitino Iceberg REST service supports using static access-key-id and secret-ac
 | `oss-endpoint`          | The endpoint of Aliyun OSS service.                                                                                             | (none)                                  | No       | 0.7.0-incubating |
 
 For other Iceberg OSS properties not managed by Gravitino like `client.security-token`, you could config it directly by `gravitino.bypass.client.security-token`.
+Passing credentials or security tokens through `gravitino.bypass.` properties has a credential leakage risk. See
+[Catalog Properties Configuration](./gravitino-server-config.md#catalog-properties-configuration) for details.
 
 :::info
 Please set the `warehouse` parameter to `oss://{bucket_name}/${prefix_name}`. Additionally, download the [Gravitino Iceberg Aliyun bundle](https://mvnrepository.com/artifact/org.apache.gravitino/gravitino-iceberg-aliyun-bundle) and place it in the `catalogs/lakehouse-iceberg/libs/` directory.
@@ -219,6 +221,8 @@ For other storages that are not managed by Gravitino directly, you can manage th
 | `io-impl`          | The IO implementation for `FileIO` in Iceberg. Use the fully qualified class name to override the default implementation. | `org.apache.iceberg.io.ResolvingFileIO` | No       | 0.6.0-incubating |
 
 To pass custom properties such as `security-token` to your custom `FileIO`, you can directly configure it by `gravitino.bypass.security-token`. `security-token` will be included in the properties when the initialize method of `FileIO` is invoked.
+Passing credentials or security tokens through `gravitino.bypass.` properties has a credential leakage risk. See
+[Catalog Properties Configuration](./gravitino-server-config.md#catalog-properties-configuration) for details.
 
 :::info
 Please set the `warehouse` parameter to `{storage_prefix}://{bucket_name}/${prefix_name}`. Additionally, download corresponding jars in the `catalogs/lakehouse-iceberg/libs/` directory.


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add documentation warnings for using `gravitino.bypass.` properties to pass credentials.

### Why are the changes needed?

Using `gravitino.bypass.` properties to pass credentials may leak sensitive values because these properties are not fully managed by Gravitino and may be returned in REST API responses as plain text.

Fix: #11645

### Does this PR introduce _any_ user-facing change?

Yes. The documentation now warns users about credential leakage risks when passing credentials through `gravitino.bypass.` properties.

### How was this patch tested?

Not run. This is a documentation-only change.