### PR TITLE
[#11077] docs: Document Trino 482 fix for SHOW SCHEMAS on Gravitino IRC

### DIFF
--- a/docs/iceberg-rest-engine/trino.md
+++ b/docs/iceberg-rest-engine/trino.md
@@ -198,7 +198,7 @@ When Trino connects to Gravitino IRC with `iceberg.rest-catalog.security=OAUTH2`
 before 482, each recursive call creates a separate OAuth session, which can trigger excessive token
 requests and cause errors such as `Connection pool shut down` or `StackOverflowError`.
 
-Upgrade to **Trino 482+**.
+**Solution:** Upgrade to **Trino 482+**.
 
 ### `TIMESTAMP WITH TIME ZONE` Values Are Not Adjusted to the Client Session Time Zone
 

--- a/docs/iceberg-rest-engine/trino.md
+++ b/docs/iceberg-rest-engine/trino.md
@@ -198,8 +198,7 @@ WITH (
 before 482, each recursive call creates a separate OAuth session, which can trigger excessive token
 requests and cause errors such as `Connection pool shut down` or `StackOverflowError`.
 
-**Solution:**
-Upgrade to Trino 482+.
+**Solution:** Upgrade to Trino 482+.
 
 ### `TIMESTAMP WITH TIME ZONE` Values Are Not Adjusted to the Client Session Time Zone
 
@@ -207,8 +206,8 @@ Upgrade to Trino 482+.
 the client session time zone. Unlike Spark and Flink, Trino displays these values based on the
 stored timestamp-with-time-zone value.
 
-**Solution:**
-Use `at_timezone` together with `current_timezone()`:
+**Solution:** To convert a `TIMESTAMP WITH TIME ZONE` value to the current client session time
+zone, use `at_timezone` together with `current_timezone()`:
 
 ```sql
 SELECT

--- a/docs/iceberg-rest-engine/trino.md
+++ b/docs/iceberg-rest-engine/trino.md
@@ -198,7 +198,9 @@ When Trino connects to Gravitino IRC with `iceberg.rest-catalog.security=OAUTH2`
 before 482, each recursive call creates a separate OAuth session, which can trigger excessive token
 requests and cause errors such as `Connection pool shut down` or `StackOverflowError`.
 
-**Solution:** Upgrade to **Trino 482+**.
+```
+Solution: Upgrade to Trino 482+.
+```
 
 ### `TIMESTAMP WITH TIME ZONE` Values Are Not Adjusted to the Client Session Time Zone
 

--- a/docs/iceberg-rest-engine/trino.md
+++ b/docs/iceberg-rest-engine/trino.md
@@ -190,6 +190,16 @@ WITH (
 
 ## Known Issues
 
+### `SHOW SCHEMAS` Fails on Gravitino IRC (OAuth2, Nested Namespaces)
+
+When Trino connects to Gravitino IRC with `iceberg.rest-catalog.security=OAUTH2`,
+`iceberg.rest-catalog.nested-namespace-enabled=true`, and `iceberg.rest-catalog.session=NONE`
+(the default), `SHOW SCHEMAS` recursively calls Iceberg REST `listNamespaces`. On Trino releases
+before 482, each recursive call creates a separate OAuth session, which can trigger excessive token
+requests and cause errors such as `Connection pool shut down` or `StackOverflowError`.
+
+Upgrade to **Trino 482+**.
+
 ### `TIMESTAMP WITH TIME ZONE` Values Are Not Adjusted to the Client Session Time Zone
 
 For `TIMESTAMP WITH TIME ZONE` values, Trino does not adjust query results according to the client

--- a/docs/iceberg-rest-engine/trino.md
+++ b/docs/iceberg-rest-engine/trino.md
@@ -192,24 +192,23 @@ WITH (
 
 ### `SHOW SCHEMAS` Fails on Gravitino IRC (OAuth2, Nested Namespaces)
 
-When Trino connects to Gravitino IRC with `iceberg.rest-catalog.security=OAUTH2`,
+**Cause:** When Trino connects to Gravitino IRC with `iceberg.rest-catalog.security=OAUTH2`,
 `iceberg.rest-catalog.nested-namespace-enabled=true`, and `iceberg.rest-catalog.session=NONE`
 (the default), `SHOW SCHEMAS` recursively calls Iceberg REST `listNamespaces`. On Trino releases
 before 482, each recursive call creates a separate OAuth session, which can trigger excessive token
 requests and cause errors such as `Connection pool shut down` or `StackOverflowError`.
 
-```
-Solution: Upgrade to Trino 482+.
-```
+**Solution:**
+Upgrade to Trino 482+.
 
 ### `TIMESTAMP WITH TIME ZONE` Values Are Not Adjusted to the Client Session Time Zone
 
-For `TIMESTAMP WITH TIME ZONE` values, Trino does not adjust query results according to the client
-session time zone. Unlike Spark and Flink, Trino displays these values based on the stored
-timestamp-with-time-zone value.
+**Cause:** For `TIMESTAMP WITH TIME ZONE` values, Trino does not adjust query results according to
+the client session time zone. Unlike Spark and Flink, Trino displays these values based on the
+stored timestamp-with-time-zone value.
 
-To convert a `TIMESTAMP WITH TIME ZONE` value to the current client session time zone, use
-`at_timezone` together with `current_timezone()`:
+**Solution:**
+Use `at_timezone` together with `current_timezone()`:
 
 ```sql
 SELECT


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add a Known Issues entry to `docs/iceberg-rest-engine/trino.md` describing
`SHOW SCHEMAS` failures when Trino connects to Gravitino IRC with OAuth2 and
nested namespaces enabled, and note that Trino 482+ resolves the issue.

### Why are the changes needed?

Trino 482 includes a fix for excessive OAuth token requests during recursive
namespace listing on Iceberg REST catalogs. Users hitting this scenario need
documentation on the affected configuration and the required Trino version.

Fix: #11077

### Does this PR introduce _any_ user-facing change?

Documentation only. No API or configuration changes.

### How was this patch tested?

./gradlew :docs:build