### PR TITLE
[#11781] fix(idp-basic): Cache Basic auth group names by username

### DIFF
--- a/core/src/main/java/org/apache/gravitino/Configs.java
+++ b/core/src/main/java/org/apache/gravitino/Configs.java
@@ -245,6 +245,30 @@ public class Configs {
               ConfigConstants.NOT_BLANK_ERROR_MSG)
           .createWithDefault(Lists.newArrayList("simple"));
 
+  public static final long DEFAULT_BASIC_AUTHENTICATION_GROUPS_CACHE_TTL_SECS = 3600L;
+
+  public static final ConfigEntry<Long> BASIC_AUTHENTICATION_GROUPS_CACHE_TTL_SECS =
+      new ConfigBuilder("gravitino.authenticator.basic.groupsCacheTtlSecs")
+          .doc(
+              "The expiration time in seconds for the built-in IdP Basic authentication "
+                  + "group-name cache keyed by username")
+          .version(ConfigConstants.VERSION_1_3_0)
+          .longConf()
+          .checkValue(value -> value > 0, ConfigConstants.POSITIVE_NUMBER_ERROR_MSG)
+          .createWithDefault(DEFAULT_BASIC_AUTHENTICATION_GROUPS_CACHE_TTL_SECS);
+
+  public static final long DEFAULT_BASIC_AUTHENTICATION_GROUPS_CACHE_SIZE = 10000L;
+
+  public static final ConfigEntry<Long> BASIC_AUTHENTICATION_GROUPS_CACHE_SIZE =
+      new ConfigBuilder("gravitino.authenticator.basic.groupsCacheSize")
+          .doc(
+              "The maximum number of cached usernames for the built-in IdP Basic authentication "
+                  + "group-name cache")
+          .version(ConfigConstants.VERSION_1_3_0)
+          .longConf()
+          .checkValue(value -> value > 0, ConfigConstants.POSITIVE_NUMBER_ERROR_MSG)
+          .createWithDefault(DEFAULT_BASIC_AUTHENTICATION_GROUPS_CACHE_SIZE);
+
   public static final ConfigEntry<Long> STORE_TRANSACTION_MAX_SKEW_TIME =
       new ConfigBuilder("gravitino.entity.store.maxTransactionSkewTimeMs")
           .doc("The maximum skew time of transactions in milliseconds")

--- a/docs/security/how-to-authenticate.md
+++ b/docs/security/how-to-authenticate.md
@@ -94,6 +94,10 @@ The Web UI uses the first entry in `gravitino.authenticators` from `/configs`. W
 the login page shows a username and password form backed by built-in IdP user metadata. See
 [built-in IDP Web UI](how-to-use-built-in-idp.md#web-ui).
 
+Built-in IdP Basic authentication caches each user's group names keyed by username. Tune the cache
+with `gravitino.authenticator.basic.groupsCacheTtlSecs` and
+`gravitino.authenticator.basic.groupsCacheSize` (see [built-in IDP configuration](how-to-use-built-in-idp.md#configuration)).
+
 ### OAuth Mode
 
 Gravitino supports external OAuth 2.0 servers with two token validation methods:

--- a/docs/security/how-to-use-built-in-idp.md
+++ b/docs/security/how-to-use-built-in-idp.md
@@ -80,11 +80,13 @@ Before you call `/api/idp/*`, ensure the following:
 
 Set service admins in `gravitino.conf` (see also [Prerequisites](#prerequisites)):
 
-| Configuration item                        | Description                                                              | Example                                     |
-|-------------------------------------------|--------------------------------------------------------------------------|---------------------------------------------|
-| `gravitino.authenticators`                | Must include `basic` when the built-in IdP plugin is enabled             | `basic`                                     |
-| `gravitino.server.rest.extensionPackages` | Registers built-in IdP REST APIs                                         | `org.apache.gravitino.idp.web.rest.feature` |
-| `gravitino.authorization.serviceAdmins`   | Comma-separated service admin that can call built-in IDP management APIs | `admin`                                     |
+| Configuration item                                 | Description                                                              | Example                                     |
+|----------------------------------------------------|--------------------------------------------------------------------------|---------------------------------------------|
+| `gravitino.authenticators`                         | Must include `basic` when the built-in IdP plugin is enabled             | `basic`                                     |
+| `gravitino.server.rest.extensionPackages`          | Registers built-in IdP REST APIs                                         | `org.apache.gravitino.idp.web.rest.feature` |
+| `gravitino.authorization.serviceAdmins`            | Comma-separated service admin that can call built-in IDP management APIs | `admin`                                     |
+| `gravitino.authenticator.basic.groupsCacheTtlSecs` | Expiration in seconds for cached group names keyed by username.          | `3600` (default)                            |
+| `gravitino.authenticator.basic.groupsCacheSize`    | Maximum number of cached usernames for group names.                      | `10000` (default)                           |
 
 Example:
 

--- a/plugins/idp-basic/src/main/java/org/apache/gravitino/idp/IdpUserGroupManager.java
+++ b/plugins/idp-basic/src/main/java/org/apache/gravitino/idp/IdpUserGroupManager.java
@@ -60,6 +60,7 @@ public class IdpUserGroupManager implements Closeable {
   private final IdpGarbageCollector garbageCollector;
   private final IdGenerator idGenerator;
   private final PasswordHasher passwordHasher;
+  private final IdpUserGroupsCache userGroupsCache;
 
   /**
    * Returns the shared built-in IdP user and group manager for the server process.
@@ -83,6 +84,7 @@ public class IdpUserGroupManager implements Closeable {
     this.relationalStorage = new IdpRelationalStorage(config);
     this.idGenerator = idGenerator;
     this.passwordHasher = PasswordHasherFactory.create();
+    this.userGroupsCache = new IdpUserGroupsCache(config);
     this.garbageCollector = new IdpGarbageCollector(config);
     this.garbageCollector.start();
   }
@@ -137,7 +139,11 @@ public class IdpUserGroupManager implements Closeable {
    * @return True if the user was removed, false if it did not exist.
    */
   public boolean removeUser(String username) {
-    return USER_SERVICE.deleteIdpUser(username);
+    boolean removed = USER_SERVICE.deleteIdpUser(username);
+    if (removed) {
+      userGroupsCache.invalidate(username);
+    }
+    return removed;
   }
 
   /**
@@ -150,18 +156,31 @@ public class IdpUserGroupManager implements Closeable {
     return USER_SERVICE.getIdpUser(username);
   }
 
+  /**
+   * Authenticates credentials against built-in IdP user metadata.
+   *
+   * <p>Password verification always hits storage. Group membership is served from {@link
+   * IdpUserGroupsCache} keyed by username.
+   *
+   * @param username The username.
+   * @param password The plaintext password.
+   * @return The authenticated built-in IdP user.
+   */
   public IdpUser authenticate(String username, String password) {
     try {
-      IdpUser user = USER_SERVICE.getIdpUser(username);
-      if (user.passwordHash() == null || !passwordHasher.verify(password, user.passwordHash())) {
+      IdpUserPO userPO = USER_SERVICE.getIdpUserByUsername(username);
+      if (userPO.getPasswordHash() == null
+          || !passwordHasher.verify(password, userPO.getPasswordHash())) {
         throw new UnauthorizedException(
             "Invalid username or password", AuthConstants.AUTHORIZATION_BASIC_HEADER.trim());
       }
-      return user;
     } catch (NotFoundException e) {
       throw new UnauthorizedException(
           "Invalid username or password", AuthConstants.AUTHORIZATION_BASIC_HEADER.trim());
     }
+    return new IdpUser(
+        username,
+        userGroupsCache.get(username, () -> USER_SERVICE.listGroupNamesByUsername(username)));
   }
 
   /**
@@ -195,7 +214,12 @@ public class IdpUserGroupManager implements Closeable {
    * @return True if the group was removed, false if it did not exist.
    */
   public boolean removeGroup(String groupName, boolean force) {
-    return GROUP_SERVICE.deleteIdpGroup(groupName, force);
+    List<String> members = GROUP_SERVICE.listUsernamesByGroupName(groupName);
+    boolean removed = GROUP_SERVICE.deleteIdpGroup(groupName, force, members);
+    if (removed) {
+      userGroupsCache.invalidate(members);
+    }
+    return removed;
   }
 
   /**
@@ -225,6 +249,8 @@ public class IdpUserGroupManager implements Closeable {
         !usersToAddList.isEmpty() || !usersToRemoveList.isEmpty(),
         "usersToAdd and usersToRemove cannot both be empty");
     GROUP_SERVICE.changeGroupMembership(groupName, usersToAddList, usersToRemoveList);
+    userGroupsCache.invalidate(usersToAddList);
+    userGroupsCache.invalidate(usersToRemoveList);
     return getGroup(groupName);
   }
 

--- a/plugins/idp-basic/src/main/java/org/apache/gravitino/idp/IdpUserGroupsCache.java
+++ b/plugins/idp-basic/src/main/java/org/apache/gravitino/idp/IdpUserGroupsCache.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.idp;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+import org.apache.gravitino.Config;
+import org.apache.gravitino.Configs;
+import org.apache.gravitino.cache.CaffeineGravitinoCache;
+import org.apache.gravitino.cache.GravitinoCache;
+
+/** Caches built-in IdP group names keyed by username. */
+public class IdpUserGroupsCache {
+
+  private final GravitinoCache<String, List<String>> groupNamesCache;
+
+  /**
+   * Creates a user-groups cache using Basic authentication cache settings from the server config.
+   *
+   * @param config The server configuration.
+   */
+  public IdpUserGroupsCache(Config config) {
+    long expirationSecs = config.get(Configs.BASIC_AUTHENTICATION_GROUPS_CACHE_TTL_SECS);
+    long maxSize = config.get(Configs.BASIC_AUTHENTICATION_GROUPS_CACHE_SIZE);
+    this.groupNamesCache =
+        new CaffeineGravitinoCache<>(TimeUnit.SECONDS.toMillis(expirationSecs), maxSize);
+  }
+
+  /**
+   * Returns cached group names for the given username, loading them when absent.
+   *
+   * @param username The username.
+   * @param loader Supplies the group names on cache miss.
+   * @return The group names for the user.
+   */
+  public List<String> get(String username, Supplier<List<String>> loader) {
+    return groupNamesCache.get(username, ignored -> loader.get());
+  }
+
+  /**
+   * Invalidates cached group names for the given username.
+   *
+   * @param username The username whose cached group names should be removed.
+   */
+  public void invalidate(String username) {
+    invalidate(Collections.singleton(username));
+  }
+
+  /**
+   * Invalidates cached group names for the given usernames.
+   *
+   * @param usernames The usernames whose cached group names should be removed.
+   */
+  public void invalidate(Collection<String> usernames) {
+    if (usernames == null || usernames.isEmpty()) {
+      return;
+    }
+    groupNamesCache.runInvalidationBatch(
+        () -> {
+          for (String username : usernames) {
+            if (username != null) {
+              groupNamesCache.invalidate(username);
+            }
+          }
+        });
+  }
+}

--- a/plugins/idp-basic/src/main/java/org/apache/gravitino/idp/storage/service/IdpGroupMetaService.java
+++ b/plugins/idp-basic/src/main/java/org/apache/gravitino/idp/storage/service/IdpGroupMetaService.java
@@ -103,13 +103,14 @@ public class IdpGroupMetaService {
    * @param groupName the group name
    * @param force when false, rejects deletion if the group still has members; when true, removes
    *     memberships and deletes the group
+   * @param members the usernames that currently belong to the group
    * @return true if the group was deleted
    */
   @Monitored(
       metricsSource = GRAVITINO_RELATIONAL_STORE_METRIC_NAME,
       baseMetricName = "deleteIdpGroup")
-  public boolean deleteIdpGroup(String groupName, boolean force) {
-    if (!force && !listUsernamesByGroupName(groupName).isEmpty()) {
+  public boolean deleteIdpGroup(String groupName, boolean force, List<String> members) {
+    if (!force && !members.isEmpty()) {
       throw new IllegalStateException(
           String.format("IdP group %s is not empty, use force=true to delete it", groupName));
     }

--- a/plugins/idp-basic/src/test/java/org/apache/gravitino/idp/TestIdpUserGroupManager.java
+++ b/plugins/idp-basic/src/test/java/org/apache/gravitino/idp/TestIdpUserGroupManager.java
@@ -41,6 +41,7 @@ import org.apache.gravitino.Config;
 import org.apache.gravitino.auth.AuthenticatorType;
 import org.apache.gravitino.exceptions.AlreadyExistsException;
 import org.apache.gravitino.exceptions.NotFoundException;
+import org.apache.gravitino.exceptions.UnauthorizedException;
 import org.apache.gravitino.idp.basic.IdpCredentialValidator;
 import org.apache.gravitino.idp.model.IdpGroup;
 import org.apache.gravitino.idp.model.IdpUser;
@@ -278,6 +279,63 @@ public class TestIdpUserGroupManager {
         "initAdminSame1", manager.authenticate("initAdminSame1", VALID_PASSWORD).name());
     Assertions.assertEquals(
         "initAdminSame2", manager.authenticate("initAdminSame2", VALID_PASSWORD).name());
+  }
+
+  @Test
+  public void testAuthWithGroups() throws IOException {
+    manager.addUser("testAuthPrincipalUser", VALID_PASSWORD);
+    manager.addGroup("testAuthPrincipalGroup");
+    manager.changeGroupMembership(
+        "testAuthPrincipalGroup", Lists.newArrayList("testAuthPrincipalUser"), null);
+
+    IdpUser user = manager.authenticate("testAuthPrincipalUser", VALID_PASSWORD);
+
+    Assertions.assertEquals("testAuthPrincipalUser", user.name());
+    Assertions.assertEquals(1, user.groupNames().size());
+    Assertions.assertEquals("testAuthPrincipalGroup", user.groupNames().get(0));
+  }
+
+  @Test
+  public void testAuthWrongPassword() throws IOException {
+    manager.addUser("testAuthPwdVerifyUser", VALID_PASSWORD);
+
+    manager.authenticate("testAuthPwdVerifyUser", VALID_PASSWORD);
+    manager.authenticate("testAuthPwdVerifyUser", VALID_PASSWORD);
+
+    Assertions.assertThrows(
+        UnauthorizedException.class,
+        () -> manager.authenticate("testAuthPwdVerifyUser", "wrong-password"));
+  }
+
+  @Test
+  public void testAuthOldPassword() throws IOException {
+    manager.addUser("testAuthPwdChangeUser", VALID_PASSWORD);
+
+    manager.authenticate("testAuthPwdChangeUser", VALID_PASSWORD);
+    manager.changePassword("testAuthPwdChangeUser", NEW_VALID_PASSWORD);
+
+    Assertions.assertThrows(
+        UnauthorizedException.class,
+        () -> manager.authenticate("testAuthPwdChangeUser", VALID_PASSWORD));
+
+    IdpUser user = manager.authenticate("testAuthPwdChangeUser", NEW_VALID_PASSWORD);
+    Assertions.assertEquals("testAuthPwdChangeUser", user.name());
+  }
+
+  @Test
+  public void testInvalidateGroupsCache() throws IOException {
+    manager.addUser("testGroupsCacheUser", VALID_PASSWORD);
+
+    IdpUser first = manager.authenticate("testGroupsCacheUser", VALID_PASSWORD);
+    Assertions.assertEquals(0, first.groupNames().size());
+
+    manager.addGroup("testGroupsCacheGroup");
+    manager.changeGroupMembership(
+        "testGroupsCacheGroup", Lists.newArrayList("testGroupsCacheUser"), null);
+
+    IdpUser second = manager.authenticate("testGroupsCacheUser", VALID_PASSWORD);
+    Assertions.assertEquals(1, second.groupNames().size());
+    Assertions.assertEquals("testGroupsCacheGroup", second.groupNames().get(0));
   }
 
   private static Config createH2Config(Path h2Path) {

--- a/plugins/idp-basic/src/test/java/org/apache/gravitino/idp/TestIdpUserGroupManager.java
+++ b/plugins/idp-basic/src/test/java/org/apache/gravitino/idp/TestIdpUserGroupManager.java
@@ -338,6 +338,23 @@ public class TestIdpUserGroupManager {
     Assertions.assertEquals("testGroupsCacheGroup", second.groupNames().get(0));
   }
 
+  @Test
+  public void testRemoveUserCache() throws IOException {
+    manager.addUser("testRemoveUserCache", VALID_PASSWORD);
+    manager.addGroup("testRemoveUserCacheGroup");
+    manager.changeGroupMembership(
+        "testRemoveUserCacheGroup", Lists.newArrayList("testRemoveUserCache"), null);
+
+    IdpUser beforeRemove = manager.authenticate("testRemoveUserCache", VALID_PASSWORD);
+    Assertions.assertEquals(1, beforeRemove.groupNames().size());
+
+    Assertions.assertTrue(manager.removeUser("testRemoveUserCache"));
+    manager.addUser("testRemoveUserCache", VALID_PASSWORD);
+
+    IdpUser afterRecreate = manager.authenticate("testRemoveUserCache", VALID_PASSWORD);
+    Assertions.assertEquals(0, afterRecreate.groupNames().size());
+  }
+
   private static Config createH2Config(Path h2Path) {
     Config backendConfig = new Config(false) {};
     backendConfig.set(ENTITY_STORE, RELATIONAL_ENTITY_STORE);

--- a/plugins/idp-basic/src/test/java/org/apache/gravitino/idp/TestIdpUserGroupsCache.java
+++ b/plugins/idp-basic/src/test/java/org/apache/gravitino/idp/TestIdpUserGroupsCache.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.idp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.gravitino.Config;
+import org.apache.gravitino.Configs;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class TestIdpUserGroupsCache {
+
+  private static final String USERNAME = "alice";
+
+  private Config config;
+  private IdpUserGroupsCache userGroupsCache;
+
+  @BeforeEach
+  void setUp() {
+    config = new Config(false) {};
+    config.set(Configs.BASIC_AUTHENTICATION_GROUPS_CACHE_TTL_SECS, 60L);
+    config.set(Configs.BASIC_AUTHENTICATION_GROUPS_CACHE_SIZE, 100L);
+    userGroupsCache = new IdpUserGroupsCache(config);
+  }
+
+  @Test
+  void testCacheHit() {
+    AtomicInteger loadCount = new AtomicInteger();
+    List<String> groupNames = Arrays.asList("group-a", "group-b");
+
+    userGroupsCache.get(USERNAME, () -> load(loadCount, groupNames));
+    userGroupsCache.get(USERNAME, () -> load(loadCount, groupNames));
+
+    assertEquals(1, loadCount.get());
+  }
+
+  @Test
+  void testInvalidateUser() {
+    AtomicInteger loadCount = new AtomicInteger();
+    List<String> groupNames = Arrays.asList("group-a");
+
+    userGroupsCache.get(USERNAME, () -> load(loadCount, groupNames));
+    userGroupsCache.invalidate(USERNAME);
+    userGroupsCache.get(USERNAME, () -> load(loadCount, groupNames));
+
+    assertEquals(2, loadCount.get());
+  }
+
+  @Test
+  void testInvalidateUsers() {
+    AtomicInteger loadCount = new AtomicInteger();
+    List<String> groupNames = Arrays.asList("group-a");
+
+    userGroupsCache.get(USERNAME, () -> load(loadCount, groupNames));
+    userGroupsCache.invalidate(Collections.singletonList(USERNAME));
+    userGroupsCache.get(USERNAME, () -> load(loadCount, groupNames));
+
+    assertEquals(2, loadCount.get());
+  }
+
+  private static List<String> load(AtomicInteger loadCount, List<String> groupNames) {
+    loadCount.incrementAndGet();
+    return groupNames;
+  }
+}

--- a/plugins/idp-basic/src/test/java/org/apache/gravitino/idp/auth/TestBasicAuthenticationIntegration.java
+++ b/plugins/idp-basic/src/test/java/org/apache/gravitino/idp/auth/TestBasicAuthenticationIntegration.java
@@ -40,6 +40,7 @@ import java.util.Base64;
 import java.util.Comparator;
 import java.util.stream.Stream;
 import org.apache.gravitino.Config;
+import org.apache.gravitino.Configs;
 import org.apache.gravitino.UserPrincipal;
 import org.apache.gravitino.auth.AuthConstants;
 import org.apache.gravitino.exceptions.UnauthorizedException;
@@ -75,6 +76,8 @@ class TestBasicAuthenticationIntegration {
     config.set(ENTITY_RELATIONAL_JDBC_BACKEND_WAIT_MILLISECONDS, 1000L);
     config.set(STORE_DELETE_AFTER_TIME, 20 * 60 * 1000L);
     config.set(CACHE_ENABLED, false);
+    config.set(Configs.BASIC_AUTHENTICATION_GROUPS_CACHE_TTL_SECS, 60L);
+    config.set(Configs.BASIC_AUTHENTICATION_GROUPS_CACHE_SIZE, 100L);
 
     userGroupManager = IdpUserGroupManagerTestHelper.newManager(config, RandomIdGenerator.INSTANCE);
     userGroupManager.addUser(USER, PASSWORD);

--- a/plugins/idp-basic/src/test/java/org/apache/gravitino/idp/auth/TestBasicAuthenticator.java
+++ b/plugins/idp-basic/src/test/java/org/apache/gravitino/idp/auth/TestBasicAuthenticator.java
@@ -108,10 +108,10 @@ class TestBasicAuthenticator {
   @Test
   void testValidCredentials() throws Exception {
     IdpUserGroupManager userGroupManager = mock(IdpUserGroupManager.class);
+    String authHeader = basicAuthHeader("alice", "Passw0rd-For-Alice");
     when(userGroupManager.authenticate("alice", "Passw0rd-For-Alice"))
         .thenReturn(new IdpUser("alice", Arrays.asList("group-a", "group-b")));
     BasicAuthenticator authenticator = authenticator(userGroupManager);
-    String authHeader = basicAuthHeader("alice", "Passw0rd-For-Alice");
 
     UserPrincipal principal =
         (UserPrincipal) authenticator.authenticateToken(basicAuthBytes(authHeader));
@@ -194,14 +194,16 @@ class TestBasicAuthenticator {
     when(userGroupManager.authenticate("alice", "Passw0rd-For-Alice"))
         .thenReturn(new IdpUser("alice", Arrays.asList()));
     BasicAuthenticator authenticator = authenticator(userGroupManager);
-    String credential =
-        "  "
-            + Base64.getEncoder()
-                .encodeToString("alice:Passw0rd-For-Alice".getBytes(StandardCharsets.UTF_8))
-            + "  ";
 
     UserPrincipal principal =
-        (UserPrincipal) authenticator.authenticateToken(basicAuthBytesWithCredential(credential));
+        (UserPrincipal)
+            authenticator.authenticateToken(
+                basicAuthBytesWithCredential(
+                    "  "
+                        + Base64.getEncoder()
+                            .encodeToString(
+                                "alice:Passw0rd-For-Alice".getBytes(StandardCharsets.UTF_8))
+                        + "  "));
 
     assertEquals("alice", principal.getName());
   }
@@ -222,6 +224,7 @@ class TestBasicAuthenticator {
   @Test
   void testWrongPassword() throws Exception {
     IdpUserGroupManager userGroupManager = mock(IdpUserGroupManager.class);
+    String authHeader = basicAuthHeader("alice", "Passw0rd-For-Alice");
     when(userGroupManager.authenticate("alice", "Passw0rd-For-Alice"))
         .thenThrow(
             new UnauthorizedException(
@@ -231,9 +234,7 @@ class TestBasicAuthenticator {
     UnauthorizedException exception =
         assertThrows(
             UnauthorizedException.class,
-            () ->
-                authenticator.authenticateToken(
-                    basicAuthBytes(basicAuthHeader("alice", "Passw0rd-For-Alice"))));
+            () -> authenticator.authenticateToken(basicAuthBytes(authHeader)));
 
     assertUnauthorized(exception);
   }
@@ -261,12 +262,11 @@ class TestBasicAuthenticator {
     return authenticator(mock(IdpUserGroupManager.class));
   }
 
-  private static BasicAuthenticator authenticator(IdpUserGroupManager userGroupManager)
-      throws Exception {
+  private BasicAuthenticator authenticator(IdpUserGroupManager userGroupManager) throws Exception {
     BasicAuthenticator authenticator = new BasicAuthenticator();
-    Field field = BasicAuthenticator.class.getDeclaredField("userGroupManager");
-    field.setAccessible(true);
-    field.set(authenticator, userGroupManager);
+    Field userGroupManagerField = BasicAuthenticator.class.getDeclaredField("userGroupManager");
+    userGroupManagerField.setAccessible(true);
+    userGroupManagerField.set(authenticator, userGroupManager);
     return authenticator;
   }
 }

--- a/plugins/idp-basic/src/test/java/org/apache/gravitino/idp/storage/service/TestIdpGroupMetaService.java
+++ b/plugins/idp-basic/src/test/java/org/apache/gravitino/idp/storage/service/TestIdpGroupMetaService.java
@@ -121,9 +121,12 @@ class TestIdpGroupMetaService extends AbstractIdpMetaServiceTest {
     IdpGroupMetaService groupMetaService = IdpGroupMetaService.getInstance();
 
     assertThrows(
-        IllegalStateException.class, () -> groupMetaService.deleteIdpGroup("group1", false));
+        IllegalStateException.class,
+        () -> groupMetaService.deleteIdpGroup("group1", false, List.of("user1", "user2")));
 
-    runServiceCall(() -> assertTrue(groupMetaService.deleteIdpGroup("group1", true)));
+    runServiceCall(
+        () ->
+            assertTrue(groupMetaService.deleteIdpGroup("group1", true, List.of("user1", "user2"))));
     assertNull(idpGroupMetaMapper.selectIdpGroup("group1"));
     assertEquals(4, countGroups());
     assertEquals(8, countUserGroupRels());


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add `IdpUserGroupsCache` to cache built-in IdP group names keyed by username during Basic authentication, reducing relational store lookups on repeated requests. Password verification still uses `getIdpUserByUsername` on every request; only group membership is cached. Invalidate cached group names when users are removed, group membership changes, or a group is force-deleted. Add server configs `gravitino.authenticator.basic.groupsCacheTtlSecs` (default 3600) and `gravitino.authenticator.basic.groupsCacheSize` (default 10000), documented in the built-in IDP guide.

### Why are the changes needed?

Basic authentication previously loaded full user metadata (including group membership) from the relational store on every request. Group authorization adds extra DB work compared to user-only checks. This change caches group names per username while preserving per-request password verification, as discussed in #11781.

Fix: #11781

### Does this PR introduce _any_ user-facing change?

Yes, two new optional configuration keys:

- `gravitino.authenticator.basic.groupsCacheTtlSecs` — TTL in seconds for the per-username group names cache (default 3600)
- `gravitino.authenticator.basic.groupsCacheSize` — maximum number of cached usernames (default 10000)

No existing keys or default authentication behavior change.

### How was this patch tested?

- `./gradlew :plugins:idp-basic:test -PskipITs`
- `TestIdpUserGroupsCache` — cache hit/miss and invalidation
- `TestIdpUserGroupManager` — auth with groups, wrong/old password, cache invalidation on membership change and user removal
- `TestBasicAuthenticator` and `TestBasicAuthenticationIntegration`