### PR TITLE
[#11716] docs: Document Web UI OIDC setup with Keycloak (secure context, public client, issuer alignment)

### DIFF
--- a/docs/security/how-to-authenticate.md
+++ b/docs/security/how-to-authenticate.md
@@ -107,6 +107,15 @@ To enable OAuth mode:
 - For **static key validation**: Configure `gravitino.authenticator.oauth.defaultSignKey`, `gravitino.authenticator.oauth.serverUri` and `gravitino.authenticator.oauth.tokenPath`.
 - For **JWKS validation**: Configure `gravitino.authenticator.oauth.jwksUri` and `gravitino.authenticator.oauth.tokenValidatorClass=org.apache.gravitino.server.authentication.JwksTokenValidator`. You can use either `gravitino.authenticator.oauth.provider=default` or `gravitino.authenticator.oauth.provider=oidc` depending on whether you want Web UI OIDC login flow.
 - For **Web UI OIDC authentication**: Set `gravitino.authenticator.oauth.provider=oidc` and configure `gravitino.authenticator.oauth.clientId`, `gravitino.authenticator.oauth.authority`, and `gravitino.authenticator.oauth.scope`. These settings are exposed to the Web UI via the `/configs` endpoint to enable OAuth login flow. Configure your OAuth provider with the callback redirect URI: `https://your-gravitino-server/ui/oauth/callback`.
+
+  :::note
+  The Web UI OIDC login uses the Authorization Code flow with PKCE, which depends on the browser
+  [Web Crypto API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Crypto_API). Browsers only
+  expose this API in a [secure context](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts),
+  that is, when the Web UI is served over HTTPS or from `localhost`. If you open the Web UI over plain
+  HTTP on a non-`localhost` host, login fails because the crypto primitives required for PKCE are
+  unavailable. Serve the Web UI over HTTPS (or access it via `localhost`) for OIDC login to work.
+  :::
 - Next, for the client side, users can enable `OAuth` mode by the following code:
 
 ```java
@@ -653,3 +662,74 @@ For Gravitino Iceberg REST Service, the 'Accept: application/vnd.gravitino.v1+js
 ```shell
 curl -v -X GET -H "Content-Type: application/json" -H "Authorization: Bearer <access_token>" http://127.0.0.1:9001/iceberg/v1/config
 ```
+
+### Enable Web UI OIDC login with Keycloak
+
+The `gravitino-client` registered above is a confidential client used for machine-to-machine flows
+(client credentials and password grants). The browser Web UI cannot use a confidential client because
+it cannot keep a client secret, so the Web UI OIDC login requires a separate public client. A typical
+Keycloak deployment therefore uses two clients:
+
+| Client             | Type         | Used by                                                       | Keycloak settings                                                                   |
+|--------------------|--------------|---------------------------------------------------------------|-------------------------------------------------------------------------------------|
+| `gravitino-client` | Confidential | Engines and machine flows (CLI, connectors, service accounts) | *Client authentication* on, *Standard flow* and *Service accounts roles* enabled    |
+| `gravitino-ui`     | Public       | Browser Web UI OIDC login                                     | *Client authentication* off, *Standard flow* enabled                                |
+
+To register the public client for the Web UI:
+
+* Click *Clients* in the `gravitinorealm` realm, then *Create client*.
+* Fill in *Client type*: `OpenID Connect`, *Client ID*: `gravitino-ui`, then click *Next*.
+* Turn *Client authentication* **off** (this makes it a public client) and enable *Standard flow*. Click *Next*.
+* Set *Valid redirect URIs* to `https://your-gravitino-server/ui/oauth/callback`.
+* Set *Valid post logout redirect URIs* to `https://your-gravitino-server/*` so logout can redirect back to the Web UI.
+* Set *Web origins* to `https://your-gravitino-server`.
+* Click *Save*.
+
+Then point the Web UI OIDC settings at this public client in `conf/gravitino.conf`:
+
+```text
+gravitino.authenticators = oauth
+gravitino.authenticator.oauth.provider = oidc
+gravitino.authenticator.oauth.clientId = gravitino-ui
+gravitino.authenticator.oauth.authority = http://localhost:8080/realms/gravitinorealm
+gravitino.authenticator.oauth.scope = openid profile email
+gravitino.authenticator.oauth.jwksUri = http://localhost:8080/realms/gravitinorealm/protocol/openid-connect/certs
+gravitino.authenticator.oauth.tokenValidatorClass = org.apache.gravitino.server.authentication.JwksTokenValidator
+gravitino.authenticator.oauth.serviceAudience = account
+gravitino.authenticator.oauth.principalFields = preferred_username,email,sub
+```
+
+This example uses JWKS-based validation, where the server fetches Keycloak's public keys from
+`jwksUri` automatically. It therefore does not need the static-key settings
+(`gravitino.authenticator.oauth.defaultSignKey`, `gravitino.authenticator.oauth.serverUri`, and
+`gravitino.authenticator.oauth.tokenPath`) shown in the machine-flow example above. JWKS validation
+is recommended for Keycloak; only set the static-key settings if you intentionally use
+`tokenValidatorClass=org.apache.gravitino.server.authentication.StaticSignKeyValidator` instead. The
+same server configuration validates tokens from both the Web UI and the machine clients, so you do
+not need a separate validator per client.
+
+:::note
+The Web UI OIDC login requires a [secure context](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts):
+serve the Web UI over HTTPS or access it via `localhost`. See the secure-context note in the
+[OAuth Mode](#oauth-mode) section for details.
+:::
+
+#### Align the token issuer for split-hostname deployments
+
+The `iss` (issuer) claim in a Keycloak token is built from the hostname the token was obtained
+through. When the browser and the Gravitino server reach Keycloak through different hostnames (for
+example, the browser uses a public URL while the server uses an internal Docker or cluster hostname),
+the `iss` claim in the browser-issued token will not match the `authority` the server expects, and
+validation fails with an error such as `JWT iss claim value rejected`.
+
+To keep the issuer consistent regardless of which hostname is used to reach Keycloak, set a unified
+**Frontend URL** on the realm:
+
+* Open the `gravitinorealm` realm, go to *Realm settings* > *General*.
+* Set *Frontend URL* to the canonical, externally reachable Keycloak base URL (for example,
+  `https://keycloak.example.com`).
+* Save, then use that same base URL in `gravitino.authenticator.oauth.authority` (and the matching
+  `jwksUri`).
+
+With the Frontend URL set, Keycloak stamps the same `iss` claim on every token regardless of the
+hostname the request arrived on, so browser-issued and server-validated tokens agree.


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fill three documentation gaps in `docs/security/how-to-authenticate.md` for the v2 Web UI OIDC login with Keycloak:

1. **Secure context requirement** — A note in the *OAuth Mode* section explaining that Web UI OIDC login uses the Authorization Code flow with PKCE, which depends on the browser Web Crypto API and therefore requires a secure context (HTTPS or `localhost`). Plain HTTP on a non-`localhost` host fails.
2. **Separate client configurations** — A new *Enable Web UI OIDC login with Keycloak* subsection that distinguishes the confidential client (machine/engine flows) from a public client (`Client authentication` off, `Standard flow` on) required by the browser UI, with the matching `oidc`-provider configuration.
3. **Token issuer alignment** — Guidance to set the Keycloak realm Frontend URL so the `iss` claim matches across split-hostname deployments, avoiding `JWT iss claim value rejected`.

### Why are the changes needed?

Users setting up the v2 Web UI with Keycloak OIDC hit undocumented failures: login breaks over plain HTTP, a single confidential client does not work for the browser, and split-hostname setups get token rejections. These were reported in #11716.

Fix: #11716

### Does this PR introduce _any_ user-facing change?

No code change. Documentation only.

### How was this patch tested?

Documentation-only change. Verified with the repo docs audit scripts (title/intro/heading/spacing and internal link/anchor checks) — all pass.