### PR TITLE
[MINOR] test(client-python): Fix API unit test discovery

### DIFF
--- a/clients/client-python/tests/unittests/api/__init__.py
+++ b/clients/client-python/tests/unittests/api/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/clients/client-python/tests/unittests/api/stats/test_supports_statistics.py
+++ b/clients/client-python/tests/unittests/api/stats/test_supports_statistics.py
@@ -41,8 +41,11 @@ class TestSupportsStatistics(unittest.TestCase):
         """Test that a concrete implementation can be created."""
 
         class ConcreteStatisticValue(StatisticValue[int]):
+            def __init__(self, value: int = 50):
+                self._value = value
+
             def value(self) -> int:
-                return 50
+                return self._value
 
             def data_type(self) -> Types.IntegerType:
                 return Types.IntegerType.get()
@@ -69,9 +72,7 @@ class TestSupportsStatistics(unittest.TestCase):
                 return self._name
 
             def value(self) -> StatisticValue[int] | None:
-                val = ConcreteStatisticValue()
-                val._val = self._value  # pylint: disable=protected-access
-                return val
+                return ConcreteStatisticValue(self._value)
 
             def reserved(self) -> bool:
                 return False

--- a/clients/client-python/tests/unittests/api/tag/__init__.py
+++ b/clients/client-python/tests/unittests/api/tag/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add the missing Python package markers under the API unit test directories so that `unittest` can discover and execute those tests.

Also fix a pylint issue exposed after the API tests are included in the default test run.

### Why are the changes needed?

Without the package markers, Python's unittest discovery does not recurse into the API test directories, causing existing API unit tests to be skipped.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

The Python client formatting, lint, and unit test checks passed. The default unit test task now discovers and runs the API unit tests.