### PR TITLE
[#11743] fix(license): Correct Bouncy Castle license attribution in release files

### DIFF
--- a/LICENSE.bin
+++ b/LICENSE.bin
@@ -330,7 +330,6 @@
    Apache Kyuubi
    Apache Ranger
    Apache Ranger intg
-   Bouncy Castle
    Jackson JSON processor
    DataNucleus
    Modernizer Maven Plugin
@@ -436,6 +435,7 @@
    Kyligence/kylinpy
    elarivie/pyReaderWriterLock
    tkem/cachetools
+   Bouncy Castle
 
    This product bundles various third-party components also under the
    Common Development and Distribution License 1.0

--- a/NOTICE.bin
+++ b/NOTICE.bin
@@ -262,7 +262,7 @@ Apache log4j
 Copyright 2010 The Apache Software Foundation
 
 Bouncy Castle
-Copyright (c) 2000 - 2023 The Legion of the Bouncy Castle Inc.
+Copyright (c) 2000 - 2026 The Legion of the Bouncy Castle Inc.
 
 Byte Buddy
 Copyright 2014 - Present Rafael Winterhalter

--- a/licenses/bouncycastle.txt
+++ b/licenses/bouncycastle.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2000 - 2023 The Legion of the Bouncy Castle Inc. (https://www.bouncycastle.org)
+Copyright (c) 2000 - 2026 The Legion of the Bouncy Castle Inc. (https://www.bouncycastle.org)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software
 and associated documentation files (the "Software"), to deal in the Software without restriction,


### PR DESCRIPTION
### What changes were proposed in this pull request?

Correct Bouncy Castle (`org.bouncycastle:bcprov-jdk18on`) license attribution in release compliance files:

- Remove `Bouncy Castle` from the Apache 2.0 bundled components list in `LICENSE.bin`
- Add `Bouncy Castle` to the MIT license section in `LICENSE.bin`
- Update the copyright year to `2000 - 2026` in `NOTICE.bin` and `licenses/bouncycastle.txt` to match upstream

### Why are the changes needed?

Bouncy Castle is distributed under the Bouncy Castle License (MIT-style), but it was incorrectly listed under the Apache 2.0 section in `LICENSE.bin`. This was flagged during release vote review as a license compliance issue.

Fix: #11743

### Does this PR introduce _any_ user-facing change?

No user-facing behavior change. This only updates release `LICENSE`/`NOTICE` attribution files.

### How was this patch tested?

Manual verification:
- Confirmed `Bouncy Castle` appears only once in `LICENSE.bin`, under the MIT section
- Confirmed copyright text in `NOTICE.bin` and `licenses/bouncycastle.txt` matches upstream Bouncy Castle license page