### PR TITLE
[MINOR] fix(oceanbase): Avoid MySQL driver version check

### DIFF
--- a/catalogs-contrib/catalog-jdbc-oceanbase/src/main/java/org/apache/gravitino/catalog/oceanbase/OceanBaseCatalog.java
+++ b/catalogs-contrib/catalog-jdbc-oceanbase/src/main/java/org/apache/gravitino/catalog/oceanbase/OceanBaseCatalog.java
@@ -20,7 +20,6 @@ package org.apache.gravitino.catalog.oceanbase;
 
 import java.util.Map;
 import org.apache.gravitino.catalog.jdbc.JdbcCatalog;
-import org.apache.gravitino.catalog.jdbc.MySQLProtocolCompatibleCatalogOperations;
 import org.apache.gravitino.catalog.jdbc.converter.JdbcColumnDefaultValueConverter;
 import org.apache.gravitino.catalog.jdbc.converter.JdbcTypeConverter;
 import org.apache.gravitino.catalog.jdbc.operation.JdbcDatabaseOperations;
@@ -42,7 +41,7 @@ public class OceanBaseCatalog extends JdbcCatalog {
 
   @Override
   protected CatalogOperations newOps(Map<String, String> config) {
-    return new MySQLProtocolCompatibleCatalogOperations(
+    return new OceanBaseCatalogOperations(
         createExceptionConverter(),
         createJdbcTypeConverter(),
         createJdbcDatabaseOperations(),

--- a/catalogs-contrib/catalog-jdbc-oceanbase/src/main/java/org/apache/gravitino/catalog/oceanbase/OceanBaseCatalogOperations.java
+++ b/catalogs-contrib/catalog-jdbc-oceanbase/src/main/java/org/apache/gravitino/catalog/oceanbase/OceanBaseCatalogOperations.java
@@ -18,24 +18,20 @@
  */
 package org.apache.gravitino.catalog.oceanbase;
 
-import org.apache.gravitino.catalog.jdbc.JdbcCatalogOperations;
+import org.apache.gravitino.catalog.jdbc.MySQLProtocolCompatibleCatalogOperations;
 import org.apache.gravitino.catalog.jdbc.converter.JdbcColumnDefaultValueConverter;
 import org.apache.gravitino.catalog.jdbc.converter.JdbcExceptionConverter;
 import org.apache.gravitino.catalog.jdbc.converter.JdbcTypeConverter;
 import org.apache.gravitino.catalog.jdbc.operation.JdbcDatabaseOperations;
 import org.apache.gravitino.catalog.jdbc.operation.JdbcTableOperations;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Operations for interacting with the OceanBase catalog in Apache Gravitino.
  *
- * <p>OceanBase supports both MySQL Connector/J and the OceanBase JDBC driver, so it should not use
- * {@code MySQLProtocolCompatibleCatalogOperations}, which rejects non-MySQL Connector/J drivers by
- * major version during catalog initialization.
+ * <p>OceanBase supports both MySQL Connector/J and the OceanBase JDBC driver, so it should skip the
+ * MySQL Connector/J major-version check during catalog initialization.
  */
-public class OceanBaseCatalogOperations extends JdbcCatalogOperations {
-  private static final Logger LOG = LoggerFactory.getLogger(OceanBaseCatalogOperations.class);
+public class OceanBaseCatalogOperations extends MySQLProtocolCompatibleCatalogOperations {
 
   /**
    * Constructs a new instance of {@link OceanBaseCatalogOperations}.
@@ -61,20 +57,7 @@ public class OceanBaseCatalogOperations extends JdbcCatalogOperations {
         columnDefaultValueConverter);
   }
 
-  /** Closes the OceanBase catalog and shuts down MySQL Connector/J cleanup resources if present. */
+  /** Skips MySQL Connector/J major-version checks for OceanBase JDBC drivers. */
   @Override
-  public void close() {
-    super.close();
-
-    try {
-      Class.forName("com.mysql.cj.jdbc.AbandonedConnectionCleanupThread")
-          .getMethod("uncheckedShutdown")
-          .invoke(null);
-      LOG.info("AbandonedConnectionCleanupThread has been shutdown...");
-    } catch (ClassNotFoundException e) {
-      LOG.debug("MySQL AbandonedConnectionCleanupThread not found on classpath, skipping shutdown");
-    } catch (Exception e) {
-      LOG.warn("Failed to shutdown AbandonedConnectionCleanupThread", e);
-    }
-  }
+  public void checkJDBCDriverVersion() {}
 }

--- a/catalogs-contrib/catalog-jdbc-oceanbase/src/main/java/org/apache/gravitino/catalog/oceanbase/OceanBaseCatalogOperations.java
+++ b/catalogs-contrib/catalog-jdbc-oceanbase/src/main/java/org/apache/gravitino/catalog/oceanbase/OceanBaseCatalogOperations.java
@@ -72,7 +72,7 @@ public class OceanBaseCatalogOperations extends JdbcCatalogOperations {
           .invoke(null);
       LOG.info("AbandonedConnectionCleanupThread has been shutdown...");
     } catch (ClassNotFoundException e) {
-      LOG.debug("MySQL AbandonedConnectionCleanupThread was not found", e);
+      LOG.debug("MySQL AbandonedConnectionCleanupThread not found on classpath, skipping shutdown");
     } catch (Exception e) {
       LOG.warn("Failed to shutdown AbandonedConnectionCleanupThread", e);
     }

--- a/catalogs-contrib/catalog-jdbc-oceanbase/src/main/java/org/apache/gravitino/catalog/oceanbase/OceanBaseCatalogOperations.java
+++ b/catalogs-contrib/catalog-jdbc-oceanbase/src/main/java/org/apache/gravitino/catalog/oceanbase/OceanBaseCatalogOperations.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog.oceanbase;
+
+import org.apache.gravitino.catalog.jdbc.JdbcCatalogOperations;
+import org.apache.gravitino.catalog.jdbc.converter.JdbcColumnDefaultValueConverter;
+import org.apache.gravitino.catalog.jdbc.converter.JdbcExceptionConverter;
+import org.apache.gravitino.catalog.jdbc.converter.JdbcTypeConverter;
+import org.apache.gravitino.catalog.jdbc.operation.JdbcDatabaseOperations;
+import org.apache.gravitino.catalog.jdbc.operation.JdbcTableOperations;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Operations for interacting with the OceanBase catalog in Apache Gravitino.
+ *
+ * <p>OceanBase supports both MySQL Connector/J and the OceanBase JDBC driver, so it should not use
+ * {@code MySQLProtocolCompatibleCatalogOperations}, which rejects non-MySQL Connector/J drivers by
+ * major version during catalog initialization.
+ */
+public class OceanBaseCatalogOperations extends JdbcCatalogOperations {
+  private static final Logger LOG = LoggerFactory.getLogger(OceanBaseCatalogOperations.class);
+
+  /**
+   * Constructs a new instance of {@link OceanBaseCatalogOperations}.
+   *
+   * @param exceptionConverter The exception converter to be used by the operations.
+   * @param jdbcTypeConverter The type converter to be used by the operations.
+   * @param databaseOperation The database operations to be used by the operations.
+   * @param tableOperation The table operations to be used by the operations.
+   * @param columnDefaultValueConverter The column default value converter to be used by the
+   *     operations.
+   */
+  public OceanBaseCatalogOperations(
+      JdbcExceptionConverter exceptionConverter,
+      JdbcTypeConverter jdbcTypeConverter,
+      JdbcDatabaseOperations databaseOperation,
+      JdbcTableOperations tableOperation,
+      JdbcColumnDefaultValueConverter columnDefaultValueConverter) {
+    super(
+        exceptionConverter,
+        jdbcTypeConverter,
+        databaseOperation,
+        tableOperation,
+        columnDefaultValueConverter);
+  }
+
+  /** Closes the OceanBase catalog and shuts down MySQL Connector/J cleanup resources if present. */
+  @Override
+  public void close() {
+    super.close();
+
+    try {
+      Class.forName("com.mysql.cj.jdbc.AbandonedConnectionCleanupThread")
+          .getMethod("uncheckedShutdown")
+          .invoke(null);
+      LOG.info("AbandonedConnectionCleanupThread has been shutdown...");
+    } catch (ClassNotFoundException e) {
+      LOG.debug("MySQL AbandonedConnectionCleanupThread was not found", e);
+    } catch (Exception e) {
+      LOG.warn("Failed to shutdown AbandonedConnectionCleanupThread", e);
+    }
+  }
+}

--- a/catalogs-contrib/catalog-jdbc-oceanbase/src/test/java/org/apache/gravitino/catalog/oceanbase/TestOceanBaseCatalogOperations.java
+++ b/catalogs-contrib/catalog-jdbc-oceanbase/src/test/java/org/apache/gravitino/catalog/oceanbase/TestOceanBaseCatalogOperations.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog.oceanbase;
+
+import java.util.Collections;
+import java.util.Map;
+import org.apache.gravitino.catalog.jdbc.MySQLProtocolCompatibleCatalogOperations;
+import org.apache.gravitino.connector.CatalogOperations;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TestOceanBaseCatalogOperations {
+
+  @Test
+  public void testOceanBaseCatalogUsesOceanBaseOperations() {
+    CatalogOperations operations = new TestableOceanBaseCatalog().newOps(Collections.emptyMap());
+
+    Assertions.assertInstanceOf(OceanBaseCatalogOperations.class, operations);
+    Assertions.assertFalse(operations instanceof MySQLProtocolCompatibleCatalogOperations);
+  }
+
+  @Test
+  public void testCheckJDBCDriverVersionDoesNotRejectOceanBaseDriverVersion() {
+    OceanBaseCatalogOperations operations =
+        new OceanBaseCatalogOperations(null, null, null, null, null);
+
+    Assertions.assertDoesNotThrow(operations::checkJDBCDriverVersion);
+  }
+
+  private static class TestableOceanBaseCatalog extends OceanBaseCatalog {
+    @Override
+    protected CatalogOperations newOps(Map<String, String> config) {
+      return super.newOps(config);
+    }
+  }
+}

--- a/catalogs-contrib/catalog-jdbc-oceanbase/src/test/java/org/apache/gravitino/catalog/oceanbase/TestOceanBaseCatalogOperations.java
+++ b/catalogs-contrib/catalog-jdbc-oceanbase/src/test/java/org/apache/gravitino/catalog/oceanbase/TestOceanBaseCatalogOperations.java
@@ -31,7 +31,7 @@ public class TestOceanBaseCatalogOperations {
     CatalogOperations operations = new OceanBaseCatalog().newOps(Collections.emptyMap());
 
     Assertions.assertInstanceOf(OceanBaseCatalogOperations.class, operations);
-    Assertions.assertFalse(operations instanceof MySQLProtocolCompatibleCatalogOperations);
+    Assertions.assertInstanceOf(MySQLProtocolCompatibleCatalogOperations.class, operations);
   }
 
   @Test

--- a/catalogs-contrib/catalog-jdbc-oceanbase/src/test/java/org/apache/gravitino/catalog/oceanbase/TestOceanBaseCatalogOperations.java
+++ b/catalogs-contrib/catalog-jdbc-oceanbase/src/test/java/org/apache/gravitino/catalog/oceanbase/TestOceanBaseCatalogOperations.java
@@ -19,7 +19,6 @@
 package org.apache.gravitino.catalog.oceanbase;
 
 import java.util.Collections;
-import java.util.Map;
 import org.apache.gravitino.catalog.jdbc.MySQLProtocolCompatibleCatalogOperations;
 import org.apache.gravitino.connector.CatalogOperations;
 import org.junit.jupiter.api.Assertions;
@@ -29,7 +28,7 @@ public class TestOceanBaseCatalogOperations {
 
   @Test
   public void testOceanBaseCatalogUsesOceanBaseOperations() {
-    CatalogOperations operations = new TestableOceanBaseCatalog().newOps(Collections.emptyMap());
+    CatalogOperations operations = new OceanBaseCatalog().newOps(Collections.emptyMap());
 
     Assertions.assertInstanceOf(OceanBaseCatalogOperations.class, operations);
     Assertions.assertFalse(operations instanceof MySQLProtocolCompatibleCatalogOperations);
@@ -37,16 +36,10 @@ public class TestOceanBaseCatalogOperations {
 
   @Test
   public void testCheckJDBCDriverVersionDoesNotRejectOceanBaseDriverVersion() {
+    // OceanBase JDBC driver versions can be lower than the MySQL Connector/J minimum version.
     OceanBaseCatalogOperations operations =
         new OceanBaseCatalogOperations(null, null, null, null, null);
 
     Assertions.assertDoesNotThrow(operations::checkJDBCDriverVersion);
-  }
-
-  private static class TestableOceanBaseCatalog extends OceanBaseCatalog {
-    @Override
-    protected CatalogOperations newOps(Map<String, String> config) {
-      return super.newOps(config);
-    }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR introduces `OceanBaseCatalogOperations` for the OceanBase JDBC catalog and makes `OceanBaseCatalog` use it instead of `MySQLProtocolCompatibleCatalogOperations`.

The new operations class extends the generic `JdbcCatalogOperations`, so OceanBase catalog initialization no longer applies the MySQL Connector/J major-version check. It still shuts down MySQL Connector/J cleanup resources when present, which keeps the MySQL protocol driver path covered.

A unit test is added to verify that OceanBase catalog uses `OceanBaseCatalogOperations` and does not use `MySQLProtocolCompatibleCatalogOperations`.

### Why are the changes needed?

OceanBase catalog supports both MySQL protocol URLs and OceanBase protocol URLs. Users may configure either MySQL Connector/J or the OceanBase official JDBC driver.

Currently, OceanBase catalog reuses `MySQLProtocolCompatibleCatalogOperations`, which rejects drivers whose major version is lower than 8. This can incorrectly reject OceanBase JDBC drivers, for example `oceanbase-client-2.4.18.jar`, during catalog creation with an error like:

`Mysql catalog does not support the jdbc driver version 2.4.18, minimal required version is 8.0`

This issue is not specific to `2.4.18`; OceanBase JDBC driver 4.x can also be incorrectly rejected because its major version is still lower than 8.

Fix: N/A

### Does this PR introduce _any_ user-facing change?

Yes. Creating an OceanBase catalog with the OceanBase JDBC driver is no longer incorrectly blocked by the MySQL Connector/J version check.

No public API or catalog property is added or removed.

### How was this patch tested?

Added unit coverage in `TestOceanBaseCatalogOperations`.

`git diff --check` passed.

Gradle tests were not run locally because the current machine only has JDK 8 installed, while Gravitino requires JDK 17 to build.