### PR TITLE
[MINOR] fix(ci): align chart test actions with ASF allowlist

### DIFF
--- a/.github/workflows/asf-allowlist-check.yml
+++ b/.github/workflows/asf-allowlist-check.yml
@@ -41,3 +41,5 @@ jobs:
         with:
           persist-credentials: false
       - uses: apache/infrastructure-actions/allowlist-check@main
+        with:
+          scan-glob: ".github/**/*.y*ml"

--- a/.github/workflows/chart-test.yaml
+++ b/.github/workflows/chart-test.yaml
@@ -42,7 +42,7 @@ jobs:
           check-latest: true
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@2fe8321ec9b8d234608c02c67623a886b72d7335
+        uses: helm/chart-testing-action@6ec842c01de15ebb84c8627d2744a0c2f2755c9f # v2.8.0
 
       - name: List changed
         id: list-changed

--- a/.github/workflows/chart-test.yaml
+++ b/.github/workflows/chart-test.yaml
@@ -41,8 +41,51 @@ jobs:
           python-version: '3.x'
           check-latest: true
 
+      - name: Set up Cosign
+        uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
+
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@6ec842c01de15ebb84c8627d2744a0c2f2755c9f # v2.8.0
+        run: |
+          set -euo pipefail
+
+          CT_VERSION=3.14.0
+          YAMLLINT_VERSION=1.33.0
+          YAMALE_VERSION=6.0.0
+
+          if [[ "$(uname -m)" == "aarch64" ]]; then
+            arch=arm64
+          else
+            arch=amd64
+          fi
+
+          cache_dir="${RUNNER_TOOL_CACHE}/ct/${CT_VERSION}/${arch}"
+          venv_dir="${cache_dir}/venv"
+
+          if [[ ! -d "${cache_dir}" ]]; then
+            mkdir -p "${cache_dir}"
+
+            archive="chart-testing_${CT_VERSION}_linux_${arch}.tar.gz"
+            release_url="https://github.com/helm/chart-testing/releases/download/v${CT_VERSION}"
+
+            curl --retry 5 --retry-delay 1 -sSLo ct.tar.gz "${release_url}/${archive}"
+            cosign verify-blob --certificate "${release_url}/${archive}.pem" --signature "${release_url}/${archive}.sig" \
+              --certificate-identity "https://github.com/helm/chart-testing/.github/workflows/release.yaml@refs/heads/main" \
+              --certificate-oidc-issuer "https://token.actions.githubusercontent.com" ct.tar.gz
+
+            tar -xzf ct.tar.gz -C "${cache_dir}"
+            rm -f ct.tar.gz
+
+            python -m venv "${venv_dir}"
+            "${venv_dir}/bin/python" -m pip install --upgrade pip
+            "${venv_dir}/bin/python" -m pip install "yamllint==${YAMLLINT_VERSION}" "yamale==${YAMALE_VERSION}"
+          fi
+
+          echo "${cache_dir}" >> "${GITHUB_PATH}"
+          echo "CT_CONFIG_DIR=${cache_dir}/etc" >> "${GITHUB_ENV}"
+          echo "VIRTUAL_ENV=${venv_dir}" >> "${GITHUB_ENV}"
+          echo "${venv_dir}/bin" >> "${GITHUB_PATH}"
+
+          "${cache_dir}/ct" version
 
       - name: List changed
         id: list-changed


### PR DESCRIPTION
### What changes were proposed in this pull request?

Install chart-testing directly in the chart test workflow instead of using `helm/chart-testing-action`, and make the ASF allowlist check scan both `.yml` and `.yaml` workflow files.

The direct install keeps the same chart-testing version and verifies the release archive with the ASF-approved `sigstore/cosign-installer` action.

### Why are the changes needed?

`helm/chart-testing-action@6ec842...` is itself on the ASF allowlist, but its composite action invokes `astral-sh/setup-uv@eb189...`, which is not allowed by the GitHub Actions policy and causes `Test Charts` to fail while preparing required actions.

The allowlist check also used the default `.github/**/*.yml` scan glob, so it missed `.yaml` workflow files such as `chart-test.yaml`.

Fix: N/A

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

- Ran ASF allowlist check against `.github/**/*.y*ml`
- Ran `bash -n` against the generated chart-testing setup script
- Ran `git diff --check HEAD~2 HEAD`