### PR TITLE
[#3767] refactor(client-python): Share metalake operation test fixtures

### DIFF
--- a/clients/client-python/tests/unittests/client/operation_test_fixtures.py
+++ b/clients/client-python/tests/unittests/client/operation_test_fixtures.py
@@ -1,0 +1,89 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from unittest.mock import patch
+
+from gravitino.client.gravitino_client import GravitinoClient
+from gravitino.dto.audit_dto import AuditDTO
+from gravitino.dto.authorization.group_dto import GroupDTO
+from gravitino.dto.authorization.role_dto import RoleDTO
+from gravitino.dto.authorization.user_dto import UserDTO
+from tests.unittests import mock_base
+
+
+def build_default_audit() -> AuditDTO:
+    return mock_base.build_audit_info()
+
+
+def build_admin_audit() -> AuditDTO:
+    return AuditDTO(_creator="admin", _create_time="2024-01-01T00:00:00Z")
+
+
+def build_user_dto(
+    name: str = "alice",
+    roles: list | None = None,
+    audit: AuditDTO | None = None,
+) -> UserDTO:
+    return (
+        UserDTO.builder()
+        .with_name(name)
+        .with_roles(roles if roles is not None else [])
+        .with_audit(audit or build_default_audit())
+        .build()
+    )
+
+
+def build_group_dto(
+    name: str = "engineers",
+    roles: list | None = None,
+    audit: AuditDTO | None = None,
+) -> GroupDTO:
+    return (
+        GroupDTO.builder()
+        .with_name(name)
+        .with_roles(roles if roles is not None else [])
+        .with_audit(audit or build_default_audit())
+        .build()
+    )
+
+
+def build_role_dto(
+    name: str = "admin_role",
+    props: dict | None = None,
+    sec_objs: list | None = None,
+    audit: AuditDTO | None = None,
+) -> RoleDTO:
+    return (
+        RoleDTO.builder()
+        .with_name(name)
+        .with_properties(props)
+        .with_securable_objects(sec_objs or [])
+        .with_audit(audit or build_admin_audit())
+        .build()
+    )
+
+
+def make_gravitino_client() -> GravitinoClient:
+    return GravitinoClient.__new__(GravitinoClient)
+
+
+def mock_get_metalake():
+    return patch.object(
+        GravitinoClient,
+        "get_metalake",
+        return_value=mock_base.mock_load_metalake(),
+    )

--- a/clients/client-python/tests/unittests/client/test_metalake_group_operations.py
+++ b/clients/client-python/tests/unittests/client/test_metalake_group_operations.py
@@ -18,8 +18,6 @@
 import unittest
 from unittest.mock import patch
 
-from gravitino.client.gravitino_client import GravitinoClient
-from gravitino.dto.authorization.group_dto import GroupDTO
 from gravitino.dto.requests.group_add_request import GroupAddRequest
 from gravitino.dto.responses.remove_response import RemoveResponse
 from gravitino.dto.responses.group_response import (
@@ -35,16 +33,11 @@ from gravitino.exceptions.base import (
 )
 from gravitino.exceptions.handlers.group_error_handler import GROUP_ERROR_HANDLER
 from tests.unittests import mock_base
-
-
-def _build_group_dto(name: str = "engineers", roles: list | None = None) -> GroupDTO:
-    return (
-        GroupDTO.builder()
-        .with_name(name)
-        .with_roles(roles if roles is not None else [])
-        .with_audit(mock_base.build_audit_info())
-        .build()
-    )
+from tests.unittests.client.operation_test_fixtures import (
+    build_group_dto,
+    make_gravitino_client,
+    mock_get_metalake,
+)
 
 
 class TestMetalakeGroupOperations(unittest.TestCase):
@@ -53,7 +46,7 @@ class TestMetalakeGroupOperations(unittest.TestCase):
 
     def test_add_group(self):
         metalake = mock_base.mock_load_metalake()
-        group = _build_group_dto()
+        group = build_group_dto()
         mock_resp = mock_base.mock_http_response(GroupResponse(0, group).to_json())
 
         with patch(
@@ -87,7 +80,7 @@ class TestMetalakeGroupOperations(unittest.TestCase):
 
     def test_get_group(self):
         metalake = mock_base.mock_load_metalake()
-        group = _build_group_dto(roles=["role_a", "role_b"])
+        group = build_group_dto(roles=["role_a", "role_b"])
         mock_resp = mock_base.mock_http_response(GroupResponse(0, group).to_json())
 
         with patch(
@@ -139,7 +132,7 @@ class TestMetalakeGroupOperations(unittest.TestCase):
 
     def test_list_groups(self):
         metalake = mock_base.mock_load_metalake()
-        groups = [_build_group_dto("alice"), _build_group_dto("bob")]
+        groups = [build_group_dto("alice"), build_group_dto("bob")]
         mock_resp = mock_base.mock_http_response(GroupListResponse(0, groups).to_json())
 
         with patch(
@@ -185,20 +178,12 @@ class TestMetalakeGroupOperations(unittest.TestCase):
 class TestGravitinoClientGroupDelegates(unittest.TestCase):
     """Verify that GravitinoClient correctly delegates Group operations."""
 
-    def _make_client(self):
-        client = GravitinoClient.__new__(GravitinoClient)
-        return client
-
     def test_client_add_group(self):
-        client = self._make_client()
-        group = _build_group_dto()
+        client = make_gravitino_client()
+        group = build_group_dto()
         mock_resp = mock_base.mock_http_response(GroupResponse(0, group).to_json())
         with (
-            patch.object(
-                GravitinoClient,
-                "get_metalake",
-                return_value=mock_base.mock_load_metalake(),
-            ),
+            mock_get_metalake(),
             patch(
                 "gravitino.utils.http_client.HTTPClient.post", return_value=mock_resp
             ),
@@ -207,29 +192,21 @@ class TestGravitinoClientGroupDelegates(unittest.TestCase):
             self.assertEqual("engineers", result.name())
 
     def test_client_get_group(self):
-        client = self._make_client()
-        group = _build_group_dto(roles=["r1"])
+        client = make_gravitino_client()
+        group = build_group_dto(roles=["r1"])
         mock_resp = mock_base.mock_http_response(GroupResponse(0, group).to_json())
         with (
-            patch.object(
-                GravitinoClient,
-                "get_metalake",
-                return_value=mock_base.mock_load_metalake(),
-            ),
+            mock_get_metalake(),
             patch("gravitino.utils.http_client.HTTPClient.get", return_value=mock_resp),
         ):
             result = client.get_group("engineers")
             self.assertEqual(["r1"], result.roles())
 
     def test_client_remove_group(self):
-        client = self._make_client()
+        client = make_gravitino_client()
         mock_resp = mock_base.mock_http_response(RemoveResponse(0, True).to_json())
         with (
-            patch.object(
-                GravitinoClient,
-                "get_metalake",
-                return_value=mock_base.mock_load_metalake(),
-            ),
+            mock_get_metalake(),
             patch(
                 "gravitino.utils.http_client.HTTPClient.delete", return_value=mock_resp
             ),
@@ -237,31 +214,23 @@ class TestGravitinoClientGroupDelegates(unittest.TestCase):
             self.assertTrue(client.remove_group("engineers"))
 
     def test_client_list_groups(self):
-        client = self._make_client()
-        groups = [_build_group_dto("alice"), _build_group_dto("bob")]
+        client = make_gravitino_client()
+        groups = [build_group_dto("alice"), build_group_dto("bob")]
         mock_resp = mock_base.mock_http_response(GroupListResponse(0, groups).to_json())
         with (
-            patch.object(
-                GravitinoClient,
-                "get_metalake",
-                return_value=mock_base.mock_load_metalake(),
-            ),
+            mock_get_metalake(),
             patch("gravitino.utils.http_client.HTTPClient.get", return_value=mock_resp),
         ):
             result = client.list_groups()
             self.assertEqual(["alice", "bob"], [u.name() for u in result])
 
     def test_client_list_group_names(self):
-        client = self._make_client()
+        client = make_gravitino_client()
         mock_resp = mock_base.mock_http_response(
             GroupNamesListResponse(0, ["alice", "bob"]).to_json()
         )
         with (
-            patch.object(
-                GravitinoClient,
-                "get_metalake",
-                return_value=mock_base.mock_load_metalake(),
-            ),
+            mock_get_metalake(),
             patch("gravitino.utils.http_client.HTTPClient.get", return_value=mock_resp),
         ):
             result = client.list_group_names()

--- a/clients/client-python/tests/unittests/client/test_metalake_role_operations.py
+++ b/clients/client-python/tests/unittests/client/test_metalake_role_operations.py
@@ -21,13 +21,8 @@ from unittest.mock import patch
 from gravitino.api.authorization.privileges import Privilege
 from gravitino.api.authorization.securable_objects import SecurableObjects
 from gravitino.api.metadata_object import MetadataObject
-from gravitino.client.gravitino_client import GravitinoClient
-from gravitino.dto.audit_dto import AuditDTO
-from gravitino.dto.authorization.group_dto import GroupDTO
 from gravitino.dto.authorization.privilege_dto import PrivilegeDTO
-from gravitino.dto.authorization.role_dto import RoleDTO
 from gravitino.dto.authorization.securable_object_dto import SecurableObjectDTO
-from gravitino.dto.authorization.user_dto import UserDTO
 from gravitino.dto.requests.role_create_request import RoleCreateRequest
 from gravitino.dto.requests.role_grant_request import RoleGrantRequest
 from gravitino.dto.requests.role_revoke_request import RoleRevokeRequest
@@ -49,45 +44,13 @@ from gravitino.exceptions.handlers.permission_error_handler import (
 )
 from gravitino.exceptions.handlers.role_error_handler import ROLE_ERROR_HANDLER
 from tests.unittests import mock_base
-
-
-def _audit() -> AuditDTO:
-    return AuditDTO(_creator="admin", _create_time="2024-01-01T00:00:00Z")
-
-
-def _build_role_dto(
-    name: str = "admin_role",
-    props: dict | None = None,
-    sec_objs: list | None = None,
-) -> RoleDTO:
-    return (
-        RoleDTO.builder()
-        .with_name(name)
-        .with_properties(props)
-        .with_securable_objects(sec_objs or [])
-        .with_audit(_audit())
-        .build()
-    )
-
-
-def _build_user_dto(name: str = "alice", roles: list | None = None) -> UserDTO:
-    return (
-        UserDTO.builder()
-        .with_name(name)
-        .with_roles(roles or [])
-        .with_audit(_audit())
-        .build()
-    )
-
-
-def _build_group_dto(name: str = "engineers", roles: list | None = None) -> GroupDTO:
-    return (
-        GroupDTO.builder()
-        .with_name(name)
-        .with_roles(roles if roles is not None else [])
-        .with_audit(_audit())
-        .build()
-    )
+from tests.unittests.client.operation_test_fixtures import (
+    build_group_dto,
+    build_role_dto,
+    build_user_dto,
+    make_gravitino_client,
+    mock_get_metalake,
+)
 
 
 class TestMetalakeRoleOperations(unittest.TestCase):
@@ -117,7 +80,7 @@ class TestMetalakeRoleOperations(unittest.TestCase):
                 [PrivilegeDTO(Privilege.Name.USE_CATALOG, Privilege.Condition.ALLOW)],
             )
         ]
-        role = _build_role_dto(sec_objs=sec_objs)
+        role = build_role_dto(sec_objs=sec_objs)
         mock_resp = mock_base.mock_http_response(RoleResponse(0, role).to_json())
 
         with patch(
@@ -164,7 +127,7 @@ class TestMetalakeRoleOperations(unittest.TestCase):
 
     def test_get_role(self):
         metalake = mock_base.mock_load_metalake()
-        role = _build_role_dto(props={"k": "v"})
+        role = build_role_dto(props={"k": "v"})
         mock_resp = mock_base.mock_http_response(RoleResponse(0, role).to_json())
 
         with patch(
@@ -237,7 +200,7 @@ class TestMetalakeRoleOperations(unittest.TestCase):
 
     def test_grant_roles_to_user(self):
         metalake = mock_base.mock_load_metalake()
-        user = _build_user_dto(roles=["admin_role"])
+        user = build_user_dto(roles=["admin_role"])
         mock_resp = mock_base.mock_http_response(UserResponse(0, user).to_json())
 
         with patch(
@@ -260,7 +223,7 @@ class TestMetalakeRoleOperations(unittest.TestCase):
 
     def test_revoke_roles_from_user(self):
         metalake = mock_base.mock_load_metalake()
-        user = _build_user_dto(roles=[])
+        user = build_user_dto(roles=[])
         mock_resp = mock_base.mock_http_response(UserResponse(0, user).to_json())
 
         with patch(
@@ -282,7 +245,7 @@ class TestMetalakeRoleOperations(unittest.TestCase):
 
     def test_grant_roles_to_group(self):
         metalake = mock_base.mock_load_metalake()
-        group = _build_group_dto(roles=["admin_role"])
+        group = build_group_dto(roles=["admin_role"])
         mock_resp = mock_base.mock_http_response(GroupResponse(0, group).to_json())
 
         with patch(
@@ -304,7 +267,7 @@ class TestMetalakeRoleOperations(unittest.TestCase):
 
     def test_revoke_roles_from_group(self):
         metalake = mock_base.mock_load_metalake()
-        group = _build_group_dto(roles=[])
+        group = build_group_dto(roles=[])
         mock_resp = mock_base.mock_http_response(GroupResponse(0, group).to_json())
 
         with patch(
@@ -333,7 +296,7 @@ class TestMetalakeRoleOperations(unittest.TestCase):
                 PrivilegeDTO(Privilege.Name.CREATE_SCHEMA, Privilege.Condition.ALLOW),
             ],
         )
-        role = _build_role_dto(sec_objs=[sec_obj])
+        role = build_role_dto(sec_objs=[sec_obj])
         mock_resp = mock_base.mock_http_response(RoleResponse(0, role).to_json())
 
         with patch(
@@ -365,7 +328,7 @@ class TestMetalakeRoleOperations(unittest.TestCase):
 
     def test_revoke_privileges_from_role(self):
         metalake = mock_base.mock_load_metalake()
-        role = _build_role_dto(sec_objs=[])
+        role = build_role_dto(sec_objs=[])
         mock_resp = mock_base.mock_http_response(RoleResponse(0, role).to_json())
 
         with patch(
@@ -396,20 +359,12 @@ class TestMetalakeRoleOperations(unittest.TestCase):
 class TestGravitinoClientRoleDelegates(unittest.TestCase):
     """Verify that GravitinoClient correctly delegates Role operations."""
 
-    def _make_client(self):
-        client = GravitinoClient.__new__(GravitinoClient)
-        return client
-
     def test_client_create_role(self):
-        client = self._make_client()
-        role = _build_role_dto()
+        client = make_gravitino_client()
+        role = build_role_dto()
         mock_resp = mock_base.mock_http_response(RoleResponse(0, role).to_json())
         with (
-            patch.object(
-                GravitinoClient,
-                "get_metalake",
-                return_value=mock_base.mock_load_metalake(),
-            ),
+            mock_get_metalake(),
             patch(
                 "gravitino.utils.http_client.HTTPClient.post",
                 return_value=mock_resp,
@@ -419,15 +374,11 @@ class TestGravitinoClientRoleDelegates(unittest.TestCase):
             self.assertEqual("admin_role", result.name())
 
     def test_client_get_role(self):
-        client = self._make_client()
-        role = _build_role_dto(props={"k": "v"})
+        client = make_gravitino_client()
+        role = build_role_dto(props={"k": "v"})
         mock_resp = mock_base.mock_http_response(RoleResponse(0, role).to_json())
         with (
-            patch.object(
-                GravitinoClient,
-                "get_metalake",
-                return_value=mock_base.mock_load_metalake(),
-            ),
+            mock_get_metalake(),
             patch(
                 "gravitino.utils.http_client.HTTPClient.get",
                 return_value=mock_resp,
@@ -437,14 +388,10 @@ class TestGravitinoClientRoleDelegates(unittest.TestCase):
             self.assertEqual({"k": "v"}, result.properties())
 
     def test_client_delete_role(self):
-        client = self._make_client()
+        client = make_gravitino_client()
         mock_resp = mock_base.mock_http_response(DropResponse(0, True).to_json())
         with (
-            patch.object(
-                GravitinoClient,
-                "get_metalake",
-                return_value=mock_base.mock_load_metalake(),
-            ),
+            mock_get_metalake(),
             patch(
                 "gravitino.utils.http_client.HTTPClient.delete",
                 return_value=mock_resp,
@@ -453,16 +400,12 @@ class TestGravitinoClientRoleDelegates(unittest.TestCase):
             self.assertTrue(client.delete_role("admin_role"))
 
     def test_client_list_role_names(self):
-        client = self._make_client()
+        client = make_gravitino_client()
         mock_resp = mock_base.mock_http_response(
             RoleNamesListResponse(0, ["role1", "role2"]).to_json()
         )
         with (
-            patch.object(
-                GravitinoClient,
-                "get_metalake",
-                return_value=mock_base.mock_load_metalake(),
-            ),
+            mock_get_metalake(),
             patch(
                 "gravitino.utils.http_client.HTTPClient.get",
                 return_value=mock_resp,
@@ -472,15 +415,11 @@ class TestGravitinoClientRoleDelegates(unittest.TestCase):
             self.assertEqual(["role1", "role2"], result)
 
     def test_client_grant_roles_to_user(self):
-        client = self._make_client()
-        user = _build_user_dto(roles=["admin_role"])
+        client = make_gravitino_client()
+        user = build_user_dto(roles=["admin_role"])
         mock_resp = mock_base.mock_http_response(UserResponse(0, user).to_json())
         with (
-            patch.object(
-                GravitinoClient,
-                "get_metalake",
-                return_value=mock_base.mock_load_metalake(),
-            ),
+            mock_get_metalake(),
             patch(
                 "gravitino.utils.http_client.HTTPClient.put",
                 return_value=mock_resp,
@@ -490,15 +429,11 @@ class TestGravitinoClientRoleDelegates(unittest.TestCase):
             self.assertEqual(["admin_role"], result.roles())
 
     def test_client_revoke_roles_from_user(self):
-        client = self._make_client()
-        user = _build_user_dto(roles=[])
+        client = make_gravitino_client()
+        user = build_user_dto(roles=[])
         mock_resp = mock_base.mock_http_response(UserResponse(0, user).to_json())
         with (
-            patch.object(
-                GravitinoClient,
-                "get_metalake",
-                return_value=mock_base.mock_load_metalake(),
-            ),
+            mock_get_metalake(),
             patch(
                 "gravitino.utils.http_client.HTTPClient.put",
                 return_value=mock_resp,
@@ -508,15 +443,11 @@ class TestGravitinoClientRoleDelegates(unittest.TestCase):
             self.assertEqual([], result.roles())
 
     def test_client_grant_roles_to_group(self):
-        client = self._make_client()
-        group = _build_group_dto(roles=["admin_role"])
+        client = make_gravitino_client()
+        group = build_group_dto(roles=["admin_role"])
         mock_resp = mock_base.mock_http_response(GroupResponse(0, group).to_json())
         with (
-            patch.object(
-                GravitinoClient,
-                "get_metalake",
-                return_value=mock_base.mock_load_metalake(),
-            ),
+            mock_get_metalake(),
             patch(
                 "gravitino.utils.http_client.HTTPClient.put",
                 return_value=mock_resp,
@@ -526,15 +457,11 @@ class TestGravitinoClientRoleDelegates(unittest.TestCase):
             self.assertEqual(["admin_role"], result.roles())
 
     def test_client_revoke_roles_from_group(self):
-        client = self._make_client()
-        group = _build_group_dto(roles=[])
+        client = make_gravitino_client()
+        group = build_group_dto(roles=[])
         mock_resp = mock_base.mock_http_response(GroupResponse(0, group).to_json())
         with (
-            patch.object(
-                GravitinoClient,
-                "get_metalake",
-                return_value=mock_base.mock_load_metalake(),
-            ),
+            mock_get_metalake(),
             patch(
                 "gravitino.utils.http_client.HTTPClient.put",
                 return_value=mock_resp,
@@ -544,15 +471,11 @@ class TestGravitinoClientRoleDelegates(unittest.TestCase):
             self.assertEqual([], result.roles())
 
     def test_client_grant_privileges_to_role(self):
-        client = self._make_client()
-        role = _build_role_dto()
+        client = make_gravitino_client()
+        role = build_role_dto()
         mock_resp = mock_base.mock_http_response(RoleResponse(0, role).to_json())
         with (
-            patch.object(
-                GravitinoClient,
-                "get_metalake",
-                return_value=mock_base.mock_load_metalake(),
-            ),
+            mock_get_metalake(),
             patch(
                 "gravitino.utils.http_client.HTTPClient.put",
                 return_value=mock_resp,
@@ -570,15 +493,11 @@ class TestGravitinoClientRoleDelegates(unittest.TestCase):
             self.assertEqual("admin_role", result.name())
 
     def test_client_revoke_privileges_from_role(self):
-        client = self._make_client()
-        role = _build_role_dto()
+        client = make_gravitino_client()
+        role = build_role_dto()
         mock_resp = mock_base.mock_http_response(RoleResponse(0, role).to_json())
         with (
-            patch.object(
-                GravitinoClient,
-                "get_metalake",
-                return_value=mock_base.mock_load_metalake(),
-            ),
+            mock_get_metalake(),
             patch(
                 "gravitino.utils.http_client.HTTPClient.put",
                 return_value=mock_resp,

--- a/clients/client-python/tests/unittests/client/test_metalake_user_operations.py
+++ b/clients/client-python/tests/unittests/client/test_metalake_user_operations.py
@@ -18,8 +18,6 @@
 import unittest
 from unittest.mock import patch
 
-from gravitino.client.gravitino_client import GravitinoClient
-from gravitino.dto.authorization.user_dto import UserDTO
 from gravitino.dto.requests.user_add_request import UserAddRequest
 from gravitino.dto.responses.remove_response import RemoveResponse
 from gravitino.dto.responses.user_response import (
@@ -35,16 +33,11 @@ from gravitino.exceptions.base import (
 )
 from gravitino.exceptions.handlers.user_error_handler import USER_ERROR_HANDLER
 from tests.unittests import mock_base
-
-
-def _build_user_dto(name: str = "alice", roles: list | None = None) -> UserDTO:
-    return (
-        UserDTO.builder()
-        .with_name(name)
-        .with_roles(roles if roles is not None else [])
-        .with_audit(mock_base.build_audit_info())
-        .build()
-    )
+from tests.unittests.client.operation_test_fixtures import (
+    build_user_dto,
+    make_gravitino_client,
+    mock_get_metalake,
+)
 
 
 class TestMetalakeUserOperations(unittest.TestCase):
@@ -53,7 +46,7 @@ class TestMetalakeUserOperations(unittest.TestCase):
 
     def test_add_user(self):
         metalake = mock_base.mock_load_metalake()
-        user = _build_user_dto()
+        user = build_user_dto()
         mock_resp = mock_base.mock_http_response(UserResponse(0, user).to_json())
 
         with patch(
@@ -87,7 +80,7 @@ class TestMetalakeUserOperations(unittest.TestCase):
 
     def test_get_user(self):
         metalake = mock_base.mock_load_metalake()
-        user = _build_user_dto(roles=["role_a", "role_b"])
+        user = build_user_dto(roles=["role_a", "role_b"])
         mock_resp = mock_base.mock_http_response(UserResponse(0, user).to_json())
 
         with patch(
@@ -139,7 +132,7 @@ class TestMetalakeUserOperations(unittest.TestCase):
 
     def test_list_users(self):
         metalake = mock_base.mock_load_metalake()
-        users = [_build_user_dto("alice"), _build_user_dto("bob")]
+        users = [build_user_dto("alice"), build_user_dto("bob")]
         mock_resp = mock_base.mock_http_response(UserListResponse(0, users).to_json())
 
         with patch(
@@ -185,20 +178,12 @@ class TestMetalakeUserOperations(unittest.TestCase):
 class TestGravitinoClientUserDelegates(unittest.TestCase):
     """Verify that GravitinoClient correctly delegates User operations."""
 
-    def _make_client(self):
-        client = GravitinoClient.__new__(GravitinoClient)
-        return client
-
     def test_client_add_user(self):
-        client = self._make_client()
-        user = _build_user_dto()
+        client = make_gravitino_client()
+        user = build_user_dto()
         mock_resp = mock_base.mock_http_response(UserResponse(0, user).to_json())
         with (
-            patch.object(
-                GravitinoClient,
-                "get_metalake",
-                return_value=mock_base.mock_load_metalake(),
-            ),
+            mock_get_metalake(),
             patch(
                 "gravitino.utils.http_client.HTTPClient.post", return_value=mock_resp
             ),
@@ -207,29 +192,21 @@ class TestGravitinoClientUserDelegates(unittest.TestCase):
             self.assertEqual("alice", result.name())
 
     def test_client_get_user(self):
-        client = self._make_client()
-        user = _build_user_dto(roles=["r1"])
+        client = make_gravitino_client()
+        user = build_user_dto(roles=["r1"])
         mock_resp = mock_base.mock_http_response(UserResponse(0, user).to_json())
         with (
-            patch.object(
-                GravitinoClient,
-                "get_metalake",
-                return_value=mock_base.mock_load_metalake(),
-            ),
+            mock_get_metalake(),
             patch("gravitino.utils.http_client.HTTPClient.get", return_value=mock_resp),
         ):
             result = client.get_user("alice")
             self.assertEqual(["r1"], result.roles())
 
     def test_client_remove_user(self):
-        client = self._make_client()
+        client = make_gravitino_client()
         mock_resp = mock_base.mock_http_response(RemoveResponse(0, True).to_json())
         with (
-            patch.object(
-                GravitinoClient,
-                "get_metalake",
-                return_value=mock_base.mock_load_metalake(),
-            ),
+            mock_get_metalake(),
             patch(
                 "gravitino.utils.http_client.HTTPClient.delete", return_value=mock_resp
             ),
@@ -237,31 +214,23 @@ class TestGravitinoClientUserDelegates(unittest.TestCase):
             self.assertTrue(client.remove_user("alice"))
 
     def test_client_list_users(self):
-        client = self._make_client()
-        users = [_build_user_dto("alice"), _build_user_dto("bob")]
+        client = make_gravitino_client()
+        users = [build_user_dto("alice"), build_user_dto("bob")]
         mock_resp = mock_base.mock_http_response(UserListResponse(0, users).to_json())
         with (
-            patch.object(
-                GravitinoClient,
-                "get_metalake",
-                return_value=mock_base.mock_load_metalake(),
-            ),
+            mock_get_metalake(),
             patch("gravitino.utils.http_client.HTTPClient.get", return_value=mock_resp),
         ):
             result = client.list_users()
             self.assertEqual(["alice", "bob"], [u.name() for u in result])
 
     def test_client_list_user_names(self):
-        client = self._make_client()
+        client = make_gravitino_client()
         mock_resp = mock_base.mock_http_response(
             UserNamesListResponse(0, ["alice", "bob"]).to_json()
         )
         with (
-            patch.object(
-                GravitinoClient,
-                "get_metalake",
-                return_value=mock_base.mock_load_metalake(),
-            ),
+            mock_get_metalake(),
             patch("gravitino.utils.http_client.HTTPClient.get", return_value=mock_resp),
         ):
             result = client.list_user_names()


### PR DESCRIPTION
### What changes were proposed in this pull request?

- Add shared Python client unit test fixtures for metalake operation tests.
- Move repeated user, group, and role DTO builders into `operation_test_fixtures.py`.
- Share the `GravitinoClient` test instance creation and `get_metalake` mock setup across user, group, and role delegate tests.
- Update metalake user/group/role unit tests to reuse the shared helpers instead of duplicating setup code.

### Why are the changes needed?

The metalake user, group, and role operation unit tests duplicated similar DTO construction and client mock setup code. This contributes to the Python client's duplicate-code pylint cleanup work and makes the tests harder to keep consistent.

Centralizing these fixtures reduces repeated test boilerplate while keeping the tested behavior unchanged.

Related to #3767.

### Does this PR introduce *any* user-facing change?

No.

### How was this patch tested?

- `PYTHONPATH=. /private/tmp/gravitino-client-python-test-venv/bin/python -m unittest tests.unittests.client.test_metalake_user_operations tests.unittests.client.test_metalake_group_operations tests.unittests.client.test_metalake_role_operations`
  - Result: `Ran 54 tests`, `OK`
- `PYTHONPATH=. PYLINTHOME=/private/tmp/gravitino-pylint-cache /private/tmp/gravitino-client-python-test-venv/bin/pylint --rcfile=pylintrc --persistent=n tests/unittests/client/operation_test_fixtures.py tests/unittests/client/test_metalake_user_operations.py tests/unittests/client/test_metalake_group_operations.py tests/unittests/client/test_metalake_role_operations.py`
  - Result: `10.00/10`
- `git diff --check`