### PR TITLE
fix(authz): don't cache partial role policy when a securable object can't resolve

### DIFF
--- a/server-common/src/main/java/org/apache/gravitino/server/authorization/jcasbin/JcasbinAuthorizer.java
+++ b/server-common/src/main/java/org/apache/gravitino/server/authorization/jcasbin/JcasbinAuthorizer.java
@@ -1202,8 +1202,18 @@ public class JcasbinAuthorizer implements GravitinoAuthorizer {
       if (cachedUpdatedAt.isPresent()) {
         clearRolePolicies(roleId);
       }
-      loadPolicyByRoleEntity(roleEntity, requestContext);
-      loadedRoles.put(roleId, dbUpdatedAt);
+      boolean fullyResolved = loadPolicyByRoleEntity(roleEntity, requestContext);
+      if (fullyResolved) {
+        loadedRoles.put(roleId, dbUpdatedAt);
+      } else {
+        // At least one securable object could not be resolved to a metadata id (for example a
+        // transient catalog/entity lookup miss). Caching the role now would pin an incomplete
+        // policy at this version until the next TTL eviction, silently under-granting for the
+        // whole window. Drop the partial policy and leave the role uncached so the next
+        // authorization reloads it and self-heals once resolution recovers.
+        clearRolePolicies(roleId);
+        loadedRoles.invalidate(roleId);
+      }
     }
   }
 
