### PR TITLE
[#11782] feat(lance): support Hive Metastore (hive2) namespace backend for Lance REST server

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,6 +33,7 @@ log4j = "2.25.4"
 arrow = "18.3.0"
 lance = "6.0.0"
 lance-namespace = "0.7.5"
+lance-namespace-impls = "0.4.1"
 delta-kernel = "3.3.0"
 jetty = "9.4.58.v20250814"
 jersey = "2.41"
@@ -205,6 +206,7 @@ log4j-layout-template-json = { group = "org.apache.logging.log4j", name = "log4j
 arrow-vector = { group = "org.apache.arrow", name = "arrow-vector", version.ref = "arrow" }
 lance = { group = "org.lance", name = "lance-core", version.ref = "lance" }
 lance-namespace-core = { group = "org.lance", name = "lance-namespace-core", version.ref = "lance-namespace" }
+lance-namespace-hive2 = { group = "org.lance", name = "lance-namespace-hive2", version.ref = "lance-namespace-impls" }
 delta-kernel = { group = "io.delta", name = "delta-kernel-api", version.ref = "delta-kernel" }
 delta-kernel-defaults = { group = "io.delta", name = "delta-kernel-defaults", version.ref = "delta-kernel" }
 jakarta-validation-api = { group = "jakarta.validation", name = "jakarta.validation-api", version.ref = "jakarta-validation" }

--- a/lance/lance-common/build.gradle.kts
+++ b/lance/lance-common/build.gradle.kts
@@ -24,7 +24,50 @@ plugins {
   id("idea")
 }
 
+// Pin the Lance Namespace API to the version Gravitino standardizes on (0.7.5). lance-namespace-hive2
+// 0.4.1 is built against lance-namespace 0.7.7 and drags its 0.7.7 core/apache-client in
+// transitively; those are excluded from the hive2 dependency below so the whole module resolves to
+// the single, consistent 0.7.5 Lance Namespace version Gravitino declares.
+configurations.all {
+  // Legacy Netty fat-jars (netty-all 4.0.x, netty 3.x) arrive transitively via Hadoop/Hive/
+  // lance-core and shadow the modern netty-buffer 4.1.x that Arrow's allocation manager requires,
+  // breaking arrow-memory-netty initialization on JDK 17. Arrow uses netty-buffer/netty-common
+  // directly, so drop the fat-jars everywhere in this module.
+  exclude(group = "io.netty", module = "netty-all")
+  exclude(group = "io.netty", module = "netty")
+  // Hive (hive-common 2.3.9, pulled transitively by lance-namespace-hive2) drags in an ancient
+  // Jetty (org.eclipse.jetty.aggregate:jetty-all 7.6.0, where Container is a *class*) plus
+  // mortbay/orbit Jetty. These land in the packaged libs/, and because the distribution globs
+  // jars alphabetically, jetty-all-7.6.0 loads before Gravitino's Jetty 9.4.x at runtime ->
+  // "class org.eclipse.jetty.server.Connector can not implement ...Container" -
+  // IncompatibleClassChangeError that crashes the standalone server at startup. The Hive metastore
+  // client needs no servlet container, so drop all legacy Jetty everywhere in this module.
+  exclude(group = "org.eclipse.jetty.aggregate")
+  exclude(group = "org.eclipse.jetty.orbit")
+  exclude(group = "org.mortbay.jetty")
+  // Hive/Hadoop also drag in the ancient Servlet 2.4 / JSP 2.0 APIs (javax.servlet:servlet-api:2.4,
+  // javax.servlet:jsp-api:2.0). These land in libs/ and, loaded alphabetically before the modern
+  // javax.servlet:javax.servlet-api:3.1.0 that Jetty 9.4 requires, shadow it at runtime ->
+  // NoSuchMethodError: HttpServletRequest.getDispatcherType() (a Servlet 3.0+ method) on the first
+  // request. Drop the obsolete servlet/jsp API jars; the correct javax.servlet-api 3.1.0 remains.
+  exclude(group = "javax.servlet", module = "servlet-api")
+  exclude(group = "javax.servlet", module = "jsp-api")
+  resolutionStrategy {
+    // Pin all Arrow modules to Gravitino's version so the arrow-memory-netty allocation manager
+    // matches arrow-memory-core regardless of the version lance-namespace-impls-core pulls in.
+    force("org.apache.arrow:arrow-memory-netty:${libs.versions.arrow.get()}")
+    force("org.apache.arrow:arrow-memory-core:${libs.versions.arrow.get()}")
+    force("org.apache.arrow:arrow-vector:${libs.versions.arrow.get()}")
+    force("org.apache.arrow:arrow-format:${libs.versions.arrow.get()}")
+  }
+}
+
 dependencies {
+  // Force upgrade for outdated transitive libthrift pulled by Hive Metastore
+  constraints {
+    implementation(libs.thrift)
+  }
+
   implementation(project(":api"))
   implementation(project(":clients:client-java"))
   implementation(project(":common")) {
@@ -32,6 +75,49 @@ dependencies {
   }
   implementation(project(":core")) {
     exclude("*")
+  }
+
+  // Hive Metastore + Hadoop3 client for the Hive Lance namespace backend.
+  implementation(libs.hadoop3.client.api)
+  implementation(libs.hadoop3.client.runtime)
+  // use hdfs-default.xml
+  implementation(libs.hadoop3.hdfs) {
+    exclude("*")
+  }
+  implementation(libs.hive2.metastore) {
+    exclude("co.cask.tephra")
+    exclude("com.github.spotbugs")
+    exclude("com.google.code.findbugs", "jsr305")
+    exclude("com.sun.jersey")
+    exclude("com.tdunning", "json")
+    exclude("com.zaxxer", "HikariCP")
+    exclude("com.github.joshelser")
+    exclude("io.dropwizard.metrics")
+    exclude("javax.servlet")
+    exclude("javax.transaction", "transaction-api")
+    exclude("jline")
+    exclude("org.apache.ant")
+    exclude("org.apache.avro", "avro")
+    exclude("org.apache.curator")
+    exclude("org.apache.derby")
+    exclude("org.apache.hbase")
+    exclude("org.apache.hive", "hive-service-rpc")
+    exclude("org.apache.hadoop")
+    exclude("org.apache.hadoop", "hadoop-yarn-api")
+    exclude("org.apache.hadoop", "hadoop-yarn-server-applicationhistoryservice")
+    exclude("org.apache.hadoop", "hadoop-yarn-server-common")
+    exclude("org.apache.hadoop", "hadoop-yarn-server-resourcemanager")
+    exclude("org.apache.hadoop", "hadoop-yarn-server-web-proxy")
+    exclude("org.apache.logging.log4j")
+    exclude("org.apache.parquet", "parquet-hadoop-bundle")
+    exclude("org.apache.orc")
+    exclude("org.apache.zookeeper")
+    exclude("org.datanucleus")
+    exclude("org.eclipse.jetty.aggregate", "jetty-all")
+    exclude("org.eclipse.jetty.orbit", "javax.servlet")
+    exclude("org.mortbay.jetty")
+    exclude("org.pentaho") // missing dependency
+    exclude("org.slf4j", "slf4j-log4j12")
   }
 
   implementation(libs.commons.lang3)
@@ -52,11 +138,41 @@ dependencies {
     exclude(group = "org.apache.opendal", module = "*")
     exclude(group = "org.junit.jupiter", module = "*")
   }
+
+  // Official Lance Hive 2 namespace implementation. It pulls Hadoop 2.8.5 + an embedded
+  // metastore stack (Derby/DataNucleus); exclude those so we run on Gravitino's Hadoop 3
+  // metastore client. lance-namespace-impls-core provides LanceTableUtil/RestClient.
+  implementation(libs.lance.namespace.hive2) {
+    exclude(group = "org.lance", module = "lance-core")
+    // lance-namespace-hive2 0.4.1 pulls lance-namespace-core / -apache-client 0.7.7 transitively;
+    // exclude them so the 0.7.5 artifacts Gravitino declares (via libs.lance.namespace.core above)
+    // are the single Lance Namespace version on the classpath.
+    exclude(group = "org.lance", module = "lance-namespace-core")
+    exclude(group = "org.lance", module = "lance-namespace-apache-client")
+    exclude(group = "org.apache.hadoop")
+    exclude(group = "org.apache.derby")
+    exclude(group = "org.datanucleus")
+    exclude(group = "org.apache.hive", module = "hive-exec")
+    exclude(group = "org.apache.hive", module = "hive-service")
+    exclude(group = "com.google.guava", module = "guava") // provided by gravitino
+    exclude(group = "com.fasterxml.jackson.core", module = "*") // provided by gravitino
+    exclude(group = "com.fasterxml.jackson.datatype", module = "*") // provided by gravitino
+    exclude(group = "org.apache.commons", module = "commons-lang3") // provided by gravitino
+    // arrow-dataset / arrow-c-data (and their legacy io.netty 3.x/4.0.x transitives) are not used
+    // by the Hive namespace; drop them so they don't shadow Gravitino's arrow-vector runtime.
+    exclude(group = "org.apache.arrow", module = "arrow-dataset")
+    exclude(group = "org.apache.arrow", module = "arrow-c-data")
+    exclude(group = "io.netty", module = "netty-all")
+    exclude(group = "io.netty", module = "netty")
+    exclude(group = "org.slf4j", module = "slf4j-simple")
+    exclude(group = "org.junit.jupiter", module = "*")
+  }
   implementation(libs.slf4j.api)
 
   testImplementation(project(":server-common"))
   testImplementation(libs.junit.jupiter.api)
   testImplementation(libs.junit.jupiter.params)
+  testImplementation(libs.mockito.core)
   testRuntimeOnly(libs.junit.jupiter.engine)
 }
 

--- a/lance/lance-common/src/main/java/org/apache/gravitino/lance/common/config/LanceConfig.java
+++ b/lance/lance-common/src/main/java/org/apache/gravitino/lance/common/config/LanceConfig.java
@@ -39,6 +39,14 @@ public class LanceConfig extends Config implements OverwriteDefaultConfig {
   public static final String GRAVITINO_NAMESPACE_BACKEND = "gravitino";
   public static final String GRAVITINO_URI = "http://localhost:8090";
 
+  // Backed by lance-namespace-hive2; named "hive2" because Lance also ships a separate
+  // lance-namespace-hive3 implementation.
+  public static final String HIVE2_NAMESPACE_BACKEND = "hive2";
+  // The hive-* config keys are shared Hive Metastore settings, not tied to the hive2 backend
+  // name, so a future hive3 backend can reuse them as-is.
+  public static final String HIVE_CONFIG_KEY_PREFIX = "hive";
+  public static final int DEFAULT_HIVE_CLIENT_POOL_SIZE = 3;
+
   public static final ConfigEntry<String> NAMESPACE_BACKEND =
       new ConfigBuilder(CONFIG_NAMESPACE_BACKEND)
           .doc("The backend implementation for namespace operations")
@@ -60,6 +68,27 @@ public class LanceConfig extends Config implements OverwriteDefaultConfig {
           .stringConf()
           .createWithDefault(GRAVITINO_URI);
 
+  public static final ConfigEntry<String> HIVE_METASTORE_URIS =
+      new ConfigBuilder(HIVE_CONFIG_KEY_PREFIX + "-metastore-uris")
+          .doc("The Hive Metastore thrift URIs, e.g., thrift://host:9083")
+          .version(ConfigConstants.VERSION_1_3_0)
+          .stringConf()
+          .create();
+
+  public static final ConfigEntry<String> HIVE_WAREHOUSE =
+      new ConfigBuilder(HIVE_CONFIG_KEY_PREFIX + "-warehouse")
+          .doc("The warehouse/root storage location for the Hive Lance namespace backend")
+          .version(ConfigConstants.VERSION_1_3_0)
+          .stringConf()
+          .create();
+
+  public static final ConfigEntry<Integer> HIVE_CLIENT_POOL_SIZE =
+      new ConfigBuilder(HIVE_CONFIG_KEY_PREFIX + "-client-pool-size")
+          .doc("The size of the Hive Metastore client pool")
+          .version(ConfigConstants.VERSION_1_3_0)
+          .intConf()
+          .createWithDefault(DEFAULT_HIVE_CLIENT_POOL_SIZE);
+
   public LanceConfig(Map<String, String> properties) {
     super(false);
     loadFromMap(properties, key -> true);
@@ -79,6 +108,18 @@ public class LanceConfig extends Config implements OverwriteDefaultConfig {
 
   public String getGravitinoMetalake() {
     return get(METALAKE_NAME);
+  }
+
+  public String getHiveMetastoreUris() {
+    return get(HIVE_METASTORE_URIS);
+  }
+
+  public String getHiveWarehouse() {
+    return get(HIVE_WAREHOUSE);
+  }
+
+  public int getHiveClientPoolSize() {
+    return get(HIVE_CLIENT_POOL_SIZE);
   }
 
   @Override

--- a/lance/lance-common/src/main/java/org/apache/gravitino/lance/common/ops/LanceNamespaceBackend.java
+++ b/lance/lance-common/src/main/java/org/apache/gravitino/lance/common/ops/LanceNamespaceBackend.java
@@ -20,9 +20,13 @@ package org.apache.gravitino.lance.common.ops;
 
 import java.util.Arrays;
 import org.apache.gravitino.lance.common.ops.gravitino.GravitinoLanceNamespaceWrapper;
+import org.apache.gravitino.lance.common.ops.hive.HiveLanceNamespaceWrapper;
 
 public enum LanceNamespaceBackend {
-  GRAVITINO("gravitino", GravitinoLanceNamespaceWrapper.class);
+  GRAVITINO("gravitino", GravitinoLanceNamespaceWrapper.class),
+  // Backed by lance-namespace-hive2; named "hive2" because Lance also ships a separate
+  // lance-namespace-hive3 implementation.
+  HIVE2("hive2", HiveLanceNamespaceWrapper.class);
 
   private final String type;
   private final Class<? extends NamespaceWrapper> wrapperClass;

--- a/lance/lance-common/src/main/java/org/apache/gravitino/lance/common/ops/hive/HiveLanceNamespaceOperations.java
+++ b/lance/lance-common/src/main/java/org/apache/gravitino/lance/common/ops/hive/HiveLanceNamespaceOperations.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.lance.common.ops.hive;
+
+import java.util.List;
+import java.util.Map;
+import org.apache.gravitino.lance.common.ops.LanceNamespaceOperations;
+import org.lance.namespace.errors.LanceNamespaceException;
+import org.lance.namespace.hive2.Hive2Namespace;
+import org.lance.namespace.model.CreateNamespaceRequest;
+import org.lance.namespace.model.CreateNamespaceResponse;
+import org.lance.namespace.model.DescribeNamespaceRequest;
+import org.lance.namespace.model.DescribeNamespaceResponse;
+import org.lance.namespace.model.DropNamespaceRequest;
+import org.lance.namespace.model.DropNamespaceResponse;
+import org.lance.namespace.model.ListNamespacesRequest;
+import org.lance.namespace.model.ListNamespacesResponse;
+import org.lance.namespace.model.ListTablesRequest;
+import org.lance.namespace.model.ListTablesResponse;
+import org.lance.namespace.model.NamespaceExistsRequest;
+
+/**
+ * Adapts Gravitino's {@link LanceNamespaceOperations} interface onto the official {@link
+ * Hive2Namespace} implementation. Each call parses the delimited identifier into the list form the
+ * Lance Namespace model expects, delegates to {@link Hive2Namespace}, and returns its response
+ * directly (the Gravitino interface and {@link Hive2Namespace} share the {@code
+ * org.lance.namespace.model} response types).
+ */
+public class HiveLanceNamespaceOperations implements LanceNamespaceOperations {
+
+  private final Hive2Namespace delegate;
+
+  /**
+   * Create namespace operations delegating to the given {@link Hive2Namespace}.
+   *
+   * @param delegate the underlying Lance Hive 2 namespace implementation
+   */
+  public HiveLanceNamespaceOperations(Hive2Namespace delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public ListNamespacesResponse listNamespaces(
+      String namespaceId, String delimiter, String pageToken, Integer limit) {
+    ListNamespacesRequest request = new ListNamespacesRequest();
+    request.setId(IdentifierUtil.parse(namespaceId, delimiter));
+    request.setPageToken(pageToken);
+    request.setLimit(limit);
+    return delegate.listNamespaces(request);
+  }
+
+  @Override
+  public DescribeNamespaceResponse describeNamespace(String namespaceId, String delimiter) {
+    DescribeNamespaceRequest request = new DescribeNamespaceRequest();
+    request.setId(IdentifierUtil.parse(namespaceId, delimiter));
+    return delegate.describeNamespace(request);
+  }
+
+  @Override
+  public CreateNamespaceResponse createNamespace(
+      String namespaceId, String delimiter, String mode, Map<String, String> properties) {
+    CreateNamespaceRequest request = new CreateNamespaceRequest();
+    request.setId(IdentifierUtil.parse(namespaceId, delimiter));
+    request.setMode(mode);
+    request.setProperties(properties);
+    return delegate.createNamespace(request);
+  }
+
+  @Override
+  public DropNamespaceResponse dropNamespace(
+      String namespaceId, String delimiter, String mode, String behavior) {
+    DropNamespaceRequest request = new DropNamespaceRequest();
+    request.setId(IdentifierUtil.parse(namespaceId, delimiter));
+    request.setMode(mode);
+    request.setBehavior(behavior);
+    return delegate.dropNamespace(request);
+  }
+
+  @Override
+  public void namespaceExists(String namespaceId, String delimiter) throws LanceNamespaceException {
+    NamespaceExistsRequest request = new NamespaceExistsRequest();
+    request.setId(IdentifierUtil.parse(namespaceId, delimiter));
+    delegate.namespaceExists(request);
+  }
+
+  @Override
+  public ListTablesResponse listTables(
+      String namespaceId, String delimiter, String pageToken, Integer limit) {
+    ListTablesRequest request = new ListTablesRequest();
+    List<String> id = IdentifierUtil.parse(namespaceId, delimiter);
+    request.setId(id);
+    request.setPageToken(pageToken);
+    request.setLimit(limit);
+    return delegate.listTables(request);
+  }
+}

--- a/lance/lance-common/src/main/java/org/apache/gravitino/lance/common/ops/hive/HiveLanceNamespaceWrapper.java
+++ b/lance/lance-common/src/main/java/org/apache/gravitino/lance/common/ops/hive/HiveLanceNamespaceWrapper.java
@@ -1,0 +1,165 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.lance.common.ops.hive;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.gravitino.lance.common.config.LanceConfig;
+import org.apache.gravitino.lance.common.ops.LanceNamespaceOperations;
+import org.apache.gravitino.lance.common.ops.LanceTableOperations;
+import org.apache.gravitino.lance.common.ops.NamespaceWrapper;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.lance.namespace.hive2.Hive2Namespace;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * {@link NamespaceWrapper} backed by the official {@code lance-namespace-hive2} implementation
+ * ({@link Hive2Namespace}). A namespace maps to a Hive database and a table maps to a {@code
+ * db.table} entry registered in the Hive Metastore as an external Lance table.
+ *
+ * <p>This wrapper owns a single {@link Hive2Namespace} instance and exposes it to the namespace and
+ * table operation adapters, which translate between Gravitino's flat-parameter operation interfaces
+ * and the Lance Namespace request/response model.
+ */
+public class HiveLanceNamespaceWrapper extends NamespaceWrapper {
+
+  private static final Logger LOG = LoggerFactory.getLogger(HiveLanceNamespaceWrapper.class);
+
+  /** Prefix for raw Hadoop/Hive properties forwarded into the Hadoop configuration. */
+  private static final String HIVE_CONFIG_PREFIX = "hive.";
+
+  /** {@link Hive2Namespace} config key for the client pool size. */
+  private static final String HIVE2_CLIENT_POOL_SIZE = "client.pool-size";
+
+  /** {@link Hive2Namespace} config key for the storage root used to derive default locations. */
+  private static final String HIVE2_ROOT = "root";
+
+  private Hive2Namespace delegate;
+  private BufferAllocator allocator;
+
+  private LanceNamespaceOperations namespaceOperations;
+  private LanceTableOperations tableOperations;
+
+  @VisibleForTesting
+  HiveLanceNamespaceWrapper() {
+    super(null);
+  }
+
+  /**
+   * Create a Hive namespace wrapper.
+   *
+   * @param config the Lance configuration
+   */
+  public HiveLanceNamespaceWrapper(LanceConfig config) {
+    super(config);
+  }
+
+  /**
+   * Get the underlying Lance Hive 2 namespace implementation.
+   *
+   * @return the delegate, or null if {@link #initialize()} has not run
+   */
+  public Hive2Namespace getDelegate() {
+    return delegate;
+  }
+
+  @Override
+  protected void initialize() {
+    String metastoreUris = config().get(LanceConfig.HIVE_METASTORE_URIS);
+    String warehouse = config().get(LanceConfig.HIVE_WAREHOUSE);
+    int poolSize = config().get(LanceConfig.HIVE_CLIENT_POOL_SIZE);
+
+    Configuration hadoopConf = new Configuration();
+    if (StringUtils.isNotBlank(metastoreUris)) {
+      hadoopConf.set(HiveConf.ConfVars.METASTOREURIS.varname, metastoreUris);
+    }
+    if (StringUtils.isNotBlank(warehouse)) {
+      hadoopConf.set(HiveConf.ConfVars.METASTOREWAREHOUSE.varname, warehouse);
+    }
+
+    // Forward any raw hive.* properties into the Hadoop configuration.
+    config()
+        .getAllConfig()
+        .forEach(
+            (key, value) -> {
+              if (key.startsWith(HIVE_CONFIG_PREFIX)) {
+                hadoopConf.set(key, value);
+                LOG.info("Applying Hive config: {} = {}", key, value);
+              }
+            });
+
+    Map<String, String> namespaceProperties = new HashMap<>();
+    namespaceProperties.put(HIVE2_CLIENT_POOL_SIZE, String.valueOf(poolSize));
+    if (StringUtils.isNotBlank(warehouse)) {
+      namespaceProperties.put(HIVE2_ROOT, warehouse);
+    }
+
+    this.allocator = new RootAllocator();
+    this.delegate = new Hive2Namespace();
+    this.delegate.setHadoopConf(hadoopConf);
+    this.delegate.initialize(namespaceProperties, allocator);
+
+    LOG.info(
+        "Hive Lance namespace backend initialized with metastore uris '{}', warehouse '{}',"
+            + " pool size {}",
+        metastoreUris,
+        warehouse,
+        poolSize);
+
+    this.namespaceOperations = new HiveLanceNamespaceOperations(delegate);
+    this.tableOperations = new HiveLanceTableOperations(delegate);
+  }
+
+  @Override
+  protected LanceNamespaceOperations newNamespaceOps() {
+    return namespaceOperations;
+  }
+
+  @Override
+  protected LanceTableOperations newTableOps() {
+    return tableOperations;
+  }
+
+  @Override
+  public void close() {
+    // Release the Hive Metastore client pool held by the delegate. lance-namespace-impls 0.4.0
+    // (lance-format/lance-namespace-impls#137) makes Hive2Namespace implement Closeable; before the
+    // bump this pool was leaked on shutdown.
+    if (delegate != null) {
+      try {
+        delegate.close();
+      } catch (Exception e) {
+        LOG.warn("Error closing Hive2Namespace for Hive Lance namespace backend", e);
+      }
+    }
+    if (allocator != null) {
+      try {
+        allocator.close();
+      } catch (Exception e) {
+        LOG.warn("Error closing Arrow allocator for Hive Lance namespace backend", e);
+      }
+    }
+  }
+}

--- a/lance/lance-common/src/main/java/org/apache/gravitino/lance/common/ops/hive/HiveLanceTableOperations.java
+++ b/lance/lance-common/src/main/java/org/apache/gravitino/lance/common/ops/hive/HiveLanceTableOperations.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.lance.common.ops.hive;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.gravitino.lance.common.ops.LanceTableOperations;
+import org.lance.namespace.errors.TableNotFoundException;
+import org.lance.namespace.hive2.Hive2Namespace;
+import org.lance.namespace.model.AlterTableAlterColumnsRequest;
+import org.lance.namespace.model.AlterTableDropColumnsRequest;
+import org.lance.namespace.model.CreateTableRequest;
+import org.lance.namespace.model.CreateTableResponse;
+import org.lance.namespace.model.DeclareTableRequest;
+import org.lance.namespace.model.DeclareTableResponse;
+import org.lance.namespace.model.DeregisterTableRequest;
+import org.lance.namespace.model.DeregisterTableResponse;
+import org.lance.namespace.model.DescribeTableRequest;
+import org.lance.namespace.model.DescribeTableResponse;
+import org.lance.namespace.model.DropTableRequest;
+import org.lance.namespace.model.DropTableResponse;
+import org.lance.namespace.model.RegisterTableRequest;
+import org.lance.namespace.model.RegisterTableResponse;
+import org.lance.namespace.model.TableExistsRequest;
+
+/**
+ * Adapts Gravitino's {@link LanceTableOperations} interface onto the official {@link
+ * Hive2Namespace} implementation.
+ *
+ * <p>{@link Hive2Namespace} implements the metastore-registry operations (describe/declare/drop/
+ * deregister/exists). It does not implement {@code createTable}, {@code registerTable}, or column
+ * alteration; those delegate to the Lance Namespace default behavior, which reports them as
+ * unsupported for this backend. Table creation is performed through {@link #declareTable}.
+ */
+public class HiveLanceTableOperations implements LanceTableOperations {
+
+  private final Hive2Namespace delegate;
+
+  /**
+   * Create table operations delegating to the given {@link Hive2Namespace}.
+   *
+   * @param delegate the underlying Lance Hive 2 namespace implementation
+   */
+  public HiveLanceTableOperations(Hive2Namespace delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public DescribeTableResponse describeTable(
+      String tableId,
+      String delimiter,
+      Optional<Long> version,
+      boolean checkDeclared,
+      @SuppressWarnings("unused") boolean loadDetailedMetadata) {
+    DescribeTableRequest request = new DescribeTableRequest();
+    request.setId(IdentifierUtil.parse(tableId, delimiter));
+    version.ifPresent(request::setVersion);
+    request.setCheckDeclared(checkDeclared);
+    // The Hive metastore backend only stores the table pointer (location + properties); it cannot
+    // open the Lance dataset to produce detailed metadata (schema/version/stats). The underlying
+    // Hive2Namespace rejects loadDetailedMetadata=true with "not supported for this
+    // implementation".
+    // Callers that need the schema (e.g. the Spark connector) read it by opening the dataset
+    // directly from storage, so we always request the lightweight (pointer-only) describe here.
+    request.setLoadDetailedMetadata(false);
+    return delegate.describeTable(request);
+  }
+
+  @Override
+  public CreateTableResponse createTable(
+      String tableId,
+      String mode,
+      String delimiter,
+      String tableLocation,
+      Map<String, String> tableProperties,
+      byte[] arrowStreamBody) {
+    CreateTableRequest request = new CreateTableRequest();
+    request.setId(IdentifierUtil.parse(tableId, delimiter));
+    request.setMode(mode);
+    request.setProperties(tableProperties);
+    return delegate.createTable(request, arrowStreamBody);
+  }
+
+  @Override
+  public DeclareTableResponse declareTable(
+      String tableId, String delimiter, String tableLocation, Map<String, String> tableProperties) {
+    DeclareTableRequest request = new DeclareTableRequest();
+    request.setId(IdentifierUtil.parse(tableId, delimiter));
+    request.setLocation(tableLocation);
+    request.setProperties(tableProperties);
+    return delegate.declareTable(request);
+  }
+
+  @Override
+  public RegisterTableResponse registerTable(
+      String tableId, String mode, String delimiter, Map<String, String> tableProperties) {
+    RegisterTableRequest request = new RegisterTableRequest();
+    request.setId(IdentifierUtil.parse(tableId, delimiter));
+    request.setMode(mode);
+    request.setProperties(tableProperties);
+    return delegate.registerTable(request);
+  }
+
+  @Override
+  public DeregisterTableResponse deregisterTable(String tableId, String delimiter) {
+    DeregisterTableRequest request = new DeregisterTableRequest();
+    request.setId(IdentifierUtil.parse(tableId, delimiter));
+    return delegate.deregisterTable(request);
+  }
+
+  @Override
+  public boolean tableExists(String tableId, String delimiter) {
+    TableExistsRequest request = new TableExistsRequest();
+    request.setId(IdentifierUtil.parse(tableId, delimiter));
+    try {
+      delegate.tableExists(request);
+      return true;
+    } catch (TableNotFoundException e) {
+      return false;
+    }
+  }
+
+  @Override
+  public DropTableResponse dropTable(String tableId, String delimiter) {
+    DropTableRequest request = new DropTableRequest();
+    request.setId(IdentifierUtil.parse(tableId, delimiter));
+    return delegate.dropTable(request);
+  }
+
+  @Override
+  public Object alterTable(String tableId, String delimiter, Object request) {
+    List<String> id = IdentifierUtil.parse(tableId, delimiter);
+    if (request instanceof AlterTableDropColumnsRequest) {
+      AlterTableDropColumnsRequest dropColumns = (AlterTableDropColumnsRequest) request;
+      dropColumns.setId(id);
+      return delegate.alterTableDropColumns(dropColumns);
+    }
+    if (request instanceof AlterTableAlterColumnsRequest) {
+      AlterTableAlterColumnsRequest alterColumns = (AlterTableAlterColumnsRequest) request;
+      alterColumns.setId(id);
+      return delegate.alterTableAlterColumns(alterColumns);
+    }
+    throw new IllegalArgumentException(
+        "Unsupported alter table request type: " + request.getClass().getName());
+  }
+}

--- a/lance/lance-common/src/main/java/org/apache/gravitino/lance/common/ops/hive/IdentifierUtil.java
+++ b/lance/lance-common/src/main/java/org/apache/gravitino/lance/common/ops/hive/IdentifierUtil.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.lance.common.ops.hive;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Parses the delimited identifier strings used by the Lance REST surface into the {@code
+ * List<String>} form expected by the Lance Namespace request model.
+ */
+final class IdentifierUtil {
+
+  private IdentifierUtil() {}
+
+  /**
+   * Split a delimited identifier into its levels.
+   *
+   * @param id the identifier, e.g. {@code "db.table"}; {@code null} or empty yields an empty list
+   * @param delimiter the literal delimiter, e.g. {@code "."} (treated literally, not as a regex)
+   * @return the parsed, non-empty levels in order
+   */
+  static List<String> parse(String id, String delimiter) {
+    if (StringUtils.isEmpty(id)) {
+      return Collections.emptyList();
+    }
+    return Arrays.stream(id.split(Pattern.quote(delimiter)))
+        .filter(StringUtils::isNotEmpty)
+        .collect(Collectors.toList());
+  }
+}

--- a/lance/lance-common/src/test/java/org/apache/gravitino/lance/common/ops/hive/TestHiveClasspathHygiene.java
+++ b/lance/lance-common/src/test/java/org/apache/gravitino/lance/common/ops/hive/TestHiveClasspathHygiene.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.lance.common.ops.hive;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Guards the runtime classpath against the legacy Jetty artifacts that the Hive metastore client
+ * (hive-common 2.3.9, pulled transitively by lance-namespace-hive2) drags in.
+ *
+ * <p>Those jars — {@code org.eclipse.jetty.aggregate:jetty-all:7.6.0} (where {@code
+ * org.eclipse.jetty.util.component.Container} is a <em>class</em>), {@code org.mortbay.jetty:*},
+ * and {@code org.eclipse.jetty.orbit:*} — collide with Gravitino's Jetty 9.4.x (where {@code
+ * Container} is an <em>interface</em>). In the packaged distribution the jars in {@code libs/} are
+ * loaded in alphabetical order, so {@code jetty-all-7.6.0} shadows the modern Jetty and the
+ * standalone server dies at startup with {@code IncompatibleClassChangeError: class
+ * org.eclipse.jetty.server.Connector can not implement ...Container}.
+ *
+ * <p>A functional integration test does not reliably catch this: Gradle's test classpath is ordered
+ * by the dependency graph (modern Jetty first), so the good class loads and the server starts. This
+ * test instead inspects the classpath directly, so it fails deterministically regardless of load
+ * order.
+ */
+class TestHiveClasspathHygiene {
+
+  /** Jar-name fragments that must never appear on the runtime classpath. */
+  private static final List<String> FORBIDDEN_JAR_FRAGMENTS = Arrays.asList("jetty-all", "mortbay");
+
+  @Test
+  void testNoLegacyJettyOnClasspath() {
+    String classpath = System.getProperty("java.class.path", "");
+    List<String> offenders =
+        Arrays.stream(classpath.split(java.io.File.pathSeparator))
+            .filter(
+                entry -> {
+                  String name = entry.toLowerCase();
+                  return FORBIDDEN_JAR_FRAGMENTS.stream().anyMatch(name::contains);
+                })
+            .collect(Collectors.toList());
+
+    if (!offenders.isEmpty()) {
+      fail(
+          "Legacy Jetty jars found on the runtime classpath; they collide with Gravitino's "
+              + "Jetty 9.4.x and crash the standalone Lance REST server at startup. Exclude them "
+              + "from the Hive dependencies in lance-common/build.gradle.kts. Offenders: "
+              + offenders);
+    }
+  }
+
+  @Test
+  void testJettyContainerIsAnInterface() throws ClassNotFoundException {
+    // The exact failure mode: with a conflicting Jetty, Container resolves to a class rather than
+    // an interface, and Connector (9.4.x) can no longer implement it.
+    Class<?> container = Class.forName("org.eclipse.jetty.util.component.Container");
+    assertTrue(
+        container.isInterface(),
+        "org.eclipse.jetty.util.component.Container must be an interface (Jetty 9.4.x). A "
+            + "conflicting legacy Jetty is on the classpath where it is a class, which breaks "
+            + "org.eclipse.jetty.server.Connector at server startup.");
+  }
+}

--- a/lance/lance-common/src/test/java/org/apache/gravitino/lance/common/ops/hive/TestHiveLanceConfig.java
+++ b/lance/lance-common/src/test/java/org/apache/gravitino/lance/common/ops/hive/TestHiveLanceConfig.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.lance.common.ops.hive;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.google.common.collect.ImmutableMap;
+import org.apache.gravitino.lance.common.config.LanceConfig;
+import org.apache.gravitino.lance.common.ops.LanceNamespaceBackend;
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for the Hive-related {@link LanceConfig} keys and backend wiring. */
+class TestHiveLanceConfig {
+
+  @Test
+  void testHiveConfigKeysParse() {
+    LanceConfig config =
+        new LanceConfig(
+            ImmutableMap.of(
+                "hive-metastore-uris", "thrift://host:9083",
+                "hive-warehouse", "s3://bucket/wh",
+                "hive-client-pool-size", "7"));
+    assertEquals("thrift://host:9083", config.getHiveMetastoreUris());
+    assertEquals("s3://bucket/wh", config.getHiveWarehouse());
+    assertEquals(7, config.getHiveClientPoolSize());
+  }
+
+  @Test
+  void testHiveClientPoolSizeDefault() {
+    LanceConfig config = new LanceConfig(ImmutableMap.of());
+    assertEquals(3, config.getHiveClientPoolSize());
+  }
+
+  @Test
+  void testBackendFromTypeHive() {
+    LanceNamespaceBackend backend = LanceNamespaceBackend.fromType("hive2");
+    assertEquals(LanceNamespaceBackend.HIVE2, backend);
+    assertEquals(HiveLanceNamespaceWrapper.class, backend.getWrapperClass());
+  }
+}

--- a/lance/lance-common/src/test/java/org/apache/gravitino/lance/common/ops/hive/TestHiveLanceNamespaceOperations.java
+++ b/lance/lance-common/src/test/java/org/apache/gravitino/lance/common/ops/hive/TestHiveLanceNamespaceOperations.java
@@ -1,0 +1,161 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.lance.common.ops.hive;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.lance.namespace.hive2.Hive2Namespace;
+import org.lance.namespace.model.CreateNamespaceRequest;
+import org.lance.namespace.model.CreateNamespaceResponse;
+import org.lance.namespace.model.DescribeNamespaceRequest;
+import org.lance.namespace.model.DescribeNamespaceResponse;
+import org.lance.namespace.model.DropNamespaceRequest;
+import org.lance.namespace.model.DropNamespaceResponse;
+import org.lance.namespace.model.ListNamespacesRequest;
+import org.lance.namespace.model.ListNamespacesResponse;
+import org.lance.namespace.model.ListTablesRequest;
+import org.lance.namespace.model.ListTablesResponse;
+import org.lance.namespace.model.NamespaceExistsRequest;
+import org.mockito.ArgumentCaptor;
+
+/**
+ * Unit tests for {@link HiveLanceNamespaceOperations}, which adapts Gravitino's namespace-operation
+ * interface onto a mocked {@link Hive2Namespace}.
+ */
+class TestHiveLanceNamespaceOperations {
+
+  private static final String DELIMITER = "$";
+
+  private Hive2Namespace delegate;
+  private HiveLanceNamespaceOperations ops;
+
+  @BeforeEach
+  void setUp() {
+    delegate = mock(Hive2Namespace.class);
+    ops = new HiveLanceNamespaceOperations(delegate);
+  }
+
+  @Test
+  void testListNamespacesTranslatesRootIdToEmptyList() {
+    ListNamespacesResponse expected = new ListNamespacesResponse();
+    when(delegate.listNamespaces(any(ListNamespacesRequest.class))).thenReturn(expected);
+
+    ListNamespacesResponse actual = ops.listNamespaces("", DELIMITER, "tok", 10);
+
+    assertSame(expected, actual);
+    ArgumentCaptor<ListNamespacesRequest> captor =
+        ArgumentCaptor.forClass(ListNamespacesRequest.class);
+    verify(delegate).listNamespaces(captor.capture());
+    ListNamespacesRequest sent = captor.getValue();
+    assertEquals(List.of(), sent.getId());
+    assertEquals("tok", sent.getPageToken());
+    assertEquals(10, sent.getLimit());
+  }
+
+  @Test
+  void testCreateNamespaceTranslatesRequest() {
+    CreateNamespaceResponse expected = new CreateNamespaceResponse();
+    when(delegate.createNamespace(any(CreateNamespaceRequest.class))).thenReturn(expected);
+
+    CreateNamespaceResponse actual =
+        ops.createNamespace("db1", DELIMITER, "create", ImmutableMap.of("k", "v"));
+
+    assertSame(expected, actual);
+    ArgumentCaptor<CreateNamespaceRequest> captor =
+        ArgumentCaptor.forClass(CreateNamespaceRequest.class);
+    verify(delegate).createNamespace(captor.capture());
+    CreateNamespaceRequest sent = captor.getValue();
+    assertEquals(List.of("db1"), sent.getId());
+    assertEquals("create", sent.getMode());
+    assertEquals("v", sent.getProperties().get("k"));
+  }
+
+  @Test
+  void testDescribeNamespaceTranslatesRequest() {
+    DescribeNamespaceResponse expected = new DescribeNamespaceResponse();
+    when(delegate.describeNamespace(any(DescribeNamespaceRequest.class))).thenReturn(expected);
+
+    DescribeNamespaceResponse actual = ops.describeNamespace("db1", DELIMITER);
+
+    assertSame(expected, actual);
+    ArgumentCaptor<DescribeNamespaceRequest> captor =
+        ArgumentCaptor.forClass(DescribeNamespaceRequest.class);
+    verify(delegate).describeNamespace(captor.capture());
+    assertEquals(List.of("db1"), captor.getValue().getId());
+  }
+
+  @Test
+  void testDropNamespaceTranslatesModeAndBehavior() {
+    DropNamespaceResponse expected = new DropNamespaceResponse();
+    when(delegate.dropNamespace(any(DropNamespaceRequest.class))).thenReturn(expected);
+
+    DropNamespaceResponse actual = ops.dropNamespace("db1", DELIMITER, "fail", "Restrict");
+
+    assertSame(expected, actual);
+    ArgumentCaptor<DropNamespaceRequest> captor =
+        ArgumentCaptor.forClass(DropNamespaceRequest.class);
+    verify(delegate).dropNamespace(captor.capture());
+    DropNamespaceRequest sent = captor.getValue();
+    assertEquals(List.of("db1"), sent.getId());
+    assertEquals("fail", sent.getMode());
+    assertEquals("Restrict", sent.getBehavior());
+  }
+
+  @Test
+  void testNamespaceExistsDelegates() {
+    ops.namespaceExists("db1", DELIMITER);
+    ArgumentCaptor<NamespaceExistsRequest> captor =
+        ArgumentCaptor.forClass(NamespaceExistsRequest.class);
+    verify(delegate).namespaceExists(captor.capture());
+    assertEquals(List.of("db1"), captor.getValue().getId());
+  }
+
+  @Test
+  void testListTablesTranslatesRequest() {
+    ListTablesResponse expected = new ListTablesResponse();
+    when(delegate.listTables(any(ListTablesRequest.class))).thenReturn(expected);
+
+    ListTablesResponse actual = ops.listTables("db1", DELIMITER, null, null);
+
+    assertSame(expected, actual);
+    ArgumentCaptor<ListTablesRequest> captor = ArgumentCaptor.forClass(ListTablesRequest.class);
+    verify(delegate).listTables(captor.capture());
+    assertEquals(List.of("db1"), captor.getValue().getId());
+  }
+
+  @Test
+  void testMultiLevelIdSplits() {
+    when(delegate.describeNamespace(any(DescribeNamespaceRequest.class)))
+        .thenReturn(new DescribeNamespaceResponse());
+    ops.describeNamespace("a$b", DELIMITER);
+    ArgumentCaptor<DescribeNamespaceRequest> captor =
+        ArgumentCaptor.forClass(DescribeNamespaceRequest.class);
+    verify(delegate).describeNamespace(captor.capture());
+    assertEquals(List.of("a", "b"), captor.getValue().getId());
+  }
+}

--- a/lance/lance-common/src/test/java/org/apache/gravitino/lance/common/ops/hive/TestHiveLanceNamespaceWrapperClose.java
+++ b/lance/lance-common/src/test/java/org/apache/gravitino/lance/common/ops/hive/TestHiveLanceNamespaceWrapperClose.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.lance.common.ops.hive;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import com.google.common.collect.ImmutableMap;
+import java.lang.reflect.Field;
+import java.util.Map;
+import org.apache.gravitino.lance.common.config.LanceConfig;
+import org.junit.jupiter.api.Test;
+import org.lance.namespace.hive2.Hive2Namespace;
+
+/**
+ * Verifies that closing {@link HiveLanceNamespaceWrapper} releases the Hive Metastore client pool
+ * held by its {@link Hive2Namespace} delegate.
+ *
+ * <p>{@code lance-namespace-impls} 0.4.0 (lance-format/lance-namespace-impls#137) makes {@code
+ * Hive2Namespace} implement {@code Closeable}; before the bump the pooled metastore connections
+ * were leaked on shutdown. The delegate's client pool connects to the metastore only lazily (on the
+ * first metastore call), so this test exercises construction and close entirely offline — no
+ * running metastore required.
+ */
+class TestHiveLanceNamespaceWrapperClose {
+
+  private static final Map<String, String> CONFIG =
+      ImmutableMap.of(
+          "namespace-backend", "hive2",
+          "hive-metastore-uris", "thrift://localhost:1",
+          "hive-warehouse", "s3://test-bucket/warehouse",
+          "hive-client-pool-size", "1");
+
+  @Test
+  void testCloseReleasesTheClientPool() throws Exception {
+    HiveLanceNamespaceWrapper wrapper = new HiveLanceNamespaceWrapper(new LanceConfig(CONFIG));
+    // Trigger lazy initialization so the delegate (and its client pool) is built.
+    wrapper.asTableOps();
+    Object pool = clientPoolOf(wrapper.getDelegate());
+    assertNotNull(pool, "the Hive2Namespace client pool should be created on initialization");
+
+    // Closing the wrapper must release the delegate's Hive metastore client pool; before the
+    // lance-namespace-impls 0.4.0 Closeable fix this pool was leaked on shutdown.
+    wrapper.close();
+
+    assertClosed(pool);
+  }
+
+  private static Object clientPoolOf(Object hive2Namespace) {
+    return readField(hive2Namespace, "clientPool");
+  }
+
+  /** Assert the lance-namespace ClientPoolImpl's private {@code closed} flag is set. */
+  private static void assertClosed(Object clientPool) {
+    Object closed = readField(clientPool, "closed");
+    assertEquals(Boolean.TRUE, closed, "the Hive metastore client pool must be closed");
+  }
+
+  private static Object readField(Object target, String fieldName) {
+    // Walk up the class hierarchy: e.g. ClientPoolImpl#closed is declared on a superclass of
+    // Hive2ClientPool.
+    for (Class<?> cls = target.getClass(); cls != null; cls = cls.getSuperclass()) {
+      try {
+        Field field = cls.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        return field.get(target);
+      } catch (NoSuchFieldException e) {
+        // try the superclass
+      } catch (IllegalAccessException e) {
+        return fail("Could not read field '" + fieldName + "': " + e.getMessage());
+      }
+    }
+    return fail(
+        "Field '"
+            + fieldName
+            + "' not found on "
+            + target.getClass().getName()
+            + "; the Hive client-pool close assumption must be re-verified.");
+  }
+}

--- a/lance/lance-common/src/test/java/org/apache/gravitino/lance/common/ops/hive/TestHiveLanceTableOperations.java
+++ b/lance/lance-common/src/test/java/org/apache/gravitino/lance/common/ops/hive/TestHiveLanceTableOperations.java
@@ -1,0 +1,177 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.lance.common.ops.hive;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.lance.namespace.errors.TableNotFoundException;
+import org.lance.namespace.hive2.Hive2Namespace;
+import org.lance.namespace.model.AlterTableDropColumnsRequest;
+import org.lance.namespace.model.AlterTableDropColumnsResponse;
+import org.lance.namespace.model.DeclareTableRequest;
+import org.lance.namespace.model.DeclareTableResponse;
+import org.lance.namespace.model.DeregisterTableRequest;
+import org.lance.namespace.model.DeregisterTableResponse;
+import org.lance.namespace.model.DescribeTableRequest;
+import org.lance.namespace.model.DescribeTableResponse;
+import org.lance.namespace.model.DropTableRequest;
+import org.lance.namespace.model.DropTableResponse;
+import org.lance.namespace.model.TableExistsRequest;
+import org.mockito.ArgumentCaptor;
+
+/**
+ * Unit tests for {@link HiveLanceTableOperations}, which adapts Gravitino's table-operation
+ * interface onto a mocked {@link Hive2Namespace}.
+ */
+class TestHiveLanceTableOperations {
+
+  private static final String DELIMITER = "$";
+
+  private Hive2Namespace delegate;
+  private HiveLanceTableOperations ops;
+
+  @BeforeEach
+  void setUp() {
+    delegate = mock(Hive2Namespace.class);
+    ops = new HiveLanceTableOperations(delegate);
+  }
+
+  @Test
+  void testDescribeTableTranslatesRequestAndReturnsResponse() {
+    DescribeTableResponse expected = new DescribeTableResponse();
+    when(delegate.describeTable(any(DescribeTableRequest.class))).thenReturn(expected);
+
+    DescribeTableResponse actual =
+        ops.describeTable("db$t", DELIMITER, Optional.of(3L), true, false);
+
+    assertSame(expected, actual);
+    ArgumentCaptor<DescribeTableRequest> captor =
+        ArgumentCaptor.forClass(DescribeTableRequest.class);
+    verify(delegate).describeTable(captor.capture());
+    DescribeTableRequest sent = captor.getValue();
+    assertEquals(List.of("db", "t"), sent.getId());
+    assertEquals(3L, sent.getVersion());
+    assertEquals(Boolean.TRUE, sent.getCheckDeclared());
+    assertEquals(Boolean.FALSE, sent.getLoadDetailedMetadata());
+  }
+
+  @Test
+  void testDescribeTableForcesLoadDetailedMetadataFalse() {
+    // The Hive metastore backend cannot produce detailed metadata, so even when the caller asks
+    // for it (loadDetailedMetadata=true) the adapter must downgrade to the pointer-only describe;
+    // otherwise the underlying Hive2Namespace rejects it as "not supported for this
+    // implementation".
+    DescribeTableResponse expected = new DescribeTableResponse();
+    when(delegate.describeTable(any(DescribeTableRequest.class))).thenReturn(expected);
+
+    DescribeTableResponse actual =
+        ops.describeTable("db$t", DELIMITER, Optional.empty(), false, true);
+
+    assertSame(expected, actual);
+    ArgumentCaptor<DescribeTableRequest> captor =
+        ArgumentCaptor.forClass(DescribeTableRequest.class);
+    verify(delegate).describeTable(captor.capture());
+    assertEquals(Boolean.FALSE, captor.getValue().getLoadDetailedMetadata());
+  }
+
+  @Test
+  void testDeclareTableTranslatesRequestAndReturnsResponse() {
+    DeclareTableResponse expected = new DeclareTableResponse();
+    when(delegate.declareTable(any(DeclareTableRequest.class))).thenReturn(expected);
+
+    DeclareTableResponse actual =
+        ops.declareTable("db$t", DELIMITER, "s3://bucket/db/t", ImmutableMap.of("k", "v"));
+
+    assertSame(expected, actual);
+    ArgumentCaptor<DeclareTableRequest> captor = ArgumentCaptor.forClass(DeclareTableRequest.class);
+    verify(delegate).declareTable(captor.capture());
+    DeclareTableRequest sent = captor.getValue();
+    assertEquals(List.of("db", "t"), sent.getId());
+    assertEquals("s3://bucket/db/t", sent.getLocation());
+    assertEquals("v", sent.getProperties().get("k"));
+  }
+
+  @Test
+  void testDropTableTranslatesRequestAndReturnsResponse() {
+    DropTableResponse expected = new DropTableResponse();
+    when(delegate.dropTable(any(DropTableRequest.class))).thenReturn(expected);
+
+    DropTableResponse actual = ops.dropTable("db$t", DELIMITER);
+
+    assertSame(expected, actual);
+    ArgumentCaptor<DropTableRequest> captor = ArgumentCaptor.forClass(DropTableRequest.class);
+    verify(delegate).dropTable(captor.capture());
+    assertEquals(List.of("db", "t"), captor.getValue().getId());
+  }
+
+  @Test
+  void testDeregisterTableTranslatesRequestAndReturnsResponse() {
+    DeregisterTableResponse expected = new DeregisterTableResponse();
+    when(delegate.deregisterTable(any(DeregisterTableRequest.class))).thenReturn(expected);
+
+    DeregisterTableResponse actual = ops.deregisterTable("db$t", DELIMITER);
+
+    assertSame(expected, actual);
+    ArgumentCaptor<DeregisterTableRequest> captor =
+        ArgumentCaptor.forClass(DeregisterTableRequest.class);
+    verify(delegate).deregisterTable(captor.capture());
+    assertEquals(List.of("db", "t"), captor.getValue().getId());
+  }
+
+  @Test
+  void testTableExistsTrueWhenDelegateDoesNotThrow() {
+    HiveLanceTableOperations operations = new HiveLanceTableOperations(delegate);
+    assertTrue(operations.tableExists("db$t", DELIMITER));
+    verify(delegate).tableExists(any(TableExistsRequest.class));
+  }
+
+  @Test
+  void testTableExistsFalseWhenDelegateThrowsNotFound() {
+    org.mockito.Mockito.doThrow(new TableNotFoundException("missing", null, "db.t"))
+        .when(delegate)
+        .tableExists(any(TableExistsRequest.class));
+    assertFalse(ops.tableExists("db$t", DELIMITER));
+  }
+
+  @Test
+  void testAlterTableDropColumnsDelegates() {
+    AlterTableDropColumnsResponse expected = new AlterTableDropColumnsResponse();
+    when(delegate.alterTableDropColumns(any(AlterTableDropColumnsRequest.class)))
+        .thenReturn(expected);
+
+    AlterTableDropColumnsRequest request = new AlterTableDropColumnsRequest();
+    request.setColumns(List.of("c1"));
+    Object actual = ops.alterTable("db$t", DELIMITER, request);
+
+    assertSame(expected, actual);
+    assertEquals(List.of("db", "t"), request.getId());
+  }
+}

--- a/lance/lance-rest-server/build.gradle.kts
+++ b/lance/lance-rest-server/build.gradle.kts
@@ -58,6 +58,25 @@ lanceSparkBundleVersions.forEach { version ->
   }
 }
 
+// The standalone distribution packages this module's runtimeClasspath into libs/. The Hive
+// metastore client (via :lance:lance-common -> lance-namespace-hive2 -> hive-common) transitively
+// drags in legacy servlet containers/APIs that collide with Gravitino's Jetty 9.4.x + Servlet 3.1:
+//   - org.eclipse.jetty.aggregate:jetty-all:7.6.0 / org.mortbay.jetty / org.eclipse.jetty.orbit
+//     -> IncompatibleClassChangeError: Connector can not implement Container
+//   - javax.servlet:servlet-api:2.4 / javax.servlet:jsp-api:2.0
+//     -> NoSuchMethodError: HttpServletRequest.getDispatcherType() (a Servlet 3.0+ method)
+// Because libs/ is loaded alphabetically at runtime, these old jars shadow the modern ones and
+// crash the server (at startup, or on the first request). The Hive metastore client needs no
+// servlet container, so drop them from this module's classpath too (the excludes in lance-common
+// do not propagate to a consuming module's runtimeClasspath).
+configurations.all {
+  exclude(group = "org.eclipse.jetty.aggregate")
+  exclude(group = "org.eclipse.jetty.orbit")
+  exclude(group = "org.mortbay.jetty")
+  exclude(group = "javax.servlet", module = "servlet-api")
+  exclude(group = "javax.servlet", module = "jsp-api")
+}
+
 dependencies {
   implementation(project(":api"))
   implementation(project(":common")) {

--- a/lance/lance-rest-server/src/test/java/org/apache/gravitino/lance/integration/test/LanceRESTHiveCatalogIT.java
+++ b/lance/lance-rest-server/src/test/java/org/apache/gravitino/lance/integration/test/LanceRESTHiveCatalogIT.java
@@ -1,0 +1,442 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.lance.integration.test;
+
+import static org.apache.gravitino.lance.common.config.LanceConfig.HIVE_CLIENT_POOL_SIZE;
+import static org.apache.gravitino.lance.common.config.LanceConfig.HIVE_METASTORE_URIS;
+import static org.apache.gravitino.lance.common.config.LanceConfig.HIVE_WAREHOUSE;
+import static org.apache.gravitino.lance.common.config.LanceConfig.LANCE_CONFIG_PREFIX;
+import static org.apache.gravitino.lance.common.config.LanceConfig.NAMESPACE_BACKEND;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.gravitino.integration.test.container.ContainerSuite;
+import org.apache.gravitino.integration.test.container.HiveContainer;
+import org.apache.gravitino.integration.test.util.BaseIT;
+import org.apache.gravitino.integration.test.util.GravitinoITUtils;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.lance.namespace.LanceNamespace;
+import org.lance.namespace.client.apache.ApiClient;
+import org.lance.namespace.client.apache.api.TableApi;
+import org.lance.namespace.errors.ErrorCode;
+import org.lance.namespace.errors.LanceNamespaceException;
+import org.lance.namespace.model.AlterTableDropColumnsRequest;
+import org.lance.namespace.model.CreateNamespaceRequest;
+import org.lance.namespace.model.CreateNamespaceResponse;
+import org.lance.namespace.model.DeclareTableRequest;
+import org.lance.namespace.model.DeclareTableResponse;
+import org.lance.namespace.model.DeregisterTableRequest;
+import org.lance.namespace.model.DeregisterTableResponse;
+import org.lance.namespace.model.DescribeNamespaceRequest;
+import org.lance.namespace.model.DescribeNamespaceResponse;
+import org.lance.namespace.model.DescribeTableRequest;
+import org.lance.namespace.model.DescribeTableResponse;
+import org.lance.namespace.model.DropNamespaceRequest;
+import org.lance.namespace.model.DropTableRequest;
+import org.lance.namespace.model.ListNamespacesRequest;
+import org.lance.namespace.model.ListNamespacesResponse;
+import org.lance.namespace.model.ListTablesRequest;
+import org.lance.namespace.model.ListTablesResponse;
+import org.lance.namespace.model.NamespaceExistsRequest;
+import org.lance.namespace.model.RegisterTableRequest;
+import org.lance.namespace.model.TableExistsRequest;
+
+/**
+ * Integration test for the Lance REST server backed by a Hive Metastore.
+ *
+ * <p>This test launches the embedded Gravitino server with the Lance REST aux-service configured to
+ * use the {@code hive} namespace backend, pointed at a live Hive Metastore container. Unlike the
+ * Gravitino backend (3-level catalog/schema/table), the Hive backend uses the 2-level {@code
+ * db.table} model: a namespace is a single Hive database and a table is {@code db.table}.
+ *
+ * <p>Requires Docker; gated by the {@code gravitino-docker-test} tag.
+ */
+@Tag("gravitino-docker-test")
+@TestInstance(Lifecycle.PER_CLASS)
+public class LanceRESTHiveCatalogIT extends BaseIT {
+
+  private static final ContainerSuite CONTAINER_SUITE = ContainerSuite.getInstance();
+  private static final String DELIMITER = ".";
+
+  private final BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
+  private LanceNamespace ns;
+  private String warehouse;
+
+  @BeforeAll
+  public void startIntegrationTest() throws Exception {
+    // Start the Hive Metastore container before launching the Gravitino server so the
+    // metastore URI can be wired into the Lance REST aux-service config.
+    CONTAINER_SUITE.startHiveContainer();
+    String hiveIp = CONTAINER_SUITE.getHiveContainer().getContainerIpAddress();
+    String metastoreUris =
+        String.format("thrift://%s:%d", hiveIp, HiveContainer.HIVE_METASTORE_PORT);
+    this.warehouse =
+        String.format(
+            "hdfs://%s:%d/user/hive/warehouse", hiveIp, HiveContainer.HDFS_DEFAULTFS_PORT);
+
+    // Select and configure the Hive namespace backend for the Lance REST aux-service.
+    Map<String, String> hiveConfigs = new HashMap<>();
+    hiveConfigs.put(LANCE_CONFIG_PREFIX + NAMESPACE_BACKEND.getKey(), "hive2");
+    hiveConfigs.put(LANCE_CONFIG_PREFIX + HIVE_METASTORE_URIS.getKey(), metastoreUris);
+    hiveConfigs.put(LANCE_CONFIG_PREFIX + HIVE_WAREHOUSE.getKey(), warehouse);
+    hiveConfigs.put(LANCE_CONFIG_PREFIX + HIVE_CLIENT_POOL_SIZE.getKey(), "2");
+    registerCustomConfigs(hiveConfigs);
+
+    super.ignoreLanceAuxRestService = false;
+    super.startIntegrationTest();
+
+    Map<String, String> props = Maps.newHashMap();
+    props.put("uri", getLanceRestServiceUrl());
+    props.put("delimiter", DELIMITER);
+    this.ns = LanceNamespace.connect("rest", props, allocator);
+  }
+
+  @AfterAll
+  public void clean() throws Exception {
+    Exception failure = null;
+    try {
+      allocator.close();
+    } catch (Exception e) {
+      failure = e;
+    }
+    try {
+      super.stopIntegrationTest();
+    } catch (Exception e) {
+      if (failure == null) {
+        failure = e;
+      } else {
+        failure.addSuppressed(e);
+      }
+    }
+    if (failure != null) {
+      throw failure;
+    }
+  }
+
+  @Test
+  public void testNamespaceLifecycle() {
+    String db = GravitinoITUtils.genRandomName("lance_hive_ns").toLowerCase();
+
+    // Create the namespace (Hive database).
+    CreateNamespaceRequest createReq = new CreateNamespaceRequest();
+    createReq.addIdItem(db);
+    createReq.setProperties(ImmutableMap.of("database.description", "lance hive it"));
+    CreateNamespaceResponse createResp = ns.createNamespace(createReq);
+    Assertions.assertNotNull(createResp);
+
+    // It should now exist.
+    NamespaceExistsRequest existsReq = new NamespaceExistsRequest();
+    existsReq.addIdItem(db);
+    Assertions.assertDoesNotThrow(() -> ns.namespaceExists(existsReq));
+
+    // Describe should return the database properties (including the location).
+    DescribeNamespaceRequest describeReq = new DescribeNamespaceRequest();
+    describeReq.addIdItem(db);
+    DescribeNamespaceResponse describeResp = ns.describeNamespace(describeReq);
+    Assertions.assertNotNull(describeResp.getProperties());
+    Assertions.assertTrue(describeResp.getProperties().containsKey("database.location-uri"));
+
+    // The root namespace listing should include the new database.
+    ListNamespacesResponse listResp = ns.listNamespaces(new ListNamespacesRequest());
+    Assertions.assertTrue(listResp.getNamespaces().contains(db));
+
+    // Drop the (empty) namespace.
+    DropNamespaceRequest dropReq = new DropNamespaceRequest();
+    dropReq.addIdItem(db);
+    Assertions.assertDoesNotThrow(() -> ns.dropNamespace(dropReq));
+
+    // Describing it again should fail.
+    DescribeNamespaceRequest describeMissing = new DescribeNamespaceRequest();
+    describeMissing.addIdItem(db);
+    RuntimeException ex =
+        Assertions.assertThrows(
+            RuntimeException.class, () -> ns.describeNamespace(describeMissing));
+    assertLanceErrorCode(ex, ErrorCode.NAMESPACE_NOT_FOUND);
+  }
+
+  @Test
+  public void testCreateNamespaceModes() {
+    String db = GravitinoITUtils.genRandomName("lance_hive_modes").toLowerCase();
+    CreateNamespaceRequest createReq = new CreateNamespaceRequest();
+    createReq.addIdItem(db);
+    ns.createNamespace(createReq);
+
+    // create again with default (create) mode should fail.
+    RuntimeException ex =
+        Assertions.assertThrows(RuntimeException.class, () -> ns.createNamespace(createReq));
+    assertLanceErrorCode(ex, ErrorCode.NAMESPACE_ALREADY_EXISTS);
+
+    // exist_ok mode should succeed.
+    createReq.setMode("exist_ok");
+    Assertions.assertDoesNotThrow(() -> ns.createNamespace(createReq));
+
+    // overwrite mode should succeed (recreates the database).
+    createReq.setMode("overwrite");
+    Assertions.assertDoesNotThrow(() -> ns.createNamespace(createReq));
+
+    DropNamespaceRequest dropReq = new DropNamespaceRequest();
+    dropReq.addIdItem(db);
+    ns.dropNamespace(dropReq);
+  }
+
+  @Test
+  public void testDropNonEmptyNamespaceRestrictAndCascadeRejected() {
+    String db = GravitinoITUtils.genRandomName("lance_hive_nonempty").toLowerCase();
+    createDatabase(db);
+    declareTable(db, "t1", tableLocation(db, "t1"));
+
+    // RESTRICT (default) on a non-empty database should fail.
+    DropNamespaceRequest restrictReq = new DropNamespaceRequest();
+    restrictReq.addIdItem(db);
+    RuntimeException restrictEx =
+        Assertions.assertThrows(RuntimeException.class, () -> ns.dropNamespace(restrictReq));
+    assertLanceErrorCode(restrictEx, ErrorCode.INVALID_INPUT);
+
+    // CASCADE is not supported by the Hive backend.
+    DropNamespaceRequest cascadeReq = new DropNamespaceRequest();
+    cascadeReq.addIdItem(db);
+    cascadeReq.setBehavior("cascade");
+    RuntimeException cascadeEx =
+        Assertions.assertThrows(RuntimeException.class, () -> ns.dropNamespace(cascadeReq));
+    assertLanceErrorCode(cascadeEx, ErrorCode.INVALID_INPUT);
+
+    // Clean up: drop the table, then the now-empty database.
+    DropTableRequest dropTable = new DropTableRequest();
+    dropTable.setId(List.of(db, "t1"));
+    ns.dropTable(dropTable);
+    DropNamespaceRequest dropDb = new DropNamespaceRequest();
+    dropDb.addIdItem(db);
+    ns.dropNamespace(dropDb);
+  }
+
+  @Test
+  public void testDeclareDescribeAndListTables() {
+    String db = GravitinoITUtils.genRandomName("lance_hive_tables").toLowerCase();
+    createDatabase(db);
+
+    String location = tableLocation(db, "declared");
+    DeclareTableResponse declareResp = declareTable(db, "declared", location);
+    Assertions.assertEquals(location, declareResp.getLocation());
+    Assertions.assertEquals(Boolean.FALSE, declareResp.getManagedVersioning());
+
+    // describeTable must request loadDetailedMetadata=false; the Hive backend rejects detailed
+    // metadata because the metastore stores Lance tables as pointers without column schema.
+    DescribeTableResponse describeResp = describeTable(db, "declared");
+    Assertions.assertEquals(location, describeResp.getLocation());
+    Assertions.assertEquals(Boolean.FALSE, describeResp.getManagedVersioning());
+    Assertions.assertEquals("lance", describeResp.getProperties().get("table_type"));
+
+    // tableExists should pass for the declared table.
+    TableExistsRequest existsReq = new TableExistsRequest();
+    existsReq.setId(List.of(db, "declared"));
+    Assertions.assertDoesNotThrow(() -> ns.tableExists(existsReq));
+
+    // listTables should return the declared lance table.
+    ListTablesRequest listReq = new ListTablesRequest();
+    listReq.setId(List.of(db));
+    ListTablesResponse listResp = ns.listTables(listReq);
+    Assertions.assertEquals(Sets.newHashSet("declared"), listResp.getTables());
+
+    cleanupTable(db, "declared");
+    dropDatabase(db);
+  }
+
+  @Test
+  public void testDescribeTableDetailedMetadataDowngraded() {
+    String db = GravitinoITUtils.genRandomName("lance_hive_detailed").toLowerCase();
+    createDatabase(db);
+    String location = tableLocation(db, "detailed");
+    declareTable(db, "detailed", location);
+
+    // The Hive metastore backend only stores the table pointer and cannot open the Lance dataset to
+    // produce detailed metadata, so the adapter downgrades loadDetailedMetadata=true to a
+    // pointer-only describe rather than letting the underlying Hive2Namespace reject it. The call
+    // must succeed and return the pointer metadata.
+    DescribeTableRequest req = new DescribeTableRequest();
+    req.setId(List.of(db, "detailed"));
+    req.setLoadDetailedMetadata(true);
+    DescribeTableResponse resp = Assertions.assertDoesNotThrow(() -> ns.describeTable(req));
+    Assertions.assertEquals(location, resp.getLocation());
+    Assertions.assertEquals(Boolean.FALSE, resp.getManagedVersioning());
+    Assertions.assertEquals("lance", resp.getProperties().get("table_type"));
+
+    cleanupTable(db, "detailed");
+    dropDatabase(db);
+  }
+
+  @Test
+  public void testDeclareAndDeregisterTable() {
+    String db = GravitinoITUtils.genRandomName("lance_hive_register").toLowerCase();
+    createDatabase(db);
+
+    // The Hive backend creates tables through declareTable (metastore pointer); createTable and
+    // registerTable are not supported by the underlying lance-namespace-hive2 implementation.
+    String location = tableLocation(db, "declared");
+    declareTable(db, "declared", location);
+    Assertions.assertEquals(location, describeTable(db, "declared").getLocation());
+
+    // Deregister keeps no data (external table) and removes the metastore entry.
+    DeregisterTableRequest deregisterReq = new DeregisterTableRequest();
+    deregisterReq.setId(List.of(db, "declared"));
+    DeregisterTableResponse deregisterResp = ns.deregisterTable(deregisterReq);
+    Assertions.assertEquals(location, deregisterResp.getLocation());
+
+    // Describing the deregistered table should fail.
+    DescribeTableRequest describeReq = new DescribeTableRequest();
+    describeReq.setId(List.of(db, "declared"));
+    describeReq.setLoadDetailedMetadata(false);
+    RuntimeException ex =
+        Assertions.assertThrows(RuntimeException.class, () -> ns.describeTable(describeReq));
+    assertLanceErrorCode(ex, ErrorCode.TABLE_NOT_FOUND);
+
+    dropDatabase(db);
+  }
+
+  @Test
+  public void testRegisterTableUnsupported() {
+    String db = GravitinoITUtils.genRandomName("lance_hive_register_unsupported").toLowerCase();
+    createDatabase(db);
+
+    RegisterTableRequest registerReq = new RegisterTableRequest();
+    registerReq.setId(List.of(db, "registered"));
+    registerReq.setLocation(tableLocation(db, "registered"));
+    registerReq.setMode("create");
+    // registerTable is not supported by the Hive backend.
+    Assertions.assertThrows(RuntimeException.class, () -> ns.registerTable(registerReq));
+
+    dropDatabase(db);
+  }
+
+  @Test
+  public void testDropTable() {
+    String db = GravitinoITUtils.genRandomName("lance_hive_drop").toLowerCase();
+    createDatabase(db);
+    declareTable(db, "to_drop", tableLocation(db, "to_drop"));
+
+    DropTableRequest dropReq = new DropTableRequest();
+    dropReq.setId(List.of(db, "to_drop"));
+    Assertions.assertDoesNotThrow(() -> ns.dropTable(dropReq));
+
+    // Dropping again should fail with TABLE_NOT_FOUND.
+    RuntimeException ex =
+        Assertions.assertThrows(RuntimeException.class, () -> ns.dropTable(dropReq));
+    assertLanceErrorCode(ex, ErrorCode.TABLE_NOT_FOUND);
+
+    dropDatabase(db);
+  }
+
+  @Test
+  public void testTableNotFound() {
+    String db = GravitinoITUtils.genRandomName("lance_hive_missing").toLowerCase();
+    createDatabase(db);
+
+    TableExistsRequest existsReq = new TableExistsRequest();
+    existsReq.setId(List.of(db, "nope"));
+    RuntimeException ex =
+        Assertions.assertThrows(RuntimeException.class, () -> ns.tableExists(existsReq));
+    assertLanceErrorCode(ex, ErrorCode.TABLE_NOT_FOUND);
+
+    dropDatabase(db);
+  }
+
+  @Test
+  public void testAlterTableUnsupported() {
+    String db = GravitinoITUtils.genRandomName("lance_hive_alter").toLowerCase();
+    createDatabase(db);
+    declareTable(db, "altered", tableLocation(db, "altered"));
+
+    AlterTableDropColumnsRequest dropColumns = new AlterTableDropColumnsRequest();
+    dropColumns.setId(List.of(db, "altered"));
+    dropColumns.setColumns(List.of("value"));
+
+    // Column alteration is not supported by the Hive backend; the call must fail. The exact
+    // message is not asserted because it is surfaced through the REST client as an HTTP error.
+    TableApi tableApi = createTableApi();
+    Assertions.assertThrows(
+        Exception.class,
+        () ->
+            tableApi.alterTableDropColumns(
+                String.join(DELIMITER, db, "altered"), dropColumns, DELIMITER));
+
+    cleanupTable(db, "altered");
+    dropDatabase(db);
+  }
+
+  private void createDatabase(String db) {
+    CreateNamespaceRequest req = new CreateNamespaceRequest();
+    req.addIdItem(db);
+    ns.createNamespace(req);
+  }
+
+  private void dropDatabase(String db) {
+    DropNamespaceRequest req = new DropNamespaceRequest();
+    req.addIdItem(db);
+    ns.dropNamespace(req);
+  }
+
+  private DeclareTableResponse declareTable(String db, String table, String location) {
+    DeclareTableRequest req = new DeclareTableRequest();
+    req.setId(List.of(db, table));
+    req.setLocation(location);
+    return ns.declareTable(req);
+  }
+
+  private DescribeTableResponse describeTable(String db, String table) {
+    DescribeTableRequest req = new DescribeTableRequest();
+    req.setId(List.of(db, table));
+    req.setLoadDetailedMetadata(false);
+    return ns.describeTable(req);
+  }
+
+  private void cleanupTable(String db, String table) {
+    DropTableRequest req = new DropTableRequest();
+    req.setId(List.of(db, table));
+    Assertions.assertDoesNotThrow(() -> ns.dropTable(req));
+  }
+
+  private String tableLocation(String db, String table) {
+    return String.format("%s/%s.db/%s", warehouse, db, table);
+  }
+
+  private TableApi createTableApi() {
+    ApiClient apiClient = new ApiClient().setBasePath(getLanceRestServiceUrl());
+    return new TableApi(apiClient);
+  }
+
+  private String getLanceRestServiceUrl() {
+    return String.format("http://%s:%d/lance", "localhost", getLanceRESTServerPort());
+  }
+
+  private static void assertLanceErrorCode(RuntimeException exception, ErrorCode expected) {
+    Assertions.assertInstanceOf(LanceNamespaceException.class, exception);
+    Assertions.assertEquals(expected.getCode(), ((LanceNamespaceException) exception).getCode());
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

Adds a `hive2` namespace backend to the Lance REST server so Lance tables can be managed in a Hive Metastore (HMS), mirroring how the Iceberg REST server supports HMS.

The backend type is named `hive2` (rather than `hive`) after the `lance-namespace-hive2` implementation it wraps, since Lance also ships a separate `lance-namespace-hive3` implementation — this leaves room to add a `hive3` backend later without a confusing rename. The `hive-*` config keys are shared Hive Metastore settings (not tied to the backend name), so a future `hive3` backend can reuse them as-is.

- Registers `HIVE2("hive2", HiveLanceNamespaceWrapper.class)` in the existing `LanceNamespaceBackend` enum plug-point — no REST-server wiring changes needed.
- The backend is built on the official **`org.lance:lance-namespace-hive2`** implementation (`Hive2Namespace`, which implements `LanceNamespace`). Thin adapter classes (`HiveLanceNamespaceOperations`, `HiveLanceTableOperations`) translate Gravitino's flat-parameter operation interfaces onto the Lance Namespace request/response model; `HiveLanceNamespaceWrapper` builds the Hadoop `Configuration` from `LanceConfig` and owns the delegate.
- Namespace model: a namespace is a Hive database (1 level); a table is `db.table` (2 levels), registered as an `EXTERNAL_TABLE` with `table_type=lance`. It is a pointer registry (`managedVersioning=false`) — no Lance data is written by the catalog.
- New config keys on `LanceConfig`: `hive-metastore-uris`, `hive-warehouse`, `hive-client-pool-size` (default 3).
- `Hive2Namespace` implements `Closeable` (as of `lance-namespace-hive2` 0.4.1); `HiveLanceNamespaceWrapper#close()` closes the delegate so the pooled Hive metastore connections are released on shutdown instead of leaked (covered by `TestHiveLanceNamespaceWrapperClose`).
- `describeTable` always requests the lightweight pointer-only describe — the HMS backend stores only the table pointer (location + properties); the schema/stats live in the Lance dataset on storage.

**Dependency handling.** The backend uses **`lance-namespace-hive2:0.4.1`**, which is built against `lance-namespace 0.7.7` and pulls Hadoop 2.8.5 + an embedded-metastore stack. The build:
- excludes its Hadoop 2.8.5 / Derby / DataNucleus so the module runs on Gravitino's Hadoop 3 metastore client;
- excludes the transitive `lance-namespace-core`/`apache-client` 0.7.7 so **0.7.5** (the version Gravitino standardizes on, declared via `libs.lance.namespace.core`) remains the single Lance Namespace version on the classpath (verified on `runtimeClasspath`), and pins Arrow to 18.x;
- drops legacy Netty fat-jars (`netty-all` 4.0.x / `netty` 3.x) that otherwise shadow `netty-buffer` 4.1.x and break `arrow-memory-netty` initialization on JDK 17;
- drops the legacy servlet stack that `hive-common` drags in transitively (`jetty-all` 7.6.0 / mortbay / orbit Jetty, `javax.servlet:servlet-api:2.4`, `jsp-api:2.0`) from both `lance-common` and `lance-rest-server` — packaged `libs/` jars load alphabetically, so these otherwise shadow Gravitino's Jetty 9.4 / Servlet 3.1 and crash the standalone server (`IncompatibleClassChangeError` at startup, or `NoSuchMethodError: HttpServletRequest.getDispatcherType()` on the first request). Guarded by `TestHiveClasspathHygiene`.

### Why are the changes needed?

Lance tables currently can only be cataloged through the Gravitino backend. Many deployments already run a Hive Metastore as their central metadata service; this lets them register and discover Lance tables there without standing up extra infrastructure. Building on the official `lance-namespace-hive2` keeps behavior aligned with the upstream Lance ecosystem.

Fix: #11782

### Does this PR introduce _any_ user-facing change?

Yes — new property keys:
- `gravitino.lance-rest.namespace-backend=hive2`
- `gravitino.lance-rest.hive-metastore-uris`
- `gravitino.lance-rest.hive-warehouse`
- `gravitino.lance-rest.hive-client-pool-size`

New dependency version entry: `lance-namespace-impls = 0.4.1` (`lance-namespace` stays at 0.7.5).

Note: with the Hive backend, table creation is performed via **`declareTable`** (a metastore pointer). `createTable`, `registerTable`, and column alteration are reported as unsupported by the underlying `lance-namespace-hive2` implementation, and `describeTable` returns the pointer-only metadata (the schema lives in the Lance dataset on storage, not the catalog).

### How was this patch tested?

- Unit tests (mocked `Hive2Namespace`) covering the namespace/table operation adapters, identifier parsing, config/backend wiring, wrapper close behavior, and classpath hygiene: `:lance:lance-common:test` and `:lance:lance-rest-server:test` (with `-PskipITs`) — all pass on latest `main`.
- A Docker-gated integration test `LanceRESTHiveCatalogIT` (`@Tag("gravitino-docker-test")`) that launches the embedded Gravitino server with the Lance REST aux-service on the `hive` backend against a live Hive Metastore container and exercises the namespace/table lifecycle. (Requires Docker; run with `-PskipDockerTests=false`.)
