### PR TITLE
[#11947] feat(client-python): Support view operations

### DIFF
--- a/clients/client-python/gravitino/api/catalog.py
+++ b/clients/client-python/gravitino/api/catalog.py
@@ -158,6 +158,16 @@ class Catalog(Auditable):
         """
         raise UnsupportedOperationException("Catalog does not support table operations")
 
+    def as_view_catalog(self) -> "ViewCatalog":  # noqa: F821
+        """
+        Raises:
+            UnsupportedOperationException if the catalog does not support view operations.
+
+        Returns:
+            the {@link ViewCatalog} if the catalog supports view operations.
+        """
+        raise UnsupportedOperationException("Catalog does not support view operations")
+
     def as_fileset_catalog(self) -> "FilesetCatalog":  # noqa: F821
         """
         Raises:

--- a/clients/client-python/gravitino/api/rel/dialects.py
+++ b/clients/client-python/gravitino/api/rel/dialects.py
@@ -1,0 +1,25 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+
+class Dialects:
+    """Predefined SQL dialect identifiers."""
+
+    TRINO = "trino"
+    SPARK = "spark"
+    HIVE = "hive"
+    FLINK = "flink"

--- a/clients/client-python/gravitino/api/rel/representation.py
+++ b/clients/client-python/gravitino/api/rel/representation.py
@@ -1,0 +1,28 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from abc import ABC, abstractmethod
+
+
+class Representation(ABC):
+    """A representation of a view definition."""
+
+    TYPE_SQL = "sql"
+
+    @abstractmethod
+    def type(self) -> str:
+        """Returns the representation type."""

--- a/clients/client-python/gravitino/api/rel/sql_representation.py
+++ b/clients/client-python/gravitino/api/rel/sql_representation.py
@@ -1,0 +1,47 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from dataclasses import dataclass
+
+from gravitino.api.rel.representation import Representation
+from gravitino.utils.precondition import Precondition
+
+
+@dataclass(frozen=True)
+class SQLRepresentation(Representation):
+    """A SQL-based representation of a view definition."""
+
+    _dialect: str
+    _sql: str
+
+    def __post_init__(self):
+        Precondition.check_string_not_empty(
+            self._dialect, "dialect must not be null or empty"
+        )
+        Precondition.check_string_not_empty(self._sql, "sql must not be null or empty")
+
+    def type(self) -> str:
+        """Returns the representation type."""
+        return Representation.TYPE_SQL
+
+    def dialect(self) -> str:
+        """Returns the SQL dialect."""
+        return self._dialect
+
+    def sql(self) -> str:
+        """Returns the SQL text."""
+        return self._sql

--- a/clients/client-python/gravitino/api/rel/view.py
+++ b/clients/client-python/gravitino/api/rel/view.py
@@ -1,0 +1,68 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from abc import abstractmethod
+from typing import Optional
+
+from gravitino.api.auditable import Auditable
+from gravitino.api.rel.column import Column
+from gravitino.api.rel.representation import Representation
+from gravitino.api.rel.sql_representation import SQLRepresentation
+
+
+class View(Auditable):
+    """An interface representing a logical view in a namespace."""
+
+    @abstractmethod
+    def name(self) -> str:
+        """Returns the view name."""
+
+    def comment(self) -> Optional[str]:
+        """Returns the view comment."""
+        return None
+
+    @abstractmethod
+    def columns(self) -> list[Column]:
+        """Returns the output columns of the view."""
+
+    @abstractmethod
+    def representations(self) -> list[Representation]:
+        """Returns the representations of the view."""
+
+    def default_catalog(self) -> Optional[str]:
+        """Returns the default catalog used to resolve unqualified identifiers."""
+        return None
+
+    def default_schema(self) -> Optional[str]:
+        """Returns the default schema used to resolve unqualified identifiers."""
+        return None
+
+    def sql_for(self, dialect: str) -> Optional[SQLRepresentation]:
+        """Returns the SQL representation for the given dialect."""
+        if dialect is None:
+            return None
+        for representation in self.representations():
+            if (
+                isinstance(representation, SQLRepresentation)
+                and representation.dialect().lower() == dialect.lower()
+            ):
+                return representation
+        return None
+
+    def properties(self) -> dict[str, str]:
+        """Returns the view properties."""
+        return {}

--- a/clients/client-python/gravitino/api/rel/view_catalog.py
+++ b/clients/client-python/gravitino/api/rel/view_catalog.py
@@ -1,0 +1,148 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from abc import ABC, abstractmethod
+from typing import Optional
+
+from gravitino.api.rel.column import Column
+from gravitino.api.rel.representation import Representation
+from gravitino.api.rel.view import View
+from gravitino.exceptions.base import NoSuchViewException
+from gravitino.name_identifier import NameIdentifier
+from gravitino.namespace import Namespace
+
+
+class ViewCatalog(ABC):
+    """The `ViewCatalog` interface defines the public API for managing views in a schema.
+
+    If the catalog implementation supports views, it must implement this interface.
+    """
+
+    @abstractmethod
+    def list_views(self, namespace: Namespace) -> list[NameIdentifier]:
+        """List the views in a namespace from the catalog.
+
+        Args:
+            namespace (Namespace): A namespace.
+
+        Returns:
+            list[NameIdentifier]: An array of view identifiers in the namespace.
+
+        Raises:
+            NoSuchSchemaException: If the schema does not exist.
+        """
+
+    @abstractmethod
+    def load_view(self, identifier: NameIdentifier) -> View:
+        """Load view metadata by `NameIdentifier` from the catalog.
+
+        Args:
+            identifier (NameIdentifier): A view identifier.
+
+        Returns:
+            View: The view metadata.
+
+        Raises:
+            NoSuchViewException: If the view does not exist.
+        """
+
+    def view_exists(self, identifier: NameIdentifier) -> bool:
+        """Check if a view with the given name exists in the catalog.
+
+        Args:
+            identifier: The view identifier.
+
+        Returns:
+            True if the view exists, False otherwise.
+        """
+        try:
+            self.load_view(identifier)
+            return True
+        except NoSuchViewException:
+            return False
+
+    @abstractmethod
+    def create_view(
+        self,
+        identifier: NameIdentifier,
+        columns: list[Column],
+        representations: list[Representation],
+        comment: Optional[str] = None,
+        default_catalog: Optional[str] = None,
+        default_schema: Optional[str] = None,
+        properties: Optional[dict[str, str]] = None,
+    ) -> View:
+        """Create a view in the catalog.
+
+        Args:
+            identifier (NameIdentifier):
+                A view identifier.
+            columns (list[Column]):
+                The columns of the new view.
+            representations (list[Representation]):
+                The SQL representations of the new view.
+            comment (str, optional):
+                The view comment. Defaults to `None`.
+            default_catalog (str, optional):
+                The default catalog name used to resolve unqualified objects in the view.
+                Defaults to `None`.
+            default_schema (str, optional):
+                The default schema name used to resolve unqualified objects in the view.
+                Defaults to `None`.
+            properties (dict[str, str], optional):
+                The view properties. Defaults to `None`.
+
+        Returns:
+            View:
+                The created view metadata.
+
+        Raises:
+            NoSuchSchemaException:
+                If the schema does not exist.
+            ViewAlreadyExistsException:
+                If the view already exists.
+        """
+
+    @abstractmethod
+    def alter_view(self, identifier: NameIdentifier, *changes) -> View:
+        """Alter a view in the catalog.
+
+        Args:
+            identifier (NameIdentifier): A view identifier.
+            *changes:
+                View changes to apply to the view.
+
+        Returns:
+            View: The updated view metadata.
+
+        Raises:
+            NoSuchViewException:
+                If the view does not exist.
+            IllegalArgumentException:
+                If the change is rejected by the implementation.
+        """
+
+    @abstractmethod
+    def drop_view(self, identifier: NameIdentifier) -> bool:
+        """Drop a view from the catalog.
+
+        Args:
+            identifier (NameIdentifier): A view identifier.
+
+        Returns:
+            bool: `True` if the view is dropped, `False` if the view does not exist.
+        """

--- a/clients/client-python/gravitino/api/rel/view_change.py
+++ b/clients/client-python/gravitino/api/rel/view_change.py
@@ -1,0 +1,149 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from abc import ABC
+from dataclasses import dataclass
+from typing import Optional
+
+from gravitino.api.rel.column import Column
+from gravitino.api.rel.representation import Representation
+from gravitino.utils.precondition import Precondition
+
+
+class ViewChange(ABC):
+    """Defines changes that can be applied to a view."""
+
+    @staticmethod
+    def rename(new_name: str) -> "RenameView":
+        """Create a change for renaming a view."""
+        return RenameView(new_name)
+
+    @staticmethod
+    def set_property(property_name: str, value: str) -> "SetProperty":
+        """Create a change for setting a view property."""
+        return SetProperty(property_name, value)
+
+    @staticmethod
+    def remove_property(property_name: str) -> "RemoveProperty":
+        """Create a change for removing a view property."""
+        return RemoveProperty(property_name)
+
+    @staticmethod
+    def replace_view(
+        columns: list[Column],
+        representations: list[Representation],
+        default_catalog: Optional[str] = None,
+        default_schema: Optional[str] = None,
+        comment: Optional[str] = None,
+    ) -> "ReplaceView":
+        """Create a change for replacing the view body."""
+        return ReplaceView(
+            columns, representations, default_catalog, default_schema, comment
+        )
+
+
+@dataclass(frozen=True)
+class RenameView(ViewChange):
+    """A ViewChange to rename a view."""
+
+    _new_name: str
+
+    def __post_init__(self):
+        Precondition.check_string_not_empty(
+            self._new_name, "newName must not be null or empty"
+        )
+
+    def new_name(self) -> str:
+        """Returns the new view name."""
+        return self._new_name
+
+
+@dataclass(frozen=True)
+class SetProperty(ViewChange):
+    """A ViewChange to set a view property."""
+
+    _property: str
+    _value: str
+
+    def __post_init__(self):
+        Precondition.check_string_not_empty(
+            self._property, "property must not be null or empty"
+        )
+
+    def property(self) -> str:
+        """Returns the property name."""
+        return self._property
+
+    def value(self) -> str:
+        """Returns the property value."""
+        return self._value
+
+
+@dataclass(frozen=True)
+class RemoveProperty(ViewChange):
+    """A ViewChange to remove a view property."""
+
+    _property: str
+
+    def __post_init__(self):
+        Precondition.check_string_not_empty(
+            self._property, "property must not be null or empty"
+        )
+
+    def property(self) -> str:
+        """Returns the property name."""
+        return self._property
+
+
+@dataclass(frozen=True)
+class ReplaceView(ViewChange):
+    """A ViewChange to replace the view body."""
+
+    _columns: list[Column]
+    _representations: list[Representation]
+    _default_catalog: Optional[str] = None
+    _default_schema: Optional[str] = None
+    _comment: Optional[str] = None
+
+    def __post_init__(self):
+        Precondition.check_argument(
+            self._columns is not None, "columns must not be null"
+        )
+        Precondition.check_argument(
+            self._representations is not None and len(self._representations) > 0,
+            "representations must not be null or empty",
+        )
+
+    def columns(self) -> list[Column]:
+        """Returns the new output columns."""
+        return self._columns
+
+    def representations(self) -> list[Representation]:
+        """Returns the new representations."""
+        return self._representations
+
+    def default_catalog(self) -> Optional[str]:
+        """Returns the new default catalog."""
+        return self._default_catalog
+
+    def default_schema(self) -> Optional[str]:
+        """Returns the new default schema."""
+        return self._default_schema
+
+    def comment(self) -> Optional[str]:
+        """Returns the new comment."""
+        return self._comment

--- a/clients/client-python/gravitino/client/generic_view.py
+++ b/clients/client-python/gravitino/client/generic_view.py
@@ -1,0 +1,72 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from typing import Optional
+
+from gravitino.api.audit import Audit
+from gravitino.api.rel.column import Column
+from gravitino.api.rel.representation import Representation
+from gravitino.api.rel.view import View
+from gravitino.dto.rel.view_dto import ViewDTO
+
+
+class GenericView(View):
+    """A generic implementation of the View interface."""
+
+    def __init__(
+        self,
+        view_dto: ViewDTO,
+    ):
+        """Create a GenericView from a ViewDTO.
+
+        Args:
+            view_dto: The view DTO.
+        """
+        self._view_dto = view_dto
+
+    def __eq__(self, value: object) -> bool:
+        if not isinstance(value, GenericView):
+            return False
+
+        return self._view_dto == value._view_dto
+
+    def __hash__(self) -> int:
+        return hash(self._view_dto)
+
+    def name(self) -> str:
+        return self._view_dto.name()
+
+    def comment(self) -> Optional[str]:
+        return self._view_dto.comment()
+
+    def columns(self) -> list[Column]:
+        return self._view_dto.columns()
+
+    def representations(self) -> list[Representation]:
+        return self._view_dto.representations()
+
+    def default_catalog(self) -> Optional[str]:
+        return self._view_dto.default_catalog()
+
+    def default_schema(self) -> Optional[str]:
+        return self._view_dto.default_schema()
+
+    def properties(self) -> dict[str, str]:
+        return self._view_dto.properties()
+
+    def audit_info(self) -> Audit:
+        return self._view_dto.audit_info()

--- a/clients/client-python/gravitino/client/relational_catalog.py
+++ b/clients/client-python/gravitino/client/relational_catalog.py
@@ -26,17 +26,26 @@ from gravitino.api.rel.expressions.transforms.transform import Transform
 from gravitino.api.rel.indexes.index import Index
 from gravitino.api.rel.table import Table
 from gravitino.api.rel.table_catalog import TableCatalog
+from gravitino.api.rel.representation import Representation
+from gravitino.api.rel.view import View
+from gravitino.api.rel.view_catalog import ViewCatalog
+from gravitino.api.rel.view_change import ViewChange
 from gravitino.client.base_schema_catalog import BaseSchemaCatalog
+from gravitino.client.generic_view import GenericView
 from gravitino.client.relational_table import RelationalTable
 from gravitino.dto.audit_dto import AuditDTO
 from gravitino.dto.rel.distribution_dto import DistributionDTO
 from gravitino.dto.requests.table_create_request import TableCreateRequest
 from gravitino.dto.requests.table_updates_request import TableUpdatesRequest
+from gravitino.dto.requests.view_create_request import ViewCreateRequest
+from gravitino.dto.requests.view_updates_request import ViewUpdatesRequest
 from gravitino.dto.responses.drop_response import DropResponse
 from gravitino.dto.responses.entity_list_response import EntityListResponse
 from gravitino.dto.responses.table_response import TableResponse
+from gravitino.dto.responses.view_response import ViewResponse
 from gravitino.dto.util.dto_converters import DTOConverters
 from gravitino.exceptions.handlers.table_error_handler import TABLE_ERROR_HANDLER
+from gravitino.exceptions.handlers.view_error_handler import VIEW_ERROR_HANDLER
 from gravitino.name_identifier import NameIdentifier
 from gravitino.namespace import Namespace
 from gravitino.rest.rest_utils import encode_string
@@ -44,7 +53,7 @@ from gravitino.utils import HTTPClient
 
 
 class RelationalCatalog(
-    BaseSchemaCatalog, TableCatalog
+    BaseSchemaCatalog, TableCatalog, ViewCatalog
 ):  # pylint: disable=too-many-ancestors
     """Relational catalog is a catalog implementation
 
@@ -88,6 +97,29 @@ class RelationalCatalog(
         """
         return self
 
+    def as_view_catalog(self) -> ViewCatalog:
+        """Return this relational catalog as a :class:`ViewCatalog`.
+
+        Returns:
+            ViewCatalog: The current catalog instance as a ``ViewCatalog``.
+        """
+        return self
+
+    def _get_entity_full_namespace(self, entity_namespace: Namespace) -> Namespace:
+        """Get the full namespace of an entity with the given short namespace.
+
+        Args:
+            entity_namespace (Namespace): The entity's short namespace, which is the schema name.
+
+        Returns:
+            Namespace: full namespace of the entity, which is "metalake.catalog.schema" format.
+        """
+        return Namespace.of(
+            self._catalog_namespace.level(0),
+            self._name,
+            entity_namespace.level(0),
+        )
+
     def _check_table_name_identifier(self, identifier: NameIdentifier) -> None:
         """Check whether the `NameIdentifier` of a table is valid.
 
@@ -119,27 +151,51 @@ class RelationalCatalog(
             f"Table namespace must be non-null and have 1 level, the input namespace is {namespace}",
         )
 
-    def _get_table_full_namespace(self, table_namespace: Namespace) -> Namespace:
-        """Get the full namespace of the table with the given table's short namespace (schema name).
-
-        Args:
-            table_namespace (Namespace): The table's short namespace, which is the schema name.
-
-        Returns:
-            Namespace: full namespace of the table, which is "metalake.catalog.schema" format.
-        """
-        return Namespace.of(
-            self._catalog_namespace.level(0),
-            self._name,
-            table_namespace.level(0),
-        )
-
     def _format_table_request_path(self, ns: Namespace) -> str:
         schema_ns = Namespace.of(ns.level(0), ns.level(1))
         return (
             f"{BaseSchemaCatalog.format_schema_request_path(schema_ns)}"
             f"/{encode_string(ns.level(2))}"
             "/tables"
+        )
+
+    def _check_view_name_identifier(self, identifier: NameIdentifier) -> None:
+        """Check whether the `NameIdentifier` of a view is valid.
+
+        Args:
+            identifier (NameIdentifier):
+                The NameIdentifier to check, which should be "schema.view" format.
+
+        Raises:
+            IllegalNameIdentifierException: If the Namespace is not valid.
+        """
+        NameIdentifier.check(identifier is not None, "NameIdentifier must not be null")
+        NameIdentifier.check(
+            identifier.name() is not None and identifier.name() != "",
+            "NameIdentifier name must not be empty",
+        )
+        self._check_view_namespace(identifier.namespace())
+
+    def _check_view_namespace(self, namespace: Namespace) -> None:
+        """Check whether the namespace of a view is valid, which should be "schema".
+
+        Args:
+            namespace (Namespace): The namespace to check.
+
+        Raises:
+            IllegalNamespaceException: If the Namespace is not valid.
+        """
+        Namespace.check(
+            namespace is not None and namespace.length() == 1,
+            f"View namespace must be non-null and have 1 level, the input namespace is {namespace}",
+        )
+
+    def _format_view_request_path(self, ns: Namespace) -> str:
+        schema_ns = Namespace.of(ns.level(0), ns.level(1))
+        return (
+            f"{BaseSchemaCatalog.format_schema_request_path(schema_ns)}"
+            f"/{encode_string(ns.level(2))}"
+            "/views"
         )
 
     def create_table(
@@ -169,7 +225,7 @@ class RelationalCatalog(
             _indexes=DTOConverters.to_dtos(indexes),
         )
         req.validate()
-        full_namespace = self._get_table_full_namespace(identifier.namespace())
+        full_namespace = self._get_entity_full_namespace(identifier.namespace())
         resp = self.rest_client.post(
             self._format_table_request_path(full_namespace),
             json=req,
@@ -181,7 +237,7 @@ class RelationalCatalog(
 
     def list_tables(self, namespace: Namespace) -> list[NameIdentifier]:
         self._check_table_namespace(namespace)
-        full_namespace = self._get_table_full_namespace(namespace)
+        full_namespace = self._get_entity_full_namespace(namespace)
         resp = self.rest_client.get(
             self._format_table_request_path(full_namespace),
             error_handler=TABLE_ERROR_HANDLER,
@@ -207,7 +263,7 @@ class RelationalCatalog(
         required_privilege_names: Optional[set[Privilege.Name]] = None,
     ) -> Table:
         self._check_table_name_identifier(identifier)
-        full_namespace = self._get_table_full_namespace(identifier.namespace())
+        full_namespace = self._get_entity_full_namespace(identifier.namespace())
         query_params = (
             {
                 RelationalCatalog.PRIVILEGES: ",".join(
@@ -244,7 +300,7 @@ class RelationalCatalog(
 
     def alter_table(self, identifier: NameIdentifier, *changes) -> Table:
         self._check_table_name_identifier(identifier)
-        full_namespace = self._get_table_full_namespace(identifier.namespace())
+        full_namespace = self._get_entity_full_namespace(identifier.namespace())
         updates_request = TableUpdatesRequest(
             updates=[
                 DTOConverters.to_table_update_request(change) for change in changes
@@ -276,12 +332,100 @@ class RelationalCatalog(
 
     def _drop_table(self, identifier: NameIdentifier, purge: bool) -> bool:
         self._check_table_name_identifier(identifier)
-        full_namespace = self._get_table_full_namespace(identifier.namespace())
+        full_namespace = self._get_entity_full_namespace(identifier.namespace())
         resp = self.rest_client.delete(
             f"{self._format_table_request_path(full_namespace)}"
             f"/{encode_string(identifier.name())}",
             error_handler=TABLE_ERROR_HANDLER,
             params={"purge": "true"} if purge else None,
+        )
+        drop_resp = DropResponse.from_json(resp.body, infer_missing=True)
+        drop_resp.validate()
+        return drop_resp.dropped()
+
+    def list_views(self, namespace: Namespace) -> list[NameIdentifier]:
+        self._check_view_namespace(namespace)
+        full_namespace = self._get_entity_full_namespace(namespace)
+        resp = self.rest_client.get(
+            self._format_view_request_path(full_namespace),
+            error_handler=VIEW_ERROR_HANDLER,
+        )
+        entity_list_resp = EntityListResponse.from_json(resp.body, infer_missing=True)
+        entity_list_resp.validate()
+        return [
+            NameIdentifier.of(ident.namespace().level(2), ident.name())
+            for ident in entity_list_resp.identifiers()
+        ]
+
+    def load_view(self, identifier: NameIdentifier) -> View:
+        self._check_view_name_identifier(identifier)
+        full_namespace = self._get_entity_full_namespace(identifier.namespace())
+        resp = self.rest_client.get(
+            f"{self._format_view_request_path(full_namespace)}"
+            f"/{encode_string(identifier.name())}",
+            error_handler=VIEW_ERROR_HANDLER,
+        )
+        view_resp = ViewResponse.from_json(resp.body, infer_missing=True)
+        view_resp.validate()
+        return GenericView(view_resp.view())
+
+    def create_view(
+        self,
+        identifier: NameIdentifier,
+        columns: list[Column],
+        representations: list[Representation],
+        comment: Optional[str] = None,
+        default_catalog: Optional[str] = None,
+        default_schema: Optional[str] = None,
+        properties: Optional[dict[str, str]] = None,
+    ) -> View:
+        self._check_view_name_identifier(identifier)
+        req = ViewCreateRequest(
+            _name=identifier.name(),
+            _columns=DTOConverters.to_dtos(columns),
+            _representations=DTOConverters.to_dtos(representations),
+            _comment=comment,
+            _default_catalog=default_catalog,
+            _default_schema=default_schema,
+            _properties=properties,
+        )
+        req.validate()
+        full_namespace = self._get_entity_full_namespace(identifier.namespace())
+        resp = self.rest_client.post(
+            self._format_view_request_path(full_namespace),
+            json=req,
+            error_handler=VIEW_ERROR_HANDLER,
+        )
+        view_resp = ViewResponse.from_json(resp.body, infer_missing=True)
+        view_resp.validate()
+        return GenericView(view_resp.view())
+
+    def alter_view(self, identifier: NameIdentifier, *changes: ViewChange) -> View:
+        self._check_view_name_identifier(identifier)
+        updates_request = ViewUpdatesRequest(
+            _updates=[
+                DTOConverters.to_view_update_request(change) for change in changes
+            ]
+        )
+        updates_request.validate()
+        full_namespace = self._get_entity_full_namespace(identifier.namespace())
+        resp = self.rest_client.put(
+            f"{self._format_view_request_path(full_namespace)}"
+            f"/{encode_string(identifier.name())}",
+            json=updates_request,
+            error_handler=VIEW_ERROR_HANDLER,
+        )
+        view_resp = ViewResponse.from_json(resp.body, infer_missing=True)
+        view_resp.validate()
+        return GenericView(view_resp.view())
+
+    def drop_view(self, identifier: NameIdentifier) -> bool:
+        self._check_view_name_identifier(identifier)
+        full_namespace = self._get_entity_full_namespace(identifier.namespace())
+        resp = self.rest_client.delete(
+            f"{self._format_view_request_path(full_namespace)}"
+            f"/{encode_string(identifier.name())}",
+            error_handler=VIEW_ERROR_HANDLER,
         )
         drop_resp = DropResponse.from_json(resp.body, infer_missing=True)
         drop_resp.validate()

--- a/clients/client-python/gravitino/dto/rel/json_serdes/representation_serdes.py
+++ b/clients/client-python/gravitino/dto/rel/json_serdes/representation_serdes.py
@@ -1,0 +1,43 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from gravitino.api.rel.representation import Representation
+from gravitino.dto.rel.representation_dto import RepresentationDTO
+from gravitino.dto.rel.sql_representation_dto import SQLRepresentationDTO
+from gravitino.exceptions.base import IllegalArgumentException
+
+
+class RepresentationSerdes:
+    """Serdes for view representation DTOs."""
+
+    @staticmethod
+    def deserialize(value: dict) -> RepresentationDTO:
+        """Decode a representation DTO from a dictionary."""
+        if value is None:
+            return None
+        if value.get("type") == Representation.TYPE_SQL:
+            return SQLRepresentationDTO.from_dict(value)
+        raise IllegalArgumentException(
+            f"Unsupported representation type: {value.get('type')}"
+        )
+
+    @staticmethod
+    def serialize(value: RepresentationDTO) -> dict:
+        """Encode a representation DTO to a dictionary."""
+        if value is None:
+            return None
+        return value.to_dict()

--- a/clients/client-python/gravitino/dto/rel/representation_dto.py
+++ b/clients/client-python/gravitino/dto/rel/representation_dto.py
@@ -1,0 +1,30 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from abc import abstractmethod
+
+from dataclasses_json import DataClassJsonMixin
+
+from gravitino.api.rel.representation import Representation
+
+
+class RepresentationDTO(Representation, DataClassJsonMixin):
+    """DTO base class for view representations."""
+
+    @abstractmethod
+    def validate(self) -> None:
+        """Validates the representation DTO."""

--- a/clients/client-python/gravitino/dto/rel/sql_representation_dto.py
+++ b/clients/client-python/gravitino/dto/rel/sql_representation_dto.py
@@ -1,0 +1,58 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from dataclasses import dataclass, field
+
+from dataclasses_json import config
+
+from gravitino.api.rel.representation import Representation
+from gravitino.dto.rel.representation_dto import RepresentationDTO
+from gravitino.utils.precondition import Precondition
+
+
+@dataclass
+class SQLRepresentationDTO(RepresentationDTO):
+    """DTO for SQL view representations."""
+
+    _dialect: str = field(metadata=config(field_name="dialect"))
+    _sql: str = field(metadata=config(field_name="sql"))
+    _type: str = field(
+        default=Representation.TYPE_SQL, metadata=config(field_name="type")
+    )
+
+    def type(self) -> str:
+        """Returns the representation type."""
+        return self._type
+
+    def dialect(self) -> str:
+        """Returns the SQL dialect."""
+        return self._dialect
+
+    def sql(self) -> str:
+        """Returns the SQL text."""
+        return self._sql
+
+    def validate(self) -> None:
+        Precondition.check_string_not_empty(
+            self._dialect, '"dialect" field is required and cannot be empty'
+        )
+        Precondition.check_string_not_empty(
+            self._sql, '"sql" field is required and cannot be empty'
+        )
+
+    def __hash__(self) -> int:
+        return hash((self._type, self._dialect, self._sql))

--- a/clients/client-python/gravitino/dto/rel/view_dto.py
+++ b/clients/client-python/gravitino/dto/rel/view_dto.py
@@ -1,0 +1,129 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+from dataclasses_json import DataClassJsonMixin, config
+
+from gravitino.api.rel.column import Column
+from gravitino.api.rel.representation import Representation
+from gravitino.api.rel.view import View
+from gravitino.dto.audit_dto import AuditDTO
+from gravitino.dto.rel.column_dto import ColumnDTO
+from gravitino.dto.rel.json_serdes.representation_serdes import RepresentationSerdes
+from gravitino.dto.rel.representation_dto import RepresentationDTO
+from gravitino.dto.util.dto_converters import DTOConverters
+from gravitino.utils.precondition import Precondition
+
+
+@dataclass
+class ViewDTO(View, DataClassJsonMixin):  # pylint: disable=too-many-instance-attributes
+    """Represents a View DTO."""
+
+    _name: str = field(metadata=config(field_name="name"))
+    _columns: Optional[list[ColumnDTO]] = field(
+        default=None, metadata=config(field_name="columns")
+    )
+    _representations: list[RepresentationDTO] = field(
+        default=None,
+        metadata=config(
+            field_name="representations",
+            encoder=lambda items: [
+                RepresentationSerdes.serialize(item) for item in items
+            ],
+            decoder=lambda values: [
+                RepresentationSerdes.deserialize(value) for value in values
+            ],
+        ),
+    )
+    _audit: Optional[AuditDTO] = field(
+        default=None, metadata=config(field_name="audit")
+    )
+    _comment: Optional[str] = field(default=None, metadata=config(field_name="comment"))
+    _default_catalog: Optional[str] = field(
+        default=None, metadata=config(field_name="defaultCatalog")
+    )
+    _default_schema: Optional[str] = field(
+        default=None, metadata=config(field_name="defaultSchema")
+    )
+    _properties: Optional[dict[str, str]] = field(
+        default=None, metadata=config(field_name="properties")
+    )
+
+    def __post_init__(self):
+        Precondition.check_string_not_empty(self._name, "name cannot be null or empty")
+        Precondition.check_argument(self._audit is not None, "audit cannot be null")
+        Precondition.check_argument(
+            self._representations is not None and len(self._representations) > 0,
+            "representations cannot be null or empty",
+        )
+        for representation in self._representations:
+            Precondition.check_argument(
+                representation is not None, "representation must not be null"
+            )
+            representation.validate()
+
+    def name(self) -> str:
+        return self._name
+
+    def comment(self) -> Optional[str]:
+        return self._comment
+
+    def columns(self) -> list[Column]:
+        return self._columns or []
+
+    def representations(self) -> list[Representation]:
+        return DTOConverters.from_dtos(self._representations)
+
+    def default_catalog(self) -> Optional[str]:
+        return self._default_catalog
+
+    def default_schema(self) -> Optional[str]:
+        return self._default_schema
+
+    def properties(self) -> dict[str, str]:
+        return self._properties or {}
+
+    def audit_info(self) -> AuditDTO:
+        return self._audit
+
+    def __eq__(self, other) -> bool:
+        if not isinstance(other, ViewDTO):
+            return False
+        return (
+            self._name == other._name
+            and self._columns == other._columns
+            and self._representations == other._representations
+            and self._comment == other._comment
+            and self._default_catalog == other._default_catalog
+            and self._default_schema == other._default_schema
+            and self._properties == other._properties
+        )
+
+    def __hash__(self) -> int:
+        return hash(
+            (
+                self._name,
+                tuple(self._columns or []),
+                tuple(self._representations or []),
+                self._comment,
+                self._default_catalog,
+                self._default_schema,
+                tuple(sorted((self._properties or {}).items())),
+            )
+        )

--- a/clients/client-python/gravitino/dto/requests/view_create_request.py
+++ b/clients/client-python/gravitino/dto/requests/view_create_request.py
@@ -1,0 +1,90 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+from dataclasses_json import config
+
+from gravitino.dto.rel.column_dto import ColumnDTO
+from gravitino.dto.rel.json_serdes.representation_serdes import RepresentationSerdes
+from gravitino.dto.rel.representation_dto import RepresentationDTO
+from gravitino.dto.rel.sql_representation_dto import SQLRepresentationDTO
+from gravitino.rest.rest_message import RESTRequest
+from gravitino.utils.precondition import Precondition
+
+
+@dataclass
+class ViewCreateRequest(RESTRequest):
+    """Represents a request to create a view."""
+
+    _name: str = field(metadata=config(field_name="name"))
+    _columns: Optional[list[ColumnDTO]] = field(
+        default=None, metadata=config(field_name="columns")
+    )
+    _representations: list[RepresentationDTO] = field(
+        default=None,
+        metadata=config(
+            field_name="representations",
+            encoder=lambda items: [
+                RepresentationSerdes.serialize(item) for item in items
+            ],
+        ),
+    )
+    _comment: Optional[str] = field(default=None, metadata=config(field_name="comment"))
+    _default_catalog: Optional[str] = field(
+        default=None, metadata=config(field_name="defaultCatalog")
+    )
+    _default_schema: Optional[str] = field(
+        default=None, metadata=config(field_name="defaultSchema")
+    )
+    _properties: Optional[dict[str, str]] = field(
+        default=None, metadata=config(field_name="properties")
+    )
+
+    def validate(self):
+        Precondition.check_string_not_empty(
+            self._name, '"name" field is required and cannot be empty'
+        )
+        Precondition.check_argument(
+            self._representations is not None and len(self._representations) > 0,
+            '"representations" field is required and cannot be empty',
+        )
+        for representation in self._representations:
+            Precondition.check_argument(
+                representation is not None, "representation must not be null"
+            )
+            representation.validate()
+        if self._columns:
+            for column in self._columns:
+                Precondition.check_argument(
+                    column is not None, "column must not be null"
+                )
+                column.validate()
+        ViewCreateRequest.validate_no_duplicate_dialects(self._representations)
+
+    @staticmethod
+    def validate_no_duplicate_dialects(representations: list[RepresentationDTO]):
+        """Validate that SQL representations do not use duplicate dialects."""
+        seen_dialects = set()
+        for representation in representations:
+            if isinstance(representation, SQLRepresentationDTO):
+                Precondition.check_argument(
+                    representation.dialect() not in seen_dialects,
+                    f"Duplicate SQL representation dialect: {representation.dialect()}",
+                )
+                seen_dialects.add(representation.dialect())

--- a/clients/client-python/gravitino/dto/requests/view_update_request.py
+++ b/clients/client-python/gravitino/dto/requests/view_update_request.py
@@ -1,0 +1,161 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Optional
+
+from dataclasses_json import config, dataclass_json
+
+from gravitino.api.rel.view_change import ViewChange
+from gravitino.dto.rel.column_dto import ColumnDTO
+from gravitino.dto.rel.json_serdes.representation_serdes import RepresentationSerdes
+from gravitino.dto.rel.representation_dto import RepresentationDTO
+from gravitino.dto.requests.view_create_request import ViewCreateRequest
+from gravitino.rest.rest_message import RESTRequest
+from gravitino.utils.precondition import Precondition
+
+
+@dataclass_json
+@dataclass
+class ViewUpdateRequestBase(RESTRequest, ABC):
+    """Base class for all view update requests."""
+
+    _type: str = field(init=False, metadata=config(field_name="@type"))
+
+    @abstractmethod
+    def view_change(self) -> ViewChange:
+        """Convert to view change operation."""
+
+
+class ViewUpdateRequest:
+    """Namespace for all view update request types."""
+
+    @dataclass_json
+    @dataclass
+    class RenameViewRequest(ViewUpdateRequestBase):
+        """Update request to rename a view."""
+
+        _new_name: str = field(metadata=config(field_name="newName"))
+
+        def __post_init__(self):
+            self._type = "rename"
+
+        def validate(self):
+            Precondition.check_string_not_empty(
+                self._new_name, '"newName" field is required and cannot be empty'
+            )
+
+        def view_change(self) -> ViewChange:
+            return ViewChange.rename(self._new_name)
+
+    @dataclass_json
+    @dataclass
+    class SetViewPropertyRequest(ViewUpdateRequestBase):
+        """Update request to set a view property."""
+
+        _property: str = field(metadata=config(field_name="property"))
+        _value: str = field(metadata=config(field_name="value"))
+
+        def __post_init__(self):
+            self._type = "setProperty"
+
+        def validate(self):
+            Precondition.check_string_not_empty(
+                self._property, '"property" field is required and cannot be empty'
+            )
+            Precondition.check_argument(
+                self._value is not None, '"value" field is required and cannot be null'
+            )
+
+        def view_change(self) -> ViewChange:
+            return ViewChange.set_property(self._property, self._value)
+
+    @dataclass_json
+    @dataclass
+    class RemoveViewPropertyRequest(ViewUpdateRequestBase):
+        """Update request to remove a view property."""
+
+        _property: str = field(metadata=config(field_name="property"))
+
+        def __post_init__(self):
+            self._type = "removeProperty"
+
+        def validate(self):
+            Precondition.check_string_not_empty(
+                self._property, '"property" field is required and cannot be empty'
+            )
+
+        def view_change(self) -> ViewChange:
+            return ViewChange.remove_property(self._property)
+
+    @dataclass_json
+    @dataclass
+    class ReplaceViewRequest(ViewUpdateRequestBase):
+        """Update request to replace the view body."""
+
+        _columns: Optional[list[ColumnDTO]] = field(
+            default=None, metadata=config(field_name="columns")
+        )
+        _representations: list[RepresentationDTO] = field(
+            default=None,
+            metadata=config(
+                field_name="representations",
+                encoder=lambda items: [
+                    RepresentationSerdes.serialize(item) for item in items
+                ],
+            ),
+        )
+        _default_catalog: Optional[str] = field(
+            default=None, metadata=config(field_name="defaultCatalog")
+        )
+        _default_schema: Optional[str] = field(
+            default=None, metadata=config(field_name="defaultSchema")
+        )
+        _comment: Optional[str] = field(
+            default=None, metadata=config(field_name="comment")
+        )
+
+        def __post_init__(self):
+            self._type = "replaceView"
+
+        def validate(self):
+            Precondition.check_argument(
+                self._representations is not None and len(self._representations) > 0,
+                '"representations" field is required and cannot be empty',
+            )
+            for representation in self._representations:
+                Precondition.check_argument(
+                    representation is not None, "representation must not be null"
+                )
+                representation.validate()
+            if self._columns:
+                for column in self._columns:
+                    Precondition.check_argument(
+                        column is not None, "column must not be null"
+                    )
+                    column.validate()
+            ViewCreateRequest.validate_no_duplicate_dialects(self._representations)
+
+        def view_change(self) -> ViewChange:
+            return ViewChange.replace_view(
+                self._columns or [],
+                self._representations,
+                self._default_catalog,
+                self._default_schema,
+                self._comment,
+            )

--- a/clients/client-python/gravitino/dto/requests/view_updates_request.py
+++ b/clients/client-python/gravitino/dto/requests/view_updates_request.py
@@ -1,0 +1,38 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from dataclasses import dataclass, field
+
+from dataclasses_json import config
+
+from gravitino.dto.requests.view_update_request import ViewUpdateRequestBase
+from gravitino.rest.rest_message import RESTRequest
+from gravitino.utils.precondition import Precondition
+
+
+@dataclass
+class ViewUpdatesRequest(RESTRequest):
+    """Represents a request to update a view with multiple changes."""
+
+    _updates: list[ViewUpdateRequestBase] = field(metadata=config(field_name="updates"))
+
+    def validate(self):
+        Precondition.check_argument(self._updates is not None, "updates cannot be null")
+        Precondition.check_argument(len(self._updates) > 0, "updates cannot be empty")
+        for update in self._updates:
+            Precondition.check_argument(update is not None, "update cannot be null")
+            update.validate()

--- a/clients/client-python/gravitino/dto/responses/view_response.py
+++ b/clients/client-python/gravitino/dto/responses/view_response.py
@@ -1,0 +1,47 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from dataclasses import dataclass, field
+
+from dataclasses_json import config
+
+from gravitino.dto.rel.view_dto import ViewDTO
+from gravitino.dto.responses.base_response import BaseResponse
+from gravitino.exceptions.base import IllegalArgumentException
+
+
+@dataclass
+class ViewResponse(BaseResponse):
+    """Response object for view-related operations."""
+
+    _view: ViewDTO = field(metadata=config(field_name="view"))
+
+    def view(self) -> ViewDTO:
+        """Returns the view DTO."""
+        return self._view
+
+    def validate(self):
+        """Validates the response data."""
+        super().validate()
+        if self._view is None:
+            raise IllegalArgumentException("view must not be null")
+        if not self._view.name():
+            raise IllegalArgumentException("view 'name' must not be null or empty")
+        if self._view.audit_info() is None:
+            raise IllegalArgumentException("view 'audit' must not be null")
+        if not self._view.representations():
+            raise IllegalArgumentException("view 'representations' must not be null")

--- a/clients/client-python/gravitino/dto/responses/view_response.py
+++ b/clients/client-python/gravitino/dto/responses/view_response.py
@@ -44,4 +44,6 @@ class ViewResponse(BaseResponse):
         if self._view.audit_info() is None:
             raise IllegalArgumentException("view 'audit' must not be null")
         if not self._view.representations():
-            raise IllegalArgumentException("view 'representations' must not be null")
+            raise IllegalArgumentException(
+                "view 'representations' must not be null or empty"
+            )

--- a/clients/client-python/gravitino/dto/util/dto_converters.py
+++ b/clients/client-python/gravitino/dto/util/dto_converters.py
@@ -41,6 +41,8 @@ from gravitino.api.rel.partitions.identity_partition import IdentityPartition
 from gravitino.api.rel.partitions.list_partition import ListPartition
 from gravitino.api.rel.partitions.partition import Partition
 from gravitino.api.rel.partitions.range_partition import RangePartition
+from gravitino.api.rel.representation import Representation
+from gravitino.api.rel.sql_representation import SQLRepresentation
 from gravitino.api.rel.table import Table
 from gravitino.api.rel.table_change import (
     AddColumn,
@@ -55,6 +57,12 @@ from gravitino.api.rel.table_change import (
     UpdateColumnType,
 )
 from gravitino.api.rel.types.types import Types
+from gravitino.api.rel.view_change import (
+    RemoveProperty,
+    RenameView,
+    ReplaceView,
+    SetProperty,
+)
 from gravitino.dto.rel.column_dto import ColumnDTO
 from gravitino.dto.rel.distribution_dto import DistributionDTO
 from gravitino.dto.rel.expressions.field_reference_dto import FieldReferenceDTO
@@ -87,11 +95,17 @@ from gravitino.dto.rel.partitions.identity_partition_dto import IdentityPartitio
 from gravitino.dto.rel.partitions.list_partition_dto import ListPartitionDTO
 from gravitino.dto.rel.partitions.partition_dto import PartitionDTO
 from gravitino.dto.rel.partitions.range_partition_dto import RangePartitionDTO
+from gravitino.dto.rel.representation_dto import RepresentationDTO
 from gravitino.dto.rel.sort_order_dto import SortOrderDTO
+from gravitino.dto.rel.sql_representation_dto import SQLRepresentationDTO
 from gravitino.dto.rel.table_dto import TableDTO
 from gravitino.dto.requests.table_update_request import (
     TableUpdateRequest,
     TableUpdateRequestBase,
+)
+from gravitino.dto.requests.view_update_request import (
+    ViewUpdateRequest,
+    ViewUpdateRequestBase,
 )
 from gravitino.exceptions.base import IllegalArgumentException
 
@@ -226,6 +240,19 @@ class DTOConverters:
             dto.auto_increment(),
             DTOConverters.from_function_arg(dto.default_value()),
         )
+
+    @from_dto.register
+    @staticmethod
+    def _(dto: SQLRepresentationDTO) -> SQLRepresentation:
+        """Converts a SQLRepresentationDTO to a SQLRepresentation.
+
+        Args:
+            dto (SQLRepresentationDTO): The SQLRepresentation DTO to be converted.
+
+        Returns:
+            SQLRepresentation: The SQLRepresentation.
+        """
+        return SQLRepresentation(_dialect=dto.dialect(), _sql=dto.sql())
 
     @from_dto.register
     @staticmethod
@@ -377,20 +404,23 @@ class DTOConverters:
 
     @overload
     @staticmethod
+    def from_dtos(
+        dtos: list[RepresentationDTO],
+    ) -> list[Representation]: ...  # pragma: no cover
+
+    @overload
+    @staticmethod
     def from_dtos(dtos: list[Partitioning]) -> list[Transform]: ...  # pragma: no cover
 
     @staticmethod
     def from_dtos(dtos):
-        """Converts list of `ColumnDTO`, `IndexDTO`, `SortOrderDTO`, or `Partitioning`
-        to the corresponding list of `Column`s, `Index`es, `SortOrder`s, or `Transform`s.
+        """Converts a list of DTOs to the corresponding API objects.
 
         Args:
-            dtos (list[ColumnDTO] | list[IndexDTO] | list[SortOrderDTO] | list[Partitioning]):
-                The DTOs to be converted.
+            dtos: The DTOs to be converted.
 
         Returns:
-            list[Column] | list[Index] | list[SortOrder] | list[Transform]:
-                The list of Columns, Indexes, SortOrders, or Transforms depends on the input DTOs.
+            The converted objects.
         """
         if not dtos:
             return []
@@ -559,6 +589,16 @@ class DTOConverters:
 
     @to_dto.register
     @staticmethod
+    def _(obj: RepresentationDTO) -> RepresentationDTO:
+        return obj
+
+    @to_dto.register
+    @staticmethod
+    def _(obj: SQLRepresentation) -> SQLRepresentationDTO:
+        return SQLRepresentationDTO(_dialect=obj.dialect(), _sql=obj.sql())
+
+    @to_dto.register
+    @staticmethod
     def _(obj: Partitioning) -> Partitioning:
         return obj
 
@@ -645,6 +685,18 @@ class DTOConverters:
     @overload
     @staticmethod
     def to_dtos(dtos: list[SortOrderDTO]) -> list[SortOrderDTO]: ...  # pragma: no cover
+
+    @overload
+    @staticmethod
+    def to_dtos(
+        dtos: list[Representation],
+    ) -> list[RepresentationDTO]: ...  # pragma: no cover
+
+    @overload
+    @staticmethod
+    def to_dtos(
+        dtos: list[RepresentationDTO],
+    ) -> list[RepresentationDTO]: ...  # pragma: no cover
 
     @overload
     @staticmethod
@@ -797,6 +849,34 @@ class DTOConverters:
             return TableUpdateRequest.DeleteTableIndexRequest(
                 _name=delete_index.get_name(),
                 _if_exists=delete_index.is_if_exists(),
+            )
+
+        raise IllegalArgumentException(
+            f"Unknown change type: {change.__class__.__name__}"
+        )
+
+    @staticmethod
+    def to_view_update_request(change) -> ViewUpdateRequestBase:
+        if isinstance(change, RenameView):
+            return ViewUpdateRequest.RenameViewRequest(_new_name=change.new_name())
+
+        if isinstance(change, SetProperty):
+            return ViewUpdateRequest.SetViewPropertyRequest(
+                _property=change.property(), _value=change.value()
+            )
+
+        if isinstance(change, RemoveProperty):
+            return ViewUpdateRequest.RemoveViewPropertyRequest(
+                _property=change.property()
+            )
+
+        if isinstance(change, ReplaceView):
+            return ViewUpdateRequest.ReplaceViewRequest(
+                _columns=DTOConverters.to_dtos(change.columns()),
+                _representations=DTOConverters.to_dtos(change.representations()),
+                _default_catalog=change.default_catalog(),
+                _default_schema=change.default_schema(),
+                _comment=change.comment(),
             )
 
         raise IllegalArgumentException(

--- a/clients/client-python/gravitino/exceptions/base.py
+++ b/clients/client-python/gravitino/exceptions/base.py
@@ -217,6 +217,10 @@ class NoSuchTableException(NotFoundException):
     """An exception thrown when a table with specified name is not existed."""
 
 
+class NoSuchViewException(NotFoundException):
+    """An exception thrown when a view with specified name is not found."""
+
+
 class NoSuchPartitionException(NotFoundException):
     """An exception thrown when a partition with specified name is not existed."""
 
@@ -227,6 +231,10 @@ class PartitionAlreadyExistsException(AlreadyExistsException):
 
 class TableAlreadyExistsException(AlreadyExistsException):
     """An exception thrown when a table already exists."""
+
+
+class ViewAlreadyExistsException(AlreadyExistsException):
+    """An exception thrown when a view already exists."""
 
 
 class NoSuchFunctionException(NotFoundException):

--- a/clients/client-python/gravitino/exceptions/handlers/view_error_handler.py
+++ b/clients/client-python/gravitino/exceptions/handlers/view_error_handler.py
@@ -1,0 +1,78 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from gravitino.constants.error import ErrorConstants
+from gravitino.dto.responses.error_response import ErrorResponse
+from gravitino.exceptions.base import (
+    CatalogNotInUseException,
+    ForbiddenException,
+    IllegalArgumentException,
+    MetalakeNotInUseException,
+    NoSuchCatalogException,
+    NoSuchSchemaException,
+    NoSuchViewException,
+    NotFoundException,
+    NotInUseException,
+    UnsupportedOperationException,
+    ViewAlreadyExistsException,
+)
+from gravitino.exceptions.handlers.rest_error_handler import RestErrorHandler
+
+
+class ViewErrorHandler(RestErrorHandler):
+    """Error handler for view operations."""
+
+    def handle(self, error_response: ErrorResponse):
+        error_message = error_response.format_error_message()
+        code = ErrorConstants(error_response.code())
+        exception_type = error_response.type()
+
+        if code is ErrorConstants.ILLEGAL_ARGUMENTS_CODE:
+            raise IllegalArgumentException(error_message)
+
+        if code is ErrorConstants.NOT_FOUND_CODE:
+            if exception_type == NoSuchCatalogException.__name__:
+                raise NoSuchCatalogException(error_message)
+            if exception_type == NoSuchSchemaException.__name__:
+                raise NoSuchSchemaException(error_message)
+            if exception_type == NoSuchViewException.__name__:
+                raise NoSuchViewException(error_message)
+            raise NotFoundException(error_message)
+
+        if code is ErrorConstants.ALREADY_EXISTS_CODE:
+            raise ViewAlreadyExistsException(error_message)
+
+        if code is ErrorConstants.INTERNAL_ERROR_CODE:
+            raise RuntimeError(error_message)
+
+        if code is ErrorConstants.UNSUPPORTED_OPERATION_CODE:
+            raise UnsupportedOperationException(error_message)
+
+        if code is ErrorConstants.FORBIDDEN_CODE:
+            raise ForbiddenException(error_message)
+
+        if code is ErrorConstants.NOT_IN_USE_CODE:
+            if exception_type == CatalogNotInUseException.__name__:
+                raise CatalogNotInUseException(error_message)
+            if exception_type == MetalakeNotInUseException.__name__:
+                raise MetalakeNotInUseException(error_message)
+            raise NotInUseException(error_message)
+
+        super().handle(error_response)
+
+
+VIEW_ERROR_HANDLER = ViewErrorHandler()

--- a/clients/client-python/tests/integration/test_relational_catalog.py
+++ b/clients/client-python/tests/integration/test_relational_catalog.py
@@ -25,17 +25,23 @@ from gravitino import (
     NameIdentifier,
 )
 from gravitino.api.rel.column import Column
+from gravitino.api.rel.dialects import Dialects
 from gravitino.api.rel.expressions.distributions.distributions import Distributions
 from gravitino.api.rel.expressions.transforms.transforms import Transforms
 from gravitino.api.rel.indexes.indexes import Indexes
+from gravitino.api.rel.sql_representation import SQLRepresentation
 from gravitino.api.rel.table import Table
 from gravitino.api.rel.table_change import TableChange
 from gravitino.api.rel.types.types import Types
+from gravitino.api.rel.view import View
+from gravitino.api.rel.view_change import ViewChange
 from gravitino.client.relational_table import RelationalTable
 from gravitino.exceptions.base import (
     NoSuchSchemaException,
     NoSuchTableException,
+    NoSuchViewException,
     TableAlreadyExistsException,
+    ViewAlreadyExistsException,
 )
 from gravitino.namespace import Namespace
 from tests.integration.containers.hdfs_container import HDFSContainer
@@ -53,6 +59,10 @@ class TestRelationalCatalog(IntegrationTestEnv):
     TABLE_IDENT: NameIdentifier = NameIdentifier.of(SCHEMA_NAME, TABLE_NAME)
     TABLE_COMMENT: str = "Test table for relational catalog"
     TABLE_PROPERTIES = {"property1": "value1", "property2": "value2"}
+    VIEW_NAME: str = "test_view"
+    VIEW_IDENT: NameIdentifier = NameIdentifier.of(SCHEMA_NAME, VIEW_NAME)
+    VIEW_COMMENT: str = "Test view for relational catalog"
+    VIEW_PROPERTIES = {"view_property1": "value1", "view_property2": "value2"}
 
     @classmethod
     def setUpClass(cls):
@@ -135,6 +145,28 @@ class TestRelationalCatalog(IntegrationTestEnv):
             distribution=Distributions.NONE,
             sort_orders=[],
             indexes=Indexes.EMPTY_INDEXES,
+        )
+
+    def _create_test_view(self) -> View:
+        """Create a test view with basic columns."""
+
+        view_catalog = self.catalog.as_view_catalog()
+        columns = [
+            Column.of("id", Types.LongType.get(), "Primary key"),
+            Column.of("name", Types.StringType.get(), "Name column"),
+        ]
+
+        return view_catalog.create_view(
+            identifier=TestRelationalCatalog.VIEW_IDENT,
+            columns=columns,
+            representations=[
+                SQLRepresentation(
+                    Dialects.HIVE,
+                    f"SELECT id, name FROM {TestRelationalCatalog.TABLE_NAME}",
+                )
+            ],
+            comment=TestRelationalCatalog.VIEW_COMMENT,
+            properties=TestRelationalCatalog.VIEW_PROPERTIES,
         )
 
     def test_relational_catalog_create_table(self):
@@ -311,3 +343,147 @@ class TestRelationalCatalog(IntegrationTestEnv):
             new_property_value,
         )
         self.assertNotIn("property2", altered_table.properties())
