### PR TITLE
[#10805] Support bulk user operations

### DIFF
--- a/common/src/main/java/org/apache/gravitino/dto/requests/BulkRequestValidator.java
+++ b/common/src/main/java/org/apache/gravitino/dto/requests/BulkRequestValidator.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.dto.requests;
+
+import com.google.common.base.Preconditions;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+
+class BulkRequestValidator {
+
+  private BulkRequestValidator() {}
+
+  static void checkNoDuplicateNames(String fieldName, String[] names) {
+    Set<String> nameSet = new HashSet<>();
+    for (String name : names) {
+      Preconditions.checkArgument(
+          nameSet.add(name), "\"%s\" cannot contain duplicated name: %s", fieldName, name);
+    }
+  }
+
+  static void checkNoDuplicateNames(String fieldName, UserAddRequest[] requests) {
+    checkNoDuplicateNames(
+        fieldName, Arrays.stream(requests).map(UserAddRequest::getName).toArray(String[]::new));
+  }
+
+  static void checkNoDuplicateExternalIds(String fieldName, UserAddRequest[] requests) {
+    Set<String> externalIdSet = new HashSet<>();
+    Arrays.stream(requests)
+        .map(UserAddRequest::getExternalId)
+        .filter(Objects::nonNull)
+        .forEach(
+            externalId ->
+                Preconditions.checkArgument(
+                    externalIdSet.add(externalId),
+                    "\"%s\" cannot contain duplicated external id: %s",
+                    fieldName,
+                    externalId));
+  }
+}

--- a/common/src/main/java/org/apache/gravitino/dto/requests/BulkUserAddRequest.java
+++ b/common/src/main/java/org/apache/gravitino/dto/requests/BulkUserAddRequest.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.dto.requests;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Preconditions;
+import java.util.Arrays;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+import lombok.extern.jackson.Jacksonized;
+import org.apache.gravitino.rest.RESTRequest;
+
+/** Represents a request to add multiple users. */
+@Getter
+@EqualsAndHashCode
+@ToString
+@Builder
+@Jacksonized
+public class BulkUserAddRequest implements RESTRequest {
+
+  @JsonProperty("users")
+  private final UserAddRequest[] users;
+
+  /** Default constructor for BulkUserAddRequest. (Used for Jackson deserialization.) */
+  public BulkUserAddRequest() {
+    this(null);
+  }
+
+  /**
+   * Creates a new BulkUserAddRequest.
+   *
+   * @param users The users to add.
+   */
+  public BulkUserAddRequest(UserAddRequest[] users) {
+    this.users = users;
+  }
+
+  /**
+   * Validates the {@link BulkUserAddRequest} request.
+   *
+   * @throws IllegalArgumentException If the request is invalid, this exception is thrown.
+   */
+  @Override
+  public void validate() throws IllegalArgumentException {
+    Preconditions.checkArgument(users != null, "\"users\" field is required");
+    Preconditions.checkArgument(users.length > 0, "\"users\" field cannot be empty");
+    Arrays.stream(users)
+        .forEach(
+            user -> {
+              Preconditions.checkArgument(user != null, "\"users\" cannot contain null item");
+              user.validate();
+            });
+    BulkRequestValidator.checkNoDuplicateNames("users", users);
+    BulkRequestValidator.checkNoDuplicateExternalIds("users", users);
+  }
+}

--- a/common/src/main/java/org/apache/gravitino/dto/requests/UsernamesRequest.java
+++ b/common/src/main/java/org/apache/gravitino/dto/requests/UsernamesRequest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.dto.requests;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Preconditions;
+import java.util.Arrays;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+import lombok.extern.jackson.Jacksonized;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.gravitino.rest.RESTRequest;
+
+/** Represents a request to operate on multiple users. */
+@Getter
+@EqualsAndHashCode
+@ToString
+@Builder
+@Jacksonized
+public class UsernamesRequest implements RESTRequest {
+
+  @JsonProperty("usernames")
+  private final String[] usernames;
+
+  /** Default constructor for UsernamesRequest. (Used for Jackson deserialization.) */
+  public UsernamesRequest() {
+    this(null);
+  }
+
+  /**
+   * Creates a new UsernamesRequest.
+   *
+   * @param usernames The usernames to operate on.
+   */
+  public UsernamesRequest(String[] usernames) {
+    this.usernames = usernames;
+  }
+
+  /**
+   * Validates the {@link UsernamesRequest} request.
+   *
+   * @throws IllegalArgumentException If the request is invalid, this exception is thrown.
+   */
+  @Override
+  public void validate() throws IllegalArgumentException {
+    Preconditions.checkArgument(usernames != null, "\"usernames\" field is required");
+    Preconditions.checkArgument(usernames.length > 0, "\"usernames\" field cannot be empty");
+    Arrays.stream(usernames)
+        .forEach(
+            username ->
+                Preconditions.checkArgument(
+                    StringUtils.isNotBlank(username), "\"usernames\" cannot contain blank name"));
+    BulkRequestValidator.checkNoDuplicateNames("usernames", usernames);
+  }
+}

--- a/common/src/main/java/org/apache/gravitino/dto/responses/BulkOperationFailureDTO.java
+++ b/common/src/main/java/org/apache/gravitino/dto/responses/BulkOperationFailureDTO.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.dto.responses;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Preconditions;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+import org.apache.commons.lang3.StringUtils;
+
+/** Represents a failed item in a bulk operation response. */
+@Getter
+@EqualsAndHashCode
+@ToString
+public class BulkOperationFailureDTO {
+
+  @JsonProperty("name")
+  private final String name;
+
+  @JsonProperty("reason")
+  private final String reason;
+
+  /** Default constructor for BulkOperationFailureDTO. (Used for Jackson deserialization.) */
+  public BulkOperationFailureDTO() {
+    this(null, null);
+  }
+
+  /**
+   * Creates a new BulkOperationFailureDTO.
+   *
+   * @param name The failed entity name.
+   * @param reason The failure reason.
+   */
+  public BulkOperationFailureDTO(String name, String reason) {
+    this.name = name;
+    this.reason = reason;
+  }
+
+  /** Validates this failed item. */
+  public void validate() {
+    Preconditions.checkArgument(StringUtils.isNotBlank(name), "\"name\" must not be blank");
+    Preconditions.checkArgument(StringUtils.isNotBlank(reason), "\"reason\" must not be blank");
+  }
+}

--- a/common/src/main/java/org/apache/gravitino/dto/responses/BulkOperationResponse.java
+++ b/common/src/main/java/org/apache/gravitino/dto/responses/BulkOperationResponse.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.dto.responses;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Preconditions;
+import java.util.Arrays;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+import org.apache.commons.lang3.StringUtils;
+
+/** Represents the result of a bulk operation. */
+@Getter
+@ToString
+@EqualsAndHashCode(callSuper = true)
+public class BulkOperationResponse extends BaseResponse {
+
+  @JsonProperty("succeeded")
+  private final String[] succeeded;
+
+  @JsonProperty("failed")
+  private final BulkOperationFailureDTO[] failed;
+
+  /**
+   * Creates a new BulkOperationResponse.
+   *
+   * @param succeeded The successfully processed entity names.
+   * @param failed The failed entity names and reasons.
+   */
+  public BulkOperationResponse(String[] succeeded, BulkOperationFailureDTO[] failed) {
+    this.succeeded = succeeded;
+    this.failed = failed;
+  }
+
+  /** Default constructor for BulkOperationResponse. (Used for Jackson deserialization.) */
+  public BulkOperationResponse() {
+    this(null, null);
+  }
+
+  /**
+   * Validates the {@link BulkOperationResponse} response.
+   *
+   * @throws IllegalArgumentException If the response is invalid, this exception is thrown.
+   */
+  @Override
+  public void validate() throws IllegalArgumentException {
+    super.validate();
+    Preconditions.checkArgument(succeeded != null, "\"succeeded\" must not be null");
+    Preconditions.checkArgument(failed != null, "\"failed\" must not be null");
+    Arrays.stream(succeeded)
+        .forEach(
+            name ->
+                Preconditions.checkArgument(
+                    StringUtils.isNotBlank(name), "\"succeeded\" cannot contain blank name"));
+    Arrays.stream(failed).forEach(BulkOperationFailureDTO::validate);
+  }
+}

--- a/common/src/test/java/org/apache/gravitino/dto/requests/TestBulkRequests.java
+++ b/common/src/test/java/org/apache/gravitino/dto/requests/TestBulkRequests.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.dto.requests;
+
+import org.apache.gravitino.json.JsonUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TestBulkRequests {
+
+  @Test
+  public void testDuplicateUsernames() {
+    UsernamesRequest request = new UsernamesRequest(new String[] {"user1", "user1"});
+
+    Assertions.assertThrows(IllegalArgumentException.class, request::validate);
+  }
+
+  @Test
+  public void testUsernamesRequestJsonField() throws Exception {
+    UsernamesRequest request =
+        JsonUtils.objectMapper()
+            .readValue("{\"usernames\":[\"user1\",\"user2\"]}", UsernamesRequest.class);
+
+    request.validate();
+    Assertions.assertArrayEquals(new String[] {"user1", "user2"}, request.getUsernames());
+  }
+
+  @Test
+  public void testDuplicateUsersForBulkAdd() {
+    BulkUserAddRequest request =
+        new BulkUserAddRequest(
+            new UserAddRequest[] {
+              new UserAddRequest("user1", "external1", true),
+              new UserAddRequest("user1", "external2", true)
+            });
+
+    Assertions.assertThrows(IllegalArgumentException.class, request::validate);
+  }
+
+  @Test
+  public void testDuplicateUserExternalIdsForBulkAdd() {
+    BulkUserAddRequest request =
+        new BulkUserAddRequest(
+            new UserAddRequest[] {
+              new UserAddRequest("user1", "external1", true),
+              new UserAddRequest("user2", "external1", true)
+            });
+
+    Assertions.assertThrows(IllegalArgumentException.class, request::validate);
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/authorization/AccessControlDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/authorization/AccessControlDispatcher.java
@@ -67,6 +67,17 @@ public interface AccessControlDispatcher {
       throws UserAlreadyExistsException, NoSuchMetalakeException;
 
   /**
+   * Adds Users in bulk.
+   *
+   * @param metalake The Metalake of the Users.
+   * @param users The Users to add.
+   * @return The result of the bulk add operation.
+   * @throws NoSuchMetalakeException If the Metalake with the given name does not exist.
+   * @throws RuntimeException If adding the Users encounters storage issues.
+   */
+  BulkOperationResult bulkAddUsers(String metalake, UserAdd[] users) throws NoSuchMetalakeException;
+
+  /**
    * Removes a User.
    *
    * @param metalake The Metalake of the User.
@@ -77,6 +88,18 @@ public interface AccessControlDispatcher {
    * @throws RuntimeException If removing the User encounters storage issues.
    */
   boolean removeUser(String metalake, String user) throws NoSuchMetalakeException;
+
+  /**
+   * Removes Users in bulk.
+   *
+   * @param metalake The Metalake of the Users.
+   * @param users The names of Users to remove.
+   * @return The result of the bulk remove operation.
+   * @throws NoSuchMetalakeException If the Metalake with the given name does not exist.
+   * @throws RuntimeException If removing the Users encounters storage issues.
+   */
+  BulkOperationResult bulkRemoveUsers(String metalake, String[] users)
+      throws NoSuchMetalakeException;
 
   /**
    * Removes a User by external identifier.

--- a/core/src/main/java/org/apache/gravitino/authorization/AccessControlManager.java
+++ b/core/src/main/java/org/apache/gravitino/authorization/AccessControlManager.java
@@ -79,11 +79,60 @@ public class AccessControlManager implements AccessControlDispatcher {
   }
 
   @Override
+  public BulkOperationResult bulkAddUsers(String metalake, UserAdd[] users)
+      throws NoSuchMetalakeException {
+    return TreeLockUtils.doWithTreeLock(
+        NameIdentifier.of(AuthorizationUtils.ofUserNamespace(metalake).levels()),
+        LockType.WRITE,
+        () -> {
+          BulkResultBuilder resultBuilder = new BulkResultBuilder();
+          for (UserAdd user : users) {
+            try {
+              User addedUser =
+                  user.externalId() != null
+                      ? userGroupExternalManager.addUser(
+                          metalake,
+                          user.name(),
+                          user.externalId(),
+                          user.enabled() == null || user.enabled())
+                      : userGroupManager.addUser(metalake, user.name());
+              resultBuilder.addSucceeded(addedUser.name());
+            } catch (Exception e) {
+              resultBuilder.addFailed(user.name(), failureReason(e));
+            }
+          }
+          return resultBuilder.build();
+        });
+  }
+
+  @Override
   public boolean removeUser(String metalake, String user) throws NoSuchMetalakeException {
     return TreeLockUtils.doWithTreeLock(
         NameIdentifier.of(AuthorizationUtils.ofUserNamespace(metalake).levels()),
         LockType.WRITE,
         () -> userGroupManager.removeUser(metalake, user));
+  }
+
+  @Override
+  public BulkOperationResult bulkRemoveUsers(String metalake, String[] users)
+      throws NoSuchMetalakeException {
+    return TreeLockUtils.doWithTreeLock(
+        NameIdentifier.of(AuthorizationUtils.ofUserNamespace(metalake).levels()),
+        LockType.WRITE,
+        () -> {
+          BulkResultBuilder resultBuilder = new BulkResultBuilder();
+          for (String user : users) {
+            try {
+              if (!userGroupManager.removeUser(metalake, user)) {
+                throw new IllegalArgumentException("User does not exist");
+              }
+              resultBuilder.addSucceeded(user);
+            } catch (Exception e) {
+              resultBuilder.addFailed(user, failureReason(e));
+            }
+          }
+          return resultBuilder.build();
+        });
   }
 
   @Override
@@ -332,5 +381,31 @@ public class AccessControlManager implements AccessControlDispatcher {
         LockType.WRITE,
         () ->
             permissionManager.overridePrivilegesInRole(metalake, role, securableObjectsToOverride));
+  }
+
+  private static String failureReason(Exception e) {
+    String message = e.getMessage();
+    if (message == null || message.isBlank()) {
+      return e.getClass().getSimpleName();
+    }
+    return e.getClass().getSimpleName() + ": " + message;
+  }
+
+  private static class BulkResultBuilder {
+    private final List<String> succeeded = new java.util.ArrayList<>();
+    private final List<BulkOperationResult.Failure> failed = new java.util.ArrayList<>();
+
+    private void addSucceeded(String name) {
+      succeeded.add(name);
+    }
+
+    private void addFailed(String name, String reason) {
+      failed.add(new BulkOperationResult.Failure(name, reason));
+    }
+
+    private BulkOperationResult build() {
+      return new BulkOperationResult(
+          succeeded.toArray(new String[0]), failed.toArray(new BulkOperationResult.Failure[0]));
+    }
   }
 }

--- a/core/src/main/java/org/apache/gravitino/authorization/BulkOperationResult.java
+++ b/core/src/main/java/org/apache/gravitino/authorization/BulkOperationResult.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.authorization;
+
+/** Represents the result of a bulk operation. */
+public class BulkOperationResult {
+
+  private final String[] succeeded;
+  private final Failure[] failed;
+
+  /**
+   * Creates a new BulkOperationResult instance.
+   *
+   * @param succeeded The names that were processed successfully.
+   * @param failed The failures for individual names.
+   */
+  public BulkOperationResult(String[] succeeded, Failure[] failed) {
+    this.succeeded = succeeded;
+    this.failed = failed;
+  }
+
+  /**
+   * Gets the names that were processed successfully.
+   *
+   * @return The names that were processed successfully.
+   */
+  public String[] succeeded() {
+    return succeeded;
+  }
+
+  /**
+   * Gets the failures for individual names.
+   *
+   * @return The failures for individual names.
+   */
+  public Failure[] failed() {
+    return failed;
+  }
+
+  /** Represents a failure for a single bulk operation item. */
+  public static class Failure {
+    private final String name;
+    private final String reason;
+
+    /**
+     * Creates a new Failure instance.
+     *
+     * @param name The failed name.
+     * @param reason The failure reason.
+     */
+    public Failure(String name, String reason) {
+      this.name = name;
+      this.reason = reason;
+    }
+
+    /**
+     * Gets the failed name.
+     *
+     * @return The failed name.
+     */
+    public String name() {
+      return name;
+    }
+
+    /**
+     * Gets the failure reason.
+     *
+     * @return The failure reason.
+     */
+    public String reason() {
+      return reason;
+    }
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/authorization/UserAdd.java
+++ b/core/src/main/java/org/apache/gravitino/authorization/UserAdd.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.authorization;
+
+import javax.annotation.Nullable;
+
+/** Represents a User to add. */
+public class UserAdd {
+
+  private final String name;
+  @Nullable private final String externalId;
+  @Nullable private final Boolean enabled;
+
+  /**
+   * Creates a new UserAdd instance.
+   *
+   * @param name The name of the User.
+   * @param externalId The external identifier of the User.
+   * @param enabled Whether the User is enabled.
+   */
+  public UserAdd(String name, @Nullable String externalId, @Nullable Boolean enabled) {
+    this.name = name;
+    this.externalId = externalId;
+    this.enabled = enabled;
+  }
+
+  /**
+   * Gets the name of the User.
+   *
+   * @return The name of the User.
+   */
+  public String name() {
+    return name;
+  }
+
+  /**
+   * Gets the external identifier of the User.
+   *
+   * @return The external identifier of the User.
+   */
+  @Nullable
+  public String externalId() {
+    return externalId;
+  }
+
+  /**
+   * Gets whether the User is enabled.
+   *
+   * @return Whether the User is enabled.
+   */
+  @Nullable
+  public Boolean enabled() {
+    return enabled;
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/hook/AccessControlHookDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/hook/AccessControlHookDispatcher.java
@@ -26,6 +26,7 @@ import org.apache.gravitino.GravitinoEnv;
 import org.apache.gravitino.MetadataObject;
 import org.apache.gravitino.authorization.AccessControlDispatcher;
 import org.apache.gravitino.authorization.AuthorizationUtils;
+import org.apache.gravitino.authorization.BulkOperationResult;
 import org.apache.gravitino.authorization.GravitinoAuthorizer;
 import org.apache.gravitino.authorization.Group;
 import org.apache.gravitino.authorization.Owner;
@@ -34,6 +35,7 @@ import org.apache.gravitino.authorization.Privilege;
 import org.apache.gravitino.authorization.Role;
 import org.apache.gravitino.authorization.SecurableObject;
 import org.apache.gravitino.authorization.User;
+import org.apache.gravitino.authorization.UserAdd;
 import org.apache.gravitino.exceptions.GroupAlreadyExistsException;
 import org.apache.gravitino.exceptions.IllegalRoleException;
 import org.apache.gravitino.exceptions.NoSuchGroupException;
@@ -76,8 +78,20 @@ public class AccessControlHookDispatcher implements AccessControlDispatcher {
   }
 
   @Override
+  public BulkOperationResult bulkAddUsers(String metalake, UserAdd[] users)
+      throws NoSuchMetalakeException {
+    return dispatcher.bulkAddUsers(metalake, users);
+  }
+
+  @Override
   public boolean removeUser(String metalake, String user) throws NoSuchMetalakeException {
     return dispatcher.removeUser(metalake, user);
+  }
+
+  @Override
+  public BulkOperationResult bulkRemoveUsers(String metalake, String[] users)
+      throws NoSuchMetalakeException {
+    return dispatcher.bulkRemoveUsers(metalake, users);
   }
 
   @Override

--- a/core/src/main/java/org/apache/gravitino/listener/AccessControlEventDispatcher.java
+++ b/core/src/main/java/org/apache/gravitino/listener/AccessControlEventDispatcher.java
@@ -24,11 +24,13 @@ import java.util.Map;
 import java.util.Set;
 import org.apache.gravitino.MetadataObject;
 import org.apache.gravitino.authorization.AccessControlDispatcher;
+import org.apache.gravitino.authorization.BulkOperationResult;
 import org.apache.gravitino.authorization.Group;
 import org.apache.gravitino.authorization.Privilege;
 import org.apache.gravitino.authorization.Role;
 import org.apache.gravitino.authorization.SecurableObject;
 import org.apache.gravitino.authorization.User;
+import org.apache.gravitino.authorization.UserAdd;
 import org.apache.gravitino.exceptions.GroupAlreadyExistsException;
 import org.apache.gravitino.exceptions.IllegalRoleException;
 import org.apache.gravitino.exceptions.NoSuchGroupException;
@@ -183,6 +185,13 @@ public class AccessControlEventDispatcher implements AccessControlDispatcher {
 
   /** {@inheritDoc} */
   @Override
+  public BulkOperationResult bulkAddUsers(String metalake, UserAdd[] users)
+      throws NoSuchMetalakeException {
+    return dispatcher.bulkAddUsers(metalake, users);
+  }
+
+  /** {@inheritDoc} */
+  @Override
   public boolean removeUser(String metalake, String user) throws NoSuchMetalakeException {
     String initiator = PrincipalUtils.getCurrentUserName();
 
@@ -196,6 +205,13 @@ public class AccessControlEventDispatcher implements AccessControlDispatcher {
       eventBus.dispatchEvent(new RemoveUserFailureEvent(initiator, metalake, e, user));
       throw e;
     }
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public BulkOperationResult bulkRemoveUsers(String metalake, String[] users)
+      throws NoSuchMetalakeException {
+    return dispatcher.bulkRemoveUsers(metalake, users);
   }
 
   /** {@inheritDoc} */

--- a/core/src/test/java/org/apache/gravitino/authorization/TestAccessControlManager.java
+++ b/core/src/test/java/org/apache/gravitino/authorization/TestAccessControlManager.java
@@ -246,6 +246,45 @@ public class TestAccessControlManager {
   }
 
   @Test
+  public void testBulkAddUsers() {
+    accessControlManager.addUser(METALAKE, "bulkAddUser2");
+
+    BulkOperationResult result =
+        accessControlManager.bulkAddUsers(
+            METALAKE,
+            new UserAdd[] {
+              new UserAdd("bulkAddUser1", "bulk-add-user-1", false),
+              new UserAdd("bulkAddUser2", null, null)
+            });
+
+    Assertions.assertArrayEquals(new String[] {"bulkAddUser1"}, result.succeeded());
+    Assertions.assertEquals(1, result.failed().length);
+    Assertions.assertEquals("bulkAddUser2", result.failed()[0].name());
+    Assertions.assertTrue(result.failed()[0].reason().contains("UserAlreadyExistsException"));
+
+    User user = accessControlManager.getUser(METALAKE, "bulkAddUser1");
+    Assertions.assertEquals("bulk-add-user-1", user.externalId());
+    Assertions.assertFalse(user.enabled());
+
+    accessControlManager.removeUser(METALAKE, "bulkAddUser1");
+    accessControlManager.removeUser(METALAKE, "bulkAddUser2");
+  }
+
+  @Test
+  public void testBulkRemoveUsers() {
+    accessControlManager.addUser(METALAKE, "bulkRemoveUser1");
+
+    BulkOperationResult result =
+        accessControlManager.bulkRemoveUsers(
+            METALAKE, new String[] {"bulkRemoveUser1", "bulkRemoveUser2"});
+
+    Assertions.assertArrayEquals(new String[] {"bulkRemoveUser1"}, result.succeeded());
+    Assertions.assertEquals(1, result.failed().length);
+    Assertions.assertEquals("bulkRemoveUser2", result.failed()[0].name());
+    Assertions.assertTrue(result.failed()[0].reason().contains("IllegalArgumentException"));
+  }
+
+  @Test
   public void testListUsers() {
     accessControlManager.addUser("metalake_list", "testList1");
     accessControlManager.addUser("metalake_list", "testList2");

--- a/docs/open-api/openapi.yaml
+++ b/docs/open-api/openapi.yaml
@@ -188,6 +188,12 @@ paths:
   /metalakes/{metalake}/users/{user}:
     $ref: "./users.yaml#/paths/~1metalakes~1%7Bmetalake%7D~1users~1%7Buser%7D"
 
+  /bulk/metalakes/{metalake}/users/add:
+    $ref: "./users.yaml#/paths/~1bulk~1metalakes~1%7Bmetalake%7D~1users~1add"
+
+  /bulk/metalakes/{metalake}/users/remove:
+    $ref: "./users.yaml#/paths/~1bulk~1metalakes~1%7Bmetalake%7D~1users~1remove"
+
   /metalakes/{metalake}/groups:
     $ref: "./groups.yaml#/paths/~1metalakes~1%7Bmetalake%7D~1groups"
 
@@ -319,6 +325,43 @@ components:
           type: array
           items:
             type: string
+
+    BulkOperationFailure:
+      type: object
+      required:
+        - name
+        - reason
+      properties:
+        name:
+          type: string
+          description: The entity name that failed to be processed
+        reason:
+          type: string
+          description: The failure reason
+
+    BulkOperationResponse:
+      type: object
+      required:
+        - code
+        - succeeded
+        - failed
+      properties:
+        code:
+          type: integer
+          format: int32
+          description: Status code of the response
+          enum:
+            - 0
+        succeeded:
+          type: array
+          description: The entity names that were processed successfully
+          items:
+            type: string
+        failed:
+          type: array
+          description: The entity names that failed to be processed
+          items:
+            $ref: "#/components/schemas/BulkOperationFailure"
 
   responses:
     EntityListResponse:
@@ -634,4 +677,3 @@ components:
     KerberosAuth:
       type: http
       scheme: negotiate
-

--- a/docs/open-api/users.yaml
+++ b/docs/open-api/users.yaml
@@ -140,6 +140,109 @@ paths:
           $ref: "./openapi.yaml#/components/responses/RemoveResponse"
         "400":
           $ref: "./openapi.yaml#/components/responses/BadRequestErrorResponse"
+        "404":
+          description: Not Found - The specified metalake does not exist
+          content:
+            application/vnd.gravitino.v1+json:
+              schema:
+                $ref: "./openapi.yaml#/components/schemas/ErrorModel"
+              examples:
+                NoSuchMetalakeException:
+                  $ref: "./metalakes.yaml#/components/examples/NoSuchMetalakeException"
+        "5xx":
+          $ref: "./openapi.yaml#/components/responses/ServerErrorResponse"
+
+  /bulk/metalakes/{metalake}/users/add:
+    parameters:
+      - $ref: "./openapi.yaml#/components/parameters/metalake"
+
+    post:
+      tags:
+        - access control
+      summary: Add users in bulk
+      operationId: bulkAddUsers
+      description: |
+        Validates the request body and authorization before processing any user.
+        If validation or authorization fails, including duplicated user names or external IDs,
+        no user is processed and an error response is returned.
+        After validation succeeds, users are processed independently. Successful user names are
+        returned in `succeeded`, and per-user business failures are returned in `failed`.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/BulkUserAddRequest"
+            examples:
+              BulkUserAddRequest:
+                $ref: "#/components/examples/BulkUserAddRequest"
+      responses:
+        "200":
+          description: Returns the bulk add result
+          content:
+            application/vnd.gravitino.v1+json:
+              schema:
+                $ref: "./openapi.yaml#/components/schemas/BulkOperationResponse"
+              examples:
+                BulkOperationResponse:
+                  $ref: "#/components/examples/BulkOperationResponse"
+        "400":
+          $ref: "./openapi.yaml#/components/responses/BadRequestErrorResponse"
+        "404":
+          description: Not Found - The specified metalake does not exist
+          content:
+            application/vnd.gravitino.v1+json:
+              schema:
+                $ref: "./openapi.yaml#/components/schemas/ErrorModel"
+              examples:
+                NoSuchMetalakeException:
+                  $ref: "./metalakes.yaml#/components/examples/NoSuchMetalakeException"
+        "5xx":
+          $ref: "./openapi.yaml#/components/responses/ServerErrorResponse"
+
+  /bulk/metalakes/{metalake}/users/remove:
+    parameters:
+      - $ref: "./openapi.yaml#/components/parameters/metalake"
+
+    post:
+      tags:
+        - access control
+      summary: Remove users in bulk
+      operationId: bulkRemoveUsers
+      description: |
+        Validates the request body and authorization before processing any user.
+        If validation or authorization fails, including duplicated user names, no user is processed
+        and an error response is returned.
+        After validation succeeds, users are processed independently. Successful user names are
+        returned in `succeeded`, and per-user business failures are returned in `failed`.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UsernamesRequest"
+            examples:
+              UsernamesRequest:
+                $ref: "#/components/examples/UsernamesRequest"
+      responses:
+        "200":
+          description: Returns the bulk remove result
+          content:
+            application/vnd.gravitino.v1+json:
+              schema:
+                $ref: "./openapi.yaml#/components/schemas/BulkOperationResponse"
+              examples:
+                BulkOperationResponse:
+                  $ref: "#/components/examples/BulkOperationResponse"
+        "400":
+          $ref: "./openapi.yaml#/components/responses/BadRequestErrorResponse"
+        "404":
+          description: Not Found - The specified metalake does not exist
+          content:
+            application/vnd.gravitino.v1+json:
+              schema:
+                $ref: "./openapi.yaml#/components/schemas/ErrorModel"
+              examples:
+                NoSuchMetalakeException:
+                  $ref: "./metalakes.yaml#/components/examples/NoSuchMetalakeException"
         "5xx":
           $ref: "./openapi.yaml#/components/responses/ServerErrorResponse"
 
@@ -194,6 +297,31 @@ components:
           description: Whether the user is enabled
           default: true
 
+    BulkUserAddRequest:
+      type: object
+      required:
+        - users
+      properties:
+        users:
+          type: array
+          description: The users to add
+          minItems: 1
+          items:
+            $ref: "#/components/schemas/UserAddRequest"
+
+    UsernamesRequest:
+      type: object
+      required:
+        - usernames
+      properties:
+        usernames:
+          type: array
+          description: The names of users to operate on
+          minItems: 1
+          uniqueItems: true
+          items:
+            type: string
+
   responses:
     UserResponse:
       type: object
@@ -228,6 +356,37 @@ components:
         "name": "user",
         "externalId": "ext-user",
         "enabled": true
+      }
+
+    UsernamesRequest:
+      value: {
+        "usernames": [ "user1", "user2" ]
+      }
+
+    BulkUserAddRequest:
+      value: {
+        "users": [
+          {
+            "name": "user1",
+            "externalId": "ext-user1",
+            "enabled": true
+          },
+          {
+            "name": "user2",
+            "externalId": "ext-user2",
+            "enabled": false
+          }
+        ]
+      }
+
+    BulkOperationResponse:
+      value: {
+        "code": 0,
+        "succeeded": [ "user1" ],
+        "failed": [ {
+          "name": "user2",
+          "reason": "UserAlreadyExistsException: User already exists"
+        } ]
       }
 
     NameListResponse:

--- a/docs/security/access-control.md
+++ b/docs/security/access-control.md
@@ -573,6 +573,81 @@ Restart the Gravitino server for the configuration changes to take effect.
 
 The following sections demonstrate how to perform common access control operations using both the REST API (Shell) and Java client.
 
+### Bulk User Operations
+
+Bulk user operations help administrators reduce repeated client-side API calls when managing many users in the same metalake. They are useful for scenarios such as onboarding or offboarding a team, synchronizing users from an external identity provider, or cleaning up multiple obsolete users.
+
+The bulk user APIs validate the request body and authorization before processing any user. If the request is invalid, for example when the user list is empty or contains duplicated names or external IDs, Gravitino rejects the request and doesn't process any user. After validation succeeds, Gravitino processes each user independently and returns successful names in `succeeded` and per-user business failures in `failed`.
+
+Use the following APIs to add and remove users in bulk:
+
+| API                                               | Required privilege                       | Request body |
+|---------------------------------------------------|------------------------------------------|--------------|
+| `POST /api/bulk/metalakes/{metalake}/users/add`    | `OWNER` of the metalake or `MANAGE_USERS` | `users`      |
+| `POST /api/bulk/metalakes/{metalake}/users/remove` | `OWNER` of the metalake                   | `usernames`  |
+
+:::info
+The bulk user APIs require authorization to be enabled. For more information, see [Authorization](#authorization).
+:::
+
+#### Add Users in Bulk
+
+<Tabs groupId='language' queryString>
+<TabItem value="shell" label="Shell">
+
+```shell
+curl -X POST -H "Accept: application/vnd.gravitino.v1+json" \
+-H "Content-Type: application/json" -d '{
+  "users": [
+    {
+      "name": "user1",
+      "externalId": "ext-user1",
+      "enabled": true
+    },
+    {
+      "name": "user2",
+      "externalId": "ext-user2",
+      "enabled": false
+    }
+  ]
+}' http://localhost:8090/api/bulk/metalakes/test/users/add
+```
+
+</TabItem>
+</Tabs>
+
+#### Remove Users in Bulk
+
+<Tabs groupId='language' queryString>
+<TabItem value="shell" label="Shell">
+
+```shell
+curl -X POST -H "Accept: application/vnd.gravitino.v1+json" \
+-H "Content-Type: application/json" -d '{
+  "usernames": ["user1", "user2"]
+}' http://localhost:8090/api/bulk/metalakes/test/users/remove
+```
+
+</TabItem>
+</Tabs>
+
+#### Bulk Operation Response
+
+The response includes the user names that were processed successfully and the failures for individual users:
+
+```json
+{
+  "code": 0,
+  "succeeded": ["user1"],
+  "failed": [
+    {
+      "name": "user2",
+      "reason": "IllegalArgumentException: User does not exist"
+    }
+  ]
+}
+```
+
 ## User Operations
 
 ### Add a User

--- a/server/src/main/java/org/apache/gravitino/server/web/rest/UserOperations.java
+++ b/server/src/main/java/org/apache/gravitino/server/web/rest/UserOperations.java
@@ -38,10 +38,16 @@ import org.apache.gravitino.GravitinoEnv;
 import org.apache.gravitino.MetadataObject;
 import org.apache.gravitino.MetadataObjects;
 import org.apache.gravitino.authorization.AccessControlDispatcher;
+import org.apache.gravitino.authorization.BulkOperationResult;
 import org.apache.gravitino.authorization.Owner;
 import org.apache.gravitino.authorization.OwnerDispatcher;
 import org.apache.gravitino.authorization.User;
+import org.apache.gravitino.authorization.UserAdd;
+import org.apache.gravitino.dto.requests.BulkUserAddRequest;
 import org.apache.gravitino.dto.requests.UserAddRequest;
+import org.apache.gravitino.dto.requests.UsernamesRequest;
+import org.apache.gravitino.dto.responses.BulkOperationFailureDTO;
+import org.apache.gravitino.dto.responses.BulkOperationResponse;
 import org.apache.gravitino.dto.responses.NameListResponse;
 import org.apache.gravitino.dto.responses.RemoveResponse;
 import org.apache.gravitino.dto.responses.UserListResponse;
@@ -59,7 +65,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @NameBindings.AccessControlInterfaces
-@Path("/metalakes/{metalake}/users")
+@Path("/")
 public class UserOperations {
 
   private static final Logger LOG = LoggerFactory.getLogger(UserOperations.class);
@@ -81,7 +87,7 @@ public class UserOperations {
   }
 
   @GET
-  @Path("{user}")
+  @Path("/metalakes/{metalake}/users/{user}")
   @Produces("application/vnd.gravitino.v1+json")
   @Timed(name = "get-user." + MetricNames.HTTP_PROCESS_DURATION, absolute = true)
   @ResponseMetered(name = "get-user", absolute = true)
@@ -105,6 +111,7 @@ public class UserOperations {
   }
 
   @GET
+  @Path("/metalakes/{metalake}/users")
   @Produces("application/vnd.gravitino.v1+json")
   @Timed(name = "list-user." + MetricNames.HTTP_PROCESS_DURATION, absolute = true)
   @ResponseMetered(name = "list-user", absolute = true)
@@ -147,6 +154,7 @@ public class UserOperations {
   }
 
   @POST
+  @Path("/metalakes/{metalake}/users")
   @Produces("application/vnd.gravitino.v1+json")
   @Timed(name = "add-user." + MetricNames.HTTP_PROCESS_DURATION, absolute = true)
   @ResponseMetered(name = "add-user", absolute = true)
@@ -178,7 +186,7 @@ public class UserOperations {
   }
 
   @DELETE
-  @Path("{user}")
+  @Path("/metalakes/{metalake}/users/{user}")
   @Produces("application/vnd.gravitino.v1+json")
   @Timed(name = "remove-user." + MetricNames.HTTP_PROCESS_DURATION, absolute = true)
   @ResponseMetered(name = "remove-user", absolute = true)
@@ -215,5 +223,87 @@ public class UserOperations {
     } catch (Exception e) {
       return ExceptionHandlers.handleUserException(OperationType.REMOVE, user, metalake, e);
     }
+  }
+
+  /**
+   * Adds users in bulk.
+   *
+   * @param metalake The metalake name.
+   * @param request The bulk user add request.
+   * @return The bulk operation result.
+   */
+  @POST
+  @Path("/bulk/metalakes/{metalake}/users/add")
+  @Produces("application/vnd.gravitino.v1+json")
+  @Timed(name = "bulk-add-users." + MetricNames.HTTP_PROCESS_DURATION, absolute = true)
+  @ResponseMetered(name = "bulk-add-users", absolute = true)
+  @AuthorizationExpression(expression = "METALAKE::OWNER || METALAKE::MANAGE_USERS")
+  public Response addUsers(
+      @PathParam("metalake") @AuthorizationMetadata(type = Entity.EntityType.METALAKE)
+          String metalake,
+      BulkUserAddRequest request) {
+    try {
+      return Utils.doAs(
+          httpRequest,
+          () -> {
+            request.validate();
+            MetalakeManager.checkMetalakeInUse(metalake);
+            return Utils.ok(
+                toBulkOperationResponse(
+                    accessControlManager.bulkAddUsers(metalake, toUserAdds(request.getUsers()))));
+          });
+    } catch (Exception e) {
+      return ExceptionHandlers.handleUserException(OperationType.ADD, "", metalake, e);
+    }
+  }
+
+  /**
+   * Removes users in bulk.
+   *
+   * @param metalake The metalake name.
+   * @param request The bulk usernames request.
+   * @return The bulk operation result.
+   */
+  @POST
+  @Path("/bulk/metalakes/{metalake}/users/remove")
+  @Produces("application/vnd.gravitino.v1+json")
+  @Timed(name = "bulk-remove-users." + MetricNames.HTTP_PROCESS_DURATION, absolute = true)
+  @ResponseMetered(name = "bulk-remove-users", absolute = true)
+  @AuthorizationExpression(expression = "METALAKE::OWNER")
+  public Response removeUsers(
+      @PathParam("metalake") @AuthorizationMetadata(type = Entity.EntityType.METALAKE)
+          String metalake,
+      UsernamesRequest request) {
+    try {
+      return Utils.doAs(
+          httpRequest,
+          () -> {
+            request.validate();
+            MetalakeManager.checkMetalakeInUse(metalake);
+            return Utils.ok(
+                toBulkOperationResponse(
+                    accessControlManager.bulkRemoveUsers(metalake, request.getUsernames())));
+          });
+    } catch (Exception e) {
+      return ExceptionHandlers.handleUserException(OperationType.REMOVE, "", metalake, e);
+    }
+  }
+
+  private static UserAdd[] toUserAdds(UserAddRequest[] requests) {
+    UserAdd[] users = new UserAdd[requests.length];
+    for (int i = 0; i < requests.length; i++) {
+      users[i] =
+          new UserAdd(requests[i].getName(), requests[i].getExternalId(), requests[i].getEnabled());
+    }
+    return users;
+  }
+
+  private static BulkOperationResponse toBulkOperationResponse(BulkOperationResult result) {
+    BulkOperationResult.Failure[] failures = result.failed();
+    BulkOperationFailureDTO[] failureDTOs = new BulkOperationFailureDTO[failures.length];
+    for (int i = 0; i < failures.length; i++) {
+      failureDTOs[i] = new BulkOperationFailureDTO(failures[i].name(), failures[i].reason());
+    }
+    return new BulkOperationResponse(result.succeeded(), failureDTOs);
   }
 }

--- a/server/src/test/java/org/apache/gravitino/server/web/rest/TestBulkOperations.java
+++ b/server/src/test/java/org/apache/gravitino/server/web/rest/TestBulkOperations.java
@@ -1,0 +1,208 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.server.web.rest;
+
+import static org.apache.gravitino.Configs.TREE_LOCK_CLEAN_INTERVAL;
+import static org.apache.gravitino.Configs.TREE_LOCK_MAX_NODE_IN_MEMORY;
+import static org.apache.gravitino.Configs.TREE_LOCK_MIN_NODE_IN_MEMORY;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import org.apache.commons.lang3.reflect.FieldUtils;
+import org.apache.gravitino.Config;
+import org.apache.gravitino.EntityStore;
+import org.apache.gravitino.GravitinoEnv;
+import org.apache.gravitino.authorization.AccessControlManager;
+import org.apache.gravitino.authorization.BulkOperationResult;
+import org.apache.gravitino.authorization.OwnerDispatcher;
+import org.apache.gravitino.catalog.CatalogDispatcher;
+import org.apache.gravitino.connector.PropertiesMetadata;
+import org.apache.gravitino.dto.requests.BulkUserAddRequest;
+import org.apache.gravitino.dto.requests.UserAddRequest;
+import org.apache.gravitino.dto.requests.UsernamesRequest;
+import org.apache.gravitino.dto.responses.BulkOperationResponse;
+import org.apache.gravitino.lock.LockManager;
+import org.apache.gravitino.meta.BaseMetalake;
+import org.apache.gravitino.rest.RESTUtils;
+import org.glassfish.hk2.utilities.binding.AbstractBinder;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.glassfish.jersey.test.TestProperties;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class TestBulkOperations extends BaseOperationsTest {
+
+  private static final AccessControlManager manager = mock(AccessControlManager.class);
+  private static final OwnerDispatcher ownerDispatcher = mock(OwnerDispatcher.class);
+  private static final EntityStore entityStore = mock(EntityStore.class);
+  private static final CatalogDispatcher catalogDispatcher = mock(CatalogDispatcher.class);
+
+  private static class MockServletRequestFactory extends ServletRequestFactoryBase {
+    @Override
+    public HttpServletRequest get() {
+      HttpServletRequest request = mock(HttpServletRequest.class);
+      when(request.getRemoteUser()).thenReturn(null);
+      return request;
+    }
+  }
+
+  @BeforeAll
+  static void setup() throws IllegalAccessException {
+    Config config = mock(Config.class);
+    Mockito.doReturn(100000L).when(config).get(TREE_LOCK_MAX_NODE_IN_MEMORY);
+    Mockito.doReturn(1000L).when(config).get(TREE_LOCK_MIN_NODE_IN_MEMORY);
+    Mockito.doReturn(36000L).when(config).get(TREE_LOCK_CLEAN_INTERVAL);
+    FieldUtils.writeField(GravitinoEnv.getInstance(), "lockManager", new LockManager(config), true);
+    FieldUtils.writeField(GravitinoEnv.getInstance(), "accessControlDispatcher", manager, true);
+    FieldUtils.writeField(GravitinoEnv.getInstance(), "ownerDispatcher", ownerDispatcher, true);
+    FieldUtils.writeField(GravitinoEnv.getInstance(), "entityStore", entityStore, true);
+    FieldUtils.writeField(GravitinoEnv.getInstance(), "catalogDispatcher", catalogDispatcher, true);
+  }
+
+  @BeforeEach
+  void resetMocks() throws IOException {
+    reset(manager, ownerDispatcher, entityStore, catalogDispatcher);
+    BaseMetalake metalake = inUseMetalake();
+    when(entityStore.get(any(), any(), any())).thenReturn(metalake);
+    when(catalogDispatcher.catalogExists(any())).thenReturn(true);
+  }
+
+  @Override
+  protected Application configure() {
+    try {
+      forceSet(
+          TestProperties.CONTAINER_PORT, String.valueOf(RESTUtils.findAvailablePort(2000, 3000)));
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+
+    ResourceConfig resourceConfig = new ResourceConfig();
+    resourceConfig.register(UserOperations.class);
+    resourceConfig.register(
+        new AbstractBinder() {
+          @Override
+          protected void configure() {
+            bindFactory(MockServletRequestFactory.class).to(HttpServletRequest.class);
+          }
+        });
+
+    return resourceConfig;
+  }
+
+  @Test
+  void testBulkAddUsers() {
+    when(manager.bulkAddUsers(eq("metalake1"), any()))
+        .thenReturn(
+            new BulkOperationResult(
+                new String[] {"user1"},
+                new BulkOperationResult.Failure[] {
+                  new BulkOperationResult.Failure("user2", "UserAlreadyExistsException: mock error")
+                }));
+
+    Response resp =
+        target("/bulk/metalakes/metalake1/users/add")
+            .request(MediaType.APPLICATION_JSON_TYPE)
+            .accept("application/vnd.gravitino.v1+json")
+            .post(
+                Entity.entity(
+                    new BulkUserAddRequest(
+                        new UserAddRequest[] {
+                          new UserAddRequest("user1"), new UserAddRequest("user2")
+                        }),
+                    MediaType.APPLICATION_JSON_TYPE));
+
+    Assertions.assertEquals(Response.Status.OK.getStatusCode(), resp.getStatus());
+    BulkOperationResponse response = resp.readEntity(BulkOperationResponse.class);
+    Assertions.assertArrayEquals(new String[] {"user1"}, response.getSucceeded());
+    Assertions.assertEquals(1, response.getFailed().length);
+    Assertions.assertEquals("user2", response.getFailed()[0].getName());
+  }
+
+  @Test
+  void testBulkAddUsersWithExternalId() {
+    when(manager.bulkAddUsers(eq("metalake1"), any()))
+        .thenReturn(
+            new BulkOperationResult(
+                new String[] {"user1", "user2"}, new BulkOperationResult.Failure[0]));
+
+    Response resp =
+        target("/bulk/metalakes/metalake1/users/add")
+            .request(MediaType.APPLICATION_JSON_TYPE)
+            .accept("application/vnd.gravitino.v1+json")
+            .post(
+                Entity.entity(
+                    new BulkUserAddRequest(
+                        new UserAddRequest[] {
+                          new UserAddRequest("user1", "external1", false),
+                          new UserAddRequest("user2", "external2", null)
+                        }),
+                    MediaType.APPLICATION_JSON_TYPE));
+
+    Assertions.assertEquals(Response.Status.OK.getStatusCode(), resp.getStatus());
+    BulkOperationResponse response = resp.readEntity(BulkOperationResponse.class);
+    Assertions.assertArrayEquals(new String[] {"user1", "user2"}, response.getSucceeded());
+    Assertions.assertEquals(0, response.getFailed().length);
+  }
+
+  @Test
+  void testBulkRemoveUsersWithPartialFailure() {
+    when(manager.bulkRemoveUsers(eq("metalake1"), any()))
+        .thenReturn(
+            new BulkOperationResult(
+                new String[] {"user1"},
+                new BulkOperationResult.Failure[] {
+                  new BulkOperationResult.Failure(
+                      "user2", "IllegalArgumentException: User does not exist")
+                }));
+
+    Response resp =
+        target("/bulk/metalakes/metalake1/users/remove")
+            .request(MediaType.APPLICATION_JSON_TYPE)
+            .accept("application/vnd.gravitino.v1+json")
+            .post(
+                Entity.entity(
+                    new UsernamesRequest(new String[] {"user1", "user2"}),
+                    MediaType.APPLICATION_JSON_TYPE));
+
+    Assertions.assertEquals(Response.Status.OK.getStatusCode(), resp.getStatus());
+    BulkOperationResponse response = resp.readEntity(BulkOperationResponse.class);
+    Assertions.assertArrayEquals(new String[] {"user1"}, response.getSucceeded());
+    Assertions.assertEquals("user2", response.getFailed()[0].getName());
+  }
+
+  private BaseMetalake inUseMetalake() {
+    BaseMetalake metalake = mock(BaseMetalake.class);
+    PropertiesMetadata propertiesMetadata = mock(PropertiesMetadata.class);
+    when(propertiesMetadata.getOrDefault(any(), any())).thenReturn(true);
+    when(metalake.propertiesMetadata()).thenReturn(propertiesMetadata);
+    return metalake;
+  }
+}


### PR DESCRIPTION
Part of #11942
Related to #10805

### What changes were proposed in this pull request?

This PR adds bulk user operations under a metalake:

- `POST /api/bulk/metalakes/{metalake}/users/add`
- `POST /api/bulk/metalakes/{metalake}/users/remove`

It also introduces common bulk operation infrastructure that will be reused by follow-up PRs for groups and roles:

- Common bulk request validation for empty and duplicated names.
- Common bulk response DTOs with `succeeded` and `failed` results.
- Common REST utility for per-item bulk operation results.

### Why are the changes needed?

Currently, users need to call the single-user APIs repeatedly to add or remove multiple users. These APIs provide a batch operation interface for user management and reduce repeated client-side API calls.

This is the first split PR for #10805. Follow-up PRs will add bulk group operations and bulk role operations.

For the `externalId` discussion, the existing single user/group/role access-control APIs are name-based and do not support `externalId` as the association key. This PR keeps the bulk user APIs aligned with the existing name-based API contract. `externalId` support may require a separate API/model design and can be discussed as a follow-up.

Part of #10805.

### Does this PR introduce _any_ user-facing change?

Yes. This PR introduces new REST APIs for bulk user add/remove operations.

### How was this patch tested?

```bash
./gradlew spotlessApply
./gradlew :common:test --tests org.apache.gravitino.dto.requests.TestBulkRequests
./gradlew :server:test --tests org.apache.gravitino.server.web.rest.TestBulkOperations -PskipITs
./gradlew :docs:build