### PR TITLE
[#11907] feat(trino-connector): Support selecting Trino IT container subset via TEST_CONTAINERS

### DIFF
--- a/integration-test-common/docker-script/compose-env.sh
+++ b/integration-test-common/docker-script/compose-env.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
@@ -16,20 +15,17 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
 #
-cd "$(dirname "$0")"
 
-LOG_DIR=../build/trino-ci-container-log
-if [ -d $LOG_DIR ]; then
-  if [ -n "$(docker ps -aq -f name=trino-ci-hive)" ]; then
-    docker cp trino-ci-hive:/usr/local/hadoop/logs $LOG_DIR/hdfs
-    docker cp trino-ci-hive:/tmp/root $LOG_DIR/hive
-  fi
-  if [ -n "$(docker ps -aq -f name=trino-ci-trino)" ]; then
-    docker cp trino-ci-trino:/tmp/trino.log $LOG_DIR/trino.log
-  fi
+TEST_CONTAINERS=${TEST_CONTAINERS:-default}
+
+if [ "$TEST_CONTAINERS" = "default" ]; then
+  COMPOSE_FILE=docker-compose.yaml
+else
+  COMPOSE_FILE=docker-compose-trino-${TEST_CONTAINERS}.yaml
 fi
 
-export GRAVITINO_TRINO_CONNECTOR_DIR=/dev/null
-docker compose down --remove-orphans
+if [ ! -f "$COMPOSE_FILE" ]; then
+  echo "ERROR: Unsupported TEST_CONTAINERS value: $TEST_CONTAINERS (expected compose file $COMPOSE_FILE not found)."
+  exit 1
+fi

--- a/integration-test-common/docker-script/docker-compose-trino-mysql.yaml
+++ b/integration-test-common/docker-script/docker-compose-trino-mysql.yaml
@@ -1,0 +1,66 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+services:
+  mysql:
+    image: mysql:8.0
+    container_name: trino-ci-mysql
+    volumes:
+      - ./init/mysql:/docker-entrypoint-initdb.d/
+    environment:
+      MYSQL_ROOT_PASSWORD: ds123
+      MYSQL_USER: trino
+      MYSQL_PASSWORD: ds123
+      MYSQL_DATABASE: gt_db
+    command:
+      --default-authentication-plugin=mysql_native_password
+      --character-set-server=utf8mb4
+      --collation-server=utf8mb4_general_ci
+      --explicit_defaults_for_timestamp=true
+      --lower_case_table_names=1
+    healthcheck:
+      test: ["CMD-SHELL", "mysqladmin ping"]
+      interval: 10s
+      timeout: 60s
+      retries: 5
+
+  trino:
+    image: trinodb/trino:${TRINO_VERSION:-478}
+    container_name: trino-ci-trino
+    environment:
+      - HADOOP_USER_NAME=anonymous
+      - GRAVITINO_HOST_IP=host.docker.internal
+      - GRAVITINO_HOST_PORT=${GRAVITINO_SERVER_PORT:-8090}
+      - GRAVITINO_METALAKE_NAME=test
+      - TRINO_WORKER_NUM=0
+      - TRINO_ROLE=coordinator
+    entrypoint: /bin/bash /tmp/trino/init.sh
+    volumes:
+      - ./init/trino:/tmp/trino
+      - ${GRAVITINO_TRINO_CONNECTOR_DIR:-../../trino-connector/trino-connector-473-478/build/libs}:/usr/lib/trino/plugin/gravitino
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    healthcheck:
+      test: ["CMD", "trino", "--execute", "SELECT 1"]
+      interval: 10s
+      timeout: 60s
+      retries: 5
+    depends_on:
+      mysql:
+        condition: service_healthy

--- a/integration-test-common/docker-script/docker-compose-trino-mysql.yaml
+++ b/integration-test-common/docker-script/docker-compose-trino-mysql.yaml
@@ -64,3 +64,11 @@ services:
     depends_on:
       mysql:
         condition: service_healthy
+
+networks:
+  default:
+    name: trino-net
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 10.20.31.16/28

--- a/integration-test-common/docker-script/docker-compose.yaml
+++ b/integration-test-common/docker-script/docker-compose.yaml
@@ -141,6 +141,7 @@ services:
 
 networks:
   default:
+    name: trino-net
     driver: bridge
     ipam:
       config:

--- a/integration-test-common/docker-script/docker-compose.yaml
+++ b/integration-test-common/docker-script/docker-compose.yaml
@@ -21,7 +21,7 @@ services:
   hive:
     image: apache/gravitino-ci:hive-0.1.20
     networks:
-      - trino-net
+      - default
     container_name: trino-ci-hive
     environment:
       - HADOOP_USER_NAME=anonymous
@@ -45,7 +45,7 @@ services:
       POSTGRES_PASSWORD: ds123
       ALLOW_IP_RANGE: 0.0.0.0/0
     networks:
-      - trino-net
+      - default
     volumes:
       - ./init/postgres:/docker-entrypoint-initdb.d/
     healthcheck:
@@ -58,7 +58,7 @@ services:
     image: mysql:8.0
     container_name: trino-ci-mysql
     networks:
-      - trino-net
+      - default
     volumes:
       - ./init/mysql:/docker-entrypoint-initdb.d/
     environment:
@@ -81,7 +81,7 @@ services:
   trino:
     image: trinodb/trino:${TRINO_VERSION:-478}
     networks:
-      - trino-net
+      - default
     container_name: trino-ci-trino
     environment:
       - HADOOP_USER_NAME=anonymous
@@ -115,7 +115,7 @@ services:
   trino-worker:
     image: trinodb/trino:${TRINO_VERSION:-478}
     networks:
-      - trino-net
+      - default
     deploy:
       replicas: ${TRINO_WORKER_NUM:-0}
     environment:
@@ -140,9 +140,8 @@ services:
         condition: service_healthy
 
 networks:
-  trino-net:
+  default:
     driver: bridge
-    name: trino-net
     ipam:
       config:
         - subnet: 10.20.31.16/28

--- a/integration-test-common/docker-script/inspect_ip.sh
+++ b/integration-test-common/docker-script/inspect_ip.sh
@@ -18,5 +18,24 @@
 # under the License.
 
 #
+cd "$(dirname "$0")"
 
-docker inspect --format='{{.Name}}:{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' $(docker ps -q) |grep "/trino-ci-" | sed 's/\/trino-ci-//g'
+container_urls=$(docker inspect --format='{{.Name}}:{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' $(docker ps -q) | grep "/trino-ci-" | sed 's/\/trino-ci-//g')
+
+while IFS=: read -r container_name address; do
+  case "$container_name" in
+    trino)
+      echo "trino_uri=http://$address:8080"
+      ;;
+    hive)
+      echo "hive_uri=thrift://$address:9083"
+      echo "hdfs_uri=hdfs://$address:9000"
+      ;;
+    mysql)
+      echo "mysql_uri=jdbc:mysql://$address:3306"
+      ;;
+    postgresql)
+      echo "postgresql_uri=jdbc:postgresql://$address"
+      ;;
+  esac
+done <<< "$container_urls"