+
+    def test_relational_catalog_create_view(self):
+        """Test creating a view in the relational catalog."""
+        self._create_test_table()
+        view = self._create_test_view()
+        self.assertIsNotNone(view)
+        self.assertEqual(view.name(), TestRelationalCatalog.VIEW_NAME)
+        self.assertEqual(view.comment(), TestRelationalCatalog.VIEW_COMMENT)
+        self.assertEqual(view.properties().get("view_property1"), "value1")
+        self.assertEqual(view.properties().get("view_property2"), "value2")
+        self.assertEqual(len(view.columns()), 2)
+        self.assertEqual(view.columns()[0].name(), "id")
+        self.assertEqual(view.columns()[0].data_type(), Types.LongType.get())
+        self.assertEqual(view.columns()[1].name(), "name")
+        self.assertEqual(view.columns()[1].data_type(), Types.StringType.get())
+        self.assertEqual(
+            view.sql_for(Dialects.HIVE).sql(),
+            f"SELECT id, name FROM {TestRelationalCatalog.TABLE_NAME}",
+        )
+
+    def test_relational_catalog_create_view_already_exists(self):
+        """Test creating a view that already exists should raise exception."""
+        self._create_test_table()
+        self._create_test_view()
+        view_catalog = self.catalog.as_view_catalog()
+
+        with self.assertRaises(ViewAlreadyExistsException):
+            view_catalog.create_view(
+                identifier=TestRelationalCatalog.VIEW_IDENT,
+                columns=[Column.of("id", Types.LongType.get(), "Primary key")],
+                representations=[
+                    SQLRepresentation(
+                        Dialects.HIVE,
+                        f"SELECT id FROM {TestRelationalCatalog.TABLE_NAME}",
+                    )
+                ],
+            )
+
+    def test_relational_catalog_list_views(self):
+        """Test listing views in the relational catalog."""
+        self._create_test_table()
+        self._create_test_view()
+        view_catalog = self.catalog.as_view_catalog()
+
+        view_identifiers = view_catalog.list_views(
+            Namespace.of(TestRelationalCatalog.SCHEMA_NAME)
+        )
+        self.assertEqual(len(view_identifiers), 1)
+        self.assertEqual(view_identifiers[0], TestRelationalCatalog.VIEW_IDENT)
+
+    def test_relational_catalog_list_views_invalid_namespace(self):
+        """Test listing views with invalid namespace."""
+        view_catalog = self.catalog.as_view_catalog()
+        invalid_namespace = NameIdentifier.of(
+            "non_existent_schema", "dummy"
+        ).namespace()
+
+        with self.assertRaises(NoSuchSchemaException):
+            view_catalog.list_views(namespace=invalid_namespace)
+
+    def test_relational_catalog_load_view(self):
+        """Test loading a view from the relational catalog."""
+        self._create_test_table()
+        self._create_test_view()
+        view_catalog = self.catalog.as_view_catalog()
+
+        view = view_catalog.load_view(identifier=TestRelationalCatalog.VIEW_IDENT)
+        self.assertEqual(view.name(), TestRelationalCatalog.VIEW_NAME)
+        self.assertEqual(view.comment(), TestRelationalCatalog.VIEW_COMMENT)
+
+    def test_relational_catalog_load_view_not_exists(self):
+        """Test loading a view that doesn't exist should raise exception."""
+        view_catalog = self.catalog.as_view_catalog()
+        non_existent_view = NameIdentifier.of(
+            TestRelationalCatalog.SCHEMA_NAME, "non_existent_view"
+        )
+
+        with self.assertRaises(NoSuchViewException):
+            view_catalog.load_view(identifier=non_existent_view)
+
+    def test_relational_catalog_view_exists(self):
+        """Test checking if a view exists."""
+        self._create_test_table()
+        view_catalog = self.catalog.as_view_catalog()
+
+        self.assertFalse(
+            view_catalog.view_exists(identifier=TestRelationalCatalog.VIEW_IDENT)
+        )
+
+        self._create_test_view()
+
+        self.assertTrue(
+            view_catalog.view_exists(identifier=TestRelationalCatalog.VIEW_IDENT)
+        )
+
+    def test_relational_catalog_drop_view(self):
+        """Test dropping a view from the relational catalog."""
+        self._create_test_table()
+        self._create_test_view()
+        view_catalog = self.catalog.as_view_catalog()
+
+        is_dropped = view_catalog.drop_view(TestRelationalCatalog.VIEW_IDENT)
+        self.assertTrue(is_dropped)
+        self.assertFalse(
+            view_catalog.view_exists(identifier=TestRelationalCatalog.VIEW_IDENT)
+        )
+
+    def test_relational_catalog_drop_view_not_exists(self):
+        """Test dropping a view that doesn't exist should return False."""
+        view_catalog = self.catalog.as_view_catalog()
+        ident = NameIdentifier.of(TestRelationalCatalog.SCHEMA_NAME, "invalid_view")
+
+        is_dropped = view_catalog.drop_view(ident)
+        self.assertFalse(is_dropped)
+
+    def test_relational_catalog_alter_view(self):
+        """Test altering a view from the relational catalog."""
+        self._create_test_table()
+        self._create_test_view()
+        view_catalog = self.catalog.as_view_catalog()
+
+        new_property_value = "new_property_value"
+        changes = [
+            ViewChange.set_property("view_property1", new_property_value),
+            ViewChange.remove_property("view_property2"),
+        ]
+
+        altered_view = view_catalog.alter_view(
+            TestRelationalCatalog.VIEW_IDENT, *changes
+        )
+
+        self.assertEqual(
+            altered_view.properties().get("view_property1"),
+            new_property_value,
+        )
+        self.assertNotIn("view_property2", altered_view.properties())
+
+    def test_relational_catalog_alter_view_not_exists(self):
+        """Test altering a view that doesn't exist should raise NoSuchViewException."""
+        view_catalog = self.catalog.as_view_catalog()
+        ident = NameIdentifier.of(TestRelationalCatalog.SCHEMA_NAME, "invalid_view")
+
+        with self.assertRaises(NoSuchViewException):
+            view_catalog.alter_view(ident, ViewChange.set_property("property", "value"))

