### PR TITLE
[#3767] refactor(client-python): Share metalake integration test setup

### DIFF
--- a/clients/client-python/tests/integration/integration_test_env.py
+++ b/clients/client-python/tests/integration/integration_test_env.py
@@ -25,7 +25,7 @@ import shutil
 
 import requests
 
-from gravitino import GravitinoAdminClient
+from gravitino import GravitinoAdminClient, GravitinoClient
 from gravitino.exceptions.base import GravitinoRuntimeException
 from tests.integration.config import Config
 
@@ -149,6 +149,40 @@ class IntegrationTestEnv(unittest.TestCase):
         if gravitino_server_running:
             logger.error("Can't stop Gravitino server!")
 
+    @staticmethod
+    def create_gravitino_client(metalake_name: str) -> GravitinoClient:
+        return GravitinoClient(uri="http://localhost:8090", metalake_name=metalake_name)
+
+    @classmethod
+    def create_metalake_client(
+        cls,
+        admin_client: GravitinoAdminClient,
+        metalake_name: str,
+        comment: str = "",
+    ) -> GravitinoClient:
+        admin_client.create_metalake(metalake_name, comment=comment, properties={})
+        return cls.create_gravitino_client(metalake_name)
+
+    @staticmethod
+    def drop_test_metalake(
+        admin_client: GravitinoAdminClient, metalake_name: str, log_prefix: str = ""
+    ):
+        try:
+            dropped = admin_client.drop_metalake(metalake_name, force=True)
+            if log_prefix:
+                logger.info(
+                    "%s: drop metalake %s[%s]", log_prefix, metalake_name, dropped
+                )
+            else:
+                logger.info("Drop metalake %s[%s]", metalake_name, dropped)
+        except GravitinoRuntimeException:
+            if log_prefix:
+                logger.warning(
+                    "%s: failed to drop metalake %s", log_prefix, metalake_name
+                )
+            else:
+                logger.warning("Failed to drop metalake %s", metalake_name)
+
     @classmethod
     def restart_server(cls):
         logger.info("Restarting Gravitino server...")
@@ -239,3 +273,26 @@ class IntegrationTestEnv(unittest.TestCase):
         with open(conf_path, mode="w", encoding="utf-8") as file:
             for line in filtered_lines:
                 file.write(line)
+
+
+class MetalakeTestMixin:
+    """Provide common metalake setup and cleanup for integration tests."""
+
+    def setUp(self):  # pylint: disable=invalid-name
+        super().setUp()
+        self.init_test_env()
+
+    def tearDown(self):  # pylint: disable=invalid-name
+        try:
+            self.clean_test_data()
+        finally:
+            super().tearDown()
+
+    def init_test_env(self):
+        self.gravitino_client = self.create_metalake_client(
+            self.gravitino_admin_client, self.metalake_name
+        )
+
+    def clean_test_data(self):
+        self.gravitino_client = self.create_gravitino_client(self.metalake_name)
+        self.drop_test_metalake(self.gravitino_admin_client, self.metalake_name)

--- a/clients/client-python/tests/integration/test_catalog.py
+++ b/clients/client-python/tests/integration/test_catalog.py
@@ -31,12 +31,12 @@ from gravitino.exceptions.base import (
     NoSuchCatalogException,
 )
 
-from tests.integration.integration_test_env import IntegrationTestEnv
+from tests.integration.integration_test_env import IntegrationTestEnv, MetalakeTestMixin
 
 logger = logging.getLogger(__name__)
 
 
-class TestCatalog(IntegrationTestEnv):
+class TestCatalog(MetalakeTestMixin, IntegrationTestEnv):
     metalake_name: str = "TestSchema_metalake" + str(randint(1, 10000))
 
     catalog_name: str = "testCatalog" + str(randint(1, 10000))
@@ -53,20 +53,6 @@ class TestCatalog(IntegrationTestEnv):
     )
     gravitino_client: GravitinoClient = None
 
-    def setUp(self):
-        self.init_test_env()
-
-    def tearDown(self):
-        self.clean_test_data()
-
-    def init_test_env(self):
-        self.gravitino_admin_client.create_metalake(
-            self.metalake_name, comment="", properties={}
-        )
-        self.gravitino_client = GravitinoClient(
-            uri="http://localhost:8090", metalake_name=self.metalake_name
-        )
-
     def create_catalog(self, catalog_name) -> Catalog:
         return self.gravitino_client.create_catalog(
             name=catalog_name,
@@ -77,9 +63,7 @@ class TestCatalog(IntegrationTestEnv):
         )
 
     def clean_test_data(self):
