### PR TITLE
[MINOR] improvement(cache): Add logs for Caffeine cache removals

### DIFF
--- a/catalogs/catalog-fileset/src/main/java/org/apache/gravitino/catalog/fileset/FilesetCatalogOperations.java
+++ b/catalogs/catalog-fileset/src/main/java/org/apache/gravitino/catalog/fileset/FilesetCatalogOperations.java
@@ -282,7 +282,7 @@ public class FilesetCatalogOperations extends ManagedSchemaOperations
               .removalListener(
                   (key, value, cause) -> {
                     FileSystemCacheKey cacheKey = (FileSystemCacheKey) key;
-                    LOG.info(
+                    LOG.debug(
                         "Removing FileSystem from cache: scheme={}, authority={}, user={}, cause={}",
                         cacheKey == null ? null : cacheKey.scheme,
                         cacheKey == null ? null : cacheKey.authority,

--- a/catalogs/catalog-fileset/src/main/java/org/apache/gravitino/catalog/fileset/FilesetCatalogOperations.java
+++ b/catalogs/catalog-fileset/src/main/java/org/apache/gravitino/catalog/fileset/FilesetCatalogOperations.java
@@ -280,7 +280,14 @@ public class FilesetCatalogOperations extends ManagedSchemaOperations
           Caffeine.newBuilder()
               .expireAfterAccess(1, TimeUnit.HOURS)
               .removalListener(
-                  (ignored, value, cause) -> {
+                  (key, value, cause) -> {
+                    FileSystemCacheKey cacheKey = (FileSystemCacheKey) key;
+                    LOG.debug(
+                        "Removing FileSystem from cache: scheme={}, authority={}, user={}, cause={}",
+                        cacheKey == null ? null : cacheKey.scheme,
+                        cacheKey == null ? null : cacheKey.authority,
+                        cacheKey == null ? null : cacheKey.currentUser,
+                        cause);
                     try {
                       ((FileSystem) value).close();
                     } catch (IOException e) {

--- a/catalogs/catalog-fileset/src/main/java/org/apache/gravitino/catalog/fileset/FilesetCatalogOperations.java
+++ b/catalogs/catalog-fileset/src/main/java/org/apache/gravitino/catalog/fileset/FilesetCatalogOperations.java
@@ -282,7 +282,7 @@ public class FilesetCatalogOperations extends ManagedSchemaOperations
               .removalListener(
                   (key, value, cause) -> {
                     FileSystemCacheKey cacheKey = (FileSystemCacheKey) key;
-                    LOG.debug(
+                    LOG.info(
                         "Removing FileSystem from cache: scheme={}, authority={}, user={}, cause={}",
                         cacheKey == null ? null : cacheKey.scheme,
                         cacheKey == null ? null : cacheKey.authority,

--- a/catalogs/hive-metastore-common/src/main/java/org/apache/gravitino/hive/CachedClientPool.java
+++ b/catalogs/hive-metastore-common/src/main/java/org/apache/gravitino/hive/CachedClientPool.java
@@ -82,7 +82,7 @@ public class CachedClientPool implements ClientPool<HiveClient, GravitinoRuntime
             .expireAfterAccess(evictionInterval, TimeUnit.MILLISECONDS)
             .removalListener(
                 (key, value, cause) -> {
-                  LOG.info("Removing HiveClientPool from cache: key={}, cause={}", key, cause);
+                  LOG.debug("Removing HiveClientPool from cache: key={}, cause={}", key, cause);
                   ((HiveClientPool) value).close();
                 })
             .scheduler(Scheduler.forScheduledExecutorService(scheduler))

--- a/catalogs/hive-metastore-common/src/main/java/org/apache/gravitino/hive/CachedClientPool.java
+++ b/catalogs/hive-metastore-common/src/main/java/org/apache/gravitino/hive/CachedClientPool.java
@@ -37,6 +37,8 @@ import org.apache.gravitino.hive.client.HiveClient;
 import org.apache.gravitino.utils.ClientPool;
 import org.apache.gravitino.utils.PrincipalUtils;
 import org.immutables.value.Value;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Referred from Apache Iceberg's CachedClientPool implementation
@@ -49,6 +51,8 @@ import org.immutables.value.Value;
  * <p>A ClientPool that caches the underlying HiveClientPool instances.
  */
 public class CachedClientPool implements ClientPool<HiveClient, GravitinoRuntimeException> {
+  private static final Logger LOG = LoggerFactory.getLogger(CachedClientPool.class);
+
   private static final ClientPropertiesMetadata PROPERTIES_METADATA =
       new ClientPropertiesMetadata();
 
@@ -76,7 +80,11 @@ public class CachedClientPool implements ClientPool<HiveClient, GravitinoRuntime
     this.clientPoolCache =
         Caffeine.newBuilder()
             .expireAfterAccess(evictionInterval, TimeUnit.MILLISECONDS)
-            .removalListener((ignored, value, cause) -> ((HiveClientPool) value).close())
+            .removalListener(
+                (key, value, cause) -> {
+                  LOG.info("Removing HiveClientPool from cache: key={}, cause={}", key, cause);
+                  ((HiveClientPool) value).close();
+                })
             .scheduler(Scheduler.forScheduledExecutorService(scheduler))
             .build();
   }

--- a/clients/filesystem-hadoop3/src/main/java/org/apache/gravitino/filesystem/hadoop/BaseGVFSOperations.java
+++ b/clients/filesystem-hadoop3/src/main/java/org/apache/gravitino/filesystem/hadoop/BaseGVFSOperations.java
@@ -925,6 +925,17 @@ public abstract class BaseGVFSOperations implements Closeable {
                         1, newDaemonThreadFactory("gvfs-filesystem-cache-cleaner"))))
             .removalListener(
                 (key, value, cause) -> {
+                  FileSystemCacheKey cacheKey = (FileSystemCacheKey) key;
+                  String user =
+                      cacheKey == null || cacheKey.ugi() == null
+                          ? null
+                          : cacheKey.ugi().getUserName();
+                  LOG.debug(
+                      "Removing FileSystem from cache: scheme={}, authority={}, user={}, cause={}",
+                      cacheKey == null ? null : cacheKey.scheme(),
+                      cacheKey == null ? null : cacheKey.authority(),
+                      user,
+                      cause);
                   if (closeOnEviction) {
                     FileSystem fs = (FileSystem) value;
                     if (fs != null) {
@@ -933,13 +944,18 @@ public abstract class BaseGVFSOperations implements Closeable {
                       try {
                         fs.close();
                       } catch (IOException e) {
-                        LOG.error("Cannot close the file system for fileset: {}", key, e);
+                        LOG.error(
+                            "Failed to close cached FileSystem: scheme={}, authority={}, user={}, cause={}",
+                            cacheKey == null ? null : cacheKey.scheme(),
+                            cacheKey == null ? null : cacheKey.authority(),
+                            user,
+                            cause,
+                            e);
                       }
                     }
                     return;
                   }
                   // Default: do not close on eviction; close is deferred to GVFS shutdown.
-                  LOG.debug("FileSystem evicted from cache (key={}, cause={})", key, cause);
                 });
     cacheBuilder.expireAfterAccess(evictionMillsAfterAccess, TimeUnit.MILLISECONDS);
     return cacheBuilder.build();

--- a/clients/filesystem-hadoop3/src/main/java/org/apache/gravitino/filesystem/hadoop/BaseGVFSOperations.java
+++ b/clients/filesystem-hadoop3/src/main/java/org/apache/gravitino/filesystem/hadoop/BaseGVFSOperations.java
@@ -930,7 +930,7 @@ public abstract class BaseGVFSOperations implements Closeable {
                       cacheKey == null || cacheKey.ugi() == null
                           ? null
                           : cacheKey.ugi().getUserName();
-                  LOG.info(
+                  LOG.debug(
                       "Removing FileSystem from cache: scheme={}, authority={}, user={}, cause={}",
                       cacheKey == null ? null : cacheKey.scheme(),
                       cacheKey == null ? null : cacheKey.authority(),

--- a/clients/filesystem-hadoop3/src/main/java/org/apache/gravitino/filesystem/hadoop/BaseGVFSOperations.java
+++ b/clients/filesystem-hadoop3/src/main/java/org/apache/gravitino/filesystem/hadoop/BaseGVFSOperations.java
@@ -930,7 +930,7 @@ public abstract class BaseGVFSOperations implements Closeable {
                       cacheKey == null || cacheKey.ugi() == null
                           ? null
                           : cacheKey.ugi().getUserName();
-                  LOG.debug(
+                  LOG.info(
                       "Removing FileSystem from cache: scheme={}, authority={}, user={}, cause={}",
                       cacheKey == null ? null : cacheKey.scheme(),
                       cacheKey == null ? null : cacheKey.authority(),

--- a/core/src/main/java/org/apache/gravitino/cache/CaffeineEntityCache.java
+++ b/core/src/main/java/org/apache/gravitino/cache/CaffeineEntityCache.java
@@ -127,6 +127,7 @@ public class CaffeineEntityCache extends BaseEntityCache {
         .executor(CLEANUP_EXECUTOR)
         .removalListener(
             (key, value, cause) -> {
+              LOG.debug("Removed entity cache entry, key={}, cause={}", key, cause);
               if (cause == RemovalCause.EXPLICIT || cause == RemovalCause.REPLACED) {
                 return;
               }
@@ -134,9 +135,8 @@ public class CaffeineEntityCache extends BaseEntityCache {
                 invalidateExpiredItem(key);
               } catch (Throwable t) {
                 LOG.error(
-                    "Failed to remove entity key={} value={} from cache asynchronously, cause={}",
+                    "Failed to remove entity key={} from cache asynchronously, cause={}",
                     key,
-                    value,
                     cause,
                     t);
               }

--- a/core/src/main/java/org/apache/gravitino/cache/CaffeineEntityCache.java
+++ b/core/src/main/java/org/apache/gravitino/cache/CaffeineEntityCache.java
@@ -127,7 +127,7 @@ public class CaffeineEntityCache extends BaseEntityCache {
         .executor(CLEANUP_EXECUTOR)
         .removalListener(
             (key, value, cause) -> {
-              LOG.debug("Removed entity cache entry, key={}, cause={}", key, cause);
+              LOG.info("Removed entity cache entry, key={}, cause={}", key, cause);
               if (cause == RemovalCause.EXPLICIT || cause == RemovalCause.REPLACED) {
                 return;
               }

--- a/core/src/main/java/org/apache/gravitino/cache/CaffeineEntityCache.java
+++ b/core/src/main/java/org/apache/gravitino/cache/CaffeineEntityCache.java
@@ -127,7 +127,7 @@ public class CaffeineEntityCache extends BaseEntityCache {
         .executor(CLEANUP_EXECUTOR)
         .removalListener(
             (key, value, cause) -> {
-              LOG.info("Removed entity cache entry, key={}, cause={}", key, cause);
+              LOG.debug("Removed entity cache entry, key={}, cause={}", key, cause);
               if (cause == RemovalCause.EXPLICIT || cause == RemovalCause.REPLACED) {
                 return;
               }

--- a/core/src/main/java/org/apache/gravitino/catalog/CatalogManager.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/CatalogManager.java
@@ -324,12 +324,12 @@ public class CatalogManager implements CatalogDispatcher, Closeable {
             .expireAfterAccess(cacheEvictionIntervalInMs, TimeUnit.MILLISECONDS)
             .removalListener(
                 (k, v, c) -> {
+                  LOG.info("Removed catalog cache entry, identifier={}, cause={}", k, c);
                   for (Consumer<NameIdentifier> listener : removalListeners) {
                     if (k != null) {
                       listener.accept((NameIdentifier) k);
                     }
                   }
-                  LOG.info("Closing catalog {}.", k);
                   ((CatalogWrapper) v).close();
                 })
             .scheduler(

--- a/core/src/main/java/org/apache/gravitino/catalog/CatalogManager.java
+++ b/core/src/main/java/org/apache/gravitino/catalog/CatalogManager.java
@@ -324,7 +324,7 @@ public class CatalogManager implements CatalogDispatcher, Closeable {
             .expireAfterAccess(cacheEvictionIntervalInMs, TimeUnit.MILLISECONDS)
             .removalListener(
                 (k, v, c) -> {
-                  LOG.info("Removed catalog cache entry, identifier={}, cause={}", k, c);
+                  LOG.debug("Removed catalog cache entry, identifier={}, cause={}", k, c);
                   for (Consumer<NameIdentifier> listener : removalListeners) {
                     if (k != null) {
                       listener.accept((NameIdentifier) k);

--- a/core/src/main/java/org/apache/gravitino/credential/CredentialCache.java
+++ b/core/src/main/java/org/apache/gravitino/credential/CredentialCache.java
@@ -90,8 +90,9 @@ public class CredentialCache<T> implements Closeable {
             .expireAfter(new CredentialExpireTimeCalculator(cacheExpireRatio))
             .maximumSize(cacheSize)
             .removalListener(
-                (cacheKey, credential, c) ->
-                    LOG.debug("Credential expire, cache key: {}.", cacheKey))
+                (cacheKey, credential, cause) ->
+                    LOG.debug(
+                        "Removed credential cache entry, cacheKey={}, cause={}", cacheKey, cause))
             .build();
   }
 

--- a/core/src/main/java/org/apache/gravitino/credential/CredentialCache.java
+++ b/core/src/main/java/org/apache/gravitino/credential/CredentialCache.java
@@ -91,7 +91,7 @@ public class CredentialCache<T> implements Closeable {
             .maximumSize(cacheSize)
             .removalListener(
                 (cacheKey, credential, cause) ->
-                    LOG.debug(
+                    LOG.info(
                         "Removed credential cache entry, cacheKey={}, cause={}", cacheKey, cause))
             .build();
   }

--- a/core/src/main/java/org/apache/gravitino/credential/CredentialCache.java
+++ b/core/src/main/java/org/apache/gravitino/credential/CredentialCache.java
@@ -91,7 +91,7 @@ public class CredentialCache<T> implements Closeable {
             .maximumSize(cacheSize)
             .removalListener(
                 (cacheKey, credential, cause) ->
-                    LOG.info(
+                    LOG.debug(
                         "Removed credential cache entry, cacheKey={}, cause={}", cacheKey, cause))
             .build();
   }

--- a/core/src/main/java/org/apache/gravitino/stats/storage/LancePartitionStatisticStorage.java
+++ b/core/src/main/java/org/apache/gravitino/stats/storage/LancePartitionStatisticStorage.java
@@ -208,7 +208,7 @@ public class LancePartitionStatisticStorage implements PartitionStatisticStorage
                   .removalListener(
                       (RemovalListener<Long, DatasetHolder>)
                           (key, value, cause) -> {
-                            LOG.debug(
+                            LOG.info(
                                 "Removed Lance dataset cache entry, tableId={}, cause={}",
                                 key,
                                 cause);

--- a/core/src/main/java/org/apache/gravitino/stats/storage/LancePartitionStatisticStorage.java
+++ b/core/src/main/java/org/apache/gravitino/stats/storage/LancePartitionStatisticStorage.java
@@ -208,7 +208,7 @@ public class LancePartitionStatisticStorage implements PartitionStatisticStorage
                   .removalListener(
                       (RemovalListener<Long, DatasetHolder>)
                           (key, value, cause) -> {
-                            LOG.info(
+                            LOG.debug(
                                 "Removed Lance dataset cache entry, tableId={}, cause={}",
                                 key,
                                 cause);

--- a/core/src/main/java/org/apache/gravitino/stats/storage/LancePartitionStatisticStorage.java
+++ b/core/src/main/java/org/apache/gravitino/stats/storage/LancePartitionStatisticStorage.java
@@ -208,6 +208,10 @@ public class LancePartitionStatisticStorage implements PartitionStatisticStorage
                   .removalListener(
                       (RemovalListener<Long, DatasetHolder>)
                           (key, value, cause) -> {
+                            LOG.debug(
+                                "Removed Lance dataset cache entry, tableId={}, cause={}",
+                                key,
+                                cause);
                             if (value != null && cause != RemovalCause.EXPLICIT) {
                               closeDatasetHolder(value);
                             }

--- a/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/utils/IcebergHiveCachedClientPool.java
+++ b/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/utils/IcebergHiveCachedClientPool.java
@@ -132,7 +132,7 @@ public class IcebergHiveCachedClientPool
               .removalListener(
                   (key, value, cause) -> {
                     Key cacheKey = (Key) key;
-                    LOG.info(
+                    LOG.debug(
                         "Removing HiveClientPool from cache: key={}, cause={}",
                         cacheKey == null ? null : cacheKey.elements(),
                         cause);

--- a/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/utils/IcebergHiveCachedClientPool.java
+++ b/iceberg/iceberg-common/src/main/java/org/apache/gravitino/iceberg/common/utils/IcebergHiveCachedClientPool.java
@@ -131,12 +131,13 @@ public class IcebergHiveCachedClientPool
               .expireAfterAccess(evictionInterval, TimeUnit.MILLISECONDS)
               .removalListener(
                   (key, value, cause) -> {
+                    Key cacheKey = (Key) key;
+                    LOG.info(
+                        "Removing HiveClientPool from cache: key={}, cause={}",
+                        cacheKey == null ? null : cacheKey.elements(),
+                        cause);
                     HiveClientPool hiveClientPool = (HiveClientPool) value;
                     if (hiveClientPool != null) {
-                      LOG.info(
-                          "Removing an expired HiveClientPool instance: {} for Key: {}",
-                          hiveClientPool,
-                          key);
                       hiveClientPool.close();
                     }
                   })

--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/IcebergCatalogWrapperManager.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/IcebergCatalogWrapperManager.java
@@ -65,7 +65,10 @@ public class IcebergCatalogWrapperManager implements AutoCloseable {
             .removalListener(
                 (k, v, c) -> {
                   String catalogName = (String) k;
-                  LOG.info("Remove IcebergCatalogWrapper cache {}.", catalogName);
+                  LOG.info(
+                      "Removing IcebergCatalogWrapper from cache: catalog={}, cause={}",
+                      catalogName,
+                      c);
                   closeIcebergCatalogWrapper((IcebergCatalogWrapper) v);
                 })
             .scheduler(

--- a/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/IcebergCatalogWrapperManager.java
+++ b/iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/service/IcebergCatalogWrapperManager.java
@@ -65,7 +65,7 @@ public class IcebergCatalogWrapperManager implements AutoCloseable {
             .removalListener(
                 (k, v, c) -> {
                   String catalogName = (String) k;
-                  LOG.info(
+                  LOG.debug(
                       "Removing IcebergCatalogWrapper from cache: catalog={}, cause={}",
                       catalogName,
                       c);

--- a/server-common/src/main/java/org/apache/gravitino/server/authorization/jcasbin/JcasbinLoadedRolesCache.java
+++ b/server-common/src/main/java/org/apache/gravitino/server/authorization/jcasbin/JcasbinLoadedRolesCache.java
@@ -51,7 +51,7 @@ class JcasbinLoadedRolesCache implements GravitinoCache<Long, Long> {
             .executor(Runnable::run)
             .removalListener(
                 (Long roleId, Long value, RemovalCause cause) -> {
-                  LOG.debug(
+                  LOG.info(
                       "Removed JCasbin loaded role cache entry, roleId={}, cause={}",
                       roleId,
                       cause);

--- a/server-common/src/main/java/org/apache/gravitino/server/authorization/jcasbin/JcasbinLoadedRolesCache.java
+++ b/server-common/src/main/java/org/apache/gravitino/server/authorization/jcasbin/JcasbinLoadedRolesCache.java
@@ -25,6 +25,8 @@ import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import org.apache.gravitino.cache.GravitinoCache;
 import org.casbin.jcasbin.main.Enforcer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A {@link GravitinoCache} of {@code roleId -> updated_at} that synchronously deletes the role's
@@ -37,6 +39,8 @@ import org.casbin.jcasbin.main.Enforcer;
  */
 class JcasbinLoadedRolesCache implements GravitinoCache<Long, Long> {
 
+  private static final Logger LOG = LoggerFactory.getLogger(JcasbinLoadedRolesCache.class);
+
   private final Cache<Long, Long> cache;
 
   JcasbinLoadedRolesCache(long ttlMs, long maxSize, Enforcer allowEnforcer, Enforcer denyEnforcer) {
@@ -47,6 +51,10 @@ class JcasbinLoadedRolesCache implements GravitinoCache<Long, Long> {
             .executor(Runnable::run)
             .removalListener(
                 (Long roleId, Long value, RemovalCause cause) -> {
+                  LOG.debug(
+                      "Removed JCasbin loaded role cache entry, roleId={}, cause={}",
+                      roleId,
+                      cause);
                   if (roleId != null && cause != RemovalCause.REPLACED) {
                     allowEnforcer.deleteRole(String.valueOf(roleId));
                     denyEnforcer.deleteRole(String.valueOf(roleId));

--- a/server-common/src/main/java/org/apache/gravitino/server/authorization/jcasbin/JcasbinLoadedRolesCache.java
+++ b/server-common/src/main/java/org/apache/gravitino/server/authorization/jcasbin/JcasbinLoadedRolesCache.java
@@ -51,7 +51,7 @@ class JcasbinLoadedRolesCache implements GravitinoCache<Long, Long> {
             .executor(Runnable::run)
             .removalListener(
                 (Long roleId, Long value, RemovalCause cause) -> {
-                  LOG.info(
+                  LOG.debug(
                       "Removed JCasbin loaded role cache entry, roleId={}, cause={}",
                       roleId,
                       cause);


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add DEBUG-level removal logs to all production Caffeine removal listeners. The logs include cache-specific keys or identifiers and the removal cause, while avoiding cached values that may be sensitive or large.

### Why are the changes needed?

Cache expiration, eviction, replacement, and explicit invalidation were not consistently observable across modules. Consistent DEBUG-level logs make cache lifecycle and resource cleanup easier to diagnose.

Fix: N/A

### Does this PR introduce _any_ user-facing change?

Yes. Cache removal logs now consistently use DEBUG level and include cache keys or identifiers and removal causes. There are no API or configuration changes.

### How was this patch tested?

- Ran `./gradlew spotlessApply`.
- Ran targeted unit tests for the affected core, server-common, catalog-fileset, hive-metastore-common, filesystem-hadoop3, iceberg-common, and iceberg-rest-server modules.
- After standardizing the log level, reran targeted tests for core, server-common, catalog-fileset, and filesystem-hadoop3.
- Attempted `./gradlew test -PskipITs`; an unrelated `TestJDBCBackendBatchGet` PostgreSQL case failed because the container reported `No space left on device`.