### PR TITLE
[#11453] feat(catalog): Add generic read-only JDBC catalog

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1205,6 +1205,7 @@ tasks {
       ":catalogs:catalog-glue:copyLibAndConfig",
       ":catalogs:catalog-hive:copyLibAndConfig",
       ":catalogs:catalog-jdbc-doris:copyLibAndConfig",
+      ":catalogs:catalog-jdbc-generic:copyLibAndConfig",
       ":catalogs:catalog-jdbc-mysql:copyLibAndConfig",
       ":catalogs:catalog-jdbc-postgresql:copyLibAndConfig",
       ":catalogs:catalog-jdbc-starrocks:copyLibAndConfig",

--- a/catalogs/catalog-jdbc-generic/build.gradle.kts
+++ b/catalogs/catalog-jdbc-generic/build.gradle.kts
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+description = "catalog-jdbc-generic"
+
+plugins {
+  `maven-publish`
+  id("java")
+  id("idea")
+}
+
+dependencies {
+  compileOnly(project(":api"))
+  compileOnly(project(":common"))
+  compileOnly(project(":core"))
+
+  implementation(project(":catalogs:catalog-jdbc-common")) {
+    exclude(group = "*")
+  }
+
+  implementation(libs.bundles.log4j)
+  implementation(libs.commons.collections4)
+  implementation(libs.commons.lang3)
+  implementation(libs.guava)
+
+  testImplementation(project(":api"))
+  testImplementation(project(":common"))
+  testImplementation(project(":core"))
+  testImplementation(project(":catalogs:catalog-jdbc-common"))
+
+  testImplementation(libs.h2db)
+  testImplementation(libs.junit.jupiter.api)
+
+  testRuntimeOnly(libs.junit.jupiter.engine)
+}
+
+tasks {
+  register("runtimeJars", Copy::class) {
+    from(configurations.runtimeClasspath)
+    into("build/libs")
+  }
+
+  val copyCatalogLibs by registering(Copy::class) {
+    dependsOn("jar", "runtimeJars")
+    from("build/libs") {
+      exclude("guava-*.jar")
+      exclude("log4j-*.jar")
+      exclude("slf4j-*.jar")
+      exclude("error_prone_annotations-*.jar")
+    }
+    into("$rootDir/distribution/package/catalogs/jdbc-generic/libs")
+  }
+
+  val copyCatalogConfig by registering(Copy::class) {
+    from("src/main/resources")
+    into("$rootDir/distribution/package/catalogs/jdbc-generic/conf")
+
+    include("jdbc-generic.conf")
+
+    exclude { details ->
+      details.file.isDirectory()
+    }
+
+    fileMode = 0b111101101
+  }
+
+  register("copyLibAndConfig", Copy::class) {
+    dependsOn(copyCatalogLibs, copyCatalogConfig)
+  }
+}
+
+tasks.getByName("generateMetadataFileForMavenJavaPublication") {
+  dependsOn("runtimeJars")
+}

--- a/catalogs/catalog-jdbc-generic/src/main/java/org/apache/gravitino/catalog/generic/GenericJdbcCatalog.java
+++ b/catalogs/catalog-jdbc-generic/src/main/java/org/apache/gravitino/catalog/generic/GenericJdbcCatalog.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog.generic;
+
+import org.apache.gravitino.catalog.generic.converter.GenericJdbcTypeConverter;
+import org.apache.gravitino.catalog.generic.operation.GenericJdbcDatabaseOperations;
+import org.apache.gravitino.catalog.generic.operation.GenericJdbcTableOperations;
+import org.apache.gravitino.catalog.jdbc.JdbcCatalog;
+import org.apache.gravitino.catalog.jdbc.converter.JdbcColumnDefaultValueConverter;
+import org.apache.gravitino.catalog.jdbc.converter.JdbcTypeConverter;
+import org.apache.gravitino.catalog.jdbc.operation.JdbcDatabaseOperations;
+import org.apache.gravitino.catalog.jdbc.operation.JdbcTableOperations;
+
+/** Generic read-only JDBC catalog based on standard {@link java.sql.DatabaseMetaData}. */
+public class GenericJdbcCatalog extends JdbcCatalog {
+
+  @Override
+  public String shortName() {
+    return "jdbc-generic";
+  }
+
+  @Override
+  protected JdbcTypeConverter createJdbcTypeConverter() {
+    return new GenericJdbcTypeConverter();
+  }
+
+  @Override
+  protected JdbcDatabaseOperations createJdbcDatabaseOperations() {
+    return new GenericJdbcDatabaseOperations();
+  }
+
+  @Override
+  protected JdbcTableOperations createJdbcTableOperations() {
+    return new GenericJdbcTableOperations();
+  }
+
+  @Override
+  protected JdbcColumnDefaultValueConverter createJdbcColumnDefaultValueConverter() {
+    return new JdbcColumnDefaultValueConverter();
+  }
+}

--- a/catalogs/catalog-jdbc-generic/src/main/java/org/apache/gravitino/catalog/generic/GenericJdbcMetadataConfig.java
+++ b/catalogs/catalog-jdbc-generic/src/main/java/org/apache/gravitino/catalog/generic/GenericJdbcMetadataConfig.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog.generic;
+
+import java.util.Arrays;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringUtils;
+
+/** Metadata discovery configuration for the generic JDBC catalog. */
+public class GenericJdbcMetadataConfig {
+
+  /** Optional JDBC catalog pattern passed to {@link java.sql.DatabaseMetaData}. */
+  public static final String CATALOG_PATTERN = "jdbc.metadata.catalog-pattern";
+
+  /** Optional JDBC schema pattern passed to {@link java.sql.DatabaseMetaData}. */
+  public static final String SCHEMA_PATTERN = "jdbc.metadata.schema-pattern";
+
+  /** Comma-separated table types passed to {@link java.sql.DatabaseMetaData#getTables}. */
+  public static final String TABLE_TYPES = "jdbc.metadata.table-types";
+
+  /** Comma-separated schemas to include in metadata discovery. */
+  public static final String INCLUDE_SCHEMAS = "jdbc.metadata.include-schemas";
+
+  /** Comma-separated schemas to exclude from metadata discovery. */
+  public static final String EXCLUDE_SCHEMAS = "jdbc.metadata.exclude-schemas";
+
+  private static final String DEFAULT_TABLE_TYPES = "TABLE,VIEW";
+
+  private static final Set<String> DEFAULT_EXCLUDED_SCHEMAS =
+      Set.of(
+          "information_schema",
+          "mysql",
+          "performance_schema",
+          "pg_catalog",
+          "pg_toast",
+          "sys",
+          "system");
+
+  private final String catalogPattern;
+  private final String schemaPattern;
+  private final String[] tableTypes;
+  private final Set<String> includedSchemas;
+  private final Set<String> excludedSchemas;
+
+  /** Creates a metadata discovery config from catalog properties. */
+  public GenericJdbcMetadataConfig(Map<String, String> properties) {
+    this.catalogPattern = normalizePattern(properties.get(CATALOG_PATTERN));
+    this.schemaPattern = normalizePattern(properties.get(SCHEMA_PATTERN));
+    this.tableTypes =
+        split(properties.getOrDefault(TABLE_TYPES, DEFAULT_TABLE_TYPES)).stream()
+            .map(type -> type.toUpperCase(Locale.ROOT))
+            .toArray(String[]::new);
+    this.includedSchemas = split(properties.get(INCLUDE_SCHEMAS));
+    this.excludedSchemas =
+        properties.containsKey(EXCLUDE_SCHEMAS)
+            ? split(properties.get(EXCLUDE_SCHEMAS))
+            : DEFAULT_EXCLUDED_SCHEMAS;
+  }
+
+  /** Returns the JDBC catalog pattern to pass into metadata calls. */
+  public String catalogPattern() {
+    return catalogPattern;
+  }
+
+  /** Returns the JDBC schema pattern to pass into metadata calls. */
+  public String schemaPattern() {
+    return schemaPattern;
+  }
+
+  /** Returns table types to include in table metadata discovery. */
+  public String[] tableTypes() {
+    return tableTypes.clone();
+  }
+
+  /** Returns whether the schema should be exposed by the generic catalog. */
+  public boolean includesSchema(String schemaName) {
+    String normalized = normalizeName(schemaName);
+    return (includedSchemas.isEmpty() || includedSchemas.contains(normalized))
+        && !excludedSchemas.contains(normalized);
+  }
+
+  private static String normalizePattern(String pattern) {
+    if (StringUtils.isBlank(pattern)) {
+      return null;
+    }
+    return pattern.replace('*', '%');
+  }
+
+  private static Set<String> split(String value) {
+    if (StringUtils.isBlank(value)) {
+      return Set.of();
+    }
+    return Arrays.stream(value.split(","))
+        .map(String::trim)
+        .filter(StringUtils::isNotEmpty)
+        .map(GenericJdbcMetadataConfig::normalizeName)
+        .collect(Collectors.toUnmodifiableSet());
+  }
+
+  private static String normalizeName(String value) {
+    return value.toLowerCase(Locale.ROOT);
+  }
+}

--- a/catalogs/catalog-jdbc-generic/src/main/java/org/apache/gravitino/catalog/generic/converter/GenericJdbcTypeConverter.java
+++ b/catalogs/catalog-jdbc-generic/src/main/java/org/apache/gravitino/catalog/generic/converter/GenericJdbcTypeConverter.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog.generic.converter;
+
+import org.apache.gravitino.catalog.jdbc.converter.JdbcTypeConverter;
+import org.apache.gravitino.rel.types.Type;
+import org.apache.gravitino.rel.types.Types;
+
+/** Conservative type converter based on standard JDBC type codes. */
+public class GenericJdbcTypeConverter extends JdbcTypeConverter {
+
+  /** JDBC type bean that also carries the standard {@code java.sql.Types} code. */
+  public static class GenericJdbcTypeBean extends JdbcTypeBean {
+    private final int jdbcType;
+
+    /** Creates a generic JDBC type bean. */
+    public GenericJdbcTypeBean(String typeName, int jdbcType) {
+      super(typeName);
+      this.jdbcType = jdbcType;
+    }
+
+    /** Returns the standard JDBC type code. */
+    public int getJdbcType() {
+      return jdbcType;
+    }
+  }
+
+  @Override
+  public Type toGravitino(JdbcTypeBean typeBean) {
+    if (!(typeBean instanceof GenericJdbcTypeBean)) {
+      return Types.ExternalType.of(typeBean.getTypeName());
+    }
+
+    GenericJdbcTypeBean genericTypeBean = (GenericJdbcTypeBean) typeBean;
+    switch (genericTypeBean.getJdbcType()) {
+      case java.sql.Types.BOOLEAN:
+      case java.sql.Types.BIT:
+        return Types.BooleanType.get();
+      case java.sql.Types.TINYINT:
+        return Types.ByteType.get();
+      case java.sql.Types.SMALLINT:
+        return Types.ShortType.get();
+      case java.sql.Types.INTEGER:
+        return Types.IntegerType.get();
+      case java.sql.Types.BIGINT:
+        return Types.LongType.get();
+      case java.sql.Types.FLOAT:
+      case java.sql.Types.REAL:
+        return Types.FloatType.get();
+      case java.sql.Types.DOUBLE:
+        return Types.DoubleType.get();
+      case java.sql.Types.DECIMAL:
+      case java.sql.Types.NUMERIC:
+        return toDecimalType(genericTypeBean);
+      case java.sql.Types.CHAR:
+      case java.sql.Types.NCHAR:
+        return genericTypeBean.getColumnSize() == null
+            ? Types.StringType.get()
+            : Types.FixedCharType.of(genericTypeBean.getColumnSize());
+      case java.sql.Types.VARCHAR:
+      case java.sql.Types.NVARCHAR:
+        return genericTypeBean.getColumnSize() == null
+            ? Types.StringType.get()
+            : Types.VarCharType.of(genericTypeBean.getColumnSize());
+      case java.sql.Types.LONGVARCHAR:
+      case java.sql.Types.LONGNVARCHAR:
+        return Types.StringType.get();
+      case java.sql.Types.DATE:
+        return Types.DateType.get();
+      case java.sql.Types.TIME:
+      case java.sql.Types.TIME_WITH_TIMEZONE:
+        return Types.TimeType.get();
+      case java.sql.Types.TIMESTAMP:
+        return Types.TimestampType.withoutTimeZone();
+      case java.sql.Types.TIMESTAMP_WITH_TIMEZONE:
+        return Types.TimestampType.withTimeZone();
+      case java.sql.Types.BINARY:
+      case java.sql.Types.VARBINARY:
+      case java.sql.Types.LONGVARBINARY:
+      case java.sql.Types.BLOB:
+        return Types.BinaryType.get();
+      default:
+        return Types.ExternalType.of(genericTypeBean.getTypeName());
+    }
+  }
+
+  @Override
+  public String fromGravitino(Type type) {
+    if (type instanceof Types.BooleanType) {
+      return "BOOLEAN";
+    } else if (type instanceof Types.ByteType) {
+      return "TINYINT";
+    } else if (type instanceof Types.ShortType) {
+      return "SMALLINT";
+    } else if (type instanceof Types.IntegerType) {
+      return "INTEGER";
+    } else if (type instanceof Types.LongType) {
+      return "BIGINT";
+    } else if (type instanceof Types.FloatType) {
+      return "REAL";
+    } else if (type instanceof Types.DoubleType) {
+      return "DOUBLE";
+    } else if (type instanceof Types.DecimalType) {
+      return type.simpleString();
+    } else if (type instanceof Types.FixedCharType) {
+      return type.simpleString();
+    } else if (type instanceof Types.VarCharType) {
+      return type.simpleString();
+    } else if (type instanceof Types.StringType) {
+      return "VARCHAR";
+    } else if (type instanceof Types.DateType) {
+      return "DATE";
+    } else if (type instanceof Types.TimeType) {
+      return "TIME";
+    } else if (type instanceof Types.TimestampType) {
+      return "TIMESTAMP";
+    } else if (type instanceof Types.BinaryType) {
+      return "VARBINARY";
+    } else if (type instanceof Types.ExternalType) {
+      return ((Types.ExternalType) type).catalogString();
+    }
+
+    throw new IllegalArgumentException(
+        String.format(
+            "Couldn't convert Gravitino type %s to generic JDBC type", type.simpleString()));
+  }
+
+  private Type toDecimalType(GenericJdbcTypeBean typeBean) {
+    Integer precision = typeBean.getColumnSize();
+    Integer scale = typeBean.getScale();
+    if (precision == null || precision <= 0) {
+      return Types.ExternalType.of(typeBean.getTypeName());
+    }
+    return Types.DecimalType.of(precision, scale == null ? 0 : scale);
+  }
+}

--- a/catalogs/catalog-jdbc-generic/src/main/java/org/apache/gravitino/catalog/generic/operation/GenericJdbcDatabaseOperations.java
+++ b/catalogs/catalog-jdbc-generic/src/main/java/org/apache/gravitino/catalog/generic/operation/GenericJdbcDatabaseOperations.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog.generic.operation;
+
+import com.google.common.collect.ImmutableMap;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import javax.sql.DataSource;
+import org.apache.gravitino.catalog.generic.GenericJdbcMetadataConfig;
+import org.apache.gravitino.catalog.jdbc.JdbcSchema;
+import org.apache.gravitino.catalog.jdbc.converter.JdbcExceptionConverter;
+import org.apache.gravitino.catalog.jdbc.operation.JdbcDatabaseOperations;
+import org.apache.gravitino.exceptions.NoSuchSchemaException;
+import org.apache.gravitino.exceptions.SchemaAlreadyExistsException;
+import org.apache.gravitino.meta.AuditInfo;
+
+/** Read-only schema operations for the generic JDBC catalog. */
+public class GenericJdbcDatabaseOperations extends JdbcDatabaseOperations {
+
+  private static final String TABLE_SCHEM = "TABLE_SCHEM";
+
+  private GenericJdbcMetadataConfig metadataConfig;
+
+  @Override
+  public void initialize(
+      DataSource dataSource, JdbcExceptionConverter exceptionMapper, Map<String, String> conf) {
+    super.initialize(dataSource, exceptionMapper, conf);
+    this.metadataConfig = new GenericJdbcMetadataConfig(conf);
+  }
+
+  @Override
+  public void create(String databaseName, String comment, Map<String, String> properties)
+      throws SchemaAlreadyExistsException {
+    throw readOnlyException("create schema");
+  }
+
+  @Override
+  public boolean delete(String databaseName, boolean cascade) {
+    throw readOnlyException("drop schema");
+  }
+
+  @Override
+  public List<String> listDatabases() {
+    List<String> schemaNames = new ArrayList<>();
+    try (Connection connection = getConnection();
+        ResultSet schemas = getSchemas(connection, metadataConfig.schemaPattern())) {
+      while (schemas.next()) {
+        String schemaName = schemas.getString(TABLE_SCHEM);
+        if (schemaName != null && metadataConfig.includesSchema(schemaName)) {
+          schemaNames.add(schemaName);
+        }
+      }
+      return schemaNames;
+    } catch (SQLException se) {
+      throw exceptionMapper.toGravitinoException(se);
+    }
+  }
+
+  @Override
+  public boolean exist(String databaseName) {
+    try (Connection connection = getConnection();
+        ResultSet schemas = getSchemas(connection, databaseName)) {
+      while (schemas.next()) {
+        if (Objects.equals(schemas.getString(TABLE_SCHEM), databaseName)
+            && metadataConfig.includesSchema(databaseName)) {
+          return true;
+        }
+      }
+      return false;
+    } catch (SQLException se) {
+      throw exceptionMapper.toGravitinoException(se);
+    }
+  }
+
+  @Override
+  public JdbcSchema load(String databaseName) throws NoSuchSchemaException {
+    if (!exist(databaseName)) {
+      throw new NoSuchSchemaException("No such schema: %s", databaseName);
+    }
+
+    return JdbcSchema.builder()
+        .withName(databaseName)
+        .withProperties(ImmutableMap.of())
+        .withAuditInfo(AuditInfo.EMPTY)
+        .build();
+  }
+
+  @Override
+  protected boolean supportSchemaComment() {
+    return false;
+  }
+
+  @Override
+  protected Set<String> createSysDatabaseNameSet() {
+    return Set.of();
+  }
+
+  ResultSet getSchemas(Connection connection, String schemaPattern) throws SQLException {
+    DatabaseMetaData metaData = connection.getMetaData();
+    return metaData.getSchemas(metadataConfig.catalogPattern(), schemaPattern);
+  }
+
+  static UnsupportedOperationException readOnlyException(String operation) {
+    return new UnsupportedOperationException(
+        "Generic JDBC catalog is read-only and does not support " + operation);
+  }
+}

--- a/catalogs/catalog-jdbc-generic/src/main/java/org/apache/gravitino/catalog/generic/operation/GenericJdbcTableOperations.java
+++ b/catalogs/catalog-jdbc-generic/src/main/java/org/apache/gravitino/catalog/generic/operation/GenericJdbcTableOperations.java
@@ -1,0 +1,261 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog.generic.operation;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import javax.sql.DataSource;
+import org.apache.gravitino.catalog.generic.GenericJdbcMetadataConfig;
+import org.apache.gravitino.catalog.generic.converter.GenericJdbcTypeConverter.GenericJdbcTypeBean;
+import org.apache.gravitino.catalog.jdbc.JdbcColumn;
+import org.apache.gravitino.catalog.jdbc.JdbcTable;
+import org.apache.gravitino.catalog.jdbc.converter.JdbcColumnDefaultValueConverter;
+import org.apache.gravitino.catalog.jdbc.converter.JdbcExceptionConverter;
+import org.apache.gravitino.catalog.jdbc.converter.JdbcTypeConverter;
+import org.apache.gravitino.catalog.jdbc.operation.DatabaseOperation;
+import org.apache.gravitino.catalog.jdbc.operation.JdbcTableOperations;
+import org.apache.gravitino.catalog.jdbc.operation.RequireDatabaseOperation;
+import org.apache.gravitino.exceptions.NoSuchSchemaException;
+import org.apache.gravitino.exceptions.NoSuchTableException;
+import org.apache.gravitino.exceptions.TableAlreadyExistsException;
+import org.apache.gravitino.rel.TableChange;
+import org.apache.gravitino.rel.expressions.Expression;
+import org.apache.gravitino.rel.expressions.distributions.Distribution;
+import org.apache.gravitino.rel.expressions.sorts.SortOrder;
+import org.apache.gravitino.rel.expressions.transforms.Transform;
+import org.apache.gravitino.rel.indexes.Index;
+
+/** Read-only table operations for the generic JDBC catalog. */
+public class GenericJdbcTableOperations extends JdbcTableOperations
+    implements RequireDatabaseOperation {
+
+  private static final String TABLE_NAME = "TABLE_NAME";
+  private static final String TABLE_SCHEM = "TABLE_SCHEM";
+
+  private GenericJdbcMetadataConfig metadataConfig;
+  private GenericJdbcDatabaseOperations databaseOperations;
+
+  @Override
+  public void initialize(
+      DataSource dataSource,
+      JdbcExceptionConverter exceptionMapper,
+      JdbcTypeConverter jdbcTypeConverter,
+      JdbcColumnDefaultValueConverter jdbcColumnDefaultValueConverter,
+      Map<String, String> conf) {
+    super.initialize(
+        dataSource, exceptionMapper, jdbcTypeConverter, jdbcColumnDefaultValueConverter, conf);
+    this.metadataConfig = new GenericJdbcMetadataConfig(conf);
+  }
+
+  @Override
+  public void setDatabaseOperation(DatabaseOperation databaseOperation) {
+    this.databaseOperations = (GenericJdbcDatabaseOperations) databaseOperation;
+  }
+
+  @Override
+  public void create(
+      String databaseName,
+      String tableName,
+      JdbcColumn[] columns,
+      String comment,
+      Map<String, String> properties,
+      Transform[] partitioning,
+      Distribution distribution,
+      Index[] indexes)
+      throws TableAlreadyExistsException {
+    throw GenericJdbcDatabaseOperations.readOnlyException("create table");
+  }
+
+  @Override
+  public void create(
+      String databaseName,
+      String tableName,
+      JdbcColumn[] columns,
+      String comment,
+      Map<String, String> properties,
+      Transform[] partitioning,
+      Distribution distribution,
+      Index[] indexes,
+      SortOrder[] sortOrders)
+      throws TableAlreadyExistsException {
+    throw GenericJdbcDatabaseOperations.readOnlyException("create table");
+  }
+
+  @Override
+  public boolean drop(String databaseName, String tableName) {
+    throw GenericJdbcDatabaseOperations.readOnlyException("drop table");
+  }
+
+  @Override
+  public void rename(String databaseName, String oldTableName, String newTableName)
+      throws NoSuchTableException {
+    throw GenericJdbcDatabaseOperations.readOnlyException("rename table");
+  }
+
+  @Override
+  public void alterTable(String databaseName, String tableName, TableChange... changes)
+      throws NoSuchTableException {
+    throw GenericJdbcDatabaseOperations.readOnlyException("alter table");
+  }
+
+  @Override
+  public boolean purge(String databaseName, String tableName) {
+    throw GenericJdbcDatabaseOperations.readOnlyException("purge table");
+  }
+
+  @Override
+  public List<String> listTables(String databaseName) throws NoSuchSchemaException {
+    checkSchemaExists(databaseName);
+    List<String> tableNames = new ArrayList<>();
+    try (Connection connection = getConnection(databaseName);
+        ResultSet tables = getTables(connection, databaseName)) {
+      while (tables.next()) {
+        String tableName = tables.getString(TABLE_NAME);
+        if (tableName != null && Objects.equals(tables.getString(TABLE_SCHEM), databaseName)) {
+          tableNames.add(tableName);
+        }
+      }
+      return tableNames;
+    } catch (SQLException se) {
+      throw exceptionMapper.toGravitinoException(se);
+    }
+  }
+
+  @Override
+  protected Connection getConnection(String catalog) throws SQLException {
+    return dataSource.getConnection();
+  }
+
+  @Override
+  protected ResultSet getTable(Connection connection, String databaseName, String tableName)
+      throws SQLException {
+    DatabaseMetaData metaData = connection.getMetaData();
+    return metaData.getTables(
+        metadataConfig.catalogPattern(), databaseName, tableName, metadataConfig.tableTypes());
+  }
+
+  @Override
+  protected ResultSet getColumns(Connection connection, String databaseName, String tableName)
+      throws SQLException {
+    DatabaseMetaData metaData = connection.getMetaData();
+    return metaData.getColumns(metadataConfig.catalogPattern(), databaseName, tableName, null);
+  }
+
+  @Override
+  protected ResultSet getIndexInfo(String databaseName, String tableName, DatabaseMetaData metaData)
+      throws SQLException {
+    return metaData.getIndexInfo(
+        metadataConfig.catalogPattern(), databaseName, tableName, false, false);
+  }
+
+  @Override
+  protected ResultSet getPrimaryKeys(
+      String databaseName, String tableName, DatabaseMetaData metaData) throws SQLException {
+    return metaData.getPrimaryKeys(metadataConfig.catalogPattern(), databaseName, tableName);
+  }
+
+  @Override
+  protected JdbcTable.Builder getTableBuilder(
+      ResultSet tablesResult, String databaseName, String tableName) throws SQLException {
+    while (tablesResult.next()) {
+      if (Objects.equals(tablesResult.getString(TABLE_NAME), tableName)
+          && Objects.equals(tablesResult.getString(TABLE_SCHEM), databaseName)) {
+        return getBasicJdbcTableInfo(tablesResult).withDatabaseName(databaseName);
+      }
+    }
+
+    throw new NoSuchTableException("Table %s does not exist in %s.", tableName, databaseName);
+  }
+
+  @Override
+  protected JdbcColumn.Builder getColumnBuilder(
+      ResultSet columnsResult, String databaseName, String tableName) throws SQLException {
+    if (Objects.equals(columnsResult.getString(TABLE_NAME), tableName)
+        && Objects.equals(columnsResult.getString(TABLE_SCHEM), databaseName)) {
+      return getBasicJdbcColumnInfo(columnsResult);
+    }
+    return null;
+  }
+
+  @Override
+  protected JdbcColumn.Builder getBasicJdbcColumnInfo(ResultSet column) throws SQLException {
+    String typeName = column.getString("TYPE_NAME");
+    int columnSize = column.getInt("COLUMN_SIZE");
+    boolean columnSizeWasNull = column.wasNull();
+    int scale = column.getInt("DECIMAL_DIGITS");
+    boolean scaleWasNull = column.wasNull();
+    GenericJdbcTypeBean typeBean = new GenericJdbcTypeBean(typeName, column.getInt("DATA_TYPE"));
+    typeBean.setColumnSize(columnSizeWasNull ? null : columnSize);
+    typeBean.setScale(scaleWasNull ? null : scale);
+
+    String comment = column.getString("REMARKS");
+    boolean nullable = column.getInt("NULLABLE") == DatabaseMetaData.columnNullable;
+    String columnDef = column.getString("COLUMN_DEF");
+    Expression defaultValue =
+        columnDefaultValueConverter.toGravitino(typeBean, columnDef, false, nullable);
+
+    return JdbcColumn.builder()
+        .withName(column.getString("COLUMN_NAME"))
+        .withType(typeConverter.toGravitino(typeBean))
+        .withComment(comment == null || comment.isEmpty() ? null : comment)
+        .withNullable(nullable)
+        .withDefaultValue(defaultValue);
+  }
+
+  @Override
+  protected String generateCreateTableSql(
+      String tableName,
+      JdbcColumn[] columns,
+      String comment,
+      Map<String, String> properties,
+      Transform[] partitioning,
+      Distribution distribution,
+      Index[] indexes) {
+    throw GenericJdbcDatabaseOperations.readOnlyException("create table");
+  }
+
+  @Override
+  protected String generatePurgeTableSql(String tableName) {
+    throw GenericJdbcDatabaseOperations.readOnlyException("purge table");
+  }
+
+  @Override
+  protected String generateAlterTableSql(
+      String databaseName, String tableName, TableChange... changes) {
+    throw GenericJdbcDatabaseOperations.readOnlyException("alter table");
+  }
+
+  private ResultSet getTables(Connection connection, String databaseName) throws SQLException {
+    DatabaseMetaData metaData = connection.getMetaData();
+    return metaData.getTables(
+        metadataConfig.catalogPattern(), databaseName, null, metadataConfig.tableTypes());
+  }
+
+  private void checkSchemaExists(String databaseName) {
+    if (databaseOperations != null && !databaseOperations.exist(databaseName)) {
+      throw new NoSuchSchemaException("No such schema: %s", databaseName);
+    }
+  }
+}

--- a/catalogs/catalog-jdbc-generic/src/main/resources/META-INF/services/org.apache.gravitino.CatalogProvider
+++ b/catalogs/catalog-jdbc-generic/src/main/resources/META-INF/services/org.apache.gravitino.CatalogProvider
@@ -1,0 +1,19 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+org.apache.gravitino.catalog.generic.GenericJdbcCatalog

--- a/catalogs/catalog-jdbc-generic/src/main/resources/jdbc-generic.conf
+++ b/catalogs/catalog-jdbc-generic/src/main/resources/jdbc-generic.conf
@@ -1,0 +1,29 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# jdbc-url = jdbc:example://localhost:1234/database
+# jdbc-user = gravitino
+# jdbc-password = gravitino
+# jdbc-driver = com.example.Driver
+#
+# Optional JDBC metadata filters. `*` is accepted and converted to the JDBC `%` wildcard.
+# jdbc.metadata.catalog-pattern = *
+# jdbc.metadata.schema-pattern = *
+# jdbc.metadata.table-types = TABLE,VIEW
+# jdbc.metadata.include-schemas = app,public
+# jdbc.metadata.exclude-schemas = information_schema,sys,system

--- a/catalogs/catalog-jdbc-generic/src/test/java/org/apache/gravitino/catalog/generic/TestGenericJdbcCatalog.java
+++ b/catalogs/catalog-jdbc-generic/src/test/java/org/apache/gravitino/catalog/generic/TestGenericJdbcCatalog.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog.generic;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.Test;
+
+/** Tests for {@link GenericJdbcCatalog}. */
+public class TestGenericJdbcCatalog {
+
+  @Test
+  public void testShortName() {
+    GenericJdbcCatalog catalog = new GenericJdbcCatalog();
+
+    assertEquals("jdbc-generic", catalog.shortName());
+    assertNotNull(catalog.newCapability());
+  }
+}

--- a/catalogs/catalog-jdbc-generic/src/test/java/org/apache/gravitino/catalog/generic/converter/TestGenericJdbcTypeConverter.java
+++ b/catalogs/catalog-jdbc-generic/src/test/java/org/apache/gravitino/catalog/generic/converter/TestGenericJdbcTypeConverter.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog.generic.converter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.apache.gravitino.catalog.generic.converter.GenericJdbcTypeConverter.GenericJdbcTypeBean;
+import org.apache.gravitino.rel.types.Types;
+import org.junit.jupiter.api.Test;
+
+/** Tests for {@link GenericJdbcTypeConverter}. */
+public class TestGenericJdbcTypeConverter {
+
+  private final GenericJdbcTypeConverter converter = new GenericJdbcTypeConverter();
+
+  @Test
+  public void testStandardJdbcTypesToGravitino() {
+    GenericJdbcTypeBean decimal = type("DECIMAL", java.sql.Types.DECIMAL);
+    decimal.setColumnSize(10);
+    decimal.setScale(2);
+
+    GenericJdbcTypeBean varchar = type("VARCHAR", java.sql.Types.VARCHAR);
+    varchar.setColumnSize(32);
+
+    assertEquals(
+        Types.BooleanType.get(), converter.toGravitino(type("BOOLEAN", java.sql.Types.BOOLEAN)));
+    assertEquals(
+        Types.IntegerType.get(), converter.toGravitino(type("INTEGER", java.sql.Types.INTEGER)));
+    assertEquals(Types.DecimalType.of(10, 2), converter.toGravitino(decimal));
+    assertEquals(Types.VarCharType.of(32), converter.toGravitino(varchar));
+    assertEquals(
+        Types.StringType.get(),
+        converter.toGravitino(type("LONGVARCHAR", java.sql.Types.LONGVARCHAR)));
+    assertEquals(Types.BinaryType.get(), converter.toGravitino(type("BLOB", java.sql.Types.BLOB)));
+  }
+
+  @Test
+  public void testUnknownJdbcTypeFallsBackToExternalType() {
+    assertEquals(
+        Types.ExternalType.of("GEOMETRY"),
+        converter.toGravitino(type("GEOMETRY", java.sql.Types.OTHER)));
+  }
+
+  private GenericJdbcTypeBean type(String typeName, int jdbcType) {
+    return new GenericJdbcTypeBean(typeName, jdbcType);
+  }
+}

--- a/catalogs/catalog-jdbc-generic/src/test/java/org/apache/gravitino/catalog/generic/operation/TestGenericJdbcOperations.java
+++ b/catalogs/catalog-jdbc-generic/src/test/java/org/apache/gravitino/catalog/generic/operation/TestGenericJdbcOperations.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog.generic.operation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.sql.Connection;
+import java.sql.Statement;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.sql.DataSource;
+import org.apache.gravitino.catalog.generic.GenericJdbcMetadataConfig;
+import org.apache.gravitino.catalog.generic.converter.GenericJdbcTypeConverter;
+import org.apache.gravitino.catalog.jdbc.JdbcSchema;
+import org.apache.gravitino.catalog.jdbc.JdbcTable;
+import org.apache.gravitino.catalog.jdbc.converter.JdbcColumnDefaultValueConverter;
+import org.apache.gravitino.catalog.jdbc.converter.JdbcExceptionConverter;
+import org.apache.gravitino.exceptions.NoSuchSchemaException;
+import org.apache.gravitino.rel.indexes.Index;
+import org.apache.gravitino.rel.types.Types;
+import org.h2.jdbcx.JdbcDataSource;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/** Tests for generic JDBC schema and table metadata operations. */
+public class TestGenericJdbcOperations {
+
+  private DataSource dataSource;
+  private GenericJdbcDatabaseOperations databaseOperations;
+  private GenericJdbcTableOperations tableOperations;
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    Map<String, String> conf = new HashMap<>();
+    conf.put(GenericJdbcMetadataConfig.EXCLUDE_SCHEMAS, "INFORMATION_SCHEMA,HIDDEN");
+
+    JdbcDataSource jdbcDataSource = new JdbcDataSource();
+    jdbcDataSource.setUrl("jdbc:h2:mem:generic_jdbc;DB_CLOSE_DELAY=-1");
+    jdbcDataSource.setUser("sa");
+    dataSource = jdbcDataSource;
+
+    try (Connection connection = dataSource.getConnection();
+        Statement statement = connection.createStatement()) {
+      statement.execute("CREATE SCHEMA APP");
+      statement.execute("CREATE SCHEMA HIDDEN");
+      statement.execute(
+          "CREATE TABLE APP.CUSTOMERS ("
+              + "ID INTEGER NOT NULL PRIMARY KEY, "
+              + "NAME VARCHAR(40), "
+              + "ACTIVE BOOLEAN, "
+              + "AMOUNT DECIMAL(10, 2), "
+              + "PAYLOAD BINARY(4), "
+              + "CREATED_AT TIMESTAMP)");
+      statement.execute("CREATE VIEW APP.CUSTOMER_NAMES AS SELECT NAME FROM APP.CUSTOMERS");
+    }
+
+    databaseOperations = new GenericJdbcDatabaseOperations();
+    databaseOperations.initialize(dataSource, new JdbcExceptionConverter() {}, conf);
+
+    tableOperations = new GenericJdbcTableOperations();
+    tableOperations.initialize(
+        dataSource,
+        new JdbcExceptionConverter() {},
+        new GenericJdbcTypeConverter(),
+        new JdbcColumnDefaultValueConverter(),
+        conf);
+    tableOperations.setDatabaseOperation(databaseOperations);
+  }
+
+  @AfterEach
+  public void tearDown() throws Exception {
+    try (Connection connection = dataSource.getConnection();
+        Statement statement = connection.createStatement()) {
+      statement.execute("DROP ALL OBJECTS");
+    }
+  }
+
+  @Test
+  public void testListAndLoadSchemas() {
+    List<String> schemas = databaseOperations.listDatabases();
+
+    assertTrue(schemas.contains("APP"));
+    assertFalse(schemas.contains("HIDDEN"));
+    assertFalse(schemas.contains("INFORMATION_SCHEMA"));
+
+    JdbcSchema schema = databaseOperations.load("APP");
+    assertEquals("APP", schema.name());
+    assertThrows(NoSuchSchemaException.class, () -> databaseOperations.load("HIDDEN"));
+  }
+
+  @Test
+  public void testListAndLoadTables() {
+    List<String> tables = tableOperations.listTables("APP");
+
+    assertTrue(tables.contains("CUSTOMERS"));
+    assertTrue(tables.contains("CUSTOMER_NAMES"));
+
+    JdbcTable table = tableOperations.load("APP", "CUSTOMERS");
+    assertEquals("CUSTOMERS", table.name());
+    assertEquals(6, table.columns().length);
+    assertEquals("ID", table.columns()[0].name());
+    assertEquals(Types.IntegerType.get(), table.columns()[0].dataType());
+    assertEquals(Types.VarCharType.of(40), table.columns()[1].dataType());
+    assertEquals(Types.BooleanType.get(), table.columns()[2].dataType());
+    assertEquals(Types.DecimalType.of(10, 2), table.columns()[3].dataType());
+    assertEquals(Types.BinaryType.get(), table.columns()[4].dataType());
+    assertEquals(Types.TimestampType.withoutTimeZone(), table.columns()[5].dataType());
+    assertTrue(
+        Arrays.stream(table.index())
+            .anyMatch(
+                index ->
+                    index.type() == Index.IndexType.PRIMARY_KEY
+                        && Arrays.deepEquals(new String[][] {{"ID"}}, index.fieldNames())));
+  }
+
+  @Test
+  public void testReadOnlyOperationsAreRejected() {
+    assertThrows(
+        UnsupportedOperationException.class,
+        () -> databaseOperations.create("NEW_SCHEMA", null, Map.of()));
+    assertThrows(UnsupportedOperationException.class, () -> databaseOperations.delete("APP", true));
+    assertThrows(
+        UnsupportedOperationException.class, () -> tableOperations.drop("APP", "CUSTOMERS"));
+    assertThrows(
+        UnsupportedOperationException.class,
+        () -> tableOperations.rename("APP", "CUSTOMERS", "CUSTOMERS_NEW"));
+  }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -38,6 +38,7 @@ include("catalogs:catalog-lakehouse-generic")
 include(
   "catalogs:catalog-jdbc-common",
   "catalogs:catalog-jdbc-doris",
+  "catalogs:catalog-jdbc-generic",
   "catalogs:catalog-jdbc-mysql",
   "catalogs:catalog-jdbc-postgresql",
   "catalogs:catalog-jdbc-starrocks"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds a generic read-only JDBC catalog provider named `jdbc-generic`.

The new catalog uses standard `DatabaseMetaData` calls to discover schemas, tables, views, columns, primary keys, and unique indexes. It also adds conservative JDBC type mapping for common standard types, with unknown or vendor-specific types preserved as Gravitino `ExternalType`.

It includes metadata filter options for catalog pattern, schema pattern, table types, included schemas, and excluded schemas, and wires the new module into the Gradle settings and catalog distribution packaging.

### Why are the changes needed?

Fix: #11453

This provides a baseline JDBC metadata catalog for databases that do not yet have a dedicated Gravitino JDBC catalog implementation.

### Does this PR introduce any user-facing change?

Yes. Users can configure the new `jdbc-generic` catalog for read-only metadata discovery through JDBC.

Write and DDL operations are intentionally unsupported in this catalog.

### How was this patch tested?

- `./gradlew :catalogs:catalog-jdbc-generic:spotlessApply -PskipITs`
- `./gradlew :catalogs:catalog-jdbc-generic:test -PskipITs`
- `./gradlew :catalogs:catalog-jdbc-generic:build -PskipITs`
- `./gradlew :catalogs:catalog-jdbc-generic:copyLibAndConfig -PskipITs`