### PR TITLE
[#11963] fix(cli): support parsing the variant column type

### DIFF
--- a/clients/cli/src/main/java/org/apache/gravitino/cli/TypeConverter.java
+++ b/clients/cli/src/main/java/org/apache/gravitino/cli/TypeConverter.java
@@ -76,6 +76,8 @@ public class TypeConverter {
         return Types.StringType.get();
       case "binary":
         return Types.BinaryType.get();
+      case "variant":
+        return Types.VariantType.get();
       default:
         throw new IllegalArgumentException("Unknown or unsupported type: " + typeName);
     }

--- a/clients/cli/src/test/java/org/apache/gravitino/cli/TestParseType.java
+++ b/clients/cli/src/test/java/org/apache/gravitino/cli/TestParseType.java
@@ -47,6 +47,12 @@ public class TestParseType {
   }
 
   @Test
+  public void testParseTypeVariant() {
+    Type type = ParseType.toType("variant");
+    assertThat(type, instanceOf(Types.VariantType.class));
+  }
+
+  @Test
   public void testParseTypeListValidInput() {
     Type type = ParseType.toType("list(integer)");
     assertThat(type, instanceOf(Types.ListType.class));

--- a/clients/cli/src/test/java/org/apache/gravitino/cli/TestTypeConverter.java
+++ b/clients/cli/src/test/java/org/apache/gravitino/cli/TestTypeConverter.java
@@ -50,6 +50,7 @@ public class TestTypeConverter {
     assertEquals(Types.UUIDType.get(), TypeConverter.convert("uuid"));
     assertEquals(Types.StringType.get(), TypeConverter.convert("string"));
     assertEquals(Types.BinaryType.get(), TypeConverter.convert("binary"));
+    assertEquals(Types.VariantType.get(), TypeConverter.convert("variant"));
   }
 
   @Test


### PR DESCRIPTION
### What changes were proposed in this pull request?

Adds a `variant` case to the CLI's `TypeConverter.convert(String)` so a user can specify a `variant` column from the terminal via the type string (e.g. `--datatype variant`). Previously this threw `IllegalArgumentException: Unknown or unsupported type: variant`, even though `Types.VariantType` exists in the type system.

- `TypeConverter.java`: map `"variant"` → `Types.VariantType.get()`.
- Added unit tests in `TestTypeConverter` and `TestParseType` covering both the direct converter and the full `ParseType.toType("variant")` entry point.

### Why are the changes needed?

The native `variant` type (#11932) was wired into the type system but not into the CLI's string→type parsing. As a result the CLI could not create or alter a column of type `variant`, leaving a gap in the "specify a column by typing its type string" flow. `variant` is a parameterless primitive, so parsing is lossless.

Fix: #11963

### Does this PR introduce _any_ user-facing change?

Yes. The CLI now accepts `variant` as a column datatype (case-insensitive), e.g.:

```
gravitino table create ... --columns col --datatype variant
```

### How was this patch tested?

Added and ran unit tests:

```
./gradlew :clients:cli:test --tests 'org.apache.gravitino.cli.TestTypeConverter' \
                            --tests 'org.apache.gravitino.cli.TestParseType' -PskipITs
```

Both pass. Tests assert `TypeConverter.convert("variant")` and `ParseType.toType("variant")` return `Types.VariantType`.