### PR TITLE
[#11850] feat(iceberg): apply web identity credentials to server FileIO

### DIFF
--- a/catalogs/catalog-lakehouse-iceberg/src/main/java/org/apache/gravitino/catalog/lakehouse/iceberg/IcebergCatalogOperations.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/main/java/org/apache/gravitino/catalog/lakehouse/iceberg/IcebergCatalogOperations.java
@@ -42,6 +42,11 @@ import org.apache.gravitino.connector.CatalogInfo;
 import org.apache.gravitino.connector.CatalogOperations;
 import org.apache.gravitino.connector.HasPropertyMetadata;
 import org.apache.gravitino.connector.SupportsSchemas;
+import org.apache.gravitino.credential.CatalogCredentialContext;
+import org.apache.gravitino.credential.CatalogCredentialManager;
+import org.apache.gravitino.credential.Credential;
+import org.apache.gravitino.credential.CredentialPropertyUtils;
+import org.apache.gravitino.credential.CredentialUtils;
 import org.apache.gravitino.exceptions.ConnectionFailedException;
 import org.apache.gravitino.exceptions.NoSuchCatalogException;
 import org.apache.gravitino.exceptions.NoSuchSchemaException;
@@ -124,6 +129,7 @@ public class IcebergCatalogOperations
     Map<String, String> resultConf = Maps.newHashMap(prefixMap);
     resultConf.putAll(gravitinoConfig);
     resultConf.put("catalog_uuid", info.id().toString());
+    injectCredentialConfig(conf, info.name(), resultConf);
     IcebergConfig icebergConfig = new IcebergConfig(resultConf);
 
     IcebergCatalogWrapper rawWrapper = new IcebergCatalogWrapper(icebergConfig);
@@ -136,6 +142,22 @@ public class IcebergCatalogOperations
     this.icebergCatalogWrapperHelper =
         new IcebergCatalogWrapperHelper(icebergCatalogWrapper.getCatalog());
     this.icebergViewCatalogOperations = new IcebergViewCatalogOperations(icebergCatalogWrapper);
+  }
+
+  private static void injectCredentialConfig(
+      Map<String, String> conf, String catalogName, Map<String, String> resultConf) {
+    List<Credential> credentials = new ArrayList<>();
+    CatalogCredentialContext context =
+        new CatalogCredentialContext(PrincipalUtils.getCurrentUserName());
+    try (CatalogCredentialManager credentialManager =
+        new CatalogCredentialManager(catalogName, conf)) {
+      for (String credentialProvider : CredentialUtils.getCredentialProvidersByOrder(() -> conf)) {
+        credentialManager.getCredential(credentialProvider, context).ifPresent(credentials::add);
+      }
+    }
+
+    CredentialPropertyUtils.applyIcebergCredentials(
+        credentials.toArray(new Credential[0]), resultConf);
   }
 
   /** Closes the Iceberg catalog and releases the associated client pool. */

--- a/catalogs/catalog-lakehouse-iceberg/src/main/java/org/apache/gravitino/catalog/lakehouse/iceberg/IcebergCatalogOperations.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/main/java/org/apache/gravitino/catalog/lakehouse/iceberg/IcebergCatalogOperations.java
@@ -45,8 +45,7 @@ import org.apache.gravitino.connector.SupportsSchemas;
 import org.apache.gravitino.credential.CatalogCredentialContext;
 import org.apache.gravitino.credential.CatalogCredentialManager;
 import org.apache.gravitino.credential.Credential;
-import org.apache.gravitino.credential.CredentialPropertyUtils;
-import org.apache.gravitino.credential.CredentialUtils;
+import org.apache.gravitino.credential.config.CredentialConfig;
 import org.apache.gravitino.exceptions.ConnectionFailedException;
 import org.apache.gravitino.exceptions.NoSuchCatalogException;
 import org.apache.gravitino.exceptions.NoSuchSchemaException;
@@ -59,6 +58,7 @@ import org.apache.gravitino.exceptions.ViewAlreadyExistsException;
 import org.apache.gravitino.iceberg.common.IcebergConfig;
 import org.apache.gravitino.iceberg.common.authentication.AuthenticationConfig;
 import org.apache.gravitino.iceberg.common.authentication.SupportsKerberos;
+import org.apache.gravitino.iceberg.common.credential.IcebergServerCredentialUtils;
 import org.apache.gravitino.iceberg.common.ops.IcebergCatalogWrapper;
 import org.apache.gravitino.iceberg.common.ops.IcebergCatalogWrapper.IcebergTableChange;
 import org.apache.gravitino.iceberg.common.ops.KerberosAwareIcebergCatalogProxy;
@@ -151,13 +151,14 @@ public class IcebergCatalogOperations
         new CatalogCredentialContext(PrincipalUtils.getCurrentUserName());
     try (CatalogCredentialManager credentialManager =
         new CatalogCredentialManager(catalogName, conf)) {
-      for (String credentialProvider : CredentialUtils.getCredentialProvidersByOrder(() -> conf)) {
+      for (String credentialProvider :
+          new CredentialConfig(conf).get(CredentialConfig.CREDENTIAL_PROVIDERS)) {
         credentialManager.getCredential(credentialProvider, context).ifPresent(credentials::add);
       }
     }
 
-    CredentialPropertyUtils.applyIcebergCredentials(
-        credentials.toArray(new Credential[0]), resultConf);
+    IcebergServerCredentialUtils.applyCredentials(
+        catalogName, credentials.toArray(new Credential[0]), conf, resultConf);
   }
 
   /** Closes the Iceberg catalog and releases the associated client pool. */

--- a/catalogs/catalog-lakehouse-iceberg/src/test/java/org/apache/gravitino/catalog/lakehouse/iceberg/TestIcebergCatalogOperations.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/test/java/org/apache/gravitino/catalog/lakehouse/iceberg/TestIcebergCatalogOperations.java
@@ -34,6 +34,8 @@ import org.apache.gravitino.connector.CatalogInfo;
 import org.apache.gravitino.connector.HasPropertyMetadata;
 import org.apache.gravitino.credential.CredentialConstants;
 import org.apache.gravitino.exceptions.GravitinoRuntimeException;
+import org.apache.gravitino.iceberg.common.credential.GravitinoIcebergAwsCredentialsProvider;
+import org.apache.gravitino.iceberg.common.credential.IcebergServerCredentialUtils;
 import org.apache.gravitino.iceberg.common.ops.IcebergCatalogWrapper;
 import org.apache.gravitino.meta.AuditInfo;
 import org.apache.iceberg.rest.responses.ListNamespacesResponse;
@@ -104,7 +106,7 @@ public class TestIcebergCatalogOperations {
   }
 
   @Test
-  public void testInitializeInjectsCredentialProviderConfig() {
+  public void testInitializeConfiguresRefreshableCredentialProvider() {
     Map<String, String> conf = new HashMap<>();
     conf.put(IcebergConstants.CATALOG_BACKEND, "memory");
     conf.put(CredentialConstants.CREDENTIAL_PROVIDERS, TestIcebergCredentialProvider.TYPE);
@@ -135,12 +137,22 @@ public class TestIcebergCatalogOperations {
         catalogOperations.icebergCatalogWrapper.getIcebergConfig().getIcebergCatalogProperties();
 
     Assertions.assertEquals(
-        "test-access-key", icebergCatalogProperties.get(IcebergConstants.ICEBERG_S3_ACCESS_KEY_ID));
+        GravitinoIcebergAwsCredentialsProvider.class.getName(),
+        icebergCatalogProperties.get(IcebergServerCredentialUtils.CLIENT_CREDENTIALS_PROVIDER));
     Assertions.assertEquals(
-        "test-secret-key",
-        icebergCatalogProperties.get(IcebergConstants.ICEBERG_S3_SECRET_ACCESS_KEY));
+        CATALOG,
+        icebergCatalogProperties.get(
+            IcebergServerCredentialUtils.CLIENT_CREDENTIALS_PROVIDER_PREFIX
+                + GravitinoIcebergAwsCredentialsProvider.CATALOG_NAME));
     Assertions.assertEquals(
-        "test-session-token", icebergCatalogProperties.get(IcebergConstants.ICEBERG_S3_TOKEN));
-    Assertions.assertEquals("123", icebergCatalogProperties.get("s3.session-token-expires-at-ms"));
+        TestIcebergCredentialProvider.TYPE,
+        icebergCatalogProperties.get(
+            IcebergServerCredentialUtils.CLIENT_CREDENTIALS_PROVIDER_PREFIX
+                + CredentialConstants.CREDENTIAL_PROVIDERS));
+    Assertions.assertFalse(
+        icebergCatalogProperties.containsKey(IcebergConstants.ICEBERG_S3_ACCESS_KEY_ID));
+    Assertions.assertFalse(
+        icebergCatalogProperties.containsKey(IcebergConstants.ICEBERG_S3_SECRET_ACCESS_KEY));
+    Assertions.assertFalse(icebergCatalogProperties.containsKey(IcebergConstants.ICEBERG_S3_TOKEN));
   }
 }