--- a/integration-test-common/docker-script/launch.sh
+++ b/integration-test-common/docker-script/launch.sh
@@ -31,6 +31,7 @@ then
 fi
 
 cd ${playground_dir}
+source ./compose-env.sh
 
 # create log dir
 LOG_DIR=../build/trino-ci-container-log
@@ -39,10 +40,14 @@ mkdir -p $LOG_DIR
 LOG_PATH=$LOG_DIR/trino-ci-docker-compose.log
 echo "The docker compose log is: $LOG_PATH"
 
-docker compose up -d
+docker compose -f "$COMPOSE_FILE" up -d
+
+# Count actual created services (excludes services scaled to 0 replicas,
+# e.g. trino-worker when TRINO_WORKER_NUM is unset).
+EXPECTED_SERVICE_COUNT=$(docker compose -f "$COMPOSE_FILE" ps --services | wc -l)
 
 # Stream logs directly to the log file (no console output).
-nohup docker compose logs -f -t | tee -a "$LOG_PATH" &
+nohup docker compose -f "$COMPOSE_FILE" logs -f -t | tee -a "$LOG_PATH" &
 LOG_FOLLOW_PID=$!
 cleanup_log_follow() {
   if [ -n "$LOG_FOLLOW_PID" ] && kill -0 "$LOG_FOLLOW_PID" 2>/dev/null; then
@@ -55,12 +60,12 @@ max_attempts=300
 attempts=0
 
 while true; do
-    docker compose exec -T trino trino --execute "SELECT 1" >/dev/null 2>&1 && {
+    docker compose -f "$COMPOSE_FILE" exec -T trino trino --execute "SELECT 1" >/dev/null 2>&1 && {
         break;
     }
 
-    num_container=$(docker ps --format '{{.Names}}' | grep trino-ci | wc -l)
-    if [ "$num_container" -lt 4 ]; then
+    num_container=$(docker compose -f "$COMPOSE_FILE" ps -q | wc -l)
+    if [ "$num_container" -lt "$EXPECTED_SERVICE_COUNT" ]; then
         echo "ERROR: Trino-ci containers start failed."
         exit 0
     fi
@@ -74,28 +79,30 @@ while true; do
     sleep 1
 done
 
-# Wait for HDFS to be fully ready
-echo "Waiting for HDFS to be fully ready..."
-hdfs_attempts=0
-hdfs_max_attempts=60
+if docker compose -f "$COMPOSE_FILE" ps --services | grep -q "^hive$"; then
+  # Wait for HDFS to be fully ready
+  echo "Waiting for HDFS to be fully ready..."
+  hdfs_attempts=0
+  hdfs_max_attempts=60
 
-while true; do
-    # Check if HDFS DataNode is ready by testing file creation
-    docker compose exec -T hive hdfs dfs -test -d / >/dev/null 2>&1 && \
-    docker compose exec -T hive hdfs dfsadmin -report 2>/dev/null | grep -q "Live datanodes" && {
-        echo "HDFS is ready."
-        # Give HDFS a bit more time to stabilize
-        sleep 5
-        break;
-    }
+  while true; do
+      # Check if HDFS DataNode is ready by testing file creation
+      docker compose -f "$COMPOSE_FILE" exec -T hive hdfs dfs -test -d / >/dev/null 2>&1 && \
+      docker compose -f "$COMPOSE_FILE" exec -T hive hdfs dfsadmin -report 2>/dev/null | grep -q "Live datanodes" && {
+          echo "HDFS is ready."
+          # Give HDFS a bit more time to stabilize
+          sleep 5
+          break;
+      }
 
-    if [ "$hdfs_attempts" -ge "$hdfs_max_attempts" ]; then
-        echo "WARNING: HDFS did not become fully ready within $hdfs_max_attempts seconds, but continuing..."
-        break
-    fi
+      if [ "$hdfs_attempts" -ge "$hdfs_max_attempts" ]; then
+          echo "WARNING: HDFS did not become fully ready within $hdfs_max_attempts seconds, but continuing..."
+          break
+      fi
 
-    ((hdfs_attempts++))
-    sleep 1
-done
+      ((hdfs_attempts++))
+      sleep 1
+  done
+fi
 
 echo "All docker compose service is now available."

--- a/integration-test-common/docker-script/launch.sh
+++ b/integration-test-common/docker-script/launch.sh
@@ -67,7 +67,7 @@ while true; do
     num_container=$(docker compose -f "$COMPOSE_FILE" ps -q | wc -l)
     if [ "$num_container" -lt "$EXPECTED_SERVICE_COUNT" ]; then
         echo "ERROR: Trino-ci containers start failed."
-        exit 0
+        exit 1
     fi
 
     if [ "$attempts" -ge "$max_attempts" ]; then

--- a/integration-test-common/docker-script/shutdown.sh
+++ b/integration-test-common/docker-script/shutdown.sh
@@ -32,4 +32,6 @@ if [ -d $LOG_DIR ]; then
 fi
 
 export GRAVITINO_TRINO_CONNECTOR_DIR=/dev/null
-docker compose down --remove-orphans
+for compose_file in docker-compose*.yaml; do
+  docker compose -f "$compose_file" down --remove-orphans
+done

--- a/integration-test-common/src/test/java/org/apache/gravitino/integration/test/container/TrinoITContainers.java
+++ b/integration-test-common/src/test/java/org/apache/gravitino/integration/test/container/TrinoITContainers.java
@@ -19,6 +19,7 @@
 package org.apache.gravitino.integration.test.container;
 
 import java.io.File;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.gravitino.integration.test.util.CommandExecutor;
@@ -159,7 +160,7 @@ public class TrinoITContainers implements AutoCloseable {
   }
 
   public Map<String, String> getServiceUrls() {
-    return servicesUri;
+    return Collections.unmodifiableMap(new HashMap<>(servicesUri));
   }
 
   @Override

--- a/integration-test-common/src/test/java/org/apache/gravitino/integration/test/container/TrinoITContainers.java
+++ b/integration-test-common/src/test/java/org/apache/gravitino/integration/test/container/TrinoITContainers.java
@@ -18,7 +18,6 @@
  */
 package org.apache.gravitino.integration.test.container;
 
-import com.google.common.collect.ImmutableSet;
 import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
@@ -33,12 +32,12 @@ import org.testcontainers.containers.ContainerLaunchException;
 public class TrinoITContainers implements AutoCloseable {
   private static final Logger LOG = LoggerFactory.getLogger(TrinoITContainers.class);
 
+  private static final String TEST_CONTAINERS = "TEST_CONTAINERS";
+
   public static String dockerComposeDir;
 
-  private static ImmutableSet<String> servicesName =
-      ImmutableSet.of("trino", "hive_metastore", "hdfs", "mysql", "postgresql");
-
   Map<String, String> servicesUri = new HashMap<>();
+  private final Map<String, String> containerEnv = new HashMap<>();
 
   TrinoITContainers() {
     String dir = System.getenv("GRAVITINO_ROOT_DIR");
@@ -50,7 +49,7 @@ public class TrinoITContainers implements AutoCloseable {
   }
 
   public void launch(int gravitinoServerPort) throws Exception {
-    launch(gravitinoServerPort, "hive2", false, null, null, null);
+    launch(gravitinoServerPort, "hive2", false, null, null, null, null);
   }
 
   public void launch(
@@ -59,9 +58,10 @@ public class TrinoITContainers implements AutoCloseable {
       boolean isTrinoConnectorTest,
       Integer trinoWorkerNum,
       Integer trinoVersion,
-      String trinoConnectorDir)
+      String trinoConnectorDir,
+      String testContainers)
       throws Exception {
-    shutdown();
+    servicesUri.clear();
 
     Map<String, String> env = new HashMap<>();
     if (trinoWorkerNum != null) {
@@ -80,11 +80,20 @@ public class TrinoITContainers implements AutoCloseable {
       env.put("GRAVITINO_TRINO_CONNECTOR_DIR", trinoConnectorDir);
     }
     env.put("GRAVITINO_SERVER_PORT", String.valueOf(gravitinoServerPort));
-    env.put("HIVE_RUNTIME_VERSION", hiveRuntimeVersion);
     env.put("TRINO_CONNECTOR_TEST", String.valueOf(isTrinoConnectorTest));
+    if (hiveRuntimeVersion != null) {
+      env.put("HIVE_RUNTIME_VERSION", hiveRuntimeVersion);
+    }
+    if (Strings.isNotBlank(testContainers)) {
+      env.put(TEST_CONTAINERS, testContainers);
+    }
     if (System.getProperty("gravitino.log.path") != null) {
       env.put("GRAVITINO_LOG_PATH", System.getProperty("gravitino.log.path"));
     }
+    containerEnv.clear();
+    containerEnv.putAll(env);
+
+    shutdown();
 
     LOG.info("Launching containers with env: {}", env);
     String command = ITUtils.joinPath(dockerComposeDir, "launch.sh");
@@ -106,49 +115,38 @@ public class TrinoITContainers implements AutoCloseable {
     String command = ITUtils.joinPath(dockerComposeDir, "inspect_ip.sh");
     Object output =
         CommandExecutor.executeCommandLocalHost(
-            command, false, ProcessData.TypesOfData.STREAMS_MERGED);
+            command, false, ProcessData.TypesOfData.STREAMS_MERGED, containerEnv);
     LOG.info("Command {} output:\n{}", command, output);
 
     // expect the output to be like:
-    // trino:10.20.30.21
-    // hive:10.20.30.19
-    // mysql:10.20.30.20
-    // postgresql:10.20.30.18
+    // trino_uri=http://10.20.30.21:8080
+    // hive_uri=thrift://10.20.30.19:9083
+    // hdfs_uri=hdfs://10.20.30.19:9000
+    // mysql_uri=jdbc:mysql://10.20.30.20:3306
+    // postgresql_uri=jdbc:postgresql://10.20.30.18
 
-    String containerIpMapping = output.toString();
-    if (containerIpMapping.isEmpty()) {
+    String serviceURLs = output.toString();
+    if (serviceURLs.isEmpty()) {
       throw new ContainerLaunchException(
           "Failed to get the container status, the containers have not started");
     }
 
     try {
-      String[] containerInfos = containerIpMapping.split("\n");
-      for (String container : containerInfos) {
-        String[] info = container.split(":");
-
-        String containerName = info[0];
-        String address = info[1];
-
-        if (containerName.equals("trino")) {
-          servicesUri.put("trino", String.format("http://%s:8080", address));
-        } else if (containerName.equals("hive")) {
-          servicesUri.put("hive_metastore", String.format("thrift://%s:9083", address));
-          servicesUri.put("hdfs", String.format("hdfs://%s:9000", address));
-        } else if (containerName.equals("mysql")) {
-          servicesUri.put("mysql", String.format("jdbc:mysql://%s:3306", address));
-        } else if (containerName.equals("postgresql")) {
-          servicesUri.put("postgresql", String.format("jdbc:postgresql://%s", address));
+      String[] serviceInfos = serviceURLs.split("\n");
+      for (String serviceInfo : serviceInfos) {
+        String[] info = serviceInfo.split("=", 2);
+        if (info.length != 2) {
+          continue;
         }
+
+        servicesUri.put(info[0], info[1]);
       }
     } catch (Exception e) {
-      throw new ContainerLaunchException("Unexpected container status :\n" + containerIpMapping, e);
+      throw new ContainerLaunchException("Unexpected container status :\n" + serviceURLs, e);
     }
 
-    for (String serviceName : servicesName) {
-      if (!servicesUri.containsKey(serviceName)) {
-        throw new ContainerLaunchException(
-            String.format("The container for the %s service is not started: ", serviceName));
-      }
+    if (!servicesUri.containsKey("trino_uri")) {
+      throw new ContainerLaunchException("The container for the trino service is not started");
     }
   }
 
@@ -156,28 +154,12 @@ public class TrinoITContainers implements AutoCloseable {
     String command = ITUtils.joinPath(dockerComposeDir, "shutdown.sh");
     Object output =
         CommandExecutor.executeCommandLocalHost(
-            command, false, ProcessData.TypesOfData.STREAMS_MERGED);
+            command, false, ProcessData.TypesOfData.STREAMS_MERGED, containerEnv);
     LOG.info("Command {} output:\n{}", command, output);
   }
 
-  public String getTrinoUri() {
-    return servicesUri.get("trino");
-  }
-
-  public String getHiveMetastoreUri() {
-    return servicesUri.get("hive_metastore");
-  }
-
-  public String getHdfsUri() {
-    return servicesUri.get("hdfs");
-  }
-
-  public String getMysqlUri() {
-    return servicesUri.get("mysql");
-  }
-
-  public String getPostgresqlUri() {
-    return servicesUri.get("postgresql");
+  public Map<String, String> getServiceUrls() {
+    return servicesUri;
   }
 
   @Override

--- a/trino-connector/integration-test/src/test/java/org/apache/gravitino/trino/connector/integration/test/TrinoQueryIT.java
+++ b/trino-connector/integration-test/src/test/java/org/apache/gravitino/trino/connector/integration/test/TrinoQueryIT.java
@@ -74,13 +74,16 @@ public class TrinoQueryIT extends TrinoQueryITBase {
 
   static String trinoConnectorDir;
 
+  static String testContainers;
+
   static {
     testsetsDir = TrinoQueryIT.class.getClassLoader().getResource("trino-ci-testset").getPath();
     testsetsDir = ITUtils.joinPath(testsetsDir, "testsets");
   }
 
   public void setup() throws Exception {
-    trinoQueryITBase = new TrinoQueryITBase(trinoWorkerNum, trinoVersion, trinoConnectorDir);
+    trinoQueryITBase =
+        new TrinoQueryITBase(trinoWorkerNum, trinoVersion, trinoConnectorDir, testContainers);
     trinoQueryITBase.setup();
     cleanupTestEnv();
 

--- a/trino-connector/integration-test/src/test/java/org/apache/gravitino/trino/connector/integration/test/TrinoQueryITBase.java
+++ b/trino-connector/integration-test/src/test/java/org/apache/gravitino/trino/connector/integration/test/TrinoQueryITBase.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import org.apache.commons.io.FileUtils;
 import org.apache.gravitino.Catalog;
@@ -64,6 +65,7 @@ public class TrinoQueryITBase {
   protected static GravitinoAdminClient gravitinoClient;
   protected static TrinoITContainers trinoITContainers;
   protected static TrinoQueryRunner trinoQueryRunner;
+  protected static Map<String, String> serviceUrls = new HashMap<>();
 
   protected static final String metalakeName = "test";
   protected static GravitinoMetalake metalake;
@@ -76,12 +78,19 @@ public class TrinoQueryITBase {
 
   protected String trinoConnectorDir;
 
+  protected String testContainers;
+
   public TrinoQueryITBase() {}
 
-  public TrinoQueryITBase(Integer trinoWorkerNum, Integer trinoVersion, String trinoConnectorDir) {
+  public TrinoQueryITBase(
+      Integer trinoWorkerNum,
+      Integer trinoVersion,
+      String trinoConnectorDir,
+      String testContainers) {
     this.trinoWorkerNum = trinoWorkerNum;
     this.trinoVersion = trinoVersion;
     this.trinoConnectorDir = trinoConnectorDir;
+    this.testContainers = testContainers;
   }
 
   private void setEnv() throws Exception {
@@ -112,13 +121,16 @@ public class TrinoQueryITBase {
           isTrinoConnectorTest,
           trinoWorkerNum,
           trinoVersion,
-          trinoConnectorDir);
+          trinoConnectorDir,
+          testContainers);
 
-      trinoUri = trinoITContainers.getTrinoUri();
-      hiveMetastoreUri = trinoITContainers.getHiveMetastoreUri();
-      hdfsUri = trinoITContainers.getHdfsUri();
-      mysqlUri = trinoITContainers.getMysqlUri();
-      postgresqlUri = trinoITContainers.getPostgresqlUri();
+      serviceUrls.clear();
+      serviceUrls.putAll(trinoITContainers.getServiceUrls());
+      trinoUri = serviceUrls.getOrDefault("trino_uri", trinoUri);
+      hiveMetastoreUri = serviceUrls.getOrDefault("hive_uri", hiveMetastoreUri);
+      hdfsUri = serviceUrls.getOrDefault("hdfs_uri", hdfsUri);
+      mysqlUri = serviceUrls.getOrDefault("mysql_uri", mysqlUri);
+      postgresqlUri = serviceUrls.getOrDefault("postgresql_uri", postgresqlUri);
 
     } else if (autoStartGravitino) {
       baseIT.startIntegrationTest();

--- a/trino-connector/integration-test/src/test/java/org/apache/gravitino/trino/connector/integration/test/TrinoQueryTestTool.java
+++ b/trino-connector/integration-test/src/test/java/org/apache/gravitino/trino/connector/integration/test/TrinoQueryTestTool.java
@@ -109,6 +109,11 @@ public class TrinoQueryTestTool {
               + "the default value is ${project_root}/trino-connector/trino-connector/build/libs.");
 
       options.addOption(
+          "test_containers",
+          true,
+          "Specify the docker compose test containers to start, the default value is 'default'.");
+
+      options.addOption(
           "env_only",
           false,
           "Start the environment (Gravitino + Trino) and keep it running for manual testing. Press Ctrl+C to shutdown.");
@@ -258,6 +263,7 @@ public class TrinoQueryTestTool {
       TrinoQueryIT.trinoWorkerNum = extractIntValue(commandLine, "trino_worker_num");
       TrinoQueryIT.trinoVersion = extractIntValue(commandLine, "trino_version");
       TrinoQueryIT.trinoConnectorDir = commandLine.getOptionValue("trino_connector_dir");
+      TrinoQueryIT.testContainers = commandLine.getOptionValue("test_containers");
 
       checkEnv();
 

--- a/trino-connector/integration-test/trino-test-tools/trino_integration_test.sh
+++ b/trino-connector/integration-test/trino-test-tools/trino_integration_test.sh
@@ -60,6 +60,8 @@ fi
 # --trino_version is forwarded to Gradle and also used for patch selection.
 auto_patch=false
 trino_version=""
+test_set=""
+has_test_containers=false
 args=""
 for arg in "$@"; do
     case "$arg" in
@@ -70,12 +72,29 @@ for arg in "$@"; do
             trino_version="${arg#*=}"
             args="$args $arg"
             ;;
+        --test_set=*)
+            test_set="${arg#*=}"
+            args="$args $arg"
+            ;;
+        --test_containers=*)
+            has_test_containers=true
+            args="$args $arg"
+            ;;
         *)
             args="$args $arg"
             ;;
     esac
 done
 args="${args# }"
+
+# Auto-map a testset to its dedicated docker compose container subset, unless
+# --test_containers was already given explicitly on the command line.
+declare -A TESTSET_CONTAINERS_MAP=(
+    ["jdbc-mysql"]="mysql"
+)
+if [ "$has_test_containers" = false ] && [ -n "${TESTSET_CONTAINERS_MAP[$test_set]:-}" ]; then
+    args="$args --test_containers=${TESTSET_CONTAINERS_MAP[$test_set]}"
+fi
 
 TESTSETS_DIR="$GRAVITINO_ROOT_DIR/trino-connector/integration-test/src/test/resources/trino-ci-testset/testsets"
 

--- a/web-v2/integration-test/src/test/java/org/apache/gravitino/integration/test/web/ui/CatalogsPageTest.java
+++ b/web-v2/integration-test/src/test/java/org/apache/gravitino/integration/test/web/ui/CatalogsPageTest.java
@@ -123,10 +123,11 @@ public class CatalogsPageTest extends BaseWebIT {
     trinoITContainers = ContainerSuite.getTrinoITContainers();
     trinoITContainers.launch(getGravitinoServerPort());
 
-    hiveMetastoreUri = trinoITContainers.getHiveMetastoreUri();
-    hdfsUri = trinoITContainers.getHdfsUri();
-    mysqlUri = trinoITContainers.getMysqlUri();
-    postgresqlUri = trinoITContainers.getPostgresqlUri();
+    Map<String, String> serviceUrls = trinoITContainers.getServiceUrls();
+    hiveMetastoreUri = serviceUrls.get("hive_uri");
+    hdfsUri = serviceUrls.get("hdfs_uri");
+    mysqlUri = serviceUrls.get("mysql_uri");
+    postgresqlUri = serviceUrls.get("postgresql_uri");
 
     metalakePage = new MetalakePage(driver);
     catalogsPage = new CatalogsPage(driver);

--- a/web/integration-test/src/test/java/org/apache/gravitino/integration/test/web/ui/CatalogsPageTest.java
+++ b/web/integration-test/src/test/java/org/apache/gravitino/integration/test/web/ui/CatalogsPageTest.java
@@ -123,10 +123,11 @@ public class CatalogsPageTest extends BaseWebIT {
     trinoITContainers = ContainerSuite.getTrinoITContainers();
     trinoITContainers.launch(getGravitinoServerPort());
 
-    hiveMetastoreUri = trinoITContainers.getHiveMetastoreUri();
-    hdfsUri = trinoITContainers.getHdfsUri();
-    mysqlUri = trinoITContainers.getMysqlUri();
-    postgresqlUri = trinoITContainers.getPostgresqlUri();
+    Map<String, String> serviceUrls = trinoITContainers.getServiceUrls();
+    hiveMetastoreUri = serviceUrls.get("hive_uri");
+    hdfsUri = serviceUrls.get("hdfs_uri");
+    mysqlUri = serviceUrls.get("mysql_uri");
+    postgresqlUri = serviceUrls.get("postgresql_uri");
 
     metalakePage = new MetalakePage(driver);
     catalogsPage = new CatalogsPage(driver);


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add a `TEST_CONTAINERS` env var / `--test_containers` CLI option so Trino IT can start only the containers a test needs (e.g. `trino`+`mysql`) instead of the full stack. `TrinoITContainers` now exposes a generic `getServiceUrls()` map instead of fixed getters; `launch.sh`/`shutdown.sh`/`inspect_ip.sh` no longer assume the full container set; adds `docker-compose-trino-mysql.yaml` as the first subset; `trino_integration_test.sh` auto-maps `--test_set=jdbc-mysql` to `--test_containers=mysql`.

### Why are the changes needed?

Trino IT always starts the full container stack even when a testset only needs one backend.

Fix: #11907

### Does this PR introduce _any_ user-facing change?

Adds an optional `--test_containers` CLI flag / `TEST_CONTAINERS` env var; default (full stack) unchanged.

### How was this patch tested?

Ran `trino_integration_test.sh` with default full-stack and mysql-only subset against `jdbc-mysql`. Manually verified launch/inspect/shutdown scripts clean up containers and networks correctly.