### PR TITLE
[#11813] fix(gvfs): override getScheme() to return 'gvfs'

### DIFF
--- a/clients/filesystem-hadoop3/src/main/java/org/apache/gravitino/filesystem/hadoop/GravitinoVirtualFileSystem.java
+++ b/clients/filesystem-hadoop3/src/main/java/org/apache/gravitino/filesystem/hadoop/GravitinoVirtualFileSystem.java
@@ -123,6 +123,12 @@ public class GravitinoVirtualFileSystem extends FileSystem {
     return this.uri;
   }
 
+  /** Returns the GVFS scheme to avoid {@link UnsupportedOperationException} in commit jobs. */
+  @Override
+  public String getScheme() {
+    return GravitinoVirtualFileSystemConfiguration.GVFS_SCHEME;
+  }
+
   @Override
   public synchronized Path getWorkingDirectory() {
     return this.workingDirectory;

--- a/clients/filesystem-hadoop3/src/test/java/org/apache/gravitino/filesystem/hadoop/TestGvfsBase.java
+++ b/clients/filesystem-hadoop3/src/test/java/org/apache/gravitino/filesystem/hadoop/TestGvfsBase.java
@@ -257,6 +257,17 @@ public class TestGvfsBase extends GravitinoMockServerBase {
   }
 
   @Test
+  public void testGetScheme() throws IOException {
+    Assumptions.assumeTrue(getClass() == TestGvfsBase.class);
+    try (FileSystem fs = new Path("gvfs://fileset/").getFileSystem(conf)) {
+      // The default FileSystem#getScheme() throws UnsupportedOperationException, which breaks
+      // Hadoop / Spark commit protocols when writing to a gvfs:// path. GVFS must override it
+      // and return the GVFS scheme constant.
+      assertEquals(GravitinoVirtualFileSystemConfiguration.GVFS_SCHEME, fs.getScheme());
+    }
+  }
+
+  @Test
   public void testRequestHeaders()
       throws NoSuchFieldException, IllegalAccessException, IOException {
     String envKey = "GRAVITINO_TEST_HEADER";


### PR DESCRIPTION
FileSystem#getScheme() throws UnsupportedOperationException by default, which breaks Hadoop/Spark commit protocols (e.g. FileOutputCommitter, ManifestCommitter) when writing to a gvfs:// path. Override getScheme() in GravitinoVirtualFileSystem to return the GVFS scheme constant. Added unit test testGetScheme in TestGvfsBase.

<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): Support xxx"
     - "[#233] fix: Check null before access result in xxx"
     - "[MINOR] refactor: Fix typo in variable name"
     - "[MINOR] docs: Fix typo in README"
     - "[#255] test: Fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Override `getScheme()` in `GravitinoVirtualFileSystem` to return the GVFS scheme constant (`gvfs`), instead of relying on the default `org.apache.hadoop.fs.FileSystem#getScheme()` which throws `UnsupportedOperationException`.

```java
@Override
public String getScheme() {
  return GravitinoVirtualFileSystemConfiguration.GVFS_SCHEME;
}
```

### Why are the changes needed?

Hadoop's default `FileSystem#getScheme()` throws `UnsupportedOperationException` if a subclass doesn't override it. Hadoop / Spark commit protocols call `getScheme()` during job setup / commit, so writing to a `gvfs://` path currently fails. Returning the well-known `gvfs` scheme — which is already the URI scheme GVFS advertises and the value of `GravitinoVirtualFileSystemConfiguration.GVFS_SCHEME` — makes GVFS behave like every other Hadoop `FileSystem` implementation (LocalFS → `file`, HDFS → `hdfs`, S3A → `s3a`, …).

Fix: #11813

### Does this PR introduce _any_ user-facing change?

No public API change. `FileSystem#getScheme()` on a `GravitinoVirtualFileSystem` instance now returns `"gvfs"` instead of throwing. No new / removed configuration keys.

### How was this patch tested?

Added a new unit test `TestGvfsBase#testGetScheme` that asserts `fs.getScheme()` equals `GravitinoVirtualFileSystemConfiguration.GVFS_SCHEME`. Ran `./gradlew :clients:filesystem-hadoop3:test` locally and all tests pass.