--- a/catalogs/catalog-lakehouse-iceberg/src/test/java/org/apache/gravitino/catalog/lakehouse/iceberg/TestIcebergCatalogOperations.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/test/java/org/apache/gravitino/catalog/lakehouse/iceberg/TestIcebergCatalogOperations.java
@@ -23,12 +23,19 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableMap;
+import java.time.Instant;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 import org.apache.gravitino.Catalog;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
+import org.apache.gravitino.connector.CatalogInfo;
+import org.apache.gravitino.connector.HasPropertyMetadata;
+import org.apache.gravitino.credential.CredentialConstants;
 import org.apache.gravitino.exceptions.GravitinoRuntimeException;
 import org.apache.gravitino.iceberg.common.ops.IcebergCatalogWrapper;
+import org.apache.gravitino.meta.AuditInfo;
 import org.apache.iceberg.rest.responses.ListNamespacesResponse;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -94,5 +101,46 @@ public class TestIcebergCatalogOperations {
     Assertions.assertEquals(2, result.length);
     Assertions.assertTrue(Arrays.stream(result).anyMatch(id -> "db1".equals(id.name())));
     Assertions.assertTrue(Arrays.stream(result).anyMatch(id -> "db2".equals(id.name())));
+  }
+
+  @Test
+  public void testInitializeInjectsCredentialProviderConfig() {
+    Map<String, String> conf = new HashMap<>();
+    conf.put(IcebergConstants.CATALOG_BACKEND, "memory");
+    conf.put(CredentialConstants.CREDENTIAL_PROVIDERS, TestIcebergCredentialProvider.TYPE);
+
+    CatalogInfo info =
+        new CatalogInfo(
+            1L,
+            CATALOG,
+            Catalog.Type.RELATIONAL,
+            "lakehouse-iceberg",
+            "comment",
+            conf,
+            AuditInfo.builder()
+                .withCreator("test")
+                .withCreateTime(Instant.EPOCH)
+                .withLastModifier("test")
+                .withLastModifiedTime(Instant.EPOCH)
+                .build(),
+            Namespace.of(METALAKE));
+
+    IcebergCatalogOperations catalogOperations = new IcebergCatalogOperations();
+    HasPropertyMetadata propertiesMetadata = mock(HasPropertyMetadata.class);
+    when(propertiesMetadata.catalogPropertiesMetadata())
+        .thenReturn(new IcebergCatalogPropertiesMetadata());
+    catalogOperations.initialize(conf, info, propertiesMetadata);
+
+    Map<String, String> icebergCatalogProperties =
+        catalogOperations.icebergCatalogWrapper.getIcebergConfig().getIcebergCatalogProperties();
+
+    Assertions.assertEquals(
+        "test-access-key", icebergCatalogProperties.get(IcebergConstants.ICEBERG_S3_ACCESS_KEY_ID));
+    Assertions.assertEquals(
+        "test-secret-key",
+        icebergCatalogProperties.get(IcebergConstants.ICEBERG_S3_SECRET_ACCESS_KEY));
+    Assertions.assertEquals(
+        "test-session-token", icebergCatalogProperties.get(IcebergConstants.ICEBERG_S3_TOKEN));
+    Assertions.assertEquals("123", icebergCatalogProperties.get("s3.session-token-expires-at-ms"));
   }
 }

--- a/catalogs/catalog-lakehouse-iceberg/src/test/java/org/apache/gravitino/catalog/lakehouse/iceberg/TestIcebergCredentialProvider.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/test/java/org/apache/gravitino/catalog/lakehouse/iceberg/TestIcebergCredentialProvider.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog.lakehouse.iceberg;
+
+import java.util.Map;
+import org.apache.gravitino.credential.AwsIrsaCredential;
+import org.apache.gravitino.credential.Credential;
+import org.apache.gravitino.credential.CredentialContext;
+import org.apache.gravitino.credential.CredentialProvider;
+
+/** Test credential provider that emits an AWS IRSA credential for Iceberg config injection. */
+public class TestIcebergCredentialProvider implements CredentialProvider {
+
+  /** Test-only credential provider type. */
+  public static final String TYPE = "test-iceberg-aws-irsa";
+
+  @Override
+  public void initialize(Map<String, String> properties) {}
+
+  @Override
+  public String credentialType() {
+    return TYPE;
+  }
+
+  @Override
+  public Credential getCredential(CredentialContext context) {
+    return new AwsIrsaCredential("test-access-key", "test-secret-key", "test-session-token", 123);
+  }
+
+  @Override
+  public void close() {}
+}

--- a/catalogs/catalog-lakehouse-iceberg/src/test/resources/META-INF/services/org.apache.gravitino.credential.CredentialProvider
+++ b/catalogs/catalog-lakehouse-iceberg/src/test/resources/META-INF/services/org.apache.gravitino.credential.CredentialProvider
@@ -1,0 +1,19 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+org.apache.gravitino.catalog.lakehouse.iceberg.TestIcebergCredentialProvider

