### PR TITLE
[MINOR] chore: Add nevzheng as GitHub triage collaborator

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -62,6 +62,7 @@ github:
     - markhoerth
     - danhuawang
     - lasdf1234
+    - nevzheng
 
 notifications:
   commits: commits@gravitino.apache.org


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add `nevzheng` to the `github.collaborators` section of `.asf.yaml`.

For Apache repositories, external collaborators listed in this section receive the GitHub Triage role. This role permits issue and pull-request management without granting write access to the code.

This PR is intentionally being opened as a draft while the community discusses and records the required approval.

### Why are the changes needed?

This change would allow `nevzheng` to help organize the Gravitino contribution workflow by:

- Triaging and labeling issues and pull requests.
- Assigning issues and pull requests.
- Applying milestones.
- Requesting pull-request reviews.
- Helping route contributions to the appropriate reviewers.

These permissions would make PR responsibilities clearer and allow review work to be coordinated through GitHub.

The Apache GitHub Triage role is documented here:

https://infra.apache.org/github-roles.html

Approval discussion: #12027

This PR should remain a draft and should not be merged until the required project approval is recorded.

Fix: #12027

### Does this PR introduce _any_ user-facing change?

No. This only updates repository collaboration permissions and does not change Gravitino code, APIs, or configuration exposed to users.

### How was this patch tested?

Validated that `.asf.yaml` remains valid YAML and that the patch passes `git diff --check`.
