### PR TITLE
[MINOR] chore(web-v2): Allow newer Node.js versions

### DIFF
--- a/web-v2/web/package.json
+++ b/web-v2/web/package.json
@@ -2,7 +2,7 @@
   "name": "gravitino-web",
   "private": true,
   "engines": {
-    "node": "20.19.0",
+    "node": ">=20.19.0",
     "npm": ">=9.8.1"
   },
   "scripts": {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR relaxes the Node.js engine constraint in web-v2 from an exact version to a minimum version:

```json
"node": ">=20.19.0"
```

This makes web-v2 consistent with web v1, which already uses `>=20.19.0`.

### Why are the changes needed?

web v1 and web-v2 are both built by the Gradle Node plugin with Node.js `20.19.0`. However, their `package.json` engine constraints are inconsistent:

- web v1 uses `>=20.19.0`
- web-v2 uses exactly `20.19.0`

Because `web-v2/web/.npmrc` enables `engine-strict=true`, local `pnpm` commands fail when using newer Node.js versions, even if they satisfy the intended minimum version requirement.

Gradle still builds web-v2 with Node.js `20.19.0`, so this change does not affect the Gradle-managed build environment.

Fix: N/A

### Does this PR introduce _any_ user-facing change?

No end-user-facing change.

For developers, local web-v2 commands can now run with Node.js versions newer than `20.19.0`, consistent with web v1.

### How was this patch tested?

Not run. The change only relaxes the `engines.node` semver range in `web-v2/web/package.json`.