### PR TITLE
[MINOR] fix(web-v2): Remove stale twc prefix from toast

### DIFF
--- a/web-v2/web/src/components/StyledToast.js
+++ b/web-v2/web/src/components/StyledToast.js
@@ -43,11 +43,11 @@ export default function StyledToast() {
             {({ icon, message }) => (
               <>
                 {icon}
-                <div className='twc-flex twc-w-full twc-break-normal [&>div]:twc-justify-start'>{message}</div>
-                <div className='twc-flex twc-h-full'>
+                <div className='flex w-full break-normal [&>div]:justify-start'>{message}</div>
+                <div className='flex h-full'>
                   {t.type !== 'loading' && (
                     <button
-                      className='twc-border-0 twc-text-[#666] twc-w-6 twc-h-6 twc-justify-start twc-rounded-full twc-ring-primary-400 twc-transition hover:twc-bg-[#f8f8f8] focus:twc-outline-none focus-visible:twc-ring'
+                      className='h-6 w-6 justify-start rounded-full border-0 text-[#666] ring-primary-400 transition hover:bg-[#f8f8f8] focus:outline-none focus-visible:ring'
                       onClick={() => toast.dismiss(t.id)}
                     >
                       x


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR removes the stale `twc-` Tailwind prefix from the web-v2 `StyledToast` component.

`web-v2` does not configure the `twc-` Tailwind prefix, while web-v1 does. The remaining `twc-*` classes in `StyledToast` are migrated to the unprefixed Tailwind classes used by web-v2.

### Why are the changes needed?

The `twc-*` classes in web-v2 do not match the current web-v2 Tailwind configuration, so those utility classes are not generated. This leaves the toast component with stale styling class names.

### Does this PR introduce _any_ user-facing change?

No.

The toast component keeps the same intended styling, but now uses valid web-v2 Tailwind class names.

### How was this patch tested?

Ran web-v2 lint, format check, and unit tests.
Verified that no `twc-` references remain in the web-v2 source or Tailwind config.
