### PR TITLE
[#12059] fix(trino): complete V3 type compatibility

### DIFF
--- a/docs/trino-connector/catalog-iceberg.md
+++ b/docs/trino-connector/catalog-iceberg.md
@@ -20,6 +20,15 @@ To use Iceberg, you need:
   - ORC
   - Parquet (default)
 
+## Iceberg V3 type compatibility
+
+The supported Trino versions are 435 through 478. They predate Trino's Iceberg V3 type support, so
+the connector rejects incompatible V3 types before invoking the internal Iceberg connector.
+
+| Gravitino type                         | Outcome                                                                                     |
+|----------------------------------------|---------------------------------------------------------------------------------------------|
+| `Timestamp(9)` / `Timestamp_tz(9)`    | Rejected before connector invocation; these versions preserve only microsecond precision 6. |
+
 ## Schema Operations
 
 ### Create a Schema

--- a/docs/trino-connector/catalog-iceberg.md
+++ b/docs/trino-connector/catalog-iceberg.md
@@ -30,6 +30,7 @@ the connector rejects incompatible V3 types before invoking the internal Iceberg
 | `Timestamp(9)` / `Timestamp_tz(9)`    | Rejected before connector invocation; these versions preserve only microsecond precision 6. |
 | `Variant`                              | Rejected before connector invocation; Trino Iceberg support starts in version 481.           |
 | `Unknown`                              | Rejected before connector invocation; Trino cannot use a null-only type for table columns.    |
+| `Geometry`                             | Rejected before connector invocation; Trino Iceberg support starts in version 482.           |
 
 ## Schema Operations
 

--- a/docs/trino-connector/catalog-iceberg.md
+++ b/docs/trino-connector/catalog-iceberg.md
@@ -22,16 +22,22 @@ To use Iceberg, you need:
 
 ## Iceberg V3 type compatibility
 
-The supported Trino versions are 435 through 478. They predate Trino's Iceberg V3 type support, so
-the connector rejects incompatible V3 types before invoking the internal Iceberg connector.
+The Gravitino connector currently supports Trino versions 435 through 478. The runtime Trino
+version is passed to the Iceberg type converter so that it can reject a conversion before any
+catalog mutation when the runtime cannot preserve the type.
 
-| Gravitino type                         | Outcome                                                                                     |
-|----------------------------------------|---------------------------------------------------------------------------------------------|
-| `Timestamp(9)` / `Timestamp_tz(9)`    | Rejected before connector invocation; these versions preserve only microsecond precision 6. |
-| `Variant`                              | Rejected before connector invocation; Trino Iceberg support starts in version 481.           |
-| `Unknown`                              | Rejected before connector invocation; Trino cannot use a null-only type for table columns.    |
-| `Geometry`                             | Rejected before connector invocation; Trino Iceberg support starts in version 482.           |
-| `Geography`                            | Rejected before connector invocation; Trino Iceberg support starts in version 482.           |
+| Iceberg / Gravitino type                       | Minimum upstream Trino version | Gravitino conversion policy                                                                           |
+|------------------------------------------------|--------------------------------|--------------------------------------------------------------------------------------------------------|
+| `Timestamp(p)` / `Timestamp_tz(p)`, `p <= 6`  | 435                            | Supported and normalized to Iceberg microsecond precision 6.                                          |
+| `Timestamp(9)` / `Timestamp_tz(9)`            | 481                            | Supported by the converter on Trino 481 or newer; rejected on the currently packaged versions.        |
+| `Variant`                                      | 481                            | Rejected even on Trino 481 or newer because Gravitino cannot preserve the complete type semantics.    |
+| `Unknown`                                      | Not supported                  | Rejected because Trino cannot use Iceberg's null-only type as a persisted table column.                |
+| `Geometry`                                     | 482                            | Rejected even on Trino 482 or newer because Gravitino cannot preserve the complete CRS metadata.      |
+| `Geography`                                    | 482                            | Rejected even on Trino 482 or newer because Gravitino cannot preserve the complete edge/CRS metadata. |
+
+Timestamp precisions 7, 8, and 10 through 12 have no lossless Iceberg representation and are
+rejected for every Trino version. The 481 and 482 rows encode the converter policy for future
+connector module ranges; they do not expand the currently packaged Trino range beyond 478.
 
 ## Schema Operations
 

--- a/docs/trino-connector/catalog-iceberg.md
+++ b/docs/trino-connector/catalog-iceberg.md
@@ -31,6 +31,7 @@ the connector rejects incompatible V3 types before invoking the internal Iceberg
 | `Variant`                              | Rejected before connector invocation; Trino Iceberg support starts in version 481.           |
 | `Unknown`                              | Rejected before connector invocation; Trino cannot use a null-only type for table columns.    |
 | `Geometry`                             | Rejected before connector invocation; Trino Iceberg support starts in version 482.           |
+| `Geography`                            | Rejected before connector invocation; Trino Iceberg support starts in version 482.           |
 
 ## Schema Operations
 

--- a/docs/trino-connector/catalog-iceberg.md
+++ b/docs/trino-connector/catalog-iceberg.md
@@ -29,6 +29,7 @@ the connector rejects incompatible V3 types before invoking the internal Iceberg
 |----------------------------------------|---------------------------------------------------------------------------------------------|
 | `Timestamp(9)` / `Timestamp_tz(9)`    | Rejected before connector invocation; these versions preserve only microsecond precision 6. |
 | `Variant`                              | Rejected before connector invocation; Trino Iceberg support starts in version 481.           |
+| `Unknown`                              | Rejected before connector invocation; Trino cannot use a null-only type for table columns.    |
 
 ## Schema Operations
 

--- a/docs/trino-connector/catalog-iceberg.md
+++ b/docs/trino-connector/catalog-iceberg.md
@@ -28,6 +28,7 @@ the connector rejects incompatible V3 types before invoking the internal Iceberg
 | Gravitino type                         | Outcome                                                                                     |
 |----------------------------------------|---------------------------------------------------------------------------------------------|
 | `Timestamp(9)` / `Timestamp_tz(9)`    | Rejected before connector invocation; these versions preserve only microsecond precision 6. |
+| `Variant`                              | Rejected before connector invocation; Trino Iceberg support starts in version 481.           |
 
 ## Schema Operations
 

--- a/trino-connector/integration-test/src/test/java/org/apache/gravitino/trino/connector/integration/test/TestTrinoQueryIT.java
+++ b/trino-connector/integration-test/src/test/java/org/apache/gravitino/trino/connector/integration/test/TestTrinoQueryIT.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.trino.connector.integration.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+/** Tests runtime parameter substitution in {@link TrinoQueryIT}. */
+public class TestTrinoQueryIT {
+
+  @AfterEach
+  void clearQueryParameters() {
+    TrinoQueryIT.queryParams.clear();
+  }
+
+  @Test
+  void testResolveExpectedRuntimeVersion() throws Exception {
+    TrinoQueryIT.queryParams.put("trino_version", "478");
+
+    assertEquals(
+        "current Trino version is 478",
+        TrinoQueryIT.resolveParameters("current Trino version is ${trino_version}"));
+  }
+
+  @Test
+  void testRejectMissingExpectedRuntimeVersion() {
+    Exception exception =
+        assertThrows(
+            Exception.class,
+            () -> TrinoQueryIT.resolveParameters("current Trino version is ${trino_version}"));
+
+    assertEquals(
+        "Parameter trino_version is not defined in test parameters", exception.getMessage());
+  }
+}

--- a/trino-connector/integration-test/src/test/java/org/apache/gravitino/trino/connector/integration/test/TrinoQueryIT.java
+++ b/trino-connector/integration-test/src/test/java/org/apache/gravitino/trino/connector/integration/test/TrinoQueryIT.java
@@ -47,6 +47,7 @@ import org.slf4j.LoggerFactory;
 
 public class TrinoQueryIT extends TrinoQueryITBase {
   private static final Logger LOG = LoggerFactory.getLogger(TrinoQueryIT.class);
+  private static final int DEFAULT_TRINO_VERSION = 478;
 
   protected static String testsetsDir;
   protected AtomicInteger passCount = new AtomicInteger(0);
@@ -93,6 +94,9 @@ public class TrinoQueryIT extends TrinoQueryITBase {
     queryParams.put("trino_uri", trinoUri);
     queryParams.put("postgresql_uri", postgresqlUri);
     queryParams.put("gravitino_uri", gravitinoUri);
+    queryParams.put(
+        "trino_version",
+        String.valueOf(trinoVersion == null ? DEFAULT_TRINO_VERSION : trinoVersion));
 
     LOG.info("Test query env parameters: {}", queryParams);
   }
@@ -195,7 +199,7 @@ public class TrinoQueryIT extends TrinoQueryITBase {
     return sql.replaceAll("--.*?\\n", "");
   }
 
-  private static String resolveParameters(String sql) throws Exception {
+  static String resolveParameters(String sql) throws Exception {
     // ${?param} is optional (resolves to empty string when not provided); ${param} is required.
     Matcher sqlMatcher = PARAM_PATTERN.matcher(sql);
     StringBuffer replacedString = new StringBuffer();
@@ -249,6 +253,7 @@ public class TrinoQueryIT extends TrinoQueryITBase {
           expectResult = resultMatcher.group(4).trim();
         }
       }
+      expectResult = resolveParameters(expectResult);
 
       String result = queryRunner.runQuery(sql).trim();
       result = result.replaceAll("WARNING:.*?\\n", "");

--- a/trino-connector/integration-test/src/test/java/org/apache/gravitino/trino/connector/integration/test/TrinoQueryTestTool.java
+++ b/trino-connector/integration-test/src/test/java/org/apache/gravitino/trino/connector/integration/test/TrinoQueryTestTool.java
@@ -99,7 +99,7 @@ public class TrinoQueryTestTool {
               + "otherwise fall back to a single-node setup with combined coordinator-worker roles.");
 
       options.addOption(
-          "trino_version", true, "Specify the Trino version to test, the default value is 435.");
+          "trino_version", true, "Specify the Trino version to test, the default value is 478.");
 
       options.addOption(
           "trino_connector_dir",

--- a/trino-connector/integration-test/src/test/resources/trino-ci-testset/testsets/lakehouse-iceberg/00014_v3_type_compatibility.sql
+++ b/trino-connector/integration-test/src/test/resources/trino-ci-testset/testsets/lakehouse-iceberg/00014_v3_type_compatibility.sql
@@ -1,0 +1,23 @@
+CREATE SCHEMA gt_v3_type_compatibility;
+
+USE gt_v3_type_compatibility;
+
+CREATE TABLE rejected_nanosecond_timestamp (
+    value TIMESTAMP(9)
+);
+
+SHOW TABLES LIKE 'rejected_nanosecond_timestamp';
+
+CREATE TABLE rejected_geometry (
+    value GEOMETRY
+);
+
+SHOW TABLES LIKE 'rejected_geometry';
+
+CREATE TABLE rejected_geography (
+    value SPHERICALGEOGRAPHY
+);
+
+SHOW TABLES LIKE 'rejected_geography';
+
+DROP SCHEMA gt_v3_type_compatibility;

--- a/trino-connector/integration-test/src/test/resources/trino-ci-testset/testsets/lakehouse-iceberg/00014_v3_type_compatibility.txt
+++ b/trino-connector/integration-test/src/test/resources/trino-ci-testset/testsets/lakehouse-iceberg/00014_v3_type_compatibility.txt
@@ -1,0 +1,17 @@
+CREATE SCHEMA
+
+USE
+
+<QUERY_FAILED> Iceberg V3 nanosecond timestamp requires Trino 481 or newer; current Trino version is ${trino_version}
+
+<BLANK_LINE>
+
+<QUERY_FAILED> Iceberg V3 geometry requires Trino 482 or newer; current Trino version is ${trino_version}
+
+<BLANK_LINE>
+
+<QUERY_FAILED> Iceberg V3 geography requires Trino 482 or newer; current Trino version is ${trino_version}
+
+<BLANK_LINE>
+
+DROP SCHEMA

--- a/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/catalog/CatalogConnectorAdapter.java
+++ b/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/catalog/CatalogConnectorAdapter.java
@@ -67,6 +67,16 @@ public interface CatalogConnectorAdapter {
   CatalogConnectorMetadataAdapter getMetadataAdapter();
 
   /**
+   * Returns the metadata adapter for the catalog connector on a specific Trino runtime.
+   *
+   * @param trinoVersion the runtime Trino SPI version
+   * @return the metadata adapter
+   */
+  default CatalogConnectorMetadataAdapter getMetadataAdapter(int trinoVersion) {
+    return getMetadataAdapter();
+  }
+
+  /**
    * @return ColumnProperties list that used to validate column properties.
    */
   default List<PropertyMetadata<?>> getColumnProperties() {

--- a/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/catalog/CatalogConnectorContext.java
+++ b/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/catalog/CatalogConnectorContext.java
@@ -39,6 +39,8 @@ import org.apache.gravitino.trino.connector.metadata.GravitinoCatalog;
  */
 public class CatalogConnectorContext {
 
+  private static final int MIN_SUPPORTED_TRINO_VERSION = 435;
+
   private final GravitinoCatalog catalog;
   private final GravitinoMetalake metalake;
 
@@ -51,6 +53,8 @@ public class CatalogConnectorContext {
   private final CatalogConnectorAdapter adapter;
 
   private final GravitinoConfig config;
+
+  private final int trinoVersion;
 
   /**
    * Constructs a new CatalogConnectorContext.
@@ -67,11 +71,32 @@ public class CatalogConnectorContext {
       Connector internalConnector,
       CatalogConnectorAdapter adapter,
       GravitinoConfig config) {
+    this(catalog, metalake, internalConnector, adapter, config, MIN_SUPPORTED_TRINO_VERSION);
+  }
+
+  /**
+   * Constructs a new CatalogConnectorContext for a specific Trino runtime.
+   *
+   * @param catalog the Gravitino catalog
+   * @param metalake the Gravitino metalake
+   * @param internalConnector the internal connector
+   * @param adapter the catalog connector adapter
+   * @param config the Gravitino connector configuration
+   * @param trinoVersion the runtime Trino SPI version
+   */
+  public CatalogConnectorContext(
+      GravitinoCatalog catalog,
+      GravitinoMetalake metalake,
+      Connector internalConnector,
+      CatalogConnectorAdapter adapter,
+      GravitinoConfig config,
+      int trinoVersion) {
     this.catalog = catalog;
     this.metalake = metalake;
     this.internalConnector = internalConnector;
     this.adapter = adapter;
     this.config = config;
+    this.trinoVersion = trinoVersion;
   }
 
   /**
@@ -166,7 +191,7 @@ public class CatalogConnectorContext {
    * @return the metadata adapter
    */
   public CatalogConnectorMetadataAdapter getMetadataAdapter() {
-    return adapter.getMetadataAdapter();
+    return adapter.getMetadataAdapter(trinoVersion);
   }
 
   /** Builder class for creating CatalogConnectorContext instances. */
@@ -271,7 +296,13 @@ public class CatalogConnectorContext {
       Connector connector =
           GravitinoConnectorPluginManager.instance(context.getClass().getClassLoader())
               .createConnector(internalConnectorName, connectorConfig, context);
-      return new CatalogConnectorContext(catalog, metalake, connector, connectorAdapter, config);
+      return new CatalogConnectorContext(
+          catalog,
+          metalake,
+          connector,
+          connectorAdapter,
+          config,
+          Integer.parseInt(context.getSpiVersion()));
     }
   }
 }

--- a/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/catalog/iceberg/IcebergConnectorAdapter.java
+++ b/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/catalog/iceberg/IcebergConnectorAdapter.java
@@ -36,6 +36,7 @@ import org.apache.gravitino.trino.connector.metadata.GravitinoCatalog;
  */
 public class IcebergConnectorAdapter implements CatalogConnectorAdapter {
 
+  private static final int MIN_SUPPORTED_TRINO_VERSION = 435;
   private static final String CONNECTOR_ICEBERG = "iceberg";
   private final IcebergPropertyMeta propertyMetadata;
   private final PropertyConverter catalogConverter;
@@ -65,8 +66,14 @@ public class IcebergConnectorAdapter implements CatalogConnectorAdapter {
 
   @Override
   public CatalogConnectorMetadataAdapter getMetadataAdapter() {
+    return getMetadataAdapter(MIN_SUPPORTED_TRINO_VERSION);
+  }
+
+  @Override
+  public CatalogConnectorMetadataAdapter getMetadataAdapter(int trinoVersion) {
     // TODO yuhui Need to improve schema table and column properties
-    return new IcebergMetadataAdapter(getSchemaProperties(), getTableProperties(), emptyList());
+    return new IcebergMetadataAdapter(
+        getSchemaProperties(), getTableProperties(), emptyList(), trinoVersion);
   }
 
   @Override

--- a/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/catalog/iceberg/IcebergDataTypeTransformer.java
+++ b/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/catalog/iceberg/IcebergDataTypeTransformer.java
@@ -25,6 +25,7 @@ import io.trino.spi.type.TimestampType;
 import io.trino.spi.type.TimestampWithTimeZoneType;
 import io.trino.spi.type.VarbinaryType;
 import io.trino.spi.type.VarcharType;
+import java.util.OptionalInt;
 import org.apache.gravitino.rel.types.Type;
 import org.apache.gravitino.rel.types.Type.Name;
 import org.apache.gravitino.rel.types.Types;
@@ -34,18 +35,30 @@ import org.apache.gravitino.trino.connector.util.GeneralDataTypeTransformer;
 /** Type transformer between Apache Iceberg and Trino */
 public class IcebergDataTypeTransformer extends GeneralDataTypeTransformer {
 
-  private static final int ICEBERG_TIMESTAMP_PRECISION = TRINO_MICROS_PRECISION;
+  private static final int ICEBERG_MICROS_TIMESTAMP_PRECISION = TRINO_MICROS_PRECISION;
+  private static final int ICEBERG_NANOS_TIMESTAMP_PRECISION = 9;
+
+  private final int trinoVersion;
+
+  /**
+   * Constructs an Iceberg type transformer for a specific Trino runtime.
+   *
+   * @param trinoVersion the runtime Trino SPI version
+   */
+  public IcebergDataTypeTransformer(int trinoVersion) {
+    this.trinoVersion = trinoVersion;
+  }
 
   @Override
   public Type getGravitinoType(io.trino.spi.type.Type type) {
     if (hasBaseType(type, "unknown")) {
-      throw unsupportedUnknownType();
+      throw unsupportedIcebergV3Type(IcebergV3Type.UNKNOWN);
     } else if (hasBaseType(type, "variant")) {
-      throw unsupportedIcebergV3Type("variant", 481);
+      throw unsupportedIcebergV3Type(IcebergV3Type.VARIANT);
     } else if (hasBaseType(type, "geometry")) {
-      throw unsupportedIcebergV3Type("geometry", 482);
+      throw unsupportedIcebergV3Type(IcebergV3Type.GEOMETRY);
     } else if (hasBaseType(type, "geography") || hasBaseType(type, "sphericalgeography")) {
-      throw unsupportedIcebergV3Type("geography", 482);
+      throw unsupportedIcebergV3Type(IcebergV3Type.GEOGRAPHY);
     }
 
     Class<? extends io.trino.spi.type.Type> typeClass = type.getClass();
@@ -65,14 +78,14 @@ public class IcebergDataTypeTransformer extends GeneralDataTypeTransformer {
       // Iceberg only supports time type with microsecond (6) precision
       return Types.TimeType.of(TRINO_MICROS_PRECISION);
     } else if (io.trino.spi.type.TimestampType.class.isAssignableFrom(typeClass)) {
-      validateTimestampPrecision(((TimestampType) type).getPrecision(), type.getDisplayName());
-      // Iceberg only supports timestamp type (without time zone) with microsecond (6) precision
-      return Types.TimestampType.withoutTimeZone(ICEBERG_TIMESTAMP_PRECISION);
+      int precision =
+          icebergTimestampPrecision(((TimestampType) type).getPrecision(), type.getDisplayName());
+      return Types.TimestampType.withoutTimeZone(precision);
     } else if (io.trino.spi.type.TimestampWithTimeZoneType.class.isAssignableFrom(typeClass)) {
-      validateTimestampPrecision(
-          ((TimestampWithTimeZoneType) type).getPrecision(), type.getDisplayName());
-      // Iceberg only supports timestamp with time zone type with microsecond (6) precision
-      return Types.TimestampType.withTimeZone(ICEBERG_TIMESTAMP_PRECISION);
+      int precision =
+          icebergTimestampPrecision(
+              ((TimestampWithTimeZoneType) type).getPrecision(), type.getDisplayName());
+      return Types.TimestampType.withTimeZone(precision);
     }
 
     return super.getGravitinoType(type);
@@ -81,57 +94,97 @@ public class IcebergDataTypeTransformer extends GeneralDataTypeTransformer {
   @Override
   public io.trino.spi.type.Type getTrinoType(Type type) {
     if (Name.NULL == type.name()) {
-      throw unsupportedUnknownType();
+      throw unsupportedIcebergV3Type(IcebergV3Type.UNKNOWN);
     } else if (Name.FIXED == type.name()) {
       return VarbinaryType.VARBINARY;
     } else if (Name.VARIANT == type.name()) {
-      throw unsupportedIcebergV3Type(type.simpleString(), 481);
+      throw unsupportedIcebergV3Type(IcebergV3Type.VARIANT);
     } else if (Name.GEOMETRY == type.name()) {
-      throw unsupportedIcebergV3Type(type.simpleString(), 482);
+      throw unsupportedIcebergV3Type(IcebergV3Type.GEOMETRY);
     } else if (Name.GEOGRAPHY == type.name()) {
-      throw unsupportedIcebergV3Type(type.simpleString(), 482);
+      throw unsupportedIcebergV3Type(IcebergV3Type.GEOGRAPHY);
     } else if (Name.TIME == type.name()) {
       return TimeType.TIME_MICROS;
     } else if (Name.TIMESTAMP == type.name()) {
       Types.TimestampType timestampType = (Types.TimestampType) type;
-      if (timestampType.hasPrecisionSet()) {
-        validateTimestampPrecision(timestampType.precision(), type.simpleString());
-      }
+      int precision =
+          timestampType.hasPrecisionSet()
+              ? icebergTimestampPrecision(timestampType.precision(), type.simpleString())
+              : ICEBERG_MICROS_TIMESTAMP_PRECISION;
       if (timestampType.hasTimeZone()) {
-        return TimestampWithTimeZoneType.TIMESTAMP_TZ_MICROS;
+        return TimestampWithTimeZoneType.createTimestampWithTimeZoneType(precision);
       } else {
-        return TimestampType.TIMESTAMP_MICROS;
+        return TimestampType.createTimestampType(precision);
       }
     }
 
     return super.getTrinoType(type);
   }
 
-  private static void validateTimestampPrecision(int precision, String typeName) {
-    if (precision != ICEBERG_TIMESTAMP_PRECISION) {
-      throw new TrinoException(
-          GravitinoErrorCode.GRAVITINO_ILLEGAL_ARGUMENT,
-          String.format(
-              "The supported Trino Iceberg connector versions cannot preserve %s; only timestamp precision %d is lossless",
-              typeName, ICEBERG_TIMESTAMP_PRECISION));
+  private int icebergTimestampPrecision(int precision, String typeName) {
+    if (precision <= ICEBERG_MICROS_TIMESTAMP_PRECISION) {
+      return ICEBERG_MICROS_TIMESTAMP_PRECISION;
     }
+    if (precision == ICEBERG_NANOS_TIMESTAMP_PRECISION) {
+      if (trinoVersion >= IcebergV3Type.NANOSECOND_TIMESTAMP.minimumTrinoVersion.getAsInt()) {
+        return ICEBERG_NANOS_TIMESTAMP_PRECISION;
+      }
+      throw unsupportedIcebergV3Type(IcebergV3Type.NANOSECOND_TIMESTAMP);
+    }
+
+    throw new TrinoException(
+        GravitinoErrorCode.GRAVITINO_ILLEGAL_ARGUMENT,
+        String.format(
+            "Iceberg cannot preserve %s; timestamp precision must be %d or %d",
+            typeName, ICEBERG_MICROS_TIMESTAMP_PRECISION, ICEBERG_NANOS_TIMESTAMP_PRECISION));
   }
 
   private static boolean hasBaseType(io.trino.spi.type.Type type, String typeName) {
     return type.getTypeSignature().getBase().equalsIgnoreCase(typeName);
   }
 
-  private static TrinoException unsupportedIcebergV3Type(String typeName, int requiredVersion) {
+  private TrinoException unsupportedIcebergV3Type(IcebergV3Type type) {
+    if (type.minimumTrinoVersion.isEmpty()) {
+      return new TrinoException(
+          GravitinoErrorCode.GRAVITINO_ILLEGAL_ARGUMENT,
+          String.format(
+              "Iceberg V3 %s is not supported by any Trino Iceberg connector version",
+              type.displayName));
+    }
+    int minimumTrinoVersion = type.minimumTrinoVersion.getAsInt();
+    if (trinoVersion < minimumTrinoVersion) {
+      return new TrinoException(
+          GravitinoErrorCode.GRAVITINO_ILLEGAL_ARGUMENT,
+          String.format(
+              "Iceberg V3 %s requires Trino %d or newer; current Trino version is %d",
+              type.displayName, minimumTrinoVersion, trinoVersion));
+    }
+
     return new TrinoException(
         GravitinoErrorCode.GRAVITINO_ILLEGAL_ARGUMENT,
         String.format(
-            "The supported Trino Iceberg connector versions cannot preserve Iceberg V3 %s; support starts in Trino %d",
-            typeName, requiredVersion));
+            "The Gravitino connector cannot losslessly convert Iceberg V3 %s on Trino %d",
+            type.displayName, trinoVersion));
   }
 
-  private static TrinoException unsupportedUnknownType() {
-    return new TrinoException(
-        GravitinoErrorCode.GRAVITINO_ILLEGAL_ARGUMENT,
-        "The Trino Iceberg connector cannot represent Iceberg V3 unknown as a table column");
+  private enum IcebergV3Type {
+    NANOSECOND_TIMESTAMP("nanosecond timestamp", 481),
+    VARIANT("variant", 481),
+    UNKNOWN("unknown"),
+    GEOMETRY("geometry", 482),
+    GEOGRAPHY("geography", 482);
+
+    private final String displayName;
+    private final OptionalInt minimumTrinoVersion;
+
+    IcebergV3Type(String displayName, int minimumTrinoVersion) {
+      this.displayName = displayName;
+      this.minimumTrinoVersion = OptionalInt.of(minimumTrinoVersion);
+    }
+
+    IcebergV3Type(String displayName) {
+      this.displayName = displayName;
+      this.minimumTrinoVersion = OptionalInt.empty();
+    }
   }
 }

--- a/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/catalog/iceberg/IcebergDataTypeTransformer.java
+++ b/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/catalog/iceberg/IcebergDataTypeTransformer.java
@@ -38,7 +38,9 @@ public class IcebergDataTypeTransformer extends GeneralDataTypeTransformer {
 
   @Override
   public Type getGravitinoType(io.trino.spi.type.Type type) {
-    if (hasBaseType(type, "variant")) {
+    if (hasBaseType(type, "unknown")) {
+      throw unsupportedUnknownType();
+    } else if (hasBaseType(type, "variant")) {
       throw unsupportedIcebergV3Type("variant", 481);
     }
 
@@ -74,7 +76,9 @@ public class IcebergDataTypeTransformer extends GeneralDataTypeTransformer {
 
   @Override
   public io.trino.spi.type.Type getTrinoType(Type type) {
-    if (Name.FIXED == type.name()) {
+    if (Name.NULL == type.name()) {
+      throw unsupportedUnknownType();
+    } else if (Name.FIXED == type.name()) {
       return VarbinaryType.VARBINARY;
     } else if (Name.VARIANT == type.name()) {
       throw unsupportedIcebergV3Type(type.simpleString(), 481);
@@ -115,5 +119,11 @@ public class IcebergDataTypeTransformer extends GeneralDataTypeTransformer {
         String.format(
             "The supported Trino Iceberg connector versions cannot preserve Iceberg V3 %s; support starts in Trino %d",
             typeName, requiredVersion));
+  }
+
+  private static TrinoException unsupportedUnknownType() {
+    return new TrinoException(
+        GravitinoErrorCode.GRAVITINO_ILLEGAL_ARGUMENT,
+        "The Trino Iceberg connector cannot represent Iceberg V3 unknown as a table column");
   }
 }

--- a/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/catalog/iceberg/IcebergDataTypeTransformer.java
+++ b/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/catalog/iceberg/IcebergDataTypeTransformer.java
@@ -42,6 +42,8 @@ public class IcebergDataTypeTransformer extends GeneralDataTypeTransformer {
       throw unsupportedUnknownType();
     } else if (hasBaseType(type, "variant")) {
       throw unsupportedIcebergV3Type("variant", 481);
+    } else if (hasBaseType(type, "geometry")) {
+      throw unsupportedIcebergV3Type("geometry", 482);
     }
 
     Class<? extends io.trino.spi.type.Type> typeClass = type.getClass();
@@ -82,6 +84,8 @@ public class IcebergDataTypeTransformer extends GeneralDataTypeTransformer {
       return VarbinaryType.VARBINARY;
     } else if (Name.VARIANT == type.name()) {
       throw unsupportedIcebergV3Type(type.simpleString(), 481);
+    } else if (Name.GEOMETRY == type.name()) {
+      throw unsupportedIcebergV3Type(type.simpleString(), 482);
     } else if (Name.TIME == type.name()) {
       return TimeType.TIME_MICROS;
     } else if (Name.TIMESTAMP == type.name()) {

--- a/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/catalog/iceberg/IcebergDataTypeTransformer.java
+++ b/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/catalog/iceberg/IcebergDataTypeTransformer.java
@@ -38,6 +38,10 @@ public class IcebergDataTypeTransformer extends GeneralDataTypeTransformer {
 
   @Override
   public Type getGravitinoType(io.trino.spi.type.Type type) {
+    if (hasBaseType(type, "variant")) {
+      throw unsupportedIcebergV3Type("variant", 481);
+    }
+
     Class<? extends io.trino.spi.type.Type> typeClass = type.getClass();
     if (typeClass == io.trino.spi.type.CharType.class) {
       throw new TrinoException(
@@ -72,6 +76,8 @@ public class IcebergDataTypeTransformer extends GeneralDataTypeTransformer {
   public io.trino.spi.type.Type getTrinoType(Type type) {
     if (Name.FIXED == type.name()) {
       return VarbinaryType.VARBINARY;
+    } else if (Name.VARIANT == type.name()) {
+      throw unsupportedIcebergV3Type(type.simpleString(), 481);
     } else if (Name.TIME == type.name()) {
       return TimeType.TIME_MICROS;
     } else if (Name.TIMESTAMP == type.name()) {
@@ -97,5 +103,17 @@ public class IcebergDataTypeTransformer extends GeneralDataTypeTransformer {
               "The supported Trino Iceberg connector versions cannot preserve %s; only timestamp precision %d is lossless",
               typeName, ICEBERG_TIMESTAMP_PRECISION));
     }
+  }
+
+  private static boolean hasBaseType(io.trino.spi.type.Type type, String typeName) {
+    return type.getTypeSignature().getBase().equalsIgnoreCase(typeName);
+  }
+
+  private static TrinoException unsupportedIcebergV3Type(String typeName, int requiredVersion) {
+    return new TrinoException(
+        GravitinoErrorCode.GRAVITINO_ILLEGAL_ARGUMENT,
+        String.format(
+            "The supported Trino Iceberg connector versions cannot preserve Iceberg V3 %s; support starts in Trino %d",
+            typeName, requiredVersion));
   }
 }

--- a/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/catalog/iceberg/IcebergDataTypeTransformer.java
+++ b/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/catalog/iceberg/IcebergDataTypeTransformer.java
@@ -34,6 +34,8 @@ import org.apache.gravitino.trino.connector.util.GeneralDataTypeTransformer;
 /** Type transformer between Apache Iceberg and Trino */
 public class IcebergDataTypeTransformer extends GeneralDataTypeTransformer {
 
+  private static final int ICEBERG_TIMESTAMP_PRECISION = TRINO_MICROS_PRECISION;
+
   @Override
   public Type getGravitinoType(io.trino.spi.type.Type type) {
     Class<? extends io.trino.spi.type.Type> typeClass = type.getClass();
@@ -53,11 +55,14 @@ public class IcebergDataTypeTransformer extends GeneralDataTypeTransformer {
       // Iceberg only supports time type with microsecond (6) precision
       return Types.TimeType.of(TRINO_MICROS_PRECISION);
     } else if (io.trino.spi.type.TimestampType.class.isAssignableFrom(typeClass)) {
+      validateTimestampPrecision(((TimestampType) type).getPrecision(), type.getDisplayName());
       // Iceberg only supports timestamp type (without time zone) with microsecond (6) precision
-      return Types.TimestampType.withoutTimeZone(TRINO_MICROS_PRECISION);
+      return Types.TimestampType.withoutTimeZone(ICEBERG_TIMESTAMP_PRECISION);
     } else if (io.trino.spi.type.TimestampWithTimeZoneType.class.isAssignableFrom(typeClass)) {
+      validateTimestampPrecision(
+          ((TimestampWithTimeZoneType) type).getPrecision(), type.getDisplayName());
       // Iceberg only supports timestamp with time zone type with microsecond (6) precision
-      return Types.TimestampType.withTimeZone(TRINO_MICROS_PRECISION);
+      return Types.TimestampType.withTimeZone(ICEBERG_TIMESTAMP_PRECISION);
     }
 
     return super.getGravitinoType(type);
@@ -71,6 +76,9 @@ public class IcebergDataTypeTransformer extends GeneralDataTypeTransformer {
       return TimeType.TIME_MICROS;
     } else if (Name.TIMESTAMP == type.name()) {
       Types.TimestampType timestampType = (Types.TimestampType) type;
+      if (timestampType.hasPrecisionSet()) {
+        validateTimestampPrecision(timestampType.precision(), type.simpleString());
+      }
       if (timestampType.hasTimeZone()) {
         return TimestampWithTimeZoneType.TIMESTAMP_TZ_MICROS;
       } else {
@@ -79,5 +87,15 @@ public class IcebergDataTypeTransformer extends GeneralDataTypeTransformer {
     }
 
     return super.getTrinoType(type);
+  }
+
+  private static void validateTimestampPrecision(int precision, String typeName) {
+    if (precision != ICEBERG_TIMESTAMP_PRECISION) {
+      throw new TrinoException(
+          GravitinoErrorCode.GRAVITINO_ILLEGAL_ARGUMENT,
+          String.format(
+              "The supported Trino Iceberg connector versions cannot preserve %s; only timestamp precision %d is lossless",
+              typeName, ICEBERG_TIMESTAMP_PRECISION));
+    }
   }
 }

--- a/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/catalog/iceberg/IcebergDataTypeTransformer.java
+++ b/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/catalog/iceberg/IcebergDataTypeTransformer.java
@@ -44,6 +44,8 @@ public class IcebergDataTypeTransformer extends GeneralDataTypeTransformer {
       throw unsupportedIcebergV3Type("variant", 481);
     } else if (hasBaseType(type, "geometry")) {
       throw unsupportedIcebergV3Type("geometry", 482);
+    } else if (hasBaseType(type, "geography") || hasBaseType(type, "sphericalgeography")) {
+      throw unsupportedIcebergV3Type("geography", 482);
     }
 
     Class<? extends io.trino.spi.type.Type> typeClass = type.getClass();
@@ -85,6 +87,8 @@ public class IcebergDataTypeTransformer extends GeneralDataTypeTransformer {
     } else if (Name.VARIANT == type.name()) {
       throw unsupportedIcebergV3Type(type.simpleString(), 481);
     } else if (Name.GEOMETRY == type.name()) {
+      throw unsupportedIcebergV3Type(type.simpleString(), 482);
+    } else if (Name.GEOGRAPHY == type.name()) {
       throw unsupportedIcebergV3Type(type.simpleString(), 482);
     } else if (Name.TIME == type.name()) {
       return TimeType.TIME_MICROS;

--- a/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/catalog/iceberg/IcebergMetadataAdapter.java
+++ b/trino-connector/trino-connector/src/main/java/org/apache/gravitino/trino/connector/catalog/iceberg/IcebergMetadataAdapter.java
@@ -63,12 +63,18 @@ public class IcebergMetadataAdapter extends CatalogConnectorMetadataAdapter {
    * @param schemaProperties the list of schema property metadata
    * @param tableProperties the list of table property metadata
    * @param columnProperties the list of column property metadata
+   * @param trinoVersion the runtime Trino SPI version
    */
   public IcebergMetadataAdapter(
       List<PropertyMetadata<?>> schemaProperties,
       List<PropertyMetadata<?>> tableProperties,
-      List<PropertyMetadata<?>> columnProperties) {
-    super(schemaProperties, tableProperties, columnProperties, new IcebergDataTypeTransformer());
+      List<PropertyMetadata<?>> columnProperties,
+      int trinoVersion) {
+    super(
+        schemaProperties,
+        tableProperties,
+        columnProperties,
+        new IcebergDataTypeTransformer(trinoVersion));
     this.tableConverter = new IcebergTablePropertyConverter();
     this.schemaConverter = new IcebergSchemaPropertyConverter();
   }

--- a/trino-connector/trino-connector/src/test/java/org/apache/gravitino/trino/connector/catalog/iceberg/TestIcebergDataTypeTransformer.java
+++ b/trino-connector/trino-connector/src/test/java/org/apache/gravitino/trino/connector/catalog/iceberg/TestIcebergDataTypeTransformer.java
@@ -120,6 +120,18 @@ public class TestIcebergDataTypeTransformer {
         () -> transformer.getGravitinoType(mockTrinoType("unknown")), expectedMessage);
   }
 
+  @Test
+  public void testRejectGeometry() {
+    IcebergDataTypeTransformer transformer = new IcebergDataTypeTransformer();
+    String expectedMessage = "support starts in Trino 482";
+    Type type = Types.GeometryType.of("EPSG:3857");
+
+    assertIllegalArgument(() -> transformer.getTrinoType(type), expectedMessage);
+    assertMetadataRejectedBeforeConnectorInvocation(type, expectedMessage);
+    assertIllegalArgument(
+        () -> transformer.getGravitinoType(mockTrinoType("geometry")), expectedMessage);
+  }
+
   private static void assertMetadataRejectedBeforeConnectorInvocation(Type type) {
     assertMetadataRejectedBeforeConnectorInvocation(type, "only timestamp precision 6 is lossless");
   }

--- a/trino-connector/trino-connector/src/test/java/org/apache/gravitino/trino/connector/catalog/iceberg/TestIcebergDataTypeTransformer.java
+++ b/trino-connector/trino-connector/src/test/java/org/apache/gravitino/trino/connector/catalog/iceberg/TestIcebergDataTypeTransformer.java
@@ -22,6 +22,11 @@ package org.apache.gravitino.trino.connector.catalog.iceberg;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.trino.spi.TrinoException;
+import io.trino.spi.connector.ColumnMetadata;
+import io.trino.spi.connector.ConnectorMetadata;
+import io.trino.spi.connector.ConnectorTableMetadata;
+import io.trino.spi.connector.SaveMode;
+import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.type.TimeType;
 import io.trino.spi.type.TimestampType;
 import io.trino.spi.type.TimestampWithTimeZoneType;
@@ -30,6 +35,8 @@ import io.trino.spi.type.VarcharType;
 import org.apache.gravitino.rel.types.Type;
 import org.apache.gravitino.rel.types.Types;
 import org.apache.gravitino.trino.connector.GravitinoErrorCode;
+import org.apache.gravitino.trino.connector.GravitinoMetadata;
+import org.apache.gravitino.trino.connector.catalog.CatalogConnectorMetadata;
 import org.apache.gravitino.trino.connector.metadata.GravitinoColumn;
 import org.apache.gravitino.trino.connector.metadata.GravitinoTable;
 import org.apache.gravitino.trino.connector.util.GeneralDataTypeTransformer;
@@ -40,9 +47,12 @@ import org.mockito.Mockito;
 
 public class TestIcebergDataTypeTransformer {
 
+  private static final int TRINO_478 = 478;
+
   @Test
   public void testTrinoTypeToGravitinoType() {
-    GeneralDataTypeTransformer generalDataTypeTransformer = new IcebergDataTypeTransformer();
+    GeneralDataTypeTransformer generalDataTypeTransformer =
+        new IcebergDataTypeTransformer(TRINO_478);
     io.trino.spi.type.Type charTypeWithLengthOne = io.trino.spi.type.CharType.createCharType(1);
 
     Exception e =
@@ -74,11 +84,18 @@ public class TestIcebergDataTypeTransformer {
     Assertions.assertEquals(
         generalDataTypeTransformer.getTrinoType(Types.TimestampType.withTimeZone()),
         TimestampWithTimeZoneType.TIMESTAMP_TZ_MICROS);
+
+    Assertions.assertEquals(
+        generalDataTypeTransformer.getGravitinoType(TimestampType.TIMESTAMP_MILLIS),
+        Types.TimestampType.withoutTimeZone(6));
+    Assertions.assertEquals(
+        generalDataTypeTransformer.getGravitinoType(TimestampWithTimeZoneType.TIMESTAMP_TZ_MILLIS),
+        Types.TimestampType.withTimeZone(6));
   }
 
   @Test
   public void testRejectNanosecondTimestamps() {
-    IcebergDataTypeTransformer transformer = new IcebergDataTypeTransformer();
+    IcebergDataTypeTransformer transformer = new IcebergDataTypeTransformer(TRINO_478);
     Type[] gravitinoTypes = {
       Types.TimestampType.withoutTimeZone(9), Types.TimestampType.withTimeZone(9)
     };
@@ -88,20 +105,73 @@ public class TestIcebergDataTypeTransformer {
     };
 
     for (Type type : gravitinoTypes) {
-      assertIllegalArgument(
-          () -> transformer.getTrinoType(type), "only timestamp precision 6 is lossless");
+      assertIllegalArgument(() -> transformer.getTrinoType(type), "requires Trino 481 or newer");
       assertMetadataRejectedBeforeConnectorInvocation(type);
     }
     for (io.trino.spi.type.Type type : trinoTypes) {
       assertIllegalArgument(
-          () -> transformer.getGravitinoType(type), "only timestamp precision 6 is lossless");
+          () -> transformer.getGravitinoType(type), "requires Trino 481 or newer");
     }
   }
 
   @Test
+  public void testNanosecondTimestampsStartInTrino481() {
+    IcebergDataTypeTransformer transformer = new IcebergDataTypeTransformer(481);
+
+    Assertions.assertEquals(
+        transformer.getTrinoType(Types.TimestampType.withoutTimeZone(9)),
+        TimestampType.createTimestampType(9));
+    Assertions.assertEquals(
+        transformer.getTrinoType(Types.TimestampType.withTimeZone(9)),
+        TimestampWithTimeZoneType.createTimestampWithTimeZoneType(9));
+    Assertions.assertEquals(
+        transformer.getGravitinoType(TimestampType.createTimestampType(9)),
+        Types.TimestampType.withoutTimeZone(9));
+    Assertions.assertEquals(
+        transformer.getGravitinoType(TimestampWithTimeZoneType.createTimestampWithTimeZoneType(9)),
+        Types.TimestampType.withTimeZone(9));
+  }
+
+  @Test
+  public void testRejectTimestampPrecisionWithoutIcebergRepresentation() {
+    IcebergDataTypeTransformer transformer = new IcebergDataTypeTransformer(482);
+
+    assertIllegalArgument(
+        () -> transformer.getTrinoType(Types.TimestampType.withoutTimeZone(7)),
+        "timestamp precision must be 6 or 9");
+    assertIllegalArgument(
+        () -> transformer.getGravitinoType(TimestampType.createTimestampType(12)),
+        "timestamp precision must be 6 or 9");
+  }
+
+  @Test
+  public void testCreateTableRejectsBeforeCatalogMutation() {
+    CatalogConnectorMetadata catalogMetadata = Mockito.mock(CatalogConnectorMetadata.class);
+    ConnectorMetadata internalMetadata = Mockito.mock(ConnectorMetadata.class);
+    IcebergMetadataAdapter adapter =
+        (IcebergMetadataAdapter) new IcebergConnectorAdapter().getMetadataAdapter(TRINO_478);
+    GravitinoMetadata metadata =
+        new GravitinoMetadata(catalogMetadata, adapter, internalMetadata) {};
+    ConnectorTableMetadata tableMetadata =
+        new ConnectorTableMetadata(
+            new SchemaTableName("schema", "unsupported_type"),
+            ImmutableList.of(
+                ColumnMetadata.builder()
+                    .setName("col")
+                    .setType(TimestampType.createTimestampType(9))
+                    .build()),
+            ImmutableMap.of(IcebergPropertyMeta.ICEBERG_FORMAT_PROPERTY, "PARQUET"));
+
+    assertIllegalArgument(
+        () -> metadata.createTable(null, tableMetadata, SaveMode.FAIL),
+        "current Trino version is 478");
+    Mockito.verifyNoInteractions(catalogMetadata, internalMetadata);
+  }
+
+  @Test
   public void testRejectVariant() {
-    IcebergDataTypeTransformer transformer = new IcebergDataTypeTransformer();
-    String expectedMessage = "support starts in Trino 481";
+    IcebergDataTypeTransformer transformer = new IcebergDataTypeTransformer(TRINO_478);
+    String expectedMessage = "requires Trino 481 or newer";
 
     assertIllegalArgument(() -> transformer.getTrinoType(Types.VariantType.get()), expectedMessage);
     assertMetadataRejectedBeforeConnectorInvocation(Types.VariantType.get(), expectedMessage);
@@ -111,8 +181,8 @@ public class TestIcebergDataTypeTransformer {
 
   @Test
   public void testRejectUnknown() {
-    IcebergDataTypeTransformer transformer = new IcebergDataTypeTransformer();
-    String expectedMessage = "cannot represent Iceberg V3 unknown as a table column";
+    IcebergDataTypeTransformer transformer = new IcebergDataTypeTransformer(TRINO_478);
+    String expectedMessage = "not supported by any Trino Iceberg connector version";
 
     assertIllegalArgument(() -> transformer.getTrinoType(Types.NullType.get()), expectedMessage);
     assertMetadataRejectedBeforeConnectorInvocation(Types.NullType.get(), expectedMessage);
@@ -122,8 +192,8 @@ public class TestIcebergDataTypeTransformer {
 
   @Test
   public void testRejectGeometry() {
-    IcebergDataTypeTransformer transformer = new IcebergDataTypeTransformer();
-    String expectedMessage = "support starts in Trino 482";
+    IcebergDataTypeTransformer transformer = new IcebergDataTypeTransformer(TRINO_478);
+    String expectedMessage = "requires Trino 482 or newer";
     Type type = Types.GeometryType.of("EPSG:3857");
 
     assertIllegalArgument(() -> transformer.getTrinoType(type), expectedMessage);
@@ -134,8 +204,8 @@ public class TestIcebergDataTypeTransformer {
 
   @Test
   public void testRejectGeography() {
-    IcebergDataTypeTransformer transformer = new IcebergDataTypeTransformer();
-    String expectedMessage = "support starts in Trino 482";
+    IcebergDataTypeTransformer transformer = new IcebergDataTypeTransformer(TRINO_478);
+    String expectedMessage = "requires Trino 482 or newer";
     Type type = Types.GeographyType.of("EPSG:4326", "karney");
 
     assertIllegalArgument(() -> transformer.getTrinoType(type), expectedMessage);
@@ -146,14 +216,40 @@ public class TestIcebergDataTypeTransformer {
         () -> transformer.getGravitinoType(mockTrinoType("sphericalgeography")), expectedMessage);
   }
 
+  @Test
+  public void testRejectTypesWithoutLosslessGravitinoConversionOnNewerTrino() {
+    IcebergDataTypeTransformer trino481Transformer = new IcebergDataTypeTransformer(481);
+    assertIllegalArgument(
+        () -> trino481Transformer.getTrinoType(Types.VariantType.get()),
+        "cannot losslessly convert Iceberg V3 variant on Trino 481");
+    assertIllegalArgument(
+        () -> trino481Transformer.getGravitinoType(mockTrinoType("variant")),
+        "cannot losslessly convert Iceberg V3 variant on Trino 481");
+
+    IcebergDataTypeTransformer trino482Transformer = new IcebergDataTypeTransformer(482);
+    assertIllegalArgument(
+        () -> trino482Transformer.getTrinoType(Types.GeometryType.of("EPSG:3857")),
+        "cannot losslessly convert Iceberg V3 geometry on Trino 482");
+    assertIllegalArgument(
+        () -> trino482Transformer.getGravitinoType(mockTrinoType("geometry")),
+        "cannot losslessly convert Iceberg V3 geometry on Trino 482");
+    assertIllegalArgument(
+        () -> trino482Transformer.getTrinoType(Types.GeographyType.of("EPSG:4326", "spherical")),
+        "cannot losslessly convert Iceberg V3 geography on Trino 482");
+    assertIllegalArgument(
+        () -> trino482Transformer.getGravitinoType(mockTrinoType("geography")),
+        "cannot losslessly convert Iceberg V3 geography on Trino 482");
+  }
+
   private static void assertMetadataRejectedBeforeConnectorInvocation(Type type) {
-    assertMetadataRejectedBeforeConnectorInvocation(type, "only timestamp precision 6 is lossless");
+    assertMetadataRejectedBeforeConnectorInvocation(type, "requires Trino 481 or newer");
   }
 
   private static void assertMetadataRejectedBeforeConnectorInvocation(
       Type type, String expectedMessage) {
     IcebergMetadataAdapter adapter =
-        new IcebergMetadataAdapter(ImmutableList.of(), ImmutableList.of(), ImmutableList.of());
+        new IcebergMetadataAdapter(
+            ImmutableList.of(), ImmutableList.of(), ImmutableList.of(), TRINO_478);
     GravitinoTable table =
         new GravitinoTable(
             "schema",

--- a/trino-connector/trino-connector/src/test/java/org/apache/gravitino/trino/connector/catalog/iceberg/TestIcebergDataTypeTransformer.java
+++ b/trino-connector/trino-connector/src/test/java/org/apache/gravitino/trino/connector/catalog/iceberg/TestIcebergDataTypeTransformer.java
@@ -19,15 +19,22 @@
 
 package org.apache.gravitino.trino.connector.catalog.iceberg;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import io.trino.spi.TrinoException;
 import io.trino.spi.type.TimeType;
 import io.trino.spi.type.TimestampType;
 import io.trino.spi.type.TimestampWithTimeZoneType;
 import io.trino.spi.type.VarcharType;
+import org.apache.gravitino.rel.types.Type;
 import org.apache.gravitino.rel.types.Types;
+import org.apache.gravitino.trino.connector.GravitinoErrorCode;
+import org.apache.gravitino.trino.connector.metadata.GravitinoColumn;
+import org.apache.gravitino.trino.connector.metadata.GravitinoTable;
 import org.apache.gravitino.trino.connector.util.GeneralDataTypeTransformer;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 
 public class TestIcebergDataTypeTransformer {
 
@@ -65,5 +72,49 @@ public class TestIcebergDataTypeTransformer {
     Assertions.assertEquals(
         generalDataTypeTransformer.getTrinoType(Types.TimestampType.withTimeZone()),
         TimestampWithTimeZoneType.TIMESTAMP_TZ_MICROS);
+  }
+
+  @Test
+  public void testRejectNanosecondTimestamps() {
+    IcebergDataTypeTransformer transformer = new IcebergDataTypeTransformer();
+    Type[] gravitinoTypes = {
+      Types.TimestampType.withoutTimeZone(9), Types.TimestampType.withTimeZone(9)
+    };
+    io.trino.spi.type.Type[] trinoTypes = {
+      TimestampType.createTimestampType(9),
+      TimestampWithTimeZoneType.createTimestampWithTimeZoneType(9)
+    };
+
+    for (Type type : gravitinoTypes) {
+      assertIllegalArgument(
+          () -> transformer.getTrinoType(type), "only timestamp precision 6 is lossless");
+      assertMetadataRejectedBeforeConnectorInvocation(type);
+    }
+    for (io.trino.spi.type.Type type : trinoTypes) {
+      assertIllegalArgument(
+          () -> transformer.getGravitinoType(type), "only timestamp precision 6 is lossless");
+    }
+  }
+
+  private static void assertMetadataRejectedBeforeConnectorInvocation(Type type) {
+    IcebergMetadataAdapter adapter =
+        new IcebergMetadataAdapter(ImmutableList.of(), ImmutableList.of(), ImmutableList.of());
+    GravitinoTable table =
+        new GravitinoTable(
+            "schema",
+            "unsupported_type",
+            ImmutableList.of(new GravitinoColumn("col", type, 0, "", true)),
+            "",
+            ImmutableMap.of());
+
+    assertIllegalArgument(
+        () -> adapter.getTableMetadata(table), "only timestamp precision 6 is lossless");
+  }
+
+  private static void assertIllegalArgument(Executable executable, String expectedMessage) {
+    TrinoException exception = Assertions.assertThrows(TrinoException.class, executable);
+    Assertions.assertEquals(
+        GravitinoErrorCode.GRAVITINO_ILLEGAL_ARGUMENT.toErrorCode(), exception.getErrorCode());
+    Assertions.assertTrue(exception.getMessage().contains(expectedMessage));
   }
 }

--- a/trino-connector/trino-connector/src/test/java/org/apache/gravitino/trino/connector/catalog/iceberg/TestIcebergDataTypeTransformer.java
+++ b/trino-connector/trino-connector/src/test/java/org/apache/gravitino/trino/connector/catalog/iceberg/TestIcebergDataTypeTransformer.java
@@ -132,6 +132,20 @@ public class TestIcebergDataTypeTransformer {
         () -> transformer.getGravitinoType(mockTrinoType("geometry")), expectedMessage);
   }
 
+  @Test
+  public void testRejectGeography() {
+    IcebergDataTypeTransformer transformer = new IcebergDataTypeTransformer();
+    String expectedMessage = "support starts in Trino 482";
+    Type type = Types.GeographyType.of("EPSG:4326", "karney");
+
+    assertIllegalArgument(() -> transformer.getTrinoType(type), expectedMessage);
+    assertMetadataRejectedBeforeConnectorInvocation(type, expectedMessage);
+    assertIllegalArgument(
+        () -> transformer.getGravitinoType(mockTrinoType("geography")), expectedMessage);
+    assertIllegalArgument(
+        () -> transformer.getGravitinoType(mockTrinoType("sphericalgeography")), expectedMessage);
+  }
+
   private static void assertMetadataRejectedBeforeConnectorInvocation(Type type) {
     assertMetadataRejectedBeforeConnectorInvocation(type, "only timestamp precision 6 is lossless");
   }

--- a/trino-connector/trino-connector/src/test/java/org/apache/gravitino/trino/connector/catalog/iceberg/TestIcebergDataTypeTransformer.java
+++ b/trino-connector/trino-connector/src/test/java/org/apache/gravitino/trino/connector/catalog/iceberg/TestIcebergDataTypeTransformer.java
@@ -25,6 +25,7 @@ import io.trino.spi.TrinoException;
 import io.trino.spi.type.TimeType;
 import io.trino.spi.type.TimestampType;
 import io.trino.spi.type.TimestampWithTimeZoneType;
+import io.trino.spi.type.TypeSignature;
 import io.trino.spi.type.VarcharType;
 import org.apache.gravitino.rel.types.Type;
 import org.apache.gravitino.rel.types.Types;
@@ -35,6 +36,7 @@ import org.apache.gravitino.trino.connector.util.GeneralDataTypeTransformer;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
+import org.mockito.Mockito;
 
 public class TestIcebergDataTypeTransformer {
 
@@ -96,7 +98,23 @@ public class TestIcebergDataTypeTransformer {
     }
   }
 
+  @Test
+  public void testRejectVariant() {
+    IcebergDataTypeTransformer transformer = new IcebergDataTypeTransformer();
+    String expectedMessage = "support starts in Trino 481";
+
+    assertIllegalArgument(() -> transformer.getTrinoType(Types.VariantType.get()), expectedMessage);
+    assertMetadataRejectedBeforeConnectorInvocation(Types.VariantType.get(), expectedMessage);
+    assertIllegalArgument(
+        () -> transformer.getGravitinoType(mockTrinoType("variant")), expectedMessage);
+  }
+
   private static void assertMetadataRejectedBeforeConnectorInvocation(Type type) {
+    assertMetadataRejectedBeforeConnectorInvocation(type, "only timestamp precision 6 is lossless");
+  }
+
+  private static void assertMetadataRejectedBeforeConnectorInvocation(
+      Type type, String expectedMessage) {
     IcebergMetadataAdapter adapter =
         new IcebergMetadataAdapter(ImmutableList.of(), ImmutableList.of(), ImmutableList.of());
     GravitinoTable table =
@@ -107,8 +125,13 @@ public class TestIcebergDataTypeTransformer {
             "",
             ImmutableMap.of());
 
-    assertIllegalArgument(
-        () -> adapter.getTableMetadata(table), "only timestamp precision 6 is lossless");
+    assertIllegalArgument(() -> adapter.getTableMetadata(table), expectedMessage);
+  }
+
+  private static io.trino.spi.type.Type mockTrinoType(String baseType) {
+    io.trino.spi.type.Type type = Mockito.mock(io.trino.spi.type.Type.class);
+    Mockito.when(type.getTypeSignature()).thenReturn(new TypeSignature(baseType));
+    return type;
   }
 
   private static void assertIllegalArgument(Executable executable, String expectedMessage) {

--- a/trino-connector/trino-connector/src/test/java/org/apache/gravitino/trino/connector/catalog/iceberg/TestIcebergDataTypeTransformer.java
+++ b/trino-connector/trino-connector/src/test/java/org/apache/gravitino/trino/connector/catalog/iceberg/TestIcebergDataTypeTransformer.java
@@ -109,6 +109,17 @@ public class TestIcebergDataTypeTransformer {
         () -> transformer.getGravitinoType(mockTrinoType("variant")), expectedMessage);
   }
 
+  @Test
+  public void testRejectUnknown() {
+    IcebergDataTypeTransformer transformer = new IcebergDataTypeTransformer();
+    String expectedMessage = "cannot represent Iceberg V3 unknown as a table column";
+
+    assertIllegalArgument(() -> transformer.getTrinoType(Types.NullType.get()), expectedMessage);
+    assertMetadataRejectedBeforeConnectorInvocation(Types.NullType.get(), expectedMessage);
+    assertIllegalArgument(
+        () -> transformer.getGravitinoType(mockTrinoType("unknown")), expectedMessage);
+  }
+
   private static void assertMetadataRejectedBeforeConnectorInvocation(Type type) {
     assertMetadataRejectedBeforeConnectorInvocation(type, "only timestamp precision 6 is lossless");
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Make the Trino Iceberg type converter aware of the runtime Trino SPI version and define the compatibility policy for Iceberg V3-native types.

- Pass `ConnectorContext.getSpiVersion()` through the catalog adapters to `IcebergDataTypeTransformer`.
- Preserve microsecond timestamps on all packaged Trino versions and allow nanosecond timestamps when the runtime is Trino 481 or newer.
- Reject timestamp precisions that Iceberg cannot represent losslessly.
- Encode the upstream Trino gates for Variant (481), Geometry (482), and Geography (482), while rejecting them even on newer runtimes when Gravitino cannot preserve their complete semantics.
- Reject Unknown because Trino cannot persist Iceberg's null-only type as a table column.
- Document the Trino/Iceberg type compatibility matrix.

The packaged connector modules remain Trino 435 through 478. The 481 and 482 policy boundaries prepare the converter for future module ranges; they do not expand the currently shipped range.

### Why are the changes needed?

Trino added Iceberg V3 type capabilities across different releases. Without runtime-aware conversion, Gravitino can reject a type for the wrong reason, lose precision or metadata, or delegate an invalid schema after catalog mutation begins.

The converter now makes the decision at the adapter boundary and reports the exact minimum/current Trino versions.

Fix: #12059

Related: #12056

### Does this PR introduce _any_ user-facing change?

Yes. Unsupported Iceberg V3 schemas now fail deterministically before catalog mutation, with version-specific diagnostics. Supported timestamp precision is normalized or preserved according to the runtime capability.

### How was this patch tested?

- Added bidirectional unit coverage for the Trino 478, 481, and 482 policy boundaries.
- Verified timestamp precision normalization and rejection of non-Iceberg precisions.
- Verified unsupported schemas are rejected before delegated catalog mutation.
- Added E2E coverage for `TIMESTAMP(9)`, `GEOMETRY`, and `SPHERICALGEOGRAPHY`, including exact runtime-version assertions and checks that no table was created.
- Added expected-result parameter substitution so the existing supported-version E2E matrix can assert each launched Trino version.
- Ran all six packaged Trino connector artifact test suites (435–439 through 473–478).
- Ran the focused Docker E2E fixture on Trino 478.
- Ran `./gradlew spotlessApply`.