--- a/clients/client-python/tests/unittests/api/rel/test_view.py
+++ b/clients/client-python/tests/unittests/api/rel/test_view.py
@@ -1,0 +1,117 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import unittest
+
+from gravitino.api.rel.column import Column
+from gravitino.api.rel.dialects import Dialects
+from gravitino.api.rel.representation import Representation
+from gravitino.api.rel.sql_representation import SQLRepresentation
+from gravitino.api.rel.types.types import Types
+from gravitino.api.rel.view_change import (
+    RemoveProperty,
+    RenameView,
+    ReplaceView,
+    SetProperty,
+    ViewChange,
+)
+
+
+class TestView(unittest.TestCase):
+    def test_dialects(self):
+        self.assertEqual("trino", Dialects.TRINO)
+        self.assertEqual("spark", Dialects.SPARK)
+        self.assertEqual("hive", Dialects.HIVE)
+        self.assertEqual("flink", Dialects.FLINK)
+
+    def test_sql_representation(self):
+        representation = SQLRepresentation(Dialects.TRINO, "SELECT 1")
+
+        self.assertEqual(Representation.TYPE_SQL, representation.type())
+        self.assertEqual(Dialects.TRINO, representation.dialect())
+        self.assertEqual("SELECT 1", representation.sql())
+        self.assertEqual(representation, SQLRepresentation(Dialects.TRINO, "SELECT 1"))
+        self.assertNotEqual(
+            representation, SQLRepresentation(Dialects.SPARK, "SELECT 1")
+        )
+
+        with self.assertRaises(ValueError):
+            SQLRepresentation("", "SELECT 1")
+        with self.assertRaises(ValueError):
+            SQLRepresentation(Dialects.TRINO, "")
+
+    def test_view_change_rename(self):
+        change = ViewChange.rename("new_view")
+
+        self.assertIsInstance(change, RenameView)
+        self.assertEqual("new_view", change.new_name())
+        self.assertEqual(change, ViewChange.rename("new_view"))
+        self.assertNotEqual(change, ViewChange.rename("another_view"))
+
+        with self.assertRaises(ValueError):
+            ViewChange.rename("")
+
+    def test_view_change_set_property(self):
+        change = ViewChange.set_property("key", "value")
+
+        self.assertIsInstance(change, SetProperty)
+        self.assertEqual("key", change.property())
+        self.assertEqual("value", change.value())
+        self.assertEqual(change, ViewChange.set_property("key", "value"))
+
+        with self.assertRaises(ValueError):
+            ViewChange.set_property("", "value")
+
+    def test_view_change_remove_property(self):
+        change = ViewChange.remove_property("key")
+
+        self.assertIsInstance(change, RemoveProperty)
+        self.assertEqual("key", change.property())
+        self.assertEqual(change, ViewChange.remove_property("key"))
+
+        with self.assertRaises(ValueError):
+            ViewChange.remove_property("")
+
+    def test_view_change_replace_view(self):
+        columns = [Column.of("id", Types.IntegerType.get())]
+        representations = [SQLRepresentation(Dialects.TRINO, "SELECT id FROM tbl")]
+
+        change = ViewChange.replace_view(
+            columns,
+            representations,
+            default_catalog="catalog",
+            default_schema="schema",
+            comment="comment",
+        )
+
+        self.assertIsInstance(change, ReplaceView)
+        self.assertEqual(columns, change.columns())
+        self.assertEqual(representations, change.representations())
+        self.assertEqual("catalog", change.default_catalog())
+        self.assertEqual("schema", change.default_schema())
+        self.assertEqual("comment", change.comment())
+        self.assertEqual(
+            change,
+            ViewChange.replace_view(
+                columns, representations, "catalog", "schema", "comment"
+            ),
+        )
+
+        with self.assertRaises(ValueError):
+            ViewChange.replace_view(None, representations)
+        with self.assertRaises(ValueError):
+            ViewChange.replace_view(columns, [])