-        self.gravitino_client = GravitinoClient(
-            uri="http://localhost:8090", metalake_name=self.metalake_name
-        )
+        self.gravitino_client = self.create_gravitino_client(self.metalake_name)
         try:
             logger.info(
                 "TestCatalog: drop catalog %s[%s]",
@@ -89,18 +73,9 @@ class TestCatalog(IntegrationTestEnv):
         except GravitinoRuntimeException:
             logger.warning("TestCatalog: failed to drop catalog %s", self.catalog_name)
 
-        try:
-            logger.info(
-                "TestCatalog: drop metalake %s[%s]",
-                self.metalake_name,
-                self.gravitino_admin_client.drop_metalake(
-                    self.metalake_name, force=True
-                ),
-            )
-        except GravitinoRuntimeException:
-            logger.warning(
-                "TestCatalog: failed to drop metalake %s", self.metalake_name
-            )
+        self.drop_test_metalake(
+            self.gravitino_admin_client, self.metalake_name, "TestCatalog"
+        )
 
         self.catalog_name = self.catalog_name_bak
 

--- a/clients/client-python/tests/integration/test_owner.py
+++ b/clients/client-python/tests/integration/test_owner.py
@@ -33,12 +33,12 @@ from gravitino.exceptions.base import (
     NotFoundException,
 )
 
-from tests.integration.integration_test_env import IntegrationTestEnv
+from tests.integration.integration_test_env import IntegrationTestEnv, MetalakeTestMixin
 
 logger = logging.getLogger(__name__)
 
 
-class TestOwner(IntegrationTestEnv):
+class TestOwner(MetalakeTestMixin, IntegrationTestEnv):
     metalake_name: str = "test_owner_metalake" + str(randint(1, 10000))
     catalog_name: str = "test_owner_catalog" + str(randint(1, 10000))
     test_user: str = "test_owner_user"
@@ -73,20 +73,6 @@ class TestOwner(IntegrationTestEnv):
         else:
             super().tearDownClass()
 
-    def setUp(self):
-        self.init_test_env()
-
-    def tearDown(self):
-        self.clean_test_data()
-
-    def init_test_env(self):
-        self.gravitino_admin_client.create_metalake(
-            self.metalake_name, comment="", properties={}
-        )
-        self.gravitino_client = GravitinoClient(
-            uri="http://localhost:8090", metalake_name=self.metalake_name
-        )
-
     def create_catalog(self, catalog_name) -> Catalog:
         return self.gravitino_client.create_catalog(
             name=catalog_name,
@@ -97,18 +83,13 @@ class TestOwner(IntegrationTestEnv):
         )
 
     def clean_test_data(self):
-        self.gravitino_client = GravitinoClient(
-            uri="http://localhost:8090", metalake_name=self.metalake_name
-        )
+        self.gravitino_client = self.create_gravitino_client(self.metalake_name)
         try:
             self.gravitino_client.drop_catalog(name=self.catalog_name, force=True)
         except GravitinoRuntimeException:
             logger.warning("Failed to drop catalog %s", self.catalog_name)
 
-        try:
-            self.gravitino_admin_client.drop_metalake(self.metalake_name, force=True)
-        except GravitinoRuntimeException:
-            logger.warning("Failed to drop metalake %s", self.metalake_name)
+        self.drop_test_metalake(self.gravitino_admin_client, self.metalake_name)
 
     def test_get_owner_metalake(self):
         metalake_obj = MetadataObjects.of(

--- a/clients/client-python/tests/integration/test_schema.py
+++ b/clients/client-python/tests/integration/test_schema.py
@@ -33,12 +33,12 @@ from gravitino.exceptions.base import (
     SchemaAlreadyExistsException,
 )
 
-from tests.integration.integration_test_env import IntegrationTestEnv
+from tests.integration.integration_test_env import IntegrationTestEnv, MetalakeTestMixin
 
 logger = logging.getLogger(__name__)
 
 
-class TestSchema(IntegrationTestEnv):
+class TestSchema(MetalakeTestMixin, IntegrationTestEnv):
     metalake_name: str = "TestSchema_metalake" + str(randint(1, 10000))
 
     catalog_name: str = "testCatalog"
@@ -71,19 +71,8 @@ class TestSchema(IntegrationTestEnv):
     )
     gravitino_client: GravitinoClient = None
 
-    def setUp(self):
-        self.init_test_env()
-
-    def tearDown(self):
-        self.clean_test_data()
-
     def init_test_env(self):
-        self.gravitino_admin_client.create_metalake(
-            self.metalake_name, comment="", properties={}
-        )
-        self.gravitino_client = GravitinoClient(
-            uri="http://localhost:8090", metalake_name=self.metalake_name
-        )
+        super().init_test_env()
         self.gravitino_client.create_catalog(
             name=self.catalog_name,
             catalog_type=Catalog.Type.FILESET,
@@ -93,9 +82,7 @@ class TestSchema(IntegrationTestEnv):
         )
 
     def clean_test_data(self):
-        self.gravitino_client = GravitinoClient(
-            uri="http://localhost:8090", metalake_name=self.metalake_name
-        )
+        self.gravitino_client = self.create_gravitino_client(self.metalake_name)
         catalog = self.gravitino_client.load_catalog(name=self.catalog_name)
         try:
             logger.info(
@@ -124,16 +111,7 @@ class TestSchema(IntegrationTestEnv):
         except GravitinoRuntimeException:
             logger.warning("Failed to drop catalog %s", self.catalog_name)
 
-        try:
-            logger.info(
-                "Drop metalake %s[%s]",
-                self.metalake_name,
-                self.gravitino_admin_client.drop_metalake(
-                    self.metalake_name, force=True
-                ),
-            )
-        except GravitinoRuntimeException:
-            logger.warning("Failed to drop metalake %s", self.metalake_name)
+        self.drop_test_metalake(self.gravitino_admin_client, self.metalake_name)
 
     def create_schema(self) -> Schema:
         catalog = self.gravitino_client.load_catalog(name=self.catalog_name)

--- a/clients/client-python/tests/integration/test_user.py
+++ b/clients/client-python/tests/integration/test_user.py
@@ -15,23 +15,19 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import logging
 import os
 from random import randint
 
 from gravitino import GravitinoAdminClient, GravitinoClient
 from gravitino.exceptions.base import (
-    GravitinoRuntimeException,
     NoSuchUserException,
     UserAlreadyExistsException,
 )
 
-from tests.integration.integration_test_env import IntegrationTestEnv
-
-logger = logging.getLogger(__name__)
+from tests.integration.integration_test_env import IntegrationTestEnv, MetalakeTestMixin
 
 
-class TestUser(IntegrationTestEnv):
+class TestUser(MetalakeTestMixin, IntegrationTestEnv):
     metalake_name: str = "test_user_metalake" + str(randint(1, 10000))
 
     gravitino_admin_client: GravitinoAdminClient = None
@@ -72,29 +68,6 @@ class TestUser(IntegrationTestEnv):
             cls.restart_server()
         else:
             super().tearDownClass()
-
-    def setUp(self):
-        self.init_test_env()
-
-    def tearDown(self):
-        self.clean_test_data()
-
-    def init_test_env(self):
-        self.gravitino_admin_client.create_metalake(
-            self.metalake_name, comment="", properties={}
-        )
-        self.gravitino_client = GravitinoClient(
-            uri="http://localhost:8090", metalake_name=self.metalake_name
-        )
-
-    def clean_test_data(self):
-        self.gravitino_client = GravitinoClient(
-            uri="http://localhost:8090", metalake_name=self.metalake_name
-        )
-        try:
-            self.gravitino_admin_client.drop_metalake(self.metalake_name, force=True)
-        except GravitinoRuntimeException:
-            logger.warning("Failed to drop metalake %s", self.metalake_name)
 
     def test_add_user(self):
         user = self.gravitino_client.add_user("test_add_user")


### PR DESCRIPTION
### What changes were proposed in this pull request?

- Added shared metalake/client helpers and `MetalakeTestMixin` in the Python integration test environment.
- Updated user, owner, catalog, and schema integration tests to reuse the shared metalake setup and cleanup flow.
- Kept test-specific cleanup logic for catalog and schema resources, while preserving the existing `TestCatalog` metalake cleanup logging.

### Why are the changes needed?

Several Python client integration tests repeated the same metalake creation, `GravitinoClient` initialization, and metalake cleanup code. Sharing the common setup and cleanup logic reduces duplicated test infrastructure code while keeping each test's resource-specific cleanup behavior unchanged.

Fix: #3767

### Does this PR introduce *any* user-facing change?

No.

### How was this patch tested?

- `git diff --check`
- `./gradlew :clients:client-python:pylint`