### PR TITLE
[#12058] fix(flink): enforce version-aware V3 type compatibility

### DIFF
--- a/docs/flink-connector/flink-connector.md
+++ b/docs/flink-connector/flink-connector.md
@@ -150,12 +150,15 @@ Gravitino flink connector support the following datatype mapping between Flink a
 ### Iceberg V3 type interoperability
 
 The Flink connector either preserves an Iceberg V3 type exactly or rejects it before changing
-catalog metadata. These behaviors apply to the supported Flink 1.18, 1.19, and 1.20 runtimes.
+catalog metadata. Gravitino currently publishes and tests Flink 1.18, 1.19, and 1.20 modules with
+the corresponding [Iceberg dependency pins](https://github.com/apache/gravitino/blob/main/gradle/libs.versions.toml).
+The converter reads the active Flink runtime version so the same conversion methods can enforce
+the correct contract without version-specific copies.
 
-| Gravitino type family                 | Flink behavior |
-|---------------------------------------|----------------|
-| `timestamp(9)`, `timestamp_tz(9)`     | Preserved as `TIMESTAMP(9)` and `TIMESTAMP_LTZ(9)`. Offset-bearing Flink `TIMESTAMP(9) WITH TIME ZONE` is rejected because converting it to `TIMESTAMP_LTZ` would discard its per-value offset semantics. |
-| `variant`                             | Rejected because Flink 1.18–1.20 has no `VARIANT` logical type. |
-| `unknown` (`NullType`)                | Preserved as nullable Flink `NULL`. A non-nullable Unknown column is rejected because `NULL` has no non-null value. |
-| `geometry(crs)`                       | Rejected because Flink 1.18–1.20 has no geometry logical type that preserves CRS metadata. |
-| `geography(crs, algorithm)`           | Rejected because Flink 1.18–1.20 has no geography logical type that preserves CRS and edge-algorithm metadata. |
+| Gravitino type family | Flink behavior | Minimum compatible version | Upstream evidence |
+|-----------------------|----------------|----------------------------|-------------------|
+| `timestamp(9)`, `timestamp_tz(9)` | Flink 1.18 and 1.19 reject precision above 6 because their pinned Iceberg paths can silently convert it to microseconds. Flink 1.20 preserves it as `TIMESTAMP(9)` and `TIMESTAMP_LTZ(9)`. Offset-bearing Flink `TIMESTAMP WITH TIME ZONE` always rejects because `TIMESTAMP_LTZ` would discard its per-value offset. | Flink 1.20 + Iceberg 1.11.0 | [Iceberg nanosecond fix](https://github.com/apache/iceberg/pull/15475), [Flink 1.20 backport](https://github.com/apache/iceberg/pull/16240) |
+| `variant` | Rejects through Flink 1.20. The native `VARIANT` conversion path is enabled when the connector runs with Flink 2.1 or later; a Gravitino Flink 2.1 module is not currently published. | Flink 2.1 + Iceberg 1.11.0 | [Flink 2.1 `VARIANT`](https://nightlies.apache.org/flink/flink-docs-release-2.1/docs/dev/table/types/#variant), [Iceberg integration](https://github.com/apache/iceberg/pull/15265) |
+| nullable `unknown` (`NullType`) | Preserved on the Iceberg-backed schema/load path as nullable Flink `NULL`, backed by Iceberg `UNKNOWN`. A non-nullable Unknown column rejects because `NULL` has no non-null value. Flink `NULL` remains a planning-only type, not general table DDL support. | Flink 1.18 + Iceberg 1.9.0 | [Iceberg 1.18/1.19 support](https://github.com/apache/iceberg/pull/12532), [Iceberg 1.20 support](https://github.com/apache/iceberg/pull/12470), [Flink `NullType` contract](https://github.com/apache/flink/blob/release-2.1/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/NullType.java) |
+| `geometry(crs)` | Rejected because Flink has no native logical type that preserves CRS metadata. | None through released Flink 2.3 | [Flink 2.3 type list](https://nightlies.apache.org/flink/flink-docs-release-2.3/docs/sql/reference/data-types/), [Iceberg geometry contract](https://iceberg.apache.org/spec/#version-3-extended-types-and-capabilities) |
+| `geography(crs, algorithm)` | Rejected because Flink has no native logical type that preserves CRS and edge-algorithm metadata. Upstream support is proposed but not released. | None through released Flink 2.3 | [Flink 2.3 type list](https://nightlies.apache.org/flink/flink-docs-release-2.3/docs/sql/reference/data-types/), [Flink geography proposal](https://issues.apache.org/jira/browse/FLINK-39896), [Iceberg geography contract](https://iceberg.apache.org/spec/#version-3-extended-types-and-capabilities) |

--- a/docs/flink-connector/flink-connector.md
+++ b/docs/flink-connector/flink-connector.md
@@ -146,3 +146,12 @@ Gravitino flink connector support the following datatype mapping between Flink a
 | `tinyint`                        | `byte`                        | 0.6.0-incubating |
 | `varbinary`                      | `binary`                      | 0.6.0-incubating |
 | `varchar`                        | `string`                      | 0.6.0-incubating |
+
+### Iceberg V3 type interoperability
+
+The Flink connector either preserves an Iceberg V3 type exactly or rejects it before changing
+catalog metadata. These behaviors apply to the supported Flink 1.18, 1.19, and 1.20 runtimes.
+
+| Gravitino type family                 | Flink behavior |
+|---------------------------------------|----------------|
+| `timestamp(9)`, `timestamp_tz(9)`     | Preserved as `TIMESTAMP(9)` and `TIMESTAMP_LTZ(9)`. Offset-bearing Flink `TIMESTAMP(9) WITH TIME ZONE` is rejected because converting it to `TIMESTAMP_LTZ` would discard its per-value offset semantics. |

--- a/docs/flink-connector/flink-connector.md
+++ b/docs/flink-connector/flink-connector.md
@@ -157,3 +157,4 @@ catalog metadata. These behaviors apply to the supported Flink 1.18, 1.19, and 1
 | `timestamp(9)`, `timestamp_tz(9)`     | Preserved as `TIMESTAMP(9)` and `TIMESTAMP_LTZ(9)`. Offset-bearing Flink `TIMESTAMP(9) WITH TIME ZONE` is rejected because converting it to `TIMESTAMP_LTZ` would discard its per-value offset semantics. |
 | `variant`                             | Rejected because Flink 1.18–1.20 has no `VARIANT` logical type. |
 | `unknown` (`NullType`)                | Preserved as nullable Flink `NULL`. A non-nullable Unknown column is rejected because `NULL` has no non-null value. |
+| `geometry(crs)`                       | Rejected because Flink 1.18–1.20 has no geometry logical type that preserves CRS metadata. |

--- a/docs/flink-connector/flink-connector.md
+++ b/docs/flink-connector/flink-connector.md
@@ -155,3 +155,4 @@ catalog metadata. These behaviors apply to the supported Flink 1.18, 1.19, and 1
 | Gravitino type family                 | Flink behavior |
 |---------------------------------------|----------------|
 | `timestamp(9)`, `timestamp_tz(9)`     | Preserved as `TIMESTAMP(9)` and `TIMESTAMP_LTZ(9)`. Offset-bearing Flink `TIMESTAMP(9) WITH TIME ZONE` is rejected because converting it to `TIMESTAMP_LTZ` would discard its per-value offset semantics. |
+| `variant`                             | Rejected because Flink 1.18–1.20 has no `VARIANT` logical type. |

--- a/docs/flink-connector/flink-connector.md
+++ b/docs/flink-connector/flink-connector.md
@@ -156,3 +156,4 @@ catalog metadata. These behaviors apply to the supported Flink 1.18, 1.19, and 1
 |---------------------------------------|----------------|
 | `timestamp(9)`, `timestamp_tz(9)`     | Preserved as `TIMESTAMP(9)` and `TIMESTAMP_LTZ(9)`. Offset-bearing Flink `TIMESTAMP(9) WITH TIME ZONE` is rejected because converting it to `TIMESTAMP_LTZ` would discard its per-value offset semantics. |
 | `variant`                             | Rejected because Flink 1.18–1.20 has no `VARIANT` logical type. |
+| `unknown` (`NullType`)                | Preserved as nullable Flink `NULL`. A non-nullable Unknown column is rejected because `NULL` has no non-null value. |

--- a/docs/flink-connector/flink-connector.md
+++ b/docs/flink-connector/flink-connector.md
@@ -158,3 +158,4 @@ catalog metadata. These behaviors apply to the supported Flink 1.18, 1.19, and 1
 | `variant`                             | Rejected because Flink 1.18–1.20 has no `VARIANT` logical type. |
 | `unknown` (`NullType`)                | Preserved as nullable Flink `NULL`. A non-nullable Unknown column is rejected because `NULL` has no non-null value. |
 | `geometry(crs)`                       | Rejected because Flink 1.18–1.20 has no geometry logical type that preserves CRS metadata. |
+| `geography(crs, algorithm)`           | Rejected because Flink 1.18–1.20 has no geography logical type that preserves CRS and edge-algorithm metadata. |

--- a/flink-connector/flink-common/src/main/java/org/apache/gravitino/flink/connector/catalog/BaseCatalog.java
+++ b/flink-connector/flink-common/src/main/java/org/apache/gravitino/flink/connector/catalog/BaseCatalog.java
@@ -98,6 +98,7 @@ import org.apache.gravitino.rel.expressions.sorts.SortOrder;
 import org.apache.gravitino.rel.expressions.transforms.Transform;
 import org.apache.gravitino.rel.indexes.Index;
 import org.apache.gravitino.rel.indexes.Indexes;
+import org.apache.gravitino.rel.types.Types;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -1123,6 +1124,10 @@ public abstract class BaseCatalog extends AbstractCatalog {
     org.apache.flink.table.api.Schema.Builder builder =
         org.apache.flink.table.api.Schema.newBuilder();
     for (Column column : columns) {
+      if (column.dataType() instanceof Types.NullType && !column.nullable()) {
+        throw new IllegalArgumentException(
+            "Flink NULL columns must be nullable because NULL has no non-null value");
+      }
       DataType flinkType = TypeUtils.toFlinkType(column.dataType());
       builder
           .column(column.name(), column.nullable() ? flinkType.nullable() : flinkType.notNull())

--- a/flink-connector/flink-common/src/main/java/org/apache/gravitino/flink/connector/utils/TypeUtils.java
+++ b/flink-connector/flink-common/src/main/java/org/apache/gravitino/flink/connector/utils/TypeUtils.java
@@ -240,6 +240,9 @@ public class TypeUtils {
         return DataTypes.INTERVAL(DataTypes.YEAR());
       case INTERVAL_DAY:
         return DataTypes.INTERVAL(DataTypes.DAY());
+      case VARIANT:
+        throw new IllegalArgumentException(
+            "Flink 1.18-1.20 has no VARIANT logical type for Gravitino variant");
       case EXTERNAL:
         Types.ExternalType externalType = (Types.ExternalType) gravitinoType;
         String catalogString = externalType.catalogString();

--- a/flink-connector/flink-common/src/main/java/org/apache/gravitino/flink/connector/utils/TypeUtils.java
+++ b/flink-connector/flink-common/src/main/java/org/apache/gravitino/flink/connector/utils/TypeUtils.java
@@ -243,6 +243,9 @@ public class TypeUtils {
       case VARIANT:
         throw new IllegalArgumentException(
             "Flink 1.18-1.20 has no VARIANT logical type for Gravitino variant");
+      case GEOMETRY:
+        throw new IllegalArgumentException(
+            "Flink 1.18-1.20 has no geometry logical type that preserves CRS metadata");
       case EXTERNAL:
         Types.ExternalType externalType = (Types.ExternalType) gravitinoType;
         String catalogString = externalType.catalogString();

--- a/flink-connector/flink-common/src/main/java/org/apache/gravitino/flink/connector/utils/TypeUtils.java
+++ b/flink-connector/flink-common/src/main/java/org/apache/gravitino/flink/connector/utils/TypeUtils.java
@@ -246,6 +246,10 @@ public class TypeUtils {
       case GEOMETRY:
         throw new IllegalArgumentException(
             "Flink 1.18-1.20 has no geometry logical type that preserves CRS metadata");
+      case GEOGRAPHY:
+        throw new IllegalArgumentException(
+            "Flink 1.18-1.20 has no geography logical type that preserves CRS and edge algorithm "
+                + "metadata");
       case EXTERNAL:
         Types.ExternalType externalType = (Types.ExternalType) gravitinoType;
         String catalogString = externalType.catalogString();

--- a/flink-connector/flink-common/src/main/java/org/apache/gravitino/flink/connector/utils/TypeUtils.java
+++ b/flink-connector/flink-common/src/main/java/org/apache/gravitino/flink/connector/utils/TypeUtils.java
@@ -22,6 +22,7 @@ package org.apache.gravitino.flink.connector.utils;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.apache.flink.FlinkVersion;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.ArrayType;
@@ -48,7 +49,36 @@ public class TypeUtils {
 
   private TypeUtils() {}
 
+  /**
+   * Converts a Flink logical type to a Gravitino type using the active Flink runtime.
+   *
+   * @param logicalType the Flink logical type
+   * @return the corresponding Gravitino type
+   */
   public static Type toGravitinoType(LogicalType logicalType) {
+    return fromFlinkType(logicalType, FlinkVersion.current().toString());
+  }
+
+  /**
+   * Converts a Flink logical type to a Gravitino type using the active Flink version's
+   * compatibility rules.
+   *
+   * @param logicalType the Flink logical type
+   * @param flinkVersionId the active Flink version ID, such as {@code 1.20}
+   * @return the corresponding Gravitino type
+   */
+  public static Type fromFlinkType(LogicalType logicalType, String flinkVersionId) {
+    if ("VARIANT".equals(logicalType.getTypeRoot().name())) {
+      if (isFlinkVersionBefore(flinkVersionId, 2, 1)) {
+        throw new IllegalArgumentException(
+            "Flink "
+                + flinkVersionId
+                + " has no VARIANT logical type for Gravitino variant; VARIANT requires Flink 2.1 "
+                + "or later");
+      }
+      return Types.VariantType.get();
+    }
+
     switch (logicalType.getTypeRoot()) {
       case VARCHAR:
         return Types.StringType.get();
@@ -86,6 +116,7 @@ public class TypeUtils {
         org.apache.flink.table.types.logical.TimestampType timestampType =
             (org.apache.flink.table.types.logical.TimestampType) logicalType;
         int timestampPrecision = timestampType.getPrecision();
+        validateTimestampPrecisionForVersion(timestampPrecision, flinkVersionId);
         return Types.TimestampType.withoutTimeZone(timestampPrecision);
       case INTERVAL_YEAR_MONTH:
         return Types.IntervalYearType.get();
@@ -97,6 +128,7 @@ public class TypeUtils {
         org.apache.flink.table.types.logical.LocalZonedTimestampType localZonedTimestampType =
             (org.apache.flink.table.types.logical.LocalZonedTimestampType) logicalType;
         int localZonedPrecision = localZonedTimestampType.getPrecision();
+        validateTimestampPrecisionForVersion(localZonedPrecision, flinkVersionId);
         return Types.TimestampType.withTimeZone(localZonedPrecision);
       case TIMESTAMP_WITH_TIME_ZONE:
         throw new IllegalArgumentException(
@@ -105,14 +137,16 @@ public class TypeUtils {
       case ARRAY:
         ArrayType arrayType = (ArrayType) logicalType;
         LogicalType elementLogicalType = arrayType.getElementType();
-        Type elementType = toGravitinoType(elementLogicalType);
+        Type elementType = fromFlinkType(elementLogicalType, flinkVersionId);
         return Types.ListType.of(elementType, elementLogicalType.isNullable());
       case MAP:
         MapType mapType = (MapType) logicalType;
         LogicalType keyType = mapType.getKeyType();
         LogicalType valueType = mapType.getValueType();
         return Types.MapType.of(
-            toGravitinoType(keyType), toGravitinoType(valueType), valueType.isNullable());
+            fromFlinkType(keyType, flinkVersionId),
+            fromFlinkType(valueType, flinkVersionId),
+            valueType.isNullable());
       case ROW:
         RowType rowType = (RowType) logicalType;
         Types.StructType.Field[] fields =
@@ -120,7 +154,7 @@ public class TypeUtils {
                 .map(
                     field -> {
                       LogicalType fieldLogicalType = field.getType();
-                      Type fieldType = toGravitinoType(fieldLogicalType);
+                      Type fieldType = fromFlinkType(fieldLogicalType, flinkVersionId);
                       return Types.StructType.Field.of(
                           field.getName(),
                           fieldType,
@@ -147,7 +181,25 @@ public class TypeUtils {
     }
   }
 
+  /**
+   * Converts a Gravitino type to a Flink data type using the active Flink runtime.
+   *
+   * @param gravitinoType the Gravitino type
+   * @return the corresponding Flink data type
+   */
   public static DataType toFlinkType(Type gravitinoType) {
+    return toFlinkType(gravitinoType, FlinkVersion.current().toString());
+  }
+
+  /**
+   * Converts a Gravitino type to a Flink data type using the active Flink version's compatibility
+   * rules.
+   *
+   * @param gravitinoType the Gravitino type
+   * @param flinkVersionId the active Flink version ID, such as {@code 1.20}
+   * @return the corresponding Flink data type
+   */
+  public static DataType toFlinkType(Type gravitinoType, String flinkVersionId) {
     switch (gravitinoType.name()) {
       case DOUBLE:
         return DataTypes.DOUBLE();
@@ -191,6 +243,7 @@ public class TypeUtils {
                 "Flink supports timestamp precision from 0 to 9, but got " + precision);
           }
         }
+        validateTimestampPrecisionForVersion(precision, flinkVersionId);
         if (timestampType.hasTimeZone()) {
           return DataTypes.TIMESTAMP_LTZ(precision);
         } else {
@@ -199,12 +252,13 @@ public class TypeUtils {
       case LIST:
         Types.ListType listType = (Types.ListType) gravitinoType;
         return DataTypes.ARRAY(
-            nullable(toFlinkType(listType.elementType()), listType.elementNullable()));
+            nullable(
+                toFlinkType(listType.elementType(), flinkVersionId), listType.elementNullable()));
       case MAP:
         Types.MapType mapType = (Types.MapType) gravitinoType;
         return DataTypes.MAP(
-            toFlinkType(mapType.keyType()),
-            nullable(toFlinkType(mapType.valueType()), mapType.valueNullable()));
+            toFlinkType(mapType.keyType(), flinkVersionId),
+            nullable(toFlinkType(mapType.valueType(), flinkVersionId), mapType.valueNullable()));
       case STRUCT:
         Types.StructType structType = (Types.StructType) gravitinoType;
         List<DataTypes.Field> fields =
@@ -213,10 +267,13 @@ public class TypeUtils {
                     f -> {
                       if (f.comment() == null) {
                         return DataTypes.FIELD(
-                            f.name(), nullable(toFlinkType(f.type()), f.nullable()));
+                            f.name(),
+                            nullable(toFlinkType(f.type(), flinkVersionId), f.nullable()));
                       } else {
                         return DataTypes.FIELD(
-                            f.name(), nullable(toFlinkType(f.type()), f.nullable()), f.comment());
+                            f.name(),
+                            nullable(toFlinkType(f.type(), flinkVersionId), f.nullable()),
+                            f.comment());
                       }
                     })
                 .collect(Collectors.toList());
@@ -241,15 +298,17 @@ public class TypeUtils {
       case INTERVAL_DAY:
         return DataTypes.INTERVAL(DataTypes.DAY());
       case VARIANT:
-        throw new IllegalArgumentException(
-            "Flink 1.18-1.20 has no VARIANT logical type for Gravitino variant");
+        return toFlinkVariantType(flinkVersionId);
       case GEOMETRY:
         throw new IllegalArgumentException(
-            "Flink 1.18-1.20 has no geometry logical type that preserves CRS metadata");
+            "Flink "
+                + flinkVersionId
+                + " has no geometry logical type that preserves CRS metadata");
       case GEOGRAPHY:
         throw new IllegalArgumentException(
-            "Flink 1.18-1.20 has no geography logical type that preserves CRS and edge algorithm "
-                + "metadata");
+            "Flink "
+                + flinkVersionId
+                + " has no geography logical type that preserves CRS and edge algorithm metadata");
       case EXTERNAL:
         Types.ExternalType externalType = (Types.ExternalType) gravitinoType;
         String catalogString = externalType.catalogString();
@@ -260,6 +319,54 @@ public class TypeUtils {
         return TypeConversions.fromLogicalToDataType(parsedType);
       default:
         throw new UnsupportedOperationException("Not support " + gravitinoType.toString());
+    }
+  }
+
+  private static void validateTimestampPrecisionForVersion(int precision, String flinkVersionId) {
+    if (precision > FLINK_MICROS_PRECISION && isFlinkVersionBefore(flinkVersionId, 1, 20)) {
+      throw new IllegalArgumentException(
+          "Flink "
+              + flinkVersionId
+              + " cannot safely round-trip timestamp precision "
+              + precision
+              + " through Iceberg; nanosecond timestamps require Flink 1.20 or later");
+    }
+  }
+
+  private static DataType toFlinkVariantType(String flinkVersionId) {
+    if (isFlinkVersionBefore(flinkVersionId, 2, 1)) {
+      throw new IllegalArgumentException(
+          "Flink "
+              + flinkVersionId
+              + " has no VARIANT logical type for Gravitino variant; VARIANT requires Flink 2.1 "
+              + "or later");
+    }
+
+    try {
+      return (DataType) DataTypes.class.getMethod("VARIANT").invoke(null);
+    } catch (ReflectiveOperationException e) {
+      throw new IllegalArgumentException(
+          "The configured Flink version "
+              + flinkVersionId
+              + " supports VARIANT, but the active Flink runtime does not expose "
+              + "DataTypes.VARIANT()",
+          e);
+    }
+  }
+
+  private static boolean isFlinkVersionBefore(
+      String flinkVersionId, int requiredMajor, int requiredMinor) {
+    String[] versionParts = flinkVersionId.split("\\.");
+    if (versionParts.length < 2) {
+      throw new IllegalArgumentException("Invalid Flink version ID: " + flinkVersionId);
+    }
+
+    try {
+      int major = Integer.parseInt(versionParts[0]);
+      int minor = Integer.parseInt(versionParts[1]);
+      return major < requiredMajor || (major == requiredMajor && minor < requiredMinor);
+    } catch (NumberFormatException e) {
+      throw new IllegalArgumentException("Invalid Flink version ID: " + flinkVersionId, e);
     }
   }
 

--- a/flink-connector/flink-common/src/main/java/org/apache/gravitino/flink/connector/utils/TypeUtils.java
+++ b/flink-connector/flink-common/src/main/java/org/apache/gravitino/flink/connector/utils/TypeUtils.java
@@ -41,7 +41,7 @@ public class TypeUtils {
 
   // Flink supports time/timestamp precision from 0 to 9 (nanosecond precision).
   // @see
-  // https://nightlies.apache.org/flink/flink-docs-release-2.1/docs/dev/table/types/#date-and-time
+  // https://nightlies.apache.org/flink/flink-docs-release-1.20/docs/dev/table/types/#date-and-time
   protected static final int FLINK_SECONDS_PRECISION = 0;
   protected static final int FLINK_MICROS_PRECISION = 6;
   protected static final int FLINK_NANOS_PRECISION = 9;
@@ -99,10 +99,9 @@ public class TypeUtils {
         int localZonedPrecision = localZonedTimestampType.getPrecision();
         return Types.TimestampType.withTimeZone(localZonedPrecision);
       case TIMESTAMP_WITH_TIME_ZONE:
-        org.apache.flink.table.types.logical.ZonedTimestampType zonedTimestampType =
-            (org.apache.flink.table.types.logical.ZonedTimestampType) logicalType;
-        int zonedPrecision = zonedTimestampType.getPrecision();
-        return Types.TimestampType.withTimeZone(zonedPrecision);
+        throw new IllegalArgumentException(
+            "Flink TIMESTAMP WITH TIME ZONE stores an offset per value and cannot be "
+                + "losslessly represented by Gravitino timestamp_tz; use TIMESTAMP_LTZ");
       case ARRAY:
         ArrayType arrayType = (ArrayType) logicalType;
         LogicalType elementLogicalType = arrayType.getElementType();
@@ -188,10 +187,8 @@ public class TypeUtils {
         if (timestampType.hasPrecisionSet()) {
           precision = timestampType.precision();
           if (precision < FLINK_SECONDS_PRECISION || precision > FLINK_NANOS_PRECISION) {
-            throw new UnsupportedOperationException(
-                "Unsupported timestamp precision for Flink: "
-                    + precision
-                    + ". Flink supports precision from 0 to 9.");
+            throw new IllegalArgumentException(
+                "Flink supports timestamp precision from 0 to 9, but got " + precision);
           }
         }
         if (timestampType.hasTimeZone()) {

--- a/flink-connector/flink-common/src/test/java/org/apache/gravitino/flink/connector/catalog/TestBaseCatalog.java
+++ b/flink-connector/flink-common/src/test/java/org/apache/gravitino/flink/connector/catalog/TestBaseCatalog.java
@@ -240,6 +240,23 @@ public class TestBaseCatalog {
   }
 
   @Test
+  public void testRejectGeometryBeforeSchemaExposure() {
+    IllegalArgumentException exception =
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                BaseCatalog.buildSchemaFromColumns(
+                    new org.apache.gravitino.rel.Column[] {
+                      org.apache.gravitino.rel.Column.of(
+                          "geometry_column", Types.GeometryType.crs84())
+                    }));
+
+    Assertions.assertEquals(
+        "Flink 1.18-1.20 has no geometry logical type that preserves CRS metadata",
+        exception.getMessage());
+  }
+
+  @Test
   public void testToGravitinoDistributionDefaultsToNone() {
     TestableBaseCatalog catalog =
         new TestableBaseCatalog(Mockito.mock(AbstractCatalog.class), mockUnsupportedViewCatalog());

--- a/flink-connector/flink-common/src/test/java/org/apache/gravitino/flink/connector/catalog/TestBaseCatalog.java
+++ b/flink-connector/flink-common/src/test/java/org/apache/gravitino/flink/connector/catalog/TestBaseCatalog.java
@@ -257,6 +257,24 @@ public class TestBaseCatalog {
   }
 
   @Test
+  public void testRejectGeographyBeforeSchemaExposure() {
+    IllegalArgumentException exception =
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                BaseCatalog.buildSchemaFromColumns(
+                    new org.apache.gravitino.rel.Column[] {
+                      org.apache.gravitino.rel.Column.of(
+                          "geography_column", Types.GeographyType.crs84())
+                    }));
+
+    Assertions.assertEquals(
+        "Flink 1.18-1.20 has no geography logical type that preserves CRS and edge algorithm "
+            + "metadata",
+        exception.getMessage());
+  }
+
+  @Test
   public void testToGravitinoDistributionDefaultsToNone() {
     TestableBaseCatalog catalog =
         new TestableBaseCatalog(Mockito.mock(AbstractCatalog.class), mockUnsupportedViewCatalog());

--- a/flink-connector/flink-common/src/test/java/org/apache/gravitino/flink/connector/catalog/TestBaseCatalog.java
+++ b/flink-connector/flink-common/src/test/java/org/apache/gravitino/flink/connector/catalog/TestBaseCatalog.java
@@ -25,6 +25,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import org.apache.flink.FlinkVersion;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.Schema;
 import org.apache.flink.table.catalog.AbstractCatalog;
@@ -39,6 +40,7 @@ import org.apache.flink.table.catalog.ResolvedCatalogTable;
 import org.apache.flink.table.catalog.ResolvedCatalogView;
 import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.catalog.TableChange;
+import org.apache.flink.table.types.DataType;
 import org.apache.gravitino.Catalog;
 import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.Namespace;
@@ -142,23 +144,32 @@ public class TestBaseCatalog {
   }
 
   @Test
-  public void testBuildSchemaWithNanosecondTimestamps() {
-    Schema schema =
-        BaseCatalog.buildSchemaFromColumns(
-                new org.apache.gravitino.rel.Column[] {
-                  org.apache.gravitino.rel.Column.of(
-                      "timestamp_ns", Types.TimestampType.withoutTimeZone(9)),
-                  org.apache.gravitino.rel.Column.of(
-                      "timestamp_tz_ns", Types.TimestampType.withTimeZone(9))
-                })
-            .build();
+  public void testNanosecondTimestampSchemaUsesRuntimeVersion() {
+    org.apache.gravitino.rel.Column[] columns = {
+      org.apache.gravitino.rel.Column.of("timestamp_ns", Types.TimestampType.withoutTimeZone(9)),
+      org.apache.gravitino.rel.Column.of("timestamp_tz_ns", Types.TimestampType.withTimeZone(9))
+    };
 
-    Assertions.assertEquals(
-        DataTypes.TIMESTAMP(9),
-        ((Schema.UnresolvedPhysicalColumn) schema.getColumns().get(0)).getDataType());
-    Assertions.assertEquals(
-        DataTypes.TIMESTAMP_LTZ(9),
-        ((Schema.UnresolvedPhysicalColumn) schema.getColumns().get(1)).getDataType());
+    if (isCurrentFlinkAtLeast(1, 20)) {
+      Schema schema = BaseCatalog.buildSchemaFromColumns(columns).build();
+      Assertions.assertEquals(
+          DataTypes.TIMESTAMP(9),
+          ((Schema.UnresolvedPhysicalColumn) schema.getColumns().get(0)).getDataType());
+      Assertions.assertEquals(
+          DataTypes.TIMESTAMP_LTZ(9),
+          ((Schema.UnresolvedPhysicalColumn) schema.getColumns().get(1)).getDataType());
+    } else {
+      IllegalArgumentException exception =
+          Assertions.assertThrows(
+              IllegalArgumentException.class, () -> BaseCatalog.buildSchemaFromColumns(columns));
+      Assertions.assertTrue(
+          exception
+              .getMessage()
+              .contains(
+                  "Flink "
+                      + FlinkVersion.current()
+                      + " cannot safely round-trip timestamp precision 9"));
+    }
   }
 
   @Test
@@ -194,18 +205,29 @@ public class TestBaseCatalog {
 
   @Test
   public void testRejectVariantBeforeSchemaExposure() {
-    IllegalArgumentException exception =
-        Assertions.assertThrows(
-            IllegalArgumentException.class,
-            () ->
-                BaseCatalog.buildSchemaFromColumns(
-                    new org.apache.gravitino.rel.Column[] {
-                      org.apache.gravitino.rel.Column.of("variant_column", Types.VariantType.get())
-                    }));
+    org.apache.gravitino.rel.Column[] columns = {
+      org.apache.gravitino.rel.Column.of("variant_column", Types.VariantType.get())
+    };
 
-    Assertions.assertEquals(
-        "Flink 1.18-1.20 has no VARIANT logical type for Gravitino variant",
-        exception.getMessage());
+    if (isCurrentFlinkAtLeast(2, 1)) {
+      Schema schema = BaseCatalog.buildSchemaFromColumns(columns).build();
+      Assertions.assertEquals(
+          "VARIANT",
+          ((DataType) ((Schema.UnresolvedPhysicalColumn) schema.getColumns().get(0)).getDataType())
+              .getLogicalType()
+              .getTypeRoot()
+              .name());
+    } else {
+      IllegalArgumentException exception =
+          Assertions.assertThrows(
+              IllegalArgumentException.class, () -> BaseCatalog.buildSchemaFromColumns(columns));
+      Assertions.assertEquals(
+          "Flink "
+              + FlinkVersion.current()
+              + " has no VARIANT logical type for Gravitino variant; VARIANT requires Flink 2.1 "
+              + "or later",
+          exception.getMessage());
+    }
   }
 
   @Test
@@ -252,7 +274,9 @@ public class TestBaseCatalog {
                     }));
 
     Assertions.assertEquals(
-        "Flink 1.18-1.20 has no geometry logical type that preserves CRS metadata",
+        "Flink "
+            + FlinkVersion.current()
+            + " has no geometry logical type that preserves CRS metadata",
         exception.getMessage());
   }
 
@@ -269,7 +293,9 @@ public class TestBaseCatalog {
                     }));
 
     Assertions.assertEquals(
-        "Flink 1.18-1.20 has no geography logical type that preserves CRS and edge algorithm "
+        "Flink "
+            + FlinkVersion.current()
+            + " has no geography logical type that preserves CRS and edge algorithm "
             + "metadata",
         exception.getMessage());
   }
@@ -459,6 +485,13 @@ public class TestBaseCatalog {
     SQLRepresentation second = (SQLRepresentation) reps[1];
     Assertions.assertEquals(PaimonConstants.VIEW_QUERY_DIALECT, second.dialect());
     Assertions.assertEquals("SELECT id FROM t", second.sql());
+  }
+
+  private static boolean isCurrentFlinkAtLeast(int requiredMajor, int requiredMinor) {
+    String[] versionParts = FlinkVersion.current().toString().split("\\.");
+    int major = Integer.parseInt(versionParts[0]);
+    int minor = Integer.parseInt(versionParts[1]);
+    return major > requiredMajor || (major == requiredMajor && minor >= requiredMinor);
   }
 
   /**

--- a/flink-connector/flink-common/src/test/java/org/apache/gravitino/flink/connector/catalog/TestBaseCatalog.java
+++ b/flink-connector/flink-common/src/test/java/org/apache/gravitino/flink/connector/catalog/TestBaseCatalog.java
@@ -209,6 +209,37 @@ public class TestBaseCatalog {
   }
 
   @Test
+  public void testBuildSchemaWithNullableUnknown() {
+    Schema schema =
+        BaseCatalog.buildSchemaFromColumns(
+                new org.apache.gravitino.rel.Column[] {
+                  org.apache.gravitino.rel.Column.of("unknown_column", Types.NullType.get())
+                })
+            .build();
+
+    Assertions.assertEquals(
+        DataTypes.NULL(),
+        ((Schema.UnresolvedPhysicalColumn) schema.getColumns().get(0)).getDataType());
+  }
+
+  @Test
+  public void testRejectNonNullableUnknownBeforeSchemaExposure() {
+    IllegalArgumentException exception =
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                BaseCatalog.buildSchemaFromColumns(
+                    new org.apache.gravitino.rel.Column[] {
+                      org.apache.gravitino.rel.Column.of(
+                          "unknown_column", Types.NullType.get(), null, false, false, null)
+                    }));
+
+    Assertions.assertEquals(
+        "Flink NULL columns must be nullable because NULL has no non-null value",
+        exception.getMessage());
+  }
+
+  @Test
   public void testToGravitinoDistributionDefaultsToNone() {
     TestableBaseCatalog catalog =
         new TestableBaseCatalog(Mockito.mock(AbstractCatalog.class), mockUnsupportedViewCatalog());

--- a/flink-connector/flink-common/src/test/java/org/apache/gravitino/flink/connector/catalog/TestBaseCatalog.java
+++ b/flink-connector/flink-common/src/test/java/org/apache/gravitino/flink/connector/catalog/TestBaseCatalog.java
@@ -31,8 +31,11 @@ import org.apache.flink.table.catalog.AbstractCatalog;
 import org.apache.flink.table.catalog.CatalogBaseTable;
 import org.apache.flink.table.catalog.CatalogDatabase;
 import org.apache.flink.table.catalog.CatalogDatabaseImpl;
+import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.CatalogView;
 import org.apache.flink.table.catalog.Column;
+import org.apache.flink.table.catalog.ObjectPath;
+import org.apache.flink.table.catalog.ResolvedCatalogTable;
 import org.apache.flink.table.catalog.ResolvedCatalogView;
 import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.catalog.TableChange;
@@ -47,6 +50,7 @@ import org.apache.gravitino.flink.connector.utils.DefaultCatalogCompat;
 import org.apache.gravitino.rel.Dialects;
 import org.apache.gravitino.rel.Representation;
 import org.apache.gravitino.rel.SQLRepresentation;
+import org.apache.gravitino.rel.TableCatalog;
 import org.apache.gravitino.rel.ViewCatalog;
 import org.apache.gravitino.rel.ViewChange;
 import org.apache.gravitino.rel.expressions.distributions.Distributions;
@@ -135,6 +139,57 @@ public class TestBaseCatalog {
     List<org.apache.gravitino.rel.TableChange> expected =
         ImmutableList.of(org.apache.gravitino.rel.TableChange.updateComment("new comment"));
     Assertions.assertArrayEquals(expected.toArray(), tableChanges);
+  }
+
+  @Test
+  public void testBuildSchemaWithNanosecondTimestamps() {
+    Schema schema =
+        BaseCatalog.buildSchemaFromColumns(
+                new org.apache.gravitino.rel.Column[] {
+                  org.apache.gravitino.rel.Column.of(
+                      "timestamp_ns", Types.TimestampType.withoutTimeZone(9)),
+                  org.apache.gravitino.rel.Column.of(
+                      "timestamp_tz_ns", Types.TimestampType.withTimeZone(9))
+                })
+            .build();
+
+    Assertions.assertEquals(
+        DataTypes.TIMESTAMP(9),
+        ((Schema.UnresolvedPhysicalColumn) schema.getColumns().get(0)).getDataType());
+    Assertions.assertEquals(
+        DataTypes.TIMESTAMP_LTZ(9),
+        ((Schema.UnresolvedPhysicalColumn) schema.getColumns().get(1)).getDataType());
+  }
+
+  @Test
+  public void testRejectOffsetTimestampBeforeTableMutation() {
+    TableCatalog tableCatalog = Mockito.mock(TableCatalog.class);
+    Catalog gravitinoCatalog = Mockito.mock(Catalog.class);
+    Mockito.when(gravitinoCatalog.asTableCatalog()).thenReturn(tableCatalog);
+    BaseCatalog catalog =
+        new TestableBaseCatalog(Mockito.mock(AbstractCatalog.class), gravitinoCatalog);
+
+    Schema schema =
+        Schema.newBuilder()
+            .column("timestamp_tz_ns", DataTypes.TIMESTAMP_WITH_TIME_ZONE(9))
+            .build();
+    CatalogTable unresolvedTable =
+        DefaultCatalogCompat.INSTANCE.createCatalogTable(
+            schema, "test", ImmutableList.of(), ImmutableMap.of());
+    ResolvedCatalogTable resolvedTable =
+        new ResolvedCatalogTable(
+            unresolvedTable,
+            ResolvedSchema.of(
+                Column.physical("timestamp_tz_ns", DataTypes.TIMESTAMP_WITH_TIME_ZONE(9))));
+
+    IllegalArgumentException exception =
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                catalog.createTable(
+                    new ObjectPath("database", "timestamp_tz_table"), resolvedTable, false));
+    Assertions.assertTrue(exception.getMessage().contains("cannot be losslessly represented"));
+    Mockito.verifyNoInteractions(tableCatalog);
   }
 
   @Test

--- a/flink-connector/flink-common/src/test/java/org/apache/gravitino/flink/connector/catalog/TestBaseCatalog.java
+++ b/flink-connector/flink-common/src/test/java/org/apache/gravitino/flink/connector/catalog/TestBaseCatalog.java
@@ -193,6 +193,22 @@ public class TestBaseCatalog {
   }
 
   @Test
+  public void testRejectVariantBeforeSchemaExposure() {
+    IllegalArgumentException exception =
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                BaseCatalog.buildSchemaFromColumns(
+                    new org.apache.gravitino.rel.Column[] {
+                      org.apache.gravitino.rel.Column.of("variant_column", Types.VariantType.get())
+                    }));
+
+    Assertions.assertEquals(
+        "Flink 1.18-1.20 has no VARIANT logical type for Gravitino variant",
+        exception.getMessage());
+  }
+
+  @Test
   public void testToGravitinoDistributionDefaultsToNone() {
     TestableBaseCatalog catalog =
         new TestableBaseCatalog(Mockito.mock(AbstractCatalog.class), mockUnsupportedViewCatalog());

--- a/flink-connector/flink-common/src/test/java/org/apache/gravitino/flink/connector/integration/test/iceberg/FlinkIcebergJdbcCatalogIT.java
+++ b/flink-connector/flink-common/src/test/java/org/apache/gravitino/flink/connector/integration/test/iceberg/FlinkIcebergJdbcCatalogIT.java
@@ -19,16 +19,40 @@
 
 package org.apache.gravitino.flink.connector.integration.test.iceberg;
 
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import java.sql.SQLException;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
 import java.util.Map;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.ResultKind;
+import org.apache.flink.table.api.Schema;
+import org.apache.flink.table.api.TableResult;
+import org.apache.flink.table.catalog.CatalogBaseTable;
+import org.apache.flink.table.catalog.ObjectPath;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.types.Row;
+import org.apache.gravitino.NameIdentifier;
 import org.apache.gravitino.catalog.lakehouse.iceberg.IcebergConstants;
 import org.apache.gravitino.flink.connector.iceberg.GravitinoIcebergCatalogFactoryOptions;
 import org.apache.gravitino.flink.connector.iceberg.IcebergPropertiesConstants;
+import org.apache.gravitino.flink.connector.integration.test.utils.TestUtils;
 import org.apache.gravitino.integration.test.container.ContainerSuite;
 import org.apache.gravitino.integration.test.container.MySQLContainer;
 import org.apache.gravitino.integration.test.util.TestDatabaseName;
+import org.apache.gravitino.rel.Column;
+import org.apache.gravitino.rel.Table;
+import org.apache.gravitino.rel.types.Types;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIf;
+import org.junit.jupiter.api.condition.EnabledIf;
 
 /** Iceberg catalog with a JDBC (MySQL) metadata backend. */
 @Tag("gravitino-docker-test")
@@ -36,8 +60,176 @@ public abstract class FlinkIcebergJdbcCatalogIT extends FlinkIcebergCatalogIT {
 
   private static final TestDatabaseName TEST_DB_NAME =
       TestDatabaseName.FLINK_ICEBERG_JDBC_CATALOG_IT;
+  private static final String NANOSECOND_TIMESTAMP_VALUE = "2024-01-02 03:04:05.123456789";
 
   private static MySQLContainer mySQLContainer;
+
+  @Test
+  @DisabledIf("supportsNanosecondTimestampRoundTrip")
+  public void testRejectNanosecondTimestampCreateBeforeMutation() {
+    String databaseName = "test_reject_timestamp_nanos_create";
+
+    doWithSchema(
+        currentCatalog(),
+        databaseName,
+        catalog -> {
+          assertNanosecondCreateRejected(catalog, databaseName, "timestamp_ns", "TIMESTAMP(9)");
+          assertNanosecondCreateRejected(
+              catalog, databaseName, "timestamptz_ns", "TIMESTAMP_LTZ(9)");
+        },
+        true,
+        supportDropCascade());
+  }
+
+  @Test
+  @DisabledIf("supportsNanosecondTimestampRoundTrip")
+  public void testRejectExistingNanosecondTimestampOnLoad() {
+    String databaseName = "test_reject_timestamp_nanos_load";
+    String tableName = "timestamp_nanos";
+    NameIdentifier identifier = NameIdentifier.of(databaseName, tableName);
+
+    doWithSchema(
+        currentCatalog(),
+        databaseName,
+        catalog -> {
+          catalog
+              .asTableCatalog()
+              .createTable(
+                  identifier,
+                  new Column[] {
+                    Column.of("timestamp_ns", Types.TimestampType.withoutTimeZone(9)),
+                    Column.of("timestamptz_ns", Types.TimestampType.withTimeZone(9))
+                  },
+                  null,
+                  ImmutableMap.of(IcebergConstants.FORMAT_VERSION, "3"));
+
+          try {
+            org.apache.flink.table.catalog.Catalog flinkCatalog =
+                tableEnv.getCatalog(DEFAULT_ICEBERG_CATALOG).orElseThrow(AssertionError::new);
+            Exception exception =
+                Assertions.assertThrows(
+                    Exception.class,
+                    () -> flinkCatalog.getTable(new ObjectPath(databaseName, identifier.name())));
+            Assertions.assertTrue(
+                ExceptionUtils.getStackTrace(exception)
+                    .contains("cannot safely round-trip timestamp precision 9"),
+                "Expected a nanosecond compatibility rejection, but got: " + exception);
+          } finally {
+            catalog.asTableCatalog().dropTable(identifier);
+          }
+        },
+        true,
+        supportDropCascade());
+  }
+
+  @Test
+  @EnabledIf("supportsNanosecondTimestampRoundTrip")
+  public void testNanosecondTimestampSchemaAndValueRoundTrip() {
+    String databaseName = "test_timestamp_nanos_round_trip";
+    String tableName = "timestamp_nanos";
+    ZoneId originalLocalTimeZone = tableEnv.getConfig().getLocalTimeZone();
+
+    try {
+      tableEnv.getConfig().setLocalTimeZone(ZoneId.of("UTC"));
+      doWithSchema(
+          currentCatalog(),
+          databaseName,
+          catalog -> {
+            TableResult createResult =
+                sql(
+                    "CREATE TABLE %s ("
+                        + "timestamp_ns TIMESTAMP(9), "
+                        + "timestamptz_ns TIMESTAMP_LTZ(9)"
+                        + ") WITH ("
+                        + "'format-version' = '3', "
+                        + "'write.format.default' = 'parquet'"
+                        + ")",
+                    tableName);
+            TestUtils.assertTableResult(createResult, ResultKind.SUCCESS);
+
+            NameIdentifier identifier = NameIdentifier.of(databaseName, tableName);
+            Table gravitinoTable = catalog.asTableCatalog().loadTable(identifier);
+            Assertions.assertEquals(
+                Types.TimestampType.withoutTimeZone(9), gravitinoTable.columns()[0].dataType());
+            Assertions.assertEquals(
+                Types.TimestampType.withTimeZone(9), gravitinoTable.columns()[1].dataType());
+            Assertions.assertEquals(
+                "3", gravitinoTable.properties().get(IcebergConstants.FORMAT_VERSION));
+            Assertions.assertEquals(
+                "parquet", gravitinoTable.properties().get("write.format.default"));
+
+            assertFlinkNanosecondSchema(databaseName, tableName);
+
+            TestUtils.assertTableResult(
+                sql(
+                    "INSERT INTO %s VALUES ("
+                        + "CAST('%s' AS TIMESTAMP(9)), "
+                        + "CAST('%s' AS TIMESTAMP_LTZ(9))"
+                        + ")",
+                    tableName, NANOSECOND_TIMESTAMP_VALUE, NANOSECOND_TIMESTAMP_VALUE),
+                ResultKind.SUCCESS_WITH_CONTENT,
+                Row.of(-1L));
+
+            List<Row> rows = Lists.newArrayList(sql("SELECT * FROM %s", tableName).collect());
+            Assertions.assertEquals(1, rows.size());
+            Assertions.assertEquals(
+                LocalDateTime.parse("2024-01-02T03:04:05.123456789"), rows.get(0).getField(0));
+            Assertions.assertEquals(
+                Instant.parse("2024-01-02T03:04:05.123456789Z"), rows.get(0).getField(1));
+          },
+          true,
+          supportDropCascade());
+    } finally {
+      tableEnv.getConfig().setLocalTimeZone(originalLocalTimeZone);
+    }
+  }
+
+  @Test
+  public void testLoadNullableIcebergUnknownAsFlinkNull() {
+    String databaseName = "test_load_iceberg_unknown";
+    String tableName = "unknown_column";
+    NameIdentifier identifier = NameIdentifier.of(databaseName, tableName);
+
+    doWithSchema(
+        currentCatalog(),
+        databaseName,
+        catalog -> {
+          Table created =
+              catalog
+                  .asTableCatalog()
+                  .createTable(
+                      identifier,
+                      new Column[] {
+                        Column.of("id", Types.IntegerType.get()),
+                        Column.of("payload", Types.NullType.get())
+                      },
+                      null,
+                      ImmutableMap.of(IcebergConstants.FORMAT_VERSION, "3"));
+          Assertions.assertTrue(created.columns()[1].nullable());
+          Assertions.assertEquals(Types.NullType.get(), created.columns()[1].dataType());
+
+          try {
+            Table loaded = catalog.asTableCatalog().loadTable(identifier);
+            Assertions.assertEquals(Types.NullType.get(), loaded.columns()[1].dataType());
+
+            org.apache.flink.table.catalog.Catalog flinkCatalog =
+                tableEnv.getCatalog(DEFAULT_ICEBERG_CATALOG).orElseThrow(AssertionError::new);
+            CatalogBaseTable flinkTable =
+                Assertions.assertDoesNotThrow(
+                    () -> flinkCatalog.getTable(new ObjectPath(databaseName, tableName)));
+            Schema.UnresolvedPhysicalColumn payloadColumn =
+                (Schema.UnresolvedPhysicalColumn)
+                    flinkTable.getUnresolvedSchema().getColumns().get(1);
+            Assertions.assertEquals(DataTypes.NULL(), payloadColumn.getDataType());
+            Assertions.assertTrue(
+                ((DataType) payloadColumn.getDataType()).getLogicalType().isNullable());
+          } finally {
+            catalog.asTableCatalog().dropTable(identifier);
+          }
+        },
+        true,
+        supportDropCascade());
+  }
 
   @Override
   protected void initCatalogEnv() throws Exception {
@@ -106,6 +298,48 @@ public abstract class FlinkIcebergJdbcCatalogIT extends FlinkIcebergCatalogIT {
   @Override
   protected String getUri() {
     return mySQLContainer.getJdbcUrl(TEST_DB_NAME);
+  }
+
+  /**
+   * Returns whether this Flink and Iceberg runtime pair safely round-trips nanosecond timestamps.
+   *
+   * @return {@code true} when precision-9 timestamp reads and writes are lossless
+   */
+  protected boolean supportsNanosecondTimestampRoundTrip() {
+    return false;
+  }
+
+  private void assertNanosecondCreateRejected(
+      org.apache.gravitino.Catalog catalog,
+      String databaseName,
+      String tableName,
+      String flinkType) {
+    Exception exception =
+        Assertions.assertThrows(
+            Exception.class,
+            () ->
+                sql("CREATE TABLE %s (ts %s) WITH ('format-version' = '3')", tableName, flinkType));
+    Assertions.assertTrue(
+        ExceptionUtils.getStackTrace(exception)
+            .contains("cannot safely round-trip timestamp precision 9"),
+        "Expected a nanosecond compatibility rejection, but got: " + exception);
+    Assertions.assertFalse(
+        catalog.asTableCatalog().tableExists(NameIdentifier.of(databaseName, tableName)),
+        "A rejected nanosecond table must not be created in Gravitino");
+  }
+
+  private void assertFlinkNanosecondSchema(String databaseName, String tableName) {
+    org.apache.flink.table.catalog.Catalog flinkCatalog =
+        tableEnv.getCatalog(DEFAULT_ICEBERG_CATALOG).orElseThrow(AssertionError::new);
+    CatalogBaseTable flinkTable =
+        Assertions.assertDoesNotThrow(
+            () -> flinkCatalog.getTable(new ObjectPath(databaseName, tableName)));
+    List<Schema.UnresolvedColumn> columns = flinkTable.getUnresolvedSchema().getColumns();
+    Assertions.assertEquals(
+        DataTypes.TIMESTAMP(9), ((Schema.UnresolvedPhysicalColumn) columns.get(0)).getDataType());
+    Assertions.assertEquals(
+        DataTypes.TIMESTAMP_LTZ(9),
+        ((Schema.UnresolvedPhysicalColumn) columns.get(1)).getDataType());
   }
 
   private String getDriverClassName() {

--- a/flink-connector/flink-common/src/test/java/org/apache/gravitino/flink/connector/utils/TestTypeUtils.java
+++ b/flink-connector/flink-common/src/test/java/org/apache/gravitino/flink/connector/utils/TestTypeUtils.java
@@ -290,6 +290,15 @@ public class TestTypeUtils {
   }
 
   @Test
+  public void testUnknownTypeRoundTrip() {
+    Types.NullType unknown = Types.NullType.get();
+
+    Assertions.assertEquals(DataTypes.NULL(), TypeUtils.toFlinkType(unknown));
+    Assertions.assertEquals(
+        unknown, TypeUtils.toGravitinoType(TypeUtils.toFlinkType(unknown).getLogicalType()));
+  }
+
+  @Test
   public void testMultisetTypeConversion() {
     // MULTISET<STRING> (VARCHAR(MAX)) should be preserved as ExternalType
     Assertions.assertEquals(

--- a/flink-connector/flink-common/src/test/java/org/apache/gravitino/flink/connector/utils/TestTypeUtils.java
+++ b/flink-connector/flink-common/src/test/java/org/apache/gravitino/flink/connector/utils/TestTypeUtils.java
@@ -299,6 +299,25 @@ public class TestTypeUtils {
   }
 
   @Test
+  public void testRejectGeometryTypes() {
+    String expectedMessage =
+        "Flink 1.18-1.20 has no geometry logical type that preserves CRS metadata";
+
+    Assertions.assertEquals(
+        expectedMessage,
+        Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> TypeUtils.toFlinkType(Types.GeometryType.crs84()))
+            .getMessage());
+    Assertions.assertEquals(
+        expectedMessage,
+        Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> TypeUtils.toFlinkType(Types.GeometryType.of("EPSG:3857")))
+            .getMessage());
+  }
+
+  @Test
   public void testMultisetTypeConversion() {
     // MULTISET<STRING> (VARCHAR(MAX)) should be preserved as ExternalType
     Assertions.assertEquals(

--- a/flink-connector/flink-common/src/test/java/org/apache/gravitino/flink/connector/utils/TestTypeUtils.java
+++ b/flink-connector/flink-common/src/test/java/org/apache/gravitino/flink/connector/utils/TestTypeUtils.java
@@ -71,8 +71,8 @@ public class TestTypeUtils {
     Assertions.assertEquals(Types.ShortType.get(), TypeUtils.toGravitinoType(new SmallIntType()));
     Assertions.assertEquals(
         Types.TimestampType.withoutTimeZone(6), TypeUtils.toGravitinoType(new TimestampType()));
-    Assertions.assertEquals(
-        Types.TimestampType.withTimeZone(6), TypeUtils.toGravitinoType(new ZonedTimestampType()));
+    Assertions.assertThrows(
+        IllegalArgumentException.class, () -> TypeUtils.toGravitinoType(new ZonedTimestampType()));
     Assertions.assertEquals(
         Types.TimestampType.withTimeZone(6),
         TypeUtils.toGravitinoType(new LocalZonedTimestampType()));
@@ -242,16 +242,40 @@ public class TestTypeUtils {
   }
 
   @Test
+  public void testNanosecondTimestampRoundTrip() {
+    Types.TimestampType timestamp = Types.TimestampType.withoutTimeZone(9);
+    Types.TimestampType timestampTz = Types.TimestampType.withTimeZone(9);
+
+    Assertions.assertEquals(
+        timestamp, TypeUtils.toGravitinoType(TypeUtils.toFlinkType(timestamp).getLogicalType()));
+    Assertions.assertEquals(
+        timestampTz,
+        TypeUtils.toGravitinoType(TypeUtils.toFlinkType(timestampTz).getLogicalType()));
+  }
+
+  @Test
+  public void testRejectOffsetBearingFlinkTimestamp() {
+    IllegalArgumentException exception =
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () -> TypeUtils.toGravitinoType(new ZonedTimestampType(9)));
+    Assertions.assertEquals(
+        "Flink TIMESTAMP WITH TIME ZONE stores an offset per value and cannot be "
+            + "losslessly represented by Gravitino timestamp_tz; use TIMESTAMP_LTZ",
+        exception.getMessage());
+  }
+
+  @Test
   public void testInvalidPrecisionHandling() {
     Assertions.assertThrows(
         UnsupportedOperationException.class, () -> TypeUtils.toFlinkType(Types.TimeType.of(10)));
 
     Assertions.assertThrows(
-        UnsupportedOperationException.class,
+        IllegalArgumentException.class,
         () -> TypeUtils.toFlinkType(Types.TimestampType.withoutTimeZone(10)));
 
     Assertions.assertThrows(
-        UnsupportedOperationException.class,
+        IllegalArgumentException.class,
         () -> TypeUtils.toFlinkType(Types.TimestampType.withTimeZone(10)));
   }
 

--- a/flink-connector/flink-common/src/test/java/org/apache/gravitino/flink/connector/utils/TestTypeUtils.java
+++ b/flink-connector/flink-common/src/test/java/org/apache/gravitino/flink/connector/utils/TestTypeUtils.java
@@ -19,6 +19,7 @@
 
 package org.apache.gravitino.flink.connector.utils;
 
+import org.apache.flink.FlinkVersion;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.catalog.UnresolvedIdentifier;
 import org.apache.flink.table.types.logical.ArrayType;
@@ -50,6 +51,11 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class TestTypeUtils {
+
+  private static final String FLINK_1_18 = "1.18";
+  private static final String FLINK_1_19 = "1.19";
+  private static final String FLINK_1_20 = "1.20";
+  private static final String FLINK_2_1 = "2.1";
 
   @Test
   public void testToGravitinoType() {
@@ -205,7 +211,8 @@ public class TestTypeUtils {
     Assertions.assertEquals(
         Types.TimestampType.withoutTimeZone(6), TypeUtils.toGravitinoType(new TimestampType(6)));
     Assertions.assertEquals(
-        Types.TimestampType.withoutTimeZone(9), TypeUtils.toGravitinoType(new TimestampType(9)));
+        Types.TimestampType.withoutTimeZone(9),
+        TypeUtils.fromFlinkType(new TimestampType(9), FLINK_1_20));
 
     // TIMESTAMP with timezone (LocalZoned)
     Assertions.assertEquals(
@@ -219,7 +226,7 @@ public class TestTypeUtils {
         TypeUtils.toGravitinoType(new LocalZonedTimestampType(6)));
     Assertions.assertEquals(
         Types.TimestampType.withTimeZone(9),
-        TypeUtils.toGravitinoType(new LocalZonedTimestampType(9)));
+        TypeUtils.fromFlinkType(new LocalZonedTimestampType(9), FLINK_1_20));
 
     // Test converting back
     Assertions.assertEquals(
@@ -229,7 +236,8 @@ public class TestTypeUtils {
     Assertions.assertEquals(
         DataTypes.TIMESTAMP(6), TypeUtils.toFlinkType(Types.TimestampType.withoutTimeZone(6)));
     Assertions.assertEquals(
-        DataTypes.TIMESTAMP(9), TypeUtils.toFlinkType(Types.TimestampType.withoutTimeZone(9)));
+        DataTypes.TIMESTAMP(9),
+        TypeUtils.toFlinkType(Types.TimestampType.withoutTimeZone(9), FLINK_1_20));
 
     Assertions.assertEquals(
         DataTypes.TIMESTAMP_LTZ(0), TypeUtils.toFlinkType(Types.TimestampType.withTimeZone(0)));
@@ -238,7 +246,8 @@ public class TestTypeUtils {
     Assertions.assertEquals(
         DataTypes.TIMESTAMP_LTZ(6), TypeUtils.toFlinkType(Types.TimestampType.withTimeZone(6)));
     Assertions.assertEquals(
-        DataTypes.TIMESTAMP_LTZ(9), TypeUtils.toFlinkType(Types.TimestampType.withTimeZone(9)));
+        DataTypes.TIMESTAMP_LTZ(9),
+        TypeUtils.toFlinkType(Types.TimestampType.withTimeZone(9), FLINK_1_20));
   }
 
   @Test
@@ -247,10 +256,35 @@ public class TestTypeUtils {
     Types.TimestampType timestampTz = Types.TimestampType.withTimeZone(9);
 
     Assertions.assertEquals(
-        timestamp, TypeUtils.toGravitinoType(TypeUtils.toFlinkType(timestamp).getLogicalType()));
+        timestamp,
+        TypeUtils.fromFlinkType(
+            TypeUtils.toFlinkType(timestamp, FLINK_1_20).getLogicalType(), FLINK_1_20));
     Assertions.assertEquals(
         timestampTz,
-        TypeUtils.toGravitinoType(TypeUtils.toFlinkType(timestampTz).getLogicalType()));
+        TypeUtils.fromFlinkType(
+            TypeUtils.toFlinkType(timestampTz, FLINK_1_20).getLogicalType(), FLINK_1_20));
+  }
+
+  @Test
+  public void testRejectNanosecondTimestampsBeforeFlink120() {
+    for (String flinkVersionId : new String[] {FLINK_1_18, FLINK_1_19}) {
+      Assertions.assertThrows(
+          IllegalArgumentException.class,
+          () -> TypeUtils.fromFlinkType(new TimestampType(9), flinkVersionId));
+      Assertions.assertThrows(
+          IllegalArgumentException.class,
+          () ->
+              TypeUtils.fromFlinkType(
+                  new ArrayType(new LocalZonedTimestampType(9)), flinkVersionId));
+      Assertions.assertThrows(
+          IllegalArgumentException.class,
+          () -> TypeUtils.toFlinkType(Types.TimestampType.withoutTimeZone(9), flinkVersionId));
+      Assertions.assertThrows(
+          IllegalArgumentException.class,
+          () ->
+              TypeUtils.toFlinkType(
+                  Types.ListType.nullable(Types.TimestampType.withTimeZone(9)), flinkVersionId));
+    }
   }
 
   @Test
@@ -283,58 +317,98 @@ public class TestTypeUtils {
   public void testRejectVariantType() {
     IllegalArgumentException exception =
         Assertions.assertThrows(
-            IllegalArgumentException.class, () -> TypeUtils.toFlinkType(Types.VariantType.get()));
+            IllegalArgumentException.class,
+            () -> TypeUtils.toFlinkType(Types.VariantType.get(), FLINK_1_20));
     Assertions.assertEquals(
-        "Flink 1.18-1.20 has no VARIANT logical type for Gravitino variant",
+        "Flink 1.20 has no VARIANT logical type for Gravitino variant; VARIANT requires Flink 2.1 "
+            + "or later",
         exception.getMessage());
+
+    if (isCurrentFlinkAtLeast(2, 1)) {
+      Assertions.assertEquals(
+          "VARIANT",
+          TypeUtils.toFlinkType(Types.VariantType.get(), FLINK_2_1)
+              .getLogicalType()
+              .getTypeRoot()
+              .name());
+    } else {
+      IllegalArgumentException runtimeException =
+          Assertions.assertThrows(
+              IllegalArgumentException.class,
+              () -> TypeUtils.toFlinkType(Types.VariantType.get(), FLINK_2_1));
+      Assertions.assertEquals(
+          "The configured Flink version 2.1 supports VARIANT, but the active Flink runtime does not "
+              + "expose DataTypes.VARIANT()",
+          runtimeException.getMessage());
+    }
+
+    if (!isCurrentFlinkAtLeast(2, 1)) {
+      IllegalArgumentException futureRuntimeException =
+          Assertions.assertThrows(
+              IllegalArgumentException.class,
+              () -> TypeUtils.toFlinkType(Types.VariantType.get(), "2.2"));
+      Assertions.assertTrue(
+          futureRuntimeException.getMessage().startsWith("The configured Flink version 2.2"));
+    }
   }
 
   @Test
   public void testUnknownTypeRoundTrip() {
     Types.NullType unknown = Types.NullType.get();
 
-    Assertions.assertEquals(DataTypes.NULL(), TypeUtils.toFlinkType(unknown));
-    Assertions.assertEquals(
-        unknown, TypeUtils.toGravitinoType(TypeUtils.toFlinkType(unknown).getLogicalType()));
+    for (String flinkVersionId : new String[] {FLINK_1_18, FLINK_1_19, FLINK_1_20}) {
+      Assertions.assertEquals(DataTypes.NULL(), TypeUtils.toFlinkType(unknown, flinkVersionId));
+      Assertions.assertEquals(
+          unknown,
+          TypeUtils.fromFlinkType(
+              TypeUtils.toFlinkType(unknown, flinkVersionId).getLogicalType(), flinkVersionId));
+    }
   }
 
   @Test
   public void testRejectGeometryTypes() {
-    String expectedMessage =
-        "Flink 1.18-1.20 has no geometry logical type that preserves CRS metadata";
+    String expectedMessage = "Flink 2.1 has no geometry logical type that preserves CRS metadata";
 
     Assertions.assertEquals(
         expectedMessage,
         Assertions.assertThrows(
                 IllegalArgumentException.class,
-                () -> TypeUtils.toFlinkType(Types.GeometryType.crs84()))
+                () -> TypeUtils.toFlinkType(Types.GeometryType.crs84(), FLINK_2_1))
             .getMessage());
     Assertions.assertEquals(
         expectedMessage,
         Assertions.assertThrows(
                 IllegalArgumentException.class,
-                () -> TypeUtils.toFlinkType(Types.GeometryType.of("EPSG:3857")))
+                () -> TypeUtils.toFlinkType(Types.GeometryType.of("EPSG:3857"), FLINK_2_1))
             .getMessage());
   }
 
   @Test
   public void testRejectGeographyTypes() {
     String expectedMessage =
-        "Flink 1.18-1.20 has no geography logical type that preserves CRS and edge algorithm "
+        "Flink 2.1 has no geography logical type that preserves CRS and edge algorithm "
             + "metadata";
 
     Assertions.assertEquals(
         expectedMessage,
         Assertions.assertThrows(
                 IllegalArgumentException.class,
-                () -> TypeUtils.toFlinkType(Types.GeographyType.crs84()))
+                () -> TypeUtils.toFlinkType(Types.GeographyType.crs84(), FLINK_2_1))
             .getMessage());
     Assertions.assertEquals(
         expectedMessage,
         Assertions.assertThrows(
                 IllegalArgumentException.class,
-                () -> TypeUtils.toFlinkType(Types.GeographyType.of("EPSG:4326", "karney")))
+                () ->
+                    TypeUtils.toFlinkType(Types.GeographyType.of("EPSG:4326", "karney"), FLINK_2_1))
             .getMessage());
+  }
+
+  @Test
+  public void testRejectInvalidFlinkVersionId() {
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> TypeUtils.toFlinkType(Types.TimestampType.withoutTimeZone(9), "current"));
   }
 
   @Test
@@ -366,5 +440,12 @@ public class TestTypeUtils {
     Assertions.assertEquals(
         DataTypes.MULTISET(DataTypes.BIGINT()),
         TypeUtils.toFlinkType(Types.ExternalType.of("MULTISET<BIGINT>")));
+  }
+
+  private static boolean isCurrentFlinkAtLeast(int requiredMajor, int requiredMinor) {
+    String[] versionParts = FlinkVersion.current().toString().split("\\.");
+    int major = Integer.parseInt(versionParts[0]);
+    int minor = Integer.parseInt(versionParts[1]);
+    return major > requiredMajor || (major == requiredMajor && minor >= requiredMinor);
   }
 }

--- a/flink-connector/flink-common/src/test/java/org/apache/gravitino/flink/connector/utils/TestTypeUtils.java
+++ b/flink-connector/flink-common/src/test/java/org/apache/gravitino/flink/connector/utils/TestTypeUtils.java
@@ -280,6 +280,16 @@ public class TestTypeUtils {
   }
 
   @Test
+  public void testRejectVariantType() {
+    IllegalArgumentException exception =
+        Assertions.assertThrows(
+            IllegalArgumentException.class, () -> TypeUtils.toFlinkType(Types.VariantType.get()));
+    Assertions.assertEquals(
+        "Flink 1.18-1.20 has no VARIANT logical type for Gravitino variant",
+        exception.getMessage());
+  }
+
+  @Test
   public void testMultisetTypeConversion() {
     // MULTISET<STRING> (VARCHAR(MAX)) should be preserved as ExternalType
     Assertions.assertEquals(

--- a/flink-connector/flink-common/src/test/java/org/apache/gravitino/flink/connector/utils/TestTypeUtils.java
+++ b/flink-connector/flink-common/src/test/java/org/apache/gravitino/flink/connector/utils/TestTypeUtils.java
@@ -318,6 +318,26 @@ public class TestTypeUtils {
   }
 
   @Test
+  public void testRejectGeographyTypes() {
+    String expectedMessage =
+        "Flink 1.18-1.20 has no geography logical type that preserves CRS and edge algorithm "
+            + "metadata";
+
+    Assertions.assertEquals(
+        expectedMessage,
+        Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> TypeUtils.toFlinkType(Types.GeographyType.crs84()))
+            .getMessage());
+    Assertions.assertEquals(
+        expectedMessage,
+        Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> TypeUtils.toFlinkType(Types.GeographyType.of("EPSG:4326", "karney")))
+            .getMessage());
+  }
+
+  @Test
   public void testMultisetTypeConversion() {
     // MULTISET<STRING> (VARCHAR(MAX)) should be preserved as ExternalType
     Assertions.assertEquals(

--- a/flink-connector/v1.20/flink/src/test/java/org/apache/gravitino/flink/connector/integration/test/iceberg/FlinkIcebergJdbcCatalogIT120.java
+++ b/flink-connector/v1.20/flink/src/test/java/org/apache/gravitino/flink/connector/integration/test/iceberg/FlinkIcebergJdbcCatalogIT120.java
@@ -26,4 +26,11 @@ import org.junit.jupiter.api.condition.DisabledIf;
 // embedded MiniGravitino server shares the JVM with the Flink Iceberg runtime. Run in deploy mode
 // only. @DisabledIf is not @Inherited, so each concrete subclass must declare it explicitly.
 @DisabledIf("org.apache.gravitino.integration.test.util.ITUtils#isEmbedded")
-public class FlinkIcebergJdbcCatalogIT120 extends FlinkIcebergJdbcCatalogIT {}
+public class FlinkIcebergJdbcCatalogIT120 extends FlinkIcebergJdbcCatalogIT {
+
+  /** {@inheritDoc} */
+  @Override
+  protected boolean supportsNanosecondTimestampRoundTrip() {
+    return true;
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

Make the five Gravitino V3-native type families depend on the active Flink runtime version. The shared converter accepts a mapping only when the Flink/Iceberg path preserves its complete contract; otherwise create, alter, and load fail before catalog mutation.

Gravitino currently publishes Flink 1.18, 1.19, and 1.20 modules with these [Iceberg dependency pins](https://github.com/apache/gravitino/blob/main/gradle/libs.versions.toml). The converter takes one runtime version ID, propagates it through nested types, and enables native `VARIANT` for Flink 2.1 and every later numeric version without a connector-version allowlist.

| Type family | Outcome | Minimum compatible version | Upstream evidence |
| --- | --- | --- | --- |
| `timestamp(9)`, `timestamp_tz(9)` | Flink 1.18/1.19 reject precision above 6; Flink 1.20 preserves `TIMESTAMP(9)`/`TIMESTAMP_LTZ(9)` schemas and values exactly. Offset-bearing `TIMESTAMP WITH TIME ZONE` rejects because conversion would discard per-value offsets. | Flink 1.20 + Iceberg 1.11.0 | [Iceberg nanosecond fix](https://github.com/apache/iceberg/pull/15475), [Flink 1.20 backport](https://github.com/apache/iceberg/pull/16240) |
| `variant` | Reject below Flink 2.1. An active Flink 2.1 or later runtime uses native `VARIANT`, including future versions; Gravitino does not yet publish a Flink 2.1 module. | Flink 2.1 + Iceberg 1.11.0 | [Flink 2.1 `VARIANT`](https://nightlies.apache.org/flink/flink-docs-release-2.1/docs/dev/table/types/#variant), [Iceberg integration](https://github.com/apache/iceberg/pull/15265) |
| nullable `unknown` / `NULL` | Preserve Iceberg `UNKNOWN` as nullable Flink `NULL` on schema/load paths. Required Unknown rejects, and Flink `NULL` is not exposed as general table DDL. | Flink 1.18 + Iceberg 1.9.0 | [Iceberg Flink 1.18/1.19 support](https://github.com/apache/iceberg/pull/12532), [Iceberg Flink 1.20 support](https://github.com/apache/iceberg/pull/12470), [Flink `NullType` contract](https://github.com/apache/flink/blob/release-2.1/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/NullType.java) |
| `geometry(crs)` | Reject because Flink has no native logical type that preserves CRS metadata. | None through released Flink 2.3 | [Flink 2.3 type list](https://nightlies.apache.org/flink/flink-docs-release-2.3/docs/sql/reference/data-types/), [Iceberg geometry contract](https://iceberg.apache.org/spec/#version-3-extended-types-and-capabilities) |
| `geography(crs, algorithm)` | Reject because Flink has no native logical type that preserves CRS and edge-algorithm metadata. Upstream support is proposed but not released. | None through released Flink 2.3 | [Flink 2.3 type list](https://nightlies.apache.org/flink/flink-docs-release-2.3/docs/sql/reference/data-types/), [Flink geography proposal](https://issues.apache.org/jira/browse/FLINK-39896), [Iceberg geography contract](https://iceberg.apache.org/spec/#version-3-extended-types-and-capabilities) |

### Why are the changes needed?

Flink conversion previously had one unconditional contract for all versions. That could silently lose nanosecond precision on older Iceberg paths and could not take advantage of native `VARIANT` in Flink 2.1+. Explicit version gates preserve exact mappings, reject unsafe ones before mutation, and remain forward-compatible.

Fixes #12058

Related: #12056

### Does this PR introduce _any_ user-facing change?

Yes. Flink 1.18/1.19 now reject unsafe precision-7-to-9 timestamps, Flink 1.20 preserves nanosecond timestamps exactly, nullable Iceberg Unknown loads as Flink `NULL`, and Flink 2.1+ can use native `VARIANT`. Unsupported spatial types fail explicitly before catalog mutation.

### How was this patch tested?

- Passed focused `TypeUtils` and catalog conversion suites under Flink 1.18, 1.19, and 1.20.
- Passed an isolated Flink 1.20 deploy integration test that writes and reads actual precision-9 timestamp values and loads nullable Iceberg `UNKNOWN` as Flink `NULL`.
- Added deploy integration coverage for pre-mutation nanosecond rejection on Flink 1.18/1.19.
- Smoke-tested both Variant conversion directions against real Flink 2.1 runtime jars, including active runtime-version lookup.
- Passed distribution compilation and formatting checks.
- Updated `docs/flink-connector/flink-connector.md` with the version/evidence matrix.