### PR TITLE
[#11728] feat(iceberg-rest): Add register view support for IRC

### DIFF
--- a/core/src/main/java/org/apache/gravitino/audit/AuditLog.java
+++ b/core/src/main/java/org/apache/gravitino/audit/AuditLog.java
@@ -332,6 +332,8 @@ public interface AuditLog {
 
     CREATE_VIEW,
 
+    REGISTER_VIEW,
+
     ALTER_VIEW,
 
     REPLACE_VIEW,

--- a/core/src/main/java/org/apache/gravitino/audit/v2/CompatibilityUtils.java
+++ b/core/src/main/java/org/apache/gravitino/audit/v2/CompatibilityUtils.java
@@ -95,6 +95,7 @@ public class CompatibilityUtils {
           .put(OperationType.LIST_TOPIC, Operation.LIST_TOPIC)
           .put(OperationType.LOAD_TOPIC, Operation.LOAD_TOPIC)
           .put(OperationType.CREATE_VIEW, Operation.CREATE_VIEW)
+          .put(OperationType.REGISTER_VIEW, Operation.REGISTER_VIEW)
           .put(OperationType.ALTER_VIEW, Operation.ALTER_VIEW)
           .put(OperationType.REPLACE_VIEW, Operation.REPLACE_VIEW)
           .put(OperationType.DROP_VIEW, Operation.DROP_VIEW)

--- a/core/src/main/java/org/apache/gravitino/listener/api/event/OperationType.java
+++ b/core/src/main/java/org/apache/gravitino/listener/api/event/OperationType.java
@@ -99,6 +99,7 @@ public enum OperationType {
 
   // View event
   CREATE_VIEW,
+  REGISTER_VIEW,
   ALTER_VIEW,
   REPLACE_VIEW,
   DROP_VIEW,

--- a/core/src/test/java/org/apache/gravitino/audit/v2/TestCompatibilityUtils.java
+++ b/core/src/test/java/org/apache/gravitino/audit/v2/TestCompatibilityUtils.java
@@ -103,6 +103,7 @@ public class TestCompatibilityUtils {
       {OperationType.LOAD_TOPIC, Operation.LOAD_TOPIC},
       {OperationType.LIST_TOPIC, Operation.LIST_TOPIC},
       {OperationType.CREATE_VIEW, Operation.CREATE_VIEW},
+      {OperationType.REGISTER_VIEW, Operation.REGISTER_VIEW},
       {OperationType.ALTER_VIEW, Operation.ALTER_VIEW},
       {OperationType.REPLACE_VIEW, Operation.REPLACE_VIEW},
       {OperationType.DROP_VIEW, Operation.DROP_VIEW},

--- a/docs/iceberg-rest-service.md
+++ b/docs/iceberg-rest-service.md
@@ -36,7 +36,6 @@ The Iceberg REST server provides:
 The following Iceberg REST API features are not implemented:
 
 - Multi-table transactions.
-- View registration.
 
 ## Deployment
 

--- a/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/ops/IcebergCatalogWrapper.java
+++ b/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/ops/IcebergCatalogWrapper.java
@@ -54,6 +54,7 @@ import org.apache.iceberg.rest.requests.CreateNamespaceRequest;
 import org.apache.iceberg.rest.requests.CreateTableRequest;
 import org.apache.iceberg.rest.requests.CreateViewRequest;
 import org.apache.iceberg.rest.requests.RegisterTableRequest;
+import org.apache.iceberg.rest.requests.RegisterViewRequest;
 import org.apache.iceberg.rest.requests.RenameTableRequest;
 import org.apache.iceberg.rest.requests.UpdateNamespacePropertiesRequest;
 import org.apache.iceberg.rest.requests.UpdateTableRequest;
@@ -204,6 +205,10 @@ public class IcebergCatalogWrapper implements AutoCloseable {
 
   public LoadTableResponse registerTable(Namespace namespace, RegisterTableRequest request) {
     return CatalogHandlers.registerTable(getCatalog(), namespace, request);
+  }
+
+  public LoadViewResponse registerView(Namespace namespace, RegisterViewRequest request) {
+    return CatalogHandlers.registerView(getViewCatalog(), namespace, request);
   }
 
   /**

--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/dispatcher/IcebergViewEventDispatcher.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/dispatcher/IcebergViewEventDispatcher.java
@@ -37,6 +37,9 @@ import org.apache.gravitino.listener.api.event.IcebergListViewPreEvent;
 import org.apache.gravitino.listener.api.event.IcebergLoadViewEvent;
 import org.apache.gravitino.listener.api.event.IcebergLoadViewFailureEvent;
 import org.apache.gravitino.listener.api.event.IcebergLoadViewPreEvent;
+import org.apache.gravitino.listener.api.event.IcebergRegisterViewEvent;
+import org.apache.gravitino.listener.api.event.IcebergRegisterViewFailureEvent;
+import org.apache.gravitino.listener.api.event.IcebergRegisterViewPreEvent;
 import org.apache.gravitino.listener.api.event.IcebergRenameViewEvent;
 import org.apache.gravitino.listener.api.event.IcebergRenameViewFailureEvent;
 import org.apache.gravitino.listener.api.event.IcebergRenameViewPreEvent;
@@ -50,6 +53,7 @@ import org.apache.gravitino.listener.api.event.IcebergViewExistsPreEvent;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.rest.requests.CreateViewRequest;
+import org.apache.iceberg.rest.requests.RegisterViewRequest;
 import org.apache.iceberg.rest.requests.RenameTableRequest;
 import org.apache.iceberg.rest.requests.UpdateTableRequest;
 import org.apache.iceberg.rest.responses.ListTablesResponse;
@@ -101,6 +105,33 @@ public class IcebergViewEventDispatcher implements IcebergViewOperationDispatche
     eventBus.dispatchEvent(
         new IcebergCreateViewEvent(
             context, nameIdentifier, transformedCreateEvent.createViewRequest(), loadViewResponse));
+    return loadViewResponse;
+  }
+
+  @Override
+  public LoadViewResponse registerView(
+      IcebergRequestContext context, Namespace namespace, RegisterViewRequest registerViewRequest) {
+    TableIdentifier viewIdentifier = TableIdentifier.of(namespace, registerViewRequest.name());
+    NameIdentifier nameIdentifier =
+        IcebergRESTUtils.getGravitinoNameIdentifier(
+            metalakeName, context.catalogName(), viewIdentifier);
+
+    eventBus.dispatchEvent(
+        new IcebergRegisterViewPreEvent(context, nameIdentifier, registerViewRequest));
+
+    LoadViewResponse loadViewResponse;
+    try {
+      loadViewResponse =
+          icebergViewOperationDispatcher.registerView(context, namespace, registerViewRequest);
+    } catch (Exception e) {
+      eventBus.dispatchEvent(
+          new IcebergRegisterViewFailureEvent(context, nameIdentifier, registerViewRequest, e));
+      throw e;
+    }
+
+    eventBus.dispatchEvent(
+        new IcebergRegisterViewEvent(
+            context, nameIdentifier, registerViewRequest, loadViewResponse));
     return loadViewResponse;
   }
 

--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/dispatcher/IcebergViewHookDispatcher.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/dispatcher/IcebergViewHookDispatcher.java
@@ -32,6 +32,7 @@ import org.apache.gravitino.utils.HierarchicalSchemaUtil;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.rest.requests.CreateViewRequest;
+import org.apache.iceberg.rest.requests.RegisterViewRequest;
 import org.apache.iceberg.rest.requests.RenameTableRequest;
 import org.apache.iceberg.rest.requests.UpdateTableRequest;
 import org.apache.iceberg.rest.responses.ListTablesResponse;
@@ -80,6 +81,27 @@ public class IcebergViewHookDispatcher implements IcebergViewOperationDispatcher
         context.catalogName(),
         namespace,
         createViewRequest.name(),
+        context.userName(),
+        GravitinoEnv.getInstance().internalOwnerDispatcher());
+
+    return response;
+  }
+
+  @Override
+  public LoadViewResponse registerView(
+      IcebergRequestContext context, Namespace namespace, RegisterViewRequest registerViewRequest) {
+    LoadViewResponse response = dispatcher.registerView(context, namespace, registerViewRequest);
+
+    // Import is intentionally NOT wrapped in try-catch: if it fails the view exists in Iceberg
+    // but not in Gravitino, and silently swallowing that would mislead callers into thinking the
+    // entity is registered. Surface the failure so the caller can react.
+    strictImportView(context.catalogName(), namespace, registerViewRequest.name());
+
+    IcebergOwnershipUtils.setViewOwner(
+        metalake,
+        context.catalogName(),
+        namespace,
+        registerViewRequest.name(),
         context.userName(),
         GravitinoEnv.getInstance().internalOwnerDispatcher());
 
@@ -213,6 +235,18 @@ public class IcebergViewHookDispatcher implements IcebergViewOperationDispatcher
             viewName,
             e.getMessage());
       }
+    }
+  }
+
+  private void strictImportView(String catalogName, Namespace namespace, String viewName) {
+    ViewDispatcher viewDispatcher = GravitinoEnv.getInstance().internalViewDispatcher();
+    if (viewDispatcher != null) {
+      viewDispatcher.loadView(
+          IcebergIdentifierUtils.toGravitinoTableIdentifier(
+              metalake,
+              catalogName,
+              TableIdentifier.of(namespace, viewName),
+              HierarchicalSchemaUtil.schemaSeparator()));
     }
   }
 

--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/dispatcher/IcebergViewOperationDispatcher.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/dispatcher/IcebergViewOperationDispatcher.java
@@ -23,6 +23,7 @@ import org.apache.gravitino.listener.api.event.IcebergRequestContext;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.rest.requests.CreateViewRequest;
+import org.apache.iceberg.rest.requests.RegisterViewRequest;
 import org.apache.iceberg.rest.requests.RenameTableRequest;
 import org.apache.iceberg.rest.requests.UpdateTableRequest;
 import org.apache.iceberg.rest.responses.ListTablesResponse;
@@ -44,6 +45,17 @@ public interface IcebergViewOperationDispatcher {
    */
   LoadViewResponse createView(
       IcebergRequestContext context, Namespace namespace, CreateViewRequest createViewRequest);
+
+  /**
+   * Registers an existing Iceberg view.
+   *
+   * @param context Iceberg REST request context information.
+   * @param namespace The namespace within which the view should be registered.
+   * @param registerViewRequest The request object containing the details for registering the view.
+   * @return A {@link LoadViewResponse} object containing the result of the operation.
+   */
+  LoadViewResponse registerView(
+      IcebergRequestContext context, Namespace namespace, RegisterViewRequest registerViewRequest);
 
   /**
    * Updates an Iceberg view.

--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/dispatcher/IcebergViewOperationExecutor.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/dispatcher/IcebergViewOperationExecutor.java
@@ -24,6 +24,7 @@ import org.apache.gravitino.listener.api.event.IcebergRequestContext;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.rest.requests.CreateViewRequest;
+import org.apache.iceberg.rest.requests.RegisterViewRequest;
 import org.apache.iceberg.rest.requests.RenameTableRequest;
 import org.apache.iceberg.rest.requests.UpdateTableRequest;
 import org.apache.iceberg.rest.responses.ListTablesResponse;
@@ -43,6 +44,14 @@ public class IcebergViewOperationExecutor implements IcebergViewOperationDispatc
     return icebergCatalogWrapperManager
         .getCatalogWrapper(context.catalogName())
         .createView(namespace, createViewRequest);
+  }
+
+  @Override
+  public LoadViewResponse registerView(
+      IcebergRequestContext context, Namespace namespace, RegisterViewRequest registerViewRequest) {
+    return icebergCatalogWrapperManager
+        .getCatalogWrapper(context.catalogName())
+        .registerView(namespace, registerViewRequest);
   }
 
   @Override

--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/rest/IcebergConfigOperations.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/rest/IcebergConfigOperations.java
@@ -87,6 +87,7 @@ public class IcebergConfigOperations {
           .add(Endpoint.V1_DELETE_VIEW)
           .add(Endpoint.V1_RENAME_VIEW)
           .add(Endpoint.V1_VIEW_EXISTS)
+          .add(Endpoint.V1_REGISTER_VIEW)
           .build();
 
   @Inject

--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/rest/IcebergNamespaceOperations.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/rest/IcebergNamespaceOperations.java
@@ -52,6 +52,7 @@ import org.apache.gravitino.iceberg.service.IcebergObjectMapper;
 import org.apache.gravitino.iceberg.service.IcebergRESTUtils;
 import org.apache.gravitino.iceberg.service.authorization.IcebergRESTServerContext;
 import org.apache.gravitino.iceberg.service.dispatcher.IcebergNamespaceOperationDispatcher;
+import org.apache.gravitino.iceberg.service.dispatcher.IcebergViewOperationDispatcher;
 import org.apache.gravitino.listener.api.event.IcebergRequestContext;
 import org.apache.gravitino.metrics.MetricNames;
 import org.apache.gravitino.server.authorization.MetadataAuthzHelper;
@@ -65,11 +66,13 @@ import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.rest.RESTUtil;
 import org.apache.iceberg.rest.requests.CreateNamespaceRequest;
 import org.apache.iceberg.rest.requests.RegisterTableRequest;
+import org.apache.iceberg.rest.requests.RegisterViewRequest;
 import org.apache.iceberg.rest.requests.UpdateNamespacePropertiesRequest;
 import org.apache.iceberg.rest.responses.CreateNamespaceResponse;
 import org.apache.iceberg.rest.responses.GetNamespaceResponse;
 import org.apache.iceberg.rest.responses.ListNamespacesResponse;
 import org.apache.iceberg.rest.responses.LoadTableResponse;
+import org.apache.iceberg.rest.responses.LoadViewResponse;
 import org.apache.iceberg.rest.responses.UpdateNamespacePropertiesResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -83,13 +86,16 @@ public class IcebergNamespaceOperations {
 
   private ObjectMapper icebergObjectMapper;
   private IcebergNamespaceOperationDispatcher namespaceOperationDispatcher;
+  private IcebergViewOperationDispatcher viewOperationDispatcher;
 
   @Context private HttpServletRequest httpRequest;
 
   @Inject
   public IcebergNamespaceOperations(
-      IcebergNamespaceOperationDispatcher namespaceOperationDispatcher) {
+      IcebergNamespaceOperationDispatcher namespaceOperationDispatcher,
+      IcebergViewOperationDispatcher viewOperationDispatcher) {
     this.namespaceOperationDispatcher = namespaceOperationDispatcher;
+    this.viewOperationDispatcher = viewOperationDispatcher;
     this.icebergObjectMapper = IcebergObjectMapper.getInstance();
   }
 
@@ -343,6 +349,42 @@ public class IcebergNamespaceOperations {
                 namespaceOperationDispatcher.registerTable(
                     context, icebergNS, registerTableRequest);
             return IcebergRESTUtils.buildResponseWithETag(loadTableResponse);
+          });
+    } catch (Exception e) {
+      return IcebergExceptionMapper.toRESTResponse(e);
+    }
+  }
+
+  @POST
+  @Path("{namespace}/register-view")
+  @Produces(MediaType.APPLICATION_JSON)
+  @Timed(name = "register-view." + MetricNames.HTTP_PROCESS_DURATION, absolute = true)
+  @ResponseMetered(name = "register-view", absolute = true)
+  @AuthorizationExpression(
+      expression = AuthorizationExpressionConstants.ICEBERG_CREATE_VIEW_AUTHORIZATION_EXPRESSION,
+      accessMetadataType = MetadataObject.Type.SCHEMA)
+  public Response registerView(
+      @AuthorizationMetadata(type = Entity.EntityType.CATALOG) @PathParam("prefix") String prefix,
+      @AuthorizationMetadata(type = Entity.EntityType.SCHEMA) @Encoded() @PathParam("namespace")
+          String namespace,
+      RegisterViewRequest registerViewRequest) {
+    String catalogName = IcebergRESTUtils.getCatalogName(prefix);
+    Namespace icebergNS =
+        RESTUtil.decodeNamespace(namespace, IcebergRESTUtils.NAMESPACE_SEPARATOR_URLENCODED_UTF_8);
+    LOG.info(
+        "Register Iceberg view, catalog: {}, namespace: {}, registerViewRequest: {}",
+        catalogName,
+        icebergNS,
+        registerViewRequest);
+    try {
+      return Utils.doAs(
+          httpRequest,
+          () -> {
+            IcebergRequestContext context =
+                new IcebergRequestContext(httpServletRequest(), catalogName);
+            LoadViewResponse loadViewResponse =
+                viewOperationDispatcher.registerView(context, icebergNS, registerViewRequest);
+            return IcebergRESTUtils.ok(loadViewResponse);
           });
     } catch (Exception e) {
       return IcebergExceptionMapper.toRESTResponse(e);

--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/listener/api/event/IcebergRegisterViewEvent.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/listener/api/event/IcebergRegisterViewEvent.java
@@ -1,0 +1,59 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.apache.gravitino.listener.api.event;
+
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.annotation.DeveloperApi;
+import org.apache.gravitino.iceberg.service.IcebergRESTUtils;
+import org.apache.iceberg.rest.requests.RegisterViewRequest;
+import org.apache.iceberg.rest.responses.LoadViewResponse;
+
+/** Represent an event after registering Iceberg view successfully. */
+@DeveloperApi
+public class IcebergRegisterViewEvent extends IcebergViewEvent {
+
+  private final RegisterViewRequest registerViewRequest;
+  private final LoadViewResponse loadViewResponse;
+
+  public IcebergRegisterViewEvent(
+      IcebergRequestContext icebergRequestContext,
+      NameIdentifier viewIdentifier,
+      RegisterViewRequest registerViewRequest,
+      LoadViewResponse loadViewResponse) {
+    super(icebergRequestContext, viewIdentifier);
+    this.registerViewRequest =
+        IcebergRESTUtils.cloneIcebergRESTObject(registerViewRequest, RegisterViewRequest.class);
+    this.loadViewResponse =
+        IcebergRESTUtils.cloneIcebergRESTObject(loadViewResponse, LoadViewResponse.class);
+  }
+
+  public RegisterViewRequest registerViewRequest() {
+    return registerViewRequest;
+  }
+
+  public LoadViewResponse loadViewResponse() {
+    return loadViewResponse;
+  }
+
+  @Override
+  public OperationType operationType() {
+    return OperationType.REGISTER_VIEW;
+  }
+}

--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/listener/api/event/IcebergRegisterViewFailureEvent.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/listener/api/event/IcebergRegisterViewFailureEvent.java
@@ -1,0 +1,50 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.apache.gravitino.listener.api.event;
+
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.annotation.DeveloperApi;
+import org.apache.gravitino.iceberg.service.IcebergRESTUtils;
+import org.apache.iceberg.rest.requests.RegisterViewRequest;
+
+/** Represent a failure event when registering Iceberg view failed. */
+@DeveloperApi
+public class IcebergRegisterViewFailureEvent extends IcebergViewFailureEvent {
+  private final RegisterViewRequest registerViewRequest;
+
+  public IcebergRegisterViewFailureEvent(
+      IcebergRequestContext icebergRequestContext,
+      NameIdentifier viewIdentifier,
+      RegisterViewRequest registerViewRequest,
+      Exception e) {
+    super(icebergRequestContext, viewIdentifier, e);
+    this.registerViewRequest =
+        IcebergRESTUtils.cloneIcebergRESTObject(registerViewRequest, RegisterViewRequest.class);
+  }
+
+  public RegisterViewRequest registerViewRequest() {
+    return registerViewRequest;
+  }
+
+  @Override
+  public OperationType operationType() {
+    return OperationType.REGISTER_VIEW;
+  }
+}

--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/listener/api/event/IcebergRegisterViewPreEvent.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/listener/api/event/IcebergRegisterViewPreEvent.java
@@ -1,0 +1,47 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.apache.gravitino.listener.api.event;
+
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.annotation.DeveloperApi;
+import org.apache.iceberg.rest.requests.RegisterViewRequest;
+
+/** Represent a pre event before registering Iceberg view. */
+@DeveloperApi
+public class IcebergRegisterViewPreEvent extends IcebergViewPreEvent {
+  private final RegisterViewRequest registerViewRequest;
+
+  public IcebergRegisterViewPreEvent(
+      IcebergRequestContext icebergRequestContext,
+      NameIdentifier viewIdentifier,
+      RegisterViewRequest registerViewRequest) {
+    super(icebergRequestContext, viewIdentifier);
+    this.registerViewRequest = registerViewRequest;
+  }
+
+  public RegisterViewRequest registerViewRequest() {
+    return registerViewRequest;
+  }
+
+  @Override
+  public OperationType operationType() {
+    return OperationType.REGISTER_VIEW;
+  }
+}

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/dispatcher/TestIcebergViewHookDispatcher.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/dispatcher/TestIcebergViewHookDispatcher.java
@@ -48,6 +48,7 @@ import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.rest.requests.CreateViewRequest;
 import org.apache.iceberg.rest.requests.ImmutableCreateViewRequest;
+import org.apache.iceberg.rest.requests.RegisterViewRequest;
 import org.apache.iceberg.rest.requests.RenameTableRequest;
 import org.apache.iceberg.rest.requests.UpdateTableRequest;
 import org.apache.iceberg.rest.responses.ListTablesResponse;
@@ -263,6 +264,52 @@ public class TestIcebergViewHookDispatcher {
     verify(mockExecutor, times(1)).createView(mockContext, namespace, createRequest);
     verify(mockInternalViewDispatcher, times(1)).loadView(any(NameIdentifier.class));
     verify(mockViewDispatcher, never()).loadView(any());
+    verify(mockOwnerDispatcher, never()).setOwner(any(), any(), any(), any());
+  }
+
+  @Test
+  public void testRegisterViewThrowsWhenSetOwnerFails() {
+    Namespace namespace = Namespace.of(SCHEMA_NAME);
+    RegisterViewRequest mockRequest = mock(RegisterViewRequest.class);
+    when(mockRequest.name()).thenReturn(VIEW_NAME);
+
+    LoadViewResponse mockResponse = mock(LoadViewResponse.class);
+    when(mockExecutor.registerView(mockContext, namespace, mockRequest)).thenReturn(mockResponse);
+
+    doThrow(new RuntimeException("Set owner failed"))
+        .when(mockInternalOwnerDispatcher)
+        .setOwner(any(), any(), any(), any());
+
+    RuntimeException thrown =
+        assertThrows(
+            RuntimeException.class,
+            () -> hookDispatcher.registerView(mockContext, namespace, mockRequest));
+    assertEquals("Set owner failed", thrown.getMessage());
+    verify(mockExecutor, times(1)).registerView(mockContext, namespace, mockRequest);
+    verify(mockInternalViewDispatcher, times(1)).loadView(any(NameIdentifier.class));
+    verify(mockViewDispatcher, never()).loadView(any());
+    verify(mockOwnerDispatcher, never()).setOwner(any(), any(), any(), any());
+  }
+
+  @Test
+  public void testRegisterViewPropagatesImportFailure() {
+    Namespace namespace = Namespace.of(SCHEMA_NAME);
+    RegisterViewRequest mockRequest = mock(RegisterViewRequest.class);
+    when(mockRequest.name()).thenReturn(VIEW_NAME);
+
+    LoadViewResponse mockResponse = mock(LoadViewResponse.class);
+    when(mockExecutor.registerView(mockContext, namespace, mockRequest)).thenReturn(mockResponse);
+
+    doThrow(new RuntimeException("Import failed"))
+        .when(mockInternalViewDispatcher)
+        .loadView(any(NameIdentifier.class));
+
+    RuntimeException thrown =
+        assertThrows(
+            RuntimeException.class,
+            () -> hookDispatcher.registerView(mockContext, namespace, mockRequest));
+    assertEquals("Import failed", thrown.getMessage());
+    verify(mockInternalOwnerDispatcher, never()).setOwner(any(), any(), any(), any());
     verify(mockOwnerDispatcher, never()).setOwner(any(), any(), any(), any());
   }
 

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/dispatcher/TestIcebergViewOperationExecutor.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/dispatcher/TestIcebergViewOperationExecutor.java
@@ -29,6 +29,7 @@ import org.apache.gravitino.listener.api.event.IcebergRequestContext;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.rest.requests.CreateViewRequest;
+import org.apache.iceberg.rest.requests.RegisterViewRequest;
 import org.apache.iceberg.rest.requests.RenameTableRequest;
 import org.apache.iceberg.rest.requests.UpdateTableRequest;
 import org.apache.iceberg.rest.responses.ListTablesResponse;
@@ -66,6 +67,19 @@ public class TestIcebergViewOperationExecutor {
 
     Assertions.assertEquals(mockResponse, result);
     verify(mockCatalogWrapper).createView(namespace, mockRequest);
+  }
+
+  @Test
+  public void testRegisterView() {
+    Namespace namespace = Namespace.of("test_ns");
+    RegisterViewRequest mockRequest = mock(RegisterViewRequest.class);
+    LoadViewResponse mockResponse = mock(LoadViewResponse.class);
+    when(mockCatalogWrapper.registerView(namespace, mockRequest)).thenReturn(mockResponse);
+
+    LoadViewResponse result = executor.registerView(mockContext, namespace, mockRequest);
+
+    Assertions.assertEquals(mockResponse, result);
+    verify(mockCatalogWrapper).registerView(namespace, mockRequest);
   }
 
   @Test

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/CatalogWrapperForTest.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/CatalogWrapperForTest.java
@@ -38,9 +38,15 @@ import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.rest.requests.CreateTableRequest;
 import org.apache.iceberg.rest.requests.RegisterTableRequest;
+import org.apache.iceberg.rest.requests.RegisterViewRequest;
+import org.apache.iceberg.rest.responses.ImmutableLoadViewResponse;
 import org.apache.iceberg.rest.responses.LoadTableResponse;
+import org.apache.iceberg.rest.responses.LoadViewResponse;
 import org.apache.iceberg.types.Types.NestedField;
 import org.apache.iceberg.types.Types.StringType;
+import org.apache.iceberg.view.ImmutableSQLViewRepresentation;
+import org.apache.iceberg.view.ImmutableViewVersion;
+import org.apache.iceberg.view.ViewMetadata;
 
 // Test wrapper that mocks operations the in-memory catalog cannot perform natively
 // (e.g. registerTable, which requires a real metadata.json file at the given location),
@@ -103,6 +109,36 @@ public class CatalogWrapperForTest extends CatalogWrapperForREST {
           CredentialPrivilege.WRITE);
     }
     return loadTableResponse;
+  }
+
+  @Override
+  public LoadViewResponse registerView(Namespace namespace, RegisterViewRequest request) {
+    if (request.name().contains("fail")) {
+      throw new AlreadyExistsException("Already exits exception for test");
+    }
+
+    String location =
+        request.metadataLocation().contains("://") ? request.metadataLocation() : "/mock";
+    Schema mockSchema = new Schema(NestedField.of(1, false, "foo_string", StringType.get()));
+    ImmutableViewVersion viewVersion =
+        ImmutableViewVersion.builder()
+            .versionId(1)
+            .timestampMillis(System.currentTimeMillis())
+            .schemaId(mockSchema.schemaId())
+            .defaultNamespace(namespace)
+            .addRepresentations(
+                ImmutableSQLViewRepresentation.builder().sql("select 1").dialect("spark").build())
+            .build();
+    ViewMetadata viewMetadata =
+        ViewMetadata.builder()
+            .setLocation(location)
+            .setProperties(ImmutableMap.of())
+            .setCurrentVersion(viewVersion, mockSchema)
+            .build();
+    return ImmutableLoadViewResponse.builder()
+        .metadataLocation(location + "/metadata/version-hint.text")
+        .metadata(viewMetadata)
+        .build();
   }
 
   private boolean shouldGeneratePlanTasksData(CreateTableRequest request) {

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/IcebergNamespaceTestBase.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/IcebergNamespaceTestBase.java
@@ -33,7 +33,9 @@ import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.rest.RESTUtil;
 import org.apache.iceberg.rest.requests.CreateNamespaceRequest;
 import org.apache.iceberg.rest.requests.ImmutableRegisterTableRequest;
+import org.apache.iceberg.rest.requests.ImmutableRegisterViewRequest;
 import org.apache.iceberg.rest.requests.RegisterTableRequest;
+import org.apache.iceberg.rest.requests.RegisterViewRequest;
 import org.apache.iceberg.rest.requests.UpdateNamespacePropertiesRequest;
 import org.apache.iceberg.rest.responses.CreateNamespaceResponse;
 import org.apache.iceberg.rest.responses.GetNamespaceResponse;
@@ -58,6 +60,24 @@ public class IcebergNamespaceTestBase extends IcebergTestBase {
         ImmutableRegisterTableRequest.builder().name(tableName).metadataLocation("mock").build();
     return getNamespaceClientBuilder(Optional.of(ns), Optional.of("register"), Optional.empty())
         .post(Entity.entity(request, MediaType.APPLICATION_JSON_TYPE));
+  }
+
+  protected Response doRegisterView(String viewName, Namespace ns) {
+    RegisterViewRequest request =
+        ImmutableRegisterViewRequest.builder().name(viewName).metadataLocation("mock").build();
+    return getNamespaceClientBuilder(
+            Optional.of(ns), Optional.of("register-view"), Optional.empty())
+        .post(Entity.entity(request, MediaType.APPLICATION_JSON_TYPE));
+  }
+
+  protected void verifyRegisterViewSucc(String viewName, Namespace ns) {
+    Response response = doRegisterView(viewName, ns);
+    Assertions.assertEquals(Status.OK.getStatusCode(), response.getStatus());
+  }
+
+  protected void verifyRegisterViewFail(int status, String viewName, Namespace ns) {
+    Response response = doRegisterView(viewName, ns);
+    Assertions.assertEquals(status, response.getStatus());
   }
 
   protected Response doRegisterTableWithCredentialVending(

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/MockIcebergNamespaceOperations.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/MockIcebergNamespaceOperations.java
@@ -22,13 +22,15 @@ package org.apache.gravitino.iceberg.service.rest;
 import javax.inject.Inject;
 import javax.servlet.http.HttpServletRequest;
 import org.apache.gravitino.iceberg.service.dispatcher.IcebergNamespaceOperationDispatcher;
+import org.apache.gravitino.iceberg.service.dispatcher.IcebergViewOperationDispatcher;
 
 public class MockIcebergNamespaceOperations extends IcebergNamespaceOperations {
 
   @Inject
   public MockIcebergNamespaceOperations(
-      IcebergNamespaceOperationDispatcher namespaceOperationDispatcher) {
-    super(namespaceOperationDispatcher);
+      IcebergNamespaceOperationDispatcher namespaceOperationDispatcher,
+      IcebergViewOperationDispatcher viewOperationDispatcher) {
+    super(namespaceOperationDispatcher, viewOperationDispatcher);
   }
 
   // HTTP request is null in Jersey test, create a mock request

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/TestIcebergViewOperations.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/rest/TestIcebergViewOperations.java
@@ -44,6 +44,9 @@ import org.apache.gravitino.listener.api.event.IcebergListViewPreEvent;
 import org.apache.gravitino.listener.api.event.IcebergLoadViewEvent;
 import org.apache.gravitino.listener.api.event.IcebergLoadViewFailureEvent;
 import org.apache.gravitino.listener.api.event.IcebergLoadViewPreEvent;
+import org.apache.gravitino.listener.api.event.IcebergRegisterViewEvent;
+import org.apache.gravitino.listener.api.event.IcebergRegisterViewFailureEvent;
+import org.apache.gravitino.listener.api.event.IcebergRegisterViewPreEvent;
 import org.apache.gravitino.listener.api.event.IcebergRenameViewEvent;
 import org.apache.gravitino.listener.api.event.IcebergRenameViewFailureEvent;
 import org.apache.gravitino.listener.api.event.IcebergRenameViewPreEvent;
@@ -194,6 +197,21 @@ public class TestIcebergViewOperations extends IcebergNamespaceTestBase {
 
     verifyCreateViewFail(namespace, "create_foo1", 409);
     verifyCreateViewFail(namespace, "", 400);
+  }
+
+  @Test
+  void testRegisterView() {
+    Namespace namespace = Namespace.of("register_view_ns");
+    verifyRegisterViewSucc("register_view_foo1", namespace);
+    Assertions.assertTrue(dummyEventListener.popPreEvent() instanceof IcebergRegisterViewPreEvent);
+    Assertions.assertTrue(dummyEventListener.popPostEvent() instanceof IcebergRegisterViewEvent);
+
+    verifyRegisterViewFail(409, "fail_register_view_foo1", namespace);
+    Assertions.assertTrue(dummyEventListener.popPreEvent() instanceof IcebergRegisterViewPreEvent);
+    Assertions.assertTrue(
+        dummyEventListener.popPostEvent() instanceof IcebergRegisterViewFailureEvent);
+
+    verifyRegisterViewSucc("register_view_foo2", Namespace.of("register_view_ns_2", "a"));
   }
 
   @ParameterizedTest


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add Iceberg REST Catalog `register-view` support to Gravitino IRC, aligned with the existing `register-table` flow:

- Expose `POST .../namespaces/{namespace}/register-view` in `IcebergNamespaceOperations`.
- Wire `registerView` through the view dispatcher chain (`IcebergViewHookDispatcher` → `IcebergViewEventDispatcher` → `IcebergViewOperationExecutor` → `IcebergCatalogWrapper` → Iceberg `CatalogHandlers.registerView`).
- When authorization is enabled, strictly import the view into Gravitino metadata and set the authenticated IRC caller as owner (same semantics as `register-table`).
- Add audit/event support (`IcebergRegisterViewPreEvent`, success/failure events, `OperationType`).
- Advertise `Endpoint.V1_REGISTER_VIEW` in IRC config.
- Add unit tests for REST, dispatcher, executor, and hook layers.

Fix: #11728

### Why are the changes needed?

Iceberg REST API defines `register-view` for registering existing view metadata, but Gravitino IRC only supported `register-table`. This gap blocks view import/migration workflows and leaves IRC view endpoint coverage incomplete.

### Does this PR introduce _any_ user-facing change?

Yes.

1. New IRC endpoint: `POST /v1/{prefix}namespaces/{namespace}/register-view`.
2. IRC `/v1/config` now includes `V1_REGISTER_VIEW` in the advertised endpoints list.

### How was this patch tested?

- `./gradlew :iceberg:iceberg-rest-server:test --tests org.apache.gravitino.iceberg.service.rest.TestIcebergViewOperations -PskipITs`
- `./gradlew :iceberg:iceberg-rest-server:test --tests org.apache.gravitino.iceberg.service.dispatcher.TestIcebergViewHookDispatcher -PskipITs`
- `./gradlew :iceberg:iceberg-rest-server:test --tests org.apache.gravitino.iceberg.service.dispatcher.TestIcebergViewOperationExecutor -PskipITs`