### PR TITLE
[#11841] fix ClickHouse partition expression round trip

### DIFF
--- a/catalogs-contrib/catalog-jdbc-clickhouse/src/main/java/org/apache/gravitino/catalog/clickhouse/operations/ClickHouseTableSqlUtils.java
+++ b/catalogs-contrib/catalog-jdbc-clickhouse/src/main/java/org/apache/gravitino/catalog/clickhouse/operations/ClickHouseTableSqlUtils.java
@@ -35,6 +35,8 @@ final class ClickHouseTableSqlUtils {
 
   private static final Pattern TO_DATE_PATTERN =
       Pattern.compile("toDate\\((.+)\\)", Pattern.CASE_INSENSITIVE);
+  private static final Pattern TO_DAY_PATTERN =
+      Pattern.compile("toYYYYMMDD\\((.+)\\)", Pattern.CASE_INSENSITIVE);
   private static final Pattern TO_YEAR_PATTERN =
       Pattern.compile("toYear\\((.+)\\)", Pattern.CASE_INSENSITIVE);
   private static final Pattern TO_MONTH_PATTERN =
@@ -76,7 +78,7 @@ final class ClickHouseTableSqlUtils {
           .formatted(quoteIdentifier(partitionFieldName(transform)));
       case Transforms.NAME_OF_MONTH -> "toYYYYMM(%s)"
           .formatted(quoteIdentifier(partitionFieldName(transform)));
-      case Transforms.NAME_OF_DAY -> "toDate(%s)"
+      case Transforms.NAME_OF_DAY -> "toYYYYMMDD(%s)"
           .formatted(quoteIdentifier(partitionFieldName(transform)));
       default -> throw new IllegalArgumentException(
           "Unsupported partition transform: " + transform.name());
@@ -181,28 +183,25 @@ final class ClickHouseTableSqlUtils {
 
     Matcher toYearMatcher = TO_YEAR_PATTERN.matcher(trimmedExpression);
     if (toYearMatcher.matches()) {
-      String identifier = normalizeIdentifier(toYearMatcher.group(1));
-      Preconditions.checkArgument(
-          StringUtils.isNotBlank(identifier),
-          "Unsupported partition expression: " + originalPartitionKey);
+      String identifier = extractPartitionColumn(toYearMatcher.group(1), originalPartitionKey);
       return Transforms.year(identifier);
     }
 
     Matcher toYYYYMMMatcher = TO_MONTH_PATTERN.matcher(trimmedExpression);
     if (toYYYYMMMatcher.matches()) {
-      String identifier = normalizeIdentifier(toYYYYMMMatcher.group(1));
-      Preconditions.checkArgument(
-          StringUtils.isNotBlank(identifier),
-          "Unsupported partition expression: " + originalPartitionKey);
+      String identifier = extractPartitionColumn(toYYYYMMMatcher.group(1), originalPartitionKey);
       return Transforms.month(identifier);
+    }
+
+    Matcher toYYYYMMDDMatcher = TO_DAY_PATTERN.matcher(trimmedExpression);
+    if (toYYYYMMDDMatcher.matches()) {
+      String identifier = extractPartitionColumn(toYYYYMMDDMatcher.group(1), originalPartitionKey);
+      return Transforms.day(identifier);
     }
 
     Matcher toDateMatcher = TO_DATE_PATTERN.matcher(trimmedExpression);
     if (toDateMatcher.matches()) {
-      String identifier = normalizeIdentifier(toDateMatcher.group(1));
-      Preconditions.checkArgument(
-          StringUtils.isNotBlank(identifier),
-          "Unsupported partition expression: " + originalPartitionKey);
+      String identifier = extractPartitionColumn(toDateMatcher.group(1), originalPartitionKey);
       return Transforms.day(identifier);
     }
 
@@ -218,6 +217,18 @@ final class ClickHouseTableSqlUtils {
         "Only simple identifier is supported for partition expression, but got: "
             + originalPartitionKey);
     return Transforms.identity(identifier);
+  }
+
+  private static String extractPartitionColumn(String expression, String originalPartitionKey) {
+    String identifier = normalizeIdentifier(expression);
+    Matcher toDateMatcher = TO_DATE_PATTERN.matcher(identifier);
+    if (toDateMatcher.matches()) {
+      identifier = normalizeIdentifier(toDateMatcher.group(1));
+    }
+    Preconditions.checkArgument(
+        isStrictIdentifier(identifier),
+        "Unsupported partition expression: " + originalPartitionKey);
+    return identifier;
   }
 
   private static String normalizePartitionKey(String partitionKey) {

--- a/catalogs-contrib/catalog-jdbc-clickhouse/src/test/java/org/apache/gravitino/catalog/clickhouse/operations/TestClickHouseTableOperations.java
+++ b/catalogs-contrib/catalog-jdbc-clickhouse/src/test/java/org/apache/gravitino/catalog/clickhouse/operations/TestClickHouseTableOperations.java
@@ -943,7 +943,7 @@ public class TestClickHouseTableOperations extends TestClickHouse {
             Distributions.NONE,
             indexes,
             ClickHouseUtils.getSortOrders("c1"));
-    Assertions.assertTrue(dayPartitionSql.contains("PARTITION BY toDate(`c1`)"));
+    Assertions.assertTrue(dayPartitionSql.contains("PARTITION BY toYYYYMMDD(`c1`)"));
 
     String multiPartitionSql =
         ops.buildCreateSql(
@@ -956,7 +956,7 @@ public class TestClickHouseTableOperations extends TestClickHouse {
             indexes,
             ClickHouseUtils.getSortOrders("c1"));
     Assertions.assertTrue(
-        multiPartitionSql.contains("PARTITION BY tuple(toYear(`c1`), toDate(`c1`))"));
+        multiPartitionSql.contains("PARTITION BY tuple(toYear(`c1`), toYYYYMMDD(`c1`))"));
 
     IllegalArgumentException exception =
         Assertions.assertThrows(

--- a/catalogs-contrib/catalog-jdbc-clickhouse/src/test/java/org/apache/gravitino/catalog/clickhouse/operations/TestClickHouseTableOperationsPartitioning.java
+++ b/catalogs-contrib/catalog-jdbc-clickhouse/src/test/java/org/apache/gravitino/catalog/clickhouse/operations/TestClickHouseTableOperationsPartitioning.java
@@ -32,9 +32,18 @@ public class TestClickHouseTableOperationsPartitioning {
     Assertions.assertEquals(1, dayPartitions.length);
     assertSingleFieldTransform(dayPartitions[0], Transforms.NAME_OF_DAY, "event_time");
 
+    Transform[] dayNumberPartitions = operations.parsePartitioning("toYYYYMMDD(event_time)");
+    Assertions.assertEquals(1, dayNumberPartitions.length);
+    assertSingleFieldTransform(dayNumberPartitions[0], Transforms.NAME_OF_DAY, "event_time");
+
     Transform[] monthPartitions = operations.parsePartitioning("toYYYYMM(event_time)");
     Assertions.assertEquals(1, monthPartitions.length);
     assertSingleFieldTransform(monthPartitions[0], Transforms.NAME_OF_MONTH, "event_time");
+
+    Transform[] nestedMonthPartitions =
+        operations.parsePartitioning("toYYYYMM(toDate(event_time))");
+    Assertions.assertEquals(1, nestedMonthPartitions.length);
+    assertSingleFieldTransform(nestedMonthPartitions[0], Transforms.NAME_OF_MONTH, "event_time");
 
     Transform[] yearPartitions = operations.parsePartitioning("toYear(event_time)");
     Assertions.assertEquals(1, yearPartitions.length);
@@ -55,6 +64,13 @@ public class TestClickHouseTableOperationsPartitioning {
 
     Assertions.assertEquals(0, operations.parsePartitioning("tuple()").length);
     Assertions.assertEquals(0, operations.parsePartitioning("  ").length);
+  }
+
+  @Test
+  public void testFormatDayPartitionExpression() {
+    Assertions.assertEquals(
+        "toYYYYMMDD(`event_time`)",
+        ClickHouseTableSqlUtils.toPartitionExpression(Transforms.day("event_time")));
   }
 
   private void assertSingleFieldTransform(

--- a/docs/jdbc-clickhouse-catalog.md
+++ b/docs/jdbc-clickhouse-catalog.md
@@ -252,7 +252,7 @@ If you need Gravitino to manage an existing cluster database or table, recreate 
 - `PARTITION BY`: single-column identity and some functions are supported only, and only for MergeTree-family engines. For example `PARTITION BY created_at` or `PARTITION BY toYYYYMM(created_at)` are supported, but `PARTITION BY (created_at + 1)` are not supported.
    In all, the following partitioning expressions are supported:
    - Identity: `PARTITION BY column_name`
-   - Functions: `PARTITION BY toDate(column_name)`, `PARTITION BY toYear(column_name)`, `PARTITION BY toYYYYMM(column_name)`. Other functions are not supported.
+   - Functions: `PARTITION BY toDate(column_name)`, `PARTITION BY toYYYYMMDD(column_name)`, `PARTITION BY toYear(column_name)`, `PARTITION BY toYYYYMM(column_name)`. Other functions are not supported.
    - Not support: `PARTITION BY (column_name + 1)`, `PARTITION BY (toYear(column_name) + 1)`, etc. (Note: ClickHouse itself does support arbitrary partitioning expressions, but Gravitino supports only the above patterns for partitioning). 
 
 - Distribution: fixed to `Distributions.NONE`. For a `Distributed` engine table, you can specify the sharding key and remote database/table through table properties to fulfill the same use cases. We will later consider adding more flexible distribution strategies if there is demand.


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix ClickHouse partition expression round-tripping for day transforms and nested date wrappers:

- format Gravitino day transforms as `toYYYYMMDD(column)` instead of `toDate(column)`
- parse `toYYYYMMDD(column)` back to a day transform
- unwrap a supported `toDate(...)` wrapper when parsing expressions such as `toYYYYMM(toDate(event_time))`
- update the ClickHouse catalog documentation for supported partition functions

### Why are the changes needed?

Fixes #11841.

Without this change, a ClickHouse partition expression like `toYYYYMM(toDate(event_time))` is parsed with `toDate(event_time)` as the field name. Also, day transforms are formatted as `toDate(...)`, which does not round-trip cleanly with the ClickHouse day partition form described in the issue.

### Does this PR introduce _any_ user-facing change?

Yes. ClickHouse day partition transforms are now generated as `toYYYYMMDD(column)`. Existing `toDate(column)` partition expressions are still accepted when reading metadata.

### How was this patch tested?

- `JAVA_HOME=$(/usr/libexec/java_home -v 17) ./gradlew :catalogs-contrib:catalog-jdbc-clickhouse:test --tests org.apache.gravitino.catalog.clickhouse.operations.TestClickHouseTableOperationsPartitioning -PskipITs`
- `JAVA_HOME=$(/usr/libexec/java_home -v 17) ./gradlew :catalogs-contrib:catalog-jdbc-clickhouse:spotlessCheck -PskipITs`
- `git diff --check`