### PR TITLE
[#11795] fix(docker): Upgrade bundled PostgreSQL JDBC driver

### DIFF
--- a/dev/docker/gravitino/gravitino-dependency.sh
+++ b/dev/docker/gravitino/gravitino-dependency.sh
@@ -74,7 +74,7 @@ mkdir -p "${jdbc_driver_dir}"
 mysql_driver="mysql-connector-java-8.0.27.jar"
 wget "https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.27/$mysql_driver" -O "${jdbc_driver_dir}/${mysql_driver}"
 
-pg_driver="postgresql-42.7.0.jar"
+pg_driver="postgresql-42.7.11.jar"
 wget "https://jdbc.postgresql.org/download/${pg_driver}" -O "${jdbc_driver_dir}/${pg_driver}"
 
 echo "Finish downloading"

--- a/dev/docker/trino/Dockerfile
+++ b/dev/docker/trino/Dockerfile
@@ -23,7 +23,7 @@ USER root
 
 COPY --chown=trino:trino packages/trino/conf /etc/trino
 COPY --chown=trino:trino packages/gravitino-trino-connector/mysql-connector-java-8.0.27.jar /usr/lib/trino/plugin/iceberg/
-COPY --chown=trino:trino packages/gravitino-trino-connector/postgresql-42.7.0.jar /usr/lib/trino/plugin/iceberg/
+COPY --chown=trino:trino packages/gravitino-trino-connector/postgresql-42.7.11.jar /usr/lib/trino/plugin/iceberg/
 
 RUN mkdir /tmp/gravitino
 COPY --chown=trino:trino packages/gravitino-trino-connector /tmp/gravitino

--- a/dev/docker/trino/trino-dependency.sh
+++ b/dev/docker/trino/trino-dependency.sh
@@ -32,7 +32,7 @@ ${gravitino_home}/gradlew :trino-connector:trino-connector-473-478:assembleTrino
 cp -r "${gravitino_home}/distribution/gravitino-trino-connector-473-478" "${trino_dir}/packages/gravitino-trino-connector"
 
 MYSQL_VERSION="8.0.27"
-PG_VERSION="42.7.0"
+PG_VERSION="42.7.11"
 MYSQL_JAVA_CONNECTOR_URL="https://repo1.maven.org/maven2/mysql/mysql-connector-java/${MYSQL_VERSION}/mysql-connector-java-${MYSQL_VERSION}.jar"
 PG_JAVA_CONNECTOR_URL="https://jdbc.postgresql.org/download/postgresql-${PG_VERSION}.jar"
 

--- a/dev/docker/trino/trino-dependency.sh
+++ b/dev/docker/trino/trino-dependency.sh
@@ -42,7 +42,7 @@ if [ ! -f "${trino_dir}/packages/gravitino-trino-connector/mysql-connector-java-
 fi
 
 # Download PostgreSQL jdbc driver if it does not exist.
-if [ ! -f "${trino_dir}/packages/gravitino-trino-connector/postgresql-{PG_VERSION}.jar" ]; then
+if [ ! -f "${trino_dir}/packages/gravitino-trino-connector/postgresql-${PG_VERSION}.jar" ]; then
   cd "${trino_dir}/packages/gravitino-trino-connector/" && curl -O "$PG_JAVA_CONNECTOR_URL" && cd -
 fi
 

--- a/docs/how-to-use-relational-backend-storage.md
+++ b/docs/how-to-use-relational-backend-storage.md
@@ -138,7 +138,7 @@ create them in advance and set the database and schema in the JDBC URL.
 ### Step 3: Place the PostgreSQL Connector Jar
 
 You should **download** the PostgreSQL connector Jar for the corresponding version of PostgreSQL you use
-(You can download it from the [PostgreSQL-driver-jar](https://jdbc.postgresql.org/download/postgresql-42.7.0.jar)),
+(You can download it from the [PostgreSQL-driver-jar](https://jdbc.postgresql.org/download/postgresql-42.7.11.jar)),
 which is name like `postgresql-{version}.jar`.
 
 Then place it in the distribution package directory:

--- a/integration-test-common/src/test/java/org/apache/gravitino/integration/test/util/BaseIT.java
+++ b/integration-test-common/src/test/java/org/apache/gravitino/integration/test/util/BaseIT.java
@@ -114,7 +114,7 @@ public class BaseIT {
       "https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.26/mysql-connector-java-8.0.26.jar";
 
   public static final String DOWNLOAD_POSTGRESQL_JDBC_DRIVER_URL =
-      "https://jdbc.postgresql.org/download/postgresql-42.7.0.jar";
+      "https://jdbc.postgresql.org/download/postgresql-42.7.11.jar";
 
   public static final String DOWNLOAD_CLICKHOUSE_JDBC_DRIVER_URL =
       "https://repo1.maven.org/maven2/com/clickhouse/clickhouse-jdbc/0.7.1/clickhouse-jdbc-0.7.1-all.jar";

--- a/trino-connector/integration-test/trino-test-tools/download_jar.sh
+++ b/trino-connector/integration-test/trino-test-tools/download_jar.sh
@@ -54,10 +54,10 @@ download_mysql_jar() {
 }
 
 download_postgresql_jar() {
-  download_jar "postgresql-42.7.0.jar" \
-  "https://jdbc.postgresql.org/download/postgresql-42.7.0.jar" \
+  download_jar "postgresql-42.7.11.jar" \
+  "https://jdbc.postgresql.org/download/postgresql-42.7.11.jar" \
   "$GRAVITINO_SERVER_DIR/catalogs/jdbc-postgresql/libs"
-  cp -rp $GRAVITINO_SERVER_DIR/catalogs/jdbc-postgresql/libs/postgresql-42.7.0.jar $GRAVITINO_SERVER_DIR/catalogs/lakehouse-iceberg/libs
+  cp -rp $GRAVITINO_SERVER_DIR/catalogs/jdbc-postgresql/libs/postgresql-42.7.11.jar $GRAVITINO_SERVER_DIR/catalogs/lakehouse-iceberg/libs
 }
 
 download_iceberg_aws_bundle() {
@@ -84,4 +84,3 @@ download_trino-cascading-connector() {
       exit 1
   fi
 }
-


### PR DESCRIPTION
### What changes were proposed in this pull request?

Upgrade the PostgreSQL JDBC driver downloaded into Docker and test helper packages from `42.7.0` to `42.7.11`.

This updates the Gravitino Docker dependency script, Trino Docker/test helper references, integration test download URL, and documentation link.

### Why are the changes needed?

The Gravitino 1.3.0-rc6 image scan reports CRITICAL `CVE-2024-1597` for `/opt/gravitino/jdbc-drivers/postgresql-42.7.0.jar`.

Fix: #11795

### Does this PR introduce _any_ user-facing change?

No API or configuration property changes. Docker/test helper scripts and documentation now reference PostgreSQL JDBC `42.7.11`.

### How was this patch tested?

- Confirmed no `postgresql-42.7.0` references remain in the touched areas.
- Verified `https://jdbc.postgresql.org/download/postgresql-42.7.11.jar` returns HTTP 200.
