### PR TITLE
[#11985] fix(openapi): drop stray OpenAPI 3.1 null token from statistics value

### DIFF
--- a/docs/open-api/statistics.yaml
+++ b/docs/open-api/statistics.yaml
@@ -445,8 +445,10 @@ components:
               items: { }
             - type: object
               additionalProperties: { }
-            - type: "null"
-          description: The value of the statistic
+          description: >-
+            The statistic's value, present only when the statistic has one. Its
+            type depends on the statistic — a string, number, integer, boolean,
+            array, or object.
         reserved:
           type: boolean
           description: Whether the statistic is reserved


### PR DESCRIPTION
### What changes were proposed in this pull request?

Removes the `type: "null"` branch from `Statistic.value`'s `oneOf` in `docs/open-api/statistics.yaml` and gives the field a more useful description.

### Why are the changes needed?

`type: "null"` is JSON Schema / OpenAPI **3.1** syntax. The document declares `openapi: 3.0.3`, where it is invalid — Redocly `recommended-strict` reports it as a `struct` error, the single hard structural error in the spec.

`value` is already optional: `StatisticDTO` holds it as an `@Nullable` `Optional<StatisticValue<?>>` and it is not in the schema's `required` list, so "no value" is expressed by the field's absence. The null branch is therefore unnecessary, and dropping it keeps a clean typed `oneOf` for codegen.

This is genuinely a 3.0.3 document with one stray 3.1 token, so it is fixed in place. Expressing a union-of-types-plus-null natively would require upgrading to 3.1, which removes the `nullable` keyword and would mean migrating ~130 `nullable` usages plus verifying tooling — a separate discussion, out of scope here.

Part of #11985

### Does this PR introduce _any_ user-facing change?

No. Spec/docs-only. `Statistic.value` remains optional and typed; no REST API, schema, or property-key changes.

### How was this patch tested?

`cd dev/openapi && npx redocly lint --extends=recommended-strict` — the `statistics.yaml` finding is cleared (total errors 10 → 9) with no new findings introduced.
