### PR TITLE
[#11985] fix(openapi): restore the ExternalType variant to DataType

### DIFF
--- a/docs/open-api/datatype.yaml
+++ b/docs/open-api/datatype.yaml
@@ -27,6 +27,7 @@ components:
         - $ref: "#/components/schemas/MapType"
         - $ref: "#/components/schemas/UnionType"
         - $ref: "#/components/schemas/UnparsedType"
+        - $ref: "#/components/schemas/ExternalType"
 
     PrimitiveType:
       type: string
@@ -207,20 +208,20 @@ components:
         ]
       }
 
-  ExternalType:
-    type: object
-    required:
-      - type
-      - catalogString
-    properties:
-      type:
-        type: string
-        enum:
-          - "external"
-      catalogString:
-        type: string
-        description: The string representation of this type in the catalog
-    example: {
-      "type": "external",
-      "catalogString": "user-defined"
-    }
+    ExternalType:
+      type: object
+      required:
+        - type
+        - catalogString
+      properties:
+        type:
+          type: string
+          enum:
+            - "external"
+        catalogString:
+          type: string
+          description: The string representation of this type in the catalog
+      example: {
+        "type": "external",
+        "catalogString": "user-defined"
+      }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Restores `ExternalType` to the OpenAPI `DataType` union:

- adds `ExternalType` to `DataType.oneOf`;
- moves `ExternalType` under `components.schemas`.

### Why are the changes needed?

Gravitino can return `{"type":"external","catalogString":"..."}` for column types originating from external catalogs. The schema was misnested and missing from `DataType`, so generated clients could not model or deserialize this valid response.

Part of #11985.

### Does this PR introduce any user-facing change?

The OpenAPI contract now describes a response the server could already return. There is no server behavior change.

### How was this patch tested?

- `./gradlew :docs:build` passes.
- The complete specification bundles successfully with Redocly; assertions confirm `ExternalType` is a schema and a `DataType` variant.
- OpenAPI Generator 7.23.0 successfully generates the full `typescript-fetch` client; the generated `DataType` union and decoder include `ExternalType`.
- Progenitor A/B test using the bundled `DataType` graph:
  - `main` rejects an external-type response because its generated union lacks the variant;
  - this PR deserializes the same response and preserves `catalogString`.
- The generated Rust crate passes `cargo check`; the consumer test passes.

Full-spec Progenitor generation remains blocked earlier by an unrelated vendor media-type limitation tracked by #11985.