--- a/clients/client-python/tests/unittests/dto/rel/test_representation_serdes.py
+++ b/clients/client-python/tests/unittests/dto/rel/test_representation_serdes.py
@@ -1,0 +1,45 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import unittest
+
+from gravitino.api.rel.dialects import Dialects
+from gravitino.api.rel.representation import Representation
+from gravitino.dto.rel.json_serdes.representation_serdes import RepresentationSerdes
+from gravitino.dto.rel.sql_representation_dto import SQLRepresentationDTO
+from gravitino.exceptions.base import IllegalArgumentException
+
+
+class TestRepresentationSerdes(unittest.TestCase):
+    def test_representation_serdes(self):
+        representation = SQLRepresentationDTO(
+            _dialect=Dialects.TRINO, _sql="SELECT id FROM table"
+        )
+        serialized = RepresentationSerdes.serialize(representation)
+
+        self.assertEqual(Representation.TYPE_SQL, serialized["type"])
+        self.assertEqual(Dialects.TRINO, serialized["dialect"])
+        self.assertEqual("SELECT id FROM table", serialized["sql"])
+        self.assertEqual(representation, RepresentationSerdes.deserialize(serialized))
+
+    def test_representation_serdes_none(self):
+        self.assertIsNone(RepresentationSerdes.serialize(None))
+        self.assertIsNone(RepresentationSerdes.deserialize(None))
+
+    def test_representation_serdes_unknown_type(self):
+        with self.assertRaises(IllegalArgumentException):
+            RepresentationSerdes.deserialize({"type": "unknown"})

