### PR TITLE
[#8384] fix(catalog-oceanbase): Wrap column names with backticks

### DIFF
--- a/catalogs-contrib/catalog-jdbc-oceanbase/src/main/java/org/apache/gravitino/catalog/oceanbase/operation/OceanBaseTableOperations.java
+++ b/catalogs-contrib/catalog-jdbc-oceanbase/src/main/java/org/apache/gravitino/catalog/oceanbase/operation/OceanBaseTableOperations.java
@@ -543,18 +543,23 @@ public class OceanBaseTableOperations extends JdbcTableOperations {
     String col = updateColumnPosition.fieldName()[0];
     JdbcColumn column = getJdbcColumnFromTable(jdbcTable, col);
     StringBuilder columnDefinition = new StringBuilder();
-    columnDefinition.append(MODIFY_COLUMN).append(col);
+    columnDefinition.append(MODIFY_COLUMN).append(BACK_QUOTE).append(col).append(BACK_QUOTE);
     appendColumnDefinition(column, columnDefinition);
     if (updateColumnPosition.getPosition() instanceof TableChange.First) {
       columnDefinition.append("FIRST");
     } else if (updateColumnPosition.getPosition() instanceof TableChange.After) {
       TableChange.After afterPosition = (TableChange.After) updateColumnPosition.getPosition();
-      columnDefinition.append(AFTER).append(afterPosition.getColumn());
+      columnDefinition
+          .append(AFTER)
+          .append(BACK_QUOTE)
+          .append(afterPosition.getColumn())
+          .append(BACK_QUOTE);
     } else {
       Arrays.stream(jdbcTable.columns())
           .reduce((column1, column2) -> column2)
           .map(Column::name)
-          .ifPresent(s -> columnDefinition.append(AFTER).append(s));
+          .ifPresent(
+              s -> columnDefinition.append(AFTER).append(BACK_QUOTE).append(s).append(BACK_QUOTE));
     }
     return columnDefinition.toString();
   }
@@ -588,7 +593,7 @@ public class OceanBaseTableOperations extends JdbcTableOperations {
     }
     String col = updateColumnDefaultValue.fieldName()[0];
     JdbcColumn column = getJdbcColumnFromTable(jdbcTable, col);
-    StringBuilder sqlBuilder = new StringBuilder(MODIFY_COLUMN + col);
+    StringBuilder sqlBuilder = new StringBuilder(MODIFY_COLUMN + BACK_QUOTE + col + BACK_QUOTE);
     JdbcColumn newColumn =
         JdbcColumn.builder()
             .withName(col)
@@ -607,7 +612,7 @@ public class OceanBaseTableOperations extends JdbcTableOperations {
     }
     String col = updateColumnType.fieldName()[0];
     JdbcColumn column = getJdbcColumnFromTable(jdbcTable, col);
-    StringBuilder sqlBuilder = new StringBuilder(MODIFY_COLUMN + col);
+    StringBuilder sqlBuilder = new StringBuilder(MODIFY_COLUMN + BACK_QUOTE + col + BACK_QUOTE);
     JdbcColumn newColumn =
         JdbcColumn.builder()
             .withName(col)


### PR DESCRIPTION
### What changes were proposed in this pull request?

Wrap column names with backticks in `OceanBaseTableOperations` to prevent SQL syntax errors with reserved words or special characters.

### Why are the changes needed?

Fix: #8384

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

`./gradlew :catalogs-contrib:catalog-jdbc-oceanbase:spotlessApply`
`./gradlew :catalogs-contrib:catalog-jdbc-oceanbase:test`