### PR TITLE
[#11851] docs: Add optimizer service design

### DIFF
--- a/design-docs/optimizer-service-design.md
+++ b/design-docs/optimizer-service-design.md
@@ -1,0 +1,844 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements. See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership. The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License. You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied. See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+# Design: Optimizer Service for Apache Gravitino
+
+---
+
+## Background
+
+The Table Maintenance Service (Optimizer) is currently an alpha feature in Apache Gravitino. The
+optimizer package provides CLI commands that connect statistics and metrics collection, rule
+evaluation, strategy recommendation, and job submission.
+
+The current optimizer execution model is local-process oriented:
+
+| Command | Current execution style | Main responsibility |
+| --- | --- | --- |
+| `update-statistics` | CLI loads optimizer config and runs updater logic locally | Calculate and persist table or partition statistics |
+| `append-metrics` | CLI loads optimizer config and runs updater logic locally | Calculate and append table, partition, or job metrics |
+| `submit-strategy-jobs` | CLI loads optimizer config and runs recommender logic locally | Evaluate policies and optionally submit jobs |
+| `monitor-metrics` | CLI loads optimizer config and runs monitor logic locally | Evaluate before/after metrics around an action time |
+| `list-table-metrics` | CLI queries metrics storage locally | Query stored table or partition metrics |
+| `list-job-metrics` | CLI queries metrics storage locally | Query stored job metrics |
+| `submit-update-stats-job` | CLI submits Gravitino jobs | Submit built-in Iceberg update stats/metrics Spark jobs |
+
+This model is useful for local validation and batch scripts, but it has operational limitations:
+
+1. Optimizer work is tied to the CLI process lifecycle. If the process exits, operators lose a
+   consistent service-side task record for updater, recommender, and monitor work.
+2. The CLI is both user interface and execution runtime. This makes it hard to centralize retries,
+   concurrency control, audit logging, and service-level metrics.
+3. Long-running work has no shared asynchronous task model. Users cannot submit a request, disconnect,
+   and later query status through a stable API.
+4. Horizontal scaling and resource isolation are difficult because each invocation creates its own
+   runtime and provider instances.
+5. Automation systems must shell out to the CLI instead of calling a service API with structured
+   request and response payloads.
+
+The current architecture is:
+
+```text
+User or automation
+      |
+      v
+gravitino-optimizer.sh
+      |
+      +--> OptimizerCmd
+             |
+             +--> Updater / Recommender / Monitor / Metrics query
+             |
+             +--> Gravitino server REST APIs and optional metrics storage
+```
+
+This design introduces a long-running Optimizer Service while preserving the existing CLI as a
+client and local execution tool.
+
+---
+
+## Goals
+
+1. **Service Mode for Optimizer Workloads**: Users can run a long-running optimizer service and
+   submit updater, recommender, monitor, and metrics-query requests through REST APIs.
+2. **Asynchronous Task Execution**: Mutating or long-running optimizer commands return a request ID
+   immediately and expose status, result, and error details through query APIs.
+3. **CLI Compatibility**: Existing optimizer CLI commands and options continue to work. A
+   configuration switch controls whether supported commands execute locally or call the service.
+4. **Shared Task Runtime**: Updater, recommender, and monitor modules use one task state model,
+   request ID format, cancellation contract, and list/query behavior.
+5. **Operational Controls**: The service exposes health checks, bounded queues, configurable worker
+   pools, request validation, structured lifecycle logs, and metrics for task execution.
+6. **Incremental Migration**: The design can be implemented in phases without requiring all optimizer
+   commands to move to service mode in one release.
+7. **Job Framework Compatibility**: `submit-update-stats-job` continues to use the existing Gravitino
+   job framework for Spark job submission. The Optimizer Service does not replace the job manager.
+
+---
+
+## Non-Goals
+
+1. **Provider SPI Rewrite**: This design does not replace `StatisticsUpdater`, `MetricsUpdater`,
+   `StatisticsCalculator`, `StatisticsProvider`, `StrategyProvider`, `TableMetadataProvider`,
+   `JobSubmitter`, `MetricsProvider`, `MetricsEvaluator`, or `MonitorCallback`. The service calls
+   the existing provider contracts.
+2. **Strategy Algorithm Changes**: This design does not change how policies are evaluated or how
+   recommendations are ranked. It only changes the execution boundary.
+3. **Statistics and Metrics Model Changes**: This design does not change Gravitino statistics APIs,
+   metrics storage schemas, metric names, or JSON Lines input semantics.
+4. **Gravitino Job Manager Replacement**: This design does not create a second job management system.
+   Built-in maintenance jobs continue to be submitted to the Gravitino job framework.
+5. **Immediate Removal of Local CLI Mode**: Local CLI execution remains supported for compatibility,
+   local debugging, and environments that do not deploy the service.
+6. **Full Multi-Node Coordination in MVP**: The first implementation may use an in-memory task store.
+   Durable task storage and multi-node ownership are included as later hardening work.
+
+---
+
+## Solution Investigations
+
+| Approach | Pros | Cons | Decision |
+| --- | --- | --- | --- |
+| Keep CLI-only execution | No new server process. Minimal implementation work. Preserves current behavior. | Does not solve async status tracking, centralized observability, retries, queueing, or structured automation APIs. Each invocation remains an isolated runtime. | Rejected because it does not address the operational problems. |
+| Embed optimizer execution in the Gravitino server | Reuses the existing server process, REST stack, auth, and deployment path. Avoids another daemon. | Couples maintenance workloads to the metadata server. Heavy optimizer tasks, provider dependencies, and worker pools can affect metadata API latency and server stability. The optimizer package already has a separate distribution and configuration model. | Rejected for MVP because optimizer workloads should be isolated from the metadata control plane. |
+| Add an independent Optimizer Service | Keeps optimizer workloads isolated, preserves the optimizer distribution boundary, and allows independent scaling and resource limits. The CLI can become a client without losing local mode. | Adds a daemon, service configuration, REST resources, and task runtime that must be operated and tested. | **Chosen** because it solves the target operational issues while respecting existing Gravitino boundaries. |
+| Use only the existing Gravitino job framework for every optimizer action | Provides persisted job status and existing server APIs for job execution. | Updater, recommender, monitor, and metrics-query commands are not all jobs. Some requests need provider execution and immediate result payloads, while Spark job submission already has a separate job manager. Forcing all optimizer actions into jobs would blur responsibilities. | Rejected because the job framework should remain the execution backend for submitted jobs, not the universal optimizer control API. |
+
+---
+
+## Proposal
+
+### Architecture
+
+Introduce an independent Optimizer Service in the optimizer distribution:
+
+```text
+User or automation
+      |
+      +-------------------------------+
+      |                               |
+      v                               v
+gravitino-optimizer.sh          REST client
+      |                               |
+      +---------------+---------------+
+                      |
+                      v
+             Optimizer Service
+                      |
+        +-------------+-------------+----------------+----------------+
+        |                           |                |                |
+        v                           v                v                v
+  UpdaterModule              RecommenderModule  MonitorModule   MetricsQueryModule
+        |                           |                |                |
+        +-------------+-------------+----------------+----------------+
+                      |
+                      v
+                 TaskRuntime
+                      |
+        +-------------+-------------+
+        |                           |
+        v                           v
+ Existing provider SPIs      Gravitino server and metrics storage
+```
+
+The service runs as a separate process from the Gravitino server. It uses optimizer configuration to
+load existing providers and exposes REST APIs under one optimizer-specific prefix:
+
+```text
+/api/optimizer/v1
+```
+
+The prefix keeps optimizer APIs separate from Gravitino metadata APIs and leaves room for future
+service-level authentication, routing, and documentation.
+
+### Components
+
+| Component | Responsibility |
+| --- | --- |
+| `OptimizerServiceServer` | Starts the HTTP server, registers REST resources, initializes modules, exposes lifecycle hooks, and owns graceful shutdown. |
+| `TaskRuntime` | Creates request IDs, stores task records, runs asynchronous tasks, handles state transitions, lists tasks, and performs best-effort cancellation. |
+| `UpdaterModule` | Converts updater REST requests into calls to `Updater` for statistics and metrics updates. |
+| `RecommenderModule` | Converts recommender REST requests into calls to `Recommender` for dry-run recommendation or job submission. |
+| `MonitorModule` | Converts monitor REST requests into calls to `Monitor` for rule evaluation and callback execution. |
+| `MetricsQueryModule` | Serves structured table, partition, and job metrics query APIs using existing metrics storage/provider logic. |
+| `OptimizerServiceClient` | Client used by the CLI when service mode is enabled. |
+
+### Task State Model
+
+The task runtime uses one state model across updater, recommender, and monitor tasks:
+
+| State | Meaning |
+| --- | --- |
+| `PENDING` | The service accepted the request and queued it for execution. |
+| `RUNNING` | A worker is executing the request. |
+| `SUCCEEDED` | Execution finished and the task record contains a result payload. |
+| `FAILED` | Execution failed and the task record contains a sanitized error summary. |
+| `CANCELED` | The request was canceled before completion or the worker observed cancellation. |
+
+Each task record stores:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `requestId` | string | Unique optimizer task ID. |
+| `module` | enum | `UPDATER`, `RECOMMENDER`, or `MONITOR`. |
+| `state` | enum | Current task state. |
+| `createdAt` | string | ISO-8601 creation time. |
+| `startedAt` | string | ISO-8601 start time, if started. |
+| `endedAt` | string | ISO-8601 end time, if completed. |
+| `requestHash` | string | Hash of normalized request payload for audit and troubleshooting. |
+| `result` | object | Module-specific result payload for successful tasks. |
+| `error` | object | Sanitized error code, message, and optional stack summary for failed tasks. |
+
+The MVP may use an in-memory task store. The storage API should be pluggable so a later
+implementation can add a DB-backed store without changing REST semantics.
+
+### REST API
+
+All endpoints use JSON payloads and responses. List APIs support pagination in the service model even
+if the MVP initially returns an in-memory bounded list.
+
+#### POST /api/optimizer/v1/updater/requests
+
+Creates an asynchronous updater task.
+
+**Request:**
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `updateType` | string | yes | `STATISTICS` for `update-statistics` or `METRICS` for `append-metrics`. |
+| `calculatorName` | string | yes | Statistics calculator name, for example `local-stats-calculator`. |
+| `identifiers` | array[string] | no | Table or job identifiers. Empty means the selected calculator/provider decides scope. |
+| `statisticsPayload` | string | no | Inline JSON Lines payload. Mutually exclusive with `filePath`. |
+| `filePath` | string | no | Server-local JSON Lines input file path. Mutually exclusive with `statisticsPayload`. |
+
+**Response:** `202 Accepted`
+
+```json
+{
+  "requestId": "updater-018f2f4f",
+  "state": "PENDING"
+}
+```
+
+**Behavior:**
+
+The service validates the same command rules as the CLI. For `local-stats-calculator`, either
+`statisticsPayload` or `filePath` is required. `statisticsPayload` and `filePath` cannot both be set.
+The task result includes the updater summary currently printed by the CLI.
+
+#### GET /api/optimizer/v1/updater/requests/{requestId}
+
+Returns one updater task.
+
+**Response:** `200 OK`
+
+```json
+{
+  "requestId": "updater-018f2f4f",
+  "module": "UPDATER",
+  "state": "SUCCEEDED",
+  "createdAt": "2026-06-30T10:00:00Z",
+  "startedAt": "2026-06-30T10:00:01Z",
+  "endedAt": "2026-06-30T10:00:03Z",
+  "result": {
+    "updateType": "STATISTICS",
+    "summary": {
+      "updatedTables": 1,
+      "updatedPartitions": 0,
+      "updatedJobs": 0
+    }
+  }
+}
+```
+
+**Behavior:**
+
+Returns `404 Not Found` if the request ID does not exist in the task store.
+
+#### GET /api/optimizer/v1/updater/requests
+
+Lists updater tasks.
+
+**Request query parameters:**
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `state` | string | no | Filter by task state. |
+| `fromTime` | string | no | Include tasks created at or after this ISO-8601 time. |
+| `toTime` | string | no | Include tasks created before or at this ISO-8601 time. |
+| `limit` | integer | no | Maximum records to return. |
+| `pageToken` | string | no | Pagination token for later persistent stores. |
+
+**Response:** `200 OK`
+
+```json
+{
+  "requests": [
+    {
+      "requestId": "updater-018f2f4f",
+      "module": "UPDATER",
+      "state": "SUCCEEDED",
+      "createdAt": "2026-06-30T10:00:00Z"
+    }
+  ],
+  "nextPageToken": ""
+}
+```
+
+#### POST /api/optimizer/v1/updater/requests/{requestId}/cancel
+
+Requests best-effort cancellation for one updater task.
+
+**Response:** `200 OK`
+
+```json
+{
+  "requestId": "updater-018f2f4f",
+  "state": "CANCELED"
+}
+```
+
+**Behavior:**
+
+Queued tasks can be canceled before execution. Running tasks are interrupted only when the provider
+or worker observes cancellation. Completed tasks remain in their terminal state.
+
+#### POST /api/optimizer/v1/recommender/requests
+
+Creates an asynchronous recommender task.
+
+**Request:**
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `strategyName` | string | yes | Policy name to evaluate, matching CLI `--strategy-name`. |
+| `identifiers` | array[string] | yes | Table identifiers. |
+| `dryRun` | boolean | no | Preview recommendations without submitting jobs. Default is `false`. |
+| `limit` | integer | no | Maximum number of recommendations or submissions to process. |
+
+**Response:** `202 Accepted`
+
+```json
+{
+  "requestId": "recommender-018f2f50",
+  "state": "PENDING"
+}
+```
+
+**Behavior:**
+
+The service validates identifiers, strategy name, and positive `limit` values. Dry-run tasks return
+recommendation details. Non-dry-run tasks submit jobs through the configured `JobSubmitter`, which may
+call Gravitino job APIs.
+
+#### GET /api/optimizer/v1/recommender/requests/{requestId}
+
+Returns one recommender task.
+
+**Response:** `200 OK`
+
+```json
+{
+  "requestId": "recommender-018f2f50",
+  "module": "RECOMMENDER",
+  "state": "SUCCEEDED",
+  "result": {
+    "dryRun": true,
+    "recommendations": [
+      {
+        "strategyName": "iceberg_compaction_default",
+        "identifier": "rest_catalog.db.t1",
+        "score": 100,
+        "jobTemplate": "builtin-iceberg-rewrite-data-files",
+        "jobOptions": {
+          "catalog_name": "rest_catalog",
+          "table_identifier": "db.t1"
+        },
+        "jobId": ""
+      }
+    ]
+  }
+}
+```
+
+**Behavior:**
+
+Returns submitted job IDs when the configured submitter creates Gravitino jobs.
+
+#### GET /api/optimizer/v1/recommender/requests
+
+Lists recommender tasks.
+
+**Request query parameters:**
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `state` | string | no | Filter by task state. |
+| `fromTime` | string | no | Include tasks created at or after this ISO-8601 time. |
+| `toTime` | string | no | Include tasks created before or at this ISO-8601 time. |
+| `limit` | integer | no | Maximum records to return. |
+| `pageToken` | string | no | Pagination token for later persistent stores. |
+
+**Response:** `200 OK`
+
+```json
+{
+  "requests": [
+    {
+      "requestId": "recommender-018f2f50",
+      "module": "RECOMMENDER",
+      "state": "SUCCEEDED",
+      "createdAt": "2026-06-30T10:10:00Z"
+    }
+  ],
+  "nextPageToken": ""
+}
+```
+
+**Behavior:**
+
+The service returns recommender task summaries sorted by creation time. The MVP may only return tasks
+that are still retained by the in-memory task store.
+
+#### POST /api/optimizer/v1/recommender/requests/{requestId}/cancel
+
+Requests best-effort cancellation for one recommender task.
+
+**Response:** `200 OK`
+
+```json
+{
+  "requestId": "recommender-018f2f50",
+  "state": "CANCELED"
+}
+```
+
+**Behavior:**
+
+Queued tasks can be canceled before execution. Running recommendation tasks are canceled only when
+the worker or provider observes cancellation. Jobs already submitted through Gravitino are not
+automatically canceled by canceling the optimizer task.
+
+#### POST /api/optimizer/v1/monitor/requests
+
+Creates an asynchronous monitor task.
+
+**Request:**
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `identifiers` | array[string] | yes | Table or job identifiers to evaluate. |
+| `actionTime` | integer | yes | Action timestamp in epoch seconds. |
+| `rangeSeconds` | integer | no | Evaluation window. Default is the current CLI default, 86400 seconds. |
+| `partitionPath` | array[object] | no | Partition path. Allowed only when exactly one table identifier is provided. |
+
+**Response:** `202 Accepted`
+
+```json
+{
+  "requestId": "monitor-018f2f51",
+  "state": "PENDING"
+}
+```
+
+**Behavior:**
+
+The service evaluates monitor rules with the configured metrics provider, evaluator, table-job
+relation provider, and callbacks. The task result includes the evaluation records currently printed by
+the CLI.
+
+#### GET /api/optimizer/v1/monitor/requests/{requestId}
+
+Returns one monitor task.
+
+**Response:** `200 OK`
+
+```json
+{
+  "requestId": "monitor-018f2f51",
+  "module": "MONITOR",
+  "state": "SUCCEEDED",
+  "result": {
+    "evaluations": [
+      {
+        "identifier": "rest_catalog.db.t1",
+        "scope": "table",
+        "evaluator": "gravitino-metrics-evaluator",
+        "passed": true
+      }
+    ]
+  }
+}
+```
+
+#### GET /api/optimizer/v1/monitor/requests
+
+Lists monitor tasks.
+
+**Request query parameters:**
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `state` | string | no | Filter by task state. |
+| `fromTime` | string | no | Include tasks created at or after this ISO-8601 time. |
+| `toTime` | string | no | Include tasks created before or at this ISO-8601 time. |
+| `limit` | integer | no | Maximum records to return. |
+| `pageToken` | string | no | Pagination token for later persistent stores. |
+
+**Response:** `200 OK`
+
+```json
+{
+  "requests": [
+    {
+      "requestId": "monitor-018f2f51",
+      "module": "MONITOR",
+      "state": "SUCCEEDED",
+      "createdAt": "2026-06-30T10:20:00Z"
+    }
+  ],
+  "nextPageToken": ""
+}
+```
+
+**Behavior:**
+
+The service returns monitor task summaries sorted by creation time. The MVP may only return tasks
+that are still retained by the in-memory task store.
+
+#### POST /api/optimizer/v1/monitor/requests/{requestId}/cancel
+
+Requests best-effort cancellation for one monitor task.
+
+**Response:** `200 OK`
+
+```json
+{
+  "requestId": "monitor-018f2f51",
+  "state": "CANCELED"
+}
+```
+
+**Behavior:**
+
+Queued tasks can be canceled before execution. Running monitor tasks are canceled only when the
+worker or provider observes cancellation. Monitor callbacks that have already been invoked are not
+rolled back.
+
+#### GET /api/optimizer/v1/metrics/tables
+
+Queries table or partition metrics.
+
+**Request query parameters:**
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `identifiers` | string | yes | Comma-separated table identifiers. |
+| `partitionPath` | string | no | Partition path JSON array. Requires exactly one identifier. |
+
+**Response:** `200 OK`
+
+```json
+{
+  "metrics": [
+    {
+      "identifier": "rest_catalog.db.t1",
+      "scope": "table",
+      "points": [
+        {
+          "name": "row_count",
+          "value": 100,
+          "timestamp": 1735689600
+        }
+      ]
+    }
+  ]
+}
+```
+
+**Behavior:**
+
+This is a synchronous query endpoint because it reads existing metrics and is expected to be short.
+Large result pagination can be added with the same `limit` and `pageToken` pattern.
+
+#### GET /api/optimizer/v1/metrics/jobs
+
+Queries job metrics.
+
+**Request query parameters:**
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `identifiers` | string | yes | Comma-separated job identifiers. |
+
+**Response:** `200 OK`
+
+```json
+{
+  "metrics": [
+    {
+      "identifier": "job_1",
+      "scope": "job",
+      "points": [
+        {
+          "name": "duration_ms",
+          "value": 12500,
+          "timestamp": 1735689800
+        }
+      ]
+    }
+  ]
+}
+```
+
+#### GET /api/optimizer/v1/health
+
+Returns service health.
+
+**Response:** `200 OK`
+
+```json
+{
+  "status": "UP",
+  "modules": {
+    "updater": "UP",
+    "recommender": "UP",
+    "monitor": "UP",
+    "metricsQuery": "UP"
+  }
+}
+```
+
+### CLI Service Mode
+
+Add optimizer service configuration keys:
+
+| Key | Default | Description |
+| --- | --- | --- |
+| `gravitino.optimizer.service.enabled` | `false` | Enables CLI remote execution for supported commands. |
+| `gravitino.optimizer.service.url` | none | Base URL of the Optimizer Service, for example `http://localhost:8091`. |
+| `gravitino.optimizer.service.requestTimeoutMs` | `30000` | HTTP request timeout for CLI service calls. |
+| `gravitino.optimizer.service.pollIntervalMs` | `1000` | Poll interval when the CLI waits for async task completion. |
+| `gravitino.optimizer.service.waitForCompletion` | `true` | Whether CLI commands wait and print final results by default. |
+
+The existing CLI commands remain the primary user interface:
+
+| CLI command | Service mode behavior |
+| --- | --- |
+| `update-statistics` | Calls `POST /api/optimizer/v1/updater/requests` with `updateType=STATISTICS`. |
+| `append-metrics` | Calls `POST /api/optimizer/v1/updater/requests` with `updateType=METRICS`. |
+| `submit-strategy-jobs` | Calls `POST /api/optimizer/v1/recommender/requests`. |
+| `monitor-metrics` | Calls `POST /api/optimizer/v1/monitor/requests`. |
+| `list-table-metrics` | Calls `GET /api/optimizer/v1/metrics/tables`. |
+| `list-job-metrics` | Calls `GET /api/optimizer/v1/metrics/jobs`. |
+| `submit-update-stats-job` | Initially remains local CLI submission to the Gravitino job framework. A later phase may add an optimizer task wrapper. |
+
+If service mode is disabled, commands use the current local execution path. If service mode is
+enabled and the service call fails, the CLI should fail fast by default. Automatic local fallback can
+hide partial service outages and cause duplicated submissions, so fallback should require an explicit
+future configuration if it is added.
+
+### User Process
+
+The service mode user flow is:
+
+1. The operator configures `conf/gravitino-optimizer.conf` with Gravitino connection settings,
+   optimizer providers, and service settings.
+2. The operator starts the Optimizer Service with the optimizer distribution.
+3. A user runs an existing CLI command such as:
+
+   ```bash
+   ./bin/gravitino-optimizer.sh \
+     --type submit-strategy-jobs \
+     --identifiers rest_catalog.db.t1 \
+     --strategy-name iceberg_compaction_default \
+     --dry-run \
+     --limit 10
+   ```
+
+4. The CLI validates arguments, detects service mode, submits a REST request, and prints the request
+   ID.
+5. If `waitForCompletion` is enabled, the CLI polls the task status endpoint and prints the final
+   result using output compatible with the existing command.
+6. Automation can call the REST API directly, store the request ID, and query the result later.
+
+### Implementation Process
+
+The internal flow for asynchronous tasks is:
+
+```text
+CLI or REST client
+      |
+      v
+REST resource validates request
+      |
+      v
+TaskRuntime creates task record in PENDING state
+      |
+      v
+Worker picks task and marks RUNNING
+      |
+      v
+Module invokes existing optimizer class
+      |
+      +--> Updater / Recommender / Monitor
+      |
+      v
+TaskRuntime stores SUCCEEDED, FAILED, or CANCELED result
+      |
+      v
+Client queries task result
+```
+
+Implementation should keep module boundaries thin. Existing `Updater`, `Recommender`, and `Monitor`
+classes remain the execution core. REST resources translate requests into module calls, and modules
+translate module results into REST result DTOs.
+
+### Backward Compatibility
+
+This design is backward compatible for existing CLI users:
+
+1. Service mode is disabled by default.
+2. Existing command names and options remain valid.
+3. Existing local output should remain the default when service mode is disabled.
+4. Service mode may print the request ID in addition to existing summary lines. This is additive.
+5. `submit-update-stats-job` keeps the existing local submission path until a service wrapper is
+   implemented.
+
+New REST APIs are additive. They do not change existing Gravitino metadata APIs or job APIs.
+
+### Security
+
+The service must validate all request parameters at the REST boundary using the same rules as the
+CLI. File-based input such as `filePath` is server-local in service mode and should be documented as
+an operator-controlled path, not a client upload path.
+
+Authentication and authorization can be phased:
+
+1. MVP supports deployments behind trusted internal networks or reverse proxies.
+2. A later phase can integrate with Gravitino authentication mechanisms or service-specific tokens.
+3. Direct REST clients should receive sanitized error messages that do not expose secrets from config
+   files, job options, or provider exceptions.
+
+### Reliability and Observability
+
+The service should provide:
+
+| Area | Requirement |
+| --- | --- |
+| Queue control | Per-module queue size and worker count. |
+| Timeout | Per-task execution timeout and HTTP client timeout. |
+| Cancellation | Best-effort cancellation for queued and cooperative running tasks. |
+| Shutdown | Graceful shutdown that stops accepting requests and drains or cancels queued work. |
+| Logs | Request lifecycle logs with request ID, module, state transition, and duration. |
+| Metrics | Task counts by module/state, latency, queue depth, worker utilization, and failure counts. |
+| Health | Health endpoint with module initialization status. |
+
+### Rollout Plan
+
+#### Phase 1: Service Shell and Task Runtime
+
+Create the service entry point, REST server, health endpoint, task runtime, in-memory task store, and
+common DTOs. Add unit tests for state transitions, cancellation, serialization, and request listing.
+
+#### Phase 2: Updater Service Mode
+
+Implement updater REST APIs and CLI service mode for `update-statistics` and `append-metrics`.
+Validate parity with local execution using existing updater tests and new service-mode CLI tests.
+
+#### Phase 3: Recommender Service Mode
+
+Implement recommender REST APIs and CLI service mode for `submit-strategy-jobs`. Cover dry-run and
+real submission paths, including returned job IDs from the configured submitter.
+
+#### Phase 4: Monitor and Metrics Query APIs
+
+Implement monitor task APIs and synchronous metrics query APIs. Add CLI service mode for
+`monitor-metrics`, `list-table-metrics`, and `list-job-metrics`.
+
+#### Phase 5: Built-In Update Stats Job Wrapper
+
+Optionally add an asynchronous optimizer task wrapper for `submit-update-stats-job`. The actual Spark
+job submission and status remain owned by the Gravitino job framework.
+
+#### Phase 6: Hardening
+
+Add persistent task storage, authentication integration, service metrics export, stronger graceful
+shutdown semantics, and optional multi-node deployment support.
+
+---
+
+## Task Breakdown
+
+### Phase 1: Service Shell and Shared Runtime
+
+- [ ] Add optimizer service configuration keys to `OptimizerConfig`.
+- [ ] Add `OptimizerServiceServer` entry point and startup script in the optimizer distribution.
+- [ ] Add common request, response, task record, task state, and error DTOs.
+- [ ] Implement `TaskRuntime` with in-memory task storage, bounded queues, worker pools, state
+      transitions, list/query support, and best-effort cancellation.
+- [ ] Add `GET /api/optimizer/v1/health`.
+- [ ] Add unit tests for task state transitions, task listing filters, cancellation, and DTO
+      serialization.
+
+### Phase 2: Updater APIs and CLI Service Mode
+
+- [ ] Add updater REST resource for submit, get, list, and cancel APIs.
+- [ ] Add `UpdaterModule` that adapts REST requests to existing `Updater` execution.
+- [ ] Add `OptimizerServiceClient` support for updater APIs.
+- [ ] Add CLI service-mode routing for `update-statistics`.
+- [ ] Add CLI service-mode routing for `append-metrics`.
+- [ ] Add tests for updater request validation, local calculator input rules, successful results, and
+      failure results.
+
+### Phase 3: Recommender APIs and CLI Service Mode
+
+- [ ] Add recommender REST resource for submit, get, list, and cancel APIs.
+- [ ] Add `RecommenderModule` that adapts REST requests to existing `Recommender` execution.
+- [ ] Add `OptimizerServiceClient` support for recommender APIs.
+- [ ] Add CLI service-mode routing for `submit-strategy-jobs`.
+- [ ] Add tests for dry-run recommendations, limit handling, job submission results, and service-mode
+      CLI output.
+
+### Phase 4: Monitor and Metrics Query APIs
+
+- [ ] Add monitor REST resource for submit, get, list, and cancel APIs.
+- [ ] Add `MonitorModule` that adapts REST requests to existing `Monitor` execution.
+- [ ] Add metrics query REST resource for table, partition, and job metric queries.
+- [ ] Add `OptimizerServiceClient` support for monitor and metrics query APIs.
+- [ ] Add CLI service-mode routing for `monitor-metrics`.
+- [ ] Add CLI service-mode routing for `list-table-metrics` and `list-job-metrics`.
+- [ ] Add tests for monitor validation, partition path handling, evaluation results, and metrics query
+      responses.
+
+### Phase 5: Built-In Job Wrapper
+
+- [ ] Add optional service task API for `submit-update-stats-job` request wrapping.
+- [ ] Keep actual job creation in the existing Gravitino job framework.
+- [ ] Add CLI service-mode routing for `submit-update-stats-job` only after the wrapper is available.
+- [ ] Add tests that returned optimizer task results include submitted Gravitino job IDs.
+
+### Phase 6: Hardening and Documentation
+
+- [ ] Add persistent task store abstraction and DB-backed implementation.
+- [ ] Add service authentication and sanitized error handling.
+- [ ] Add service metrics for task counts, latency, queue depth, and worker utilization.
+- [ ] Add graceful shutdown tests.
+- [ ] Update user-facing TMS documentation in `docs/table-maintenance-service/`.
+- [ ] Add OpenAPI documentation if optimizer service APIs are published under `docs/open-api/`.
+- [ ] Validate OpenAPI documentation with `./gradlew :docs:build` if OpenAPI files are changed.

--- a/design-docs/optimizer-service-design.md
+++ b/design-docs/optimizer-service-design.md
@@ -29,15 +29,15 @@ evaluation, strategy recommendation, and job submission.
 
 The current optimizer execution model is local-process oriented:
 
-| Command | Current execution style | Main responsibility |
-| --- | --- | --- |
-| `update-statistics` | CLI loads optimizer config and runs updater logic locally | Calculate and persist table or partition statistics |
-| `append-metrics` | CLI loads optimizer config and runs updater logic locally | Calculate and append table, partition, or job metrics |
-| `submit-strategy-jobs` | CLI loads optimizer config and runs recommender logic locally | Evaluate policies and optionally submit jobs |
-| `monitor-metrics` | CLI loads optimizer config and runs monitor logic locally | Evaluate before/after metrics around an action time |
-| `list-table-metrics` | CLI queries metrics storage locally | Query stored table or partition metrics |
-| `list-job-metrics` | CLI queries metrics storage locally | Query stored job metrics |
-| `submit-update-stats-job` | CLI submits Gravitino jobs | Submit built-in Iceberg update stats/metrics Spark jobs |
+| Command                   | Current execution style                                       | Main responsibility                                     |
+| ------------------------- | ------------------------------------------------------------- | ------------------------------------------------------- |
+| `update-statistics`       | CLI loads optimizer config and runs updater logic locally     | Calculate and persist table or partition statistics     |
+| `append-metrics`          | CLI loads optimizer config and runs updater logic locally     | Calculate and append table, partition, or job metrics   |
+| `submit-strategy-jobs`    | CLI loads optimizer config and runs recommender logic locally | Evaluate policies and optionally submit jobs            |
+| `monitor-metrics`         | CLI loads optimizer config and runs monitor logic locally     | Evaluate before/after metrics around an action time     |
+| `list-table-metrics`      | CLI queries metrics storage locally                           | Query stored table or partition metrics                 |
+| `list-job-metrics`        | CLI queries metrics storage locally                           | Query stored job metrics                                |
+| `submit-update-stats-job` | CLI submits Gravitino jobs                                    | Submit built-in Iceberg update stats/metrics Spark jobs |
 
 This model is useful for local validation and batch scripts, but it has operational limitations:
 
@@ -76,12 +76,12 @@ client and local execution tool.
 
 1. **Service Mode for Optimizer Workloads**: Users can run a long-running optimizer service and
    submit updater, recommender, monitor, and metrics-query requests through REST APIs.
-2. **Asynchronous Task Execution**: Mutating or long-running optimizer commands return a request ID
+2. **Asynchronous Task Execution**: Mutating or long-running optimizer commands return a task ID
    immediately and expose status, result, and error details through query APIs.
 3. **CLI Compatibility**: Existing optimizer CLI commands and options continue to work. A
    configuration switch controls whether supported commands execute locally or call the service.
-4. **Shared Task Runtime**: Updater, recommender, and monitor modules use one task state model,
-   request ID format, cancellation contract, and list/query behavior.
+4. **Shared Task Runtime**: Updater, recommender, and monitor modules use one task status model,
+   task ID format, cancellation contract, and list/query behavior.
 5. **Operational Controls**: The service exposes health checks, bounded queues, configurable worker
    pools, request validation, structured lifecycle logs, and metrics for task execution.
 6. **Incremental Migration**: The design can be implemented in phases without requiring all optimizer
@@ -112,12 +112,56 @@ client and local execution tool.
 
 ## Solution Investigations
 
-| Approach | Pros | Cons | Decision |
-| --- | --- | --- | --- |
-| Keep CLI-only execution | No new server process. Minimal implementation work. Preserves current behavior. | Does not solve async status tracking, centralized observability, retries, queueing, or structured automation APIs. Each invocation remains an isolated runtime. | Rejected because it does not address the operational problems. |
-| Embed optimizer execution in the Gravitino server | Reuses the existing server process, REST stack, auth, and deployment path. Avoids another daemon. | Couples maintenance workloads to the metadata server. Heavy optimizer tasks, provider dependencies, and worker pools can affect metadata API latency and server stability. The optimizer package already has a separate distribution and configuration model. | Rejected for MVP because optimizer workloads should be isolated from the metadata control plane. |
-| Add an independent Optimizer Service | Keeps optimizer workloads isolated, preserves the optimizer distribution boundary, and allows independent scaling and resource limits. The CLI can become a client without losing local mode. | Adds a daemon, service configuration, REST resources, and task runtime that must be operated and tested. | **Chosen** because it solves the target operational issues while respecting existing Gravitino boundaries. |
-| Use only the existing Gravitino job framework for every optimizer action | Provides persisted job status and existing server APIs for job execution. | Updater, recommender, monitor, and metrics-query commands are not all jobs. Some requests need provider execution and immediate result payloads, while Spark job submission already has a separate job manager. Forcing all optimizer actions into jobs would blur responsibilities. | Rejected because the job framework should remain the execution backend for submitted jobs, not the universal optimizer control API. |
+### Option A: Keep CLI-only execution
+
+Continue running all optimizer work inside the CLI process, with no server component.
+
+**Pros:** No new server process. Minimal implementation work. Preserves current behavior.
+
+**Cons:** Does not solve async status tracking, centralized observability, retries, queueing, or
+structured automation APIs. Each invocation remains an isolated runtime.
+
+**Decision:** Rejected because it does not address the operational problems.
+
+### Option B: Embed optimizer execution in the Gravitino server
+
+Run the optimizer modules inside the existing Gravitino metadata server process.
+
+**Pros:** Reuses the existing server process, REST stack, auth, and deployment path. Avoids another
+daemon.
+
+**Cons:** Couples maintenance workloads to the metadata server. Heavy optimizer tasks, provider
+dependencies, and worker pools can affect metadata API latency and server stability. The optimizer
+package already has a separate distribution and configuration model.
+
+**Decision:** Rejected for MVP because optimizer workloads should be isolated from the metadata
+control plane.
+
+### Option C: Use only the existing Gravitino job framework for every optimizer action
+
+Model every optimizer command (updater, recommender, monitor, metrics query) as a Gravitino job.
+
+**Pros:** Provides persisted job status and existing server APIs for job execution.
+
+**Cons:** Updater, recommender, monitor, and metrics-query commands are not all jobs. Some requests
+need provider execution and immediate result payloads, while Spark job submission already has a
+separate job manager. Forcing all optimizer actions into jobs would blur responsibilities.
+
+**Decision:** Rejected because the job framework should remain the execution backend for submitted
+jobs, not the universal optimizer control API.
+
+### Option D: Add an independent Optimizer Service (Chosen)
+
+Introduce a standalone Optimizer Service in the optimizer distribution, with the CLI as one client.
+
+**Pros:** Keeps optimizer workloads isolated, preserves the optimizer distribution boundary, and
+allows independent scaling and resource limits. The CLI can become a client without losing local mode.
+
+**Cons:** Adds a daemon, service configuration, REST resources, and task runtime that must be operated
+and tested.
+
+**Decision:** **Chosen** because it solves the target operational issues while respecting existing
+Gravitino boundaries.
 
 ---
 
@@ -168,97 +212,116 @@ service-level authentication, routing, and documentation.
 
 ### Components
 
-| Component | Responsibility |
-| --- | --- |
-| `OptimizerServiceServer` | Starts the HTTP server, registers REST resources, initializes modules, exposes lifecycle hooks, and owns graceful shutdown. |
-| `TaskRuntime` | Creates request IDs, stores task records, runs asynchronous tasks, handles state transitions, lists tasks, and performs best-effort cancellation. |
-| `UpdaterModule` | Converts updater REST requests into calls to `Updater` for statistics and metrics updates. |
-| `RecommenderModule` | Converts recommender REST requests into calls to `Recommender` for dry-run recommendation or job submission. |
-| `MonitorModule` | Converts monitor REST requests into calls to `Monitor` for rule evaluation and callback execution. |
-| `MetricsQueryModule` | Serves structured table, partition, and job metrics query APIs using existing metrics storage/provider logic. |
-| `OptimizerServiceClient` | Client used by the CLI when service mode is enabled. |
+| Component                | Responsibility                                                                                                                                  |
+| ------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `OptimizerServiceServer` | Starts the HTTP server, registers REST resources, initializes modules, exposes lifecycle hooks, and owns graceful shutdown.                     |
+| `TaskRuntime`            | Creates task IDs, stores task records, runs asynchronous tasks, handles status transitions, lists tasks, and performs best-effort cancellation. |
+| `UpdaterModule`          | Converts updater REST requests into calls to `Updater` for statistics and metrics updates.                                                      |
+| `RecommenderModule`      | Converts recommender REST requests into calls to `Recommender` for dry-run recommendation or job submission.                                    |
+| `MonitorModule`          | Converts monitor REST requests into calls to `Monitor` for rule evaluation and callback execution.                                              |
+| `MetricsQueryModule`     | Serves structured table, partition, and job metrics query APIs using existing metrics storage/provider logic.                                   |
+| `OptimizerServiceClient` | Client used by the CLI when service mode is enabled.                                                                                            |
 
-### Task State Model
+### Task Status Model
 
-The task runtime uses one state model across updater, recommender, and monitor tasks:
+The task runtime uses one status model across updater, recommender, and monitor tasks. The status
+vocabulary follows the Gravitino job model (`queued`, `started`, `succeeded`, `failed`, `cancelling`,
+`canceled`) so that optimizer tasks read the same way as job runs:
 
-| State | Meaning |
-| --- | --- |
-| `PENDING` | The service accepted the request and queued it for execution. |
-| `RUNNING` | A worker is executing the request. |
-| `SUCCEEDED` | Execution finished and the task record contains a result payload. |
-| `FAILED` | Execution failed and the task record contains a sanitized error summary. |
-| `CANCELED` | The request was canceled before completion or the worker observed cancellation. |
+| Status       | Meaning                                                                 |
+| ------------ | ----------------------------------------------------------------------- |
+| `queued`     | The service accepted the request and queued it for execution.           |
+| `started`    | A worker is executing the request.                                      |
+| `succeeded`  | Execution finished and the task record contains a result payload.       |
+| `failed`     | Execution failed and the task record contains a sanitized error object. |
+| `cancelling` | Cancellation was requested for a started task and is being applied.     |
+| `canceled`   | The request was canceled before or during execution.                    |
 
-`SUCCEEDED`, `FAILED`, and `CANCELED` are terminal states. The allowed transitions are:
+`succeeded`, `failed`, and `canceled` are terminal statuses. The allowed transitions are:
 
 ```text
-PENDING --> RUNNING --> SUCCEEDED
-   |           |
-   |           +------> FAILED
-   |           |
-   +-----------+------> CANCELED
+queued --> started --> succeeded
+  |          |
+  |          +--------> failed
+  |          |
+  |          +--------> cancelling --> canceled
+  |
+  +-------------------------------> canceled
 ```
 
-A task in `PENDING` can move directly to `CANCELED` if it is canceled before a worker picks it up. A
-task in `RUNNING` reaches `CANCELED` only when the worker or provider observes cancellation.
+A task in `queued` moves directly to `canceled` if it is canceled before a worker picks it up. A
+`started` task first enters `cancelling` and reaches `canceled` only when the worker or provider
+observes cancellation.
 
-Each task record stores:
+Each task record follows the job record shape (identifier, status, `audit`) plus optimizer-specific
+timing and payload fields:
 
-| Field | Type | Description |
-| --- | --- | --- |
-| `requestId` | string | Unique optimizer task ID. |
-| `module` | enum | `UPDATER`, `RECOMMENDER`, or `MONITOR`. |
-| `state` | enum | Current task state. |
-| `createdAt` | string | ISO-8601 creation time. |
-| `startedAt` | string | ISO-8601 start time, if started. |
-| `endedAt` | string | ISO-8601 end time, if completed. |
-| `requestHash` | string | Hash of normalized request payload for audit and troubleshooting. |
-| `result` | object | Module-specific result payload for successful tasks. |
-| `error` | object | Sanitized error code, message, and optional stack summary for failed tasks. |
+| Field         | Type   | Description                                                                 |
+| ------------- | ------ | --------------------------------------------------------------------------- |
+| `taskId`      | string | Unique optimizer task ID, for example `updater-018f2f4f`.                   |
+| `module`      | string | `updater`, `recommender`, or `monitor`.                                     |
+| `status`      | string | Current task status.                                                        |
+| `startedAt`   | string | ISO-8601 start time, if started.                                            |
+| `finishedAt`  | string | ISO-8601 completion time, if in a terminal status.                          |
+| `requestHash` | string | Hash of the normalized request payload for audit and troubleshooting.       |
+| `result`      | object | Module-specific result payload for successful tasks.                        |
+| `error`       | object | Sanitized error object for failed tasks.                                    |
+| `audit`       | object | Audit info (`createTime`, `creator`), matching the Gravitino `Audit` model. |
 
-For a `FAILED` task, the `error` object has a stable shape so clients and automation can branch on it:
+For a `failed` task, the `error` object mirrors the Gravitino `ErrorModel` (`code`, `type`, `message`)
+so clients and automation branch on the same shape used by the metadata APIs:
 
 ```json
 {
-  "code": "INVALID_INPUT",
-  "message": "statisticsPayload and filePath cannot both be set",
-  "stackSummary": ""
+  "code": 1001,
+  "type": "IllegalArgumentException",
+  "message": "statisticsPayload and filePath cannot both be set"
 }
 ```
 
-`code` is a machine-readable error category, `message` is a sanitized human-readable summary, and
-`stackSummary` is an optional truncated trace that never includes secrets from config files, job
-options, or provider exceptions.
+`message` is always sanitized and never exposes secrets from config files, job options, or provider
+exceptions.
 
 The MVP may use an in-memory task store. The storage API should be pluggable so a later
 implementation can add a DB-backed store without changing REST semantics.
 
 ### REST API
 
-All endpoints use JSON payloads and responses. List APIs support pagination in the service model even
-if the MVP initially returns an in-memory bounded list.
+The API follows the same conventions as the Gravitino job run APIs (`/metalakes/{metalake}/jobs/runs`):
 
-#### POST /api/optimizer/v1/updater/requests
+- All endpoints exchange JSON using the `application/vnd.gravitino.v1+json` media type.
+- Every response body carries an integer `code` (`0` for success) wrapping the payload.
+- Each asynchronous module exposes the same four operations as job runs: submit (`POST .../tasks`),
+  get (`GET .../tasks/{taskId}`), list (`GET .../tasks`), and cancel (`POST .../tasks/{taskId}`).
+- Errors use the Gravitino `ErrorModel` (`code`, `type`, `message`, `stack`), so a missing task
+  returns a `NoSuchTaskException` and an invalid payload returns an `IllegalArgumentException`.
+- List APIs support pagination in the service model even if the MVP initially returns an in-memory
+  bounded list.
 
-Creates an asynchronous updater task.
+#### POST /api/optimizer/v1/updater/tasks
+
+Submits an asynchronous updater task.
 
 **Request:**
 
-| Field | Type | Required | Description |
-| --- | --- | --- | --- |
-| `updateType` | string | yes | `STATISTICS` for `update-statistics` or `METRICS` for `append-metrics`. |
-| `calculatorName` | string | yes | Statistics calculator name, for example `local-stats-calculator`. |
-| `identifiers` | array[string] | no | Table or job identifiers. Empty means the selected calculator/provider decides scope. |
-| `statisticsPayload` | string | no | Inline JSON Lines payload. Mutually exclusive with `filePath`. |
-| `filePath` | string | no | Server-local JSON Lines input file path. Mutually exclusive with `statisticsPayload`. |
+| Field               | Type          | Required | Description                                                                           |
+| ------------------- | ------------- | -------- | ------------------------------------------------------------------------------------- |
+| `updateType`        | string        | yes      | `STATISTICS` for `update-statistics` or `METRICS` for `append-metrics`.               |
+| `calculatorName`    | string        | yes      | Statistics calculator name, for example `local-stats-calculator`.                     |
+| `identifiers`       | array[string] | no       | Table or job identifiers. Empty means the selected calculator/provider decides scope. |
+| `statisticsPayload` | string        | no       | Inline JSON Lines payload. Mutually exclusive with `filePath`.                        |
+| `filePath`          | string        | no       | Server-local JSON Lines input file path. Mutually exclusive with `statisticsPayload`. |
 
-**Response:** `202 Accepted`
+**Response:** `200 OK`
 
 ```json
 {
-  "requestId": "updater-018f2f4f",
-  "state": "PENDING"
+  "code": 0,
+  "task": {
+    "taskId": "updater-018f2f4f",
+    "module": "updater",
+    "status": "queued"
+  }
 }
 ```
 
@@ -268,7 +331,7 @@ The service validates the same command rules as the CLI. For `local-stats-calcul
 `statisticsPayload` or `filePath` is required. `statisticsPayload` and `filePath` cannot both be set.
 The task result includes the updater summary currently printed by the CLI.
 
-#### GET /api/optimizer/v1/updater/requests/{requestId}
+#### GET /api/optimizer/v1/updater/tasks/{taskId}
 
 Returns one updater task.
 
@@ -276,18 +339,24 @@ Returns one updater task.
 
 ```json
 {
-  "requestId": "updater-018f2f4f",
-  "module": "UPDATER",
-  "state": "SUCCEEDED",
-  "createdAt": "2026-06-30T10:00:00Z",
-  "startedAt": "2026-06-30T10:00:01Z",
-  "endedAt": "2026-06-30T10:00:03Z",
-  "result": {
-    "updateType": "STATISTICS",
-    "summary": {
-      "updatedTables": 1,
-      "updatedPartitions": 0,
-      "updatedJobs": 0
+  "code": 0,
+  "task": {
+    "taskId": "updater-018f2f4f",
+    "module": "updater",
+    "status": "succeeded",
+    "startedAt": "2026-06-30T10:00:01Z",
+    "finishedAt": "2026-06-30T10:00:03Z",
+    "result": {
+      "updateType": "STATISTICS",
+      "summary": {
+        "updatedTables": 1,
+        "updatedPartitions": 0,
+        "updatedJobs": 0
+      }
+    },
+    "audit": {
+      "createTime": "2026-06-30T10:00:00Z",
+      "creator": "anonymous"
     }
   }
 }
@@ -295,75 +364,89 @@ Returns one updater task.
 
 **Behavior:**
 
-Returns `404 Not Found` if the request ID does not exist in the task store.
+Returns `404 Not Found` with a `NoSuchTaskException` `ErrorModel` if the task ID does not exist in the
+task store.
 
-#### GET /api/optimizer/v1/updater/requests
+#### GET /api/optimizer/v1/updater/tasks
 
 Lists updater tasks.
 
 **Request query parameters:**
 
-| Field | Type | Required | Description |
-| --- | --- | --- | --- |
-| `state` | string | no | Filter by task state. |
-| `fromTime` | string | no | Include tasks created at or after this ISO-8601 time. |
-| `toTime` | string | no | Include tasks created before or at this ISO-8601 time. |
-| `limit` | integer | no | Maximum records to return. |
-| `pageToken` | string | no | Pagination token for later persistent stores. |
+| Field       | Type    | Required | Description                                            |
+| ----------- | ------- | -------- | ------------------------------------------------------ |
+| `status`    | string  | no       | Filter by task status.                                 |
+| `fromTime`  | string  | no       | Include tasks created at or after this ISO-8601 time.  |
+| `toTime`    | string  | no       | Include tasks created before or at this ISO-8601 time. |
+| `limit`     | integer | no       | Maximum records to return.                             |
+| `pageToken` | string  | no       | Pagination token for later persistent stores.          |
 
 **Response:** `200 OK`
 
 ```json
 {
-  "requests": [
+  "code": 0,
+  "tasks": [
     {
-      "requestId": "updater-018f2f4f",
-      "module": "UPDATER",
-      "state": "SUCCEEDED",
-      "createdAt": "2026-06-30T10:00:00Z"
+      "taskId": "updater-018f2f4f",
+      "module": "updater",
+      "status": "succeeded",
+      "audit": {
+        "createTime": "2026-06-30T10:00:00Z",
+        "creator": "anonymous"
+      }
     }
   ],
   "nextPageToken": ""
 }
 ```
 
-#### POST /api/optimizer/v1/updater/requests/{requestId}/cancel
+#### POST /api/optimizer/v1/updater/tasks/{taskId}
 
-Requests best-effort cancellation for one updater task.
+Requests best-effort cancellation for one updater task, mirroring `POST /jobs/runs/{jobId}`.
 
 **Response:** `200 OK`
 
 ```json
 {
-  "requestId": "updater-018f2f4f",
-  "state": "CANCELED"
+  "code": 0,
+  "task": {
+    "taskId": "updater-018f2f4f",
+    "module": "updater",
+    "status": "cancelling"
+  }
 }
 ```
 
 **Behavior:**
 
-Queued tasks can be canceled before execution. Running tasks are interrupted only when the provider
-or worker observes cancellation. Completed tasks remain in their terminal state.
+A `queued` task moves directly to `canceled`. A `started` task moves to `cancelling` and reaches
+`canceled` only when the provider or worker observes cancellation. Completed tasks remain in their
+terminal status.
 
-#### POST /api/optimizer/v1/recommender/requests
+#### POST /api/optimizer/v1/recommender/tasks
 
-Creates an asynchronous recommender task.
+Submits an asynchronous recommender task.
 
 **Request:**
 
-| Field | Type | Required | Description |
-| --- | --- | --- | --- |
-| `strategyName` | string | yes | Policy name to evaluate, matching CLI `--strategy-name`. |
-| `identifiers` | array[string] | yes | Table identifiers. |
-| `dryRun` | boolean | no | Preview recommendations without submitting jobs. Default is `false`. |
-| `limit` | integer | no | Maximum number of recommendations or submissions to process. |
+| Field          | Type          | Required | Description                                                          |
+| -------------- | ------------- | -------- | -------------------------------------------------------------------- |
+| `strategyName` | string        | yes      | Policy name to evaluate, matching CLI `--strategy-name`.             |
+| `identifiers`  | array[string] | yes      | Table identifiers.                                                   |
+| `dryRun`       | boolean       | no       | Preview recommendations without submitting jobs. Default is `false`. |
+| `limit`        | integer       | no       | Maximum number of recommendations or submissions to process.         |
 
-**Response:** `202 Accepted`
+**Response:** `200 OK`
 
 ```json
 {
-  "requestId": "recommender-018f2f50",
-  "state": "PENDING"
+  "code": 0,
+  "task": {
+    "taskId": "recommender-018f2f50",
+    "module": "recommender",
+    "status": "queued"
+  }
 }
 ```
 
@@ -373,7 +456,7 @@ The service validates identifiers, strategy name, and positive `limit` values. D
 recommendation details. Non-dry-run tasks submit jobs through the configured `JobSubmitter`, which may
 call Gravitino job APIs.
 
-#### GET /api/optimizer/v1/recommender/requests/{requestId}
+#### GET /api/optimizer/v1/recommender/tasks/{taskId}
 
 Returns one recommender task.
 
@@ -381,56 +464,68 @@ Returns one recommender task.
 
 ```json
 {
-  "requestId": "recommender-018f2f50",
-  "module": "RECOMMENDER",
-  "state": "SUCCEEDED",
-  "result": {
-    "dryRun": true,
-    "recommendations": [
-      {
-        "strategyName": "iceberg_compaction_default",
-        "identifier": "rest_catalog.db.t1",
-        "score": 100,
-        "jobTemplate": "builtin-iceberg-rewrite-data-files",
-        "jobOptions": {
-          "catalog_name": "rest_catalog",
-          "table_identifier": "db.t1"
-        },
-        "jobId": ""
-      }
-    ]
+  "code": 0,
+  "task": {
+    "taskId": "recommender-018f2f50",
+    "module": "recommender",
+    "status": "succeeded",
+    "result": {
+      "dryRun": true,
+      "recommendations": [
+        {
+          "strategyName": "iceberg_compaction_default",
+          "identifier": "rest_catalog.db.t1",
+          "score": 100,
+          "jobTemplate": "builtin-iceberg-rewrite-data-files",
+          "jobOptions": {
+            "catalog_name": "rest_catalog",
+            "table_identifier": "db.t1"
+          },
+          "jobId": ""
+        }
+      ]
+    },
+    "audit": {
+      "createTime": "2026-06-30T10:10:00Z",
+      "creator": "anonymous"
+    }
   }
 }
 ```
 
 **Behavior:**
 
-Returns submitted job IDs when the configured submitter creates Gravitino jobs.
+The `jobId` field carries the submitted Gravitino job ID when the configured submitter creates a job,
+so the optimizer task result links directly to the job run tracked by the job framework.
 
-#### GET /api/optimizer/v1/recommender/requests
+#### GET /api/optimizer/v1/recommender/tasks
 
 Lists recommender tasks.
 
 **Request query parameters:**
 
-| Field | Type | Required | Description |
-| --- | --- | --- | --- |
-| `state` | string | no | Filter by task state. |
-| `fromTime` | string | no | Include tasks created at or after this ISO-8601 time. |
-| `toTime` | string | no | Include tasks created before or at this ISO-8601 time. |
-| `limit` | integer | no | Maximum records to return. |
-| `pageToken` | string | no | Pagination token for later persistent stores. |
+| Field       | Type    | Required | Description                                            |
+| ----------- | ------- | -------- | ------------------------------------------------------ |
+| `status`    | string  | no       | Filter by task status.                                 |
+| `fromTime`  | string  | no       | Include tasks created at or after this ISO-8601 time.  |
+| `toTime`    | string  | no       | Include tasks created before or at this ISO-8601 time. |
+| `limit`     | integer | no       | Maximum records to return.                             |
+| `pageToken` | string  | no       | Pagination token for later persistent stores.          |
 
 **Response:** `200 OK`
 
 ```json
 {
-  "requests": [
+  "code": 0,
+  "tasks": [
     {
-      "requestId": "recommender-018f2f50",
-      "module": "RECOMMENDER",
-      "state": "SUCCEEDED",
-      "createdAt": "2026-06-30T10:10:00Z"
+      "taskId": "recommender-018f2f50",
+      "module": "recommender",
+      "status": "succeeded",
+      "audit": {
+        "createTime": "2026-06-30T10:10:00Z",
+        "creator": "anonymous"
+      }
     }
   ],
   "nextPageToken": ""
@@ -442,7 +537,7 @@ Lists recommender tasks.
 The service returns recommender task summaries sorted by creation time. The MVP may only return tasks
 that are still retained by the in-memory task store.
 
-#### POST /api/optimizer/v1/recommender/requests/{requestId}/cancel
+#### POST /api/optimizer/v1/recommender/tasks/{taskId}
 
 Requests best-effort cancellation for one recommender task.
 
@@ -450,36 +545,44 @@ Requests best-effort cancellation for one recommender task.
 
 ```json
 {
-  "requestId": "recommender-018f2f50",
-  "state": "CANCELED"
+  "code": 0,
+  "task": {
+    "taskId": "recommender-018f2f50",
+    "module": "recommender",
+    "status": "cancelling"
+  }
 }
 ```
 
 **Behavior:**
 
-Queued tasks can be canceled before execution. Running recommendation tasks are canceled only when
-the worker or provider observes cancellation. Jobs already submitted through Gravitino are not
+A `queued` task moves directly to `canceled`; a `started` task moves through `cancelling` when the
+worker or provider observes cancellation. Jobs already submitted through Gravitino are not
 automatically canceled by canceling the optimizer task.
 
-#### POST /api/optimizer/v1/monitor/requests
+#### POST /api/optimizer/v1/monitor/tasks
 
-Creates an asynchronous monitor task.
+Submits an asynchronous monitor task.
 
 **Request:**
 
-| Field | Type | Required | Description |
-| --- | --- | --- | --- |
-| `identifiers` | array[string] | yes | Table or job identifiers to evaluate. |
-| `actionTime` | integer | yes | Action timestamp in epoch seconds. |
-| `rangeSeconds` | integer | no | Evaluation window. Default is the current CLI default, 86400 seconds. |
-| `partitionPath` | array[object] | no | Partition path. Allowed only when exactly one table identifier is provided. |
+| Field           | Type          | Required | Description                                                                 |
+| --------------- | ------------- | -------- | --------------------------------------------------------------------------- |
+| `identifiers`   | array[string] | yes      | Table or job identifiers to evaluate.                                       |
+| `actionTime`    | integer       | yes      | Action timestamp in epoch seconds.                                          |
+| `rangeSeconds`  | integer       | no       | Evaluation window. Default is the current CLI default, 86400 seconds.       |
+| `partitionPath` | array[object] | no       | Partition path. Allowed only when exactly one table identifier is provided. |
 
-**Response:** `202 Accepted`
+**Response:** `200 OK`
 
 ```json
 {
-  "requestId": "monitor-018f2f51",
-  "state": "PENDING"
+  "code": 0,
+  "task": {
+    "taskId": "monitor-018f2f51",
+    "module": "monitor",
+    "status": "queued"
+  }
 }
 ```
 
@@ -489,7 +592,7 @@ The service evaluates monitor rules with the configured metrics provider, evalua
 relation provider, and callbacks. The task result includes the evaluation records currently printed by
 the CLI.
 
-#### GET /api/optimizer/v1/monitor/requests/{requestId}
+#### GET /api/optimizer/v1/monitor/tasks/{taskId}
 
 Returns one monitor task.
 
@@ -497,46 +600,57 @@ Returns one monitor task.
 
 ```json
 {
-  "requestId": "monitor-018f2f51",
-  "module": "MONITOR",
-  "state": "SUCCEEDED",
-  "result": {
-    "evaluations": [
-      {
-        "identifier": "rest_catalog.db.t1",
-        "scope": "table",
-        "evaluator": "gravitino-metrics-evaluator",
-        "passed": true
-      }
-    ]
+  "code": 0,
+  "task": {
+    "taskId": "monitor-018f2f51",
+    "module": "monitor",
+    "status": "succeeded",
+    "result": {
+      "evaluations": [
+        {
+          "identifier": "rest_catalog.db.t1",
+          "scope": "table",
+          "evaluator": "gravitino-metrics-evaluator",
+          "passed": true
+        }
+      ]
+    },
+    "audit": {
+      "createTime": "2026-06-30T10:20:00Z",
+      "creator": "anonymous"
+    }
   }
 }
 ```
 
-#### GET /api/optimizer/v1/monitor/requests
+#### GET /api/optimizer/v1/monitor/tasks
 
 Lists monitor tasks.
 
 **Request query parameters:**
 
-| Field | Type | Required | Description |
-| --- | --- | --- | --- |
-| `state` | string | no | Filter by task state. |
-| `fromTime` | string | no | Include tasks created at or after this ISO-8601 time. |
-| `toTime` | string | no | Include tasks created before or at this ISO-8601 time. |
-| `limit` | integer | no | Maximum records to return. |
-| `pageToken` | string | no | Pagination token for later persistent stores. |
+| Field       | Type    | Required | Description                                            |
+| ----------- | ------- | -------- | ------------------------------------------------------ |
+| `status`    | string  | no       | Filter by task status.                                 |
+| `fromTime`  | string  | no       | Include tasks created at or after this ISO-8601 time.  |
+| `toTime`    | string  | no       | Include tasks created before or at this ISO-8601 time. |
+| `limit`     | integer | no       | Maximum records to return.                             |
+| `pageToken` | string  | no       | Pagination token for later persistent stores.          |
 
 **Response:** `200 OK`
 
 ```json
 {
-  "requests": [
+  "code": 0,
+  "tasks": [
     {
-      "requestId": "monitor-018f2f51",
-      "module": "MONITOR",
-      "state": "SUCCEEDED",
-      "createdAt": "2026-06-30T10:20:00Z"
+      "taskId": "monitor-018f2f51",
+      "module": "monitor",
+      "status": "succeeded",
+      "audit": {
+        "createTime": "2026-06-30T10:20:00Z",
+        "creator": "anonymous"
+      }
     }
   ],
   "nextPageToken": ""
@@ -548,7 +662,7 @@ Lists monitor tasks.
 The service returns monitor task summaries sorted by creation time. The MVP may only return tasks
 that are still retained by the in-memory task store.
 
-#### POST /api/optimizer/v1/monitor/requests/{requestId}/cancel
+#### POST /api/optimizer/v1/monitor/tasks/{taskId}
 
 Requests best-effort cancellation for one monitor task.
 
@@ -556,32 +670,39 @@ Requests best-effort cancellation for one monitor task.
 
 ```json
 {
-  "requestId": "monitor-018f2f51",
-  "state": "CANCELED"
+  "code": 0,
+  "task": {
+    "taskId": "monitor-018f2f51",
+    "module": "monitor",
+    "status": "cancelling"
+  }
 }
 ```
 
 **Behavior:**
 
-Queued tasks can be canceled before execution. Running monitor tasks are canceled only when the
+A `queued` task moves directly to `canceled`; a `started` task moves through `cancelling` when the
 worker or provider observes cancellation. Monitor callbacks that have already been invoked are not
 rolled back.
 
 #### GET /api/optimizer/v1/metrics/tables
 
-Queries table or partition metrics.
+Queries table or partition metrics. Unlike the module tasks, metrics queries are synchronous because
+they read existing metrics and are expected to be short, so they return the result directly instead of
+a task record.
 
 **Request query parameters:**
 
-| Field | Type | Required | Description |
-| --- | --- | --- | --- |
-| `identifiers` | string | yes | Comma-separated table identifiers. |
-| `partitionPath` | string | no | Partition path JSON array. Requires exactly one identifier. |
+| Field           | Type   | Required | Description                                                 |
+| --------------- | ------ | -------- | ----------------------------------------------------------- |
+| `identifiers`   | string | yes      | Comma-separated table identifiers.                          |
+| `partitionPath` | string | no       | Partition path JSON array. Requires exactly one identifier. |
 
 **Response:** `200 OK`
 
 ```json
 {
+  "code": 0,
   "metrics": [
     {
       "identifier": "rest_catalog.db.t1",
@@ -600,8 +721,8 @@ Queries table or partition metrics.
 
 **Behavior:**
 
-This is a synchronous query endpoint because it reads existing metrics and is expected to be short.
-Large result pagination can be added with the same `limit` and `pageToken` pattern.
+Large result pagination can be added with the same `limit` and `pageToken` pattern used by the task
+list APIs.
 
 #### GET /api/optimizer/v1/metrics/jobs
 
@@ -609,14 +730,15 @@ Queries job metrics.
 
 **Request query parameters:**
 
-| Field | Type | Required | Description |
-| --- | --- | --- | --- |
-| `identifiers` | string | yes | Comma-separated job identifiers. |
+| Field         | Type   | Required | Description                      |
+| ------------- | ------ | -------- | -------------------------------- |
+| `identifiers` | string | yes      | Comma-separated job identifiers. |
 
 **Response:** `200 OK`
 
 ```json
 {
+  "code": 0,
   "metrics": [
     {
       "identifier": "job_1",
@@ -635,7 +757,8 @@ Queries job metrics.
 
 #### GET /api/optimizer/v1/health
 
-Returns service health.
+Returns service health. This is an operational endpoint and is the one response that is not wrapped in
+the `code` envelope, so external liveness probes can consume it directly.
 
 **Response:** `200 OK`
 
@@ -656,37 +779,37 @@ Returns service health.
 The service reads the same `conf/gravitino-optimizer.conf` file as the CLI, plus service-side keys
 that control the HTTP endpoint and the task runtime described in the Reliability section:
 
-| Key | Default | Description |
-| --- | --- | --- |
-| `gravitino.optimizer.server.host` | `0.0.0.0` | Bind address for the Optimizer Service HTTP server. |
-| `gravitino.optimizer.server.port` | `8091` | Listen port for the Optimizer Service HTTP server. |
-| `gravitino.optimizer.server.workerPoolSize` | `4` | Worker threads per module for asynchronous task execution. |
-| `gravitino.optimizer.server.queueCapacity` | `100` | Maximum queued tasks per module before new submissions are rejected. |
-| `gravitino.optimizer.server.taskTimeoutMs` | `600000` | Per-task execution timeout after which the task is marked `FAILED`. |
-| `gravitino.optimizer.server.taskRetentionMs` | `3600000` | How long terminal task records are retained by the in-memory store. |
+| Key                                          | Default   | Description                                                          |
+| -------------------------------------------- | --------- | -------------------------------------------------------------------- |
+| `gravitino.optimizer.server.host`            | `0.0.0.0` | Bind address for the Optimizer Service HTTP server.                  |
+| `gravitino.optimizer.server.port`            | `8091`    | Listen port for the Optimizer Service HTTP server.                   |
+| `gravitino.optimizer.server.workerPoolSize`  | `4`       | Worker threads per module for asynchronous task execution.           |
+| `gravitino.optimizer.server.queueCapacity`   | `100`     | Maximum queued tasks per module before new submissions are rejected. |
+| `gravitino.optimizer.server.taskTimeoutMs`   | `600000`  | Per-task execution timeout after which the task is marked `failed`.  |
+| `gravitino.optimizer.server.taskRetentionMs` | `3600000` | How long terminal task records are retained by the in-memory store.  |
 
 ### CLI Service Mode
 
 Add optimizer CLI service configuration keys:
 
-| Key | Default | Description |
-| --- | --- | --- |
-| `gravitino.optimizer.service.enabled` | `false` | Enables CLI remote execution for supported commands. |
-| `gravitino.optimizer.service.url` | none | Base URL of the Optimizer Service, for example `http://localhost:8091`. |
-| `gravitino.optimizer.service.requestTimeoutMs` | `30000` | HTTP request timeout for CLI service calls. |
-| `gravitino.optimizer.service.pollIntervalMs` | `1000` | Poll interval when the CLI waits for async task completion. |
-| `gravitino.optimizer.service.waitForCompletion` | `true` | Whether CLI commands wait and print final results by default. |
+| Key                                             | Default | Description                                                             |
+| ----------------------------------------------- | ------- | ----------------------------------------------------------------------- |
+| `gravitino.optimizer.service.enabled`           | `false` | Enables CLI remote execution for supported commands.                    |
+| `gravitino.optimizer.service.url`               | none    | Base URL of the Optimizer Service, for example `http://localhost:8091`. |
+| `gravitino.optimizer.service.requestTimeoutMs`  | `30000` | HTTP request timeout for CLI service calls.                             |
+| `gravitino.optimizer.service.pollIntervalMs`    | `1000`  | Poll interval when the CLI waits for async task completion.             |
+| `gravitino.optimizer.service.waitForCompletion` | `true`  | Whether CLI commands wait and print final results by default.           |
 
 The existing CLI commands remain the primary user interface:
 
-| CLI command | Service mode behavior |
-| --- | --- |
-| `update-statistics` | Calls `POST /api/optimizer/v1/updater/requests` with `updateType=STATISTICS`. |
-| `append-metrics` | Calls `POST /api/optimizer/v1/updater/requests` with `updateType=METRICS`. |
-| `submit-strategy-jobs` | Calls `POST /api/optimizer/v1/recommender/requests`. |
-| `monitor-metrics` | Calls `POST /api/optimizer/v1/monitor/requests`. |
-| `list-table-metrics` | Calls `GET /api/optimizer/v1/metrics/tables`. |
-| `list-job-metrics` | Calls `GET /api/optimizer/v1/metrics/jobs`. |
+| CLI command               | Service mode behavior                                                                                                   |
+| ------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `update-statistics`       | Calls `POST /api/optimizer/v1/updater/tasks` with `updateType=STATISTICS`.                                              |
+| `append-metrics`          | Calls `POST /api/optimizer/v1/updater/tasks` with `updateType=METRICS`.                                                 |
+| `submit-strategy-jobs`    | Calls `POST /api/optimizer/v1/recommender/tasks`.                                                                       |
+| `monitor-metrics`         | Calls `POST /api/optimizer/v1/monitor/tasks`.                                                                           |
+| `list-table-metrics`      | Calls `GET /api/optimizer/v1/metrics/tables`.                                                                           |
+| `list-job-metrics`        | Calls `GET /api/optimizer/v1/metrics/jobs`.                                                                             |
 | `submit-update-stats-job` | Initially remains local CLI submission to the Gravitino job framework. A later phase may add an optimizer task wrapper. |
 
 If service mode is disabled, commands use the current local execution path. If service mode is
@@ -712,11 +835,10 @@ The service mode user flow is:
      --limit 10
    ```
 
-4. The CLI validates arguments, detects service mode, submits a REST request, and prints the request
-   ID.
+4. The CLI validates arguments, detects service mode, submits a REST request, and prints the task ID.
 5. If `waitForCompletion` is enabled, the CLI polls the task status endpoint and prints the final
    result using output compatible with the existing command.
-6. Automation can call the REST API directly, store the request ID, and query the result later.
+6. Automation can call the REST API directly, store the task ID, and query the result later.
 
 ### Implementation Process
 
@@ -729,10 +851,10 @@ CLI or REST client
 REST resource validates request
       |
       v
-TaskRuntime creates task record in PENDING state
+TaskRuntime creates task record in queued status
       |
       v
-Worker picks task and marks RUNNING
+Worker picks task and marks it started
       |
       v
 Module invokes existing optimizer class
@@ -740,7 +862,7 @@ Module invokes existing optimizer class
       +--> Updater / Recommender / Monitor
       |
       v
-TaskRuntime stores SUCCEEDED, FAILED, or CANCELED result
+TaskRuntime stores succeeded, failed, or canceled result
       |
       v
 Client queries task result
@@ -757,7 +879,7 @@ This design is backward compatible for existing CLI users:
 1. Service mode is disabled by default.
 2. Existing command names and options remain valid.
 3. Existing local output should remain the default when service mode is disabled.
-4. Service mode may print the request ID in addition to existing summary lines. This is additive.
+4. Service mode may print the task ID in addition to existing summary lines. This is additive.
 5. `submit-update-stats-job` keeps the existing local submission path until a service wrapper is
    implemented.
 
@@ -780,15 +902,15 @@ Authentication and authorization can be phased:
 
 The service should provide:
 
-| Area | Requirement |
-| --- | --- |
-| Queue control | Per-module queue size and worker count. |
-| Timeout | Per-task execution timeout and HTTP client timeout. |
-| Cancellation | Best-effort cancellation for queued and cooperative running tasks. |
-| Shutdown | Graceful shutdown that stops accepting requests and drains or cancels queued work. |
-| Logs | Request lifecycle logs with request ID, module, state transition, and duration. |
-| Metrics | Task counts by module/state, latency, queue depth, worker utilization, and failure counts. |
-| Health | Health endpoint with module initialization status. |
+| Area          | Requirement                                                                                 |
+| ------------- | ------------------------------------------------------------------------------------------- |
+| Queue control | Per-module queue size and worker count.                                                     |
+| Timeout       | Per-task execution timeout and HTTP client timeout.                                         |
+| Cancellation  | Best-effort cancellation for queued and cooperative running tasks.                          |
+| Shutdown      | Graceful shutdown that stops accepting requests and drains or cancels queued work.          |
+| Logs          | Task lifecycle logs with task ID, module, status transition, and duration.                  |
+| Metrics       | Task counts by module/status, latency, queue depth, worker utilization, and failure counts. |
+| Health        | Health endpoint with module initialization status.                                          |
 
 ### Rollout Plan
 

--- a/design-docs/optimizer-service-design.md
+++ b/design-docs/optimizer-service-design.md
@@ -41,16 +41,14 @@ The current optimizer execution model is local-process oriented:
 
 This model is useful for local validation and batch scripts, but it has operational limitations:
 
-1. Optimizer work is tied to the CLI process lifecycle. If the process exits, operators lose a
-   consistent service-side task record for updater, recommender, and monitor work.
-2. The CLI is both user interface and execution runtime. This makes it hard to centralize retries,
-   concurrency control, audit logging, and service-level metrics.
-3. Long-running work has no shared asynchronous task model. Users cannot submit a request, disconnect,
-   and later query status through a stable API.
-4. Horizontal scaling and resource isolation are difficult because each invocation creates its own
-   runtime and provider instances.
-5. Automation systems must shell out to the CLI instead of calling a service API with structured
+1. The CLI is both user interface and execution runtime. This makes it hard to centralize service
+   configuration, request validation, audit logging, and service-level metrics.
+2. Automation systems must shell out to the CLI instead of calling a service API with structured
    request and response payloads.
+3. Every CLI invocation creates its own runtime and provider instances.
+4. The current CLI has no optimizer-owned background execution model. Commands run synchronously in
+   the calling process. When Spark maintenance work is needed, the CLI submits a Gravitino job and
+   returns the Gravitino `jobId`; job status remains owned by the Gravitino job framework.
 
 The current architecture is:
 
@@ -67,27 +65,27 @@ gravitino-optimizer.sh
              +--> Gravitino server REST APIs and optional metrics storage
 ```
 
-This design introduces a long-running Optimizer Service while preserving the existing CLI as a
-client and local execution tool.
+This design introduces a long-running Optimizer Service and a separate service client CLI while
+preserving the existing CLI as the local execution tool.
 
 ---
 
 ## Goals
 
-1. **Service Mode for Optimizer Workloads**: Users can run a long-running optimizer service and
-   submit updater, recommender, monitor, and metrics-query requests through REST APIs.
-2. **Asynchronous Task Execution**: Mutating or long-running optimizer commands return a task ID
-   immediately and expose status, result, and error details through query APIs.
-3. **CLI Compatibility**: Existing optimizer CLI commands and options continue to work. A
-   configuration switch controls whether supported commands execute locally or call the service.
-4. **Shared Task Runtime**: Updater, recommender, and monitor modules use one task status model,
-   task ID format, cancellation contract, and list/query behavior.
-5. **Operational Controls**: The service exposes health checks, bounded queues, configurable worker
-   pools, request validation, structured lifecycle logs, and metrics for task execution.
-6. **Incremental Migration**: The design can be implemented in phases without requiring all optimizer
-   commands to move to service mode in one release.
-7. **Job Framework Compatibility**: `submit-update-stats-job` continues to use the existing Gravitino
-   job framework for Spark job submission. The Optimizer Service does not replace the job manager.
+1. **Service Mode for Optimizer Workloads**: Users can run a long-running optimizer service and call
+   optimizer operations through REST APIs.
+2. **CLI Compatibility**: Existing optimizer CLI commands and options continue to work for local
+   execution.
+3. **Separate Service Client CLI**: A new client CLI calls the Optimizer Service with command options
+   aligned to the existing local CLI.
+4. **Synchronous API Semantics**: The MVP service follows current CLI behavior. Each request executes
+   in the HTTP request path and returns the same kind of result the CLI prints today.
+5. **Structured Responses**: REST responses return typed summaries, recommendations, metrics, monitor
+   evaluations, submitted Gravitino job IDs, or sanitized errors.
+6. **Job Framework Compatibility**: Spark maintenance work continues to use the existing Gravitino job
+   framework. The Optimizer Service returns submitted `jobId` values but does not track job status.
+7. **Incremental Migration**: The design can be implemented in phases without requiring all optimizer
+   commands to be added to the service client in one release.
 
 ---
 
@@ -101,12 +99,14 @@ client and local execution tool.
    recommendations are ranked. It only changes the execution boundary.
 3. **Statistics and Metrics Model Changes**: This design does not change Gravitino statistics APIs,
    metrics storage schemas, metric names, or JSON Lines input semantics.
-4. **Gravitino Job Manager Replacement**: This design does not create a second job management system.
+4. **Optimizer Task Model in MVP**: This design does not introduce optimizer task IDs, task status,
+   task cancellation, task listing, task retention, or persistent optimizer task storage.
+5. **Gravitino Job Manager Replacement**: This design does not create a second job management system.
    Built-in maintenance jobs continue to be submitted to the Gravitino job framework.
-5. **Immediate Removal of Local CLI Mode**: Local CLI execution remains supported for compatibility,
+6. **Immediate Removal of Local CLI Mode**: Local CLI execution remains supported for compatibility,
    local debugging, and environments that do not deploy the service.
-6. **Full Multi-Node Coordination in MVP**: The first implementation may use an in-memory task store.
-   Durable task storage and multi-node ownership are included as later hardening work.
+7. **Request-Scoped Tenant Routing in MVP**: The MVP does not accept tenant or metalake information
+   in request paths. Each Optimizer Service instance uses its configured Gravitino context.
 
 ---
 
@@ -114,54 +114,55 @@ client and local execution tool.
 
 ### Option A: Keep CLI-only execution
 
-Continue running all optimizer work inside the CLI process, with no server component.
+Continue running all optimizer work inside the CLI process, with no service process.
 
 **Pros:** No new server process. Minimal implementation work. Preserves current behavior.
 
-**Cons:** Does not solve async status tracking, centralized observability, retries, queueing, or
-structured automation APIs. Each invocation remains an isolated runtime.
+**Cons:** Does not provide structured REST APIs, centralized service configuration, shared
+observability, or a stable endpoint for automation.
 
-**Decision:** Rejected because it does not address the operational problems.
+**Decision:** Rejected because it does not address the automation and operational problems.
 
 ### Option B: Embed optimizer execution in the Gravitino server
 
-Run the optimizer modules inside the existing Gravitino metadata server process.
+Run the optimizer execution logic inside the existing Gravitino metadata server process.
 
 **Pros:** Reuses the existing server process, REST stack, auth, and deployment path. Avoids another
 daemon.
 
-**Cons:** Couples maintenance workloads to the metadata server. Heavy optimizer tasks, provider
-dependencies, and worker pools can affect metadata API latency and server stability. The optimizer
-package already has a separate distribution and configuration model.
+**Cons:** Couples maintenance workloads to the metadata server. Optimizer providers, metrics storage
+drivers, and job-submission dependencies can affect metadata API latency and server stability. The
+optimizer package already has a separate distribution and configuration model.
 
 **Decision:** Rejected for MVP because optimizer workloads should be isolated from the metadata
 control plane.
 
 ### Option C: Use only the existing Gravitino job framework for every optimizer action
 
-Model every optimizer command (updater, recommender, monitor, metrics query) as a Gravitino job.
+Model every optimizer command as a Gravitino job.
 
 **Pros:** Provides persisted job status and existing server APIs for job execution.
 
-**Cons:** Updater, recommender, monitor, and metrics-query commands are not all jobs. Some requests
-need provider execution and immediate result payloads, while Spark job submission already has a
-separate job manager. Forcing all optimizer actions into jobs would blur responsibilities.
+**Cons:** Most optimizer commands are not jobs. `update-statistics`, `append-metrics`,
+`monitor-metrics`, and metrics queries need immediate result payloads. Forcing all optimizer actions
+into jobs would blur responsibilities.
 
 **Decision:** Rejected because the job framework should remain the execution backend for submitted
 jobs, not the universal optimizer control API.
 
-### Option D: Add an independent Optimizer Service (Chosen)
+### Option D: Add an independent synchronous Optimizer Service (Chosen)
 
 Introduce a standalone Optimizer Service in the optimizer distribution, with the CLI as one client.
+The service exposes synchronous REST endpoints that map to existing CLI commands.
 
-**Pros:** Keeps optimizer workloads isolated, preserves the optimizer distribution boundary, and
-allows independent scaling and resource limits. The CLI can become a client without losing local mode.
+**Pros:** Keeps optimizer workloads isolated, preserves the optimizer distribution boundary, supports
+structured automation, and avoids adding a second task or job status model.
 
-**Cons:** Adds a daemon, service configuration, REST resources, and task runtime that must be operated
-and tested.
+**Cons:** Adds a daemon, service configuration, REST resources, and request timeout/concurrency
+handling.
 
-**Decision:** **Chosen** because it solves the target operational issues while respecting existing
-Gravitino boundaries.
+**Decision:** **Chosen** because it solves the target automation problem while matching current CLI
+semantics and respecting existing Gravitino boundaries.
 
 ---
 
@@ -174,30 +175,25 @@ Introduce an independent Optimizer Service in the optimizer distribution:
 ```text
 User or automation
       |
-      +-------------------------------+
-      |                               |
-      v                               v
-gravitino-optimizer.sh          REST client
-      |                               |
-      +---------------+---------------+
-                      |
-                      v
-             Optimizer Service
-                      |
-        +-------------+-------------+----------------+----------------+
-        |                           |                |                |
-        v                           v                v                v
-  UpdaterModule              RecommenderModule  MonitorModule   MetricsQueryModule
-        |                           |                |                |
-        +-------------+-------------+----------------+----------------+
-                      |
-                      v
-                 TaskRuntime
-                      |
-        +-------------+-------------+
-        |                           |
-        v                           v
- Existing provider SPIs      Gravitino server and metrics storage
+      +--------------------------+-----------------------------+
+      |                          |                             |
+      v                          v                             v
+gravitino-optimizer.sh  gravitino-optimizer-client.sh     REST client
+      |                          |                             |
+      v                          +--------------+--------------+
+ Existing optimizer classes                     |
+                                                v
+                                      Optimizer Service
+                                                |
+        +-------------------+-------------------+-------------------+-------------------+-------------------+
+        |                   |                   |                   |                   |                   |
+        v                   v                   v                   v                   v
+ UpdateStatisticsHandler  StrategyJobsHandler  MonitorHandler  MetricsQueryHandler  SubmitUpdateJobHandler
+        |                   |                   |                   |                   |
+        +-------------------+-------------------+-------------------+-------------------+
+                                                |
+                                                v
+             Existing optimizer classes, provider SPIs, Gravitino jobs, and metrics storage
 ```
 
 The service runs as a separate process from the Gravitino server. It uses optimizer configuration to
@@ -210,117 +206,60 @@ load existing providers and exposes REST APIs under one optimizer-specific prefi
 The prefix keeps optimizer APIs separate from Gravitino metadata APIs and leaves room for future
 service-level authentication, routing, and documentation.
 
-### Components
+The MVP service uses its configured Gravitino context for every request. The REST path does not
+expose tenant or metalake information.
 
-| Component                | Responsibility                                                                                                                                  |
-| ------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------- |
-| `OptimizerServiceServer` | Starts the HTTP server, registers REST resources, initializes modules, exposes lifecycle hooks, and owns graceful shutdown.                     |
-| `TaskRuntime`            | Creates task IDs, stores task records, runs asynchronous tasks, handles status transitions, lists tasks, and performs best-effort cancellation. |
-| `UpdaterModule`          | Converts updater REST requests into calls to `Updater` for statistics and metrics updates.                                                      |
-| `RecommenderModule`      | Converts recommender REST requests into calls to `Recommender` for dry-run recommendation or job submission.                                    |
-| `MonitorModule`          | Converts monitor REST requests into calls to `Monitor` for rule evaluation and callback execution.                                              |
-| `MetricsQueryModule`     | Serves structured table, partition, and job metrics query APIs using existing metrics storage/provider logic.                                   |
-| `OptimizerServiceClient` | Client used by the CLI when service mode is enabled.                                                                                            |
+### Internal Structure
 
-### Task Status Model
-
-The task runtime uses one status model across updater, recommender, and monitor tasks. The status
-vocabulary follows the Gravitino job model (`queued`, `started`, `succeeded`, `failed`, `cancelling`,
-`canceled`) so that optimizer tasks read the same way as job runs:
-
-| Status       | Meaning                                                                 |
-| ------------ | ----------------------------------------------------------------------- |
-| `queued`     | The service accepted the request and queued it for execution.           |
-| `started`    | A worker is executing the request.                                      |
-| `succeeded`  | Execution finished and the task record contains a result payload.       |
-| `failed`     | Execution failed and the task record contains a sanitized error object. |
-| `cancelling` | Cancellation was requested for a started task and is being applied.     |
-| `canceled`   | The request was canceled before or during execution.                    |
-
-`succeeded`, `failed`, and `canceled` are terminal statuses. The allowed transitions are:
-
-```text
-queued --> started --> succeeded
-  |          |
-  |          +--------> failed
-  |          |
-  |          +--------> cancelling --> canceled
-  |
-  +-------------------------------> canceled
-```
-
-A task in `queued` moves directly to `canceled` if it is canceled before a worker picks it up. A
-`started` task first enters `cancelling` and reaches `canceled` only when the worker or provider
-observes cancellation.
-
-Each task record follows the job record shape (identifier, status, `audit`) plus optimizer-specific
-timing and payload fields:
-
-| Field         | Type   | Description                                                                 |
-| ------------- | ------ | --------------------------------------------------------------------------- |
-| `taskId`      | string | Unique optimizer task ID, for example `updater-018f2f4f`.                   |
-| `module`      | string | `updater`, `recommender`, or `monitor`.                                     |
-| `status`      | string | Current task status.                                                        |
-| `startedAt`   | string | ISO-8601 start time, if started.                                            |
-| `finishedAt`  | string | ISO-8601 completion time, if in a terminal status.                          |
-| `requestHash` | string | Hash of the normalized request payload for audit and troubleshooting.       |
-| `result`      | object | Module-specific result payload for successful tasks.                        |
-| `error`       | object | Sanitized error object for failed tasks.                                    |
-| `audit`       | object | Audit info (`createTime`, `creator`), matching the Gravitino `Audit` model. |
-
-For a `failed` task, the `error` object mirrors the Gravitino `ErrorModel` (`code`, `type`, `message`)
-so clients and automation branch on the same shape used by the metadata APIs:
-
-```json
-{
-  "code": 1001,
-  "type": "IllegalArgumentException",
-  "message": "statisticsPayload and filePath cannot both be set"
-}
-```
-
-`message` is always sanitized and never exposes secrets from config files, job options, or provider
-exceptions.
-
-The MVP may use an in-memory task store. The storage API should be pluggable so a later
-implementation can add a DB-backed store without changing REST semantics.
+| Part                        | Responsibility                                                                                                      |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `OptimizerServiceServer`    | Starts the HTTP server, registers REST resources, initializes handlers, exposes lifecycle hooks, and owns shutdown. |
+| `UpdateStatisticsHandler`   | Converts update-statistics and append-metrics requests into calls to `Updater`.                                     |
+| `StrategyJobsHandler`       | Converts submit-strategy-jobs requests into calls to `Recommender`.                                                |
+| `MonitorMetricsHandler`     | Converts monitor-metrics requests into calls to `Monitor`.                                                         |
+| `MetricsQueryHandler`       | Serves table, partition, and job metrics query APIs using existing metrics storage/provider logic.                  |
+| `SubmitUpdateJobHandler`    | Converts submit-update-stats-job requests into Gravitino `runJob` calls and returns submitted job IDs.             |
+| `OptimizerServiceClient`    | Client used by the service client CLI.                                                                            |
 
 ### REST API
 
-The API follows the same conventions as the Gravitino job run APIs (`/metalakes/{metalake}/jobs/runs`):
+The API follows the same conventions as other Gravitino REST APIs:
 
 - All endpoints exchange JSON using the `application/vnd.gravitino.v1+json` media type.
 - Every response body carries an integer `code` (`0` for success) wrapping the payload.
-- Each asynchronous module exposes the same four operations as job runs: submit (`POST .../tasks`),
-  get (`GET .../tasks/{taskId}`), list (`GET .../tasks`), and cancel (`POST .../tasks/{taskId}`).
-- Errors use the Gravitino `ErrorModel` (`code`, `type`, `message`, `stack`), so a missing task
-  returns a `NoSuchTaskException` and an invalid payload returns an `IllegalArgumentException`.
-- List APIs support pagination in the service model even if the MVP initially returns an in-memory
-  bounded list.
+- Endpoints are grouped by optimizer domain (`statistics`, `metrics`, `recommendations`, `monitors`,
+  and `jobs`) instead of exposing CLI command names directly in the path.
+- `metrics/jobs` means metrics scoped by Gravitino job identifier. `jobs/update-stats` is reserved
+  for submitting built-in Gravitino update-stats jobs.
+- Endpoints are synchronous. The service returns only after the underlying optimizer operation
+  finishes or fails.
+- Errors use the Gravitino `ErrorModel` (`code`, `type`, `message`, `stack`). The `message` must be
+  sanitized and must not expose secrets from config files, job options, or provider exceptions.
 
-#### POST /api/optimizer/v1/updater/tasks
+#### POST /api/optimizer/v1/statistics/update
 
-Submits an asynchronous updater task.
+Runs the same logic as CLI `update-statistics`.
 
 **Request:**
 
 | Field               | Type          | Required | Description                                                                           |
 | ------------------- | ------------- | -------- | ------------------------------------------------------------------------------------- |
-| `updateType`        | string        | yes      | `STATISTICS` for `update-statistics` or `METRICS` for `append-metrics`.               |
 | `calculatorName`    | string        | yes      | Statistics calculator name, for example `local-stats-calculator`.                     |
-| `identifiers`       | array[string] | no       | Table or job identifiers. Empty means the selected calculator/provider decides scope. |
+| `identifiers`       | array[string] | no       | Table identifiers. Empty means the selected calculator/provider decides scope.        |
 | `statisticsPayload` | string        | no       | Inline JSON Lines payload. Mutually exclusive with `filePath`.                        |
-| `filePath`          | string        | no       | Server-local JSON Lines input file path. Mutually exclusive with `statisticsPayload`. |
+| `filePath`          | string        | no       | Server-local JSON Lines path allowed only under configured prefixes. Mutually exclusive with `statisticsPayload`. |
 
 **Response:** `200 OK`
 
 ```json
 {
   "code": 0,
-  "task": {
-    "taskId": "updater-018f2f4f",
-    "module": "updater",
-    "status": "queued"
+  "summary": {
+    "updateType": "STATISTICS",
+    "totalRecords": 1,
+    "tableRecords": 1,
+    "partitionRecords": 0,
+    "jobRecords": 0
   }
 }
 ```
@@ -329,104 +268,40 @@ Submits an asynchronous updater task.
 
 The service validates the same command rules as the CLI. For `local-stats-calculator`, either
 `statisticsPayload` or `filePath` is required. `statisticsPayload` and `filePath` cannot both be set.
-The task result includes the updater summary currently printed by the CLI.
+The service client should translate client-local `--file-path` into `statisticsPayload`; REST
+`filePath` remains a server-side operator feature guarded by allowed path prefixes.
 
-#### GET /api/optimizer/v1/updater/tasks/{taskId}
+#### POST /api/optimizer/v1/metrics/append
 
-Returns one updater task.
+Runs the same logic as CLI `append-metrics`.
+
+**Request:**
+
+| Field               | Type          | Required | Description                                                                           |
+| ------------------- | ------------- | -------- | ------------------------------------------------------------------------------------- |
+| `calculatorName`    | string        | yes      | Statistics calculator name, for example `local-stats-calculator`.                     |
+| `identifiers`       | array[string] | no       | Table or job identifiers. Empty means the selected calculator/provider decides scope. |
+| `statisticsPayload` | string        | no       | Inline JSON Lines payload. Mutually exclusive with `filePath`.                        |
+| `filePath`          | string        | no       | Server-local JSON Lines path allowed only under configured prefixes. Mutually exclusive with `statisticsPayload`. |
 
 **Response:** `200 OK`
 
 ```json
 {
   "code": 0,
-  "task": {
-    "taskId": "updater-018f2f4f",
-    "module": "updater",
-    "status": "succeeded",
-    "startedAt": "2026-06-30T10:00:01Z",
-    "finishedAt": "2026-06-30T10:00:03Z",
-    "result": {
-      "updateType": "STATISTICS",
-      "summary": {
-        "updatedTables": 1,
-        "updatedPartitions": 0,
-        "updatedJobs": 0
-      }
-    },
-    "audit": {
-      "createTime": "2026-06-30T10:00:00Z",
-      "creator": "anonymous"
-    }
+  "summary": {
+    "updateType": "METRICS",
+    "totalRecords": 3,
+    "tableRecords": 1,
+    "partitionRecords": 1,
+    "jobRecords": 1
   }
 }
 ```
 
-**Behavior:**
+#### POST /api/optimizer/v1/recommendations/submit
 
-Returns `404 Not Found` with a `NoSuchTaskException` `ErrorModel` if the task ID does not exist in the
-task store.
-
-#### GET /api/optimizer/v1/updater/tasks
-
-Lists updater tasks.
-
-**Request query parameters:**
-
-| Field       | Type    | Required | Description                                            |
-| ----------- | ------- | -------- | ------------------------------------------------------ |
-| `status`    | string  | no       | Filter by task status.                                 |
-| `fromTime`  | string  | no       | Include tasks created at or after this ISO-8601 time.  |
-| `toTime`    | string  | no       | Include tasks created before or at this ISO-8601 time. |
-| `limit`     | integer | no       | Maximum records to return.                             |
-| `pageToken` | string  | no       | Pagination token for later persistent stores.          |
-
-**Response:** `200 OK`
-
-```json
-{
-  "code": 0,
-  "tasks": [
-    {
-      "taskId": "updater-018f2f4f",
-      "module": "updater",
-      "status": "succeeded",
-      "audit": {
-        "createTime": "2026-06-30T10:00:00Z",
-        "creator": "anonymous"
-      }
-    }
-  ],
-  "nextPageToken": ""
-}
-```
-
-#### POST /api/optimizer/v1/updater/tasks/{taskId}
-
-Requests best-effort cancellation for one updater task, mirroring `POST /jobs/runs/{jobId}`.
-
-**Response:** `200 OK`
-
-```json
-{
-  "code": 0,
-  "task": {
-    "taskId": "updater-018f2f4f",
-    "module": "updater",
-    "status": "cancelling"
-  }
-}
-```
-
-**Behavior:**
-
-A `queued` task moves directly to `canceled`. A `started` task moves to `cancelling` and reaches
-`canceled` only when the provider or worker observes cancellation. Completed tasks remain in their
-terminal status.
-
-#### POST /api/optimizer/v1/recommender/tasks
-
-Submits an asynchronous recommender task.
+Runs the same logic as CLI `submit-strategy-jobs`.
 
 **Request:**
 
@@ -442,133 +317,39 @@ Submits an asynchronous recommender task.
 ```json
 {
   "code": 0,
-  "task": {
-    "taskId": "recommender-018f2f50",
-    "module": "recommender",
-    "status": "queued"
-  }
-}
-```
-
-**Behavior:**
-
-The service validates identifiers, strategy name, and positive `limit` values. Dry-run tasks return
-recommendation details. Non-dry-run tasks submit jobs through the configured `JobSubmitter`, which may
-call Gravitino job APIs.
-
-#### GET /api/optimizer/v1/recommender/tasks/{taskId}
-
-Returns one recommender task.
-
-**Response:** `200 OK`
-
-```json
-{
-  "code": 0,
-  "task": {
-    "taskId": "recommender-018f2f50",
-    "module": "recommender",
-    "status": "succeeded",
-    "result": {
-      "dryRun": true,
-      "recommendations": [
-        {
-          "strategyName": "iceberg_compaction_default",
-          "identifier": "rest_catalog.db.t1",
-          "score": 100,
-          "jobTemplate": "builtin-iceberg-rewrite-data-files",
-          "jobOptions": {
-            "catalog_name": "rest_catalog",
-            "table_identifier": "db.t1"
-          },
-          "jobId": ""
-        }
-      ]
-    },
-    "audit": {
-      "createTime": "2026-06-30T10:10:00Z",
-      "creator": "anonymous"
-    }
-  }
-}
-```
-
-**Behavior:**
-
-The `jobId` field carries the submitted Gravitino job ID when the configured submitter creates a job,
-so the optimizer task result links directly to the job run tracked by the job framework.
-
-#### GET /api/optimizer/v1/recommender/tasks
-
-Lists recommender tasks.
-
-**Request query parameters:**
-
-| Field       | Type    | Required | Description                                            |
-| ----------- | ------- | -------- | ------------------------------------------------------ |
-| `status`    | string  | no       | Filter by task status.                                 |
-| `fromTime`  | string  | no       | Include tasks created at or after this ISO-8601 time.  |
-| `toTime`    | string  | no       | Include tasks created before or at this ISO-8601 time. |
-| `limit`     | integer | no       | Maximum records to return.                             |
-| `pageToken` | string  | no       | Pagination token for later persistent stores.          |
-
-**Response:** `200 OK`
-
-```json
-{
-  "code": 0,
-  "tasks": [
+  "dryRun": false,
+  "results": [
     {
-      "taskId": "recommender-018f2f50",
-      "module": "recommender",
-      "status": "succeeded",
-      "audit": {
-        "createTime": "2026-06-30T10:10:00Z",
-        "creator": "anonymous"
-      }
+      "strategyName": "iceberg_compaction_default",
+      "identifier": "rest_catalog.db.t1",
+      "score": 100,
+      "jobTemplate": "builtin-iceberg-rewrite-data-files",
+      "jobOptions": {
+        "catalog_name": "rest_catalog",
+        "table_identifier": "db.t1"
+      },
+      "jobId": "job-123"
     }
-  ],
-  "nextPageToken": ""
+  ]
 }
 ```
 
 **Behavior:**
 
-The service returns recommender task summaries sorted by creation time. The MVP may only return tasks
-that are still retained by the in-memory task store.
+The service validates identifiers, strategy name, and positive `limit` values. Dry-run requests
+return recommendation details with empty `jobId` values. Non-dry-run requests submit jobs through the
+configured `JobSubmitter`; when that submitter creates Gravitino jobs, returned `jobId` values are
+owned and tracked by the Gravitino job framework.
 
-#### POST /api/optimizer/v1/recommender/tasks/{taskId}
+#### POST /api/optimizer/v1/monitors/metrics
 
-Requests best-effort cancellation for one recommender task.
-
-**Response:** `200 OK`
-
-```json
-{
-  "code": 0,
-  "task": {
-    "taskId": "recommender-018f2f50",
-    "module": "recommender",
-    "status": "cancelling"
-  }
-}
-```
-
-**Behavior:**
-
-A `queued` task moves directly to `canceled`; a `started` task moves through `cancelling` when the
-worker or provider observes cancellation. Jobs already submitted through Gravitino are not
-automatically canceled by canceling the optimizer task.
-
-#### POST /api/optimizer/v1/monitor/tasks
-
-Submits an asynchronous monitor task.
+Runs the same logic as CLI `monitor-metrics`.
 
 **Request:**
 
 | Field           | Type          | Required | Description                                                                 |
 | --------------- | ------------- | -------- | --------------------------------------------------------------------------- |
-| `identifiers`   | array[string] | yes      | Table or job identifiers to evaluate.                                       |
+| `identifiers`   | array[string] | yes      | Table identifiers to evaluate.                                              |
 | `actionTime`    | integer       | yes      | Action timestamp in epoch seconds.                                          |
 | `rangeSeconds`  | integer       | no       | Evaluation window. Default is the current CLI default, 86400 seconds.       |
 | `partitionPath` | array[object] | no       | Partition path. Allowed only when exactly one table identifier is provided. |
@@ -578,118 +359,21 @@ Submits an asynchronous monitor task.
 ```json
 {
   "code": 0,
-  "task": {
-    "taskId": "monitor-018f2f51",
-    "module": "monitor",
-    "status": "queued"
-  }
-}
-```
-
-**Behavior:**
-
-The service evaluates monitor rules with the configured metrics provider, evaluator, table-job
-relation provider, and callbacks. The task result includes the evaluation records currently printed by
-the CLI.
-
-#### GET /api/optimizer/v1/monitor/tasks/{taskId}
-
-Returns one monitor task.
-
-**Response:** `200 OK`
-
-```json
-{
-  "code": 0,
-  "task": {
-    "taskId": "monitor-018f2f51",
-    "module": "monitor",
-    "status": "succeeded",
-    "result": {
-      "evaluations": [
-        {
-          "identifier": "rest_catalog.db.t1",
-          "scope": "table",
-          "evaluator": "gravitino-metrics-evaluator",
-          "passed": true
-        }
-      ]
-    },
-    "audit": {
-      "createTime": "2026-06-30T10:20:00Z",
-      "creator": "anonymous"
-    }
-  }
-}
-```
-
-#### GET /api/optimizer/v1/monitor/tasks
-
-Lists monitor tasks.
-
-**Request query parameters:**
-
-| Field       | Type    | Required | Description                                            |
-| ----------- | ------- | -------- | ------------------------------------------------------ |
-| `status`    | string  | no       | Filter by task status.                                 |
-| `fromTime`  | string  | no       | Include tasks created at or after this ISO-8601 time.  |
-| `toTime`    | string  | no       | Include tasks created before or at this ISO-8601 time. |
-| `limit`     | integer | no       | Maximum records to return.                             |
-| `pageToken` | string  | no       | Pagination token for later persistent stores.          |
-
-**Response:** `200 OK`
-
-```json
-{
-  "code": 0,
-  "tasks": [
+  "evaluations": [
     {
-      "taskId": "monitor-018f2f51",
-      "module": "monitor",
-      "status": "succeeded",
-      "audit": {
-        "createTime": "2026-06-30T10:20:00Z",
-        "creator": "anonymous"
-      }
+      "identifier": "rest_catalog.db.t1",
+      "scope": "table",
+      "partitionPath": null,
+      "evaluator": "gravitino-metrics-evaluator",
+      "passed": true
     }
-  ],
-  "nextPageToken": ""
+  ]
 }
 ```
-
-**Behavior:**
-
-The service returns monitor task summaries sorted by creation time. The MVP may only return tasks
-that are still retained by the in-memory task store.
-
-#### POST /api/optimizer/v1/monitor/tasks/{taskId}
-
-Requests best-effort cancellation for one monitor task.
-
-**Response:** `200 OK`
-
-```json
-{
-  "code": 0,
-  "task": {
-    "taskId": "monitor-018f2f51",
-    "module": "monitor",
-    "status": "cancelling"
-  }
-}
-```
-
-**Behavior:**
-
-A `queued` task moves directly to `canceled`; a `started` task moves through `cancelling` when the
-worker or provider observes cancellation. Monitor callbacks that have already been invoked are not
-rolled back.
 
 #### GET /api/optimizer/v1/metrics/tables
 
-Queries table or partition metrics. Unlike the module tasks, metrics queries are synchronous because
-they read existing metrics and are expected to be short, so they return the result directly instead of
-a task record.
+Runs the same logic as CLI `list-table-metrics`.
 
 **Request query parameters:**
 
@@ -707,6 +391,7 @@ a task record.
     {
       "identifier": "rest_catalog.db.t1",
       "scope": "table",
+      "partitionPath": null,
       "points": [
         {
           "name": "row_count",
@@ -719,14 +404,9 @@ a task record.
 }
 ```
 
-**Behavior:**
-
-Large result pagination can be added with the same `limit` and `pageToken` pattern used by the task
-list APIs.
-
 #### GET /api/optimizer/v1/metrics/jobs
 
-Queries job metrics.
+Runs the same logic as CLI `list-job-metrics`.
 
 **Request query parameters:**
 
@@ -755,6 +435,50 @@ Queries job metrics.
 }
 ```
 
+#### POST /api/optimizer/v1/jobs/update-stats
+
+Runs the same logic as CLI `submit-update-stats-job`.
+
+**Request:**
+
+| Field            | Type          | Required | Description                                                                  |
+| ---------------- | ------------- | -------- | ---------------------------------------------------------------------------- |
+| `identifiers`    | array[string] | yes      | Table identifiers.                                                           |
+| `dryRun`         | boolean       | no       | Preview job configs without submitting jobs. Default is `false`.             |
+| `updateMode`     | string        | no       | `stats`, `metrics`, or `all`. Default is `all`.                              |
+| `updaterOptions` | object        | no       | Flat option map passed to updater logic.                                     |
+| `sparkConf`      | object        | no       | Flat Spark and Iceberg catalog config map used by the submitted job.         |
+
+**Response:** `200 OK`
+
+```json
+{
+  "code": 0,
+  "dryRun": false,
+  "submitted": [
+    {
+      "identifier": "rest_catalog.db.t1",
+      "jobTemplate": "builtin-iceberg-update-stats",
+      "jobId": "job-456",
+      "jobConfig": {
+        "catalog_name": "rest_catalog",
+        "table_identifier": "db.t1",
+        "update_mode": "all"
+      }
+    }
+  ],
+  "summary": {
+    "total": 1,
+    "submitted": 1
+  }
+}
+```
+
+**Behavior:**
+
+The service only submits Gravitino jobs and returns job IDs. Job execution status, cancellation, and
+history remain owned by the Gravitino job framework.
+
 #### GET /api/optimizer/v1/health
 
 Returns service health. This is an operational endpoint and is the one response that is not wrapped in
@@ -764,70 +488,70 @@ the `code` envelope, so external liveness probes can consume it directly.
 
 ```json
 {
-  "status": "UP",
-  "modules": {
-    "updater": "UP",
-    "recommender": "UP",
-    "monitor": "UP",
-    "metricsQuery": "UP"
-  }
+  "status": "UP"
 }
 ```
 
 ### Service Configuration
 
 The service reads the same `conf/gravitino-optimizer.conf` file as the CLI, plus service-side keys
-that control the HTTP endpoint and the task runtime described in the Reliability section:
+that control the HTTP endpoint:
 
-| Key                                          | Default   | Description                                                          |
-| -------------------------------------------- | --------- | -------------------------------------------------------------------- |
-| `gravitino.optimizer.server.host`            | `0.0.0.0` | Bind address for the Optimizer Service HTTP server.                  |
-| `gravitino.optimizer.server.port`            | `8091`    | Listen port for the Optimizer Service HTTP server.                   |
-| `gravitino.optimizer.server.workerPoolSize`  | `4`       | Worker threads per module for asynchronous task execution.           |
-| `gravitino.optimizer.server.queueCapacity`   | `100`     | Maximum queued tasks per module before new submissions are rejected. |
-| `gravitino.optimizer.server.taskTimeoutMs`   | `600000`  | Per-task execution timeout after which the task is marked `failed`.  |
-| `gravitino.optimizer.server.taskRetentionMs` | `3600000` | How long terminal task records are retained by the in-memory store.  |
+| Key                                                   | Default     | Description                                                         |
+| ----------------------------------------------------- | ----------- | ------------------------------------------------------------------- |
+| `gravitino.optimizer.server.host`                     | `127.0.0.1` | Bind address. Use `0.0.0.0` only for explicitly remote deployments. |
+| `gravitino.optimizer.server.port`                     | `8091`      | Listen port for the Optimizer Service HTTP server.                  |
+| `gravitino.optimizer.server.requestTimeoutMs`         | `600000`    | Maximum time for one synchronous service request.                   |
+| `gravitino.optimizer.server.allowedInputPathPrefixes` | none        | Allowed server-local prefixes for REST `filePath`; empty disables `filePath`. |
 
-### CLI Service Mode
+### Service Client CLI
 
-Add optimizer CLI service configuration keys:
+Keep `gravitino-optimizer.sh` as the local execution CLI. Add a separate service client script, for
+example `gravitino-optimizer-client.sh`, for remote execution through the Optimizer Service. The
+client reuses the current command names, option names, validation rules, and output style where
+possible, but it does not instantiate local providers or run optimizer logic.
 
-| Key                                             | Default | Description                                                             |
-| ----------------------------------------------- | ------- | ----------------------------------------------------------------------- |
-| `gravitino.optimizer.service.enabled`           | `false` | Enables CLI remote execution for supported commands.                    |
-| `gravitino.optimizer.service.url`               | none    | Base URL of the Optimizer Service, for example `http://localhost:8091`. |
-| `gravitino.optimizer.service.requestTimeoutMs`  | `30000` | HTTP request timeout for CLI service calls.                             |
-| `gravitino.optimizer.service.pollIntervalMs`    | `1000`  | Poll interval when the CLI waits for async task completion.             |
-| `gravitino.optimizer.service.waitForCompletion` | `true`  | Whether CLI commands wait and print final results by default.           |
+Add service client configuration keys:
 
-The existing CLI commands remain the primary user interface:
+| Key                                                   | Default | Description                                                             |
+| ----------------------------------------------------- | ------- | ----------------------------------------------------------------------- |
+| `gravitino.optimizer.client.serviceUrl`               | none    | Base URL of the Optimizer Service, for example `http://localhost:8091`. |
+| `gravitino.optimizer.client.requestTimeoutMs`         | `30000` | HTTP request timeout for service calls.                                 |
 
-| CLI command               | Service mode behavior                                                                                                   |
-| ------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
-| `update-statistics`       | Calls `POST /api/optimizer/v1/updater/tasks` with `updateType=STATISTICS`.                                              |
-| `append-metrics`          | Calls `POST /api/optimizer/v1/updater/tasks` with `updateType=METRICS`.                                                 |
-| `submit-strategy-jobs`    | Calls `POST /api/optimizer/v1/recommender/tasks`.                                                                       |
-| `monitor-metrics`         | Calls `POST /api/optimizer/v1/monitor/tasks`.                                                                           |
-| `list-table-metrics`      | Calls `GET /api/optimizer/v1/metrics/tables`.                                                                           |
-| `list-job-metrics`        | Calls `GET /api/optimizer/v1/metrics/jobs`.                                                                             |
-| `submit-update-stats-job` | Initially remains local CLI submission to the Gravitino job framework. A later phase may add an optimizer task wrapper. |
+The two CLIs have separate execution backends:
 
-If service mode is disabled, commands use the current local execution path. If service mode is
-enabled and the service call fails, the CLI should fail fast by default. Automatic local fallback can
-hide partial service outages and cause duplicated submissions, so fallback should require an explicit
-future configuration if it is added.
+| CLI script                       | Execution backend                                      |
+| -------------------------------- | ------------------------------------------------------ |
+| `gravitino-optimizer.sh`         | Local optimizer execution using configured providers.  |
+| `gravitino-optimizer-client.sh`  | Remote execution through Optimizer Service REST APIs.  |
+
+The service client maps commands to REST endpoints:
+
+| CLI command               | Service client behavior                                    |
+| ------------------------- | ---------------------------------------------------------- |
+| `update-statistics`       | Calls `POST /api/optimizer/v1/statistics/update`.          |
+| `append-metrics`          | Calls `POST /api/optimizer/v1/metrics/append`.             |
+| `submit-strategy-jobs`    | Calls `POST /api/optimizer/v1/recommendations/submit`.     |
+| `monitor-metrics`         | Calls `POST /api/optimizer/v1/monitors/metrics`.           |
+| `list-table-metrics`      | Calls `GET /api/optimizer/v1/metrics/tables`.              |
+| `list-job-metrics`        | Calls `GET /api/optimizer/v1/metrics/jobs`.                |
+| `submit-update-stats-job` | Calls `POST /api/optimizer/v1/jobs/update-stats`.          |
+
+If the service client call fails, the client should fail fast by default. Automatic fallback to local
+execution is intentionally not supported because it can hide partial service outages and cause
+duplicated submissions.
 
 ### User Process
 
-The service mode user flow is:
+The service client user flow is:
 
 1. The operator configures `conf/gravitino-optimizer.conf` with Gravitino connection settings,
    optimizer providers, and service settings.
 2. The operator starts the Optimizer Service with the optimizer distribution.
-3. A user runs an existing CLI command such as:
+3. A user runs the service client CLI with familiar optimizer command options, such as:
 
    ```bash
-   ./bin/gravitino-optimizer.sh \
+   ./bin/gravitino-optimizer-client.sh \
      --type submit-strategy-jobs \
      --identifiers rest_catalog.db.t1 \
      --strategy-name iceberg_compaction_default \
@@ -835,14 +559,13 @@ The service mode user flow is:
      --limit 10
    ```
 
-4. The CLI validates arguments, detects service mode, submits a REST request, and prints the task ID.
-5. If `waitForCompletion` is enabled, the CLI polls the task status endpoint and prints the final
-   result using output compatible with the existing command.
-6. Automation can call the REST API directly, store the task ID, and query the result later.
+4. The client validates arguments, sends a synchronous REST request, and waits for the HTTP response.
+5. The client prints output compatible with the existing local CLI command.
+6. Automation can call the REST API directly and consume structured response payloads.
 
 ### Implementation Process
 
-The internal flow for asynchronous tasks is:
+The internal flow for service requests is:
 
 ```text
 CLI or REST client
@@ -851,156 +574,145 @@ CLI or REST client
 REST resource validates request
       |
       v
-TaskRuntime creates task record in queued status
+Handler invokes existing optimizer class
+      |
+      +--> Updater / Recommender / Monitor / MetricsProvider / GravitinoClient
       |
       v
-Worker picks task and marks it started
-      |
-      v
-Module invokes existing optimizer class
-      |
-      +--> Updater / Recommender / Monitor
-      |
-      v
-TaskRuntime stores succeeded, failed, or canceled result
-      |
-      v
-Client queries task result
+REST resource returns structured result or sanitized error
 ```
 
-Implementation should keep module boundaries thin. Existing `Updater`, `Recommender`, and `Monitor`
-classes remain the execution core. REST resources translate requests into module calls, and modules
-translate module results into REST result DTOs.
+Implementation should keep handler boundaries thin. Existing `Updater`, `Recommender`, `Monitor`,
+metrics provider logic, and Gravitino job submission remain the execution core. REST resources
+translate requests into handler calls, and handlers translate optimizer results into REST result DTOs.
 
 ### Backward Compatibility
 
 This design is backward compatible for existing CLI users:
 
-1. Service mode is disabled by default.
+1. `gravitino-optimizer.sh` remains the local execution CLI.
 2. Existing command names and options remain valid.
-3. Existing local output should remain the default when service mode is disabled.
-4. Service mode may print the task ID in addition to existing summary lines. This is additive.
-5. `submit-update-stats-job` keeps the existing local submission path until a service wrapper is
-   implemented.
+3. Existing local output remains unchanged in `gravitino-optimizer.sh`.
+4. The new service client is opt-in and should print output compatible with the existing command
+   output.
+5. Submitted Gravitino job IDs remain visible in service responses and service client output.
 
 New REST APIs are additive. They do not change existing Gravitino metadata APIs or job APIs.
 
 ### Security
 
-The service must validate all request parameters at the REST boundary using the same rules as the
-CLI. File-based input such as `filePath` is server-local in service mode and should be documented as
-an operator-controlled path, not a client upload path.
+The service must validate request parameters with the same rules as the CLI. REST `filePath` is
+server-local, disabled by default, and must resolve under `allowedInputPathPrefixes` when enabled.
 
 Authentication and authorization can be phased:
 
-1. MVP supports deployments behind trusted internal networks or reverse proxies.
-2. A later phase can integrate with Gravitino authentication mechanisms or service-specific tokens.
-3. Direct REST clients should receive sanitized error messages that do not expose secrets from config
-   files, job options, or provider exceptions.
+1. MVP binds to loopback by default; remote deployments should add a trusted network boundary,
+   reverse proxy, or service token before exposing mutating APIs.
+2. Audit creator is the authenticated service principal, or `anonymous` only when auth is disabled.
+3. Later phases can add Gravitino auth integration and request-scoped authorization.
+4. Direct REST clients receive sanitized errors that do not expose config, job-option, or provider
+   secrets.
 
 ### Reliability and Observability
 
 The service should provide:
 
-| Area          | Requirement                                                                                 |
-| ------------- | ------------------------------------------------------------------------------------------- |
-| Queue control | Per-module queue size and worker count.                                                     |
-| Timeout       | Per-task execution timeout and HTTP client timeout.                                         |
-| Cancellation  | Best-effort cancellation for queued and cooperative running tasks.                          |
-| Shutdown      | Graceful shutdown that stops accepting requests and drains or cancels queued work.          |
-| Logs          | Task lifecycle logs with task ID, module, status transition, and duration.                  |
-| Metrics       | Task counts by module/status, latency, queue depth, worker utilization, and failure counts. |
-| Health        | Health endpoint with module initialization status.                                          |
+| Area            | Requirement                                                                                     |
+| --------------- | ----------------------------------------------------------------------------------------------- |
+| Request control | HTTP request timeout and optional max concurrent request limit.                                  |
+| Shutdown        | Graceful shutdown that stops accepting new requests and waits for in-flight requests to finish. |
+| Logs            | Request lifecycle logs with command name, request ID, result status, and duration.              |
+| Metrics         | Request counts by command/status, latency, active request count, and failure counts.            |
+| Health          | Health endpoint with optimizer service status.                                                  |
 
 ### Rollout Plan
 
-#### Phase 1: Service Shell and Shared Runtime
+#### Phase 1: Service Shell and Common DTOs
 
-Create the service entry point, REST server, health endpoint, task runtime, in-memory task store, and
-common DTOs. Add unit tests for status transitions, cancellation, serialization, and task listing.
+Create the service entry point, REST server, health endpoint, common request/response DTOs, sanitized
+error handling, and request timeout configuration.
 
-#### Phase 2: Updater APIs and CLI Service Mode
+#### Phase 2: Updater APIs and Service Client CLI
 
-Implement updater REST APIs and CLI service mode for `update-statistics` and `append-metrics`.
-Validate parity with local execution using existing updater tests and new service-mode CLI tests.
+Implement `update-statistics` and `append-metrics` REST APIs and service client support. Validate
+parity with local execution, including client `--file-path` conversion and REST `filePath` allowlist
+validation.
 
-#### Phase 3: Recommender APIs and CLI Service Mode
+#### Phase 3: Recommender APIs and Service Client CLI
 
-Implement recommender REST APIs and CLI service mode for `submit-strategy-jobs`. Cover dry-run and
-real submission paths, including returned job IDs from the configured submitter.
+Implement `submit-strategy-jobs` REST API and service client support. Cover dry-run and real submission
+paths, including returned Gravitino job IDs.
 
 #### Phase 4: Monitor and Metrics Query APIs
 
-Implement monitor task APIs and synchronous metrics query APIs. Add CLI service mode for
-`monitor-metrics`, `list-table-metrics`, and `list-job-metrics`.
+Implement `monitor-metrics`, `list-table-metrics`, and `list-job-metrics` REST APIs and service client
+mode.
 
-#### Phase 5: Built-In Update Stats Job Wrapper
+#### Phase 5: Built-In Update Stats Job Submission
 
-Optionally add an asynchronous optimizer task wrapper for `submit-update-stats-job`. The actual Spark
-job submission and status remain owned by the Gravitino job framework.
+Implement `submit-update-stats-job` REST API and service client support. The service returns submitted
+Gravitino job IDs; actual job execution and status remain owned by the Gravitino job framework.
 
 #### Phase 6: Hardening and Documentation
 
-Add persistent task storage, authentication integration, service metrics export, stronger graceful
-shutdown semantics, and optional multi-node deployment support.
+Add authentication integration, service metrics export, and stronger graceful shutdown semantics.
 
 ---
 
 ## Task Breakdown
 
-### Phase 1: Service Shell and Shared Runtime
+### Phase 1: Service Shell and Common DTOs
 
 - [ ] Add optimizer service configuration keys to `OptimizerConfig`.
 - [ ] Add `OptimizerServiceServer` entry point and startup script in the optimizer distribution.
-- [ ] Add common request, response, task record, task status, and error DTOs.
-- [ ] Implement `TaskRuntime` with in-memory task storage, bounded queues, worker pools, status
-      transitions, list/query support, and best-effort cancellation.
+- [ ] Add common request, response, summary, result, and error DTOs.
 - [ ] Add `GET /api/optimizer/v1/health`.
-- [ ] Add unit tests for task status transitions, task listing filters, cancellation, and DTO
-      serialization.
+- [ ] Add sanitized error handling and request timeout handling.
+- [ ] Add unit tests for DTO serialization, validation errors, timeout handling, and sanitized
+      errors.
 
-### Phase 2: Updater APIs and CLI Service Mode
+### Phase 2: Updater APIs and Service Client CLI
 
-- [ ] Add updater REST resource for submit, get, list, and cancel APIs.
-- [ ] Add `UpdaterModule` that adapts REST requests to existing `Updater` execution.
+- [ ] Add REST resources for `update-statistics` and `append-metrics`.
+- [ ] Add `UpdateStatisticsHandler` that adapts REST requests to existing `Updater` execution.
 - [ ] Add `OptimizerServiceClient` support for updater APIs.
-- [ ] Add CLI service-mode routing for `update-statistics`.
-- [ ] Add CLI service-mode routing for `append-metrics`.
-- [ ] Add tests for updater request validation, local calculator input rules, successful results, and
-      failure results.
+- [ ] Add service client commands for `update-statistics`.
+- [ ] Add service client commands for `append-metrics`.
+- [ ] Add tests for updater validation, client `--file-path` conversion, REST `filePath` allowlist,
+      successful summaries, and failure responses.
 
-### Phase 3: Recommender APIs and CLI Service Mode
+### Phase 3: Recommender APIs and Service Client CLI
 
-- [ ] Add recommender REST resource for submit, get, list, and cancel APIs.
-- [ ] Add `RecommenderModule` that adapts REST requests to existing `Recommender` execution.
-- [ ] Add `OptimizerServiceClient` support for recommender APIs.
-- [ ] Add CLI service-mode routing for `submit-strategy-jobs`.
-- [ ] Add tests for dry-run recommendations, limit handling, job submission results, and service-mode
-      CLI output.
+- [ ] Add REST resource for `submit-strategy-jobs`.
+- [ ] Add `StrategyJobsHandler` that adapts REST requests to existing `Recommender` execution.
+- [ ] Add `OptimizerServiceClient` support for strategy job APIs.
+- [ ] Add service client command for `submit-strategy-jobs`.
+- [ ] Add tests for dry-run recommendations, limit handling, submitted job IDs, and service client
+      output.
 
 ### Phase 4: Monitor and Metrics Query APIs
 
-- [ ] Add monitor REST resource for submit, get, list, and cancel APIs.
-- [ ] Add `MonitorModule` that adapts REST requests to existing `Monitor` execution.
-- [ ] Add metrics query REST resource for table, partition, and job metric queries.
+- [ ] Add REST resource for `monitor-metrics`.
+- [ ] Add `MonitorMetricsHandler` that adapts REST requests to existing `Monitor` execution.
+- [ ] Add metrics query REST resources for table, partition, and job metric queries.
 - [ ] Add `OptimizerServiceClient` support for monitor and metrics query APIs.
-- [ ] Add CLI service-mode routing for `monitor-metrics`.
-- [ ] Add CLI service-mode routing for `list-table-metrics` and `list-job-metrics`.
+- [ ] Add service client command for `monitor-metrics`.
+- [ ] Add service client commands for `list-table-metrics` and `list-job-metrics`.
 - [ ] Add tests for monitor validation, partition path handling, evaluation results, and metrics query
       responses.
 
-### Phase 5: Built-In Update Stats Job Wrapper
+### Phase 5: Built-In Update Stats Job Submission
 
-- [ ] Add optional service task API for `submit-update-stats-job` request wrapping.
+- [ ] Add REST resource for `submit-update-stats-job`.
 - [ ] Keep actual job creation in the existing Gravitino job framework.
-- [ ] Add CLI service-mode routing for `submit-update-stats-job` only after the wrapper is available.
-- [ ] Add tests that returned optimizer task results include submitted Gravitino job IDs.
+- [ ] Add `OptimizerServiceClient` support for update-stats job submission.
+- [ ] Add service client command for `submit-update-stats-job`.
+- [ ] Add tests that service responses include submitted Gravitino job IDs.
 
 ### Phase 6: Hardening and Documentation
 
-- [ ] Add persistent task store abstraction and DB-backed implementation.
 - [ ] Add service authentication and sanitized error handling.
-- [ ] Add service metrics for task counts, latency, queue depth, and worker utilization.
+- [ ] Add service metrics for request counts, latency, active requests, and failures.
 - [ ] Add graceful shutdown tests.
 - [ ] Update user-facing TMS documentation in `docs/table-maintenance-service/`.
 - [ ] Add OpenAPI documentation if optimizer service APIs are published under `docs/open-api/`.

--- a/design-docs/optimizer-service-design.md
+++ b/design-docs/optimizer-service-design.md
@@ -190,6 +190,19 @@ The task runtime uses one state model across updater, recommender, and monitor t
 | `FAILED` | Execution failed and the task record contains a sanitized error summary. |
 | `CANCELED` | The request was canceled before completion or the worker observed cancellation. |
 
+`SUCCEEDED`, `FAILED`, and `CANCELED` are terminal states. The allowed transitions are:
+
+```text
+PENDING --> RUNNING --> SUCCEEDED
+   |           |
+   |           +------> FAILED
+   |           |
+   +-----------+------> CANCELED
+```
+
+A task in `PENDING` can move directly to `CANCELED` if it is canceled before a worker picks it up. A
+task in `RUNNING` reaches `CANCELED` only when the worker or provider observes cancellation.
+
 Each task record stores:
 
 | Field | Type | Description |
@@ -203,6 +216,20 @@ Each task record stores:
 | `requestHash` | string | Hash of normalized request payload for audit and troubleshooting. |
 | `result` | object | Module-specific result payload for successful tasks. |
 | `error` | object | Sanitized error code, message, and optional stack summary for failed tasks. |
+
+For a `FAILED` task, the `error` object has a stable shape so clients and automation can branch on it:
+
+```json
+{
+  "code": "INVALID_INPUT",
+  "message": "statisticsPayload and filePath cannot both be set",
+  "stackSummary": ""
+}
+```
+
+`code` is a machine-readable error category, `message` is a sanitized human-readable summary, and
+`stackSummary` is an optional truncated trace that never includes secrets from config files, job
+options, or provider exceptions.
 
 The MVP may use an in-memory task store. The storage API should be pluggable so a later
 implementation can add a DB-backed store without changing REST semantics.
@@ -624,9 +651,23 @@ Returns service health.
 }
 ```
 
+### Service Configuration
+
+The service reads the same `conf/gravitino-optimizer.conf` file as the CLI, plus service-side keys
+that control the HTTP endpoint and the task runtime described in the Reliability section:
+
+| Key | Default | Description |
+| --- | --- | --- |
+| `gravitino.optimizer.server.host` | `0.0.0.0` | Bind address for the Optimizer Service HTTP server. |
+| `gravitino.optimizer.server.port` | `8091` | Listen port for the Optimizer Service HTTP server. |
+| `gravitino.optimizer.server.workerPoolSize` | `4` | Worker threads per module for asynchronous task execution. |
+| `gravitino.optimizer.server.queueCapacity` | `100` | Maximum queued tasks per module before new submissions are rejected. |
+| `gravitino.optimizer.server.taskTimeoutMs` | `600000` | Per-task execution timeout after which the task is marked `FAILED`. |
+| `gravitino.optimizer.server.taskRetentionMs` | `3600000` | How long terminal task records are retained by the in-memory store. |
+
 ### CLI Service Mode
 
-Add optimizer service configuration keys:
+Add optimizer CLI service configuration keys:
 
 | Key | Default | Description |
 | --- | --- | --- |
@@ -751,17 +792,17 @@ The service should provide:
 
 ### Rollout Plan
 
-#### Phase 1: Service Shell and Task Runtime
+#### Phase 1: Service Shell and Shared Runtime
 
 Create the service entry point, REST server, health endpoint, task runtime, in-memory task store, and
 common DTOs. Add unit tests for state transitions, cancellation, serialization, and request listing.
 
-#### Phase 2: Updater Service Mode
+#### Phase 2: Updater APIs and CLI Service Mode
 
 Implement updater REST APIs and CLI service mode for `update-statistics` and `append-metrics`.
 Validate parity with local execution using existing updater tests and new service-mode CLI tests.
 
-#### Phase 3: Recommender Service Mode
+#### Phase 3: Recommender APIs and CLI Service Mode
 
 Implement recommender REST APIs and CLI service mode for `submit-strategy-jobs`. Cover dry-run and
 real submission paths, including returned job IDs from the configured submitter.
@@ -776,7 +817,7 @@ Implement monitor task APIs and synchronous metrics query APIs. Add CLI service 
 Optionally add an asynchronous optimizer task wrapper for `submit-update-stats-job`. The actual Spark
 job submission and status remain owned by the Gravitino job framework.
 
-#### Phase 6: Hardening
+#### Phase 6: Hardening and Documentation
 
 Add persistent task storage, authentication integration, service metrics export, stronger graceful
 shutdown semantics, and optional multi-node deployment support.
@@ -826,7 +867,7 @@ shutdown semantics, and optional multi-node deployment support.
 - [ ] Add tests for monitor validation, partition path handling, evaluation results, and metrics query
       responses.
 
-### Phase 5: Built-In Job Wrapper
+### Phase 5: Built-In Update Stats Job Wrapper
 
 - [ ] Add optional service task API for `submit-update-stats-job` request wrapping.
 - [ ] Keep actual job creation in the existing Gravitino job framework.

--- a/design-docs/optimizer-service-design.md
+++ b/design-docs/optimizer-service-design.md
@@ -917,7 +917,7 @@ The service should provide:
 #### Phase 1: Service Shell and Shared Runtime
 
 Create the service entry point, REST server, health endpoint, task runtime, in-memory task store, and
-common DTOs. Add unit tests for state transitions, cancellation, serialization, and request listing.
+common DTOs. Add unit tests for status transitions, cancellation, serialization, and task listing.
 
 #### Phase 2: Updater APIs and CLI Service Mode
 
@@ -952,11 +952,11 @@ shutdown semantics, and optional multi-node deployment support.
 
 - [ ] Add optimizer service configuration keys to `OptimizerConfig`.
 - [ ] Add `OptimizerServiceServer` entry point and startup script in the optimizer distribution.
-- [ ] Add common request, response, task record, task state, and error DTOs.
-- [ ] Implement `TaskRuntime` with in-memory task storage, bounded queues, worker pools, state
+- [ ] Add common request, response, task record, task status, and error DTOs.
+- [ ] Implement `TaskRuntime` with in-memory task storage, bounded queues, worker pools, status
       transitions, list/query support, and best-effort cancellation.
 - [ ] Add `GET /api/optimizer/v1/health`.
-- [ ] Add unit tests for task state transitions, task listing filters, cancellation, and DTO
+- [ ] Add unit tests for task status transitions, task listing filters, cancellation, and DTO
       serialization.
 
 ### Phase 2: Updater APIs and CLI Service Mode


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add a design document for introducing an Optimizer Service for Apache Gravitino.

The design covers:
- Current optimizer CLI limitations.
- Goals, non-goals, and solution alternatives.
- Proposed service architecture, task runtime, REST APIs, CLI service mode, rollout plan, and task breakdown.

### Why are the changes needed?

The current Table Maintenance Service (Optimizer) is primarily driven by local CLI execution. A design document is needed to describe how to evolve it into a long-running service with asynchronous task execution, queryable status, and CLI compatibility.

Fix: #11851

### Does this PR introduce _any_ user-facing change?

No. This PR only adds a design document.

### How was this patch tested?

- `git diff --check`
- `git diff --cached --check`
- Verified the design document follows the project `gravitino-design-doc` structure.