--- a/clients/client-python/tests/unittests/dto/rel/test_sql_representation_dto.py
+++ b/clients/client-python/tests/unittests/dto/rel/test_sql_representation_dto.py
@@ -1,0 +1,55 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import unittest
+
+from gravitino.api.rel.dialects import Dialects
+from gravitino.api.rel.representation import Representation
+from gravitino.dto.rel.sql_representation_dto import SQLRepresentationDTO
+
+
+class TestSQLRepresentationDTO(unittest.TestCase):
+    def test_sql_representation_dto(self):
+        representation = SQLRepresentationDTO(
+            _dialect=Dialects.TRINO, _sql="SELECT id FROM table"
+        )
+
+        self.assertEqual(Representation.TYPE_SQL, representation.type())
+        self.assertEqual(Dialects.TRINO, representation.dialect())
+        self.assertEqual("SELECT id FROM table", representation.sql())
+        self.assertEqual(
+            representation,
+            SQLRepresentationDTO(_dialect=Dialects.TRINO, _sql="SELECT id FROM table"),
+        )
+        self.assertEqual(
+            hash(representation),
+            hash(
+                SQLRepresentationDTO(
+                    _dialect=Dialects.TRINO, _sql="SELECT id FROM table"
+                )
+            ),
+        )
+        self.assertNotEqual(
+            representation,
+            SQLRepresentationDTO(_dialect=Dialects.SPARK, _sql="SELECT id FROM table"),
+        )
+
+    def test_sql_representation_dto_validate(self):
+        with self.assertRaises(ValueError):
+            SQLRepresentationDTO(_dialect="", _sql="SELECT 1").validate()
+        with self.assertRaises(ValueError):
+            SQLRepresentationDTO(_dialect=Dialects.TRINO, _sql="").validate()

