### PR TITLE
[#11810] fix(core): treat authorization plugin classes as isolated in IsolatedClassLoader

### DIFF
--- a/core/src/main/java/org/apache/gravitino/utils/IsolatedClassLoader.java
+++ b/core/src/main/java/org/apache/gravitino/utils/IsolatedClassLoader.java
@@ -246,7 +246,20 @@ public class IsolatedClassLoader implements Closeable {
     // compiler-generated synthetic classes (e.g. $1 from switch-on-enum) are then requested
     // from the server classloader which cannot find them, causing a permanent
     // NoClassDefFoundError that is cached by the JVM for the lifetime of the process.
+    // org.apache.gravitino.authorization.{ranger,chain,jdbc,common}.* are authorization plugin
+    // classes loaded through this IsolatedClassLoader. They must be treated as isolated (catalog)
+    // classes; otherwise they are delegated to the server classloader, and their nested or
+    // compiler-generated synthetic classes (e.g. the inner enum
+    // RangerPrivileges$RangerHdfsPrivilege)
+    // cannot be resolved from the server classpath, producing a permanently cached
+    // NoClassDefFoundError. Note org.apache.gravitino.authorization.* (without these sub-packages)
+    // holds server-side classes (e.g. RoleManager) that must stay shared, so only the plugin
+    // sub-packages are whitelisted here.
     return name.startsWith("org.apache.gravitino.hive.")
+        || name.startsWith("org.apache.gravitino.authorization.ranger.")
+        || name.startsWith("org.apache.gravitino.authorization.chain.")
+        || name.startsWith("org.apache.gravitino.authorization.jdbc.")
+        || name.startsWith("org.apache.gravitino.authorization.common.")
         || name.startsWith("org.apache.gravitino.catalog.hive.")
         || name.startsWith("org.apache.gravitino.catalog.lakehouse.")
         || name.startsWith("org.apache.gravitino.catalog.jdbc.")

--- a/core/src/test/java/org/apache/gravitino/utils/TestIsolatedClassLoader.java
+++ b/core/src/test/java/org/apache/gravitino/utils/TestIsolatedClassLoader.java
@@ -80,11 +80,33 @@ public class TestIsolatedClassLoader {
   }
 
   @Test
+  public void testAuthorizationPluginPackagesRecognizedAsCatalogClass() throws Exception {
+    // Authorization plugin classes are loaded through the IsolatedClassLoader. They must be
+    // treated as catalog classes; otherwise they are delegated to the server classloader and their
+    // nested classes (e.g. the inner enum RangerPrivileges$RangerHdfsPrivilege) fail to load,
+    // causing a permanently cached NoClassDefFoundError.
+    Assertions.assertTrue(
+        isCatalogClass("org.apache.gravitino.authorization.ranger.RangerPrivileges"));
+    Assertions.assertTrue(
+        isCatalogClass(
+            "org.apache.gravitino.authorization.ranger.RangerPrivileges$RangerHdfsPrivilege"));
+    Assertions.assertTrue(
+        isCatalogClass("org.apache.gravitino.authorization.chain.ChainedAuthorizationPlugin"));
+    Assertions.assertTrue(
+        isCatalogClass("org.apache.gravitino.authorization.jdbc.JdbcAuthorizationPlugin"));
+    Assertions.assertTrue(
+        isCatalogClass("org.apache.gravitino.authorization.common.AuthorizationProperties"));
+  }
+
+  @Test
   public void testNonCatalogPackagesNotRecognizedAsCatalogClass() throws Exception {
     // Server-side / shared classes must NOT be treated as catalog classes.
     Assertions.assertFalse(isCatalogClass("org.apache.gravitino.connector.BaseCatalog"));
     Assertions.assertFalse(isCatalogClass("org.apache.gravitino.NameIdentifier"));
     Assertions.assertFalse(isCatalogClass("org.apache.gravitino.catalog.SomeSharedClass"));
+    // Server-side authorization classes (without a plugin sub-package) must stay shared.
+    Assertions.assertFalse(isCatalogClass("org.apache.gravitino.authorization.RoleManager"));
+    Assertions.assertFalse(isCatalogClass("org.apache.gravitino.authorization.AuthorizationUtils"));
     Assertions.assertFalse(isCatalogClass("java.lang.String"));
     Assertions.assertFalse(isCatalogClass("org.slf4j.Logger"));
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add the authorization plugin packages `org.apache.gravitino.authorization.{ranger,chain,jdbc,common}.` to `IsolatedClassLoader.isCatalogClass()` so these plugin classes are loaded by the isolated classloader instead of being delegated to the server classloader. The bare `org.apache.gravitino.authorization.*` prefix is intentionally left out so server-side classes (e.g. `RoleManager`, `AuthorizationUtils`) remain shared.

Tests: add `TestIsolatedClassLoader.testAuthorizationPluginPackagesRecognizedAsCatalogClass` and extend the negative test to assert server-side authorization classes stay shared.

### Why are the changes needed?

Authorization plugin classes were classified as *shared* and delegated to the server classloader. Under certain classloader-initialization timing windows the server classloader becomes the defining classloader of a plugin class (e.g. `RangerPrivileges`), and its nested/synthetic classes (e.g. the inner enum `RangerPrivileges$RangerHdfsPrivilege`) cannot be resolved from the server classpath. The JVM permanently caches this load failure for the lifetime of the process, so every subsequent role/authorization operation throws `NoClassDefFoundError` until restart. This surfaces intermittently in `RangerHiveE2EIT`.

This is the same class of bug as #11704 (fixed for the hive packages in #11705), now applied to the authorization plugins.

Fix: #11810

### Does this PR introduce _any_ user-facing change?

No. This is an internal classloader fix with no API or behavior change.

### How was this patch tested?

`./gradlew :core:test --tests "org.apache.gravitino.utils.TestIsolatedClassLoader"` — passes (4 test methods, including the new authorization-plugin coverage and the server-side-stays-shared assertions).