--- a/clients/filesystem-hadoop3/src/test/java/org/apache/gravitino/filesystem/hadoop/integration/test/FilesetS3WebIdentityCredentialIT.java
+++ b/clients/filesystem-hadoop3/src/test/java/org/apache/gravitino/filesystem/hadoop/integration/test/FilesetS3WebIdentityCredentialIT.java
@@ -1,0 +1,253 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.filesystem.hadoop.integration.test;
+
+import static org.apache.gravitino.catalog.fileset.FilesetCatalogPropertiesMetadata.FILESYSTEM_PROVIDERS;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.gravitino.Catalog;
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.catalog.hadoop.fs.GravitinoFileSystemCredentialsProvider;
+import org.apache.gravitino.client.GravitinoMetalake;
+import org.apache.gravitino.credential.AwsIrsaCredential;
+import org.apache.gravitino.credential.Credential;
+import org.apache.gravitino.credential.CredentialConstants;
+import org.apache.gravitino.file.Fileset;
+import org.apache.gravitino.filesystem.hadoop.DefaultGravitinoFileSystemCredentialsProvider;
+import org.apache.gravitino.filesystem.hadoop.GravitinoVirtualFileSystemConfiguration;
+import org.apache.gravitino.integration.test.util.BaseIT;
+import org.apache.gravitino.integration.test.util.GravitinoITUtils;
+import org.apache.gravitino.s3.credential.webidentity.WebIdentityTokenSourceConfig;
+import org.apache.gravitino.storage.S3Properties;
+import org.apache.hadoop.conf.Configuration;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class FilesetS3WebIdentityCredentialIT extends BaseIT {
+
+  private static final Logger LOG = LoggerFactory.getLogger(FilesetS3WebIdentityCredentialIT.class);
+  private static final String WEB_IDENTITY_TOKEN = "configured-web-identity-token";
+
+  @TempDir private static Path tempDir;
+
+  private final AtomicReference<String> requestBody = new AtomicReference<>();
+
+  private HttpServer stsServer;
+  private Path webIdentityTokenFile;
+  private String metalakeName;
+  private String catalogName;
+  private String schemaName;
+  private String filesetName;
+  private GravitinoMetalake metalake;
+
+  @BeforeAll
+  public void startIntegrationTest() {
+    // Do nothing.
+  }
+
+  @BeforeAll
+  public void startUp() throws Exception {
+    copyBundleJarsToHadoop("aws-bundle");
+    stsServer = startFakeStsServer();
+    webIdentityTokenFile = tempDir.resolve("web-identity-token");
+    Files.write(webIdentityTokenFile, WEB_IDENTITY_TOKEN.getBytes(StandardCharsets.UTF_8));
+
+    super.startIntegrationTest();
+
+    metalakeName = GravitinoITUtils.genRandomName("web_identity_metalake");
+    catalogName = GravitinoITUtils.genRandomName("catalog");
+    schemaName = GravitinoITUtils.genRandomName("schema");
+    filesetName = GravitinoITUtils.genRandomName("fileset");
+
+    Assertions.assertFalse(client.metalakeExists(metalakeName));
+    metalake = client.createMetalake(metalakeName, "metalake comment", Collections.emptyMap());
+    Assertions.assertTrue(client.metalakeExists(metalakeName));
+
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put(FILESYSTEM_PROVIDERS, "s3");
+    properties.put("disable-filesystem-ops", "true");
+    properties.put(CredentialConstants.CREDENTIAL_CACHE_EXPIRE_RATIO, "0");
+    properties.put(
+        CredentialConstants.CREDENTIAL_PROVIDERS, AwsIrsaCredential.AWS_IRSA_CREDENTIAL_TYPE);
+    properties.put(S3Properties.GRAVITINO_S3_ROLE_ARN, "arn:aws:iam::123456789012:role/test-role");
+    properties.put(S3Properties.GRAVITINO_S3_REGION, "us-east-1");
+    properties.put(S3Properties.GRAVITINO_S3_STS_ENDPOINT, fakeStsEndpoint());
+    properties.put(WebIdentityTokenSourceConfig.SOURCE, "file");
+    properties.put(WebIdentityTokenSourceConfig.FILE_PATH, webIdentityTokenFile.toString());
+
+    Catalog catalog =
+        metalake.createCatalog(
+            catalogName, Catalog.Type.FILESET, "hadoop", "catalog comment", properties);
+    Assertions.assertTrue(metalake.catalogExists(catalogName));
+
+    catalog.asSchemas().createSchema(schemaName, "schema comment", properties);
+    Assertions.assertTrue(catalog.asSchemas().schemaExists(schemaName));
+    catalog
+        .asFilesetCatalog()
+        .createFileset(
+            NameIdentifier.of(schemaName, filesetName),
+            "fileset comment",
+            Fileset.Type.MANAGED,
+            storageLocation(),
+            ImmutableMap.of());
+  }
+
+  @AfterAll
+  public void tearDown() throws IOException {
+    try {
+      if (metalake != null && catalogName != null) {
+        Catalog catalog = metalake.loadCatalog(catalogName);
+        if (schemaName != null) {
+          catalog.asSchemas().dropSchema(schemaName, true);
+        }
+        metalake.dropCatalog(catalogName, true);
+      }
+      if (client != null && metalakeName != null) {
+        client.dropMetalake(metalakeName, true);
+      }
+    } finally {
+      if (client != null) {
+        client.close();
+        client = null;
+      }
+      if (stsServer != null) {
+        stsServer.stop(0);
+      }
+      try {
+        closer.close();
+      } catch (Exception e) {
+        LOG.error("Exception in closing CloseableGroup", e);
+      }
+    }
+  }
+
+  @Test
+  void testFilesetCredentialUsesFileWebIdentityTokenSource() {
+    requestBody.set(null);
+    Fileset fileset =
+        metalake
+            .loadCatalog(catalogName)
+            .asFilesetCatalog()
+            .loadFileset(NameIdentifier.of(schemaName, filesetName));
+
+    Credential[] credentials = fileset.supportsCredentials().getCredentials();
+
+    Assertions.assertEquals(1, credentials.length);
+    Assertions.assertInstanceOf(AwsIrsaCredential.class, credentials[0]);
+    assertFakeStsReceivedWebIdentityToken();
+    Assertions.assertTrue(decodedRequestBody().contains("Policy="));
+  }
+
+  @Test
+  void testGvfsCredentialProviderUsesFileWebIdentityTokenSource() {
+    requestBody.set(null);
+    DefaultGravitinoFileSystemCredentialsProvider provider =
+        new DefaultGravitinoFileSystemCredentialsProvider();
+    Configuration configuration = new Configuration();
+    configuration.set(
+        GravitinoVirtualFileSystemConfiguration.FS_GRAVITINO_SERVER_URI_KEY, serverUri);
+    configuration.set(
+        GravitinoVirtualFileSystemConfiguration.FS_GRAVITINO_CLIENT_METALAKE_KEY, metalakeName);
+    configuration.set(
+        GravitinoFileSystemCredentialsProvider.GVFS_NAME_IDENTIFIER,
+        NameIdentifier.of(metalakeName, catalogName, schemaName, filesetName).toString());
+    provider.setConf(configuration);
+
+    Credential[] credentials = provider.getCredentials();
+
+    Assertions.assertEquals(1, credentials.length);
+    Assertions.assertInstanceOf(AwsIrsaCredential.class, credentials[0]);
+    assertFakeStsReceivedWebIdentityToken();
+    Assertions.assertTrue(decodedRequestBody().contains("Policy="));
+  }
+
+  private HttpServer startFakeStsServer() throws IOException {
+    HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+    server.createContext("/", this::handleAssumeRoleWithWebIdentity);
+    server.start();
+    return server;
+  }
+
+  private void handleAssumeRoleWithWebIdentity(HttpExchange exchange) throws IOException {
+    requestBody.set(new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8));
+    byte[] response = assumeRoleWithWebIdentityResponse().getBytes(StandardCharsets.UTF_8);
+    exchange.getResponseHeaders().set("Content-Type", "text/xml");
+    exchange.sendResponseHeaders(200, response.length);
+    exchange.getResponseBody().write(response);
+    exchange.close();
+  }
+
+  private String fakeStsEndpoint() {
+    return "http://127.0.0.1:" + stsServer.getAddress().getPort();
+  }
+
+  private String storageLocation() {
+    return "s3a://bucket1/" + filesetName;
+  }
+
+  private void assertFakeStsReceivedWebIdentityToken() {
+    String decodedBody = decodedRequestBody();
+    Assertions.assertTrue(decodedBody.contains("Action=AssumeRoleWithWebIdentity"));
+    Assertions.assertTrue(decodedBody.contains("WebIdentityToken=" + WEB_IDENTITY_TOKEN));
+  }
+
+  private String decodedRequestBody() {
+    Assertions.assertNotNull(requestBody.get(), "Fake STS server did not receive a request");
+    return URLDecoder.decode(requestBody.get(), StandardCharsets.UTF_8);
+  }
+
+  private String assumeRoleWithWebIdentityResponse() {
+    return "<AssumeRoleWithWebIdentityResponse "
+        + "xmlns=\"https://sts.amazonaws.com/doc/2011-06-15/\">"
+        + "<AssumeRoleWithWebIdentityResult>"
+        + "<Credentials>"
+        + "<AccessKeyId>test-access-key</AccessKeyId>"
+        + "<SecretAccessKey>test-secret-key</SecretAccessKey>"
+        + "<SessionToken>test-session-token</SessionToken>"
+        + "<Expiration>2035-01-01T00:00:00Z</Expiration>"
+        + "</Credentials>"
+        + "<SubjectFromWebIdentityToken>subject</SubjectFromWebIdentityToken>"
+        + "<Audience>audience</Audience>"
+        + "<AssumedRoleUser>"
+        + "<Arn>arn:aws:sts::123456789012:assumed-role/test-role/session</Arn>"
+        + "<AssumedRoleId>test-role-id:test-session</AssumedRoleId>"
+        + "</AssumedRoleUser>"
+        + "</AssumeRoleWithWebIdentityResult>"
+        + "<ResponseMetadata><RequestId>test-request</RequestId></ResponseMetadata>"
+        + "</AssumeRoleWithWebIdentityResponse>";
+  }
+}

