### PR TITLE
[#12021] feat(trino-connector): Support oauth2 per-user token forwarding in session forwarding

### DIFF
--- a/docs/trino-connector/authentication.md
+++ b/docs/trino-connector/authentication.md
@@ -153,9 +153,9 @@ SHOW CATALOGS;
 
 ### Session Credential Forwarding
 
-Setting `gravitino.client.session.forwardUser=true` with `authType=simple` creates a dedicated Gravitino client per Trino session user, so each user is visible in the Gravitino audit log instead of the shared `gravitino.user`.
+Setting `gravitino.client.session.forwardUser=true` creates a dedicated Gravitino client per Trino session user, so each user is visible in the Gravitino audit log instead of the shared `gravitino.user` or service identity. It is supported with `authType=simple` and `authType=oauth2`.
 
-**Configuration:**
+**Configuration (`authType=simple`):**
 
 ```properties
 connector.name=gravitino
@@ -166,13 +166,34 @@ gravitino.client.authType=simple
 gravitino.client.session.forwardUser=true
 ```
 
+With `authType=simple`, the Trino session username is forwarded to Gravitino as the simple-auth identity.
+
+**Configuration (`authType=oauth2`):**
+
+```properties
+connector.name=gravitino
+gravitino.metalake=metalake
+gravitino.uri=http://localhost:8090
+
+gravitino.client.authType=oauth2
+gravitino.client.oauth2.serverUri=http://oauth-server:8080
+gravitino.client.oauth2.credential=client_id:client_secret
+gravitino.client.oauth2.path=oauth2/token
+gravitino.client.oauth2.scope=gravitino
+gravitino.client.session.forwardUser=true
+```
+
+With `authType=oauth2`, the end user's IdP access token is presented to Gravitino directly instead of the shared client-credentials identity. The token is read from the Trino session's extra-credentials under the key `token`, which requires a Trino coordinator configured with `http-server.authentication.oauth2.forward-token-to-connectors=true` and an `OAuth2Authenticator` that populates that extra credential with the caller's access token; without it, `buildForSession` fails with an error explaining the missing token. The `gravitino.client.oauth2.*` properties above still configure the shared bootstrap/admin client used for catalog discovery — they are unrelated to the per-user forwarded token.
+
+For an Iceberg catalog with `catalog-backend=rest` (backed by an Iceberg REST Catalog), enabling `forwardUser` with `authType=oauth2` also causes the connector to forward the end user's token to the REST catalog itself (`iceberg.rest-catalog.security=OAUTH2`, `iceberg.rest-catalog.session=USER`), so per-user authorization applies on both the Gravitino API path and the REST catalog path.
+
 **Configuration properties:**
 
-| Property                                                     | Description                                                                                  | Default value   | Required   | Since version   |
-|--------------------------------------------------------------|----------------------------------------------------------------------------------------------|-----------------|------------|-----------------|
-| `gravitino.client.session.forwardUser`                       | When `true` with `authType=simple`, forwards the Trino session user to Gravitino per-query   | `false`         | No         | 1.3.0           |
-| `gravitino.client.session.cache.maxSize`                     | Maximum number of per-user sessions to keep in the cache                                     | `500`           | No         | 1.3.0           |
-| `gravitino.client.session.cache.expireAfterAccessSeconds`    | Seconds before an idle per-user session is evicted from the cache                            | `3600`          | No         | 1.3.0           |
+| Property                                                     | Description                                                                                    | Default value   | Required   | Since version   |
+|--------------------------------------------------------------|--------------------------------------------------------------------------------------------------|-----------------|------------|-----------------|
+| `gravitino.client.session.forwardUser`                       | When `true` with `authType=simple` or `authType=oauth2`, forwards the Trino session user/token to Gravitino per-query   | `false`         | No         | 1.3.0           |
+| `gravitino.client.session.cache.maxSize`                     | Maximum number of per-user sessions to keep in the cache                                       | `500`           | No         | 1.3.0           |
+| `gravitino.client.session.cache.expireAfterAccessSeconds`    | Seconds before an idle per-user session is evicted from the cache                              | `3600`          | No         | 1.3.0           |
 
 ### Notes
 

--- a/docs/trino-connector/authentication.md
+++ b/docs/trino-connector/authentication.md
@@ -242,7 +242,43 @@ The `gravitino.client.oauth2.*` properties configure the shared service identity
 discovery; the per-user forwarded token (from step 1) is what each query actually authenticates
 with once `forwardUser=true`.
 
-**4. Query as a specific user.** With a real OIDC login flow, Trino populates the forwarded token
+**4. Create the metalake and catalog.** Create the metalake `my_metalake` first (via the
+Gravitino REST API, SDK, or CLI — see
+[Manage metalakes](../manage-metalake-using-gravitino.md#create-a-metalake)), then create a
+REST-backed Iceberg catalog under it from the Trino CLI using the
+`gravitino.system.create_catalog` procedure. To also forward the end user's token to the Iceberg
+REST catalog (IRC) itself, set `trino.bypass.iceberg.rest-catalog.security=OAUTH2` and
+`trino.bypass.iceberg.rest-catalog.session=USER` on the catalog, alongside its bootstrap
+`trino.bypass.iceberg.rest-catalog.oauth2.*` credentials:
+
+```sql
+call gravitino.system.create_catalog(
+    'my_catalog',
+    'lakehouse-iceberg',
+    map(
+        array['uri', 'catalog-backend', 'warehouse',
+          'trino.bypass.iceberg.rest-catalog.security', 'trino.bypass.iceberg.rest-catalog.session',
+          'trino.bypass.iceberg.rest-catalog.oauth2.credential', 'trino.bypass.iceberg.rest-catalog.oauth2.scope',
+          'trino.bypass.iceberg.rest-catalog.oauth2.server-uri'
+        ],
+        array['http://irc-host:9001/iceberg', 'rest', 'my_catalog',
+          'OAUTH2', 'USER',
+          'service-account-id:service-account-secret', 'email',
+          'http://your-idp/realms/gravitino/protocol/openid-connect/token'
+        ]
+    )
+);
+```
+
+This call itself runs with the connector's own shared service identity, not any forwarded user
+token — `forwardUser` only affects `SELECT`/`SHOW`-style queries against the catalog afterward,
+not catalog registration itself. `create_catalog` both creates the catalog in Gravitino and loads
+it into Trino as its own top-level catalog — not as a schema nested under a single `gravitino`
+catalog. If the two `trino.bypass.iceberg.rest-catalog.*` properties above are omitted, the REST
+catalog keeps its own default security setting, independent of
+`gravitino.client.session.forwardUser`, and the end user's token never reaches the IRC.
+
+**5. Query as a specific user.** With a real OIDC login flow, Trino populates the forwarded token
 automatically after the user signs in. For manual testing, the same extra-credential can be set
 directly on the CLI:
 
@@ -253,25 +289,11 @@ trino --server http://localhost:8080 \
   --execute "SHOW SCHEMAS IN my_catalog"
 ```
 
-`my_catalog` here is a catalog registered under `my_metalake` in Gravitino — with
-`catalog.management=dynamic`, the connector registers each Gravitino catalog as its own top-level
-Trino catalog, not as a schema nested under a single `gravitino` catalog. Gravitino sees this
-request as `alice`, not the shared service identity — `alice`'s own privileges apply, and a
-request with a missing or invalid token is rejected before it reaches the catalog.
-
-**5. Iceberg REST catalog (IRC).** If `my_catalog` has `catalog-backend=rest`, forwarding the same
-token to the IRC itself requires opting in explicitly on that catalog's own properties:
-
-```properties
-trino.bypass.iceberg.rest-catalog.security=OAUTH2
-trino.bypass.iceberg.rest-catalog.session=USER
-```
-
-set alongside its bootstrap `trino.bypass.iceberg.rest-catalog.oauth2.credential`/`scope`/
-`server-uri`. With these set, the forwarded token from step 4 reaches the IRC directly, so
-per-user authorization applies consistently whether Trino talks to Gravitino's native API or
-straight to the IRC. Without them, the REST catalog keeps its own default security setting,
-independent of `gravitino.client.session.forwardUser`.
+Gravitino sees this request as `alice`, not the shared service identity — `alice`'s own
+privileges apply, and a request with a missing or invalid token is rejected before it reaches the
+catalog. Because `my_catalog` was created with `trino.bypass.iceberg.rest-catalog.session=USER`
+in step 4, the same forwarded token also reaches the IRC directly, so per-user authorization
+applies consistently whether Trino talks to Gravitino's native API or straight to the IRC.
 
 ## Notes
 

--- a/docs/trino-connector/authentication.md
+++ b/docs/trino-connector/authentication.md
@@ -11,6 +11,8 @@ The Gravitino Trino connector supports authenticating to the Gravitino server us
 
 If `gravitino.client.authType` is not set, the connector operates in no-authentication mode and connects to the Gravitino server without any credentials.
 
+## Authentication Types
+
 ### Simple Authentication
 
 Simple authentication uses a username to authenticate with the Gravitino server.
@@ -90,32 +92,6 @@ gravitino.client.oauth2.scope=gravitino
 | `gravitino.client.oauth2.path`         | OAuth2 token endpoint path                                          | (none)          | Yes if authType is `oauth2`  | 1.3.0           |
 | `gravitino.client.oauth2.scope`        | OAuth2 scope                                                        | (none)          | Yes if authType is `oauth2`  | 1.3.0           |
 
-### Kerberos Authentication
-
-Kerberos authentication uses Kerberos tickets to authenticate with the Gravitino server.
-
-**Configuration in `etc/catalog/gravitino.properties`:**
-
-```properties
-connector.name=gravitino
-gravitino.metalake=metalake
-gravitino.uri=http://localhost:8090
-
-# Kerberos authentication with keytab
-gravitino.client.authType=kerberos
-gravitino.client.kerberos.principal=user@REALM
-gravitino.client.kerberos.keytabFilePath=/path/to/user.keytab
-```
-
-**Configuration properties:**
-
-| Property                                     | Description                                                         | Default value   | Required                                  | Since version   |
-|----------------------------------------------|---------------------------------------------------------------------|-----------------|-------------------------------------------|-----------------|
-| `gravitino.client.authType`                  | Authentication type: `simple`, `basic`, `oauth2`, or `kerberos`     | (none)          | Yes (to enable Kerberos)                  | 1.3.0           |
-| `gravitino.client.kerberos.principal`        | Kerberos principal                                                  | (none)          | Yes if authType is `kerberos`             | 1.3.0           |
-| `gravitino.client.kerberos.keytabFilePath`   | Path to keytab file                                                 | (none)          | No (uses ticket cache if not specified)   | 1.3.0           |
-
-
 ### Example: Connecting to OAuth-Protected Gravitino Server
 
 This example shows how to configure the Trino connector to connect to a Gravitino server protected by OAuth authentication.
@@ -151,7 +127,32 @@ gravitino.client.oauth2.scope=test
 SHOW CATALOGS;
 ```
 
-### Session Credential Forwarding
+### Kerberos Authentication
+
+Kerberos authentication uses Kerberos tickets to authenticate with the Gravitino server.
+
+**Configuration in `etc/catalog/gravitino.properties`:**
+
+```properties
+connector.name=gravitino
+gravitino.metalake=metalake
+gravitino.uri=http://localhost:8090
+
+# Kerberos authentication with keytab
+gravitino.client.authType=kerberos
+gravitino.client.kerberos.principal=user@REALM
+gravitino.client.kerberos.keytabFilePath=/path/to/user.keytab
+```
+
+**Configuration properties:**
+
+| Property                                     | Description                                                         | Default value   | Required                                  | Since version   |
+|----------------------------------------------|---------------------------------------------------------------------|-----------------|-------------------------------------------|-----------------|
+| `gravitino.client.authType`                  | Authentication type: `simple`, `basic`, `oauth2`, or `kerberos`     | (none)          | Yes (to enable Kerberos)                  | 1.3.0           |
+| `gravitino.client.kerberos.principal`        | Kerberos principal                                                  | (none)          | Yes if authType is `kerberos`             | 1.3.0           |
+| `gravitino.client.kerberos.keytabFilePath`   | Path to keytab file                                                 | (none)          | No (uses ticket cache if not specified)   | 1.3.0           |
+
+## Session Credential Forwarding
 
 Setting `gravitino.client.session.forwardUser=true` creates a dedicated Gravitino client per Trino session user, so each user is visible in the Gravitino audit log instead of the shared `gravitino.user` or service identity. It is supported with `authType=simple` and `authType=oauth2`.
 
@@ -185,7 +186,7 @@ gravitino.client.session.forwardUser=true
 
 With `authType=oauth2`, the end user's IdP access token is presented to Gravitino directly instead of the shared client-credentials identity. The token is read from the Trino session's extra-credentials under the key `token`, which requires a Trino coordinator configured with `http-server.authentication.oauth2.forward-token-to-connectors=true` and an `OAuth2Authenticator` that populates that extra credential with the caller's access token; without it, `buildForSession` fails with an error explaining the missing token. The `gravitino.client.oauth2.*` properties above still configure the shared bootstrap/admin client used for catalog discovery — they are unrelated to the per-user forwarded token.
 
-For an Iceberg catalog with `catalog-backend=rest` (backed by an Iceberg REST Catalog), enabling `forwardUser` with `authType=oauth2` also causes the connector to forward the end user's token to the REST catalog itself (`iceberg.rest-catalog.security=OAUTH2`, `iceberg.rest-catalog.session=USER`), so per-user authorization applies on both the Gravitino API path and the REST catalog path.
+For an Iceberg catalog with `catalog-backend=rest` (backed by an Iceberg REST Catalog), the connector does not set `iceberg.rest-catalog.security`/`iceberg.rest-catalog.session` on its own — that catalog's own `gravitino.client.*` config is unrelated to how its underlying Iceberg REST catalog authenticates. To also forward the end user's token to the REST catalog itself, set `trino.bypass.iceberg.rest-catalog.security=OAUTH2` and `trino.bypass.iceberg.rest-catalog.session=USER` explicitly on that catalog's properties, alongside its bootstrap `trino.bypass.iceberg.rest-catalog.oauth2.*` credentials; see the worked example below.
 
 **Configuration properties:**
 
@@ -195,14 +196,91 @@ For an Iceberg catalog with `catalog-backend=rest` (backed by an Iceberg REST Ca
 | `gravitino.client.session.cache.maxSize`                     | Maximum number of per-user sessions to keep in the cache                                       | `500`           | No         | 1.3.0           |
 | `gravitino.client.session.cache.expireAfterAccessSeconds`    | Seconds before an idle per-user session is evicted from the cache                              | `3600`          | No         | 1.3.0           |
 
-### Notes
+### Example: OAuth2 Per-User Token Forwarding
+
+This example walks through a full setup where each Trino user's own OAuth2 access token is
+forwarded to Gravitino and to an Iceberg REST catalog (IRC), instead of a single shared service
+identity.
+
+**1. Trino coordinator: forward the logged-in user's token to connectors** (in `etc/config.properties`):
+
+```properties
+http-server.authentication.type=oauth2
+http-server.authentication.oauth2.forward-token-to-connectors=true
+```
+
+This requires a Trino coordinator whose `OAuth2Authenticator` populates the session's
+extra-credentials with the user's IdP access token under the key `token` when this flag is set;
+stock Trino does not do this yet.
+
+**2. Gravitino server: enable OAuth2** (in `conf/gravitino.conf`):
+
+```properties
+gravitino.authenticators=oauth
+gravitino.authenticator.oauth.serviceAudience=account
+gravitino.authenticator.oauth.jwksUri=http://your-idp/realms/gravitino/protocol/openid-connect/certs
+gravitino.authenticator.oauth.tokenValidatorClass=org.apache.gravitino.server.authentication.JwksTokenValidator
+gravitino.authenticator.oauth.principalFields=preferred_username,email,sub
+```
+
+**3. Trino connector: enable OAuth2 forwarding** (in `etc/catalog/gravitino.properties`):
+
+```properties
+connector.name=gravitino
+gravitino.metalake=my_metalake
+gravitino.uri=http://localhost:8090
+
+gravitino.client.authType=oauth2
+gravitino.client.oauth2.serverUri=http://your-idp
+gravitino.client.oauth2.credential=service-account-id:service-account-secret
+gravitino.client.oauth2.path=realms/gravitino/protocol/openid-connect/token
+gravitino.client.oauth2.scope=email
+gravitino.client.session.forwardUser=true
+```
+
+The `gravitino.client.oauth2.*` properties configure the shared service identity used for catalog
+discovery; the per-user forwarded token (from step 1) is what each query actually authenticates
+with once `forwardUser=true`.
+
+**4. Query as a specific user.** With a real OIDC login flow, Trino populates the forwarded token
+automatically after the user signs in. For manual testing, the same extra-credential can be set
+directly on the CLI:
+
+```shell
+trino --server http://localhost:8080 \
+  --user alice \
+  --extra-credential token=<alice-idp-access-token> \
+  --execute "SHOW SCHEMAS IN my_catalog"
+```
+
+`my_catalog` here is a catalog registered under `my_metalake` in Gravitino — with
+`catalog.management=dynamic`, the connector registers each Gravitino catalog as its own top-level
+Trino catalog, not as a schema nested under a single `gravitino` catalog. Gravitino sees this
+request as `alice`, not the shared service identity — `alice`'s own privileges apply, and a
+request with a missing or invalid token is rejected before it reaches the catalog.
+
+**5. Iceberg REST catalog (IRC).** If `my_catalog` has `catalog-backend=rest`, forwarding the same
+token to the IRC itself requires opting in explicitly on that catalog's own properties:
+
+```properties
+trino.bypass.iceberg.rest-catalog.security=OAUTH2
+trino.bypass.iceberg.rest-catalog.session=USER
+```
+
+set alongside its bootstrap `trino.bypass.iceberg.rest-catalog.oauth2.credential`/`scope`/
+`server-uri`. With these set, the forwarded token from step 4 reaches the IRC directly, so
+per-user authorization applies consistently whether Trino talks to Gravitino's native API or
+straight to the IRC. Without them, the REST catalog keeps its own default security setting,
+independent of `gravitino.client.session.forwardUser`.
+
+## Notes
 
 - The Gravitino server must be configured with the corresponding authentication mechanism enabled.
 - For OAuth2 authentication, ensure the OAuth2 server is accessible from the Trino coordinator and workers.
 - For Kerberos authentication, ensure the Kerberos configuration is properly set up on all Trino nodes.
 - Authentication configuration is passed through the `gravitino.client.*` prefix to the underlying Gravitino Java client.
 
-### See Also
+## See Also
 
 - [Gravitino Server Authentication Configuration](../security/how-to-authenticate.md)
 - [How to use the built-in IDP](../security/how-to-use-built-in-idp.md)

--- a/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/GravitinoConnector.java
+++ b/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/GravitinoConnector.java
@@ -226,7 +226,13 @@ public class GravitinoConnector implements Connector {
   }
 
   private CatalogConnectorMetadata resolveSessionMetadata(ConnectorSession session) {
-    String credKey = "simple:" + session.getUser();
+    String credKey =
+        catalogConnectorContext
+                .getConfig()
+                .getClientConfig()
+                .getOrDefault(GravitinoAuthProvider.AUTH_TYPE_KEY, "simple")
+            + ":"
+            + session.getUser();
     try {
       return perUserSessionCache.get(
               credKey,
@@ -265,10 +271,11 @@ public class GravitinoConnector implements Connector {
           "gravitino.client.session.forwardUser=true requires gravitino.client.authType to be set");
     }
     GravitinoAuthProvider.AuthType authType = GravitinoAuthProvider.parseAuthType(authTypeStr);
-    if (authType != GravitinoAuthProvider.AuthType.SIMPLE) {
+    if (authType != GravitinoAuthProvider.AuthType.SIMPLE
+        && authType != GravitinoAuthProvider.AuthType.OAUTH2) {
       throw new TrinoException(
           GravitinoErrorCode.GRAVITINO_ILLEGAL_ARGUMENT,
-          "gravitino.client.session.forwardUser=true only supports authType=simple, got: "
+          "gravitino.client.session.forwardUser=true only supports authType=simple or oauth2, got: "
               + authTypeStr);
     }
 

--- a/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/GravitinoConnector.java
+++ b/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/GravitinoConnector.java
@@ -21,10 +21,12 @@ package org.apache.gravitino.trino.connector;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.trino.spi.StandardErrorCode.PERMISSION_DENIED;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.RemovalNotification;
+import com.google.common.util.concurrent.UncheckedExecutionException;
 import io.trino.spi.TrinoException;
 import io.trino.spi.connector.Connector;
 import io.trino.spi.connector.ConnectorAccessControl;
@@ -226,13 +228,13 @@ public class GravitinoConnector implements Connector {
   }
 
   private CatalogConnectorMetadata resolveSessionMetadata(ConnectorSession session) {
-    String credKey =
+    String authType =
         catalogConnectorContext
-                .getConfig()
-                .getClientConfig()
-                .getOrDefault(GravitinoAuthProvider.AUTH_TYPE_KEY, "simple")
-            + ":"
-            + session.getUser();
+            .getConfig()
+            .getClientConfig()
+            .getOrDefault(GravitinoAuthProvider.AUTH_TYPE_KEY, "simple");
+    String token = session.getIdentity().getExtraCredentials().get("token");
+    String credKey = sessionCacheKey(authType, session.getUser(), token);
     try {
       return perUserSessionCache.get(
               credKey,
@@ -246,7 +248,7 @@ public class GravitinoConnector implements Connector {
                     userClient, new CatalogConnectorMetadata(userMetalake, catalogIdentifier));
               })
           .metadata;
-    } catch (ExecutionException e) {
+    } catch (ExecutionException | UncheckedExecutionException e) {
       Throwable cause = e.getCause();
       LOG.warn(
           "Failed to create per-user Gravitino client for user '{}': {}",
@@ -260,6 +262,13 @@ public class GravitinoConnector implements Connector {
               + cause.getMessage(),
           cause);
     }
+  }
+
+  @VisibleForTesting
+  static String sessionCacheKey(String authType, String user, String token) {
+    String tokenPart =
+        StringUtils.isBlank(token) ? "" : ":" + Integer.toHexString(token.hashCode());
+    return authType + ":" + user + tokenPart;
   }
 
   private Cache<String, UserSession> buildSessionCache(GravitinoConfig config) {

--- a/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/catalog/iceberg/IcebergCatalogPropertyConverter.java
+++ b/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/catalog/iceberg/IcebergCatalogPropertyConverter.java
@@ -161,9 +161,19 @@ public class IcebergCatalogPropertyConverter extends CatalogPropertyConverter {
           "Missing required property for Rest backend: " + missingProperty);
     }
 
-    Map<String, String> jdbcProperties = new HashMap<>();
-    jdbcProperties.put("iceberg.catalog.type", "rest");
-    jdbcProperties.put("iceberg.rest-catalog.uri", properties.get(IcebergConstants.URI));
-    return jdbcProperties;
+    Map<String, String> restProperties = new HashMap<>();
+    restProperties.put("iceberg.catalog.type", "rest");
+    restProperties.put("iceberg.rest-catalog.uri", properties.get(IcebergConstants.URI));
+    if (properties.containsKey(IcebergConstants.WAREHOUSE)) {
+      restProperties.put(
+          "iceberg.rest-catalog.warehouse", properties.get(IcebergConstants.WAREHOUSE));
+    }
+    // Forward the end-user IdP token to the IRC for per-user authorization. The patched
+    // Trino captures the user token into the session and TrinoRestCatalog forwards it as-is
+    // when session security is USER. Bootstrap credential, server-uri, scope, and S3 config
+    // are supplied through the catalog's trino.bypass.* properties.
+    restProperties.put("iceberg.rest-catalog.security", "OAUTH2");
+    restProperties.put("iceberg.rest-catalog.session", "USER");
+    return restProperties;
   }
 }

--- a/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/catalog/iceberg/IcebergCatalogPropertyConverter.java
+++ b/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/catalog/iceberg/IcebergCatalogPropertyConverter.java
@@ -168,12 +168,6 @@ public class IcebergCatalogPropertyConverter extends CatalogPropertyConverter {
       restProperties.put(
           "iceberg.rest-catalog.warehouse", properties.get(IcebergConstants.WAREHOUSE));
     }
-    // Forward the end-user IdP token to the IRC for per-user authorization. The patched
-    // Trino captures the user token into the session and TrinoRestCatalog forwards it as-is
-    // when session security is USER. Bootstrap credential, server-uri, scope, and S3 config
-    // are supplied through the catalog's trino.bypass.* properties.
-    restProperties.put("iceberg.rest-catalog.security", "OAUTH2");
-    restProperties.put("iceberg.rest-catalog.session", "USER");
     return restProperties;
   }
 }

--- a/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/security/GravitinoAuthProvider.java
+++ b/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/security/GravitinoAuthProvider.java
@@ -165,8 +165,10 @@ public class GravitinoAuthProvider {
    * connector session. This is the entry point for the per-user client cache when {@code
    * forwardUser=true}.
    *
-   * <p>Currently only {@code authType=simple} is supported: the Trino session username is used as
-   * the Gravitino simple-auth identity.
+   * <p>For {@code authType=simple} the Trino session username is used as the Gravitino simple-auth
+   * identity. For {@code authType=oauth2} the end-user IdP token forwarded into the connector
+   * session (extra-credential key {@code token}) is presented to Gravitino as the bearer token, so
+   * the server authorizes against the end user rather than a shared service identity.
    *
    * @param config the Gravitino connector configuration
    * @param session the current Trino connector session
@@ -196,13 +198,29 @@ public class GravitinoAuthProvider {
 
     GravitinoAdminClient.AdminClientBuilder builder = GravitinoAdminClient.builder(uri);
 
-    if (authType != AuthType.SIMPLE) {
-      throw new UnsupportedOperationException(
-          "Auth type "
-              + authType
-              + " does not support session forwarding. Only simple is supported.");
+    switch (authType) {
+      case SIMPLE:
+        builder.withSimpleAuth(session.getUser());
+        break;
+      case OAUTH2:
+        {
+          String userToken = session.getIdentity().getExtraCredentials().get("token");
+          if (StringUtils.isBlank(userToken)) {
+            throw new IllegalArgumentException(
+                "No forwarded user token found in session extra-credentials under key 'token'. "
+                    + "Ensure Trino is configured with "
+                    + "http-server.authentication.oauth2.forward-token-to-connectors=true and the "
+                    + "patched OAuth2Authenticator that injects the user token is in use.");
+          }
+          builder.withOAuth(new StaticUserTokenProvider(userToken));
+        }
+        break;
+      default:
+        throw new UnsupportedOperationException(
+            "Auth type "
+                + authType
+                + " does not support session forwarding. Only simple and oauth2 are supported.");
     }
-    builder.withSimpleAuth(session.getUser());
 
     removeAuthSpecificKeys(clientConfig);
     builder.withClientConfig(clientConfig);

--- a/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/security/StaticUserTokenProvider.java
+++ b/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/security/StaticUserTokenProvider.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.trino.connector.security;
+
+import org.apache.gravitino.client.OAuth2TokenProvider;
+
+/**
+ * An {@link OAuth2TokenProvider} that returns a pre-fetched, already-valid access token rather than
+ * minting one via client credentials. Used for per-user session forwarding: the end user's IdP
+ * access token, forwarded by Trino into the connector session, is presented directly to Gravitino
+ * so the server authorizes against the end user's identity instead of a shared service identity.
+ *
+ * <p>The raw token is returned from {@link #getAccessToken()}. The {@code Bearer } prefix is added
+ * by {@link OAuth2TokenProvider#getTokenData()}, so the token held here must not include it.
+ */
+public final class StaticUserTokenProvider extends OAuth2TokenProvider {
+
+  private final String accessToken;
+
+  /**
+   * Constructs a provider that always returns the given access token.
+   *
+   * @param accessToken the raw bearer token (without the {@code Bearer } prefix) to present to
+   *     Gravitino
+   */
+  public StaticUserTokenProvider(String accessToken) {
+    this.accessToken = accessToken;
+  }
+
+  @Override
+  protected String getAccessToken() {
+    return accessToken;
+  }
+}

--- a/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/security/StaticUserTokenProvider.java
+++ b/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/security/StaticUserTokenProvider.java
@@ -18,6 +18,8 @@
  */
 package org.apache.gravitino.trino.connector.security;
 
+import com.google.common.base.Preconditions;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.gravitino.client.OAuth2TokenProvider;
 
 /**
@@ -40,6 +42,8 @@ public final class StaticUserTokenProvider extends OAuth2TokenProvider {
    *     Gravitino
    */
   public StaticUserTokenProvider(String accessToken) {
+    Preconditions.checkArgument(
+        StringUtils.isNotBlank(accessToken), "accessToken must not be blank");
     this.accessToken = accessToken;
   }
 

--- a/trino-connector/trino-connector/src/test/java/org/apache/gravitino/trino/connector/TestGravitinoConnectorForwardUser.java
+++ b/trino-connector/trino-connector/src/test/java/org/apache/gravitino/trino/connector/TestGravitinoConnectorForwardUser.java
@@ -20,6 +20,7 @@ package org.apache.gravitino.trino.connector;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -88,6 +89,41 @@ class TestGravitinoConnectorForwardUser {
   void testForwardUserFalseWithNoAuthTypeSucceeds() {
     CatalogConnectorContext ctx = mockContextWithConfig(ImmutableMap.of());
     assertDoesNotThrow(() -> new GravitinoConnector(ctx));
+  }
+
+  @Test
+  void testSessionCacheKeyIsolatesDifferentUsers() {
+    assertNotEquals(
+        GravitinoConnector.sessionCacheKey("oauth2", "alice", "tok"),
+        GravitinoConnector.sessionCacheKey("oauth2", "bob", "tok"));
+  }
+
+  @Test
+  void testSessionCacheKeyIsolatesDifferentAuthTypes() {
+    assertNotEquals(
+        GravitinoConnector.sessionCacheKey("oauth2", "alice", "tok"),
+        GravitinoConnector.sessionCacheKey("simple", "alice", "tok"));
+  }
+
+  @Test
+  void testSessionCacheKeyIsolatesDifferentTokens() {
+    assertNotEquals(
+        GravitinoConnector.sessionCacheKey("oauth2", "alice", "token-a"),
+        GravitinoConnector.sessionCacheKey("oauth2", "alice", "token-b"));
+  }
+
+  @Test
+  void testSessionCacheKeyIsStableForSameUserAuthTypeAndToken() {
+    assertEquals(
+        GravitinoConnector.sessionCacheKey("oauth2", "alice", "tok"),
+        GravitinoConnector.sessionCacheKey("oauth2", "alice", "tok"));
+  }
+
+  @Test
+  void testSessionCacheKeyIgnoresBlankTokenForSimpleAuth() {
+    assertEquals(
+        GravitinoConnector.sessionCacheKey("simple", "alice", null),
+        GravitinoConnector.sessionCacheKey("simple", "alice", ""));
   }
 
   private static CatalogConnectorContext mockContextWithConfig(

--- a/trino-connector/trino-connector/src/test/java/org/apache/gravitino/trino/connector/TestGravitinoConnectorForwardUser.java
+++ b/trino-connector/trino-connector/src/test/java/org/apache/gravitino/trino/connector/TestGravitinoConnectorForwardUser.java
@@ -63,15 +63,14 @@ class TestGravitinoConnectorForwardUser {
   }
 
   @Test
-  void testForwardUserWithOAuth2AuthTypeThrowsAtConstruction() {
+  void testForwardUserWithOAuth2AuthTypeSucceeds() {
     CatalogConnectorContext ctx =
         mockContextWithConfig(
             ImmutableMap.of(
                 GravitinoAuthProvider.FORWARD_SESSION_USER_KEY, "true",
                 GravitinoAuthProvider.AUTH_TYPE_KEY, "oauth2"));
 
-    TrinoException ex = assertThrows(TrinoException.class, () -> new GravitinoConnector(ctx));
-    assertEquals(GravitinoErrorCode.GRAVITINO_ILLEGAL_ARGUMENT.toErrorCode(), ex.getErrorCode());
+    assertDoesNotThrow(() -> new GravitinoConnector(ctx));
   }
 
   @Test

--- a/trino-connector/trino-connector/src/test/java/org/apache/gravitino/trino/connector/catalog/iceberg/TestIcebergCatalogPropertyConverter.java
+++ b/trino-connector/trino-connector/src/test/java/org/apache/gravitino/trino/connector/catalog/iceberg/TestIcebergCatalogPropertyConverter.java
@@ -58,6 +58,33 @@ public class TestIcebergCatalogPropertyConverter {
   }
 
   @Test
+  public void testRestBackendProperty() {
+    PropertyConverter propertyConverter = new IcebergCatalogPropertyConverter();
+    Map<String, String> gravitinoIcebergConfig =
+        ImmutableMap.<String, String>builder()
+            .put("uri", "http://localhost:9001/iceberg")
+            .put("catalog-backend", "rest")
+            .put("warehouse", "gt_iceberg_rest")
+            .build();
+    Map<String, String> restBackendConfig =
+        propertyConverter.gravitinoToEngineProperties(gravitinoIcebergConfig);
+
+    Assertions.assertEquals(restBackendConfig.get("iceberg.catalog.type"), "rest");
+    Assertions.assertEquals(
+        restBackendConfig.get("iceberg.rest-catalog.uri"), "http://localhost:9001/iceberg");
+    Assertions.assertEquals(
+        restBackendConfig.get("iceberg.rest-catalog.warehouse"), "gt_iceberg_rest");
+
+    Map<String, String> wrongMap = Maps.newHashMap(gravitinoIcebergConfig);
+    wrongMap.remove("uri");
+
+    Assertions.assertThrows(
+        TrinoException.class,
+        () -> propertyConverter.gravitinoToEngineProperties(wrongMap),
+        "Missing required property for Rest backend: [uri]");
+  }
+
+  @Test
   public void testJDBCBackendProperty() {
     PropertyConverter propertyConverter = new IcebergCatalogPropertyConverter();
     Map<String, String> gravitinoIcebergConfig =

--- a/trino-connector/trino-connector/src/test/java/org/apache/gravitino/trino/connector/security/TestGravitinoAuthProvider.java
+++ b/trino-connector/trino-connector/src/test/java/org/apache/gravitino/trino/connector/security/TestGravitinoAuthProvider.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableMap;
 import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.security.ConnectorIdentity;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -256,6 +257,43 @@ public class TestGravitinoAuthProvider {
 
     assertThrows(
         UnsupportedOperationException.class,
+        () -> GravitinoAuthProvider.buildForSession(config, session));
+  }
+
+  @Test
+  public void testBuildForSessionOAuth2WithForwardedToken() {
+    GravitinoConfig config =
+        buildConfig(
+            ImmutableMap.of(
+                GravitinoAuthProvider.AUTH_TYPE_KEY, "oauth2",
+                GravitinoAuthProvider.FORWARD_SESSION_USER_KEY, "true"));
+
+    ConnectorSession session = mock(ConnectorSession.class);
+    ConnectorIdentity identity = mock(ConnectorIdentity.class);
+    when(session.getUser()).thenReturn("alice");
+    when(session.getIdentity()).thenReturn(identity);
+    when(identity.getExtraCredentials()).thenReturn(ImmutableMap.of("token", "alice-jwt"));
+
+    GravitinoAdminClient client = GravitinoAuthProvider.buildForSession(config, session);
+    assertNotNull(client);
+  }
+
+  @Test
+  public void testBuildForSessionOAuth2ThrowsWhenTokenMissing() {
+    GravitinoConfig config =
+        buildConfig(
+            ImmutableMap.of(
+                GravitinoAuthProvider.AUTH_TYPE_KEY, "oauth2",
+                GravitinoAuthProvider.FORWARD_SESSION_USER_KEY, "true"));
+
+    ConnectorSession session = mock(ConnectorSession.class);
+    ConnectorIdentity identity = mock(ConnectorIdentity.class);
+    when(session.getUser()).thenReturn("alice");
+    when(session.getIdentity()).thenReturn(identity);
+    when(identity.getExtraCredentials()).thenReturn(ImmutableMap.of());
+
+    assertThrows(
+        IllegalArgumentException.class,
         () -> GravitinoAuthProvider.buildForSession(config, session));
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add `authType=oauth2` support to `forwardUser=true` session forwarding. The connector
now reads the end-user token forwarded by Trino into session extra-credentials and
uses it to build a per-user Gravitino client, instead of only trusting the username via
`authType=simple`. REST-backed Iceberg catalogs also get per-user forwarding to the
Iceberg REST catalog (IRC).

### Why are the changes needed?

`forwardUser=true` only supported `authType=simple`, which isn't enough for
deployments that need real per-user authorization.

Fix: #12021

### Does this PR introduce any user-facing change?

`gravitino.client.session.forwardUser=true` now also works with `authType=oauth2`.

### How was this patch tested?

New/updated unit tests, plus manual end-to-end verification against a local Keycloak +
Gravitino (OAuth2) + Iceberg REST catalog setup.