### PR TITLE
[MINOR] fix(workflow): refresh docker login action SHA for ASF allowlist

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -118,7 +118,7 @@ jobs:
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
 
       - name: Login to Docker Hub
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           username: ${{ github.event.inputs.username }}
           password: ${{ secrets.DOCKER_REPOSITORY_PASSWORD }}


### PR DESCRIPTION
### What changes were proposed in this pull request?

Update `.github/workflows/docker-image.yml` to replace the expired
`docker/login-action` v4.0.0 SHA with the current ASF-allowlisted
v4.2.0 SHA.

### Why are the changes needed?

The existing `docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2`
reference is no longer on the ASF allowlist, which causes
`asf-allowlist-check` to fail when scanning repository workflows.

Fix: N/A

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Ran the ASF allowlist check locally against `.github/**/*.y*ml`;
all 19 unique action refs passed.