--- a/common/src/main/java/org/apache/gravitino/credential/CredentialPropertyUtils.java
+++ b/common/src/main/java/org/apache/gravitino/credential/CredentialPropertyUtils.java
@@ -122,7 +122,12 @@ public class CredentialPropertyUtils {
    */
   public static Credential[] getCredentials(Catalog catalog) {
     try {
-      return catalog.supportsCredentials().getCredentials();
+      SupportsCredentials supportsCredentials = catalog.supportsCredentials();
+      if (supportsCredentials == null) {
+        LOG.debug("Catalog returns null SupportsCredentials, skipping credential injection");
+        return new Credential[0];
+      }
+      return supportsCredentials.getCredentials();
     } catch (UnsupportedOperationException e) {
       LOG.debug("Catalog does not support credential vending, skipping injection", e);
       return new Credential[0];

--- a/common/src/test/java/org/apache/gravitino/credential/TestCredentialPropertiesUtils.java
+++ b/common/src/test/java/org/apache/gravitino/credential/TestCredentialPropertiesUtils.java
@@ -20,7 +20,10 @@
 package org.apache.gravitino.credential;
 
 import com.google.common.collect.ImmutableMap;
+import java.util.Collections;
 import java.util.Map;
+import org.apache.gravitino.Audit;
+import org.apache.gravitino.Catalog;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -146,5 +149,50 @@ public class TestCredentialPropertiesUtils {
         "v1/irc1/namespaces/db/tables/tbl/credentials",
         refreshEndpointProperties.get(
             CredentialPropertyUtils.ICEBERG_ADLS_REFRESH_CREDENTIALS_ENDPOINT));
+  }
+
+  @Test
+  void testGetCredentialsReturnsEmptyWhenSupportsCredentialsIsNull() {
+    Credential[] credentials = CredentialPropertyUtils.getCredentials(new NullSupportsCatalog());
+
+    Assertions.assertEquals(0, credentials.length);
+  }
+
+  private static class NullSupportsCatalog implements Catalog {
+
+    @Override
+    public String name() {
+      return "catalog";
+    }
+
+    @Override
+    public Type type() {
+      return Type.RELATIONAL;
+    }
+
+    @Override
+    public String provider() {
+      return "provider";
+    }
+
+    @Override
+    public String comment() {
+      return "comment";
+    }
+
+    @Override
+    public Map<String, String> properties() {
+      return Collections.emptyMap();
+    }
+
+    @Override
+    public Audit auditInfo() {
+      return null;
+    }
+
+    @Override
+    public SupportsCredentials supportsCredentials() {
+      return null;
+    }
   }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -167,12 +167,14 @@ ql-expression = "4.0.3"
 
 [libraries]
 aspectj-aspectjrt = { group = "org.aspectj", name = "aspectjrt", version.ref = "aspectj" }
+aws-auth = { group = "software.amazon.awssdk", name = "auth", version.ref = "awssdk" }
 aws-dynamodb = { group = "software.amazon.awssdk", name = "dynamodb", version.ref = "awssdk" }
 aws-glue = { group = "software.amazon.awssdk", name = "glue", version.ref = "awssdk" }
 aws-iam = { group = "software.amazon.awssdk", name = "iam", version.ref = "awssdk" }
 aws-policy = { group = "software.amazon.awssdk", name = "iam-policy-builder", version.ref = "awssdk" }
 aws-s3 = { group = "software.amazon.awssdk", name = "s3", version.ref = "awssdk" }
 aws-sts = { group = "software.amazon.awssdk", name = "sts", version.ref = "awssdk" }
+aws-utils = { group = "software.amazon.awssdk", name = "utils", version.ref = "awssdk" }
 aws-kms = { group = "software.amazon.awssdk", name = "kms", version.ref = "awssdk" }
 azure-identity = { group = "com.azure", name = "azure-identity", version.ref = "azure-identity"}
 azure-storage-file-datalake = { group = "com.azure", name = "azure-storage-file-datalake", version.ref = "azure-storage-file-datalake"}

--- a/iceberg/iceberg-common/build.gradle.kts
+++ b/iceberg/iceberg-common/build.gradle.kts
@@ -44,6 +44,9 @@ dependencies {
   implementation(project(":common")) {
     exclude("*")
   }
+  implementation(project(":clients:client-java")) {
+    exclude("*")
+  }
   implementation(libs.bundles.iceberg)
   implementation(libs.bundles.log4j)
   implementation(libs.bundles.kerby) {
@@ -55,6 +58,8 @@ dependencies {
     exclude("org.ow2.asm")
   }
   implementation(libs.asm)
+  implementation(libs.aws.auth)
+  implementation(libs.aws.utils)
   implementation(libs.commons.lang3)
   implementation(libs.guava)
   implementation(libs.iceberg.aliyun)

--- a/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/credential/GravitinoIcebergAwsCredentialsProvider.java
+++ b/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/credential/GravitinoIcebergAwsCredentialsProvider.java
@@ -1,0 +1,272 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.iceberg.common.credential;
+
+import com.google.common.base.Preconditions;
+import java.io.Closeable;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.gravitino.Catalog;
+import org.apache.gravitino.catalog.lakehouse.iceberg.IcebergConstants;
+import org.apache.gravitino.client.DefaultOAuth2TokenProvider;
+import org.apache.gravitino.client.GravitinoClient;
+import org.apache.gravitino.credential.AwsIrsaCredential;
+import org.apache.gravitino.credential.CatalogCredentialContext;
+import org.apache.gravitino.credential.CatalogCredentialManager;
+import org.apache.gravitino.credential.Credential;
+import org.apache.gravitino.credential.CredentialPropertyUtils;
+import org.apache.gravitino.credential.S3SecretKeyCredential;
+import org.apache.gravitino.credential.S3TokenCredential;
+import org.apache.gravitino.credential.config.CredentialConfig;
+import org.apache.gravitino.utils.PrincipalUtils;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
+import software.amazon.awssdk.utils.SdkAutoCloseable;
+
+/**
+ * AWS SDK v2 credentials provider for Iceberg server-side S3 FileIO.
+ *
+ * <p>Iceberg loads this class through {@code client.credentials-provider}. The provider refreshes
+ * Gravitino-vended S3 credentials before they expire instead of pinning a static session token in
+ * the long-lived Iceberg catalog configuration.
+ */
+public class GravitinoIcebergAwsCredentialsProvider
+    implements AwsCredentialsProvider, SdkAutoCloseable {
+
+  /** Property that selects the backing credential source. */
+  public static final String SOURCE = "credential-source";
+
+  /** Source that generates credentials in the current JVM with {@link CatalogCredentialManager}. */
+  public static final String SOURCE_LOCAL = "local";
+
+  /** Source that refreshes credentials through the Gravitino REST client. */
+  public static final String SOURCE_REMOTE = "remote";
+
+  /** Catalog name used for credential generation. */
+  public static final String CATALOG_NAME = "catalog-name";
+
+  private static final double REFRESH_TIME_FACTOR = 0.5D;
+  private static final String SIMPLE_AUTH_TYPE = "simple";
+  private static final String OAUTH2_AUTH_TYPE = "oauth2";
+
+  private final CredentialSupplier credentialSupplier;
+
+  private volatile AwsCredentials cachedCredentials;
+  private volatile long refreshTimeInMs;
+
+  private GravitinoIcebergAwsCredentialsProvider(CredentialSupplier credentialSupplier) {
+    this.credentialSupplier = credentialSupplier;
+  }
+
+  /**
+   * Creates a Gravitino Iceberg AWS credentials provider.
+   *
+   * @param properties Iceberg {@code client.credentials-provider.*} properties with the prefix
+   *     stripped
+   * @return AWS credentials provider
+   */
+  public static AwsCredentialsProvider create(Map<String, String> properties) {
+    Preconditions.checkArgument(
+        properties != null, "Credential provider properties must not be null");
+    String source = properties.getOrDefault(SOURCE, SOURCE_LOCAL);
+    if (SOURCE_LOCAL.equalsIgnoreCase(source)) {
+      return new GravitinoIcebergAwsCredentialsProvider(new LocalCredentialSupplier(properties));
+    } else if (SOURCE_REMOTE.equalsIgnoreCase(source)) {
+      return new GravitinoIcebergAwsCredentialsProvider(new RemoteCredentialSupplier(properties));
+    }
+
+    throw new IllegalArgumentException("Unsupported Gravitino credential source: " + source);
+  }
+
+  @Override
+  public AwsCredentials resolveCredentials() {
+    long now = System.currentTimeMillis();
+    AwsCredentials credentials = cachedCredentials;
+    if (credentials != null && now < refreshTimeInMs) {
+      return credentials;
+    }
+
+    synchronized (this) {
+      now = System.currentTimeMillis();
+      credentials = cachedCredentials;
+      if (credentials != null && now < refreshTimeInMs) {
+        return credentials;
+      }
+
+      Credential gravitinoCredential = selectS3Credential(credentialSupplier.getCredentials());
+      credentials = toAwsCredentials(gravitinoCredential);
+      cachedCredentials = credentials;
+      refreshTimeInMs = calculateRefreshTimeInMs(gravitinoCredential.expireTimeInMs(), now);
+      return credentials;
+    }
+  }
+
+  @Override
+  public void close() {
+    try {
+      credentialSupplier.close();
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to close Gravitino Iceberg AWS credentials provider", e);
+    }
+  }
+
+  private static long calculateRefreshTimeInMs(long expireTimeInMs, long now) {
+    if (expireTimeInMs <= 0) {
+      return Long.MAX_VALUE;
+    }
+
+    long timeToExpire = expireTimeInMs - now;
+    if (timeToExpire <= 0) {
+      return now;
+    }
+
+    return now + (long) (timeToExpire * REFRESH_TIME_FACTOR);
+  }
+
+  private static Credential selectS3Credential(Credential[] credentials) {
+    Credential selected = null;
+    for (Credential credential : credentials) {
+      if (credential instanceof S3TokenCredential || credential instanceof AwsIrsaCredential) {
+        selected = credential;
+      } else if (selected == null && credential instanceof S3SecretKeyCredential) {
+        selected = credential;
+      }
+    }
+
+    if (selected == null) {
+      throw new IllegalStateException("No S3 credential found for Iceberg server-side FileIO");
+    }
+    return selected;
+  }
+
+  private static AwsCredentials toAwsCredentials(Credential credential) {
+    if (credential instanceof S3TokenCredential) {
+      S3TokenCredential s3 = (S3TokenCredential) credential;
+      return AwsSessionCredentials.builder()
+          .accessKeyId(s3.accessKeyId())
+          .secretAccessKey(s3.secretAccessKey())
+          .sessionToken(s3.sessionToken())
+          .expirationTime(Instant.ofEpochMilli(s3.expireTimeInMs()))
+          .build();
+    } else if (credential instanceof AwsIrsaCredential) {
+      AwsIrsaCredential irsa = (AwsIrsaCredential) credential;
+      return AwsSessionCredentials.builder()
+          .accessKeyId(irsa.accessKeyId())
+          .secretAccessKey(irsa.secretAccessKey())
+          .sessionToken(irsa.sessionToken())
+          .expirationTime(Instant.ofEpochMilli(irsa.expireTimeInMs()))
+          .build();
+    } else if (credential instanceof S3SecretKeyCredential) {
+      S3SecretKeyCredential s3 = (S3SecretKeyCredential) credential;
+      return AwsBasicCredentials.create(s3.accessKeyId(), s3.secretAccessKey());
+    }
+
+    throw new IllegalArgumentException("Unsupported S3 credential: " + credential.credentialType());
+  }
+
+  private interface CredentialSupplier extends Closeable {
+    Credential[] getCredentials();
+  }
+
+  private static class LocalCredentialSupplier implements CredentialSupplier {
+    private final CatalogCredentialManager credentialManager;
+    private final List<String> credentialProviders;
+
+    LocalCredentialSupplier(Map<String, String> properties) {
+      String catalogName = required(properties, CATALOG_NAME);
+      this.credentialManager = new CatalogCredentialManager(catalogName, properties);
+      this.credentialProviders =
+          new CredentialConfig(properties).get(CredentialConfig.CREDENTIAL_PROVIDERS);
+    }
+
+    @Override
+    public Credential[] getCredentials() {
+      CatalogCredentialContext context =
+          new CatalogCredentialContext(PrincipalUtils.getCurrentUserName());
+      List<Credential> credentials = new ArrayList<>();
+      for (String credentialProvider : credentialProviders) {
+        credentialManager.getCredential(credentialProvider, context).ifPresent(credentials::add);
+      }
+      return credentials.toArray(new Credential[0]);
+    }
+
+    @Override
+    public void close() {
+      credentialManager.close();
+    }
+  }
+
+  private static class RemoteCredentialSupplier implements CredentialSupplier {
+    private final GravitinoClient client;
+    private final String catalogName;
+
+    RemoteCredentialSupplier(Map<String, String> properties) {
+      this.catalogName = required(properties, CATALOG_NAME);
+      this.client = createGravitinoClient(properties);
+    }
+
+    @Override
+    public Credential[] getCredentials() {
+      Catalog catalog = client.loadCatalog(catalogName);
+      return CredentialPropertyUtils.getCredentials(catalog);
+    }
+
+    @Override
+    public void close() {
+      client.close();
+    }
+  }
+
+  private static GravitinoClient createGravitinoClient(Map<String, String> properties) {
+    GravitinoClient.ClientBuilder builder =
+        GravitinoClient.builder(required(properties, IcebergConstants.GRAVITINO_URI))
+            .withMetalake(required(properties, IcebergConstants.GRAVITINO_METALAKE));
+    String authType =
+        properties.getOrDefault(IcebergConstants.GRAVITINO_AUTH_TYPE, SIMPLE_AUTH_TYPE);
+    if (SIMPLE_AUTH_TYPE.equalsIgnoreCase(authType)) {
+      builder.withSimpleAuth(
+          properties.getOrDefault(
+              IcebergConstants.GRAVITINO_SIMPLE_USERNAME, "iceberg-rest-server"));
+    } else if (OAUTH2_AUTH_TYPE.equalsIgnoreCase(authType)) {
+      DefaultOAuth2TokenProvider oAuth2TokenProvider =
+          DefaultOAuth2TokenProvider.builder()
+              .withUri(required(properties, IcebergConstants.GRAVITINO_OAUTH2_SERVER_URI))
+              .withCredential(required(properties, IcebergConstants.GRAVITINO_OAUTH2_CREDENTIAL))
+              .withPath(required(properties, IcebergConstants.GRAVITINO_OAUTH2_TOKEN_PATH))
+              .withScope(required(properties, IcebergConstants.GRAVITINO_OAUTH2_SCOPE))
+              .build();
+      builder.withOAuth(oAuth2TokenProvider);
+    } else {
+      throw new UnsupportedOperationException("Unsupported auth type: " + authType);
+    }
+    return builder.build();
+  }
+
+  private static String required(Map<String, String> properties, String key) {
+    String value = properties.get(key);
+    Preconditions.checkArgument(StringUtils.isNotBlank(value), key + " should not be empty");
+    return value;
+  }
+}

--- a/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/credential/IcebergServerCredentialUtils.java
+++ b/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/credential/IcebergServerCredentialUtils.java
@@ -66,13 +66,18 @@ public final class IcebergServerCredentialUtils {
         GravitinoIcebergAwsCredentialsProvider.SOURCE,
         GravitinoIcebergAwsCredentialsProvider.SOURCE_LOCAL);
 
+    boolean hasRefreshableAwsCredential = false;
     for (Credential credential : credentials) {
       if (isExpiringS3Credential(credential)) {
-        configureRefreshableAwsProvider(effectiveProviderProperties, targetProperties);
+        hasRefreshableAwsCredential = true;
       } else {
         CredentialPropertyUtils.applyIcebergCredentials(
             new Credential[] {credential}, targetProperties);
       }
+    }
+
+    if (hasRefreshableAwsCredential) {
+      configureRefreshableAwsProvider(effectiveProviderProperties, targetProperties);
     }
   }
 

--- a/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/credential/IcebergServerCredentialUtils.java
+++ b/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/credential/IcebergServerCredentialUtils.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.iceberg.common.credential;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.gravitino.credential.AwsIrsaCredential;
+import org.apache.gravitino.credential.Credential;
+import org.apache.gravitino.credential.CredentialPropertyUtils;
+import org.apache.gravitino.credential.S3TokenCredential;
+
+/** Utilities for applying Gravitino credentials to server-side Iceberg catalog properties. */
+public final class IcebergServerCredentialUtils {
+
+  /** Iceberg property that names an AWS SDK v2 credentials provider class. */
+  public static final String CLIENT_CREDENTIALS_PROVIDER = "client.credentials-provider";
+
+  /** Prefix stripped by Iceberg before passing properties to the credentials provider. */
+  public static final String CLIENT_CREDENTIALS_PROVIDER_PREFIX = "client.credentials-provider.";
+
+  private static final String ICEBERG_S3_ACCESS_KEY_ID = "s3.access-key-id";
+  private static final String ICEBERG_S3_SECRET_ACCESS_KEY = "s3.secret-access-key";
+  private static final String ICEBERG_S3_SESSION_TOKEN = "s3.session-token";
+  private static final String ICEBERG_S3_SESSION_TOKEN_EXPIRES_AT_MS =
+      "s3.session-token-expires-at-ms";
+
+  /**
+   * Applies credentials to Iceberg catalog properties.
+   *
+   * <p>Expiring S3 credentials are represented by a refreshable AWS SDK credentials provider;
+   * non-expiring and non-S3 credentials are converted to regular Iceberg properties.
+   *
+   * @param catalogName catalog name
+   * @param credentials credentials to apply
+   * @param credentialProviderProperties properties passed to the refreshable provider
+   * @param targetProperties mutable Iceberg catalog properties
+   */
+  public static void applyCredentials(
+      String catalogName,
+      Credential[] credentials,
+      Map<String, String> credentialProviderProperties,
+      Map<String, String> targetProperties) {
+    Map<String, String> effectiveProviderProperties = new HashMap<>();
+    if (credentialProviderProperties != null) {
+      effectiveProviderProperties.putAll(credentialProviderProperties);
+    }
+    effectiveProviderProperties.put(
+        GravitinoIcebergAwsCredentialsProvider.CATALOG_NAME, catalogName);
+    effectiveProviderProperties.putIfAbsent(
+        GravitinoIcebergAwsCredentialsProvider.SOURCE,
+        GravitinoIcebergAwsCredentialsProvider.SOURCE_LOCAL);
+
+    for (Credential credential : credentials) {
+      if (isExpiringS3Credential(credential)) {
+        configureRefreshableAwsProvider(effectiveProviderProperties, targetProperties);
+      } else {
+        CredentialPropertyUtils.applyIcebergCredentials(
+            new Credential[] {credential}, targetProperties);
+      }
+    }
+  }
+
+  /**
+   * Returns whether the credentials include an expiring S3 credential that needs a refreshable AWS
+   * credentials provider.
+   *
+   * @param credentials credentials to inspect
+   * @return true if a refreshable AWS credentials provider is needed
+   */
+  public static boolean hasRefreshableAwsCredential(Credential[] credentials) {
+    for (Credential credential : credentials) {
+      if (isExpiringS3Credential(credential)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static boolean isExpiringS3Credential(Credential credential) {
+    return credential instanceof S3TokenCredential || credential instanceof AwsIrsaCredential;
+  }
+
+  private static void configureRefreshableAwsProvider(
+      Map<String, String> credentialProviderProperties, Map<String, String> targetProperties) {
+    targetProperties.remove(ICEBERG_S3_ACCESS_KEY_ID);
+    targetProperties.remove(ICEBERG_S3_SECRET_ACCESS_KEY);
+    targetProperties.remove(ICEBERG_S3_SESSION_TOKEN);
+    targetProperties.remove(ICEBERG_S3_SESSION_TOKEN_EXPIRES_AT_MS);
+    targetProperties.put(
+        CLIENT_CREDENTIALS_PROVIDER, GravitinoIcebergAwsCredentialsProvider.class.getName());
+    credentialProviderProperties.forEach(
+        (key, value) -> targetProperties.put(CLIENT_CREDENTIALS_PROVIDER_PREFIX + key, value));
+  }
+
+  private IcebergServerCredentialUtils() {}
+}

--- a/iceberg/iceberg-common/src/test/java/org/apache/gravitino/iceberg/common/credential/TestGravitinoIcebergAwsCredentialsProvider.java
+++ b/iceberg/iceberg-common/src/test/java/org/apache/gravitino/iceberg/common/credential/TestGravitinoIcebergAwsCredentialsProvider.java
@@ -21,7 +21,9 @@ package org.apache.gravitino.iceberg.common.credential;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.gravitino.credential.AwsIrsaCredential;
+import org.apache.gravitino.credential.Credential;
 import org.apache.gravitino.credential.CredentialConstants;
+import org.apache.gravitino.credential.S3SecretKeyCredential;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
@@ -63,6 +65,26 @@ public class TestGravitinoIcebergAwsCredentialsProvider {
         targetProperties.get(
             IcebergServerCredentialUtils.CLIENT_CREDENTIALS_PROVIDER_PREFIX
                 + "custom-hidden-property"));
+    Assertions.assertFalse(targetProperties.containsKey("s3.access-key-id"));
+    Assertions.assertFalse(targetProperties.containsKey("s3.secret-access-key"));
+    Assertions.assertFalse(targetProperties.containsKey("s3.session-token"));
+  }
+
+  @Test
+  void testApplyCredentialsPrefersRefreshableProviderOverStaticS3Credentials() {
+    Credential[] credentials =
+        new Credential[] {
+          new AwsIrsaCredential("access-key", "secret-key", "session-token", 123),
+          new S3SecretKeyCredential("static-access-key", "static-secret-key")
+        };
+    Map<String, String> targetProperties = new HashMap<>();
+
+    IcebergServerCredentialUtils.applyCredentials(
+        "catalog", credentials, new HashMap<>(), targetProperties);
+
+    Assertions.assertEquals(
+        GravitinoIcebergAwsCredentialsProvider.class.getName(),
+        targetProperties.get(IcebergServerCredentialUtils.CLIENT_CREDENTIALS_PROVIDER));
     Assertions.assertFalse(targetProperties.containsKey("s3.access-key-id"));
     Assertions.assertFalse(targetProperties.containsKey("s3.secret-access-key"));
     Assertions.assertFalse(targetProperties.containsKey("s3.session-token"));

--- a/iceberg/iceberg-common/src/test/java/org/apache/gravitino/iceberg/common/credential/TestGravitinoIcebergAwsCredentialsProvider.java
+++ b/iceberg/iceberg-common/src/test/java/org/apache/gravitino/iceberg/common/credential/TestGravitinoIcebergAwsCredentialsProvider.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.iceberg.common.credential;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.gravitino.credential.AwsIrsaCredential;
+import org.apache.gravitino.credential.CredentialConstants;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
+
+public class TestGravitinoIcebergAwsCredentialsProvider {
+
+  @Test
+  void testApplyCredentialsUsesRefreshableProviderForExpiringS3Credentials() {
+    Map<String, String> sourceProperties = new HashMap<>();
+    sourceProperties.put(
+        CredentialConstants.CREDENTIAL_PROVIDERS, TestRefreshingS3CredentialProvider.TYPE);
+    sourceProperties.put("custom-hidden-property", "hidden-value");
+    Map<String, String> targetProperties = new HashMap<>();
+
+    IcebergServerCredentialUtils.applyCredentials(
+        "catalog",
+        new AwsIrsaCredential[] {
+          new AwsIrsaCredential("access-key", "secret-key", "session-token", 123)
+        },
+        sourceProperties,
+        targetProperties);
+
+    Assertions.assertEquals(
+        GravitinoIcebergAwsCredentialsProvider.class.getName(),
+        targetProperties.get(IcebergServerCredentialUtils.CLIENT_CREDENTIALS_PROVIDER));
+    Assertions.assertEquals(
+        "catalog",
+        targetProperties.get(
+            IcebergServerCredentialUtils.CLIENT_CREDENTIALS_PROVIDER_PREFIX
+                + GravitinoIcebergAwsCredentialsProvider.CATALOG_NAME));
+    Assertions.assertEquals(
+        TestRefreshingS3CredentialProvider.TYPE,
+        targetProperties.get(
+            IcebergServerCredentialUtils.CLIENT_CREDENTIALS_PROVIDER_PREFIX
+                + CredentialConstants.CREDENTIAL_PROVIDERS));
+    Assertions.assertEquals(
+        "hidden-value",
+        targetProperties.get(
+            IcebergServerCredentialUtils.CLIENT_CREDENTIALS_PROVIDER_PREFIX
+                + "custom-hidden-property"));
+    Assertions.assertFalse(targetProperties.containsKey("s3.access-key-id"));
+    Assertions.assertFalse(targetProperties.containsKey("s3.secret-access-key"));
+    Assertions.assertFalse(targetProperties.containsKey("s3.session-token"));
+  }
+
+  @Test
+  void testLocalProviderRefreshesExpiredCredential() {
+    TestRefreshingS3CredentialProvider.reset();
+    Map<String, String> properties = new HashMap<>();
+    properties.put(
+        GravitinoIcebergAwsCredentialsProvider.SOURCE,
+        GravitinoIcebergAwsCredentialsProvider.SOURCE_LOCAL);
+    properties.put(GravitinoIcebergAwsCredentialsProvider.CATALOG_NAME, "catalog");
+    properties.put(
+        CredentialConstants.CREDENTIAL_PROVIDERS, TestRefreshingS3CredentialProvider.TYPE);
+    properties.put(CredentialConstants.CREDENTIAL_CACHE_EXPIRE_RATIO, "0");
+
+    TestRefreshingS3CredentialProvider.setExpireTimeInMs(System.currentTimeMillis() + 1);
+    AwsCredentialsProvider provider = GravitinoIcebergAwsCredentialsProvider.create(properties);
+    AwsSessionCredentials first = (AwsSessionCredentials) provider.resolveCredentials();
+
+    TestRefreshingS3CredentialProvider.setExpireTimeInMs(System.currentTimeMillis() + 60_000);
+    AwsSessionCredentials second = (AwsSessionCredentials) provider.resolveCredentials();
+
+    Assertions.assertEquals("access-key-1", first.accessKeyId());
+    Assertions.assertEquals("access-key-2", second.accessKeyId());
+    Assertions.assertEquals(2, TestRefreshingS3CredentialProvider.generatedCount());
+  }
+}

--- a/iceberg/iceberg-common/src/test/java/org/apache/gravitino/iceberg/common/credential/TestRefreshingS3CredentialProvider.java
+++ b/iceberg/iceberg-common/src/test/java/org/apache/gravitino/iceberg/common/credential/TestRefreshingS3CredentialProvider.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.iceberg.common.credential;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.gravitino.credential.CatalogCredentialContext;
+import org.apache.gravitino.credential.Credential;
+import org.apache.gravitino.credential.CredentialContext;
+import org.apache.gravitino.credential.CredentialProvider;
+import org.apache.gravitino.credential.S3TokenCredential;
+
+/** Test credential provider that emits a new S3 session credential on each request. */
+public class TestRefreshingS3CredentialProvider implements CredentialProvider {
+
+  /** Test credential provider type. */
+  public static final String TYPE = "test-refreshing-s3-token";
+
+  private static final AtomicInteger GENERATED_COUNT = new AtomicInteger();
+  private static volatile long expireTimeInMs = System.currentTimeMillis() + 60_000;
+
+  /** Resets this provider's test state. */
+  public static void reset() {
+    GENERATED_COUNT.set(0);
+    expireTimeInMs = System.currentTimeMillis() + 60_000;
+  }
+
+  /**
+   * Sets the expiration time returned by subsequently generated credentials.
+   *
+   * @param expireTimeInMs expiration time in milliseconds
+   */
+  public static void setExpireTimeInMs(long expireTimeInMs) {
+    TestRefreshingS3CredentialProvider.expireTimeInMs = expireTimeInMs;
+  }
+
+  /**
+   * Returns the number of generated credentials.
+   *
+   * @return generated credential count
+   */
+  public static int generatedCount() {
+    return GENERATED_COUNT.get();
+  }
+
+  @Override
+  public void initialize(Map<String, String> properties) {}
+
+  @Override
+  public String credentialType() {
+    return TYPE;
+  }
+
+  @Override
+  public Credential getCredential(CredentialContext context) {
+    if (!(context instanceof CatalogCredentialContext)) {
+      return null;
+    }
+
+    int id = GENERATED_COUNT.incrementAndGet();
+    return new S3TokenCredential(
+        "access-key-" + id, "secret-key-" + id, "session-token-" + id, expireTimeInMs);
+  }
+
+  @Override
+  public void close() {}
+}

--- a/iceberg/iceberg-common/src/test/resources/META-INF/services/org.apache.gravitino.credential.CredentialProvider
+++ b/iceberg/iceberg-common/src/test/resources/META-INF/services/org.apache.gravitino.credential.CredentialProvider
@@ -1,0 +1,19 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+org.apache.gravitino.iceberg.common.credential.TestRefreshingS3CredentialProvider

--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/provider/DynamicIcebergConfigProvider.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/provider/DynamicIcebergConfigProvider.java
@@ -23,8 +23,9 @@ import static org.apache.gravitino.connector.BaseCatalog.CATALOG_BYPASS_PREFIX;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import java.io.Closeable;
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import org.apache.commons.lang3.StringUtils;
@@ -38,14 +39,17 @@ import org.apache.gravitino.client.DefaultOAuth2TokenProvider;
 import org.apache.gravitino.client.GravitinoClient;
 import org.apache.gravitino.client.GravitinoClient.ClientBuilder;
 import org.apache.gravitino.connector.BaseCatalog;
-import org.apache.gravitino.credential.JdbcCredential;
-import org.apache.gravitino.credential.SupportsCredentials;
+import org.apache.gravitino.credential.CatalogCredentialContext;
+import org.apache.gravitino.credential.Credential;
+import org.apache.gravitino.credential.CredentialPropertyUtils;
+import org.apache.gravitino.credential.CredentialUtils;
 import org.apache.gravitino.exceptions.NoSuchCatalogException;
 import org.apache.gravitino.iceberg.common.IcebergConfig;
 import org.apache.gravitino.iceberg.service.authorization.IcebergRESTServerContext;
 import org.apache.gravitino.server.web.JettyServerConfig;
 import org.apache.gravitino.utils.MapUtils;
 import org.apache.gravitino.utils.NameIdentifierUtil;
+import org.apache.gravitino.utils.PrincipalUtils;
 
 /**
  * This provider proxy Gravitino lakehouse-iceberg catalogs.
@@ -104,36 +108,48 @@ public class DynamicIcebergConfigProvider implements IcebergConfigProvider {
         "lakehouse-iceberg".equals(catalog.provider()),
         String.format("%s.%s is not iceberg catalog", gravitinoMetalake, catalogName));
 
-    // Sensitive credentials (e.g. jdbc-password) are marked hidden in PropertiesMetadata and
-    // filtered out of catalog.properties(). We need two different strategies to recover them:
+    // Sensitive credentials are marked hidden in PropertiesMetadata and filtered out of
+    // catalog.properties(). We need two different strategies to recover them:
     //
     // Auxiliary mode: the catalog is a BaseCatalog running in the same JVM as the Gravitino
     // server. Call propertiesWithCredentialProviders() which returns the raw entity properties
-    // including all hidden fields.
+    // including all hidden fields, then generate credentials locally.
     //
     // Standalone mode: the catalog is a client-side object obtained via the Gravitino REST API.
-    // Call getCredentials() to retrieve vended credentials, then inject any JdbcCredential
-    // fields into the properties map so the JDBC backend can connect.
+    // Call supportsCredentials().getCredentials() to retrieve vended credentials.
     Map<String, String> catalogProperties;
     if (catalog instanceof BaseCatalog) {
       catalogProperties = ((BaseCatalog<?>) catalog).propertiesWithCredentialProviders();
     } else {
       catalogProperties = new HashMap<>(catalog.properties());
-      if (catalog instanceof SupportsCredentials) {
-        Arrays.stream(((SupportsCredentials) catalog).getCredentials())
-            .filter(c -> c instanceof JdbcCredential)
-            .map(c -> (JdbcCredential) c)
-            .findFirst()
-            .ifPresent(
-                jdbc -> {
-                  catalogProperties.putIfAbsent(
-                      IcebergConstants.GRAVITINO_JDBC_USER, jdbc.jdbcUser());
-                  catalogProperties.putIfAbsent(
-                      IcebergConstants.GRAVITINO_JDBC_PASSWORD, jdbc.jdbcPassword());
-                });
-      }
     }
+    CredentialPropertyUtils.applyIcebergCredentials(
+        getCatalogCredentials(catalog, catalogProperties), catalogProperties);
     return Optional.of(getIcebergConfigFromCatalogProperties(catalogProperties));
+  }
+
+  private static Credential[] getCatalogCredentials(
+      Catalog catalog, Map<String, String> catalogProperties) {
+    if (catalog instanceof BaseCatalog) {
+      return getInternalCatalogCredentials((BaseCatalog<?>) catalog, catalogProperties);
+    }
+
+    return CredentialPropertyUtils.getCredentials(catalog);
+  }
+
+  private static Credential[] getInternalCatalogCredentials(
+      BaseCatalog<?> catalog, Map<String, String> catalogProperties) {
+    List<Credential> credentials = new ArrayList<>();
+    CatalogCredentialContext context =
+        new CatalogCredentialContext(PrincipalUtils.getCurrentUserName());
+    for (String credentialType :
+        CredentialUtils.getCredentialProvidersByOrder(() -> catalogProperties)) {
+      catalog
+          .catalogCredentialManager()
+          .getCredential(credentialType, context)
+          .ifPresent(credentials::add);
+    }
+    return credentials.toArray(new Credential[0]);
   }
 
   /**

--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/provider/DynamicIcebergConfigProvider.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/provider/DynamicIcebergConfigProvider.java
@@ -42,9 +42,11 @@ import org.apache.gravitino.connector.BaseCatalog;
 import org.apache.gravitino.credential.CatalogCredentialContext;
 import org.apache.gravitino.credential.Credential;
 import org.apache.gravitino.credential.CredentialPropertyUtils;
-import org.apache.gravitino.credential.CredentialUtils;
+import org.apache.gravitino.credential.config.CredentialConfig;
 import org.apache.gravitino.exceptions.NoSuchCatalogException;
 import org.apache.gravitino.iceberg.common.IcebergConfig;
+import org.apache.gravitino.iceberg.common.credential.GravitinoIcebergAwsCredentialsProvider;
+import org.apache.gravitino.iceberg.common.credential.IcebergServerCredentialUtils;
 import org.apache.gravitino.iceberg.service.authorization.IcebergRESTServerContext;
 import org.apache.gravitino.server.web.JettyServerConfig;
 import org.apache.gravitino.utils.MapUtils;
@@ -123,9 +125,30 @@ public class DynamicIcebergConfigProvider implements IcebergConfigProvider {
     } else {
       catalogProperties = new HashMap<>(catalog.properties());
     }
-    CredentialPropertyUtils.applyIcebergCredentials(
-        getCatalogCredentials(catalog, catalogProperties), catalogProperties);
+    Credential[] credentials = getCatalogCredentials(catalog, catalogProperties);
+    Map<String, String> credentialProviderProperties =
+        IcebergServerCredentialUtils.hasRefreshableAwsCredential(credentials)
+            ? getCredentialProviderProperties(catalog, catalogProperties, catalogName)
+            : null;
+    IcebergServerCredentialUtils.applyCredentials(
+        catalogName, credentials, credentialProviderProperties, catalogProperties);
     return Optional.of(getIcebergConfigFromCatalogProperties(catalogProperties));
+  }
+
+  private Map<String, String> getCredentialProviderProperties(
+      Catalog catalog, Map<String, String> catalogProperties, String catalogName) {
+    if (catalog instanceof BaseCatalog) {
+      return catalogProperties;
+    }
+
+    Map<String, String> providerProperties = new HashMap<>(properties);
+    providerProperties.put(
+        GravitinoIcebergAwsCredentialsProvider.SOURCE,
+        GravitinoIcebergAwsCredentialsProvider.SOURCE_REMOTE);
+    providerProperties.put(IcebergConstants.GRAVITINO_URI, getGravitinoUri());
+    providerProperties.put(IcebergConstants.GRAVITINO_METALAKE, gravitinoMetalake);
+    providerProperties.put(GravitinoIcebergAwsCredentialsProvider.CATALOG_NAME, catalogName);
+    return providerProperties;
   }
 
   private static Credential[] getCatalogCredentials(
@@ -143,7 +166,7 @@ public class DynamicIcebergConfigProvider implements IcebergConfigProvider {
     CatalogCredentialContext context =
         new CatalogCredentialContext(PrincipalUtils.getCurrentUserName());
     for (String credentialType :
-        CredentialUtils.getCredentialProvidersByOrder(() -> catalogProperties)) {
+        new CredentialConfig(catalogProperties).get(CredentialConfig.CREDENTIAL_PROVIDERS)) {
       catalog
           .catalogCredentialManager()
           .getCredential(credentialType, context)
@@ -166,21 +189,25 @@ public class DynamicIcebergConfigProvider implements IcebergConfigProvider {
         if (serverContext.isAuxMode()) {
           catalogFetcher = new InternalCatalogFetcher(gravitinoMetalake);
         } else {
-          String uri = properties.get(IcebergConstants.GRAVITINO_URI);
-          if (StringUtils.isBlank(uri)) {
-            JettyServerConfig config =
-                JettyServerConfig.fromConfig(
-                    GravitinoEnv.getInstance().config(),
-                    JettyServerConfig.GRAVITINO_SERVER_CONFIG_PREFIX);
-            uri = String.format("http://%s:%d", config.getHost(), config.getHttpPort());
-          }
-          Preconditions.checkArgument(
-              StringUtils.isNotBlank(uri), IcebergConstants.GRAVITINO_URI + " is blank");
-          catalogFetcher = new HttpCatalogFetcher(uri, gravitinoMetalake, properties);
+          catalogFetcher = new HttpCatalogFetcher(getGravitinoUri(), gravitinoMetalake, properties);
         }
       }
     }
     return catalogFetcher;
+  }
+
+  private String getGravitinoUri() {
+    String uri = properties.get(IcebergConstants.GRAVITINO_URI);
+    if (StringUtils.isBlank(uri)) {
+      JettyServerConfig config =
+          JettyServerConfig.fromConfig(
+              GravitinoEnv.getInstance().config(),
+              JettyServerConfig.GRAVITINO_SERVER_CONFIG_PREFIX);
+      uri = String.format("http://%s:%d", config.getHost(), config.getHttpPort());
+    }
+    Preconditions.checkArgument(
+        StringUtils.isNotBlank(uri), IcebergConstants.GRAVITINO_URI + " is blank");
+    return uri;
   }
 
   @Override

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/provider/TestDynamicIcebergConfigProvider.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/provider/TestDynamicIcebergConfigProvider.java
@@ -35,6 +35,8 @@ import org.apache.gravitino.GravitinoEnv;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.catalog.CatalogDispatcher;
 import org.apache.gravitino.catalog.lakehouse.iceberg.IcebergConstants;
+import org.apache.gravitino.credential.AwsIrsaCredential;
+import org.apache.gravitino.credential.SupportsCredentials;
 import org.apache.gravitino.exceptions.NoSuchCatalogException;
 import org.apache.gravitino.iceberg.common.IcebergConfig;
 import org.apache.gravitino.iceberg.common.ops.IcebergCatalogWrapper;
@@ -359,6 +361,52 @@ public class TestDynamicIcebergConfigProvider {
     Optional<IcebergConfig> icebergConfig = provider.getIcebergCatalogConfig(catalogName);
 
     Assertions.assertTrue(icebergConfig.isPresent());
+  }
+
+  @Test
+  public void testInjectsVendedStorageCredentialsIntoIcebergConfig() {
+    String metalakeName = "test_metalake";
+    String catalogName = "credential_catalog";
+
+    Catalog mockCatalog = Mockito.mock(Catalog.class);
+    SupportsCredentials supportsCredentials = Mockito.mock(SupportsCredentials.class);
+    Mockito.when(mockCatalog.provider()).thenReturn("lakehouse-iceberg");
+    Mockito.when(mockCatalog.properties())
+        .thenReturn(
+            new HashMap<String, String>() {
+              {
+                put(IcebergConstants.CATALOG_BACKEND, "custom");
+                put(IcebergConstants.CATALOG_BACKEND_NAME, catalogName);
+              }
+            });
+    Mockito.when(mockCatalog.supportsCredentials()).thenReturn(supportsCredentials);
+    Mockito.when(supportsCredentials.getCredentials())
+        .thenReturn(
+            new AwsIrsaCredential[] {
+              new AwsIrsaCredential("test-access-key", "test-secret-key", "test-session-token", 123)
+            });
+
+    Map<String, String> properties = new HashMap<>();
+    properties.put(IcebergConstants.GRAVITINO_URI, "http://localhost:8090");
+    properties.put(IcebergConstants.GRAVITINO_METALAKE, metalakeName);
+
+    DynamicIcebergConfigProvider provider = new DynamicIcebergConfigProvider();
+    provider.initialize(properties);
+
+    Map<String, Catalog> catalogMap = new HashMap<>();
+    catalogMap.put(catalogName, mockCatalog);
+    setMockCatalogFetcher(provider, catalogMap);
+
+    Optional<IcebergConfig> icebergConfig = provider.getIcebergCatalogConfig(catalogName);
+
+    Assertions.assertTrue(icebergConfig.isPresent());
+    Map<String, String> icebergCatalogProperties =
+        icebergConfig.get().getIcebergCatalogProperties();
+    Assertions.assertEquals("test-access-key", icebergCatalogProperties.get("s3.access-key-id"));
+    Assertions.assertEquals(
+        "test-secret-key", icebergCatalogProperties.get("s3.secret-access-key"));
+    Assertions.assertEquals("test-session-token", icebergCatalogProperties.get("s3.session-token"));
+    Assertions.assertEquals("123", icebergCatalogProperties.get("s3.session-token-expires-at-ms"));
   }
 
   @Test

--- a/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/provider/TestDynamicIcebergConfigProvider.java
+++ b/iceberg/iceberg-rest-server/src/test/java/org/apache/gravitino/iceberg/service/provider/TestDynamicIcebergConfigProvider.java
@@ -39,6 +39,8 @@ import org.apache.gravitino.credential.AwsIrsaCredential;
 import org.apache.gravitino.credential.SupportsCredentials;
 import org.apache.gravitino.exceptions.NoSuchCatalogException;
 import org.apache.gravitino.iceberg.common.IcebergConfig;
+import org.apache.gravitino.iceberg.common.credential.GravitinoIcebergAwsCredentialsProvider;
+import org.apache.gravitino.iceberg.common.credential.IcebergServerCredentialUtils;
 import org.apache.gravitino.iceberg.common.ops.IcebergCatalogWrapper;
 import org.apache.gravitino.iceberg.service.authorization.IcebergRESTServerContext;
 import org.apache.gravitino.utils.NameIdentifierUtil;
@@ -364,7 +366,7 @@ public class TestDynamicIcebergConfigProvider {
   }
 
   @Test
-  public void testInjectsVendedStorageCredentialsIntoIcebergConfig() {
+  public void testConfiguresRefreshableVendedStorageCredentialsIntoIcebergConfig() {
     String metalakeName = "test_metalake";
     String catalogName = "credential_catalog";
 
@@ -402,11 +404,32 @@ public class TestDynamicIcebergConfigProvider {
     Assertions.assertTrue(icebergConfig.isPresent());
     Map<String, String> icebergCatalogProperties =
         icebergConfig.get().getIcebergCatalogProperties();
-    Assertions.assertEquals("test-access-key", icebergCatalogProperties.get("s3.access-key-id"));
     Assertions.assertEquals(
-        "test-secret-key", icebergCatalogProperties.get("s3.secret-access-key"));
-    Assertions.assertEquals("test-session-token", icebergCatalogProperties.get("s3.session-token"));
-    Assertions.assertEquals("123", icebergCatalogProperties.get("s3.session-token-expires-at-ms"));
+        GravitinoIcebergAwsCredentialsProvider.class.getName(),
+        icebergCatalogProperties.get(IcebergServerCredentialUtils.CLIENT_CREDENTIALS_PROVIDER));
+    Assertions.assertEquals(
+        GravitinoIcebergAwsCredentialsProvider.SOURCE_REMOTE,
+        icebergCatalogProperties.get(
+            IcebergServerCredentialUtils.CLIENT_CREDENTIALS_PROVIDER_PREFIX
+                + GravitinoIcebergAwsCredentialsProvider.SOURCE));
+    Assertions.assertEquals(
+        catalogName,
+        icebergCatalogProperties.get(
+            IcebergServerCredentialUtils.CLIENT_CREDENTIALS_PROVIDER_PREFIX
+                + GravitinoIcebergAwsCredentialsProvider.CATALOG_NAME));
+    Assertions.assertEquals(
+        "http://localhost:8090",
+        icebergCatalogProperties.get(
+            IcebergServerCredentialUtils.CLIENT_CREDENTIALS_PROVIDER_PREFIX
+                + IcebergConstants.GRAVITINO_URI));
+    Assertions.assertEquals(
+        metalakeName,
+        icebergCatalogProperties.get(
+            IcebergServerCredentialUtils.CLIENT_CREDENTIALS_PROVIDER_PREFIX
+                + IcebergConstants.GRAVITINO_METALAKE));
+    Assertions.assertFalse(icebergCatalogProperties.containsKey("s3.access-key-id"));
+    Assertions.assertFalse(icebergCatalogProperties.containsKey("s3.secret-access-key"));
+    Assertions.assertFalse(icebergCatalogProperties.containsKey("s3.session-token"));
   }
 
   @Test


### PR DESCRIPTION
### What changes were proposed in this pull request?

Apply vended credentials to server-side Iceberg catalog configuration for both Gravitino Iceberg catalog operations and Iceberg REST dynamic catalog configuration.

This PR:
- Applies credentials generated by catalog credential providers to Iceberg catalog properties.
- Makes Iceberg REST dynamic catalog configuration inject all supported vended credentials, not only JDBC credentials.
- Handles null `supportsCredentials()` defensively when collecting catalog credentials.
- Adds tests for:
  - Server-side Iceberg catalog credential provider injection.
  - Iceberg REST dynamic provider injection of `AwsIrsaCredential`.
  - `FileWebIdentityTokenSource` with Fileset and GVFS credential paths using a local fake STS server.

### Why are the changes needed?

Server-side Iceberg S3FileIO did not receive credentials generated from web identity flows such as `FileWebIdentityTokenSource`. As a result, Azure/OIDC web identity based flows could vend credentials for some paths, but Iceberg REST server-side S3 access was not configured with the generated AWS session credentials.

Fix: #11850

### Does this PR introduce _any_ user-facing change?

No new user-facing API or property key is introduced.

Existing credential vending configuration, including `aws-irsa` and `s3-web-identity-token-source=file`, now also applies to server-side Iceberg FileIO configuration.

### How was this patch tested?

- `./gradlew :common:test --tests org.apache.gravitino.credential.TestCredentialPropertiesUtils`
- `./gradlew :bundles:aws:test --tests org.apache.gravitino.s3.credential.TestAwsIrsaCredentialGenerator`
- `./gradlew :iceberg:iceberg-rest-server:test --tests org.apache.gravitino.iceberg.service.provider.TestDynamicIcebergConfigProvider`
- `./gradlew :catalogs:catalog-lakehouse-iceberg:test --tests org.apache.gravitino.catalog.lakehouse.iceberg.TestIcebergCatalogOperations`
- `./gradlew :clients:filesystem-hadoop3:test --tests org.apache.gravitino.filesystem.hadoop.integration.test.FilesetS3WebIdentityCredentialIT`
- `git diff --check`
