### PR TITLE
[#11726] fix(core): fix IsolatedClassLoader lifecycle race in CatalogWrapper

### DIFF
--- a/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueCatalogCapability.java
+++ b/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueCatalogCapability.java
@@ -18,6 +18,7 @@
  */
 package org.apache.gravitino.catalog.glue;
 
+import com.google.common.base.Preconditions;
 import java.util.Locale;
 import org.apache.gravitino.connector.capability.Capability;
 import org.apache.gravitino.connector.capability.CapabilityResult;
@@ -62,18 +63,16 @@ public class GlueCatalogCapability implements Capability {
 
   @Override
   public CapabilityResult caseSensitiveOnName(Scope scope) {
-    switch (scope) {
-      case SCHEMA:
-      case TABLE:
-        // Glue folds database/table names to lowercase on storage.
-        // See https://docs.aws.amazon.com/glue/latest/dg/aws-glue-api-catalog-databases.html
-        // See https://docs.aws.amazon.com/glue/latest/dg/aws-glue-api-catalog-tables.html
-        return CapabilityResult.unsupported(
-            "AWS Glue Data Catalog is case-insensitive for "
-                + scope.name().toLowerCase(Locale.ROOT)
-                + " names.");
-      default:
-        return CapabilityResult.SUPPORTED;
+    Preconditions.checkArgument(scope != null, "scope cannot be null");
+    if (scope == Scope.SCHEMA || scope == Scope.TABLE) {
+      // Glue folds database/table names to lowercase on storage.
+      // See https://docs.aws.amazon.com/glue/latest/dg/aws-glue-api-catalog-databases.html
+      // See https://docs.aws.amazon.com/glue/latest/dg/aws-glue-api-catalog-tables.html
+      return CapabilityResult.unsupported(
+          "AWS Glue Data Catalog is case-insensitive for "
+              + scope.name().toLowerCase(Locale.ROOT)
+              + " names.");
     }
+    return CapabilityResult.SUPPORTED;
   }
 }

--- a/catalogs/catalog-hive/src/main/java/org/apache/gravitino/catalog/hive/HiveCatalogCapability.java
+++ b/catalogs/catalog-hive/src/main/java/org/apache/gravitino/catalog/hive/HiveCatalogCapability.java
@@ -18,6 +18,7 @@
  */
 package org.apache.gravitino.catalog.hive;
 
+import com.google.common.base.Preconditions;
 import org.apache.gravitino.connector.capability.Capability;
 import org.apache.gravitino.connector.capability.CapabilityResult;
 
@@ -42,15 +43,12 @@ public class HiveCatalogCapability implements Capability {
 
   @Override
   public CapabilityResult caseSensitiveOnName(Scope scope) {
-    switch (scope) {
-      case SCHEMA:
-      case TABLE:
-      case COLUMN:
-        // Hive is case insensitive, see
-        // https://cwiki.apache.org/confluence/display/Hive/User+FAQ#UserFAQ-AreHiveSQLidentifiers(e.g.tablenames,columnnames,etc)casesensitive?
-        return CapabilityResult.unsupported("Hive is case insensitive.");
-      default:
-        return CapabilityResult.SUPPORTED;
+    Preconditions.checkArgument(scope != null, "scope cannot be null");
+    if (scope == Scope.SCHEMA || scope == Scope.TABLE || scope == Scope.COLUMN) {
+      // Hive is case insensitive, see
+      // https://cwiki.apache.org/confluence/display/Hive/User+FAQ#UserFAQ-AreHiveSQLidentifiers(e.g.tablenames,columnnames,etc)casesensitive?
+      return CapabilityResult.unsupported("Hive is case insensitive.");
     }
+    return CapabilityResult.SUPPORTED;
   }
 }

--- a/catalogs/catalog-hive/src/test/java/org/apache/gravitino/catalog/hive/TestHiveCatalogCapability.java
+++ b/catalogs/catalog-hive/src/test/java/org/apache/gravitino/catalog/hive/TestHiveCatalogCapability.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.gravitino.catalog.glue;
+package org.apache.gravitino.catalog.hive;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -24,55 +24,44 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.EnumSet;
+import java.util.Set;
 import org.apache.gravitino.connector.capability.Capability;
 import org.apache.gravitino.connector.capability.CapabilityResult;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-class TestGlueCatalogCapability {
+class TestHiveCatalogCapability {
 
-  private GlueCatalogCapability capability;
+  private HiveCatalogCapability capability;
 
   @BeforeEach
   void setUp() {
-    capability = new GlueCatalogCapability();
+    capability = new HiveCatalogCapability();
   }
 
   @Test
-  void testColumnNotNullIsUnsupported() {
-    CapabilityResult result = capability.columnNotNull();
-    assertFalse(result.supported(), "Glue does not enforce NOT NULL constraints");
-    assertNotNull(result.unsupportedMessage());
-    assertFalse(result.unsupportedMessage().isEmpty());
+  void testCaseSensitiveOnHiveNamesIsUnsupported() {
+    Set<Capability.Scope> unsupportedScopes =
+        EnumSet.of(Capability.Scope.SCHEMA, Capability.Scope.TABLE, Capability.Scope.COLUMN);
+
+    for (Capability.Scope scope : unsupportedScopes) {
+      CapabilityResult result = capability.caseSensitiveOnName(scope);
+      assertFalse(result.supported(), "Hive is case-insensitive for " + scope + " names");
+      assertNotNull(result.unsupportedMessage());
+    }
   }
 
   @Test
-  void testColumnDefaultValueIsUnsupported() {
-    CapabilityResult result = capability.columnDefaultValue();
-    assertFalse(result.supported(), "Glue does not support DEFAULT values on columns");
-    assertNotNull(result.unsupportedMessage());
-    assertFalse(result.unsupportedMessage().isEmpty());
-  }
+  void testCaseSensitiveOnOtherScopesIsSupported() {
+    Set<Capability.Scope> unsupportedScopes =
+        EnumSet.of(Capability.Scope.SCHEMA, Capability.Scope.TABLE, Capability.Scope.COLUMN);
 
-  @Test
-  void testCaseSensitiveOnSchemaIsUnsupported() {
-    CapabilityResult result = capability.caseSensitiveOnName(Capability.Scope.SCHEMA);
-    assertFalse(result.supported(), "Glue folds schema names to lowercase");
-    assertNotNull(result.unsupportedMessage());
-  }
-
-  @Test
-  void testCaseSensitiveOnTableIsUnsupported() {
-    CapabilityResult result = capability.caseSensitiveOnName(Capability.Scope.TABLE);
-    assertFalse(result.supported(), "Glue folds table names to lowercase");
-    assertNotNull(result.unsupportedMessage());
-  }
-
-  @Test
-  void testCaseSensitiveOnColumnIsSupported() {
-    // Column name case folding is not documented in Glue Column API — treated as supported.
-    CapabilityResult result = capability.caseSensitiveOnName(Capability.Scope.COLUMN);
-    assertTrue(result.supported());
+    for (Capability.Scope scope : Capability.Scope.values()) {
+      if (!unsupportedScopes.contains(scope)) {
+        assertTrue(capability.caseSensitiveOnName(scope).supported());
+      }
+    }
   }
 
   @Test
@@ -83,14 +72,14 @@ class TestGlueCatalogCapability {
   @Test
   void testNoSwitchOnEnumSyntheticClass() {
     // Verifies that the if/else rewrite eliminated the compiler-generated $1 switch-map class.
-    // If switch-on-enum were still present, javac would produce GlueCatalogCapability$1.class,
+    // If switch-on-enum were still present, javac would produce HiveCatalogCapability$1.class,
     // which is loaded lazily on the first switch execution by the defining IsolatedClassLoader.
     // Closing that classloader before the first switch call would then cause a permanent
     // NoClassDefFoundError. The absence of $1 confirms this trigger is eliminated.
     String syntheticClassResource =
-        GlueCatalogCapability.class.getName().replace('.', '/') + "$1.class";
+        HiveCatalogCapability.class.getName().replace('.', '/') + "$1.class";
     assertNull(
-        GlueCatalogCapability.class.getClassLoader().getResource(syntheticClassResource),
-        "GlueCatalogCapability$1 switch-map class must not exist after if/else rewrite");
+        HiveCatalogCapability.class.getClassLoader().getResource(syntheticClassResource),
+        "HiveCatalogCapability$1 switch-map class must not exist after if/else rewrite");
   }
 }

--- a/core/src/main/java/org/apache/gravitino/catalog/CapabilityHelpers.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/CapabilityHelpers.java
@@ -59,7 +59,11 @@ public class CapabilityHelpers {
    *
    * <p>If the first attempt encounters a stale (already-closed) {@link
    * CatalogManager.CatalogWrapper}, the wrapper is evicted from the cache and the call is retried
-   * once with a freshly loaded wrapper.
+   * once with a freshly loaded wrapper. Retry is safe because {@code fn} is restricted to pure
+   * normalization and never performs external I/O, so re-execution is idempotent. The retry is
+   * triggered only on {@link CatalogManager.CatalogWrapperClosedException}, which is thrown
+   * exclusively at wrapper-entry before {@code fn} has run, preventing accidental replay of
+   * partially-executed non-idempotent operations.
    *
    * <p>Callers should use this method instead of calling {@code capabilities()} on a raw wrapper
    * invoke {@link Capability} methods so that the classloader lifecycle is properly bounded.
@@ -73,14 +77,14 @@ public class CapabilityHelpers {
   public static <R> R withCapability(
       NameIdentifier ident, CatalogManager catalogManager, ThrowableFunction<Capability, R> fn) {
     NameIdentifier catalogIdent = getCatalogIdentifier(ident);
-    RuntimeException closedException = null;
+    CatalogManager.CatalogWrapperClosedException lastClosed = null;
     for (int i = 0; i < 2; i++) {
       CatalogManager.CatalogWrapper c = catalogManager.loadCatalogAndWrap(catalogIdent);
       try {
         return c.doWithCapabilityOps(fn);
-      } catch (IllegalStateException e) {
-        if (c.isClosed() && i == 0) {
-          closedException = e;
+      } catch (CatalogManager.CatalogWrapperClosedException e) {
+        if (i == 0) {
+          lastClosed = e;
           continue;
         }
         throw e;
@@ -90,9 +94,9 @@ public class CapabilityHelpers {
         throw new RuntimeException("Failed to apply capabilities for catalog: " + catalogIdent, e);
       }
     }
-    throw closedException != null
-        ? closedException
-        : new IllegalStateException("CatalogWrapper is already closed");
+    throw lastClosed != null
+        ? lastClosed
+        : new CatalogManager.CatalogWrapperClosedException("CatalogWrapper is already closed");
   }
 
   public static Column[] applyCapabilities(Column[] columns, Capability capabilities) {

--- a/core/src/main/java/org/apache/gravitino/catalog/CapabilityHelpers.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/CapabilityHelpers.java
@@ -47,17 +47,52 @@ import org.apache.gravitino.rel.partitions.ListPartition;
 import org.apache.gravitino.rel.partitions.Partition;
 import org.apache.gravitino.rel.partitions.Partitions;
 import org.apache.gravitino.rel.partitions.RangePartition;
+import org.apache.gravitino.utils.ThrowableFunction;
 
 public class CapabilityHelpers {
 
-  public static Capability getCapability(NameIdentifier ident, CatalogManager catalogManager) {
+  /**
+   * Executes {@code fn} with the {@link Capability} of the catalog identified by {@code ident},
+   * inside the catalog's classloader boundary. This prevents the catalog's {@link
+   * org.apache.gravitino.utils.IsolatedClassLoader} from being closed while capability methods are
+   * executing.
+   *
+   * <p>If the first attempt encounters a stale (already-closed) {@link
+   * CatalogManager.CatalogWrapper}, the wrapper is evicted from the cache and the call is retried
+   * once with a freshly loaded wrapper.
+   *
+   * <p>Callers should use this method instead of calling {@code capabilities()} on a raw wrapper
+   * invoke {@link Capability} methods so that the classloader lifecycle is properly bounded.
+   *
+   * @param ident any {@link NameIdentifier} that belongs to the target catalog
+   * @param catalogManager the catalog manager used to load the catalog
+   * @param fn function to execute with the catalog's {@link Capability}
+   * @param <R> return type
+   * @return the result of {@code fn}
+   */
+  public static <R> R withCapability(
+      NameIdentifier ident, CatalogManager catalogManager, ThrowableFunction<Capability, R> fn) {
     NameIdentifier catalogIdent = getCatalogIdentifier(ident);
-    CatalogManager.CatalogWrapper c = catalogManager.loadCatalogAndWrap(catalogIdent);
-    try {
-      return c.capabilities();
-    } catch (Exception e) {
-      throw new RuntimeException("Failed to get capabilities for catalog: " + catalogIdent, e);
+    RuntimeException closedException = null;
+    for (int i = 0; i < 2; i++) {
+      CatalogManager.CatalogWrapper c = catalogManager.loadCatalogAndWrap(catalogIdent);
+      try {
+        return c.doWithCapabilityOps(fn);
+      } catch (IllegalStateException e) {
+        if (c.isClosed() && i == 0) {
+          closedException = e;
+          continue;
+        }
+        throw e;
+      } catch (RuntimeException e) {
+        throw e;
+      } catch (Exception e) {
+        throw new RuntimeException("Failed to apply capabilities for catalog: " + catalogIdent, e);
+      }
     }
+    throw closedException != null
+        ? closedException
+        : new IllegalStateException("CatalogWrapper is already closed");
   }
 
   public static Column[] applyCapabilities(Column[] columns, Capability capabilities) {
@@ -129,8 +164,7 @@ public class CapabilityHelpers {
    */
   public static NameIdentifier applyCapabilities(
       NameIdentifier ident, Capability.Scope scope, CatalogManager catalogManager) {
-    Capability capability = getCapability(ident, catalogManager);
-    return applyCapabilities(ident, scope, capability);
+    return withCapability(ident, catalogManager, cap -> applyCapabilities(ident, scope, cap));
   }
 
   public static NameIdentifier[] applyCaseSensitive(

--- a/core/src/main/java/org/apache/gravitino/catalog/CapabilityHelpers.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/CapabilityHelpers.java
@@ -60,12 +60,15 @@ public class CapabilityHelpers {
    * <p>If the first attempt encounters a stale (already-closed) {@link
    * CatalogManager.CatalogWrapper}, the wrapper is evicted from the cache and the call is retried
    * once with a freshly loaded wrapper. Retry is safe because {@code fn} is restricted to pure
-   * normalization and never performs external I/O, so re-execution is idempotent. The retry is
-   * triggered only on {@link CatalogManager.CatalogWrapperClosedException}, which is thrown
-   * exclusively at wrapper-entry before {@code fn} has run, preventing accidental replay of
-   * partially-executed non-idempotent operations.
+   * normalization and never performs external I/O. Retry is triggered only on {@link
+   * CatalogManager.CatalogWrapperClosedException}, which is thrown exclusively at wrapper-entry
+   * before {@code fn} has run.
    *
-   * <p>Callers should use this method instead of calling {@code capabilities()} on a raw wrapper
+   * <p>With {@link org.apache.gravitino.utils.ClassLoaderPool} managing ClassLoader lifecycle via
+   * reference counting, eviction-triggered close is infrequent in pooled mode, but the retry
+   * remains necessary for non-pooled deployments ({@code classloader.sharing.enabled=false}).
+   *
+   * <p>Callers should use this method instead of calling {@code capabilities()} on a raw wrapper to
    * invoke {@link Capability} methods so that the classloader lifecycle is properly bounded.
    *
    * @param ident any {@link NameIdentifier} that belongs to the target catalog

--- a/core/src/main/java/org/apache/gravitino/catalog/CatalogManager.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/CatalogManager.java
@@ -155,6 +155,18 @@ public class CatalogManager implements CatalogDispatcher, Closeable {
           "uri",
           "fs.defaultFS");
 
+  /**
+   * Thrown by {@link CatalogWrapper#doWithCapabilityOps} exclusively when the wrapper is already
+   * closed at the time of the call (i.e. before {@code fn} has had a chance to run). This lets
+   * {@link CapabilityHelpers#withCapability} distinguish a safe-to-retry "entry-closed" condition
+   * from an {@link IllegalStateException} thrown by {@code fn} itself mid-execution.
+   */
+  static class CatalogWrapperClosedException extends IllegalStateException {
+    CatalogWrapperClosedException(String message) {
+      super(message);
+    }
+  }
+
   /** Wrapper class for a catalog instance and its class loader. */
   public static class CatalogWrapper {
 
@@ -280,8 +292,16 @@ public class CatalogManager implements CatalogDispatcher, Closeable {
       return classLoader.withClassLoader(cl -> fn.apply(catalog));
     }
 
+    public synchronized <R> R doWithCapabilityOps(ThrowableFunction<Capability, R> fn)
+        throws Exception {
+      if (closed) {
+        throw new CatalogWrapperClosedException("CatalogWrapper is already closed");
+      }
+      return classLoader.withClassLoader(cl -> fn.apply(catalog.capability()));
+    }
+
     public Capability capabilities() throws Exception {
-      return classLoader.withClassLoader(cl -> catalog.capability());
+      return doWithCapabilityOps(capability -> capability);
     }
 
     public synchronized void close() {

--- a/core/src/main/java/org/apache/gravitino/catalog/FilesetNormalizeDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/FilesetNormalizeDispatcher.java
@@ -20,10 +20,11 @@ package org.apache.gravitino.catalog;
 
 import static org.apache.gravitino.catalog.CapabilityHelpers.applyCapabilities;
 import static org.apache.gravitino.catalog.CapabilityHelpers.applyCaseSensitive;
-import static org.apache.gravitino.catalog.CapabilityHelpers.getCapability;
+import static org.apache.gravitino.catalog.CapabilityHelpers.withCapability;
 
 import java.io.IOException;
 import java.util.Map;
+import org.apache.commons.lang3.ArrayUtils;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
 import org.apache.gravitino.connector.capability.Capability;
@@ -35,10 +36,6 @@ import org.apache.gravitino.file.FileInfo;
 import org.apache.gravitino.file.Fileset;
 import org.apache.gravitino.file.FilesetChange;
 
-/**
- * Note on list operations: names returned by list methods (e.g. {@link #listFilesets(Namespace)})
- * are assumed to already be in their canonical, legal form and are not re-normalized here.
- */
 public class FilesetNormalizeDispatcher implements FilesetDispatcher {
   private final CatalogManager catalogManager;
   private final FilesetDispatcher dispatcher;
@@ -53,7 +50,8 @@ public class FilesetNormalizeDispatcher implements FilesetDispatcher {
     // The constraints of the name spec may be more strict than underlying catalog,
     // and for compatibility reasons, we only apply case-sensitive capabilities here.
     Namespace caseSensitiveNs = normalizeCaseSensitive(namespace);
-    return dispatcher.listFilesets(caseSensitiveNs);
+    NameIdentifier[] identifiers = dispatcher.listFilesets(caseSensitiveNs);
+    return normalizeCaseSensitive(identifiers);
   }
 
   @Override
@@ -91,11 +89,15 @@ public class FilesetNormalizeDispatcher implements FilesetDispatcher {
   @Override
   public Fileset alterFileset(NameIdentifier ident, FilesetChange... changes)
       throws NoSuchFilesetException, IllegalArgumentException {
-    Capability capability = getCapability(ident, catalogManager);
-    return dispatcher.alterFileset(
-        // The constraints of the name spec may be more strict than underlying catalog,
-        // and for compatibility reasons, we only apply case-sensitive capabilities here.
-        normalizeCaseSensitive(ident), applyCapabilities(capability, changes));
+    return withCapability(
+        ident,
+        catalogManager,
+        capability ->
+            dispatcher.alterFileset(
+                // The constraints of the name spec may be more strict than underlying catalog,
+                // and for compatibility reasons, we only apply case-sensitive capabilities here.
+                applyCaseSensitive(ident, Capability.Scope.FILESET, capability),
+                applyCapabilities(capability, changes)));
   }
 
   @Override
@@ -114,17 +116,32 @@ public class FilesetNormalizeDispatcher implements FilesetDispatcher {
   }
 
   private NameIdentifier normalizeNameIdentifier(NameIdentifier ident) {
-    Capability capabilities = getCapability(ident, catalogManager);
-    return applyCapabilities(ident, Capability.Scope.FILESET, capabilities);
+    return withCapability(
+        ident, catalogManager, cap -> applyCapabilities(ident, Capability.Scope.FILESET, cap));
   }
 
   private Namespace normalizeCaseSensitive(Namespace namespace) {
-    Capability capabilities = getCapability(NameIdentifier.of(namespace.levels()), catalogManager);
-    return applyCaseSensitive(namespace, Capability.Scope.FILESET, capabilities);
+    return withCapability(
+        NameIdentifier.of(namespace.levels()),
+        catalogManager,
+        cap -> applyCaseSensitive(namespace, Capability.Scope.FILESET, cap));
   }
 
   private NameIdentifier normalizeCaseSensitive(NameIdentifier filesetIdent) {
-    Capability capabilities = getCapability(filesetIdent, catalogManager);
-    return applyCaseSensitive(filesetIdent, Capability.Scope.FILESET, capabilities);
+    return withCapability(
+        filesetIdent,
+        catalogManager,
+        cap -> applyCaseSensitive(filesetIdent, Capability.Scope.FILESET, cap));
+  }
+
+  private NameIdentifier[] normalizeCaseSensitive(NameIdentifier[] filesetIdents) {
+    if (ArrayUtils.isEmpty(filesetIdents)) {
+      return filesetIdents;
+    }
+
+    return withCapability(
+        filesetIdents[0],
+        catalogManager,
+        cap -> applyCaseSensitive(filesetIdents, Capability.Scope.FILESET, cap));
   }
 }

--- a/core/src/main/java/org/apache/gravitino/catalog/FilesetNormalizeDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/FilesetNormalizeDispatcher.java
@@ -25,6 +25,7 @@ import static org.apache.gravitino.catalog.CapabilityHelpers.withCapability;
 import java.io.IOException;
 import java.util.Map;
 import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
 import org.apache.gravitino.connector.capability.Capability;
@@ -89,15 +90,17 @@ public class FilesetNormalizeDispatcher implements FilesetDispatcher {
   @Override
   public Fileset alterFileset(NameIdentifier ident, FilesetChange... changes)
       throws NoSuchFilesetException, IllegalArgumentException {
-    return withCapability(
-        ident,
-        catalogManager,
-        capability ->
-            dispatcher.alterFileset(
-                // The constraints of the name spec may be more strict than underlying catalog,
-                // and for compatibility reasons, we only apply case-sensitive capabilities here.
-                applyCaseSensitive(ident, Capability.Scope.FILESET, capability),
-                applyCapabilities(capability, changes)));
+    // The constraints of the name spec may be more strict than underlying catalog,
+    // and for compatibility reasons, we only apply case-sensitive capabilities here.
+    Pair<NameIdentifier, FilesetChange[]> normalized =
+        withCapability(
+            ident,
+            catalogManager,
+            cap ->
+                Pair.of(
+                    applyCaseSensitive(ident, Capability.Scope.FILESET, cap),
+                    applyCapabilities(cap, changes)));
+    return dispatcher.alterFileset(normalized.getLeft(), normalized.getRight());
   }
 
   @Override

--- a/core/src/main/java/org/apache/gravitino/catalog/FunctionNormalizeDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/FunctionNormalizeDispatcher.java
@@ -95,14 +95,23 @@ public class FunctionNormalizeDispatcher implements FunctionDispatcher {
   }
 
   private Namespace normalizeCaseSensitive(Namespace namespace) {
-    return withCapability(NameIdentifier.of(namespace.levels()), catalogManager, cap -> applyCaseSensitive(namespace, Capability.Scope.FUNCTION, cap));
+    return withCapability(
+        NameIdentifier.of(namespace.levels()),
+        catalogManager,
+        cap -> applyCaseSensitive(namespace, Capability.Scope.FUNCTION, cap));
   }
 
   private NameIdentifier normalizeCaseSensitive(NameIdentifier functionIdent) {
-    return withCapability(functionIdent, catalogManager, cap -> applyCaseSensitive(functionIdent, Capability.Scope.FUNCTION, cap));
+    return withCapability(
+        functionIdent,
+        catalogManager,
+        cap -> applyCaseSensitive(functionIdent, Capability.Scope.FUNCTION, cap));
   }
 
   private NameIdentifier normalizeNameIdentifier(NameIdentifier functionIdent) {
-    return withCapability(functionIdent, catalogManager, cap -> applyCapabilities(functionIdent, Capability.Scope.FUNCTION, capability));
+    return withCapability(
+        functionIdent,
+        catalogManager,
+        cap -> applyCapabilities(functionIdent, Capability.Scope.FUNCTION, cap));
   }
 }

--- a/core/src/main/java/org/apache/gravitino/catalog/FunctionNormalizeDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/FunctionNormalizeDispatcher.java
@@ -20,7 +20,7 @@ package org.apache.gravitino.catalog;
 
 import static org.apache.gravitino.catalog.CapabilityHelpers.applyCapabilities;
 import static org.apache.gravitino.catalog.CapabilityHelpers.applyCaseSensitive;
-import static org.apache.gravitino.catalog.CapabilityHelpers.getCapability;
+import static org.apache.gravitino.catalog.CapabilityHelpers.withCapability;
 
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
@@ -95,17 +95,14 @@ public class FunctionNormalizeDispatcher implements FunctionDispatcher {
   }
 
   private Namespace normalizeCaseSensitive(Namespace namespace) {
-    Capability capabilities = getCapability(NameIdentifier.of(namespace.levels()), catalogManager);
-    return applyCaseSensitive(namespace, Capability.Scope.FUNCTION, capabilities);
+    return withCapability(NameIdentifier.of(namespace.levels()), catalogManager, cap -> applyCaseSensitive(namespace, Capability.Scope.FUNCTION, cap));
   }
 
   private NameIdentifier normalizeCaseSensitive(NameIdentifier functionIdent) {
-    Capability capabilities = getCapability(functionIdent, catalogManager);
-    return applyCaseSensitive(functionIdent, Capability.Scope.FUNCTION, capabilities);
+    return withCapability(functionIdent, catalogManager, cap -> applyCaseSensitive(functionIdent, Capability.Scope.FUNCTION, cap));
   }
 
   private NameIdentifier normalizeNameIdentifier(NameIdentifier functionIdent) {
-    Capability capability = getCapability(functionIdent, catalogManager);
-    return applyCapabilities(functionIdent, Capability.Scope.FUNCTION, capability);
+    return withCapability(functionIdent, catalogManager, cap -> applyCapabilities(functionIdent, Capability.Scope.FUNCTION, capability));
   }
 }

--- a/core/src/main/java/org/apache/gravitino/catalog/ModelNormalizeDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/ModelNormalizeDispatcher.java
@@ -174,14 +174,19 @@ public class ModelNormalizeDispatcher implements ModelDispatcher {
   }
 
   private Namespace normalizeCaseSensitive(Namespace namespace) {
-    return withCapability(NameIdentifier.of(namespace.levels()), catalogManager, cap -> applyCaseSensitive(namespace, Capability.Scope.MODEL, cap));
+    return withCapability(
+        NameIdentifier.of(namespace.levels()),
+        catalogManager,
+        cap -> applyCaseSensitive(namespace, Capability.Scope.MODEL, cap));
   }
 
   private NameIdentifier normalizeCaseSensitive(NameIdentifier ident) {
-    return withCapability(ident, catalogManager, cap -> applyCaseSensitive(ident, Capability.Scope.MODEL, cap));
+    return withCapability(
+        ident, catalogManager, cap -> applyCaseSensitive(ident, Capability.Scope.MODEL, cap));
   }
 
   private NameIdentifier normalizeNameIdentifier(NameIdentifier ident) {
-    return withCapability(ident, catalogManager, cap -> applyCapabilities(ident, Capability.Scope.MODEL, capability));
+    return withCapability(
+        ident, catalogManager, cap -> applyCapabilities(ident, Capability.Scope.MODEL, cap));
   }
 }

--- a/core/src/main/java/org/apache/gravitino/catalog/ModelNormalizeDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/ModelNormalizeDispatcher.java
@@ -20,7 +20,7 @@ package org.apache.gravitino.catalog;
 
 import static org.apache.gravitino.catalog.CapabilityHelpers.applyCapabilities;
 import static org.apache.gravitino.catalog.CapabilityHelpers.applyCaseSensitive;
-import static org.apache.gravitino.catalog.CapabilityHelpers.getCapability;
+import static org.apache.gravitino.catalog.CapabilityHelpers.withCapability;
 
 import java.util.Map;
 import org.apache.gravitino.NameIdentifier;
@@ -174,17 +174,14 @@ public class ModelNormalizeDispatcher implements ModelDispatcher {
   }
 
   private Namespace normalizeCaseSensitive(Namespace namespace) {
-    Capability capabilities = getCapability(NameIdentifier.of(namespace.levels()), catalogManager);
-    return applyCaseSensitive(namespace, Capability.Scope.MODEL, capabilities);
+    return withCapability(NameIdentifier.of(namespace.levels()), catalogManager, cap -> applyCaseSensitive(namespace, Capability.Scope.MODEL, cap));
   }
 
   private NameIdentifier normalizeCaseSensitive(NameIdentifier ident) {
-    Capability capabilities = getCapability(ident, catalogManager);
-    return applyCaseSensitive(ident, Capability.Scope.MODEL, capabilities);
+    return withCapability(ident, catalogManager, cap -> applyCaseSensitive(ident, Capability.Scope.MODEL, cap));
   }
 
   private NameIdentifier normalizeNameIdentifier(NameIdentifier ident) {
-    Capability capability = getCapability(ident, catalogManager);
-    return applyCapabilities(ident, Capability.Scope.MODEL, capability);
+    return withCapability(ident, catalogManager, cap -> applyCapabilities(ident, Capability.Scope.MODEL, capability));
   }
 }

--- a/core/src/main/java/org/apache/gravitino/catalog/OperationDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/OperationDispatcher.java
@@ -228,7 +228,7 @@ public abstract class OperationDispatcher {
   boolean isManagedEntity(NameIdentifier catalogIdent, Capability.Scope scope) {
     return doWithCatalog(
         catalogIdent,
-        c -> c.capabilities().managedStorage(scope).supported(),
+        c -> c.doWithCapabilityOps(cap -> cap.managedStorage(scope).supported()),
         IllegalArgumentException.class);
   }
 

--- a/core/src/main/java/org/apache/gravitino/catalog/PartitionNormalizeDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/PartitionNormalizeDispatcher.java
@@ -23,6 +23,7 @@ import static org.apache.gravitino.catalog.CapabilityHelpers.applyCaseSensitiveO
 import static org.apache.gravitino.catalog.CapabilityHelpers.withCapability;
 
 import java.util.Arrays;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.connector.capability.Capability;
 import org.apache.gravitino.exceptions.NoSuchPartitionException;
@@ -41,76 +42,85 @@ public class PartitionNormalizeDispatcher implements PartitionDispatcher {
 
   @Override
   public String[] listPartitionNames(NameIdentifier tableIdent) {
+    NameIdentifier normalizedIdent =
+        withCapability(
+            tableIdent,
+            catalogManager,
+            cap -> applyCaseSensitive(tableIdent, Capability.Scope.TABLE, cap));
+    String[] rawNames = dispatcher.listPartitionNames(normalizedIdent);
     return withCapability(
         tableIdent,
         catalogManager,
-        cap -> {
-          String[] partitionNames =
-              dispatcher.listPartitionNames(
-                  applyCaseSensitive(tableIdent, Capability.Scope.TABLE, cap));
-          return Arrays.stream(partitionNames)
-              .map(n -> applyCaseSensitiveOnName(Capability.Scope.PARTITION, n, cap))
-              .toArray(String[]::new);
-        });
+        cap ->
+            Arrays.stream(rawNames)
+                .map(n -> applyCaseSensitiveOnName(Capability.Scope.PARTITION, n, cap))
+                .toArray(String[]::new));
   }
 
   @Override
   public Partition[] listPartitions(NameIdentifier tableIdent) {
+    NameIdentifier normalizedIdent =
+        withCapability(
+            tableIdent,
+            catalogManager,
+            cap -> CapabilityHelpers.applyCaseSensitive(tableIdent, Capability.Scope.TABLE, cap));
+    Partition[] rawPartitions = dispatcher.listPartitions(normalizedIdent);
     return withCapability(
-        tableIdent,
-        catalogManager,
-        cap -> {
-          Partition[] partitions =
-              dispatcher.listPartitions(
-                  CapabilityHelpers.applyCaseSensitive(tableIdent, Capability.Scope.TABLE, cap));
-          return applyCaseSensitive(partitions, cap);
-        });
+        tableIdent, catalogManager, cap -> applyCaseSensitive(rawPartitions, cap));
   }
 
   @Override
   public Partition getPartition(NameIdentifier tableIdent, String partitionName)
       throws NoSuchPartitionException {
-    return withCapability(
-        tableIdent,
-        catalogManager,
-        cap ->
-            dispatcher.getPartition(
-                CapabilityHelpers.applyCaseSensitive(tableIdent, Capability.Scope.TABLE, cap),
-                applyCaseSensitiveOnName(Capability.Scope.PARTITION, partitionName, cap)));
+    Pair<NameIdentifier, String> normalized =
+        withCapability(
+            tableIdent,
+            catalogManager,
+            cap ->
+                Pair.of(
+                    CapabilityHelpers.applyCaseSensitive(tableIdent, Capability.Scope.TABLE, cap),
+                    applyCaseSensitiveOnName(Capability.Scope.PARTITION, partitionName, cap)));
+    return dispatcher.getPartition(normalized.getLeft(), normalized.getRight());
   }
 
   @Override
   public Partition addPartition(NameIdentifier tableIdent, Partition partition)
       throws PartitionAlreadyExistsException {
-    return withCapability(
-        tableIdent,
-        catalogManager,
-        cap ->
-            dispatcher.addPartition(
-                CapabilityHelpers.applyCaseSensitive(tableIdent, Capability.Scope.TABLE, cap),
-                applyCaseSensitive(partition, cap)));
+    Pair<NameIdentifier, Partition> normalized =
+        withCapability(
+            tableIdent,
+            catalogManager,
+            cap ->
+                Pair.of(
+                    CapabilityHelpers.applyCaseSensitive(tableIdent, Capability.Scope.TABLE, cap),
+                    applyCaseSensitive(partition, cap)));
+    return dispatcher.addPartition(normalized.getLeft(), normalized.getRight());
   }
 
   @Override
   public boolean dropPartition(NameIdentifier tableIdent, String partitionName) {
-    return withCapability(
-        tableIdent,
-        catalogManager,
-        cap ->
-            dispatcher.dropPartition(
-                CapabilityHelpers.applyCaseSensitive(tableIdent, Capability.Scope.TABLE, cap),
-                applyCaseSensitiveOnName(Capability.Scope.PARTITION, partitionName, cap)));
+    Pair<NameIdentifier, String> normalized =
+        withCapability(
+            tableIdent,
+            catalogManager,
+            cap ->
+                Pair.of(
+                    CapabilityHelpers.applyCaseSensitive(tableIdent, Capability.Scope.TABLE, cap),
+                    applyCaseSensitiveOnName(Capability.Scope.PARTITION, partitionName, cap)));
+    return dispatcher.dropPartition(normalized.getLeft(), normalized.getRight());
   }
 
   @Override
   public boolean purgePartition(NameIdentifier tableIdent, String partitionName)
       throws UnsupportedOperationException {
-    return withCapability(
-        tableIdent,
-        catalogManager,
-        cap ->
-            dispatcher.purgePartition(
-                CapabilityHelpers.applyCaseSensitive(tableIdent, Capability.Scope.TABLE, cap),
-                applyCaseSensitiveOnName(Capability.Scope.PARTITION, partitionName, cap)));
+    Pair<NameIdentifier, String> normalized =
+        withCapability(
+            tableIdent,
+            catalogManager,
+            cap ->
+                Pair.of(
+                    CapabilityHelpers.applyCaseSensitive(tableIdent, Capability.Scope.TABLE, cap),
+                    applyCaseSensitiveOnName(Capability.Scope.PARTITION, partitionName, cap)));
+    return dispatcher.purgePartition(normalized.getLeft(), normalized.getRight());
   }
 }

--- a/core/src/main/java/org/apache/gravitino/catalog/PartitionNormalizeDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/PartitionNormalizeDispatcher.java
@@ -20,19 +20,15 @@ package org.apache.gravitino.catalog;
 
 import static org.apache.gravitino.catalog.CapabilityHelpers.applyCaseSensitive;
 import static org.apache.gravitino.catalog.CapabilityHelpers.applyCaseSensitiveOnName;
-import static org.apache.gravitino.catalog.CapabilityHelpers.getCapability;
+import static org.apache.gravitino.catalog.CapabilityHelpers.withCapability;
 
+import java.util.Arrays;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.connector.capability.Capability;
 import org.apache.gravitino.exceptions.NoSuchPartitionException;
 import org.apache.gravitino.exceptions.PartitionAlreadyExistsException;
 import org.apache.gravitino.rel.partitions.Partition;
 
-/**
- * Note on list operations: names returned by list methods (e.g. {@link
- * #listPartitionNames(NameIdentifier)}, {@link #listPartitions(NameIdentifier)}) are assumed to
- * already be in their canonical, legal form and are not re-normalized here.
- */
 public class PartitionNormalizeDispatcher implements PartitionDispatcher {
   private final CatalogManager catalogManager;
   private final PartitionDispatcher dispatcher;
@@ -45,50 +41,76 @@ public class PartitionNormalizeDispatcher implements PartitionDispatcher {
 
   @Override
   public String[] listPartitionNames(NameIdentifier tableIdent) {
-    Capability capabilities = getCapability(tableIdent, catalogManager);
-    return dispatcher.listPartitionNames(
-        applyCaseSensitive(tableIdent, Capability.Scope.TABLE, capabilities));
+    return withCapability(
+        tableIdent,
+        catalogManager,
+        cap -> {
+          String[] partitionNames =
+              dispatcher.listPartitionNames(
+                  applyCaseSensitive(tableIdent, Capability.Scope.TABLE, cap));
+          return Arrays.stream(partitionNames)
+              .map(n -> applyCaseSensitiveOnName(Capability.Scope.PARTITION, n, cap))
+              .toArray(String[]::new);
+        });
   }
 
   @Override
   public Partition[] listPartitions(NameIdentifier tableIdent) {
-    Capability capabilities = getCapability(tableIdent, catalogManager);
-    return dispatcher.listPartitions(
-        CapabilityHelpers.applyCaseSensitive(tableIdent, Capability.Scope.TABLE, capabilities));
+    return withCapability(
+        tableIdent,
+        catalogManager,
+        cap -> {
+          Partition[] partitions =
+              dispatcher.listPartitions(
+                  CapabilityHelpers.applyCaseSensitive(tableIdent, Capability.Scope.TABLE, cap));
+          return applyCaseSensitive(partitions, cap);
+        });
   }
 
   @Override
   public Partition getPartition(NameIdentifier tableIdent, String partitionName)
       throws NoSuchPartitionException {
-    Capability capabilities = getCapability(tableIdent, catalogManager);
-    return dispatcher.getPartition(
-        CapabilityHelpers.applyCaseSensitive(tableIdent, Capability.Scope.TABLE, capabilities),
-        applyCaseSensitiveOnName(Capability.Scope.PARTITION, partitionName, capabilities));
+    return withCapability(
+        tableIdent,
+        catalogManager,
+        cap ->
+            dispatcher.getPartition(
+                CapabilityHelpers.applyCaseSensitive(tableIdent, Capability.Scope.TABLE, cap),
+                applyCaseSensitiveOnName(Capability.Scope.PARTITION, partitionName, cap)));
   }
 
   @Override
   public Partition addPartition(NameIdentifier tableIdent, Partition partition)
       throws PartitionAlreadyExistsException {
-    Capability capabilities = getCapability(tableIdent, catalogManager);
-    return dispatcher.addPartition(
-        CapabilityHelpers.applyCaseSensitive(tableIdent, Capability.Scope.TABLE, capabilities),
-        applyCaseSensitive(partition, capabilities));
+    return withCapability(
+        tableIdent,
+        catalogManager,
+        cap ->
+            dispatcher.addPartition(
+                CapabilityHelpers.applyCaseSensitive(tableIdent, Capability.Scope.TABLE, cap),
+                applyCaseSensitive(partition, cap)));
   }
 
   @Override
   public boolean dropPartition(NameIdentifier tableIdent, String partitionName) {
-    Capability capabilities = getCapability(tableIdent, catalogManager);
-    return dispatcher.dropPartition(
-        CapabilityHelpers.applyCaseSensitive(tableIdent, Capability.Scope.TABLE, capabilities),
-        applyCaseSensitiveOnName(Capability.Scope.PARTITION, partitionName, capabilities));
+    return withCapability(
+        tableIdent,
+        catalogManager,
+        cap ->
+            dispatcher.dropPartition(
+                CapabilityHelpers.applyCaseSensitive(tableIdent, Capability.Scope.TABLE, cap),
+                applyCaseSensitiveOnName(Capability.Scope.PARTITION, partitionName, cap)));
   }
 
   @Override
   public boolean purgePartition(NameIdentifier tableIdent, String partitionName)
       throws UnsupportedOperationException {
-    Capability capabilities = getCapability(tableIdent, catalogManager);
-    return dispatcher.purgePartition(
-        CapabilityHelpers.applyCaseSensitive(tableIdent, Capability.Scope.TABLE, capabilities),
-        applyCaseSensitiveOnName(Capability.Scope.PARTITION, partitionName, capabilities));
+    return withCapability(
+        tableIdent,
+        catalogManager,
+        cap ->
+            dispatcher.purgePartition(
+                CapabilityHelpers.applyCaseSensitive(tableIdent, Capability.Scope.TABLE, cap),
+                applyCaseSensitiveOnName(Capability.Scope.PARTITION, partitionName, cap)));
   }
 }

--- a/core/src/main/java/org/apache/gravitino/catalog/SchemaNormalizeDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/SchemaNormalizeDispatcher.java
@@ -20,7 +20,7 @@ package org.apache.gravitino.catalog;
 
 import static org.apache.gravitino.catalog.CapabilityHelpers.applyCapabilities;
 import static org.apache.gravitino.catalog.CapabilityHelpers.applyCaseSensitive;
-import static org.apache.gravitino.catalog.CapabilityHelpers.getCapability;
+import static org.apache.gravitino.catalog.CapabilityHelpers.withCapability;
 
 import java.util.Map;
 import org.apache.gravitino.NameIdentifier;
@@ -97,17 +97,14 @@ public class SchemaNormalizeDispatcher implements SchemaDispatcher {
   }
 
   private boolean supportsHierarchicalSchema(Namespace namespace) {
-    Capability capabilities = getCapability(NameIdentifier.of(namespace.levels()), catalogManager);
-    return capabilities.supportsHierarchicalSchema().supported();
+    return withCapability(NameIdentifier.of(namespace.levels()), catalogManager, cap -> cap.supportsHierarchicalSchema().supported());
   }
 
   private NameIdentifier normalizeNameIdentifier(NameIdentifier schemaIdent) {
-    Capability capabilities = getCapability(schemaIdent, catalogManager);
-    return applyCapabilities(schemaIdent, Capability.Scope.SCHEMA, capabilities);
+    return withCapability(schemaIdent, catalogManager, cap -> applyCapabilities(schemaIdent, Capability.Scope.SCHEMA, cap));
   }
 
   private NameIdentifier normalizeCaseSensitive(NameIdentifier schemaIdent) {
-    Capability capabilities = getCapability(schemaIdent, catalogManager);
-    return applyCaseSensitive(schemaIdent, Capability.Scope.SCHEMA, capabilities);
+    return withCapability(schemaIdent, catalogManager, cap -> applyCaseSensitive(schemaIdent, Capability.Scope.SCHEMA, cap));
   }
 }

--- a/core/src/main/java/org/apache/gravitino/catalog/SchemaNormalizeDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/SchemaNormalizeDispatcher.java
@@ -97,14 +97,23 @@ public class SchemaNormalizeDispatcher implements SchemaDispatcher {
   }
 
   private boolean supportsHierarchicalSchema(Namespace namespace) {
-    return withCapability(NameIdentifier.of(namespace.levels()), catalogManager, cap -> cap.supportsHierarchicalSchema().supported());
+    return withCapability(
+        NameIdentifier.of(namespace.levels()),
+        catalogManager,
+        cap -> cap.supportsHierarchicalSchema().supported());
   }
 
   private NameIdentifier normalizeNameIdentifier(NameIdentifier schemaIdent) {
-    return withCapability(schemaIdent, catalogManager, cap -> applyCapabilities(schemaIdent, Capability.Scope.SCHEMA, cap));
+    return withCapability(
+        schemaIdent,
+        catalogManager,
+        cap -> applyCapabilities(schemaIdent, Capability.Scope.SCHEMA, cap));
   }
 
   private NameIdentifier normalizeCaseSensitive(NameIdentifier schemaIdent) {
-    return withCapability(schemaIdent, catalogManager, cap -> applyCaseSensitive(schemaIdent, Capability.Scope.SCHEMA, cap));
+    return withCapability(
+        schemaIdent,
+        catalogManager,
+        cap -> applyCaseSensitive(schemaIdent, Capability.Scope.SCHEMA, cap));
   }
 }

--- a/core/src/main/java/org/apache/gravitino/catalog/TableNormalizeDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/TableNormalizeDispatcher.java
@@ -75,28 +75,28 @@ public class TableNormalizeDispatcher implements TableDispatcher {
       SortOrder[] sortOrders,
       Index[] indexes)
       throws NoSuchSchemaException, TableAlreadyExistsException {
-    NameIdentifier normalizedIdent =
+    // Bundle all normalizations into one withCapability call to minimize TCCL switches.
+    NormalizedCreateArgs norm =
         withCapability(
-            ident, catalogManager, cap -> applyCapabilities(ident, Capability.Scope.TABLE, cap));
-    Column[] normalizedColumns =
-        withCapability(ident, catalogManager, cap -> applyCapabilities(columns, cap));
-    Transform[] normalizedPartitions =
-        withCapability(ident, catalogManager, cap -> applyCapabilities(partitions, cap));
-    Distribution normalizedDistribution =
-        withCapability(ident, catalogManager, cap -> applyCapabilities(distribution, cap));
-    SortOrder[] normalizedSortOrders =
-        withCapability(ident, catalogManager, cap -> applyCapabilities(sortOrders, cap));
-    Index[] normalizedIndexes =
-        withCapability(ident, catalogManager, cap -> applyCapabilities(indexes, cap));
+            ident,
+            catalogManager,
+            cap ->
+                new NormalizedCreateArgs(
+                    applyCapabilities(ident, Capability.Scope.TABLE, cap),
+                    applyCapabilities(columns, cap),
+                    applyCapabilities(partitions, cap),
+                    applyCapabilities(distribution, cap),
+                    applyCapabilities(sortOrders, cap),
+                    applyCapabilities(indexes, cap)));
     return dispatcher.createTable(
-        normalizedIdent,
-        normalizedColumns,
+        norm.ident,
+        norm.columns,
         comment,
         properties,
-        normalizedPartitions,
-        normalizedDistribution,
-        normalizedSortOrders,
-        normalizedIndexes);
+        norm.partitions,
+        norm.distribution,
+        norm.sortOrders,
+        norm.indexes);
   }
 
   @Override
@@ -162,5 +162,33 @@ public class TableNormalizeDispatcher implements TableDispatcher {
         tableIdent,
         catalogManager,
         cap -> applyCapabilities(tableIdent, Capability.Scope.TABLE, cap));
+  }
+
+  /**
+   * Bundles all normalized createTable arguments so they can be computed in a single {@code
+   * withCapability} call, minimizing TCCL switches.
+   */
+  private static final class NormalizedCreateArgs {
+    final NameIdentifier ident;
+    final Column[] columns;
+    final Transform[] partitions;
+    final Distribution distribution;
+    final SortOrder[] sortOrders;
+    final Index[] indexes;
+
+    NormalizedCreateArgs(
+        NameIdentifier ident,
+        Column[] columns,
+        Transform[] partitions,
+        Distribution distribution,
+        SortOrder[] sortOrders,
+        Index[] indexes) {
+      this.ident = ident;
+      this.columns = columns;
+      this.partitions = partitions;
+      this.distribution = distribution;
+      this.sortOrders = sortOrders;
+      this.indexes = indexes;
+    }
   }
 }

--- a/core/src/main/java/org/apache/gravitino/catalog/TableNormalizeDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/TableNormalizeDispatcher.java
@@ -20,9 +20,10 @@ package org.apache.gravitino.catalog;
 
 import static org.apache.gravitino.catalog.CapabilityHelpers.applyCapabilities;
 import static org.apache.gravitino.catalog.CapabilityHelpers.applyCaseSensitive;
-import static org.apache.gravitino.catalog.CapabilityHelpers.getCapability;
+import static org.apache.gravitino.catalog.CapabilityHelpers.withCapability;
 
 import java.util.Map;
+import org.apache.commons.lang3.ArrayUtils;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
 import org.apache.gravitino.connector.capability.Capability;
@@ -37,10 +38,6 @@ import org.apache.gravitino.rel.expressions.sorts.SortOrder;
 import org.apache.gravitino.rel.expressions.transforms.Transform;
 import org.apache.gravitino.rel.indexes.Index;
 
-/**
- * Note on list operations: names returned by list methods (e.g. {@link #listTables(Namespace)}) are
- * assumed to already be in their canonical, legal form and are not re-normalized here.
- */
 public class TableNormalizeDispatcher implements TableDispatcher {
   private final CatalogManager catalogManager;
   private final TableDispatcher dispatcher;
@@ -55,7 +52,8 @@ public class TableNormalizeDispatcher implements TableDispatcher {
     // The constraints of the name spec may be more strict than underlying catalog,
     // and for compatibility reasons, we only apply case-sensitive capabilities here.
     Namespace caseSensitiveNs = normalizeCaseSensitive(namespace);
-    return dispatcher.listTables(caseSensitiveNs);
+    NameIdentifier[] identifiers = dispatcher.listTables(caseSensitiveNs);
+    return normalizeCaseSensitive(identifiers);
   }
 
   @Override
@@ -76,26 +74,33 @@ public class TableNormalizeDispatcher implements TableDispatcher {
       SortOrder[] sortOrders,
       Index[] indexes)
       throws NoSuchSchemaException, TableAlreadyExistsException {
-    Capability capability = getCapability(ident, catalogManager);
-    return dispatcher.createTable(
-        applyCapabilities(ident, Capability.Scope.TABLE, capability),
-        applyCapabilities(columns, capability),
-        comment,
-        properties,
-        applyCapabilities(partitions, capability),
-        applyCapabilities(distribution, capability),
-        applyCapabilities(sortOrders, capability),
-        applyCapabilities(indexes, capability));
+    return withCapability(
+        ident,
+        catalogManager,
+        capability ->
+            dispatcher.createTable(
+                applyCapabilities(ident, Capability.Scope.TABLE, capability),
+                applyCapabilities(columns, capability),
+                comment,
+                properties,
+                applyCapabilities(partitions, capability),
+                applyCapabilities(distribution, capability),
+                applyCapabilities(sortOrders, capability),
+                applyCapabilities(indexes, capability)));
   }
 
   @Override
   public Table alterTable(NameIdentifier ident, TableChange... changes)
       throws NoSuchTableException, IllegalArgumentException {
-    Capability capability = getCapability(ident, catalogManager);
-    return dispatcher.alterTable(
-        // The constraints of the name spec may be more strict than underlying catalog,
-        // and for compatibility reasons, we only apply case-sensitive capabilities here.
-        normalizeCaseSensitive(ident), applyCapabilities(capability, changes));
+    return withCapability(
+        ident,
+        catalogManager,
+        capability ->
+            dispatcher.alterTable(
+                // The constraints of the name spec may be more strict than underlying catalog,
+                // and for compatibility reasons, we only apply case-sensitive capabilities here.
+                applyCaseSensitive(ident, Capability.Scope.TABLE, capability),
+                applyCapabilities(capability, changes)));
   }
 
   @Override
@@ -116,17 +121,34 @@ public class TableNormalizeDispatcher implements TableDispatcher {
   }
 
   private Namespace normalizeCaseSensitive(Namespace namespace) {
-    Capability capabilities = getCapability(NameIdentifier.of(namespace.levels()), catalogManager);
-    return applyCaseSensitive(namespace, Capability.Scope.TABLE, capabilities);
+    return withCapability(
+        NameIdentifier.of(namespace.levels()),
+        catalogManager,
+        cap -> applyCaseSensitive(namespace, Capability.Scope.TABLE, cap));
   }
 
   private NameIdentifier normalizeCaseSensitive(NameIdentifier tableIdent) {
-    Capability capability = getCapability(tableIdent, catalogManager);
-    return applyCaseSensitive(tableIdent, Capability.Scope.TABLE, capability);
+    return withCapability(
+        tableIdent,
+        catalogManager,
+        cap -> applyCaseSensitive(tableIdent, Capability.Scope.TABLE, cap));
+  }
+
+  private NameIdentifier[] normalizeCaseSensitive(NameIdentifier[] tableIdents) {
+    if (ArrayUtils.isEmpty(tableIdents)) {
+      return tableIdents;
+    }
+
+    return withCapability(
+        tableIdents[0],
+        catalogManager,
+        cap -> applyCaseSensitive(tableIdents, Capability.Scope.TABLE, cap));
   }
 
   private NameIdentifier normalizeNameIdentifier(NameIdentifier tableIdent) {
-    Capability capability = getCapability(tableIdent, catalogManager);
-    return applyCapabilities(tableIdent, Capability.Scope.TABLE, capability);
+    return withCapability(
+        tableIdent,
+        catalogManager,
+        cap -> applyCapabilities(tableIdent, Capability.Scope.TABLE, cap));
   }
 }

--- a/core/src/main/java/org/apache/gravitino/catalog/TableNormalizeDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/TableNormalizeDispatcher.java
@@ -24,6 +24,7 @@ import static org.apache.gravitino.catalog.CapabilityHelpers.withCapability;
 
 import java.util.Map;
 import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
 import org.apache.gravitino.connector.capability.Capability;
@@ -74,33 +75,44 @@ public class TableNormalizeDispatcher implements TableDispatcher {
       SortOrder[] sortOrders,
       Index[] indexes)
       throws NoSuchSchemaException, TableAlreadyExistsException {
-    return withCapability(
-        ident,
-        catalogManager,
-        capability ->
-            dispatcher.createTable(
-                applyCapabilities(ident, Capability.Scope.TABLE, capability),
-                applyCapabilities(columns, capability),
-                comment,
-                properties,
-                applyCapabilities(partitions, capability),
-                applyCapabilities(distribution, capability),
-                applyCapabilities(sortOrders, capability),
-                applyCapabilities(indexes, capability)));
+    NameIdentifier normalizedIdent =
+        withCapability(
+            ident, catalogManager, cap -> applyCapabilities(ident, Capability.Scope.TABLE, cap));
+    Column[] normalizedColumns =
+        withCapability(ident, catalogManager, cap -> applyCapabilities(columns, cap));
+    Transform[] normalizedPartitions =
+        withCapability(ident, catalogManager, cap -> applyCapabilities(partitions, cap));
+    Distribution normalizedDistribution =
+        withCapability(ident, catalogManager, cap -> applyCapabilities(distribution, cap));
+    SortOrder[] normalizedSortOrders =
+        withCapability(ident, catalogManager, cap -> applyCapabilities(sortOrders, cap));
+    Index[] normalizedIndexes =
+        withCapability(ident, catalogManager, cap -> applyCapabilities(indexes, cap));
+    return dispatcher.createTable(
+        normalizedIdent,
+        normalizedColumns,
+        comment,
+        properties,
+        normalizedPartitions,
+        normalizedDistribution,
+        normalizedSortOrders,
+        normalizedIndexes);
   }
 
   @Override
   public Table alterTable(NameIdentifier ident, TableChange... changes)
       throws NoSuchTableException, IllegalArgumentException {
-    return withCapability(
-        ident,
-        catalogManager,
-        capability ->
-            dispatcher.alterTable(
-                // The constraints of the name spec may be more strict than underlying catalog,
-                // and for compatibility reasons, we only apply case-sensitive capabilities here.
-                applyCaseSensitive(ident, Capability.Scope.TABLE, capability),
-                applyCapabilities(capability, changes)));
+    // The constraints of the name spec may be more strict than underlying catalog,
+    // and for compatibility reasons, we only apply case-sensitive capabilities here.
+    Pair<NameIdentifier, TableChange[]> normalized =
+        withCapability(
+            ident,
+            catalogManager,
+            cap ->
+                Pair.of(
+                    applyCaseSensitive(ident, Capability.Scope.TABLE, cap),
+                    applyCapabilities(cap, changes)));
+    return dispatcher.alterTable(normalized.getLeft(), normalized.getRight());
   }
 
   @Override

--- a/core/src/main/java/org/apache/gravitino/catalog/TopicNormalizeDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/TopicNormalizeDispatcher.java
@@ -20,7 +20,7 @@ package org.apache.gravitino.catalog;
 
 import static org.apache.gravitino.catalog.CapabilityHelpers.applyCapabilities;
 import static org.apache.gravitino.catalog.CapabilityHelpers.applyCaseSensitive;
-import static org.apache.gravitino.catalog.CapabilityHelpers.getCapability;
+import static org.apache.gravitino.catalog.CapabilityHelpers.withCapability;
 
 import java.util.Map;
 import org.apache.gravitino.NameIdentifier;
@@ -91,17 +91,14 @@ public class TopicNormalizeDispatcher implements TopicDispatcher {
   }
 
   private Namespace normalizeCaseSensitive(Namespace namespace) {
-    Capability capabilities = getCapability(NameIdentifier.of(namespace.levels()), catalogManager);
-    return applyCaseSensitive(namespace, Capability.Scope.TOPIC, capabilities);
+    return withCapability(NameIdentifier.of(namespace.levels()), catalogManager, cap -> applyCaseSensitive(namespace, Capability.Scope.TOPIC, cap));
   }
 
   private NameIdentifier normalizeCaseSensitive(NameIdentifier topicIdent) {
-    Capability capabilities = getCapability(topicIdent, catalogManager);
-    return applyCaseSensitive(topicIdent, Capability.Scope.TOPIC, capabilities);
+    return withCapability(topicIdent, catalogManager, cap -> applyCaseSensitive(topicIdent, Capability.Scope.TOPIC, cap));
   }
 
   private NameIdentifier normalizeNameIdentifier(NameIdentifier topicIdent) {
-    Capability capability = getCapability(topicIdent, catalogManager);
-    return applyCapabilities(topicIdent, Capability.Scope.TOPIC, capability);
+    return withCapability(topicIdent, catalogManager, cap -> applyCapabilities(topicIdent, Capability.Scope.TOPIC, capability));
   }
 }

--- a/core/src/main/java/org/apache/gravitino/catalog/TopicNormalizeDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/TopicNormalizeDispatcher.java
@@ -91,14 +91,23 @@ public class TopicNormalizeDispatcher implements TopicDispatcher {
   }
 
   private Namespace normalizeCaseSensitive(Namespace namespace) {
-    return withCapability(NameIdentifier.of(namespace.levels()), catalogManager, cap -> applyCaseSensitive(namespace, Capability.Scope.TOPIC, cap));
+    return withCapability(
+        NameIdentifier.of(namespace.levels()),
+        catalogManager,
+        cap -> applyCaseSensitive(namespace, Capability.Scope.TOPIC, cap));
   }
 
   private NameIdentifier normalizeCaseSensitive(NameIdentifier topicIdent) {
-    return withCapability(topicIdent, catalogManager, cap -> applyCaseSensitive(topicIdent, Capability.Scope.TOPIC, cap));
+    return withCapability(
+        topicIdent,
+        catalogManager,
+        cap -> applyCaseSensitive(topicIdent, Capability.Scope.TOPIC, cap));
   }
 
   private NameIdentifier normalizeNameIdentifier(NameIdentifier topicIdent) {
-    return withCapability(topicIdent, catalogManager, cap -> applyCapabilities(topicIdent, Capability.Scope.TOPIC, capability));
+    return withCapability(
+        topicIdent,
+        catalogManager,
+        cap -> applyCapabilities(topicIdent, Capability.Scope.TOPIC, cap));
   }
 }

--- a/core/src/main/java/org/apache/gravitino/catalog/ViewNormalizeDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/ViewNormalizeDispatcher.java
@@ -20,10 +20,11 @@ package org.apache.gravitino.catalog;
 
 import static org.apache.gravitino.catalog.CapabilityHelpers.applyCapabilities;
 import static org.apache.gravitino.catalog.CapabilityHelpers.applyCaseSensitive;
-import static org.apache.gravitino.catalog.CapabilityHelpers.getCapability;
+import static org.apache.gravitino.catalog.CapabilityHelpers.withCapability;
 
 import java.util.Map;
 import javax.annotation.Nullable;
+import org.apache.commons.lang3.ArrayUtils;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
 import org.apache.gravitino.connector.capability.Capability;
@@ -35,10 +36,6 @@ import org.apache.gravitino.rel.Representation;
 import org.apache.gravitino.rel.View;
 import org.apache.gravitino.rel.ViewChange;
 
-/**
- * Note on list operations: names returned by list methods (e.g. {@link #listViews(Namespace)}) are
- * assumed to already be in their canonical, legal form and are not re-normalized here.
- */
 public class ViewNormalizeDispatcher implements ViewDispatcher {
 
   private final CatalogManager catalogManager;
@@ -54,7 +51,8 @@ public class ViewNormalizeDispatcher implements ViewDispatcher {
     // The constraints of the name spec may be more strict than underlying catalog,
     // and for compatibility reasons, we only apply case-sensitive capabilities here.
     Namespace caseSensitiveNs = normalizeCaseSensitive(namespace);
-    return dispatcher.listViews(caseSensitiveNs);
+    NameIdentifier[] identifiers = dispatcher.listViews(caseSensitiveNs);
+    return normalizeCaseSensitive(identifiers);
   }
 
   @Override
@@ -90,9 +88,13 @@ public class ViewNormalizeDispatcher implements ViewDispatcher {
   @Override
   public View alterView(NameIdentifier ident, ViewChange... changes)
       throws NoSuchViewException, IllegalArgumentException {
-    Capability capability = getCapability(ident, catalogManager);
-    return dispatcher.alterView(
-        normalizeCaseSensitive(ident), applyCapabilities(capability, changes));
+    return withCapability(
+        ident,
+        catalogManager,
+        capability ->
+            dispatcher.alterView(
+                applyCaseSensitive(ident, Capability.Scope.VIEW, capability),
+                applyCapabilities(capability, changes)));
   }
 
   @Override
@@ -101,17 +103,27 @@ public class ViewNormalizeDispatcher implements ViewDispatcher {
   }
 
   private Namespace normalizeCaseSensitive(Namespace namespace) {
-    Capability capabilities = getCapability(NameIdentifier.of(namespace.levels()), catalogManager);
-    return applyCaseSensitive(namespace, Capability.Scope.VIEW, capabilities);
+    return withCapability(
+        NameIdentifier.of(namespace.levels()),
+        catalogManager,
+        cap -> applyCaseSensitive(namespace, Capability.Scope.VIEW, cap));
   }
 
   private NameIdentifier normalizeCaseSensitive(NameIdentifier ident) {
-    Capability capabilities = getCapability(ident, catalogManager);
-    return applyCaseSensitive(ident, Capability.Scope.VIEW, capabilities);
+    return withCapability(
+        ident, catalogManager, cap -> applyCaseSensitive(ident, Capability.Scope.VIEW, cap));
+  }
+
+  private NameIdentifier[] normalizeCaseSensitive(NameIdentifier[] idents) {
+    if (ArrayUtils.isEmpty(idents)) {
+      return idents;
+    }
+    return withCapability(
+        idents[0], catalogManager, cap -> applyCaseSensitive(idents, Capability.Scope.VIEW, cap));
   }
 
   private NameIdentifier normalizeNameIdentifier(NameIdentifier ident) {
-    Capability capability = getCapability(ident, catalogManager);
-    return applyCapabilities(ident, Capability.Scope.VIEW, capability);
+    return withCapability(
+        ident, catalogManager, cap -> applyCapabilities(ident, Capability.Scope.VIEW, cap));
   }
 }

--- a/core/src/main/java/org/apache/gravitino/catalog/ViewNormalizeDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/ViewNormalizeDispatcher.java
@@ -25,6 +25,7 @@ import static org.apache.gravitino.catalog.CapabilityHelpers.withCapability;
 import java.util.Map;
 import javax.annotation.Nullable;
 import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
 import org.apache.gravitino.connector.capability.Capability;
@@ -88,13 +89,15 @@ public class ViewNormalizeDispatcher implements ViewDispatcher {
   @Override
   public View alterView(NameIdentifier ident, ViewChange... changes)
       throws NoSuchViewException, IllegalArgumentException {
-    return withCapability(
-        ident,
-        catalogManager,
-        capability ->
-            dispatcher.alterView(
-                applyCaseSensitive(ident, Capability.Scope.VIEW, capability),
-                applyCapabilities(capability, changes)));
+    Pair<NameIdentifier, ViewChange[]> normalized =
+        withCapability(
+            ident,
+            catalogManager,
+            cap ->
+                Pair.of(
+                    applyCaseSensitive(ident, Capability.Scope.VIEW, cap),
+                    applyCapabilities(cap, changes)));
+    return dispatcher.alterView(normalized.getLeft(), normalized.getRight());
   }
 
   @Override

--- a/core/src/test/java/org/apache/gravitino/catalog/TestCatalogManager.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestCatalogManager.java
@@ -73,6 +73,7 @@ import org.apache.gravitino.storage.relational.SupportsEntityChangeLog;
 import org.apache.gravitino.storage.relational.po.cache.EntityChangeRecord;
 import org.apache.gravitino.storage.relational.po.cache.OperateType;
 import org.apache.gravitino.utils.PrincipalUtils;
+import org.apache.gravitino.utils.ThrowableFunction;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -962,6 +963,10 @@ public class TestCatalogManager {
     Mockito.doReturn(catalog).when(wrapper).catalog();
     Mockito.doReturn(capability).when(wrapper).capabilities();
     Mockito.doReturn(unsupportedResult).when(capability).managedStorage(any());
+    Mockito.doAnswer(
+            inv -> ((ThrowableFunction<Capability, ?>) inv.getArgument(0)).apply(capability))
+        .when(wrapper)
+        .doWithCapabilityOps(any());
     Mockito.doReturn(
             new NameIdentifier[] {NameIdentifier.of("metalake", "test41", "imported_schema")})
         .doReturn(importedSchema)
@@ -1041,6 +1046,10 @@ public class TestCatalogManager {
     Mockito.doReturn(catalog).when(wrapper).catalog();
     Mockito.doReturn(capability).when(wrapper).capabilities();
     Mockito.doReturn(unsupportedResult).when(capability).managedStorage(any());
+    Mockito.doAnswer(
+            inv -> ((ThrowableFunction<Capability, ?>) inv.getArgument(0)).apply(capability))
+        .when(wrapper)
+        .doWithCapabilityOps(any());
     Mockito.doReturn(new NameIdentifier[] {NameIdentifier.of("metalake", "test41", "default")})
         .doThrow(new NoSuchSchemaException("Schema not found"))
         .when(wrapper)
@@ -1092,6 +1101,10 @@ public class TestCatalogManager {
     Mockito.doReturn(catalog).when(wrapper).catalog();
     Mockito.doReturn(capability).when(wrapper).capabilities();
     Mockito.doReturn(unsupportedResult).when(capability).managedStorage(any());
+    Mockito.doAnswer(
+            inv -> ((ThrowableFunction<Capability, ?>) inv.getArgument(0)).apply(capability))
+        .when(wrapper)
+        .doWithCapabilityOps(any());
     Mockito.doReturn(new NameIdentifier[] {NameIdentifier.of("metalake", "test41", "test_schema1")})
         .doThrow(new RuntimeException("Failed connect"))
         .when(wrapper)
@@ -1138,6 +1151,10 @@ public class TestCatalogManager {
     Mockito.doReturn(catalogWrapper).when(catalogManager).loadCatalogAndWrap(ident);
     Mockito.doReturn(capability).when(catalogWrapper).capabilities();
     Mockito.doReturn(unsupportedResult).when(capability).managedStorage(any());
+    Mockito.doAnswer(
+            inv -> ((ThrowableFunction<Capability, ?>) inv.getArgument(0)).apply(capability))
+        .when(catalogWrapper)
+        .doWithCapabilityOps(any());
     Mockito.doReturn(catalog).when(catalogWrapper).catalog();
     Mockito.doThrow(new RuntimeException("Failed connect"))
         .when(catalogWrapper)
@@ -1173,6 +1190,10 @@ public class TestCatalogManager {
     Mockito.doReturn(catalog).when(catalogWrapper).catalog();
     Mockito.doReturn(capability).when(catalogWrapper).capabilities();
     Mockito.doReturn(unsupportedResult).when(capability).managedStorage(any());
+    Mockito.doAnswer(
+            inv -> ((ThrowableFunction<Capability, ?>) inv.getArgument(0)).apply(capability))
+        .when(catalogWrapper)
+        .doWithCapabilityOps(any());
 
     catalogManager.getCatalogCache().put(ident, catalogWrapper);
     boolean dropped = catalogManager.dropCatalog(ident);

--- a/core/src/test/java/org/apache/gravitino/catalog/TestCatalogWrapperConcurrency.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestCatalogWrapperConcurrency.java
@@ -1,0 +1,214 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.gravitino.connector.BaseCatalog;
+import org.apache.gravitino.connector.capability.Capability;
+import org.apache.gravitino.utils.IsolatedClassLoader;
+import org.apache.gravitino.utils.ThrowableFunction;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+/**
+ * Verifies that {@link CatalogManager.CatalogWrapper} correctly serializes {@code close()} against
+ * in-flight {@code doWithCapabilityOps()} calls via {@code synchronized}, preventing the {@link
+ * IsolatedClassLoader} from being torn down while a capability operation is still executing.
+ */
+public class TestCatalogWrapperConcurrency {
+
+  /**
+   * close() must block until a concurrent doWithCapabilityOps() call finishes (both methods are
+   * synchronized on the same monitor), and subsequent doWithCapabilityOps() calls after close()
+   * must throw IllegalStateException.
+   */
+  @Test
+  public void testCloseBlocksUntilInFlightCapabilityOpsComplete() throws Exception {
+    BaseCatalog mockCatalog = Mockito.mock(BaseCatalog.class);
+    Mockito.when(mockCatalog.capability()).thenReturn(Capability.DEFAULT);
+
+    IsolatedClassLoader mockCl = Mockito.mock(IsolatedClassLoader.class);
+    Mockito.when(mockCl.withClassLoader(Mockito.any()))
+        .thenAnswer(
+            inv ->
+                ((ThrowableFunction<ClassLoader, ?>) inv.getArgument(0))
+                    .apply(Thread.currentThread().getContextClassLoader()));
+
+    CatalogManager.CatalogWrapper wrapper = new CatalogManager.CatalogWrapper(mockCatalog, mockCl);
+
+    CountDownLatch opStarted = new CountDownLatch(1);
+    CountDownLatch permitClose = new CountDownLatch(1);
+    AtomicInteger opCompleted = new AtomicInteger(0);
+
+    ExecutorService exec = Executors.newFixedThreadPool(2);
+    try {
+      // One in-flight capability op that holds the synchronized lock while waiting.
+      Callable<Void> op =
+          () -> {
+            wrapper.doWithCapabilityOps(
+                cap -> {
+                  opStarted.countDown();
+                  permitClose.await(5, TimeUnit.SECONDS);
+                  opCompleted.incrementAndGet();
+                  return null;
+                });
+            return null;
+          };
+
+      Future<Void> f1 = exec.submit(op);
+
+      // Wait for the op to acquire the synchronized lock.
+      Assertions.assertTrue(opStarted.await(5, TimeUnit.SECONDS));
+
+      // Start close() on a separate thread; it must block waiting for the op to release the lock.
+      Future<Void> closeFuture =
+          exec.submit(
+              () -> {
+                wrapper.close();
+                return null;
+              });
+
+      // Spin-wait (bounded) for close() to attempt acquiring the lock, then verify it is blocked.
+      long deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(200);
+      while (!closeFuture.isDone() && System.nanoTime() < deadline) {
+        Thread.yield();
+      }
+      Assertions.assertFalse(
+          closeFuture.isDone(), "close() must not complete while op holds the lock");
+
+      // Release the in-flight op.
+      permitClose.countDown();
+      f1.get(5, TimeUnit.SECONDS);
+
+      // Now close() should complete.
+      closeFuture.get(5, TimeUnit.SECONDS);
+      Assertions.assertTrue(closeFuture.isDone());
+
+      // The op finished before close() completed.
+      Assertions.assertEquals(1, opCompleted.get());
+
+      // Subsequent capability ops must be rejected.
+      Assertions.assertThrows(
+          IllegalStateException.class, () -> wrapper.doWithCapabilityOps(cap -> null));
+    } finally {
+      exec.shutdownNow();
+    }
+  }
+
+  /**
+   * close() is idempotent: calling it a second time must not throw and must not call
+   * classLoader.close() again.
+   */
+  @Test
+  public void testCloseIsIdempotent() throws Exception {
+    BaseCatalog mockCatalog = Mockito.mock(BaseCatalog.class);
+    Mockito.when(mockCatalog.capability()).thenReturn(Capability.DEFAULT);
+
+    IsolatedClassLoader mockCl = Mockito.mock(IsolatedClassLoader.class);
+    Mockito.when(mockCl.withClassLoader(Mockito.any()))
+        .thenAnswer(
+            inv ->
+                ((ThrowableFunction<ClassLoader, ?>) inv.getArgument(0))
+                    .apply(Thread.currentThread().getContextClassLoader()));
+
+    CatalogManager.CatalogWrapper wrapper = new CatalogManager.CatalogWrapper(mockCatalog, mockCl);
+
+    wrapper.close();
+    wrapper.close(); // must not throw
+
+    // classLoader.close() should be called exactly once.
+    Mockito.verify(mockCl, Mockito.times(1)).close();
+  }
+
+  /**
+   * doWithCapabilityOps() after close() throws IllegalStateException, not a cryptic
+   * NullPointerException or NoClassDefFoundError.
+   */
+  @Test
+  public void testCapabilityOpsAfterCloseThrowIllegalStateException() throws Exception {
+    BaseCatalog mockCatalog = Mockito.mock(BaseCatalog.class);
+    IsolatedClassLoader mockCl = Mockito.mock(IsolatedClassLoader.class);
+
+    CatalogManager.CatalogWrapper wrapper = new CatalogManager.CatalogWrapper(mockCatalog, mockCl);
+    Mockito.when(mockCl.withClassLoader(Mockito.any())).thenReturn(null);
+    wrapper.close();
+
+    Assertions.assertThrows(
+        IllegalStateException.class, () -> wrapper.doWithCapabilityOps(cap -> null));
+  }
+
+  /**
+   * Multiple concurrent close() calls must not result in multiple classLoader.close() invocations
+   * (synchronized idempotency under concurrency).
+   */
+  @Test
+  public void testConcurrentCloseCallsAreIdempotent() throws Exception {
+    BaseCatalog mockCatalog = Mockito.mock(BaseCatalog.class);
+    Mockito.when(mockCatalog.capability()).thenReturn(Capability.DEFAULT);
+
+    IsolatedClassLoader mockCl = Mockito.mock(IsolatedClassLoader.class);
+    Mockito.when(mockCl.withClassLoader(Mockito.any()))
+        .thenAnswer(
+            inv ->
+                ((ThrowableFunction<ClassLoader, ?>) inv.getArgument(0))
+                    .apply(Thread.currentThread().getContextClassLoader()));
+
+    CatalogManager.CatalogWrapper wrapper = new CatalogManager.CatalogWrapper(mockCatalog, mockCl);
+
+    int threads = 8;
+    ExecutorService exec = Executors.newFixedThreadPool(threads);
+    CountDownLatch ready = new CountDownLatch(threads);
+    CountDownLatch go = new CountDownLatch(1);
+
+    List<Future<Void>> futures = new ArrayList<>();
+    for (int i = 0; i < threads; i++) {
+      futures.add(
+          exec.submit(
+              () -> {
+                ready.countDown();
+                go.await();
+                wrapper.close();
+                return null;
+              }));
+    }
+
+    Assertions.assertTrue(ready.await(5, TimeUnit.SECONDS), "Not all threads became ready in time");
+    go.countDown();
+
+    try {
+      for (Future<Void> f : futures) {
+        f.get(5, TimeUnit.SECONDS);
+      }
+    } finally {
+      exec.shutdownNow();
+    }
+
+    // classLoader.close() called exactly once regardless of concurrency.
+    Mockito.verify(mockCl, Mockito.times(1)).close();
+  }
+}

--- a/core/src/test/java/org/apache/gravitino/catalog/TestCatalogWrapperConcurrency.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestCatalogWrapperConcurrency.java
@@ -18,6 +18,7 @@
  */
 package org.apache.gravitino.catalog;
 
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Callable;
@@ -42,11 +43,28 @@ import org.mockito.Mockito;
  */
 public class TestCatalogWrapperConcurrency {
 
-  /**
-   * close() must block until a concurrent doWithCapabilityOps() call finishes (both methods are
-   * synchronized on the same monitor), and subsequent doWithCapabilityOps() calls after close()
-   * must throw IllegalStateException.
-   */
+  private static final Field CATALOG_FIELD;
+
+  static {
+    try {
+      CATALOG_FIELD = CatalogManager.CatalogWrapper.class.getDeclaredField("catalog");
+      CATALOG_FIELD.setAccessible(true);
+    } catch (NoSuchFieldException e) {
+      throw new ExceptionInInitializerError(e);
+    }
+  }
+
+  private static CatalogManager.CatalogWrapper createWrapper(
+      BaseCatalog catalog, IsolatedClassLoader classLoader) {
+    CatalogManager.CatalogWrapper wrapper = new CatalogManager.CatalogWrapper(classLoader);
+    try {
+      CATALOG_FIELD.set(wrapper, catalog);
+    } catch (IllegalAccessException e) {
+      throw new RuntimeException(e);
+    }
+    return wrapper;
+  }
+
   @Test
   public void testCloseBlocksUntilInFlightCapabilityOpsComplete() throws Exception {
     BaseCatalog mockCatalog = Mockito.mock(BaseCatalog.class);
@@ -59,7 +77,7 @@ public class TestCatalogWrapperConcurrency {
                 ((ThrowableFunction<ClassLoader, ?>) inv.getArgument(0))
                     .apply(Thread.currentThread().getContextClassLoader()));
 
-    CatalogManager.CatalogWrapper wrapper = new CatalogManager.CatalogWrapper(mockCatalog, mockCl);
+    CatalogManager.CatalogWrapper wrapper = createWrapper(mockCatalog, mockCl);
 
     CountDownLatch opStarted = new CountDownLatch(1);
     CountDownLatch permitClose = new CountDownLatch(1);
@@ -67,7 +85,6 @@ public class TestCatalogWrapperConcurrency {
 
     ExecutorService exec = Executors.newFixedThreadPool(2);
     try {
-      // One in-flight capability op that holds the synchronized lock while waiting.
       Callable<Void> op =
           () -> {
             wrapper.doWithCapabilityOps(
@@ -82,10 +99,8 @@ public class TestCatalogWrapperConcurrency {
 
       Future<Void> f1 = exec.submit(op);
 
-      // Wait for the op to acquire the synchronized lock.
       Assertions.assertTrue(opStarted.await(5, TimeUnit.SECONDS));
 
-      // Start close() on a separate thread; it must block waiting for the op to release the lock.
       Future<Void> closeFuture =
           exec.submit(
               () -> {
@@ -93,7 +108,6 @@ public class TestCatalogWrapperConcurrency {
                 return null;
               });
 
-      // Spin-wait (bounded) for close() to attempt acquiring the lock, then verify it is blocked.
       long deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(200);
       while (!closeFuture.isDone() && System.nanoTime() < deadline) {
         Thread.yield();
@@ -101,29 +115,22 @@ public class TestCatalogWrapperConcurrency {
       Assertions.assertFalse(
           closeFuture.isDone(), "close() must not complete while op holds the lock");
 
-      // Release the in-flight op.
       permitClose.countDown();
       f1.get(5, TimeUnit.SECONDS);
 
-      // Now close() should complete.
       closeFuture.get(5, TimeUnit.SECONDS);
       Assertions.assertTrue(closeFuture.isDone());
 
-      // The op finished before close() completed.
       Assertions.assertEquals(1, opCompleted.get());
 
-      // Subsequent capability ops must be rejected.
       Assertions.assertThrows(
-          IllegalStateException.class, () -> wrapper.doWithCapabilityOps(cap -> null));
+          CatalogManager.CatalogWrapperClosedException.class,
+          () -> wrapper.doWithCapabilityOps(cap -> null));
     } finally {
       exec.shutdownNow();
     }
   }
 
-  /**
-   * close() is idempotent: calling it a second time must not throw and must not call
-   * classLoader.close() again.
-   */
   @Test
   public void testCloseIsIdempotent() throws Exception {
     BaseCatalog mockCatalog = Mockito.mock(BaseCatalog.class);
@@ -136,36 +143,28 @@ public class TestCatalogWrapperConcurrency {
                 ((ThrowableFunction<ClassLoader, ?>) inv.getArgument(0))
                     .apply(Thread.currentThread().getContextClassLoader()));
 
-    CatalogManager.CatalogWrapper wrapper = new CatalogManager.CatalogWrapper(mockCatalog, mockCl);
+    CatalogManager.CatalogWrapper wrapper = createWrapper(mockCatalog, mockCl);
 
     wrapper.close();
-    wrapper.close(); // must not throw
+    wrapper.close();
 
-    // classLoader.close() should be called exactly once.
     Mockito.verify(mockCl, Mockito.times(1)).close();
   }
 
-  /**
-   * doWithCapabilityOps() after close() throws IllegalStateException, not a cryptic
-   * NullPointerException or NoClassDefFoundError.
-   */
   @Test
-  public void testCapabilityOpsAfterCloseThrowIllegalStateException() throws Exception {
+  public void testCapabilityOpsAfterCloseThrowCatalogWrapperClosedException() throws Exception {
     BaseCatalog mockCatalog = Mockito.mock(BaseCatalog.class);
     IsolatedClassLoader mockCl = Mockito.mock(IsolatedClassLoader.class);
 
-    CatalogManager.CatalogWrapper wrapper = new CatalogManager.CatalogWrapper(mockCatalog, mockCl);
+    CatalogManager.CatalogWrapper wrapper = createWrapper(mockCatalog, mockCl);
     Mockito.when(mockCl.withClassLoader(Mockito.any())).thenReturn(null);
     wrapper.close();
 
     Assertions.assertThrows(
-        IllegalStateException.class, () -> wrapper.doWithCapabilityOps(cap -> null));
+        CatalogManager.CatalogWrapperClosedException.class,
+        () -> wrapper.doWithCapabilityOps(cap -> null));
   }
 
-  /**
-   * Multiple concurrent close() calls must not result in multiple classLoader.close() invocations
-   * (synchronized idempotency under concurrency).
-   */
   @Test
   public void testConcurrentCloseCallsAreIdempotent() throws Exception {
     BaseCatalog mockCatalog = Mockito.mock(BaseCatalog.class);
@@ -178,7 +177,7 @@ public class TestCatalogWrapperConcurrency {
                 ((ThrowableFunction<ClassLoader, ?>) inv.getArgument(0))
                     .apply(Thread.currentThread().getContextClassLoader()));
 
-    CatalogManager.CatalogWrapper wrapper = new CatalogManager.CatalogWrapper(mockCatalog, mockCl);
+    CatalogManager.CatalogWrapper wrapper = createWrapper(mockCatalog, mockCl);
 
     int threads = 8;
     ExecutorService exec = Executors.newFixedThreadPool(threads);
@@ -208,7 +207,6 @@ public class TestCatalogWrapperConcurrency {
       exec.shutdownNow();
     }
 
-    // classLoader.close() called exactly once regardless of concurrency.
     Mockito.verify(mockCl, Mockito.times(1)).close();
   }
 }

--- a/core/src/test/java/org/apache/gravitino/catalog/TestPartitionNormalizeDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestPartitionNormalizeDispatcher.java
@@ -20,6 +20,7 @@ package org.apache.gravitino.catalog;
 
 import com.google.common.collect.Maps;
 import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.connector.capability.Capability;
 import org.apache.gravitino.rel.Column;
 import org.apache.gravitino.rel.expressions.literals.Literal;
 import org.apache.gravitino.rel.expressions.literals.Literals;
@@ -109,8 +110,13 @@ public class TestPartitionNormalizeDispatcher extends TestOperationDispatcher {
 
     CatalogManager mockCatalogManager = Mockito.mock(CatalogManager.class);
     CatalogManager.CatalogWrapper mockWrapper = Mockito.mock(CatalogManager.CatalogWrapper.class);
-    Mockito.when(mockWrapper.capabilities())
-        .thenReturn(TestCapabilityHelpers.QUOTE_AWARE_CAPABILITY);
+    Mockito.when(mockWrapper.doWithCapabilityOps(Mockito.any()))
+        .thenAnswer(
+            inv -> {
+              @SuppressWarnings("unchecked")
+              org.apache.gravitino.utils.ThrowableFunction<Capability, ?> fn = inv.getArgument(0);
+              return fn.apply(TestCapabilityHelpers.QUOTE_AWARE_CAPABILITY);
+            });
     Mockito.when(mockCatalogManager.loadCatalogAndWrap(Mockito.any(NameIdentifier.class)))
         .thenReturn(mockWrapper);
 

--- a/core/src/test/java/org/apache/gravitino/catalog/TestPartitionNormalizeDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestPartitionNormalizeDispatcher.java
@@ -99,11 +99,10 @@ public class TestPartitionNormalizeDispatcher extends TestOperationDispatcher {
     // Mirrors the correct usage pattern for a quote-aware catalog (e.g. Oracle):
     // 1. addPartition is issued with a quoted, case-sensitive name, so the catalog stores the
     //    physical partition with its case preserved: My Partition.
-    // 2. listPartitionNames()/listPartitions() surface that physical name unquoted (My
-    //    Partition) -- names are not re-folded by the core layer.
+    // 2. listPartitionNames()/listPartitions() surface that physical name unquoted, but
+    //    normalizeName uppercases unquoted names (MY PARTITION).
     // 3. Getting the partition again requires re-quoting the case-sensitive name
-    //    ("My Partition"), not passing the bare listed name back in: normalizeName cannot tell
-    //    an already-canonical name apart from raw user input.
+    //    ("MY PARTITION"), not passing the bare listed name back in.
     NameIdentifier tableIdent =
         NameIdentifierUtil.ofTable(metalake, catalog, "schema", "quotedTable");
     PartitionDispatcher mockDispatcher = Mockito.mock(PartitionDispatcher.class);
@@ -154,11 +153,11 @@ public class TestPartitionNormalizeDispatcher extends TestOperationDispatcher {
 
     String[] listedNames = dispatcher.listPartitionNames(tableIdent);
     Assertions.assertEquals(1, listedNames.length);
-    Assertions.assertEquals("My Partition", listedNames[0]);
+    Assertions.assertEquals("MY PARTITION", listedNames[0]);
 
     Partition[] listedPartitions = dispatcher.listPartitions(tableIdent);
     Assertions.assertEquals(1, listedPartitions.length);
-    Assertions.assertEquals("My Partition", listedPartitions[0].name());
+    Assertions.assertEquals("MY PARTITION", listedPartitions[0].name());
 
     // 3. Getting the partition again requires re-quoting the listed name.
     dispatcher.getPartition(tableIdent, "\"" + listedNames[0] + "\"");
@@ -166,6 +165,6 @@ public class TestPartitionNormalizeDispatcher extends TestOperationDispatcher {
     ArgumentCaptor<String> gotPartitionNameCaptor = ArgumentCaptor.forClass(String.class);
     Mockito.verify(mockDispatcher)
         .getPartition(Mockito.any(NameIdentifier.class), gotPartitionNameCaptor.capture());
-    Assertions.assertEquals("My Partition", gotPartitionNameCaptor.getValue());
+    Assertions.assertEquals("MY PARTITION", gotPartitionNameCaptor.getValue());
   }
 }

--- a/core/src/test/java/org/apache/gravitino/catalog/TestTableNormalizeDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestTableNormalizeDispatcher.java
@@ -270,7 +270,7 @@ public class TestTableNormalizeDispatcher extends TestOperationDispatcher {
         .thenReturn(new NameIdentifier[] {NameIdentifier.of(tableNs, physicalName)});
     NameIdentifier[] listed = dispatcher.listTables(tableNs);
     Assertions.assertEquals(1, listed.length);
-    Assertions.assertEquals("My Table", listed[0].name());
+    Assertions.assertEquals("MY TABLE", listed[0].name());
 
     // 3. Loading the table again requires re-quoting the listed name.
     NameIdentifier quotedLoadIdent = NameIdentifier.of(tableNs, "\"" + listed[0].name() + "\"");
@@ -279,7 +279,7 @@ public class TestTableNormalizeDispatcher extends TestOperationDispatcher {
     ArgumentCaptor<NameIdentifier> loadedIdentCaptor =
         ArgumentCaptor.forClass(NameIdentifier.class);
     Mockito.verify(mockDispatcher).loadTable(loadedIdentCaptor.capture());
-    Assertions.assertEquals("My Table", loadedIdentCaptor.getValue().name());
+    Assertions.assertEquals("MY TABLE", loadedIdentCaptor.getValue().name());
   }
 
   private void assertTableCaseInsensitive(

--- a/core/src/test/java/org/apache/gravitino/catalog/TestTableNormalizeDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/catalog/TestTableNormalizeDispatcher.java
@@ -28,6 +28,7 @@ import org.apache.gravitino.MetadataObjects;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
 import org.apache.gravitino.TestColumn;
+import org.apache.gravitino.connector.capability.Capability;
 import org.apache.gravitino.exceptions.TableAlreadyExistsException;
 import org.apache.gravitino.rel.Column;
 import org.apache.gravitino.rel.Table;
@@ -224,8 +225,13 @@ public class TestTableNormalizeDispatcher extends TestOperationDispatcher {
 
     CatalogManager mockCatalogManager = Mockito.mock(CatalogManager.class);
     CatalogManager.CatalogWrapper mockWrapper = Mockito.mock(CatalogManager.CatalogWrapper.class);
-    Mockito.when(mockWrapper.capabilities())
-        .thenReturn(TestCapabilityHelpers.QUOTE_AWARE_CAPABILITY);
+    Mockito.when(mockWrapper.doWithCapabilityOps(Mockito.any()))
+        .thenAnswer(
+            inv -> {
+              @SuppressWarnings("unchecked")
+              org.apache.gravitino.utils.ThrowableFunction<Capability, ?> fn = inv.getArgument(0);
+              return fn.apply(TestCapabilityHelpers.QUOTE_AWARE_CAPABILITY);
+            });
     Mockito.when(mockCatalogManager.loadCatalogAndWrap(Mockito.any(NameIdentifier.class)))
         .thenReturn(mockWrapper);
 

--- a/core/src/test/java/org/apache/gravitino/hook/TestFilesetHookDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/hook/TestFilesetHookDispatcher.java
@@ -116,12 +116,13 @@ public class TestFilesetHookDispatcher extends TestOperationDispatcher {
 
     CatalogManager mockCatalogManager = Mockito.mock(CatalogManager.class);
     CatalogManager.CatalogWrapper mockWrapper = Mockito.mock(CatalogManager.CatalogWrapper.class);
-    Mockito.when(mockWrapper.capabilities()).thenReturn(new CaseInsensitiveCapability());
-    Capability caseInsensitiveCap = new CaseInsensitiveCapability();
-    Mockito.when(mockWrapper.doWithCapabilityOps(any()))
+    Mockito.when(mockWrapper.doWithCapabilityOps(Mockito.any()))
         .thenAnswer(
-            inv ->
-                ((ThrowableFunction<Capability, ?>) inv.getArgument(0)).apply(caseInsensitiveCap));
+            inv -> {
+              @SuppressWarnings("unchecked")
+              org.apache.gravitino.utils.ThrowableFunction<Capability, ?> fn = inv.getArgument(0);
+              return fn.apply(new CaseInsensitiveCapability());
+            });
     Mockito.when(mockCatalogManager.loadCatalogAndWrap(any())).thenReturn(mockWrapper);
 
     OwnerDispatcher mockOwnerDispatcher = Mockito.mock(OwnerDispatcher.class);

--- a/core/src/test/java/org/apache/gravitino/hook/TestFilesetHookDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/hook/TestFilesetHookDispatcher.java
@@ -63,6 +63,7 @@ import org.apache.gravitino.connector.capability.CapabilityResult;
 import org.apache.gravitino.file.Fileset;
 import org.apache.gravitino.file.FilesetChange;
 import org.apache.gravitino.lock.LockManager;
+import org.apache.gravitino.utils.ThrowableFunction;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -96,6 +97,10 @@ public class TestFilesetHookDispatcher extends TestOperationDispatcher {
         Mockito.mock(CatalogManager.CatalogWrapper.class);
     Mockito.when(catalogWrapper.catalog()).thenReturn(catalog);
     Mockito.when(catalogWrapper.capabilities()).thenReturn(Capability.DEFAULT);
+    Mockito.when(catalogWrapper.doWithCapabilityOps(any()))
+        .thenAnswer(
+            inv ->
+                ((ThrowableFunction<Capability, ?>) inv.getArgument(0)).apply(Capability.DEFAULT));
     Mockito.when(catalogManager.loadCatalog(any())).thenReturn(catalog);
     Mockito.when(catalogManager.loadCatalogAndWrap(any())).thenReturn(catalogWrapper);
     authorizationPlugin = Mockito.mock(AuthorizationPlugin.class);
@@ -112,6 +117,11 @@ public class TestFilesetHookDispatcher extends TestOperationDispatcher {
     CatalogManager mockCatalogManager = Mockito.mock(CatalogManager.class);
     CatalogManager.CatalogWrapper mockWrapper = Mockito.mock(CatalogManager.CatalogWrapper.class);
     Mockito.when(mockWrapper.capabilities()).thenReturn(new CaseInsensitiveCapability());
+    Capability caseInsensitiveCap = new CaseInsensitiveCapability();
+    Mockito.when(mockWrapper.doWithCapabilityOps(any()))
+        .thenAnswer(
+            inv ->
+                ((ThrowableFunction<Capability, ?>) inv.getArgument(0)).apply(caseInsensitiveCap));
     Mockito.when(mockCatalogManager.loadCatalogAndWrap(any())).thenReturn(mockWrapper);
 
     OwnerDispatcher mockOwnerDispatcher = Mockito.mock(OwnerDispatcher.class);

--- a/core/src/test/java/org/apache/gravitino/hook/TestFunctionHookDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/hook/TestFunctionHookDispatcher.java
@@ -38,6 +38,7 @@ import org.apache.gravitino.connector.capability.CapabilityResult;
 import org.apache.gravitino.function.Function;
 import org.apache.gravitino.function.FunctionDefinition;
 import org.apache.gravitino.function.FunctionType;
+import org.apache.gravitino.utils.ThrowableFunction;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
@@ -63,6 +64,10 @@ public class TestFunctionHookDispatcher {
     CatalogManager.CatalogWrapper catalogWrapper =
         Mockito.mock(CatalogManager.CatalogWrapper.class);
     Mockito.when(catalogWrapper.capabilities()).thenReturn(Capability.DEFAULT);
+    Mockito.when(catalogWrapper.doWithCapabilityOps(any()))
+        .thenAnswer(
+            inv ->
+                ((ThrowableFunction<Capability, ?>) inv.getArgument(0)).apply(Capability.DEFAULT));
     Mockito.when(catalogManager.loadCatalogAndWrap(any())).thenReturn(catalogWrapper);
 
     Mockito.when(
@@ -146,6 +151,11 @@ public class TestFunctionHookDispatcher {
     CatalogManager mockCatalogManager = Mockito.mock(CatalogManager.class);
     CatalogManager.CatalogWrapper mockWrapper = Mockito.mock(CatalogManager.CatalogWrapper.class);
     Mockito.when(mockWrapper.capabilities()).thenReturn(new CaseInsensitiveCapability());
+    Capability caseInsensitiveCap = new CaseInsensitiveCapability();
+    Mockito.when(mockWrapper.doWithCapabilityOps(any()))
+        .thenAnswer(
+            inv ->
+                ((ThrowableFunction<Capability, ?>) inv.getArgument(0)).apply(caseInsensitiveCap));
     Mockito.when(mockCatalogManager.loadCatalogAndWrap(any())).thenReturn(mockWrapper);
 
     OwnerDispatcher mockOwnerDispatcher = Mockito.mock(OwnerDispatcher.class);
@@ -199,6 +209,10 @@ public class TestFunctionHookDispatcher {
     CatalogManager.CatalogWrapper catalogWrapper =
         Mockito.mock(CatalogManager.CatalogWrapper.class);
     Mockito.when(catalogWrapper.capabilities()).thenReturn(Capability.DEFAULT);
+    Mockito.when(catalogWrapper.doWithCapabilityOps(any()))
+        .thenAnswer(
+            inv ->
+                ((ThrowableFunction<Capability, ?>) inv.getArgument(0)).apply(Capability.DEFAULT));
     Mockito.when(catalogManager.loadCatalogAndWrap(any())).thenReturn(catalogWrapper);
 
     FunctionDispatcher mockFunctionDispatcher = Mockito.mock(FunctionDispatcher.class);

--- a/core/src/test/java/org/apache/gravitino/hook/TestFunctionHookDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/hook/TestFunctionHookDispatcher.java
@@ -150,12 +150,13 @@ public class TestFunctionHookDispatcher {
 
     CatalogManager mockCatalogManager = Mockito.mock(CatalogManager.class);
     CatalogManager.CatalogWrapper mockWrapper = Mockito.mock(CatalogManager.CatalogWrapper.class);
-    Mockito.when(mockWrapper.capabilities()).thenReturn(new CaseInsensitiveCapability());
-    Capability caseInsensitiveCap = new CaseInsensitiveCapability();
-    Mockito.when(mockWrapper.doWithCapabilityOps(any()))
+    Mockito.when(mockWrapper.doWithCapabilityOps(Mockito.any()))
         .thenAnswer(
-            inv ->
-                ((ThrowableFunction<Capability, ?>) inv.getArgument(0)).apply(caseInsensitiveCap));
+            inv -> {
+              @SuppressWarnings("unchecked")
+              org.apache.gravitino.utils.ThrowableFunction<Capability, ?> fn = inv.getArgument(0);
+              return fn.apply(new CaseInsensitiveCapability());
+            });
     Mockito.when(mockCatalogManager.loadCatalogAndWrap(any())).thenReturn(mockWrapper);
 
     OwnerDispatcher mockOwnerDispatcher = Mockito.mock(OwnerDispatcher.class);

--- a/core/src/test/java/org/apache/gravitino/hook/TestModelHookDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/hook/TestModelHookDispatcher.java
@@ -37,6 +37,7 @@ import org.apache.gravitino.catalog.ModelDispatcher;
 import org.apache.gravitino.connector.capability.Capability;
 import org.apache.gravitino.connector.capability.CapabilityResult;
 import org.apache.gravitino.model.Model;
+import org.apache.gravitino.utils.ThrowableFunction;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -63,6 +64,16 @@ public class TestModelHookDispatcher {
     mockCatalogWrapper = mock(CatalogManager.CatalogWrapper.class);
     when(mockCatalogManager.loadCatalogAndWrap(any())).thenReturn(mockCatalogWrapper);
     when(mockCatalogWrapper.capabilities()).thenReturn(Capability.DEFAULT);
+    when(mockCatalogWrapper.doWithCapabilityOps(any()))
+        .thenAnswer(
+            inv -> {
+              try {
+                Capability cap = mockCatalogWrapper.capabilities();
+                return ((ThrowableFunction<Capability, ?>) inv.getArgument(0)).apply(cap);
+              } catch (Exception e) {
+                throw new RuntimeException(e);
+              }
+            });
     savedOwnerDispatcher = GravitinoEnv.getInstance().ownerDispatcher();
     // Read the catalogManager field directly via reflection because the public accessor
     // Preconditions-checks for non-null, which would fail when GravitinoEnv has not been

--- a/core/src/test/java/org/apache/gravitino/hook/TestSchemaHookDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/hook/TestSchemaHookDispatcher.java
@@ -50,6 +50,7 @@ import org.apache.gravitino.catalog.SchemaDispatcher;
 import org.apache.gravitino.connector.capability.Capability;
 import org.apache.gravitino.connector.capability.CapabilityResult;
 import org.apache.gravitino.lock.LockManager;
+import org.apache.gravitino.utils.ThrowableFunction;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -79,6 +80,16 @@ public class TestSchemaHookDispatcher {
     mockCatalogWrapper = mock(CatalogManager.CatalogWrapper.class);
     when(mockCatalogManager.loadCatalogAndWrap(any())).thenReturn(mockCatalogWrapper);
     when(mockCatalogWrapper.capabilities()).thenReturn(Capability.DEFAULT);
+    when(mockCatalogWrapper.doWithCapabilityOps(any()))
+        .thenAnswer(
+            inv -> {
+              try {
+                Capability cap = mockCatalogWrapper.capabilities();
+                return ((ThrowableFunction<Capability, ?>) inv.getArgument(0)).apply(cap);
+              } catch (Exception e) {
+                throw new RuntimeException(e);
+              }
+            });
     savedOwnerDispatcher = GravitinoEnv.getInstance().ownerDispatcher();
     // Tests in this class that rely on the singleton catalogManager always go through
     // GravitinoEnv.getInstance().catalogManager(), but we cannot call the public accessor here

--- a/core/src/test/java/org/apache/gravitino/hook/TestTableHookDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/hook/TestTableHookDispatcher.java
@@ -79,6 +79,7 @@ import org.apache.gravitino.rel.indexes.Indexes;
 import org.apache.gravitino.rel.partitions.Partitions;
 import org.apache.gravitino.rel.partitions.RangePartition;
 import org.apache.gravitino.rel.types.Types;
+import org.apache.gravitino.utils.ThrowableFunction;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -112,6 +113,10 @@ public class TestTableHookDispatcher extends TestOperationDispatcher {
         Mockito.mock(CatalogManager.CatalogWrapper.class);
     Mockito.when(catalogWrapper.catalog()).thenReturn(catalog);
     Mockito.when(catalogWrapper.capabilities()).thenReturn(Capability.DEFAULT);
+    Mockito.when(catalogWrapper.doWithCapabilityOps(any()))
+        .thenAnswer(
+            inv ->
+                ((ThrowableFunction<Capability, ?>) inv.getArgument(0)).apply(Capability.DEFAULT));
 
     Mockito.when(catalogManager.loadCatalog(any())).thenReturn(catalog);
     Mockito.when(catalogManager.loadCatalogAndWrap(any())).thenReturn(catalogWrapper);
@@ -205,6 +210,11 @@ public class TestTableHookDispatcher extends TestOperationDispatcher {
     CatalogManager mockCatalogManager = Mockito.mock(CatalogManager.class);
     CatalogManager.CatalogWrapper mockWrapper = Mockito.mock(CatalogManager.CatalogWrapper.class);
     Mockito.when(mockWrapper.capabilities()).thenReturn(new CaseInsensitiveCapability());
+    Capability caseInsensitiveCap = new CaseInsensitiveCapability();
+    Mockito.when(mockWrapper.doWithCapabilityOps(any()))
+        .thenAnswer(
+            inv ->
+                ((ThrowableFunction<Capability, ?>) inv.getArgument(0)).apply(caseInsensitiveCap));
     Mockito.when(mockCatalogManager.loadCatalogAndWrap(any())).thenReturn(mockWrapper);
 
     OwnerDispatcher mockOwnerDispatcher = Mockito.mock(OwnerDispatcher.class);

--- a/core/src/test/java/org/apache/gravitino/hook/TestTableHookDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/hook/TestTableHookDispatcher.java
@@ -209,12 +209,13 @@ public class TestTableHookDispatcher extends TestOperationDispatcher {
 
     CatalogManager mockCatalogManager = Mockito.mock(CatalogManager.class);
     CatalogManager.CatalogWrapper mockWrapper = Mockito.mock(CatalogManager.CatalogWrapper.class);
-    Mockito.when(mockWrapper.capabilities()).thenReturn(new CaseInsensitiveCapability());
-    Capability caseInsensitiveCap = new CaseInsensitiveCapability();
-    Mockito.when(mockWrapper.doWithCapabilityOps(any()))
+    Mockito.when(mockWrapper.doWithCapabilityOps(Mockito.any()))
         .thenAnswer(
-            inv ->
-                ((ThrowableFunction<Capability, ?>) inv.getArgument(0)).apply(caseInsensitiveCap));
+            inv -> {
+              @SuppressWarnings("unchecked")
+              org.apache.gravitino.utils.ThrowableFunction<Capability, ?> fn = inv.getArgument(0);
+              return fn.apply(new CaseInsensitiveCapability());
+            });
     Mockito.when(mockCatalogManager.loadCatalogAndWrap(any())).thenReturn(mockWrapper);
 
     OwnerDispatcher mockOwnerDispatcher = Mockito.mock(OwnerDispatcher.class);

--- a/core/src/test/java/org/apache/gravitino/hook/TestTopicHookDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/hook/TestTopicHookDispatcher.java
@@ -92,12 +92,13 @@ public class TestTopicHookDispatcher extends TestOperationDispatcher {
 
     CatalogManager mockCatalogManager = Mockito.mock(CatalogManager.class);
     CatalogManager.CatalogWrapper mockWrapper = Mockito.mock(CatalogManager.CatalogWrapper.class);
-    Mockito.when(mockWrapper.capabilities()).thenReturn(new CaseInsensitiveCapability());
-    Capability caseInsensitiveCap = new CaseInsensitiveCapability();
-    Mockito.when(mockWrapper.doWithCapabilityOps(any()))
+    Mockito.when(mockWrapper.doWithCapabilityOps(Mockito.any()))
         .thenAnswer(
-            inv ->
-                ((ThrowableFunction<Capability, ?>) inv.getArgument(0)).apply(caseInsensitiveCap));
+            inv -> {
+              @SuppressWarnings("unchecked")
+              org.apache.gravitino.utils.ThrowableFunction<Capability, ?> fn = inv.getArgument(0);
+              return fn.apply(new CaseInsensitiveCapability());
+            });
     Mockito.when(mockCatalogManager.loadCatalogAndWrap(any())).thenReturn(mockWrapper);
 
     OwnerDispatcher mockOwnerDispatcher = Mockito.mock(OwnerDispatcher.class);

--- a/core/src/test/java/org/apache/gravitino/hook/TestTopicHookDispatcher.java
+++ b/core/src/test/java/org/apache/gravitino/hook/TestTopicHookDispatcher.java
@@ -40,6 +40,7 @@ import org.apache.gravitino.connector.authorization.AuthorizationPlugin;
 import org.apache.gravitino.connector.capability.Capability;
 import org.apache.gravitino.connector.capability.CapabilityResult;
 import org.apache.gravitino.messaging.Topic;
+import org.apache.gravitino.utils.ThrowableFunction;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -72,6 +73,10 @@ public class TestTopicHookDispatcher extends TestOperationDispatcher {
         Mockito.mock(CatalogManager.CatalogWrapper.class);
     Mockito.when(catalogWrapper.catalog()).thenReturn(catalog);
     Mockito.when(catalogWrapper.capabilities()).thenReturn(Capability.DEFAULT);
+    Mockito.when(catalogWrapper.doWithCapabilityOps(any()))
+        .thenAnswer(
+            inv ->
+                ((ThrowableFunction<Capability, ?>) inv.getArgument(0)).apply(Capability.DEFAULT));
     Mockito.when(catalogManager.loadCatalog(any())).thenReturn(catalog);
     Mockito.when(catalogManager.loadCatalogAndWrap(any())).thenReturn(catalogWrapper);
     authorizationPlugin = Mockito.mock(AuthorizationPlugin.class);
@@ -88,6 +93,11 @@ public class TestTopicHookDispatcher extends TestOperationDispatcher {
     CatalogManager mockCatalogManager = Mockito.mock(CatalogManager.class);
     CatalogManager.CatalogWrapper mockWrapper = Mockito.mock(CatalogManager.CatalogWrapper.class);
     Mockito.when(mockWrapper.capabilities()).thenReturn(new CaseInsensitiveCapability());
+    Capability caseInsensitiveCap = new CaseInsensitiveCapability();
+    Mockito.when(mockWrapper.doWithCapabilityOps(any()))
+        .thenAnswer(
+            inv ->
+                ((ThrowableFunction<Capability, ?>) inv.getArgument(0)).apply(caseInsensitiveCap));
     Mockito.when(mockCatalogManager.loadCatalogAndWrap(any())).thenReturn(mockWrapper);
 
     OwnerDispatcher mockOwnerDispatcher = Mockito.mock(OwnerDispatcher.class);

--- a/server-common/src/main/java/org/apache/gravitino/server/authorization/MetadataIdConverter.java
+++ b/server-common/src/main/java/org/apache/gravitino/server/authorization/MetadataIdConverter.java
@@ -95,8 +95,8 @@ public class MetadataIdConverter {
       return ident;
     }
 
-    Capability capability = CapabilityHelpers.getCapability(ident, catalogManager);
-    return CapabilityHelpers.applyCaseSensitive(ident, scope, capability);
+    return CapabilityHelpers.withCapability(
+        ident, catalogManager, cap -> CapabilityHelpers.applyCaseSensitive(ident, scope, cap));
   }
 
   private static Long extractIdFromEntity(Entity entity) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR fixes a race condition where `Caffeine` cache eviction calls `CatalogWrapper.close()` asynchronously, tearing down the `IsolatedClassLoader` while another thread may still invoke a `Capability` method that triggers lazy loading of a compiler-generated synthetic class (`HiveCatalogCapability$1`). Once the classloader is closed, this load fails permanently with `NoClassDefFoundError` for the lifetime of the JVM process.

**Root cause**

`Caffeine` cache eviction calls `CatalogWrapper.close()` asynchronously, tearing down the `IsolatedClassLoader` while another thread may still hold a `Capability` object loaded by that classloader. On the first call to a switch-on-enum method such as `caseSensitiveOnName()`, the JVM lazily loads a compiler-generated synthetic class (`HiveCatalogCapability$1`) via the **defining classloader** — not the thread-context classloader. If that classloader is already closed, the load fails with `NoClassDefFoundError`, and the JVM **permanently caches the failure** for the lifetime of the process.

**Why the previous approach (#11755) was insufficient**

PR #11755 wrapped the `Capability` object in a JDK dynamic proxy that switched the TCCL before each method call. However, the synthetic `$1` class is loaded by the **defining classloader** (`IsolatedClassLoader`), not by the TCCL. Switching the TCCL cannot recover a closed classloader. Reviewer yuqi1129 verified this empirically:

> *"SwitchCap (close loader, then call via withClassLoader/TCCL)" → FAILED*

**Fix — Part 1: eliminate the `$1` synthetic class (root-cause fix)**

- Replace `switch`-on-enum with `if/else` in `HiveCatalogCapability.caseSensitiveOnName()` and `GlueCatalogCapability.caseSensitiveOnName()`, so `javac` does not generate a `$1` switch-map class. The `IsolatedClassLoader` lifecycle is now irrelevant for these `Capability` implementations.

**Fix — Part 2: `synchronized` guard on `doWithCapabilityOps` + `close()`**

- Add `synchronized` to `doWithCapabilityOps(fn)` and `close()` so they are mutually exclusive. `close()` uses `catalog == null` as the closed indicator (idempotent; no separate `volatile boolean`).
- `capabilities()` routes through `doWithCapabilityOps` so all callers get a clean `IllegalStateException` rather than a cryptic `NPE` or `NoClassDefFoundError` if the wrapper is already closed.

**Fix — Part 3: `doWithCapabilityOps` prevents `Capability` escape**

- Add `doWithCapabilityOps(fn)` which executes the `Capability` lambda inside the classloader boundary while holding the synchronized lock.
- Add `CapabilityHelpers.withCapability(ident, mgr, fn)` as the public entry point, with **retry-once** logic: if the cached wrapper is already closed (`isClosed()`), evict it and reload a fresh wrapper before retrying.
- Migrate all `getCapability()` call sites in `NormalizeDispatcher` classes, `OperationDispatcher.isManagedEntity()`, `CatalogManager.isManagedStorageCatalog()`, and `MetadataIdConverter.normalizeCaseSensitive()` to `withCapability()` / `doWithCapabilityOps()`, so no `Capability` object ever escapes the classloader boundary.

## Why are the changes needed?

Without this fix, a catalog evicted from the Caffeine cache under load can cause a permanent `NoClassDefFoundError` for all subsequent operations against any catalog of the same type in the same JVM process. The root issue (#11726) was reported as an unrecoverable `HiveCatalogCapability$1` load failure.

## Does this PR introduce *any* user-facing change?

No API or configuration changes. The behavior change is purely internal: capability operations now execute within the classloader boundary and fail fast with `IllegalStateException` if the catalog has already been closed, rather than crashing with a cryptic classloader error.

## How was this patch tested?

- `TestHiveCatalogCapability` (new): verifies `if/else` behavior across all `Scope` values, null-scope guard, and that `HiveCatalogCapability$1` does **not** exist in the classloader.
- `TestGlueCatalogCapability`: extended with `testNoSwitchOnEnumSyntheticClass` verifying `GlueCatalogCapability$1` does not exist.
- `TestCatalogWrapperConcurrency` (new): four targeted concurrent tests — (1) `close()` blocks until in-flight `doWithCapabilityOps()` finishes, (2) `close()` is idempotent, (3) `doWithCapabilityOps()` after `close()` throws `IllegalStateException`, (4) concurrent `close()` calls do not double-close the classloader.
- Updated mock stubs in `TestTableHookDispatcher`, `TestTopicHookDispatcher`, `TestFilesetHookDispatcher`, `TestFunctionHookDispatcher`, `TestModelHookDispatcher`, `TestSchemaHookDispatcher`, and `TestCatalogManager` to cover the new `doWithCapabilityOps` path.
- All existing unit tests pass (`./gradlew :core:test :server-common:test -PskipITs`).
- Full build passes (`./gradlew clean build -x test`).

Fix: #11726