### PR TITLE
[#12057] fix(spark): complete V3 type compatibility

### DIFF
--- a/docs/spark-connector/spark-catalog-iceberg.md
+++ b/docs/spark-connector/spark-catalog-iceberg.md
@@ -66,9 +66,13 @@ rejects Gravitino `timestamp(p)` and `timestamp_tz(p)` types when `p` is greater
 silently truncating their values. This includes Iceberg V3 nanosecond timestamp types, which map to
 precision `9`.
 
+Spark 3.x has no data type that can losslessly represent Iceberg V3 `variant`. The connector rejects
+the type, including when it is nested, before exposing the table to Spark.
+
 | Gravitino type family | Spark 3.3 | Spark 3.4 | Spark 3.5 |
 |-----------------------|-----------|-----------|-----------|
 | `timestamp(9)`, `timestamp_tz(9)` | Rejected before conversion | Rejected before conversion | Rejected before conversion |
+| `variant` | Rejected before conversion | Rejected before conversion | Rejected before conversion |
 
 ## SQL Example
 

--- a/docs/spark-connector/spark-catalog-iceberg.md
+++ b/docs/spark-connector/spark-catalog-iceberg.md
@@ -69,10 +69,16 @@ precision `9`.
 Spark 3.x has no data type that can losslessly represent Iceberg V3 `variant`. The connector rejects
 the type, including when it is nested, before exposing the table to Spark.
 
+Iceberg 1.11 maps an optional Iceberg V3 `unknown` field to Spark `NullType`. Therefore, Spark 3.4
+and 3.5 support optional, null-only fields when using the Iceberg catalog. Required `unknown` fields
+are rejected. Spark 3.3 uses Iceberg 1.8.1 and rejects the type. Other Gravitino Spark catalogs also
+reject `NullType`; this mapping is not applied to Hive, JDBC, Glue, or Paimon.
+
 | Gravitino type family | Spark 3.3 | Spark 3.4 | Spark 3.5 |
 |-----------------------|-----------|-----------|-----------|
 | `timestamp(9)`, `timestamp_tz(9)` | Rejected before conversion | Rejected before conversion | Rejected before conversion |
 | `variant` | Rejected before conversion | Rejected before conversion | Rejected before conversion |
+| `unknown` / Spark `NullType` | Rejected | Optional, null-only fields with Iceberg 1.11 | Optional, null-only fields with Iceberg 1.11 |
 
 ## SQL Example
 

--- a/docs/spark-connector/spark-catalog-iceberg.md
+++ b/docs/spark-connector/spark-catalog-iceberg.md
@@ -74,11 +74,16 @@ and 3.5 support optional, null-only fields when using the Iceberg catalog. Requi
 are rejected. Spark 3.3 uses Iceberg 1.8.1 and rejects the type. Other Gravitino Spark catalogs also
 reject `NullType`; this mapping is not applied to Hive, JDBC, Glue, or Paimon.
 
+Spark 3.x has no geometry data type that preserves WKB values together with Gravitino's CRS
+metadata. The connector rejects `geometry`, including nested geometry, rather than translating it
+to an untyped binary value.
+
 | Gravitino type family | Spark 3.3 | Spark 3.4 | Spark 3.5 |
 |-----------------------|-----------|-----------|-----------|
 | `timestamp(9)`, `timestamp_tz(9)` | Rejected before conversion | Rejected before conversion | Rejected before conversion |
 | `variant` | Rejected before conversion | Rejected before conversion | Rejected before conversion |
 | `unknown` / Spark `NullType` | Rejected | Optional, null-only fields with Iceberg 1.11 | Optional, null-only fields with Iceberg 1.11 |
+| `geometry` | Rejected before conversion | Rejected before conversion | Rejected before conversion |
 
 ## SQL Example
 

--- a/docs/spark-connector/spark-catalog-iceberg.md
+++ b/docs/spark-connector/spark-catalog-iceberg.md
@@ -78,12 +78,17 @@ Spark 3.x has no geometry data type that preserves WKB values together with Grav
 metadata. The connector rejects `geometry`, including nested geometry, rather than translating it
 to an untyped binary value.
 
+Spark 3.x likewise cannot preserve a geography field's WKB values, CRS, and edge-interpolation
+algorithm as one typed value. The connector rejects `geography`, including nested geography,
+instead of discarding the CRS or algorithm.
+
 | Gravitino type family | Spark 3.3 | Spark 3.4 | Spark 3.5 |
 |-----------------------|-----------|-----------|-----------|
 | `timestamp(9)`, `timestamp_tz(9)` | Rejected before conversion | Rejected before conversion | Rejected before conversion |
 | `variant` | Rejected before conversion | Rejected before conversion | Rejected before conversion |
 | `unknown` / Spark `NullType` | Rejected | Optional, null-only fields with Iceberg 1.11 | Optional, null-only fields with Iceberg 1.11 |
 | `geometry` | Rejected before conversion | Rejected before conversion | Rejected before conversion |
+| `geography` | Rejected before conversion | Rejected before conversion | Rejected before conversion |
 
 ## SQL Example
 

--- a/docs/spark-connector/spark-catalog-iceberg.md
+++ b/docs/spark-connector/spark-catalog-iceberg.md
@@ -59,6 +59,17 @@ Doesn't support distribution and sort orders.
   - `ALTER TABLE prod.db.sample CREATE TAG tagName`
 - AtomicCreateTableAsSelect&AtomicReplaceTableAsSelect
 
+### Iceberg V3 type compatibility
+
+Spark 3.3, 3.4, and 3.5 represent timestamps with at most microsecond precision. The connector
+rejects Gravitino `timestamp(p)` and `timestamp_tz(p)` types when `p` is greater than `6` instead of
+silently truncating their values. This includes Iceberg V3 nanosecond timestamp types, which map to
+precision `9`.
+
+| Gravitino type family | Spark 3.3 | Spark 3.4 | Spark 3.5 |
+|-----------------------|-----------|-----------|-----------|
+| `timestamp(9)`, `timestamp_tz(9)` | Rejected before conversion | Rejected before conversion | Rejected before conversion |
+
 ## SQL Example
 
 ```sql

--- a/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/SparkTableChangeConverter.java
+++ b/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/SparkTableChangeConverter.java
@@ -20,6 +20,7 @@ package org.apache.gravitino.spark.connector;
 
 import com.google.common.base.Preconditions;
 import org.apache.spark.sql.connector.catalog.TableChange;
+import org.apache.spark.sql.types.NullType;
 
 public class SparkTableChangeConverter {
   private SparkTypeConverter sparkTypeConverter;
@@ -45,6 +46,12 @@ public class SparkTableChangeConverter {
       return org.apache.gravitino.rel.TableChange.removeProperty(removeProperty.property());
     } else if (change instanceof TableChange.AddColumn) {
       TableChange.AddColumn addColumn = (TableChange.AddColumn) change;
+      if (addColumn.dataType() instanceof NullType && !addColumn.isNullable()) {
+        throw new IllegalArgumentException(
+            String.format(
+                "Spark NullType column '%s' must be nullable",
+                String.join(".", addColumn.fieldNames())));
+      }
       return org.apache.gravitino.rel.TableChange.addColumn(
           addColumn.fieldNames(),
           sparkTypeConverter.toGravitinoType(addColumn.dataType()),

--- a/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/SparkTypeConverter.java
+++ b/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/SparkTypeConverter.java
@@ -105,7 +105,8 @@ public class SparkTypeConverter {
               .toArray(Types.StructType.Field[]::new);
       return Types.StructType.of(fields);
     } else if (sparkType instanceof NullType) {
-      return Types.NullType.get();
+      throw new IllegalArgumentException(
+          "Spark NullType is only supported by Spark 3.4 and 3.5 Iceberg catalogs");
     }
     throw new UnsupportedOperationException("Not support " + sparkType.toString());
   }
@@ -197,7 +198,8 @@ public class SparkTypeConverter {
               .collect(Collectors.toList());
       return DataTypes.createStructType(fields);
     } else if (gravitinoType instanceof Types.NullType) {
-      return DataTypes.NullType;
+      throw new IllegalArgumentException(
+          "Gravitino null type is only supported by Spark 3.4 and 3.5 Iceberg catalogs");
     }
     throw new UnsupportedOperationException("Not support " + gravitinoType.toString());
   }

--- a/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/SparkTypeConverter.java
+++ b/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/SparkTypeConverter.java
@@ -163,6 +163,8 @@ public class SparkTypeConverter {
       throw new IllegalArgumentException("Spark 3.x does not support the Gravitino variant type");
     } else if (gravitinoType instanceof Types.GeometryType) {
       throw new IllegalArgumentException("Spark 3.x does not support the Gravitino geometry type");
+    } else if (gravitinoType instanceof Types.GeographyType) {
+      throw new IllegalArgumentException("Spark 3.x does not support the Gravitino geography type");
     } else if (gravitinoType instanceof Types.BinaryType) {
       return DataTypes.BinaryType;
     } else if (gravitinoType instanceof Types.BooleanType) {

--- a/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/SparkTypeConverter.java
+++ b/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/SparkTypeConverter.java
@@ -111,6 +111,10 @@ public class SparkTypeConverter {
   }
 
   public DataType toSparkType(Type gravitinoType) {
+    if (gravitinoType instanceof Types.TimestampType) {
+      validateTimestampPrecision((Types.TimestampType) gravitinoType);
+    }
+
     if (gravitinoType instanceof Types.ByteType) {
       if (((Types.ByteType) gravitinoType).signed()) {
         return DataTypes.ByteType;
@@ -194,5 +198,20 @@ public class SparkTypeConverter {
       return DataTypes.NullType;
     }
     throw new UnsupportedOperationException("Not support " + gravitinoType.toString());
+  }
+
+  /**
+   * Validates that a Gravitino timestamp precision can be represented in Spark.
+   *
+   * @param timestampType the Gravitino timestamp type
+   * @throws IllegalArgumentException if the precision exceeds Spark's microsecond precision
+   */
+  protected static void validateTimestampPrecision(Types.TimestampType timestampType) {
+    if (timestampType.hasPrecisionSet() && timestampType.precision() > 6) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Spark supports timestamp precision up to 6, but %s has precision %d",
+              timestampType.simpleString(), timestampType.precision()));
+    }
   }
 }

--- a/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/SparkTypeConverter.java
+++ b/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/SparkTypeConverter.java
@@ -161,6 +161,8 @@ public class SparkTypeConverter {
       return DataTypes.StringType;
     } else if (gravitinoType instanceof Types.VariantType) {
       throw new IllegalArgumentException("Spark 3.x does not support the Gravitino variant type");
+    } else if (gravitinoType instanceof Types.GeometryType) {
+      throw new IllegalArgumentException("Spark 3.x does not support the Gravitino geometry type");
     } else if (gravitinoType instanceof Types.BinaryType) {
       return DataTypes.BinaryType;
     } else if (gravitinoType instanceof Types.BooleanType) {

--- a/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/SparkTypeConverter.java
+++ b/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/SparkTypeConverter.java
@@ -158,6 +158,8 @@ public class SparkTypeConverter {
       // Spark has no native UUID type. Represent UUID as StringType to align with
       // Spark built-in PostgreSQL JDBC mapping (uuid -> StringType).
       return DataTypes.StringType;
+    } else if (gravitinoType instanceof Types.VariantType) {
+      throw new IllegalArgumentException("Spark 3.x does not support the Gravitino variant type");
     } else if (gravitinoType instanceof Types.BinaryType) {
       return DataTypes.BinaryType;
     } else if (gravitinoType instanceof Types.BooleanType) {

--- a/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/catalog/BaseCatalog.java
+++ b/spark-connector/spark-common/src/main/java/org/apache/gravitino/spark/connector/catalog/BaseCatalog.java
@@ -65,6 +65,7 @@ import org.apache.spark.sql.connector.catalog.TableCatalog;
 import org.apache.spark.sql.connector.catalog.TableChange;
 import org.apache.spark.sql.connector.catalog.functions.UnboundFunction;
 import org.apache.spark.sql.connector.expressions.Transform;
+import org.apache.spark.sql.types.NullType;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 import org.apache.spark.sql.util.CaseInsensitiveStringMap;
@@ -639,6 +640,10 @@ public abstract class BaseCatalog implements TableCatalog, SupportsNamespaces, F
   }
 
   private org.apache.gravitino.rel.Column createGravitinoColumn(StructField structField) {
+    if (structField.dataType() instanceof NullType && !structField.nullable()) {
+      throw new IllegalArgumentException(
+          String.format("Spark NullType column '%s' must be nullable", structField.name()));
+    }
     return org.apache.gravitino.rel.Column.of(
         structField.name(),
         sparkTypeConverter.toGravitinoType(structField.dataType()),

--- a/spark-connector/spark-common/src/test/java/org/apache/gravitino/spark/connector/TestSparkTypeConverter.java
+++ b/spark-connector/spark-common/src/test/java/org/apache/gravitino/spark/connector/TestSparkTypeConverter.java
@@ -42,6 +42,7 @@ import org.apache.gravitino.rel.types.Types.StructType;
 import org.apache.gravitino.rel.types.Types.TimestampType;
 import org.apache.gravitino.rel.types.Types.UUIDType;
 import org.apache.gravitino.rel.types.Types.VarCharType;
+import org.apache.gravitino.rel.types.Types.VariantType;
 import org.apache.spark.sql.types.CharType;
 import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.DataTypes;
@@ -129,6 +130,19 @@ public class TestSparkTypeConverter {
             IllegalArgumentException.class,
             () -> sparkTypeConverter.toSparkType(TimestampType.withTimeZone(9)));
     Assertions.assertTrue(exception.getMessage().contains("timestamp_tz(9)"));
+  }
+
+  @Test
+  void testRejectVariant() {
+    IllegalArgumentException exception =
+        Assertions.assertThrowsExactly(
+            IllegalArgumentException.class,
+            () -> sparkTypeConverter.toSparkType(VariantType.get()));
+    Assertions.assertTrue(exception.getMessage().contains("variant"));
+
+    Assertions.assertThrowsExactly(
+        IllegalArgumentException.class,
+        () -> sparkTypeConverter.toSparkType(ListType.of(VariantType.get(), true)));
   }
 
   /** Create a Gravitino StructType for testing. */

--- a/spark-connector/spark-common/src/test/java/org/apache/gravitino/spark/connector/TestSparkTypeConverter.java
+++ b/spark-connector/spark-common/src/test/java/org/apache/gravitino/spark/connector/TestSparkTypeConverter.java
@@ -31,6 +31,7 @@ import org.apache.gravitino.rel.types.Types.DecimalType;
 import org.apache.gravitino.rel.types.Types.DoubleType;
 import org.apache.gravitino.rel.types.Types.FixedCharType;
 import org.apache.gravitino.rel.types.Types.FloatType;
+import org.apache.gravitino.rel.types.Types.GeographyType;
 import org.apache.gravitino.rel.types.Types.GeometryType;
 import org.apache.gravitino.rel.types.Types.IntegerType;
 import org.apache.gravitino.rel.types.Types.ListType;
@@ -164,6 +165,19 @@ public class TestSparkTypeConverter {
     Assertions.assertThrowsExactly(
         IllegalArgumentException.class,
         () -> sparkTypeConverter.toSparkType(ListType.of(geometry, true)));
+  }
+
+  @Test
+  void testRejectGeography() {
+    GeographyType geography = GeographyType.of("EPSG:4326", "karney");
+    IllegalArgumentException exception =
+        Assertions.assertThrowsExactly(
+            IllegalArgumentException.class, () -> sparkTypeConverter.toSparkType(geography));
+    Assertions.assertTrue(exception.getMessage().contains("geography"));
+
+    Assertions.assertThrowsExactly(
+        IllegalArgumentException.class,
+        () -> sparkTypeConverter.toSparkType(ListType.of(geography, true)));
   }
 
   /** Create a Gravitino StructType for testing. */

--- a/spark-connector/spark-common/src/test/java/org/apache/gravitino/spark/connector/TestSparkTypeConverter.java
+++ b/spark-connector/spark-common/src/test/java/org/apache/gravitino/spark/connector/TestSparkTypeConverter.java
@@ -117,6 +117,20 @@ public class TestSparkTypeConverter {
                 () -> sparkTypeConverter.toGravitinoType(sparkType)));
   }
 
+  @Test
+  void testRejectNanosecondTimestampWithTimeZone() {
+    Assertions.assertEquals(
+        DataTypes.TimestampType, sparkTypeConverter.toSparkType(TimestampType.withTimeZone()));
+    Assertions.assertEquals(
+        DataTypes.TimestampType, sparkTypeConverter.toSparkType(TimestampType.withTimeZone(6)));
+
+    IllegalArgumentException exception =
+        Assertions.assertThrowsExactly(
+            IllegalArgumentException.class,
+            () -> sparkTypeConverter.toSparkType(TimestampType.withTimeZone(9)));
+    Assertions.assertTrue(exception.getMessage().contains("timestamp_tz(9)"));
+  }
+
   /** Create a Gravitino StructType for testing. */
   private static StructType createGravitinoStructType() {
     return StructType.of(

--- a/spark-connector/spark-common/src/test/java/org/apache/gravitino/spark/connector/TestSparkTypeConverter.java
+++ b/spark-connector/spark-common/src/test/java/org/apache/gravitino/spark/connector/TestSparkTypeConverter.java
@@ -85,8 +85,6 @@ public class TestSparkTypeConverter {
         MapType.of(IntegerType.get(), StringType.get(), true),
         DataTypes.createMapType(DataTypes.IntegerType, DataTypes.StringType));
     gravitinoToSparkTypeMapper.put(createGravitinoStructType(), createSparkStructType());
-    gravitinoToSparkTypeMapper.put(NullType.get(), DataTypes.NullType);
-
     this.sparkTypeConverter = new SparkTypeConverter();
   }
 
@@ -143,6 +141,15 @@ public class TestSparkTypeConverter {
     Assertions.assertThrowsExactly(
         IllegalArgumentException.class,
         () -> sparkTypeConverter.toSparkType(ListType.of(VariantType.get(), true)));
+  }
+
+  @Test
+  void testRejectUnknownWithoutVersionSpecificIcebergSupport() {
+    Assertions.assertThrowsExactly(
+        IllegalArgumentException.class, () -> sparkTypeConverter.toSparkType(NullType.get()));
+    Assertions.assertThrowsExactly(
+        IllegalArgumentException.class,
+        () -> sparkTypeConverter.toGravitinoType(DataTypes.NullType));
   }
 
   /** Create a Gravitino StructType for testing. */

--- a/spark-connector/spark-common/src/test/java/org/apache/gravitino/spark/connector/TestSparkTypeConverter.java
+++ b/spark-connector/spark-common/src/test/java/org/apache/gravitino/spark/connector/TestSparkTypeConverter.java
@@ -31,6 +31,7 @@ import org.apache.gravitino.rel.types.Types.DecimalType;
 import org.apache.gravitino.rel.types.Types.DoubleType;
 import org.apache.gravitino.rel.types.Types.FixedCharType;
 import org.apache.gravitino.rel.types.Types.FloatType;
+import org.apache.gravitino.rel.types.Types.GeometryType;
 import org.apache.gravitino.rel.types.Types.IntegerType;
 import org.apache.gravitino.rel.types.Types.ListType;
 import org.apache.gravitino.rel.types.Types.LongType;
@@ -150,6 +151,19 @@ public class TestSparkTypeConverter {
     Assertions.assertThrowsExactly(
         IllegalArgumentException.class,
         () -> sparkTypeConverter.toGravitinoType(DataTypes.NullType));
+  }
+
+  @Test
+  void testRejectGeometry() {
+    GeometryType geometry = GeometryType.of("EPSG:3857");
+    IllegalArgumentException exception =
+        Assertions.assertThrowsExactly(
+            IllegalArgumentException.class, () -> sparkTypeConverter.toSparkType(geometry));
+    Assertions.assertTrue(exception.getMessage().contains("geometry"));
+
+    Assertions.assertThrowsExactly(
+        IllegalArgumentException.class,
+        () -> sparkTypeConverter.toSparkType(ListType.of(geometry, true)));
   }
 
   /** Create a Gravitino StructType for testing. */

--- a/spark-connector/v3.4/spark/src/main/java/org/apache/gravitino/spark/connector/SparkTypeConverter34.java
+++ b/spark-connector/v3.4/spark/src/main/java/org/apache/gravitino/spark/connector/SparkTypeConverter34.java
@@ -39,6 +39,7 @@ public class SparkTypeConverter34 extends SparkTypeConverter {
   public DataType toSparkType(Type gravitinoType) {
     if (gravitinoType instanceof Types.TimestampType
         && !((Types.TimestampType) gravitinoType).hasTimeZone()) {
+      validateTimestampPrecision((Types.TimestampType) gravitinoType);
       return DataTypes.TimestampNTZType;
     } else {
       return super.toSparkType(gravitinoType);

--- a/spark-connector/v3.4/spark/src/main/java/org/apache/gravitino/spark/connector/iceberg/SparkIcebergTypeConverter34.java
+++ b/spark-connector/v3.4/spark/src/main/java/org/apache/gravitino/spark/connector/iceberg/SparkIcebergTypeConverter34.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.spark.connector.iceberg;
+
+import org.apache.gravitino.rel.types.Type;
+import org.apache.gravitino.rel.types.Types;
+import org.apache.gravitino.spark.connector.SparkTypeConverter34;
+import org.apache.spark.sql.types.DataType;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.NullType;
+
+/**
+ * Converts types for Spark 3.4 and 3.5 Iceberg catalogs.
+ *
+ * <p>Iceberg 1.11 maps its V3 unknown type to Spark {@link NullType}. Other Spark catalog
+ * implementations do not share this contract, so the mapping is intentionally isolated here.
+ */
+public class SparkIcebergTypeConverter34 extends SparkTypeConverter34 {
+
+  @Override
+  public Type toGravitinoType(DataType sparkType) {
+    if (sparkType instanceof NullType) {
+      return Types.NullType.get();
+    }
+    return super.toGravitinoType(sparkType);
+  }
+
+  @Override
+  public DataType toSparkType(Type gravitinoType) {
+    if (gravitinoType instanceof Types.NullType) {
+      return DataTypes.NullType;
+    }
+    return super.toSparkType(gravitinoType);
+  }
+}

--- a/spark-connector/v3.4/spark/src/test/java/org/apache/gravitino/spark/connector/TestSparkTypeConverter34.java
+++ b/spark-connector/v3.4/spark/src/test/java/org/apache/gravitino/spark/connector/TestSparkTypeConverter34.java
@@ -38,4 +38,17 @@ public class TestSparkTypeConverter34 {
         DataTypes.TimestampNTZType,
         sparkTypeConverter.toSparkType(TimestampType.withoutTimeZone()));
   }
+
+  @Test
+  void testRejectNanosecondTimestampWithoutTimeZone() {
+    Assertions.assertEquals(
+        DataTypes.TimestampNTZType,
+        sparkTypeConverter.toSparkType(TimestampType.withoutTimeZone(6)));
+
+    IllegalArgumentException exception =
+        Assertions.assertThrowsExactly(
+            IllegalArgumentException.class,
+            () -> sparkTypeConverter.toSparkType(TimestampType.withoutTimeZone(9)));
+    Assertions.assertTrue(exception.getMessage().contains("timestamp(9)"));
+  }
 }

--- a/spark-connector/v3.4/spark/src/test/java/org/apache/gravitino/spark/connector/iceberg/TestSparkIcebergTypeConverter34.java
+++ b/spark-connector/v3.4/spark/src/test/java/org/apache/gravitino/spark/connector/iceberg/TestSparkIcebergTypeConverter34.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.spark.connector.iceberg;
+
+import org.apache.gravitino.rel.types.Types.NullType;
+import org.apache.gravitino.spark.connector.SparkTableChangeConverter34;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.spark.SparkSchemaUtil;
+import org.apache.iceberg.types.Types.UnknownType;
+import org.apache.spark.sql.connector.catalog.TableChange;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TestSparkIcebergTypeConverter34 {
+
+  private final SparkIcebergTypeConverter34 converter = new SparkIcebergTypeConverter34();
+
+  @Test
+  void testUnknownTypeConversion() {
+    Assertions.assertEquals(DataTypes.NullType, converter.toSparkType(NullType.get()));
+    Assertions.assertEquals(NullType.get(), converter.toGravitinoType(DataTypes.NullType));
+  }
+
+  @Test
+  void testPinnedIcebergUnknownSchemaRoundTrip() {
+    StructType sparkSchema =
+        DataTypes.createStructType(
+            new StructField[] {
+              DataTypes.createStructField("id", DataTypes.IntegerType, false),
+              DataTypes.createStructField("payload", DataTypes.NullType, true)
+            });
+
+    Schema icebergSchema = SparkSchemaUtil.convert(sparkSchema);
+    Assertions.assertInstanceOf(UnknownType.class, icebergSchema.findType("payload"));
+    Assertions.assertTrue(icebergSchema.findField("payload").isOptional());
+
+    StructType roundTripped = SparkSchemaUtil.convert(icebergSchema);
+    Assertions.assertEquals(DataTypes.NullType, roundTripped.apply("payload").dataType());
+    Assertions.assertTrue(roundTripped.apply("payload").nullable());
+  }
+
+  @Test
+  void testRejectRequiredUnknownBeforeAlter() {
+    SparkTableChangeConverter34 changeConverter = new SparkTableChangeConverter34(converter);
+    TableChange change = TableChange.addColumn(new String[] {"payload"}, DataTypes.NullType, false);
+
+    IllegalArgumentException exception =
+        Assertions.assertThrowsExactly(
+            IllegalArgumentException.class, () -> changeConverter.toGravitinoTableChange(change));
+    Assertions.assertTrue(exception.getMessage().contains("must be nullable"));
+  }
+}

--- a/spark-connector/v3.5/spark/src/test/java/org/apache/gravitino/spark/connector/iceberg/TestSparkIcebergTypeConverter35.java
+++ b/spark-connector/v3.5/spark/src/test/java/org/apache/gravitino/spark/connector/iceberg/TestSparkIcebergTypeConverter35.java
@@ -18,19 +18,22 @@
  */
 package org.apache.gravitino.spark.connector.iceberg;
 
-import org.apache.gravitino.spark.connector.SparkTableChangeConverter;
-import org.apache.gravitino.spark.connector.SparkTableChangeConverter34;
-import org.apache.gravitino.spark.connector.SparkTypeConverter;
+import org.apache.gravitino.rel.types.Types.NullType;
+import org.apache.iceberg.spark.SparkSchemaUtil;
+import org.apache.iceberg.types.Types.UnknownType;
+import org.apache.spark.sql.types.DataTypes;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
-public class GravitinoIcebergCatalogSpark34 extends GravitinoIcebergCatalog {
-  @Override
-  protected SparkTypeConverter getSparkTypeConverter() {
-    return new SparkIcebergTypeConverter34();
-  }
+public class TestSparkIcebergTypeConverter35 {
 
-  @Override
-  protected SparkTableChangeConverter getSparkTableChangeConverter(
-      SparkTypeConverter sparkTypeConverter) {
-    return new SparkTableChangeConverter34(sparkTypeConverter);
+  @Test
+  void testPinnedIcebergUnknownTypeRoundTrip() {
+    SparkIcebergTypeConverter34 converter = new SparkIcebergTypeConverter34();
+    Assertions.assertEquals(DataTypes.NullType, converter.toSparkType(NullType.get()));
+    Assertions.assertEquals(NullType.get(), converter.toGravitinoType(DataTypes.NullType));
+
+    Assertions.assertInstanceOf(UnknownType.class, SparkSchemaUtil.convert(DataTypes.NullType));
+    Assertions.assertEquals(DataTypes.NullType, SparkSchemaUtil.convert(UnknownType.get()));
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Define and document Spark compatibility for the five Gravitino V3-native type families.

| Type family | Outcome |
| --- | --- |
| Nanosecond timestamps | Reject precision greater than 6 rather than silently narrowing to Spark microseconds. |
| Variant | Reject because the supported Spark versions do not provide a stable, lossless target. |
| Unknown/Null | Preserve nullable Iceberg unknown columns where the Spark/Iceberg version exposes an exact NullType mapping; reject unsupported version/nullability combinations. |
| Geometry | Reject because Spark cannot preserve the CRS contract. |
| Geography | Reject because Spark cannot preserve CRS and edge-algorithm metadata. |

### Why are the changes needed?

The Spark connector must not silently convert V3-native types to narrower or opaque Spark types. Every mapping now either round-trips exactly or fails before connector-side table exposure or mutation.

Fix: #12057

Related: #12056

Related: #11936

### Does this PR introduce _any_ user-facing change?

Yes. Unsupported V3-native columns now fail explicitly. Existing timestamp precision 6 and below remains unchanged, and supported nullable Unknown mappings retain their type identity.

### How was this patch tested?

- Added focused shared converter coverage.
- Covered the Spark 3.4 and 3.5 Iceberg converter paths.
- Covered supported mappings, rejected mappings, nested types, and no-side-effect behavior.
- Updated `docs/spark-connector/spark-catalog-iceberg.md`.