@@ -1224,16 +1234,24 @@ public class JcasbinAuthorizer implements GravitinoAuthorizer {
   //  Policy loading from role entity
   // ---------------------------------------------------------------------------
 
-  private void loadPolicyByRoleEntity(
+  /**
+   * Loads the role's securable-object privileges into the enforcers. Returns {@code true} only when
+   * every securable object was resolved to a metadata id; {@code false} when at least one could not
+   * be resolved, so the caller can avoid caching an incomplete policy as fully loaded.
+   */
+  private boolean loadPolicyByRoleEntity(
       RoleEntity roleEntity, AuthorizationRequestContext requestContext) {
     String metalake = NameIdentifierUtil.getMetalake(roleEntity.nameIdentifier());
     List<SecurableObject> securableObjects = roleEntity.securableObjects();
 
+    boolean fullyResolved = true;
     for (SecurableObject securableObject : securableObjects) {
       Optional<Long> metadataId =
           lookups.resolveMetadataId(securableObject, metalake, requestContext);
-      // A role may still reference a metadata object that has since been dropped; skip it.
+      // The object may have been dropped, or its id lookup transiently failed. Either way skip it
+      // for now and report the load as incomplete so the role is not cached as fully loaded.
       if (!metadataId.isPresent()) {
+        fullyResolved = false;
         continue;
       }
       for (Privilege privilege : securableObject.privileges()) {
@@ -1259,5 +1277,6 @@ public class JcasbinAuthorizer implements GravitinoAuthorizer {
             condition.name().toLowerCase(Locale.ROOT));
       }
     }
+    return fullyResolved;
   }
 }

--- a/server-common/src/test/java/org/apache/gravitino/server/authorization/jcasbin/TestJcasbinAuthorizer.java
+++ b/server-common/src/test/java/org/apache/gravitino/server/authorization/jcasbin/TestJcasbinAuthorizer.java
@@ -1522,6 +1522,53 @@ public class TestJcasbinAuthorizer {
     assertFalse(loadedRoles.getIfPresent(testRoleId).isPresent());
   }
 
+  /**
+   * Reproduces the partial-policy-load stickiness bug. When a role's securable object transiently
+   * fails to resolve to a metadata id during a policy reload (e.g. right after the loadedRoles TTL
+   * evicts the role, while the catalog/entity resolution is momentarily unavailable), {@code
+   * loadPolicyByRoleEntity} silently {@code continue}s past that grant AND {@code
+   * versionCheckAndLoadRoles} still records the role in {@code loadedRoles} at the current version.
+   * The stale, privilege-less policy is then served on every subsequent request until the next
+   * eviction, so authorization does not self-heal once resolution recovers.
+   */
+  @Test
+  public void testTransientMetadataResolutionFailureDoesNotStickDenial() throws Exception {
+    makeCompletableFutureUseCurrentThread(jcasbinAuthorizer);
+    Principal currentPrincipal = PrincipalUtils.getCurrentPrincipal();
+
+    // Role grants USE_CATALOG on testCatalog; the user holds it directly.
+    RoleEntity allowRole =
+        mockRoleInStore(ALLOW_ROLE_ID, "allowRole", ImmutableList.of(getAllowSecurableObject()));
+    mockDirectUserRoles(allowRole);
+
+    // Baseline: the catalog id resolves, the policy loads, authorization succeeds.
+    assertTrue(doAuthorize(currentPrincipal), "baseline authorize should succeed");
+
+    // Simulate the TTL eviction that clears the role's policies + a metadataId cache eviction so
+    // the reload re-hits MetadataIdConverter.getID.
+    jcasbinAuthorizer.handleRolePrivilegeChange(ALLOW_ROLE_ID);
+    getMetadataIdCache(jcasbinAuthorizer).invalidateAll();
+
+    // Transient resolution failure on reload: getID returns empty for the securable object.
+    metadataIdConverterMockedStatic
+        .when(() -> MetadataIdConverter.getID(any(), eq(METALAKE)))
+        .thenReturn(Optional.empty());
+
+    // During the outage the grant cannot be evaluated -> denied (expected).
+    assertFalse(doAuthorize(currentPrincipal), "authorize denied while metadata id cannot resolve");
+
+    // Resolution recovers.
+    metadataIdConverterMockedStatic
+        .when(() -> MetadataIdConverter.getID(any(), eq(METALAKE)))
+        .thenReturn(Optional.of(CATALOG_ID));
+    getMetadataIdCache(jcasbinAuthorizer).invalidateAll();
+
+    // The role was cached as fully loaded during the outage with an empty policy and its version
+    // has not changed, so the reload is skipped and the denial sticks. It should self-heal.
+    assertTrue(
+        doAuthorize(currentPrincipal), "authorize should recover once metadata id resolves again");
+  }
+
   @Test
   public void testOwnerCacheInvalidation() throws Exception {
     // Get the ownerRel cache via reflection


### PR DESCRIPTION
### What changes were proposed in this pull request?

`JcasbinAuthorizer.loadPolicyByRoleEntity` skips a securable object whose metadata id cannot be resolved (`resolveMetadataId` returns empty) via `continue`, but `versionCheckAndLoadRoles` still records the role in `loadedRoles` at the current version. As a result, if the id lookup for a securable object *transiently* fails during a policy reload — for example right after the `loadedRoles` TTL evicts the role while the catalog/entity resolution is momentarily unavailable — an **incomplete (under-granting) policy is cached as "fully loaded"** and served on every subsequent request until the next cache eviction (`GRAVITINO_AUTHORIZATION_CACHE_EXPIRATION_SECS`, default 3600s). Authorization does **not** self-heal once resolution recovers.

This change makes `loadPolicyByRoleEntity` report whether **every** securable object resolved. The caller only marks the role loaded on a complete load; on an incomplete load it drops the partial policy and leaves the role uncached, so the next authorization reloads it and self-heals.

Note on trade-off: a role that references a *permanently* dropped metadata object will now reload each request until its securable objects are cleaned up. If maintainers prefer, `resolveMetadataId` could distinguish "object genuinely absent" (skip permanently) from "transient lookup failure" (retry) — happy to follow up.

### Why are the changes needed?

Fine-grained authorization can silently and persistently under-grant. A single transient metadata-id resolution miss during a role-policy reload poisons the cache for the full expiration window (default 1 hour), so a user/role that legitimately holds a grant is denied even though the grant and the target object both exist. The symptom is characteristic: authorization works immediately after a server restart (fresh policy load), then flips to `Forbidden` about one cache-TTL later and stays stuck until the next eviction.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Added `TestJcasbinAuthorizer.testTransientMetadataResolutionFailureDoesNotStickDenial`, which drives the real `JcasbinAuthorizer`: baseline authorize succeeds; the role is evicted and `MetadataIdConverter.getID` is stubbed to return empty for one reload (transient outage), yielding a deny; resolution then recovers. Before the fix the denial sticks (`expected: <true> but was: <false>`); after the fix authorization self-heals. The full `TestJcasbinAuthorizer` suite passes.
