### PR TITLE
[#9836] feat(client): Add TLS configuration for HTTPS and mTLS

### DIFF
--- a/clients/client-java/src/main/java/org/apache/gravitino/client/EnvironmentTLSConfigurer.java
+++ b/clients/client-java/src/main/java/org/apache/gravitino/client/EnvironmentTLSConfigurer.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.client;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.security.GeneralSecurityException;
+import java.security.KeyStore;
+import java.util.Map;
+import java.util.Optional;
+import javax.annotation.Nullable;
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
+import org.apache.commons.lang3.StringUtils;
+
+final class EnvironmentTLSConfigurer implements TLSConfigurer {
+
+  static final String KEY_STORE_PATH = "GRAVITINO_CLIENT_TLS_KEY_STORE_PATH";
+  static final String KEY_STORE_PASSWORD = "GRAVITINO_CLIENT_TLS_KEY_STORE_PASSWORD";
+  static final String KEY_STORE_TYPE = "GRAVITINO_CLIENT_TLS_KEY_STORE_TYPE";
+  static final String TRUST_STORE_PATH = "GRAVITINO_CLIENT_TLS_TRUST_STORE_PATH";
+  static final String TRUST_STORE_PASSWORD = "GRAVITINO_CLIENT_TLS_TRUST_STORE_PASSWORD";
+  static final String TRUST_STORE_TYPE = "GRAVITINO_CLIENT_TLS_TRUST_STORE_TYPE";
+
+  private static final String DEFAULT_STORE_TYPE = "PKCS12";
+
+  private final SSLContext sslContext;
+
+  private EnvironmentTLSConfigurer(SSLContext sslContext) {
+    this.sslContext = sslContext;
+  }
+
+  static Optional<TLSConfigurer> fromEnvironment(Map<String, String> environment) {
+    boolean hasKeyStoreConfig =
+        hasAnyValue(environment, KEY_STORE_PATH, KEY_STORE_PASSWORD, KEY_STORE_TYPE);
+    boolean hasTrustStoreConfig =
+        hasAnyValue(environment, TRUST_STORE_PATH, TRUST_STORE_PASSWORD, TRUST_STORE_TYPE);
+
+    if (!hasKeyStoreConfig && !hasTrustStoreConfig) {
+      return Optional.empty();
+    }
+
+    @Nullable
+    KeyManager[] keyManagers =
+        hasKeyStoreConfig
+            ? createKeyManagers(
+                requiredValue(environment, KEY_STORE_PATH),
+                requiredValue(environment, KEY_STORE_PASSWORD),
+                storeType(environment, KEY_STORE_TYPE))
+            : null;
+    @Nullable
+    TrustManager[] trustManagers =
+        hasTrustStoreConfig
+            ? createTrustManagers(
+                requiredValue(environment, TRUST_STORE_PATH),
+                requiredValue(environment, TRUST_STORE_PASSWORD),
+                storeType(environment, TRUST_STORE_TYPE))
+            : null;
+
+    try {
+      SSLContext sslContext = SSLContext.getInstance("TLS");
+      sslContext.init(keyManagers, trustManagers, null);
+      return Optional.of(new EnvironmentTLSConfigurer(sslContext));
+    } catch (GeneralSecurityException e) {
+      throw new IllegalArgumentException("Failed to initialize the client TLS context", e);
+    }
+  }
+
+  @Override
+  public SSLContext sslContext() {
+    return sslContext;
+  }
+
+  private static boolean hasAnyValue(Map<String, String> environment, String... keys) {
+    for (String key : keys) {
+      if (StringUtils.isNotBlank(environment.get(key))) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static String requiredValue(Map<String, String> environment, String key) {
+    String value = environment.get(key);
+    if (StringUtils.isBlank(value)) {
+      throw new IllegalArgumentException(
+          String.format("Environment variable %s is required for client TLS", key));
+    }
+    return value;
+  }
+
+  private static String storeType(Map<String, String> environment, String key) {
+    return StringUtils.defaultIfBlank(environment.get(key), DEFAULT_STORE_TYPE);
+  }
+
+  private static KeyManager[] createKeyManagers(String path, String password, String type) {
+    try {
+      KeyStore keyStore = loadStore(Paths.get(path), password, type, "key store");
+      KeyManagerFactory factory =
+          KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+      factory.init(keyStore, password.toCharArray());
+      return factory.getKeyManagers();
+    } catch (GeneralSecurityException e) {
+      throw new IllegalArgumentException(
+          String.format("Failed to initialize the client TLS key store at %s", path), e);
+    }
+  }
+
+  private static TrustManager[] createTrustManagers(String path, String password, String type) {
+    try {
+      KeyStore trustStore = loadStore(Paths.get(path), password, type, "trust store");
+      TrustManagerFactory factory =
+          TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+      factory.init(trustStore);
+      return factory.getTrustManagers();
+    } catch (GeneralSecurityException e) {
+      throw new IllegalArgumentException(
+          String.format("Failed to initialize the client TLS trust store at %s", path), e);
+    }
+  }
+
+  private static KeyStore loadStore(Path path, String password, String type, String description) {
+    try {
+      KeyStore store = KeyStore.getInstance(type);
+      try (InputStream input = Files.newInputStream(path)) {
+        store.load(input, password.toCharArray());
+      }
+      return store;
+    } catch (GeneralSecurityException | IOException e) {
+      throw new IllegalArgumentException(
+          String.format("Failed to load the client TLS %s at %s", description, path), e);
+    }
+  }
+}

--- a/clients/client-java/src/main/java/org/apache/gravitino/client/GravitinoAdminClient.java
+++ b/clients/client-java/src/main/java/org/apache/gravitino/client/GravitinoAdminClient.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 import org.apache.gravitino.MetalakeChange;
 import org.apache.gravitino.SupportsMetalakes;
 import org.apache.gravitino.dto.requests.MetalakeCreateRequest;
@@ -58,14 +59,16 @@ public class GravitinoAdminClient extends GravitinoClientBase implements Support
    *     support the case that the client-side version is higher than the server-side version.
    * @param headers The base header for Gravitino API.
    * @param properties A map of properties (key-value pairs) used to configure the Gravitino client.
+   * @param tlsConfigurer The TLS configurer, or null to use environment or JVM defaults.
    */
   private GravitinoAdminClient(
       String uri,
       AuthDataProvider authDataProvider,
       boolean checkVersion,
       Map<String, String> headers,
-      Map<String, String> properties) {
-    super(uri, authDataProvider, checkVersion, headers, properties);
+      Map<String, String> properties,
+      @Nullable TLSConfigurer tlsConfigurer) {
+    super(uri, authDataProvider, checkVersion, headers, properties, tlsConfigurer);
   }
 
   /**
@@ -259,7 +262,7 @@ public class GravitinoAdminClient extends GravitinoClientBase implements Support
       Preconditions.checkArgument(
           uri != null && !uri.isEmpty(), "The argument 'uri' must be a valid URI");
       return new GravitinoAdminClient(
-          uri, authDataProvider, isVersionCheckEnabled(), headers, properties);
+          uri, authDataProvider, isVersionCheckEnabled(), headers, properties, tlsConfigurer);
     }
   }
 }

--- a/clients/client-java/src/main/java/org/apache/gravitino/client/GravitinoClient.java
+++ b/clients/client-java/src/main/java/org/apache/gravitino/client/GravitinoClient.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import javax.annotation.Nullable;
 import org.apache.gravitino.Catalog;
 import org.apache.gravitino.CatalogChange;
 import org.apache.gravitino.MetadataObject;
@@ -93,6 +94,7 @@ public class GravitinoClient extends GravitinoClientBase
    *     support the case that the client-side version is higher than the server-side version.
    * @param headers The base header for Gravitino API.
    * @param properties A map of properties (key-value pairs) used to configure the Gravitino client.
+   * @param tlsConfigurer The TLS configurer, or null to use environment or JVM defaults.
    * @throws NoSuchMetalakeException if the metalake with specified name does not exist.
    */
   private GravitinoClient(
@@ -101,8 +103,9 @@ public class GravitinoClient extends GravitinoClientBase
       AuthDataProvider authDataProvider,
       boolean checkVersion,
       Map<String, String> headers,
-      Map<String, String> properties) {
-    super(uri, authDataProvider, checkVersion, headers, properties);
+      Map<String, String> properties,
+      @Nullable TLSConfigurer tlsConfigurer) {
+    super(uri, authDataProvider, checkVersion, headers, properties, tlsConfigurer);
     this.metalake = loadMetalake(metalakeName);
   }
 
@@ -744,7 +747,13 @@ public class GravitinoClient extends GravitinoClientBase
           "The argument 'metalakeName' must be a valid name");
 
       return new GravitinoClient(
-          uri, metalakeName, authDataProvider, isVersionCheckEnabled(), headers, properties);
+          uri,
+          metalakeName,
+          authDataProvider,
+          isVersionCheckEnabled(),
+          headers,
+          properties,
+          tlsConfigurer);
     }
   }
 }

