### PR TITLE
[#11985] fix(openapi): repair three codegen-breaking defects invisible to lint

### DIFF
--- a/docs/open-api/filesets.yaml
+++ b/docs/open-api/filesets.yaml
@@ -231,7 +231,6 @@ paths:
           required: false
           schema:
             type: string
-            default: null
           description: The name of the storage location
       responses:
         "200":

--- a/docs/open-api/models.yaml
+++ b/docs/open-api/models.yaml
@@ -385,7 +385,6 @@ paths:
           required: false
           schema:
             type: string
-            default: null
           description: The uri name of the model version
       responses:
         "200":
@@ -423,7 +422,6 @@ paths:
           required: false
           schema:
             type: string
-            default: null
           description: The uri name of the model version
       responses:
         "200":
@@ -889,6 +887,7 @@ components:
           type: array
           description: The list of model versions
           items:
+            type: integer
             format: int32
 
     ModelVersionInfoListResponse:

--- a/docs/open-api/tables.yaml
+++ b/docs/open-api/tables.yaml
@@ -348,11 +348,9 @@ components:
         type: string
 
     ColumnDefaultValue:
-      $ref: "./expression.yaml#/components/schemas/FunctionArg"
+      allOf:
+        - $ref: "./expression.yaml#/components/schemas/FunctionArg"
       description: The default value of the column
-      required: false
-      nullable: true
-      default: null
 
     Column:
       type: object


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fixes three defects in the OpenAPI spec that a linter cannot see but a typed code generator chokes on. Each is a different OpenAPI 3.0 pitfall:

1. **`default: null` on optional string query params** — `models.yaml` `uriName` (×2) and `filesets.yaml` `location_name`. `null` is not a valid default for a `type: string` schema, and the params are already `required: false`, so the default is meaningless. → removed.
2. **`$ref` sibling keywords silently ignored** — `tables.yaml` `ColumnDefaultValue` declared `nullable`, `description`, `required`, and `default: null` *next to* a `$ref`. In OpenAPI 3.0 everything beside a `$ref` is dropped, so none of it ever applied. → wrapped the `$ref` in `allOf` so the `description` actually attaches; dropped the ignored/invalid keywords.
3. **Bare `format` without `type`** — `models.yaml` model `versions` used `items: { format: int32 }` with no `type`, leaving a generator nothing to infer. → added `type: integer`.

### Why are the changes needed?

The value of shipping an OpenAPI spec is that a generator can turn it into a typed client with zero friction. These three defects break that: `progenitor`/`typify` (Rust) — the strictest common consumer — fail on an invalid `default`, an untyped `format`, and (for `ColumnDefaultValue`) a nullability annotation that never took effect.

Critically, **all three pass `redocly lint --extends=recommended-strict`** — the error count is unchanged by this PR (10 → 10 against `main`). They are exactly the class of problem a linter cannot catch and only a codegen pass surfaces, which is why the spec-validation pipeline adds a `progenitor` codegen smoke test.

Part of #11985

### Does this PR introduce _any_ user-facing change?

No behavioral change. Spec/docs-only:
- The three query params remain optional; only a meaningless `null` default is removed.
- `ColumnDefaultValue` is unchanged on the wire (its `$ref` siblings were already ignored); it now correctly carries its description.
- Model `versions` items are now typed as `integer` (they already were integers).

No REST API, schema, or property-key changes.

### How was this patch tested?

- `redocly lint --extends=recommended-strict` — error count unchanged (10 → 10), confirming no regression and that these defects are invisible to the linter.
- `redocly bundle` — the fixed spec bundles to valid `openapi.json`.
- Confirmed zero `default: null` remain across `docs/open-api/`.
