### PR TITLE
[#11985] fix(openapi): clear the remaining non-lineage recommended-strict findings

### DIFF
--- a/docs/open-api/datatype.yaml
+++ b/docs/open-api/datatype.yaml
@@ -30,37 +30,15 @@ components:
 
     PrimitiveType:
       type: string
-      example:
-        - "boolean"
-        - "byte"
-        - "byte unsigned"
-        - "short"
-        - "short unsigned"
-        - "integer"
-        - "integer unsigned"
-        - "long"
-        - "long unsigned"
-        - "float"
-        - "double"
-        - "decimal(10,2)"
-        - "date"
-        - "time(3)"
-        - "timestamp(3)"
-        - "timestamp_tz(3)"
-        - "string"
-        - "char(10)"
-        - "varchar(10)"
-        - "interval_day"
-        - "interval_year"
-        - "uuid"
-        - "fixed(16)"
-        - "binary"
-        - "variant"
-        - "null"
-        - "geometry"
-        - "geometry(srid:3857)"
-        - "geography"
-        - "geography(EPSG:4326,karney)"
+      description: >-
+        The string name of a primitive type. Simple names: boolean, byte,
+        byte unsigned, short, short unsigned, integer, integer unsigned, long,
+        long unsigned, float, double, date, string, binary, uuid, interval_day,
+        interval_year, variant, null, geometry, geography. Parameterized names:
+        decimal(precision,scale), time(precision), timestamp(precision),
+        timestamp_tz(precision), char(length), varchar(length), fixed(length),
+        geometry(srid), geography(crs,algorithm).
+      example: "integer"
 
     UnionType:
       type: object
@@ -202,9 +180,7 @@ components:
           description: The unparsed type
       example: {
         "type": "unparsed",
-        "unparsedType": [
-          "unknown-type"
-        ]
+        "unparsedType": "unknown-type"
       }
 
   ExternalType:

--- a/docs/open-api/openapi.yaml
+++ b/docs/open-api/openapi.yaml
@@ -46,6 +46,7 @@ servers:
 security:
   - OAuth2WithJWT: [serviceAudience]
   - BasicAuth: []
+  - KerberosAuth: []
 
 paths:
   /health:

--- a/docs/open-api/policies.yaml
+++ b/docs/open-api/policies.yaml
@@ -635,6 +635,7 @@ components:
         "@type": "updateContent",
         "policyType": "custom",
         "newContent": {
+          "policyType": "custom",
           "customRules": {
             "rule1": 456
           },

--- a/docs/open-api/tables.yaml
+++ b/docs/open-api/tables.yaml
@@ -524,10 +524,9 @@ components:
           description: The comment of the column to add
           nullable: true
         position:
-          $ref: "#/components/schemas/ColumnPosition"
+          allOf:
+            - $ref: "#/components/schemas/ColumnPosition"
           description: The position of the column to add
-          nullable: true
-          default: "default"
         nullable:
           type: boolean
           description: Whether the column to add is nullable
@@ -539,9 +538,9 @@ components:
           nullable: true
           default: false
         defaultValue:
-          $ref: "#/components/schemas/ColumnDefaultValue"
+          allOf:
+            - $ref: "#/components/schemas/ColumnDefaultValue"
           description: The default value of the column to add
-          nullable: true
       example: {
         "@type": "addColumn",
         "fieldName": [ "new_column" ],


### PR DESCRIPTION
### What changes were proposed in this pull request?

Clears the five remaining **non-lineage** Redocly `recommended-strict` findings. Each is a spec-correctness fix where the described contract didn't match its own schema — **documentation/spec only, no wire or behavior change.**

| # | Schema (file) | Lint error | Fix | Validation |
|---|---|---|---|---|
| 1 | `PrimitiveType` (`datatype.yaml`) | schema is `type: string` but `example` was a YAML **array** of type names → example doesn't match type | Replaced the array with a single valid `example: "integer"`; moved the type enumeration into `description` | finding at `datatype.yaml:34` cleared |
| 2 | `UnparsedType` (`datatype.yaml`) | `unparsedType` is `type: string` but the example gave an **array** `["unknown-type"]` | `"unparsedType": "unknown-type"` | `datatype.yaml:205` cleared |
| 3 | `UpdatePolicyContentRequest` (`policies.yaml`) | `newContent` example missing the required `policyType` discriminator → example fails its schema | Added `"policyType": "custom"` | `policies.yaml:637` cleared |
| 4 | `AddTableColumnRequest` (`tables.yaml`) | `position`/`defaultValue` placed `nullable`/`default` as **siblings of a `$ref`** (OAS 3.0 ignores keywords beside a `$ref`; the stray `nullable` with no `type` breaks example validation) | Wrapped each `$ref` in `allOf` so `description` attaches; dropped the ignored keywords | `tables.yaml:506` cleared |
| 5 | `KerberosAuth` (`openapi.yaml`) | security scheme defined but never referenced (`no-unused-components`) | Added it to the global `security` requirement (Kerberos is a supported authenticator) rather than deleting it | `openapi.yaml:636` cleared |

### Why are the changes needed?

The OpenAPI description is the contract downstream, non-Java consumers rely on (SDK generators, connectors, mock servers). These five findings are invalid examples / schema mistakes that make examples fail to render or validate and can break typed codegen. Clearing them leaves the `recommended-strict` count at **4 — all of which are the lineage findings**, handled separately in #11989. That puts the linter one step from enforcing (the pipeline in #11986).

### Does this PR introduce _any_ user-facing change?

No. No REST API, schema shape, or property-key changes. Rendered API-doc examples become valid, and `KerberosAuth` becomes a documented auth option (it was already a supported authenticator).

### How was this patch tested?

Ran Redocly strict lint (`@redocly/cli` 2.x) against the bundled spec, before and after, on this branch rebased on `main`:

```
redocly lint docs/open-api/openapi.yaml --extends=recommended-strict
```

- **Before (current `main`): 9 errors** — the 5 addressed here + 4 lineage.
- **After (this branch): 4 errors** — all in `lineage.yaml` (`RunEvent` / `DatasetEvent` / `JobEvent`), out of scope here and tracked in #11989.

All 5 targeted findings are confirmed cleared, with no new findings introduced. The branch is rebased on `main` and merges cleanly.

Part of #11985