--- a/clients/client-python/tests/unittests/dto/rel/test_view_dto.py
+++ b/clients/client-python/tests/unittests/dto/rel/test_view_dto.py
@@ -1,0 +1,355 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import unittest
+
+from gravitino.api.rel.dialects import Dialects
+from gravitino.api.rel.sql_representation import SQLRepresentation
+from gravitino.api.rel.types.types import Types
+from gravitino.dto.audit_dto import AuditDTO
+from gravitino.dto.rel.column_dto import ColumnDTO
+from gravitino.dto.rel.sql_representation_dto import SQLRepresentationDTO
+from gravitino.dto.rel.view_dto import ViewDTO
+
+
+class TestViewDTO(unittest.TestCase):
+    @staticmethod
+    def _column(name: str = "id") -> ColumnDTO:
+        return ColumnDTO(
+            _name=name,
+            _data_type=Types.IntegerType.get(),
+            _comment="column comment",
+            _nullable=False,
+        )
+
+    @staticmethod
+    def _representation(
+        dialect: str = Dialects.TRINO, sql: str = "SELECT id FROM table"
+    ) -> SQLRepresentationDTO:
+        return SQLRepresentationDTO(_dialect=dialect, _sql=sql)
+
+    def _view_dto(
+        self,
+        name: str = "test_view",
+        columns: list[ColumnDTO] = None,
+        representations: list[SQLRepresentationDTO] = None,
+        comment: str = "view comment",
+        properties: dict[str, str] = None,
+    ) -> ViewDTO:
+        return ViewDTO(
+            _name=name,
+            _columns=columns if columns is not None else [self._column()],
+            _representations=(
+                representations
+                if representations is not None
+                else [self._representation()]
+            ),
+            _comment=comment,
+            _default_catalog="catalog",
+            _default_schema="schema",
+            _properties=properties if properties is not None else {"k1": "v1"},
+            _audit=AuditDTO(
+                "creator", "2022-01-01T00:00:00Z", "modifier", "2022-01-02T00:00:00Z"
+            ),
+        )
+
+    def test_view_dto_serialization(self):
+        view = self._view_dto()
+
+        deserialized = ViewDTO.from_json(view.to_json())
+
+        self.assertEqual(view, deserialized)
+        self.assertEqual("test_view", deserialized.name())
+        self.assertEqual("view comment", deserialized.comment())
+        self.assertEqual("catalog", deserialized.default_catalog())
+        self.assertEqual("schema", deserialized.default_schema())
+        self.assertEqual({"k1": "v1"}, deserialized.properties())
+        self.assertEqual("creator", deserialized.audit_info().creator())
+        self.assertEqual(1, len(deserialized.columns()))
+        self.assertEqual(1, len(deserialized.representations()))
+        self.assertIsInstance(deserialized.representations()[0], SQLRepresentation)
+        self.assertEqual(
+            "SELECT id FROM table",
+            deserialized.representations()[0].sql(),
+        )
+
+    def test_view_dto_deserialize_from_raw_json(self):
+        raw_json = """
+        {
+            "name": "raw_view",
+            "comment": "raw comment",
+            "columns": [
+                {
+                    "name": "id",
+                    "type": "integer",
+                    "comment": "id column",
+                    "nullable": false,
+                    "autoIncrement": false
+                }
+            ],
+            "representations": [
+                {
+                    "type": "sql",
+                    "dialect": "spark",
+                    "sql": "SELECT id FROM table"
+                }
+            ],
+            "defaultCatalog": "catalog",
+            "defaultSchema": "schema",
+            "properties": {
+                "k1": "v1"
+            },
+            "audit": {
+                "creator": "creator"
+            }
+        }
+        """
+
+        view = ViewDTO.from_json(raw_json)
+
+        self.assertEqual("raw_view", view.name())
+        self.assertEqual("raw comment", view.comment())
+        self.assertEqual("catalog", view.default_catalog())
+        self.assertEqual("schema", view.default_schema())
+        self.assertEqual({"k1": "v1"}, view.properties())
+        self.assertEqual("creator", view.audit_info().creator())
+        self.assertEqual(1, len(view.columns()))
+        self.assertEqual("id", view.columns()[0].name())
+        self.assertEqual(1, len(view.representations()))
+        self.assertIsInstance(view.representations()[0], SQLRepresentation)
+        self.assertEqual("spark", view.representations()[0].dialect())
+        self.assertEqual("SELECT id FROM table", view.representations()[0].sql())
+
+    def test_view_dto_defaults(self):
+        view = ViewDTO(
+            _name="test_view",
+            _representations=[self._representation()],
+            _audit=AuditDTO("creator"),
+        )
+
+        self.assertEqual([], view.columns())
+        self.assertEqual({}, view.properties())
+        self.assertIsNone(view.comment())
+        self.assertIsNone(view.default_catalog())
+        self.assertIsNone(view.default_schema())
+
+    def test_view_dto_deserialize_invalid_name(self):
+        raw_json = """
+        {
+            "name": "",
+            "representations": [
+                {
+                    "type": "sql",
+                    "dialect": "spark",
+                    "sql": "SELECT 1"
+                }
+            ],
+            "audit": {
+                "creator": "creator"
+            }
+        }
+        """
+
+        with self.assertRaisesRegex(ValueError, "name cannot be null or empty"):
+            ViewDTO.from_json(raw_json)
+
+    def test_view_dto_deserialize_missing_audit(self):
+        raw_json = """
+        {
+            "name": "test_view",
+            "representations": [
+                {
+                    "type": "sql",
+                    "dialect": "spark",
+                    "sql": "SELECT 1"
+                }
+            ]
+        }
+        """
+
+        with self.assertRaisesRegex(ValueError, "audit cannot be null"):
+            ViewDTO.from_json(raw_json)
+
+    def test_view_dto_deserialize_missing_representations(self):
+        raw_json = """
+        {
+            "name": "test_view",
+            "audit": {
+                "creator": "creator"
+            }
+        }
+        """
+
+        with self.assertRaisesRegex(
+            ValueError, "representations cannot be null or empty"
+        ):
+            ViewDTO.from_json(raw_json)
+
+    def test_view_dto_deserialize_invalid_representations(self):
+        raw_json_strings = [
+            """
+            {
+                "name": "test_view",
+                "representations": [],
+                "audit": {
+                    "creator": "creator"
+                }
+            }
+            """,
+            """
+            {
+                "name": "test_view",
+                "representations": [null],
+                "audit": {
+                    "creator": "creator"
+                }
+            }
+            """,
+            """
+            {
+                "name": "test_view",
+                "representations": [
+                    {
+                        "type": "sql",
+                        "dialect": "",
+                        "sql": "SELECT 1"
+                    }
+                ],
+                "audit": {
+                    "creator": "creator"
+                }
+            }
+            """,
+            """
+            {
+                "name": "test_view",
+                "representations": [
+                    {
+                        "type": "sql",
+                        "dialect": "spark",
+                        "sql": ""
+                    }
+                ],
+                "audit": {
+                    "creator": "creator"
+                }
+            }
+            """,
+        ]
+
+        for raw_json in raw_json_strings:
+            with self.assertRaises(ValueError):
+                ViewDTO.from_json(raw_json)
+
+    def test_view_dto_validate_constructor_arguments(self):
+        with self.assertRaises(ValueError):
+            ViewDTO(
+                _name="",
+                _representations=[self._representation()],
+                _audit=AuditDTO("creator"),
+            )
+        with self.assertRaises(ValueError):
+            ViewDTO(_name="test_view", _representations=[], _audit=AuditDTO("creator"))
+        with self.assertRaises(ValueError):
+            ViewDTO(
+                _name="test_view", _representations=[None], _audit=AuditDTO("creator")
+            )
+        with self.assertRaises(ValueError):
+            ViewDTO(
+                _name="test_view",
+                _representations=[self._representation()],
+                _audit=None,
+            )
+
+    def test_view_dto_sql_for(self):
+        view = self._view_dto(
+            representations=[
+                self._representation(Dialects.TRINO, "SELECT 1"),
+                self._representation(Dialects.SPARK, "SELECT 2"),
+            ]
+        )
+        deserialized = ViewDTO.from_json(view.to_json())
+
+        self.assertEqual("SELECT 1", deserialized.sql_for("trino").sql())
+        self.assertEqual("SELECT 1", deserialized.sql_for("TRINO").sql())
+        self.assertEqual("SELECT 1", deserialized.sql_for("Trino").sql())
+        self.assertEqual("SELECT 2", deserialized.sql_for(Dialects.SPARK).sql())
+        self.assertIsNone(deserialized.sql_for("hive"))
+        self.assertIsNone(deserialized.sql_for(None))
+
+    def test_view_dto_equal_and_hash(self):
+        view = self._view_dto()
+        same_view = self._view_dto()
+        view_with_different_name = self._view_dto(name="another_view")
+        view_with_different_column = self._view_dto(
+            columns=[self._column("another_id")]
+        )
+        view_with_different_representation = self._view_dto(
+            representations=[self._representation(Dialects.SPARK, "SELECT id FROM tbl")]
+        )
+        view_with_different_comment = self._view_dto(comment="another comment")
+        view_with_different_default_catalog = ViewDTO(
+            _name="test_view",
+            _columns=[self._column()],
+            _representations=[self._representation()],
+            _comment="view comment",
+            _default_catalog="another_catalog",
+            _default_schema="schema",
+            _properties={"k1": "v1"},
+            _audit=AuditDTO("creator"),
+        )
+        view_with_different_default_schema = ViewDTO(
+            _name="test_view",
+            _columns=[self._column()],
+            _representations=[self._representation()],
+            _comment="view comment",
+            _default_catalog="catalog",
+            _default_schema="another_schema",
+            _properties={"k1": "v1"},
+            _audit=AuditDTO("creator"),
+        )
+        view_with_different_property = self._view_dto(properties={"k2": "v2"})
+        view_with_different_audit = ViewDTO(
+            _name="test_view",
+            _columns=[self._column()],
+            _representations=[self._representation()],
+            _comment="view comment",
+            _default_catalog="catalog",
+            _default_schema="schema",
+            _properties={"k1": "v1"},
+            _audit=AuditDTO("another_creator"),
+        )
+
+        self.assertEqual(view, same_view)
+        self.assertEqual(hash(view), hash(same_view))
+        self.assertNotEqual(view, view_with_different_name)
+        self.assertNotEqual(hash(view), hash(view_with_different_name))
+        self.assertNotEqual(view, view_with_different_column)
+        self.assertNotEqual(hash(view), hash(view_with_different_column))
+        self.assertNotEqual(view, view_with_different_representation)
+        self.assertNotEqual(hash(view), hash(view_with_different_representation))
+        self.assertNotEqual(view, view_with_different_comment)
+        self.assertNotEqual(hash(view), hash(view_with_different_comment))
+        self.assertNotEqual(view, view_with_different_default_catalog)
+        self.assertNotEqual(hash(view), hash(view_with_different_default_catalog))
+        self.assertNotEqual(view, view_with_different_default_schema)
+        self.assertNotEqual(hash(view), hash(view_with_different_default_schema))
+        self.assertNotEqual(view, view_with_different_property)
+        self.assertNotEqual(hash(view), hash(view_with_different_property))
+        self.assertEqual(view, view_with_different_audit)
+        self.assertEqual(hash(view), hash(view_with_different_audit))
+        self.assertNotEqual(view, "not_a_view")

--- a/clients/client-python/tests/unittests/dto/requests/test_view_create_request.py
+++ b/clients/client-python/tests/unittests/dto/requests/test_view_create_request.py
@@ -1,0 +1,128 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import unittest
+
+from gravitino.api.rel.dialects import Dialects
+from gravitino.api.rel.representation import Representation
+from gravitino.api.rel.types.types import Types
+from gravitino.dto.rel.column_dto import ColumnDTO
+from gravitino.dto.rel.sql_representation_dto import SQLRepresentationDTO
+from gravitino.dto.requests.view_create_request import ViewCreateRequest
+
+
+class TestViewCreateRequest(unittest.TestCase):
+    @staticmethod
+    def _request(
+        name: str = "test_view",
+        columns: list[ColumnDTO] = None,
+        representations: list[SQLRepresentationDTO] = None,
+    ) -> ViewCreateRequest:
+        return ViewCreateRequest(
+            _name=name,
+            _columns=(
+                columns
+                if columns is not None
+                else [
+                    ColumnDTO(
+                        _name="id",
+                        _data_type=Types.IntegerType.get(),
+                        _nullable=False,
+                    )
+                ]
+            ),
+            _representations=(
+                representations
+                if representations is not None
+                else [
+                    SQLRepresentationDTO(
+                        _dialect=Dialects.TRINO,
+                        _sql="SELECT id FROM test_table",
+                    )
+                ]
+            ),
+            _comment="comment",
+            _default_catalog="catalog",
+            _default_schema="schema",
+            _properties={"k1": "v1"},
+        )
+
+    def test_validate_and_serialize(self):
+        request = self._request()
+
+        request.validate()
+        json_str = request.to_json()
+
+        self.assertIn('"name": "test_view"', json_str)
+        self.assertIn('"columns"', json_str)
+        self.assertIn('"representations"', json_str)
+        self.assertIn(f'"type": "{Representation.TYPE_SQL}"', json_str)
+        self.assertIn(f'"dialect": "{Dialects.TRINO}"', json_str)
+        self.assertIn('"sql": "SELECT id FROM test_table"', json_str)
+        self.assertIn('"defaultCatalog": "catalog"', json_str)
+        self.assertIn('"defaultSchema": "schema"', json_str)
+
+    def test_validate_rejects_invalid_name(self):
+        request = self._request(name="")
+
+        with self.assertRaises(ValueError):
+            request.validate()
+
+    def test_validate_rejects_empty_representations(self):
+        request = self._request(representations=[])
+
+        with self.assertRaises(ValueError):
+            request.validate()
+
+    def test_validate_rejects_null_representation(self):
+        request = self._request(representations=[None])
+
+        with self.assertRaises(ValueError):
+            request.validate()
+
+    def test_validate_rejects_invalid_representation(self):
+        request = self._request(
+            representations=[SQLRepresentationDTO(_dialect="", _sql="SELECT 1")]
+        )
+
+        with self.assertRaises(ValueError):
+            request.validate()
+
+    def test_validate_rejects_null_column(self):
+        request = self._request(columns=[None])
+
+        with self.assertRaises(ValueError):
+            request.validate()
+
+    def test_validate_rejects_invalid_column(self):
+        request = self._request(
+            columns=[ColumnDTO(_name="", _data_type=Types.IntegerType.get())]
+        )
+
+        with self.assertRaises(ValueError):
+            request.validate()
+
+    def test_validate_rejects_duplicate_dialect(self):
+        request = self._request(
+            representations=[
+                SQLRepresentationDTO(_dialect=Dialects.TRINO, _sql="SELECT 1"),
+                SQLRepresentationDTO(_dialect=Dialects.TRINO, _sql="SELECT 2"),
+            ]
+        )
+
+        with self.assertRaises(ValueError):
+            request.validate()

--- a/clients/client-python/tests/unittests/dto/requests/test_view_update_request.py
+++ b/clients/client-python/tests/unittests/dto/requests/test_view_update_request.py
@@ -1,0 +1,164 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import unittest
+
+from gravitino.api.rel.dialects import Dialects
+from gravitino.api.rel.types.types import Types
+from gravitino.dto.rel.column_dto import ColumnDTO
+from gravitino.dto.rel.sql_representation_dto import SQLRepresentationDTO
+from gravitino.dto.requests.view_update_request import ViewUpdateRequest
+from gravitino.dto.requests.view_updates_request import ViewUpdatesRequest
+
+
+class TestViewUpdateRequest(unittest.TestCase):
+    @staticmethod
+    def _column() -> ColumnDTO:
+        return ColumnDTO(
+            _name="id",
+            _data_type=Types.IntegerType.get(),
+            _nullable=False,
+        )
+
+    @staticmethod
+    def _representation(
+        dialect: str = Dialects.TRINO, sql: str = "SELECT id FROM table"
+    ) -> SQLRepresentationDTO:
+        return SQLRepresentationDTO(_dialect=dialect, _sql=sql)
+
+    def test_rename_view_request(self):
+        request = ViewUpdateRequest.RenameViewRequest(_new_name="new_view")
+
+        request.validate()
+        self.assertIn('"@type": "rename"', request.to_json())
+        self.assertEqual("new_view", request.view_change().new_name())
+
+        with self.assertRaises(ValueError):
+            ViewUpdateRequest.RenameViewRequest(_new_name="").validate()
+
+    def test_set_view_property_request(self):
+        request = ViewUpdateRequest.SetViewPropertyRequest(
+            _property="key", _value="value"
+        )
+
+        request.validate()
+        self.assertIn('"@type": "setProperty"', request.to_json())
+        self.assertEqual("key", request.view_change().property())
+        self.assertEqual("value", request.view_change().value())
+
+        with self.assertRaises(ValueError):
+            ViewUpdateRequest.SetViewPropertyRequest(
+                _property="", _value="value"
+            ).validate()
+        with self.assertRaises(ValueError):
+            ViewUpdateRequest.SetViewPropertyRequest(
+                _property="key", _value=None
+            ).validate()
+
+    def test_remove_view_property_request(self):
+        request = ViewUpdateRequest.RemoveViewPropertyRequest(_property="key")
+
+        request.validate()
+        self.assertIn('"@type": "removeProperty"', request.to_json())
+        self.assertEqual("key", request.view_change().property())
+
+        with self.assertRaises(ValueError):
+            ViewUpdateRequest.RemoveViewPropertyRequest(_property="").validate()
+
+    def test_replace_view_request(self):
+        request = ViewUpdateRequest.ReplaceViewRequest(
+            _columns=[self._column()],
+            _representations=[self._representation()],
+            _default_catalog="catalog",
+            _default_schema="schema",
+            _comment="comment",
+        )
+
+        request.validate()
+        json_str = request.to_json()
+        change = request.view_change()
+
+        self.assertIn('"@type": "replaceView"', json_str)
+        self.assertIn('"representations"', json_str)
+        self.assertEqual("catalog", change.default_catalog())
+        self.assertEqual("schema", change.default_schema())
+        self.assertEqual("comment", change.comment())
+        self.assertEqual(1, len(change.columns()))
+        self.assertEqual(1, len(change.representations()))
+
+    def test_replace_view_request_defaults_empty_columns(self):
+        request = ViewUpdateRequest.ReplaceViewRequest(
+            _representations=[self._representation()]
+        )
+
+        request.validate()
+        self.assertEqual([], request.view_change().columns())
+
+    def test_replace_view_request_validate(self):
+        with self.assertRaises(ValueError):
+            ViewUpdateRequest.ReplaceViewRequest(_representations=[]).validate()
+        with self.assertRaises(ValueError):
+            ViewUpdateRequest.ReplaceViewRequest(_representations=[None]).validate()
+        with self.assertRaises(ValueError):
+            ViewUpdateRequest.ReplaceViewRequest(
+                _representations=[self._representation("", "SELECT 1")]
+            ).validate()
+        with self.assertRaises(ValueError):
+            ViewUpdateRequest.ReplaceViewRequest(
+                _columns=[None], _representations=[self._representation()]
+            ).validate()
+        with self.assertRaises(ValueError):
+            ViewUpdateRequest.ReplaceViewRequest(
+                _columns=[ColumnDTO(_name="", _data_type=Types.IntegerType.get())],
+                _representations=[self._representation()],
+            ).validate()
+        with self.assertRaises(ValueError):
+            ViewUpdateRequest.ReplaceViewRequest(
+                _representations=[
+                    self._representation(Dialects.TRINO, "SELECT 1"),
+                    self._representation(Dialects.TRINO, "SELECT 2"),
+                ]
+            ).validate()
+
+    def test_view_updates_request(self):
+        updates = ViewUpdatesRequest(
+            _updates=[
+                ViewUpdateRequest.RenameViewRequest(_new_name="new_view"),
+                ViewUpdateRequest.SetViewPropertyRequest(
+                    _property="key", _value="value"
+                ),
+            ]
+        )
+
+        updates.validate()
+        json_str = updates.to_json()
+
+        self.assertIn('"updates"', json_str)
+        self.assertIn('"@type": "rename"', json_str)
+        self.assertIn('"@type": "setProperty"', json_str)
+
+    def test_view_updates_request_validate(self):
+        with self.assertRaises(ValueError):
+            ViewUpdatesRequest(_updates=None).validate()
+        with self.assertRaises(ValueError):
+            ViewUpdatesRequest(_updates=[]).validate()
+        with self.assertRaises(ValueError):
+            ViewUpdatesRequest(_updates=[None]).validate()
+        with self.assertRaises(ValueError):
+            ViewUpdatesRequest(
+                _updates=[ViewUpdateRequest.RenameViewRequest(_new_name="")]
+            ).validate()

