### PR TITLE
[#11740] fix(trino-connector): Load Iceberg JDBC catalogs with hidden credentials

### DIFF
--- a/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/catalog/iceberg/IcebergCatalogPropertyConverter.java
+++ b/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/catalog/iceberg/IcebergCatalogPropertyConverter.java
@@ -40,8 +40,7 @@ import org.apache.gravitino.trino.connector.catalog.CatalogPropertyConverter;
  */
 public class IcebergCatalogPropertyConverter extends CatalogPropertyConverter {
 
-  private static final Set<String> JDBC_BACKEND_REQUIRED_PROPERTIES =
-      Set.of("jdbc-driver", "uri", "jdbc-user", "jdbc-password");
+  private static final Set<String> JDBC_BACKEND_REQUIRED_PROPERTIES = Set.of("jdbc-driver", "uri");
 
   private static final Set<String> HIVE_BACKEND_REQUIRED_PROPERTIES = Set.of("uri");
 

--- a/trino-connector/trino-connector/src/test/java/org/apache/gravitino/trino/connector/catalog/iceberg/TestIcebergCatalogPropertyConverter.java
+++ b/trino-connector/trino-connector/src/test/java/org/apache/gravitino/trino/connector/catalog/iceberg/TestIcebergCatalogPropertyConverter.java
@@ -174,7 +174,6 @@ public class TestIcebergCatalogPropertyConverter {
   }
 
   @Test
-  @SuppressWarnings("unchecked")
   public void testBuildConnectorPropertiesWithJdbcCredential() throws Exception {
     String name = "test_catalog";
     Map<String, String> properties =

--- a/trino-connector/trino-connector/src/test/java/org/apache/gravitino/trino/connector/catalog/iceberg/TestIcebergCatalogPropertyConverter.java
+++ b/trino-connector/trino-connector/src/test/java/org/apache/gravitino/trino/connector/catalog/iceberg/TestIcebergCatalogPropertyConverter.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import org.apache.gravitino.Catalog;
 import org.apache.gravitino.catalog.property.PropertyConverter;
 import org.apache.gravitino.credential.Credential;
+import org.apache.gravitino.credential.JdbcCredential;
 import org.apache.gravitino.trino.connector.metadata.GravitinoCatalog;
 import org.apache.gravitino.trino.connector.metadata.TestGravitinoCatalog;
 import org.junit.jupiter.api.Assertions;
@@ -170,5 +171,31 @@ public class TestIcebergCatalogPropertyConverter {
     // test unknown properties
     Assertions.assertNull(config.get("unknown-key"));
     Assertions.assertEquals(config.get("iceberg.unknown-key"), "1");
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testBuildConnectorPropertiesWithJdbcCredential() throws Exception {
+    String name = "test_catalog";
+    Map<String, String> properties =
+        ImmutableMap.<String, String>builder()
+            .put("uri", "jdbc:mysql://localhost:3306/metastore_db?createDatabaseIfNotExist=true")
+            .put("catalog-backend", "jdbc")
+            .put("warehouse", "/tmp/warehouse")
+            .put("jdbc-driver", "com.mysql.cj.jdbc.Driver")
+            .build();
+    Catalog mockCatalog =
+        TestGravitinoCatalog.mockCatalog(
+            name, "lakehouse-iceberg", "test catalog", Catalog.Type.RELATIONAL, properties);
+    IcebergConnectorAdapter adapter = new IcebergConnectorAdapter();
+
+    Map<String, String> config =
+        adapter.buildInternalConnectorConfig(
+            new GravitinoCatalog("test", mockCatalog),
+            new Credential[] {new JdbcCredential("root", "ds123")});
+
+    Assertions.assertEquals(config.get("iceberg.catalog.type"), "jdbc");
+    Assertions.assertEquals(config.get("iceberg.jdbc-catalog.connection-user"), "root");
+    Assertions.assertEquals(config.get("iceberg.jdbc-catalog.connection-password"), "ds123");
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix Trino Iceberg JDBC catalog loading by using vended `JdbcCredential` for hidden JDBC credentials.

### Why are the changes needed?

`jdbc-user` and `jdbc-password` are hidden catalog properties. The Trino connector cannot read them from catalog properties, so it fails before credential vending is applied.

Fix: #11740

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Add UT.