### PR TITLE
[#11819] fix(ci): Use approved setup actions and add ASF actions allowlist check

### DIFF
--- a/.github/workflows/asf-allowlist-check.yml
+++ b/.github/workflows/asf-allowlist-check.yml
@@ -1,0 +1,43 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: "ASF Allowlist Check"
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - ".github/**"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/**"
+
+permissions:
+  contents: read
+
+jobs:
+  asf-allowlist-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: apache/infrastructure-actions/allowlist-check@main

--- a/.github/workflows/chart-release.yaml
+++ b/.github/workflows/chart-release.yaml
@@ -45,7 +45,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4.3.0
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310
 
       - name: Login to Docker Hub
         run: |

--- a/.github/workflows/chart-test.yaml
+++ b/.github/workflows/chart-test.yaml
@@ -34,7 +34,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Helm
-        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310
 
       - uses: actions/setup-python@v5.3.0
         with:
@@ -42,7 +42,7 @@ jobs:
           check-latest: true
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@6ec842c01de15ebb84c8627d2744a0c2f2755c9f
+        uses: helm/chart-testing-action@2fe8321ec9b8d234608c02c67623a886b72d7335
 
       - name: List changed
         id: list-changed
@@ -123,7 +123,7 @@ jobs:
           done
 
       - name: Set up kubectl
-        uses: azure/setup-kubectl@15650b3ad78fff148532a140b8a4c821796b2d7b
+        uses: azure/setup-kubectl@829323503d1be3d00ca8346e5391ca0b07a9ab0d
 
       - name: Run chart-testing (install default,gravitino)
         if: steps.list-changed.outputs.changed == 'true'

--- a/.github/workflows/trino-multi-version-test.yml
+++ b/.github/workflows/trino-multi-version-test.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: ./.github/actions/setup-java-toolchains
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
 
       - name: Check required command
         run: dev/ci/check_commands.sh


### PR DESCRIPTION
### What changes were proposed in this pull request?

1. Update `.github/workflows/chart-release.yaml` and `.github/workflows/chart-test.yaml` to use the secure, approved commit SHA `9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310` (corresponding to release tag `v5.0.1`) for `azure/setup-helm`.
2. Roll back `helm/chart-testing-action` in `.github/workflows/chart-test.yaml` to commit `2fe8321ec9b8d234608c02c67623a886b72d7335` to avoid invoking the unapproved `setup-uv` action in its latest version.
3. Update `.github/workflows/chart-test.yaml` to use the secure, approved commit SHA `829323503d1be3d00ca8346e5391ca0b07a9ab0d` (corresponding to release tag `v5.1.0`) for `azure/setup-kubectl`.
4. Update `.github/workflows/trino-multi-version-test.yml` to use the secure, approved commit SHA `ce360397dd3f832beb865e1373c09c0e9f86d70a` (corresponding to release tag `v4.0.0`) for `docker/setup-qemu-action`.
5. Add a new `.github/workflows/asf-allowlist-check.yml` workflow to automatically check the allowlist compliance of GitHub Actions on pull requests modifying `.github/` directory.

### Why are the changes needed?

1. The manual trigger of the `Publish Helm Charts` workflow failed because the Apache foundation security policy restricts third-party actions using version tags like `@v4.3.0`.
2. The latest commit of `helm/chart-testing-action` transitively invokes `astral-sh/setup-uv@eb1897b8dc4b5d5bfe39a428a8f2304605e0983c` which is not on the [ASF Infrastructure allowed actions list](https://github.com/apache/infrastructure-actions/blob/main/actions.yml). Rolling it back to the commit before introducing `setup-uv` resolves the issue.
3. The old commit SHA `15650b3ad78fff148532a140b8a4c821796b2d7b` used for `azure/setup-kubectl` is scheduled to expire on `2026-07-11` according to the allowed list, which requires an upgrade.
4. The tag version `v3` for `docker/setup-qemu-action` used in `trino-multi-version-test.yml` violates the security policy.
5. Adding the `asf-allowlist-check` workflow helps prevent similar silent "startup failure" issues in the future at the PR phase.

Fix: #11819

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

This is a GitHub Actions workflow configuration change. The commit SHAs are verified against the ASF Actions allowed list.