--- a/clients/client-python/tests/unittests/dto/responses/test_view_response.py
+++ b/clients/client-python/tests/unittests/dto/responses/test_view_response.py
@@ -1,0 +1,51 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import unittest
+
+from gravitino.api.rel.dialects import Dialects
+from gravitino.dto.audit_dto import AuditDTO
+from gravitino.dto.rel.sql_representation_dto import SQLRepresentationDTO
+from gravitino.dto.rel.view_dto import ViewDTO
+from gravitino.dto.responses.view_response import ViewResponse
+from gravitino.exceptions.base import IllegalArgumentException
+
+
+class TestViewResponse(unittest.TestCase):
+    @staticmethod
+    def _view_dto() -> ViewDTO:
+        return ViewDTO(
+            _name="test_view",
+            _representations=[
+                SQLRepresentationDTO(_dialect=Dialects.TRINO, _sql="SELECT 1")
+            ],
+            _audit=AuditDTO("creator"),
+        )
+
+    def test_view_response(self):
+        response = ViewResponse(_code=0, _view=self._view_dto())
+
+        response.validate()
+        deserialized = ViewResponse.from_json(response.to_json())
+
+        self.assertEqual("test_view", deserialized.view().name())
+        self.assertEqual("creator", deserialized.view().audit_info().creator())
+        self.assertEqual(1, len(deserialized.view().representations()))
+
+    def test_view_response_validate(self):
+        with self.assertRaises(IllegalArgumentException):
+            ViewResponse(_code=0, _view=None).validate()

--- a/clients/client-python/tests/unittests/dto/util/test_dto_converters.py
+++ b/clients/client-python/tests/unittests/dto/util/test_dto_converters.py
@@ -23,6 +23,7 @@ from typing import Dict, cast
 from unittest.mock import MagicMock, patch
 
 from gravitino.api.rel.column import Column
+from gravitino.api.rel.dialects import Dialects
 from gravitino.api.rel.expressions.distributions.distributions import Distributions
 from gravitino.api.rel.expressions.distributions.strategy import Strategy
 from gravitino.api.rel.expressions.expression import Expression
@@ -41,7 +42,9 @@ from gravitino.api.rel.indexes.indexes import Indexes
 from gravitino.api.rel.partitions.partition import Partition
 from gravitino.api.rel.partitions.partitions import Partitions
 from gravitino.api.rel.table import Table
+from gravitino.api.rel.sql_representation import SQLRepresentation
 from gravitino.api.rel.types.types import Types
+from gravitino.api.rel.view_change import ViewChange
 from gravitino.dto.rel.column_dto import ColumnDTO
 from gravitino.dto.rel.distribution_dto import DistributionDTO
 from gravitino.dto.rel.expressions.field_reference_dto import FieldReferenceDTO
@@ -71,7 +74,9 @@ from gravitino.dto.rel.partitions.identity_partition_dto import IdentityPartitio
 from gravitino.dto.rel.partitions.list_partition_dto import ListPartitionDTO
 from gravitino.dto.rel.partitions.range_partition_dto import RangePartitionDTO
 from gravitino.dto.rel.sort_order_dto import SortOrderDTO
+from gravitino.dto.rel.sql_representation_dto import SQLRepresentationDTO
 from gravitino.dto.rel.table_dto import TableDTO
+from gravitino.dto.requests.view_update_request import ViewUpdateRequest
 from gravitino.dto.util.dto_converters import DTOConverters
 from gravitino.exceptions.base import IllegalArgumentException
 
@@ -537,6 +542,20 @@ class TestDTOConverters(unittest.TestCase):
         converted = DTOConverters.from_dtos(sort_order_dtos)
         self.assertListEqual(converted, expected)
 
+    def test_from_dtos_representations(self):
+        representation_dtos = [
+            SQLRepresentationDTO(Dialects.TRINO, "SELECT 1"),
+            SQLRepresentationDTO(Dialects.SPARK, "SELECT 2"),
+        ]
+        expected = [
+            SQLRepresentation(Dialects.TRINO, "SELECT 1"),
+            SQLRepresentation(Dialects.SPARK, "SELECT 2"),
+        ]
+
+        converted = DTOConverters.from_dtos(representation_dtos)
+
+        self.assertListEqual(converted, expected)
+
     def test_from_dtos_partitioning(self):
         field_name = ["score"]
         field_names = [field_name]
@@ -667,6 +686,62 @@ class TestDTOConverters(unittest.TestCase):
     def test_to_dto_raise_exception(self):
         with self.assertRaisesRegex(IllegalArgumentException, "Unsupported type"):
             DTOConverters.to_dto("test")
