### PR TITLE
[#11817] fix(idp): Use millisecond precision for soft deletes

### DIFF
--- a/plugins/idp-basic/src/main/java/org/apache/gravitino/idp/storage/mapper/provider/base/IdpGroupMetaBaseSQLProvider.java
+++ b/plugins/idp-basic/src/main/java/org/apache/gravitino/idp/storage/mapper/provider/base/IdpGroupMetaBaseSQLProvider.java
@@ -80,6 +80,6 @@ public class IdpGroupMetaBaseSQLProvider {
   }
 
   protected String currentTimeMillisExpression() {
-    return "(UNIX_TIMESTAMP() * 1000.0)";
+    return "(UNIX_TIMESTAMP() * 1000.0) + EXTRACT(MICROSECOND FROM CURRENT_TIMESTAMP(3)) / 1000";
   }
 }

--- a/plugins/idp-basic/src/main/java/org/apache/gravitino/idp/storage/mapper/provider/base/IdpUserGroupRelBaseSQLProvider.java
+++ b/plugins/idp-basic/src/main/java/org/apache/gravitino/idp/storage/mapper/provider/base/IdpUserGroupRelBaseSQLProvider.java
@@ -125,6 +125,6 @@ public class IdpUserGroupRelBaseSQLProvider {
   }
 
   protected String currentTimeMillisExpression() {
-    return "(UNIX_TIMESTAMP() * 1000.0)";
+    return "(UNIX_TIMESTAMP() * 1000.0) + EXTRACT(MICROSECOND FROM CURRENT_TIMESTAMP(3)) / 1000";
   }
 }

--- a/plugins/idp-basic/src/main/java/org/apache/gravitino/idp/storage/mapper/provider/base/IdpUserMetaBaseSQLProvider.java
+++ b/plugins/idp-basic/src/main/java/org/apache/gravitino/idp/storage/mapper/provider/base/IdpUserMetaBaseSQLProvider.java
@@ -105,6 +105,6 @@ public class IdpUserMetaBaseSQLProvider {
   }
 
   protected String currentTimeMillisExpression() {
-    return "(UNIX_TIMESTAMP() * 1000.0)";
+    return "(UNIX_TIMESTAMP() * 1000.0) + EXTRACT(MICROSECOND FROM CURRENT_TIMESTAMP(3)) / 1000";
   }
 }

--- a/plugins/idp-basic/src/test/java/org/apache/gravitino/idp/storage/mapper/provider/base/TestIdpBaseSQLProviders.java
+++ b/plugins/idp-basic/src/test/java/org/apache/gravitino/idp/storage/mapper/provider/base/TestIdpBaseSQLProviders.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.idp.storage.mapper.provider.base;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class TestIdpBaseSQLProviders {
+
+  private static final String MILLISECOND_TIMESTAMP_COMPONENT =
+      "EXTRACT(MICROSECOND FROM CURRENT_TIMESTAMP(3)) / 1000";
+
+  @Test
+  void testSoftDeleteIdpUserUsesMillisecondPrecisionDeletedAt() {
+    String sql = new IdpUserMetaBaseSQLProvider().softDeleteIdpUser("user1");
+
+    assertUsesMillisecondTimestamp(sql);
+  }
+
+  @Test
+  void testSoftDeleteIdpGroupUsesMillisecondPrecisionDeletedAt() {
+    String sql = new IdpGroupMetaBaseSQLProvider().softDeleteIdpGroup("group1");
+
+    assertUsesMillisecondTimestamp(sql);
+  }
+
+  @Test
+  void testSoftDeleteIdpUserGroupRelUsesMillisecondPrecisionDeletedAt() {
+    IdpUserGroupRelBaseSQLProvider provider = new IdpUserGroupRelBaseSQLProvider();
+
+    assertUsesMillisecondTimestamp(provider.softDeleteRelations("group1", List.of("user1")));
+    assertUsesMillisecondTimestamp(provider.softDeleteRelationsByUsername("user1"));
+    assertUsesMillisecondTimestamp(provider.softDeleteRelationsByGroupName("group1"));
+  }
+
+  private static void assertUsesMillisecondTimestamp(String sql) {
+    assertTrue(sql.contains("(UNIX_TIMESTAMP() * 1000.0)"), sql);
+    assertTrue(sql.contains(MILLISECOND_TIMESTAMP_COMPONENT), sql);
+  }
+}

--- a/plugins/idp-basic/src/test/java/org/apache/gravitino/idp/storage/mapper/provider/base/TestIdpSoftDeleteSQLProvider.java
+++ b/plugins/idp-basic/src/test/java/org/apache/gravitino/idp/storage/mapper/provider/base/TestIdpSoftDeleteSQLProvider.java
@@ -24,27 +24,27 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
-class TestIdpBaseSQLProviders {
+class TestIdpSoftDeleteSQLProvider {
 
   private static final String MILLISECOND_TIMESTAMP_COMPONENT =
       "EXTRACT(MICROSECOND FROM CURRENT_TIMESTAMP(3)) / 1000";
 
   @Test
-  void testSoftDeleteIdpUserUsesMillisecondPrecisionDeletedAt() {
+  void testUserDeletedAtPrecision() {
     String sql = new IdpUserMetaBaseSQLProvider().softDeleteIdpUser("user1");
 
     assertUsesMillisecondTimestamp(sql);
   }
 
   @Test
-  void testSoftDeleteIdpGroupUsesMillisecondPrecisionDeletedAt() {
+  void testGroupDeletedAtPrecision() {
     String sql = new IdpGroupMetaBaseSQLProvider().softDeleteIdpGroup("group1");
 
     assertUsesMillisecondTimestamp(sql);
   }
 
   @Test
-  void testSoftDeleteIdpUserGroupRelUsesMillisecondPrecisionDeletedAt() {
+  void testRelationDeletedAtPrecision() {
     IdpUserGroupRelBaseSQLProvider provider = new IdpUserGroupRelBaseSQLProvider();
 
     assertUsesMillisecondTimestamp(provider.softDeleteRelations("group1", List.of("user1")));


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR updates the built-in IdP MySQL soft-delete timestamp expression to include millisecond precision for:

- IdP user metadata
- IdP group metadata
- IdP user-group relation metadata

It also adds provider-level regression tests to make sure these soft-delete SQL statements keep the millisecond component.

### Why are the changes needed?

The IdP metadata tables use unique keys that include `deleted_at`, for example `(user_name, deleted_at)` on `idp_user_meta`.

The previous MySQL expression used only:

```sql
UNIX_TIMESTAMP() * 1000.0
```

In practice this can produce second-level effective values such as `...000`. If tests or clients delete, recreate, and delete the same IdP user/group/relation within the same second, the second soft delete can hit a duplicate key error. This caused the observed flaky `IdpRESTApiIT` failure in `IdP Basic Test`.

Fix: #11817

### Does this PR introduce _any_ user-facing change?

No. This only changes internal relational metadata soft-delete timestamp precision for the built-in IdP plugin.

### How was this patch tested?

- `env SKIP_DOCKER_TESTS=true ./gradlew :plugins:idp-basic:test -PskipITs -PskipDockerTests=true`
- `./gradlew :plugins:idp-basic:test -PtestMode=embedded -PjdbcBackend=mysql -PskipDockerTests=false --tests org.apache.gravitino.idp.integration.test.IdpRESTApiIT`
- `./gradlew :plugins:idp-basic:spotlessApply`
- `git diff --check`