### PR TITLE
[#11899] fix(flink): exclude vulnerable log4j 2.x from hive-common compile classpath

### DIFF
--- a/flink-connector/v1.18/flink/build.gradle.kts
+++ b/flink-connector/v1.18/flink/build.gradle.kts
@@ -57,6 +57,7 @@ dependencies {
   compileOnly(libs.hive2.common) {
     exclude("org.eclipse.jetty.aggregate", "jetty-all")
     exclude("org.eclipse.jetty.orbit", "javax.servlet")
+    exclude("org.apache.logging.log4j")
   }
 
   testImplementation(project(":api"))

--- a/flink-connector/v1.19/flink/build.gradle.kts
+++ b/flink-connector/v1.19/flink/build.gradle.kts
@@ -57,6 +57,7 @@ dependencies {
   compileOnly(libs.hive2.common) {
     exclude("org.eclipse.jetty.aggregate", "jetty-all")
     exclude("org.eclipse.jetty.orbit", "javax.servlet")
+    exclude("org.apache.logging.log4j")
   }
 
   testImplementation(project(":api"))

--- a/flink-connector/v1.20/flink/build.gradle.kts
+++ b/flink-connector/v1.20/flink/build.gradle.kts
@@ -57,6 +57,7 @@ dependencies {
   compileOnly(libs.hive2.common) {
     exclude("org.eclipse.jetty.aggregate", "jetty-all")
     exclude("org.eclipse.jetty.orbit", "javax.servlet")
+    exclude("org.apache.logging.log4j")
   }
 
   testImplementation(project(":api"))


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add `exclude("org.apache.logging.log4j")` to the `compileOnly(libs.hive2.common)` block in:
- `flink-connector/v1.18/flink/build.gradle.kts`
- `flink-connector/v1.19/flink/build.gradle.kts`
- `flink-connector/v1.20/flink/build.gradle.kts`

### Why are the changes needed?

These modules declare `org.apache.hive:hive-common:2.3.9` as a `compileOnly` dependency, which transitively pulls `org.apache.logging.log4j:log4j-1.2-api` / `log4j-web` / `log4j-core:2.6.2` (affected by Log4Shell, CVE-2021-44228) onto the compile classpath.

`flink-common` already excludes `org.apache.logging.log4j` from its `hive2.exec` dependency; the versioned Flink modules omit the same exclude on `hive2.common`. This change makes them consistent, removes the vulnerable log4j from the compile classpath, and avoids SCA false positives. The `flink-runtime` shadow jar already forbids `org.apache.logging.log4j`, so the connector runtime artifact is unaffected.

Fixes #11899

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Local compilation of all three modules:

```
./gradlew :flink-connector:flink-1.18:compileJava \
          :flink-connector:flink-1.19:compileJava \
          :flink-connector:flink-1.20:compileJava
```

All succeed; the connector code does not reference log4j classes.