+
+    def test_sql_representation_conversion(self):
+        representation = SQLRepresentation(Dialects.TRINO, "SELECT 1")
+
+        dto = DTOConverters.to_dto(representation)
+        converted = DTOConverters.from_dto(dto)
+
+        self.assertIsInstance(dto, SQLRepresentationDTO)
+        self.assertEqual(Dialects.TRINO, dto.dialect())
+        self.assertEqual("SELECT 1", dto.sql())
+        self.assertEqual(representation, converted)
+        self.assertEqual(dto, DTOConverters.to_dto(dto))
+
+    def test_to_view_update_request(self):
+        rename_request = DTOConverters.to_view_update_request(
+            ViewChange.rename("new_view")
+        )
+        set_property_request = DTOConverters.to_view_update_request(
+            ViewChange.set_property("key", "value")
+        )
+        remove_property_request = DTOConverters.to_view_update_request(
+            ViewChange.remove_property("key")
+        )
+        replace_view_request = DTOConverters.to_view_update_request(
+            ViewChange.replace_view(
+                [Column.of("id", Types.IntegerType.get())],
+                [SQLRepresentation(Dialects.TRINO, "SELECT id FROM table")],
+                "catalog",
+                "schema",
+                "comment",
+            )
+        )
+
+        self.assertIsInstance(rename_request, ViewUpdateRequest.RenameViewRequest)
+        self.assertEqual("new_view", rename_request.view_change().new_name())
+        self.assertIsInstance(
+            set_property_request, ViewUpdateRequest.SetViewPropertyRequest
+        )
+        self.assertEqual("key", set_property_request.view_change().property())
+        self.assertEqual("value", set_property_request.view_change().value())
+        self.assertIsInstance(
+            remove_property_request, ViewUpdateRequest.RemoveViewPropertyRequest
+        )
+        self.assertEqual("key", remove_property_request.view_change().property())
+        self.assertIsInstance(
+            replace_view_request, ViewUpdateRequest.ReplaceViewRequest
+        )
+        self.assertEqual(
+            "catalog", replace_view_request.view_change().default_catalog()
+        )
+        self.assertEqual("schema", replace_view_request.view_change().default_schema())
+        self.assertEqual("comment", replace_view_request.view_change().comment())
+
+    def test_to_view_update_request_unsupported_change(self):
+        with self.assertRaisesRegex(IllegalArgumentException, "Unknown change type"):
+            DTOConverters.to_view_update_request("invalid_change")
 
     def test_to_dto_range_partition(self):
         converted = DTOConverters.to_dto(
@@ -856,6 +931,21 @@ class TestDTOConverters(unittest.TestCase):
             self.assertEqual(converted.name(), expected.name())
             self.assertListEqual(converted.field_names(), expected.field_names())
 
+        self.assertListEqual(DTOConverters.to_dtos(converted_dtos), converted_dtos)
+
+    def test_to_dtos_representations(self):
+        representations = [
+            SQLRepresentation(Dialects.TRINO, "SELECT 1"),
+            SQLRepresentation(Dialects.SPARK, "SELECT 2"),
+        ]
+        expected_dtos = [
+            SQLRepresentationDTO(Dialects.TRINO, "SELECT 1"),
+            SQLRepresentationDTO(Dialects.SPARK, "SELECT 2"),
+        ]
+
+        converted_dtos = DTOConverters.to_dtos(representations)
+
+        self.assertListEqual(converted_dtos, expected_dtos)
         self.assertListEqual(DTOConverters.to_dtos(converted_dtos), converted_dtos)
 
     def test_to_dtos_single_field_transforms(self):

--- a/clients/client-python/tests/unittests/test_error_handler.py
+++ b/clients/client-python/tests/unittests/test_error_handler.py
@@ -43,6 +43,7 @@ from gravitino.exceptions.base import (
     NoSuchSchemaException,
     NoSuchTableException,
     NoSuchUserException,
+    NoSuchViewException,
     NotEmptyException,
     NotFoundException,
     NotInUseException,
@@ -53,6 +54,7 @@ from gravitino.exceptions.base import (
     TableAlreadyExistsException,
     UnsupportedOperationException,
     UserAlreadyExistsException,
+    ViewAlreadyExistsException,
     GroupAlreadyExistsException,
 )
 from gravitino.exceptions.handlers.catalog_error_handler import CATALOG_ERROR_HANDLER
@@ -73,6 +75,7 @@ from gravitino.exceptions.handlers.role_error_handler import ROLE_ERROR_HANDLER
 from gravitino.exceptions.handlers.schema_error_handler import SCHEMA_ERROR_HANDLER
 from gravitino.exceptions.handlers.table_error_handler import TABLE_ERROR_HANDLER
 from gravitino.exceptions.handlers.user_error_handler import USER_ERROR_HANDLER
+from gravitino.exceptions.handlers.view_error_handler import VIEW_ERROR_HANDLER
 
 
 class TestErrorHandler(unittest.TestCase):
@@ -432,6 +435,86 @@ class TestErrorHandler(unittest.TestCase):
 
         with self.assertRaises(RESTException):
             TABLE_ERROR_HANDLER.handle(
+                ErrorResponse.generate_error_response(Exception, "mock error")
+            )
+
+    def test_view_error_handler(self):
+        with self.assertRaises(IllegalArgumentException):
+            VIEW_ERROR_HANDLER.handle(
+                ErrorResponse.generate_error_response(
+                    IllegalArgumentException, "mock error"
+                )
+            )
+
+        with self.assertRaises(NoSuchCatalogException):
+            VIEW_ERROR_HANDLER.handle(
+                ErrorResponse.generate_error_response(
+                    NoSuchCatalogException, "mock error"
+                )
+            )
+
+        with self.assertRaises(NoSuchSchemaException):
+            VIEW_ERROR_HANDLER.handle(
+                ErrorResponse.generate_error_response(
+                    NoSuchSchemaException, "mock error"
+                )
+            )
+
+        with self.assertRaises(NoSuchViewException):
+            VIEW_ERROR_HANDLER.handle(
+                ErrorResponse.generate_error_response(NoSuchViewException, "mock error")
+            )
+
+        with self.assertRaises(NotFoundException):
+            VIEW_ERROR_HANDLER.handle(
+                ErrorResponse.generate_error_response(NotFoundException, "mock error")
+            )
+
+        with self.assertRaises(ViewAlreadyExistsException):
+            VIEW_ERROR_HANDLER.handle(
+                ErrorResponse.generate_error_response(
+                    ViewAlreadyExistsException, "mock error"
+                )
+            )
+
+        with self.assertRaises(RuntimeError):
+            VIEW_ERROR_HANDLER.handle(
+                ErrorResponse.generate_error_response(RuntimeError, "mock error")
+            )
+
+        with self.assertRaises(UnsupportedOperationException):
+            VIEW_ERROR_HANDLER.handle(
+                ErrorResponse.generate_error_response(
+                    UnsupportedOperationException, "mock error"
+                )
+            )
+
+        with self.assertRaises(ForbiddenException):
+            VIEW_ERROR_HANDLER.handle(
+                ErrorResponse.generate_error_response(ForbiddenException, "mock error")
+            )
+
+        with self.assertRaises(CatalogNotInUseException):
+            VIEW_ERROR_HANDLER.handle(
+                ErrorResponse.generate_error_response(
+                    CatalogNotInUseException, "mock error"
+                )
+            )
+
+        with self.assertRaises(MetalakeNotInUseException):
+            VIEW_ERROR_HANDLER.handle(
+                ErrorResponse.generate_error_response(
+                    MetalakeNotInUseException, "mock error"
+                )
+            )
+
+        with self.assertRaises(NotInUseException):
+            VIEW_ERROR_HANDLER.handle(
+                ErrorResponse.generate_error_response(NotInUseException, "mock error")
+            )
+
+        with self.assertRaises(RESTException):
+            VIEW_ERROR_HANDLER.handle(
                 ErrorResponse.generate_error_response(Exception, "mock error")
             )
 

--- a/clients/client-python/tests/unittests/test_generic_view.py
+++ b/clients/client-python/tests/unittests/test_generic_view.py
@@ -1,0 +1,82 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import unittest
+
+from gravitino.api.rel.dialects import Dialects
+from gravitino.client.generic_view import GenericView
+from gravitino.dto.audit_dto import AuditDTO
+from gravitino.dto.rel.sql_representation_dto import SQLRepresentationDTO
+from gravitino.dto.rel.view_dto import ViewDTO
+
+
+class TestGenericView(unittest.TestCase):
+    def _generic_view(
+        self,
+        name: str = "demo_view",
+        comment: str = "comment",
+        sql: str = "SELECT 1",
+        default_catalog: str = "demo_catalog",
+        default_schema: str = "demo_schema",
+    ) -> GenericView:
+        return GenericView(
+            ViewDTO(
+                _name=name,
+                _representations=[
+                    SQLRepresentationDTO(_dialect=Dialects.TRINO, _sql=sql)
+                ],
+                _comment=comment,
+                _default_catalog=default_catalog,
+                _default_schema=default_schema,
+                _properties={"key": "value"},
+                _audit=AuditDTO("creator"),
+            ),
+        )
+
+    def test_generic_view(self) -> None:
+        generic_view = self._generic_view()
+
+        self.assertEqual("demo_view", generic_view.name())
+        self.assertEqual("comment", generic_view.comment())
+        self.assertEqual("demo_catalog", generic_view.default_catalog())
+        self.assertEqual("demo_schema", generic_view.default_schema())
+        self.assertEqual({"key": "value"}, generic_view.properties())
+        self.assertEqual(0, len(generic_view.columns()))
+        self.assertEqual(1, len(generic_view.representations()))
+        self.assertEqual("SELECT 1", generic_view.sql_for(Dialects.TRINO).sql())
+        self.assertEqual("creator", generic_view.audit_info().creator())
+
+    def test_generic_view_equality(self) -> None:
+        generic_view1 = self._generic_view()
+        generic_view2 = self._generic_view()
+        generic_view_with_different_name = self._generic_view(name="another_view")
+        generic_view_with_different_comment = self._generic_view(comment="another")
+        generic_view_with_different_sql = self._generic_view(sql="SELECT 2")
+
+        self.assertEqual(generic_view1, generic_view2)
+        self.assertNotEqual(generic_view1, generic_view_with_different_name)
+        self.assertNotEqual(generic_view1, generic_view_with_different_comment)
+        self.assertNotEqual(generic_view1, generic_view_with_different_sql)
+        self.assertFalse(generic_view1 == "invalid_generic_view")
+
+    def test_generic_view_hash(self) -> None:
+        generic_view1 = self._generic_view()
+        generic_view2 = self._generic_view()
+        generic_view_with_different_name = self._generic_view(name="another_view")
+
+        self.assertEqual(hash(generic_view1), hash(generic_view2))
+        self.assertNotEqual(hash(generic_view1), hash(generic_view_with_different_name))

--- a/clients/client-python/tests/unittests/test_relational_catalog.py
+++ b/clients/client-python/tests/unittests/test_relational_catalog.py
@@ -20,19 +20,31 @@ from http.client import HTTPResponse
 from unittest.mock import Mock, patch
 
 from gravitino.api.authorization.privileges import Privilege
+from gravitino.api.rel.column import Column
+from gravitino.api.rel.dialects import Dialects
+from gravitino.api.rel.sql_representation import SQLRepresentation
 from gravitino.api.rel.table_change import TableChange
+from gravitino.api.rel.types.types import Types
+from gravitino.api.rel.view_change import ViewChange
 from gravitino.client.relational_catalog import RelationalCatalog
 from gravitino.dto.audit_dto import AuditDTO
+from gravitino.dto.rel.column_dto import ColumnDTO
 from gravitino.dto.rel.distribution_dto import DistributionDTO
+from gravitino.dto.rel.sql_representation_dto import SQLRepresentationDTO
 from gravitino.dto.rel.table_dto import TableDTO
+from gravitino.dto.rel.view_dto import ViewDTO
+from gravitino.dto.requests.view_updates_request import ViewUpdatesRequest
 from gravitino.dto.responses.drop_response import DropResponse
 from gravitino.dto.responses.entity_list_response import EntityListResponse
 from gravitino.dto.responses.table_response import TableResponse
+from gravitino.dto.responses.view_response import ViewResponse
 from gravitino.dto.util.dto_converters import DTOConverters
 from gravitino.exceptions.base import (
     NoSuchSchemaException,
     NoSuchTableException,
+    NoSuchViewException,
     TableAlreadyExistsException,
+    ViewAlreadyExistsException,
 )
 from gravitino.name_identifier import NameIdentifier
 from gravitino.namespace import Namespace
@@ -48,6 +60,8 @@ class TestRelationalCatalog(unittest.TestCase):
         cls.table_name = "test_table"
         cls.catalog_namespace = Namespace.of(cls.metalake_name)
         cls.table_identifier = NameIdentifier.of(cls.schema_name, cls.table_name)
+        cls.view_name = "test_view"
+        cls.view_identifier = NameIdentifier.of(cls.schema_name, cls.view_name)
         cls.rest_client = HTTPClient("http://localhost:8090")
         cls.catalog = RelationalCatalog(
             catalog_namespace=cls.catalog_namespace,
@@ -185,6 +199,30 @@ class TestRelationalCatalog(unittest.TestCase):
         }
         """
         cls.table_dto = TableDTO.from_json(cls.TABLE_DTO_JSON_STRING)
+        cls.view_dto = ViewDTO(
+            _name=cls.view_name,
+            _columns=[
+                ColumnDTO(
+                    _name="id",
+                    _data_type=Types.IntegerType.get(),
+                    _comment="id column",
+                    _nullable=False,
+                )
+            ],
+            _representations=[
+                SQLRepresentationDTO(
+                    _dialect=Dialects.TRINO,
+                    _sql="SELECT id FROM test_table",
+                )
+            ],
+            _comment="test view comment",
+            _default_catalog="test_catalog",
+            _default_schema="test_schema",
+            _properties={"k1": "v1"},
+            _audit=AuditDTO(
+                "creator", "2022-01-01T00:00:00Z", "modifier", "2022-01-01T00:00:00Z"
+            ),
+        )
 
     def _get_mock_http_resp(self, json_str: str, return_code: int = 200):
         mock_http_resp = Mock(HTTPResponse)
@@ -198,6 +236,10 @@ class TestRelationalCatalog(unittest.TestCase):
     def test_as_table_catalog(self):
         table_catalog = self.catalog.as_table_catalog()
         self.assertIs(table_catalog, self.catalog)
+
+    def test_as_view_catalog(self):
+        view_catalog = self.catalog.as_view_catalog()
+        self.assertIs(view_catalog, self.catalog)
 
     def test_create_table(self):
         resp_body = TableResponse(0, self.table_dto)
@@ -452,3 +494,186 @@ class TestRelationalCatalog(unittest.TestCase):
                 TableChange.update_column_nullability(["id"], nullable=True),
             )
             self.assertEqual(table.name(), self.table_dto.name())
+
+    def test_list_views(self):
+        view1 = NameIdentifier.of(
+            self.metalake_name, self.catalog_name, self.schema_name, "view1"
+        )
+        view2 = NameIdentifier.of(
+            self.metalake_name, self.catalog_name, self.schema_name, "view2"
+        )
+
+        resp_body = EntityListResponse(0, [view1, view2])
+        mock_resp = self._get_mock_http_resp(resp_body.to_json())
+
+        with patch(
+            "gravitino.utils.http_client.HTTPClient.get",
+            return_value=mock_resp,
+        ):
+            views = self.catalog.as_view_catalog().list_views(
+                Namespace.of(self.schema_name)
+            )
+            self.assertEqual(2, len(views))
+            self.assertEqual("view1", views[0].name())
+            self.assertEqual("view2", views[1].name())
+
+    def test_list_views_invalid_namespace(self):
+        with patch(
+            "gravitino.utils.http_client.HTTPClient.get",
+            side_effect=NoSuchSchemaException("Schema not found"),
+        ):
+            with self.assertRaises(NoSuchSchemaException):
+                self.catalog.as_view_catalog().list_views(
+                    Namespace.of("invalid_schema")
+                )
+
+    def test_load_view(self):
+        resp_body = ViewResponse(0, self.view_dto)
+        mock_resp = self._get_mock_http_resp(resp_body.to_json())
+
+        with patch(
+            "gravitino.utils.http_client.HTTPClient.get",
+            return_value=mock_resp,
+        ):
+            view = self.catalog.as_view_catalog().load_view(self.view_identifier)
+            self.assertEqual(self.view_name, view.name())
+            self.assertEqual("test view comment", view.comment())
+            self.assertEqual("test_catalog", view.default_catalog())
+            self.assertEqual("test_schema", view.default_schema())
+            self.assertEqual("v1", view.properties()["k1"])
+            self.assertEqual(
+                "SELECT id FROM test_table", view.sql_for(Dialects.TRINO).sql()
+            )
+
+    def test_load_view_not_exists(self):
+        with patch(
+            "gravitino.utils.http_client.HTTPClient.get",
+            side_effect=NoSuchViewException("View not found"),
+        ):
+            with self.assertRaises(NoSuchViewException):
+                self.catalog.as_view_catalog().load_view(self.view_identifier)
+
+    def test_create_view(self):
+        resp_body = ViewResponse(0, self.view_dto)
+        mock_resp = self._get_mock_http_resp(resp_body.to_json())
+
+        with patch(
+            "gravitino.utils.http_client.HTTPClient.post",
+            return_value=mock_resp,
+        ):
+            view = self.catalog.as_view_catalog().create_view(
+                self.view_identifier,
+                [Column.of("id", Types.IntegerType.get(), nullable=False)],
+                [SQLRepresentation(Dialects.TRINO, "SELECT id FROM test_table")],
+                comment="test view comment",
+                default_catalog="test_catalog",
+                default_schema="test_schema",
+                properties={"k1": "v1"},
+            )
+            self.assertEqual(self.view_name, view.name())
+            self.assertEqual("test view comment", view.comment())
+
+    def test_create_view_already_exists(self):
+        with patch(
+            "gravitino.utils.http_client.HTTPClient.post",
+            side_effect=ViewAlreadyExistsException("View already exists"),
+        ):
+            with self.assertRaises(ViewAlreadyExistsException):
+                self.catalog.as_view_catalog().create_view(
+                    self.view_identifier,
+                    [Column.of("id", Types.IntegerType.get())],
+                    [SQLRepresentation(Dialects.TRINO, "SELECT id FROM test_table")],
+                )
+
+    def test_alter_view(self):
+        updated_view_dto = ViewDTO(
+            _name="new_view",
+            _columns=[
+                ColumnDTO(
+                    _name="id",
+                    _data_type=Types.IntegerType.get(),
+                    _comment="id column",
+                    _nullable=False,
+                )
+            ],
+            _representations=[
+                SQLRepresentationDTO(
+                    _dialect=Dialects.TRINO,
+                    _sql="SELECT id FROM test_table",
+                )
+            ],
+            _comment="test view comment",
+            _default_catalog="test_catalog",
+            _default_schema="test_schema",
+            _properties={"k1": "v1"},
+            _audit=AuditDTO(
+                "creator", "2022-01-01T00:00:00Z", "modifier", "2022-01-01T00:00:00Z"
+            ),
+        )
+        resp_body = ViewResponse(0, updated_view_dto)
+        mock_resp = self._get_mock_http_resp(resp_body.to_json())
+
+        with patch(
+            "gravitino.utils.http_client.HTTPClient.put",
+            return_value=mock_resp,
+        ):
+            view = self.catalog.as_view_catalog().alter_view(
+                self.view_identifier,
+                ViewChange.rename("new_view"),
+            )
+            self.assertEqual("new_view", view.name())
+
+    def test_alter_view_not_exists(self):
+        with patch(
+            "gravitino.utils.http_client.HTTPClient.put",
+            side_effect=NoSuchViewException("View not found"),
+        ):
+            with self.assertRaises(NoSuchViewException):
+                self.catalog.as_view_catalog().alter_view(
+                    self.view_identifier,
+                    ViewChange.rename("new_view"),
+                )
+
+    def test_drop_view(self):
+        resp_body = DropResponse(0, True)
+        mock_resp = self._get_mock_http_resp(resp_body.to_json())
+
+        with patch(
+            "gravitino.utils.http_client.HTTPClient.delete",
+            return_value=mock_resp,
+        ):
+            is_dropped = self.catalog.as_view_catalog().drop_view(self.view_identifier)
+            self.assertTrue(is_dropped)
+
+    def test_drop_view_not_exists(self):
+        resp_body = DropResponse(0, False)
+        mock_resp = self._get_mock_http_resp(resp_body.to_json())
+
+        with patch(
+            "gravitino.utils.http_client.HTTPClient.delete",
+            return_value=mock_resp,
+        ):
+            is_dropped = self.catalog.as_view_catalog().drop_view(self.view_identifier)
+            self.assertFalse(is_dropped)
+
+    def test_view_updates_request_serialization(self):
+        rename_request = DTOConverters.to_view_update_request(
+            ViewChange.rename("new_view")
+        )
+        replace_request = DTOConverters.to_view_update_request(
+            ViewChange.replace_view(
+                [],
+                [SQLRepresentation(Dialects.TRINO, "SELECT 1")],
+                "test_catalog",
+                "test_schema",
+                "new comment",
+            )
+        )
+
+        request = ViewUpdatesRequest([rename_request, replace_request])
+        request.validate()
+        request_json = request.to_json()
+
+        self.assertIn('"updates"', request_json)
+        self.assertIn('"@type": "rename"', request_json)
+        self.assertIn('"@type": "replaceView"', request_json)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds view operation support to the Python client.

The main changes include:

- Add Python client view API abstractions, including `View`, `ViewCatalog`, `ViewChange`, `Representation`, and `SQLRepresentation`.
- Add view DTOs, requests, responses, and representation serialization/deserialization.
- Add relational catalog support for view operations:
  - `list_views`
  - `load_view`
  - `create_view`
  - `alter_view`
  - `drop_view`
- Add a default `view_exists` helper in `ViewCatalog`.
- Add view-specific error handling.
- Add unit tests and integration tests for Python client view operations.

### Why are the changes needed?

The Python client did not support Gravitino view operations before this PR. Users could not manage views through the Python client even though views are first-class metadata objects in Gravitino.

This also prepares the Python client for follow-up view-related capabilities, such as associating tags with views.

Fix: #11947

### Does this PR introduce _any_ user-facing change?

Yes.

Python client users can now manage views through `RelationalCatalog.as_view_catalog()`, including listing, loading, creating, altering, dropping, and checking view existence through the default `ViewCatalog.view_exists()` helper.

### How was this patch tested?

Added unit tests and integration tests for the new Python client view support.

Ran:

```bash
./gradlew :clients:client-python:black :clients:client-python:unitTests :clients:client-python:integrationTest
```

Results:

- `black`: passed
- `pylint`: passed, rated `10.00/10`
- `unitTests`: passed, `Ran 843 tests ... OK`
- `integrationTest`: passed, `Ran 471 tests ... OK (skipped=344)`
