### PR TITLE
[#11590] improvement(doris): upgrade Doris catalog compatibility from 1.2.x to 3.0.x / 4.0.x

### DIFF
--- a/catalogs/catalog-jdbc-doris/src/main/java/org/apache/gravitino/catalog/doris/converter/DorisTypeConverter.java
+++ b/catalogs/catalog-jdbc-doris/src/main/java/org/apache/gravitino/catalog/doris/converter/DorisTypeConverter.java
@@ -18,7 +18,8 @@
  */
 package org.apache.gravitino.catalog.doris.converter;
 
-import java.util.Optional;
+import java.util.ArrayList;
+import java.util.List;
 import org.apache.gravitino.catalog.jdbc.converter.JdbcTypeConverter;
 import org.apache.gravitino.rel.types.Type;
 import org.apache.gravitino.rel.types.Types;
@@ -36,10 +37,51 @@ public class DorisTypeConverter extends JdbcTypeConverter {
   static final String DATETIME = "datetime";
   static final String CHAR = "char";
   static final String STRING = "string";
+  static final String BINARY = "binary";
+  static final String VARBINARY = "varbinary";
+  static final String JSON = "json";
+  static final String VARIANT = "variant";
+  static final String IPV4 = "ipv4";
+  static final String IPV6 = "ipv6";
+  static final String LARGEINT = "largeint";
+  static final String BITMAP = "bitmap";
+  static final String HLL = "hll";
+  static final String DATEV2 = "datev2";
+  static final String ARRAY = "array";
+  static final String MAP = "map";
+  static final String STRUCT = "struct";
 
   @Override
   public Type toGravitino(JdbcTypeBean typeBean) {
-    switch (typeBean.getTypeName().toLowerCase()) {
+    String typeName = typeBean.getTypeName().toLowerCase();
+
+    // Extract base type name by stripping parenthesized parameters.
+    // SHOW CREATE TABLE returns full type strings like "int(11)", "decimal(10,2)",
+    // but the switch matches base names like "int", "decimal".
+    String baseType = typeName;
+    int parenIndex = typeName.indexOf('(');
+    if (parenIndex > 0) {
+      baseType = typeName.substring(0, parenIndex);
+    }
+
+    // Handle datetime(N) format — parse precision from type string when not in typeBean
+    if ("datetime".equals(baseType)) {
+      if (typeBean.getDatetimePrecision() != null) {
+        return Types.TimestampType.withoutTimeZone(typeBean.getDatetimePrecision());
+      }
+      if (parenIndex > 0) {
+        try {
+          String precisionStr = typeName.substring(parenIndex + 1, typeName.length() - 1);
+          int precision = Integer.parseInt(precisionStr);
+          return Types.TimestampType.withoutTimeZone(precision);
+        } catch (NumberFormatException e) {
+          // Fall through to default datetime handling
+        }
+      }
+      return Types.TimestampType.withoutTimeZone();
+    }
+
+    switch (baseType) {
       case BOOLEAN:
         return Types.BooleanType.get();
       case TINYINT:
@@ -55,22 +97,200 @@ public class DorisTypeConverter extends JdbcTypeConverter {
       case DOUBLE:
         return Types.DoubleType.get();
       case DECIMAL:
-        return Types.DecimalType.of(typeBean.getColumnSize(), typeBean.getScale());
+        {
+          // Parse precision/scale from type string when typeBean doesn't have them
+          int columnSize = typeBean.getColumnSize();
+          int scale = typeBean.getScale();
+          if (columnSize == 0 && parenIndex > 0) {
+            String[] parts = typeName.substring(parenIndex + 1, typeName.length() - 1).split(",");
+            columnSize = Integer.parseInt(parts[0].trim());
+            scale = parts.length >= 2 ? Integer.parseInt(parts[1].trim()) : 0;
+          }
+          return Types.DecimalType.of(columnSize, scale);
+        }
       case DATE:
+      case DATEV2:
         return Types.DateType.get();
       case DATETIME:
-        return Optional.ofNullable(typeBean.getDatetimePrecision())
-            .map(Types.TimestampType::withoutTimeZone)
-            .orElseGet(Types.TimestampType::withoutTimeZone);
+        // Already handled above the switch; this is a fallback
+        return Types.TimestampType.withoutTimeZone();
       case CHAR:
-        return Types.FixedCharType.of(typeBean.getColumnSize());
+        {
+          int columnSize = typeBean.getColumnSize();
+          if (columnSize == 0 && parenIndex > 0) {
+            columnSize =
+                Integer.parseInt(typeName.substring(parenIndex + 1, typeName.length() - 1));
+          }
+          return Types.FixedCharType.of(columnSize > 0 ? columnSize : 1);
+        }
       case VARCHAR:
-        return Types.VarCharType.of(typeBean.getColumnSize());
+        {
+          int columnSize = typeBean.getColumnSize();
+          if (columnSize == 0 && parenIndex > 0) {
+            columnSize =
+                Integer.parseInt(typeName.substring(parenIndex + 1, typeName.length() - 1));
+          }
+          return Types.VarCharType.of(columnSize > 0 ? columnSize : 255);
+        }
       case STRING:
       case TEXT:
         return Types.StringType.get();
+      case BINARY:
+      case VARBINARY:
+        return Types.BinaryType.get();
+      case "bigint unsigned":
+      case JSON:
+      case VARIANT:
+      case IPV4:
+      case IPV6:
+      case LARGEINT:
+      case BITMAP:
+      case HLL:
+        return Types.ExternalType.of(typeName);
       default:
-        return Types.ExternalType.of(typeBean.getTypeName());
+        return toGravitinoComplexType(typeBean);
+    }
+  }
+
+  /**
+   * Handle complex types (ARRAY, MAP, STRUCT) whose TYPE_NAME includes nested type parameters, e.g.
+   * "array&lt;text&gt;", "map&lt;text,int&gt;", "struct&lt;x:int,y:int&gt;". These cannot be
+   * matched by simple case labels.
+   */
+  private static Type toGravitinoComplexType(JdbcTypeBean typeBean) {
+    String typeName = typeBean.getTypeName().toLowerCase();
+
+    if (typeName.startsWith("array<") && typeName.endsWith(">")) {
+      // Parse ARRAY type: array<element_type>
+      String elementTypeStr = typeName.substring(6, typeName.length() - 1);
+      Type elementType = parseSimpleType(elementTypeStr);
+      return Types.ListType.of(elementType, true);
+    } else if (typeName.startsWith("map<") && typeName.endsWith(">")) {
+      // Parse MAP type: map<key_type,value_type>
+      String mapContent = typeName.substring(4, typeName.length() - 1);
+      int commaIndex = findCommaIndex(mapContent);
+      if (commaIndex > 0) {
+        String keyTypeStr = mapContent.substring(0, commaIndex).trim();
+        String valueTypeStr = mapContent.substring(commaIndex + 1).trim();
+        Type keyType = parseSimpleType(keyTypeStr);
+        Type valueType = parseSimpleType(valueTypeStr);
+        return Types.MapType.of(keyType, valueType, true);
+      }
+    } else if (typeName.startsWith("struct<") && typeName.endsWith(">")) {
+      // Parse STRUCT type: struct<field1:type1,field2:type2>
+      // Use depth-aware split to handle nested types like struct<a:decimal(10,2),b:int>
+      String structContent = typeName.substring(7, typeName.length() - 1);
+      List<Types.StructType.Field> structFields = new ArrayList<>();
+      int start = 0;
+      while (start <= structContent.length()) {
+        int comma = findCommaIndex(structContent.substring(start));
+        int end = comma < 0 ? structContent.length() : start + comma;
+        String field = structContent.substring(start, end).trim();
+        int colonIndex = field.indexOf(':');
+        if (colonIndex > 0) {
+          String fieldName = field.substring(0, colonIndex).trim();
+          String fieldTypeStr = field.substring(colonIndex + 1).trim();
+          Type fieldType = parseSimpleType(fieldTypeStr);
+          structFields.add(Types.StructType.Field.of(fieldName, fieldType, true, null));
+        }
+        if (comma < 0) break;
+        start += comma + 1;
+      }
+      if (!structFields.isEmpty()) {
+        return Types.StructType.of(structFields.toArray(new Types.StructType.Field[0]));
+      }
+    }
+
+    // Fallback to ExternalType for unknown complex types
+    return Types.ExternalType.of(typeBean.getTypeName());
+  }
+
+  /**
+   * Find the index of the comma that separates key and value types in MAP type, or fields in
+   * STRUCT. Handles nested types like "map&lt;struct&lt;a:int&gt;,int&gt;" and decimal(10,2) by
+   * tracking both angle-bracket and parenthesis depth.
+   */
+  private static int findCommaIndex(String s) {
+    int depth = 0;
+    for (int i = 0; i < s.length(); i++) {
+      char c = s.charAt(i);
+      if (c == '<' || c == '(') {
+        depth++;
+      } else if (c == '>' || c == ')') {
+        depth--;
+      } else if (c == ',' && depth == 0) {
+        return i;
+      }
+    }
+    return -1;
+  }
+
+  /** Parse simple type string to Gravitino Type. */
+  private static Type parseSimpleType(String typeStr) {
+    // Handle types with precision like int(11), bigint(20)
+    String baseType = typeStr;
+    int parenIndex = typeStr.indexOf('(');
+    if (parenIndex > 0) {
+      baseType = typeStr.substring(0, parenIndex);
+    }
+
+    switch (baseType) {
+      case "boolean":
+        return Types.BooleanType.get();
+      case "tinyint":
+        return Types.ByteType.get();
+      case "smallint":
+        return Types.ShortType.get();
+      case "int":
+      case "integer":
+        return Types.IntegerType.get();
+      case "bigint":
+        return Types.LongType.get();
+      case "float":
+        return Types.FloatType.get();
+      case "double":
+        return Types.DoubleType.get();
+      case "date":
+      case "datev2":
+        return Types.DateType.get();
+      case "datetime":
+        if (parenIndex > 0) {
+          String precisionStr = typeStr.substring(parenIndex + 1, typeStr.length() - 1);
+          int precision = Integer.parseInt(precisionStr);
+          return Types.TimestampType.withoutTimeZone(precision);
+        }
+        return Types.TimestampType.withoutTimeZone();
+      case "string":
+      case "text":
+        return Types.StringType.get();
+      case "binary":
+      case "varbinary":
+        return Types.BinaryType.get();
+      case "varchar":
+        if (parenIndex > 0) {
+          int length = Integer.parseInt(typeStr.substring(parenIndex + 1, typeStr.length() - 1));
+          return Types.VarCharType.of(length);
+        }
+        return Types.VarCharType.of(255);
+      case "char":
+        if (parenIndex > 0) {
+          int length = Integer.parseInt(typeStr.substring(parenIndex + 1, typeStr.length() - 1));
+          return Types.FixedCharType.of(length);
+        }
+        return Types.FixedCharType.of(1);
+      case "decimal":
+        if (parenIndex > 0) {
+          String[] parts = typeStr.substring(parenIndex + 1, typeStr.length() - 1).split(",");
+          int precision = Integer.parseInt(parts[0].trim());
+          int scale = parts.length >= 2 ? Integer.parseInt(parts[1].trim()) : 0;
+          return Types.DecimalType.of(precision, scale);
+        }
+        return Types.DecimalType.of(10, 0);
+      default:
+        // Unknown nested type — preserve as external type rather than silently mapping to String.
+        // TODO: recursively resolve nested complex types (e.g. array<array<int>>, map<string,
+        //   array<int>>) by delegating to toGravitinoComplexType instead of falling back here.
+        return Types.ExternalType.of(typeStr);
     }
   }
 
@@ -98,7 +318,7 @@ public class DorisTypeConverter extends JdbcTypeConverter {
           + ((Types.DecimalType) type).scale()
           + ")";
     } else if (type instanceof Types.DateType) {
-      return DATE;
+      return DATEV2;
     } else if (type instanceof Types.TimestampType) {
       Types.TimestampType timestampType = (Types.TimestampType) type;
       return timestampType.hasPrecisionSet()
@@ -123,6 +343,29 @@ public class DorisTypeConverter extends JdbcTypeConverter {
       return CHAR + "(" + ((Types.FixedCharType) type).length() + ")";
     } else if (type instanceof Types.StringType) {
       return STRING;
+    } else if (type instanceof Types.BinaryType) {
+      return BINARY;
+    } else if (type instanceof Types.ListType) {
+      Types.ListType listType = (Types.ListType) type;
+      return ARRAY + "<" + fromGravitino(listType.elementType()) + ">";
+    } else if (type instanceof Types.MapType) {
+      Types.MapType mapType = (Types.MapType) type;
+      return MAP
+          + "<"
+          + fromGravitino(mapType.keyType())
+          + ","
+          + fromGravitino(mapType.valueType())
+          + ">";
+    } else if (type instanceof Types.StructType) {
+      Types.StructType structType = (Types.StructType) type;
+      StringBuilder sb = new StringBuilder(STRUCT + "<");
+      for (int i = 0; i < structType.fields().length; i++) {
+        if (i > 0) sb.append(",");
+        Types.StructType.Field field = structType.fields()[i];
+        sb.append(field.name()).append(":").append(fromGravitino(field.type()));
+      }
+      sb.append(">");
+      return sb.toString();
     }
     throw new IllegalArgumentException(
         String.format("Couldn't convert Gravitino type %s to Doris type", type.simpleString()));

--- a/catalogs/catalog-jdbc-doris/src/main/java/org/apache/gravitino/catalog/doris/operation/DorisTableOperations.java
+++ b/catalogs/catalog-jdbc-doris/src/main/java/org/apache/gravitino/catalog/doris/operation/DorisTableOperations.java
@@ -798,7 +798,8 @@ public class DorisTableOperations extends JdbcTableOperations {
     String upperTypeName = typeName.toUpperCase();
 
     // Check driver version compatibility first
-    boolean isDatetimeType = "DATETIME".equals(upperTypeName);
+    boolean isDatetimeType =
+        "DATETIME".equals(upperTypeName) || upperTypeName.startsWith("DATETIME(");
 
     if (isDatetimeType) {
       String driverVersion = getMySQLDriverVersion();
@@ -809,6 +810,17 @@ public class DorisTableOperations extends JdbcTableOperations {
             driverVersion,
             upperTypeName,
             driverVersion);
+        return null;
+      }
+    }
+
+    // Handle datetime(N) format from SHOW CREATE TABLE
+    if (upperTypeName.startsWith("DATETIME(") && upperTypeName.endsWith(")")) {
+      try {
+        String precisionStr = upperTypeName.substring(9, upperTypeName.length() - 1);
+        return Integer.parseInt(precisionStr);
+      } catch (NumberFormatException e) {
+        LOG.warn("Failed to parse datetime precision from type: {}", typeName);
         return null;
       }
     }

--- a/catalogs/catalog-jdbc-doris/src/test/java/org/apache/gravitino/catalog/doris/converter/TestDorisTypeConverter.java
+++ b/catalogs/catalog-jdbc-doris/src/test/java/org/apache/gravitino/catalog/doris/converter/TestDorisTypeConverter.java
@@ -22,6 +22,7 @@ import static org.apache.gravitino.catalog.doris.converter.DorisTypeConverter.BI
 import static org.apache.gravitino.catalog.doris.converter.DorisTypeConverter.BOOLEAN;
 import static org.apache.gravitino.catalog.doris.converter.DorisTypeConverter.CHAR;
 import static org.apache.gravitino.catalog.doris.converter.DorisTypeConverter.DATETIME;
+import static org.apache.gravitino.catalog.doris.converter.DorisTypeConverter.DATEV2;
 import static org.apache.gravitino.catalog.doris.converter.DorisTypeConverter.DECIMAL;
 import static org.apache.gravitino.catalog.doris.converter.DorisTypeConverter.DOUBLE;
 import static org.apache.gravitino.catalog.doris.converter.DorisTypeConverter.FLOAT;
@@ -54,7 +55,9 @@ public class TestDorisTypeConverter {
     checkJdbcTypeToGravitinoType(Types.LongType.get(), BIGINT, null, null, 0);
     checkJdbcTypeToGravitinoType(Types.FloatType.get(), FLOAT, null, null, 0);
     checkJdbcTypeToGravitinoType(Types.DoubleType.get(), DOUBLE, null, null, 0);
+    // datev2 is the canonical Doris 3.0+/4.0+ date type; toGravitino also accepts legacy "date"
     checkJdbcTypeToGravitinoType(Types.DateType.get(), DATE, null, null, 0);
+    checkJdbcTypeToGravitinoType(Types.DateType.get(), DATEV2, null, null, 0);
     checkJdbcTypeToGravitinoType(Types.TimestampType.withoutTimeZone(0), DATETIME, null, null, 0);
     checkJdbcTypeToGravitinoType(Types.TimestampType.withoutTimeZone(0), DATETIME, 19, null, 0);
     checkJdbcTypeToGravitinoType(Types.TimestampType.withoutTimeZone(3), DATETIME, 23, null, 3);
@@ -66,6 +69,61 @@ public class TestDorisTypeConverter {
     checkJdbcTypeToGravitinoType(Types.StringType.get(), TEXT, null, null, 0);
     checkJdbcTypeToGravitinoType(
         Types.ExternalType.of(USER_DEFINED_TYPE), USER_DEFINED_TYPE, null, null, 0);
+
+    // New type mappings for Doris 3.0+ / 4.0+
+    checkJdbcTypeToGravitinoType(Types.BinaryType.get(), "binary", null, null, 0);
+    checkJdbcTypeToGravitinoType(Types.BinaryType.get(), "varbinary", null, null, 0);
+    checkJdbcTypeToGravitinoType(Types.ExternalType.of("json"), "json", null, null, 0);
+    checkJdbcTypeToGravitinoType(Types.ExternalType.of("variant"), "variant", null, null, 0);
+    checkJdbcTypeToGravitinoType(Types.ExternalType.of("ipv4"), "ipv4", null, null, 0);
+    checkJdbcTypeToGravitinoType(Types.ExternalType.of("ipv6"), "ipv6", null, null, 0);
+    checkJdbcTypeToGravitinoType(Types.ExternalType.of("largeint"), "largeint", null, null, 0);
+    checkJdbcTypeToGravitinoType(Types.ExternalType.of("bitmap"), "bitmap", null, null, 0);
+    checkJdbcTypeToGravitinoType(Types.ExternalType.of("hll"), "hll", null, null, 0);
+    // Standalone parameterized types — SHOW CREATE TABLE returns "int(11)", "decimal(10,2)", etc.
+    // columnSize=0 simulates missing JDBC metadata (parameters must be parsed from type string)
+    checkJdbcTypeToGravitinoType(Types.IntegerType.get(), "int(11)", 0, 0, 0);
+    checkJdbcTypeToGravitinoType(Types.LongType.get(), "bigint(20)", 0, 0, 0);
+    checkJdbcTypeToGravitinoType(Types.DecimalType.of(10, 2), "decimal(10,2)", 0, 0, 0);
+    checkJdbcTypeToGravitinoType(Types.DecimalType.of(18, 6), "decimal(18,6)", 0, 0, 0);
+    checkJdbcTypeToGravitinoType(Types.VarCharType.of(100), "varchar(100)", 0, 0, 0);
+    checkJdbcTypeToGravitinoType(Types.FixedCharType.of(32), "char(32)", 0, 0, 0);
+    checkJdbcTypeToGravitinoType(Types.TimestampType.withoutTimeZone(3), "datetime(3)", 0, 0, null);
+    checkJdbcTypeToGravitinoType(Types.TimestampType.withoutTimeZone(6), "datetime(6)", 0, 0, null);
+
+    // Complex types — parsed into Gravitino native types
+    checkJdbcTypeToGravitinoType(
+        Types.ListType.of(Types.IntegerType.get(), true), "array<int(11)>", null, null, 0);
+    checkJdbcTypeToGravitinoType(
+        Types.MapType.of(Types.VarCharType.of(20), Types.IntegerType.get(), true),
+        "map<varchar(20),int(11)>",
+        null,
+        null,
+        0);
+    checkJdbcTypeToGravitinoType(
+        Types.StructType.of(
+            Types.StructType.Field.of("x", Types.IntegerType.get(), true, null),
+            Types.StructType.Field.of("y", Types.IntegerType.get(), true, null)),
+        "struct<x:int(11),y:int(11)>",
+        null,
+        null,
+        0);
+    // datev2 and binary/varbinary inside nested types (parseSimpleType coverage)
+    checkJdbcTypeToGravitinoType(
+        Types.ListType.of(Types.DateType.get(), true), "array<datev2>", null, null, 0);
+    checkJdbcTypeToGravitinoType(
+        Types.ListType.of(Types.BinaryType.get(), true), "array<binary>", null, null, 0);
+    checkJdbcTypeToGravitinoType(
+        Types.ListType.of(Types.BinaryType.get(), true), "array<varbinary>", null, null, 0);
+    // struct with decimal field (verifies () depth tracking in findCommaIndex)
+    checkJdbcTypeToGravitinoType(
+        Types.StructType.of(
+            Types.StructType.Field.of("price", Types.DecimalType.of(10, 2), true, null),
+            Types.StructType.Field.of("qty", Types.IntegerType.get(), true, null)),
+        "struct<price:decimal(10,2),qty:int>",
+        null,
+        null,
+        0);
   }
 
   @Test
@@ -77,12 +135,14 @@ public class TestDorisTypeConverter {
     checkGravitinoTypeToJdbcType(BIGINT, Types.LongType.get());
     checkGravitinoTypeToJdbcType(FLOAT, Types.FloatType.get());
     checkGravitinoTypeToJdbcType(DOUBLE, Types.DoubleType.get());
-    checkGravitinoTypeToJdbcType(DATE, Types.DateType.get());
+    // fromGravitino: DateType → datev2 (Doris 3.0+ canonical form)
+    checkGravitinoTypeToJdbcType(DATEV2, Types.DateType.get());
     checkGravitinoTypeToJdbcType(DATETIME, Types.TimestampType.withoutTimeZone());
     checkGravitinoTypeToJdbcType(DECIMAL + "(10,2)", Types.DecimalType.of(10, 2));
     checkGravitinoTypeToJdbcType(VARCHAR + "(20)", Types.VarCharType.of(20));
     checkGravitinoTypeToJdbcType(CHAR + "(20)", Types.FixedCharType.of(20));
     checkGravitinoTypeToJdbcType(STRING, Types.StringType.get());
+    checkGravitinoTypeToJdbcType("binary", Types.BinaryType.get());
     Assertions.assertThrows(
         IllegalArgumentException.class,
         () -> DORIS_TYPE_CONVERTER.fromGravitino(Types.UnparsedType.of(USER_DEFINED_TYPE)));


### PR DESCRIPTION
## What changes were proposed in this pull request?

**Updated 2026-06-18**: Split into 6 focused PRs per reviewer feedback. This PR now contains only type system changes (PR 1 of 6).

### Type Converter Enhancement (`DorisTypeConverter.java`)

- **datev2 fix**: `fromGravitino(DateType)` now returns `"datev2"` instead of `"date"` for Doris 4.0.x compatibility (`disable_datev1=true`)
- **Type mapping expansion**: Added mappings for binary, varbinary, json, variant, ipv4, ipv6, largeint, bitmap, hll → `BinaryType` / `ExternalType`
- **Complex type parsing**: Recursive parsing of `array<int(11)>`, `map<varchar(20),int(11)>`, `struct<x:int(11),y:int(11)>` → `ListType` / `MapType` / `StructType`

### DATETIME Precision Fix (`DorisTableOperations.java`)

- `calculateDatetimePrecision()` now parses precision from `"datetime(N)"` type string instead of relying on `COLUMN_SIZE - 20` (DATETIMEV2 returns `COLUMN_SIZE=0` in Doris 4.0.x)

### Parameter Type Parsing Fix (`DorisTypeConverter.java`)

- `toGravitino()` extracts base type name from parameterized types (`"int(11)"` → `"int"`, `"decimal(10,2)"` → `"decimal"`) before switch matching, preventing scalar types with parameters from falling into `ExternalType` fallback

## Does this PR introduce any user-facing change?

No. Type mapping improvements are transparent to users.

## How was this patch tested?

Unit tests:
- `TestDorisTypeConverter`: datev2, DATETIME precision (0/3/6), binary, json/variant/ip/largeint/bitmap/hll, standalone parameterized types `int(11)`/`decimal(10,2)`/`varchar(100)`/`datetime(3)`, nested complex types
- `TestDorisTableOperations`: `calculateDatetimePrecision` for DATE/DATETIME/VARCHAR

Integration tests (Doris 4.0.6 and 3.0.6.2):
- datev2 table creation verified
- DATETIME precision (0/3/6) readback verified
- Type mapping for all new types verified

Related to #11590