--- a/clients/client-java/src/main/java/org/apache/gravitino/client/GravitinoClientBase.java
+++ b/clients/client-java/src/main/java/org/apache/gravitino/client/GravitinoClientBase.java
@@ -29,6 +29,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Collections;
 import java.util.Map;
+import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
@@ -71,6 +72,27 @@ public abstract class GravitinoClientBase implements Closeable {
       boolean checkVersion,
       Map<String, String> headers,
       Map<String, String> properties) {
+    this(uri, authDataProvider, checkVersion, headers, properties, null);
+  }
+
+  /**
+   * Constructs a new GravitinoClient with the given URI, authenticator, AuthDataProvider and TLS
+   * configurer.
+   *
+   * @param uri The base URI for the Gravitino API.
+   * @param authDataProvider The provider of the data which is used for authentication.
+   * @param checkVersion Whether to check the version of the Gravitino server.
+   * @param headers The base header of the Gravitino API.
+   * @param properties A map of properties (key-value pairs) used to configure the Gravitino client.
+   * @param tlsConfigurer The TLS configurer, or null to use environment or JVM defaults.
+   */
+  protected GravitinoClientBase(
+      String uri,
+      AuthDataProvider authDataProvider,
+      boolean checkVersion,
+      Map<String, String> headers,
+      Map<String, String> properties,
+      @Nullable TLSConfigurer tlsConfigurer) {
     ObjectMapper mapper = ObjectMapperProvider.objectMapper();
 
     if (checkVersion) {
@@ -81,6 +103,7 @@ public abstract class GravitinoClientBase implements Closeable {
               .withObjectMapper(mapper)
               .withPreConnectHandler(this::checkVersion)
               .withHeaders(headers)
+              .withTlsConfigurer(tlsConfigurer)
               .build();
 
     } else {
@@ -90,6 +113,7 @@ public abstract class GravitinoClientBase implements Closeable {
               .withAuthDataProvider(authDataProvider)
               .withObjectMapper(mapper)
               .withHeaders(headers)
+              .withTlsConfigurer(tlsConfigurer)
               .build();
     }
   }
@@ -214,6 +238,8 @@ public abstract class GravitinoClientBase implements Closeable {
     protected Map<String, String> headers = ImmutableMap.of();
     /** A map of properties (key-value pairs) used to configure the Gravitino client. */
     protected Map<String, String> properties = ImmutableMap.of();
+    /** The TLS configurer for HTTPS connections. */
+    @Nullable protected TLSConfigurer tlsConfigurer;
 
     /**
      * The constructor for the Builder class.
@@ -367,6 +393,20 @@ public abstract class GravitinoClientBase implements Closeable {
       if (properties != null) {
         this.properties = ImmutableMap.copyOf(properties);
       }
+      return this;
+    }
+
+    /**
+     * Sets the TLS configuration used by the Gravitino client.
+     *
+     * <p>An explicitly supplied configurer takes precedence over environment-based TLS settings.
+     * Passing null uses environment-based TLS settings when present, otherwise the JVM defaults.
+     *
+     * @param tlsConfigurer The TLS configurer, or null to use environment or JVM defaults.
+     * @return This Builder instance for method chaining.
+     */
+    public Builder<T> withTlsConfigurer(@Nullable TLSConfigurer tlsConfigurer) {
+      this.tlsConfigurer = tlsConfigurer;
       return this;
     }
 

--- a/clients/client-java/src/main/java/org/apache/gravitino/client/HTTPClient.java
+++ b/clients/client-java/src/main/java/org/apache/gravitino/client/HTTPClient.java
@@ -35,6 +35,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.gravitino.Version;
 import org.apache.gravitino.auth.AuthConstants;
@@ -52,6 +53,7 @@ import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
 import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
 import org.apache.hc.client5.http.io.HttpClientConnectionManager;
+import org.apache.hc.client5.http.ssl.DefaultClientTlsStrategy;
 import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.HttpHeaders;
@@ -64,6 +66,7 @@ import org.apache.hc.core5.http.io.entity.StringEntity;
 import org.apache.hc.core5.http.message.BasicHeader;
 import org.apache.hc.core5.io.CloseMode;
 import org.apache.hc.core5.net.URIBuilder;
+import org.apache.hc.core5.reactor.ssl.SSLBufferMode;
 
 /**
  * An HttpClient for usage with the REST catalog.
@@ -107,6 +110,7 @@ public class HTTPClient implements RESTClient {
    * @param authDataProvider The provider of authentication data.
    * @param beforeConnectHandler The function to be executed before connecting to the server.
    * @param properties A map of properties (key-value pairs) used to configure the HTTP client.
+   * @param tlsConfigurer The TLS configurer, or null to use the default TLS behavior.
    */
   private HTTPClient(
       String uri,
@@ -114,14 +118,16 @@ public class HTTPClient implements RESTClient {
       ObjectMapper objectMapper,
       AuthDataProvider authDataProvider,
       Runnable beforeConnectHandler,
-      Map<String, String> properties) {
+      Map<String, String> properties,
+      @Nullable TLSConfigurer tlsConfigurer) {
     this.uri = uri;
     this.mapper = objectMapper;
     GravitinoClientConfiguration clientConfiguration =
         GravitinoClientConfiguration.buildFromProperties(properties);
 
     HttpClientBuilder clientBuilder = HttpClients.custom();
-    clientBuilder.setConnectionManager(configureConnectionManager(clientConfiguration));
+    clientBuilder.setConnectionManager(
+        configureConnectionManager(clientConfiguration, tlsConfigurer));
 
     if (baseHeaders != null) {
       clientBuilder.setDefaultHeaders(
@@ -746,7 +752,7 @@ public class HTTPClient implements RESTClient {
   }
 
   private static HttpClientConnectionManager configureConnectionManager(
-      GravitinoClientConfiguration clientConfiguration) {
+      GravitinoClientConfiguration clientConfiguration, @Nullable TLSConfigurer tlsConfigurer) {
     PoolingHttpClientConnectionManagerBuilder connectionManagerBuilder =
         PoolingHttpClientConnectionManagerBuilder.create();
 
@@ -757,6 +763,16 @@ public class HTTPClient implements RESTClient {
 
     ConnectionConfig connectionConfig = configureConnectionConfig(clientConfiguration);
     connectionManagerBuilder.setDefaultConnectionConfig(connectionConfig);
+
+    if (tlsConfigurer != null) {
+      connectionManagerBuilder.setTlsSocketStrategy(
+          new DefaultClientTlsStrategy(
+              tlsConfigurer.sslContext(),
+              tlsConfigurer.supportedProtocols(),
+              tlsConfigurer.supportedCipherSuites(),
+              SSLBufferMode.STATIC,
+              tlsConfigurer.hostnameVerifier()));
+    }
     return connectionManagerBuilder.build();
   }
 
@@ -772,6 +788,16 @@ public class HTTPClient implements RESTClient {
     return connConfigBuilder.build();
   }
 
+  @VisibleForTesting
+  @Nullable
+  static TLSConfigurer resolveTLSConfigurer(
+      @Nullable TLSConfigurer explicitConfigurer, Map<String, String> environment) {
+    if (explicitConfigurer != null) {
+      return explicitConfigurer;
+    }
+    return EnvironmentTLSConfigurer.fromEnvironment(environment).orElse(null);
+  }
+
   /**
    * Builder class for configuring and creating instances of HTTPClient.
    *
@@ -782,6 +808,7 @@ public class HTTPClient implements RESTClient {
     private final Map<String, String> properties;
 
     private final Map<String, String> baseHeaders = Maps.newHashMap();
+    @Nullable private TLSConfigurer tlsConfigurer;
     private String uri;
     private ObjectMapper mapper = ObjectMapperProvider.objectMapper();
     private AuthDataProvider authDataProvider;
@@ -861,14 +888,31 @@ public class HTTPClient implements RESTClient {
     }
 
     /**
+     * Sets the TLS configuration used by the HTTP client.
+     *
+     * @param tlsConfigurer The TLS configurer, or null to use environment or JVM defaults.
+     * @return This Builder instance for method chaining.
+     */
+    public Builder withTlsConfigurer(@Nullable TLSConfigurer tlsConfigurer) {
+      this.tlsConfigurer = tlsConfigurer;
+      return this;
+    }
+
+    /**
      * Builds and returns an instance of the HTTPClient with the configured options.
      *
      * @return An instance of HTTPClient with the configured options.
      */
     public HTTPClient build() {
-
+      TLSConfigurer effectiveTlsConfigurer = resolveTLSConfigurer(tlsConfigurer, System.getenv());
       return new HTTPClient(
-          uri, baseHeaders, mapper, authDataProvider, beforeConnectHandler, properties);
+          uri,
+          baseHeaders,
+          mapper,
+          authDataProvider,
+          beforeConnectHandler,
+          properties,
+          effectiveTlsConfigurer);
     }
   }
 

--- a/clients/client-java/src/main/java/org/apache/gravitino/client/TLSConfigurer.java
+++ b/clients/client-java/src/main/java/org/apache/gravitino/client/TLSConfigurer.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.client;
+
+import javax.annotation.Nullable;
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLContext;
+import org.apache.hc.client5.http.ssl.HttpsSupport;
+import org.apache.hc.core5.ssl.SSLContexts;
+
+/**
+ * Configures TLS settings for connections created by the Gravitino client.
+ *
+ * <p>An explicit configurer takes precedence over environment configuration. Without one, the
+ * client reads the following environment variables:
+ *
+ * <ul>
+ *   <li>{@code GRAVITINO_CLIENT_TLS_KEY_STORE_PATH}, {@code
+ *       GRAVITINO_CLIENT_TLS_KEY_STORE_PASSWORD}, and optional {@code
+ *       GRAVITINO_CLIENT_TLS_KEY_STORE_TYPE}
+ *   <li>{@code GRAVITINO_CLIENT_TLS_TRUST_STORE_PATH}, {@code
+ *       GRAVITINO_CLIENT_TLS_TRUST_STORE_PASSWORD}, and optional {@code
+ *       GRAVITINO_CLIENT_TLS_TRUST_STORE_TYPE}
+ * </ul>
+ *
+ * <p>Store types default to {@code PKCS12}. There is no default file location. When no explicit or
+ * environment configuration is present, the JVM TLS defaults are used.
+ */
+public interface TLSConfigurer {
+
+  /**
+   * Returns the SSL context used for TLS connections.
+   *
+   * @return the configured SSL context
+   */
+  default SSLContext sslContext() {
+    return SSLContexts.createDefault();
+  }
+
+  /**
+   * Returns the hostname verifier used for TLS connections.
+   *
+   * @return the hostname verifier
+   */
+  default HostnameVerifier hostnameVerifier() {
+    return HttpsSupport.getDefaultHostnameVerifier();
+  }
+
+  /**
+   * Returns the supported TLS protocols, or null to use the client defaults.
+   *
+   * @return the supported TLS protocols
+   */
+  @Nullable
+  default String[] supportedProtocols() {
+    return null;
+  }
+
+  /**
+   * Returns the supported cipher suites, or null to use the client defaults.
+   *
+   * @return the supported cipher suites
+   */
+  @Nullable
+  default String[] supportedCipherSuites() {
+    return null;
+  }
+}

--- a/clients/client-java/src/test/java/org/apache/gravitino/client/TestEnvironmentTLSConfigurer.java
+++ b/clients/client-java/src/test/java/org/apache/gravitino/client/TestEnvironmentTLSConfigurer.java
@@ -1,0 +1,179 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.client;
+
+import static org.mockserver.integration.ClientAndServer.startClientAndServer;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.google.common.collect.ImmutableMap;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Map;
+import org.apache.gravitino.exceptions.RESTException;
+import org.apache.gravitino.rest.RESTResponse;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockserver.configuration.Configuration;
+import org.mockserver.integration.ClientAndServer;
+import org.mockserver.logging.MockServerLogger;
+import org.mockserver.socket.tls.KeyStoreFactory;
+
+class TestEnvironmentTLSConfigurer {
+
+  @Test
+  void testEmptyEnvironmentUsesJvmDefaults() {
+    Assertions.assertFalse(EnvironmentTLSConfigurer.fromEnvironment(ImmutableMap.of()).isPresent());
+    Assertions.assertNull(HTTPClient.resolveTLSConfigurer(null, ImmutableMap.of()));
+  }
+
+  @Test
+  void testStorePathAndPasswordMustBeConfiguredTogether() {
+    IllegalArgumentException keyStoreException =
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                EnvironmentTLSConfigurer.fromEnvironment(
+                    ImmutableMap.of(EnvironmentTLSConfigurer.KEY_STORE_PASSWORD, "secret")));
+    Assertions.assertTrue(
+        keyStoreException.getMessage().contains(EnvironmentTLSConfigurer.KEY_STORE_PATH));
+
+    IllegalArgumentException trustStoreException =
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                EnvironmentTLSConfigurer.fromEnvironment(
+                    ImmutableMap.of(EnvironmentTLSConfigurer.TRUST_STORE_PATH, "/missing")));
+    Assertions.assertTrue(
+        trustStoreException.getMessage().contains(EnvironmentTLSConfigurer.TRUST_STORE_PASSWORD));
+  }
+
+  @Test
+  void testInvalidStoreDoesNotExposePassword() {
+    String password = "do-not-log-this-password";
+    IllegalArgumentException exception =
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                EnvironmentTLSConfigurer.fromEnvironment(
+                    ImmutableMap.of(
+                        EnvironmentTLSConfigurer.KEY_STORE_PATH,
+                        "/missing/client.p12",
+                        EnvironmentTLSConfigurer.KEY_STORE_PASSWORD,
+                        password)));
+
+    Assertions.assertTrue(exception.getMessage().contains("/missing/client.p12"));
+    Assertions.assertFalse(exception.getMessage().contains(password));
+  }
+
+  @Test
+  void testExplicitConfigurerTakesPrecedenceOverEnvironment() {
+    TLSConfigurer explicitConfigurer = new TLSConfigurer() {};
+    Map<String, String> invalidEnvironment =
+        ImmutableMap.of(EnvironmentTLSConfigurer.KEY_STORE_PASSWORD, "secret");
+
+    Assertions.assertSame(
+        explicitConfigurer,
+        HTTPClient.resolveTLSConfigurer(explicitConfigurer, invalidEnvironment));
+  }
+
+  @Test
+  void testMutualTlsHandshakeRequiresClientCertificate() throws IOException {
+    Configuration configuration =
+        Configuration.configuration()
+            .tlsMutualAuthenticationRequired(true)
+            .livenessHttpGetPath("/mtls");
+    KeyStoreFactory keyStoreFactory =
+        new KeyStoreFactory(configuration, new MockServerLogger(getClass()));
+    Path keyStorePath = Paths.get(keyStoreFactory.keyStoreFileName).toAbsolutePath();
+    String previousTrustStore = System.getProperty("javax.net.ssl.trustStore");
+    ClientAndServer server = null;
+
+    try {
+      keyStoreFactory.loadOrCreateKeyStore();
+      restoreSystemProperty("javax.net.ssl.trustStore", previousTrustStore);
+
+      server = startClientAndServer(configuration);
+
+      Map<String, String> trustOnlyEnvironment =
+          ImmutableMap.of(
+              EnvironmentTLSConfigurer.TRUST_STORE_PATH,
+              keyStorePath.toString(),
+              EnvironmentTLSConfigurer.TRUST_STORE_PASSWORD,
+              KeyStoreFactory.KEY_STORE_PASSWORD,
+              EnvironmentTLSConfigurer.TRUST_STORE_TYPE,
+              KeyStoreFactory.KEY_STORE_TYPE);
+      TLSConfigurer trustOnlyConfigurer =
+          HTTPClient.resolveTLSConfigurer(null, trustOnlyEnvironment);
+      Assertions.assertNotNull(trustOnlyConfigurer);
+
+      try (HTTPClient client = newClient(server, trustOnlyConfigurer)) {
+        RESTException exception =
+            Assertions.assertThrows(
+                RESTException.class,
+                () -> client.get("mtls", StatusResponse.class, ImmutableMap.of(), error -> {}));
+        Assertions.assertTrue(
+            exception.getMessage().contains("Failed to execute request"), exception::toString);
+      }
+
+      Map<String, String> mutualTlsEnvironment =
+          ImmutableMap.<String, String>builder()
+              .putAll(trustOnlyEnvironment)
+              .put(EnvironmentTLSConfigurer.KEY_STORE_PATH, keyStorePath.toString())
+              .put(EnvironmentTLSConfigurer.KEY_STORE_PASSWORD, KeyStoreFactory.KEY_STORE_PASSWORD)
+              .put(EnvironmentTLSConfigurer.KEY_STORE_TYPE, KeyStoreFactory.KEY_STORE_TYPE)
+              .build();
+      TLSConfigurer mutualTlsConfigurer =
+          HTTPClient.resolveTLSConfigurer(null, mutualTlsEnvironment);
+      Assertions.assertNotNull(mutualTlsConfigurer);
+
+      try (HTTPClient client = newClient(server, mutualTlsConfigurer)) {
+        client.get("mtls", StatusResponse.class, ImmutableMap.of(), error -> {});
+      }
+    } finally {
+      if (server != null) {
+        server.stop();
+      }
+      restoreSystemProperty("javax.net.ssl.trustStore", previousTrustStore);
+      Files.deleteIfExists(keyStorePath);
+    }
+  }
+
+  private static HTTPClient newClient(ClientAndServer server, TLSConfigurer tlsConfigurer) {
+    return HTTPClient.builder(ImmutableMap.of())
+        .uri(String.format("https://localhost:%d", server.getPort()))
+        .withTlsConfigurer(tlsConfigurer)
+        .build();
+  }
+
+  private static void restoreSystemProperty(String key, String value) {
+    if (value == null) {
+      System.clearProperty(key);
+    } else {
+      System.setProperty(key, value);
+    }
+  }
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  private static class StatusResponse implements RESTResponse {
+    @Override
+    public void validate() throws IllegalArgumentException {}
+  }
+}

--- a/docs/how-to-use-gravitino-client.md
+++ b/docs/how-to-use-gravitino-client.md
@@ -46,6 +46,13 @@ GravitinoAdminClient gravitinoAdminClient = GravitinoAdminClient.builder("http:/
 
 **Note:** Invalid configuration properties will result in exceptions.
 
+### HTTPS and Mutual TLS
+
+The Java client can load a custom server trust store and an optional client certificate for mTLS.
+These settings use environment variables rather than `withClientConfig`. See
+[Java Client Certificate Configuration](./security/how-to-use-https.md#java-client-certificate-configuration)
+for the supported variables and a PKCS12 setup example.
+
 ## Python Client
 
 Customize the Gravitino Python client with config properties like this:

--- a/docs/security/how-to-use-https.md
+++ b/docs/security/how-to-use-https.md
@@ -47,6 +47,61 @@ Both the Gravitino server and Iceberg REST service can configure and support HTT
 | `gravitino.iceberg-rest.trustStorePassword`     | Password to the trust store.                                       | (none)            | Yes if use HTTPS and the authentication of client | 0.3.0         |
 | `gravitino.iceberg-rest.trustStoreType`         | The type to the trust store.                                       | `JKS`             | No                                                | 0.3.0         |
 
+### Java Client Certificate Configuration
+
+#### Connect with HTTPS
+
+Use HTTPS to encrypt traffic and verify the server identity. Use an `https://` server URI; no client
+TLS configuration is needed when the JVM already trusts the server certificate.
+
+#### Trust a Server Signed by a Private CA
+
+Use a custom trust store when an internal or self-managed CA is not trusted by the JVM.
+
+Import the CA certificate into a trust store, then configure its path and password:
+
+```shell
+keytool -importcert -alias gravitino-ca -file ca.crt \
+  -keystore truststore.p12 -storetype PKCS12
+
+export GRAVITINO_CLIENT_TLS_TRUST_STORE_PATH=/absolute/path/truststore.p12
+export GRAVITINO_CLIENT_TLS_TRUST_STORE_PASSWORD='trust-store-password'
+```
+
+#### Present a Client Certificate for mTLS
+
+Use mTLS to allow only clients with a certificate signed by a CA trusted by the server.
+
+Create a PKCS12 key store containing the client certificate and matching private key:
+
+```shell
+openssl pkcs12 -export \
+  -in client.crt \
+  -inkey client.key \
+  -certfile ca.crt \
+  -name gravitino-client \
+  -out client.p12
+```
+
+Export the path and the password entered when prompted:
+
+```shell
+export GRAVITINO_CLIENT_TLS_KEY_STORE_PATH=/absolute/path/client.p12
+export GRAVITINO_CLIENT_TLS_KEY_STORE_PASSWORD='key-store-password'
+```
+
+Enable client authentication on the Gravitino server with
+`gravitino.server.webserver.enableClientAuth = true` and configure the server trust store with the
+CA that signed the client certificate.
+
+The certificate controls whether the connection is accepted. The `Authorization` header still
+determines the Gravitino user.
+
+Key and trust stores default to `PKCS12`; set `GRAVITINO_CLIENT_TLS_KEY_STORE_TYPE` or
+`GRAVITINO_CLIENT_TLS_TRUST_STORE_TYPE` to use another Java key store type. Configure each path
+together with its password. Precedence is an explicit `TLSConfigurer`, then environment variables,
+then JVM defaults.
+
 Refer to the "Additional JSSE Standard Names" section of the [Java security guide](https://docs.oracle.com/javase/8/docs/technotes/guides/security/StandardNames.html#jssenames) for the list of protocols related to tlsProtocol. You can find the list of `tlsProtocol` values for Java 8 in this document.
 
 Refer to the "Additional JSSE Standard Names" section of the [Java security guide](https://docs.oracle.com/javase/8/docs/technotes/guides/security/StandardNames.html#ciphersuites) for the list of protocols related to tlsProtocol. You can find the list of `enableCipherAlgorithms` values for Java 8 in this document.


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add HTTPS and mutual TLS support to the Gravitino Java client.

This change:

- Adds a `TLSConfigurer` API to `GravitinoClient`, `GravitinoAdminClient`, and `HTTPClient`.
- Loads optional client keystores and server truststores from environment variables.
- Uses explicit `TLSConfigurer`, environment variables, then JVM defaults as precedence.
- Validates incomplete and invalid TLS configuration.
- Updates `docs/security/how-to-use-https.md` with three client use cases:
  - Use HTTPS to encrypt traffic and verify the server.
  - Trust internal servers whose private CA is not trusted by the JVM.
  - Use mTLS to restrict connections to certified clients.
- Links the certificate instructions from `docs/how-to-use-gravitino-client.md`.

### Why are the changes needed?

The server can require and validate client certificates, but the Java client cannot currently present one.

This change enables HTTPS with custom trust material and mTLS client certificates. The certificate controls whether the connection is accepted; the `Authorization` header still determines the Gravitino user.

Fix: #9836

### Does this PR introduce _any_ user-facing change?

Yes.

A new `withTlsConfigurer` client API is available.

The following environment variables are added:

- `GRAVITINO_CLIENT_TLS_KEY_STORE_PATH`
- `GRAVITINO_CLIENT_TLS_KEY_STORE_PASSWORD`
- `GRAVITINO_CLIENT_TLS_KEY_STORE_TYPE`
- `GRAVITINO_CLIENT_TLS_TRUST_STORE_PATH`
- `GRAVITINO_CLIENT_TLS_TRUST_STORE_PASSWORD`
- `GRAVITINO_CLIENT_TLS_TRUST_STORE_TYPE`

Store types default to `PKCS12`. There is no default file location.

### How was this patch tested?

Tests cover:

- JVM defaults when TLS configuration is absent.
- Explicit configuration taking precedence over environment configuration.
- Incomplete and invalid store configuration.
- Passwords not appearing in errors.
- Rejection when a required client certificate is absent.
- Successful connection with a trusted client certificate.

Commands run:

`./gradlew :clients:client-java:spotlessCheck :clients:client-java:test :clients:client-java:javadoc -PskipITs`

`./gradlew :docs:build`
