### PR TITLE
[MINOR] refactor(flink-connector): Align JDBC connector common logic

### DIFF
--- a/flink-connector/flink-common/src/main/java/org/apache/gravitino/flink/connector/jdbc/GravitinoJdbcCatalog.java
+++ b/flink-connector/flink-common/src/main/java/org/apache/gravitino/flink/connector/jdbc/GravitinoJdbcCatalog.java
@@ -151,6 +151,16 @@ public class GravitinoJdbcCatalog extends BaseCatalog {
   }
 
   /**
+   * Returns the mutable options map shared with {@link BaseCatalog}, allowing subclasses to inject
+   * credentials into catalog options after construction.
+   *
+   * @return the mutable catalog options map
+   */
+  protected Map<String, String> getMutableOptions() {
+    return mutableOptions;
+  }
+
+  /**
    * Overwrites the Flink JDBC user and password in {@code options} with credentials obtained from
    * the server via credential vending, if available. Falls back to the existing options if the
    * catalog does not support credential vending or no JDBC credential is returned.
@@ -159,7 +169,7 @@ public class GravitinoJdbcCatalog extends BaseCatalog {
    * @param options the mutable Flink catalog options map to update
    */
   @VisibleForTesting
-  static void applyJdbcCredential(Catalog catalog, Map<String, String> options) {
+  protected static void applyJdbcCredential(Catalog catalog, Map<String, String> options) {
     Credential[] credentials;
     try {
       credentials = catalog.supportsCredentials().getCredentials();

--- a/flink-connector/flink-common/src/main/java/org/apache/gravitino/flink/connector/jdbc/JdbcPropertiesConstants.java
+++ b/flink-connector/flink-common/src/main/java/org/apache/gravitino/flink/connector/jdbc/JdbcPropertiesConstants.java
@@ -30,6 +30,7 @@ public class JdbcPropertiesConstants {
   public static final String GRAVITINO_JDBC_PASSWORD = "jdbc-password";
   public static final String GRAVITINO_JDBC_URL = "jdbc-url";
   public static final String GRAVITINO_JDBC_DRIVER = "jdbc-driver";
+  public static final String GRAVITINO_JDBC_DATABASE = "jdbc-database";
 
   public static final String FLINK_JDBC_URL = "base-url";
   public static final String FLINK_JDBC_USER = "username";

--- a/flink-connector/flink-common/src/test/java/org/apache/gravitino/flink/connector/integration/test/FlinkCommonIT.java
+++ b/flink-connector/flink-common/src/test/java/org/apache/gravitino/flink/connector/integration/test/FlinkCommonIT.java
@@ -87,6 +87,23 @@ public abstract class FlinkCommonIT extends FlinkEnvIT {
 
   protected abstract boolean supportDropCascade();
 
+  /**
+   * Returns {@code true} if the catalog supports schema CREATE/DROP via the Gravitino API. Controls
+   * only the pure schema-lifecycle tests ({@code testCreateSchema}).
+   */
+  protected boolean supportsSchemaLifecycle() {
+    return true;
+  }
+
+  /**
+   * Returns {@code true} if get-schema tests can run. The base-class test creates the schema via
+   * the Gravitino API, so this still depends on {@link #supportsSchemaLifecycle()}. Subclasses that
+   * override {@code testGetSchemaWithoutCommentAndOption} directly should ignore this flag.
+   */
+  protected boolean supportsSchemaLifecycleAndGetSchema() {
+    return supportsSchemaLifecycle() && supportGetSchemaWithoutCommentAndOption();
+  }
+
   protected boolean supportsPrimaryKey() {
     return true;
   }
@@ -117,6 +134,7 @@ public abstract class FlinkCommonIT extends FlinkEnvIT {
   }
 
   @Test
+  @EnabledIf("supportsSchemaLifecycle")
   public void testCreateSchema() {
     doWithCatalog(
         currentCatalog(),
@@ -134,7 +152,7 @@ public abstract class FlinkCommonIT extends FlinkEnvIT {
   }
 
   @Test
-  @EnabledIf("supportGetSchemaWithoutCommentAndOption")
+  @EnabledIf("supportsSchemaLifecycleAndGetSchema")
   public void testGetSchemaWithoutCommentAndOption() {
     doWithCatalog(
         currentCatalog(),
@@ -190,6 +208,7 @@ public abstract class FlinkCommonIT extends FlinkEnvIT {
   }
 
   @Test
+  @EnabledIf("supportsSchemaLifecycle")
   public void testListSchema() {
     doWithCatalog(
         currentCatalog(),

--- a/flink-connector/flink-common/src/test/java/org/apache/gravitino/flink/connector/store/TestGravitinoSessionCatalogStore.java
+++ b/flink-connector/flink-common/src/test/java/org/apache/gravitino/flink/connector/store/TestGravitinoSessionCatalogStore.java
@@ -69,6 +69,16 @@ public class TestGravitinoSessionCatalogStore {
         new GravitinoSessionCatalogStore(gravitinoCatalogStore, memoryCatalogStore);
   }
 
+  @Test
+  void testKnownGravitinoCatalogTypesAreGravitinoManaged() {
+    Assertions.assertTrue(isGravitinoManagedCatalogType("gravitino-hive"));
+    Assertions.assertTrue(isGravitinoManagedCatalogType("gravitino-jdbc-mysql"));
+    Assertions.assertTrue(isGravitinoManagedCatalogType("gravitino-jdbc-postgresql"));
+    Assertions.assertFalse(isGravitinoManagedCatalogType("gravitino-jdbc-custom"));
+    Assertions.assertFalse(isGravitinoManagedCatalogType("jdbc-mysql"));
+    Assertions.assertFalse(isGravitinoManagedCatalogType(null));
+  }
+
   // -------------------------------------------------------------------------
   // storeCatalog
   // -------------------------------------------------------------------------


### PR DESCRIPTION
### What changes were proposed in this pull request?

Align common Flink JDBC connector logic and related tests.

This PR:
- Exposes shared JDBC catalog mutable options and credential injection to subclasses.
- Adds the common `jdbc-database` property constant for Flink JDBC catalog conversion.
- Splits Flink common IT schema lifecycle checks from get-schema capability checks.
- Adds coverage for existing Gravitino-managed catalog type routing.

### Why are the changes needed?

These changes keep common Flink JDBC connector behavior reusable without adding database-specific logic to the OSS implementation.

They also allow catalogs that do not support schema lifecycle operations to reuse the shared Flink integration test base.

Fix: #N/A

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Targeted Flink common tests.