### PR TITLE
[#11793] feat(hive-catalog): Aggregate partition-level totalSize into table-level for partitioned Hive tables

### DIFF
--- a/catalogs/catalog-common/src/main/java/org/apache/gravitino/catalog/hive/HiveConstants.java
+++ b/catalogs/catalog-common/src/main/java/org/apache/gravitino/catalog/hive/HiveConstants.java
@@ -37,6 +37,7 @@ public class HiveConstants {
   public static final String COMMENT = "comment";
   public static final String NUM_FILES = "numFiles";
   public static final String TOTAL_SIZE = "totalSize";
+  public static final String NUM_PARTITIONS = "numPartitions";
   public static final String EXTERNAL = "EXTERNAL";
   public static final String FORMAT = "format";
   public static final String TABLE_TYPE = "table-type";

--- a/catalogs/catalog-hive/src/main/java/org/apache/gravitino/catalog/hive/HiveCatalogOperations.java
+++ b/catalogs/catalog-hive/src/main/java/org/apache/gravitino/catalog/hive/HiveCatalogOperations.java
@@ -25,7 +25,9 @@ import static org.apache.gravitino.catalog.hive.HiveCatalogPropertiesMetadata.ME
 import static org.apache.gravitino.catalog.hive.HiveCatalogPropertiesMetadata.PRINCIPAL;
 import static org.apache.gravitino.catalog.hive.HiveConstants.HIVE_FILTER_FIELD_PARAMS;
 import static org.apache.gravitino.catalog.hive.HiveConstants.HIVE_METASTORE_URIS;
+import static org.apache.gravitino.catalog.hive.HiveConstants.NUM_PARTITIONS;
 import static org.apache.gravitino.catalog.hive.HiveConstants.TABLE_TYPE;
+import static org.apache.gravitino.catalog.hive.HiveConstants.TOTAL_SIZE;
 import static org.apache.gravitino.catalog.hive.TableType.EXTERNAL_TABLE;
 import static org.apache.gravitino.connector.BaseCatalog.CATALOG_BYPASS_PREFIX;
 import static org.apache.gravitino.hive.HiveTable.SUPPORT_TABLE_TYPES;
@@ -69,6 +71,7 @@ import org.apache.gravitino.exceptions.SchemaAlreadyExistsException;
 import org.apache.gravitino.exceptions.TableAlreadyExistsException;
 import org.apache.gravitino.exceptions.ViewAlreadyExistsException;
 import org.apache.gravitino.hive.CachedClientPool;
+import org.apache.gravitino.hive.HivePartition;
 import org.apache.gravitino.hive.HiveSchema;
 import org.apache.gravitino.hive.HiveTable;
 import org.apache.gravitino.meta.AuditInfo;
@@ -114,6 +117,9 @@ public class HiveCatalogOperations
   // The maximum number of tables that can be returned by the listTableNamesByFilter function.
   // The default value is -1, which means that all tables are returned.
   private static final short MAX_TABLES = -1;
+  // The batch size for partition statistics aggregation to avoid loading all partitions
+  // into memory at once.
+  private static final int PARTITION_BATCH_SIZE = 1000;
   static final String ALL_TABLE_PATTERN = "*";
 
   // Map that maintains the mapping of keys in Gravitino to that in Hive, for example, users
@@ -491,11 +497,127 @@ public class HiveCatalogOperations
     try {
       HiveTable table =
           clientPool.run(c -> c.getTable(catalogName, schemaIdent.name(), tableIdent.name()));
+      aggregatePartitionTotalSize(table);
       return new HiveTableHandle(table, clientPool);
 
     } catch (InterruptedException e) {
       throw new RuntimeException(
           "Failed to load Hive table " + tableIdent.name() + " from Hive metastore", e);
+    }
+  }
+
+  /**
+   * Aggregates partition-level totalSize into table-level properties for partitioned Hive tables.
+   * Uses batched partition loading (batch size = {@value #PARTITION_BATCH_SIZE}) to control memory
+   * usage, mimicking Hive's DESCRIBE TABLE behavior.
+   *
+   * <p>Steps:
+   *
+   * <ol>
+   *   <li>Fetch all partition names via lightweight {@code listPartitionNames} call
+   *   <li>Chunk names into batches of {@value #PARTITION_BATCH_SIZE}
+   *   <li>For each batch, fetch partition objects via {@code listPartitionsByNames}
+   *   <li>Accumulate totalSize from partition metadata
+   *   <li>Write aggregated totalSize and numPartitions into table properties
+   * </ol>
+   *
+   * <p>Failures are logged at WARN level and do not block the table load. Aggregated values exist
+   * only in memory and are NOT persisted back to HMS.
+   *
+   * @param table the HiveTable whose properties will be enriched
+   */
+  private void aggregatePartitionTotalSize(HiveTable table) {
+    // Only aggregate for partitioned tables
+    if (table == null || table.partitionFieldNames().isEmpty()) {
+      return;
+    }
+
+    Map<String, String> tableProps = table.properties();
+    // Skip if table-level totalSize already exists, to avoid redundant work
+    if (tableProps != null && tableProps.containsKey(TOTAL_SIZE)) {
+      return;
+    }
+
+    try {
+      // Step 1: Get all partition names (lightweight, only strings)
+      List<String> allPartitionNames = clientPool.run(c -> c.listPartitionNames(table, (short) -1));
+
+      if (allPartitionNames == null || allPartitionNames.isEmpty()) {
+        tableProps.put(TOTAL_SIZE, "0");
+        tableProps.put(NUM_PARTITIONS, "0");
+        return;
+      }
+
+      long totalSizeSum = 0L;
+      int totalPartitions = 0;
+
+      // Step 2 & 3: Iterate in batches
+      int totalCount = allPartitionNames.size();
+      for (int i = 0; i < totalCount; i += PARTITION_BATCH_SIZE) {
+        int end = Math.min(i + PARTITION_BATCH_SIZE, totalCount);
+        List<String> batch = new ArrayList<>(allPartitionNames.subList(i, end));
+
+        List<HivePartition> partitions = clientPool.run(c -> c.listPartitionsByNames(table, batch));
+
+        // Step 4: Extract totalSize from each partition in the batch
+        for (HivePartition partition : partitions) {
+          Map<String, String> partProps = partition.properties();
+          if (partProps != null) {
+            String totalSizeStr = partProps.get(TOTAL_SIZE);
+            if (totalSizeStr != null) {
+              try {
+                totalSizeSum += Long.parseLong(totalSizeStr);
+              } catch (NumberFormatException e) {
+                LOG.warn(
+                    "Invalid {} value '{}' for partition {} of table {}.{}",
+                    TOTAL_SIZE,
+                    totalSizeStr,
+                    partition.name(),
+                    table.databaseName(),
+                    table.name());
+              }
+            }
+          }
+          totalPartitions++;
+        }
+
+        if (LOG.isDebugEnabled()) {
+          LOG.debug(
+              "Aggregated batch {}-{} / {} partitions for Hive table {}.{}",
+              i + 1,
+              end,
+              totalCount,
+              table.databaseName(),
+              table.name());
+        }
+      }
+
+      // Step 5: Write aggregated values to table properties (in-memory only, not persisted to HMS)
+      tableProps.put(TOTAL_SIZE, Long.toString(totalSizeSum));
+      tableProps.put(NUM_PARTITIONS, Integer.toString(totalPartitions));
+
+      LOG.info(
+          "Aggregated partition totalSize for Hive table {}.{}: totalSize={}, numPartitions={}",
+          table.databaseName(),
+          table.name(),
+          totalSizeSum,
+          totalPartitions);
+
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      LOG.warn(
+          "Interrupted while aggregating partition totalSize for Hive table {}.{}, "
+              + "returning table without aggregated totalSize",
+          table.databaseName(),
+          table.name(),
+          e);
+    } catch (Exception e) {
+      LOG.warn(
+          "Failed to aggregate partition totalSize for Hive table {}.{}, "
+              + "returning table without aggregated totalSize",
+          table.databaseName(),
+          table.name(),
+          e);
     }
   }
 

--- a/catalogs/hive-metastore-common/src/main/java/org/apache/gravitino/hive/client/HiveClient.java
+++ b/catalogs/hive-metastore-common/src/main/java/org/apache/gravitino/hive/client/HiveClient.java
@@ -70,6 +70,16 @@ public interface HiveClient extends AutoCloseable {
   List<HivePartition> listPartitions(
       HiveTable table, List<String> filterPartitionValueList, short pageSize);
 
+  /**
+   * Lists partitions of a table by given partition names. Used for batched partition-level
+   * statistics aggregation.
+   *
+   * @param table the Hive table
+   * @param partitionNames the partition name list to fetch
+   * @return list of HivePartitions corresponding to the given names
+   */
+  List<HivePartition> listPartitionsByNames(HiveTable table, List<String> partitionNames);
+
   HivePartition getPartition(HiveTable table, String partitionName);
 
   HivePartition addPartition(HiveTable table, HivePartition partition);

--- a/catalogs/hive-metastore-common/src/main/java/org/apache/gravitino/hive/client/HiveClientImpl.java
+++ b/catalogs/hive-metastore-common/src/main/java/org/apache/gravitino/hive/client/HiveClientImpl.java
@@ -135,6 +135,11 @@ public class HiveClientImpl implements HiveClient {
   }
 
   @Override
+  public List<HivePartition> listPartitionsByNames(HiveTable table, List<String> partitionNames) {
+    return shim.listPartitionsByNames(table, partitionNames);
+  }
+
+  @Override
   public HivePartition getPartition(HiveTable table, String partitionName) {
     return shim.getPartition(table, partitionName);
   }

--- a/catalogs/hive-metastore-common/src/main/java/org/apache/gravitino/hive/client/HiveShim.java
+++ b/catalogs/hive-metastore-common/src/main/java/org/apache/gravitino/hive/client/HiveShim.java
@@ -97,6 +97,10 @@ public abstract class HiveShim {
   public abstract List<HivePartition> listPartitions(
       HiveTable table, List<String> filterPartitionValueList, short pageSize);
 
+  /** Fetches partitions by their names, used for batched stats aggregation. */
+  public abstract List<HivePartition> listPartitionsByNames(
+      HiveTable table, List<String> partitionNames);
+
   public abstract HivePartition getPartition(HiveTable table, String partitionName);
 
   public abstract HivePartition addPartition(HiveTable table, HivePartition partition);

--- a/catalogs/hive-metastore-common/src/main/java/org/apache/gravitino/hive/client/HiveShimV2.java
+++ b/catalogs/hive-metastore-common/src/main/java/org/apache/gravitino/hive/client/HiveShimV2.java
@@ -216,6 +216,17 @@ class HiveShimV2 extends HiveShim {
   }
 
   @Override
+  public List<HivePartition> listPartitionsByNames(HiveTable table, List<String> partitionNames) {
+    try {
+      String databaseName = table.databaseName();
+      var partitions = client.getPartitionsByNames(databaseName, table.name(), partitionNames);
+      return partitions.stream().map(p -> HiveTableConverter.fromHivePartition(table, p)).toList();
+    } catch (Exception e) {
+      throw HiveExceptionConverter.toGravitinoException(e, ExceptionTarget.table(table.name()));
+    }
+  }
+
+  @Override
   public HivePartition getPartition(HiveTable table, String partitionName) {
     try {
       String databaseName = table.databaseName();

--- a/catalogs/hive-metastore-common/src/main/java/org/apache/gravitino/hive/client/HiveShimV3.java
+++ b/catalogs/hive-metastore-common/src/main/java/org/apache/gravitino/hive/client/HiveShimV3.java
@@ -61,6 +61,7 @@ class HiveShimV3 extends HiveShimV2 {
   private final Method addPartitionMethod;
   private final Method dropPartitionMethod;
   private final Method getTableObjectsByNameMethod;
+  private final Method getPartitionsByNamesMethod;
   private final Method databaseSetCatalogNameMethod;
   private final Method getCatalogsMethod;
   private final Method createCatalogMethod;
@@ -142,6 +143,9 @@ class HiveShimV3 extends HiveShimV2 {
       this.getTableObjectsByNameMethod =
           IMetaStoreClient.class.getMethod(
               "getTableObjectsByName", String.class, String.class, List.class);
+      this.getPartitionsByNamesMethod =
+          IMetaStoreClient.class.getMethod(
+              "getPartitionsByNames", String.class, String.class, String.class, List.class);
       this.getCatalogsMethod = IMetaStoreClient.class.getMethod("getCatalogs");
 
       this.catalogClass = this.getClass().getClassLoader().loadClass(CATALOG_CLASS);
@@ -383,6 +387,23 @@ class HiveShimV3 extends HiveShimV2 {
                 table.name(),
                 filterPartitionValueList,
                 pageSizeArg);
+    return partitions.stream().map(p -> HiveTableConverter.fromHivePartition(table, p)).toList();
+  }
+
+  @Override
+  public List<HivePartition> listPartitionsByNames(HiveTable table, List<String> partitionNames) {
+    String catalogName = table.catalogName();
+    String databaseName = table.databaseName();
+    var partitions =
+        (List<org.apache.hadoop.hive.metastore.api.Partition>)
+            invoke(
+                ExceptionTarget.table(table.name()),
+                client,
+                getPartitionsByNamesMethod,
+                catalogName,
+                databaseName,
+                table.name(),
+                partitionNames);
     return partitions.stream().map(p -> HiveTableConverter.fromHivePartition(table, p)).toList();
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds automatic partition-level statistics aggregation for Hive partitioned tables, enabling the REST API (`GET /tables/{table}`) to return a table-level `totalSize` by summing up partition-level `totalSize` values at query time.

**Changes include:**

1. New `listPartitionsByNames` API — Added to `HiveClient`, `HiveShim`, `HiveShimV2`, `HiveShimV3` and `HiveClientImpl`. This method fetches partition objects by a list of partition names, enabling batched metadata loading.

2. Batched partition statistics aggregation — Added `aggregatePartitionTotalSize()` in `HiveCatalogOperations`. It uses `listPartitionNames` (lightweight, strings only) followed by batched `listPartitionsByNames` calls (batch size = 1000) to sum `totalSize` from all partitions. The aggregated values are written into `HiveTable.properties()` **in memory only** and are NOT persisted back to HMS.

3. Lazy trigger — Aggregation is skipped if the table-level `totalSize` property already exists, avoiding redundant computation.

### Why are the changes needed?

Hive Metastore stores statistics at the partition level only. When a partitioned table is described via Hive CLI, Hive internally iterates all partitions and sums their stats in memory. Gravitino lacked this capability, so the REST API returned no `totalSize` for partitioned Hive tables. This PR replicates Hive's behavior with a memory-efficient batched approach.

### Does this PR introduce _any_ user-facing change?

- **Yes** — For Hive partitioned tables that have partition-level statistics but no table-level statistics, the REST API and Java Client `loadTable()` will now include `totalSize` and `numPartitions` in `table.properties()`.
- **No breaking changes** — The aggregation happens transparently at query time and does not modify HMS data.

### How was this patch tested?

1. Created a Hive partitioned table with 3 partitions.
2. Verified via `curl GET /tables/{table}` that `totalSize` equals the sum of partition-level values.
3. Verified non-partitioned tables and tables with existing table-level stats are unaffected.