### PR TITLE
[TEST]

### DIFF
--- a/core/src/main/java/org/apache/gravitino/cache/CaffeineEntityCache.java
+++ b/core/src/main/java/org/apache/gravitino/cache/CaffeineEntityCache.java
@@ -197,6 +197,23 @@ public class CaffeineEntityCache extends BaseEntityCache {
 
   /** {@inheritDoc} */
   @Override
+  public boolean invalidateRelationCache(
+      NameIdentifier ident, Entity.EntityType type, SupportsRelationOperations.Type relType) {
+    checkArguments(ident, type, relType);
+
+    EntityCacheRelationKey entityCacheKey = EntityCacheRelationKey.of(ident, type, relType);
+    return segmentedLock.withLock(
+        entityCacheKey,
+        () -> {
+          cacheData.invalidate(entityCacheKey);
+          cacheIndex.remove(entityCacheKey.toString());
+          reverseIndex.remove(entityCacheKey);
+          return true;
+        });
+  }
+
+  /** {@inheritDoc} */
+  @Override
   public boolean invalidate(NameIdentifier ident, Entity.EntityType type) {
     checkArguments(ident, type);
     return segmentedLock.withLock(

--- a/core/src/main/java/org/apache/gravitino/cache/NoOpsCache.java
+++ b/core/src/main/java/org/apache/gravitino/cache/NoOpsCache.java
@@ -127,6 +127,13 @@ public class NoOpsCache extends BaseEntityCache {
 
   /** {@inheritDoc} */
   @Override
+  public boolean invalidateRelationCache(
+      NameIdentifier ident, Entity.EntityType type, SupportsRelationOperations.Type relType) {
+    return false;
+  }
+
+  /** {@inheritDoc} */
+  @Override
   public boolean contains(
       NameIdentifier ident, Entity.EntityType type, SupportsRelationOperations.Type relType) {
     return false;

--- a/core/src/main/java/org/apache/gravitino/cache/SupportsRelationEntityCache.java
+++ b/core/src/main/java/org/apache/gravitino/cache/SupportsRelationEntityCache.java
@@ -57,6 +57,17 @@ public interface SupportsRelationEntityCache {
       NameIdentifier ident, Entity.EntityType type, SupportsRelationOperations.Type relType);
 
   /**
+   * Invalidates only the exact cached relation for the given entity and relation type.
+   *
+   * @param ident the name identifier
+   * @param type the entity type
+   * @param relType the relation type
+   * @return true if the cache entry was removed
+   */
+  boolean invalidateRelationCache(
+      NameIdentifier ident, Entity.EntityType type, SupportsRelationOperations.Type relType);
+
+  /**
    * Checks whether an entity with the given name identifier, type, and relation type is present in
    * the cache.
    *

--- a/core/src/main/java/org/apache/gravitino/storage/relational/RelationalEntityStore.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/RelationalEntityStore.java
@@ -41,6 +41,7 @@ import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
 import org.apache.gravitino.RelationalEntity;
 import org.apache.gravitino.SupportsRelationOperations;
+import org.apache.gravitino.authorization.SecurableObject;
 import org.apache.gravitino.cache.CacheFactory;
 import org.apache.gravitino.cache.CachedEntityIdResolver;
 import org.apache.gravitino.cache.EntityCache;
@@ -48,8 +49,13 @@ import org.apache.gravitino.cache.EntityCacheKey;
 import org.apache.gravitino.cache.EntityCacheRelationKey;
 import org.apache.gravitino.cache.NoOpsCache;
 import org.apache.gravitino.exceptions.NoSuchEntityException;
+import org.apache.gravitino.meta.GroupEntity;
+import org.apache.gravitino.meta.RoleEntity;
+import org.apache.gravitino.meta.UserEntity;
 import org.apache.gravitino.storage.relational.service.EntityIdService;
 import org.apache.gravitino.utils.Executable;
+import org.apache.gravitino.utils.MetadataObjectUtil;
+import org.apache.gravitino.utils.NameIdentifierUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -143,6 +149,7 @@ public class RelationalEntityStore
   public <E extends Entity & HasIdentifier> void put(E e, boolean overwritten)
       throws IOException, EntityAlreadyExistsException {
     backend.insert(e, overwritten);
+    invalidateDerivedRelationCaches(e);
     cache.put(e);
   }
 
@@ -152,6 +159,7 @@ public class RelationalEntityStore
       throws IOException, NoSuchEntityException, EntityAlreadyExistsException {
     E updatedEntity = backend.update(ident, entityType, updater);
     cache.invalidate(ident, entityType);
+    invalidateDerivedRelationCaches(updatedEntity);
     return updatedEntity;
   }
 
@@ -410,6 +418,58 @@ public class RelationalEntityStore
   public <E extends Entity & HasIdentifier> void batchPut(List<E> entities, boolean overwritten)
       throws IOException, EntityAlreadyExistsException {
     backend.batchPut(entities, overwritten);
+  }
+
+  private void invalidateDerivedRelationCaches(Entity entity) {
+    if (entity instanceof RoleEntity) {
+      invalidateMetadataObjectRoleRelCache((RoleEntity) entity);
+    } else if (entity instanceof UserEntity) {
+      invalidateRoleUserRelCache((UserEntity) entity);
+    } else if (entity instanceof GroupEntity) {
+      invalidateRoleGroupRelCache((GroupEntity) entity);
+    }
+  }
+
+  private void invalidateMetadataObjectRoleRelCache(RoleEntity roleEntity) {
+    if (roleEntity.securableObjects() == null) {
+      return;
+    }
+
+    String metalakeName = roleEntity.namespace().level(0);
+    for (SecurableObject securableObject : roleEntity.securableObjects()) {
+      NameIdentifier identifier = MetadataObjectUtil.toEntityIdent(metalakeName, securableObject);
+      Entity.EntityType entityType = MetadataObjectUtil.toEntityType(securableObject.type());
+      cache.invalidateRelationCache(
+          identifier, entityType, SupportsRelationOperations.Type.METADATA_OBJECT_ROLE_REL);
+    }
+  }
+
+  private void invalidateRoleUserRelCache(UserEntity userEntity) {
+    if (userEntity.roleNames() == null) {
+      return;
+    }
+
+    String metalakeName = userEntity.namespace().level(0);
+    for (String roleName : userEntity.roleNames()) {
+      cache.invalidateRelationCache(
+          NameIdentifierUtil.ofRole(metalakeName, roleName),
+          Entity.EntityType.ROLE,
+          SupportsRelationOperations.Type.ROLE_USER_REL);
+    }
+  }
+
+  private void invalidateRoleGroupRelCache(GroupEntity groupEntity) {
+    if (groupEntity.roleNames() == null) {
+      return;
+    }
+
+    String metalakeName = groupEntity.namespace().level(0);
+    for (String roleName : groupEntity.roleNames()) {
+      cache.invalidateRelationCache(
+          NameIdentifierUtil.ofRole(metalakeName, roleName),
+          Entity.EntityType.ROLE,
+          SupportsRelationOperations.Type.ROLE_GROUP_REL);
+    }
   }
 
   private <E extends Entity & HasIdentifier> Optional<List<RelationalEntity<?>>> getCachedRelations(

--- a/core/src/test/java/org/apache/gravitino/storage/TestEntityStorageRelationCache.java
+++ b/core/src/test/java/org/apache/gravitino/storage/TestEntityStorageRelationCache.java
@@ -58,6 +58,7 @@ import org.apache.gravitino.meta.CatalogEntity;
 import org.apache.gravitino.meta.FilesetEntity;
 import org.apache.gravitino.meta.FunctionEntity;
 import org.apache.gravitino.meta.GenericEntity;
+import org.apache.gravitino.meta.GroupEntity;
 import org.apache.gravitino.meta.PolicyEntity;
 import org.apache.gravitino.meta.RoleEntity;
 import org.apache.gravitino.meta.SchemaEntity;
@@ -74,6 +75,7 @@ import org.apache.gravitino.storage.relational.RelationalEntityStore;
 import org.apache.gravitino.utils.NameIdentifierUtil;
 import org.apache.gravitino.utils.NamespaceUtil;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -1603,6 +1605,381 @@ public class TestEntityStorageRelationCache extends AbstractEntityStorageTest {
         Assertions.assertTrue(
             rolesAfterRevoke.isEmpty(),
             "listEntitiesByRelation must return empty after revoking the last privilege from role");
+
+      } finally {
+        destroy(type);
+      }
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("storageProvider")
+  void testGrantPrivilegeInvalidatesMetadataObjectRoleRelCache(String type, boolean enableCache)
+      throws Exception {
+    Assumptions.assumeTrue(enableCache);
+
+    Config config = Mockito.mock(Config.class);
+    Mockito.when(config.get(Configs.CACHE_ENABLED)).thenReturn(enableCache);
+    init(type, config);
+
+    AuditInfo auditInfo =
+        AuditInfo.builder().withCreator("creator").withCreateTime(Instant.now()).build();
+
+    try (EntityStore store = EntityStoreFactory.createEntityStore(config)) {
+      try {
+        store.initialize(config);
+
+        BaseMetalake metalake =
+            createBaseMakeLake(RandomIdGenerator.INSTANCE.nextId(), "metalake", auditInfo);
+        store.put(metalake, false);
+
+        CatalogEntity catalog =
+            createCatalog(
+                RandomIdGenerator.INSTANCE.nextId(),
+                NamespaceUtil.ofCatalog("metalake"),
+                "catalog",
+                auditInfo);
+        store.put(catalog, false);
+
+        SchemaEntity schema =
+            createSchemaEntity(
+                RandomIdGenerator.INSTANCE.nextId(),
+                Namespace.of("metalake", "catalog"),
+                "test_schema",
+                auditInfo);
+        store.put(schema, false);
+
+        SecurableObject catalogObject = SecurableObjects.ofCatalog("catalog", Lists.newArrayList());
+        SecurableObject schemaObject =
+            SecurableObjects.ofSchema(
+                catalogObject, "test_schema", Lists.newArrayList(Privileges.UseSchema.allow()));
+
+        RoleEntity roleA =
+            RoleEntity.builder()
+                .withId(RandomIdGenerator.INSTANCE.nextId())
+                .withName("roleA")
+                .withNamespace(AuthorizationUtils.ofRoleNamespace("metalake"))
+                .withProperties(null)
+                .withAuditInfo(auditInfo)
+                .withSecurableObjects(Lists.newArrayList(schemaObject))
+                .build();
+        store.put(roleA, false);
+
+        RoleEntity roleB =
+            RoleEntity.builder()
+                .withId(RandomIdGenerator.INSTANCE.nextId())
+                .withName("roleB")
+                .withNamespace(AuthorizationUtils.ofRoleNamespace("metalake"))
+                .withProperties(null)
+                .withAuditInfo(auditInfo)
+                .withSecurableObjects(Lists.newArrayList())
+                .build();
+        store.put(roleB, false);
+
+        SupportsRelationOperations relationOperations = (SupportsRelationOperations) store;
+
+        List<RoleEntity> rolesBeforeGrant =
+            relationOperations.listEntitiesByRelation(
+                SupportsRelationOperations.Type.METADATA_OBJECT_ROLE_REL,
+                schema.nameIdentifier(),
+                Entity.EntityType.SCHEMA,
+                true);
+        Assertions.assertEquals(1, rolesBeforeGrant.size());
+        Assertions.assertEquals("roleA", rolesBeforeGrant.get(0).name());
+
+        store.update(
+            roleB.nameIdentifier(),
+            RoleEntity.class,
+            Entity.EntityType.ROLE,
+            existing ->
+                RoleEntity.builder()
+                    .withId(existing.id())
+                    .withName(existing.name())
+                    .withNamespace(existing.namespace())
+                    .withProperties(existing.properties())
+                    .withAuditInfo(existing.auditInfo())
+                    .withSecurableObjects(Lists.newArrayList(schemaObject))
+                    .build());
+
+        List<RoleEntity> roleEntitiesAfterGrant =
+            relationOperations.listEntitiesByRelation(
+                SupportsRelationOperations.Type.METADATA_OBJECT_ROLE_REL,
+                schema.nameIdentifier(),
+                Entity.EntityType.SCHEMA,
+                true);
+        List<String> rolesAfterGrant =
+            roleEntitiesAfterGrant.stream()
+                .map(RoleEntity::name)
+                .sorted()
+                .collect(Collectors.toList());
+        Assertions.assertEquals(
+            Lists.newArrayList("roleA", "roleB"),
+            rolesAfterGrant,
+            "grant must be immediately visible via listEntitiesByRelation");
+
+      } finally {
+        destroy(type);
+      }
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("storageProvider")
+  void testCreateRoleInvalidatesMetadataObjectRoleRelCache(String type, boolean enableCache)
+      throws Exception {
+    Assumptions.assumeTrue(enableCache);
+
+    Config config = Mockito.mock(Config.class);
+    Mockito.when(config.get(Configs.CACHE_ENABLED)).thenReturn(enableCache);
+    init(type, config);
+
+    AuditInfo auditInfo =
+        AuditInfo.builder().withCreator("creator").withCreateTime(Instant.now()).build();
+
+    try (EntityStore store = EntityStoreFactory.createEntityStore(config)) {
+      try {
+        store.initialize(config);
+
+        BaseMetalake metalake =
+            createBaseMakeLake(RandomIdGenerator.INSTANCE.nextId(), "metalake", auditInfo);
+        store.put(metalake, false);
+
+        CatalogEntity catalog =
+            createCatalog(
+                RandomIdGenerator.INSTANCE.nextId(),
+                NamespaceUtil.ofCatalog("metalake"),
+                "catalog",
+                auditInfo);
+        store.put(catalog, false);
+
+        SchemaEntity schema =
+            createSchemaEntity(
+                RandomIdGenerator.INSTANCE.nextId(),
+                Namespace.of("metalake", "catalog"),
+                "test_schema",
+                auditInfo);
+        store.put(schema, false);
+
+        SecurableObject catalogObject = SecurableObjects.ofCatalog("catalog", Lists.newArrayList());
+        SecurableObject schemaObject =
+            SecurableObjects.ofSchema(
+                catalogObject, "test_schema", Lists.newArrayList(Privileges.UseSchema.allow()));
+
+        RoleEntity roleA =
+            RoleEntity.builder()
+                .withId(RandomIdGenerator.INSTANCE.nextId())
+                .withName("roleA")
+                .withNamespace(AuthorizationUtils.ofRoleNamespace("metalake"))
+                .withProperties(null)
+                .withAuditInfo(auditInfo)
+                .withSecurableObjects(Lists.newArrayList(schemaObject))
+                .build();
+        store.put(roleA, false);
+
+        SupportsRelationOperations relationOperations = (SupportsRelationOperations) store;
+
+        List<RoleEntity> rolesBeforeCreate =
+            relationOperations.listEntitiesByRelation(
+                SupportsRelationOperations.Type.METADATA_OBJECT_ROLE_REL,
+                schema.nameIdentifier(),
+                Entity.EntityType.SCHEMA,
+                true);
+        Assertions.assertEquals(1, rolesBeforeCreate.size());
+        Assertions.assertEquals("roleA", rolesBeforeCreate.get(0).name());
+
+        RoleEntity roleB =
+            RoleEntity.builder()
+                .withId(RandomIdGenerator.INSTANCE.nextId())
+                .withName("roleB")
+                .withNamespace(AuthorizationUtils.ofRoleNamespace("metalake"))
+                .withProperties(null)
+                .withAuditInfo(auditInfo)
+                .withSecurableObjects(Lists.newArrayList(schemaObject))
+                .build();
+        store.put(roleB, false);
+
+        List<RoleEntity> roleEntitiesAfterCreate =
+            relationOperations.listEntitiesByRelation(
+                SupportsRelationOperations.Type.METADATA_OBJECT_ROLE_REL,
+                schema.nameIdentifier(),
+                Entity.EntityType.SCHEMA,
+                true);
+        List<String> rolesAfterCreate =
+            roleEntitiesAfterCreate.stream()
+                .map(RoleEntity::name)
+                .sorted()
+                .collect(Collectors.toList());
+        Assertions.assertEquals(
+            Lists.newArrayList("roleA", "roleB"),
+            rolesAfterCreate,
+            "new role must be immediately visible via listEntitiesByRelation");
+
+      } finally {
+        destroy(type);
+      }
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("storageProvider")
+  void testGrantRoleToUserInvalidatesRoleUserRelCache(String type, boolean enableCache)
+      throws Exception {
+    Assumptions.assumeTrue(enableCache);
+
+    Config config = Mockito.mock(Config.class);
+    Mockito.when(config.get(Configs.CACHE_ENABLED)).thenReturn(enableCache);
+    init(type, config);
+
+    AuditInfo auditInfo =
+        AuditInfo.builder().withCreator("creator").withCreateTime(Instant.now()).build();
+
+    try (EntityStore store = EntityStoreFactory.createEntityStore(config)) {
+      try {
+        store.initialize(config);
+
+        BaseMetalake metalake =
+            createBaseMakeLake(RandomIdGenerator.INSTANCE.nextId(), "metalake", auditInfo);
+        store.put(metalake, false);
+
+        RoleEntity role =
+            RoleEntity.builder()
+                .withId(RandomIdGenerator.INSTANCE.nextId())
+                .withName("roleA")
+                .withNamespace(AuthorizationUtils.ofRoleNamespace("metalake"))
+                .withProperties(null)
+                .withAuditInfo(auditInfo)
+                .withSecurableObjects(Lists.newArrayList())
+                .build();
+        store.put(role, false);
+
+        UserEntity user =
+            createUserEntity(
+                RandomIdGenerator.INSTANCE.nextId(),
+                AuthorizationUtils.ofUserNamespace("metalake"),
+                "userA",
+                auditInfo);
+        store.put(user, false);
+
+        SupportsRelationOperations relationOperations = (SupportsRelationOperations) store;
+        List<UserEntity> usersBeforeGrant =
+            relationOperations.listEntitiesByRelation(
+                SupportsRelationOperations.Type.ROLE_USER_REL,
+                role.nameIdentifier(),
+                Entity.EntityType.ROLE,
+                true);
+        Assertions.assertTrue(usersBeforeGrant.isEmpty());
+
+        store.update(
+            user.nameIdentifier(),
+            UserEntity.class,
+            Entity.EntityType.USER,
+            existing ->
+                UserEntity.builder()
+                    .withId(existing.id())
+                    .withNamespace(existing.namespace())
+                    .withName(existing.name())
+                    .withRoleNames(Lists.newArrayList(role.name()))
+                    .withRoleIds(Lists.newArrayList(role.id()))
+                    .withAuditInfo(existing.auditInfo())
+                    .build());
+
+        List<UserEntity> userEntitiesAfterGrant =
+            relationOperations.listEntitiesByRelation(
+                SupportsRelationOperations.Type.ROLE_USER_REL,
+                role.nameIdentifier(),
+                Entity.EntityType.ROLE,
+                true);
+        List<String> usersAfterGrant =
+            userEntitiesAfterGrant.stream().map(UserEntity::name).collect(Collectors.toList());
+        Assertions.assertEquals(
+            Lists.newArrayList("userA"),
+            usersAfterGrant,
+            "granted user must be immediately visible via ROLE_USER_REL from role side");
+
+      } finally {
+        destroy(type);
+      }
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("storageProvider")
+  void testGrantRoleToGroupInvalidatesRoleGroupRelCache(String type, boolean enableCache)
+      throws Exception {
+    Assumptions.assumeTrue(enableCache);
+
+    Config config = Mockito.mock(Config.class);
+    Mockito.when(config.get(Configs.CACHE_ENABLED)).thenReturn(enableCache);
+    init(type, config);
+
+    AuditInfo auditInfo =
+        AuditInfo.builder().withCreator("creator").withCreateTime(Instant.now()).build();
+
+    try (EntityStore store = EntityStoreFactory.createEntityStore(config)) {
+      try {
+        store.initialize(config);
+
+        BaseMetalake metalake =
+            createBaseMakeLake(RandomIdGenerator.INSTANCE.nextId(), "metalake", auditInfo);
+        store.put(metalake, false);
+
+        RoleEntity role =
+            RoleEntity.builder()
+                .withId(RandomIdGenerator.INSTANCE.nextId())
+                .withName("roleA")
+                .withNamespace(AuthorizationUtils.ofRoleNamespace("metalake"))
+                .withProperties(null)
+                .withAuditInfo(auditInfo)
+                .withSecurableObjects(Lists.newArrayList())
+                .build();
+        store.put(role, false);
+
+        GroupEntity group =
+            GroupEntity.builder()
+                .withId(RandomIdGenerator.INSTANCE.nextId())
+                .withNamespace(AuthorizationUtils.ofGroupNamespace("metalake"))
+                .withName("groupA")
+                .withRoleNames(Lists.newArrayList())
+                .withRoleIds(Lists.newArrayList())
+                .withAuditInfo(auditInfo)
+                .build();
+        store.put(group, false);
+
+        SupportsRelationOperations relationOperations = (SupportsRelationOperations) store;
+        List<GroupEntity> groupsBeforeGrant =
+            relationOperations.listEntitiesByRelation(
+                SupportsRelationOperations.Type.ROLE_GROUP_REL,
+                role.nameIdentifier(),
+                Entity.EntityType.ROLE,
+                true);
+        Assertions.assertTrue(groupsBeforeGrant.isEmpty());
+
+        store.update(
+            group.nameIdentifier(),
+            GroupEntity.class,
+            Entity.EntityType.GROUP,
+            existing ->
+                GroupEntity.builder()
+                    .withId(existing.id())
+                    .withNamespace(existing.namespace())
+                    .withName(existing.name())
+                    .withRoleNames(Lists.newArrayList(role.name()))
+                    .withRoleIds(Lists.newArrayList(role.id()))
+                    .withAuditInfo(existing.auditInfo())
+                    .build());
+
+        List<GroupEntity> groupEntitiesAfterGrant =
+            relationOperations.listEntitiesByRelation(
+                SupportsRelationOperations.Type.ROLE_GROUP_REL,
+                role.nameIdentifier(),
+                Entity.EntityType.ROLE,
+                true);
+        List<String> groupsAfterGrant =
+            groupEntitiesAfterGrant.stream().map(GroupEntity::name).collect(Collectors.toList());
+        Assertions.assertEquals(
+            Lists.newArrayList("groupA"),
+            groupsAfterGrant,
+            "granted group must be immediately visible via ROLE_GROUP_REL from role side");
 
       } finally {
         destroy(type);


### PR DESCRIPTION
### What changes were proposed in this pull request?

Invalidate derived relation cache entries after entity writes for role-related relationships stored inside entity fields:

- Role securable objects invalidate object-side `METADATA_OBJECT_ROLE_REL` caches.
- User role grants invalidate role-side `ROLE_USER_REL` caches.
- Group role grants invalidate role-side `ROLE_GROUP_REL` caches.

### Why are the changes needed?

When a new relation is added through an entity update, the reverse index may not contain a path from the updated entity to an already cached relation list on the other side. A later load/list can then return stale data until the relation cache entry expires.

Fix: #11701

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

- `./gradlew :core:spotlessApply`
- `git diff --check`
- `./gradlew :core:test --tests org.apache.gravitino.storage.TestEntityStorageRelationCache.testGrantPrivilegeInvalidatesMetadataObjectRoleRelCache --tests org.apache.gravitino.storage.TestEntityStorageRelationCache.testCreateRoleInvalidatesMetadataObjectRoleRelCache --tests org.apache.gravitino.storage.TestEntityStorageRelationCache.testGrantRoleToUserInvalidatesRoleUserRelCache --tests org.apache.gravitino.storage.TestEntityStorageRelationCache.testGrantRoleToGroupInvalidatesRoleGroupRelCache --tests org.apache.gravitino.storage.TestEntityStorageRelationCache.testCacheInvalidationOnNewRelationReverse -PskipITs -PskipDockerTests=false`