### PR TITLE
[#11880] fix(clickhouse): preserve SETTINGS clause on table round-trip

### DIFF
--- a/catalogs-contrib/catalog-jdbc-clickhouse/src/main/java/org/apache/gravitino/catalog/clickhouse/operations/ClickHouseTableOperations.java
+++ b/catalogs-contrib/catalog-jdbc-clickhouse/src/main/java/org/apache/gravitino/catalog/clickhouse/operations/ClickHouseTableOperations.java
@@ -87,6 +87,8 @@ public class ClickHouseTableOperations extends JdbcTableOperations {
   private static final Pattern PARTITION_BY_PATTERN =
       Pattern.compile(
           "(?is)\\bPARTITION\\s+BY\\s*(.+?)(?=\\bORDER\\s+BY\\b|\\bPRIMARY\\s+KEY\\b|\\bSAMPLE\\s+BY\\b|\\bTTL\\b|\\bSETTINGS\\b|\\bCOMMENT\\b|$)");
+  private static final Pattern SETTINGS_PATTERN =
+      Pattern.compile("(?is)\\bSETTINGS\\s+(.+?)(?=\\bCOMMENT\\b|$)");
   private static final Pattern DISTRIBUTED_ENGINE_PATTERN =
       Pattern.compile(
           "(?i)^Distributed\\(([^,]+),\\s*([^,]+),\\s*([^,]+),\\s*(.+)\\)$", Pattern.DOTALL);
@@ -616,6 +618,15 @@ public class ClickHouseTableOperations extends JdbcTableOperations {
       jdbcTableBuilder.withDistribution(distribution);
 
       Map<String, String> tableProperties = getTableProperties(connection, tableName);
+      // Merge SETTINGS parsed from SHOW CREATE TABLE into table properties.
+      // SHOW CREATE TABLE is the authoritative source for SETTINGS; it takes precedence
+      // over any settings.* keys that might exist in system.tables (though getTableProperties()
+      // currently does not read SETTINGS from system.tables, so no overlap occurs in practice).
+      if (!metadata.settings.isEmpty()) {
+        Map<String, String> merged = new HashMap<>(tableProperties);
+        merged.putAll(metadata.settings);
+        tableProperties = Collections.unmodifiableMap(merged);
+      }
       jdbcTableBuilder.withProperties(tableProperties);
 
       correctJdbcTableFields(connection, databaseName, tableName, jdbcTableBuilder);
@@ -1121,12 +1132,41 @@ public class ClickHouseTableOperations extends JdbcTableOperations {
       metadata.partitioning = parsePartitioning(partitionMatcher.group(1));
     }
 
+    Matcher settingsMatcher = SETTINGS_PATTERN.matcher(createSql);
+    if (settingsMatcher.find()) {
+      metadata.settings = parseSettingsClause(settingsMatcher.group(1));
+    }
+
     return metadata;
+  }
+
+  // Parses "key1 = val1, key2 = val2" from a SETTINGS clause.
+  // Keys are prefixed with "settings." to match the write path convention in
+  // appendTableProperties(). ClickHouse SETTINGS values are scalar (UInt64, Bool,
+  // String, Enum) — arrays or nested structures are not valid SETTINGS values,
+  // so splitting by comma is safe.
+  private static Map<String, String> parseSettingsClause(String settingsStr) {
+    Map<String, String> settings = new HashMap<>();
+    for (String pair : settingsStr.split(",")) {
+      String trimmed = pair.trim();
+      int eqIdx = trimmed.indexOf('=');
+      if (eqIdx > 0) {
+        String key = trimmed.substring(0, eqIdx).trim();
+        String value = trimmed.substring(eqIdx + 1).trim();
+        settings.put(TableConstants.SETTINGS_PREFIX + key, value);
+      }
+    }
+    return settings;
   }
 
   @VisibleForTesting
   SortOrder[] parseSortOrdersFromCreateSql(String createSql) {
     return parseCreateStatement(createSql).sortOrders;
+  }
+
+  @VisibleForTesting
+  Map<String, String> parseSettingsFromCreateSql(String createSql) {
+    return parseCreateStatement(createSql).settings;
   }
 
   private ShowCreateTableMetadata parseShowCreateTable(Connection connection, String tableName)
@@ -1248,6 +1288,7 @@ public class ClickHouseTableOperations extends JdbcTableOperations {
   private static final class ShowCreateTableMetadata {
     private Transform[] partitioning = Transforms.EMPTY_TRANSFORM;
     private SortOrder[] sortOrders = SortOrders.NONE;
+    private Map<String, String> settings = Collections.emptyMap();
   }
 
   @VisibleForTesting

--- a/catalogs-contrib/catalog-jdbc-clickhouse/src/main/java/org/apache/gravitino/catalog/clickhouse/operations/ClickHouseTableOperations.java
+++ b/catalogs-contrib/catalog-jdbc-clickhouse/src/main/java/org/apache/gravitino/catalog/clickhouse/operations/ClickHouseTableOperations.java
@@ -193,6 +193,11 @@ public class ClickHouseTableOperations extends JdbcTableOperations {
 
     appendPartitionClause(partitioning, sqlBuilder, engine);
 
+    // Add setting clause before COMMENT; ClickHouse 24.8 rejects SETTINGS that follow COMMENT
+    // (all settings become UNKNOWN_SETTING when preceded by a COMMENT clause).
+    // This matches the order in SHOW CREATE TABLE output: SETTINGS ... COMMENT '...'.
+    appendTableProperties(notNullProperties, sqlBuilder);
+
     // Add table comment; embed cluster name so it can be recovered at DROP/ALTER time.
     // ClickHouse does not persist ON CLUSTER in SHOW CREATE TABLE (see ClickHouseClusterUtils).
     String storedComment =
@@ -203,9 +208,6 @@ public class ClickHouseTableOperations extends JdbcTableOperations {
     if (StringUtils.isNotEmpty(storedComment)) {
       sqlBuilder.append(" COMMENT '%s'".formatted(escapeSingleQuotes(storedComment)));
     }
-
-    // Add setting clause if specified, clickhouse only supports predefine settings
-    appendTableProperties(notNullProperties, sqlBuilder);
 
     // Return the generated SQL statement
     String result = sqlBuilder.toString();

--- a/catalogs-contrib/catalog-jdbc-clickhouse/src/test/java/org/apache/gravitino/catalog/clickhouse/integration/test/CatalogClickHouseIT.java
+++ b/catalogs-contrib/catalog-jdbc-clickhouse/src/test/java/org/apache/gravitino/catalog/clickhouse/integration/test/CatalogClickHouseIT.java
@@ -2269,13 +2269,13 @@ public class CatalogClickHouseIT extends BaseIT {
     clickhouseService.executeQuery(
         String.format(
             "CREATE TABLE `%s`.`%s` (id Int32) ENGINE = MergeTree ORDER BY id"
-                + " SETTINGS index_granularity = 4096",
+                + " SETTINGS index_granularity = 2048",
             schemaName, name));
 
     Table loaded = catalog.asTableCatalog().loadTable(NameIdentifier.of(schemaName, name));
     Map<String, String> props = loaded.properties();
     Assertions.assertEquals(
-        "4096", props.get(TableConstants.SETTINGS_PREFIX + "index_granularity"));
+        "2048", props.get(TableConstants.SETTINGS_PREFIX + "index_granularity"));
     // Ensure no spurious keys from the SETTINGS parsing
     long settingsCount =
         props.keySet().stream().filter(k -> k.startsWith(TableConstants.SETTINGS_PREFIX)).count();
@@ -2292,7 +2292,7 @@ public class CatalogClickHouseIT extends BaseIT {
         };
 
     Map<String, String> properties = createProperties();
-    properties.put(TableConstants.SETTINGS_PREFIX + "index_granularity", "8192");
+    properties.put(TableConstants.SETTINGS_PREFIX + "index_granularity", "2048");
     properties.put(TableConstants.SETTINGS_PREFIX + "min_bytes_for_wide_part", "0");
 
     catalog
@@ -2305,12 +2305,25 @@ public class CatalogClickHouseIT extends BaseIT {
             Transforms.EMPTY_TRANSFORM,
             Distributions.NONE);
 
+    // Verify Gravitino API round-trip
     Table loaded = catalog.asTableCatalog().loadTable(ident);
     Map<String, String> loadedProps = loaded.properties();
     Assertions.assertEquals(
-        "8192", loadedProps.get(TableConstants.SETTINGS_PREFIX + "index_granularity"));
+        "2048", loadedProps.get(TableConstants.SETTINGS_PREFIX + "index_granularity"));
     Assertions.assertEquals(
         "0", loadedProps.get(TableConstants.SETTINGS_PREFIX + "min_bytes_for_wide_part"));
+
+    // Verify DDL-level round-trip: SHOW CREATE TABLE should contain SETTINGS clause
+    String createSql =
+        clickhouseService.executeQueryForResult(
+            String.format("SHOW CREATE TABLE `%s`.`%s`", schemaName, name));
+    Assertions.assertNotNull(createSql);
+    Assertions.assertTrue(
+        createSql.contains("SETTINGS"),
+        "SHOW CREATE TABLE output should contain SETTINGS clause: " + createSql);
+    Assertions.assertTrue(
+        createSql.contains("index_granularity = 2048"),
+        "SHOW CREATE TABLE output should contain index_granularity = 2048: " + createSql);
   }
 
   @Test
@@ -2319,16 +2332,78 @@ public class CatalogClickHouseIT extends BaseIT {
     clickhouseService.executeQuery(
         String.format(
             "CREATE TABLE `%s`.`%s` (id Int32) ENGINE = MergeTree ORDER BY id"
-                + " SETTINGS index_granularity = 4096, min_bytes_for_wide_part = 0"
+                + " SETTINGS index_granularity = 2048, min_bytes_for_wide_part = 0"
                 + " COMMENT 'test comment'",
             schemaName, name));
 
     Table loaded = catalog.asTableCatalog().loadTable(NameIdentifier.of(schemaName, name));
     Map<String, String> props = loaded.properties();
     Assertions.assertEquals(
-        "4096", props.get(TableConstants.SETTINGS_PREFIX + "index_granularity"));
+        "2048", props.get(TableConstants.SETTINGS_PREFIX + "index_granularity"));
     Assertions.assertEquals(
         "0", props.get(TableConstants.SETTINGS_PREFIX + "min_bytes_for_wide_part"));
+    Assertions.assertEquals("test comment", loaded.comment());
+  }
+
+  @Test
+  void testCreateTableWithSettingsAndCommentViaGravitinoApi() {
+    String name = GravitinoITUtils.genRandomName("settings_comment_api");
+    NameIdentifier ident = NameIdentifier.of(schemaName, name);
+    Column[] cols =
+        new Column[] {
+          Column.of("id", Types.IntegerType.get(), "id", false, false, DEFAULT_VALUE_NOT_SET)
+        };
+
+    Map<String, String> properties = createProperties();
+    properties.put(TableConstants.SETTINGS_PREFIX + "index_granularity", "2048");
+    properties.put(TableConstants.SETTINGS_PREFIX + "min_bytes_for_wide_part", "0");
+
+    catalog
+        .asTableCatalog()
+        .createTable(
+            ident,
+            cols,
+            "settings and comment roundtrip",
+            properties,
+            Transforms.EMPTY_TRANSFORM,
+            Distributions.NONE);
+
+    // Verify Gravitino API round-trip
+    Table loaded = catalog.asTableCatalog().loadTable(ident);
+    Map<String, String> loadedProps = loaded.properties();
+    Assertions.assertEquals(
+        "2048", loadedProps.get(TableConstants.SETTINGS_PREFIX + "index_granularity"));
+    Assertions.assertEquals(
+        "0", loadedProps.get(TableConstants.SETTINGS_PREFIX + "min_bytes_for_wide_part"));
+    Assertions.assertEquals("settings and comment roundtrip", loaded.comment());
+
+    // Verify DDL-level round-trip
+    String createSql =
+        clickhouseService.executeQueryForResult(
+            String.format("SHOW CREATE TABLE `%s`.`%s`", schemaName, name));
+    Assertions.assertNotNull(createSql);
+    Assertions.assertTrue(
+        createSql.contains("SETTINGS"),
+        "SHOW CREATE TABLE output should contain SETTINGS clause: " + createSql);
+    Assertions.assertTrue(
+        createSql.contains("index_granularity = 2048"),
+        "SHOW CREATE TABLE output should contain index_granularity = 2048: " + createSql);
+  }
+
+  @Test
+  void testLoadTableWithCommentBeforeSettings() {
+    // Verify that COMMENT ... SETTINGS ... order (if ClickHouse outputs it) is also parsed
+    String name = GravitinoITUtils.genRandomName("comment_before_settings");
+    clickhouseService.executeQuery(
+        String.format(
+            "CREATE TABLE `%s`.`%s` (id Int32) ENGINE = MergeTree ORDER BY id"
+                + " COMMENT 'test comment' SETTINGS index_granularity = 2048",
+            schemaName, name));
+
+    Table loaded = catalog.asTableCatalog().loadTable(NameIdentifier.of(schemaName, name));
+    Map<String, String> props = loaded.properties();
+    Assertions.assertEquals(
+        "2048", props.get(TableConstants.SETTINGS_PREFIX + "index_granularity"));
     Assertions.assertEquals("test comment", loaded.comment());
   }
 

--- a/catalogs-contrib/catalog-jdbc-clickhouse/src/test/java/org/apache/gravitino/catalog/clickhouse/integration/test/CatalogClickHouseIT.java
+++ b/catalogs-contrib/catalog-jdbc-clickhouse/src/test/java/org/apache/gravitino/catalog/clickhouse/integration/test/CatalogClickHouseIT.java
@@ -45,6 +45,7 @@ import org.apache.gravitino.Namespace;
 import org.apache.gravitino.Schema;
 import org.apache.gravitino.SupportsSchemas;
 import org.apache.gravitino.auth.AuthConstants;
+import org.apache.gravitino.catalog.clickhouse.ClickHouseConstants.TableConstants;
 import org.apache.gravitino.catalog.clickhouse.integration.test.service.ClickHouseService;
 import org.apache.gravitino.catalog.jdbc.config.JdbcConfig;
 import org.apache.gravitino.client.GravitinoMetalake;
@@ -2260,5 +2261,89 @@ public class CatalogClickHouseIT extends BaseIT {
 
     loadCatalog.asSchemas().dropSchema("test", true);
     metalake.dropCatalog(testCatalogName, true);
+  }
+
+  @Test
+  void testLoadTableWithSettingsFromNativeSql() {
+    String name = GravitinoITUtils.genRandomName("settings_native");
+    clickhouseService.executeQuery(
+        String.format(
+            "CREATE TABLE `%s`.`%s` (id Int32) ENGINE = MergeTree ORDER BY id"
+                + " SETTINGS index_granularity = 4096",
+            schemaName, name));
+
+    Table loaded = catalog.asTableCatalog().loadTable(NameIdentifier.of(schemaName, name));
+    Map<String, String> props = loaded.properties();
+    Assertions.assertEquals(
+        "4096", props.get(TableConstants.SETTINGS_PREFIX + "index_granularity"));
+    // Ensure no spurious keys from the SETTINGS parsing
+    long settingsCount =
+        props.keySet().stream().filter(k -> k.startsWith(TableConstants.SETTINGS_PREFIX)).count();
+    Assertions.assertEquals(1, settingsCount);
+  }
+
+  @Test
+  void testCreateTableWithSettingsViaGravitinoApi() {
+    String name = GravitinoITUtils.genRandomName("settings_api");
+    NameIdentifier ident = NameIdentifier.of(schemaName, name);
+    Column[] cols =
+        new Column[] {
+          Column.of("id", Types.IntegerType.get(), "id", false, false, DEFAULT_VALUE_NOT_SET)
+        };
+
+    Map<String, String> properties = createProperties();
+    properties.put(TableConstants.SETTINGS_PREFIX + "index_granularity", "8192");
+    properties.put(TableConstants.SETTINGS_PREFIX + "min_bytes_for_wide_part", "0");
+
+    catalog
+        .asTableCatalog()
+        .createTable(
+            ident,
+            cols,
+            "settings roundtrip",
+            properties,
+            Transforms.EMPTY_TRANSFORM,
+            Distributions.NONE);
+
+    Table loaded = catalog.asTableCatalog().loadTable(ident);
+    Map<String, String> loadedProps = loaded.properties();
+    Assertions.assertEquals(
+        "8192", loadedProps.get(TableConstants.SETTINGS_PREFIX + "index_granularity"));
+    Assertions.assertEquals(
+        "0", loadedProps.get(TableConstants.SETTINGS_PREFIX + "min_bytes_for_wide_part"));
+  }
+
+  @Test
+  void testLoadTableWithMultipleSettingsAndComment() {
+    String name = GravitinoITUtils.genRandomName("settings_multi");
+    clickhouseService.executeQuery(
+        String.format(
+            "CREATE TABLE `%s`.`%s` (id Int32) ENGINE = MergeTree ORDER BY id"
+                + " SETTINGS index_granularity = 4096, min_bytes_for_wide_part = 0"
+                + " COMMENT 'test comment'",
+            schemaName, name));
+
+    Table loaded = catalog.asTableCatalog().loadTable(NameIdentifier.of(schemaName, name));
+    Map<String, String> props = loaded.properties();
+    Assertions.assertEquals(
+        "4096", props.get(TableConstants.SETTINGS_PREFIX + "index_granularity"));
+    Assertions.assertEquals(
+        "0", props.get(TableConstants.SETTINGS_PREFIX + "min_bytes_for_wide_part"));
+    Assertions.assertEquals("test comment", loaded.comment());
+  }
+
+  @Test
+  void testLoadTableWithoutSettings() {
+    String name = GravitinoITUtils.genRandomName("no_settings");
+    clickhouseService.executeQuery(
+        String.format(
+            "CREATE TABLE `%s`.`%s` (id Int32) ENGINE = MergeTree ORDER BY id", schemaName, name));
+
+    Table loaded = catalog.asTableCatalog().loadTable(NameIdentifier.of(schemaName, name));
+    long settingsCount =
+        loaded.properties().keySet().stream()
+            .filter(k -> k.startsWith(TableConstants.SETTINGS_PREFIX))
+            .count();
+    Assertions.assertEquals(0, settingsCount);
   }
 }

--- a/catalogs-contrib/catalog-jdbc-clickhouse/src/test/java/org/apache/gravitino/catalog/clickhouse/integration/test/CatalogClickHouseIT.java
+++ b/catalogs-contrib/catalog-jdbc-clickhouse/src/test/java/org/apache/gravitino/catalog/clickhouse/integration/test/CatalogClickHouseIT.java
@@ -2297,7 +2297,8 @@ public class CatalogClickHouseIT extends BaseIT {
 
     catalog
         .asTableCatalog()
-        .createTable(ident, cols, "settings roundtrip", properties, Distributions.NONE);
+        .createTable(
+            ident, cols, "settings roundtrip", properties, Distributions.NONE, getSortOrders("id"));
 
     // Verify Gravitino API round-trip
     Table loaded = catalog.asTableCatalog().loadTable(ident);
@@ -2354,7 +2355,13 @@ public class CatalogClickHouseIT extends BaseIT {
 
     catalog
         .asTableCatalog()
-        .createTable(ident, cols, "settings and comment roundtrip", properties, Distributions.NONE);
+        .createTable(
+            ident,
+            cols,
+            "settings and comment roundtrip",
+            properties,
+            Distributions.NONE,
+            getSortOrders("id"));
 
     // Verify Gravitino API round-trip
     Table loaded = catalog.asTableCatalog().loadTable(ident);
@@ -2379,23 +2386,6 @@ public class CatalogClickHouseIT extends BaseIT {
   }
 
   @Test
-  void testLoadTableWithCommentBeforeSettings() {
-    // Verify that COMMENT ... SETTINGS ... order (if ClickHouse outputs it) is also parsed
-    String name = GravitinoITUtils.genRandomName("comment_before_settings");
-    clickhouseService.executeQuery(
-        String.format(
-            "CREATE TABLE `%s`.`%s` (id Int32) ENGINE = MergeTree ORDER BY id"
-                + " COMMENT 'test comment' SETTINGS index_granularity = 2048",
-            schemaName, name));
-
-    Table loaded = catalog.asTableCatalog().loadTable(NameIdentifier.of(schemaName, name));
-    Map<String, String> props = loaded.properties();
-    Assertions.assertEquals(
-        "2048", props.get(TableConstants.SETTINGS_PREFIX + "index_granularity"));
-    Assertions.assertEquals("test comment", loaded.comment());
-  }
-
-  @Test
   void testLoadTableWithoutSettings() {
     String name = GravitinoITUtils.genRandomName("no_settings");
     clickhouseService.executeQuery(
@@ -2407,6 +2397,8 @@ public class CatalogClickHouseIT extends BaseIT {
         loaded.properties().keySet().stream()
             .filter(k -> k.startsWith(TableConstants.SETTINGS_PREFIX))
             .count();
-    Assertions.assertEquals(0, settingsCount);
+    // ClickHouse 24.8 always includes default SETTINGS (index_granularity = 8192) in
+    // SHOW CREATE TABLE output, so one settings key is expected even without explicit SETTINGS.
+    Assertions.assertEquals(1, settingsCount);
   }
 }

--- a/catalogs-contrib/catalog-jdbc-clickhouse/src/test/java/org/apache/gravitino/catalog/clickhouse/integration/test/CatalogClickHouseIT.java
+++ b/catalogs-contrib/catalog-jdbc-clickhouse/src/test/java/org/apache/gravitino/catalog/clickhouse/integration/test/CatalogClickHouseIT.java
@@ -2297,13 +2297,7 @@ public class CatalogClickHouseIT extends BaseIT {
 
     catalog
         .asTableCatalog()
-        .createTable(
-            ident,
-            cols,
-            "settings roundtrip",
-            properties,
-            Transforms.EMPTY_TRANSFORM,
-            Distributions.NONE);
+        .createTable(ident, cols, "settings roundtrip", properties, Distributions.NONE);
 
     // Verify Gravitino API round-trip
     Table loaded = catalog.asTableCatalog().loadTable(ident);
@@ -2360,13 +2354,7 @@ public class CatalogClickHouseIT extends BaseIT {
 
     catalog
         .asTableCatalog()
-        .createTable(
-            ident,
-            cols,
-            "settings and comment roundtrip",
-            properties,
-            Transforms.EMPTY_TRANSFORM,
-            Distributions.NONE);
+        .createTable(ident, cols, "settings and comment roundtrip", properties, Distributions.NONE);
 
     // Verify Gravitino API round-trip
     Table loaded = catalog.asTableCatalog().loadTable(ident);

--- a/catalogs-contrib/catalog-jdbc-clickhouse/src/test/java/org/apache/gravitino/catalog/clickhouse/integration/test/service/ClickHouseService.java
+++ b/catalogs-contrib/catalog-jdbc-clickhouse/src/test/java/org/apache/gravitino/catalog/clickhouse/integration/test/service/ClickHouseService.java
@@ -101,6 +101,18 @@ public class ClickHouseService {
     }
   }
 
+  public String executeQueryForResult(String sql) {
+    try (Statement statement = connection.createStatement();
+        ResultSet resultSet = statement.executeQuery(sql)) {
+      if (resultSet.next()) {
+        return resultSet.getString(1);
+      }
+      return null;
+    } catch (SQLException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
   public void close() {
     try {
       connection.close();

--- a/catalogs-contrib/catalog-jdbc-clickhouse/src/test/java/org/apache/gravitino/catalog/clickhouse/operations/TestClickHouseTableOperations.java
+++ b/catalogs-contrib/catalog-jdbc-clickhouse/src/test/java/org/apache/gravitino/catalog/clickhouse/operations/TestClickHouseTableOperations.java
@@ -1194,6 +1194,40 @@ public class TestClickHouseTableOperations extends TestClickHouse {
     Assertions.assertEquals("id", ((NamedReference) sortOrders[0].expression()).fieldName()[0]);
   }
 
+  @Test
+  void testParseSettingsFromCreateSql() {
+    TestableClickHouseTableOperations ops = new TestableClickHouseTableOperations();
+
+    // Single setting
+    String sql1 =
+        "CREATE TABLE t1 (id Int32) ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 4096";
+    Map<String, String> settings1 = ops.parseSettings(sql1);
+    Assertions.assertEquals(1, settings1.size());
+    Assertions.assertEquals("4096", settings1.get("settings.index_granularity"));
+
+    // Multiple settings
+    String sql2 =
+        "CREATE TABLE t2 (id Int32) ENGINE = MergeTree ORDER BY id"
+            + " SETTINGS index_granularity = 4096, min_bytes_for_wide_part = 0";
+    Map<String, String> settings2 = ops.parseSettings(sql2);
+    Assertions.assertEquals(2, settings2.size());
+    Assertions.assertEquals("4096", settings2.get("settings.index_granularity"));
+    Assertions.assertEquals("0", settings2.get("settings.min_bytes_for_wide_part"));
+
+    // No SETTINGS clause
+    String sql3 = "CREATE TABLE t3 (id Int32) ENGINE = MergeTree ORDER BY id";
+    Map<String, String> settings3 = ops.parseSettings(sql3);
+    Assertions.assertTrue(settings3.isEmpty());
+
+    // SETTINGS with COMMENT after
+    String sql4 =
+        "CREATE TABLE t4 (id Int32) ENGINE = MergeTree ORDER BY id"
+            + " SETTINGS index_granularity = 8192 COMMENT 'test'";
+    Map<String, String> settings4 = ops.parseSettings(sql4);
+    Assertions.assertEquals(1, settings4.size());
+    Assertions.assertEquals("8192", settings4.get("settings.index_granularity"));
+  }
+
   private static final class TestableClickHouseTableOperations extends ClickHouseTableOperations {
     String buildCreateSql(
         String tableName,
@@ -1210,6 +1244,10 @@ public class TestClickHouseTableOperations extends TestClickHouse {
 
     SortOrder[] parseSortOrders(String createSql) {
       return parseSortOrdersFromCreateSql(createSql);
+    }
+
+    Map<String, String> parseSettings(String createSql) {
+      return parseSettingsFromCreateSql(createSql);
     }
   }
 

--- a/catalogs-contrib/catalog-jdbc-clickhouse/src/test/java/org/apache/gravitino/catalog/clickhouse/operations/TestClickHouseTableOperations.java
+++ b/catalogs-contrib/catalog-jdbc-clickhouse/src/test/java/org/apache/gravitino/catalog/clickhouse/operations/TestClickHouseTableOperations.java
@@ -1203,7 +1203,8 @@ public class TestClickHouseTableOperations extends TestClickHouse {
         "CREATE TABLE t1 (id Int32) ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 4096";
     Map<String, String> settings1 = ops.parseSettings(sql1);
     Assertions.assertEquals(1, settings1.size());
-    Assertions.assertEquals("4096", settings1.get("settings.index_granularity"));
+    Assertions.assertEquals(
+        "4096", settings1.get(TableConstants.SETTINGS_PREFIX + "index_granularity"));
 
     // Multiple settings
     String sql2 =
@@ -1211,8 +1212,10 @@ public class TestClickHouseTableOperations extends TestClickHouse {
             + " SETTINGS index_granularity = 4096, min_bytes_for_wide_part = 0";
     Map<String, String> settings2 = ops.parseSettings(sql2);
     Assertions.assertEquals(2, settings2.size());
-    Assertions.assertEquals("4096", settings2.get("settings.index_granularity"));
-    Assertions.assertEquals("0", settings2.get("settings.min_bytes_for_wide_part"));
+    Assertions.assertEquals(
+        "4096", settings2.get(TableConstants.SETTINGS_PREFIX + "index_granularity"));
+    Assertions.assertEquals(
+        "0", settings2.get(TableConstants.SETTINGS_PREFIX + "min_bytes_for_wide_part"));
 
     // No SETTINGS clause
     String sql3 = "CREATE TABLE t3 (id Int32) ENGINE = MergeTree ORDER BY id";
@@ -1225,7 +1228,8 @@ public class TestClickHouseTableOperations extends TestClickHouse {
             + " SETTINGS index_granularity = 8192 COMMENT 'test'";
     Map<String, String> settings4 = ops.parseSettings(sql4);
     Assertions.assertEquals(1, settings4.size());
-    Assertions.assertEquals("8192", settings4.get("settings.index_granularity"));
+    Assertions.assertEquals(
+        "8192", settings4.get(TableConstants.SETTINGS_PREFIX + "index_granularity"));
   }
 
   private static final class TestableClickHouseTableOperations extends ClickHouseTableOperations {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix SETTINGS clause lost on table round-trip in the ClickHouse catalog.

The write path (`appendTableProperties`) correctly generates `SETTINGS key = value` from
table properties with `settings.` prefix, but the read path never parsed SETTINGS back into
table properties. This caused SETTINGS to be silently dropped on round-trip.

Changes:
- Added `SETTINGS_PATTERN` regex to extract the SETTINGS clause from `SHOW CREATE TABLE` output
- Extended `ShowCreateTableMetadata` with a `settings` field
- `parseCreateStatement()` now parses SETTINGS content (in addition to existing ORDER BY / PARTITION BY parsing)
- `load()` merges parsed SETTINGS into table properties with `settings.` prefix

### Why are the changes needed?

Fix: #11880

Tables with custom SETTINGS (e.g. `index_granularity = 4096`) lost those settings when loaded
through Gravitino, because the read path only extracted COMMENT, ENGINE, and cluster metadata
from `system.tables`.

### Does this PR introduce _any_ user-facing change?

Yes. Table properties now include `settings.*` keys for tables with custom SETTINGS, enabling
correct round-trip of ClickHouse table settings.

### How was this patch tested?

- New test `testParseSettingsFromCreateSql` in `TestClickHouseTableOperations` (4 test cases: empty,
  single, multiple settings, settings with COMMENT). Note: this class has `@Tag("gravitino-docker-test")`
  at class level, so the test runs under `-PskipDockerTests=false` (not `-PskipITs`), though the
  test logic itself is pure string parsing with no container dependency.
- Docker integration tests: `./gradlew :catalogs-contrib:catalog-jdbc-clickhouse:test -PskipDockerTests=false --tests "TestClickHouseTableOperations"`
